### PR TITLE
Distinguish provider capacity backpressure from delegate failure

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -941,10 +941,27 @@ WHERE work_item_id=? AND current_stage=? AND state='active' AND pause_reason='' 
 // runner failure without any intervening forward progress. 'redispatch' is
 // deliberately NOT progress: a recovery that keeps re-dispatching work that
 // keeps failing is exactly the no-progress loop this bounds.
+// Capacity backpressure is excluded: the provider refused to start the work, so
+// the delegate never got a chance to fail. Those waits are bounded separately by
+// CapacityWaitsSinceProgress.
 func (s *Store) RunnerFailuresSinceProgress(ctx context.Context, workItemID, stage string) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM lifecycle_event
 WHERE work_item_id=? AND stage=? AND kind='pause'
+  AND detail NOT LIKE 'capacity_backpressure:%'
+  AND id > COALESCE((SELECT MAX(id) FROM lifecycle_event
+                     WHERE work_item_id=? AND kind IN ('advance','loop','create')), 0)`,
+		workItemID, stage, workItemID).Scan(&count)
+	return count, err
+}
+
+// CapacityWaitsSinceProgress counts how many times this stage has parked waiting
+// out provider capacity without any intervening forward progress.
+func (s *Store) CapacityWaitsSinceProgress(ctx context.Context, workItemID, stage string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM lifecycle_event
+WHERE work_item_id=? AND stage=? AND kind='pause'
+  AND detail LIKE 'capacity_backpressure:%'
   AND id > COALESCE((SELECT MAX(id) FROM lifecycle_event
                      WHERE work_item_id=? AND kind IN ('advance','loop','create')), 0)`,
 		workItemID, stage, workItemID).Scan(&count)
