### PR TITLE
Exempt container-bound delegates from the worktree-location write guard

### DIFF
--- a/src/modules/guardrails/guardrails_orchestrator.c
+++ b/src/modules/guardrails/guardrails_orchestrator.c
@@ -1243,6 +1243,15 @@ int pre_tool_check_inner(const char *tool_name, const char *input_json, session_
    const char *effective_cwd = tool_effective_cwd(root, cwd);
    int command_targets_worktree = shell_command_targets_worktree(tool_name, cmd, effective_cwd);
    int target_is_worktree = path_tool_targets_worktree(tool_name, fp, effective_cwd);
+   /* A delegate bound to its OWN sandbox container writes into the container's
+    * bind-mounted worktree — that mount IS the isolation boundary. The host-oriented
+    * worktree-location guards below (and the on-disk-state guards further down) are then
+    * irrelevant and actively wrong: they run in the server process against the HOST view
+    * and cannot see the container's cwd as a worktree, so they block every write the
+    * delegate makes ("write blocked because this session is not running in a worktree"),
+    * stalling it to a zero-diff turn. The predicate is only true on that delegate's turn
+    * thread, so interactive/host turns keep every guard. */
+   const int container_delegate = workspace_turn_container_bound();
    if (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd) &&
        (bash_has_git_push_requiring_gate(cmd->valuestring) ||
         bash_has_gh_pr_create(cmd->valuestring)))
@@ -1280,9 +1289,10 @@ int pre_tool_check_inner(const char *tool_name, const char *input_json, session_
       }
    }
 
