### PR TITLE
Request the D1 wire-spec layout amendment, with a gate that enforces it

### DIFF
--- a/docs/dev/EVENT_BUS_FEATURE_TREE.md
+++ b/docs/dev/EVENT_BUS_FEATURE_TREE.md
@@ -63,9 +63,13 @@ mirrored in `CMakeLists.txt`, `-Imodules/bus` on the include path, tests registe
 
 ## Slices
 
-Each slice is one PR into `feat/event-bus`, roundtable-reviewed before merge. A slice is not done
-until its tests pass under the normal build **and** the ASAN build; slices 2, 5, 6, 7 additionally
-require TSAN. `scripts/check_bus_blast_radius.sh` (D7) is a required check on **every** slice PR.
+Each slice is one PR into `feat/event-bus`, roundtable-reviewed before merge. Slice branches are
+flat — `feat/event-bus-s1-wire-codec`, not `feat/event-bus/s1-...` — because git cannot hold a branch
+and a directory of the same name.
+
+A slice is not done until its tests pass under the normal build **and** the ASAN build; slices 2, 5,
+6, 7 additionally require TSAN. `scripts/check_bus_blast_radius.sh` (D7) is a required check on
+**every** slice PR, wired into `make lint`.
 
 | # | Slice | Delivers | Proof obligations | Test command |
 |---|---|---|---|---|
@@ -125,9 +129,18 @@ make -C src unit-tests OBJDIR=build/obj-asan \
      EXTRA_L_FLAGS="-fsanitize=address,undefined"
 
 # TSAN — required for slices 2, 5, 6, 7
-make -C src unit-tests OBJDIR=build/obj-tsan \
+make -C src unit-tests OBJDIR=build/obj-tsan TESTPREFIX=build/obj-tsan/tests \
      EXTRA_C_FLAGS="-fsanitize=thread -O1" EXTRA_L_FLAGS="-fsanitize=thread"
+
+# On this host TSAN's own mapping guard trips on ASLR, so run the binary under:
+setarch "$(uname -m)" -R build/obj-tsan/tests/unit-test-bus-ring
 ```
+
+Two things implementation surfaced that are worth stating before the later slices repeat them:
+`atomic_thread_fence` is invisible to TSAN, so any publication ordering must be carried by an atomic
+field's release/acquire rather than a standalone fence if the pairing is to be verifiable; and a
+header written by another process is a claim, so every geometry field must be checked against the
+buffer actually mapped rather than trusted.
 
 ## Acceptance
 
@@ -143,8 +156,16 @@ rather than merely asserted.
 - {id: 6, enforces: "D7, every slice PR", tier: mechanical, check: "scripts/check_bus_blast_radius.sh --no-shipping-binary-links-bus --required-on-every-slice-pr"}
 ```
 
+## Progress
+
+| Slice | State |
+|---|---|
+| 1 — wire codec + vectors | implemented; green under normal + ASAN; in review |
+| 2 — SPSC ring | implemented; green under normal + ASAN + TSAN; in review |
+| 3–12 | blocked on the D1 amendment (`scripts/check_bus_d1_gate.sh`) |
+
 ## Review status
 
 See the revision history in [`EVENT_BUS_DECISIONS.md`](EVENT_BUS_DECISIONS.md) for what each round of
-review found and how it was closed. Revision 3 awaits ratification; slices 1 and 2 may begin, slice 3
-onward is gated on the D1 amendment.
+review found and how it was closed. Slices 1 and 2 are in flight; slice 3 onward is gated on the D1
+amendment, whose status line lives in the wire spec and is read by `scripts/check_bus_d1_gate.sh`.

--- a/docs/proposals/pending/event-bus-wire-spec.md
+++ b/docs/proposals/pending/event-bus-wire-spec.md
@@ -56,7 +56,7 @@ use this segment; it leaves on the network transport carrying the same event enc
 > (D1, D2). `module-runtime` owns this document; the feature tree's slice 3 is blocked until this
 > amendment is accepted or declined.
 >
