### PR TITLE
Rename audit_bus → obs_bus (the module carries four event kinds now)

### DIFF
--- a/docs/dev/EVENT_BUS_DECISIONS.md
+++ b/docs/dev/EVENT_BUS_DECISIONS.md
@@ -335,14 +335,14 @@ target sources — and that `src/modules/bus/` is referenced only by the bus tes
 The rule above ("the bus links into **no** shipping binary") held for the whole twelve-slice feature
 tree. **Delivery step 3 — the first real module migration onto the bus — deliberately ends it.** The
 per-action governed-action audit row (`modules/guardrails/guardrails_action_audit.c`) no longer calls
-the file writer directly; it publishes the row over the bus via `modules/audit/audit_bus.c`, whose
+the file writer directly; it publishes the row over the bus via `modules/audit/obs_bus.c`, whose
 consumer thread drains it to the ledger. This is an all-or-nothing migration — there is no flagged
 parallel direct path — so the bus becomes load-bearing for one real, off-critical-path operation.
 
 The blast-radius invariant therefore **narrows from "no shipping binary" to "exactly one, only via
 audit":**
 
-- **Source.** Only `src/modules/bus/*` and `src/modules/audit/audit_bus.c` may include a bus header.
+- **Source.** Only `src/modules/bus/*` and `src/modules/audit/obs_bus.c` may include a bus header.
 - **Objects.** Only `aimee-server` links the bus, through a single `BUS_SHIP_OBJS` group named on its
   link line; `src/Makefile` may name `modules/bus` only in the `BUS_SHIP` source list and the two
   per-object `-Imodules/bus` compile rules. Audit is compiled into `aimee-server` (via
@@ -352,7 +352,7 @@ audit":**
 
 `scripts/check_bus_blast_radius.sh` was revised to enforce exactly this: layer 1 permits the confined
 `src/Makefile` references and requires `BUS_SHIP_OBJS` to be consumed only by `$(SERVER)`; layer 3
-allowlists `audit_bus.c`; layer 4 exempts `aimee-server` (it carries the bus on purpose) and holds
+allowlists `obs_bus.c`; layer 4 exempts `aimee-server` (it carries the bus on purpose) and holds
 every other binary to zero bus symbols. **Honest limit:** shipping binaries are stripped (`-s`) with
 LTO, so `nm` sees no static symbols in them — layer 4 is a best-effort backstop for unstripped/CI
 builds, and the load-bearing guarantee is the source/build-text layers, which are complete by
@@ -360,7 +360,7 @@ construction.
 
 **Durability note.** The old direct write `fflush`'d each row, so it was durable the instant it
 returned. The bus path is asynchronous: the producer publishes and returns, and the consumer writes
-sub-millisecond later. A graceful shutdown drains losslessly (`audit_bus_stop`, also via `atexit`),
+sub-millisecond later. A graceful shutdown drains losslessly (`obs_bus_stop`, also via `atexit`),
 but a hard kill (`SIGKILL`/crash) can lose the few rows still in the ring. This is consistent with the
 audit row's pre-existing best-effort contract (`audit_action_log` already dropped silently when the
 log was not open) and is the accepted trade for moving the write off the caller's thread.

--- a/scripts/check_bus_blast_radius.sh
+++ b/scripts/check_bus_blast_radius.sh
@@ -5,9 +5,9 @@
 # binary linked the bus. Delivery step 3 — the first real module migration —
 # links it into EXACTLY ONE shipping binary, aimee-server, and ONLY to carry the
 # per-action governed-action audit row: guardrails_action_audit.c publishes the
-# row via modules/audit/audit_bus.c, which a consumer thread drains to the ledger.
+# row via modules/audit/obs_bus.c, which a consumer thread drains to the ledger.
 # So the blast radius is now precisely:
-#   - bus SOURCE:  only src/modules/bus/* and src/modules/audit/audit_bus.c may
+#   - bus SOURCE:  only src/modules/bus/* and src/modules/audit/obs_bus.c may
 #                  include a bus header (layer 3).
 #   - bus OBJECTS: only the aimee-server link line may name the bus objects
 #                  (BUS_SHIP_OBJS), and only the BUS_SHIP definition + its compile
@@ -88,7 +88,7 @@ strip_comments() {
 # each exemption is ANCHORED to a specific line form so a bus reference cannot
 # ride in on a line that merely mentions an allowed token:
 #   (a) modules/bus may be NAMED only on the BUS_SHIP_SRCS definition and the
-#       per-object -Imodules/bus compile rules for the bus + audit_bus/audit_replay
+#       per-object -Imodules/bus compile rules for the bus + obs_bus/audit_replay
 #       objects. A -Imodules/bus on ANY other object rule, or modules/bus anywhere
 #       else, trips the gate.
 #   (b) BUS_SHIP_SRCS may be CONSUMED only by its own definition and the
@@ -99,7 +99,7 @@ strip_comments() {
 hits=$({ grep -nE 'modules/bus' src/Makefile 2>/dev/null || true; } | strip_comments |
    { grep -vE '^[0-9]+:BUS_SHIP_SRCS[[:space:]]*[+:]?=' || true; } |
    { grep -vE '^[0-9]+:\$\(OBJDIR\)/modules/bus/%\.o:[[:space:]]*C_FLAGS[[:space:]]*\+=[[:space:]]*-Imodules/bus$' || true; } |
-   { grep -vE '^[0-9]+:\$\(OBJDIR\)/modules/audit/audit_(bus|replay)\.o:[[:space:]]*C_FLAGS[[:space:]]*\+=[[:space:]]*-Imodules/bus$' || true; })
+   { grep -vE '^[0-9]+:\$\(OBJDIR\)/modules/audit/(obs_bus|audit_replay)\.o:[[:space:]]*C_FLAGS[[:space:]]*\+=[[:space:]]*-Imodules/bus$' || true; })
 if [ -n "$hits" ]; then
    note "FAIL: src/Makefile names modules/bus outside the BUS_SHIP definition/compile rules"
    printf '%s\n' "$hits" >&2
@@ -155,7 +155,7 @@ done < <(find . \( -name CMakeLists.txt -o -name '*.cmake' \) \
 for f in src/tests/CMakeLists.txt src/tests/Rules.mk; do
    [ -f "$f" ] || continue
    hits=$({ grep -n 'modules/bus' "$f" 2>/dev/null || true; } | strip_comments |
-      { grep -vE 'test_bus|unit-test-bus|bus-conformance-host|bus_conformance_host|bus-bench|bus_bench|audit_bus|audit_replay|guardrails_semantic|OBJDIR\)/modules/bus' || true; })
+      { grep -vE 'test_bus|unit-test-bus|bus-conformance-host|bus_conformance_host|bus-bench|bus_bench|obs_bus|audit_replay|guardrails_semantic|OBJDIR\)/modules/bus' || true; })
    if [ -n "$hits" ]; then
       note "FAIL: $f uses modules/bus outside a bus test target"
       printf '%s\n' "$hits" >&2
@@ -174,11 +174,11 @@ while IFS= read -r hit; do
    src/tests/bus_conformance_host.c) continue ;; # slice-10 test harness
    src/tests/bus_bench.c) continue ;;             # slice-12 benchmark
    # The first real module migration onto the bus (delivery step 3): the audit
-   # module is a bus consumer, so it includes bus headers. audit_bus.c publishes
+   # module is a bus consumer, so it includes bus headers. obs_bus.c publishes
    # /drains the governed-action row; audit_replay.c reads a capture file back for
    # the aimee-server --audit-replay operator tool. Both are linked into
    # aimee-server only (BUS_SHIP_OBJS); layer 1 proves no other target links them.
-   src/modules/audit/audit_bus.c) continue ;;
+   src/modules/audit/obs_bus.c) continue ;;
    src/modules/audit/audit_replay.c) continue ;;
    esac
    note "FAIL: $hit"
@@ -303,7 +303,7 @@ if [ "$fail" -ne 0 ]; then
    note ""
    note "The event bus may be linked only into aimee-server, and only to carry the"
    note "audit migration (D7 step 3). A bus symbol in any other shipping binary, or"
-   note "a bus reference outside modules/bus + audit_bus, is a blast-radius"
+   note "a bus reference outside modules/bus + obs_bus, is a blast-radius"
    note "regression. See docs/dev/EVENT_BUS_DECISIONS.md."
    exit 1
 fi

--- a/scripts/check_bus_perf_gate.sh
+++ b/scripts/check_bus_perf_gate.sh
@@ -98,7 +98,7 @@ fi
 
 # 4. The vault credential-access audit trail (delivery step 3, another module on
 #    the bus): a functional check that vault access flows through the REAL server
-#    bridge -> audit_bus -> ledger with the fields mapped and NO secret leaked.
+#    bridge -> obs_bus -> ledger with the fields mapped and NO secret leaked.
 #    Run here (like the durability test) because it needs the same special bus
 #    link set the standard unit-tests build does not assemble.
 echo "checking vault-access-on-bus audit trail..."
@@ -114,7 +114,7 @@ echo "vault-access audit: ok (access -> bridge -> bus -> ledger; no secret leak)
 
 # 5. The sandbox degraded-isolation audit trail: a guarded exec that ran
 #    unsandboxed (or was refused) because the sandbox was unavailable flows
