### PR TITLE
Treat a configured trigger.max_concurrent of 0 as paused, not unlimited

### DIFF
--- a/server-go/internal/api/server_test.go
+++ b/server-go/internal/api/server_test.go
@@ -409,3 +409,30 @@ func runGit(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
 	}
 }
+
+// trigger.max_concurrent = 0 is an operator saying "admit nothing". The store's
+// cap sentinel treats <=0 as unlimited (child slices depend on that), so the
+// admission paths must refuse a configured 0 explicitly — otherwise "pause
+// admission" silently removes the limit instead of applying it.
+func TestConfiguredZeroConcurrencyPausesAdmission(t *testing.T) {
+	server, _, _ := newTestServer(t)
+	configPath := filepath.Join(t.TempDir(), "aimee.yaml")
+	if err := os.WriteFile(configPath, []byte("trigger:\n  max_concurrent: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := appconfig.NewStore(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.SetConfigStore(store)
+	if got := store.Int("trigger.max_concurrent", 2); got != 0 {
+		t.Fatalf("config did not load max_concurrent=0, got %d", got)
+	}
+	body := strings.NewReader(`{"proposal_md":"## do a thing\n\nwhy: because","workflow":"build","repo":"/tmp"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/dev/submit", body)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 paused-admission, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/server-go/internal/api/submit.go
+++ b/server-go/internal/api/submit.go
@@ -59,6 +59,13 @@ func (s *Server) devSubmit(w http.ResponseWriter, r *http.Request) {
 	if s.config != nil {
 		cap = s.config.Int("trigger.max_concurrent", cap)
 	}
+	// See scanTrigger: the store treats <=0 as unlimited (child slices depend on
+	// that), so a configured 0 must be refused here or "pause admission" would
+	// instead remove the limit.
+	if cap == 0 {
+		writeError(w, http.StatusConflict, errors.New("admission paused: trigger.max_concurrent is 0"))
+		return
+	}
 	registry, err := s.workflowRegistry()
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, err)

--- a/server-go/internal/api/trigger.go
+++ b/server-go/internal/api/trigger.go
@@ -401,6 +401,13 @@ func (s *Server) fileProposal(ctx context.Context, request triggerFireRequest) (
 	if s.config != nil {
 		cap = s.config.Int("trigger.max_concurrent", cap)
 	}
+	// The store's cap sentinel is "<=0 means unlimited" (child slices rely on it),
+	// but an operator who sets trigger.max_concurrent to 0 means "admit nothing".
+	// Honour that here rather than silently removing the limit.
+	if cap == 0 {
+		_ = s.artifacts.DeleteWorkItem(workItemID)
+		return "", "", fmt.Errorf("%w (admission paused: trigger.max_concurrent is 0)", db1.ErrAdmissionFull)
+	}
 	if err := s.db.AdmitRoot(ctx, db1.CreateWorkItem{
 		ID: workItemID, Repo: workspace, ProposalPath: identity, WorkflowName: definition.Name,
 		WorkflowVersion: definition.Version, StartStage: start, Mode: request.Mode,


### PR DESCRIPTION
`createWorkItem`'s cap sentinel is *"<= 0 means unlimited"*, and child slices depend on it — `CreateWorkItem` passes `cap=0` for every packet, so the sentinel can't just be redefined.

But that same value is what an operator reaches for to **stop** admission. Setting `trigger.max_concurrent=0` did the exact opposite of what it reads like: it removed the limit and let the trigger keep admitting roots. Observed live — it cost two spurious runs while trying to hold admission during a proposal swap.

Refuses a configured `0` at the two admission entry points (`scanTrigger` and `/v1/dev/submit`), leaving the store sentinel untouched so slice creation keeps working.

Test: `TestConfiguredZeroConcurrencyPausesAdmission` — `/v1/dev/submit` returns 409 when configured to 0. Full suite green.