### PR TITLE
refactor(workflows): complete module ownership

### DIFF
--- a/docs/modules/workflows.md
+++ b/docs/modules/workflows.md
@@ -15,7 +15,7 @@ notification, and trigger dispatch through `gw_orch_workflows_run`. Definitions 
 must remain deterministic and versioned; provider seams perform effects without owning the lifecycle.
 
 The descriptor declares this module's thirty sources, twenty-four module-root headers, thirty-three
-direct tests, and this document; it does not yet set `ownership_complete`. All twenty-four headers are
+direct tests, and this document; it sets `ownership_complete: true`. All twenty-four headers are
 declared as `private_headers` because they live at the module root rather than under
 `src/modules/workflows/include/aimee/workflows/`, the layout the header-layout checker treats as
 private; every one pairs with a like-named source, and six sources carry no paired header
@@ -25,8 +25,9 @@ CMake compiles twenty-four, omitting `gw_orch_workflows.c`, `wfe_live_foreach.c`
 `wfe_live_panel.c`, `wfe_panel_roundtable.c`, and `wfe_replay_worktree.c` — the live, panel, forge,
 replay, and gateway-orchestration units that are server-side — the same intentional thin-client
 boundary recorded for the earlier modules. `docs/validation/core-modularization-slice-54.md` records
