### PR TITLE
cleanup(plugin-loader): internalize the five module-only exports

### DIFF
--- a/docs/modules/plugin-loader.md
+++ b/docs/modules/plugin-loader.md
@@ -12,20 +12,19 @@ pre-LLM hook contract; those remain required in
 
 `src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h` exports
 `plugin_loader_scan_dir` and `plugin_loader_discover_all`.
-`src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h` exports manifest parsing,
-installed-registry operations,
-install/enable/remove, hook/tool aggregation, conflict checks, `plugin_manifest_parse`, and
-`plugin_load_and_register`. It consumes the required `plugin_permission_name` and
-`plugin_permission_from_str` vocabulary.
+`src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h` exports `plugin_manifest_parse`,
+`plugin_registry_load`/`plugin_registry_json`, install/enable/remove, and hook/tool aggregation. It
+consumes the required `plugin_permission_name` and `plugin_permission_from_str` vocabulary.
 Loader types consume `aimee/module-runtime/extension.h` one way; module-runtime never includes this
 module.
 
-Five exports have no tracked production caller outside the module: `plugin_registry_path`,
-`plugin_registry_save`, and `plugin_load_and_register` are called only from `plugin.c` and
-`plugin_loader.c`; `plugin_tool_conflicts_with_builtin` is called from `plugin.c` plus the focused
-test, its only external caller; and `plugin_registry_get` has no module-local caller and only the
-focused test as a tracked caller. These remain exported ahead of a later internalization pass; each is
-still reachable from `plugin.c`, `plugin_loader.c`, or the focused test, so none is dead.
+Five symbols have no caller outside the module and are declared in the module-private
+`src/modules/plugin-loader/plugin_internal.h`, not the public headers. `plugin_registry_path` and
+`plugin_registry_save` are used only inside `plugin.c` and are `static` there — the internal header
+does not carry them. `plugin_load_and_register` (called by `plugin_loader.c`), `plugin_registry_get`
+(the focused test only), and `plugin_tool_conflicts_with_builtin` (`plugin.c` plus the focused test)
+need cross-translation-unit visibility, so they are declared in `plugin_internal.h`, which
+`plugin.c` and `plugin_loader.c` include as a sibling and the test reaches through the source root.
 
 Two former exports had no caller anywhere in the tracked tree and were removed:
 `plugin_load_all_registered`, a second registration entry point superseded by

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -281,6 +281,7 @@ class DescriptorTests(unittest.TestCase):
             ("module-runtime", "sources", "src/modules/module-runtime/pre_llm_hook.c"),
             ("plugin-loader", "sources", "src/modules/plugin-loader/plugin.c"),
             ("plugin-loader", "sources", "src/modules/plugin-loader/plugin_loader.c"),
+            ("plugin-loader", "private_headers", "src/modules/plugin-loader/plugin_internal.h"),
             ("gateway", "sources", "src/modules/gateway/gateway_delegate.c"),
             ("gateway", "sources", "src/modules/gateway/gateway_pipeline.c"),
             ("gateway", "sources", "src/modules/gateway/gateway_policy.c"),

--- a/src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h
+++ b/src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h
@@ -51,18 +51,9 @@ typedef struct
 
 /* --- Plugin registry API --- */
 
-/* Registry path: ~/.config/aimee/plugins/installed.json */
-const char *plugin_registry_path(void);
-
 /* Load all plugins from the registry into plugins[].
  * Returns count (0 means empty registry; not an error). */
 int plugin_registry_load(plugin_t *plugins, int max);
-
-/* Save plugins[] to the registry. Returns 0 on success. */
-int plugin_registry_save(const plugin_t *plugins, int count);
-
-/* Find a plugin by name in the registry. Returns 0 on success, -1 if absent. */
-int plugin_registry_get(const char *name, plugin_t *out);
 
 /* Return a malloc'd JSON array describing installed plugins. Caller frees. */
 char *plugin_registry_json(void);
@@ -74,14 +65,6 @@ char *plugin_registry_json(void);
  * Also supports plugin.yaml (YAML format) if available.
  * Returns 0 on success, -1 on error (sets err_buf). */
 int plugin_manifest_parse(const char *dir, plugin_t *out, char *err_buf, size_t err_len);
