### PR TITLE
Log which provider fails a list_files, not just "glob failed"

### DIFF
--- a/src/modules/tools/agent_tools.c
+++ b/src/modules/tools/agent_tools.c
@@ -1444,7 +1444,15 @@ char *tool_list_files(const char *path, const char *pattern)
    char **entries = NULL;
    int n = 0;
    if (ws->list(ws, actual_path, pattern, &entries, &n) != 0)
+   {
+      /* "glob failed" is opaque and list_files fails for container delegates while bash
+       * ls works — log which provider (0=shared 1=detached 2=mirror 3=container) and the
+       * exact path/pattern so the failing route is pinpointed, not guessed. */
+      LOG_WARN("agent-tools",
+               "list_files: provider list failed (ws_kind=%d path='%s' pattern='%s')",
+               (int)ws->kind, actual_path ? actual_path : "(null)", pattern ? pattern : "");
       return safe_strdup("error: glob failed");
+   }
    if (n == 0 && pattern && strncmp(pattern, "**/", 3) == 0)
    {
       ws_provider_free_list(entries, n);


### PR DESCRIPTION
`list_files` returns a bare `error: glob failed` whenever `workspace_provider_active()->list()` fails. For container delegates it fails **every** time, on every path, while `bash ls` on the same path works. The docker backend's `list_dir` diagnostic (added in #1971) **never fires** — proving `list_files` does **not** reach the container backend at all. Something upstream (the resolved provider or the path) is wrong, but the opaque message hides which.

Log the provider **kind** (`0=shared 1=detached 2=mirror 3=container`) and the exact resolved path + pattern at the failure point, so the misrouted list call is pinpointed on the next run instead of guessed. Log-only; no behaviour change.

Part of the container-delegate reliability series (#1964, #1966, #1971).