### PR TITLE
refactor(git): declare module ownership

### DIFF
--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -15,6 +15,20 @@ projects, forge credentials/API, OAuth device flows, and SSH-agent setup. The ap
 is `memory.repository-record.ingest.v1`: Git is submit-only, while [memory](memory.md) retains schema,
 redaction acceptance, persistence, embedding, reranking, and code intelligence.
 
+The descriptor declares this module's twenty-six sources, eighteen module-root headers, fourteen
+direct tests, and this document; it does not yet set `ownership_complete`. All eighteen headers are
+declared as `private_headers` because they live at the module root rather than under
+`src/modules/git/include/aimee/git/`, the layout the header-layout checker treats as private; sixteen
+pair with a source, and two have no paired source — `git_verify_internal.h` (the verify-family seam)
+and `mcp_git.h` (the shared MCP-git header). Make compiles all twenty-six sources; CMake compiles the
+twelve the thin `aimee` client reaches (the eight `git_verify_*` sources and the four `mcp_git_*`
+tools) and omits the fourteen credential, OAuth, ops, forge-vault, host, org-repos, and PR-API sources
+that are server/kb-side, the same intentional thin-client boundary recorded for gateway, learning,
+workspace, vault, and config. This descriptor's `ownership_complete` latch is independent of the
+separate `git-core-contract` governance, which bounds git's core capability rather than its file
+ownership. `docs/validation/core-modularization-slice-50.md` records the audit; latching follows in a
+separate slice so the completeness audit does not review declarations authored in the same change.
+
 ## Dependencies and consumers
 
 - `audit`: records repository reads, mutations, provenance, policy decisions, and outcomes.
@@ -85,10 +99,19 @@ locking outside Git/worktree primitives is a hypothesis, unverified.
 
 ## Tests and failure behavior
 