-
-/* --- Load and register ---
- *
- * Load a plugin from its source_path, create a plugin_ctx_t,
- * and call the plugin's register(ctx) entry point.
- * Returns 0 on success, -1 on error (sets err_buf).
- * The plugin's on_init is called after registration succeeds. */
-int plugin_load_and_register(const plugin_t *plugin, char *err_buf, size_t err_len);
 
 /* --- Install / enable / disable / remove --- */
 
@@ -115,8 +98,5 @@ int plugin_collect_hooks(const plugin_t *plugins, int count, const char *event, 
 
 /* Collect all tools from enabled plugins into out[]. Returns count. */
 int plugin_collect_tools(const plugin_t *plugins, int count, plugin_tool_t *out, int max_tools);
-
-/* Check if a tool name conflicts with a built-in. Returns 1 if conflict, 0 otherwise. */
-int plugin_tool_conflicts_with_builtin(const char *tool_name);
 
 #endif /* AIMEE_PLUGIN_LOADER_PLUGIN_H */

--- a/src/modules/plugin-loader/module.yaml
+++ b/src/modules/plugin-loader/module.yaml
@@ -22,6 +22,9 @@
     "src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h",
     "src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h"
   ],
+  "private_headers": [
+    "src/modules/plugin-loader/plugin_internal.h"
+  ],
   "tests": [
     "src/tests/test_plugin.c",
     "src/tests/test_plugin_loader.c"

--- a/src/modules/plugin-loader/plugin.c
+++ b/src/modules/plugin-loader/plugin.c
@@ -1,6 +1,7 @@
 /* plugin.c: optional plugin manifests, persistence, and dynamic loading */
 #include "aimee.h"
 #include "aimee/plugin-loader/plugin.h"
+#include "plugin_internal.h"
 #include "memory_provider.h"
 #include "headers/context_engine.h"
 #include "cJSON.h"
@@ -8,16 +9,13 @@
 #include "platform_path.h"
 #include <dlfcn.h>
 #include <dirent.h>
-
-/* Forward declarations */
-int plugin_tool_conflicts_with_builtin(const char *tool_name);
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 /* --- Registry path --- */
 
-const char *plugin_registry_path(void)
+static const char *plugin_registry_path(void)
 {
    static char path[MAX_PATH_LEN];
    if (path[0])
@@ -202,7 +200,7 @@ int plugin_registry_load(plugin_t *plugins, int max)
    return count;
 }
 
-int plugin_registry_save(const plugin_t *plugins, int count)
+static int plugin_registry_save(const plugin_t *plugins, int count)
 {
    ensure_plugins_dir();
    cJSON *arr = cJSON_CreateArray();

--- a/src/modules/plugin-loader/plugin_internal.h
+++ b/src/modules/plugin-loader/plugin_internal.h
@@ -1,0 +1,25 @@
+/* plugin_internal.h: plugin-loader contract shared across the module's own
+ * translation units (plugin.c, plugin_loader.c) and the focused plugin tests.
+ *
+ * These symbols have no caller outside the module, so they are kept out of the
+ * public include/aimee/plugin-loader/ headers. plugin.c and plugin_loader.c
+ * include this as a sibling ("plugin_internal.h"); tests reach it through the
+ * source root ("modules/plugin-loader/plugin_internal.h").
+ */
+#ifndef AIMEE_PLUGIN_LOADER_PLUGIN_INTERNAL_H
+#define AIMEE_PLUGIN_LOADER_PLUGIN_INTERNAL_H
+
+#include "aimee/plugin-loader/plugin.h"
+
+/* Find a plugin by name in the registry. Returns 0 on success, -1 if absent. */
+int plugin_registry_get(const char *name, plugin_t *out);
+
+/* Load a plugin from its source_path, create a plugin_ctx_t, and call the
+ * plugin's register(ctx) entry point. The plugin's on_init runs after
+ * registration succeeds. Returns 0 on success, -1 on error (sets err_buf). */
+int plugin_load_and_register(const plugin_t *plugin, char *err_buf, size_t err_len);
+
+/* Check if a tool name conflicts with a built-in. Returns 1 if conflict, 0 otherwise. */
+int plugin_tool_conflicts_with_builtin(const char *tool_name);
+
+#endif /* AIMEE_PLUGIN_LOADER_PLUGIN_INTERNAL_H */

--- a/src/modules/plugin-loader/plugin_loader.c
+++ b/src/modules/plugin-loader/plugin_loader.c
@@ -4,6 +4,7 @@
  * docs/proposals/pending/plugin-extension-surface-and-context-engine.md.
  */
 #include "aimee/plugin-loader/plugin_loader.h"
+#include "plugin_internal.h"
 #include "headers/log.h"
 #include "config.h"
 #include "headers/aimee_home.h"

--- a/src/tests/test_plugin.c
+++ b/src/tests/test_plugin.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include "aimee.h"
 #include "aimee/plugin-loader/plugin.h"
+#include "modules/plugin-loader/plugin_internal.h"
 #include "aimee/module-runtime/extension.h"
 #include "cJSON.h"
 #include "platform_test_util.h"

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -147,7 +147,7 @@
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h",
-          "sha256": "7613924175497c26d15b4b7e5926b671b10a37c1ee0a67c9c2b8e1026a0c01e9"
+          "sha256": "d49a7a4729bde286fb08446359a596d8b2674d3c6d7069455629ea7c0d165195"
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h",
@@ -1307,7 +1307,7 @@
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h",
-          "sha256": "7613924175497c26d15b4b7e5926b671b10a37c1ee0a67c9c2b8e1026a0c01e9"
+          "sha256": "d49a7a4729bde286fb08446359a596d8b2674d3c6d7069455629ea7c0d165195"
         },
         {
           "path": "src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h",
@@ -1352,7 +1352,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "f83d40f26effb5c264dbae2df4386f468c6f9195f953ee426d851207ad6b6a2a",
+      "sha256": "75853849c97cb9e5134c6626568c86ec598ab5f861a36033cb2b4e67082d4f91",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## What

The five `plugin.h` exports with no caller outside the module are moved off the public surface, completing the internalization the dead-symbol cleanup (#1912) deferred. `plugin.h` now advertises only the genuinely public API (`plugin_registry_load`/`plugin_registry_json`, `plugin_manifest_parse`, install/enable/remove, hook/tool aggregation, permission vocabulary).

| Symbol | Callers | Disposition |
|---|---|---|
| `plugin_registry_path` | `plugin.c` only | now `static` in plugin.c |
| `plugin_registry_save` | `plugin.c` only | now `static` in plugin.c |
| `plugin_load_and_register` | `plugin_loader.c` | → `plugin_internal.h` |
| `plugin_registry_get` | focused test only | → `plugin_internal.h` |
| `plugin_tool_conflicts_with_builtin` | `plugin.c` + test | → `plugin_internal.h` |

## Include mechanics (no forbidden -I root)

`plugin_internal.h` lives at the module root. `plugin.c`/`plugin_loader.c` include it as a sibling; `test_plugin.c` reaches it through the source root — `#include "modules/plugin-loader/plugin_internal.h"` — matching the existing `test_aws_auth.c` pattern. This avoids adding `-Imodules/plugin-loader`, which the header-layout `retired-include-root` rule forbids for a module with canonical public headers.

## Latched descriptor

`plugin_internal.h` is the module's first module-root header, so it's declared in the descriptor's new `private_headers`. The completeness latch still holds (declared sources+private_headers == actual module-local files), and the mutation suite gains a plugin-loader private-header removal case.

## Verification (all green locally)

- `AIMEE_WITH_PLUGIN_LOADER=1`: clean build; `unit-test-plugin`, `unit-test-plugin-loader`, `unit-test-plugin-c-hook` pass
- Default build **and link** (all four binaries; dashboard/cmd/mcp consumers of `plugin.h` compile against the reduced header)
- `make lint`, `validate_module_descriptors` (latch holds), 42-case mutation suite, and module doc / header-layout / source-ownership / test-registration / cleanup / refactor-baseline checks all pass
- Refactor baseline for `plugin.h` (+ the public-symbols aggregate) refrozen; `plugin_internal.h` is private and correctly not baseline-tracked

_(Local default build used the extracted-p11-kit-header override for `vault_custody_pkcs11.o`, unrelated to this change.)_