### PR TITLE
Say what a gate was still blocked on when its rounds run out

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -1610,8 +1610,13 @@ type ReviewOutcome struct {
 // RecordRequestedChanges atomically records a plan-gate rejection. A retry cap
 // is a recoverable park, never terminal abandonment. Repeating an identical
 // plan+feedback pair parks early because no information is changing.
+// unresolved names the findings still blocking when the gate runs out of rounds.
+// Without it the park records the bare reason "convergence_limit", which says a
+// budget was spent but not what was never fixed -- leaving a human to reconstruct
+// it from the last feedback artifact. A gate that burned every round on the same
+// finding is evidence about the plan or the request; the park should carry it.
 func (s *Store) RecordRequestedChanges(ctx context.Context, workItemID, gate, planStage,
-	planHash, feedbackHash string, maxIterations, maxIdentical int, costUSD float64) (ReviewOutcome, error) {
+	planHash, feedbackHash, unresolved string, maxIterations, maxIdentical int, costUSD float64) (ReviewOutcome, error) {
 	if workItemID == "" || gate == "" || planStage == "" || planHash == "" || feedbackHash == "" {
 		return ReviewOutcome{}, errors.New("complete review transition coordinates are required")
 	}
@@ -1685,9 +1690,13 @@ SET current_stage=?, pause_reason=?, paused_state=?, content_hash=?, cum_cost_us
 WHERE work_item_id=?`, planStage, out.PauseReason, gate, planHash, costUSD, workItemID); err != nil {
 			return ReviewOutcome{}, fmt.Errorf("park non-converging work item: %w", err)
 		}
+		detail := out.PauseReason
+		if strings.TrimSpace(unresolved) != "" {
+			detail = fmt.Sprintf("%s after %d rounds; still unresolved: %s", out.PauseReason, attempts, unresolved)
+		}
 		if _, err := tx.ExecContext(ctx, `
 INSERT INTO lifecycle_event (work_item_id, stage, kind, actor, detail, content_hash, cost_usd)
-VALUES (?, ?, 'pause', 'go-wfe', ?, ?, ?)`, workItemID, gate, out.PauseReason, planHash, costUSD); err != nil {
+VALUES (?, ?, 'pause', 'go-wfe', ?, ?, ?)`, workItemID, gate, detail, planHash, costUSD); err != nil {
 			return ReviewOutcome{}, fmt.Errorf("record convergence park: %w", err)
 		}
 	} else {

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -511,7 +511,7 @@ func TestMaxIterationsParksWithoutAbandoning(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		out, err := store.RecordRequestedChanges(ctx, "wi_cap", "plan_gate", "plan",
-			"plan-"+string(rune('a'+i)), "feedback-"+string(rune('a'+i)), 3, 3, 0)
+			"plan-"+string(rune('a'+i)), "feedback-"+string(rune('a'+i)), "subject anchor never defined", 3, 3, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -534,7 +534,7 @@ func TestIdenticalPlanAndFeedbackParksAsNoProgress(t *testing.T) {
 	ctx := context.Background()
 	for i := 0; i < 3; i++ {
 		out, err := store.RecordRequestedChanges(ctx, "wi_repeat", "plan_gate", "plan",
-			"same-plan", "same-feedback", 24, 3, 0)
+			"same-plan", "same-feedback", "", 24, 3, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -558,7 +558,7 @@ func TestChangedPlanOrFeedbackIsPositiveProgress(t *testing.T) {
 	cases := [][2]string{{"plan-a", "feedback-a"}, {"plan-b", "feedback-a"}, {"plan-b", "feedback-b"}}
 	for _, pair := range cases {
 		out, err := store.RecordRequestedChanges(ctx, "wi_progress", "plan_gate", "plan",
-			pair[0], pair[1], 24, 3, 0)
+			pair[0], pair[1], "", 24, 3, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1124,7 +1124,7 @@ func TestGateIterationCapSurvivesTheAuthorsReentry(t *testing.T) {
 	parkedAt := -1
 	for i := 0; i < 10; i++ {
 		out, err := store.RecordRequestedChanges(ctx, "wi_loop", "plan_gate", "plan",
-			fmt.Sprintf("plan-%d", i), fmt.Sprintf("feedback-%d", i), 3, 99, 0)
+			fmt.Sprintf("plan-%d", i), fmt.Sprintf("feedback-%d", i), "", 3, 99, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -436,7 +436,8 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 			return out, e.parkAfterSpend(ctx, item, "feedback_encode_failed", err, step.CostUSD)
 		}
 		transition, err := e.db.RecordRequestedChanges(ctx, item.ID, node.ID, node.OnFail,
-			reviewed.Hash, wfe.Hash(encoded), maxIterations(node), e.maxNoProgress, step.CostUSD)
+			reviewed.Hash, wfe.Hash(encoded), unresolvedBlockers(step.Feedback),
+			maxIterations(node), e.maxNoProgress, step.CostUSD)
 		if err != nil {
 			return out, err
 		}
@@ -553,4 +554,37 @@ func positiveIntParam(node wfe.Node, name string) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// unresolvedBlockers summarises what a gate is still blocking on, for the park
+// detail when it exhausts its rounds. A gate that spent its whole budget without
+// clearing these is saying something about the plan or the request, and the park
+// is where a human looks first -- "convergence_limit" alone sends them digging
+// through the feedback artifact to find out what never got fixed.
+func unresolvedBlockers(feedback *wfe.ReviewFeedback) string {
+	if feedback == nil {
+		return ""
+	}
+	summaries := make([]string, 0, 3)
+	for _, finding := range feedback.Findings {
+		switch strings.ToLower(strings.TrimSpace(finding.Severity)) {
+		case "foundational", "blocking":
+		default:
+			continue
+		}
+		summary := strings.TrimSpace(finding.Summary)
+		if summary == "" {
+			continue
+		}
+		if len(summary) > 160 {
+			summary = summary[:157] + "..."
+		}
+		summaries = append(summaries, summary)
+		// Three is enough to characterise the blockage; the full set stays in the
+		// feedback artifact, and an unbounded detail would bloat every event row.
+		if len(summaries) == 3 {
+			break
+		}
+	}
+	return strings.Join(summaries, " | ")
 }

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -561,30 +561,57 @@ func positiveIntParam(node wfe.Node, name string) (int, bool) {
 // clearing these is saying something about the plan or the request, and the park
 // is where a human looks first -- "convergence_limit" alone sends them digging
 // through the feedback artifact to find out what never got fixed.
+//
+// The chairman's findings come first. Its verdict overrides the seats', and its
+// original-request alignment finding is the closest thing the run has to a stated
+// reason the work failed, so it is what a human needs to read first. Each entry
+// carries its recommendation, because "what was wrong" without "what to do" still
+// leaves the reader opening artifacts.
 func unresolvedBlockers(feedback *wfe.ReviewFeedback) string {
 	if feedback == nil {
 		return ""
 	}
-	summaries := make([]string, 0, 3)
-	for _, finding := range feedback.Findings {
+	blocking := func(finding wfe.Finding) bool {
 		switch strings.ToLower(strings.TrimSpace(finding.Severity)) {
 		case "foundational", "blocking":
-		default:
-			continue
+			return strings.TrimSpace(finding.Summary) != ""
 		}
-		summary := strings.TrimSpace(finding.Summary)
-		if summary == "" {
-			continue
+		return false
+	}
+	ordered := make([]wfe.Finding, 0, len(feedback.Findings))
+	for _, finding := range feedback.Findings {
+		if blocking(finding) && strings.EqualFold(strings.TrimSpace(finding.Persona), "chairman") {
+			ordered = append(ordered, finding)
 		}
-		if len(summary) > 160 {
-			summary = summary[:157] + "..."
+	}
+	for _, finding := range feedback.Findings {
+		if blocking(finding) && !strings.EqualFold(strings.TrimSpace(finding.Persona), "chairman") {
+			ordered = append(ordered, finding)
 		}
-		summaries = append(summaries, summary)
-		// Three is enough to characterise the blockage; the full set stays in the
-		// feedback artifact, and an unbounded detail would bloat every event row.
-		if len(summaries) == 3 {
+	}
+
+	clip := func(text string, limit int) string {
+		text = strings.Join(strings.Fields(text), " ")
+		if len(text) > limit {
+			return text[:limit-3] + "..."
+		}
+		return text
+	}
+	entries := make([]string, 0, 3)
+	for _, finding := range ordered {
+		entry := clip(finding.Summary, 200)
+		if rec := clip(finding.Recommendation, 120); rec != "" {
+			entry += " -> " + rec
+		}
+		if persona := strings.TrimSpace(finding.Persona); persona != "" {
+			entry = "[" + persona + "] " + entry
+		}
+		entries = append(entries, entry)
+		// Three is enough to characterise the blockage; the full review stays in
+		// the feedback artifact, and an unbounded detail would bloat every event.
+		if len(entries) == 3 {
 			break
 		}
 	}
-	return strings.Join(summaries, " | ")
+	return strings.Join(entries, " | ")
 }

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -1420,3 +1420,48 @@ func (r cancelBeforeParkRunner) Run(_ context.Context, req StepRequest) (StepRes
 	r.cancel()
 	return StepResult{Status: StepAdvanced, CostUSD: 0.2}, nil
 }
+
+// A gate that spends its whole round budget is evidence about the plan or the
+// request, but the park recorded only "convergence_limit" -- a spent budget with
+// no statement of what was never fixed. Observed on wi_79e96261: ten rounds, and
+// the operator had to open the feedback artifact to learn the gate had been stuck
+// on a subject declaration the proposal never defined.
+func TestUnresolvedBlockersSummarisesWhatHeldTheGate(t *testing.T) {
+	if got := unresolvedBlockers(nil); got != "" {
+		t.Fatalf("no feedback must summarise to nothing, got %q", got)
+	}
+	feedback := &wfe.ReviewFeedback{Findings: []wfe.Finding{
+		{Severity: "suggestion", Summary: "could be tidier"},
+		{Severity: "foundational", Summary: "the declared subject is never defined"},
+		{Severity: "nit", Summary: "typo"},
+		{Severity: "blocking", Summary: "the sweep has no acceptance criterion"},
+	}}
+	got := unresolvedBlockers(feedback)
+	if !strings.Contains(got, "the declared subject is never defined") ||
+		!strings.Contains(got, "the sweep has no acceptance criterion") {
+		t.Fatalf("blocking and foundational findings must survive: %q", got)
+	}
+	// Suggestions and nits never held the gate, so naming them would misdirect
+	// whoever reads the park.
+	if strings.Contains(got, "could be tidier") || strings.Contains(got, "typo") {
+		t.Fatalf("non-blocking findings must not appear: %q", got)
+	}
+}
+
+// The detail lands on an append-only event row, so an unbounded summary would
+// bloat every park. Three findings characterise the blockage; the rest stay in
+// the feedback artifact.
+func TestUnresolvedBlockersIsBounded(t *testing.T) {
+	feedback := &wfe.ReviewFeedback{}
+	for i := 0; i < 6; i++ {
+		feedback.Findings = append(feedback.Findings, wfe.Finding{
+			Severity: "blocking", Summary: strings.Repeat("x", 400)})
+	}
+	got := unresolvedBlockers(feedback)
+	if strings.Count(got, "|") != 2 {
+		t.Fatalf("expected at most three findings, got %d separators", strings.Count(got, "|"))
+	}
+	if strings.Contains(got, strings.Repeat("x", 200)) {
+		t.Fatal("individual summaries must be truncated")
+	}
+}

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -1431,15 +1431,24 @@ func TestUnresolvedBlockersSummarisesWhatHeldTheGate(t *testing.T) {
 		t.Fatalf("no feedback must summarise to nothing, got %q", got)
 	}
 	feedback := &wfe.ReviewFeedback{Findings: []wfe.Finding{
-		{Severity: "suggestion", Summary: "could be tidier"},
-		{Severity: "foundational", Summary: "the declared subject is never defined"},
-		{Severity: "nit", Summary: "typo"},
-		{Severity: "blocking", Summary: "the sweep has no acceptance criterion"},
+		{Severity: "suggestion", Persona: "qa", Summary: "could be tidier"},
+		{Severity: "blocking", Persona: "architect", Summary: "the sweep has no acceptance criterion",
+			Recommendation: "list the files to move"},
+		{Severity: "nit", Persona: "qa", Summary: "typo"},
+		{Severity: "foundational", Persona: "chairman", Summary: "the declared subject is never defined",
+			Recommendation: "amend the proposal to define it"},
 	}}
 	got := unresolvedBlockers(feedback)
-	if !strings.Contains(got, "the declared subject is never defined") ||
-		!strings.Contains(got, "the sweep has no acceptance criterion") {
-		t.Fatalf("blocking and foundational findings must survive: %q", got)
+	// The chairman's verdict overrides the seats', so its reason must lead: it is
+	// the run's stated explanation of why the work failed.
+	if !strings.HasPrefix(got, "[chairman] the declared subject is never defined") {
+		t.Fatalf("chairman's review must come first: %q", got)
+	}
+	if !strings.Contains(got, "-> amend the proposal to define it") {
+		t.Fatalf("recommendation must survive so the reader knows what to do: %q", got)
+	}
+	if !strings.Contains(got, "the sweep has no acceptance criterion") {
+		t.Fatalf("other blocking findings must still appear: %q", got)
 	}
 	// Suggestions and nits never held the gate, so naming them would misdirect
 	// whoever reads the park.
@@ -1455,13 +1464,14 @@ func TestUnresolvedBlockersIsBounded(t *testing.T) {
 	feedback := &wfe.ReviewFeedback{}
 	for i := 0; i < 6; i++ {
 		feedback.Findings = append(feedback.Findings, wfe.Finding{
-			Severity: "blocking", Summary: strings.Repeat("x", 400)})
+			Severity: "blocking", Summary: strings.Repeat("x", 400),
+			Recommendation: strings.Repeat("y", 400)})
 	}
 	got := unresolvedBlockers(feedback)
-	if strings.Count(got, "|") != 2 {
-		t.Fatalf("expected at most three findings, got %d separators", strings.Count(got, "|"))
+	if strings.Count(got, " | ") != 2 {
+		t.Fatalf("expected at most three findings, got %d separators", strings.Count(got, " | "))
 	}
-	if strings.Contains(got, strings.Repeat("x", 200)) {
-		t.Fatal("individual summaries must be truncated")
+	if strings.Contains(got, strings.Repeat("x", 220)) || strings.Contains(got, strings.Repeat("y", 140)) {
+		t.Fatal("summary and recommendation must each be truncated")
 	}
 }


### PR DESCRIPTION
## Why

A gate that spends its entire round budget is telling you something about the plan or the request. The park recorded only:

```
convergence_limit
```

A budget was spent. Nothing about what was never fixed.

## The case that prompted it

Run `wi_79e96261` — ten rounds, parked `convergence_limit`. The real blockage: the proposal asks the lint to fire when a *"declared subject/anchor no longer resolves"*, and **no such declaration exists in the repo**. The panel had been saying so since round 3.

None of that reached the park. An operator sees a bare reason and has to go open `feedback.json` to reconstruct why ten rounds were spent.

## What changes

The park detail now carries the round count and the findings still blocking:

```
convergence_limit after 10 rounds; still unresolved: the declared subject is never
defined | the sweep has no acceptance criterion
```

- **Only foundational and blocking findings.** Suggestions and nits never held the gate; naming them would misdirect whoever reads the park.
- **Capped at three, each truncated.** This lands on an append-only event row, and the complete set is already in the feedback artifact.

## What this deliberately does NOT do

It does **not** rename the park to `request_unimplementable`. The engine cannot distinguish a bad plan from a bad request, and asserting either would be a guess dressed as a diagnosis. It reports the evidence; the human makes the call.

That distinction matters because #2005 already added the path for a reviewer that *can* make the call — a `blocked` verdict. This is the deterministic complement: it needs no model cooperation and fires on evidence the engine already has.

Worth stating plainly: on its first opportunity, #2005's `blocked` verdict was **not** used — the panel returned `changes` and the run parked on `convergence_limit` anyway. That is precisely why a mechanism that does not depend on a model volunteering anything is worth having alongside it.