### PR TITLE
Codex tool calls were collected off the stream and then thrown away

### DIFF
--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -1065,13 +1065,35 @@ native_provider_http:
             }
             for (const char *q = b; (q = strstr(q, "\"type\":\"reasoning\"")) != NULL; q++)
                n_reasoning++;
+            /* Name the item types actually arriving: counting only "reasoning"
+             * left four items per turn unaccounted for once reasoning intent was
+             * declared. Collect the item.type of every output_item.done. */
+            char types[512] = "";
+            for (const char *q = b; (q = strstr(q, "event: response.output_item.done")) != NULL;
+                 q++)
+            {
+               const char *it = strstr(q, "\"item\":{");
+               if (!it)
+                  break;
+               const char *ty = strstr(it, "\"type\":\"");
+               if (!ty)
+                  continue;
+               ty += 8;
+               const char *end = strchr(ty, '"');
+               if (!end || end - ty > 40)
+                  continue;
+               char one[64];
+               snprintf(one, sizeof(one), "%.*s,", (int)(end - ty), ty);
+               if (strlen(types) + strlen(one) < sizeof(types) - 1)
+                  strcat(types, one);
+            }
             const char *tail = blen > 600 ? b + blen - 600 : b;
             LOG_WARN("agent",
                      "delegate '%s': responses body parsed but yielded no content and no tool "
                      "call; %zu bytes, events: output_item.done=%d output_text.delta=%d "
-                     "completed=%d failed=%d reasoning_items=%d; tail: %.600s",
+                     "completed=%d failed=%d reasoning_items=%d; item_types=[%s]; tail: %.400s",
                      agent->name, blen, n_item_done, n_delta, n_completed, n_failed, n_reasoning,
-                     tail);
+                     types, tail);
          }
       }
       else

--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -605,6 +605,22 @@ static void responses_parse_sse_events(const char *body, parsed_response_t *out,
    free(data);
 }
 
+/* 1 if `resp`'s output array already carries a function_call item. */
+static int responses_object_has_function_call(cJSON *resp)
+{
+   cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+   if (!cJSON_IsArray(output))
+      return 0;
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, output)
+   {
+      cJSON *type = cJSON_GetObjectItemCaseSensitive(item, "type");
+      if (type && cJSON_IsString(type) && strcmp(type->valuestring, "function_call") == 0)
+         return 1;
+   }
+   return 0;
+}
+
 /* 1 if `resp`'s output array already carries a non-empty output_text part. */
 static int responses_object_has_output_text(cJSON *resp)
 {
@@ -661,9 +677,39 @@ cJSON *agent_responses_sse_response_object(const char *body)
    responses_take_longer_content(&scratch, &part_text);
    responses_take_longer_content(&scratch, &done_text);
    responses_take_longer_content(&scratch, &delta_text);
-   cJSON_Delete(collected);
 
    cJSON *resp = completed ? completed : cJSON_Parse(body);
+   /* Codex's response.completed payload can arrive with an output array that
+    * omits the items it already streamed -- the same emptiness handled for text
+    * just below. A function_call delivered via response.output_item.done was
+    * therefore collected here and then thrown away with `collected`, so the
+    * whole turn produced no tool call and no text: the delegate reported
+    * "no content in final response" with tool_calls=0 on every attempt.
+    * Measured on a live codex turn: item_types=[reasoning,function_call] on the
+    * wire, zero tool calls extracted.
+    *
+    * Fold the streamed function_call items back in when the response object
+    * carries none of its own. Never when it does -- the completed payload is
+    * authoritative whenever it is populated. */
+   if (resp && !responses_object_has_function_call(resp))
+   {
+      const cJSON *item = NULL;
+      cJSON_ArrayForEach(item, collected)
+      {
+         const cJSON *type = cJSON_GetObjectItemCaseSensitive((cJSON *)item, "type");
+         if (!cJSON_IsString(type) || strcmp(type->valuestring, "function_call") != 0)
+            continue;
+         cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+         if (!cJSON_IsArray(output))
+            output = cJSON_AddArrayToObject(resp, "output");
+         cJSON *dup = cJSON_Duplicate(item, 1);
+         if (output && dup)
+            cJSON_AddItemToArray(output, dup);
+         else
+            cJSON_Delete(dup);
+      }
+   }
+   cJSON_Delete(collected);
    if (resp && scratch.content && scratch.content[0] && !responses_object_has_output_text(resp))
    {
       cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -66,6 +66,8 @@ void test_escalation_respects_policy_and_health_gates(void);
 void test_responses_parser_keeps_all_output_text_parts(void);
 void test_responses_parser_accumulates_output_text_deltas(void);
 void test_responses_object_folds_in_delta_text(void);
+void test_responses_object_folds_in_streamed_function_call(void);
+void test_responses_object_keeps_existing_function_call(void);
 void test_responses_object_keeps_existing_text(void);
 void test_ir_parse_responses_tool_call(void);
 void test_ir_parse_responses_text_only(void);
@@ -3320,6 +3322,8 @@ int main(void)
    test_responses_parser_keeps_all_output_text_parts();
    test_responses_parser_accumulates_output_text_deltas();
    test_responses_object_folds_in_delta_text();
+   test_responses_object_folds_in_streamed_function_call();
+   test_responses_object_keeps_existing_function_call();
    test_responses_object_keeps_existing_text();
    test_ir_parse_responses_tool_call();
    test_ir_parse_responses_text_only();

--- a/src/tests/test_agent_responses.c
+++ b/src/tests/test_agent_responses.c
@@ -101,6 +101,75 @@ void test_responses_object_folds_in_delta_text(void)
    cJSON_Delete(resp);
 }
 
+/* The codex wire delivers a function_call as a response.output_item.done event and
+ * its response.completed event carries "output":[] -- exactly the emptiness the text
+ * case above handles. The streamed call was collected and then discarded, so
+ * responses_backend_parse saw no tool call and the delegate reported
+ * "no content in final response" with tool_calls=0 on every attempt, at turn 1,
+ * forever. Measured live: item_types=[reasoning,function_call] on the wire, zero
+ * tool calls extracted. Fold the streamed call back in, as the text is. */
+void test_responses_object_folds_in_streamed_function_call(void)
+{
+   const char *body =
+       "event: response.output_item.done\r\n"
+       "data: {\"item\":{\"type\":\"reasoning\",\"summary\":\"thinking\"}}\r\n\r\n"
+       "event: response.output_item.done\r\n"
+       "data: {\"item\":{\"type\":\"function_call\",\"call_id\":\"call_42\","
+       "\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"/tmp/x\\\"}\"}}\r\n\r\n"
+       "event: response.completed\r\n"
+       "data: {\"response\":{\"output\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":7}}}"
+       "\r\n\r\n";
+
+   struct cJSON *resp = agent_responses_sse_response_object(body);
+   assert(resp != NULL);
+   struct cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+   assert(cJSON_IsArray(output));
+   struct cJSON *item = NULL;
+   const char *name = NULL, *call_id = NULL;
+   cJSON_ArrayForEach(item, output)
+   {
+      struct cJSON *type = cJSON_GetObjectItemCaseSensitive(item, "type");
+      if (type && cJSON_IsString(type) && strcmp(type->valuestring, "function_call") == 0)
+      {
+         struct cJSON *n = cJSON_GetObjectItemCaseSensitive(item, "name");
+         struct cJSON *c = cJSON_GetObjectItemCaseSensitive(item, "call_id");
+         name = n && cJSON_IsString(n) ? n->valuestring : NULL;
+         call_id = c && cJSON_IsString(c) ? c->valuestring : NULL;
+      }
+   }
+   assert(name != NULL && strcmp(name, "read_file") == 0);
+   assert(call_id != NULL && strcmp(call_id, "call_42") == 0);
+   cJSON_Delete(resp);
+}
+
+/* Never duplicate a call the completed payload already carries -- that payload is
+ * authoritative whenever it is populated, and a doubled call would be executed twice. */
+void test_responses_object_keeps_existing_function_call(void)
+{
+   const char *body =
+       "event: response.output_item.done\r\n"
+       "data: {\"item\":{\"type\":\"function_call\",\"call_id\":\"call_7\","
+       "\"name\":\"list_files\",\"arguments\":\"{}\"}}\r\n\r\n"
+       "event: response.completed\r\n"
+       "data: {\"response\":{\"output\":[{\"type\":\"function_call\",\"call_id\":\"call_7\","
+       "\"name\":\"list_files\",\"arguments\":\"{}\"}],\"usage\":{\"input_tokens\":1,"
+       "\"output_tokens\":2}}}\r\n\r\n";
+
+   struct cJSON *resp = agent_responses_sse_response_object(body);
+   assert(resp != NULL);
+   struct cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+   int calls = 0;
+   struct cJSON *item = NULL;
+   cJSON_ArrayForEach(item, output)
+   {
+      struct cJSON *type = cJSON_GetObjectItemCaseSensitive(item, "type");
+      if (type && cJSON_IsString(type) && strcmp(type->valuestring, "function_call") == 0)
+         calls++;
+   }
+   assert(calls == 1);
+   cJSON_Delete(resp);
+}
+
 /* Guard against double-injection: when the completed object ALREADY carries the
  * message text (non-codex responses that repeat it in output[]), the extractor must
  * leave a single output_text -- not append a duplicate. */


