### PR TITLE
Slice 2 (re-land): SPSC ring primitive

### DIFF
--- a/src/modules/bus/bus_ring.c
+++ b/src/modules/bus/bus_ring.c
@@ -1,4 +1,6 @@
-/* bus_ring.c: SPSC ring buffer. See bus_ring.h for the concurrency contract.
+/* bus_ring.c: SPSC ring buffer. See bus_ring.h for the concurrency contract and
+ * for why geometry is copied into a process-local handle rather than re-read
+ * from shared memory.
  *
  * The memory-ordering argument, once, because it is the whole correctness case:
  *
@@ -30,9 +32,7 @@ static int is_pow2(uint32_t v)
 
 static size_t header_bytes(void)
 {
-   /* offsetof(slots) already includes the alignment padding the compiler
-    * inserted for the cache-line-aligned members. */
-   return offsetof(bus_ring_t, slots);
+   return offsetof(bus_ring_shared_t, slots);
 }
 
 size_t bus_ring_bytes(uint32_t slot_size, uint32_t capacity)
@@ -43,8 +43,6 @@ size_t bus_ring_bytes(uint32_t slot_size, uint32_t capacity)
        capacity > BUS_RING_MAX_CAPACITY)
       return 0;
 
-   /* Both operands are bounded above, so this cannot overflow size_t on any
-    * platform with a 64-bit size_t; the check is kept for the 32-bit case. */
    size_t slots = (size_t)slot_size * (size_t)capacity;
    if (slots / capacity != slot_size)
       return 0;
@@ -55,8 +53,20 @@ size_t bus_ring_bytes(uint32_t slot_size, uint32_t capacity)
    return total;
 }
 
+/* Fill a handle from geometry that has already been validated. One place, so
+ * init and attach cannot disagree about what a handle means. */
+static void handle_from(bus_ring_t *out, bus_ring_shared_t *s, uint32_t slot_size,
+                        uint32_t capacity, uint32_t slots_off)
+{
+   out->shared = s;
+   out->slots = (uint8_t *)s + slots_off;
+   out->slot_size = slot_size;
+   out->capacity = capacity;
+   out->mask = capacity - 1;
+}
+
 bus_ring_result_t bus_ring_init(void *mem, size_t memsz, uint32_t slot_size, uint32_t capacity,
-                                bus_ring_t **out)
+                                bus_ring_t *out)
 {
    if (!mem || !out)
       return BUS_RING_ERR_MEM;
@@ -67,81 +77,93 @@ bus_ring_result_t bus_ring_init(void *mem, size_t memsz, uint32_t slot_size, uin
    if (memsz < need)
       return BUS_RING_ERR_MEM;
 
-   bus_ring_t *r = (bus_ring_t *)mem;
+   bus_ring_shared_t *s = (bus_ring_shared_t *)mem;
    memset(mem, 0, need);
-   r->slot_size = slot_size;
-   r->capacity = capacity;
-   r->mask = capacity - 1;
-   r->slots_off = (uint32_t)header_bytes();
-   atomic_store_explicit(&r->head, 0, memory_order_relaxed);
-   atomic_store_explicit(&r->tail, 0, memory_order_relaxed);
+   atomic_store_explicit(&s->slot_size, slot_size, memory_order_relaxed);
+   atomic_store_explicit(&s->capacity, capacity, memory_order_relaxed);
+   atomic_store_explicit(&s->mask, capacity - 1, memory_order_relaxed);
+   atomic_store_explicit(&s->slots_off, (uint32_t)header_bytes(), memory_order_relaxed);
+   atomic_store_explicit(&s->head, 0, memory_order_relaxed);
+   atomic_store_explicit(&s->tail, 0, memory_order_relaxed);
 
    /* Magic last, with a release store: a peer that sees the magic is guaranteed
     * to see the fully initialised header behind it. Writing it first would
     * expose a half-built ring to anyone already polling for it. */
-   atomic_store_explicit(&r->magic, BUS_RING_MAGIC, memory_order_release);
+   atomic_store_explicit(&s->magic, BUS_RING_MAGIC, memory_order_release);
 
-   *out = r;
+   handle_from(out, s, slot_size, capacity, (uint32_t)header_bytes());
    return BUS_RING_OK;
 }
 
-bus_ring_result_t bus_ring_attach(void *mem, size_t memsz, bus_ring_t **out)
+bus_ring_result_t bus_ring_attach(void *mem, size_t memsz, bus_ring_t *out)
 {
    if (!mem || !out)
       return BUS_RING_ERR_MEM;
    if (memsz < header_bytes())
       return BUS_RING_ERR_MEM;
 
-   bus_ring_t *r = (bus_ring_t *)mem;
-   if (atomic_load_explicit(&r->magic, memory_order_acquire) != BUS_RING_MAGIC)
+   bus_ring_shared_t *s = (bus_ring_shared_t *)mem;
+   if (atomic_load_explicit(&s->magic, memory_order_acquire) != BUS_RING_MAGIC)
       return BUS_RING_ERR_MAGIC;
 
-   /* The header was written by another process. Treat every field as a claim
-    * to be checked against the buffer actually mapped, not as a fact: a header
+   /* Each geometry field is read EXACTLY ONCE, into a local. Re-reading any of
+    * them after validation would let a peer change the value between the check
+    * and the use — the whole reason the handle exists. */
+   uint32_t slot_size = atomic_load_explicit(&s->slot_size, memory_order_acquire);
+   uint32_t capacity = atomic_load_explicit(&s->capacity, memory_order_acquire);
+   uint32_t mask = atomic_load_explicit(&s->mask, memory_order_acquire);
+   uint32_t slots_off = atomic_load_explicit(&s->slots_off, memory_order_acquire);
+
+   /* Everything below judges those locals. The header is a claim; a header
     * describing a larger ring than was mapped would otherwise turn into reads
     * past the end of the mapping. */
-   if (!is_pow2(r->capacity) || r->capacity < BUS_RING_MIN_CAPACITY ||
-       r->capacity > BUS_RING_MAX_CAPACITY)
+   if (!is_pow2(capacity) || capacity < BUS_RING_MIN_CAPACITY ||
+       capacity > BUS_RING_MAX_CAPACITY)
       return BUS_RING_ERR_GEOMETRY;
-   if (r->slot_size == 0 || r->slot_size > BUS_RING_MAX_SLOT_SIZE)
+   if (slot_size == 0 || slot_size > BUS_RING_MAX_SLOT_SIZE)
       return BUS_RING_ERR_GEOMETRY;
-   if (r->mask != r->capacity - 1)
+   if (mask != capacity - 1)
       return BUS_RING_ERR_LAYOUT;
-   if (r->slots_off != header_bytes())
+   if (slots_off != header_bytes())
       return BUS_RING_ERR_LAYOUT;
 
-   size_t need = bus_ring_bytes(r->slot_size, r->capacity);
+   size_t need = bus_ring_bytes(slot_size, capacity);
    if (need == 0)
       return BUS_RING_ERR_GEOMETRY;
    if (memsz < need)
       return BUS_RING_ERR_LAYOUT;
 
-   /* An index pair that claims more entries than the ring can hold is either
-    * corruption or a hostile write; either way it must not become an
-    * out-of-bounds slot index. */
-   uint64_t head = atomic_load_explicit(&r->head, memory_order_acquire);
-   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_acquire);
-   if (head - tail > r->capacity)
+   /* An index pair claiming more entries than the ring can hold is corruption.
+    * Reading the two counters is only meaningful because attach is an
+    * initialization-phase operation with no concurrent traffic (see the header):
+    * during traffic these two loads would not form a coherent snapshot and a
+    * healthy ring could be rejected. `> capacity` and not `>=`, because a
+    * difference of exactly capacity is the ordinary full state. */
+   uint64_t head = atomic_load_explicit(&s->head, memory_order_acquire);
+   uint64_t tail = atomic_load_explicit(&s->tail, memory_order_acquire);
+   if (head - tail > capacity)
       return BUS_RING_ERR_LAYOUT;
 
-   *out = r;
+   handle_from(out, s, slot_size, capacity, slots_off);
    return BUS_RING_OK;
 }
 
-static uint8_t *slot_at(bus_ring_t *r, uint64_t index)
+/* Addressing uses only the handle's validated copies, so no value a peer can
+ * write to the shared header can move where this process reads or writes. */
+static uint8_t *slot_at(const bus_ring_t *r, uint64_t index)
 {
    return r->slots + (size_t)(index & r->mask) * r->slot_size;
 }
 
