### PR TITLE
Slice 7: credit-based flow control (block/shed, typed overflow)

### DIFF
--- a/src/modules/bus/bus_host.h
+++ b/src/modules/bus/bus_host.h
@@ -90,18 +90,48 @@ typedef struct
    bus_qpair_t qpair;         /* host handles into it */
    uint64_t last_heartbeat;   /* last client_heartbeat value the host observed */
    uint64_t heartbeat_at;     /* host clock when it last advanced */
-   uint64_t dropped;          /* events the host could not deliver (full inbound) */
+   uint64_t dropped;          /* malformed/undeliverable events, counted not silent */
+
+   /* Block-policy backpressure: a destination-full event is left at this
+    * producer's outbound ring head (uncommitted) and retried next pump. It is
+    * seq-stamped and tapped exactly once, so those are remembered across
+    * retries, and the observers already delivered to are tracked so a fan-out is
+    * not double-delivered. */
+   int blocked;
+   uint64_t blocked_seq;
+   uint64_t blocked_delivered[BUS_ARENA_SLOT_WORDS];
 } bus_slot_t;
 
-/* A registered event kind: who observes its notifications, and who serves its
- * requests. Observers is a slot bitmap; server is a slot index or NONE. */
+/* Per-kind overflow policy (D5). Block is the safe default: a full destination
+ * holds the event at the producer's ring head rather than losing it. Shed is
+ * opt-in per kind: a full destination is told, via a typed overflow event, that
+ * it lost one — never a silent drop. */
+typedef enum
+{
+   BUS_KIND_BLOCK = 0,
+   BUS_KIND_SHED
+} bus_kind_policy_t;
+
+/* A registered event kind: who observes its notifications, who serves its
+ * requests, and its overflow policy. Observers is a slot bitmap; server is a
+ * slot index or NONE. */
 typedef struct
 {
    int in_use;
    uint32_t kind;
    uint64_t observers[BUS_ARENA_SLOT_WORDS];
    int32_t server; /* serving slot, or -1 */
+   bus_kind_policy_t policy;
 } bus_kind_t;
+
+/* The inline body of an overflow event: which event was shed, and to whom. A
+ * consumer can enumerate exactly the seq values it lost from these alone (D6). */
+typedef struct
+{
+   uint64_t shed_seq;
+   uint32_t shed_kind;
+   uint32_t dst_slot;
+} bus_overflow_t;
 
 /* An outstanding request, so a reply can be routed back to its requester. */
 typedef struct
