### PR TITLE
Reclaim per-session claude HOME on delegate exit

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -99,9 +99,13 @@ FROM runtime-web-stage-${WITH_RUNTIME_WEB} AS runtime-web-stage
 FROM debian:bookworm-slim AS code-server-stage-1
 ARG TARGETARCH
 ARG CODE_SERVER_VERSION=4.96.4
+# Release downloads go through GitHub/CDN edges that intermittently return 5xx
+# (a 504 here failed the whole T3 e2e-docker topology). `curl -fsSL` alone turns
+# that into a hard build failure, so retry with backoff. --retry-all-errors is
+# required: -f makes an HTTP 504 exit 22, which plain --retry would NOT retry.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
-    && curl -fsSL "https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_${TARGETARCH}.deb" -o /tmp/cs.deb \
+    && curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors --retry-max-time 180 --connect-timeout 30 "https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_${TARGETARCH}.deb" -o /tmp/cs.deb \
     && mkdir -p /opt/codeserver \
     && dpkg-deb -x /tmp/cs.deb /opt/codeserver \
     && rm /tmp/cs.deb \
@@ -157,12 +161,12 @@ RUN set -eux; \
       arm64) darch=aarch64; carch=aarch64 ;; \
       *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL "https://download.docker.com/linux/static/stable/${darch}/docker-${DOCKER_CLI_VERSION}.tgz" \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors --retry-max-time 180 --connect-timeout 30 "https://download.docker.com/linux/static/stable/${darch}/docker-${DOCKER_CLI_VERSION}.tgz" \
       | tar -xz -C /tmp docker/docker; \
     install -m0755 /tmp/docker/docker /usr/local/bin/docker; \
     rm -rf /tmp/docker; \
     mkdir -p /usr/local/lib/docker/cli-plugins; \
-    curl -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${carch}" \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors --retry-max-time 180 --connect-timeout 30 "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${carch}" \
       -o /usr/local/lib/docker/cli-plugins/docker-compose; \
     chmod 0755 /usr/local/lib/docker/cli-plugins/docker-compose; \
     docker --version; docker compose version
@@ -175,7 +179,7 @@ ARG GH_CLI_VERSION=2.96.0
 RUN set -eux; \
     gharch="${TARGETARCH:-amd64}"; \
     case "$gharch" in amd64|arm64) ;; *) echo "unsupported TARGETARCH=${gharch}" >&2; exit 1 ;; esac; \
-    curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${gharch}.tar.gz" \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors --retry-max-time 180 --connect-timeout 30 "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${gharch}.tar.gz" \
       | tar -xz -C /tmp "gh_${GH_CLI_VERSION}_linux_${gharch}/bin/gh"; \
     install -m0755 "/tmp/gh_${GH_CLI_VERSION}_linux_${gharch}/bin/gh" /usr/local/bin/gh; \
     rm -rf "/tmp/gh_${GH_CLI_VERSION}_linux_${gharch}"; \

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -38,6 +38,12 @@ typedef struct
    /* Clean response text already streamed to the caller this turn (so recv emits
     * only the growth as an incremental delta). malloc'd; freed on destroy. */
    char *stream_emitted;
+   /* Per-session claude HOME minted by cli_session_isolated_claude_home for an
+    * isolated delegate seat (NULL when the seat runs in the shared HOME). Owned by
+    * the session: cli_session_destroy rm-rf's the tree and frees this, so the home
+    * is reclaimed the moment the delegate exits instead of lingering for the 1h
+    * age-based sweep. malloc'd. */
+   char *iso_home;
 } cli_session_t;
 
 /* Incremental stream callback: invoked by cli_session_recv with each newly
@@ -122,6 +128,12 @@ void cli_session_prepare_claude(const char *work_dir, int autonomous);
  * home_out on success, -1 on any failure (caller then uses the shared HOME).
  * Reaps per-session homes older than an hour on each call. */
 int cli_session_isolated_claude_home(const char *work_dir, char *home_out, size_t home_out_sz);