-the audit; latching follows in a separate slice so the completeness audit does not review declarations
-authored in the same change.
+the declaration audit and `docs/validation/core-modularization-slice-55.md` the completeness audit; the
+two were split so the latch reviews declarations merged on their own first. Adding a new module-local
+source or module-root header without declaring it now fails CI on `rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-55.md
+++ b/docs/validation/core-modularization-slice-55.md
@@ -1,0 +1,83 @@
+# Core modularization slice 55: latch workflows ownership
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `workflows` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 54 declared and audited the thirty sources, twenty-four module-root
+private headers, thirty-three direct tests, and document on their own, and this slice asserts those
+declarations exhaustively cover the module root and adds the latch mutation coverage. It changes
+descriptor metadata, validation coverage, documentation, and cleanup accounting only; no production
+code, public symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`workflows` is the seventeenth latched module and the eighth Class B module. Its thirty-source and
+twenty-four-header declared sets are the second-largest in the program, behind git.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/workflows/include/aimee/workflows/` (which does not exist). The module root contains
+exactly the thirty declared sources and twenty-four declared headers and nothing else matching those
+roles, so the declared sets equal the actual sets and the latch is exact. The descriptor's `docs` field
+equals `["docs/modules/workflows.md"]`, as the latch requires.
+
+Slice 54 established the source liveness, build-membership, and test-classification evidence, and the
+slice-decision roundtable approved the calls: all twenty-four headers stay privately declared; the
+thirty-three declared tests exclude four that link no workflows object; and the CMake
+twenty-four-of-thirty membership is an intentional thin-client boundary. That audit is not repeated
+here; this slice adds only the completeness assertion on the already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+DB1's `wfe_store.c` and `wfe_binding.c` — which share this module's `wfe_` name prefix but are DB1
+sources — or the server-side workflow route handlers have been moved in, and it does not claim
+identical build-product membership across Make and CMake, where six sources are Make-only.
+
+## The `wfe_` prefix stays a live hazard after latching
+
+Slice 54 recorded that `wfe_` is shared with `src/db1/wfe_store.c` and `src/db1/wfe_binding.c`, and
+that three of its four test exclusions existed because of that collision. Latching does not resolve
+the hazard, it narrows it: the completeness latch now guarantees that any new `wfe_*.c` or `wfe_*.h`
+placed **in the module root** must be declared or CI fails, so a workflows-owned file cannot be added
+silently. It says nothing about a new `wfe_`-named file added under `src/db1/`, and nothing about how
+a future `test_wfe_*.c` is attributed. Test attribution remains a judgement made by linked object, and
+the test-registration baseline is the mechanism that surfaces a change to any declared test's
+registration.
+
+## Regression controls
+
+The descriptor mutation suite removes `wfe_engine.c` and requires `rule=ownership-complete` on
+`/sources`, and removes `wfe_engine.h` and requires the same rule on `/private_headers`. It plants
+`src/modules/workflows/undeclared.c` and `undeclared.h` and requires the rule on `/sources` and
+`/private_headers`. It removes `docs/modules/workflows.md` from the descriptor's `docs` field and
+requires the rule on `/docs`. The graph-derived latched-descriptor assertion from slice 43 now also
+covers `workflows`, so clearing the latch fails directly. The empty-domain guard from slice 39 does not
+apply, because the module root is not empty. The unmodified descriptor graph must pass.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-wfe-engine build/obj/tests/unit-test-wfe-router
+src/build/obj/tests/unit-test-wfe-engine
+src/build/obj/tests/unit-test-wfe-router
+```
+
+`cmake` is unavailable in the environment used for this slice; the eleven CTest-registered workflows
+tests and the twenty-four-source thin-client subset are covered by the required pull-request CMake
+jobs.
+
+With `workflows` latched, seventeen modules carry `ownership_complete`. One Class B module remains —
+`memory`, the largest — and the eight Class A modules remain blocked by the empty-domain guard and
+tracked in `docs/validation/core-modularization-class-a-migration.md`. Technical-writer review,
+exact-final-diff roundtable approval, and every required pull-request check are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -286,6 +286,8 @@ class DescriptorTests(unittest.TestCase):
             ("git", "sources", "src/modules/git/git_ops.c"),
             ("git", "private_headers", "src/modules/git/git_verify_internal.h"),
             ("delegates", "sources", "src/modules/delegates/delegate_driver.c"),
+            ("workflows", "sources", "src/modules/workflows/wfe_engine.c"),
+            ("workflows", "private_headers", "src/modules/workflows/wfe_engine.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -306,7 +308,7 @@ class DescriptorTests(unittest.TestCase):
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config", "git", "delegates"):
+                           "workspace", "vault", "config", "git", "delegates", "workflows"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -410,7 +412,7 @@ class DescriptorTests(unittest.TestCase):
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config", "git", "delegates"):
+                           "workspace", "vault", "config", "git", "delegates", "workflows"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/workflows/module.yaml
+++ b/src/modules/workflows/module.yaml
@@ -17,6 +17,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/workflows/gw_orch_workflows.c",
     "src/modules/workflows/wfe_advance.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -792,6 +792,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains thirty-three workflows rows, eleven of which are CTest-registered as well as Make-registered.",
       "independent_review": "The slice-decision roundtable confirmed all three scoping decisions, agreed test_wfe_webapi.c should be included under the linked-object criterion, and specifically endorsed recording the wfe_ prefix collision in the validation record so future slices do not re-derive the trap. It also flagged loose phrasing in the unpaired-source list, which is corrected with the exact six names. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-54.md", "docs/modules/workflows.md", "src/modules/workflows/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 55,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the workflows descriptor against the declarations slice 54 authored and reviewed on their own, the latch half of the pair for the eighth Class B module, and recorded that latching narrows but does not resolve the wfe_ name-prefix hazard shared with DB1.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, thirty sources and twenty-four headers, not that DB1's wfe_store.c and wfe_binding.c or the server-side workflow route handlers have been moved in", "Latching guarantees a new wfe_*.c or wfe_*.h in the module root must be declared, but says nothing about a new wfe_-named file under src/db1 and nothing about how a future test_wfe_*.c is attributed; test attribution remains a linked-object judgement surfaced by the test-registration baseline", "CMake compiles twenty-four of the thirty sources and omits the six live, panel, forge, replay, and gateway-orchestration units that are server-side, the same intentional thin-client boundary recorded for the eight earlier modules"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction, so the completeness audit reviews declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "One Class B module remains, memory; DB1's wfe_store.c and wfe_binding.c will be declared when db1 is given a descriptor."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "the remaining memory declaration and latch slices", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains workflows-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures against the second-largest declared sets in the program.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 54, endorsed recording the wfe_ prefix collision, and caught loose phrasing in the unpaired-source list corrected there; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-55.md", "docs/modules/workflows.md", "src/modules/workflows/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 55 — the **latch** half for `workflows`, against the declarations [#1887](https://github.com/RakuenSoftware/aimee/pull/1887) merged on their own. Seventeenth module latched, eighth Class B. Declared sets are the second-largest in the program behind git.

## Latching narrows, but does not resolve, the `wfe_` hazard

Slice 54 recorded that `wfe_` is shared with `src/db1/wfe_store.c` and `src/db1/wfe_binding.c`, and that three of its four test exclusions existed because of that collision. This latch is honest about what it does and doesn't fix:

- **It does guarantee** that any new `wfe_*.c` or `wfe_*.h` placed *in the module root* must be declared or CI fails — a workflows-owned file can no longer be added silently.
- **It says nothing** about a new `wfe_`-named file added under `src/db1/`, and nothing about how a future `test_wfe_*.c` is attributed. Test attribution remains a linked-object judgement, surfaced by the test-registration baseline.

## Scope

The latch scopes to the module root as it stands (30 sources, 24 headers). DB1's `wfe_store.c`/`wfe_binding.c` and the server-side workflow route handlers are not claimed, and Make/CMake build-product membership is not claimed identical (six sources are Make-only). No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

All local checks pass; wfe-engine and wfe-router unit tests build and run green. The exact-diff roundtable returned no issues; it asked me to confirm the slice-43 graph-derived cleared-latch assertion actually covers workflows — verified, it now enumerates all 17 latched descriptors dynamically.

Seventeen modules now carry `ownership_complete`. **One Class B module remains: `memory`**, the largest.