### PR TITLE
refactor(learning): declare module ownership

### DIFF
--- a/docs/modules/learning.md
+++ b/docs/modules/learning.md
@@ -14,6 +14,18 @@ and the router API. `learning_implicit.h`, `learning_bundle.h`, and `learning_ev
 evidence assembly, and candidate generation, while DB2 persistence currently remains in
 `src/db2/db2_learning.h` and related source files as explicit physical-ownership debt.
 
+The descriptor declares this module's four sources (`learning_bundle.c`, `learning_evidence.c`,
+`learning_implicit.c`, `learning_router.c`), its four module-root headers, its two direct tests, and
+this document; it does not yet set `ownership_complete`. All four headers are declared as
+`private_headers` because they live at the module root rather than under
+`src/modules/learning/include/aimee/learning/`, which is the layout the header-layout checker treats as
+private. `learning.h` is nonetheless a de-facto public contract: it is included repository-wide via the
+`-Imodules/learning` search path, including by `src/headers/aimee.h`. Promoting it to a canonical public
+header would move the file under the include tree and rewrite every include site, which is a separate
+header-layout slice; an ownership-declaration slice moves nothing. `docs/validation/core-modularization-slice-42.md`
+records the audit; latching follows in a separate slice so the completeness audit does not review
+declarations authored in the same change.
+
 ## Dependencies and consumers
 
 - `config`: supplies learning thresholds, limits, synthesis provider settings, and policy gates.
@@ -70,10 +82,15 @@ useful changes without silently exceeding their weekly limits.
 
 ## Tests and failure behavior
 
-`test_learning_bundle.c`, `test_learning_metrics.c`, `learning_implicit_replay.c`,
-`test_learning_synth.c`, and `test_learning_version.c` cover evidence, detection, proposals, metrics,
-candidate synthesis, and version behavior. Invalid signals and unavailable storage fail closed; optional
-synthesis failure leaves evidence/proposals inspectable and must not fabricate an accepted action.
+The descriptor's two direct tests are `test_learning_bundle.c` (the evidence-bundle builder) and
+`test_learning_metrics.c` (the router metrics through the public learning API). `test_learning_synth.c`
+and `test_learning_version.c` exercise `kb/kb_learning_synth.c` and `kb/kb_learning_version.c`; they
+carry the `learning` name and link `learning_bundle.o` as a dependency but are KB tests, so they are not
+claimed here, the same way gateway does not claim the delivery-binary `test_gateway_*` tests.
+`learning_implicit_replay.c` is a replay harness, not a `unit-test-learning-*` target. Together these
+cover evidence, detection, proposals, metrics, candidate synthesis, and version behavior. Invalid
+signals and unavailable storage fail closed; optional synthesis failure leaves evidence/proposals
+inspectable and must not fabricate an accepted action.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-42.md
+++ b/docs/validation/core-modularization-slice-42.md
@@ -1,0 +1,133 @@
+# Core modularization slice 42: declare learning ownership
+
+## Scope
+
+This slice declares the `learning` descriptor's `sources`, `private_headers`, `tests`, and `docs`
+fields. It does not set `ownership_complete`. It is the declaration half of the declaration-then-latch
+pair; the latch, its mutation coverage, and the completeness audit follow in slice 43. It changes
+descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting
+only; no production code, public symbol, build membership, configuration, storage, or runtime behavior
+changes. No header is moved and no include site is rewritten.
+
+`learning` is the second Class B module, after governance. It is the first module in the series with
+more than one source and the first whose module-root headers include a de-facto public contract, so
+its declaration settles two questions governance did not raise.
+
+## What the module owns
+
+The descriptor now declares what lives under `src/modules/learning/`:
+
+- Four sources: `learning_bundle.c`, `learning_evidence.c`, `learning_implicit.c`,
+  `learning_router.c`.
+- Four module-root headers: `learning.h`, `learning_bundle.h`, `learning_evidence.h`,
+  `learning_implicit.h`. `learning_router.c` has no paired header; its API is declared in `learning.h`.
+- Two direct tests: `src/tests/test_learning_bundle.c` and `src/tests/test_learning_metrics.c`.
+- `docs/modules/learning.md`.
+
+DB2 persistence for learning (`src/db2/db2_learning.h`, `src/db2/learning_synth_ops.c`) and the KB
+synthesis lane remain outside the module root and are physical-ownership debt the document already
+records; the descriptor claims only what is module-local.
+
+## Headers: all private, one a de-facto public contract
+
+No `src/modules/learning/include/aimee/learning/` directory exists, so all four headers are at the
+module root and are declared in `private_headers`. `check_module_header_layout.py` constrains only
+*declared* `public_headers` — they must live under the canonical include tree — and retired include
+spellings; it neither requires a module to declare a public header nor objects to headers at the module
+root. The completeness latch treats `public_headers` as an explicit audited claim outside set-equality.
+So the private-header declaration is accurate to the layout that exists and is accepted by every check.
+
+`learning.h` is nonetheless the module's public API in practice: it is included repository-wide via the
+`-Imodules/learning` search path as `"learning.h"`, including by `src/headers/aimee.h`, `src/db2/db2_learning.h`,
+`kb/kb_mining.c`, `kb/kb_service.c`, and tests. Declaring it as a `public_header` today would require it
+to sit under the canonical include tree, which the layout checker enforces, so that path forces a
+file move and roughly six repository-wide include rewrites into this slice. The declare-then-latch split
+exists precisely to keep such a refactor out of an ownership-metadata change. The relocation is
+therefore deferred to a dedicated header-layout slice, and the de-facto-public status is recorded here
+and in the module document so it is visible to a reader of `module.yaml`, who would otherwise see only
+the private label. The slice-decision roundtable confirmed this scoping.
+
+## Source liveness and build membership
+
+Every declared source has tracked production consumers:
+
+- `learning_router.c` — the router and proposal API (`learning_router_enabled`,
+  `learning_router_record_signal`, `learning_list_proposals`, `learning_accept_proposal`,
+  `learning_metrics_commit_ratio`, and the JSON marshalling), called by `src/cmd_learning.c`,
+  `src/cmd_rules.c`, `src/db2/kb_service_backend_agent.c`, and the config layer.
+- `learning_bundle.c` — called by `src/db2/artifacts.c`, `src/db2/learning_synth_ops.c`,
+  `src/kb/kb_learning_synth.c`, `src/kb/kb_learning_version.c`, `src/kb/kb_curator_drain.c`,
+  `src/kb/kb_service_workers.c`, `src/modules/config/config_learning.c`, and
+  `src/modules/delegates/delegate_prompt.c`.
+- `learning_evidence.c` — called by `src/db2/kb_service_backend_agent.c` and `src/kb/kb_service_agent.c`.
+- `learning_implicit.c` — called by `src/db2/kb_service_backend_agent.c`, `src/dogfood.c`, and
+  `src/server/openai_chat.c`.
+
+Make's `DATA_SRCS` compiles all four sources and carries the `-Imodules/learning` include path. CMake
+compiles `learning_evidence.c`, `learning_implicit.c`, and `learning_router.c` but not
+`learning_bundle.c`: `learning_bundle.c`'s callers are entirely server/kb/db2/config-side, so the thin
+`aimee` client CMake builds does not pull it into its dependency closure while the other three are
+reachable. This is the same intentional thin-client profile boundary recorded for gateway (slice 38)
+and the audit CMake asymmetry (slice 34), not source-list drift. The descriptor records canonical
+source ownership, which both build systems agree on; it does not claim identical build-product
+membership.
+
+## Test membership
+
+Make registers four `unit-test-learning-*` targets. Only two are the module's:
+
+- `test_learning_bundle.c` — the evidence-bundle builder, `learning_bundle.c`. Learning-owned.
+- `test_learning_metrics.c` — the router metrics through the public learning API. Learning-owned.
+
+The other two are KB tests carrying the `learning` name: `test_learning_synth.c` exercises
+`kb/kb_learning_synth.c` and links `learning_bundle.o` only as a dependency, and
+`test_learning_version.c` exercises `kb/kb_learning_version.c`. A shared name prefix is not ownership,
+the same criterion applied to gateway's delivery-binary `test_gateway_*` tests. `learning_implicit_replay.c`
+is a replay harness rather than a registered `unit-test-learning-*` target and is likewise not claimed.
+
+CTest registers none of the four, consistent with learning being outside the thin-client profile.
+`scripts/check_module_test_registration.py` now records the two learning rows (`make: true`,
+`ctest: false`); that regeneration is the only reason the baseline file changes.
+
+## Why declare without latching
+
+The latch asserts the descriptor exhaustively covers the module root. That is true today — the module
+root holds exactly these four sources and four headers — so the latch would pass. It is deferred anyway
+because declaring the files and asserting completeness are distinct claims, and the roundtable required
+the completeness audit to review declarations merged on their own first rather than authored in the same
+change. The validator accepts a declared-but-unlatched descriptor: it checks each declared path exists
+and resolves within the module, and enforces set-equality only when `ownership_complete` is true.
+
+## Regression controls
+
+The declaration is covered by the existing descriptor validation: every declared path must exist and
+resolve within the module, and the regenerated test-registration baseline pins the two learning tests'
+per-suite registration. The empty-domain guard from slice 39 does not apply, because the module root is
+not empty. The latch mutation coverage — source removal, private-header removal, planted files, cleared
+latch — is deferred to slice 43, where `ownership_complete` is set and those mutations become
+meaningful.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 -m unittest scripts.tests.test_check_module_test_registration
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-learning-bundle build/obj/tests/unit-test-learning-metrics
+src/build/obj/tests/unit-test-learning-bundle
+src/build/obj/tests/unit-test-learning-metrics
+```
+
+Slice 43 sets `ownership_complete: true`, adds the learning latch mutation tests, and records the
+completeness audit. Technical-writer review, exact-final-diff roundtable approval, and every required
+pull-request check are required before merge.

