### PR TITLE
Slice 4: host-mediated arena lease allocator

### DIFF
--- a/src/modules/bus/bus_arena.c
+++ b/src/modules/bus/bus_arena.c
@@ -1,0 +1,416 @@
+/* bus_arena.c: host-mediated lease allocator. See bus_arena.h for the D3 model.
+ *
+ * The allocator is a first-fit free list with coalescing. Coalescing on every
+ * free is what keeps churn from stranding the arena: two frees that touch merge,
+ * so after everything is released the arena is one span again. All of this
+ * bookkeeping is host-private — the shared arena holds only payload bytes.
+ */
+#include <string.h>
+
+#include "bus_arena.h"
+
+/* Alignment so consecutive leases do not share a machine word, and lengths are
+ * rounded up predictably. */
+#define ARENA_ALIGN 16u
+
+static uint64_t align_up(uint64_t n)
+{
+   return (n + (ARENA_ALIGN - 1)) & ~((uint64_t)ARENA_ALIGN - 1);
+}
+
+/* ---- slot bitmaps ---- */
+
+static void bits_set(uint64_t *bits, uint32_t slot)
+{
+   bits[slot / 64] |= (uint64_t)1 << (slot % 64);
+}
+static void bits_clear(uint64_t *bits, uint32_t slot)
+{
+   bits[slot / 64] &= ~((uint64_t)1 << (slot % 64));
+}
+static int bits_test(const uint64_t *bits, uint32_t slot)
+{
+   return (bits[slot / 64] >> (slot % 64)) & 1;
+}
+static uint32_t bits_popcount(const uint64_t *bits)
+{
+   uint32_t n = 0;
+   for (int i = 0; i < BUS_ARENA_SLOT_WORDS; i++)
+   {
+      uint64_t w = bits[i];
+      while (w)
+      {
+         w &= w - 1;
+         n++;
+      }
+   }
+   return n;
+}
+
+/* ---- free list ---- */
+
+/* Insert [off,len) keeping the list sorted by offset, then coalesce neighbours.
+ *
+ * The array holds BUS_ARENA_MAX_LEASES + 1 spans, which cannot overflow: free
+ * and allocated spans strictly alternate along the arena, so with at most
+ * MAX_LEASES allocated spans there are at most MAX_LEASES + 1 free spans, and
+ * the transient +1 during a shift-then-coalesce insert is exactly the spare
+ * slot. This runs after a free (which never raises the live-lease count), so the
+ * pre-insert free_count is always < the array bound. */
+static void free_insert(bus_arena_t *a, uint64_t off, uint64_t len)
+{
+   uint32_t i = 0;
+   while (i < a->free_count && a->freelist[i].offset < off)
+      i++;
+
+   /* shift up to make room */
+   for (uint32_t j = a->free_count; j > i; j--)
+      a->freelist[j] = a->freelist[j - 1];
+   a->freelist[i].offset = off;
+   a->freelist[i].len = len;
+   a->free_count++;
+
+   /* coalesce with the previous span if adjacent */
+   if (i > 0 && a->freelist[i - 1].offset + a->freelist[i - 1].len == a->freelist[i].offset)
+   {
+      a->freelist[i - 1].len += a->freelist[i].len;
+      for (uint32_t j = i; j + 1 < a->free_count; j++)
+         a->freelist[j] = a->freelist[j + 1];
+      a->free_count--;
+      i--;
+   }
+   /* coalesce with the next span if adjacent */
+   if (i + 1 < a->free_count &&
+       a->freelist[i].offset + a->freelist[i].len == a->freelist[i + 1].offset)
+   {
+      a->freelist[i].len += a->freelist[i + 1].len;
+      for (uint32_t j = i + 1; j + 1 < a->free_count; j++)
+         a->freelist[j] = a->freelist[j + 1];
+      a->free_count--;
+   }
+}
+
+/* First-fit carve of `len` bytes; returns 1 and sets *off on success. */
+static int free_take(bus_arena_t *a, uint64_t len, uint64_t *off)
+{
+   for (uint32_t i = 0; i < a->free_count; i++)
+   {
+      if (a->freelist[i].len >= len)
+      {
+         *off = a->freelist[i].offset;
+         a->freelist[i].offset += len;
+         a->freelist[i].len -= len;
+         if (a->freelist[i].len == 0)
+         {
+            for (uint32_t j = i; j + 1 < a->free_count; j++)
+               a->freelist[j] = a->freelist[j + 1];
+            a->free_count--;
+         }
+         return 1;
+      }
+   }
+   return 0;
+}
+
+/* ---- init ---- */
+
+bus_arena_result_t bus_arena_init(bus_arena_t *a, uint8_t *base, uint64_t size,
+                                  uint32_t max_slots, uint32_t per_client_cap)
+{
+   if (!a || !base || size == 0 || max_slots == 0 || max_slots > BUS_ARENA_MAX_SLOTS ||
+       per_client_cap == 0)
+      return BUS_ARENA_ERR_ARG;
+
+   memset(a, 0, sizeof *a);
+   a->base = base;
+   a->size = size;
+   a->max_slots = max_slots;
+   a->per_client_cap = per_client_cap;
+   a->freelist[0].offset = 0;
+   a->freelist[0].len = size;
+   a->free_count = 1;
+   return BUS_ARENA_OK;
+}
+
+/* ---- lease helpers ---- */
+
+static bus_lease_t *lease_at(bus_arena_t *a, uint32_t id)
+{
+   if (id >= a->lease_count || !a->leases[id].active)
+      return NULL;
+   return &a->leases[id];
+}
+
+static uint32_t lease_refcount(const bus_lease_t *l)
+{
+   return (uint32_t)l->producer_ref + bits_popcount(l->consumer_bits);
+}
+
+/* Free a lease's span and clear the slot for reuse, keeping generation so the
+ * next reuse presents a fresh one. */
+static void lease_reclaim(bus_arena_t *a, bus_lease_t *l)
+{
+   free_insert(a, l->offset, l->len);
+   a->bytes_in_use -= l->len;
+   if (a->live_per_slot[l->owner_slot] > 0)
+      a->live_per_slot[l->owner_slot]--;
+   uint32_t gen = l->generation;
+   memset(l, 0, sizeof *l);
+   l->generation = gen; /* preserved: a stale reader must still mismatch */
+}
+
+static void lease_drop_if_zero(bus_arena_t *a, bus_lease_t *l)
+{
+   if (lease_refcount(l) == 0)
+      lease_reclaim(a, l);
+}
+
+/* ---- alloc ---- */
+
+bus_arena_result_t bus_arena_alloc(bus_arena_t *a, uint32_t owner_slot, uint32_t len,
+                                   uint32_t *lease_id)
+{
+   if (!a || !lease_id || owner_slot >= a->max_slots || len == 0)
+      return BUS_ARENA_ERR_ARG;
+
+   /* The cap is enforced HERE, synchronously, before any bytes are written —
+    * not at reap, which lags behind a heartbeat. */
+   if (a->live_per_slot[owner_slot] >= a->per_client_cap)
+      return BUS_ARENA_ERR_CAP;
+
+   uint64_t need = align_up(len);
+   /* A length near UINT32_MAX aligns past it; a span the arena cannot hold is
+    * out of space, not a truncated l->len. Bounding need by the arena size makes
+    * both true at once — nothing this large ever fits, and l->len never wraps. */
+   if (need == 0 || need > a->size)
+      return BUS_ARENA_ERR_NOSPACE;
+
+   /* find a free lease-table slot */
+   uint32_t id = BUS_ARENA_MAX_LEASES;
+   for (uint32_t i = 0; i < BUS_ARENA_MAX_LEASES; i++)
+   {
+      if (!a->leases[i].active)
+      {
+         id = i;
+         break;
+      }
+   }
+   if (id == BUS_ARENA_MAX_LEASES)
+      return BUS_ARENA_ERR_NOLEASE;
+
+   uint64_t off;
+   if (!free_take(a, need, &off))
+      return BUS_ARENA_ERR_NOSPACE;
+
+   bus_lease_t *l = &a->leases[id];
+   uint32_t gen = l->generation + 1; /* fresh generation for this reuse */
+   memset(l, 0, sizeof *l);
+   l->active = 1;
+   l->producer_ref = 1;
+   l->owner_slot = (uint8_t)owner_slot;
+   l->generation = gen;
+   l->offset = off;
+   l->len = (uint32_t)need;
+
+   if (id >= a->lease_count)
+      a->lease_count = id + 1;
+   a->live_per_slot[owner_slot]++;
+   a->bytes_in_use += need;
+   *lease_id = id;
+   return BUS_ARENA_OK;
+}
+
+bus_arena_result_t bus_arena_fill_ptr(bus_arena_t *a, uint32_t lease_id, uint8_t **ptr)
+{
+   if (!a || !ptr)
+      return BUS_ARENA_ERR_ARG;
+   bus_lease_t *l = lease_at(a, lease_id);
+   if (!l)
+      return BUS_ARENA_ERR_ARG;
+   if (!l->producer_ref)
+      return BUS_ARENA_ERR_STATE; /* already published or cancelled */
+   *ptr = a->base + l->offset;
+   return BUS_ARENA_OK;
+}
+
+bus_arena_result_t bus_arena_ref(const bus_arena_t *a, uint32_t lease_id, bus_arena_ref_t *ref)
+{
+   if (!a || !ref)
+      return BUS_ARENA_ERR_ARG;
+   const bus_lease_t *l = (lease_id < a->lease_count && a->leases[lease_id].active)
+                             ? &a->leases[lease_id]
+                             : NULL;
+   if (!l)
+      return BUS_ARENA_ERR_ARG;
+   ref->offset = l->offset;
+   ref->len = l->len;
+   ref->generation = l->generation;
+   return BUS_ARENA_OK;
+}
+
+/* ---- publish ---- */
+
+bus_arena_result_t bus_arena_publish(bus_arena_t *a, uint32_t lease_id,
+                                     const uint8_t *observer_slots, uint32_t k)
+{
+   if (!a || (k > 0 && !observer_slots))
+      return BUS_ARENA_ERR_ARG;
+   bus_lease_t *l = lease_at(a, lease_id);
+   if (!l)
+      return BUS_ARENA_ERR_ARG;
+   if (!l->producer_ref)
+      return BUS_ARENA_ERR_STATE; /* publish is a once-only transition */
+
+   /* Validate observers first, so a bad list leaves the lease untouched. A slot
+    * may not appear twice: catching a duplicate needs a seen-set built as we go,
+    * not a test against consumer_bits (which are still zero here) — an idempotent
+    * bit-set would otherwise silently collapse [2,2] into a single ref while the
+    * caller believed it published to two, and the refcount would be wrong. */
+   uint64_t seen[BUS_ARENA_SLOT_WORDS] = {0};
+   for (uint32_t i = 0; i < k; i++)
+   {
+      uint32_t s = observer_slots[i];
+      if (s >= a->max_slots)
+         return BUS_ARENA_ERR_ARG;
+      if (bits_test(seen, s))
+         return BUS_ARENA_ERR_ARG; /* a slot may not appear twice */
+      bits_set(seen, s);
+   }
+
+   for (uint32_t i = 0; i < k; i++)
+      bits_set(l->consumer_bits, observer_slots[i]);
+   l->producer_ref = 0; /* ownership transfers to the consumers */
+
+   /* Publishing to zero observers takes the refcount straight to zero. */
+   lease_drop_if_zero(a, l);
+   return BUS_ARENA_OK;
+}
+
+/* ---- consumer read / release ---- */
+
+bus_arena_result_t bus_arena_read_ptr(const bus_arena_t *a, uint32_t lease_id,
+                                      uint32_t generation, uint32_t consumer_slot,
+                                      const uint8_t **ptr)
+{
+   if (!a || !ptr || consumer_slot >= a->max_slots)
+      return BUS_ARENA_ERR_ARG;
+   if (lease_id >= a->lease_count || !a->leases[lease_id].active)
+      return BUS_ARENA_ERR_STALE;
+   const bus_lease_t *l = &a->leases[lease_id];
+   if (l->generation != generation)
+      return BUS_ARENA_ERR_STALE;
+   if (!bits_test(l->consumer_bits, consumer_slot))
+      return BUS_ARENA_ERR_NOTHOLDER;
+   *ptr = a->base + l->offset;
+   return BUS_ARENA_OK;
+}
+
+bus_arena_result_t bus_arena_release(bus_arena_t *a, uint32_t lease_id, uint32_t generation,
+                                     uint32_t consumer_slot)
+{
+   if (!a || consumer_slot >= a->max_slots)
+      return BUS_ARENA_ERR_ARG;
+   if (lease_id >= a->lease_count || !a->leases[lease_id].active)
+      return BUS_ARENA_ERR_STALE;
+   bus_lease_t *l = &a->leases[lease_id];
+   if (l->generation != generation)
+      return BUS_ARENA_ERR_STALE;
+   if (!bits_test(l->consumer_bits, consumer_slot))
+      return BUS_ARENA_ERR_NOTHOLDER;
+
+   bits_clear(l->consumer_bits, consumer_slot);
+   lease_drop_if_zero(a, l);
+   return BUS_ARENA_OK;
+}
+
+bus_arena_result_t bus_arena_cancel(bus_arena_t *a, uint32_t lease_id)
+{
+   if (!a)
+      return BUS_ARENA_ERR_ARG;
+   bus_lease_t *l = lease_at(a, lease_id);
+   if (!l)
+      return BUS_ARENA_ERR_ARG;
+   if (!l->producer_ref)
+      return BUS_ARENA_ERR_STATE; /* nothing to cancel: already published */
+   l->producer_ref = 0;
+   lease_drop_if_zero(a, l);
+   return BUS_ARENA_OK;
+}
+
+/* ---- reap ---- */
+
+void bus_arena_reap_producer(bus_arena_t *a, uint32_t slot)
+{
+   if (!a || slot >= a->max_slots)
+      return;
+   for (uint32_t i = 0; i < a->lease_count; i++)
+   {
+      bus_lease_t *l = &a->leases[i];
+      if (l->active && l->producer_ref && l->owner_slot == slot)
+      {
+         l->producer_ref = 0; /* orphaned-but-live: consumers still drain it */
+         lease_drop_if_zero(a, l);
+      }
+   }
+}
+
+void bus_arena_reap_consumer(bus_arena_t *a, uint32_t slot)
+{
+   if (!a || slot >= a->max_slots)
+      return;
+   for (uint32_t i = 0; i < a->lease_count; i++)
+   {
+      bus_lease_t *l = &a->leases[i];
+      if (l->active && bits_test(l->consumer_bits, slot))
+      {
+         bits_clear(l->consumer_bits, slot);
+         lease_drop_if_zero(a, l);
+      }
+   }
+}
+
+/* ---- observers ---- */
+
+uint32_t bus_arena_live_leases(const bus_arena_t *a, uint32_t slot)
+{
+   if (!a || slot >= a->max_slots)
+      return 0;
+   return a->live_per_slot[slot];
+}
+
+uint64_t bus_arena_bytes_in_use(const bus_arena_t *a)
+{
+   return a ? a->bytes_in_use : 0;
+}
+
+uint32_t bus_arena_refcount(const bus_arena_t *a, uint32_t lease_id)
+{
+   if (!a || lease_id >= a->lease_count || !a->leases[lease_id].active)
+      return 0;
+   return lease_refcount(&a->leases[lease_id]);
+}
+
+const char *bus_arena_result_name(bus_arena_result_t r)
+{
+   switch (r)
+   {
+   case BUS_ARENA_OK:
+      return "OK";
+   case BUS_ARENA_ERR_ARG:
+      return "ERR_ARG";
+   case BUS_ARENA_ERR_NOSPACE:
+      return "ERR_NOSPACE";
+   case BUS_ARENA_ERR_NOLEASE:
+      return "ERR_NOLEASE";
+   case BUS_ARENA_ERR_CAP:
+      return "ERR_CAP";
+   case BUS_ARENA_ERR_STALE:
+      return "ERR_STALE";
+   case BUS_ARENA_ERR_NOTHOLDER:
+      return "ERR_NOTHOLDER";
+   case BUS_ARENA_ERR_STATE:
+      return "ERR_STATE";
+   default:
+      return "ERR_UNKNOWN";
+   }
+}

