### PR TITLE
fix(governance): regenerate module-test-registration baseline (panel-provider rule)

### DIFF
--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -159,7 +159,7 @@
     },
     {
       "ctest": false,
-      "make": false,
+      "make": true,
       "module": "delegates",
       "test": "src/tests/test_panel_provider.c"
     },


### PR DESCRIPTION
One-line baseline regen: `test_panel_provider.c` is now `make: true` after PR #1950 restored the `unit-test-panel-provider` rule. `check_module_test_registration` was failing on testing because `module-inventory.yml` only runs on `feature/core-modularization`, so the drift wasn't caught on the #1950 merge. Found by the overnight autonomous test loop on CT 301 (build+governance sweep of the merged state). Also suggests extending module-inventory.yml's trigger to `testing`.