### PR TITLE
Reclaim wedged agent-admission slots so a stuck delegate can't pin capacity

### DIFF
--- a/src/headers/agent_admission.h
+++ b/src/headers/agent_admission.h
@@ -1,6 +1,8 @@
 #ifndef AGENT_ADMISSION_H
 #define AGENT_ADMISSION_H
 
+#include <time.h>
+
 /* agent_admission: the SINGLE admission controller every aimee-run agent turn passes
  * through, whatever the producer (chat front-end, delegate, WFE panel, ensemble, aux,
  * cron/trigger, fallback peer). It is the one place concurrency is bounded, and it is
@@ -80,8 +82,25 @@ agent_slot_t *agent_admission_acquire(const agent_admit_req_t *req, agent_admit_
  * holder releases. */
 void agent_admission_release(agent_slot_t *slot);
 
+/* Mark a context as still alive so the idle reaper won't reclaim it. Drive it from the
+ * same progress heartbeat that proves the turn is advancing (see server_delegate_monitor):
+ * a tmux-CLI delegate runs its whole turn inside one acquire, so without this a long-but-
+ * healthy turn would look idle. No-op for an unknown/empty handle. */
+void agent_admission_touch(const char *ctx_handle);
+
+/* Reclaim every context idle for >= max_idle_secs — i.e. whose holder thread wedged or
+ * died without releasing, so its global/per-agent/per-model capacity would stay pinned
+ * until process restart. Live turns are safe: they touch their context on acquire, on
+ * each nested turn, and on every heartbeat, all far inside the TTL. Returns the count
+ * reclaimed; <=0 is a no-op. A late real release from a reaped holder is a safe no-op
+ * (context generation guard). */
+int agent_admission_reap_idle(int max_idle_secs);
+
 /* Test/inspection helpers (also used by assertions). Return -1 if unconfigured. */
 int agent_admission_global_active(void);
 int agent_admission_agent_active(const char *agent);
+
+/* Test seam: override the reaper/acquire clock (NULL restores wall-clock time). */
+void agent_admission_set_now_hook_for_test(time_t (*fn)(void));
 
 #endif /* AGENT_ADMISSION_H */

--- a/src/server/agent_admission.c
+++ b/src/server/agent_admission.c
@@ -39,6 +39,11 @@ typedef struct
    int refcount;        /* live holders of this context */
    unsigned generation; /* bumped on free; guards stale slot handles */
    int in_use;
+   /* admit_now() stamped at acquire, each reentrant turn, and every progress
+    * heartbeat (agent_admission_touch). agent_admission_reap_idle reclaims a
+    * context whose holder thread wedged or died without releasing — its capacity
+    * would otherwise be pinned until process restart. */
+   time_t last_activity;
 } admission_ctx_t;
 
 typedef struct
@@ -78,6 +83,18 @@ static struct
    int next_ticket;
    waiter_t waiters[ADMIT_MAX_WAITERS];
 } g = {.lock = PTHREAD_MUTEX_INITIALIZER, .cond = PTHREAD_COND_INITIALIZER};
+
+/* Clock seam: wall-clock seconds by default; tests override it to drive the idle
+ * reaper deterministically without sleeping. */
+static time_t (*s_now_hook)(void);
+static time_t admit_now(void)
+{
+   return s_now_hook ? s_now_hook() : time(NULL);
+}
+void agent_admission_set_now_hook_for_test(time_t (*fn)(void))
+{
+   s_now_hook = fn;
+}
 
 /* ---- small flat-table helpers (call with g.lock held) ---------------------- */
 
@@ -233,6 +250,7 @@ static agent_slot_t *admit_new_context_locked(const agent_admit_req_t *req)
    admission_ctx_t *c = &g.ctxs[idx];
    c->in_use = 1;
    c->refcount = 1;
+   c->last_activity = admit_now();
    snprintf(c->ctx, sizeof(c->ctx), "%s", req->ctx_handle);
    snprintf(c->agent, sizeof(c->agent), "%s", req->agent);
    snprintf(c->model, sizeof(c->model), "%s", req->model);
