### PR TITLE
Reap delegate containers on runtimes without regex name filters

### DIFF
--- a/src/modules/delegates/delegate_backend_docker.c
+++ b/src/modules/delegates/delegate_backend_docker.c
@@ -231,10 +231,34 @@ static int run_docker(const char *const argv[])
 
 #define DOCKER_PROBE_TIMEOUT_MS 15000
 
+/* True when `name` is one of ours. The container-name prefix is matched HERE
+ * rather than with `docker ps --filter name=^aimee-delegate-`: the anchored regex
+ * is a Docker-ism, and runtimes that treat the name filter as a literal substring
+ * (e.g. the LXC-backed docker shim) match nothing at all, silently turning both
+ * cleanup paths into no-ops and leaking a container per stale turn. Filtering in C
+ * keeps the strict prefix the anchor was there to enforce, on every runtime. */
+static int is_delegate_container_name(const char *name)
+{
+   return name && strncmp(name, "aimee-delegate-", 15) == 0;
+}
+
+/* Accept only a bare container id, so a hostile or malformed name can never reach
+ * `docker rm`. */
+static int is_container_id(const char *id)
+{
+   size_t len = id ? strlen(id) : 0;
+   if (len < 12 || len > 64)
+      return 0;
+   for (size_t i = 0; i < len; i++)
+      if (!isxdigit((unsigned char)id[i]))
+         return 0;
+   return 1;
+}
+
 int delegate_backend_docker_remove_orphans(void)
 {
-   const char *list_argv[] = {resolve_docker_bin(),    "ps", "-aq", "--filter",
-                              "name=^aimee-delegate-", NULL};
+   const char *list_argv[] = {resolve_docker_bin(), "ps", "-a", "--format",
+                              "{{.ID}} {{.Names}}", NULL};
    char *out = NULL;
    if (safe_exec_capture_cwd_env_timeout(list_argv, NULL, NULL, &out, 1 << 20,
                                          DOCKER_PROBE_TIMEOUT_MS) != 0)
@@ -244,13 +268,14 @@ int delegate_backend_docker_remove_orphans(void)
    }
    int removed = 0;
    char *save = NULL;
