### PR TITLE
Audit sandbox isolation degradation over the event bus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,6 +885,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_state.c
     ${AIMEE_SRC_DIR}/server/server_audit_replay_routes.c
     ${AIMEE_SRC_DIR}/server/vault_audit_bridge.c
+    ${AIMEE_SRC_DIR}/server/sandbox_audit_bridge.c
     ${AIMEE_SRC_DIR}/server/server_runner_endpoints.c
     ${AIMEE_SRC_DIR}/server/server_state_audit.c
     ${AIMEE_SRC_DIR}/server/server_css_query.c
@@ -894,6 +895,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_state.c
     ${AIMEE_SRC_DIR}/server/server_audit_replay_routes.c
     ${AIMEE_SRC_DIR}/server/vault_audit_bridge.c
+    ${AIMEE_SRC_DIR}/server/sandbox_audit_bridge.c
     ${AIMEE_SRC_DIR}/server/server_runner_endpoints.c
     ${AIMEE_SRC_DIR}/server/server_state_audit.c
     ${AIMEE_SRC_DIR}/server/server_css_query.c

--- a/scripts/check_bus_perf_gate.sh
+++ b/scripts/check_bus_perf_gate.sh
@@ -112,4 +112,19 @@ if ! printf '%s\n' "$vault_out" | grep -q "test_bus_vault_audit: OK"; then
 fi
 echo "vault-access audit: ok (access -> bridge -> bus -> ledger; no secret leak)"
 
-echo "check_bus_perf_gate: ok — dispatch + audit within budget; audit durability holds; vault-access audit holds; memory rows pending"
+# 5. The sandbox degraded-isolation audit trail: a guarded exec that ran
+#    unsandboxed (or was refused) because the sandbox was unavailable flows
+#    through the REAL server bridge -> audit_bus -> ledger, fields mapped, no
+#    secret leaked. Same special-link reason as the vault test.
+echo "checking sandbox degraded-isolation audit trail..."
+sbx_out=$(make -C src --no-print-directory unit-test-bus-sandbox-audit 2>&1 || true)
+if ! printf '%s\n' "$sbx_out" | grep -q "test_bus_sandbox_audit: OK"; then
+   echo "" >&2
+   echo "FAIL: the sandbox-on-bus audit test did not pass — a degraded-isolation" >&2
+   echo "      exec is not being recorded correctly through the bridge, or a secret leaked." >&2
+   printf '%s\n' "$sbx_out" | tail -8 >&2
+   exit 1
+fi
+echo "sandbox audit: ok (degraded isolation -> bridge -> bus -> ledger; no secret leak)"
+
+echo "check_bus_perf_gate: ok — dispatch + audit within budget; audit durability holds; vault-access + sandbox audit hold; memory rows pending"

--- a/src/Makefile
+++ b/src/Makefile
@@ -457,6 +457,9 @@ SERVER_SRCS += modules/economizer/gateway_mutate_wire.c
 # The one object that links vault_service to the (D7-confined) audit bus, keeping
 # vault_service.o itself bus-free; server-only, co-linked with $(BUS_SHIP_OBJS).
 SERVER_SRCS += server/vault_audit_bridge.c
