### PR TITLE
fix(plugin-loader): correct stale plugin_load_all_registered header comment

### DIFF
--- a/docs/modules/plugin-loader.md
+++ b/docs/modules/plugin-loader.md
@@ -31,10 +31,7 @@ call is absent — so in the tracked startup path bundled discovery takes the
 `$AIMEE_INSTALL_PREFIX`-then-`./plugins/` fallback. Both remain declared in public headers and
 shipped as external symbols, so a downstream host can link and call them — including calling the
 setter before discovery; their removal is an API and ABI compatibility decision, not a dead-code
-cleanup. The
-`plugin_load_all_registered` header comment still promises a call to
-`plugin_collect_delegate_backends`, which the ABI/loader split in #1722 removed; the comment was
-not updated with it.
+cleanup.
 
 ## Dependencies and consumers
 

--- a/src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h
+++ b/src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h
@@ -84,8 +84,8 @@ int plugin_manifest_parse(const char *dir, plugin_t *out, char *err_buf, size_t 
 int plugin_load_and_register(const plugin_t *plugin, char *err_buf, size_t err_len);
 
 /* Load all enabled plugins from the registry and call their register(ctx).
- * Calls plugin_collect_delegate_backends() after registration.
- * Returns 0 on success (even if no plugins), -1 on critical error. */
+ * Returns 0 on success (even if no plugins are enabled), -1 if any enabled
+ * plugin failed to load. */
 int plugin_load_all_registered(char *err_buf, size_t err_len);
 
 /* --- Install / enable / disable / remove --- */

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -147,7 +147,7 @@
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h",
-          "sha256": "4d19916e464cab53f021ef25f788c415f3a84535fef16f3724ddbacfab55c187"
+          "sha256": "c7771d412be38388ccd229d0ff11567044f9137d6edee2dee01da02749c9b7a5"
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h",
@@ -1307,7 +1307,7 @@
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h",
-          "sha256": "4d19916e464cab53f021ef25f788c415f3a84535fef16f3724ddbacfab55c187"
+          "sha256": "c7771d412be38388ccd229d0ff11567044f9137d6edee2dee01da02749c9b7a5"
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h",
@@ -1352,7 +1352,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "54566bc1962c97a57bc818a4518029ec11982663ebf349b0a246110064a683e8",
+      "sha256": "ca751342e05714e674e6c34b19aa495cc23dcc607be28cfbc047ad789171a7a8",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## What

`plugin.h`'s comment on `plugin_load_all_registered` promised it "Calls `plugin_collect_delegate_backends()` after registration" — but the ABI/loader split in #1722 removed that function. The current implementation (`plugin.c:914`) only loads the registry and calls each enabled plugin's `register(ctx)`. The comment describes behavior that no longer exists.

## Change

- Replace the false line with an accurate return contract: `0` on success (including no enabled plugins), `-1` if any enabled plugin fails to load — matching the implementation.
- Remove the now-obsolete note in `docs/modules/plugin-loader.md` that flagged the stale comment.
- Refreeze the `plugin.h` refactor baseline hashes (two per-file pins + the `public-symbols` aggregate digest).

## Scope / non-goals

Comment, doc, and baseline-hash only. **No symbol is removed and no behavior changes.** The two uncalled exports (`plugin_load_all_registered`, `plugin_loader_set_install_prefix`) are deliberately left in place — the audit classifies their removal as an API/ABI compatibility decision, not a dead-code cleanup.

Discharges the documentation defect recorded in `docs/validation/core-modularization-slice-36.md`.

## Verification (all pass locally)

```
python3 scripts/refactor_baselines.py check
python3 scripts/check_module_docs.py
python3 scripts/validate_module_descriptors.py --check-schema src/modules
python3 scripts/check_cleanup_ledger.py
python3 scripts/check_module_header_layout.py
python3 scripts/check_module_source_ownership.py
```