### PR TITLE
Emit a liveness heartbeat for tmux-CLI delegate turns

### DIFF
--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -58,6 +58,18 @@ typedef int (*cli_session_cancel_cb_t)(void *ud);
 void cli_session_set_cancel_check(cli_session_cancel_cb_t cb, void *ud);
 cli_session_cancel_cb_t cli_session_get_cancel_check(void **ud_out);
 
+/* Liveness heartbeat callback: cli_session_recv invokes it periodically (throttled
+ * to ~CLI_SESSION_HEARTBEAT_MS) while it waits for the CLI to finish a turn. A
+ * tmux-CLI delegate (e.g. claude) runs the model loop inside the CLI process, so
+ * aimee's HTTP progress heartbeat never fires and the stale-idle monitor would
+ * cancel a long-but-healthy turn. This proves the recv loop is alive; a genuinely
+ * wedged CLI is still bounded by recv's own idle timeout. Thread-local, saved and
+ * restored around a nested turn like the stream/cancel callbacks. */
+typedef void (*cli_session_heartbeat_cb_t)(void *ud);
+void cli_session_set_heartbeat_cb(cli_session_heartbeat_cb_t cb, void *ud);
+cli_session_heartbeat_cb_t cli_session_get_heartbeat_cb(void **ud_out);
+#define CLI_SESSION_HEARTBEAT_MS 15000
+
 /* Provider-error grace (thread-local, ms): how long recv tolerates the CLI
  * sitting in a provider error/retry state before giving up with -4. 0 disables
  * the bound (legacy: only the idle timeout applies). Save/restore around a nested

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -102,6 +102,24 @@ cli_session_cancel_cb_t cli_session_get_cancel_check(void **ud_out)
    return g_cancel_cb;
 }
 
+/* Per-thread liveness heartbeat (set by the delegate worker to bump the job's
+ * heartbeat_at). Thread-local so concurrent turns on the pool never cross. */
+static __thread cli_session_heartbeat_cb_t g_heartbeat_cb = NULL;
+static __thread void *g_heartbeat_ud = NULL;
+
+void cli_session_set_heartbeat_cb(cli_session_heartbeat_cb_t cb, void *ud)
+{
+   g_heartbeat_cb = cb;
+   g_heartbeat_ud = ud;
+}
+
+cli_session_heartbeat_cb_t cli_session_get_heartbeat_cb(void **ud_out)
+{
+   if (ud_out)
+      *ud_out = g_heartbeat_ud;
+   return g_heartbeat_cb;
+}
+
 /* Per-thread provider-error grace (ms); 0 = disabled. Thread-local so concurrent
  * turns on the pool each carry their own bound. */
 static __thread int g_error_grace_ms = 0;
@@ -1061,6 +1079,7 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
    long long err_start = 0; /* mono_ms when that state began (valid iff err_active) */
    int saw_answer = 0;
    int marker_cli = strstr(s->cli_kind, "claude") != NULL || strstr(s->cli_kind, "codex") != NULL;
+   long long last_hb = 0; /* mono_ms of the last liveness heartbeat (0 = never) */
    free(s->stream_emitted);
    s->stream_emitted = strdup("");
 
@@ -1070,6 +1089,21 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
       {
          out[0] = '\0';
          return -1;
+      }
+
+      /* Liveness heartbeat: this recv is actively driving the CLI turn, but a
+       * tmux-CLI delegate makes no aimee HTTP calls, so the HTTP progress
+       * heartbeat never fires and the stale-idle monitor would cancel a healthy
+       * long turn. Prove the loop is alive on a throttle well under that
+       * threshold; recv's own idle timeout still bounds a genuinely wedged CLI. */
+      if (g_heartbeat_cb)
+      {
+         long long now_hb = mono_ms();
+         if (last_hb == 0 || now_hb - last_hb >= CLI_SESSION_HEARTBEAT_MS)
+         {
+            g_heartbeat_cb(g_heartbeat_ud);
+            last_hb = now_hb;
+         }
       }
 
       /* Cancellation (steering/interrupt or session close): stop the CLI mid-

--- a/src/server/server_delegate_monitor.c
+++ b/src/server/server_delegate_monitor.c
@@ -1,7 +1,8 @@
 /* server_delegate_monitor.c: see server_delegate_monitor.h */
 
 #include "server_delegate_monitor.h"
-#include "http_retry.h" /* http_set_progress_cb */
+#include "http_retry.h"  /* http_set_progress_cb */
+#include "cli_session.h" /* cli_session_set_heartbeat_cb (tmux-CLI delegates) */
 #include "log.h"
 
 #include <pthread.h>
@@ -32,15 +33,26 @@ static void delegate_heartbeat_cb(void)
       db1_agent_job_heartbeat(g_hb_job_id);
 }
 