-void *bus_ring_produce_begin(bus_ring_t *r)
+void *bus_ring_produce_begin(const bus_ring_t *r)
 {
-   if (!r)
+   if (!r || !r->shared)
       return NULL;
 
    /* Our own index: nobody else writes it, so relaxed is enough. */
-   uint64_t head = atomic_load_explicit(&r->head, memory_order_relaxed);
+   uint64_t head = atomic_load_explicit(&r->shared->head, memory_order_relaxed);
    /* The consumer's index: acquire, so slots it released are safe to reuse. */
-   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_acquire);
+   uint64_t tail = atomic_load_explicit(&r->shared->tail, memory_order_acquire);
 
    if (head - tail >= r->capacity)
       return NULL; /* full */
@@ -149,50 +171,46 @@ void *bus_ring_produce_begin(bus_ring_t *r)
    return slot_at(r, head);
 }
 
-void bus_ring_produce_commit(bus_ring_t *r)
+void bus_ring_produce_commit(const bus_ring_t *r)
 {
-   if (!r)
+   if (!r || !r->shared)
       return;
-   uint64_t head = atomic_load_explicit(&r->head, memory_order_relaxed);
+   uint64_t head = atomic_load_explicit(&r->shared->head, memory_order_relaxed);
    /* Release: everything written into the slot happens-before the consumer's
     * acquire load of this index. */
-   atomic_store_explicit(&r->head, head + 1, memory_order_release);
+   atomic_store_explicit(&r->shared->head, head + 1, memory_order_release);
 }
 
 const void *bus_ring_consume_begin(const bus_ring_t *r)
 {
-   if (!r)
+   if (!r || !r->shared)
       return NULL;
 
-   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_relaxed);
-   uint64_t head = atomic_load_explicit(&r->head, memory_order_acquire);
+   uint64_t tail = atomic_load_explicit(&r->shared->tail, memory_order_relaxed);
+   uint64_t head = atomic_load_explicit(&r->shared->head, memory_order_acquire);
 
    if (head == tail)
       return NULL; /* empty */
 
-   /* Casting away const is confined to this line. The consumer does not write
-    * the slot; the interface returns const, and only the address arithmetic
-    * needs a mutable base. */
-   bus_ring_t *m = (bus_ring_t *)(uintptr_t)r;
-   return slot_at(m, tail);
+   return slot_at(r, tail);
 }
 
-void bus_ring_consume_commit(bus_ring_t *r)
+void bus_ring_consume_commit(const bus_ring_t *r)
 {
-   if (!r)
+   if (!r || !r->shared)
       return;
-   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_relaxed);
+   uint64_t tail = atomic_load_explicit(&r->shared->tail, memory_order_relaxed);
    /* Release: our reads of the slot happen-before the producer's acquire load
     * of this index, so it cannot overwrite bytes we are still reading. */
-   atomic_store_explicit(&r->tail, tail + 1, memory_order_release);
+   atomic_store_explicit(&r->shared->tail, tail + 1, memory_order_release);
 }
 
 uint64_t bus_ring_count(const bus_ring_t *r)
 {
-   if (!r)
+   if (!r || !r->shared)
       return 0;
-   uint64_t head = atomic_load_explicit(&r->head, memory_order_acquire);
-   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_acquire);
+   uint64_t head = atomic_load_explicit(&r->shared->head, memory_order_acquire);
+   uint64_t tail = atomic_load_explicit(&r->shared->tail, memory_order_acquire);
    return head - tail;
 }
 

--- a/src/modules/bus/bus_ring.c
+++ b/src/modules/bus/bus_ring.c
@@ -1,0 +1,221 @@
+/* bus_ring.c: SPSC ring buffer. See bus_ring.h for the concurrency contract.
+ *
+ * The memory-ordering argument, once, because it is the whole correctness case:
+ *
+ *   Producer: fills slot[head & mask], then stores head+1 with release.
+ *   Consumer: loads head with acquire, then reads slot[tail & mask].
+ *
+ * The release/acquire pair on `head` orders the slot writes before the index
+ * that publishes them, so a consumer that sees the new head is guaranteed to
+ * see the bytes. The mirror pair on `tail` does the same for reuse: the
+ * producer must not overwrite a slot until it has acquired the tail that
+ * released it.
+ *
+ * Each side loads its *own* index relaxed — nobody else writes it, so there is
+ * nothing to synchronise with — and the other side's index with acquire.
+ */
+#include <string.h>
+
+#include "bus_ring.h"
+
+/* Bound the geometry so a corrupt or hostile header cannot ask for an
+ * allocation that overflows the size computation below. */
+#define BUS_RING_MAX_SLOT_SIZE (1u << 24)
+#define BUS_RING_MAX_CAPACITY  (1u << 20)
+
+static int is_pow2(uint32_t v)
+{
+   return v != 0 && (v & (v - 1)) == 0;
+}
+
+static size_t header_bytes(void)
+{
+   /* offsetof(slots) already includes the alignment padding the compiler
+    * inserted for the cache-line-aligned members. */
+   return offsetof(bus_ring_t, slots);
+}
+
+size_t bus_ring_bytes(uint32_t slot_size, uint32_t capacity)
+{
+   if (slot_size == 0 || slot_size > BUS_RING_MAX_SLOT_SIZE)
+      return 0;
+   if (!is_pow2(capacity) || capacity < BUS_RING_MIN_CAPACITY ||
+       capacity > BUS_RING_MAX_CAPACITY)
+      return 0;
+
+   /* Both operands are bounded above, so this cannot overflow size_t on any
+    * platform with a 64-bit size_t; the check is kept for the 32-bit case. */
+   size_t slots = (size_t)slot_size * (size_t)capacity;
+   if (slots / capacity != slot_size)
+      return 0;
+
+   size_t total = header_bytes() + slots;
+   if (total < slots)
+      return 0;
+   return total;
+}
+
+bus_ring_result_t bus_ring_init(void *mem, size_t memsz, uint32_t slot_size, uint32_t capacity,
+                                bus_ring_t **out)
+{
+   if (!mem || !out)
+      return BUS_RING_ERR_MEM;
+
+   size_t need = bus_ring_bytes(slot_size, capacity);
+   if (need == 0)
+      return BUS_RING_ERR_GEOMETRY;
+   if (memsz < need)
+      return BUS_RING_ERR_MEM;
+
+   bus_ring_t *r = (bus_ring_t *)mem;
+   memset(mem, 0, need);
+   r->slot_size = slot_size;
+   r->capacity = capacity;
+   r->mask = capacity - 1;
+   r->slots_off = (uint32_t)header_bytes();
+   atomic_store_explicit(&r->head, 0, memory_order_relaxed);
+   atomic_store_explicit(&r->tail, 0, memory_order_relaxed);
+
+   /* Magic last, with a release store: a peer that sees the magic is guaranteed
+    * to see the fully initialised header behind it. Writing it first would
+    * expose a half-built ring to anyone already polling for it. */
+   atomic_store_explicit(&r->magic, BUS_RING_MAGIC, memory_order_release);
+
+   *out = r;
+   return BUS_RING_OK;
+}
+
+bus_ring_result_t bus_ring_attach(void *mem, size_t memsz, bus_ring_t **out)
+{
+   if (!mem || !out)
+      return BUS_RING_ERR_MEM;
+   if (memsz < header_bytes())
+      return BUS_RING_ERR_MEM;
+
+   bus_ring_t *r = (bus_ring_t *)mem;
+   if (atomic_load_explicit(&r->magic, memory_order_acquire) != BUS_RING_MAGIC)
+      return BUS_RING_ERR_MAGIC;
+
+   /* The header was written by another process. Treat every field as a claim
+    * to be checked against the buffer actually mapped, not as a fact: a header
+    * describing a larger ring than was mapped would otherwise turn into reads
+    * past the end of the mapping. */
+   if (!is_pow2(r->capacity) || r->capacity < BUS_RING_MIN_CAPACITY ||
+       r->capacity > BUS_RING_MAX_CAPACITY)
+      return BUS_RING_ERR_GEOMETRY;
+   if (r->slot_size == 0 || r->slot_size > BUS_RING_MAX_SLOT_SIZE)
+      return BUS_RING_ERR_GEOMETRY;
+   if (r->mask != r->capacity - 1)
+      return BUS_RING_ERR_LAYOUT;
+   if (r->slots_off != header_bytes())
+      return BUS_RING_ERR_LAYOUT;
+
+   size_t need = bus_ring_bytes(r->slot_size, r->capacity);
+   if (need == 0)
+      return BUS_RING_ERR_GEOMETRY;
+   if (memsz < need)
+      return BUS_RING_ERR_LAYOUT;
+
+   /* An index pair that claims more entries than the ring can hold is either
+    * corruption or a hostile write; either way it must not become an
+    * out-of-bounds slot index. */
+   uint64_t head = atomic_load_explicit(&r->head, memory_order_acquire);
+   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_acquire);
+   if (head - tail > r->capacity)
+      return BUS_RING_ERR_LAYOUT;
+
+   *out = r;
+   return BUS_RING_OK;
+}
+
+static uint8_t *slot_at(bus_ring_t *r, uint64_t index)
+{
+   return r->slots + (size_t)(index & r->mask) * r->slot_size;
+}
+
+void *bus_ring_produce_begin(bus_ring_t *r)
+{
+   if (!r)
+      return NULL;
+
+   /* Our own index: nobody else writes it, so relaxed is enough. */
+   uint64_t head = atomic_load_explicit(&r->head, memory_order_relaxed);
+   /* The consumer's index: acquire, so slots it released are safe to reuse. */
+   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_acquire);
+
+   if (head - tail >= r->capacity)
+      return NULL; /* full */
+
+   return slot_at(r, head);
+}
+
+void bus_ring_produce_commit(bus_ring_t *r)
+{
+   if (!r)
+      return;
+   uint64_t head = atomic_load_explicit(&r->head, memory_order_relaxed);
+   /* Release: everything written into the slot happens-before the consumer's
+    * acquire load of this index. */
+   atomic_store_explicit(&r->head, head + 1, memory_order_release);
+}
+
+const void *bus_ring_consume_begin(const bus_ring_t *r)
+{
+   if (!r)
+      return NULL;
+
+   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_relaxed);
+   uint64_t head = atomic_load_explicit(&r->head, memory_order_acquire);
+
+   if (head == tail)
+      return NULL; /* empty */
+
+   /* Casting away const is confined to this line. The consumer does not write
+    * the slot; the interface returns const, and only the address arithmetic
+    * needs a mutable base. */
+   bus_ring_t *m = (bus_ring_t *)(uintptr_t)r;
+   return slot_at(m, tail);
+}
+
+void bus_ring_consume_commit(bus_ring_t *r)
+{
+   if (!r)
+      return;
+   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_relaxed);
+   /* Release: our reads of the slot happen-before the producer's acquire load
+    * of this index, so it cannot overwrite bytes we are still reading. */
+   atomic_store_explicit(&r->tail, tail + 1, memory_order_release);
+}
+
+uint64_t bus_ring_count(const bus_ring_t *r)
+{
+   if (!r)
+      return 0;
+   uint64_t head = atomic_load_explicit(&r->head, memory_order_acquire);
+   uint64_t tail = atomic_load_explicit(&r->tail, memory_order_acquire);
+   return head - tail;
+}
+
+uint32_t bus_ring_capacity(const bus_ring_t *r)
+{
+   return r ? r->capacity : 0;
+}
+
+const char *bus_ring_result_name(bus_ring_result_t r)
+{
+   switch (r)
+   {
+   case BUS_RING_OK:
+      return "OK";
+   case BUS_RING_ERR_MEM:
+      return "ERR_MEM";
+   case BUS_RING_ERR_GEOMETRY:
+      return "ERR_GEOMETRY";
+   case BUS_RING_ERR_MAGIC:
+      return "ERR_MAGIC";
+   case BUS_RING_ERR_LAYOUT:
+      return "ERR_LAYOUT";
+   default:
+      return "ERR_UNKNOWN";
+   }
+}

