### PR TITLE
Price the local aimee-synth model as known-free

### DIFF
--- a/src/server/token_tracker.c
+++ b/src/server/token_tracker.c
@@ -75,6 +75,12 @@ static const model_price_t pricing[] = {
     {"minimax", 0.0, 0.0, 0.0, 0.0},
     {"mistral", 0.0, 0.0, 0.0, 0.0},
     {"mimo", 0.0, 0.0, 0.0, 0.0},
+    /* aimee-synth: the on-box local synthesis model (local-gemma4, served at
+     * localhost:8742). Runs on hardware we already own, so its real price is
+     * zero — a KNOWN zero, not unknown. Without this entry a capped delegate run
+     * refuses it ("cannot enforce max_cost_usd for model 'aimee-synth'") even
+     * though a free model trivially satisfies any cap. */
+    {"aimee-synth", 0.0, 0.0, 0.0, 0.0},
 };
 
 #define PRICING_COUNT (int)(sizeof(pricing) / sizeof(pricing[0]))

--- a/src/tests/test_token_tracker.c
+++ b/src/tests/test_token_tracker.c
@@ -80,6 +80,10 @@ static void test_cost_ceiling_boundaries(void)
    assert(token_cost_ceiling("some-unknown-model-xyz", 1.0, 0, 0, &cap, &total) == -1);
    assert(token_cost_ceiling("minimax-m2", 1.0, 100, 11, &cap, &total) == 0);
    assert(cap == 11);
+   /* aimee-synth is a known-free local model: a cap is trivially satisfiable,
+    * so the ceiling resolves to "free" (0), never "cannot enforce" (-1). */
+   assert(token_cost_ceiling("aimee-synth", 1.0, 100, 11, &cap, &total) == 0);
+   assert(cap == 11);
    assert(token_cost_ceiling("gpt-4o", -1.0, 0, 0, &cap, &total) == -1);
    assert(token_cost_ceiling("gpt-4o", 0.01, 10000000, 0, &cap, &total) == -1);
    assert(token_cost_ceiling("gpt-4o", 0.000000001, 0, 0, &cap, &total) == -1);


### PR DESCRIPTION
## Problem

The local synthesis delegate `local-gemma4` (model `aimee-synth`, served on-box at `localhost:8742`) took **zero jobs** in the overnight WFE run. Its last attempts before that all failed identically:

```
cannot enforce max_cost_usd 5.000000 for model 'aimee-synth'
cannot enforce max_cost_usd 0.333333 for model 'aimee-synth'
```

It's a local model — it costs nothing to run — so any dollar cap is trivially satisfiable. But `token_cost_ceiling()` distinguishes *free* from *unpriced* by table membership:

- a model **in** the static price table at `0/0` → `priced=1` → ceiling `0` (free, allowed)
- a model **absent** from the table → `priced=0` → `-1` → `delegate_apply_cost_limit` refuses with the error above

`aimee-synth` was simply never added to the free-local list that already declares its siblings `minimax`, `mistral`, and `mimo` as known-free. So a genuinely-free model was treated as unknown-cost and refused under any cap.

## Change

Add `{"aimee-synth", 0.0, 0.0, 0.0, 0.0}` to that same list. This is not an invented price — a self-hosted local model's real price *is* zero, declared as a KNOWN zero (`priced=1`) exactly like its siblings, so it flows through the existing "explicitly free model" path. A deployment that instead pays a hosted API for a same-named model still gets the real price via the nonzero registry / models.dev override (a `0/0` static entry never overrides a nonzero registry price).

## Tests

Added an assertion mirroring the existing `minimax-m2` free-model case:

```c
assert(token_cost_ceiling("aimee-synth", 1.0, 100, 11, &cap, &total) == 0);
assert(cap == 11);
```

Confirmed to fail on the unmodified table (returns `-1`, "cannot enforce"), pass with the entry. Full `unit-test-token-tracker` suite green.

## Follow-up

This unblocks capped work reaching `aimee-synth`, but the agent is still **disabled** in `/var/lib/aimee/agents.json` on the appliance. Enabling it (to add a free implementer/reviewer to the pool) is an operator action, separate from this code fix.