### PR TITLE
refactor(delegates): complete module ownership

### DIFF
--- a/docs/modules/delegates.md
+++ b/docs/modules/delegates.md
@@ -17,7 +17,7 @@ root `cmd_agent_delegate.c` is an entry-point consumer. Remaining server/root im
 debt, not a second supported delegate engine.
 
 The descriptor declares this module's twenty-seven sources, twenty-one public headers, nineteen direct
-tests, and this document; it does not yet set `ownership_complete`. `delegates` is the only module in
+tests, and this document; it sets `ownership_complete: true`. `delegates` is the only module in
 the program whose headers all live under the canonical `src/modules/delegates/include/aimee/delegates/`
 tree, so it declares no `private_headers`: the module root holds no header, and an absent field is an
 empty declared set against an empty actual set. An earlier slice declared the panel and IR-rescue
@@ -26,8 +26,11 @@ and the broader direct-test set. Make compiles all twenty-seven sources; CMake c
 omitting `aimee_ir_rescue.c`, `delegate_ephemeral_ws.c`, `delegate_sandbox_image.c`, and
 `gw_orch_delegates.c`, the server/kb-side units — the same intentional thin-client boundary recorded
 for gateway, learning, workspace, vault, config, and git, though CMake reaches far more of this module
-than of those. `docs/validation/core-modularization-slice-52.md` records the audit; latching follows in
-a separate slice so the completeness audit does not review declarations authored in the same change.
+than of those. `docs/validation/core-modularization-slice-52.md` records the declaration audit and
+`docs/validation/core-modularization-slice-53.md` the completeness audit; the two were split so the
+latch reviews declarations merged on their own first. Adding a new module-local source now fails CI on
+`rule=ownership-complete`, and so does adding a module-root header: the absent `private_headers` field
+means the empty set is enforced, not unchecked.
 
 ### IR-side prose tool-call rescue
 

--- a/docs/validation/core-modularization-slice-53.md
+++ b/docs/validation/core-modularization-slice-53.md
@@ -1,0 +1,86 @@
+# Core modularization slice 53: latch delegates ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `delegates` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 52 completed the twenty-seven-source declaration and expanded the
+declared tests to nineteen on their own, and this slice asserts those declarations exhaustively cover
+the module root and adds the latch mutation coverage. It changes descriptor metadata, validation
+coverage, documentation, and cleanup accounting only; no production code, public symbol, build
+membership, configuration, storage, or runtime behavior changes.
+
+`delegates` is the sixteenth latched module and the seventh Class B module. It is the first latched
+module with **zero private headers and a canonical public header tree**, so it is the first whose
+`private_headers` completeness role is enforced as an empty set rather than a declared list.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/delegates/include/aimee/delegates/`. The module root contains exactly the twenty-seven
+declared sources and no headers at all. The declared source set equals the actual source set, and the
+absent `private_headers` field is an empty declared set matching the empty actual set, so the latch is
+exact on both roles. The descriptor's `docs` field equals `["docs/modules/delegates.md"]`, as the latch
+requires.
+
+Slice 52 established the source liveness, build-membership, and test-classification evidence, and the
+slice-decision roundtable approved the calls: declare all twenty-seven sources, expand the tests to
+nineteen, and omit the `private_headers` field entirely. That audit is not repeated here; this slice
+adds only the completeness assertion on the already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+the durable delegate worker and HTTP/RPC orchestration in `src/server/server_compute*`, or the
+root-level `cmd_agent_delegate.c` entry point, have been moved in — the module document records those
+as relocation debt — and it does not claim identical build-product membership across Make and CMake,
+where four sources are Make-only.
+
+## An absent role is enforced, not unchecked
+
+Because `delegates` declares no `private_headers` field, the natural question is whether that role is
+simply skipped. It is not. The mutation suite plants `src/modules/delegates/undeclared.h` and the
+validator fails `rule=ownership-complete` on `/private_headers`, because the actual set becomes
+non-empty while the declared set stays empty. The absent field therefore means *this role must remain
+empty*, not *this role is unvalidated*: adding any module-root header to `delegates` fails CI until it
+is either declared or moved under the canonical include tree. This was verified before the declaration
+slice was written and is re-proven by the mutation added here.
+
+## Regression controls
+
+The descriptor mutation suite removes `delegate_driver.c` and requires `rule=ownership-complete` on
+`/sources`. It plants `src/modules/delegates/undeclared.c` and `undeclared.h` and requires the rule on
+`/sources` and `/private_headers` respectively — the latter being the empty-set enforcement described
+above. It removes `docs/modules/delegates.md` from the descriptor's `docs` field and requires the rule
+on `/docs`. The graph-derived latched-descriptor assertion from slice 43 now also covers `delegates`,
+so clearing the latch fails directly. There is no declared-private-header removal case, because the
+module declares none. The empty-domain guard from slice 39 does not apply, because the module root
+holds twenty-seven sources. The unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-delegate-driver build/obj/tests/unit-test-delegate-plan
+src/build/obj/tests/unit-test-delegate-driver
+src/build/obj/tests/unit-test-delegate-plan
+```
+
+`cmake` is unavailable in the environment used for this slice; the twenty-three-source thin-client
+subset and the CTest registration of `test_delegate_plan` are covered by the required pull-request
+CMake jobs.
+
+With `delegates` latched, sixteen modules carry `ownership_complete`. The remaining two Class B
+modules (`workflows`, `memory`) follow the same declaration-then-latch pair, and the eight Class A
+modules remain blocked by the empty-domain guard and tracked in
+`docs/validation/core-modularization-class-a-migration.md`. Technical-writer review, exact-final-diff
+roundtable approval, and every required pull-request check are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -285,6 +285,7 @@ class DescriptorTests(unittest.TestCase):
             ("config", "private_headers", "src/modules/config/config_internal.h"),
             ("git", "sources", "src/modules/git/git_ops.c"),
             ("git", "private_headers", "src/modules/git/git_verify_internal.h"),