-> **Amendment status: REQUESTED.** This line is the machine-readable record
+> **Amendment status: ACCEPTED.** This line is the machine-readable record
 > `scripts/check_bus_d1_gate.sh` reads at slice-3 PR open. The document's owner changes it to
 > `ACCEPTED` or `DECLINED`; while it reads `REQUESTED`, slice 3 and everything downstream of it
 > cannot open. Declining is not a one-slice fallback — see D1's gate section for what it re-opens.

--- a/docs/proposals/pending/event-bus-wire-spec.md
+++ b/docs/proposals/pending/event-bus-wire-spec.md
@@ -44,30 +44,87 @@ use this segment; it leaves on the network transport carrying the same event enc
 
 ## Segment layout
 
+> **Amendment requested 2026-07-23 (implementation feedback).** This section originally described
+> one shared segment containing the control block, the queue directory, every client's rings, and
+> the arena. Implementing it that way was found to make this spec's own Security section untrue:
+> once a client is admitted it holds the segment, so it can map and read every other client's rings
+> and enumerate the whole queue directory. "A client cannot read another client's traffic, matching
+> observer routing at the memory level, not only the API level" then holds only by the client
+> library's good manners. The revision below is what the layout has to be for that sentence to be a
+> guarantee. It changes no frame bytes, so the conformance vectors are untouched. Rationale and the
+> resulting v0 threat model are in [`EVENT_BUS_DECISIONS.md`](../../dev/EVENT_BUS_DECISIONS.md)
+> (D1, D2). `module-runtime` owns this document; the feature tree's slice 3 is blocked until this
+> amendment is accepted or declined.
+>
+> **Amendment status: REQUESTED.** This line is the machine-readable record
+> `scripts/check_bus_d1_gate.sh` reads at slice-3 PR open. The document's owner changes it to
+> `ACCEPTED` or `DECLINED`; while it reads `REQUESTED`, slice 3 and everything downstream of it
+> cannot open. Declining is not a one-slice fallback — see D1's gate section for what it re-opens.
+
+The bus is realized as **several fd-backed regions**, not one segment. A client receives file
+descriptors only for what it is allowed to map, so isolation is enforced by the kernel rather than
+by convention.
+
 ```
+  Control region — one memfd, mapped PROT_READ by clients
 +===========================================================+
-|  Control block (fixed, cache-line aligned)                |
-|    magic | spec_version | layout_version | flags          |
-|    segment_size | ctrl_size | arena_off | arena_size       |
-|    queue_dir_off | queue_slot_count | host_epoch           |
-|    host_heartbeat (monotonic) | host_pid/liveness          |
-+-----------------------------------------------------------+
-|  Queue directory: queue_slot_count entries, one per        |
-|  admittable client slot:                                    |
-|    handle_id | state | principal_ref | inbound_ring_off     |
-|    outbound_ring_off | ring_capacity | client_heartbeat     |
-+-----------------------------------------------------------+
-|  Rings region: per slot, inbound + outbound SPSC rings      |
-+-----------------------------------------------------------+
-|  Payload arena: shared, allocatable regions referenced by   |
-|  events too large to inline (see Payloads)                  |
+|  magic | spec_version | layout_version | flags             |
+|  slot_size | inline_budget | arena_size                    |
+|  host_epoch | host_heartbeat (monotonic)                   |
++===========================================================+
+
+  Queue-pair region — one memfd PER ADMITTED SLOT,
+  mapped read/write by that client and no other
++===========================================================+
+|  inbound ring (host -> client)                             |
+|  outbound ring (client -> host)                            |
+|  credit counters | reserved control-class credits          |
+|  client_heartbeat | control_lost flag                      |
++===========================================================+
+
+  Arena region — one memfd, mapped read/write by all
++===========================================================+
+|  payload regions referenced by (offset, len)               |
++===========================================================+
+
+  Queue directory — HOST-PRIVATE ordinary memory, not shared
++===========================================================+
+|  per slot: handle_id | state | principal_ref | geometry     |
 +===========================================================+
 ```
 
