### PR TITLE
refactor(workspace): declare module ownership

### DIFF
--- a/docs/modules/workspace.md
+++ b/docs/modules/workspace.md
@@ -15,6 +15,22 @@ worktree creation at line 1175, manifests and handles,
 `ws_scope_*` containment. The duplicated worktree declarations in `guardrails.h` are a
 compatibility/ownership seam to consolidate, not a second workspace implementation.
 
+The descriptor declares this module's eleven sources, eleven module-root headers, eleven direct
+tests, and this document; it does not yet set `ownership_complete`. All eleven headers are declared as
+`private_headers` because they live at the module root rather than under
+`src/modules/workspace/include/aimee/workspace/`, the layout the header-layout checker treats as
+private; `workspace_provider.h` is the provider dispatch interface and has no paired source, while
+`cli_workspace_serve.c` has no paired header. Three sources — `workspace_provider_container.c`,
+`workspace_provider_detached.c`, and `workspace_runner_queue.c` — have no external includer but are
+live module-internal units: the container and detached providers are selected through
+`workspace_provider.h` by `workspace_turn.c` and `cli_workspace_serve.c`, and the runner queue is
+consumed through `workspace_runner_registry.h`. Make compiles all eleven sources; CMake compiles the
+four the thin `aimee` client reaches (`cli_workspace_serve.c`, `workspace.c`, `workspace_manifest.c`,
+`workspace_provider_detached.c`) and omits the seven server/runner-side units, the same intentional
+thin-client boundary recorded for gateway and learning. `docs/validation/core-modularization-slice-44.md`
+records the audit; latching follows in a separate slice so the completeness audit does not review
+declarations authored in the same change.
+
 ## Dependencies and consumers
 
 - `config`: supplies workspace registrations, provider metadata, mirrors, and sandbox overrides.
@@ -83,10 +99,16 @@ session/delegate worktrees and registries; locking outside Git/worktree primitiv
 
 ## Tests and failure behavior
 
