### PR TITLE
Drop the sidecar fallback to a host that cannot resolve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,9 +153,16 @@ ENV AIMEE_HOME=/var/lib/aimee
 #   AIMEE_EMBEDDER_URL  pin the embedder (/embed) independently
 #   AIMEE_RERANKER_URL  pin the reranker (/rerank) independently
 #   LLM_ENDPOINT        Tier-A synth only (small-model interface)
-# Unset, embeddings fall back to the 384-dim builtin (test/shim only). The deploy
-# unit (compose / smoothnas plugin) sets these and brings up a default CPU
-# aimee-llm sibling when nothing is configured. (Old combined leftovers
+# One of these is REQUIRED. The seeded default config selects the remote embedder
+# sidecar, so with no endpoint set the DB2 dim probe fails and db2_init refuses to
+# initialise rather than record a wrong vector width (db2_init.c) -- the kb then
+# never binds its HTTP port. Verified on the shipped image with nothing else
+# configured: the embedded cluster comes up, the service does not.
+#
+# The 384-dim builtin embedder exists but is NOT reached in that state: it applies
+# only when no embed command is configured at all, and the baked config always
+# configures one. The deploy unit (compose / smoothnas plugin) sets these and
+# brings up a default CPU aimee-llm sibling, which is why this is invisible there. (Old combined leftovers
 # AIMEE_EMBEDDER_URL=embedder:8080 / LLM_ENDPOINT=llm:8080 were removed: on a
 # split deploy they silently pointed at non-existent services.)
 # Bind the /v1 HTTP API on 0.0.0.0 (not the 127.0.0.1 default), so the published

--- a/docs/proposals/pending/ci-on-slice-subprs.md
+++ b/docs/proposals/pending/ci-on-slice-subprs.md
@@ -17,32 +17,174 @@ pull_request:
 Slice sub-PRs target `aimee/feat/<work_item_id>`, which is not in that list.
 Observed on PR #2011, opened and merged by the pipeline: `check-runs` total_count
 = 0. The engine correctly advanced — `wfe_live_forge.c` deliberately treats
-GIT_PR_CI_NONE as merge-permitting so an intermediate PR cannot park forever —
+`GIT_PR_CI_NONE` as merge-permitting so an intermediate PR cannot park forever —
 so the gate passed because there was nothing to check.
 
-Consequence: every slice merges into the feature branch unverified. A slice can
-break the build and only the final feature->testing PR discovers it, after all
-slices have already merged, with no attribution to the slice that caused it.
+Consequence: a slice sub-PR whose target branch is not in the trigger list merges
+into the feature branch with no check runs. A slice can break the build and the
+final feature->testing PR is the first gate that would discover it, with no
+attribution to the slice that caused it.
+
+## Established
+
+By direct observation:
+
+- `ci.yml`'s `pull_request.branches` list does not include `aimee/feat/**`.
+- PR #2011 merged with `check-runs` total_count = 0.
+- `GIT_PR_CI_NONE` is defined at `src/modules/git/git_pr_api.h:75`
+  (`GIT_PR_CI_NONE = 0, /* no CI reported for the head commit */`), and
+  `src/modules/workflows/wfe_live_forge.c:197` handles that case with the
+  rationale recorded in the comment at line 201 — the engine "already treats
+  `GIT_PR_CI_NONE` as merge-permitting". This is verified design intent, cited to
+  file and line, not inferred from behaviour.
+- **`RakuenSoftware/aimee` is a public repository** (`gh repo view`:
+  `"visibility":"PUBLIC"`). GitHub-hosted *standard* runners are free for public
+  repositories; the per-OS billing multipliers (Linux 1x, Windows 2x, macOS 10x)
+  apply to private-repo minute consumption, not here.
+- **Job structure:** `ci.yml` defines **15 jobs**. One of them, `e2e-docker`,
+  carries `matrix: topology: [T1, T2, T3]` and expands to 3 executions, giving
+  **17 job executions per run**. Every job targets `ubuntu-latest`,
+  `windows-latest` or `macos-latest` — all standard hosted runners, all free-tier
+  for this repo. The table below and the concurrency figures are stated in
+  *executions* (17), not definitions (15), since executions are what consume
+  runner slots.
+
+### Measured job durations
+
+Elapsed wall-clock per job, from the Actions jobs API for the two most recent
+complete `ci.yml` runs. These are **elapsed minutes, not billed minutes** — see
+above; nothing here is billed.
+
+| Job | Runner | Run 30221629787 | Run 30221474744 |
+|---|---|---|---|
+| no-coauthor-trailers | ubuntu | 0.16 | 0.16 |
+| lint | ubuntu | 0.96 | 1.03 |
+| build | ubuntu | 1.96 | 2.06 |
+| build-integrity | ubuntu | 4.90 | 4.90 |
+| unit-tests | ubuntu | 5.86 | 5.83 |
+| init-migrate-service-test | ubuntu | 1.16 | 1.20 |
+| windows-cmake | windows | 4.20 | 4.06 |
+| windows-build | windows | 3.36 | 3.51 |
+| macos-build | macos | 0.61 | 0.53 |
+| memory-retrieval-eval | ubuntu | 0.76 | 0.56 |
+| bench-check | ubuntu | 0.68 | 0.63 |
+| treesitter | ubuntu | 0.96 | 1.13 |
+| vault-pkcs11-token | ubuntu | 0.48 | 0.38 |
+| e2e-adoption | ubuntu | 1.80 | 1.83 |
+| e2e-docker (T1) | ubuntu | 8.05 | 8.00 |
+| e2e-docker (T2) | ubuntu | 9.73 | 10.01 |
+| e2e-docker (T3) | ubuntu | 3.00 | 3.18 |
+| **Sum of all jobs** | | **48.63** | **49.00** |
+| `build` + `unit-tests` only | | **7.82** | **7.89** |
+| Longest single job (= wall-clock floor) | | 9.73 (e2e-docker T2) | 10.01 (e2e-docker T2) |
+
+Derivation: the "sum" rows add the column above them; the option-2 row adds only
+`build` and `unit-tests`. Jobs run concurrently, so the sum is total machine
+occupancy, not elapsed time — elapsed time is bounded below by the longest job.
+
+**n = 2.** These are point estimates from two runs. They do not characterise
+variance, which for hosted runners is driven largely by queue and runner
+availability. Treat the figures as indicative, not as a cost model.
+
+## What the measurements actually show
+
+Since minutes are free for this repo, the sum-of-jobs figure is **not a cost**.
+The real costs of adding slice CI are:
+
+1. **Wall-clock added per slice.** The full gate's *total workflow elapsed time*
+   is measured, from three complete runs:
+
+   | run | elapsed |
+   |---|---|
+   | 30223112295 (`e161dd34`, dispatched) | 9m45s |
+   | 30221629787 | 10m07s |
+   | 30221474744 | 10m21s |
+
+   So a full slice gate costs **~10 minutes** of wall-clock (n=3).
+
+   The corresponding figure for option 2 is **not measured** — that
+   configuration does not exist, so no run of it can be timed. Its elapsed time
+   is bounded *below* by its longest job (`unit-tests`, ~5.85 min) plus queue and
+   setup overhead, which the job table does not capture. Consequently the saving
+   from option 2 is **at most ~4 minutes per slice, and probably less**. Treat
+   that as an indicative upper bound on the benefit, not a measured difference.
+2. **Runner concurrency.** A 5-slice run adds 5 x 17 = **85 job executions**
+   (17 executions per run, see Job structure above) competing for the account's
+   concurrent-job allowance against all other CI in flight. This is the one
+   genuine scarcity, and it is **not quantified here**: the account's concurrency
+   ceiling and its current utilisation were not measured. If slice CI is adopted
+   and other PRs start queueing behind it, this is the cause to look at first.
 
 ## Options
 
