### PR TITLE
A merge conflict must be terminal in the Go engine too

### DIFF
--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -1475,3 +1475,102 @@ func TestUnresolvedBlockersIsBounded(t *testing.T) {
 		t.Fatal("summary and recommendation must each be truncated")
 	}
 }
+
+// conflictMergeRunner stands in for the merge step meeting a genuine content
+// conflict: the discriminator in forge.go classified the forge error as
+// terminal, so the runner reports StepFailed instead of StepPending.
+type conflictMergeRunner struct{}
+
+func (conflictMergeRunner) Run(context.Context, StepRequest) (StepResult, error) {
+	return StepResult{Status: StepFailed,
+		Detail: "merge conflict needs a content decision, no retry can resolve it"}, nil
+}
+
+// A merge that hits a content conflict must END the item, not park it. Before
+// this was wired up, every merge failure became StepPending/"merge_pending",
+// which the scheduler re-queues on a 15s backoff forever — so an unmergeable
+// slice held the single active-root slot indefinitely and the whole run
+// deadlocked. StepFailed is the status that releases it, and nothing covered
+// that mapping.
+func TestStepFailedFinishesItemRejectedSoTheSlotIsReleased(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte(`name: slice
+start: merge
+nodes:
+  - id: source
+    block: understand
+  - id: impl
+    block: implement
+    in: {plan: source.out}
+  - id: freeze
+    block: freeze
+    in: {branch: impl.out}
+    next: pr
+  - id: pr
+    block: pr.open
+    in: {src: freeze.out}
+    next: ci
+  - id: ci
+    block: gate.ci
+    in: {pr: pr.out}
+    on_pass: merge
+    on_fail: impl
+  - id: merge
+    block: merge
+    in: {pr: pr.out}
+`)
+	if err := os.WriteFile(filepath.Join(workflowDir, "slice.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal("wi_conflict", []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := artifacts.PutNodeArtifact("wi_conflict", "pr", "pr", []byte("https://github.com/acme/repo/pull/42")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateWorkItem(context.Background(), db1.CreateWorkItem{ID: "wi_conflict",
+		Repo: "repo", ProposalPath: "p", WorkflowName: "slice",
+		WorkflowVersion: def.Version, StartStage: "merge"}); err != nil {
+		t.Fatal(err)
+	}
+	eng, err := New(store, artifacts, workflowDir, conflictMergeRunner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := eng.Advance(context.Background(), "wi_conflict")
+	if err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	if !out.Terminal || out.State != "rejected" {
+		t.Fatalf("a merge conflict must finish the item rejected, got terminal=%v state=%q",
+			out.Terminal, out.State)
+	}
+	if out.Parked || out.PauseReason != "" {
+		t.Fatalf("a merge conflict must not park for retry, got parked=%v reason=%q",
+			out.Parked, out.PauseReason)
+	}
+	item, err := store.WorkItem(context.Background(), "wi_conflict")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.State != "rejected" {
+		t.Fatalf("persisted state = %q, want rejected", item.State)
+	}
+}

--- a/server-go/internal/engine/forge.go
+++ b/server-go/internal/engine/forge.go
@@ -207,6 +207,28 @@ func (f *HTTPForge) execute(ctx context.Context, input, output any) error {
 	return nil
 }
 
+// mergeErrIsConflict reports whether a failed Merge describes a content
+// conflict, which is terminal, rather than a lost race, which a retry wins.
+//
+// GitHub answers HTTP 405/409 for both. A lost race means head or base moved
+// while we were merging ("Base branch was modified"); retrying wins it. A
+// content conflict is a property of the two trees, so no retry can ever win and
+// the step must fail instead of pending forever.
+//
+// Match the noun phrase "merge conflict" (this also covers "merge conflicts").
+// The bare word "conflict" is deliberately NOT matched: HTTP 409 is literally
+// named "Conflict" and its lost-race messages can carry that bare word, which
+// would misclassify a winnable race as terminal.
+//
+// Fails safe: an unrecognised message is reported as NOT a conflict, preserving
+// the retrying behaviour rather than rejecting work on a message we do not know.
+func mergeErrIsConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "merge conflict")
+}
+
 func managedBranch(branch string) bool {
 	return strings.HasPrefix(branch, "aimee/wi/wi_") || strings.HasPrefix(branch, "aimee/feat/wi_")
 }

