### PR TITLE
refactor(config): complete module ownership

### DIFF
--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -16,7 +16,7 @@ orchestration, or a GUI's navigation and presentation.
 registering a re-applier when bound state can safely change live.
 
 The descriptor declares this module's fifteen sources, seven module-root headers, four direct tests,
-and this document; it does not yet set `ownership_complete`. All seven headers are declared as
+and this document; it sets `ownership_complete: true`. All seven headers are declared as
 `private_headers` because they live at the module root rather than under
 `src/modules/config/include/aimee/config/`, the layout the header-layout checker treats as private;
 `config_internal.h` is the internal seam header and has no paired source, and nine section-parser
@@ -27,9 +27,10 @@ and server layers, so it is a public-header candidate for a future header-layout
 ownership-declaration slice moves nothing. Make compiles all fifteen sources; CMake compiles the twelve
 the thin `aimee` client reaches and omits `config_fields.c`, `config_mode.c`, and `config_server_api.c`
 whose callers are cmd/server/TLS-side, the same intentional thin-client boundary recorded for gateway,
-learning, workspace, and vault. `docs/validation/core-modularization-slice-48.md` records the audit;
-latching follows in a separate slice so the completeness audit does not review declarations authored in
-the same change.
+learning, workspace, and vault. `docs/validation/core-modularization-slice-48.md` records the declaration audit and
+`docs/validation/core-modularization-slice-49.md` the completeness audit; the two were split so the
+latch reviews declarations merged on their own first. Adding a new module-local source or module-root
+header without declaring it now fails CI on `rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-49.md
+++ b/docs/validation/core-modularization-slice-49.md
@@ -1,0 +1,75 @@
+# Core modularization slice 49: latch config ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `config` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 48 declared and audited the fifteen sources, seven module-root
+private headers, four direct tests, and document on their own, and this slice asserts those
+declarations exhaustively cover the module root and adds the latch mutation coverage. It changes
+descriptor metadata, validation coverage, documentation, and cleanup accounting only; no production
+code, public symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`config` is the fourteenth latched module and the fifth Class B module. Its fifteen-element source set
+is the largest latched so far.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/config/include/aimee/config/` (which does not exist). The module root contains exactly the
+fifteen declared sources and seven declared headers and nothing else matching those roles, so the
+declared sets equal the actual sets and the latch is exact. The descriptor's `docs` field equals
+`["docs/modules/config.md"]`, as the latch requires.
+
+Slice 48 established the source liveness, build-membership, and test-classification evidence, and the
+slice-decision roundtable approved the calls with no findings: all seven headers stay privately
+declared (`config_fields.h` noted as a future public-header candidate); all four `test_config*` tests
+are config-owned by subject; and the CMake twelve-of-fifteen membership is an intentional thin-client
+boundary. That audit is not repeated here; this slice adds only the completeness assertion on the
+already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+the cmd/server/UI config-facing code outside the module root has been moved in, and it does not claim
+identical build-product membership across Make and CMake — `config_fields.c`, `config_mode.c`, and
+`config_server_api.c` are Make-only.
+
+## Regression controls
+
+The descriptor mutation suite removes `config.c` and requires `rule=ownership-complete` on `/sources`,
+and removes `config_internal.h` and requires the same rule on `/private_headers`. It plants
+`src/modules/config/undeclared.c` and `undeclared.h` and requires the rule on `/sources` and
+`/private_headers`. It removes `docs/modules/config.md` from the descriptor's `docs` field and requires
+the rule on `/docs`. The graph-derived latched-descriptor assertion from slice 43 now also covers
+`config`, so clearing the latch fails directly. The empty-domain guard from slice 39 does not apply,
+because the module root is not empty. The unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-config build/obj/tests/unit-test-config-snapshot
+src/build/obj/tests/unit-test-config
+src/build/obj/tests/unit-test-config-snapshot
+```
+
+`cmake` is unavailable in the environment used for this slice, and CMake compiles a twelve-source
+subset of this module into the thin client, registering only `test_config` as a CTest case, so there is
+no additional module-specific CMake command to add; the required pull-request CMake jobs continue to
+cover the thin-client profile they own.
+
+With `config` latched, fourteen modules carry `ownership_complete`. The remaining four Class B modules
+(`git`, `delegates`, `workflows`, `memory`) follow the same declaration-then-latch pair, and the eight
+Class A modules remain blocked by the empty-domain guard and tracked in
+`docs/validation/core-modularization-class-a-migration.md`. Technical-writer review, exact-final-diff
+roundtable approval, and every required pull-request check are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -281,6 +281,8 @@ class DescriptorTests(unittest.TestCase):
             ("workspace", "private_headers", "src/modules/workspace/workspace_provider.h"),
             ("vault", "sources", "src/modules/vault/vault_service.c"),
             ("vault", "private_headers", "src/modules/vault/vault_internal.h"),
+            ("config", "sources", "src/modules/config/config.c"),
+            ("config", "private_headers", "src/modules/config/config_internal.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -301,7 +303,7 @@ class DescriptorTests(unittest.TestCase):
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault"):
+                           "workspace", "vault", "config"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -405,7 +407,7 @@ class DescriptorTests(unittest.TestCase):
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault"):
+                           "workspace", "vault", "config"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/config/module.yaml
+++ b/src/modules/config/module.yaml
@@ -7,6 +7,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/config/config.c",
     "src/modules/config/config_charter.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -690,6 +690,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains four config rows.",
       "independent_review": "The slice-decision roundtable confirmed all three scoping decisions with no findings: test_config_economizer.c is a config test by subject and link evidence, the CMake three-source omission is an intentional thin-client boundary, and config_fields.h and config_internal.h are correctly declared private with the config_fields.h promotion noted for a future slice. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-48.md", "docs/modules/config.md", "src/modules/config/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 49,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the config descriptor against the declarations slice 48 authored and reviewed on their own, the latch half of the pair for the fifth Class B module, exercising the source set-equality check against a fifteen-element declared set, the largest source set latched so far.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, fifteen sources and seven module-root headers, not that the cmd/server/UI config-facing code outside the module root has been moved in", "CMake compiles twelve of the fifteen sources and omits config_fields.c, config_mode.c, and config_server_api.c, the same intentional thin-client boundary recorded for gateway, audit, learning, workspace, and vault", "config_fields.h remains declared private, a public-header candidate for a future header-layout slice"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The remaining four Class B modules follow the same declaration-then-latch pair; a separate header-layout slice may promote config_fields.h to a canonical public header."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining Class B declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains config-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first applied to a fifteen-element declared source set, the largest so far.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 48 with no findings; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-49.md", "docs/modules/config.md", "src/modules/config/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 49 — the **latch** half for `config`, against the declarations [#1880](https://github.com/RakuenSoftware/aimee/pull/1880) merged on their own. Fourteenth module latched, fifth Class B.

## Largest source set

`config`'s fifteen-element `sources` set is the largest latched so far. The regression suite removes `config.c` from the fifteen and `config_internal.h` from the seven and requires `rule=ownership-complete` naming the missing file; the graph-derived cleared-latch assertion (from slice 43) covers config automatically — confirmed it now enumerates all fourteen latched descriptors.

## Scope

The latch scopes to the module root as it stands (fifteen sources, seven headers). The cmd/server/UI config code outside the module root is not claimed; `config_fields.h` stays privately declared pending a separate header-layout slice; and Make/CMake build-product membership is not claimed identical (`config_fields.c`, `config_mode.c`, `config_server_api.c` are Make-only). No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

All local checks pass; config core and snapshot unit tests build and run green. The exact-diff roundtable returned no blocking issues (it asked to confirm the graph-derived cleared-latch assertion covers config — verified — and a one-word ledger precision, applied).

Fourteen modules now carry `ownership_complete`; four Class B modules remain (`git`, `delegates`, `workflows`, `memory`).