+# Likewise, the sole object linking sandbox.c to the audit bus (sandbox.o stays
+# bus-free). Server-only.
+SERVER_SRCS += server/sandbox_audit_bridge.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) modules/guardrails/guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/headers/sandbox.h
+++ b/src/headers/sandbox.h
@@ -58,6 +58,43 @@ int sandbox_detect_container(void);
 int sandbox_available(const char **reason);
 
 /*
+ * sandbox_command_program:
+ *   Extract the leading PROGRAM name of a /bin/sh -c command line into |out| — the
+ *   first token after any `VAR=value` environment-assignment prefixes, basename
+ *   only, never its arguments. This is a NON-SECRET label: a command line can
+ *   carry secrets in its arguments or env assignments (tokens, keys), so only the
+ *   program is ever surfaced (e.g. "TOKEN=sk-.. /usr/bin/npm install x" -> "npm").
+ *   |out| is always NUL-terminated; empty for a NULL/blank command.
+ */
+void sandbox_command_program(const char *cmd, char *out, size_t out_len);
+
+/*
+ * Audit hook: notified when a guarded execution's isolation DEGRADES — the
+ * sandbox was requested (mode != off) but was unavailable, so the command either
+ * ran UNSANDBOXED (verdict "unsandboxed_fallback") or was REFUSED (verdict
+ * "refused", for require-isolation callers). These rare, high-signal events are
+ * the sandbox activity worth an audit trail; a routine successful sandboxed exec
+ * is deliberately NOT recorded (high volume, low signal, would evict governance
+ * rows). Only NON-SECRET fields cross: the program name (never arguments), the
+ * mode, the network-isolation flag, the verdict, and the availability reason.
+ *
+ * Installed once at startup by a server-only bridge that forwards to the audit
+ * event bus; sandbox.c itself has NO event-bus dependency (stays linkable into
+ * every binary). NULL by default. Set once before serving.
+ */
+typedef void (*sandbox_audit_hook_fn)(const char *program, sandbox_mode_t mode,
+                                      int network_isolated, const char *verdict,
+                                      const char *reason);
+void sandbox_set_audit_hook(sandbox_audit_hook_fn fn);
+
+/*
+ * Test-only seam: override the availability probe so the degraded-isolation audit
+ * paths are deterministically reachable regardless of the host kernel/container.
+ * Pass NULL to restore the real probe.
+ */
+void sandbox_set_available_override_for_test(int (*fn)(const char **reason));
+
+/*
  * sandbox_exec:
  *   Execute |cmd| via /bin/sh -c inside the sandbox described by |cfg|.
  *   The child's stdout/stderr are written to |out_fd|/|err_fd|.

--- a/src/posix/sandbox.c
+++ b/src/posix/sandbox.c
@@ -43,6 +43,82 @@
 #include <unistd.h>
 
 /* -------------------------------------------------------------------------
+ * Audit hook + test seam (see sandbox.h)
+ * ---------------------------------------------------------------------- */
+
+/* Installed once at startup by the server-only bridge; NULL = no audit. */
+static sandbox_audit_hook_fn g_sbx_audit_hook = NULL;
+void sandbox_set_audit_hook(sandbox_audit_hook_fn fn)
+{
+   g_sbx_audit_hook = fn;
+}
+
+/* Test-only availability override (NULL in production). */
+static int (*g_sbx_avail_override)(const char **) = NULL;
+void sandbox_set_available_override_for_test(int (*fn)(const char **reason))
+{
+   g_sbx_avail_override = fn;
+}
+
+void sandbox_command_program(const char *cmd, char *out, size_t out_len)
+{
+   if (!out || out_len == 0)
+      return;
+   out[0] = '\0';
+   if (!cmd)
+      return;
+   const char *p = cmd;
+   for (;;)
+   {
+      while (*p == ' ' || *p == '\t')
+         p++;
+      if (!*p)
+         return;
+      /* Skip a leading `NAME=value` environment assignment (its value may be a
+       * secret) and continue to the real program token. */
+      if ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') || *p == '_')
+      {
+         const char *r = p;
+         while ((*r >= 'A' && *r <= 'Z') || (*r >= 'a' && *r <= 'z') || (*r >= '0' && *r <= '9') ||
+                *r == '_')
+            r++;
+         if (*r == '=')
+         {
+            while (*p && *p != ' ' && *p != '\t')
+               p++;
+            continue;
+         }
+      }
+      break;
+   }
+   const char *end = p;
+   while (*end && *end != ' ' && *end != '\t')
+      end++;
+   const char *base = p;
+   for (const char *s = p; s < end; s++)
+      if (*s == '/')
+         base = s + 1;
+   size_t blen = (size_t)(end - base);
+   if (blen >= out_len)
+      blen = out_len - 1;
+   memcpy(out, base, blen);
+   out[blen] = '\0';
+}
+
+/* Fire the audit hook (if installed) for a degraded-isolation outcome. Extracts
+ * the NON-SECRET program name; never passes the raw command line. */
+static void sbx_audit_degraded(const char *cmd, const sandbox_config_t *cfg, const char *verdict,
+                               const char *reason)
+{
+   sandbox_audit_hook_fn h = g_sbx_audit_hook;
+   if (!h)
+      return;
+   char prog[64];
+   sandbox_command_program(cmd, prog, sizeof prog);
+   h(prog, cfg->mode, cfg->network_isolated, verdict, reason ? reason : "");
+}
+
+/* -------------------------------------------------------------------------
  * Container detection
  * ---------------------------------------------------------------------- */
 
