### PR TITLE
Make the vault the single source of truth for delegate OAuth tokens

### DIFF
--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -129,6 +129,18 @@ void cli_session_prepare_claude(const char *work_dir, int autonomous);
  * Reaps per-session homes older than an hour on each call. */
 int cli_session_isolated_claude_home(const char *work_dir, char *home_out, size_t home_out_sz);
 
+/* Refresh the shared codex OAuth token file (<home>/.codex/auth.json) from the
+ * vault before a codex delegate launches, so the vault stays the single source of
+ * truth. Best-effort: 0 on success or when no codex token is vaulted (legacy file
+ * left as-is), -1 only on a write failure. */
+int cli_session_materialize_codex_oauth(void);
+
+/* Materialize seam: read the vaulted (agent, "oauth") token into `out`. The strong
+ * implementation (server_cli_oauth.c) reads the vault; a weak default in
+ * cli_session.c returns non-zero so binaries without the vault fall back to the
+ * legacy on-disk credential. Returns 0 (token written) or non-zero (no entry). */
+int cli_oauth_vault_materialize_get(const char *agent, char *out, size_t out_len);
+
 /* Hand a minted isolated HOME (from cli_session_isolated_claude_home) to the
  * session so cli_session_destroy reclaims it on exit. Copies `home`; pass NULL to
  * clear. Call after a successful cli_session_create so every teardown path (error

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -78,6 +78,7 @@ static int cli_session_execute_inner(const agent_t *agent, const agent_network_t
     * substring match: this gates --dangerously-skip-permissions and the config
     * seeding, so it must not fire for an unrelated agent named e.g. "claudette". */
    int is_claude = strcmp(kind, "claude") == 0 || strncmp(kind, "claude-", 7) == 0;
+   int is_codex = strcmp(kind, "codex") == 0 || strncmp(kind, "codex-", 6) == 0;
    char cli_cmd_buf[CLI_SESSION_CMD_MAX];
    const char *cli_cmd = base_cmd;
    int need_model = agent->model[0] && !strstr(base_cmd, "--model") && !strstr(base_cmd, " -m ");
@@ -141,6 +142,10 @@ static int cli_session_execute_inner(const agent_t *agent, const agent_network_t
             cli_cmd = cli_cmd_home;
       }
    }
+   /* codex is not per-session isolated; refresh its shared token file from the
+    * vault (single source of truth) so a re-auth takes effect before this launch. */
+   if (is_codex && deleg)
+      (void)cli_session_materialize_codex_oauth();
 
    /* Prefix the launched CLI command with a per-session AIMEE_SESSION_ID assignment
     * (`AIMEE_SESSION_ID=<sid> <cli_cmd>` run by `/bin/sh -c`) so the PreToolUse hook

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -21,6 +21,21 @@
 #include <time.h>
 #include <unistd.h>
 
+/* OAuth-credential materialize seam. cli_session avoids a hard link dependency on
+ * the vault (which every test binary linking this TU would otherwise have to pull
+ * in): the REAL implementation lives in server_cli_oauth.c and reads the
+ * (agent, "oauth") secret from the vault. This weak default returns non-zero (no
+ * vaulted token) so binaries that do not link the vault fall back to the legacy
+ * on-disk credential. Returns 0 and fills out on success, non-zero otherwise. */
+__attribute__((weak)) int cli_oauth_vault_materialize_get(const char *agent, char *out,
+                                                          size_t out_len)
+{
+   (void)agent;
+   if (out && out_len)
+      out[0] = '\0';
+   return 1;
+}
+
 /* Run a tmux shell command for the session. On a detached (thin-client)
  * workspace the standard `claude` CLI, tmux, and the working tree live on the
  * CLIENT, so marshal the command over the reverse channel to run there; a
@@ -469,19 +484,35 @@ int cli_session_isolated_claude_home(const char *work_dir, char *home_out, size_
    if (mkdir(cdir, 0700) != 0 && errno != EEXIST)
       return -1;
 
-   /* Share the OAuth token (required to authenticate) and settings.json (MCP
-    * servers + hooks + the auto-updater disable) by symlink. The credential is
-    * mandatory: without it claude cannot auth, so a failed link falls back to the
-    * shared HOME rather than launching an unauthenticated seat. */
+   /* Materialize the OAuth token from the VAULT (single source of truth, written by
+    * the login flow, server-KEK wrapped) into this per-session home. Reading it
+    * from the vault means a re-auth is reflected everywhere without depending on a
+    * HOME-resolved plaintext file (the old symlink diverged when the login wrote
+    * $AIMEE_HOME but the delegate read $HOME). The credential is mandatory: without
+    * it claude cannot auth, so any failure falls back to the shared HOME. Written
+    * 0600 under the already-0700 .claude dir. */
    char src[PATH_MAX], dst[PATH_MAX];
-   if ((size_t)snprintf(src, sizeof(src), "%s/.claude/.credentials.json", shared) >= sizeof(src) ||
-       (size_t)snprintf(dst, sizeof(dst), "%s/.credentials.json", cdir) >= sizeof(dst))
+   if ((size_t)snprintf(dst, sizeof(dst), "%s/.credentials.json", cdir) >= sizeof(dst))
       return -1;
