### PR TITLE
refactor(vault): declare module ownership

### DIFF
--- a/docs/modules/vault.md
+++ b/docs/modules/vault.md
@@ -15,6 +15,23 @@ Canonical implementation lives in `src/modules/vault`: the server-wrap retrieval
 attested identities, and `vault_capability` limits delegated access. Direct calls to internal vault
 implementations outside these facades are boundary violations rather than alternate public APIs.
 
+The descriptor declares this module's twelve sources, thirteen module-root headers, eleven direct
+tests, and this document; it does not yet set `ownership_complete`. All thirteen headers are declared
+as `private_headers` because they live at the module root rather than under
+`src/modules/vault/include/aimee/vault/`, the layout the header-layout checker treats as private;
+`vault_internal.h` is the backend-seam header and has no paired source. The four custody backends
+(`vault_custody_kms.c`, `vault_custody_mock.c`, `vault_custody_pkcs11.c`, `vault_custody_tpm2.c`) are
+always compiled by Make: `WITH_TPM2` and `WITH_PKCS11` toggle a `-D` flag that switches the tpm2 and
+pkcs11 sources between a real implementation and a fail-closed stub rather than omitting them.
+`vault_hwm.c` has no external includer but is live: `vault_custody_kms.c` calls
+`vault_hwm_attest_verify` in its high-water-mark attestation path. CMake compiles the six sources the
+thin `aimee` client reaches (`vault_capability.c`, `vault_crypto.c`, `vault_kek_cache.c`,
+`vault_principal.c`, `vault_service.c`, `vault_store.c`) and omits the four custody backends,
+`vault_hwm.c`, and `vault_server_key.c`, the same intentional thin-client boundary recorded for
+gateway, learning, and workspace. `docs/validation/core-modularization-slice-46.md` records the audit;
+latching follows in a separate slice so the completeness audit does not review declarations authored
+in the same change.
+
 ## Dependencies and consumers
 
 - `config`: supplies selected custody provider and provider-specific effective settings.
@@ -74,10 +91,22 @@ principal, decision, and outcome metadata before transient plaintext is discarde
 
 ## Tests and failure behavior
 