-`test_workspace.c`, handle, manifest, mirror, provider, detached/container, runner queue/registry,
-scope, and turn suites cover the implementation. Invalid or foreign roots, traversal/symlink escape,
-missing runner, drift, provider mismatch, and dirty cleanup must surface explicitly. A failed isolated
-binding must never retry through the shared host provider.
+The descriptor's eleven direct tests are `test_workspace.c`, `test_workspace_handle.c`,
+`test_workspace_manifest.c`, `test_workspace_mirror.c`, `test_workspace_provider.c`,
+`test_workspace_provider_container.c`, `test_workspace_provider_detached.c`,
+`test_workspace_runner_queue.c`, `test_workspace_runner_registry.c`, `test_workspace_scope.c`, and
+`test_workspace_turn.c`, covering the implementation. `test_workspace_memory.c` carries the workspace
+name and links `workspace.o` but is a memory test: its subject `memory_auto_tag_workspace` is defined
+in `src/modules/memory/memory_core.c`, so it exercises memory's workspace-scoped tagging and is not
+claimed here, the same way learning does not claim the KB `test_learning_synth.c`. Invalid or foreign
+roots, traversal/symlink escape, missing runner, drift, provider mismatch, and dirty cleanup must
+surface explicitly. A failed isolated binding must never retry through the shared host provider.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-44.md
+++ b/docs/validation/core-modularization-slice-44.md
@@ -1,0 +1,131 @@
+# Core modularization slice 44: declare workspace ownership
+
+## Scope
+
+This slice declares the `workspace` descriptor's `sources`, `private_headers`, `tests`, and `docs`
+fields. It does not set `ownership_complete`. It is the declaration half of the declaration-then-latch
+pair; the latch, its mutation coverage, and the completeness audit follow in slice 45. It changes
+descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting
+only; no production code, public symbol, build membership, configuration, storage, or runtime behavior
+changes. No header is moved and no include site is rewritten.
+
+`workspace` is the third Class B module, after governance and learning, and the largest declared so
+far: eleven sources, eleven module-root headers, and eleven direct tests carved out of a
+twelve-target `unit-test-workspace*` family.
+
+## What the module owns
+
+The module root `src/modules/workspace/` contains, excluding `module.yaml`:
+
+- Eleven sources: `cli_workspace_serve.c`, `workspace.c`, `workspace_handle.c`,
+  `workspace_manifest.c`, `workspace_mirror.c`, `workspace_provider_container.c`,
+  `workspace_provider_detached.c`, `workspace_runner_queue.c`, `workspace_runner_registry.c`,
+  `workspace_scope.c`, `workspace_turn.c`.
+- Eleven headers: the paired header for each source except `cli_workspace_serve.c`, plus
+  `workspace_provider.h`, the provider dispatch interface, which has no paired source.
+
+No `src/modules/workspace/include/aimee/workspace/` directory exists, so every header is at the module
+root and is declared in `private_headers`. The header-layout checker constrains only declared
+`public_headers`, so the private declaration is accurate to the layout; any future promotion of a
+workspace header to the canonical include tree is a separate header-layout slice.
+
+## Source liveness
+
+Every declared source is live:
+
+- `workspace.c`, `workspace_handle.c`, `workspace_mirror.c`, `workspace_scope.c`, and
+  `workspace_turn.c` have large external caller counts across the server, posix, db2, and cmd layers
+  (workspace resolution, handles, mirroring, scope containment, and per-turn binding are used
+  throughout agent execution).
+- `workspace_manifest.c` and `workspace_runner_registry.c` have external callers in the runner and
+  serve paths.
+- `cli_workspace_serve.c` is the client serve entry point.
+- `workspace_provider_container.c`, `workspace_provider_detached.c`, and `workspace_runner_queue.c`
+  have no external includer but are live module-internal units. The container and detached providers
+  are provider implementations selected through `workspace_provider.h`, the module's own dispatch
+  interface: `workspace_turn.c` includes both and holds a per-turn container provider, and
+  `cli_workspace_serve.c` includes the detached provider. The runner queue is consumed through
+  `workspace_runner_registry.h`, the module's runner surface. Their externally visible boundary is the
+  interface header; the implementation source sitting behind it with no outside includer is the
+  expected shape for a module-internal unit, not a dead island.
+
+## Build membership
+
+Make's `DATA_SRCS` compiles all eleven sources and carries the `-Imodules/workspace` include path.
+CMake compiles four: `cli_workspace_serve.c`, `workspace.c`, `workspace_manifest.c`, and
+`workspace_provider_detached.c` — the entry, the core, the manifest, and the one provider the thin
+`aimee` client instantiates when it serves a detached workspace. It omits the seven server/runner-side
+units: `workspace_handle.c`, `workspace_mirror.c`, `workspace_provider_container.c`,
+`workspace_runner_queue.c`, `workspace_runner_registry.c`, `workspace_scope.c`, and
+`workspace_turn.c`. This is the same intentional thin-client profile boundary recorded for gateway
+(slice 38), audit (slice 34), and learning (slice 42), not source-list drift: the four CMake sources
+are the client-serving subset, and the required Windows and Linux CMake jobs build the thin client
+green from exactly that four-source set, which is the standing evidence that the client's link-time
+closure does not reach the omitted seven. The descriptor records canonical source ownership, which both
+build systems agree on; it does not claim identical build-product membership.
+
+## Test membership
+
+There are twelve `test_workspace*.c` files and twelve `unit-test-workspace*` Make targets. Eleven are
+declared, one per module concern: `test_workspace.c`, `test_workspace_handle.c`,
+`test_workspace_manifest.c`, `test_workspace_mirror.c`, `test_workspace_provider.c`,
+`test_workspace_provider_container.c`, `test_workspace_provider_detached.c`,
+`test_workspace_runner_queue.c`, `test_workspace_runner_registry.c`, `test_workspace_scope.c`, and
+`test_workspace_turn.c`.
+
+The twelfth, `test_workspace_memory.c`, is not a workspace test. Its subject is
+`memory_auto_tag_workspace`, which is defined in `src/modules/memory/memory_core.c`; it exercises
+memory's workspace-scoped tagging through the DB2 test shim and links `workspace.o` only to supply
+workspace identity. It carries the `workspace` name but is a memory test, the same situation as
+learning's KB test `test_learning_synth.c` and gateway's delivery-binary `test_gateway_*` tests. It
+stays unclaimed and will belong to memory's eventual ownership.
+
+CTest registers none of the workspace tests, consistent with the module's server/runner sources sitting
+outside the thin-client profile. `scripts/check_module_test_registration.py` now records eleven
+workspace rows (`make: true`, `ctest: false`); that regeneration is the only reason the baseline file
+changes.
+
+## Why declare without latching
+
+The latch asserts the descriptor exhaustively covers the module root. That is true today — the module
+root holds exactly these eleven sources and eleven headers — so the latch would pass. It is deferred
+because declaring the files and asserting completeness are distinct claims, and the roundtable required
+the completeness audit to review declarations merged on their own first rather than authored in the
+same change. The validator accepts a declared-but-unlatched descriptor: it checks each declared path
+exists and resolves within the module, and enforces set-equality only when `ownership_complete` is
+true.
+
+## Regression controls
+
+The declaration is covered by the existing descriptor validation: every declared path must exist and
+resolve within the module, and the regenerated test-registration baseline pins the eleven workspace
+tests' per-suite registration. The empty-domain guard from slice 39 does not apply, because the module
+root is not empty. The latch mutation coverage — source removal, private-header removal, planted files,
+cleared latch — is deferred to slice 45, where `ownership_complete` is set and those mutations become
+meaningful.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 -m unittest scripts.tests.test_check_module_test_registration
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+```
+
+The eleven workspace unit tests build under Make from the module objects; the required pull-request
+CMake jobs build the thin client from the four-source subset and are the standing evidence for the
+thin-client boundary above.
+
+Slice 45 sets `ownership_complete: true`, adds the workspace latch mutation tests, and records the
+completeness audit. Technical-writer review, exact-final-diff roundtable approval, and every required
+pull-request check are required before merge.

--- a/src/modules/workspace/module.yaml
+++ b/src/modules/workspace/module.yaml
@@ -9,5 +9,47 @@
   ],
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/workspace/cli_workspace_serve.c",
+    "src/modules/workspace/workspace.c",
+    "src/modules/workspace/workspace_handle.c",
+    "src/modules/workspace/workspace_manifest.c",
+    "src/modules/workspace/workspace_mirror.c",
+    "src/modules/workspace/workspace_provider_container.c",
+    "src/modules/workspace/workspace_provider_detached.c",
+    "src/modules/workspace/workspace_runner_queue.c",
+    "src/modules/workspace/workspace_runner_registry.c",
+    "src/modules/workspace/workspace_scope.c",
+    "src/modules/workspace/workspace_turn.c"
+  ],
+  "private_headers": [
+    "src/modules/workspace/workspace.h",
+    "src/modules/workspace/workspace_handle.h",
+    "src/modules/workspace/workspace_manifest.h",
+    "src/modules/workspace/workspace_mirror.h",
+    "src/modules/workspace/workspace_provider.h",
+    "src/modules/workspace/workspace_provider_container.h",
+    "src/modules/workspace/workspace_provider_detached.h",
+    "src/modules/workspace/workspace_runner_queue.h",
+    "src/modules/workspace/workspace_runner_registry.h",
+    "src/modules/workspace/workspace_scope.h",
+    "src/modules/workspace/workspace_turn.h"
+  ],
+  "tests": [
+    "src/tests/test_workspace.c",
+    "src/tests/test_workspace_handle.c",
+    "src/tests/test_workspace_manifest.c",
+    "src/tests/test_workspace_mirror.c",
+    "src/tests/test_workspace_provider.c",
+    "src/tests/test_workspace_provider_container.c",
+    "src/tests/test_workspace_provider_detached.c",
+    "src/tests/test_workspace_runner_queue.c",
+    "src/tests/test_workspace_runner_registry.c",
+    "src/tests/test_workspace_scope.c",
+    "src/tests/test_workspace_turn.c"
+  ],
+  "docs": [
+    "docs/modules/workspace.md"
+  ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -605,6 +605,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains learning-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising set-equality on a multi-element declared source and private-header set; the cleared-latch assertion is also converted from a hardcoded module list to a graph-derived scan, which retroactively restores coverage of governance and prevents future drift.",
       "independent_review": "The slice-decision roundtable approved the declaration scope in slice 42; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-43.md", "docs/modules/learning.md", "src/modules/learning/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 44,
+      "state": "present_and_verified",
+      "disposition": "Declared the workspace descriptor's eleven sources, eleven module-root private headers, eleven direct tests, and document without setting ownership_complete, the declaration half of the pair for the third and largest Class B module so far, carving eleven module tests out of a twelve-target family and confirming three internal-only sources are live.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["CMake compiles four of the eleven sources, the thin-client-reachable subset, and omits seven server/runner-side units, the same intentional thin-client boundary recorded for gateway, audit, and learning; the required CMake jobs building the thin client green from the four-source set are the standing evidence the client closure does not reach the seven", "workspace_provider_container.c, workspace_provider_detached.c, and workspace_runner_queue.c have no external includer but are live module-internal units selected through workspace_provider.h and workspace_runner_registry.h", "test_workspace_memory.c carries the workspace name and links workspace.o but is a memory test of memory_auto_tag_workspace, defined in src/modules/memory/memory_core.c, and is not claimed", "all eleven headers are declared private because none sits under a canonical include tree; workspace_provider.h is the dispatch interface with no paired source and cli_workspace_serve.c has no paired header"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Claiming test_workspace_memory.c by its name, or flagging the three internal-only sources as dead, was rejected: the first is a memory test by subject and the second three are wired through the module's own provider and runner interfaces.",
+        "revisit": "Slice 45 latches workspace and makes the runner_queue-through-runner_registry wiring explicit in the completeness audit; a separate header-layout slice may relocate workspace headers under a canonical include tree."
+      },
+      "consumers": ["server, posix, db2, and cmd workspace consumers", "the client serve path", "the workspace latch slice", "remaining Class B declaration slices"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains eleven workspace rows.",
+      "independent_review": "The slice-decision roundtable confirmed all three scoping decisions: exclude test_workspace_memory.c as a memory test, treat the three internal-only sources as live module-owned, and document the seven-source CMake omission as an intentional thin-client boundary. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-44.md", "docs/modules/workspace.md", "src/modules/workspace/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
     }
   ]
 }

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -240,6 +240,72 @@
       "make": true,
       "module": "translation",
       "test": "src/tests/test_aimee_ir_stream.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_handle.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_manifest.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_mirror.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_provider.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_provider_container.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_provider_detached.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_runner_queue.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_runner_registry.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_scope.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "workspace",
+      "test": "src/tests/test_workspace_turn.c"
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 44 — the **declaration** half of the pair for `workspace`, the third and largest Class B module. Declares the descriptor's ownership fields; does not set `ownership_complete`. The slice-decision roundtable approved all three scoping calls.

## Eleven sources, eleven headers, eleven of twelve tests

The module root holds eleven sources and eleven module-root headers (`workspace_provider.h` is the provider dispatch interface with no paired source; `cli_workspace_serve.c` has no paired header). All headers are declared `private_headers` — no canonical include tree exists; promotion is a separate header-layout slice.

Three sources — `workspace_provider_container.c`, `workspace_provider_detached.c`, `workspace_runner_queue.c` — have no external includer but are **live module-internal units**: the container/detached providers are selected through `workspace_provider.h` by `workspace_turn.c` and `cli_workspace_serve.c`, and the runner queue is consumed through `workspace_runner_registry.h`. Their externally visible boundary is the interface header; the impl source behind it with no outside includer is the expected shape, not a dead island.

## test_workspace_memory.c is a memory test

Twelve `test_workspace*.c` files, twelve `unit-test-workspace*` targets. Eleven map one-to-one to the module's concerns and are declared. The twelfth, `test_workspace_memory.c`, exercises `memory_auto_tag_workspace` — defined in `src/modules/memory/memory_core.c` — and links `workspace.o` only for identity. It carries the `workspace` name but is a memory test, the same criterion applied to learning's KB `test_learning_synth.c` and gateway's `test_gateway_*` delivery tests. Not claimed.

## Four of eleven sources in CMake

Make compiles all eleven; CMake compiles the four the thin `aimee` client reaches (`cli_workspace_serve.c`, `workspace.c`, `workspace_manifest.c`, `workspace_provider_detached.c`) and omits the seven server/runner-side units. Same intentional thin-client boundary as gateway (38), audit (34), learning (42). The required CMake jobs building the thin client green from that four-source set are the standing evidence the client's closure doesn't reach the seven. The descriptor records canonical source ownership — which both build systems agree on — not identical build-product membership.

## Validation

All local checks pass; workspace core, turn, and provider-container unit tests build and run green. The test-registration baseline gains exactly the eleven workspace rows. The exact-diff roundtable returned no issues. Latch, mutation coverage, and completeness audit come in slice 45.