@@ -1224,7 +1241,9 @@ func (s *Store) Resume(ctx context.Context, workItemID string) error {
 	if reason == "" {
 		return errors.New("workflow is not paused")
 	}
-	operatorReasons := map[string]bool{"manual": true, "wall_cap": true, "turn_cap": true, "retry_limit": true, "convergence_limit": true, "convergence_no_progress": true, "budget_cap": true, "fanout_limit": true, "workflow_definition_invalid": true, "workflow_block_unavailable": true}
+	// delegate_failed parks explicitly for a human, so a human must be able to
+	// release it once the underlying delegate problem is addressed.
+	operatorReasons := map[string]bool{"manual": true, "wall_cap": true, "turn_cap": true, "retry_limit": true, "convergence_limit": true, "convergence_no_progress": true, "budget_cap": true, "fanout_limit": true, "workflow_definition_invalid": true, "workflow_block_unavailable": true, "delegate_failed": true}
 	if !operatorReasons[reason] {
 		return fmt.Errorf("pause reason %q is lifecycle-owned and cannot be resumed manually", reason)
 	}

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -68,6 +68,25 @@ type Runner interface {
 // one stage before the item is parked for a human instead of auto-resumed.
 const maxRunnerFailuresWithoutProgress = 8
 
+// maxCapacityWaitsWithoutProgress bounds how long a stage waits out provider
+// capacity before giving up. Capacity backpressure is self-clearing, so this is
+// far higher than the runner-failure bound: it exists only so a permanently
+// throttled credential cannot hold an item forever.
+const maxCapacityWaitsWithoutProgress = 240
+
+// isCapacityBackpressure reports whether err is the provider refusing more work
+// right now rather than the delegate failing. Both forms carry their own
+// retry-after, so re-dispatching after a wait is the correct recovery and the
+// attempt must not count against the no-progress bound.
+func isCapacityBackpressure(err error) bool {
+	if err == nil {
+		return false
+	}
+	detail := err.Error()
+	return strings.Contains(detail, "aimee_err=concurrency_limit") ||
+		strings.Contains(detail, "is rate-limited; retry in")
+}
+
 type Engine struct {
 	db            *db1.Store
 	artifacts     *wfe.ArtifactStore
@@ -240,11 +259,22 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 			return out, nil
 		}
 		reason := "runner_unavailable"
+		capacity := isCapacityBackpressure(err)
+		if capacity {
+			// The provider refused the dispatch outright; no delegate ran. Park
+			// on a distinct transient reason so this waits out the throttle on a
+			// longer backoff instead of burning the runner-failure bound.
+			reason = "capacity_backpressure"
+		}
 		// A stage that keeps failing without ever advancing is not a transient
 		// outage: stop auto-resuming it and park for a human. Without this an
 		// endlessly-failing delegate retries on the transient backoff forever.
-		if failures, ferr := e.db.RunnerFailuresSinceProgress(context.WithoutCancel(ctx), item.ID, item.Stage); ferr == nil &&
-			failures >= maxRunnerFailuresWithoutProgress {
+		bound, counter := maxRunnerFailuresWithoutProgress, e.db.RunnerFailuresSinceProgress
+		if capacity {
+			bound, counter = maxCapacityWaitsWithoutProgress, e.db.CapacityWaitsSinceProgress
+		}
+		if failures, ferr := counter(context.WithoutCancel(ctx), item.ID, item.Stage); ferr == nil &&
+			failures >= bound {
 			reason = "delegate_failed"
 		}
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1066,5 +1067,93 @@ func TestPersistentRunnerFailureParksForHuman(t *testing.T) {
 	got, err := store.WorkItem(t.Context(), item.ID)
 	if err != nil || got.PauseReason != "delegate_failed" {
 		t.Fatalf("item not parked delegate_failed: %+v err=%v", got, err)
+	}
+}
+
+type rateLimitedRunner struct{ calls int }
+
+func (r *rateLimitedRunner) Run(context.Context, StepRequest) (StepResult, error) {
+	r.calls++
+	return StepResult{}, &DelegateExecutionError{
+		Err:        fmt.Errorf("vault credential for agent 'MiniMax-M3' is rate-limited; retry in 30s"),
+		Dispatched: false,
+	}
+}
+
+// Provider capacity refusals are self-clearing and advertise their own
+// retry-after, so waiting them out must not consume the runner-failure bound
+// that parks an item for a human. Before this was distinguished, a throttled
+// credential parked a live run permanently within a minute.
+func TestCapacityBackpressureDoesNotParkForHuman(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte("name: one\nstart: work\nnodes:\n  - id: work\n    block: author.proposal\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "one.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := db1.CreateWorkItem{ID: "wi_capacity", Repo: "repo", ProposalPath: "pf", WorkflowName: "one", WorkflowVersion: def.Version, StartStage: "work", MaxCostUSD: 100}
+	if err := store.CreateWorkItem(t.Context(), item); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal(item.ID, []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	runner := &rateLimitedRunner{}
+	eng, err := New(store, artifacts, workflowDir, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 0; attempt < maxRunnerFailuresWithoutProgress+4; attempt++ {
+		out, err := eng.Advance(t.Context(), item.ID)
+		if err != nil {
+			t.Fatalf("advance %d: %v", attempt, err)
+		}
+		if out.PauseReason != "capacity_backpressure" {
+			t.Fatalf("attempt %d: capacity refusal parked %q, want capacity_backpressure", attempt, out.PauseReason)
+		}
+		if _, err := store.ResumeTransient(t.Context(), "capacity_backpressure", 0); err != nil {
+			t.Fatalf("resume %d: %v", attempt, err)
+		}
+	}
+}
+
+// A stage parked for a human must be releasable by a human once the underlying
+// delegate problem is fixed.
+func TestDelegateFailedIsOperatorResumable(t *testing.T) {
+	root := t.TempDir()
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	item := db1.CreateWorkItem{ID: "wi_parked", Repo: "repo", ProposalPath: "pf", WorkflowName: "one", WorkflowVersion: "v1", StartStage: "work", MaxCostUSD: 100}
+	if err := store.CreateWorkItem(t.Context(), item); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Park(t.Context(), item.ID, "work", "delegate_failed", 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Resume(t.Context(), item.ID); err != nil {
+		t.Fatalf("operator cannot release a park meant for a human: %v", err)
+	}
+	got, err := store.WorkItem(t.Context(), item.ID)
+	if err != nil || got.PauseReason != "" {
+		t.Fatalf("item still paused: %+v err=%v", got, err)
 	}
 }

--- a/server-go/internal/engine/scheduler.go
+++ b/server-go/internal/engine/scheduler.go
@@ -38,6 +38,9 @@ type transientPause struct {
 // attempt. Work-item cost and turn caps remain the bounded safety backstops.
 var schedulerTransientPauses = []transientPause{
 	{reason: "runner_unavailable", backoff: 5 * time.Second},
+	// Provider throttles advertise retry-after windows in the tens of seconds;
+	// re-dispatching on the runner_unavailable backoff just re-trips the limit.
+	{reason: "capacity_backpressure", backoff: 30 * time.Second},
 	{reason: "ci_pending", backoff: 15 * time.Second},
 	{reason: "merge_pending", backoff: 15 * time.Second},
 	{reason: "panel_unreachable", backoff: 60 * time.Second},


### PR DESCRIPTION
## Problem

A throttled MiniMax credential parked a live 21-slice WFE run permanently **within a minute**. Observed on .254 during an end-to-end run:

```
00:57:47 impl redispatch | replay result lost; re-dispatching fresh
00:57:48 impl pause      | runner_unavailable: ... 'MiniMax-M3' is rate-limited; retry in 8s
00:57:53 impl redispatch | replay result lost; re-dispatching fresh
00:57:55 impl pause      | runner_unavailable: ... 'MiniMax-M3' is rate-limited; retry in 6s
...
00:58:19 impl pause      | delegate_failed: ... 'MiniMax-M3' is rate-limited; retry in 10s
```

The engine classified capacity refusals (`rate-limited; retry in Ns`, `aimee_err=concurrency_limit`) as runner failures. Each refusal parked `runner_unavailable`; the scheduler re-dispatched 5s later into the *same still-active throttle*; eight of those exhausted `maxRunnerFailuresWithoutProgress` and parked `delegate_failed`. This produced 170 failed delegate jobs in 10 minutes and a terminally parked slice.

Worse, `delegate_failed` was not in the operator-resumable set, so the park intended "for a human" could not be released *by* a human.

## Change

A capacity refusal is categorically not a delegate failure — the provider declined to start the work, so no delegate ran, and the refusal carries its own retry-after.

- New pause reason `capacity_backpressure` for these refusals, resumed on a **30s** backoff that outlasts a typical throttle window rather than re-tripping it at 5s.
- Counted against a separate bound (`maxCapacityWaitsWithoutProgress = 240`) that exists only so a permanently throttled credential cannot hold an item forever. `RunnerFailuresSinceProgress` now excludes them, so waiting out a throttle no longer consumes the budget meant for genuinely failing delegates.
- `delegate_failed` added to the operator-resumable reasons.

This restores the intended lifecycle contract: recoverable causes re-dispatch, only non-recoverable ones park for a human.

## Tests

Both new tests were confirmed to **fail on the unmodified engine** before the fix:

```
--- FAIL: TestCapacityBackpressureDoesNotParkForHuman
    attempt 0: capacity refusal parked "runner_unavailable", want capacity_backpressure
--- FAIL: TestDelegateFailedIsOperatorResumable
    operator cannot release a park meant for a human: pause reason "delegate_failed" is lifecycle-owned
```

Full `internal/engine` and `internal/db1` suites pass with the fix.

## Validation status

Unit-tested, not yet deployed. Deliberately **not** deployed to .254 yet: a live 21-slice E2E run is in flight there and restarting the server mid-run would disrupt it. Mitigated in the interim by reverting `MiniMax max_parallel` 8 -> 4 (the credential rate limit, not the provider, is the real constraint) and `autonomy.concurrency` -> 3, after which the run has held at zero failures.