### PR TITLE
Audit memory mutations on aimee-kb's own event bus (D7 → two trusted daemons)

### DIFF
--- a/docs/dev/EVENT_BUS_DECISIONS.md
+++ b/docs/dev/EVENT_BUS_DECISIONS.md
@@ -343,17 +343,19 @@ The blast-radius invariant therefore **narrows from "no shipping binary" to "exa
 audit":**
 
 - **Source.** Only `src/modules/bus/*` and `src/modules/audit/obs_bus.c` may include a bus header.
-- **Objects.** Only `aimee-server` links the bus, through a single `BUS_SHIP_OBJS` group named on its
-  link line; `src/Makefile` may name `modules/bus` only in the `BUS_SHIP` source list and the two
-  per-object `-Imodules/bus` compile rules. Audit is compiled into `aimee-server` (via
-  `guardrails_action_audit.c`, in `DATA_SRCS`) and nowhere else among shipping binaries, so that is
-  the whole footprint.
-- **Every other shipping binary stays bus-free.**
+- **Objects.** Only the trusted server daemons — `aimee-server` and `aimee-kb` — link the bus, each
+  through the single `BUS_SHIP_OBJS` group named on its link line; `src/Makefile` may name
+  `modules/bus` only in the `BUS_SHIP` source list and the two per-object `-Imodules/bus` compile
+  rules. `aimee-server` carries the audit / guardrail / vault / sandbox / server-side-memory events;
+  `aimee-kb` runs its own bus to record the authoritative memory-mutation events at the store
+  (`memory_core_crud`), which is why it links `BUS_SHIP_OBJS` plus a tiny stub for the guardrail sink
+  it never drives (`kb/kb_obs_bus_stub.c`).
+- **Every other shipping binary — the thin-client `aimee`, the gateway, runtime-web — stays bus-free.**
 
 `scripts/check_bus_blast_radius.sh` was revised to enforce exactly this: layer 1 permits the confined
-`src/Makefile` references and requires `BUS_SHIP_OBJS` to be consumed only by `$(SERVER)`; layer 3
-allowlists `obs_bus.c`; layer 4 exempts `aimee-server` (it carries the bus on purpose) and holds
-every other binary to zero bus symbols. **Honest limit:** shipping binaries are stripped (`-s`) with
+`src/Makefile` references and requires `BUS_SHIP_OBJS` to be consumed only by `$(SERVER)` or `$(KB)`;
+layer 3 allowlists `obs_bus.c`; layer 4 exempts `aimee-server` and `aimee-kb` (they carry the bus on
+purpose) and holds every other binary to zero bus symbols. **Honest limit:** shipping binaries are stripped (`-s`) with
 LTO, so `nm` sees no static symbols in them — layer 4 is a best-effort backstop for unstripped/CI
 builds, and the load-bearing guarantee is the source/build-text layers, which are complete by
 construction.

--- a/scripts/check_bus_blast_radius.sh
+++ b/scripts/check_bus_blast_radius.sh
@@ -113,9 +113,9 @@ if [ -n "$hits" ]; then
    fail=1
 fi
 hits=$({ grep -nE 'BUS_SHIP_OBJS' src/Makefile 2>/dev/null || true; } | strip_comments |
-   { grep -vE '^[0-9]+:BUS_SHIP_OBJS[[:space:]]*[+:]?=|\$\(SERVER\):' || true; })
+   { grep -vE '^[0-9]+:BUS_SHIP_OBJS[[:space:]]*[+:]?=|\$\(SERVER\):|\$\(KB\):' || true; })
 if [ -n "$hits" ]; then
-   note "FAIL: BUS_SHIP_OBJS is linked by a target other than aimee-server (\$(SERVER))"
+   note "FAIL: BUS_SHIP_OBJS is linked by a target other than the trusted daemons \$(SERVER)/\$(KB)"
    printf '%s\n' "$hits" >&2
    fail=1
 fi
@@ -266,13 +266,16 @@ for bin in "$@"; do
       missing=$((missing + 1))
       continue
     fi
-   # aimee-server carries the bus on purpose (D7 step 3: the audit migration).
-   # It is EXPECTED to reference bus symbols; layers 1-3 and the src/Makefile
-   # confinement above prove no other target links them, and nm cannot see static
-   # bus symbols in this stripped binary in any case. Exempt it explicitly rather
-   # than leaning on that blindness.
+   # The TRUSTED SERVER DAEMONS carry the bus on purpose: aimee-server (the audit,
+   # guardrail, vault, sandbox, and server-side memory events) and aimee-kb (its
+   # own bus, recording the authoritative memory-mutation events at the store).
+   # Both are EXPECTED to reference bus symbols; layers 1-3 and the src/Makefile
+   # confinement above prove no OTHER target links them (the bus stays out of the
+   # thin-client / CLI binaries), and nm cannot see static bus symbols in these
+   # stripped binaries in any case. Exempt them explicitly rather than leaning on
+   # that blindness.
    case "$(basename "$path")" in
-   aimee-server | aimee-server.exe)
+   aimee-server | aimee-server.exe | aimee-kb | aimee-kb.exe)
       checked=$((checked + 1))
       continue
       ;;
@@ -301,10 +304,10 @@ done
 
 if [ "$fail" -ne 0 ]; then
    note ""