@@ -82,6 +158,8 @@ int sandbox_detect_container(void)
 
 int sandbox_available(const char **reason)
 {
+   if (g_sbx_avail_override)
+      return g_sbx_avail_override(reason);
 #ifndef __linux__
    if (reason)
       *reason = "Linux namespaces not available on this platform";
@@ -585,10 +663,12 @@ static pid_t sandbox_exec_internal(const sandbox_config_t *cfg, const char *cmd,
       {
          log_warn("sandbox: unavailable (%s) — refusing unsandboxed guarded execution",
                   unavail_reason ? unavail_reason : "unknown reason");
+         sbx_audit_degraded(cmd, cfg, "refused", unavail_reason);
          return -1;
       }
       log_warn("sandbox: unavailable (%s) — running unsandboxed",
                unavail_reason ? unavail_reason : "unknown reason");
+      sbx_audit_degraded(cmd, cfg, "unsandboxed_fallback", unavail_reason);
       pid_t pid = fork();
       if (pid == 0)
       {

--- a/src/server/sandbox_audit_bridge.c
+++ b/src/server/sandbox_audit_bridge.c
@@ -1,0 +1,41 @@
+/* sandbox_audit_bridge.c: forwards sandbox degraded-isolation events onto the
+ * audit event bus. The one place that links sandbox.c to the (D7-confined) audit
+ * bus — see sandbox_audit_bridge.h. Only non-secret fields cross here; the raw
+ * command line (which may carry secrets in its arguments) is never in scope — the
+ * hook already reduced it to a bare program name. */
+#include "sandbox_audit_bridge.h"
+
+#include <stdio.h>
+
+#include "audit_action.h" /* audit_args_hash, AUDIT_ARGS_HASH_LEN */
+#include "audit_bus.h"    /* audit_bus_emit */
+#include "sandbox.h"      /* sandbox_audit_hook_fn, sandbox_mode_to_string */
+
+/* sandbox_audit_hook_fn: publish one degraded-isolation audit row over the bus
+ * (KIND_AUDIT_ACTION -> the audit ledger + capture/replay). NON-SECRET only:
+ * actor "sandbox" (a subsystem event, no principal at this primitive), tool
+ * "sandbox.exec", the program name (command), the requested isolation (mode, with
+ * a "+netiso" suffix when network isolation was requested), the availability
+ * reason, and the verdict ("unsandboxed_fallback" / "refused"). No task
+ * association -> task_id 0. */
+static void on_sandbox_degraded(const char *program, sandbox_mode_t mode, int network_isolated,
+                                const char *verdict, const char *reason)
+{
+   char modestr[48];
+   snprintf(modestr, sizeof modestr, "%s%s", sandbox_mode_to_string(mode),
+            network_isolated ? "+netiso" : "");
+
+   /* Keyed per-op fingerprint, uniform with the other audit rows; the program
+    * identity is carried human-readable in the command field. */
+   char args_hash[AUDIT_ARGS_HASH_LEN];
+   snprintf(args_hash, sizeof args_hash, "v1-");
+   audit_args_hash("sandbox.exec", NULL, args_hash, sizeof args_hash);
+
+   audit_bus_emit("sandbox", "sandbox.exec", args_hash, program ? program : "", modestr,
+                  reason ? reason : "", verdict, /*task_id=*/0);
+}
+
+void sandbox_audit_bridge_install(void)
+{
+   sandbox_set_audit_hook(on_sandbox_degraded);
+}

--- a/src/server/sandbox_audit_bridge.h
+++ b/src/server/sandbox_audit_bridge.h
@@ -1,0 +1,16 @@
+#ifndef AIMEE_SANDBOX_AUDIT_BRIDGE_H
+#define AIMEE_SANDBOX_AUDIT_BRIDGE_H 1
+
+/* Install the sandbox degraded-isolation audit hook, forwarding each event
+ * (a guarded exec that ran unsandboxed, or was refused, because the sandbox was
+ * requested but unavailable) to the audit event bus — the same KIND_AUDIT_ACTION
+ * ledger + capture/replay stream the governed-action, guardrail, and vault-access
+ * events use. These rare, high-signal events surface when OS isolation the system
+ * intended to apply did not.
+ *
+ * Server-only by design: this bridge is the single object linking sandbox.c to
+ * the (D7-confined) audit bus, keeping sandbox.o itself bus-free and linkable into
+ * every binary. Call once at server startup, after audit_ensure_key(). */
+void sandbox_audit_bridge_install(void);
+
+#endif /* AIMEE_SANDBOX_AUDIT_BRIDGE_H */

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -34,9 +34,10 @@
 #include "headers/context_engine.h"
 #include "headers/server_cli_oauth.h"
 #include "vault_server_key.h"
-#include "vault_service.h"      /* VAULT_SERVER_PRINCIPAL (rotation target) */
-#include "vault_audit_bridge.h" /* route vault credential-access events onto the audit bus */
-#include "audit_replay.h"       /* --audit-replay: inspect a governed-action capture file */
+#include "vault_service.h"        /* VAULT_SERVER_PRINCIPAL (rotation target) */
+#include "vault_audit_bridge.h"   /* route vault credential-access events onto the audit bus */
+#include "sandbox_audit_bridge.h" /* route sandbox degraded-isolation events onto the audit bus */
+#include "audit_replay.h"         /* --audit-replay: inspect a governed-action capture file */
 #include <signal.h>
 #include <errno.h>
 #include <stdio.h>
@@ -163,8 +164,9 @@ static int run_server(const char *socket_path, log_level_t log_level)
    /* Initialize logging */
    log_init(log_level);
    audit_log_open();
-   audit_ensure_key();           /* provision the per-action audit key (best-effort) */
-   vault_audit_bridge_install(); /* route vault credential-access events onto the audit bus */
+   audit_ensure_key();             /* provision the per-action audit key (best-effort) */
+   vault_audit_bridge_install();   /* route vault credential-access events onto the audit bus */
+   sandbox_audit_bridge_install(); /* route sandbox degraded-isolation events onto the audit bus */
 
    /* Activate the GitHub App installation-token provider for the server's forge
     * identity. Inert unless AIMEE_FORGE_APP_* is set (see forge_app_token.c). */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2912,6 +2912,32 @@ unit-test-bus-vault-audit: $(TESTPREFIX)/unit-test-bus-vault-audit
 # the standard unit-tests build does not assemble, so the bench gate
 # (check_bus_perf_gate.sh) force-builds + runs it via this .PHONY target instead.
 
+# Sandbox degraded-isolation audit, end-to-end through the REAL server bridge
+# (sandbox_audit_bridge.o) -> audit_bus -> ledger. Same bus link set as the audit
+# durability test, plus the bridge, posix/sandbox.o, and audit_action.o.
+$(TESTPREFIX)/unit-test-bus-sandbox-audit: $(OBJDIR)/tests/test_bus_sandbox_audit.o \
+                                           $(OBJDIR)/server/sandbox_audit_bridge.o \
+                                           $(OBJDIR)/posix/sandbox.o \
+                                           $(OBJDIR)/modules/audit/audit_bus.o \
+                                           $(OBJDIR)/modules/audit/audit_ledger.o \
+                                           $(OBJDIR)/modules/audit/audit_action.o \
+                                           $(OBJDIR)/modules/workflows/wfe_canonical.o \
+                                           $(OBJDIR)/aimee_home.o \
+                                           $(OBJDIR)/modules/bus/bus_client.o \
+                                           $(OBJDIR)/modules/bus/bus_host.o \
+                                           $(OBJDIR)/modules/bus/bus_route.o \
+                                           $(OBJDIR)/modules/bus/bus_region.o \
+                                           $(OBJDIR)/modules/bus/bus_ring.o \
+                                           $(OBJDIR)/modules/bus/bus_arena.o \
+                                           $(OBJDIR)/modules/bus/bus_wire.o \
+                                           $(OBJDIR)/modules/bus/bus_capture.o \
+                                           $(BUS_MEM_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lpthread
+
+.PHONY: unit-test-bus-sandbox-audit
+unit-test-bus-sandbox-audit: $(TESTPREFIX)/unit-test-bus-sandbox-audit
+	$<
+
 # Shutdown race: concurrent producers vs audit_bus_stop() (regression test for the
 # in-flight-emit-vs-teardown UAF). Same link set as the guardrail durability test.
 $(OBJDIR)/tests/test_bus_shutdown_race.o: C_FLAGS += -Imodules/bus

--- a/src/tests/test_bus_sandbox_audit.c
+++ b/src/tests/test_bus_sandbox_audit.c
@@ -1,0 +1,120 @@
+/* test_bus_sandbox_audit.c: the sandbox degraded-isolation audit trail, END TO
+ * END through the REAL server bridge (sandbox_audit_bridge.c) onto the audit
+ * event bus and into the ledger.
+ *
+ * test_sandbox.c pins sandbox -> hook (a capturing stub). This pins the other
+ * half: the real bridge's field mapping. It installs sandbox_audit_bridge_install
+ * + forces the sandbox unavailable (so a guarded exec degrades), drives a real
+ * sandbox_exec fallback, drains the async bus, then reads the ledger back and
+ * asserts the row's actor/tool/command/mode/verdict — and that NO secret from the
+ * command's env-assignment prefix leaked into the trail.
+ */
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "audit_action.h" /* audit_ensure_key */
+#include "audit_bus.h"
+#include "audit_ledger.h"
+#include "cJSON.h"
+#include "log.h" /* audit_log_open */
+#include "sandbox.h"
+#include "server/sandbox_audit_bridge.h"
+
+static const char *sval(cJSON *row, const char *key)
+{
+   const char *v = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(row, key));
+   return v ? v : "";
+}
+
+static cJSON *find_row(cJSON *rows, const char *tool, const char *command)
+{
+   cJSON *r = NULL;
+   cJSON_ArrayForEach(r, rows)
+   {
+      if (strcmp(sval(r, "tool"), tool) == 0 && strcmp(sval(r, "command"), command) == 0)
+         return r;
+   }
+   return NULL;
+}
+
+static int avail_unavailable(const char **reason)
+{
+   if (reason)
+      *reason = "forced-unavailable (test)";
+   return 0;
+}
+
+int main(void)
+{
+   printf("test_bus_sandbox_audit:\n");
+
+   char home[] = "/tmp/aimee-bussbx-XXXXXX";
+   if (!mkdtemp(home))
+   {
+      fprintf(stderr, "FAIL: tmp home\n");
+      return 1;
+   }
+   setenv("AIMEE_HOME", home, 1);
+   audit_log_open();
+   audit_ensure_key();
+
+   /* Install the REAL bridge + force degradation deterministically. */
+   sandbox_audit_bridge_install();
+   sandbox_set_available_override_for_test(avail_unavailable);
+
+   int devnull = open("/dev/null", O_WRONLY);
+   assert(devnull >= 0);
+
+   sandbox_config_t cfg;
+   memset(&cfg, 0, sizeof cfg);
+   cfg.mode = SANDBOX_MODE_WORKSPACE_ONLY;
+   cfg.network_isolated = 1;
+
+   /* A guarded exec that falls back to unsandboxed (secret in the env prefix). */
+   const char *secret = "sk-sandbox-DO-NOT-LOG-4b2a";
+   char cmd[128];
+   snprintf(cmd, sizeof cmd, "APIKEY=%s /usr/bin/true", secret);
+   pid_t pid = sandbox_exec(&cfg, cmd, devnull, devnull, NULL);
+   assert(pid > 0);
+   waitpid(pid, NULL, 0);
+
+   /* A require-isolation exec that is refused. */
+   pid_t rc = sandbox_exec_with_readonly(&cfg, "npm publish", devnull, devnull, NULL, NULL, NULL);
+   assert(rc == -1);
+
+   audit_bus_stop(); /* drain to the ledger */
+
+   cJSON *rows = audit_ledger_read(NULL, NULL);
+   assert(rows);
+
+   /* The fallback row: actor=sandbox, program in command, mode workspace_only+netiso. */
+   cJSON *fb = find_row(rows, "sandbox.exec", "true");
+   assert(fb);
+   assert(strcmp(sval(fb, "actor"), "sandbox") == 0);
+   assert(strcmp(sval(fb, "verdict"), "unsandboxed_fallback") == 0);
+   assert(strcmp(sval(fb, "mode"), "workspace_only+netiso") == 0);
+   assert(sval(fb, "reason_code")[0] != '\0');
+
+   /* The refused row. */
+   cJSON *rf = find_row(rows, "sandbox.exec", "npm");
+   assert(rf);
+   assert(strcmp(sval(rf, "verdict"), "refused") == 0);
+
+   /* THE invariant: the secret in the command's env prefix never reached the ledger. */
+   char *dump = cJSON_PrintUnformatted(rows);
+   assert(dump);
+   assert(!strstr(dump, secret));
+   free(dump);
+
+   cJSON_Delete(rows);
+   sandbox_set_available_override_for_test(NULL);
+   close(devnull);
+   printf("test_bus_sandbox_audit: OK (degraded isolation -> bridge -> bus -> ledger; no secret "
+          "leak)\n");
+   return 0;
+}

--- a/src/tests/test_sandbox.c
+++ b/src/tests/test_sandbox.c
@@ -1,8 +1,11 @@
 /* test_sandbox.c: unit tests for sandbox config parsing, container detection,
- * and availability checks. */
+ * availability checks, and the degraded-isolation audit hook. */
 #include <assert.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "sandbox.h"
 
@@ -84,6 +87,133 @@ static void test_config_defaults(void)
 }
 
 /* -------------------------------------------------------------------------
+ * sandbox_command_program — NON-SECRET program extraction
+ * ---------------------------------------------------------------------- */
+
+static void test_command_program(void)
+{
+   char out[64];
+
+   sandbox_command_program("npm install left-pad", out, sizeof out);
+   assert(strcmp(out, "npm") == 0);
+
+   sandbox_command_program("/usr/bin/python3 -c 'print(1)'", out, sizeof out);
+   assert(strcmp(out, "python3") == 0);
+
+   /* Leading env assignments (which may carry secrets) are skipped, and their
+    * values NEVER appear in the extracted program name. */
+   sandbox_command_program("TOKEN=sk-secret-abc curl https://x/api?key=sk-secret-abc", out,
+                           sizeof out);
+   assert(strcmp(out, "curl") == 0);
+   assert(strstr(out, "sk-secret") == NULL);
+
+   sandbox_command_program("  FOO=1 BAR=2 /bin/ls -la", out, sizeof out);
+   assert(strcmp(out, "ls") == 0);
+
+   sandbox_command_program("", out, sizeof out);
+   assert(out[0] == '\0');
+   out[0] = 'x';
+   sandbox_command_program(NULL, out, sizeof out);
+   assert(out[0] == '\0');
+
+   printf("  PASS: test_command_program\n");
+}
+
+/* -------------------------------------------------------------------------
+ * degraded-isolation audit hook
+ * ---------------------------------------------------------------------- */
+
+static struct
+{
+   int calls;
+   char program[64];
+   sandbox_mode_t mode;
+   int network_isolated;
+   char verdict[32];
+   char reason[64];
+} g_last;
+
+static void capture_hook(const char *program, sandbox_mode_t mode, int network_isolated,
+                         const char *verdict, const char *reason)
+{
+   g_last.calls++;
+   snprintf(g_last.program, sizeof g_last.program, "%s", program);
+   g_last.mode = mode;
+   g_last.network_isolated = network_isolated;
+   snprintf(g_last.verdict, sizeof g_last.verdict, "%s", verdict);
+   snprintf(g_last.reason, sizeof g_last.reason, "%s", reason);
+}
+
+/* The override forces the sandbox "unavailable" so the degraded paths are
+ * deterministically reached regardless of the host kernel. */
+static int avail_unavailable(const char **reason)
+{
+   if (reason)
+      *reason = "forced-unavailable (test)";
+   return 0;
+}
+
+static void test_audit_hook_degraded(void)
+{
+   int devnull = open("/dev/null", O_WRONLY);
+   assert(devnull >= 0);
+
+   sandbox_set_available_override_for_test(avail_unavailable);
+   sandbox_set_audit_hook(capture_hook);
+
+   sandbox_config_t cfg;
+   memset(&cfg, 0, sizeof cfg);
+   cfg.mode = SANDBOX_MODE_WORKSPACE_ONLY;
+   cfg.network_isolated = 1;
+
+   /* A non-require-isolation guarded exec falls back to running UNSANDBOXED when
+    * the sandbox is unavailable — audited, and the command's secret-bearing env
+    * assignment must not leak (only the program name crosses). */
+   memset(&g_last, 0, sizeof g_last);
+   pid_t pid = sandbox_exec(&cfg, "TOKEN=sk-leak-9z /usr/bin/true", devnull, devnull, NULL);
+   assert(pid > 0);
+   waitpid(pid, NULL, 0);
+   assert(g_last.calls == 1);
+   assert(strcmp(g_last.program, "true") == 0);
+   assert(strstr(g_last.program, "sk-leak") == NULL);
+   assert(g_last.mode == SANDBOX_MODE_WORKSPACE_ONLY);
+   assert(g_last.network_isolated == 1);
+   assert(strcmp(g_last.verdict, "unsandboxed_fallback") == 0);
+   assert(g_last.reason[0] != '\0');
+
+   /* A require-isolation exec is REFUSED (-1) rather than downgraded — audited. */
+   memset(&g_last, 0, sizeof g_last);
+   pid_t rc =
+       sandbox_exec_with_readonly(&cfg, "curl https://x", devnull, devnull, NULL, NULL, NULL);
+   assert(rc == -1);
+   assert(g_last.calls == 1);
+   assert(strcmp(g_last.program, "curl") == 0);
+   assert(strcmp(g_last.verdict, "refused") == 0);
+
+   /* mode==off is NOT a degradation: it runs unsandboxed by policy, no audit. */
+   memset(&g_last, 0, sizeof g_last);
+   sandbox_config_t off;
+   memset(&off, 0, sizeof off);
+   off.mode = SANDBOX_MODE_OFF;
+   pid = sandbox_exec(&off, "/usr/bin/true", devnull, devnull, NULL);
+   assert(pid > 0);
+   waitpid(pid, NULL, 0);
+   assert(g_last.calls == 0);
+
+   /* A NULL hook records nothing (no crash). */
+   sandbox_set_audit_hook(NULL);
+   memset(&g_last, 0, sizeof g_last);
+   pid = sandbox_exec(&cfg, "/usr/bin/true", devnull, devnull, NULL);
+   assert(pid > 0);
+   waitpid(pid, NULL, 0);
+   assert(g_last.calls == 0);
+
+   sandbox_set_available_override_for_test(NULL);
+   close(devnull);
+   printf("  PASS: test_audit_hook_degraded\n");
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 
@@ -96,6 +226,8 @@ int main(void)
    test_available_returns_int_with_reason();
    test_available_null_reason_ok();
    test_config_defaults();
+   test_command_program();
+   test_audit_hook_degraded();
 
    printf("sandbox: all tests passed\n");
    return 0;


### PR DESCRIPTION
## What

The **sandbox half** of the vault/sandbox audit-events increment (vault half was #1939). When a guarded tool exec requests OS isolation (`mode != off`) but the sandbox is **unavailable**, `sandbox_exec` either runs the command **unsandboxed** (fallback) or **refuses** it (require-isolation callers). These rare, high-signal security events now emit a non-secret audit row onto the same `KIND_AUDIT_ACTION` ledger + capture/replay stream the governed-action, guardrail, and vault-access events use — surfacing when isolation the system *intended* to apply did not.

**Scope is deliberate:** a routine *successful* sandboxed exec is **not** recorded — that's high-volume, low-signal, and would evict governance rows from the rotating ledger. We audit the *exceptions* (isolation degraded/refused), which is exactly what a record+replay audit trail wants.

## Design — same dependency inversion as the vault bridge (D7 intact)

`posix/sandbox.o` links into many binaries, so a direct bus call would blow the D7 blast-radius gate. Instead:
- `sandbox.c` exposes a **NULL-default audit hook** (`sandbox_set_audit_hook`) — zero bus dependency, stays linkable everywhere.
- A single **server-only bridge** (`server/sandbox_audit_bridge.c`) maps the hook → `audit_bus_emit`, installed at server startup.

## Secret safety

Only the program **name** crosses the boundary. `sandbox_command_program` strips leading `VAR=value` env-assignment prefixes (which can carry secrets/tokens) and all arguments, surfacing just the basename — e.g. `TOKEN=sk-.. /usr/bin/npm install x` → `npm`. Both the unit test and the bridge test assert no secret reaches the trail.

## Determinism

The degradation paths depend on the host kernel/container. A **test-only** availability override (`sandbox_set_available_override_for_test`, NULL in production — no footgun) makes them deterministically reachable in tests.

## Row shape

`actor`=`sandbox`, `tool`=`sandbox.exec`, `command`=program name, `mode`=`workspace_only`/`allowlist`(+`+netiso`), `reason_code`=availability reason, `verdict`=`unsandboxed_fallback`/`refused`.

## Verification

- `aimee-server` + all shipping binaries build & link.
- **D7 blast-radius gate: green** (all 7 shipping binaries inspected, no bus symbol).
- clang-format-19 clean; **655 test binaries link** (no ripple).
- `test_sandbox` (program extraction incl. no-leak, degraded-hook, mode=off no-op, NULL-hook no-op) passes.
- `test_bus_sandbox_audit` (real bridge → bus → ledger, fields + no-secret) passes; run via the bench gate like the other bus tests.
- Full `check_bus_perf_gate` green: dispatch + audit durability + vault-access + sandbox audit all hold.