### PR TITLE
Converge role eligibility on one rule: declared role or 'all'

### DIFF
--- a/src/agent_tier_lint.c
+++ b/src/agent_tier_lint.c
@@ -195,12 +195,14 @@ static int price_dominates_across_reachable_bands(const agent_t *a, const agent_
 /* Could these two agents ever be candidates for the SAME route? Comparing tiers
  * across agents that never compete is a false positive: routing never chooses
  * between them, so "routing prefers the more expensive model" would be untrue
- * and the advice to re-tier them misleading. Substitutability here means sharing
- * at least one role — including the default exec roles, which agent_supports_role
- * grants to every agent regardless of its declared list. */
+ * and the advice to re-tier them misleading.
+ *
+ * Selection is declared-role membership only (agent_has_role: the role itself or
+ * the `all` wildcard) — there is no exec-role fallback, so two agents compete iff
+ * they share a declared role. exec_roles[] governs tool exposure at execution
+ * time, not who is picked, so it no longer creates route competition. */
 static int agents_compete_for_a_role(const agent_t *a, const agent_t *b)
 {
-   /* Declared roles, either direction, plus the "all" wildcard. */
    for (int i = 0; i < a->role_count; i++)
    {
       const char *role = a->roles[i];
@@ -211,46 +213,6 @@ static int agents_compete_for_a_role(const agent_t *a, const agent_t *b)
    {
       const char *role = b->roles[i];
       if (role[0] && (strcmp(role, "all") == 0 || agent_has_role(a, role)))
-         return 1;
-   }
-
-   /* IMPLICIT overlap. agent_supports_role() also admits any agent for an exec
-    * role, so two agents with entirely disjoint declared roles still compete for
-    * every exec role both accept. Iterating only declared roles missed this and
-    * suppressed real conflicts: an agent declaring "explain" and one declaring
-    * "summarize" are both routable for review/code/test.
-    *
-    * The default exec set is internal to agent_config.c, so probe through the
-    * public predicate with the roles actually in use rather than duplicating the
-    * table here — a copy would silently drift. */
-   static const char *const probe_roles[] = {
-       /* Canonical roles only — `test`/`implement` are aliases and were removed
-        * from default_exec_roles, so probing them here would never match. */
-       "deploy", "validate", "diagnose",   "execute",    "review",
-       "code",   "refactor", "draft",      "explain",    "summarize",
-       "format", "search",   "continuity", "beat-check", NULL,
-   };
-   for (int i = 0; probe_roles[i]; i++)
-   {
-      if ((agent_has_role(a, probe_roles[i]) || agent_is_exec_role(a, probe_roles[i])) &&
-          (agent_has_role(b, probe_roles[i]) || agent_is_exec_role(b, probe_roles[i])))
-         return 1;
-   }
-
-   /* CUSTOM exec roles. The probe list above covers the built-in universe, but
-    * exec_roles[] is operator-configurable, so a shared "custom-migration" would
-    * otherwise be missed entirely — both agents are routable for it while this
-    * returned false. Compare the configured lists directly, in both directions. */
-   for (int i = 0; i < a->exec_role_count; i++)
-   {
-      if (a->exec_roles[i][0] &&
-          (agent_has_role(b, a->exec_roles[i]) || agent_is_exec_role(b, a->exec_roles[i])))
-         return 1;
-   }
-   for (int i = 0; i < b->exec_role_count; i++)
-   {
-      if (b->exec_roles[i][0] &&
-          (agent_has_role(a, b->exec_roles[i]) || agent_is_exec_role(a, b->exec_roles[i])))
          return 1;
    }
    return 0;

--- a/src/modules/delegates/delegate_role.c
+++ b/src/modules/delegates/delegate_role.c
@@ -25,18 +25,9 @@ static int delegate_agent_supports_role(const agent_t *agent, const char *role)
 {
    if (!agent || !role || !role[0])
       return 0;
-   for (int i = 0; i < agent->role_count; i++)
-   {
-      /* "all" is a wildcard: the agent serves every role. */
-      if (strcmp(agent->roles[i], "all") == 0 || strcmp(agent->roles[i], role) == 0)
-         return 1;
-   }
-   for (int i = 0; i < agent->exec_role_count; i++)
-   {
-      if (strcmp(agent->exec_roles[i], role) == 0)
-         return 1;
-   }
-   return 0;
+   /* Single source of truth for role eligibility: has the `all` wildcard or the
+    * role itself. No exec-role fallback (see agent_has_role / agent_supports_role). */
+   return agent_has_role(agent, role);
 }
 
 /* Roles deleted in the persona-vs-role cull. They are named here so an operator

--- a/src/modules/delegates/delegate_routing.c
+++ b/src/modules/delegates/delegate_routing.c
@@ -157,7 +157,7 @@ int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
    for (int i = 0; i < cfg->agent_count; i++)
    {
       agent_t *ag = &cfg->agents[i];
-      if (ag->enabled && (agent_has_role(ag, role) || agent_is_exec_role(ag, role)))
+      if (ag->enabled && agent_has_role(ag, role))
          role_candidates++;
    }
    if (role_candidates == 0)
@@ -176,7 +176,7 @@ int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
       for (int i = 0; i < cfg->agent_count; i++)
       {
          agent_t *ag = &cfg->agents[i];
-         if (!ag->enabled || (!agent_has_role(ag, role) && !agent_is_exec_role(ag, role)))
+         if (!ag->enabled || !agent_has_role(ag, role))
             continue;
          if (agent_meets_filter(ag, required_caps, min_context, drop_deprecated))
             kept_full++;
@@ -201,7 +201,7 @@ int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
       agent_t *ag = &cfg->agents[i];
       if (!ag->enabled)
          continue;
-      if (!agent_has_role(ag, role) && !agent_is_exec_role(ag, role))
+      if (!agent_has_role(ag, role))
          continue;
       if (!agent_meets_filter(ag, eff, min_context, drop_deprecated))
       {
@@ -241,7 +241,7 @@ agent_t *delegate_route_by_provider(agent_config_t *cfg, const char *role, const
       if (!ag->enabled || strcmp(ag->provider, provider) != 0 ||
           !agent_is_available_for_routing(ag))
          continue;
-      if (role && !agent_has_role(ag, role) && !agent_is_exec_role(ag, role))
+      if (role && !agent_has_role(ag, role))
          continue;
       if (!best || ag->cost_tier < best->cost_tier)
       {
@@ -267,7 +267,7 @@ int delegate_max_cost_tier(agent_config_t *cfg, const char *role)
       agent_t *ag = &cfg->agents[i];
       if (!ag->enabled || !agent_is_available_for_routing(ag))
          continue;
-      if (role && !agent_has_role(ag, role) && !agent_is_exec_role(ag, role))
+      if (role && !agent_has_role(ag, role))
          continue;
       if (ag->cost_tier > max_tier)
          max_tier = ag->cost_tier;
@@ -403,7 +403,7 @@ int delegate_apply_route_overrides(agent_config_t *cfg, const char *role, const 
          route_err(errbuf, errbuf_sz, "%s", emsg, NULL);
          return -1;
       }
-      if (role && role[0] && !agent_has_role(selected, role) && !agent_is_exec_role(selected, role))
+      if (role && role[0] && !agent_has_role(selected, role))
       {
          route_err(errbuf, errbuf_sz, "agent '%s' cannot handle role '%s'", via_name, role);
          return -1;

--- a/src/modules/roundtable/delegate_ensemble.c
+++ b/src/modules/roundtable/delegate_ensemble.c
@@ -1327,7 +1327,10 @@ int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag)
    (void)cfg;
    if (!ag || !ag->enabled || !ag->name[0])
       return 0;
-   if (!agent_has_role(ag, "review") && !agent_is_exec_role(ag, "review"))
+   /* A review seat requires the agent to DECLARE the review role (or `all`); an
+    * implementation-only delegate is never seated on a review panel by exec-role
+    * default. Single rule, shared with routing. */
+   if (!agent_has_role(ag, "review"))
       return 0;
    if (ag->primary_only)
       return 0;

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -81,7 +81,9 @@ int agent_rc_should_try_another(int rc, const char *error)
 
 static int agent_supports_delegate_role(const agent_t *ag, const char *role)
 {
-   return ag && role && (agent_has_role(ag, role) || agent_is_exec_role(ag, role));
+   /* Role eligibility is declaration-only: `all` or the role itself. No exec-role
+    * fallback (see agent_has_role). */
+   return ag && role && agent_has_role(ag, role);
 }
 
 static int agent_is_named_in_fallback_chain(const agent_config_t *cfg, const char *name)

--- a/src/server/agent_route.c
+++ b/src/server/agent_route.c
@@ -55,18 +55,15 @@ int agent_supports_persona(const agent_t *agent, const char *persona)
    return 0;
 }
 
+/* Selection eligibility is exactly role membership: an agent serves `role` iff
+ * it declares the `all` wildcard or the role itself (agent_has_role). There is
+ * deliberately NO exec-role fallback here — a role an agent did not declare is a
+ * role it is not selected for. This is the single rule every routing, fallback,
+ * and panel-seating path uses; agent_is_exec_role governs only tool exposure at
+ * execution time, not who is picked. */
 static int agent_supports_role(const agent_t *agent, const char *role)
 {
-   if (agent_has_role(agent, role))
-      return 1;
-
-   /* Execution roles can be handled by any enabled agent.  The tools_enabled
-    * flag controls whether tool use is offered during execution, not whether
-    * the agent is eligible for selection. */
-   if (agent_is_exec_role(agent, role))
-      return 1;
-
-   return 0;
+   return agent_has_role(agent, role);
 }
 
 static int agent_command_on_path(const char *cmd)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -391,8 +391,13 @@ static void test_agent_route(void)
    cfg.agents[1].cost_tier = 1;
    cfg.agents[1].enabled = 1;
    cfg.agents[1].tools_enabled = 1;
-   strcpy(cfg.agents[1].exec_roles[0], "custom_exec");
-   cfg.agents[1].exec_role_count = 1;
+   /* Selection is declared-role only: a role must appear in `roles` (or `all`).
+    * exec_roles govern tool exposure, not who is routed, so a role-less agent is
+    * routable for nothing and a role reaches only the agents that declare it. */
+   strcpy(cfg.agents[0].roles[0], "execute");
+   cfg.agents[0].role_count = 1;
+   strcpy(cfg.agents[1].roles[0], "custom_exec");
+   cfg.agents[1].role_count = 1;
    assert(agent_route(&cfg, "execute") == &cfg.agents[0]);
    assert(agent_route(&cfg, "custom_exec") == &cfg.agents[1]);
    assert(agent_route(&cfg, "no_role") == NULL);

--- a/src/tests/test_agent_caps.c
+++ b/src/tests/test_agent_caps.c
@@ -605,21 +605,19 @@ void test_primary_turn_reaches_default_above_min_tier(void)
    assert(agent_route(&cfg, "review") == &cfg.agents[1]);
    cfg.agents[0].enabled = 1;
 
-   /* A default that does not serve the role is not a usable seat either. This
-    * must be checked with a NON-exec role: agent_supports_role() waves any agent
-    * through for the 18 default exec roles (deploy/validate/test/diagnose/
-    * execute/review/code/refactor/draft/implement/...), so a `roles` list is not
-    * consulted at all for those. "explain" is not among them. */
+   /* A default that does not serve the role is not a usable seat either.
+    * Selection is declared-role only: an agent is routable for a role solely
+    * when its `roles` list names that role (or `all`). */
    strcpy(cfg.agents[0].roles[0], "review");
    strcpy(cfg.agents[1].roles[0], "explain");
    assert(agent_route(&cfg, "explain") == &cfg.agents[1]);
 
-   /* Guard rail for the above: for an EXEC role the default is reachable even
-    * though its roles list names something else, because the exec-role fallback
-    * bypasses role filtering entirely. Documented so a future role split does
-    * not assume `roles` gates these. */
+   /* No exec-role fallback: with the default's roles naming something other than
+    * `review`, and no peer declaring `review`, the role is unroutable — the
+    * default is NOT waved through just because `review` was once a default exec
+    * role. This is the behaviour the $random/gemma4 fix depends on. */
    strcpy(cfg.agents[0].roles[0], "explain");
-   assert(agent_route(&cfg, "review") == &cfg.agents[0]);
+   assert(agent_route(&cfg, "review") == NULL);
 
    /* Session affinity outranks the default: a tmux agent holds a STATEFUL
     * session, so a primary turn must not be yanked to an HTTP default and
@@ -1519,17 +1517,17 @@ void test_declared_roles_route_precisely(void)
    assert(agent_route_with_caps(&cfg, "code_simple", &sys_cfg, 0, 0) == &cfg.agents[0]);
    assert(agent_route_with_caps(&cfg, "code_complex", &sys_cfg, 0, 0) == &cfg.agents[1]);
 
-   /* A built-in exec role neither declares is served by NEITHER: an explicit
-    * exec_roles list replaces the permissive default set rather than adding to
-    * it. This is the half an earlier claim got wrong. */
-   assert(agent_is_exec_role(&cfg.agents[0], "review") == 0);
+   /* A role neither agent declares is served by NEITHER. Routing is declared-role
+    * only, so a built-in exec role is no more privileged than any other name. */
    assert(agent_route(&cfg, "review") == NULL);
 
-   /* Clearing the explicit list restores the permissive DEFAULT, which is what
-    * the earlier claim actually described — a default, not a broken gate. */
+   /* Exec-role membership does NOT grant routing. `review` remains a default exec
+    * role (it still governs tool exposure), so agent_is_exec_role reports it once
+    * the explicit exec list is cleared — but that never makes the agent a review
+    * SEAT. Selection needs the `review` role (or `all`) in `roles`. */
    cfg.agents[0].exec_role_count = 0;
    assert(agent_is_exec_role(&cfg.agents[0], "review") == 1);
-   assert(agent_route(&cfg, "review") == &cfg.agents[0]);
+   assert(agent_route(&cfg, "review") == NULL);
 
    /* And the "all" wildcard in `roles` re-opens everything, so a fine-grained
     * deployment must avoid it. */

--- a/src/tests/test_agent_tier_lint.c
+++ b/src/tests/test_agent_tier_lint.c
@@ -458,24 +458,27 @@ static void test_cached_price_axis(void)
    printf("  PASS: test_cached_price_axis\n");
 }
 
-/* Two agents with entirely disjoint DECLARED roles still compete through the
- * default exec-role set, which agent_supports_role() grants to every agent.
- * Iterating declared roles alone missed that and suppressed real conflicts. */
-static void test_implicit_exec_role_competition_is_detected(void)
+/* Two agents with entirely disjoint DECLARED roles do NOT compete for any route.
+ * Selection is declared-role only — there is no exec-role fallback that would
+ * make every agent routable for review/code/test alike — so pricing them at
+ * different tiers is not a conflict: routing never chooses between them. */
+static void test_disjoint_declared_roles_do_not_compete(void)
 {
    agent_config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
    add_agent(&cfg, "dear_at_tier0", "testvendor", "dear", 0);
    add_agent(&cfg, "cheap_at_tier1", "testvendor", "cheap", 1);
-   /* Disjoint declared roles, but NO exec_roles override -> both inherit the
-    * default exec set and are routable for review/code/test alike. */
    snprintf(cfg.agents[0].roles[0], sizeof(cfg.agents[0].roles[0]), "%s", "explain");
    snprintf(cfg.agents[1].roles[0], sizeof(cfg.agents[1].roles[0]), "%s", "summarize");
 
    agent_tier_conflict_t out[AGENT_TIER_LINT_MAX];
+   assert(agent_tier_price_conflicts(&cfg, out, AGENT_TIER_LINT_MAX) == 0);
+
+   /* A shared declared role brings them back into competition. */
+   snprintf(cfg.agents[1].roles[0], sizeof(cfg.agents[1].roles[0]), "%s", "explain");
    assert(agent_tier_price_conflicts(&cfg, out, AGENT_TIER_LINT_MAX) == 1);
 
-   printf("  PASS: test_implicit_exec_role_competition_is_detected\n");
+   printf("  PASS: test_disjoint_declared_roles_do_not_compete\n");
 }
 
 /* Context-band pricing. Several providers charge more once a request exceeds a
@@ -640,10 +643,11 @@ static void test_unreachable_band_does_not_suppress_valid_conflict(void)
    printf("  PASS: test_unreachable_band_does_not_suppress_valid_conflict\n");
 }
 
-/* Custom exec roles are operator-configurable and outside the built-in probe
- * list, so two agents sharing only such a role would otherwise be judged
- * non-competing and their conflict suppressed. */
-static void test_custom_exec_role_competition_is_detected(void)
+/* exec_roles govern tool exposure at execution time, not selection: two agents
+ * that share only an exec role (custom or built-in) but declare disjoint roles
+ * are never routed against each other, so pricing them at different tiers is not
+ * a conflict. A shared exec role alone must NOT be reported. */
+static void test_shared_exec_role_alone_does_not_compete(void)
 {
    agent_config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
@@ -662,9 +666,9 @@ static void test_custom_exec_role_competition_is_detected(void)
    cfg.agents[1].exec_role_count = 1;
 
    agent_tier_conflict_t out[AGENT_TIER_LINT_MAX];
-   assert(agent_tier_price_conflicts(&cfg, out, AGENT_TIER_LINT_MAX) == 1);
+   assert(agent_tier_price_conflicts(&cfg, out, AGENT_TIER_LINT_MAX) == 0);
 
-   printf("  PASS: test_custom_exec_role_competition_is_detected\n");
+   printf("  PASS: test_shared_exec_role_alone_does_not_compete\n");
 }
 
 int main(void)
@@ -680,7 +684,7 @@ int main(void)
    test_equal_axis_dominance_is_flagged();
    test_partial_price_data_is_not_compared();
    test_non_competing_roles_not_flagged();
-   test_implicit_exec_role_competition_is_detected();
+   test_disjoint_declared_roles_do_not_compete();
    test_operator_price_override_wins();
    test_price_override_per_axis();
    test_cached_price_axis();
@@ -691,7 +695,7 @@ int main(void)
    test_unreachable_band_is_ignored();
    test_ordering_that_flips_back_is_not_flagged();
    test_unreachable_band_does_not_suppress_valid_conflict();
-   test_custom_exec_role_competition_is_detected();
+   test_shared_exec_role_alone_does_not_compete();
    test_guards();
    printf("agent_tier_lint: all tests passed\n");
    return 0;

--- a/src/tests/test_delegate_role.c
+++ b/src/tests/test_delegate_role.c
@@ -7,6 +7,19 @@
 #include <stdlib.h>   /* mkdtemp */
 #include <sys/stat.h> /* mkdir */
 
+/* delegate_agent_supports_role() now defers to the canonical agent_has_role()
+ * (declared-role membership, `all` wildcard included). Stub it here — the real
+ * definition lives in agent_route.o, which this unit test does not link. */
+int agent_has_role(const agent_t *agent, const char *role)
+{
+   if (!agent || !role || !role[0])
+      return 0;
+   for (int i = 0; i < agent->role_count; i++)
+      if (strcmp(agent->roles[i], "all") == 0 || strcmp(agent->roles[i], role) == 0)
+         return 1;
+   return 0;
+}
+
 /* role_template_max_turns() (reached via delegate_default_max_turns_for_role) reads
  * <config_default_dir()>/role_templates/<canonical-role>.md and parses `max_turns:`
  * from its frontmatter, returning -1 when the file is absent. Stub config_default_dir

--- a/src/tests/test_roundtable_seat_resolve.c
+++ b/src/tests/test_roundtable_seat_resolve.c
@@ -43,13 +43,11 @@ int main(void)
    mk_agent(&cfg.agents[1], "agentB", "review", 1);
    mk_agent(&cfg.agents[2], "agentC", "review", 1);
    mk_agent(&cfg.agents[3], "agentD", "review", 0); /* disabled */
-   /* agentE serves only "code": an EXPLICIT exec_roles list omitting "review" is
-    * what actually makes an agent non-review-capable (an empty exec list falls back
-    * to the default roles, which include "review"). This mirrors a specialized
-    * agent like gpu-mid that must never be seated on a review panel. */
+   /* agentE declares only the "code" role and NO explicit exec_roles. Because
+    * `review` is not a default exec role, that alone makes it non-review-capable:
+    * an implementation-only delegate (e.g. a local synth model) is never seated on
+    * a review panel just for leaving exec_roles empty. */
    mk_agent(&cfg.agents[4], "agentE", "code", 1);
-   snprintf(cfg.agents[4].exec_roles[0], sizeof cfg.agents[4].exec_roles[0], "code");
-   cfg.agents[4].exec_role_count = 1;
    cfg.agent_count = 5;
 
    int idx = -1;


### PR DESCRIPTION
## Problem

An agent could be selected for a role two unrelated ways: by **declaring** the role (or `all`), **or** by the permissive default exec-role set that applies to any agent with no explicit `exec_roles`. That default set includes `review`.

So an implementation-only delegate — e.g. the local synth model, `roles: [code, draft, refactor, validate, execute, ...]`, no `exec_roles` and no `review` role — was silently eligible to be seated on a **merge-gate roundtable panel**. That is the concrete `$random` bug: a random review seat could pick a model that must never review.

The same `agent_has_role(x,r) || agent_is_exec_role(x,r)` pattern was duplicated across six-plus call sites (`agent_route`, `delegate_routing` ×6, `delegate_ensemble`, `agent_fallback`, `agent_tier_lint`), and two `*_supports_role` wrappers that didn't even agree with each other — `delegate_role.c`'s version used explicit `exec_roles` only, the router's used the default set.

## Change

One rule, one place: **an agent serves a role iff it declares that role or the `all` wildcard** (`agent_has_role`). No exec-role fallback in selection.

`exec_roles[]` still governs **tool exposure** at execution time (`agent_runtime` / `agent_is_exec_role`) — unchanged. It simply no longer decides *who is picked*.

Every selection path now funnels through `agent_has_role`:

| Site | Before | After |
|---|---|---|
| `agent_route.c` `agent_supports_role` | has_role ∨ is_exec_role | `agent_has_role` |
| `delegate_role.c` `delegate_agent_supports_role` | has_role ∨ explicit exec | `agent_has_role` |
| `delegate_routing.c` (6 filters) | has_role ∨ is_exec_role | `agent_has_role` |
| `delegate_ensemble.c` review seat | has_role ∨ is_exec_role | requires `review`/`all` |
| `agent_fallback.c` | has_role ∨ is_exec_role | `agent_has_role` |
| `agent_tier_lint.c` competition | declared ∪ exec-probe ∪ custom-exec | shared **declared** role only |

**Routing consequence:** a role reaches only the agents that declare it (or `all`); an agent with only `exec_roles`, or none, is routable for nothing. In this deployment that is intended — `all` agents (MiniMax/kimi) still serve every role including review, while a role-scoped implementation agent (gemma4) serves implementation and is barred from review panels. The WFE dispatches only `draft`/`code`/`review`, all covered.

## Tests

Each affected test was asserting the old exec-fallback and now fails on it; updated to the new contract: `test_agent`, `test_agent_caps`, `test_agent_tier_lint` (two competition tests inverted to "shared exec role alone does not compete"), `test_delegate_role` (now stubs `agent_has_role`, which `delegate_role.o` references), `test_roundtable_seat_resolve`.

All ten role-touching suites pass; `server` + `kb` build clean under `-Wall -Wextra -Werror`.

## Companion

Pairs with #1903 (price the local `aimee-synth` model as free). Together they let the local synth delegate be enabled for **implementation** work without being cost-refused and without ever being seated on a review panel.