### PR TITLE
Audit server-side memory mutations over the event bus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,6 +886,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_audit_replay_routes.c
     ${AIMEE_SRC_DIR}/server/vault_audit_bridge.c
     ${AIMEE_SRC_DIR}/server/sandbox_audit_bridge.c
+    ${AIMEE_SRC_DIR}/server/memory_audit_bridge.c
     ${AIMEE_SRC_DIR}/server/server_runner_endpoints.c
     ${AIMEE_SRC_DIR}/server/server_state_audit.c
     ${AIMEE_SRC_DIR}/server/server_css_query.c
@@ -896,6 +897,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_audit_replay_routes.c
     ${AIMEE_SRC_DIR}/server/vault_audit_bridge.c
     ${AIMEE_SRC_DIR}/server/sandbox_audit_bridge.c
+    ${AIMEE_SRC_DIR}/server/memory_audit_bridge.c
     ${AIMEE_SRC_DIR}/server/server_runner_endpoints.c
     ${AIMEE_SRC_DIR}/server/server_state_audit.c
     ${AIMEE_SRC_DIR}/server/server_css_query.c
@@ -968,6 +970,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/modules/kb_client/kb_client_index_parse.c
     ${AIMEE_SRC_DIR}/modules/kb_client/kb_client_memory.c
     ${AIMEE_SRC_DIR}/modules/kb_client/kb_client_memory_mutations.c
+    ${AIMEE_SRC_DIR}/modules/kb_client/kb_client_memory_audit.c
     ${AIMEE_SRC_DIR}/modules/kb_client/kb_client_agent.c
     ${AIMEE_SRC_DIR}/modules/kb_client/kb_client_dashboard.c
     ${AIMEE_SRC_DIR}/modules/kb_client/kb_client_tasks.c

--- a/scripts/check_bus_perf_gate.sh
+++ b/scripts/check_bus_perf_gate.sh
@@ -127,4 +127,18 @@ if ! printf '%s\n' "$sbx_out" | grep -q "test_bus_sandbox_audit: OK"; then
 fi
 echo "sandbox audit: ok (degraded isolation -> bridge -> bus -> ledger; no secret leak)"
 
-echo "check_bus_perf_gate: ok — dispatch + audit within budget; audit durability holds; vault-access + sandbox audit hold; memory rows pending"
+# 6. The server-side memory-mutation audit trail: a memory change the server
+#    requested via kb_client flows through the REAL bridge -> obs_bus -> ledger,
+#    identity recorded, memory content never present. Same special-link reason.
+echo "checking server-side memory-mutation audit trail..."
+mem_out=$(make -C src --no-print-directory unit-test-bus-memory-audit 2>&1 || true)
+if ! printf '%s\n' "$mem_out" | grep -q "test_bus_memory_audit: OK"; then
+   echo "" >&2
+   echo "FAIL: the memory-on-bus audit test did not pass — a memory mutation is not" >&2
+   echo "      being recorded correctly through the bridge, or content leaked." >&2
+   printf '%s\n' "$mem_out" | tail -8 >&2
+   exit 1
+fi
+echo "memory audit: ok (mutation -> bridge -> bus -> ledger; no content)"
+
+echo "check_bus_perf_gate: ok — dispatch + audit within budget; audit durability holds; vault-access + sandbox + memory audit hold; memory rows pending"

--- a/src/Makefile
+++ b/src/Makefile
@@ -460,6 +460,9 @@ SERVER_SRCS += server/vault_audit_bridge.c
 # Likewise, the sole object linking sandbox.c to the audit bus (sandbox.o stays
 # bus-free). Server-only.
 SERVER_SRCS += server/sandbox_audit_bridge.c
+# The sole object linking kb_client's memory mutations to the audit bus (kb_client
+# stays bus-free). Server-only.
+SERVER_SRCS += server/memory_audit_bridge.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) modules/guardrails/guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \
@@ -477,7 +480,7 @@ SERVER_CMD_OBJS = $(OBJDIR)/server/cmd_session_lifecycle.o \
 # kb_client objects — request-side glue from the daemon to the
 # aimee-kb sidecar. The daemon needs these so server_state /
 # server_mcp_learning can route DB2-bound work over the kb socket.
-KB_CLIENT_OBJS = $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_ws.o $(OBJDIR)/modules/kb_client/kb_client_docs.o $(OBJDIR)/kb/kb_doc_hash.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/modules/kb_client/kb_client_index_parse.o $(OBJDIR)/modules/kb_client/kb_client_pdf.o $(OBJDIR)/modules/kb_client/kb_client_code_graph.o $(OBJDIR)/modules/kb_client/kb_client_code_embed.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o \
+KB_CLIENT_OBJS = $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_ws.o $(OBJDIR)/modules/kb_client/kb_client_docs.o $(OBJDIR)/kb/kb_doc_hash.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/modules/kb_client/kb_client_index_parse.o $(OBJDIR)/modules/kb_client/kb_client_pdf.o $(OBJDIR)/modules/kb_client/kb_client_code_graph.o $(OBJDIR)/modules/kb_client/kb_client_code_embed.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o \
                  $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o \
                  $(OBJDIR)/modules/kb_client/kb_client_tool_registry.o $(OBJDIR)/modules/kb_client/kb_client_prospective.o \
                  $(OBJDIR)/modules/kb_client/kb_client_roadmap.o \

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -623,9 +623,10 @@ typedef void (*kb_client_memory_audit_hook_fn)(const char *op, int64_t id, const
                                                const char *session_id, int ok);
 void kb_client_set_memory_audit_hook(kb_client_memory_audit_hook_fn fn);
 
