### PR TITLE
index.ingest bypassed the per-user write-tier gate

### DIFF
--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -2354,7 +2354,22 @@ uint32_t v1_route_caps_lookup(const char *method, const char *path)
  * rather than a per-row struct field — avoids a missing-initializer churn across
  * every existing read row under -Wextra. Add a data-write route's op here when
  * you add the row. */
+/* Data-plane writes. A route whose op is NOT here is invisible to the write-tier
+ * gate, so a caller holding only the shared bearer reaches it with no grant.
+ *
+ * index.ingest was missing, and the asymmetry was visible from a plain client on a
+ * clean install: POST /v1/memory/store -> 403 while POST /v1/index/ingest -> 200
+ * for the same caller, with kb then queueing curator work for the new project.
+ * Both the acceptance criteria and QUICKSTART call indexing a data-plane write
+ * needing at least `data`, so the omission was an oversight rather than a
+ * decision — the routes that ARE deliberately reachable without a tier live in
+ * v1_route_tcp_exempt (the workspace resource plane), and this was not one.
+ *
+ * Consequence, and it matches the documented contract: a remote
+ * `aimee workspace add` does registration (exempt) plus ingest, so the ingest half
+ * now needs a `data` grant while registration keeps working with none. */
 static const char *const g_v1_write_ops[] = {"memory.store",
+                                             "index.ingest",
                                              "work.add",
                                              "work.claim",
                                              "work.complete",

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -1178,6 +1178,19 @@ int main(void)
       assert(server_http_route_is_local_only("POST", "/v1/workspaces") == 0);
       assert(server_http_route_is_local_only("DELETE", "/v1/workspaces/%2Fp") == 0);
 
+      /* INDEXING IS A DATA-PLANE WRITE. It was absent from g_v1_write_ops, so the
+       * write-tier gate never saw it: on a clean install the same bearer got 403
+       * on /v1/memory/store and 200 on /v1/index/ingest, and kb queued curator
+       * work for the new project. Registration staying exempt while its ingest is
+       * gated is exactly what §1.4 and Parts 2-4 of QUICKSTART promise, so the
+       * pair is asserted together — they are easy to conflate, and conflating
+       * them is how the gap got in. */
+      assert(server_http_route_is_local_only("POST", "/v1/index/ingest") == 1);
+      /* The index READ family must stay ungated, or every query needs a grant. */
+      assert(server_http_route_is_local_only("POST", "/v1/index/find") == 0);
+      assert(server_http_route_is_local_only("POST", "/v1/index/deps") == 0);
+      assert(server_http_route_is_local_only("POST", "/v1/memory/search") == 0);
+
       /* Detached-runner reverse channel: tool:execute, TCP-reachable (the
        * serving client drives it remotely). An unscoped TCP bearer holds
        * CAP_TOOL_EXECUTE (CAPS_AUTHENTICATED) so it is allowed; a scoped


### PR DESCRIPTION
Fixes #2024. Found by walking a clean install, not by reading the list.

## Observed

Remote client, shared bearer, **no write-tier grant**, same server, same session:

```
POST /v1/memory/store  -> 403 (caps)     gated
POST /v1/workspaces    -> 200            TCP-exempt by design
POST /v1/index/ingest  -> 200            NOT gated
```

and kb did real work for the new project:

```
kb.curator.queue: queued 1 extract_code_unit job(s) for project 'nogrant-probe'
kb.curator.extract_code: invoking sidecar for symbol 'ungranted_probe'
```

## Cause

`v1_route_is_local_only()` — historical name; it reports *does this route dispatch a
data-write op* — answers from `g_v1_write_ops`, and `index.ingest` was not in it. A
route missing from that list is invisible to the tier gate #2015 added.

An omission, not a decision: the routes deliberately reachable without a tier live in
`v1_route_tcp_exempt` (workspace registration/removal, runner reverse channel), and
`index.ingest` is not among them. §11 and QUICKSTART both call indexing a data-plane
write needing at least `data`. §11 tested `memory.store` at tier `off`; nothing tested
ingest, which is how this survived a review that found ten other things.

## Consequence

Documented contract, not a regression: a remote `aimee workspace add` does registration
(exempt) **plus** ingest, so the ingest half now needs a `data` grant while registration
keeps working with none.

## Test

Asserts the **pair** — ingest gated, registration not — because those are easy to
conflate and conflating them is how this got in. Also pins the index read family and
`memory.search` as ungated so a future sweep cannot quietly put every query behind a
grant.

**Red-checked:** removing `index.ingest` from the list again aborts the assertion.
`make -C src all` and `unit-tests` green.

## Not established

Whether an ungranted ingest leaves **durable** rows — `kb_file_index` and
`kb_async_jobs` still showed only an earlier pre-#2015 ingest. The curator work is
observed; persistence is not proven. The authorization gap is a code-level fact
independent of that; the blast radius is not.