-#    through the REAL server bridge -> audit_bus -> ledger, fields mapped, no
+#    through the REAL server bridge -> obs_bus -> ledger, fields mapped, no
 #    secret leaked. Same special-link reason as the vault test.
 echo "checking sandbox degraded-isolation audit trail..."
 sbx_out=$(make -C src --no-print-directory unit-test-bus-sandbox-audit 2>&1 || true)

--- a/src/Makefile
+++ b/src/Makefile
@@ -384,16 +384,16 @@ DATA_OBJS = $(DATA_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Event bus, linked ONLY into aimee-server via the audit migration ---
 # The per-action audit row (guardrails_action_audit.c, in DATA_SRCS above) is
-# emitted over the event bus (delivery step 3): audit_bus.c publishes it and a
-# consumer thread performs the ledger append. audit_bus.c and the bus it uses are
+# emitted over the event bus (delivery step 3): obs_bus.c publishes it and a
+# consumer thread performs the ledger append. obs_bus.c and the bus it uses are
 # the ONLY bus code in any shipping binary, and aimee-server is the ONLY shipping
 # binary that links it (the sole shipping consumer of guardrails_action_audit).
 # The D7 blast-radius gate enforces exactly this: bus symbols may appear in
 # aimee-server and nowhere else. See docs/dev/EVENT_BUS_DECISIONS.md (D7).
-BUS_SHIP_SRCS = modules/bus/bus_wire.c modules/bus/bus_ring.c modules/bus/bus_region.c modules/bus/bus_arena.c modules/bus/bus_route.c modules/bus/bus_host.c modules/bus/bus_client.c modules/bus/bus_capture.c modules/audit/audit_bus.c modules/audit/audit_replay.c
+BUS_SHIP_SRCS = modules/bus/bus_wire.c modules/bus/bus_ring.c modules/bus/bus_region.c modules/bus/bus_arena.c modules/bus/bus_route.c modules/bus/bus_host.c modules/bus/bus_client.c modules/bus/bus_capture.c modules/audit/obs_bus.c modules/audit/audit_replay.c
 BUS_SHIP_OBJS = $(BUS_SHIP_SRCS:%.c=$(OBJDIR)/%.o)
 $(OBJDIR)/modules/bus/%.o: C_FLAGS += -Imodules/bus
-$(OBJDIR)/modules/audit/audit_bus.o: C_FLAGS += -Imodules/bus
+$(OBJDIR)/modules/audit/obs_bus.o: C_FLAGS += -Imodules/bus
 $(OBJDIR)/modules/audit/audit_replay.o: C_FLAGS += -Imodules/bus
 
 # --- Layer 2: Agent execution (agent loop, tools, HTTP, policy) ---

--- a/src/modules/audit/audit_replay.c
+++ b/src/modules/audit/audit_replay.c
@@ -1,7 +1,7 @@
 /* audit_replay.c: read an audit-on-bus capture file and re-present the
  * governed-action rows. See audit_replay.h.
  *
- * Two consumers: the aimee-server --audit-replay CLI (text, audit_bus_replay_print)
+ * Two consumers: the aimee-server --audit-replay CLI (text, obs_bus_replay_print)
  * and the /v1/audit endpoints (JSON, audit_replay_to_json / audit_replay_capture_list).
  */
 #include "audit_replay.h"
@@ -14,7 +14,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "audit_bus.h" /* AUDIT_BUS_KIND_ACTION */
+#include "obs_bus.h" /* OBS_BUS_KIND_ACTION */
 #include "bus_capture.h"
 #include "cJSON.h"
 
@@ -29,7 +29,7 @@
  * envelope and cJSON's escaping expansion. */
 #define AB_REPLAY_JSON_BUDGET (200 * 1024)
 
-/* Read a length-prefixed string from the audit-row payload (audit_bus.c's wire
+/* Read a length-prefixed string from the audit-row payload (obs_bus.c's wire
  * form: 7 length-prefixed strings then an int64 task id). Returns new offset, or
  * 0 on malformed input. */
 static uint32_t get_str(const uint8_t *b, uint32_t off, uint32_t len, char *out, uint32_t cap)
@@ -109,7 +109,7 @@ struct text_sink
 static void on_record_text(void *ctx, const bus_capture_event_t *ev)
 {
    struct text_sink *s = ctx;
-   if (ev->type != BUS_CAP_EVENT || ev->frame.event_kind != AUDIT_BUS_KIND_ACTION)
+   if (ev->type != BUS_CAP_EVENT || ev->frame.event_kind != OBS_BUS_KIND_ACTION)
       return;
    char actor[128], tool[256], hash[96], command[512], mode[64], reason[128], verdict[32];
    int64_t task_id;
@@ -128,7 +128,7 @@ static void on_record_text(void *ctx, const bus_capture_event_t *ev)
    s->rows++;
 }
 
-int audit_bus_replay_print(const char *path, FILE *out)
+int obs_bus_replay_print(const char *path, FILE *out)
 {
    size_t size = 0;
    uint8_t *buf = read_all(path, &size);
@@ -175,7 +175,7 @@ struct json_sink
 static void on_record_json(void *ctx, const bus_capture_event_t *ev)
 {
    struct json_sink *s = ctx;
-   if (ev->type != BUS_CAP_EVENT || ev->frame.event_kind != AUDIT_BUS_KIND_ACTION)
+   if (ev->type != BUS_CAP_EVENT || ev->frame.event_kind != OBS_BUS_KIND_ACTION)
       return;
    char actor[128], tool[256], hash[96], command[512], mode[64], reason[128], verdict[32];
    int64_t task_id;

--- a/src/modules/audit/audit_replay.h
+++ b/src/modules/audit/audit_replay.h
@@ -1,7 +1,7 @@
 /* audit_replay.h: read an audit-on-bus capture file and re-present the
  * governed-action rows it recorded.
  *
- * The event bus exists for auditability and record+replay; audit_bus.c records
+ * The event bus exists for auditability and record+replay; obs_bus.c records
  * every governed-action row to a per-session capture file. This is the operator
  * side: given such a file, replay it — observationally, nothing re-executed — and
  * print each row in the order it happened, with the stream's terminal
@@ -32,7 +32,7 @@ extern "C"
     * Returns 0 if the stream parsed as a valid capture (COMPLETE or OPEN), -1 if
     * the file could not be read, and -2 if the stream is TRUNCATED or CORRUPT
     * (still prints what was recoverable before the break). */
-   int audit_bus_replay_print(const char *path, FILE *out);
+   int obs_bus_replay_print(const char *path, FILE *out);
 
    /* JSON forms for the /v1/audit endpoints (both return caller-owned cJSON).
     * audit_replay_to_json returns {status, total, count, offset, rows:[{seq,

--- a/src/modules/audit/obs_bus.c
+++ b/src/modules/audit/obs_bus.c
@@ -1,5 +1,5 @@
-/* audit_bus.c: the governed-action audit row, carried over the event bus.
- * See audit_bus.h for the rationale and lifecycle.
+/* obs_bus.c: the governed-action audit row, carried over the event bus.
+ * See obs_bus.h for the rationale and lifecycle.
  *
  * Shape: one in-process bus host, one producer client (published to by any number
  * of caller threads, serialized by a mutex so the SPSC producer ring has a single
@@ -9,7 +9,7 @@
  * publishes and returns; the consumer writes asynchronously.
  */
 #define _GNU_SOURCE
-#include "audit_bus.h"
+#include "obs_bus.h"
 
 #include <dirent.h>
 #include <fcntl.h>
@@ -30,8 +30,8 @@
 #include "config.h"     /* config_default_dir */
 #include "log.h"
 
-#define KIND_AUDIT_ACTION    AUDIT_BUS_KIND_ACTION
-#define KIND_GUARDRAIL_EVENT AUDIT_BUS_KIND_GUARDRAIL
+#define KIND_AUDIT_ACTION    OBS_BUS_KIND_ACTION
+#define KIND_GUARDRAIL_EVENT OBS_BUS_KIND_GUARDRAIL
 
 /* Per-field caps for the wire form. Generous vs the emitter's inputs (args_hash
  * 68, command preview 288, the rest short) so nothing a caller passes is clipped
@@ -149,7 +149,7 @@ static int write_row(const uint8_t *buf, uint32_t len)
        !(off = get_str(buf, off, len, reason, sizeof reason)) ||
        !(off = get_str(buf, off, len, verdict, sizeof verdict)) || off + 8 > len)
    {
-      aimee_log(LOG_WARN, "audit_bus", "dropping malformed audit row (len=%u)", len);
+      aimee_log(LOG_WARN, "obs_bus", "dropping malformed audit row (len=%u)", len);
       return 0;
    }
    int64_t task_id;
@@ -193,7 +193,7 @@ static int write_guardrail(const uint8_t *p, uint32_t len)
    if (!(off = get_str(p, off, len, e.session_id, sizeof e.session_id)) ||
        !(off = get_str(p, off, len, e.tool_name, sizeof e.tool_name)) || off + 5 * 8 > len)
    {
-      aimee_log(LOG_WARN, "audit_bus", "dropping malformed guardrail event (len=%u)", len);
+      aimee_log(LOG_WARN, "obs_bus", "dropping malformed guardrail event (len=%u)", len);
       return 0;
    }
    double d[5];
@@ -209,7 +209,7 @@ static int write_guardrail(const uint8_t *p, uint32_t len)
        !(off = get_str(p, off, len, e.final_action, sizeof e.final_action)) ||
        !(off = get_str(p, off, len, e.explanation, sizeof e.explanation)) || off + 4 > len)
    {
-      aimee_log(LOG_WARN, "audit_bus", "dropping malformed guardrail event (len=%u)", len);
+      aimee_log(LOG_WARN, "obs_bus", "dropping malformed guardrail event (len=%u)", len);
       return 0;
    }
    int32_t dry;
@@ -270,7 +270,7 @@ static void capture_flush(void)
       return;
    if (g.capture.broken)
    {
-      aimee_log(LOG_WARN, "audit_bus", "capture sink broke (alloc); replay stream abandoned");
+      aimee_log(LOG_WARN, "obs_bus", "capture sink broke (alloc); replay stream abandoned");
       close(g.cap_fd);
       g.cap_fd = -1;
       return;
@@ -281,7 +281,7 @@ static void capture_flush(void)
       ssize_t w = write(g.cap_fd, g.capture.buf + off, g.capture.len - off);
       if (w <= 0)
       {
-         aimee_log(LOG_WARN, "audit_bus", "capture file write failed; replay stream abandoned");
+         aimee_log(LOG_WARN, "obs_bus", "capture file write failed; replay stream abandoned");
          close(g.cap_fd);
          g.cap_fd = -1;
          g.capture.broken = 1; /* stop the tap appending to a sink we can no longer drain */
@@ -357,7 +357,7 @@ static void capture_open(void)
    const char *dir = config_default_dir();
    if (!dir || !dir[0])
    {
-      aimee_log(LOG_WARN, "audit_bus", "no home dir; audit capture/replay stream disabled");
+      aimee_log(LOG_WARN, "obs_bus", "no home dir; audit capture/replay stream disabled");
       return;
    }
    /* time+pid identifies the process/session; a per-process counter breaks ties
@@ -371,7 +371,7 @@ static void capture_open(void)
    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
    if (fd < 0)
    {
-      aimee_log(LOG_WARN, "audit_bus", "cannot open audit capture file; replay stream disabled");
+      aimee_log(LOG_WARN, "obs_bus", "cannot open audit capture file; replay stream disabled");
       return;
    }
    g.cap_fd = fd;
@@ -464,12 +464,12 @@ static int start_locked(void)
 
    if (bus_host_create(&g.host, &cfg, NULL, NULL) != BUS_HOST_OK)
    {
-      aimee_log(LOG_ERROR, "audit_bus", "bus host create failed; audit rows will not be recorded");
+      aimee_log(LOG_ERROR, "obs_bus", "bus host create failed; audit rows will not be recorded");
       return -1;
    }
    if (attach(&g.producer) != 0 || attach(&g.consumer) != 0)
    {
-      aimee_log(LOG_ERROR, "audit_bus", "audit bus client attach failed");
+      aimee_log(LOG_ERROR, "obs_bus", "audit bus client attach failed");
       bus_host_destroy(&g.host);
       return -1;
    }
@@ -482,7 +482,7 @@ static int start_locked(void)
 
    if (pthread_create(&g.thread, NULL, consumer_main, NULL) != 0)
    {
-      aimee_log(LOG_ERROR, "audit_bus", "audit consumer thread spawn failed");
+      aimee_log(LOG_ERROR, "obs_bus", "audit consumer thread spawn failed");
       if (g.cap_fd >= 0)
          close(g.cap_fd);
       bus_capture_free(&g.capture);
@@ -497,7 +497,7 @@ static int start_locked(void)
    return 0;
 }
 
-int audit_bus_start(void)
+int obs_bus_start(void)
 {
    pthread_mutex_lock(&start_lock);
    int rc = g.started ? 0 : start_locked();
@@ -505,25 +505,25 @@ int audit_bus_start(void)
    return rc;
 }
 
-/* Lazy start on first emit, so audit_bus_emit is a drop-in for the old direct
+/* Lazy start on first emit, so obs_bus_emit is a drop-in for the old direct
  * audit_action_log in EVERY context (server, standalone agent, CLI) — a row is
- * never lost merely because no one called audit_bus_start(). atexit drains at a
+ * never lost merely because no one called obs_bus_start(). atexit drains at a
  * graceful process exit. Once stop() has run (g.terminated), a late emit does
- * NOT resurrect the bus; only an explicit audit_bus_start() restarts it. */
+ * NOT resurrect the bus; only an explicit obs_bus_start() restarts it. */
 static void ensure_started(void)
 {
    if (atomic_load_explicit(&g.emitting, memory_order_acquire))
       return;
    pthread_mutex_lock(&start_lock);
    if (!g.started && !g.terminated && start_locked() == 0)
-      atexit(audit_bus_stop);
+      atexit(obs_bus_stop);
    pthread_mutex_unlock(&start_lock);
 }
 
 /* Enter the emit window. Returns 1 if the caller may publish (and MUST call
  * leave_emit afterwards), 0 if the bus is not accepting emits.
  *
- * The refcount + re-check is what makes shutdown safe: audit_bus_stop sets
+ * The refcount + re-check is what makes shutdown safe: obs_bus_stop sets
  * emitting=0 and then waits for `publishers` to reach 0 before tearing down the
  * producer/host/pub_lock. A producer increments `publishers` BEFORE re-reading
  * emitting, so once stop observes publishers==0 (after storing emitting=0), no
@@ -580,18 +580,17 @@ static void publish(uint32_t kind, const uint8_t *buf, uint32_t len)
    if (!ok)
    {
       atomic_fetch_add_explicit(&g.dropped, 1, memory_order_relaxed);
-      aimee_log(LOG_WARN, "audit_bus",
+      aimee_log(LOG_WARN, "obs_bus",
                 "event not recorded (kind=%u rc=%d) — consumer stuck or publish error", kind, rc);
    }
 }
 
-void audit_bus_emit(const char *actor, const char *tool, const char *args_hash, const char *command,
-                    const char *mode, const char *reason_code, const char *verdict,
-                    long long task_id)
+void obs_bus_emit(const char *actor, const char *tool, const char *args_hash, const char *command,
+                  const char *mode, const char *reason_code, const char *verdict, long long task_id)
 {
    if (!enter_emit())
    {
-      aimee_log(LOG_WARN, "audit_bus", "audit bus unavailable; row not recorded");
+      aimee_log(LOG_WARN, "obs_bus", "audit bus unavailable; row not recorded");
       return;
    }
 
@@ -601,20 +600,20 @@ void audit_bus_emit(const char *actor, const char *tool, const char *args_hash, 
    if (len == 0)
    {
       atomic_fetch_add_explicit(&g.dropped, 1, memory_order_relaxed);
-      aimee_log(LOG_WARN, "audit_bus", "audit row too large to serialize; not recorded");
+      aimee_log(LOG_WARN, "obs_bus", "audit row too large to serialize; not recorded");
    }
    else
       publish(KIND_AUDIT_ACTION, buf, len);
    leave_emit();
 }
 
-void audit_bus_emit_guardrail(const guardrail_event_t *e)
+void obs_bus_emit_guardrail(const guardrail_event_t *e)
 {
    if (!e)
       return;
    if (!enter_emit())
    {
-      aimee_log(LOG_WARN, "audit_bus", "audit bus unavailable; guardrail event not recorded");
+      aimee_log(LOG_WARN, "obs_bus", "audit bus unavailable; guardrail event not recorded");
       return;
    }
 
@@ -623,14 +622,14 @@ void audit_bus_emit_guardrail(const guardrail_event_t *e)
    if (len == 0)
    {
       atomic_fetch_add_explicit(&g.dropped, 1, memory_order_relaxed);
-      aimee_log(LOG_WARN, "audit_bus", "guardrail event too large to serialize; not recorded");
+      aimee_log(LOG_WARN, "obs_bus", "guardrail event too large to serialize; not recorded");
    }
    else
       publish(KIND_GUARDRAIL_EVENT, buf, len);
    leave_emit();
 }
 
-void audit_bus_stop(void)
+void obs_bus_stop(void)
 {
    pthread_mutex_lock(&start_lock);
    if (!g.started)
@@ -672,7 +671,7 @@ void audit_bus_stop(void)
    pthread_mutex_unlock(&start_lock);
 }
 
-void audit_bus_flush(void)
+void obs_bus_flush(void)
 {
    if (!g.started)
       return;
@@ -683,7 +682,7 @@ void audit_bus_flush(void)
     * stuck consumer cannot hang the caller forever. Does NOT stop the bus. */
    uint64_t target = atomic_load_explicit(&g.enqueued, memory_order_acquire);
    const struct timespec nap = {.tv_sec = 0, .tv_nsec = 100 * 1000}; /* 100 us */
-   for (int i = 0; i < 50000; i++)                                    /* ~5 s cap */
+   for (int i = 0; i < 50000; i++)                                   /* ~5 s cap */
    {
       if (atomic_load_explicit(&g.processed, memory_order_acquire) >= target)
          return;
@@ -691,12 +690,12 @@ void audit_bus_flush(void)
    }
 }
 
-uint64_t audit_bus_dropped(void)
+uint64_t obs_bus_dropped(void)
 {
    return atomic_load_explicit(&g.dropped, memory_order_relaxed);
 }
 
-uint64_t audit_bus_written(void)
+uint64_t obs_bus_written(void)
 {
    return atomic_load_explicit(&g.written, memory_order_relaxed);
 }

--- a/src/modules/audit/obs_bus.h
+++ b/src/modules/audit/obs_bus.h
@@ -1,28 +1,33 @@
-/* audit_bus.h: the governed-action audit row, carried over the event bus.
+/* obs_bus.h: the in-process OBSERVABILITY bus — off-critical-path events carried
+ * over the shared-memory event bus to their durable sinks + a capture/replay
+ * stream.
  *
- * This is the first REAL module migration onto the shared-memory event bus
- * (delivery step 3). The per-action audit row emitter used to call the file
- * writer (audit_action_log) directly on the caller's thread. It now PUBLISHES the
- * row to the bus, and a dedicated consumer thread drains the bus and performs the
- * real append. The direct call is gone — this is an all-or-nothing transition,
- * not a flagged parallel path: the bus is the sole route for the audit row.
+ * This began (delivery step 3) as the governed-action audit row's migration off a
+ * direct, on-thread file write onto the bus, and has since become the shared
+ * transport for several off-path observability event kinds (see the KIND_* list
+ * below): governed-action audit rows, guardrail-semantic risk events, and — via
+ * server-only bridges that reuse the action kind — vault credential-access and
+ * sandbox isolation-degradation audit events. Each migration is all-or-nothing:
+ * the bus is the SOLE route for that event, not a flagged parallel path.
  *
- * Why audit first (memory, the intended hub, is not yet modularized): the audit
- * row is a side-channel, off the answer's critical path, so it is the cheapest
- * place to make the bus load-bearing. A publish is fire-and-forget; the consumer
- * writes asynchronously. The committed budget is therefore an ENQUEUE-overhead
- * ceiling plus a DURABILITY invariant (every accepted row is written exactly
- * once), not a request/reply round-trip.
+ * A publish is fire-and-forget; a dedicated consumer thread drains the bus and
+ * performs the real append/insert asynchronously. The committed budget is
+ * therefore an ENQUEUE-overhead ceiling plus a DURABILITY invariant (every
+ * accepted event reaches its sink exactly once), not a request/reply round-trip.
  *
  * Lifecycle (single process — bus host + consumer live in the server):
- *   audit_bus_start()  once at server startup, after audit_ensure_key / log_init.
- *   audit_bus_emit(..) from any thread, per governed tool call (publish).
- *   audit_bus_stop()   once at shutdown: stops emitting, DRAINS the remaining
- *                      rows, joins the consumer, tears the bus down. The drain is
- *                      what makes shutdown lossless.
+ *   obs_bus_start()  once at server startup, after audit_ensure_key / log_init.
+ *   obs_bus_emit(..) from any thread, per governed tool call (publish).
+ *   obs_bus_stop()   once at shutdown: stops emitting, DRAINS the remaining
+ *                      events, joins the consumer, tears the bus down. The drain
+ *                      is what makes shutdown lossless.
+ *
+ * (Historically named audit_bus; renamed to obs_bus once it carried more than the
+ * audit row. The durable audit LEDGER, WORM chain, and replay reader keep their
+ * audit_* names — they are genuinely about the audit record, not the transport.)
  */
-#ifndef AIMEE_AUDIT_BUS_H
-#define AIMEE_AUDIT_BUS_H 1
+#ifndef AIMEE_OBS_BUS_H
+#define AIMEE_OBS_BUS_H 1
 
 #include <stdint.h>
 
@@ -39,14 +44,14 @@ extern "C"
  *   KIND_ACTION    (3000) — the governed-action audit row  -> the audit ledger
  *   KIND_GUARDRAIL (3001) — the guardrail-semantic risk event -> db1 guardrail_events
  * Shared so writers and the replay reader (audit_replay.c) agree on them. */
-#define AUDIT_BUS_KIND_ACTION    3000
-#define AUDIT_BUS_KIND_GUARDRAIL 3001
+#define OBS_BUS_KIND_ACTION    3000
+#define OBS_BUS_KIND_GUARDRAIL 3001
 
    /* Bring the audit bus up: create the in-process host, attach the producer and
     * the consumer, subscribe the consumer to the audit-row kind, and spawn the
     * consumer thread. Idempotent: a second call while running is a no-op that
     * returns 0. Returns 0 on success, -1 if the bus could not be created. */
-   int audit_bus_start(void);
+   int obs_bus_start(void);
 
    /* Publish one governed-action audit row. Same field contract as
     * audit_action_log — the fields are serialized and published; the consumer
@@ -54,39 +59,39 @@ extern "C"
     * concurrently (the single producer is serialized internally). If the bus is
     * not running this is a visible no-op (a wiring error, logged), never a silent
     * fallback to a direct write. */
-   void audit_bus_emit(const char *actor, const char *tool, const char *args_hash,
-                       const char *command, const char *mode, const char *reason_code,
-                       const char *verdict, long long task_id);
+   void obs_bus_emit(const char *actor, const char *tool, const char *args_hash,
+                     const char *command, const char *mode, const char *reason_code,
+                     const char *verdict, long long task_id);
 
    /* Publish one guardrail-semantic risk event over the bus (same async,
-    * off-critical-path, best-effort contract as audit_bus_emit). The consumer
+    * off-critical-path, best-effort contract as obs_bus_emit). The consumer
     * thread performs the real db1 guardrail_events insert; the direct insert at
     * the emit site is gone. Safe to call from any thread; a no-op (logged) if the
     * bus is not running. */
-   void audit_bus_emit_guardrail(const guardrail_event_t *e);
+   void obs_bus_emit_guardrail(const guardrail_event_t *e);
 
    /* Block until the consumer has written every event emitted so far to its sink
     * (the ledger / db1), WITHOUT stopping the bus. For a caller that emits and then
     * reads the sink synchronously (mainly tests: the write is otherwise async).
     * Bounded (~5s); a no-op if the bus is not running. */
-   void audit_bus_flush(void);
+   void obs_bus_flush(void);
 
    /* Stop emitting, drain every already-published row to the writer, join the
     * consumer thread, and tear the bus down. Lossless: rows published before the
     * call are written before it returns. Idempotent. */
-   void audit_bus_stop(void);
+   void obs_bus_stop(void);
 
    /* Number of rows that could not be published because the bus queue was full
     * (backpressure). Zero under normal load; a non-zero value is a visible signal
     * that the consumer could not keep up, never a silently dropped record. */
-   uint64_t audit_bus_dropped(void);
+   uint64_t obs_bus_dropped(void);
 
    /* Number of rows the consumer has written to the ledger since start. Exposed
     * for the durability test (published == written + dropped once drained). */
-   uint64_t audit_bus_written(void);
+   uint64_t obs_bus_written(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* AIMEE_AUDIT_BUS_H */
+#endif /* AIMEE_OBS_BUS_H */

--- a/src/modules/guardrails/guardrails_action_audit.c
+++ b/src/modules/guardrails/guardrails_action_audit.c
@@ -13,7 +13,7 @@
 
 #include "aimee.h" /* MODE_APPROVE */
 #include "audit_action.h"
-#include "audit_bus.h" /* the per-action row now crosses the event bus, not a direct write */
+#include "obs_bus.h" /* the per-action row now crosses the event bus, not a direct write */
 #include "audit_worm.h"
 #include "config.h"
 #include "guardrails.h"
@@ -135,7 +135,7 @@ static void emit_action_audit(const char *tool_name, const char *input_json,
     * audit_action_log. The direct call is gone — the bus is the sole route (an
     * all-or-nothing migration, no flagged parallel write). Still off the verdict's
     * critical path and best-effort: a publish failure never blocks the tool. */
-   audit_bus_emit(actor, tool_name, args_hash, command, mode, reason, verdict, task_id);
+   obs_bus_emit(actor, tool_name, args_hash, command, mode, reason, verdict, task_id);
    emit_worm_row(actor, tool_name, args_hash, mode, reason, verdict, task_id);
 }
 

--- a/src/modules/guardrails/guardrails_semantic.c
+++ b/src/modules/guardrails/guardrails_semantic.c
@@ -10,7 +10,7 @@
  * JSON) degrades to parse_ok=0 and recommendation="allow". The deterministic
  * guardrail result is unaffected. One warning is logged on failure. */
 #include "guardrails_semantic.h"
-#include "audit_bus.h" /* guardrail events cross the event bus, not a direct db1 insert */
+#include "obs_bus.h" /* guardrail events cross the event bus, not a direct db1 insert */
 #include "db1/guardrail_events.h"
 #if !defined(AIMEE_DB2_DISABLED)
 #include "db2/bandit.h"
@@ -313,5 +313,5 @@ void gsem_record(const char *session_id, const gsem_input_t *in, const gsem_outp
     * db1 guardrail_events insert, and the capture tap records it alongside the
     * governed-action audit rows in one replayable stream. The direct insert is
     * gone. Off the critical path and best-effort, as before. */
-   audit_bus_emit_guardrail(&e);
+   obs_bus_emit_guardrail(&e);
 }

--- a/src/server/sandbox_audit_bridge.c
+++ b/src/server/sandbox_audit_bridge.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 #include "audit_action.h" /* audit_args_hash, AUDIT_ARGS_HASH_LEN */
-#include "audit_bus.h"    /* audit_bus_emit */
+#include "obs_bus.h"      /* obs_bus_emit */
 #include "sandbox.h"      /* sandbox_audit_hook_fn, sandbox_mode_to_string */
 
 /* sandbox_audit_hook_fn: publish one degraded-isolation audit row over the bus
@@ -31,8 +31,8 @@ static void on_sandbox_degraded(const char *program, sandbox_mode_t mode, int ne
    snprintf(args_hash, sizeof args_hash, "v1-");
    audit_args_hash("sandbox.exec", NULL, args_hash, sizeof args_hash);
 
-   audit_bus_emit("sandbox", "sandbox.exec", args_hash, program ? program : "", modestr,
-                  reason ? reason : "", verdict, /*task_id=*/0);
+   obs_bus_emit("sandbox", "sandbox.exec", args_hash, program ? program : "", modestr,
+                reason ? reason : "", verdict, /*task_id=*/0);
 }
 
 void sandbox_audit_bridge_install(void)