+
+/* Hand a minted isolated HOME (from cli_session_isolated_claude_home) to the
+ * session so cli_session_destroy reclaims it on exit. Copies `home`; pass NULL to
+ * clear. Call after a successful cli_session_create so every teardown path (error
+ * or normal) removes the home. No-op-safe when the seat uses the shared HOME. */
+void cli_session_set_isolated_home(cli_session_t *s, const char *home);
 
 /* Kills the tmux session. No-op if already dead. */
 void cli_session_destroy(cli_session_t *s);

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -128,9 +128,12 @@ static int cli_session_execute_inner(const agent_t *agent, const agent_network_t
     * interactive session is single, so it keeps the shared HOME. Best-effort: a
     * failed mint leaves cli_cmd untouched (shared HOME, prior behavior). */
    char cli_cmd_home[CLI_SESSION_CMD_MAX];
+   /* Hoisted so the minted path survives past this block to be handed to the
+    * session after create (empty = no isolated home was minted). */
+   char iso_home[PATH_MAX];
+   iso_home[0] = '\0';
    if (is_claude && deleg)
    {
-      char iso_home[PATH_MAX];
       if (cli_session_isolated_claude_home(cwd, iso_home, sizeof(iso_home)) == 0)
       {
          int n = snprintf(cli_cmd_home, sizeof(cli_cmd_home), "HOME='%s' %s", iso_home, cli_cmd);
@@ -182,6 +185,12 @@ static int cli_session_execute_inner(const agent_t *agent, const agent_network_t
    }
    /* cli_kind drives the TUI response parser (claude ●/❯/✻ vs codex •/›). */
    cli_session_set_kind(&sess, agent->cli_kind[0] ? agent->cli_kind : agent->name);
+
+   /* Hand the minted per-session HOME to the session so every teardown path
+    * (error or normal) rm-rf's it — homes are reclaimed on delegate exit rather
+    * than lingering until the 1h age sweep. No-op when no isolated home was minted. */
+   if (iso_home[0])
+      cli_session_set_isolated_home(&sess, iso_home);
 
    size_t plen = (system_prompt ? strlen(system_prompt) : 0) + strlen(user_prompt) + 4;
    char *full_prompt = malloc(plen);

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -144,6 +144,14 @@ void cli_session_set_kind(cli_session_t *s, const char *cli_kind)
    snprintf(s->cli_kind, sizeof(s->cli_kind), "%s", cli_kind ? cli_kind : "");
 }
 
+void cli_session_set_isolated_home(cli_session_t *s, const char *home)
+{
+   if (!s)
+      return;
+   free(s->iso_home);
+   s->iso_home = (home && home[0]) ? strdup(home) : NULL;
+}
+
 void cli_session_mark_baseline(cli_session_t *s)
 {
    if (!s)
@@ -645,6 +653,17 @@ void cli_session_destroy(cli_session_t *s)
    s->baseline = NULL;
    free(s->stream_emitted);
    s->stream_emitted = NULL;
+   /* Reclaim the isolated claude HOME the moment the seat tears down, so homes
+    * track the delegate lifecycle instead of piling up until the 1h age sweep.
+    * Unconditional (before the active/alive early-returns): a home may have been
+    * minted for a seat whose tmux session already died. cli_rmrf uses FTW_PHYS, so
+    * the symlinked shared credential/settings targets are never followed. */
+   if (s->iso_home)
+   {
+      cli_rmrf(s->iso_home);
+      free(s->iso_home);
+      s->iso_home = NULL;
+   }
    if (!s->active)
       return;
    if (!cli_session_is_alive(s))

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -1104,8 +1104,8 @@ static void test_isolated_home_reclaimed_on_destroy(void)
    assert(s.iso_home && strcmp(s.iso_home, home) == 0);
    cli_session_destroy(&s);
 
-   assert(stat(home, &st) != 0); /* the whole home tree is gone */
-   assert(s.iso_home == NULL);   /* handle freed + cleared */
+   assert(stat(home, &st) != 0);                    /* the whole home tree is gone */
+   assert(s.iso_home == NULL);                      /* handle freed + cleared */
    assert(stat(creds, &st) == 0 && st.st_size > 0); /* shared credential untouched */
 
    /* Idempotent / safe on a session with no isolated home. */

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -1068,9 +1068,62 @@ static void test_isolated_claude_home(void)
    printf("  PASS: test_isolated_claude_home\n");
 }
 
+/* cli_session_destroy reclaims the minted isolated HOME so homes track the
+ * delegate lifecycle instead of lingering until the 1h age sweep. Also pins the
+ * FTW_PHYS safety: the SHARED credential the home symlinks to must survive. */
+static void test_isolated_home_reclaimed_on_destroy(void)
+{
+   char shared[128];
+   snprintf(shared, sizeof(shared), "/tmp/aimee-isorm-%d", (int)getpid());
+   char cdir[192], creds[288], json[288];
+   snprintf(cdir, sizeof(cdir), "%s/.claude", shared);
+   mkdir(shared, 0700);
+   mkdir(cdir, 0700);
+   snprintf(creds, sizeof(creds), "%s/.credentials.json", cdir);
+   snprintf(json, sizeof(json), "%s/.claude.json", shared);
+   FILE *f = fopen(creds, "w");
+   assert(f);
+   fputs("{\"token\":\"x\"}", f);
+   fclose(f);
+   f = fopen(json, "w");
+   assert(f);
+   fputs("{\"oauthAccount\":{\"id\":\"a\"}}", f);
+   fclose(f);
+   setenv("HOME", shared, 1);
+
+   char home[PATH_MAX];
+   assert(cli_session_isolated_claude_home("/w/d", home, sizeof(home)) == 0);
+   struct stat st;
+   assert(stat(home, &st) == 0 && S_ISDIR(st.st_mode)); /* minted on disk */
+
+   /* A never-created (active=0) session still reclaims its attached home on
+    * destroy — cleanup runs before the active/alive early-returns. */
+   cli_session_t s;
+   memset(&s, 0, sizeof(s));
+   cli_session_set_isolated_home(&s, home);
+   assert(s.iso_home && strcmp(s.iso_home, home) == 0);
+   cli_session_destroy(&s);
+
+   assert(stat(home, &st) != 0); /* the whole home tree is gone */
+   assert(s.iso_home == NULL);   /* handle freed + cleared */
+   assert(stat(creds, &st) == 0 && st.st_size > 0); /* shared credential untouched */
+
+   /* Idempotent / safe on a session with no isolated home. */
+   cli_session_t s2;
+   memset(&s2, 0, sizeof(s2));
+   cli_session_destroy(&s2);
+
+   unlink(creds);
+   unlink(json);
+   rmdir(cdir);
+   rmdir(shared);
+   printf("  PASS: test_isolated_home_reclaimed_on_destroy\n");
+}
+
 int main(void)
 {
    test_isolated_claude_home();
+   test_isolated_home_reclaimed_on_destroy();
 
    printf("test_resolve_cwd_existing_used... ");
    test_resolve_cwd_existing_used();


### PR DESCRIPTION
## Problem

The per-session `~/.claude` HOME minted for each Claude delegate seat (#1936) was never reclaimed at teardown. `cli_session_isolated_claude_home` mints the home in `agent_runtime_tmux.c`, bakes it into the tmux command as `HOME='…'`, then **discards the path** — `cli_session_destroy` had no handle on it. The only reclaim was `cli_claude_homes_sweep` (mtime > 1h), fired lazily on the *next* mint.

Result: each home lingered up to an hour after its delegate exited, each holding the CLI's full `~/.claude` working tree (projects/history/shell-snapshots; the shared one is ~47M). Under sustained roundtable/impl concurrency the homes pile up (observed 5 → 18 live on the appliance in ~40m).

## Fix

Tie cleanup to the session lifecycle:
- `cli_session_t` gains an owned `iso_home`; `cli_session_set_isolated_home()` attaches the minted path after a successful `create()`.
- `cli_session_destroy()` rm-rf's it **before** the active/alive early-returns, so every teardown path (error or normal) reclaims it. `cli_rmrf` uses `FTW_PHYS` → the symlinked shared credential/settings targets are removed as links, never followed.
- The 1h sweep stays only as a crash backstop (server killed mid-turn).

## Test

`test_isolated_home_reclaimed_on_destroy`: mints a real home, attaches it, destroys, asserts the tree is gone, the handle is cleared, and the **shared credential survives** (pins the FTW_PHYS safety). Full `cli_session` suite green; server builds clean under `-Werror`.