-   note "The event bus may be linked only into aimee-server, and only to carry the"
-   note "audit migration (D7 step 3). A bus symbol in any other shipping binary, or"
-   note "a bus reference outside modules/bus + obs_bus, is a blast-radius"
-   note "regression. See docs/dev/EVENT_BUS_DECISIONS.md."
+   note "The event bus may be linked only into the trusted server daemons"
+   note "(aimee-server and aimee-kb), never a thin-client/CLI binary. A bus symbol"
+   note "in any other shipping binary, or a bus reference outside modules/bus +"
+   note "obs_bus, is a blast-radius regression. See docs/dev/EVENT_BUS_DECISIONS.md."
    exit 1
 fi
 

--- a/scripts/check_bus_perf_gate.sh
+++ b/scripts/check_bus_perf_gate.sh
@@ -141,4 +141,18 @@ if ! printf '%s\n' "$mem_out" | grep -q "test_bus_memory_audit: OK"; then
 fi
 echo "memory audit: ok (mutation -> bridge -> bus -> ledger; no content)"
 
-echo "check_bus_perf_gate: ok — dispatch + audit within budget; audit durability holds; vault-access + sandbox + memory audit hold; memory rows pending"
+# 7. The KB store-side memory audit: memory_core_crud fires the hook on every
+#    mutation (insert / merge / update / reject / delete) and, end-to-end, the REAL
+#    aimee-kb bridge lands a fingerprinted, content-free row in the KB ledger.
+echo "checking KB store-side memory-audit hook (end to end)..."
+kbmem_out=$(make -C src --no-print-directory unit-test-memory-audit-hook 2>&1 || true)
+if ! printf '%s\n' "$kbmem_out" | grep -q "test_memory_audit_hook: OK"; then
+   echo "" >&2
+   echo "FAIL: the KB store-side memory-audit test did not pass — memory_core_crud is" >&2
+   echo "      not firing the hook correctly, or the KB bridge/ledger path regressed." >&2
+   printf '%s\n' "$kbmem_out" | tail -8 >&2
+   exit 1
+fi
+echo "KB memory audit: ok (memory_core_crud -> hook -> KB bridge -> bus -> ledger)"
+
+echo "check_bus_perf_gate: ok — dispatch + audit within budget; audit durability holds; vault-access + sandbox + memory (server + kb) audit hold; memory rows pending"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1145,7 +1145,7 @@ $(SERVER): $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(AGENT_OBJS) $(SERVER_DATA_O
 # oauth_pkce.o provides the base64url encoder kb/enroll.c uses to mint
 # enrollment tokens (now reachable from `aimee-kb enroll`). It is a leaf crypto
 # util (openssl + platform_random only), so the kb sidecar links it directly.
-$(KB): $(KB_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_BEDROCK_IR_OBJS) $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(TS_VENDOR_OBJS) | $(KB_RESOLVER)
+$(KB): $(KB_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_BEDROCK_IR_OBJS) $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(TS_VENDOR_OBJS) $(BUS_SHIP_OBJS) $(OBJDIR)/kb/kb_obs_bus_stub.o $(OBJDIR)/kb/kb_memory_audit_bridge.o | $(KB_RESOLVER)
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_KB) $(KB_TPM2_LDLIBS) $(KB_PKCS11_LDLIBS)
 

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -361,11 +361,13 @@ int memory_list(const char *tier, const char *kind, int limit, memory_t *out, in
 int memory_delete(int64_t id);
 int memory_stats(memory_stats_t *out);
 
-/* Audit hook: notified after each memory MUTATION at the store (insert / update /
- * delete / reject) with NON-CONTENT fields only — the operation, the memory id,
- * and (for insert) its tier / kind / key identity, confidence, and session. This
- * fires in aimee-kb, at the authoritative mutation site, so it catches EVERY
- * caller (agent-driven via kb_client, KB-internal maintenance, and CLI). A
+/* Audit hook: notified after each memory MUTATION at the store — insert, an
+ * exact-key or near-duplicate content overwrite ("memory.merge"), update, delete,
+ * and reject — with NON-CONTENT fields only: the operation, the memory id, and
+ * (for insert/merge) its tier / kind / key identity, confidence, and session. (A
+ * supersede is recorded as its follow-on insert.) This fires in aimee-kb, at the
+ * authoritative mutation site, so it catches every caller regardless of entry
+ * point — agent-driven via kb_client, KB-internal maintenance, and CLI. A
  * KB-side bridge forwards it to aimee-kb's own observability bus. The memory
  * CONTENT (and use_cases / reject reason) — the PII payload — is NEVER passed;
  * and the key/kind, which can themselves embed PII, are fingerprinted by the

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -360,6 +360,21 @@ int memory_reject(int64_t id, const char *reason);
 int memory_list(const char *tier, const char *kind, int limit, memory_t *out, int max);
 int memory_delete(int64_t id);
 int memory_stats(memory_stats_t *out);
+
+/* Audit hook: notified after each memory MUTATION at the store (insert / update /
+ * delete / reject) with NON-CONTENT fields only — the operation, the memory id,
+ * and (for insert) its tier / kind / key identity, confidence, and session. This
+ * fires in aimee-kb, at the authoritative mutation site, so it catches EVERY
+ * caller (agent-driven via kb_client, KB-internal maintenance, and CLI). A
+ * KB-side bridge forwards it to aimee-kb's own observability bus. The memory
+ * CONTENT (and use_cases / reject reason) — the PII payload — is NEVER passed;
+ * and the key/kind, which can themselves embed PII, are fingerprinted by the
+ * bridge before they reach any ledger. update/delete/reject carry only the id
+ * (the row's identity is not re-read on the mutation path). The memory module has
+ * NO event-bus dependency (the bus lives only in the bridge). NULL by default. */
+typedef void (*memory_audit_hook_fn)(const char *op, int64_t id, const char *tier, const char *kind,
+                                     const char *key, double confidence, const char *session_id);
+void memory_set_audit_hook(memory_audit_hook_fn fn);
 int memory_rebuild_derived_indexes(int limit);
 int memory_repair_vector_index(int64_t memory_id, const char *command);
 int memory_repair_vector_index_failed_only(const char *command, int limit, int *failed_out);

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -43,7 +43,9 @@
 #include "kb_vault_tpm_runtime_lock.h"
 #include "db2/kb_audit_worm.h"
 #include "db2/vault_operator_status_runtime.h"
-#include "vault_server_key.h" /* startup durable seal-epoch synchronization */
+#include "vault_server_key.h"       /* startup durable seal-epoch synchronization */
+#include "kb_memory_audit_bridge.h" /* record memory mutations on aimee-kb's own obs bus */
+#include "log.h"                    /* audit_log_open — KB memory-audit ledger */
 #include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1540,6 +1542,12 @@ int main(int argc, char **argv)
 
    config_t kb_cfg;
    config_load(&kb_cfg);
+
+   /* aimee-kb records the AUTHORITATIVE memory-mutation events on its own
+    * observability bus at the store (every caller). Open the KB audit ledger so
+    * the bus consumer can persist the rows, then install the store-side hook. */
+   audit_log_open();
+   kb_memory_audit_bridge_install();
 
    /* P7-D3a is an all-or-none service-manager contract. The listener fd and
     * pathname are fixed in the wire module; only activation and the dedicated

--- a/src/kb/kb_memory_audit_bridge.c
+++ b/src/kb/kb_memory_audit_bridge.c
@@ -1,0 +1,44 @@
+/* kb_memory_audit_bridge.c: forwards aimee-kb's authoritative memory mutations
+ * (memory_core_crud) onto aimee-kb's OWN observability bus. The one place linking
+ * the memory store to the bus in the KB; the memory module stays bus-free. Only
+ * NON-CONTENT fields cross, and the (kind, key) identity is fingerprinted — the
+ * raw key/kind, which can embed PII the KB's content gates do not cover, never
+ * reach the ledger. Mirrors server/memory_audit_bridge.c, but at the store side
+ * (every caller) and via memory_set_audit_hook. */
+#include "kb_memory_audit_bridge.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "aimee.h"   /* prerequisites for memory.h (KIND_*, config_t, ...) */
+#include "memory.h"  /* memory_set_audit_hook */
+#include "obs_bus.h" /* obs_bus_emit, obs_bus_key_fingerprint */
+
+/* memory_audit_hook_fn: publish one memory-mutation audit row over the KB's bus
+ * (KIND_ACTION -> the KB audit ledger + capture/replay). NON-SECRET only: actor =
+ * the session that made the change (or "memory"), tool = the op, a PII-safe
+ * FINGERPRINT of the (kind, key) identity in command (insert only; id-only ops
+ * leave it empty), tier in mode, confidence in reason_code, and the numeric memory
+ * id as task_id. The store fires the hook only on success, so verdict is "ok". */
+static void on_memory_mutation(const char *op, int64_t id, const char *tier, const char *kind,
+                               const char *key, double confidence, const char *session_id)
+{
+   char command[32];
+   if ((kind && kind[0]) || (key && key[0]))
+      obs_bus_key_fingerprint(kind, key, command, sizeof command);
+   else
+      command[0] = '\0';
+
+   char reason[48];
+   reason[0] = '\0';
+   if (confidence > 0.0)
+      snprintf(reason, sizeof reason, "conf=%.2f", confidence);
+
+   obs_bus_emit(session_id && session_id[0] ? session_id : "memory", op, "v1-", command,
+                tier ? tier : "", reason, "ok", (long long)id);
+}
+
+void kb_memory_audit_bridge_install(void)
+{
+   memory_set_audit_hook(on_memory_mutation);
+}

--- a/src/kb/kb_memory_audit_bridge.h
+++ b/src/kb/kb_memory_audit_bridge.h
@@ -1,0 +1,13 @@
+#ifndef AIMEE_KB_MEMORY_AUDIT_BRIDGE_H
+#define AIMEE_KB_MEMORY_AUDIT_BRIDGE_H 1
+
+/* Install the KB-side memory-mutation audit hook. aimee-kb records the
+ * AUTHORITATIVE memory event on its OWN observability bus at the store
+ * (memory_core_crud), so it captures EVERY caller — agent-driven via kb_client,
+ * KB-internal maintenance (conflict-merge, lifecycle, synthesis), and CLI — not
+ * just the server-initiated requests the server-side bridge sees. NON-CONTENT
+ * only; the key/kind are fingerprinted (obs_bus_key_fingerprint) so no PII
+ * reaches the ledger. Call once at aimee-kb startup. */
+void kb_memory_audit_bridge_install(void);
+
+#endif /* AIMEE_KB_MEMORY_AUDIT_BRIDGE_H */

--- a/src/kb/kb_obs_bus_stub.c
+++ b/src/kb/kb_obs_bus_stub.c
@@ -1,0 +1,18 @@
+/* kb_obs_bus_stub.c: aimee-kb-only stubs for obs_bus sinks the KB never drives.
+ *
+ * aimee-kb runs its OWN obs_bus instance to record the authoritative memory-
+ * mutation events at the store (memory_core_crud). Those events use the ACTION
+ * kind -> audit_action_log (log.c, already linked into aimee-kb). obs_bus's
+ * consumer, however, is one translation unit that ALSO dispatches the GUARDRAIL
+ * kind to db1_guardrail_event_insert — a db1 sink that lives only in aimee-server
+ * and that the KB never emits. The call is dead code in the KB (the KB subscribes
+ * to and publishes only the action kind), but the symbol is still referenced at
+ * link time, so this stub satisfies the linker without pulling db1 into aimee-kb.
+ * If it were ever reached it fails closed (returns -1). */
+#include "guardrail_events.h"
+
+int db1_guardrail_event_insert(const guardrail_event_t *e)
+{
+   (void)e;
+   return -1; /* never reached in aimee-kb; fail closed if it somehow is */
+}

--- a/src/modules/audit/obs_bus.c
+++ b/src/modules/audit/obs_bus.c
@@ -29,6 +29,7 @@
 #include "bus_region.h" /* bus_control_epoch */
 #include "config.h"     /* config_default_dir */
 #include "log.h"
+#include "wfe_def.h" /* wfe_sha256_raw — obs_bus_key_fingerprint */
 
 #define KIND_AUDIT_ACTION    OBS_BUS_KIND_ACTION
 #define KIND_GUARDRAIL_EVENT OBS_BUS_KIND_GUARDRAIL
@@ -698,4 +699,32 @@ uint64_t obs_bus_dropped(void)
 uint64_t obs_bus_written(void)
 {
    return atomic_load_explicit(&g.written, memory_order_relaxed);
+}
+
+void obs_bus_key_fingerprint(const char *kind, const char *key, char *out, size_t out_len)
+{
+   if (!out || out_len == 0)
+      return;
+   out[0] = '\0';
+   if (out_len < 16)
+      return;
+   char buf[1200];
+   int n = snprintf(buf, sizeof buf, "%s\x1f%s", kind ? kind : "", key ? key : "");
+   size_t len = (n < 0) ? 0 : ((size_t)n < sizeof buf ? (size_t)n : sizeof buf);
+   unsigned char dig[32];
+   if (wfe_sha256_raw(buf, len, dig) != 0)
+   {
+      snprintf(out, out_len, "mk:?");
+      return;
+   }
+   static const char hx[] = "0123456789abcdef";
+   out[0] = 'm';
+   out[1] = 'k';
+   out[2] = ':';
+   for (int i = 0; i < 6; i++)
+   {
+      out[3 + i * 2] = hx[(dig[i] >> 4) & 0xf];
+      out[3 + i * 2 + 1] = hx[dig[i] & 0xf];
+   }
+   out[15] = '\0';
 }

--- a/src/modules/audit/obs_bus.h
+++ b/src/modules/audit/obs_bus.h
@@ -29,6 +29,7 @@
 #ifndef AIMEE_OBS_BUS_H
 #define AIMEE_OBS_BUS_H 1
 
+#include <stddef.h> /* size_t */
 #include <stdint.h>
 
 #include "guardrail_events.h" /* guardrail_event_t — a second event kind on this bus */
@@ -89,6 +90,14 @@ extern "C"
    /* Number of rows the consumer has written to the ledger since start. Exposed
     * for the durability test (published == written + dropped once drained). */
    uint64_t obs_bus_written(void);
+
+   /* Write a PII-safe fingerprint of a (kind, key) identity into `out` (>= 16
+    * bytes): "mk:" + the first 6 bytes of SHA-256(kind\x1fkey) in hex. Used by the
+    * memory-audit bridges (server + aimee-kb) so an agent-supplied key/kind — which
+    * can embed PII, and which the KB's content gates do NOT cover — is NEVER written
+    * verbatim to the ledger, while still correlating (same identity -> same handle).
+    * One shared implementation so the two bridges cannot diverge. */
+   void obs_bus_key_fingerprint(const char *kind, const char *key, char *out, size_t out_len);
 
 #ifdef __cplusplus
 }

