### PR TITLE
Slice 10: cross-language conformance suite

### DIFF
--- a/scripts/check_bus_blast_radius.sh
+++ b/scripts/check_bus_blast_radius.sh
@@ -111,7 +111,7 @@ done < <(find . \( -name CMakeLists.txt -o -name '*.cmake' \) \
 for f in src/tests/CMakeLists.txt src/tests/Rules.mk; do
    [ -f "$f" ] || continue
    hits=$({ grep -n 'modules/bus' "$f" 2>/dev/null || true; } | strip_comments |
-      { grep -vE 'test_bus|unit-test-bus|OBJDIR\)/modules/bus' || true; })
+      { grep -vE 'test_bus|unit-test-bus|bus-conformance-host|bus_conformance_host|OBJDIR\)/modules/bus' || true; })
    if [ -n "$hits" ]; then
       note "FAIL: $f uses modules/bus outside a bus test target"
       printf '%s\n' "$hits" >&2
@@ -127,6 +127,7 @@ while IFS= read -r hit; do
    case "$file" in
    src/modules/bus/*) continue ;;
    src/tests/test_bus_*) continue ;;
+   src/tests/bus_conformance_host.c) continue ;; # slice-10 test harness
    esac
    note "FAIL: $hit"
    fail=1

--- a/scripts/check_bus_single_host.sh
+++ b/scripts/check_bus_single_host.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# check_bus_single_host.sh — enforce D8: there is exactly one bus host, and the
+# Go client is a client only.
+#
+# The conformance suite's credibility rests on two INDEPENDENT client
+# implementations agreeing about ONE host. If a second host implementation
+# existed, or if the Go "client" actually created regions and admitted peers, the
+# agreement would be a codec agreeing with itself. Four assertions, each
+# mechanical:
+#
+#   1. bus_host_create is defined in exactly one translation unit.
+#   2. memfd_create (region creation) appears only in the bus's own region/host
+#      code, never in a second would-be host.
+#   3. no Go file in server-go/bus creates regions or accepts attaches — it maps
+#      what it is handed and connects; it never listens or memfds.
+#   4. no Go test regenerates or shadows the committed wire vectors, so a drift
+#      in the C host's frame bytes is caught by the C<->Go vector agreement rather
+#      than papered over by a Go-local override.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fail=0
+note() { printf '%s\n' "$*" >&2; }
+
+# 1. exactly one definition of bus_host_create.
+defs=$({ grep -rlE 'bus_host_result_t[[:space:]]+bus_host_create[[:space:]]*\(' \
+   src/modules/bus/*.c 2>/dev/null || true; })
+n=$(printf '%s\n' "$defs" | grep -c . || true)
+if [ "$n" != "1" ]; then
+   note "FAIL: bus_host_create is defined in $n translation units (want 1):"
+   printf '%s\n' "$defs" >&2
+   fail=1
+fi
+
+# 2. Within the bus module, a region (memfd) is created in exactly one place —
+#    bus_region.c. This is about a second BUS host, not global memfd policy:
+#    other subsystems (git credential fds, ssh-agent) use memfd_create for their
+#    own reasons and are none of the bus's business. So the scan is scoped to
+#    src/modules/bus/ and matches the CALL (with a paren), not comments.
+while IFS= read -r hit; do
+   [ -z "$hit" ] && continue
+   file="${hit%%:*}"
+   case "$file" in
+   src/modules/bus/bus_region.c) continue ;;
+   esac
+   note "FAIL: a second region creator — memfd_create called outside bus_region.c: $hit"
+   fail=1
+done < <(grep -rn 'memfd_create[[:space:]]*(' src/modules/bus/*.c 2>/dev/null || true)
+
+# 3. the Go client is a client only: it must not create regions (memfd) or
+#    accept/listen (a host does that).
+if [ -d server-go/bus ]; then
+   for forbidden in 'MemfdCreate' 'unix.Listen' 'unix.Accept' 'unix.Bind'; do
+      if grep -rn "$forbidden" server-go/bus/*.go 2>/dev/null | grep -v '_test.go' >/dev/null; then
+         note "FAIL: server-go/bus uses '$forbidden' — a client does not host"
+         grep -rn "$forbidden" server-go/bus/*.go | grep -v '_test.go' >&2
+         fail=1
+      fi
+   done
+
+   # 4. no Go file writes the committed vector table (only the Python generator
+   #    may). A Go-local vector override would hide a real wire drift.
+   if grep -rn 'wire_vectors\.tsv' server-go/ 2>/dev/null | grep -iE 'Create|OpenFile|WriteFile|os\.O_WRONLY|os\.O_CREATE' >/dev/null; then
+      note "FAIL: a Go file writes wire_vectors.tsv — the vectors are the single authority"
+      fail=1
+   fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+   note ""
+   note "D8: exactly one host, and the Go side is a client only. See"
+   note "docs/dev/EVENT_BUS_DECISIONS.md."
+   exit 1
+fi
+
+echo "check_bus_single_host: ok — one host_create, memfd only in the host, Go is client-only"

--- a/scripts/test_bus_conformance.sh
+++ b/scripts/test_bus_conformance.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# test_bus_conformance.sh — the event-bus conformance suite (slice 10).
+#
+# Runs the three legs that keep the wire spec honest:
+#   1. Vectors: the C codec and the Go codec both produce and accept the exact
+#      committed bytes (each in its own unit test).
+#   2. Interop: the single in-source C host, exposed on a Unix socket, driven by
+#      a real Go client across a process boundary — both directions, plus
+#      capability_absent.
+#   3. Single-host: the mechanical D8 check (one host, Go is client-only).
+#
+# Everything is bounded by timeouts so the suite cannot hang.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "== 1. wire vectors: C codec =="
+make -C src --no-print-directory unit-test-bus-wire
+
+echo "== 1. wire vectors: Go codec =="
+( cd server-go && CGO_ENABLED=0 go test ./bus/... -run 'TestWireVectors|TestValidationAxes|TestRing|TestControl' )
+
+echo "== 2. cross-language interop: C host <-> Go client =="
+make -C src --no-print-directory bus-conformance-host
+harness="$repo_root/src/build/obj/tests/bus-conformance-host"
+if [ ! -x "$harness" ]; then
+   # honour a non-default TESTPREFIX/OBJDIR if the caller set one
+   harness=$(find "$repo_root/src" -name bus-conformance-host -type f -perm -u+x 2>/dev/null | head -1)
+fi
+[ -x "$harness" ] || { echo "FAIL: conformance host harness not built" >&2; exit 1; }
+( cd server-go && BUS_CONFORMANCE_HOST="$harness" \
+   CGO_ENABLED=0 go test ./bus/... -run TestCrossLanguageConformance -v -timeout 60s )
+
+echo "== 3. single-host (D8) =="
+"$repo_root/scripts/check_bus_single_host.sh"
+
+echo "test_bus_conformance: ok"

--- a/server-go/bus/conformance_test.go
+++ b/server-go/bus/conformance_test.go
@@ -1,0 +1,142 @@
+package bus
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestCrossLanguageConformance connects a real Go client to the in-source C host
+// (built as a test harness) over a Unix socket, and exercises both directions of
+// the wire. Two independent client implementations — this Go one and the C one
+// inside the harness — on one host is the credibility test for "any language".
+//
+// The harness binary path is passed in BUS_CONFORMANCE_HOST; without it the test
+// skips, so `go test ./bus/...` alone stays hermetic. scripts/test_bus_conformance.sh
+// builds the harness and sets the variable.
+func TestCrossLanguageConformance(t *testing.T) {
+	harness := os.Getenv("BUS_CONFORMANCE_HOST")
+	if harness == "" {
+		t.Skip("BUS_CONFORMANCE_HOST not set; run via scripts/test_bus_conformance.sh")
+	}
+
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "bus.sock")
+
+	cmd := exec.Command(harness, sock, "15000")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start harness: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		if t.Failed() {
+			t.Logf("harness output:\n%s", out.String())
+		}
+	}()
+
+	// Wait for the harness to create the listening socket.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(sock); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("harness socket did not appear")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Connect a real Go client over SOCK_SEQPACKET.
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET, 0)
+	if err != nil {
+		t.Fatalf("socket: %v", err)
+	}
+	if err := unix.Connect(fd, &unix.SockaddrUnix{Name: sock}); err != nil {
+		unix.Close(fd)
+		t.Fatalf("connect: %v", err)
+	}
+	// Keep the connection open for the client's lifetime — the harness treats a
+	// closed peer as a shutdown signal.
+	defer unix.Close(fd)
+
+	c, err := Attach(fd)
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	defer c.Detach()
+	t.Logf("attached: handle=%d slot=%d cap=%d", c.Handle, c.slotSize, c.queueCapacity)
+
+	// pollFor waits up to a deadline for an event matching pred.
+	pollFor := func(pred func(Event) bool, what string) Event {
+		t.Helper()
+		dl := time.Now().Add(5 * time.Second)
+		for time.Now().Before(dl) {
+			ev, ok, err := c.Poll()
+			if err != nil {
+				t.Fatalf("poll (%s): %v", what, err)
+			}
+			if ok && pred(ev) {
+				return ev
+			}
+			if !ok {
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+		t.Fatalf("timed out waiting for %s", what)
+		return Event{}
+	}
+
+	// 1. Go -> C -> Go: publish a notification the C client acks.
+	payload := []byte("go-says-hi")
+	if err := c.Publish(KIND_NOTIFY, payload); err != nil {
+		t.Fatalf("publish notify: %v", err)
+	}
+	ack := pollFor(func(ev Event) bool { return ev.Frame.EventKind == KIND_ACK }, "ack")
+	if !bytes.Equal(ack.Payload, payload) {
+		t.Fatalf("ack payload = %q, want %q", ack.Payload, payload)
+	}
+	t.Log("notification round-trip Go->C->Go ok")
+
+	// 2. Go <-> C: an echo request/reply across the language boundary.
+	req := []byte("echo-me")
+	if err := c.Request(KIND_ECHO, 0xABCDEF, req); err != nil {
+		t.Fatalf("request echo: %v", err)
+	}
+	reply := pollFor(func(ev Event) bool {
+		return ev.Frame.EventKind == KIND_ECHO && ev.Frame.HdrFlags&FReply != 0
+	}, "echo reply")
+	if reply.Frame.CorrelationID != 0xABCDEF || !bytes.Equal(reply.Payload, req) {
+		t.Fatalf("echo reply mismatch: corr=0x%x payload=%q", reply.Frame.CorrelationID, reply.Payload)
+	}
+	t.Log("echo request/reply Go<->C ok")
+
+	// 3. A request for a kind with no server draws capability_absent.
+	if err := c.Request(KIND_NOSERVER, 0x999, nil); err != nil {
+		t.Fatalf("request noserver: %v", err)
+	}
+	ca := pollFor(func(ev Event) bool {
+		return ev.Frame.EventKind == KindCapabilityAbsent
+	}, "capability_absent")
+	if ca.Frame.CorrelationID != 0x999 || ca.Frame.HdrFlags&FReply == 0 {
+		t.Fatalf("capability_absent mismatch: corr=0x%x flags=0x%x",
+			ca.Frame.CorrelationID, ca.Frame.HdrFlags)
+	}
+	t.Log("capability_absent ok")
+}
+
+const (
+	// Kinds must match bus_conformance_host.c.
+	KIND_NOTIFY   uint32 = 1000
+	KIND_ACK      uint32 = 1001
+	KIND_ECHO     uint32 = 1002
+	KIND_NOSERVER uint32 = 1003
+)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2612,6 +2612,23 @@ $(TESTPREFIX)/unit-test-bus-client: $(OBJDIR)/tests/test_bus_client.o \
                                     $(OBJDIR)/modules/bus/bus_wire.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
 
+# Event-bus conformance host harness (feature tree slice 10). A test binary that
+# exposes the C host on a Unix socket so the Go reference client can interoperate
+# with it across a process boundary. Never linked into a shipping target.
+$(OBJDIR)/tests/bus_conformance_host.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/bus-conformance-host: $(OBJDIR)/tests/bus_conformance_host.o \
+                                    $(OBJDIR)/modules/bus/bus_client.o \
+                                    $(OBJDIR)/modules/bus/bus_host.o \
+                                    $(OBJDIR)/modules/bus/bus_route.o \
+                                    $(OBJDIR)/modules/bus/bus_region.o \
+                                    $(OBJDIR)/modules/bus/bus_ring.o \
+                                    $(OBJDIR)/modules/bus/bus_arena.o \
+                                    $(OBJDIR)/modules/bus/bus_wire.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
+
+.PHONY: bus-conformance-host
+bus-conformance-host: $(TESTPREFIX)/bus-conformance-host
+
 .PHONY: unit-test-bus-client
 unit-test-bus-client: $(TESTPREFIX)/unit-test-bus-client
 	$<

--- a/src/tests/bus_conformance_host.c
+++ b/src/tests/bus_conformance_host.c
@@ -1,0 +1,204 @@
+/* bus_conformance_host.c: the C bus host, exposed on a Unix socket so an
+ * external client — notably the Go reference client — can attach and interoperate
+ * with the single in-source C host across a process boundary. This is the
+ * cross-language conformance vehicle (slice 10): two independent client
+ * implementations on one host is what keeps the wire spec honest.
+ *
+ * It runs the C host plus one internal C client that plays the server/subscriber
+ * side, so an external client can prove both directions:
+ *   - KIND_NOTIFY: the external client publishes; the internal C client receives
+ *     and answers with a KIND_ACK the external client is subscribed to
+ *     (external -> host -> C client -> host -> external);
+ *   - KIND_ECHO: the internal C client serves; the external client's request is
+ *     echoed back as a reply (external <-> C client through the host);
+ *   - a request for KIND_NOSERVER draws a synthesized capability_absent.
+ *
+ * Usage: bus_conformance_host <socket-path> [timeout-ms]
+ * It listens, accepts exactly one external client, pumps and services until the
+ * external client disconnects or the timeout elapses, then exits 0. A bounded
+ * timeout means it can never hang CI.
+ *
+ * This is a test binary, never linked into a shipping target (D7).
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "bus_client.h"
+#include "bus_host.h"
+
+#define KIND_NOTIFY   1000
+#define KIND_ACK      1001
+#define KIND_ECHO     1002
+#define KIND_NOSERVER 1003
+
+static uint64_t now_ms(void)
+{
+   struct timespec ts;
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+   return (uint64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+struct serve_arg
+{
+   bus_host_t *h;
+   int fd;
+};
+static void *serve_thread(void *p)
+{
+   struct serve_arg *a = p;
+   bus_host_serve_attach(a->h, a->fd);
+   return NULL;
+}
+
+/* Attach the internal C client over a socketpair the host serves on a thread. */
+static int attach_internal(bus_host_t *h, bus_client_t *c)
+{
+   int sv[2];
+   if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) != 0)
+      return -1;
+   struct serve_arg a = {.h = h, .fd = sv[1]};
+   pthread_t t;
+   if (pthread_create(&t, NULL, serve_thread, &a) != 0)
+      return -1;
+   bus_client_result_t rc = bus_client_attach(sv[0], c);
+   pthread_join(t, NULL);
+   close(sv[0]);
+   close(sv[1]);
+   return rc == BUS_CLIENT_OK ? 0 : -1;
+}
+
+/* Find the one admitted slot that is not the internal client's. */
+static int find_external(bus_host_t *h, uint32_t internal_handle)
+{
+   for (uint32_t i = 0; i < h->cfg.max_slots; i++)
+      if (h->slots[i].in_use && i != internal_handle)
+         return (int)i;
+   return -1;
+}
+
+int main(int argc, char **argv)
+{
+   if (argc < 2)
+   {
+      fprintf(stderr, "usage: %s <socket-path> [timeout-ms]\n", argv[0]);
+      return 2;
+   }
+   const char *path = argv[1];
+   uint64_t timeout_ms = (argc > 2) ? strtoull(argv[2], NULL, 10) : 10000;
+
+   bus_host_config_t cfg;
+   memset(&cfg, 0, sizeof cfg);
+   cfg.max_slots = 4;
+   cfg.slot_size = 256;
+   cfg.inline_budget = 192;
+   cfg.queue_capacity = 16;
+   cfg.arena_size = 256 * 1024;
+
+   bus_host_t h;
+   if (bus_host_create(&h, &cfg, NULL, NULL) != BUS_HOST_OK)
+   {
+      fprintf(stderr, "host create failed\n");
+      return 1;
+   }
+
+   /* Internal C client: subscribes to KIND_NOTIFY and serves KIND_ECHO. */
+   bus_client_t cc;
+   if (attach_internal(&h, &cc) != 0)
+   {
+      fprintf(stderr, "internal client attach failed\n");
+      return 1;
+   }
+   bus_host_subscribe(&h, cc.reply.handle_id, KIND_NOTIFY);
+   bus_host_serve_kind(&h, cc.reply.handle_id, KIND_ECHO);
+
+   /* Listening socket. */
+   unlink(path);
+   int lsock = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+   if (lsock < 0)
+   {
+      perror("socket");
+      return 1;
+   }
+   struct sockaddr_un addr;
+   memset(&addr, 0, sizeof addr);
+   addr.sun_family = AF_UNIX;
+   snprintf(addr.sun_path, sizeof addr.sun_path, "%s", path);
+   if (bind(lsock, (struct sockaddr *)&addr, sizeof addr) != 0 || listen(lsock, 1) != 0)
+   {
+      perror("bind/listen");
+      return 1;
+   }
+
+   /* Signal readiness: the file existing is the readiness marker the runner
+    * waits on. Accept one external client (blocking, but bounded by the runner's
+    * own timeout on the whole process). */
+   int csock = accept(lsock, NULL, NULL);
+   if (csock < 0)
+   {
+      perror("accept");
+      return 1;
+   }
+   if (bus_host_serve_attach(&h, csock) != BUS_HOST_OK)
+   {
+      fprintf(stderr, "external attach denied\n");
+      return 1;
+   }
+   int ext = find_external(&h, cc.reply.handle_id);
+   if (ext < 0)
+   {
+      fprintf(stderr, "external slot not found\n");
+      return 1;
+   }
+   /* The external client is subscribed to the ack kind so it can observe that
+    * the C client received its notification. */
+   bus_host_subscribe(&h, (uint32_t)ext, KIND_ACK);
+
+   /* Pump + service loop, bounded. */
+   uint64_t start = now_ms();
+   while (now_ms() - start < timeout_ms)
+   {
+      bus_host_pump(&h);
+      cc.reply.host_epoch = bus_control_epoch(h.control); /* keep epoch fresh */
+
+      bus_event_t ev;
+      while (bus_client_poll(&cc, &ev) == BUS_CLIENT_OK)
+      {
+         if (ev.frame.event_kind == KIND_NOTIFY)
+         {
+            /* Prove receipt: answer with an ack the external client sees. */
+            bus_client_publish(&cc, KIND_ACK, ev.payload, ev.payload_len);
+         }
+         else if (ev.frame.event_kind == KIND_ECHO && (ev.frame.hdr_flags & BUS_F_REQUEST))
+         {
+            bus_client_reply(&cc, KIND_ECHO, ev.frame.correlation_id, ev.payload,
+                             ev.payload_len);
+         }
+      }
+      bus_host_pump(&h);
+
+      /* If the external client has gone, stop. A zero-length recv (peer closed)
+       * is detected by a non-blocking peek. */
+      char probe;
+      ssize_t pr = recv(csock, &probe, 1, MSG_PEEK | MSG_DONTWAIT);
+      if (pr == 0)
+         break; /* peer closed */
+
+      struct timespec nap = {.tv_sec = 0, .tv_nsec = 1 * 1000 * 1000};
+      nanosleep(&nap, NULL);
+   }
+
+   bus_client_detach(&cc);
+   bus_host_destroy(&h);
+   close(csock);
+   close(lsock);
+   unlink(path);
+   return 0;
+}