@@ -272,6 +290,7 @@ agent_slot_t *agent_admission_acquire(const agent_admit_req_t *req, agent_admit_
    if (existing)
    {
       existing->refcount++;
+      existing->last_activity = admit_now();
       agent_slot_t *h = make_handle((int)(existing - g.ctxs));
       pthread_mutex_unlock(&g.lock);
       set_status(status, h ? AGENT_ADMIT_OK : AGENT_ADMIT_INVALID);
@@ -371,6 +390,54 @@ void agent_admission_release(agent_slot_t *slot)
    }
    pthread_mutex_unlock(&g.lock);
    free(slot);
+}
+
+void agent_admission_touch(const char *ctx_handle)
+{
+   if (!ctx_handle || !ctx_handle[0])
+      return;
+   pthread_mutex_lock(&g.lock);
+   admission_ctx_t *c = ctx_find_locked(ctx_handle);
+   if (c)
+      c->last_activity = admit_now();
+   pthread_mutex_unlock(&g.lock);
+}
+
+int agent_admission_reap_idle(int max_idle_secs)
+{
+   if (max_idle_secs <= 0)
+      return 0;
+   time_t now = admit_now();
+   int reaped = 0;
+   pthread_mutex_lock(&g.lock);
+   for (int i = 0; i < ADMIT_MAX_CONTEXTS; i++)
+   {
+      admission_ctx_t *c = &g.ctxs[i];
+      if (!c->in_use || (now - c->last_activity) < max_idle_secs)
+         continue;
+      /* The holder(s) wedged or died without releasing. Return the per-context caps
+       * exactly as the last release would (counts are per-context, not per-refcount,
+       * so decrement once regardless of refcount), then bump the generation so any
+       * outstanding handle's eventual real release is a safe no-op via the guard in
+       * agent_admission_release. */
+      counter_t *ac = counter_find(g.agents, g.agent_count, c->agent);
+      counter_t *mc = counter_find(g.models, g.model_count, c->model);
+      if (g.global_active > 0)
+         g.global_active--;
+      if (ac && ac->active > 0)
+         ac->active--;
+      if (mc && mc->active > 0)
+         mc->active--;
+      c->refcount = 0;
+      c->in_use = 0;
+      c->generation++;
+      c->ctx[0] = c->agent[0] = c->model[0] = '\0';
+      reaped++;
+   }
+   if (reaped)
+      pthread_cond_broadcast(&g.cond); /* freed capacity: wake any waiters */
+   pthread_mutex_unlock(&g.lock);
+   return reaped;
 }
 
 /* ---- inspection ---------------------------------------------------------- */

--- a/src/server/server_delegate_monitor.c
+++ b/src/server/server_delegate_monitor.c
@@ -2,8 +2,9 @@
 
 #include "server_delegate_monitor.h"
 #include <aimee/delegates/delegate_backend_docker.h> /* delegate_backend_docker_reap_aged (leaked-container reap) */
-#include "http_retry.h"                              /* http_set_progress_cb */
-#include "cli_session.h" /* cli_session_set_heartbeat_cb (tmux-CLI delegates) */
+#include "agent_admission.h" /* agent_admission_touch / _reap_idle (wedged-slot reclaim) */
+#include "http_retry.h"      /* http_set_progress_cb */
+#include "cli_session.h"     /* cli_session_set_heartbeat_cb (tmux-CLI delegates) */
 #include "log.h"
 
 #include <pthread.h>
