### PR TITLE
Slice 12: dispatch-overhead perf gate; close the feature tree

### DIFF
--- a/bench/bus_baseline.json
+++ b/bench/bus_baseline.json
@@ -1,0 +1,23 @@
+{
+  "description": "Event-bus performance budget baseline (D4 / shared invariant 15). The dispatch-overhead ceiling is a merge gate: a slice may not land while scripts/check_bus_perf_gate.sh is red. Changing the ceiling is a reviewed change to this file, so 'within budget' always names a real, checkable number. The memory round-trip rows are deliberately pending: they can only be measured against a pre-migration baseline in the memory-migration slice (delivery step 3) and must not be fabricated here.",
+  "metrics": {
+    "dispatch_overhead_ns": {
+      "description": "Per-event bus dispatch: host enqueue (a producer writing its outbound ring) through client dequeue (a subscriber reading its inbound ring), excluding module work on the payload. Median over batched samples from src/tests/bus_bench.c.",
+      "ceiling_ns": 2000,
+      "observed_ns": 134,
+      "observed_note": "reference dev box, 16-byte inline payload; the ceiling carries ~15x headroom so CI variance does not flake the gate while a gross regression (e.g. a per-event syscall) still trips it."
+    },
+    "memory_roundtrip_p50_ns": {
+      "status": "pending",
+      "reason": "the module->memory round trip can only be measured against a pre-migration baseline, which exists only in the memory-migration slice (delivery step 3). Recording a number here would be fabricating one."
+    },
+    "memory_roundtrip_p99_ns": {
+      "status": "pending",
+      "reason": "see memory_roundtrip_p50_ns."
+    },
+    "max_regression_factor": {
+      "value": 2.0,
+      "description": "the maximum factor the memory round trip may regress against its pre-migration baseline once that baseline exists. Enforced by the memory-migration slice, not this one."
+    }
+  }
+}

--- a/docs/dev/EVENT_BUS_FEATURE_TREE.md
+++ b/docs/dev/EVENT_BUS_FEATURE_TREE.md
@@ -158,14 +158,45 @@ rather than merely asserted.
 
 ## Progress
 
+All twelve slices are merged into `feat/event-bus`. The D1 amendment was accepted (2026-07-24), which
+unblocked slice 3 onward.
+
 | Slice | State |
 |---|---|
-| 1 — wire codec + vectors | implemented; green under normal + ASAN; in review |
-| 2 — SPSC ring | implemented; green under normal + ASAN + TSAN; in review |
-| 3–12 | blocked on the D1 amendment (`scripts/check_bus_d1_gate.sh`) |
+| 1 — wire codec + vectors | merged; normal + ASAN |
+| 2 — SPSC ring | merged; normal + ASAN + TSAN |
+| 3 — region layout | merged; normal + ASAN (fork+SIGSEGV read-only proof) |
+| 4 — arena leases | merged; normal + ASAN |
+| 5 — host admission | merged; normal + ASAN + TSAN |
+| 6 — routing + tap | merged; normal + ASAN + TSAN |
+| 7 — flow control | merged; normal + ASAN + TSAN |
+| 8 — C reference client | merged; normal + ASAN + TSAN |
+| 9 — Go reference client | merged; pure Go, vectors byte-exact |
+| 10 — conformance suite | merged; real Go client ↔ C host interop |
+| 11 — capture + replay | merged; normal + ASAN + TSAN |
+| 12 — perf baseline gate | merged; ~134 ns/event dispatch, 2000 ns ceiling |
 
-## Review status
+The suite ran under self-review from slice 4 onward (the shared roundtable panel was only partly
+working); every slice's adversarial self-review caught real defects before merge — a control fd
+passed read-write, reply/cancel spoofing, a null-deref, a slot overflow, encoder-derived vectors, and
+a no-op D7 gate among them.
 
