### PR TITLE
fix(e2e): surface embedder degradation + drop stale MiniLM 384-dim docstring

### DIFF
--- a/scripts/aimee-local-stack-e2e.sh
+++ b/scripts/aimee-local-stack-e2e.sh
@@ -49,9 +49,10 @@ done
 cd "$(dirname "$0")/.."
 REPO="$(pwd)"
 
-red()   { printf '\033[31m%s\033[0m\n' "$*"; }
-green() { printf '\033[32m%s\033[0m\n' "$*"; }
-bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
 
 SERVER_URL="http://127.0.0.1:${SERVER_PORT}"
 AUTH=(-H "Authorization: Bearer ${BEARER}")
@@ -108,7 +109,9 @@ if [[ "$MODE" == "full" ]]; then
   [[ -n "${AIMEE_EMBEDDER_URL:-}" ]] && export AIMEE_EMBEDDER_URL
   export AIMEE_KB_HTTP_BIND=1
   echo "    DB2: ${AIMEE_DB2_URL}"
-  "$REPO/aimee-kb" --http-port=8741 &
+  # Capture kb output so the embedder-fidelity gate below can see whether pgvec
+  # accepted the memory vectors or refused them on a dim mismatch.
+  "$REPO/aimee-kb" --http-port=8741 >"$AIMEE_HOME/kb.log" 2>&1 &
   kb_pid=$!
   export AIMEE_KB_API_URL="http://127.0.0.1:8741"
 elif [[ "$MODE" == "hybrid" ]]; then
@@ -172,6 +175,28 @@ if SERVER_URL="$SERVER_URL" BEARER="$BEARER" "$REPO/scripts/aimee-write-read-e2e
   green "  PASS  write→read round-trip"; PASS=$((PASS + 1))
 else
   red   "  FAIL  write→read round-trip"; FAIL=$((FAIL + 1))
+fi
+
+# Embedder fidelity: the round-trip above passes on list + KEYWORD retrieval even
+# when no real embedder is wired — the memory embedding silently falls back to the
+# builtin hash (a vestigial 384-d stand-in) whose vectors pgvec then REFUSES on a
+# dim mismatch against a corpus built by the real embedder (Qwen3-Embedding: 1024-d
+# CPU / 2560-d GPU). That makes the semantic/vector path a no-op while the run still
+# reports green. Surface it: if kb refused the memory vector, the semantic path was
+# NOT exercised — announce it loudly, and hard-fail under AIMEE_E2E_REQUIRE_REAL_EMBEDDER=1.
+bold "==> Embedder fidelity (semantic vector path)"
+mm="$(grep -aoE 'memory embedding dim mismatch: got [0-9]+, expected [0-9]+' "$AIMEE_HOME/kb.log" 2>/dev/null | tail -1 || true)"
+if [[ -n "$mm" ]]; then
+  yellow "  DEGRADED  ${mm}; vectors refused — semantic search NOT exercised (list/keyword only)."
+  yellow "            Wire a real embedder: point AIMEE_EMBEDDER_URL / AIMEE_LLM_URL at a"
+  yellow "            Qwen3-Embedding endpoint whose dim matches the corpus (1024 CPU / 2560 GPU)."
+  if [[ "${AIMEE_E2E_REQUIRE_REAL_EMBEDDER:-0}" == "1" ]]; then
+    red "  FAIL  real embedder required (AIMEE_E2E_REQUIRE_REAL_EMBEDDER=1) but the run degraded to the builtin embedder"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  green "  PASS  memory vectors accepted (no dim mismatch) — real semantic path exercised"
+  PASS=$((PASS + 1))
 fi
 
 echo

--- a/scripts/embed-remote.py
+++ b/scripts/embed-remote.py
@@ -8,7 +8,10 @@ container. Stdlib only — no torch in the kb image.
 
 Contract (platform_exec_pipe in src/memory_core_scope_embed.inc):
   stdin:  raw UTF-8 text
-  stdout: JSON float array  [0.123, -0.456, ...]  (384-dim, L2-normalised)
+  stdout: JSON float array  [0.123, -0.456, ...]  (L2-normalised). The dimension
+          is whatever the pinned embedder emits — 1024 for the default CPU tier
+          (Qwen3-Embedding-0.6B), 2560 for the 4B GPU tier — NOT a fixed size;
+          probe it with `--dim`.
   exit 0 on success; non-zero on error (C caller logs a warning and skips)
 
 Config (env), in precedence order:


### PR DESCRIPTION
**Stacked on #1979** (base = `fix/local-stack-e2e-bootstrap-bearer`; retarget to `testing` once #1979 merges).

## Problem
The T5/T6 write→read round-trip asserts store + list + **keyword** retrieval — all of which pass even when **no real embedder is wired**. In that case memory embedding falls back to the **builtin hash** (a vestigial **384-d** stand-in from the deprecated all-MiniLM-L6-v2 era), and pgvec then **refuses** those vectors on a dim mismatch against a corpus built by the real embedder (**Qwen3-Embedding**: 1024-d CPU / 2560-d GPU, via the unified aimee-llm container). So the semantic vector path was a **silent no-op** while the run reported green. Surfaced during the overnight e2e cycle (`got 384, expected 1024; refusing upsert`).

## Fix
1. **Embedder-fidelity gate** in `aimee-local-stack-e2e.sh`: after the round-trip, inspect the kb log for `memory embedding dim mismatch … refusing upsert`.
   - Vectors refused → loud **DEGRADED** banner (semantic search not exercised; list/keyword only), and **hard-fail under `AIMEE_E2E_REQUIRE_REAL_EMBEDDER=1`**.
   - No mismatch → assert the real semantic path was exercised.
   - kb output redirected to a log so the gate can read it.
2. **Docstring** in `embed-remote.py`: drop the stale `(384-dim)` output claim (MiniLM-era leftover). The output dim is embedder-defined now (1024 CPU / 2560 GPU), probed via `--dim`.

## Validation (dedicated e2e CT, testing)
| Run | Result |
|---|---|
| default | `DEGRADED` banner, **5 passed / 0 failed**, exit 0 |
| `AIMEE_E2E_REQUIRE_REAL_EMBEDDER=1` | `DEGRADED` + `FAIL`, **5 passed / 1 failed**, exit 1 |

Test harness + docstring only; no product code changed.

## Related staleness (not fixed here — flagging for an owner)
`scripts/embedder-server.py` and `compose*.yaml` still default `EMBEDDER_MODEL` to `pplx-embed-v1-*`, the pre-unified-llm-cutover torch sidecar. Per `docs/runbooks/unified-llm-cutover.md` the shipping embed path is now Qwen3-Embedding via llama-server. Worth a separate reconciliation.