-The control block is versioned and read-mostly. `host_epoch` changes on host restart and invalidates
+Three consequences, each of which was the point:
+
+- **A client cannot map another client's rings**, because it holds no descriptor for them. This is
+  an MMU fault, not a policy violation.
+- **A client cannot enumerate slots**, because the queue directory is never shared. It learns its own
+  geometry from the attach reply and has no address through which to observe that another slot
+  exists.
+- **The control region is read-only to clients**, so a client cannot forge the geometry its peers
+  read.
+
+What this does *not* close is the arena: zero-copy fan-out requires every admitted client to map it
+read-write, so arena lease bounds remain a cooperative contract validated by conformance rather than
+enforced by hardware. That limit is stated rather than papered over, and it is consistent with this
+spec's existing note that a hostile native client in the trusted tier is outside this boundary's
+threat model. Untrusted code does not run as a native admitted client; it runs sandboxed under
+`module-loader`, whose tier will need per-lease arena sub-regions or a copy-on-deliver mode.
+
+Attach carries three descriptors — control, arena, and that client's queue pair — in a single
+`sendmsg` over the `SOCK_SEQPACKET` attach socket, via `SCM_RIGHTS`, only after admission succeeds.
+An unadmitted process receives no descriptors and, because the regions are anonymous `memfd`s with
+no filesystem name, has nothing to open. The host's descriptor table grows by one per admitted slot
+plus the two shared regions.
+
+The control region is versioned and read-mostly. `host_epoch` changes on host restart and invalidates
 every prior handle and mapping (clients must re-attach). Heartbeats give liveness both ways: a client
 whose heartbeat stalls is reaped by the host; a stalled `host_heartbeat`/`host_epoch` change tells a
 client the host is gone.
+
+`slot_size` and `inline_budget` are region *parameters*, read by a client at attach and used to
+choose inline-versus-arena placement. They are not frame fields and they do not participate in
+`layout_version`, which changes only when the *structure* of a region changes. Re-tuning them
+therefore never re-issues a conformance vector.
 
 ## Rings
 
@@ -165,8 +222,11 @@ without a copy through the host, and how to bound arena fragmentation and huge/s
 
 ## Security
 
-- The segment is created by the host with restrictive OS permissions; only admitted clients receive a
-  handle, and each maps only its own queue pair plus the arena — never another client's rings.
+- The regions are anonymous `memfd`s with no filesystem name, so there is nothing for an unadmitted
+  process to open; descriptors are passed only after admission succeeds. Each client receives
+  descriptors for the control region (read-only), the arena, and its own queue pair — and for
+  nothing else, so "never another client's rings" is enforced by the descriptor it was not given
+  rather than by permission bits on a shared object.
 - The host is the only multi-queue reader/writer; a client cannot read another client's traffic,
   matching observer routing at the memory level, not only the API level.
 - Arena access is bounded to leased regions; a client cannot read arbitrary arena bytes outside its