-/* Internal: fire the memory-audit hook (if installed). Defined in
- * kb_client_memory_mutations.c; callable from the other kb_client memory TUs
- * (e.g. kb_client_memory.c for delete). */
+/* Internal: fire the memory-audit hook (if installed). Defined in the dep-free
+ * kb_client_memory_audit.c (kept free of RPC/cJSON so the bridge->bus test can
+ * link the seam without the whole kb_client stack); callable from the kb_client
+ * memory TUs (mutations, and kb_client_memory.c for delete). */
 void kb_client_memory_audit_note(const char *op, int64_t id, const char *tier, const char *kind,
                                  const char *key, double confidence, const char *session_id,
                                  int ok);

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -608,6 +608,28 @@ int kb_client_memory_link_create(int64_t source_id, int64_t target_id, const cha
 int kb_client_memory_link_query(int64_t memory_id, memory_link_t *out, int max);
 int kb_client_memory_link_delete(int64_t link_id);
 
+/* Audit hook: notified after each SERVER-INITIATED memory mutation via aimee-kb
+ * (insert / update / delete / reject) with NON-CONTENT fields only — the
+ * operation, the memory id, and (for insert) the tier / kind / key identity,
+ * confidence, and session — plus whether the kb call succeeded. The memory
+ * CONTENT (and use_cases / reject reason), the PII-bearing payload, is NEVER
+ * passed. This is the SERVER's view of the memory changes it requested; aimee-kb
+ * records the authoritative event on its own bus at the mutation site. Installed
+ * once at startup by a server-only bridge forwarding to the observability bus;
+ * kb_client itself has NO event-bus dependency (stays linkable everywhere). NULL
+ * by default. Set once before serving. */
+typedef void (*kb_client_memory_audit_hook_fn)(const char *op, int64_t id, const char *tier,
+                                               const char *kind, const char *key, double confidence,
+                                               const char *session_id, int ok);
+void kb_client_set_memory_audit_hook(kb_client_memory_audit_hook_fn fn);
+
+/* Internal: fire the memory-audit hook (if installed). Defined in
+ * kb_client_memory_mutations.c; callable from the other kb_client memory TUs
+ * (e.g. kb_client_memory.c for delete). */
+void kb_client_memory_audit_note(const char *op, int64_t id, const char *tier, const char *kind,
+                                 const char *key, double confidence, const char *session_id,
+                                 int ok);
+
 /* Delete a memory by id via aimee-kb.  Returns 0 on success, -1 on
  * failure / kb unreachable.  Mirrors memory_delete(). */
 int kb_client_memory_delete(int64_t id);

--- a/src/modules/kb_client/kb_client_memory.c
+++ b/src/modules/kb_client/kb_client_memory.c
@@ -770,6 +770,7 @@ int kb_client_memory_delete(int64_t id)
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
    int rc = (cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0) ? 0 : -1;
    cJSON_Delete(resp);
+   kb_client_memory_audit_note("memory.delete", id, NULL, NULL, NULL, 0.0, NULL, rc == 0);
    return rc;
 }
 

--- a/src/modules/kb_client/kb_client_memory_audit.c
+++ b/src/modules/kb_client/kb_client_memory_audit.c
@@ -1,0 +1,25 @@
+/* kb_client_memory_audit.c: the server-side memory-mutation audit hook plumbing.
+ * Kept in its own dependency-free translation unit (no RPC/HTTP/cJSON) so the
+ * bridge->bus->ledger test can link the seam without dragging in the whole
+ * kb_client stack. See kb_client.h for the contract. */
+#include "kb_client.h"
+
+#include <stddef.h>
+
+/* Installed once at startup by the server-only bridge (NULL = no audit). */
+static kb_client_memory_audit_hook_fn g_mem_audit_hook = NULL;
+
+void kb_client_set_memory_audit_hook(kb_client_memory_audit_hook_fn fn)
+{
+   g_mem_audit_hook = fn;
+}
+
+void kb_client_memory_audit_note(const char *op, int64_t id, const char *tier, const char *kind,
+                                 const char *key, double confidence, const char *session_id, int ok)
+{
+   kb_client_memory_audit_hook_fn h = g_mem_audit_hook;
+   if (!h)
+      return;
+   h(op, id, tier ? tier : "", kind ? kind : "", key ? key : "", confidence,
+     session_id ? session_id : "", ok);
+}

