### PR TITLE
Recover lost replay-only WFE work instead of looping runner_unavailable

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -937,6 +937,69 @@ WHERE work_item_id=? AND current_stage=? AND state='active' AND pause_reason='' 
 	return tx.Commit()
 }
 
+// RecoverLostReplay resolves a replay-only invocation whose durable delegate
+// result is gone (e.g. a restart killed the in-flight job). A reservation left
+// 'unresolved' was an ambiguous, interrupted dispatch whose estimate never
+// reached cum_cost_usd: the interruption is recoverable, so the reservation is
+// released and the item is left runnable for a fresh dispatch (redispatch=true).
+// A reservation left 'actual' means the cost was measured and reconciled but the
+// result cannot be reproduced: re-running would double-bill known spend, so the
+// measured cost is committed and the item is parked non-transiently for a human
+// (redispatch=false). Only the current owner may recover.
+func (s *Store) RecoverLostReplay(ctx context.Context, workItemID, stage, owner string) (redispatch bool, err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	var state, currentOwner string
+	var amount float64
+	if err := tx.QueryRowContext(ctx, `SELECT reservation_state,reservation_owner,reserved_cost_usd
+FROM lifecycle_work_item WHERE work_item_id=?`, workItemID).Scan(&state, &currentOwner, &amount); err != nil {
+		return false, err
+	}
+	if currentOwner != owner {
+		return false, errors.New("lost-replay reservation is owned by another invocation")
+	}
+	switch state {
+	case "unresolved":
+		// Recoverable interruption: drop the never-committed estimate and leave the
+		// item runnable so the next scheduler pass re-dispatches fresh work.
+		result, err := tx.ExecContext(ctx, `UPDATE lifecycle_work_item
+SET reserved_cost_usd=0,reservation_state='',reservation_owner='',reservation_lease_until='',updated_at=datetime('now')
+WHERE work_item_id=? AND reservation_owner=? AND reservation_state='unresolved'`, workItemID, owner)
+		if err != nil {
+			return false, err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return false, errors.New("lost-replay reservation changed concurrently")
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO lifecycle_event (work_item_id,stage,kind,actor,detail,cost_usd) VALUES (?,?, 'redispatch','go-wfe','replay result lost; re-dispatching fresh',0)`, workItemID, stage); err != nil {
+			return false, err
+		}
+		return true, tx.Commit()
+	case "actual":
+		// Known spend whose result is unreproducible: commit the measured cost and
+		// park for a human rather than silently re-billing it.
+		result, err := tx.ExecContext(ctx, `UPDATE lifecycle_work_item
+SET cum_cost_usd=cum_cost_usd+reserved_cost_usd,reserved_cost_usd=0,reservation_state='',reservation_owner='',
+    reservation_lease_until='',pause_reason='replay_unrecoverable',paused_state=current_stage,updated_at=datetime('now')
+WHERE work_item_id=? AND reservation_owner=? AND reservation_state='actual'`, workItemID, owner)
+		if err != nil {
+			return false, err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return false, errors.New("lost-replay reservation changed concurrently")
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO lifecycle_event (work_item_id,stage,kind,actor,detail,cost_usd) VALUES (?,?, 'pause','go-wfe','replay_unrecoverable: reconciled result lost, parked for human',?)`, workItemID, stage, amount); err != nil {
+			return false, err
+		}
+		return false, tx.Commit()
+	default:
+		return false, fmt.Errorf("lost-replay reservation is not replayable (state=%q)", state)
+	}
+}
+
 func (s *Store) ParkBudgetTree(ctx context.Context, rootID, completedItemID string, addedCost float64) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -1025,3 +1025,88 @@ func TestReconcileRejectsNonFiniteCost(t *testing.T) {
 		t.Fatalf("cum_cost polluted by rejected cost: %+v err=%v", got, err)
 	}
 }