-   /* symlink() happily links to a missing target, so verify the shared token
-    * actually exists — a dangling credential link would launch an unauthenticated
-    * seat. No token -> fall back to the shared HOME. */
-   if (access(src, R_OK) != 0 || symlink(src, dst) != 0)
-      return -1;
+   char cred[8192];
+   if (cli_oauth_vault_materialize_get("claude", cred, sizeof(cred)) == 0 && cred[0])
+   {
+      int wrote = cli_write_file_atomic(dst, cred) == 0;
+      memset(cred, 0, sizeof(cred));
+      if (!wrote)
+         return -1;
+      (void)chmod(dst, 0600);
+   }
+   else
+   {
+      /* Legacy fallback: no vaulted token yet (pre-migration) — symlink the shared
+       * plaintext token. symlink() happily links to a missing target, so verify it
+       * exists first; a dangling link would launch an unauthenticated seat. */
+      if ((size_t)snprintf(src, sizeof(src), "%s/.claude/.credentials.json", shared) >= sizeof(src))
+         return -1;
+      if (access(src, R_OK) != 0 || symlink(src, dst) != 0)
+         return -1;
+   }
    if ((size_t)snprintf(src, sizeof(src), "%s/.claude/settings.json", shared) < sizeof(src) &&
        (size_t)snprintf(dst, sizeof(dst), "%s/settings.json", cdir) < sizeof(dst))
       (void)symlink(src, dst); /* helpful, not fatal */
@@ -524,6 +555,35 @@ int cli_session_isolated_claude_home(const char *work_dir, char *home_out, size_
       return -1;
 
    snprintf(home_out, home_out_sz, "%s", home);
+   return 0;
+}
+
+/* Materialize the codex OAuth token from the VAULT into the shared codex home
+ * (<home>/.codex/auth.json) before a codex delegate launches. codex delegates are
+ * not per-session isolated (unlike claude), so they read the shared file; refresh
+ * it from the vault (single source of truth) each launch so a re-auth takes effect
+ * without a stale plaintext file. Best-effort: returns 0 on success or when the
+ * vault has no codex token yet (legacy: the existing file, if any, is left as-is),
+ * -1 only on a write failure. Written 0600 under a 0700 .codex dir. */
+int cli_session_materialize_codex_oauth(void)
+{
+   char cred[8192];
+   if (cli_oauth_vault_materialize_get("codex", cred, sizeof(cred)) != 0 || !cred[0])
+      return 0; /* no vaulted codex token — leave any legacy file untouched */
+   const char *home = cli_claude_home(); /* process HOME (vendor-agnostic) */
+   char dir[PATH_MAX], dst[PATH_MAX];
+   if ((size_t)snprintf(dir, sizeof(dir), "%s/.codex", home) >= sizeof(dir) ||
+       (size_t)snprintf(dst, sizeof(dst), "%s/auth.json", dir) >= sizeof(dst))
+   {
+      memset(cred, 0, sizeof(cred));
+      return -1;
+   }
+   mkdir(dir, 0700); /* ignore EEXIST */
+   int wrote = cli_write_file_atomic(dst, cred) == 0;
+   memset(cred, 0, sizeof(cred));
+   if (!wrote)
+      return -1;
+   (void)chmod(dst, 0600);
    return 0;
 }
 

--- a/src/server/server_cli_oauth.c
+++ b/src/server/server_cli_oauth.c
@@ -12,6 +12,7 @@
 #include "util.h" /* safe_exec_capture_env */
 #include "log.h"
 #include "platform_path.h" /* platform_mkdir_p */
+#include "vault_service.h" /* vault_service_set_server — OAuth token single source of truth */
 
 #include <ctype.h>
 #include <fcntl.h>
