### PR TITLE
feat(server): verify the kb-signed identity token (per-user remote_writes, verify half)

### DIFF
--- a/src/headers/server_identity_token.h
+++ b/src/headers/server_identity_token.h
@@ -1,0 +1,67 @@
+#ifndef AIMEE_SERVER_IDENTITY_TOKEN_H
+#define AIMEE_SERVER_IDENTITY_TOKEN_H
+
+/* server_identity_token.h — server-side verification of the kb-signed data-plane
+ * identity token (proposal per-user-remote-writes-authz.md §4). Counterpart to
+ * the kb-side builder in kb_identity_token.{h,c}. Implemented in
+ * server_mgmt_token.c so it reuses that file's vetted JWS/JWKS primitives
+ * (base64url decode, RS256 verify, JWKS key-selection by kid), and is kept a
+ * strictly separate token type from the P5 management JWT: it requires the
+ * `aimee-id+jwt` header `typ`, so a management token can never verify here and
+ * vice versa.
+ *
+ * The verifier authenticates the token itself — signature (by `kid`), `typ`,
+ * `iss`/`aud` equality, the P1 composite-identity `sub` form, a valid `tier`,
+ * and the `iat`/`exp` window — and returns the typed claims. The CALLER still
+ * enforces the two server-state checks that are not token-intrinsic:
+ * `team ∈ this server's enrolled teams` and `jti` replay rejection. Every check
+ * is fail-closed. */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kb_identity_token.h" /* kb_identity_tier_t */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Maximum accepted lifetime (seconds) for a data-plane identity token; a
+    * token whose exp-iat exceeds this is rejected regardless of the clock. */
+#define SERVER_IDENTITY_TOKEN_MAX_LIFETIME 3600
+
+   typedef struct
+   {
+      char issuer[256];
+      char audience[128];
+      char subject[577];
+      int64_t team_id;
+      kb_identity_tier_t tier;
+      char jti[129];
+      char kid[65];
+      int64_t issued_at;
+      int64_t expires_at;
+   } server_identity_token_claims_t;
+
+   typedef enum
+   {
+      SERVER_IDENTITY_TOKEN_INVALID = 0,
+      SERVER_IDENTITY_TOKEN_OK = 1,
+      SERVER_IDENTITY_TOKEN_UNKNOWN_KID = 2,
+   } server_identity_token_result_t;
+
+   /* Verify a compact-serialization identity token against the supplied JWKS.
+    * `now` is the current unix time (seconds). On OK, `*out` holds the typed
+    * claims; on any failure `*out` is zeroed. The caller supplies the JWKS
+    * (e.g. from the server's authenticated JWKS cache). */
+   server_identity_token_result_t
+   server_identity_token_verify(const char *jwt, size_t jwt_len, const char *jwks_json,
+                                const char *expected_issuer, const char *expected_audience,
+                                int64_t now, server_identity_token_claims_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AIMEE_SERVER_IDENTITY_TOKEN_H */

--- a/src/server/server_mgmt_token.c
+++ b/src/server/server_mgmt_token.c
@@ -1,5 +1,7 @@
 #include "server_mgmt_token.h"
 
+#include "server_identity_token.h"
+
 #include "cJSON.h"
 
 #include <limits.h>
@@ -657,4 +659,146 @@ int server_mgmt_token_verify(const char *jwt, size_t jwt_len, const char *jwks_j
    return server_mgmt_token_verify_ex(jwt, jwt_len, jwks_json, expected_issuer, expected_audience,
                                       peer_issuer, peer_serial, peer_fingerprint, request_sha256,
                                       now, out) == SERVER_MGMT_TOKEN_OK;
+}
+
+/* ---------------------------------------------------------------------------
+ * Data-plane identity token (per-user remote_writes, proposal §4). A strictly
+ * separate token type from the management JWT above: it requires the
+ * `aimee-id+jwt` header `typ`, carries a three-level `tier` instead of a
+ * capability, and has NO peer-cert binding or request digest. It reuses this
+ * file's vetted JWS/JWKS primitives (decode_segment, b64_decode, b64_canonical,
+ * parse_json, select_key, verify_signature). See server_identity_token.h.
+ * ------------------------------------------------------------------------- */
+
+/* Header schema for the identity token: alg=RS256, typ=aimee-id+jwt, kid. The
+ * distinct `typ` is what makes a management token unverifiable here (and an
+ * identity token unverifiable by parse_header), independent of the audience. */
+static int parse_identity_header(cJSON *header, char kid[65])
+{
+   static const char *const names[] = {"alg", "typ", "kid"};
+   const cJSON *v[3];
+   return no_duplicate_members(header) && exact_object(header, names, 3, v) &&
+          cJSON_IsString(v[0]) && strcmp(v[0]->valuestring, "RS256") == 0 && cJSON_IsString(v[1]) &&
+          strcmp(v[1]->valuestring, "aimee-id+jwt") == 0 && cJSON_IsString(v[2]) &&
+          ascii_token(v[2]->valuestring, 1, 64) && copy_string(v[2], kid, 65);
+}
+
+static int identity_tier_from_str(const char *s, kb_identity_tier_t *out)
+{
+   if (strcmp(s, "off") == 0)
+      *out = KB_IDENTITY_TIER_OFF;
+   else if (strcmp(s, "data") == 0)
+      *out = KB_IDENTITY_TIER_DATA;
+   else if (strcmp(s, "full") == 0)
+      *out = KB_IDENTITY_TIER_FULL;
+   else
+      return 0;
+   return 1;
+}
+
+static int parse_identity_payload(cJSON *payload, const unsigned char *raw, size_t raw_n,
+                                  const char *issuer, const char *audience, int64_t now,
+                                  server_identity_token_claims_t *out)
+{
+   static const char *const names[] = {"v",    "iss", "aud", "sub", "team_id",
+                                       "tier", "jti", "iat", "exp"};
+   const cJSON *v[9];
+   int64_t version = 0, team = 0, issued = 0, expires = 0;
+   if (!no_duplicate_members(payload) || !exact_object(payload, names, 9, v) ||
+       !raw_uint(raw, raw_n, "v", &version) || !raw_uint(raw, raw_n, "team_id", &team) ||
+       !raw_uint(raw, raw_n, "iat", &issued) || !raw_uint(raw, raw_n, "exp", &expires) ||
+       version != 1 || team <= 0 || now < 0 || issued > now || expires <= now ||
+       expires <= issued || expires - issued > SERVER_IDENTITY_TOKEN_MAX_LIFETIME)
+      return 0;
+   /* Types: v/team_id/iat/exp are numbers, the rest strings. */
+   for (size_t i = 0; i < 9; ++i)
+      if ((i == 0 || i == 4 || i == 7 || i == 8) ? !cJSON_IsNumber(v[i]) : !cJSON_IsString(v[i]))
+         return 0;
+   kb_identity_tier_t tier;
+   if (strcmp(v[1]->valuestring, issuer) != 0 || strcmp(v[2]->valuestring, audience) != 0 ||
+       !identity_key(v[3]->valuestring) || !identity_tier_from_str(v[5]->valuestring, &tier) ||
+       !ascii_token(v[6]->valuestring, 8, 128))
+      return 0;
+   out->team_id = team;
+   out->tier = tier;
+   out->issued_at = issued;
+   out->expires_at = expires;
+   if (!copy_string(v[1], out->issuer, sizeof(out->issuer)) ||
+       !copy_string(v[2], out->audience, sizeof(out->audience)) ||
+       !copy_string(v[3], out->subject, sizeof(out->subject)) ||
+       !copy_string(v[6], out->jti, sizeof(out->jti)))
+      return 0;
+   return 1;
+}
+
+server_identity_token_result_t
+server_identity_token_verify(const char *jwt, size_t jwt_len, const char *jwks_json,
+                             const char *expected_issuer, const char *expected_audience,
+                             int64_t now, server_identity_token_claims_t *out)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+   if (!jwt || !jwks_json || !out || !control_free(expected_issuer, 1, 255) ||
+       !ascii_token(expected_audience, 1, 127) || now < 0)
+      return SERVER_IDENTITY_TOKEN_INVALID;
+   size_t wire_n = jwt_len;
+   size_t jwks_n = strnlen(jwks_json, JWKS_MAX + 1);
+   if (!wire_n || wire_n > TOKEN_WIRE_MAX || memchr(jwt, '\0', wire_n) || !jwks_n ||
+       jwks_n > JWKS_MAX)
+      return SERVER_IDENTITY_TOKEN_INVALID;
+   const char *dot1 = memchr(jwt, '.', wire_n);
+   size_t after_dot1 = dot1 ? wire_n - (size_t)(dot1 + 1 - jwt) : 0;
+   const char *dot2 = dot1 ? memchr(dot1 + 1, '.', after_dot1) : NULL;
+   size_t after_dot2 = dot2 ? wire_n - (size_t)(dot2 + 1 - jwt) : 0;
+   if (!dot1 || !dot2 || dot1 == jwt || dot2 == dot1 + 1 || !after_dot2 ||
+       memchr(dot2 + 1, '.', after_dot2))
+      return SERVER_IDENTITY_TOKEN_INVALID;
+   size_t henc_n = (size_t)(dot1 - jwt), penc_n = (size_t)(dot2 - dot1 - 1);
+   size_t senc_n = wire_n - (size_t)(dot2 + 1 - jwt);
+   unsigned char header_raw[TOKEN_HEADER_MAX + 1], payload_raw[TOKEN_PAYLOAD_MAX + 1];
+   unsigned char signature[TOKEN_SIG_MAX];
+   size_t header_n = 0, payload_n = 0, signature_n = 0;
+   cJSON *header = NULL, *payload = NULL;
+   EVP_PKEY *key = NULL;
+   server_identity_token_claims_t candidate;
+   memset(&candidate, 0, sizeof(candidate));
+   server_identity_token_result_t result = SERVER_IDENTITY_TOKEN_INVALID;
+   int ok = decode_segment(jwt, henc_n, header_raw, TOKEN_HEADER_MAX, &header_n) &&
+            decode_segment(dot1 + 1, penc_n, payload_raw, TOKEN_PAYLOAD_MAX, &payload_n) &&
+            b64_decode(dot2 + 1, senc_n, signature, TOKEN_SIG_MAX, &signature_n) &&
+            b64_canonical(dot2 + 1, senc_n, signature, signature_n) && signature_n > 0;
+   if (!ok)
+      goto done;
+   ok = 0;
+   header_raw[header_n] = '\0';
+   payload_raw[payload_n] = '\0';
+   header = parse_json(header_raw, header_n);
+   payload = parse_json(payload_raw, payload_n);
+   if (!header || !payload || !parse_identity_header(header, candidate.kid))
+      goto done;
+   key_select_result_t selected = select_key(jwks_json, jwks_n, candidate.kid, &key);
+   if (selected == KEY_SELECT_UNKNOWN)
+   {
+      result = SERVER_IDENTITY_TOKEN_UNKNOWN_KID;
+      goto done;
+   }
+   if (selected != KEY_SELECT_OK || !key ||
+       !verify_signature(key, jwt, (size_t)(dot2 - jwt), signature, signature_n) ||
+       !parse_identity_payload(payload, payload_raw, payload_n, expected_issuer, expected_audience,
+                               now, &candidate))
+      goto done;
+   *out = candidate;
+   ok = 1;
+   result = SERVER_IDENTITY_TOKEN_OK;
+done:
+   if (!ok)
+      memset(out, 0, sizeof(*out));
+   EVP_PKEY_free(key);
+   json_delete(header);
+   json_delete(payload);
+   OPENSSL_cleanse(&candidate, sizeof(candidate));
+   OPENSSL_cleanse(header_raw, sizeof(header_raw));
+   OPENSSL_cleanse(payload_raw, sizeof(payload_raw));
+   OPENSSL_cleanse(signature, sizeof(signature));
+   return result;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -618,6 +618,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-server-mgmt-checkpoint-client \
                $(TESTPREFIX)/unit-test-kb-mgmt-token \
                $(TESTPREFIX)/unit-test-kb-identity-token \
+               $(TESTPREFIX)/unit-test-server-identity-token \
                $(TESTPREFIX)/unit-test-server-management-jti \
                $(TESTPREFIX)/unit-test-server-management-tls \
                $(TESTPREFIX)/unit-test-kb-mgmt-status-authority \
@@ -2007,6 +2008,13 @@ $(TESTPREFIX)/unit-test-kb-identity-token: $(OBJDIR)/tests/test_kb_identity_toke
                                            $(OBJDIR)/kb/kb_identity_token.o \
                                            $(OBJDIR)/server/oauth_pkce.o \
                                            $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-server-identity-token: $(OBJDIR)/tests/test_server_identity_token.o \
+                                               $(OBJDIR)/server/server_mgmt_token.o \
+                                               $(OBJDIR)/kb/kb_identity_token.o \
+                                               $(OBJDIR)/server/oauth_pkce.o \
+                                               $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-server-management-jti: \

--- a/src/tests/test_server_identity_token.c
+++ b/src/tests/test_server_identity_token.c
@@ -1,0 +1,194 @@
+/* test_server_identity_token.c — round-trip + fail-closed tests for the
+ * server-side data-plane identity-token verifier (proposal §4). Builds a real
+ * kb-signed token with kb_identity_token_build, constructs a JWKS from the
+ * signing key's public half, and asserts server_identity_token_verify accepts
+ * the good token and rejects every tampering / policy violation. */
+#include <assert.h>
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "kb_identity_token.h"
+#include "oauth_pkce.h" /* oauth_pkce_base64url_encode */
+#include "server_identity_token.h"
+
+/* --- RS256 signer over the compact signing input --- */
+static EVP_PKEY *g_key;
+static int sign_rs256(void *ctx, const unsigned char *in, size_t in_n, unsigned char *sig,
+                      size_t cap, size_t *sig_n)
+{
+   (void)ctx;
+   EVP_MD_CTX *md = EVP_MD_CTX_new();
+   size_t n = cap;
+   int ok = md && EVP_DigestSignInit(md, NULL, EVP_sha256(), NULL, g_key) == 1 &&
+            EVP_DigestSign(md, sig, &n, in, in_n) == 1;
+   EVP_MD_CTX_free(md);
+   if (!ok)
+      return 0;
+   *sig_n = n;
+   return 1;
+}
+
+static EVP_PKEY *new_rsa(unsigned bits)
+{
+   EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+   EVP_PKEY *key = NULL;
+   assert(ctx && EVP_PKEY_keygen_init(ctx) == 1 &&
+          EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, (int)bits) == 1 && EVP_PKEY_keygen(ctx, &key) == 1);
+   EVP_PKEY_CTX_free(ctx);
+   return key;
+}
+
+/* base64url a BIGNUM's big-endian bytes. */
+static void bn_b64url(EVP_PKEY *key, const char *param, char *out, size_t cap)
+{
+   BIGNUM *bn = NULL;
+   assert(EVP_PKEY_get_bn_param(key, param, &bn) == 1 && bn);
+   int len = BN_num_bytes(bn);
+   unsigned char buf[1024];
+   assert(len > 0 && (size_t)len <= sizeof(buf));
+   assert(BN_bn2bin(bn, buf) == len);
+   assert(oauth_pkce_base64url_encode(buf, (size_t)len, out, cap) == 0);
+   BN_free(bn);
+}
+
+/* Build a one-key JWKS for `key` under `kid`. */
+static void make_jwks(EVP_PKEY *key, const char *kid, char *out, size_t cap)
+{
+   char n[1024], e[64];
+   bn_b64url(key, OSSL_PKEY_PARAM_RSA_N, n, sizeof(n));
+   bn_b64url(key, OSSL_PKEY_PARAM_RSA_E, e, sizeof(e));
+   int w = snprintf(out, cap,
+                    "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"%s\",\"use\":\"sig\","
+                    "\"alg\":\"RS256\",\"n\":\"%s\",\"e\":\"%s\"}]}",
+                    kid, n, e);
+   assert(w > 0 && (size_t)w < cap);
+}
+
+static kb_identity_token_claims_t base_claims(void)
+{
+   kb_identity_token_claims_t c;
+   memset(&c, 0, sizeof(c));
+   snprintf(c.issuer, sizeof(c.issuer), "kb");
+   snprintf(c.audience, sizeof(c.audience), "server-abc");
+   snprintf(c.subject, sizeof(c.subject), "oidc:idp-example:user-42");
+   c.team_id = 7;
+   c.tier = KB_IDENTITY_TIER_DATA;
+   snprintf(c.jti, sizeof(c.jti), "id-jti-00000001");
+   snprintf(c.kid, sizeof(c.kid), "kid-2026-a");
+   c.issued_at = 1000;
+   c.expires_at = 1300;
+   return c;
+}
+
+int main(void)
+{
+   g_key = new_rsa(2048);
+   char jwks[4096];
+   make_jwks(g_key, "kid-2026-a", jwks, sizeof(jwks));
+
+   char jwt[KB_IDENTITY_TOKEN_WIRE_MAX];
+   size_t jl = 0;
+   kb_identity_token_claims_t c = base_claims();
+   assert(kb_identity_token_build(&c, sign_rs256, NULL, jwt, sizeof(jwt), &jl) ==
+          KB_IDENTITY_TOKEN_OK);
+
+   const int64_t NOW = 1200; /* within [iat=1000, exp=1300) */
+   server_identity_token_claims_t out;
+
+   /* 1) Happy path: a valid token verifies and the claims come back. */
+   assert(server_identity_token_verify(jwt, jl, jwks, "kb", "server-abc", NOW, &out) ==
+          SERVER_IDENTITY_TOKEN_OK);
+   assert(strcmp(out.issuer, "kb") == 0);
+   assert(strcmp(out.audience, "server-abc") == 0);
+   assert(strcmp(out.subject, "oidc:idp-example:user-42") == 0);
+   assert(out.team_id == 7);
+   assert(out.tier == KB_IDENTITY_TIER_DATA);
+   assert(strcmp(out.jti, "id-jti-00000001") == 0);
+   assert(strcmp(out.kid, "kid-2026-a") == 0);
+   assert(out.issued_at == 1000 && out.expires_at == 1300);
+
+   /* 2) Every tier round-trips. */
+   kb_identity_tier_t tiers[] = {KB_IDENTITY_TIER_OFF, KB_IDENTITY_TIER_DATA,
+                                 KB_IDENTITY_TIER_FULL};
+   for (unsigned i = 0; i < 3; i++)
+   {
+      c = base_claims();
+      c.tier = tiers[i];
+      assert(kb_identity_token_build(&c, sign_rs256, NULL, jwt, sizeof(jwt), &jl) ==
+             KB_IDENTITY_TOKEN_OK);
+      assert(server_identity_token_verify(jwt, jl, jwks, "kb", "server-abc", NOW, &out) ==
+             SERVER_IDENTITY_TOKEN_OK);
+      assert(out.tier == tiers[i]);
+   }
+
+   /* Rebuild the canonical good token for the tampering cases. */
+   c = base_claims();
+   assert(kb_identity_token_build(&c, sign_rs256, NULL, jwt, sizeof(jwt), &jl) ==
+          KB_IDENTITY_TOKEN_OK);
+
+   /* 3) Tampered signature: flip the last character. */
+   {
+      char t[KB_IDENTITY_TOKEN_WIRE_MAX];
+      memcpy(t, jwt, jl + 1);
+      t[jl - 1] = (t[jl - 1] == 'A') ? 'B' : 'A';
+      assert(server_identity_token_verify(t, jl, jwks, "kb", "server-abc", NOW, &out) ==
+             SERVER_IDENTITY_TOKEN_INVALID);
+   }
+
+   /* 4) Unknown kid: a JWKS whose only key is under a different kid. */
+   {
+      char other_jwks[4096];
+      make_jwks(g_key, "kid-different", other_jwks, sizeof(other_jwks));
+      assert(server_identity_token_verify(jwt, jl, other_jwks, "kb", "server-abc", NOW, &out) ==
+             SERVER_IDENTITY_TOKEN_UNKNOWN_KID);
+   }
+
+   /* 5) Wrong audience / issuer -> denied. */
+   assert(server_identity_token_verify(jwt, jl, jwks, "kb", "server-XYZ", NOW, &out) ==
+          SERVER_IDENTITY_TOKEN_INVALID);
+   assert(server_identity_token_verify(jwt, jl, jwks, "not-kb", "server-abc", NOW, &out) ==
+          SERVER_IDENTITY_TOKEN_INVALID);
+
+   /* 6) Expiry window: at/after exp is denied; before iat is denied. */
+   assert(server_identity_token_verify(jwt, jl, jwks, "kb", "server-abc", 1300, &out) ==
+          SERVER_IDENTITY_TOKEN_INVALID);
+   assert(server_identity_token_verify(jwt, jl, jwks, "kb", "server-abc", 999, &out) ==
+          SERVER_IDENTITY_TOKEN_INVALID);
+
+   /* 7) A signature from a DIFFERENT key is rejected (JWKS pins the signer). */
+   {
+      EVP_PKEY *good = g_key;
+      g_key = new_rsa(2048); /* sign with an impostor key... */
+      char imposter[KB_IDENTITY_TOKEN_WIRE_MAX];
+      size_t il = 0;
+      c = base_claims();
+      assert(kb_identity_token_build(&c, sign_rs256, NULL, imposter, sizeof(imposter), &il) ==
+             KB_IDENTITY_TOKEN_OK);
+      EVP_PKEY_free(g_key);
+      g_key = good; /* ...but verify against the real key's JWKS */
+      assert(server_identity_token_verify(imposter, il, jwks, "kb", "server-abc", NOW, &out) ==
+             SERVER_IDENTITY_TOKEN_INVALID);
+   }
+
+   /* 8) Non-conforming subject (not the P1 composite form) is rejected. */
+   {
+      c = base_claims();
+      snprintf(c.subject, sizeof(c.subject), "just-a-name");
+      assert(kb_identity_token_build(&c, sign_rs256, NULL, jwt, sizeof(jwt), &jl) ==
+             KB_IDENTITY_TOKEN_OK);
+      assert(server_identity_token_verify(jwt, jl, jwks, "kb", "server-abc", NOW, &out) ==
+             SERVER_IDENTITY_TOKEN_INVALID);
+   }
+
+   /* 9) Malformed wire (single segment) is rejected, not crashed. */
+   assert(server_identity_token_verify("not-a-jwt", 9, jwks, "kb", "server-abc", NOW, &out) ==
+          SERVER_IDENTITY_TOKEN_INVALID);
+
+   EVP_PKEY_free(g_key);
+   printf("  PASS: server_identity_token_verify accepts valid tokens, fails closed on tamper/"
+          "policy\n");
+   return 0;
+}


