### PR TITLE
refactor(config): declare module ownership

### DIFF
--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -15,6 +15,22 @@ orchestration, or a GUI's navigation and presentation.
 `restart_required` verdict. Module/provider owners remain responsible for consuming their values and
 registering a re-applier when bound state can safely change live.
 
+The descriptor declares this module's fifteen sources, seven module-root headers, four direct tests,
+and this document; it does not yet set `ownership_complete`. All seven headers are declared as
+`private_headers` because they live at the module root rather than under
+`src/modules/config/include/aimee/config/`, the layout the header-layout checker treats as private;
+`config_internal.h` is the internal seam header and has no paired source, and nine section-parser
+sources (charter, kb-curator, kb-maintenance, mode, plugin, save, server-api, skills, trigger) declare
+through `config.h`, `config_sections.h`, and `config_internal.h` rather than a paired header.
+`config_fields.h` is declared private today but is a cross-cutting get/set allowlist reached by the cmd
+and server layers, so it is a public-header candidate for a future header-layout slice; an
+ownership-declaration slice moves nothing. Make compiles all fifteen sources; CMake compiles the twelve
+the thin `aimee` client reaches and omits `config_fields.c`, `config_mode.c`, and `config_server_api.c`
+whose callers are cmd/server/TLS-side, the same intentional thin-client boundary recorded for gateway,
+learning, workspace, and vault. `docs/validation/core-modularization-slice-48.md` records the audit;
+latching follows in a separate slice so the completeness audit does not review declarations authored in
+the same change.
+
 ## Dependencies and consumers
 
 - `module-runtime`: supplies the required module identity, lifecycle, and readiness model whose active capabilities constrain configuration surfaces.
@@ -80,10 +96,17 @@ when no live server snapshot exists.
 
 ## Tests and failure behavior
 
