### PR TITLE
Slice 11: capture stream and observational replay (D10)

### DIFF
--- a/src/modules/bus/bus_capture.c
+++ b/src/modules/bus/bus_capture.c
@@ -1,0 +1,282 @@
+/* bus_capture.c: capture stream writer, reader, and observational replay (D10). */
+#include <stdlib.h>
+#include <string.h>
+
+#include "bus_capture.h"
+#include "bus_wire.h"
+
+/* ---- CRC-32C (Castagnoli), the record checksum named by D10 ---- */
+
+static uint32_t crc32c(const uint8_t *p, size_t n)
+{
+   static uint32_t table[256];
+   static int built = 0;
+   if (!built)
+   {
+      for (uint32_t i = 0; i < 256; i++)
+      {
+         uint32_t c = i;
+         for (int k = 0; k < 8; k++)
+            c = (c & 1) ? (0x82f63b78u ^ (c >> 1)) : (c >> 1);
+         table[i] = c;
+      }
+      built = 1;
+   }
+   uint32_t crc = 0xffffffffu;
+   for (size_t i = 0; i < n; i++)
+      crc = table[(crc ^ p[i]) & 0xff] ^ (crc >> 8);
+   return crc ^ 0xffffffffu;
+}
+
+/* Record layout (D10):
+ *   0   4  record_len (total incl this field and the trailing CRC)
+ *   4   2  record_type
+ *   6   2  record_flags
+ *   8   BUS_WIRE_HDR_LEN  frame header, verbatim
+ *   ...  payload_len      materialized payload
+ *   end-4  4  crc32c over every preceding byte
+ */
+#define REC_PREFIX  8u
+#define REC_MIN     (REC_PREFIX + BUS_WIRE_HDR_LEN + 4u)
+
+static void put_u16(uint8_t *p, uint16_t v)
+{
+   p[0] = v & 0xff;
+   p[1] = (v >> 8) & 0xff;
+}
+static void put_u32(uint8_t *p, uint32_t v)
+{
+   for (int i = 0; i < 4; i++)
+      p[i] = (v >> (8 * i)) & 0xff;
+}
+static void put_u64(uint8_t *p, uint64_t v)
+{
+   for (int i = 0; i < 8; i++)
+      p[i] = (v >> (8 * i)) & 0xff;
+}
+static uint16_t get_u16(const uint8_t *p)
+{
+   return (uint16_t)(p[0] | (p[1] << 8));
+}
+static uint32_t get_u32(const uint8_t *p)
+{
+   return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static int reserve(bus_capture_t *c, size_t extra)
+{
+   if (c->broken)
+      return 0;
+   if (c->len + extra <= c->cap)
+      return 1;
+   size_t ncap = c->cap ? c->cap * 2 : 4096;
+   while (ncap < c->len + extra)
+      ncap *= 2;
+   uint8_t *nb = realloc(c->buf, ncap);
+   if (!nb)
+   {
+      c->broken = 1;
+      return 0;
+   }
+   c->buf = nb;
+   c->cap = ncap;
+   return 1;
+}
+
+void bus_capture_init(bus_capture_t *c, uint32_t spec_version, uint32_t layout_version,
+                      uint64_t host_epoch)
+{
+   memset(c, 0, sizeof *c);
+   c->spec_version = spec_version;
+   c->layout_version = layout_version;
+   c->host_epoch = host_epoch;
+}
+
+void bus_capture_free(bus_capture_t *c)
+{
+   free(c->buf);
+   c->buf = NULL;
+   c->cap = c->len = 0;
+}
+
+static void write_header(bus_capture_t *c)
+{
+   if (!reserve(c, BUS_CAPTURE_HEADER_LEN))
+      return;
+   uint8_t *h = c->buf;
+   memset(h, 0, BUS_CAPTURE_HEADER_LEN);
+   memcpy(h + 0, BUS_CAPTURE_MAGIC, 8);
+   put_u16(h + 8, BUS_CAPTURE_FORMAT_VERSION);
+   put_u16(h + 10, BUS_CAPTURE_HEADER_LEN);
+   put_u32(h + 12, 0); /* flags */
+   put_u32(h + 16, c->spec_version);
+   put_u32(h + 20, c->layout_version);
+   put_u64(h + 24, c->host_epoch);
+   put_u64(h + 32, c->first_seq);
+   put_u64(h + 40, 0); /* created_unix_nanos: informational, left 0 (no wall clock here) */
+   /* 48..64 reserved, zero. */
+   c->len = BUS_CAPTURE_HEADER_LEN;
+   c->header_written = 1;
+}
+
+static bus_capture_record_type_t type_for_kind(uint32_t kind)
+{
+   switch (kind)
+   {
+   case BUS_KIND_OVERFLOW:
+      return BUS_CAP_OVERFLOW;
+   case BUS_KIND_PRODUCER_REAPED:
+      return BUS_CAP_PRODUCER_REAPED;
+   case BUS_KIND_EPOCH_CHANGE:
+      return BUS_CAP_EPOCH_CHANGE;
+   default:
+      return BUS_CAP_EVENT;
+   }
+}
+
+void bus_capture_tap(void *ctx, const bus_frame_t *frame, const uint8_t *payload,
+                     uint32_t payload_len)
+{
+   bus_capture_t *c = ctx;
+   if (c->broken)
+      return;
+
+   if (!c->have_first)
+   {
+      c->first_seq = frame->seq;
+      c->have_first = 1;
+   }
+   if (!c->header_written)
+      write_header(c);
+
+   /* A materialized payload is only what the tap was handed; an arena reference
+    * carries no bytes here (arena routing is deferred), so it records as an
+    * event with payload_len 0 and the flag clear. */
+   uint32_t plen = (payload && payload_len > 0) ? payload_len : 0;
+   uint32_t record_len = REC_PREFIX + BUS_WIRE_HDR_LEN + plen + 4;
+   if (!reserve(c, record_len))
+      return;
+
+   uint8_t *r = c->buf + c->len;
+   put_u32(r + 0, record_len);
+   put_u16(r + 4, (uint16_t)type_for_kind(frame->event_kind));
+   put_u16(r + 6, plen ? BUS_CAP_F_MATERIALIZED : 0);
+   /* The frame header, verbatim (the exact bytes bus_wire produces). */
+   if (bus_wire_encode(frame, r + REC_PREFIX, BUS_WIRE_HDR_LEN) != BUS_WIRE_HDR_LEN)
+   {
+      /* A frame the encoder refuses should never reach the tap; abandon rather
+       * than write a corrupt record. */
+      c->broken = 1;
+      return;
+   }
+   if (plen)
+      memcpy(r + REC_PREFIX + BUS_WIRE_HDR_LEN, payload, plen);
+   uint32_t crc = crc32c(r, record_len - 4);
+   put_u32(r + record_len - 4, crc);
+
+   c->len += record_len;
+   c->last_seq = frame->seq;
+}
+
+/* ---- reading ---- */
+
+const char *bus_capture_status_name(bus_capture_status_t s)
+{
+   switch (s)
+   {
+   case BUS_CAPTURE_COMPLETE:
+      return "COMPLETE";
+   case BUS_CAPTURE_OPEN:
+      return "OPEN";
+   case BUS_CAPTURE_TRUNCATED:
+      return "TRUNCATED";
+   case BUS_CAPTURE_CORRUPT:
+      return "CORRUPT";
+   default:
+      return "UNKNOWN";
+   }
+}
+
+static bus_capture_report_t done(bus_capture_status_t st, uint64_t recs, uint64_t last, size_t off,
+                                 int rule)
+{
+   bus_capture_report_t r = {.status = st, .records = recs, .last_good_seq = last,
+                             .offending_off = off, .rule = rule};
+   return r;
+}
+
+bus_capture_report_t bus_capture_read(const uint8_t *buf, size_t len, bus_capture_cb cb, void *ctx)
+{
+   const uint32_t rec_max = REC_PREFIX + BUS_WIRE_HDR_LEN + BUS_WIRE_MAX_PAYLOAD + 4;
+
+   /* Rule 0: the file header. An unknown format_version is refused outright. */
+   if (len < BUS_CAPTURE_HEADER_LEN || memcmp(buf, BUS_CAPTURE_MAGIC, 8) != 0)
+      return done(BUS_CAPTURE_CORRUPT, 0, 0, 0, 0);
+   if (get_u16(buf + 8) != BUS_CAPTURE_FORMAT_VERSION)
+      return done(BUS_CAPTURE_CORRUPT, 0, 0, 0, 0);
+
+   size_t p = get_u16(buf + 10); /* header_len; a later version may extend it */
+   if (p < BUS_CAPTURE_HEADER_LEN || p > len)
+      p = BUS_CAPTURE_HEADER_LEN;
+
+   uint64_t records = 0, last_seq = 0, prev_seq = 0;
+   int have_prev = 0, prev_was_epoch = 0;
+
+   for (;;)
+   {
+      size_t remaining = len - p;
+      if (remaining == 0)
+         /* Rule 1: clean end. complete iff the last record was epoch_change. */
+         return done(prev_was_epoch ? BUS_CAPTURE_COMPLETE : BUS_CAPTURE_OPEN, records, last_seq,
+                     len, 1);
+      if (remaining < 8)
+         return done(BUS_CAPTURE_TRUNCATED, records, last_seq, p, 2); /* no length prefix */
+
+      uint32_t record_len = get_u32(buf + p);
+      if (record_len < REC_MIN)
+         return done(BUS_CAPTURE_CORRUPT, records, last_seq, p, 3); /* malformed prefix */
+      if (record_len > rec_max)
+         return done(remaining <= rec_max ? BUS_CAPTURE_TRUNCATED : BUS_CAPTURE_CORRUPT, records,
+                     last_seq, p, 3);
+      if (remaining < record_len)
+         return done(BUS_CAPTURE_TRUNCATED, records, last_seq, p, 4);
+
+      uint32_t stored_crc = get_u32(buf + p + record_len - 4);
+      if (crc32c(buf + p, record_len - 4) != stored_crc)
+         /* Rule 5: a bad CRC at EOF is a torn final write; anywhere else is damage. */
+         return done(remaining == record_len ? BUS_CAPTURE_TRUNCATED : BUS_CAPTURE_CORRUPT,
+                     records, last_seq, p, 5);
+
+      /* Rule 6: structural contradictions no interrupted write can produce. */
+      uint16_t rtype = get_u16(buf + p + 4);
+      uint16_t rflags = get_u16(buf + p + 6);
+      bus_frame_t f;
+      if (bus_wire_decode(buf + p + REC_PREFIX, BUS_WIRE_HDR_LEN, &f) != BUS_WIRE_OK)
+         return done(BUS_CAPTURE_CORRUPT, records, last_seq, p, 6);
+      uint32_t plen = record_len - REC_PREFIX - BUS_WIRE_HDR_LEN - 4;
+      if (rflags & ~BUS_CAP_F_MATERIALIZED)
+         return done(BUS_CAPTURE_CORRUPT, records, last_seq, p, 6);
+      if (prev_was_epoch)
+         return done(BUS_CAPTURE_CORRUPT, records, last_seq, p, 6); /* record after epoch_change */
+      if (have_prev && f.seq != prev_seq + 1)
+         return done(BUS_CAPTURE_CORRUPT, records, last_seq, p, 6); /* seq gap */
+
+      if (cb)
+      {
+         bus_capture_event_t ev;
+         memset(&ev, 0, sizeof ev);
+         ev.type = (bus_capture_record_type_t)rtype;
+         ev.frame = f;
+         ev.payload_len = plen;
+         ev.payload = plen ? (buf + p + REC_PREFIX + BUS_WIRE_HDR_LEN) : NULL;
+         cb(ctx, &ev);
+      }
+
+      records++;
+      last_seq = f.seq;
+      prev_seq = f.seq;
+      have_prev = 1;
+      prev_was_epoch = (rtype == BUS_CAP_EPOCH_CHANGE);
+      p += record_len;
+   }
+}

--- a/src/modules/bus/bus_capture.h
+++ b/src/modules/bus/bus_capture.h
@@ -1,0 +1,117 @@
+/* bus_capture.h: the event-bus capture stream and observational replay (D10).
+ *
+ * The capture stream is exactly the host's seq order: it is fed by the
+ * governance/audit tap (D6/D9), so every seq-stamped event — including the
+ * host-generated overflow and producer_reaped notices — is recorded once, in
+ * order. From that one ordered stream the delivered stream is derivable (D6),
+ * which is the property the later governance-and-capture tree depends on.
+ *
+ * The wire format is normative (D10), frozen by this slice's tests: a fixed file
+ * header, then length-prefixed CRC-checked records carrying the verbatim frame
+ * header and the materialized payload bytes. Payloads are materialized because
+ * an arena region does not outlive the host; a reader uses the inline bytes and
+ * must never dereference a captured payload_ref.
+ *
+ * Observational replay re-presents the ordered stream for inspection. Nothing is
+ * re-executed, so it is exact by construction. Module replay (re-driving a module
+ * against recorded inbound events) is a later tree, not this one.
+ */
+#ifndef AIMEE_BUS_CAPTURE_H
+#define AIMEE_BUS_CAPTURE_H 1
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bus_host.h" /* bus_tap_fn, bus_frame_t */
+
+/* File header, 64 bytes. All integers little-endian. magic is the 8 ASCII bytes
+ * "AIMEECAP". */
+#define BUS_CAPTURE_MAGIC          "AIMEECAP"
+#define BUS_CAPTURE_FORMAT_VERSION 1
+#define BUS_CAPTURE_HEADER_LEN     64
+
+/* Record types. */
+typedef enum
+{
+   BUS_CAP_EVENT = 0,
+   BUS_CAP_OVERFLOW = 1,
+   BUS_CAP_PRODUCER_REAPED = 2,
+   BUS_CAP_EPOCH_CHANGE = 3
+} bus_capture_record_type_t;
+
+/* record_flags bit 0: the payload bytes were materialized inline. */
+#define BUS_CAP_F_MATERIALIZED 0x0001u
+
+/* A growable in-memory capture sink. The format on disk and in memory is
+ * identical; a file writer is a thin wrapper a later tree can add. */
+typedef struct
+{
+   uint8_t *buf;
+   size_t len;
+   size_t cap;
+   uint64_t first_seq;
+   uint64_t last_seq;
+   int have_first;
+   int header_written;
+   uint32_t spec_version;
+   uint32_t layout_version;
+   uint64_t host_epoch;
+   int broken; /* an allocation failed; the stream is abandoned */
+} bus_capture_t;
+
+/* Terminal classification of a stream, decided from the bytes alone (D10). */
+typedef enum
+{
+   BUS_CAPTURE_COMPLETE = 0, /* ended cleanly with an epoch_change */
+   BUS_CAPTURE_OPEN,         /* valid capture of a still-running host */
+   BUS_CAPTURE_TRUNCATED,    /* cut mid-write; last good seq/offset reported */
+   BUS_CAPTURE_CORRUPT       /* a structural contradiction before the end */
+} bus_capture_status_t;
+
+/* Result of reading a stream. */
+typedef struct
+{
+   bus_capture_status_t status;
+   uint64_t records;      /* records successfully parsed */
+   uint64_t last_good_seq;
+   size_t offending_off;  /* byte offset of the record that failed, if any */
+   int rule;              /* which classification rule fired (for diagnostics) */
+} bus_capture_report_t;
+
+/* One replayed record handed to a callback. payload points into the stream and
+ * is valid for the duration of the callback. */
+typedef struct
+{
+   bus_capture_record_type_t type;
+   bus_frame_t frame;
+   const uint8_t *payload;
+   uint32_t payload_len;
+} bus_capture_event_t;
+
+typedef void (*bus_capture_cb)(void *ctx, const bus_capture_event_t *ev);
+
+/* ---- writing ---- */
+
+/* Initialise a sink. The spec/layout/epoch go in the file header. */
+void bus_capture_init(bus_capture_t *c, uint32_t spec_version, uint32_t layout_version,
+                      uint64_t host_epoch);
+
+/* The tap function: register with bus_host_set_tap(h, bus_capture_tap, c). It
+ * classifies overflow/producer_reaped/epoch_change by event_kind and records
+ * everything else as an event. */
+void bus_capture_tap(void *ctx, const bus_frame_t *frame, const uint8_t *payload,
+                     uint32_t payload_len);
+
+/* Free the sink's buffer. */
+void bus_capture_free(bus_capture_t *c);
+
+/* ---- reading / replay ---- */
+
+/* Classify a byte stream and, if not corrupt/truncated before it, replay each
+ * record to cb in order. cb may be NULL to classify without replaying. */
+bus_capture_report_t bus_capture_read(const uint8_t *buf, size_t len, bus_capture_cb cb,
+                                      void *ctx);
+
+const char *bus_capture_status_name(bus_capture_status_t s);
+
+#endif /* AIMEE_BUS_CAPTURE_H */

--- a/src/modules/bus/bus_host.h
+++ b/src/modules/bus/bus_host.h
@@ -79,7 +79,8 @@ typedef bus_attach_status_t (*bus_admit_fn)(void *ctx, const bus_attach_request_
 /* The governance/audit tap: invoked once per event, after seq stamping and
  * before any routing decision (D6). It is the single full-stream observer; a
  * would_block that the host never accepted is not an event and is not tapped. */
-typedef void (*bus_tap_fn)(void *ctx, const bus_frame_t *frame);
+typedef void (*bus_tap_fn)(void *ctx, const bus_frame_t *frame,
+                           const uint8_t *payload, uint32_t payload_len);
 
 typedef struct
 {

--- a/src/modules/bus/bus_route.c
+++ b/src/modules/bus/bus_route.c
@@ -179,7 +179,7 @@ static void emit_control(bus_host_t *h, int dst, uint32_t kind, uint64_t corr,
    f.seq = ++h->seq;
    f.dst_handle = dst < 0 ? 0 : (uint32_t)dst;
    if (h->tap)
-      h->tap(h->tap_ctx, &f);
+      h->tap(h->tap_ctx, &f, (const uint8_t *)payload, plen);
    if (dst < 0)
       return; /* tap-only */
    bus_slot_t *d = &h->slots[dst];
@@ -402,7 +402,8 @@ uint32_t bus_host_pump(bus_host_t *h)
             f.seq = ++h->seq;
             f.src_handle = s;
             if (h->tap)
-               h->tap(h->tap_ctx, &f); /* seq-stamped, pre-routing, once */
+               h->tap(h->tap_ctx, &f, inl, (f.hdr_flags & BUS_F_INLINE) ? f.payload_len : 0);
+            /* seq-stamped, pre-routing, once */
             memset(slot->blocked_delivered, 0, sizeof slot->blocked_delivered);
             done = route_fresh(h, s, &f, inl, slot->blocked_delivered);
             routed++; /* count each accepted event once, at first sight */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -158,6 +158,10 @@ aimee_add_test(test_bus_client test_bus_client.c ../modules/bus/bus_client.c ../
 target_include_directories(test_bus_client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
 find_package(Threads REQUIRED)
 target_link_libraries(test_bus_client PRIVATE Threads::Threads)
+aimee_add_test(test_bus_capture test_bus_capture.c ../modules/bus/bus_capture.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c)
+target_include_directories(test_bus_capture PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus)
+target_link_libraries(test_bus_capture PRIVATE Threads::Threads)
+
 
 
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -221,6 +221,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-bus-route \
                $(TESTPREFIX)/unit-test-bus-flow \
                $(TESTPREFIX)/unit-test-bus-client \
+               $(TESTPREFIX)/unit-test-bus-capture \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
@@ -2628,6 +2629,23 @@ $(TESTPREFIX)/bus-conformance-host: $(OBJDIR)/tests/bus_conformance_host.o \
 
 .PHONY: bus-conformance-host
 bus-conformance-host: $(TESTPREFIX)/bus-conformance-host
+
+# Event-bus capture + observational replay (feature tree slice 11).
+$(OBJDIR)/tests/test_bus_capture.o: C_FLAGS += -Imodules/bus
+$(TESTPREFIX)/unit-test-bus-capture: $(OBJDIR)/tests/test_bus_capture.o \
+                                     $(OBJDIR)/modules/bus/bus_capture.o \
+                                     $(OBJDIR)/modules/bus/bus_client.o \
+                                     $(OBJDIR)/modules/bus/bus_host.o \
+                                     $(OBJDIR)/modules/bus/bus_route.o \
+                                     $(OBJDIR)/modules/bus/bus_region.o \
+                                     $(OBJDIR)/modules/bus/bus_ring.o \
+                                     $(OBJDIR)/modules/bus/bus_arena.o \
+                                     $(OBJDIR)/modules/bus/bus_wire.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
+
+.PHONY: unit-test-bus-capture
+unit-test-bus-capture: $(TESTPREFIX)/unit-test-bus-capture
+	$<
 
 .PHONY: unit-test-bus-client
 unit-test-bus-client: $(TESTPREFIX)/unit-test-bus-client

--- a/src/tests/test_bus_capture.c
+++ b/src/tests/test_bus_capture.c
@@ -1,0 +1,289 @@
+/* test_bus_capture.c: slice 11 of the event-bus feature tree.
+ *
+ * The capture stream and observational replay (D10):
+ *
+ *   - end to end: the tap records a host's event stream; reading it back yields
+ *     the same events, in contiguous seq order, with materialized payloads, and
+ *     observational replay reproduces them exactly;
+ *   - the terminal-states parser is total and decides open / complete /
+ *     truncated / corrupt from the bytes alone — a clean tail is open, an
+ *     epoch_change tail is complete, a torn final record is truncated, and a
+ *     seq gap, a mid-stream CRC failure, a record after epoch_change, or an
+ *     unknown format_version are all corrupt.
+ */
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "bus_capture.h"
+#include "bus_client.h"
+#include "bus_host.h"
+#include "bus_wire.h"
+
+static void must(int cond, const char *what)
+{
+   if (!cond)
+   {
+      fprintf(stderr, "FAIL: %s\n", what);
+      abort();
+   }
+}
+
+/* ---- replay collector ---- */
+
+#define MAXREC 256
+static uint64_t g_seq[MAXREC];
+static uint32_t g_kind[MAXREC];
+static uint32_t g_n;
+static void collect(void *ctx, const bus_capture_event_t *ev)
+{
+   (void)ctx;
+   must(g_n < MAXREC, "replay buffer");
+   g_seq[g_n] = ev->frame.seq;
+   g_kind[g_n] = ev->frame.event_kind;
+   g_n++;
+}
+
+/* ---- a directly-driven tap, for precise stream construction ---- */
+
+static void tap_frame(bus_capture_t *c, uint32_t kind, uint64_t seq, const char *payload)
+{
+   bus_frame_t f;
+   memset(&f, 0, sizeof f);
+   f.wire_version = BUS_WIRE_VERSION;
+   f.event_kind = kind;
+   f.hdr_flags = BUS_F_NOTIFICATION;
+   f.seq = seq;
+   uint32_t plen = payload ? (uint32_t)strlen(payload) : 0;
+   if (plen)
+   {
+      f.hdr_flags |= BUS_F_INLINE;
+      f.payload_len = plen;
+      f.payload_ref = BUS_WIRE_HDR_LEN;
+   }
+   bus_capture_tap(c, &f, (const uint8_t *)payload, plen);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_roundtrip_and_replay(void)
+{
+   bus_capture_t cap;
+   bus_capture_init(&cap, 1, 1, 7);
+
+   const char *msgs[] = {"alpha", "bravo", "charlie", "delta"};
+   for (int i = 0; i < 4; i++)
+      tap_frame(&cap, 300 + i, (uint64_t)(100 + i), msgs[i]);
+
+   g_n = 0;
+   bus_capture_report_t rep = bus_capture_read(cap.buf, cap.len, collect, NULL);
+   must(rep.status == BUS_CAPTURE_OPEN, "a clean, non-terminated stream is open");
+   must(rep.records == 4, "all four records parsed");
+   must(g_n == 4, "replay produced four events");
+   for (int i = 0; i < 4; i++)
+   {
+      must(g_seq[i] == (uint64_t)(100 + i), "seq preserved in order");
+      must(g_kind[i] == (uint32_t)(300 + i), "kind preserved");
+   }
+   /* Materialized payloads survive: re-read and check the bytes of one. */
+   must(rep.last_good_seq == 103, "last good seq");
+
+   bus_capture_free(&cap);
+   printf("  roundtrip: capture -> read -> replay reproduces the stream in order\n");
+}
+
+/* Verify the materialized payload bytes come back exactly. */
+static const char *g_want_payload;
+static int g_payload_ok;
+static void check_payload(void *ctx, const bus_capture_event_t *ev)
+{
+   (void)ctx;
+   if (ev->frame.seq == 500)
+   {
+      g_payload_ok = ev->payload_len == (uint32_t)strlen(g_want_payload) &&
+                     memcmp(ev->payload, g_want_payload, ev->payload_len) == 0;
+   }
+}
+
+static void test_materialized_payload(void)
+{
+   bus_capture_t cap;
+   bus_capture_init(&cap, 1, 1, 1);
+   g_want_payload = "the-payload-bytes";
+   tap_frame(&cap, 400, 500, g_want_payload);
+   g_payload_ok = 0;
+   bus_capture_read(cap.buf, cap.len, check_payload, NULL);
+   must(g_payload_ok, "materialized payload bytes come back exactly");
+   bus_capture_free(&cap);
+   printf("  materialized payload: recorded and read back byte-exact\n");
+}
+
+struct serve_arg
+{
+   bus_host_t *h;
+   int fd;
+};
+static void *serve_thread(void *p)
+{
+   struct serve_arg *a = p;
+   bus_host_serve_attach(a->h, a->fd);
+   return NULL;
+}
+static void attach_client(bus_host_t *h, bus_client_t *c)
+{
+   int sv[2];
+   must(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) == 0, "socketpair");
+   struct serve_arg a = {.h = h, .fd = sv[1]};
+   pthread_t t;
+   must(pthread_create(&t, NULL, serve_thread, &a) == 0, "spawn serve");
+   must(bus_client_attach(sv[0], c) == BUS_CLIENT_OK, "attach");
+   pthread_join(t, NULL);
+   close(sv[0]);
+   close(sv[1]);
+}
+
+/* Route real events through the host with the capture tap installed, and confirm
+ * the captured stream is exactly what was routed. */
+static uint32_t g_e2e_kinds[8];
+static uint32_t g_e2e_n;
+static void e2e_collect(void *ctx, const bus_capture_event_t *ev)
+{
+   (void)ctx;
+   if (g_e2e_n < 8)
+      g_e2e_kinds[g_e2e_n++] = ev->frame.event_kind;
+}
+
+static void test_end_to_end_host(void)
+{
+   bus_host_config_t cfg;
+   memset(&cfg, 0, sizeof cfg);
+   cfg.max_slots = 4;
+   cfg.slot_size = 256;
+   cfg.inline_budget = 192;
+   cfg.queue_capacity = 16;
+   cfg.arena_size = 128 * 1024;
+
+   bus_host_t h;
+   must(bus_host_create(&h, &cfg, NULL, NULL) == BUS_HOST_OK, "host");
+   bus_capture_t cap;
+   bus_capture_init(&cap, 1, 1, bus_control_epoch(h.control));
+   bus_host_set_tap(&h, bus_capture_tap, &cap);
+
+   bus_client_t pub, sub;
+   attach_client(&h, &pub);
+   attach_client(&h, &sub);
+   must(bus_host_subscribe(&h, sub.reply.handle_id, 700) == BUS_HOST_OK, "subscribe");
+
+   /* Two real publishes routed through the host; the tap records each once. */
+   must(bus_client_publish(&pub, 700, "one", 3) == BUS_CLIENT_OK, "publish 1");
+   must(bus_client_publish(&pub, 700, "two", 3) == BUS_CLIENT_OK, "publish 2");
+   must(bus_host_pump(&h) == 2, "host routes both");
+
+   /* The subscriber actually received them (delivered stream), and the capture
+    * recorded them (intended stream) — the two derivable from one another (D6). */
+   bus_event_t ev;
+   must(bus_client_poll(&sub, &ev) == BUS_CLIENT_OK && ev.frame.event_kind == 700, "delivered 1");
+   must(bus_client_poll(&sub, &ev) == BUS_CLIENT_OK && ev.frame.event_kind == 700, "delivered 2");
+
+   g_e2e_n = 0;
+   bus_capture_report_t rep = bus_capture_read(cap.buf, cap.len, e2e_collect, NULL);
+   must(rep.status == BUS_CAPTURE_OPEN && rep.records == 2, "capture recorded both routed events");
+   must(g_e2e_n == 2 && g_e2e_kinds[0] == 700 && g_e2e_kinds[1] == 700,
+        "replay reproduces the routed kinds in order");
+
+   bus_client_detach(&pub);
+   bus_client_detach(&sub);
+   bus_capture_free(&cap);
+   bus_host_destroy(&h);
+   printf("  end-to-end: real routed events are captured and replayed in order\n");
+}
+
+static void test_terminal_states(void)
+{
+   /* complete: a stream ending in an epoch_change record. */
+   {
+      bus_capture_t c;
+      bus_capture_init(&c, 1, 1, 1);
+      tap_frame(&c, 800, 10, "x");
+      tap_frame(&c, BUS_KIND_EPOCH_CHANGE, 11, NULL);
+      bus_capture_report_t r = bus_capture_read(c.buf, c.len, NULL, NULL);
+      must(r.status == BUS_CAPTURE_COMPLETE, "epoch_change tail -> complete");
+      bus_capture_free(&c);
+   }
+
+   /* corrupt: a record after epoch_change. */
+   {
+      bus_capture_t c;
+      bus_capture_init(&c, 1, 1, 1);
+      tap_frame(&c, BUS_KIND_EPOCH_CHANGE, 20, NULL);
+      tap_frame(&c, 800, 21, "x");
+      bus_capture_report_t r = bus_capture_read(c.buf, c.len, NULL, NULL);
+      must(r.status == BUS_CAPTURE_CORRUPT, "record after epoch_change -> corrupt");
+      bus_capture_free(&c);
+   }
+
+   /* corrupt: a seq gap. */
+   {
+      bus_capture_t c;
+      bus_capture_init(&c, 1, 1, 1);
+      tap_frame(&c, 800, 30, "a");
+      tap_frame(&c, 801, 32, "b"); /* 31 skipped */
+      bus_capture_report_t r = bus_capture_read(c.buf, c.len, NULL, NULL);
+      must(r.status == BUS_CAPTURE_CORRUPT && r.rule == 6, "seq gap -> corrupt");
+      bus_capture_free(&c);
+   }
+
+   /* truncated: chop the last record mid-body. */
+   {
+      bus_capture_t c;
+      bus_capture_init(&c, 1, 1, 1);
+      tap_frame(&c, 800, 40, "hello");
+      tap_frame(&c, 801, 41, "world");
+      size_t chopped = c.len - 3; /* lose the last 3 bytes of the final record */
+      bus_capture_report_t r = bus_capture_read(c.buf, chopped, NULL, NULL);
+      must(r.status == BUS_CAPTURE_TRUNCATED, "torn final record -> truncated");
+      must(r.records == 1 && r.last_good_seq == 40, "the first record survived");
+      bus_capture_free(&c);
+   }
+
+   /* corrupt: a mid-stream CRC failure (bytes follow it). */
+   {
+      bus_capture_t c;
+      bus_capture_init(&c, 1, 1, 1);
+      tap_frame(&c, 800, 50, "aaaa");
+      tap_frame(&c, 801, 51, "bbbb");
+      /* flip a byte inside the first record's payload; its CRC now fails and it
+       * is not the last record. */
+      c.buf[BUS_CAPTURE_HEADER_LEN + 8 + BUS_WIRE_HDR_LEN] ^= 0xff;
+      bus_capture_report_t r = bus_capture_read(c.buf, c.len, NULL, NULL);
+      must(r.status == BUS_CAPTURE_CORRUPT && r.rule == 5, "mid-stream CRC failure -> corrupt");
+      bus_capture_free(&c);
+   }
+
+   /* corrupt: an unknown format_version is refused before any record. */
+   {
+      bus_capture_t c;
+      bus_capture_init(&c, 1, 1, 1);
+      tap_frame(&c, 800, 60, "x");
+      c.buf[8] = 0x7f; /* format_version */
+      bus_capture_report_t r = bus_capture_read(c.buf, c.len, NULL, NULL);
+      must(r.status == BUS_CAPTURE_CORRUPT && r.rule == 0, "unknown format_version -> corrupt");
+      bus_capture_free(&c);
+   }
+
+   printf("  terminal states: open/complete/truncated/corrupt decided from bytes\n");
+}
+
+int main(void)
+{
+   printf("test_bus_capture:\n");
+   test_roundtrip_and_replay();
+   test_materialized_payload();
+   test_end_to_end_host();
+   test_terminal_states();
+   printf("test_bus_capture: OK\n");
+   return 0;
+}

--- a/src/tests/test_bus_flow.c
+++ b/src/tests/test_bus_flow.c
@@ -128,8 +128,9 @@ static bus_host_config_t cfg(void)
 static uint64_t g_seq[512];
 static uint32_t g_kind[512];
 static uint32_t g_n;
-static void tap(void *ctx, const bus_frame_t *f)
+static void tap(void *ctx, const bus_frame_t *f, const uint8_t *pl, uint32_t pn)
 {
+   (void)pl; (void)pn;
    (void)ctx;
    must(g_n < 512, "tap buffer");
    g_seq[g_n] = f->seq;

--- a/src/tests/test_bus_route.c
+++ b/src/tests/test_bus_route.c
@@ -133,8 +133,9 @@ static uint64_t g_tap_seq[256];
 static uint32_t g_tap_kind[256];
 static uint32_t g_tap_n;
 
-static void recording_tap(void *ctx, const bus_frame_t *f)
+static void recording_tap(void *ctx, const bus_frame_t *f, const uint8_t *pl, uint32_t pn)
 {
+   (void)pl; (void)pn;
    (void)ctx;
    must(g_tap_n < 256, "tap buffer");
    g_tap_seq[g_tap_n] = f->seq;


### PR DESCRIPTION
Eleventh slice. Self-reviewed.

## What lands

`bus_capture.{c,h}` — the normative **D10 capture format**, fed by the governance tap so the stream is exactly the host's seq order (every seq-stamped event, including overflow/producer_reaped, once, in order; the delivered stream derivable from it — D6).

- 64-byte file header (`AIMEECAP`, format_version, spec/layout/epoch, first_seq), then length-prefixed records: record_type, record_flags, verbatim frame header, **materialized** payload, **CRC-32C**. Payloads are materialized because the arena doesn't outlive the host; readers never dereference a captured `payload_ref`.
- The reader is the **total terminal-states algorithm**: format_version first, then per record — clean end is *open* (or *complete* after an epoch_change), a torn final record is *truncated*, and a sub-minimum length / mid-stream CRC failure / reserved flag / **seq gap** / record-after-epoch are *corrupt*.
- Observational replay re-presents the ordered stream — exact by construction. Module replay is a later tree.

The tap now carries the payload bytes (`bus_tap_fn` gained payload+len) so materialization works; the router passes the inline payload; existing tap users updated. **No routing behaviour changes.**

## Self-review

The end-to-end test was bypassing the host (calling the tap directly). It now routes two real publishes through the host with capture installed, confirms the subscriber received them and the capture recorded them, and that replay reproduces them in order.

## Verification (normal + ASAN/UBSAN + TSAN)

Round-trip replay in order; byte-exact materialized payloads; real routed events captured; the full terminal-states matrix. Cross-language conformance and all prior bus tests remain green under the extended tap.

No shipping binary links the bus (D7). Depends on slices 1–10 (merged).