--- a/src/server/server_audit_replay_routes.c
+++ b/src/server/server_audit_replay_routes.c
@@ -1,7 +1,7 @@
 /* server_audit_replay_routes.c: the /v1/audit capture-replay HTTP handlers.
  *
  * Split out of server_state.c (which was at the 2500-line cap). These expose the
- * audit-on-bus capture streams — recorded by modules/audit/audit_bus.c — over the
+ * audit-on-bus capture streams — recorded by modules/audit/obs_bus.c — over the
  * /v1 surface as a dashboard read: list the capture files, and replay one file's
  * governed-action rows as JSON. The heavy lifting (reading + decoding a capture,
  * the byte-budget paging, the path-traversal-safe basename check) lives in

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -441,7 +441,7 @@ int main(int argc, char **argv)
          fprintf(stderr, "usage: aimee-server --audit-replay <capture-file>\n");
          return 2;
       }
-      int rc = audit_bus_replay_print(argv[2], stdout);
+      int rc = obs_bus_replay_print(argv[2], stdout);
       return rc == 0 ? 0 : 1;
    }
 

--- a/src/server/vault_audit_bridge.c
+++ b/src/server/vault_audit_bridge.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 
 #include "audit_action.h"  /* audit_args_hash, AUDIT_ARGS_HASH_LEN */
