### PR TITLE
Archive the search-egress proposal: it shipped

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -7,8 +7,8 @@ section does not imply global priority.
 
 | State | Folder | Count |
 | --- | --- | --- |
-| Shipped | [`proposals/done/`](proposals/done/) | 209 |
-| Pending | [`proposals/pending/`](proposals/pending/) | 57 |
+| Shipped | [`proposals/done/`](proposals/done/) | 210 |
+| Pending | [`proposals/pending/`](proposals/pending/) | 56 |
 | Accepted (locked, unimplemented) | `proposals/accepted/` | 0 |
 | Deferred | `proposals/deferred/` | 0 |
 | Rejected | `proposals/rejected/` | 0 |
@@ -97,7 +97,6 @@ The complete 2026-07-26 reconciliation, including source/test/commit evidence fo
 - [Proposal: Proposal-supersession hygiene — same-commit move + a documented rule](proposals/pending/proposal-supersession-hygiene.md)
 - [Remote session start: workspace context residual](proposals/pending/remote-session-start-workspace-context.md)
 - [Route descriptor single source: residual work](proposals/pending/route-descriptor-single-source-of-truth-residual.md)
-- [Search egress policy: separate untrusted destinations from operator-configured endpoints](proposals/pending/search-egress-policy-split.md)
 - [Proposal: Standing LoCoMo / LongMemEval benchmark cadence](proposals/pending/standing-benchmark-cadence.md)
 - [Proposal: the registration chain and the static thin client](proposals/pending/thin-client-capability-advertisement.md)
 - [Tiered LLM offering: remaining program scope](proposals/pending/tiered-llm-offering-residual.md)

--- a/docs/proposals/done/search-egress-policy-split.md
+++ b/docs/proposals/done/search-egress-policy-split.md
@@ -1,8 +1,23 @@
 # Search egress policy: separate untrusted destinations from operator-configured endpoints
 
+- **State:** DONE — delivered scope archived 2026-07-26.
+
 *Filed as a precondition record for
-[surface-neutral-retrieval-substrate.md](../done/surface-neutral-retrieval-substrate.md)
+[surface-neutral-retrieval-substrate.md](surface-neutral-retrieval-substrate.md)
 ("S2"). Classification: **security, medium**.*
+
+> **Delivered.** `src/server/web_search.c` now routes every network call through
+> the shared guarded transport in `src/posix/web_egress.c`, with the two policies
+> this proposal asked for: `WEB_EGRESS_UNTRUSTED` for model/result-supplied URLs
+> (DuckDuckGo fetch, and `web_egress_fetch_pinned` for the top-N result fetch that
+> promoted this to a blocker) and `WEB_EGRESS_CONFIGURED` for the operator-supplied
+> SearXNG endpoint. Coverage lives in `src/tests/test_web_egress.c`, with a Windows
+> port at `src/windows/web_egress.c`.
+>
+> Residual, deliberately not blocking: the Tavily call still uses `http_retry_post`
+> directly rather than the guarded transport. Its URL is a compile-time constant,
+> which this proposal explicitly classified as not attacker-steerable, so it is a
+> consistency gap rather than the SSRF this record was about.
 
 > **PROMOTED TO BLOCKER.** This was filed as a latent structural gap, on the
 > reasoning that `web_search`'s endpoints are compile-time constants so nothing


### PR DESCRIPTION
## What

Moves `search-egress-policy-split.md` from `pending/` to `done/`, because the work is already in the tree.

## Evidence

`src/server/web_search.c` routes its network calls through the shared guarded transport in `src/posix/web_egress.c`, using exactly the two policies the proposal asked for:

```c
:279  web_egress_fetch(url, WEB_EGRESS_UNTRUSTED,  ...)   // DuckDuckGo
:329  web_egress_fetch(url, WEB_EGRESS_CONFIGURED, ...)   // SearXNG (operator-supplied)
:621  web_egress_fetch_pinned(results[i].url, WEB_EGRESS_UNTRUSTED, ...)
```

Line 621 is the top-N result fetch — the specific SSRF that got this record **PROMOTED TO BLOCKER**. It goes through the pinned untrusted path. There is a dedicated `web_egress` module, a Windows port (`src/windows/web_egress.c`), and `src/tests/test_web_egress.c`.

## Why it still looked live

Its own references had gone stale. It cites `agent_http_get` at `:268`/`:302`, which no longer appears in `web_search.c` at all, and says the validators have callers "only in `web_read.c` and `test_agent.c`" — they now live in their own module with their own tests.

This is the exact drift class `proposal-supersession-hygiene` was written to catch: a delivered proposal sitting in `pending/` because nothing moved it.

## Residual, recorded not hidden

The Tavily call still uses `http_retry_post` directly rather than the guarded transport. Its URL is a compile-time constant — a category **this proposal itself** classified as not attacker-steerable — so it is a consistency gap rather than the SSRF this record was about. Noted in the archived file.

## Index

`check-proposal-links` flagged `docs/PROPOSALS.md` still linking the pending path. The entry is delisted and the counts now match the directories on disk (shipped 210, pending 56).
