### PR TITLE
The cpu synth model filename 404s, which blocks every release

### DIFF
--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -73,7 +73,7 @@ rerank_coords() {
 synth_coords() {
   case "$SYNTH_TIER" in
     cpu)
-      SYNTH_REPO="ggml-org/gemma-4-E4B-it-GGUF"; SYNTH_FILE="gemma-4-E4B-it-Q4_K_M.gguf"
+      SYNTH_REPO="ggml-org/gemma-4-E4B-it-GGUF"; SYNTH_FILE="gemma-4-E4B-it-Q4_0.gguf"
       SYNTH_REVISION="main"; SYNTH_SHA256=""
       TIER_FA="off"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; TIER_CTX="32768"; SYNTH_NGL=0
       ;;


### PR DESCRIPTION
One line. Unblocks all image publishing.

## What is broken

`ggml-org/gemma-4-E4B-it-GGUF` does not contain `gemma-4-E4B-it-Q4_K_M.gguf`. The repo
is fine (200); that quantization simply is not published in it — the file list is
BF16 / Q4_0 / Q8_0 (plus mmproj and mtp variants). So the request 404s:

```
aimee-llm: fetching synth tier 'cpu' into /models/cpu
aimee-llm: download FAILED: .../gemma-4-E4B-it-Q4_K_M.gguf
aimee-llm: pre-bake download failed
```

## Why it blocks far more than one model

`aimee-llm-cpu` bakes models at build time, so the 404 fails that image on both amd64
and arm64 → fails the `images` job → fails **auto-release**. auto-release is what
publishes `aimee-server` and `aimee-kb` as well, so one dead URL has stopped **all**
image publishing since **2026-07-14**.

Consequence, measured on a clean install today (#2020): every published image is 13 days
to 4 weeks stale, and two new-user blockers turned out to be fixes that already existed
in the repo and had simply never shipped.

## Why it lands on main directly

`testing` already carries the corrected filename — but releases only fire on a push to
`main`, and `main` is where the dead URL lives. The fix for the broken pipeline could
not itself be published. This breaks that deadlock with the smallest possible change.

## Verification

Both cpu-tier URLs checked before proposing:

```
200  Qwen/Qwen3-Embedding-0.6B-GGUF/.../Qwen3-Embedding-0.6B-f16.gguf
200  ggml-org/gemma-4-E4B-it-GGUF/.../gemma-4-E4B-it-Q4_0.gguf
```

Deliberately minimal — a new LLM is landing soon, so this only unblocks publishing rather
than revisiting tier selection. Merging cuts a release from main's current code; promoting
`testing` (647 commits, including today's eight fixes) remains a separate decision.