### PR TITLE
witness follow-ups: file P7 plans under done/, de-flake gate-race liveness

### DIFF
--- a/docs/proposals/done/tiered-llm-p7-external-worm-witness.plan.md
+++ b/docs/proposals/done/tiered-llm-p7-external-worm-witness.plan.md
@@ -1,14 +1,13 @@
 # P7 external WORM witness and full kill matrix
 
 - **State:** implemented and validated on branch `rewrite/go-server-wfe` (through
-  `ecbfbc35`); awaiting merge to `testing`. E1, E2, and E3 are all delivered — the
+  `ecbfbc35`); merged to `testing` via PR #1930 (2026-07-24). E1, E2, and E3 are all delivered — the
   P2b release gate flip is live (`kb_egress_release_allowed()` returns
   `witness_release_gate_open()`). Validated end-to-end on a fresh CT103 env: witness
   unit suite, integration gate (producer/emit/tamper/recovery/canary), the E3 kill
   matrix, hardened boot over verify-full TLS (both directions), runtime-role least
   privilege, and a ThreadSanitizer lane for the release-gate cross-thread cell. A
-  clean roundtable review approved the core diff. This doc moves to
-  `docs/proposals/done/` when the branch merges.
+  clean roundtable review approved the core diff.
 - **Depends on:** P7-reseal D1, D2a, D2b, D3a, D3b (merged), P3a WORM ledger, and
   the existing kb audit chain.
 - **Enables:** the last open P7 line item — `external WORM delivery + full kill

--- a/docs/proposals/done/tiered-llm-p7-witness-e1-record-checkpoint-evidence-log.plan.md
+++ b/docs/proposals/done/tiered-llm-p7-witness-e1-record-checkpoint-evidence-log.plan.md
@@ -1,10 +1,9 @@
 # P7-witness-e1 witness record, checkpoint, export form, and evidence log
 
 - **State:** implemented and validated on branch `rewrite/go-server-wfe` (through
-  `ecbfbc35`); awaiting merge to `testing`. Record/checkpoint/inclusion-proof
+  `ecbfbc35`); merged to `testing` via PR #1930 (2026-07-24). Record/checkpoint/inclusion-proof
   encodings, deterministic export form, evidence log, and per-`(tenant, provider)`
   shard counters are delivered with exact stable vectors and offline verification.
-  Moves to `docs/proposals/done/` when the branch merges.
 - **Depends on:** P7-reseal D3b, the kb audit chain
   (`src/db2/kb_audit_worm.c`), and the reseal outbox
   (`kb_vault_rewrap_worm`).

--- a/docs/proposals/done/tiered-llm-p7-witness-e2-append-emission-verification.plan.md
+++ b/docs/proposals/done/tiered-llm-p7-witness-e2-append-emission-verification.plan.md
@@ -1,13 +1,12 @@
 # P7-witness-e2 atomic append, emission, and continuous verification
 
 - **State:** implemented and validated on branch `rewrite/go-server-wfe` (through
-  `ecbfbc35`); awaiting merge to `testing`. Atomic witness append is wired into all
+  `ecbfbc35`); merged to `testing` via PR #1930 (2026-07-24). Atomic witness append is wired into all
   three source ledgers (audit, reseal, open) — proven by the wiring + atomicity gate
   enforced from `run-p1-rls-gate.sh`. Emission on the log path, numeric-only health
   metrics, continuous chain verification with typed integrity alerts, the offline
   verifier tool, and boot fail-closed for a key-holding kb are all delivered. Does
-  not touch `kb_egress_release_allowed()` (that flip is E3). Moves to
-  `docs/proposals/done/` when the branch merges.
+  not touch `kb_egress_release_allowed()` (that flip is E3).
 - **Depends on:** E1 (record, checkpoint, export form, evidence log), P7-reseal
   D3b, the kb audit chain, and the P9a telemetry seam.
 - **Enables:** E3's kill matrix and, only after it, the release-gate flip.

--- a/docs/proposals/done/tiered-llm-p7-witness-e3-kill-matrix-and-release.plan.md
+++ b/docs/proposals/done/tiered-llm-p7-witness-e3-kill-matrix-and-release.plan.md
@@ -1,13 +1,13 @@
 # P7-witness-e3 full kill matrix and the release gate
 
 - **State:** implemented and validated on branch `rewrite/go-server-wfe` (through
-  `ecbfbc35`); awaiting merge to `testing`. The kill matrix (daemon hard-kill,
+  `ecbfbc35`); merged to `testing` via PR #1930 (2026-07-24). The kill matrix (daemon hard-kill,
   boot-tpm under swtpm, hardened boot over verify-full TLS both directions), the
   tamper scenarios (incl. comparison catching a coherent rewrite against a retained
   copy), and the raw-key canary scans are delivered. The release-gate flip is live:
   `kb_egress_release_allowed()` returns `witness_release_gate_open()` (five
   fail-closed terms). §4b/§4c document the runtime-role grant and hardened-bootstrap
-  fixes found in self-review. Moves to `docs/proposals/done/` when the branch merges.
+  fixes found in self-review.
 - **Depends on:** E1, E2, and every merged P7 reseal slice through D3b.
 - **Enables:** the P2b production release gate — the last open P7 line item.
 - **Umbrella:** `tiered-llm-p7-external-worm-witness.plan.md`.

--- a/src/tests/test_witness_gate_race.c
+++ b/src/tests/test_witness_gate_race.c
@@ -7,12 +7,14 @@
  * made it a C11 _Atomic with release/acquire ordering.
  *
  * This test drives the exact store/load the gate relies on from separate writer and
- * reader threads. Two things it asserts on every build:
- *   - liveness: the reader observes writes progress (it sees more than one distinct
- *     published value), so the hand-off is not silently wedged;
- *   - domain safety: the reader NEVER observes a value outside {-1,0,1}. A torn or
- *     otherwise undefined read of the cell is the only way an out-of-domain value
- *     could appear, so any such observation fails the test.
+ * reader threads. It ASSERTS domain safety: the reader NEVER observes a value outside
+ * {-1,0,1}. A torn or otherwise undefined read of the cell is the only way an
+ * out-of-domain value could appear, so any such observation fails the test.
+ *
+ * It also reports how many distinct values the reader observed (a liveness signal),
+ * but does NOT fail on a low count: on a loaded CI runner the reader thread can be
+ * starved enough to see fewer than two distinct values with nothing actually wrong,
+ * so a hard liveness assertion here is a flake, not a guard.
  *
  * Its real teeth are under ThreadSanitizer (scripts/run-witness-gate-tsan.sh): if the
  * cell is ever reverted to a non-atomic type / access, TSan reports a data race
@@ -86,14 +88,9 @@ int main(void)
       fprintf(stderr, "witness gate race: FAIL — reader saw %ld out-of-domain value(s)\n", bad);
       return 1;
    }
-   /* Liveness: the reader must have observed the published value change. If it saw a
-    * single constant value the whole time the hand-off is not actually working. */
-   if (distinct < 2)
-   {
-      fprintf(stderr, "witness gate race: FAIL — reader saw no progress (distinct=%ld)\n",
-              distinct);
-      return 1;
-   }
+   /* Liveness is reported, not asserted: reader-thread starvation under CI load can
+    * legitimately leave distinct < 2 with no defect, so failing on it only produces
+    * flakes. Domain safety (above) and the TSan lane are the real regression guards. */
    printf("witness gate race: ok (distinct transitions observed=%ld, out-of-domain=0)\n", distinct);
    return 0;
 }


### PR DESCRIPTION
Two small follow-ups after the P7 witness umbrella landed on `testing` (PR #1930).

### 1. File the P7 witness plans under `done/`
The umbrella + E1/E2/E3 plans merged, so move them from `docs/proposals/pending/` to `docs/proposals/done/` (the `pending/`→`done/` convention the reseal D-plans already follow) and update each `State:` header from "awaiting merge" to "merged to `testing` via PR #1930". All 196 proposal links still resolve (`proposal-links-check: ok`); the docs cross-reference siblings by bare filename and moved together, so links are intact.

### 2. De-flake `test_witness_gate_race.c`
The gate-race test's **liveness** check (`distinct < 2` → fail) is scheduler-dependent: under CI load the reader thread can be starved enough to observe fewer than two distinct published values with nothing actually wrong, which shows up as an intermittent failure. Make the distinct-count **report-only** instead of fatal.

The test's real regression guards are unchanged:
- **domain safety** — the reader must never observe a value outside `{-1,0,1}` (a torn/undefined read is the only way that happens) — still a hard assertion;
- the **ThreadSanitizer lane** (`make witness-gate-tsan`) — the actual detector of a non-atomic revert.

No production code changes.