--- a/src/modules/memory/memory_core_crud.c
+++ b/src/modules/memory/memory_core_crud.c
@@ -43,6 +43,26 @@
 #include <unistd.h>
 #include <pthread.h>
 
+/* The store-side memory-mutation audit sink (NULL = no audit); installed once at
+ * aimee-kb startup by the KB observability bridge. See memory.h. */
+static memory_audit_hook_fn g_mem_audit_hook = NULL;
+
+void memory_set_audit_hook(memory_audit_hook_fn fn)
+{
+   g_mem_audit_hook = fn;
+}
+
+/* Fire the audit hook (if installed) with the mutation's NON-CONTENT identity.
+ * Never receives memory content; the key/kind are fingerprinted downstream. */
+static void mem_audit(const char *op, int64_t id, const char *tier, const char *kind,
+                      const char *key, double confidence, const char *session_id)
+{
+   memory_audit_hook_fn h = g_mem_audit_hook;
+   if (h)
+      h(op, id, tier ? tier : "", kind ? kind : "", key ? key : "", confidence,
+        session_id ? session_id : "");
+}
+
 /* gate_check_sensitive, gate_check_ephemeral, and gate_has_evidence_markers
  * are platform-owned quality gates. */
 
@@ -438,6 +458,8 @@ int memory_insert_ex(const char *tier, const char *kind, const char *key, const 
          db1_context_cache_invalidate();
       if (!skip_side_effects)
          memory_maybe_run_maintenance();
+      /* Authoritative store-side audit: a new memory was written (non-content). */
+      mem_audit("memory.insert", new_id, tier, kind, norm_key, confidence, session_id);
       return 0;
    }
 }