-#include "audit_bus.h"     /* audit_bus_emit */
+#include "obs_bus.h"       /* obs_bus_emit */
 #include "vault_service.h" /* vault_audit_hook_fn, vault_status_t/_str, attested_transport_t */
 
 /* Short, stable label for the attestation behind the access (the audit row's
@@ -72,8 +72,8 @@ static void on_vault_access(const char *op, const char *principal, const char *a
    snprintf(args_hash, sizeof args_hash, "v1-");
    audit_args_hash(op, NULL, args_hash, sizeof args_hash);
 
-   audit_bus_emit(principal, op, args_hash, command, transport_label(transport),
-                  vault_status_str(st), verdict_of(st), /*task_id=*/0);
+   obs_bus_emit(principal, op, args_hash, command, transport_label(transport), vault_status_str(st),
+                verdict_of(st), /*task_id=*/0);
 }
 
 void vault_audit_bridge_install(void)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -185,35 +185,35 @@ target_link_libraries(test_bus_config_autonomy PRIVATE Threads::Threads)
 
 # audit-on-bus durability: the first module being migrated onto the bus. Emits N
 # rows through the real producer/consumer and requires the real ledger to hold
-# exactly N, each once, zero drops. audit_bus + bus compiled in; the ledger reader
+# exactly N, each once, zero drops. obs_bus + bus compiled in; the ledger reader
 # and file writer come from aimee-core. Test binary only.
