### PR TITLE
Slice 3: fd-backed region layout (control / queue-pair / arena)

### DIFF
--- a/src/modules/bus/bus_region.c
+++ b/src/modules/bus/bus_region.c
@@ -1,0 +1,361 @@
+/* bus_region.c: fd-backed region create/map/validate. See bus_region.h.
+ *
+ * memfd_create is Linux-only, and that is a deliberate v0 choice (D1): both
+ * bus-hosting services are containerised Linux, and an anonymous memfd has no
+ * filesystem name for an unadmitted process to open. A shm_open portability
+ * fallback is a later slice and would reintroduce the named-segment weakness.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "bus_region.h"
+
+/* Bound arena size so a corrupt header cannot request an unmappable region. */
+#define BUS_ARENA_MAX_SIZE (1ull << 32) /* 4 GiB */
+
+typedef struct
+{
+   _Atomic uint32_t magic;
+   _Atomic uint32_t reserved;
+   _Atomic uint64_t size;
+} bus_arena_hdr_t;
+
+_Static_assert(sizeof(bus_arena_hdr_t) == 16, "arena header size is frozen");
+
+static size_t page_round_up(size_t n)
+{
+   long ps = sysconf(_SC_PAGESIZE);
+   size_t page = (ps > 0) ? (size_t)ps : 4096;
+   size_t rounded = (n + page - 1) & ~(page - 1);
+   if (rounded < n)
+      return 0; /* overflow */
+   return rounded;
+}
+
+bus_region_result_t bus_region_create(const char *name, size_t size, bus_region_t *out)
+{
+   if (!out || size == 0)
+      return BUS_REGION_ERR_ARG;
+
+   size_t rounded = page_round_up(size);
+   if (rounded == 0)
+      return BUS_REGION_ERR_SIZE;
+
+   int fd = memfd_create(name ? name : "aimee-bus", MFD_CLOEXEC);
+   if (fd < 0)
+      return BUS_REGION_ERR_OS;
+   if (ftruncate(fd, (off_t)rounded) != 0)
+   {
+      int saved = errno;
+      close(fd);
+      errno = saved;
+      return BUS_REGION_ERR_OS;
+   }
+
+   out->fd = fd;
+   out->base = NULL;
+   out->size = rounded;
+   out->writable = 0;
+   return BUS_REGION_OK;
+}
+
+bus_region_result_t bus_region_map(int fd, size_t size, int writable, bus_region_t *out)
+{
+   if (!out || fd < 0 || size == 0)
+      return BUS_REGION_ERR_ARG;
+
+   int prot = writable ? (PROT_READ | PROT_WRITE) : PROT_READ;
+   void *base = mmap(NULL, size, prot, MAP_SHARED, fd, 0);
+   if (base == MAP_FAILED)
+      return BUS_REGION_ERR_OS;
+
+   out->fd = fd;
+   out->base = base;
+   out->size = size;
+   out->writable = writable ? 1 : 0;
+   return BUS_REGION_OK;
+}
+
+void bus_region_unmap(bus_region_t *r)
+{
+   if (r && r->base)
+   {
+      munmap(r->base, r->size);
+      r->base = NULL;
+   }
+}
+
+/* ------------------------------------------------------------------ */
+/* control region                                                      */
+
+size_t bus_control_bytes(void)
+{
+   return sizeof(bus_control_t);
+}
+
+bus_region_result_t bus_control_init(bus_region_t *r, uint32_t slot_size, uint32_t inline_budget,
+                                     uint32_t queue_capacity, uint64_t arena_size)
+{
+   if (!r || !r->base)
+      return BUS_REGION_ERR_ARG;
+   if (!r->writable)
+      return BUS_REGION_ERR_ARG;
+   if (r->size < sizeof(bus_control_t))
+      return BUS_REGION_ERR_SIZE;
+   if (slot_size == 0 || inline_budget > slot_size || arena_size == 0 ||
+       arena_size > BUS_ARENA_MAX_SIZE)
+      return BUS_REGION_ERR_GEOMETRY;
+
+   bus_control_t *c = (bus_control_t *)r->base;
+   memset(c, 0, sizeof *c);
+   atomic_store_explicit(&c->spec_version, BUS_SPEC_VERSION, memory_order_relaxed);
+   atomic_store_explicit(&c->layout_version, BUS_LAYOUT_VERSION, memory_order_relaxed);
+   atomic_store_explicit(&c->flags, 0, memory_order_relaxed);
+   atomic_store_explicit(&c->slot_size, slot_size, memory_order_relaxed);
+   atomic_store_explicit(&c->inline_budget, inline_budget, memory_order_relaxed);
+   atomic_store_explicit(&c->queue_capacity, queue_capacity, memory_order_relaxed);
+   atomic_store_explicit(&c->arena_size, arena_size, memory_order_relaxed);
+   atomic_store_explicit(&c->host_epoch, 1, memory_order_relaxed);
+   atomic_store_explicit(&c->host_heartbeat, 0, memory_order_relaxed);
+
+   /* Magic last, released: a client that sees it is guaranteed the header
+    * behind it. */
+   atomic_store_explicit(&c->magic, BUS_CONTROL_MAGIC, memory_order_release);
+   return BUS_REGION_OK;
+}
+
+bus_region_result_t bus_control_attach(const bus_region_t *r, bus_control_t **out)
+{
+   if (!r || !r->base || !out)
+      return BUS_REGION_ERR_ARG;
+   if (r->size < sizeof(bus_control_t))
+      return BUS_REGION_ERR_SIZE;
+
+   bus_control_t *c = (bus_control_t *)r->base;
+   if (atomic_load_explicit(&c->magic, memory_order_acquire) != BUS_CONTROL_MAGIC)
+      return BUS_REGION_ERR_MAGIC;
+   if (atomic_load_explicit(&c->spec_version, memory_order_acquire) != BUS_SPEC_VERSION ||
+       atomic_load_explicit(&c->layout_version, memory_order_acquire) != BUS_LAYOUT_VERSION)
+      return BUS_REGION_ERR_VERSION;
+
+   /* The D4 parameters are a claim; a client will size mappings against them, so
+    * a header describing nonsense must be refused rather than propagated. */
+   uint32_t slot = atomic_load_explicit(&c->slot_size, memory_order_acquire);
+   uint32_t inl = atomic_load_explicit(&c->inline_budget, memory_order_acquire);
+   uint64_t arena = atomic_load_explicit(&c->arena_size, memory_order_acquire);
+   if (slot == 0 || inl > slot || arena == 0 || arena > BUS_ARENA_MAX_SIZE)
+      return BUS_REGION_ERR_GEOMETRY;
+
+   *out = c;
+   return BUS_REGION_OK;
+}
+
+uint64_t bus_control_epoch(const bus_control_t *c)
+{
+   return c ? atomic_load_explicit(&c->host_epoch, memory_order_acquire) : 0;
+}
+
+int bus_control_epoch_changed(const bus_control_t *c, uint64_t attached_epoch)
+{
+   return c && atomic_load_explicit(&c->host_epoch, memory_order_acquire) != attached_epoch;
+}
+
+void bus_control_bump_epoch(bus_control_t *c)
+{
+   if (c)
+      atomic_fetch_add_explicit(&c->host_epoch, 1, memory_order_acq_rel);
+}
+
+void bus_control_heartbeat(bus_control_t *c, uint64_t now)
+{
+   if (c)
+      atomic_store_explicit(&c->host_heartbeat, now, memory_order_release);
+}
+
+/* ------------------------------------------------------------------ */
+/* queue-pair region                                                   */
+
+/* header, then inbound ring, then outbound ring, each page-agnostic but
+ * 64-byte aligned so the rings' own cache-line layout is honoured. */
+static size_t align64(size_t n)
+{
+   return (n + 63) & ~((size_t)63);
+}
+
+static size_t qpair_inbound_off(void)
+{
+   return align64(sizeof(bus_qpair_hdr_t));
+}
+
+static size_t qpair_outbound_off(uint32_t slot_size, uint32_t capacity)
+{
+   size_t ring = bus_ring_bytes(slot_size, capacity);
+   if (ring == 0)
+      return 0;
+   return align64(qpair_inbound_off() + ring);
+}
+
+size_t bus_qpair_bytes(uint32_t slot_size, uint32_t capacity)
+{
+   size_t ring = bus_ring_bytes(slot_size, capacity);
+   if (ring == 0)
+      return 0;
+   size_t out_off = qpair_outbound_off(slot_size, capacity);
+   if (out_off == 0)
+      return 0;
+   return out_off + ring;
+}
+
+bus_region_result_t bus_qpair_init(bus_region_t *r, uint32_t slot_size, uint32_t capacity)
+{
+   if (!r || !r->base || !r->writable)
+      return BUS_REGION_ERR_ARG;
+   size_t need = bus_qpair_bytes(slot_size, capacity);
+   if (need == 0)
+      return BUS_REGION_ERR_GEOMETRY;
+   if (r->size < need)
+      return BUS_REGION_ERR_SIZE;
+
+   uint8_t *b = (uint8_t *)r->base;
+   bus_qpair_hdr_t *h = (bus_qpair_hdr_t *)b;
+   memset(h, 0, sizeof *h);
+   atomic_store_explicit(&h->slot_size, slot_size, memory_order_relaxed);
+   atomic_store_explicit(&h->capacity, capacity, memory_order_relaxed);
+   atomic_store_explicit(&h->data_credits, capacity, memory_order_relaxed);
+   atomic_store_explicit(&h->control_credits, BUS_CONTROL_CREDITS_DEFAULT, memory_order_relaxed);
+   atomic_store_explicit(&h->control_lost, 0, memory_order_relaxed);
+   atomic_store_explicit(&h->inbound_off, (uint32_t)qpair_inbound_off(), memory_order_relaxed);
+   atomic_store_explicit(&h->outbound_off, (uint32_t)qpair_outbound_off(slot_size, capacity),
+                         memory_order_relaxed);
+   atomic_store_explicit(&h->client_heartbeat, 0, memory_order_relaxed);
+
+   bus_ring_t tmp;
+   bus_ring_result_t rr;
+   rr = bus_ring_init(b + qpair_inbound_off(), r->size - qpair_inbound_off(), slot_size, capacity,
+                      &tmp);
+   if (rr != BUS_RING_OK)
+      return BUS_REGION_ERR_GEOMETRY;
+   size_t out_off = qpair_outbound_off(slot_size, capacity);
+   rr = bus_ring_init(b + out_off, r->size - out_off, slot_size, capacity, &tmp);
+   if (rr != BUS_RING_OK)
+      return BUS_REGION_ERR_GEOMETRY;
+
+   /* Magic last. */
+   atomic_store_explicit(&h->magic, BUS_QPAIR_MAGIC, memory_order_release);
+   return BUS_REGION_OK;
+}
+
+bus_region_result_t bus_qpair_attach(const bus_region_t *r, bus_qpair_t *out)
+{
+   if (!r || !r->base || !out)
+      return BUS_REGION_ERR_ARG;
+   if (r->size < sizeof(bus_qpair_hdr_t))
+      return BUS_REGION_ERR_SIZE;
+
+   bus_qpair_hdr_t *h = (bus_qpair_hdr_t *)r->base;
+   if (atomic_load_explicit(&h->magic, memory_order_acquire) != BUS_QPAIR_MAGIC)
+      return BUS_REGION_ERR_MAGIC;
+
+   uint32_t slot = atomic_load_explicit(&h->slot_size, memory_order_acquire);
+   uint32_t cap = atomic_load_explicit(&h->capacity, memory_order_acquire);
+   uint32_t in_off = atomic_load_explicit(&h->inbound_off, memory_order_acquire);
+   uint32_t out_off = atomic_load_explicit(&h->outbound_off, memory_order_acquire);
+
+   /* Everything is a claim. The offsets and geometry must place two whole rings
+    * inside the mapping, or a later hot-path access walks off the end. */
+   size_t need = bus_qpair_bytes(slot, cap);
+   if (need == 0 || r->size < need)
+      return BUS_REGION_ERR_GEOMETRY;
+   if (in_off != qpair_inbound_off() || out_off != qpair_outbound_off(slot, cap))
+      return BUS_REGION_ERR_GEOMETRY;
+
+   uint8_t *b = (uint8_t *)r->base;
+   bus_ring_result_t rr;
+   rr = bus_ring_attach(b + in_off, r->size - in_off, &out->inbound);
+   if (rr != BUS_RING_OK)
+      return BUS_REGION_ERR_GEOMETRY;
+   rr = bus_ring_attach(b + out_off, r->size - out_off, &out->outbound);
+   if (rr != BUS_RING_OK)
+      return BUS_REGION_ERR_GEOMETRY;
+
+   out->hdr = h;
+   return BUS_REGION_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* arena region                                                        */
+
+size_t bus_arena_region_bytes(uint64_t arena_size)
+{
+   if (arena_size == 0 || arena_size > BUS_ARENA_MAX_SIZE)
+      return 0;
+   return sizeof(bus_arena_hdr_t) + (size_t)arena_size;
+}
+
+bus_region_result_t bus_arena_region_init(bus_region_t *r, uint64_t arena_size)
+{
+   if (!r || !r->base || !r->writable)
+      return BUS_REGION_ERR_ARG;
+   size_t need = bus_arena_region_bytes(arena_size);
+   if (need == 0)
+      return BUS_REGION_ERR_GEOMETRY;
+   if (r->size < need)
+      return BUS_REGION_ERR_SIZE;
+
+   bus_arena_hdr_t *h = (bus_arena_hdr_t *)r->base;
+   memset(h, 0, sizeof *h);
+   atomic_store_explicit(&h->size, arena_size, memory_order_relaxed);
+   atomic_store_explicit(&h->magic, BUS_ARENA_MAGIC, memory_order_release);
+   return BUS_REGION_OK;
+}
+
+bus_region_result_t bus_arena_region_attach(const bus_region_t *r, uint8_t **base,
+                                            uint64_t *size)
+{
+   if (!r || !r->base || !base || !size)
+      return BUS_REGION_ERR_ARG;
+   if (r->size < sizeof(bus_arena_hdr_t))
+      return BUS_REGION_ERR_SIZE;
+
+   bus_arena_hdr_t *h = (bus_arena_hdr_t *)r->base;
+   if (atomic_load_explicit(&h->magic, memory_order_acquire) != BUS_ARENA_MAGIC)
+      return BUS_REGION_ERR_MAGIC;
+
+   uint64_t arena = atomic_load_explicit(&h->size, memory_order_acquire);
+   if (arena == 0 || arena > BUS_ARENA_MAX_SIZE)
+      return BUS_REGION_ERR_GEOMETRY;
+   if (r->size < sizeof(bus_arena_hdr_t) + arena)
+      return BUS_REGION_ERR_SIZE;
+
+   *base = (uint8_t *)r->base + sizeof(bus_arena_hdr_t);
+   *size = arena;
+   return BUS_REGION_OK;
+}
+
+const char *bus_region_result_name(bus_region_result_t r)
+{
+   switch (r)
+   {
+   case BUS_REGION_OK:
+      return "OK";
+   case BUS_REGION_ERR_ARG:
+      return "ERR_ARG";
+   case BUS_REGION_ERR_OS:
+      return "ERR_OS";
+   case BUS_REGION_ERR_SIZE:
+      return "ERR_SIZE";
+   case BUS_REGION_ERR_MAGIC:
+      return "ERR_MAGIC";
+   case BUS_REGION_ERR_VERSION:
+      return "ERR_VERSION";
+   case BUS_REGION_ERR_GEOMETRY:
+      return "ERR_GEOMETRY";
+   case BUS_REGION_ERR_EPOCH:
+      return "ERR_EPOCH";
+   default:
+      return "ERR_UNKNOWN";
+   }
+}

--- a/src/modules/bus/bus_region.c
+++ b/src/modules/bus/bus_region.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "bus_region.h"
@@ -67,6 +68,17 @@ bus_region_result_t bus_region_map(int fd, size_t size, int writable, bus_region
    if (!out || fd < 0 || size == 0)
       return BUS_REGION_ERR_ARG;
 
+   /* mmap will happily map past the end of the backing memfd; touching those
+    * pages then raises SIGBUS, and every later bounds check that trusts r->size
+    * would have approved a header whose backing object is shorter. So the
+    * mapping may not exceed the fd's actual length — verified before mmap, not
+    * discovered by a fault later. */
+   struct stat st;
+   if (fstat(fd, &st) != 0)
+      return BUS_REGION_ERR_OS;
+   if (st.st_size < 0 || size > (size_t)st.st_size)
+      return BUS_REGION_ERR_SIZE;
+
    int prot = writable ? (PROT_READ | PROT_WRITE) : PROT_READ;
    void *base = mmap(NULL, size, prot, MAP_SHARED, fd, 0);
    if (base == MAP_FAILED)
@@ -108,6 +120,12 @@ bus_region_result_t bus_control_init(bus_region_t *r, uint32_t slot_size, uint32
    if (slot_size == 0 || inline_budget > slot_size || arena_size == 0 ||
        arena_size > BUS_ARENA_MAX_SIZE)
       return BUS_REGION_ERR_GEOMETRY;
+   /* queue_capacity sizes a queue-pair region's rings, so it is held to the same
+    * geometry the ring accepts: bus_qpair_bytes returns 0 for any capacity the
+    * ring would reject. A control region that stored a bad capacity would let a
+    * later queue-pair mapping be sized on nonsense. */
+   if (bus_qpair_bytes(slot_size, queue_capacity) == 0)
+      return BUS_REGION_ERR_GEOMETRY;
 
    bus_control_t *c = (bus_control_t *)r->base;
    memset(c, 0, sizeof *c);
@@ -142,11 +160,17 @@ bus_region_result_t bus_control_attach(const bus_region_t *r, bus_control_t **ou
       return BUS_REGION_ERR_VERSION;
 
    /* The D4 parameters are a claim; a client will size mappings against them, so
-    * a header describing nonsense must be refused rather than propagated. */
+    * a header describing nonsense must be refused rather than propagated. Every
+    * value a mapping or a ring walk is later sized on is validated here,
+    * including queue_capacity (which sizes the queue-pair rings) — an omission
+    * the first review caught. */
    uint32_t slot = atomic_load_explicit(&c->slot_size, memory_order_acquire);
    uint32_t inl = atomic_load_explicit(&c->inline_budget, memory_order_acquire);
+   uint32_t qcap = atomic_load_explicit(&c->queue_capacity, memory_order_acquire);
    uint64_t arena = atomic_load_explicit(&c->arena_size, memory_order_acquire);
    if (slot == 0 || inl > slot || arena == 0 || arena > BUS_ARENA_MAX_SIZE)
+      return BUS_REGION_ERR_GEOMETRY;
+   if (bus_qpair_bytes(slot, qcap) == 0)
       return BUS_REGION_ERR_GEOMETRY;
 
    *out = c;

--- a/src/modules/bus/bus_region.h
+++ b/src/modules/bus/bus_region.h
@@ -1,0 +1,177 @@
+/* bus_region.h: the fd-backed shared-memory regions of the event bus.
+ *
+ * This is the layer the D1 amendment (docs/dev/EVENT_BUS_DECISIONS.md) turned
+ * the bus into: several separately-mapped regions rather than one segment, so a
+ * client holds a descriptor only for what it may see.
+ *
+ *   Control region   — one memfd, mapped PROT_READ by clients. Holds the
+ *                      versioned header and the D4 parameters (slot_size,
+ *                      inline_budget, arena_size) a client reads at attach, plus
+ *                      host_epoch and host_heartbeat. Read-only to clients is an
+ *                      MMU fact here, not a convention: a client that tries to
+ *                      write it faults.
+ *
+ *   Queue-pair region — one memfd PER admitted slot, mapped read/write by that
+ *                      client and no other. Holds the client's inbound and
+ *                      outbound bus_rings plus its credit counters, control-class
+ *                      reserve, client_heartbeat, and control_lost flag.
+ *
+ *   Arena region     — one memfd, mapped read/write by all admitted clients.
+ *                      Slice 3 creates, maps and validates it; the lease
+ *                      allocator that lives inside it is slice 4.
+ *
+ *   Queue directory  — NOT here. It is host-private ordinary memory (slice 5),
+ *                      never a mapped region, which is what makes a client
+ *                      unable to enumerate other slots.
+ *
+ * This slice owns creating, mapping and validating the regions. Admission (who
+ * gets which descriptor), routing, and the arena allocator are later slices.
+ * Nothing here opens a socket or decides policy.
+ *
+ * Everything a client reads from a region is treated as written by another
+ * process: validated against the bytes actually mapped, never trusted.
+ */
+#ifndef AIMEE_BUS_REGION_H
+#define AIMEE_BUS_REGION_H 1
+
+#include <stdatomic.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bus_ring.h"
+
+#define BUS_CONTROL_MAGIC 0x4c544342u /* "BCTL" */
+#define BUS_QPAIR_MAGIC   0x52504251u /* "QPBR" */
+#define BUS_ARENA_MAGIC   0x4e524142u /* "BARN" */
+
+#define BUS_SPEC_VERSION   1
+#define BUS_LAYOUT_VERSION 1
+
+/* The reserved control-class credit pool (D6): a client saturated with data
+ * events still has room to be told it lost some. Provisional, re-tuned in
+ * slice 12 alongside the D4 parameters. */
+#define BUS_CONTROL_CREDITS_DEFAULT 4
+
+typedef enum
+{
+   BUS_REGION_OK = 0,
+   BUS_REGION_ERR_ARG,      /* a null or nonsensical argument */
+   BUS_REGION_ERR_OS,       /* memfd_create / ftruncate / mmap failed (see errno) */
+   BUS_REGION_ERR_SIZE,     /* the mapping is too small for the claimed layout */
+   BUS_REGION_ERR_MAGIC,    /* not the region kind expected */
+   BUS_REGION_ERR_VERSION,  /* spec/layout version this build cannot map */
+   BUS_REGION_ERR_GEOMETRY, /* a parameter is out of range or self-inconsistent */
+   BUS_REGION_ERR_EPOCH     /* host_epoch changed since the caller attached */
+} bus_region_result_t;
+
+/* A mapped region. base is the mmap; size is the whole mapping; writable records
+ * how it was mapped so a validate can refuse to hand a writer a read-only map. */
+typedef struct
+{
+   int fd;
+   void *base;
+   size_t size;
+   int writable;
+} bus_region_t;
+
+/* The control region header. Read-mostly, and read-only to clients. Fields are
+ * atomic so a client's read races cleanly with the host's heartbeat write.
+ *
+ * slot_size / inline_budget / arena_size are the D4 parameters: a client reads
+ * them here at attach and never compiles them in. They are region parameters,
+ * not wire fields, and do not participate in layout_version. */
+typedef struct
+{
+   _Atomic uint32_t magic;
+   _Atomic uint32_t spec_version;
+   _Atomic uint32_t layout_version;
+   _Atomic uint32_t flags;
+   _Atomic uint32_t slot_size;
+   _Atomic uint32_t inline_budget;
+   _Atomic uint32_t queue_capacity; /* ring capacity a queue-pair region uses */
+   _Atomic uint32_t reserved0;
+   _Atomic uint64_t arena_size;
+   _Atomic uint64_t host_epoch;
+   _Atomic uint64_t host_heartbeat;
+   _Atomic uint64_t reserved1[5];
+} bus_control_t;
+
+_Static_assert(sizeof(bus_control_t) == 96, "control header size is frozen by layout_version");
+
+/* The queue-pair region header, followed by the inbound and outbound rings.
+ * inbound is host->client, outbound is client->host. The credit and control_lost
+ * fields are laid out here by slice 3 and exercised by slice 7 (flow control)
+ * and D6 (control-class delivery); they are initialised to defaults now. */
+typedef struct
+{
+   _Atomic uint32_t magic;
+   _Atomic uint32_t slot_size;
+   _Atomic uint32_t capacity;
+   _Atomic uint32_t data_credits;
+   _Atomic uint32_t control_credits;
+   _Atomic uint32_t control_lost;
+   _Atomic uint32_t inbound_off;
+   _Atomic uint32_t outbound_off;
+   _Atomic uint64_t client_heartbeat;
+   _Atomic uint64_t reserved[7];
+} bus_qpair_hdr_t;
+
+_Static_assert(sizeof(bus_qpair_hdr_t) == 96, "queue-pair header size is frozen by layout_version");
+
+/* Handles into a mapped queue-pair region: the two ring handles plus the header. */
+typedef struct
+{
+   bus_qpair_hdr_t *hdr;
+   bus_ring_t inbound;
+   bus_ring_t outbound;
+} bus_qpair_t;
+
+/* ---- region lifecycle ---- */
+
+/* Create an anonymous memfd of at least `size` bytes (rounded up to a page) and
+ * return it *unmapped*. The name is advisory (memfd names are not a namespace).
+ * The fd is close-on-exec; the caller owns it. */
+bus_region_result_t bus_region_create(const char *name, size_t size, bus_region_t *out);
+
+/* Map an existing region fd. writable selects PROT_READ vs PROT_READ|PROT_WRITE:
+ * a client maps the control region read-only, its own queue pair and the arena
+ * read/write. */
+bus_region_result_t bus_region_map(int fd, size_t size, int writable, bus_region_t *out);
+
+/* Unmap and forget. Does not close the fd. */
+void bus_region_unmap(bus_region_t *r);
+
+/* ---- control region ---- */
+
+size_t bus_control_bytes(void);
+bus_region_result_t bus_control_init(bus_region_t *r, uint32_t slot_size, uint32_t inline_budget,
+                                     uint32_t queue_capacity, uint64_t arena_size);
+/* Validate a mapped control region and return a pointer to its header. */
+bus_region_result_t bus_control_attach(const bus_region_t *r, bus_control_t **out);
+
+/* Liveness. A client caches the epoch it attached at; a change means the host
+ * restarted and every handle and mapping is stale. */
+uint64_t bus_control_epoch(const bus_control_t *c);
+int bus_control_epoch_changed(const bus_control_t *c, uint64_t attached_epoch);
+void bus_control_bump_epoch(bus_control_t *c);
+void bus_control_heartbeat(bus_control_t *c, uint64_t now);
+
+/* ---- queue-pair region ---- */
+
+size_t bus_qpair_bytes(uint32_t slot_size, uint32_t capacity);
+bus_region_result_t bus_qpair_init(bus_region_t *r, uint32_t slot_size, uint32_t capacity);
+/* Validate a mapped queue-pair region and resolve both ring handles. */
+bus_region_result_t bus_qpair_attach(const bus_region_t *r, bus_qpair_t *out);
+
+/* ---- arena region ---- */
+
+size_t bus_arena_region_bytes(uint64_t arena_size);
+bus_region_result_t bus_arena_region_init(bus_region_t *r, uint64_t arena_size);
+/* Validate a mapped arena region; returns the usable arena base and size. The
+ * allocator over this space is slice 4. */
+bus_region_result_t bus_arena_region_attach(const bus_region_t *r, uint8_t **base,
+                                            uint64_t *size);
+
+const char *bus_region_result_name(bus_region_result_t r);
+
+#endif /* AIMEE_BUS_REGION_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -141,6 +141,9 @@ aimee_add_test(test_bus_ring test_bus_ring.c ../modules/bus/bus_ring.c)
 target_include_directories(test_bus_ring PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 find_package(Threads REQUIRED)
 target_link_libraries(test_bus_ring PRIVATE Threads::Threads)
+aimee_add_test(test_bus_region test_bus_region.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c)
+target_include_directories(test_bus_region PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+
 
 
 aimee_add_test(test_self_update test_self_update.c ../self_update_util.c)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -215,6 +215,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-prompt-sanitizer \
                $(TESTPREFIX)/unit-test-bus-wire \
                $(TESTPREFIX)/unit-test-bus-ring \
+               $(TESTPREFIX)/unit-test-bus-region \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2544,6 +2545,18 @@ $(OBJDIR)/tests/test_bus_ring.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-ring: $(OBJDIR)/tests/test_bus_ring.o \
                                   $(OBJDIR)/modules/bus/bus_ring.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
+
+# Event-bus region layout (feature tree slice 3). Uses memfd_create + mmap; no
+# DB. Links the ring (slice 2) since a queue-pair region contains two rings.
+$(OBJDIR)/tests/test_bus_region.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-region: $(OBJDIR)/tests/test_bus_region.o \
+                                    $(OBJDIR)/modules/bus/bus_region.o \
+                                    $(OBJDIR)/modules/bus/bus_ring.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+.PHONY: unit-test-bus-region
+unit-test-bus-region: $(TESTPREFIX)/unit-test-bus-region
+	$<
 
 .PHONY: unit-test-bus-ring
 unit-test-bus-ring: $(TESTPREFIX)/unit-test-bus-ring

--- a/src/tests/test_bus_region.c
+++ b/src/tests/test_bus_region.c
@@ -1,0 +1,345 @@
+/* test_bus_region.c: slice 3 of the event-bus feature tree.
+ *
+ * The regions are the D1 isolation boundary, so the tests check the boundary as
+ * a fact rather than a convention:
+ *
+ *   - A client maps the control region PROT_READ. Writing it must FAULT, not be
+ *     tolerated. That is verified by forking a child that writes the mapping and
+ *     asserting it dies on SIGSEGV/SIGBUS — the enforced half of D2, proven
+ *     against the MMU rather than asserted in prose.
+ *
+ *   - Every header a client reads is treated as written by another process:
+ *     corrupt magic, version, or geometry is refused, not propagated into a
+ *     mapping size or a ring walk.
+ *
+ *   - The D4 parameters are read back from the control region, so a value that
+ *     was never compiled in survives create -> map -> attach.
+ *
+ *   - A stale host_epoch is detected.
+ *
+ *   - A queue-pair region round-trips real traffic through both of its rings
+ *     while mapped, which is the proof that the region layout actually places
+ *     two working rings where the header claims.
+ */
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "bus_region.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+static void must_result(bus_region_result_t got, bus_region_result_t want, const char *what)
+{
+   if (got != want)
+   {
+      fprintf(stderr, "FAIL: %s: expected %s, got %s\n", what, bus_region_result_name(want),
+              bus_region_result_name(got));
+      abort();
+   }
+}
+
+/* ------------------------------------------------------------------ */
+/* control region                                                      */
+
+static void test_control_roundtrip(void)
+{
+   /* Deliberately non-default parameters, so "read back from the region" is a
+    * real claim and not "matches a compiled constant". */
+   const uint32_t slot = 320, inl = 200, cap = 32;
+   const uint64_t arena = 512 * 1024;
+
+   bus_region_t create;
+   must_result(bus_region_create("ctl", bus_control_bytes(), &create), BUS_REGION_OK, "create");
+
+   bus_region_t host;
+   must_result(bus_region_map(create.fd, create.size, 1, &host), BUS_REGION_OK, "host map rw");
+   must_result(bus_control_init(&host, slot, inl, cap, arena), BUS_REGION_OK, "control init");
+
+   /* A client maps the same fd read-only and reads the parameters back. */
+   bus_region_t client;
+   must_result(bus_region_map(create.fd, create.size, 0, &client), BUS_REGION_OK,
+               "client map ro");
+   bus_control_t *c = NULL;
+   must_result(bus_control_attach(&client, &c), BUS_REGION_OK, "control attach");
+   must(atomic_load_explicit(&c->slot_size, memory_order_relaxed) == slot, "slot_size read back");
+   must(atomic_load_explicit(&c->inline_budget, memory_order_relaxed) == inl,
+        "inline_budget read back");
+   must(atomic_load_explicit(&c->queue_capacity, memory_order_relaxed) == cap,
+        "capacity read back");
+   must(atomic_load_explicit(&c->arena_size, memory_order_relaxed) == arena, "arena read back");
+
+   /* Epoch: cache it, bump it on the host mapping, detect the change. */
+   uint64_t attached = bus_control_epoch(c);
+   must(attached == 1, "fresh epoch is 1");
+   must(!bus_control_epoch_changed(c, attached), "no change yet");
+   bus_control_bump_epoch((bus_control_t *)host.base);
+   must(bus_control_epoch_changed(c, attached), "client sees the epoch bump");
+
+   bus_region_unmap(&client);
+   bus_region_unmap(&host);
+   close(create.fd);
+   printf("  control: params read back from the region, epoch bump detected\n");
+}
+
+#define RO_FAULT_SENTINEL 42
+
+static void ro_fault_handler(int sig)
+{
+   (void)sig;
+   _exit(RO_FAULT_SENTINEL);
+}
+
+/* Fork a child that writes the read-only control mapping. The write must fault.
+ * Doing it in a child keeps the fault from taking the test down, and turns "is
+ * the mapping really read-only" into a checked outcome.
+ *
+ * How the fault surfaces depends on the build: on a plain build the child's own
+ * SIGSEGV/SIGBUS handler runs and exits with a sentinel; under ASAN, ASAN's
+ * deadly-signal handler runs first, reports the SEGV, and aborts the child with
+ * SIGABRT. Both prove the write faulted. The one outcome that fails the test is
+ * the child exiting 0 — that would mean the write to a PROT_READ page was
+ * tolerated. */
+static void test_control_readonly_faults(void)
+{
+   bus_region_t create;
+   must_result(bus_region_create("ctl-ro", bus_control_bytes(), &create), BUS_REGION_OK,
+               "create");
+   bus_region_t host;
+   must_result(bus_region_map(create.fd, create.size, 1, &host), BUS_REGION_OK, "host map");
+   must_result(bus_control_init(&host, 256, 192, 16, 4096), BUS_REGION_OK, "init");
+
+   bus_region_t ro;
+   must_result(bus_region_map(create.fd, create.size, 0, &ro), BUS_REGION_OK, "map ro");
+
+   fflush(stdout);
+   pid_t pid = fork();
+   must(pid >= 0, "fork");
+   if (pid == 0)
+   {
+      signal(SIGSEGV, ro_fault_handler);
+      signal(SIGBUS, ro_fault_handler);
+      /* Child: this store is to a PROT_READ page. It must fault. */
+      volatile uint32_t *p = (volatile uint32_t *)ro.base;
+      *p = 0xdeadbeef;
+      _exit(0); /* reached only if the write did NOT fault */
+   }
+
+   int status = 0;
+   must(waitpid(pid, &status, 0) == pid, "waitpid");
+
+   int faulted = 0;
+   const char *how = "?";
+   if (WIFEXITED(status) && WEXITSTATUS(status) == RO_FAULT_SENTINEL)
+   {
+      faulted = 1;
+      how = "handler";
+   }
+   else if (WIFSIGNALED(status))
+   {
+      int sig = WTERMSIG(status);
+      faulted = (sig == SIGSEGV || sig == SIGBUS || sig == SIGABRT);
+      how = (sig == SIGABRT) ? "sanitizer-abort" : "signal";
+   }
+   must(faulted, "write to the read-only mapping faulted (child did not exit 0)");
+
+   bus_region_unmap(&ro);
+   bus_region_unmap(&host);
+   close(create.fd);
+   printf("  control read-only: a client write faults (%s)\n", how);
+}
+
+static void test_control_corruption_refused(void)
+{
+   bus_region_t create;
+   must_result(bus_region_create("ctl-bad", bus_control_bytes(), &create), BUS_REGION_OK,
+               "create");
+   bus_region_t host;
+   must_result(bus_region_map(create.fd, create.size, 1, &host), BUS_REGION_OK, "map");
+   must_result(bus_control_init(&host, 256, 192, 16, 4096), BUS_REGION_OK, "init");
+   bus_control_t *c = (bus_control_t *)host.base;
+   bus_control_t *dummy;
+
+   uint32_t u32;
+   uint64_t u64;
+
+   u32 = atomic_load_explicit(&c->magic, memory_order_relaxed);
+   atomic_store_explicit(&c->magic, 0, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_MAGIC, "bad magic refused");
+   atomic_store_explicit(&c->magic, u32, memory_order_relaxed);
+
+   u32 = atomic_load_explicit(&c->layout_version, memory_order_relaxed);
+   atomic_store_explicit(&c->layout_version, u32 + 1, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_VERSION, "bad version refused");
+   atomic_store_explicit(&c->layout_version, u32, memory_order_relaxed);
+
+   u32 = atomic_load_explicit(&c->slot_size, memory_order_relaxed);
+   atomic_store_explicit(&c->slot_size, 0, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_GEOMETRY,
+               "zero slot_size refused");
+   atomic_store_explicit(&c->slot_size, u32, memory_order_relaxed);
+
+   /* inline_budget larger than the slot is nonsense a client must not size on. */
+   atomic_store_explicit(&c->inline_budget, u32 + 1, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_GEOMETRY,
+               "inline_budget past slot refused");
+   atomic_store_explicit(&c->inline_budget, 192, memory_order_relaxed);
+
+   u64 = atomic_load_explicit(&c->arena_size, memory_order_relaxed);
+   atomic_store_explicit(&c->arena_size, 0, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_GEOMETRY,
+               "zero arena_size refused");
+   atomic_store_explicit(&c->arena_size, u64, memory_order_relaxed);
+
+   /* And a valid header still attaches after all that poking. */
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_OK, "restored header attaches");
+
+   bus_region_unmap(&host);
+   close(create.fd);
+   printf("  control corruption: magic, version, and geometry all refused\n");
+}
+
+/* A short mapping must be refused rather than read past. */
+static void test_short_mapping(void)
+{
+   bus_region_t create;
+   must_result(bus_region_create("short", bus_control_bytes(), &create), BUS_REGION_OK,
+               "create");
+   /* Map only one page but claim the region is smaller than the header. */
+   bus_region_t tiny;
+   must_result(bus_region_map(create.fd, create.size, 0, &tiny), BUS_REGION_OK, "map");
+   tiny.size = sizeof(bus_control_t) - 1; /* pretend the mapping is too small */
+   bus_control_t *dummy;
+   must_result(bus_control_attach(&tiny, &dummy), BUS_REGION_ERR_SIZE,
+               "attach refuses a header that does not fit");
+   tiny.size = create.size;
+   bus_region_unmap(&tiny);
+   close(create.fd);
+   printf("  short mapping: a header that does not fit is refused\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* queue-pair region                                                   */
+
+static void test_qpair_roundtrip(void)
+{
+   const uint32_t slot = 128, cap = 16;
+   size_t need = bus_qpair_bytes(slot, cap);
+   must(need > 0, "qpair geometry valid");
+
+   bus_region_t create;
+   must_result(bus_region_create("qp", need, &create), BUS_REGION_OK, "create");
+   bus_region_t host;
+   must_result(bus_region_map(create.fd, create.size, 1, &host), BUS_REGION_OK, "map");
+   must_result(bus_qpair_init(&host, slot, cap), BUS_REGION_OK, "qpair init");
+
+   /* Attach as the host would, and drive both rings — inbound host->client,
+    * outbound client->host — through the mapped region. */
+   bus_qpair_t qp;
+   must_result(bus_qpair_attach(&host, &qp), BUS_REGION_OK, "qpair attach");
+   must(bus_ring_capacity(&qp.inbound) == cap, "inbound capacity");
+   must(bus_ring_capacity(&qp.outbound) == cap, "outbound capacity");
+   must(atomic_load_explicit(&qp.hdr->control_credits, memory_order_relaxed) ==
+           BUS_CONTROL_CREDITS_DEFAULT,
+        "control-class reserve initialised");
+
+   for (uint32_t i = 0; i < cap; i++)
+   {
+      void *s = bus_ring_produce_begin(&qp.outbound);
+      must(s != NULL, "produce into outbound");
+      *(uint32_t *)s = 0x1000 + i;
+      bus_ring_produce_commit(&qp.outbound);
+   }
+   must(bus_ring_produce_begin(&qp.outbound) == NULL, "outbound full at capacity");
+   for (uint32_t i = 0; i < cap; i++)
+   {
+      const void *s = bus_ring_consume_begin(&qp.outbound);
+      must(s != NULL, "consume outbound");
+      must(*(const uint32_t *)s == 0x1000 + i, "outbound FIFO through the region");
+      bus_ring_consume_commit(&qp.outbound);
+   }
+
+   /* Corruption: bad magic and moved offsets are refused. */
+   bus_qpair_t dummy;
+   uint32_t m = atomic_load_explicit(&qp.hdr->magic, memory_order_relaxed);
+   atomic_store_explicit(&qp.hdr->magic, 0, memory_order_relaxed);
+   must_result(bus_qpair_attach(&host, &dummy), BUS_REGION_ERR_MAGIC, "bad qpair magic refused");
+   atomic_store_explicit(&qp.hdr->magic, m, memory_order_relaxed);
+
+   uint32_t off = atomic_load_explicit(&qp.hdr->outbound_off, memory_order_relaxed);
+   atomic_store_explicit(&qp.hdr->outbound_off, off + 64, memory_order_relaxed);
+   must_result(bus_qpair_attach(&host, &dummy), BUS_REGION_ERR_GEOMETRY,
+               "moved outbound offset refused");
+   atomic_store_explicit(&qp.hdr->outbound_off, off, memory_order_relaxed);
+
+   bus_region_unmap(&host);
+   close(create.fd);
+   printf("  queue-pair: both rings round-trip through the mapped region\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* arena region                                                        */
+
+/* Corrupt the arena magic in place and confirm attach refuses it. Separated
+ * from the body below only for readability. */
+static void arena_corruption_refused(bus_region_t *host)
+{
+   uint8_t *base;
+   uint64_t size;
+   uint32_t *magic = (uint32_t *)host->base; /* first 4 bytes are the arena magic */
+   uint32_t saved = *magic;
+   *magic = 0;
+   must_result(bus_arena_region_attach(host, &base, &size), BUS_REGION_ERR_MAGIC,
+               "bad arena magic refused");
+   *magic = saved;
+}
+
+static void test_arena_region(void)
+{
+   const uint64_t arena = 256 * 1024;
+   size_t need = bus_arena_region_bytes(arena);
+   must(need > 0, "arena geometry valid");
+
+   bus_region_t create;
+   must_result(bus_region_create("arena", need, &create), BUS_REGION_OK, "create");
+   bus_region_t host;
+   must_result(bus_region_map(create.fd, create.size, 1, &host), BUS_REGION_OK, "map");
+   must_result(bus_arena_region_init(&host, arena), BUS_REGION_OK, "arena init");
+
+   uint8_t *base = NULL;
+   uint64_t size = 0;
+   must_result(bus_arena_region_attach(&host, &base, &size), BUS_REGION_OK, "arena attach");
+   must(size == arena, "arena size read back");
+   must(base > (uint8_t *)host.base, "arena base is past the header");
+   /* The usable arena is inside the mapping. */
+   must(base + size <= (uint8_t *)host.base + host.size, "arena fits the mapping");
+
+   arena_corruption_refused(&host);
+
+   bus_region_unmap(&host);
+   close(create.fd);
+   printf("  arena: base and size validated, header corruption refused\n");
+}
+
+int main(void)
+{
+   printf("test_bus_region:\n");
+   test_control_roundtrip();
+   test_control_readonly_faults();
+   test_control_corruption_refused();
+   test_short_mapping();
+   test_qpair_roundtrip();
+   test_arena_region();
+   printf("test_bus_region: OK\n");
+   return 0;
+}

--- a/src/tests/test_bus_region.c
+++ b/src/tests/test_bus_region.c
@@ -201,6 +201,23 @@ static void test_control_corruption_refused(void)
                "zero arena_size refused");
    atomic_store_explicit(&c->arena_size, u64, memory_order_relaxed);
 
+   u32 = atomic_load_explicit(&c->spec_version, memory_order_relaxed);
+   atomic_store_explicit(&c->spec_version, u32 + 1, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_VERSION,
+               "bad spec_version refused");
+   atomic_store_explicit(&c->spec_version, u32, memory_order_relaxed);
+
+   /* queue_capacity sizes the queue-pair rings; a non-power-of-two must be
+    * refused here rather than sizing a ring on it later. */
+   u32 = atomic_load_explicit(&c->queue_capacity, memory_order_relaxed);
+   atomic_store_explicit(&c->queue_capacity, 15, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_GEOMETRY,
+               "bad queue_capacity refused");
+   atomic_store_explicit(&c->queue_capacity, 0, memory_order_relaxed);
+   must_result(bus_control_attach(&host, &dummy), BUS_REGION_ERR_GEOMETRY,
+               "zero queue_capacity refused");
+   atomic_store_explicit(&c->queue_capacity, u32, memory_order_relaxed);
+
    /* And a valid header still attaches after all that poking. */
    must_result(bus_control_attach(&host, &dummy), BUS_REGION_OK, "restored header attaches");
 
@@ -209,23 +226,35 @@ static void test_control_corruption_refused(void)
    printf("  control corruption: magic, version, and geometry all refused\n");
 }
 
-/* A short mapping must be refused rather than read past. */
-static void test_short_mapping(void)
+/* A short backing object must be refused before it can fault, not merely a
+ * short size claim. Two real cases:
+ *   1. Mapping MORE than the memfd holds — mmap would succeed and later touches
+ *      would SIGBUS. bus_region_map must refuse it up front.
+ *   2. A memfd large enough to map but too small for the claimed layout — attach
+ *      must refuse rather than walk past the backing. */
+static void test_short_backing(void)
 {
-   bus_region_t create;
-   must_result(bus_region_create("short", bus_control_bytes(), &create), BUS_REGION_OK,
-               "create");
-   /* Map only one page but claim the region is smaller than the header. */
-   bus_region_t tiny;
-   must_result(bus_region_map(create.fd, create.size, 0, &tiny), BUS_REGION_OK, "map");
-   tiny.size = sizeof(bus_control_t) - 1; /* pretend the mapping is too small */
-   bus_control_t *dummy;
-   must_result(bus_control_attach(&tiny, &dummy), BUS_REGION_ERR_SIZE,
-               "attach refuses a header that does not fit");
-   tiny.size = create.size;
-   bus_region_unmap(&tiny);
-   close(create.fd);
-   printf("  short mapping: a header that does not fit is refused\n");
+   /* Case 1: a genuinely short memfd, asked to map beyond its length. */
+   bus_region_t small;
+   must_result(bus_region_create("short-fd", 64, &small), BUS_REGION_OK, "create small");
+   /* small.size is one page (rounded). Ask to map two pages of a one-page fd. */
+   bus_region_t over;
+   must_result(bus_region_map(small.fd, small.size + small.size, 0, &over), BUS_REGION_ERR_SIZE,
+               "map beyond the backing fd is refused before it can SIGBUS");
+   close(small.fd);
+
+   /* Case 2: a one-page region is fine to map, but a queue-pair layout that
+    * needs more than a page must be refused at init/attach, not walked past. */
+   bus_region_t page;
+   must_result(bus_region_create("one-page", 64, &page), BUS_REGION_OK, "create page");
+   bus_region_t mapped;
+   must_result(bus_region_map(page.fd, page.size, 1, &mapped), BUS_REGION_OK, "map one page");
+   /* 4096-byte slots x 64 needs far more than a page. */
+   must_result(bus_qpair_init(&mapped, 4096, 64), BUS_REGION_ERR_SIZE,
+               "qpair layout larger than the mapping is refused");
+   bus_region_unmap(&mapped);
+   close(page.fd);
+   printf("  short backing: over-length map and over-large layout both refused\n");
 }
 
 /* ------------------------------------------------------------------ */
@@ -253,38 +282,61 @@ static void test_qpair_roundtrip(void)
            BUS_CONTROL_CREDITS_DEFAULT,
         "control-class reserve initialised");
 
-   for (uint32_t i = 0; i < cap; i++)
+   /* Both rings, driven independently with distinct payloads, so a defect in
+    * the inbound ring's placement or init cannot hide behind the outbound one.
+    * inbound is host->client (0x2000+), outbound is client->host (0x1000+). */
+   bus_ring_t *rings[2] = {&qp.inbound, &qp.outbound};
+   uint32_t bases[2] = {0x2000, 0x1000};
+   for (int r = 0; r < 2; r++)
    {
-      void *s = bus_ring_produce_begin(&qp.outbound);
-      must(s != NULL, "produce into outbound");
-      *(uint32_t *)s = 0x1000 + i;
-      bus_ring_produce_commit(&qp.outbound);
-   }
-   must(bus_ring_produce_begin(&qp.outbound) == NULL, "outbound full at capacity");
-   for (uint32_t i = 0; i < cap; i++)
-   {
-      const void *s = bus_ring_consume_begin(&qp.outbound);
-      must(s != NULL, "consume outbound");
-      must(*(const uint32_t *)s == 0x1000 + i, "outbound FIFO through the region");
-      bus_ring_consume_commit(&qp.outbound);
+      for (uint32_t i = 0; i < cap; i++)
+      {
+         void *s = bus_ring_produce_begin(rings[r]);
+         must(s != NULL, "produce into ring");
+         *(uint32_t *)s = bases[r] + i;
+         bus_ring_produce_commit(rings[r]);
+      }
+      must(bus_ring_produce_begin(rings[r]) == NULL, "ring full at capacity");
+      for (uint32_t i = 0; i < cap; i++)
+      {
+         const void *s = bus_ring_consume_begin(rings[r]);
+         must(s != NULL, "consume ring");
+         must(*(const uint32_t *)s == bases[r] + i, "ring FIFO through the region");
+         bus_ring_consume_commit(rings[r]);
+      }
+      must(bus_ring_count(rings[r]) == 0, "ring drained");
    }
 
-   /* Corruption: bad magic and moved offsets are refused. */
+   /* Corruption of the qpair header surface: magic, geometry, and offsets. */
    bus_qpair_t dummy;
-   uint32_t m = atomic_load_explicit(&qp.hdr->magic, memory_order_relaxed);
-   atomic_store_explicit(&qp.hdr->magic, 0, memory_order_relaxed);
-   must_result(bus_qpair_attach(&host, &dummy), BUS_REGION_ERR_MAGIC, "bad qpair magic refused");
-   atomic_store_explicit(&qp.hdr->magic, m, memory_order_relaxed);
-
-   uint32_t off = atomic_load_explicit(&qp.hdr->outbound_off, memory_order_relaxed);
-   atomic_store_explicit(&qp.hdr->outbound_off, off + 64, memory_order_relaxed);
-   must_result(bus_qpair_attach(&host, &dummy), BUS_REGION_ERR_GEOMETRY,
-               "moved outbound offset refused");
-   atomic_store_explicit(&qp.hdr->outbound_off, off, memory_order_relaxed);
+   struct
+   {
+      const char *what;
+      _Atomic uint32_t *field;
+      uint32_t bad;
+      bus_region_result_t want;
+   } lies[] = {
+      {"bad magic", &qp.hdr->magic, 0, BUS_REGION_ERR_MAGIC},
+      {"bad slot_size", &qp.hdr->slot_size, 0, BUS_REGION_ERR_GEOMETRY},
+      {"bad capacity", &qp.hdr->capacity, 15, BUS_REGION_ERR_GEOMETRY},
+      {"moved inbound offset", &qp.hdr->inbound_off, 8, BUS_REGION_ERR_GEOMETRY},
+      {"moved outbound offset",
+       &qp.hdr->outbound_off,
+       atomic_load_explicit(&qp.hdr->outbound_off, memory_order_relaxed) + 64,
+       BUS_REGION_ERR_GEOMETRY},
+   };
+   for (size_t i = 0; i < sizeof lies / sizeof lies[0]; i++)
+   {
+      uint32_t saved = atomic_load_explicit(lies[i].field, memory_order_relaxed);
+      atomic_store_explicit(lies[i].field, lies[i].bad, memory_order_relaxed);
+      must_result(bus_qpair_attach(&host, &dummy), lies[i].want, lies[i].what);
+      atomic_store_explicit(lies[i].field, saved, memory_order_relaxed);
+   }
+   must_result(bus_qpair_attach(&host, &dummy), BUS_REGION_OK, "restored qpair attaches");
 
    bus_region_unmap(&host);
    close(create.fd);
-   printf("  queue-pair: both rings round-trip through the mapped region\n");
+   printf("  queue-pair: both rings round-trip independently, header lies refused\n");
 }
 
 /* ------------------------------------------------------------------ */
@@ -302,6 +354,20 @@ static void arena_corruption_refused(bus_region_t *host)
    must_result(bus_arena_region_attach(host, &base, &size), BUS_REGION_ERR_MAGIC,
                "bad arena magic refused");
    *magic = saved;
+
+   /* A size the mapping cannot back must be refused, not walked past. The size
+    * field is the u64 at offset 8 of the arena header. */
+   uint64_t *szp = (uint64_t *)((uint8_t *)host->base + 8);
+   uint64_t saved_sz = *szp;
+   *szp = host->size + (1u << 20); /* claim far more than is mapped */
+   must_result(bus_arena_region_attach(host, &base, &size), BUS_REGION_ERR_SIZE,
+               "arena size larger than the mapping refused");
+   *szp = 0;
+   must_result(bus_arena_region_attach(host, &base, &size), BUS_REGION_ERR_GEOMETRY,
+               "zero arena size refused");
+   *szp = saved_sz;
+   must_result(bus_arena_region_attach(host, &base, &size), BUS_REGION_OK,
+               "restored arena attaches");
 }
 
 static void test_arena_region(void)
@@ -337,7 +403,7 @@ int main(void)
    test_control_roundtrip();
    test_control_readonly_faults();
    test_control_corruption_refused();
-   test_short_mapping();
+   test_short_backing();
    test_qpair_roundtrip();
    test_arena_region();
    printf("test_bus_region: OK\n");


### PR DESCRIPTION
Third slice of the event-bus feature tree, and the first on the accepted D1 multi-region layout.

## What lands

`bus_region.{c,h}` — create, map and validate the memfd-backed regions:
- **Control region** (one memfd, `PROT_READ` to clients): versioned header + the D4 parameters read at attach and never compiled in, plus host_epoch/host_heartbeat. Read-only is an MMU fact.
- **Queue-pair region** (one memfd per slot): the client's inbound + outbound `bus_ring`s plus data/control credits, control_lost, client_heartbeat. Credit fields are exercised by slice 7 / D6; defaulted now.
- **Arena region**: created, mapped, validated; the lease allocator is slice 4.
- The **queue directory is deliberately not a region** — host-private memory (slice 5), which is what stops a client enumerating other slots.

Every header a client reads is validated as untrusted before it can size a mapping or a ring walk; header sizes are frozen by `_Static_assert`.

## Verification (normal + ASAN/UBSAN)

The read-only proof forks a child that writes the `PROT_READ` control mapping and asserts it **faults** — the enforced half of D2, against the MMU rather than in prose. Robust across plain and ASAN builds. Corruption/version/geometry/short-mapping all refused; a queue-pair region round-trips real traffic through both rings while mapped.

No shipping binary links the bus (D7). Depends on slices 1–2 (already merged).