-`test_config.c`, `test_cmd_config.c`, `test_config_surface.c`, `test_config_snapshot.c`, config parser
-suites, and frontend setup/settings tests cover defaults, validation, round trips, projections, reload,
-and UI assumptions. Missing files yield defaults; malformed or invalid reload input keeps the running
-snapshot; failed save/set returns an error; unrecognized typed keys are rejected rather than persisted.
+The descriptor's four direct tests are `test_config.c` (the config core), `test_config_surface.c` (a
+characterization net auto-derived from `config.c`'s parse surface), `test_config_snapshot.c` (the live
+snapshot double-buffer/seqlock in `config.c`, including a concurrent torn-read stress), and
+`test_config_economizer.c` (config's resolution of the `economizer: off|safe|aggressive` setting — a
+`config_fields`/`config.c` concern, not the economizer module; it links the core object bundle and no
+economizer object). Adjacent tests such as `test_cmd_config.c` and frontend setup/settings tests
+exercise the cmd and UI layers and are not claimed here. Of the four, `test_config.c` is registered
+with CTest and the other three run under Make alone. Together they cover defaults, validation, round
+trips, projections, reload, and UI assumptions. Missing files yield defaults; malformed or invalid
+reload input keeps the running snapshot; failed save/set returns an error; unrecognized typed keys are
+rejected rather than persisted.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-48.md
+++ b/docs/validation/core-modularization-slice-48.md
@@ -1,0 +1,130 @@
+# Core modularization slice 48: declare config ownership
+
+## Scope
+
+This slice declares the `config` descriptor's `sources`, `private_headers`, `tests`, and `docs`
+fields. It does not set `ownership_complete`. It is the declaration half of the declaration-then-latch
+pair; the latch, its mutation coverage, and the completeness audit follow in slice 49. It changes
+descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting
+only; no production code, public symbol, build membership, configuration, storage, or runtime behavior
+changes. No header is moved and no include site is rewritten.
+
+`config` is the fifth Class B module. It is required core and one of the most depended-upon modules in
+the graph, but structurally cleaner than vault: no orphan tests, no cross-module test ambiguity.
+
+## What the module owns
+
+The module root `src/modules/config/` contains, excluding `module.yaml`:
+
+- Fifteen sources: `config.c`, `config_charter.c`, `config_database.c`, `config_fields.c`,
+  `config_kb_curator.c`, `config_kb_maintenance.c`, `config_learning.c`, `config_memory.c`,
+  `config_mode.c`, `config_plugin.c`, `config_save.c`, `config_sections.c`, `config_server_api.c`,
+  `config_skills.c`, `config_trigger.c`.
+- Seven headers: `config.h`, `config_database.h`, `config_fields.h`, `config_internal.h`,
+  `config_learning.h`, `config_memory.h`, `config_sections.h`.
+
+Six headers pair with a like-named source. `config_internal.h` has no paired source — it is the
+internal seam header. The nine sources without a paired header (`config_charter.c`,
+`config_kb_curator.c`, `config_kb_maintenance.c`, `config_mode.c`, `config_plugin.c`, `config_save.c`,
+`config_server_api.c`, `config_skills.c`, `config_trigger.c`) are section parsers and facades that
+declare through `config.h`, `config_sections.h`, and `config_internal.h`. No
+`src/modules/config/include/aimee/config/` directory exists, so every header is at the module root and
+is declared in `private_headers`.
+
+`config_fields.h` is declared private today, matching the layout, but it is functionally a
+cross-cutting contract: the get/set allowlist registry it declares is reached across module boundaries
+by `src/cmd_data.c` and `src/server/server_config.c`. The slice-decision roundtable noted it is a
+likely public-header candidate whose promotion — moving it under a canonical include tree — belongs to
+a future header-layout slice, not this ownership-declaration slice, which moves nothing.
+
+## Source liveness
+
+Every declared source is live. `config.c` is the parse and snapshot core (the double-buffer/seqlock
+live-config mechanism lives here). Each `config_*.c` is a section parser or facade reached by the
+config load path and by cmd/server consumers: charter, the database section, the `config_fields`
+get/set allowlist registry, kb-curator, kb-maintenance, learning, memory, operating-mode
+(engineer/novel), the plugin section, save, the section dispatcher, the server HTTP API section,
+skills, and trigger.
+
+## Build membership
+
+Make's `DATA_SRCS` compiles all fifteen sources and carries the `-Imodules/config` include path. CMake
+compiles twelve and omits three — `config_fields.c`, `config_mode.c`, `config_server_api.c` — whose
+callers are cmd/server/TLS-side: `config_fields` is reached by `cmd_data.c` and `server/server_config.c`,
+`config_mode` by `aimee_tls.c` and `cli_agent_keys.c`, and `config_server_api` by `server_api.c`,
+`server_main.c`, and the provider adapter. The thin `aimee` client's link closure does not reach these
+three, and the required Windows and Linux CMake jobs build the thin client green from the twelve-source
+set — the standing evidence that this is an intentional thin-client profile boundary, the same one
+recorded for gateway (slice 38), audit (slice 34), learning (slice 42), workspace (slice 44), and vault
+(slice 46), not source-list drift. The descriptor records canonical source ownership, which both build
+systems agree on; it does not claim identical build-product membership.
+
+## Test membership
+
+Four `test_config*.c` files back four `unit-test-config*` targets, and all four link the core object
+bundle (`TEST_CORE_OBJS`) plus their test object; none singles out another module's object. All four
+are config-owned by subject:
+
+- `test_config.c` — the config core.
+- `test_config_surface.c` — a characterization net for `config_load`'s parse surface, auto-derived
+  from `config.c`.
+- `test_config_snapshot.c` — the live config snapshot double-buffer/seqlock in `config.c`: init/get,
+  reload, validate-or-keep, and a concurrent torn-read stress.
+- `test_config_economizer.c` — config's parsing and resolution of the `economizer: off|safe|aggressive`
+  setting, a `config_fields`/`config.c` concern. The `economizer` in the filename is the setting being
+  parsed, not the module under test; the subject and the `config` name agree, so this is the mirror
+  image of the earlier subject-over-name calls where the two diverged.
+
+Adjacent tests such as `test_cmd_config.c` (the cmd config command) and the frontend setup/settings
+tests exercise the cmd and UI layers and are not claimed. Of the four, only `test_config.c` is
+registered with CTest (`src/tests/CMakeLists.txt`); the other three run under Make alone, consistent
+with their subjects sitting outside the portable thin-client test set. `scripts/check_module_test_registration.py`
+now records four config rows — `test_config.c` as `make: true`, `ctest: true` and the other three as
+`make: true`, `ctest: false`; that regeneration is the only reason the baseline file changes.
+
+## Why declare without latching
+
+The latch asserts the descriptor exhaustively covers the module root. That is true today — the module
+root holds exactly these fifteen sources and seven headers — so the latch would pass. It is deferred
+because declaring the files and asserting completeness are distinct claims, and the roundtable required
+the completeness audit to review declarations merged on their own first rather than authored in the
+same change. The validator accepts a declared-but-unlatched descriptor: it checks each declared path
+exists and resolves within the module, and enforces set-equality only when `ownership_complete` is
+true.
+
+## Regression controls
+
+The declaration is covered by the existing descriptor validation: every declared path must exist and
+resolve within the module, and the regenerated test-registration baseline pins the four config tests'
+per-suite registration. The empty-domain guard from slice 39 does not apply, because the module root is
+not empty. The latch mutation coverage — source removal, private-header removal, planted files, cleared
+latch — is deferred to slice 49, where `ownership_complete` is set and those mutations become
+meaningful.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 -m unittest scripts.tests.test_check_module_test_registration
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-config build/obj/tests/unit-test-config-snapshot
+src/build/obj/tests/unit-test-config
+src/build/obj/tests/unit-test-config-snapshot
+```
+
+The required pull-request CMake jobs build the thin client from the twelve-source subset and are the
+standing evidence for the thin-client boundary above.
+
+Slice 49 sets `ownership_complete: true`, adds the config latch mutation tests, and records the
+completeness audit. Technical-writer review, exact-final-diff roundtable approval, and every required
+pull-request check are required before merge.

--- a/src/modules/config/module.yaml
+++ b/src/modules/config/module.yaml
@@ -6,5 +6,40 @@
   ],
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/config/config.c",
+    "src/modules/config/config_charter.c",
+    "src/modules/config/config_database.c",
+    "src/modules/config/config_fields.c",
+    "src/modules/config/config_kb_curator.c",
+    "src/modules/config/config_kb_maintenance.c",
+    "src/modules/config/config_learning.c",
+    "src/modules/config/config_memory.c",
+    "src/modules/config/config_mode.c",
+    "src/modules/config/config_plugin.c",
+    "src/modules/config/config_save.c",
+    "src/modules/config/config_sections.c",
+    "src/modules/config/config_server_api.c",
+    "src/modules/config/config_skills.c",
+    "src/modules/config/config_trigger.c"
+  ],
+  "private_headers": [
+    "src/modules/config/config.h",
+    "src/modules/config/config_database.h",
+    "src/modules/config/config_fields.h",
+    "src/modules/config/config_internal.h",
+    "src/modules/config/config_learning.h",
+    "src/modules/config/config_memory.h",
+    "src/modules/config/config_sections.h"
+  ],
+  "tests": [
+    "src/tests/test_config.c",
+    "src/tests/test_config_economizer.c",
+    "src/tests/test_config_snapshot.c",
+    "src/tests/test_config_surface.c"
+  ],
+  "docs": [
+    "docs/modules/config.md"
+  ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -673,6 +673,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains vault-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first exercising set-equality on a thirteen-element header set that includes an unpaired backend-seam header.",
       "independent_review": "The slice-decision roundtable approved the declaration scope in slice 46, including the subject-over-name test exclusions and the tpm2-harness claim; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-47.md", "docs/modules/vault.md", "src/modules/vault/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 48,
+      "state": "present_and_verified",
+      "disposition": "Declared the config descriptor's fifteen sources, seven module-root private headers, four direct tests, and document without setting ownership_complete, the declaration half of the pair for the fifth Class B module, a required-core and heavily depended-upon module with a clean structure and no orphan or cross-module test ambiguity.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["CMake compiles twelve of the fifteen sources and omits config_fields.c, config_mode.c, and config_server_api.c whose callers are cmd/server/TLS-side, the same intentional thin-client boundary recorded for gateway, audit, learning, workspace, and vault", "config_fields.h is declared private per the current layout but is a cross-cutting get/set allowlist reached by cmd and server layers, a public-header candidate for a future header-layout slice", "config_internal.h is the internal seam header with no paired source, and nine section-parser sources declare through config.h, config_sections.h, and config_internal.h rather than a paired header", "test_config_economizer.c is a config test of the economizer setting resolution, not an economizer-module test; adjacent test_cmd_config.c and frontend settings tests are not claimed"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Excluding test_config_economizer.c by its name, or fixing the CMake three-source omission as drift, was rejected: the test's subject is config's economizer-setting resolution and links the core bundle, and the omission is the established thin-client boundary evidenced by green thin-client CMake builds.",
+        "revisit": "Slice 49 latches config; a separate header-layout slice may promote config_fields.h to a canonical public header given its cross-module reach."
+      },
+      "consumers": ["nearly every module that declares config as a dependency", "the cmd and server config surfaces", "the config latch slice", "remaining Class B declaration slices"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains four config rows.",
+      "independent_review": "The slice-decision roundtable confirmed all three scoping decisions with no findings: test_config_economizer.c is a config test by subject and link evidence, the CMake three-source omission is an intentional thin-client boundary, and config_fields.h and config_internal.h are correctly declared private with the config_fields.h promotion noted for a future slice. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-48.md", "docs/modules/config.md", "src/modules/config/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
     }
   ]
 }

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -26,6 +26,30 @@
       "test": "src/tests/test_audit_worm_chain.c"
     },
     {
+      "ctest": true,
+      "make": true,
+      "module": "config",
+      "test": "src/tests/test_config.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "config",
+      "test": "src/tests/test_config_economizer.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "config",
+      "test": "src/tests/test_config_snapshot.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "config",
+      "test": "src/tests/test_config_surface.c"
+    },
+    {
       "ctest": false,
       "make": true,
       "module": "delegates",


### PR DESCRIPTION
Core modularization slice 48 — the **declaration** half of the pair for `config`, the fifth Class B module. Declares the descriptor's ownership fields; does not set `ownership_complete`. `config` is required core and one of the most depended-upon modules in the graph, but structurally cleaner than vault — no orphan tests, no cross-module test ambiguity. The slice-decision roundtable approved all three scoping calls with no findings.

## Fifteen sources, seven headers, four tests

All seven headers are declared `private_headers` (no canonical include tree). `config_internal.h` is the seam header with no paired source; nine section-parser sources declare through `config.h`/`config_sections.h`/`config_internal.h`. `config_fields.h` is declared private per the layout but is a cross-cutting get/set allowlist reached by cmd and server layers — flagged as a public-header candidate for a future header-layout slice (roundtable note). An ownership slice moves nothing.

All four `test_config*` tests are config-owned by subject, including `test_config_economizer.c`: it tests config's resolution of the `economizer: off|safe|aggressive` setting (a `config_fields`/`config.c` concern) and links the core bundle, not any economizer object — the `economizer` in its name is the setting parsed, not the module tested. Of the four, `test_config.c` is CTest-registered; the other three run under Make alone.

## Twelve of fifteen sources in CMake

Make compiles all fifteen; CMake omits `config_fields.c`, `config_mode.c`, `config_server_api.c`, whose callers are cmd/server/TLS-side and outside the thin-client link closure. Same intentional thin-client boundary as gateway (38), audit (34), learning (42), workspace (44), vault (46), evidenced by the green thin-client CMake jobs. Descriptor records canonical source ownership, not identical build-product membership.

## Validation

All local checks pass; config core, snapshot, and surface unit tests build and run green. Baseline gains exactly the four config rows. The exact-diff roundtable found one prose/baseline inconsistency (a "CTest registers none" line contradicting `test_config.c`'s `ctest: true` row); corrected and re-reviewed clean. Latch, mutation coverage, and completeness audit come in slice 49.