### PR TITLE
Fix fanout wedge: scope packet identity to the fanout generation

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1004,7 +1004,14 @@ func (r *NativeRunner) foreach(ctx context.Context, req StepRequest) (StepResult
 			r.rollbackChildren(ctx, created)
 			return StepResult{}, err
 		}
-		if err := r.db.CreateWorkItem(ctx, db1.CreateWorkItem{ID: id, Repo: req.WorkItem.Repo, ProposalPath: "packet:" + wfe.Hash(packet), WorkflowName: childName, WorkflowVersion: definition.Version, StartStage: start, Mode: "autonomous", ParentID: req.WorkItem.ID}); err != nil {
+		// The child id already carries the fanout generation and is unique, so
+		// deriving the identity from it keeps UNIQUE(repo, proposal_path)
+		// satisfied when refinement regenerates byte-identical packet content.
+		// Keying on the packet hash alone collided with the prior generation's
+		// row and wedged the parent in slices. The content hash stays appended
+		// for operator diagnosis. Same-generation retries still deduplicate on
+		// the id above, before this insert is reached.
+		if err := r.db.CreateWorkItem(ctx, db1.CreateWorkItem{ID: id, Repo: req.WorkItem.Repo, ProposalPath: "packet:" + id + ":" + wfe.Hash(packet), WorkflowName: childName, WorkflowVersion: definition.Version, StartStage: start, Mode: "autonomous", ParentID: req.WorkItem.ID}); err != nil {
 			r.rollbackChildren(ctx, created)
 			return StepResult{}, err
 		}

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1231,3 +1231,108 @@ func TestRoundtableSkipsReviewWhenArtifactIsUnchanged(t *testing.T) {
 		t.Fatalf("prior findings not re-served: %+v", result.Feedback)
 	}
 }
+
+// A refinement loop regenerates byte-identical packets. The fanout generation
+// in the child id makes those children distinct rows, so the packet identity
+// recorded alongside them must be generation-scoped too. Keying it on the
+// packet hash alone violated UNIQUE(repo, proposal_path) against the previous
+// generation, which surfaced as a permanent runner_unavailable park.
+func TestForeachRespawnsIdenticalPacketsInALaterGeneration(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	child := []byte("name: slice\nstart: impl\nnodes:\n  - id: impl\n    block: author.proposal\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "slice.yaml"), child, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registry, err := wfe.NewRegistry(workflowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const parentID = "wi_parent"
+	if err := artifacts.PutProposal(parentID, []byte("build the feature")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateWorkItem(t.Context(), db1.CreateWorkItem{
+		ID: parentID, Repo: "repo", ProposalPath: "proposal.md", WorkflowName: "build-e2e",
+		StartStage: "slices", Mode: "autonomous",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
+	packets := wfe.Artifact{Type: "packets", Content: []byte(
+		`{"packets":[{"packet_id":"p1","summary":"implement","target_blocks":["implement"]}]}`)}
+	packets.Hash = wfe.Hash(packets.Content)
+	parent, err := store.WorkItem(t.Context(), parentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := StepRequest{
+		WorkItem: parent,
+		Node:     wfe.Node{ID: "slices", Block: "foreach.workflow", Params: map[string]any{"workflow": "slice"}},
+		Inputs:   map[string]wfe.Artifact{"packets": packets},
+	}
+
+	result, err := runner.foreach(t.Context(), request)
+	if err != nil {
+		t.Fatalf("first fanout: %v", err)
+	}
+	if result.Status != StepPending || result.PauseReason != "slices_running" {
+		t.Fatalf("first fanout status=%q reason=%q, want pending/slices_running", result.Status, result.PauseReason)
+	}
+	firstGeneration := childIDs(t, store, parentID)
+	if len(firstGeneration) != 1 {
+		t.Fatalf("first fanout spawned %d children, want 1", len(firstGeneration))
+	}
+
+	// Same generation, identical packets: the id dedup must hold, with no
+	// second row and no constraint failure.
+	if _, err := runner.foreach(t.Context(), request); err != nil {
+		t.Fatalf("same-generation retry: %v", err)
+	}
+	if ids := childIDs(t, store, parentID); len(ids) != 1 {
+		t.Fatalf("same-generation retry spawned duplicates: %v", ids)
+	}
+
+	// A gate loop advances the fanout generation; the packets are unchanged.
+	if err := store.Move(t.Context(), parentID, "slices", "slices", "loop", "requested_changes", "", 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.foreach(t.Context(), request); err != nil {
+		t.Fatalf("identical packets in a later generation must respawn, got: %v", err)
+	}
+	secondGeneration := childIDs(t, store, parentID)
+	if len(secondGeneration) != 2 {
+		t.Fatalf("later generation produced %d children total, want 2: %v", len(secondGeneration), secondGeneration)
+	}
+	if secondGeneration[0] == secondGeneration[1] {
+		t.Fatalf("generations collided on one id: %v", secondGeneration)
+	}
+	if !strings.Contains(secondGeneration[0], ".g0.") || !strings.Contains(secondGeneration[1], ".g1.") {
+		t.Fatalf("children are not generation-scoped: %v", secondGeneration)
+	}
+}
+
+func childIDs(t *testing.T, store *db1.Store, parentID string) []string {
+	t.Helper()
+	children, err := store.Children(t.Context(), parentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 0, len(children))
+	for _, c := range children {
+		ids = append(ids, c.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
Every build-e2e work item on the appliance today died in the slices stage
and had to be operator-stopped. Four of the six died on the same insert:

  runner_unavailable: insert work item: constraint failed:
  UNIQUE constraint failed: lifecycle_work_item.repo,
                            lifecycle_work_item.proposal_path (2067)

foreach spawns one child per packet with an id that carries the fanout
generation (parent.s<hash>.g<loopCount>.<i>) but recorded proposal_path as
"packet:"+Hash(packet), which has no generation in it. When a gate loops
with requested_changes and the re-split emits byte-identical packets, the
new id is fresh — so the byID dedup above the insert correctly misses —
while proposal_path collides with the previous generation's row. The
insert error propagates out of the step, parks the parent as
runner_unavailable, retries every 5s three times, and leaves the item
wedged until an operator stops it. wi_ba1bfba7 shows the whole shape:
g1 spawned 16:14:29, accepted 16:19:06, re-split 16:19:14, then eight
failed retries.

That directly contradicts the documented intent of the generation counter
(StageLoopCount, db1/store.go): "Failed fanout loops and prior successful
passes both count, so downstream refinement cannot reuse terminal children
when the regenerated packet content is identical." The generation was
doing that job; the content-only proposal_path silently vetoed it.

Derive the child's proposal_path from the child id instead. The id is
already unique and generation-scoped, so UNIQUE(repo, proposal_path) is
satisfied by construction. The packet hash stays appended for operator
diagnosis. Same-generation retries are unaffected: they still deduplicate
on the id before reaching the insert.

No migration is needed. Existing rows hold "packet:<hash>" and new rows
hold "packet:<id>:<hash>", so the two formats cannot collide.

Covered by TestForeachRespawnsIdenticalPacketsInALaterGeneration, which
asserts all three properties: first fanout spawns g0, an identical
same-generation call spawns no duplicate, and a gate loop lets identical
packets respawn as g1. Against the unfixed runner it fails with the exact
production constraint error above.