-`test_mcp_git.c`, git ops/project/host/credential/OAuth/SSH/PR/verify suites, guardrail Git tests, and
-integration tool calls cover current behavior. Missing repository, denied mutation, dirty/conflicting
-state, invalid ref/path, failed signature/redaction, absent credential, forge error, or failed verify step
-must return typed failure; non-Git base workspace operations continue normally.
+The descriptor's fourteen direct tests are `test_forge_credentials.c`, `test_git_cred_inject.c`,
+`test_git_forge_vault.c`, `test_git_host_resolve.c`, `test_git_ops.c`, `test_git_pr_ci_grade.c`,
+`test_git_project.c`, `test_git_ssh_agent.c`, `test_git_verify_contract.c`, `test_git_verify_select.c`,
+`test_mcp_git.c`, and the three CTest-only `test_git_oauth_device.c`, `test_git_oauth_gh.c`, and
+`test_git_org_repos.c` — registered in `src/tests/CMakeLists.txt` but not built by a Make `unit-test-*`
+target, so recorded as `make: false, ctest: true`, the inverse of the usual pattern. Two adjacent
+tests are not claimed: `test_forge_app_token.c` exercises the root-level `src/forge_app_token.c`, not a
+git-module source, and `test_forge_credentials_live.c` is the `forge-cred-live` integration harness
+that needs a running forge — supplementary coverage of `forge_credentials.c`, which already has a unit
+test. Together with guardrail Git tests and integration tool calls they cover current behavior.
+Missing repository, denied mutation, dirty/conflicting state, invalid ref/path, failed
+signature/redaction, absent credential, forge error, or failed verify step must return typed failure;
+non-Git base workspace operations continue normally.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-50.md
+++ b/docs/validation/core-modularization-slice-50.md
@@ -1,0 +1,138 @@
+# Core modularization slice 50: declare git ownership
+
+## Scope
+
+This slice declares the `git` descriptor's `sources`, `private_headers`, `tests`, and `docs` fields.
+It does not set `ownership_complete`. It is the declaration half of the declaration-then-latch pair;
+the latch, its mutation coverage, and the completeness audit follow in slice 51. It changes descriptor
+metadata, the regenerated test-registration baseline, documentation, and cleanup accounting only; no
+production code, public symbol, build membership, configuration, storage, or runtime behavior changes.
+No header is moved, no include site is rewritten, and neither the `git-core-contract` proposal nor its
+approval evidence is touched.
+
+`git` is the sixth Class B module and the largest by file count so far: twenty-six sources, eighteen
+module-root headers, and fourteen direct tests carved out of sixteen `test_git*`/`test_forge*` files.
+
+## The git-core-contract is orthogonal
+
+`git` has a dedicated governance mechanism — `docs/proposals/pending/git-core-contract.md` with
+roundtable-approval evidence in `docs/validation/roundtable/git-core-contract.json`, enforced by
+`check_git_core_contract.py` in the `git-core-contract` CI job. That contract bounds git's *core
+capability* — what git may and may not do as a submit-only module against memory's
+`repository-record.ingest.v1` contract. It is not the descriptor's file-ownership latch. The check
+reads `module.yaml` only to validate the contract, and this ownership-declaration slice does not touch
+the proposal or its evidence. `check_git_core_contract.py --require-status roundtable-approved` passes
+both before and after this declaration.
+
+## What the module owns
+
+The module root `src/modules/git/` contains, excluding `module.yaml`, twenty-six sources and eighteen
+headers. No `src/modules/git/include/aimee/git/` directory exists, so every header is at the module
+root and is declared in `private_headers`.
+
+- Sources: the forge-credential broker (`forge_credentials.c`), credential injection
+  (`git_cred_inject.c`), the forge vault (`git_forge_vault.c`), host-cred and host-resolve
+  (`git_host_cred.c`, `git_host_resolve.c`), the three OAuth backends (`git_oauth_device.c`,
+  `git_oauth_gh.c`, `git_oauth_github.c`), git ops (`git_ops.c`), org-repos (`git_org_repos.c`), the
+  PR API and CI grader (`git_pr_api.c`, `git_pr_ci_grade.c`), project (`git_project.c`), ssh-agent
+  (`git_ssh_agent.c`), the eight-file verify family (`git_verify.c`, `git_verify_config.c`,
+  `git_verify_hook.c`, `git_verify_jobs.c`, `git_verify_ops.c`, `git_verify_select.c`,
+  `git_verify_state.c`, `git_verify_step.c`), and the four MCP git tools (`mcp_git_branch.c`,
+  `mcp_git_pr.c`, `mcp_git_query.c`, `mcp_git_write.c`).
+- Headers: sixteen pair with a like-named source. Two have no paired source — `git_verify_internal.h`
+  (the verify-family seam) and `mcp_git.h` (the shared MCP-git header). The sources without a paired
+  header (`git_pr_ci_grade.c`, the `git_verify_config/hook/ops/state/step.c` family, and the four
+  `mcp_git_*.c`) declare through `git_verify.h`, `git_verify_internal.h`, and `mcp_git.h`.
+
+Every source is live, reached across the server, kb, cmd, and MCP layers by the forge-credential,
+credential-injection, OAuth, git-operation, org-repo, PR, verify, and MCP-git-tool paths.
+
+## Build membership
+
+Make's `DATA_SRCS` compiles all twenty-six sources and carries the `-Imodules/git` include path. CMake
+compiles twelve: the eight `git_verify_*` sources and the four `mcp_git_*` tools — the git verify
+surface and the MCP git tools the thin `aimee` client reaches. It omits the fourteen credential, OAuth,
+ops, forge-vault, host, org-repos, and PR-API sources, which are the server/kb-side git machinery. The
+required Windows and Linux CMake jobs build the thin client green from the twelve-source set — the
+standing evidence that this is an intentional thin-client profile boundary, the same one recorded for
+gateway (slice 38), audit (slice 34), learning (slice 42), workspace (slice 44), vault (slice 46), and
+config (slice 48), not source-list drift. The descriptor records canonical source ownership, which
+both build systems agree on; it does not claim identical build-product membership.
+
+## Test membership
+
+Fourteen tests are declared, each driving a git-module source. Eleven run under Make `unit-test-*`
+targets: `test_forge_credentials.c`, `test_git_cred_inject.c`, `test_git_forge_vault.c`,
+`test_git_host_resolve.c`, `test_git_ops.c`, `test_git_pr_ci_grade.c`, `test_git_project.c`,
+`test_git_ssh_agent.c`, `test_git_verify_contract.c`, `test_git_verify_select.c`, and
+`test_mcp_git.c`.
+
+Three are CTest-only — registered in `src/tests/CMakeLists.txt` but built by no Make `unit-test-*`
+target: `test_git_oauth_device.c`, `test_git_oauth_gh.c`, and `test_git_org_repos.c`. Their subjects
+(`git_oauth_device.c`, `git_oauth_gh.c`, `git_org_repos.c`) are git-module sources, so they are
+declared; their registration rows are `make: false, ctest: true`, the inverse of the usual pattern and
+the same asymmetry audit records for `test_audit_action` and `test_audit_ledger`. Classification is by
+subject membership in the module, not by which build system drives the test.
+
+Two adjacent tests are excluded:
+
+- `test_forge_app_token.c` exercises `src/forge_app_token.c`, a root-level source that is not a
+  git-module file. `forge_credentials.c` — the git-module forge-credential broker, tested by
+  `test_forge_credentials.c` — is a different file. A shared `forge` name prefix is not ownership.
+- `test_forge_credentials_live.c` backs the `forge-cred-live` integration harness, which requires
+  `AIMEE_TEST_FORGE_REPO`, `AIMEE_TEST_FORGE_TOKEN`, and a running forge. Its subject
+  `forge_credentials.c` already has a unit test (`test_forge_credentials.c`), so unlike vault's tpm2
+  harness — claimed because it was the *only* exerciser of its source — this harness is supplementary
+  integration coverage, not sole coverage, and is not claimed.
+
+`scripts/check_module_test_registration.py` now records fourteen git rows — eleven `make: true,
+ctest: false` and three `make: false, ctest: true`; that regeneration is the only reason the baseline
+file changes.
+
+## Why declare without latching
+
+The latch asserts the descriptor exhaustively covers the module root. That is true today — the module
+root holds exactly these twenty-six sources and eighteen headers — so the latch would pass. It is
+deferred because declaring the files and asserting completeness are distinct claims, and the roundtable
+required the completeness audit to review declarations merged on their own first rather than authored
+in the same change. The validator accepts a declared-but-unlatched descriptor: it checks each declared
+path exists and resolves within the module, and enforces set-equality only when `ownership_complete`
+is true.
+
+## Regression controls
+
+The declaration is covered by the existing descriptor validation: every declared path must exist and
+resolve within the module, and the regenerated test-registration baseline pins the fourteen git tests'
+per-suite registration, including the three CTest-only rows. The empty-domain guard from slice 39 does
+not apply, because the module root is not empty. The latch mutation coverage — source removal,
+private-header removal, planted files, cleared latch — is deferred to slice 51, where
+`ownership_complete` is set and those mutations become meaningful.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 -m unittest scripts.tests.test_check_module_test_registration
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_git_core_contract.py --require-status roundtable-approved
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-git-ops build/obj/tests/unit-test-mcp-git
+src/build/obj/tests/unit-test-git-ops
+src/build/obj/tests/unit-test-mcp-git
+```
+
+The three CTest-only git tests build under a CMake-capable environment, which is unavailable here; the
+required pull-request CMake jobs cover them and build the thin client from the twelve-source subset.
+
+Slice 51 sets `ownership_complete: true`, adds the git latch mutation tests, and records the
+completeness audit. Technical-writer review, exact-final-diff roundtable approval, and every required
+pull-request check are required before merge.

--- a/src/modules/git/module.yaml
+++ b/src/modules/git/module.yaml
@@ -12,5 +12,72 @@
   ],
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/git/forge_credentials.c",
+    "src/modules/git/git_cred_inject.c",
+    "src/modules/git/git_forge_vault.c",
+    "src/modules/git/git_host_cred.c",
+    "src/modules/git/git_host_resolve.c",
+    "src/modules/git/git_oauth_device.c",
+    "src/modules/git/git_oauth_gh.c",
+    "src/modules/git/git_oauth_github.c",
+    "src/modules/git/git_ops.c",
+    "src/modules/git/git_org_repos.c",
+    "src/modules/git/git_pr_api.c",
+    "src/modules/git/git_pr_ci_grade.c",
+    "src/modules/git/git_project.c",
+    "src/modules/git/git_ssh_agent.c",
+    "src/modules/git/git_verify.c",
+    "src/modules/git/git_verify_config.c",
+    "src/modules/git/git_verify_hook.c",
+    "src/modules/git/git_verify_jobs.c",
+    "src/modules/git/git_verify_ops.c",
+    "src/modules/git/git_verify_select.c",
+    "src/modules/git/git_verify_state.c",
+    "src/modules/git/git_verify_step.c",
+    "src/modules/git/mcp_git_branch.c",
+    "src/modules/git/mcp_git_pr.c",
+    "src/modules/git/mcp_git_query.c",
+    "src/modules/git/mcp_git_write.c"
+  ],
+  "private_headers": [
+    "src/modules/git/forge_credentials.h",
+    "src/modules/git/git_cred_inject.h",
+    "src/modules/git/git_forge_vault.h",
+    "src/modules/git/git_host_cred.h",
+    "src/modules/git/git_host_resolve.h",
+    "src/modules/git/git_oauth_device.h",
+    "src/modules/git/git_oauth_gh.h",
+    "src/modules/git/git_oauth_github.h",
+    "src/modules/git/git_ops.h",
+    "src/modules/git/git_org_repos.h",
+    "src/modules/git/git_pr_api.h",
+    "src/modules/git/git_project.h",
+    "src/modules/git/git_ssh_agent.h",
+    "src/modules/git/git_verify.h",
+    "src/modules/git/git_verify_internal.h",
+    "src/modules/git/git_verify_jobs.h",
+    "src/modules/git/git_verify_select.h",
+    "src/modules/git/mcp_git.h"
+  ],
+  "tests": [
+    "src/tests/test_forge_credentials.c",
+    "src/tests/test_git_cred_inject.c",
+    "src/tests/test_git_forge_vault.c",
+    "src/tests/test_git_host_resolve.c",
+    "src/tests/test_git_oauth_device.c",
+    "src/tests/test_git_oauth_gh.c",
+    "src/tests/test_git_ops.c",
+    "src/tests/test_git_org_repos.c",
+    "src/tests/test_git_pr_ci_grade.c",
+    "src/tests/test_git_project.c",
+    "src/tests/test_git_ssh_agent.c",
+    "src/tests/test_git_verify_contract.c",
+    "src/tests/test_git_verify_select.c",
+    "src/tests/test_mcp_git.c"
+  ],
+  "docs": [
+    "docs/modules/git.md"
+  ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -707,6 +707,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains config-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the first applied to a fifteen-element declared source set, the largest so far.",
       "independent_review": "The slice-decision roundtable approved the declaration scope in slice 48 with no findings; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-49.md", "docs/modules/config.md", "src/modules/config/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 50,
+      "state": "present_and_verified",
+      "disposition": "Declared the git descriptor's twenty-six sources, eighteen module-root private headers, fourteen direct tests, and document without setting ownership_complete, the declaration half of the pair for the sixth and largest-by-file-count Class B module, keeping the ownership latch orthogonal to the separate git-core-contract governance.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["CMake compiles twelve of the twenty-six sources, the eight git_verify_* and four mcp_git_* the thin client reaches, and omits the fourteen credential/OAuth/ops/forge-vault/host/org-repos/PR-API sources, the same intentional thin-client boundary recorded for gateway, audit, learning, workspace, vault, and config", "Three declared tests (test_git_oauth_device, test_git_oauth_gh, test_git_org_repos) are CTest-only, recorded make:false ctest:true, the inverse asymmetry audit records for its action and ledger tests", "test_forge_app_token.c is excluded because its subject src/forge_app_token.c is a root-level non-module source; test_forge_credentials_live.c is excluded as a supplementary live integration harness whose source forge_credentials.c already has a unit test", "git_verify_internal.h and mcp_git.h are unpaired seam/shared headers declared private; the git-core-contract proposal and its approval evidence are untouched"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Claiming test_forge_app_token.c or test_forge_credentials_live.c by their forge name, or excluding the CTest-only oauth and org-repos tests because Make does not build them, was rejected: the first two exercise a non-module source or are supplementary integration, and the CTest-only three drive git-module sources.",
+        "revisit": "Slice 51 latches git; a separate header-layout slice may relocate git headers under a canonical include tree."
+      },
+      "consumers": ["server, kb, cmd, and MCP git consumers", "the git latch slice", "remaining Class B declaration slices"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains fourteen git rows including three CTest-only rows.",
+      "independent_review": "The slice-decision roundtable confirmed all three scoping decisions and caught a header-count arithmetic error (sixteen paired plus two unpaired equals eighteen, not seventeen plus two), which is corrected in the written declaration. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-50.md", "docs/modules/git.md", "src/modules/git/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
     }
   ]
 }

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -82,6 +82,90 @@
     {
       "ctest": false,
       "make": true,
+      "module": "git",
+      "test": "src/tests/test_forge_credentials.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_cred_inject.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_forge_vault.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_host_resolve.c"
+    },
+    {
+      "ctest": true,
+      "make": false,
+      "module": "git",
+      "test": "src/tests/test_git_oauth_device.c"
+    },
+    {
+      "ctest": true,
+      "make": false,
+      "module": "git",
+      "test": "src/tests/test_git_oauth_gh.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_ops.c"
+    },
+    {
+      "ctest": true,
+      "make": false,
+      "module": "git",
+      "test": "src/tests/test_git_org_repos.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_pr_ci_grade.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_project.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_ssh_agent.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_verify_contract.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_git_verify_select.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "git",
+      "test": "src/tests/test_mcp_git.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
       "module": "governance",
       "test": "src/tests/test_response_governance_stage.c"
     },


### PR DESCRIPTION
Core modularization slice 50 — the **declaration** half of the pair for `git`, the sixth Class B module and the largest by file count. Declares the descriptor's ownership fields; does not set `ownership_complete`. The slice-decision roundtable approved all three scoping calls.

## Twenty-six sources, eighteen headers, fourteen tests

All eighteen headers are declared `private_headers` (no canonical include tree): sixteen pair with a source, and two have no paired source — `git_verify_internal.h` (verify-family seam) and `mcp_git.h` (shared MCP-git header).

Fourteen tests declared by subject. **Three are CTest-only** — `test_git_oauth_device.c`, `test_git_oauth_gh.c`, `test_git_org_repos.c` are registered in `src/tests/CMakeLists.txt` but built by no Make `unit-test-*` target, so recorded `make: false, ctest: true` — the inverse of the usual pattern and the same asymmetry audit records for its action/ledger tests.

**Two excluded:** `test_forge_app_token.c` (subject is root-level `src/forge_app_token.c`, not a git-module file — distinct from the git-module `forge_credentials.c`) and `test_forge_credentials_live.c` (the `forge-cred-live` integration harness needing a running forge; its source already has a unit test, so it's supplementary, not sole coverage — contrast vault's tpm2 harness which was claimed as the only exerciser).

## Twelve of twenty-six sources in CMake

Make compiles all twenty-six; CMake compiles the eight `git_verify_*` and four `mcp_git_*` the thin `aimee` client reaches and omits the fourteen credential/OAuth/ops/forge-vault/host/org-repos/PR-API sources (server/kb-side). Same intentional thin-client boundary as gateway (38), audit (34), learning (42), workspace (44), vault (46), config (48).

## git-core-contract is orthogonal

`git` has a separate governance mechanism (`git-core-contract` CI job) that bounds its *core capability*, not its file ownership. The ownership latch is independent; this slice touches neither the contract proposal nor its approval evidence, and `check_git_core_contract.py --require-status roundtable-approved` passes before and after.

## Validation

All local checks pass, including `check_git_core_contract.py`; git ops, mcp-git, and verify-contract unit tests build and run green. Baseline gains exactly the fourteen git rows (three CTest-only). The exact-diff roundtable returned no issues; a header-count arithmetic slip (16 paired + 2 unpaired = 18) was caught in scoping and corrected before writing. Latch, mutation coverage, and completeness audit come in slice 51.