### PR TITLE
Give each claude delegate seat its own HOME so concurrent seats don't wedge

### DIFF
--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -115,6 +115,14 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
  * for the TUI to start at all); the bypass warning is left untouched. */
 void cli_session_prepare_claude(const char *work_dir, int autonomous);
 
+/* Mint a per-session claude HOME so concurrent delegate seats don't share one
+ * ~/.claude.json + ~/.claude runtime tree (which claude-code writes non-atomically
+ * all turn, wedging concurrent seats). Only the OAuth token + settings.json are
+ * shared (symlinked); the rest is per-turn. Best-effort: returns 0 and fills
+ * home_out on success, -1 on any failure (caller then uses the shared HOME).
+ * Reaps per-session homes older than an hour on each call. */
+int cli_session_isolated_claude_home(const char *work_dir, char *home_out, size_t home_out_sz);
+
 /* Kills the tmux session. No-op if already dead. */
 void cli_session_destroy(cli_session_t *s);
 

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -6,6 +6,7 @@
 #include "cli_session.h"
 #include "log.h"
 #include <ctype.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -117,6 +118,26 @@ static int cli_session_execute_inner(const agent_t *agent, const agent_network_t
     * other CLIs. */
    if (is_claude)
       cli_session_prepare_claude(cwd, autonomous);
