### PR TITLE
A grant alone cannot enable remote writes — document the three server prerequisites

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -81,10 +81,32 @@ If the server endpoints return `200` and `kb/status` reports the DB and vector s
     users only**, a `full` grant permits remote code execution as that subject.
 
   Grants live in `kb_write_tier_grant` and are administered with
-  `kb_write_tier_grant_set` / `kb_write_tier_grant_revoke`. A user obtains an
+  `kb_write_tier_grant_set` / `kb_write_tier_grant_revoke` (`aimee kb grant
+  set|list|revoke --server <id> --team <n>`, local UDS only). A user obtains an
   identity token by logging in to kb (OIDC, or PAM when no OIDC profile is
   configured). See [UPGRADING.md](UPGRADING.md) for granting the first user, the
   exact subject spelling, and how to tell "no grant" apart from "wrong subject".
+
+  **A grant is not enough on its own.** The server can only resolve a caller's tier
+  once it knows who it is and which keys to trust, so all three of these must be set
+  on `aimee-server` or *every* `/v1` write is denied regardless of grants:
+
+  | Variable | What it is |
+  |---|---|
+  | `AIMEE_SERVER_TEAM_ID` | the kb team this server is enrolled in |
+  | `AIMEE_SERVER_ID` | this server's id — the identity token's audience |
+  | `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE` | path to the root-owned `0600` trust bundle pinning kb's signing keys |
+
+  **`compose.server-managed.yaml` does not set these**, so a stock Docker install
+  cannot enable remote writes until you add them — see
+  [#2026](https://github.com/RakuenSoftware/aimee/issues/2026). The server says so at
+  startup, and that line is the fastest way to confirm the cause:
+
+  ```
+  ERROR server.http: AIMEE_SERVER_TEAM_ID is unset or invalid: reads continue, but
+  every /v1 write will be denied with no_team_configured until it is set to this
+  server's team id
+  ```
 
   (Workspace registration over the network, `workspace add/serve/remove`, is a
   deliberate, bearer-gated exception and works with no grant at all.)


### PR DESCRIPTION
Follows #2022, which I got half right. Relates to #2026.

#2022 rewrote §1.4 to say writes are authorized by a **per-user grant**. True, and
incomplete: the server can only resolve a caller's tier once it knows its own identity
and which keys to trust.

`build_config()` in `server_write_tier_db1.c` needs all three:

| Variable | What it is |
|---|---|
| `AIMEE_SERVER_TEAM_ID` | the kb team this server is enrolled in |
| `AIMEE_SERVER_ID` | this server's id — the identity token's audience |
| `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE` | root-owned `0600` bundle pinning kb's signing keys |

Missing any one → `NO_TEAM_CONFIGURED` / `INVALID` → **every** `/v1` write denied,
regardless of grants.

`compose.server-managed.yaml` sets none of them, and no production code does — only
tests. So a reader following §1.4 as written creates a grant, sees writes still refused,
and has nothing pointing at the cause. **That is a worse failure than the one #2022
fixed**, because the instruction now looks complete.

This adds the prerequisites as an explicit table, states plainly that the stock Docker
install does not set them, links #2026, and quotes the startup ERROR the server already
emits — which is what told me on a live install that grants could never work there:

```
ERROR server.http: AIMEE_SERVER_TEAM_ID is unset or invalid: reads continue, but every
/v1 write will be denied with no_team_configured until it is set to this server's team id
```

Also names the operator CLI (`aimee kb grant set|list|revoke --server --team`, UDS-only)
rather than only the SQL functions.

Docs only. The underlying gap — that the documented deployment provides no way to set
these — is #2026 and needs a deployment/wizard decision, not a doc change.