### PR TITLE
Let the delegate prompt budget follow the model, not a 20K constant

### DIFF
--- a/src/cmd_agent_delegate.c
+++ b/src/cmd_agent_delegate.c
@@ -882,8 +882,18 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
     * ~/.config/aimee/projects/<name>/project.yaml; defaults to 20K tokens. */
    if (sys_prompt)
    {
+      /* Precedence: --token-budget, then an explicit project.yaml value, then what
+       * the eligible models actually accept. The old behaviour stopped at the
+       * 20K constant, so a 200K or 1M-context model still had its system prompt
+       * tail-truncated -- silently, apart from a WARN. */
       int budget = token_budget_override > 0 ? token_budget_override
                                              : delegate_token_budget_load(cwd_for_template, role);
+      if (token_budget_override <= 0 && budget == DELEGATE_TOKEN_BUDGET_DEFAULT)
+      {
+         int model_budget = delegate_token_budget_for_agents(&cfg);
+         if (model_budget > budget)
+            budget = model_budget;
+      }
       char *limited = delegate_prompt_limit(sys_prompt, budget);
       if (limited)
       {

--- a/src/headers/agent_coord.h
+++ b/src/headers/agent_coord.h
@@ -43,6 +43,14 @@ char *delegate_prompt_limit(const char *prompt, int token_budget);
  * Returns the configured value, or DELEGATE_TOKEN_BUDGET_DEFAULT if not set. */
 int delegate_token_budget_load(const char *project_root, const char *role);
 
+/* Input budget a specific model can accept (context window minus its output
+ * ceiling), honouring an agent's explicit context_window override. 0 = unknown. */
+int delegate_token_budget_for_agent(const char *model, int agent_context_window);
+
+/* Smallest such budget across every agent still eligible after routing: the
+ * agent is picked downstream, so the prompt has to fit the smallest of them. */
+int delegate_token_budget_for_agents(const agent_config_t *cfg);
+
 int agent_coordinate(agent_config_t *cfg, const char *task, agent_result_t *out);
 int agent_vote(agent_config_t *cfg, const char *role, const char *prompt, int n_voters,
                agent_result_t *out);

--- a/src/server/agent_coord.c
+++ b/src/server/agent_coord.c
@@ -10,6 +10,7 @@
 #include "dstr.h"
 #include "cJSON.h"
 #include "git_verify.h"
+#include "model_registry.h"
 #include "log.h"
 #include <ctype.h>
 
@@ -323,6 +324,52 @@ char *delegate_prompt_limit(const char *prompt, int token_budget)
       char *r = dstr_steal(&out);
       return r ? r : safe_strdup(prompt);
    }
+}
+
+/* The input budget a model can actually accept, rather than a fixed constant.
+ *
+ * DELEGATE_TOKEN_BUDGET_DEFAULT is 20000 tokens. Every delegate whose prompt
+ * exceeded that was tail-truncated -- 1807 times on one deployment -- discarding
+ * whatever sat at the end of the system prompt, with only a WARN to say so. A
+ * model advertising a 200K or 1M context was still being cut at 20K.
+ *
+ * Budget = context window - max_output: the window is what the model holds, and
+ * the output ceiling has to be left free or the reply has nowhere to go. An
+ * agent's explicit middleware.context_window wins over the registry, matching
+ * agent_effective_context_window() in the runtime.
+ *
+ * Returns 0 when nothing is known, so the caller keeps its existing default. */
+int delegate_token_budget_for_agent(const char *model, int agent_context_window)
+{
+   int window = agent_context_window > 0 ? agent_context_window : model_context_window(model);
+   if (window <= 0)
+      return 0;
+   int reserve = model_max_output(NULL, model);
+   if (reserve > 0 && reserve < window)
+      window -= reserve;
+   if (window < DELEGATE_TOKEN_BUDGET_MIN_TASK)
+      window = DELEGATE_TOKEN_BUDGET_MIN_TASK;
+   return window;
+}
+
+/* The budget that fits EVERY agent still eligible after routing. The agent is
+ * chosen downstream, so the prompt must fit whichever one wins; the smallest
+ * eligible window is the only safe answer. */
+int delegate_token_budget_for_agents(const agent_config_t *cfg)
+{
+   if (!cfg || cfg->agent_count <= 0)
+      return 0;
+   int smallest = 0;
+   for (int i = 0; i < cfg->agent_count; i++)
+   {
+      int budget = delegate_token_budget_for_agent(cfg->agents[i].model,
+                                                   cfg->agents[i].middleware.context_window);
+      if (budget <= 0)
+         continue;
+      if (smallest == 0 || budget < smallest)
+         smallest = budget;
+   }
+   return smallest;
 }
 
 int delegate_token_budget_load(const char *project_root, const char *role)