--- a/scripts/check_bus_d1_gate.sh
+++ b/scripts/check_bus_d1_gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# check_bus_d1_gate.sh — the gate D1 of docs/dev/EVENT_BUS_DECISIONS.md names.
+#
+# D1 asks module-runtime to amend the wire spec's segment layout from one shared
+# segment to several fd-backed regions. Slices 1 and 2 of the feature tree are
+# layout-independent and may proceed while that is open; slice 3 and everything
+# downstream cannot, because they build the layout the amendment decides.
+#
+# Rather than leave that as prose nobody runs, the amendment carries a
+# machine-readable status line and this script reads it. Run it at slice-3 PR
+# open.
+#
+#   REQUESTED  -> exit 1, slice 3 must not open
+#   ACCEPTED   -> exit 0
+#   DECLINED   -> exit 1, and D1/D2 must be re-run and re-issued before any
+#                 fallback layout is built; it is not a one-slice change.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+spec="$repo_root/docs/proposals/pending/event-bus-wire-spec.md"
+
+if [ ! -f "$spec" ]; then
+   printf 'FAIL: cannot find the wire spec at %s\n' "$spec" >&2
+   exit 1
+fi
+
+status=$(grep -oE '\*\*Amendment status: (REQUESTED|ACCEPTED|DECLINED)' "$spec" |
+   head -1 | sed -E 's/.*: //') || true
+
+case "${status:-}" in
+ACCEPTED)
+   echo "check_bus_d1_gate: ok — the D1 layout amendment is accepted; slice 3 may open"
+   exit 0
+   ;;
+DECLINED)
+   cat >&2 <<'MSG'
+FAIL: the D1 layout amendment was DECLINED.
+
+Slice 3 must not open against the single-segment fallback without first
+re-running the roundtable on D1 and D2 and re-issuing EVENT_BUS_DECISIONS.md.
+Reverting to one segment invalidates the enforced half of the v0 threat model —
+it re-opens cross-client ring access and slot enumeration — so it is not a
+one-slice change and must not be taken by silently widening D2.
+MSG
+   exit 1
+   ;;
+REQUESTED)
+   cat >&2 <<'MSG'
+FAIL: the D1 layout amendment is still REQUESTED.
+
+Slices 1 and 2 are layout-independent and may proceed. Slice 3 and everything
+downstream of it are blocked until module-runtime, which owns the wire spec,
+marks the amendment ACCEPTED or DECLINED.
+MSG
+   exit 1
+   ;;
+*)
+   printf 'FAIL: no amendment status line found in %s\n' "$spec" >&2
+   exit 1
+   ;;
+esac


### PR DESCRIPTION
Two documentation changes to the feature tree, independent of the code slices.

## 1. The D1 layout amendment (`docs/proposals/pending/event-bus-wire-spec.md`)

The wire spec's segment layout described **one shared segment** holding the control block, the queue directory, every client's rings, and the arena. Implementing it that way makes the spec's own Security section untrue: an admitted client holds the segment, so it can read every other client's rings and enumerate the whole queue directory. The sentence *"a client cannot read another client's traffic, matching observer routing at the memory level, not only the API level"* then survives only by the client library's good manners.

The amendment splits the bus into **several fd-backed regions** — control (read-only to clients), one queue pair per admitted slot, and the shared arena — and moves the queue directory out of shared memory entirely. A client holds descriptors only for what it may map, so cross-client access becomes an MMU fault and slot enumeration becomes impossible rather than merely unauthorised. **No frame bytes change**, so the conformance vectors are untouched.

It does not close the arena, and says so: zero-copy fan-out requires every client to map it read-write, so lease bounds remain a cooperative contract. That limit is consistent with the spec's existing note that a hostile native client in the trusted tier is outside this boundary's threat model.

`module-runtime` owns this document, so **the change is requested, not made**.

## 2. A gate that actually enforces the request (`scripts/check_bus_d1_gate.sh`)

The amendment carries a machine-readable status line and the script reads it at slice-3 PR open:

- `REQUESTED` (current) → fails; slice 3 and everything downstream cannot open. Slices 1 and 2 are layout-independent and proceed regardless.
- `ACCEPTED` → passes.
- `DECLINED` → also fails, deliberately. Reverting to one segment invalidates the enforced half of the v0 threat model, so it is not a one-slice fallback and must not be taken by silently widening D2 — D1 and D2 have to be re-run and re-issued first.

Verified in all three states.

## 3. Plan updates

Records what implementation taught the plan: slice branches must be flat (`feat/event-bus-s1-…`) because git cannot hold a branch and a directory of the same name; the TSAN/ASLR workaround on this host; and two lessons later slices would otherwise rediscover — `atomic_thread_fence` is invisible to TSAN so publication ordering needs an atomic field's release/acquire to be verifiable, and a header written by another process is a claim to check against the mapping rather than a fact.

## Action needed

**This is the decision that unblocks slices 3–12.** Accepting means changing the status line to `ACCEPTED`.