+            ("delegates", "sources", "src/modules/delegates/delegate_driver.c"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -305,7 +306,7 @@ class DescriptorTests(unittest.TestCase):
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config", "git"):
+                           "workspace", "vault", "config", "git", "delegates"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -409,7 +410,7 @@ class DescriptorTests(unittest.TestCase):
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config", "git"):
+                           "workspace", "vault", "config", "git", "delegates"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -38,6 +38,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/delegates/aimee_ir_rescue.c",
     "src/modules/delegates/delegate_backend.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -758,6 +758,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains twenty-four source entries and seventeen test entries validated for existence and containment, and the test-registration baseline gains nineteen delegates rows.",
       "independent_review": "The slice-decision roundtable confirmed all three scoping decisions: expand the tests to nineteen, treat the three delegate_prompt-only tests as that source's coverage, and omit the private_headers field for a module with zero module-root headers. It flagged that slice 53 should verify the latcher treats an absent field as evaluated-empty; that was verified against the validator before writing this slice. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-52.md", "docs/modules/delegates.md", "src/modules/delegates/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 53,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the delegates descriptor against the declarations slice 52 authored and reviewed on their own, the latch half of the pair for the seventh Class B module, and proved that an absent private_headers field enforces an empty set rather than skipping the role.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, twenty-seven sources and no headers, not that the durable delegate worker in src/server/server_compute* or the root cmd_agent_delegate.c entry point have been moved in; the module document records those as relocation debt", "CMake compiles twenty-three of the twenty-seven sources and omits the IR-rescue, ephemeral-workspace, sandbox-image, and gateway-orchestration units, the same intentional thin-client boundary recorded for the earlier modules", "This is the first latched module with zero private headers and a canonical public header tree, so its private_headers role is enforced as an empty set rather than a declared list"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The remaining two Class B modules follow the same declaration-then-latch pair; relocating the server-side delegate worker into the module would extend these declarations."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining Class B declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains delegates-specific missing-source, planted-source, planted-header, missing-document, and cleared-latch failures, the planted-header case proving the absent private_headers field enforces emptiness.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 52 and flagged that the latcher's treatment of an absent field should be verified; that was verified before slice 52 was written and is re-proven here by the planted-header mutation. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-53.md", "docs/modules/delegates.md", "src/modules/delegates/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 53 — the **latch** half for `delegates`, against the declarations [#1884](https://github.com/RakuenSoftware/aimee/pull/1884) merged on their own. Sixteenth module latched, seventh Class B.

## First latch with an enforced *empty* role

`delegates` is the first latched module with **zero private headers and a canonical public header tree**, so its `private_headers` role is enforced as an empty set rather than a declared list. The natural question is whether an absent field means the role is simply skipped — it does not.

The mutation suite plants `src/modules/delegates/undeclared.h` and the validator fails `rule=ownership-complete` on `/private_headers`, because the actual set becomes non-empty while the declared set stays empty. **An absent field means "this role must remain empty," not "this role is unvalidated."** Adding any module-root header to `delegates` now fails CI until it's declared or moved under the canonical include tree. This was verified before the declaration slice was written (the scoping roundtable's diligence item) and is re-proven by the mutation added here.

## Scope

The latch scopes to the module root as it stands (27 sources, no headers). The durable delegate worker in `src/server/server_compute*` and the root `cmd_agent_delegate.c` entry point are **not** claimed — the module document records them as relocation debt — and Make/CMake build-product membership is not claimed identical (four sources are Make-only). No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

All local checks pass; delegate driver and plan unit tests build and run green. The exact-diff roundtable returned no issues.

Sixteen modules now carry `ownership_complete`; two Class B modules remain (`workflows`, `memory`).