+
+// A replay whose durable result is gone recovers per reservation state: an
+// 'unresolved' (interrupted) reservation is released for a fresh dispatch; an
+// 'actual' (measured, reconciled) reservation commits its cost and parks for a
+// human rather than silently re-billing it.
+func TestRecoverLostReplayReleasesUnresolvedAndParksActual(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("unresolved_redispatches", func(t *testing.T) {
+		store := newTestStore(t)
+		item := CreateWorkItem{ID: "wi_lost_unresolved", Repo: "r", ProposalPath: "u", WorkflowName: "build", WorkflowVersion: "v1", StartStage: "impl", MaxCostUSD: 1}
+		if err := store.CreateWorkItem(ctx, item); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.ReserveWorkflowBudget(ctx, item.ID, "owner1"); err != nil {
+			t.Fatal(err)
+		}
+		// Ambiguous post-dispatch failure leaves the reservation 'unresolved'.
+		if err := store.ParkRunnerFailure(ctx, item.ID, "impl", "owner1", "runner_unavailable", "d", true, false, 0); err != nil {
+			t.Fatal(err)
+		}
+		// A restart resumes: a new owner takes replay ownership.
+		if _, err := store.db.ExecContext(ctx, `UPDATE lifecycle_work_item SET pause_reason='', reservation_lease_until=datetime('now','-1 minute') WHERE work_item_id=?`, item.ID); err != nil {
+			t.Fatal(err)
+		}
+		res, err := store.ReserveWorkflowBudget(ctx, item.ID, "owner2")
+		if err != nil || !res.ReplayOnly {
+			t.Fatalf("res=%+v err=%v", res, err)
+		}
+		redispatch, err := store.RecoverLostReplay(ctx, item.ID, "impl", "owner2")
+		if err != nil || !redispatch {
+			t.Fatalf("redispatch=%v err=%v", redispatch, err)
+		}
+		got, err := store.WorkItem(ctx, item.ID)
+		if err != nil || got.State != "active" || got.PauseReason != "" || got.ReservationState != "" || got.ReservedCostUSD != 0 {
+			t.Fatalf("item not runnable/cleared: %+v err=%v", got, err)
+		}
+	})
+
+	t.Run("actual_parks_for_human", func(t *testing.T) {
+		store := newTestStore(t)
+		item := CreateWorkItem{ID: "wi_lost_actual", Repo: "r", ProposalPath: "a", WorkflowName: "build", WorkflowVersion: "v1", StartStage: "impl", MaxCostUSD: 1}
+		if err := store.CreateWorkItem(ctx, item); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.ReserveWorkflowBudget(ctx, item.ID, "owner1"); err != nil {
+			t.Fatal(err)
+		}
+		if allowed, err := store.ReconcileWorkflowBudget(ctx, item.ID, "owner1", 0.4); err != nil || !allowed {
+			t.Fatalf("reconcile allowed=%v err=%v", allowed, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE lifecycle_work_item SET reservation_lease_until=datetime('now','-1 minute') WHERE work_item_id=?`, item.ID); err != nil {
+			t.Fatal(err)
+		}
+		res, err := store.ReserveWorkflowBudget(ctx, item.ID, "owner2")
+		if err != nil || !res.ReplayOnly {
+			t.Fatalf("res=%+v err=%v", res, err)
+		}
+		redispatch, err := store.RecoverLostReplay(ctx, item.ID, "impl", "owner2")
+		if err != nil || redispatch {
+			t.Fatalf("redispatch=%v err=%v", redispatch, err)
+		}
+		got, err := store.WorkItem(ctx, item.ID)
+		if err != nil || got.PauseReason != "replay_unrecoverable" || got.ReservationState != "" || got.ReservedCostUSD != 0 || got.CumulativeCostUSD != 0.4 {
+			t.Fatalf("expected parked with committed cost: %+v err=%v", got, err)
+		}
+	})
+
+	t.Run("wrong_owner_refused", func(t *testing.T) {
+		store := newTestStore(t)
+		item := CreateWorkItem{ID: "wi_lost_owner", Repo: "r", ProposalPath: "o", WorkflowName: "build", WorkflowVersion: "v1", StartStage: "impl", MaxCostUSD: 1}
+		if err := store.CreateWorkItem(ctx, item); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.ReserveWorkflowBudget(ctx, item.ID, "owner1"); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.ParkRunnerFailure(ctx, item.ID, "impl", "owner1", "runner_unavailable", "d", true, false, 0); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.RecoverLostReplay(ctx, item.ID, "impl", "intruder"); err == nil {
+			t.Fatal("recover accepted a non-owner")
+		}
+	})
+}

--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -125,6 +125,13 @@ var ErrDelegateCancelUnacknowledged = errors.New("delegate cancellation was not 
 var ErrDelegateNoJobID = errors.New("agent service returned no job id")
 var ErrDelegateTerminal = errors.New("delegate job reached a failed terminal state")
 
+// ErrDelegateReplayUnavailable is returned when a replay-only invocation cannot
+// find the durable delegate result it is required to reuse (e.g. the in-flight
+// job was killed by a restart and its mapping was lost). Replay can never
+// succeed, so the engine must recover — re-dispatch a recoverable interruption
+// or park a lost reconciled result for a human — instead of retrying forever.
+var ErrDelegateReplayUnavailable = errors.New("replay-only delegate result is unavailable")
+
 // DelegateExecutionError carries the billing boundary across transport and
 // runner layers. A caller must not infer provider dispatch merely because the
 // delegate API was called: validation and admission failures are pre-dispatch,
@@ -303,7 +310,7 @@ func (c *HTTPAgentClient) delegateOnce(ctx context.Context, request DelegateRequ
 		}
 	}
 	if launched.JobID <= 0 && request.ReplayOnly {
-		return DelegateResult{}, &DelegateExecutionError{Err: errors.New("replay-only delegate result is unavailable"), Dispatched: true, CostKnown: false}
+		return DelegateResult{}, &DelegateExecutionError{Err: ErrDelegateReplayUnavailable, Dispatched: true, CostKnown: false}
 	}
 	if launched.JobID == 0 {
 		if err := c.doJSONKey(ctx, http.MethodPost, "/v1/delegate/run", payload, &launched, key); err != nil {

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -218,6 +218,23 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		defer budgetLock.Unlock()
 	}
 	if err != nil {
+		// A replay-only invocation whose durable result is gone can never succeed
+		// by retrying: recover it (re-dispatch a recoverable interruption, or park a
+		// lost reconciled result for a human) instead of looping runner_unavailable.
+		if errors.Is(err, ErrDelegateReplayUnavailable) {
+			retainBudget = true // RecoverLostReplay owns the reservation transition.
+			redispatch, recErr := e.db.RecoverLostReplay(context.WithoutCancel(ctx), item.ID, item.Stage, owner)
+			if recErr != nil {
+				return out, recErr
+			}
+			if redispatch {
+				// The item is left runnable with no reservation; the next scheduler
+				// pass re-reserves and dispatches fresh work.
+				return out, nil
+			}
+			out.Parked, out.PauseReason = true, "replay_unrecoverable"
+			return out, nil
+		}
 		reason := "runner_unavailable"
 		if errors.Is(err, context.DeadlineExceeded) {
 			reason = "wall_cap"

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -17,6 +17,18 @@ import (
 	"github.com/JBailes/aimee/server-go/internal/wfe"
 )
 
+func execOnDB(t *testing.T, path, query string, args ...any) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // expireBudgetLease simulates a crashed owner whose reservation lease has run
 // out. Replay ownership is only transferable once the lease lapses.
 func expireBudgetLease(t *testing.T, path, workItemID string) {
@@ -898,4 +910,93 @@ func TestMeasuredZeroCostIsNotInflated(t *testing.T) {
 	if got.CumulativeCostUSD != 0 {
 		t.Fatalf("measured zero was inflated to %v: %+v", got.CumulativeCostUSD, got)
 	}
+}
+
+type replayUnavailableRunner struct{ t *testing.T }
+
+func (r replayUnavailableRunner) Run(_ context.Context, req StepRequest) (StepResult, error) {
+	if !req.ReplayOnly {
+		r.t.Fatal("replay-unavailable runner invoked without ReplayOnly")
+	}
+	return StepResult{}, &DelegateExecutionError{Err: ErrDelegateReplayUnavailable, Dispatched: true, CostKnown: false}
+}
+
+// A replay-only invocation whose durable result is gone must recover, not loop:
+// an interrupted (unresolved) reservation re-dispatches; a lost reconciled
+// (actual) one parks for a human.
+func TestLostReplayRecoversInsteadOfLooping(t *testing.T) {
+	setup := func(t *testing.T, id string) (*db1.Store, *Engine, string) {
+		root := t.TempDir()
+		workflowDir := filepath.Join(root, "workflows")
+		if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		definition := []byte("name: one\nstart: work\nnodes:\n  - id: work\n    block: author.proposal\n")
+		if err := os.WriteFile(filepath.Join(workflowDir, "one.yaml"), definition, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		def, err := wfe.ParseDefinition(definition)
+		if err != nil {
+			t.Fatal(err)
+		}
+		store, err := db1.Open(filepath.Join(root, "aimee.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: id, WorkflowName: "one", WorkflowVersion: def.Version, StartStage: "work", MaxCostUSD: 1}
+		if err := store.CreateWorkItem(t.Context(), item); err != nil {
+			t.Fatal(err)
+		}
+		if err := artifacts.PutProposal(item.ID, []byte("proposal")); err != nil {
+			t.Fatal(err)
+		}
+		eng, err := New(store, artifacts, workflowDir, replayUnavailableRunner{t: t})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return store, eng, filepath.Join(root, "aimee.db")
+	}
+
+	t.Run("unresolved_redispatches", func(t *testing.T) {
+		store, eng, dbPath := setup(t, "wi_replay_lost_unresolved")
+		if _, err := store.ReserveWorkflowBudget(t.Context(), "wi_replay_lost_unresolved", "o1"); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.ParkRunnerFailure(t.Context(), "wi_replay_lost_unresolved", "work", "o1", "runner_unavailable", "d", true, false, 0); err != nil {
+			t.Fatal(err)
+		}
+		execOnDB(t, dbPath, `UPDATE lifecycle_work_item SET pause_reason='', reservation_lease_until=datetime('now','-1 minute') WHERE work_item_id=?`, "wi_replay_lost_unresolved")
+		out, err := eng.Advance(t.Context(), "wi_replay_lost_unresolved")
+		if err != nil || out.Parked || out.Ran {
+			t.Fatalf("expected a silent redispatch: out=%+v err=%v", out, err)
+		}
+		got, err := store.WorkItem(t.Context(), "wi_replay_lost_unresolved")
+		if err != nil || got.State != "active" || got.PauseReason != "" || got.ReservationState != "" {
+			t.Fatalf("item not left runnable: %+v err=%v", got, err)
+		}
+	})
+
+	t.Run("actual_parks_for_human", func(t *testing.T) {
+		store, eng, dbPath := setup(t, "wi_replay_lost_actual")
+		if _, err := store.ReserveWorkflowBudget(t.Context(), "wi_replay_lost_actual", "o1"); err != nil {
+			t.Fatal(err)
+		}
+		if allowed, err := store.ReconcileWorkflowBudget(t.Context(), "wi_replay_lost_actual", "o1", 0.3); err != nil || !allowed {
+			t.Fatalf("reconcile allowed=%v err=%v", allowed, err)
+		}
+		execOnDB(t, dbPath, `UPDATE lifecycle_work_item SET reservation_lease_until=datetime('now','-1 minute') WHERE work_item_id=?`, "wi_replay_lost_actual")
+		out, err := eng.Advance(t.Context(), "wi_replay_lost_actual")
+		if err != nil || !out.Parked || out.PauseReason != "replay_unrecoverable" {
+			t.Fatalf("expected park replay_unrecoverable: out=%+v err=%v", out, err)
+		}
+		got, err := store.WorkItem(t.Context(), "wi_replay_lost_actual")
+		if err != nil || got.PauseReason != "replay_unrecoverable" || got.CumulativeCostUSD != 0.3 || got.ReservationState != "" {
+			t.Fatalf("expected committed cost + human park: %+v err=%v", got, err)
+		}
+	})
 }


### PR DESCRIPTION
## Problem

A work item whose reservation is `unresolved` or `actual` is dispatched with `ReplayOnly=true` so a restart reuses the durable delegate result rather than launching new billable work. But when that durable result is **gone** — e.g. a server restart killed the in-flight delegate and its job mapping — `delegateOnce` returned a generic error, the engine parked `runner_unavailable` (a **transient** pause the scheduler auto-resumes on a 5s backoff), and the item retried the impossible replay **forever**. Idle workers, zero forward progress, admission wedged behind the stuck roots.

Observed on the `.254` appliance after a deploy restart: ~25 slice items re-parking every 5s with `runner_unavailable: replay-only delegate result is unavailable`.

## Fix

Recover by the kill reason instead of retrying the impossible:

- `delegateOnce` returns a typed `ErrDelegateReplayUnavailable`.
- On that error the engine calls `Store.RecoverLostReplay`:
  - **`unresolved`** (ambiguous, interrupted dispatch whose estimate never reached `cum_cost_usd`) — recoverable interruption: release the reservation and leave the item runnable so the next scheduler pass **re-dispatches fresh**.
  - **`actual`** (cost measured and reconciled, result unreproducible) — re-running would double-bill known spend: commit the measured cost and **park non-transiently as `replay_unrecoverable`** for a human. `replay_unrecoverable` is deliberately not in the transient-resume set.

This matches the intended model: queue → delegate → work; on kill, recoverable → re-dispatch, else park for human.

## Tests
- `TestRecoverLostReplayReleasesUnresolvedAndParksActual` (store: both branches + wrong-owner refusal)
- `TestLostReplayRecoversInsteadOfLooping` (engine end-to-end: redispatch vs human park)
- `go build`, `go vet`, `go test ./...`, `go test -race` on db1 + engine — green.