### PR TITLE
Fix three defects that stop the WFE completing a run

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -110,6 +110,24 @@ void agent_set_route_degraded_filter(int (*fn)(const char *agent_name));
  * route to a client-only claude. */
 void agent_set_route_policy_filter(int (*fn)(const agent_t *agent));
 
+/* Optional route-time capacity probe: returns the number of slots CURRENTLY in
+ * use by `agent_name`, or -1 when unknown/unconfigured. The server registers
+ * agent_admission_agent_active; CLI and test builds leave it NULL.
+ *
+ * Routing PREFERS agents with a free slot (active < max_parallel) over saturated
+ * ones. Without it, routing and admission disagreed about "available": routing
+ * checks health, policy and structure but not capacity, so it handed out agents
+ * that were already at max_parallel, and admission then rejected them with
+ * AGENT_RC_AT_LIMIT. Health could not close the gap, because being at-limit is
+ * deliberately NOT recorded as a provider fault (see agent_fallback.c), so a
+ * saturated agent is never marked DOWN and stays selectable forever.
+ *
+ * This only ever REORDERS preference — if every candidate is saturated, routing
+ * falls back to the full set, so a populated pool can never be filtered down to
+ * "no agent available", and blocking admission still waits for a slot. An
+ * unknown answer (-1, or no probe) counts as "has capacity". */
+void agent_set_route_capacity_probe(int (*fn)(const char *agent_name));
+
 /* Primary-turn marker for the delegate-policy filter. The PRIMARY chat turn
  * routes the provider-named agent through the same machinery as delegation
  * (agent_run_with_tools -> agent_route), where the `primary_only` gate above

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -619,7 +619,13 @@ int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number
    else if (st == 405 || st == 409)
    {
       gh_err(resp, st, "pr merge", err, errlen);
-      res = 2; /* not mergeable / head moved */
+      /* Separate the terminal case from the retryable one. A content conflict is
+       * a property of the two trees: retrying reproduces it exactly. A moved
+       * head/base is a lost race that a retry wins. Both arrive as 405/409, so
+       * the body is the only discriminator GitHub gives us. Match on the message
+       * text produced by gh_err rather than the raw body so a conflict reported
+       * with different JSON framing still classifies. */
+      res = git_pr_merge_err_is_conflict(err) ? 3 : 2;
    }
    else
    {

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -100,7 +100,25 @@ int git_pr_ci_permits_merge(git_pr_ci_t ci);
 
 /* Squash-merge PUT /pulls/<n>/merge with an explicitly empty synthesized
  * commit body. Returns 0 merged, 1 already merged, 2 not mergeable (405/409),
- * -1 error. */
+ * 3 merge CONFLICT, -1 error.
+ *
+ * 2 vs 3 matters to every caller that retries. GitHub answers 405/409 for two
+ * unrelated situations: a lost race (the head or base moved between the
+ * mergeability check and the PUT — "Head branch was modified", "Base branch was
+ * modified"), and a genuine content conflict ("Pull Request has merge
+ * conflicts"). The first resolves itself on a retry; the second is a property of
+ * the two trees and is identical on every retry, forever. Collapsing them made
+ * the engine re-attempt an unwinnable merge indefinitely (observed: 15 attempts
+ * over 3 hours on one run, holding the single active-root slot). Callers must
+ * treat 3 as terminal. */
+
+/* Does this 405/409 merge error describe a content CONFLICT (terminal) rather
+ * than a lost race (retryable)? Text-matching a forge message is unlovely, but
+ * GitHub returns the same status for both and the message is the only signal it
+ * gives. Fails SAFE: an unrecognised message is reported as NOT a conflict, so
+ * an unfamiliar phrasing degrades to today's retry behaviour rather than
+ * terminating a run that could have succeeded. Pure; unit-tested. */
+int git_pr_merge_err_is_conflict(const char *err);
 int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number, char *err,
                          size_t errlen);
 

--- a/src/modules/git/git_pr_ci_grade.c
+++ b/src/modules/git/git_pr_ci_grade.c
@@ -5,7 +5,45 @@
 
 #include "cJSON.h"
 
+#include <ctype.h>
 #include <string.h>
+
+/* Case-insensitive substring search. Not strcasestr(): that is a GNU extension,
+ * and this file is deliberately built into minimal test binaries that do not
+ * define _GNU_SOURCE. */
+static const char *ci_grade_casestr(const char *hay, const char *needle)
+{
+   if (!hay || !needle || !needle[0])
+      return NULL;
+   for (const char *h = hay; *h; h++)
+   {
+      const char *a = h, *b = needle;
+      while (*a && *b && tolower((unsigned char)*a) == tolower((unsigned char)*b))
+      {
+         a++;
+         b++;
+      }
+      if (!*b)
+         return h;
+   }
+   return NULL;
+}
+
+int git_pr_merge_err_is_conflict(const char *err)
+{
+   if (!err || !err[0])
+      return 0;
+   /* GitHub's conflict wording, observed live: "Pull Request has merge
+    * conflicts". Match the distinctive noun phrase rather than the whole
+    * sentence, so a reworded message ("has merge conflict", "merge conflicts
+    * detected") still classifies.
+    *
+    * "conflict" alone is deliberately NOT matched: HTTP 409 is literally named
+    * "Conflict" and its lost-race messages can carry the bare word, and that is
+    * exactly the case that must stay retryable. Requiring the pair keeps the
+    * predicate from terminating runs that a retry would have won. */
+   return ci_grade_casestr(err, "merge conflict") != NULL;
+}
 
 int git_pr_ci_permits_merge(git_pr_ci_t ci)
 {

--- a/src/modules/workflows/wfe_blocks.c
+++ b/src/modules/workflows/wfe_blocks.c
@@ -1514,6 +1514,13 @@ static wfe_step_result_t exec_merge(wfe_ctx *ctx, const wfe_node_t *node)
       return wfe_step_advanced("merged", "", 0.0);
    case WFE_MERGE_NOT_MERGEABLE:
       return wfe_step_looped();
+   case WFE_MERGE_CONFLICT:
+      /* Terminal: the conflict is a property of the two trees, so every retry
+       * reproduces it. Looping (or parking in the self-resolving merge_pending)
+       * would re-attempt it forever while holding the run's active-root slot and
+       * blocking every other work item behind it. Fail so the slot is released
+       * and a human sees a conflict that needs a content decision. */
+      return wfe_step_failed();
    default:
       /* transient/unknown forge error on the merge act itself: park for a human
        * re-drive rather than hard-failing the run. We only reach here with a

--- a/src/modules/workflows/wfe_blocks.c
+++ b/src/modules/workflows/wfe_blocks.c
@@ -1312,8 +1312,8 @@ int wfe_slice_recreates_base_path(const char *workdir, const char *base_ref, con
 
    /* Paths this slice ADDED relative to where it was cut. -z keeps paths with
     * spaces/specials unambiguous (no core.quotePath quoting). */
-   const char *argv[] = {"git", "-C",          workdir, "diff",           "--name-only",
-                         "-z",  "--diff-filter=A",      base_sha, "HEAD", NULL};
+   const char *argv[] = {"git",    "-C",   workdir, "diff", "--name-only", "-z", "--diff-filter=A",
+                         base_sha, "HEAD", NULL};
    char *added = NULL;
    if (git_capture(argv, &added) != 0 || !added)
    {

--- a/src/modules/workflows/wfe_blocks.c
+++ b/src/modules/workflows/wfe_blocks.c
@@ -1279,6 +1279,91 @@ static wfe_step_result_t exec_source_archive(wfe_ctx *ctx, const wfe_node_t *nod
    return wfe_step_advanced(handle, head, 0.0);
 }
 
+/* Does this slice CREATE a path that already exists on `base_ref`, with
+ * different content? That is an add/add conflict waiting to happen at merge.
+ *
+ * Slices of one work item are cut from the feature branch at the same instant
+ * and merged one at a time. When two of them each *create* the same file — the
+ * normal shape when the deliverable is a single document — the first merges and
+ * every later one hits `add/add`: two independently authored versions with no
+ * common ancestor for the content. Nothing mechanical resolves that; a rebase
+ * reproduces it exactly. Left undetected it surfaces only at merge, as a bare
+ * forge 400, after every slice has paid its full implementation cost.
+ *
+ * Checked against the CURRENT feature head rather than against sibling slices,
+ * which is both simpler and race-free: there is no shared mutable state to
+ * serialise, only a read of a branch that already reflects whatever has merged.
+ * The trade-off is that it fires from the second colliding slice onward, not on
+ * the first — the first one is not yet a collision.
+ *
+ * Identical content is NOT flagged: git merges an add/add cleanly when both
+ * sides added the same bytes, so failing it would reject work that would land.
+ *
+ * Returns 1 and fills `path_out` when a diverging collision exists, else 0.
+ * Fails SAFE: any git error returns 0, leaving today's behaviour (surface at
+ * merge) rather than failing a slice on a command we could not run. */
+int wfe_slice_recreates_base_path(const char *workdir, const char *base_ref, const char *base_sha,
+                                  char *path_out, size_t path_cap)
+{
+   if (path_out && path_cap)
+      path_out[0] = '\0';
+   if (!workdir || !workdir[0] || !base_ref || !base_ref[0] || !base_sha || !base_sha[0])
+      return 0;
+
+   /* Paths this slice ADDED relative to where it was cut. -z keeps paths with
+    * spaces/specials unambiguous (no core.quotePath quoting). */
+   const char *argv[] = {"git", "-C",          workdir, "diff",           "--name-only",
+                         "-z",  "--diff-filter=A",      base_sha, "HEAD", NULL};
+   char *added = NULL;
+   if (git_capture(argv, &added) != 0 || !added)
+   {
+      free(added);
+      return 0;
+   }
+
+   int found = 0;
+   for (const char *p = added; *p && !found; p += strlen(p) + 1)
+   {
+      char ours[80] = "", theirs[80] = "";
+      char spec_ours[1200], spec_theirs[1200];
+      snprintf(spec_ours, sizeof spec_ours, "HEAD:%s", p);
+      snprintf(spec_theirs, sizeof spec_theirs, "%s:%s", base_ref, p);
+
+      /* Absent on the base ref -> no collision; this slice is the only author. */
+      const char *tv[] = {"git", "-C", workdir, "rev-parse", "--verify", "-q", spec_theirs, NULL};
+      char *t = NULL;
+      if (git_capture(tv, &t) != 0 || !t || !t[0])
+      {
+         free(t);
+         continue;
+      }
+      snprintf(theirs, sizeof theirs, "%s", t);
+      chomp(theirs);
+      free(t);
+
+      const char *ov[] = {"git", "-C", workdir, "rev-parse", "--verify", "-q", spec_ours, NULL};
+      char *o = NULL;
+      if (git_capture(ov, &o) != 0 || !o || !o[0])
+      {
+         free(o);
+         continue;
+      }
+      snprintf(ours, sizeof ours, "%s", o);
+      chomp(ours);
+      free(o);
+
+      /* Same blob on both sides merges cleanly — only divergence conflicts. */
+      if (ours[0] && theirs[0] && strcmp(ours, theirs) != 0)
+      {
+         if (path_out && path_cap)
+            snprintf(path_out, path_cap, "%s", p);
+         found = 1;
+      }
+   }
+   free(added);
+   return found;
+}
+
 /* freeze: capture the cumulative diff at a stable freeze commit. */
 static wfe_step_result_t exec_freeze(wfe_ctx *ctx, const wfe_node_t *node)
 {
@@ -1289,6 +1374,35 @@ static wfe_step_result_t exec_freeze(wfe_ctx *ctx, const wfe_node_t *node)
    if (wfe_git_freeze(wd, base_branch ? base_branch : "HEAD", base, head, dhash, err, sizeof err) !=
        0)
       return wfe_step_failed();
+
+   /* Fail now, not at merge, if this slice re-creates a file a sibling already
+    * landed on the feature branch with different content. That is an add/add
+    * conflict: no rebase or retry resolves it, so letting it reach merge only
+    * spends the rest of the pipeline to arrive at an unwinnable merge. Naming
+    * the path here is the difference between an actionable failure and the bare
+    * forge 400 it would otherwise become. */
+   if (base_branch && base_branch[0])
+   {
+      char clash[1024];
+      if (wfe_slice_recreates_base_path(wd, base_branch, base, clash, sizeof clash))
+      {
+         /* PERMANENT, not TRANSIENT: re-running the slice produces another
+          * independently authored version of the same file, which collides the
+          * same way. There is no new input that changes the outcome, so the
+          * taxonomy's "never auto-retry without new input" rule applies at its
+          * strongest here.
+          *
+          * The colliding path is known (`clash`) but not reported: this block
+          * interface carries no message field, by design — a step speaks only
+          * through wfe_step_result_t. Surfacing it needs that struct widened,
+          * which is a broader change than this fix; until then the operator sees
+          * a permanent freeze failure rather than the path. Still a strict
+          * improvement on discovering it as a bare forge 400 at merge, after the
+          * whole pipeline has run. */
+         return wfe_step_failed_class(WFE_FAIL_PERMANENT, 0);
+      }
+   }
+
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
    return wfe_step_advanced(handle, dhash, 0.0);

--- a/src/modules/workflows/wfe_blocks.h
+++ b/src/modules/workflows/wfe_blocks.h
@@ -42,7 +42,8 @@ typedef enum
 {
    WFE_MERGE_OK = 0,        /* merged now */
    WFE_MERGE_ALREADY,       /* already merged -> idempotent no-op success */
-   WFE_MERGE_NOT_MERGEABLE, /* conflict / lost race -> loop */
+   WFE_MERGE_NOT_MERGEABLE, /* lost race (head/base moved) -> loop; self-resolves */
+   WFE_MERGE_CONFLICT,      /* content conflict -> TERMINAL; retrying cannot win */
    WFE_MERGE_ERROR          /* forge error -> fail closed */
 } wfe_merge_result_t;
 

--- a/src/modules/workflows/wfe_blocks.h
+++ b/src/modules/workflows/wfe_blocks.h
@@ -170,6 +170,23 @@ int wfe_tdd_red_ok(const char *workdir);
  * for the unit test. */
 int wfe_tdd_tests_survive(const char *workdir, const char *red_sha);
 
+/* Add/add pre-check at freeze. Returns 1 (and fills `path_out`) when this slice
+ * CREATES a path that already exists on `base_ref` with DIFFERENT content — the
+ * shape that cannot be merged once a sibling slice has landed the same file, and
+ * that no rebase resolves. Identical content is not flagged: git merges an
+ * add/add cleanly when both sides added the same bytes.
+ *
+ * Compared against the current feature head rather than against sibling slices,
+ * which is race-free — it reads a branch that already reflects whatever merged,
+ * so there is no shared mutable state to serialise. It therefore fires from the
+ * second colliding slice onward; the first is not yet a collision.
+ *
+ * Best-effort like the guard above: any git failure returns 0, leaving the merge
+ * to surface it, rather than failing a slice on a command we could not run.
+ * Exposed for the unit test. */
+int wfe_slice_recreates_base_path(const char *workdir, const char *base_ref, const char *base_sha,
+                                  char *path_out, size_t path_cap);
+
 /* ---- Child-workflow fan-out seam for foreach.workflow (sliced-lifecycle build).
  * The block decomposes the split packets into one CHILD workflow run per packet
  * (the "slice" workflow: implement -> freeze -> roundtable -> sub-PR -> green CI ->

--- a/src/modules/workflows/wfe_live_forge.c
+++ b/src/modules/workflows/wfe_live_forge.c
@@ -315,6 +315,13 @@ static wfe_merge_result_t live_merge(const char *repo, const char *pr)
    case 2:
       aimee_log(LOG_WARN, "wfe-forge", "merge of PR %d: %s", num, err);
       return WFE_MERGE_NOT_MERGEABLE;
+   case 3:
+      /* A content conflict, not a lost race. Looping here re-attempts a merge
+       * that is identical every time and can never succeed, while the run holds
+       * the single active-root slot. Terminal, and say what conflicted. */
+      aimee_log(LOG_ERROR, "wfe-forge", "merge of PR %d conflicts and cannot be retried: %s", num,
+                err);
+      return WFE_MERGE_CONFLICT;
    default:
       aimee_log(LOG_WARN, "wfe-forge", "merge of PR %d: %s", num, err);
       return WFE_MERGE_ERROR; /* unknown -> park for a human */

--- a/src/server/agent_route.c
+++ b/src/server/agent_route.c
@@ -152,6 +152,32 @@ void agent_set_route_policy_filter(int (*fn)(const agent_t *agent))
    g_route_policy_filter = fn;
 }
 
+/* Optional route-time capacity probe; see agent_set_route_capacity_probe. A hook,
+ * like the health and policy filters above, so this unit keeps no link
+ * dependency on the admission controller and filter-less builds (CLI / tests)
+ * keep the prior behaviour. */
+static int (*g_route_capacity_probe)(const char *agent_name) = NULL;
+
+void agent_set_route_capacity_probe(int (*fn)(const char *agent_name))
+{
+   g_route_capacity_probe = fn;
+}
+
+/* Does this agent have a free concurrency slot right now? Returns 1 when it
+ * does, and ALSO when capacity is unknown — no probe registered, controller
+ * unconfigured (-1), or an agent with no per-agent cap. Unknown must read as
+ * "yes": this predicate only narrows a candidate set, so answering "no" on
+ * ignorance would drop seats for a reason we cannot substantiate. */
+static int agent_has_free_slot(const agent_t *ag)
+{
+   if (!g_route_capacity_probe || !ag || !ag->name[0] || ag->max_parallel <= 0)
+      return 1;
+   int active = g_route_capacity_probe(ag->name);
+   if (active < 0)
+      return 1; /* unconfigured / unknown */
+   return active < ag->max_parallel;
+}
+
 /* See agent_config.h: marks the current thread's turn as PRIMARY (not
  * delegation) so the policy filter doesn't exclude the provider-named agent
  * from its own chat turn. */
@@ -373,7 +399,31 @@ int delegate_pick_for_role(agent_config_t *cfg, const char *role, const char *co
    }
    if (n == 0)
       return -1;
-   return elig[delegate_role_rand() % (unsigned)n];
+
+   /* Prefer a seat that can actually start now. Eligibility above asks whether
+    * the agent is routable (health, policy, structure, credentials) but not
+    * whether it has a free concurrency slot, so a saturated agent stayed
+    * selectable and the seat failed at admission with AGENT_RC_AT_LIMIT. Health
+    * cannot close that gap: being at-limit is deliberately NOT recorded as a
+    * provider fault (agent_fallback.c), so such an agent is never marked DOWN.
+    * Live effect: roundtable seats drew a saturated agent, failed instantly, and
+    * a panel needing 2 of 3 seats was declared unreachable while other agents
+    * sat idle.
+    *
+    * PREFER, never exclude. If every eligible agent is saturated we fall back to
+    * the full eligible set, so this cannot turn a populated roster into "no
+    * agent for role" (-1) — the caller still gets a seat and blocking admission
+    * waits for a slot, exactly as before. It only stops us choosing a full agent
+    * over a free one. */
+   int freeel[MAX_AGENTS];
+   int nfree = 0;
+   for (int i = 0; i < n; i++)
+      if (agent_has_free_slot(&cfg->agents[elig[i]]))
+         freeel[nfree++] = elig[i];
+
+   const int *pool = nfree > 0 ? freeel : elig;
+   int pool_n = nfree > 0 ? nfree : n;
+   return pool[delegate_role_rand() % (unsigned)pool_n];
 }
 
 int agent_pick_named_for_role(agent_config_t *cfg, const char *name, const char *role)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -41,8 +41,8 @@
 #include "server_pipeline.h" /* roundtable authoring pipeline (pipeline.*) */
 #include "commands.h"
 #include "agent.h"
-#include "agent_exec.h"     /* agent_audit_async_flush — drain audit queue at shutdown */
-#include "webuser_editor.h" /* webuser_editor_shutdown — reap editors at shutdown (WP-I) */
+#include "agent_exec.h"      /* agent_audit_async_flush — drain audit queue at shutdown */
+#include "webuser_editor.h"  /* webuser_editor_shutdown — reap editors at shutdown (WP-I) */
 #include "agent_admission.h" /* agent_admission_agent_active — route capacity probe */
 #include "agent_config.h"
 #include "provider_catalog.h"
@@ -2348,10 +2348,7 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * delegates to itself, and an agent flagged "Primary Agent Only"
     * (agents.json `primary_only`) is never a delegation target. */
    agent_set_route_policy_filter(server_agent_route_policy_excluded);
-   /* Prefer a seat with a free concurrency slot. Routing otherwise hands out an
-    * agent already at max_parallel, which admission immediately rejects — and
-    * at-limit deliberately never records provider health, so such an agent is
-    * never marked DOWN and stays selectable indefinitely. */
+   /* Prefer a seat with a free slot over a saturated one (see agent_config.h). */
    agent_set_route_capacity_probe(agent_admission_agent_active);
    LOG_INFO("server",
             "initialized (v%s, protocol %d, background=%d session=%d threads); /v1 HTTP "

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -43,6 +43,7 @@
 #include "agent.h"
 #include "agent_exec.h"     /* agent_audit_async_flush — drain audit queue at shutdown */
 #include "webuser_editor.h" /* webuser_editor_shutdown — reap editors at shutdown (WP-I) */
+#include "agent_admission.h" /* agent_admission_agent_active — route capacity probe */
 #include "agent_config.h"
 #include "provider_catalog.h"
 #include <aimee/delegates/delegate_credentials.h>
@@ -2347,6 +2348,11 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * delegates to itself, and an agent flagged "Primary Agent Only"
     * (agents.json `primary_only`) is never a delegation target. */
    agent_set_route_policy_filter(server_agent_route_policy_excluded);
+   /* Prefer a seat with a free concurrency slot. Routing otherwise hands out an
+    * agent already at max_parallel, which admission immediately rejects — and
+    * at-limit deliberately never records provider health, so such an agent is
+    * never marked DOWN and stays selectable indefinitely. */
+   agent_set_route_capacity_probe(agent_admission_agent_active);
    LOG_INFO("server",
             "initialized (v%s, protocol %d, background=%d session=%d threads); /v1 HTTP "
             "surface owns the listeners",

--- a/src/tests/test_git_pr_ci_grade.c
+++ b/src/tests/test_git_pr_ci_grade.c
@@ -77,7 +77,7 @@ int main(void)
     * have merged. Hence the predicate fails SAFE toward retry. */
    assert(git_pr_merge_err_is_conflict("github API (pr merge, HTTP 405): Pull Request has merge "
                                        "conflicts"));
-   assert(git_pr_merge_err_is_conflict("merge conflict")); /* minimal phrasing */
+   assert(git_pr_merge_err_is_conflict("merge conflict"));           /* minimal phrasing */
    assert(git_pr_merge_err_is_conflict("MERGE CONFLICTS DETECTED")); /* case-insensitive */
 
    /* Lost races must stay retryable — these are the messages a retry wins. */

--- a/src/tests/test_git_pr_ci_grade.c
+++ b/src/tests/test_git_pr_ci_grade.c
@@ -69,6 +69,31 @@ int main(void)
    /* end to end: a malformed payload must not reach a merge */
    assert(!git_pr_ci_permits_merge(git_pr_ci_grade_json("not json", "also not json")));
 
+   /* --- terminal conflict vs retryable lost race (both arrive as 405/409) ---
+    * A content conflict is identical on every retry, so it must be terminal; a
+    * moved head/base is a lost race a retry wins. Getting this wrong in the
+    * retryable direction wedges a run forever (observed: 15 attempts over 3
+    * hours); getting it wrong in the terminal direction kills a run that would
+    * have merged. Hence the predicate fails SAFE toward retry. */
+   assert(git_pr_merge_err_is_conflict("github API (pr merge, HTTP 405): Pull Request has merge "
+                                       "conflicts"));
+   assert(git_pr_merge_err_is_conflict("merge conflict")); /* minimal phrasing */
+   assert(git_pr_merge_err_is_conflict("MERGE CONFLICTS DETECTED")); /* case-insensitive */
+
+   /* Lost races must stay retryable — these are the messages a retry wins. */
+   assert(!git_pr_merge_err_is_conflict(
+       "github API (pr merge, HTTP 409): Head branch was modified. Review and try the merge "
+       "again."));
+   assert(!git_pr_merge_err_is_conflict("github API (pr merge, HTTP 405): Base branch was "
+                                        "modified. Review and try the merge again."));
+   /* The bare word must NOT terminate: HTTP 409 is named "Conflict", so a
+    * lost-race message can carry it with no content conflict involved. */
+   assert(!git_pr_merge_err_is_conflict("github API (pr merge, HTTP 409): Conflict"));
+   /* Unrecognised / empty degrade to retry, never to a terminal kill. */
+   assert(!git_pr_merge_err_is_conflict("github API (pr merge, HTTP 405): failed"));
+   assert(!git_pr_merge_err_is_conflict(""));
+   assert(!git_pr_merge_err_is_conflict(NULL));
+
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_roundtable_seat_resolve.c
+++ b/src/tests/test_roundtable_seat_resolve.c
@@ -23,6 +23,17 @@ static void mk_agent(agent_t *a, const char *name, const char *role, int enabled
    snprintf(a->api_key, sizeof a->api_key, "sk-test-%s", name); /* literal -> routable */
 }
 
+/* Stub capacity probe: reports slots in use per agent name, or -1 for unknown. */
+static int g_cap_full, g_cap_free;
+static int cap_probe(const char *agent_name)
+{
+   if (agent_name && strcmp(agent_name, "full") == 0)
+      return g_cap_full;
+   if (agent_name && strcmp(agent_name, "free") == 0)
+      return g_cap_free;
+   return -1;
+}
+
 int main(void)
 {
    /* Deterministic random draws. */
@@ -94,6 +105,53 @@ int main(void)
    /* Bad args. */
    assert(rt_resolve_seat_model(NULL, "agentA", "review", NULL, 0, &idx) == RT_SEAT_INVALID);
    assert(rt_resolve_seat_model(&cfg, "agentA", "review", NULL, 0, NULL) == RT_SEAT_INVALID);
+
+   /* --- a "$random" seat prefers an agent with a free concurrency slot ---
+    * Routing checks health/policy/structure but not capacity, so a saturated
+    * agent stayed selectable and the seat failed at admission with
+    * AGENT_RC_AT_LIMIT. Health cannot compensate: at-limit is deliberately never
+    * recorded as a provider fault, so the agent is never marked DOWN. */
+   agent_config_t ccfg;
+   memset(&ccfg, 0, sizeof ccfg);
+   mk_agent(&ccfg.agents[0], "full", "review", 1);
+   mk_agent(&ccfg.agents[1], "free", "review", 1);
+   ccfg.agents[0].max_parallel = 3;
+   ccfg.agents[1].max_parallel = 3;
+   ccfg.agent_count = 2;
+
+   agent_set_route_capacity_probe(cap_probe);
+   /* "full" is at its cap, "free" is idle: every draw must pick "free". */
+   g_cap_full = 3;
+   g_cap_free = 0;
+   for (int i = 0; i < 40; i++)
+   {
+      assert(rt_resolve_seat_model(&ccfg, "$random", "review", NULL, 0, &idx) == RT_SEAT_OK);
+      assert(idx == 1); /* never the saturated agent while a free one exists */
+   }
+
+   /* Both saturated: PREFER must not become EXCLUDE. The seat still resolves —
+    * the caller gets an agent and blocking admission waits for a slot — rather
+    * than collapsing a populated roster into "no agent for role". */
+   g_cap_full = 3;
+   g_cap_free = 3;
+   assert(rt_resolve_seat_model(&ccfg, "$random", "review", NULL, 0, &idx) == RT_SEAT_OK);
+   assert(idx == 0 || idx == 1);
+
+   /* Unknown capacity (-1, i.e. controller unconfigured) must read as "has
+    * capacity", so an unconfigured build keeps the prior behaviour. */
+   g_cap_full = -1;
+   g_cap_free = -1;
+   assert(rt_resolve_seat_model(&ccfg, "$random", "review", NULL, 0, &idx) == RT_SEAT_OK);
+   assert(idx == 0 || idx == 1);
+
+   /* A pinned seat is unaffected by capacity: it resolves to that exact agent
+    * (no substitution) even when saturated — admission decides, not routing. */
+   g_cap_full = 3;
+   g_cap_free = 0;
+   assert(rt_resolve_seat_model(&ccfg, "full", "review", NULL, 0, &idx) == RT_SEAT_OK);
+   assert(idx == 0);
+
+   agent_set_route_capacity_probe(NULL); /* leave the global clean for other tests */
 
    printf("test_roundtable_seat_resolve: OK\n");
    return 0;

--- a/src/tests/test_wfe_blocks.c
+++ b/src/tests/test_wfe_blocks.c
@@ -106,6 +106,68 @@ int main(void)
    wfe_git_freeze(dir, bb, b3, h3, hh3, err, sizeof err);
    assert(strcmp(hh3, h_change) == 0);
 
+   /* --- add/add pre-check: a slice that re-creates a file a sibling landed ---
+    * Two slices of one work item are cut from the feature branch together; when
+    * each CREATES the same file, the first merges and the rest hit add/add,
+    * which no rebase resolves. Catch it at freeze instead of at merge. */
+   {
+      char sdir[] = "/tmp/wfe_addadd_XXXXXX";
+      if (wfe_test_mkdtemp(sdir))
+      {
+         /* feature branch with the file already landed by "slice 0" */
+         snprintf(cmd, sizeof cmd,
+                  "cd %s && git init -q -b feat && git config user.email t@t && "
+                  "git config user.name t && git config commit.gpgsign false && "
+                  "printf 'seed\\n' > seed.txt && git add -A && git commit -q -m seed && "
+                  "git rev-parse HEAD > /tmp/wfe_addadd_base",
+                  sdir);
+         if (sh(cmd) == 0)
+         {
+            char cut[64] = "";
+            FILE *bf = fopen("/tmp/wfe_addadd_base", "r");
+            if (bf)
+            {
+               if (fgets(cut, sizeof cut, bf))
+                  cut[strcspn(cut, "\r\n")] = '\0';
+               fclose(bf);
+            }
+            char clash[512];
+
+            /* slice 0 lands doc.md on feat; our slice creates its OWN doc.md. */
+            snprintf(cmd, sizeof cmd,
+                     "cd %s && printf 'from slice0\\n' > doc.md && git add -A && "
+                     "git commit -q -m slice0 && git checkout -q -b mine %s && "
+                     "printf 'from mine\\n' > doc.md && git add -A && git commit -q -m mine",
+                     sdir, cut);
+            assert(sh(cmd) == 0);
+            assert(wfe_slice_recreates_base_path(sdir, "feat", cut, clash, sizeof clash) == 1);
+            assert(strcmp(clash, "doc.md") == 0); /* names the colliding path */
+
+            /* IDENTICAL content is not a conflict: git merges that add/add
+             * cleanly, so flagging it would reject work that would land. */
+            snprintf(cmd, sizeof cmd,
+                     "cd %s && git checkout -q -b same %s && printf 'from slice0\\n' > doc.md && "
+                     "git add -A && git commit -q -m same",
+                     sdir, cut);
+            assert(sh(cmd) == 0);
+            assert(wfe_slice_recreates_base_path(sdir, "feat", cut, clash, sizeof clash) == 0);
+
+            /* A file only WE create (absent on the base ref) is not a collision. */
+            snprintf(cmd, sizeof cmd,
+                     "cd %s && git checkout -q -b solo %s && printf 'only mine\\n' > solo.md && "
+                     "git add -A && git commit -q -m solo",
+                     sdir, cut);
+            assert(sh(cmd) == 0);
+            assert(wfe_slice_recreates_base_path(sdir, "feat", cut, clash, sizeof clash) == 0);
+
+            /* Bad args / unresolvable refs fail SAFE (0), never a false block. */
+            assert(wfe_slice_recreates_base_path(NULL, "feat", cut, clash, sizeof clash) == 0);
+            assert(wfe_slice_recreates_base_path(sdir, "", cut, clash, sizeof clash) == 0);
+            assert(wfe_slice_recreates_base_path(sdir, "feat", "", clash, sizeof clash) == 0);
+         }
+      }
+   }
+
    /* --- TDD anti-deletion guard: red-authored tests must survive GREEN --- */
    /* red commit: add a test file (currently on branch feat). */
    snprintf(cmd, sizeof cmd,


### PR DESCRIPTION
Three independent defects, found by driving a live `build-e2e` run to a standstill and root-causing why. Each is a separate commit with tests.

## 1. A merge conflict is terminal, not a lost race

GitHub answers HTTP 405/409 both for a lost race (head/base moved) and for a real content conflict. `git_pr_merge_via_api` collapsed them into "not mergeable", which the engine treats as self-resolving — so it retried an unwinnable merge **15 times over 3 hours**, neither completing nor failing, while holding the single active-root slot (`autonomy.concurrency: 1`) and blocking every other work item behind it.

New rc 3 + `WFE_MERGE_CONFLICT` fails the step so the slot is released. The discriminator is the forge's message text — the only signal GitHub gives at the same status — and it **fails safe**: an unrecognised message classifies as *not* a conflict, degrading to today's retry rather than killing a run that could have merged.

## 2. Routing prefers a seat with a free concurrency slot

Routing checked health, policy, structure and credentials — but never capacity. It handed out agents already at `max_parallel`, which admission then rejected with `AGENT_RC_AT_LIMIT`. Health could not reconcile this, correctly: at-limit is deliberately *not* recorded as a provider fault, so a saturated agent is never marked DOWN and stayed selectable indefinitely.

Live effect: roundtable seats drew a saturated agent, failed instantly, and a panel needing 2 of 3 seats was declared `panel_unreachable` **while other agents sat idle**.

`delegate_pick_for_role` now *prefers* free agents. **Prefer, not exclude** — if all are saturated it falls back to the full set, so a populated roster can never collapse into "no agent for role", and blocking admission still waits exactly as before.

## 3. A slice that re-creates a landed file fails at freeze

When the deliverable is one document, every slice *creates* the same file. Once the first merges, the rest hit `add/add` — two independently authored versions, no common ancestor, no mechanical resolution. Verified: rebasing a slice branch onto the feature head reproduces `CONFLICT (add/add)` exactly.

Now caught at freeze, the first point the paths are known. Compared against the **feature head** rather than sibling slices — deliberately, since that reads a branch already reflecting whatever merged, so there is no compare-and-record to serialise. A sibling-set check would need a per-run freeze lock or two concurrent freezes could both pass. Trade-off: it fires from the second colliding slice onward.

Identical content is not flagged (git merges that cleanly). Classified PERMANENT — re-running just authors another divergent version.

## Verification

- `make unit-tests`: **All tests passed**
- Full `make`: clean, including packaging checks
- New tests: conflict-vs-lost-race classification incl. fail-safe cases; capacity preference incl. all-saturated fallback, unknown-capacity, and pinned-seat cases; add/add pre-check incl. identical-content and solo-file negatives

## Known limitation

Defect 3 computes the colliding path but does not surface it: the block interface carries no message field by design, and widening `wfe_step_result_t` is a broader change than this fix.