### PR DESCRIPTION
Every codex delegate failed identically — `turn 1`, `tool_calls=0`, `no content in final response` — on two hosts, for days. **The model was calling tools the whole time; we discarded them.**

## The defect

`agent_responses_sse_response_object` parses the SSE stream into `collected`, which holds every output item. It then builds the response object the IR consumes from the `response.completed` payload **alone**, and deletes `collected`.

Codex's completed payload arrives with an empty `output` array — the exact emptiness this function *already handles for text*, folding the SSE-aggregated text back in (with a comment saying codex's completed body "is often EMPTY"). The same emptiness for a `function_call` was never handled. So a tool call delivered via `response.output_item.done` was collected, dropped, and the turn produced neither content nor a call.

## Evidence from the live wire

Captured with the temporary diagnostics from #2034 and #2038:

```
95072 bytes, output_item.done=2, output_text.delta=0, completed=1,
item_types=[reasoning,function_call]
```

A `function_call` plainly on the wire; zero tool calls extracted.

## The fix

Fold the streamed `function_call` items back into the response object when it carries none of its own — mirroring the text path directly above it. **Never** when it does: the completed payload stays authoritative whenever populated, so a call cannot be executed twice.

## Verified on a live codex delegate

It read a file containing a random token generated seconds earlier and returned it exactly — impossible without a real tool call:

| | before | after |
|---|---|---|
| turns | 1 | **5** |
| API calls | 2 | 6 |
| tool calls | 0 | executed |
| result | `no content in final response` | `SECRET_MARKER=zx1785170808qq7` |

Red before green: without the fold-back, `test_responses_object_folds_in_streamed_function_call` fails on the missing `read_file` call. A second test pins the no-duplication case. `unit-test-agent` passes in full.

## Also included

The `item_types=[...]` diagnostic that located this, so the next wire-shape defect is one log line away instead of a rebuild.

## What this supersedes

Earlier explanations of this failure were wrong and are corrected by this: it is not a provider fault, not auth (HTTP 200 throughout), not a tool budget (never spent), and not the missing `ChatGPT-Account-ID` header. It is ours.