### PR TITLE
test(vault): run the pkcs11 custody provider against SoftHSM2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
           done
           echo "Postgres did not become ready in time"; docker logs aimee-pg || true; exit 1
       - name: Unit tests
-        run: cd src && make -j$(nproc) unit-tests
+        run: cd src && make -j$(nproc) unit-tests build/obj/tests/p7-pkcs11-harness
 
   init-migrate-service-test:
     runs-on: ubuntu-latest
@@ -694,3 +694,22 @@ jobs:
           cd src
           make AIMEE_TREESITTER=1 build/obj/tests/unit-test-code-treesitter
           ./build/obj/tests/unit-test-code-treesitter
+
+  vault-pkcs11-token:
+    name: vault-pkcs11-token
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
+          sudo apt-get install -y -q gcc make \
+            libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libp11-kit-dev \
+            libpq-dev softhsm2 opensc
+      - name: Run the SoftHSM2 PKCS#11 custody gate (must not skip)
+        env:
+          AIMEE_PKCS11_GATE_REQUIRE: "1"
+        run: bash scripts/p7_pkcs11_softhsm_test.sh

--- a/scripts/p7_pkcs11_softhsm_test.sh
+++ b/scripts/p7_pkcs11_softhsm_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# p7_pkcs11_softhsm_test.sh: integration gate for the PKCS#11 vault custody
+# provider, exercised against SoftHSM2 (a software PKCS#11 token that implements
+# the same PKCS#11 API a real HSM does, so a green run here validates the
+# provider's C_Login / C_FindObjects / C_GetAttributeValue path end to end).
+#
+# The PKCS#11 provider is the only build (no stub), but get_kek/unseal need a
+# real token, so this is a standalone gate rather than a default unit test —
+# the same treatment as the tpm2 custody provider's swtpm gate.
+#
+# It SKIPS CLEANLY (exit 0) when the token toolchain is unavailable:
+#   - softhsm2-util not installed, or
+#   - pkcs11-tool (opensc) not installed, or
+#   - the SoftHSM2 module .so cannot be located.
+#
+# On a capable host it: creates an isolated SoftHSM2 token, writes a known
+# 32-byte KEK as a CKO_DATA object labelled `aimee-kek` (the provider looks up
+# by label and reads CKA_VALUE, which a data object always exposes), points the
+# provider env at that token, builds the harness, and runs the fixed assertions
+# in tests/test_vault_custody_pkcs11.c (unseal -> unsealed, get_kek nonzero,
+# seal -> sealed).
+set -euo pipefail
+
+# In CI the token toolchain is provisioned deliberately, so a "skip" would mean
+# the provisioning is broken and the test silently did not run. Set
+# AIMEE_PKCS11_GATE_REQUIRE=1 there to turn every skip into a hard failure, so a
+# missing dependency cannot masquerade as a pass. Unset (the default) keeps the
+# gate skip-clean for developer/appliance hosts without SoftHSM2.
+log()  { printf '%s\n' "p7-pkcs11-softhsm: $*"; }
+skip() {
+  if [ "${AIMEE_PKCS11_GATE_REQUIRE:-0}" = "1" ]; then
+    log "FAIL (require mode): $*"
+    exit 1
+  fi
+  log "SKIP: $*"
+  exit 0
+}
+
+command -v softhsm2-util >/dev/null 2>&1 || skip "softhsm2-util not installed"
+command -v pkcs11-tool   >/dev/null 2>&1 || skip "pkcs11-tool (opensc) not installed"
+
+# Locate the SoftHSM2 PKCS#11 module.
+MODULE=""
+for cand in \
+  /usr/lib/softhsm/libsofthsm2.so \
+  /usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+  /usr/local/lib/softhsm/libsofthsm2.so; do
+  [ -f "$cand" ] && { MODULE="$cand"; break; }
+done
+[ -n "$MODULE" ] || skip "libsofthsm2.so not found"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HARNESS_REL="build/obj/tests/p7-pkcs11-harness"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# Isolated token store, so the gate never touches a host token database.
+export SOFTHSM2_CONF="$WORK/softhsm2.conf"
+mkdir -p "$WORK/tokens"
+printf 'directories.tokendir = %s\n' "$WORK/tokens" > "$SOFTHSM2_CONF"
+
+PIN="1234"
+SO_PIN="5678"
+LABEL="aimee-kek"
+
+log "initialising SoftHSM2 token"
+softhsm2-util --init-token --free --label aimee-vault --pin "$PIN" --so-pin "$SO_PIN" >/dev/null
+
+# Known 32-byte KEK, written as a data object the provider reads by label.
+head -c 32 /dev/urandom > "$WORK/kek.bin"
+log "writing $LABEL data object"
+pkcs11-tool --module "$MODULE" --login --pin "$PIN" \
+  --write-object "$WORK/kek.bin" --type data --label "$LABEL" >/dev/null
+
+log "building harness"
+make -C "$REPO_ROOT/src" "$HARNESS_REL" >/dev/null
+
+log "running provider assertions"
+AIMEE_VAULT_PKCS11_MODULE="$MODULE" \
+AIMEE_VAULT_PKCS11_PIN="$PIN" \
+AIMEE_VAULT_PKCS11_LABEL="$LABEL" \
+  "$REPO_ROOT/src/$HARNESS_REL"
+
+log "PASS"

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3507,6 +3507,16 @@ $(TESTPREFIX)/p7-tpm2-harness: $(OBJDIR)/tests/test_vault_tpm2.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) $(KB_TPM2_LDLIBS)
 