@@ -463,12 +485,18 @@ int memory_update_content(int64_t id, const char *content)
    if (id <= 0 || !content || !content[0])
       return -1;
    int changes = db2_memory_update_content(id, content);
-   return changes > 0 ? 0 : -1;
+   int rc = changes > 0 ? 0 : -1;
+   if (rc == 0)
+      mem_audit("memory.update", id, NULL, NULL, NULL, 0.0, NULL);
+   return rc;
 }
 
 int memory_reject(int64_t id, const char *reason)
 {
-   return db2_memory_reject(id, reason);
+   int rc = db2_memory_reject(id, reason);
+   if (rc == 0)
+      mem_audit("memory.reject", id, NULL, NULL, NULL, 0.0, NULL);
+   return rc;
 }
 
 int memory_list(const char *tier, const char *kind, int limit, memory_t *out, int max)
@@ -507,7 +535,10 @@ int memory_delete(int64_t id)
    int changes = db2_memory_delete_row(id);
    if (changes > 0 && db1_context_cache_invalidate)
       db1_context_cache_invalidate();
-   return changes > 0 ? 0 : -1;
+   int rc = changes > 0 ? 0 : -1;
+   if (rc == 0)
+      mem_audit("memory.delete", id, NULL, NULL, NULL, 0.0, NULL);
+   return rc;
 }
 
 int memory_stats(memory_stats_t *out)

