### PR TITLE
Slice 8: C reference client library

### DIFF
--- a/src/modules/bus/bus_client.c
+++ b/src/modules/bus/bus_client.c
@@ -1,0 +1,240 @@
+/* bus_client.c: the C reference bus client. See bus_client.h. */
+#include <string.h>
+#include <unistd.h>
+
+#include "bus_client.h"
+#include "bus_ring.h"
+
+bus_client_result_t bus_client_attach(int sock, bus_client_t *c)
+{
+   if (!c || sock < 0)
+      return BUS_CLIENT_ERR_ARG;
+   memset(c, 0, sizeof *c);
+
+   bus_attach_request_t req;
+   memset(&req, 0, sizeof req);
+   req.magic = BUS_ATTACH_REQ_MAGIC;
+   req.wire_version_min = BUS_WIRE_VERSION;
+   req.wire_version_max = BUS_WIRE_VERSION;
+   if (bus_fd_send(sock, &req, sizeof req, NULL, 0) != 0)
+      return BUS_CLIENT_ERR_OS;
+
+   int fds[3];
+   int nfd = 0;
+   long n = bus_fd_recv(sock, &c->reply, sizeof c->reply, fds, 3, &nfd);
+   if (n != (long)sizeof c->reply || c->reply.magic != BUS_ATTACH_REPLY_MAGIC)
+   {
+      for (int i = 0; i < nfd; i++)
+         close(fds[i]);
+      return BUS_CLIENT_ERR_PROTOCOL;
+   }
+
+   c->attach_status = (bus_attach_status_t)c->reply.status;
+   if (c->reply.status != BUS_ATTACH_OK)
+   {
+      for (int i = 0; i < nfd; i++)
+         close(fds[i]);
+      return BUS_CLIENT_DENIED;
+   }
+   if (nfd != 3)
+   {
+      for (int i = 0; i < nfd; i++)
+         close(fds[i]);
+      return BUS_CLIENT_ERR_PROTOCOL;
+   }
+
+   /* control (read-only), arena (rw), own queue pair (rw). */
+   bus_client_result_t rc = BUS_CLIENT_ERR_OS;
+   if (bus_region_map(fds[0], bus_control_bytes(), 0, &c->control) != BUS_REGION_OK)
+      goto done;
+   if (bus_region_map(fds[1], bus_arena_region_bytes(c->reply.arena_size), 1, &c->arena) !=
+       BUS_REGION_OK)
+      goto done;
+   if (bus_region_map(fds[2], bus_qpair_bytes(c->reply.slot_size, c->reply.queue_capacity), 1,
+                      &c->qpair) != BUS_REGION_OK)
+      goto done;
+   if (bus_control_attach(&c->control, &c->ctl) != BUS_REGION_OK)
+      goto done;
+   if (bus_qpair_attach(&c->qpair, &c->qp) != BUS_REGION_OK)
+      goto done;
+
+   c->attached_epoch = c->reply.host_epoch;
+   rc = BUS_CLIENT_OK;
+
+done:
+   /* The mappings hold their own references; the descriptors can be closed. */
+   for (int i = 0; i < 3; i++)
+      close(fds[i]);
+   if (rc != BUS_CLIENT_OK)
+      bus_client_detach(c);
+   return rc;
+}
+
+void bus_client_detach(bus_client_t *c)
+{
+   if (!c)
+      return;
+   bus_region_unmap(&c->control);
+   bus_region_unmap(&c->arena);
+   bus_region_unmap(&c->qpair);
+   memset(c, 0, sizeof *c);
+}
+
+/* Encode a frame (and inline payload) into the outbound ring. */
+static bus_client_result_t emit(bus_client_t *c, uint16_t flags, uint32_t kind, uint64_t corr,
+                                const void *payload, uint32_t len)
+{
+   if (!c || c->ctl == NULL)
+      return BUS_CLIENT_ERR_ARG;
+   /* Inline payloads only in this slice (arena is a later integration), and the
+    * payload sits after the 64-byte header, so it must fit the inline budget AND
+    * leave the header room in the slot — a config with inline_budget == slot_size
+    * would otherwise let this overrun the ring slot. */
+   if (len > 0 && (len > c->reply.inline_budget ||
+                   (uint64_t)BUS_WIRE_HDR_LEN + len > c->reply.slot_size))
+      return BUS_CLIENT_ERR_PAYLOAD;
+   if (len > 0 && !payload)
+      return BUS_CLIENT_ERR_ARG;
+
+   /* Fail fast if the host has gone; a stale mapping must not be written as if
+    * it were live. */
+   if (bus_client_epoch_changed(c))
+      return BUS_CLIENT_EPOCH;
+
+   uint8_t *slot = bus_ring_produce_begin(&c->qp.outbound);
+   if (!slot)
+      return BUS_CLIENT_WOULD_BLOCK;
+
+   bus_frame_t f;
+   memset(&f, 0, sizeof f);
+   f.hdr_flags = flags | (len ? BUS_F_INLINE : 0);
+   f.wire_version = BUS_WIRE_VERSION;
+   f.event_kind = kind;
+   f.correlation_id = corr;
+   f.src_handle = c->reply.handle_id;
+   if (len)
+   {
+      f.payload_len = len;
+      f.payload_ref = BUS_WIRE_HDR_LEN;
+   }
+   if (bus_wire_encode(&f, slot, c->reply.slot_size) != BUS_WIRE_HDR_LEN)
+      return BUS_CLIENT_ERR_ARG;
+   if (len)
+      memcpy(slot + BUS_WIRE_HDR_LEN, payload, len);
+   bus_ring_produce_commit(&c->qp.outbound);
+   return BUS_CLIENT_OK;
+}
+
+bus_client_result_t bus_client_publish(bus_client_t *c, uint32_t kind, const void *payload,
+                                       uint32_t len)
+{
+   return emit(c, BUS_F_NOTIFICATION, kind, 0, payload, len);
+}
+
+bus_client_result_t bus_client_request(bus_client_t *c, uint32_t kind, uint64_t correlation,
+                                       const void *payload, uint32_t len)
+{
+   if (correlation == 0)
+      return BUS_CLIENT_ERR_ARG; /* a correlated pattern needs a nonzero id */
+   return emit(c, BUS_F_REQUEST, kind, correlation, payload, len);
+}
+
+bus_client_result_t bus_client_reply(bus_client_t *c, uint32_t kind, uint64_t correlation,
+                                     const void *payload, uint32_t len)
+{
+   if (correlation == 0)
+      return BUS_CLIENT_ERR_ARG;
+   return emit(c, BUS_F_REPLY, kind, correlation, payload, len);
+}
+
+bus_client_result_t bus_client_cancel(bus_client_t *c, uint32_t kind, uint64_t correlation)
+{
+   if (correlation == 0)
+      return BUS_CLIENT_ERR_ARG;
+   return emit(c, BUS_F_CANCEL, kind, correlation, NULL, 0);
+}
+
+bus_client_result_t bus_client_poll(bus_client_t *c, bus_event_t *out)
+{
+   if (!c || !out || c->ctl == NULL)
+      return BUS_CLIENT_ERR_ARG;
+
+   /* After a host restart every mapping is stale — the inbound ring belongs to a
+    * defunct region and will never carry a new event. Fail closed rather than
+    * hand back a stale frame; the caller must re-attach. */
+   if (bus_client_epoch_changed(c))
+      return BUS_CLIENT_EPOCH;
+
+   /* Release the slot handed out by the previous poll — its payload pointer is
+    * now invalid, which is the documented contract. */
+   if (c->have_pending_read)
+   {
+      bus_ring_consume_commit(&c->qp.inbound);
+      c->have_pending_read = 0;
+   }
+
+   const uint8_t *slot = bus_ring_consume_begin(&c->qp.inbound);
+   if (!slot)
+      return BUS_CLIENT_EMPTY;
+
+   memset(out, 0, sizeof *out);
+   if (bus_wire_decode(slot, c->reply.slot_size, &out->frame) != BUS_WIRE_OK)
+   {
+      /* A malformed inbound frame should never happen — the host encodes it —
+       * but if it does, drop it rather than hand back garbage. */
+      bus_ring_consume_commit(&c->qp.inbound);
+      return BUS_CLIENT_EMPTY;
+   }
+   if ((out->frame.hdr_flags & BUS_F_INLINE) && out->frame.payload_len > 0 &&
+       (uint64_t)out->frame.payload_ref + out->frame.payload_len <= c->reply.slot_size)
+   {
+      out->payload = slot + out->frame.payload_ref;
+      out->payload_len = out->frame.payload_len;
+   }
+   c->have_pending_read = 1;
+   return BUS_CLIENT_OK;
+}
+
+void bus_client_heartbeat(bus_client_t *c, uint64_t now)
+{
+   if (c && c->qp.hdr)
+      atomic_store_explicit(&c->qp.hdr->client_heartbeat, now, memory_order_release);
+}
+
+int bus_client_epoch_changed(const bus_client_t *c)
+{
+   return c && c->ctl && bus_control_epoch_changed(c->ctl, c->attached_epoch);
+}
+
+int bus_client_control_lost(const bus_client_t *c)
+{
+   return c && c->qp.hdr &&
+          atomic_load_explicit(&c->qp.hdr->control_lost, memory_order_acquire) != 0;
+}
+
+const char *bus_client_result_name(bus_client_result_t r)
+{
+   switch (r)
+   {
+   case BUS_CLIENT_OK:
+      return "OK";
+   case BUS_CLIENT_WOULD_BLOCK:
+      return "WOULD_BLOCK";
+   case BUS_CLIENT_EMPTY:
+      return "EMPTY";
+   case BUS_CLIENT_DENIED:
+      return "DENIED";
+   case BUS_CLIENT_EPOCH:
+      return "EPOCH";
+   case BUS_CLIENT_ERR_ARG:
+      return "ERR_ARG";
+   case BUS_CLIENT_ERR_PAYLOAD:
+      return "ERR_PAYLOAD";
+   case BUS_CLIENT_ERR_OS:
+      return "ERR_OS";
+   case BUS_CLIENT_ERR_PROTOCOL:
+      return "ERR_PROTOCOL";
+   default:
+      return "ERR_UNKNOWN";
+   }
+}

