### PR TITLE
Surface a lost panel replay so reservation recovery can run

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -576,6 +576,19 @@ type panelSeatReport struct {
 	Response panelResponse
 }
 
+// chairmanDeadline gives the chairman its own budget, measured from the step
+// context rather than from whatever the analysis phase left behind. The chairman
+// is a separate delegate turn: it reads every seat's report plus the artifact and
+// writes the final verdict, so it needs the same time a seat had, not a remainder.
+// Sharing one deadline starved it to zero whenever the seats ran long, and it
+// failed on the POST that launches its job.
+func chairmanDeadline(step context.Context, deadlineMS int) (context.Context, context.CancelFunc) {
+	if deadlineMS <= 0 {
+		return step, func() {}
+	}
+	return context.WithTimeout(step, time.Duration(deadlineMS)*time.Millisecond)
+}
+
 type panelAnalysis struct {
 	Feedback    wfe.ReviewFeedback
 	Approvals   int
@@ -701,6 +714,13 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 		}
 	}
 	if panel.ChairmanEnabled {
+		// The chairman is a separate step and gets its own deadline, not the tail of
+		// the analysis phase's. It previously inherited the shared panel context, so
+		// slow seats left it nothing and it failed on the POST that launches its job
+		// — discarding a completed panel and re-running those same slow seats.
+		chairmanCtx, chairmanCancel := chairmanDeadline(ctx, panel.DeadlineMS)
+		roundtableCtx = chairmanCtx
+		defer chairmanCancel()
 		req.CostLimitUSD = remainingCostLimit(stepCostLimit, totalCost)
 		if stepCostLimit > 0 && req.CostLimitUSD <= 0 {
 			rt := roundtableResult(&feedback, false, false, analysis, len(seats), totalCost)

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -584,6 +584,10 @@ type panelAnalysis struct {
 	CostUnknown bool
 	Unreachable string
 	Reports     []panelSeatReport
+	// ReplayLost records that a seat could not be replayed because its durable
+	// result is gone. Retrying cannot fix that; only the engine's reservation
+	// recovery can, and it is reached by returning the error rather than parking.
+	ReplayLost bool
 }
 
 func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepResult, error) {
@@ -667,6 +671,16 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 	// one unavailable seat must not discard a usable quorum. Park only when the
 	// number of complete reports is actually below that configured minimum.
 	if analysis.Unreachable != "" && len(analysis.Reports) < panel.MinSuccessful {
+		// A seat whose durable result is gone cannot be recovered by waiting: the
+		// reservation stays replay-only, so every retry replays into the same
+		// missing result and parks again. Returning the error hands it to the
+		// engine's reservation recovery, which re-dispatches fresh work or parks
+		// the unreproducible spend for a human. Parking here instead is what made
+		// a slice cycle panel_unreachable for hours without ever progressing.
+		if analysis.ReplayLost {
+			return StepResult{CostUSD: analysis.CostUSD, CostUnknown: analysis.CostUnknown},
+				fmt.Errorf("roundtable panel could not be replayed: %s: %w", analysis.Unreachable, ErrDelegateReplayUnavailable)
+		}
 		rt := roundtableResult(&analysis.Feedback, false, false, analysis, len(seats), analysis.CostUSD)
 		rt.DeadlineHit = deadlineHit || errors.Is(roundtableCtx.Err(), context.DeadlineExceeded)
 		return StepResult{Status: StepPending, PauseReason: "panel_unreachable", Detail: analysis.Unreachable, CostUSD: analysis.CostUSD, CostUnknown: analysis.CostUnknown, Roundtable: rt}, nil
@@ -831,6 +845,7 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 	var cost float64
 	costUnknown := false
 	var seatFailures []string
+	replayLost := false
 	for _, o := range outcomes {
 		cost += o.cost
 		costUnknown = costUnknown || o.costUnknown
@@ -838,6 +853,9 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 			reason := "malformed_after_repair"
 			if o.transport {
 				reason = "delegate_error"
+			}
+			if errors.Is(o.err, ErrDelegateReplayUnavailable) {
+				replayLost = true
 			}
 			seatFailures = append(seatFailures, o.seat.persona+": "+reason+": "+o.err.Error())
 			voters--
@@ -895,7 +913,7 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 			feedback.Findings = append(feedback.Findings, wfe.Finding{ID: firstNonempty(f.ID, fmt.Sprintf("%s-%d", o.seat.persona, i+1)), Persona: o.seat.persona, Severity: firstNonempty(f.Severity, "blocking"), Location: f.Location, Summary: f.Summary, Recommendation: f.Recommendation})
 		}
 	}
-	return panelAnalysis{Feedback: feedback, Approvals: approvals, Voters: voters, CostUSD: cost, CostUnknown: costUnknown, Unreachable: strings.Join(seatFailures, "; "), Reports: reports}
+	return panelAnalysis{Feedback: feedback, Approvals: approvals, Voters: voters, CostUSD: cost, CostUnknown: costUnknown, Unreachable: strings.Join(seatFailures, "; "), Reports: reports, ReplayLost: replayLost}
 }
 
 // blockingFindingCount counts only the severities that must stop an artifact.

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1601,3 +1601,55 @@ func chairmanTestRoundtable(t *testing.T) *roundtablecfg.Store {
 	}
 	return store
 }
