### PR TITLE
Complete a no-op slice instead of looping an empty diff through review

### DIFF
--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -23,6 +23,12 @@ const (
 	StepChanges  StepStatus = "changes"
 	StepPending  StepStatus = "pending"
 	StepFailed   StepStatus = "failed"
+	// StepAccepted completes the work item as a no-op success now, skipping any
+	// remaining stages. Used when a step determines there is nothing left to do
+	// (e.g. freeze finds an empty diff because the slice's work is already present
+	// in the base) — proceeding would only freeze/review/PR an empty artifact and
+	// loop to convergence_no_progress.
+	StepAccepted StepStatus = "accepted"
 )
 
 type StepRequest struct {
@@ -375,6 +381,16 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 			return out, err
 		}
 		out.NextStage = next
+		return out, nil
+
+	case StepAccepted:
+		// Nothing left to do — complete the item as an accepted no-op, skipping any
+		// remaining stages (no empty artifact to review, PR, or merge).
+		if err := e.db.Finish(ctx, item.ID, node.ID, "accepted", step.Detail,
+			step.ContentHash, step.CostUSD); err != nil {
+			return out, err
+		}
+		out.Terminal, out.State = true, "accepted"
 		return out, nil
 
 	case StepChanges:

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -735,6 +735,87 @@ nodes:
 	}
 }
 
+type acceptedRunner struct{}
+
+func (acceptedRunner) Run(context.Context, StepRequest) (StepResult, error) {
+	return StepResult{Status: StepAccepted, Detail: "no-op: empty diff vs base"}, nil
+}
+
+// A step returning StepAccepted completes the item as an accepted no-op and does
+// NOT advance to a remaining stage. This is what freeze does on an empty diff so a
+// no-op slice cannot loop through review to convergence_no_progress.
+func TestStepAcceptedFinishesItemWithoutAdvancing(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte(`name: slice
+start: freeze
+nodes:
+  - id: source
+    block: understand
+  - id: impl
+    block: implement
+    in: {plan: source.out}
+  - id: freeze
+    block: freeze
+    in: {branch: impl.out}
+    next: pr
+  - id: pr
+    block: pr.open
+    in: {src: freeze.out}
+    next: ci
+  - id: ci
+    block: gate.ci
+    in: {pr: pr.out}
+    on_pass: merge
+    on_fail: impl
+  - id: merge
+    block: merge
+    in: {pr: pr.out}
+`)
+	if err := os.WriteFile(filepath.Join(workflowDir, "slice.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal("wi_noop", []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := artifacts.PutNodeArtifact("wi_noop", "impl", "branch", []byte("head")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateWorkItem(context.Background(), db1.CreateWorkItem{ID: "wi_noop", Repo: "repo", ProposalPath: "p", WorkflowName: "slice", WorkflowVersion: def.Version, StartStage: "freeze"}); err != nil {
+		t.Fatal(err)
+	}
+	eng, err := New(store, artifacts, workflowDir, acceptedRunner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := eng.Advance(context.Background(), "wi_noop")
+	if err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	if !out.Terminal || out.State != "accepted" {
+		t.Fatalf("StepAccepted must finish the item accepted, got terminal=%v state=%q", out.Terminal, out.State)
+	}
+	if out.NextStage != "" {
+		t.Fatalf("no-op accept must not advance to a next stage, got %q", out.NextStage)
+	}
+}
+
 func TestGateReviewsItsBoundArtifactNotThePlanShortcut(t *testing.T) {
 	root := t.TempDir()
 	workflowDir := filepath.Join(root, "workflows")

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -536,6 +536,14 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 	if err != nil {
 		return StepResult{}, err
 	}
+	if strings.TrimSpace(diff) == "" {
+		// The slice produced no net change vs its base — its work is already present
+		// (e.g. a sibling merged it and base-integration pulled it in) or the task was
+		// a no-op. Freezing an empty diff sends an empty artifact through review, which
+		// rejects it, looping the slice to convergence_no_progress. There is nothing to
+		// review, PR, or merge, so complete the slice as an accepted no-op.
+		return StepResult{Status: StepAccepted, Detail: "no-op: empty diff vs base"}, nil
+	}
 	return StepResult{Status: StepAdvanced, ArtifactType: "frozen_diff", Artifact: diff, ContentHash: wfe.Hash([]byte(diff))}, nil
 }
 


### PR DESCRIPTION
## Problem

A slice whose `freeze` produces an **empty diff** (no net change vs its base — its work is already present because a sibling merged it and base-integration pulled it in, or the task was a genuine no-op) still advanced with an empty `frozen_diff` artifact (content hash `e3b0c44…` = SHA-256 of ""). The roundtable review correctly rejects an empty artifact, so the slice looped `impl → freeze → rt_gate → requested_changes` until the convergence guard parked it `convergence_no_progress` — **permanently stalling the feature on redundant/no-op slices.** (Observed live: the f98d feature's g0.15–20 slices all reviewing the empty-string hash.)

## Fix

Add a `StepAccepted` step status: the engine finishes the item as an **accepted no-op**, skipping any remaining stages. `freeze` returns it when the diff is empty — there is nothing to review, PR, or merge, so the slice completes cleanly instead of feeding an empty artifact into review and looping.

## Test

`TestStepAcceptedFinishesItemWithoutAdvancing`: a step returning `StepAccepted` finishes the item terminal-accepted and does **not** advance to a next stage. Full engine suite green; `go build ./...` clean.

Depends conceptually on #1948 (base-integration) which is what makes dependent slices produce empty diffs once their prerequisites merge.