### PR TITLE
Fix witness-gate-race flake: guarantee the reader observes progress

### DIFF
--- a/src/tests/test_witness_gate_race.c
+++ b/src/tests/test_witness_gate_race.c
@@ -21,18 +21,24 @@
 
 #include <assert.h>
 #include <pthread.h>
+#include <sched.h>
 #include <stdatomic.h>
 #include <stdio.h>
 
 #include "kb/kb_witness_gate_state.h"
 
-/* Enough iterations to give TSan a wide window to catch an unsynchronised access and
- * to make a wedged hand-off statistically certain to be caught. */
-#define ITERS 2000000
+/* A wide window so TSan can catch an unsynchronised access. */
+#define MIN_ITERS 2000000
+/* Transitions the reader must observe before the writer is allowed to stop —
+ * the liveness guarantee that removes the scheduling flake below. */
+#define NEED_DISTINCT 8
+/* Safety cap far above MIN_ITERS: a genuinely wedged hand-off (reader never sees
+ * the value change) fails as a bounded error instead of hanging. */
+#define HARD_CAP 200000000L
 
 static _Atomic int stop;
 static _Atomic long domain_violations;
-static _Atomic long distinct_seen; /* count of reads that differed from the prior read */
+static _Atomic long distinct_seen; /* reads that differed from the prior read (published live) */
 
 static void *writer(void *unused)
 {
@@ -41,8 +47,23 @@ static void *writer(void *unused)
     * observe, in a non-trivial order (mirrors the cadence: unknown at boot, then
     * flips between clean and not-clean). */
    static const int seq[] = {-1, 1, 0, 1, 0, 0, 1, -1};
-   for (long i = 0; i < ITERS; i++)
+   /* Do not stop after a fixed count: on a loaded runner (unit-tests runs the
+    * suite with xargs -P) the reader can be starved for the whole loop and see a
+    * single constant value — the old "no progress" flake. Yield periodically so
+    * the reader is scheduled, and keep publishing until it has actually observed
+    * NEED_DISTINCT transitions AND the TSan window is wide enough. HARD_CAP bounds
+    * a truly broken hand-off. */
+   for (long i = 0;; i++)
+   {
       kb_witness_gate_state_set(seq[i & 7]);
+      if ((i & 0x3FF) == 0)
+         sched_yield();
+      if (i >= MIN_ITERS &&
+          atomic_load_explicit(&distinct_seen, memory_order_relaxed) >= NEED_DISTINCT)
+         break;
+      if (i >= HARD_CAP)
+         break;
+   }
    atomic_store_explicit(&stop, 1, memory_order_release);
    return NULL;
 }
@@ -51,7 +72,7 @@ static void *reader(void *unused)
 {
    (void)unused;
    int prev = kb_witness_gate_state_get();
-   long local_distinct = 0, local_bad = 0;
+   long local_bad = 0;
    while (!atomic_load_explicit(&stop, memory_order_acquire))
    {
       int v = kb_witness_gate_state_get();
@@ -59,12 +80,13 @@ static void *reader(void *unused)
          local_bad++;
       if (v != prev)
       {
-         local_distinct++;
+         /* Publish each transition live so the writer can see the reader is making
+          * progress and stop only then. */
+         atomic_fetch_add_explicit(&distinct_seen, 1, memory_order_relaxed);
          prev = v;
       }
    }
    atomic_fetch_add_explicit(&domain_violations, local_bad, memory_order_relaxed);
-   atomic_fetch_add_explicit(&distinct_seen, local_distinct, memory_order_relaxed);
    return NULL;
 }
 


### PR DESCRIPTION
## Problem

`test_witness_gate_race` is the run's **known intermittent flake** (called out in the #1925 work notes). A writer thread cycles the witness-gate cell through its domain a fixed 2,000,000 times then stops; a reader thread counts distinct values it observes and the test asserts the reader saw the value change (`distinct >= 2`).

The writer did 2M atomic stores **with no yield**, and the `unit-tests` target runs the whole suite in parallel (`xargs -P`). On a loaded runner the reader thread gets **starved for the entire loop**: it reads the boot value (`-1`), the writer races to completion (last value is also `-1`), the reader reads `-1` again — `distinct` stays `0` and the liveness check fails with *"reader saw no progress"*. Silent-ish `FAILED:` that has blocked many unrelated PRs.

## Fix

Keep the wide concurrent window (TSan still exercises the unsynchronised access) but make liveness deterministic:
1. `sched_yield()` periodically in the writer so the reader is actually scheduled.
2. Don't stop until the reader has **published `NEED_DISTINCT` real transitions** (reader now increments `distinct_seen` live), bounded by a `HARD_CAP` so a genuinely wedged hand-off fails as a bounded error instead of hanging.

Same iteration count in the normal case → **no slower**.

## Verification

**48/48 green under 16-way oversubscription on an 8-core box** (the exact starvation condition), where the old version flakes. Also 20/20 solo.