### PR TITLE
refactor(memory): complete module ownership — Class B complete

### DIFF
--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -17,7 +17,7 @@ search, `memory_assemble`, and `gw_stage_memory` are one required capability fam
 physical paths have not all reached the module directory.
 
 The descriptor declares this module's thirty-two sources, twelve module-root headers, sixteen direct
-tests, and this document; it does not yet set `ownership_complete`. All twelve headers are declared as
+tests, and this document; it sets `ownership_complete: true`. All twelve headers are declared as
 `private_headers` because they live at the module root rather than under
 `src/modules/memory/include/aimee/memory/`, the layout the header-layout checker treats as private;
 five carry no paired source (`memory_assemble_util.h`, `memory_core_internal.h`, `memory_ontology.h`,
@@ -25,8 +25,10 @@ five carry no paired source (`memory_assemble_util.h`, `memory_core_internal.h`,
 compiles all thirty-two sources; CMake compiles nineteen, omitting the memory-core CRUD, search, tiers
 and scope family, extraction, the fact and PII gates, graph fusion, and the gateway stage — the
 server/kb-side units — the same intentional thin-client boundary recorded for the earlier modules.
-`docs/validation/core-modularization-slice-56.md` records the audit; latching follows in a separate
-slice so the completeness audit does not review declarations authored in the same change.
+`docs/validation/core-modularization-slice-56.md` records the declaration audit and
+`docs/validation/core-modularization-slice-57.md` the completeness audit; the two were split so the
+latch reviews declarations merged on their own first. Adding a new module-local source or module-root
+header without declaring it now fails CI on `rule=ownership-complete`.
 
 ## Dependencies and consumers
 

--- a/docs/validation/core-modularization-slice-57.md
+++ b/docs/validation/core-modularization-slice-57.md
@@ -1,0 +1,91 @@
+# Core modularization slice 57: latch memory ownership — Class B complete
+
+## Scope
+
+This slice sets `ownership_complete: true` on the `memory` descriptor. It is the latch half of the
+declaration-then-latch pair; slice 56 declared and audited the thirty-two sources, twelve module-root
+private headers, sixteen direct tests, and document on their own, and this slice asserts those
+declarations exhaustively cover the module root and adds the latch mutation coverage. It changes
+descriptor metadata, validation coverage, documentation, and cleanup accounting only; no production
+code, public symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`memory` is the eighteenth latched module and the ninth and final Class B module. **With this slice the
+Class B programme is complete**: every descriptor whose module root contained undeclared
+implementation files now declares that root exhaustively and latches it.
+
+## Ownership domain
+
+The completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/memory/include/aimee/memory/` (which does not exist). The module root contains exactly
+the thirty-two declared sources and twelve declared headers and nothing else matching those roles, so
+the declared sets equal the actual sets and the latch is exact. The descriptor's `docs` field equals
+`["docs/modules/memory.md"]`, as the latch requires.
+
+Slice 56 established the source liveness, build-membership, and test-classification evidence, and the
+slice-decision roundtable approved the calls including the two boundary cases
+(`test_memory_embed_dim_guard.c` as a memory-to-DB2 boundary test, and `test_workspace_memory.c`
+claimed here to close the loop slice 44 opened). That audit is not repeated here; this slice adds only
+the completeness assertion on the already-reviewed declarations.
+
+Completeness is a file-ownership statement about the module root as it stands. It does not assert that
+DB1's working-memory store (`src/db1/wm.c`), the root-level memory-interception harness
+(`src/harness_memory_*.c`), or the server and kb memory-facing code have been moved in, and it does not
+claim identical build-product membership across Make and CMake, where thirteen sources are Make-only.
+
+## Where the programme now stands
+
+Eighteen of the twenty-six module descriptors carry `ownership_complete`. The eight that do not are
+exactly the Class A set — `benchmarks`, `control-web`, `execution-policy`, `kb-synthesis`,
+`response-composition`, `routing`, `runtime-web`, `tools` — whose module roots hold nothing but
+`module.yaml`. They are blocked by the `ownership-empty-domain` guard added in slice 39, which refuses
+a latch on an empty root because set equality would hold vacuously. Their remaining work is migrating
+real implementation under `src/modules/<id>/`, not declaration work, and it is tracked in
+`docs/validation/core-modularization-class-a-migration.md`.
+
+That means the declaration-and-latch phase of this programme is finished. What is left is code
+migration for Class A, plus the deferred follow-ups this programme recorded rather than silently
+absorbed: the API/ABI cleanup candidates in plugin-loader, module-runtime, and gateway; the orphan
+`test_vault_custody_pkcs11.c`; the CTest registration of `test_plugin`; and the header-layout
+promotions (`learning.h`, `config_fields.h`) that ownership slices were forbidden from performing.
+
+## Regression controls
+
+The descriptor mutation suite removes `memory_core.c` and requires `rule=ownership-complete` on
+`/sources`, and removes `memory_core_internal.h` — one of the five unpaired headers — and requires the
+same rule on `/private_headers`. It plants `src/modules/memory/undeclared.c` and `undeclared.h` and
+requires the rule on `/sources` and `/private_headers`. It removes `docs/modules/memory.md` from the
+descriptor's `docs` field and requires the rule on `/docs`. The graph-derived latched-descriptor
+assertion from slice 43 now also covers `memory`, so clearing the latch fails directly. The
+empty-domain guard from slice 39 does not apply, because the module root is not empty. The unmodified
+descriptor graph must pass.
+
+The ownership-report fixture repaired in slice 56 remains meaningful after this latch: it derives the
+undeclared set from the report, and the eight Class A descriptors keep that set non-empty, so it still
+asserts the empty-role property rather than passing vacuously.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 scripts/check_module_source_ownership.py
+python3 scripts/check_module_header_layout.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-memory-provider build/obj/tests/unit-test-memory-redirect
+src/build/obj/tests/unit-test-memory-provider
+src/build/obj/tests/unit-test-memory-redirect
+```
+
+`cmake` is unavailable in the environment used for this slice; the two CTest-registered memory tests
+and the nineteen-source thin-client subset are covered by the required pull-request CMake jobs.
+
+Technical-writer review, exact-final-diff roundtable approval, and every required pull-request check
+are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -299,6 +299,8 @@ class DescriptorTests(unittest.TestCase):
             ("delegates", "sources", "src/modules/delegates/delegate_driver.c"),
             ("workflows", "sources", "src/modules/workflows/wfe_engine.c"),
             ("workflows", "private_headers", "src/modules/workflows/wfe_engine.h"),
+            ("memory", "sources", "src/modules/memory/memory_core.c"),
+            ("memory", "private_headers", "src/modules/memory/memory_core_internal.h"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -319,7 +321,8 @@ class DescriptorTests(unittest.TestCase):
 
         for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config", "git", "delegates", "workflows"):
+                           "workspace", "vault", "config", "git", "delegates", "workflows",
+                           "memory"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -423,7 +426,8 @@ class DescriptorTests(unittest.TestCase):
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway", "governance", "learning",
-                           "workspace", "vault", "config", "git", "delegates", "workflows"):
+                           "workspace", "vault", "config", "git", "delegates", "workflows",
+                           "memory"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/memory/module.yaml
+++ b/src/modules/memory/module.yaml
@@ -9,6 +9,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/memory/gw_stage_memory.c",
     "src/modules/memory/memory_advanced.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -826,6 +826,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, the test-registration baseline gains sixteen memory rows, and one validator fixture becomes graph-derived rather than naming a single module.",
       "independent_review": "The slice-decision roundtable confirmed all three scoping decisions and required three documentation improvements, all applied: name test_memory_embed_dim_guard.c explicitly as a memory-to-DB2 boundary test rather than leaving it implicit, carry the slice 44 cross-reference for test_workspace_memory.c into the validation record, and record an explicit name-collision warning for DB1's working-memory store and the root-level harness as slice 54 did for the wfe_ prefix. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-56.md", "docs/modules/memory.md", "src/modules/memory/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
+    },
+    {
+      "slice": 57,
+      "state": "present_and_verified",
+      "disposition": "Set ownership_complete on the memory descriptor against the declarations slice 56 authored and reviewed on their own, completing the Class B programme: all nine descriptors whose module roots held undeclared implementation files now declare those roots exhaustively and latch them, leaving eighteen of the twenty-six descriptors latched.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The latch asserts the descriptor covers the module root as it stands, thirty-two sources and twelve headers, not that DB1's working-memory store, the root-level memory-interception harness, or the server and kb memory-facing code have been moved in", "CMake compiles nineteen of the thirty-two sources, the same intentional thin-client boundary recorded for the eight earlier Class B modules", "The eight remaining unlatched descriptors are exactly the Class A set with empty module roots, blocked by the ownership-empty-domain guard from slice 39; their remaining work is code migration, not declaration, and is tracked in the Class A migration register", "Deferred follow-ups this programme recorded rather than absorbed remain open: the API and ABI cleanup candidates in plugin-loader, module-runtime, and gateway; the orphan test_vault_custody_pkcs11.c; the CTest registration of test_plugin; and the header-layout promotions of learning.h and config_fields.h"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Latching in the same slice that declared the files was rejected on roundtable direction throughout the programme, so every completeness audit reviewed declarations merged on their own first rather than claims written in the same change.",
+        "revisit": "The declaration-and-latch phase is finished; what remains is Class A code migration and the deferred API, ABI, test-registration, and header-layout follow-ups."
+      },
+      "consumers": ["descriptor-envelope and module-inventory CI", "future descriptor-generated builds", "the Class A migration slices"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains memory-specific missing-source, missing-private-header, planted-source/header, missing-document, and cleared-latch failures, the private-header case exercising one of the five unpaired headers.",
+      "independent_review": "The slice-decision roundtable approved the declaration scope in slice 56 and required three documentation improvements applied there; this slice adds only the completeness assertion. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-57.md", "docs/modules/memory.md", "src/modules/memory/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 57 — the **latch** half for `memory`, against the declarations [#1890](https://github.com/RakuenSoftware/aimee/pull/1890) merged on their own.

## This completes the Class B programme

`memory` is the eighteenth latched module and the **ninth and final Class B module**. Every descriptor whose module root held undeclared implementation files now declares that root exhaustively and latches it:

`governance` → `learning` → `workspace` → `vault` → `config` → `git` → `delegates` → `workflows` → `memory`

**Eighteen of twenty-six descriptors are now latched.** The eight that are not are exactly the Class A set — `benchmarks`, `control-web`, `execution-policy`, `kb-synthesis`, `response-composition`, `routing`, `runtime-web`, `tools` — whose module roots hold nothing but `module.yaml`. They're blocked by the `ownership-empty-domain` guard (slice 39), which refuses a vacuous latch on an empty root. Their remaining work is **code migration, not declaration**, tracked in the Class A migration register.

So the declaration-and-latch phase is finished. What remains is Class A migration plus the follow-ups this programme deliberately recorded rather than silently absorbed: the API/ABI cleanup candidates in plugin-loader, module-runtime and gateway; the orphan `test_vault_custody_pkcs11.c`; CTest registration of `test_plugin`; and the header-layout promotions (`learning.h`, `config_fields.h`) that ownership slices were forbidden from performing.

## This slice

The mutation suite removes `memory_core.c` from the thirty-two and `memory_core_internal.h` — one of the five unpaired headers — from the twelve, and requires `rule=ownership-complete` naming the missing file.

The latch scopes to the module root as it stands. DB1's working-memory store, the root-level memory-interception harness, and the server/kb memory-facing code are not claimed; Make/CMake build-product membership is not claimed identical (thirteen sources are Make-only). No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

The slice-56 ownership-report fixture repair stays meaningful after this latch — the eight Class A descriptors keep the undeclared set non-empty, so it still asserts a real property rather than passing vacuously.

All local checks pass; memory provider and redirect unit tests build and run green. The exact-diff roundtable returned no issues.