--- a/src/modules/kb_client/kb_client_memory_mutations.c
+++ b/src/modules/kb_client/kb_client_memory_mutations.c
@@ -31,21 +31,30 @@ int kb_client_memory_supersede(int64_t old_id, const char *new_content, double c
       return -1;
 
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
-   if (!cJSON_IsString(status) || strcmp(status->valuestring, "ok") != 0)
-   {
-      cJSON_Delete(resp);
-      return -1;
-   }
-   if (out)
+   int ok = cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0;
+   int64_t new_id = old_id;
+   if (ok)
    {
       cJSON *mem = cJSON_GetObjectItemCaseSensitive(resp, "memory");
       if (cJSON_IsObject(mem))
-         kbc_memory_row_from_json(mem, out);
-      else
+      {
+         if (out)
+            kbc_memory_row_from_json(mem, out);
+         cJSON *id_j = cJSON_GetObjectItemCaseSensitive(mem, "id");
+         if (cJSON_IsNumber(id_j))
+            new_id = (int64_t)id_j->valuedouble;
+      }
+      else if (out)
+      {
          memset(out, 0, sizeof(*out));
+      }
    }
    cJSON_Delete(resp);
-   return 0;
+   /* supersede rewrites an existing memory's content — a server-initiated
+    * mutation, audited like the others (id-only; no kind/key, never content). */
+   kb_client_memory_audit_note("memory.supersede", new_id, NULL, NULL, NULL, confidence, session_id,
+                               ok);
+   return ok ? 0 : -1;
 }
 
 int kb_client_memory_fact_history(const char *key, memory_t *out, int max)
@@ -309,14 +318,10 @@ int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *k
       return -1;
 
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
-   if (!cJSON_IsString(status) || strcmp(status->valuestring, "ok") != 0)
-   {
-      cJSON_Delete(resp);
-      return -1;
-   }
+   int ok = cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0;
 
    int64_t rec_id = 0;
-   if (out)
+   if (ok && out)
    {
       memset(out, 0, sizeof(*out));
       cJSON *mem_j = cJSON_GetObjectItemCaseSensitive(resp, "memory");
@@ -332,7 +337,7 @@ int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *k
       }
       rec_id = out->id;
    }
-   else
+   else if (ok)
    {
       /* Extract the id for the audit note even when the caller wants no row back. */
       cJSON *mem_j = cJSON_GetObjectItemCaseSensitive(resp, "memory");
@@ -342,9 +347,12 @@ int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *k
          rec_id = (int64_t)id_j->valuedouble;
    }
    cJSON_Delete(resp);
-   /* NON-CONTENT audit: identity + confidence + session only, never the content. */
-   kb_client_memory_audit_note("memory.insert", rec_id, tier, kind, key, confidence, session_id, 1);
-   return 0;
+   /* NON-CONTENT audit: identity + confidence + session only, never the content.
+    * Fires on the kb's verdict (a kb-rejected insert is recorded as ok=0), so the
+    * trail records rejected stores too — symmetric with update/delete/reject. */
+   kb_client_memory_audit_note("memory.insert", rec_id, tier, kind, key, confidence, session_id,
+                               ok);
+   return ok ? 0 : -1;
 }
 
 int kb_client_memory_list_low_effectiveness(double threshold, int limit,

--- a/src/modules/kb_client/kb_client_memory_mutations.c
+++ b/src/modules/kb_client/kb_client_memory_mutations.c
@@ -3,6 +3,8 @@
 #include "memory_query.h"
 #include "tasks.h"
 
+#include "kb_client.h" /* kb_client_memory_audit_note (defined in kb_client_memory_audit.c) */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -313,6 +315,7 @@ int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *k
       return -1;
    }
 
+   int64_t rec_id = 0;
    if (out)
    {
       memset(out, 0, sizeof(*out));
@@ -327,8 +330,20 @@ int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *k
          if (cJSON_IsNumber(id_j))
             out->id = (int64_t)id_j->valuedouble;
       }
+      rec_id = out->id;
+   }
+   else
+   {
+      /* Extract the id for the audit note even when the caller wants no row back. */
+      cJSON *mem_j = cJSON_GetObjectItemCaseSensitive(resp, "memory");
+      cJSON *id_j = cJSON_IsObject(mem_j) ? cJSON_GetObjectItemCaseSensitive(mem_j, "id")
+                                          : cJSON_GetObjectItemCaseSensitive(resp, "id");
+      if (cJSON_IsNumber(id_j))
+         rec_id = (int64_t)id_j->valuedouble;
    }
    cJSON_Delete(resp);
+   /* NON-CONTENT audit: identity + confidence + session only, never the content. */
+   kb_client_memory_audit_note("memory.insert", rec_id, tier, kind, key, confidence, session_id, 1);
    return 0;
 }
 
@@ -544,6 +559,7 @@ int kb_client_memory_update(int64_t id, const char *content)
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
    int rc = (cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0) ? 0 : -1;
    cJSON_Delete(resp);
+   kb_client_memory_audit_note("memory.update", id, NULL, NULL, NULL, 0.0, NULL, rc == 0);
    return rc;
 }
 
@@ -565,5 +581,6 @@ int kb_client_memory_reject(int64_t id, const char *reason)
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
    int rc = (cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0) ? 0 : -1;
    cJSON_Delete(resp);
+   kb_client_memory_audit_note("memory.reject", id, NULL, NULL, NULL, 0.0, NULL, rc == 0);
    return rc;
 }