-1. Add `aimee/feat/**` to the `ci.yml` pull_request branch list. Slices get the
-   full existing gate. Cost: one full CI run per slice; a 5-packet run becomes 5
-   additional CI runs.
+1. Add `aimee/feat/**` to the `ci.yml` `pull_request.branches` list. Slices get
+   the full existing gate.
 2. Add a reduced job (build + unit tests only) for `aimee/feat/**`, deferring
-   e2e/docker legs to the final PR. Cheaper; catches compile and unit breakage at
-   the slice that caused it.
-3. Leave as-is and rely on the final PR. Cheapest; loses per-slice attribution
-   and lets a broken slice merge.
+   e2e/docker legs to the final PR.
+3. Leave as-is and rely on the final PR.
 
 ## Recommendation
 
-Option 2. The value of slice-level CI is attribution — knowing which slice broke
-the build — and build+unit tests deliver most of that at a fraction of the cost.
-The expensive e2e legs still run once on the final PR, where they gate delivery.
+**Option 1.**
+
+The case for option 2 was cost, and for this repository that cost does not
+exist: minutes are free. What option 2 actually buys is at most ~4 minutes of
+latency
+per slice and a reduction in concurrent job slots. What it costs is real:
+partial attribution (e2e-only and cross-slice regressions still surface only at
+the final PR) and a second CI configuration that must be kept in sync with the
+first — a standing source of drift where the slice gate and the delivery gate
+silently diverge.
+
+Trading complete attribution and a single source of truth for four minutes is a
+bad trade when nothing is being billed. Option 1 also needs no new job
+definitions: it is one line added to an existing trigger list.
+
+If runner concurrency later proves to be the binding constraint — the one cost
+above that is real but unmeasured — option 2 remains available as a targeted
+remedy, and should be revisited with concurrency data in hand rather than
+adopted pre-emptively now.
+
+**Post-adoption measurement, with an explicit trigger for reconsidering.**
+Because concurrency is knowingly unquantified at decision time, adopting option 1
+carries an obligation to measure it afterwards rather than leave it open:
+
+Baseline first: before enabling slice CI, record the median queue wait of PR
+runs over 10 runs; call it `Q0`. Then, over the first 10 pipeline runs with slice
+CI enabled, record: maximum concurrent job executions reached (`Cmax`); median
+queue wait of *unrelated* PR runs (`Q1`); and total elapsed time of each slice
+gate.
+
+**Reconsider option 2 if any of these is true** (each mechanically checkable):
+
+- `Q1 >= Q0 + 2 minutes`, measured as the median over those 10 runs; **or**
+- slice gate elapsed time exceeds **20 minutes** in **3 or more** of the 10 runs
+  (against the measured ~10-minute standalone figure); **or**
+- `Cmax` reaches the account's documented concurrent-job ceiling in **2 or more**
+  of the 10 runs. (The ceiling must be read from the account's plan limits at
+  measurement time; it is not known here, which is precisely why it is recorded
+  rather than assumed.)
+
+If none of the three fires across those 10 runs, close the question and record
+concurrency as measured and adequate.
 
 ## Acceptance
 
+Common to any option that adds slice CI:
+
 - A slice sub-PR targeting `aimee/feat/**` reports at least one check run.
-- A slice that breaks the build fails its own sub-PR rather than the final one.
 - The final feature->testing PR still runs the complete gate unchanged.
+
+If **option 1** is implemented:
+
+- A slice that breaks *any* gated leg — including an e2e or docker leg — fails
+  its own sub-PR rather than the final one.
+- No new workflow file or job definition is introduced; the change is confined
+  to `ci.yml`'s trigger list.
+
+If **option 2** is implemented instead:
+
+- A slice that breaks the build or a unit test fails its own sub-PR.
+- An e2e-only or cross-slice regression is still expected to surface only at the
+  final PR. This is an accepted limitation of option 2 specifically, and must be
+  recorded as such so the weaker guarantee is not mistaken for the full gate.

--- a/docs/proposals/pending/ci-on-slice-subprs.md
+++ b/docs/proposals/pending/ci-on-slice-subprs.md
@@ -1,0 +1,48 @@
+# Proposal: run CI on slice sub-PRs
+
+- **State:** pending — single slice.
+
+## Problem
+
+The build-e2e workflow merges each slice through a sub-PR whose stated gate is
+"sub-PR -> GREEN CI -> merge into the feature branch". In practice no CI runs.
+
+`.github/workflows/ci.yml` triggers on:
+
+```yaml
+pull_request:
+  branches: [main, testing, feature/core-modularization]
+```
+
+Slice sub-PRs target `aimee/feat/<work_item_id>`, which is not in that list.
+Observed on PR #2011, opened and merged by the pipeline: `check-runs` total_count
+= 0. The engine correctly advanced — `wfe_live_forge.c` deliberately treats
+GIT_PR_CI_NONE as merge-permitting so an intermediate PR cannot park forever —
+so the gate passed because there was nothing to check.
+
+Consequence: every slice merges into the feature branch unverified. A slice can
+break the build and only the final feature->testing PR discovers it, after all
+slices have already merged, with no attribution to the slice that caused it.
+
+## Options
+
+1. Add `aimee/feat/**` to the `ci.yml` pull_request branch list. Slices get the
+   full existing gate. Cost: one full CI run per slice; a 5-packet run becomes 5
+   additional CI runs.
+2. Add a reduced job (build + unit tests only) for `aimee/feat/**`, deferring
+   e2e/docker legs to the final PR. Cheaper; catches compile and unit breakage at
+   the slice that caused it.
+3. Leave as-is and rely on the final PR. Cheapest; loses per-slice attribution
+   and lets a broken slice merge.
+
+## Recommendation
+
+Option 2. The value of slice-level CI is attribution — knowing which slice broke
+the build — and build+unit tests deliver most of that at a fraction of the cost.
+The expensive e2e legs still run once on the final PR, where they gate delivery.
+
+## Acceptance
+
+- A slice sub-PR targeting `aimee/feat/**` reports at least one check run.
+- A slice that breaks the build fails its own sub-PR rather than the final one.
+- The final feature->testing PR still runs the complete gate unchanged.

