### PR TITLE
refactor(vault): complete module ownership

### DIFF
--- a/docs/modules/vault.md
+++ b/docs/modules/vault.md
@@ -16,7 +16,7 @@ attested identities, and `vault_capability` limits delegated access. Direct call
 implementations outside these facades are boundary violations rather than alternate public APIs.
 
 The descriptor declares this module's twelve sources, thirteen module-root headers, eleven direct
-tests, and this document; it does not yet set `ownership_complete`. All thirteen headers are declared
+tests, and this document; it sets `ownership_complete: true`. All thirteen headers are declared
 as `private_headers` because they live at the module root rather than under
 `src/modules/vault/include/aimee/vault/`, the layout the header-layout checker treats as private;
 `vault_internal.h` is the backend-seam header and has no paired source. The four custody backends
@@ -28,9 +28,10 @@ pkcs11 sources between a real implementation and a fail-closed stub rather than 
 thin `aimee` client reaches (`vault_capability.c`, `vault_crypto.c`, `vault_kek_cache.c`,
 `vault_principal.c`, `vault_service.c`, `vault_store.c`) and omits the four custody backends,
 `vault_hwm.c`, and `vault_server_key.c`, the same intentional thin-client boundary recorded for
-gateway, learning, and workspace. `docs/validation/core-modularization-slice-46.md` records the audit;
-latching follows in a separate slice so the completeness audit does not review declarations authored
-in the same change.
+gateway, learning, and workspace. `docs/validation/core-modularization-slice-46.md` records the declaration audit and
+`docs/validation/core-modularization-slice-47.md` the completeness audit; the two were split so the
+latch reviews declarations merged on their own first. Adding a new module-local source or module-root
+header without declaring it now fails CI on `rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-47.md
+++ b/docs/validation/core-modularization-slice-47.md
@@ -1,0 +1,89 @@
+# Core modularization slice 47: latch vault ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `vault` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 46 declared and audited the twelve sources, thirteen module-root
+private headers, eleven direct tests, and document on their own, and this slice asserts those
+declarations exhaustively cover the module root and adds the latch mutation coverage. It changes
+descriptor metadata, validation coverage, documentation, and cleanup accounting only; no production
+code, public symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`vault` is the thirteenth latched module. Its private-header set of thirteen is the largest in the
+program, and it includes `vault_internal.h`, a header with no paired source, so the
+`private_headers` set-equality check compares a thirteen-element declared set that is not merely the
+mirror of the source set against the thirteen actual headers.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/vault/include/aimee/vault/` (which does not exist). The module root contains exactly the
+twelve declared sources and thirteen declared headers and nothing else matching those roles, so the
+declared sets equal the actual sets and the latch is exact. The descriptor's `docs` field equals
+`["docs/modules/vault.md"]`, as the latch requires.
+
+Slice 46 established the source liveness, build-membership, and test-classification evidence, and the
+slice-decision roundtable approved the calls: all thirteen headers stay privately declared; the five
+other-module `test_vault_*` files are not claimed; the orphan `test_vault_custody_pkcs11.c` stays
+undeclared and flagged; and the `WITH_TPM2`-gated `test_vault_tpm2.c` is claimed as the only test of
+the real tpm2 custody source. That audit is not repeated here; this slice adds only the completeness
+assertion on the already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+the server (`server_vault.c`, `server_vault_bootstrap.c`), KB (`kb_vault_policy.c`), or DB2 vault code
+outside the module root has been moved in, and it does not claim identical build-product membership
+across Make and CMake — the custody backends, `vault_hwm.c`, and `vault_server_key.c` are Make-only.
+
+## Set-equality with an unpaired header
+
+The `private_headers` declared set is thirteen entries against thirteen actual module-root headers,
+the largest header set latched so far. Twelve of the thirteen mirror a source; the thirteenth,
+`vault_internal.h`, is the backend-seam header with no paired source, so the header set is not simply
+the source set with a suffix swap. The regression suite removes `vault_service.c` from `sources` and
+requires `rule=ownership-complete` on `/sources` with the source named missing, and removes
+`vault_internal.h` from `private_headers` and requires the same rule on `/private_headers` with the
+header named missing — confirming the check bites on the unpaired header specifically, not only on a
+header that shadows a removed source.
+
+## Regression controls
+
+The descriptor mutation suite removes `vault_service.c` and requires `rule=ownership-complete` on
+`/sources`, and removes `vault_internal.h` and requires the same rule on `/private_headers`. It plants
+`src/modules/vault/undeclared.c` and `undeclared.h` and requires the rule on `/sources` and
+`/private_headers`. It removes `docs/modules/vault.md` from the descriptor's `docs` field and requires
+the rule on `/docs`. The graph-derived latched-descriptor assertion from slice 43 now also covers
+`vault`, so clearing the latch fails directly. The empty-domain guard from slice 39 does not apply,
+because the module root is not empty. The unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-vault-service build/obj/tests/unit-test-vault-crypto
+src/build/obj/tests/unit-test-vault-service
+src/build/obj/tests/unit-test-vault-crypto
+```
+
+`test_vault_tpm2.c` builds only under `make WITH_TPM2=1` and is not in the default local test list.
+`cmake` is unavailable in the environment used for this slice, and CMake compiles a subset of this
+module's sources into the thin client without a module test target, so there is no module-specific
+CMake command to add; the required pull-request CMake jobs continue to cover the thin-client profile
+they own.
+
+With `vault` latched, thirteen modules carry `ownership_complete`. The remaining five Class B modules
+(`config`, `git`, `delegates`, `workflows`, `memory`) follow the same declaration-then-latch pair, and
+the eight Class A modules remain blocked by the empty-domain guard and tracked in
+`docs/validation/core-modularization-class-a-migration.md`. Technical-writer review, exact-final-diff
+roundtable approval, and every required pull-request check are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -279,6 +279,8 @@ class DescriptorTests(unittest.TestCase):
             ("learning", "private_headers", "src/modules/learning/learning.h"),
             ("workspace", "sources", "src/modules/workspace/workspace_turn.c"),
             ("workspace", "private_headers", "src/modules/workspace/workspace_provider.h"),
+            ("vault", "sources", "src/modules/vault/vault_service.c"),
+            ("vault", "private_headers", "src/modules/vault/vault_internal.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -299,7 +301,7 @@ class DescriptorTests(unittest.TestCase):
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace"):
+                           "workspace", "vault"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -403,7 +405,7 @@ class DescriptorTests(unittest.TestCase):
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace"):
+                           "workspace", "vault"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/vault/module.yaml
+++ b/src/modules/vault/module.yaml
@@ -9,6 +9,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/vault/vault_capability.c",
     "src/modules/vault/vault_crypto.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -656,6 +656,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains eleven vault rows.",
       "independent_review": "The slice-decision roundtable confirmed the subject-over-name exclusion of the five other-module tests, directed that the orphan pkcs11 test stay undeclared and flagged, and directed that the WITH_TPM2-gated tpm2 harness be declared as the only test of the real tpm2 custody source. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-46.md", "docs/modules/vault.md", "src/modules/vault/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 47,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the vault descriptor against the declarations slice 46 authored and reviewed on their own, the latch half of the pair for the fourth Class B module, and exercised the private_headers set-equality check against a thirteen-element set that includes the unpaired vault_internal.h backend-seam header.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, twelve sources and thirteen module-root headers, not that the server, KB, or DB2 vault code outside the module root has been moved in", "CMake compiles six of the twelve sources and omits the four custody backends, vault_hwm.c, and vault_server_key.c, the same intentional thin-client boundary recorded for gateway, audit, learning, and workspace", "test_vault_custody_pkcs11.c remains an orphan no target builds, flagged for a later cleanup"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The remaining five Class B modules follow the same declaration-then-latch pair; a later cleanup wires or deletes the orphan pkcs11 test, and a separate header-layout slice may relocate vault headers under a canonical include tree."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining Class B declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains vault-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising set-equality on a thirteen-element header set that includes an unpaired backend-seam header.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 46, including the subject-over-name test exclusions and the tpm2-harness claim; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-47.md", "docs/modules/vault.md", "src/modules/vault/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 47 — the **latch** half for `vault`, against the declarations [#1877](https://github.com/RakuenSoftware/aimee/pull/1877) merged on their own. Thirteenth module latched, fourth Class B.

## Largest header set, with an unpaired header

`vault`'s thirteen-element `private_headers` set is the largest latched so far and includes `vault_internal.h`, the backend-seam header with **no paired source** — so the header set is not merely the source set with a suffix swap. The regression suite removes `vault_internal.h` specifically and requires `rule=ownership-complete` on `/private_headers`, confirming the check bites on the unpaired header, not only on one that shadows a removed source. Source-removal, planted-file, missing-doc, and cleared-latch coverage complete the set.

## Scope

The latch scopes to the module root as it stands (twelve sources, thirteen headers). The server (`server_vault.c`, `server_vault_bootstrap.c`), KB (`kb_vault_policy.c`), and DB2 vault code outside the module root is not claimed, and Make/CMake build-product membership is not claimed identical — the custody backends, `vault_hwm.c`, and `vault_server_key.c` remain Make-only. No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

All local checks pass; vault service and crypto unit tests build and run green. The exact-diff roundtable returned no structural issues.

Thirteen modules now carry `ownership_complete`; five Class B modules remain (`config`, `git`, `delegates`, `workflows`, `memory`).