### PR TITLE
Fix `aimee index callers <symbol> --json` returning empty results

### DIFF
--- a/src/cli_v1_routes.c
+++ b/src/cli_v1_routes.c
@@ -742,11 +742,20 @@ cJSON *marshal_index_structure(int argc, char **argv)
 
 cJSON *marshal_index_find_callers(int argc, char **argv)
 {
+   /* `project` is an OPTIONAL second positional, so an output-mode flag like
+    * `--json` must not be mistaken for it: `aimee index callers <symbol> --json`
+    * would otherwise send project="--json", which matches no project and returns
+    * an empty result. Parse flags out (rpc_parse drops `--json` as a valueless
+    * bool) and read only the true positionals. */
+   static const char *bools[] = {"json", NULL};
+   rpc_opts_t opts;
+   rpc_parse(argc, argv, bools, &opts);
+
    cJSON *req = marshal_no_args("index.find_callers");
-   if (argc > 0)
-      cJSON_AddStringToObject(req, "symbol", argv[0]);
-   if (argc > 1)
-      cJSON_AddStringToObject(req, "project", argv[1]);
+   if (opts.pos_count > 0)
+      cJSON_AddStringToObject(req, "symbol", opts.positional[0]);
+   if (opts.pos_count > 1)
+      cJSON_AddStringToObject(req, "project", opts.positional[1]);
    return req;
 }
 

--- a/src/tests/test_cli_v1_delegate.c
+++ b/src/tests/test_cli_v1_delegate.c
@@ -746,6 +746,33 @@ static void test_subcommand_json_flag_is_output_mode(void)
    printf("  PASS: test_subcommand_json_flag_is_output_mode\n");
 }
 
+/* Regression: `aimee index callers <symbol> --json` must not treat the output-mode
+ * `--json` flag as the OPTIONAL `project` positional. Before the fix the marshaler
+ * read raw argv[1], sending project="--json" — which matches no project, so the
+ * server returned an empty caller set for every symbol whenever --json was used
+ * without an explicit project. */
+static void test_index_find_callers_json_flag_not_project(void)
+{
+   char *argv[] = {"helper_double", "--json"};
+   cJSON *req = marshal_index_find_callers(2, argv);
+   assert(req != NULL);
+   assert(strcmp(cJSON_GetObjectItem(req, "method")->valuestring, "index.find_callers") == 0);
+   assert(strcmp(cJSON_GetObjectItem(req, "symbol")->valuestring, "helper_double") == 0);
+   /* No project was given, so the key must be absent (never "--json"). */
+   assert(cJSON_GetObjectItem(req, "project") == NULL);
+   cJSON_Delete(req);
+
+   /* An explicit project is still forwarded, with --json (trailing) ignored. */
+   char *argv2[] = {"helper_double", "myproj", "--json"};
+   cJSON *req2 = marshal_index_find_callers(3, argv2);
+   assert(req2 != NULL);
+   assert(strcmp(cJSON_GetObjectItem(req2, "symbol")->valuestring, "helper_double") == 0);
+   assert(strcmp(cJSON_GetObjectItem(req2, "project")->valuestring, "myproj") == 0);
+   cJSON_Delete(req2);
+
+   printf("  PASS: test_index_find_callers_json_flag_not_project\n");
+}
+
 static void test_trigger_routes_lookup(void)
 {
    cli_v1_route_t route;
@@ -1450,6 +1477,7 @@ int main(void)
    test_git_verify_marshaled_with_session_id();
    test_get_help_route_marshaled();
    test_subcommand_json_flag_is_output_mode();
+   test_index_find_callers_json_flag_not_project();
    test_trigger_routes_lookup();
    test_dogfood_routes_and_marshaling();
    test_eval_routes_and_marshaling();


### PR DESCRIPTION
## Summary
`aimee index callers <symbol> --json` returned `{"hits":[]}` for **every** symbol when no explicit project was given — a real, user-facing correctness bug in the shipping CLI.

## Root cause
In JSON output mode the thin client marshals `index callers` via `marshal_index_find_callers()`, which read raw argv positionally:
- `argv[0]` → `symbol`
- `argv[1]` → `project` (OPTIONAL)

`--json` is an output-mode flag, not a positional. So `aimee index callers helper_double --json` marshaled `project="--json"`. No project matches that name, so the KB call `canonical_index_find_callers(project="--json", ...)` returned nothing.

Why it hid so well:
- **Human/text output was fine** — it dispatches through `cmd_index.c` (`idx_callers`), which strips flags separately.
- **`--json` WITH an explicit project was fine** — `--json` then lands in `argv[2]` and is ignored.
- Only `--json` + *no project* hit the bug.

## Scope
Audited sibling marshalers. Only `marshal_index_find_callers` is affected:
- `marshal_index_find` reads only `argv[0]` (safe).
- `marshal_index_file_request` (structure, blast_radius) reads `argv[1]` but both commands take **two required** positionals, so `--json` can never displace one in valid usage.

## Fix
Parse flags out with `rpc_parse()` (same pattern as `marshal_index_deps`) and read only true positionals. `json` is registered as a valueless bool so the flag is dropped regardless of position.

## Verification (dedicated Debian CT, stock `testing` @ c6b21ece)
Reproduced end-to-end against a real `aimee-kb` + `aimee-server` with a scanned test project:
- `aimee index callers helper_double` (text) → 9 callers ✅
- `aimee index callers helper_double --json` (no project) → `{"hits":[]}` ❌ (before fix)
- `aimee index callers helper_double diagproj --json` (with project) → correct hits ✅
- Direct KB `GET /v1/code/callers?symbol=helper_double` → full results ✅ (confirmed the engine/DB were correct; bug was purely in CLI arg marshaling)

Added regression test `test_index_find_callers_json_flag_not_project` (in `test_cli_v1_delegate.c`). Confirmed **red-before-green**: without the source fix the test aborts at `assert(project == NULL)` (project was `"--json"`); with the fix all tests pass.

Local checks: unit-test-cli-v1-delegate ✅, clang-format-19 ✅, `make cli-v1-routes-check` ✅.