--- a/src/modules/bus/bus_client.h
+++ b/src/modules/bus/bus_client.h
@@ -1,0 +1,103 @@
+/* bus_client.h: the C reference bus client.
+ *
+ * A per-language client library is what a module uses to attach the bus and
+ * publish/subscribe/request (suite terminology). This is the C reference
+ * implementation; slice 9 is the Go one, and the two — held to the same wire
+ * vectors — are what keep the spec honest.
+ *
+ * The client attaches over the host's SOCK_SEQPACKET channel, receives its three
+ * descriptors, and maps the control region (read-only), the arena, and its own
+ * queue pair. After that it never touches a socket: it publishes by writing its
+ * outbound ring and receives by reading its inbound ring, both zero-copy in the
+ * shared mapping.
+ *
+ * The host and the client are separate processes; the client never drives the
+ * host. It writes outbound and reads inbound, and the host's routing thread does
+ * the rest. A request therefore completes in two steps a caller pumps at its own
+ * pace: send the request, then poll for the reply.
+ */
+#ifndef AIMEE_BUS_CLIENT_H
+#define AIMEE_BUS_CLIENT_H 1
+
+#include <stdint.h>
+
+#include "bus_host.h" /* attach request/reply wire + fd helpers */
+#include "bus_region.h"
+#include "bus_wire.h"
+
+typedef enum
+{
+   BUS_CLIENT_OK = 0,
+   BUS_CLIENT_WOULD_BLOCK, /* the outbound ring is full; retry later */
+   BUS_CLIENT_EMPTY,       /* poll found no event */
+   BUS_CLIENT_DENIED,      /* attach was refused (see .attach_status) */
+   BUS_CLIENT_EPOCH,       /* the host restarted; this client must re-attach */
+   BUS_CLIENT_ERR_ARG,
+   BUS_CLIENT_ERR_PAYLOAD, /* payload does not fit the inline budget */
+   BUS_CLIENT_ERR_OS,      /* a socket/map failure during attach */
+   BUS_CLIENT_ERR_PROTOCOL
+} bus_client_result_t;
+
+typedef struct
+{
+   bus_attach_reply_t reply;
+   bus_attach_status_t attach_status;
+   bus_region_t control, arena, qpair;
+   bus_control_t *ctl;
+   bus_qpair_t qp;
+   uint64_t attached_epoch;
+   int have_pending_read; /* an inbound slot handed out by poll, not yet released */
+} bus_client_t;
+
+/* A received event. `payload` points into the shared inbound slot and is valid
+ * until the next bus_client_poll call — zero-copy read in place. */
+typedef struct
+{
+   bus_frame_t frame;
+   const uint8_t *payload;
+   uint32_t payload_len;
+} bus_event_t;
+
+/* Attach over a connected SOCK_SEQPACKET socket. On OK the client is mapped and
+ * ready; on BUS_CLIENT_DENIED the reason is in c->attach_status. */
+bus_client_result_t bus_client_attach(int sock, bus_client_t *c);
+
+/* Unmap and forget. Does not close the attach socket (the caller owns it). */
+void bus_client_detach(bus_client_t *c);
+
+/* Publish a one-way notification of `kind`. Inline payload only (len must fit the
+ * inline budget). Returns BUS_CLIENT_WOULD_BLOCK if the outbound ring is full. */
+bus_client_result_t bus_client_publish(bus_client_t *c, uint32_t kind, const void *payload,
+                                       uint32_t len);
+
+/* Send a correlated request. The reply arrives later as an inbound event with
+ * the same correlation; poll for it. */
+bus_client_result_t bus_client_request(bus_client_t *c, uint32_t kind, uint64_t correlation,
+                                       const void *payload, uint32_t len);
+
+/* Reply to a request (a serving module). */
+bus_client_result_t bus_client_reply(bus_client_t *c, uint32_t kind, uint64_t correlation,
+                                     const void *payload, uint32_t len);
+
+/* Cancel an outstanding request. */
+bus_client_result_t bus_client_cancel(bus_client_t *c, uint32_t kind, uint64_t correlation);
+
+/* Take the next inbound event. Returns BUS_CLIENT_EMPTY if none. The returned
+ * payload pointer is valid until the next poll. */
+bus_client_result_t bus_client_poll(bus_client_t *c, bus_event_t *out);
+
+/* Write a heartbeat so the host knows this client is alive. `now` is any value
+ * that advances over time. */
+void bus_client_heartbeat(bus_client_t *c, uint64_t now);
+
+/* 1 if the host has restarted since attach (a bumped epoch) — every handle and
+ * mapping is stale and the client must re-attach. */
+int bus_client_epoch_changed(const bus_client_t *c);
+
+/* 1 if the host set this client's sticky control_lost flag (a control-class
+ * notice could not be delivered even from the reserve). */
+int bus_client_control_lost(const bus_client_t *c);
+
+const char *bus_client_result_name(bus_client_result_t r);
+
+#endif /* AIMEE_BUS_CLIENT_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -154,6 +154,11 @@ target_include_directories(test_bus_route PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..
 aimee_add_test(test_bus_flow test_bus_flow.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c)
 target_include_directories(test_bus_flow PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 
+aimee_add_test(test_bus_client test_bus_client.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c)
+target_include_directories(test_bus_client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+find_package(Threads REQUIRED)
+target_link_libraries(test_bus_client PRIVATE Threads::Threads)
+
 
 
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -220,6 +220,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-bus-host \
                $(TESTPREFIX)/unit-test-bus-route \
                $(TESTPREFIX)/unit-test-bus-flow \
+               $(TESTPREFIX)/unit-test-bus-client \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2598,6 +2599,22 @@ $(TESTPREFIX)/unit-test-bus-flow: $(OBJDIR)/tests/test_bus_flow.o \
                                   $(OBJDIR)/modules/bus/bus_arena.o \
                                   $(OBJDIR)/modules/bus/bus_wire.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS)
+
+# Event-bus C reference client (feature tree slice 8).
+$(OBJDIR)/tests/test_bus_client.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-client: $(OBJDIR)/tests/test_bus_client.o \
+                                    $(OBJDIR)/modules/bus/bus_client.o \
+                                    $(OBJDIR)/modules/bus/bus_host.o \
+                                    $(OBJDIR)/modules/bus/bus_route.o \
+                                    $(OBJDIR)/modules/bus/bus_region.o \
+                                    $(OBJDIR)/modules/bus/bus_ring.o \
+                                    $(OBJDIR)/modules/bus/bus_arena.o \
+                                    $(OBJDIR)/modules/bus/bus_wire.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
+
+.PHONY: unit-test-bus-client
+unit-test-bus-client: $(TESTPREFIX)/unit-test-bus-client
+	$<
 
 .PHONY: unit-test-bus-flow
 unit-test-bus-flow: $(TESTPREFIX)/unit-test-bus-flow

--- a/src/tests/test_bus_client.c
+++ b/src/tests/test_bus_client.c
@@ -1,0 +1,251 @@
+/* test_bus_client.c: slice 8 of the event-bus feature tree.
+ *
+ * The C reference client, driven against a real host in one process. Once
+ * attached, host and client share memory, so the test pumps the host's routing
+ * by hand between client calls. It exercises every message pattern and the
+ * backpressure path through the library rather than the raw rings.
+ *
+ * The attach handshake is the one place send and recv must cross, so it runs on
+ * a helper thread: bus_client_attach (send-then-recv) on the main thread and
+ * bus_host_serve_attach (recv-then-send) on the helper, both over a
+ * SOCK_SEQPACKET socketpair. After that everything is single-threaded.
+ */
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "bus_client.h"
+#include "bus_host.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+static void must_rc(bus_client_result_t got, bus_client_result_t want, const char *what)
+{
+   if (got != want)
+   {
+      fprintf(stderr, "FAIL: %s: expected %s got %s\n", what, bus_client_result_name(want),
+              bus_client_result_name(got));
+      abort();
+   }
+}
+
+struct serve_arg
+{
+   bus_host_t *h;
+   int fd;
+   bus_host_result_t result;
+};
+
+static void *serve_thread(void *p)
+{
+   struct serve_arg *a = p;
+   a->result = bus_host_serve_attach(a->h, a->fd);
+   return NULL;
+}
+
+/* Attach one client, returning the client result. The host end of the socket is
+ * served on a helper thread so the single-process handshake does not deadlock. */
+static bus_client_result_t attach_client(bus_host_t *h, bus_client_t *c)
+{
+   int sv[2];
+   must(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) == 0, "socketpair");
+   struct serve_arg a = {.h = h, .fd = sv[1], .result = BUS_HOST_ERR_ARG};
+   pthread_t t;
+   must(pthread_create(&t, NULL, serve_thread, &a) == 0, "spawn serve");
+   bus_client_result_t rc = bus_client_attach(sv[0], c);
+   must(pthread_join(t, NULL) == 0, "join serve");
+   close(sv[0]);
+   close(sv[1]);
+   return rc;
+}
+
+static bus_host_config_t cfg(void)
+{
+   bus_host_config_t c;
+   memset(&c, 0, sizeof c);
+   c.max_slots = 4;
+   c.slot_size = 256;
+   c.inline_budget = 192;
+   c.queue_capacity = 8;
+   c.arena_size = 128 * 1024;
+   return c;
+}
+
+#define KIND_A 500
+
+static void test_publish_and_poll(void)
+{
+   bus_host_config_t cf = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cf, NULL, NULL) == BUS_HOST_OK, "host");
+
+   bus_client_t pub, sub;
+   must_rc(attach_client(&h, &pub), BUS_CLIENT_OK, "publisher attaches");
+   must_rc(attach_client(&h, &sub), BUS_CLIENT_OK, "subscriber attaches");
+   must(bus_host_subscribe(&h, sub.reply.handle_id, KIND_A) == BUS_HOST_OK, "subscribe");
+
+   const char *msg = "hello-bus";
+   must_rc(bus_client_publish(&pub, KIND_A, msg, (uint32_t)strlen(msg)), BUS_CLIENT_OK,
+           "publish");
+
+   /* Nothing arrives until the host routes. */
+   bus_event_t ev;
+   must_rc(bus_client_poll(&sub, &ev), BUS_CLIENT_EMPTY, "nothing before pump");
+   must(bus_host_pump(&h) == 1, "host routes the notification");
+
+   must_rc(bus_client_poll(&sub, &ev), BUS_CLIENT_OK, "subscriber polls the event");
+   must(ev.frame.event_kind == KIND_A, "right kind");
+   must(ev.payload_len == strlen(msg) && memcmp(ev.payload, msg, ev.payload_len) == 0,
+        "zero-copy payload matches");
+   must_rc(bus_client_poll(&sub, &ev), BUS_CLIENT_EMPTY, "only one event");
+
+   bus_client_detach(&pub);
+   bus_client_detach(&sub);
+   bus_host_destroy(&h);
+   printf("  publish/poll: a notification reaches the subscriber zero-copy\n");
+}
+
+static void test_request_reply(void)
+{
+   bus_host_config_t cf = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cf, NULL, NULL) == BUS_HOST_OK, "host");
+
+   bus_client_t req, server;
+   must_rc(attach_client(&h, &req), BUS_CLIENT_OK, "requester attaches");
+   must_rc(attach_client(&h, &server), BUS_CLIENT_OK, "server attaches");
+   must(bus_host_serve_kind(&h, server.reply.handle_id, KIND_A) == BUS_HOST_OK, "serve kind");
+
+   const uint64_t corr = 0xBEEF;
+   must_rc(bus_client_request(&req, KIND_A, corr, "ping", 4), BUS_CLIENT_OK, "send request");
+   must(bus_host_pump(&h) == 1, "route request");
+
+   bus_event_t ev;
+   must_rc(bus_client_poll(&server, &ev), BUS_CLIENT_OK, "server gets request");
+   must(ev.frame.correlation_id == corr && (ev.frame.hdr_flags & BUS_F_REQUEST), "is the request");
+   must(ev.payload_len == 4 && memcmp(ev.payload, "ping", 4) == 0, "request payload");
+
+   must_rc(bus_client_reply(&server, KIND_A, corr, "pong", 4), BUS_CLIENT_OK, "server replies");
+   must(bus_host_pump(&h) == 1, "route reply");
+
+   must_rc(bus_client_poll(&req, &ev), BUS_CLIENT_OK, "requester gets reply");
+   must(ev.frame.correlation_id == corr && (ev.frame.hdr_flags & BUS_F_REPLY), "is the reply");
+   must(ev.payload_len == 4 && memcmp(ev.payload, "pong", 4) == 0, "reply payload");
+
+   bus_client_detach(&req);
+   bus_client_detach(&server);
+   bus_host_destroy(&h);
+   printf("  request/reply: round-trips through the client library\n");
+}
+
+static void test_capability_absent(void)
+{
+   bus_host_config_t cf = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cf, NULL, NULL) == BUS_HOST_OK, "host");
+   bus_client_t req;
+   must_rc(attach_client(&h, &req), BUS_CLIENT_OK, "attach");
+
+   must_rc(bus_client_request(&req, KIND_A, 0x1234, NULL, 0), BUS_CLIENT_OK, "request no server");
+   must(bus_host_pump(&h) == 1, "route");
+   bus_event_t ev;
+   must_rc(bus_client_poll(&req, &ev), BUS_CLIENT_OK, "poll");
+   must(ev.frame.event_kind == BUS_KIND_CAPABILITY_ABSENT && ev.frame.correlation_id == 0x1234,
+        "got capability_absent for the missing server");
+
+   bus_client_detach(&req);
+   bus_host_destroy(&h);
+   printf("  capability_absent: surfaced to the requester\n");
+}
+
+static void test_would_block(void)
+{
+   bus_host_config_t cf = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cf, NULL, NULL) == BUS_HOST_OK, "host");
+   bus_client_t pub;
+   must_rc(attach_client(&h, &pub), BUS_CLIENT_OK, "attach");
+
+   /* Fill the outbound ring without pumping the host: capacity publishes
+    * succeed, then the next returns would_block rather than overwriting or
+    * crashing. */
+   uint32_t cap = pub.reply.queue_capacity;
+   uint32_t ok = 0;
+   for (uint32_t i = 0; i < cap + 4; i++)
+   {
+      bus_client_result_t r = bus_client_publish(&pub, KIND_A, "x", 1);
+      if (r == BUS_CLIENT_OK)
+         ok++;
+      else
+      {
+         must_rc(r, BUS_CLIENT_WOULD_BLOCK, "full outbound returns would_block");
+         break;
+      }
+   }
+   must(ok == cap, "exactly capacity publishes succeeded before would_block");
+
+   /* Draining via the host frees the ring, and publishing resumes. */
+   bus_host_pump(&h);
+   must_rc(bus_client_publish(&pub, KIND_A, "x", 1), BUS_CLIENT_OK, "publish resumes after drain");
+
+   /* An oversize payload is refused up front, not truncated. */
+   char big[512];
+   memset(big, 'z', sizeof big);
+   must_rc(bus_client_publish(&pub, KIND_A, big, cf.inline_budget + 1), BUS_CLIENT_ERR_PAYLOAD,
+           "oversize inline payload refused");
+
+   bus_client_detach(&pub);
+   bus_host_destroy(&h);
+   printf("  would_block: a full outbound ring is reported, not overrun\n");
+}
+
+static void test_heartbeat_and_epoch(void)
+{
+   bus_host_config_t cf = cfg();
+   bus_host_t h;
+   must(bus_host_create(&h, &cf, NULL, NULL) == BUS_HOST_OK, "host");
+   bus_client_t c;
+   must_rc(attach_client(&h, &c), BUS_CLIENT_OK, "attach");
+
+   /* Heartbeat keeps the client from being reaped. */
+   bus_client_heartbeat(&c, 1);
+   must(bus_host_reap(&h, 100, 50) == 0, "baseline");
+   bus_client_heartbeat(&c, 2);
+   must(bus_host_reap(&h, 130, 50) == 0, "beating client not reaped");
+   must(bus_host_admitted(&h) == 1, "still admitted");
+
+   /* A host restart is observed. */
+   must(!bus_client_epoch_changed(&c), "no restart yet");
+   bus_host_bump_epoch(&h);
+   must(bus_client_epoch_changed(&c), "client observes the host restart");
+   /* And a publish after a restart refuses rather than writing a stale mapping. */
+   must_rc(bus_client_publish(&c, KIND_A, "x", 1), BUS_CLIENT_EPOCH, "publish refused after restart");
+   bus_event_t ev;
+   must_rc(bus_client_poll(&c, &ev), BUS_CLIENT_EPOCH, "poll refused after restart");
+
+   bus_client_detach(&c);
+   bus_host_destroy(&h);
+   printf("  heartbeat/epoch: kept alive; a restart is observed and fails closed\n");
+}
+
+int main(void)
+{
+   printf("test_bus_client:\n");
+   test_publish_and_poll();
+   test_request_reply();
+   test_capability_absent();
+   test_would_block();
+   test_heartbeat_and_epoch();
+   printf("test_bus_client: OK\n");
+   return 0;
+}