-   for (char *id = strtok_r(out, "\r\n", &save); id; id = strtok_r(NULL, "\r\n", &save))
+   for (char *line = strtok_r(out, "\r\n", &save); line; line = strtok_r(NULL, "\r\n", &save))
    {
-      size_t len = strlen(id);
-      int valid = len >= 12 && len <= 64;
-      for (size_t i = 0; valid && i < len; i++)
-         valid = isxdigit((unsigned char)id[i]) != 0;
-      if (!valid)
+      char id[80], name[256];
+      if (sscanf(line, "%79s %255s", id, name) != 2)
+         continue;
+      if (!is_delegate_container_name(name))
+         continue;
+      if (!is_container_id(id))
       {
          LOG_WARN("delegate-sandbox", "refusing invalid orphan container id from docker: %s", id);
          continue;
@@ -291,9 +316,8 @@ static time_t docker_utc_epoch(int y, int mo, int d, int h, int mi, int s)
  * turn is never removed. Returns the count removed, or -1 on a docker error. */
 int delegate_backend_docker_reap_aged(int max_age_secs)
 {
-   const char *list_argv[] = {
-       resolve_docker_bin(),     "ps", "--filter", "name=^aimee-delegate-", "--format",
-       "{{.ID}} {{.CreatedAt}}", NULL};
+   const char *list_argv[] = {resolve_docker_bin(), "ps", "--format",
+                              "{{.ID}} {{.Names}} {{.CreatedAt}}", NULL};
    char *out = NULL;
    if (safe_exec_capture_cwd_env_timeout(list_argv, NULL, NULL, &out, 1 << 20,
                                          DOCKER_PROBE_TIMEOUT_MS) != 0)
@@ -306,18 +330,14 @@ int delegate_backend_docker_reap_aged(int max_age_secs)
    char *save = NULL;
    for (char *line = strtok_r(out, "\r\n", &save); line; line = strtok_r(NULL, "\r\n", &save))
    {
-      /* Line is Go's default CreatedAt format: "<id> 2006-01-02 15:04:05 -0700 MST". */
-      char id[80];
+      /* Line is "<id> <name> " + Go's default CreatedAt: "2006-01-02 15:04:05 -0700 MST". */
+      char id[80], name[256];
       int yy, mo, dd, hh, mi, ss;
       char off[8] = "+0000";
-      if (sscanf(line, "%79s %d-%d-%d %d:%d:%d %7s", id, &yy, &mo, &dd, &hh, &mi, &ss, off) < 7)
+      if (sscanf(line, "%79s %255s %d-%d-%d %d:%d:%d %7s", id, name, &yy, &mo, &dd, &hh, &mi, &ss,
+                 off) < 8)
          continue;
-      /* Only accept a bare container id (hex), same guard as remove_orphans. */
-      size_t len = strlen(id);
-      int valid = len >= 12 && len <= 64;
-      for (size_t i = 0; valid && i < len; i++)
-         valid = isxdigit((unsigned char)id[i]) != 0;
-      if (!valid)
+      if (!is_delegate_container_name(name) || !is_container_id(id))
          continue;
       long off_secs = 0;
       if ((off[0] == '+' || off[0] == '-') && strlen(off) >= 5 && isdigit((unsigned char)off[1]))

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -241,7 +241,8 @@ static const char *write_fake_docker_fixture(void)
            "    for path in \"$STATE_DIR\"/*.exists; do\n"
            "      [ -e \"$path\" ] || continue\n"
            "      name=\"${path##*/}\"\n"
-           "      printf '%%s\\n' \"${name%%.exists}\"\n"
+           "      id=\"${name%%.exists}\"\n"
+           "      printf '%%s aimee-delegate-%%s\\n' \"$id\" \"$id\"\n"
            "    done\n"
            "    exit 0\n"
            "    ;;\n"
@@ -885,8 +886,10 @@ static void test_reap_aged_removes_only_old(void)
            "#!/bin/bash\n"
            "case \"$1\" in\n"
            "  ps)\n"
-           "    echo \"aaaaaaaaaaaa 2000-01-01 00:00:00 +0000 UTC\"\n"
-           "    echo \"bbbbbbbbbbbb $(date -u +'%%Y-%%m-%%d %%H:%%M:%%S') +0000 UTC\"\n"
+           "    echo \"aaaaaaaaaaaa aimee-delegate-old 2000-01-01 00:00:00 +0000 UTC\"\n"
+           "    echo \"bbbbbbbbbbbb aimee-delegate-new $(date -u +'%%Y-%%m-%%d %%H:%%M:%%S') "
+           "+0000 UTC\"\n"
+           "    echo \"cccccccccccc some-other-container 2000-01-01 00:00:00 +0000 UTC\"\n"
            "    ;;\n"
            "  rm)\n"
            "    shift 2\n"
@@ -907,8 +910,11 @@ static void test_reap_aged_removes_only_old(void)
    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
    buf[n] = '\0';
    fclose(f);
-   assert(strstr(buf, "aaaaaaaaaaaa") != NULL); /* ancient -> reaped */
-   assert(strstr(buf, "bbbbbbbbbbbb") == NULL); /* current -> kept */
+   assert(strstr(buf, "aaaaaaaaaaaa") != NULL); /* ancient delegate -> reaped */
+   assert(strstr(buf, "bbbbbbbbbbbb") == NULL); /* current delegate -> kept */
+   /* Ancient, but NOT ours. The container-name prefix is enforced in C now that the
+    * `--filter name=^aimee-delegate-` anchor is gone, so this must survive. */
+   assert(strstr(buf, "cccccccccccc") == NULL);
 
    unsetenv("AIMEE_DOCKER_BIN");
    unlink(script);


### PR DESCRIPTION
## The leak

14 `aimee-delegate-*` containers running on an idle host, oldest up **16 hours**. A delegate should be short-lived.

## Root cause

Both cleanup paths asked docker for their own containers with an anchored name filter:

```
--filter name=^aimee-delegate-
```

The `^` is a Docker-ism. Docker treats the name filter as a **regex**; a runtime that treats it as a **literal substring** matches nothing at all. On the LXC-backed shim (`docker 24.0.0-lxc`) that is exactly what happens:

| query | result |
|---|---|
| `ps --filter name=^aimee-delegate- --format '{{.ID}} {{.CreatedAt}}'` | **empty** |
| `ps --filter name=aimee-delegate --format '{{.ID}} {{.CreatedAt}}'` | 14 rows |
| `ps --format '{{.ID}} {{.CreatedAt}}'` | 14 rows |
| `ps -aq --filter name=^aimee-delegate-` | **empty** |

So `remove_orphans()` (startup) and `reap_aged()` (delegate monitor, `server_delegate_monitor.c:141`) were both **silent no-ops** — they ran, found nothing, reported nothing. The leak `reap_aged`'s own comment describes — one container per stale-cancelled or failed turn — therefore ran unbounded until a restart.

Worth noting the reaper was written *specifically* for this leak and was correct; it just never saw a container.

## The fix

Neither function depends on the runtime's filter semantics any more. Both list containers **with names** and match the `aimee-delegate-` prefix in C.

That preserves the strict prefix the anchor existed to enforce — on every runtime — and the bare-hex container-id guard before `docker rm` is unchanged.

Verified against the runtime that broke the old form: the new `ps -a --format '{{.ID}} {{.Names}}'` and `ps --format '{{.ID}} {{.Names}} {{.CreatedAt}}'` both return all 14, with hex ids and timestamps in exactly the format `reap_aged` parses.

## Test

`test_reap_aged_removes_only_old` now also emits an ancient container that is **not** ours and asserts it survives, so the prefix guard cannot regress into removing foreign containers. `test_remove_orphans_accepts_only_container_ids` still rejects the over-long id. Both pass.

## Not fixed here

`docker_release()` still only removes the container on the normal completion path, so the reaper remains the safety net rather than the primary mechanism. That is the pre-existing design and is out of scope for this fix.