### PR TITLE
Require a fresh (unexpired) token before a claude re-auth reports success

### DIFF
--- a/src/headers/server_cli_oauth.h
+++ b/src/headers/server_cli_oauth.h
@@ -84,4 +84,11 @@ int cli_oauth_scrape_codex_code(const char *pane, char *out, size_t n);
  * chars); 0 otherwise. */
 int cli_oauth_code_is_safe(const char *code);
 
+/* 1 iff the claude credentials JSON at `path` exists and carries an "expiresAt"
+ * (epoch-ms) strictly in the future — i.e. a genuinely fresh sign-in, not a leftover
+ * expired token. 0 for absent / unreadable / no expiresAt / already expired. This is
+ * what makes a claude re-auth wait for the real browser step instead of "succeeding"
+ * instantly against a stale file. */
+int cli_oauth_claude_token_is_fresh(const char *path);
+
 #endif /* DEC_SERVER_CLI_OAUTH_H */

--- a/src/server/server_cli_oauth.c
+++ b/src/server/server_cli_oauth.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <sys/file.h> /* flock */
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 /* Wall-clock ceilings for every spawned process. None of these may run unbounded:
@@ -129,6 +130,35 @@ static char *oauth_read_secret_file(const char *path)
    }
    buf[used] = '\0';
    return buf;
+}
+
+/* claude's ~/.claude/.credentials.json records the token's absolute expiry as
+ * "expiresAt":<epoch-ms>. A re-auth is only genuinely complete once a token with a
+ * FUTURE expiry has been written: a pre-existing EXPIRED file left from an earlier
+ * sign-in must NOT count as success, or the poll reports authenticated instantly against
+ * the dead token — storing it to the vault and tearing the login session down before the
+ * user ever finishes the browser flow. Returns 1 only for a present, parseable,
+ * not-yet-expired token; 0 otherwise (absent / unreadable / no expiresAt / expired). */
+int cli_oauth_claude_token_is_fresh(const char *path)
+{
+   char *buf = oauth_read_secret_file(path);
+   if (!buf)
+      return 0;
+   int fresh = 0;
+   const char *p = strstr(buf, "\"expiresAt\"");
+   if (p)
+   {
+      p += strlen("\"expiresAt\"");
+      while (*p == ':' || *p == ' ' || *p == '\t')
+         p++;
+      long long expires_ms = strtoll(p, NULL, 10);
+      long long now_ms = (long long)time(NULL) * 1000LL;
+      if (expires_ms > now_ms)
+         fresh = 1;
+   }
+   memset(buf, 0, strlen(buf));
+   free(buf);
+   return fresh;
 }
 
 /* Persist the vendor's freshly-written OAuth token into the vault as the single
@@ -646,11 +676,13 @@ int cli_oauth_poll(cli_oauth_vendor_t v, const char *session, cli_oauth_state_t 
        * completes. Check ONLY that file — `.claude.json` is unconditional app
        * state created on first launch, so treating it as proof of auth was a false
        * positive that reported success (and tore the session down) before the real
-       * credentials were written, leaving the CLI unauthenticated. */
+       * credentials were written, leaving the CLI unauthenticated. And require the
+       * token to be UNEXPIRED: an old expired .credentials.json from a prior sign-in
+       * is present from the first byte, so a bare existence check reports success
+       * instantly against the dead token and never captures the fresh one. */
       char tok[600];
       snprintf(tok, sizeof(tok), "%s/.claude/.credentials.json", home_dir());
-      struct stat sb;
-      authed = (stat(tok, &sb) == 0 && sb.st_size > 0);
+      authed = cli_oauth_claude_token_is_fresh(tok);
    }
    if (authed)
    {

--- a/src/tests/test_server_cli_oauth.c
+++ b/src/tests/test_server_cli_oauth.c
@@ -6,7 +6,9 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 /* --- stubs for the linked-but-unexercised deps of server_cli_oauth.o --- */
 int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
@@ -103,6 +105,45 @@ static void test_code_is_safe(void)
    printf("  test_code_is_safe: ok\n");
 }
 