--- a/src/modules/bus/bus_ring.h
+++ b/src/modules/bus/bus_ring.h
@@ -11,19 +11,43 @@
  * keeping this layer ignorant of it is what lets slice 2 land before the D1
  * layout question is settled.
  *
- * Two processes map the same bytes at different addresses, so the ring stores
- * no pointers: every reference inside it is an offset from the header.
+ * Two processes map the same bytes at different addresses, so the shared header
+ * stores no pointers: every reference inside it is an offset.
+ *
+ * ---------------------------------------------------------------------------
+ * The split between bus_ring_t and bus_ring_t handle is the safety property
+ * ---------------------------------------------------------------------------
+ *
+ * bus_ring_shared_t is the header in shared memory. A peer — possibly a
+ * misbehaving or compromised one — can write to it at any moment. Validating
+ * its geometry and then *reading that geometry again* on the hot path would be
+ * worthless: the values could change between the check and the use, and the
+ * resulting `slots + (index & mask) * slot_size` would address outside the
+ * mapping. It is also a data race in the C sense, so the compiler is entitled
+ * to reload, hoist, or speculate those fields.
+ *
+ * So geometry is validated once, at attach, and *copied* into a process-local
+ * bus_ring_t. The hot path uses only the local copy. A peer can scribble on
+ * the shared header afterwards and it cannot move where this process writes;
+ * the worst it can do is corrupt payload bytes, which is the cooperative-arena
+ * limit already stated in D2.
+ *
+ * Only head and tail are read from shared memory on the hot path, and they are
+ * atomic, bounds-masked by the local geometry, and cannot produce an
+ * out-of-range address whatever value they hold.
  *
  * Concurrency contract:
  *
  *   - The producer calls bus_ring_produce_begin / _commit. Nobody else may.
  *   - The consumer calls bus_ring_consume_begin / _commit. Nobody else may.
  *   - Both may run at once, on different cores, with no coordination.
+ *   - bus_ring_init and bus_ring_attach are initialization-phase operations and
+ *     are not concurrent with traffic on the same ring (see bus_ring_attach).
  *
  * Publication is a release store on the producer index and consumption is an
- * acquire load of it, which is what makes the slot's contents visible to the
- * reader before the index that exposes them. The reverse pair on the consumer
- * index does the same for slot reuse.
+ * acquire load of it, which makes the slot's contents visible to the reader
+ * before the index that exposes them. The reverse pair on the consumer index
+ * does the same for slot reuse.
  */
 #ifndef AIMEE_BUS_RING_H
 #define AIMEE_BUS_RING_H 1
@@ -37,7 +61,8 @@
 /* Indices sit on separate cache lines. Producer and consumer write different
  * lines, so neither invalidates the other's cache on every operation — without
  * this the two ends contend on one line and the ring runs at a fraction of its
- * speed under load. */
+ * speed under load. Asserted by offset, not by hope: see the static asserts
+ * below and the offset checks in the tests. */
 #define BUS_RING_CACHELINE 64
 
 /* A ring must hold at least two slots for full and empty to be distinguishable
@@ -53,59 +78,91 @@ typedef enum
    BUS_RING_ERR_LAYOUT    /* header self-description disagrees with the buffer */
 } bus_ring_result_t;
 
-/* The in-memory header. Both processes map this, so its layout is a contract:
+/* The shared header. Both processes map this, so its layout is a contract:
  * fields may only be added in the reserved space, and any change to the shape
- * is a layout_version change (D4).
+ * is a layout_version change (D4). The static asserts below pin every offset,
+ * so an inadvertent field insertion becomes a build error rather than a silent
+ * disagreement between two processes that map the same bytes.
+ *
+ * Geometry fields are read exactly once, at attach, and never again — see the
+ * header comment. They are declared atomic so that read is not a data race
+ * even when a peer is writing them.
  *
  * head and tail are free-running 64-bit counters, masked to index slots. They
  * are never wrapped back to zero, which is what removes the ABA problem a
- * wrapping index would have: at a billion operations a second a 64-bit counter
- * takes about six centuries to overflow, so "full" and "empty" are always
- * distinguishable from the pair alone and never alias. */
+ * wrapping index would have. They are not magic: a uint64_t does eventually
+ * overflow, and states exactly 2^64 operations apart would alias. At a billion
+ * operations per second that is about 585 years of continuous traffic on one
+ * ring instance, which is far outside any bus lifetime — the guarantee is a
+ * stated bound, not an impossibility. */
 typedef struct
 {
-   /* Atomic because it is genuinely accessed concurrently: it is the flag that
-    * publishes a fully-built header to a peer that may already be polling for
-    * it. A release store here pairs with the acquire load in bus_ring_attach,
-    * which is the same job a standalone fence would do — except that a fence is
-    * invisible to ThreadSanitizer, so the pairing could not be verified. */
-   _Atomic uint32_t magic;
-   uint32_t slot_size;
-   uint32_t capacity; /* power of two */
-   uint32_t mask;     /* capacity - 1, so the hot path masks instead of dividing */
-   uint32_t slots_off;
-   uint32_t reserved[3];
+   _Atomic uint32_t magic; /* release-stored last; publishes the header */
+   _Atomic uint32_t slot_size;
+   _Atomic uint32_t capacity;
+   _Atomic uint32_t mask;
+   _Atomic uint32_t slots_off;
+   _Atomic uint32_t reserved[3];
 
    _Alignas(BUS_RING_CACHELINE) _Atomic uint64_t head; /* producer writes */
    _Alignas(BUS_RING_CACHELINE) _Atomic uint64_t tail; /* consumer writes */
    _Alignas(BUS_RING_CACHELINE) uint8_t slots[];
+} bus_ring_shared_t;
+
+/* Cross-process layout is load-bearing: two processes with different struct
+ * layouts would disagree about where the slots start, and attach would reject
+ * the ring. Pinning the offsets makes that a compile-time failure here rather
+ * than a runtime mystery there. */
+_Static_assert(offsetof(bus_ring_shared_t, magic) == 0, "magic must lead the header");
+_Static_assert(offsetof(bus_ring_shared_t, head) == BUS_RING_CACHELINE,
+               "head must start its own cache line");
+_Static_assert(offsetof(bus_ring_shared_t, tail) == 2 * BUS_RING_CACHELINE,
+               "tail must not share a cache line with head");
+_Static_assert(offsetof(bus_ring_shared_t, slots) == 3 * BUS_RING_CACHELINE,
+               "slots must not share a cache line with tail");
+
+/* The process-local handle. Geometry here has been validated and copied; a peer
+ * cannot reach it. This is what every hot-path call takes. */
+typedef struct
+{
+   bus_ring_shared_t *shared; /* head/tail live here, and only head/tail */
+   uint8_t *slots;            /* resolved once from the validated slots_off */
+   uint32_t slot_size;
+   uint32_t capacity;
+   uint32_t mask;
 } bus_ring_t;
 
 /* Bytes needed for a ring of this geometry, including the header and padding.
  * Returns 0 if the geometry is invalid or would overflow. */
 size_t bus_ring_bytes(uint32_t slot_size, uint32_t capacity);
 