+# P7 pkcs11 custody integration harness: the PKCS#11 provider is the only build,
+# but exercising get_kek/unseal needs a real token, so this is a standalone gate
+# (scripts/p7_pkcs11_softhsm_test.sh), not a default unit test. Build with
+#   make $(OBJDIR)/tests/p7-pkcs11-harness
+$(TESTPREFIX)/p7-pkcs11-harness: $(OBJDIR)/tests/test_vault_custody_pkcs11.o \
+                              $(OBJDIR)/modules/vault/vault_custody_pkcs11.o \
+                              $(OBJDIR)/modules/vault/vault_crypto.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) $(KB_PKCS11_LDLIBS)
+
 $(TESTPREFIX)/unit-test-agent-key-import: $(OBJDIR)/tests/test_agent_key_import.o \
                               $(OBJDIR)/cli_agent_keys.o \
                               $(TEST_CORE_OBJS)


### PR DESCRIPTION
PR2 of 2. De-orphans `test_vault_custody_pkcs11.c` and runs it against SoftHSM2. Follows PR1 (#1901), which made the p11-kit PKCS#11 provider the only build.

## Shape — mirrors the tpm2 provider

The test exercises the real provider's `unseal → get_kek(nonzero) → seal` path, which needs a live PKCS#11 token. So it is wired as a **standalone `p7-pkcs11-harness`** (not a default unit test) driven by a **skip-clean gate** — exactly how the tpm2 custody provider is handled by `scripts/p7_tpm2_swtpm_test.sh`.

`scripts/p7_pkcs11_softhsm_test.sh` provisions an isolated SoftHSM2 token, writes a known 32-byte KEK as a **`CKO_DATA` object** labelled `aimee-kek` (the provider does a label-only `C_FindObjects` then reads `CKA_VALUE`, which a data object always exposes — no `CKA_EXTRACTABLE`/`CKA_SENSITIVE` footguns), points the provider env at the token, builds the harness, and runs the assertions.

## Anti-SKIP guard (roundtable F1)

The gate skips cleanly on hosts without SoftHSM2/OpenSC. `AIMEE_PKCS11_GATE_REQUIRE=1` turns a skip into a **hard failure**, so a broken provisioning cannot masquerade as a green pass. The new `vault-pkcs11-token` CI job sets it.

## CI

- New **`vault-pkcs11-token`** job: installs `softhsm2` + `opensc` (+ the p11-kit build dep), runs the gate in require mode.
- The required **`unit-tests`** job additionally compiles `p7-pkcs11-harness` so a future change can't silently re-orphan it (roundtable F4).

## Verified vs. driven-on-CI

Verified locally: the harness builds clean with the p11-kit headers supplied, and the gate skip-cleans by default / hard-fails in require mode. The **SoftHSM2 provisioning itself is verified by the new CI job**, since it can't be installed on the dev box — per the roundtable, this PR is not merged until that job is observed genuinely green.

## Noted, out of scope (roundtable F2)

Reading the raw KEK via `CKA_VALUE` uses the token as a *secret store* rather than for HSM-backed *non-extractability*. That is a property of the existing provider (unchanged here), worth tracking as a separate security-design item.

The scoping roundtable approved Option B (run in CI) with these findings applied.