--- a/src/tests/test_delegate_token_budget.c
+++ b/src/tests/test_delegate_token_budget.c
@@ -419,7 +419,6 @@ static void test_load_per_role_budget(void)
 
 /* --- main --- */
 
-
 /* A 20K constant truncated every delegate whose prompt exceeded it -- 1807 times
  * on one deployment -- regardless of what the model could actually hold. The
  * budget has to follow the model: 128K means 128K, 1M means 1M. */

--- a/src/tests/test_delegate_token_budget.c
+++ b/src/tests/test_delegate_token_budget.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include "aimee.h"
 #include "agent_coord.h"
+#include "model_registry.h"
 #include "platform_path.h"
 #include "platform_test_util.h"
 
@@ -418,6 +419,62 @@ static void test_load_per_role_budget(void)
 
 /* --- main --- */
 
+
+/* A 20K constant truncated every delegate whose prompt exceeded it -- 1807 times
+ * on one deployment -- regardless of what the model could actually hold. The
+ * budget has to follow the model: 128K means 128K, 1M means 1M. */
+static void test_budget_follows_the_model_context_window(void)
+{
+   /* Registry-known models: the budget tracks the window, not the constant. */
+   int small = delegate_token_budget_for_agent("gpt-4o", 0);
+   int large = delegate_token_budget_for_agent("gemini-1.5-pro", 0);
+   assert(small > DELEGATE_TOKEN_BUDGET_DEFAULT);
+   assert(large > small);
+   printf("  PASS: test_budget_follows_the_model_context_window\n");
+}
+
+/* Output needs somewhere to go: the input budget is the window minus the model's
+ * output ceiling, never the whole window. */
+static void test_budget_reserves_room_for_output(void)
+{
+   int budget = delegate_token_budget_for_agent("gpt-4o", 0);
+   assert(budget > 0);
+   assert(budget < model_context_window("gpt-4o"));
+   printf("  PASS: test_budget_reserves_room_for_output\n");
+}
+
+/* An operator's explicit per-agent context_window overrides the registry, the
+ * same precedence agent_effective_context_window() uses at runtime. */
+static void test_agent_context_window_overrides_registry(void)
+{
+   int budget = delegate_token_budget_for_agent("gpt-4o", 500000);
+   assert(budget > delegate_token_budget_for_agent("gpt-4o", 0));
+   /* Unknown model with an explicit window is still usable. */
+   assert(delegate_token_budget_for_agent("not-a-real-model-xyz", 300000) > 0);
+   /* Unknown model with nothing to go on reports 0 so the caller keeps its default. */
+   assert(delegate_token_budget_for_agent("not-a-real-model-xyz", 0) == 0);
+   printf("  PASS: test_agent_context_window_overrides_registry\n");
+}
+
+/* The agent is chosen after the prompt is built, so the prompt must fit whichever
+ * one wins -- the smallest eligible window is the only safe budget. */
+static void test_budget_across_agents_takes_the_smallest(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+   snprintf(cfg.agents[0].model, sizeof(cfg.agents[0].model), "%s", "gemini-1.5-pro");
+   snprintf(cfg.agents[1].model, sizeof(cfg.agents[1].model), "%s", "gpt-4o");
+   int smallest = delegate_token_budget_for_agents(&cfg);
+   assert(smallest == delegate_token_budget_for_agent("gpt-4o", 0));
+   assert(smallest < delegate_token_budget_for_agent("gemini-1.5-pro", 0));
+   /* No agents: nothing is known, so the caller keeps its default. */
+   cfg.agent_count = 0;
+   assert(delegate_token_budget_for_agents(&cfg) == 0);
+   assert(delegate_token_budget_for_agents(NULL) == 0);
+   printf("  PASS: test_budget_across_agents_takes_the_smallest\n");
+}
+
 int main(void)
 {
    printf("test_delegate_token_budget\n");
@@ -439,6 +496,10 @@ int main(void)
    test_load_custom_budget_from_yaml();
    test_load_ignores_invalid_value();
    test_load_per_role_budget();
+   test_budget_follows_the_model_context_window();
+   test_budget_reserves_room_for_output();
+   test_agent_context_window_overrides_registry();
+   test_budget_across_agents_takes_the_smallest();
 
    dtb_clear_home();
    cleanup_tmpdir();


### PR DESCRIPTION
## The bug

`DELEGATE_TOKEN_BUDGET_DEFAULT` is **20000 tokens**. Any delegate prompt above it was tail-truncated:

```c
/* --- Phase 4: Generic tail truncation — keep first budget_chars of content --- */
size_t keep = budget_chars < wlen ? budget_chars : wlen;
dstr_append(&out, working, keep);
dstr_append_str(&out, "\n[TRUNCATED: system prompt exceeded token budget]");
```

On one deployment that fired **1807 times**, 159 of them in a single day, always at the same 20000-token budget. A model advertising 200K or 1M of context was still cut at 20K — so whatever sat at the end of the system prompt was discarded before the model ever saw it, with only a `WARN` to say so.

This matters more than it looks: `role_template_build()` substitutes the task into `{{TASK}}` inside the role template, so the delegate's actual instructions live *inside* the prompt being truncated.

## The registry already knew

| call | returns |
|---|---|
| `model_context_window("gpt-4o")` | 128000 |
| `model_context_window("gemini-1.5-pro")` | 1000000 |
| `model_max_output(provider, model)` | the output ceiling |
| `agent_effective_context_window()` | prefers an agent's explicit `middleware.context_window` |

None of it reached the budget.

## The fix

Budget = **context window − max_output**: what the model can actually accept as input, leaving its reply somewhere to go.

The agent is chosen *after* the prompt is built, so `delegate_token_budget_for_agents()` takes the **smallest** window among agents still eligible after routing — the prompt has to fit whichever one wins.

Precedence is unchanged where it was explicit:

1. `--token-budget N`
2. `delegate_token_budget[_<role>]` in `project.yaml`
3. **model-derived budget** (new)
4. the old 20K constant, as a floor when nothing is known

An unknown model with no agent override returns `0`, so the caller keeps its existing default rather than guessing.

## Tests

Four added to `test_delegate_token_budget.c`:

- budget tracks the window: `gpt-4o` exceeds the old constant, `gemini-1.5-pro` exceeds `gpt-4o`
- budget stays below the full window, so output has room
- an explicit agent `context_window` overrides the registry; an unknown model with no override reports `0`
- across agents, the smallest eligible budget wins; empty/NULL config reports `0`

`aimee-server` builds clean; `unit-test-server-compute` and `unit-test-delegate-backend-docker` (which stub these symbols) still build.

## Not addressed here

Whether phases 1–3 of the shed (file refs, context sections, skill content) should run at all once the budget is realistic, and whether a prompt that still exceeds a 1M window should fail loudly rather than truncate silently. Both are follow-ups.
