### PR TITLE
Fix list_files: wsc_list mis-read the backend entry COUNT as an error

### DIFF
--- a/src/modules/workspace/workspace_provider_container.c
+++ b/src/modules/workspace/workspace_provider_container.c
@@ -219,21 +219,16 @@ static int wsc_list(const workspace_provider_t *p, const char *dir, const char *
       *count = 0;
    ws_container_provider_t *self = wsc_self(p);
    if (!self->backend || !self->backend->list_dir || !dir || !out || !count)
-   {
-      LOG_WARN("ws-container", "wsc_list guard fail: backend=%p list_dir=%p dir=%s",
-               (void *)(self ? self->backend : NULL),
-               (void *)(self && self->backend ? (void *)self->backend->list_dir : NULL),
-               dir ? dir : "(null)");
       return -1;
-   }
 
    char **entries = NULL;
-   int lrc = self->backend->list_dir(self->backend, self->state, dir, &entries);
-   if (lrc != 0)
-   {
-      LOG_WARN("ws-container", "wsc_list: backend list_dir('%s') rc=%d", dir, lrc);
+   /* The backend's list_dir returns the ENTRY COUNT on success (>= 0) and a negative
+    * value on failure — NOT 0/non-zero (see docker_list_dir/local_list_dir `return i`,
+    * and the backend test asserting `list_dir(...) >= 2`). Treating any non-zero as
+    * failure rejected every NON-EMPTY directory as "glob failed", so list_files worked
+    * only on empty dirs; the real count is taken from the NUL-terminated entries below. */
+   if (self->backend->list_dir(self->backend, self->state, dir, &entries) < 0)
       return -1;
-   }
    if (!entries)
    {
       *count = 0;

--- a/src/tests/test_workspace_provider_container.c
+++ b/src/tests/test_workspace_provider_container.c
@@ -88,7 +88,10 @@ static int fake_list_dir(delegate_backend_t *self, void *state, const char *path
    e[2] = safe_strdup("util.c");
    e[3] = NULL;
    *out = e;
-   return 0;
+   /* Match the real backends (docker_list_dir/local_list_dir): list_dir returns the
+    * ENTRY COUNT on success, not 0. Returning 0 here masked the wsc_list bug that read
+    * any non-zero as failure, so every non-empty directory listing was rejected. */
+   return 3;
 }
 
 static delegate_backend_t g_fake = {.name = "fake",


### PR DESCRIPTION
## Root cause (found via layered diagnostics #1971 → #1973 → #1975)

The container workspace provider's `list()` treated **any non-zero** return from the backend's `list_dir` as failure:
```c
if (self->backend->list_dir(...) != 0) return -1;
```
But `list_dir` returns the **ENTRY COUNT** on success (>= 0) and negative on failure — `docker_list_dir`/`local_list_dir` both `return i`, and the backend test asserts `list_dir(...) >= 2`. So every **non-empty** directory (count > 0) was read as an error → `error: glob failed`, while an **empty** directory (count 0) "worked".

The `wsc_list` diagnostic (#1975) proved it live:
```
wsc_list: backend list_dir('.../docs') rc=52    # 52 = entry count, not an error
wsc_list: backend list_dir('.../.')    rc=61    # 61 = entry count
```

## Impact

Container delegates' `list_files` failed on **every real directory**, so an implement delegate couldn't enumerate its own tree with the file tool and had to fall back to `bash ls`. `read_file` was unaffected because it returns `0/-1` (so `wsc_read_all`'s `!= 0` is correct); only `list_dir` uses a count return, so only `list()` was wrong.

## Fix

Check `< 0` instead of `!= 0`. The real count is already derived from the NUL-terminated entries array, so the return value is only a success/failure signal here.

## Test

The provider test's `fake_list_dir` returned `0` with 3 entries — an unrealistic stub that masked the bug. Made it return the count like the real backends; now `test_list_globs_and_stat` **fails on the old `!= 0`** (verified: `Assertion 'p->list(...) == 0' failed`) and **passes on `< 0`**.

Final fix in the container-delegate reliability series (#1964, #1966, #1971, #1975). Retires the diagnostics' purpose.