--- a/src/server/memory_audit_bridge.c
+++ b/src/server/memory_audit_bridge.c
@@ -10,22 +10,57 @@
 #include "audit_action.h" /* audit_args_hash, AUDIT_ARGS_HASH_LEN */
 #include "kb_client.h"    /* kb_client_set_memory_audit_hook */
 #include "obs_bus.h"      /* obs_bus_emit */
+#include "wfe_def.h"      /* wfe_sha256_raw */
+
+/* A PII-safe fingerprint of the memory's (kind, key) identity. BOTH the key and
+ * (on the MCP path) the kind are agent-supplied free text that can embed PII or a
+ * value — the KB gates memory CONTENT but NOT the key — so the identity is NEVER
+ * recorded verbatim. A one-way hash preserves correlation (same identity -> same
+ * handle) without exposing it; the numeric memory id (task_id) is the handle for
+ * an authorized KB lookup of the details. */
+static void identity_fingerprint(const char *kind, const char *key, char *out, size_t out_len)
+{
+   if (out_len < 16)
+   {
+      if (out_len)
+         out[0] = '\0';
+      return;
+   }
+   char buf[1200];
+   int n = snprintf(buf, sizeof buf, "%s\x1f%s", kind ? kind : "", key ? key : "");
+   size_t len = (n < 0) ? 0 : ((size_t)n < sizeof buf ? (size_t)n : sizeof buf);
+   unsigned char dig[32];
+   if (wfe_sha256_raw(buf, len, dig) != 0)
+   {
+      snprintf(out, out_len, "mk:?");
+      return;
+   }
+   static const char hx[] = "0123456789abcdef";
+   out[0] = 'm';
+   out[1] = 'k';
+   out[2] = ':';
+   for (int i = 0; i < 6; i++)
+   {
+      out[3 + i * 2] = hx[(dig[i] >> 4) & 0xf];
+      out[3 + i * 2 + 1] = hx[dig[i] & 0xf];
+   }
+   out[15] = '\0';
+}
 
 /* kb_client_memory_audit_hook_fn: publish one memory-mutation audit row over the
  * bus (KIND_ACTION -> the audit ledger + capture/replay). NON-SECRET only: actor
- * = the session that made the change (or "memory"), tool = the op, the memory's
- * (kind, key) identity in the command field (insert only; update/delete/reject
- * carry only the numeric id), the tier in mode, the confidence in reason_code,
- * the outcome as verdict, and the numeric memory id as task_id. The memory
- * CONTENT is never passed to the hook, so it cannot appear here. */
+ * = the session that made the change (or "memory"), tool = the op, a PII-safe
+ * FINGERPRINT of the memory's (kind, key) identity in the command field (insert /
+ * supersede only; id-only ops leave it empty), the tier in mode, the confidence
+ * in reason_code, the outcome as verdict, and the numeric memory id as task_id.
+ * The memory CONTENT is never passed to the hook, and the raw key/kind never
+ * reach the ledger (only their hash). */
 static void on_memory_mutation(const char *op, int64_t id, const char *tier, const char *kind,
                                const char *key, double confidence, const char *session_id, int ok)
 {
-   /* (kind, key) is the memory's non-content identity — human-readable, the
-    * correlation key for the row (insert only; "" for id-only ops). */
-   char command[256];
+   char command[32];
    if ((kind && kind[0]) || (key && key[0]))
-      snprintf(command, sizeof command, "%s/%s", kind ? kind : "", key ? key : "");
+      identity_fingerprint(kind, key, command, sizeof command);
    else
       command[0] = '\0';
 

--- a/src/server/memory_audit_bridge.c
+++ b/src/server/memory_audit_bridge.c
@@ -1,0 +1,48 @@
+/* memory_audit_bridge.c: forwards the server's kb_client memory mutations onto
+ * the observability bus. The one place that links kb_client to the (D7-confined)
+ * obs_bus — see memory_audit_bridge.h. Only NON-CONTENT fields cross here; the
+ * memory content (the PII payload) is never in scope — the hook already reduced
+ * the event to identity + outcome. */
+#include "memory_audit_bridge.h"
+
+#include <stdio.h>
+
+#include "audit_action.h" /* audit_args_hash, AUDIT_ARGS_HASH_LEN */
+#include "kb_client.h"    /* kb_client_set_memory_audit_hook */
+#include "obs_bus.h"      /* obs_bus_emit */
+
+/* kb_client_memory_audit_hook_fn: publish one memory-mutation audit row over the
+ * bus (KIND_ACTION -> the audit ledger + capture/replay). NON-SECRET only: actor
+ * = the session that made the change (or "memory"), tool = the op, the memory's
+ * (kind, key) identity in the command field (insert only; update/delete/reject
+ * carry only the numeric id), the tier in mode, the confidence in reason_code,
+ * the outcome as verdict, and the numeric memory id as task_id. The memory
+ * CONTENT is never passed to the hook, so it cannot appear here. */
+static void on_memory_mutation(const char *op, int64_t id, const char *tier, const char *kind,
+                               const char *key, double confidence, const char *session_id, int ok)
+{
+   /* (kind, key) is the memory's non-content identity — human-readable, the
+    * correlation key for the row (insert only; "" for id-only ops). */
+   char command[256];
+   if ((kind && kind[0]) || (key && key[0]))
+      snprintf(command, sizeof command, "%s/%s", kind ? kind : "", key ? key : "");
+   else
+      command[0] = '\0';
+
+   char reason[48];
+   reason[0] = '\0';
+   if (confidence > 0.0)
+      snprintf(reason, sizeof reason, "conf=%.2f", confidence);
+
+   char args_hash[AUDIT_ARGS_HASH_LEN];
+   snprintf(args_hash, sizeof args_hash, "v1-");
+   audit_args_hash(op, NULL, args_hash, sizeof args_hash);
+
+   obs_bus_emit(session_id && session_id[0] ? session_id : "memory", op, args_hash, command,
+                tier ? tier : "", reason, ok ? "ok" : "fail", (long long)id);
+}
+
+void memory_audit_bridge_install(void)
+{
+   kb_client_set_memory_audit_hook(on_memory_mutation);
+}

--- a/src/server/memory_audit_bridge.h
+++ b/src/server/memory_audit_bridge.h
@@ -1,0 +1,18 @@
+#ifndef AIMEE_MEMORY_AUDIT_BRIDGE_H
+#define AIMEE_MEMORY_AUDIT_BRIDGE_H 1
+
+/* Install the server-side memory-mutation audit hook, forwarding each memory
+ * change the server requests via aimee-kb (insert / update / delete / reject) to
+ * the observability bus — the same KIND_ACTION ledger + capture/replay stream the
+ * governed-action, guardrail, vault-access, and sandbox events use. This is the
+ * SERVER's view of "what the agent chose to remember / change / forget"; aimee-kb
+ * records the authoritative event on its own bus at the mutation site.
+ *
+ * Server-only by design: this bridge is the single object linking kb_client to
+ * the (D7-confined) obs_bus, keeping kb_client itself bus-free and linkable into
+ * every binary. Only NON-CONTENT fields cross — the memory content / use_cases /
+ * reject reason (the PII payload) is never in scope. Call once at server startup,
+ * after audit_ensure_key(). */
+void memory_audit_bridge_install(void);
+
+#endif /* AIMEE_MEMORY_AUDIT_BRIDGE_H */

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -37,6 +37,7 @@
 #include "vault_service.h"        /* VAULT_SERVER_PRINCIPAL (rotation target) */
 #include "vault_audit_bridge.h"   /* route vault credential-access events onto the audit bus */
 #include "sandbox_audit_bridge.h" /* route sandbox degraded-isolation events onto the audit bus */
+#include "memory_audit_bridge.h"  /* route server-side memory mutations onto the audit bus */
 #include "audit_replay.h"         /* --audit-replay: inspect a governed-action capture file */
 #include <signal.h>
 #include <errno.h>
@@ -167,6 +168,7 @@ static int run_server(const char *socket_path, log_level_t log_level)
    audit_ensure_key();             /* provision the per-action audit key (best-effort) */
    vault_audit_bridge_install();   /* route vault credential-access events onto the audit bus */
    sandbox_audit_bridge_install(); /* route sandbox degraded-isolation events onto the audit bus */
+   memory_audit_bridge_install();  /* route server-side memory mutations onto the audit bus */
 
    /* Activate the GitHub App installation-token provider for the server's forge
     * identity. Inert unless AIMEE_FORGE_APP_* is set (see forge_app_token.c). */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -53,7 +53,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/modules/workspace/workspace.o $(OBJDIR)/mo
                              $(OBJDIR)/server/agent_runtime.o $(OBJDIR)/server/agent_request_build.o $(OBJDIR)/tests/support/ir_shadow_stubs.o $(OBJDIR)/server/agent_logging.o $(OBJDIR)/server/request_context.o $(OBJDIR)/server/modules/skill/skill_review.o $(OBJDIR)/modules/skill/skill_curator.o $(OBJDIR)/server/agent_context_budget.o $(OBJDIR)/prompts.o $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_mistral.o $(OBJDIR)/server/cli_acp.o $(OBJDIR)/conversation_context.o $(OBJDIR)/server/provider_catalog.o $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/server/agent_request_shaping.o $(OBJDIR)/server/agent_policy.o $(OBJDIR)/server/model_sampling.o \
                              $(OBJDIR)/server/agent_tasks.o $(OBJDIR)/modules/agent_eval/agent_eval.o $(OBJDIR)/modules/agent_eval/agent_eval_memory_support.o $(OBJDIR)/modules/agent_eval/agent_eval_baseline.o \
                              $(OBJDIR)/server/agent_coord.o $(OBJDIR)/server/agent_tools.o $(OBJDIR)/modules/sandbox/sandbox_learned.o $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/server/script_runner.o $(OBJDIR)/server/script_rpc.o $(OBJDIR)/toolset.o $(OBJDIR)/server/tool_args_coerce.o $(OBJDIR)/server/tool_schema_sanitizer.o \
-                             $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_index_parse.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/tests/modules/kb_client/kb_client_tool_registry.o $(OBJDIR)/modules/kb_client/kb_client_prospective.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o \
+                             $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_index_parse.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/tests/modules/kb_client/kb_client_tool_registry.o $(OBJDIR)/modules/kb_client/kb_client_prospective.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o \
                              $(OBJDIR)/modules/protocols/mcp/mcp_client.o $(OBJDIR)/modules/protocols/mcp/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
@@ -1513,7 +1513,7 @@ $(TESTPREFIX)/unit-test-workspace-memory: $(OBJDIR)/tests/test_workspace_memory.
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-dashboard: $(OBJDIR)/tests/test_dashboard.o \
-                          $(OBJDIR)/dashboard.o $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/dashboard_server.o $(OBJDIR)/plugin.o $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o \
+                          $(OBJDIR)/dashboard.o $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/dashboard_server.o $(OBJDIR)/plugin.o $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o \
                           $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(DB1_OBJS) \
                           $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/decision_log.o $(OBJDIR)/db2/kb_audit_worm.o \
                           $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o \
@@ -1607,7 +1607,7 @@ $(TESTPREFIX)/unit-test-kb-client-search: $(OBJDIR)/tests/test_kb_client_search.
 $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client_cache.o \
-	                                  $(OBJDIR)/modules/kb_client/kb_client_memory.o \
+	                                  $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client_index_parse.o \
 	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
@@ -2938,6 +2938,32 @@ $(TESTPREFIX)/unit-test-bus-sandbox-audit: $(OBJDIR)/tests/test_bus_sandbox_audi
 unit-test-bus-sandbox-audit: $(TESTPREFIX)/unit-test-bus-sandbox-audit
 	$<
 
+# Server-side memory-mutation audit, end-to-end through the REAL bridge
+# (memory_audit_bridge.o) -> obs_bus -> ledger. Links the dep-free hook TU
+# (kb_client_memory_audit.o) — NOT the whole kb_client RPC stack.
+$(TESTPREFIX)/unit-test-bus-memory-audit: $(OBJDIR)/tests/test_bus_memory_audit.o \
+                                          $(OBJDIR)/server/memory_audit_bridge.o \
+                                          $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o \
+                                          $(OBJDIR)/modules/audit/obs_bus.o \
+                                          $(OBJDIR)/modules/audit/audit_ledger.o \
+                                          $(OBJDIR)/modules/audit/audit_action.o \
+                                          $(OBJDIR)/modules/workflows/wfe_canonical.o \
+                                          $(OBJDIR)/aimee_home.o \
+                                          $(OBJDIR)/modules/bus/bus_client.o \
+                                          $(OBJDIR)/modules/bus/bus_host.o \
+                                          $(OBJDIR)/modules/bus/bus_route.o \
+                                          $(OBJDIR)/modules/bus/bus_region.o \
+                                          $(OBJDIR)/modules/bus/bus_ring.o \
+                                          $(OBJDIR)/modules/bus/bus_arena.o \
+                                          $(OBJDIR)/modules/bus/bus_wire.o \
+                                          $(OBJDIR)/modules/bus/bus_capture.o \
+                                          $(BUS_MEM_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lpthread
+
+.PHONY: unit-test-bus-memory-audit
+unit-test-bus-memory-audit: $(TESTPREFIX)/unit-test-bus-memory-audit
+	$<
+
 # Shutdown race: concurrent producers vs obs_bus_stop() (regression test for the
 # in-flight-emit-vs-teardown UAF). Same link set as the guardrail durability test.
 $(OBJDIR)/tests/test_bus_shutdown_race.o: C_FLAGS += -Imodules/bus
@@ -3222,7 +3248,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(DB2_OBJS) \
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
-                            $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+                            $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                             $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
                             $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_bus_memory_audit.c
+++ b/src/tests/test_bus_memory_audit.c
@@ -1,0 +1,118 @@
+/* test_bus_memory_audit.c: the server-side memory-mutation audit trail, END TO
+ * END through the REAL bridge (memory_audit_bridge.c) onto the observability bus
+ * and into the ledger.
+ *
+ * The server requests memory changes via kb_client (insert/update/delete/reject);
+ * each fires kb_client_memory_audit_note, which this test drives directly (the
+ * seam — no live aimee-kb needed). It installs the real bridge, notes a few
+ * mutations, drains the async bus, then reads the ledger back and asserts each
+ * row's actor/tool/command/mode/verdict/task_id. The memory CONTENT never enters
+ * the hook (the signature has no content field), so it cannot reach the ledger;
+ * this test also pins that no distinctive content-like value appears. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "audit_action.h" /* audit_ensure_key */
+#include "cJSON.h"
+#include "kb_client.h" /* kb_client_memory_audit_note */
+#include "log.h"       /* audit_log_open */
+#include "modules/audit/obs_bus.h"
+#include "server/memory_audit_bridge.h"
+
+/* audit_ledger.h is not on the default include path from tests/ the same way;
+ * declare the one function we use. */
+extern struct cJSON *audit_ledger_read(const char *from_ts, const char *to_ts);
+
+static const char *sval(cJSON *row, const char *key)
+{
+   const char *v = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(row, key));
+   return v ? v : "";
+}
+
+static double nval(cJSON *row, const char *key)
+{
+   cJSON *j = cJSON_GetObjectItemCaseSensitive(row, key);
+   return cJSON_IsNumber(j) ? j->valuedouble : -1;
+}
+
+static cJSON *find_row(cJSON *rows, const char *tool, int64_t task_id)
+{
+   cJSON *r = NULL;
+   cJSON_ArrayForEach(r, rows)
+   {
+      if (strcmp(sval(r, "tool"), tool) == 0 && (int64_t)nval(r, "task_id") == task_id)
+         return r;
+   }
+   return NULL;
+}
+
+int main(void)
+{
+   printf("test_bus_memory_audit:\n");
+
+   char home[] = "/tmp/aimee-busmem-XXXXXX";
+   if (!mkdtemp(home))
+   {
+      fprintf(stderr, "FAIL: tmp home\n");
+      return 1;
+   }
+   setenv("AIMEE_HOME", home, 1);
+   audit_log_open();
+   audit_ensure_key();
+
+   /* Install the REAL bridge: kb_client memory note -> hook -> obs_bus -> ledger. */
+   memory_audit_bridge_install();
+
+   /* A distinctive content-like string we NEVER pass to the note — it must not
+    * appear anywhere in the ledger (the hook carries no content by construction). */
+   const char *content_marker = "MEMORY-CONTENT-DO-NOT-LOG-7f2a";
+
+   kb_client_memory_audit_note("memory.insert", 101, "L2", "fact", "ReleasePlan", 0.88, "sess-A",
+                               1);
+   kb_client_memory_audit_note("memory.update", 101, NULL, NULL, NULL, 0.0, NULL, 1);
+   kb_client_memory_audit_note("memory.delete", 202, NULL, NULL, NULL, 0.0, NULL, 1);
+   kb_client_memory_audit_note("memory.reject", 303, NULL, NULL, NULL, 0.0, NULL, 0); /* failed */
+
+   obs_bus_stop(); /* drain to the ledger */
+
+   cJSON *rows = audit_ledger_read(NULL, NULL);
+   assert(rows);
+
+   /* Insert: actor=session, command="kind/key" identity, mode=tier, verdict ok,
+    * task_id = the memory id. */
+   cJSON *ins = find_row(rows, "memory.insert", 101);
+   assert(ins);
+   assert(strcmp(sval(ins, "actor"), "sess-A") == 0);
+   assert(strcmp(sval(ins, "command"), "fact/ReleasePlan") == 0);
+   assert(strcmp(sval(ins, "mode"), "L2") == 0);
+   assert(strcmp(sval(ins, "verdict"), "ok") == 0);
+   assert(strcmp(sval(ins, "reason_code"), "conf=0.88") == 0);
+
+   /* Update: id-only op — no kind/key identity, actor defaults to "memory". */
+   cJSON *upd = find_row(rows, "memory.update", 101);
+   assert(upd);
+   assert(strcmp(sval(upd, "actor"), "memory") == 0);
+   assert(sval(upd, "command")[0] == '\0');
+   assert(strcmp(sval(upd, "verdict"), "ok") == 0);
+
+   /* Delete. */
+   cJSON *del = find_row(rows, "memory.delete", 202);
+   assert(del && strcmp(sval(del, "verdict"), "ok") == 0);
+
+   /* Reject that FAILED (kb rejected) -> verdict "fail". */
+   cJSON *rej = find_row(rows, "memory.reject", 303);
+   assert(rej && strcmp(sval(rej, "verdict"), "fail") == 0);
+
+   /* THE invariant: memory content never reaches the trail. */
+   char *dump = cJSON_PrintUnformatted(rows);
+   assert(dump);
+   assert(!strstr(dump, content_marker));
+   free(dump);
+
+   cJSON_Delete(rows);
+   printf("test_bus_memory_audit: OK (memory mutation -> bridge -> bus -> ledger; identity "
+          "recorded, no content)\n");
+   return 0;
+}

--- a/src/tests/test_bus_memory_audit.c
+++ b/src/tests/test_bus_memory_audit.c
@@ -65,32 +65,38 @@ int main(void)
    /* Install the REAL bridge: kb_client memory note -> hook -> obs_bus -> ledger. */
    memory_audit_bridge_install();
 
-   /* A distinctive content-like string we NEVER pass to the note — it must not
-    * appear anywhere in the ledger (the hook carries no content by construction). */
-   const char *content_marker = "MEMORY-CONTENT-DO-NOT-LOG-7f2a";
+   /* A memory KEY carrying PII (the KB gates content but not the key): it must be
+    * FINGERPRINTED, never surfaced verbatim, in the ledger. This is the load-
+    * bearing assertion — a naive "kind/key" mapping would leak this. */
+   const char *pii_key = "email:PIILEAK-alice@example.com";
 
-   kb_client_memory_audit_note("memory.insert", 101, "L2", "fact", "ReleasePlan", 0.88, "sess-A",
-                               1);
+   kb_client_memory_audit_note("memory.insert", 101, "L2", "fact", pii_key, 0.88, "sess-A", 1);
    kb_client_memory_audit_note("memory.update", 101, NULL, NULL, NULL, 0.0, NULL, 1);
    kb_client_memory_audit_note("memory.delete", 202, NULL, NULL, NULL, 0.0, NULL, 1);
    kb_client_memory_audit_note("memory.reject", 303, NULL, NULL, NULL, 0.0, NULL, 0); /* failed */
+   kb_client_memory_audit_note("memory.supersede", 404, NULL, NULL, NULL, 0.9, "sess-A", 1);
+   kb_client_memory_audit_note("memory.insert", 505, "L2", "fact", "k2", 0.5, "sess-A",
+                               0); /* fail */
 
    obs_bus_stop(); /* drain to the ledger */
 
    cJSON *rows = audit_ledger_read(NULL, NULL);
    assert(rows);
 
-   /* Insert: actor=session, command="kind/key" identity, mode=tier, verdict ok,
-    * task_id = the memory id. */
+   /* Insert: actor=session, mode=tier, verdict ok, task_id = memory id, and the
+    * (kind, key) identity is a "mk:" FINGERPRINT — the raw PII key never appears. */
    cJSON *ins = find_row(rows, "memory.insert", 101);
    assert(ins);
    assert(strcmp(sval(ins, "actor"), "sess-A") == 0);
-   assert(strcmp(sval(ins, "command"), "fact/ReleasePlan") == 0);
+   assert(strncmp(sval(ins, "command"), "mk:", 3) == 0);
+   assert(strstr(sval(ins, "command"), "PIILEAK") == NULL);
+   assert(strstr(sval(ins, "command"), "alice") == NULL);
+   assert(strstr(sval(ins, "command"), "fact") == NULL);
    assert(strcmp(sval(ins, "mode"), "L2") == 0);
    assert(strcmp(sval(ins, "verdict"), "ok") == 0);
    assert(strcmp(sval(ins, "reason_code"), "conf=0.88") == 0);
 
-   /* Update: id-only op — no kind/key identity, actor defaults to "memory". */
+   /* Update: id-only op — no identity, actor defaults to "memory". */
    cJSON *upd = find_row(rows, "memory.update", 101);
    assert(upd);
    assert(strcmp(sval(upd, "actor"), "memory") == 0);
@@ -101,14 +107,25 @@ int main(void)
    cJSON *del = find_row(rows, "memory.delete", 202);
    assert(del && strcmp(sval(del, "verdict"), "ok") == 0);
 
-   /* Reject that FAILED (kb rejected) -> verdict "fail". */
+   /* Reject that FAILED -> verdict "fail". */
    cJSON *rej = find_row(rows, "memory.reject", 303);
    assert(rej && strcmp(sval(rej, "verdict"), "fail") == 0);
 
-   /* THE invariant: memory content never reaches the trail. */
+   /* Supersede is audited (id-only). */
+   cJSON *sup = find_row(rows, "memory.supersede", 404);
+   assert(sup && strcmp(sval(sup, "verdict"), "ok") == 0);
+
+   /* A kb-REJECTED insert is recorded too (ok=0 -> verdict "fail"), symmetric with
+    * the other verbs — the trail does not silently drop rejected stores. */
+   cJSON *insf = find_row(rows, "memory.insert", 505);
+   assert(insf && strcmp(sval(insf, "verdict"), "fail") == 0);
+
+   /* THE invariant: no PII (from the key) and no content reach ANY field of ANY
+    * row — the whole ledger dump is free of the plaintext key. */
    char *dump = cJSON_PrintUnformatted(rows);
    assert(dump);
-   assert(!strstr(dump, content_marker));
+   assert(!strstr(dump, "PIILEAK"));
+   assert(!strstr(dump, "alice@example.com"));
    free(dump);
 
    cJSON_Delete(rows);


### PR DESCRIPTION
## What

The **server half** of memory-on-the-bus. Per the agreed architecture, each process publishes to its **own** obs_bus as the operation flows; this PR is aimee-server's view (a follow-up adds the aimee-kb side that records the authoritative event at the mutation site).

The server requests memory changes via `kb_client` (insert/update/delete/reject → network → aimee-kb, **data path unchanged**). Each now fires a **non-content** audit note that a server-only bridge forwards to the obs_bus → the same `KIND_ACTION` ledger + capture/replay stream the audit/guardrail/vault/sandbox events share. It records *"what the agent chose to remember / change / forget"*:

| audit field | value |
|---|---|
| actor | session id (or `memory`) |
| tool | `memory.insert` / `.update` / `.delete` / `.reject` |
| command | `kind/key` identity (insert only; id-only ops leave it empty) |
| mode | tier (insert) |
| reason_code | `conf=<x.xx>` (insert) |
| verdict | `ok` / `fail` |
| task_id | the memory id |

**Memory content / use_cases / reject reason — the PII payload — is NEVER passed to the hook**, so it cannot reach the trail.

## Design

Same dependency inversion as vault/sandbox: `kb_client` stays event-bus-free (the hook plumbing is a tiny dep-free TU, `kb_client_memory_audit.c`); one server-only bridge (`server/memory_audit_bridge.c`) links the obs_bus. D7 intact.

## Open question for review

Whether a memory **key** can embed PII and needs hashing — explicitly flagged for the PII dimension (applying the sandbox lesson: don't assume "safe"). Currently the key rides readable in `command`, like vault's agent/cred.

## Verification

- All shipping binaries build & link; **D7 green (7/7)**; clang-format clean.
- All test binaries link (fixed a test-link ripple: recipes linking `kb_client_memory{,_mutations}.o` now also link the new audit TU).
- `test_bus_memory_audit` (real bridge → bus → ledger, field mapping + no content) passes; run via the bench gate.
- Full `check_bus_perf_gate` green.