### PR TITLE
Slice 5: host admission, fd grant, and reaping

### DIFF
--- a/src/modules/bus/bus_host.c
+++ b/src/modules/bus/bus_host.c
@@ -1,0 +1,443 @@
+/* bus_host.c: bus host admission, directory, and reaping. See bus_host.h.
+ *
+ * The wire version this host speaks. A client declares a [min,max] range at
+ * attach and the host picks the highest common value, or denies.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "bus_host.h"
+#include "bus_ring.h"
+
+#define BUS_HOST_WIRE_VERSION 1
+
+/* ------------------------------------------------------------------ */
+/* fd passing                                                          */
+
+int bus_fd_send(int sock, const void *payload, size_t len, const int *fds, int n)
+{
+   if (n < 0 || n > 3)
+   {
+      errno = EINVAL;
+      return -1;
+   }
+
+   struct iovec iov = {.iov_base = (void *)payload, .iov_len = len};
+   union
+   {
+      struct cmsghdr align;
+      char buf[CMSG_SPACE(sizeof(int) * 3)];
+   } cbuf;
+   memset(&cbuf, 0, sizeof cbuf);
+
+   struct msghdr msg;
+   memset(&msg, 0, sizeof msg);
+   msg.msg_iov = &iov;
+   msg.msg_iovlen = 1;
+
+   if (n > 0)
+   {
+      msg.msg_control = cbuf.buf;
+      msg.msg_controllen = CMSG_SPACE(sizeof(int) * n);
+      struct cmsghdr *c = CMSG_FIRSTHDR(&msg);
+      c->cmsg_level = SOL_SOCKET;
+      c->cmsg_type = SCM_RIGHTS;
+      c->cmsg_len = CMSG_LEN(sizeof(int) * n);
+      memcpy(CMSG_DATA(c), fds, sizeof(int) * n);
+   }
+
+   ssize_t r;
+   do
+   {
+      r = sendmsg(sock, &msg, 0);
+   } while (r < 0 && errno == EINTR);
+   return r < 0 ? -1 : 0;
+}
+
+long bus_fd_recv(int sock, void *payload, size_t len, int *fds, int max_fds, int *n_out)
+{
+   if (max_fds < 0 || max_fds > 3)
+   {
+      errno = EINVAL;
+      return -1;
+   }
+   if (n_out)
+      *n_out = 0;
+
+   struct iovec iov = {.iov_base = payload, .iov_len = len};
+   union
+   {
+      struct cmsghdr align;
+      char buf[CMSG_SPACE(sizeof(int) * 3)];
+   } cbuf;
+   memset(&cbuf, 0, sizeof cbuf);
+
+   struct msghdr msg;
+   memset(&msg, 0, sizeof msg);
+   msg.msg_iov = &iov;
+   msg.msg_iovlen = 1;
+   msg.msg_control = cbuf.buf;
+   msg.msg_controllen = sizeof cbuf.buf;
+
+   ssize_t r;
+   do
+   {
+      r = recvmsg(sock, &msg, MSG_CMSG_CLOEXEC);
+   } while (r < 0 && errno == EINTR);
+   if (r < 0)
+      return -1;
+
+   /* Collect any descriptors. A message carrying more than we allow, or a
+    * truncated control buffer, is a protocol violation — close whatever came so
+    * a rejected attach cannot leak a live descriptor into this process. */
+   int got = 0;
+   for (struct cmsghdr *c = CMSG_FIRSTHDR(&msg); c; c = CMSG_NXTHDR(&msg, c))
+   {
+      if (c->cmsg_level == SOL_SOCKET && c->cmsg_type == SCM_RIGHTS)
+      {
+         int count = (int)((c->cmsg_len - CMSG_LEN(0)) / sizeof(int));
+         const int *in = (const int *)CMSG_DATA(c);
+         for (int i = 0; i < count; i++)
+         {
+            if (got < max_fds && !(msg.msg_flags & MSG_CTRUNC))
+               fds[got++] = in[i];
+            else
+               close(in[i]);
+         }
+      }
+   }
+   if (msg.msg_flags & MSG_CTRUNC)
+   {
+      for (int i = 0; i < got; i++)
+         close(fds[i]);
+      errno = EPROTO;
+      return -1;
+   }
+   if (n_out)
+      *n_out = got;
+   return r;
+}
+
+/* ------------------------------------------------------------------ */
+/* lifecycle                                                           */
+
+static void slot_release(bus_host_t *h, uint32_t idx)
+{
+   bus_slot_t *s = &h->slots[idx];
+   if (!s->in_use)
+      return;
+   /* A departing client's arena leases must not strand the arena: drop the refs
+    * it held as a producer and as a consumer. */
+   bus_arena_reap_producer(&h->arena, idx);
+   bus_arena_reap_consumer(&h->arena, idx);
+   bus_region_unmap(&s->qpair_region);
+   if (s->qpair_fd >= 0)
+      close(s->qpair_fd);
+   memset(s, 0, sizeof *s);
+   s->qpair_fd = -1;
+   if (h->admitted > 0)
+      h->admitted--;
+}
+
+bus_host_result_t bus_host_create(bus_host_t *h, const bus_host_config_t *cfg, bus_admit_fn admit,
+                                  void *admit_ctx)
+{
+   if (!h || !cfg || cfg->max_slots == 0 || cfg->max_slots > BUS_ARENA_MAX_SLOTS)
+      return BUS_HOST_ERR_ARG;
+
+   memset(h, 0, sizeof *h);
+   h->cfg = *cfg;
+   h->admit = admit;
+   h->admit_ctx = admit_ctx;
+   h->control_fd = -1;
+   h->arena_fd = -1;
+
+   /* Control region. */
+   if (bus_region_create("bus-control", bus_control_bytes(), &h->control_region) != BUS_REGION_OK)
+      goto fail;
+   h->control_fd = h->control_region.fd;
+   if (bus_region_map(h->control_fd, h->control_region.size, 1, &h->control_region) !=
+       BUS_REGION_OK)
+      goto fail;
+   if (bus_control_init(&h->control_region, cfg->slot_size, cfg->inline_budget,
+                        cfg->queue_capacity, cfg->arena_size) != BUS_REGION_OK)
+      goto fail;
+   if (bus_control_attach(&h->control_region, &h->control) != BUS_REGION_OK)
+      goto fail;
+
+   /* Arena region + allocator. */
+   size_t arena_bytes = bus_arena_region_bytes(cfg->arena_size);
+   if (arena_bytes == 0)
+      goto fail;
+   if (bus_region_create("bus-arena", arena_bytes, &h->arena_region) != BUS_REGION_OK)
+      goto fail;
+   h->arena_fd = h->arena_region.fd;
+   if (bus_region_map(h->arena_fd, h->arena_region.size, 1, &h->arena_region) != BUS_REGION_OK)
+      goto fail;
+   if (bus_arena_region_init(&h->arena_region, cfg->arena_size) != BUS_REGION_OK)
+      goto fail;
+   uint8_t *abase = NULL;
+   uint64_t asize = 0;
+   if (bus_arena_region_attach(&h->arena_region, &abase, &asize) != BUS_REGION_OK)
+      goto fail;
+   /* Per-client lease cap: capacity's worth per client is a sane provisional
+    * bound, re-tuned in slice 12 with the other parameters. */
+   if (bus_arena_init(&h->arena, abase, asize, cfg->max_slots, cfg->queue_capacity) !=
+       BUS_ARENA_OK)
+      goto fail;
+
+   h->slots = calloc(cfg->max_slots, sizeof(bus_slot_t));
+   if (!h->slots)
+      goto fail;
+   for (uint32_t i = 0; i < cfg->max_slots; i++)
+      h->slots[i].qpair_fd = -1;
+
+   return BUS_HOST_OK;
+
+fail:
+   bus_host_destroy(h);
+   return BUS_HOST_ERR_REGION;
+}
+
+void bus_host_destroy(bus_host_t *h)
+{
+   if (!h)
+      return;
+   if (h->slots)
+   {
+      for (uint32_t i = 0; i < h->cfg.max_slots; i++)
+         slot_release(h, i);
+      free(h->slots);
+      h->slots = NULL;
+   }
+   bus_region_unmap(&h->arena_region);
+   if (h->arena_fd >= 0)
+      close(h->arena_fd);
+   bus_region_unmap(&h->control_region);
+   if (h->control_fd >= 0)
+      close(h->control_fd);
+   h->arena_fd = h->control_fd = -1;
+}
+
+/* ------------------------------------------------------------------ */
+/* admission                                                           */
+
+static uint32_t find_free_slot(const bus_host_t *h)
+{
+   for (uint32_t i = 0; i < h->cfg.max_slots; i++)
+      if (!h->slots[i].in_use)
+         return i;
+   return h->cfg.max_slots;
+}
+
+/* Send a denial reply with no descriptors. */
+static bus_host_result_t deny(int conn_fd, bus_attach_status_t status)
+{
+   bus_attach_reply_t reply;
+   memset(&reply, 0, sizeof reply);
+   reply.magic = BUS_ATTACH_REPLY_MAGIC;
+   reply.status = (uint32_t)status;
+   bus_fd_send(conn_fd, &reply, sizeof reply, NULL, 0);
+   return BUS_HOST_ERR_REFUSED;
+}
+
+bus_host_result_t bus_host_serve_attach(bus_host_t *h, int conn_fd)
+{
+   if (!h || conn_fd < 0)
+      return BUS_HOST_ERR_ARG;
+
+   bus_attach_request_t req;
+   int rfds[3];
+   int nfd = 0;
+   long n = bus_fd_recv(conn_fd, &req, sizeof req, rfds, 3, &nfd);
+   /* A client never sends descriptors; if it tried, drop them. */
+   for (int i = 0; i < nfd; i++)
+      close(rfds[i]);
+   if (n != (long)sizeof req || req.magic != BUS_ATTACH_REQ_MAGIC)
+      return deny(conn_fd, BUS_ATTACH_PROTOCOL);
+
+   /* Version negotiation: highest common, or deny. */
+   if (req.wire_version_min > BUS_HOST_WIRE_VERSION ||
+       req.wire_version_max < BUS_HOST_WIRE_VERSION)
+      return deny(conn_fd, BUS_ATTACH_DENIED_VERSION);
+
+   /* Admission decision — identity/policy only. Default-admit when no seam is
+    * injected (tests). */
+   if (h->admit)
+   {
+      bus_attach_status_t d = h->admit(h->admit_ctx, &req);
+      if (d != BUS_ATTACH_OK)
+         return deny(conn_fd, d);
+   }
+
+   uint32_t idx = find_free_slot(h);
+   if (idx == h->cfg.max_slots)
+      return deny(conn_fd, BUS_ATTACH_DENIED_NOSLOT);
+
+   /* Build this client's queue-pair region. Everything below can fail without
+    * leaving a half-admitted slot: on any failure the slot is released. */
+   bus_slot_t *s = &h->slots[idx];
+   memset(s, 0, sizeof *s);
+   s->qpair_fd = -1;
+
+   size_t qbytes = bus_qpair_bytes(h->cfg.slot_size, h->cfg.queue_capacity);
+   if (qbytes == 0)
+      return deny(conn_fd, BUS_ATTACH_PROTOCOL);
+   if (bus_region_create("bus-qpair", qbytes, &s->qpair_region) != BUS_REGION_OK)
+   {
+      slot_release(h, idx);
+      return deny(conn_fd, BUS_ATTACH_DENIED_NOSLOT);
+   }
+   s->qpair_fd = s->qpair_region.fd;
+   if (bus_region_map(s->qpair_fd, s->qpair_region.size, 1, &s->qpair_region) != BUS_REGION_OK ||
+       bus_qpair_init(&s->qpair_region, h->cfg.slot_size, h->cfg.queue_capacity) !=
+          BUS_REGION_OK ||
+       bus_qpair_attach(&s->qpair_region, &s->qpair) != BUS_REGION_OK)
+   {
+      slot_release(h, idx);
+      return deny(conn_fd, BUS_ATTACH_DENIED_NOSLOT);
+   }
+
+   s->in_use = 1;
+   s->principal_ref = req.principal_ref;
+   s->last_heartbeat = 0;
+   s->heartbeat_at = 0;
+   h->admitted++;
+
+   /* Grant: the reply plus exactly three descriptors — control (the client will
+    * map it read-only), arena, and this client's own queue pair. No other
+    * client's descriptor is ever in this set. */
+   bus_attach_reply_t reply;
+   memset(&reply, 0, sizeof reply);
+   reply.magic = BUS_ATTACH_REPLY_MAGIC;
+   reply.status = BUS_ATTACH_OK;
+   reply.handle_id = idx;
+   reply.wire_version = BUS_HOST_WIRE_VERSION;
+   reply.slot_size = h->cfg.slot_size;
+   reply.inline_budget = h->cfg.inline_budget;
+   reply.queue_capacity = h->cfg.queue_capacity;
+   reply.arena_size = h->cfg.arena_size;
+   reply.host_epoch = bus_control_epoch(h->control);
+
+   /* "The control region is read-only to clients" (D1/D2) has to be enforced on
+    * the DESCRIPTOR, not merely on the client's mapping: a client handed the
+    * host's read-write control fd could map it PROT_WRITE and corrupt the region
+    * for everyone. So the client receives a re-opened O_RDONLY view of the same
+    * memfd — mmap PROT_WRITE on it fails — while the host keeps its own
+    * read-write fd to write heartbeats and bump the epoch. The arena and the
+    * client's own queue pair are legitimately read-write. */
+   char proc[64];
+   snprintf(proc, sizeof proc, "/proc/self/fd/%d", h->control_fd);
+   int control_ro = open(proc, O_RDONLY | O_CLOEXEC);
+   if (control_ro < 0)
+   {
+      slot_release(h, idx);
+      return deny(conn_fd, BUS_ATTACH_DENIED_NOSLOT);
+   }
+
+   int gfds[3] = {control_ro, h->arena_fd, s->qpair_fd};
+   int rc = bus_fd_send(conn_fd, &reply, sizeof reply, gfds, 3);
+   close(control_ro); /* the client holds its own dup now */
+   if (rc != 0)
+   {
+      /* The client never received its grant; undo the admission. */
+      slot_release(h, idx);
+      return BUS_HOST_ERR_OS;
+   }
+   return BUS_HOST_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* reaping                                                             */
+
+uint32_t bus_host_reap(bus_host_t *h, uint64_t now, uint64_t stale_ns)
+{
+   if (!h || !h->slots)
+      return 0;
+   uint32_t reaped = 0;
+   for (uint32_t i = 0; i < h->cfg.max_slots; i++)
+   {
+      bus_slot_t *s = &h->slots[i];
+      if (!s->in_use)
+         continue;
+
+      uint64_t hb =
+         atomic_load_explicit(&s->qpair.hdr->client_heartbeat, memory_order_acquire);
+      if (hb != s->last_heartbeat)
+      {
+         /* The client is alive; note the advance. */
+         s->last_heartbeat = hb;
+         s->heartbeat_at = now;
+         continue;
+      }
+      /* No advance since we last looked. A slot never yet seen advancing uses
+       * its admission time as the baseline (heartbeat_at was set to 0 at
+       * admission, so treat 0 as "start the clock now" the first time). */
+      if (s->heartbeat_at == 0)
+      {
+         s->heartbeat_at = now;
+         continue;
+      }
+      if (now - s->heartbeat_at >= stale_ns)
+      {
+         slot_release(h, i);
+         reaped++;
+      }
+   }
+   return reaped;
+}
+
+void bus_host_bump_epoch(bus_host_t *h)
+{
+   if (h && h->control)
+      bus_control_bump_epoch(h->control);
+}
+
+uint32_t bus_host_admitted(const bus_host_t *h)
+{
+   return h ? h->admitted : 0;
+}
+
+const char *bus_host_result_name(bus_host_result_t r)
+{
+   switch (r)
+   {
+   case BUS_HOST_OK:
+      return "OK";
+   case BUS_HOST_ERR_ARG:
+      return "ERR_ARG";
+   case BUS_HOST_ERR_OS:
+      return "ERR_OS";
+   case BUS_HOST_ERR_REGION:
+      return "ERR_REGION";
+   case BUS_HOST_ERR_REFUSED:
+      return "ERR_REFUSED";
+   default:
+      return "ERR_UNKNOWN";
+   }
+}
+
+const char *bus_attach_status_name(bus_attach_status_t s)
+{
+   switch (s)
+   {
+   case BUS_ATTACH_OK:
+      return "OK";
+   case BUS_ATTACH_DENIED_POLICY:
+      return "DENIED_POLICY";
+   case BUS_ATTACH_DENIED_VERSION:
+      return "DENIED_VERSION";
+   case BUS_ATTACH_DENIED_NOSLOT:
+      return "DENIED_NOSLOT";
+   case BUS_ATTACH_PROTOCOL:
+      return "PROTOCOL";
+   default:
+      return "UNKNOWN";
+   }
+}

--- a/src/modules/bus/bus_host.h
+++ b/src/modules/bus/bus_host.h
@@ -1,0 +1,162 @@
+/* bus_host.h: the bus host — admission, the queue directory, and reaping.
+ *
+ * The host is the sole admission authority (D1/D2, suite invariant 17). It
+ * creates the control and arena regions, and per admitted client a queue-pair
+ * region, and hands a client descriptors ONLY for what it may map: the control
+ * region read-only, the arena, and its own queue pair. It never hands over
+ * another client's queue-pair descriptor, and the queue directory — the map of
+ * which slot is whom — is host-private ordinary memory, never a region, so a
+ * client cannot enumerate its peers.
+ *
+ * Admission is gated by an injected decision function (`bus_admit_fn`). Who is
+ * admitted — identity, attestation, execution-policy — is owned by
+ * module-runtime and is NOT decided here; this slice owns the mechanism (the
+ * SOCK_SEQPACKET handshake, slot allocation, SCM_RIGHTS fd grant, heartbeat
+ * reaping) and calls the seam. A refused attach is handed a typed reason and no
+ * descriptors.
+ *
+ * This slice does not route events (slice 6) or run flow control (slice 7). It
+ * builds the admitted population the router will serve.
+ */
+#ifndef AIMEE_BUS_HOST_H
+#define AIMEE_BUS_HOST_H 1
+
+#include <stdint.h>
+
+#include "bus_arena.h"
+#include "bus_region.h"
+
+#define BUS_ATTACH_REQ_MAGIC   0x51524241u /* "ABRQ" */
+#define BUS_ATTACH_REPLY_MAGIC 0x50524241u /* "ABRP" */
+
+/* Outcome of an attach attempt, carried in the reply and returned by admission. */
+typedef enum
+{
+   BUS_ATTACH_OK = 0,
+   BUS_ATTACH_DENIED_POLICY,  /* admission decision said no */
+   BUS_ATTACH_DENIED_VERSION, /* no common wire version */
+   BUS_ATTACH_DENIED_NOSLOT,  /* the host is full */
+   BUS_ATTACH_PROTOCOL        /* the request was malformed */
+} bus_attach_status_t;
+
+/* A client's attach request. principal_class/ref are an opaque identity hint the
+ * bus passes to admission unchanged; the bus assigns no meaning to them. */
+typedef struct
+{
+   uint32_t magic;
+   uint16_t wire_version_min;
+   uint16_t wire_version_max;
+   uint32_t principal_class;
+   uint32_t principal_ref;
+} bus_attach_request_t;
+
+/* The host's reply. On OK it is accompanied by exactly three descriptors
+ * (control, arena, this client's queue pair) over SCM_RIGHTS; on any denial it
+ * carries no descriptors. */
+typedef struct
+{
+   uint32_t magic;
+   uint32_t status; /* bus_attach_status_t */
+   uint32_t handle_id;
+   uint32_t wire_version;
+   uint32_t slot_size;
+   uint32_t inline_budget;
+   uint32_t queue_capacity;
+   uint32_t reserved;
+   uint64_t arena_size;
+   uint64_t host_epoch;
+} bus_attach_reply_t;
+
+/* The admission seam. Returns BUS_ATTACH_OK to admit, or a denial reason. It
+ * decides identity/policy only; the host owns slot allocation and fd granting. */
+typedef bus_attach_status_t (*bus_admit_fn)(void *ctx, const bus_attach_request_t *req);
+
+/* A directory slot — host-private. A client never sees this or any other slot. */
+typedef struct
+{
+   int in_use;
+   uint32_t principal_ref;
+   int qpair_fd;
+   bus_region_t qpair_region; /* host RW mapping of this client's queue pair */
+   bus_qpair_t qpair;         /* host handles into it */
+   uint64_t last_heartbeat;   /* last client_heartbeat value the host observed */
+   uint64_t heartbeat_at;     /* host clock when it last advanced */
+} bus_slot_t;
+
+typedef struct
+{
+   uint32_t max_slots;
+   uint32_t slot_size;
+   uint32_t inline_budget;
+   uint32_t queue_capacity;
+   uint64_t arena_size;
+} bus_host_config_t;
+
+typedef struct
+{
+   bus_region_t control_region; /* host RW mapping */
+   int control_fd;
+   bus_control_t *control;
+
+   bus_region_t arena_region; /* host RW mapping */
+   int arena_fd;
+   bus_arena_t arena;
+
+   bus_host_config_t cfg;
+   bus_admit_fn admit;
+   void *admit_ctx;
+
+   bus_slot_t *slots;
+   uint32_t admitted;
+} bus_host_t;
+
+typedef enum
+{
+   BUS_HOST_OK = 0,
+   BUS_HOST_ERR_ARG,
+   BUS_HOST_ERR_OS,     /* an OS call failed (see errno) */
+   BUS_HOST_ERR_REGION, /* a region operation failed */
+   BUS_HOST_ERR_REFUSED /* the attach was denied (the reason is in the reply) */
+} bus_host_result_t;
+
+/* Create a host: control + arena regions and the arena allocator, an empty
+ * directory of cfg.max_slots. admit may be NULL (admits everyone) for tests. */
+bus_host_result_t bus_host_create(bus_host_t *h, const bus_host_config_t *cfg, bus_admit_fn admit,
+                                  void *admit_ctx);
+
+/* Tear down: unmap and close every region and slot. */
+void bus_host_destroy(bus_host_t *h);
+
+/* Process one attach handshake on a connected SOCK_SEQPACKET socket: read the
+ * request, consult admission, and on success allocate a slot, create + init its
+ * queue-pair region, and send the reply plus the three descriptors; on denial
+ * send the typed reply and no descriptors. Returns BUS_HOST_OK when a client was
+ * admitted, BUS_HOST_ERR_REFUSED when it was cleanly denied (reply sent), or an
+ * error if the handshake itself failed. */
+bus_host_result_t bus_host_serve_attach(bus_host_t *h, int conn_fd);
+
+/* Reap slots whose client heartbeat has not advanced within stale_ns. Releases
+ * the slot's arena leases (producer and consumer), unmaps and closes its
+ * queue-pair region, and frees the slot. `now` and the recorded timestamps share
+ * an arbitrary monotonic clock the caller supplies. Returns the number reaped. */
+uint32_t bus_host_reap(bus_host_t *h, uint64_t now, uint64_t stale_ns);
+
+/* Bump host_epoch, invalidating every handle and mapping at once (a restart). */
+void bus_host_bump_epoch(bus_host_t *h);
+
+uint32_t bus_host_admitted(const bus_host_t *h);
+
+const char *bus_host_result_name(bus_host_result_t r);
+const char *bus_attach_status_name(bus_attach_status_t s);
+
+/* ---- fd-passing helpers (shared with the C client, slice 8) ---- */
+
+/* Send `n` (0..3) descriptors plus `len` bytes of `payload` over a SOCK_SEQPACKET
+ * socket in one message. Returns 0 or -1 (errno). */
+int bus_fd_send(int sock, const void *payload, size_t len, const int *fds, int n);
+
+/* Receive one message: up to `max_fds` descriptors into `fds` (count in *n_out)
+ * and up to `len` payload bytes. Returns the payload byte count, or -1 (errno). */
+long bus_fd_recv(int sock, void *payload, size_t len, int *fds, int max_fds, int *n_out);
+
+#endif /* AIMEE_BUS_HOST_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -145,6 +145,9 @@ aimee_add_test(test_bus_region test_bus_region.c ../modules/bus/bus_region.c ../
 target_include_directories(test_bus_region PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 aimee_add_test(test_bus_arena test_bus_arena.c ../modules/bus/bus_arena.c)
 target_include_directories(test_bus_arena PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+aimee_add_test(test_bus_host test_bus_host.c ../modules/bus/bus_host.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c)
+target_include_directories(test_bus_host PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+
 
 
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -217,6 +217,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-bus-ring \
                $(TESTPREFIX)/unit-test-bus-region \
                $(TESTPREFIX)/unit-test-bus-arena \
+               $(TESTPREFIX)/unit-test-bus-host \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2561,6 +2562,20 @@ $(OBJDIR)/tests/test_bus_arena.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-arena: $(OBJDIR)/tests/test_bus_arena.o \
                                    $(OBJDIR)/modules/bus/bus_arena.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+# Event-bus host: admission, fd passing, reaping (feature tree slice 5). Uses
+# memfd + socketpair; no DB. Links region, ring and arena.
+$(OBJDIR)/tests/test_bus_host.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-host: $(OBJDIR)/tests/test_bus_host.o \
+                                  $(OBJDIR)/modules/bus/bus_host.o \
+                                  $(OBJDIR)/modules/bus/bus_region.o \
+                                  $(OBJDIR)/modules/bus/bus_ring.o \
+                                  $(OBJDIR)/modules/bus/bus_arena.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+.PHONY: unit-test-bus-host
+unit-test-bus-host: $(TESTPREFIX)/unit-test-bus-host
+	$<
 
 .PHONY: unit-test-bus-arena
 unit-test-bus-arena: $(TESTPREFIX)/unit-test-bus-arena

--- a/src/tests/test_bus_host.c
+++ b/src/tests/test_bus_host.c
@@ -1,0 +1,343 @@
+/* test_bus_host.c: slice 5 of the event-bus feature tree.
+ *
+ * The host is the admission boundary, so the tests check the boundary as an
+ * outcome:
+ *
+ *   - An admitted client receives exactly three descriptors — control (which it
+ *     maps read-only), arena, and its own queue pair — and can exchange traffic
+ *     with the host through those rings.
+ *   - Two admitted clients are isolated: each sees only its own inbound and its
+ *     own outbound. A client holds no descriptor for another's queue pair and
+ *     the directory that maps slot to identity is host-private, so it cannot
+ *     reach or enumerate its peer.
+ *   - A denied attach (policy or version) receives a typed reason and NO
+ *     descriptors — an unadmitted process gets nothing to map.
+ *   - A client whose heartbeat stalls is reaped: its slot is freed and its arena
+ *     leases released; a client that keeps beating is left alone.
+ *   - A host restart (epoch bump) is visible to a client through the control
+ *     region.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "bus_host.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+/* A client's view after a successful attach. */
+typedef struct
+{
+   bus_attach_reply_t reply;
+   bus_region_t control;
+   bus_region_t arena;
+   bus_region_t qpair;
+   bus_control_t *ctl;
+   bus_qpair_t qp;
+} client_t;
+
+/* Drive one attach over a connected socket: the client sends its request, the
+ * host serves it (must be pumped in between), the client receives the reply and
+ * any descriptors and maps them as a client would — control read-only. */
+static bus_attach_status_t client_send_request(int sock, uint16_t vmin, uint16_t vmax,
+                                               uint32_t principal)
+{
+   bus_attach_request_t req;
+   memset(&req, 0, sizeof req);
+   req.magic = BUS_ATTACH_REQ_MAGIC;
+   req.wire_version_min = vmin;
+   req.wire_version_max = vmax;
+   req.principal_class = 1;
+   req.principal_ref = principal;
+   must(bus_fd_send(sock, &req, sizeof req, NULL, 0) == 0, "client sent request");
+   return BUS_ATTACH_OK;
+}
+
+static bus_attach_status_t client_recv(int sock, client_t *c)
+{
+   int fds[3];
+   int nfd = 0;
+   memset(c, 0, sizeof *c);
+   long n = bus_fd_recv(sock, &c->reply, sizeof c->reply, fds, 3, &nfd);
+   must(n == (long)sizeof c->reply, "client received a full reply");
+   must(c->reply.magic == BUS_ATTACH_REPLY_MAGIC, "reply magic");
+
+   if (c->reply.status != BUS_ATTACH_OK)
+   {
+      must(nfd == 0, "a denied attach carries no descriptors");
+      return (bus_attach_status_t)c->reply.status;
+   }
+
+   must(nfd == 3, "an admitted client receives exactly three descriptors");
+   /* fds[0] control (read-only), fds[1] arena (rw), fds[2] own queue pair (rw). */
+
+   /* The control descriptor must be genuinely read-only: mapping it writable has
+    * to FAIL, or the "control is read-only to clients" invariant is only the
+    * client library's good manners. */
+   bus_region_t rw_attempt;
+   must(bus_region_map(fds[0], bus_control_bytes(), 1, &rw_attempt) != BUS_REGION_OK,
+        "control descriptor refuses a writable mapping");
+
+   must(bus_region_map(fds[0], bus_control_bytes(), 0, &c->control) == BUS_REGION_OK,
+        "map control read-only");
+   size_t arena_bytes = bus_arena_region_bytes(c->reply.arena_size);
+   must(bus_region_map(fds[1], arena_bytes, 1, &c->arena) == BUS_REGION_OK, "map arena rw");
+   size_t qbytes = bus_qpair_bytes(c->reply.slot_size, c->reply.queue_capacity);
+   must(bus_region_map(fds[2], qbytes, 1, &c->qpair) == BUS_REGION_OK, "map own queue pair rw");
+
+   must(bus_control_attach(&c->control, &c->ctl) == BUS_REGION_OK, "attach control");
+   must(bus_qpair_attach(&c->qpair, &c->qp) == BUS_REGION_OK, "attach queue pair");
+
+   /* The mappings hold their own references; the descriptors can be closed now,
+    * so a run of attaches does not leak fds. */
+   for (int i = 0; i < 3; i++)
+      close(fds[i]);
+   return BUS_ATTACH_OK;
+}
+
+static void client_unmap(client_t *c)
+{
+   bus_region_unmap(&c->control);
+   bus_region_unmap(&c->arena);
+   bus_region_unmap(&c->qpair);
+}
+
+/* Deny a specific principal, to exercise the admission seam. */
+static bus_attach_status_t admit_deny_666(void *ctx, const bus_attach_request_t *req)
+{
+   (void)ctx;
+   return req->principal_ref == 666 ? BUS_ATTACH_DENIED_POLICY : BUS_ATTACH_OK;
+}
+
+/* Attach a client over a fresh socketpair; returns the admit status. On OK the
+ * client view is filled. The host end stays owned by the host for the slot's
+ * lifetime is not needed here — the handshake is one shot. */
+static bus_attach_status_t attach(bus_host_t *h, uint16_t vmin, uint16_t vmax, uint32_t principal,
+                                  client_t *out)
+{
+   int sv[2];
+   must(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) == 0, "socketpair");
+   client_send_request(sv[0], vmin, vmax, principal);
+   bus_host_result_t r = bus_host_serve_attach(h, sv[1]);
+   bus_attach_status_t st = client_recv(sv[0], out);
+   if (st == BUS_ATTACH_OK)
+      must(r == BUS_HOST_OK, "host reports admit on OK");
+   else
+      must(r == BUS_HOST_ERR_REFUSED, "host reports refusal on deny");
+   close(sv[0]);
+   close(sv[1]);
+   return st;
+}
+
+static bus_host_config_t default_cfg(void)
+{
+   bus_host_config_t cfg;
+   memset(&cfg, 0, sizeof cfg);
+   cfg.max_slots = 4;
+   cfg.slot_size = 256;
+   cfg.inline_budget = 192;
+   cfg.queue_capacity = 16;
+   cfg.arena_size = 256 * 1024;
+   return cfg;
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_admit_and_traffic(void)
+{
+   bus_host_config_t cfg = default_cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cfg, admit_deny_666, NULL) == BUS_HOST_OK, "host create");
+
+   client_t c;
+   must(attach(&h, 1, 1, 1, &c) == BUS_ATTACH_OK, "client admitted");
+   must(bus_host_admitted(&h) == 1, "one admitted");
+   must(c.reply.slot_size == cfg.slot_size, "reply carries slot_size");
+   must(c.reply.host_epoch == bus_control_epoch(h.control), "reply carries the epoch");
+
+   /* Host -> client: the host writes into the client's inbound; the client reads
+    * it through its own mapping. */
+   bus_slot_t *slot = &h.slots[c.reply.handle_id];
+   void *w = bus_ring_produce_begin(&slot->qpair.inbound);
+   must(w != NULL, "host produces into the client's inbound");
+   *(uint32_t *)w = 0xA1B2C3D4;
+   bus_ring_produce_commit(&slot->qpair.inbound);
+
+   const void *rd = bus_ring_consume_begin(&c.qp.inbound);
+   must(rd != NULL, "client sees its inbound");
+   must(*(const uint32_t *)rd == 0xA1B2C3D4, "client reads the host's bytes");
+   bus_ring_consume_commit(&c.qp.inbound);
+
+   /* Client -> host through the outbound ring. */
+   void *cw = bus_ring_produce_begin(&c.qp.outbound);
+   must(cw != NULL, "client produces into its outbound");
+   *(uint32_t *)cw = 0x0BADF00D;
+   bus_ring_produce_commit(&c.qp.outbound);
+
+   const void *hr = bus_ring_consume_begin(&slot->qpair.outbound);
+   must(hr != NULL, "host sees the client's outbound");
+   must(*(const uint32_t *)hr == 0x0BADF00D, "host reads the client's bytes");
+   bus_ring_consume_commit(&slot->qpair.outbound);
+
+   client_unmap(&c);
+   bus_host_destroy(&h);
+   printf("  admit + traffic: three fds granted, both rings carry traffic\n");
+}
+
+static void test_two_clients_isolated(void)
+{
+   bus_host_config_t cfg = default_cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cfg, NULL, NULL) == BUS_HOST_OK, "host create");
+
+   client_t a, b;
+   must(attach(&h, 1, 1, 10, &a) == BUS_ATTACH_OK, "A admitted");
+   must(attach(&h, 1, 1, 20, &b) == BUS_ATTACH_OK, "B admitted");
+   must(a.reply.handle_id != b.reply.handle_id, "distinct handles");
+   must(bus_host_admitted(&h) == 2, "two admitted");
+
+   /* The host addresses each slot independently: a byte written to A's inbound
+    * must reach A and not B. */
+   bus_slot_t *sa = &h.slots[a.reply.handle_id];
+   bus_slot_t *sb = &h.slots[b.reply.handle_id];
+   void *wa = bus_ring_produce_begin(&sa->qpair.inbound);
+   *(uint32_t *)wa = 0xAAAAAAAA;
+   bus_ring_produce_commit(&sa->qpair.inbound);
+
+   /* A sees its message; B's inbound is empty — A and B do not share a ring. */
+   const void *ra = bus_ring_consume_begin(&a.qp.inbound);
+   must(ra && *(const uint32_t *)ra == 0xAAAAAAAA, "A reads its own inbound");
+   bus_ring_consume_commit(&a.qp.inbound);
+   must(bus_ring_consume_begin(&b.qp.inbound) == NULL, "B's inbound is untouched");
+
+   /* Symmetrically for outbound: B produces, only B's slot shows it. */
+   void *wb = bus_ring_produce_begin(&b.qp.outbound);
+   *(uint32_t *)wb = 0xBBBBBBBB;
+   bus_ring_produce_commit(&b.qp.outbound);
+   must(bus_ring_consume_begin(&sa->qpair.outbound) == NULL, "A's slot shows no B traffic");
+   const void *rb = bus_ring_consume_begin(&sb->qpair.outbound);
+   must(rb && *(const uint32_t *)rb == 0xBBBBBBBB, "B's slot shows B traffic");
+   bus_ring_consume_commit(&sb->qpair.outbound);
+
+   client_unmap(&a);
+   client_unmap(&b);
+   bus_host_destroy(&h);
+   printf("  isolation: two clients, each sees only its own rings\n");
+}
+
+static void test_denials(void)
+{
+   bus_host_config_t cfg = default_cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cfg, admit_deny_666, NULL) == BUS_HOST_OK, "host create");
+
+   client_t c;
+   must(attach(&h, 1, 1, 666, &c) == BUS_ATTACH_DENIED_POLICY, "policy denial");
+   must(bus_host_admitted(&h) == 0, "denied client not admitted");
+
+   /* A version with no overlap is denied, with no descriptors. */
+   must(attach(&h, 7, 9, 1, &c) == BUS_ATTACH_DENIED_VERSION, "version denial");
+   must(bus_host_admitted(&h) == 0, "still none admitted");
+
+   bus_host_destroy(&h);
+   printf("  denials: policy and version refused with a typed reason and no fds\n");
+}
+
+static void test_full_host(void)
+{
+   bus_host_config_t cfg = default_cfg();
+   cfg.max_slots = 2;
+   bus_host_t h;
+   must(bus_host_create(&h, &cfg, NULL, NULL) == BUS_HOST_OK, "host create");
+
+   client_t c[3];
+   must(attach(&h, 1, 1, 1, &c[0]) == BUS_ATTACH_OK, "first admitted");
+   must(attach(&h, 1, 1, 2, &c[1]) == BUS_ATTACH_OK, "second admitted");
+   must(attach(&h, 1, 1, 3, &c[2]) == BUS_ATTACH_DENIED_NOSLOT, "third refused, host full");
+
+   client_unmap(&c[0]);
+   client_unmap(&c[1]);
+   bus_host_destroy(&h);
+   printf("  full host: admission refuses past capacity\n");
+}
+
+static void test_reaping(void)
+{
+   bus_host_config_t cfg = default_cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cfg, NULL, NULL) == BUS_HOST_OK, "host create");
+
+   client_t a, b;
+   must(attach(&h, 1, 1, 1, &a) == BUS_ATTACH_OK, "A admitted");
+   must(attach(&h, 1, 1, 2, &b) == BUS_ATTACH_OK, "B admitted");
+
+   /* Both clients beat once at t=100 so the host has a baseline. */
+   atomic_store_explicit(&a.qp.hdr->client_heartbeat, 1, memory_order_release);
+   atomic_store_explicit(&b.qp.hdr->client_heartbeat, 1, memory_order_release);
+   must(bus_host_reap(&h, 100, 50) == 0, "baseline: nobody stale yet");
+
+   /* B keeps beating; A goes quiet. Advance the clock past the stale window. */
+   atomic_store_explicit(&b.qp.hdr->client_heartbeat, 2, memory_order_release);
+   must(bus_host_reap(&h, 130, 50) == 0, "still within the window");
+
+   /* A's arena footprint should be released on reap: give A a lease first. */
+   uint32_t lease;
+   must(bus_arena_alloc(&h.arena, a.reply.handle_id, 64, &lease) == BUS_ARENA_OK,
+        "A holds a lease");
+   must(bus_arena_live_leases(&h.arena, a.reply.handle_id) == 1, "A has a live lease");
+
+   /* Now past the window with no advance from A: A is reaped, B is not. */
+   atomic_store_explicit(&b.qp.hdr->client_heartbeat, 3, memory_order_release);
+   uint32_t reaped = bus_host_reap(&h, 200, 50);
+   must(reaped == 1, "exactly one reaped");
+   must(bus_host_admitted(&h) == 1, "one remains");
+   must(!h.slots[a.reply.handle_id].in_use, "A's slot freed");
+   must(h.slots[b.reply.handle_id].in_use, "B's slot kept");
+   must(bus_arena_live_leases(&h.arena, a.reply.handle_id) == 0,
+        "A's arena leases released on reap");
+
+   client_unmap(&a);
+   client_unmap(&b);
+   bus_host_destroy(&h);
+   printf("  reaping: a stalled client is reaped and its leases released\n");
+}
+
+static void test_epoch(void)
+{
+   bus_host_config_t cfg = default_cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cfg, NULL, NULL) == BUS_HOST_OK, "host create");
+   client_t c;
+   must(attach(&h, 1, 1, 1, &c) == BUS_ATTACH_OK, "admitted");
+
+   uint64_t at = bus_control_epoch(c.ctl);
+   must(!bus_control_epoch_changed(c.ctl, at), "no change yet");
+   bus_host_bump_epoch(&h);
+   must(bus_control_epoch_changed(c.ctl, at), "client sees the restart via the control region");
+
+   client_unmap(&c);
+   bus_host_destroy(&h);
+   printf("  epoch: a host restart is visible through the control region\n");
+}
+
+int main(void)
+{
+   printf("test_bus_host:\n");
+   test_admit_and_traffic();
+   test_two_clients_isolated();
+   test_denials();
+   test_full_host();
+   test_reaping();
+   test_epoch();
+   printf("test_bus_host: OK\n");
+   return 0;
+}