+
+// replayLostSeatAgents fails every seat the way a replay-only invocation does
+// when its durable delegate result is gone.
+type replayLostSeatAgents struct{}
+
+func (replayLostSeatAgents) Delegate(_ context.Context, _ DelegateRequest) (DelegateResult, error) {
+	return DelegateResult{}, &DelegateExecutionError{Err: ErrDelegateReplayUnavailable, Dispatched: true}
+}
+
+func (a replayLostSeatAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	return testDelegateGroup(ctx, requests, a.Delegate)
+}
+
+// Parking on a lost replay is unrecoverable by waiting: the reservation stays
+// replay-only, so the resumed attempt replays into the same missing result and
+// parks again. A live slice burned hours cycling that way. The gate must return
+// the error so the engine's reservation recovery runs.
+func TestPanelWithLostReplayReturnsTheErrorInsteadOfParking(t *testing.T) {
+	runner := &NativeRunner{agents: replayLostSeatAgents{}, roundtables: unpinnedTestRoundtable(t, "qa", "reviewer")}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("a complete plan artifact for review")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(t.Context(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Params: map[string]any{"roundtable": "default"}},
+		Proposal: "review the plan", Inputs: map[string]wfe.Artifact{"src": reviewed},
+		ReplayOnly: true,
+	})
+	if !errors.Is(err, ErrDelegateReplayUnavailable) {
+		t.Fatalf("lost replay did not surface for recovery: result=%+v err=%v", result, err)
+	}
+	if result.Status == StepPending && result.PauseReason == "panel_unreachable" {
+		t.Fatal("lost replay parked instead of returning the error")
+	}
+}
+
+// A seat that is merely unreachable is still a park: waiting can fix that.
+func TestPanelWithAnUnreachableSeatStillParks(t *testing.T) {
+	runner := &NativeRunner{agents: chairmanFailureAgents{}, roundtables: unpinnedTestRoundtable(t, "chairman", "chairman")}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("a complete plan artifact for review")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(t.Context(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Params: map[string]any{"roundtable": "default"}},
+		Proposal: "review the plan", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StepPending || result.PauseReason != "panel_unreachable" {
+		t.Fatalf("an unreachable seat should still park: %+v", result)
+	}
+}

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1653,3 +1653,48 @@ func TestPanelWithAnUnreachableSeatStillParks(t *testing.T) {
 		t.Fatalf("an unreachable seat should still park: %+v", result)
 	}
 }
+
+// The chairman is a separate step: it gets the configured deadline in full,
+// measured from the step context, however long the seats took. Sharing the
+// panel's context starved it to zero whenever they ran long, and it failed on
+// the POST that merely launches its job.
+func TestChairmanGetsItsOwnFullDeadline(t *testing.T) {
+	const deadlineMS = 600_000
+	budget := time.Duration(deadlineMS) * time.Millisecond
+	step := t.Context()
+
+	ctx, done := chairmanDeadline(step, deadlineMS)
+	defer done()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("chairman ran with no deadline at all")
+	}
+	// Its budget is the configured one, not a remainder, so it must be close to
+	// the full value rather than some fraction of it.
+	if remaining := time.Until(deadline); remaining < budget-time.Minute {
+		t.Fatalf("chairman budget=%v, want the configured %v", remaining, budget)
+	}
+
+	t.Run("an exhausted analysis phase does not shorten it", func(t *testing.T) {
+		exhausted, cancel := context.WithTimeout(step, time.Millisecond)
+		defer cancel()
+		<-exhausted.Done()
+		ctx, done := chairmanDeadline(step, deadlineMS)
+		defer done()
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("chairman inherited a spent budget: %v", err)
+		}
+		deadline, _ := ctx.Deadline()
+		if remaining := time.Until(deadline); remaining < budget-time.Minute {
+			t.Fatalf("chairman budget=%v after slow seats, want %v", remaining, budget)
+		}
+	})
+
+	t.Run("no configured deadline is left alone", func(t *testing.T) {
+		ctx, done := chairmanDeadline(step, 0)
+		defer done()
+		if ctx != step {
+			t.Fatal("an unbounded roundtable must stay unbounded")
+		}
+	})
+}


### PR DESCRIPTION
A slice spent 4h16m on nine review rounds. The rounds themselves were fast —
three complete impl -> freeze -> gate cycles took 14 minutes — but 117 of those
256 minutes were spent parked, producing nothing, in 20-to-40-minute dead
stretches.

The cause is a loop the panel could not leave. When a step's budget reservation
is left 'unresolved' or 'actual', the next invocation is replay-only: it must
reuse the durable delegate result rather than re-bill known spend. If that result
is gone, every seat fails with ErrDelegateReplayUnavailable.

engine.go runs RecoverLostReplay only for a step that RETURNS that error — it
re-dispatches a recoverable interruption, or parks unreproducible spend for a
human. author and implement do return it, which is why their recovery shows up
in the record as 'replay result lost; re-dispatching fresh'.

The roundtable never returned it. A failed seat becomes an abstention, and the
gate returned StepPending{panel_unreachable} with a nil error. So recovery never
ran, the reservation stayed replay-only, the 60-second backoff resumed straight
back into the same missing result, and the panel parked again. Waiting cannot
fix a result that no longer exists.

The panel now reports whether a seat failed for that specific reason, and when
it cannot reach min_successful because of it, returns the error instead of
parking. Everything else still parks: an unreachable or slow seat is exactly the
case a backoff does fix, and that path is unchanged.

Tests cover both sides — a lost replay surfaces the error rather than parking,
and a merely unreachable seat still parks.