--- a/src/modules/memory/memory_core_crud.c
+++ b/src/modules/memory/memory_core_crud.c
@@ -354,6 +354,9 @@ int memory_insert_ex(const char *tier, const char *kind, const char *key, const 
             db1_context_cache_invalidate();
          if (!skip_side_effects)
             memory_maybe_run_maintenance();
+         /* An existing memory's content was overwritten by an exact-key merge —
+          * a real mutation, audited (distinct op so merges stay filterable). */
+         mem_audit("memory.merge", existing_id, tier, kind, norm_key, new_conf, session_id);
          return 0;
       }
    }
@@ -424,6 +427,9 @@ int memory_insert_ex(const char *tier, const char *kind, const char *key, const 
          if (db1_context_cache_invalidate)
             db1_context_cache_invalidate();
          memory_maybe_run_maintenance();
+         /* An existing near-duplicate memory's content was overwritten — audited
+          * (the submitted key's identity fingerprint; task_id is the merged id). */
+         mem_audit("memory.merge", dup_id, tier, kind, norm_key, new_conf, session_id);
          return 0;
       }
    }

--- a/src/server/memory_audit_bridge.c
+++ b/src/server/memory_audit_bridge.c
@@ -9,43 +9,7 @@
 
 #include "audit_action.h" /* audit_args_hash, AUDIT_ARGS_HASH_LEN */
 #include "kb_client.h"    /* kb_client_set_memory_audit_hook */
