### PR TITLE
fix(e2e): enroll via rotate_bearer in local-stack harness (T5/T6 false-negative)

### DIFF
--- a/scripts/aimee-local-stack-e2e.sh
+++ b/scripts/aimee-local-stack-e2e.sh
@@ -128,16 +128,34 @@ bold "==> Starting aimee-server"
 "$REPO/aimee-server" --socket="$AIMEE_HOME/aimee-server.sock" &
 server_pid=$!
 
-bold "==> Waiting up to ${WAIT_SECONDS}s for server /v1/health"
+# The listener binds with the seeded bootstrap bearer (aimee-local-dev), which by
+# design authorizes ONLY POST /v1/api/rotate_bearer until it is rotated to a strong
+# per-deployment token (see AIMEE_BOOTSTRAP_BEARER in src/modules/config/config.h) —
+# so a plain /v1/health poll with the bootstrap bearer 401s forever. Enroll exactly
+# as the thin client does: poll rotate_bearer (which also confirms the server is
+# serving), then use the minted bearer for every subsequent request.
+bold "==> Enrolling: rotate bootstrap bearer (waits up to ${WAIT_SECONDS}s for server)"
 deadline=$((SECONDS + WAIT_SECONDS))
+rotated=""
 while true; do
-  if curl -fsS --max-time 3 "${AUTH[@]}" "${SERVER_URL}/v1/health" >/dev/null 2>&1; then
-    green "    server is up"; break
+  resp="$(curl -fsS --max-time 3 "${AUTH[@]}" -X POST "${SERVER_URL}/v1/api/rotate_bearer" 2>/dev/null || true)"
+  if [[ "$resp" == *'"bearer_token"'* ]]; then
+    rotated="$(sed -n 's/.*"bearer_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' <<<"$resp")"
+    [[ -n "$rotated" ]] && { green "    enrolled: rotated to a per-deployment bearer"; break; }
   fi
   if ! kill -0 "$server_pid" 2>/dev/null; then red "    aimee-server exited during startup"; exit 1; fi
-  if (( SECONDS >= deadline )); then red "    server did not come up within ${WAIT_SECONDS}s"; exit 1; fi
+  if (( SECONDS >= deadline )); then red "    server did not come up / rotate within ${WAIT_SECONDS}s"; exit 1; fi
   sleep 2
 done
+BEARER="$rotated"
+AUTH=(-H "Authorization: Bearer ${BEARER}")
+
+bold "==> Waiting for /v1/health"
+if curl -fsS --max-time 5 "${AUTH[@]}" "${SERVER_URL}/v1/health" >/dev/null 2>&1; then
+  green "    server is up"
+else
+  red "    server up but /v1/health failed with rotated bearer"; exit 1
+fi
 
 bold "==> Core contract"
 check "GET /v1/health"  '"service":"aimee-server"' "${SERVER_URL}/v1/health"


### PR DESCRIPTION
## Problem
`scripts/aimee-local-stack-e2e.sh` (the T5/T6 local-stack e2e, invoked by `e2e-matrix.sh` with no `BEARER` override) seeded the server with the well-known **bootstrap** bearer `aimee-local-dev`, then polled `/v1/health` with that same token. By design the server refuses every TCP `/v1` route **except** `POST /v1/api/rotate_bearer` while the live bearer still equals the bootstrap value (`AIMEE_BOOTSTRAP_BEARER`, `src/modules/config/config.h`). So health returned **401 forever** → the harness always died with `server did not come up within Ns`.

This is a **pre-existing harness bug** — the bootstrap-refuse gate predates the core-modularization merge (#1950), so it is **not** a regression from it. It surfaced during an overnight e2e cycle on the dedicated CT.

## Fix
Enroll exactly as the thin client does: after starting the server, poll `POST /v1/api/rotate_bearer` (the one route the bootstrap token may call, which also confirms the listener is serving), capture the minted per-deployment bearer, and use it for all subsequent requests. The write→read child already receives `BEARER`, so it inherits the rotated token.

## Validation (dedicated e2e CT, testing @ 44320e3e)
```
==> Enrolling: rotate bootstrap bearer ...
    enrolled: rotated to a per-deployment bearer
    server is up
  PASS  GET /v1/health
  PASS  GET /v1/version
  PASS  GET /v1/kb/status -> vector
  PASS  POST /v1/kb/search -> hits
  PASS  store accepted
  PASS  list returns the stored content (round-trip persisted)
  PASS  keyword search surfaces the stored fact
==> Summary (full): 5 passed, 0 failed    (exit 0)
```
Scope: test harness only (`scripts/aimee-local-stack-e2e.sh`); no product code changed.