### PR TITLE
Fix foreach ff-merge: merge FETCH_HEAD, not the never-created origin/<branch>

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1039,8 +1039,17 @@ func (r *NativeRunner) foreach(ctx context.Context, req StepRequest) (StepResult
 	if err != nil {
 		return StepResult{}, err
 	}
-	_, _ = gitText(ctx, workdir, "fetch", "origin", branch)
-	if _, err := gitText(ctx, workdir, "merge", "--ff-only", "origin/"+branch); err != nil {
+	// Fetch the feature branch and ff-merge what the fetch retrieved. `git fetch
+	// origin <branch>` with an explicit refspec updates ONLY FETCH_HEAD, not the
+	// refs/remotes/origin/<branch> tracking ref — so merging "origin/<branch>" fails
+	// with "not something we can merge" the first time this branch is fetched here
+	// (the tracking ref never existed). Merge FETCH_HEAD, which the fetch just set to
+	// the remote tip. This step is only reached once every slice has merged its sub-PR
+	// into the feature branch, so FETCH_HEAD is exactly the assembled feature tip.
+	if _, err := gitText(ctx, workdir, "fetch", "origin", branch); err != nil {
+		return StepResult{}, err
+	}
+	if _, err := gitText(ctx, workdir, "merge", "--ff-only", "FETCH_HEAD"); err != nil {
 		return StepResult{}, err
 	}
 	return StepResult{Status: StepAdvanced, ArtifactType: "branch", Artifact: branch, ContentHash: wfe.Hash([]byte(branch))}, nil


### PR DESCRIPTION
## Bug

After every slice merges its sub-PR into the run's feature branch, the `foreach` block reassembles that branch into the run worktree:
```
git fetch origin <branch>
git merge --ff-only origin/<branch>
```
But `git fetch origin <branch>` with an **explicit refspec** updates only **FETCH_HEAD** — it does **not** create/advance `refs/remotes/origin/<branch>`. So the first time a run reaches this step, `origin/<branch>` doesn't exist and the merge fails with `not something we can merge`, parking the run at `slices/delegate_failed` with the finished feature branch unmerged.

It went unnoticed because **no run had ever gotten a slice to fully merge before** — every earlier run died at impl (the container-delegate write bugs). This was the very next wall once a real slice completed and produced sub-PR #1978.

Reproduced live in the run's worktree:
```
git merge --ff-only origin/aimee/feat/<run>  → merge: ... - not something we can merge
git merge --ff-only FETCH_HEAD               → Updating c297bcfe..1a2471ac  Fast-forward
```

## Fix

Merge `FETCH_HEAD` — the preceding fetch just set it to the remote feature tip, exactly the assembled branch to fast-forward onto. Also stop ignoring the fetch error, so a failed fetch parks with a clear reason.

Verified: `TestNativeSchedulerDrivesConfiguredBuildThroughSliceToFinalPR` + the full engine suite pass; `gofmt` clean.