-#include "obs_bus.h"      /* obs_bus_emit */
-#include "wfe_def.h"      /* wfe_sha256_raw */
-
-/* A PII-safe fingerprint of the memory's (kind, key) identity. BOTH the key and
- * (on the MCP path) the kind are agent-supplied free text that can embed PII or a
- * value — the KB gates memory CONTENT but NOT the key — so the identity is NEVER
- * recorded verbatim. A one-way hash preserves correlation (same identity -> same
- * handle) without exposing it; the numeric memory id (task_id) is the handle for
- * an authorized KB lookup of the details. */
-static void identity_fingerprint(const char *kind, const char *key, char *out, size_t out_len)
-{
-   if (out_len < 16)
-   {
-      if (out_len)
-         out[0] = '\0';
-      return;
-   }
-   char buf[1200];
-   int n = snprintf(buf, sizeof buf, "%s\x1f%s", kind ? kind : "", key ? key : "");
-   size_t len = (n < 0) ? 0 : ((size_t)n < sizeof buf ? (size_t)n : sizeof buf);
-   unsigned char dig[32];
-   if (wfe_sha256_raw(buf, len, dig) != 0)
-   {
-      snprintf(out, out_len, "mk:?");
-      return;
-   }
-   static const char hx[] = "0123456789abcdef";
-   out[0] = 'm';
-   out[1] = 'k';
-   out[2] = ':';
-   for (int i = 0; i < 6; i++)
-   {
-      out[3 + i * 2] = hx[(dig[i] >> 4) & 0xf];
-      out[3 + i * 2 + 1] = hx[dig[i] & 0xf];
-   }
-   out[15] = '\0';
-}
+#include "obs_bus.h"      /* obs_bus_emit, obs_bus_key_fingerprint */
 
 /* kb_client_memory_audit_hook_fn: publish one memory-mutation audit row over the
  * bus (KIND_ACTION -> the audit ledger + capture/replay). NON-SECRET only: actor
@@ -60,7 +24,7 @@ static void on_memory_mutation(const char *op, int64_t id, const char *tier, con
 {
    char command[32];
    if ((kind && kind[0]) || (key && key[0]))
-      identity_fingerprint(kind, key, command, sizeof command);
+      obs_bus_key_fingerprint(kind, key, command, sizeof command);
    else
       command[0] = '\0';
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -5347,6 +5347,12 @@ $(TESTPREFIX)/unit-test-working-profile: $(OBJDIR)/tests/test_working_profile.o 
 $(TESTPREFIX)/unit-test-curiosity: $(OBJDIR)/tests/test_curiosity.o $(TEST_DATA_OBJS_MOCK)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
+# KB store-side memory-audit hook: memory_core_crud fires memory_set_audit_hook.
+# Uses the in-memory db2 shim (same set as unit-test-curiosity).
+$(TESTPREFIX)/unit-test-memory-audit-hook: $(OBJDIR)/tests/test_memory_audit_hook.o $(TEST_DATA_OBJS_MOCK)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+TEST_TARGETS += $(TESTPREFIX)/unit-test-memory-audit-hook
+
 $(TESTPREFIX)/unit-test-cmd-identity: $(OBJDIR)/tests/test_cmd_identity.o \
                      $(OBJDIR)/cmd_identity.o $(OBJDIR)/working_profile.o \
                      $(DB1_OBJS) \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -5347,10 +5347,23 @@ $(TESTPREFIX)/unit-test-working-profile: $(OBJDIR)/tests/test_working_profile.o 
 $(TESTPREFIX)/unit-test-curiosity: $(OBJDIR)/tests/test_curiosity.o $(TEST_DATA_OBJS_MOCK)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-# KB store-side memory-audit hook: memory_core_crud fires memory_set_audit_hook.
-# Uses the in-memory db2 shim (same set as unit-test-curiosity).
-$(TESTPREFIX)/unit-test-memory-audit-hook: $(OBJDIR)/tests/test_memory_audit_hook.o $(TEST_DATA_OBJS_MOCK)
-	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+# KB store-side memory-audit hook + end-to-end onto aimee-kb's obs_bus/ledger:
+# memory_core_crud (db2 shim) fires the hook, the REAL KB bridge maps it, and the
+# row lands in the ledger. Links the db2-shim memory set plus the bus stack.
+$(TESTPREFIX)/unit-test-memory-audit-hook: $(OBJDIR)/tests/test_memory_audit_hook.o \
+                                           $(OBJDIR)/kb/kb_memory_audit_bridge.o \
+                                           $(OBJDIR)/modules/audit/obs_bus.o \
+                                           $(OBJDIR)/modules/audit/audit_ledger.o \
+                                           $(OBJDIR)/modules/bus/bus_client.o \
+                                           $(OBJDIR)/modules/bus/bus_host.o \
+                                           $(OBJDIR)/modules/bus/bus_route.o \
+                                           $(OBJDIR)/modules/bus/bus_region.o \
+                                           $(OBJDIR)/modules/bus/bus_ring.o \
+                                           $(OBJDIR)/modules/bus/bus_arena.o \
+                                           $(OBJDIR)/modules/bus/bus_wire.o \
+                                           $(OBJDIR)/modules/bus/bus_capture.o \
+                                           $(TEST_DATA_OBJS_MOCK)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lpthread
 TEST_TARGETS += $(TESTPREFIX)/unit-test-memory-audit-hook
 
 $(TESTPREFIX)/unit-test-cmd-identity: $(OBJDIR)/tests/test_cmd_identity.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -5364,7 +5364,13 @@ $(TESTPREFIX)/unit-test-memory-audit-hook: $(OBJDIR)/tests/test_memory_audit_hoo
                                            $(OBJDIR)/modules/bus/bus_capture.o \
                                            $(TEST_DATA_OBJS_MOCK)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lpthread
-TEST_TARGETS += $(TESTPREFIX)/unit-test-memory-audit-hook
+
+# NOT in TEST_TARGETS: it links the bus objects, which the standard unit-tests
+# build does not assemble — so the bench gate (check_bus_perf_gate.sh) force-builds
+# and runs it via this .PHONY target, like the other bus tests.
+.PHONY: unit-test-memory-audit-hook
+unit-test-memory-audit-hook: $(TESTPREFIX)/unit-test-memory-audit-hook
+	$<
 
 $(TESTPREFIX)/unit-test-cmd-identity: $(OBJDIR)/tests/test_cmd_identity.o \
                      $(OBJDIR)/cmd_identity.o $(OBJDIR)/working_profile.o \

--- a/src/tests/test_bus_memory_audit.c
+++ b/src/tests/test_bus_memory_audit.c
@@ -62,6 +62,21 @@ int main(void)
    audit_log_open();
    audit_ensure_key();
 
+   /* Directly pin the shared PII fingerprint (used by BOTH the server and aimee-kb
+    * memory bridges): "mk:" prefix, never the raw PII identity, deterministic, and
+    * distinct for distinct identities. */
+   {
+      char fp1[32], fp2[32], fp3[32];
+      obs_bus_key_fingerprint("fact", "email:alice@example.com", fp1, sizeof fp1);
+      obs_bus_key_fingerprint("fact", "email:alice@example.com", fp2, sizeof fp2);
+      obs_bus_key_fingerprint("fact", "email:bob@example.com", fp3, sizeof fp3);
+      assert(strncmp(fp1, "mk:", 3) == 0);
+      assert(strstr(fp1, "alice") == NULL && strstr(fp1, "email") == NULL &&
+             strstr(fp1, "fact") == NULL);
+      assert(strcmp(fp1, fp2) == 0); /* deterministic — correlatable */
+      assert(strcmp(fp1, fp3) != 0); /* distinct identities distinguishable */
+   }
+
    /* Install the REAL bridge: kb_client memory note -> hook -> obs_bus -> ledger. */
    memory_audit_bridge_install();
 