+/* cli_session heartbeat callbacks carry a void* ud; ignore it and bump the same
+ * thread-local job as the HTTP path so a tmux-CLI delegate (claude/codex) stays
+ * alive through a long turn instead of being reaped as idle. */
+static void delegate_heartbeat_cli_cb(void *ud)
+{
+   (void)ud;
+   delegate_heartbeat_cb();
+}
+
 void server_delegate_heartbeat_begin(int job_id)
 {
    g_hb_job_id = job_id > 0 ? job_id : 0;
    http_set_progress_cb(job_id > 0 ? delegate_heartbeat_cb : NULL);
+   cli_session_set_heartbeat_cb(job_id > 0 ? delegate_heartbeat_cli_cb : NULL, NULL);
 }
 
 void server_delegate_heartbeat_end(void)
 {
    http_set_progress_cb(NULL);
+   cli_session_set_heartbeat_cb(NULL, NULL);
    g_hb_job_id = 0;
 }
 

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -209,6 +209,35 @@ static void test_recv_ok_on_stable_pane(void)
    assert(strstr(buf, "STATIC OUTPUT") != NULL);
 }
 
+static int g_hb_calls;
+static void hb_counter_cb(void *ud)
+{
+   (void)ud;
+   g_hb_calls++;
+}
+
+/* A tmux-CLI turn makes no aimee HTTP calls, so recv must drive the liveness
+ * heartbeat itself or the stale-idle monitor reaps a healthy long turn (the
+ * claude roundtable-seat regression). The heartbeat fires on the first loop
+ * iteration, so even a short recv proves the wiring. */
+static void test_recv_drives_heartbeat(void)
+{
+   setenv("FAKE_TMUX_MODE", "changing", 1);
+   cli_session_t s = fake_session();
+   char buf[8192];
+   g_hb_calls = 0;
+   cli_session_set_heartbeat_cb(hb_counter_cb, NULL);
+   (void)cli_session_recv(&s, buf, sizeof(buf), 1000);
+   cli_session_set_heartbeat_cb(NULL, NULL);
+   assert(g_hb_calls >= 1);
+
+   /* With no callback set, recv must not crash and must not call the old one. */
+   g_hb_calls = 0;
+   s = fake_session();
+   (void)cli_session_recv(&s, buf, sizeof(buf), 1000);
+   assert(g_hb_calls == 0);
+}
+
 static void test_capture_joins_wraps_and_includes_scrollback(void)
 {
    unlink(g_capturelog);
@@ -1155,6 +1184,7 @@ int main(void)
 
    printf("test_recv_ok_on_stable_pane... ");
    test_recv_ok_on_stable_pane();
+   test_recv_drives_heartbeat();
    printf("OK\n");
 
    printf("test_capture_joins_wraps_and_includes_scrollback... ");


### PR DESCRIPTION
## Problem

A tmux-CLI delegate (claude, codex) runs the entire model + tool loop **inside the CLI process** — it makes no aimee HTTP calls. So aimee's HTTP progress heartbeat (`http_set_progress_cb → db1_agent_job_heartbeat`) never fires, `heartbeat_at` stays frozen at job creation, and the stale-idle monitor cancels the job after `IDLE_THRESHOLD` (450s) with `stale: idle (no heartbeat progress)`.

A single fast review finishes before the threshold, but a long review — or one of several **concurrent** claude roundtable seats (slower under contention) — reliably gets reaped mid-turn. So claude is unreliable as a roundtable reviewer exactly when several sessions convene panels at once.

**Observed on .254:** 3 concurrent `claude` review jobs, all `api_call_count=0` with `heartbeat_at` frozen; one cancelled `stale: idle` at ~7.5 min.

## Fix

Drive the heartbeat from the one place that knows the tmux turn is alive — `cli_session_recv`'s poll loop. It already carries thread-local stream and cancel callbacks; this adds a heartbeat callback in the same shape, invoked on a **15s throttle** (well under the 450s idle threshold). `server_delegate_heartbeat_begin/end` register it alongside the HTTP progress cb, so both delegate backends share one begin/end.

A genuinely wedged CLI is still bounded by `recv`'s own idle timeout, so the stale monitor keeps its meaning — this only stops it from reaping a *healthy* long turn.

## Tests

`test_recv_drives_heartbeat` asserts `cli_session_recv` invokes the callback (and doesn't when none is set). Confirmed to **fail on the unmodified recv loop** (`g_hb_calls >= 1` assertion). Full `unit-test-cli-session` suite green; `server` + `kb` build clean under `-Wall -Wextra -Werror`.

## Context

Found while validating that claude works as a roundtable seat for other sessions' roundtable calls. Pairs with #1927 (keep claude's auto-updater from bricking the install). Together: claude installs stay healthy *and* claude's long/concurrent review turns don't get falsely reaped.