### PR TITLE
The "tampered signature" check did not always tamper

### DIFF
--- a/scripts/run-write-tier-enforce-live.sh
+++ b/scripts/run-write-tier-enforce-live.sh
@@ -219,7 +219,22 @@ deny "wrong issuer          " "$(./write-tier-enforce-live mint --key "$TOKEN_KE
 # unknown to this server.
 ./write-tier-enforce-live provision --db1 "$work/other.db" --bundle "$work/other.pem" --key "$work/other-key.pem" >/dev/null 2>&1
 deny "signed by a foreign key" "$(./write-tier-enforce-live mint --key "$work/other-key.pem" --aud "$SERVER_ID" --team $TEAM_ID --sub 'oidc:test:alice' --tier full --jti enf-$$-key)"
-deny "tampered signature    " "$(mint full | sed 's/.$/A/')"
+# The mutation must be GUARANTEED to change the token. `sed 's/.$/A/'` did not:
+# when the signature already ended in 'A' it rewrote 'A' as 'A', left the token
+# byte-identical, and the server correctly accepted it -- so the rig reported
+# "tampered signature -> 200 (expected a refusal)" and a green build failed
+# claiming the signature check was broken. Base64url gives that a ~1-in-64 chance
+# per run; observed on CI. Flip the last character to a DIFFERENT one instead.
+orig_tok=$(mint full)
+case "$orig_tok" in
+  *A) tampered="${orig_tok%?}B" ;;
+  *)  tampered="${orig_tok%?}A" ;;
+esac
+if [ "$tampered" = "$orig_tok" ]; then
+  fail "tampered signature: the mutation left the token unchanged, so this proves nothing"
+else
+  deny "tampered signature    " "$tampered"
+fi
 
 # --- 4. no token at all ----------------------------------------------------
 # The legacy-cutover half of §11: a valid shared bearer, and nothing else, must


### PR DESCRIPTION
```
FAIL tampered signature -> 200 (expected a refusal)
```

Seen on CI. It reads as signature verification being broken. It is not — **the rig
failed to tamper**.

## Cause

```bash
deny "tampered signature" "$(mint full | sed 's/.$/A/')"
```

The mutation rewrites the last character as `A`. When the signature already **ends in
`A`**, that rewrites `A` as `A`: the token is byte-identical, the server correctly
accepts it, and the rig reports the gate as broken. Base64url's alphabet makes that
roughly **1 run in 64**.

Verified exhaustively over the alphabet:

```
chars where the OLD mutation was a no-op: ['A']
chars where the NEW mutation is a no-op:  []
```

## Why it matters more than a flake

It is flaky **and, when it flakes, it cries security failure**. A blocking gate that
occasionally claims signature verification is broken trains people to re-run it — which
is exactly how a real failure would get waved through.

## Fix

Flip the last character to a *different* one (`A` → `B`, anything else → `A`) so the
token always changes. And assert the mutation actually happened rather than assuming it:

```bash
if [ "$tampered" = "$orig_tok" ]; then
  fail "tampered signature: the mutation left the token unchanged, so this proves nothing"
else
  deny "tampered signature    " "$tampered"
fi
```

That second half matters more than the flip. A check that can silently degrade into a
no-op is the same defect class as the false successes fixed elsewhere today — this one
merely fails loudly by luck rather than passing quietly.

Found while investigating a failure on #2040, which is unrelated to that PR's change.