### PR TITLE
Stop a stage entry from resetting the cap that bounds it

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -1118,13 +1118,16 @@ VALUES (?, ?, ?, 'go-wfe', ?, ?, ?)`, workItemID, fromStage, kind, detail, conte
 		return fmt.Errorf("record stage transition: %w", err)
 	}
 	if kind != "loop" {
+		// Clearing the stage we just LEFT is the point: it completed, so a later
+		// revisit starts with a fresh budget. Clearing the stage we are entering
+		// is not — it reset the counter that bounds a refinement loop. A gate that
+		// loops to its author (gate --loop--> plan) is re-entered by the author's
+		// own advance (plan --advance--> gate), and that advance was wiping the
+		// gate's accumulated attempts, so its cap could never be reached and the
+		// pair looped without bound. Observed: a plan gate at 63 loops against a
+		// cap of 20, burning five hours before it happened to converge.
 		if _, err := tx.ExecContext(ctx, `DELETE FROM lifecycle_stage_attempt WHERE work_item_id=? AND stage=?`, workItemID, fromStage); err != nil {
 			return fmt.Errorf("clear completed stage attempts: %w", err)
-		}
-		if fromStage != toStage {
-			if _, err := tx.ExecContext(ctx, `DELETE FROM lifecycle_stage_attempt WHERE work_item_id=? AND stage=?`, workItemID, toStage); err != nil {
-				return err
-			}
 		}
 	}
 	if err := tx.Commit(); err != nil {

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -1110,3 +1110,35 @@ func TestRecoverLostReplayReleasesUnresolvedAndParksActual(t *testing.T) {
 		}
 	})
 }
+
+// The production refinement cycle is gate --loop--> author, then
+// author --advance--> gate. That re-entering advance was clearing the gate's own
+// attempt counter, so the cap never accumulated and the pair looped without
+// bound: a live plan gate reached 63 loops against a cap of 20. Entering a stage
+// must not reset the budget that bounds it; only completing one may.
+func TestGateIterationCapSurvivesTheAuthorsReentry(t *testing.T) {
+	store := newTestStore(t)
+	createTestItem(t, store, "wi_loop")
+	ctx := context.Background()
+
+	parkedAt := -1
+	for i := 0; i < 10; i++ {
+		out, err := store.RecordRequestedChanges(ctx, "wi_loop", "plan_gate", "plan",
+			fmt.Sprintf("plan-%d", i), fmt.Sprintf("feedback-%d", i), 3, 99, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Parked {
+			parkedAt = i
+			break
+		}
+		// The author re-authors and advances back into the gate.
+		if err := store.Move(ctx, "wi_loop", "plan", "plan_gate", "advance", "",
+			fmt.Sprintf("plan-%d", i), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if parkedAt != 2 {
+		t.Fatalf("gate parked at loop %d, want 2 (cap of 3); the author's re-entry reset the counter", parkedAt)
+	}
+}


### PR DESCRIPTION
A plan gate looped 63 times overnight against a cap of 20, burning five hours
before it happened to converge. The cap was never reachable.

Store.Move clears lifecycle_stage_attempt on any non-loop transition, for both
the stage being left and the stage being entered:

    if kind != "loop" {
        DELETE ... AND stage=?   // fromStage
        if fromStage != toStage {
            DELETE ... AND stage=?   // toStage
        }
    }

Clearing the stage we LEFT is the point: it completed, so a later revisit starts
with a fresh budget. Clearing the stage we are ENTERING defeats every refinement
loop. The production cycle is gate --loop--> author, then author --advance-->
gate, and that second transition has toStage == the gate, so the author's own
re-entry wiped the gate's accumulated attempts on every pass. RecordRetry and
RecordRequestedChanges both faithfully increment and compare against
maxIterations; the counter was simply being deleted underneath them.

Only the departed stage is cleared now.

This was invisible to the existing cap test because it calls
RecordRequestedChanges three times back to back, without the author advance that
production performs between rejections. The new test models the real cycle and
fails against the previous behaviour: it never parks, where it should park on
the third rejection against a cap of three.

Worth noting what this does NOT fix: max_rounds, which the shipped workflows set
on every gate node, is not read by the engine at all — maxIterations only reads
max_iters (default 20). That is a separate phantom-config defect, and correcting
it needs an intent decision, because build.yaml's own comments disagree about
whether max_rounds bounds the gate loop or the panel's internal debate, and the
declared value of 6 is below the default it was apparently meant to raise.