@@ -23,6 +24,11 @@ int db1_agent_job_classify_stale(int job_id, int idle_threshold_secs, int in_too
 int db1_agent_job_cancel_by_id(int job_id, const char *reason);
 void db1_agent_job_heartbeat(int job_id);
 
+/* The id of the delegation running on this thread (== the admission context handle for a
+ * delegate turn). Weak so unit binaries that don't link the runtime resolve it to NULL and
+ * simply skip the admission touch; the server always provides the strong definition. */
+const char *delegation_active_id(void) __attribute__((weak));
+
 /* Per-turn heartbeat for the in-flight background delegate on this thread. The
  * http_retry progress callback fires after every model HTTP attempt; bumping the
  * heartbeat there keeps a slow-but-progressing delegate alive (see header). */
@@ -32,6 +38,15 @@ static void delegate_heartbeat_cb(void)
 {
    if (g_hb_job_id > 0)
       db1_agent_job_heartbeat(g_hb_job_id);
+   /* Same liveness signal for the admission controller: a tmux-CLI delegate holds its
+    * slot for the whole turn, so touch it here to keep the wedged-slot reaper off a
+    * healthy long turn. delegation_active_id() is the slot's context handle. */
+   if (delegation_active_id)
+   {
+      const char *deleg = delegation_active_id();
+      if (deleg && deleg[0])
+         agent_admission_touch(deleg);
+   }
 }
 
 /* cli_session heartbeat callbacks carry a void* ud; ignore it and bump the same
@@ -101,6 +116,13 @@ int server_delegate_monitor_sweep(int idle_threshold_secs, int in_tool_threshold
  * live long-running turn is never removed. */
 #define CONTAINER_REAP_AGE_SECS 1800
 
+/* Idle threshold for reclaiming a wedged admission slot: a holder that stops touching
+ * its context (heartbeat every ~15 s) for this long has died or wedged without releasing,
+ * so its concurrency capacity is pinned and blocks new turns for that agent. Sits far
+ * above the heartbeat interval (a healthy long turn is never reaped) yet below the
+ * stale-job cancel thresholds so freed capacity returns promptly, each sweep. */
+#define ADMISSION_IDLE_REAP_SECS 240
+
 static void *monitor_thread(void *arg)
 {
    (void)arg;
@@ -109,6 +131,10 @@ static void *monitor_thread(void *arg)
    {
       (void)server_delegate_monitor_sweep(DEFAULT_IDLE_THRESHOLD_SECS,
                                           DEFAULT_IN_TOOL_THRESHOLD_SECS);
+
+      int freed = agent_admission_reap_idle(ADMISSION_IDLE_REAP_SECS);
+      if (freed > 0)
+         LOG_WARN("server.delegate_monitor", "reclaimed %d wedged admission slot(s)", freed);
 
       if (++sweeps % CONTAINER_REAP_EVERY_N_SWEEPS == 0)
       {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -4088,6 +4088,7 @@ $(TESTPREFIX)/unit-test-db1-agent-job-heartbeat: \
 $(TESTPREFIX)/unit-test-server-delegate-monitor: \
                                        $(OBJDIR)/tests/test_server_delegate_monitor.o \
                                        $(OBJDIR)/server/server_delegate_monitor.o \
+                                       $(OBJDIR)/server/agent_admission.o \
                                        $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                        $(OBJDIR)/db1/agent_jobs.o $(OBJDIR)/log.o \
                                        $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \

--- a/src/tests/test_agent_admission.c
+++ b/src/tests/test_agent_admission.c
@@ -8,6 +8,10 @@
 #include <string.h>
 #include <unistd.h>
 
+/* Idle-reaper TTL the tests drive against (seconds); matches the monitor's operating
+ * threshold in spirit — the exact value is irrelevant since the clock is injected. */
+#define ADMIT_TEST_TTL 240
+
 static agent_admit_req_t req(const char *ctx, const char *agent, const char *model, int max)
 {
    agent_admit_req_t r;
@@ -146,6 +150,81 @@ static void test_release_null_and_stale(void)
    printf("  PASS: release_null_and_stale\n");
 }
 
+/* ---- idle reaper: reclaim a slot whose holder wedged/died without releasing ---- */
+
+static time_t s_fake_now;
+static time_t fake_now(void)
+{
+   return s_fake_now;
+}
+
+static void test_reap_idle_reclaims_wedged_slot(void)
+{
+   agent_admission_set_now_hook_for_test(fake_now);
+   s_fake_now = 1000;
+   configure(10, 10);
+   agent_admit_status_t st;
+
+   /* claude at max_parallel=1: one holder saturates it. */
+   agent_admit_req_t r = req("deleg-A", "claude", "sonnet", 1);
+   agent_slot_t *wedged = agent_admission_acquire(&r, &st);
+   assert(wedged && st == AGENT_ADMIT_OK);
+   assert(agent_admission_agent_active("claude") == 1);
+
+   /* The leak symptom: a new claude turn is rejected while the holder pins the slot. */
+   agent_admit_req_t r2 = req("deleg-B", "claude", "sonnet", 1);
+   assert(agent_admission_acquire(&r2, &st) == NULL && st == AGENT_ADMIT_AT_LIMIT);
+
+   /* Holder never releases (its thread wedged). Below the TTL nothing is reclaimed... */
+   s_fake_now += ADMIT_TEST_TTL - 1;
+   assert(agent_admission_reap_idle(ADMIT_TEST_TTL) == 0);
+   assert(agent_admission_agent_active("claude") == 1);
+
+   /* ...at/after the TTL the wedged slot is reclaimed. */
+   s_fake_now += 2;
+   assert(agent_admission_reap_idle(ADMIT_TEST_TTL) == 1);
+   assert(agent_admission_agent_active("claude") == 0);
+
+   /* Capacity is back: a fresh claude turn is admitted. */
+   agent_slot_t *fresh = agent_admission_acquire(&r2, &st);
+   assert(fresh && st == AGENT_ADMIT_OK);
+   assert(agent_admission_agent_active("claude") == 1);
+
+   /* The wedged holder's late real release is a safe no-op (generation guard): it must
+    * not double-decrement and drop the fresh holder's count. */
+   agent_admission_release(wedged);
+   assert(agent_admission_agent_active("claude") == 1);
+
+   agent_admission_release(fresh);
+   assert(agent_admission_agent_active("claude") == 0);
+   agent_admission_set_now_hook_for_test(NULL);
+   printf("  PASS: reap_idle_reclaims_wedged_slot\n");
+}
+
+static void test_touch_protects_live_slot(void)
+{
+   agent_admission_set_now_hook_for_test(fake_now);
+   s_fake_now = 5000;
+   configure(10, 10);
+   agent_admit_status_t st;
+   agent_admit_req_t r = req("deleg-live", "agentY", "m", 1);
+   agent_slot_t *s = agent_admission_acquire(&r, &st);
+   assert(s && st == AGENT_ADMIT_OK);
+
+   /* Wall time marches well past the TTL, but the turn keeps heartbeating within it, so
+    * the reaper never touches it. */
+   for (int i = 0; i < 6; i++)
+   {
+      s_fake_now += ADMIT_TEST_TTL - 1;
+      agent_admission_touch("deleg-live");
+      assert(agent_admission_reap_idle(ADMIT_TEST_TTL) == 0);
+      assert(agent_admission_agent_active("agentY") == 1);
+   }
+   agent_admission_release(s);
+   agent_admission_set_now_hook_for_test(NULL);
+   printf("  PASS: touch_protects_live_slot\n");
+}
+
 /* ---- concurrency stress: peak in-flight must never exceed the global cap ---- */
 
 #define STRESS_THREADS 40
@@ -206,6 +285,8 @@ int main(void)
    test_per_model_cap();
    test_context_reuse();
    test_release_null_and_stale();
+   test_reap_idle_reclaims_wedged_slot();
+   test_touch_protects_live_slot();
    test_stress_peak_never_exceeds_cap();
    printf("agent_admission: all tests passed\n");
    return 0;


### PR DESCRIPTION
## Problem (observed live on the appliance)

`claude` sat at **3/3** admission slots with **zero** claude processes or tmux sessions running, and every new claude delegate failed with:
```
agent 'claude' at concurrency limit (max_parallel=3) [aimee_err=concurrency_limit]
```
This blocked **all** claude WFE work independent of the OAuth/token path.

**Root cause** (`src/server/agent_admission.c`): admission slots are an in-process refcount with **no TTL and no reaper**. A per-agent count decrements only when the holder calls `agent_admission_release`. When a delegate worker thread wedges mid-turn (a tmux-CLI pane whose CLI process died, a hung setup step), it holds its slot without ever releasing — so that agent's `max_parallel` capacity is pinned until the server process restarts. A restart cleared it; it re-leaked to 3/3 within ~15 minutes.

## Fix — a TTL-idle reaper with a liveness heartbeat

- Each admission context stamps `last_activity` on acquire, on every reentrant turn, and on each **progress heartbeat** (`agent_admission_touch`, called from the delegate monitor's heartbeat callback using `delegation_active_id()` — which *is* the slot's context handle). A healthy long turn heartbeats every ~15s, so it stays well inside the TTL.
- `agent_admission_reap_idle(max_idle_secs)` reclaims any context idle past the TTL: it returns the global/per-agent/per-model caps exactly as the final release would, and bumps the context generation so the wedged holder's eventual **real** release is a safe no-op (existing generation guard) rather than a double-decrement.
- The monitor runs it **every sweep** with a **240s** threshold — far above the heartbeat interval (a live turn is never reaped) and below the stale-job cancel thresholds, so freed capacity returns promptly.

## Safety / layering

- `delegation_active_id` is declared **weak** in the monitor, so unit binaries that don't link the runtime resolve it to NULL and simply skip the touch; the server always provides the strong definition.
- A clock seam (`agent_admission_set_now_hook_for_test`) drives the new tests deterministically.

## Tests

- `reap_idle_reclaims_wedged_slot`: a saturating holder pins the slot; a new turn is rejected; below the TTL nothing is reaped; at the TTL the slot is reclaimed and a fresh turn is admitted; the wedged holder's late release does **not** disturb the fresh holder's count.
- `touch_protects_live_slot`: repeated over-TTL wall-clock gaps with a heartbeat each interval are never reaped.
- `unit-test-server-delegate-monitor` still passes (now links `agent_admission.o`).

Server + `unit-test-agent-admission`, `unit-test-server-delegate-monitor`, `unit-test-agent` all build/link/pass on current `testing`; all changed files clang-format clean.

Once merged + deployed, the reaper reclaims the currently-leaked claude slots **live** (no restart needed), unblocking claude delegates — at which point the vaulted OAuth token can finally be validated end-to-end.