### PR TITLE
Deferring work means not building its groundwork either

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -237,6 +237,7 @@ func (r *NativeRunner) author(ctx context.Context, req StepRequest, kind string)
 		"do not add deliverables, mechanisms, file formats, flags, or migrations the request did not ask for, and do not generalize a specific ask into a framework. " +
 		"Work the request did not ask for but that you judge genuinely necessary is technical debt. Taking on documented technical debt is completely acceptable; the requirement is that it is written down. " +
 		"Name it under a Technical debt, Deferred follow-up, or Non-goals heading and do not plan it — that is a correct and expected outcome, not a failure to plan. " +
+		"Deferring it means planning none of it, including its groundwork: do not plan a store, fixture, format, or hook whose only purpose is to enable work this same plan defers. " +
 		"What is not acceptable is leaving it undocumented: debt you neither plan nor record is a gap that silently ships.\n\nORIGINAL REQUEST:\n" + string(proposal.Content)
 	if req.Feedback != nil {
 		encoded, _ := json.Marshal(req.Feedback)

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1724,6 +1724,31 @@ func TestPlannerIsAskedForTheSmallestPlanThatSatisfiesTheRequest(t *testing.T) {
 	}
 }
 
+// Told to defer unrequested work, the planner deferred the work and planned its
+// foundations anyway: a snapshot ledger, then committed git fixtures, each one
+// there only to enable a history-aware mode the same plan listed as deferred.
+// The panel caught both, but every catch costs a gate round, and the run parked
+// at convergence_limit one round short. Deferring has to mean the groundwork too.
+func TestPlannerIsToldNotToBuildFoundationsForWorkItDefers(t *testing.T) {
+	agents := &recordingAgents{draftResponses: []string{"# Plan\n\nDo exactly what was asked."}}
+	runner := &NativeRunner{agents: agents}
+	_, err := runner.author(t.Context(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Repo: "/repo"},
+		Node:     wfe.Node{ID: "plan"},
+		Inputs:   map[string]wfe.Artifact{"proposal": {Type: "proposal", Content: []byte("add a CONTRIBUTING.md section")}},
+	}, "plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := agents.requests[0].Prompt
+	for _, want := range []string{"Deferring it means planning none of it, including its groundwork",
+		"whose only purpose is to enable work this same plan defers"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("planner prompt lets deferred work keep its foundations, missing %q", want)
+		}
+	}
+}
+
 // Reviewers treated only SUBSTITUTION as drift, so a plan that kept the goal and
 // piled work on top read as aligned and the gate ratcheted scope upward every
 // round. Unrequested addition is drift too — without dulling the panel's real


### PR DESCRIPTION
## What

One clause added to the `author.plan` prompt: deferring unrequested work means planning none of it, **including its groundwork** — no store, fixture, format, or hook whose only purpose is to enable work the same plan defers.

## Why

Observed in run `wi_3aab2e60` (the first run under #1997's scope bound, same 2,774-byte proposal as the 11-packet baseline). The planner honoured the instruction to defer unrequested work, then built its foundations anyway:

| Round | Added | Panel verdict |
|---|---|---|
| 3–4 | `.proposal-reconcile-snapshots.json` ledger + `RECONCILE-REVIEW.md` queue | drifted → planner removed both |
| 6 | committed git-repository fixture infrastructure | drifted → out of budget |

Both existed solely to enable a history-aware mode the same plan listed under *Deferred follow-up*.

#1997 works — the panel caught every addition unprompted, and the plan came in at 7,980 B against the baseline's 23,698 B with 3 work sections against 8. But the guard fires at **review**, and each catch costs a gate round. Three of six rounds went to add → reject → remove, and the run parked at `convergence_limit` one round short. The baseline passed on its sixth attempt with the same `max_rounds: 6`.

This moves the bound to the author, where it costs nothing.

## Scope

Prompt text plus one test. No engine behaviour change, no budget change. The test asserts the clause is present, so a later edit cannot silently drop it — it cannot prove reviewers or planners honour it; only a real run shows that.