-aimee_add_test(test_bus_audit_durability test_bus_audit_durability.c ../modules/audit/audit_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
+aimee_add_test(test_bus_audit_durability test_bus_audit_durability.c ../modules/audit/obs_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
 target_include_directories(test_bus_audit_durability PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus ${CMAKE_CURRENT_SOURCE_DIR}/../modules/audit)
 target_link_libraries(test_bus_audit_durability PRIVATE Threads::Threads)
 
 # audit-on-bus record+replay: the auditability payoff. Emits rows, reads the real
 # capture file back, requires faithful ordered replay of every governed-action row.
-aimee_add_test(test_bus_audit_replay test_bus_audit_replay.c ../modules/audit/audit_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
+aimee_add_test(test_bus_audit_replay test_bus_audit_replay.c ../modules/audit/obs_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
 target_include_directories(test_bus_audit_replay PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus ${CMAKE_CURRENT_SOURCE_DIR}/../modules/audit)
 target_link_libraries(test_bus_audit_replay PRIVATE Threads::Threads)
 
 # audit-on-bus capture retention: prior sessions kept, files bounded.
-aimee_add_test(test_bus_audit_retention test_bus_audit_retention.c ../modules/audit/audit_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
+aimee_add_test(test_bus_audit_retention test_bus_audit_retention.c ../modules/audit/obs_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
 target_include_directories(test_bus_audit_retention PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus ${CMAKE_CURRENT_SOURCE_DIR}/../modules/audit)
 target_link_libraries(test_bus_audit_retention PRIVATE Threads::Threads)
 
 # The operator replay tool (aimee-server --audit-replay): render a capture file.
-aimee_add_test(test_bus_audit_replay_tool test_bus_audit_replay_tool.c ../modules/audit/audit_bus.c ../modules/audit/audit_replay.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
+aimee_add_test(test_bus_audit_replay_tool test_bus_audit_replay_tool.c ../modules/audit/obs_bus.c ../modules/audit/audit_replay.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
 target_include_directories(test_bus_audit_replay_tool PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus ${CMAKE_CURRENT_SOURCE_DIR}/../modules/audit)
 target_link_libraries(test_bus_audit_replay_tool PRIVATE Threads::Threads)
 
 # Second module on the bus: the guardrail-semantic event -> db1 guardrail_events.
-aimee_add_test(test_bus_guardrail_durability test_bus_guardrail_durability.c ../modules/audit/audit_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
+aimee_add_test(test_bus_guardrail_durability test_bus_guardrail_durability.c ../modules/audit/obs_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
 target_include_directories(test_bus_guardrail_durability PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus ${CMAKE_CURRENT_SOURCE_DIR}/../modules/audit)
 target_link_libraries(test_bus_guardrail_durability PRIVATE Threads::Threads)
 
-# Shutdown race: concurrent producers vs audit_bus_stop() (UAF regression).
-aimee_add_test(test_bus_shutdown_race test_bus_shutdown_race.c ../modules/audit/audit_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
+# Shutdown race: concurrent producers vs obs_bus_stop() (UAF regression).
+aimee_add_test(test_bus_shutdown_race test_bus_shutdown_race.c ../modules/audit/obs_bus.c ../modules/bus/bus_client.c ../modules/bus/bus_host.c ../modules/bus/bus_route.c ../modules/bus/bus_region.c ../modules/bus/bus_ring.c ../modules/bus/bus_arena.c ../modules/bus/bus_wire.c ../modules/bus/bus_capture.c)
 target_include_directories(test_bus_shutdown_race PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bus ${CMAKE_CURRENT_SOURCE_DIR}/../modules/audit)
 target_link_libraries(test_bus_shutdown_race PRIVATE Threads::Threads)
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -26,7 +26,7 @@ unit-test-server-management-listener-live: $(TESTPREFIX)/unit-test-server-manage
 	$<
 
 P5B3C_LIVE_SERVER_OBJS = $(filter-out $(OBJDIR)/server/server_main.o,$(SERVER_OBJS)) \
-    $(OBJDIR)/modules/audit/audit_bus.o $(OBJDIR)/modules/audit/audit_replay.o \
+    $(OBJDIR)/modules/audit/obs_bus.o $(OBJDIR)/modules/audit/audit_replay.o \
     $(OBJDIR)/modules/bus/bus_client.o $(OBJDIR)/modules/bus/bus_host.o \
     $(OBJDIR)/modules/bus/bus_route.o $(OBJDIR)/modules/bus/bus_region.o \
     $(OBJDIR)/modules/bus/bus_ring.o $(OBJDIR)/modules/bus/bus_arena.o \
@@ -79,12 +79,12 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/modules/workspace/workspace.o $(OBJDIR)/mo
                              $(PLATFORM_AGENT_OBJS)
 
 # This bundle carries guardrails_action_audit.o and guardrails_semantic.o, which
-# now reference audit_bus_emit / audit_bus_emit_guardrail — so every test linking
+# now reference obs_bus_emit / obs_bus_emit_guardrail — so every test linking
 # it also needs the bus objects. Listed individually (NOT $(BUS_SHIP_OBJS)) so the
 # D7 "only aimee-server links BUS_SHIP_OBJS" invariant is untouched; these are
 # TEST binaries, which are allowed to link the bus. guardrail_events.o /
 # aimee_home.o / log.o are already in TEST_DATA_OBJS.
-BUS_TEST_OBJS = $(OBJDIR)/modules/audit/audit_bus.o \
+BUS_TEST_OBJS = $(OBJDIR)/modules/audit/obs_bus.o \
                 $(OBJDIR)/modules/bus/bus_client.o $(OBJDIR)/modules/bus/bus_host.o \
                 $(OBJDIR)/modules/bus/bus_route.o $(OBJDIR)/modules/bus/bus_region.o \
                 $(OBJDIR)/modules/bus/bus_ring.o $(OBJDIR)/modules/bus/bus_arena.o \
@@ -2759,13 +2759,13 @@ unit-test-bus-config-autonomy: $(TESTPREFIX)/unit-test-bus-config-autonomy
 	$<
 
 # The audit-on-bus DURABILITY test: the first module whose real path is being
-# migrated onto the bus. Emits N rows through the real audit_bus producer/consumer
+# migrated onto the bus. Emits N rows through the real obs_bus producer/consumer
 # and requires the real ledger to hold exactly N, each once, zero drops. Links
-# audit_bus + audit_ledger + the bus + the shared support objects. Test binary only.
-$(OBJDIR)/modules/audit/audit_bus.o: C_FLAGS += -Imodules/bus
+# obs_bus + audit_ledger + the bus + the shared support objects. Test binary only.
+$(OBJDIR)/modules/audit/obs_bus.o: C_FLAGS += -Imodules/bus
 $(OBJDIR)/tests/test_bus_audit_durability.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-audit-durability: $(OBJDIR)/tests/test_bus_audit_durability.o \
-                                              $(OBJDIR)/modules/audit/audit_bus.o \
+                                              $(OBJDIR)/modules/audit/obs_bus.o \
                                               $(OBJDIR)/modules/audit/audit_ledger.o \
                                               $(OBJDIR)/aimee_home.o \
                                               $(OBJDIR)/modules/bus/bus_client.o \
@@ -2789,7 +2789,7 @@ unit-test-bus-audit-durability: $(TESTPREFIX)/unit-test-bus-audit-durability
 # link set as durability plus bus_capture.o. Test binary only.
 $(OBJDIR)/tests/test_bus_audit_replay.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-audit-replay: $(OBJDIR)/tests/test_bus_audit_replay.o \
-                                          $(OBJDIR)/modules/audit/audit_bus.o \
+                                          $(OBJDIR)/modules/audit/obs_bus.o \
                                           $(OBJDIR)/modules/audit/audit_ledger.o \
                                           $(OBJDIR)/aimee_home.o \
                                           $(OBJDIR)/modules/bus/bus_client.o \
@@ -2811,7 +2811,7 @@ unit-test-bus-audit-replay: $(TESTPREFIX)/unit-test-bus-audit-replay
 # but the files stay bounded. Same link set as replay/durability.
 $(OBJDIR)/tests/test_bus_audit_retention.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-audit-retention: $(OBJDIR)/tests/test_bus_audit_retention.o \
-                                             $(OBJDIR)/modules/audit/audit_bus.o \
+                                             $(OBJDIR)/modules/audit/obs_bus.o \
                                              $(OBJDIR)/modules/audit/audit_ledger.o \
                                              $(OBJDIR)/aimee_home.o \
                                              $(OBJDIR)/modules/bus/bus_client.o \
@@ -2834,7 +2834,7 @@ unit-test-bus-audit-retention: $(TESTPREFIX)/unit-test-bus-audit-retention
 $(OBJDIR)/modules/audit/audit_replay.o: C_FLAGS += -Imodules/bus
 $(OBJDIR)/tests/test_bus_audit_replay_tool.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-audit-replay-tool: $(OBJDIR)/tests/test_bus_audit_replay_tool.o \
-                                               $(OBJDIR)/modules/audit/audit_bus.o \
+                                               $(OBJDIR)/modules/audit/obs_bus.o \
                                                $(OBJDIR)/modules/audit/audit_replay.o \
                                                $(OBJDIR)/modules/audit/audit_ledger.o \
                                                $(OBJDIR)/aimee_home.o \
@@ -2855,10 +2855,10 @@ unit-test-bus-audit-replay-tool: $(TESTPREFIX)/unit-test-bus-audit-replay-tool
 
 # Second module on the bus: the guardrail-semantic event. Emits N over the bus and
 # requires the real db1 guardrail_events table to hold exactly N. guardrail_events.o
-# is in BUS_MEM_OBJS; audit_bus dispatches this kind to db1.
+# is in BUS_MEM_OBJS; obs_bus dispatches this kind to db1.
 $(OBJDIR)/tests/test_bus_guardrail_durability.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-guardrail-durability: $(OBJDIR)/tests/test_bus_guardrail_durability.o \
-                                                  $(OBJDIR)/modules/audit/audit_bus.o \
+                                                  $(OBJDIR)/modules/audit/obs_bus.o \
                                                   $(OBJDIR)/modules/audit/audit_ledger.o \
                                                   $(OBJDIR)/aimee_home.o \
                                                   $(OBJDIR)/modules/bus/bus_client.o \
@@ -2877,12 +2877,12 @@ unit-test-bus-guardrail-durability: $(TESTPREFIX)/unit-test-bus-guardrail-durabi
 	$<
 
 # Vault credential-access audit, end-to-end through the REAL server bridge
-# (vault_audit_bridge.o) -> audit_bus -> ledger. Same bus link set as the audit
+# (vault_audit_bridge.o) -> obs_bus -> ledger. Same bus link set as the audit
 # durability test, plus the bridge, the vault service + its crypto/store/cache
 # deps, and audit_action.o (audit_args_hash + audit_ensure_key).
 $(TESTPREFIX)/unit-test-bus-vault-audit: $(OBJDIR)/tests/test_bus_vault_audit.o \
                                          $(OBJDIR)/server/vault_audit_bridge.o \
-                                         $(OBJDIR)/modules/audit/audit_bus.o \
+                                         $(OBJDIR)/modules/audit/obs_bus.o \
                                          $(OBJDIR)/modules/audit/audit_ledger.o \
                                          $(OBJDIR)/modules/audit/audit_action.o \
                                          $(OBJDIR)/modules/workflows/wfe_canonical.o \
@@ -2913,12 +2913,12 @@ unit-test-bus-vault-audit: $(TESTPREFIX)/unit-test-bus-vault-audit
 # (check_bus_perf_gate.sh) force-builds + runs it via this .PHONY target instead.
 
 # Sandbox degraded-isolation audit, end-to-end through the REAL server bridge
-# (sandbox_audit_bridge.o) -> audit_bus -> ledger. Same bus link set as the audit
+# (sandbox_audit_bridge.o) -> obs_bus -> ledger. Same bus link set as the audit
 # durability test, plus the bridge, posix/sandbox.o, and audit_action.o.
 $(TESTPREFIX)/unit-test-bus-sandbox-audit: $(OBJDIR)/tests/test_bus_sandbox_audit.o \
                                            $(OBJDIR)/server/sandbox_audit_bridge.o \
                                            $(OBJDIR)/posix/sandbox.o \
-                                           $(OBJDIR)/modules/audit/audit_bus.o \
+                                           $(OBJDIR)/modules/audit/obs_bus.o \
                                            $(OBJDIR)/modules/audit/audit_ledger.o \
                                            $(OBJDIR)/modules/audit/audit_action.o \
                                            $(OBJDIR)/modules/workflows/wfe_canonical.o \
@@ -2938,11 +2938,11 @@ $(TESTPREFIX)/unit-test-bus-sandbox-audit: $(OBJDIR)/tests/test_bus_sandbox_audi
 unit-test-bus-sandbox-audit: $(TESTPREFIX)/unit-test-bus-sandbox-audit
 	$<
 
-# Shutdown race: concurrent producers vs audit_bus_stop() (regression test for the
+# Shutdown race: concurrent producers vs obs_bus_stop() (regression test for the
 # in-flight-emit-vs-teardown UAF). Same link set as the guardrail durability test.
 $(OBJDIR)/tests/test_bus_shutdown_race.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-bus-shutdown-race: $(OBJDIR)/tests/test_bus_shutdown_race.o \
-                                           $(OBJDIR)/modules/audit/audit_bus.o \
+                                           $(OBJDIR)/modules/audit/obs_bus.o \
                                            $(OBJDIR)/modules/audit/audit_ledger.o \
                                            $(OBJDIR)/aimee_home.o \
                                            $(OBJDIR)/modules/bus/bus_client.o \
@@ -5756,13 +5756,13 @@ $(TESTPREFIX)/unit-test-kb-mdl: $(OBJDIR)/tests/test_kb_mdl.o \
                      $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
 
-# guardrails_semantic.o -> audit_bus_emit_guardrail, so this test now links the
+# guardrails_semantic.o -> obs_bus_emit_guardrail, so this test now links the
 # bus (gsem_record records over it) plus the bus's own deps.
 $(OBJDIR)/tests/test_guardrails_semantic.o: C_FLAGS += -Imodules/bus
 $(TESTPREFIX)/unit-test-guardrails-semantic: $(OBJDIR)/tests/test_guardrails_semantic.o \
                      $(OBJDIR)/modules/guardrails/guardrails_semantic.o \
                      $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/guardrail_events.o \
-                     $(OBJDIR)/modules/audit/audit_bus.o $(OBJDIR)/modules/audit/audit_ledger.o \
+                     $(OBJDIR)/modules/audit/obs_bus.o $(OBJDIR)/modules/audit/audit_ledger.o \
                      $(OBJDIR)/aimee_home.o \
                      $(OBJDIR)/modules/bus/bus_client.o $(OBJDIR)/modules/bus/bus_host.o \
                      $(OBJDIR)/modules/bus/bus_route.o $(OBJDIR)/modules/bus/bus_region.o \

--- a/src/tests/test_bus_audit_durability.c
+++ b/src/tests/test_bus_audit_durability.c
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <time.h>
 
-#include "audit_bus.h"
+#include "obs_bus.h"
 #include "audit_ledger.h"
 #include "cJSON.h"
 #include "log.h"
@@ -59,9 +59,9 @@ int main(void)
    setenv("AIMEE_HOME", home, 1);
    audit_log_open(); /* opens audit.log under AIMEE_HOME so the consumer can append */
 
-   if (audit_bus_start() != 0)
+   if (obs_bus_start() != 0)
    {
-      fprintf(stderr, "FAIL: audit_bus_start\n");
+      fprintf(stderr, "FAIL: obs_bus_start\n");
       return 1;
    }
 
@@ -75,15 +75,15 @@ int main(void)
       snprintf(tool, sizeof tool, "Tool_%d", i % 7);
       snprintf(hash, sizeof hash, "v1-%d", i);
       uint64_t s = now_ns();
-      audit_bus_emit("primary", tool, hash, "cd ; rm", "approve", "read_before_write", "block", i);
+      obs_bus_emit("primary", tool, hash, "cd ; rm", "approve", "read_before_write", "block", i);
       emit_ns[i] = now_ns() - s;
    }
 
    /* Stop drains every in-flight row before returning. */
-   audit_bus_stop();
+   obs_bus_stop();
 
-   uint64_t dropped = audit_bus_dropped();
-   uint64_t written = audit_bus_written();
+   uint64_t dropped = obs_bus_dropped();
+   uint64_t written = obs_bus_written();
    printf("  emitted %d, written %llu, dropped %llu\n", N, (unsigned long long)written,
           (unsigned long long)dropped);
    if (dropped != 0)

--- a/src/tests/test_bus_audit_replay.c
+++ b/src/tests/test_bus_audit_replay.c
@@ -20,14 +20,14 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "audit_bus.h"
+#include "obs_bus.h"
 #include "bus_capture.h"
 #include "log.h"
 
 #define N                 3000
-#define KIND_AUDIT_ACTION 3000 /* must match audit_bus.c */
+#define KIND_AUDIT_ACTION 3000 /* must match obs_bus.c */
 
-/* Read a length-prefixed string from the audit-row payload (audit_bus.c's wire
+/* Read a length-prefixed string from the audit-row payload (obs_bus.c's wire
  * form: 7 length-prefixed strings then an int64 task_id). Returns new offset or
  * 0 on malformed input. */
 static uint32_t get_str(const uint8_t *b, uint32_t off, uint32_t len, char *out, uint32_t cap)
@@ -99,9 +99,9 @@ int main(void)
    setenv("AIMEE_HOME", home, 1);
    audit_log_open();
 
-   if (audit_bus_start() != 0)
+   if (obs_bus_start() != 0)
    {
-      fprintf(stderr, "FAIL: audit_bus_start\n");
+      fprintf(stderr, "FAIL: obs_bus_start\n");
       return 1;
    }
 
@@ -113,9 +113,9 @@ int main(void)
       snprintf(tool, sizeof tool, "Tool_%d", i % 7);
       snprintf(hash, sizeof hash, "v1-%d", i);
       const char *verdict = (i % 2) ? "block" : "allow";
-      audit_bus_emit("primary", tool, hash, "cd ; rm", "approve", "read_before_write", verdict, i);
+      obs_bus_emit("primary", tool, hash, "cd ; rm", "approve", "read_before_write", verdict, i);
    }
-   audit_bus_stop(); /* final flush persists the capture stream */
+   obs_bus_stop(); /* final flush persists the capture stream */
 
    /* Find this session's capture file (named audit-bus-capture-<time>-<pid>.aimeecap). */
    char path[4096];

--- a/src/tests/test_bus_audit_replay_tool.c
+++ b/src/tests/test_bus_audit_replay_tool.c
@@ -3,7 +3,7 @@
  *
  * The bus-level replay is proven elsewhere (test_bus_audit_replay); this covers
  * the OPERATOR path: run a real audit session, then feed its capture file to
- * audit_bus_replay_print and require the rendered output to name every recorded
+ * obs_bus_replay_print and require the rendered output to name every recorded
  * governed-action row and report the stream status.
  */
 #include <assert.h>
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#include "audit_bus.h"
+#include "obs_bus.h"
 #include "audit_replay.h"
 #include "cJSON.h"
 #include "log.h"
@@ -33,15 +33,15 @@ int main(void)
    setenv("AIMEE_HOME", home, 1);
    audit_log_open();
 
-   assert(audit_bus_start() == 0);
+   assert(obs_bus_start() == 0);
    for (int i = 0; i < ROWS; i++)
    {
       char tool[32];
       snprintf(tool, sizeof tool, "Tool_%d", i % 7);
-      audit_bus_emit("primary", tool, "v1-x", "cd ; rm", "approve", "read_before_write",
-                     (i % 2) ? "block" : "allow", i);
+      obs_bus_emit("primary", tool, "v1-x", "cd ; rm", "approve", "read_before_write",
+                   (i % 2) ? "block" : "allow", i);
    }
-   audit_bus_stop();
+   obs_bus_stop();
 
    /* Locate the session capture file. */
    char path[4096];
@@ -63,12 +63,12 @@ int main(void)
    size_t osz = 0;
    FILE *m = open_memstream(&obuf, &osz);
    assert(m);
-   int rc = audit_bus_replay_print(path, m);
+   int rc = obs_bus_replay_print(path, m);
    fclose(m);
 
    if (rc != 0)
    {
-      fprintf(stderr, "FAIL: audit_bus_replay_print returned %d for a valid stream\n", rc);
+      fprintf(stderr, "FAIL: obs_bus_replay_print returned %d for a valid stream\n", rc);
       return 1;
    }
    char needle[64];
@@ -92,14 +92,14 @@ int main(void)
    free(obuf);
 
    /* NULL out: classify without printing, still valid. */
-   if (audit_bus_replay_print(path, NULL) != 0)
+   if (obs_bus_replay_print(path, NULL) != 0)
    {
       fprintf(stderr, "FAIL: classify-only pass rejected a valid stream\n");
       return 1;
    }
 
    /* A missing file is a clean error, not a crash. */
-   if (audit_bus_replay_print("/no/such/capture.aimeecap", NULL) != -1)
+   if (obs_bus_replay_print("/no/such/capture.aimeecap", NULL) != -1)
    {
       fprintf(stderr, "FAIL: a missing capture file should return -1\n");
       return 1;
@@ -139,16 +139,16 @@ int main(void)
 
    /* Byte budget (regression for the /v1 256 KB overflow): a large capture must
     * be PAGED even with a big row limit, never materialized past the budget. */
-   const int BIG = 2500;           /* ~150 B/row >> the 200 KB budget */
-   assert(audit_bus_start() == 0); /* fresh session (clears the terminated guard) */
+   const int BIG = 2500;         /* ~150 B/row >> the 200 KB budget */
+   assert(obs_bus_start() == 0); /* fresh session (clears the terminated guard) */
    for (int i = 0; i < BIG; i++)
    {
       char t[32], h[32];
       snprintf(t, sizeof t, "Tool_%d", i % 7);
       snprintf(h, sizeof h, "v1-%d", i);
-      audit_bus_emit("primary", t, h, "cd ; rm", "approve", "read_before_write", "block", i);
+      obs_bus_emit("primary", t, h, "cd ; rm", "approve", "read_before_write", "block", i);
    }
-   audit_bus_stop();
+   obs_bus_stop();
    /* Pick the largest capture file (the BIG session's). */
    char big[4096];
    big[0] = '\0';

--- a/src/tests/test_bus_audit_retention.c
+++ b/src/tests/test_bus_audit_retention.c
@@ -18,10 +18,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "audit_bus.h"
+#include "obs_bus.h"
 #include "log.h"
 
-#define KEEP 16 /* must match AB_CAP_KEEP in audit_bus.c */
+#define KEEP 16 /* must match AB_CAP_KEEP in obs_bus.c */
 
 static int count_capture_files(const char *dir)
 {
@@ -88,14 +88,14 @@ int main(void)
    printf("  seeded %d old capture files (retention bound %d)\n", seeded, KEEP);
 
    /* Run a real audit session: it creates one live file and prunes to KEEP. */
-   if (audit_bus_start() != 0)
+   if (obs_bus_start() != 0)
    {
-      fprintf(stderr, "FAIL: audit_bus_start\n");
+      fprintf(stderr, "FAIL: obs_bus_start\n");
       return 1;
    }
    for (int i = 0; i < 200; i++)
-      audit_bus_emit("primary", "Write", "v1-x", "cd ; rm", "approve", "reason", "block", i);
-   audit_bus_stop();
+      obs_bus_emit("primary", "Write", "v1-x", "cd ; rm", "approve", "reason", "block", i);
+   obs_bus_stop();
 
    int remaining = count_capture_files(home);
    printf("  after a session + prune: %d capture files remain\n", remaining);

--- a/src/tests/test_bus_guardrail_durability.c
+++ b/src/tests/test_bus_guardrail_durability.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "audit_bus.h" /* audit_bus_*, guardrail_event_t, db1_guardrail_event_* */
+#include "obs_bus.h" /* obs_bus_*, guardrail_event_t, db1_guardrail_event_* */
 #include "db1/db1.h"
 
 #define N 2000
@@ -39,7 +39,7 @@ int main(void)
    /* Each event carries a UNIQUE identity (session_id "s<i>") and per-i field
     * values, so the read-back can prove exactly-once (a loss+dup that nets to N
     * would fail the seen[] check) AND that every field round-tripped the wire. */
-   assert(audit_bus_start() == 0);
+   assert(obs_bus_start() == 0);
    for (int i = 0; i < N; i++)
    {
       guardrail_event_t e;
@@ -56,12 +56,12 @@ int main(void)
       snprintf(e.final_action, sizeof e.final_action, (i % 2) ? "block" : "allow");
       snprintf(e.explanation, sizeof e.explanation, "expl %d", i);
       e.dry_run = i % 2;
-      audit_bus_emit_guardrail(&e);
+      obs_bus_emit_guardrail(&e);
    }
-   audit_bus_stop(); /* drains every in-flight event to db1 */
+   obs_bus_stop(); /* drains every in-flight event to db1 */
 
-   uint64_t dropped = audit_bus_dropped();
-   uint64_t written = audit_bus_written();
+   uint64_t dropped = obs_bus_dropped();
+   uint64_t written = obs_bus_written();
    printf("  emitted %d, written %llu, dropped %llu\n", N, (unsigned long long)written,
           (unsigned long long)dropped);
    if (dropped != 0 || written != (uint64_t)N)

--- a/src/tests/test_bus_sandbox_audit.c
+++ b/src/tests/test_bus_sandbox_audit.c
@@ -18,7 +18,7 @@
 #include <unistd.h>
 
 #include "audit_action.h" /* audit_ensure_key */
-#include "audit_bus.h"
+#include "obs_bus.h"
 #include "audit_ledger.h"
 #include "cJSON.h"
 #include "log.h" /* audit_log_open */
@@ -101,7 +101,7 @@ int main(void)
    pid_t rc = sandbox_exec_with_readonly(&cfg, "npm publish", devnull, devnull, NULL, NULL, NULL);
    assert(rc == -1);
 
-   audit_bus_stop(); /* drain to the ledger */
+   obs_bus_stop(); /* drain to the ledger */
 
    cJSON *rows = audit_ledger_read(NULL, NULL);
    assert(rows);

--- a/src/tests/test_bus_shutdown_race.c
+++ b/src/tests/test_bus_shutdown_race.c
@@ -1,6 +1,6 @@
-/* test_bus_shutdown_race.c: concurrent producers racing audit_bus_stop().
+/* test_bus_shutdown_race.c: concurrent producers racing obs_bus_stop().
  *
- * Regression test for the shutdown race: audit_bus_stop() used to tear down the
+ * Regression test for the shutdown race: obs_bus_stop() used to tear down the
  * producer / host / pub_lock while in-flight emit() calls were still using them —
  * a use-after-free, and silently lost rows. The fix makes emit register in a
  * publisher refcount before re-checking `emitting`, and stop wait for that count
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <time.h>
 
-#include "audit_bus.h"
+#include "obs_bus.h"
 #include "db1/db1.h"
 
 #define NTHREADS 4
@@ -37,7 +37,7 @@ static void *producer(void *arg)
     * every row unambiguously (see the categorization in guardrail_events.c). */
    snprintf(e.final_action, sizeof e.final_action, "block");
    while (atomic_load(&g_keep_going))
-      audit_bus_emit_guardrail(&e); /* emits before, during, and after stop() */
+      obs_bus_emit_guardrail(&e); /* emits before, during, and after stop() */
    return NULL;
 }
 
@@ -53,7 +53,7 @@ int main(void)
    }
    setenv("AIMEE_HOME", home, 1);
    assert(db1_init(":memory:") == 0);
-   assert(audit_bus_start() == 0);
+   assert(obs_bus_start() == 0);
 
    pthread_t th[NTHREADS];
    for (long i = 0; i < NTHREADS; i++)
@@ -63,15 +63,15 @@ int main(void)
     * this is the window the fix protects. */
    struct timespec warmup = {.tv_sec = 0, .tv_nsec = 20 * 1000 * 1000}; /* 20 ms */
    nanosleep(&warmup, NULL);
-   audit_bus_stop(); /* must quiesce in-flight producers before teardown */
+   obs_bus_stop(); /* must quiesce in-flight producers before teardown */
 
    /* Producers keep calling after stop; those are rejected no-ops. Now wind down. */
    atomic_store(&g_keep_going, 0);
    for (int i = 0; i < NTHREADS; i++)
       pthread_join(th[i], NULL);
 
-   uint64_t written = audit_bus_written();
-   uint64_t dropped = audit_bus_dropped();
+   uint64_t written = obs_bus_written();
+   uint64_t dropped = obs_bus_dropped();
 
    /* Consistency: every guardrail event counted as WRITTEN must actually be in
     * db1 — no silent loss, no double count. */

--- a/src/tests/test_bus_vault_audit.c
+++ b/src/tests/test_bus_vault_audit.c
@@ -17,7 +17,7 @@
 #include <string.h>
 
 #include "audit_action.h" /* audit_ensure_key */
-#include "audit_bus.h"
+#include "obs_bus.h"
 #include "audit_ledger.h"
 #include "cJSON.h"
 #include "log.h" /* audit_log_open */
@@ -79,7 +79,7 @@ int main(void)
    audit_ensure_key(); /* so args_hash is a real keyed digest, not the sentinel */
    vault_kek_cache_clear();
 
-   /* Install the REAL bridge: vault access -> hook -> audit_bus -> ledger. */
+   /* Install the REAL bridge: vault access -> hook -> obs_bus -> ledger. */
    vault_audit_bridge_install();
 
    const char *p = "uid:7000";
@@ -97,7 +97,7 @@ int main(void)
    assert(vault_service_delete(p, "claude", "api_key") == VAULT_OK);
    assert(vault_service_unlock(p, ATTEST_TCP_BEARER, rk, sizeof rk, T0) == VAULT_ERR_TRANSPORT);
 
-   audit_bus_stop(); /* drains every in-flight row into the ledger */
+   obs_bus_stop(); /* drains every in-flight row into the ledger */
 
    cJSON *rows = audit_ledger_read(NULL, NULL);
    assert(rows);

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include "aimee.h"
 #include "db.h"
-#include "audit_bus.h" /* audit_bus_flush — gsem_record records guardrail events async now */
+#include "obs_bus.h" /* obs_bus_flush — gsem_record records guardrail events async now */
 #include "db1.h"
 #include "db2.h"
 #include "db2_test_shim.h"
@@ -2098,7 +2098,7 @@ static void test_semantic_advisory_pre_tool_check(void)
 
    /* gsem_record now records over the event bus (async); flush so the count
     * baseline and the post-check counts reflect the writes deterministically. */
-   audit_bus_flush();
+   obs_bus_flush();
    guardrail_event_counts_t before_counts;
    assert(db1_guardrail_event_counts_7d(&before_counts) == 0);
 
@@ -2129,7 +2129,7 @@ static void test_semantic_advisory_pre_tool_check(void)
    assert(rc == 0);
    assert(strstr(msg, "semantic guardrail: high risk") != NULL);
 
-   audit_bus_flush(); /* drain the two async guardrail events into db1 before counting */
+   obs_bus_flush(); /* drain the two async guardrail events into db1 before counting */
    guardrail_event_counts_t counts;
    assert(db1_guardrail_event_counts_7d(&counts) == 0);
    assert(counts.warn == before_counts.warn);

--- a/src/tests/test_guardrails_semantic.c
+++ b/src/tests/test_guardrails_semantic.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "audit_bus.h" /* gsem_record now records via the bus; drain it before asserting */
+#include "obs_bus.h" /* gsem_record now records via the bus; drain it before asserting */
 #include "db1.h"
 #include "guardrail_events.h"
 #include "guardrails_semantic.h"
@@ -276,7 +276,7 @@ static void test_gsem_record(const char *path)
 
    /* The insert is now asynchronous (bus consumer). Drain before asserting: stop
     * flushes every in-flight event to db1 before it returns. */
-   audit_bus_stop();
+   obs_bus_stop();
 
    guardrail_event_counts_t counts;
    assert(db1_guardrail_event_counts_7d(&counts) == 0);


### PR DESCRIPTION
## What

Pure mechanical refactor, **no behavior change**. The in-process shared-memory bus began as the governed-action audit row's migration, but now carries **four** off-critical-path observability event kinds — audit rows, guardrail-semantic risk events, and (via server-only bridges reusing the action kind) vault credential-access + sandbox isolation-degradation audits. So `audit_bus` had become a misnomer; this renames it to `obs_bus` (observability bus).

## Scope — the transport only

Renamed:
- `modules/audit/audit_bus.{c,h}` → `obs_bus.{c,h}`
- `audit_bus_*` → `obs_bus_*`, `AUDIT_BUS_KIND_*` → `OBS_BUS_KIND_*`, include guard, the `"audit_bus"` log tag
- the D7 allowlist path (`check_bus_blast_radius.sh`), bench-gate comments, and `docs/dev/EVENT_BUS_DECISIONS.md`

**Deliberately unchanged** — these are genuinely about the audit *record*, not the transport: `audit_ledger`, `audit_action`, `audit_worm`, `audit_replay`, the `guardrails_action_audit` / `vault_audit_bridge` / `sandbox_audit_bridge` filenames, the `/v1 /audit/*` routes, and the `--audit-replay` CLI flag. The file stays in `modules/audit/` (rename only; no directory move — a possible further tidy, deferred to keep this a low-risk mechanical change).

## Verification

- `aimee-server` + all shipping binaries build & link.
- **D7 blast-radius gate green** (7/7; the layer-2 allowlist regex updated from `audit_(bus|replay)` to `(obs_bus|audit_replay)` for the renamed compile rule).
- clang-format-19 clean; every test binary links.
- All bus tests (durability, replay, retention, shutdown-race, guardrail, vault, sandbox) and guardrails tests pass.
- Full `check_bus_perf_gate` green.