--- a/docs/proposals/pending/gate-the-integration-tip.md
+++ b/docs/proposals/pending/gate-the-integration-tip.md
@@ -1,0 +1,150 @@
+# Proposal: gate the integration branch tip, not only the PRs that build it
+
+- **State:** pending — single slice.
+
+## Problem
+
+`.github/workflows/ci.yml` triggers on:
+
+```yaml
+on:
+  pull_request:
+    branches: [main, testing, feature/core-modularization]
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+```
+
+There is no `push` trigger. CI therefore runs against a PR's *merge preview*,
+never against the branch tip that results from merging it.
+
+Measured on the current release tip, `testing` @ `e161dd34`:
+
+```
+$ gh api repos/{owner}/{repo}/commits/e161dd34/check-runs
+total_count = 2
+  build (aimee-server, Dockerfile.server)  success
+  build (aimee-kb, Dockerfile)             success
+```
+
+Two image builds. None of the 17 gate jobs — `unit-tests`, `build-integrity`,
+`e2e-docker` T1/T2/T3, `lint`, the Windows/macOS legs — has ever run against
+this commit. The same is true of every previous tip.
+
+## Why this is not merely theoretical
+
+Each of the 14 commits in this release (#1994–#2010) was gated in isolation,
+against the tip as it stood when that PR was opened. Nothing re-checks the
+combination. The failure mode this misses is the semantic conflict: two PRs that
+each pass alone and break in combination — one renames a helper while another
+adds a caller, one changes a default while another adds a test asserting the old
+one. Textual conflicts are caught by git; semantic ones are caught only by
+running the gate on the merged result, which never happens.
+
+GitHub's merge-queue and "require branches to be up to date before merging"
+settings exist precisely to close this gap. Neither is in use here: PRs merge
+against whatever base they were opened on.
+
+Note that this is the same class of hole as the slice sub-PR gap described in
+[ci-on-slice-subprs.md](ci-on-slice-subprs.md) — work merging through a gate
+that did not actually run. They are independent instances and can be fixed
+independently, but a fix for one does not address the other.
+
+## A push trigger alone does not give a complete gate
+
+Two jobs are conditioned on the event type:
+
+```yaml
+no-coauthor-trailers:
+  if: github.event_name == 'pull_request'
+bench-check:
+  if: github.event_name == 'pull_request'
+```
+
+Confirmed empirically: the manually dispatched run `30223112295` on `e161dd34`
+reported **success**, but with those two jobs `skipped` — 15 of 17 jobs actually
+ran. A `push`-triggered run would skip them for the same reason.
+
+The two are not equivalent in importance:
+
+- `no-coauthor-trailers` scans a PR's new commits (`base..head`). On a tip gate
+  there is no such range, so skipping it is correct, and the check has already
+  done its job on the way in.
+- **`bench-check` is a genuine gap.** It is skipped on a tip gate, so
+  performance regressions arising from the *combination* of merged PRs are not
+  checked at integration level — which is exactly the class of problem this
+  proposal exists to catch.
+
+Any option below that relies on the `push` event must therefore also decide what
+to do about `bench-check`: either relax its `if:` to run on the tip (and give it
+a meaningful baseline to compare against, which on a push is not the PR base),
+or accept explicitly that integration-level performance is ungated. This
+proposal does not resolve that; it is called out so the gap is not mistaken for
+coverage. Note that a green tip run means "15 of 17 jobs passed", and any
+release certification should say so rather than claiming a full gate.
+
+## Options
+
+1. **Add a `push` trigger** for `main`, `testing`, `feature/core-modularization`.
+   The tip is gated on every merge. Cost: one extra full run per merge; a
+   failure is discovered post-merge, so it reports rather than prevents.
+2. **Require branches up to date before merging** (branch protection). Forces a
+   rebase/merge-from-base before a PR can land, so the gated merge preview is
+   the tip. Cost: re-runs CI on every PR each time the base moves; on a busy
+   base this serialises merges and is the setting most likely to cause friction.
+3. **GitHub merge queue.** Gates the prospective merged result and only lands it
+   if green. Strongest guarantee, prevents rather than reports. Cost: most
+   configuration; changes how everything merges.
+4. **Scheduled gate on the tip** (e.g. nightly `schedule:` on `testing`). Cheap
+   to add, catches combination breakage within a day. Cost: not tied to a merge,
+   so attribution to a specific PR is weaker and detection is delayed.
+5. **Leave as-is**, and rely on the release-time full run being dispatched by
+   hand — which is what was done for this release, and only because the gap was
+   noticed.
+
+## Established vs. assumed
+
+Established:
+
+- The trigger list contains no `push` (read from `ci.yml`).
+- `e161dd34` has 2 check runs, both image builds (API, quoted above).
+- The full gate on the tip *can* be dispatched manually: `workflow_dispatch` is
+  configured, and doing so for `e161dd34` produced run `30223112295`.
+
+Assumed, NOT established:
+
+- **That a semantic conflict has actually shipped.** No historical incident is
+  cited here. The argument is that the gap exists and is unguarded, not that it
+  has already caused a specific failure. If the decision hinges on demonstrated
+  harm rather than exposure, that evidence has not been gathered.
+- **Merge frequency and its interaction with option 2's serialisation cost.**
+  Not measured.
+
+## Recommendation
+
+Option 1, and it should be uncontroversial: the repo is public, so the extra run
+costs no billed minutes (see the cost analysis in
+[ci-on-slice-subprs.md](ci-on-slice-subprs.md)), and it is a two-line change to
+an existing trigger block.
+
+Option 1 reports rather than prevents — a broken tip is found minutes after the
+merge, not before it. That is a genuine weakness, and options 2 and 3 are
+strictly stronger. But they change how every PR merges, which is a workflow
+decision with human cost, whereas option 1 is additive and reversible. The
+recommendation is to take option 1 now to get visibility, and treat option 3 as
+a separate decision informed by how often option 1 actually goes red. If it
+never goes red over a meaningful number of merges, the stronger options are not
+worth their friction.
+
+## Acceptance
+
+- A merge to `testing` produces a CI run against the resulting tip commit.
+- That run's check runs are visible on the tip commit
+  (`gh api repos/{owner}/{repo}/commits/<tip>/check-runs` returns the gate jobs,
+  not just the image builds).
+- A release can be certified by pointing at a green run on the exact commit
+  being released, with no manual `workflow_dispatch` step.
+- The certification states which jobs ran and which were skipped. A tip run that
+  skips `bench-check` is not described as a full gate.
+- `bench-check` on the tip is either enabled with a defined baseline, or its
+  absence is recorded as a known, accepted gap — not left to be discovered.
+- PR-triggered runs are unchanged.

--- a/docs/proposals/pending/wfe-panel-cannot-seat-under-self-load.md
+++ b/docs/proposals/pending/wfe-panel-cannot-seat-under-self-load.md
@@ -1,0 +1,235 @@
+# Proposal: the WFE rt_gate panel cannot seat under the engine's own load
+
+- **State:** pending — single slice.
+
+## Symptom
+
+A live `build-e2e` run (`wi_f96d4b18…`, release `testing` @ `e161dd34`) cannot
+pass `rt_gate`. Slice 1 paused three times with the same reason and the same
+10-minute period:
+
+```
+21:27:46  pause  panel_unreachable: architect: delegate_error: context deadline exceeded;
+                                    reviewer: delegate_error: context deadline exceeded
+22:07:47  pause  (identical)
+22:47:xx  pause  (identical)
+```
+
+Each attempt fails **exactly 10 minutes** after entering `rt_gate`
+(`21:17:46` → `21:27:46`), then auto-resumes 30 minutes later and repeats. The
+run burns its `autonomy.max_resumes` budget (50) making no progress.
+
+## Mechanism
+
+`roundtables/wfe.json` seats 3 personas plus a chairman, `turns: parallel`,
+`min_successful: 2`, `deadline_ms: 600000`. Each seat picks `$random` from the
+configured agents. Deployed `agents.json`:
+
+| agent | model | max_parallel | timeout_ms |
+|---|---|---|---|
+| codex | gpt-5.6-sol | 10 | 600000 |
+| MiniMax-M3 | MiniMax-M3 | 4 | 180000 |
+| claude | (unset) | **unset → 3** (`AGENT_DEFAULT_MAX_PARALLEL`, `agent_types.h:47`) | 600000 |
+| local-gemma4 | aimee-synth | 2 | 300000 |
+| kimi-k2.7-code | kimi-k2.7-code | unset → 3 | 180000 |
+
+Two seat-level failure modes were observed directly in the job queue:
+
+```
+job 14813  review  failed     claude       agent 'claude' at concurrency limit (max_parallel=3)
+job 14821  review  failed     claude       agent 'claude' at concurrency limit (max_parallel=3)
+job 14812  review  cancelled  MiniMax-M3   cancelled: WFE turn cancelled
+                              (created 22:37:47, cancelled 22:47:51 — the 600000ms panel deadline)
+```
+
+- A `claude` seat fails **immediately** at 3 concurrent.
+- A `MiniMax-M3` seat is **cancelled mid-work** (turn 7–8) at the panel deadline.
+
+With two slices at `rt_gate` at once, the engine asks for up to 8 concurrent
+agents. `claude` saturates at 3 and its seats fail instantly; slow seats are
+killed at 600s. Fewer than `min_successful: 2` seats return, so the panel is
+declared unreachable. **The engine starves itself** — no external load is
+required.
+
+**This is load-dependent, not deterministic.** Slice 1 passed `rt_gate` on its
+fourth attempt at 23:21:05, and slice 2 passed on its first at 23:10:19. The
+defect makes seating unreliable under the engine's own concurrency; it does not
+make it impossible. Any claim that the gate "cannot" be passed is too strong —
+what is established is that it fails a substantial fraction of the time, with a
+failure mode that costs a full 10-minute deadline and a 30-minute backoff each
+time.
+
+## Why the agent pool is the suspect, not the thread pool
+
+The natural suspicion is the server compute pool, but that is a dead end and is
+recorded here so it is not re-investigated: `9fd1b2c0` ("match roundtable worker
+capacity") raised `CONFIG_DEFAULT_BACKGROUND_THREADS` 2 → 14 "matching the
+standard 10 Codex + 4 MiniMax roundtable capacity", and `840132c8` ("decouple
+roundtable admission from compute workers") then **deliberately reverted it to
+2** because admission no longer runs through compute workers. Both are ancestors
+of the deployed release — verified, not assumed:
+
+```
+$ git merge-base --is-ancestor 9fd1b2c0 origin/testing && echo YES    # YES
+$ git merge-base --is-ancestor 840132c8 origin/testing && echo YES    # YES
+$ git show e161dd34:src/modules/config/config.h | grep BACKGROUND_THREADS
+#define CONFIG_DEFAULT_BACKGROUND_THREADS 2
+```
+
+The deployed release therefore carries the revert, and the revert is correct.
+
+This exclusion is **evidence-based but not dispositive**: it shows the specific
+thread-count hypothesis is wrong, not that the deployed runtime is unconstrained
+elsewhere (a per-queue admission limit, say, was not traced). What rules the
+thread pool out as *the* constraint at the observed failure time is the direct
+evidence: the failing seats name a per-agent concurrency limit, not worker or
+queue starvation.
+
+That commit pair does, however, record the intended roundtable capacity:
+**10 Codex + 4 MiniMax = 14**. `claude` and `local-gemma4` are not part of it,
+yet `$random` can seat them.
+
+Note also that `local-gemma4` targets `aimee-synth`, i.e. the `aimee-llm`
+gateway. Whenever that container is down — as it is now, deliberately, for
+replacement-LLM testing — every seat that draws `local-gemma4` fails. Taking
+`aimee-llm` down therefore silently degrades the roundtable panel. That coupling
+is not obvious from either side.
+
+## Established vs. assumed
+
+Established: the pause timestamps and 10-minute period; the three job records
+quoted above; the `agents.json` values; `AGENT_DEFAULT_MAX_PARALLEL == 3`; the
+`wfe.json` seat/deadline/`min_successful` settings; the commit pair above.
+
+### Root cause: routing is not saturation-aware
+
+`$random` resolves through `agent_route_*` in `src/modules/routing/routing.c`,
+which filters candidates on `enabled`, role support, cost tier, and
+`agent_is_available_for_routing()`. That last call delegates to
+`agent_routing_block_reason()`, which checks:
+
+- provider health (`g_route_health_filter` → `AGENT_ROUTE_HEALTH_DOWN`),
+- the client-only-claude structural rule,
+- the policy filter (`primary_only` etc.),
+- backend command availability (tmux/CLI on PATH).
+
+**It does not check whether the agent has a free concurrency slot.** A saturated
+agent remains a fully valid routing candidate, is selected, and only then fails
+at admission (`agent_runtime.c:259`) with `AGENT_RC_AT_LIMIT`.
+
+The health path cannot compensate, and deliberately so: `agent_fallback.c:61`
+records that the "at concurrency limit" message is classified **non-retryable so
+at-limit never records health**. That is correct in itself — saturation is not a
+provider fault and must not poison health — but it means a saturated agent is
+never marked `HEALTH_DOWN` either. It therefore stays selectable indefinitely.
+
+So routing and admission disagree: routing believes the agent is available;
+admission knows it is full.
+
+One step in that chain is **not verified**, and the claim is limited accordingly.
+`agent_runtime.c:255` sets `AGENT_ADMIT_NONBLOCKING` only when
+`tl_admission_fail_fast` is set; otherwise admission *blocks* and waits for a
+slot. Which caller sets that flag for a panel seat was not traced. What is
+observed is that panel seats **did** take the fail-fast path — jobs 14813 and
+14821 failed instantly rather than waiting — so the flag is evidently set
+somewhere on this path, but the responsible caller has not been identified.
+
+Limited to what that supports: on the observed fail-fast path, a seat drawing a
+saturated agent fails immediately, and with `min_successful: 2` a couple of such
+draws take down the gate. Whether *every* seat takes that path is unestablished.
+
+Assumed, NOT established:
+
+- **That `MiniMax-M3` would finish given more time.** It was cancelled while
+  still advancing turns; whether it converges at, say, 20 minutes is untested.
+- **Whether `claude`'s cap of 3 is deliberate.** It is unset in `agents.json` and
+  falls through to the compile-time default. Whether that reflects a provider
+  rate limit or simply nobody setting it is unknown, and it determines whether
+  option 1 is safe.
+
+## Options
+
+1. **Give `claude` an explicit `max_parallel`** matching its real provider
+   limit. Smallest change. Unsafe until the third assumption above is settled —
+   raising it past a real rate limit trades one failure for another.
+2. **Restrict `$random` to the intended capacity pool** (`codex`, `MiniMax-M3`),
+   excluding `claude` and `local-gemma4`. Matches the documented design intent.
+   Cost: a smaller pool, and it hard-codes a roster that was meant to be dynamic.
+3. **Make an at-limit seat wait rather than fail.** `agent_runtime.c:255` already
+   blocks by default (`flags = tl_admission_fail_fast ? AGENT_ADMIT_NONBLOCKING : 0`)
+   and `AGENT_RC_AT_LIMIT` is meant to drive fallback to another agent. Panel
+   seats are evidently taking the fail-fast path. Making them queue or fall back
+   is the most principled fix. Cost: needs the fail-fast caller identified first;
+   a queueing seat also consumes panel deadline while waiting.
+4. **Exclude agents whose backend is unreachable** from seat selection, so a
+   downed `aimee-llm` cannot silently cost the panel a seat. Complementary to any
+   of the above, not a substitute.
+5. **Raise `deadline_ms`** so slower seats finish. Addresses only the cancellation
+   half, not the `claude` saturation half, and lengthens every failure.
+
+6. **Make routing saturation-aware.** Add a "no free slot" block reason to
+   `agent_routing_block_reason()` so a saturated agent is not a candidate, while
+   leaving health classification untouched (saturation still must not be
+   recorded as a provider fault). Routing then picks a peer that can actually
+   run, which is what the `$random` pool exists to provide.
+
+## Recommendation
+
+**Option 6**, with option 3 as its complement.
+
+The defect is that routing and admission disagree about what "available" means.
+Options 1, 2 and 5 all tune numbers so the disagreement stops being reachable in
+one particular configuration; none of them removes it. Raise `claude`'s cap and
+the same failure returns at a higher slice count; restrict the pool and it
+returns whenever the narrowed pool saturates.
+
+Option 6 removes the disagreement at its source and needs no knowledge of any
+provider's real rate limit, which is the fact that makes option 1 unsafe today.
+It also preserves the `agent_fallback.c` invariant: the fix is in *selection*,
+not in health classification, so saturation still never counts as a fault.
+
+Option 3 remains worth doing for the residual race — an agent can saturate
+between selection and admission — so a seat that loses that race should fall
+back or wait rather than fail. Option 6 makes that race rare; option 3 makes it
+harmless.
+
+Option 4 should be taken regardless. It is a correctness bug independent of
+load: with `aimee-llm` deliberately stopped, any seat drawn against
+`local-gemma4` is a guaranteed failure. (This may already be covered by the
+existing health filter — `AGENT_ROUTE_HEALTH_DOWN` — if the catalog marks the
+dead gateway down; that was not verified, and should be before implementing
+anything separate.)
+
+## Acceptance
+
+The defect is load-dependent and intermittent, so a single green live run proves
+nothing. Acceptance is therefore stated as deterministic tests, with the live run
+as supporting evidence only.
+
+Deterministic:
+
+- **Saturated pool:** with agent A at its limit and agent B free, seat selection
+  returns B, not A. No seat fails with `concurrency_limit`.
+- **Empty eligible pool:** with *every* eligible agent saturated, selection
+  returns a distinct, named "no agent with free capacity" condition — not a bare
+  "no agent" error, and not a seat that fails at admission.
+- **Concurrent-admission race:** when N seats select simultaneously against a
+  pool with fewer than N free slots, each seat either obtains a slot or reports
+  the no-capacity condition; none fails with a generic provider error.
+- **Deadline expiry:** a seat still waiting when the panel deadline elapses is
+  reported as deadline-expired-while-waiting, distinguishable from a provider
+  fault and from no-capacity.
+- **Health-classification invariant preserved:** a seat that hits the
+  concurrency limit still does **not** record provider health (the
+  `agent_fallback.c:61` invariant), verified by a test.
+- **Unreachable backend:** with `aimee-llm` stopped, no seat is assigned to
+  `local-gemma4`.
+
+Supporting evidence, not a gate:
+
+- Across at least 10 `build-e2e` runs with two or more slices at `rt_gate`
+  simultaneously, no run pauses with `panel_unreachable`. A single passing run is
+  explicitly insufficient, since slice 2 passed on its first attempt even with
+  the defect present.
+- A pause caused by unfillable seats says so, rather than reporting a generic
+  deadline-exceeded.

--- a/docs/proposals/pending/wfe-slices-conflict-on-shared-file.md
+++ b/docs/proposals/pending/wfe-slices-conflict-on-shared-file.md
@@ -1,0 +1,310 @@
+# Proposal: slices that each create the same file cannot merge after the first one lands
+
+- **State:** pending — single slice.
+
+## Symptom
+
+In the live `build-e2e` run `wi_f96d4b18…`, both slices that reached the merge
+stage stopped there with the same error:
+
+```
+slice 2   23:10:24  merge  pause  merge_pending: forge resource 400:
+          {"error":"github API (pr merge, HTTP 405): Pull Request has merge conflicts"}
+slice 1   23:21:10  merge  pause  (identical)
+```
+
+`gh pr list` confirms it:
+
+```
+#2013  CONFLICTING  base=aimee/feat/wi_f96d4b18…  head=aimee/wi/wi_f96d4b18….g0.2
+```
+
+## Cause
+
+Every slice of this work item writes the same single file. The deliverable *is*
+one runbook:
+
+```
+$ git diff --name-only origin/aimee/feat/<wi>...origin/aimee/wi/<wi>.…g0.2
+docs/runbooks/appliance-state-recovery.md
+
+$ git show --name-only --format="" da80f8e7      # slice 0, already merged
+docs/runbooks/appliance-state-recovery.md
+```
+
+All five slice branches were cut from the feature branch at the same instant
+(every `create` event carries `20:09:34`). Slice 0 merged at 21:03. Each later
+slice is now based on a feature branch that has moved, and its diff touches the
+file that moved.
+
+Crucially, the slices do not *edit* a shared file — they each **create** it. A
+rebase therefore cannot help. Tested in a throwaway clone:
+
+```
+$ git rebase aimee/feat/<wi>            # on slice 2's branch
+CONFLICT (add/add): Merge conflict in docs/runbooks/appliance-state-recovery.md
+error: could not apply bc2bb826... wfe: impl
+AA docs/runbooks/appliance-state-recovery.md
+```
+
+`add/add` means two full, independently authored versions of the same document
+with no common ancestor for the content. There is nothing to replay cleanly onto.
+Resolving it requires deciding what the merged document should say — a content
+decision, not a mechanical one.
+
+Two gaps combine:
+
+1. **No disjoint-ownership guard at slice time.** `test_plan_flags_overlapping_owned_files`
+   shows the delegate planner has a notion of overlapping owned files, but
+   nothing stopped the WFE slicer emitting five slices that all own one path.
+2. **No rebase before merge.** The slice-merge path does not update a slice
+   branch onto the current feature head before attempting the merge. A grep of
+   `src/modules/workflows/` and `src/server/` finds no such step. This is a
+   separate weakness; as shown above it would *not* have fixed this incident.
+
+## Consequence
+
+Both slices that have reached merge have failed there, and neither failure is a
+flake or load-dependent. Whether slices 3 and 4 fail the same way is a
+prediction, not an observation — see the assumptions below.
+
+**The engine retries the unresolvable conflict indefinitely.** Measured on the
+live run more than three hours after the first failure:
+
+| slice | merge events | first | last |
+|---|---|---|---|
+| 1 | 7 | 23:21:10 | 02:21:27 |
+| 2 | 8 | 23:10:24 | 02:21:29 |
+
+Fifteen attempts, roughly one every 25 minutes, none of which can ever succeed:
+the conflict is a property of the two trees, so it is identical on every retry.
+The run neither completes nor fails — it occupies the single active-root slot
+(`autonomy.concurrency: 1`, `trigger.max_concurrent: 1`) indefinitely, blocking
+every other work item behind it. A merge conflict is not a transient forge error
+and should not be retried as one.
+
+Stated precisely, and no more broadly than the evidence supports: **two slices
+that each independently create the same path, with content-divergent versions,
+cannot be merged after the first one lands.** Three narrowings matter:
+
+- It is narrower than "any single-file deliverable". Slices editing *distinct
+  regions of a file that already exists* share a common ancestor and can merge
+  normally; that is a stale-base problem (gap 2), not this one.
+- It is narrower than "independently creating the same path". Two slices that
+  create the same path with *identical* content merge without a conflict; git
+  only reports `add/add` as a conflict when the added content diverges.
+- The `add/add` result quoted above is established for the tested branch pair
+  (slice 2 onto the feature head). It is evidence for the general rule, not proof
+  of it.
+
+This is separate from, and additional to, the panel-seating defect in
+[wfe-panel-cannot-seat-under-self-load.md](wfe-panel-cannot-seat-under-self-load.md).
+Fixing that one alone lets slices reach merge faster and fail there — as slice 1
+demonstrated, passing `rt_gate` on its fourth attempt and then hitting this.
+
+## Options
+
+1. **Rebase the slice branch onto the feature head before merging**, re-gating if
+   the rebase changed the tree. Addresses stale bases generally. Does **not**
+   address add/add.
+2. **Merge the feature branch into the slice branch**, then merge back. Same
+   limitation as option 1 for add/add.
+3. **Reject the unsafe intersection at slice time**: refuse to emit a plan in
+   which more than one slice *creates* the same path. **Not implementable
+   against the current schema — see below.** Prevents the diagnosed class
+   without touching plans whose slices edit distinct regions of an existing file,
+   but only if slice-time path data exists, and it does not.
+3c. **Detect the collision at freeze time, before merge.** After `impl` each
+   slice has a frozen diff, so its actual created/modified paths are known. If
+   two slices in the same run create the same path with divergent content, fail
+   them *there* — with the conflicting path named — instead of letting each
+   reach `merge` and surface a bare forge 400. Implementable with data the
+   engine already has.
+3b. **Reject *all* owned_files intersections at slice time.** Stricter and
+   simpler to implement, but it forbids the distinct-region-edit case this
+   proposal says can merge normally. Adopting it needs a separate justification
+   — e.g. that region-level disjointness cannot be verified reliably at slice
+   time — which this proposal does not make.
+4. **Retry with a rebase on conflict.** Cheapest, but for add/add the retry lands
+   on the same unresolvable conflict.
+5. **Leave as-is.** Not viable: a content-divergent create/create plan, such as
+   the observed run, fails **late and opaquely** — after all implementation cost
+   has been paid, at the last stage, as a bare `forge resource 400` that names
+   neither the conflicting path nor the sibling it collides with. The failure is
+   reported (there are explicit merge pauses), but not in a form an operator can
+   act on.
+
+## Established vs. assumed
+
+Established:
+
+- Both merge pauses and their identical error text, timestamped above.
+- PR #2013 is `CONFLICTING`.
+- Slice 0 and slice 2 change exactly the same one path.
+- All five slices were created at `20:09:34`; slice 0 merged at 21:03.
+- The rebase produces `CONFLICT (add/add)` — tested, quoted above.
+- No rebase or branch-update step exists in the slice-merge path.
+- Two of the four post-slice-0 slices (1 and 2) have failed at merge, and **both
+  were independently confirmed to have the same cause**, not merely the same
+  top-level error. Slice 1 (`a62163b0`, PR #2014, `CONFLICTING`) changes the same
+  single path and rebases with the same result:
+
+  ```
+  $ git diff --name-only aimee/feat/<wi>...s1
+  docs/runbooks/appliance-state-recovery.md
+  $ git rebase aimee/feat/<wi>
+  CONFLICT (add/add): Merge conflict in docs/runbooks/appliance-state-recovery.md
+  error: could not apply a62163b0... wfe: impl
+  ```
+
+  So the failure is systematic rather than a property of one slice's content.
+
+### Slice-time path data does not exist (checked)
+
+Option 3 was originally recommended here on the assumption that the slicer knows
+which paths each slice will own. **It does not.** `exec_split`
+(`src/modules/workflows/wfe_blocks.c:1838`) asks the architect delegate for:
+
+```json
+{"schema_version":1,"packets":[{"packet_id":"p1","summary":"...",
+  "target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["..."]}]}
+```
+
+There is no path or file field in the packet schema. Confirming it from the other
+direction: `owned_files` appears only in the delegate/roadmap subsystem
+(`src/modules/delegates/delegate_plan.c`, `src/modules/roadmap/roadmap_decompose.c`
+and neighbours) and **nowhere** under `src/modules/workflows/`. The overlap test
+cited earlier is real — `src/tests/test_delegate_plan.c:116`,
+`test_plan_flags_overlapping_owned_files` — but it guards the *delegate planner*,
+not the WFE slicer. They are different code paths, and the WFE one has no
+per-slice path data to check.
+
+So a slice-time rejection would first require extending the packet schema to
+carry intended paths and getting the architect delegate to populate them
+reliably — a larger change than this proposal originally implied, and one whose
+reliability depends on a model's self-declaration.
+
+Assumed, NOT established:
+
+- **That slices 3 and 4 will fail the same way.** They share the base and target
+  file, but neither has reached merge yet.
+- **Why the planner emitted five slices for a one-file deliverable.** Whether it
+  has no overlap check on this path, ignored one, or deliberately split by
+  document section was not determined. Option 3's exact form depends on which.
+- **Relative frequency of the two gaps.** No count was taken of how often recent
+  runs hit add/add-style overlap versus ordinary stale-base conflicts. The
+  priority order below rests on the fact that gap 1 is *currently blocking a run*
+  and gap 2 is not, rather than on measured frequency. If gap 2 turns out to be
+  far more common in practice, that order should be revisited.
+
+## Recommendation
+
+Two separate decisions, deliberately not bundled:
+
+**Take option 3c now. Treat option 3 as desirable but not currently
+implementable.**
+
+The earlier draft of this proposal recommended option 3 (reject at slice time).
+That recommendation was wrong, and the check above is why: the WFE packet schema
+carries no path data, so there is nothing to check at slice time. Recommending it
+would have meant recommending a fix that cannot be written.
+
+Option 3c catches the same defect at the first point where the engine actually
+has the facts. After `impl`, each slice's frozen diff names the paths it created.
+Comparing a freshly frozen slice against its already-frozen siblings is a local
+computation on data already in hand, and it fires **as the second colliding slice
+freezes** — before that slice reaches `merge`. The operator sees "slices 1 and 2
+both create docs/runbooks/…, content differs" instead of a bare forge 400 at the
+last stage.
+
+Stated at that scope on purpose: the check is anchored to the per-slice freeze
+transition, not to a run-level gate. Whether the engine has a run-level gate
+between freeze and merge — which could fail the entire run in one place rather
+than per-slice — was not verified, and nothing here depends on it.
+
+It is strictly worse than option 3 in one respect: the implementation cost has
+already been paid by the time it fires. It does not prevent five delegates
+authoring five versions of one document; it prevents the run from ending in an
+unresolvable merge, and it explains why.
+
+Option 3 remains the better long-term shape *if* the packet schema is extended to
+carry intended paths. That is a separate piece of work, and its reliability
+depends on the architect delegate declaring paths accurately, which is unproven.
+It should not be adopted on this proposal's evidence.
+
+Option 3b (reject all ownership intersections) is not recommended: it would
+forbid the distinct-region edits this proposal says merge fine, and it faces the
+same missing-data problem as option 3.
+
+**Optional, on its own merits — option 1.** Scoped to ordinary shared-base
+staleness: a long-running slice whose base moved while it touched different
+files. This is a real improvement but it is *not* a fix for this defect, and
+should not be adopted as a substitute for option 3.
+
+**Execution order, if both are taken:** option 3c's sibling-freeze check first;
+rebase-before-merge applies only to slices that survive it. That ordering matters
+— rebasing a slice whose frozen diff already collides with a sibling's just moves
+the failure later.
+
+Slice-time rejection is deliberately **not** part of this ordering. It is not
+implementable today (see above), and reintroducing it here would bundle the
+rejected option 3 back into the decision. If the packet schema is later extended
+to carry intended paths, the ordering becomes: slice-time rejection, then 3c as
+the backstop for paths the plan did not declare, then rebase.
+
+Option 4 should be resisted as a primary fix: it treats the conflict as an
+exception to retry, when for slices that each create the same file the conflict
+is the guaranteed steady state.
+
+## Acceptance
+
+For option 3c, the remedy proposed here:
+
+- When two sibling slices in a run have frozen diffs that both **create** the
+  same path with **divergent** content, the run fails at that point, naming the
+  path and the slices involved — before either reaches `merge`.
+- Two sibling slices creating the same path with *identical* content are not
+  failed by this rule (git merges them cleanly).
+- Slices editing *distinct regions of an existing* shared file are not failed by
+  this rule.
+- Replaying `wi_f96d4b18…` against the fix fails **when the second slice
+  freezes**, naming `docs/runbooks/appliance-state-recovery.md` and the sibling
+  it collides with — instead of two PRs left `CONFLICTING`.
+
+  Scoped deliberately to the per-slice freeze transition, which is state the
+  engine already holds. Whether a *run-level* gate exists between freeze and
+  merge that could fail the whole run at once was **not verified**, so no
+  criterion here depends on one. If such a gate does exist, failing the run
+  there would be preferable and this criterion should be revisited.
+- **The check is atomic with respect to concurrent freezes.** Two sibling slices
+  that freeze simultaneously must not both pass by each failing to observe the
+  other. This requires serialising the compare-and-record step — a per-run freeze
+  lock, a single-writer freeze queue, or equivalent — so that for any colliding
+  pair exactly one slice observes the other's recorded paths and fails.
+  Without this, the fix is a time-of-check/time-of-use race that the observed run
+  did not happen to exercise, because its slices froze minutes apart
+  (23:01:43 and 23:21:05).
+- Regression coverage: a test for divergent create/create across siblings
+  (fails), a test for identical create/create (passes), a test for
+  distinct-region edits to an existing file (passes), and a **concurrent-freeze**
+  test in which two colliding slices freeze simultaneously and exactly one is
+  failed.
+
+Independently of which option is chosen:
+
+- **A merge conflict is treated as terminal, not transient.** A slice whose merge
+  fails with a conflict does not retry the identical merge indefinitely; it fails
+  with the conflicting paths named, and releases the run's active-root slot.
+  (Observed: 15 retries over 3 hours, blocking every other work item behind the
+  single `autonomy.concurrency: 1` slot.)
+
+Deferred — follow-up acceptance criteria for whichever implementation is chosen,
+not claims about this proposal:
+
+- No run terminates in a state requiring a manual content-merge step, and no
+  pipeline PR is left `CONFLICTING`.
+- A slice that cannot merge reports the conflicting paths and the conflict type,
+  rather than surfacing a bare `forge resource 400`.
+- If option 1 is implemented: a slice whose base moved and whose files are
+  disjoint from what landed is updated onto the feature head and merges without
+  manual intervention.

--- a/scripts/embed-remote.py
+++ b/scripts/embed-remote.py
@@ -18,7 +18,9 @@ Config (env), in precedence order:
   AIMEE_EMBEDDER_URL  base URL of the embedder service (pins the embedder)
   AIMEE_LLM_URL       base URL of the unified aimee-llm container (one knob for
                       embed + rerank + synth); used when AIMEE_EMBEDDER_URL is unset
-  (fallback)          http://embedder:8080 (legacy compose embedder service)
+  (unset)             no embedder configured; reported immediately so the caller
+                      can use its builtin path. Pin the legacy compose service
+                      with AIMEE_EMBEDDER_URL=http://embedder:8080 if wanted.
 
 Usage:
   embedding_command: "python3 /opt/aimee/scripts/embed-remote.py"
@@ -30,11 +32,22 @@ import sys
 import urllib.error
 import urllib.request
 
+# No implicit legacy fallback. This used to default to http://embedder:8080, the
+# old combined-compose service name, which resolves nowhere on a split deploy or a
+# bare `docker run` -- so an unconfigured kb retried a host that cannot exist and
+# never reported healthy. The Dockerfile removed the matching AIMEE_EMBEDDER_URL /
+# LLM_ENDPOINT env defaults for exactly that reason; this fallback survived it.
+# Unset now means "no embedder configured", reported immediately so the caller can
+# take its builtin path. The legacy service is still reachable by setting
+# AIMEE_EMBEDDER_URL=http://embedder:8080 explicitly, as compose.yaml documents.
 ENDPOINT = (
-    os.environ.get("AIMEE_EMBEDDER_URL")
-    or os.environ.get("AIMEE_LLM_URL")
-    or "http://embedder:8080"
+    os.environ.get("AIMEE_EMBEDDER_URL") or os.environ.get("AIMEE_LLM_URL") or ""
 ).rstrip("/")
+
+NO_ENDPOINT_MESSAGE = (
+    "embed-remote: no embedder configured "
+    "(set AIMEE_LLM_URL, or AIMEE_EMBEDDER_URL to pin one)\n"
+)
 TIMEOUT = int(os.environ.get("AIMEE_EMBEDDER_TIMEOUT", "30"))
 
 
@@ -52,6 +65,9 @@ def probe_dim() -> int:
     positive integer dim; exit non-zero (caller treats as 'not ready') while the
     model is still loading, on any HTTP/parse error, or on a missing/non-positive
     dim. Single GET, no embedding — cheap enough to poll."""
+    if not ENDPOINT:
+        sys.stderr.write(NO_ENDPOINT_MESSAGE)
+        return 1
     try:
         with urllib.request.urlopen(f"{ENDPOINT}/health", timeout=TIMEOUT) as resp:
             payload = json.loads(resp.read().decode("utf-8"))
@@ -75,6 +91,9 @@ def probe_dim() -> int:
 def main() -> None:
     if "--dim" in sys.argv[1:]:
         sys.exit(probe_dim())
+    if not ENDPOINT:
+        sys.stderr.write(NO_ENDPOINT_MESSAGE)
+        sys.exit(1)
     raw = sys.stdin.read()
     if not raw.strip():
         sys.stderr.write("embed-remote: empty input\n")

--- a/scripts/rerank-remote.py
+++ b/scripts/rerank-remote.py
@@ -24,7 +24,8 @@ Config (env), in precedence order:
   AIMEE_EMBEDDER_URL  base URL of the embedder service (rerank shares it by default)
   AIMEE_LLM_URL       base URL of the unified aimee-llm container (one knob for
                       embed + rerank + synth)
-  (fallback)          http://embedder:8080 (legacy compose embedder service)
+  (unset)             no reranker configured; reported immediately. Pin the
+                      legacy compose service explicitly if wanted.
   AIMEE_RERANK_TIMEOUT  request timeout seconds (default 30)
 
 Usage:
@@ -36,16 +37,26 @@ import sys
 import urllib.error
 import urllib.request
 
+# No implicit legacy fallback -- see the note in embed-remote.py. Defaulting to
+# the old combined-compose http://embedder:8080 made an unconfigured kb dial a
+# host that cannot resolve on a split deploy or a bare `docker run`. Pin the
+# legacy service explicitly if you want it.
 ENDPOINT = (
     os.environ.get("AIMEE_RERANKER_URL")
     or os.environ.get("AIMEE_EMBEDDER_URL")
     or os.environ.get("AIMEE_LLM_URL")
-    or "http://embedder:8080"
+    or ""
 ).rstrip("/")
 TIMEOUT = int(os.environ.get("AIMEE_RERANK_TIMEOUT", "30"))
 
 
 def main() -> None:
+    if not ENDPOINT:
+        sys.stderr.write(
+            "rerank-remote: no reranker configured "
+            "(set AIMEE_LLM_URL, or AIMEE_RERANKER_URL to pin one)\n"
+        )
+        sys.exit(1)
     payload = sys.stdin.read()
     if not payload.strip():
         sys.stderr.write("rerank-remote: empty input\n")


### PR DESCRIPTION
## Symptom

Running the shipped `aimee-kb` image with no siblings brings its database up correctly and then never reports healthy:

```
embed-remote --dim: /health at http://embedder:8080 unreachable:
  <urlopen error [Errno -2] Name or service not known>
```

## Cause

`embed-remote.py` and `rerank-remote.py` fall back to `http://embedder:8080` — the old combined-compose service name — when no endpoint variable is set:

```python
os.environ.get("AIMEE_EMBEDDER_URL")
or os.environ.get("AIMEE_LLM_URL")
or "http://embedder:8080"
```

That hostname does not resolve on a split deploy or a bare `docker run`, so an unconfigured kb retries a host that cannot exist.

The Dockerfile already removed the matching env defaults for exactly this reason:

> *(Old combined leftovers `AIMEE_EMBEDDER_URL=embedder:8080` / `LLM_ENDPOINT=llm:8080` were removed: on a split deploy they silently pointed at non-existent services.)*

The env vars went; the fallback inside the sidecars did not, so the behaviour survived the fix.

## Change

Unset now means "nothing configured" and is reported immediately — the same non-zero exit + stderr signal the caller already handles for an unreachable embedder — so the kb can take its documented builtin path rather than waiting on a dead hostname.

Verified:

| case | before | after |
|---|---|---|
| nothing set | dials `embedder:8080`, DNS failure | `no embedder configured (set AIMEE_LLM_URL, …)`, exit 1 |
| `AIMEE_LLM_URL` set | dials it | unchanged |
| `AIMEE_EMBEDDER_URL=http://embedder:8080` | dials it | unchanged |

Nothing depends on the implicit fallback: `compose.yaml:75` always sets `AIMEE_LLM_URL` (defaulting to `aimee-llm:8080`), and line 21 documents the legacy rollback as requiring an explicit `AIMEE_EMBEDDER_URL=http://embedder:8080`.

`kb-container-packaging-check` and `sidecar-clients-check` pass.

## Provenance

Found while testing #2001's embedded-postgres path in a clean container. That path is what makes a bare `docker run aimee-kb` viable for the first time, which is why this pre-existing defect surfaces now: the database comes up, the service does not.
