### PR TITLE
Fix secret leak in sandbox program extraction (convergence fixes for #1942)

### DIFF
--- a/src/headers/sandbox.h
+++ b/src/headers/sandbox.h
@@ -81,6 +81,16 @@ void sandbox_command_program(const char *cmd, char *out, size_t out_len);
  * Installed once at startup by a server-only bridge that forwards to the audit
  * event bus; sandbox.c itself has NO event-bus dependency (stays linkable into
  * every binary). NULL by default. Set once before serving.
+ *
+ * Coverage note (deliberate limitation): the hook fires for degradations the
+ * PARENT observes — the sandbox being unavailable before the fork, and a
+ * require-isolation child reporting failed in-namespace setup. A NON-require-
+ * isolation exec whose child fails unshare()/mount-ns setup AFTER the fork execs
+ * unsandboxed without a parent-visible signal, so that case is NOT audited. It is
+ * rare (availability was already confirmed) and closing it would require the
+ * parent to block on a child status byte on every exec; the trail therefore
+ * records "requested-but-unavailable" and "refused" degradations, not every
+ * possible post-fork downgrade.
  */
 typedef void (*sandbox_audit_hook_fn)(const char *program, sandbox_mode_t mode,
                                       int network_isolated, const char *verdict,

--- a/src/posix/sandbox.c
+++ b/src/posix/sandbox.c
@@ -60,6 +60,45 @@ void sandbox_set_available_override_for_test(int (*fn)(const char **reason))
    g_sbx_avail_override = fn;
 }
 
+/* Characters allowed in a bare program path we are willing to surface verbatim.
+ * A real program token is a plain path; anything else is refused (see below). */
+static int sbx_prog_char(char c)
+{
+   return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' ||
+          c == '/' || c == '.' || c == '-' || c == '+';
+}
+
+/* True if the whitespace-delimited token [tok, end) is a SIMPLE `NAME=value`
+ * environment assignment whose whole token is safe to skip: the value must
+ * contain no shell byte that could span the whitespace boundary or start a
+ * construct (quote, '$', backtick, backslash) or otherwise smuggle secret bytes
+ * into the next token. Anything fancier and we refuse to keep parsing. */
+static int sbx_is_simple_assignment(const char *tok, const char *end)
+{
+   const char *p = tok;
+   if (!((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') || *p == '_'))
+      return 0;
+   while (p < end && ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') ||
+                      (*p >= '0' && *p <= '9') || *p == '_'))
+      p++;
+   if (p >= end || *p != '=')
+      return 0; /* not NAME= */
+   for (const char *v = p + 1; v < end; v++)
+   {
+      char c = *v;
+      if (c == '\'' || c == '"' || c == '$' || c == '`' || c == '\\' || c == '(' || c == ')' ||
+          c == ';' || c == '&' || c == '|' || c == '<' || c == '>' || c == '{' || c == '}')
+         return 0;
+   }
+   return 1;
+}
+
+/* Safe-by-construction: emit the program basename ONLY when the command is a run
+ * of simple `NAME=value` assignments followed by a bare program path. Any shell
+ * construct in the way — a leading subshell '(', a quote, '$', a value that spans
+ * whitespace, an assignment we can't cleanly skip — could carry secret bytes, so
+ * we emit the fixed marker "unparsed" instead of raw command text. Emitting NO
+ * program bytes is strictly safer than risking a secret in the audit trail. */
 void sandbox_command_program(const char *cmd, char *out, size_t out_len)
 {
    if (!out || out_len == 0)
@@ -73,27 +112,28 @@ void sandbox_command_program(const char *cmd, char *out, size_t out_len)
       while (*p == ' ' || *p == '\t')
          p++;
       if (!*p)
-         return;
-      /* Skip a leading `NAME=value` environment assignment (its value may be a
-       * secret) and continue to the real program token. */
-      if ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') || *p == '_')
+         return; /* only assignments / blank — no program to name */
+      const char *end = p;
+      while (*end && *end != ' ' && *end != '\t')
+         end++;
+      if (sbx_is_simple_assignment(p, end))
       {
-         const char *r = p;
-         while ((*r >= 'A' && *r <= 'Z') || (*r >= 'a' && *r <= 'z') || (*r >= '0' && *r <= '9') ||
-                *r == '_')
-            r++;
-         if (*r == '=')
-         {
-            while (*p && *p != ' ' && *p != '\t')
-               p++;
-            continue;
-         }
+         p = end; /* skip the whole assignment token, value included */
+         continue;
       }
-      break;
+      break; /* p..end is the program-token candidate */
    }
    const char *end = p;
    while (*end && *end != ' ' && *end != '\t')
       end++;
+   for (const char *s = p; s < end; s++)
+   {
+      if (!sbx_prog_char(*s))
+      {
+         snprintf(out, out_len, "unparsed");
+         return;
+      }
+   }
    const char *base = p;
    for (const char *s = p; s < end; s++)
       if (*s == '/')
@@ -798,6 +838,10 @@ static pid_t sandbox_exec_internal(const sandbox_config_t *cfg, const char *cmd,
       close(setup_pipe[0]);
       if (n != 1 || setup_status != '1')
       {
+         /* Child reported that in-namespace setup (unshare / mount ns) failed;
+          * a require-isolation exec is refused rather than downgraded. This is a
+          * child-side degradation the parent CAN observe, so it is audited. */
+         sbx_audit_degraded(cmd, cfg, "refused", "namespace setup failed in child");
          waitpid(pid, NULL, 0);
          return -1;
       }

--- a/src/tests/test_bus_sandbox_audit.c
+++ b/src/tests/test_bus_sandbox_audit.c
@@ -76,10 +76,24 @@ int main(void)
    cfg.network_isolated = 1;
 
    /* A guarded exec that falls back to unsandboxed (secret in the env prefix). */
-   const char *secret = "sk-sandbox-DO-NOT-LOG-4b2a";
-   char cmd[128];
-   snprintf(cmd, sizeof cmd, "APIKEY=%s /usr/bin/true", secret);
+   const char *env_secret = "sk-sandbox-env-DO-NOT-LOG-4b2a";
+   char cmd[160];
+   snprintf(cmd, sizeof cmd, "APIKEY=%s /usr/bin/true", env_secret);
    pid_t pid = sandbox_exec(&cfg, cmd, devnull, devnull, NULL);
+   assert(pid > 0);
+   waitpid(pid, NULL, 0);
+
+   /* A fallback with network isolation OFF and a secret in the ARGUMENTS: the mode
+    * must have no "+netiso" suffix, and the arg secret must not reach the ledger
+    * (only the program name "curl" is surfaced). */
+   const char *arg_secret = "sk-sandbox-arg-DO-NOT-LOG-9c3e";
+   sandbox_config_t noneti;
+   memset(&noneti, 0, sizeof noneti);
+   noneti.mode = SANDBOX_MODE_ALLOWLIST;
+   noneti.network_isolated = 0;
+   char cmd2[160];
+   snprintf(cmd2, sizeof cmd2, "/usr/bin/curl -H authorization:%s https://x", arg_secret);
+   pid = sandbox_exec(&noneti, cmd2, devnull, devnull, NULL);
    assert(pid > 0);
    waitpid(pid, NULL, 0);
 
@@ -92,23 +106,32 @@ int main(void)
    cJSON *rows = audit_ledger_read(NULL, NULL);
    assert(rows);
 
-   /* The fallback row: actor=sandbox, program in command, mode workspace_only+netiso. */
+   /* The fallback row: actor=sandbox, program in command, mode workspace_only+netiso,
+    * and the reason_code carries the (test-forced) availability reason verbatim. */
    cJSON *fb = find_row(rows, "sandbox.exec", "true");
    assert(fb);
    assert(strcmp(sval(fb, "actor"), "sandbox") == 0);
    assert(strcmp(sval(fb, "verdict"), "unsandboxed_fallback") == 0);
    assert(strcmp(sval(fb, "mode"), "workspace_only+netiso") == 0);
-   assert(sval(fb, "reason_code")[0] != '\0');
+   assert(strcmp(sval(fb, "reason_code"), "forced-unavailable (test)") == 0);
+
+   /* The network-isolation-off row: mode is "allowlist" with NO "+netiso" suffix. */
+   cJSON *nn = find_row(rows, "sandbox.exec", "curl");
+   assert(nn);
+   assert(strcmp(sval(nn, "mode"), "allowlist") == 0);
+   assert(strstr(sval(nn, "mode"), "netiso") == NULL);
 
    /* The refused row. */
    cJSON *rf = find_row(rows, "sandbox.exec", "npm");
    assert(rf);
    assert(strcmp(sval(rf, "verdict"), "refused") == 0);
 
-   /* THE invariant: the secret in the command's env prefix never reached the ledger. */
+   /* THE invariant: NO secret — from the env prefix OR the arguments — ever reached
+    * any field of any ledger row. */
    char *dump = cJSON_PrintUnformatted(rows);
    assert(dump);
-   assert(!strstr(dump, secret));
+   assert(!strstr(dump, env_secret));
+   assert(!strstr(dump, arg_secret));
    free(dump);
 
    cJSON_Delete(rows);

--- a/src/tests/test_sandbox.c
+++ b/src/tests/test_sandbox.c
@@ -110,6 +110,37 @@ static void test_command_program(void)
    sandbox_command_program("  FOO=1 BAR=2 /bin/ls -la", out, sizeof out);
    assert(strcmp(out, "ls") == 0);
 
+   /* A value with no shell-special byte (even one containing '=') is a simple
+    * assignment and is skipped whole. */
+   sandbox_command_program("URL=http://x/a-b_c /usr/bin/wget", out, sizeof out);
+   assert(strcmp(out, "wget") == 0);
+
+   /* The first program of a pipeline is named; the rest are arguments (no leak). */
+   sandbox_command_program("npm run build | tee out.log", out, sizeof out);
+   assert(strcmp(out, "npm") == 0);
+
+   /* --- adversarial forms that MUST NOT leak: each yields the "unparsed" marker,
+    * never the secret-bearing bytes. These pin the safe-by-construction parser. */
+   const char *leaky[] = {
+       "(TOKEN=sk-secret-123 npm publish)",         /* subshell prefix */
+       "PASS='hunter2 secretword' /usr/bin/deploy", /* quoted value spanning ws */
+       "TOKEN=$(cat /run/secrets/api_key) curl x",  /* command substitution */
+       "'TOKEN=sk-secret' cmd",                     /* leading quote */
+       "\"KEY=sk-secret\" cmd",                     /* leading dquote */
+       "FOO=a\\ b realcmd",                         /* backslash-escaped space */
+       "FOO=x;curl evil",                           /* metachar in value */
+       "$SECRETVAR",                                /* leading '$' */
+       "`id`",                                      /* backtick */
+       NULL,
+   };
+   for (int i = 0; leaky[i]; i++)
+   {
+      sandbox_command_program(leaky[i], out, sizeof out);
+      assert(strcmp(out, "unparsed") == 0);
+      assert(strstr(out, "secret") == NULL && strstr(out, "hunter2") == NULL &&
+             strstr(out, "api_key") == NULL);
+   }
+
    sandbox_command_program("", out, sizeof out);
    assert(out[0] == '\0');
    out[0] = 'x';
@@ -151,6 +182,13 @@ static int avail_unavailable(const char **reason)
    if (reason)
       *reason = "forced-unavailable (test)";
    return 0;
+}
+
+/* Forces "available" so the real sandboxed path is taken (which must NOT audit). */
+static int avail_available(const char **reason)
+{
+   (void)reason;
+   return 1;
 }
 
 static void test_audit_hook_degraded(void)
@@ -200,7 +238,20 @@ static void test_audit_hook_degraded(void)
    waitpid(pid, NULL, 0);
    assert(g_last.calls == 0);
 
+   /* When the sandbox IS available, the exec takes the real isolated path and the
+    * degradation hook must stay SILENT — only exceptions are recorded, never a
+    * routine sandboxed run. (The child may still degrade post-fork on a kernel
+    * without userns, but that non-require path is out of parent-audit scope.) */
+   sandbox_set_audit_hook(capture_hook);
+   sandbox_set_available_override_for_test(avail_available);
+   memset(&g_last, 0, sizeof g_last);
+   pid = sandbox_exec(&cfg, "/usr/bin/true", devnull, devnull, NULL);
+   if (pid > 0)
+      waitpid(pid, NULL, 0);
+   assert(g_last.calls == 0);
+
    /* A NULL hook records nothing (no crash). */
+   sandbox_set_available_override_for_test(avail_unavailable);
    sandbox_set_audit_hook(NULL);
    memset(&g_last, 0, sizeof g_last);
    pid = sandbox_exec(&cfg, "/usr/bin/true", devnull, devnull, NULL);


### PR DESCRIPTION
## Why this is a separate PR

PR #1942 (sandbox isolation-degradation audit) merged at commit `50b521b5` — the merge raced **ahead of** my convergence push, so commit `f8cb86ca` (the review fixes) did **not** land. This PR carries exactly those fixes onto testing. **It closes a real secret-leak that #1942 shipped.**

## The blocker (now fixed)

The multi-agent review of #1942 found `sandbox_command_program` leaked secret bytes into the audit ledger on command lines the naive tokenizer mishandled:
- a leading shell construct — subshell `(`, quote, `$` — was emitted **verbatim** (`(TOKEN=sk-secret npm)` → `(TOKEN=sk-secret`);
- an env-assignment **value** containing whitespace/quotes/command-substitution (`PASS='a b' cmd`, `TOKEN=$(cat /s) cmd`) made the skip stop mid-value and parse the secret remainder as the "program".

**Fix — safe by construction:** only a run of *simple* `NAME=value` assignments (value free of shell-special bytes) followed by a **bare program path** `[A-Za-z0-9_./+-]` is surfaced (basename). Anything else emits the fixed marker `"unparsed"` — never raw command bytes. `test_command_program` pins nine adversarial forms.

## Also (majors/minors from the review)

- **Child-side degradation:** the require-isolation path now audits a child's failed in-namespace setup as `refused`; the non-require post-fork downgrade is documented as out-of-parent-scope (not silently claimed as covered).
- **Tests:** adversarial no-leak corpus; an `available=1` case proving the hook stays **silent** on the real sandboxed path; bridge test now asserts `reason_code` verbatim, a `network_isolated=0` row has no `+netiso`, and a secret in the command **arguments** never reaches the ledger.

## Verification

`aimee-server` + all shipping build; D7 green (7/7); clang-format clean; sandbox unit + bridge tests pass; full bench gate green (vault + sandbox audit hold).