### PR TITLE
Fail-closed: refuse an unsandboxed delegate shell on the host

### DIFF
--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -711,6 +711,10 @@ int64_t auto_snapshot_record(const char *path)
    return snap_id;
 }
 
+/* Provided by server_compute (weak NULL fallback elsewhere): the id of the
+ * delegation running on this thread, or NULL for the trusted primary session. */
+const char *delegation_active_id(void);
+
 char *tool_bash(const char *command, int timeout_ms)
 {
    /* Detached workspace (turn bound to a serving client): marshal the shell
@@ -804,6 +808,33 @@ char *tool_bash(const char *command, int timeout_ms)
    int guarded_parent = guard_ro && guard_ro[0];
    char guarded_fallback_err[256] = "";
    pid_t pid;
+
+   /* Fail-closed containment: a DELEGATE (untrusted model) must never run a shell
+    * UNSANDBOXED on the aimee-server host. That host process is uid 0 with the
+    * docker socket mounted, so an unsandboxed command (e.g. `docker run --privileged
+    * -v /:/host ...`) is a host-root escalation that bypasses every aimee control.
+    * The detached/container-sandboxed delegate paths returned above; reaching here is
+    * co-located execution. On Linux that is isolated by sandbox_exec unless the
+    * sandbox is OFF (or a guarded_parent LXC plain-fork fallback fires); off-Linux
+    * there is no namespace sandbox at all. Refuse those unsandboxed cases for a
+    * delegate — the trusted primary (operator) session, which has no active
+    * delegation, is unaffected and still runs on the host. */
+#ifdef __linux__
+   const int host_unsandboxed = (sbox_cfg.mode == SANDBOX_MODE_OFF);
+#else
+   const int host_unsandboxed = !guarded_parent; /* guarded_parent already refused below */
+#endif
+   if (host_unsandboxed && delegation_active_id())
+   {
+      close(stdout_pipe[0]);
+      close(stdout_pipe[1]);
+      close(stderr_pipe[0]);
+      close(stderr_pipe[1]);
+      return safe_strdup(
+          "{\"stdout\":\"\",\"stderr\":\"refused: a delegated shell requires sandbox isolation, "
+          "but the sandbox is off/unavailable; running unsandboxed on the aimee-server host is "
+          "not permitted\",\"exit_code\":-1}");
+   }
 #ifndef __linux__
    if (guarded_parent)
    {

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1257,8 +1257,8 @@ static void test_tool_bash_delegate_unsandboxed_refused(void)
    g_test_delegation_id = "test-deleg";
    char *result = tool_bash("echo escalated", 5000);
    assert(result != NULL);
-   assert(strstr(result, "refused") != NULL);       /* fail-closed */
-   assert(strstr(result, "escalated") == NULL);      /* the command did NOT run */
+   assert(strstr(result, "refused") != NULL);   /* fail-closed */
+   assert(strstr(result, "escalated") == NULL); /* the command did NOT run */
    assert(strstr(result, "\"exit_code\":-1") != NULL);
    free(result);
 

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -72,6 +72,16 @@ void test_ir_parse_responses_text_only(void);
 void test_responses_parser_uses_output_text_done(void);
 void test_responses_parser_separates_message_items(void);
 
+/* Strong override of the weak delegation_active_id() (agent_tools_dispatch.c) so a
+ * test can simulate running inside a delegation. NULL => the trusted primary
+ * session. server_compute_mailbox.o (the real strong definition) is not linked
+ * into unit-test-agent, so this override is unambiguous. */
+static const char *g_test_delegation_id;
+const char *delegation_active_id(void)
+{
+   return g_test_delegation_id;
+}
+
 /* --- Expose tool functions for testing via redeclaration --- */
 char *tool_bash(const char *command, int timeout_ms);
 char *tool_read_file(const char *path, int offset, int limit, int raw);
@@ -1234,6 +1244,29 @@ static void test_tool_bash(void)
 
    result = tool_bash("yes x | head -c 65536", 5000);
    assert(result && strstr(result, "\"exit_code\":0") != NULL);
+   free(result);
+}
+
+/* Containment: a DELEGATE (untrusted model) must never run a shell UNSANDBOXED on
+ * the aimee-server host — that host is uid 0 with the docker socket mounted, so an
+ * unsandboxed command is a host-root escalation. The test config's sandbox mode is
+ * OFF (default), so tool_bash would otherwise fork on the host; with a delegation
+ * active it must refuse instead. The primary session (no delegation) still runs. */
+static void test_tool_bash_delegate_unsandboxed_refused(void)
+{
+   g_test_delegation_id = "test-deleg";
+   char *result = tool_bash("echo escalated", 5000);
+   assert(result != NULL);
+   assert(strstr(result, "refused") != NULL);       /* fail-closed */
+   assert(strstr(result, "escalated") == NULL);      /* the command did NOT run */
+   assert(strstr(result, "\"exit_code\":-1") != NULL);
+   free(result);
+
+   /* The trusted primary (operator) session still runs on the host. */
+   g_test_delegation_id = NULL;
+   result = tool_bash("echo primary-ok", 5000);
+   assert(result != NULL);
+   assert(strstr(result, "primary-ok") != NULL);
    free(result);
 }
 
@@ -3281,6 +3314,7 @@ int main(void)
    test_responses_parser_separates_message_items();
    test_agent_is_exec_role();
    test_tool_bash();
+   test_tool_bash_delegate_unsandboxed_refused();
    test_detached_skips_worktree_rewrite();
    test_tool_read_file();
    test_tool_write_file();


### PR DESCRIPTION
Containment fix (2a): a delegate shell must never run unsandboxed on the aimee-server host (uid 0 + docker socket = host-root escalation). tool_bash now refuses fail-closed when execution would be unsandboxed (sandbox mode OFF / non-Linux) AND a delegation is active; the primary operator session is unaffected. Test: test_tool_bash_delegate_unsandboxed_refused. unit-test-agent green, -Werror clean. Follow-up 2b: tmux-CLI delegates bypass tool_bash. Operational #1: appliance root password published in git history + codex config -> must be rotated.