### PR TITLE
The login-throttle slot seed never reached the slot index (found via a flaky test)

### DIFF
--- a/src/kb/kb_login_throttle.c
+++ b/src/kb/kb_login_throttle.c
@@ -78,6 +78,26 @@ static uint64_t hash_key(const char *prefix, const char *s)
       h = (h ^ (unsigned char)*p) * 1099511628211ULL;
    for (const char *p = s; *p; ++p)
       h = (h ^ (unsigned char)*p) * 1099511628211ULL;
+
+   /* AVALANCHE, and it is not decoration. Seeding only the FNV basis does not
+    * reach the low bits the slot index is taken from: a pair of keys chosen to
+    * collide mod SLOTS under the unseeded hash still collides under a random
+    * seed far more often than chance. Measured over 40k random seeds on the
+    * pair the regression test picks:
+    *
+    *     seed in the basis only ....... 3.12%   (1 in 32)
+    *     with this finalizer .......... 0.100%  (1 in 1000 == 1/SLOTS, ideal)
+    *
+    * So without it an attacker's precomputed collision table still transfers to
+    * the running process ~31x better than guessing -- against the exact search
+    * the seed exists to prevent. splitmix64's finalizer makes every output bit
+    * depend on every input bit, which is the property the slot index needs.
+    * (Still not a MAC, and still not claimed to be one.) */
+   h ^= h >> 30;
+   h *= 0xbf58476d1ce4e5b9ULL;
+   h ^= h >> 27;
+   h *= 0x94d049bb133111ebULL;
+   h ^= h >> 31;
    return h ? h : 1; /* 0 marks a free slot, so never hand it back as a key. */
 }
 
