### PR TITLE
Integrate feature branch into slice worktree at impl entry

### DIFF
--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -1,0 +1,122 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// gitRun runs a git command in dir, failing the test on error.
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+// setupSliceRepo builds a repo with a feature branch aimee/feat/wi_parent and a
+// slice worktree on aimee/wi/wi_child cut from it. Returns (repo, slicedir).
+func setupSliceRepo(t *testing.T) (string, string) {
+	t.Helper()
+	repo := t.TempDir()
+	gitRun(t, repo, "init", "-b", "trunk")
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "README")
+	gitRun(t, repo, "commit", "-m", "init")
+	gitRun(t, repo, "branch", "aimee/feat/wi_parent", "trunk")
+	slicedir := filepath.Join(t.TempDir(), "slice")
+	gitRun(t, repo, "worktree", "add", slicedir, "-b", "aimee/wi/wi_child", "aimee/feat/wi_parent")
+	return repo, slicedir
+}
+
+// advanceFeature commits a file onto aimee/feat/wi_parent in the main repo,
+// simulating a sibling slice merging into the feature branch.
+func advanceFeature(t *testing.T, repo, name, content string) {
+	t.Helper()
+	gitRun(t, repo, "checkout", "aimee/feat/wi_parent")
+	if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", name)
+	gitRun(t, repo, "commit", "-m", "sibling: "+name)
+	gitRun(t, repo, "checkout", "trunk")
+}
+
+func TestIntegrateFeatureBasePicksUpSiblingMerge(t *testing.T) {
+	repo, slicedir := setupSliceRepo(t)
+	// A sibling slice merges a prerequisite into the feature branch AFTER our
+	// worktree was cut.
+	advanceFeature(t, repo, "prereq.go", "package prereq\n")
+
+	// The prerequisite is not visible in the slice worktree yet.
+	if _, err := os.Stat(filepath.Join(slicedir, "prereq.go")); !os.IsNotExist(err) {
+		t.Fatalf("prereq.go should be absent before integration, stat err=%v", err)
+	}
+
+	park, err := integrateFeatureBase(context.Background(), slicedir, "wi_parent")
+	if err != nil {
+		t.Fatalf("integrateFeatureBase: %v", err)
+	}
+	if park != "" {
+		t.Fatalf("expected clean integration, got park=%q", park)
+	}
+	// The prerequisite is now present — the dependent slice can proceed.
+	if _, err := os.Stat(filepath.Join(slicedir, "prereq.go")); err != nil {
+		t.Fatalf("prereq.go should be present after integration: %v", err)
+	}
+}
+
+func TestIntegrateFeatureBaseNoopWhenAlreadyCurrent(t *testing.T) {
+	repo, slicedir := setupSliceRepo(t)
+	_ = repo
+	// Base == HEAD's ancestor already: integration is a no-op, no park.
+	park, err := integrateFeatureBase(context.Background(), slicedir, "wi_parent")
+	if err != nil || park != "" {
+		t.Fatalf("expected clean no-op, got park=%q err=%v", park, err)
+	}
+}
+
+func TestIntegrateFeatureBaseConflictAbortsCleanly(t *testing.T) {
+	repo, slicedir := setupSliceRepo(t)
+
+	// The slice edits shared.go one way...
+	if err := os.WriteFile(filepath.Join(slicedir, "shared.go"), []byte("package a // slice\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, slicedir, "add", "shared.go")
+	gitRun(t, slicedir, "commit", "-m", "slice edit")
+
+	// ...while a sibling edits the same file the other way on the feature branch.
+	advanceFeature(t, repo, "shared.go", "package a // sibling\n")
+
+	park, err := integrateFeatureBase(context.Background(), slicedir, "wi_parent")
+	if err != nil {
+		t.Fatalf("integrateFeatureBase returned err: %v", err)
+	}
+	if park != "base_integration_conflict" {
+		t.Fatalf("expected base_integration_conflict, got %q", park)
+	}
+	// The worktree must be left clean — never half-merged.
+	if status := gitRun(t, slicedir, "status", "--porcelain"); status != "" {
+		t.Fatalf("worktree not clean after conflict abort: %q", status)
+	}
+	// No merge must be in progress (MERGE_HEAD absent).
+	cmd := exec.Command("git", "-C", slicedir, "rev-parse", "-q", "--verify", "MERGE_HEAD")
+	if err := cmd.Run(); err == nil {
+		t.Fatal("MERGE_HEAD still present: merge was not aborted")
+	}
+	// The slice's own commit survives.
+	if _, err := os.Stat(filepath.Join(slicedir, "shared.go")); err != nil {
+		t.Fatalf("slice's own shared.go should survive the abort: %v", err)
+	}
+}

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -318,6 +318,23 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	if err != nil {
 		return StepResult{}, err
 	}
+	// A slice worktree is cut off aimee/feat/<parent> once, at creation. Sibling
+	// slices merge into that feature branch afterwards, but the reused worktree is
+	// never re-synced — so a dependent slice runs against a base missing its
+	// prerequisites, produces no diff, and parks convergence_no_progress. Integrate
+	// the feature branch here, at code-mutating entry (implement/document + its TDD
+	// pre-step below), so this attempt sees siblings that have merged since. Not done
+	// at freeze/pr/ci/merge — those must observe a stable diff.
+	if req.WorkItem.ParentID != "" {
+		parkReason, integErr := integrateFeatureBase(ctx, workdir, req.WorkItem.ParentID)
+		if integErr != nil {
+			return StepResult{}, integErr
+		}
+		if parkReason != "" {
+			return StepResult{Status: StepPending, PauseReason: parkReason,
+				Detail: "conflict merging aimee/feat/" + req.WorkItem.ParentID + " into slice"}, nil
+		}
+	}
 	prompt := "Implement the complete approved task in this worktree, run the repository verification, fix failures, and leave the accepted changes in the worktree."
 	if docs {
 		prompt = "Document the complete implemented change in this worktree. Update the appropriate user and developer documentation and inline comments; leave the accepted changes in the worktree."
@@ -457,6 +474,43 @@ func commitChanges(ctx context.Context, workdir, stage string) error {
 	}
 	_, err := gitText(ctx, workdir, "-c", "user.name=aimee-wfe", "-c", "user.email=wfe@aimee.local", "commit", "-m", "wfe: "+stage)
 	return err
+}
+
+// integrateFeatureBase merges the parent feature branch (aimee/feat/<parentID>)
+// into a slice worktree so a dependent slice picks up siblings that merged after
+// its worktree was cut. aimee/feat/<parent> is a LOCAL ref that sibling merge
+// steps advance in the shared ref store, so this is a pure-local merge — no fetch,
+// which also keeps this off the fleet-wide credential rate limiter. It merges
+// (never rebases) to preserve SHAs the downstream merge-into-feature and PR diff
+// depend on.
+//
+// Returns ("", nil) when there is nothing to integrate (base absent, or already an
+// ancestor of HEAD) or the merge succeeds. On a conflicting/failed merge it never
+// leaves a half-merged tree: it aborts, hard-resets as a last resort to guarantee a
+// clean worktree, and returns the park reason "base_integration_conflict" so the
+// slice surfaces distinctly instead of masquerading as convergence_no_progress or
+// poisoning the reused worktree.
+func integrateFeatureBase(ctx context.Context, workdir, parentID string) (string, error) {
+	base := "aimee/feat/" + parentID
+	// The feature branch may not exist yet (first generation, before any slice has
+	// merged into it) — nothing to integrate.
+	if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", base+"^{commit}"); err != nil {
+		return "", nil
+	}
+	// Already contains the base tip: merge would be a no-op.
+	if _, err := gitText(ctx, workdir, "merge-base", "--is-ancestor", base, "HEAD"); err == nil {
+		return "", nil
+	}
+	if _, err := gitText(ctx, workdir, "-c", "user.name=aimee-wfe", "-c", "user.email=wfe@aimee.local",
+		"merge", "--no-edit", base); err == nil {
+		return "", nil
+	}
+	// Merge failed (conflict or otherwise): restore a clean worktree before parking.
+	_, _ = gitText(ctx, workdir, "merge", "--abort")
+	if status, _ := gitText(ctx, workdir, "status", "--porcelain"); status != "" {
+		_, _ = gitText(ctx, workdir, "reset", "--hard", "HEAD")
+	}
+	return "base_integration_conflict", nil
 }
 
 func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult, error) {


### PR DESCRIPTION
## Problem

A slice worktree is cut off `aimee/feat/<parent>` **once**, at creation. Sibling slices merge into that feature branch afterward, but the reused worktree is **never re-synced** (`WorktreeManager.Ensure` early-returns the cached worktree; `mutate` runs the agent without syncing). So a dependent slice runs against a base missing its prerequisites — the impl agent correctly refuses to fabricate, produces no diff, and the slice parks `convergence_no_progress`. **Multi-slice features stall permanently once any slice depends on another** (observed live: slices g0.5/g0.10 in run 5dbdfcce).

## Fix

Integrate the parent feature branch into the slice worktree at **code-mutating entry** (the implement/document step + its TDD pre-step) — the point that needs prerequisites. Not at freeze/pr/ci/merge, which must observe a stable diff.

Mechanism (hardened by a round-1 design review that caught two defects in the naive approach):
- **Local merge, no fetch.** `aimee/feat/<parent>` is a *local* ref that sibling merge steps advance in the shared ref store, so this is a pure-local `git merge` — no fetch, keeping it off the fleet-wide credential rate limiter. (The naive "fetch origin <base>" would have been a no-op: it updates the remote-tracking ref, not the local ref `worktree add` uses.)
- **Merge, not rebase** — preserves SHAs the downstream merge-into-feature and PR diff depend on.
- **Conflict never corrupts.** On a conflicting merge: `git merge --abort`, assert a clean tree (hard-reset as last resort), and park with a **distinct** reason `base_integration_conflict` — so it surfaces distinctly instead of masquerading as `convergence_no_progress` or poisoning the reused worktree.

## Test

`integrate_base_test.go`: (1) picks up a sibling merge into the slice worktree, (2) no-op when already current, (3) conflict → abort leaving a **clean** worktree with the slice's own commit intact and no `MERGE_HEAD`. Full engine suite green; `go build ./...` clean.

## Scope

WFE (Go) side only — fixes the live stall. The C-side session/delegate path (basing on `origin/<primary>`, needs a fetched refresh + dirty-tree handling) is a separate follow-up.