### PR TITLE
The wizard's Deploy step stopped the server running it

### DIFF
--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -175,13 +175,29 @@ static int run_capture(const char *const argv[], char **envp, char *out, size_t 
    return 0;
 }
 
-/* Background worker: `docker compose -f <file> up -d --remove-orphans`. */
+/* Background worker: `docker compose -f <file> up -d`.
+ *
+ * NO --remove-orphans, and this is not a style preference: it made the deploy
+ * STOP THE SERVER RUNNING IT. aimee-server is started by compose.server-managed.yaml
+ * under COMPOSE_PROJECT_NAME=aimee, and the managed file this command targets
+ * defines only postgres/aimee-kb/aimee-llm. So compose finds a container in
+ * project "aimee" that its file does not define, calls it an orphan, and removes
+ * it — the orchestrator deleting itself mid-deploy. Observed on a clean install:
+ * the wizard's Deploy step ran, and 47 seconds later the server logged
+ * "server: shut down" and the container exited, leaving a new user with a dead
+ * install and no obvious cause.
+ *
+ * The shared project name is deliberate (the managed services join the server's
+ * network), so the fix is to drop the orphan sweep rather than the project. What
+ * that gives up is small and recoverable: a service removed from the managed file
+ * leaves its container behind until an operator prunes it. What it buys is that
+ * deploying cannot destroy the thing doing the deploying. */
 static void *deploy_worker(void *arg)
 {
    (void)arg;
    char file[512];
    deploy_apply_compose_file(file, sizeof(file));
-   const char *argv[] = {"docker", "compose", "-f", file, "up", "-d", "--remove-orphans", NULL};
+   const char *argv[] = {"docker", "compose", "-f", file, "up", "-d", NULL};
    char **envp = build_deploy_envp();
 
    char out[DEPLOY_OUT_CAP];


### PR DESCRIPTION
Found by installing from scratch on a clean host, not by reading the code.

## What a new user sees

Following `docs/QUICKSTART.md` verbatim on a fresh Debian 13 box: the server comes
up healthy, the wizard's **Deploy** step starts, and 47 seconds later `aimee-server`
is gone. The server log ends with a clean `server: shut down`, so nothing looks
like a crash — the new user is left with a dead install and no obvious cause.

## Mechanism

`aimee-server` is started by `compose.server-managed.yaml` under
`COMPOSE_PROJECT_NAME=aimee`. The deploy runs:

```
docker compose -f /opt/aimee/deploy/aimee-managed.compose.yaml up -d --remove-orphans
```

against that **same project**, and that file defines only `postgres`, `aimee-kb`
and `aimee-llm`. Compose finds a container in project `aimee` that its file does
not define, classifies it as an orphan, and removes it. The orchestrator deletes
itself mid-deploy.

Compose states it outright. With the flag removed, the same run now only warns:

```
Found orphan containers ([aimee-aimee-server-1]) for this project
```

## The fix, and what it costs

The shared project name is deliberate — the managed services join the server's
network — so the **orphan sweep** goes, not the project.

What that gives up is small and recoverable: a service dropped from the managed
file leaves its container behind until an operator prunes it. What it buys is that
deploying cannot destroy the thing doing the deploying.

## Verification

Fresh CT (Debian 13, Docker 29.6.2, clone of `testing`, quickstart followed verbatim):

| | Before | After |
|---|---|---|
| `docker compose ... up -d` exit | server killed, deploy dies with it | `last_exit=0` |
| `aimee-server` | **Exited (1)** | **Up (healthy)** |
| `aimee-postgres-1` | — | Up (healthy) |
| `aimee-aimee-kb-1` | — | Up |

## A trap for the next person

This does not reproduce by running the command by hand:

- Without `COMPOSE_PROFILES` the managed file selects no service and compose exits
  `no service selected`.
- The orphan sweep happens **late** in `up`, so a run still pulling a multi-gigabyte
  image looks harmless for minutes.

Both led me to clear the hypothesis twice before `docker events` showed the explicit
`kill` → `stop` → `die` and forced the issue.

## Related, not fixed here

The published `ghcr.io/rakuensoftware/aimee-server:latest` is **13 days stale**
(built 2026-07-14) and its entrypoint lacks the docker-socket group grant that is
already in this repo, so on a clean install Deploy fails even earlier with
`permission denied ... /var/run/docker.sock`. That one needs a **republish**, not a
code change — the fix is already committed. Filing separately.