-/* Lay a ring out in mem. The caller owns the memory; this only writes the
- * header. */
+/* Lay a ring out in mem and return a handle to it. The caller owns the memory. */
 bus_ring_result_t bus_ring_init(void *mem, size_t memsz, uint32_t slot_size, uint32_t capacity,
-                                bus_ring_t **out);
+                                bus_ring_t *out);
 
-/* Adopt a ring another process laid out. Everything the header claims is
- * checked against the buffer actually mapped, because the header may have been
- * written by a process this one does not trust. */
-bus_ring_result_t bus_ring_attach(void *mem, size_t memsz, bus_ring_t **out);
+/* Adopt a ring another process laid out. Every field the header claims is
+ * checked against the buffer actually mapped, then copied into *out.
+ *
+ * Attach is an initialization-phase operation: it must not run concurrently
+ * with traffic on the same ring. The head/tail sanity check reads the two
+ * counters separately, and a producer and consumer advancing between those two
+ * loads could make a perfectly healthy ring look inconsistent. Rather than
+ * paper over that with a retry loop that could still be unlucky, the lifecycle
+ * rule is the contract: the host attaches a client's ring before handing the
+ * client its descriptor, so there is no traffic to race with. */
+bus_ring_result_t bus_ring_attach(void *mem, size_t memsz, bus_ring_t *out);
 
 /* Producer. _begin returns a writable slot, or NULL when the ring is full; the
  * slot is not visible to the consumer until _commit. Splitting them is what
  * makes the write zero-copy: the producer fills the shared slot in place
  * rather than filling a local buffer and copying it in. */
-void *bus_ring_produce_begin(bus_ring_t *r);
-void bus_ring_produce_commit(bus_ring_t *r);
+void *bus_ring_produce_begin(const bus_ring_t *r);
+void bus_ring_produce_commit(const bus_ring_t *r);
 
 /* Consumer. _begin returns the oldest unread slot, or NULL when the ring is
  * empty; the slot stays valid until _commit releases it for reuse. */
 const void *bus_ring_consume_begin(const bus_ring_t *r);
