### PR TITLE
Do not seat a roundtable agent that is already at its limit

### DIFF
--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -498,6 +498,23 @@ type delegateCandidate struct {
 	Name, Provider, Model string
 	Roles, Personas       []string
 	MaxParallel           int
+	// ActiveDelegates is the agent's live occupancy as reported by the delegate
+	// service, or -1 when it did not report any. Unknown must behave as idle:
+	// this only orders and narrows candidates, so treating ignorance as "busy"
+	// would drop seats for a reason we cannot substantiate.
+	ActiveDelegates int
+}
+
+// freeSlots is how many more delegates this agent can take right now. Occupancy
+// the agent already carries counts against its cap, not just the seats being
+// assigned in this group -- a panel that ignores it seats a saturated agent and
+// the seat fails at admission with aimee_err=concurrency_limit.
+func (c delegateCandidate) freeSlots(groupUses int) int {
+	active := c.ActiveDelegates
+	if active < 0 {
+		active = 0
+	}
+	return c.MaxParallel - active - groupUses
 }
 
 func (c *HTTPAgentClient) planDelegateGroup(ctx context.Context, requests []DelegateRequest) ([]DelegateRequest, error) {
@@ -535,13 +552,29 @@ func (c *HTTPAgentClient) planDelegateGroup(ctx context.Context, requests []Dele
 		if !delegateSelectorUnbound(request.Delegate) || request.Participant != "" {
 			continue
 		}
+		// Prefer a seat that can actually start now, then fall back to the full
+		// eligible set. PREFER, never exclude: if every eligible agent is busy the
+		// seat is still filled and the dispatch is retried as capacity
+		// backpressure (isCapacityBackpressure), which is recoverable -- whereas
+		// refusing to route makes the whole panel unreachable, which is not.
 		best := -1
-		for j, candidate := range candidates {
-			if agentUses[candidate.Name] >= candidate.MaxParallel || !matchesSelector(candidate.Roles, request.Role) || !matchesSelector(candidate.Personas, request.Persona) {
-				continue
+		for _, freeOnly := range []bool{true, false} {
+			for j, candidate := range candidates {
+				if !matchesSelector(candidate.Roles, request.Role) || !matchesSelector(candidate.Personas, request.Persona) {
+					continue
+				}
+				if agentUses[candidate.Name] >= candidate.MaxParallel {
+					continue
+				}
+				if freeOnly && candidate.freeSlots(agentUses[candidate.Name]) < 1 {
+					continue
+				}
+				if best < 0 || candidateLess(candidate, candidates[best], providerUses, modelUses, agentUses) {
+					best = j
+				}
 			}
-			if best < 0 || candidateLess(candidate, candidates[best], providerUses, modelUses, agentUses) {
-				best = j
+			if best >= 0 {
+				break
 			}
 		}
 		if best < 0 {
@@ -595,15 +628,18 @@ func matchesSelector(values []string, wanted string) bool {
 func (c *HTTPAgentClient) delegateCandidates(ctx context.Context) ([]delegateCandidate, error) {
 	var response struct {
 		Agents []struct {
-			Name        string   `json:"name"`
-			Provider    string   `json:"provider"`
-			Model       string   `json:"model"`
-			Enabled     bool     `json:"enabled"`
-			Available   *bool    `json:"delegate_available"`
-			PrimaryOnly bool     `json:"primary_only"`
-			MaxParallel int      `json:"max_parallel"`
-			Roles       []string `json:"roles"`
-			Personas    []string `json:"personas"`
+			Name        string `json:"name"`
+			Provider    string `json:"provider"`
+			Model       string `json:"model"`
+			Enabled     bool   `json:"enabled"`
+			Available   *bool  `json:"delegate_available"`
+			PrimaryOnly bool   `json:"primary_only"`
+			MaxParallel int    `json:"max_parallel"`
+			// Absent when the delegate service cannot determine occupancy; a
+			// pointer so "absent" stays distinguishable from a reported zero.
+			ActiveDelegates *int     `json:"active_delegates"`
+			Roles           []string `json:"roles"`
+			Personas        []string `json:"personas"`
 		} `json:"agents"`
 	}
 	if err := c.doJSON(ctx, http.MethodGet, "/v1/agent/list", nil, &response); err != nil {
@@ -622,7 +658,12 @@ func (c *HTTPAgentClient) delegateCandidates(ctx context.Context) ([]delegateCan
 		if model == "" {
 			model = agent.Name
 		}
-		candidates = append(candidates, delegateCandidate{Name: agent.Name, Provider: provider, Model: model, Roles: agent.Roles, Personas: agent.Personas, MaxParallel: agent.MaxParallel})
+		active := -1
+		if agent.ActiveDelegates != nil {
+			active = *agent.ActiveDelegates
+		}
+		candidates = append(candidates, delegateCandidate{Name: agent.Name, Provider: provider, Model: model,
+			Roles: agent.Roles, Personas: agent.Personas, MaxParallel: agent.MaxParallel, ActiveDelegates: active})
 	}
 	return candidates, nil
 }

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -1069,3 +1069,140 @@ func TestHTTPAgentClientRequiresAuthenticationOffLoopback(t *testing.T) {
 		t.Fatalf("authenticated remote agent service rejected: %v", err)
 	}
 }
+
+// A panel seat must not be given to an agent that is already at max_parallel
+// while an idle agent is eligible. The router used to count only the seats it
+// was assigning in this group, so an agent saturated by other work still looked
+// free: the seat was dispatched, admission refused it with
+// aimee_err=concurrency_limit, and a panel needing 2 of 3 seats was reported
+// unreachable while another agent sat idle. Observed live on run wi_e51e37cf,
+// where every "claude" seat failed instantly with
+// "agent 'claude' at concurrency limit (max_parallel=3)".
+func TestGroupRoutingSkipsAnAgentAlreadyAtItsConcurrencyLimit(t *testing.T) {
+	var mu sync.Mutex
+	var vias []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/agent/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{"agents": []map[string]any{
+				// Saturated by work outside this group.
+				{"name": "busy", "provider": "p1", "model": "m1", "enabled": true, "max_parallel": 3,
+					"active_delegates": 3, "roles": []string{"review"}, "personas": []string{"all"}},
+				// Idle and equally eligible.
+				{"name": "idle", "provider": "p2", "model": "m2", "enabled": true, "max_parallel": 3,
+					"active_delegates": 0, "roles": []string{"review"}, "personas": []string{"all"}},
+			}})
+		case "/v1/delegate/run":
+			var payload map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			mu.Lock()
+			vias = append(vias, fmt.Sprint(payload["via"]))
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 1, "participant": "p"})
+		case "/v1/delegate/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "done", "result": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, PollEvery: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.DelegateGroup(t.Context(), []DelegateRequest{
+		{Role: "review", Persona: "architect", Prompt: "review"},
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	if len(vias) != 1 {
+		t.Fatalf("expected one dispatch, got %v", vias)
+	}
+	if vias[0] != "idle" {
+		t.Fatalf("seat routed to %q; a saturated agent must not be preferred over an idle one", vias[0])
+	}
+}
+
+// PREFER, never exclude: when every eligible agent is saturated the seat must
+// still be filled. Dispatch then fails as capacity backpressure, which the
+// engine retries -- refusing to route instead makes the panel unreachable,
+// which it does not recover from.
+func TestGroupRoutingStillFillsASeatWhenEveryAgentIsSaturated(t *testing.T) {
+	var mu sync.Mutex
+	var vias []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/agent/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{"agents": []map[string]any{
+				{"name": "busy-a", "provider": "p1", "model": "m1", "enabled": true, "max_parallel": 2,
+					"active_delegates": 2, "roles": []string{"review"}, "personas": []string{"all"}},
+				{"name": "busy-b", "provider": "p2", "model": "m2", "enabled": true, "max_parallel": 2,
+					"active_delegates": 5, "roles": []string{"review"}, "personas": []string{"all"}},
+			}})
+		case "/v1/delegate/run":
+			var payload map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			mu.Lock()
+			vias = append(vias, fmt.Sprint(payload["via"]))
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 1, "participant": "p"})
+		case "/v1/delegate/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "done", "result": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, PollEvery: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.DelegateGroup(t.Context(), []DelegateRequest{
+		{Role: "review", Persona: "architect", Prompt: "review"},
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	if len(vias) != 1 {
+		t.Fatalf("a saturated roster must still fill the seat, got dispatches %v", vias)
+	}
+}
+
+// An agent that reports no occupancy at all (older delegate service) must keep
+// its previous behaviour and stay routable -- absent must not read as "busy".
+func TestGroupRoutingTreatsUnreportedOccupancyAsRoutable(t *testing.T) {
+	var mu sync.Mutex
+	var vias []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/agent/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{"agents": []map[string]any{
+				{"name": "unreported", "provider": "p1", "model": "m1", "enabled": true, "max_parallel": 1,
+					"roles": []string{"review"}, "personas": []string{"all"}},
+			}})
+		case "/v1/delegate/run":
+			var payload map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			mu.Lock()
+			vias = append(vias, fmt.Sprint(payload["via"]))
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 1, "participant": "p"})
+		case "/v1/delegate/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "done", "result": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, PollEvery: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.DelegateGroup(t.Context(), []DelegateRequest{
+		{Role: "review", Persona: "architect", Prompt: "review"},
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	if len(vias) != 1 || vias[0] != "unreported" {
+		t.Fatalf("unreported occupancy must stay routable, got %v", vias)
+	}
+}

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -127,6 +127,9 @@ void agent_set_route_policy_filter(int (*fn)(const agent_t *agent));
  * "no agent available", and blocking admission still waits for a slot. An
  * unknown answer (-1, or no probe) counts as "has capacity". */
 void agent_set_route_capacity_probe(int (*fn)(const char *agent_name));
