### PR TITLE
A partial implement that produced no commit must not advance

### DIFF
--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -5,7 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/JBailes/aimee/server-go/internal/db1"
+	"github.com/JBailes/aimee/server-go/internal/wfe"
 )
 
 // gitRun runs a git command in dir, failing the test on error.
@@ -118,5 +122,90 @@ func TestIntegrateFeatureBaseConflictAbortsCleanly(t *testing.T) {
 	// The slice's own commit survives.
 	if _, err := os.Stat(filepath.Join(slicedir, "shared.go")); err != nil {
 		t.Fatalf("slice's own shared.go should survive the abort: %v", err)
+	}
+}
+
+// A delegate that reports partial and writes nothing must fail its slice, not
+// advance it. Observed on wi_3d5de168: every implement job came back
+//
+//	partial — "named file 'docs/runbooks/appliance-state-recovery.md' was not
+//	created by delegate ... The task remains unimplemented"
+//
+// and the engine advanced anyway. freeze then saw an empty diff, read it as "the
+// work is already in the base", and accepted the slice — so the run reached
+// done=5 with no commits, no file and no PR, recorded as success.
+type partialNoCommitAgents struct{}
+
+func (partialNoCommitAgents) Delegate(_ context.Context, _ DelegateRequest) (DelegateResult, error) {
+	return DelegateResult{
+		Response: "named file 'docs/runbooks/x.md' was not created by delegate; the task remains unimplemented",
+		Partial:  true,
+	}, nil
+}
+
+func (a partialNoCommitAgents) DelegateGroup(_ context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	out := make([]DelegateGroupResult, len(requests))
+	for i := range requests {
+		out[i] = DelegateGroupResult{Response: "partial"}
+	}
+	return out
+}
+
+func TestPartialImplementWithNoCommitDoesNotAdvance(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "init", "-b", "trunk")
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "README")
+	gitRun(t, repo, "commit", "-m", "init")
+	gitRun(t, repo, "remote", "add", "origin", repo)
+	gitRun(t, repo, "update-ref", "refs/remotes/origin/trunk", "HEAD")
+	gitRun(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+
+	store, err := db1.Open(filepath.Join(root, "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := t.Context()
+	for _, in := range []db1.CreateWorkItem{
+		{ID: "wi_parent", Repo: repo, ProposalPath: "p", WorkflowName: "build", StartStage: "feature"},
+		{ID: "wi_child", Repo: repo, ProposalPath: "c", WorkflowName: "slice", StartStage: "impl", ParentID: "wi_parent"},
+	} {
+		if err := store.CreateWorkItem(ctx, in); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manager, err := NewWorktreeManager(store, filepath.Join(root, "trees"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent, _ := store.WorkItem(ctx, "wi_parent")
+	if _, _, err := manager.Ensure(ctx, parent, true); err != nil {
+		t.Fatal(err)
+	}
+	child, _ := store.WorkItem(ctx, "wi_child")
+
+	runner := &NativeRunner{agents: partialNoCommitAgents{}, worktrees: manager, db: store}
+	// docs=true: the verifier is skipped on a documentation slice, which is how
+	// this reached freeze with nothing in the worktree.
+	out, err := runner.mutate(ctx, StepRequest{WorkItem: child, Node: wfe.Node{ID: "impl"}}, true)
+	if err != nil {
+		t.Fatalf("mutate: %v", err)
+	}
+	if out.Status == StepAdvanced {
+		t.Fatal("a partial delegate that produced no commit must not advance the slice")
+	}
+	if out.Status != StepChanges {
+		t.Fatalf("expected StepChanges, got %q", out.Status)
+	}
+	// The delegate already said exactly what was wrong; that is the finding.
+	if !strings.Contains(out.Detail, "was not created by delegate") {
+		t.Fatalf("delegate's own diagnosis must survive into the step detail: %q", out.Detail)
 	}
 }

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -376,6 +376,10 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		}
 		prompt += "\n\nTDD: failing tests have already been authored in the worktree. Make them pass without weakening or deleting their assertions."
 	}
+	// acceptPartial is granted here on the contract that this block "is
+	// independently committed and verified by the Go native runner". Record the
+	// pre-delegate HEAD so that promise can actually be checked below.
+	baseHead, baseHeadErr := gitText(ctx, workdir, "rev-parse", "HEAD")
 	result, err := r.delegate(ctx, req, DelegateRequest{Role: "code", Persona: paramString(req.Node, "persona", "engineer"), Delegate: paramString(req.Node, "delegate", ""), Prompt: prompt, Workdir: workdir, Tools: true, acceptPartial: true})
 	if err != nil {
 		return StepResult{}, err
@@ -387,6 +391,23 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	}
 	if err := commitChanges(ctx, workdir, req.Node.ID); err != nil {
 		return StepResult{}, err
+	}
+	// A delegate that reported partial AND left no commit did not implement the
+	// task -- it said so itself. Advancing turns that into an empty diff at freeze,
+	// which reads as "the work is already in the base" and accepts the slice, so a
+	// run can reach done=N with no commits, no artifact and no PR. Only the partial
+	// case fails here: a completed delegate that legitimately had nothing to do is
+	// still the freeze no-op path.
+	if result.Partial && baseHeadErr == nil {
+		head, headErr := gitText(ctx, workdir, "rev-parse", "HEAD")
+		if headErr == nil && head == baseHead {
+			detail := strings.TrimSpace(result.Response)
+			if detail == "" {
+				detail = "delegate returned a partial result and produced no commit"
+			}
+			return StepResult{Status: StepChanges, Detail: safeDiagnostic(detail),
+				CostUSD: cost, CostUnknown: costUnknown}, nil
+		}
 	}
 	if !docs {
 		if err := r.verifier.Verify(ctx, workdir); err != nil {


### PR DESCRIPTION
## What happened

Run `wi_3d5de168` finished `state=accepted` with `done=5` — five slices, **zero commits, no file, no PR**. A successful-looking run that produced nothing.

Every implement job reported itself honestly:

```
partial — "named file 'docs/runbooks/appliance-state-recovery.md' was not created
by delegate ... no repository tools executed successfully before the tool-turn
budget was exhausted. The task remains unimplemented."
```

The engine advanced anyway. `freeze` then found an empty diff, read it as the legitimate *"work is already present in the base"* case, and accepted the slice.

## Why the guard was missing

`acceptPartial` is granted to implement/document on a stated contract:

> acceptPartial is reserved for native branch-producing blocks **whose worktree output is independently committed and verified by the Go native runner**.

Neither half held:

- nothing checked that a commit was actually produced
- `Verify` is skipped entirely when `docs=true`, so a documentation slice had **no** check at all

## The fix

Record HEAD before the delegate; if the delegate reported `partial` **and** HEAD is unmoved after `commitChanges`, return `StepChanges` carrying the delegate's own diagnosis — which is already a precise, actionable finding.

Deliberately narrow: **only the partial case fails.** A delegate that *completed* and legitimately had nothing to do still reaches the freeze no-op path, which is what that path exists for.

## Test

`TestPartialImplementWithNoCommitDoesNotAdvance` builds a real repo, feature branch and slice worktree, drives `mutate()` with `docs=true` (the configuration that had no check), and asserts the step does not advance and that the delegate's diagnosis survives into the detail.

Verified by disabling the guard: the test fails with *"a partial delegate that produced no commit must not advance the slice"*. Full `server-go` suite green.

## Related

The delegate's failure — "no repository tools executed successfully before the tool-turn budget was exhausted" — is a separate defect. #2009 addresses one plausible contributor (the prompt budget); whether the tool-turn budget itself is too small is still open.
