### PR TITLE
Reap leaked delegate containers periodically

### DIFF
--- a/src/modules/delegates/delegate_backend_docker.c
+++ b/src/modules/delegates/delegate_backend_docker.c
@@ -265,6 +265,80 @@ int delegate_backend_docker_remove_orphans(void)
    return removed;
 }
 
+/* Days-from-civil (Hinnant) → UTC epoch seconds for a naive Y-M-D H:M:S.
+ * Avoids the non-portable timegm(); the caller applies the TZ offset. */
+static time_t docker_utc_epoch(int y, int mo, int d, int h, int mi, int s)
+{
+   y -= mo <= 2;
+   int era = (y >= 0 ? y : y - 399) / 400;
+   unsigned yoe = (unsigned)(y - era * 400);
+   unsigned doy = (153u * (unsigned)(mo + (mo > 2 ? -3 : 9)) + 2u) / 5u + (unsigned)d - 1u;
+   unsigned doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+   long days = (long)era * 146097L + (long)doe - 719468L;
+   return (time_t)days * 86400 + h * 3600 + mi * 60 + s;
+}
+
+/* Periodic runtime reap of aged delegate containers.
+ *
+ * remove_orphans() only runs at startup, and docker_release() only removes the
+ * container on the NORMAL turn-completion path. When the heartbeat monitor
+ * stale-cancels a delegate job (or the delegate crashes/fails) its running
+ * container is left behind — leaking one container per stale/failed turn until the
+ * next restart. Over a long uptime these accumulate and fill the image volume.
+ *
+ * Reap any aimee-delegate-* container older than max_age_secs, chosen ABOVE the
+ * in-tool job cap (DEFAULT_IN_TOOL_THRESHOLD_SECS, 1200s) so a live long-running
+ * turn is never removed. Returns the count removed, or -1 on a docker error. */
+int delegate_backend_docker_reap_aged(int max_age_secs)
+{
+   const char *list_argv[] = {
+       resolve_docker_bin(),     "ps", "--filter", "name=^aimee-delegate-", "--format",
+       "{{.ID}} {{.CreatedAt}}", NULL};
+   char *out = NULL;
+   if (safe_exec_capture_cwd_env_timeout(list_argv, NULL, NULL, &out, 1 << 20,
+                                         DOCKER_PROBE_TIMEOUT_MS) != 0)
+   {
+      free(out);
+      return -1;
+   }
+   time_t now = time(NULL);
+   int removed = 0;
+   char *save = NULL;
+   for (char *line = strtok_r(out, "\r\n", &save); line; line = strtok_r(NULL, "\r\n", &save))
+   {
+      /* Line is Go's default CreatedAt format: "<id> 2006-01-02 15:04:05 -0700 MST". */
+      char id[80];
+      int yy, mo, dd, hh, mi, ss;
+      char off[8] = "+0000";
+      if (sscanf(line, "%79s %d-%d-%d %d:%d:%d %7s", id, &yy, &mo, &dd, &hh, &mi, &ss, off) < 7)
+         continue;
+      /* Only accept a bare container id (hex), same guard as remove_orphans. */
+      size_t len = strlen(id);
+      int valid = len >= 12 && len <= 64;
+      for (size_t i = 0; valid && i < len; i++)
+         valid = isxdigit((unsigned char)id[i]) != 0;
+      if (!valid)
+         continue;
+      long off_secs = 0;
+      if ((off[0] == '+' || off[0] == '-') && strlen(off) >= 5 && isdigit((unsigned char)off[1]))
+      {
+         int oh = (off[1] - '0') * 10 + (off[2] - '0');
+         int om = (off[3] - '0') * 10 + (off[4] - '0');
+         off_secs = (long)(oh * 3600 + om * 60) * (off[0] == '-' ? -1 : 1);
+      }
+      time_t created = docker_utc_epoch(yy, mo, dd, hh, mi, ss) - off_secs;
+      if (created <= 0 || (long)(now - created) < max_age_secs)
+         continue;
+      const char *rm_argv[] = {resolve_docker_bin(), "rm", "-f", id, NULL};
+      if (run_docker(rm_argv) == 0)
+         removed++;
+      else
+         LOG_WARN("delegate-sandbox", "failed to reap aged delegate container %s", id);
+   }
+   free(out);
+   return removed;
+}
+
 /* Determine whether the running sandbox `container` was actually isolated by the
  * runtime, i.e. whether `--network none` was honoured. Asks the HOST daemon (not a
  * binary inside the untrusted image, so distroless/scratch images are fine) for the

--- a/src/modules/delegates/include/aimee/delegates/delegate_backend_docker.h
+++ b/src/modules/delegates/include/aimee/delegates/delegate_backend_docker.h
@@ -45,6 +45,13 @@ extern "C"
     * container is necessarily orphaned. Returns removed count or -1. */
    int delegate_backend_docker_remove_orphans(void);
 
