### PR TITLE
Keep a park from being lost to the step's own cancellation

### DIFF
--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -456,7 +456,10 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		} else {
 			detail = reason + ": " + safeDiagnostic(detail)
 		}
-		if err := e.db.ParkWithDetail(ctx, item.ID, node.ID, reason, detail, step.CostUSD); err != nil {
+		// The delegate has already run and its spend is reconciled; a cancelled
+		// park loses the transition and strands the reservation in 'actual',
+		// which the next replay can only park as replay_unrecoverable.
+		if err := e.db.ParkWithDetail(context.WithoutCancel(ctx), item.ID, node.ID, reason, detail, step.CostUSD); err != nil {
 			return out, err
 		}
 		out.Parked, out.PauseReason = true, reason
@@ -484,7 +487,7 @@ func (e *Engine) parkAfterSpend(ctx context.Context, item db1.WorkItem, reason s
 	if cause != nil {
 		detail += ": " + safeDiagnostic(cause.Error())
 	}
-	if err := e.db.ParkWithDetail(ctx, item.ID, item.Stage, reason, detail, costUSD); err != nil {
+	if err := e.db.ParkWithDetail(context.WithoutCancel(ctx), item.ID, item.Stage, reason, detail, costUSD); err != nil {
 		return fmt.Errorf("%s: %v; park failed: %w", reason, cause, err)
 	}
 	return nil

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -1347,3 +1347,76 @@ func TestMaxRoundsIsTheNodeRepeatBudget(t *testing.T) {
 		})
 	}
 }
+
+// The runner's context carries the step deadline. A park happens AFTER the
+// delegate ran and its spend was reconciled, so inheriting that cancellation
+// loses the transition and strands the reservation in 'actual' — the exact
+// state the next replay can only park as replay_unrecoverable, which no
+// operator can resume. Observed in wi_ee32a2e3: "begin park transition:
+// context deadline exceeded", then an unrecoverable park one round later.
+func TestParkSurvivesACancelledStepContext(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte("name: one\nstart: draft\nnodes:\n  - id: draft\n    block: author.proposal\n    next: plan\n  - id: plan\n    block: author.plan\n    in:\n      proposal: draft.out\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "one.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := db1.CreateWorkItem{ID: "wi_park_cancelled", Repo: "repo", ProposalPath: "p",
+		WorkflowName: "one", WorkflowVersion: def.Version, StartStage: "draft", MaxCostUSD: 1}
+	if err := store.CreateWorkItem(t.Context(), item); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal(item.ID, []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	eng, err := New(store, artifacts, workflowDir, cancelBeforeParkRunner{cancel: cancel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := eng.Advance(ctx, "wi_park_cancelled"); err != nil {
+		t.Fatalf("advance draft: %v", err)
+	}
+	if _, err := eng.Advance(ctx, "wi_park_cancelled"); err != nil {
+		t.Fatalf("advance plan: %v", err)
+	}
+	got, err := store.WorkItem(t.Context(), "wi_park_cancelled")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PauseReason != "plan_missing" {
+		t.Fatalf("park lost to the cancelled step context: pause_reason=%q", got.PauseReason)
+	}
+	if got.ReservationState != "" || got.ReservedCostUSD != 0 {
+		t.Fatalf("reservation stranded by a lost park: state=%q reserved=%v",
+			got.ReservationState, got.ReservedCostUSD)
+	}
+}
+
+// Cancels the step context the way an expiring deadline would, then returns a
+// result that forces the engine down its park-after-spend path.
+type cancelBeforeParkRunner struct{ cancel context.CancelFunc }
+
+func (r cancelBeforeParkRunner) Run(_ context.Context, req StepRequest) (StepResult, error) {
+	if req.Node.Block != "author.plan" {
+		return StepResult{Status: StepAdvanced, Artifact: "a proposal"}, nil
+	}
+	r.cancel()
+	return StepResult{Status: StepAdvanced, CostUSD: 0.2}, nil
+}


### PR DESCRIPTION
## The failure

Run `wi_ee32a2e3` died at `plan_gate` round 5 with **one blocking finding left**, having converged from 5 findings to 1 and 11,436 B to 10,221 B. It was not a convergence failure:

```
11:17:35 ERROR advance workflow work_item=wi_ee32a2e3…
         error="begin park transition: context deadline exceeded"
11:19:31 plan_gate pause  replay_unrecoverable: reconciled result lost, parked for human
```

## Why one timeout is fatal

A park is bookkeeping **after** the delegate ran and its spend was reconciled, but both `ParkWithDetail` call sites inherited the step context. When that context's deadline expires first, the transition is lost and the reservation stays in `actual` with no durable result.

That is exactly the state `RecoverLostReplay` can only resolve by parking `replay_unrecoverable` — correctly, since re-running would silently re-bill measured spend. And `replay_unrecoverable` is deliberately **absent** from `Resume`'s operator-resumable set:

```
409 {"error":"pause reason \"replay_unrecoverable\" is lifecycle-owned and cannot be resumed manually"}
```

So one transient DB timeout wedges a run permanently, with no operator recovery. The fail-closed design is right; the input to it was wrong.

## The fix

`context.WithoutCancel` on both sites. This is the established idiom for durability writes in the same file — `ParkBudgetTree`, the deferred budget release, `RecoverLostReplay` and the `wall_cap` park all already use it. These two were the outliers.

## Test

`TestParkSurvivesACancelledStepContext` drives a runner that cancels the step context the way an expiring deadline would, then asserts the park persisted and the reservation is not stranded. Without the fix it reproduces the production error exactly:

```
advance plan: plan_missing: runner returned no plan; park failed: begin park transition: context canceled
```

## Deliberately not fixed

`scheduler.go`'s `turn_cap` park has the same asymmetry as the `wall_cap` park two lines below it, but it fires before dispatch with no spend and no reservation — a lost one simply re-parks next pass. Noted rather than folded in.