@@ -89,6 +90,83 @@ static const char *home_dir(void)
 {
    const char *h = getenv("AIMEE_HOME");
    return (h && h[0]) ? h : "/var/lib/aimee";
+}
+
+/* The vendor CLI's on-disk OAuth token file, relative to the vendor HOME. */
+static const char *oauth_token_relpath(cli_oauth_vendor_t v)
+{
+   return v == CLI_OAUTH_CODEX ? ".codex/auth.json" : ".claude/.credentials.json";
+}
+
+/* Read up to cap bytes of a small credential file into a fresh NUL-terminated
+ * buffer (caller frees + scrubs), or NULL. The OAuth token files are tiny. */
+static char *oauth_read_secret_file(const char *path)
+{
+   int fd = open(path, O_RDONLY | O_CLOEXEC);
+   if (fd < 0)
+      return NULL;
+   enum
+   {
+      OAUTH_SECRET_CAP = 64 * 1024
+   };
+   char *buf = malloc(OAUTH_SECRET_CAP);
+   if (!buf)
+   {
+      close(fd);
+      return NULL;
+   }
+   size_t used = 0;
+   ssize_t n;
+   while (used < OAUTH_SECRET_CAP - 1 &&
+          (n = read(fd, buf + used, OAUTH_SECRET_CAP - 1 - used)) > 0)
+      used += (size_t)n;
+   close(fd);
+   if (n < 0 || used == 0)
+   {
+      memset(buf, 0, OAUTH_SECRET_CAP);
+      free(buf);
+      return NULL;
+   }
+   buf[used] = '\0';
+   return buf;
+}
+
+/* Persist the vendor's freshly-written OAuth token into the vault as the single
+ * source of truth, keyed (agent=<vendor>, cred="oauth") under the server principal
+ * (server-KEK wrapped, no unlock). Delegate launches materialize it from here, so a
+ * re-auth is reflected everywhere without depending on a HOME-resolved plaintext
+ * file. Best-effort: on failure the login still succeeds and the plaintext file
+ * remains as a fallback, but we log loudly since the vault is the intended store. */
+static void oauth_store_token_in_vault(cli_oauth_vendor_t v)
+{
+   char path[600];
+   snprintf(path, sizeof(path), "%s/%s", home_dir(), oauth_token_relpath(v));
+   char *secret = oauth_read_secret_file(path);
+   if (!secret)
+   {
+      aimee_log(LOG_WARN, "cli.oauth", "%s: could not read token file to vault it: %s",
+                g_vendors[v].name, path);
+      return;
+   }
+   if (vault_service_set_server(g_vendors[v].name, "oauth", secret) == VAULT_OK)
+      aimee_log(LOG_INFO, "cli.oauth", "%s OAuth token stored in vault (single source of truth)",
+                g_vendors[v].name);
+   else
+      aimee_log(LOG_WARN, "cli.oauth",
+                "%s OAuth token vault store FAILED — falling back to plaintext file",
+                g_vendors[v].name);
+   memset(secret, 0, strlen(secret));
+   free(secret);
+}
+
+/* Strong override of cli_session.c's weak materialize seam: read the vaulted
+ * (agent, "oauth") token so a delegate launch can write it into its ephemeral HOME
+ * (the single-source-of-truth read side). This TU already links the vault; keeping
+ * the seam out of cli_session.c means test binaries linking cli_session.o need no
+ * vault objects. Returns 0 (token written to out) or non-zero (no entry / error). */
+int cli_oauth_vault_materialize_get(const char *agent, char *out, size_t out_len)
+{
+   return vault_service_get_server_principal(agent, "oauth", out, out_len) == VAULT_OK ? 0 : 1;
 }
 
 /* Build the explicit child environment for a vendor command: HOME + per-vendor
@@ -576,6 +654,9 @@ int cli_oauth_poll(cli_oauth_vendor_t v, const char *session, cli_oauth_state_t 
    }
    if (authed)
    {
+      /* Persist the token into the vault (single source of truth) before locking
+       * down / tearing down: the delegate launch materializes it from the vault. */
+      oauth_store_token_in_vault(v);
       /* Lock down the token files, then tear the session down. */
       char tokdir[600];
       snprintf(tokdir, sizeof(tokdir), "%s/%s", home_dir(),


### PR DESCRIPTION
## Problem

claude and codex delegates each read an on-disk OAuth credential
(`~/.claude/.credentials.json`, `~/.codex/auth.json`), but the two sides
disagreed on where that file lives:

- **Write path** (web-GUI re-auth, `server_cli_oauth.c`) resolved HOME via `AIMEE_HOME`.
- **Read path** (delegate launch, `cli_session.c`) preferred `$HOME`.

A re-auth wrote one tree and the delegate read another, so a fresh token
never reached the delegate. Symptom: claude turns silently 401'd (0 API
calls → "no file changes" on every WFE impl slice) **even after
re-authorizing from the web GUI**.

## Fix

Route both vendors through the vault as the single source of truth.

- **Store on OAuth completion:** the token file is written into the vault
  under `(<vendor>, "oauth")` via `vault_service_set_server` (server-KEK
  wrapped, no unlock). claude *and* codex.
- **Materialize at delegate launch:**
  - claude — `cli_session_isolated_claude_home` writes the vaulted token
    into the per-session HOME (0600) instead of symlinking the shared
    on-disk credential; legacy symlink remains the fallback.
  - codex (not per-session isolated) — `cli_session_materialize_codex_oauth`
    refreshes `<home>/.codex/auth.json` from the vault before launch.

## Link seam

`cli_oauth_vault_materialize_get` is a **weak** default in `cli_session.c`
(returns non-zero → legacy on-disk fallback) with the **strong**
vault-backed override in `server_cli_oauth.c`. This keeps `cli_session.o`
free of a hard vault dependency, so test binaries and any build linking
`cli_session` without the vault still link cleanly.

## Verification

- Server + `unit-test-cli-session`, `unit-test-agent`,
  `unit-test-server-cli-oauth` all build and link on the current
  `testing` base (post core-mod restructure).
- `unit-test-cli-session` (exercises the weak-seam legacy fallback) and
  `unit-test-server-cli-oauth` pass.
- All four changed files are clang-format clean.

The end-to-end proof (re-auth → vault → live claude delegate produces API
calls) is **validation-pending** on deploy to the appliance.