### PR TITLE
Fix the CPU-stack release blockers found by a clean-room install

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -595,7 +595,7 @@ noted in parentheses.
 > Some older in-process command modules still exist in the source tree
 > (`cmd_roadmap.c`, `cmd_auto.c`, extended `cmd_memory_*` maintenance verbs), but
 > they are not part of the installed thin-client contract until they have a typed
-> server RPC route. If `aimee <command>` says "has no typed server RPC route",
+> server RPC route. If `aimee <command>` says "has no /v1 route",
 > treat that command as implementation work in progress rather than user-facing
 > documentation.
 
@@ -784,19 +784,19 @@ visible in `aimee help --all` for your installed build.
 - `graph sync-code` · `graph explain`.
 - `trajectory export` · `trajectory batch`.
 
-### 7.20 Manuscript, `aimee manuscript`
+### 7.21 Manuscript, `aimee manuscript`
 
 Novel/long-form writing helpers (client-local): `manuscript scenes` ·
 `manuscript wordcount` · `manuscript outline` · `manuscript check [files…]`.
 
-### 7.21 Server, profiles, admin
+### 7.22 Server, profiles, admin
 
 - `server start` · `server restart` · `server status` / `server health`, manage `aimee-server`.
 - `profile create|list|show|delete|current [--force]`, configuration profiles.
 - `git verify` / `verify` (`git.verify`), verify current changes before merge.
 - `clean [--force]`, remove local config and integrations.
 
-### 7.22 Hidden / integration entry points
+### 7.23 Hidden / integration entry points
 
 Used by tool integrations, not typed by users directly:
 

--- a/compose.server-managed.yaml
+++ b/compose.server-managed.yaml
@@ -53,6 +53,9 @@ services:
       # Passed through to the managed services when a role is placed local (GPU
       # tier, images, default LLM tier). Left at defaults for a CPU deploy.
       AIMEE_LLM_IMAGE: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
+      # The CPU deploy (the default topology) runs aimee-llm-cpu, not aimee-llm, so
+      # it needs its own override or a pinned/mirrored CPU stack is unreachable.
+      AIMEE_LLM_CPU_IMAGE: ${AIMEE_LLM_CPU_IMAGE:-ghcr.io/rakuensoftware/aimee-llm-cpu:latest}
       AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
       AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}

--- a/distro-detect.sh
+++ b/distro-detect.sh
@@ -1,25 +1,44 @@
 #!/usr/bin/env bash
 # distro-detect.sh — detect the host package manager and map abstract
 # dependency names to distro-specific package names.
-# Source this file; it exports PKG_MGR, PKG_INSTALL, and PKG_UPDATE.
+# Source this file; it exports AIMEE_SUDO, PKG_MGR, PKG_INSTALL, and PKG_UPDATE.
+
+# Privilege prefix for package/service operations. Empty when already root — a
+# stock container or cloud base image typically runs as root and ships NO sudo, so
+# hardcoding `sudo` made install-deps.sh die with "sudo: command not found" on the
+# most common first-run environment. Non-root without sudo is a hard error: the
+# caller cannot install packages at all, and failing here beats failing later.
+detect_sudo() {
+    if [ "$(id -u)" -eq 0 ]; then
+        AIMEE_SUDO=""
+    elif command -v sudo &>/dev/null; then
+        AIMEE_SUDO="sudo"
+    else
+        echo "Error: this script installs system packages and needs root." >&2
+        echo "Run it as root, or install sudo and re-run as a user with sudo rights." >&2
+        exit 1
+    fi
+    export AIMEE_SUDO
+}
 
 detect_pkg_manager() {
+    detect_sudo
     if command -v dnf &>/dev/null; then
         PKG_MGR="dnf"
-        PKG_INSTALL="sudo dnf install -y"
-        PKG_UPDATE="sudo dnf makecache"
+        PKG_INSTALL="$AIMEE_SUDO dnf install -y"
+        PKG_UPDATE="$AIMEE_SUDO dnf makecache"
     elif command -v yum &>/dev/null; then
         PKG_MGR="yum"
-        PKG_INSTALL="sudo yum install -y"
-        PKG_UPDATE="sudo yum makecache"
+        PKG_INSTALL="$AIMEE_SUDO yum install -y"
+        PKG_UPDATE="$AIMEE_SUDO yum makecache"
     elif command -v apt-get &>/dev/null; then
         PKG_MGR="apt"
-        PKG_INSTALL="sudo apt-get install -y"
-        PKG_UPDATE="sudo apt-get update -qq"
+        PKG_INSTALL="$AIMEE_SUDO apt-get install -y"
+        PKG_UPDATE="$AIMEE_SUDO apt-get update -qq"
     elif command -v pacman &>/dev/null; then
         PKG_MGR="pacman"
-        PKG_INSTALL="sudo pacman -S --noconfirm"
-        PKG_UPDATE="sudo pacman -Sy"
+        PKG_INSTALL="$AIMEE_SUDO pacman -S --noconfirm"
+        PKG_UPDATE="$AIMEE_SUDO pacman -Sy"
     elif command -v brew &>/dev/null; then
         PKG_MGR="brew"
         PKG_INSTALL="brew install"

--- a/distro-detect.sh
+++ b/distro-detect.sh
@@ -41,6 +41,7 @@ pkg_name() {
                 libsqlite3-dev)      echo "sqlite-devel" ;;
                 libpq-dev)           echo "libpq-devel" ;;
                 libzstd-dev)         echo "libzstd-devel" ;;
+                zlib1g-dev)          echo "zlib-devel" ;;
                 libcurl4-openssl-dev) echo "libcurl-devel" ;;
                 libpam0g-dev)        echo "pam-devel" ;;
                 libsecret-1-dev)     echo "libsecret-devel" ;;
@@ -72,6 +73,7 @@ pkg_name() {
                 libsqlite3-dev)      echo "sqlite" ;;
                 libpq-dev)           echo "postgresql-libs" ;;
                 libzstd-dev)         echo "zstd" ;;
+                zlib1g-dev)          echo "zlib" ;;
                 libcurl4-openssl-dev) echo "curl" ;;
                 libpam0g-dev)        echo "pam" ;;
                 libsecret-1-dev)     echo "libsecret" ;;
@@ -90,6 +92,7 @@ pkg_name() {
                 libsqlite3-dev)      echo "sqlite" ;;
                 libpq-dev)           echo "libpq" ;;
                 libzstd-dev)         echo "zstd" ;;
+                zlib1g-dev)          echo "zlib" ;;
                 libcurl4-openssl-dev) echo "curl" ;;
                 libpam0g-dev)        echo "" ;;  # PAM is built-in on macOS
                 universal-ctags)     echo "universal-ctags" ;;
@@ -132,6 +135,7 @@ REQUIRED_DEPS=(
     libsqlite3-dev
     libpq-dev
     libzstd-dev
+    zlib1g-dev
     libcurl4-openssl-dev
     libpam0g-dev
     universal-ctags
@@ -151,6 +155,7 @@ dep_present() {
         libsqlite3-dev)       pkg-config --exists sqlite3 2>/dev/null ;;
         libpq-dev)            pkg-config --exists libpq 2>/dev/null ;;
         libzstd-dev)          pkg-config --exists libzstd 2>/dev/null ;;
+        zlib1g-dev)           pkg-config --exists zlib 2>/dev/null ;;
         libcurl4-openssl-dev) pkg-config --exists libcurl 2>/dev/null ;;
         # No pkg-config .pc for PAM; probe the header the way cgo will, which
         # also resolves the macOS SDK location. If no C compiler is present yet

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -20,8 +20,10 @@ Advanced operators who prefer to run each service as its own long-lived containe
 ### Prerequisites
 
 - Docker Engine + the Docker Compose plugin (`docker compose`, v2).
+- `git`, `curl` and `jq` — used by the commands below. A stock server image may have none of them (`apt-get install git curl jq`).
 - Host Docker socket access — `compose.server-managed.yaml` mounts it so the server can launch the other containers. It's root-equivalent, so run this only on a host you trust the server on.
-- ~8 GB RAM and ~10 GB disk. `aimee-llm` pulls ~5.5 GB of CPU model weights (embed, rerank, synth) into a volume the first time the wizard deploys it.
+- **~25 GB free disk.** Measured on a clean Debian 13 host after a full CPU deploy: 11.7 GB of images + 7 GB of volumes ≈ 19 GB of Docker data, ~20 GB total with the OS and checkout. Most of it is `aimee-llm-cpu`, an 11 GB image with the embed/rerank/synth weights **baked in** — the CPU tier downloads no models at deploy time and mounts no model volume. (The GPU `aimee-llm` image is small and fetches its tier into a volume on first boot instead.)
+- **8 GB RAM works; 16 GB is comfortable.** The model weights are mmap'd, so most of the LLM container's footprint is reclaimable page cache — on a 16 GB host the idle stack sits at ~4 GB resident plus ~5 GB cache.
 - No credentials or API keys needed for the default build.
 
 ### 1.1 Start the server
@@ -47,7 +49,7 @@ The wizard covers:
 - **Connection** — connect a git host so aimee can clone your repos. Pick one auth method and the wizard shows only its fields: **OAuth sign-in** (GitHub, GitLab, Gitea/Forgejo), an **access token** (HTTPS, any host including Bitbucket), or an **SSH key** (private key for `git@host:owner/repo.git`). Public repos clone without any of them. Optional — you can connect a host later.
 - **Workspaces & projects** — point at an owner/org, list its repos, and bulk-clone them into a workspace.
 
-The final **Deploy** launches `aimee-kb` + `aimee-llm` + Postgres and shows their status. The first run pulls images and the CPU model weights (a few minutes); later boots are fast — state lives in named volumes.
+The final **Deploy** launches `aimee-kb` + the LLM container + Postgres and shows their status. On the default CPU topology that LLM container is `aimee-llm-cpu`, whose weights are baked into the image, so the wait is the 11 GB image pull rather than a model download; later boots are fast — state lives in named volumes.
 
 #### Your login account
 
