### PR TITLE
fix(cmake): repair Linux full-CMake stale refs left by module moves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,7 +634,7 @@ set(DATA_SRCS
     ${AIMEE_SRC_DIR}/modules/guardrails/guardrails_orchestrator.c
     ${AIMEE_SRC_DIR}/modules/guardrails/guardrails_action_audit.c
     ${AIMEE_SRC_DIR}/modules/guardrails/guardrails_tdd.c
-   _learn.c
+    ${AIMEE_SRC_DIR}/workflow_learn.c
     ${AIMEE_SRC_DIR}/session_state.c
     ${AIMEE_SRC_DIR}/session_briefing.c
     ${AIMEE_SRC_DIR}/file_safety.c

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -68,11 +68,12 @@ aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)
 # the module + cJSON directly rather than linking aimee-core, so the test's
 # agent_http_get/git_host_cred_get stubs don't clash with the real symbols.
 add_executable(test_git_org_repos test_git_org_repos.c
-  ../server/git_org_repos.c ../vendor/cJSON.c)
+  ../modules/git/git_org_repos.c ../vendor/cJSON.c)
 target_include_directories(test_git_org_repos PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..
   ${CMAKE_CURRENT_SOURCE_DIR}/../headers
     ${CMAKE_CURRENT_SOURCE_DIR}/../modules/config
+    ${CMAKE_CURRENT_SOURCE_DIR}/../modules/git
   ${CMAKE_CURRENT_SOURCE_DIR}/../vendor/headers)
 aimee_enable_test_asserts(test_git_org_repos)
 add_test(NAME test_git_org_repos COMMAND test_git_org_repos)
@@ -83,11 +84,13 @@ set_tests_properties(test_git_org_repos PROPERTIES
 # GitLab/Gitea device flow. HTTP + vault externals stubbed in the test (never
 # invoked by the pure functions under test).
 add_executable(test_git_oauth_device test_git_oauth_device.c
-  ../server/git_oauth_device.c ../vendor/cJSON.c)
+  ../modules/git/git_oauth_device.c ../vendor/cJSON.c)
 target_include_directories(test_git_oauth_device PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..
   ${CMAKE_CURRENT_SOURCE_DIR}/../headers
     ${CMAKE_CURRENT_SOURCE_DIR}/../modules/config
+    ${CMAKE_CURRENT_SOURCE_DIR}/../modules/git
+    ${CMAKE_CURRENT_SOURCE_DIR}/../modules/vault
   ${CMAKE_CURRENT_SOURCE_DIR}/../vendor/headers)
 aimee_enable_test_asserts(test_git_oauth_device)
 add_test(NAME test_git_oauth_device COMMAND test_git_oauth_device)
@@ -99,11 +102,12 @@ set_tests_properties(test_git_oauth_device PROPERTIES
 # (never invoked by the pure functions under test). POSIX-only (<pty.h>).
 if(NOT WIN32)
   add_executable(test_git_oauth_gh test_git_oauth_gh.c
-    ../server/git_oauth_gh.c)
+    ../modules/git/git_oauth_gh.c)
   target_include_directories(test_git_oauth_gh PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}/../headers
     ${CMAKE_CURRENT_SOURCE_DIR}/../modules/config
+    ${CMAKE_CURRENT_SOURCE_DIR}/../modules/git
     ${CMAKE_CURRENT_SOURCE_DIR}/../vendor/headers)
   target_link_libraries(test_git_oauth_gh PRIVATE Threads::Threads)
   aimee_enable_test_asserts(test_git_oauth_gh)


### PR DESCRIPTION
## What

The full Linux CMake configure was **broken** — `cmake -S . -B build` failed at configure time. CI never caught it: the CMake CI jobs build only the **thin-client profile** (a subset), never the full `aimee-data` library or the git test targets, so these refs were exercised nowhere. Surfaced by validating the feature tip on the .253 aimee-test container (which has `cmake` + `libp11-kit-dev`, unlike my local box).

Two independent modularization regressions:

| # | defect | cause | fix |
|---|---|---|---|
| 1 | `CMakeLists.txt` DATA_SRCS has a bare `_learn.c` (configure error in `aimee-data`) | #1553 (WFE-canonical) truncated `${AIMEE_SRC_DIR}/workflow_learn.c` in a botched edit; the file still exists | restore the path |
| 2 | git test targets build `../server/git_{org_repos,oauth_device,oauth_gh}.c` (configure error — files moved) | git-module migration moved them to `../modules/git/` | repoint sources + add `../modules/git` (all three) and `../modules/vault` (oauth_device needs `vault_service.h`) |

## Validated on .253 (aimee-test container)

- `cmake -S . -B` now **configures clean** (was failing)
- `aimee-core` and `aimee-data` build (the `_learn.c` fix)
- the three git test targets build **and pass**: `3/3 Passed` under ctest

Native Make build and the CMake thin-client profiles are unaffected (Make already used the moved paths; the thin-client profile builds none of these targets).

## Not in this PR (separate same-class follow-up, pre-existing)

A few other full-CMake **test** targets still have stale include paths after the module moves and fail to *compile* (they don't block configure or the core build): `test_db2_pool` (needs `..` for `db2/db2_pool.h`, `../headers` for `log.h`) and the `server.h` consumers `test_kb_lab`/`test_compute_pool`/`test_server_session_pools`/`test_turn_registry` (need `../modules/vault` for `vault_principal.h`). Repairing the full CMake test suite is a focused follow-up; this PR fixes the configure-breaking regressions + the git tests it exposed.

_Note: CI validates the thin-client CMake profile, not the full Linux CMake build, so this fix is validated on .253 rather than by a CI gate. Adding a full-Linux-CMake CI job would prevent this class of regression — flagged for consideration._