### PR TITLE
Skip the roundtable panel when the artifact is unchanged

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -561,6 +561,14 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 	if !ok {
 		return StepResult{}, errors.New("roundtable missing src input")
 	}
+	// The author looped back without changing the artifact, so a fresh panel
+	// would reach the same verdict at full cost. Re-serve the existing findings
+	// instead of paying for a re-review of identical bytes.
+	if req.Feedback != nil && req.Feedback.ArtifactHash == reviewed.Hash && len(req.Feedback.Findings) > 0 {
+		unchanged := *req.Feedback
+		return StepResult{Status: StepChanges, Feedback: &unchanged,
+			Detail: "artifact unchanged since the previous review; prior findings still apply"}, nil
+	}
 	workdir := req.WorkItem.Worktree
 	if workdir == "" && req.WorkItem.Repo != "" {
 		var err error

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1195,3 +1195,39 @@ func TestBlockingFindingCountIgnoresAdvisorySeverities(t *testing.T) {
 		})
 	}
 }
+
+// Looping back to the gate without changing the artifact must not pay for a
+// fresh panel: identical bytes yield an identical verdict, so the prior findings
+// are re-served. A live run burned three roundtable rounds re-reviewing one
+// unchanged artifact hash before this.
+func TestRoundtableSkipsReviewWhenArtifactIsUnchanged(t *testing.T) {
+	agents := &recordingAgents{reviewResponse: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"ok"},"verdict":"approve","findings":[]}`}
+	runner := &NativeRunner{agents: agents}
+	artifact := wfe.Artifact{Type: "plan", Content: []byte("unchanged plan")}
+	artifact.Hash = wfe.Hash(artifact.Content)
+	prior := &wfe.ReviewFeedback{SchemaVersion: 1, ArtifactHash: artifact.Hash, Findings: []wfe.Finding{{
+		ID: "f1", Persona: "qa", Severity: "blocking", Summary: "still broken", Recommendation: "fix it",
+	}}}
+	result, err := runner.roundtable(context.Background(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi_unchanged", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Block: "gate.roundtable"},
+		Proposal: "fix the scheduler",
+		Inputs:   map[string]wfe.Artifact{"src": artifact},
+		Feedback: prior,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agents.requests) != 0 {
+		t.Fatalf("panel was re-invoked on an unchanged artifact: %d delegate requests", len(agents.requests))
+	}
+	if result.Status != StepChanges {
+		t.Fatalf("status=%q, want changes", result.Status)
+	}
+	if result.CostUSD != 0 {
+		t.Fatalf("unchanged re-review cost %v, want 0", result.CostUSD)
+	}
+	if result.Feedback == nil || len(result.Feedback.Findings) != 1 || result.Feedback.Findings[0].ID != "f1" {
+		t.Fatalf("prior findings not re-served: %+v", result.Feedback)
+	}
+}


### PR DESCRIPTION
## Problem

When an author loops back to a `gate.roundtable` without changing the artifact, the gate convenes a full fresh panel over byte-identical content. It necessarily reaches the same verdict, at full provider cost, and consumes one of the stage's bounded gate rounds.

Observed in a live 21-slice run on .254. One slice was reviewed three consecutive times on the same artifact hash:

```
00:51:42 freeze advance b7a272fbebe7
00:52:35 rt_gate loop    b7a272fbebe7
00:57:29 freeze advance b7a272fbebe7
01:01:17 rt_gate loop    b7a272fbebe7
01:10:02 freeze advance b7a272fbebe7
01:11:08 rt_gate loop    b7a272fbebe7
01:13:52 freeze advance f1a23d90ae02   <- first actual change
```

Three of that slice's six `max_rounds` were spent re-deriving a verdict already known, plus three panels' worth of spend.

## Change

`ReviewFeedback` already carries the `ArtifactHash` it was produced against. When the incoming feedback matches the artifact now presented and carries findings, re-serve those findings instead of reconvening the panel.

Semantics are unchanged: the step still returns `StepChanges`, the loop still runs, and the author still receives the same findings. Only the redundant provider spend and the duplicate round are removed. Any real change to the artifact changes its hash and takes the normal review path.

## Tests

`TestRoundtableSkipsReviewWhenArtifactIsUnchanged` asserts no delegate request is issued, cost is zero, and prior findings are re-served. Confirmed to fail on the unmodified runner:

```
--- FAIL: TestRoundtableSkipsReviewWhenArtifactIsUnchanged
    panel was re-invoked on an unchanged artifact: 2 delegate requests
```

Full `internal/engine` and `internal/db1` suites pass.

## Validation status

Unit-tested, not deployed. Not deployed to .254 because a live E2E run is in flight there and restarting the server mid-run would disrupt it.

## Note on the underlying no-op

This removes the *waste*, not the cause. An `implement` step that produces no change still advances to `freeze` and re-enters the gate. That is worth addressing separately — this change makes it cheap rather than making it correct.