@@ -196,6 +226,10 @@ bus_host_result_t bus_host_subscribe(bus_host_t *h, uint32_t slot, uint32_t even
 /* Register `slot` as the single server for `event_kind` (its requests). A second
  * server for the same kind is refused. */
 bus_host_result_t bus_host_serve_kind(bus_host_t *h, uint32_t slot, uint32_t event_kind);
+
+/* Set a kind's overflow policy. Default is BUS_KIND_BLOCK. */
+bus_host_result_t bus_host_set_kind_policy(bus_host_t *h, uint32_t event_kind,
+                                           bus_kind_policy_t policy);
 
 /* Drain every admitted client's outbound ring once, routing each event: stamp
  * seq, offer it to the tap, then deliver — notifications to the kind's authorized

--- a/src/modules/bus/bus_route.c
+++ b/src/modules/bus/bus_route.c
@@ -1,15 +1,29 @@
-/* bus_route.c: the host's routing and governance tap. See bus_host.h.
+/* bus_route.c: the host's routing, governance tap, and flow control (D5/D6).
  *
- * The host drains each admitted client's outbound ring, and for every event:
+ * The host drains each admitted client's outbound ring. For every event it
  * stamps a monotonic seq, offers it to the tap (the single full-stream observer,
- * before any routing decision — D6), then delivers it by pattern. All of this
- * runs in one thread, so seq order is the tap order and the capture order.
+ * before any routing decision — D6), then delivers by pattern under a
+ * credit-based flow-control discipline:
  *
- * This slice routes inline-payload events. An event whose payload lives in the
- * arena needs the host to publish that lease (slice 4) to the resolved observer
- * set before forwarding the reference; that composition is a named follow-up and
- * arena-flagged frames are dropped-with-count here rather than delivered to a
- * consumer that could not read them.
+ *   - The drain loop never blocks on a destination. A full destination is
+ *     resolved by that kind's policy immediately, and the loop moves on.
+ *   - BLOCK (the default): the event is left at the producer's ring head,
+ *     uncommitted, and retried next pump. The host holds at most this one
+ *     in-flight event per producer, so backpressure propagates to the producer
+ *     (its outbound stops draining) without an unbounded host queue. It is
+ *     seq-stamped and tapped once; retries deliver only to the observers that
+ *     have not yet received it.
+ *   - SHED (opt-in per kind): a full destination is sent a typed overflow event
+ *     naming the lost seq/kind — never a silent drop.
+ *
+ * Control-class events (overflow, producer_reaped, capability_absent) draw on a
+ * reserve carved from the tail of each inbound ring, so a data-saturated client
+ * still has room to be told what it lost. If even the reserve is full, a sticky
+ * control_lost flag is set — the degenerate-case backstop that keeps "never
+ * silently" true.
+ *
+ * This slice routes inline-payload events; arena-payload delivery is a separate
+ * slice-4/6 integration and arena-flagged frames are dropped-with-count here.
  */
 #include <string.h>
 
@@ -19,7 +33,7 @@
 
 #define KIND_SERVER_NONE (-1)
 
-/* ---- slot bitmap over observers ---- */
+/* ---- slot bitmaps ---- */
 
 static void obs_set(uint64_t *bits, uint32_t slot)
 {
@@ -53,14 +67,15 @@ static bus_kind_t *kind_intern(bus_host_t *h, uint32_t kind)
    {
       if (!h->kinds[i].in_use)
       {
+         memset(&h->kinds[i], 0, sizeof h->kinds[i]);
          h->kinds[i].in_use = 1;
          h->kinds[i].kind = kind;
-         memset(h->kinds[i].observers, 0, sizeof h->kinds[i].observers);
          h->kinds[i].server = KIND_SERVER_NONE;
+         h->kinds[i].policy = BUS_KIND_BLOCK;
          return &h->kinds[i];
       }
    }
-   return NULL; /* registry full */
+   return NULL;
 }
 
 void bus_host_set_tap(bus_host_t *h, bus_tap_fn fn, void *ctx)
@@ -90,15 +105,106 @@ bus_host_result_t bus_host_serve_kind(bus_host_t *h, uint32_t slot, uint32_t eve
    if (!k)
       return BUS_HOST_ERR_ARG;
    if (k->server != KIND_SERVER_NONE && k->server != (int32_t)slot)
-      return BUS_HOST_ERR_ARG; /* one server per kind */
+      return BUS_HOST_ERR_ARG;
    k->server = (int32_t)slot;
    return BUS_HOST_OK;
 }
 
-/* When a slot departs (reap/detach), scrub it from every registry role and drop
- * any pending request it was party to. Called from slot_release in bus_host.c. */
+bus_host_result_t bus_host_set_kind_policy(bus_host_t *h, uint32_t event_kind,
+                                           bus_kind_policy_t policy)
+{
+   if (!h || (policy != BUS_KIND_BLOCK && policy != BUS_KIND_SHED))
+      return BUS_HOST_ERR_ARG;
+   bus_kind_t *k = kind_intern(h, event_kind);
+   if (!k)
+      return BUS_HOST_ERR_ARG;
+   k->policy = policy;
+   return BUS_HOST_OK;
+}
+
+/* ---- delivery primitives ---- */
+
+/* Free inbound slots available to a class of traffic. Data may use all but the
+ * control reserve; control may use everything. bus_ring_count is the host's own
+ * view of a ring only it produces into, so it never over-fills; a stale count
+ * (the client just freed a slot) only defers a data event, which is safe. */
+static int has_room(const bus_slot_t *d, int is_control)
+{
+   uint32_t cap = bus_ring_capacity(&d->qpair.inbound);
+   uint32_t reserve = atomic_load_explicit(&d->qpair.hdr->control_credits, memory_order_relaxed);
+   uint64_t used = bus_ring_count(&d->qpair.inbound);
+   uint32_t limit = is_control ? cap : (reserve < cap ? cap - reserve : 0);
+   return used < limit;
+}
+
+/* Encode a (seq/dst-stamped) frame and any inline payload into a destination
+ * inbound slot. Assumes has_room already said yes. Returns 1 on success. */
+static int put(bus_host_t *h, bus_slot_t *d, const bus_frame_t *f, const uint8_t *inline_src)
+{
+   uint8_t *slot = bus_ring_produce_begin(&d->qpair.inbound);
+   if (!slot)
+      return 0;
+   bus_frame_t out = *f;
+   if (bus_wire_encode(&out, slot, h->cfg.slot_size) != BUS_WIRE_HDR_LEN)
+      return 0;
+   if ((out.hdr_flags & BUS_F_INLINE) && out.payload_len > 0)
+   {
+      if ((uint64_t)out.payload_ref + out.payload_len > h->cfg.slot_size)
+         return 0;
+      memcpy(slot + out.payload_ref, inline_src, out.payload_len);
+   }
+   bus_ring_produce_commit(&d->qpair.inbound);
+   return 1;
+}
+
+/* Emit a host-generated control-class event (overflow, producer_reaped,
+ * capability_absent): stamp seq, tap, deliver from the reserve. If even the
+ * reserve is full, set the destination's sticky control_lost. dst < 0 means
+ * tap-only (producer_reaped names a client that no longer exists). */
+static void emit_control(bus_host_t *h, int dst, uint32_t kind, uint64_t corr,
+                         const void *payload, uint32_t plen)
+{
+   bus_frame_t f;
+   memset(&f, 0, sizeof f);
+   f.wire_version = BUS_WIRE_VERSION;
+   f.event_kind = kind;
+   f.correlation_id = corr;
+   f.hdr_flags = (corr ? BUS_F_REPLY : BUS_F_NOTIFICATION) | BUS_F_CONTROL;
+   if (plen)
+   {
+      f.hdr_flags |= BUS_F_INLINE;
+      f.payload_len = plen;
+      f.payload_ref = BUS_WIRE_HDR_LEN;
+   }
+   f.seq = ++h->seq;
+   f.dst_handle = dst < 0 ? 0 : (uint32_t)dst;
+   if (h->tap)
+      h->tap(h->tap_ctx, &f);
+   if (dst < 0)
+      return; /* tap-only */
+   bus_slot_t *d = &h->slots[dst];
+   if (has_room(d, 1) && put(h, d, &f, payload))
+      return;
+   atomic_store_explicit(&d->qpair.hdr->control_lost, 1, memory_order_release);
+}
+
+/* Shed one data event to a full destination: tell it, via an overflow event,
+ * exactly which seq/kind it lost. */
+static void shed(bus_host_t *h, uint32_t dst, const bus_frame_t *shed_f)
+{
+   bus_overflow_t ov = {.shed_seq = shed_f->seq, .shed_kind = shed_f->event_kind, .dst_slot = dst};
+   emit_control(h, (int)dst, BUS_KIND_OVERFLOW, 0, &ov, (uint32_t)sizeof ov);
+}
+
+/* ---- forget a departing slot ---- */
+
 void bus_route_forget_slot(bus_host_t *h, uint32_t slot)
 {
+   /* If the slot had a block-held event in flight, it is discarded now: name its
+    * seq to the tap as producer_reaped so the loss is recorded, not silent. */
+   if (h->slots[slot].blocked)
+      emit_control(h, -1, BUS_KIND_PRODUCER_REAPED, 0, NULL, 0);
+
    for (uint32_t i = 0; i < BUS_HOST_MAX_KINDS; i++)
    {
       if (!h->kinds[i].in_use)
@@ -140,134 +246,116 @@ static bus_pending_t *pending_find(bus_host_t *h, uint64_t corr)
    return NULL;
 }
 
-/* ---- delivery ---- */
+/* ---- routing ---- */
 
-/* Write a (seq/dst-stamped) frame and its inline payload into a destination
- * slot's inbound ring. Returns 1 on delivery, 0 if the ring was full. The full
- * case is counted, not silent — slice 7 replaces the drop with credit-based
- * backpressure and a typed overflow event. */
-static int deliver(bus_host_t *h, uint32_t dst_slot, const bus_frame_t *f,
-                   const uint8_t *inline_src)
+/* Route a notification to observers. Returns 1 if fully resolved (may commit the
+ * source), 0 if a BLOCK-policy destination was full and the event must stay at
+ * the producer's ring head. `delivered` tracks observers already served across
+ * retries. */
+static int route_notification(bus_host_t *h, uint32_t src, bus_frame_t *f,
+                              const uint8_t *inl, bus_kind_t *k, uint64_t *delivered)
 {
-   bus_slot_t *d = &h->slots[dst_slot];
-   uint8_t *slot = bus_ring_produce_begin(&d->qpair.inbound);
-   if (!slot)
+   int all_done = 1;
+   for (uint32_t s = 0; s < h->cfg.max_slots; s++)
    {
-      d->dropped++;
-      return 0;
-   }
-
-   bus_frame_t out = *f;
-   out.dst_handle = dst_slot;
-   if (bus_wire_encode(&out, slot, h->cfg.slot_size) != BUS_WIRE_HDR_LEN)
-   {
-      d->dropped++;
-      return 0;
-   }
-   if ((out.hdr_flags & BUS_F_INLINE) && out.payload_len > 0)
-   {
-      /* Inline payloads sit just past the header, inside the slot. */
-      if ((uint64_t)out.payload_ref + out.payload_len > h->cfg.slot_size)
+      if (!h->slots[s].in_use || !obs_test(k->observers, s))
+         continue;
+      if (obs_test(delivered, s))
+         continue; /* already delivered on a prior retry */
+      bus_slot_t *d = &h->slots[s];
+      if (has_room(d, 0) && put(h, d, f, inl))
       {
-         d->dropped++;
-         return 0;
+         obs_set(delivered, s);
+         continue;
       }
-      memcpy(slot + out.payload_ref, inline_src, out.payload_len);
+      /* Full destination. */
+      if (k->policy == BUS_KIND_SHED)
+      {
+         shed(h, s, f);
+         obs_set(delivered, s); /* shed is resolution: never retried */
+      }
+      else
+      {
+         all_done = 0; /* BLOCK: leave the event in flight for this destination */
+      }
    }
-   bus_ring_produce_commit(&d->qpair.inbound);
-   return 1;
+   return all_done;
 }
 
-/* Synthesize a capability_absent reply to a requester whose target kind has no
- * ready server. */
-static void deliver_capability_absent(bus_host_t *h, uint32_t requester, uint64_t corr)
+/* Route a fresh event (first time it is seen). Returns 1 if fully resolved. On a
+ * BLOCK stall it returns 0 and sets *blocked_delivered so retries resume. */
+static int route_fresh(bus_host_t *h, uint32_t src, bus_frame_t *f, const uint8_t *inl,
+                       uint64_t *delivered)
 {
-   bus_frame_t r;
-   memset(&r, 0, sizeof r);
-   r.hdr_flags = BUS_F_REPLY;
-   r.wire_version = BUS_WIRE_VERSION;
-   r.event_kind = BUS_KIND_CAPABILITY_ABSENT;
-   r.correlation_id = corr;
-   r.seq = ++h->seq;
-   if (h->tap)
-      h->tap(h->tap_ctx, &r);
-   deliver(h, requester, &r, NULL);
-}
-
-/* Route one decoded event from `src_slot`. `inline_src` points at the inline
- * payload within the source ring slot (valid until the source is consumed). */
-static void route_one(bus_host_t *h, uint32_t src_slot, bus_frame_t *f, const uint8_t *inline_src)
-{
-   f->seq = ++h->seq;
-   f->src_handle = src_slot;
-
-   /* The tap sees every seq-stamped event, before any routing decision. */
-   if (h->tap)
-      h->tap(h->tap_ctx, f);
-
-   /* Arena-payload delivery is a separate integration; do not hand a consumer a
-    * reference it cannot read. Counted against the source so it is not silent. */
    if (f->hdr_flags & BUS_F_ARENA)
    {
-      h->slots[src_slot].dropped++;
-      return;
+      h->slots[src].dropped++;
+      return 1; /* out of scope this slice; resolved (dropped, counted) */
    }
 
    bus_kind_t *k = kind_find(h, f->event_kind);
 
    if (f->hdr_flags & BUS_F_NOTIFICATION)
-   {
-      if (!k)
-         return; /* nobody observes this kind */
-      for (uint32_t s = 0; s < h->cfg.max_slots; s++)
-         if (h->slots[s].in_use && obs_test(k->observers, s))
-            deliver(h, s, f, inline_src);
-      return;
-   }
+      return k ? route_notification(h, src, f, inl, k, delivered) : 1;
 
    if (f->hdr_flags & BUS_F_REQUEST)
    {
       if (!k || k->server == KIND_SERVER_NONE || !h->slots[k->server].in_use)
       {
-         deliver_capability_absent(h, src_slot, f->correlation_id);
-         return;
+         emit_control(h, (int)src, BUS_KIND_CAPABILITY_ABSENT, f->correlation_id, NULL, 0);
+         return 1;
       }
-      /* Point-to-point to the server, and remember the correlation so the reply
-       * routes back to this requester only. */
-      if (!pending_add(h, f->correlation_id, src_slot, (uint32_t)k->server))
+      bus_slot_t *d = &h->slots[k->server];
+      /* A request is point-to-point; block if the server is full. */
+      if (!has_room(d, 0))
       {
-         deliver_capability_absent(h, src_slot, f->correlation_id);
-         return;
+         if (k->policy == BUS_KIND_SHED)
+         {
+            shed(h, (uint32_t)k->server, f);
+            return 1;
+         }
+         return 0; /* block: retry next pump */
       }
-      deliver(h, (uint32_t)k->server, f, inline_src);
-      return;
+      if (!pending_add(h, f->correlation_id, src, (uint32_t)k->server))
+      {
+         emit_control(h, (int)src, BUS_KIND_CAPABILITY_ABSENT, f->correlation_id, NULL, 0);
+         return 1;
+      }
+      put(h, d, f, inl);
+      return 1;
    }
 
    if (f->hdr_flags & BUS_F_REPLY)
    {
       bus_pending_t *p = pending_find(h, f->correlation_id);
-      if (!p)
-         return; /* no such outstanding request; drop */
-      /* Only the server the request was routed to may answer it. Without this a
-       * client could forge a reply for another client's correlation and have it
-       * delivered to the requester. */
-      if (p->server != src_slot)
-         return;
+      if (!p || p->server != src)
+         return 1; /* no matching request, or a forged reply; drop */
       uint32_t requester = p->requester;
+      if (!h->slots[requester].in_use)
+      {
+         p->in_use = 0;
+         return 1;
+      }
+      bus_slot_t *d = &h->slots[requester];
+      if (!has_room(d, 0))
+         return 0; /* block until the requester has room; keep the pending entry */
       p->in_use = 0;
-      if (h->slots[requester].in_use)
-         deliver(h, requester, f, inline_src);
-      return;
+      put(h, d, f, inl);
+      return 1;
    }
 
    if (f->hdr_flags & BUS_F_CANCEL)
    {
       bus_pending_t *p = pending_find(h, f->correlation_id);
-      /* Only the original requester may cancel its own request. */
-      if (p && p->requester == src_slot && h->slots[p->server].in_use)
-         deliver(h, p->server, f, inline_src); /* best-effort */
-      return;
+      if (p && p->requester == src && h->slots[p->server].in_use)
+      {
+         bus_slot_t *d = &h->slots[p->server];
+         if (has_room(d, 0))
+            put(h, d, f, inl); /* best-effort */
+      }
+      return 1;
    }
+   return 1;
 }
 
 uint32_t bus_host_pump(bus_host_t *h)
@@ -289,22 +377,51 @@ uint32_t bus_host_pump(bus_host_t *h)
             break;
 
          bus_frame_t f;
-         if (bus_wire_decode(ring_slot, h->cfg.slot_size, &f) == BUS_WIRE_OK)
+         if (bus_wire_decode(ring_slot, h->cfg.slot_size, &f) != BUS_WIRE_OK)
          {
-            const uint8_t *inl = NULL;
-            if ((f.hdr_flags & BUS_F_INLINE) && f.payload_len > 0 &&
-                (uint64_t)f.payload_ref + f.payload_len <= h->cfg.slot_size)
-               inl = ring_slot + f.payload_ref;
-            route_one(h, s, &f, inl);
-            routed++;
+            slot->dropped++;
+            bus_ring_consume_commit(&slot->qpair.outbound);
+            continue;
+         }
+
+         const uint8_t *inl = NULL;
+         if ((f.hdr_flags & BUS_F_INLINE) && f.payload_len > 0 &&
+             (uint64_t)f.payload_ref + f.payload_len <= h->cfg.slot_size)
+            inl = ring_slot + f.payload_ref;
+
+         int done;
+         if (slot->blocked)
+         {
+            /* Same head event as last pump: reuse its seq, do not re-tap. */
+            f.seq = slot->blocked_seq;
+            f.src_handle = s;
+            done = route_fresh(h, s, &f, inl, slot->blocked_delivered);
          }
          else
          {
-            /* A malformed frame from a client is dropped, counted, and does not
-             * stall the drain. */
-            slot->dropped++;
+            f.seq = ++h->seq;
+            f.src_handle = s;
+            if (h->tap)
+               h->tap(h->tap_ctx, &f); /* seq-stamped, pre-routing, once */
+            memset(slot->blocked_delivered, 0, sizeof slot->blocked_delivered);
+            done = route_fresh(h, s, &f, inl, slot->blocked_delivered);
+            routed++; /* count each accepted event once, at first sight */
          }
-         bus_ring_consume_commit(&slot->qpair.outbound);
+
+         if (done)
+         {
+            slot->blocked = 0;
+            bus_ring_consume_commit(&slot->qpair.outbound);
+         }
+         else
+         {
+            /* BLOCK: leave the event at the ring head, stop draining this
+             * producer this round. Its outbound stops moving, which is the
+             * backpressure. */
+            slot->blocked = 1;
+            slot->blocked_seq = f.seq;
+            break;
+         }
       }
    }
    return routed;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -151,6 +151,9 @@ target_include_directories(test_bus_host PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../
 aimee_add_test(test_bus_route test_bus_route.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c)
 target_include_directories(test_bus_route PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 
+aimee_add_test(test_bus_flow test_bus_flow.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c)
+target_include_directories(test_bus_flow PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+
 
 
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -219,6 +219,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-bus-arena \
                $(TESTPREFIX)/unit-test-bus-host \
                $(TESTPREFIX)/unit-test-bus-route \
+               $(TESTPREFIX)/unit-test-bus-flow \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2586,6 +2587,21 @@ $(TESTPREFIX)/unit-test-bus-route: $(OBJDIR)/tests/test_bus_route.o \
                                    $(OBJDIR)/modules/bus/bus_arena.o \
                                    $(OBJDIR)/modules/bus/bus_wire.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+# Event-bus flow control (feature tree slice 7).
+$(OBJDIR)/tests/test_bus_flow.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-flow: $(OBJDIR)/tests/test_bus_flow.o \
+                                  $(OBJDIR)/modules/bus/bus_host.o \
+                                  $(OBJDIR)/modules/bus/bus_route.o \
+                                  $(OBJDIR)/modules/bus/bus_region.o \
+                                  $(OBJDIR)/modules/bus/bus_ring.o \
+                                  $(OBJDIR)/modules/bus/bus_arena.o \
+                                  $(OBJDIR)/modules/bus/bus_wire.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+.PHONY: unit-test-bus-flow
+unit-test-bus-flow: $(TESTPREFIX)/unit-test-bus-flow
+	$<
 
 .PHONY: unit-test-bus-route
 unit-test-bus-route: $(TESTPREFIX)/unit-test-bus-route

--- a/src/tests/test_bus_flow.c
+++ b/src/tests/test_bus_flow.c
@@ -1,0 +1,437 @@
+/* test_bus_flow.c: slice 7 of the event-bus feature tree — flow control.
+ *
+ * The properties that make backpressure safe, checked as outcomes:
+ *
+ *   - A BLOCK-policy event to a full destination is not lost: it is held at the
+ *     producer's ring head and delivered once the destination drains. It is
+ *     seq-stamped and tapped exactly once across the retries.
+ *   - One slow consumer stalls only its own producer, never another.
+ *   - A SHED-policy event to a full destination produces a typed overflow event
+ *     naming the lost seq and kind — a consumer can enumerate its losses.
+ *   - Overflow (a control-class event) is delivered from a reserve even when the
+ *     data ring is full; when the reserve too is exhausted, a sticky
+ *     control_lost flag is set — never a silent loss.
+ *   - Reaping a producer that had a block-held event names the discarded seq to
+ *     the tap as producer_reaped.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "bus_host.h"
+#include "bus_ring.h"
+#include "bus_wire.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+typedef struct
+{
+   bus_attach_reply_t reply;
+   bus_region_t control, arena, qpair;
+   bus_control_t *ctl;
+   bus_qpair_t qp;
+} client_t;
+
+static void attach(bus_host_t *h, uint32_t principal, client_t *c)
+{
+   int sv[2];
+   must(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) == 0, "socketpair");
+   bus_attach_request_t req;
+   memset(&req, 0, sizeof req);
+   req.magic = BUS_ATTACH_REQ_MAGIC;
+   req.wire_version_min = 1;
+   req.wire_version_max = 1;
+   req.principal_ref = principal;
+   must(bus_fd_send(sv[0], &req, sizeof req, NULL, 0) == 0, "send request");
+   must(bus_host_serve_attach(h, sv[1]) == BUS_HOST_OK, "admitted");
+   int fds[3];
+   int nfd = 0;
+   memset(c, 0, sizeof *c);
+   must(bus_fd_recv(sv[0], &c->reply, sizeof c->reply, fds, 3, &nfd) == (long)sizeof c->reply,
+        "recv reply");
+   must(bus_region_map(fds[0], bus_control_bytes(), 0, &c->control) == BUS_REGION_OK, "map ctl");
+   must(bus_region_map(fds[1], bus_arena_region_bytes(c->reply.arena_size), 1, &c->arena) ==
+           BUS_REGION_OK,
+        "map arena");
+   must(bus_region_map(fds[2], bus_qpair_bytes(c->reply.slot_size, c->reply.queue_capacity), 1,
+                       &c->qpair) == BUS_REGION_OK,
+        "map qpair");
+   must(bus_control_attach(&c->control, &c->ctl) == BUS_REGION_OK, "attach ctl");
+   must(bus_qpair_attach(&c->qpair, &c->qp) == BUS_REGION_OK, "attach qp");
+   for (int i = 0; i < 3; i++)
+      close(fds[i]);
+   close(sv[0]);
+   close(sv[1]);
+}
+
+static void detach(client_t *c)
+{
+   bus_region_unmap(&c->control);
+   bus_region_unmap(&c->arena);
+   bus_region_unmap(&c->qpair);
+}
+
+static void emit(client_t *c, uint16_t flags, uint32_t kind, uint32_t plen, uint8_t fill)
+{
+   uint8_t *slot = bus_ring_produce_begin(&c->qp.outbound);
+   must(slot != NULL, "outbound has room");
+   bus_frame_t f;
+   memset(&f, 0, sizeof f);
+   f.hdr_flags = flags | (plen ? BUS_F_INLINE : 0);
+   f.wire_version = BUS_WIRE_VERSION;
+   f.event_kind = kind;
+   f.payload_len = plen;
+   if (plen)
+      f.payload_ref = BUS_WIRE_HDR_LEN;
+   must(bus_wire_encode(&f, slot, c->reply.slot_size) == BUS_WIRE_HDR_LEN, "encode");
+   if (plen)
+      memset(slot + BUS_WIRE_HDR_LEN, fill, plen);
+   bus_ring_produce_commit(&c->qp.outbound);
+}
+
+static int recv_event(client_t *c, bus_frame_t *out, uint8_t *payload, uint32_t cap)
+{
+   const uint8_t *slot = bus_ring_consume_begin(&c->qp.inbound);
+   if (!slot)
+      return 0;
+   must(bus_wire_decode(slot, c->reply.slot_size, out) == BUS_WIRE_OK, "decode inbound");
+   if ((out->hdr_flags & BUS_F_INLINE) && out->payload_len > 0 && payload &&
+       out->payload_len <= cap)
+      memcpy(payload, slot + out->payload_ref, out->payload_len);
+   bus_ring_consume_commit(&c->qp.inbound);
+   return 1;
+}
+
+static bus_host_config_t cfg(void)
+{
+   bus_host_config_t c;
+   memset(&c, 0, sizeof c);
+   c.max_slots = 4;
+   c.slot_size = 128;
+   c.inline_budget = 64;
+   c.queue_capacity = 8; /* small, with a control reserve of 4 -> 4 data slots */
+   c.arena_size = 64 * 1024;
+   return c;
+}
+
+/* ---- tap recorder ---- */
+
+static uint64_t g_seq[512];
+static uint32_t g_kind[512];
+static uint32_t g_n;
+static void tap(void *ctx, const bus_frame_t *f)
+{
+   (void)ctx;
+   must(g_n < 512, "tap buffer");
+   g_seq[g_n] = f->seq;
+   g_kind[g_n] = f->event_kind;
+   g_n++;
+}
+static uint32_t tap_count_kind(uint32_t kind)
+{
+   uint32_t n = 0;
+   for (uint32_t i = 0; i < g_n; i++)
+      if (g_kind[i] == kind)
+         n++;
+   return n;
+}
+
+#define KIND_A 400
+
+/* The inbound data limit is capacity - control_reserve. */
+static uint32_t data_limit(const client_t *c)
+{
+   uint32_t reserve =
+      atomic_load_explicit(&c->qp.hdr->control_credits, memory_order_relaxed);
+   return c->reply.queue_capacity - reserve;
+}
+
+static void test_block_holds_then_delivers(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+   g_n = 0;
+   bus_host_set_tap(&h, tap, NULL);
+
+   client_t pub, obs;
+   attach(&h, 1, &pub);
+   attach(&h, 2, &obs);
+   must(bus_host_subscribe(&h, obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "subscribe");
+   /* KIND_A defaults to BLOCK. */
+
+   uint32_t lim = data_limit(&obs);
+   /* Emit one more than the data limit; the last one must block, not be lost. */
+   for (uint32_t i = 0; i <= lim; i++)
+      emit(&pub, BUS_F_NOTIFICATION, KIND_A, 4, (uint8_t)i);
+
+   /* First pump: lim events delivered, the (lim+1)th blocks at the producer. */
+   bus_host_pump(&h);
+   must(h.slots[pub.reply.handle_id].blocked, "producer is blocked on the full destination");
+   uint32_t tap_after_first = tap_count_kind(KIND_A);
+   must(tap_after_first == lim + 1, "the blocked event was tapped once already");
+
+   /* The consumer drains one slot; next pump delivers the held event. */
+   bus_frame_t f;
+   uint8_t buf[8];
+   must(recv_event(&obs, &f, buf, sizeof buf) == 1, "consumer drains one");
+   bus_host_pump(&h);
+   must(!h.slots[pub.reply.handle_id].blocked, "producer unblocked once room appeared");
+
+   /* Drain everything and count: exactly lim+1 distinct events reached the
+    * consumer, none lost, none duplicated. */
+   uint32_t got = 1; /* already drained one above */
+   while (recv_event(&obs, &f, buf, sizeof buf))
+      got++;
+   must(got == lim + 1, "every blocked event was delivered exactly once");
+   /* And the tap still saw it exactly once (no re-tap across retries). */
+   must(tap_count_kind(KIND_A) == lim + 1, "no event tapped twice across retries");
+
+   detach(&pub);
+   detach(&obs);
+   bus_host_destroy(&h);
+   printf("  block: a full destination holds the event, then delivers it once\n");
+}
+
+static void test_block_is_per_producer(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+
+   client_t slow_pub, fast_pub, slow_obs, fast_obs;
+   attach(&h, 1, &slow_pub);
+   attach(&h, 2, &fast_pub);
+   attach(&h, 3, &slow_obs);
+   attach(&h, 4, &fast_obs);
+   must(bus_host_subscribe(&h, slow_obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "slow subs");
+   must(bus_host_subscribe(&h, fast_obs.reply.handle_id, KIND_A + 1) == BUS_HOST_OK, "fast subs");
+
+   /* Overfill the slow observer's kind so slow_pub blocks; fast_pub targets a
+    * different kind/consumer that has room. */
+   uint32_t lim = data_limit(&slow_obs);
+   for (uint32_t i = 0; i <= lim; i++)
+      emit(&slow_pub, BUS_F_NOTIFICATION, KIND_A, 4, 0);
+   emit(&fast_pub, BUS_F_NOTIFICATION, KIND_A + 1, 4, 0);
+
+   bus_host_pump(&h);
+   must(h.slots[slow_pub.reply.handle_id].blocked, "slow producer blocked");
+   must(!h.slots[fast_pub.reply.handle_id].blocked, "fast producer not blocked");
+
+   /* The fast observer got its event despite the slow producer being stuck. */
+   bus_frame_t f;
+   must(recv_event(&fast_obs, &f, NULL, 0) == 1, "fast consumer served while slow is blocked");
+
+   detach(&slow_pub);
+   detach(&fast_pub);
+   detach(&slow_obs);
+   detach(&fast_obs);
+   bus_host_destroy(&h);
+   printf("  block: one slow consumer stalls only its own producer\n");
+}
+
+/* A block-policy notification to two observers, one full and one with room: the
+ * observer with room is served immediately and exactly once — it must not be
+ * re-delivered when the blocked observer later drains. This exercises the
+ * per-retry delivered-bitmap, the subtle part of block fan-out. */
+static void test_block_fanout_no_double_deliver(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+
+   client_t pub, full_obs, roomy_obs;
+   attach(&h, 1, &pub);
+   attach(&h, 2, &full_obs);
+   attach(&h, 3, &roomy_obs);
+   must(bus_host_subscribe(&h, full_obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "full subs");
+   must(bus_host_subscribe(&h, roomy_obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "roomy subs");
+
+   /* Fill full_obs to its data limit with prior events, then emit one more that
+    * fans out to both. full_obs blocks; roomy_obs must get it once. */
+   uint32_t lim = data_limit(&full_obs);
+   for (uint32_t i = 0; i < lim; i++)
+   {
+      emit(&pub, BUS_F_NOTIFICATION, KIND_A, 4, 0);
+      bus_host_pump(&h);
+      /* roomy_obs also receives these; drain it so only the final event matters. */
+      bus_frame_t tmp;
+      recv_event(&roomy_obs, &tmp, NULL, 0);
+   }
+   /* full_obs is now at its data limit; roomy_obs is empty. */
+   emit(&pub, BUS_F_NOTIFICATION, KIND_A, 4, 0x77);
+   bus_host_pump(&h);
+   must(h.slots[pub.reply.handle_id].blocked, "producer blocked on the full observer");
+
+   /* roomy_obs got the fan-out event exactly once already. */
+   bus_frame_t f;
+   uint8_t buf[8];
+   must(recv_event(&roomy_obs, &f, buf, sizeof buf) == 1 && buf[0] == 0x77,
+        "roomy observer got the event");
+   must(recv_event(&roomy_obs, &f, buf, sizeof buf) == 0, "roomy observer got it only once");
+
+   /* Drain full_obs; the retry delivers the held copy to it, and must NOT
+    * re-deliver to roomy_obs. */
+   while (recv_event(&full_obs, &f, buf, sizeof buf))
+      ; /* drain all */
+   bus_host_pump(&h);
+   must(!h.slots[pub.reply.handle_id].blocked, "producer unblocked");
+   must(recv_event(&full_obs, &f, buf, sizeof buf) == 1 && buf[0] == 0x77,
+        "full observer finally got the held event");
+   must(recv_event(&roomy_obs, &f, buf, sizeof buf) == 0,
+        "roomy observer was not re-delivered on the retry");
+
+   detach(&pub);
+   detach(&full_obs);
+   detach(&roomy_obs);
+   bus_host_destroy(&h);
+   printf("  block fan-out: the served observer is not re-delivered on retry\n");
+}
+
+static void test_shed_emits_overflow(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+   g_n = 0;
+   bus_host_set_tap(&h, tap, NULL);
+
+   client_t pub, obs;
+   attach(&h, 1, &pub);
+   attach(&h, 2, &obs);
+   must(bus_host_subscribe(&h, obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "subscribe");
+   must(bus_host_set_kind_policy(&h, KIND_A, BUS_KIND_SHED) == BUS_HOST_OK, "KIND_A sheds");
+
+   uint32_t lim = data_limit(&obs);
+   /* Fill the data allowance, then emit one more: it must be shed with a typed
+    * overflow rather than blocking or vanishing. */
+   for (uint32_t i = 0; i < lim; i++)
+      emit(&pub, BUS_F_NOTIFICATION, KIND_A, 4, 0);
+   emit(&pub, BUS_F_NOTIFICATION, KIND_A, 4, 0xEE); /* the one that overflows */
+   bus_host_pump(&h);
+   must(!h.slots[pub.reply.handle_id].blocked, "shed does not block the producer");
+
+   /* Drain the data events, then the overflow (control-class, from the reserve)
+    * naming the shed seq. */
+   bus_frame_t f;
+   uint8_t buf[32];
+   uint32_t data = 0, overflow = 0;
+   while (recv_event(&obs, &f, buf, sizeof buf))
+   {
+      if (f.event_kind == BUS_KIND_OVERFLOW)
+      {
+         overflow++;
+         must(f.hdr_flags & BUS_F_CONTROL, "overflow is control-class");
+         bus_overflow_t ov;
+         memcpy(&ov, buf, sizeof ov);
+         must(ov.shed_kind == KIND_A, "overflow names the shed kind");
+         must(ov.dst_slot == obs.reply.handle_id, "overflow names the destination");
+         /* The shed seq was a real tapped seq. */
+         int found = 0;
+         for (uint32_t i = 0; i < g_n; i++)
+            if (g_seq[i] == ov.shed_seq && g_kind[i] == KIND_A)
+               found = 1;
+         must(found, "the shed seq was a genuine tapped event");
+      }
+      else
+      {
+         data++;
+      }
+   }
+   must(data == lim, "the data allowance was delivered");
+   must(overflow == 1, "exactly one overflow for the one shed event");
+
+   detach(&pub);
+   detach(&obs);
+   bus_host_destroy(&h);
+   printf("  shed: a full destination gets a typed overflow naming the lost seq\n");
+}
+
+static void test_control_lost_when_reserve_exhausted(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+
+   client_t pub, obs;
+   attach(&h, 1, &pub);
+   attach(&h, 2, &obs);
+   must(bus_host_subscribe(&h, obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "subscribe");
+   must(bus_host_set_kind_policy(&h, KIND_A, BUS_KIND_SHED) == BUS_HOST_OK, "shed");
+
+   /* Fill the ENTIRE inbound ring (data allowance + the whole control reserve)
+    * by shedding far more than capacity, so even overflow events cannot fit.
+    * The consumer never drains, so the reserve fills and control_lost latches. */
+   uint32_t cap = obs.reply.queue_capacity;
+   for (uint32_t i = 0; i < cap * 3; i++)
+   {
+      /* Re-emit as the outbound ring drains via pump each time. */
+      emit(&pub, BUS_F_NOTIFICATION, KIND_A, 4, 0);
+      bus_host_pump(&h);
+   }
+   must(atomic_load_explicit(&obs.qp.hdr->control_lost, memory_order_acquire) == 1,
+        "control_lost latched when even the reserve was exhausted");
+
+   detach(&pub);
+   detach(&obs);
+   bus_host_destroy(&h);
+   printf("  control_lost: latches when the reserve itself is exhausted\n");
+}
+
+static void test_producer_reaped_tap_only(void)
+{
+   bus_host_config_t c = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &c, NULL, NULL) == BUS_HOST_OK, "host");
+   g_n = 0;
+   bus_host_set_tap(&h, tap, NULL);
+
+   client_t pub, obs;
+   attach(&h, 1, &pub);
+   attach(&h, 2, &obs);
+   must(bus_host_subscribe(&h, obs.reply.handle_id, KIND_A) == BUS_HOST_OK, "subscribe");
+
+   /* Block the producer on the full (never-draining) destination. */
+   uint32_t lim = data_limit(&obs);
+   for (uint32_t i = 0; i <= lim; i++)
+      emit(&pub, BUS_F_NOTIFICATION, KIND_A, 4, 0);
+   bus_host_pump(&h);
+   must(h.slots[pub.reply.handle_id].blocked, "producer blocked");
+
+   uint32_t before = tap_count_kind(BUS_KIND_PRODUCER_REAPED);
+   /* Reap the blocked producer: its held event is discarded and named to the
+    * tap as producer_reaped — recorded, delivered to no one. */
+   atomic_store_explicit(&pub.qp.hdr->client_heartbeat, 0, memory_order_release);
+   bus_host_reap(&h, 100, 10); /* first tick starts the clock */
+   bus_host_reap(&h, 200, 10); /* now stale -> reaped */
+   must(!h.slots[pub.reply.handle_id].in_use, "producer reaped");
+   must(tap_count_kind(BUS_KIND_PRODUCER_REAPED) == before + 1,
+        "the discarded in-flight event was named to the tap as producer_reaped");
+
+   detach(&pub);
+   detach(&obs);
+   bus_host_destroy(&h);
+   printf("  producer_reaped: a discarded in-flight event is named to the tap\n");
+}
+
+int main(void)
+{
+   printf("test_bus_flow:\n");
+   test_block_holds_then_delivers();
+   test_block_is_per_producer();
+   test_block_fanout_no_double_deliver();
+   test_shed_emits_overflow();
+   test_control_lost_when_reserve_exhausted();
+   test_producer_reaped_tap_only();
+   printf("test_bus_flow: OK\n");
+   return 0;
+}


### PR DESCRIPTION
Seventh slice. Self-reviewed. Replaces slice 6's counted-drop with real backpressure (D5/D6).

## What lands

Per-kind overflow policy (default **BLOCK**):
- **BLOCK**: a full destination holds the event at the producer's ring head, retried next pump — at most one in-flight event per producer, so its outbound stops draining (backpressure, no unbounded host queue). Seq-stamped and tapped **once**; retries deliver only to fan-out observers not yet served.
- **SHED** (opt-in): a full destination gets a **typed overflow** naming the lost seq/kind — never silent.

The drain loop never blocks on a destination, so one slow consumer stalls only its own producer. Control-class events (overflow, producer_reaped, capability_absent) draw on a **reserve** carved from each inbound ring; when even the reserve is full, a sticky **control_lost** latches. Reaping a producer with a block-held event names the discarded seq to the tap as **producer_reaped** (tap-only).

## Self-review

Added the trickiest path: a block fan-out to two observers (one full, one with room) serves the roomy one **once** and does not re-deliver it when the blocked one drains — the per-retry delivered-bitmap.

## Verification (normal + ASAN/UBSAN + TSAN)

block holds-then-delivers-once with a single tap; block per-producer; block fan-out no double-deliver; shed→typed overflow; control_lost latches; producer_reaped to the tap. Slice 6 routing tests still green under the rewritten router.

No shipping binary links the bus (D7). Depends on slices 1–6 (merged).