### PR TITLE
Accept in-workspace absolute paths in the local backend; log wsc_list failures

### DIFF
--- a/src/modules/delegates/delegate_backend_local.c
+++ b/src/modules/delegates/delegate_backend_local.c
@@ -377,11 +377,8 @@ static int resolve_in_workspace(const local_state_t *st, const char *rel, char *
 {
    if (!st || !rel || !out || outsz == 0)
       return -1;
-   if (rel[0] == '/')
-      return -1;
-   /* Walk the components, rejecting "..". Empty components ("//")
-    * are tolerated since `path/to/foo` and `path//to/foo` both
-    * resolve identically. */
+   /* Reject any parent-traversal segment (relative or absolute). Empty components
+    * ("//") are tolerated: `path/to/foo` and `path//to/foo` resolve identically. */
    const char *p = rel;
    while (*p)
    {
@@ -393,6 +390,22 @@ static int resolve_in_workspace(const local_state_t *st, const char *rel, char *
          return -1;
       if (*p == '/')
          p++;
+   }
+   if (rel[0] == '/')
+   {
+      /* The native file tools resolve to an ABSOLUTE path via the thread cwd before
+       * calling the provider. Accept it when it is within the workspace root (which the
+       * absolute path already names); refuse anything outside so the delegate cannot
+       * reach beyond its tree. Without this, read/write/list on an absolute in-workspace
+       * path is wrongly rejected — the same bug fixed for the docker backend. */
+      size_t wlen = strlen(st->workspace);
+      if (strncmp(rel, st->workspace, wlen) == 0 && (rel[wlen] == '/' || rel[wlen] == '\0'))
+      {
+         if (snprintf(out, outsz, "%s", rel) >= (int)outsz)
+            return -1;
+         return 0;
+      }
+      return -1;
    }
    if (snprintf(out, outsz, "%s/%s", st->workspace, rel) >= (int)outsz)
       return -1;

--- a/src/modules/workspace/workspace_provider_container.c
+++ b/src/modules/workspace/workspace_provider_container.c
@@ -219,11 +219,21 @@ static int wsc_list(const workspace_provider_t *p, const char *dir, const char *
       *count = 0;
    ws_container_provider_t *self = wsc_self(p);
    if (!self->backend || !self->backend->list_dir || !dir || !out || !count)
+   {
+      LOG_WARN("ws-container", "wsc_list guard fail: backend=%p list_dir=%p dir=%s",
+               (void *)(self ? self->backend : NULL),
+               (void *)(self && self->backend ? (void *)self->backend->list_dir : NULL),
+               dir ? dir : "(null)");
       return -1;
+   }
 
    char **entries = NULL;
-   if (self->backend->list_dir(self->backend, self->state, dir, &entries) != 0)
+   int lrc = self->backend->list_dir(self->backend, self->state, dir, &entries);
+   if (lrc != 0)
+   {
+      LOG_WARN("ws-container", "wsc_list: backend list_dir('%s') rc=%d", dir, lrc);
       return -1;
+   }
    if (!entries)
    {
       *count = 0;


### PR DESCRIPTION
Two container-delegate list/file-op fixes, from tracing `list_files` failing while `bash ls` works.

## 1. local backend absolute-path resolve (fix)
`delegate_backend_local`'s `resolve_in_workspace` rejected **every** absolute path (`rel[0]=='/' -> -1`) — the identical bug fixed for the docker backend in #1966. The native file tools hand the backend an absolute in-workspace path (resolved via the thread cwd), so `read`/`write`/`list_dir` on a local-backend delegate fail on its own tree. Accept an absolute path within `st->workspace` (bounded so a prefix-sharing sibling doesn't match); keep refusing outside paths and any `..`.

## 2. `wsc_list` failure logging (diagnostic)
`ws_kind` logging (#1973) proved the active provider for the failing `list_files` is the **container** (kind 3), whose backend is docker — yet the docker `list_dir` diagnostic (#1971) never fires. So `wsc_list` returns before calling `list_dir`, but which branch is invisible. Log the guard pointers (`backend`/`list_dir`) and the backend `list_dir` return code, so the exact failure point is named. Once this deploys + runs, the `list_files` root cause is pinpointed and gets its final fix.

Server + build clean; clang-format clean.