### PR TITLE
feat(e2e): small real Qwen3-Embedding-0.6B test embedder (opt-in)

### DIFF
--- a/scripts/_embed_shim.py
+++ b/scripts/_embed_shim.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""_embed_shim.py: stdlib-only adapter that exposes aimee's embedder contract
+(POST /embed with raw UTF-8 text -> bare JSON float array; POST /embed_batch
+with a JSON array of strings -> JSON array of vectors; GET /health) in front of a
+llama.cpp `llama-server --embeddings` instance speaking the OpenAI
+/v1/embeddings API. Used by scripts/test-embedder-qwen.sh to give the local-stack
+e2e a real, small Qwen3-Embedding-0.6B (1024-d) embedder without torch/pip.
+
+Usage: _embed_shim.py <llama_port> <shim_port> <dim> [model_label]
+"""
+import json
+import sys
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+LLAMA_PORT = int(sys.argv[1])
+SHIM_PORT = int(sys.argv[2])
+DIM = int(sys.argv[3])
+MODEL = sys.argv[4] if len(sys.argv) > 4 else "Qwen3-Embedding-0.6B"
+
+
+def _embed_one(text):
+    """POST a single string to llama-server /v1/embeddings, return its vector."""
+    payload = json.dumps({"input": text, "model": MODEL}).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{LLAMA_PORT}/v1/embeddings",
+        data=payload,
+        headers={"content-type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        doc = json.load(r)
+    return doc["data"][0]["embedding"]
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._send(200, {"status": "ok", "dim": DIM, "model": MODEL})
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length", 0))
+        raw = self.rfile.read(n).decode("utf-8", "replace")
+        try:
+            if self.path == "/embed":
+                self._send(200, _embed_one(raw))
+            elif self.path == "/embed_batch":
+                texts = json.loads(raw)
+                self._send(200, [_embed_one(t) for t in texts])
+            else:
+                self._send(404, {"error": "not found"})
+        except Exception as exc:  # surface upstream failures as 502, not a hang
+            self._send(502, {"error": str(exc)})
+
+    def log_message(self, *args):
+        pass
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("127.0.0.1", SHIM_PORT), Handler).serve_forever()

--- a/scripts/aimee-local-stack-e2e.sh
+++ b/scripts/aimee-local-stack-e2e.sh
@@ -89,6 +89,27 @@ sed "s/8740/${SERVER_PORT}/; s/aimee-local-dev/${BEARER}/; s/remote_writes: \"of
 # scripts/ so the kb can actually popen embed-remote.py etc.
 sed "s#/opt/aimee/scripts/#${REPO}/scripts/#g" \
     deploy/container/aimee.yaml > "$AIMEE_HOME/.config/aimee/aimee.yaml"
+# Optional: point memory embedding at a REAL small embedder so the semantic
+# vector path is actually exercised (see scripts/test-embedder-qwen.sh, which
+# serves Qwen3-Embedding-0.6B at 1024-d). Without this the kb falls back to the
+# builtin hash and the embedder-fidelity gate below reports DEGRADED. An http(s)
+# URL is used directly (aimee POSTs raw text to {url}/embed).
+if [[ -n "${AIMEE_E2E_EMBEDDER_URL:-}" ]]; then
+  bold "==> Using real embedder for memory: ${AIMEE_E2E_EMBEDDER_URL} (dim=${AIMEE_EMBEDDING_DIM:-unset})"
+  # The SERVER forwards its own embedding_command to the kb on memory.store /
+  # memory search (server/server_api.c); the kb also reads its own for direct
+  # embedding. Set it in BOTH configs (replace an existing line, else append).
+  set_embed_cmd() {  # $1 = config file
+    if grep -qE '^embedding_command:' "$1"; then
+      sed -i "s#^embedding_command:.*#embedding_command: \"${AIMEE_E2E_EMBEDDER_URL}\"#" "$1"
+    else
+      printf '\nembedding_command: "%s"\n' "${AIMEE_E2E_EMBEDDER_URL}" >> "$1"
+    fi
+  }
+  set_embed_cmd "$AIMEE_HOME/aimee.yaml"                     # server config
+  set_embed_cmd "$AIMEE_HOME/.config/aimee/aimee.yaml"      # kb config
+  [[ -n "${AIMEE_EMBEDDING_DIM:-}" ]] && export AIMEE_EMBEDDING_DIM
+fi
 export AIMEE_SERVER_HTTP_BIND=1
 export AIMEE_DB1_URL="sqlite://${AIMEE_HOME}/aimee.db"
 

--- a/scripts/test-embedder-qwen.sh
+++ b/scripts/test-embedder-qwen.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test-embedder-qwen.sh — stand up a small, REAL Qwen3-Embedding-0.6B (1024-d)
+# embedder for e2e testing, exposing aimee's embedder contract (POST /embed with
+# raw text -> bare JSON float array). It runs llama.cpp `llama-server` on the GGUF
+# and fronts it with scripts/_embed_shim.py (stdlib only — no torch, no pip).
+#
+# Why a real model and not the deterministic EMBEDDER_STUB: the stub proves the
+# kb -> embedder -> pgvector wiring at the right dim but produces meaningless
+# vectors, so it can't catch a semantic-retrieval regression. A small Qwen3
+# embedder gives genuine 1024-d vectors cheaply (matches the CPU-default corpus).
+#
+# On success prints two lines to stdout (consumed by callers), then blocks:
+#   EMBEDDER_URL=http://127.0.0.1:<shim_port>
+#   EMBEDDER_DIM=1024
+# It keeps llama-server + the shim running until it receives SIGINT/SIGTERM.
+#
+# Env:
+#   AIMEE_E2E_EMBEDDER_CACHE  cache dir for the binary + GGUF (default ~/.cache/aimee-e2e-embedder)
+#   LLAMA_PORT                llama-server port (default 8899)
+#   SHIM_PORT                 /embed shim port (default 8080)
+#   READY_TIMEOUT             seconds to wait for the model to load (default 180)
+set -euo pipefail
+
+CACHE="${AIMEE_E2E_EMBEDDER_CACHE:-$HOME/.cache/aimee-e2e-embedder}"
+LLAMA_PORT="${LLAMA_PORT:-8899}"
+SHIM_PORT="${SHIM_PORT:-8080}"
+READY_TIMEOUT="${READY_TIMEOUT:-180}"
+GGUF_REPO="Qwen/Qwen3-Embedding-0.6B-GGUF"
+GGUF_FILE="Qwen3-Embedding-0.6B-Q8_0.gguf"
+DIM=1024
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+log() { printf '[qwen-embedder] %s\n' "$*" >&2; }
+
+mkdir -p "$CACHE"
+
+# --- 1) llama-server binary (prebuilt ubuntu-x64 release; static, no pip) ------
+LLAMA_BIN="$(find "$CACHE" -name llama-server -type f 2>/dev/null | head -1 || true)"
+if [[ -z "$LLAMA_BIN" ]]; then
+  log "fetching llama.cpp ubuntu-x64 (CPU) release"
+  # The plain CPU asset is llama-<tag>-bin-ubuntu-x64.tar.gz; the vulkan/rocm/sycl/
+  # openvino variants carry an extra token (ubuntu-vulkan-x64, ...) so anchoring on
+  # '-bin-ubuntu-x64.tar.gz' selects the CPU build uniquely.
+  url="$(curl -fsSL https://api.github.com/repos/ggml-org/llama.cpp/releases/latest \
+        | grep -oE 'https://[^"]*-bin-ubuntu-x64\.tar\.gz' | head -1)"
+  [[ -n "$url" ]] || { log "could not resolve a llama.cpp CPU release URL"; exit 1; }
+  log "url=$url"
+  curl -fsSL -o "$CACHE/llama.tar.gz" "$url"
+  rm -rf "$CACHE/llama" && mkdir -p "$CACHE/llama"
+  tar -xzf "$CACHE/llama.tar.gz" -C "$CACHE/llama"
+  LLAMA_BIN="$(find "$CACHE/llama" -name llama-server -type f | head -1)"
+  [[ -n "$LLAMA_BIN" ]] || { log "llama-server not found in release tarball"; exit 1; }
+fi
+LLAMA_LIBDIR="$(dirname "$LLAMA_BIN")"
+log "llama-server: $LLAMA_BIN"
+
+# --- 2) GGUF (small, cached) ---------------------------------------------------
+if [[ ! -f "$CACHE/$GGUF_FILE" ]]; then
+  log "downloading $GGUF_FILE (~610MB, one-time)"
+  curl -fsSL -o "$CACHE/$GGUF_FILE.part" \
+       "https://huggingface.co/$GGUF_REPO/resolve/main/$GGUF_FILE"
+  mv "$CACHE/$GGUF_FILE.part" "$CACHE/$GGUF_FILE"
+fi
+
+# --- 3) launch llama-server (embeddings) + shim, tear both down on exit --------
+llama_pid=""; shim_pid=""
+cleanup() { [[ -n "$shim_pid" ]] && kill "$shim_pid" 2>/dev/null || true
+            [[ -n "$llama_pid" ]] && kill "$llama_pid" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+log "starting llama-server on :$LLAMA_PORT"
+LD_LIBRARY_PATH="$LLAMA_LIBDIR:${LD_LIBRARY_PATH:-}" "$LLAMA_BIN" \
+  -m "$CACHE/$GGUF_FILE" --embeddings --pooling last \
+  --host 127.0.0.1 --port "$LLAMA_PORT" --ctx-size 8192 -ub 8192 \
+  >"$CACHE/llama-server.log" 2>&1 &
+llama_pid=$!
+
+deadline=$((SECONDS + READY_TIMEOUT))
+until curl -fsS --max-time 3 "http://127.0.0.1:$LLAMA_PORT/health" >/dev/null 2>&1; do
+  kill -0 "$llama_pid" 2>/dev/null || { log "llama-server exited early:"; tail -5 "$CACHE/llama-server.log" >&2; exit 1; }
+  (( SECONDS < deadline )) || { log "llama-server not ready within ${READY_TIMEOUT}s"; exit 1; }
+  sleep 2
+done
+log "llama-server ready"
+
+log "starting /embed shim on :$SHIM_PORT"
+python3 "$HERE/_embed_shim.py" "$LLAMA_PORT" "$SHIM_PORT" "$DIM" "Qwen3-Embedding-0.6B" &
+shim_pid=$!
+until curl -fsS --max-time 3 "http://127.0.0.1:$SHIM_PORT/health" >/dev/null 2>&1; do
+  kill -0 "$shim_pid" 2>/dev/null || { log "shim exited early"; exit 1; }
+  (( SECONDS < deadline )) || { log "shim not ready"; exit 1; }
+  sleep 1
+done
+
+echo "EMBEDDER_URL=http://127.0.0.1:$SHIM_PORT"
+echo "EMBEDDER_DIM=$DIM"
+log "ready: real Qwen3-Embedding-0.6B (${DIM}-d) at http://127.0.0.1:$SHIM_PORT/embed"
+wait "$llama_pid"


### PR DESCRIPTION
**Stacked on #1982** (base = `fix/e2e-embedder-honesty`; retarget up the chain as #1979/#1982 land).

Realizes: *for testing, use a very small real qwen3-embedder* rather than the 384-d builtin hash or a meaningless deterministic stub.

## What
- **`scripts/test-embedder-qwen.sh`** — fetches a prebuilt llama.cpp `llama-server` + **Qwen3-Embedding-0.6B GGUF** (Q8_0, 1024-d, ~610MB, cached under `~/.cache/aimee-e2e-embedder`) and serves it. No torch, no pip — stdlib only.
- **`scripts/_embed_shim.py`** — stdlib adapter exposing aimee's embedder contract (`POST /embed` raw text → bare JSON float array, `/embed_batch`, `/health`) in front of llama-server's OpenAI `/v1/embeddings`.
- **`aimee-local-stack-e2e.sh`** — opt-in `AIMEE_E2E_EMBEDDER_URL` sets `embedding_command` in **both** the server and kb configs. The server forwards its own `embedding_command` to the kb on `memory.store`/search (`server/server_api.c`), so memory is embedded by the real model. With it set, the embedder-fidelity gate (#1982) flips DEGRADED → PASS.

## Why a real model, not the stub
`EMBEDDER_STUB` proves the kb→embedder→pgvector wiring at the right dim but emits meaningless vectors — it can't catch a semantic-retrieval regression. Qwen3-Embedding-0.6B is the smallest real model in the shipping family and matches the CPU-default corpus dim (1024).

## Validation (dedicated e2e CT)
- `test-embedder-qwen.sh`: downloads llama.cpp b10107 + GGUF, `/health`→`{dim:1024}`, `/embed`→1024-d vector.
- Local-stack run with `AIMEE_E2E_EMBEDDER_URL=http://127.0.0.1:8080`: **`PASS memory vectors accepted (no dim mismatch) — real semantic path exercised`**, Summary (full) **6 passed / 0 failed**, exit 0.

Opt-in — default runs are unchanged (still show the DEGRADED banner). Test tooling only; no product code.

## Follow-up (not decided here)
Where the binary+GGUF live in CI (download-on-demand vs baked image vs cached artifact) is a caching-policy call for an owner — this PR only makes the capability available.