### PR TITLE
Let an unusable reviewer answer abstain, and stop discarding the evidence

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -758,6 +758,9 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 		cost        float64
 		costUnknown bool
 		err         error
+		// transport records that the seat never produced a response at all, so a
+		// dropped seat can say whether the delegate failed or answered unusably.
+		transport bool
 	}
 	requests := make([]DelegateRequest, len(seats))
 	for i, seat := range seats {
@@ -773,8 +776,11 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 		parsed, err := parsePanelResponse(call.Response, call.Err)
 		seat := seats[i]
 		seat.participant = call.Participant
-		outcomes[i] = outcome{seat: seat, result: parsed, raw: call.Response, cost: call.CostUSD, costUnknown: call.CostUnknown, err: err}
-		if err != nil && call.Err == nil && strings.TrimSpace(call.Participant) != "" {
+		outcomes[i] = outcome{seat: seat, result: parsed, raw: call.Response, cost: call.CostUSD, costUnknown: call.CostUnknown, err: err, transport: call.Err != nil}
+		// A verdict that contradicts its own findings carries no more reviewable
+		// signal than unparseable text, so it earns the same one repair attempt.
+		// Without this it was charged against the artifact having never been retried.
+		if call.Err == nil && strings.TrimSpace(call.Participant) != "" && (err != nil || panelVerdictError(parsed) != nil) {
 			repairIndexes = append(repairIndexes, i)
 		}
 	}
@@ -829,18 +835,33 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 		cost += o.cost
 		costUnknown = costUnknown || o.costUnknown
 		if o.err != nil {
-			seatFailures = append(seatFailures, o.seat.persona+": "+o.err.Error())
+			reason := "malformed_after_repair"
+			if o.transport {
+				reason = "delegate_error"
+			}
+			seatFailures = append(seatFailures, o.seat.persona+": "+reason+": "+o.err.Error())
 			voters--
 			continue
 		}
 		if o.result.RunID != req.WorkItem.ID || o.result.ArtifactHash != artifactHash {
-			seatFailures = append(seatFailures, o.seat.persona+": roundtable response identity mismatch")
+			seatFailures = append(seatFailures, o.seat.persona+": identity_mismatch: roundtable response identity mismatch")
 			voters--
 			continue
 		}
 		echoStage, echoOK := normalizeRoundtableStage(o.result.ArtifactStage)
 		if !echoOK || echoStage != artifactStage {
 			feedback.Findings = append(feedback.Findings, wfe.Finding{ID: o.seat.persona + "-artifact-stage", Persona: o.seat.persona, Severity: "blocking", Summary: "reviewer did not evaluate the declared artifact stage", Recommendation: "review the artifact at stage " + artifactStage + " and echo that exact artifact_stage"})
+			continue
+		}
+		// The stage echo is checked above and supersedes this: a seat that reviewed
+		// the wrong stage is a blocking anti-injection failure, never an abstention.
+		// Past that, a verdict still unusable after its repair attempt is absence of
+		// evidence, not evidence of a defect, so the seat abstains exactly like an
+		// unreachable one and min_successful decides. Charging it against the
+		// artifact let one garbled response veto a panel no revision could satisfy.
+		if verdictErr := panelVerdictError(o.result); verdictErr != nil {
+			seatFailures = append(seatFailures, o.seat.persona+": malformed_after_repair: "+verdictErr.Error())
+			voters--
 			continue
 		}
 		reports = append(reports, panelSeatReport{Seat: o.seat, Response: o.result})
@@ -862,16 +883,12 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 				Recommendation: "revise the direction so it directly serves the original request, then rerun the panel",
 			})
 		}
