### PR TITLE
refactor(governance): complete module ownership

### DIFF
--- a/docs/modules/governance.md
+++ b/docs/modules/governance.md
@@ -21,11 +21,14 @@ the response-governance stage alone: `gw_stage_governance.c` and its private hea
 `gw_stage_governance.h`, tested by `src/tests/test_response_governance_stage.c`. That is narrower than
 the governance plane this document describes — the OIDC, identity, policy-distribution, and console
 surfaces remain distributed across the KB, DB2, management, and console layers and are not yet
-module-local. The descriptor therefore declares its sources, private header, test, and this document but
-does not set `ownership_complete`: the module is mid-migration, and its declared set is not yet its whole
-intended surface. `docs/validation/core-modularization-slice-40.md` records the audit behind these
-declarations. Latching follows in a separate slice once the declarations have been reviewed on their own,
-so no audit blesses claims written in the same change.
+module-local. The descriptor declares its sources, private header, test, and this document and sets
+`ownership_complete: true`. The latch asserts that those declarations exhaustively cover the module
+root as it stands — one source and one private header — not that the broader governance plane has been
+migrated. `docs/validation/core-modularization-slice-40.md` records the declaration audit and
+`docs/validation/core-modularization-slice-41.md` the completeness audit; the two were split so the
+latch reviews declarations that were merged on their own first. Because the module owns exactly what it
+declares today, adding a new module-local source or private header without declaring it now fails CI on
+`rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-41.md
+++ b/docs/validation/core-modularization-slice-41.md
@@ -1,0 +1,87 @@
+# Core modularization slice 41: latch governance ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `governance` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 40 declared and audited the descriptor's `sources`,
+`private_headers`, `tests`, and `docs` fields on their own, and this slice asserts those declarations
+exhaustively cover the module root and adds the latch mutation coverage. It changes descriptor
+metadata, validation coverage, documentation, and cleanup accounting only; no production code, public
+symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`governance` is the first latched module in the series to carry a private header. The nine latched by
+slices 29-38 declared none, so this is the first time `validate_complete_ownership` enforces
+set-equality on the `private_headers` role against a real module.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/governance/include/aimee/governance/` (which does not exist — the module has no public
+header directory). The module root contains exactly `gw_stage_governance.c`, `gw_stage_governance.h`,
+and `module.yaml`. The declared source set is `{gw_stage_governance.c}` and the declared
+private-header set is `{gw_stage_governance.h}`; both equal their actual sets, so the latch is exact.
+The descriptor's `docs` field equals `["docs/modules/governance.md"]`, as the latch requires.
+
+Slice 40 established the liveness and build-membership evidence behind these declarations: the source
+is compiled by Make in `DATA_SRCS`, has tracked production callers in `src/server/anthropic_http.c`
+and `src/server/openai_chat.c`, and the private header is included by those two servers and the direct
+test. That audit is not repeated here; this slice adds only the completeness assertion on top of the
+already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+the governance plane the canonical document describes — OIDC, organizational identity, policy
+distribution, the console surfaces — has been migrated; that code remains distributed across the KB,
+DB2, management, and console layers and is not module-local. The latch means the descriptor covers what
+is under `src/modules/governance/` today, and nothing more is there today.
+
+## Private-header enforcement, exercised for the first time
+
+Until this slice, every latched module declared zero private headers, so the `private_headers` branch
+of `validate_complete_ownership` only ever compared an empty actual set against an empty declared set.
+`governance` gives it one real file on each side. The regression suite now removes
+`gw_stage_governance.h` from the descriptor's `private_headers` and requires the validator to fail
+`rule=ownership-complete` on `/private_headers` with the header named as missing, and it plants
+`src/modules/governance/undeclared.h` and requires the same rule on the same pointer. This is the first
+time the private-header half of the completeness domain is proven to bite on a declared module rather
+than vacuously.
+
+## Regression controls
+
+The descriptor mutation suite removes `gw_stage_governance.c` and requires
+`rule=ownership-complete` on `/sources`, and removes `gw_stage_governance.h` and requires the same rule
+on `/private_headers`. It plants `src/modules/governance/undeclared.c` and `undeclared.h` and requires
+the rule on `/sources` and `/private_headers` respectively. It removes `docs/modules/governance.md`
+from the descriptor's `docs` field and requires the rule on `/docs`. The latched-descriptor assertion
+introduced in slice 35 now also covers `governance`, so silently clearing the latch fails directly.
+The empty-domain guard from slice 39 does not apply, because the module root is not empty. The
+unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-response-governance-stage
+src/build/obj/tests/unit-test-response-governance-stage
+```
+
+`cmake` is unavailable in the environment used for this slice, and CMake compiles no governance source
+under a target of its own, so there is no module-specific CMake command to add; the required
+pull-request CMake jobs continue to cover the thin-client profile they own.
+
+With `governance` latched, ten modules carry `ownership_complete`. The remaining eight Class B modules
+follow the same declaration-then-latch pair, and the eight Class A modules remain blocked by the
+empty-domain guard and tracked in `docs/validation/core-modularization-class-a-migration.md`.
+Technical-writer review, exact-final-diff roundtable approval, and every required pull-request check
+are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -273,6 +273,8 @@ class DescriptorTests(unittest.TestCase):
             ("gateway", "sources", "src/modules/gateway/gateway_delegate.c"),
             ("gateway", "sources", "src/modules/gateway/gateway_pipeline.c"),
             ("gateway", "sources", "src/modules/gateway/gateway_policy.c"),
+            ("governance", "sources", "src/modules/governance/gw_stage_governance.c"),
+            ("governance", "private_headers", "src/modules/governance/gw_stage_governance.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -292,7 +294,7 @@ class DescriptorTests(unittest.TestCase):
                 tmp.cleanup()
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
-                           "module-runtime", "plugin-loader", "gateway"):
+                           "module-runtime", "plugin-loader", "gateway", "governance"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -388,7 +390,7 @@ class DescriptorTests(unittest.TestCase):
 
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
-                           "module-runtime", "plugin-loader", "gateway"):
+                           "module-runtime", "plugin-loader", "gateway", "governance"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/governance/module.yaml
+++ b/src/modules/governance/module.yaml
@@ -18,6 +18,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/governance/gw_stage_governance.c"
   ],

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -554,6 +554,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains the governance row.",
       "independent_review": "The scoping roundtable established that declaration and latching are separate acts and that governance is the correct first module because it is smallest and the first to carry a private header, exercising a validator path the nine latched modules never have. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-40.md", "docs/modules/governance.md", "src/modules/governance/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 41,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the governance descriptor against the declarations slice 40 authored and reviewed on their own, the latch half of the declaration-then-latch pair, and exercised the validator's private_headers set-equality enforcement against a real declared module for the first time.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, one source and one private header, not that the OIDC, identity, policy-distribution and console governance surfaces have been migrated; those remain distributed across kb, DB2, management and console layers", "CMake compiles no governance source under a target of its own, the same intentional thin-client profile boundary recorded for gateway"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The remaining eight Class B modules follow the same declaration-then-latch pair; the broader governance plane remains a later migration that will extend these declarations."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining Class B declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains governance-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising private_headers set-equality on a real declared module.",
+      "independent_review": "The scoping roundtable required declaration and latching be separate acts; slice 40 declared and this slice latches. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-41.md", "docs/modules/governance.md", "src/modules/governance/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 41 — the **latch** half of the declaration-then-latch pair. Sets `ownership_complete: true` on `governance`, against the declarations [#1867](https://github.com/RakuenSoftware/aimee/pull/1867) authored and merged on their own.

## First private header in the series

`governance` is the first latched module to carry a private header. Slices 29-38 all declared zero, so `validate_complete_ownership`'s `private_headers` branch has only ever compared an empty set against an empty set. This slice gives it one real file on each side, and the regression suite now:

- removes `gw_stage_governance.h` from the descriptor and requires `rule=ownership-complete` on `/private_headers`, and
- plants `src/modules/governance/undeclared.h` under the same rule.

That is genuinely new coverage — the private-header half of the completeness domain is proven to bite on a declared module rather than vacuously.

## Exact latch, narrow scope

The module root contains exactly `gw_stage_governance.c`, `gw_stage_governance.h`, and `module.yaml`. Declared sets equal actual sets, so the latch is exact. The audit (`docs/validation/core-modularization-slice-41.md`) scopes it explicitly to the module root **as it stands** — one source, one private header — and states that the OIDC, identity, policy-distribution, and console governance surfaces the document describes remain distributed across the KB, DB2, management, and console layers and are not module-local. Latching does not claim they were migrated.

The liveness and build-membership evidence was established and reviewed in the declaration slice; this slice adds only the completeness assertion on top of it.

## Blast radius

Descriptor metadata, validation coverage, documentation, and cleanup accounting only. No production source, public symbol, build membership, configuration, storage, or runtime behavior changes. All local checks pass; the governance unit test builds and runs green.

Ten modules now carry `ownership_complete`. The exact-diff roundtable returned no issues.