### PR TITLE
harden(modularization): apply roundtable-review recommendations

### DIFF
--- a/docs/validation/core-modularization-class-a-migration.md
+++ b/docs/validation/core-modularization-class-a-migration.md
@@ -89,7 +89,15 @@ Two observations worth carrying forward:
   at all — not a path, not a bare filename. Both specify their surface and lifecycle key and stop
   there. A migration slice for either starts with locating the code, not moving it. (`workflows.md`
   is the only other module document naming neither, and `workflows` is not in this class: its module
-  root holds 30 sources and 24 private headers that its descriptor does not yet declare.)
+  root holds 30 sources and 24 private headers that its descriptor does not yet declare.) These two,
+  and `response-composition` (which names only the `aimee_ir.h` IR contract, no implementation site),
+  are **deliberately unlatched**: their code does not exist yet. `control-web`/`runtime-web` are the
+  optional GUI modules owned by `docs/proposals/pending/product-governance-web-and-config.md`, which
+  will supply their implementation. The correct disposition is to keep them as valid, unlatched
+  descriptors — not to write placeholder code purely to satisfy the completeness latch, and not to
+  remove the descriptors (their IDs are reserved by the owning proposals). A silent flip of any of the
+  three to `ownership_complete: true` without real implementation would be a regression; the descriptor
+  mutation suite and the empty-domain guard (slice 39) both defend against it.
 - `kb-synthesis` remains: its canonical document names `src/kb/` (a family of ~22 `kb_curator_*`
   sources compiled into `aimee-kb`) and `src/db2`, deeply coupled to the rest of the KB — a large
   entangled extraction, not a self-contained block. The four `tools`/`routing`/`execution-policy`

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -1,4 +1,12 @@
-/* agent_tools.c: tool execution, checkpoints, and tool definition JSON builders */
+/* agent_tools.c: tool execution, checkpoints, and tool definition JSON builders.
+ *
+ * BOUNDARY (core modularization): this is the server-side session-state slice of
+ * the tools contract (turn/snapshot/toolset state, e.g. agent_tools_begin_turn /
+ * agent_tools_set_snap_id / agent_tools_set_active_toolset). It is deliberately
+ * NOT part of the `tools` module — the tool-call dispatcher and implementations
+ * live in src/modules/tools/ (agent_tools_dispatch.c, agent_tools.c). The two
+ * halves communicate only through the public agent_tools.h. Do NOT add tool
+ * dispatch or tool implementations here; they belong in src/modules/tools/. */
 #include "aimee.h"
 #include "util.h"
 #include "agent_tools.h"


### PR DESCRIPTION
Two low-risk hardening changes from the 3-model panel review of the Class A migration effort:

- **`server/agent_tools.c`**: a boundary comment marking it as the server-side **session-state slice** of the tools contract — NOT part of the `tools` module (dispatch + implementations live in `src/modules/tools/`) — and forbidding tool-dispatch additions here. Prevents the tools/session boundary from silently re-blurring (panel Q2).
- **`core-modularization-class-a-migration.md`**: documents that `control-web`/`runtime-web`/`response-composition` are **deliberately unlatched** (code doesn't exist yet), names the owning proposal for the web GUIs, and states the disposition — keep as valid unlatched descriptors, don't write placeholder code, don't remove the reserved IDs; a silent flip to `ownership_complete` would be a regression (panel Q4).

Comment + doc only, no behaviour change.

## Panel review outcome (Class A effort)

The panel (MiniMax seat; Claude stalled, Kimi quota-exhausted this cycle) reviewed the four completed migrations and confirmed:
1. The decomposition principle — *extract the self-contained slice; keep the contract in a shared header the module implements; let the linker enforce the partition* — is **sound and correctly applied** (the `memory`/DB2 precedent).
2. **No architecturally wrong boundary** across benchmarks/tools/routing/execution-policy. The execution-policy broad-extraction that self-review caught and reversed was cited as "the principle working as designed."
3. **22/26 latched is an acceptable end state** — verified no Class B regression (22 = 18 established + 4 Class A; the 4 unlatched are exactly the no-source/KB modules).
4. **kb-synthesis** → a sequenced multi-slice extraction with its own proposal (not a thin slice — no clean seam; not deferral).
5. The three no-source modules → leave unlatched + documented (this PR).