### PR TITLE
refactor(workspace): complete module ownership

### DIFF
--- a/docs/modules/workspace.md
+++ b/docs/modules/workspace.md
@@ -16,7 +16,7 @@ worktree creation at line 1175, manifests and handles,
 compatibility/ownership seam to consolidate, not a second workspace implementation.
 
 The descriptor declares this module's eleven sources, eleven module-root headers, eleven direct
-tests, and this document; it does not yet set `ownership_complete`. All eleven headers are declared as
+tests, and this document; it sets `ownership_complete: true`. All eleven headers are declared as
 `private_headers` because they live at the module root rather than under
 `src/modules/workspace/include/aimee/workspace/`, the layout the header-layout checker treats as
 private; `workspace_provider.h` is the provider dispatch interface and has no paired source, while
@@ -28,8 +28,9 @@ consumed through `workspace_runner_registry.h`. Make compiles all eleven sources
 four the thin `aimee` client reaches (`cli_workspace_serve.c`, `workspace.c`, `workspace_manifest.c`,
 `workspace_provider_detached.c`) and omits the seven server/runner-side units, the same intentional
 thin-client boundary recorded for gateway and learning. `docs/validation/core-modularization-slice-44.md`
-records the audit; latching follows in a separate slice so the completeness audit does not review
-declarations authored in the same change.
+records the declaration audit and `docs/validation/core-modularization-slice-45.md` the completeness
+audit; the two were split so the latch reviews declarations merged on their own first. Adding a new
+module-local source or module-root header without declaring it now fails CI on `rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-45.md
+++ b/docs/validation/core-modularization-slice-45.md
@@ -1,0 +1,88 @@
+# Core modularization slice 45: latch workspace ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `workspace` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 44 declared and audited the eleven sources, eleven module-root
+private headers, eleven direct tests, and document on their own, and this slice asserts those
+declarations exhaustively cover the module root and adds the latch mutation coverage. It changes
+descriptor metadata, validation coverage, documentation, and cleanup accounting only; no production
+code, public symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`workspace` is the twelfth latched module and the largest to date: eleven sources and eleven private
+headers, so the `sources` and `private_headers` set-equality checks each compare an eleven-element
+declared set against an eleven-element actual set.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/workspace/include/aimee/workspace/` (which does not exist). The module root contains
+exactly the eleven declared sources and eleven declared headers and nothing else matching those roles,
+so the declared sets equal the actual sets and the latch is exact. The descriptor's `docs` field
+equals `["docs/modules/workspace.md"]`, as the latch requires.
+
+Slice 44 established the liveness, build-membership, and test-classification evidence, and the
+slice-decision roundtable approved the three scoping calls: all eleven headers stay privately declared;
+`test_workspace_memory.c` is a memory test, not a module test; and the CMake four-of-eleven membership
+is an intentional thin-client boundary. It also carried one item forward to this slice — make the
+`workspace_runner_queue.c` wiring explicit. `workspace_runner_queue.h` is included by
+`workspace_runner_registry.h`, so the runner queue is part of the runner registry's compiled surface;
+the registry has external callers in the runner and serve paths, so the queue is reachable in
+production through it. That audit is otherwise not repeated here; this slice adds only the completeness
+assertion on the already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+the compatibility worktree declarations in `guardrails.h` (a documented consolidation seam) or any
+adjacent workspace-touching code outside the module root have been moved in, and it does not claim
+identical build-product membership across Make and CMake.
+
+## Eleven-element set-equality
+
+Governance latched with one source and one header; learning with four of each. `workspace` gives each
+set-equality check eleven declared entries against eleven actual files, the largest in the program. The
+regression suite removes `workspace_turn.c` from `sources` and requires `rule=ownership-complete` on
+`/sources` with the source named missing, and removes `workspace_provider.h` from `private_headers`
+and requires the same rule on `/private_headers` with the header named missing — confirming the checks
+bite when one element of an eleven-element declared set is dropped.
+
+## Regression controls
+
+The descriptor mutation suite removes `workspace_turn.c` and requires `rule=ownership-complete` on
+`/sources`, and removes `workspace_provider.h` and requires the same rule on `/private_headers`. It
+plants `src/modules/workspace/undeclared.c` and `undeclared.h` and requires the rule on `/sources` and
+`/private_headers`. It removes `docs/modules/workspace.md` from the descriptor's `docs` field and
+requires the rule on `/docs`. The graph-derived latched-descriptor assertion from slice 43 now also
+covers `workspace`, so clearing the latch fails directly. The empty-domain guard from slice 39 does not
+apply, because the module root is not empty. The unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-workspace build/obj/tests/unit-test-workspace-turn
+src/build/obj/tests/unit-test-workspace
+src/build/obj/tests/unit-test-workspace-turn
+```
+
+`cmake` is unavailable in the environment used for this slice, and CMake compiles a subset of this
+module's sources into the thin client without a module test target, so there is no module-specific
+CMake command to add; the required pull-request CMake jobs continue to cover the thin-client profile
+they own.
+
+With `workspace` latched, twelve modules carry `ownership_complete`. The remaining six Class B modules
+(`vault`, `config`, `git`, `delegates`, `workflows`, `memory`) follow the same declaration-then-latch
+pair, and the eight Class A modules remain blocked by the empty-domain guard and tracked in
+`docs/validation/core-modularization-class-a-migration.md`. Technical-writer review, exact-final-diff
+roundtable approval, and every required pull-request check are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -277,6 +277,8 @@ class DescriptorTests(unittest.TestCase):
             ("governance", "private_headers", "src/modules/governance/gw_stage_governance.h"),
             ("learning", "sources", "src/modules/learning/learning_router.c"),
             ("learning", "private_headers", "src/modules/learning/learning.h"),
+            ("workspace", "sources", "src/modules/workspace/workspace_turn.c"),
+            ("workspace", "private_headers", "src/modules/workspace/workspace_provider.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -296,7 +298,8 @@ class DescriptorTests(unittest.TestCase):
                 tmp.cleanup()
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
-                           "module-runtime", "plugin-loader", "gateway", "governance", "learning"):
+                           "module-runtime", "plugin-loader", "gateway", "governance", "learning",
+                           "workspace"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -399,7 +402,8 @@ class DescriptorTests(unittest.TestCase):
 
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
-                           "module-runtime", "plugin-loader", "gateway", "governance", "learning"):
+                           "module-runtime", "plugin-loader", "gateway", "governance", "learning",
+                           "workspace"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/workspace/module.yaml
+++ b/src/modules/workspace/module.yaml
@@ -10,6 +10,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/workspace/cli_workspace_serve.c",
     "src/modules/workspace/workspace.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -622,6 +622,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains eleven workspace rows.",
       "independent_review": "The slice-decision roundtable confirmed all three scoping decisions: exclude test_workspace_memory.c as a memory test, treat the three internal-only sources as live module-owned, and document the seven-source CMake omission as an intentional thin-client boundary. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-44.md", "docs/modules/workspace.md", "src/modules/workspace/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 45,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the workspace descriptor against the declarations slice 44 authored and reviewed on their own, the latch half of the pair for the third and largest Class B module, and exercised the sources and private_headers set-equality checks against an eleven-element declared set, the largest in the program.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, eleven sources and eleven module-root headers, not that the compatibility worktree declarations in guardrails.h or adjacent workspace-touching code outside the module root have been moved in", "CMake compiles four of the eleven sources and omits seven server/runner-side units, the same intentional thin-client boundary recorded for gateway, audit, and learning", "workspace_runner_queue.c is reachable in production through workspace_runner_registry.h, which includes workspace_runner_queue.h and has external callers in the runner and serve paths"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The remaining six Class B modules follow the same declaration-then-latch pair; a separate header-layout slice may relocate workspace headers under a canonical include tree."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining Class B declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains workspace-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising set-equality on an eleven-element declared source and private-header set.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 44 and carried the runner-queue wiring evidence forward to this slice; this slice adds only the completeness assertion and that evidence. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-45.md", "docs/modules/workspace.md", "src/modules/workspace/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 45 — the **latch** half for `workspace`, against the declarations [#1874](https://github.com/RakuenSoftware/aimee/pull/1874) merged on their own. Twelfth module latched, largest to date.

## Largest set-equality in the program

Governance latched with one source and one header; learning with four of each. `workspace` gives the `sources` and `private_headers` set-equality checks **eleven declared entries against eleven actual files** each. The regression suite drops one element of each eleven-element set (`workspace_turn.c`, `workspace_provider.h`) and requires `rule=ownership-complete` naming the missing file — confirming the checks bite on a single-element omission from a large set.

## Runner-queue wiring, made explicit

The declaration roundtable carried one item to this slice: demonstrate `workspace_runner_queue.c`'s wiring rather than assert it. `workspace_runner_queue.h` is included by `workspace_runner_registry.h`, which has external callers in the runner and serve paths — so the queue is reachable in production through the registry. Recorded in the completeness audit.

## Scope

The latch scopes to the module root as it stands. The compatibility worktree declarations in `guardrails.h` (a documented consolidation seam) and adjacent workspace-touching code outside the module root are not claimed, and the audit does not claim identical Make/CMake build-product membership. No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

All local checks pass; workspace core and turn unit tests build and run green. The exact-diff roundtable returned no issues.

Twelve modules now carry `ownership_complete`; six Class B modules remain (`vault`, `config`, `git`, `delegates`, `workflows`, `memory`).