-void bus_ring_consume_commit(bus_ring_t *r);
+void bus_ring_consume_commit(const bus_ring_t *r);
 
 /* Observers. Both are snapshots: by the time either returns, the other end may
  * have moved. Useful for metrics and for the credit accounting in slice 7,

--- a/src/modules/bus/bus_ring.h
+++ b/src/modules/bus/bus_ring.h
@@ -1,0 +1,118 @@
+/* bus_ring.h: the single-producer/single-consumer ring the event bus is built on.
+ *
+ * One writer, one reader, no lock. Every ring in the bus has exactly one of
+ * each by construction — a client owns its outbound ring and the host owns its
+ * inbound ring (D1) — so the SPSC restriction is not a simplification to be
+ * revisited later, it is what the topology already guarantees.
+ *
+ * The ring lives in memory the caller supplies, because in the real bus that
+ * memory is a shared mapping. Nothing here knows or cares whether it is a
+ * `memfd`, a `malloc`, or a stack buffer; slice 3 supplies the mapping, and
+ * keeping this layer ignorant of it is what lets slice 2 land before the D1
+ * layout question is settled.
+ *
+ * Two processes map the same bytes at different addresses, so the ring stores
+ * no pointers: every reference inside it is an offset from the header.
+ *
+ * Concurrency contract:
+ *
+ *   - The producer calls bus_ring_produce_begin / _commit. Nobody else may.
+ *   - The consumer calls bus_ring_consume_begin / _commit. Nobody else may.
+ *   - Both may run at once, on different cores, with no coordination.
+ *
+ * Publication is a release store on the producer index and consumption is an
+ * acquire load of it, which is what makes the slot's contents visible to the
+ * reader before the index that exposes them. The reverse pair on the consumer
+ * index does the same for slot reuse.
+ */
+#ifndef AIMEE_BUS_RING_H
+#define AIMEE_BUS_RING_H 1
+
+#include <stdatomic.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define BUS_RING_MAGIC 0x474e4952u /* "RING" */
+
+/* Indices sit on separate cache lines. Producer and consumer write different
+ * lines, so neither invalidates the other's cache on every operation — without
+ * this the two ends contend on one line and the ring runs at a fraction of its
+ * speed under load. */
+#define BUS_RING_CACHELINE 64
+
+/* A ring must hold at least two slots for full and empty to be distinguishable
+ * states rather than the same one. */
+#define BUS_RING_MIN_CAPACITY 2
+
+typedef enum
+{
+   BUS_RING_OK = 0,
+   BUS_RING_ERR_MEM,      /* the buffer is too small for the requested geometry */
+   BUS_RING_ERR_GEOMETRY, /* capacity not a power of two, or a size out of range */
+   BUS_RING_ERR_MAGIC,    /* not a ring */
+   BUS_RING_ERR_LAYOUT    /* header self-description disagrees with the buffer */
+} bus_ring_result_t;
+
+/* The in-memory header. Both processes map this, so its layout is a contract:
+ * fields may only be added in the reserved space, and any change to the shape
+ * is a layout_version change (D4).
+ *
+ * head and tail are free-running 64-bit counters, masked to index slots. They
+ * are never wrapped back to zero, which is what removes the ABA problem a
+ * wrapping index would have: at a billion operations a second a 64-bit counter
+ * takes about six centuries to overflow, so "full" and "empty" are always
+ * distinguishable from the pair alone and never alias. */
+typedef struct
+{
+   /* Atomic because it is genuinely accessed concurrently: it is the flag that
+    * publishes a fully-built header to a peer that may already be polling for
+    * it. A release store here pairs with the acquire load in bus_ring_attach,
+    * which is the same job a standalone fence would do — except that a fence is
+    * invisible to ThreadSanitizer, so the pairing could not be verified. */
+   _Atomic uint32_t magic;
+   uint32_t slot_size;
+   uint32_t capacity; /* power of two */
+   uint32_t mask;     /* capacity - 1, so the hot path masks instead of dividing */
+   uint32_t slots_off;
+   uint32_t reserved[3];
+
+   _Alignas(BUS_RING_CACHELINE) _Atomic uint64_t head; /* producer writes */
+   _Alignas(BUS_RING_CACHELINE) _Atomic uint64_t tail; /* consumer writes */
+   _Alignas(BUS_RING_CACHELINE) uint8_t slots[];
+} bus_ring_t;
+
+/* Bytes needed for a ring of this geometry, including the header and padding.
+ * Returns 0 if the geometry is invalid or would overflow. */
+size_t bus_ring_bytes(uint32_t slot_size, uint32_t capacity);
+
+/* Lay a ring out in mem. The caller owns the memory; this only writes the
+ * header. */
+bus_ring_result_t bus_ring_init(void *mem, size_t memsz, uint32_t slot_size, uint32_t capacity,
+                                bus_ring_t **out);
+
+/* Adopt a ring another process laid out. Everything the header claims is
+ * checked against the buffer actually mapped, because the header may have been
+ * written by a process this one does not trust. */
+bus_ring_result_t bus_ring_attach(void *mem, size_t memsz, bus_ring_t **out);
+
+/* Producer. _begin returns a writable slot, or NULL when the ring is full; the
+ * slot is not visible to the consumer until _commit. Splitting them is what
+ * makes the write zero-copy: the producer fills the shared slot in place
+ * rather than filling a local buffer and copying it in. */
+void *bus_ring_produce_begin(bus_ring_t *r);
+void bus_ring_produce_commit(bus_ring_t *r);
+
+/* Consumer. _begin returns the oldest unread slot, or NULL when the ring is
+ * empty; the slot stays valid until _commit releases it for reuse. */
+const void *bus_ring_consume_begin(const bus_ring_t *r);
+void bus_ring_consume_commit(bus_ring_t *r);
+
+/* Observers. Both are snapshots: by the time either returns, the other end may
+ * have moved. Useful for metrics and for the credit accounting in slice 7,
+ * never for deciding whether a _begin will succeed — call _begin for that. */
+uint64_t bus_ring_count(const bus_ring_t *r);
+uint32_t bus_ring_capacity(const bus_ring_t *r);
+
+const char *bus_ring_result_name(bus_ring_result_t r);
+
+#endif /* AIMEE_BUS_RING_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -137,6 +137,11 @@ aimee_add_test(test_bus_wire test_bus_wire.c ../modules/bus/bus_wire.c)
 target_include_directories(test_bus_wire PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 target_compile_definitions(test_bus_wire PRIVATE
   BUS_VECTOR_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures/bus")
+aimee_add_test(test_bus_ring test_bus_ring.c ../modules/bus/bus_ring.c)
+target_include_directories(test_bus_ring PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+find_package(Threads REQUIRED)
+target_link_libraries(test_bus_ring PRIVATE Threads::Threads)
+
 
 aimee_add_test(test_self_update test_self_update.c ../self_update_util.c)
 aimee_add_test(test_audit_action test_audit_action.c)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -214,6 +214,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-graph-analytics $(TESTPREFIX)/unit-test-lessons-cite-tracker $(TESTPREFIX)/unit-test-lessons-reflect $(TESTPREFIX)/unit-test-lessons-actuate $(TESTPREFIX)/unit-test-lessons-session-capture $(TESTPREFIX)/unit-test-kb-doc-hash \
                $(TESTPREFIX)/unit-test-prompt-sanitizer \
                $(TESTPREFIX)/unit-test-bus-wire \
+               $(TESTPREFIX)/unit-test-bus-ring \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2535,6 +2536,18 @@ $(OBJDIR)/tests/test_bus_wire.o: C_FLAGS += -Imodules/bus -DBUS_VECTOR_DIR=\"$(C
 $(TESTPREFIX)/unit-test-bus-wire: $(OBJDIR)/tests/test_bus_wire.o \
                                   $(OBJDIR)/modules/bus/bus_wire.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+# Event-bus SPSC ring (feature tree slice 2). Pure: no DB, no shared memory —
+# the ring lives in caller-supplied memory, which is what lets it land before
+# the region layout is settled.
+$(OBJDIR)/tests/test_bus_ring.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-ring: $(OBJDIR)/tests/test_bus_ring.o \
+                                  $(OBJDIR)/modules/bus/bus_ring.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
+
+.PHONY: unit-test-bus-ring
+unit-test-bus-ring: $(TESTPREFIX)/unit-test-bus-ring
+	$<
 
 .PHONY: unit-test-bus-wire
 unit-test-bus-wire: $(TESTPREFIX)/unit-test-bus-wire

--- a/src/tests/test_bus_ring.c
+++ b/src/tests/test_bus_ring.c
@@ -1,0 +1,281 @@
+/* test_bus_ring.c: slice 2 of the event-bus feature tree.
+ *
+ * The ring's correctness case is a concurrency argument, so the tests are
+ * built to attack it rather than to demonstrate it:
+ *
+ *   - Geometry and attach validation, including headers that lie about their
+ *     own size. In the real bus the header is written by another process, so
+ *     "the header is wrong" is a case that has to be handled, not assumed away.
+ *
+ *   - Single-threaded wrap behaviour many times around the ring, which is
+ *     where an index that aliased full with empty would show up.
+ *
+ *   - A threaded producer/consumer stress run carrying a checksummed sequence,
+ *     so a lost, duplicated, reordered, or torn item is detected rather than
+ *     merely made unlikely. Run under TSAN this also exercises the
+ *     release/acquire pairs themselves.
+ *
+ * Every check uses must() rather than assert(), so -DNDEBUG cannot quietly
+ * turn this into a test that passes because it stopped looking.
+ */
+#include <pthread.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bus_ring.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+static void must_result(bus_ring_result_t got, bus_ring_result_t want, const char *what)
+{
+   if (got != want)
+   {
+      fprintf(stderr, "FAIL: %s: expected %s, got %s\n", what, bus_ring_result_name(want),
+              bus_ring_result_name(got));
+      abort();
+   }
+}
+
+/* ------------------------------------------------------------------ */
+/* geometry                                                            */
+
+static void test_geometry(void)
+{
+   must(bus_ring_bytes(64, 8) > 0, "valid geometry sizes");
+   must(bus_ring_bytes(0, 8) == 0, "zero slot size rejected");
+   must(bus_ring_bytes(64, 0) == 0, "zero capacity rejected");
+   must(bus_ring_bytes(64, 3) == 0, "non-power-of-two capacity rejected");
+   must(bus_ring_bytes(64, 1) == 0, "capacity below the minimum rejected");
+   must(bus_ring_bytes(1u << 30, 1u << 20) == 0, "absurd geometry rejected");
+
+   /* The header must leave the slots cache-line aligned, or the false sharing
+    * the separated indices avoid comes straight back through the payload. */
+   must(bus_ring_bytes(64, 8) % BUS_RING_CACHELINE == 0, "ring size is cache-line aligned");
+
+   size_t need = bus_ring_bytes(64, 8);
+   void *mem = calloc(1, need);
+   must(mem != NULL, "alloc");
+   bus_ring_t *r = NULL;
+
+   must_result(bus_ring_init(mem, need - 1, 64, 8, &r), BUS_RING_ERR_MEM,
+               "init into a short buffer");
+   must_result(bus_ring_init(mem, need, 64, 7, &r), BUS_RING_ERR_GEOMETRY,
+               "init with bad capacity");
+   must_result(bus_ring_init(mem, need, 64, 8, &r), BUS_RING_OK, "init");
+   must(bus_ring_capacity(r) == 8, "capacity readback");
+   must(bus_ring_count(r) == 0, "fresh ring is empty");
+
+   free(mem);
+   printf("  geometry: bounds, alignment, and rejection\n");
+}
+
+/* bus_ring.c keeps header_bytes() private; the test only needs "smaller than
+ * the header", and offsetof on the public type gives that without widening the
+ * module's interface for a test's convenience. */
+static size_t header_bytes_probe(void)
+{
+   return offsetof(bus_ring_t, slots) - 1;
+}
+
+/* A header written by another process is a claim, not a fact. These are the
+ * lies that would otherwise turn into out-of-bounds access. */
+static void test_attach_validation(void)
+{
+   size_t need = bus_ring_bytes(64, 8);
+   void *mem = calloc(1, need);
+   must(mem != NULL, "alloc");
+   bus_ring_t *r = NULL;
+   must_result(bus_ring_init(mem, need, 64, 8, &r), BUS_RING_OK, "init");
+
+   bus_ring_t *got = NULL;
+   must_result(bus_ring_attach(mem, need, &got), BUS_RING_OK, "attach to a good ring");
+
+   uint32_t saved;
+
+   saved = atomic_load_explicit(&r->magic, memory_order_relaxed);
+   atomic_store_explicit(&r->magic, 0, memory_order_relaxed);
+   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_MAGIC, "attach without magic");
+   atomic_store_explicit(&r->magic, saved, memory_order_relaxed);
+
+   saved = r->capacity;
+   r->capacity = 7;
+   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_GEOMETRY,
+               "attach with non-power-of-two capacity");
+   r->capacity = saved;
+
+   saved = r->mask;
+   r->mask = 0xffff;
+   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_LAYOUT,
+               "attach with a mask that disagrees with capacity");
+   r->mask = saved;
+
+   /* The important one: a header claiming a bigger ring than was mapped. */
+   saved = r->capacity;
+   r->capacity = 1024;
+   r->mask = 1023;
+   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_LAYOUT,
+               "attach where the header outgrows the mapping");
+   r->capacity = saved;
+   r->mask = saved - 1;
+
+   /* An index pair claiming more entries than exist must not become an
+    * out-of-bounds slot index. */
+   atomic_store_explicit(&r->head, 100, memory_order_relaxed);
+   atomic_store_explicit(&r->tail, 0, memory_order_relaxed);
+   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_LAYOUT,
+               "attach with an impossible index pair");
+   atomic_store_explicit(&r->head, 0, memory_order_relaxed);
+
+   must_result(bus_ring_attach(mem, header_bytes_probe(), &got), BUS_RING_ERR_MEM,
+               "attach to a buffer smaller than the header");
+
+   free(mem);
+   printf("  attach: rejects five ways a header can lie\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* single-threaded behaviour                                           */
+
+static void test_full_empty_and_wrap(void)
+{
+   const uint32_t cap = 4, slot = 32;
+   size_t need = bus_ring_bytes(slot, cap);
+   void *mem = calloc(1, need);
+   bus_ring_t *r = NULL;
+   must_result(bus_ring_init(mem, need, slot, cap, &r), BUS_RING_OK, "init");
+
+   must(bus_ring_consume_begin(r) == NULL, "empty ring yields nothing");
+
+   for (uint32_t i = 0; i < cap; i++)
+   {
+      void *s = bus_ring_produce_begin(r);
+      must(s != NULL, "produce into a ring with room");
+      memset(s, (int)i, slot);
+      bus_ring_produce_commit(r);
+   }
+   must(bus_ring_count(r) == cap, "count at capacity");
+   must(bus_ring_produce_begin(r) == NULL, "full ring refuses a producer");
+
+   for (uint32_t i = 0; i < cap; i++)
+   {
+      const uint8_t *s = bus_ring_consume_begin(r);
+      must(s != NULL, "consume from a non-empty ring");
+      must(s[0] == (uint8_t)i, "FIFO order");
+      bus_ring_consume_commit(r);
+   }
+   must(bus_ring_count(r) == 0, "count back to empty");
+   must(bus_ring_consume_begin(r) == NULL, "drained ring yields nothing");
+
+   /* Many laps, one item at a time, so every slot is reused repeatedly. An
+    * index that wrapped rather than free-running would alias full with empty
+    * somewhere in here. */
+   for (uint32_t lap = 0; lap < 10000; lap++)
+   {
+      void *s = bus_ring_produce_begin(r);
+      must(s != NULL, "produce during wrap");
+      *(uint32_t *)s = lap;
+      bus_ring_produce_commit(r);
+
+      const void *c = bus_ring_consume_begin(r);
+      must(c != NULL, "consume during wrap");
+      must(*(const uint32_t *)c == lap, "value survives wrap");
+      bus_ring_consume_commit(r);
+   }
+   must(bus_ring_count(r) == 0, "empty after 10000 laps");
+
+   free(mem);
+   printf("  full/empty and wrap: 10000 laps through a 4-slot ring\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* threaded stress                                                     */
+
+#define STRESS_ITEMS   200000u
+#define STRESS_SLOT    64u
+#define STRESS_CAPACITY 64u
+
+typedef struct
+{
+   uint64_t seq;
+   uint64_t check; /* a function of seq, so a torn slot is visible */
+   uint8_t pad[STRESS_SLOT - 2 * sizeof(uint64_t)];
+} stress_item_t;
+
+static uint64_t mix(uint64_t v)
+{
+   /* Any cheap avalanche will do; the point is that half a written item does
+    * not accidentally satisfy the check. */
+   v ^= v >> 33;
+   v *= 0xff51afd7ed558ccdull;
+   v ^= v >> 33;
+   return v;
+}
+
+static bus_ring_t *g_ring;
+
+static void *producer_thread(void *arg)
+{
+   (void)arg;
+   for (uint64_t i = 0; i < STRESS_ITEMS; i++)
+   {
+      stress_item_t *s;
+      /* Spin rather than sleep: a full ring is the interesting state, and
+       * backing off would reduce how often the test visits it. */
+      while ((s = (stress_item_t *)bus_ring_produce_begin(g_ring)) == NULL)
+         ;
+      s->seq = i;
+      s->check = mix(i);
+      bus_ring_produce_commit(g_ring);
+   }
+   return NULL;
+}
+
+static void test_threaded_stress(void)
+{
+   size_t need = bus_ring_bytes(STRESS_SLOT, STRESS_CAPACITY);
+   void *mem = calloc(1, need);
+   must(mem != NULL, "alloc");
+   must_result(bus_ring_init(mem, need, STRESS_SLOT, STRESS_CAPACITY, &g_ring), BUS_RING_OK,
+               "init");
+
+   pthread_t producer;
+   must(pthread_create(&producer, NULL, producer_thread, NULL) == 0, "spawn producer");
+
+   for (uint64_t expect = 0; expect < STRESS_ITEMS; expect++)
+   {
+      const stress_item_t *s;
+      while ((s = (const stress_item_t *)bus_ring_consume_begin(g_ring)) == NULL)
+         ;
+      /* Order proves nothing was lost, duplicated, or reordered; the checksum
+       * proves the slot was not read half-written. */
+      must(s->seq == expect, "stress: sequence intact");
+      must(s->check == mix(expect), "stress: item not torn");
+      bus_ring_consume_commit(g_ring);
+   }
+
+   must(pthread_join(producer, NULL) == 0, "join producer");
+   must(bus_ring_count(g_ring) == 0, "stress: ring drained");
+
+   free(mem);
+   printf("  threaded stress: %u items, checksummed, none lost or torn\n", STRESS_ITEMS);
+}
+
+int main(void)
+{
+   printf("test_bus_ring:\n");
+   test_geometry();
+   test_attach_validation();
+   test_full_empty_and_wrap();
+   test_threaded_stress();
+   printf("test_bus_ring: OK\n");
+   return 0;
+}

--- a/src/tests/test_bus_ring.c
+++ b/src/tests/test_bus_ring.c
@@ -1,22 +1,29 @@
 /* test_bus_ring.c: slice 2 of the event-bus feature tree.
  *
- * The ring's correctness case is a concurrency argument, so the tests are
- * built to attack it rather than to demonstrate it:
+ * The ring's correctness case is a concurrency argument, so the tests are built
+ * to attack it rather than to demonstrate it:
  *
  *   - Geometry and attach validation, including headers that lie about their
  *     own size. In the real bus the header is written by another process, so
- *     "the header is wrong" is a case that has to be handled, not assumed away.
+ *     "the header is wrong" is a case to handle, not to assume away.
  *
- *   - Single-threaded wrap behaviour many times around the ring, which is
- *     where an index that aliased full with empty would show up.
+ *   - The handle boundary: after attach, mutating the shared header must not
+ *     change where this process addresses. That is the property that stops a
+ *     hostile peer steering our writes out of the mapping.
  *
- *   - A threaded producer/consumer stress run carrying a checksummed sequence,
- *     so a lost, duplicated, reordered, or torn item is detected rather than
- *     merely made unlikely. Run under TSAN this also exercises the
- *     release/acquire pairs themselves.
+ *   - Cache-line separation asserted by offset, not by total size. A test that
+ *     only checked the ring's size would pass even with head sharing a line
+ *     with the metadata.
  *
- * Every check uses must() rather than assert(), so -DNDEBUG cannot quietly
- * turn this into a test that passes because it stopped looking.
+ *   - Wrap behaviour many laps around the ring, where an index that aliased
+ *     full with empty would show up, and attach against a ring already in use.
+ *
+ *   - A threaded stress run whose every payload byte is a function of the
+ *     sequence number, so a lost, duplicated, reordered, or partially-written
+ *     item is detected rather than merely made unlikely.
+ *
+ * Every check uses must() rather than assert(), so -DNDEBUG cannot quietly turn
+ * this into a test that passes because it stopped looking.
  */
 #include <pthread.h>
 #include <stddef.h>
@@ -46,7 +53,7 @@ static void must_result(bus_ring_result_t got, bus_ring_result_t want, const cha
 }
 
 /* ------------------------------------------------------------------ */
-/* geometry                                                            */
+/* geometry and layout                                                 */
 
 static void test_geometry(void)
 {
@@ -57,33 +64,35 @@ static void test_geometry(void)
    must(bus_ring_bytes(64, 1) == 0, "capacity below the minimum rejected");
    must(bus_ring_bytes(1u << 30, 1u << 20) == 0, "absurd geometry rejected");
 
-   /* The header must leave the slots cache-line aligned, or the false sharing
-    * the separated indices avoid comes straight back through the payload. */
-   must(bus_ring_bytes(64, 8) % BUS_RING_CACHELINE == 0, "ring size is cache-line aligned");
+   /* Asserted by offset. The old form — total size divisible by the cache line
+    * — was satisfiable with head at offset 32, so the false-sharing guarantee
+    * it claimed to check was never actually checked. */
+   must(offsetof(bus_ring_shared_t, head) % BUS_RING_CACHELINE == 0,
+        "head begins a cache line");
+   must(offsetof(bus_ring_shared_t, head) >= BUS_RING_CACHELINE,
+        "head does not share the metadata line");
+   must(offsetof(bus_ring_shared_t, tail) >=
+           offsetof(bus_ring_shared_t, head) + BUS_RING_CACHELINE,
+        "tail does not share head's line");
+   must(offsetof(bus_ring_shared_t, slots) >=
+           offsetof(bus_ring_shared_t, tail) + BUS_RING_CACHELINE,
+        "slots do not share tail's line");
 
    size_t need = bus_ring_bytes(64, 8);
    void *mem = calloc(1, need);
    must(mem != NULL, "alloc");
-   bus_ring_t *r = NULL;
+   bus_ring_t r;
 
    must_result(bus_ring_init(mem, need - 1, 64, 8, &r), BUS_RING_ERR_MEM,
                "init into a short buffer");
    must_result(bus_ring_init(mem, need, 64, 7, &r), BUS_RING_ERR_GEOMETRY,
                "init with bad capacity");
    must_result(bus_ring_init(mem, need, 64, 8, &r), BUS_RING_OK, "init");
-   must(bus_ring_capacity(r) == 8, "capacity readback");
-   must(bus_ring_count(r) == 0, "fresh ring is empty");
+   must(bus_ring_capacity(&r) == 8, "capacity readback");
+   must(bus_ring_count(&r) == 0, "fresh ring is empty");
 
    free(mem);
-   printf("  geometry: bounds, alignment, and rejection\n");
-}
-
-/* bus_ring.c keeps header_bytes() private; the test only needs "smaller than
- * the header", and offsetof on the public type gives that without widening the
- * module's interface for a test's convenience. */
-static size_t header_bytes_probe(void)
-{
-   return offsetof(bus_ring_t, slots) - 1;
+   printf("  geometry: bounds, cache-line offsets, and rejection\n");
 }
 
 /* A header written by another process is a claim, not a fact. These are the
@@ -93,53 +102,92 @@ static void test_attach_validation(void)
    size_t need = bus_ring_bytes(64, 8);
    void *mem = calloc(1, need);
    must(mem != NULL, "alloc");
-   bus_ring_t *r = NULL;
+   bus_ring_t r;
    must_result(bus_ring_init(mem, need, 64, 8, &r), BUS_RING_OK, "init");
+   bus_ring_shared_t *s = r.shared;
 
-   bus_ring_t *got = NULL;
+   bus_ring_t got;
    must_result(bus_ring_attach(mem, need, &got), BUS_RING_OK, "attach to a good ring");
 
-   uint32_t saved;
+   struct
+   {
+      const char *what;
+      _Atomic uint32_t *field;
+      uint32_t bad;
+   } lies[] = {
+      {"no magic", &s->magic, 0},
+      {"capacity not a power of two", &s->capacity, 7},
+      {"capacity above the maximum", &s->capacity, 1u << 21},
+      {"capacity outgrows the mapping", &s->capacity, 1024},
+      {"slot size zero", &s->slot_size, 0},
+      {"slot size above the maximum", &s->slot_size, 1u << 25},
+      {"mask disagrees with capacity", &s->mask, 0xffff},
+      {"slots offset moved", &s->slots_off, 8},
+   };
 
-   saved = atomic_load_explicit(&r->magic, memory_order_relaxed);
-   atomic_store_explicit(&r->magic, 0, memory_order_relaxed);
-   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_MAGIC, "attach without magic");
-   atomic_store_explicit(&r->magic, saved, memory_order_relaxed);
-
-   saved = r->capacity;
-   r->capacity = 7;
-   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_GEOMETRY,
-               "attach with non-power-of-two capacity");
-   r->capacity = saved;
-
-   saved = r->mask;
-   r->mask = 0xffff;
-   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_LAYOUT,
-               "attach with a mask that disagrees with capacity");
-   r->mask = saved;
-
-   /* The important one: a header claiming a bigger ring than was mapped. */
-   saved = r->capacity;
-   r->capacity = 1024;
-   r->mask = 1023;
-   must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_LAYOUT,
-               "attach where the header outgrows the mapping");
-   r->capacity = saved;
-   r->mask = saved - 1;
+   for (size_t i = 0; i < sizeof lies / sizeof lies[0]; i++)
+   {
+      uint32_t saved = atomic_load_explicit(lies[i].field, memory_order_relaxed);
+      atomic_store_explicit(lies[i].field, lies[i].bad, memory_order_relaxed);
+      if (bus_ring_attach(mem, need, &got) == BUS_RING_OK)
+      {
+         fprintf(stderr, "FAIL: attach accepted a header that lied: %s\n", lies[i].what);
+         abort();
+      }
+      atomic_store_explicit(lies[i].field, saved, memory_order_relaxed);
+   }
 
    /* An index pair claiming more entries than exist must not become an
     * out-of-bounds slot index. */
-   atomic_store_explicit(&r->head, 100, memory_order_relaxed);
-   atomic_store_explicit(&r->tail, 0, memory_order_relaxed);
+   atomic_store_explicit(&s->head, 100, memory_order_relaxed);
+   atomic_store_explicit(&s->tail, 0, memory_order_relaxed);
    must_result(bus_ring_attach(mem, need, &got), BUS_RING_ERR_LAYOUT,
                "attach with an impossible index pair");
-   atomic_store_explicit(&r->head, 0, memory_order_relaxed);
 
-   must_result(bus_ring_attach(mem, header_bytes_probe(), &got), BUS_RING_ERR_MEM,
-               "attach to a buffer smaller than the header");
+   /* But exactly-full is ordinary operation, not corruption. */
+   atomic_store_explicit(&s->head, 8, memory_order_relaxed);
+   atomic_store_explicit(&s->tail, 0, memory_order_relaxed);
+   must_result(bus_ring_attach(mem, need, &got), BUS_RING_OK, "attach to an exactly-full ring");
+   atomic_store_explicit(&s->head, 0, memory_order_relaxed);
+
+   must_result(bus_ring_attach(mem, offsetof(bus_ring_shared_t, slots) - 1, &got),
+               BUS_RING_ERR_MEM, "attach to a buffer smaller than the header");
 
    free(mem);
-   printf("  attach: rejects five ways a header can lie\n");
+   printf("  attach: rejects %zu ways a header can lie, accepts exactly-full\n",
+          sizeof lies / sizeof lies[0]);
+}
+
+/* The handle is the safety boundary: once attached, nothing a peer writes to
+ * the shared header may change where this process addresses. */
+static void test_handle_isolates_geometry(void)
+{
+   const uint32_t cap = 8, slot = 64;
+   size_t need = bus_ring_bytes(slot, cap);
+   void *mem = calloc(1, need);
+   bus_ring_t r;
+   must_result(bus_ring_init(mem, need, slot, cap, &r), BUS_RING_OK, "init");
+
+   void *first = bus_ring_produce_begin(&r);
+   must(first != NULL, "produce into a fresh ring");
+
+   /* A hostile peer rewrites the geometry to values that, if the hot path
+    * re-read them, would address far outside the mapping. */
+   atomic_store_explicit(&r.shared->slot_size, 1u << 24, memory_order_relaxed);
+   atomic_store_explicit(&r.shared->capacity, 1u << 20, memory_order_relaxed);
+   atomic_store_explicit(&r.shared->mask, (1u << 20) - 1, memory_order_relaxed);
+   atomic_store_explicit(&r.shared->slots_off, 0xfffff, memory_order_relaxed);
+
+   must(bus_ring_produce_begin(&r) == first,
+        "the hot path still addresses the same slot after the header is scribbled on");
+   must(bus_ring_capacity(&r) == cap, "handle capacity is unaffected");
+
+   uint8_t *p = (uint8_t *)bus_ring_produce_begin(&r);
+   must(p >= (uint8_t *)mem && p + slot <= (uint8_t *)mem + need,
+        "the slot remains inside the mapping");
+
+   free(mem);
+   printf("  handle: copied geometry, so a scribbled header cannot move addressing\n");
 }
 
 /* ------------------------------------------------------------------ */
@@ -150,91 +198,129 @@ static void test_full_empty_and_wrap(void)
    const uint32_t cap = 4, slot = 32;
    size_t need = bus_ring_bytes(slot, cap);
    void *mem = calloc(1, need);
-   bus_ring_t *r = NULL;
+   bus_ring_t r;
    must_result(bus_ring_init(mem, need, slot, cap, &r), BUS_RING_OK, "init");
 
-   must(bus_ring_consume_begin(r) == NULL, "empty ring yields nothing");
+   must(bus_ring_consume_begin(&r) == NULL, "empty ring yields nothing");
 
    for (uint32_t i = 0; i < cap; i++)
    {
-      void *s = bus_ring_produce_begin(r);
+      void *s = bus_ring_produce_begin(&r);
       must(s != NULL, "produce into a ring with room");
       memset(s, (int)i, slot);
-      bus_ring_produce_commit(r);
+      bus_ring_produce_commit(&r);
    }
-   must(bus_ring_count(r) == cap, "count at capacity");
-   must(bus_ring_produce_begin(r) == NULL, "full ring refuses a producer");
+   must(bus_ring_count(&r) == cap, "count at capacity");
+   must(bus_ring_produce_begin(&r) == NULL, "full ring refuses a producer");
 
    for (uint32_t i = 0; i < cap; i++)
    {
-      const uint8_t *s = bus_ring_consume_begin(r);
+      const uint8_t *s = bus_ring_consume_begin(&r);
       must(s != NULL, "consume from a non-empty ring");
       must(s[0] == (uint8_t)i, "FIFO order");
-      bus_ring_consume_commit(r);
+      bus_ring_consume_commit(&r);
    }
-   must(bus_ring_count(r) == 0, "count back to empty");
-   must(bus_ring_consume_begin(r) == NULL, "drained ring yields nothing");
+   must(bus_ring_count(&r) == 0, "count back to empty");
+   must(bus_ring_consume_begin(&r) == NULL, "drained ring yields nothing");
 
    /* Many laps, one item at a time, so every slot is reused repeatedly. An
     * index that wrapped rather than free-running would alias full with empty
     * somewhere in here. */
    for (uint32_t lap = 0; lap < 10000; lap++)
    {
-      void *s = bus_ring_produce_begin(r);
+      void *s = bus_ring_produce_begin(&r);
       must(s != NULL, "produce during wrap");
       *(uint32_t *)s = lap;
-      bus_ring_produce_commit(r);
+      bus_ring_produce_commit(&r);
 
-      const void *c = bus_ring_consume_begin(r);
+      const void *c = bus_ring_consume_begin(&r);
       must(c != NULL, "consume during wrap");
       must(*(const uint32_t *)c == lap, "value survives wrap");
-      bus_ring_consume_commit(r);
+      bus_ring_consume_commit(&r);
    }
-   must(bus_ring_count(r) == 0, "empty after 10000 laps");
+   must(bus_ring_count(&r) == 0, "empty after 10000 laps");
+
+   /* A long-lived ring with advanced counters is exactly what a host adopts,
+    * so attach must work on one — not only on a freshly-initialised ring. */
+   for (uint32_t i = 0; i < 3; i++)
+   {
+      void *s = bus_ring_produce_begin(&r);
+      must(s != NULL, "seed residual items");
+      *(uint32_t *)s = 0xabcd0000u + i;
+      bus_ring_produce_commit(&r);
+   }
+   bus_ring_t re;
+   must_result(bus_ring_attach(mem, need, &re), BUS_RING_OK, "attach to a used ring");
+   must(bus_ring_count(&re) == 3, "residual count survives attach");
+   for (uint32_t i = 0; i < 3; i++)
+   {
+      const void *c = bus_ring_consume_begin(&re);
+      must(c != NULL, "consume residual through the re-attached handle");
+      must(*(const uint32_t *)c == 0xabcd0000u + i, "residual value intact");
+      bus_ring_consume_commit(&re);
+   }
 
    free(mem);
-   printf("  full/empty and wrap: 10000 laps through a 4-slot ring\n");
+   printf("  wrap: 10000 laps, then attach to the used ring and drain it\n");
 }
 
 /* ------------------------------------------------------------------ */
 /* threaded stress                                                     */
 