--- a/src/tests/test_memory_audit_hook.c
+++ b/src/tests/test_memory_audit_hook.c
@@ -5,11 +5,18 @@
  * (the KB bridge maps it onto aimee-kb's own obs_bus). */
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "aimee.h" /* KIND_FACT, TIER_L2 */
+#include "cJSON.h"
 #include "db2_test_shim.h"
+#include "kb/kb_memory_audit_bridge.h"
+#include "log.h" /* audit_log_open */
 #include "memory.h"
+#include "modules/audit/obs_bus.h"
+
+extern struct cJSON *audit_ledger_read(const char *from_ts, const char *to_ts);
 
 static struct
 {
@@ -57,6 +64,30 @@ int main(void)
    assert(!strstr(g_last.op, "SECRET") && !strstr(g_last.kind, "SECRET") &&
           !strstr(g_last.session, "SECRET"));
 
+   /* Re-inserting the SAME key with equivalent content overwrites the existing
+    * memory via the exact-key MERGE path — a content mutation that MUST be audited
+    * ("memory.merge"), not silently dropped. Its identity is fingerprinted like an
+    * insert (no content). (Identical content avoids the supersede path, which a
+    * materially-different re-store would take.) */
+   memset(&g_last, 0, sizeof g_last);
+   memory_t mm;
+   assert(memory_insert(TIER_L2, KIND_FACT, "topic:release", secret_content, 0.9, "sess-2", &mm) ==
+          0);
+   assert(g_last.calls == 1);
+   assert(strcmp(g_last.op, "memory.merge") == 0);
+   assert(g_last.id == m.id); /* merged into the existing memory */
+   assert(!strstr(g_last.key, "SECRET-CONTENT") && strstr(g_last.key, "topic") != NULL);
+
+   /* Update: fires once, id-only. */
+   memset(&g_last, 0, sizeof g_last);
+   assert(memory_update_content(m.id, "revised content") == 0);
+   assert(g_last.calls == 1 && strcmp(g_last.op, "memory.update") == 0 && g_last.id == m.id);
+
+   /* Reject: fires once, id-only. */
+   memset(&g_last, 0, sizeof g_last);
+   assert(memory_reject(m.id, "low signal") == 0);
+   assert(g_last.calls == 1 && strcmp(g_last.op, "memory.reject") == 0 && g_last.id == m.id);
+
    /* Delete: the hook fires once, id-only. */
    memset(&g_last, 0, sizeof g_last);
    assert(memory_delete(m.id) == 0);
@@ -71,6 +102,46 @@ int main(void)
    assert(memory_insert(TIER_L2, KIND_FACT, "topic:other", "content", 0.8, "sess-1", &m2) == 0);
    assert(g_last.calls == 0);
 
-   printf("test_memory_audit_hook: OK (memory_core_crud fires the hook; identity, no content)\n");
+   /* END TO END through the REAL aimee-kb bridge -> aimee-kb's obs_bus -> the KB
+    * audit ledger: proves the store-side wiring (kb_memory_audit_bridge_install +
+    * on_memory_mutation field mapping) and that the fingerprinted, content-free
+    * row actually lands in the ledger — not just that the hook fires. */
+   {
+      char home[] = "/tmp/aimee-kbmem-XXXXXX";
+      assert(mkdtemp(home));
+      setenv("AIMEE_HOME", home, 1);
+      audit_log_open();
+      kb_memory_audit_bridge_install();
+
+      memory_t e;
+      assert(memory_insert(TIER_L2, KIND_FACT, "topic:e2e", "some content", 0.7, "sess-E", &e) ==
+             0);
+      obs_bus_stop(); /* drain to the KB ledger */
+
+      cJSON *rows = audit_ledger_read(NULL, NULL);
+      assert(rows);
+      cJSON *r = NULL, *found = NULL;
+      cJSON_ArrayForEach(r, rows)
+      {
+         cJSON *t = cJSON_GetObjectItemCaseSensitive(r, "tool");
+         cJSON *tid = cJSON_GetObjectItemCaseSensitive(r, "task_id");
+         if (cJSON_IsString(t) && strcmp(t->valuestring, "memory.insert") == 0 &&
+             cJSON_IsNumber(tid) && (int64_t)tid->valuedouble == e.id)
+         {
+            found = r;
+            break;
+         }
+      }
+      assert(found);
+      const char *cmd = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(found, "command"));
+      assert(cmd && strncmp(cmd, "mk:", 3) == 0); /* identity fingerprinted, not raw */
+      char *dump = cJSON_PrintUnformatted(rows);
+      assert(dump && !strstr(dump, "topic:e2e")); /* raw key never in the ledger */
+      free(dump);
+      cJSON_Delete(rows);
+   }
+
+   printf("test_memory_audit_hook: OK (memory_core_crud fires the hook + end-to-end to the KB "
+          "ledger; identity fingerprinted, no content)\n");
    return 0;
 }

