### PR TITLE
Gate roundtable artifacts on blocking findings, not every finding

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -636,7 +636,13 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 		}
 	}
 	quorum := panel.MinSuccessful
-	if approvals >= quorum && len(feedback.Findings) == 0 {
+	// Only foundational/blocking findings gate the artifact. Suggestions and nits
+	// are recorded on the feedback (and still reach the author) but must not hold
+	// the gate: the panel prompt defines the severity taxonomy precisely so that
+	// "ordinary defects, suggestions, and nits" are distinguishable from work that
+	// cannot ship. Gating on every finding made any multi-seat gate unpassable --
+	// one nit from one seat looped the stage until its iteration cap.
+	if approvals >= quorum && blockingFindingCount(feedback.Findings) == 0 {
 		rt := roundtableResult(&feedback, true, true, analysis, len(seats), totalCost)
 		rt.Degraded = rt.Degraded || discussionFailed > 0
 		rt.DeadlineHit = deadlineHit
@@ -802,6 +808,21 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 		}
 	}
 	return panelAnalysis{Feedback: feedback, Approvals: approvals, Voters: voters, CostUSD: cost, CostUnknown: costUnknown, Unreachable: strings.Join(seatFailures, "; "), Reports: reports}
+}
+
+// blockingFindingCount counts only the severities that must stop an artifact.
+// An unrecognised or empty severity is treated as blocking: a reviewer that
+// cannot classify its own finding gets the safe interpretation.
+func blockingFindingCount(findings []wfe.Finding) int {
+	blocking := 0
+	for _, finding := range findings {
+		switch strings.ToLower(strings.TrimSpace(finding.Severity)) {
+		case "suggestion", "nit":
+		default:
+			blocking++
+		}
+	}
+	return blocking
 }
 
 func remainingCostLimit(limit, spent float64) float64 {

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1171,3 +1171,27 @@ func TestExtractJSONObjectFailsClosedAfterMismatchedCandidate(t *testing.T) {
 		}
 	}
 }
+
+// Suggestions and nits must not gate an artifact: the panel's severity taxonomy
+// exists to separate work that cannot ship from advisory polish. Gating on every
+// finding made any multi-seat gate unpassable.
+func TestBlockingFindingCountIgnoresAdvisorySeverities(t *testing.T) {
+	cases := []struct {
+		name     string
+		findings []wfe.Finding
+		want     int
+	}{
+		{"empty", nil, 0},
+		{"only advisory", []wfe.Finding{{Severity: "suggestion"}, {Severity: "nit"}, {Severity: "NIT"}, {Severity: " Suggestion "}}, 0},
+		{"blocking and foundational", []wfe.Finding{{Severity: "blocking"}, {Severity: "foundational"}}, 2},
+		{"mixed", []wfe.Finding{{Severity: "nit"}, {Severity: "blocking"}, {Severity: "suggestion"}}, 1},
+		{"unclassified is blocking", []wfe.Finding{{Severity: ""}, {Severity: "weird"}}, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := blockingFindingCount(tc.findings); got != tc.want {
+				t.Fatalf("blockingFindingCount=%d want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`gate.roundtable` approved an artifact only when aggregated feedback had **zero findings of any severity**:

```go
if approvals >= quorum && len(feedback.Findings) == 0 {
```

Findings aggregate across **every seat**, so one `nit` from one seat of a four-seat panel holds the gate. The stage loops to its iteration cap and parks having produced nothing. In practice this makes any multi-seat gate on a non-trivial artifact **unpassable** — an autonomous build can never get past its plan gate to write code.

Observed live: a build run accumulated 22 findings (13 blocking, 7 suggestion, 2 nit) across 5 plan-gate loops with no convergence path, headed for `max_iters: 24` and a park.

## Fix

Gate on `foundational`/`blocking` only. Suggestions and nits remain on the feedback and still reach the author — they just no longer block.

The panel prompt already defines this taxonomy and states *"ordinary defects, suggestions, and nits are not foundational"*; the computed severity was simply discarded at the gate. An unrecognised or empty severity counts as blocking, so a reviewer that cannot classify its own finding gets the safe interpretation.

## Tests
`TestBlockingFindingCountIgnoresAdvisorySeverities` covers empty, advisory-only, blocking/foundational, mixed, and unclassified-is-blocking. Full suite green.