+static void write_file(const char *path, const char *body)
+{
+   FILE *f = fopen(path, "w");
+   assert(f);
+   fputs(body, f);
+   fclose(f);
+}
+
+static void test_claude_token_is_fresh(void)
+{
+   const char *path = "test_claude_creds.tmp";
+   char body[256];
+   long long now_ms = (long long)time(NULL) * 1000LL;
+
+   /* Absent file -> not fresh. */
+   remove(path);
+   assert(cli_oauth_claude_token_is_fresh(path) == 0);
+
+   /* Expired token (the real-world stale-file case) -> NOT fresh: a bare existence
+    * check would have wrongly reported success here. */
+   snprintf(body, sizeof(body), "{\"claudeAiOauth\":{\"accessToken\":\"x\",\"expiresAt\":%lld}}",
+            now_ms - 3600000LL);
+   write_file(path, body);
+   assert(cli_oauth_claude_token_is_fresh(path) == 0);
+
+   /* Fresh token with a future expiry -> fresh. */
+   snprintf(body, sizeof(body), "{\"claudeAiOauth\":{\"accessToken\":\"x\",\"expiresAt\":%lld}}",
+            now_ms + 3600000LL);
+   write_file(path, body);
+   assert(cli_oauth_claude_token_is_fresh(path) == 1);
+
+   /* Present file but no expiresAt -> fail closed (not fresh). */
+   write_file(path, "{\"claudeAiOauth\":{\"accessToken\":\"x\"}}");
+   assert(cli_oauth_claude_token_is_fresh(path) == 0);
+
+   remove(path);
+   printf("  test_claude_token_is_fresh: ok\n");
+}
+
 int main(void)
 {
    printf("server_cli_oauth tests\n");
@@ -110,6 +151,7 @@ int main(void)
    test_scrape_url();
    test_scrape_codex_code();
    test_code_is_safe();
+   test_claude_token_is_fresh();
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Problem (root cause of "re-auth doesn't take effect")

`cli_oauth_poll` decided a **claude** sign-in was complete with a bare `stat`: does `~/.claude/.credentials.json` exist and is it non-empty? But that file is left on disk by the **previous** sign-in — so an expired credential from a day ago satisfies the check the instant a re-auth *starts*. The poll then:
1. reports `AUTHENTICATED`,
2. stores that **stale** token into the vault,
3. tears down the login tmux session — **before the user ever finishes the browser step.**

Observed live on the appliance: the shared claude credential was **~13h expired** with an empty `refreshToken`; a web-GUI "Re-authorize" flipped to success against it and never captured a new token. Result: every claude delegate kept 401'ing (0 API calls → "no file changes" on every WFE impl slice), and the vault's `claude/oauth` entry (written during that bogus "success") held the dead token.

## Fix

Gate the claude branch on **freshness**, not existence. `cli_oauth_claude_token_is_fresh` parses `"expiresAt"` (epoch-ms) from the credentials JSON and returns true only when it is strictly in the future. A leftover expired file no longer counts, so the poll stays `PENDING` until the real browser sign-in writes a token with a future expiry — at which point the genuinely fresh token is what lands in the vault.

`codex` is unaffected: it already probes real validity via `login status`.

## Tests

`test_claude_token_is_fresh` (helper exposed for tests): absent → not fresh; **expired → not fresh** (the exact real-world false-positive); fresh/future → fresh; present-but-no-`expiresAt` → fail-closed.

Server + `unit-test-server-cli-oauth` build/link/pass on current `testing`; all changed files clang-format clean.

## Relationship to the other fixes

This is the third of three that together make claude WFEs work end-to-end:
- #1956 — vault is the single source of truth for delegate OAuth tokens (read side).
- #1959 — reclaim wedged admission slots (a leaked semaphore was blocking all claude delegates).
- **this** — the re-auth **write** side: stop "succeeding" against a stale token so the vault actually receives a fresh one.

After merge + deploy, a web-GUI claude re-auth will wait for the real sign-in, store a valid token in the vault, and delegates will materialize a working credential.