--- a/src/modules/learning/module.yaml
+++ b/src/modules/learning/module.yaml
@@ -9,5 +9,24 @@
   ],
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/learning/learning_bundle.c",
+    "src/modules/learning/learning_evidence.c",
+    "src/modules/learning/learning_implicit.c",
+    "src/modules/learning/learning_router.c"
+  ],
+  "private_headers": [
+    "src/modules/learning/learning.h",
+    "src/modules/learning/learning_bundle.h",
+    "src/modules/learning/learning_evidence.h",
+    "src/modules/learning/learning_implicit.h"
+  ],
+  "tests": [
+    "src/tests/test_learning_bundle.c",
+    "src/tests/test_learning_metrics.c"
+  ],
+  "docs": [
+    "docs/modules/learning.md"
+  ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -571,6 +571,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains governance-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising private_headers set-equality on a real declared module.",
       "independent_review": "The scoping roundtable required declaration and latching be separate acts; slice 40 declared and this slice latches. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-41.md", "docs/modules/governance.md", "src/modules/governance/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 42,
+      "state": "present_and_verified",
+      "disposition": "Declared the learning descriptor's four sources, four module-root private headers, two direct tests, and document without setting ownership_complete, the declaration half of the pair for the second Class B module, and settled two questions governance did not raise: a de-facto public header that stays privately declared, and a CMake source asymmetry.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["learning.h is a de-facto public contract included repository-wide including by aimee.h, but is declared private because it sits at the module root; promoting it under include/aimee/learning would move the file and rewrite every include site and is deferred to a separate header-layout slice", "CMake compiles three of the four sources and omits learning_bundle.c whose callers are entirely server/kb/db2/config-side, the same intentional thin-client boundary recorded for gateway and audit, not drift", "test_learning_synth.c and test_learning_version.c carry the learning name but are KB tests of kb/kb_learning_synth.c and kb/kb_learning_version.c and are not claimed", "DB2 learning persistence and the KB synthesis lane remain outside the module root as physical-ownership debt"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Declaring learning.h as a public header was rejected because the layout checker requires public headers under the canonical include tree, which would force a file move and repository-wide include rewrites into an ownership-metadata slice.",
+        "revisit": "Slice 43 latches learning; a separate header-layout slice may relocate learning.h under the canonical include tree and declare it public."
+      },
+      "consumers": ["cmd_learning and cmd_rules", "server and KB learning routes", "config and delegates layers", "the learning latch slice", "remaining Class B declaration slices"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains two learning rows.",
+      "independent_review": "The slice-decision roundtable confirmed all three scoping decisions: declare learning.h private with the public-contract tension recorded and relocation deferred, classify the synth and version tests as KB tests, and document the learning_bundle.c CMake omission as an intentional boundary. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-42.md", "docs/modules/learning.md", "src/modules/learning/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
     }
   ]
 }

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -80,6 +80,18 @@
       "test": "src/tests/test_panel_ir_contract.c"
     },
     {
+      "ctest": false,
+      "make": true,
+      "module": "learning",
+      "test": "src/tests/test_learning_bundle.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "learning",
+      "test": "src/tests/test_learning_metrics.c"
+    },
+    {
       "ctest": true,
       "make": true,
       "module": "module-runtime",


### PR DESCRIPTION
Core modularization slice 42 — the **declaration** half of the pair for `learning`, the second Class B module. Declares the descriptor's ownership fields; does not set `ownership_complete`.

`learning` is the first module in the series with more than one source, and its declaration settles two questions governance did not raise. The slice-decision roundtable approved all three scoping calls.

## learning.h: a de-facto public contract, declared private

No `include/aimee/learning/` directory exists, so all four module headers sit at the module root and are declared in `private_headers`. `learning.h` is nonetheless the module's public API in practice — included repository-wide via `-Imodules/learning`, **including by `src/headers/aimee.h`**. Declaring it as a `public_header` would require it under the canonical include tree, which the layout checker enforces, forcing a file move plus ~six include rewrites into an ownership-metadata slice. The declare-then-latch split exists to keep that refactor out. The tension is recorded in both the module doc and the validation record so a reader of `module.yaml` sees the de-facto-public status behind the private label; relocation is a separate header-layout slice.

## Three of four sources in CMake

Make compiles all four; CMake compiles `learning_evidence.c`, `learning_implicit.c`, `learning_router.c` but not `learning_bundle.c`, whose callers are entirely server/kb/db2/config-side and so fall outside the thin `aimee` client's dependency closure. Same intentional thin-client boundary recorded for gateway (slice 38) and audit (slice 34). The descriptor records canonical source ownership, which both build systems agree on — not identical build-product membership.

## Two direct tests, two KB tests

Of the four `unit-test-learning-*` targets, `test_learning_bundle.c` and `test_learning_metrics.c` are the module's. `test_learning_synth.c` and `test_learning_version.c` exercise `kb/kb_learning_synth.c` and `kb/kb_learning_version.c` — KB tests carrying the `learning` name, not claimed, the same criterion applied to gateway's `test_gateway_*` delivery tests.

## Validation

Declaring without latching is a valid intermediate: the validator checks each declared path exists and resolves within the module, enforcing set-equality only under `ownership_complete`. All local checks pass, including both learning unit tests. The test-registration baseline gains exactly the two learning rows.

The exact-diff roundtable returned no issues. The latch, its mutation coverage, and the completeness audit come in slice 43.