### PR TITLE
Slice 6: host routing and the governance tap

### DIFF
--- a/src/modules/bus/bus_host.c
+++ b/src/modules/bus/bus_host.c
@@ -127,11 +127,16 @@ long bus_fd_recv(int sock, void *payload, size_t len, int *fds, int max_fds, int
 /* ------------------------------------------------------------------ */
 /* lifecycle                                                           */
 
+/* Defined in bus_route.c: scrub a departing slot from the observer/server
+ * registry and drop any pending request it was party to. */
+void bus_route_forget_slot(bus_host_t *h, uint32_t slot);
+
 static void slot_release(bus_host_t *h, uint32_t idx)
 {
    bus_slot_t *s = &h->slots[idx];
    if (!s->in_use)
       return;
+   bus_route_forget_slot(h, idx);
    /* A departing client's arena leases must not strand the arena: drop the refs
     * it held as a producer and as a consumer. */
    bus_arena_reap_producer(&h->arena, idx);

--- a/src/modules/bus/bus_host.h
+++ b/src/modules/bus/bus_host.h
@@ -25,6 +25,7 @@
 
 #include "bus_arena.h"
 #include "bus_region.h"
+#include "bus_wire.h"
 
 #define BUS_ATTACH_REQ_MAGIC   0x51524241u /* "ABRQ" */
 #define BUS_ATTACH_REPLY_MAGIC 0x50524241u /* "ABRP" */
@@ -72,6 +73,14 @@ typedef struct
 typedef bus_attach_status_t (*bus_admit_fn)(void *ctx, const bus_attach_request_t *req);
 
 /* A directory slot — host-private. A client never sees this or any other slot. */
+#define BUS_HOST_MAX_KINDS   256
+#define BUS_HOST_MAX_PENDING  1024
+
+/* The governance/audit tap: invoked once per event, after seq stamping and
+ * before any routing decision (D6). It is the single full-stream observer; a
+ * would_block that the host never accepted is not an event and is not tapped. */
+typedef void (*bus_tap_fn)(void *ctx, const bus_frame_t *frame);
+
 typedef struct
 {
    int in_use;
@@ -81,7 +90,27 @@ typedef struct
    bus_qpair_t qpair;         /* host handles into it */
    uint64_t last_heartbeat;   /* last client_heartbeat value the host observed */
    uint64_t heartbeat_at;     /* host clock when it last advanced */
+   uint64_t dropped;          /* events the host could not deliver (full inbound) */
 } bus_slot_t;
+
+/* A registered event kind: who observes its notifications, and who serves its
+ * requests. Observers is a slot bitmap; server is a slot index or NONE. */
+typedef struct
+{
+   int in_use;
+   uint32_t kind;
+   uint64_t observers[BUS_ARENA_SLOT_WORDS];
+   int32_t server; /* serving slot, or -1 */
+} bus_kind_t;
+
+/* An outstanding request, so a reply can be routed back to its requester. */
+typedef struct
+{
+   int in_use;
+   uint64_t correlation_id;
+   uint32_t requester;
+   uint32_t server;
+} bus_pending_t;
 
 typedef struct
 {
@@ -108,6 +137,13 @@ typedef struct
 
    bus_slot_t *slots;
    uint32_t admitted;
+
+   bus_kind_t kinds[BUS_HOST_MAX_KINDS];
+   bus_pending_t pending[BUS_HOST_MAX_PENDING];
+   uint64_t seq; /* host-assigned monotonic dispatch order */
+
+   bus_tap_fn tap;
+   void *tap_ctx;
 } bus_host_t;
 
 typedef enum
@@ -148,6 +184,26 @@ uint32_t bus_host_admitted(const bus_host_t *h);
 
 const char *bus_host_result_name(bus_host_result_t r);
 const char *bus_attach_status_name(bus_attach_status_t s);
+
+/* Set the governance/audit tap. Pass NULL to clear. */
+void bus_host_set_tap(bus_host_t *h, bus_tap_fn fn, void *ctx);
+
+/* Register `slot` as an authorized observer of `event_kind` (its notifications).
+ * Subscription is the authorization: a client never receives a kind it did not
+ * subscribe to. */
+bus_host_result_t bus_host_subscribe(bus_host_t *h, uint32_t slot, uint32_t event_kind);
+
+/* Register `slot` as the single server for `event_kind` (its requests). A second
+ * server for the same kind is refused. */
+bus_host_result_t bus_host_serve_kind(bus_host_t *h, uint32_t slot, uint32_t event_kind);
+
+/* Drain every admitted client's outbound ring once, routing each event: stamp
+ * seq, offer it to the tap, then deliver — notifications to the kind's authorized
+ * observers, a request to the kind's server (or a synthesized capability_absent
+ * reply), a reply point-to-point to its requester, a cancel to the server.
+ * Returns the number of events processed. Inline payloads only in this slice;
+ * arena-payload delivery is a separate slice-4/6 integration. */
+uint32_t bus_host_pump(bus_host_t *h);
 
 /* ---- fd-passing helpers (shared with the C client, slice 8) ---- */
 

--- a/src/modules/bus/bus_route.c
+++ b/src/modules/bus/bus_route.c
@@ -1,0 +1,311 @@
+/* bus_route.c: the host's routing and governance tap. See bus_host.h.
+ *
+ * The host drains each admitted client's outbound ring, and for every event:
+ * stamps a monotonic seq, offers it to the tap (the single full-stream observer,
+ * before any routing decision — D6), then delivers it by pattern. All of this
+ * runs in one thread, so seq order is the tap order and the capture order.
+ *
+ * This slice routes inline-payload events. An event whose payload lives in the
+ * arena needs the host to publish that lease (slice 4) to the resolved observer
+ * set before forwarding the reference; that composition is a named follow-up and
+ * arena-flagged frames are dropped-with-count here rather than delivered to a
+ * consumer that could not read them.
+ */
+#include <string.h>
+
+#include "bus_host.h"
+#include "bus_ring.h"
+#include "bus_wire.h"
+
+#define KIND_SERVER_NONE (-1)
+
+/* ---- slot bitmap over observers ---- */
+
+static void obs_set(uint64_t *bits, uint32_t slot)
+{
+   bits[slot / 64] |= (uint64_t)1 << (slot % 64);
+}
+static void obs_clear(uint64_t *bits, uint32_t slot)
+{
+   bits[slot / 64] &= ~((uint64_t)1 << (slot % 64));
+}
+static int obs_test(const uint64_t *bits, uint32_t slot)
+{
+   return (bits[slot / 64] >> (slot % 64)) & 1;
+}
+
+/* ---- registry ---- */
+
+static bus_kind_t *kind_find(bus_host_t *h, uint32_t kind)
+{
+   for (uint32_t i = 0; i < BUS_HOST_MAX_KINDS; i++)
+      if (h->kinds[i].in_use && h->kinds[i].kind == kind)
+         return &h->kinds[i];
+   return NULL;
+}
+
+static bus_kind_t *kind_intern(bus_host_t *h, uint32_t kind)
+{
+   bus_kind_t *k = kind_find(h, kind);
+   if (k)
+      return k;
+   for (uint32_t i = 0; i < BUS_HOST_MAX_KINDS; i++)
+   {
+      if (!h->kinds[i].in_use)
+      {
+         h->kinds[i].in_use = 1;
+         h->kinds[i].kind = kind;
+         memset(h->kinds[i].observers, 0, sizeof h->kinds[i].observers);
+         h->kinds[i].server = KIND_SERVER_NONE;
+         return &h->kinds[i];
+      }
+   }
+   return NULL; /* registry full */
+}
+
+void bus_host_set_tap(bus_host_t *h, bus_tap_fn fn, void *ctx)
+{
+   if (!h)
+      return;
+   h->tap = fn;
+   h->tap_ctx = ctx;
+}
+
+bus_host_result_t bus_host_subscribe(bus_host_t *h, uint32_t slot, uint32_t event_kind)
+{
+   if (!h || slot >= h->cfg.max_slots || !h->slots[slot].in_use)
+      return BUS_HOST_ERR_ARG;
+   bus_kind_t *k = kind_intern(h, event_kind);
+   if (!k)
+      return BUS_HOST_ERR_ARG;
+   obs_set(k->observers, slot);
+   return BUS_HOST_OK;
+}
+
+bus_host_result_t bus_host_serve_kind(bus_host_t *h, uint32_t slot, uint32_t event_kind)
+{
+   if (!h || slot >= h->cfg.max_slots || !h->slots[slot].in_use)
+      return BUS_HOST_ERR_ARG;
+   bus_kind_t *k = kind_intern(h, event_kind);
+   if (!k)
+      return BUS_HOST_ERR_ARG;
+   if (k->server != KIND_SERVER_NONE && k->server != (int32_t)slot)
+      return BUS_HOST_ERR_ARG; /* one server per kind */
+   k->server = (int32_t)slot;
+   return BUS_HOST_OK;
+}
+
+/* When a slot departs (reap/detach), scrub it from every registry role and drop
+ * any pending request it was party to. Called from slot_release in bus_host.c. */
+void bus_route_forget_slot(bus_host_t *h, uint32_t slot)
+{
+   for (uint32_t i = 0; i < BUS_HOST_MAX_KINDS; i++)
+   {
+      if (!h->kinds[i].in_use)
+         continue;
+      obs_clear(h->kinds[i].observers, slot);
+      if (h->kinds[i].server == (int32_t)slot)
+         h->kinds[i].server = KIND_SERVER_NONE;
+   }
+   for (uint32_t i = 0; i < BUS_HOST_MAX_PENDING; i++)
+      if (h->pending[i].in_use &&
+          (h->pending[i].requester == slot || h->pending[i].server == slot))
+         h->pending[i].in_use = 0;
+}
+
+/* ---- pending request table ---- */
+
+static bus_pending_t *pending_add(bus_host_t *h, uint64_t corr, uint32_t requester,
+                                  uint32_t server)
+{
+   for (uint32_t i = 0; i < BUS_HOST_MAX_PENDING; i++)
+   {
+      if (!h->pending[i].in_use)
+      {
+         h->pending[i].in_use = 1;
+         h->pending[i].correlation_id = corr;
+         h->pending[i].requester = requester;
+         h->pending[i].server = server;
+         return &h->pending[i];
+      }
+   }
+   return NULL;
+}
+
+static bus_pending_t *pending_find(bus_host_t *h, uint64_t corr)
+{
+   for (uint32_t i = 0; i < BUS_HOST_MAX_PENDING; i++)
+      if (h->pending[i].in_use && h->pending[i].correlation_id == corr)
+         return &h->pending[i];
+   return NULL;
+}
+
+/* ---- delivery ---- */
+
+/* Write a (seq/dst-stamped) frame and its inline payload into a destination
+ * slot's inbound ring. Returns 1 on delivery, 0 if the ring was full. The full
+ * case is counted, not silent — slice 7 replaces the drop with credit-based
+ * backpressure and a typed overflow event. */
+static int deliver(bus_host_t *h, uint32_t dst_slot, const bus_frame_t *f,
+                   const uint8_t *inline_src)
+{
+   bus_slot_t *d = &h->slots[dst_slot];
+   uint8_t *slot = bus_ring_produce_begin(&d->qpair.inbound);
+   if (!slot)
+   {
+      d->dropped++;
+      return 0;
+   }
+
+   bus_frame_t out = *f;
+   out.dst_handle = dst_slot;
+   if (bus_wire_encode(&out, slot, h->cfg.slot_size) != BUS_WIRE_HDR_LEN)
+   {
+      d->dropped++;
+      return 0;
+   }
+   if ((out.hdr_flags & BUS_F_INLINE) && out.payload_len > 0)
+   {
+      /* Inline payloads sit just past the header, inside the slot. */
+      if ((uint64_t)out.payload_ref + out.payload_len > h->cfg.slot_size)
+      {
+         d->dropped++;
+         return 0;
+      }
+      memcpy(slot + out.payload_ref, inline_src, out.payload_len);
+   }
+   bus_ring_produce_commit(&d->qpair.inbound);
+   return 1;
+}
+
+/* Synthesize a capability_absent reply to a requester whose target kind has no
+ * ready server. */
+static void deliver_capability_absent(bus_host_t *h, uint32_t requester, uint64_t corr)
+{
+   bus_frame_t r;
+   memset(&r, 0, sizeof r);
+   r.hdr_flags = BUS_F_REPLY;
+   r.wire_version = BUS_WIRE_VERSION;
+   r.event_kind = BUS_KIND_CAPABILITY_ABSENT;
+   r.correlation_id = corr;
+   r.seq = ++h->seq;
+   if (h->tap)
+      h->tap(h->tap_ctx, &r);
+   deliver(h, requester, &r, NULL);
+}
+
+/* Route one decoded event from `src_slot`. `inline_src` points at the inline
+ * payload within the source ring slot (valid until the source is consumed). */
+static void route_one(bus_host_t *h, uint32_t src_slot, bus_frame_t *f, const uint8_t *inline_src)
+{
+   f->seq = ++h->seq;
+   f->src_handle = src_slot;
+
+   /* The tap sees every seq-stamped event, before any routing decision. */
+   if (h->tap)
+      h->tap(h->tap_ctx, f);
+
+   /* Arena-payload delivery is a separate integration; do not hand a consumer a
+    * reference it cannot read. Counted against the source so it is not silent. */
+   if (f->hdr_flags & BUS_F_ARENA)
+   {
+      h->slots[src_slot].dropped++;
+      return;
+   }
+
+   bus_kind_t *k = kind_find(h, f->event_kind);
+
+   if (f->hdr_flags & BUS_F_NOTIFICATION)
+   {
+      if (!k)
+         return; /* nobody observes this kind */
+      for (uint32_t s = 0; s < h->cfg.max_slots; s++)
+         if (h->slots[s].in_use && obs_test(k->observers, s))
+            deliver(h, s, f, inline_src);
+      return;
+   }
+
+   if (f->hdr_flags & BUS_F_REQUEST)
+   {
+      if (!k || k->server == KIND_SERVER_NONE || !h->slots[k->server].in_use)
+      {
+         deliver_capability_absent(h, src_slot, f->correlation_id);
+         return;
+      }
+      /* Point-to-point to the server, and remember the correlation so the reply
+       * routes back to this requester only. */
+      if (!pending_add(h, f->correlation_id, src_slot, (uint32_t)k->server))
+      {
+         deliver_capability_absent(h, src_slot, f->correlation_id);
+         return;
+      }
+      deliver(h, (uint32_t)k->server, f, inline_src);
+      return;
+   }
+
+   if (f->hdr_flags & BUS_F_REPLY)
+   {
+      bus_pending_t *p = pending_find(h, f->correlation_id);
+      if (!p)
+         return; /* no such outstanding request; drop */
+      /* Only the server the request was routed to may answer it. Without this a
+       * client could forge a reply for another client's correlation and have it
+       * delivered to the requester. */
+      if (p->server != src_slot)
+         return;
+      uint32_t requester = p->requester;
+      p->in_use = 0;
+      if (h->slots[requester].in_use)
+         deliver(h, requester, f, inline_src);
+      return;
+   }
+
+   if (f->hdr_flags & BUS_F_CANCEL)
+   {
+      bus_pending_t *p = pending_find(h, f->correlation_id);
+      /* Only the original requester may cancel its own request. */
+      if (p && p->requester == src_slot && h->slots[p->server].in_use)
+         deliver(h, p->server, f, inline_src); /* best-effort */
+      return;
+   }
+}
+
+uint32_t bus_host_pump(bus_host_t *h)
+{
+   if (!h || !h->slots)
+      return 0;
+   uint32_t routed = 0;
+
+   for (uint32_t s = 0; s < h->cfg.max_slots; s++)
+   {
+      bus_slot_t *slot = &h->slots[s];
+      if (!slot->in_use)
+         continue;
+
+      for (;;)
+      {
+         const uint8_t *ring_slot = bus_ring_consume_begin(&slot->qpair.outbound);
+         if (!ring_slot)
+            break;
+
+         bus_frame_t f;
+         if (bus_wire_decode(ring_slot, h->cfg.slot_size, &f) == BUS_WIRE_OK)
+         {
+            const uint8_t *inl = NULL;
+            if ((f.hdr_flags & BUS_F_INLINE) && f.payload_len > 0 &&
+                (uint64_t)f.payload_ref + f.payload_len <= h->cfg.slot_size)
+               inl = ring_slot + f.payload_ref;
+            route_one(h, s, &f, inl);
+            routed++;
+         }
+         else
+         {
+            /* A malformed frame from a client is dropped, counted, and does not
+             * stall the drain. */
+            slot->dropped++;
+         }
+         bus_ring_consume_commit(&slot->qpair.outbound);
+      }
+   }
+   return routed;
+}

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -145,8 +145,11 @@ aimee_add_test(test_bus_region test_bus_region.c ../modules/bus/bus_region.c ../
 target_include_directories(test_bus_region PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 aimee_add_test(test_bus_arena test_bus_arena.c ../modules/bus/bus_arena.c)
 target_include_directories(test_bus_arena PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
-aimee_add_test(test_bus_host test_bus_host.c ../modules/bus/bus_host.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c)
+aimee_add_test(test_bus_host test_bus_host.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c)
 target_include_directories(test_bus_host PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+
+aimee_add_test(test_bus_route test_bus_route.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c)
+target_include_directories(test_bus_route PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 
 
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -218,6 +218,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-bus-region \
                $(TESTPREFIX)/unit-test-bus-arena \
                $(TESTPREFIX)/unit-test-bus-host \
+               $(TESTPREFIX)/unit-test-bus-route \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2568,10 +2569,27 @@ $(TESTPREFIX)/unit-test-bus-arena: $(OBJDIR)/tests/test_bus_arena.o \
 $(OBJDIR)/tests/test_bus_host.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-host: $(OBJDIR)/tests/test_bus_host.o \
                                   $(OBJDIR)/modules/bus/bus_host.o \
+                                  $(OBJDIR)/modules/bus/bus_route.o \
                                   $(OBJDIR)/modules/bus/bus_region.o \
                                   $(OBJDIR)/modules/bus/bus_ring.o \
-                                  $(OBJDIR)/modules/bus/bus_arena.o
+                                  $(OBJDIR)/modules/bus/bus_arena.o \
+                                  $(OBJDIR)/modules/bus/bus_wire.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+# Event-bus routing + tap (feature tree slice 6).
+$(OBJDIR)/tests/test_bus_route.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-route: $(OBJDIR)/tests/test_bus_route.o \
+                                   $(OBJDIR)/modules/bus/bus_host.o \
+                                   $(OBJDIR)/modules/bus/bus_route.o \
+                                   $(OBJDIR)/modules/bus/bus_region.o \
+                                   $(OBJDIR)/modules/bus/bus_ring.o \
+                                   $(OBJDIR)/modules/bus/bus_arena.o \
+                                   $(OBJDIR)/modules/bus/bus_wire.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+.PHONY: unit-test-bus-route
+unit-test-bus-route: $(TESTPREFIX)/unit-test-bus-route
+	$<
 
 .PHONY: unit-test-bus-host
 unit-test-bus-host: $(TESTPREFIX)/unit-test-bus-host

--- a/src/tests/test_bus_route.c
+++ b/src/tests/test_bus_route.c
@@ -1,0 +1,375 @@
+/* test_bus_route.c: slice 6 of the event-bus feature tree.
+ *
+ * Routing and the tap, checked as outcomes:
+ *
+ *   - The tap sees every event the host accepts, exactly once, in seq order,
+ *     before routing. A client that could not enqueue (its outbound never
+ *     reached the host) produced no event and is not a tap miss.
+ *   - A notification reaches every authorized observer of its kind and no other
+ *     client — a client never receives a kind it did not subscribe to.
+ *   - A request reaches only the kind's server; its reply reaches only the
+ *     original requester, matched by correlation.
+ *   - A request for a kind with no server gets a synthesized capability_absent.
+ *   - A cancel reaches the server.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "bus_host.h"
+#include "bus_ring.h"
+#include "bus_wire.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+typedef struct
+{
+   bus_attach_reply_t reply;
+   bus_region_t control, arena, qpair;
+   bus_control_t *ctl;
+   bus_qpair_t qp;
+} client_t;
+
+static void attach(bus_host_t *h, uint32_t principal, client_t *c)
+{
+   int sv[2];
+   must(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) == 0, "socketpair");
+   bus_attach_request_t req;
+   memset(&req, 0, sizeof req);
+   req.magic = BUS_ATTACH_REQ_MAGIC;
+   req.wire_version_min = 1;
+   req.wire_version_max = 1;
+   req.principal_ref = principal;
+   must(bus_fd_send(sv[0], &req, sizeof req, NULL, 0) == 0, "send request");
+   must(bus_host_serve_attach(h, sv[1]) == BUS_HOST_OK, "admitted");
+
+   int fds[3];
+   int nfd = 0;
+   memset(c, 0, sizeof *c);
+   must(bus_fd_recv(sv[0], &c->reply, sizeof c->reply, fds, 3, &nfd) == (long)sizeof c->reply,
+        "recv reply");
+   must(nfd == 3, "three fds");
+   must(bus_region_map(fds[0], bus_control_bytes(), 0, &c->control) == BUS_REGION_OK, "map ctl");
+   must(bus_region_map(fds[1], bus_arena_region_bytes(c->reply.arena_size), 1, &c->arena) ==
+           BUS_REGION_OK,
+        "map arena");
+   must(bus_region_map(fds[2], bus_qpair_bytes(c->reply.slot_size, c->reply.queue_capacity), 1,
+                       &c->qpair) == BUS_REGION_OK,
+        "map qpair");
+   must(bus_control_attach(&c->control, &c->ctl) == BUS_REGION_OK, "attach ctl");
+   must(bus_qpair_attach(&c->qpair, &c->qp) == BUS_REGION_OK, "attach qp");
+   for (int i = 0; i < 3; i++)
+      close(fds[i]);
+   close(sv[0]);
+   close(sv[1]);
+}
+
+static void detach(client_t *c)
+{
+   bus_region_unmap(&c->control);
+   bus_region_unmap(&c->arena);
+   bus_region_unmap(&c->qpair);
+}
+
+/* A client emits an event into its outbound ring: header, then inline payload. */
+static void emit(client_t *c, uint16_t flags, uint32_t kind, uint64_t corr, uint32_t plen,
+                 uint8_t fill)
+{
+   uint8_t *slot = bus_ring_produce_begin(&c->qp.outbound);
+   must(slot != NULL, "outbound has room");
+   bus_frame_t f;
+   memset(&f, 0, sizeof f);
+   f.hdr_flags = flags | (plen ? BUS_F_INLINE : 0);
+   f.wire_version = BUS_WIRE_VERSION;
+   f.event_kind = kind;
+   f.correlation_id = corr;
+   f.payload_len = plen;
+   if (plen)
+      f.payload_ref = BUS_WIRE_HDR_LEN;
+   must(bus_wire_encode(&f, slot, c->reply.slot_size) == BUS_WIRE_HDR_LEN, "encode");
+   if (plen)
+      memset(slot + BUS_WIRE_HDR_LEN, fill, plen);
+   bus_ring_produce_commit(&c->qp.outbound);
+}
+
+/* A client reads one event from its inbound ring; returns 0 if empty. */
+static int recv_event(client_t *c, bus_frame_t *out, uint8_t *payload, uint32_t payload_cap)
+{
+   const uint8_t *slot = bus_ring_consume_begin(&c->qp.inbound);
+   if (!slot)
+      return 0;
+   must(bus_wire_decode(slot, c->reply.slot_size, out) == BUS_WIRE_OK, "decode inbound");
+   if ((out->hdr_flags & BUS_F_INLINE) && out->payload_len > 0 && payload &&
+       out->payload_len <= payload_cap)
+      memcpy(payload, slot + out->payload_ref, out->payload_len);
+   bus_ring_consume_commit(&c->qp.inbound);
+   return 1;
+}
+
+static bus_host_config_t cfg(void)
+{
+   bus_host_config_t c;
+   memset(&c, 0, sizeof c);
+   c.max_slots = 4;
+   c.slot_size = 256;
+   c.inline_budget = 192;
+   c.queue_capacity = 16;
+   c.arena_size = 128 * 1024;
+   return c;
+}
+
+/* ---- tap recorder ---- */
+
+static uint64_t g_tap_seq[256];
+static uint32_t g_tap_kind[256];
+static uint32_t g_tap_n;
+
+static void recording_tap(void *ctx, const bus_frame_t *f)
+{
+   (void)ctx;
+   must(g_tap_n < 256, "tap buffer");
+   g_tap_seq[g_tap_n] = f->seq;
+   g_tap_kind[g_tap_n] = f->event_kind;
+   g_tap_n++;
+}
+
+/* ------------------------------------------------------------------ */
+
+#define KIND_A 300
+#define KIND_B 301
+
+static void test_notification_observer_routing(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+   g_tap_n = 0;
+   bus_host_set_tap(&h, recording_tap, NULL);
+
+   client_t pub, obs1, obs2, other;
+   attach(&h, 1, &pub);
+   attach(&h, 2, &obs1);
+   attach(&h, 3, &obs2);
+   attach(&h, 4, &other);
+
+   must(bus_host_subscribe(&h, obs1.reply.handle_id, KIND_A) == BUS_HOST_OK, "obs1 subscribes A");
+   must(bus_host_subscribe(&h, obs2.reply.handle_id, KIND_A) == BUS_HOST_OK, "obs2 subscribes A");
+   /* `other` subscribes a different kind, so it must not receive KIND_A. */
+   must(bus_host_subscribe(&h, other.reply.handle_id, KIND_B) == BUS_HOST_OK, "other subs B");
+
+   emit(&pub, BUS_F_NOTIFICATION, KIND_A, 0, 4, 0xAA);
+   must(bus_host_pump(&h) == 1, "one event routed");
+
+   bus_frame_t f;
+   uint8_t buf[8];
+   must(recv_event(&obs1, &f, buf, sizeof buf) == 1 && f.event_kind == KIND_A && buf[0] == 0xAA,
+        "obs1 got the notification");
+   must(recv_event(&obs2, &f, buf, sizeof buf) == 1 && f.event_kind == KIND_A,
+        "obs2 got the notification");
+   must(recv_event(&other, &f, buf, sizeof buf) == 0, "other received nothing (wrong kind)");
+   must(recv_event(&pub, &f, buf, sizeof buf) == 0, "publisher received nothing");
+
+   /* The tap saw exactly the one accepted event. */
+   must(g_tap_n == 1 && g_tap_kind[0] == KIND_A, "tap saw the one event");
+
+   detach(&pub);
+   detach(&obs1);
+   detach(&obs2);
+   detach(&other);
+   bus_host_destroy(&h);
+   printf("  notifications: reach only authorized observers; tap sees the event\n");
+}
+
+static void test_request_reply(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+   g_tap_n = 0;
+   bus_host_set_tap(&h, recording_tap, NULL);
+
+   client_t req, server, bystander;
+   attach(&h, 1, &req);
+   attach(&h, 2, &server);
+   attach(&h, 3, &bystander);
+   must(bus_host_serve_kind(&h, server.reply.handle_id, KIND_A) == BUS_HOST_OK, "server serves A");
+   /* A second server for the same kind is refused. */
+   must(bus_host_serve_kind(&h, bystander.reply.handle_id, KIND_A) != BUS_HOST_OK,
+        "second server refused");
+
+   const uint64_t corr = 0xC0FFEE;
+   emit(&req, BUS_F_REQUEST, KIND_A, corr, 4, 0x11);
+   must(bus_host_pump(&h) == 1, "request routed");
+
+   bus_frame_t f;
+   uint8_t buf[8];
+   must(recv_event(&server, &f, buf, sizeof buf) == 1 && f.correlation_id == corr &&
+           (f.hdr_flags & BUS_F_REQUEST),
+        "server got the request");
+   must(recv_event(&bystander, &f, buf, sizeof buf) == 0, "bystander got nothing");
+   must(recv_event(&req, &f, buf, sizeof buf) == 0, "requester got nothing yet");
+
+   /* Server replies with the same correlation. */
+   emit(&server, BUS_F_REPLY, KIND_A, corr, 4, 0x22);
+   must(bus_host_pump(&h) == 1, "reply routed");
+   must(recv_event(&req, &f, buf, sizeof buf) == 1 && f.correlation_id == corr &&
+           (f.hdr_flags & BUS_F_REPLY) && buf[0] == 0x22,
+        "requester got the reply");
+   must(recv_event(&server, &f, buf, sizeof buf) == 0, "server got nothing back");
+   must(recv_event(&bystander, &f, buf, sizeof buf) == 0, "bystander still got nothing");
+
+   detach(&req);
+   detach(&server);
+   detach(&bystander);
+   bus_host_destroy(&h);
+   printf("  request/reply: point-to-point to the server and back to the requester\n");
+}
+
+/* A reply may come only from the kind's server, and a cancel only from the
+ * original requester — a client cannot forge either for someone else's
+ * correlation. */
+static void test_reply_and_cancel_spoofing_refused(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+
+   client_t req, server, attacker;
+   attach(&h, 1, &req);
+   attach(&h, 2, &server);
+   attach(&h, 3, &attacker);
+   must(bus_host_serve_kind(&h, server.reply.handle_id, KIND_A) == BUS_HOST_OK, "server serves A");
+
+   const uint64_t corr = 0x5EED;
+   emit(&req, BUS_F_REQUEST, KIND_A, corr, 0, 0);
+   must(bus_host_pump(&h) == 1, "request routed");
+   bus_frame_t f;
+   must(recv_event(&server, &f, NULL, 0) == 1, "server got the request");
+
+   /* The attacker forges a reply for the requester's correlation. It must be
+    * dropped: it is not the server. */
+   emit(&attacker, BUS_F_REPLY, KIND_A, corr, 4, 0x99);
+   must(bus_host_pump(&h) == 1, "forged reply processed");
+   must(recv_event(&req, &f, NULL, 0) == 0, "forged reply did not reach the requester");
+
+   /* The attacker forges a cancel for the requester's correlation. Dropped: it
+    * is not the requester. */
+   emit(&attacker, BUS_F_CANCEL, KIND_A, corr, 0, 0);
+   must(bus_host_pump(&h) == 1, "forged cancel processed");
+   must(recv_event(&server, &f, NULL, 0) == 0, "forged cancel did not reach the server");
+
+   /* The genuine server reply still works. */
+   emit(&server, BUS_F_REPLY, KIND_A, corr, 4, 0x22);
+   must(bus_host_pump(&h) == 1, "genuine reply routed");
+   must(recv_event(&req, &f, NULL, 0) == 1 && (f.hdr_flags & BUS_F_REPLY),
+        "genuine server reply reaches the requester");
+
+   detach(&req);
+   detach(&server);
+   detach(&attacker);
+   bus_host_destroy(&h);
+   printf("  spoofing: a non-server reply and a non-requester cancel are dropped\n");
+}
+
+static void test_capability_absent(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+
+   client_t req;
+   attach(&h, 1, &req);
+   const uint64_t corr = 0xABC;
+   emit(&req, BUS_F_REQUEST, KIND_A, corr, 0, 0); /* nobody serves KIND_A */
+   must(bus_host_pump(&h) == 1, "request routed");
+
+   bus_frame_t f;
+   must(recv_event(&req, &f, NULL, 0) == 1 && f.event_kind == BUS_KIND_CAPABILITY_ABSENT &&
+           f.correlation_id == corr && (f.hdr_flags & BUS_F_REPLY),
+        "requester got a synthesized capability_absent");
+
+   detach(&req);
+   bus_host_destroy(&h);
+   printf("  capability_absent: a request with no server is answered, not dropped\n");
+}
+
+static void test_cancel(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+
+   client_t req, server;
+   attach(&h, 1, &req);
+   attach(&h, 2, &server);
+   must(bus_host_serve_kind(&h, server.reply.handle_id, KIND_A) == BUS_HOST_OK, "server serves A");
+
+   const uint64_t corr = 0xD00D;
+   emit(&req, BUS_F_REQUEST, KIND_A, corr, 0, 0);
+   must(bus_host_pump(&h) == 1, "request routed");
+   bus_frame_t f;
+   must(recv_event(&server, &f, NULL, 0) == 1, "server got the request");
+
+   emit(&req, BUS_F_CANCEL, KIND_A, corr, 0, 0);
+   must(bus_host_pump(&h) == 1, "cancel routed");
+   must(recv_event(&server, &f, NULL, 0) == 1 && (f.hdr_flags & BUS_F_CANCEL) &&
+           f.correlation_id == corr,
+        "server got the cancel");
+
+   detach(&req);
+   detach(&server);
+   bus_host_destroy(&h);
+   printf("  cancel: delivered to the server for the outstanding correlation\n");
+}
+
+static void test_tap_order_and_completeness(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+   g_tap_n = 0;
+   bus_host_set_tap(&h, recording_tap, NULL);
+
+   client_t pub, obs;
+   attach(&h, 1, &pub);
+   attach(&h, 2, &obs);
+   must(bus_host_subscribe(&h, obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "subscribe");
+
+   /* Emit several events, then pump once. */
+   const int N = 5;
+   for (int i = 0; i < N; i++)
+      emit(&pub, BUS_F_NOTIFICATION, KIND_A, 0, 4, (uint8_t)i);
+   must(bus_host_pump(&h) == (uint32_t)N, "all routed");
+
+   /* The tap saw exactly N events, in strictly ascending seq order, once each. */
+   must(g_tap_n == (uint32_t)N, "tap saw every accepted event exactly once");
+   for (int i = 1; i < N; i++)
+      must(g_tap_seq[i] == g_tap_seq[i - 1] + 1, "seq strictly ascending, no gaps");
+
+   detach(&pub);
+   detach(&obs);
+   bus_host_destroy(&h);
+   printf("  tap: every accepted event once, in contiguous seq order\n");
+}
+
+int main(void)
+{
+   printf("test_bus_route:\n");
+   test_notification_observer_routing();
+   test_request_reply();
+   test_reply_and_cancel_spoofing_refused();
+   test_capability_absent();
+   test_cancel();
+   test_tap_order_and_completeness();
+   printf("test_bus_route: OK\n");
+   return 0;
+}


### PR DESCRIPTION
Sixth slice of the event-bus feature tree. Self-reviewed.

## What lands

The host drains each client's outbound ring and per event stamps a monotonic seq, offers it to the **governance/audit tap** (single full-stream observer, before routing — D6), then delivers by pattern:
- **notification** → every authorized observer of its kind (subscription *is* the authorization);
- **request** → the kind's single server, point-to-point, with a pending entry so the reply routes back to that requester only;
- **reply** → the original requester; **cancel** → the server;
- a request for a kind with **no server** → a synthesized **capability_absent**, not a drop.

One routing thread, so seq order = tap order = capture order. A departing slot is scrubbed from the registry and pending table.

## Self-review caught two real spoofing bugs

- A reply was routed on a **correlation match alone**, so any client could forge a reply for another's request. Now a reply is delivered only when the replier **is the kind's server**.
- Any client could **cancel any correlation**. Now only the **original requester** may. A test forges both from a third client and confirms they're dropped while the genuine reply still lands.

## Verification (normal + ASAN/UBSAN + TSAN)

Observer-routed notifications reach only subscribers; request/reply point-to-point both ways; reply/cancel spoofing refused; capability_absent for a serverless request; cancel to the server; tap sees every accepted event once in contiguous seq order.

## Scope

Inline-payload routing. Arena-payload delivery (host publishes the lease to the resolved observers, slice 4 ↔ 6) is a named follow-up; arena frames are dropped-with-count here rather than handed to a consumer that can't read them. A full inbound ring is a **counted** drop — slice 7 replaces it with credits + a typed overflow.

No shipping binary links the bus (D7). Depends on slices 1–5 (merged).