--- a/src/tests/test_memory_audit_hook.c
+++ b/src/tests/test_memory_audit_hook.c
@@ -1,0 +1,76 @@
+/* test_memory_audit_hook.c: the KB store-side memory-mutation audit hook. Pins
+ * that memory_core_crud fires memory_set_audit_hook on insert / delete with the
+ * NON-CONTENT identity (op, id, kind, key, tier, session) and NEVER the content,
+ * and that a NULL hook is a no-op. This is the aimee-kb authoritative-record seam
+ * (the KB bridge maps it onto aimee-kb's own obs_bus). */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "aimee.h" /* KIND_FACT, TIER_L2 */
+#include "db2_test_shim.h"
+#include "memory.h"
+
+static struct
+{
+   int calls;
+   char op[32];
+   int64_t id;
+   char tier[16];
+   char kind[32];
+   char key[96];
+   char session[32];
+} g_last;
+
+static void capture(const char *op, int64_t id, const char *tier, const char *kind, const char *key,
+                    double confidence, const char *session_id)
+{
+   (void)confidence;
+   g_last.calls++;
+   snprintf(g_last.op, sizeof g_last.op, "%s", op);
+   g_last.id = id;
+   snprintf(g_last.tier, sizeof g_last.tier, "%s", tier);
+   snprintf(g_last.kind, sizeof g_last.kind, "%s", kind);
+   snprintf(g_last.key, sizeof g_last.key, "%s", key);
+   snprintf(g_last.session, sizeof g_last.session, "%s", session_id);
+}
+
+int main(void)
+{
+   db2_test_shim_open();
+   memory_set_audit_hook(capture);
+
+   /* Insert: the hook fires once with the identity — and NOT the content. */
+   const char *secret_content = "SECRET-CONTENT-DO-NOT-LOG-alice@example.com";
+   memory_t m;
+   memset(&g_last, 0, sizeof g_last);
+   assert(memory_insert(TIER_L2, KIND_FACT, "topic:release", secret_content, 0.8, "sess-1", &m) ==
+          0);
+   assert(g_last.calls == 1);
+   assert(strcmp(g_last.op, "memory.insert") == 0);
+   assert(g_last.id == m.id && m.id > 0);
+   assert(strcmp(g_last.kind, KIND_FACT) == 0);
+   assert(strstr(g_last.key, "topic") != NULL); /* the (normalized) key identity */
+   assert(strcmp(g_last.session, "sess-1") == 0);
+   /* The content — the PII payload — never reaches the hook. */
+   assert(!strstr(g_last.key, "SECRET-CONTENT") && !strstr(g_last.key, "alice"));
+   assert(!strstr(g_last.op, "SECRET") && !strstr(g_last.kind, "SECRET") &&
+          !strstr(g_last.session, "SECRET"));
+
+   /* Delete: the hook fires once, id-only. */
+   memset(&g_last, 0, sizeof g_last);
+   assert(memory_delete(m.id) == 0);
+   assert(g_last.calls == 1);
+   assert(strcmp(g_last.op, "memory.delete") == 0);
+   assert(g_last.id == m.id);
+
+   /* A NULL hook records nothing (no crash). */
+   memory_set_audit_hook(NULL);
+   memset(&g_last, 0, sizeof g_last);
+   memory_t m2;
+   assert(memory_insert(TIER_L2, KIND_FACT, "topic:other", "content", 0.8, "sess-1", &m2) == 0);
+   assert(g_last.calls == 0);
+
+   printf("test_memory_audit_hook: OK (memory_core_crud fires the hook; identity, no content)\n");
+   return 0;
+}


### PR DESCRIPTION
## What

The **KB half** of memory-on-the-bus, completing the agreed architecture: each process publishes to its **own** obs_bus as the op flows. aimee-kb now records the **authoritative** memory-mutation event at the store (`memory_core_crud`), catching **every** caller — agent-driven via kb_client, KB-internal maintenance (conflict-merge, lifecycle, L5 synthesis), and CLI — not just the server-initiated requests the server-side bridge (#1946) sees.

## D7 evolution (security invariant)

The event bus was confined to `aimee-server` only. It now lives in the **trusted server daemons** `aimee-server` **and** `aimee-kb` — never the thin-client `aimee`, gateway, or runtime-web binaries. `check_bus_blast_radius.sh` is updated (layer 2 allows `$(KB)` to link `BUS_SHIP_OBJS`; layer 4 exempts `aimee-kb`) and `EVENT_BUS_DECISIONS.md` documents the two-daemon rule. **Every other shipping binary still holds zero bus symbols; D7 green 7/7.**

## Mechanics

- aimee-kb links `BUS_SHIP_OBJS` + a tiny stub (`kb/kb_obs_bus_stub.c`) for the guardrail db1 sink it never drives (dead code in the KB — memory events use the ACTION kind → `audit_action_log`, already in the KB → the KB audit ledger + capture/replay).
- `memory_core_crud` exposes a NULL-default hook (`memory_set_audit_hook`, no bus dependency); a KB-side bridge (`kb/kb_memory_audit_bridge.c`) maps it → `obs_bus_emit`, installed in `kb_main`.

## PII

The `(kind, key)` identity — agent-supplied free text the KB does **not** content-gate — is **fingerprinted**, never raw (same fix as #1946's convergence). Extracted the fingerprint to **one shared impl** (`obs_bus_key_fingerprint`) so the server and KB bridges cannot diverge; the server bridge now calls it too.

## Tests

- `test_memory_audit_hook` — `memory_core_crud` fires the hook with identity, no content (db2 shim).
- direct `obs_bus_key_fingerprint` unit test — `mk:` prefix, no PII, deterministic, distinct.
- the server bridge test still green.

## Verification

aimee-kb + aimee-server + all shipping build & link; **D7 green (7/7, evolved invariant)**; clang-format clean; all test binaries link; full bench gate green.