### PR TITLE
Fix init-migrate-service-test flake: poll for the server socket, not sleep 1

### DIFF
--- a/src/tests/test_init_migrate_service.sh
+++ b/src/tests/test_init_migrate_service.sh
@@ -116,7 +116,19 @@ export AIMEE_NO_AUTOSTART=1
 
 "$SERVICE_SERVER" --foreground >/dev/null 2>&1 &
 SERVER_PID=$!
-sleep 1
+
+# Wait for the server to actually bind its HTTP socket instead of guessing with a
+# fixed `sleep 1`. On a loaded CI runner startup regularly takes several seconds,
+# and the 1s guess made this the run's flakiest test ("service route server
+# started" / "client ... server unavailable"). Poll for the socket (~30s cap) and
+# bail early if the server process dies so a crash fails fast instead of timing
+# out. A unix-socket server binds+listens as the last init step, so socket-present
+# means ready to serve.
+for _ in $(seq 1 300); do
+    [ -S "$HTTP_SOCK" ] && break
+    kill -0 "$SERVER_PID" 2>/dev/null || break
+    sleep 0.1
+done
 
 check "service route server started" test -S "$HTTP_SOCK"
 check_output "client init routes through server to kb owner" '"knowledge_ready":true' \


### PR DESCRIPTION
## Problem

`init-migrate-service-test` launches the service-routing server, waits a fixed **`sleep 1`**, then asserts the HTTP socket exists and that a client can route an `init` through it. On a loaded CI runner the server regularly needs several seconds to bind its socket, so the 1s guess made this **the run's flakiest test** — it failed intermittently across many unrelated PRs (#1897, #1899, #1927, #1936…) with:

```
FAIL: service route server started            (socket absent at 1s)
FAIL: client init routes through server ...   (got "aimee: server unavailable")
```

Every one of those passed on a plain re-run — a textbook timing flake.

## Fix

Replace the fixed sleep with a **readiness poll**: wait up to ~30s for the server to bind `$HTTP_SOCK`, breaking early if the server process dies so a real crash fails fast instead of timing out. A unix-socket server binds+listens as its last init step, so socket-present means ready to serve.

```sh
for _ in $(seq 1 300); do
    [ -S "$HTTP_SOCK" ] && break
    kill -0 "$SERVER_PID" 2>/dev/null || break
    sleep 0.1
done
```

## Verification

Full build + test run green (4/4). Test-only change; the poll strictly widens the readiness window and adds a fail-fast on server death.