-#define STRESS_ITEMS   200000u
-#define STRESS_SLOT    64u
+#define STRESS_ITEMS    200000u
+#define STRESS_SLOT     64u
 #define STRESS_CAPACITY 64u
-
-typedef struct
-{
-   uint64_t seq;
-   uint64_t check; /* a function of seq, so a torn slot is visible */
-   uint8_t pad[STRESS_SLOT - 2 * sizeof(uint64_t)];
-} stress_item_t;
 
 static uint64_t mix(uint64_t v)
 {
-   /* Any cheap avalanche will do; the point is that half a written item does
-    * not accidentally satisfy the check. */
    v ^= v >> 33;
    v *= 0xff51afd7ed558ccdull;
    v ^= v >> 33;
    return v;
 }
 
-static bus_ring_t *g_ring;
+/* Every byte of the slot is a function of the sequence number, so a torn write
+ * anywhere in the item is caught — not just in the two words a header-only
+ * checksum would have covered. */
+static void fill_item(uint8_t *p, uint64_t seq)
+{
+   for (uint32_t i = 0; i < STRESS_SLOT; i += 8)
+   {
+      uint64_t word = mix(seq * 131 + i);
+      memcpy(p + i, &word, sizeof word);
+   }
+   memcpy(p, &seq, sizeof seq); /* first word carries the sequence itself */
+}
+
+static int item_matches(const uint8_t *p, uint64_t seq)
+{
+   uint8_t expect[STRESS_SLOT];
+   fill_item(expect, seq);
+   return memcmp(p, expect, STRESS_SLOT) == 0;
+}
+
+static bus_ring_t g_ring;
+
+/* Bounded, because an unbounded spin turns a dead peer into a CI hang that is
+ * indistinguishable from a slow machine. */
+#define SPIN_LIMIT 2000000000ull
 
 static void *producer_thread(void *arg)
 {
    (void)arg;
    for (uint64_t i = 0; i < STRESS_ITEMS; i++)
    {
-      stress_item_t *s;
-      /* Spin rather than sleep: a full ring is the interesting state, and
-       * backing off would reduce how often the test visits it. */
-      while ((s = (stress_item_t *)bus_ring_produce_begin(g_ring)) == NULL)
-         ;
-      s->seq = i;
-      s->check = mix(i);
-      bus_ring_produce_commit(g_ring);
+      uint8_t *s;
+      uint64_t spins = 0;
+      while ((s = (uint8_t *)bus_ring_produce_begin(&g_ring)) == NULL)
+         if (++spins > SPIN_LIMIT)
+         {
+            fprintf(stderr, "FAIL: producer spun out waiting for room at item %llu\n",
+                    (unsigned long long)i);
+            abort();
+         }
+      fill_item(s, i);
+      bus_ring_produce_commit(&g_ring);
    }
    return NULL;
 }