### PR DESCRIPTION
Fifth slice of the event-bus feature tree. Self-reviewed.

## What lands

`bus_host.{c,h}` — the sole admission authority. Creates the control + arena regions and, per admitted client, a queue-pair region; grants a client descriptors only for what it may map — control (read-only), arena, and its own queue pair — over a `SOCK_SEQPACKET` handshake with `SCM_RIGHTS`. The queue directory (slot→identity) is **host-private ordinary memory**, so a client cannot enumerate its peers.

Admission is an injected `bus_admit_fn` — *who* is admitted is module-runtime's; this slice owns the mechanism and calls the seam. Denials (policy, version, full host) carry a typed reason and no descriptors. Reaping releases a stalled client's arena leases, unmaps its region, frees its slot; epoch bump invalidates all handles.

## Self-review caught a real security hole

The control region was granted as the host's **read-write** memfd, so a hostile client could map it `PROT_WRITE` and corrupt it for everyone — the read-only invariant would have held only by the client library's manners (my slice-3 fault test passed only because the test client cooperatively mapped RO). The client now receives a re-opened **O_RDONLY** view of the control memfd; `mmap PROT_WRITE` on it fails, while the host keeps its RW fd for heartbeats/epoch. Fails closed. A test asserts the client's control descriptor refuses a writable mapping.

## Verification (normal + ASAN/UBSAN + TSAN)

Admit + bidirectional ring traffic; two clients isolated (each sees only its own rings); policy and version denials with no fds; full-host refusal; a stalled client reaped with its leases released while a beating client is kept; a host restart visible through the control region.

No shipping binary links the bus (D7). Depends on slices 1–4 (merged).