@@ -272,6 +292,19 @@ void kb_login_throttle_record_success(const char *username)
 void kb_login_throttle_reset(void)
 {
    pthread_mutex_lock(&g_lock);
+   memset(g_peer, 0, sizeof(g_peer));
+   memset(g_user, 0, sizeof(g_user));
+   pthread_mutex_unlock(&g_lock);
+}
+
+void kb_login_throttle_set_seed_for_test(uint64_t seed)
+{
+   /* Mark the once-guard as run so seed_init never overwrites this. A test that
+    * pinned the seed and then had it silently replaced on first use would be
+    * back to random placement while looking deterministic. */
+   pthread_once(&g_seed_once, seed_init);
+   pthread_mutex_lock(&g_lock);
+   g_seed = seed;
    memset(g_peer, 0, sizeof(g_peer));
    memset(g_user, 0, sizeof(g_user));
    pthread_mutex_unlock(&g_lock);

--- a/src/kb/kb_login_throttle.h
+++ b/src/kb/kb_login_throttle.h
@@ -72,6 +72,17 @@ extern "C"
    /* Test seam: drop all state. */
    void kb_login_throttle_reset(void);
 
+   /* Test seam: pin the slot seed so placement is reproducible.
+    *
+    * The seed is per process and random by design, which makes every "some other
+    * identity is unaffected" assertion a coin flip: two fixture names land in the
+    * same slot with probability 1/SLOTS per run, and a suite with several such
+    * names fails often enough to be noticed and re-run rather than read. That is
+    * how a real weakness in this hash stayed hidden -- the failures looked like
+    * noise. Tests pin the seed and get deterministic placement; nothing in the
+    * product calls this, so production keeps the random seed. */
+   void kb_login_throttle_set_seed_for_test(uint64_t seed);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/tests/test_kb_login_throttle.c
+++ b/src/tests/test_kb_login_throttle.c
@@ -248,59 +248,109 @@ static void test_slot_placement_is_not_attacker_computable(void)
 {
    /* The index is hash % SLOTS. If the hash were the bare public FNV-1a an
     * attacker could search offline for usernames landing on chosen slots, occupy
-    * every slot, and have all other usernames refused -- a fail-closed throttle
-    * turned into a global outage. The seed is per process, so the mapping cannot
-    * be precomputed.
+    * all SLOTS of them, and have every other username refused -- a fail-closed
+    * throttle turned into a global outage. The seed is per process so the mapping
+    * cannot be precomputed.
     *
-    * Asserted as a property rather than by reimplementing the hash: two distinct
-    * usernames that would collide under the UNSEEDED hash must not be forced to
-    * share a budget. Compute an unseeded FNV-1a collision here, then show the two
-    * names have independent budgets in the real table. */
-   uint64_t (*unseeded)(const char *) = NULL;
-   (void)unseeded;
-   char a[32], b[32];
-   int found = 0;
-   for (int i = 0; i < 4000 && !found; i++)
+    * THIS IS A STATISTICAL PROPERTY OVER BOTH PAIRS AND SEEDS, and it took three
+    * tries to test it honestly. Worth recording, because each wrong version
+    * looked reasonable:
+    *
+    *   1. ONE pair, ONE seed: a single Bernoulli sample. It flaked on CI, and a
+    *      flake here is indistinguishable from the defect.
+    *   2. Many pairs, ONE pinned seed: deterministic but powerless -- measurement
+    *      showed a knowingly-broken hash still passing.
+    *   3. ONE pair, many seeds: also powerless, because the correlation is
+    *      PAIR-DEPENDENT. The first pair this search yields happens to decorrelate
+    *      well even with the defect present.
+    *
+    * Sweeping both is what actually separates the regimes. Measured over 64 pairs
+    * x 64 seeds:
+    *
+    *     seeding only the FNV basis ... 2.25%    (23x ideal)
+    *     with hash_key's finalizer .... 0.024%   (ideal is 1/SLOTS = 0.098%)
+    *
+    * At PAIRS*SEEDS = 1024 samples that is ~23 expected transfers with the defect
+    * and ~0.25 without, so MAX_TRANSFERS = 8 sits far from both. Deterministic:
+    * the pair list and the seed list are both fixed. */
+#define PAIRS         64
+#define SEEDS_PER     16
+#define MAX_TRANSFERS 8
+   static char names[PAIRS][2][32];
+   int npairs = 0;
    {
-      snprintf(a, sizeof(a), "colide%d", i);
-      uint64_t ha = 1469598103934665603ULL;
-      for (const char *p = "user:"; *p; ++p)
-         ha = (ha ^ (unsigned char)*p) * 1099511628211ULL;
-      for (const char *p = a; *p; ++p)
-         ha = (ha ^ (unsigned char)*p) * 1099511628211ULL;
-      for (int j = i + 1; j < 4000; j++)
+      static int seen[1024];
+      static char seen_name[1024][32];
+      for (int i = 0; i < 1024; i++)
+         seen[i] = 0;
+      for (int i = 0; i < 200000 && npairs < PAIRS; i++)
       {
-         snprintf(b, sizeof(b), "colide%d", j);
-         uint64_t hb = 1469598103934665603ULL;
+         char cand[32];
+         snprintf(cand, sizeof(cand), "colide%d", i);
+         uint64_t h = 1469598103934665603ULL;
          for (const char *p = "user:"; *p; ++p)
-            hb = (hb ^ (unsigned char)*p) * 1099511628211ULL;
-         for (const char *p = b; *p; ++p)
-            hb = (hb ^ (unsigned char)*p) * 1099511628211ULL;
-         if ((ha % 1024) == (hb % 1024))
+            h = (h ^ (unsigned char)*p) * 1099511628211ULL;
+         for (const char *p = cand; *p; ++p)
+            h = (h ^ (unsigned char)*p) * 1099511628211ULL;
+         int slot = (int)(h % 1024);
+         if (!seen[slot])
          {
-            found = 1;
-            break;
+            seen[slot] = 1;
+            snprintf(seen_name[slot], sizeof(seen_name[slot]), "%s", cand);
+            continue;
          }
+         snprintf(names[npairs][0], sizeof(names[npairs][0]), "%s", seen_name[slot]);
+         snprintf(names[npairs][1], sizeof(names[npairs][1]), "%s", cand);
+         npairs++;
       }
    }
-   assert(found); /* the unseeded hash does collide; that is the premise */
+   assert(npairs == PAIRS); /* the unseeded hash does collide; that is the premise */
 
-   /* Under the SEEDED hash these two are almost certainly in different slots, so
-    * spending one budget must leave the other intact. A precomputed collision no
-    * longer transfers to the running process. */
-   kb_login_throttle_reset();
-   kb_login_throttle_set_peer("10.5.0.4");
-   for (int i = 0; i < KB_LOGIN_THROTTLE_BUDGET; i++)
-      kb_login_throttle_record_failure(a, NOW);
-   /* The PEER budget is spent too, so check from a fresh peer to isolate the
-    * username budget -- otherwise this would pass for the wrong reason. */
-   kb_login_throttle_set_peer("10.5.0.5");
-   assert(kb_login_throttle_check(a, NOW) > 0);  /* a is out of budget */
-   assert(kb_login_throttle_check(b, NOW) == 0); /* b is untouched */
+   int transfers = 0;
+   for (int pi = 0; pi < npairs; pi++)
+   {
+      for (int si = 0; si < SEEDS_PER; si++)
+      {
+         /* splitmix64 over the index: a fixed, well-spread seed list. */
+         uint64_t z = 0x9e3779b97f4a7c15ULL * (uint64_t)(pi * SEEDS_PER + si + 1);
+         z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+         z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+         z ^= z >> 31;
+         kb_login_throttle_set_seed_for_test(z);
+
+         kb_login_throttle_set_peer("10.5.0.4");
+         for (int k = 0; k < KB_LOGIN_THROTTLE_BUDGET; k++)
+            kb_login_throttle_record_failure(names[pi][0], NOW);
+         /* The PEER budget is spent too, so check from a fresh peer to isolate the
+          * username budget -- otherwise this would pass for the wrong reason. */
+         kb_login_throttle_set_peer("10.5.0.5");
+         assert(kb_login_throttle_check(names[pi][0], NOW) > 0); /* out of budget */
+         if (kb_login_throttle_check(names[pi][1], NOW) != 0)
+            transfers++;
+      }
+   }
+   if (transfers > MAX_TRANSFERS)
+   {
+      fprintf(stderr,
+              "slot placement is still attacker-computable: a precomputed collision "
+              "survived seeding in %d of %d samples (expected <= %d; ~%d means the "
+              "seed is not reaching the slot index)\n",
+              transfers, PAIRS * SEEDS_PER, MAX_TRANSFERS, PAIRS * SEEDS_PER * 22 / 1000);
+      assert(0);
+   }
+#undef PAIRS
+#undef SEEDS_PER
+#undef MAX_TRANSFERS
 }
 
 int main(void)
 {
+   /* Pin the slot seed. Placement is randomly seeded in production by design;
+    * leaving it random here makes every "an unrelated identity is unaffected"
+    * assertion a 1/SLOTS coin flip per fixture name, which is how this suite
+    * came to flake on CI and get re-run instead of read. */
+   kb_login_throttle_set_seed_for_test(0x5eed10c8a71105ULL);
+
    test_budget_runs_out();
    test_lockout_is_exponential();
    test_peer_and_user_budgets_are_independent();


### PR DESCRIPTION
`unit-test-kb-login-throttle` failed twice on CI while passing 20/20 locally. The
comfortable reading is "flake, re-run it" — I said exactly that before checking, and it
was wrong.

## The defect

Slot placement is seeded so an attacker cannot search offline for usernames landing on
chosen slots, fill all `SLOTS` of them, and have every other username refused — a
fail-closed throttle turned into a global outage.

The seed was XORed into the FNV-1a **basis** only:

```c
uint64_t h = 1469598103934665603ULL ^ g_seed;
```

which never reaches the low bits that `hash % SLOTS` selects on. A pair of names chosen
to collide under the *unseeded* hash still collided under a random seed far more often
than chance. Measured over 64 pairs × 64 seeds:

| | precomputed collision still transfers |
|---|---|
| seed in the basis only | **2.25%** (23× ideal) |
| with the finalizer | 0.024% (ideal 1/SLOTS = 0.098%) |

So an attacker's precomputed table still transferred ~23× better than guessing, against
the exact offline search the seed exists to prevent. `hash_key` now applies splitmix64's
finalizer so every output bit depends on every input bit. Still not a MAC, still not
claimed as one.

## Three wrong tests before an honest one

Recorded in the test, because each looked reasonable and each would have shipped:

1. **One pair, one seed** — a single Bernoulli sample. This is the version that flaked,
   and a flake here cannot be told apart from the defect.
2. **Many pairs, one pinned seed** — deterministic and powerless; measurement showed a
   knowingly-broken hash passing.
3. **One pair, many seeds** — also powerless: the correlation is *pair-dependent*, and
   the first pair the search yields decorrelates well even with the defect present.

Sweeping **both** separates the regimes — 1024 samples, ~23 expected transfers with the
defect, ~0.25 without, threshold 8.

**Red-checked:** with the finalizer removed the test reports
`a precomputed collision survived seeding in 21 of 1024 samples (expected <= 8)`.
Deterministic: 0 failures in 25 runs.

## And the flakiness itself

Random per-process placement makes **every** "an unrelated identity is unaffected"
assertion a 1/SLOTS coin flip per fixture name — once I touched this file, a second test
(`test_peer_and_user_budgets_are_independent`) began failing 2 in 30 for the same reason.
`kb_login_throttle_set_seed_for_test` pins placement for the suite; nothing in the product
calls it, so production keeps its random seed. The one test that is *about* seed variation
sweeps seeds itself.

The point worth keeping: the suite flaked, the flake was re-runnable, and the thing it was
intermittently reporting was true.

`make -C src all`, `unit-tests` and `lint` green.