--- a/src/modules/bus/bus_arena.h
+++ b/src/modules/bus/bus_arena.h
@@ -1,0 +1,169 @@
+/* bus_arena.h: the host-mediated lease allocator over the shared arena region.
+ *
+ * D3 (docs/dev/EVENT_BUS_DECISIONS.md): a producer requests a lease, fills it,
+ * publishes the reference; a consumer reads in place and releases; the host
+ * tracks the lease. Payload bytes are never copied through the host — only the
+ * lease bookkeeping is host-mediated.
+ *
+ * The allocator's bookkeeping is therefore HOST-PRIVATE, exactly like the queue
+ * directory: the shared arena region holds only payload bytes, and the lease
+ * table lives in this process's own memory. A misbehaving client can corrupt
+ * arena bytes (the cooperative-arena limit of D2), but it cannot reach the lease
+ * table and so cannot forge a lease's lifetime.
+ *
+ * The lifetime model, verbatim from D3:
+ *
+ *   bus_arena_alloc            region created, refcount 1, held by the producer
+ *   bus_arena_publish to k     +k consumer refs, -1 producer ref (ownership
+ *                              transfers to the consumers)
+ *   a consumer releases        -1
+ *   bus_arena_cancel           -1 (the producer's, on an unpublished lease)
+ *   producer reap              drops the producer ref it still holds
+ *   consumer reap              drops every ref attributed to that consumer
+ *
+ * A region returns to the free pool only at refcount zero. Publishing to zero
+ * observers takes the refcount straight to zero and reclaims immediately.
+ *
+ * Two safety rules this interface enforces so a slow or dead peer cannot corrupt
+ * a live reader:
+ *
+ *   - A lease carries a GENERATION, bumped every time its slot is reused. A
+ *     consumer read or release validates the generation; a stale one is a typed
+ *     error, never a read of whatever now occupies those bytes.
+ *   - The per-client live-lease CAP is enforced synchronously at
+ *     bus_arena_alloc, before any bytes are written — not at reap, which is
+ *     heartbeat-lagging. A client at its cap is refused a new lease immediately.
+ *     The cap counts a lease against its allocating slot until the lease is
+ *     fully drained (refcount zero), not merely until it is published: this
+ *     bounds a producer's total live arena footprint and applies natural
+ *     backpressure to a producer whose consumers are not keeping up.
+ */
+#ifndef AIMEE_BUS_ARENA_H
+#define AIMEE_BUS_ARENA_H 1
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Compile-time ceilings. A slot is a client identity (0..max_slots-1); a lease
+ * is an allocation. Both are bounded so the host-private tables are fixed-size
+ * and a hostile count cannot ask for an unbounded allocation. */
+#define BUS_ARENA_MAX_SLOTS  256
+#define BUS_ARENA_MAX_LEASES 4096
+#define BUS_ARENA_SLOT_WORDS (BUS_ARENA_MAX_SLOTS / 64)
+
+typedef enum
+{
+   BUS_ARENA_OK = 0,
+   BUS_ARENA_ERR_ARG,       /* null or out-of-range argument */
+   BUS_ARENA_ERR_NOSPACE,   /* no free span large enough */
+   BUS_ARENA_ERR_NOLEASE,   /* the lease table is full */
+   BUS_ARENA_ERR_CAP,       /* the owner is at its per-client live-lease cap */
+   BUS_ARENA_ERR_STALE,     /* the generation does not match — the lease was reused */
+   BUS_ARENA_ERR_NOTHOLDER, /* the slot does not hold a consumer ref on this lease */
+   BUS_ARENA_ERR_STATE      /* the lease is not in a state this call is valid for */
+} bus_arena_result_t;
+
+/* A published reference: what the producer puts in a frame's payload_ref/len,
+ * plus the generation a consumer must present to read it. */
+typedef struct
+{
+   uint64_t offset; /* into the arena's usable bytes */
+   uint32_t len;
+   uint32_t generation;
+} bus_arena_ref_t;
+
+/* One lease. Host-private; never mapped by a client. */
+typedef struct
+{
+   uint8_t active;
+   uint8_t producer_ref;               /* 0 or 1 */
+   uint8_t owner_slot;                  /* the producer that allocated it */
+   uint32_t generation;                /* bumped on each reuse of this table slot */
+   uint64_t offset;                    /* span start in the arena */
+   uint32_t len;                       /* span length */
+   uint64_t consumer_bits[BUS_ARENA_SLOT_WORDS]; /* which slots hold a consumer ref */
+} bus_lease_t;
+
+/* A free span. Host-private free list, kept sorted and coalesced so churn does
+ * not strand the arena. */
+typedef struct
+{
+   uint64_t offset;
+   uint64_t len;
+} bus_free_span_t;
+
+typedef struct
+{
+   uint8_t *base; /* arena usable bytes (already past the region header) */
+   uint64_t size;
+   uint32_t max_slots;
+   uint32_t per_client_cap;
+
+   bus_lease_t leases[BUS_ARENA_MAX_LEASES];
+   uint32_t lease_count; /* high-water of table slots ever used */
+
+   bus_free_span_t freelist[BUS_ARENA_MAX_LEASES + 1];
+   uint32_t free_count;
+
+   uint32_t live_per_slot[BUS_ARENA_MAX_SLOTS];
+   uint64_t bytes_in_use;
+} bus_arena_t;
+
+/* Initialise over an arena region's usable bytes (from bus_arena_region_attach).
+ * per_client_cap bounds live leases per slot; max_slots bounds valid slot ids. */
+bus_arena_result_t bus_arena_init(bus_arena_t *a, uint8_t *base, uint64_t size,
+                                  uint32_t max_slots, uint32_t per_client_cap);
+
+/* Allocate a span for `owner_slot`. On success *lease_id names the lease and the
+ * refcount is 1 (the producer's). Refuses synchronously with ERR_CAP if the
+ * owner is at its cap, ERR_NOSPACE if no span fits, ERR_NOLEASE if the table is
+ * full. */
+bus_arena_result_t bus_arena_alloc(bus_arena_t *a, uint32_t owner_slot, uint32_t len,
+                                   uint32_t *lease_id);
+
+/* Writable pointer into the leased span, for the producer to fill before
+ * publishing. Valid only while the producer still holds its ref. */
+bus_arena_result_t bus_arena_fill_ptr(bus_arena_t *a, uint32_t lease_id, uint8_t **ptr);
+
+/* The reference to publish in a frame. */
+bus_arena_result_t bus_arena_ref(const bus_arena_t *a, uint32_t lease_id, bus_arena_ref_t *ref);
+
+/* Publish to `k` observer slots (each 0..max_slots-1). Adds k consumer refs and
+ * drops the producer ref. k == 0 reclaims the span immediately (nobody can read
+ * it). A slot may not appear twice. */
+bus_arena_result_t bus_arena_publish(bus_arena_t *a, uint32_t lease_id,
+                                     const uint8_t *observer_slots, uint32_t k);
+
+/* A consumer's read pointer, gated on the generation and on the slot actually
+ * holding a ref. ERR_STALE if the lease was reused; ERR_NOTHOLDER if the slot
+ * does not hold a ref. */
+bus_arena_result_t bus_arena_read_ptr(const bus_arena_t *a, uint32_t lease_id,
+                                      uint32_t generation, uint32_t consumer_slot,
+                                      const uint8_t **ptr);
+
+/* A consumer releases its ref. Generation-checked. Reclaims at refcount zero. */
+bus_arena_result_t bus_arena_release(bus_arena_t *a, uint32_t lease_id, uint32_t generation,
+                                     uint32_t consumer_slot);
+
+/* The producer cancels an allocated-but-unpublished lease (its normal error
+ * path). Drops the producer ref; reclaims at zero. */
+bus_arena_result_t bus_arena_cancel(bus_arena_t *a, uint32_t lease_id);
+
+/* Reap a producer: drop the producer ref on every lease it still owns
+ * unpublished-or-published. Published leases become orphaned-but-live and drain
+ * as consumers release; unreferenced ones are reclaimed. */
+void bus_arena_reap_producer(bus_arena_t *a, uint32_t slot);
+
+/* Reap a consumer: drop every consumer ref attributed to the slot, across all
+ * leases, reclaiming any that reach zero. Without this a dead consumer's refs
+ * would be permanently unreleasable and repeated deaths would exhaust the arena. */
+void bus_arena_reap_consumer(bus_arena_t *a, uint32_t slot);
+
+/* Observers. */
+uint32_t bus_arena_live_leases(const bus_arena_t *a, uint32_t slot);
+uint64_t bus_arena_bytes_in_use(const bus_arena_t *a);
+uint32_t bus_arena_refcount(const bus_arena_t *a, uint32_t lease_id);
+
+const char *bus_arena_result_name(bus_arena_result_t r);
+
+#endif /* AIMEE_BUS_ARENA_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -143,6 +143,9 @@ find_package(Threads REQUIRED)
 target_link_libraries(test_bus_ring PRIVATE Threads::Threads)
 aimee_add_test(test_bus_region test_bus_region.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c)
 target_include_directories(test_bus_region PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+aimee_add_test(test_bus_arena test_bus_arena.c ../modules/bus/bus_arena.c)
+target_include_directories(test_bus_arena PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+
 
 
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -216,6 +216,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-bus-wire \
                $(TESTPREFIX)/unit-test-bus-ring \
                $(TESTPREFIX)/unit-test-bus-region \
+               $(TESTPREFIX)/unit-test-bus-arena \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2553,6 +2554,17 @@ $(TESTPREFIX)/unit-test-bus-region: $(OBJDIR)/tests/test_bus_region.o \
                                     $(OBJDIR)/modules/bus/bus_region.o \
                                     $(OBJDIR)/modules/bus/bus_ring.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+# Event-bus arena lease allocator (feature tree slice 4). Host-private; no shared
+# memory of its own, no DB — it manages spans over a caller-supplied buffer.
+$(OBJDIR)/tests/test_bus_arena.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-arena: $(OBJDIR)/tests/test_bus_arena.o \
+                                   $(OBJDIR)/modules/bus/bus_arena.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+.PHONY: unit-test-bus-arena
+unit-test-bus-arena: $(TESTPREFIX)/unit-test-bus-arena
+	$<
 
 .PHONY: unit-test-bus-region
 unit-test-bus-region: $(TESTPREFIX)/unit-test-bus-region

--- a/src/tests/test_bus_arena.c
+++ b/src/tests/test_bus_arena.c
@@ -1,0 +1,351 @@
+/* test_bus_arena.c: slice 4 of the event-bus feature tree.
+ *
+ * The lease allocator's whole reason to exist is that a slow or dead peer must
+ * not corrupt a live reader, so the tests are the D3 lifecycle and its three
+ * fault-injection cases, checked as outcomes:
+ *
+ *   - the refcount lifecycle: alloc takes the producer's ref, publish transfers
+ *     it to the consumers, release drains it, and the region is reclaimed only
+ *     at zero;
+ *   - a stale generation is a typed error, never a read of reused bytes;
+ *   - the per-client cap is refused synchronously at alloc, before any bytes are
+ *     written and before any reap;
+ *   - producer reap leaves a published region live for its readers;
+ *   - consumer reap releases that consumer's refs so a dead consumer cannot
+ *     strand the arena;
+ *   - churn does not fragment the arena into uselessness.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bus_arena.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+static void must_result(bus_arena_result_t got, bus_arena_result_t want, const char *what)
+{
+   if (got != want)
+   {
+      fprintf(stderr, "FAIL: %s: expected %s, got %s\n", what, bus_arena_result_name(want),
+              bus_arena_result_name(got));
+      abort();
+   }
+}
+
+static bus_arena_t *make(uint64_t size, uint32_t max_slots, uint32_t cap)
+{
+   static bus_arena_t a; /* big struct; keep it off the stack */
+   static uint8_t *pool;
+   free(pool);
+   pool = malloc(size);
+   must(pool != NULL, "pool alloc");
+   must_result(bus_arena_init(&a, pool, size, max_slots, cap), BUS_ARENA_OK, "init");
+   return &a;
+}
+
+/* ------------------------------------------------------------------ */
+/* the refcount lifecycle                                              */
+
+static void test_lifecycle(void)
+{
+   bus_arena_t *a = make(64 * 1024, 8, 16);
+
+   uint32_t id;
+   must_result(bus_arena_alloc(a, 1, 100, &id), BUS_ARENA_OK, "alloc");
+   must(bus_arena_refcount(a, id) == 1, "alloc takes the producer's ref");
+   must(bus_arena_live_leases(a, 1) == 1, "one live lease for the owner");
+
+   /* Fill through the writable pointer, then publish to two observers. */
+   uint8_t *w;
+   must_result(bus_arena_fill_ptr(a, id, &w), BUS_ARENA_OK, "fill ptr");
+   memset(w, 0xab, 100);
+
+   bus_arena_ref_t ref;
+   must_result(bus_arena_ref(a, id, &ref), BUS_ARENA_OK, "ref");
+
+   uint8_t observers[2] = {2, 3};
+   must_result(bus_arena_publish(a, id, observers, 2), BUS_ARENA_OK, "publish to 2");
+   must(bus_arena_refcount(a, id) == 2, "publish transfers producer ref to 2 consumers");
+
+   /* The producer's fill pointer is no longer valid after publish. */
+   must_result(bus_arena_fill_ptr(a, id, &w), BUS_ARENA_ERR_STATE,
+               "fill refused after publish");
+
+   /* Each consumer reads in place, gated on the generation. */
+   const uint8_t *r2, *r3;
+   must_result(bus_arena_read_ptr(a, id, ref.generation, 2, &r2), BUS_ARENA_OK, "consumer 2 read");
+   must_result(bus_arena_read_ptr(a, id, ref.generation, 3, &r3), BUS_ARENA_OK, "consumer 3 read");
+   must(r2[0] == 0xab && r3[99] == 0xab, "consumers see the producer's bytes");
+
+   /* A slot that was not an observer cannot read. */
+   const uint8_t *r4;
+   must_result(bus_arena_read_ptr(a, id, ref.generation, 4, &r4), BUS_ARENA_ERR_NOTHOLDER,
+               "non-observer cannot read");
+
+   must_result(bus_arena_release(a, id, ref.generation, 2), BUS_ARENA_OK, "consumer 2 releases");
+   must(bus_arena_refcount(a, id) == 1, "one consumer left");
+   must_result(bus_arena_release(a, id, ref.generation, 3), BUS_ARENA_OK, "consumer 3 releases");
+   must(bus_arena_refcount(a, id) == 0, "region reclaimed at zero");
+   must(bus_arena_live_leases(a, 1) == 0, "owner's live count back to zero");
+   must(bus_arena_bytes_in_use(a) == 0, "arena empty");
+
+   /* Publish to zero observers reclaims immediately — nobody can read it. */
+   must_result(bus_arena_alloc(a, 1, 50, &id), BUS_ARENA_OK, "alloc again");
+   must_result(bus_arena_publish(a, id, NULL, 0), BUS_ARENA_OK, "publish to nobody");
+   must(bus_arena_refcount(a, id) == 0, "zero-observer publish reclaims");
+
+   /* Cancel is the producer's unpublished error path. */
+   must_result(bus_arena_alloc(a, 1, 50, &id), BUS_ARENA_OK, "alloc for cancel");
+   must_result(bus_arena_cancel(a, id), BUS_ARENA_OK, "cancel");
+   must(bus_arena_refcount(a, id) == 0, "cancel drops the producer ref");
+   must(bus_arena_bytes_in_use(a) == 0, "cancelled lease freed");
+
+   printf("  lifecycle: alloc->publish->release, zero-observer, cancel\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* stale generation                                                    */
+
+static void test_stale_generation(void)
+{
+   bus_arena_t *a = make(64 * 1024, 8, 16);
+
+   uint32_t id;
+   must_result(bus_arena_alloc(a, 1, 64, &id), BUS_ARENA_OK, "alloc");
+   bus_arena_ref_t ref;
+   must_result(bus_arena_ref(a, id, &ref), BUS_ARENA_OK, "ref");
+   uint8_t obs = 2;
+   must_result(bus_arena_publish(a, id, &obs, 1), BUS_ARENA_OK, "publish");
+   uint32_t old_gen = ref.generation;
+
+   /* Consumer releases; the lease slot is now free and will be reused. */
+   must_result(bus_arena_release(a, id, old_gen, 2), BUS_ARENA_OK, "release");
+
+   /* Reuse the same table slot for a new lease — it gets a fresh generation. */
+   uint32_t id2;
+   must_result(bus_arena_alloc(a, 1, 64, &id2), BUS_ARENA_OK, "realloc");
+   must(id2 == id, "same table slot reused");
+   bus_arena_ref_t ref2;
+   must_result(bus_arena_ref(a, id2, &ref2), BUS_ARENA_OK, "ref2");
+   must(ref2.generation != old_gen, "reuse presents a fresh generation");
+
+   /* A reader still holding the old generation must be refused, not handed the
+    * new tenant's bytes. */
+   uint8_t obs2 = 3;
+   must_result(bus_arena_publish(a, id2, &obs2, 1), BUS_ARENA_OK, "publish2");
+   const uint8_t *p;
+   must_result(bus_arena_read_ptr(a, id2, old_gen, 3, &p), BUS_ARENA_ERR_STALE,
+               "stale generation read is refused");
+   must_result(bus_arena_release(a, id2, old_gen, 3), BUS_ARENA_ERR_STALE,
+               "stale generation release is refused");
+
+   printf("  stale generation: a reused lease refuses the old generation\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* per-client cap, synchronous at alloc                                */
+
+static void test_cap_synchronous(void)
+{
+   const uint32_t cap = 3;
+   bus_arena_t *a = make(64 * 1024, 8, cap);
+
+   uint32_t ids[3];
+   for (uint32_t i = 0; i < cap; i++)
+      must_result(bus_arena_alloc(a, 5, 32, &ids[i]), BUS_ARENA_OK, "alloc up to cap");
+
+   /* At the cap the very next alloc is refused immediately — no reap, no
+    * heartbeat, before any byte is written. */
+   uint32_t over;
+   must_result(bus_arena_alloc(a, 5, 32, &over), BUS_ARENA_ERR_CAP,
+               "alloc past the cap is refused synchronously");
+
+   /* Another slot is unaffected — the cap is per client. */
+   uint32_t other;
+   must_result(bus_arena_alloc(a, 6, 32, &other), BUS_ARENA_OK, "a different slot is unaffected");
+
+   /* Freeing one reopens a slot for the capped client. */
+   must_result(bus_arena_cancel(a, ids[0]), BUS_ARENA_OK, "free one");
+   must_result(bus_arena_alloc(a, 5, 32, &over), BUS_ARENA_OK, "capped client can alloc again");
+
+   printf("  cap: refused synchronously at alloc, per client, reopens on free\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* fault injection                                                     */
+
+/* (a) reap a producer while a consumer is mid-read: the region must stay live
+ *     on intact bytes until the reader releases. */
+static void test_reap_producer_with_reader(void)
+{
+   bus_arena_t *a = make(64 * 1024, 8, 16);
+
+   uint32_t id;
+   must_result(bus_arena_alloc(a, 1, 128, &id), BUS_ARENA_OK, "alloc");
+   uint8_t *w;
+   must_result(bus_arena_fill_ptr(a, id, &w), BUS_ARENA_OK, "fill");
+   for (int i = 0; i < 128; i++)
+      w[i] = (uint8_t)i;
+   bus_arena_ref_t ref;
+   must_result(bus_arena_ref(a, id, &ref), BUS_ARENA_OK, "ref");
+   uint8_t obs = 2;
+   must_result(bus_arena_publish(a, id, &obs, 1), BUS_ARENA_OK, "publish to consumer 2");
+
+   /* The producer (slot 1) dies. Its ref is already gone after publish, but reap
+    * must not disturb the consumer's live reference. */
+   bus_arena_reap_producer(a, 1);
+   must(bus_arena_refcount(a, id) == 1, "region stays live for the reader after producer reap");
+
+   const uint8_t *p;
+   must_result(bus_arena_read_ptr(a, id, ref.generation, 2, &p), BUS_ARENA_OK,
+               "reader still reads after producer reap");
+   for (int i = 0; i < 128; i++)
+      must(p[i] == (uint8_t)i, "bytes intact after producer reap");
+
+   must_result(bus_arena_release(a, id, ref.generation, 2), BUS_ARENA_OK, "reader releases");
+   must(bus_arena_refcount(a, id) == 0, "reclaimed once the reader is done");
+
+   /* Reap a producer that still holds an UNPUBLISHED lease: it is dropped. */
+   must_result(bus_arena_alloc(a, 1, 64, &id), BUS_ARENA_OK, "alloc unpublished");
+   bus_arena_reap_producer(a, 1);
+   must(bus_arena_refcount(a, id) == 0, "unpublished lease dropped on producer reap");
+
+   printf("  reap producer: a published region stays live for its reader\n");
+}
+
+/* (b) a consumer dies without releasing: its refs must be dropped so the arena
+ *     is recovered, not stranded. */
+static void test_reap_consumer_recovers(void)
+{
+   const uint64_t size = 8192;
+   bus_arena_t *a = make(size, 8, 64);
+
+   /* Fill the arena with leases all published to a consumer that then dies. */
+   uint32_t ids[16];
+   uint32_t n = 0;
+   uint8_t obs = 2;
+   for (; n < 16; n++)
+   {
+      if (bus_arena_alloc(a, 1, 256, &ids[n]) != BUS_ARENA_OK)
+         break;
+      must_result(bus_arena_publish(a, ids[n], &obs, 1), BUS_ARENA_OK, "publish to consumer 2");
+   }
+   must(n > 0, "some leases allocated");
+   must(bus_arena_bytes_in_use(a) > 0, "arena in use");
+
+   /* Consumer 2 dies without releasing anything. */
+   bus_arena_reap_consumer(a, 2);
+   must(bus_arena_bytes_in_use(a) == 0, "consumer reap recovers all the arena");
+   for (uint32_t i = 0; i < n; i++)
+      must(bus_arena_refcount(a, ids[i]) == 0, "every lease reclaimed");
+
+   /* And the recovered arena is fully usable again — repeated consumer deaths do
+    * not exhaust it. */
+   uint32_t big;
+   must_result(bus_arena_alloc(a, 1, 256, &big), BUS_ARENA_OK, "arena usable after reap");
+
+   printf("  reap consumer: a dead consumer's refs are dropped, arena recovered\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* fragmentation                                                       */
+
+static void test_no_fragmentation(void)
+{
+   const uint64_t size = 16384;
+   bus_arena_t *a = make(size, 8, 4096);
+
+   /* Alloc many small leases, free every other one, free the rest — coalescing
+    * must return the arena to a single span so a near-full alloc succeeds. */
+   uint32_t ids[32];
+   uint32_t n = 0;
+   for (; n < 32; n++)
+      if (bus_arena_alloc(a, 1, 256, &ids[n]) != BUS_ARENA_OK)
+         break;
+   must(n >= 8, "several leases fit");
+
+   for (uint32_t i = 0; i < n; i += 2)
+      must_result(bus_arena_cancel(a, ids[i]), BUS_ARENA_OK, "free evens");
+   for (uint32_t i = 1; i < n; i += 2)
+      must_result(bus_arena_cancel(a, ids[i]), BUS_ARENA_OK, "free odds");
+
+   must(bus_arena_bytes_in_use(a) == 0, "all freed");
+
+   /* A single allocation of most of the arena must now succeed — if the free
+    * list had not coalesced, it would be shattered into 256-byte holes. */
+   uint32_t whole;
+   must_result(bus_arena_alloc(a, 1, (uint32_t)(size - 256), &whole), BUS_ARENA_OK,
+               "large alloc succeeds after churn (arena coalesced)");
+
+   printf("  fragmentation: churn coalesces back to a usable whole\n");
+}
+
+/* Publishing to a list with a duplicate slot must be refused, and must leave the
+ * lease untouched — the refcount cannot silently be one short of the claim. */
+static void test_duplicate_observer_refused(void)
+{
+   bus_arena_t *a = make(64 * 1024, 8, 16);
+   uint32_t id;
+   must_result(bus_arena_alloc(a, 1, 64, &id), BUS_ARENA_OK, "alloc");
+   uint8_t dup[3] = {2, 3, 2};
+   must_result(bus_arena_publish(a, id, dup, 3), BUS_ARENA_ERR_ARG, "duplicate observer refused");
+   /* The lease is untouched: still the producer's, publishable cleanly. */
+   must(bus_arena_refcount(a, id) == 1, "refused publish left the producer ref");
+   uint8_t ok[2] = {2, 3};
+   must_result(bus_arena_publish(a, id, ok, 2), BUS_ARENA_OK, "clean publish afterwards");
+   must(bus_arena_refcount(a, id) == 2, "refcount matches the two distinct observers");
+   printf("  duplicate observer: refused, lease left intact\n");
+}
+
+/* Drive the lease table and the free list near their bounds with an adversarial
+ * alternating free order, so a free-list overflow (a heap smash) would surface
+ * under ASAN rather than only at 4096 leases in production. */
+static void test_capacity_stress(void)
+{
+   const uint32_t slots = 128;
+   /* Enough arena for many small leases; enough table entries to matter. */
+   bus_arena_t *a = make(1u << 20, slots, BUS_ARENA_MAX_LEASES);
+
+   uint32_t ids[2048];
+   uint32_t n = 0;
+   for (; n < 2048; n++)
+      if (bus_arena_alloc(a, n % slots, 64, &ids[n]) != BUS_ARENA_OK)
+         break;
+   must(n >= 1024, "many leases allocated");
+
+   /* Free every other one first — maximal fragmentation, most free spans. */
+   for (uint32_t i = 0; i < n; i += 2)
+      must_result(bus_arena_cancel(a, ids[i]), BUS_ARENA_OK, "free evens");
+   /* Then the rest, which must coalesce everything back. */
+   for (uint32_t i = 1; i < n; i += 2)
+      must_result(bus_arena_cancel(a, ids[i]), BUS_ARENA_OK, "free odds");
+
+   must(bus_arena_bytes_in_use(a) == 0, "all freed after adversarial churn");
+   uint32_t whole;
+   must_result(bus_arena_alloc(a, 0, (uint32_t)((1u << 20) - 64), &whole), BUS_ARENA_OK,
+               "arena coalesced back to a single usable span");
+   printf("  capacity stress: %u leases, alternating free, no overflow\n", n);
+}
+
+int main(void)
+{
+   printf("test_bus_arena:\n");
+   test_lifecycle();
+   test_stale_generation();
+   test_cap_synchronous();
+   test_duplicate_observer_refused();
+   test_reap_producer_with_reader();
+   test_reap_consumer_recovers();
+   test_no_fragmentation();
+   test_capacity_stress();
+   printf("test_bus_arena: OK\n");
+   return 0;
+}


### PR DESCRIPTION
Fourth slice of the event-bus feature tree. Self-reviewed (roundtable paused per operator direction while the server panel is only partly working).

## What lands

`bus_arena.{c,h}` — the D3 lease allocator over the shared arena region. Bookkeeping is **host-private** like the queue directory: the arena holds only payload bytes, so a misbehaving client can corrupt bytes (the cooperative-arena limit of D2) but cannot reach the lease table and forge a lifetime.

Full D3 refcount lifecycle: alloc takes the producer's ref; publish to k observers adds k consumer refs and drops the producer ref (zero observers reclaims immediately); release drains; cancel is the producer's unpublished path; producer reap leaves a published region live for its readers; consumer reap drops every ref attributed to that slot so a dead consumer can't strand the arena. Reclaimed only at refcount zero.

Safety: a generation bumped on each reuse makes a stale read/release a typed error, not a read of the new tenant's bytes; the per-client cap is enforced synchronously at alloc, counting a lease against its owner until fully drained (producer backpressure). First-fit with coalescing on every free; the free-list bound (MAX_LEASES + 1) is argued and exercised by a 2048-lease adversarial churn under ASAN.

## Self-review found and fixed two real defects

- **publish did not detect a duplicate slot within the observer list** — an idempotent bit-set would have left the refcount one short of the claim. Now rejected via a seen-set.
- **a length near UINT32_MAX aligned past it and truncated `l->len` to 0** — now bounded by the arena size, so nothing that large ever fits.

## Verification (normal + ASAN/UBSAN)

Lifecycle; stale-generation refusal; the synchronous per-client cap; duplicate-observer refusal; and the three D3 fault-injection cases — reap-producer-with-reader-in-flight (reader completes on intact bytes), consumer-reap-recovers-the-arena, coalescing under churn — plus the 2048-lease capacity stress.

No shipping binary links the bus (D7). Depends on slices 1–3 (merged).