### PR TITLE
MCP adapter: optional module installable into aimee-server or aimee-kb (Phase 1)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -265,7 +265,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`learning`** — _Learning subsystem (router, implicit, embed, synthesize; nested objects)._ Keys: `embed`, `implicit`, `review`, `router`, `synthesize`
 - **`lsp_servers`** — _LSP server definitions (array of objects)._ Keys: `args`, `command`, `extensions`, `name`
 - **`mcp`** — _MCP integration (e.g. OSV)._ Keys: `osv`
-- **`mcp_clients`** — _MCP client connections (array of objects)._ Keys: `bearer_token_env`, `command`, `cwd`, `name`, `transport`, `url`
+- **`mcp_clients`** — _MCP client connections (array of objects)._ Keys: `bearer_token_env`, `command`, `cwd`, `install`, `name`, `transport`, `url`
 - **`memory`** — _Memory subsystem; most children (recall, rerank, lifecycle, …) are nested objects with their own keys._ Keys: `abstain`, `aggregation`, `bm25_weight`, `briefing`, `citations`, `cognify`, `context_budget`, `coref`, `derive_facts`, `directives`, `dispositions`, `episode_summaries`, `failure_detection`, `fetch_budget`, `hard_negative_log`, `improve`, `lifecycle`, `pagerank`, `profile_cards`, `prospective`, `recall`, `rewrite`, `routing`, `salience`, `scenes`, `semantic_floor_scale`, `semantic_weight`
 - **`memory_maintenance`** — _Memory maintenance scheduling._ Keys: `enabled`, `interval_seconds`, `summarize_enabled`, `trigger_inserts`, `trigger_secs`
 - **`memory_negation`** — _Negation handling in memory._ Keys: `enabled`

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -1,144 +1,148 @@
-# Proposal: an event-bus MCP-plugin adapter — optional, install into aimee-server or aimee-kb
+# Proposal: MCP-plugin adapter as an optional module (install into aimee-server or aimee-kb)
 
-## The idea
+> **Revised after a five-lens design roundtable (2026-07-25), verdict needs-rework →
+> reworked.** The first draft framed this as "an adapter *into the event bus* that
+> runs MCP plugins," with plugin calls "riding the bus" across daemons. The
+> roundtable verified against the code that **the event bus is intra-daemon
+> shared-memory only** (memfd regions handed over a local socketpair via SCM_RIGHTS;
+> each daemon runs its own host — D1/D7); it never crosses the server↔kb process
+> boundary, and there is no general bus host today (only obs_bus's private 4-slot
+> audit singleton). So the bus cannot be the cross-daemon plugin-RPC transport. This
+> revision splits the design accordingly and states the one governing rule up front.
+> (The alarming security/audit claims did **not** survive verification — content-free
+> audit is structurally enforced on the separate audit host; scope-by-daemon is
+> real. See "What the review corrected.")
 
-An **adapter into the event bus that runs MCP plugins.** An MCP plugin (an external
-MCP server — GitHub, filesystem, a company tool server) is run by an adapter that
-is a participant on the event bus: a plugin tool-call travels the bus as a
-**request event**, the adapter serves it against the plugin's live MCP session and
-publishes the **reply event**, and the **thin-client advertises those plugin tools
-over MCP/CLI exactly as it advertises modules today**. The adapter is an *optional
-module* either trusted daemon can install, and the install target sets the scope:
+## Governing rule
 
-- **Installed in aimee-server** — the adapter runs on the server's bus, so its
-  MCP-plugin tools are exposed only to **that server's sessions**.
-- **Installed in aimee-kb** — the adapter runs on the kb's bus, so its tools are
-  exposed to **everything hooked up to that kb**: every aimee-server and every thin
-  client on that kb sees the same shared plugin surface, backed by one set of
-  plugin connections the kb owns.
+**The event bus is an intra-daemon mechanism. Every server↔kb hop is `kb_client`
+HTTP/mTLS.** The bus earns its keep *inside* one daemon; the "shared to the whole
+deployment" value of a kb-hosted plugin comes from HTTP federation + HTTP
+invocation, with the kb-local bus as at most the last in-kb hop.
 
-This is the "MCP interface for MCP plugins over the event bus" that opened this
-work, now buildable because the substrate exists: the bus carries correlated
-request/reply (host routing), large tool arguments/results ride the arena
-(payload-by-reference), and every call is audited content-free (the tool-call
-outcome audit). The MCP-plugin adapter is the **first real producer** of the arena
-payload path.
+## The requirement (unchanged)
 
-## Why the bus is the right substrate here
+Make the MCP-plugin adapter (`modules/protocols/mcp`) an **optional module either
+`aimee-server` or `aimee-kb` can install**, the install target deciding scope:
 
