### PR TITLE
Accept in-workspace absolute paths in the docker delegate file ops

### DIFF
--- a/src/modules/delegates/delegate_backend_docker.c
+++ b/src/modules/delegates/delegate_backend_docker.c
@@ -1203,8 +1203,8 @@ static int docker_resolve_in_workspace(const docker_state_t *st, const char *rel
 {
    if (!st || !rel || !out || outsz == 0)
       return -1;
-   if (rel[0] == '/')
-      return -1;
+   /* Reject any parent-traversal segment outright — it could escape the workspace
+    * whether the input is relative or absolute. */
    const char *p = rel;
    while (*p)
    {
@@ -1217,8 +1217,28 @@ static int docker_resolve_in_workspace(const docker_state_t *st, const char *rel
       if (*p == '/')
          p++;
    }
-   if (snprintf(out, outsz, "%s/%s", st->workdir[0] ? st->workdir : resolve_docker_workdir(),
-                rel) >= (int)outsz)
+   const char *workdir = st->workdir[0] ? st->workdir : resolve_docker_workdir();
+   if (rel[0] == '/')
+   {
+      /* Accept an ABSOLUTE path only when it is within the workspace root. The slice
+       * worktree is bind-mounted path-identically, so such a path is already the valid
+       * in-container path. The native file tools (tool_read_file/tool_write_file) resolve
+       * to an absolute path via the thread cwd BEFORE calling the provider, so without
+       * this branch every in-workspace read/write is wrongly rejected (bash still works
+       * because it runs a raw `cd && ...` command that never reaches this resolver) — the
+       * live symptom was container delegates hitting "cannot open"/"cannot write" on their
+       * own worktree. A path OUTSIDE the workspace stays refused: the container must not
+       * reach the host tree. */
+      size_t wlen = strlen(workdir);
+      if (strncmp(rel, workdir, wlen) == 0 && (rel[wlen] == '/' || rel[wlen] == '\0'))
+      {
+         if (snprintf(out, outsz, "%s", rel) >= (int)outsz)
+            return -1;
+         return 0;
+      }
+      return -1;
+   }
+   if (snprintf(out, outsz, "%s/%s", workdir, rel) >= (int)outsz)
       return -1;
    return 0;
 }

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -101,6 +101,50 @@ static void test_docker_write_then_read_roundtrip(void)
    printf("  PASS: test_docker_write_then_read_roundtrip\n");
 }
 
+/* The native file tools (tool_read_file/tool_write_file) resolve to an ABSOLUTE
+ * in-workspace path via the thread cwd before calling the provider. The worktree is
+ * bind-mounted path-identically, so that path is valid in-container and MUST be accepted
+ * — previously it was rejected outright ("cannot open"/"cannot write" on a container
+ * delegate's own worktree), while a path OUTSIDE the workspace must still be refused. */
+static void test_docker_absolute_in_workspace_path_accepted(void)
+{
+   delegate_backend_reset_for_test();
+   delegate_backend_register_docker();
+   delegate_backend_t *b = delegate_backend_docker_get();
+   void *state = NULL;
+   setup_docker_fileio_state(b, "task-abs-1", &state);
+
+   char workdir[256];
+   snprintf(workdir, sizeof(workdir), "/tmp/aimee-docker-workdir-%d", (int)getpid());
+   char abs[512];
+
+   /* Read back a relative-written file via its ABSOLUTE in-workspace path. */
+   assert(b->write_file(b, state, "note.txt", "abs read\n") == 0);
+   snprintf(abs, sizeof(abs), "%s/note.txt", workdir);
+   char *content = NULL;
+   assert(b->read_file(b, state, abs, 0, 0, &content) == 0);
+   assert(content != NULL && strcmp(content, "abs read\n") == 0);
+   free(content);
+
+   /* Write via an ABSOLUTE in-workspace path, then read it back relatively. */
+   snprintf(abs, sizeof(abs), "%s/note2.txt", workdir);
+   assert(b->write_file(b, state, abs, "abs write\n") == 0);
+   content = NULL;
+   assert(b->read_file(b, state, "note2.txt", 0, 0, &content) == 0);
+   assert(content != NULL && strcmp(content, "abs write\n") == 0);
+   free(content);
+
+   /* An absolute path OUTSIDE the workspace root is still refused (no host escape),
+    * including a sibling that merely shares the workdir prefix. */
+   assert(b->write_file(b, state, "/tmp/outside-escape.txt", "x") == -1);
+   char sibling[320];
+   snprintf(sibling, sizeof(sibling), "%s-evil/x.txt", workdir);
+   assert(b->write_file(b, state, sibling, "x") == -1);
+
+   teardown_docker_fileio_state(b, state);
+   printf("  PASS: test_docker_absolute_in_workspace_path_accepted\n");
+}
+
 static void test_docker_path_validation_rejects_escapes(void)
 {
    delegate_backend_reset_for_test();
@@ -892,6 +936,7 @@ int main(void)
    test_docker_exec_set_cwd_prefixes_subsequent_calls();
    test_acquire_rejects_invalid_args();
    test_docker_write_then_read_roundtrip();
+   test_docker_absolute_in_workspace_path_accepted();
    test_docker_path_validation_rejects_escapes();
    test_docker_list_dir_returns_entries();
    test_docker_mounts_caller_workspace();


### PR DESCRIPTION
## Bug

`docker_resolve_in_workspace` rejected **every** absolute path (`if (rel[0]=='/') return -1;`) and only prepended `workdir` to relative ones. But the native file tools resolve to an **absolute** path via the thread cwd *before* calling the provider — `tool_read_file`/`tool_write_file`/`tool_list_files` hand the backend `/var/lib/aimee/wfe-worktrees/<slice>/docs/x`, not `docs/x`.

So for a **container delegate**, `read_file`/`write_file`/`list_files` on its own worktree all failed with `error: cannot open` / `error: cannot write` / `glob failed` — even though the file was right there. `bash` masked it: the shell tool runs a raw `cd '<cwd>' && <cmd>` that never reaches this resolver, so a delegate could `cat`/write via bash but not through the file tools. Combined with the worktree write-guard bug (#1964), this converged implement slices to zero-diff no-ops.

Found in the live `execution_trace`:
```
read_file  {"path":"docs/wfe-autonomy-runbook.md"} -> error: cannot open /var/lib/aimee/wfe-worktrees/wi_.../docs/...
```

## Fix

The slice worktree is bind-mounted **path-identically**, so an absolute path under the workspace root *is* the valid in-container path. Accept an absolute path when it's within `st->workdir` (with a boundary check so a sibling sharing the prefix — `<workdir>-evil/x` — doesn't match). Keep refusing absolute paths **outside** the workspace and any `..` segment, so the container still can't reach the host tree.

## Test

`test_docker_absolute_in_workspace_path_accepted`: an absolute in-workspace path round-trips through `read_file` and `write_file`; a path outside the workspace and a prefix-sharing sibling stay refused. Existing escape-rejection tests still pass.

This is the second of the two container-delegate routing bugs (with #1964, the worktree write-guard). Together they let HTTP delegates (MiniMax/kimi) actually write files in their sandbox.