-		if o.result.Verdict == "approve" && len(o.result.Findings) == 0 {
+		if panelVerdict(o.result) == "approve" {
 			// The feedback finding already prevents advancement; also exclude this
 			// vote from quorum so the fail-closed invariant is local and explicit.
 			if alignmentOK {
 				approvals++
 			}
-			continue
-		}
-		if o.result.Verdict != "changes" || len(o.result.Findings) == 0 {
-			feedback.Findings = append(feedback.Findings, wfe.Finding{ID: o.seat.persona + "-malformed", Persona: o.seat.persona, Severity: "blocking", Summary: "reviewer returned a contradictory or incomplete verdict", Recommendation: "return approve with no findings, or changes with actionable findings"})
 			continue
 		}
 		for i, f := range o.result.Findings {
@@ -905,6 +922,33 @@ func remainingCostLimit(limit, spent float64) float64 {
 		return 0
 	}
 	return remaining
+}
+
+// panelVerdictError reports why a parsed seat response is not a usable verdict.
+// Approve carries no findings and changes carries at least one; anything else is
+// a reviewer that contradicted itself, which says nothing about the artifact.
+// panelVerdict is the one normalization of a seat or chairman verdict. Both
+// paths must read the same value: validating one form and branching on another
+// silently turns a usable verdict into a non-vote.
+func panelVerdict(parsed panelResponse) string {
+	return strings.ToLower(strings.TrimSpace(parsed.Verdict))
+}
+
+func panelVerdictError(parsed panelResponse) error {
+	switch panelVerdict(parsed) {
+	case "approve":
+		if len(parsed.Findings) != 0 {
+			return errors.New("approve verdict returned with findings")
+		}
+		return nil
+	case "changes":
+		if len(parsed.Findings) == 0 {
+			return errors.New("changes verdict returned without findings")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unusable verdict %q", parsed.Verdict)
+	}
 }
 
 func parsePanelResponse(response string, delegateErr error) (panelResponse, error) {

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1026,9 +1026,15 @@ func TestMalformedCapacityDuplicateCannotSatisfyRequiredPersona(t *testing.T) {
 		{persona: "security", selector: "codex", ordinal: 0},
 		{persona: "security", selector: "minimax", ordinal: 1},
 	}
-	_, _, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "review", "hash", "plan", 1)
-	if unreachable == "" || voters != 1 {
-		t.Fatalf("malformed duplicate satisfied required persona: voters=%d unreachable=%q", voters, unreachable)
+	// The duplicate contradicts itself (approve carrying a finding). It abstains
+	// rather than voting, so it can neither satisfy the required persona nor mask
+	// the seat that failed: both seats drop out and nothing is approved.
+	_, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "review", "hash", "plan", 1)
+	if unreachable == "" || voters != 0 || approvals != 0 {
+		t.Fatalf("malformed duplicate satisfied required persona: approvals=%d voters=%d unreachable=%q", approvals, voters, unreachable)
+	}
+	if !strings.Contains(unreachable, "malformed_after_repair") || !strings.Contains(unreachable, "delegate_error") {
+		t.Fatalf("dropped seats are not self-describing: %q", unreachable)
 	}
 }
 
@@ -1405,4 +1411,193 @@ func TestRoundtableNamingAnAbsentPresetParks(t *testing.T) {
 	if len(agents.requests) != 0 {
 		t.Fatalf("absent preset dispatched %d seats", len(agents.requests))
 	}
+}
+
+// contradictingSeatAgents answers every seat with a well-formed approval except
+// the named persona, which contradicts itself (approve carrying a finding) on
+// both its first attempt and its repair. The JSON parses, so the syntactic
+// repair path alone never sees it.
+type contradictingSeatAgents struct {
+	mu       sync.Mutex
+	persona  string
+	attempts int
+}
+
+func (a *contradictingSeatAgents) Delegate(_ context.Context, _ DelegateRequest) (DelegateResult, error) {
+	return DelegateResult{}, errors.New("unexpected direct delegation")
+}
+
+func (a *contradictingSeatAgents) DelegateGroup(_ context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]DelegateGroupResult, len(requests))
+	for i, request := range requests {
+		body := `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`
+		if request.Persona == a.persona {
+			a.attempts++
+			body = `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[{"id":"contradiction","severity":"blocking","summary":"approve carrying a finding"}]}`
+		}
+		out[i] = DelegateGroupResult{Participant: "seat-" + request.Persona, Response: withTestRoundtableIdentity(body, request)}
+	}
+	return out
+}
+
+// A seat whose verdict is still unusable after its repair attempt is absence of
+// evidence, not evidence of a defect. It abstains like an unreachable seat and
+// min_successful decides, instead of vetoing a panel that no revision could
+// satisfy. The repair must still be attempted first.
+func TestContradictorySeatAbstainsAfterRepairInsteadOfVetoingThePanel(t *testing.T) {
+	agents := &contradictingSeatAgents{persona: "architect"}
+	runner := &NativeRunner{agents: agents, roundtables: unpinnedTestRoundtable(t, "architect", "qa", "reviewer")}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("a complete plan artifact for review")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(t.Context(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Params: map[string]any{"roundtable": "default"}},
+		Proposal: "review the plan", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// min_successful is 3 here (one seat per persona), so losing a seat drops the
+	// usable reports below the configured floor and the panel must NOT advance.
+	if result.Status == StepAdvanced {
+		t.Fatalf("panel advanced below its configured minimum: %+v", result)
+	}
+	if a := agents.attempts; a != 2 {
+		t.Fatalf("contradictory seat attempts=%d, want 2 (first + one repair)", a)
+	}
+	if result.Roundtable == nil || !result.Roundtable.Degraded || result.Roundtable.ParticipantsUsed != 2 {
+		t.Fatalf("dropped seat is not visible in the record: %+v", result.Roundtable)
+	}
+	for _, finding := range result.Roundtable.Items {
+		if strings.Contains(finding.ID, "malformed") {
+			t.Fatalf("contradictory seat was charged against the artifact: %+v", finding)
+		}
+	}
+}
+
+// The same panel, sized so the remaining seats still meet min_successful, must
+// advance: the abstention costs a voter but does not lower the configured bar.
+func TestPanelAdvancesWhenAbstentionStillLeavesTheConfiguredMinimum(t *testing.T) {
+	agents := &contradictingSeatAgents{persona: "architect"}
+	dir := t.TempDir()
+	body := `{"name":"default","seats":[{"model":"","persona":"architect"},{"model":"","persona":"qa"},{"model":"","persona":"reviewer"}],"min_successful":2}`
+	if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := roundtablecfg.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{agents: agents, roundtables: store}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("a complete plan artifact for review")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(t.Context(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Params: map[string]any{"roundtable": "default"}},
+		Proposal: "review the plan", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StepAdvanced {
+		t.Fatalf("two clean approvals against min_successful 2 did not advance: %+v", result)
+	}
+	if result.Roundtable == nil || !result.Roundtable.Degraded {
+		t.Fatalf("advancing on a short panel must still report degraded: %+v", result.Roundtable)
+	}
+}
+
+// proseChairmanAgents answers seats cleanly and makes the chairman return prose
+// on its first turn. `replyAfterRepair` is what the chairman says when re-asked.
+type proseChairmanAgents struct {
+	mu               sync.Mutex
+	chairmanCalls    int
+	replyAfterRepair string
+}
+
+func (a *proseChairmanAgents) Delegate(_ context.Context, request DelegateRequest) (DelegateResult, error) {
+	if request.Persona == "chairman" {
+		a.mu.Lock()
+		a.chairmanCalls++
+		call := a.chairmanCalls
+		a.mu.Unlock()
+		if call == 1 {
+			return DelegateResult{Response: "Certainly! Here is my assessment of the plan:\n\nThe plan looks reasonable overall."}, nil
+		}
+		if a.replyAfterRepair == "repeat-prose" {
+			return DelegateResult{Response: "Still prose, still no JSON object anywhere."}, nil
+		}
+		return DelegateResult{Response: chairmanApprovalFor(request)}, nil
+	}
+	return DelegateResult{Response: withTestRoundtableIdentity(`{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`, request)}, nil
+}
+
+func (a *proseChairmanAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	return testDelegateGroup(ctx, requests, a.Delegate)
+}
+
+// An analysis seat gets one repair attempt; the chairman had none, so a single
+// prose reply discarded a completed panel and parked the gate, and the resume
+// re-ran every seat at full cost. It gets the same one attempt now.
+func TestChairmanRepairsItsFirstUnstructuredReply(t *testing.T) {
+	agents := &proseChairmanAgents{}
+	runner := &NativeRunner{agents: agents, roundtables: chairmanTestRoundtable(t)}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("a complete plan artifact for review")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(t.Context(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Params: map[string]any{"roundtable": "default"}},
+		Proposal: "review the plan", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StepAdvanced {
+		t.Fatalf("chairman prose was not repaired: %+v", result)
+	}
+	if agents.chairmanCalls != 2 {
+		t.Fatalf("chairman calls=%d, want 2 (first + one repair)", agents.chairmanCalls)
+	}
+}
+
+// When the repair also fails, the park detail must carry what the chairman
+// actually returned. Without it an operator cannot tell prose from a truncated
+// verdict from an empty reply, and the three have different fixes.
+func TestChairmanParkDetailCarriesTheUnusableResponse(t *testing.T) {
+	agents := &proseChairmanAgents{replyAfterRepair: "repeat-prose"}
+	runner := &NativeRunner{agents: agents, roundtables: chairmanTestRoundtable(t)}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("a complete plan artifact for review")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(t.Context(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Params: map[string]any{"roundtable": "default"}},
+		Proposal: "review the plan", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StepPending || result.PauseReason != "roundtable_chairman" {
+		t.Fatalf("unusable chairman did not park: %+v", result)
+	}
+	if !strings.Contains(result.Detail, "bytes, begins") || !strings.Contains(result.Detail, "Still prose") {
+		t.Fatalf("park detail discards the chairman response: %q", result.Detail)
+	}
+}
+
+// chairmanTestRoundtable saves a two-seat preset with an enabled chairman.
+func chairmanTestRoundtable(t *testing.T) *roundtablecfg.Store {
+	t.Helper()
+	dir := t.TempDir()
+	body := `{"name":"default","seats":[{"model":"","persona":"qa"},{"model":"","persona":"reviewer"}],` +
+		`"min_successful":2,"chairman":"$random","chairman_enabled":true}`
+	if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := roundtablecfg.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
 }

--- a/server-go/internal/engine/roundtable_chairman.go
+++ b/server-go/internal/engine/roundtable_chairman.go
@@ -20,6 +20,24 @@ type chairmanPacket struct {
 	Reports         []discussionTranscriptReport `json:"independent_reports"`
 }
 
+// chairmanResponseNote is a bounded, single-line excerpt of what the chairman
+// actually returned. The failure reaches an operator only as a park detail, and
+// without the response there is no way to tell a truncated verdict from prose,
+// an empty reply, or a turn that ended on a tool call — the diagnosis and the
+// fix differ for each. Untrusted content, so it is quoted and length-capped.
+func chairmanResponseNote(response string) string {
+	trimmed := strings.TrimSpace(response)
+	if trimmed == "" {
+		return " (empty response)"
+	}
+	excerpt := strings.Join(strings.Fields(trimmed), " ")
+	const limit = 300
+	if len(excerpt) > limit {
+		excerpt = excerpt[:limit] + "…"
+	}
+	return fmt.Sprintf(" (%d bytes, begins %q)", len(trimmed), excerpt)
+}
+
 // runPanelChairman is an optional, single post-synthesis review. The configured
 // chairman receives the original request, artifact, independent reports, and
 // deterministic feedback, then submits the final structured verdict. Failure is
@@ -44,13 +62,32 @@ func (r *NativeRunner) runPanelChairman(ctx context.Context, req StepRequest, pa
 	if err != nil {
 		return feedback, analysis.Approvals, cost, costUnknown, "chairman failed: " + err.Error()
 	}
-	doc, err := extractJSONObject(result.Response)
-	if err != nil {
-		return feedback, analysis.Approvals, cost, costUnknown, "chairman returned no structured verdict"
+	final, parseErr := parsePanelResponse(result.Response, nil)
+	if parseErr == nil {
+		parseErr = panelVerdictError(final)
 	}
-	var final panelResponse
-	if err := json.Unmarshal(doc, &final); err != nil {
-		return feedback, analysis.Approvals, cost, costUnknown, "chairman returned malformed JSON"
+	// An analysis seat gets one repair attempt before its answer is written off.
+	// The chairman had none, so a single unparseable reply discarded the whole
+	// paid panel round and parked the gate for the scheduler to re-run from the
+	// top. Give it the same one attempt, on the same participant.
+	if parseErr != nil {
+		repair := request
+		repair.Prompt = panelResponseRepairPrompt(req.WorkItem.ID, reviewed.Hash, artifactStage, result.Response)
+		repair.DurableSlot = panelChairmanDurableSlot(req) + ":repair:1"
+		repaired, repairErr := r.delegate(ctx, req, repair)
+		cost += repaired.CostUSD
+		costUnknown = costUnknown || repaired.CostUnknown
+		if repairErr != nil {
+			return feedback, analysis.Approvals, cost, costUnknown, "chairman failed: " + repairErr.Error()
+		}
+		final, parseErr = parsePanelResponse(repaired.Response, nil)
+		if parseErr == nil {
+			parseErr = panelVerdictError(final)
+		}
+		if parseErr != nil {
+			return feedback, analysis.Approvals, cost, costUnknown,
+				"chairman returned no structured verdict after repair: " + parseErr.Error() + chairmanResponseNote(repaired.Response)
+		}
 	}
 	if final.RunID != req.WorkItem.ID || final.ArtifactHash != reviewed.Hash {
 		return feedback, analysis.Approvals, cost, costUnknown, "chairman returned mismatched run or artifact identity"
@@ -63,19 +100,15 @@ func (r *NativeRunner) runPanelChairman(ctx context.Context, req StepRequest, pa
 	if alignment != "aligned" && alignment != "drifted" && alignment != "unclear" {
 		return feedback, analysis.Approvals, cost, costUnknown, "chairman did not provide a valid original-request alignment"
 	}
-	switch strings.ToLower(strings.TrimSpace(final.Verdict)) {
+	// panelVerdictError above already rejected a verdict that contradicts its
+	// findings, so only the alignment conditions remain to check here.
+	switch panelVerdict(final) {
 	case "approve":
-		if len(final.Findings) != 0 {
-			return feedback, analysis.Approvals, cost, costUnknown, "chairman returned approve with findings"
-		}
 		if alignment != "aligned" {
 			return feedback, analysis.Approvals, cost, costUnknown, "chairman returned approve without confirming original-request alignment"
 		}
 		return wfe.ReviewFeedback{SchemaVersion: 1, ArtifactHash: feedback.ArtifactHash}, len(analysis.Reports), cost, costUnknown, ""
 	case "changes":
-		if len(final.Findings) == 0 {
-			return feedback, analysis.Approvals, cost, costUnknown, "chairman returned changes without findings"
-		}
 		capacity := len(final.Findings)
 		if alignment != "aligned" {
 			capacity++


### PR DESCRIPTION
Three defects in the same seam, all found by running the WFE against a real
proposal on the appliance.

1. A malformed seat verdict vetoed the panel

An analysis seat whose verdict contradicted its findings appended a blocking
finding against the ARTIFACT. The gate needs approvals >= quorum AND zero
blocking findings, so one garbled response failed a panel where every other seat
approved, and no author revision could clear it — the finding described the
reviewer's output, not the work. Observed live: three of four seats approved, the
fourth returned a contradictory verdict, and the stage looped impl -> freeze ->
rt_gate until it exhausted max_rounds and had to be operator-stopped.

A seat that errors is already a tolerated abstention (voters--, bounded by
min_successful). A garbled answer carries strictly less signal than silence, so
it now abstains the same way: absence of evidence, not evidence of a defect. The
seat counts toward neither approvals nor usable reports, so reports append moved
below the check.

Guards, as reviewed by the roundtable:
  - Repair first. Seat repair only ever covered SYNTACTIC failure; a verdict that
    contradicts its findings parses cleanly and was written off having never been
    retried. Repair selection now includes it, so abstention is terminal, not the
    first response.
  - min_successful is untouched and remains the floor. It counts usable reports,
    not a fraction of voters. Too many abstentions drop reports below it and the
    gate parks panel_unreachable for a human. The bar never moves.
  - Visible degradation. Dropped seats are recorded with a reason —
    malformed_after_repair, delegate_error, identity_mismatch — so a short panel
    is self-describing, and Degraded follows from reports < seats.
  - Wrong artifact stage stays a blocking finding. It is an anti-injection
    control: the artifact is untrusted and may carry its own ARTIFACT STAGE line,
    so an injected artifact must not be able to choose which seats drop out. Its
    two existing tests pass unmodified.

2. The chairman had no repair at all

Seats got one repair attempt; the chairman got none, so a single prose or
truncated reply discarded a completed, paid panel round and parked the gate.
roundtable_chairman is a transient pause, so the scheduler resumes it after 60s
and re-runs every seat from the top: the unchanged-artifact short-circuit needs
req.Feedback, which a park does not carry. It gets the same one attempt now, on
the same participant.

3. The failure discarded the response that would explain it

Every chairman parse failure returned a fixed string and dropped the reply, so
"chairman returned no structured verdict" could not be told apart from prose, an
empty answer, a turn that ended on a tool call, or a verdict truncated mid-object
— which have different fixes. The park detail now carries a bounded, quoted,
whitespace-collapsed excerpt with the byte count. Untrusted content, so it is
length-capped and %q-quoted.

Also: panelVerdict is now the single normalization of a verdict string. The
chairman lowercased and trimmed while seats compared exactly, so validating one
form and branching on the other would have turned "Approve" into a silent
non-vote. With shape validated up front, the chairman's own redundant
approve-with-findings and changes-without-findings checks are unreachable and are
removed.

Tests: a contradictory seat is retried once then abstains, is absent from the
findings, and leaves the panel short of min_successful so it does not advance;
the same panel advances when the remaining seats still meet the floor, still
reporting degraded; the chairman recovers from a first prose reply; a chairman
still unusable after repair parks with its response in the detail. The existing
capacity-duplicate test is updated to the new contract — it now asserts the
stronger guarantee that the malformed duplicate neither votes nor counts.