-See the revision history in [`EVENT_BUS_DECISIONS.md`](EVENT_BUS_DECISIONS.md) for what each round of
-review found and how it was closed. Slices 1 and 2 are in flight; slice 3 onward is gated on the D1
-amendment, whose status line lives in the wire spec and is read by `scripts/check_bus_d1_gate.sh`.
+## What is deliberately deferred (later trees, not this one)
+
+- **Arena-payload routing.** The host publishes an arena lease (slice 4) to the resolved observer set
+  before forwarding the reference; slices 6/7 route inline payloads and drop arena-flagged frames
+  with a count. This is a focused slice-4/6 composition.
+- **Module replay.** Slice 11 delivers observational replay; re-driving a module against recorded
+  inbound events is a later tree (D10).
+- **`shm_open` portability fallback.** v0 is Linux-only by D1; a fallback carries its own threat-model
+  note.
+- **The memory round-trip perf rows.** Marked pending in `bench/bus_baseline.json`; measurable only
+  against a pre-migration baseline in the memory-migration slice (delivery step 3).
+
+## Gates in place
+
+- `scripts/check_bus_blast_radius.sh` (D7) — no shipping binary links the bus; wired into `make lint`,
+  runs on every slice PR.
+- `scripts/check_bus_d1_gate.sh` — the D1 amendment status (now ACCEPTED).
+- `scripts/test_bus_conformance.sh` — C vectors, Go vectors, cross-language interop, single-host (D8).
+- `scripts/check_bus_perf_gate.sh` (D4 / invariant 15) — dispatch-overhead ceiling; memory rows pending.

--- a/scripts/check_bus_blast_radius.sh
+++ b/scripts/check_bus_blast_radius.sh
@@ -111,7 +111,7 @@ done < <(find . \( -name CMakeLists.txt -o -name '*.cmake' \) \
 for f in src/tests/CMakeLists.txt src/tests/Rules.mk; do
    [ -f "$f" ] || continue
    hits=$({ grep -n 'modules/bus' "$f" 2>/dev/null || true; } | strip_comments |
-      { grep -vE 'test_bus|unit-test-bus|bus-conformance-host|bus_conformance_host|OBJDIR\)/modules/bus' || true; })
+      { grep -vE 'test_bus|unit-test-bus|bus-conformance-host|bus_conformance_host|bus-bench|bus_bench|OBJDIR\)/modules/bus' || true; })
    if [ -n "$hits" ]; then
       note "FAIL: $f uses modules/bus outside a bus test target"
       printf '%s\n' "$hits" >&2