+/* Live delegate occupancy for `agent_name`, or -1 when unknown. Lets the served
+ * agent list publish occupancy to out-of-process routers (the Go WFE). */
+int agent_route_agent_active(const char *agent_name);
 
 /* Primary-turn marker for the delegate-policy filter. The PRIMARY chat turn
  * routes the provider-named agent through the same machinery as delegation

--- a/src/server/agent_route.c
+++ b/src/server/agent_route.c
@@ -163,6 +163,22 @@ void agent_set_route_capacity_probe(int (*fn)(const char *agent_name))
    g_route_capacity_probe = fn;
 }
 
+/* How many delegates is this agent running right now, or -1 when that is not
+ * knowable here (no probe registered, or the controller is unconfigured).
+ *
+ * Exposed so the agent list served over /v1 can publish live occupancy. The Go
+ * WFE routes seats in a separate process and cannot call the in-process probe
+ * above, so without this it can only see max_parallel and will happily seat an
+ * agent that is already saturated — the seat then fails at admission with
+ * AGENT_RC_AT_LIMIT. Keeps the same hook indirection, so this unit still has no
+ * link dependency on the admission controller. */
+int agent_route_agent_active(const char *agent_name)
+{
+   if (!g_route_capacity_probe || !agent_name || !agent_name[0])
+      return -1;
+   return g_route_capacity_probe(agent_name);
+}
+
 /* Does this agent have a free concurrency slot right now? Returns 1 when it
  * does, and ALSO when capacity is unknown — no probe registered, controller
  * unconfigured (-1), or an agent with no per-agent cap. Unknown must read as

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -477,6 +477,12 @@ static cJSON *server_agent_to_json(const agent_t *ag)
    cJSON_AddBoolToObject(obj, "primary_only", ag->primary_only);
    cJSON_AddNumberToObject(obj, "max_turns", ag->max_turns);
    cJSON_AddNumberToObject(obj, "max_parallel", ag->max_parallel);
+   /* Live occupancy, so an out-of-process router (the Go WFE) can avoid seating
+    * an agent that is already at max_parallel. Omitted entirely when unknown --
+    * a consumer must not read "absent" as "idle". */
+   int active = agent_route_agent_active(ag->name);
+   if (active >= 0)
+      cJSON_AddNumberToObject(obj, "active_delegates", active);
    if (ag->middleware.context_window > 0)
       cJSON_AddNumberToObject(obj, "context_window", ag->middleware.context_window);
    cJSON *roles = cJSON_CreateArray();