### PR DESCRIPTION
Eighth slice. Self-reviewed. The C reference client a module uses to attach the bus and publish/subscribe/request — the first of the two implementations the wire vectors hold both to (slice 9 is Go).

## What lands

`bus_client.{c,h}`: attach over SOCK_SEQPACKET, receive the three descriptors, map control (read-only) / arena / own queue pair. After attach it never touches a socket — publish writes the outbound ring, receive reads the inbound, both zero-copy in the shared mapping.

- publish (notification); request/reply/cancel (correlated);
- **zero-copy poll** whose payload pointer is valid until the next poll (which releases the previous inbound slot);
- a full outbound ring returns **would_block**, not overwrite/block;
- heartbeat keeps the client alive; a host restart is observed and **fails closed**.

## Self-review caught two defects

- **emit** bounded payload by the inline budget but not by the slot, so `inline_budget == slot_size` (which control-init permits) would overrun the slot past the 64-byte header — now bounded by both.
- **poll** did not check the epoch, so after a restart it could hand back a stale frame from a defunct region — now returns `BUS_CLIENT_EPOCH` like publish. A restart forces re-attach on both paths.

## Verification (normal + ASAN/UBSAN + TSAN)

publish→subscriber zero-copy; request/reply round-trip; capability_absent to the requester; would_block then resume; oversize payload refused; heartbeat keeps alive; restart observed and fails closed on publish and poll. Attach handshake on a helper thread, TSAN-clean.

No shipping binary links the bus (D7). Depends on slices 1–7 (merged).