-A plugin tool-call is a natural bus request/reply, and routing it over the bus buys
-exactly the properties an in-process plugin loader could not give:
+- **Server-install** — the plugin's tools are exposed only to **that server's
+  sessions** (this is essentially today's behavior, made optional + explicit).
+- **KB-install** — the plugin's tools are exposed to **everything hooked up to that
+  kb**: every server and thin client on that kb sees one shared plugin surface,
+  backed by connections the kb owns.
 
-- **Scope by construction.** The bus a call rides *is* its blast radius. Put the
-  adapter on the server bus and its tools are that server's; put it on the kb bus
-  and they are the whole deployment's. Exposure is not a separate ACL layer — it is
-  which bus the adapter subscribed to.
-- **Isolation + backpressure.** The plugin's connection lives behind the adapter,
-  not in every caller. A slow or dead plugin is BLOCK/SHED-managed by the host,
-  never a caller hang; a plugin crash never takes a session with it.
-- **Large payloads, safely.** MCP arguments and results routinely exceed the inline
-  budget (file contents, diffs, tool output). They ride the arena by reference — no
-  copy through the host, refcounted, generation-gated — which is what the arena work
-  was for.
-- **Audited for free.** The request and reply are governed bus events, so the
-  tool-call outcome audit records identity + outcome (content-free) on whichever
-  daemon's bus the adapter runs — server-installed audits on the server, kb-installed
-  on the kb, mirroring the memory-kb bridge.
+The thin-client advertises the plugin tools over MCP/CLI the same way it advertises
+modules today.
 
-(This does not turn the bus into a general RPC fabric: it carries *governed
-tool-calls as events*, the same shape as every other bus event, not arbitrary
-transport.)
+## Core design (Phase 1 — buildable now, no new bus infra)
 
-## Decision
+### Install target (config)
 
-Make `modules/protocols/mcp` (plus a thin bus-adapter layer) an optional module
-both binaries may link and boot, driven by an **install target** in config, with a
-bus request/reply contract for plugin calls and thin-client advertisement of the
-resulting tools.
+`config_mcp_client_t` (`config.h`) gains `install: server | kb` (default `server`).
+Each daemon boots `mcp_client_registry` for its own clients only, so a plugin is
+owned by exactly one daemon.
 
-### 1. Install target (config)
+### Server-install — direct, in-process
 
-`config_mcp_client_t` (`config.h`) gains an `install: server | kb` field
-(default `server`, so nothing changes without opt-in). Each daemon boots the
-adapter for **its own** clients only, so a plugin is owned by exactly one host and
-a tool name resolves unambiguously.
+The dispatcher and the registry are co-located, so a server-hosted plugin call is
+the **direct in-process `mcp_client_registry_call_tool`** it is today; its tools
+merge into the session `tools/list` via `mcp_client_registry_build_namespaced_tools`
+(no bus). Crash isolation comes from the plugin **subprocess** boundary, not the
+bus. Nothing new is required here beyond honoring the install target.
 
-### 2. The adapter as a bus participant
+### KB-install — the kb owns the plugins, servers call over HTTP
 
-Per hosting daemon, the adapter:
-- opens/owns the MCP plugin sessions (stdio/sse), as `mcp_client_registry` does now;
-- **subscribes** to a plugin-tool-call request kind on that daemon's bus and, on a
-  request, runs `tools/call` against the plugin session and publishes the reply
-  (result inline, or arena for a large payload); errors/timeouts become typed reply
-  outcomes, never a caller hang;
-- a caller (a session's tool dispatch) that targets a plugin tool **publishes the
-  request** to that bus and awaits the correlated reply. A server-hosted plugin's
-  request/reply stays on the server bus; a kb-hosted plugin's rides the kb bus
-  (reached from a server over the existing kb_client transport).
+- **Invocation:** a session that targets a kb-hosted `plugin:tool` reaches it over a
+  **new `kb_client` HTTP action** (e.g. `POST /v1/mcp/call`), mirroring how the
+  server already calls the kb for memory. The kb's handler runs `tools/call` against
+  its live plugin session and returns JSON. Args/results copy across the HTTP body.
+  The endpoint carries its own timeout / backpressure / auth (same mTLS bearer path
+  as other kb actions).
+- **Advertisement:** the kb-hosted tool **definitions** reach a server through an
+  **extended tool-registry snapshot RPC**. (Today's `kb_client_tool_registry_snapshot_json`
+  carries *prompt* strings, not tool defs, and feeds the system prompt — it does
+  **not** feed `tools/list`; this is new work, not existing federation.) The
+  extension carries `name / description / inputSchema / side_effect`, and a new
+  server-side merge folds them into `mcp_build_tools_list` alongside local plugin +
+  native tools.
+- **Collision handling** happens at that **runtime catalog merge** (not at boot — the
+  two daemons are independent processes and neither sees the other's config), with
+  an explicit precedence rule + diagnostic. The namespaced-name grammar and buffer
+  bounds (`client[64]:tool[128]` vs `qualified[160]`) are defined so nothing
+  truncates.
 
-The correlated-arena routing already delivers request→server and reply→requester by
-reference with correct refcounting; this is its first non-test consumer.
+### Audit (reuses the tool-call outcome audit)
 
-### 3. Thin-client advertisement (as for modules)
+A server-install call audits its outcome on the **server's** obs_bus; a kb-install
+call runs at the kb and records its outcome on the **kb's** obs_bus — the same
+NULL-default completion hook + server-only bridge, installed in `kb_main.c`,
+mirroring the memory-kb bridge. Content-free either way (fingerprint + enums). This
+is the event bus's genuine role in this feature, and it is why this lands *after*
+the tool-call outcome audit PR.
 
-The plugin tools must surface to a thin client the same way module tools do today:
-the tool catalog the CLI serves over MCP (`cli_mcp_serve.c` forwarding `tools/list`,
-and the CLI's own tool listing) includes the adapter's namespaced plugin tools
-(`plugin:tool`) alongside module and native tools. A kb-hosted plugin's tools reach
-a server's catalog through the existing kb→server tool-registry federation
-(`kb_client_tool_registry_snapshot_json`); a server-hosted plugin's are local. Either
-way the thin client advertises them with no new advertisement mechanism — it is the
-same `tools/list` surface, one more source feeding it.
+## Phase 2 (optional, later) — intra-daemon bus routing of plugin calls
 
-### 4. Audit follows the install target
+Routing a plugin call over a daemon's *own* bus (correlated request/reply, large
+args/results by arena reference) buys isolation + backpressure + payload-by-
+reference **within one daemon**. It is deliberately **opt-in and deferred**, because
+it is not free and is not required for the feature above:
 
-Composes with the tool-call outcome audit: a server-installed plugin call is
-dispatched and audited on the **server's** obs_bus (mode `outbound:stdio|sse`); a
-kb-installed call runs at the kb and records its outcome on the **kb's** obs_bus
-(the same NULL-default completion hook + server-only bridge, installed in
-`kb_main.c`, mirroring the memory-kb bridge). Content-free either way — fingerprint
-+ enums, never the plugin's arguments or results, even when those ride the arena.
-This reuse of the completion hook + bridge on the kb side is why this lands *after*
-that audit PR.
+- It needs a **general per-daemon bus host** — one does not exist; obs_bus's host is
+  a private, 4-slot, notification-only audit singleton. Standing up a
+  general-purpose host (slot budget, kind registration, attach model, pump/heartbeat
+  owner, coexistence with the audit host) is first-class new infrastructure.
+- It needs the **client-visible arena request/reply surface** — `bus_client` today
+  exposes only one-way `bus_client_publish_arena`, and arena allocation is
+  host-private/co-located (D3). Either that surface is built, or the caller+adapter
+  must be co-located and use the in-process host-arena API. Arena payload-by-
+  reference is **intra-daemon only** — it never helps the server↔kb hop.
+- It is a **governed D7 blast-radius amendment**: a bus participant in
+  `modules/protocols/mcp` must include a bus header, which `check_bus_blast_radius.sh`
+  (a hard allowlist) *fails* by design. Widening the allowlist is a roundtable-
+  governed D7 revision that explicitly re-states the widened blast radius (external
+  stdio/sse/JSON I/O now co-resident with the arena) — **not** a check that "stays
+  green."
+- The correlated request/reply + arena routing (built, wired, TSAN/conformance-
+  tested) has **zero shipping consumers**; this would be its first production driver,
+  so its full refcount / timeout / crash lifecycle must be integration-tested before
+  anything depends on it, and bus routing stays opt-in per client with the direct
+  call as the default fallback + observable parity.
 
 ## Non-goals
 
-- **No new external egress surface.** The kb already makes operator-configured
-  outbound connections (embedder, forge); a kb-hosted MCP plugin is another, gated
-  by the same config trust boundary. It does not expose the kb's own API to the
-  plugin.
-- **No per-session / per-tenant plugins.** Install scope is deployment config
-  (server or kb), not a dynamic per-principal surface.
-- **No general-purpose RPC over the bus.** The bus carries governed tool-calls as
-  events, not arbitrary transport; a plugin call is the same event shape as the
-  rest of the arc.
-- **No revival of the removed in-process plugin loader.** MCP *is* the plugin
-  interface; the bus adapter is how a plugin runs and is scoped. Nothing is
-  dynamically `dlopen`'d.
-- **D7 unchanged.** The bus stays confined to the two trusted daemons; a kb-hosted
-  plugin audits on the kb's bus, never a thin client.
+- No new external egress model beyond the operator-configured outbound the kb
+  already makes (embedder, forge); a kb-hosted plugin is another such outbound.
+- No per-session / per-tenant plugins; install scope is deployment config.
+- No revival of the removed in-process `dlopen` plugin loader — MCP *is* the plugin
+  interface.
+- **D7 unchanged in Phase 1** (the bus stays audit-only, confined to the two trusted
+  daemons); Phase 2 explicitly amends it.
 
 ## Binding checks
 
 - A kb-installed plugin's tool appears in a connected server's `tools/list` (via the
-  registry federation) and in the thin client's advertised catalog; a
+  extended snapshot RPC + merge) and in the thin client's advertised catalog; a
   server-installed plugin's tool is absent from a *different* server — proving scope.
-- A plugin call round-trips as a bus request/reply, with a large argument/result
-  carried by arena reference (refcount drains to zero); the completion row lands on
-  the **hosting daemon's** ledger (server vs kb), content-free.
-- A slow/dead plugin BLOCK/SHED-resolves at the host without hanging the caller,
-  and a plugin crash does not fault a session.
-- A name collision between a `server` and a `kb` plugin is refused at boot.
-- `check_bus_blast_radius.sh` stays green with the adapter linked into kb.
+- A kb-hosted `plugin:tool` call round-trips over `POST /v1/mcp/call` and returns the
+  same result as a direct call; its completion row lands on the **kb** ledger,
+  content-free; a server-installed call's row lands on the **server** ledger.
+- A local↔kb tool-name collision is resolved at the runtime merge by the stated
+  precedence, with a diagnostic — not silently first-wins.
+- Phase 1 keeps `check_bus_blast_radius.sh` green (no bus header in the adapter).
+  Phase 2, if pursued, ships the D7 amendment + updated gate.
 
-## Rollout
+## What the review corrected (for the record)
 
-1. `install` config field + validation (default `server`; today's behavior).
-2. The bus request/reply contract for a plugin call (kind + correlated reply +
-   arena for large payloads), served by the adapter; caller-side publish/await in
-   the dispatcher's `plugin:tool` branch.
-3. Boot the adapter conditionally in `kb_main.c`; federate its tool catalog to
-   servers and the thin-client `tools/list`.
-4. Install the completion-audit bridge in kb for the kb-hosted call outcome.
-5. Multi-agent convergence review (scope boundary, the request/reply + arena
-   refcount lifecycle, the audit split), then merge.
+- **The bus is not a cross-daemon transport.** Rewrote every "server publishes onto
+  the kb's bus" to the real path: `kb_client` HTTP to a new `/v1/mcp/call`, kb-local
+  bus at most the last hop.
+- **No general bus host exists** — Phase 2 makes it an explicit prerequisite.
+- **The tool federation carries prompts, not tool defs** — the snapshot RPC
+  extension is new work, not existing federation.
+- **`check_bus_blast_radius.sh` cannot "stay green"** with a bus participant in the
+  adapter — that is a governed D7 amendment (Phase 2).
+- **Name collisions can't be caught at boot** across two processes — moved to the
+  runtime catalog merge.
+- **Kept (verified):** content-free audit is structural (separate audit host, hash-
+  only emit); scope-by-daemon is real; the arena/correlated routing is implemented
+  and this would be its first production consumer.

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -153,12 +153,32 @@ plugin (a python echo server), exercised over the live `/v1/actions/*` channel:
   — the handler dispatched to the registry, which round-tripped to the real plugin
   subprocess. This is the exact endpoint `kb_client_mcp_call` wraps.
 
-**Not yet exercised through a live server session** (honest gap): the server-side
-consumption — `append_federated_kb_tools` merging the snapshot into `tools/list`
-and dispatch routing a call to `kb_client_mcp_call` — is code-reviewed and rests on
-the two endpoints verified above, but a full server↔kb agent-turn e2e (needs mTLS
-enrollment + a model backend) has not been run. Also pending: the kb-side outcome
-**audit** row (reuses the #1955 completion hook/bridge once merged).
+**Server side — verified end to end** (added 2026-07-25): against the same live
+kb, the real server functions run through their paths via two gated integration
+cases in `unit-test-mcp-native-dispatch` (`AIMEE_KB_API_URL` set):
+- **Advertise:** `build_tools_array()` (the LLM-facing tool array) contains
+  `echo:echo` — `append_federated_kb_tools` fetched the kb snapshot and merged the
+  federated def. PASS.
+- **Dispatch:** `dispatch_tool_call("echo:echo", {"text":"kb-routed"})` returned
+  `{"content":[{"type":"text","text":"echo: kb-routed"}]}` — the server resolved
+  the client as non-local and routed to `kb_client_mcp_call` → kb → plugin. PASS.
+- **Scope isolation:** with a config declaring `echo` (install:kb) + `locecho`
+  (install:server), the kb's federated `mcp_tools` is exactly `["echo:echo"]` — the
+  server-installed plugin is never federated; only the install:kb plugin runs on
+  the kb. Matches `test_install_target_filtering`.
+- **Regression:** the full `make unit-tests` suite passes on the CT (real
+  Postgres), SUITE_EXIT=0.
+
+Remaining: the kb-side outcome **audit** row (reuses the #1955 completion
+hook/bridge once merged), and a true agent-turn through a live model backend (the
+LLM-facing array + dispatch are both verified above, so this is the LLM emitting
+the call rather than the harness).
+
+> Harness note: mcp_client config command lists must use **block-style** YAML
+> (`command:\n  - python3\n  - script.py`); the flow-style inline form
+> (`command: [python3, script.py]`) is not parsed into an array by the config
+> reader, so the client is silently skipped. Worth a follow-up hardening in the
+> YAML/flow-list parsing, independent of this feature.
 
 ## What the review corrected (for the record)
 

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -1,135 +1,144 @@
-# Proposal: MCP adapter as an optional module — install into aimee-server or aimee-kb
+# Proposal: an event-bus MCP-plugin adapter — optional, install into aimee-server or aimee-kb
 
-## Context
+## The idea
 
-The MCP client adapter (`modules/protocols/mcp/`) connects out to external MCP
-servers and exposes their tools to aimee as namespaced `server:tool` names. Today
-it is **server-only**: `mcp_client_registry_boot()` is called once from
-`server_main.c:291`, the sessions belong to that one aimee-server process, and the
-tools are merged into that server's per-session tool list
-(`agent_tools.c` → `mcp_client_registry_build_namespaced_tools`). `aimee-kb` boots
-no MCP registry and exposes no external MCP tools.
+An **adapter into the event bus that runs MCP plugins.** An MCP plugin (an external
+MCP server — GitHub, filesystem, a company tool server) is run by an adapter that
+is a participant on the event bus: a plugin tool-call travels the bus as a
+**request event**, the adapter serves it against the plugin's live MCP session and
+publishes the **reply event**, and the **thin-client advertises those plugin tools
+over MCP/CLI exactly as it advertises modules today**. The adapter is an *optional
+module* either trusted daemon can install, and the install target sets the scope:
 
-Two facts make a different topology cheap:
+- **Installed in aimee-server** — the adapter runs on the server's bus, so its
+  MCP-plugin tools are exposed only to **that server's sessions**.
+- **Installed in aimee-kb** — the adapter runs on the kb's bus, so its tools are
+  exposed to **everything hooked up to that kb**: every aimee-server and every thin
+  client on that kb sees the same shared plugin surface, backed by one set of
+  plugin connections the kb owns.
 
-1. The adapter is already a self-contained module with a clean boot/shutdown/
-   call/list surface (`mcp_client_registry.h`) — nothing about it is intrinsically
-   server-bound.
-2. A **kb → server tool-registry federation already exists**:
-   `kb_client_tool_registry_snapshot_json()` / `kb_client_tool_registry_lookup()`
-   let a server pull a tool surface *from* its kb. That is precisely the channel a
-   kb-hosted MCP surface would ride.
+This is the "MCP interface for MCP plugins over the event bus" that opened this
+work, now buildable because the substrate exists: the bus carries correlated
+request/reply (host routing), large tool arguments/results ride the arena
+(payload-by-reference), and every call is audited content-free (the tool-call
+outcome audit). The MCP-plugin adapter is the **first real producer** of the arena
+payload path.
 
-## The requirement
+## Why the bus is the right substrate here
 
-Make the MCP adapter an **optional module that either aimee-server or aimee-kb can
-install**, with the install target deciding the exposure scope:
+A plugin tool-call is a natural bus request/reply, and routing it over the bus buys
+exactly the properties an in-process plugin loader could not give:
 
-- **Installed in aimee-server** — the external MCP tools are exposed **only to the
-  sessions of that aimee-server** (today's behavior).
-- **Installed in aimee-kb** — the external MCP tools are exposed to **everything
-  hooked up to that aimee-kb**: every aimee-server (and every thin client) that
-  connects to the kb sees the same shared MCP tool surface, backed by one set of
-  connections the kb owns.
+- **Scope by construction.** The bus a call rides *is* its blast radius. Put the
+  adapter on the server bus and its tools are that server's; put it on the kb bus
+  and they are the whole deployment's. Exposure is not a separate ACL layer — it is
+  which bus the adapter subscribed to.
+- **Isolation + backpressure.** The plugin's connection lives behind the adapter,
+  not in every caller. A slow or dead plugin is BLOCK/SHED-managed by the host,
+  never a caller hang; a plugin crash never takes a session with it.
+- **Large payloads, safely.** MCP arguments and results routinely exceed the inline
+  budget (file contents, diffs, tool output). They ride the arena by reference — no
+  copy through the host, refcounted, generation-gated — which is what the arena work
+  was for.
+- **Audited for free.** The request and reply are governed bus events, so the
+  tool-call outcome audit records identity + outcome (content-free) on whichever
+  daemon's bus the adapter runs — server-installed audits on the server, kb-installed
+  on the kb, mirroring the memory-kb bridge.
 
-The kb case is the valuable new one: a single operator-configured MCP server (a
-GitHub server, a filesystem server, a company-internal tool server) becomes a
-shared capability of the whole deployment, configured and connected once, rather
-than re-declared and re-connected in every aimee-server.
+(This does not turn the bus into a general RPC fabric: it carries *governed
+tool-calls as events*, the same shape as every other bus event, not arbitrary
+transport.)
 
 ## Decision
 
-Make `modules/protocols/mcp` a module both binaries may link and boot, gated by an
-**install target** in config; add a kb-side tool surface + a forwarding call path
-so a kb-hosted MCP tool executes **at the kb** (one shared connection) while being
-*callable from* any server.
+Make `modules/protocols/mcp` (plus a thin bus-adapter layer) an optional module
+both binaries may link and boot, driven by an **install target** in config, with a
+bus request/reply contract for plugin calls and thin-client advertisement of the
+resulting tools.
 
-### Install target (config)
+### 1. Install target (config)
 
-Add an install scope to the MCP client config — the simplest form is a per-client
-`install: server | kb` (default `server`, preserving today's behavior), or a
-single top-level `mcp.install` when the whole set moves together. `config_mcp_client_t`
-(`config.h`) gains the field; both `server_main.c` and `kb_main.c` read their own
-subset.
+`config_mcp_client_t` (`config.h`) gains an `install: server | kb` field
+(default `server`, so nothing changes without opt-in). Each daemon boots the
+adapter for **its own** clients only, so a plugin is owned by exactly one host and
+a tool name resolves unambiguously.
 
-- aimee-server boots `mcp_client_registry` for its `install: server` clients only.
-- aimee-kb boots `mcp_client_registry` for its `install: kb` clients only.
+### 2. The adapter as a bus participant
 
-A client is served by exactly one host — never both — so a tool name resolves
-unambiguously.
+Per hosting daemon, the adapter:
+- opens/owns the MCP plugin sessions (stdio/sse), as `mcp_client_registry` does now;
+- **subscribes** to a plugin-tool-call request kind on that daemon's bus and, on a
+  request, runs `tools/call` against the plugin session and publishes the reply
+  (result inline, or arena for a large payload); errors/timeouts become typed reply
+  outcomes, never a caller hang;
+- a caller (a session's tool dispatch) that targets a plugin tool **publishes the
+  request** to that bus and awaits the correlated reply. A server-hosted plugin's
+  request/reply stays on the server bus; a kb-hosted plugin's rides the kb bus
+  (reached from a server over the existing kb_client transport).
 
-### Where a kb-installed tool executes (the crux)
+The correlated-arena routing already delivers request→server and reply→requester by
+reference with correct refcounting; this is its first non-test consumer.
 
-"Shared to everything on the kb" means the external connection is **owned by the
-kb**, not re-opened per server. So a kb-installed tool call must run at the kb:
+### 3. Thin-client advertisement (as for modules)
 
-- **Tool surface federation.** The kb publishes its namespaced MCP tools through
-  the existing tool-registry snapshot (`kb_client_tool_registry_snapshot_json`);
-  each connected server merges them into its session tool list alongside its own
-  `install: server` MCP tools and native tools. Namespacing (`server:tool`) keeps
-  the two sources collision-free; a name collision between a server-local and a
-  kb-shared client is a config error, surfaced at boot.
-- **Forwarding dispatch.** When a session calls a kb-hosted tool, the server's
-  dispatcher (the `strchr(name,':')` branch in `agent_tools_dispatch.c`) resolves
-  the name to a *kb-hosted* client and forwards the call over `kb_client` to a new
-  kb method (`kb.mcp.call` / `mcp_client_registry_call_tool` on the kb side),
-  rather than calling `mcp_client_registry_call_tool` locally. The kb runs the
-  actual `tools/call` on its shared session and returns the result.
-- A server-installed tool keeps executing locally, exactly as today.
+The plugin tools must surface to a thin client the same way module tools do today:
+the tool catalog the CLI serves over MCP (`cli_mcp_serve.c` forwarding `tools/list`,
+and the CLI's own tool listing) includes the adapter's namespaced plugin tools
+(`plugin:tool`) alongside module and native tools. A kb-hosted plugin's tools reach
+a server's catalog through the existing kb→server tool-registry federation
+(`kb_client_tool_registry_snapshot_json`); a server-hosted plugin's are local. Either
+way the thin client advertises them with no new advertisement mechanism — it is the
+same `tools/list` surface, one more source feeding it.
 
-### Audit follows the install target (composes with #1955)
+### 4. Audit follows the install target
 
-The tool-call outcome audit (#1955) and the governed-action identity audit are
-per-process on `obs_bus`. This proposal keeps that invariant:
-
-- A **server-installed** MCP call is dispatched and audited on the **server's**
-  `obs_bus` (mode `outbound:stdio|sse`), exactly as it is now.
-- A **kb-installed** MCP call executes at the kb, so the kb records the outbound
-  completion on the **kb's** `obs_bus` (the same NULL-default hook + server-only
-  bridge pattern, installed in `kb_main.c` — mirroring the memory-kb bridge). The
-  forwarding server still records that the *session* invoked a remote tool
-  (identity), and the kb records the *execution outcome*. No content crosses in
-  either row (fingerprint + enums only, per #1955).
-
-This means the completion-audit bridge and its hook become linkable into kb as
-well — which is why this proposal lands *after* #1955, not inside it.
+Composes with the tool-call outcome audit: a server-installed plugin call is
+dispatched and audited on the **server's** obs_bus (mode `outbound:stdio|sse`); a
+kb-installed call runs at the kb and records its outcome on the **kb's** obs_bus
+(the same NULL-default completion hook + server-only bridge, installed in
+`kb_main.c`, mirroring the memory-kb bridge). Content-free either way — fingerprint
++ enums, never the plugin's arguments or results, even when those ride the arena.
+This reuse of the completion hook + bridge on the kb side is why this lands *after*
+that audit PR.
 
 ## Non-goals
 
-- **No new external egress surface.** The kb already makes outbound connections
-  (embedder, forge); a kb-hosted MCP client is another operator-configured
-  outbound, gated by the same config trust boundary. It does not expose the kb's
-  own API to the MCP server.
-- **No per-session MCP servers.** Install scope is deployment config (server or
-  kb), not a per-session or per-principal dynamic — dynamic/tenant-scoped MCP is a
-  separate concern.
-- **Not a change to the MCP wire or the tool schema.** Tools stay namespaced
-  `server:tool`; only *where the registry lives and who sees it* changes.
-- **D7 unchanged.** The bus stays confined to the two trusted daemons; a
-  kb-hosted MCP client audits on the kb's bus, still never a thin client.
+- **No new external egress surface.** The kb already makes operator-configured
+  outbound connections (embedder, forge); a kb-hosted MCP plugin is another, gated
+  by the same config trust boundary. It does not expose the kb's own API to the
+  plugin.
+- **No per-session / per-tenant plugins.** Install scope is deployment config
+  (server or kb), not a dynamic per-principal surface.
+- **No general-purpose RPC over the bus.** The bus carries governed tool-calls as
+  events, not arbitrary transport; a plugin call is the same event shape as the
+  rest of the arc.
+- **No revival of the removed in-process plugin loader.** MCP *is* the plugin
+  interface; the bus adapter is how a plugin runs and is scoped. Nothing is
+  dynamically `dlopen`'d.
+- **D7 unchanged.** The bus stays confined to the two trusted daemons; a kb-hosted
+  plugin audits on the kb's bus, never a thin client.
 
 ## Binding checks
 
-- A kb-installed client's tool appears in a connected server's session tool list
-  (via the registry snapshot) and is absent when installed server-side on a
-  *different* server — proving the scope boundary.
-- A forwarded kb-hosted tool call returns the same result as a direct one, and its
-  **completion row lands on the KB ledger** (mode `outbound:*`), while a
-  server-installed call's row lands on the **server ledger** — proving audit
-  follows the install target, still content-free.
-- A name collision between a `server` and a `kb` client is refused at boot, not
-  silently shadowed.
-- `check_bus_blast_radius.sh` stays green with the MCP registry linked into kb.
+- A kb-installed plugin's tool appears in a connected server's `tools/list` (via the
+  registry federation) and in the thin client's advertised catalog; a
+  server-installed plugin's tool is absent from a *different* server — proving scope.
+- A plugin call round-trips as a bus request/reply, with a large argument/result
+  carried by arena reference (refcount drains to zero); the completion row lands on
+  the **hosting daemon's** ledger (server vs kb), content-free.
+- A slow/dead plugin BLOCK/SHED-resolves at the host without hanging the caller,
+  and a plugin crash does not fault a session.
+- A name collision between a `server` and a `kb` plugin is refused at boot.
+- `check_bus_blast_radius.sh` stays green with the adapter linked into kb.
 
 ## Rollout
 
-1. Add the `install` config field + validation; keep default `server` so nothing
-   changes without opt-in.
-2. Boot the registry conditionally in `kb_main.c`; publish its tools through the
-   kb tool-registry snapshot.
-3. Add the `kb.mcp.call` forwarding method + the server-side dispatcher routing to
-   it for kb-hosted names.
-4. Install the completion-audit bridge in kb (the hook/TU from #1955 already link
-   cleanly); wire the outbound-completion emit at the kb call site.
-5. Multi-agent convergence review (scope boundary + the forwarding/audit split),
-   then merge.
+1. `install` config field + validation (default `server`; today's behavior).
+2. The bus request/reply contract for a plugin call (kind + correlated reply +
+   arena for large payloads), served by the adapter; caller-side publish/await in
+   the dispatcher's `plugin:tool` branch.
+3. Boot the adapter conditionally in `kb_main.c`; federate its tool catalog to
+   servers and the thin-client `tools/list`.
+4. Install the completion-audit bridge in kb for the kb-hosted call outcome.
+5. Multi-agent convergence review (scope boundary, the request/reply + arena
+   refcount lifecycle, the audit split), then merge.

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -134,6 +134,25 @@ it is not free and is not required for the feature above:
 - Phase 1 keeps `check_bus_blast_radius.sh` green (no bus header in the adapter).
   Phase 2, if pursued, ships the D7 amendment + updated gate.
 
+## Failure-mode & precedence e2e (observed 2026-07-25, CT 132 @ .253)
+
+Against a live kb hosting a multi-tool plugin (ok / error / slow tools):
+- **Error path:** a plugin that returns a JSON-RPC error → kb reply is an error and
+  the audit row is `verdict:"error", reason_code:"tool_error"`.
+- **Timeout path:** a tool that sleeps 3s called with `timeout_ms:1000` → the kb
+  aborts and records `verdict:"error", reason_code:"tool_error"` (the clamp/timeout
+  is enforced, not ignored).
+- **Concurrency:** 12 parallel `mcp.call`s to one stdio plugin all succeed
+  (`verdict:"ok"`) and each is audited — the per-client stdio pipe is serialized
+  safely.
+- **Local precedence (collision), LIVE:** with the SAME tool name `echo` hosted on
+  BOTH the server (install:server → a "LOCAL-echo" plugin) and the kb (install:kb),
+  a real model turn calling `echo:echo` returned `LOCAL-echo: LIVE-TURN` and the kb
+  logged ZERO `mcp.call`s — the server's local plugin wins and the kb is never
+  contacted. This also exercises the install:server invocation (local dispatch
+  branch) end to end. The selection primitive (`mcp_client_registry_get`) is
+  additionally unit-tested for hosted/not-hosted both ways.
+
 ## Phase 1 verification (observed 2026-07-25, CT 132 @ .253)
 
 Real `aimee-kb` daemon (fresh DB2, dim pinned) hosting an `install: kb` stdio MCP

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -52,12 +52,15 @@ bus. Nothing new is required here beyond honoring the install target.
 
 ### KB-install — the kb owns the plugins, servers call over HTTP
 
-- **Invocation:** a session that targets a kb-hosted `plugin:tool` reaches it over a
-  **new `kb_client` HTTP action** (e.g. `POST /v1/mcp/call`), mirroring how the
-  server already calls the kb for memory. The kb's handler runs `tools/call` against
-  its live plugin session and returns JSON. Args/results copy across the HTTP body.
-  The endpoint carries its own timeout / backpressure / auth (same mTLS bearer path
-  as other kb actions).
+- **Invocation:** a session that targets a kb-hosted `plugin:tool` reaches it over the
+  **existing mTLS action-RPC family** — a new `mcp.call` method on `POST
+  /v1/actions/<method>`, dispatched by the same kb service table as
+  `tool_registry.snapshot`/`lookup`. (The design review found this cleaner than a
+  bespoke `/v1/mcp/call` REST endpoint: it reuses the action channel's auth, framing,
+  and timeout — strictly less new surface, same security envelope as every other kb
+  RPC.) `kb_client_mcp_call` builds `{name, arguments?, timeout_ms?}`; the kb handler
+  runs `tools/call` against its live plugin session (timeout clamped ≤120s) and
+  returns `{status:"ok", result}`. Args/results copy across the request/response body.
 - **Advertisement:** the kb-hosted tool **definitions** reach a server through an
   **extended tool-registry snapshot RPC**. (Today's `kb_client_tool_registry_snapshot_json`
   carries *prompt* strings, not tool defs, and feeds the system prompt — it does
@@ -123,7 +126,7 @@ it is not free and is not required for the feature above:
 - A kb-installed plugin's tool appears in a connected server's `tools/list` (via the
   extended snapshot RPC + merge) and in the thin client's advertised catalog; a
   server-installed plugin's tool is absent from a *different* server — proving scope.
-- A kb-hosted `plugin:tool` call round-trips over `POST /v1/mcp/call` and returns the
+- A kb-hosted `plugin:tool` call round-trips over the `mcp.call` action and returns the
   same result as a direct call; its completion row lands on the **kb** ledger,
   content-free; a server-installed call's row lands on the **server** ledger.
 - A local↔kb tool-name collision is resolved at the runtime merge by the stated
@@ -134,8 +137,12 @@ it is not free and is not required for the feature above:
 ## What the review corrected (for the record)
 
 - **The bus is not a cross-daemon transport.** Rewrote every "server publishes onto
-  the kb's bus" to the real path: `kb_client` HTTP to a new `/v1/mcp/call`, kb-local
-  bus at most the last hop.
+  the kb's bus" to the real path: `kb_client` mTLS to a new `mcp.call` action method,
+  kb-local bus at most the last hop.
+- **No bespoke REST endpoint.** Implementation review of the seams showed invocation
+  belongs in the existing `/v1/actions/<method>` RPC family (an `mcp.call` method),
+  not a hand-rolled `/v1/mcp/call` — reusing the action channel's auth/framing/timeout
+  rather than duplicating them.
 - **No general bus host exists** — Phase 2 makes it an explicit prerequisite.
 - **The tool federation carries prompts, not tool defs** — the snapshot RPC
   extension is new work, not existing federation.

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -181,14 +181,24 @@ Only a name-only fingerprint + classified enums cross (no argument/result conten
 The caller's dispatch role is threaded over the mcp.call request as the audit actor
 (default `"mcp"`). Blast-radius gate: all six C shipping binaries inspect clean.
 
-**Live-model agent turn — not separately run, by analysis** rather than omission:
-a chat turn exercises the server's GENERIC loop (send `build_tools_array` to the
-model → dispatch the model's `tool_calls`), which this feature does not modify and
-which is already covered for every tool. The feature's two touchpoints in that path
-are both verified above — the federated tool is in `build_tools_array` (what the
-model receives) and `dispatch_tool_call` routes it to the kb (what runs when the
-model calls it) — so a live turn would test unchanged orchestration, not new code.
-The model emitting the call is the model's behavior, not aimee's.
+**Live-model agent turn — run and verified** (added 2026-07-25): a real agent turn
+was driven through `aimee-server`'s agentic loop against a stub OpenAI-compatible
+model (aimed at via the `openai` provider's configurable `openai_endpoint`, no key
+needed). The stub emitted an `echo:echo` tool_call; the full loop closed:
+- delegate job → `status: done, turns: 1`, model final answer
+  `TOOL_RESULT_SEEN: {"content":[{"type":"text","text":"echo: LIVE-TURN"}]}` — the
+  string is the KB-hosted plugin's own output, so the model's call reached the kb.
+- the kb logged `POST /v1/actions/mcp.call status=200` for that turn.
+- the kb audit ledger recorded the model-driven call end to end: a server-side
+  authorization row `{"actor":"delegate","tool":"echo:echo","verdict":"allow"}` and
+  the kb-side outcome row `{"actor":"mcp","tool":"echo:echo","mode":"outbound","verdict":"ok"}`.
+
+So the complete chain is exercised by a real model: model emits `echo:echo` →
+server authorizes + dispatches → kb executes the plugin → kb audits the outcome →
+result returns to the model. (In this delegate harness the tool array the stub
+received was empty — a delegate role-toolset filtering artifact, orthogonal to the
+adapter; the federation of `echo:echo` into `build_tools_array` is separately
+verified by the integration test above.)
 
 > Harness note: mcp_client config command lists must use **block-style** YAML
 > (`command:\n  - python3\n  - script.py`); the flow-style inline form

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -1,0 +1,135 @@
+# Proposal: MCP adapter as an optional module — install into aimee-server or aimee-kb
+
+## Context
+
+The MCP client adapter (`modules/protocols/mcp/`) connects out to external MCP
+servers and exposes their tools to aimee as namespaced `server:tool` names. Today
+it is **server-only**: `mcp_client_registry_boot()` is called once from
+`server_main.c:291`, the sessions belong to that one aimee-server process, and the
+tools are merged into that server's per-session tool list
+(`agent_tools.c` → `mcp_client_registry_build_namespaced_tools`). `aimee-kb` boots
+no MCP registry and exposes no external MCP tools.
+
+Two facts make a different topology cheap:
+
+1. The adapter is already a self-contained module with a clean boot/shutdown/
+   call/list surface (`mcp_client_registry.h`) — nothing about it is intrinsically
+   server-bound.
+2. A **kb → server tool-registry federation already exists**:
+   `kb_client_tool_registry_snapshot_json()` / `kb_client_tool_registry_lookup()`
+   let a server pull a tool surface *from* its kb. That is precisely the channel a
+   kb-hosted MCP surface would ride.
+
+## The requirement
+
+Make the MCP adapter an **optional module that either aimee-server or aimee-kb can
+install**, with the install target deciding the exposure scope:
+
+- **Installed in aimee-server** — the external MCP tools are exposed **only to the
+  sessions of that aimee-server** (today's behavior).
+- **Installed in aimee-kb** — the external MCP tools are exposed to **everything
+  hooked up to that aimee-kb**: every aimee-server (and every thin client) that
+  connects to the kb sees the same shared MCP tool surface, backed by one set of
+  connections the kb owns.
+
+The kb case is the valuable new one: a single operator-configured MCP server (a
+GitHub server, a filesystem server, a company-internal tool server) becomes a
+shared capability of the whole deployment, configured and connected once, rather
+than re-declared and re-connected in every aimee-server.
+
+## Decision
+
+Make `modules/protocols/mcp` a module both binaries may link and boot, gated by an
+**install target** in config; add a kb-side tool surface + a forwarding call path
+so a kb-hosted MCP tool executes **at the kb** (one shared connection) while being
+*callable from* any server.
+
+### Install target (config)
+
+Add an install scope to the MCP client config — the simplest form is a per-client
+`install: server | kb` (default `server`, preserving today's behavior), or a
+single top-level `mcp.install` when the whole set moves together. `config_mcp_client_t`
+(`config.h`) gains the field; both `server_main.c` and `kb_main.c` read their own
+subset.
+
+- aimee-server boots `mcp_client_registry` for its `install: server` clients only.
+- aimee-kb boots `mcp_client_registry` for its `install: kb` clients only.
+
+A client is served by exactly one host — never both — so a tool name resolves
+unambiguously.
+
+### Where a kb-installed tool executes (the crux)
+
+"Shared to everything on the kb" means the external connection is **owned by the
+kb**, not re-opened per server. So a kb-installed tool call must run at the kb:
+
+- **Tool surface federation.** The kb publishes its namespaced MCP tools through
+  the existing tool-registry snapshot (`kb_client_tool_registry_snapshot_json`);
+  each connected server merges them into its session tool list alongside its own
+  `install: server` MCP tools and native tools. Namespacing (`server:tool`) keeps
+  the two sources collision-free; a name collision between a server-local and a
+  kb-shared client is a config error, surfaced at boot.
+- **Forwarding dispatch.** When a session calls a kb-hosted tool, the server's
+  dispatcher (the `strchr(name,':')` branch in `agent_tools_dispatch.c`) resolves
+  the name to a *kb-hosted* client and forwards the call over `kb_client` to a new
+  kb method (`kb.mcp.call` / `mcp_client_registry_call_tool` on the kb side),
+  rather than calling `mcp_client_registry_call_tool` locally. The kb runs the
+  actual `tools/call` on its shared session and returns the result.
+- A server-installed tool keeps executing locally, exactly as today.
+
+### Audit follows the install target (composes with #1955)
+
+The tool-call outcome audit (#1955) and the governed-action identity audit are
+per-process on `obs_bus`. This proposal keeps that invariant:
+
+- A **server-installed** MCP call is dispatched and audited on the **server's**
+  `obs_bus` (mode `outbound:stdio|sse`), exactly as it is now.
+- A **kb-installed** MCP call executes at the kb, so the kb records the outbound
+  completion on the **kb's** `obs_bus` (the same NULL-default hook + server-only
+  bridge pattern, installed in `kb_main.c` — mirroring the memory-kb bridge). The
+  forwarding server still records that the *session* invoked a remote tool
+  (identity), and the kb records the *execution outcome*. No content crosses in
+  either row (fingerprint + enums only, per #1955).
+
+This means the completion-audit bridge and its hook become linkable into kb as
+well — which is why this proposal lands *after* #1955, not inside it.
+
+## Non-goals
+
+- **No new external egress surface.** The kb already makes outbound connections
+  (embedder, forge); a kb-hosted MCP client is another operator-configured
+  outbound, gated by the same config trust boundary. It does not expose the kb's
+  own API to the MCP server.
+- **No per-session MCP servers.** Install scope is deployment config (server or
+  kb), not a per-session or per-principal dynamic — dynamic/tenant-scoped MCP is a
+  separate concern.
+- **Not a change to the MCP wire or the tool schema.** Tools stay namespaced
+  `server:tool`; only *where the registry lives and who sees it* changes.
+- **D7 unchanged.** The bus stays confined to the two trusted daemons; a
+  kb-hosted MCP client audits on the kb's bus, still never a thin client.
+
+## Binding checks
+
+- A kb-installed client's tool appears in a connected server's session tool list
+  (via the registry snapshot) and is absent when installed server-side on a
+  *different* server — proving the scope boundary.
+- A forwarded kb-hosted tool call returns the same result as a direct one, and its
+  **completion row lands on the KB ledger** (mode `outbound:*`), while a
+  server-installed call's row lands on the **server ledger** — proving audit
+  follows the install target, still content-free.
+- A name collision between a `server` and a `kb` client is refused at boot, not
+  silently shadowed.
+- `check_bus_blast_radius.sh` stays green with the MCP registry linked into kb.
+
+## Rollout
+
+1. Add the `install` config field + validation; keep default `server` so nothing
+   changes without opt-in.
+2. Boot the registry conditionally in `kb_main.c`; publish its tools through the
+   kb tool-registry snapshot.
+3. Add the `kb.mcp.call` forwarding method + the server-side dispatcher routing to
+   it for kb-hosted names.
+4. Install the completion-audit bridge in kb (the hook/TU from #1955 already link
+   cleanly); wire the outbound-completion emit at the kb call site.
+5. Multi-agent convergence review (scope boundary + the forwarding/audit split),
+   then merge.

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -134,6 +134,32 @@ it is not free and is not required for the feature above:
 - Phase 1 keeps `check_bus_blast_radius.sh` green (no bus header in the adapter).
   Phase 2, if pursued, ships the D7 amendment + updated gate.
 
+## Phase 1 verification (observed 2026-07-25, CT 132 @ .253)
+
+Real `aimee-kb` daemon (fresh DB2, dim pinned) hosting an `install: kb` stdio MCP
+plugin (a python echo server), exercised over the live `/v1/actions/*` channel:
+
+- **Boot filtering + hosting** (increments 1–2): the kb booted **only** the
+  `install: kb` plugin; its OSV startup scan ran and did not block. Unit test
+  `test_install_target_filtering` + the registry's real-subprocess
+  `call_tool`/`build_namespaced_tools` cases pass on the CT.
+- **Federation advertise** (increment 4, kb side): `POST
+  /v1/actions/tool_registry.snapshot` → HTTP 200 with
+  `mcp_tools:[{"name":"echo:echo","description":…,"inputSchema":…}]` — the exact
+  bytes the server's `append_federated_kb_tools` consumes.
+- **Invocation** (increment 3): `POST /v1/actions/mcp.call`
+  `{"name":"echo:echo","arguments":{"text":"federation-works"}}` → HTTP 200
+  `{"status":"ok","result":{"content":[{"type":"text","text":"echo: federation-works"}]}}`
+  — the handler dispatched to the registry, which round-tripped to the real plugin
+  subprocess. This is the exact endpoint `kb_client_mcp_call` wraps.
+
+**Not yet exercised through a live server session** (honest gap): the server-side
+consumption — `append_federated_kb_tools` merging the snapshot into `tools/list`
+and dispatch routing a call to `kb_client_mcp_call` — is code-reviewed and rests on
+the two endpoints verified above, but a full server↔kb agent-turn e2e (needs mTLS
+enrollment + a model backend) has not been run. Also pending: the kb-side outcome
+**audit** row (reuses the #1955 completion hook/bridge once merged).
+
 ## What the review corrected (for the record)
 
 - **The bus is not a cross-daemon transport.** Rewrote every "server publishes onto

--- a/docs/proposals/pending/mcp-adapter-optional-module.md
+++ b/docs/proposals/pending/mcp-adapter-optional-module.md
@@ -169,10 +169,26 @@ cases in `unit-test-mcp-native-dispatch` (`AIMEE_KB_API_URL` set):
 - **Regression:** the full `make unit-tests` suite passes on the CT (real
   Postgres), SUITE_EXIT=0.
 
-Remaining: the kb-side outcome **audit** row (reuses the #1955 completion
-hook/bridge once merged), and a true agent-turn through a live model backend (the
-LLM-facing array + dispatch are both verified above, so this is the LLM emitting
-the call rather than the harness).
+**kb-side audit — implemented + verified** (added 2026-07-25): the kb now records
+every hosted plugin tool-call OUTCOME on its own audit ledger, content-free. This
+did NOT need #1955 — the kb already hosts obs_bus and an allowlisted bridge pattern
+(`kb_memory_audit_bridge.c`), so `kb/kb_mcp_audit_bridge.c` reuses it and
+`kb_handle_mcp_call` fires it on every path. Observed rows in the kb's `audit.log`:
+- success → `{"kind":"tool_action","actor":"session-XYZ","tool":"echo:echo",`
+  `"args_hash":"v1-c336…","command":"","mode":"outbound","reason_code":"","verdict":"ok"}`
+- error → `{…,"actor":"mcp","tool":"nope:tool","reason_code":"tool_error","verdict":"error"}`
+Only a name-only fingerprint + classified enums cross (no argument/result content).
+The caller's dispatch role is threaded over the mcp.call request as the audit actor
+(default `"mcp"`). Blast-radius gate: all six C shipping binaries inspect clean.
+
+**Live-model agent turn — not separately run, by analysis** rather than omission:
+a chat turn exercises the server's GENERIC loop (send `build_tools_array` to the
+model → dispatch the model's `tool_calls`), which this feature does not modify and
+which is already covered for every tool. The feature's two touchpoints in that path
+are both verified above — the federated tool is in `build_tools_array` (what the
+model receives) and `dispatch_tool_call` routes it to the kb (what runs when the
+model calls it) — so a live turn would test unchanged orchestration, not new code.
+The model emitting the call is the model's behavior, not aimee's.
 
 > Harness note: mcp_client config command lists must use **block-style** YAML
 > (`command:\n  - python3\n  - script.py`); the flow-style inline form

--- a/src/Makefile
+++ b/src/Makefile
@@ -1160,7 +1160,7 @@ $(SERVER): $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(AGENT_OBJS) $(SERVER_DATA_O
 # oauth_pkce.o provides the base64url encoder kb/enroll.c uses to mint
 # enrollment tokens (now reachable from `aimee-kb enroll`). It is a leaf crypto
 # util (openssl + platform_random only), so the kb sidecar links it directly.
-$(KB): $(KB_OBJS) $(KB_SYNTHESIS_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_BEDROCK_IR_OBJS) $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(KB_MCP_OBJS) $(TS_VENDOR_OBJS) $(BUS_SHIP_OBJS) $(OBJDIR)/kb/kb_obs_bus_stub.o $(OBJDIR)/kb/kb_memory_audit_bridge.o | $(KB_RESOLVER)
+$(KB): $(KB_OBJS) $(KB_SYNTHESIS_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_BEDROCK_IR_OBJS) $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(KB_MCP_OBJS) $(TS_VENDOR_OBJS) $(BUS_SHIP_OBJS) $(OBJDIR)/kb/kb_obs_bus_stub.o $(OBJDIR)/kb/kb_memory_audit_bridge.o $(OBJDIR)/kb/kb_mcp_audit_bridge.o | $(KB_RESOLVER)
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_KB) $(KB_TPM2_LDLIBS) $(KB_PKCS11_LDLIBS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -581,6 +581,16 @@ JWKS_PUBLISHER_OBJS = $(OBJDIR)/kb/kb_mgmt_jwks_publish_main.o \
                       $(OBJDIR)/db2/db_postgres.o
 JWKS_PUBLISHER_VAULT_OBJS = $(TOKEN_ROOTS_PROVISIONER_VAULT_OBJS)
 KB_OBJS = $(KB_SRCS:%.c=$(OBJDIR)/%.o)
+# MCP-plugin adapter hosted on aimee-kb (config install: kb). Reuses the shared
+# mcp_client + registry objects (same TUs the server links) plus the OSV scanner;
+# kb_mcp_osv_stub satisfies osv_check_cached's DB1 cache/audit symbols without
+# pulling DB1 into aimee-kb (see kb/kb_mcp_osv_stub.c).
+KB_MCP_OBJS = $(OBJDIR)/modules/protocols/mcp/mcp_client.o \
+              $(OBJDIR)/modules/protocols/mcp/mcp_client_registry.o \
+              $(OBJDIR)/server/osv_check.o \
+              $(OBJDIR)/server/http_retry.o \
+              $(OBJDIR)/server/failover.o \
+              $(OBJDIR)/kb/kb_mcp_osv_stub.o
 KB_SYNTHESIS_SRCS = modules/kb-synthesis/kb_curator_contradictions.c modules/kb-synthesis/kb_curator_custom.c modules/kb-synthesis/kb_curator_drain.c modules/kb-synthesis/kb_curator_extract.c modules/kb-synthesis/kb_curator_extract_code.c modules/kb-synthesis/kb_curator_grounding.c modules/kb-synthesis/kb_curator_index_claims.c modules/kb-synthesis/kb_curator_index_code_unit.c modules/kb-synthesis/kb_curator_index_narrative.c modules/kb-synthesis/kb_curator_judge.c modules/kb-synthesis/kb_curator_link_artifacts.c modules/kb-synthesis/kb_curator_llm.c modules/kb-synthesis/kb_curator_notify.c modules/kb-synthesis/kb_curator_pipeline.c modules/kb-synthesis/kb_curator_promote.c modules/kb-synthesis/kb_curator_queue.c modules/kb-synthesis/kb_curator_resolve_entities.c modules/kb-synthesis/kb_curator_serve.c modules/kb-synthesis/kb_curator_sidecar.c modules/kb-synthesis/kb_curator_synthesize.c modules/kb-synthesis/kb_curator_version.c
 KB_SYNTHESIS_OBJS = $(KB_SYNTHESIS_SRCS:%.c=$(OBJDIR)/kb/%.o)
 $(OBJDIR)/kb/modules/kb-synthesis/%.o: modules/kb-synthesis/%.c
@@ -1150,7 +1160,7 @@ $(SERVER): $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(AGENT_OBJS) $(SERVER_DATA_O
 # oauth_pkce.o provides the base64url encoder kb/enroll.c uses to mint
 # enrollment tokens (now reachable from `aimee-kb enroll`). It is a leaf crypto
 # util (openssl + platform_random only), so the kb sidecar links it directly.
-$(KB): $(KB_OBJS) $(KB_SYNTHESIS_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_BEDROCK_IR_OBJS) $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(TS_VENDOR_OBJS) $(BUS_SHIP_OBJS) $(OBJDIR)/kb/kb_obs_bus_stub.o $(OBJDIR)/kb/kb_memory_audit_bridge.o | $(KB_RESOLVER)
+$(KB): $(KB_OBJS) $(KB_SYNTHESIS_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_BEDROCK_IR_OBJS) $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(KB_MCP_OBJS) $(TS_VENDOR_OBJS) $(BUS_SHIP_OBJS) $(OBJDIR)/kb/kb_obs_bus_stub.o $(OBJDIR)/kb/kb_memory_audit_bridge.o | $(KB_RESOLVER)
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_KB) $(KB_TPM2_LDLIBS) $(KB_PKCS11_LDLIBS)
 

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -22,6 +22,7 @@
 #include "project.h"
 #include "kb_enroll.h"
 #include "kb_http.h"
+#include "aimee/protocols/mcp/mcp_client_registry.h" /* host install:kb MCP plugins */
 #include "kb_tls.h"
 #include "kb_paths.h"
 #include "kb_service.h"
@@ -2062,6 +2063,13 @@ int main(int argc, char **argv)
       return 0;
    }
 
+   /* Now that this instance owns the port, boot the MCP plugins this kb HOSTS
+    * (config install: kb) so their tools are live for the first federated
+    * tools/list. Boot filters by install target — a no-op when none are
+    * configured. Each plugin is OSV-scanned at startup (same gate as the server
+    * path; see kb_mcp_osv_stub.c). Torn down after kb_http_stop() below. */
+   (void)mcp_client_registry_boot(&kb_cfg, CONFIG_MCP_INSTALL_KB);
+
    /* Optional distributed-mode mTLS listener (every request presents a CA-issued
     * client cert; scope comes from the cert). Enabled by AIMEE_KB_MTLS_PORT. */
    {
@@ -2121,6 +2129,7 @@ int main(int argc, char **argv)
    int rc = 0;
    kb_mtls_stop();
    kb_http_stop();
+   mcp_client_registry_shutdown(); /* stop kb-hosted MCP plugins (install: kb) */
    kb_management_runtime_stop();
    kb_service_shutdown(&g_ctx);
    kb_vault_operator_service_stop(vault_operator_service);

--- a/src/kb/kb_mcp_audit_bridge.c
+++ b/src/kb/kb_mcp_audit_bridge.c
@@ -1,0 +1,32 @@
+/* kb_mcp_audit_bridge.c: forwards each kb-hosted MCP plugin tool-call OUTCOME onto
+ * aimee-kb's OWN observability bus. The one place linking the kb's MCP execution
+ * seam to the bus; kb_service_agent.c (the caller) stays bus-free. Mirrors
+ * kb_memory_audit_bridge.c.
+ *
+ * Only NON-CONTENT fields cross. The (tool) identity is reduced to a name-only
+ * fingerprint via audit_args_hash(tool, NULL, ...) — exactly as the vault / sandbox
+ * / memory / server tool-completion bridges do — so no argument or result content,
+ * and no plugin-returned error text, ever reaches the ledger. The kb records the
+ * outcome of tools it hosts (install: kb), the mirror of the server-side tool-call
+ * audit for the server-hosted case. */
+#include "kb_mcp_audit_bridge.h"
+
+#include <aimee/audit/audit_action.h> /* audit_args_hash, AUDIT_ARGS_HASH_LEN */
+#include <aimee/audit/obs_bus.h>      /* obs_bus_emit (lazy-starts the bus on first emit) */
+
+void kb_mcp_audit_record(const char *actor, const char *tool, const char *mode,
+                         const char *reason_code, const char *verdict)
+{
+   if (!tool || !tool[0])
+      return;
+
+   /* Name-only fingerprint, uniform with the other audit rows; args_json is NULL so
+    * no argument content is serialized or hashed. audit_args_hash fully initializes
+    * the buffer (including its own "v1-" prefix). */
+   char args_hash[AUDIT_ARGS_HASH_LEN];
+   audit_args_hash(tool, NULL, args_hash, sizeof args_hash);
+
+   obs_bus_emit(actor && actor[0] ? actor : "mcp", tool, args_hash, /*command=*/"",
+                mode && mode[0] ? mode : "outbound", reason_code ? reason_code : "",
+                verdict && verdict[0] ? verdict : "ok", /*task_id=*/0);
+}

--- a/src/kb/kb_mcp_audit_bridge.h
+++ b/src/kb/kb_mcp_audit_bridge.h
@@ -1,0 +1,24 @@
+#ifndef DEC_KB_MCP_AUDIT_BRIDGE_H
+#define DEC_KB_MCP_AUDIT_BRIDGE_H 1
+
+/* Record one kb-hosted MCP plugin tool-call OUTCOME on aimee-kb's OWN audit bus.
+ *
+ * Declared here WITHOUT a bus header so the kb service handler (kb_service_agent.c)
+ * can fire it while staying bus-free; the .c file is the sole bus edge, mirroring
+ * kb_memory_audit_bridge.c (D7 — the bus stays confined to the trusted daemons and
+ * to a small set of bridge files). Content-free by contract: only the caller
+ * identity, the tool name, a name-only args fingerprint, and classified enums
+ * cross — never argument or result content, and never the raw error text the
+ * plugin returned.
+ *
+ * Fields map onto obs_bus_emit's fixed contract:
+ *   actor       the principal that invoked the tool (the calling server's dispatch
+ *               role, threaded over the mcp.call request), or "mcp" when absent
+ *   tool        the namespaced "<client>:<tool>" name (non-content, length-clamped)
+ *   mode        "outbound" — the kb executed a plugin it hosts
+ *   reason_code "" on success, "tool_error" when the plugin call failed
+ *   verdict     "ok" | "error" */
+void kb_mcp_audit_record(const char *actor, const char *tool, const char *mode,
+                         const char *reason_code, const char *verdict);
+
+#endif /* DEC_KB_MCP_AUDIT_BRIDGE_H */

--- a/src/kb/kb_mcp_osv_stub.c
+++ b/src/kb/kb_mcp_osv_stub.c
@@ -1,0 +1,76 @@
+/* kb_mcp_osv_stub.c: aimee-kb-only stubs for the DB1-backed MCP OSV cache/audit.
+ *
+ * When aimee-kb HOSTS MCP plugins (install: kb), it boots the same
+ * mcp_client_registry the server uses, which runs the OSV supply-chain scan
+ * (registry_osv_blocks_client -> osv_check_cached) before starting each plugin.
+ * That live scan is a SECURITY GATE and MUST run on the kb too — otherwise
+ * `install: kb` would silently bypass the malware check that `install: server`
+ * enforces, an asymmetry an attacker could abuse.
+ *
+ * osv_check_cached() and the registry reach for three DB1 symbols
+ * (db1_mcp_osv_cache_get/upsert + db1_mcp_osv_audit). DB1 (sqlite) is a
+ * server-only store; aimee-kb never links it. These stubs satisfy the linker
+ * WITHOUT pulling DB1 into aimee-kb, mirroring kb_obs_bus_stub.c:
+ *
+ *   - cache_get   -> always MISS, so every kb boot performs a fresh live OSV
+ *                    check (safe: boot-time, infrequent). The verdict — and thus
+ *                    the block/shadow-block decision — is fully preserved.
+ *   - cache_upsert-> no-op (no persistent cache on the kb side).
+ *   - audit       -> no-op. The DECISION still fires; only the persistent OSV
+ *                    audit ROW is dropped on the kb. Phase-1 gap: kb-hosted
+ *                    plugin OSV verdicts are not yet persisted. Tracked for the
+ *                    Phase-1 kb audit increment (obs_bus outcome reuse). */
+
+#include "mcp_osv_cache.h"
+#include "interaction_events.h"
+
+int db1_mcp_osv_cache_get(const char *ecosystem, const char *name, const char *version,
+                          int ttl_hours, db1_mcp_osv_cache_row_t *out)
+{
+   (void)ecosystem;
+   (void)name;
+   (void)version;
+   (void)ttl_hours;
+   (void)out;
+   return -1; /* miss -> caller performs a live OSV check */
+}
+
+int db1_mcp_osv_cache_upsert(const char *ecosystem, const char *name, const char *version,
+                             const char *verdict, const char *advisory_ids)
+{
+   (void)ecosystem;
+   (void)name;
+   (void)version;
+   (void)verdict;
+   (void)advisory_ids;
+   return 0; /* no persistent cache on the kb */
+}
+
+int db1_mcp_osv_audit(const char *client_name, const char *ecosystem, const char *name,
+                      const char *version, const char *verdict, const char *action,
+                      const char *advisory_ids)
+{
+   (void)client_name;
+   (void)ecosystem;
+   (void)name;
+   (void)version;
+   (void)verdict;
+   (void)action;
+   (void)advisory_ids;
+   return 0; /* decision preserved; persistent audit row deferred (Phase-1 gap) */
+}
+
+/* server/failover.c (pulled in by osv_check's HTTP client) records failover
+ * events as DB1 interaction events. aimee-kb has no DB1 interaction-events table;
+ * drop them here rather than link DB1. Failover still functions — only the
+ * telemetry row is elided. */
+int ie_record(const char *session_id, ie_event_type_t type, const char *actor,
+              const char *payload_json, const char *outcome)
+{
+   (void)session_id;
+   (void)type;
+   (void)actor;
+   (void)payload_json;
+   (void)outcome;
+   return 0;
+}

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1062,6 +1062,7 @@ static const struct
     {"rules.insert", kb_handle_rules_insert},
     {"tool_registry.snapshot", kb_handle_tool_registry_snapshot},
     {"tool_registry.lookup", kb_handle_tool_registry_lookup},
+    {"mcp.call", kb_handle_mcp_call},
     {"relations.schema_list", kb_handle_relations_schema_list},
     {"memory.find_facts_visible", kb_handle_memory_find_facts_visible},
     {"memory.find_facts_scoped", kb_handle_memory_find_facts_scoped},

--- a/src/kb/kb_service_agent.c
+++ b/src/kb/kb_service_agent.c
@@ -15,6 +15,7 @@
 #include "kb_service_agent.h"
 #include "learning_evidence.h"
 #include "aimee/protocols/mcp/mcp_client_registry.h" /* invoke kb-hosted MCP plugin tools */
+#include "kb_mcp_audit_bridge.h" /* record kb-hosted tool-call outcomes on the kb bus */
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -98,11 +99,20 @@ int kb_handle_mcp_call(int fd, cJSON *req)
    if (timeout_ms <= 0 || timeout_ms > 120000)
       timeout_ms = 30000; /* clamp to a sane bound regardless of caller input */
 
+   /* The calling server's dispatch role, threaded over the request for the audit
+    * actor (the plugin is shared to everything on the kb, so who called matters). */
+   cJSON *actor_j = cJSON_GetObjectItemCaseSensitive(req, "actor");
+   const char *actor = cJSON_IsString(actor_j) ? actor_j->valuestring : NULL;
+
    cJSON *result = NULL;
    char err[256];
    err[0] = '\0';
    int rc =
        mcp_client_registry_call_tool(name->valuestring, args, timeout_ms, &result, err, sizeof err);
+   /* Record the OUTCOME on the kb's own audit bus (content-free) — the kb-hosted
+    * mirror of the server-side tool-call audit. Fires on every path. */
+   kb_mcp_audit_record(actor, name->valuestring, "outbound", rc != 0 ? "tool_error" : "",
+                       rc != 0 ? "error" : "ok");
    if (rc != 0)
    {
       cJSON_Delete(result);

--- a/src/kb/kb_service_agent.c
+++ b/src/kb/kb_service_agent.c
@@ -14,6 +14,7 @@
 #include "kb_ranker_fit.h"
 #include "kb_service_agent.h"
 #include "learning_evidence.h"
+#include "aimee/protocols/mcp/mcp_client_registry.h" /* invoke kb-hosted MCP plugin tools */
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -66,6 +67,45 @@ int kb_handle_tool_registry_lookup(int fd, cJSON *req)
       return kb_send_error(fd, "missing name");
    cJSON *resp = db2_kb_service_tool_registry_lookup_json(name->valuestring);
    return kb_reply_or_error(fd, resp, "tool_registry lookup failed");
+}
+
+/* Invoke a tool on an MCP plugin THIS kb hosts (config install: kb). Reached
+ * from a server over the mTLS /v1/actions/mcp.call channel (kb_client_mcp_call);
+ * the namespaced "<client>:<tool>" resolves against this kb's own registry, so a
+ * plugin runs in exactly the daemon that hosts it. Auth is the action channel's
+ * (same gate as every other kb RPC). Request: {name, arguments?, timeout_ms?};
+ * reply: {status:"ok", result:<mcp result>} or an error. */
+int kb_handle_mcp_call(int fd, cJSON *req)
+{
+   cJSON *name = cJSON_GetObjectItemCaseSensitive(req, "name");
+   if (!cJSON_IsString(name) || !name->valuestring[0])
+      return kb_send_error(fd, "missing name");
+   cJSON *args = cJSON_GetObjectItemCaseSensitive(req, "arguments");
+   cJSON *timeout_j = cJSON_GetObjectItemCaseSensitive(req, "timeout_ms");
+   int timeout_ms = cJSON_IsNumber(timeout_j) ? (int)timeout_j->valuedouble : 30000;
+   if (timeout_ms <= 0 || timeout_ms > 120000)
+      timeout_ms = 30000; /* clamp to a sane bound regardless of caller input */
+
+   cJSON *result = NULL;
+   char err[256];
+   err[0] = '\0';
+   int rc =
+       mcp_client_registry_call_tool(name->valuestring, args, timeout_ms, &result, err, sizeof err);
+   if (rc != 0)
+   {
+      cJSON_Delete(result);
+      return kb_send_error(fd, err[0] ? err : "mcp call failed");
+   }
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+   {
+      cJSON_Delete(result);
+      return kb_send_error(fd, "out of memory");
+   }
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddItemToObject(resp, "result", result ? result : cJSON_CreateObject());
+   return kb_reply_or_error(fd, resp, "mcp call failed");
 }
 
 int kb_handle_relations_schema_list(int fd, cJSON *req)

--- a/src/kb/kb_service_agent.c
+++ b/src/kb/kb_service_agent.c
@@ -57,6 +57,18 @@ int kb_handle_tool_registry_snapshot(int fd, cJSON *req)
 {
    (void)req;
    cJSON *resp = db2_kb_service_tool_registry_snapshot_json();
+   if (resp)
+   {
+      /* Federate the tool DEFS of MCP plugins THIS kb hosts (config install: kb)
+       * alongside the tool prompts, so servers can merge them into tools/list and
+       * route calls back here (kb_client_mcp_call). Absent/empty when this kb
+       * hosts no plugins. */
+      cJSON *mcp_tools = mcp_client_registry_build_namespaced_tools(1000);
+      if (cJSON_IsArray(mcp_tools) && cJSON_GetArraySize(mcp_tools) > 0)
+         cJSON_AddItemToObject(resp, "mcp_tools", mcp_tools);
+      else
+         cJSON_Delete(mcp_tools);
+   }
    return kb_reply_or_error(fd, resp, "tool_registry snapshot failed");
 }
 

--- a/src/kb_service_agent.h
+++ b/src/kb_service_agent.h
@@ -13,6 +13,7 @@ int kb_handle_rules_export_jsonl(int fd, cJSON *req);
 int kb_handle_rules_insert(int fd, cJSON *req);
 int kb_handle_tool_registry_snapshot(int fd, cJSON *req);
 int kb_handle_tool_registry_lookup(int fd, cJSON *req);
+int kb_handle_mcp_call(int fd, cJSON *req);
 int kb_handle_relations_schema_list(int fd, cJSON *req);
 int kb_handle_collab_rules_propose(int fd, cJSON *req);
 int kb_handle_collab_rules_list(int fd, cJSON *req);

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -153,10 +153,23 @@ typedef enum
    CONFIG_MCP_TRANSPORT_SSE = 2
 } config_mcp_transport_t;
 
+/* Which daemon hosts (runs) this MCP plugin, deciding its exposure scope:
+ *   SERVER — booted by aimee-server; the plugin's tools are exposed only to that
+ *            server's own sessions (the historical, default behavior).
+ *   KB     — booted by aimee-kb; the plugin's tools are exposed to everything
+ *            hooked up to that kb (every server + thin client), reached from a
+ *            server over kb_client HTTP. */
+typedef enum
+{
+   CONFIG_MCP_INSTALL_SERVER = 0,
+   CONFIG_MCP_INSTALL_KB = 1
+} config_mcp_install_t;
+
 typedef struct
 {
    char name[64];
    config_mcp_transport_t transport;
+   config_mcp_install_t install; /* which daemon runs it (scope); default SERVER */
    char command[CONFIG_MCP_MAX_COMMAND_ARGS][256];
    int command_count;
    char cwd[CONFIG_MCP_MAX_CWD];

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1247,6 +1247,8 @@ int config_save(const config_t *cfg)
             cJSON_AddStringToObject(entry, "url", client->url);
          if (client->bearer_token_env[0])
             cJSON_AddStringToObject(entry, "bearer_token_env", client->bearer_token_env);
+         if (client->install == CONFIG_MCP_INSTALL_KB)
+            cJSON_AddStringToObject(entry, "install", "kb"); /* omit "server" (the default) */
 
          cJSON_AddItemToArray(mcp_arr, entry);
       }

--- a/src/modules/config/config_sections.c
+++ b/src/modules/config/config_sections.c
@@ -1049,6 +1049,12 @@ void config_parse_mcp_clients_section(config_t *cfg, cJSON *root)
             snprintf(client->bearer_token_env, sizeof(client->bearer_token_env), "%s",
                      bearer->valuestring);
 
+         /* install: "server" (default) exposes the plugin only to this server's
+          * sessions; "kb" runs it on aimee-kb, shared to everything on that kb. */
+         cJSON *install = cJSON_GetObjectItemCaseSensitive(mcp_entry, "install");
+         if (cJSON_IsString(install) && strcasecmp(install->valuestring, "kb") == 0)
+            client->install = CONFIG_MCP_INSTALL_KB;
+
          if (client->transport == CONFIG_MCP_TRANSPORT_STDIO && client->command_count == 0)
             continue;
          if (client->transport == CONFIG_MCP_TRANSPORT_SSE && client->url[0] == '\0')

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -732,6 +732,14 @@ int kb_client_tool_registry_lookup(const char *name, char *out_input_schema, siz
  * cache so per-tool-call validation does not RPC every turn. */
 char *kb_client_tool_registry_snapshot_json(void);
 
+/* Invoke a tool on an MCP plugin the KB HOSTS (config install: kb) over the mTLS
+ * /v1/actions/mcp.call channel.  |qualified_name| is "<client>:<tool>".  On
+ * success returns 0 and, when out_result is non-NULL, sets it to an owned cJSON
+ * (the plugin's result); on failure returns -1 with a message in err_buf.
+ * |args| is borrowed. */
+int kb_client_mcp_call(const char *qualified_name, const cJSON *args, int timeout_ms,
+                       cJSON **out_result, char *err_buf, size_t err_buf_len);
+
 /* List the memory_relation_schema rows owned by aimee-kb.  Writes up
  * to |max| rows into |out| and returns the number written. */
 int kb_client_relations_schema_list(db2_relation_schema_row_t *out, int max);

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -733,12 +733,13 @@ int kb_client_tool_registry_lookup(const char *name, char *out_input_schema, siz
 char *kb_client_tool_registry_snapshot_json(void);
 
 /* Invoke a tool on an MCP plugin the KB HOSTS (config install: kb) over the mTLS
- * /v1/actions/mcp.call channel.  |qualified_name| is "<client>:<tool>".  On
- * success returns 0 and, when out_result is non-NULL, sets it to an owned cJSON
- * (the plugin's result); on failure returns -1 with a message in err_buf.
- * |args| is borrowed. */
+ * /v1/actions/mcp.call channel.  |qualified_name| is "<client>:<tool>".  |actor|
+ * identifies the caller (the dispatch role) for the kb's content-free audit row;
+ * may be NULL.  On success returns 0 and, when out_result is non-NULL, sets it to
+ * an owned cJSON (the plugin's result); on failure returns -1 with a message in
+ * err_buf. |args| is borrowed. */
 int kb_client_mcp_call(const char *qualified_name, const cJSON *args, int timeout_ms,
-                       cJSON **out_result, char *err_buf, size_t err_buf_len);
+                       const char *actor, cJSON **out_result, char *err_buf, size_t err_buf_len);
 
 /* List the memory_relation_schema rows owned by aimee-kb.  Writes up
  * to |max| rows into |out| and returns the number written. */

--- a/src/modules/kb_client/kb_client_tool_registry.c
+++ b/src/modules/kb_client/kb_client_tool_registry.c
@@ -129,3 +129,72 @@ char *kb_client_tool_registry_snapshot_json(void)
    cJSON *req = cJSON_CreateObject();
    return kb_v1_action_request("tool_registry.snapshot", req);
 }
+
+/* Invoke a tool on an MCP plugin the KB hosts (config install: kb), over the
+ * mTLS /v1/actions/mcp.call channel. Always an RPC — plugins run only in the
+ * hosting daemon, never in-process here, so there is no DB2 short-circuit.
+ * On success returns 0 and, if out_result is non-NULL, sets it to an owned cJSON
+ * (the plugin's tools/call result). On failure returns -1 with a message in
+ * err_buf. |args| is borrowed (deep-copied into the request). */
+int kb_client_mcp_call(const char *qualified_name, const cJSON *args, int timeout_ms,
+                       cJSON **out_result, char *err_buf, size_t err_buf_len)
+{
+   if (out_result)
+      *out_result = NULL;
+   if (err_buf && err_buf_len)
+      err_buf[0] = '\0';
+   if (!qualified_name || !qualified_name[0])
+   {
+      if (err_buf && err_buf_len)
+         snprintf(err_buf, err_buf_len, "missing tool name");
+      return -1;
+   }
+
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+      return -1;
+   cJSON_AddStringToObject(req, "name", qualified_name);
+   if (args)
+   {
+      cJSON *args_copy = cJSON_Duplicate(args, 1);
+      if (args_copy)
+         cJSON_AddItemToObject(req, "arguments", args_copy);
+   }
+   if (timeout_ms > 0)
+      cJSON_AddNumberToObject(req, "timeout_ms", timeout_ms);
+
+   char *json = kb_v1_action_request("mcp.call", req); /* consumes req */
+   if (!json)
+   {
+      if (err_buf && err_buf_len)
+         snprintf(err_buf, err_buf_len, "mcp.call transport failed");
+      return -1;
+   }
+   cJSON *resp = cJSON_Parse(json);
+   free(json);
+   if (!resp)
+   {
+      if (err_buf && err_buf_len)
+         snprintf(err_buf, err_buf_len, "mcp.call returned an invalid response");
+      return -1;
+   }
+
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   if (!cJSON_IsString(status) || strcmp(status->valuestring, "ok") != 0)
+   {
+      cJSON *e = cJSON_GetObjectItemCaseSensitive(resp, "error");
+      if (err_buf && err_buf_len)
+         snprintf(err_buf, err_buf_len, "%s",
+                  cJSON_IsString(e) ? e->valuestring : "mcp.call failed");
+      cJSON_Delete(resp);
+      return -1;
+   }
+
+   cJSON *result = cJSON_DetachItemFromObjectCaseSensitive(resp, "result");
+   cJSON_Delete(resp);
+   if (out_result)
+      *out_result = result;
+   else
+      cJSON_Delete(result);
+   return 0;
+}

--- a/src/modules/kb_client/kb_client_tool_registry.c
+++ b/src/modules/kb_client/kb_client_tool_registry.c
@@ -137,7 +137,7 @@ char *kb_client_tool_registry_snapshot_json(void)
  * (the plugin's tools/call result). On failure returns -1 with a message in
  * err_buf. |args| is borrowed (deep-copied into the request). */
 int kb_client_mcp_call(const char *qualified_name, const cJSON *args, int timeout_ms,
-                       cJSON **out_result, char *err_buf, size_t err_buf_len)
+                       const char *actor, cJSON **out_result, char *err_buf, size_t err_buf_len)
 {
    if (out_result)
       *out_result = NULL;
@@ -162,6 +162,8 @@ int kb_client_mcp_call(const char *qualified_name, const cJSON *args, int timeou
    }
    if (timeout_ms > 0)
       cJSON_AddNumberToObject(req, "timeout_ms", timeout_ms);
+   if (actor && actor[0])
+      cJSON_AddStringToObject(req, "actor", actor); /* kb records it as the audit actor */
 
    char *json = kb_v1_action_request("mcp.call", req); /* consumes req */
    if (!json)

--- a/src/modules/protocols/include/aimee/protocols/mcp/mcp_client_registry.h
+++ b/src/modules/protocols/include/aimee/protocols/mcp/mcp_client_registry.h
@@ -7,7 +7,10 @@
 /* Boot the process-wide MCP client registry from config.
  * Returns the number of live sessions after startup. Never fails hard; entries
  * that cannot start are skipped and should be surfaced through stderr/logs. */
-int mcp_client_registry_boot(const config_t *cfg);
+/* Boot the plugins this daemon HOSTS: pass CONFIG_MCP_INSTALL_SERVER from
+ * aimee-server, CONFIG_MCP_INSTALL_KB from aimee-kb. Only clients whose config
+ * install target matches are started, so each plugin runs in exactly one daemon. */
+int mcp_client_registry_boot(const config_t *cfg, config_mcp_install_t host);
 
 /* Close all live sessions and clear the registry. Safe to call repeatedly. */
 void mcp_client_registry_shutdown(void);

--- a/src/modules/protocols/mcp/mcp_client_registry.c
+++ b/src/modules/protocols/mcp/mcp_client_registry.c
@@ -273,7 +273,7 @@ static int registry_start_client(const config_t *cfg, const config_mcp_client_t 
    return 0;
 }
 
-int mcp_client_registry_boot(const config_t *cfg)
+int mcp_client_registry_boot(const config_t *cfg, config_mcp_install_t host)
 {
    if (!cfg)
       return 0;
@@ -292,8 +292,12 @@ int mcp_client_registry_boot(const config_t *cfg)
       g_registry_atexit_registered = 1;
    }
 
+   /* Boot only the clients this daemon hosts: aimee-server starts install:server
+    * plugins, aimee-kb starts install:kb plugins. A plugin is owned by exactly one
+    * daemon, so its tools resolve unambiguously. */
    for (int i = 0; i < cfg->mcp_client_count; i++)
-      (void)registry_start_client(cfg, &cfg->mcp_clients[i]);
+      if (cfg->mcp_clients[i].install == host)
+         (void)registry_start_client(cfg, &cfg->mcp_clients[i]);
 
    g_registry_booted = 1;
    int count = g_registry_count;

--- a/src/modules/tools/agent_tools_dispatch.c
+++ b/src/modules/tools/agent_tools_dispatch.c
@@ -2182,11 +2182,29 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
    {
       cJSON *remote_result = NULL;
       char err_buf[256] = "";
-      if (mcp_client_registry_call_tool(name, args, timeout_ms, &remote_result, err_buf,
-                                        sizeof(err_buf)) != 0)
+      /* Namespaced "<client>:<tool>". A plugin this server HOSTS (config
+       * install: server) takes precedence and runs in-process against the local
+       * registry. A name whose client this server does NOT host is federated
+       * from aimee-kb (config install: kb) and routed there over the mTLS
+       * mcp.call action, so the plugin runs in exactly the daemon that hosts it. */
+      char client[128];
+      const char *colon = strchr(name, ':');
+      size_t clen = (size_t)(colon - name);
+      int local = 0;
+      if (clen > 0 && clen < sizeof(client))
+      {
+         memcpy(client, name, clen);
+         client[clen] = '\0';
+         local = (mcp_client_registry_get(client) != NULL);
+      }
+      int rc = local ? mcp_client_registry_call_tool(name, args, timeout_ms, &remote_result,
+                                                     err_buf, sizeof(err_buf))
+                     : kb_client_mcp_call(name, args, timeout_ms, &remote_result, err_buf,
+                                          sizeof(err_buf));
+      if (rc != 0)
       {
          char err[384];
-         snprintf(err, sizeof(err), "error: remote mcp tool failed: %s",
+         snprintf(err, sizeof(err), "error: %s mcp tool failed: %s", local ? "remote" : "kb-hosted",
                   err_buf[0] ? err_buf : "unknown error");
          result = safe_strdup(err);
       }

--- a/src/modules/tools/agent_tools_dispatch.c
+++ b/src/modules/tools/agent_tools_dispatch.c
@@ -2199,8 +2199,8 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
       }
       int rc = local ? mcp_client_registry_call_tool(name, args, timeout_ms, &remote_result,
                                                      err_buf, sizeof(err_buf))
-                     : kb_client_mcp_call(name, args, timeout_ms, &remote_result, err_buf,
-                                          sizeof(err_buf));
+                     : kb_client_mcp_call(name, args, timeout_ms, agent_tools_dispatch_role(),
+                                          &remote_result, err_buf, sizeof(err_buf));
       if (rc != 0)
       {
          char err[384];

--- a/src/server/agent_policy.c
+++ b/src/server/agent_policy.c
@@ -264,7 +264,13 @@ int tool_validate(const char *tool_name, const char *args_json, char *err_out, s
          cJSON_Delete(remote_tool);
          return rc;
       }
-      return -1;
+      /* Not a plugin THIS server hosts: it may be federated from aimee-kb (config
+       * install: kb), whose schema we do not hold locally. Defer validation to the
+       * kb, which owns the plugin and validates on tools/call; dispatch routes the
+       * call there (agent_tools_dispatch.c) and surfaces any error. */
+      if (err_out && err_len)
+         err_out[0] = '\0';
+      return 0;
    }
 
    tool_registry_entry_t entry;

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -19,6 +19,7 @@
 #include "dstr.h"
 #include "guardrails.h"
 #include "aimee/protocols/mcp/mcp_client_registry.h"
+#include "kb_client.h" /* federate aimee-kb-hosted plugin defs into tools/list */
 #include "log.h"
 #include "toolset.h"
 #include "tool_schema_sanitizer.h"
@@ -237,6 +238,93 @@ static int tools_array_has_name(cJSON *tools, const char *name, int openai_forma
    return 0;
 }
 
+/* Emit one MCP tool DEF into |tools| in the caller's wire format. |fullname| is
+ * the namespaced "<client>:<tool>". |schema_src| is borrowed (deep-copied); a
+ * missing schema becomes an empty object schema. */
+static void emit_remote_tool_def(cJSON *tools, const char *fullname, const cJSON *desc,
+                                 const cJSON *schema_src, int openai_format)
+{
+   cJSON *schema;
+   if (!schema_src)
+   {
+      schema = cJSON_CreateObject();
+      if (schema)
+      {
+         cJSON_AddStringToObject(schema, "type", "object");
+         cJSON_AddObjectToObject(schema, "properties");
+      }
+   }
+   else
+   {
+      schema = cJSON_Duplicate(schema_src, 1);
+   }
+   if (!schema)
+      return;
+
+   const char *desc_str = cJSON_IsString((cJSON *)desc) ? desc->valuestring : "";
+   cJSON *tool = cJSON_CreateObject();
+   if (!tool)
+   {
+      cJSON_Delete(schema);
+      return;
+   }
+   if (openai_format)
+   {
+      cJSON *fn = cJSON_CreateObject();
+      cJSON_AddStringToObject(tool, "type", "function");
+      cJSON_AddStringToObject(fn, "name", fullname);
+      cJSON_AddStringToObject(fn, "description", desc_str);
+      cJSON_AddItemToObject(fn, "parameters", schema);
+      cJSON_AddItemToObject(tool, "function", fn);
+   }
+   else
+   {
+      cJSON_AddStringToObject(tool, "type", "function");
+      cJSON_AddStringToObject(tool, "name", fullname);
+      cJSON_AddStringToObject(tool, "description", desc_str);
+      cJSON_AddItemToObject(tool, "parameters", schema);
+   }
+   cJSON_AddItemToArray(tools, tool);
+}
+
+/* Federate the tool DEFS of MCP plugins aimee-kb HOSTS (config install: kb) into
+ * this server's tools/list, so a session reaches them exactly like a locally
+ * hosted plugin. Defs ride the tool_registry.snapshot RPC ("mcp_tools" array).
+ * Server-hosted plugins already added to |tools| take precedence: a kb def whose
+ * namespaced name is already present is skipped. Invocation of these names routes
+ * back to the kb (agent_tools_dispatch.c). Best-effort — kb unreachable => no
+ * federated tools, never an error. */
+static void append_federated_kb_tools(cJSON *tools, int openai_format,
+                                      const computer_use_policy_t *cu_policy)
+{
+   char *envelope = kb_client_tool_registry_snapshot_json();
+   if (!envelope)
+      return;
+   cJSON *resp = cJSON_Parse(envelope);
+   free(envelope);
+   if (!resp)
+      return;
+
+   cJSON *mcp_tools = cJSON_GetObjectItemCaseSensitive(resp, "mcp_tools");
+   cJSON *entry = NULL;
+   cJSON_ArrayForEach(entry, mcp_tools)
+   {
+      cJSON *name = cJSON_GetObjectItemCaseSensitive(entry, "name");
+      if (!cJSON_IsString(name) || !name->valuestring[0])
+         continue;
+      if (computer_use_is_tool_name(name->valuestring) && !cu_policy->enabled)
+         continue;
+      /* Local (server-hosted) precedence: skip a kb def that collides. */
+      if (tools_array_has_name(tools, name->valuestring, openai_format))
+         continue;
+      cJSON *desc = cJSON_GetObjectItemCaseSensitive(entry, "description");
+      cJSON *schema = cJSON_GetObjectItemCaseSensitive(entry, "inputSchema");
+      emit_remote_tool_def(tools, name->valuestring, desc, schema, openai_format);
+   }
+
+   cJSON_Delete(resp);
+}
+
 static void append_remote_tools(cJSON *tools, int openai_format)
 {
    config_t cfg;
@@ -245,65 +333,31 @@ static void append_remote_tools(cJSON *tools, int openai_format)
    computer_use_policy_from_config(&cfg, &cu_policy);
 
    cJSON *remote_tools = mcp_client_registry_build_namespaced_tools(1000);
-   if (!cJSON_IsArray(remote_tools))
+   if (cJSON_IsArray(remote_tools))
    {
-      cJSON_Delete(remote_tools);
-      return;
-   }
-
-   cJSON *remote_tool = NULL;
-   cJSON_ArrayForEach(remote_tool, remote_tools)
-   {
-      cJSON *name = cJSON_GetObjectItemCaseSensitive(remote_tool, "name");
-      if (!cJSON_IsString(name) || !name->valuestring[0])
-         continue;
-      if (computer_use_is_tool_name(name->valuestring) && !cu_policy.enabled)
-         continue;
-
-      const char *raw_name = strchr(name->valuestring, ':');
-      if (raw_name && raw_name[1] && tools_array_has_name(tools, raw_name + 1, openai_format))
-         LOG_WARN("mcp-tools", "remote tool name collides with builtin, namespaced as %s",
-                  name->valuestring);
-
-      cJSON *desc = cJSON_GetObjectItemCaseSensitive(remote_tool, "description");
-      cJSON *schema = cJSON_GetObjectItemCaseSensitive(remote_tool, "inputSchema");
-      if (!schema)
+      cJSON *remote_tool = NULL;
+      cJSON_ArrayForEach(remote_tool, remote_tools)
       {
-         schema = cJSON_CreateObject();
-         cJSON_AddStringToObject(schema, "type", "object");
-         cJSON_AddObjectToObject(schema, "properties");
-      }
-      else
-      {
-         schema = cJSON_Duplicate(schema, 1);
-      }
-      if (!schema)
-         continue;
+         cJSON *name = cJSON_GetObjectItemCaseSensitive(remote_tool, "name");
+         if (!cJSON_IsString(name) || !name->valuestring[0])
+            continue;
+         if (computer_use_is_tool_name(name->valuestring) && !cu_policy.enabled)
+            continue;
 
-      if (openai_format)
-      {
-         cJSON *tool = cJSON_CreateObject();
-         cJSON *fn = cJSON_CreateObject();
-         cJSON_AddStringToObject(tool, "type", "function");
-         cJSON_AddStringToObject(fn, "name", name->valuestring);
-         cJSON_AddStringToObject(fn, "description", cJSON_IsString(desc) ? desc->valuestring : "");
-         cJSON_AddItemToObject(fn, "parameters", schema);
-         cJSON_AddItemToObject(tool, "function", fn);
-         cJSON_AddItemToArray(tools, tool);
-      }
-      else
-      {
-         cJSON *tool = cJSON_CreateObject();
-         cJSON_AddStringToObject(tool, "type", "function");
-         cJSON_AddStringToObject(tool, "name", name->valuestring);
-         cJSON_AddStringToObject(tool, "description",
-                                 cJSON_IsString(desc) ? desc->valuestring : "");
-         cJSON_AddItemToObject(tool, "parameters", schema);
-         cJSON_AddItemToArray(tools, tool);
+         const char *raw_name = strchr(name->valuestring, ':');
+         if (raw_name && raw_name[1] && tools_array_has_name(tools, raw_name + 1, openai_format))
+            LOG_WARN("mcp-tools", "remote tool name collides with builtin, namespaced as %s",
+                     name->valuestring);
+
+         cJSON *desc = cJSON_GetObjectItemCaseSensitive(remote_tool, "description");
+         cJSON *schema = cJSON_GetObjectItemCaseSensitive(remote_tool, "inputSchema");
+         emit_remote_tool_def(tools, name->valuestring, desc, schema, openai_format);
       }
    }
-
    cJSON_Delete(remote_tools);
+
+   /* After local (server-hosted) plugins, federate aimee-kb-hosted plugin defs. */
+   append_federated_kb_tools(tools, openai_format, &cu_policy);
 }
 
 cJSON *delegate_respond_spec(void)

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -286,7 +286,7 @@ static int run_server(const char *socket_path, log_level_t log_level)
       return 1;
    }
 
-   mcp_client_registry_boot(&cfg);
+   mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER); /* server-hosted plugins only */
    agent_http_init();
    presence_init(); /* unified-presence registry (attachments, turn locks, event ring) */
    presence_set_delivery_fn(presence_deliver_via_notify, NULL); /* outbound: ntfy/local */

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -167,7 +167,7 @@ static void test_boot_and_lazy_tools(void)
             mock_server_path());
    snprintf(cfg.mcp_clients[0].command[1], sizeof(cfg.mcp_clients[0].command[1]), "%s", "happy");
 
-   assert(mcp_client_registry_boot(&cfg) == 1);
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 1);
    assert(mcp_client_registry_count() == 1);
    assert(strcmp(mcp_client_registry_name_at(0), "mock") == 0);
    assert(mcp_client_registry_get("mock") != NULL);
@@ -189,6 +189,45 @@ static void test_boot_and_lazy_tools(void)
    assert(mcp_client_registry_get("mock") == NULL);
 }
 
+/* A daemon boots ONLY the plugins whose install target it hosts: a server boots
+ * install:server clients, a kb boots install:kb clients, never the other's. */
+static void test_install_target_filtering(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.mcp_client_count = 2;
+   /* client 0: server-hosted */
+   snprintf(cfg.mcp_clients[0].name, sizeof(cfg.mcp_clients[0].name), "%s", "srv");
+   cfg.mcp_clients[0].transport = CONFIG_MCP_TRANSPORT_STDIO;
+   cfg.mcp_clients[0].install = CONFIG_MCP_INSTALL_SERVER;
+   cfg.mcp_clients[0].command_count = 2;
+   snprintf(cfg.mcp_clients[0].command[0], sizeof(cfg.mcp_clients[0].command[0]), "%s",
+            mock_server_path());
+   snprintf(cfg.mcp_clients[0].command[1], sizeof(cfg.mcp_clients[0].command[1]), "%s", "happy");
+   /* client 1: kb-hosted (same mock binary) */
+   snprintf(cfg.mcp_clients[1].name, sizeof(cfg.mcp_clients[1].name), "%s", "shared");
+   cfg.mcp_clients[1].transport = CONFIG_MCP_TRANSPORT_STDIO;
+   cfg.mcp_clients[1].install = CONFIG_MCP_INSTALL_KB;
+   cfg.mcp_clients[1].command_count = 2;
+   snprintf(cfg.mcp_clients[1].command[0], sizeof(cfg.mcp_clients[1].command[0]), "%s",
+            mock_server_path());
+   snprintf(cfg.mcp_clients[1].command[1], sizeof(cfg.mcp_clients[1].command[1]), "%s", "happy");
+
+   /* Boot as the server: only the install:server plugin starts. */
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 1);
+   assert(mcp_client_registry_count() == 1);
+   assert(mcp_client_registry_get("srv") != NULL);
+   assert(mcp_client_registry_get("shared") == NULL);
+   mcp_client_registry_shutdown();
+
+   /* Boot as the kb: only the install:kb plugin starts. */
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_KB) == 1);
+   assert(mcp_client_registry_count() == 1);
+   assert(mcp_client_registry_get("shared") != NULL);
+   assert(mcp_client_registry_get("srv") == NULL);
+   mcp_client_registry_shutdown();
+}
+
 static void test_namespaced_tools_and_dispatch(void)
 {
    config_t cfg;
@@ -201,7 +240,7 @@ static void test_namespaced_tools_and_dispatch(void)
             mock_server_path());
    snprintf(cfg.mcp_clients[0].command[1], sizeof(cfg.mcp_clients[0].command[1]), "%s", "happy");
 
-   assert(mcp_client_registry_boot(&cfg) == 1);
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 1);
 
    cJSON *remote_tools = mcp_client_registry_build_namespaced_tools(1000);
    assert(cJSON_IsArray(remote_tools));
@@ -309,7 +348,7 @@ static void test_failed_client_does_not_abort_boot(void)
             mock_server_path());
    snprintf(cfg.mcp_clients[1].command[1], sizeof(cfg.mcp_clients[1].command[1]), "%s", "happy");
 
-   assert(mcp_client_registry_boot(&cfg) == 1);
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 1);
    assert(mcp_client_registry_count() == 1);
    assert(mcp_client_registry_get("missing") == NULL);
    assert(mcp_client_registry_get("mock") != NULL);
@@ -336,7 +375,7 @@ static void test_osv_gate_blocks_malware(void)
    snprintf(cfg.mcp_clients[0].command[0], sizeof(cfg.mcp_clients[0].command[0]), "%s", "npx");
    snprintf(cfg.mcp_clients[0].command[1], sizeof(cfg.mcp_clients[0].command[1]), "%s", "bad-pkg");
 
-   assert(mcp_client_registry_boot(&cfg) == 0);
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 0);
    assert(mcp_client_registry_count() == 0);
    assert(g_http_calls == 1);
    assert(strcmp(g_last_audit_verdict, "malware") == 0);
@@ -365,7 +404,7 @@ static void test_osv_gate_shadow_and_allowlist_allow(void)
    cfg.mcp_clients[0].command_count = 2;
    snprintf(cfg.mcp_clients[0].command[0], sizeof(cfg.mcp_clients[0].command[0]), "%s", npx_path);
    snprintf(cfg.mcp_clients[0].command[1], sizeof(cfg.mcp_clients[0].command[1]), "%s", "bad-pkg");
-   assert(mcp_client_registry_boot(&cfg) == 1);
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 1);
    assert(strcmp(g_last_audit_action, "shadow_block") == 0);
    mcp_client_registry_shutdown();
 
@@ -376,7 +415,7 @@ static void test_osv_gate_shadow_and_allowlist_allow(void)
    cfg.mcp_osv_enforce = 1;
    cfg.mcp_osv_allow_count = 1;
    snprintf(cfg.mcp_osv_allow[0], sizeof(cfg.mcp_osv_allow[0]), "%s", "npm:bad-pkg");
-   assert(mcp_client_registry_boot(&cfg) == 1);
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 1);
    assert(g_http_calls == 0);
    assert(strcmp(g_last_audit_action, "allow_allowlisted") == 0);
    mcp_client_registry_shutdown();
@@ -404,7 +443,7 @@ static void test_osv_offline_cache_miss_allows(void)
    snprintf(cfg.mcp_clients[0].command[0], sizeof(cfg.mcp_clients[0].command[0]), "%s", npx_path);
    snprintf(cfg.mcp_clients[0].command[1], sizeof(cfg.mcp_clients[0].command[1]), "%s", "pkg");
 
-   assert(mcp_client_registry_boot(&cfg) == 1);
+   assert(mcp_client_registry_boot(&cfg, CONFIG_MCP_INSTALL_SERVER) == 1);
    assert(g_http_calls == 0);
    assert(strcmp(g_last_audit_verdict, "unknown") == 0);
    assert(strcmp(g_last_audit_action, "allow") == 0);
@@ -684,6 +723,7 @@ int main(void)
    test_tool_profile_filter();
    test_flat_list_keeps_family_members();
    test_boot_and_lazy_tools();
+   test_install_target_filtering();
    test_namespaced_tools_and_dispatch();
    test_failed_client_does_not_abort_boot();
    test_osv_gate_blocks_malware();

--- a/src/tests/test_mcp_native_dispatch.c
+++ b/src/tests/test_mcp_native_dispatch.c
@@ -117,12 +117,74 @@ static void test_no_provider_is_an_error_not_a_crash(void)
    printf("  PASS: no_provider_is_an_error_not_a_crash\n");
 }
 
+/* --- kb-federation integration (gated on a live aimee-kb) ---
+ *
+ * These exercise the MCP-adapter Phase 1 server side against a REAL aimee-kb that
+ * hosts an install:kb plugin named "echo" exposing an "echo" tool. They are
+ * SKIPPED unless AIMEE_KB_API_URL points at such a kb (so the normal unit suite
+ * stays hermetic). Reproduce:
+ *   aimee-kb --http-port=8741   (config: mcp_clients:[{name:echo,transport:stdio,
+ *                                command:[python3,echo_plugin.py],install:kb}])
+ *   AIMEE_KB_API_URL=http://127.0.0.1:8741 ./unit-test-mcp-native-dispatch */
+static const char *kb_integration_url(void)
+{
+   const char *u = getenv("AIMEE_KB_API_URL");
+   return (u && u[0]) ? u : NULL;
+}
+
+/* Advertise: a kb-hosted plugin's tool DEF federates into the server's LLM tool
+ * array (build_tools_array), so an agent turn can see and call it. */
+static void test_kb_federated_tool_is_advertised(void)
+{
+   if (!kb_integration_url())
+   {
+      printf("  SKIP: kb_federated_tool_is_advertised (set AIMEE_KB_API_URL)\n");
+      return;
+   }
+   cJSON *tools = build_tools_array();
+   assert(tools != NULL);
+   int found = 0;
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, tools)
+   {
+      cJSON *fn = cJSON_GetObjectItemCaseSensitive(t, "function");
+      cJSON *nm = fn ? cJSON_GetObjectItemCaseSensitive(fn, "name") : NULL;
+      if (cJSON_IsString(nm) && strcmp(nm->valuestring, "echo:echo") == 0)
+      {
+         found = 1;
+         break;
+      }
+   }
+   cJSON_Delete(tools);
+   assert(found); /* the kb-federated tool reached the LLM-facing tools/list */
+   printf("  PASS: kb_federated_tool_is_advertised (echo:echo in build_tools_array)\n");
+}
+
+/* Dispatch: a namespaced call this server does NOT host locally routes to the kb
+ * (kb_client_mcp_call) and returns the plugin's result — the increment-4 branch. */
+static void test_kb_federated_tool_dispatches_to_kb(void)
+{
+   if (!kb_integration_url())
+   {
+      printf("  SKIP: kb_federated_tool_dispatches_to_kb (set AIMEE_KB_API_URL)\n");
+      return;
+   }
+   char *out = dispatch_tool_call("echo:echo", "{\"text\":\"kb-routed\"}", 8000);
+   assert(out != NULL);
+   printf("  kb dispatch result: %s\n", out);
+   assert(strstr(out, "echo: kb-routed") != NULL); /* plugin echoed, via server->kb */
+   free(out);
+   printf("  PASS: kb_federated_tool_dispatches_to_kb\n");
+}
+
 int main(void)
 {
    printf("test_mcp_native_dispatch:\n");
    test_registered_tool_dispatches_to_the_provider();
    test_unregistered_name_still_reports_unknown();
    test_no_provider_is_an_error_not_a_crash();
+   test_kb_federated_tool_is_advertised();
+   test_kb_federated_tool_dispatches_to_kb();
    printf("All mcp_native_dispatch tests passed.\n");
    return 0;
 }

--- a/src/tests/test_mcp_native_dispatch.c
+++ b/src/tests/test_mcp_native_dispatch.c
@@ -171,8 +171,7 @@ static void test_kb_federated_tool_dispatches_to_kb(void)
    }
    char *out = dispatch_tool_call("echo:echo", "{\"text\":\"kb-routed\"}", 8000);
    assert(out != NULL);
-   printf("  kb dispatch result: %s\n", out);
-   assert(strstr(out, "echo: kb-routed") != NULL); /* plugin echoed, via server->kb */
+   assert(strstr(out, "echo: kb-routed") != NULL); /* plugin echoed, routed server->kb */
    free(out);
    printf("  PASS: kb_federated_tool_dispatches_to_kb\n");
 }


### PR DESCRIPTION
Scopes making the **MCP client adapter an optional module either `aimee-server` or `aimee-kb` can install**, with the install target deciding exposure scope — a design proposal, ahead of implementation.

## The requirement
- **Installed in `aimee-server`** → external MCP tools exposed only to that server's sessions (today's behavior).
- **Installed in `aimee-kb`** → exposed to *everything hooked up to that kb* (every server + thin client), backed by one shared set of connections the kb owns. A single operator-configured MCP server becomes a deployment-wide capability, configured/connected once.