--- a/server-go/internal/engine/forge_test.go
+++ b/server-go/internal/engine/forge_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"os/exec"
@@ -82,5 +83,48 @@ func TestPullNumber(t *testing.T) {
 	}
 	if _, err := pullNumber("https://github.com/acme/repo/pull/not-a-number"); err == nil {
 		t.Fatal("invalid pull reference accepted")
+	}
+}
+
+func TestMergeErrIsConflict(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The exact string the resource plane produced in production while
+			// slices g0.1/g0.2 retried an unwinnable merge every 15 seconds.
+			name: "live conflict payload",
+			err: errors.New(`forge resource 400: {"error":"github API (pr merge, HTTP 405): ` +
+				`Pull Request has merge conflicts"}`),
+			want: true,
+		},
+		{name: "singular", err: errors.New("Pull Request has a merge conflict"), want: true},
+		{name: "mixed case", err: errors.New("Merge Conflict detected"), want: true},
+		{name: "upper case", err: errors.New("MERGE CONFLICTS PRESENT"), want: true},
+		{
+			// A lost race: head or base moved mid-merge. Retrying wins it, so it
+			// must stay retryable even though GitHub answers 405 here too.
+			name: "lost race",
+			err:  errors.New("Base branch was modified. Review and try the merge again."),
+			want: false,
+		},
+		{
+			// HTTP 409 is literally named "Conflict"; the bare word must not be
+			// enough to reject a winnable race.
+			name: "bare conflict word",
+			err:  errors.New("forge resource 409: Conflict"),
+			want: false,
+		},
+		{name: "unrelated failure", err: errors.New("forge resource plane is unavailable"), want: false},
+		{name: "empty message", err: errors.New(""), want: false},
+		{name: "nil error", err: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mergeErrIsConflict(tc.err); got != tc.want {
+				t.Fatalf("mergeErrIsConflict(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1314,6 +1314,10 @@ func (r *NativeRunner) merge(ctx context.Context, req StepRequest) (StepResult, 
 		return StepResult{}, err
 	}
 	if err := r.forge.Merge(ctx, workdir, prRef, base); err != nil {
+		if mergeErrIsConflict(err) {
+			return StepResult{Status: StepFailed,
+				Detail: "merge conflict needs a content decision, no retry can resolve it: " + err.Error()}, nil
+		}
 		return StepResult{Status: StepPending, PauseReason: "merge_pending", Detail: err.Error()}, nil
 	}
 	return StepResult{Status: StepAdvanced, ArtifactType: "none", Artifact: "merged"}, nil

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1821,5 +1822,112 @@ func TestReviewersAreToldBlockedIsAboutTheRequestNotTheArtifact(t *testing.T) {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("panel prompt lacks the blocked contract %q", want)
 		}
+	}
+}
+
+// conflictForge fails Merge with the exact payload the resource plane produced
+// in production while an unmergeable slice retried every 15 seconds.
+type conflictForge struct{}
+
+func (conflictForge) Push(context.Context, string, string, string) error { return nil }
+func (conflictForge) Open(context.Context, string, string, string, string, string) (PullRequest, error) {
+	return PullRequest{}, nil
+}
+func (conflictForge) CI(context.Context, string, string) (CIState, error) { return CIPassed, nil }
+func (conflictForge) Merge(context.Context, string, string, string) error {
+	return errors.New(`forge resource 400: {"error":"github API (pr merge, HTTP 405): ` +
+		`Pull Request has merge conflicts"}`)
+}
+
+// raceForge fails Merge with a lost race, which a retry wins.
+type raceForge struct{}
+
+func (raceForge) Push(context.Context, string, string, string) error { return nil }
+func (raceForge) Open(context.Context, string, string, string, string, string) (PullRequest, error) {
+	return PullRequest{}, nil
+}
+func (raceForge) CI(context.Context, string, string) (CIState, error) { return CIPassed, nil }
+func (raceForge) Merge(context.Context, string, string, string) error {
+	return errors.New("forge resource 405: Base branch was modified. Review and try the merge again.")
+}
+
+// The merge step must distinguish a terminal content conflict from a winnable
+// race. Every merge failure used to become StepPending/"merge_pending", which
+// the scheduler re-queues on a 15s backoff with no retry ceiling — so a slice
+// whose PR could never merge held the single active-root slot forever.
+func TestMergeStepFailsTerminallyOnConflictButStillPendsOnLostRace(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		forge       Forge
+		wantStatus  StepStatus
+		wantReason  string
+		wantDetails string
+	}{
+		{name: "content conflict is terminal", forge: conflictForge{},
+			wantStatus: StepFailed, wantReason: "", wantDetails: "merge conflict"},
+		{name: "lost race stays retryable", forge: raceForge{},
+			wantStatus: StepPending, wantReason: "merge_pending", wantDetails: "Base branch was modified"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			repo := filepath.Join(root, "repo")
+			git := func(dir string, args ...string) {
+				cmd := exec.Command("git", args...)
+				cmd.Dir = dir
+				cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@example",
+					"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@example")
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git %v: %v: %s", args, err, out)
+				}
+			}
+			git(root, "init", repo)
+			if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("root\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			git(repo, "add", "README.md")
+			git(repo, "commit", "-m", "root")
+			// merge() resolves the slice worktree from its parent feature branch.
+			git(repo, "branch", "aimee/feat/wi_parent")
+
+			store, err := db1.Open(filepath.Join(root, "aimee.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			ctx := context.Background()
+			if err := store.CreateWorkItem(ctx, db1.CreateWorkItem{ID: "wi_parent", Repo: repo,
+				ProposalPath: "p", WorkflowName: "build-e2e", WorkflowVersion: "v", StartStage: "slices"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.CreateWorkItem(ctx, db1.CreateWorkItem{ID: "wi_parent.s0", Repo: repo,
+				ProposalPath: "p/slice", WorkflowName: "slice", WorkflowVersion: "v",
+				StartStage: "merge", ParentID: "wi_parent"}); err != nil {
+				t.Fatal(err)
+			}
+			worktrees, err := NewWorktreeManager(store, filepath.Join(root, "worktrees"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			item, err := store.WorkItem(ctx, "wi_parent.s0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			runner := &NativeRunner{db: store, worktrees: worktrees, forge: tc.forge}
+			result, err := runner.merge(ctx, StepRequest{WorkItem: item,
+				Inputs: map[string]wfe.Artifact{"pr": {Type: "pr",
+					Content: []byte(`{"ref":"https://github.com/acme/repo/pull/42"}`)}}})
+			if err != nil {
+				t.Fatalf("merge returned a hard error: %v", err)
+			}
+			if result.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q (detail=%q)", result.Status, tc.wantStatus, result.Detail)
+			}
+			if result.PauseReason != tc.wantReason {
+				t.Fatalf("pause reason = %q, want %q", result.PauseReason, tc.wantReason)
+			}
+			if !strings.Contains(result.Detail, tc.wantDetails) {
+				t.Fatalf("detail %q does not mention %q", result.Detail, tc.wantDetails)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#2016 made a content conflict terminal in the **C** engine. Production runs the **Go** engine, so the deadlock it was meant to fix was still live this morning.

## Evidence the deadlock survived #2016

#2016 merged at 09:22 and auto-deployed at 09:25. The retries continued afterwards:

```
09:27:00  merge | pause | merge_pending: ... HTTP 405: Pull Request has merge conflicts
09:27:16  09:27:32  09:27:48  09:28:04  09:28:20   (every 15s, indefinitely)
```

Confirmations that Go is the live path:
- `/v1/health` on the WFE socket returns `{"implementation":"go"}`
- work item events carry `actor: "go-wfe"`
- `Dockerfile.server:81` builds `aimee-wfe` from `server-go/cmd/aimee-server`
- `grep -i conflict` over `server-go/internal/engine` returned **zero** hits

## The defect

`native_runner.merge` turned every `forge.Merge` error into `StepPending` / `merge_pending`, and `scheduler.go:117` gives that reason a 15s backoff with no retry ceiling. A PR that can never merge therefore retried forever while holding the single active-root slot (`autonomy.concurrency: 1`), blocking every queued work item behind it.

The engine has two retry shapes, and this mapped a permanent condition onto the wrong one:

| Status | Bounded? | Meaning |
|---|---|---|
| `StepChanges` | yes — `RecordRetry`, parks at `retry_limit` | this attempt was wrong |
| `StepPending` | **no** — re-queued on backoff forever | waiting on an external condition |
| `StepFailed` | terminal — `Finish(..., "rejected")` | cannot proceed |

## The fix

`mergeErrIsConflict` ports the discriminator from `git_pr_api.c`. GitHub answers 405/409 both for a lost race (a retry wins) and a real content conflict (no retry can win). It matches the noun phrase `merge conflict`, and deliberately **not** the bare word `conflict` — HTTP 409 is itself named "Conflict" and its lost-race messages carry that word. Unrecognised messages stay retryable, so it fails safe.

## Verification

Red before green: with the discriminator removed the conflict case returns `"pending"` (the deadlock), while the lost-race case passes either way — so the test pins the fix, not the scaffolding.

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l` on all touched files — empty
- `go test ./...` — all packages pass, no pre-existing failures

Tests added: the discriminator (9 cases, including the exact production payload); the merge step returning `StepFailed` on conflict but still `StepPending` on a lost race, driven through a real git worktree; and the first coverage of `StepFailed` → terminal `"rejected"`, the mapping this fix depends on and which nothing exercised before.

The C implementation is left untouched.