+
+   /* Concurrency isolation for claude DELEGATE seats: several roundtable/impl
+    * seats run at once, and they otherwise share one $HOME -> one ~/.claude.json
+    * and ~/.claude runtime tree, which claude-code writes non-atomically the whole
+    * turn. Concurrent seats then corrupt/block each other and wedge to the CLI
+    * timeout. Give each delegate seat its own HOME (OAuth token + settings shared
+    * by symlink; the rest per-turn) by prefixing the launched command. The primary
+    * interactive session is single, so it keeps the shared HOME. Best-effort: a
+    * failed mint leaves cli_cmd untouched (shared HOME, prior behavior). */
+   char cli_cmd_home[CLI_SESSION_CMD_MAX];
+   if (is_claude && deleg)
+   {
+      char iso_home[PATH_MAX];
+      if (cli_session_isolated_claude_home(cwd, iso_home, sizeof(iso_home)) == 0)
+      {
+         int n = snprintf(cli_cmd_home, sizeof(cli_cmd_home), "HOME='%s' %s", iso_home, cli_cmd);
+         if (n > 0 && n < (int)sizeof(cli_cmd_home))
+            cli_cmd = cli_cmd_home;
+      }
+   }
 
    /* Prefix the launched CLI command with a per-session AIMEE_SESSION_ID assignment
     * (`AIMEE_SESSION_ID=<sid> <cli_cmd>` run by `/bin/sh -c`) so the PreToolUse hook

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -7,7 +7,10 @@
 #include "cli_session.h"
 #include "util.h"
 #include "workspace_provider.h"
+#include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <ftw.h>
 #include <limits.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -375,6 +378,145 @@ void cli_session_prepare_claude(const char *work_dir, int autonomous)
       close(lf);
    }
    pthread_mutex_unlock(&g_prep_mu);
+}
+
+/* nftw callback: remove one entry. FTW_DEPTH gives post-order so a directory is
+ * removed after its children; FTW_PHYS (set by the caller) means a symlink is
+ * removed as the link, never followed — so the shared .credentials.json target is
+ * never touched. */
+static int cli_home_unlink_cb(const char *p, const struct stat *st, int type, struct FTW *ftw)
+{
+   (void)st;
+   (void)type;
+   (void)ftw;
+   remove(p);
+   return 0;
+}
+
+static void cli_rmrf(const char *path)
+{
+   nftw(path, cli_home_unlink_cb, 16, FTW_DEPTH | FTW_PHYS);
+}
+
+/* Reap per-session claude homes older than an hour so they cannot accumulate on
+ * the volume. Best-effort; an in-use home has a fresh mtime and is skipped. */
+static void cli_claude_homes_sweep(const char *base)
+{
+   DIR *d = opendir(base);
+   if (!d)
+      return;
+   time_t now = time(NULL);
+   struct dirent *e;
+   while ((e = readdir(d)) != NULL)
+   {
+      if (e->d_name[0] == '.')
+         continue;
+      char p[PATH_MAX];
+      if ((size_t)snprintf(p, sizeof(p), "%s/%s", base, e->d_name) >= sizeof(p))
+         continue;
+      struct stat st;
+      if (lstat(p, &st) != 0 || !S_ISDIR(st.st_mode))
+         continue;
+      if (now - st.st_mtime < 3600)
+         continue;
+      cli_rmrf(p);
+   }
+   closedir(d);
+}
+
+/* Mint a per-session claude HOME so concurrent delegate seats do not share one
+ * ~/.claude.json and ~/.claude runtime tree (session history, sessions,
+ * session-env). claude-code writes those non-atomically all turn, so N concurrent
+ * seats corrupt/block each other and wedge to the CLI timeout — a review that
+ * finishes solo in ~1 min hangs under load. Each turn gets its own HOME; only the
+ * OAuth token and settings.json are shared, symlinked (read-mostly), and
+ * ~/.claude.json is seeded from the shared one (oauthAccount / onboarding / trust)
+ * then diverges per turn.
+ *
+ * Best-effort: on ANY failure returns -1 and fills nothing, so the caller launches
+ * with the shared HOME (the prior behavior) — this can never make claude
+ * unlaunchable. Fills home_out with the new HOME on success. */
+int cli_session_isolated_claude_home(const char *work_dir, char *home_out, size_t home_out_sz)
+{
+   if (!home_out || home_out_sz == 0)
+      return -1;
+   home_out[0] = '\0';
+   const char *shared = cli_claude_home();
+
+   char base[PATH_MAX];
+   if ((size_t)snprintf(base, sizeof(base), "%s/.claude-homes", shared) >= sizeof(base))
+      return -1;
+   mkdir(base, 0700); /* ignore EEXIST */
+   cli_claude_homes_sweep(base);
+
+   char home[PATH_MAX];
+   if ((size_t)snprintf(home, sizeof(home), "%s/s.XXXXXX", base) >= sizeof(home))
+      return -1;
+   if (mkdtemp(home) == NULL)
+      return -1;
+
+   char cdir[PATH_MAX];
+   if ((size_t)snprintf(cdir, sizeof(cdir), "%s/.claude", home) >= sizeof(cdir))
+      return -1;
+   if (mkdir(cdir, 0700) != 0 && errno != EEXIST)
+      return -1;
+
+   /* Share the OAuth token (required to authenticate) and settings.json (MCP
+    * servers + hooks + the auto-updater disable) by symlink. The credential is
+    * mandatory: without it claude cannot auth, so a failed link falls back to the
+    * shared HOME rather than launching an unauthenticated seat. */
+   char src[PATH_MAX], dst[PATH_MAX];
+   if ((size_t)snprintf(src, sizeof(src), "%s/.claude/.credentials.json", shared) >= sizeof(src) ||
+       (size_t)snprintf(dst, sizeof(dst), "%s/.credentials.json", cdir) >= sizeof(dst))
+      return -1;
+   /* symlink() happily links to a missing target, so verify the shared token
+    * actually exists — a dangling credential link would launch an unauthenticated
+    * seat. No token -> fall back to the shared HOME. */
+   if (access(src, R_OK) != 0 || symlink(src, dst) != 0)
+      return -1;
+   if ((size_t)snprintf(src, sizeof(src), "%s/.claude/settings.json", shared) < sizeof(src) &&
+       (size_t)snprintf(dst, sizeof(dst), "%s/settings.json", cdir) < sizeof(dst))
+      (void)symlink(src, dst); /* helpful, not fatal */
+
+   /* Seed ~/.claude.json from the shared one for oauthAccount + onboarding, plus
+    * trust for this worktree. A mid-write/corrupt shared file (skip=1) means we
+    * cannot recover the account -> fall back to the shared HOME. */
+   char sharedjson[PATH_MAX], homejson[PATH_MAX];
+   if ((size_t)snprintf(sharedjson, sizeof(sharedjson), "%s/.claude.json", shared) >=
+           sizeof(sharedjson) ||
+       (size_t)snprintf(homejson, sizeof(homejson), "%s/.claude.json", home) >= sizeof(homejson))
+      return -1;
+   int skip = 0;
+   cJSON *root = cli_claude_cfg_load(sharedjson, &skip);
+   if (!root)
+      return -1;
+   cli_json_set_true(root, "hasCompletedOnboarding");
+   if (work_dir && work_dir[0])
+   {
+      cJSON *projects = cJSON_GetObjectItemCaseSensitive(root, "projects");
+      if (!cJSON_IsObject(projects))
+      {
+         cJSON_DeleteItemFromObject(root, "projects");
+         projects = cJSON_AddObjectToObject(root, "projects");
+      }
+      cJSON *proj = projects ? cJSON_GetObjectItemCaseSensitive(projects, work_dir) : NULL;
+      if (projects && !cJSON_IsObject(proj))
+      {
+         cJSON_DeleteItemFromObject(projects, work_dir);
+         proj = cJSON_AddObjectToObject(projects, work_dir);
+      }
+      if (proj)
+         cli_json_set_true(proj, "hasTrustDialogAccepted");
+   }
+   char *out = cJSON_Print(root);
+   int wrote = out && cli_write_file_atomic(homejson, out) == 0;
+   free(out);
+   cJSON_Delete(root);
+   if (!wrote)
+      return -1;
+
+   snprintf(home_out, home_out_sz, "%s", home);
+   return 0;
 }
 
 int cli_session_resolve_cwd(const char *turn_cwd, char *out, size_t n)

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include "cJSON.h"
 #include "cli_session.h"
@@ -1014,8 +1015,63 @@ static void test_prepare_claude_nonautonomous_skips_bypass_seed(void)
    }
 }
 