@@ -128,6 +128,7 @@ while IFS= read -r hit; do
    src/modules/bus/*) continue ;;
    src/tests/test_bus_*) continue ;;
    src/tests/bus_conformance_host.c) continue ;; # slice-10 test harness
+   src/tests/bus_bench.c) continue ;;             # slice-12 benchmark
    esac
    note "FAIL: $hit"
    fail=1

--- a/scripts/check_bus_perf_gate.sh
+++ b/scripts/check_bus_perf_gate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# check_bus_perf_gate.sh — the event-bus performance budget gate (slice 12, D4 /
+# shared invariant 15).
+#
+# It builds and runs the dispatch benchmark, and fails if the measured per-event
+# dispatch overhead exceeds the committed ceiling in bench/bus_baseline.json. A
+# red gate blocks the merge, so "within budget" always names a real, checkable
+# number rather than a slogan.
+#
+# It also asserts the memory round-trip rows are still marked pending — they can
+# only be measured against a pre-migration baseline in the memory-migration
+# slice, and this gate must not let a fabricated number slip in.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+baseline="bench/bus_baseline.json"
+[ -f "$baseline" ] || { echo "FAIL: $baseline not found" >&2; exit 1; }
+
+# 1. The memory round-trip rows must be pending, not fabricated.
+pending=$(python3 - "$baseline" <<'PY'
+import json, sys
+b = json.load(open(sys.argv[1]))
+m = b["metrics"]
+ok = all(m.get(k, {}).get("status") == "pending"
+         for k in ("memory_roundtrip_p50_ns", "memory_roundtrip_p99_ns"))
+print("yes" if ok else "no")
+PY
+)
+if [ "$pending" != "yes" ]; then
+   echo "FAIL: the memory round-trip rows must be marked pending until the" >&2
+   echo "      memory-migration slice measures them against a real baseline." >&2
+   exit 1
+fi
+
+ceiling=$(python3 -c "import json;print(json.load(open('$baseline'))['metrics']['dispatch_overhead_ns']['ceiling_ns'])")
+
+# 2. Build and run the benchmark.
+echo "building the dispatch benchmark..."
+make -C src --no-print-directory bus-bench >/dev/null
+bench=$(find "$repo_root/src" -name bus-bench -type f -perm -u+x 2>/dev/null | head -1)
+[ -x "$bench" ] || { echo "FAIL: benchmark not built" >&2; exit 1; }
+
+# A shorter run in the gate keeps it quick; the measurement is a median so it is
+# stable. The ceiling's headroom absorbs CI variance.
+measured=$("$bench" 500000 2>/dev/null | sed -n 's/^dispatch_overhead_ns=//p')
+if [ -z "$measured" ]; then
+   echo "FAIL: benchmark produced no dispatch_overhead_ns" >&2
+   exit 1
+fi
+
+echo "dispatch overhead: ${measured} ns/event (ceiling ${ceiling} ns)"
+if [ "$measured" -gt "$ceiling" ]; then
+   echo "" >&2
+   echo "FAIL: dispatch overhead ${measured} ns exceeds the committed ceiling" >&2
+   echo "      ${ceiling} ns. Either a real regression landed, or the ceiling" >&2
+   echo "      needs a reviewed change in ${baseline}." >&2
+   exit 1
+fi
+
+echo "check_bus_perf_gate: ok — dispatch overhead within budget; memory rows pending"

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2643,6 +2643,22 @@ $(TESTPREFIX)/unit-test-bus-capture: $(OBJDIR)/tests/test_bus_capture.o \
                                      $(OBJDIR)/modules/bus/bus_wire.o
 	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
 
+# Event-bus dispatch benchmark (feature tree slice 12). Built -O2 for a realistic
+# measurement; a test binary, never linked into a shipping target.
+$(OBJDIR)/tests/bus_bench.o: C_FLAGS += -Imodules/bus -O2
+$(TESTPREFIX)/bus-bench: $(OBJDIR)/tests/bus_bench.o \
+                        $(OBJDIR)/modules/bus/bus_client.o \
+                        $(OBJDIR)/modules/bus/bus_host.o \
+                        $(OBJDIR)/modules/bus/bus_route.o \
+                        $(OBJDIR)/modules/bus/bus_region.o \
+                        $(OBJDIR)/modules/bus/bus_ring.o \
+                        $(OBJDIR)/modules/bus/bus_arena.o \
+                        $(OBJDIR)/modules/bus/bus_wire.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
+
+.PHONY: bus-bench
+bus-bench: $(TESTPREFIX)/bus-bench
+
 .PHONY: unit-test-bus-capture
 unit-test-bus-capture: $(TESTPREFIX)/unit-test-bus-capture
 	$<

--- a/src/tests/bus_bench.c
+++ b/src/tests/bus_bench.c
@@ -1,0 +1,151 @@
+/* bus_bench.c: the event-bus dispatch-overhead benchmark (slice 12).
+ *
+ * It measures the one number the performance budget commits to: per-event bus
+ * dispatch overhead — host enqueue (a producer writing its outbound ring)
+ * through to client dequeue (a subscriber reading its inbound ring), excluding
+ * any module work on the payload. That is the cost the bus adds to move one
+ * event, and the number a later memory-migration slice is gated against.
+ *
+ * It prints one line the perf gate parses:
+ *   dispatch_overhead_ns=<median per-event nanoseconds>
+ *
+ * This is a test binary, never linked into a shipping target (D7).
+ */
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "bus_client.h"
+#include "bus_host.h"
+#include "bus_ring.h"
+
+static uint64_t now_ns(void)
+{
+   struct timespec ts;
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+   return (uint64_t)ts.tv_sec * 1000000000ull + ts.tv_nsec;
+}
+
+struct serve_arg
+{
+   bus_host_t *h;
+   int fd;
+};
+static void *serve_thread(void *p)
+{
+   struct serve_arg *a = p;
+   bus_host_serve_attach(a->h, a->fd);
+   return NULL;
+}
+static void attach_client(bus_host_t *h, bus_client_t *c)
+{
+   int sv[2];
+   if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) != 0)
+      abort();
+   struct serve_arg a = {.h = h, .fd = sv[1]};
+   pthread_t t;
+   pthread_create(&t, NULL, serve_thread, &a);
+   if (bus_client_attach(sv[0], c) != BUS_CLIENT_OK)
+      abort();
+   pthread_join(t, NULL);
+   close(sv[0]);
+   close(sv[1]);
+}
+
+static int cmp_u64(const void *a, const void *b)
+{
+   uint64_t x = *(const uint64_t *)a, y = *(const uint64_t *)b;
+   return (x > y) - (x < y);
+}
+
+#define KIND 900
+
+int main(int argc, char **argv)
+{
+   uint64_t total = (argc > 1) ? strtoull(argv[1], NULL, 10) : 2000000;
+
+   bus_host_config_t cfg;
+   memset(&cfg, 0, sizeof cfg);
+   cfg.max_slots = 4;
+   cfg.slot_size = 256;
+   cfg.inline_budget = 192;
+   cfg.queue_capacity = 64;
+   cfg.arena_size = 256 * 1024;
+
+   bus_host_t h;
+   if (bus_host_create(&h, &cfg, NULL, NULL) != BUS_HOST_OK)
+      abort();
+   bus_client_t pub, sub;
+   attach_client(&h, &pub);
+   attach_client(&h, &sub);
+   bus_host_subscribe(&h, sub.reply.handle_id, KIND);
+
+   /* One event's dispatch = publish (producer enqueue) + host pump (route) +
+    * poll (consumer dequeue). Batched to the ring's data capacity so timer
+    * granularity does not dominate; each batch's time is divided by its events.
+    * We record per-batch per-event samples and report the median, which is
+    * robust to scheduler noise. */
+   uint32_t batch = cfg.queue_capacity - 4; /* leave headroom below capacity */
+   uint64_t batches = total / batch;
+   if (batches < 100)
+      batches = 100;
+
+   uint64_t *samples = malloc(batches * sizeof(uint64_t));
+   if (!samples)
+      abort();
+
+   const char *payload = "benchmark-payload-16b";
+   uint32_t plen = 16;
+
+   /* Warm up. */
+   for (int w = 0; w < 1000; w++)
+   {
+      for (uint32_t i = 0; i < batch; i++)
+         bus_client_publish(&pub, KIND, payload, plen);
+      bus_host_pump(&h);
+      bus_event_t ev;
+      while (bus_client_poll(&sub, &ev) == BUS_CLIENT_OK)
+         ;
+   }
+
+   for (uint64_t b = 0; b < batches; b++)
+   {
+      uint64_t t0 = now_ns();
+      for (uint32_t i = 0; i < batch; i++)
+         bus_client_publish(&pub, KIND, payload, plen);
+      bus_host_pump(&h);
+      bus_event_t ev;
+      uint32_t got = 0;
+      while (bus_client_poll(&sub, &ev) == BUS_CLIENT_OK)
+         got++;
+      uint64_t t1 = now_ns();
+      if (got != batch)
+      {
+         fprintf(stderr, "bench: expected %u events, got %u\n", batch, got);
+         return 1;
+      }
+      samples[b] = (t1 - t0) / batch;
+   }
+
+   qsort(samples, batches, sizeof(uint64_t), cmp_u64);
+   uint64_t median = samples[batches / 2];
+   uint64_t p99 = samples[(batches * 99) / 100];
+
+   printf("dispatch_overhead_ns=%llu\n", (unsigned long long)median);
+   printf("dispatch_overhead_p99_ns=%llu\n", (unsigned long long)p99);
+   fprintf(stderr, "bench: %llu batches of %u events (median %llu ns/event, p99 %llu ns)\n",
+           (unsigned long long)batches, batch, (unsigned long long)median,
+           (unsigned long long)p99);
+
+   free(samples);
+   bus_client_detach(&pub);
+   bus_client_detach(&sub);
+   bus_host_destroy(&h);
+   return 0;
+}