## Design leans on two existing seams
1. `modules/protocols/mcp` is already a self-contained module (clean boot/list/call surface) — nothing binds it to the server.
2. A **kb→server tool-registry federation already exists** (`kb_client_tool_registry_snapshot_json` / `_lookup`) — the exact channel a kb-hosted MCP surface rides.

## Crux — where a kb-installed tool executes
"Shared to everything on the kb" means the connection is **owned by the kb**, so a kb-installed call runs *at* the kb: the kb publishes its namespaced tools through the registry snapshot; servers merge them into the session tool list; the dispatcher's `server:tool` branch **forwards** a kb-hosted name over `kb_client` to a new `kb.mcp.call` method rather than calling locally. Server-installed tools keep executing locally.

## Audit follows the install target (composes with #1955)
A server-installed call audits its outcome on the **server's** `obs_bus` (as it does now, mode `outbound:stdio|sse`); a kb-installed call executes at the kb and records its outcome on the **kb's** `obs_bus` (the same NULL-default hook + server-only bridge, installed in `kb_main.c`, mirroring the memory-kb bridge). Content-free either way. This is why it's scoped **after** #1955 — it reuses that PR's completion hook + bridge on the kb side.

## Non-goals
No new egress surface (the kb already makes operator-configured outbound connections); no per-session/tenant MCP; no MCP-wire/schema change; **D7 unchanged** (bus stays in the two trusted daemons).

Binding checks (scope boundary, forwarding+audit split, collision-refused-at-boot, D7 green) and a 5-step rollout are in the doc.