-`test_vault_service.c`, `test_vault_store.c`, `test_vault_seam.c`, capability, principal, bootstrap,
-seal, rotation, PostgreSQL, KMS, PKCS#11, and TPM2 suites cover the layered contracts. Wrong principal,
-locked/sealed state, corrupt ciphertext, missing entry, expired capability, or custody failure must
-return typed failure and never expose partial plaintext or select a weaker backend silently.
+The descriptor's eleven direct tests are `test_vault_capability.c`, `test_vault_crypto.c`,
+`test_vault_kek_cache.c`, `test_vault_kms.c`, `test_vault_master_rotate.c`, `test_vault_principal.c`,
+`test_vault_seam.c`, `test_vault_server_key.c`, `test_vault_service.c`, `test_vault_store.c`, and
+`test_vault_tpm2.c`. The last backs the `WITH_TPM2`-gated `p7-tpm2-harness` and is the only test that
+links and exercises the real `vault_custody_tpm2.c`, so it is claimed despite the gate. Several
+`test_vault_*` files exercise other modules and are not claimed: `test_vault_audit.c` pins
+`vault_audit_server_write` in `src/server/server_vault.c` (server), `test_vault_seal.c` and
+`test_vault_tpm2_stub.c` drive the `kb/kb_vault_policy.c` seal barrier (KB), `test_vault_pg.c` links
+`kb/kb_main.c` (KB integration), and `test_vault_bootstrap.c` drives `server_vault_bootstrap.c`
+(server). `test_vault_custody_pkcs11.c` is an orphan that no build target compiles; it is left
+undeclared and flagged for a later cleanup rather than claimed as coverage. `vault_hwm.c`,
+`vault_custody_mock.c`, and `vault_custody_pkcs11.c` have no declared direct test; they are exercised
+transitively (the high-water-mark path through `test_vault_kms.c`, the mock custody through the
+service and store suites). Wrong principal, locked/sealed state, corrupt ciphertext, missing entry,
+expired capability, or custody failure must return typed failure and never expose partial plaintext or
+select a weaker backend silently.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-46.md
+++ b/docs/validation/core-modularization-slice-46.md
@@ -1,0 +1,151 @@
+# Core modularization slice 46: declare vault ownership
+
+## Scope
+
+This slice declares the `vault` descriptor's `sources`, `private_headers`, `tests`, and `docs`
+fields. It does not set `ownership_complete`. It is the declaration half of the declaration-then-latch
+pair; the latch, its mutation coverage, and the completeness audit follow in slice 47. It changes
+descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting
+only; no production code, public symbol, build membership, configuration, storage, or runtime behavior
+changes. No header is moved and no include site is rewritten.
+
+`vault` is the fourth Class B module and the most test-classification-heavy so far: twelve sources,
+thirteen module-root headers, and seventeen `test_vault*.c` files across fifteen `unit-test-vault-*`
+targets plus a gated harness and an orphan. Because it is security-sensitive, the source liveness and
+test classification were audited individually and taken to the slice-decision roundtable.
+
+## What the module owns
+
+The module root `src/modules/vault/` contains, excluding `module.yaml`:
+
+- Twelve sources: `vault_capability.c`, `vault_crypto.c`, `vault_custody_kms.c`,
+  `vault_custody_mock.c`, `vault_custody_pkcs11.c`, `vault_custody_tpm2.c`, `vault_hwm.c`,
+  `vault_kek_cache.c`, `vault_principal.c`, `vault_server_key.c`, `vault_service.c`,
+  `vault_store.c`.
+- Thirteen headers: the twelve paired headers plus `vault_internal.h`, the backend-seam header with
+  no paired source.
+
+No `src/modules/vault/include/aimee/vault/` directory exists, so every header is at the module root
+and is declared in `private_headers`. The header-layout checker constrains only declared
+`public_headers`, so the private declaration is accurate to the layout; any future promotion is a
+separate header-layout slice.
+
+## Source liveness
+
+Every declared source is live. Ten have external callers across the server, kb, db2, and other module
+layers — `vault_service.c` alone is reached by roughly thirty files. Two need explicit notes:
+
+- `vault_hwm.c` has no external includer but is a live module-internal unit: `vault_custody_kms.c`
+  includes `vault_hwm.h` and calls `vault_hwm_attest_verify` in its high-water-mark attestation path.
+- The four custody backends are always compiled by Make. `WITH_TPM2` and `WITH_PKCS11` toggle a `-D`
+  flag that switches `vault_custody_tpm2.c` and `vault_custody_pkcs11.c` between a real implementation
+  and a fail-closed stub; the source is never omitted. `vault_custody_mock.c` is the always-available
+  mock custody backend and `vault_custody_kms.c` the KMS backend.
+
+## Build membership
+
+Make's `DATA_SRCS` compiles all twelve sources and carries the `-Imodules/vault` include path. CMake
+compiles six: `vault_capability.c`, `vault_crypto.c`, `vault_kek_cache.c`, `vault_principal.c`,
+`vault_service.c`, `vault_store.c` — the units the thin `aimee` client reaches. It omits the four
+custody backends, `vault_hwm.c`, and `vault_server_key.c`, which are the server/kb-side custody,
+attestation, and server-sealed-KEK units. This is the same intentional thin-client profile boundary
+recorded for gateway (slice 38), audit (slice 34), learning (slice 42), and workspace (slice 44), not
+source-list drift. The descriptor records canonical source ownership, which both build systems agree
+on; it does not claim identical build-product membership.
+
+## Test membership
+
+Classification is by subject — what a test exercises, per its header comment and the object it
+primarily drives — not by the `vault` name. Eleven tests are declared:
+
+- `test_vault_capability.c`, `test_vault_crypto.c`, `test_vault_kek_cache.c`,
+  `test_vault_principal.c`, `test_vault_server_key.c`, `test_vault_service.c`, `test_vault_store.c` —
+  each drives its like-named vault source.
+- `test_vault_kms.c` drives `vault_custody_kms.c` (includes `vault_custody_kms.h`) and transitively
+  exercises `vault_hwm.c`.
+- `test_vault_master_rotate.c` and `test_vault_seam.c` link only vault-module objects (master-key
+  rotation over the service and server-key; the `vault_internal.h` backend seam over the store).
+- `test_vault_tpm2.c` backs the `WITH_TPM2`-gated `p7-tpm2-harness` and is the only test that links
+  and exercises the real `vault_custody_tpm2.c`. The slice-decision roundtable directed that it be
+  claimed despite the gate, because omitting it would leave the descriptor claiming the tpm2 custody
+  source with no named test — a hidden coverage gap. Its registration row records `make: true`
+  (the harness object is referenced in `Rules.mk`) and `ctest: false`; the `WITH_TPM2` gate is an
+  invocation condition, not a registration one.
+
+Five `test_vault_*` files are excluded because their subject is another module's source, the same
+subject-over-name criterion applied to gateway, learning, and workspace:
+
+- `test_vault_audit.c` pins `vault_audit_server_write`, defined in `src/server/server_vault.c` — a
+  server test.
+- `test_vault_seal.c` drives the custody seal/unseal barrier; its primary include is
+  `kb/kb_vault_policy.h` and it links `kb/kb_vault_policy.o` as its subject — a KB test.
+- `test_vault_tpm2_stub.c` drives the no-libtss2 default-build seal path; its primary include is
+  `kb/kb_vault_policy.h`, it links `kb_vault_policy.o`, and it does not link `vault_custody_tpm2.o`,
+  so it exercises the barrier's stub behaviour rather than the vault custody source — a KB test.
+- `test_vault_pg.c` is the Postgres credential-vault backend test and links `kb/kb_main.o` — a KB
+  integration test.
+- `test_vault_bootstrap.c` drives boot-time delegate-vault provisioning whose subject
+  `server_vault_bootstrap.c` is a server file (it links `server/server_vault_bootstrap.o` alongside
+  five vault objects) — a server test.
+
+`test_vault_custody_pkcs11.c` is referenced by no `Rules.mk` target: it is an orphan test file that no
+build compiles or runs. An unbuilt file is not a coverage claim, so it is left undeclared and recorded
+here as a cleanup follow-up — wire it to a target or delete it — rather than claimed.
+
+`vault_hwm.c`, `vault_custody_mock.c`, and `vault_custody_pkcs11.c` have no declared direct test.
+Tests are audited claims, not a per-source requirement: the high-water-mark path is covered
+transitively through `test_vault_kms.c`, and the mock custody through the service and store suites.
+The pkcs11 custody source's only test is the orphan above, which is why it has no named coverage until
+that orphan is resolved.
+
+CTest registers none of the vault tests, consistent with the module's server/kb-side sources sitting
+outside the thin-client profile. `scripts/check_module_test_registration.py` now records eleven vault
+rows (`make: true`, `ctest: false`); that regeneration is the only reason the baseline file changes.
+
+## Why declare without latching
+
+The latch asserts the descriptor exhaustively covers the module root. That is true today — the module
+root holds exactly these twelve sources and thirteen headers — so the latch would pass. It is deferred
+because declaring the files and asserting completeness are distinct claims, and the roundtable
+required the completeness audit to review declarations merged on their own first rather than authored
+in the same change. The validator accepts a declared-but-unlatched descriptor: it checks each declared
+path exists and resolves within the module, and enforces set-equality only when `ownership_complete`
+is true.
+
+## Regression controls
+
+The declaration is covered by the existing descriptor validation: every declared path must exist and
+resolve within the module, and the regenerated test-registration baseline pins the eleven vault tests'
+per-suite registration. The empty-domain guard from slice 39 does not apply, because the module root
+is not empty. The latch mutation coverage — source removal, private-header removal, planted files,
+cleared latch — is deferred to slice 47, where `ownership_complete` is set and those mutations become
+meaningful.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 -m unittest scripts.tests.test_check_module_test_registration
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-vault-service build/obj/tests/unit-test-vault-kms
+src/build/obj/tests/unit-test-vault-service
+src/build/obj/tests/unit-test-vault-kms
+```
+
+`test_vault_tpm2.c` builds only under `make WITH_TPM2=1`; its default build is the fail-closed stub
+exercised elsewhere, so it is not in the default local test list above. The required pull-request CMake
+jobs build the thin client from the six-source subset.
+
+Slice 47 sets `ownership_complete: true`, adds the vault latch mutation tests, and records the
+completeness audit. Technical-writer review, exact-final-diff roundtable approval, and every required
+pull-request check are required before merge.

--- a/src/modules/vault/module.yaml
+++ b/src/modules/vault/module.yaml
@@ -8,5 +8,50 @@
   ],
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/vault/vault_capability.c",
+    "src/modules/vault/vault_crypto.c",
+    "src/modules/vault/vault_custody_kms.c",
+    "src/modules/vault/vault_custody_mock.c",
+    "src/modules/vault/vault_custody_pkcs11.c",
+    "src/modules/vault/vault_custody_tpm2.c",
+    "src/modules/vault/vault_hwm.c",
+    "src/modules/vault/vault_kek_cache.c",
+    "src/modules/vault/vault_principal.c",
+    "src/modules/vault/vault_server_key.c",
+    "src/modules/vault/vault_service.c",
+    "src/modules/vault/vault_store.c"
+  ],
+  "private_headers": [
+    "src/modules/vault/vault_capability.h",
+    "src/modules/vault/vault_crypto.h",
+    "src/modules/vault/vault_custody_kms.h",
+    "src/modules/vault/vault_custody_mock.h",
+    "src/modules/vault/vault_custody_pkcs11.h",
+    "src/modules/vault/vault_custody_tpm2.h",
+    "src/modules/vault/vault_hwm.h",
+    "src/modules/vault/vault_internal.h",
+    "src/modules/vault/vault_kek_cache.h",
+    "src/modules/vault/vault_principal.h",
+    "src/modules/vault/vault_server_key.h",
+    "src/modules/vault/vault_service.h",
+    "src/modules/vault/vault_store.h"
+  ],
+  "tests": [
+    "src/tests/test_vault_capability.c",
+    "src/tests/test_vault_crypto.c",
+    "src/tests/test_vault_kek_cache.c",
+    "src/tests/test_vault_kms.c",
+    "src/tests/test_vault_master_rotate.c",
+    "src/tests/test_vault_principal.c",
+    "src/tests/test_vault_seam.c",
+    "src/tests/test_vault_server_key.c",
+    "src/tests/test_vault_service.c",
+    "src/tests/test_vault_store.c",
+    "src/tests/test_vault_tpm2.c"
+  ],
+  "docs": [
+    "docs/modules/vault.md"
+  ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -639,6 +639,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains workspace-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising set-equality on an eleven-element declared source and private-header set.",
       "independent_review": "The slice-decision roundtable approved the declaration scope in slice 44 and carried the runner-queue wiring evidence forward to this slice; this slice adds only the completeness assertion and that evidence. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-45.md", "docs/modules/workspace.md", "src/modules/workspace/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 46,
+      "state": "present_and_verified",
+      "disposition": "Declared the vault descriptor's twelve sources, thirteen module-root private headers, eleven direct tests, and document without setting ownership_complete, the declaration half of the pair for the fourth and most test-classification-heavy Class B module, resolving seventeen test files down to eleven module tests by subject and confirming every source is live including the always-compiled custody backends.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["CMake compiles six of the twelve sources, the thin-client-reachable subset, and omits the four custody backends, vault_hwm.c, and vault_server_key.c, the same intentional thin-client boundary recorded for gateway, audit, learning, and workspace", "vault_hwm.c has no external includer but is live: vault_custody_kms.c calls vault_hwm_attest_verify; the tpm2 and pkcs11 custody sources are always compiled, switching between real impl and fail-closed stub by -D flag", "Five test_vault_* files exercise other modules and are not claimed: audit (server_vault.c), seal and tpm2_stub (kb_vault_policy.c), pg (kb_main.c), bootstrap (server_vault_bootstrap.c)", "test_vault_tpm2.c backs the WITH_TPM2-gated p7-tpm2-harness and is claimed on roundtable direction as the only test exercising the real vault_custody_tpm2.c", "test_vault_custody_pkcs11.c is an orphan no target builds, left undeclared and flagged for a later cleanup; vault_hwm.c, vault_custody_mock.c, and vault_custody_pkcs11.c have no declared direct test and are covered transitively"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Claiming the five other-module tests by their vault name, or the orphan pkcs11 test as coverage, was rejected: each of the five drives another module's source by subject, and an unbuilt orphan is not a coverage claim.",
+        "revisit": "Slice 47 latches vault; a later cleanup wires or deletes the orphan test_vault_custody_pkcs11.c, and a separate header-layout slice may relocate vault headers under a canonical include tree."
+      },
+      "consumers": ["server, kb, db2 credential and custody consumers", "the vault latch slice", "remaining Class B declaration slices"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains eleven vault rows.",
+      "independent_review": "The slice-decision roundtable confirmed the subject-over-name exclusion of the five other-module tests, directed that the orphan pkcs11 test stay undeclared and flagged, and directed that the WITH_TPM2-gated tpm2 harness be declared as the only test of the real tpm2 custody source. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-46.md", "docs/modules/vault.md", "src/modules/vault/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
     }
   ]
 }

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -244,6 +244,72 @@
     {
       "ctest": false,
       "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_capability.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_crypto.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_kek_cache.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_kms.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_master_rotate.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_principal.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_seam.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_server_key.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_service.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_store.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "vault",
+      "test": "src/tests/test_vault_tpm2.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
       "module": "workspace",
       "test": "src/tests/test_workspace.c"
     },


### PR DESCRIPTION
Core modularization slice 46 — the **declaration** half of the pair for `vault`, the fourth Class B module and the most test-classification-heavy so far. Declares the descriptor's ownership fields; does not set `ownership_complete`. Security-sensitive, so source liveness and test classification were audited individually and taken to the slice-decision roundtable.

## Twelve sources, thirteen headers, eleven of seventeen tests

All thirteen headers are declared `private_headers` (no canonical include tree), including `vault_internal.h`, the backend-seam header with no paired source. `vault_hwm.c` has no external includer but is live — `vault_custody_kms.c` calls `vault_hwm_attest_verify`. The four custody backends are always compiled: `WITH_TPM2`/`WITH_PKCS11` toggle a `-D` flag that switches tpm2/pkcs11 between real impl and fail-closed stub, never omitting the source.

Seventeen `test_vault*.c` files resolve to **eleven** module tests, classified by subject not name:

**Declared (11):** capability, crypto, kek_cache, kms, master_rotate, principal, seam, server_key, service, store — each drives its like-named vault source — plus **`test_vault_tpm2.c`**, which backs the `WITH_TPM2`-gated `p7-tpm2-harness` and is the only test that links the real `vault_custody_tpm2.c`. The roundtable directed claiming it despite the gate, because omitting it would leave the descriptor claiming the tpm2 source with no named test.

**Excluded — subject is another module (5):** `test_vault_audit.c` (`vault_audit_server_write` in `server_vault.c`), `test_vault_seal.c` + `test_vault_tpm2_stub.c` (the `kb_vault_policy.c` seal barrier — the stub test doesn't even link `vault_custody_tpm2.o`), `test_vault_pg.c` (links `kb_main.o`), `test_vault_bootstrap.c` (`server_vault_bootstrap.c`). Same subject-over-name criterion as gateway/learning/workspace.

**Orphan:** `test_vault_custody_pkcs11.c` is referenced by no `Rules.mk` target — an unbuilt file is not a coverage claim, so it's left undeclared and flagged for a later cleanup (wire or delete).

## Six of twelve sources in CMake

Make compiles all twelve; CMake compiles the six the thin `aimee` client reaches and omits the four custody backends, `vault_hwm.c`, and `vault_server_key.c`. Same intentional thin-client boundary as gateway (38), audit (34), learning (42), workspace (44). Descriptor records canonical source ownership, not identical build-product membership.

## Validation

All local checks pass; vault service, kms, and crypto unit tests build and run green. Baseline gains exactly the eleven vault rows. The exact-diff roundtable returned no issues. Latch, mutation coverage, and completeness audit come in slice 47.