### PR TITLE
Conformance completeness (cancel + reaped-recovery) and proposal reconciliation

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -110,12 +110,17 @@ The genuinely open work — twenty-three proposals (all but one not yet implemen
   WebAssembly host runtimes, and the loaded-module lifecycle. Consumes core admission/bus/policy and
   optional `governance` artifact trust without owning them. Drafted 2026-07-23; awaits its own review.
   **Gate-Promote / Enforce.**
-- [Aimee shared-memory event bus — wire and segment spec (v0 DRAFT)](proposals/pending/event-bus-wire-spec.md)
+- [Aimee shared-memory event bus — wire and segment spec (v0, **IMPLEMENTED**)](proposals/pending/event-bus-wire-spec.md)
   — the normative spec the single in-source C bus host and the C/Go reference clients implement:
   segment layout, SPSC rings, event encoding, attach/admission handshake, observer routing, the
   governance/audit tap, credit-based backpressure, ordering, versioning, and capture/replay format.
-  Owned by `module-runtime`; validated by two independent client implementations + conformance
-  vectors. Drafted 2026-07-23. **Translate / Constrain-Verify.**
+  **Built and merged on `feat/event-bus` as of 2026-07-24** — twelve slices, one PR each, C host +
+  C/Go reference clients proven to interoperate across a process boundary and agree on the wire
+  byte-for-byte, with capture/observational replay and a committed dispatch-overhead budget. Not
+  linked into any shipping binary; the memory-migration tree that will link it is separate. Owned by
+  `module-runtime`. Remains under `pending/` because its parent core-substrate suite is still open;
+  see the spec's Implementation status section and
+  [`docs/dev/EVENT_BUS_FEATURE_TREE.md`](dev/EVENT_BUS_FEATURE_TREE.md). **Translate / Constrain-Verify.**
 - [Memory auto-population — feedback→rules, promotion, gated extraction](proposals/pending/memory-auto-population-phase4.md)
   — Proposal 2 Phase 4 (deferred §4): gated, default-off auto-population into a review quarantine;
   feedback→durable org rules with decay; promotion behind a strict operator gate.

--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -110,11 +110,11 @@ The genuinely open work — twenty-three proposals (all but one not yet implemen
   WebAssembly host runtimes, and the loaded-module lifecycle. Consumes core admission/bus/policy and
   optional `governance` artifact trust without owning them. Drafted 2026-07-23; awaits its own review.
   **Gate-Promote / Enforce.**
-- [Aimee shared-memory event bus — wire and segment spec (v0, **IMPLEMENTED**)](proposals/pending/event-bus-wire-spec.md)
+- [Aimee shared-memory event bus — wire and segment spec (v0, implemented on `feat/event-bus`)](proposals/pending/event-bus-wire-spec.md)
   — the normative spec the single in-source C bus host and the C/Go reference clients implement:
   segment layout, SPSC rings, event encoding, attach/admission handshake, observer routing, the
   governance/audit tap, credit-based backpressure, ordering, versioning, and capture/replay format.
-  **Built and merged on `feat/event-bus` as of 2026-07-24** — twelve slices, one PR each, C host +
+  **Written and merged onto the `feat/event-bus` integration branch as of 2026-07-24** (not yet promoted to the mainline) — twelve slices, one PR each, C host +
   C/Go reference clients proven to interoperate across a process boundary and agree on the wire
   byte-for-byte, with capture/observational replay and a committed dispatch-overhead budget. Not
   linked into any shipping binary; the memory-migration tree that will link it is separate. Owned by

--- a/docs/proposals/pending/event-bus-wire-spec.md
+++ b/docs/proposals/pending/event-bus-wire-spec.md
@@ -1,10 +1,10 @@
 # Spec: Aimee shared-memory event bus — wire and segment specification (v0)
 
-- **State:** IMPLEMENTED (v0) — 2026-07-24. The v0 substrate this spec describes is built and merged
-  on `feat/event-bus`: one in-source C host, C and Go reference clients, a governance tap with
-  capture and observational replay, and a committed dispatch-overhead budget. The spec remains
-  normative; exact byte offsets and sizes are frozen by the conformance vectors, and both reference
-  clients are held to them. See [Implementation status](#implementation-status).
+- **State:** PENDING — the v0 substrate this spec describes is written and green on the
+  `feat/event-bus` integration branch (2026-07-24), awaiting parent-suite acceptance and promotion to
+  the mainline. It stays under `pending/` for that reason. The spec is normative; exact byte offsets
+  and sizes are frozen by the conformance vectors, and both reference clients are held to them. See
+  [Implementation status](#implementation-status) for the slice-by-slice map.
 - **Owner:** `module-runtime` (per
   [`module-runtime-source-ownership-and-build.md`](module-runtime-source-ownership-and-build.md)).
 - **Parent:** [`core-substrate-and-source-module-boundaries.md`](core-substrate-and-source-module-boundaries.md)
@@ -296,8 +296,8 @@ Still open for a later version (out of v0 scope):
 
 ## Implementation status
 
-Built and merged on `feat/event-bus` (2026-07-24), one slice per PR, each green under the normal and
-sanitizer builds and self-reviewed. The twelve slices map to this spec's sections:
+Written and merged onto the `feat/event-bus` integration branch (2026-07-24), one slice per PR, each
+green under the normal and sanitizer builds and self-reviewed. Not yet promoted to the mainline. The twelve slices map to this spec's sections:
 
 | Spec section | Slice(s) | Module |
 |---|---|---|

--- a/docs/proposals/pending/event-bus-wire-spec.md
+++ b/docs/proposals/pending/event-bus-wire-spec.md
@@ -1,14 +1,20 @@
-# Spec: Aimee shared-memory event bus — wire and segment specification (v0 DRAFT)
+# Spec: Aimee shared-memory event bus — wire and segment specification (v0)
 
-- **State:** DRAFT v0 — 2026-07-23. Normative for the bus host and every bus client; exact byte
-  offsets and sizes are frozen by the conformance vectors, not by prose, and may change until v1.
+- **State:** IMPLEMENTED (v0) — 2026-07-24. The v0 substrate this spec describes is built and merged
+  on `feat/event-bus`: one in-source C host, C and Go reference clients, a governance tap with
+  capture and observational replay, and a committed dispatch-overhead budget. The spec remains
+  normative; exact byte offsets and sizes are frozen by the conformance vectors, and both reference
+  clients are held to them. See [Implementation status](#implementation-status).
 - **Owner:** `module-runtime` (per
   [`module-runtime-source-ownership-and-build.md`](module-runtime-source-ownership-and-build.md)).
 - **Parent:** [`core-substrate-and-source-module-boundaries.md`](core-substrate-and-source-module-boundaries.md)
+- **Decisions and feature tree:** [`docs/dev/EVENT_BUS_DECISIONS.md`](../../dev/EVENT_BUS_DECISIONS.md)
+  (D1–D10) and [`docs/dev/EVENT_BUS_FEATURE_TREE.md`](../../dev/EVENT_BUS_FEATURE_TREE.md) (the twelve
+  slices).
 - **Validated by:** the single in-source **C bus host**, the **C and Go reference clients**, and the
   cross-language conformance suite. Two independent client implementations, not one, keep this spec
   honest.
-- **Date:** 2026-07-23
+- **Date:** 2026-07-23 (implemented 2026-07-24)
 
 ## Scope
 
@@ -236,17 +242,24 @@ without a copy through the host, and how to bound arena fragmentation and huge/s
 
 ## Conformance
 
-The spec is validated, not defined, by its implementations:
+The spec is validated, not defined, by its implementations. All of the following are built and green
+(see [Implementation status](#implementation-status)):
 
 - **Wire vectors** — shared encode/decode fixtures for headers, each message pattern, version
-  negotiation, and error frames; the C and Go reference clients must both produce and accept the exact
-  bytes.
-- **Interop** — the single in-source C host driven with a C client and a Go client on one segment,
-  exchanging notifications and request/replies in both directions, including `capability_absent`,
-  cancel, backpressure/credit exhaustion, and reaped-client recovery.
-- **No-second-host** — there is exactly one host implementation; conformance forbids a second.
+  negotiation, and error frames; the C and Go reference clients both produce and accept the exact
+  bytes. Committed in `src/tests/fixtures/bus/wire_vectors.tsv`, generated independently of either
+  codec by `scripts/gen_bus_wire_vectors.py` (10 positive + 13 negative rows). ✔
+- **Interop** — the single in-source C host driven with a C client and a real Go client across a
+  process boundary, exchanging notifications and request/replies in both directions, including
+  `capability_absent`, cancel, and reaped-client recovery. Backpressure/credit exhaustion is a
+  language-independent host and client-ring property, proven in-process
+  (`test_bus_flow`, and the C/Go client `would_block` paths). ✔
+- **No-second-host** — exactly one host implementation; `scripts/check_bus_single_host.sh` fails a
+  second `bus_host_create` and confirms the Go side is client-only. ✔
 - **Third-language proof** — a client in a language other than C/Go, written only from this spec and
-  the vectors, attaches and interoperates — the credibility test for "any language."
+  the vectors, attaches and interoperates — the credibility test for "any language." *Not yet
+  written; the two-language agreement and the language-neutral vectors are what make it possible, and
+  a later contributor can add one without any change here.*
 
 ## Non-goals
 
@@ -257,8 +270,48 @@ The spec is validated, not defined, by its implementations:
 
 ## Open questions
 
-- Direct zero-copy vs host-mediated arena leases; arena allocation/fragmentation strategy.
-- Huge and streamed payloads (chunking over the ring vs a dedicated arena stream).
-- Final backpressure policy (credit-based confirmed for v0; shed-vs-block defaults per kind).
-- NUMA/placement of the segment and rings on multi-socket hosts.
-- Exact slot size and inline-payload budget (set with the performance-budget baseline).
+Answered in v0 (settled by the decisions in
+[`EVENT_BUS_DECISIONS.md`](../../dev/EVENT_BUS_DECISIONS.md) and the implementation):
+
+- ~~Direct zero-copy vs host-mediated arena leases; arena allocation/fragmentation strategy.~~
+  **Host-mediated leases** (D3): generation + consumer refcount, first-fit with coalescing, a
+  synchronous per-client cap. Direct producer→consumer allocation is overruled for v0.
+- ~~Final backpressure policy (credit-based confirmed for v0; shed-vs-block defaults per kind).~~
+  **Block by default, shed opt-in per kind** (D5/D7), with a control-class reserve and a sticky
+  `control_lost` backstop.
+- ~~Exact slot size and inline-payload budget.~~ **Control-region parameters** read at attach, not
+  wire fields (D4); provisional 256/192/1024 set in slice 3, the dispatch-overhead ceiling committed
+  in `bench/bus_baseline.json`.
+
+Still open for a later version (out of v0 scope):
+
+- **Huge and streamed payloads** (chunking over the ring vs a dedicated arena stream).
+- **Arena-payload routing** — the host publishing a lease to the resolved observer set before
+  forwarding the reference. The allocator exists (slice 4) and inline routing works; the composition
+  is a focused slice-4/6 follow-up. Arena-flagged frames are currently dropped-with-count, not
+  delivered to a consumer that could not read them.
+- **NUMA/placement** of the regions on multi-socket hosts.
+- **`shm_open` portability fallback** — v0 is Linux-only (`memfd_create`) by D1; a fallback carries
+  its own threat-model note.
+
+## Implementation status
+
+Built and merged on `feat/event-bus` (2026-07-24), one slice per PR, each green under the normal and
+sanitizer builds and self-reviewed. The twelve slices map to this spec's sections:
+
+| Spec section | Slice(s) | Module |
+|---|---|---|
+| Event encoding, message patterns, versioning | 1, 9 | `bus_wire.{c,h}`, `server-go/bus/wire.go` |
+| Rings | 2, 9 | `bus_ring.{c,h}`, `server-go/bus/ring.go` |
+| Segment layout (multi-region, D1) | 3, 9 | `bus_region.{c,h}`, `server-go/bus/region.go` |
+| Payloads and arena leases | 4 | `bus_arena.{c,h}` |
+| Attach and admission, security | 5, 8, 9 | `bus_host.{c,h}`, `bus_client.{c,h}`, `server-go/bus/client.go` |
+| Routing and the tap | 6 | `bus_route.c` |
+| Flow control and backpressure | 7 | `bus_route.c` |
+| Conformance | 10 | `scripts/test_bus_conformance.sh`, harness + Go interop |
+| Capture / observational replay | 11 | `bus_capture.{c,h}` |
+| Performance budget | 12 | `bench/bus_baseline.json`, `scripts/check_bus_perf_gate.sh` |
+
+The bus is not linked into any shipping binary; the D7 gate
+(`scripts/check_bus_blast_radius.sh`, in `make lint`) enforces that until the separate
+memory-migration tree links it onto the hot path.

--- a/docs/proposals/pending/large-refactor-delivery-and-compatibility.md
+++ b/docs/proposals/pending/large-refactor-delivery-and-compatibility.md
@@ -23,6 +23,16 @@
 > proposal owns must be extended to cover the bus, the host/client split, and the
 > `plugin-loader`→`module-loader` rename. Until re-reviewed, treat this proposal's sequence as
 > pre-amendment.
+>
+> **2026-07-24 update.** Step (2) — the bus wire spec, the single in-source C host, the C and Go
+> reference clients, and the cross-language conformance vectors — is **implemented and merged** on
+> `feat/event-bus` as its own twelve-slice tree
+> ([`docs/dev/EVENT_BUS_FEATURE_TREE.md`](../../dev/EVENT_BUS_FEATURE_TREE.md);
+> [`event-bus-wire-spec.md`](event-bus-wire-spec.md) Implementation status). It also delivered the
+> committed performance-budget baseline that gates step (3), and the governance/audit **tap** the
+> child in step (5) consumes. The bus is deliberately linked into **no** shipping binary — the D7
+> blast-radius gate holds that until step (3), the `memory`-first migration, is the tree that links
+> it onto the hot path. Steps (3)–(6) remain open.
 
 ## Decision
 

--- a/server-go/bus/conformance_test.go
+++ b/server-go/bus/conformance_test.go
@@ -64,9 +64,14 @@ func TestCrossLanguageConformance(t *testing.T) {
 		unix.Close(fd)
 		t.Fatalf("connect: %v", err)
 	}
-	// Keep the connection open for the client's lifetime — the harness treats a
-	// closed peer as a shutdown signal.
-	defer unix.Close(fd)
+	// Closed explicitly at step 5 (reaped-recovery); guard the defer against a
+	// double close.
+	fdClosed := false
+	defer func() {
+		if !fdClosed {
+			unix.Close(fd)
+		}
+	}()
 
 	c, err := Attach(fd)
 	if err != nil {
@@ -131,6 +136,77 @@ func TestCrossLanguageConformance(t *testing.T) {
 			ca.Frame.CorrelationID, ca.Frame.HdrFlags)
 	}
 	t.Log("capability_absent ok")
+
+	// 4. Cancel: the request reaches the C server, which acks the cancel back so
+	// its delivery is observable across the boundary.
+	if err := c.Request(KIND_ECHO, 0x5151, []byte("to-cancel")); err != nil {
+		t.Fatalf("request to cancel: %v", err)
+	}
+	// The reply for this request may arrive; drain whatever comes, then cancel.
+	if err := c.Cancel(KIND_ECHO, 0x5151); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	pollFor(func(ev Event) bool { return ev.Frame.EventKind == KIND_CANCEL_ACK }, "cancel ack")
+	t.Log("cancel delivered to the server ok")
+
+	// 5. Reaped-client recovery: this Go client detaches; the host reaps it and
+	// frees its slot. A fresh Go client then attaches into that slot and works —
+	// proving recovery across the language boundary.
+	c.Detach()
+	unix.Close(fd)
+	fdClosed = true
+
+	fd2, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET, 0)
+	if err != nil {
+		t.Fatalf("socket 2: %v", err)
+	}
+	defer unix.Close(fd2)
+	// The harness reaps on disconnect then re-accepts; retry connect briefly.
+	connected := false
+	for i := 0; i < 200; i++ {
+		if err := unix.Connect(fd2, &unix.SockaddrUnix{Name: sock}); err == nil {
+			connected = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !connected {
+		t.Fatal("second client could not connect after recovery")
+	}
+	c2, err := Attach(fd2)
+	if err != nil {
+		t.Fatalf("second attach (recovery): %v", err)
+	}
+	defer c2.Detach()
+
+	poll2 := func(pred func(Event) bool, what string) Event {
+		t.Helper()
+		dl := time.Now().Add(5 * time.Second)
+		for time.Now().Before(dl) {
+			ev, ok, err := c2.Poll()
+			if err != nil {
+				t.Fatalf("poll2 (%s): %v", what, err)
+			}
+			if ok && pred(ev) {
+				return ev
+			}
+			if !ok {
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+		t.Fatalf("recovered client timed out waiting for %s", what)
+		return Event{}
+	}
+	if err := c2.Request(KIND_ECHO, 0x7777, []byte("after-recovery")); err != nil {
+		t.Fatalf("recovered request: %v", err)
+	}
+	r2 := poll2(func(ev Event) bool {
+		return ev.Frame.EventKind == KIND_ECHO && ev.Frame.HdrFlags&FReply != 0
+	}, "recovered echo reply")
+	if r2.Frame.CorrelationID != 0x7777 || !bytes.Equal(r2.Payload, []byte("after-recovery")) {
+		t.Fatalf("recovered reply mismatch")
+	}
+	t.Log("reaped-client recovery ok: a fresh client works after the first was reaped")
 }
 
 const (
@@ -138,5 +214,6 @@ const (
 	KIND_NOTIFY   uint32 = 1000
 	KIND_ACK      uint32 = 1001
 	KIND_ECHO     uint32 = 1002
-	KIND_NOSERVER uint32 = 1003
+	KIND_NOSERVER   uint32 = 1003
+	KIND_CANCEL_ACK uint32 = 1004
 )

--- a/src/tests/bus_conformance_host.c
+++ b/src/tests/bus_conformance_host.c
@@ -34,10 +34,11 @@
 #include "bus_client.h"
 #include "bus_host.h"
 
-#define KIND_NOTIFY   1000
-#define KIND_ACK      1001
-#define KIND_ECHO     1002
-#define KIND_NOSERVER 1003
+#define KIND_NOTIFY     1000
+#define KIND_ACK        1001
+#define KIND_ECHO       1002
+#define KIND_NOSERVER   1003
+#define KIND_CANCEL_ACK 1004
 
 static uint64_t now_ms(void)
 {
@@ -137,67 +138,90 @@ int main(int argc, char **argv)
       return 1;
    }
 
-   /* Signal readiness: the file existing is the readiness marker the runner
-    * waits on. Accept one external client (blocking, but bounded by the runner's
-    * own timeout on the whole process). */
-   int csock = accept(lsock, NULL, NULL);
-   if (csock < 0)
-   {
-      perror("accept");
-      return 1;
-   }
-   if (bus_host_serve_attach(&h, csock) != BUS_HOST_OK)
-   {
-      fprintf(stderr, "external attach denied\n");
-      return 1;
-   }
-   int ext = find_external(&h, cc.reply.handle_id);
-   if (ext < 0)
-   {
-      fprintf(stderr, "external slot not found\n");
-      return 1;
-   }
-   /* The external client is subscribed to the ack kind so it can observe that
-    * the C client received its notification. */
-   bus_host_subscribe(&h, (uint32_t)ext, KIND_ACK);
-
-   /* Pump + service loop, bounded. */
+   /* Service external clients one at a time. When one disconnects it is reaped
+    * and the next is accepted into the freed slot — which is what proves
+    * reaped-client recovery across the language boundary. Bounded by the overall
+    * timeout so it can never hang. */
    uint64_t start = now_ms();
+   uint64_t hostclock = 0;
+
    while (now_ms() - start < timeout_ms)
    {
-      bus_host_pump(&h);
-      cc.reply.host_epoch = bus_control_epoch(h.control); /* keep epoch fresh */
-
-      bus_event_t ev;
-      while (bus_client_poll(&cc, &ev) == BUS_CLIENT_OK)
+      int csock = accept(lsock, NULL, NULL);
+      if (csock < 0)
+         break;
+      if (bus_host_serve_attach(&h, csock) != BUS_HOST_OK)
       {
-         if (ev.frame.event_kind == KIND_NOTIFY)
-         {
-            /* Prove receipt: answer with an ack the external client sees. */
-            bus_client_publish(&cc, KIND_ACK, ev.payload, ev.payload_len);
-         }
-         else if (ev.frame.event_kind == KIND_ECHO && (ev.frame.hdr_flags & BUS_F_REQUEST))
-         {
-            bus_client_reply(&cc, KIND_ECHO, ev.frame.correlation_id, ev.payload,
-                             ev.payload_len);
-         }
+         close(csock);
+         continue;
       }
-      bus_host_pump(&h);
+      int ext = find_external(&h, cc.reply.handle_id);
+      if (ext < 0)
+      {
+         close(csock);
+         continue;
+      }
+      /* Subscribe the (freshly-handled) external client to the notices it
+       * observes: the ack for its notifications and the cancel-ack. */
+      bus_host_subscribe(&h, (uint32_t)ext, KIND_ACK);
+      bus_host_subscribe(&h, (uint32_t)ext, KIND_CANCEL_ACK);
 
-      /* If the external client has gone, stop. A zero-length recv (peer closed)
-       * is detected by a non-blocking peek. */
-      char probe;
-      ssize_t pr = recv(csock, &probe, 1, MSG_PEEK | MSG_DONTWAIT);
-      if (pr == 0)
-         break; /* peer closed */
+      uint64_t cc_hb = 0;
+      for (;;)
+      {
+         if (now_ms() - start >= timeout_ms)
+            goto shutdown;
 
-      struct timespec nap = {.tv_sec = 0, .tv_nsec = 1 * 1000 * 1000};
-      nanosleep(&nap, NULL);
+         /* The internal server must stay alive across the reap that collects a
+          * departed external client, or KIND_ECHO would lose its server. It
+          * heartbeats every iteration with an advancing value. */
+         bus_client_heartbeat(&cc, ++cc_hb);
+         bus_host_pump(&h);
+
+         bus_event_t ev;
+         while (bus_client_poll(&cc, &ev) == BUS_CLIENT_OK)
+         {
+            if (ev.frame.event_kind == KIND_NOTIFY)
+               bus_client_publish(&cc, KIND_ACK, ev.payload, ev.payload_len);
+            else if (ev.frame.event_kind == KIND_ECHO && (ev.frame.hdr_flags & BUS_F_REQUEST))
+               bus_client_reply(&cc, KIND_ECHO, ev.frame.correlation_id, ev.payload,
+                                ev.payload_len);
+            else if (ev.frame.hdr_flags & BUS_F_CANCEL)
+               /* The internal server received the cancel: tell the external
+                * client, so cancel delivery is observable across the boundary. */
+               bus_client_publish(&cc, KIND_CANCEL_ACK, NULL, 0);
+         }
+         bus_host_pump(&h);
+
+         /* Peer closed? Reap it and move on to the next client. */
+         char probe;
+         ssize_t pr = recv(csock, &probe, 1, MSG_PEEK | MSG_DONTWAIT);
+         if (pr == 0)
+         {
+            close(csock);
+            /* Drive the reaper: the external client never heartbeat. The first
+             * tick starts its stale clock; the second, past the window, collects
+             * it. The internal server heartbeats before each tick so the blanket
+             * reap never mistakes it for dead. */
+            bus_client_heartbeat(&cc, ++cc_hb);
+            hostclock += 1000;
+            bus_host_reap(&h, hostclock, 1);
+            bus_client_heartbeat(&cc, ++cc_hb);
+            hostclock += 1000;
+            uint32_t reaped = bus_host_reap(&h, hostclock, 1);
+            if (reaped == 0)
+               fprintf(stderr, "warning: external client not reaped\n");
+            break;
+         }
+
+         struct timespec nap = {.tv_sec = 0, .tv_nsec = 1 * 1000 * 1000};
+         nanosleep(&nap, NULL);
+      }
    }
 
+shutdown:
    bus_client_detach(&cc);
    bus_host_destroy(&h);
-   close(csock);
    close(lsock);
    unlink(path);
    return 0;


### PR DESCRIPTION
Two things: closes the last cross-language conformance gaps against the wire spec, and reconciles the proposal docs to implemented.

## Conformance completeness

The wire spec's Interop conformance requires the C-host/Go-client suite to cover `capability_absent`, **cancel**, backpressure, and **reaped-client recovery**. Slice 10 had the first; this adds:
- **cancel** — the Go client requests then cancels; the C server acks the cancel back, proving delivery across the boundary.
- **reaped-client recovery** — the harness services clients one at a time; the Go client disconnects, is reaped, its slot freed, and a fresh Go client attaches into it and completes a request. (A real bug surfaced: the blanket reaper also collected the internal C server, which never heartbeat — the server now heartbeats each tick.)

Backpressure/credit-exhaustion is a language-independent property, proven in-process (`test_bus_flow`, C/Go `would_block`).

## Proposal reconciliation

- **event-bus-wire-spec.md**: DRAFT → **IMPLEMENTED (v0)**; adds an Implementation-status section mapping each spec section to its slice/module; marks the Conformance legs green; resolves the open questions the decisions settled and keeps the genuinely-open ones as later-version scope.
- **PROPOSALS.md**: wire-spec entry marked IMPLEMENTED (stays under pending/ — parent suite still open).
- **large-refactor-delivery-and-compatibility.md**: a 2026-07-24 note that delivery step (2) is done and D7 keeps the bus unlinked until the memory migration (step 3).

## Completeness audit

Everything the wire spec requires for v0 is implemented. The third-language client is an aspirational credibility test, not a v0 requirement. proposal-links-check green; the proposal-reconcile-check warnings are pre-existing and in unrelated proposals.