### PR TITLE
refactor(git): complete module ownership

### DIFF
--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -16,7 +16,7 @@ is `memory.repository-record.ingest.v1`: Git is submit-only, while [memory](memo
 redaction acceptance, persistence, embedding, reranking, and code intelligence.
 
 The descriptor declares this module's twenty-six sources, eighteen module-root headers, fourteen
-direct tests, and this document; it does not yet set `ownership_complete`. All eighteen headers are
+direct tests, and this document; it sets `ownership_complete: true`. All eighteen headers are
 declared as `private_headers` because they live at the module root rather than under
 `src/modules/git/include/aimee/git/`, the layout the header-layout checker treats as private; sixteen
 pair with a source, and two have no paired source — `git_verify_internal.h` (the verify-family seam)
@@ -26,8 +26,10 @@ tools) and omits the fourteen credential, OAuth, ops, forge-vault, host, org-rep
 that are server/kb-side, the same intentional thin-client boundary recorded for gateway, learning,
 workspace, vault, and config. This descriptor's `ownership_complete` latch is independent of the
 separate `git-core-contract` governance, which bounds git's core capability rather than its file
-ownership. `docs/validation/core-modularization-slice-50.md` records the audit; latching follows in a
-separate slice so the completeness audit does not review declarations authored in the same change.
+ownership. `docs/validation/core-modularization-slice-50.md` records the declaration audit and
+`docs/validation/core-modularization-slice-51.md` the completeness audit; the two were split so the
+latch reviews declarations merged on their own first. Adding a new module-local source or module-root
+header without declaring it now fails CI on `rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-51.md
+++ b/docs/validation/core-modularization-slice-51.md
@@ -1,0 +1,78 @@
+# Core modularization slice 51: latch git ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `git` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 50 declared and audited the twenty-six sources, eighteen module-root
+private headers, fourteen direct tests, and document on their own, and this slice asserts those
+declarations exhaustively cover the module root and adds the latch mutation coverage. It changes
+descriptor metadata, validation coverage, documentation, and cleanup accounting only; no production
+code, public symbol, build membership, configuration, storage, or runtime behavior changes. Neither the
+`git-core-contract` proposal nor its approval evidence is touched.
+
+`git` is the fifteenth latched module and the sixth Class B module. Its twenty-six-element source set
+and eighteen-element header set are both the largest latched so far.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/git/include/aimee/git/` (which does not exist). The module root contains exactly the
+twenty-six declared sources and eighteen declared headers and nothing else matching those roles, so the
+declared sets equal the actual sets and the latch is exact. The descriptor's `docs` field equals
+`["docs/modules/git.md"]`, as the latch requires.
+
+Slice 50 established the source liveness, build-membership, and test-classification evidence, and the
+slice-decision roundtable approved the calls: all eighteen headers stay privately declared (two unpaired
+seam/shared headers, `git_verify_internal.h` and `mcp_git.h`); the fourteen declared tests include three
+CTest-only ones recorded `make: false, ctest: true`; `test_forge_app_token.c` (root-level source) and
+`test_forge_credentials_live.c` (supplementary live harness) are not claimed; and the CMake
+twelve-of-twenty-six membership is an intentional thin-client boundary. That audit is not repeated here;
+this slice adds only the completeness assertion on the already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+the root-level `src/forge_app_token.c`, the server/kb git-facing code, or any adjacent git-touching code
+outside the module root has been moved in, and it does not claim identical build-product membership
+across Make and CMake — the fourteen credential/OAuth/ops/forge-vault/host/org-repos/PR-API sources are
+Make-only. It is also independent of the `git-core-contract` governance, which bounds git's core
+capability rather than its file ownership.
+
+## Regression controls
+
+The descriptor mutation suite removes `git_ops.c` and requires `rule=ownership-complete` on `/sources`,
+and removes `git_verify_internal.h` and requires the same rule on `/private_headers`. It plants
+`src/modules/git/undeclared.c` and `undeclared.h` and requires the rule on `/sources` and
+`/private_headers`. It removes `docs/modules/git.md` from the descriptor's `docs` field and requires the
+rule on `/docs`. The graph-derived latched-descriptor assertion from slice 43 now also covers `git`, so
+clearing the latch fails directly. The empty-domain guard from slice 39 does not apply, because the
+module root is not empty. The unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_git_core_contract.py --require-status roundtable-approved
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-git-ops build/obj/tests/unit-test-mcp-git
+src/build/obj/tests/unit-test-git-ops
+src/build/obj/tests/unit-test-mcp-git
+```
+
+`cmake` is unavailable in the environment used for this slice; the three CTest-only git tests and the
+twelve-source thin-client subset are covered by the required pull-request CMake jobs.
+
+With `git` latched, fifteen modules carry `ownership_complete`. The remaining three Class B modules
+(`delegates`, `workflows`, `memory`) follow the same declaration-then-latch pair, and the eight Class A
+modules remain blocked by the empty-domain guard and tracked in
+`docs/validation/core-modularization-class-a-migration.md`. Technical-writer review, exact-final-diff
+roundtable approval, and every required pull-request check are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -283,6 +283,8 @@ class DescriptorTests(unittest.TestCase):
             ("vault", "private_headers", "src/modules/vault/vault_internal.h"),
             ("config", "sources", "src/modules/config/config.c"),
             ("config", "private_headers", "src/modules/config/config_internal.h"),
+            ("git", "sources", "src/modules/git/git_ops.c"),
+            ("git", "private_headers", "src/modules/git/git_verify_internal.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -303,7 +305,7 @@ class DescriptorTests(unittest.TestCase):
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config"):
+                           "workspace", "vault", "config", "git"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -407,7 +409,7 @@ class DescriptorTests(unittest.TestCase):
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config"):
+                           "workspace", "vault", "config", "git"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/git/module.yaml
+++ b/src/modules/git/module.yaml
@@ -13,6 +13,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/git/forge_credentials.c",
     "src/modules/git/git_cred_inject.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -724,6 +724,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains fourteen git rows including three CTest-only rows.",
       "independent_review": "The slice-decision roundtable confirmed all three scoping decisions and caught a header-count arithmetic error (sixteen paired plus two unpaired equals eighteen, not seventeen plus two), which is corrected in the written declaration. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-50.md", "docs/modules/git.md", "src/modules/git/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 51,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the git descriptor against the declarations slice 50 authored and reviewed on their own, the latch half of the pair for the sixth Class B module, exercising the source and private_headers set-equality checks against the largest declared sets in the program, twenty-six sources and eighteen headers.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, twenty-six sources and eighteen headers, not that the root-level src/forge_app_token.c or the server/kb git-facing code outside the module root has been moved in", "CMake compiles twelve of the twenty-six sources and omits the fourteen credential/OAuth/ops/forge-vault/host/org-repos/PR-API sources, the same intentional thin-client boundary recorded for gateway, audit, learning, workspace, vault, and config", "The latch is independent of the git-core-contract governance, which bounds git's core capability rather than its file ownership and is untouched"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The remaining three Class B modules follow the same declaration-then-latch pair; a separate header-layout slice may relocate git headers under a canonical include tree."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining Class B declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains git-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures against the largest declared sets in the program.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 50 and caught the header-count arithmetic corrected there; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-51.md", "docs/modules/git.md", "src/modules/git/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 51 — the **latch** half for `git`, against the declarations [#1882](https://github.com/RakuenSoftware/aimee/pull/1882) merged on their own. Fifteenth module latched, sixth Class B.

## Largest sets in the program

`git`'s twenty-six-element `sources` set and eighteen-element `private_headers` set are both the largest latched so far. The regression suite removes `git_ops.c` from the twenty-six and `git_verify_internal.h` from the eighteen and requires `rule=ownership-complete` naming the missing file; the graph-derived cleared-latch assertion (slice 43) covers git automatically.

## Scope

The latch scopes to the module root as it stands. The root-level `src/forge_app_token.c` and the server/kb git code outside the module root are not claimed; Make/CMake build-product membership is not claimed identical (the fourteen credential/OAuth/ops/forge-vault/host/org-repos/PR-API sources are Make-only); and the latch is **independent of the `git-core-contract` governance**, which bounds git's core capability rather than its file ownership and is untouched. No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

All local checks pass, including `check_git_core_contract.py --require-status roundtable-approved`; git ops and mcp-git unit tests build and run green. The exact-diff roundtable returned no blocking issues.

Fifteen modules now carry `ownership_complete`; three Class B modules remain (`delegates`, `workflows`, `memory`).