+/* Per-session claude HOME isolation: a fresh HOME with the OAuth token symlinked
+ * from the shared home and ~/.claude.json seeded from it; missing credentials
+ * fall back (-1) so a seat is never launched unauthenticated. */
+static void test_isolated_claude_home(void)
+{
+   char shared[128];
+   snprintf(shared, sizeof(shared), "/tmp/aimee-iso-%d", (int)getpid());
+   char cdir[192], creds[288], json[288], settings[288];
+   snprintf(cdir, sizeof(cdir), "%s/.claude", shared);
+   mkdir(shared, 0700);
+   mkdir(cdir, 0700);
+   snprintf(creds, sizeof(creds), "%s/.credentials.json", cdir);
+   snprintf(json, sizeof(json), "%s/.claude.json", shared);
+   snprintf(settings, sizeof(settings), "%s/settings.json", cdir);
+   FILE *f = fopen(creds, "w");
+   assert(f);
+   fputs("{\"token\":\"x\"}", f);
+   fclose(f);
+   f = fopen(json, "w");
+   assert(f);
+   fputs("{\"oauthAccount\":{\"id\":\"a\"}}", f);
+   fclose(f);
+   f = fopen(settings, "w");
+   assert(f);
+   fputs("{}", f);
+   fclose(f);
+   setenv("HOME", shared, 1);
+
+   char home[PATH_MAX];
+   assert(cli_session_isolated_claude_home("/w/d", home, sizeof(home)) == 0);
+   assert(strncmp(home, shared, strlen(shared)) == 0); /* under the shared home */
+
+   struct stat st;
+   char p[512];
+   snprintf(p, sizeof(p), "%s/.claude/.credentials.json", home);
+   assert(lstat(p, &st) == 0 && S_ISLNK(st.st_mode)); /* creds SHARED via symlink */
+   snprintf(p, sizeof(p), "%s/.claude.json", home);
+   assert(stat(p, &st) == 0 && st.st_size > 0); /* per-session json seeded */
+   FILE *rf = fopen(p, "r");
+   assert(rf);
+   char buf[4096] = {0};
+   fread(buf, 1, sizeof(buf) - 1, rf);
+   fclose(rf);
+   assert(strstr(buf, "oauthAccount") && strstr(buf, "hasCompletedOnboarding"));
+   assert(strstr(buf, "/w/d")); /* trust seeded for the worktree */
+
+   /* No credentials in the shared home -> fall back to shared HOME (-1). */
+   unlink(creds);
+   char home2[PATH_MAX];
+   assert(cli_session_isolated_claude_home("/w/d", home2, sizeof(home2)) == -1);
+   printf("  PASS: test_isolated_claude_home\n");
+}
+
 int main(void)
 {
+   test_isolated_claude_home();
+
    printf("test_resolve_cwd_existing_used... ");
    test_resolve_cwd_existing_used();
    printf("OK\n");


### PR DESCRIPTION
## Problem

Every claude tmux-CLI seat launches with the same `$HOME=/var/lib/aimee`, so all concurrent seats share **one `~/.claude.json`** and **one `~/.claude/` runtime tree** (`history.jsonl`, `sessions/`, `session-env/` — 47M of state on the live box). claude-code rewrites those **non-atomically throughout a turn**, so N concurrent roundtable/impl seats corrupt and block each other.

**Observed on .254:** a single claude review finishes in ~1 min; **4 concurrent claude reviews all wedged and failed at the 600s CLI-response timeout.** That's why claude is unreliable as a roundtable reviewer exactly when multiple sessions convene panels at once. (Investigated per the maintainer's request; root cause confirmed in `cli_claude_home()` returning a fixed HOME.)

## Fix

`cli_session_isolated_claude_home()` mints a per-turn HOME under `<shared>/.claude-homes/`:
- **OAuth token** (`.credentials.json`) and `settings.json` are **shared by symlink** (read-mostly — the token must stay shared so refreshes stay valid).
- `~/.claude.json` is **seeded from the shared one** (`oauthAccount` + onboarding + this worktree's trust) and then diverges per turn.

`agent_runtime_tmux` prefixes the delegate launch with `HOME=<that>`. **Only DELEGATE claude seats are isolated** — the single primary interactive session keeps the shared HOME for conversation continuity.

**Safety:** best-effort with fallback at every step — a missing or mid-write shared token/json returns `-1`, and the caller launches with the shared HOME (the prior behavior). So this can never make claude unlaunchable. Per-session homes older than an hour are reaped on each call via `nftw` with `FTW_PHYS` (the shared credential the symlink points at is never followed or removed).

## Tests

`test_isolated_claude_home` asserts the mint (shared-token symlink, per-session `~/.claude.json` carrying `oauthAccount`/`hasCompletedOnboarding`/worktree trust) and the **no-credential fallback** (`-1`, which caught a dangling-symlink bug: `symlink()` succeeds to a missing target, so the source is now `access()`-checked). Full `unit-test-cli-session` suite green; `server` builds clean under `-Werror`.

## Validation status

Unit-tested, **needs live validation**: concurrent claude reviews must stop wedging once deployed. Pairs with #1932 (heartbeat) — together, long *and* concurrent claude review seats become reliable.