+   /* Periodic runtime reap of aged delegate containers (older than max_age_secs).
+    * Unlike remove_orphans (startup-only), this runs while the server is live to
+    * reclaim containers leaked when a delegate is stale-cancelled/crashes and its
+    * release() never fires. max_age_secs must exceed the in-tool job cap so a live
+    * turn is never removed. Returns removed count or -1. */
+   int delegate_backend_docker_reap_aged(int max_age_secs);
+
    /* Build the docker exec command-string used by exec(). Pure
     * string assembly. Shape:
     *   docker exec -i <container_name> bash -c '<base64-encoded-script>'

--- a/src/server/server_delegate_monitor.c
+++ b/src/server/server_delegate_monitor.c
@@ -1,7 +1,8 @@
 /* server_delegate_monitor.c: see server_delegate_monitor.h */
 
 #include "server_delegate_monitor.h"
-#include "http_retry.h"  /* http_set_progress_cb */
+#include <aimee/delegates/delegate_backend_docker.h> /* delegate_backend_docker_reap_aged (leaked-container reap) */
+#include "http_retry.h"                              /* http_set_progress_cb */
 #include "cli_session.h" /* cli_session_set_heartbeat_cb (tmux-CLI delegates) */
 #include "log.h"
 
@@ -91,13 +92,30 @@ int server_delegate_monitor_sweep(int idle_threshold_secs, int in_tool_threshold
    return cancelled;
 }
 