### PR DESCRIPTION
Tenth slice. Self-reviewed. The credibility test for "any language": the single in-source C host driven by **two independent client implementations** — the C client and a **real Go client over a socket** — agreeing about one wire.

## What lands

- **src/tests/bus_conformance_host.c** — a test-only harness exposing the C host on an AF_UNIX SOCK_SEQPACKET path, with an internal C client that subscribes and serves. An external client attaches across a genuine process boundary.
- **server-go/bus/conformance_test.go** — connects a **real Go client** and exercises both directions: Go publishes a notification the C client acks back (**Go→C→Go**), Go sends an echo request the C client replies to (**Go↔C**), and a serverless request draws **capability_absent**. Skips unless `BUS_CONFORMANCE_HOST` is set (so `go test` alone stays hermetic); bounded by timeouts.
- **scripts/test_bus_conformance.sh** — wire vectors (C + Go), the interop, and the D8 single-host check.
- **scripts/check_bus_single_host.sh** (D8) — one `bus_host_create`, one region creator in the bus module, Go never listens/accepts/memfds, no Go vector shadowing. Verified to catch a second host.

## The interop passes

The Go client and the C host exchange messages across a socket, both directions, with capability_absent — two implementations from the same prose agreeing about the same host.

## Self-review

The single-host memfd rule was global and flagged unrelated subsystems (git credential fds); scoped to `src/modules/bus/` and to the call, not comments. The D7 gate was taught to allow the harness and re-verified to still catch a real shipping-link regression.

No shipping binary links the bus (D7). Depends on slices 1–9 (merged).