### PR DESCRIPTION
The Go router counted only the seats it was assigning **in the current group**, so an agent saturated by other work still looked free. The seat was dispatched, the C admission controller refused it with `aimee_err=concurrency_limit`, and a panel needing 2 of 3 seats was reported `panel_unreachable` — while another agent sat idle.

## Observed live

On run `wi_e51e37cf`, every `claude` seat failed instantly:

```
agent 'claude' at concurrency limit (max_parallel=3) [aimee_err=concurrency_limit]
```

This looked like a broken provider backend for hours. It isn't — the agent was simply busy, and the router picked it anyway.

Working around it by pinning all three seats to one agent made each panel pass take 10+ minutes against the preset deadline, and the plan gate stopped converging. **This is the defect that actually blocks a run from reaching slices.**

## Why the existing fix didn't cover it

#2016 fixed this in the **C** router via an in-process capacity probe. The Go WFE routes in a separate process and cannot call that probe, so occupancy has to cross the wire:

- `agent_route_agent_active()` exposes the existing probe result, keeping the same hook indirection so `agent_route.c` gains **no** link dependency on the admission controller
- the served agent list publishes it as `active_delegates`, **omitted entirely when unknown** so a consumer cannot read absent as idle
- the Go router prefers candidates with a free slot, counting occupancy the agent already carries as well as the seats being assigned now

This is the third instance of the same class: a fix landed in C while production runs Go (see #2017, #2023).

## PREFER, never exclude

Matching the C rule. If every eligible agent is saturated the seat is **still filled**, and the dispatch fails as capacity backpressure, which `isCapacityBackpressure` already treats as retryable. Refusing to route would convert a recoverable wait into an unreachable panel.

## Verification

Red before green against the original selection loop — it routes the seat to the saturated agent, reproducing the live failure:

```
seat routed to "busy"; a saturated agent must not be preferred over an idle one
```

Three tests: saturated agent skipped for an idle one; a fully saturated roster still fills the seat; unreported occupancy stays routable (older delegate service).

- `go build`, `go vet`, `gofmt -l` — clean
- `go test ./...` — all packages pass
- `make ../aimee-server` — builds under `-Wall -Wextra -Werror`
- `unit-test-roundtable-seat-resolve` — passes