### PR TITLE
refactor(learning): complete module ownership

### DIFF
--- a/docs/modules/learning.md
+++ b/docs/modules/learning.md
@@ -16,15 +16,16 @@ evidence assembly, and candidate generation, while DB2 persistence currently rem
 
 The descriptor declares this module's four sources (`learning_bundle.c`, `learning_evidence.c`,
 `learning_implicit.c`, `learning_router.c`), its four module-root headers, its two direct tests, and
-this document; it does not yet set `ownership_complete`. All four headers are declared as
+this document; it sets `ownership_complete: true`. All four headers are declared as
 `private_headers` because they live at the module root rather than under
 `src/modules/learning/include/aimee/learning/`, which is the layout the header-layout checker treats as
 private. `learning.h` is nonetheless a de-facto public contract: it is included repository-wide via the
 `-Imodules/learning` search path, including by `src/headers/aimee.h`. Promoting it to a canonical public
 header would move the file under the include tree and rewrite every include site, which is a separate
 header-layout slice; an ownership-declaration slice moves nothing. `docs/validation/core-modularization-slice-42.md`
-records the audit; latching follows in a separate slice so the completeness audit does not review
-declarations authored in the same change.
+records the declaration audit and `docs/validation/core-modularization-slice-43.md` the completeness
+audit; the two were split so the latch reviews declarations merged on their own first. Adding a new
+module-local source or module-root header without declaring it now fails CI on `rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-43.md
+++ b/docs/validation/core-modularization-slice-43.md
@@ -1,0 +1,99 @@
+# Core modularization slice 43: latch learning ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `learning` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 42 declared and audited the four sources, four module-root private
+headers, two direct tests, and document on their own, and this slice asserts those declarations
+exhaustively cover the module root and adds the latch mutation coverage. It changes descriptor
+metadata, validation coverage, documentation, and cleanup accounting only; no production code, public
+symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`learning` is the eleventh latched module and the second with declared private headers, after
+governance. It is the first with more than one source and the first with more than one private header,
+so it is the first module where the `sources` and `private_headers` set-equality checks each compare a
+multi-element declared set against a multi-element actual set.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/learning/include/aimee/learning/` (which does not exist). The module root contains
+exactly:
+
+- Sources: `learning_bundle.c`, `learning_evidence.c`, `learning_implicit.c`, `learning_router.c`.
+- Headers: `learning.h`, `learning_bundle.h`, `learning_evidence.h`, `learning_implicit.h`.
+
+The declared source set equals the four actual sources and the declared private-header set equals the
+four actual headers, so the latch is exact. The descriptor's `docs` field equals
+`["docs/modules/learning.md"]`, as the latch requires.
+
+Slice 42 established the liveness, build-membership, and test-classification evidence behind these
+declarations, and the slice-decision roundtable approved the three scoping calls: `learning.h` stays
+declared private with its de-facto-public status recorded and relocation deferred; the `learning_synth`
+and `learning_version` tests are KB tests, not module tests; and the CMake omission of
+`learning_bundle.c` is an intentional thin-client boundary. That audit is not repeated here; this slice
+adds only the completeness assertion on the already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+the DB2 persistence (`src/db2/db2_learning.h`, `src/db2/learning_synth_ops.c`) or the KB synthesis lane
+have been moved into the module — they remain physical-ownership debt the document records — and it does
+not resolve the `learning.h` layout question, which a separate header-layout slice owns.
+
+## Multi-element set-equality, exercised for the first time
+
+Every module latched before governance declared zero private headers, and governance declared exactly
+one source and one header, so the `sources` and `private_headers` set-equality checks had only ever
+compared sets of size zero or one. `learning` gives each check four declared entries against four actual
+files. The regression suite removes `learning_router.c` from `sources` and requires
+`rule=ownership-complete` on `/sources` with the source named missing, and removes `learning.h` from
+`private_headers` and requires the same rule on `/private_headers` with the header named missing —
+confirming the checks bite when one element of a multi-element declared set is dropped, not only when a
+whole set is emptied.
+
+## Regression controls
+
+The descriptor mutation suite removes `learning_router.c` and requires `rule=ownership-complete` on
+`/sources`, and removes `learning.h` and requires the same rule on `/private_headers`. It plants
+`src/modules/learning/undeclared.c` and `undeclared.h` and requires the rule on `/sources` and
+`/private_headers`. It removes `docs/modules/learning.md` from the descriptor's `docs` field and
+requires the rule on `/docs`. The latched-descriptor assertion introduced in slice 35 is
+converted here from a hardcoded module list to a graph-derived scan, so it now covers every latched
+descriptor — clearing the latch on any of them fails directly. That list had silently stopped at
+`gateway`: governance (slice 41) and learning were not added to it, so the assertion had quietly
+stopped covering the two newest latched modules. Deriving the set from the descriptor graph fixes
+governance retroactively and removes the drift for good; the scan guards only against a vacuous pass
+(an empty glob) rather than a latched-module count, which would drift on every latch just as the
+hardcoded list did. The empty-domain guard from slice 39 does not
+apply, because the module root is not empty. The unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-learning-bundle build/obj/tests/unit-test-learning-metrics
+src/build/obj/tests/unit-test-learning-bundle
+src/build/obj/tests/unit-test-learning-metrics
+```
+
+`cmake` is unavailable in the environment used for this slice, and CMake compiles a subset of this
+module's sources into the thin client without a governance-style module test target, so there is no
+module-specific CMake command to add; the required pull-request CMake jobs continue to cover the
+thin-client profile they own.
+
+With `learning` latched, eleven modules carry `ownership_complete`. The remaining seven Class B modules
+follow the same declaration-then-latch pair, and the eight Class A modules remain blocked by the
+empty-domain guard and tracked in `docs/validation/core-modularization-class-a-migration.md`.
+Technical-writer review, exact-final-diff roundtable approval, and every required pull-request check are
+required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -275,6 +275,8 @@ class DescriptorTests(unittest.TestCase):
             ("gateway", "sources", "src/modules/gateway/gateway_policy.c"),
             ("governance", "sources", "src/modules/governance/gw_stage_governance.c"),
             ("governance", "private_headers", "src/modules/governance/gw_stage_governance.h"),
+            ("learning", "sources", "src/modules/learning/learning_router.c"),
+            ("learning", "private_headers", "src/modules/learning/learning.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -294,7 +296,7 @@ class DescriptorTests(unittest.TestCase):
                 tmp.cleanup()
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
-                           "module-runtime", "plugin-loader", "gateway", "governance"):
+                           "module-runtime", "plugin-loader", "gateway", "governance", "learning"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -313,16 +315,23 @@ class DescriptorTests(unittest.TestCase):
                     tmp.cleanup()
 
     def test_latched_descriptors_declare_complete_ownership(self) -> None:
-        """The latch itself is the control; mutation coverage below assumes it stays set."""
-        for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
-                           "module-runtime", "plugin-loader", "gateway"):
-            descriptor = json.loads(
-                (REPO_ROOT / "src/modules" / identifier / "module.yaml").read_text(
-                    encoding="utf-8"
-                )
-            )
-            with self.subTest(identifier=identifier):
+        """The latch itself is the control; mutation coverage below assumes it stays set.
+
+        Derived from the graph rather than a hardcoded list, so a newly latched module is
+        covered without editing this test and the set cannot drift behind the descriptors.
+        """
+        latched = 0
+        for path in sorted((REPO_ROOT / "src/modules").glob("*/module.yaml")):
+            descriptor = json.loads(path.read_text(encoding="utf-8"))
+            if descriptor.get("ownership_complete") is None:
+                continue
+            latched += 1
+            with self.subTest(identifier=path.parent.name):
                 self.assertIs(descriptor.get("ownership_complete"), True)
+        # Guard only against a vacuous pass (broken glob, every descriptor unlatched); the
+        # per-descriptor assertion above does the real work. A count floor is deliberately
+        # avoided — it would drift on every latch, the exact churn the graph scan removes.
+        self.assertTrue(latched, "no latched descriptor found; the guard would pass vacuously")
 
     def test_empty_module_root_cannot_be_latched(self) -> None:
         """An unmigrated module must not satisfy the latch vacuously."""
@@ -390,7 +399,7 @@ class DescriptorTests(unittest.TestCase):
 
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
-                           "module-runtime", "plugin-loader", "gateway", "governance"):
+                           "module-runtime", "plugin-loader", "gateway", "governance", "learning"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/learning/module.yaml
+++ b/src/modules/learning/module.yaml
@@ -10,6 +10,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/learning/learning_bundle.c",
     "src/modules/learning/learning_evidence.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -588,6 +588,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains two learning rows.",
       "independent_review": "The slice-decision roundtable confirmed all three scoping decisions: declare learning.h private with the public-contract tension recorded and relocation deferred, classify the synth and version tests as KB tests, and document the learning_bundle.c CMake omission as an intentional boundary. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-42.md", "docs/modules/learning.md", "src/modules/learning/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 43,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the learning descriptor against the declarations slice 42 authored and reviewed on their own, the latch half of the pair for the second Class B module, and exercised the sources and private_headers set-equality checks against a multi-element declared set for the first time.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, four sources and four module-root headers, not that the DB2 persistence or KB synthesis lane have been moved into the module; those remain physical-ownership debt", "learning.h stays declared private with its de-facto-public status recorded; relocation under the canonical include tree is a separate header-layout slice", "CMake compiles three of the four sources and omits server/kb-only learning_bundle.c, the same intentional thin-client boundary recorded for gateway and audit"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The remaining seven Class B modules follow the same declaration-then-latch pair; a separate header-layout slice may relocate learning.h and declare it public."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining Class B declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains learning-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising set-equality on a multi-element declared source and private-header set; the cleared-latch assertion is also converted from a hardcoded module list to a graph-derived scan, which retroactively restores coverage of governance and prevents future drift.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 42; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-43.md", "docs/modules/learning.md", "src/modules/learning/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 43 — the **latch** half for `learning`, against the declarations [#1871](https://github.com/RakuenSoftware/aimee/pull/1871) merged on their own. Eleventh module latched.

## First multi-element set-equality

Every module latched before governance declared zero private headers; governance declared exactly one source and one header. `learning` is the first with **four sources and four private headers**, so this is the first time the `sources` and `private_headers` set-equality checks each compare a multi-element declared set against a multi-element actual set. The regression suite drops one element of each four-element set (`learning_router.c`, `learning.h`) and requires `rule=ownership-complete` naming the missing file — confirming the checks bite on a single-element omission, not just an emptied set.

## Fixes a latent regression in the cleared-latch guard

While adding `learning`, I found the slice-35 latched-descriptor assertion (the guard that every latched descriptor stays latched) hardcoded its module list and had **silently stopped at `gateway`** — governance (slice 41) and learning were never added, so it had quietly stopped covering the two newest latched modules. This slice converts that assertion from a hardcoded list to a graph-derived scan, which:

- restores governance coverage retroactively,
- covers learning and every future latched module automatically, and
- guards only against a vacuous pass (empty glob), **not** a module count — a count floor would drift on every latch, the exact churn the graph scan removes. (This refinement was the one non-blocking point the exact-diff roundtable raised.)

## Scope

The latch scopes to the module root as it stands. DB2 persistence and the KB synthesis lane remain outside it (physical-ownership debt the doc records), and `learning.h` stays privately declared pending a separate header-layout slice. No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

All local checks pass; both learning unit tests build and run green. The exact-diff roundtable returned no blocking issues.