### PR DESCRIPTION
**Stacked on #1988.** Second implementation increment of the roundtable-approved per-user `remote_writes` design — the **server-side verify half** that pairs with #1988's builder. Chosen order **C-then-B** (verify first, no changes to the hardened token authority). No gate wiring yet, so no behavior change.

## What
- **`server_identity_token.h` + `server_identity_token_verify()`**, implemented in `server/server_mgmt_token.c` so it **reuses that file's vetted JWS/JWKS primitives** (base64url decode, RS256 verify, JWKS key-selection by `kid`) instead of duplicating security-sensitive crypto.
- **Type separation:** requires the `aimee-id+jwt` header `typ`, so a P5 management JWT can never verify here (and an identity token can't verify as a management JWT) — independent of the audience check.
- **Checks:** signature-by-`kid`, `iss`/`aud` equality, the **P1 composite-identity** `sub` form (`identity_key`), a valid `tier`, and the `iat`/`exp` window (≤ `SERVER_IDENTITY_TOKEN_MAX_LIFETIME`). Returns typed claims `{issuer, audience, subject, team_id, tier, jti, kid, iat, exp}`.
- **Scope boundary:** `team ∈ enrolled` and `jti` replay stay **caller-side** (server state, not token-intrinsic) — those land with the gate wiring (Slice 4).

## Test (`test_server_identity_token.c`, validated on CT 301)
Real **build→verify round-trip** (constructs a JWKS from the signing key), every tier, and **fail-closed** on: tampered signature, unknown kid, wrong aud, wrong iss, expiry (both edges), impostor-key signature, non-composite subject, and malformed wire. `unit-test-server-identity-token` **PASSes**; server + kb link clean.

Next: **B** — extend the isolated token authority (lighter parallel identity-token record) to *mint* this token with the real signing key + kid; then Slice 3 (tier storage) and Slice 4 (gate wiring: verify → team-enrollment + jti-replay → feed tier into the write gate).