### PR TITLE
Advance every gate on its on_pass edge, not just gate.roundtable

### DIFF
--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -354,7 +354,12 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 	switch step.Status {
 	case StepAdvanced:
 		next := node.Next
-		if node.Block == "gate.roundtable" && node.OnPass != "" {
+		// A gate's pass edge is `on_pass`, not `next`. This holds for every gate,
+		// not just gate.roundtable: gate.ci advances a green PR to the merge stage
+		// via on_pass. Honoring it only for gate.roundtable made gate.ci fall
+		// through to next=="" and finish the slice terminal-"accepted" at ci — so
+		// the merge node was never reached and the slice PR was left unmerged.
+		if node.OnPass != "" {
 			next = node.OnPass
 		}
 		if next == "" {

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -650,6 +650,91 @@ func (r *artifactRoutingRunner) Run(_ context.Context, req StepRequest) (StepRes
 	}
 }
 
+type ciPassRunner struct{}
+
+func (ciPassRunner) Run(context.Context, StepRequest) (StepResult, error) {
+	return StepResult{Status: StepAdvanced, ArtifactType: "verdict", Artifact: "ci_passed"}, nil
+}
+
+// A gate.ci that passes must advance to its on_pass stage (merge), exactly like
+// gate.roundtable — not fall through to next=="" and finish the slice terminal.
+// The latter left every green slice PR unmerged at "ci accepted".
+func TestGateCIAdvancesToMergeOnPass(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte(`name: slice
+start: freeze
+nodes:
+  - id: source
+    block: understand
+  - id: impl
+    block: implement
+    in: {plan: source.out}
+  - id: freeze
+    block: freeze
+    in: {branch: impl.out}
+    next: pr
+  - id: pr
+    block: pr.open
+    in: {src: freeze.out}
+    next: ci
+    on_fail: pr
+  - id: ci
+    block: gate.ci
+    in: {pr: pr.out}
+    on_pass: merge
+    on_fail: impl
+  - id: merge
+    block: merge
+    in: {pr: pr.out}
+`)
+	if err := os.WriteFile(filepath.Join(workflowDir, "slice.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal("wi_ci", []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := artifacts.PutNodeArtifact("wi_ci", "impl", "branch", []byte("head")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateWorkItem(context.Background(), db1.CreateWorkItem{ID: "wi_ci", Repo: "repo", ProposalPath: "p", WorkflowName: "slice", WorkflowVersion: def.Version, StartStage: "freeze"}); err != nil {
+		t.Fatal(err)
+	}
+	eng, err := New(store, artifacts, workflowDir, ciPassRunner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// freeze -> pr, then pr -> ci; the third advance runs gate.ci.
+	var out AdvanceResult
+	for i := 0; i < 3; i++ {
+		out, err = eng.Advance(context.Background(), "wi_ci")
+		if err != nil {
+			t.Fatalf("advance %d: %v", i, err)
+		}
+	}
+	// gate.ci passed: it must advance to merge (its on_pass), not finish the slice
+	// terminal at ci with the PR left unmerged.
+	if out.Terminal || out.NextStage != "merge" {
+		t.Fatalf("gate.ci pass should advance to merge, got %+v", out)
+	}
+}
+
 func TestGateReviewsItsBoundArtifactNotThePlanShortcut(t *testing.T) {
 	root := t.TempDir()
 	workflowDir := filepath.Join(root, "workflows")


### PR DESCRIPTION
## Problem

The engine's `StepAdvanced` transition followed `node.OnPass` **only for `gate.roundtable`**; every other block used `node.Next`:

```go
next := node.Next
if node.Block == "gate.roundtable" && node.OnPass != "" {
    next = node.OnPass
}
if next == "" { /* Finish -> terminal "accepted" */ }
```

But `gate.ci` also expresses its pass edge as `on_pass` (`on_pass: merge`, `on_fail: impl`) and sets no `next`. So a **green CI gate fell through to `next==""`** and the engine finished the slice **terminal-`accepted` at `ci`** — the `merge` node was never reached, and the slice PR was left open on the feature branch, **unmerged**. The parent could then never fan in.

## Observed on the live E2E run

Slices whose roundtable approved *and* whose CI passed sat at `ci accepted` with their PRs (e.g. #1900, #1921, #1923) created but never merged into the feature tree. The user noticed "WFE jobs not merging their PRs into the feature branch."

The sequence: roundtable signs off → PR opens → CI gate passes → **stuck**, because the CI gate's pass edge was ignored.

## Fix

A gate's pass edge is `on_pass` regardless of which gate it is. Honor `on_pass` whenever it's set. Non-gate blocks (`freeze`, `impl`, `pr.open`) don't set `on_pass` — they use `next` — so their behaviour is unchanged.

```go
next := node.Next
if node.OnPass != "" {
    next = node.OnPass
}
```

## Tests

`TestGateCIAdvancesToMergeOnPass` drives a `freeze → pr → ci → merge` slice and asserts a passing `gate.ci` advances to `merge`, not terminal-`accepted`. Confirmed to **fail on the old gate.roundtable-only condition**. Full `engine` + `db1` + `wfe` suites green.

## Note on already-stuck slices

Slices already finished terminal-`accepted` (0/1/3 on the live run) won't retroactively merge — they're terminal. This fix makes *newly-completing* slices advance ci→merge. The existing PRs can be merged manually, or those slices re-driven.