+/* Reap aged delegate containers this many sweeps apart (~5 min at 30 s/sweep).
+ * The sweep above stale-cancels the JOB but never removes its container; only the
+ * normal completion path does. Without this, a stale/crashed delegate leaks its
+ * container until the next restart, accumulating until the image volume fills. */
+#define CONTAINER_REAP_EVERY_N_SWEEPS 10
+/* Age threshold for the container reap. Above DEFAULT_IN_TOOL_THRESHOLD_SECS so a
+ * live long-running turn is never removed. */
+#define CONTAINER_REAP_AGE_SECS 1800
+
 static void *monitor_thread(void *arg)
 {
    (void)arg;
+   int sweeps = 0;
    while (!g_monitor_stop)
    {
       (void)server_delegate_monitor_sweep(DEFAULT_IDLE_THRESHOLD_SECS,
                                           DEFAULT_IN_TOOL_THRESHOLD_SECS);
+
+      if (++sweeps % CONTAINER_REAP_EVERY_N_SWEEPS == 0)
+      {
+         int reaped = delegate_backend_docker_reap_aged(CONTAINER_REAP_AGE_SECS);
+         if (reaped > 0)
+            LOG_INFO("server.delegate_monitor", "reaped %d aged delegate container(s)", reaped);
+      }
 
       /* Sleep in 1 s chunks so shutdown is responsive. */
       for (int slept = 0; slept < DEFAULT_POLL_INTERVAL_SECS && !g_monitor_stop; slept++)

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -826,9 +826,56 @@ static void test_docker_workspace_validation_refusals(void)
    printf("  PASS: docker_workspace_validation_refusals\n");
 }
 
+/* reap_aged removes delegate containers older than the threshold and keeps recent
+ * ones. Uses a self-contained fake docker: `ps` emits one ancient and one current
+ * container line in Go's CreatedAt format; `rm` logs the id it was asked to drop. */
+static void test_reap_aged_removes_only_old(void)
+{
+   char script[256], rmlog[256];
+   snprintf(script, sizeof(script), "/tmp/aimee-reap-docker-%d.sh", (int)getpid());
+   snprintf(rmlog, sizeof(rmlog), "/tmp/aimee-reap-rmlog-%d", (int)getpid());
+   unlink(rmlog);
+   FILE *f = fopen(script, "w");
+   assert(f != NULL);
+   fprintf(f,
+           "#!/bin/bash\n"
+           "case \"$1\" in\n"
+           "  ps)\n"
+           "    echo \"aaaaaaaaaaaa 2000-01-01 00:00:00 +0000 UTC\"\n"
+           "    echo \"bbbbbbbbbbbb $(date -u +'%%Y-%%m-%%d %%H:%%M:%%S') +0000 UTC\"\n"
+           "    ;;\n"
+           "  rm)\n"
+           "    shift 2\n"
+           "    echo \"$1\" >> %s\n"
+           "    ;;\n"
+           "esac\n"
+           "exit 0\n",
+           rmlog);
+   fclose(f);
+   assert(chmod(script, 0755) == 0);
+   setenv("AIMEE_DOCKER_BIN", script, 1);
+
+   assert(delegate_backend_docker_reap_aged(1800) == 1);
+
+   char buf[256] = {0};
+   f = fopen(rmlog, "r");
+   assert(f != NULL);
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   assert(strstr(buf, "aaaaaaaaaaaa") != NULL); /* ancient -> reaped */
+   assert(strstr(buf, "bbbbbbbbbbbb") == NULL); /* current -> kept */
+
+   unsetenv("AIMEE_DOCKER_BIN");
+   unlink(script);
+   unlink(rmlog);
+   printf("  PASS: test_reap_aged_removes_only_old\n");
+}
+
 int main(void)
 {
    test_remove_orphans_accepts_only_container_ids();
+   test_reap_aged_removes_only_old();
    printf("delegate_backend_docker:\n");
    test_register_puts_docker_in_registry();
    test_file_ops_reject_null_state();


### PR DESCRIPTION
## Problem

Delegate sandbox containers leaked until they filled the image volume — observed on .254 tonight: **216 running `aimee-delegate-*` containers, 105 GB, NVME tier 100% full**, so `docker pull` failed with `no space left on device` and deploys were blocked.

## Root cause

The heartbeat monitor (`server_delegate_monitor_sweep`, every 30 s) stale-**cancels** a wedged delegate *job* (`db1_agent_job_cancel_by_id`) but never removes its docker *container*. `docker_release()` (`docker rm -f`) only fires on the **normal** turn-completion path — so every stale-cancelled / crashed / failed delegate leaks a running container. The only container cleanup, `remove_orphans()`, runs **only at startup** ("orphaned by the prior process"); there's no periodic runtime reap, so leaks accumulate across a long uptime until the disk fills.

## Fix

`delegate_backend_docker_reap_aged(max_age_secs)`: lists `aimee-delegate-*` containers with their `CreatedAt` and `docker rm -f`s any older than the threshold. The monitor thread calls it every ~5 min with **1800 s** — safely above the in-tool job cap (1200 s), so a live long-running turn is never removed. Age is parsed portably (days-from-civil, no `timegm`) with the TZ offset applied.

## Test

`test_reap_aged_removes_only_old` drives it through a fake docker whose `ps` emits one ancient and one current container: the ancient is reaped, the current kept. Suite green; server + test link clean under `-Werror`.

(An overnight operational auto-reaper is already keeping .254's disk healthy until this lands.)