@@ -57,20 +59,44 @@ Each provisioned account is mirrored (username + its `/etc/shadow` hash, never t
 
 ### 1.3 Verify it's healthy
 
-```bash
-# Server /v1 over TLS (default bearer is "aimee-local-dev"; -k accepts the self-signed cert):
-curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
-curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/kb/status
+`aimee-local-dev` is a **one-time bootstrap bearer**: it authorizes exactly one call,
+the rotation below, and nothing else. Using it on an ordinary route returns `401`
+with `"the one-time bootstrap bearer must be rotated before use"` — that is the
+expected response, not a broken server. Rotate it once, then use the token you get
+back. (`-k` accepts the self-signed cert.)
 
-# The managed containers (after the wizard's Deploy step):
-docker ps    # aimee-server, aimee-kb, aimee-llm, and postgres should be running
+```bash
+# One-time: exchange the bootstrap bearer for a real one and keep it private.
+ROTATED=$(curl -k -fsS -X POST \
+  -H 'Authorization: Bearer aimee-local-dev' -H 'Content-Type: application/json' \
+  https://localhost:8743/v1/api/rotate_bearer -d '{}' | jq -er '.bearer_token')
+(umask 077 && printf '%s\n' "$ROTATED" > .aimee-server-bearer)
+
+# Now /v1 answers. Both of these should print 200:
+curl -k -sS -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $ROTATED" \
+  https://localhost:8743/v1/health
+curl -k -sS -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $ROTATED" \
+  https://localhost:8743/v1/kb/status
 ```
 
-If the server endpoints return `200` and `kb/status` reports the DB and vector store ready, the stack is up.
+`aimee remote set https://<host>:8743 <token>` does this rotation for you and stores
+the result, so the thin client in [Part 2](#part-2-linux-client) needs no manual step;
+`aimee remote enroll` re-runs it on its own.
+
+Until the wizard's **Deploy** step has run, `/v1/health` returns `200` but
+`/v1/kb/status` reports `"available": false` — the knowledge base container is not up
+yet. That is expected at this point. After Deploy:
+
+```bash
+docker ps    # aimee-server, aimee-kb, postgres, and the LLM container
+```
+
+The LLM container is **`aimee-llm-cpu`** on the default CPU topology and `aimee-llm`
+when a role is placed on a GPU; both answer to the network name `aimee-llm`.
 
 ### 1.4 Before you expose it on a network
 
-- **Override the default bearer.** `aimee-local-dev` is a loopback convenience only. Mount your own `aimee.yaml` at `/var/lib/aimee/aimee.yaml` with a real bearer and terminate TLS at a reverse proxy.
+- **Rotate the bootstrap bearer** ([1.3](#13-verify-its-healthy)) before anything reaches the network — until you do, `/v1` is unusable anyway. For a real deployment also mount your own `aimee.yaml` at `/var/lib/aimee/aimee.yaml` with your own bearer, and terminate TLS at a reverse proxy.
 - **Remote writes are off by default, and are authorized per user.** Over the network a
   remote bearer is **read/query only**. Holding the bearer no longer grants write
   access to anyone: each subject that may write needs its own **write-tier grant**,
@@ -169,10 +195,22 @@ aimee version
 ### 2.2 Point the client at your server
 
 ```bash
+# If you have NOT rotated the bootstrap bearer yet, pass it and the client rotates
+# it for you (and pins the cert + enrols an mTLS client certificate):
 aimee remote set https://YOUR_SERVER:8743 aimee-local-dev
+
+# If you DID follow 1.3, that token is already spent — pass the rotated one instead:
+aimee remote set https://YOUR_SERVER:8743 "$(cat .aimee-server-bearer)"
+
 aimee remote status     # resolved transport + /v1/health probe
 aimee status            # server, DB1, and kb health
 ```
+
+`aimee-local-dev` only works **once per server**, so passing it after a previous
+client (or [1.3](#13-verify-its-healthy)) already enrolled fails — `aimee remote set`
+exits non-zero and tells you where the real bearer is. `aimee remote status` likewise
+distinguishes "reachable but not authorized" (a bad or spent token) from unreachable,
+and exits non-zero for both, so it is safe to use as a setup check in a script.
 
 Use your real bearer token instead of `aimee-local-dev` if you changed it. The server's `/v1` is TLS-only off-loopback; certificate verification is on by default, so set `AIMEE_TLS_INSECURE=1` for the auto-provisioned self-signed cert (or trust/pin it). Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`, or pass `--server https://YOUR_SERVER:8743 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -149,7 +149,7 @@ mv aimee-linux-x86_64 ~/.local/bin/aimee
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-**Option B, build the thin client from source** (needs a C compiler, `make`, and `libsqlite3-dev`; add `libssl-dev` to keep `https://` support):
+**Option B, build the thin client from source** (needs a C compiler, `make`, `libsqlite3-dev`, and `zlib1g-dev`; add `libssl-dev` to keep `https://` support):
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -21,6 +21,22 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # shellcheck source=distro-detect.sh
 source "$SCRIPT_DIR/distro-detect.sh"
+
+# Run a command as the postgres superuser. `sudo -n -u postgres` only works when
+# sudo exists; as root (containers, cloud base images) there is no sudo, so use
+# runuser/su instead. Non-root without sudo already exited in detect_sudo.
+as_postgres() {
+    if [ "$(id -u)" -eq 0 ]; then
+        if command -v runuser &>/dev/null; then
+            runuser -u postgres -- "$@"
+        else
+            su -s /bin/sh postgres -c "$(printf '%q ' "$@")"
+        fi
+    else
+        sudo -n -u postgres "$@"
+    fi
+}
+
 detect_pkg_manager
 
 # Colors (if terminal supports them)
@@ -53,7 +69,7 @@ if [ "${#missing_deps[@]}" -gt 0 ]; then
         apt|dnf|yum)
             info "Installing missing packages: ${missing_pkgs[*]}"
             if [ "$PKG_MGR" = "apt" ]; then
-                sudo apt-get update -qq
+                $AIMEE_SUDO apt-get update -qq
             fi
             # shellcheck disable=SC2086
             $PKG_INSTALL "${missing_pkgs[@]}"
@@ -123,7 +139,7 @@ bootstrap_postgres() {
     if command -v systemctl >/dev/null 2>&1; then
         if ! systemctl is-active --quiet postgresql 2>/dev/null; then
             info "postgres: starting postgresql service"
-            sudo systemctl enable --now postgresql 2>/dev/null || \
+            $AIMEE_SUDO systemctl enable --now postgresql 2>/dev/null || \
                 warn "postgres: failed to start postgresql service via systemctl"
         fi
     elif command -v brew >/dev/null 2>&1 && brew services list 2>/dev/null | grep -q postgresql; then
@@ -143,14 +159,14 @@ bootstrap_postgres() {
 
     # Create database if missing. Try the user's own role first; on systems
     # where postgres-as-root is the only superuser path (apt-installed pg on
-    # Debian/Ubuntu) fall back to `sudo -u postgres`.
+    # Debian/Ubuntu) fall back to running as the postgres user.
     if ! psql -lqt 2>/dev/null | cut -d'|' -f1 | tr -d ' ' | grep -qx aimee_shared; then
         info "postgres: creating aimee_shared database"
         if ! createdb aimee_shared 2>/dev/null; then
             local user
             user="${USER:-$(id -un)}"
-            sudo -n -u postgres createuser --createdb "$user" 2>/dev/null || true
-            sudo -n -u postgres createdb -O "$user" aimee_shared 2>/dev/null || \
+            as_postgres createuser --createdb "$user" 2>/dev/null || true
+            as_postgres createdb -O "$user" aimee_shared 2>/dev/null || \
                 warn "postgres: createdb aimee_shared failed; create it manually"
         fi
     fi
@@ -161,7 +177,7 @@ bootstrap_postgres() {
         info "postgres: enabling pg_trgm extension on aimee_shared"
         psql -d aimee_shared -v ON_ERROR_STOP=1 \
              -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;' 2>/dev/null || \
-            sudo -n -u postgres psql -d aimee_shared -v ON_ERROR_STOP=1 \
+            as_postgres psql -d aimee_shared -v ON_ERROR_STOP=1 \
                  -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;' 2>/dev/null || \
             warn "postgres: failed to enable pg_trgm; install superuser must run \
 'CREATE EXTENSION pg_trgm;' on aimee_shared"
@@ -171,7 +187,7 @@ bootstrap_postgres() {
         info "postgres: enabling vector extension on aimee_shared"
         psql -d aimee_shared -v ON_ERROR_STOP=1 \
              -c 'CREATE EXTENSION IF NOT EXISTS vector;' 2>/dev/null || \
-            sudo -n -u postgres psql -d aimee_shared -v ON_ERROR_STOP=1 \
+            as_postgres psql -d aimee_shared -v ON_ERROR_STOP=1 \
                  -c 'CREATE EXTENSION IF NOT EXISTS vector;' 2>/dev/null || \
             warn "postgres: failed to enable vector; install superuser must run \
 'CREATE EXTENSION vector;' on aimee_shared"

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -73,8 +73,11 @@ rerank_coords() {
 synth_coords() {
   case "$SYNTH_TIER" in
     cpu)
-      SYNTH_REPO="ggml-org/gemma-4-E4B-it-GGUF"; SYNTH_FILE="gemma-4-E4B-it-Q4_K_M.gguf"
-      SYNTH_REVISION="main"; SYNTH_SHA256=""
+      # ggml-org publishes this repo at Q4_0/Q8_0/BF16 only — there is no Q4_K_M
+      # build, so the old filename 404'd and the cpu tier could never be baked.
+      SYNTH_REPO="ggml-org/gemma-4-E4B-it-GGUF"; SYNTH_FILE="gemma-4-E4B-it-Q4_0.gguf"
+      SYNTH_REVISION="b8093469224f83f5c38f691eb906c380e9e63114"
+      SYNTH_SHA256="a555b900214b477d8880e7832e0b8925e139b0159640036b09fe472b6f2097f2"
       TIER_FA="off"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; TIER_CTX="32768"; SYNTH_NGL=0
       ;;
     small)

--- a/scripts/check-async-op-handlers.py
+++ b/scripts/check-async-op-handlers.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Guard that handlers on async (rh_dispatch_op_async) /v1 routes reply inline.
+
+Those routes are driven by the op-run bridge in server_http.c: it hands the
+dispatch a socketpair, calls server_dispatch(), then shuts the write end and
+reads whatever is there. A handler that returns without having written its
+reply -- typically by handing the connection fd to a detached thread -- produces
+nothing for that read, and the run fails with "rpc produced no response".
+
+That is not hypothetical. index.scan hit it once and was converted to reply
+inline (see the comment on handle_index_scan). The same defect then sat
+unnoticed in kb.build, kb.update, kb.ingest, kb.docs.push and graph.sync_code,
+which all replied from a detached thread via a shared spawn helper: the entire
+KB write surface returned "rpc produced no response" over /v1, for thin clients
+and the browser alike.
+
+Because the detach lived in a *helper*, scanning each handler body would have
+missed it. So this check is file-granular: a source file that defines any
+handler bound to an async route must not create detached threads at all. If a
+handler there genuinely needs to run work off-thread, it must still write its
+own reply before returning.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ROUTES = ROOT / "src" / "server" / "server_http_routes.c"
+DISPATCH = ROOT / "src" / "server" / "server.c"
+SERVER_DIR = ROOT / "src" / "server"
+
+# {"POST", "/v1/kb/build", NULL, RM_EXACT, "kb.build", 0, rh_dispatch_op_async},
+ASYNC_ROUTE_RE = re.compile(
+    r'\{\s*"(?:GET|POST|PUT|DELETE)"\s*,\s*"[^"]+"\s*,[^}]*?"([a-z0-9_.]+)"\s*,[^}]*?rh_dispatch_op_async\s*\}'
+)
+# {"kb.build", handle_kb_build},
+BINDING_RE = re.compile(r'\{\s*"([a-z0-9_.]+)"\s*,\s*(handle_[a-z0-9_]+)\s*\}')
+
+
+def async_methods():
+    return set(ASYNC_ROUTE_RE.findall(ROUTES.read_text(encoding="utf-8")))
+
+
+def handler_for_method(bindings, method):
+    return bindings.get(method)
+
+
+def main() -> int:
+    methods = async_methods()
+    if not methods:
+        print("check-async-op-handlers: FAIL — found no rh_dispatch_op_async routes; "
+              "has the route table or this check's pattern changed?")
+        return 1
+
+    bindings = dict(BINDING_RE.findall(DISPATCH.read_text(encoding="utf-8")))
+
+    # Which files define the handlers bound to async methods?
+    handlers = {}
+    for m in sorted(methods):
+        h = handler_for_method(bindings, m)
+        if h:
+            handlers[h] = m
+
+    defining = {}  # file -> [(handler, method), ...]
+    define_re = {h: re.compile(r'^\s*int\s+' + re.escape(h) + r'\s*\(', re.M) for h in handlers}
+    for path in sorted(SERVER_DIR.glob("*.c")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for h, rx in define_re.items():
+            if rx.search(text):
+                defining.setdefault(path, []).append((h, handlers[h]))
+
+    failures = []
+    for path, owned in sorted(defining.items()):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "pthread_detach" in text:
+            names = ", ".join(sorted(m for _, m in owned))
+            failures.append((path.relative_to(ROOT), names))
+
+    if failures:
+        print("check-async-op-handlers: FAIL — these files define handlers on async "
+              "/v1 routes AND create detached threads. A detached reply is written "
+              "after the op-run bridge has already read and closed its socketpair, "
+              "so the run fails with \"rpc produced no response\". Reply inline.")
+        for rel, names in failures:
+            print(f"  {rel}  (async methods: {names})")
+        return 1
+
+    print(f"check-async-op-handlers: ok ({len(methods)} async routes, "
+          f"{len(handlers)} bound handlers across {len(defining)} file(s), all reply inline)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-cli-v1-routes.py
+++ b/scripts/check-cli-v1-routes.py
@@ -10,6 +10,7 @@ a registry change that isn't reflected in the committed map fails `make lint`
 instead of silently leaving the client without its first-class /v1 route.
 """
 import glob
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -42,8 +43,39 @@ def main() -> int:
               "server_http_routes.c; run scripts/gen-cli-v1-routes.py and commit.")
         return 1
     n = sum(1 for ln in fresh.splitlines() if ln.lstrip().startswith('{"'))
-    print(f"check-cli-v1-routes: ok ({n} client /v1 routes in sync)")
+
+    orphans = unreachable_methods()
+    if orphans:
+        print("check-cli-v1-routes: FAIL — these /v1 methods have a route and a "
+              "marshaller but no `aimee <cmd> <sub>` row in the dispatch table in "
+              "src/cli_v1_routes.c, so no thin client can invoke them:")
+        for m in orphans:
+            print(f"  {m}")
+        return 1
+
+    print(f"check-cli-v1-routes: ok ({n} client /v1 routes in sync, all reachable)")
     return 0
+
+
+# The generated block above keeps method -> /v1 path in sync with the server, but
+# the CLI subcommand -> method table is hand-written, so a method could be fully
+# plumbed (path + marshaller + printer) and still be unreachable from the CLI.
+# That is how `aimee kb build` shipped answering "command 'kb' has no /v1 route"
+# while POST /v1/kb/build worked -- every piece existed except the dispatch row.
+ROUTE_RE = re.compile(r'\{"([a-z0-9_.]+)",\s*"(?:GET|POST|PUT|DELETE)",\s*"/v1/[^"]+"\}')
+MARSHAL_RE = re.compile(r'\{"([a-z0-9_.]+)",\s*marshal_[a-z0-9_]+\}')
+DISPATCH_RE = re.compile(r'\{"[a-z0-9_-]+",\s*(?:NULL|"[a-z0-9 _-]*")\s*,\s*"([a-z0-9_.]+)"')
+
+
+def unreachable_methods():
+    routed, marshalled = set(), set()
+    for f in sorted(glob.glob(TARGET_GLOB)):
+        text = Path(f).read_text(encoding="utf-8")
+        routed |= set(ROUTE_RE.findall(text))
+        marshalled |= set(MARSHAL_RE.findall(text))
+    dispatch = set(DISPATCH_RE.findall(
+        Path(ROOT / "src" / "cli_v1_routes.c").read_text(encoding="utf-8")))
+    return sorted((routed & marshalled) - dispatch)
 
 
 if __name__ == "__main__":

--- a/src/Makefile
+++ b/src/Makefile
@@ -778,7 +778,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(STATUS_AUTHORIT
            $(CLI_OBJS) $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(KB_OBJS) $(KB_SYNTHESIS_OBJS) $(GATEWAY_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(PLATFORM_OBJS) $(PLATFORM_AGENT_OBJS)
 DEPS = $(ALL_OBJS:.o=.d)
 
-.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
+.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_RUNTIME_WEB) $(SERVER) $(KB) $(KB_RESOLVER) $(GATEWAY) $(FORWARDER)
 
@@ -1557,6 +1557,14 @@ v1-method-coverage-check:
 cli-v1-routes-check:
 	@python3 ../scripts/check-cli-v1-routes.py
 
+# CI gate: a handler bound to an async (rh_dispatch_op_async) /v1 route must write
+# its reply before returning. A detached-thread reply lands after the op-run bridge
+# has read and closed its socketpair, so the run fails with "rpc produced no
+# response" — which is how the whole KB write surface (kb.build/update/ingest/
+# docs.push) and graph.sync_code were dead over /v1.
+async-op-handlers-check:
+	@python3 ../scripts/check-async-op-handlers.py
+
 # CI gate: the /v1 route table's first-match dispatch stays order-correct — a
 # more-specific route (e.g. the exact /v1/workflow/items/all) must never be
 # shadowed by a later generic prefix ({id}) route. Makes the ordering constraint
@@ -1673,7 +1681,7 @@ CLANG_FORMAT ?= clang-format-19
 # Target-specific, so a standalone `make bus-blast-radius-check` stays strict.
 lint: BUS_BLAST_RADIUS_FLAGS := --allow-unbuilt
 
-lint: subject-corpus-check native-tool-parity-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check bus-blast-radius-check
+lint: subject-corpus-check native-tool-parity-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check bus-blast-radius-check
 
 # P1 (N1): every tenant-scoped db2 entrypoint must call db2_tenant_require_pg(),
 # so a new entry can never silently run without RLS on the SQLite shim.

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -550,11 +550,25 @@ static void ensemble_usage(void)
            "  See docs/ENSEMBLE.md. `aimee delegate aggregate|roundtable` remain as aliases.\n");
 }
 
-static int unsupported_client_command(const char *cmd, int json_output)
+/* Report a command that could not be routed. Two very different causes share this
+ * path: the command family genuinely has no /v1 route, or it has routes and the
+ * SUBCOMMAND was wrong. Blaming the command for the latter sends users (and
+ * maintainers) hunting for a missing route that already exists -- e.g. `aimee
+ * economizer status` reported "command 'economizer' has no /v1 route" when the
+ * registered subcommand is `stats`. So name the subcommand and list the real ones
+ * whenever the family has any. */
+static int unsupported_client_command(const char *cmd, const char *subcmd, int json_output)
 {
    const char *name = (cmd && cmd[0]) ? cmd : "launch";
-   char msg[256];
-   snprintf(msg, sizeof(msg), "command '%s' has no /v1 route; add a /v1 route", name);
+   char subs[512];
+   int have_subs = cli_v1_subcommands(name, subs, sizeof(subs));
+   char msg[768];
+   if (have_subs > 0 && subcmd && subcmd[0])
+      snprintf(msg, sizeof(msg), "'%s' is not a subcommand of '%s'; try: %s", subcmd, name, subs);
+   else if (have_subs > 0)
+      snprintf(msg, sizeof(msg), "'%s' needs a subcommand; try: %s", name, subs);
+   else
+      snprintf(msg, sizeof(msg), "command '%s' has no /v1 route", name);
 
    if (json_output)
    {
@@ -2000,5 +2014,5 @@ int main(int argc, char **argv)
       }
    }
 
-   return unsupported_client_command(cmd, json_output);
+   return unsupported_client_command(cmd, sub_argc >= 1 ? sub_argv[0] : NULL, json_output);
 }

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -460,21 +460,34 @@ static int remote_set(const char *url, const char *token, int json_output)
     * bootstrap token configured and is reported by remote_enroll. */
    int enrolled = 0;
    int mtls_enrolled = 0;
+   int bootstrap_enroll_failed = 0;
    char strong_token[256] = "";
-   if (verified && token && strcmp(token, AIMEE_BOOTSTRAP_BEARER) == 0 &&
-       remote_enroll(url, strong_token, sizeof(strong_token), json_output) == 0)
+   if (verified && token && strcmp(token, AIMEE_BOOTSTRAP_BEARER) == 0)
    {
-      enrolled = 1;
-      mtls_enrolled = g_remote_mtls_enrolled;
+      if (remote_enroll(url, strong_token, sizeof(strong_token), json_output) == 0)
+      {
+         enrolled = 1;
+         mtls_enrolled = g_remote_mtls_enrolled;
+      }
+      else
+      {
+         /* The bootstrap bearer was supplied, the channel is trusted, and the
+          * rotation was refused (typically: already consumed by an earlier client,
+          * or by following the manual rotation in QUICKSTART 1.3). What is now on
+          * disk is the dead bootstrap token, so every later command will 401.
+          * remote_enroll has already printed the recovery options; make the exit
+          * status say it failed instead of reporting a successful setup. */
+         bootstrap_enroll_failed = 1;
+      }
    }
    else if (verified && token && token[0] && remote_enroll_client_cert(json_output) == 0)
       mtls_enrolled = 1;
 
    if (json_output)
-      printf("{\"ok\":true,\"url\":\"%s\",\"token\":%s,\"pinned\":%s,\"verified\":%s,"
+      printf("{\"ok\":%s,\"url\":\"%s\",\"token\":%s,\"pinned\":%s,\"verified\":%s,"
              "\"enrolled\":%s,\"mtls_enrolled\":%s}\n",
-             url, token && *token ? "true" : "false", pinned ? "true" : "false",
-             verified ? "true" : "false", enrolled ? "true" : "false",
+             bootstrap_enroll_failed ? "false" : "true", url, token && *token ? "true" : "false",
+             pinned ? "true" : "false", verified ? "true" : "false", enrolled ? "true" : "false",
              mtls_enrolled ? "true" : "false");
    else
    {
@@ -488,7 +501,7 @@ static int remote_set(const char *url, const char *token, int json_output)
              "available on this platform).\n"
              "       Start the server and re-run `aimee remote set`, or `aimee remote trust`.\n");
    }
-   return 0;
+   return bootstrap_enroll_failed ? 1 : 0;
 }
 
 /* Re-pin the cert of the already-configured remote (e.g. after the server's
@@ -554,13 +567,19 @@ static int remote_status(int json_output)
    int st = 0;
    char *body = aimee_client_request("GET", "/v1/health", NULL, &st);
    int reachable = (body != NULL && st >= 200 && st < 500);
+   /* A 401/403 means the transport is fine but the stored token is not accepted —
+    * the single most common setup failure. Reporting a bare "Reachable: yes" for it
+    * (and exiting 0) told users their client was configured when no command would
+    * work; say what is actually wrong and fail. */
+   int unauthorized = (body != NULL && (st == 401 || st == 403));
+   int ok = (body != NULL && st >= 200 && st < 400);
    free(body);
 
    if (json_output)
    {
-      printf("{\"remote\":%s,\"target\":\"%s\",\"reachable\":%s,\"status\":%d}\n",
+      printf("{\"remote\":%s,\"target\":\"%s\",\"reachable\":%s,\"authorized\":%s,\"status\":%d}\n",
              active ? "true" : "false", active ? desc : "local-uds", reachable ? "true" : "false",
-             st);
+             unauthorized ? "false" : (ok ? "true" : "false"), st);
    }
    else
    {
@@ -568,9 +587,19 @@ static int remote_status(int json_output)
          printf("Transport: remote TCP -> %s\n", desc);
       else
          printf("Transport: local Unix socket (no remote configured)\n");
-      printf("Reachable: %s (GET /v1/health -> %d)\n", reachable ? "yes" : "no", st);
+      if (unauthorized)
+      {
+         printf("Reachable: yes, but NOT authorized (GET /v1/health -> %d)\n", st);
+         printf("  The server answered but rejected the stored token. Re-run\n"
+                "  `aimee remote set <url> <token>` with this server's bearer, or\n"
+                "  `aimee remote enroll` from an already-enrolled client.\n");
+      }
+      else
+      {
+         printf("Reachable: %s (GET /v1/health -> %d)\n", reachable ? "yes" : "no", st);
+      }
    }
-   return reachable ? 0 : 1;
+   return ok ? 0 : 1;
 }
 
 /* Force enrollment on the already-configured remote: rotate the server's /v1

--- a/src/cli_v1_routes.c
+++ b/src/cli_v1_routes.c
@@ -356,6 +356,45 @@ static const struct
     {NULL, NULL, NULL, NULL, NULL, 0},
 };
 
+/* Collect the subcommands registered for `cmd` into `out` as a comma-separated
+ * list, so a failed lookup can say which ones exist instead of blaming the whole
+ * command. Rows whose subcmd is NULL (match-any) or "" (bare command) are
+ * skipped -- they are not names a user can type. Returns the number found. */
+int cli_v1_subcommands(const char *cmd, char *out, size_t cap)
+{
+   if (out && cap)
+      out[0] = '\0';
+   if (!cmd)
+      return 0;
+   int n = 0;
+   size_t len = 0;
+   /* rpc_routes ends with a {NULL,...} sentinel — stop there, do not walk the
+    * array by sizeof or the terminator's NULL cmd reaches strcmp. */
+   for (size_t i = 0; rpc_routes[i].cmd; i++)
+   {
+      if (strcmp(rpc_routes[i].cmd, cmd) != 0)
+         continue;
+      const char *sub = rpc_routes[i].subcmd;
+      if (!sub || !sub[0])
+         continue;
+      n++;
+      if (!out || !cap)
+         continue;
+      size_t need = strlen(sub) + (len ? 2 : 0);
+      if (len + need >= cap)
+         continue; /* keep the list truncated rather than overflow */
+      if (len)
+      {
+         memcpy(out + len, ", ", 2);
+         len += 2;
+      }
+      memcpy(out + len, sub, strlen(sub));
+      len += strlen(sub);
+      out[len] = '\0';
+   }
+   return n;
+}
+
 int cli_v1_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_v1_route_t *route)
 {
    if (!cmd)

--- a/src/cli_v1_routes.c
+++ b/src/cli_v1_routes.c
@@ -207,6 +207,7 @@ static const struct
     {"wm", "list", "wm.list", NULL, "entries", 0},
     {"primary", NULL, "primary.set", NULL, NULL, 0},
     {"kb", "search", "kb.search", NULL, NULL, 60000},
+    {"kb", "build", "kb.build", NULL, NULL, 900000},
     {"kb", "update", "kb.update", NULL, NULL, 900000},
     {"kb", "docs push", "kb.docs.push", NULL, NULL, 900000},
     /* Grant administration. `show` maps to the same method as `list` — it is that listing

--- a/src/cli_v1_routes.c
+++ b/src/cli_v1_routes.c
@@ -1243,10 +1243,20 @@ cJSON *marshal_kb_build(int argc, char **argv)
 
    cJSON *req = marshal_no_args("kb.build");
 
-   if (opts.pos_count >= 1)
-      cJSON_AddStringToObject(req, "path", opts.positional[0]);
-   if (opts.pos_count >= 2)
-      cJSON_AddStringToObject(req, "project", opts.positional[1]);
+   /* MANUAL §7.16 documents `kb build [--path DIR] [--project NAME]`, but only the
+    * positional forms were read, so the documented flags parsed into opts.flags and
+    * were silently dropped — the build ran against no path at all. Accept the
+    * documented flags, falling back to the positional forms that already shipped. */
+   const char *path = rpc_get(&opts, "path");
+   const char *project = rpc_get(&opts, "project");
+   if (!path && opts.pos_count >= 1)
+      path = opts.positional[0];
+   if (!project && opts.pos_count >= 2)
+      project = opts.positional[1];
+   if (path)
+      cJSON_AddStringToObject(req, "path", path);
+   if (project)
+      cJSON_AddStringToObject(req, "project", project);
    if (rpc_get(&opts, "force"))
       cJSON_AddTrueToObject(req, "force");
    const char *v;

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -1033,11 +1033,70 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
              (strcmp(st->valuestring, "completed") == 0 || strcmp(st->valuestring, "failed") == 0 ||
               strcmp(st->valuestring, "cancelled") == 0))
          {
+            int ok = strcmp(st->valuestring, "completed") == 0;
             cJSON *result = cJSON_DetachItemFromObjectCaseSensitive(snap, "result");
+            if (ok && result)
+            {
+               cJSON_Delete(snap);
+               return result;
+            }
+            /* A failed/cancelled run, or a completed one with no result, used to
+             * become an empty object. Printers then rendered that as a zero-valued
+             * SUCCESS — `aimee kb build` reported "files indexed: 0, chunks added: 0"
+             * with exit status 0 when the run had actually failed, hiding the failure
+             * from humans and scripts alike. Surface it as an error envelope instead,
+             * carrying whatever the run recorded. */
+            const char *why = NULL;
+            /* A failed run usually carries its reason inside `result` (e.g.
+             * {"result":{"error":"rpc produced no response"}}), so look there first. */
+            if (result)
+            {
+               cJSON *re = cJSON_GetObjectItemCaseSensitive(result, "error");
+               if (cJSON_IsString(re) && re->valuestring[0])
+                  why = re->valuestring;
+               else if (cJSON_IsObject(re))
+               {
+                  cJSON *rm = cJSON_GetObjectItemCaseSensitive(re, "message");
+                  if (cJSON_IsString(rm) && rm->valuestring[0])
+                     why = rm->valuestring;
+               }
+            }
+            cJSON *e = why ? NULL : cJSON_GetObjectItemCaseSensitive(snap, "error");
+            if (cJSON_IsString(e) && e->valuestring[0])
+               why = e->valuestring;
+            else if (cJSON_IsObject(e))
+            {
+               cJSON *m = cJSON_GetObjectItemCaseSensitive(e, "message");
+               if (cJSON_IsString(m) && m->valuestring[0])
+                  why = m->valuestring;
+            }
+            if (!why)
+            {
+               cJSON *m = cJSON_GetObjectItemCaseSensitive(snap, "message");
+               if (cJSON_IsString(m) && m->valuestring[0])
+                  why = m->valuestring;
+            }
+            char msg[320];
+            if (why)
+               snprintf(msg, sizeof(msg), "%s", why);
+            else
+               snprintf(msg, sizeof(msg), "run %s with no result", st->valuestring);
+            /* Emit the OBJECT envelope {"error":{"message":...}}, not the string
+             * form. cli_v1_forward only treats a top-level string "error" as a
+             * failure when http_status >= 400 (a 2xx may legitimately carry one —
+             * cron.run returns job stderr that way), and the async path reports
+             * http_status 0. The object form is unconditionally an error there, so
+             * this reaches the caller as a real failure with exit status 1. */
+            cJSON *env = cJSON_CreateObject();
+            cJSON *err = env ? cJSON_AddObjectToObject(env, "error") : NULL;
+            if (err)
+            {
+               cJSON_AddStringToObject(err, "message", msg);
+               cJSON_AddStringToObject(err, "type", "run_failed");
+            }
+            cJSON_Delete(result);
             cJSON_Delete(snap);
-            /* Completed runs carry the raw dispatch result; a failed/empty run yields
-             * an empty object so the caller still gets a well-formed response. */
-            return result ? result : cJSON_CreateObject();
+            return env;
          }
          cJSON_Delete(snap);
       }

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -203,6 +203,10 @@ typedef struct
 /* Returns 1 if a matching /v1 route was found, 0 otherwise.
  * Tries compound sub-commands first (e.g. "ingest status") before single ones. */
 int cli_v1_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_v1_route_t *route);
+/* Comma-separated list of the subcommands registered for `cmd`; returns how many
+ * exist. Lets a failed lookup distinguish "unknown subcommand" from "this command
+ * has no /v1 route at all". */
+int cli_v1_subcommands(const char *cmd, char *out, size_t cap);
 
 /* Forward a CLI command to the server over its /v1 HTTP surface.
  * Returns 0 on success, >0 on application error, -1 on transport/protocol

--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -175,6 +175,115 @@ static int run_capture(const char *const argv[], char **envp, char *out, size_t 
    return 0;
 }
 
+/* Read KEY's value out of a NULL-terminated envp, or NULL when unset. */
+static const char *envp_get(char **envp, const char *key)
+{
+   if (!envp || !key)
+      return NULL;
+   size_t klen = strlen(key);
+   for (size_t i = 0; envp[i]; i++)
+      if (strncmp(envp[i], key, klen) == 0 && envp[i][klen] == '=')
+         return envp[i] + klen + 1;
+   return NULL;
+}
+
+/* Does COMPOSE_PROFILES select `name` as a whole, comma-separated entry?
+ * Substring matching would report "llm" for the "llm-cpu" profile. */
+static int profiles_select(const char *profiles, const char *name)
+{
+   if (!profiles || !name)
+      return 0;
+   size_t nlen = strlen(name);
+   for (const char *p = profiles; *p;)
+   {
+      const char *comma = strchr(p, ',');
+      size_t len = comma ? (size_t)(comma - p) : strlen(p);
+      if (len == nlen && strncmp(p, name, nlen) == 0)
+         return 1;
+      if (!comma)
+         break;
+      p = comma + 1;
+   }
+   return 0;
+}
+
+/* Return a copy of envp with COMPOSE_PROFILES forced to `profile` (replacing any
+ * existing entry, so the child cannot see the deploy's own selection). Heap-owned;
+ * free with free_envp. NULL on OOM. */
+static char **envp_with_profile(char **envp, const char *profile)
+{
+   size_t base = 0;
+   for (size_t i = 0; envp && envp[i]; i++)
+      base++;
+   char **out = calloc(base + 2, sizeof(char *));
+   if (!out)
+      return NULL;
+   size_t n = 0;
+   for (size_t i = 0; envp && envp[i]; i++)
+   {
+      if (strncmp(envp[i], "COMPOSE_PROFILES=", 17) == 0)
+         continue;
+      out[n] = strdup(envp[i]);
+      if (!out[n])
+      {
+         free_envp(out);
+         return NULL;
+      }
+      n++;
+   }
+   size_t len = strlen("COMPOSE_PROFILES=") + strlen(profile) + 1;
+   out[n] = malloc(len);
+   if (!out[n])
+   {
+      free_envp(out);
+      return NULL;
+   }
+   snprintf(out[n], len, "COMPOSE_PROFILES=%s", profile);
+   out[n + 1] = NULL;
+   return out;
+}
+
+/* Drop the LLM variant this deploy did not select.
+ *
+ * The managed compose runs under the SAME COMPOSE_PROJECT_NAME as
+ * compose.server-managed.yaml, so `docker compose … up --remove-orphans` classifies
+ * aimee-server — which is not a service of the managed file — as an orphan and stops
+ * and removes the very container running the deploy. (docker compose --dry-run
+ * reports "Container aimee-aimee-server-1 Stopping/Removing".) So the deploy must not
+ * pass --remove-orphans, and instead retires the one orphan the managed stack can
+ * really leave behind: the GPU (aimee-llm) and CPU (aimee-llm-cpu) services are
+ * mutually exclusive and both answer to the network name `aimee-llm`, so switching
+ * topology must take the previous one down or the alias resolves to two containers.
+ *
+ * Removing a service that was never up is a no-op, so failures here are not fatal to
+ * the deploy; the output is appended for the wizard to show. */
+static void deploy_retire_stale_llm(char **envp, const char *file, char *out, size_t out_cap)
+{
+   const char *profiles = envp_get(envp, "COMPOSE_PROFILES");
+   static const struct
+   {
+      const char *profile, *service;
+   } variants[] = {{"llm", "aimee-llm"}, {"llm-cpu", "aimee-llm-cpu"}};
+
+   for (size_t i = 0; i < sizeof(variants) / sizeof(variants[0]); i++)
+   {
+      if (profiles_select(profiles, variants[i].profile))
+         continue; /* this is the variant the deploy is bringing up */
+      char **venv = envp_with_profile(envp, variants[i].profile);
+      if (!venv)
+         continue;
+      const char *argv[] = {"docker", "compose", "-f",           file,
+                            "rm",     "-s",      "-f",           variants[i].service,
+                            NULL};
+      char buf[512];
+      int code = -1;
+      if (run_capture(argv, venv, buf, sizeof(buf), &code) == 0 && code == 0 && buf[0] &&
+          out_cap > strlen(out) + 1)
+         snprintf(out + strlen(out), out_cap - strlen(out), "%s", buf);
+      free_envp(venv);
+   }
+}
+
 /* Background worker: `docker compose -f <file> up -d`.
  *
  * NO --remove-orphans, and this is not a style preference: it made the deploy
@@ -191,21 +300,57 @@ static int run_capture(const char *const argv[], char **envp, char *out, size_t 
  * network), so the fix is to drop the orphan sweep rather than the project. What
  * that gives up is small and recoverable: a service removed from the managed file
  * leaves its container behind until an operator prunes it. What it buys is that
- * deploying cannot destroy the thing doing the deploying. */
+ * deploying cannot destroy the thing doing the deploying.
+ *
+ * It also retires the LLM variant this deploy did NOT select (see
+ * deploy_retire_stale_llm) — the one orphan the managed stack really can leave
+ * behind, since the GPU and CPU services are mutually exclusive and both answer
+ * to the network name `aimee-llm`. */
+/* Fill argv with the managed-deploy `up` command for `file` and NULL-terminate it.
+ * Deliberately omits --remove-orphans, for the reason above. Returns the number of
+ * arguments written, or -1 when cap is too small. Separated out so the command is
+ * assertable in a test rather than inlined in the worker. */
+static int deploy_up_argv(const char *file, const char **argv, size_t cap)
+{
+   const char *cmd[] = {"docker", "compose", "-f", file, "up", "-d"};
+   size_t n = sizeof(cmd) / sizeof(cmd[0]);
+   if (!argv || cap < n + 1)
+      return -1;
+   for (size_t i = 0; i < n; i++)
+      argv[i] = cmd[i];
+   argv[n] = NULL;
+   return (int)n;
+}
+
 static void *deploy_worker(void *arg)
 {
    (void)arg;
    char file[512];
    deploy_apply_compose_file(file, sizeof(file));
-   const char *argv[] = {"docker", "compose", "-f", file, "up", "-d", NULL};
+   const char *argv[8];
+   if (deploy_up_argv(file, argv, sizeof(argv) / sizeof(argv[0])) < 0)
+   {
+      pthread_mutex_lock(&g_lock);
+      g_running = 0;
+      g_last_exit = -1;
+      snprintf(g_last_out, sizeof(g_last_out), "deploy: could not build the compose command\n");
+      pthread_mutex_unlock(&g_lock);
+      return NULL;
+   }
    char **envp = build_deploy_envp();
 
    char out[DEPLOY_OUT_CAP];
    int code = -1;
    if (!envp)
       snprintf(out, sizeof(out), "deploy: failed to load config / build environment\n");
-   else if (run_capture(argv, envp, out, sizeof(out), &code) != 0)
-      snprintf(out, sizeof(out), "deploy: failed to run `docker compose` (is docker on PATH?)\n");
+   else
+   {
+      out[0] = '\0';
+      deploy_retire_stale_llm(envp, file, out, sizeof(out));
+      size_t used = strlen(out);
+      if (run_capture(argv, envp, out + used, sizeof(out) - used, &code) != 0)
+         snprintf(out, sizeof(out), "deploy: failed to run `docker compose` (is docker on PATH?)\n");
+   }
    free_envp(envp);
 
    pthread_mutex_lock(&g_lock);

--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -272,9 +272,8 @@ static void deploy_retire_stale_llm(char **envp, const char *file, char *out, si
       char **venv = envp_with_profile(envp, variants[i].profile);
       if (!venv)
          continue;
-      const char *argv[] = {"docker", "compose", "-f",           file,
-                            "rm",     "-s",      "-f",           variants[i].service,
-                            NULL};
+      const char *argv[] = {"docker", "compose",           "-f", file, "rm", "-s",
+                            "-f",     variants[i].service, NULL};
       char buf[512];
       int code = -1;
       if (run_capture(argv, venv, buf, sizeof(buf), &code) == 0 && code == 0 && buf[0] &&
@@ -349,7 +348,8 @@ static void *deploy_worker(void *arg)
       deploy_retire_stale_llm(envp, file, out, sizeof(out));
       size_t used = strlen(out);
       if (run_capture(argv, envp, out + used, sizeof(out) - used, &code) != 0)
-         snprintf(out, sizeof(out), "deploy: failed to run `docker compose` (is docker on PATH?)\n");
+         snprintf(out, sizeof(out),
+                  "deploy: failed to run `docker compose` (is docker on PATH?)\n");
    }
    free_envp(envp);
 

--- a/src/server/server_runner_endpoints.c
+++ b/src/server/server_runner_endpoints.c
@@ -176,6 +176,15 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (config_save(&cfg) != 0)
       return server_send_error(conn, "workspace: failed to save config", NULL);
 
+   /* Republish the live snapshot now instead of waiting for the server loop's
+    * config_reload_if_changed() tick. In the server, config_load() returns the
+    * snapshot rather than disk, so until that tick a `workspace list` issued right
+    * after this `workspace add` read a config without the new entry and reported
+    * "No workspaces configured" — intermittently, depending on where the write
+    * landed in the poll interval. Making the write read-your-writes consistent
+    * costs one reload on a rare path. */
+   (void)config_reload_if_changed();
+
    /* A `detached` workspace's root lives on the client; this server cannot
     * enumerate or read it, so we don't discover projects or kick a server-side
     * scan (which would read this host's filesystem). Ingestion is client-driven:

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -45,74 +45,6 @@ int send_and_free(server_conn_t *conn, cJSON *resp)
    return server_send_ok(conn, resp);
 }
 
-/* Write a JSON response and newline directly to a raw fd.
- * Used by kb proxy threads that run off the event loop. */
-static void kb_proxy_write_response(int fd, cJSON *resp)
-{
-   char *json = cJSON_PrintUnformatted(resp);
-   if (!json)
-      return;
-   size_t len = strlen(json);
-   size_t off = 0;
-   while (off < len)
-   {
-      ssize_t n = write(fd, json + off, len - off);
-      if (n <= 0)
-      {
-         if (n < 0 && errno == EINTR)
-            continue;
-         break;
-      }
-      off += (size_t)n;
-   }
-   free(json);
-   (void)write(fd, "\n", 1);
-}
-
-/* Generic context for kb proxy threads. */
-typedef struct
-{
-   int conn_fd;
-   cJSON *req;
-} kb_proxy_ctx_t;
-
-static kb_proxy_ctx_t *kb_proxy_ctx_new(server_conn_t *conn, cJSON *req)
-{
-   kb_proxy_ctx_t *c = malloc(sizeof(*c));
-   if (!c)
-      return NULL;
-   c->conn_fd = conn->fd;
-   c->req = cJSON_Duplicate(req, 1);
-   if (!c->req)
-   {
-      free(c);
-      return NULL;
-   }
-   return c;
-}
-
-static void kb_proxy_ctx_free(kb_proxy_ctx_t *c)
-{
-   if (!c)
-      return;
-   cJSON_Delete(c->req);
-   free(c);
-}
-
-static void kb_proxy_spawn(server_conn_t *conn, cJSON *req, void *(*thread_fn)(void *))
-{
-   kb_proxy_ctx_t *c = kb_proxy_ctx_new(conn, req);
-   if (!c)
-      return;
-   pthread_t tid;
-   if (pthread_create(&tid, NULL, thread_fn, c) != 0)
-   {
-      kb_proxy_ctx_free(c);
-      return;
-   }
-   pthread_detach(tid);
-}
-
 /* --- Memory handlers --- */
 
 int handle_memory_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
@@ -319,9 +251,10 @@ int handle_index_scan(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    /* Synchronous (inline kb scan + send_and_free), like handle_index_ingest:
     * over /v1 this runs in the async op-run worker (HTTP already returned the
     * run handle) and over NDJSON in the per-connection worker, so blocking here
-    * is fine. A kb_proxy_spawn detached-thread reply is NOT captured by the
-    * op-run's loopback_rpc (it reads the socketpair synchronously), which is why
-    * a remote /v1 index.scan previously failed with "rpc produced no response". */
+    * is fine. A detached-thread reply is NOT captured by the op-run's loopback_rpc
+    * (it reads the socketpair synchronously), which is why a remote /v1 index.scan
+    * previously failed with "rpc produced no response". Every relay handler in this
+    * file now replies inline for that reason — see the kb.build group below. */
    int force = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "force")) ? 1 : 0;
    kb_client_index_scan_result_t res;
    memset(&res, 0, sizeof(res));
@@ -462,45 +395,32 @@ int handle_index_find_callers(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
 
 /* --- Graph code-projection handlers --- */
 
-/* graph.sync_code runs the code-graph projection (DB2-heavy) off the request
- * lane via kb_proxy_spawn, the same non-blocking pattern as index.scan, so it
- * never ties up the ephemeral request handler. */
-static void *graph_sync_code_thread(void *arg)
-{
-   kb_proxy_ctx_t *c = arg;
-   const char *project = jo_str(c->req, "project", NULL);
-
-   kb_client_graph_sync_result_t res;
-   memset(&res, 0, sizeof(res));
-   int rc = kb_client_graph_sync_code(project ? project : "", &res);
-
-   cJSON *resp = cJSON_CreateObject();
-   if (rc == 0)
-   {
-      cJSON_AddStringToObject(resp, "status", "ok");
-      cJSON_AddStringToObject(resp, "project", res.project);
-      cJSON_AddNumberToObject(resp, "generation_id", (double)res.generation_id);
-      cJSON_AddNumberToObject(resp, "edge_count", (double)res.edge_count);
-   }
-   else
-   {
-      cJSON_AddStringToObject(resp, "status", "error");
-      cJSON_AddStringToObject(resp, "message", "graph sync-code failed");
-   }
-   kb_proxy_write_response(c->conn_fd, resp);
-   cJSON_Delete(resp);
-   kb_proxy_ctx_free(c);
-   return NULL;
-}
-
+/* graph.sync_code runs the code-graph projection (DB2-heavy). Synchronous, for the
+ * reason spelled out on handle_index_scan: a detached-thread reply is written after
+ * the op-run's loopback_rpc has already read and shut its socketpair, so it never
+ * reaches the caller. Over /v1 this body runs in the async op-run worker (HTTP has
+ * already returned the run handle) and over NDJSON in the per-connection worker, so
+ * blocking here does not tie up the request lane either way. */
 int handle_graph_sync_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
    const char *project = jo_str(req, "project", NULL);
    if (!project || !project[0])
       return server_send_error(conn, "graph.sync_code requires a project", NULL);
-   kb_proxy_spawn(conn, req, graph_sync_code_thread);
-   return 0;
+
+   kb_client_graph_sync_result_t res;
+   memset(&res, 0, sizeof(res));
+   int rc = kb_client_graph_sync_code(project, &res);
+   if (rc != 0)
+      return server_send_error(conn, "graph sync-code failed", NULL);
+
+   cJSON *resp = jo_ok();
+   if (!resp)
+      return server_send_error(conn, "out of memory", NULL);
+   cJSON_AddStringToObject(resp, "project", res.project);
+   cJSON_AddNumberToObject(resp, "generation_id", (double)res.generation_id);
+   cJSON_AddNumberToObject(resp, "edge_count", (double)res.edge_count);
+   return send_and_free(conn, resp);
 }
 
 int handle_graph_explain(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
@@ -632,84 +552,67 @@ int handle_curator_invalidated(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    return send_and_free(conn, resp);
 }
 
-/* --- kb proxy threads (build / update / ingest) ---
- * These call aimee-kb which can take minutes for large repos.  Running them
- * synchronously on the event-loop thread would block the server for the entire
- * duration, making every other aimee command appear frozen.  Each handler
- * spawns a detached thread that performs the kb RPC and writes the response
- * directly to the connection fd when it is ready. */
+/* kb.build / kb.update / kb.ingest / kb.docs.push relay to aimee-kb.
+ *
+ * All four are SYNCHRONOUS, for the reason on handle_index_scan: these used to
+ * reply from a detached thread, whose write lands after the op-run's
+ * loopback_rpc has read and shut its socketpair — so over /v1 every one of them
+ * failed with "rpc produced no response", i.e. the whole KB write surface was dead
+ * for thin clients and the browser alike. Over /v1 these bodies run in the async
+ * op-run worker (HTTP already returned the run handle) and over NDJSON in the
+ * per-connection worker, so blocking here does not tie up the request lane. */
 
-static void *kb_build_thread(void *arg)
+/* Parse aimee-kb's JSON relay reply, or emit `fallback` as a dispatch error. */
+static int kb_relay_send(server_conn_t *conn, char *json, const char *fallback)
 {
-   kb_proxy_ctx_t *c = arg;
-   const char *path = jo_str(c->req, "path", "");
-   const char *project = jo_str(c->req, "project", "");
-   const char *embed_cmd = jo_str(c->req, "embedding_command", NULL);
-   int force = jo_int(c->req, "force", 0);
-
-   char *json = kb_client_build_json(path, project, embed_cmd, force);
    cJSON *resp = json ? cJSON_Parse(json) : NULL;
    free(json);
    if (!resp)
-      resp = cJSON_Parse("{\"status\":\"error\",\"message\":\"knowledge service build failed\"}");
-   if (resp)
-   {
-      kb_proxy_write_response(c->conn_fd, resp);
-      cJSON_Delete(resp);
-   }
-   kb_proxy_ctx_free(c);
-   return NULL;
+      return server_send_error(conn, fallback, NULL);
+   return send_and_free(conn, resp);
 }
 
-static void *kb_update_thread(void *arg)
+int handle_kb_build(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
-   kb_proxy_ctx_t *c = arg;
-   const char *path = jo_str(c->req, "path", "");
-   const char *project = jo_str(c->req, "project", "");
-   const char *embed_cmd = jo_str(c->req, "embedding_command", NULL);
+   (void)ctx;
+   const char *path = jo_str(req, "path", "");
+   const char *project = jo_str(req, "project", "");
+   const char *embed_cmd = jo_str(req, "embedding_command", NULL);
+   int force = jo_int(req, "force", 0);
 
-   char *json = kb_client_update_json(path, project, embed_cmd);
-   cJSON *resp = json ? cJSON_Parse(json) : NULL;
-   free(json);
-   if (!resp)
-      resp = cJSON_Parse("{\"status\":\"error\",\"message\":\"knowledge service update failed\"}");
-   if (resp)
-   {
-      kb_proxy_write_response(c->conn_fd, resp);
-      cJSON_Delete(resp);
-   }
-   kb_proxy_ctx_free(c);
-   return NULL;
+   return kb_relay_send(conn, kb_client_build_json(path, project, embed_cmd, force),
+                        "knowledge service build failed");
 }
 
-static void *kb_ingest_thread(void *arg)
+int handle_kb_update(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
-   kb_proxy_ctx_t *c = arg;
-   const char *workspace = jo_str(c->req, "workspace", NULL);
-   const char *embed_cmd = jo_str(c->req, "embedding_command", NULL);
-   int force = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(c->req, "force")) ? 1 : 0;
+   (void)ctx;
+   const char *path = jo_str(req, "path", "");
+   const char *project = jo_str(req, "project", "");
+   const char *embed_cmd = jo_str(req, "embedding_command", NULL);
 
-   char *json = kb_client_ingest_json(workspace, embed_cmd, force);
-   cJSON *resp = json ? cJSON_Parse(json) : NULL;
-   free(json);
-   if (!resp)
-      resp = cJSON_Parse("{\"status\":\"error\",\"message\":\"knowledge service ingest failed\"}");
-   if (resp)
-   {
-      /* aimee-kb wakes its own ingest workers on enqueue (kb_handle_ingest),
-       * so the server just relays the response. */
-      kb_proxy_write_response(c->conn_fd, resp);
-      cJSON_Delete(resp);
-   }
-   kb_proxy_ctx_free(c);
-   return NULL;
+   return kb_relay_send(conn, kb_client_update_json(path, project, embed_cmd),
+                        "knowledge service update failed");
 }
 
-static void *kb_docs_push_thread(void *arg)
+int handle_kb_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
-   kb_proxy_ctx_t *c = arg;
-   const char *scope = jo_str(c->req, "scope", "global");
-   cJSON *paths_j = cJSON_GetObjectItemCaseSensitive(c->req, "paths");
+   (void)ctx;
+   const char *workspace = jo_str(req, "workspace", NULL);
+   const char *embed_cmd = jo_str(req, "embedding_command", NULL);
+   int force = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "force")) ? 1 : 0;
+
+   /* aimee-kb wakes its own ingest workers on enqueue (kb_handle_ingest), so the
+    * server just relays the response. */
+   return kb_relay_send(conn, kb_client_ingest_json(workspace, embed_cmd, force),
+                        "knowledge service ingest failed");
+}
+
+int handle_kb_docs_push(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   const char *scope = jo_str(req, "scope", "global");
+   cJSON *paths_j = cJSON_GetObjectItemCaseSensitive(req, "paths");
 
    const char *paths[128];
    int path_count = 0;
@@ -724,57 +627,11 @@ static void *kb_docs_push_thread(void *arg)
             paths[path_count++] = item->valuestring;
       }
    }
-
-   cJSON *resp = NULL;
    if (path_count <= 0)
-   {
-      resp = cJSON_Parse("{\"status\":\"error\",\"message\":\"docs paths required\"}");
-   }
-   else
-   {
-      char *json = kb_client_docs_push_json(scope, paths, path_count);
-      resp = json ? cJSON_Parse(json) : NULL;
-      free(json);
-      if (!resp)
-         resp = cJSON_Parse("{\"status\":\"error\",\"message\":\"knowledge service docs push "
-                            "failed\"}");
-   }
+      return server_send_error(conn, "docs paths required", NULL);
 
-   if (resp)
-   {
-      kb_proxy_write_response(c->conn_fd, resp);
-      cJSON_Delete(resp);
-   }
-   kb_proxy_ctx_free(c);
-   return NULL;
-}
-
-int handle_kb_build(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
-{
-   (void)ctx;
-   kb_proxy_spawn(conn, req, kb_build_thread);
-   return 0;
-}
-
-int handle_kb_update(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
-{
-   (void)ctx;
-   kb_proxy_spawn(conn, req, kb_update_thread);
-   return 0;
-}
-
-int handle_kb_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
-{
-   (void)ctx;
-   kb_proxy_spawn(conn, req, kb_ingest_thread);
-   return 0;
-}
-
-int handle_kb_docs_push(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
-{
-   (void)ctx;
-   kb_proxy_spawn(conn, req, kb_docs_push_thread);
-   return 0;
+   return kb_relay_send(conn, kb_client_docs_push_json(scope, paths, path_count),
+                        "knowledge service docs push failed");
 }
 
 int handle_kb_ingest_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)

--- a/src/server/wfe_roundtable_proxy.c
+++ b/src/server/wfe_roundtable_proxy.c
@@ -121,8 +121,8 @@ static void rt_fail(char *reason, size_t cap, const char *fmt, ...)
    va_end(ap);
 }
 
-static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *status,
-                                char *reason, size_t reason_cap)
+static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *status, char *reason,
+                                size_t reason_cap)
 {
    if (status)
       *status = 0;
@@ -322,9 +322,8 @@ int wfe_roundtable_proxy(server_conn_t *conn, const cJSON *request)
       return server_send_error(conn, "out of memory", NULL);
    int status = 0;
    char reason[320] = "";
-   char *body =
-       post_go_roundtable(wire, roundtable_receive_timeout_ms(request), &status, reason,
-                          sizeof(reason));
+   char *body = post_go_roundtable(wire, roundtable_receive_timeout_ms(request), &status, reason,
+                                   sizeof(reason));
    free(wire);
    if (!body)
    {

--- a/src/server/wfe_roundtable_proxy.c
+++ b/src/server/wfe_roundtable_proxy.c
@@ -7,6 +7,7 @@
 #include "util.h"
 
 #include <errno.h>
+#include <stdarg.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -105,16 +106,41 @@ static int roundtable_receive_timeout_ms(const cJSON *request)
    return deadline_ms + GO_ROUNDTABLE_TRANSPORT_GRACE_MS;
 }
 
-static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *status)
+/* Report WHY the Go roundtable call produced no body. Every failure below used to
+ * `return NULL`, and the caller rendered all of them as "Go roundtable service is
+ * unreachable" — so a review that ran for its full deadline and timed out looked
+ * exactly like a service that was never started, sending diagnosis after a missing
+ * process while the real cause was a seat that never returned. */
+static void rt_fail(char *reason, size_t cap, const char *fmt, ...)
+{
+   if (!reason || !cap)
+      return;
+   va_list ap;
+   va_start(ap, fmt);
+   vsnprintf(reason, cap, fmt, ap);
+   va_end(ap);
+}
+
+static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *status,
+                                char *reason, size_t reason_cap)
 {
    if (status)
       *status = 0;
+   if (reason && reason_cap)
+      reason[0] = '\0';
    const char *socket_path = getenv("AIMEE_WFE_HTTP_SOCKET");
    if (!socket_path || !socket_path[0])
+   {
+      rt_fail(reason, reason_cap,
+              "AIMEE_WFE_HTTP_SOCKET is unset (the Go WFE control plane was never started)");
       return NULL;
+   }
    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
    if (fd < 0)
+   {
+      rt_fail(reason, reason_cap, "socket(AF_UNIX) failed: %s", strerror(errno));
       return NULL;
+   }
    // Derive the receive bound from the same saved preset the Go service
    // acquires. The transport grace covers response serialization and socket
    // delivery without replacing the configured roundtable deadline.
@@ -124,6 +150,7 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout)) != 0 ||
        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout, sizeof(receive_timeout)) != 0)
    {
+      rt_fail(reason, reason_cap, "setsockopt on %s failed: %s", socket_path, strerror(errno));
       close(fd);
       return NULL;
    }
@@ -134,6 +161,8 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
            (int)sizeof addr.sun_path ||
        connect(fd, (struct sockaddr *)&addr, sizeof addr) != 0)
    {
+      rt_fail(reason, reason_cap, "cannot connect to the Go WFE socket %s: %s", socket_path,
+              strerror(errno));
       close(fd);
       return NULL;
    }
@@ -144,6 +173,7 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
    char *head = malloc(head_cap);
    if (!head)
    {
+      rt_fail(reason, reason_cap, "out of memory building the request");
       close(fd);
       return NULL;
    }
@@ -156,6 +186,8 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
    if (head_n <= 0 || (size_t)head_n >= head_cap || write_all(fd, head, (size_t)head_n) != 0 ||
        write_all(fd, body, strlen(body)) != 0)
    {
+      rt_fail(reason, reason_cap, "sending the review request failed after %ds: %s",
+              GO_ROUNDTABLE_SEND_TIMEOUT_SECS, strerror(errno));
       free(head);
       close(fd);
       return NULL;
@@ -165,6 +197,7 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
    char *raw = malloc(cap);
    if (!raw)
    {
+      rt_fail(reason, reason_cap, "out of memory reading the response");
       close(fd);
       return NULL;
    }
@@ -174,6 +207,8 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
       {
          if (cap >= GO_ROUNDTABLE_MAX_RESPONSE)
          {
+            rt_fail(reason, reason_cap, "the review response exceeded %u bytes",
+                    GO_ROUNDTABLE_MAX_RESPONSE);
             free(raw);
             close(fd);
             return NULL;
@@ -202,6 +237,17 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
    int http_status = 0;
    if (sscanf(raw, "HTTP/1.%*d %d", &http_status) != 1)
    {
+      /* The dominant case: the receive timeout elapsed with nothing read, because the
+       * panel was still running. Say so — it is a deadline, not a missing service. */
+      if (used == 0)
+         rt_fail(reason, reason_cap,
+                 "no response within %dms — the panel was still running when the deadline "
+                 "elapsed (raise the preset's deadline_ms, or check for a stalled seat with "
+                 "`aimee jobs list`)",
+                 receive_timeout_ms);
+      else
+         rt_fail(reason, reason_cap, "malformed response from the Go WFE service (%zu bytes)",
+                 used);
       free(raw);
       return NULL;
    }
@@ -210,6 +256,7 @@ static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *s
    char *body_at = strstr(raw, "\r\n\r\n");
    if (!body_at)
    {
+      rt_fail(reason, reason_cap, "truncated response from the Go WFE service (%zu bytes)", used);
       free(raw);
       return NULL;
    }
@@ -274,10 +321,18 @@ int wfe_roundtable_proxy(server_conn_t *conn, const cJSON *request)
    if (!wire)
       return server_send_error(conn, "out of memory", NULL);
    int status = 0;
-   char *body = post_go_roundtable(wire, roundtable_receive_timeout_ms(request), &status);
+   char reason[320] = "";
+   char *body =
+       post_go_roundtable(wire, roundtable_receive_timeout_ms(request), &status, reason,
+                          sizeof(reason));
    free(wire);
    if (!body)
-      return server_send_error(conn, "Go roundtable service is unreachable", NULL);
+   {
+      char msg[420];
+      snprintf(msg, sizeof(msg), "roundtable review failed: %s",
+               reason[0] ? reason : "the Go WFE service returned nothing");
+      return server_send_error(conn, msg, NULL);
+   }
    cJSON *response = cJSON_Parse(body);
    free(body);
    cJSON *error = response ? cJSON_GetObjectItemCaseSensitive(response, "error") : NULL;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -313,6 +313,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-gateway-p4-delegate \
                $(TESTPREFIX)/unit-test-hud \
                $(TESTPREFIX)/unit-test-coord-jobs \
+               $(TESTPREFIX)/unit-test-deploy-apply \
                $(TESTPREFIX)/unit-test-plan-waves \
                $(TESTPREFIX)/unit-test-history \
                $(TESTPREFIX)/unit-test-events \
@@ -3650,6 +3651,11 @@ $(TESTPREFIX)/unit-test-coord-jobs: $(OBJDIR)/tests/test_coord_jobs.o \
                             $(OBJDIR)/modules/delegates/delegate_prompt.o \
                             $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# deploy_apply.c is #included by the test for its statics, and the two config
+# symbols it calls are stubbed there — so this links nothing else.
+$(TESTPREFIX)/unit-test-deploy-apply: $(OBJDIR)/tests/test_deploy_apply.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL) -lpthread
 
 $(TESTPREFIX)/unit-test-plan-waves: $(OBJDIR)/tests/test_plan_waves.o \
                             $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -314,6 +314,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-hud \
                $(TESTPREFIX)/unit-test-coord-jobs \
                $(TESTPREFIX)/unit-test-deploy-apply \
+               $(TESTPREFIX)/unit-test-cli-v1-subcommands \
                $(TESTPREFIX)/unit-test-plan-waves \
                $(TESTPREFIX)/unit-test-history \
                $(TESTPREFIX)/unit-test-events \
@@ -1071,6 +1072,14 @@ $(TESTPREFIX)/unit-test-cli-v1-delegate: $(OBJDIR)/tests/test_cli_v1_delegate.o 
                                   $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o $(OBJDIR)/aimee_client.o \
                                   $(OBJDIR)/codex_auth.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-cli-v1-subcommands: $(OBJDIR)/tests/test_cli_v1_subcommands.o \
+                                  $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o \
+                                  $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o \
+                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+                                  $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cli-server-compat: $(OBJDIR)/tests/test_cli_server_compat.o \
                                   $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o

--- a/src/tests/test_cli_v1_subcommands.c
+++ b/src/tests/test_cli_v1_subcommands.c
@@ -1,0 +1,111 @@
+/* test_cli_v1_subcommands.c — cli_v1_subcommands(), which turns a failed route
+ * lookup into an actionable message.
+ *
+ * Before this helper existed, `aimee economizer status` reported
+ * "command 'economizer' has no /v1 route; add a /v1 route" — blaming the command
+ * (and telling the user to add a route) when the command is routed fine and only
+ * the SUBCOMMAND was wrong. That message sends people hunting for a missing route
+ * that already exists.
+ *
+ * The first cut of the helper walked rpc_routes with sizeof/sizeof, which runs
+ * off the end into the table's {NULL,...} sentinel and segfaults in strcmp. The
+ * unknown-command case below is the regression guard for that crash. */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "cli_client.h"
+
+/* A command that is not in the table at all: must report zero and must not walk
+ * into the NULL sentinel. This is the segfault guard. */
+static void test_unknown_command_is_safe(void)
+{
+   char buf[256] = "sentinel";
+   assert(cli_v1_subcommands("no-such-command-anywhere", buf, sizeof(buf)) == 0);
+   assert(buf[0] == '\0');
+
+   /* every rejected lookup path, including the ones a crash would take */
+   assert(cli_v1_subcommands("", buf, sizeof(buf)) == 0);
+   assert(cli_v1_subcommands(NULL, buf, sizeof(buf)) == 0);
+   printf("  unknown command is safe (no sentinel walk)\n");
+}
+
+/* A routed family reports its real subcommands. */
+static void test_known_command_lists_subcommands(void)
+{
+   char buf[512];
+   int n = cli_v1_subcommands("economizer", buf, sizeof(buf));
+   assert(n > 0);
+   assert(strstr(buf, "stats") != NULL);
+
+   n = cli_v1_subcommands("kb", buf, sizeof(buf));
+   assert(n >= 4);
+   assert(strstr(buf, "search") != NULL);
+   assert(strstr(buf, "build") != NULL); /* the row whose absence made kb build unreachable */
+   assert(strstr(buf, "status") != NULL);
+
+   n = cli_v1_subcommands("curator", buf, sizeof(buf));
+   assert(n > 0);
+   assert(strstr(buf, "contradictions") != NULL);
+   printf("  known commands list their subcommands\n");
+}
+
+/* Entries are comma-separated with no leading/trailing separator. */
+static void test_list_formatting(void)
+{
+   char buf[512];
+   assert(cli_v1_subcommands("kb", buf, sizeof(buf)) > 0);
+   assert(buf[0] != ',');
+   assert(buf[0] != ' ');
+   size_t len = strlen(buf);
+   assert(len > 0);
+   assert(buf[len - 1] != ',');
+   assert(buf[len - 1] != ' ');
+   assert(strstr(buf, ",,") == NULL);
+   printf("  list formatting ok\n");
+}
+
+/* A tiny buffer must truncate, never overflow. The count still reports the true
+ * number of subcommands so the caller can tell the list was clipped. */
+static void test_small_buffer_does_not_overflow(void)
+{
+   char guard[64];
+   memset(guard, 0x7f, sizeof(guard));
+   char *buf = guard + 16; /* poisoned bytes on both sides */
+   int n = cli_v1_subcommands("kb", buf, 8);
+   assert(n > 0);
+   assert(strlen(buf) < 8);
+   for (int i = 0; i < 16; i++)
+      assert((unsigned char)guard[i] == 0x7f); /* nothing written before */
+   for (size_t i = 16 + 8; i < sizeof(guard); i++)
+      assert((unsigned char)guard[i] == 0x7f); /* nothing written past cap */
+
+   /* a zero-cap / NULL out must still count without writing */
+   assert(cli_v1_subcommands("kb", NULL, 0) > 0);
+   printf("  small buffer truncates without overflow\n");
+}
+
+/* Rows that are NULL (match-any) or "" (bare command) are not typeable names and
+ * must not appear in the suggestion list. `workers` is registered only as a bare
+ * command, so it contributes no subcommand names. */
+static void test_bare_and_matchany_rows_excluded(void)
+{
+   char buf[256];
+   int n = cli_v1_subcommands("workers", buf, sizeof(buf));
+   assert(n == 0);
+   assert(buf[0] == '\0');
+   printf("  bare / match-any rows excluded\n");
+}
+
+int main(void)
+{
+   printf("test_cli_v1_subcommands\n");
+   test_unknown_command_is_safe();
+   test_known_command_lists_subcommands();
+   test_list_formatting();
+   test_small_buffer_does_not_overflow();
+   test_bare_and_matchany_rows_excluded();
+   printf("test_cli_v1_subcommands: all passed\n");
+   return 0;
+}

--- a/src/tests/test_deploy_apply.c
+++ b/src/tests/test_deploy_apply.c
@@ -1,0 +1,169 @@
+/* test_deploy_apply.c — the managed-deploy command construction.
+ *
+ * Covers the two properties the wizard's Deploy depends on:
+ *   1. the deploy never passes --remove-orphans (the managed compose shares
+ *      COMPOSE_PROJECT_NAME with compose.server-managed.yaml, so an orphan sweep
+ *      stops and removes aimee-server itself — the container running the deploy);
+ *   2. the LLM variant that was NOT selected is retired, so the mutually-exclusive
+ *      GPU/CPU services never both answer to the `aimee-llm` network name.
+ *
+ * deploy_apply.c is included directly to reach its static helpers; the two config
+ * symbols it calls are stubbed so the test needs no database. */
+
+/* deploy_apply.c calls execvpe(); its own _GNU_SOURCE lands after this file's
+ * includes have already pulled in <features.h>, so declare it up front here. */
+#define _GNU_SOURCE 1
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+#include "config_database.h"
+
+/* --- stubs for the config surface deploy_apply.c pulls in --- */
+
+static char g_stub_profiles[64] = "kb,llm-cpu";
+
+int config_load(config_t *cfg)
+{
+   if (cfg)
+      memset(cfg, 0, sizeof(*cfg));
+   return 0;
+}
+
+void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
+{
+   (void)cfg;
+   if (buf && n)
+      snprintf(buf, n, "COMPOSE_PROFILES=%s\n", g_stub_profiles);
+}
+
+#include "../server/deploy_apply.c"
+
+/* --- profiles_select: whole-entry matching, not substring --- */
+
+static void test_profiles_select(void)
+{
+   assert(profiles_select("kb,llm-cpu", "llm-cpu") == 1);
+   assert(profiles_select("kb,llm", "llm") == 1);
+   assert(profiles_select("kb", "llm") == 0);
+   assert(profiles_select("", "llm") == 0);
+   assert(profiles_select(NULL, "llm") == 0);
+
+   /* The regression that a substring match would cause: "llm-cpu" must NOT read as
+    * the GPU profile "llm", or the deploy would retire the variant it just brought
+    * up and leave the stale one running. */
+   assert(profiles_select("kb,llm-cpu", "llm") == 0);
+   assert(profiles_select("llm-cpu", "llm") == 0);
+
+   /* leading/trailing entries and a single entry */
+   assert(profiles_select("llm,kb", "llm") == 1);
+   assert(profiles_select("kb,llm", "kb") == 1);
+   assert(profiles_select("llm", "llm") == 1);
+   printf("  profiles_select ok\n");
+}
+
+/* --- envp_get --- */
+
+static void test_envp_get(void)
+{
+   char *envp[] = {(char *)"PATH=/bin", (char *)"COMPOSE_PROFILES=kb,llm", (char *)"X=1", NULL};
+   assert(strcmp(envp_get(envp, "COMPOSE_PROFILES"), "kb,llm") == 0);
+   assert(strcmp(envp_get(envp, "PATH"), "/bin") == 0);
+   assert(envp_get(envp, "MISSING") == NULL);
+   /* a prefix of a real key must not match */
+   assert(envp_get(envp, "COMPOSE") == NULL);
+   assert(envp_get(NULL, "PATH") == NULL);
+   printf("  envp_get ok\n");
+}
+
+/* --- envp_with_profile: replaces, never appends a second entry --- */
+
+static void test_envp_with_profile(void)
+{
+   char *envp[] = {(char *)"PATH=/bin", (char *)"COMPOSE_PROFILES=kb,llm-cpu", (char *)"X=1", NULL};
+   char **out = envp_with_profile(envp, "llm");
+   assert(out != NULL);
+
+   int profiles_seen = 0, path_seen = 0, x_seen = 0;
+   for (size_t i = 0; out[i]; i++)
+   {
+      if (strncmp(out[i], "COMPOSE_PROFILES=", 17) == 0)
+      {
+         profiles_seen++;
+         /* the forced value wins — a duplicate entry would leave the child's
+          * getenv() free to return the deploy's own selection instead */
+         assert(strcmp(out[i], "COMPOSE_PROFILES=llm") == 0);
+      }
+      else if (strcmp(out[i], "PATH=/bin") == 0)
+         path_seen = 1;
+      else if (strcmp(out[i], "X=1") == 0)
+         x_seen = 1;
+   }
+   assert(profiles_seen == 1);
+   assert(path_seen && x_seen);
+   free_envp(out);
+
+   /* an env with no COMPOSE_PROFILES still gains exactly one */
+   char *bare[] = {(char *)"PATH=/bin", NULL};
+   out = envp_with_profile(bare, "llm-cpu");
+   assert(out != NULL);
+   assert(strcmp(envp_get(out, "COMPOSE_PROFILES"), "llm-cpu") == 0);
+   free_envp(out);
+   printf("  envp_with_profile ok\n");
+}
+
+/* --- the deploy argv itself --- */
+
+static void test_deploy_argv_has_no_remove_orphans(void)
+{
+   char file[512];
+   deploy_apply_compose_file(file, sizeof(file));
+
+   const char *argv[8];
+   int n = deploy_up_argv(file, argv, sizeof(argv) / sizeof(argv[0]));
+   assert(n == 6);
+   assert(argv[n] == NULL);
+
+   /* The regression: --remove-orphans made compose stop and remove aimee-server,
+    * because the managed compose runs in the same project and does not declare it. */
+   for (int i = 0; i < n; i++)
+      assert(strcmp(argv[i], "--remove-orphans") != 0);
+
+   assert(strcmp(argv[0], "docker") == 0);
+   assert(strcmp(argv[1], "compose") == 0);
+   assert(strcmp(argv[2], "-f") == 0);
+   assert(strcmp(argv[3], file) == 0);
+   assert(strcmp(argv[4], "up") == 0);
+   assert(strcmp(argv[5], "-d") == 0);
+
+   /* a buffer with no room for the NULL terminator is refused, not overrun */
+   const char *tight[6];
+   assert(deploy_up_argv(file, tight, 6) == -1);
+   assert(deploy_up_argv(file, NULL, 8) == -1);
+   printf("  deploy argv omits --remove-orphans ok\n");
+}
+
+/* --- compose file resolution --- */
+
+static void test_compose_file_default(void)
+{
+   char file[512];
+   deploy_apply_compose_file(file, sizeof(file));
+   assert(file[0] == '/');
+   assert(strstr(file, "aimee-managed.compose.yaml") != NULL);
+   printf("  compose file default ok\n");
+}
+
+int main(void)
+{
+   printf("test_deploy_apply\n");
+   test_profiles_select();
+   test_envp_get();
+   test_envp_with_profile();
+   test_deploy_argv_has_no_remove_orphans();
+   test_compose_file_default();
+   printf("test_deploy_apply: all passed\n");
+   return 0;
+}


### PR DESCRIPTION
Twelve fixes found by installing the CPU stack from scratch on clean Debian 13
hosts and following the documented paths verbatim. Every one was reproduced on a
stock build first and verified live before and after.

## Release blockers

- **The whole KB write surface was dead over `/v1`.** `kb.build`, `kb.update`,
  `kb.ingest`, `kb.docs.push` and `graph.sync_code` replied from a detached
  thread, whose write lands after the op-run bridge has read and closed its
  socketpair — every one returned `rpc produced no response`, for thin clients
  and the browser alike. `index.scan` hit this once and was converted to reply
  inline; these five were left behind. Adds a lint gate (`async-op-handlers-check`)
  that fails on the pre-fix tree naming all eight affected methods.
- **`aimee-llm-cpu` could not be built at all.** The CPU synth tier pointed at
  `gemma-4-E4B-it-Q4_K_M.gguf`; ggml-org publishes only Q4_0/Q8_0/BF16, so the
  download 404'd. Repointed to Q4_0 with a pinned revision + sha256 — the cpu tier
  was also the only one tracking `main` with an empty checksum, silently skipping
  the supply-chain gate every other tier enforces.
- **Failed async runs were laundered into zero-valued success.** A failed op-run
  became an empty object, which printers rendered as `files indexed: 0, chunks
  added: 0` with **exit status 0**. That is what hid the blocker above from both
  humans and scripts.
- **`aimee kb build` was unreachable from any thin client** — path mapping,
  marshaller and printer all existed, but no dispatch row.

## Onboarding (clean-room run on a fresh host)

- QUICKSTART §1.3 told users to call `/v1/health` with `aimee-local-dev` and that
  200 means healthy. That bearer is one-time and enrollment-only, so a new user
  pastes the documented check and gets 401 while the guide claims success.
- Prerequisites understated disk by ~2x (measured 11.7 GB images + 7 GB volumes),
  omitted `git`/`curl`/`jq`, and described the CPU tier as downloading weights
  into a volume when they are baked into the image.
- `aimee remote set` exited 0 after a **failed** enrollment; `aimee remote status`
  reported "Reachable: yes" on a 401 and exited 0.
- `install-deps.sh` required `sudo` even as root, so it died on the most common
  first-run environment. `zlib1g-dev` was in neither the dependency list nor the
  docs, so both from-source paths failed to compile.

## Correctness / operability

- `workspace add` then `workspace list` raced (2 of 3 runs showed nothing): the
  server reads a config snapshot refreshed on a poll tick. Now 5/5.
- Unknown subcommands blamed the command — `aimee economizer status` said
  `command 'economizer' has no /v1 route; add a /v1 route` when the subcommand is
  `stats`. That message cost real diagnostic time.
- The roundtable reported "Go roundtable service is unreachable" for eight
  distinct failure modes, including the common one (deadline elapsed while the
  panel was still running). Diagnosing a live failure, that sent me looking for a
  missing process and socket; both were fine.

## Verification

Built and run on clean Debian 13 CTs: full CPU stack healthy (server, kb,
postgres, aimee-llm-cpu), embed/rerank/synth all serving, memory + KB semantic
retrieval working, state surviving a full restart, and the from-source
`install-deps.sh` + `install.sh` path completing as root.

`unit-test-deploy-apply`, `unit-test-cli-v1-subcommands`, `check-async-op-handlers`,
`check-cli-v1-routes` and `check-v1-route-order` all pass on the rebased tree.

Note: the `--remove-orphans` fix landed upstream independently while this was in
flight; the rebase keeps that version and adds the stale-LLM-variant retirement
on top.