@@ -252,21 +338,26 @@ static void test_threaded_stress(void)
 
    for (uint64_t expect = 0; expect < STRESS_ITEMS; expect++)
    {
-      const stress_item_t *s;
-      while ((s = (const stress_item_t *)bus_ring_consume_begin(g_ring)) == NULL)
-         ;
-      /* Order proves nothing was lost, duplicated, or reordered; the checksum
-       * proves the slot was not read half-written. */
-      must(s->seq == expect, "stress: sequence intact");
-      must(s->check == mix(expect), "stress: item not torn");
-      bus_ring_consume_commit(g_ring);
+      const uint8_t *s;
+      uint64_t spins = 0;
+      while ((s = (const uint8_t *)bus_ring_consume_begin(&g_ring)) == NULL)
+         if (++spins > SPIN_LIMIT)
+         {
+            fprintf(stderr, "FAIL: consumer spun out waiting for item %llu\n",
+                    (unsigned long long)expect);
+            abort();
+         }
+      /* Order proves nothing was lost, duplicated, or reordered; the full-slot
+       * comparison proves no byte of it was read half-written. */
+      must(item_matches(s, expect), "stress: whole item intact and in sequence");
+      bus_ring_consume_commit(&g_ring);
    }
 
    must(pthread_join(producer, NULL) == 0, "join producer");
-   must(bus_ring_count(g_ring) == 0, "stress: ring drained");
+   must(bus_ring_count(&g_ring) == 0, "stress: ring drained");
 
    free(mem);
-   printf("  threaded stress: %u items, checksummed, none lost or torn\n", STRESS_ITEMS);
+   printf("  threaded stress: %u items, every byte verified, none lost or torn\n", STRESS_ITEMS);
 }
 
 int main(void)
@@ -274,6 +365,7 @@ int main(void)
    printf("test_bus_ring:\n");
    test_geometry();
    test_attach_validation();
+   test_handle_isolates_geometry();
    test_full_empty_and_wrap();
    test_threaded_stress();
    printf("test_bus_ring: OK\n");


### PR DESCRIPTION
Re-lands slice 2. The original PR #1895 was merged into the wrong base (the slice-1 branch) because a `--base` retarget silently failed, so `bus_ring` never reached `feat/event-bus`. This is the same approved diff (clean roundtable approve on the redesigned ring), rebased over the D1 docs commits with no content change.

The ring: lock-free SPSC, split into a shared header and a process-local geometry handle so a peer cannot steer hot-path addressing out of the mapping (the memory-safety defect the review caught). Green under normal, ASAN and TSAN.