-   if ((script_tool || is_write_intent(tool_name, root)) && !cwd_is_git_checkout(effective_cwd) &&
-       !session_cwd_is_worktree(effective_cwd) && !command_targets_worktree &&
-       !target_is_worktree && !cwd_is_detached_workspace(effective_cwd))
+   if (!container_delegate && (script_tool || is_write_intent(tool_name, root)) &&
+       !cwd_is_git_checkout(effective_cwd) && !session_cwd_is_worktree(effective_cwd) &&
+       !command_targets_worktree && !target_is_worktree &&
+       !cwd_is_detached_workspace(effective_cwd))
    {
       snprintf(msg_buf, msg_len,
                "BLOCKED: write blocked because this session is not running in a worktree. "
@@ -1519,7 +1529,7 @@ int pre_tool_check_inner(const char *tool_name, const char *input_json, session_
    /* Hard block for write intents the redirect above cannot handle (e.g.
     * script tools) when the session is not running in any worktree. A detached
     * workspace is exempt: its tree lives on the serving client, not here. */
-   if ((script_tool || is_write_intent(tool_name, root)) &&
+   if (!container_delegate && (script_tool || is_write_intent(tool_name, root)) &&
        !session_cwd_is_worktree(effective_cwd) && !command_targets_worktree &&
        !target_is_worktree && !cwd_is_detached_workspace(effective_cwd))
    {
@@ -1772,16 +1782,12 @@ int pre_tool_check_inner(const char *tool_name, const char *input_json, session_
       }
    }
 
-   /* A delegate bound to its OWN container has no host-oriented file limitations:
-    * its writes land in the container's mounted worktree (its private sandbox), and
-    * the operator directive is that a container delegate may do whatever it needs to
-    * that tree. The on-disk-state write/edit guards below (read-before-write,
-    * truncating-rewrite, stale-edit) are host-safety heuristics that otherwise stall
-    * an autonomous delegate mid-task — e.g. a delegate creating a proof file a prior
-    * retry already left on disk is blocked as a "blind overwrite". Skip them for a
-    * container-bound turn; the predicate is only true on that delegate's turn thread,
-    * so interactive/host turns keep every guard. */
-   const int container_delegate = workspace_turn_container_bound();
+   /* container_delegate (computed above) also exempts the on-disk-state write/edit guards
+    * below (read-before-write, truncating-rewrite, stale-edit): those are host-safety
+    * heuristics that otherwise stall an autonomous delegate mid-task — e.g. a delegate
+    * creating a proof file a prior retry already left on disk is blocked as a "blind
+    * overwrite". A container-bound delegate owns its mounted worktree and may do whatever
+    * it needs to that tree. */
 
    /* Read-before-write guard: block Write to an existing file that has not been
     * read in this session. Agents must read a file before overwriting it so they

--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -464,8 +464,18 @@ int workspace_turn_bind_container(const char *task_id, const char *image, const 
    return 1;
 }
 
+/* Test override: -1 = report the real bound state; 0/1 = force it. Lets guardrail/tool
+ * tests exercise the container-delegate exemption without standing up a real backend. */
+static int s_container_bound_test_override = -1;
+void workspace_turn_set_container_bound_for_test(int bound)
+{
+   s_container_bound_test_override = bound;
+}
+
 int workspace_turn_container_bound(void)
 {
+   if (s_container_bound_test_override >= 0)
+      return s_container_bound_test_override;
    return t_turn_container_backend != NULL;
 }
 

--- a/src/modules/workspace/workspace_turn.h
+++ b/src/modules/workspace/workspace_turn.h
@@ -65,6 +65,10 @@ int workspace_turn_bind_container(const char *task_id, const char *image, const 
  * Valid only between bind and unbind, on the binding thread. */
 int workspace_turn_container_bound(void);
 
+/* Test seam: force workspace_turn_container_bound()'s result. -1 restores the real
+ * thread-bound state; 0/1 pin it. For tests exercising the container-delegate exemption. */
+void workspace_turn_set_container_bound_for_test(int bound);
+
 /* Clear any provider bound for this thread by workspace_turn_bind_active.
  * Safe to call unconditionally (no-op if nothing was bound). */
 void workspace_turn_unbind_active(void);

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -13,6 +13,7 @@
 #include "db2.h"
 #include "db2_test_shim.h"
 #include "workspace.h"
+#include "workspace_turn.h" /* workspace_turn_set_container_bound_for_test */
 #include "platform_test_util.h"
 #include "git_verify.h"
 
@@ -1371,6 +1372,47 @@ static void test_no_worktree_blocks_writes(void)
                        sizeof(msg));
    assert(rc == 0);
 
+   guardrails_close_test_sqlite();
+}
+
+/* A delegate bound to its own sandbox container writes into the container's bind-mounted
+ * worktree — the mount IS the boundary. The host-side "not running in a worktree" guard
+ * cannot see that and would block every write (the live failure: MiniMax/kimi implement
+ * slices produced zero diff because every write_file/execute_script was refused). The
+ * container-bound turn must be exempt from BOTH worktree-location block sites. */
+static void test_container_delegate_exempt_from_worktree_guard(void)
+{
+   guardrails_open_test_sqlite();
+   session_state_t state;
+   memset(&state, 0, sizeof(state));
+   strcpy(state.session_mode, MODE_IMPLEMENT);
+   strcpy(state.guardrail_mode, MODE_APPROVE);
+   char msg[1024] = "";
+
+   /* Baseline: NOT a container delegate, cwd outside any worktree -> write is blocked. */
+   workspace_turn_set_container_bound_for_test(0);
+   int rc = pre_tool_check(
+       "Edit", "{\"file_path\":\"/tmp/test.c\",\"old_string\":\"a\",\"new_string\":\"b\"}", &state,
+       MODE_APPROVE, "/tmp", msg, sizeof(msg));
+   assert(rc == 2 && strstr(msg, "not running in a worktree") != NULL);
+
+   /* Container-bound delegate: the same write must NOT be blocked by the worktree guard. */
+   workspace_turn_set_container_bound_for_test(1);
+   msg[0] = '\0';
+   rc = pre_tool_check("Edit",
+                       "{\"file_path\":\"/tmp/test.c\",\"old_string\":\"a\",\"new_string\":\"b\"}",
+                       &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+   assert(strstr(msg, "not running in a worktree") == NULL);
+
+   /* execute_script (the script_tool path, second block site) is also exempt. */
+   msg[0] = '\0';
+   rc =
+       pre_tool_check("execute_script", "{\"language\":\"bash\",\"body\":\"echo x > /tmp/test.c\"}",
+                      &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+   assert(strstr(msg, "not running in a worktree") == NULL);
+   (void)rc;
+
+   workspace_turn_set_container_bound_for_test(-1); /* restore real behavior */
    guardrails_close_test_sqlite();
 }
 
@@ -3484,6 +3526,7 @@ int main(void)
    test_unknown_subagent_surface_blocked();
    test_hook_call_count_increments();
    test_no_worktree_blocks_writes();
+   test_container_delegate_exempt_from_worktree_guard();
    test_shell_command_targeting_worktree_allows_write();
    test_write_file_targeting_worktree_allows_stale_cwd();
    test_external_feature_checkout_allows_writes();


### PR DESCRIPTION
## Root cause (found via the `execution_trace` table — the delegate's own tool log)

WFE implement slices on the HTTP delegates (**MiniMax, kimi**) produced **zero file changes**. The delegate trace shows the models *correctly* call `write_file`/`execute_script` to create the target file — and every attempt is refused:

```
error: guardrail blocked: BLOCKED: write blocked because this session is not
running in a worktree. Enter the session worktree before writing.
```

A delegate bound to its own sandbox container writes into the container's **bind-mounted worktree** — that mount *is* the isolation boundary. But the two "not running in a worktree" guards in `pre_tool_check` run in the aimee-server process against the **host** view, which can't see the container's cwd as a worktree. So they block every write the container delegate makes; the turn produces a no-op, the delegate fails, and the agent falls back agent-to-agent in a loop converging to nothing.

This is exactly the observed pattern: **claude edits** (tmux-CLI backend, not the containerized tool path) and **draft/plan** work (text-only, no writes), while **MiniMax/kimi implement** produce nothing.

## Fix

The container-delegate exemption *already existed* for the on-disk-state guards further down (read-before-write, truncating-rewrite, stale-edit), gated on `workspace_turn_container_bound()`. It was simply never applied to the two **worktree-location** block sites, which run earlier. Hoist `container_delegate` to the common-fields section and add `!container_delegate` to both blocks. The predicate is true only on that delegate's own turn thread, so interactive/host turns keep every guard.

## Test

`test_container_delegate_exempt_from_worktree_guard`: a non-container turn outside any worktree is still blocked (baseline), and a container-bound turn is **not** blocked at either block site (`Edit` and `execute_script`). Adds `workspace_turn_set_container_bound_for_test` seam.

Server + `unit-test-guardrails` build/link/pass; all changed files clang-format clean.

## Note on observability

This bug took hours to find because the delegate's full tool trace (request/response/every tool call + result) is written **only** to the `execution_trace` DB table and OTel — never to `server.log`. The trace *had* the answer the whole time. A companion change (#1963) starts surfacing delegate failures to the log; making the full trace visible in the operational log is worth a follow-up.