### PR DESCRIPTION
Twelfth and final slice. Self-reviewed.

## What lands

The performance budget the tree is measured against (D4 / invariant 15), as a committed number and a merge gate.

- **src/tests/bus_bench.c** measures per-event **dispatch overhead** — host enqueue → client dequeue, excluding module work — median over batched samples. **~134 ns/event** on the reference box (16-byte inline payload).
- **bench/bus_baseline.json** commits the **ceiling (2000 ns**, ~15× headroom so CI variance doesn't flake the gate while a gross regression still trips it) and records the memory round-trip rows as **pending** — measurable only against a pre-migration baseline in the memory-migration slice; a number here would be fabricated.
- **scripts/check_bus_perf_gate.sh** builds+runs the benchmark, fails if overhead exceeds the ceiling, and asserts the memory rows stay pending. Verified: passes in budget, fails a fabricated memory row, fails an exceeded ceiling.

## Closes the feature tree

All twelve slices merged. The progress table names what's deliberately deferred to later trees (arena-payload routing, module replay, shm_open fallback, the memory perf rows) and the gates in place.

**The v0 shared-memory event bus is complete**: one C host, two reference clients (C and pure-Go) proven to interoperate across a process boundary and agree on the wire byte-for-byte, a governance tap with capture and observational replay, and a dispatch budget with headroom. No shipping binary links it (D7); the memory migration is a later tree.

Depends on slices 1–11 (merged).