### PR TITLE
docs: rewrite documentation for the event bus release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Small, finished changes are easiest to review.
+
+## Before you change code
+
+1. Search memory and the code graph before reading the tree by hand.
+2. Read [OWNERS.md](OWNERS.md) for module and storage boundaries.
+3. Check [docs/proposals](docs/proposals/) for an accepted design or an owner already doing the work.
+4. Preview the blast radius for shared symbols, routes, config, storage, and wire contracts.
+
+Do not cross the DB1/DB2 boundary. `aimee-server` owns SQLite. `aimee-kb` owns PostgreSQL and
+pgvector. The thin client owns neither.
+
+## Build and test
+
+From `src/`:
+
+```bash
+make -j4
+make unit-tests
+make lint
+make docs-gen-check
+```
+
+Run the narrow test target while iterating. Run the full unit suite before sending a change. Add
+ASAN or TSAN for memory ownership, concurrency, event-bus, and shutdown work.
+
+The Makefile is canonical. Keep CMake in sync for Windows and macOS builds.
+
+## Change contracts, not copies
+
+- Commands come from the command registry and CLI help data.
+- `/v1` routes come from the route descriptors and OpenAPI sources.
+- Configuration comes from the field descriptors.
+- Event-bus frames and kinds are versioned contracts shared by C and Go.
+
+Regenerate documentation after changing one of those sources. Do not hand-edit files under
+`docs/gen/`.
+
+## Documentation
+
+Write short, direct prose. State what is true, the boundary, and the failure behavior. Put current
+usage in a guide and design history in a proposal. Do not copy command or configuration tables that
+can be generated.
+
+Update [README.md](README.md), [What's new](docs/WHATS_NEW.md), and [status](docs/STATUS.md) when a
+change alters the product surface.
+
+## Pull requests
+
+Keep one purpose per PR. Include:
+
+- the problem and the contract changed;
+- tests run and their result;
+- compatibility or migration notes;
+- security and failure behavior when the change crosses a trust boundary.
+
+Do not include generated artifacts without their source change.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,1741 +1,416 @@
-# The aimee Manual
+# The aimee manual
 
-A complete, exhaustive reference for installing, configuring, operating, and
-mastering aimee. If you want a quick overview, start with the
-[README](README.md). If you want code-level internals, see
-[`src/README.md`](src/README.md) and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+aimee gives AI tools one memory, one code graph, controlled delegates, typed workflows, and a
+server-side safety boundary. The CLI, browser, MCP, ACP, and compatible model APIs all reach the
+same runtime.
 
-This manual is organized so you can read it front-to-back the first time and use
-it as a lookup reference afterward.
+Use the [Quickstart](docs/QUICKSTART.md) for installation. This manual covers normal use and
+operations. Exact command and config tables are generated from source:
 
----
+- [CLI commands](docs/gen/cli-commands.md)
+- [Configuration](docs/gen/configuration.md)
+- [HTTP routes](docs/gen/api-v1.md)
 
-## Table of contents
+## The system
 
-1. [What aimee is](#1-what-aimee-is)
-2. [Concepts and mental model](#2-concepts-and-mental-model)
-3. [Installation](#3-installation)
-4. [Updating and uninstalling](#4-updating-and-uninstalling)
-5. [Configuration reference](#5-configuration-reference)
-6. [The command line](#6-the-command-line)
-7. [Command reference](#7-command-reference)
-8. [Memory](#8-memory)
-9. [Working memory](#9-working-memory)
-10. [Rules and feedback](#10-rules-and-feedback)
-11. [Guardrails and safety](#11-guardrails-and-safety)
-12. [The code index](#12-the-code-index)
-13. [Delegation](#13-delegation)
-14. [Roadmaps and the autonomous loop](#14-roadmaps-and-the-autonomous-loop)
-15. [The work queue](#15-the-work-queue)
-16. [Skills and toolsets](#16-skills-and-toolsets)
-17. [Sessions and worktrees](#17-sessions-and-worktrees)
-18. [Providers, models, and agents](#18-providers-models-and-agents)
-19. [Identity, charter, and personas](#19-identity-charter-and-personas)
-20. [Triggers, cron, and automation](#20-triggers-cron-and-automation)
-21. [The knowledge base](#21-the-knowledge-base)
-22. [The MCP server](#22-the-mcp-server)
-23. [Webchat and the browser UI](#23-webchat-and-the-browser-ui)
-24. [The HTTP /v1 API](#24-the-http-v1-api)
-25. [Integrations](#25-integrations)
-26. [Server and service management](#26-server-and-service-management)
-27. [Operations and deployment](#27-operations-and-deployment)
-28. [Troubleshooting](#28-troubleshooting)
-29. [Appendix A, Environment variables](#appendix-a-environment-variables)
-30. [Appendix B, Files and paths](#appendix-b-files-and-paths)
-31. [Appendix C, Glossary](#appendix-c-glossary)
+- `aimee` is a DB-free thin client. It runs hooks and stdio integrations, reads client files, and
+  sends typed requests.
+- `aimee-server` owns sessions, DB1, agents, tools, policy, credentials, provider calls, and the
+  public resource API.
+- `aimee-wfe` owns workflow definitions and lifecycle state.
+- `aimee-kb` owns durable memory, documents, the code graph, retrieval, curation, PostgreSQL, and
+  pgvector.
+- `aimee-llm` serves embedding, reranking, and synthesis on CPU or GPU.
+- `aimee-runtime-web` serves the browser workspace.
 
----
+The server and KB each run a bounded shared-memory event bus. Governed actions, memory mutations,
+guardrail decisions, vault access, sandbox degradation, MCP activity, and tool outcomes pass through
+one ordered audit tap. See [Event bus](docs/EVENT_BUS.md).
 
-## 1. What aimee is
+## First use
 
-aimee gives your AI coding tool a memory, and lets you run that tool on any
-model you like. It is a local-first layer that sits between you and tools like
-Claude Code, Codex, OpenCode, Gemini CLI, Mistral Vibe, and GitHub Copilot. One
-UI, any model, and a memory that travels with you between every model and
-provider, so switching never starts from zero and is never locked to a vendor
-(see [§25, Integrations](#25-integrations) for pointing a tool's front end at
-aimee). On top of that it adds three things your tools lack:
-
-- **Persistent memory** that compounds across sessions and across tools, so your
-  AI starts every session already knowing your infrastructure, conventions,
-  decisions, and past mistakes.
-- **Guardrails** that classify and block dangerous edits (secrets, production
-  configs), warn on known anti-patterns, and lock writes during planning.
-- **Delegation** that routes routine work (summaries, formatting, review,
-  boilerplate) to cheaper or free models, so your primary agent only handles
-  what needs its full capability.
-
-It integrates through **hooks** (intercepting tool calls) and **MCP** (exposing
-memory and code knowledge as tools). The core is written in C for speed, the
-CLI starts in under 10 ms and a pre-tool guardrail check adds about 1 ms, and it
-has **zero cloud dependencies**: everything runs on your machine, and external
-model providers are reached only when you explicitly delegate.
-
-### The four artifacts
-
-| Binary | Role |
-|--------|------|
-| `aimee` | The thin CLI you run. Holds no database; forwards typed requests to `aimee-server`. Also hosts the MCP bridge (`aimee mcp-serve`). |
-| `aimee-server` | The persistent local hub. Owns local state (DB1/SQLite), runs the compute pool, routes delegates, serves hooks, exposes the RPC and HTTP /v1 surfaces. |
-| `aimee-kb` | The knowledge service. Owns DB2 (Postgres + pgvector), which may be a local single-user database or a shared knowledge service: memories, rules, code index, embeddings, ingest/curator. |
-| `aimee-runtime-web` | A standalone Go service that serves the browser UI and proxies to `aimee-server`. |
-
-(An optional `aimee-gateway` adds ambient-presence delivery, Telegram/ntfy/
-webhooks, speech-to-text/text-to-speech, and is not part of the core path.)
-
-See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for how these fit together.
-
----
-
-## 2. Concepts and mental model
-
-**Primary agent vs delegate agent.** The *primary agent* is the AI coding
-surface you interact with (Claude Code, Gemini CLI, Codex, Vibe, Copilot, or
-aimee's own chat). aimee integrates with it through hooks, provider-CLI
-adapters, or direct primary-session adapters. *Delegate agents* are sub-agents
-configured in `agents.json` that handle offloaded work via
-`aimee delegate <role> <prompt>`.
-
-**The two storage tiers.** DB1 (SQLite, owned by the local `aimee-server`) holds
-same-user runtime state, sessions, working memory, conversation windows,
-checkpoints, jobs, local signal streams, and secrets. DB2 (Postgres + pgvector,
-owned by `aimee-kb`) holds durable knowledge, memories, rules, the code index,
-tasks/decisions, and the vector embeddings of all of it. DB2 can run locally for
-one user or as a shared KB; only knowledge that is appropriate for its configured
-scope is reflected or promoted there from local server state. The boundary is
-pinned and compile-enforced; you never choose a different backend for either
-tier. It is also the **scaling boundary**: `aimee-server` is one-per-user, while
-`aimee-kb` and its Postgres are the shared, horizontally-scalable tier (see
-[§27.5](#275-scaling-and-multi-user-deployment)). See
-[`docs/STORAGE_TIERS.md`](docs/STORAGE_TIERS.md).
-
-**Memory tiers (L0-L3).** Stored knowledge moves through four lifetimes: L0
-session scratch, L1 recent (≈30 days), L2 long-term stable facts, L3 episodic
-(past attempts/outcomes with decay). Promotion and decay are automatic. This is
-*different* from the storage tiers above, L0-L3 is the *semantic* lifecycle of a
-memory; DB1/DB2 is *where bytes live*.
-
-**Sessions and worktrees.** Each session gets its own git worktree, branch, and
-state file, so parallel sessions never collide. Guardrails redirect writes that
-target a workspace path with an active worktree.
-
-**Hooks.** aimee registers `SessionStart`, `PreToolUse`, and `PostToolUse`
-hooks with your tool. SessionStart injects context; PreToolUse classifies and
-gates each tool call; PostToolUse re-indexes edited files.
-
----
-
-## 3. Installation
-
-aimee ships four binaries: the **`aimee`** thin client, **`aimee-server`**,
-**`aimee-kb`**, and **`aimee-runtime-web`**. For a guided, step-by-step path (Docker
-server + per-OS thin-client setup), see the
-[Quickstart](docs/QUICKSTART.md); this chapter is the exhaustive reference. There
-are two ways to stand it up:
-
-- **Docker services + thin client (recommended, [§3.1](#31-run-the-services-in-docker-recommended) to [§3.2](#32-install-the-thin-client)).**
-  Deploy the single `aimee-server` container (`compose.server-managed.yaml`) and let
-  the setup wizard bring up `aimee-kb` (with embedded PostgreSQL + pgvector) and
-  `aimee-llm`; install only the
-  thin `aimee` CLI on each developer machine, pointed at the server. This is the
-  intended deployment and the path the operations chapter
-  ([§27](#27-operations-and-deployment)) details.
-- **Single-box source build ([§3.3](#33-single-box-source-build)).** Build and run
-  everything on one host with `install.sh`, no Docker. The classic
-  single-developer setup.
-
-### 3.1 Run the services in Docker (recommended)
-
-Deploy one container. `aimee-server` runs with the host Docker socket mounted, so
-the setup wizard's **Deploy** step brings up `aimee-kb` and `aimee-llm` itself.
-PostgreSQL + pgvector are bundled inside the KB image and use the KB data volume:
+After the services are running, enroll the client and check every boundary:
 
 ```bash
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee
-docker compose -f compose.server-managed.yaml up -d
-```
-
-The server fronts the `/v1` API over native TLS on `:8743` (`aimee-local-dev` is an
-enrollment-only bootstrap value; plaintext `:8740` is loopback-only and not published); the
-webchat wizard is on `:8443`. Open it, run the wizard, and hit **Deploy** on the
-last screen. Then:
-
-Use the certificate-copy, fingerprint, one-time rotation, bootstrap-denial, and
-health sequence in [Quickstart §1.3](docs/QUICKSTART.md#13-verify-its-healthy).
-The wizard does not turn the public bootstrap value into an ordinary API credential.
-
-Mounting the Docker socket is root-equivalent on the host, so run this only where you
-trust the server. To run each service as its own container instead — to scale, update,
-or place them independently — use the split `compose.server.yaml` (the
-horizontal-scaling model in [§27.5](#275-scaling-and-multi-user-deployment)). See
-[§27.1](#271-containerized-deployment) for every compose file, the container lifecycle,
-volumes, and the smoke tests. Override the default `aimee-local-dev` bearer on any
-networked deployment.
-
-### 3.2 Install the thin client
-
-Each developer installs only the `aimee` CLI. Prebuilt thin-client binaries for
-Linux, macOS, and Windows are attached to every GitHub release; or build just the
-client from a checkout (a C compiler is the only dependency, no Go, libpq, or
-zstd):
-
-```bash
-cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
-      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF
-cmake --build build --target aimee
-```
-
-On macOS add `-DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)"`; on Windows (MinGW)
-add `-G "MinGW Makefiles" -DWITH_TLS=OFF` (no TLS; terminate TLS at a proxy).
-Point the client at the server per-invocation, via the environment, or persist it:
-
-```bash
-aimee --server https://my-host:8743 --server-token=aimee-local-dev status
-
-export AIMEE_SERVER_URL=https://my-host:8743
-export AIMEE_SERVER_TOKEN=aimee-local-dev
+aimee remote set https://host:8743 <bootstrap-bearer>
+aimee remote status
 aimee status
-
-aimee remote set https://my-host:8743 aimee-local-dev   # persists to <aimee_home>/remote.conf
-aimee remote status                                    # resolved transport + /v1/health probe
-aimee remote clear                                     # revert to a local Unix socket
+aimee kb status
+aimee audit verify
 ```
 
-Precedence is `--server` > `AIMEE_SERVER_URL` > `remote.conf`. `https://` works on
-Linux/macOS builds (set `AIMEE_TLS_INSECURE=1` for self-signed certs); the Windows
-client refuses `https://`. A remote thin client drives the data/RPC plane
-(`memory`, `kb`, `rules`, `index`, `sessions`, `notes`, …); interactive `aimee
-chat`/`aimee launch` need a co-located server, and **writes are off by default over
-the network** until the server sets `aimee.api.remote_writes` (see
-[§24](#24-the-http-v1-api)). Finally, register the hooks on each machine with
-`./configure-hooks.sh` (or `configure-hooks.ps1`) so your AI coding tool calls
-aimee.
+Confirm the server certificate fingerprint out of band. The bootstrap bearer is for enrollment,
+not daily use. The first successful enrollment rotates it and records the client identity.
 
-### 3.3 Single-box source build
-
-To build and run everything on one host without Docker:
+Register a workspace from the machine that holds the files:
 
 ```bash
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee
-./install-deps.sh   # system packages + PostgreSQL bootstrap (uses sudo)
-./install.sh        # build + install + configure (no sudo)
+cd /path/to/project
+aimee workspace add .
+aimee index scan .
+aimee index overview
 ```
 
-`install-deps.sh` installs the build/runtime packages and bootstraps the
-`aimee_shared` PostgreSQL database, the only steps that need root. (For a host
-that uses a *remote* kb and needs no local database, run `AIMEE_KB_MODE=remote
-./install-deps.sh`.) Prerequisites by platform:
+A remote client uploads file content. A server never treats a client path as a path on the server.
 
-| Need | Debian/Ubuntu | Fedora/RHEL | Arch | macOS |
-|------|---------------|-------------|------|-------|
-| C toolchain | `build-essential` | `gcc make` | `base-devel` | Xcode CLT |
-| pkg-config | `pkg-config` | `pkgconf-pkg-config` | `pkgconf` | `brew install pkg-config` |
-| SQLite3 (DB1) | `libsqlite3-dev sqlite3` | `sqlite-devel sqlite` | `sqlite` | system SQLite |
-| libpq (DB2) | `libpq-dev` | `libpq-devel` | `postgresql-libs` | `brew install libpq` |
-| libcurl | `libcurl4-openssl-dev` | `libcurl-devel` | `curl` | system curl |
-| libzstd | `libzstd-dev` | `libzstd-devel` | `zstd` | `brew install zstd` |
-| PAM (webchat) | `libpam0g-dev` | `pam-devel` | `pam` | built-in |
-| Postgres + pgvector | `postgresql postgresql-contrib` + pgvector | `postgresql-server` + `pgvector_NN` | `postgresql pgvector` | `brew install postgresql pgvector` |
-| ctags (indexing) | `universal-ctags` | `ctags` | `ctags` | `brew install universal-ctags` |
-| ripgrep (search) | `ripgrep` | `ripgrep` | `ripgrep` | `brew install ripgrep` |
+## Memory
 
-Go 1.25+ is required only to build `aimee-runtime-web`. Then `install.sh`, in order:
-
-1. **Check prerequisites** (FTS5 + the dev headers); if any are missing it stops
-   and points you back at `install-deps.sh` rather than escalating privileges.
-2. **Build** (only if sources changed): `cd src && make all server`, producing
-   `aimee`, `aimee-server`, and `aimee-kb` at the repo root, plus `aimee-runtime-web`
-   when a Go toolchain is on `PATH` (otherwise `make` notes it was skipped and the
-   C services still build, webchat is optional for a source install).
-3. **Stop any running server/KB** gracefully to avoid "text file busy".
-4. **Install binaries** to `~/.local/bin/` and remove retired binaries.
-5. **Install bundled skills** to `~/.local/share/aimee/skills/` (idempotent).
-6. **Choose a kb mode**: local sidecar (default, backed by local Postgres) or a
-   remote `aimee-kb` over HTTP (persists `kb_client_url`/`kb_client_bearer_token`
-   to `aimee.yaml`).
-7. **Install service units**: systemd user units (Linux) or launchd plists
-   (macOS), and enable `aimee-kb` then `aimee-server` (server only, in remote-kb
-   mode).
-8. **Install `ast-grep` (`sg`)** for structural code search.
-9. **Configure your primary AI CLI** (Claude / Codex / Gemini / OpenAI-compatible),
-   saved to `~/.config/aimee/aimee.yaml`.
-10. **Optionally add a local delegate** via `add-local-delegate.sh` (Ollama /
-    llama.cpp).
-11. **Configure AI coding tools** via `configure-hooks.sh`: register hooks + MCP
-    for Claude Code, Gemini CLI, Codex CLI, GitHub Copilot.
-
-`install-deps.sh` also bootstraps Postgres (starts the service, creates
-`aimee_shared`, enables `pg_trgm` + `vector`); `aimee-kb`'s startup auto-bootstrap
-retries the same steps on first launch. On Windows, aimee runs as the thin client
-only (server + kb live in Docker or on a Linux/macOS host): `install.ps1` builds
-and installs just `aimee.exe`; point it at a server with `aimee remote set` (or
-`AIMEE_SERVER_URL`), then run `configure-hooks.ps1`. Update with `./update.sh` (§4).
-
-**Manual build targets:**
+Use durable memory for facts that should survive tools and sessions:
 
 ```bash
-cd src
-make                # DB-free clients  -> ../aimee, ../aimee-runtime-web
-make server         # server + KB      -> ../aimee-server, ../aimee-kb
-make install        # install all four to ~/.local/bin
-make lean           # size-optimized variants (aimee-lean, ...)
-make lint           # clang-format / static checks
-make format         # auto-fix formatting
-make unit-tests     # build and run the C test suite
-make clean          # remove build artifacts
-```
-
-Build-boundary gates you can run: `make check-linking` (no SQLite in client,
-no libpq in server, no SQLite in KB), `make module-boundary-check`,
-`make kb-target-isolation-check`. See [`src/README.md`](src/README.md) for the
-full target list and the layering rules.
-
-### 3.4 Verify
-
-```bash
-aimee version
-aimee status        # server, DB1, and knowledge-base health
-```
-
-Against a Docker server, set `AIMEE_SERVER_URL`/`AIMEE_SERVER_TOKEN` (or `aimee
-remote set`) first. On a source install, the thin CLI no longer starts the server
-implicitly; if no service is running, use `systemctl --user start aimee-server` on
-systemd systems or `aimee server start` as the cross-platform fallback.
-
----
-
-## 4. Updating and uninstalling
-
-**Update:**
-
-```bash
-./update.sh         # fetch latest, rebuild if needed, restart services
-```
-
-`update.sh` pulls the latest source (SSH with HTTPS fallback), rebuilds only when
-sources changed or `--force` is given, gracefully stops KB and server, then
-reinstalls following the same flow as `install.sh`. Windows: `update.ps1`.
-
-**Uninstall:**
-
-```bash
-aimee clean         # remove local aimee config + tool integrations
-aimee clean --force # skip confirmation
-```
-
-`aimee clean` removes `~/.config/aimee` state and unregisters hooks/MCP from
-your AI tools. It does not remove the binaries from `~/.local/bin` (delete those
-manually) or drop the Postgres `aimee_shared` database.
-
----
-
-## 5. Configuration reference
-
-aimee reads three configuration files plus per-project metadata and a set of
-environment variables. All live under `~/.config/aimee/` unless `AIMEE_HOME` is
-set (see [Appendix A](#appendix-a-environment-variables)).
-
-### 5.1 `aimee.yaml`, main configuration
-
-Located at `~/.config/aimee/aimee.yaml` (YAML, parsed internally to JSON). A
-minimal real-world file:
-
-```yaml
-guardrail_mode: approve
-provider: claude
-openai_endpoint: https://api.openai.com/v1
-openai_model: gpt-4o
-workspaces:
-  - /home/me/dev
-  - /home/me/work
-concurrency:
-  per_model:
-    MiniMax-M2.7: 3
-compact:
-  enabled: false
-```
-
-The full set of recognized top-level keys (from `config_schema[]` in
-`src/config.c`). Object/array keys have their own nested settings handled by the
-corresponding `config_*.c` module.
-
-**Storage**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `db1_path` | string | SQLite DB1 path (default `~/.config/aimee/aimee.db`). |
-| `db2_url` | string | Postgres DB2 connection URL (`postgresql://user:pass@host:port/db`). |
-| `db2_pool_size` | int | DB2 connection pool size (clamped 1-32; default 8). |
-| `db2` | object | Additional DB2 settings. |
-
-**Primary provider / models**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `provider` | string | Primary agent provider: `claude`, `codex`/`openai`, `gemini`, `mistral`, etc. |
-| `use_builtin_cli` | bool | Use aimee's built-in HTTP adapter vs the provider's native CLI. |
-| `claude_model` | string | Claude model override (empty = CLI default). |
-| `codex_model` | string | Codex/OpenAI primary model override. |
-| `model_reasoning_effort` | string | Thinking effort: `low`/`medium`/`high`/`xhigh`. |
-| `openai_endpoint` | string | OpenAI-compatible endpoint URL. |
-| `openai_model` | string | Model for that endpoint. |
-| `openai_key_cmd` | string | Shell command that prints the API key. |
-| `prompt_tier` / `delegate_prompt_tier` | string | System-prompt verbosity tier for primary / delegate. |
-| `prompt_file` | string | Override system prompt from a file. |
-
-**Embeddings**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `embedding_command` | string | External command that produces embeddings (sidecar). |
-| `embedding_model` | string | Embedding model name. |
-| `embedding_endpoint` | string | Embedding service URL. |
-| `embedding_dim` | int | Embedding dimensionality; must match the embedder model. `1024` for the CPU tier (Qwen3-Embedding-0.6B), `2560` for the GPU tiers (Qwen3-Embedding-4B). |
-
-**Memory & retrieval**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `memory_weight_profile` | string | Named retrieval-weight profile used by the retrieval pipeline. |
-| `memory_rerank_mode` / `memory_rerank` | string/object | Reranking strategy and parameters. |
-| `memory_query_expansion` | object | Query-rewrite / HyDE / decomposition settings. |
-| `memory_recall_lanes` | object | Recall-lane (lexical/dense/graph) configuration. |
-| `memory_maintenance` | object | Promotion/decay/compaction schedule. |
-| `memory` | object | General memory subsystem settings. |
-
-**Guardrails & safety**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `guardrail_mode` | string | `approve` (default), `prompt`, or `deny`, see [§11](#11-guardrails-and-safety). |
-| `guardrails` | object | Detailed guardrail policy (paths, semantic checks, TDD gate). |
-| `sandbox` | object | Sandboxing policy for tool execution. |
-| `integrity` | object | Integrity-gate settings. |
-
-**Delegation & concurrency**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `autonomous` | bool | Allow autonomous multi-step operation. |
-| `cross_verify` | object | Cross-verification of delegate output. |
-| `retry` | object | Retry policy for transient delegate failures. |
-| `max_iterations` / `max_iterations_delegate` | int | Tool-use loop caps. |
-| `max_delegation_depth` | int | How deep delegates may sub-delegate. |
-| `max_delegation_spawns` | int | Max concurrent delegate spawns. |
-| `max_background_processes` | int | Cap on background processes. |
-| `background_threads` / `compute_threads` / `session_threads` / `worker_threads` | int | Server thread-pool sizing. |
-| `concurrency` | object | Per-model concurrency limits (`concurrency.per_model.<model>: N`). |
-| `ensemble` | object | Ensemble/voting delegate settings. |
-| `roundtable` | object | Agent roundtable loop settings: `max_rounds`, `converge_threshold`, `deadline_ms`, `turns`. |
-
-**Sessions, tools, transport**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `workspaces` | array | Registered workspace root paths. |
-| `sessions` / `session` | object | Session lifecycle settings. |
-| `rewind` | object | Conversation rewind settings. |
-| `search` | object | Search behavior. |
-| `compact` | object | Context compaction (`compact.enabled`). |
-| `lsp_servers` | array | Language servers to launch for diagnostics. |
-| `mcp` / `mcp_clients` | object/array | MCP server transport and downstream MCP clients. |
-| `client_integrations_enabled` | bool | Auto-register aimee's MCP server + hooks into external AI-tool configs (Claude Code, Gemini, Copilot, Codex) on each run (default `true`; set `false` to opt out). See [§25](#25-integrations). |
-| `computer_use` | object | Computer-use tool settings. |
-| `transport` | object | Server transport (socket/TCP) settings. |
-| `otel` | object | OpenTelemetry export. |
-| `proxy_url` / `proxy_token` | string | Outbound HTTP proxy. |
-
-**Knowledge, learning, identity**
-
-| Key | Type | Meaning |
-|-----|------|---------|
-| `kb` | object | Knowledge-base / curator settings. |
-| `learning` | object | Implicit-learning pipeline settings. |
-| `intelligence` | object | Calibration / bandit / demotion settings. |
-| `charter` | object | Charter (epistemic directives) pipeline. |
-| `identity` | object | Working-profile / identity settings. |
-| `skills` | object | Skill discovery and lifecycle. |
-| `toolsets` | object | Named composable toolsets. |
-| `script` | object | Project build/test/lint command hints. |
-| `auxiliary` | object | Auxiliary-model (task → provider/model) routing. |
-| `model_meta` | object | Model-capability metadata overrides. |
-| `dogfood` | object | Dogfood review settings. |
-| `cron_jobs` | array | Scheduled cron jobs (see [§20](#20-triggers-cron-and-automation)). |
-
-> Editing tip: many settings are written for you by commands such as
-> `aimee agent setup`, `aimee provider set`, and `aimee workspace add`.
-> Hand-edit `aimee.yaml` only when a setting has no routed command, and keep it
-> valid YAML, the server reloads it on the next request.
-
-### 5.2 `agents.json`, delegate agents and network inventory
-
-Located at `~/.config/aimee/agents.json`. Defines delegate agents, the default
-agent, the fallback chain, and (optionally) a host/network inventory used to
-brief delegates. Example (secrets redacted):
-
-```json
-{
-  "default_agent": "codex",
-  "fallback_chain": ["codex", "claude", "local-llama"],
-  "agents": [
-    {
-      "name": "codex",
-      "provider": "codex",
-      "backend": "provider-cli",
-      "cli_kind": "codex",
-      "cli_cmd": "codex",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "cost_tier": 0,
-      "enabled": true
-    },
-    {
-      "name": "local-llama",
-      "endpoint": "http://localhost:11434/v1",
-      "model": "llama3.2",
-      "auth_type": "none",
-      "roles": ["summarize", "format", "draft"],
-      "cost_tier": 0,
-      "enabled": true
-    }
-  ]
-}
-```
-
-Per-agent fields:
-
-| Field | Meaning |
-|-------|---------|
-| `name` | Unique agent id used by `--via`, routing, and the fallback chain. |
-| `provider` | Provider family: `openai`, `chatgpt`/`codex`, `anthropic`/`claude`, `gemini`, `mistral`, `minimax`, … |
-| `backend` | `provider-cli` (launch a CLI), `tmux-cli`, or omitted for direct HTTP. |
-| `cli_kind` / `cli_cmd` | CLI adapter kind and executable (for provider-CLI backends). |
-| `endpoint` | HTTP endpoint for direct API agents. |
-| `model` | Model name to request. |
-| `auth_type` | `none`, `bearer`, `oauth`, or `x-api-key`. |
-| `api_key` | API key (or `$ENV_VAR`); **store secrets via env/`auth_cmd` where possible**. |
-| `auth_cmd` | Command that prints the credential. |
-| `fallback_model` | Model to retry with on HTTP 400. |
-| `roles` | Roles this agent can serve (see [§13](#13-delegation)). |
-| `cost_tier` | Lower = cheaper; the router prefers the lowest capable tier. |
-| `max_tokens` / `max_turns` / `timeout_ms` | Per-agent budgets (`max_turns: -1` = unlimited). |
-| `tools_enabled` | Whether tool-use mode is permitted. |
-| `enabled` | Toggle without deleting. |
-
-Top-level keys: `default_agent`, `fallback_chain`, `agents`, and optional
-`hosts`/`networks` (SSH/host inventory injected into delegate context). Manage
-these with `aimee agent add/local/remove/enable/disable` and
-`aimee agent setup <provider>` rather than editing by hand. Full guidance:
-[`docs/DELEGATES.md`](docs/DELEGATES.md).
-
-### 5.3 Per-project and per-workspace configuration
-
-| File | Purpose |
-|------|---------|
-| `<project>/.aimee/project.yaml` | Per-project metadata: build/test/lint commands, language, conventions. Used by guardrails, verification, and context. |
-| `<project>/.mcp.json` | Auto-generated MCP server registration pointing at `aimee mcp-serve`. |
-| `<workspace>/aimee.workspace.yaml` | Declarative multi-repo workspace manifest (repos, dependencies, required credentials). Consumed by `aimee setup`. See [`docs/WORKSPACES.md`](docs/WORKSPACES.md). |
-| `<project>/.aimee/roadmap/` | Generated roadmap projections (`ROADMAP.md`, `STATE.md`, `reports/<id>.html`). |
-
-### 5.4 Profiles
-
-`aimee profile` manages alternate configuration sets (separate `aimee.yaml`,
-`agents.json`, and state). Select one with `--profile=<name>` on any command or
-the `AIMEE_PROFILE` environment variable. Useful for separating work and
-personal setups, or for testing a new provider without disturbing your default.
-
----
-
-## 6. The command line
-
-```
-aimee [--json] [--fields=FIELDS] [--profile=PROFILE] <command> [args...]
-```
-
-Global flags:
-
-| Flag | Effect |
-|------|--------|
-| `--json` | Machine-parseable JSON output (supported by server-backed commands). |
-| `--fields=FIELDS` | Restrict JSON output to the named fields. |
-| `--profile=PROFILE` | Use a named profile (see [§5.4](#54-profiles)). |
-| `--help`, `-h` | Command help. |
-
-Discovery:
-
-```bash
-aimee help            # core commands
-aimee help --all      # core + advanced + admin
-aimee help <command>  # detailed help for one command
-```
-
-`aimee` is a *thin client*: it either performs a small local operation or
-forwards a typed request to an already-running `aimee-server`. `install.sh`
-installs and enables service units where supported; otherwise start the server
-with `aimee server start`. Commands are grouped into tiers, **core** (shown by
-`aimee help`), **advanced**, and **admin** (both shown by `aimee help --all`).
-
-Bare `aimee` prints usage. There is no built-in interactive chat client: talk to
-the primary agent through any OpenAI-compatible front end (see below), the web
-chat, or `aimee acp-serve` from an ACP editor such as Zed.
-
----
-
-## 7. Command reference
-
-This is the current thin-client command contract, grouped by family.
-Server-backed commands support `--json`. Where useful, the routed RPC method is
-noted in parentheses.
-
-> The CLI is the contract: commands here are those registered in the dispatch
-> table and RPC routes. `aimee help <command>` always reflects the installed
-> build.
->
-> Some older in-process command modules still exist in the source tree
-> (`cmd_roadmap.c`, `cmd_auto.c`, extended `cmd_memory_*` maintenance verbs), but
-> they are not part of the installed thin-client contract until they have a typed
-> server RPC route. If `aimee <command>` says "has no /v1 route",
-> treat that command as implementation work in progress rather than user-facing
-> documentation.
-
-### 7.1 Memory, `aimee memory`
-
-Persistent, tiered knowledge (DB2, via the server → KB).
-
-**Core CRUD**
-- `memory search <query>`, search stored memory (`memory.search`).
-- `memory store <key> <value> [--tier L0|L1|L2|L3] [--kind K]`, store a memory (`memory.store`).
-- `memory list [--tier T] [--kind K] [--limit N] [--status proposed]`, list memories (`memory.list`).
-- `memory get <id>` / `memory show <id>`, read one memory (`memory.get`).
-- `memory read`, assemble the current memory context (`memory.read`).
-
-The installed thin-client help currently exposes only `search`, `store`, `list`,
-`get`/`show`, and `read` as the supported memory command family. The KB and
-server contain additional maintenance, graph, provenance, vector repair,
-benchmarking, and review implementation modules; those are internal or
-not-yet-routed unless they appear in `aimee help memory` for your build.
-
-See [§8](#8-memory) for the conceptual model.
-
-### 7.2 Working memory, `aimee wm`
-
-Session-scoped scratch (DB1, TTL'd).
-
-- `wm set <key> <value> [--session ID] [--category C] [--ttl N]` (`wm.set`)
-- `wm get <key> [--session ID]` (`wm.get`)
-- `wm list [--session ID] [--category C]` (`wm.list`)
-
-### 7.3 Code index, `aimee index`
-
-Symbol-level code knowledge (DB2 code index, via KB).
-
-- `index find <identifier>` (`index.find`)
-- `index list` / `index overview` (`index.list`)
-- `index scan [--force]` (`index.scan`)
-- `index structure <file>` (`index.structure`)
-- `index callers <symbol>` (`index.find_callers`)
-- `index blast-radius <file>` (`index.blast_radius`)
-- `code audit [dir] [--json] [--fix]`: local file-health checks. `--fix` is non-mutating until there are safe, reviewable mechanical fixes.
-- `code audit --graph [--project P] [--json]`: graph-derived dead exports, import cycles, exact clones, and near clones via `aimee-server` and `aimee-kb`. Thin clients need a configured remote and a scanned/indexed project.
-
-See [§12](#12-the-code-index).
-
-### 7.4 Rules, `aimee rules`
-
-Behavioral rules derived from feedback.
-
-- `rules list` (`rules.list`) · `rules generate` (`rules.generate`) · `rules delete <id>` (`rules.delete`)
-
-### 7.5 Delegation, `aimee delegate`
-
-Offload work to a sub-agent (via the server compute pool).
-
-- `delegate <role> <prompt>` (`delegate`), roles: `code`, `review`, `explain`,
-  `refactor`, `draft`, `execute`, `summarize`, `format`, `search`, `diagnose`,
-  `validate`, `reason` (aliases: `implement`/`build`→`code`, `test`/`check`→
-  `validate`, `inspect`→`diagnose`, `research`→`execute`).
-  Flags: `--tools`, `--json`, `--background`, `--durable`, `--prompt-file PATH`,
-  `--prompt-stdin`, `--system S`, `--max-tokens N`, `--max-turns N`,
-  `--timeout N`, `--handoff-json`, `--worktree BRANCH`, `--via AGENT`,
-  `--provider NAME`, `--model NAME`, `--tier N`, `--retry N`, `--verify CMD`,
-  `--context-dir DIR`, `--files F`.
-- `delegate plan <proposal.md> [--json] [--output PATH] [--launch] [--parallel N]`, generate work packets from a proposal.
-- `delegate launch <plan.json> [--json] [--parallel N]` (`delegate.launch`), queue reviewed packets.
-- `delegate aggregate "<task>"` (`delegate.aggregate`), run one Mixture-of-Agents fan-out and synthesis over `ensemble.reference_models`.
-- `delegate roundtable "<task>" [--roundtable PRESET] [--mode draft|review] [--turns parallel|sequential] [--rounds N] [--brief TEXT] [--brief-json JSON] [--apply]` (`delegate.roundtable`), run a bounded multi-round collaborative draft or review. `--roundtable` selects a saved preset for this request without changing the active default. Directed review briefs may include focus/fixes/invariants/questions. The async run result includes `artifact`, `rounds_run`, `converged`, `degraded`, `truncated`, `cost_capped`, `deadline_hit`, `cancelled`, `best_round`, `items_round`, `artifact_round`, `cost_usd`, `items`, `answered_questions`, and `coverage_gaps`.
-- `delegate status <job_id> [job_id...] [--full|--result-limit N]` (`delegate.status`).
-- `delegate log` / `delegate history` (`delegate.log`) · `delegate --list-roles` (`agent.list`).
-
-See [§13](#13-delegation) and [`docs/DELEGATES.md`](docs/DELEGATES.md).
-
-### 7.6 Roadmaps and autonomous dispatch
-
-Spec-driven decomposition (DB2, via KB) and a deterministic dispatch loop.
-
-The source tree contains roadmap and auto-loop implementation modules
-(`cmd_roadmap.c`, `cmd_auto.c`, KB-side `roadmap.*` handlers), but the current
-thin CLI does not expose `aimee roadmap` or `aimee auto` through typed server RPC
-routes. Use `aimee delegate plan` and `aimee delegate launch` for the currently
-routed work-packet flow.
-
-See [§14](#14-roadmaps-and-the-autonomous-loop).
-
-See [§15](#15-the-work-queue).
-
-### 7.8 Coordinated jobs, `aimee job` and durable jobs, `aimee jobs`
-
-- `job start <plan_id>` · `job list [--limit N]` · `job status <id>` · `job cancel <id>`, coordinated parallel jobs.
-- `jobs list [--limit N]` · `jobs status <id>` · `jobs logs <id>` · `jobs cancel <id>`, durable delegate jobs (created by `--background`/`--durable`).
-
-### 7.9 Skills, `aimee skill`
-
-Project-scoped process skills.
-
-- `skill list` · `skill show <name>` · `skill create` · `skill edit` · `skill patch`.
-- `skill lint` · `skill eval` · `skill archive` · `skill lifecycle [--stale-days N] [--archive-days N] [--force]`.
-- `skill autostub [--force]` · `skill pin <name>` · `skill unpin <name>`.
-
-### 7.10 Toolsets, `aimee toolset`
-
-- `toolset list` · `toolset show <name>` · `toolset resolve <name>`.
-
-### 7.11 MCP registry, `aimee mcp`
-
-- `mcp audit`, list registered MCP servers and OSV verdicts.
-- `mcp recheck [name]`, force a fresh OSV query.
-
-(The MCP *bridge* is `aimee mcp-serve`; see [§22](#22-the-mcp-server).)
-
-### 7.12 Sessions, `aimee session`
-
-- `session list [--limit N]` (`session.list`) · `session show <id>` / `session get <id>` (`session.get`) · `session close <id>` (`session.close`).
-- `session brief [--limit-tokens N]`, show the persisted session-start brief.
-
-### 7.13 Worktrees, `aimee worktree`
-
-- `worktree gc [--days N] [--force] [--dry-run]` (`worktree.gc`), garbage-collect abandoned session worktrees.
-
-### 7.14 Providers and models, `aimee provider`, `aimee model`, `aimee agent`
-
-`provider`:
-- `provider list [--available] [--json]` · `provider show <name>` · `provider models <name> [--json]` · `provider test <name>` · `provider quota [name]`.
-
-`model`:
-- `model list [--capability NAME] [--open-weights]` · `model show <model>` · `model refresh`.
-
-`agent`:
-- `agent list` · `agent add` · `agent local [--provider openai|llama-eval]` · `agent remove` · `agent enable` · `agent disable`.
-- `agent probe` · `agent token <name>` · `agent setup <provider-oauth>` · `agent episodes`.
-
-`delegate-backend`:
-- `delegate-backend list` · `delegate-backend exec --backend X --task-id Y [--image I] [--host H] [--no-hibernate] "<cmd>"`.
-
-See [§18](#18-providers-models-and-agents).
-
-### 7.15 Identity, `aimee identity`
-
-- `identity show` · `identity snapshot [--out DIR]` · `identity diff [--flip-threshold N]`.
-- `identity working-profile review [--limit N] [--confidence-min F] [--json]`.
-
-### 7.16 Knowledge base, `aimee kb`
-
-- `kb search <query>` · `kb status` · `kb build [--path DIR] [--project NAME] [--force]` · `kb update`.
-- `kb docs push [--scope SCOPE] <file>...` · `kb ingest <file>` · `kb ingest status`.
-
-See [§21](#21-the-knowledge-base).
-
-### 7.17 Automation, `aimee trigger`, `aimee cron`
-
-`trigger`:
-- `trigger fire [--source S] [--task T] [--workspace WS] [--token TOK]` · `trigger list` · `trigger status [id]` · `trigger cancel [id]`.
-
-`cron`:
-- `cron list` · `cron add <id>` · `cron show <id>` · `cron run <id>` · `cron history <id>` · `cron enable <id>` · `cron disable <id> [--all]` · `cron remove <id>`.
-
-See [§20](#20-triggers-cron-and-automation).
-
-### 7.18 Benchmarks and optimization, `aimee optimize`
-
-- `optimize run --suite <suite> [--arm <arm>]`: run the server-side
-  `memory.benchmark` RPC. Synchronous retrieval suites are `code-graph-fusion`,
-  `memory`, `corpus`, `memory-retrieval`, and `live`. Dataset and judge-style
-  suites such as `locomo`, `longmemeval`, `locomo-qa`, and `longmemeval-qa`
-  return an `async-only` response that points to the CLI/delegate benchmark path.
-- `optimize compare --baseline <arm> --candidate <arm>`: compare benchmark arm
-  metrics.
-- Registered decision points include `briefing_style` (`compact`,
-  `evidence_heavy`) and `guardrail_strictness` (`balanced`, `strict`). These
-  residual UX/safety points are promotion/replay driven; online exploration
-  remains default-off unless `intelligence.bandit.live_decision_enabled` is set.
-
-### 7.19 Review surfaces
-
-Unified `aimee review` is implemented in the legacy command table but is not
-currently routed through the thin CLI. Use routed review/status surfaces that are
-visible in `aimee help --all` for your installed build.
-
-### 7.20 Insights, HUD, status, dogfood, graph, trajectory
-
-- `insights [--days N]`, token-usage totals (default 30 days) (`insights.overview`).
-- `hud`, real-time session telemetry (`hud.status`).
-- `status`, system health overview (`server.health`).
-- `dogfood tag` · `dogfood review` · `dogfood report [--month YYYY-MM] [--json]`.
-- `graph sync-code` · `graph explain`.
-- `trajectory export` · `trajectory batch`.
-
-### 7.21 Manuscript, `aimee manuscript`
-
-Novel/long-form writing helpers (client-local): `manuscript scenes` ·
-`manuscript wordcount` · `manuscript outline` · `manuscript check [files…]`.
-
-### 7.22 Server, profiles, admin
-
-- `server start` · `server restart` · `server status` / `server health`, manage `aimee-server`.
-- `profile create|list|show|delete|current [--force]`, configuration profiles.
-- `git verify` / `verify` (`git.verify`), verify current changes before merge.
-- `clean [--force]`, remove local config and integrations.
-
-### 7.23 Hidden / integration entry points
-
-Used by tool integrations, not typed by users directly:
-
-- `hooks pre` / `hooks post`, PreToolUse / PostToolUse hook handlers.
-- `session-start`, SessionStart hook handler.
-- `mcp-serve`, the stdio MCP bridge.
-- `eval run <suite_dir> [--ablation <preset|all>] [--runs N]` · `eval results [suite]`, eval harness.
-- `migrate v2`, data migration utility.
-
----
-
-## 8. Memory
-
-Memory is the on-ramp to aimee's larger goal: a self-learning, company-wide
-knowledge base. The tiers below are the durable store; the curator pipeline,
-scope lattice, knowledge graph, and reflection that turn stored facts into
-*learned*, cross-domain knowledge are described in
-[How aimee learns](docs/KNOWLEDGE.md).
-
-### 8.1 The four tiers
-
-```
-L0  Session       scratch / in-progress state   - lifetime: session only
-L1  Recent        decisions, context, checkpoints - lifetime: ~30 days
-L2  Long-term     stable facts, preferences, patterns - persistent
-L3  Episodic      past attempts, outcomes, failures - persistent, decays
-```
-
-Promotion and decay are automatic: L0 folds into L1 at session end; L1 promotes
-to L2 after ~3 reuses or confidence ≥ 0.9; unused L2 (60 days, confidence < 0.7)
-demotes back to L1; delegation patterns auto-synthesize from the agent log into
-L2 facts.
-
-### 8.2 Kinds
-
-| Kind | Meaning | Example |
-|------|---------|---------|
-| `fact` | Verified information | "PostgreSQL runs on port 5432" |
-| `preference` | User style/behavior | "Prefers concise responses" |
-| `decision` | Choice + rationale | "Chose JWT over sessions: stateless" |
-| `episode` | Past-attempt narrative | "Refactored auth module" |
-| `task` | Work item / goal | "Implement user authentication" |
-| `scratch` | Temporary working data | Current task state |
-
-### 8.3 Deduplication, contradiction, and versioning
-
-New memories are normalized (lowercase, strip fillers, collapse whitespace),
-checked for an exact key match, then for trigram similarity ≥ 0.7 against the top
-same-kind candidates; matches merge (keeping higher confidence, incrementing
-use-count) instead of inserting duplicates. When two memories conflict, negation
-and word-similarity analysis flags the contradiction, reduces both confidences
-(×0.7), and records it. Facts that change over time are *superseded*: the old
-version gets a `#vN` suffix and a `valid_until`, the new one takes the canonical
-key with `valid_from`.
-
-### 8.4 Search
-
-Fact search fuses lexical (DB2 structured) and dense (pgvector) candidates with
-reranking. Conversation-window search combines term match, lexical recall, and a
-2-hop entity-graph boost, then applies time decay and a tier weight
-(raw 1.0 / summary 0.7 / fact 0.4). Internal diagnostic and answer-generation
-helpers exist in the KB memory pipeline, but they are not current thin-client
-commands unless they appear in `aimee help memory`.
-
-`memory.ask` also carries a default-off answerability gate. When
-`memory.abstain.enabled` is set, weak retrieved evidence is refused with
-`no_answer=true`, empty rendered citations, and an `evidence_trace` containing
-candidate ids, grounding scores, thresholds, and the abstention reason. The
-context path uses the same rollout switch to withhold weak memory context and
-emit `## Memory Answerability` instead of passing weak evidence to the model.
-L4/L5 curated anchors bypass the gate.
-
-### 8.5 Everyday usage
-
-```bash
-aimee memory store db-host "PostgreSQL at 10.0.0.5:5432" --tier L2 --kind fact
-aimee memory search "database"
-aimee memory list --tier L2 --kind fact --limit 20
+aimee memory store infrastructure "Staging is in eu-west-1"
+aimee memory search "where is staging"
+aimee memory list
 aimee memory get <id>
+aimee memory read
 ```
 
----
+The KB stores typed records with source, scope, confidence, freshness, and links to artifacts.
+Curation joins duplicates, records contradictions, and lets stale evidence decay. Recall mixes
+lexical, dense, graph, and recency signals, then may rerank or synthesize. A low-evidence query can
+abstain instead of inventing an answer.
 
-## 9. Working memory
-
-Working memory (`aimee wm`) is fast, session-scoped scratch stored in DB1 with an
-optional TTL. Use it for the current task, intermediate state, or anything the AI
-should remember within a session but not promote to durable knowledge.
+Working memory is session scratch:
 
 ```bash
-aimee wm set current-task "Review PR #42 for security issues"
-aimee wm set scratch.findings "3 issues, see notes" --category review --ttl 3600
-aimee wm get current-task
-aimee wm list --category review
+aimee wm set branch feature/search
+aimee wm get branch
+aimee wm list
 ```
 
-Values fold into L1 memory at session end if relevant; otherwise they expire.
+Do not use working memory for team facts. It is local, session-scoped DB1 state.
 
----
+See [Knowledge](docs/KNOWLEDGE.md) and [Retrieval](docs/retrieval-stack.md).
 
-## 10. Rules and feedback
-
-Rules are behavioral instructions derived from your feedback and from negative
-outcomes. `aimee rules generate` builds the rules prompt injected at session
-start; `aimee rules list` shows active rules; `aimee rules delete <id>` removes
-one. Proposed-rule review code exists in the source tree, but review commands
-are not part of the current thin-client route table unless shown by
-`aimee help rules`.
-
-Interaction-style learning watches negative feedback for recurring patterns
-(e.g. "too verbose" twice → "User prefers concise responses") and stores the
-inferred preference as an L2 memory injected into both primary and delegate
-contexts.
-
----
-
-## 11. Guardrails and safety
-
-Before every tool call from the primary agent or a delegate, aimee classifies
-the target path and applies policy:
-
-```
-Edit/Write/Bash → classify path
-  ├─ sensitive (.env, credentials, keys)         → BLOCK (exit 2)
-  ├─ real workspace path with active worktree    → BLOCK + redirect to worktree
-  ├─ planning mode active and write op           → BLOCK writes
-  ├─ anti-pattern match                           → WARN (stderr, non-blocking)
-  └─ off-scope vs active task (drift)             → WARN (stderr)
-                                                  → otherwise ALLOW (exit 0)
-```
-
-**Modes** (`guardrail_mode` in `aimee.yaml`):
-
-| Mode | Amber (warn) | Red (block) |
-|------|--------------|-------------|
-| `approve` (default) | silently allow | block + inform |
-| `prompt` | block + inform | block + inform |
-| `deny` | silently block | silently block |
-
-**Planning mode** locks all write operations (Edit, Write, MultiEdit,
-destructive commands); read-only operations are always allowed. **Anti-patterns**
-come from negative-feedback rules (weight ≥ 50), failed decisions, and manual
-additions; matches warn on stderr. **Drift detection** warns when edits stray
-from the scope of the active in-progress task (key terms from the task title,
-referenced projects, and subtasks).
-
-Guardrails are enforced *server-side*, clients cannot bypass them. See
-[`docs/SECURITY.md`](docs/SECURITY.md) for the trust model and
-`src/modules/guardrails/guardrails.c` / `src/modules/guardrails/guardrails_orchestrator.c` for the implementation.
-
----
-
-## 12. The code index
-
-aimee indexes your code into DB2 so the AI can look up symbols instead of
-grepping. It extracts definitions across many languages (JS/TS, Python, Go, C/
-C++, C#, shell, CSS, Dart, Lua, and more).
+## Code intelligence
 
 ```bash
-aimee index scan --force            # build/refresh the index
-aimee index find handleLogin        # locate a symbol
-aimee index callers handleLogin     # who calls it
-aimee index structure src/auth.c    # definitions in a file
-aimee index blast-radius src/db.c   # files impacted by changing this one
-aimee code audit --graph --project my-app --json
+aimee index find kb_client
+aimee index structure src/server/server_state.c
+aimee index callers kb_client_request
+aimee index blast-radius src/modules/kb_client/kb_client.h
+aimee graph explain <relationship>
 ```
 
-`aimee code audit` has two modes. The local mode scans a working tree for file
-health signals such as untested files and TODO/FIXME markers; its `--fix` flag
-does not rewrite files yet and reports that no safe automatic fixes are
-available. The graph mode calls `/v1/code/audit` on `aimee-server`, which proxies
-to `aimee-kb`; it requires the server and KB to be reachable and the project to
-have code graph/index rows. The graph response includes dead exports, import
-cycles, exact body-hash clone groups, near-clone pairs, and clone threshold
-metadata such as `clone_min_lines`.
+The graph covers symbols, calls, imports, repository dependencies, and git co-change. In a
+multi-repository workspace, caller and blast-radius results cross repository boundaries.
 
-`find_symbol`, `preview_blast_radius`, and `ast_grep_search` are also exposed as
-MCP tools (see [§22](#22-the-mcp-server)), so a tool that speaks MCP can use the
-index directly. PostToolUse re-indexes edited files automatically.
+Run `aimee index scan` after large branch changes or when status says the index is stale. Use
+`--force` only when incremental repair is not enough.
 
----
+See [Code intelligence](docs/CODE_INTELLIGENCE.md).
 
-## 13. Delegation
+The same index powers CSS migration checks. Use `aimee css report <project>` for an overview. The
+optional render sidecar compares computed styles before and after a conversion.
 
-Delegation offloads bounded work to the cheapest capable model. The router reads
-`agents.json`, finds the lowest `cost_tier` agent whose `roles` include the
-requested role, and runs it; on failure it walks the `fallback_chain` or retries
-with `fallback_model`.
+## Delegates
+
+A delegate is a cheaper or specialized agent working under server policy:
 
 ```bash
-aimee delegate review "Review this PR for security issues"
-aimee delegate code --tools "Add tests for the auth module"
-aimee delegate summarize --files notes.md "Summarize to 5 bullets"
-aimee delegate execute --tools --background "Migrate config to YAML"
-aimee delegate roundtable "Draft a migration proposal" --rounds 3
-aimee delegate roundtable "Review this design" --mode review --turns sequential --brief "Check authorization and cancellation paths"
+aimee delegate review --persona reviewer "Review the current diff"
+aimee delegate diagnose --persona engineer "Find the cause of this failure"
+aimee delegate code --persona engineer "Implement the accepted fix"
 ```
 
-**Roles:** `code`, `review`, `explain`, `refactor`, `draft`, `execute`,
-`summarize`, `format`, `search`, `diagnose`, `validate`, `reason`.
+Roles describe the job. Personas describe the perspective and constraints. The router chooses a
+viable agent that serves the role, respects concurrency and budget, and has the required tools. If
+you pin an agent or model, failure is explicit; aimee does not silently substitute another one.
 
-**Modes:** read-only delegates inspect the parent session worktree directly;
-`--tools` enables bash/read/write in an isolated sibling worktree;
-`--background`/`--durable` create a server-owned job that survives client exit
-(inspect with `aimee jobs ...`).
+Read-only delegates may share the current tree. Write-capable delegates get an isolated worktree.
+Container delegates default to no network and no ambient credentials. Package access, egress,
+custom images, and toolchains are explicit policy.
 
-**Provider request formats:** `openai` (`/v1/chat/completions`), `chatgpt`
-(`/backend-api/codex/responses`), `anthropic` (`/v1/messages`). **Auth types:**
-`none` (Ollama), `bearer` (OpenAI/Together/Groq), `oauth` (Codex/Gemini
-subscriptions), `x-api-key` (Anthropic).
-
-**Cross-verification:** `--verify CMD` runs a build/test after delegation and
-fails (exit 3) if it does not pass; `aimee verify` can send your diff to a
-delegate for review. Full guide: [`docs/DELEGATES.md`](docs/DELEGATES.md).
-
-**Roundtable:** `aimee delegate roundtable` reuses `ensemble.enabled`,
-`ensemble.reference_models`, `ensemble.aggregator`, `ensemble.min_successful`,
-and `ensemble.max_cost_usd` (optional; unset or `0` means no cost cap, the
-default, set a positive value to cap a run). The panel and aggregator ship
-configured, so the roundtable runs with no setup. `roundtable.max_rounds` defaults to `1`,
-`roundtable.converge_threshold` to `10`, `roundtable.deadline_ms` to `600000`,
-and `roundtable.turns` to `parallel`. Draft mode returns a shared artifact;
-review mode returns a consolidated review, and `--apply` asks a final draft turn
-to apply that review.
-
----
-
-## 14. Roadmaps and the autonomous loop
-
-A roadmap decomposes a goal into a `milestone → slice → task` tree of validated
-artifacts (DB2). The roadmap and auto-loop implementation modules are present,
-but they are not current thin-client commands. The routed workflow today is
-reviewed delegate packet planning plus coordinated jobs.
+Durable work is inspectable:
 
 ```bash
-aimee delegate plan docs/proposals/pending/example.md --output /tmp/plan.json
-aimee delegate launch /tmp/plan.json --parallel 3
-aimee job status <id>
+aimee jobs list
+aimee jobs status <job-id>
+aimee jobs logs <job-id>
+aimee jobs cancel <job-id>
 ```
 
-The older roadmap/auto modules describe validated milestone/slice/task trees and
-single-track autonomous dispatch, but they are not current thin-client commands.
-The routed path today is reviewed delegate packet planning plus coordinated jobs.
+See [Delegates](docs/DELEGATES.md) and [Delegate sandbox](docs/DELEGATE_SANDBOX.md).
 
----
+## Roundtables
 
-`work sync-proposals` closes items whose underlying proposal has moved;
-`work stats` reports queue health.
-
----
-
-## 16. Skills and toolsets
-
-**Skills** are project-scoped process guides (markdown with frontmatter) that
-shape agent behavior, e.g. *systematic-debugging*, *test-driven-development*,
-*recall-before-asking*, *verification-before-completion*. Bundled skills install
-to `~/.local/share/aimee/skills/`; manage them with `aimee skill ...`
-(`list`/`show`/`create`/`edit`/`patch`/`lint`/`eval`/`archive`/`lifecycle`/`pin`).
-`aimee skill autostub` proposes skill capabilities for tools that lack coverage.
-
-**Toolsets** are composable named bundles of tools. `aimee toolset list/show/
-resolve` inspect them; select one at runtime with the `AIMEE_ACTIVE_TOOLSET`
-environment variable or `toolsets` config.
-
----
-
-## 17. Sessions and worktrees
-
-Each session has its own state file (`session-<id>.state`), git worktree, and
-branch under `~/.config/aimee/worktrees/<id>/<project>/`. This is what lets two
-sessions run in parallel without clobbering each other, and what guardrails
-enforce by redirecting writes. Inspect sessions with `aimee session list/show`;
-reclaim abandoned worktrees with `aimee worktree gc`. Multi-repo coordination is
-described in [`docs/WORKSPACES.md`](docs/WORKSPACES.md).
-
----
-
-## 18. Providers, models, and agents
-
-- **Providers** are inference backends with credentials and catalogs. `aimee
-  provider list --available` shows which have working credentials; `aimee
-  provider test <name>` probes connectivity; `aimee provider models <name>` lists
-  the catalog; `aimee provider quota` shows usage.
-- **Models** carry capability metadata (context window, cost, cutoff, flags).
-  `aimee model list --capability tools`, `aimee model show <model>`,
-  `aimee model refresh`.
-- **Agents** are delegate definitions in `agents.json`. Add one interactively
-  with `aimee agent setup <provider>` (handles OAuth device flows for
-  subscription providers), or directly with `aimee agent add` / `aimee agent
-  local`. Toggle with `enable`/`disable`, inspect history with `agent episodes`.
-
-The primary agent (the surface you chat with) is configured separately from
-delegates, by `aimee.yaml`'s `provider`/model keys or by the launch/chat/webchat
-surface, while `agents.json` defines the delegate fleet.
-
----
-
-## 19. Identity, charter, and personas
-
-The **charter** is aimee's pipeline for proposing durable behavioral artifacts
-(rules, epistemic directives, anti-patterns, working-profile traits) that can be
-reviewed before they take effect. The unified review loop is implemented in the
-legacy command modules but is not currently routed by the thin CLI.
-`aimee identity show/snapshot/diff` inspects the working profile and tracks how
-it changes over time. **Personas** (see [`docs/personas.md`](docs/personas.md))
-let a session adopt a named voice/behavior profile, settable per session in chat
-and webchat; the same personas staff roundtable review panels and
-[workflow](docs/WORKFLOWS.md) steps. aimee ships eight built-ins (`engineer`
-default, `novel`, `songwriter`, and the read-only reviewers `qa`, `security`,
-`reviewer`, `reviewer-constructive`, `architect`).
-
-**Workflows** (see [`docs/WORKFLOWS.md`](docs/WORKFLOWS.md)) compose those
-delegates and gates into a declarative dev-lifecycle graph (propose → review →
-plan → implement → PR → merge). The default `build` workflow lives in
-`config/workflows/build.yaml`; author and validate your own with `aimee workflow
-new/validate/show` or the webchat **Workflows** tab. The execution engine is
-implemented but not yet wired to a user-facing run trigger.
-
----
-
-## 20. Triggers, cron, and automation
-
-- **Triggers** queue event-driven autopilot runs: `aimee trigger fire --source
-  ci --task "fix build" --workspace myrepo`. List/inspect/cancel with
-  `trigger list/status/cancel`. A common source is a webhook relay
-  (`scripts/github-webhook-relay.py`).
-- **Cron** schedules recurring server-side jobs: `aimee cron add <id>` (define),
-  `cron list/show/history`, `cron run <id>` (run now), `cron enable/disable/
-  remove`. Jobs are stored in `aimee.yaml`'s `cron_jobs` and run by the server's
-  scheduler/watchdog.
-
----
-
-## 21. The knowledge base
-
-The KB (`aimee-kb`) ingests documents and code into DB2 and answers semantic and
-full-text queries. A shared `aimee-kb` is what makes aimee a *company-wide*
-knowledge base: it distills every team's documents, across all domains, into
-one graph and synthesizes across them. See [How aimee learns](docs/KNOWLEDGE.md)
-for the vision and the mechanisms; this section covers the commands.
+Use a roundtable when one answer is not enough:
 
 ```bash
-aimee kb build --path ./docs --project myproj   # build from a doc tree
-aimee kb update                                  # incremental refresh
-aimee kb search "how does auth work"
-aimee kb status                                  # vectors, models, health
-aimee kb docs push --scope project README.md     # stage docs for ingest
+aimee ensemble roundtable --help
 ```
 
-Ingest runs through staged document upload → curator extraction (structured
-knowledge from prose/code/API docs) → embedding → review. `aimee-kb` serves its
-contract over an **HTTP `/v1` API on port 8741**: this is the only transport;
-the legacy Unix-socket RPC was retired in #2747. The server's KB client, thin
-clients, and containerized deployments all reach it that way, via
-`AIMEE_KB_API_URL` (plus an optional bearer in `AIMEE_KB_API_BEARER_TOKEN`). The
-KB must be running (its service unit, container, or `aimee-kb --http-port=8741`)
-before the server can use kb-backed features; the server no longer autostarts it.
-The contract is `api/openapi-v1.yaml`; the generated markdown is `docs/gen/api-v1.md`.
+Seats run in parallel. Each seat has a persona and either a pinned model or a random eligible
+reviewer. Reviewers must cite repository evidence. Failed random seats retry elsewhere; pinned seats
+fail rather than changing identity. The optional chair removes unsupported or duplicate findings
+and returns one result.
 
----
+Roundtable cost belongs to the originating session or workflow. Set a positive cost cap if the run
+must stop at a fixed spend.
 
-## 22. The MCP server
+See [Roundtables](docs/ENSEMBLE.md).
 
-`aimee mcp-serve` is a stdio JSON-RPC 2.0 MCP server built into the `aimee`
-binary. It exposes aimee's knowledge and delegation as MCP tools to any
-MCP-capable client, forwarding calls to `aimee-server`.
+## Workflows
 
-| Tool | Returns |
-|------|---------|
-| `search_memory` | Matching facts (lexical + dense recall + rerank). |
-| `list_facts` | Stored L2 facts. |
-| `memory_briefing` / `memory_recall` | Structured memory context bundles for a task/session. |
-| `get_host` / `list_hosts` | Host(s) and networks from `agents.json`. |
-| `find_symbol` | Code symbol locations. |
-| `ast_grep_search` | Structural AST pattern matches (`sg --json`). |
-| `delegate` | Delegation result. |
-| `preview_blast_radius` | File dependency impact. |
-| `record_attempt` / `list_attempts` | Log / list delegation attempts. |
-| `delegate_reply` | Follow up on a prior delegation. |
-| `learning_review` | Review learning/curation candidates. |
-| `session_search` | Search local session history. |
-| `autopilot` | Drive the internal autopilot action surface for MCP callers. |
-
-`install.sh`/`configure-hooks.sh` register `aimee mcp-serve` as an MCP server for
-tools that support it (writing `<project>/.mcp.json`). `aimee mcp audit`/`mcp
-recheck` gate registered MCP packages against OSV advisories.
-
----
-
-## 23. Webchat and the browser UI
-
-`aimee-runtime-web` serves a browser chat + dashboard. It is a thin client: it holds
-no database and proxies to `aimee-server` over its `/v1` HTTP surface.
+A workflow is a typed graph of authors, delegates, verification, review, gates, forge operations,
+and fan-out:
 
 ```bash
-aimee-runtime-web --port 8080
+aimee workflow blocks
+aimee workflow new ~/.config/aimee/workflows/change.yaml
+aimee workflow validate ~/.config/aimee/workflows/change.yaml
+aimee workflow show ~/.config/aimee/workflows/change.yaml
+aimee workflow list
 ```
 
-It authenticates browser users with PAM (a self-signed TLS cert is generated if
-none is provided), serves the React UI from `frontend/`, streams chat over SSE,
-and proxies dashboard panels, collab-rule review, and a local channel board.
-Treat it as a *semi-trusted*, same-host/trusted-LAN surface, see
-[`docs/SECURITY.md`](docs/SECURITY.md).
+The Go control plane snapshots the definition and admitted request, then persists every lifecycle
+transition before it dispatches work. Plans, code, reviews, and gate decisions remain separate
+artifacts. A crash resumes from durable state.
 
-The UI is organized as a **top navigation bar**, one tab per tool, and each tab
-selects its own git **project** to operate on:
-
-- **Chat**, the agent conversation (streamed over SSE). The selected project
-  becomes the agent's working directory; webchat scope-validates it to the
-  signed-in user's own workspace.
-- **Dashboard**, a customizable grid of **server-incurred** metric panels
-  (delegations, metrics, token/cost, guardrail actions, agents, sessions,
-  readiness, and more). Toggle/reorder panels via **⚙ Customize**
-  (persisted per-browser). See [`docs/DASHBOARD.md`](docs/DASHBOARD.md).
-- **Logs**, the server's tool-action audit ledger — one row per tool call with
-  its guardrail verdict (`allow`/`block`/`rewrite`/`approval_required`),
-  filterable by verdict/actor/tool. (`aimee-kb` keeps its own dashboard for
-  KB-internal events.)
-- **Workflow Actions**, author and track [workflow](docs/WORKFLOWS.md) runs.
-- **Edit Workflows**, a visual composer for [workflow](docs/WORKFLOWS.md)
-  definitions (blocks rail, graph canvas, per-step persona/delegate assignment,
-  plus a persona manager). Validate/Save persist server-side.
-- **Projects**, connect git repositories. Clone over HTTPS *or* SSH-form URLs
-  (normalized to HTTPS); manage **per-host** credentials in the server vault and
-  sign in to GitHub via OAuth device flow. aimee-server is single-user but talks
-  to many hosts/providers, so credentials are keyed by **host, never per user**.
-- **Editor**, an in-browser **VS Code** (a per-user `code-server`, supervised
-  by the server and reverse-proxied at `/vscode/`) opened on the selected
-  project. Enabled by default (`WITH_VSCODE=1` in the image, `AIMEE_WEBCHAT_
-  EDITOR=1`).
-
----
-
-## 24. The HTTP /v1 API
-
-The server exposes a native HTTP /v1 REST surface (over `aimee-http.sock` or an
-optional localhost TCP port) for programmatic and OpenAI-compatible access.
-
-**OpenAI-compatible inference** (SSE streaming supported):
-- `POST /v1/chat/completions`, `POST /v1/completions`, `POST /v1/embeddings`,
-  `POST /v1/responses`.
-
-**Runs:**
-- `POST /v1/runs`, `GET /v1/runs/{id}`, `GET /v1/runs/{id}/events` (SSE replay),
-  `POST /v1/runs/{id}/stop`.
-
-**Read surfaces:**
-- `GET /v1/health`, `/v1/version`, `/v1/capabilities`, `/v1/models`,
-  `/v1/rules`, `/v1/notes`, `/v1/roadmap`, `/v1/agents`, `/v1/curiosity`,
-  `/v1/kb/status`, `/v1/dashboard/memory`, `/v1/dashboard/reminders`,
-  `/v1/persona`, `/v1/personas`, `/v1/personas/{name}`,
-  `/v1/sessions/{id}/persona`.
-- `POST /v1/kb/search`, `/v1/memory/recall`, `/v1/notes/search`.
-
-**Conventions:** UDS callers authenticate by peer UID; TCP callers present an
-`Authorization: Bearer <token>` (optionally `scope:`-prefixed to constrain
-capabilities, a scoped token is denied on inference with a 403). `X-Request-ID`
-is echoed and access is logged. The server contract source of truth is
-[`api/openapi-server-v1.yaml`](api/openapi-server-v1.yaml). The generated
-[`docs/gen/api-v1.md`](docs/gen/api-v1.md) documents the separate `aimee-kb`
-HTTP API generated from [`api/openapi-v1.yaml`](api/openapi-v1.yaml).
-
----
-
-## 25. Integrations
-
-| Tool | Integration | Setup |
-|------|-------------|-------|
-| Claude Code | Hooks + MCP, or any primary model via the Anthropic ingress | `./install.sh` / `aimee claude-proxy enable` |
-| Codex CLI | Hooks + MCP + local plugin, or any primary model via the Responses ingress | `./install.sh` / `~/.codex/config.toml` |
-| OpenCode | Any primary model via the OpenAI-compatible ingress | `./install.sh` |
-| Gemini CLI | Hooks | `./install.sh` |
-| Mistral Vibe | Provider-CLI primary + subscription-plan delegates (incl. `mistral-plan`) | `aimee agent setup mistral-plan` |
-| GitHub Copilot | MCP server | `./install.sh` |
-| VS Code | MCP tools in Copilot Chat agent mode, or aimee as an OpenAI-compatible model via the `/v1` API | [docs/VSCODE.md](docs/VSCODE.md) |
-
-`configure-hooks.sh` registers PreToolUse/PostToolUse/SessionStart hooks and the
-MCP server in each tool's settings. VS Code is wired MCP-only (no lifecycle
-hooks); see [docs/VSCODE.md](docs/VSCODE.md) for both the MCP and OpenAI-endpoint
-setups. Switching tools preserves all memory and
-context because everything lives in the shared server/KB, not in the tool. Direct
-Codex and Mistral primary sessions use server-side structured conversation state;
-explicit legacy routes (e.g. `codex-cli`) still use the provider CLI.
-
-**Opting out of auto-registration.** To stop aimee from writing itself into
-external tool configs, set `aimee config set client_integrations_enabled false`
-or export `AIMEE_NO_CLIENT_INTEGRATIONS=1` (the env var overrides the config key
-and is also honored by `install.sh` / `configure-hooks.sh`). Registration then
-becomes a no-op across all tools (Claude Code, Gemini, Copilot, Codex). This does
-not affect per-project `.mcp.json`: running `aimee setup` in a project directory
-still wires aimee into that single project, so you can confine aimee to one
-project instead of registering it globally.
-
-### Claude Code on any primary model (Anthropic ingress)
-
-aimee-server exposes the Anthropic Messages API at `POST /v1/messages` (with
-streaming and `/v1/messages/count_tokens`). Point Claude Code at it and every
-turn runs on aimee's configured **primary agent**, minimax, mistral, mimo,
-gemini, openai, or anthropic, instead of Anthropic's models. It is a stateless
-wire-format proxy: Claude Code keeps owning its own system prompt, history, and
-tools (tool execution stays client-side); aimee only translates the wire format
-and swaps the model. Switch models with `aimee primary <agent>`.
-
-Enable it (writes `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` into
-`~/.claude/settings.json`):
-
-```sh
-aimee claude-proxy enable http://127.0.0.1:8910 <server-bearer>
-# or, with AIMEE_SERVER_URL / AIMEE_SERVER_TOKEN already set:
-aimee claude-proxy enable
-aimee claude-proxy disable   # restore Claude Code to Anthropic
-```
-
-This is **off by default** and reroutes **all** Claude Code sessions (including
-running ones), so it is only ever changed by this explicit command. For a
-one-off session without touching settings, set the env vars inline instead:
-
-```sh
-ANTHROPIC_BASE_URL=http://127.0.0.1:8910 ANTHROPIC_AUTH_TOKEN=<bearer> claude
-```
-
-(The server must be reachable over HTTP, loopback TCP with a bearer, or a
-remote `AIMEE_SERVER_URL`.)
-
-### Codex on any primary model (Responses ingress)
-
-aimee-server also exposes the OpenAI Responses API at `POST /v1/responses` (with
-SSE streaming), the sibling of the Claude Code ingress above. To the open-source
-Codex CLI/TUI, aimee then behaves exactly like any other model: point Codex's
-model provider at aimee and it is indistinguishable from `gpt-5.x`. Codex drives
-its normal agent loop, aimee runs the turn on a registered primary-agent model
-selected by the request `model` field, and aimee participates in Codex's tool
-loop (it emits `function_call` items, Codex executes them in the user's
-workspace, and returns `function_call_output`). `GET /v1/models` lists the
-registered primary-agent models so Codex can list and switch models from its UI.
-
-Add a provider to `~/.codex/config.toml` and select it:
-
-```toml
-[model_providers.aimee]
-name = "aimee"
-base_url = "http://<aimee-host>:<port>/v1"
-wire_api = "responses"
-env_key = "AIMEE_API_KEY"          # aimee loopback bearer
-requires_openai_auth = false
-
-model_provider = "aimee"
-model = "aimee"                     # or any slug from GET /v1/models
-```
-
-Like the Anthropic ingress, this is a stateless wire-format proxy: Codex keeps
-owning its prompt, history, and tool execution; aimee translates the wire format
-and swaps the model. Switch models with `aimee primary <agent>`.
-
-### Any OpenAI-compatible front end (OpenCode, VS Code, custom clients)
-
-Tools that speak the OpenAI Chat Completions wire format point at
-`POST /v1/chat/completions` (SSE streaming supported) and run on aimee's primary
-agent the same way. This covers OpenCode, VS Code configured with aimee as an
-OpenAI-compatible model
-(see [docs/VSCODE.md](docs/VSCODE.md)), and any custom client. Whatever front end
-you choose, the memory, guardrails, and delegation are identical because they
-live in the shared server and KB, not in the tool.
-
----
-
-## 26. Server and service management
-
-`aimee-server` runs as a long-lived service. In the recommended Docker deployment
-it is a container supervised by Docker's restart policy; manage it with `docker
-compose` ([§27.1](#271-containerized-deployment)). On a source install it is a
-systemd user unit, launchd agent, or Windows service wrapper installed by the
-platform scripts. Either way the thin CLI does not implicitly spawn a server for
-ordinary RPC commands. To manage a source-installed server explicitly:
+Triggers and cron can start a run:
 
 ```bash
-aimee server status      # health
-aimee server start       # cross-platform fallback spawn if no service is running
-aimee server restart     # SIGTERM + respawn
-aimee status             # full system health overview
-aimee hud                # live session telemetry
+aimee trigger fire --help
+aimee trigger list
+aimee cron list
 ```
 
-**As a managed service:**
+Autonomous mode removes routine operator steps. It never passes a human gate. A human gate parks
+until an authenticated person signs the current content hash.
+
+Parallel slices use separate branches and worktrees, then merge against the latest accepted feature
+tip. A missing commit, merge conflict, exhausted loop, lost review replay, or broken forge operation
+parks or fails with a named reason. It does not advance on an empty result.
+
+See [Workflows](docs/WORKFLOWS.md), [Workflow actions](docs/WORKFLOW_ACTIONS.md), and
+[Autonomous development](docs/AUTONOMOUS_DEVELOPMENT.md).
+
+## Agents, providers, and models
 
 ```bash
-# Linux (systemd user units installed by install.sh)
-systemctl --user enable --now aimee-kb.service aimee-server.service
-systemctl --user status aimee-server
-journalctl --user -u aimee-server -f
-
-# macOS (launchd agents)
-launchctl load ~/Library/LaunchAgents/com.aimee.kb.plist
-launchctl load ~/Library/LaunchAgents/com.aimee.server.plist
+aimee agent list
+aimee agent probe <name>
+aimee provider list --available
+aimee provider test <name>
+aimee model list
+aimee model show <model>
 ```
 
-`aimee-kb` starts first; `aimee-server` orders after it. Units set memory/task
-limits and restart on failure. Logs go to the journal (Linux) or
-`~/Library/Logs/aimee/` (macOS), plus
-`~/.config/aimee/server.log`.
+Provider payloads are translated into one canonical request/response IR. Policy, budgets, tool
+handling, retries, accounting, and context reduction operate on that IR; provider-specific JSON
+stays at the edge.
 
----
-
-## 27. Operations and deployment
-
-### 27.1 Containerized deployment
-
-Running the services in containers is the recommended deployment: developers
-install only the thin client ([§3.2](#32-install-the-thin-client)) and point it at
-the server. Three compose files ship, built from two images: `aimee-server`
-(`Dockerfile.server`) and `aimee-kb` (`Dockerfile`). The KB image includes
-PostgreSQL 18, pgvector, and pgvectorscale. On a new install, the KB initializes
-DB2 in its persistent home volume and auto-applies its schema
-(`pg_trgm` and `vector` extensions plus tables) on first boot. The stacks run the
-`aimee-llm` inference gateway (embeddings, reranking, and synthesis) as a service,
-which downloads its cpu-tier models on first boot, so embedding and reranking work
-with nothing external. The tier is chosen by `AIMEE_LLM_TIER`: `cpu` serves
-Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers (`small` 16 GB, `mid` 24 GB,
-`large` 32 GB) serve Qwen3-Embedding-4B at 2560 dims.
-To run a standalone embedder or curator LLM instead, use
-the `curator-llm` compose profile. Backends and tiers:
-[KB_LLM_BACKENDS.md](docs/KB_LLM_BACKENDS.md) and
-[AIMEE_KB_SYNTH_TIERS.md](docs/AIMEE_KB_SYNTH_TIERS.md).
-
-| Compose file | Brings up | Use when |
-|--------------|-----------|----------|
-| `compose.server-managed.yaml` | `aimee-server` only; the wizard's Deploy step then launches self-contained `aimee-kb` + `aimee-llm` via the mounted Docker socket | **Recommended default.** One container to deploy; the browser wizard brings up the rest. |
-| `compose.server.yaml` | `aimee-server` + self-contained `aimee-kb` + the `aimee-llm` inference gateway | Advanced: the full split stack brought up together, no socket mount. Scale/update/place server and kb independently. |
-| `compose.yaml` | Self-contained `aimee-kb` + the `aimee-llm` inference gateway | The knowledge service alone: building block for a shared/scaled kb. |
-| `compose.server-standalone.yaml` | `aimee-server` only (SQLite DB1, no kb) | DB1-backed `/v1` with no shared knowledge. |
-
-**Bring up the self-deploying server:**
+Credentials live in the server vault:
 
 ```bash
-docker compose -f compose.server-managed.yaml up -d
-# open https://localhost:8443, run the wizard, hit Deploy on the last screen
-# then run the enrollment and verified-health sequence in Quickstart §1.3
+aimee vault unlock
+aimee vault set <agent> <name> <secret>
+aimee vault list
+aimee vault lock
 ```
 
-The rest of this section covers the **split stack** (`compose.server.yaml`) for
-advanced operators who run each service as its own container. It runs **both** aimee binaries as separate services: `aimee-kb` serving
-`/v1` on `:8741`, and the server fronting `/v1` over TLS on `:8743` (plaintext
-`:8740` is loopback-only) with `AIMEE_KB_API_URL=http://aimee-kb:8741`, so server
-and kb communicate over the internal network. The `aimee-llm` service provides the
-synthesis and curator gateway; to run a standalone llama.cpp curator LLM instead,
-add `--profile curator-llm` (works on `compose.server.yaml` and `compose.yaml`).
-Each container runs as a
-non-root user; the kb uses Python sidecars (`scripts/embed-remote.py`,
-`llm-chat.py`, `curator-extract.py`, `learning-synthesize.py`) for embeddings,
-synthesis, and curation, with container defaults from `deploy/container/aimee.yaml`.
+Do not put provider secrets in project files, delegate prompts, workflow artifacts, or client-side
+agent registries. Local CLI agents may use their own login on the client when they execute there;
+that credential is not uploaded.
 
-**Container lifecycle**: the binaries run as long-lived container processes
-(PID 1), supervised by Docker's restart policy, not systemd/launchd:
+## Personas, roles, rules, and toolsets
+
+Personas set the point of view; role templates set the job contract:
 
 ```bash
-docker compose -f compose.server.yaml ps           # container + health status
-docker compose -f compose.server.yaml logs -f      # follow logs (add a service to scope)
-docker compose -f compose.server.yaml restart aimee-server aimee-kb
-docker compose -f compose.server.yaml down         # stop + remove containers (volumes persist)
-docker compose -f compose.server.yaml down -v      # also DROP data volumes (destroys DB2 + state)
-docker compose -f compose.server.yaml up -d --build # update: rebuild images, recreate containers
+aimee persona list
+aimee persona show reviewer
+aimee roles list
+aimee roles show review
 ```
 
-**State and volumes.** Durable data lives in named volumes, not the container
-filesystem, so recreate is safe and only `down -v` erases it: `*-kb-home`
-(`/var/lib/aimee`) holds KB runtime state plus embedded DB2 (`aimee_shared`);
-`*-server-home` holds server runtime state (DB1 SQLite + config); `*-workspaces` (`/var/lib/aimee-workspaces`,
-`AIMEE_WORKSPACES_DIR`) holds the mirror-tier bare mirrors + reconstructed
-worktrees; `*-models` volumes cache embedder/LLM weights. The server's worker
-threads need a 64 MB stack, so every server container sets `ulimits.stack:
-67108864` (a plain `docker run` must pass `--ulimit stack=67108864`). Override the
-baked `aimee-local-dev` bearer and other config by mounting your own `aimee.yaml`
-at `/var/lib/aimee/aimee.yaml`.
-
-**Verify a stack end to end.** Each topology ships a smoke test that brings it up,
-waits for health, exercises the live surface (DB + vector readiness, search,
-embeddings, and the server→kb path), then tears down; `e2e-matrix.sh` runs several
-and prints one pass/fail table:
+Rules are durable behavior constraints:
 
 ```bash
-scripts/aimee-server-docker-smoke.sh --up --down              # split server + kb
-scripts/aimee-kb-docker-smoke.sh --up --down                  # kb-only
-scripts/aimee-server-standalone-docker-smoke.sh --up --down   # server standalone
-scripts/e2e-matrix.sh --only T1,T2,T3                         # all Docker topologies
+aimee rules list
+aimee rules generate
+aimee rules delete <id>
 ```
 
-A proxy front-end is available via `Dockerfile.proxy` + `docker-compose.proxy.yml`.
+Skills are project-scoped instruction packages. Toolsets are named bundles of tools:
 
-### 27.2 Health and observability
+```bash
+aimee skill list
+aimee skill show <name>
+aimee toolset list
+aimee toolset resolve <name>
+```
 
-- `GET /v1/health` (server and KB) for liveness.
-- `aimee status`, `aimee hud`, `aimee insights --days 30` for operational state
-  and token spend.
-- `otel` config in `aimee.yaml` for OpenTelemetry export.
-- `server.log`, `audit.log` under `~/.config/aimee/`.
+The host AI's own sub-agent launchers may be blocked so delegated work goes through aimee's policy,
+worktree, budget, and audit path.
 
-### 27.3 Backup
+## MCP, ACP, and model ingress
 
-DB2 (`aimee_shared`) holds durable knowledge, back it up with standard
-Postgres tooling (`pg_dump`). In a shared KB deployment, treat it as shared
-infrastructure and back it up accordingly. DB1 (`aimee.db`) is local
-`aimee-server` runtime state and is generally reconstructable; back it up if you
-depend on session history.
+`aimee mcp-serve` exposes memory, index, and delegate tools over stdio JSON-RPC. Client setup writes
+the supported coding-tool registrations unless `AIMEE_NO_CLIENT_INTEGRATIONS=1` is set.
 
-### 27.4 Resource tuning
+The MCP registry audits configured servers and checks packages against OSV:
 
-Thread pools and concurrency are tunable in `aimee.yaml`
-(`compute_threads`, `worker_threads`, `background_threads`, `concurrency.
-per_model.<model>`). Service-unit memory limits cap the server and KB
-independently.
+```bash
+aimee mcp audit
+aimee mcp recheck
+```
 
-### 27.5 Scaling and multi-user deployment
+ACP editors can run the ACP bridge. OpenAI Chat Completions, OpenAI Responses, and Anthropic
+Messages ingress let compatible clients use aimee as their model endpoint. All routes still pass
+server auth, policy, provider translation, and audit.
 
-aimee's scaling model follows its storage boundary exactly. The two tiers scale
-differently *by design*, and understanding which is which is the whole story:
+Use `aimee api status` for endpoint snippets. See [Public API](docs/PUBLIC_API.md).
 
-| Tier | Scope | How it scales |
-|------|-------|---------------|
-| `aimee-server` | **1:1 with a user** | Vertical only. One server per OS login, on that user's machine. |
-| `aimee-kb` | **Many users** | Horizontal. N stateless replicas behind a load balancer over one Postgres. |
-| Postgres (DB2) | The shared substrate | Standard Postgres scaling: instance sizing, pooling, read replicas; pgvector → pgvectorscale for large vector corpora. |
+## Browser workspace
 
-#### `aimee-server` is one-per-user
+The browser includes chat, projects, agents, workflows, workflow actions, the code graph, logs,
+settings, and per-user VS Code. Git credentials are stored in the server vault. SSH private keys
+live in a sealed runtime area and are exposed to git through a short-lived agent, not copied into a
+repository.
 
-`aimee-server` owns DB1, the local, same-user runtime state (sessions, working
-memory, conversation windows, checkpoints, jobs, secrets), and authenticates
-callers by `SO_PEERCRED` peer UID. Its trust model is "same Unix user = same
-principal." It is therefore **single-tenant and local by construction**: you do
-not shard it, replicate it, or place it behind a load balancer. Each developer
-(each OS login) runs exactly one `aimee-server`, normally as a systemd user unit
-or launchd agent. You scale a single user's server *vertically* (more in-flight
-delegates and parallel tool calls) with the thread-pool and concurrency knobs in
-[§27.4](#274-resource-tuning); that does not, and is not meant to, make it serve
-other users.
+The managed deployment page can control the host Docker daemon because the server container mounts
+its socket. Use the split stack when that authority is too broad.
 
-#### `aimee-kb` is the horizontally-scalable, many-user tier
+See [Browser workspace](docs/DASHBOARD.md), [VS Code](docs/VSCODE.md), and
+[Web git security](docs/WEBCHAT_GIT_SECURITY.md).
 
-`aimee-kb` owns DB2 and is where multi-user scale-out lives. Three properties make
-it horizontally scalable:
+## Configuration
 
-1. **State lives in Postgres, not in the process.** A KB instance holds only
-   transient state (connection pools, request buffers, worker loops); all durable
-   knowledge is in DB2. Each instance is effectively a **stateless request server
-   over a shared database**.
-2. **It is reachable over the network.** KB serves its full `/v1` contract over
-   HTTP on `:8741` (`AIMEE_KB_API_URL`, optional bearer token via
-   `AIMEE_KB_API_BEARER_TOKEN`), the only transport since the Unix-socket RPC was
-   retired in #2747. Many `aimee-server` instances (many users, on many
-   machines) can point at one KB endpoint.
-3. **Concurrent instances are safe with no external coordinator.** The background
-   pipeline (ingest, curator, embedding, index-update) claims work directly off
-   DB2 queues with `FOR UPDATE SKIP LOCKED`, so two workers never claim the same
-   row. Postgres *is* the coordinator.
+The main file is `~/.config/aimee/aimee.yaml`. Project settings live in
+`.aimee/project.yaml`; multi-repository workspaces use `aimee.workspace.yaml`. Agents and network
+inventory use `agents.json`.
 
-So the scale-out recipe is the standard stateless-web-tier one: **run several
-`aimee-kb` replicas behind a load balancer, all pointed at one Postgres.** Query
-traffic (search, recall, index reads, the hot path the servers hit) fans out
-across replicas; the workers on each replica drain the shared queues
-cooperatively. Point every server at the load-balanced KB with `AIMEE_KB_API_URL`
-(or the `kb` block in `aimee.yaml`).
+```bash
+aimee config show
+aimee config get <key>
+aimee config set <key> <value>
+```
 
-#### The database is just standard Postgres
+Environment variables override file values where the generated reference says they do. Restart-only
+fields take effect on the next daemon start. The browser settings page exposes only allowlisted,
+non-secret runtime fields.
 
-DB2 is one ordinary Postgres database (`aimee_shared` by default) with the
-`pg_trgm` and `vector` (pgvector) extensions; there is no bespoke datastore. You
-scale it with the normal Postgres playbook:
+Use the [generated configuration reference](docs/gen/configuration.md). It is more reliable than a
+copied table in this manual.
 
-- **Vertical sizing** of the Postgres instance (CPU/RAM/IOPS).
-- **Connection pooling** (e.g. PgBouncer) in front of Postgres; each KB instance's
-  own pool is bounded by `db2_pool_size` (1-32, default 8).
-- **Read replicas** to fan out query load when one primary is saturated.
+## Remote access
 
-Vector search rides inside the same Postgres and scales with it:
+`aimee remote set` stores the target in `~/.config/aimee/remote.conf`. That file is private to the
+user and opened without following symlinks.
 
-- **pgvector HNSW is the default**: for memory vectors always, and for all
-  small-to-medium corpora. Nothing extra to install; this is what a fresh
-  `install.sh` gives you.
-- **pgvectorscale (StreamingDiskANN) is the opt-in scale-up** for large corpora.
-  It is *additive*: built on top of pgvector, it reuses the same `vector` column
-  type and distance operators and only adds the `USING diskann` index, disk-backed
-  with bounded build memory, for the large/RAM-constrained regime where HNSW's
-  in-memory graph becomes the bottleneck. Select it per corpus table:
+The shared bearer authorizes reads. A remote write needs a short-lived KB-signed identity token and
+a grant for the exact `(server_id, team_id, subject)`. `data` covers memory, docs, and index
+ingestion. `full` also covers agent, delegate, runner, and workspace control.
 
-  ```yaml
-  db2:
-    vector:
-      corpus_index: auto          # auto | hnsw | diskann
-      corpus_diskann_threshold: 1000000   # rows/table before "auto" picks diskann
-  ```
+The server must know `AIMEE_SERVER_ID`, `AIMEE_SERVER_TEAM_ID`, and the root-owned
+`AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE`. Grant changes are local-socket only:
 
-  `auto` uses HNSW until a corpus table exceeds the threshold *and* the
-  `vectorscale` extension is installed, then picks diskann; it falls back to HNSW
-  with a notice when the extension is absent (so schema apply never hard-fails).
-  Memory/hot-path vectors stay HNSW unconditionally.
-- **Switching index type is a reindex, not a migration.** Data and queries are
-  identical across HNSW and diskann; `aimee kb repair --reindex-corpus` rebuilds
-  corpus indexes to the configured/`auto` type with no re-embedding and no query
-  rewrite. This is what makes "started local on pgvector, grew, flipped to
-  pgvectorscale" a config change rather than a data move.
+```bash
+aimee kb grant set --server <id> --team <n> --subject <subject> --tier data
+aimee kb grant list --server <id> --team <n>
+```
 
-#### Deployment topologies
+`aimee.api.remote_writes` remains readable for compatibility but no longer authorizes user writes.
+See [Upgrading](docs/UPGRADING.md#restore-remote-writes) for subject forms and first-grant recovery.
 
-| Topology | Shape | When |
-|----------|-------|------|
-| **Containerized server + KB (default)** | `aimee-server` + self-contained `aimee-kb` as containers (brought up together via `compose.server.yaml`) + the `aimee-llm` inference gateway ([§27.1](#271-containerized-deployment)); developers run only the thin client. | The recommended deployment for one user or a team. |
-| **Single developer, source build** | One `aimee-server` + one local `aimee-kb` + local Postgres, all on one host via service units. | The `install.sh` no-Docker setup. |
-| **Shared KB** | Many users' `aimee-server` instances point at one `aimee-kb`/Postgres over HTTP. DB1 stays per-user/per-machine; only KB-scoped knowledge crosses the boundary. | A team or a single user across several machines wanting shared knowledge. |
-| **Scaled KB** | Several `aimee-kb` replicas behind a load balancer (`:8741`) over one Postgres (with pooling and, if needed, read replicas + pgvectorscale). | Many users and/or a large corpus where one KB instance or plain HNSW is the bottleneck. |
+Use `aimee remote clear` to return to the local Unix socket.
 
-In every topology the contracts are identical: thin clients speak `/v1` to their
-per-user server (local `aimee-http.sock` or a remote `host:port`); servers speak
-the typed KB `/v1` HTTP API to `aimee-kb`; the storage boundary holds. See
-[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §11 for the architectural view.
+See [Thin client](docs/THIN_CLIENT.md) and [Security](docs/SECURITY.md).
 
----
+## Audit and diagnostics
 
-## 28. Troubleshooting
+```bash
+aimee status
+aimee kb status
+aimee workers
+aimee audit verify
+aimee doctor forensics
+aimee economizer stats
+```
+
+The WORM audit ledger is the durable security record. Event-bus capture is the ordered diagnostic
+and observational replay stream. Capture does not execute tools again.
+
+Audit verification uses exit codes: `0` green, `1` amber, `2` red. Treat red as an integrity
+failure, preserve the store, and investigate before rotating or truncating anything.
+
+## Update and backup
+
+Before an upgrade, back up:
+
+- `~/.config/aimee/` including DB1, config, vault material, TLS state, and workflow files;
+- the KB PostgreSQL database with `pg_dump` or the container export helper;
+- any external witness or audit seal destination.
+
+Do not copy a live SQLite file without its WAL/SHM files or a consistent backup operation. Do not
+use `docker compose down -v` when a named volume is your only database copy.
+
+After updating binaries and containers:
+
+```bash
+aimee server restart
+aimee status
+aimee kb status
+aimee audit verify
+```
+
+On a remote thin client, `aimee self-update --check` compares the client with its server. Where
+binary replacement is supported, `aimee self-update` downloads the matching release, verifies it,
+and swaps the executable without downgrading.
+
+Read [What's new](docs/WHATS_NEW.md) before changing deployment manifests.
+
+## Troubleshooting
 
 | Symptom | Check |
-|---------|-------|
-| `aimee status` cannot reach the server | Is `aimee-server` running? `aimee server start`; check `~/.config/aimee/server.log`; confirm `aimee-http.sock` exists and is owned by you. |
-| KB queries fail / `kb status` errors | Is Postgres up with `aimee_shared` and the `vector`/`pg_trgm` extensions? Is `aimee-kb` running and `db2_url` correct? |
-| Memory search returns nothing | Check `aimee memory list` to confirm stored entries, `aimee kb status` for vector/KB health, and `aimee index scan --force` when the missing evidence is code-derived. |
-| Symbol lookups empty | `aimee index scan --force`; confirm `universal-ctags` is installed. |
-| Delegate fails immediately | `aimee provider test <name>`; check credentials/`auth_cmd`; inspect `aimee delegate log`. |
-| Writes blocked unexpectedly | Planning mode active, or a worktree redirect, check `guardrail_mode` and `aimee session show`. Set `AIMEE_ANTIPATTERNS_BYPASS=1` only to confirm a diagnosis. |
-| Build fails on `make check-linking` | A tier boundary was violated (libpq in server, SQLite in KB). See [`src/README.md`](src/README.md). |
-| Webchat login fails | PAM service `aimee-runtime-web` configured? Check login rate limiting and TLS cert. |
+| --- | --- |
+| client cannot connect | `aimee remote status`; URL, DNS, port, TLS fingerprint, bearer, client cert |
+| local socket missing | service manager, `aimee server start`, server log, config-dir permissions |
+| reads work but writes fail | server id/team/JWKS trust, exact subject grant, identity-token refusal reason |
+| KB unavailable | `aimee kb status`, KB bearer, `AIMEE_KB_API_URL`, PostgreSQL readiness |
+| memory search is empty | KB scope, ingest status, embedding readiness, query filters |
+| delegate cannot write | assigned worktree, write role, sandbox backend, source authority |
+| delegate has no network | expected default; configure mediated egress or packages explicitly |
+| workflow parked | inspect the named reason, latest artifact, gate, agent limit, or merge conflict |
+| audit count is short | event-bus drop counter, sink errors, unclean shutdown, capture file status |
+| browser deploy fails | Docker socket mount, daemon access, image pull, volume permissions |
+| model returns nothing | provider response diagnostic, model registry, auth, quota, retry record |
 
-Raise log verbosity with `AIMEE_LOG_LEVEL=debug`. For unclean server exits,
-shutdown forensics are recorded to DB1 and surfaced by `aimee status`.
+Logs live under `~/.config/aimee/` for source installs and in the relevant container for compose
+deployments. Preserve the first error and the operation ID; later failures are often consequences.
 
-Feature implementation status is tracked in [`docs/STATUS.md`](docs/STATUS.md);
-platform support in [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
+## Files
 
----
-
-## Appendix A, Environment variables
-
-| Variable | Effect |
-|----------|--------|
-| `AIMEE_HOME` | Override the config/state root (default `~/.config/aimee`). |
-| `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` | Thin-client target: remote `aimee-server` URL (`http[s]://host:port`) + bearer. Overridden by `--server`/`--server-token`; persisted form is `<aimee_home>/remote.conf`. |
-| `AIMEE_TLS_INSECURE` | Skip TLS certificate verification for the thin client's `https://` connections (self-signed/dev only). |
-| `AIMEE_API_ENDPOINT` / `AIMEE_API_BEARER` / `AIMEE_API_CLIENT_TRANSPORT` | Lower-level CLI transport: endpoint (`tcp:host:port` or `unix:/path`), bearer, and `http`/`socket` selector. Mirrors `aimee.api.client_endpoint` / `bearer_token` / `client_transport` in `aimee.yaml`. |
-| `AIMEE_PROFILE` | Select a configuration profile. |
-| `AIMEE_MODE` | Operating mode (e.g. planning vs implement). |
-| `AIMEE_MODEL` / `AIMEE_EFFORT` | Override model / reasoning effort for a run. |
-| `AIMEE_LOG_LEVEL` | Log verbosity (`debug`, `info`, …). |
-| `AIMEE_SESSION_ID` | Bind the current process to a session id. |
-| `AIMEE_SESSION_START_VERBOSE` | Include broad diagnostic sections in the session brief. |
-| `AIMEE_HOOK_CLIENT` | Identify the calling tool to the hook layer. |
-| `AIMEE_NO_CLIENT_INTEGRATIONS` | If set to any value other than `0`/`false`, aimee skips auto-registering itself into external AI-tool configs. Overrides `client_integrations_enabled` (forces off only); honored by the aimee binary and by `install.sh` / `configure-hooks.sh`. |
-| `AIMEE_MCP_CWD` | Working directory for the MCP bridge. |
-| `AIMEE_ACTIVE_TOOLSET` / `AIMEE_TOOLSETS_CONFIG` | Select / locate the active toolset. |
-| `AIMEE_GUARDRAILS_PATH` | Override guardrail policy path. |
-| `AIMEE_ANTIPATTERNS_BYPASS` | Bypass anti-pattern warnings (diagnostic only). |
-| `AIMEE_CONTEXT_NO_KB` / `AIMEE_NO_CACHE` | Skip KB context / disable caches. |
-| `AIMEE_DELEGATE_DEPTH` / `AIMEE_PARENT_DELEGATION_ID` | Delegation nesting controls. |
-| `AIMEE_DELEGATE_WORKTREE_ROOT` | Root for delegate worktrees. |
-| `AIMEE_DELEGATE_SOURCE_PATHS` / `AIMEE_DELEGATE_SOURCE_AUTHORITY` | Delegate source-access policy. |
-| `AIMEE_DELEGATE_HEARTBEAT_MONITOR` | Enable delegate heartbeat monitoring. |
-| `AIMEE_PARALLEL_MAX` / `AIMEE_VERIFY_PARALLEL` | Parallelism caps for delegates / verification. |
-| `AIMEE_VERIFY_STEP_TIMEOUT_MS` | Per-step verification timeout. |
-| `AIMEE_MEMORY_WEIGHT_PROFILE` | Retrieval-weight profile override. |
-| `AIMEE_KB_API_URL` / `AIMEE_KB_API_BEARER_TOKEN` | KB `/v1` HTTP endpoint and bearer token. Required for kb-backed (shared/vector) features; the server no longer autostarts `aimee-kb`. |
-| `AIMEE_KB_NO_AUTOSTART` | Deprecated no-op (the kb socket autostart was retired in #2747; the server only reaches kb via `AIMEE_KB_API_URL`). |
-| `AIMEE_DB1_URL` / `AIMEE_DB2_URL` | Storage URLs used by containerized/explicit deploys: DB1 `sqlite:///…` (server) and DB2 `postgresql://…/aimee_shared` (kb). |
-| `AIMEE_EMBEDDER_URL` | Embedding service endpoint for the kb (e.g. the `aimee-llm` gateway `http://aimee-llm:8742`). |
-| `AIMEE_SERVER_HTTP_BIND` / `AIMEE_KB_HTTP_BIND` | Bind the server/kb `/v1` listener on `0.0.0.0` (set `1` in containers so the published port is reachable). |
-| `AIMEE_WORKSPACES_DIR` | Mirror-tier workspace root (bare mirrors + reconstructed worktrees); containers mount a volume here (`/var/lib/aimee-workspaces`). |
-| `AIMEE_KB_MODE` | Install-time selector (`local`/`remote`) consumed by `install-deps.sh`/`install.sh`. |
-| `AIMEE_SERVER_STARTUP_FD` | Internal: server startup handshake fd. |
-| `AIMEE_DOCKER_BIN` / `AIMEE_DOCKER_WORKDIR` | Docker backend for delegate execution. |
-| `AIMEE_SSH_BIN` | SSH binary for remote delegate/host access. |
-| `AIMEE_WORKTREE_GC` / `AIMEE_WORKTREE_GC_DAYS` | Worktree GC policy. |
-| `AIMEE_FORENSICS_DIR` | Shutdown-forensics output directory. |
-| `AIMEE_BUNDLED_SKILLS_DIR` | Override bundled-skills location. |
-| `AIMEE_MODELS_DEV_SNAPSHOT` / `AIMEE_MODEL_CAPABILITY_OVERRIDES` | Model metadata overrides. |
-| `AIMEE_INSTALL_PREFIX` | Install prefix used by scripts. |
-
-Provider credentials are also read from the usual provider variables
-(`OPENAI_API_KEY`, `GEMINI_API_KEY`/`GOOGLE_API_KEY`, `MISTRAL_API_KEY`, …) and
-from `~/.vibe/.env` for Mistral routes.
-
----
-
-## Appendix B, Files and paths
-
-```
+```text
 ~/.config/aimee/
-  aimee.yaml                  # main configuration
-  agents.json                 # delegate agents + network inventory
-  aimee.db (+ -wal, -shm)     # DB1 local state (SQLite)
-  aimee-http.sock             # aimee-server /v1 HTTP Unix socket (loopback)
-  remote.conf                 # persisted thin-client remote target (aimee remote set)
-  server.token                # (legacy; unused since the NDJSON RPC socket was removed)
-  server.log / audit.log      # server + audit logs
-  aimee.pid / *.lock          # process/lifecycle files
-  session-<id>.state          # per-session state
-  worktrees/<id>/<project>/   # per-session git worktrees
-  projects/<name>.md          # auto-generated project descriptions
-  tls/cert.pem, key.pem       # self-signed TLS (webchat)
+  aimee.yaml           main configuration
+  agents.json          agents and network inventory
+  aimee.db             DB1 SQLite
+  remote.conf          thin-client target and trust state
+  workflows/           workflow definitions
+  captures/ or audit-* event capture and audit material
+  tls/                 local certificate state
+  server.log           server log
 
-~/.local/bin/                 # installed binaries (aimee, aimee-server, ...)
-~/.local/share/aimee/skills/  # bundled skills
-
-<project>/.aimee/project.yaml     # per-project metadata (build/test/lint)
-<project>/.aimee/roadmap/         # roadmap projections + HTML reports
-<project>/.mcp.json               # MCP server registration
-<workspace>/aimee.workspace.yaml  # multi-repo workspace manifest
+<project>/.aimee/project.yaml
+<workspace>/aimee.workspace.yaml
 ```
 
-DB2 lives in PostgreSQL (database `aimee_shared` by default), not on the
-filesystem under `~/.config/aimee`. That Postgres instance can be local to one
-machine or shared by multiple `aimee-server` instances, depending on deployment.
+DB2 is PostgreSQL, not a file under the config directory. Workflow lifecycle rows belong to the Go
+control plane even when it shares the server container.
 
----
-
-## Appendix C, Glossary
+## Terms
 
 | Term | Meaning |
-|------|---------|
-| **Primary agent** | The AI coding tool you interact with directly. |
-| **Delegate agent** | A sub-agent in `agents.json` that handles offloaded work. |
-| **DB1 / DB2** | Pinned storage tiers: local SQLite owned by `aimee-server` / local-or-shared Postgres + pgvector owned by `aimee-kb`. |
-| **L0-L3** | Memory lifecycle tiers: session / recent / long-term / episodic. |
-| **Worktree** | Per-session isolated git working tree + branch. |
-| **Guardrail** | Server-side safety check run before each tool call. |
-| **Hook** | SessionStart / PreToolUse / PostToolUse integration point. |
-| **MCP** | Model Context Protocol; aimee exposes tools via `aimee mcp-serve`. |
-| **Capability token** | Bearer token granting scoped server operations. |
-| **Charter** | Pipeline proposing durable behavioral artifacts for review. |
-| **Roadmap / auto loop** | Goal decomposition tree + deterministic dispatch loop. |
-| **Toolset** | A named, composable bundle of tools. |
-| **KB** | The knowledge base owned by `aimee-kb` (DB2), local or shared depending on deployment. |
-
----
-
-*This manual reflects the codebase at the time of writing. The installed build is
-always authoritative, use `aimee help --all` and `aimee help <command>` for the
-exact commands and flags in your version.*
+| --- | --- |
+| primary | the AI tool or model the user is working with |
+| delegate | a policy-controlled agent doing a bounded task |
+| persona | a named perspective and instruction set |
+| DB1 | local server SQLite state |
+| DB2 | KB PostgreSQL and pgvector state |
+| event bus | intra-daemon typed shared-memory transport |
+| capture | ordered observational bus record; never automatic execution replay |
+| worktree | isolated git checkout assigned to a session or work item |
+| gate | workflow step that requires a verdict before the run advances |
+| IR | provider-neutral request and response representation |

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,43 +1,45 @@
-# Module Ownership
+# Ownership
 
-Hotspot modules requiring explicit review when modified.
-Changes to files listed below should be reviewed by the named owner.
+Every durable store, wire contract, and policy boundary has one runtime owner. Shared helpers may
+serve several modules; they do not inherit authority over those modules.
 
-## Hotspot Modules
+| Area | Owner | Paths | Review focus |
+| --- | --- | --- | --- |
+| event bus | runtime core | `src/modules/bus/`, `server-go/bus/` | wire vectors, ordering, backpressure, leases, admission, shutdown |
+| audit and governance | audit module | `src/modules/audit/` | completeness, PII bounds, WORM parity, witness behavior |
+| DB1 | server | `src/db1/` | migrations, transaction ownership, local privacy |
+| DB2 | KB | `src/db2/`, `src/kb/` | schema, scope, retrieval, pgvector, ingest |
+| workflow lifecycle | Go WFE | `server-go/internal/` | single writer, durable transition before dispatch, recovery, forge confinement |
+| tool execution | server tools/policy | tool and guardrail modules | schemas, capabilities, worktree/path checks, audit |
+| delegate sandbox | sandbox module | `src/modules/sandbox/`, delegate backends | mounts, network, credentials, packages, resource bounds |
+| vault | vault module | vault and credential bridges | custody, principal, rotation, no plaintext fallback |
+| provider IR | IR/translation modules | provider ingress/egress modules | canonical shape, loss, tool parity, streaming |
+| routes | owning service | route descriptors, OpenAPI, handlers | auth, scope, write tier, compatibility |
+| configuration | config module | field descriptors and stores | one descriptor, defaults, validation, restart behavior |
+| thin client | client transport | CLI and native TLS files | no database linkage, path ownership, trust state |
+| browser | runtime web and frontend | `runtime-web/`, `frontend/` | user isolation, CSRF, proxy authority, no direct storage |
 
-| File | Layer | Cap | Owner | Notes |
-|------|-------|-----|-------|-------|
-| `webchat/` | Go service | 2000 | aimee core | Standalone browser webchat service |
-| `src/modules/guardrails/guardrails.c` | 1 (data) | 2000 | aimee core | Safety-critical policy enforcement |
-| `src/cmd_agent.c` | 3 (cmd) | 2000 | aimee core | Agent command entry points |
-| `src/agent_tools.c` | 2 (agent) | 2000 | aimee core | Tool execution engine |
-| `src/mcp_git.c` | 0 (core) | 1850 | aimee core | Git operations (has layer exemptions) |
-| `src/cmd_agent_trace.c` | 3 (cmd) | 1750 | aimee core | Agent trace/debug UI |
-| `src/cmd_hooks.c` | 3 (cmd) | 1700 | aimee core | Hook management |
-| `src/memory.c` | 1 (data) | 1600 | aimee core | Tiered memory system |
-| `src/agent.c` | 2 (agent) | 1600 | aimee core | Agent execution loop |
-| `src/mcp_server.c` | 0 (core) | 1600 | aimee core | MCP server protocol |
-| `src/db.c` | 0 (core) | 1600 | aimee core | Database + migrations |
+## Boundary rules
 
-## Layer Exemptions
+- Lower-level helpers cannot include a higher-level owner to get at its state.
+- Code outside DB1 or DB2 uses the public typed API, never a database handle.
+- A migrated workflow family has one writer. Shadow reads may compare; dual writes are forbidden.
+- Provider wire formats end at translation. Core stages consume canonical IR.
+- A new inter-module path uses the event bus or an existing typed resource API, not a private queue.
+- A new command, route, config field, event kind, or workflow block updates its canonical descriptor
+  and generated documentation.
 
-Known layer boundary violations tracked for reduction:
+## Required review
 
-| Source File | Includes | Violation | Reason |
-|-------------|----------|-----------|--------|
-| `src/render.c` | `agent_types.h` | L0 -> L2 | Render needs agent type definitions for display |
-| `src/mcp_git.c` | `guardrails.h` | L0 -> L1 | Git operations enforce guardrail checks |
-| `src/mcp_git.c` | `branch_ownership.h` | L0 -> L1 | Git operations enforce branch ownership |
-| `src/cmd_describe.c` | `commands.h`, `agent.h` | L1 -> L2/L3 | Describe command straddles layers |
+Changes need explicit boundary review when they touch:
 
-## Layer Architecture
+- event framing, capture, or audit durability;
+- storage schema or ownership;
+- authentication, write grants, vault custody, or egress;
+- tool execution, worktree confinement, or sandbox degradation;
+- workflow state transitions, forge operations, or human gates;
+- public API compatibility or generated SDKs;
+- cross-language C/Go contracts.
 
-```
-Layer 3: Commands + UI  (cmd_*, webchat, dashboard)
-Layer 2: Agent          (agent*, http_retry)
-Layer 1: Data + Policy  (memory*, index, extractors, rules, guardrails, workspace, ...)
-Layer 0: Foundation     (db, config, util, text, render, log, platform_*, mcp_*)
-```
-
-Lower layers must not include headers from higher layers. Violations require an
-entry in the exemption table above and in `src/tests/test_build_integrity.sh`.
+Run the narrow unit target while iterating, then the ownership, linkage, module, docs, and sanitizer
+gates named by the changed area.

--- a/README.md
+++ b/README.md
@@ -1,118 +1,163 @@
 # aimee
 
 A local server that gives any AI coding tool a persistent memory, a map of your code, cheap
-delegate models, and guardrails it can't write past. Point your tool at it, or run it
+delegate models, and guardrails it can't write past. A shared-memory event bus gives the whole
+runtime one ordered place to observe and audit what it does. Point your tool at it, or run it
 alongside. Your context follows you between tools.
 
 Two parts:
 
-- **aimee-server** is an assistant to one human. Learns how you work and what you expect.
-  General purpose, but coding is what it does best, especially across large or multi-repo
-  work.
-- **aimee-kb** is a knowledge base for a whole corpus: a subject, a company, a team.
+- **aimee-server** is an assistant to one human. It owns sessions, tools, credentials, delegates,
+  and workflows.
+- **aimee-kb** is a knowledge base for a corpus, team, or company. It owns durable knowledge, code
+  indexes, retrieval, and curation.
+
+The `aimee` CLI is a thin client. Linux, macOS, and Windows builds talk to the same server.
 
 ## What it does
 
-- **Memory across sessions and tools.** A curator distills each session into a typed
-  knowledge base, dedupes facts, flags contradictions, and lets stale detail decay. Point a
-  team at one kb and everyone works from the same memory. See [KNOWLEDGE.md](docs/KNOWLEDGE.md).
-- **Your code as a graph.** aimee indexes your code into a symbol and call graph, spanning
-  repos. The AI finds callers and traces an edit's blast radius before it writes.
-  See [CODE_INTELLIGENCE.md](docs/CODE_INTELLIGENCE.md).
-- **Delegates that cut the bill.** Route review, summarization, and boilerplate to the
-  cheapest model that can do it. A local GPU model or a subscription plan costs nothing
-  extra. The primary gets a compact result back. See [DELEGATES.md](docs/DELEGATES.md).
-- **Guardrails.** `.env`, keys, and prod configs are blocked before the AI touches them.
-  Planning mode freezes writes. Every session is fully isolated by aimee.
-  See [SECURITY.md](docs/SECURITY.md).
-- **Any model, any provider.** Point a tool's OpenAI or Anthropic compatible API at aimee
-  and it runs the turn on any model: Claude, GPT, Gemini, a model on your own GPU. Or run
-  aimee beside the tool over MCP/ACP and it keeps its own model. Switch tools whenever.
-- **Workflows.** Compose a job from typed steps and aimee runs it to a PR, with review
-  panels and human sign-off gates where you want them. See [WORKFLOWS.md](docs/WORKFLOWS.md).
-- **Run your own inference.** Embeddings, reranking, and synthesis in one CPU or GPU
-  container. The kb curates locally, no outside API calls. See [KB_LLM_BACKENDS.md](docs/KB_LLM_BACKENDS.md).
-- **A browser workspace.** `aimee-runtime-web`: chat, a live code graph, a git project manager,
-  an in-app VS Code editor, and dashboards. No terminal required. See [DASHBOARD.md](docs/DASHBOARD.md).
+- **One bus for the runtime.** Each daemon owns a bounded shared-memory event bus. Governed
+  actions, memory mutations, guardrail decisions, vault reads, sandbox degradation, MCP calls,
+  and tool outcomes all cross the same sequenced tap. The tap feeds the WORM audit ledger and an
+  exact capture stream without putting storage on the request path. See [Event bus](docs/EVENT_BUS.md).
+- **Memory across sessions and tools.** The curator extracts facts, joins related evidence,
+  catches contradictions, and lets stale detail decay. One KB can hold product knowledge, code,
+  documents, decisions, and conversation history. See [Knowledge](docs/KNOWLEDGE.md).
+- **Your code as a graph.** Symbols, callers, imports, git co-changes, and cross-repo dependencies
+  feed search and blast-radius checks. See [Code intelligence](docs/CODE_INTELLIGENCE.md).
+- **Delegates that cut the bill.** Route review, diagnosis, drafting, and routine implementation to
+  the cheapest model fit for the role. Use an API, a local model, Codex OAuth, or an installed CLI.
+  See [Delegates](docs/DELEGATES.md).
+- **Roundtables.** Give a draft or diff to several models, require repository evidence, then let a
+  chair remove weak findings and return one result. See [Ensembles](docs/ENSEMBLE.md).
+- **Workflows that finish the job.** Typed blocks take a proposal through planning, implementation,
+  verification, review, and a PR. Triggers and cron jobs can start runs; human gates always stop
+  for a human. See [Workflows](docs/WORKFLOWS.md).
+- **Guardrails.** Secret paths, unsafe writes, worktree escapes, untrusted MCP packages, and direct
+  credential use are checked before execution. Delegate sandboxes can run with no network and no
+  credentials. See [Security](docs/SECURITY.md).
+- **Any model, any provider.** OpenAI Chat Completions, OpenAI Responses, Anthropic Messages,
+  Gemini, Mistral, local OpenAI-compatible servers, and AWS Bedrock all pass through one internal
+  request format. Switch the primary model without switching tools.
+- **Local inference.** One `aimee-llm` container serves embeddings, reranking, and synthesis on CPU
+  or GPU. The KB runs no model itself. See [Inference](docs/KB_LLM_BACKENDS.md).
+- **Document ingestion.** Push source trees, Markdown, text, and PDFs. Structured PDF mode keeps
+  coordinates, tables, page crops, OCR text, and citations. See [Structured PDF](docs/STRUCTURED_PDF.md).
+- **A browser workspace.** Chat, projects, agents, workflows, the code graph, logs, settings, and
+  an in-browser VS Code editor live in one UI. See [Browser UI](docs/DASHBOARD.md).
+- **An API, not a lock-in.** Use aimee through MCP, ACP, the CLI, the browser, or the versioned
+  `/v1` APIs. OpenAI- and Anthropic-compatible ingress lets existing front ends use aimee as their
+  model endpoint.
 
-Core services are C. Hot paths run in single-digit milliseconds. Nothing phones home.
+Core services are C. The workflow control plane and browser are Go. Hot paths stay small. Nothing
+phones home.
 
 ## Get started
 
-One container to start. The browser wizard brings up the rest.
+Start one container. The browser wizard brings up the KB and inference services.
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
 cd aimee
-
-# Start aimee-server. It mounts the host Docker socket so the wizard can launch
-# aimee-kb (including its embedded PostgreSQL), and the LLM for you — CPU or GPU.
-# No second compose command or database container.
 docker compose -f compose.server-managed.yaml up -d
 ```
 
-Open <https://localhost:8443>, log in as `aimee` / `aimee-local-dev`, and run the setup
-wizard: pick a primary agent, choose CPU or GPU, connect a git host, pick workspaces. Its
-**Deploy** step brings up aimee-kb and the LLM; PostgreSQL + pgvector run inside the KB
-container and persist in its volume. Change the login (`AIMEE_WEBCHAT_USER`
-/ `AIMEE_WEBCHAT_PASSWORD`) before you put it on a network.
+Open <https://localhost:8443> and sign in as `aimee` / `aimee-local-dev`. The wizard picks the
+primary agent, inference tier, git hosts, and workspaces. Its last step starts:
 
-Then install the `aimee` CLI on each dev machine and point it at the server:
+- `aimee-kb`, with private PostgreSQL 18, pgvector, and pgvectorscale inside the container;
+- `aimee-llm`, on CPU or GPU.
+
+Change `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` before putting it on a network. The
+managed compose file mounts the Docker socket; that gives aimee-server control of the host Docker
+daemon. Use the regular split stack if you do not want that.
+
+Install the `aimee` release binary on each development machine, then enroll it:
 
 ```bash
-aimee remote set https://host:8743 aimee-local-dev # pins TLS, enrolls mTLS, rotates bootstrap
-aimee status                                       # server, DB1, and knowledge-base health
-aimee kb status                                    # knowledge-base detail (ingest queue, curator)
+aimee remote set https://host:8743 aimee-local-dev
+aimee remote status
+aimee status       # server, DB1, and KB health
+aimee kb status    # detailed KB state
 ```
 
-`aimee-local-dev` is a **one-time bootstrap bearer**: the first `remote set` trades it
-for a strong per-deployment token, pins the server's certificate and enrols a client
-certificate, and it stops working after that. A second machine uses the rotated token
-(the server keeps it in `aimee.yaml` under `aimee.api.bearer_token`). See
-[QUICKSTART 1.3](docs/QUICKSTART.md#13-verify-its-healthy).
+`remote set` pins a private server certificate, prints its fingerprint, rotates the one-use
+bootstrap bearer, and, on Linux, enrolls an individual mTLS certificate. Confirm the fingerprint
+out of band. The bootstrap bearer stops working after the first enrollment.
 
-aimee wires its hooks and MCP server into your AI coding tools on first run — opt out with
-`AIMEE_NO_CLIENT_INTEGRATIONS=1`.
-
-[QUICKSTART.md](docs/QUICKSTART.md) walks the full setup. Every deployment topology and the
-from-source install live in [Deployment and operations](src/README.md#deployment-and-operations).
-Upgrading an existing install? [UPGRADING.md](docs/UPGRADING.md) lists user-facing changes.
-Questions? Join the [Discord](https://discord.gg/FjGjvcgAqz).
+The client registers hooks and MCP with supported coding tools on first setup. Set
+`AIMEE_NO_CLIENT_INTEGRATIONS=1` to keep global tool configuration untouched. The shared bearer is
+read-only. Configure server identity trust and grant the user before running write or delegate
+commands; the [Quickstart](docs/QUICKSTART.md#remote-write-setup) covers it.
 
 ```bash
-aimee memory store myhost "PVE at 10.0.0.1"   # a fact the AI keeps across sessions
+aimee memory store myhost "PVE at 10.0.0.1"
 aimee memory search "proxmox"
-aimee delegate review "Review this PR"         # route to a cheaper model
+aimee index find kb_client
+aimee delegate review --persona reviewer "Review the current diff"
 aimee status
 ```
 
+The [Quickstart](docs/QUICKSTART.md) covers release binaries, the split stack, source builds,
+client setup on all three platforms, and first-run checks.
+
+## Since v0.2.192
+
+The current tree is a large step past the last public release. The short version:
+
+- every daemon gained a bounded shared-memory event bus, C and pure-Go clients, typed routing,
+  backpressure, large-payload leases, capture/replay, and a single audit seam;
+- action audit, memory writes, semantic guardrails, vault access, sandbox degradation, MCP calls,
+  and tool outcomes moved onto that bus; accepted records drain to durable sinks on shutdown;
+- the bus made cross-language modules, external attachment, uniform policy, workflow events, and
+  full-stream telemetry possible without another private side channel; those consumers land one at
+  a time behind their own contracts and tests;
+- the workflow control plane moved to Go and now schedules parallel slices, live forge work,
+  triggers, retries, review loops, and human gates;
+- the combined appliance image is gone; managed and split deployments use separate server, KB,
+  and inference containers;
+- the KB container now owns its PostgreSQL database and can export it to an external server;
+- delegates gained role/persona routing, stronger admission, isolated worktrees, networkless
+  containers, package mediation, custom images, and learned toolchains;
+- all provider wires now pass through one canonical request/response IR;
+- server-to-KB pooling and resident thin-client keep-alive now default on, and a configured remote
+  no longer falls back to a local server for selected commands;
+- roundtables gained evidence requirements, per-seat model selection, retries, and an optional
+  reasoning chair;
+- the server gained mTLS client enrollment, per-request revocation checks, a sealed credential
+  vault, org model catalogs, budgets, rate limits, spend reporting, Bedrock, and WORM audit paths;
+- interactive `aimee chat`, the old work queue, `aimee migrate v2`, and the combined image were
+  removed.
+
+See [What's new](docs/WHATS_NEW.md) for the full grouped change list and upgrade notes.
+
 ## Docs
 
-| Document | What's in it |
-|----------|--------------|
-| [Manual](MANUAL.md) | Full reference: install, config, commands, feature guides. |
-| [Architecture](docs/ARCHITECTURE.md) | Processes, storage, trust boundaries, request lifecycles. |
-| [Technical Reference](src/README.md) | Code internals, RPC/HTTP surfaces, build, deployment. |
-| [Commands](docs/COMMANDS.md) | Client command contract, flags, options. |
-| [How aimee learns](docs/KNOWLEDGE.md) | The kb, the self-learning pipeline, delegation economics. |
-| [Code intelligence](docs/CODE_INTELLIGENCE.md) | Symbol/call graph, cross-repo deps, blast radius. |
-| [Workflows](docs/WORKFLOWS.md) | The dev-lifecycle workflow engine and authoring. |
-| [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system. |
-| [Delegate Sandbox](docs/DELEGATE_SANDBOX.md) | Running delegates in a network-none container and customizing its image. |
-| [Compatibility](docs/COMPATIBILITY.md) | Supported OS, shell, and provider matrix. |
-| [Feature Status](docs/STATUS.md) | Implementation status of all features. |
+Start at the [documentation index](docs/README.md).
 
-More references live under [docs/](docs/).
+| Document | Use it for |
+|----------|------------|
+| [Quickstart](docs/QUICKSTART.md) | Install, enroll, verify. |
+| [Manual](MANUAL.md) | Day-to-day use and operations. |
+| [Architecture](docs/ARCHITECTURE.md) | Processes, storage, trust, request flow. |
+| [Event bus](docs/EVENT_BUS.md) | Routing, ordering, audit, capture, and extension contracts. |
+| [Deployment](docs/DEPLOYMENT.md) | Managed, split, external DB2, backup, and hardening. |
+| [Upgrading](docs/UPGRADING.md) | Move from v0.2.192 without losing data or identity. |
+| [Command reference](docs/gen/cli-commands.md) | Every CLI command. Generated from source. |
+| [Configuration reference](docs/gen/configuration.md) | Every config key and environment variable. Generated from source. |
+| [Server API](docs/PUBLIC_API.md) | `/v1` transport, auth, compatibility, generated specs. |
+| [Feature status](docs/STATUS.md) | What works, what is gated, what was removed. |
+| [Troubleshooting](docs/TROUBLESHOOTING.md) | Diagnose the first broken boundary. |
+| [Technical reference](src/README.md) | Modules, build, tests, and code ownership. |
 
 ## Community
 
-Questions and discussion on the aimee Discord: <https://discord.gg/FjGjvcgAqz>.
+Questions and discussion: <https://discord.gg/FjGjvcgAqz>.
 
 ## License
 
-Copyright (C) 2026 The aimee authors. Licensed under the **GNU AGPL v3.0** (AGPL-3.0). See
+Copyright (C) 2026 The aimee authors. Licensed under the **GNU AGPL v3.0**. See
 [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
-If the AGPL doesn't suit you, other terms can be discussed. Contact <jbailes@gmail.com>.
-Bundled third-party components (cJSON, the generated SDKs under `api/sdks/`) are licensed
-separately; see [NOTICE](NOTICE).
+If the AGPL does not suit you, other terms can be discussed. Contact <jbailes@gmail.com>.
+Bundled components and generated SDKs may use different licenses; [NOTICE](NOTICE) lists them.

--- a/control-web/README.md
+++ b/control-web/README.md
@@ -1,44 +1,25 @@
-# kb-console
+# KB console
 
-Standalone Go thin-client that fronts a shared **aimee-kb**'s `/v1` for the web
-console. See `docs/KB_CONSOLE.md` for the trust model and how to run it.
+`control-web` is the browser administration client for a shared `aimee-kb`.
 
-## What is (and is NOT) reused from `webchat/`
+It owns browser login, sessions, CSRF, a deny-by-default proxy, and console-local action audit. It
+does not own KB data or reuse runtime-web PAM authority.
 
-The console deliberately mirrors `aimee-runtime-web`'s *shape* but shares no code with
-it, so the kb's auth surface is not coupled to webchat's PAM-typed upstream.
+| File | Responsibility |
+| --- | --- |
+| `auth.go` | OIDC verification and explicit break-glass path |
+| `session.go` | per-user SQLite sessions and CSRF token |
+| `acl.go` | mirror of the KB console-admin route allowlist |
+| `proxy.go` | authenticated `/api` to KB `/v1` proxy |
+| `audit.go` | console administration audit |
+| `tls.go` | HTTPS setup |
 
-**Reused (as patterns, reimplemented here):**
-- Auto-TLS HTTPS server with a self-signed cert (see `tls.go`).
-- A SQLite session store (`session.go`), 0600, with a session cookie.
-- An `/api/*` reverse proxy shape to the kb `/v1` (`proxy.go`).
-- Serving a single inlined SmoothGUI SPA (`server.go` → `frontend/dist-console/`).
-
-**NOT reused (intentionally):**
-- `github.com/RakuenSoftware/smoothgui/auth` and `RunPAMHelper` — the console does
-  no PAM. Login is OIDC (`auth.go`) with a presence-flag break-glass.
-- Any `pam_*` import or webchat session/helper code.
-
-## Files
-
-| file | role |
-|------|------|
-| `main.go` | flags/env, config load, fail-fast startup probe, TLS, listen |
-| `config.go` | config + 0600 cred-file contract + read-only OIDC file |
-| `auth.go` | OIDC JWT verify (RS256/JWKS, pinned admin claim) + break-glass flag |
-| `session.go` | SQLite sessions bound to `(iss,sub)`, timeouts, CSRF token |
-| `acl.go` | Go mirror of the kb console-admin route allowlist (defence-in-depth) |
-| `proxy.go` | deny-by-default `/api/*` → kb `/v1` with the console-admin bearer + CSRF |
-| `server.go` | routes, strict CSP, login/logout/session/SPA handlers |
-| `audit.go` | console-admin action audit (console-local sink) |
-| `tls.go`, `helpers.go` | auto-TLS, small utilities |
-
-## Build & test
+The console and KB allowlists must agree; the KB remains authoritative.
 
 ```bash
+cd control-web
+go test ./...
 go build ./...
-go test ./...          # ACL, proxy deny-by-default, CSRF, session binding, break-glass-off
 ```
 
-The kb-side containment lives in `src/kb/http/kb_route_acl.c` (unit-tested by
-`src/tests/test_kb_route_acl.c`); the console's `acl.go` must stay in sync with it.
+See [KB console](../docs/KB_CONSOLE.md).

--- a/deploy/css-render/README.md
+++ b/deploy/css-render/README.md
@@ -1,107 +1,80 @@
-# aimee css-render sidecar (#4-full render backend)
+# CSS render sidecar
 
-The render backend for the CSS migration assistant's **rendered computed-style
-oracle** (#4-full). It turns `{html, css}` into a computed-style snapshot by
-rendering in headless Chromium, so the oracle can diff the *computed* style of a
-component before vs. after a conversion, the real correctness signal, stronger
-than the static declaration-set oracle.
+This sidecar gives the CSS migration assistant a computed-style oracle. It renders untrusted HTML
+and CSS in headless Chromium, then returns a bounded snapshot for before/after comparison. aimee-kb
+never embeds a browser.
 
-Because it renders **untrusted** application/exemplar markup in a browser engine
-(a code-execution surface, proposal §8), it runs as an **isolated container** that
-aimee-kb reaches only over HTTP (or stdin/stdout). aimee never embeds a browser.
+## Contract
 
-## How aimee talks to it
+`css_render_command` reads this on stdin:
 
-aimee's render adapter is the configured `css_render_command`: a shell command
-that reads `{"html","css"}` on stdin and writes the snapshot JSON on stdout
-(exactly like `embedding_command` drives the embedder). Two shapes:
-
-- **HTTP sidecar**, a long-running container; the command `curl`s it.
-- **One-shot**, an ephemeral container per render reading stdin → stdout → exit
-  (`oneshot.js`); zero idle footprint.
-
-With it configured, aimee-kb registers the backend at startup and
-`aimee css render-capture <project> <unit> <before|after> <html> <css>` renders +
-stores a snapshot; `aimee css render-verify <project> <unit>` diffs before/after.
-
-## Files
-
-- `snapshot.js`, shared headless render (the `[data-ref]` capture + property
-  allowlist).
-- `render.js`, long-running HTTP server (`POST /render`, `GET /health`).
-- `oneshot.js`, stdin `{html,css}` → stdout snapshot → exit.
-- `css-render-ctl.sh`, on-demand lifecycle (`up` / `down` / `status` / `reap` /
-  `render`).
-- `Dockerfile`, isolated, non-root, JS-disabled render context.
-
-## Snapshot contract
-
-Request: `{"html":"...","css":"..."}` → 
 ```json
-{"nodes":[{"ref":"<selector>","computed":{"<prop>":"<value>", ...}}, ...]}
+{"html":"...","css":"..."}
 ```
-Nodes captured = every element with a `data-ref` attribute. Properties = a fixed
-box/visual allowlist (`snapshot.js` `PROPS`), small so diffs stay stable and
-snapshots bounded.
 
-## Build
+It writes:
 
-```sh
+```json
+{"nodes":[{"ref":"header","computed":{"display":"flex"}}]}
+```
+
+Only elements with `data-ref` are captured. `snapshot.js` fixes the property allowlist so snapshots
+stay small and stable.
+
+Files:
+
+- `snapshot.js`: render and capture;
+- `render.js`: long-running `POST /render` server plus `GET /health`;
+- `oneshot.js`: one render over stdin/stdout;
+- `css-render-ctl.sh`: start, stop, inspect, reap, or run the container;
+- `Dockerfile`: non-root Chromium image with page JavaScript disabled.
+
+## Run it
+
+Build once:
+
+```bash
 docker build -t aimee-css-render deploy/css-render
 ```
 
-## On-demand deployment (don't run Chromium 24/7)
+For a migration session, start the HTTP sidecar:
 
-Pick one of three patterns. All keep Chromium off except while migrating.
-
-### 1. Session-scoped (recommended, no privilege change to aimee-kb)
-
-Start the sidecar only around a migration session; aimee-kb just `curl`s it.
-
-```sh
-deploy/css-render/css-render-ctl.sh up            # before migrating
-# aimee.yaml (aimee-kb):
-#   css_style_graph_enabled: true
-#   css_render_command: "curl -s --max-time 30 --data-binary @- http://<host>:8780/render"
-# ... run `aimee css render-capture ...` / render-verify ...
-deploy/css-render/css-render-ctl.sh down          # after
+```bash
+deploy/css-render/css-render-ctl.sh up
 ```
 
-aimee-kb needs **no** container privileges, it only makes an HTTP call. The
-oracle reports `UNAVAILABLE` (never a fake verdict) whenever the sidecar is down.
-
-### 2. Lazy-start + idle-stop
-
-As (1), but leave it warm during active work and let a cron reap it after idle
-(render.js stamps a marker on every render):
-
-```cron
-*/5 * * * *  /path/css-render-ctl.sh reap 900     # stop after 15 min idle
-```
-
-### 3. Per-render ephemeral (zero idle)
-
-A fresh container per render via `oneshot.js`. Point `css_render_command` straight
-at it:
+Point aimee-kb at it:
 
 ```yaml
-css_render_command: "/path/css-render-ctl.sh render"   # == docker run --rm -i aimee-css-render node oneshot.js
+css_style_graph_enabled: true
+css_render_command: "curl -s --max-time 30 --data-binary @- http://host:8780/render"
 ```
 
-This is the most "as-needed" (no idle container at all) but pays Chromium
-cold-start (~1–3 s) per render, and **requires container-launch access wherever
-`css_render_command` runs** (i.e. a Docker socket reachable from aimee-kb), a
-privilege surface to weigh vs. patterns 1–2.
+Capture and compare:
 
-### Non-default runtimes
-
-`css-render-ctl.sh` honours `DOCKER` and `DOCKER_HOST`. For the smoothnas
-LXC2Docker runtime:
-
-```sh
-DOCKER_HOST=unix:///run/smoothnas-runtime/docker.sock deploy/css-render/css-render-ctl.sh up
+```bash
+aimee css render-capture <project> <unit> before before.html before.css
+aimee css render-capture <project> <unit> after after.html after.css
+aimee css render-verify <project> <unit>
 ```
 
-Run the sidecar on an isolated network with no access to internal services (it
-executes untrusted CSS/HTML). JavaScript is disabled in the render context; only
-`<style>` + markup are evaluated.
+Stop it when done:
+
+```bash
+deploy/css-render/css-render-ctl.sh down
+```
+
+For zero idle cost, run one container per render:
+
+```yaml
+css_render_command: "/path/to/css-render-ctl.sh render"
+```
+
+That path pays Chromium startup on every call and needs access to a container runtime. The HTTP
+sidecar keeps Docker authority out of aimee-kb.
+
+`css-render-ctl.sh` honors `DOCKER` and `DOCKER_HOST`. If the backend is down, the oracle reports
+`UNAVAILABLE`; it does not invent a verdict.
+
+Run the sidecar on an isolated network with no route to internal services. HTML and CSS are
+untrusted input even with page JavaScript disabled.

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -1,150 +1,54 @@
-# aimee-llm synth tiers
+# Inference tiers
 
-The `aimee-llm` image is the unified Vulkan llama.cpp stack: one runtime serving
-**embeddings** (`/embed`), **reranking** (`/rerank`), and **synthesis**
-(`/v1/chat/completions`). It is **model-less** — the **tier** is
-chosen at runtime via `AIMEE_LLM_TIER` and the models are **downloaded on first
-boot** into the `/models` volume. (A pre-baked **`aimee-llm-cpu`** variant ships the
-cpu tier's models in the image for offline CPU-only deploys — see *Package names*
-below.) The four tiers differ only in the **synth
-model** (and its runtime profile); embed + rerank are identical within a CPU/GPU
-class, so a KB stays byte-portable when you switch the GPU synth tier.
+One `aimee-llm` image serves embedding, reranking, and synthesis. `AIMEE_LLM_TIER` selects the model
+set and concurrency at runtime.
 
-| `AIMEE_LLM_TIER` | Embed / Rerank | Synth | Runtime (target card) | Model download |
-|---|---|---|---|---|
-| `cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) | ~6.5 GB |
-| `small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB | ~11.4 GB |
-| `mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB | ~17.8 GB |
-| `large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `mid`, 4 slots — 32 GB | ~17.8 GB |
+| Tier | Intended host | Embedding width | Synthesis shape |
+| --- | --- | ---: | --- |
+| `cpu` | CPU-only host | 1024 | small local extraction/synthesis |
+| `small` | about 16 GB GPU | 2560 | Gemma 4 12B class |
+| `mid` | about 24 GB GPU | 2560 | Gemma 4 26B-A4B class, two slots |
+| `large` | about 32 GB GPU | 2560 | same class with more slots and context |
 
-`large` is identical to `mid` (same synth GGUF/revision/SHA + MoE/FA profile); it
-only serves `SYNTH_SLOTS=4` instead of `2`, so a 32 GB card runs **4 concurrent agents**
-each with the model's full native **256 K** window (deploy `AIMEE_LLM_SYNTH_CTX=1048576`).
-Gemma-4 uses interleaved sliding-window attention (only 5 of 30 layers are full-attention),
-so even 4×256 K KV stays ~28.5 GiB — validated against the 24 GB `mid` card (2×128 K =
-22.4/24 GiB). `small`, `mid`, and `large` share the **same embedder + reranker**
-(2560-dim), so a KB embedded on one is byte-compatible with the others — switching the synth
-tier is an `AIMEE_LLM_TIER` change, no re-embed.
+Hardware estimates include model residency, not every driver or concurrent workload. Validate on the
+real host before promising a slot count.
 
-**Model download** (the first-boot fetch into the `/models` volume, per tier): `cpu`
-~6.5 GB, `small` ~11.4 GB, `mid` / `large` **~17.8 GB** (embed 4.28 GB + rerank 0.79 GB +
-synth 14.25 GB). The **image itself is small** (no baked GGUFs) — allow ~20 GB free on the
-`/models` volume per GPU tier for the downloaded models. `mid` and `large` download the same
-models (only `SYNTH_SLOTS` differs); each tier caches under its own `/models/<tier>` subdir,
-so switching tiers keeps both. Embed + synth pull straight from Hugging Face; the ettin
-reranker is a pre-converted encoder GGUF + Dense head fetched from a GitHub release
-(published by `.github/workflows/publish-rerank-artifacts.yml`).
+## Deploy
 
-## Tier-A vs Tier-B synthesis
+```yaml
+environment:
+  AIMEE_LLM_TIER: cpu   # cpu | small | mid | large
+```
 
-The curator synthesizes in two tiers:
+The normal image downloads models into a persistent volume on first boot. The pre-baked CPU image is
+for offline installs. Moving between GPU tiers keeps the 2560-wide embedding schema. Moving between
+CPU and GPU widths requires the DB2 re-embed procedure.
 
-- **Tier A**: mechanical extract/index passes (extract docs, chunk, tag, index).
-- **Tier B**, the reasoning passes: judge, resolve entities, reconcile contradictions,
-  synthesize, promote.
+## Consumers
 
-The `cpu` tier runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider (a weak model would poison the graph), so a CPU-only deployment gets retrieval + Tier-A
-synthesis and nothing more. **Tier B needs a GPU tier (`small` / `mid` / `large`)
-or an external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
-config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
+The KB uses the gateway for curator and retrieval work. The server may also register the local
+synthesis model as a free delegate. These consumers have separate admission limits so background KB
+work cannot take every interactive slot.
 
-## Package names
+## Tune
 
-Keep the `aimee-*` inference-adjacent images straight:
+Concurrency, context, GPU layers, CPU expert offload, batch size, and model paths are deployment
+settings. Start from the tier default. Change one value at a time and record:
 
-- **`aimee-kb`**: the KB service (DB2 + curator). Runs no model; it calls one
-  over HTTP. See [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
-- **`aimee-llm`**: the model-less inference image in this doc (embed + rerank +
-  synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm`
-  plugin. The tier is `AIMEE_LLM_TIER`, not the image name; the models download on
-  first boot. Use it on GPU hosts.
-- **`aimee-llm-cpu`**: the **pre-baked** CPU variant — the same
-  `Dockerfile.aimee-llm` built with `AIMEE_LLM_BAKE_TIER=cpu`, so the cpu-tier GGUFs
-  ship inside the image and it serves offline with no first-boot download and no
-  `/models` volume. This is the pure-CPU appliance LLM that, with `aimee-server` +
-  `aimee-kb`, replaces the retired all-in-one `aimee-combined`. It answers at
-  `aimee-llm:8742` like the model-less image.
+- model identity and digest;
+- driver/runtime version;
+- resident memory;
+- first-token and total latency;
+- tokens per second;
+- maximum stable concurrent slots;
+- retrieval and structured-output quality.
 
-Retired names: `aimee-kb-{cpu,gpu-small,gpu-mid,gpu-large}` and `aimee-llm-gpu`
-were old **baked per-tier** images — replaced by the model-less `aimee-llm` image +
-`AIMEE_LLM_TIER` (the current `aimee-llm-cpu` above is a separate, deliberately
-pre-baked cpu image, not one of that retired per-tier set). `aimee-embedder`/
-`aimee-embedder-4b` were the standalone torch embedder, now served by `aimee-llm`.
+An out-of-memory restart is not backpressure. Lower slots or context until the service stays ready
+under the expected mixed load.
 
-## Deploy: one env knob
+## CPU and GPU separation
 
-The synth tier is chosen by `AIMEE_LLM_TIER` on the SmoothNAS `aimee-llm` plugin
-(or any compose topology), e.g. `AIMEE_LLM_TIER=mid` for Gemma 4 26B-A4B. No separate synth
-container, no `SYNTH_LOCAL` juggling, no image swap: the tier *is* the synth, and its models
-download on first boot.
+Cheap lexical/index work stays in PostgreSQL and KB workers. Model work goes to `aimee-llm`. GPU
+tiers use the larger embedder and reranker; the retrieval pipeline itself does not change.
 
-### Two consumers of the gateway synth (`/v1/chat/completions`)
-
-The gateway (`http://<runtime-gw>:8742/v1`, model alias `aimee-synth`) is used by two
-independent callers, one automatic, one an explicit operator step:
-
-1. **KB curator synthesis (automatic).** The `aimee-kb` plugin points `LLM_ENDPOINT` /
-   `LLM_MODEL` at the gateway, so the curator's `tier_a`/`tier_b` use the synth tier the
-   moment the container is deployed. Switching tiers needs no KB change.
-
-2. **aimee-server delegate, an explicit runtime registration (NOT automatic).** To make
-   the local synth usable as an `aimee` delegate (roundtable / fallback), register it once
-   against the server (endpoint is model-neutral, so the registration survives synth-tier
-   switches):
-
-   ```sh
-   aimee agent local local-synth http://<runtime-gw>:8742/v1 \
-       --model aimee-synth --provider openai --slots <SYNTH_SLOTS>
-   ```
-
-   The gateway runs auth-off on the internal bridge, so the agent uses `auth_type: none`.
-   This lives in the server's `agents.json` (runtime/per-deployment state, not baked into
-   the image). On `.254` this is registered as `local-synth` and sits in `fallback_chain`.
-
-## Synth runtime knobs (tier defaults; overridable via plugin env)
-
-Each tier sets these from the tier table in the supervisor; an explicit env still wins.
-
-| Env | Default (per tier) | Meaning |
-|---|---|---|
-| `AIMEE_LLM_SYNTH_CTX` | 32768; `mid` deploys `262144` (2 × 128 K), `large` `1048576` (4 × 256 K) | synth context window (total across slots) |
-| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on `mid`, 4 on `large`) | `--parallel` concurrent slots |
-| `AIMEE_LLM_SYNTH_FA` | `off` cpu / `on` gpu | flash-attention (required for quantized V-cache) |
-| `AIMEE_LLM_SYNTH_KV_K` / `_KV_V` | `q8_0` / `q4_0` (K8V4) | KV cache quant on the gpu tiers |
-| `AIMEE_LLM_SYNTH_MOE` | `1` on `mid`/`large` | enable the `--n-cpu-moe` expert-offload knob |
-| `AIMEE_LLM_SYNTH_N_CPU_MOE` | `0` on `mid`/`large` | MoE layers whose experts live in system RAM (0 = fully GPU-resident) |
-
-### Tuning `N_CPU_MOE` on the `mid` tier (Gemma 4 26B-A4B, ~14 GB synth)
-
-The mid tier is **Gemma 4 26B-A4B**, a MoE with only **4B active parameters/token** at
-`qat-UD-Q4_K_XL` (~14 GB). Unlike a 22 GB synth, it **co-fits embed+rerank (~7 GB) on a
-24 GB card fully resident** (~21 GB + Gemma's cheap sliding-window KV), so the default is
-`N_CPU_MOE=0`: no expert offload, fully GPU-resident.
-
-| Card | Suggested `N_CPU_MOE` | Notes |
-|---|---|---|
-| 24 GB | `0` (default) | fully resident; fastest. Drop `SYNTH_CTX` or offload a few layers only if VRAM is tight with 2 slots × 128 K |
-| 16 GB | ~24–32 | ~14 GB synth won't co-fit ~7 GB retrieval; spill most experts to RAM (slow but works) |
-
-Raise `N_CPU_MOE` only if the container logs a VRAM allocation failure; each offloaded
-layer frees GPU memory at the cost of RAM-path latency. Only 4B params are active, so
-offload costs less here than on a dense synth of the same size.
-
-### Flash-attention / K8V4
-
-K8V4 (`q8_0` K / `q4_0` V) is verified working on RADV/gfx1100 (7900 XTX). FA is
-enforced structurally (llama.cpp refuses a quantized V-cache without it), so a
-healthy container proves FA engaged. If a backend genuinely can't do FA, set
-`AIMEE_LLM_SYNTH_KV_V=f16` (K8V8 does **not** help; any quantized V needs FA).
-
-### GPU runtime: Mesa 25 / cooperative matrix
-
-The GPU tiers are based on `debian:trixie-slim` (Mesa 25) on purpose: its RADV exposes
-`VK_KHR_cooperative_matrix` on RDNA3 (gfx1100), so llama.cpp uses the card's WMMA matrix
-cores. On an older Mesa without coopmat (bookworm's 22.3.6) llama.cpp falls back to scalar
-shaders. The synth goes compute-bound, the memory bus sits idle, and generation crawls.
-
-Measured on the 7900 XTX, `mid` tier resident: **~1265 tok/s prompt, ~62–95 tok/s generation**
-with coopmat; ~33–76 / ~30 without it. If a GPU tier is slow, check the base image is
-trixie (Mesa ≥ 24.1) and that `mem_busy` climbs under load. A pegged GPU with an idle
-memory bus means the matrix cores aren't in play.
+See [KB inference backends](KB_LLM_BACKENDS.md) and [Retrieval stack](retrieval-stack.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,524 +1,211 @@
-# aimee Architecture
+# Architecture
 
-This document describes the system architecture of aimee: its processes, trust
-and storage boundaries, internal layering, and the lifecycle of a request as it
-moves through the system. For a usage-oriented manual see
-[`MANUAL.md`](../MANUAL.md); for code-level internals see
-[`src/README.md`](../src/README.md).
+aimee is a local-first runtime between AI tools, model providers, code, and durable knowledge. It
+keeps the fast client separate from stateful services, gives storage one owner, and sends internal
+module events through one bounded bus.
 
----
-
-## 1. Design goals
-
-aimee is a local-first memory, safety, and delegation layer that sits between a
-developer's AI coding tool and the work it performs. Its architecture is shaped
-by four hard constraints:
-
-1. **Invisible latency.** Hooks run in the critical path of every file edit, so
-   the client must start and respond in milliseconds. This drives the thin
-   client / persistent server split: a process that pays no database or
-   connection cost on startup.
-2. **Pinned storage ownership.** Knowledge must outlive any single session and
-   may need to be shared across tools or hosts, while same-user runtime state
-   stays local, private, and fast. This drives the DB1 / DB2 tier split with
-   strict, compile-enforced ownership.
-3. **Zero cloud dependencies for the core.** Everything required to run aimee,
-   memory, guardrails, indexing, delegation routing, works on the local
-   machine. External model providers are reached only when the user explicitly
-   delegates.
-4. **One install, many tools.** The same server backs Claude Code, Gemini CLI,
-   Codex CLI, Mistral Vibe, and GitHub Copilot, so integration logic lives in
-   one place and switching tools preserves all memory and context.
-
----
-
-## 2. Process topology
-
-aimee ships as **four primary artifacts** plus one optional gateway. Each is a
-separate OS process with a distinct responsibility and a distinct linkage
-profile (see §5).
+## Processes
 
 ```mermaid
-graph TB
-    subgraph User["User surface"]
-        Tool["AI coding tool<br/>Claude Code / Gemini / Codex / Vibe / Copilot"]
-        Browser["Browser"]
-    end
-
-    subgraph Local["Local machine (same-user trust zone)"]
-        CLI["aimee<br/>thin CLI + MCP serve<br/>(DB-free)"]
-        WC["aimee-runtime-web<br/>Go browser service<br/>(DB-free)"]
-        SRV["aimee-server<br/>DB1 owner · compute pool<br/>· RPC + HTTP /v1"]
-        KB["aimee-kb<br/>DB2 owner · local/shared KB<br/>· pgvector · ingest/curator"]
-        GW["aimee-gateway<br/>(optional) ambient presence"]
-        DB1[("DB1<br/>SQLite")]
-        DB2[("DB2<br/>Postgres + pgvector<br/>local or shared")]
-    end
-
-    subgraph External["Untrusted zone"]
-        Providers["Model providers<br/>OpenAI / Anthropic / Gemini / Ollama"]
-    end
-
-    Tool -->|hooks: stdin/stdout| CLI
-    Tool -->|MCP: stdio JSON-RPC| CLI
-    Browser -->|HTTPS + PAM| WC
-    CLI -->|/v1 HTTP<br/>UDS or TCP| SRV
-    WC -->|/v1 HTTP<br/>UDS or TCP| SRV
-    GW -.->|/v1 HTTP| SRV
-    SRV -->|typed KB /v1<br/>HTTP :8741| KB
-    SRV --> DB1
-    KB --> DB2
-    SRV -->|delegate HTTPS| Providers
-    KB -.->|embeddings / synthesis<br/>sidecars| Providers
+flowchart LR
+    T[AI tool] -->|hooks / MCP / ACP| C[aimee thin client]
+    B[Browser] --> W[aimee-runtime-web]
+    C -->|local UDS or authenticated /v1| S[aimee-server]
+    W -->|authenticated /v1| S
+    W -->|workflow API| F[aimee-wfe]
+    F -->|typed resource calls| S
+    S -->|typed /v1| K[aimee-kb]
+    S -->|provider API| P[model providers]
+    K -->|embed / rerank / synth| L[aimee-llm]
+    S --> D1[(DB1 SQLite)]
+    F --> WF[(workflow SQLite)]
+    K --> D2[(DB2 PostgreSQL + pgvector)]
 ```
 
-| Artifact | Language | Owns | Links | Startup |
-|----------|----------|------|-------|---------|
-| `aimee` | C11 | nothing (thin client) | `-lpthread` only, **no** SQLite, **no** libpq | < 10 ms |
-| `aimee-runtime-web` | Go | nothing (thin client) | pure Go (PAM via cgo) | fast |
-| `aimee-server` | C11 | Local DB1 (SQLite), sessions, compute pool, delegate routing, hooks, MCP dispatch, HTTP /v1 | `-lsqlite3`, **never** libpq | persistent |
-| `aimee-kb` | C11 | DB2 (Postgres + pgvector), memory inference, embeddings, code index, ingest/curator; local or shared by deployment | `-lpq`, **never** SQLite | persistent |
-| `aimee-gateway` | C11 | optional ambient-presence delivery (Telegram/ntfy/webhook, STT/TTS) | minimal | optional |
+| Process | Owns | Does not own |
+| --- | --- | --- |
+| `aimee` | CLI parsing, local hooks, MCP/ACP stdio, client filesystem access | databases, server policy, provider credentials |
+| `aimee-server` | sessions, DB1, agents, tools, policy, vault, provider calls, `/v1` resource plane | DB2, workflow lifecycle |
+| `aimee-wfe` | workflow definitions, scheduling, artifacts, retries, gates, worktrees, forge lifecycle | agent credentials, KB data, general chat |
+| `aimee-kb` | DB2, memory, documents, code graph, retrieval, curation | DB1, workflow state, model serving |
+| `aimee-runtime-web` | browser auth, session proxying, UI delivery | product databases and workflow decisions |
+| `aimee-llm` | embedding, reranking, synthesis inference | knowledge storage and curation policy |
 
-The two **thin clients** (`aimee`, `aimee-runtime-web`) never touch a database.
-They reach `aimee-server` over its `/v1` HTTP surface (the local `aimee-http.sock`
-Unix socket by default, or a remote `host:port`) and forward typed requests.
-This is what keeps the CLI startup under 10 ms and why hook checks add ~1 ms to a
-tool call: the expensive state already lives in a warm, long-running server.
+`aimee-server` and `aimee-wfe` run as supervised peers in the server image. If either exits, the
+container terminates both and fails. The C server returns `410 Gone` for retired workflow lifecycle
+routes; there is one workflow writer.
 
-`aimee-server` is normally started by the installed service manager: systemd user
-units on Linux, launchd on macOS, or the Windows service wrapper. The thin client
-does not implicitly spawn a server for ordinary RPC commands; `aimee server
-start` is the manual fallback for unmanaged environments.
+The browser, KB console, and optional ambient gateway are clients. They do not bypass the service
+that owns the data they display.
 
----
+## Two transports
 
-## 3. Storage tiers (the DB1 / DB2 boundary)
+aimee has two distinct communication layers.
 
-aimee has exactly **two storage tiers**. They are pinned ownership boundaries,
-not user-selectable backends. See [`STORAGE_TIERS.md`](STORAGE_TIERS.md) for the
-canonical statement; this section explains why the boundary exists and how it is
-enforced.
+### Between processes and machines
+
+Named `/v1` HTTP routes carry client, browser, server-to-KB, and provider traffic. Local clients use
+a filesystem-protected Unix socket. Remote clients use TLS plus bearer or mTLS identity and route
+capabilities. The generic `/v1/rpc` endpoint is retired.
+
+The server-to-KB boundary is typed HTTP. `aimee-server` never links libpq or sends SQL. The KB never
+opens DB1.
+
+### Inside a daemon
+
+The event bus carries typed module events. It is not a network transport and does not replace
+authenticated `/v1` calls.
 
 ```mermaid
-graph LR
-    subgraph S["aimee-server"]
-        D1code["src/db1/* (SQLite)"]
-    end
-    subgraph K["aimee-kb"]
-        D2code["src/db2/* (Postgres + pgvector)"]
-    end
-    D1code --> DB1[("DB1 · SQLite<br/>~/.config/aimee/aimee.db")]
-    D2code --> DB2[("DB2 · Postgres<br/>aimee_shared")]
-    S -->|typed RPC, never SQL| K
+flowchart LR
+    P[producer] --> O[private outbound ring]
+    O --> H[bus host]
+    H --> I[private inbound ring]
+    I --> C[consumer]
+    H --> A[ordered audit / capture tap]
+    H <--> R[shared payload arena]
 ```
 
-| Tier | Backed by | Owned by | Holds |
-|------|-----------|----------|-------|
-| **DB1** | SQLite (`~/.config/aimee/aimee.db`) | local `aimee-server` (`src/db1/`) | Local, same-user runtime state: sessions, working-memory key/values, conversation windows, checkpoints, durable delegate jobs, eval results, local caches, local interaction/learning signals, secrets. |
-| **DB2** | Postgres + pgvector (`aimee_shared` by default) | `aimee-kb` (`src/db2/`) | Durable knowledge for the configured KB scope: memories, rules, KB metadata, tasks and decisions, code-index metadata, learning records, roadmaps, **plus** the dense vector collections derived from those records. |
-
-Key consequences of the split:
-
-- **DB1 is local.** `aimee-server` is a local, same-user process and DB1 holds
-  local information for that server: sessions, secrets, working memory,
-  checkpoints, local evidence, and operational state.
-- **DB2 can be local or shared.** `aimee-kb` owns the Postgres knowledge store.
-  In the default topology it can be a local single-user DB; in team or
-  multi-host topologies it can be a shared KB. In either case, only information
-  appropriate for the KB scope is reflected or promoted from DB1/server flows
-  into DB2.
-- **The vector tier is inside DB2.** It was originally a separate Qdrant sidecar
-  and was folded into Postgres as the `vector` (pgvector)
-  extension. Vectors share the same connection and transaction domain as the
-  rows they embed, no separate service.
-- **The boundary is compile-enforced.** `aimee-server` is built with
-  `-DAIMEE_DB2_DISABLED` and never links libpq; `aimee-kb` is built with
-  `-DAIMEE_DB1_DISABLED` and never links SQLite. `make check-linking` and
-  symbol-boundary checks (`readelf`) fail the build if a `db2_*`/`PQ*` symbol
-  appears in the server or a `db1_*`/`sqlite3_*` symbol appears in KB.
-  `scripts/check_tier_deps.sh` enforces that code outside a tier calls only the
-  typed public API, never a tier's storage handles.
-- **One sanctioned cross-tier code edge: the WORM hash chain.** The append-only
-  audit chain must produce byte-identical row hashes and checkpoint MACs whether
-  a row is written by the server's SQLite store (`src/modules/audit/audit_worm.c`)
-  or the KB's Postgres store (`src/db2/kb_audit_worm.c`). Both therefore share the
-  engine-agnostic hash primitives in `src/modules/audit/audit_worm_chain.{c,h}` —
-  a deliberate `db2/ → modules/audit/` include edge that does **not** breach the
-  tier boundary. The edge is permitted **only as long as
-  `src/modules/audit/audit_worm_chain.{c,h}` stays pure hashing** — SHA-256 only,
-  no storage handle, `sqlite3`- and `libpq`-free, and header-self-contained.
-  Reintroducing a storage-engine dependency there would re-create the layering
-  violation this section exists to prevent, so it is forbidden.
-  `src/tests/test_audit_worm_chain.c` pins the cross-engine hash vector against
-  the real primitive so the two stores cannot silently drift.
-
-The server reaches DB2 exclusively through the **KB client** (`src/server/
-kb_client*.c`): a set of typed RPC wrappers that talk to `aimee-kb` over a Unix
-socket (or HTTP on port 8741 in containerized deployments). The server holds no
-SQL for DB2 and cannot bypass the boundary.
-
----
-
-## 4. Internal layering
-
-Within the C codebase, modules are organized into four layers. Lower layers must
-not include headers from higher layers; the few tracked violations are listed in
-[`OWNERS.md`](../OWNERS.md) and enforced by `src/tests/test_build_integrity.sh`.
-
-```
-Layer 3 · Commands + UI     cmd_*, cli_*, webchat, dashboard
-Layer 2 · Agent             agent*, http_retry, delegate execution
-Layer 1 · Data + Policy     memory*, index, extractors, rules, guardrails,
-                            workspace, learning, kb_*
-Layer 0 · Foundation        db, config, util, text, render, log, platform_*,
-                            mcp_*, cJSON (vendored)
-```
-
-The layering is orthogonal to the storage-tier split: a Layer-1 data module like
-`memory_logic.c` is linked into `aimee-kb` (because it owns DB2 logic), while a
-Layer-1 policy module like `guardrails.c` is linked into `aimee-server`. Linkage
-follows ownership; layering follows dependency direction. See
-[`src/README.md`](../src/README.md) for the full module-to-binary map.
-
----
-
-## 5. Linkage and dependency profiles
-
-The build deliberately produces binaries with disjoint dependency graphs so that
-the storage boundary cannot be violated even by accident.
-
-```mermaid
-graph TD
-    Core["Core objects<br/>db, config, util, text,<br/>render, cJSON, platform, mcp_git"]
-    Data["Data + policy objects<br/>memory, index, rules, tasks,<br/>guardrails, workspace, learning"]
-    Agent["Agent objects<br/>delegate loop, tools, HTTP,<br/>policy, plan, eval"]
-    Cmd["RPC handlers<br/>session, compute, MCP, dashboard"]
-
-    aimee["aimee (client)<br/>-lpthread"]
-    server["aimee-server<br/>-lsqlite3 +ssl +pam"]
-    kb["aimee-kb<br/>-lpq +zstd +ssl"]
-    webchat["aimee-runtime-web<br/>pure Go"]
-
-    aimee --> Core
-    server --> Core --> Data
-    server --> Data --> Agent
-    server --> Agent --> Cmd
-    server --> Cmd
-    kb --> Core
-    kb --> Data
-    webchat -.->|socket| server
-    server -.->|KB RPC| kb
-```
-
-| Library | Used by | Purpose |
-|---------|---------|---------|
-| SQLite3 | `aimee-server` only | DB1 local store |
-| libpq | `aimee-kb` only | DB2 access (incl. pgvector) |
-| libcurl / WinHTTP | `aimee-server` | delegate HTTP client |
-| libssl / libcrypto | server, kb | TLS, auth provider support |
-| libpam | server (Linux), webchat | PAM authentication |
-| libsecret | server, kb (Linux, optional) | credential storage |
-| libzstd | `aimee-kb` | payload compression |
-| libm / libpthread | all C binaries | math, threads |
-| cJSON | all C binaries | JSON (vendored, compiled in) |
-
-The CMake build (`CMakeLists.txt`) mirrors the Makefile for Windows (MinGW) and
-macOS cross-platform builds; the `src/Makefile` is canonical for development and
-CI.
-
----
-
-## 6. The aimee-server
-
-`aimee-server` is the hub. It owns DB1, runs the compute pool, routes delegates,
-serves hooks, and exposes both the internal RPC protocol and the public HTTP /v1
-API.
-
-```mermaid
-graph TD
-    L["Listen sockets<br/>aimee-http.sock (HTTP /v1) + optional localhost TCP"]
-    EV["HTTP listener<br/>(accept loop hands each connection to its own worker thread)"]
-    AUTH["Auth gate<br/>local UDS = filesystem-trusted (full surface)<br/>TCP = bearer-scoped + 16 capability flags"]
-    POOL["Bounded compute pool<br/>(delegate exec, chat, tool calls)"]
-    DB1[("DB1 SQLite")]
-    KBC["KB client<br/>typed RPC to aimee-kb"]
-    PROV["Delegate HTTP client<br/>libcurl"]
-
-    L --> EV --> AUTH
-    AUTH -->|fast handlers| DB1
-    AUTH -->|blocking handlers| POOL
-    POOL --> DB1
-    POOL --> KBC
-    POOL --> PROV
-```
-
-Key properties:
-
-- **Per-connection workers, bounded compute pool.** The HTTP accept loop hands
-  each connection to its own detached worker thread, so a slow or streaming
-  request never blocks the listener and independent `/v1` requests run
-  concurrently. Heavyweight handlers (DB query, network, subprocess, delegate
-  inference) additionally run on a bounded compute pool; a compute budget gate
-  serializes heavyweight inference to bound resource use.
-- **Transport.** Clients reach the server over its `/v1` HTTP surface: the
-  always-on `~/.config/aimee/aimee-http.sock` Unix socket, plus an optional
-  localhost TCP listener. Dispatch methods use dedicated `/v1` routes; the
-  generic `POST /v1/rpc` endpoint is retired. Streaming chat uses
-  `POST /v1/chat/stream`, whose body is a sequence of newline-delimited aimee
-  events terminated by a final status object. (The legacy newline-delimited
-  JSON-RPC socket was removed.)
-- **Authentication.** The local UDS is filesystem-permission gated and fully
-  trusted: it reaches the entire dispatch surface, with no token. The optional
-  TCP listener requires a configured bearer token and is capability-scoped.
-  Authorization is expressed as **16 capability flags** (chat, delegate,
-  tool-execute, tool-bash, tool-write, memory-read/write, rules-read/admin,
-  describe-read/admin, index-read/admin,
-  session-read/admin, dashboard-read). Each method declares the capabilities it
-  requires; unknown methods default to deny.
-- **Rate limiting.** Auth failures are tracked per-UID (5 failures / 60 s →
-  cooldown); the HTTP surface can rate-limit per source.
-- **Graceful shutdown.** SIGTERM/SIGINT drains pending I/O, releases the socket,
-  and records unclean-exit forensics to DB1.
-
-See [`SECURITY.md`](SECURITY.md) for the full trust model and
-[`src/README.md`](../src/README.md) for the RPC method catalog.
-
-### The HTTP /v1 seam
-
-Alongside the internal RPC protocol, the server exposes a native HTTP /v1 REST
-surface (over `aimee-http.sock` or an optional localhost TCP port). It provides:
-
-- **OpenAI-compatible inference**, `POST /v1/chat/completions`,
-  `POST /v1/completions`, `POST /v1/embeddings`, `POST /v1/responses`, with
-  SSE streaming where supported.
-- **Native run management**, `POST /v1/runs`, `GET /v1/runs/{id}`,
-  `GET /v1/runs/{id}/events` (SSE replay), `POST /v1/runs/{id}/stop`.
-- **Read and control surfaces**, `GET /v1/health`, `/v1/version`,
-  `/v1/capabilities`, `/v1/models`, `/v1/rules`, `/v1/notes`, `/v1/roadmap`,
-  `/v1/agents`, `/v1/curiosity`, `/v1/kb/status`, `/v1/dashboard/*`, persona
-  routes, plus `POST /v1/kb/search`, `/v1/memory/recall`, `/v1/notes/search`.
-- **Auth**, UDS callers authenticate by peer UID; TCP callers present a bearer
-  token, optionally `scope:`-prefixed to constrain capabilities. `X-Request-ID`
-  is echoed; access is logged.
-
-The server contract source of truth is
-[`api/openapi-server-v1.yaml`](../api/openapi-server-v1.yaml). The KB contract is
-[`api/openapi-v1.yaml`](../api/openapi-v1.yaml), with generated markdown at
-[`docs/gen/api-v1.md`](gen/api-v1.md).
-
----
-
-## 7. The aimee-kb service
-
-`aimee-kb` owns DB2 and everything derived from it. It can run beside the local
-server or as a shared/remote KB service. The server delegates all knowledge
-operations to it via the KB client and sends only scoped knowledge artifacts,
-not raw local runtime state.
-
-A shared `aimee-kb` is the substrate for aimee's larger goal, a self-learning,
-company-wide knowledge base that distills knowledge across every domain and
-synthesizes across them. The mechanisms (curator pipeline, scope lattice,
-knowledge graph, reflection, calibration) and the trajectory are described in
-[How aimee learns](KNOWLEDGE.md); this section covers the service that runs them.
-
-Responsibilities:
-
-- **Memory pipeline**, store/recall/search over facts and conversation windows,
-  deduplication, contradiction detection, temporal fact versioning, promotion
-  and decay (the L0-L3 tier machinery).
-- **Vector operations**, pgvector collections, embeddings (built-in or via an
-  external `embedding_command` sidecar), reranking, release/repair/reconcile of
-  vector state.
-- **Code index**, symbol extraction across many languages, `find_symbol`,
-  callers, structure, blast-radius, full-text code search.
-- **Document ingest + curator**, staged document ingest, curator extraction of
-  structured knowledge from prose/code/API docs, review queue.
-- **Background workers**, ingest, embedder, curator, and index-update workers
-  drain async queues.
-
-It exposes its own HTTP /v1 surface (default port 8741) with ~40 endpoints
-(`/v1/code/*`, `/v1/docs/*`, `/v1/search`, `/v1/ingest/*`, `/v1/entities/*`,
-`/v1/reflections/*`, `/v1/maintenance/*`, etc.), used both by the server's KB
-client and by containerized deployments. See [`api/openapi-v1.yaml`](../api/openapi-v1.yaml).
-
----
-
-## 8. The webchat service
-
-`aimee-runtime-web` is a standalone Go HTTP service that serves the browser UI built
-from [`frontend/`](../frontend) (React 19 + Vite, bundled to a single HTML file).
-It is a thin client: it holds no database and proxies everything to
-`aimee-server` over the same `/v1` HTTP surface the CLI uses.
-
-- **Auth**, PAM-backed login (`aimee-runtime-web` PAM service), SQLite-backed
-  sessions with a TTL, login rate limiting, optional self-signed TLS.
-- **Routes**, chat (SSE streaming via the socket), dashboard panels (proxied
-  from the server), collab-rule review, channels (a local message board), and an
-  OpenAI-compatible model endpoint.
-- **Trust**, treated as a *semi-trusted* zone (see [`SECURITY.md`](SECURITY.md)):
-  HTTPS + PAM, but not hardened to public-internet standards. Intended for
-  same-host or trusted-LAN use.
-
----
-
-## 8a. The kb console service
-
-`aimee-kb-console` (`kb-console/*.go` + the second `frontend/` SPA) is a standalone
-Go thin-client for administering a **shared/company `aimee-kb`**: dashboard,
-accounts (client enrollment, certificate revocation, scopes, OIDC config), and
-governance (decision records, the policy-verdict action audit). Unlike webchat it
-fronts the **kb `/v1` directly** (so it works with no colocated `aimee-server`) and
-uses **no PAM**: login is OIDC (with a presence-flag break-glass), and it holds a
-scoped **console-admin** credential whose route allowlist the kb enforces
-server-side (`src/kb/http/kb_route_acl.c`). Default-off; shipped as its own
-`Dockerfile.kb-console` under the compose `console` profile. See
-[`KB_CONSOLE.md`](KB_CONSOLE.md).
-
----
-
-## 9. Request lifecycles
-
-### 9.1 A pre-tool hook (the hot path)
-
-```mermaid
-sequenceDiagram
-    participant Tool as AI tool
-    participant CLI as aimee (client)
-    participant SRV as aimee-server
-    participant KB as aimee-kb
-    Tool->>CLI: PreToolUse JSON on stdin (Edit /etc/x)
-    CLI->>SRV: hooks.pre (Unix socket)
-    SRV->>SRV: classify path, check plan mode,<br/>worktree redirect, anti-patterns, drift
-    SRV-->>CLI: allow / block(exit 2) / warn(stderr)
-    CLI-->>Tool: exit code + message
-    Note over SRV,KB: anti-pattern + memory lookups hit KB only when needed
-```
-
-The whole round-trip is ~1 ms at p50 because the client is already warm and the
-server keeps DB1 and its KB connection open.
-
-### 9.2 Session start
-
-The thin client calls `session-start`; the server assembles a context brief
-(code principles, rules, project-scoped facts, delegation hints, and, in
-verbose mode, network info, recent delegations, capabilities) by querying DB1
-and DB2-via-KB, and prints it to the tool's stdout. It also creates per-session
-worktrees and state. See "Context assembly" in [`src/README.md`](../src/README.md).
-
-### 9.3 Remote thin-client execution
-
-When `aimee mcp-serve`, chat, or launch targets a remote `aimee-server`, the
-client registers its current directory as a detached workspace, starts a
-background `workspace serve` reverse channel, and routes file/exec operations
-back to the client over `/v1/runner/poll` and `/v1/runner/respond`. The client
-removes the detached workspace when the bridge exits or remote launch fails.
-Delegate routes are exposed over `/v1/delegate/*`, but TCP access requires an
-unscoped bearer and `aimee.api.remote_writes: full`.
-
-#### Local-CLI agents run on the client
-
-A `--provider claude` agent runs the **standard `claude` CLI over tmux**, not an
-HTTP call, and **not** `claude -p` print mode: aimee drives an interactive tmux
-session. That session, the `claude` process, its login (`~/.claude`), and the
-working tree all live on the **client**, not on a remote/containerized
-`aimee-server`. So when the active workspace is `detached`, the tmux session
-driver (`cli_session`) marshals its tmux commands to the client over the **same
-reverse channel** used for file/exec ops, rather than running tmux on the server
-(which has no `claude` or tmux):
-
-```mermaid
-sequenceDiagram
-    participant Cli as aimee thin client
-    participant SRV as aimee-server (remote)
-    participant Tmux as tmux + claude (on client)
-    Cli->>SRV: POST /v1/chat/stream  (cwd in a detached workspace)
-    SRV->>Cli: runner op {exec_shell, "tmux new-session … claude"}
-    Cli->>Tmux: run tmux command locally (client's tree + ~/.claude login)
-    SRV->>Cli: runner op {exec_shell, "tmux paste-buffer / send-keys"} (prompt)
-    loop until pane output is stable
-      SRV->>Cli: runner op {exec_shell, "tmux capture-pane -p"}
-      Cli-->>SRV: captured pane text
-    end
-    SRV-->>Cli: chat SSE (final assistant text)
-```
-
-- **Reuses the existing exec seam.** The tmux commands ride the same
-  `exec_shell` reverse-channel op as the bash tool; the client just runs them
-  locally. No new client capability and no `claude -p`.
-- **No credentials on the server.** `claude` authenticates with the client's own
-  `~/.claude` login; no Claude credential is sent to or stored on the server.
-- **Co-located unchanged.** When the workspace is not detached (the server is on
-  the same host as the CLI), the tmux session runs locally exactly as before.
-- **Claude via the CLI is primary-only by default.** Claude run via the `claude`
-  CLI/tmux login (not an API key) is allowed as the interactive primary but is
-  gated out of delegate routing whenever its per-agent **Primary Agent Only**
-  flag (`primary_only` in `agents.json`) is set — the Web GUI pre-checks it when
-  you add a claude-oauth subscription, because automating a personal Claude
-  subscription as a delegate risks Anthropic account action. The routing above
-  applies to the primary chat turn always, and to a Claude-CLI delegate only when
-  you uncheck Primary Agent Only for it. The flag is a per-agent choice available
-  to any agent, and replaced the former global `claude_cli_delegate_enabled`
-  opt-in. See
-  [DELEGATES.md](DELEGATES.md#claude-via-the-cli-is-primary-only-by-default) and
-  [SECURITY.md](SECURITY.md).
-
-### 9.4 A delegate task
-
-```mermaid
-sequenceDiagram
-    participant PA as Primary agent
-    participant SRV as aimee-server
-    participant Pool as Compute pool
-    participant Prov as Provider
-    PA->>SRV: delegate <role> <prompt>
-    SRV->>SRV: route to cheapest enabled agent for role
-    SRV->>Pool: enqueue (acquire compute budget)
-    Pool->>Prov: HTTPS (OpenAI / ChatGPT / Anthropic format)
-    Prov-->>Pool: completion (retry/fallback on failure)
-    Pool-->>SRV: result (+ optional verify_cmd gate)
-    SRV-->>PA: compact result
-```
-
-Read-only delegates inspect the parent session's worktree directly;
-write-capable delegates get isolated sibling worktrees so parallel work never
-collides. `--background`/`--durable` delegates become server-owned jobs that
-survive client disconnect. See [`DELEGATES.md`](DELEGATES.md).
-
----
-
-## 10. Session isolation and worktrees
-
-Each session gets its own git worktree, branch, and state file under
-`~/.config/aimee/worktrees/<id>/<project>/`. Two sessions running in parallel
-never clobber each other's working tree. The guardrail layer enforces this: a
-write that targets a real workspace path which *has* a worktree is blocked and
-redirected to the worktree path. Abandoned worktrees are garbage-collected by
-`aimee worktree gc` (and optionally on a TTL). See [`WORKSPACES.md`](WORKSPACES.md).
-
----
-
-## 11. Deployment topologies
-
-| Topology | Shape | Notes |
-|----------|-------|-------|
-| **Containerized server + KB (recommended)** | `aimee-server` and `aimee-kb` run as separate containers with the `aimee-llm` CPU inference gateway; PostgreSQL/pgvector is embedded in the KB container for a new install. The server fronts `/v1` and reaches the KB over HTTP on `:8741`. Developers install only the cross-platform thin client and point it at the server. | `compose.server.yaml` (split stack); `Dockerfile.server`, `Dockerfile`, `Dockerfile.aimee-llm`. |
-| **Single developer, source build** | All processes on one host from `install.sh`; service units keep server/KB running; DB1 in `~/.config/aimee`, DB2 in local Postgres. | Service-managed via `systemd/user/*.service` (Linux) or `service/com.aimee.*.plist` (macOS). KB starts first; server depends on it. |
-| **Shared KB** | Multiple `aimee-server` instances (containerized or local) point at one `aimee-kb`/Postgres deployment over HTTP. DB1 remains per-user/per-machine; DB2 carries only project, workspace, global, or otherwise shareable knowledge. | Set `AIMEE_KB_API_URL` (+ optional bearer); promote scopes deliberately. |
-| **KB-only container** | Self-contained `aimee-kb` (embedded PostgreSQL/pgvector) plus a CPU inference gateway via `compose.yaml`; KB binds `0.0.0.0:8741` and calls the gateway over HTTP. Set `AIMEE_DB2_URL` only when deliberately using an external database. | The building block behind a shared/scaled KB; `Dockerfile`, `Dockerfile.aimee-llm`, `deploy/container/aimee.yaml`. |
-| **Standalone server** | `aimee-server` only (SQLite DB1, no kb), via `compose.server-standalone.yaml`. | DB1-backed `/v1` endpoints with no shared knowledge until a kb is wired in. |
-
-In every topology the contracts are identical: thin clients speak the `/v1`
-protocol to the server (local `aimee-http.sock` or a remote `host:port`); the
-server speaks the typed KB `/v1` HTTP API to `aimee-kb` (`AIMEE_KB_API_URL`; the
-legacy Unix-socket KB transport was retired in #2747); the storage boundary holds.
-
----
-
-## 12. Where to go next
-
-- **Use it:** [`MANUAL.md`](../MANUAL.md), full command, configuration, and operations reference.
-- **Hack on it:** [`src/README.md`](../src/README.md), module map, RPC catalog, memory internals, build system.
-- **Trust model:** [`SECURITY.md`](SECURITY.md).
-- **Storage contract:** [`STORAGE_TIERS.md`](STORAGE_TIERS.md).
-- **Delegates:** [`DELEGATES.md`](DELEGATES.md) · **Workspaces:** [`WORKSPACES.md`](WORKSPACES.md).
+Each daemon creates one host. Admitted clients receive a read-only control region, their own queue
+pair, and the shared arena. The host owns admission, sequence numbers, subscriptions, routing,
+correlations, credits, and client reap.
+
+The current load-bearing consumer is observability:
+
+- governed actions;
+- semantic guardrail events;
+- server and KB memory mutations;
+- vault credential access;
+- sandbox isolation degradation;
+- MCP and tool-call activity;
+- tool completion outcomes.
+
+The host tap sees accepted events before routing. It writes an ordered capture stream while the
+consumer drains typed records to the WORM ledger or DB1. Storage stays off the request path.
+
+Small events are inline. Large events use generation-checked arena leases. Backpressure is bounded;
+a producer blocks or receives `would_block`, and shed delivery is represented by an overflow event.
+There is no unbounded host queue.
+
+See [Event bus](EVENT_BUS.md).
+
+## Storage
+
+There are two product data tiers and one workflow store.
+
+| Store | Owner | Contents |
+| --- | --- | --- |
+| DB1, SQLite | `aimee-server` | sessions, working memory, local state, agent jobs, policy and audit state, caches |
+| Workflow SQLite | `aimee-wfe` | definitions, immutable snapshots, work items, lifecycle events, artifacts, retries and parks |
+| DB2, PostgreSQL + pgvector | `aimee-kb` | durable memories, documents, facts, evidence, code graph, embeddings, curation state |
+
+The DB1/DB2 boundary is compile-enforced:
+
+- server builds disable DB2 and never link libpq;
+- KB builds disable DB1 and never link SQLite;
+- thin clients link neither;
+- calls across the boundary use public typed APIs.
+
+The WORM hash primitive is the narrow exception shared by both stores. It contains hashing only—no
+database handles or queries—so both stores produce the same chain format.
+
+New KB containers run a private PostgreSQL 18 cluster when no external `AIMEE_DB2_URL` is set. It is
+still DB2, still owned by the KB, and still independently exportable.
+
+See [Storage tiers](STORAGE_TIERS.md).
+
+## Request paths
+
+### Local tool hook
+
+1. The coding tool starts the thin client with a small JSON event.
+2. The client sends it over the local Unix socket.
+3. The server authenticates the socket by filesystem ownership.
+4. Policy and guardrails return allow, deny, or context.
+5. The action and verdict enter the event-bus audit path.
+
+The client opens no database and starts no daemon. Warm state stays in `aimee-server`.
+
+### Remote thin client
+
+1. `remote.conf` resolves the server URL, certificate pin, bearer, and client identity.
+2. Native TLS verifies the endpoint.
+3. The server maps the principal to route capabilities and a write tier.
+4. Read operations dispatch normally. A write also needs a KB-signed identity token, matching
+   server/team trust, and the user's grant.
+5. Workspace and document commands upload bytes from the client; the server never resolves a path
+   on the client's machine.
+
+### Memory write and recall
+
+1. A client calls the server `/v1` surface.
+2. The server authorizes the principal and calls the KB's typed endpoint.
+3. The KB owns the transaction, lexical/dense indexes, and evidence.
+4. Mutations publish a PII-safe audit identity on the KB bus.
+5. Recall returns bounded evidence; optional rerank and synthesis go through `aimee-llm`.
+
+### Delegate turn
+
+1. The server admits a role/persona request against agent limits, budget, policy, and credentials.
+2. The workspace authority selects a local, remote-runner, or isolated-container backend.
+3. Provider requests become canonical IR, then one provider translation at the edge.
+4. Tool calls pass schema, policy, worktree, and sandbox checks.
+5. Tool activity and outcomes publish to the event bus.
+6. The server returns a compact result and preserves the durable job, cost, and audit record.
+
+### Workflow run
+
+1. `aimee-wfe` validates and snapshots the definition and admitted request.
+2. The scheduler persists a transition before dispatching work.
+3. Agent and roundtable work uses typed resource calls to the C server; credentials never cross
+   back into the workflow store.
+4. Each slice gets a confined worktree and branch.
+5. Verification, review, merge, and forge operations produce separate artifacts.
+6. A human gate parks until a signed human decision arrives. A crash resumes from the durable event
+   log.
+
+## Trust boundaries
+
+The important boundaries are:
+
+- **local user to local socket:** filesystem permissions are the identity;
+- **remote client to server:** TLS, certificate pinning, bearer/mTLS identity, route capabilities,
+  and write grants;
+- **browser to server:** browser login, CSRF protection, principal propagation, and the same server
+  authorization;
+- **server to KB:** service bearer/TLS plus typed APIs;
+- **workflow to resource plane:** local attested peer plus narrow internal operations;
+- **agent to workspace:** assigned worktree and path policy;
+- **delegate to host:** container/process sandbox, no ambient credentials, explicit egress;
+- **service to provider:** vault resolution, provider allowlist, budget, rate, and egress policy;
+- **module to bus:** admission, per-client rings, authorized event kinds, bounded flow control.
+
+An admitted native bus module is trusted code. The shared arena is cooperative isolation, not a
+sandbox. An external WORM witness is required if the threat includes full host compromise.
+
+See [Security](SECURITY.md).
+
+## Deployment shapes
+
+| Shape | Use | Tradeoff |
+| --- | --- | --- |
+| Managed server | One server container launches KB and inference from the browser | Needs the host Docker socket |
+| Split stack | Separate server, KB, and inference containers | More explicit; no server Docker control required |
+| External DB2 | KB uses managed PostgreSQL | Operator owns backup, TLS, extensions, and latency |
+| Local source install | Development and debugging | Host owns dependencies and services |
+| Thin client | Normal developer machine | Needs a reachable server; keeps state off the client |
+
+The old combined appliance image is gone.
+
+## Code boundaries
+
+- `src/modules/bus/`: event transport, arena, host, client, capture.
+- `src/modules/`: owned C modules and public headers.
+- `src/server/`: C resource plane and `/v1` handlers.
+- `src/kb/`: KB daemon and DB2-facing routes.
+- `server-go/`: workflow control plane and pure-Go bus client.
+- `runtime-web/`: browser-facing Go service.
+- `frontend/`: browser application.
+- `api/`: OpenAPI sources and generated SDKs.
+
+[Technical reference](../src/README.md) covers build targets, linkage, tests, and source ownership.

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -1,279 +1,110 @@
-# Autonomous Development
+# Autonomous development
 
-> **Hand aimee a proposal; it builds the change end-to-end.** You submit a
-> written proposal and aimee runs the *entire* development lifecycle (design,
-> plan, implement, review, PR) **server-side and unattended**. Closing
-> the browser tab does not stop it. This is **core functionality and is on by
-> default**; safety comes from the workflow's *gates*, not an off-switch.
->
-> aimee **never starts work on its own.** Every autonomous run begins from a
-> human-submitted proposal. There is no "find work to do" loop.
+Autonomous mode lets the workflow scheduler run ordinary steps without waiting for an operator. It
+does not widen tool, workspace, credential, budget, or gate authority.
 
-## What it is
+## Start
 
-Autonomous development turns a proposal into a finished, reviewed pull request
-without a human driving each step. It is a thin orchestration layer over three
-things aimee already has:
+Use Workflow Actions, a trigger, cron rule, or the typed submission API. Every path creates the same
+durable work item with:
 
-- the **workflow engine** (`wfe`), a block-composed state machine with durable
-  per-work-item state, gates, and an audit log;
-- **delegates**, sub-agents that do bounded work (here: write code with tools in
-  an isolated worktree); and
-- the **server-owned turn lifecycle**, a turn/run is owned by the server, not by
-  a client connection, so it runs to completion regardless of who is watching.
+- an immutable admitted request and proposal;
+- a named, versioned workflow;
+- a repository and worktree authority;
+- retry, round, agent, and spend limits;
+- the initiating principal and audit context.
 
-The **primary agent manages; delegates do the work.** The primary (the engine
-plus a coordinator) decomposes the plan, dispatches each unit to a delegate,
-verifies the result, and, if the work is not acceptable, sends it back to a
-*different* delegate. The primary never writes the code itself.
+## Lifecycle
 
-Throughout this page, a **run** and a **work item** are the same thing: one
-execution of a workflow for one proposal. The **primary agent** is the manager
-(the engine + coordinator); **delegates** are the workers.
+The default build path is:
 
-## Prerequisites
-
-- A running aimee server (`aimee-server`, e.g. via the `compose.server.yaml` stack).
-  The feature is default-on, there is nothing to enable.
-- An API token for the `/v1` surface (`Authorization: Bearer …`). On a remote
-  client this is your configured server token; locally the dev bearer works.
-- The default `build` workflow is **seeded automatically** into
-  `$AIMEE_HOME/workflows` at standup, so a fresh server resolves it out of the
-  box. Custom workflows live in the same directory.
-- Delegates **ship configured** (a default roster + roundtable panel). See
-  [Delegates](DELEGATES.md) only to add your own providers; verify with
-  `aimee --json agent list`.
-- For the final merge step, the server needs forge access (a configured `gh` /
-  git credential) and a `testing` branch; autonomous merges target `testing`
-  only.
-
-## Quick start
-
-Submit a proposal for autonomous execution:
-
-```bash
-curl -k -sX POST https://127.0.0.1:8743/v1/dev/submit \
-  -H "Authorization: Bearer $AIMEE_TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d '{"proposal_md": "## Add a /healthz route returning {status:ok}\n\nWhy: ...\nAcceptance: GET /healthz returns 200 with {\"status\":\"ok\"}."}'
-# -> {"work_item_id":"wi-...","workflow":"build","state":"active"}
+```text
+understand/proposal -> feature branch -> plan -> plan review
+                    -> split -> parallel slice workflows
+                    -> acceptance review -> documentation review
+                    -> final pull request
 ```
 
-A `401` means the token is missing/invalid; `400` means `proposal_md` was empty.
-On success the run proceeds on the server, you can close the connection and it
-continues. The webchat **Workflows** tab is the GUI for all of this: a **Submit
-proposal** panel (textarea → runs on the chosen workflow), a live **run list**
-with each run's stage/state, and **Approve / Reject** buttons on a run parked at
-a human gate (operator-only). You can also drive it purely via the API as above.
+Each slice gets a branch and worktree, implements one packet, verifies it, freezes the diff, and
+runs review before merge into the feature branch. New slices branch from the current merged feature
+tip.
 
-Request fields:
+The final PR targets the forge's authoritative default branch. The default workflow opens it and
+stops; normal repository review controls the merge.
 
-| field | required | meaning |
-|-------|----------|---------|
-| `proposal_md` | yes | the proposal to execute (Markdown) |
-| `workflow` | no | workflow name; defaults to `build` |
-| `repo` | no | repository identifier for the run |
+## Persistence and recovery
 
-## The lifecycle
+The Go control plane writes a lifecycle transition before external dispatch. Provider, delegate,
+runner, or compatibility-worker failure cannot erase the authoritative state.
 
-A run is a work item bound to a **workflow**, by default `build`
-(`config/workflows/build.yaml`), the standard dev lifecycle:
+On restart, the scheduler:
 
-```
-author.proposal → gate.roundtable → pr.open → gate.human (approve) →
-author.plan    → gate.roundtable →
-implement      → freeze → gate.roundtable → pr.open → gate.human (pass/fail)
-                                                         pass → merge
-                                                         fail → implement (loop)
-```
+1. reads active and parked items;
+2. reconciles in-flight reservations and artifacts;
+3. retries work that is safe to repeat;
+4. parks anything that needs a decision or manual repair.
 
-`freeze` captures the cumulative diff at a stable commit before review, so the
-roundtable and the final PR see one coherent change rather than a moving target.
-`gate.roundtable` is a machine gate (a model panel verdict); `gate.human` is a
-human gate; `gate.ci` polls the PR's CI. The `fail → implement` arrow is the
-re-delegate loop.
+It never converts a missing result into success.
 
-Workflows are user-editable; clone and change the composition with
-`aimee workflow new`. The engine has no privilege over a user-authored workflow.
-A custom workflow is just another YAML in `$AIMEE_HOME/workflows`; submit against
-it by passing its `workflow` name. For example, inserting a `gate.roundtable`
-with a `security` lens before `pr.open` adds a mandatory security review.
+## Gates
 
-### The implement stage: manage → delegate → verify → re-delegate
+- roundtable gates require valid evidence and quorum;
+- CI gates fail closed when required checks are not green;
+- mergeability gates stop on a conflict;
+- delivery gates enforce the current verdict;
+- human gates always park for a signed person.
 
-`implement` is where "the primary manages, delegates do the work" is concrete:
+Review findings persist and feed the next authoring or implementation pass. Repeated identical
+feedback and output parks as no progress instead of consuming the full budget forever.
 
-1. **Split.** The plan is decomposed into independent, file/module-scoped units.
-2. **Dispatch.** Each unit is enqueued as a delegate task onto the **coord
-   queue**. The engine does not spawn the delegate or manipulate git during
-   dispatch; a background coord dispatcher claims each task and runs it
-   through the shared delegate path, which provides agent routing, per-provider
-   concurrency limits, credential leasing, a parent-write guard, and an
-   isolated worktree whose diff it applies back into the work item's checkout.
-   The commit happens at `freeze`, not per unit.
-3. **Verify, as hard as possible.** Verification runs through the engine's gates
-   and delegates, never the primary's own hands, in ascending cost:
-   - mechanical, the build compiles, targeted tests/lint pass (`gate.ci`). The
-     `implement` block's mandatory mechanical verify runs **inside the delegate's
-     toolchain sandbox**, not the server process — see
-     [Verifying in the delegate sandbox](DELEGATE_SANDBOX_VERIFY.md);
-   - review, a roundtable / `reviewer` panel checks the change against its spec
-     (`gate.roundtable`);
-   - adversarial, for risky changes, skeptic verifiers attempt to refute it.
-4. **Re-delegate on reject.** When verification rejects a unit, the engine loops
-   back to `implement`, which re-dispatches the unit to a *different* delegate
-   (fresh perspective), bounded by a retry cap; on exhaustion it parks for a
-   human.
+## Limits
 
-Only verified work advances.
+Autonomy is bounded by:
 
-## Human gates
+- global and per-workflow agent slots;
+- per-node retry and round counts;
+- fan-out packet count;
+- provider rate and quota;
+- per-run spend;
+- tool and process timeouts;
+- worktree and branch confinement;
+- trigger concurrency;
+- sandbox network, package, and credential policy.
 
-Autonomous does not mean unsupervised. The workflow reserves **human gates**
-(proposal approval, final pass/fail). In autonomous mode the driver:
+Fields under `autonomy.*` tune these limits. Some load at workflow-process startup. See
+[Configuration](gen/configuration.md).
 
-- auto-advances *machine* gates (CI, mergeability, roundtable verdicts);
-- **parks** at **every** human gate (`pending_human`) until a person acts — a human
-  gate is **inviolable** and is never auto-satisfied (declaring one auto-satisfiable
-  via `policy: preauthorized` / `optional: true` is rejected at workflow validation);
-- **never forges a human approval**, gate-override is a signed, human-only action
-  capped at a small number of uses.
+## Park reasons
 
-Approve or reject a parked gate from the webchat **Workflow Actions** page's detail view
-panel, or via `POST /v1/workflow/items/<id>/gate {decision}`. The endpoint is
-**operator-gated** (`CAP_WORKFLOW_ADMIN`, outside the ordinary authenticated
-capability set), and approvals are HMAC-signed server-side with the operator key
-(`$AIMEE_HOME/.approval-key`) and content-hash-bound, so a delegate can never
-forge one. `reject` is terminal; `approve` resumes the run.
+| Reason | What to do |
+| --- | --- |
+| `human_gate` | inspect the exact artifact and sign approve/reject |
+| `panel_degraded` | restore eligible reviewers or change the named preset |
+| `convergence_limit` | inspect the last blockers and refine the request/workflow |
+| `convergence_no_progress` | break the repeated plan/feedback cycle |
+| agent capacity | wait, cancel stale work, or raise a safe limit |
+| missing commit | repair the delegate result; do not advance an empty implementation |
+| merge conflict | resolve against the current feature tip and rerun verification |
+| CI failure | inspect the failing check; retry only after a change or transient diagnosis |
+| forge failure | restore repository identity, credential, branch, or network authority |
+| spend limit | raise it explicitly or narrow the work |
 
-## Server-owned execution
+## Security
 
-The run and its delegate turns are owned by the server, not your connection:
+- The workflow process does not own agent credentials.
+- Forge operations are typed and confined to managed worktrees and branch namespaces.
+- Delegates retain their normal sandbox and source authority.
+- Remote workspace mutation requires full per-user write authority.
+- Tool and credential activity is audited through the event bus.
+- Autonomous mode cannot approve a human gate.
 
-- a turn publishes its full stream to the presence event ring and runs to
-  completion even if the client drops;
-- the **autonomy scheduler**, a background thread, drives every active
-  autonomous work item forward, waking on a new submission, on a satisfied gate,
-  and on a periodic backstop sweep (crash recovery);
-- reconnecting replays the run from a cursor, so you see what happened while you
-  were away.
+## Observe
 
-Interactive (human-driven) work items are left alone by the scheduler.
+Use Workflow Actions for live state and artifacts. Use `aimee trigger status`, `aimee jobs`, server
+logs, provider diagnostics, and `aimee audit verify` for the surrounding resource plane.
 
-## Safety and limits
+The event bus records migrated action paths, but workflow trigger delivery is not yet an integrated
+bus consumer. See [Event bus](EVENT_BUS.md).
 
-Autonomous development is default-on; the guardrails are structural, not a toggle:
-
-- **Human gates** are never auto-satisfied — a human gate is an inviolable stop; the
-  only way past it is a human's signed approval, and gate-override stays human-only
-  and capped.
-- **Per-run budget ceiling.** A work item carries a cost cap; on breach the run
-  **parks** (`budget_exceeded`) for a human, it never silently runs away.
-  (Today the cap is a work-item field; setting it *from* `/v1/dev/submit` is not
-  yet exposed, see [Current limitations](#current-limitations).)
-- **Autonomous merges only target `testing`.** Promotion to `main` is always a
-  human action.
-- **Every commit and PR is audited** and attributed to the run. Generated commits
-  and PRs carry **no AI co-authorship trailers** (enforced repo-wide by a
-  required CI check).
-- **Never auto-retry without new input** (a CI log, a roundtable verdict), this
-  prevents infinite loops.
-- A delegate's model refusal or a permanent/unrecoverable error terminates the
-  unit; transient errors are retried within the cap; degraded panels, budget
-  breaches, and forge failures park.
-
-### Tuning (web Settings → `autonomy.*`)
-
-The pipeline knobs are typed config fields, editable in the web **⚙️ Settings** page
-(under `autonomy.`) or `aimee.yaml`; a change applies on the next server start (an
-exported `AIMEE_AUTONOMY_*` env var still overrides). See [SETTINGS.md](SETTINGS.md).
-
-| Knob | Default | Effect |
-| --- | --- | --- |
-| `autonomy.skeptics` | 0 (off) | N adversarial skeptics on the implement gate. |
-| `autonomy.fanout` | off | Engine-level fan-out manager loop vs a single implement dispatch. |
-| `autonomy.unit_retry` | 2 | Per-unit retry-different-delegate cap under fan-out. |
-| `autonomy.unit_max` | 16 | Max fan-out units (a larger decomposition parks). |
-| `autonomy.ci_retry_max` | 2 | Per-work-item red-CI retry cap before parking. |
-
-## Observability
-
-- **Webchat Workflow Actions page**, live progress per work item: current stage, gate
-  verdicts, parked state, and the actionable approve/reject controls for human
-  gates.
-- **Event stream**, a run publishes its full turn stream (text, tool calls,
-  usage, boundaries) to the presence event ring; the webchat replays it live and,
-  after a disconnect, from a cursor.
-- **Durable audit**, every step, verdict, and cost is recorded in the DB1
-  `lifecycle_*` tables (per work item), including the commit hashes produced and
-  the gate decisions. This is the source of truth for "what did the run do".
-- **Attribution**, autonomous commits and PRs are attributed to the run and
-  carry **no** AI co-authorship trailers.
-
-## When a run parks (failure modes & recovery)
-
-The run **parks** instead of failing hard when a human is needed; the scheduler
-resumes it automatically once the blocker clears:
-
-| pause reason | what it means | how it resumes |
-|--------------|---------------|----------------|
-| `pending_human` | waiting at a human gate (proposal approval / final pass-fail) | approve or reject in the webchat Workflow Actions page → the scheduler re-drives |
-| `panel_degraded` / `panel_unreachable` | the roundtable couldn't reach a quorum | retried on the next sweep; a human can approve to proceed |
-| `ci_pending` | the PR's CI hasn't concluded | re-checked on the next sweep |
-| `merge_pending` | the forge merge state is undeterminable | re-checked on the next sweep |
-| `budget_exceeded` | the run hit its cost cap | a human decides whether to continue |
-
-The autonomy driver **never forges a human approval**. A stuck human gate can be
-cleared by a signed, human-only **gate-override** (capped at a small number of
-uses); after that it forces a terminal `rejected`. Machine failures follow the
-taxonomy in [Safety and limits](#safety-and-limits): transient → retry,
-permanent/refusal → terminal, degraded/budget/forge → park, and a unit is never
-auto-retried without new input (a CI log or a roundtable verdict).
-
-## Current limitations
-
-Scope of the current implementation (the design allows for more):
-
-- **Submit takes `proposal_md`, `workflow`, `repo` only.** Per-run `limits` and
-  gate **preauthorization** are not yet accepted at `/v1/dev/submit`; gates are
-  handled interactively via the webchat, and the cost cap is a work-item field.
-- **No dedicated `resume`/`abort`/`audit` HTTP endpoints yet.** Resume is
-  event-driven (gate approval + the scheduler sweep); drive and inspect runs via
-  the webchat Workflow Actions page and the `lifecycle_*` audit tables.
-- **Scheduler concurrency is 1** (runs are driven sequentially) for now; the
-  design's bounded-concurrency fan-out is a follow-on.
-- **`build.yaml` must be present** in `$AIMEE_HOME/workflows` (seeded at standup);
-  a submission against a missing workflow returns an error.
-
-## Configuration
-
-- **Default workflow.** `build` is seeded into `$AIMEE_HOME/workflows` at standup
-  (baked into the aimee-server image). Custom workflows live alongside it.
-- **Choosing a workflow.** Pass `workflow` to `/v1/dev/submit`, or author your
-  own with `aimee workflow new` and submit against it.
-- **Delegate roster.** The shipped roster + roundtable panel are used as-is; see
-  [Delegates](DELEGATES.md) to add providers or change the panel.
-
-## How it fits together (internals)
-
-| component | role |
-|-----------|------|
-| `POST /v1/dev/submit` (`rh_dev_submit`) | intake, the only entry; creates an autonomous work item, seeds the proposal, notifies the scheduler |
-| autonomy scheduler (`wfe_scheduler`) | server-owned thread driving active autonomous work items via `wfe_autonomy_run` |
-| workflow engine (`wfe_*`) | block-composed lifecycle, gates, durable state + audit (`lifecycle_*` tables) |
-| coord queue + dispatcher (`coord_jobs`, `coord_job_tasks`) | durable delegate-dispatch queue; a background coord dispatcher claims tasks and runs them through the shared delegate path — agent routing, per-provider concurrency limits, credential leasing, parent-write guard, and an isolated worktree whose diff is applied back |
-| live delegate provider (`wfe_live_delegate`) | the engine→delegate bridge: enqueues one coord-queue task per producing block rather than running delegates in-process (in `implement`, one task per split unit). The block's delegate role is derived from whether the block names a captured artifact: blocks that do (`author`, `understand`, `split`, `review`) run READ-only, and WFE persists the delegate reply as that artifact; worktree-mutating blocks (`implement`, `decompose`, `tdd`, `document`) run WRITE, and the shared delegate path isolates the worktree and applies the resulting diff back under the parent-write guard. `freeze` owns the commit. |
-| autonomy driver (`wfe_autonomy`) | advances machine gates, parks at human gates, never forges approval |
-| turn registry / server-owned turns | a run survives client disconnect (the foundation) |
-
-**Invariants**: aimee never self-initiates; the primary manages
-while delegates do the work; rejected work is re-delegated; **all** autonomous
-action flows through the workflow engine, there is no side-channel that takes an
-autonomous action outside the engine's gates, budget, and audit.
-
-## See also
-
-- [Delegates](DELEGATES.md), the sub-agents that do the work
-- [Architecture](ARCHITECTURE.md), where the engine sits in the system
-- `docs/proposals/pending/full-autonomous-development.md`, the design + the
-  roundtable-resolved open questions
+See [Workflows](WORKFLOWS.md), [Workflow Actions](WORKFLOW_ACTIONS.md), and
+[Delegate sandbox](DELEGATE_SANDBOX.md).

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,372 +1,71 @@
 # Benchmarks
 
-## Unified suite: provisioning & rollout validation
+A benchmark result is useful only with its corpus, build, model, configuration, hardware, and command.
+Checked-in results under `benchmarks/` preserve those conditions; they are not universal product
+claims.
 
-The unified benchmark suite (memory / coding / reasoning) ships its harness,
-target adapters, pinned judge, and per-dataset loaders in-repo. Provisioning the
-real datasets, judge model, and sandboxes, and running each track end-to-end, is
-the **rollout-validation** half; see **[benchmarks/PROVISIONING.md](../benchmarks/PROVISIONING.md)**.
+## Suites
 
-Key entry points:
+| Area | Measures |
+| --- | --- |
+| memory | recall quality, contradiction, temporal and long-context behavior |
+| retrieval | lexical/dense/graph fusion, reranking, abstention, citation |
+| curator | extraction, typed artifacts, contradiction and queue throughput |
+| code graph | symbol/caller/blast-radius precision across repositories |
+| delegates | task success, tool use, cost, latency, and failure class |
+| guardrails | allow/deny quality and false positives |
+| inference | embed/rerank/synthesis quality, slots, memory, latency |
+| event bus | dispatch overhead, flow control, capture, durability, shutdown |
+| provisioning | clean install, readiness, recovery, and upgrade |
 
-- `benchmarks/provisioning.toml`: documented, hash-pinnable provisioning path
-  for every catalog dataset.
-- `benchmarks/check_provisioning.py`: coverage + hash-integrity gate
-  (`--require-coverage`, `--verify-hashes`); wired into the `bench-smoke.yml` CI.
-- `scripts/provision-benchmarks.sh`: manifest-driven fetcher (auto-fetches what
-  it can, prints manual steps and the SHA-256 to pin).
-- `benchmarks/compare_targets.py`: publishes a cross-target comparison report
-  under `benchmarks/results/`.
-- `benchmarks/suite/run-validation.sh`: one-command operator runbook
-  (preflight → tracks → determinism → comparison → smoke budget).
+## Event-bus gate
 
-## Memory Harness v2
+The bus has a committed dispatch baseline and ceiling. The reference measurement is roughly 134 ns
+per event against a 2,000 ns ceiling for host enqueue through client dequeue, excluding module work.
+Run the gate on comparable hardware and keep the raw artifact. A slower machine can still be
+correct; changing the committed ceiling needs an explicit decision, not a convenient rebaseline.
 
-The memory-quality benchmark harness now lives under:
+Durability, replay, retention, shutdown, and C/Go conformance are correctness gates, not latency
+percentiles.
 
-- `benchmarks/memory/run.sh`
-- `benchmarks/memory/BENCHMARK_RESULTS.md`
-- `benchmarks/locomo/`
-- `benchmarks/longmemeval/`
-- `benchmarks/run-direct.sh`
-- `benchmarks/run-llm.sh`
-- `benchmarks/run-all.sh`
-- `benchmarks/smoke.sh`
-- `benchmarks/verify_scores.py`
-
-These scripts produce per-question JSON artefacts and per-category or per-subset breakdowns. The generated reports are:
-
-- `benchmarks/memory/BENCHMARK_RESULTS.md`
-- `benchmarks/locomo/BENCHMARK_RESULTS.md`
-- `benchmarks/longmemeval/BENCHMARK_RESULTS.md`
-
-The canonical suite entry point for memory-quality work is:
+## Run
 
 ```bash
-./benchmarks/memory/run.sh
+make -C src bench
+make -C src bench-check
+make -C src memory-retrieval-eval-check
+make -C src curator-eval-check
 ```
 
-Verifier example:
+Individual suites have their own README and fixtures. Live provider and KB suites should skip with a
+clear reason when the dependency is absent; they must not report a pass from an empty run.
 
-```bash
-python3 benchmarks/verify_scores.py benchmarks/results/locomo_aimee_direct_v<git-sha>.json
-```
+## Report
 
-The LLM track routes answer generation and judging through `aimee delegate execute`, so the configured execute-role agent in `~/.config/aimee/agents.json` remains the source of truth.
+Record:
 
-## Comparative Baselines and Published-Score Calibration
+- commit and dirty state;
+- command and exit status;
+- host CPU/GPU/RAM/kernel/runtime;
+- corpus name, version, size, and hash;
+- model IDs, digests, dimensions, quantization, and slots;
+- resolved configuration and feature gates;
+- warmup, repetitions, timeouts, and concurrency;
+- quality metrics with sample counts or uncertainty;
+- latency distribution, not only mean;
+- failures, skips, and degraded paths.
 
-### BM25 Parity
+Keep raw machine output beside the summary when practical.
 
-The **TrueMemory BM25 baseline** at **80.5% Cat 1-4 accuracy** on LoCoMo serves as the external anchor for all future lift claims. This ensures that reported improvements are measured against a reproducible external reference, not only against internal history.
+## Compare
 
-#### Judge / prompt deltas
+Change one variable at a time. Compare against the same corpus and acceptance metric. A cheaper or
+faster configuration is a win only if quality stays above the declared gate.
 
-The aimee harness differs from TrueMemory's evaluation setup in the following ways:
+Do not compare a local measured score directly with a paper score that used another corpus,
+prompt, judge, or retrieval budget. Reproduce the baseline in the same harness first.
 
-| Dimension | TrueMemory | aimee harness |
-|-----------|-----------|---------------|
-| Judge model | GPT-4 (paper) | Configured execute-role agent (`~/.config/aimee/agents.json`) |
-| Judge runs | 1 | 3 (majority vote) |
-| Answer prompt | Paper-specific | `benchmarks/common/llm_eval.py::ANSWER_SYSTEM` |
-| Top-K retrieval | Varies | `--top-k 100` default |
-| Dataset version | LoCoMo-10 | `locomo10.json` |
+## Rebaseline
 
-Any variance larger than 1pp versus the anchor should be documented in
-`benchmarks/locomo/BENCHMARK_RESULTS.md` with a short causal explanation.
-
-#### Available baselines
-
-| System | Script | Dependency |
-|--------|--------|------------|
-| BM25 | `bench_bm25_llm.py` | stdlib only |
-| Dense (ChromaDB) | `bench_rag_chromadb_llm.py` | `chromadb`, `sentence-transformers` |
-| Mem0 | `bench_mem0_llm.py` | `MEM0_API_KEY` + `mem0ai` |
-
-Run all available baselines:
-
-```bash
-./benchmarks/run-llm.sh --systems bm25,rag_chromadb,aimee
-```
-
-The `rag_chromadb` and `mem0` systems skip cleanly with a help message when
-their dependencies are absent, so the flag is safe to pass even in CI without
-those packages.
-
-## Performance Benchmarks
-
-### Transport latency SLO artifact
-
-Transport promotion uses the executable `latency_slo.v1` contract. A producer
-records eligibility before execution and emits at least 10,000 eligible attempts:
-
-```json
-{
-  "schema_version": "latency_slo.v1",
-  "eligibility_set_before_execution": true,
-  "profile": "wan-thin-client",
-  "path": "thin-client-server",
-  "budget": {
-    "p50_ms": 10,
-    "p99_ms": 20,
-    "combined_failure_tail_rate": 0.01,
-    "confidence": 0.95
-  },
-  "attempts": [
-    {"eligible": true, "success": true, "latency_ms": 7.2}
-  ]
-}
-```
-
-Percentiles use nearest-rank selection. An eligible attempt counts against the
-combined failure/tail budget when it fails or exceeds `budget.p99_ms`; an attempt
-is counted once when both occur. The evaluator compares the one-sided exact
-Clopper-Pearson upper confidence bound—not merely the observed rate—to the
-configured budget. Ineligible attempts remain in the artifact for auditability.
-Artifacts may tighten but cannot relax the transport ceilings of 10ms p50, 20ms
-p99, a 1% combined failure/tail upper bound, and 95% confidence.
-
-Run the contract tests and evaluate a captured artifact with:
-
-```bash
-make -C src test-latency-slo
-make -C src check-latency-slo LATENCY_SLO_INPUT=/absolute/path/result.json
-```
-
-The detailed capture format is `transport_benchmark.v1`. Its authoritative
-network profiles and workload matrix live in
-`benchmarks/transport/profiles.json`; the validator requires every timing,
-byte-count, connection, pool, and process field to be present. A stage that the
-current probe cannot measure is recorded explicitly as `null` and appears as a
-coverage gap rather than disappearing from the artifact. `timings_ms.total` is
-always required.
-
-Validate a capture and project it into the SLO evaluator's narrower input:
-
-```bash
-make -C src test-transport-artifact
-make -C src check-transport-artifact \
-  TRANSPORT_ARTIFACT_INPUT=/absolute/path/capture.json \
-  LATENCY_SLO_OUTPUT=/absolute/path/latency-slo.json
-make -C src check-latency-slo \
-  LATENCY_SLO_INPUT=/absolute/path/latency-slo.json
-```
-
-The projection does not manufacture samples or fill coverage gaps. Promotion
-still requires at least 10,000 attempts in the projected artifact and a passing
-`check-latency-slo` result.
-
-The KB mTLS listener defaults to 64 live connections. Operators may lower the
-bound with `AIMEE_KB_MTLS_MAX_CONNECTIONS` (1–64); invalid values fail startup.
-`kb_mtls_connection_stats()` exposes the configured limit plus current live and
-queued counts for transport capture without exposing request content.
-
-The listener reuses HTTP/1.1 connections sequentially by default, with a
-30-second between-request idle deadline. `Connection: close` is honored, and
-request pipelining is rejected so framing and per-request certificate authority
-checks remain unambiguous.
-
-The KB TLS client also exposes a reusable, one-in-flight connection primitive.
-It accepts only strict HTTP/1.1 responses with one `Content-Length`, a head no
-larger than 64 KiB, and a body smaller than the caller's bounded buffer; it reads
-that body exactly and never treats EOF as a successful response delimiter.
-
-The resident server→KB transport pools by its single enrolled endpoint and
-identity generation: at most 8 total connections, 2 idle, 64 waiting borrowers,
-a 30-second idle lifetime, 10-minute maximum age, and 1,000 requests per
-connection. Only one replacement handshake runs at once. Certificate rotation
-invalidates the generation, and `kb_client_mtls_pool_stats()` reports aggregate
-total/idle/busy/waiter occupancy without identity labels.
-
-Pool replacements reuse one immutable `SSL_CTX` per identity/trust generation,
-enabling TLS session resumption after a socket ages out without sharing sessions
-across certificate rotation. `kb_client_mtls_tls_stats()` exposes aggregate full
-handshake and resumed-session totals.
-
-Thin-client HTTP gzip remains an opt-in, bounded transport optimization controlled by
-`transport.thinclient_gzip_enabled` on the server and
-`AIMEE_TRANSPORT_THINCLIENT_GZIP_ENABLED=1` on the client. Eligible buffered
-responses and, after the server advertises `Accept-Request-Encoding: gzip`,
-requests of at least 4 KiB are compressed only when the wire body is smaller.
-The initial allowlist is `/v1/responses`, `/v1/completions`, `/v1/embeddings`,
-and `/v1/messages`; every other route, including authentication, enrollment,
-management, secret, event, and streaming traffic, remains identity encoded.
-Inflated bodies are capped at
-1 MiB for responses, 64 KiB including request headers, and 50 times the wire
-size; malformed, unsupported, and over-limit encodings fail closed. The flag
-remains off: the 2026-07-22 LAN capture reduced a 49,210-byte JSON request from
-51,592 to 18,110 TCP payload bytes (64.9%) but increased end-to-end latency from
-2.849 ms to 4.766 ms. That passes the wire gate but fails the required latency
-gate. A build without zlib (including the current Windows
-thin-client job) advertises no gzip capability and stays identity encoded.
-
-Thin-client HTTPS keep-alive now defaults on through
-`transport.server_keepalive_enabled` on the server and in resident clients.
-`AIMEE_TRANSPORT_SERVER_KEEPALIVE_ENABLED=0` is the client-side rollback. Each client
-thread owns at most one TLS connection with one in-flight request, a 30-second
-idle lifetime, 10-minute maximum age, and 1,000-request ceiling. Responses are
-read to their exact bounded `Content-Length`; close requests are honored and
-streaming/event routes remain one-shot. The server accepts reuse only after
-strict HTTP/1.1 framing validation and repeats certificate, revocation, bearer,
-and route-capability checks on every request. Short-lived CLI invocations still
-perform one handshake because process-local sockets do not survive process exit.
-
-The 2026-07-22 three-node Optane/LXC validation promoted connection reuse to the
-default. Server→KB pooling completed 500 valid requests at p50 1.589 ms and p95
-1.913 ms using two TCP connections, versus p50 4.762 ms and p95 5.308 ms with
-approximately 491 new connections. Resident thin-client keep-alive completed 300
-requests at p50 0.109 ms and p95 0.116 ms using one TCP connection, versus p50
-4.900 ms and p95 5.255 ms with approximately 295 new connections. Accordingly,
-`transport.kb_pool_enabled` and `transport.server_keepalive_enabled` default on;
-both gzip settings remain off.
-
-### Overview
-
-This document captures the current benchmark baseline for aimee’s latency-sensitive paths. The focus is the work that sits directly between a primary agent and useful execution: hook checks, memory access, session initialization, and delegate routing data.
-
-The current deployment mode is:
-
-- **Thin client**: `aimee` and `aimee-runtime-web` talk to
-  the local `aimee-server` over a Unix socket. DB1 stays in that local
-  server; DB2 (incl. pgvector) stays in `aimee-kb`, which may be local or
-  shared in non-default deployments.
-
-The retired in-process command-dispatch path ran command handlers in forked
-server children. That path is no longer a valid deployment mode because it let
-client command code observe DB tiers directly. Unported commands now fail before
-they reach the server until they have typed server/kb RPC routes.
-
-```mermaid
-flowchart LR
-    subgraph ThinClient[Current deployment]
-        A1[Primary agent]
-        B1[aimee]
-        C1[Unix socket]
-        D1[aimee-server]
-        E1[aimee-kb]
-        A1 --> B1 --> C1 --> D1 --> E1
-    end
-```
-
-## Methodology
-
-Benchmarks are run with `benchmarks/run.sh` and measure wall-clock latency using `date +%s%N`. Each operation is executed `N` times, and the benchmark reports p50, p95, and p99 latency in milliseconds.
-
-The benchmark suite covers the critical paths that most directly affect responsiveness:
-
-- hook latency
-- memory search
-- session startup
-- delegate routing data loading
-- maintenance work on memory state
-
-Example invocation:
-
-```bash
-cd aimee
-
-# Through aimee-server (default)
-AIMEE=aimee ./benchmarks/run.sh 100
-```
-
-Benchmark environment:
-
-- **Platform:** Proxmox VE 8.x, Debian 13, Intel Xeon, 32GB RAM, NVMe SSD
-- **Database contents:** ~30 memories, 39 network hosts, 15 workspace projects
-- **Baseline date:** 2026-04-02
-
-## Results
-
-### Thin client
-
-This is the default deployment model. The CLI connects to `aimee-server` over a Unix socket. First-call latency includes socket connection overhead, while subsequent calls can reuse the connection and benefit from warm tier-owned DB connections.
-
-| Operation | p50 | p95 | p99 | Notes |
-|-----------|-----|-----|-----|-------|
-| Startup (version) | <1ms | 1ms | 5ms | Binary load + socket connect |
-| Hook pre (Edit) | 1ms | 3ms | 19ms | Critical path: guardrail check |
-| Hook pre (Bash) | 1ms | 2ms | 18ms | Critical path: guardrail check |
-| Memory search | 7ms | 8ms | 18ms | DB2 lexical + pgvector dense retrieval |
-| Memory list (L2 facts) | 1ms | 2ms | 4ms | DB2 memory list query |
-| Agent network | 7ms | 8ms | 9ms | Load and format agents.json |
-| Session-start | 8ms | 9ms | 13ms | Context assembly (rules + facts + network) |
-| Memory maintain | 11ms | 15ms | 17ms | Promotion/demotion/expiry cycle |
-
-#### Analysis
-
-The thin client mode produces very low median latency for operations that benefit from a resident server process. Startup and hook checks are especially fast at p50, which is consistent with pushing the expensive initialization work into `aimee-server` and keeping tier-owned state warm.
-
-The main cost of this architecture appears in tail latency rather than median latency. Hook checks show p99 values of 18-19ms despite 1ms p50, which indicates that the socket boundary and connection behavior occasionally dominate the critical path. This is not a throughput problem; it is a predictability problem at the tail.
-
-Memory and session operations remain comfortably bounded. `Memory search` at 18ms p99 and `Session-start` at 13ms p99 suggest that the persistent process model is already doing what it should: keeping tier-backed retrieval and context-assembly work interactive without forcing a full initialization cycle on every call.
-
-### Retired in-process dispatch
-
-These numbers are retained as historical context only. The path used
-generic command forwarding and forked command handlers that initialized tier
-connections per call. That is no longer an allowed runtime boundary.
-
-| Operation | p50 | p95 | p99 | Notes |
-|-----------|-----|-----|-----|-------|
-| Startup (version) | 2ms | 4ms | 4ms | Binary load + arg parse |
-| Hook pre (Edit) | 4ms | 4ms | 6ms | Critical path: guardrail check |
-| Hook pre (Bash) | 3ms | 4ms | 5ms | Critical path: guardrail check |
-| Memory search | 10ms | 11ms | 12ms | DB2 lexical + pgvector dense retrieval |
-| Memory list (L2 facts) | 3ms | 3ms | 4ms | DB2 memory list query |
-| Agent network | 2ms | 3ms | 3ms | Load and format agents.json |
-| Session-start | 3ms | 4ms | 4ms | Context assembly (rules + facts + network) |
-| Memory maintain | 5ms | 6ms | 7ms | Promotion/demotion/expiry cycle |
-
-#### Analysis
-
-The retired in-process path was defined more by consistency than by absolute minimum p50 latency. Hook checks, memory access, and session-start all had narrow p50-to-p99 ranges, which meant the system behaved predictably from call to call.
-
-That tighter spread was the main result. Startup was slower at p50 than the thin client (`2ms` versus `<1ms`), and memory search was also slower at median (`10ms` versus `7ms`), matching the expected cost of per-call tier initialization. But the tail remained tighter: for example, `Memory search` reached only `12ms` at p99, and hook checks stayed between `5ms` and `6ms` at p99.
-
-The architecture no longer accepts this tradeoff because DB ownership is stricter than the benchmark convenience.
-
-## Performance Budget
-
-The following budgets define acceptable p99 latency for the key interactive paths:
-
-| Path | Target | Rationale |
-|------|--------|-----------|
-| Hook pre-tool check | <10ms p99 | Blocks between primary agent and file edit |
-| Session-start | <100ms p99 | Runs once at primary agent session start |
-| Memory search | <20ms p99 | Interactive query from primary agent or delegate |
-| Agent network | <10ms p99 | Delegate agent config file read |
-
-Current results against budget:
-
-- **Hook pre-tool check:** in-process passes comfortably; thin client exceeds the `<10ms p99` target in both measured hook cases (`18ms` and `19ms`).
-- **Session-start:** both modes pass with substantial margin (`13ms` thin client, `4ms` in-process).
-- **Memory search:** both modes pass (`18ms` thin client, `12ms` in-process).
-- **Agent network:** both modes pass (`9ms` thin client, `3ms` in-process).
-
-The current performance story is therefore not that the system is broadly slow. It is that one specific user-facing path, thin-client hook enforcement, has measurable tail-latency headroom to recover.
-
-## Scaling Notes
-
-- `Memory search` cost depends on DB2 lexical candidate generation, pgvector dense recall, and deterministic reranking. Benchmark baselines should be regenerated at larger corpus sizes rather than inferred from the current small-memory run.
-- `Session-start` context assembly scales with the number of rules, facts, and network hosts included in injected context. The current assembly fits in a 32KB buffer. Delegate agent context assembly uses a separate 16KB budget.
-- `Hook pre-tool check` is `O(1)` for path classification and `O(worktrees)` for worktree matching. As worktree count grows, this remains a likely source of incremental latency pressure even before tier-backed retrieval paths become significant.
-- Worktree creation is deferred until first write access, so `Session-start` does not include git operations.
-
-A practical reading of the current data:
-
-- Database-backed operations are already well within budget at the current dataset size.
-- Tail behavior is more sensitive to deployment architecture than median behavior.
-- If the system scales up in memories, hosts, or worktrees, the first regressions to watch are likely to be hook tail latency and context assembly size rather than average-case search latency.
-
-## Running Benchmarks
-
-Run the benchmark suite from the repository root:
-
-```bash
-cd aimee
-
-# Through aimee-server (default)
-AIMEE=aimee ./benchmarks/run.sh 100
-```
-
-Use the benchmark output to compare p99 latency against the performance budget. In CI or local regression checks, the key question is whether each critical path remains below its budget threshold, not whether every percentile exactly matches this baseline.
+Rebaseline only after an intentional contract, dependency, model, or hardware change. Preserve the
+old artifact, explain the delta, and make the acceptance decision reviewable.

--- a/docs/CODE_INTELLIGENCE.md
+++ b/docs/CODE_INTELLIGENCE.md
@@ -1,65 +1,77 @@
 # Code intelligence
 
-aimee indexes your code into a symbol and call graph and keeps it on the server, so the AI
-works from the graph instead of reading your files over again every session. It finds every
-caller of a function, traces what an edit will touch before it writes, and pulls the exact
-span it needs instead of loading whole files. The graph spans repositories, so one dependency
-map covers every repo you work across.
+aimee stores code as symbols, references, calls, imports, repository dependencies, embeddings, and
+git co-change. The graph lives in DB2 and can span every repository in a workspace.
 
-## What it indexes
-
-aimee extracts symbols, references, and call edges with tree-sitter across C, C++, C#,
-Python, Go, JavaScript, TypeScript, Rust, Java, Ruby, PHP, Kotlin, Swift, Dart, Lua, Bash,
-and CSS. The graph and the code spans live in DB2 (Postgres with pgvector), next to the
-knowledge base, so a query is a database lookup, not a filesystem scan.
-
-## Build and refresh the index
+## Index
 
 ```bash
-aimee index scan            # scan your workspaces and build or refresh the graph
-aimee index scan --force    # rebuild from scratch
-aimee index list            # list indexed projects (alias: index overview)
+aimee workspace add /path/to/repo
+aimee index scan /path/to/repo
+aimee index overview
 ```
 
-A workspace you add with `aimee workspace add` is indexed as part of the same graph. See
-[Workspace management](WORKSPACES.md).
+A remote thin client reads and uploads source content. The server never scans a client path. Ingest
+commits only after content, project, scope, and hash checks pass.
 
-## Query it
+Supported tree-sitter extractors cover the languages listed by the running KB capability endpoint.
+Do not rely on a copied language list; generated capabilities follow the built parsers.
+
+## Query
 
 ```bash
-aimee index find <name>            # locate a symbol or identifier
-aimee index callers <symbol>       # who calls this
-aimee index blast-radius <file>    # files a change here would touch
-aimee index structure <file>       # the symbols in a file
+aimee index find <name>
+aimee index callers <symbol>
+aimee index structure <file>
+aimee index blast-radius <file>
+aimee graph explain <relationship>
 ```
 
-## Cross-repo dependencies
+Caller and blast-radius results cross repository boundaries after dependencies have been resolved.
+Vendored code, caches, generated trees, and configured excludes stay out of the project graph.
 
-The graph is not per repo. aimee resolves dependency edges across the repositories in your
-workspace, so a change in a shared library shows its blast radius in the services that consume
-it, and a caller lookup crosses repo boundaries. You can ask in three directions: `out` for
-what a project depends on, `in` for the repos that depend on it (the reverse map), or `both`.
-Vendored trees and dependency caches are skipped so they do not pollute the graph.
+`ast_grep_search` is advertised only when its helper readiness contract passes. An unavailable helper
+returns unsupported; it does not fall back to a different search and label it AST-aware.
 
-## Graph audits
+## Hybrid code search
 
-`aimee code audit --graph` runs graph-derived health checks on an indexed project and returns
-dead exports, import cycles, exact clones, and near clones.
+Text and vector matches find names and concepts. The call/import/dependency graph supplies structural
+neighbors. Memory links add prior decisions and known constraints. Fusion keeps the evidence for each
+signal so a client can explain the result.
+
+## Audits
 
 ```bash
-aimee code audit --graph [--project P] [--json]
+aimee code audit <dir>
+aimee code audit --graph --project <name>
 ```
 
-A thin client needs a configured remote and an indexed project for this. Plain
-`aimee code audit [dir]` runs local file-health checks without the graph.
+The local audit reports file-level health. The graph audit reports dead exports, import cycles, exact
+clones, and near clones from an indexed project. `--fix` is non-mutating unless the installed help
+explicitly says otherwise.
 
-## How the AI uses it
+## CSS migration
 
-The graph is a tool surface for the primary agent and its delegates, not only a CLI. Before
-an edit the AI looks up callers and blast radius, and it fetches exact code spans by symbol
-instead of loading whole files into context. That is what lets it work from your code, keep
-its context small, and stop rediscovering the codebase on every session. Code search is a
-hybrid vector-graph like memory: the call graph, vector similarity, and the cross-session
-knowledge graph are ranked together (`/v1/code/hybrid`, tuned by `code_hybrid_weight_graph`
-and `code_hybrid_weight_memory`), so a lookup follows structure and meaning, not just text.
-See [How aimee learns](KNOWLEDGE.md) for how this sits alongside memory and the curator.
+The CSS index records selectors, declarations, variables, conflicts, component use, and migration
+units:
+
+```bash
+aimee css report <project>
+aimee css dead-rules <project>
+aimee css conflicts <project>
+```
+
+Computed-style verification uses an isolated Chromium sidecar. Capture a before and after snapshot,
+then compare them with `aimee css render-verify`. See the
+[CSS render sidecar](../deploy/css-render/README.md).
+
+## Refresh and failure behavior
+
+Incremental scan updates changed content. Use `--force` after extractor/schema changes or when a
+repair says the generation is inconsistent.
+
+An empty scan cannot mark a previously populated project healthy without recording why no files were
+seen. Remote index writes require a data grant for the authenticated subject.
+
+Before a broad edit, query callers and blast radius, then inspect the named files. The graph narrows
+work; it does not replace tests.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,229 +1,80 @@
-# Command Reference
+# Commands
 
-> **Complete, always-current references** (generated from the source-of-truth
-> tables, see [`gen/cli-commands.md`](gen/cli-commands.md) and
-> [`gen/configuration.md`](gen/configuration.md)):
-> - **[Full CLI command list](gen/cli-commands.md)**, every command + subcommands,
->   from `src/cli_help_data.h`.
-> - **[Configuration reference](gen/configuration.md)**, every config key (the
->   `aimee config get/set` allowlist + the config-file JSON sections).
->
-> This page is a hand-written walkthrough of the common commands; the generated
-> pages above are the authoritative, exhaustive lists.
+The exact command table is generated from the CLI registry: [CLI command reference](gen/cli-commands.md).
+This page is the map.
 
-`aimee` is a thin CLI. It either handles a small local-only operation
-or forwards a typed request to `aimee-server`. Commands that are not listed
-here are not part of the client contract until they have a typed server route.
+The `aimee` binary is a thin client. A command either performs a small local operation or sends a
+typed request to `aimee-server`. It never opens DB1 or DB2.
 
-Server-backed commands support `--json` for machine-parseable output.
+## Everyday commands
 
-## Command Tiers
+| Task | Commands |
+| --- | --- |
+| health | `status`, `kb status`, `remote status`, `workers` |
+| durable memory | `memory store`, `memory search`, `memory list`, `memory get`, `memory read` |
+| session scratch | `wm set`, `wm get`, `wm list` |
+| code graph | `index scan`, `index find`, `index callers`, `index structure`, `index blast-radius`, `graph explain` |
+| workspaces | `workspace add`, `workspace list`, `workspace remove`, `worktree gc` |
+| delegates | `delegate`, `jobs`, `agent`, `provider`, `model`, `persona`, `roles` |
+| review panels | `ensemble aggregate`, `ensemble roundtable` |
+| workflows | `workflow`, `trigger`, `cron`, `pipeline` |
+| CSS migration | `css report`, `css render-capture`, `css render-verify` |
+| rules and reusable context | `rules`, `skill`, `toolset` |
+| configuration and updates | `config`, `profile`, `remote`, `self-update` |
 
-- **Core**: everyday commands shown in `aimee --help`.
-- **Advanced**: power-user status commands shown by `aimee help --all`.
-- **Admin**: operational helpers shown by `aimee help --all`.
+Use `--json` on server-backed commands when the help advertises it. Human output can change; JSON
+fields follow the operation contract.
 
-Run `aimee help --all` to see all tiers at once, or
-`aimee help <command>` for command-specific help.
+## Operations and evidence
 
-## Core Commands
+| Task | Commands |
+| --- | --- |
+| WORM integrity | `audit verify`, `audit checkpoint`, `audit seal`, `audit snapshot` |
+| retrieval evidence | `audit trace`, `audit provenance`, `audit fidelity` |
+| runtime diagnosis | `doctor forensics`, `hud`, `insights`, `economizer stats` |
+| KB operations | `kb search`, `kb ingest`, `kb docs push`, `curator` |
+| job history | `jobs`, `job`, `episode`, `trajectory` |
+| optimization | `optimize`, `dogfood`, `code audit` |
+| service lifecycle | `server start`, `server restart` |
 
-### Stored Memory
+The event bus has no general remote shell command. Its audit results appear through `aimee audit`,
+logs, metrics, and capture tooling. See [Event bus](EVENT_BUS.md).
 
-- `aimee memory search <query>`: search stored memory through the server.
-- `aimee memory store <key> <value> [--tier T] [--kind K]`: store a memory entry.
-- `aimee memory list [--tier T] [--kind K] [--limit N]`: list stored memory entries.
-- `aimee memory get <id>`: read one memory by id.
+## Integrations
 
-### Working Memory
+- `mcp-serve` runs the local MCP stdio bridge.
+- `acp-serve` runs the ACP stdio bridge where included in the build.
+- `mcp audit` and `mcp recheck` inspect registered MCP packages.
+- `api status` prints public endpoint and client setup information.
+- `claude-proxy` points Claude Code at the Anthropic-compatible ingress.
+- hook entry points are integration commands; call them through generated client configuration, not
+  by hand.
 
-- `aimee wm set <key> <value> [--session ID] [--category C] [--ttl N]`: store a session-scoped scratch value.
-- `aimee wm get <key> [--session ID]`: read a session-scoped scratch value.
-- `aimee wm list [--session ID] [--category C]`: list session-scoped scratch values.
+## Command tiers
 
-### Manuscript
+- **Core** commands appear in normal help and carry the strongest compatibility expectation.
+- **Advanced** commands appear in `aimee help --all` and are safe for ordinary operators.
+- **Admin/internal** commands may require local authority or change with the owning subsystem.
 
-- `aimee manuscript scenes`: list detected scene/chapter markers.
-- `aimee manuscript wordcount`: count words in manuscript files.
-- `aimee manuscript outline`: print a structural outline.
-- `aimee manuscript check [files...]`: run long-form writing checks.
+A command is not public merely because a server handler exists. The DB-free client advertises it
+only after it has a local implementation or a typed route.
 
-### Rules
+## Removed commands
 
-- `aimee rules list`: list active rules through the server.
-- `aimee rules generate`: generate the rules prompt through the server.
-- `aimee rules delete <id>`: delete one rule through the server.
+- `aimee chat`: use the browser, MCP, ACP, or a compatible API client.
+- `aimee work`: use workflows, triggers, coordinated jobs, or durable delegate jobs.
+- `aimee migrate v2`: current daemons perform supported schema migration at startup.
 
-### Roadmap, Auto, and Review Implementation Modules
+Bare `aimee` prints usage; it does not launch a TUI.
 
-The source tree contains roadmap/auto/review implementation modules, but
-`aimee roadmap`, `aimee auto`, and unified `aimee review` are not current
-thin-client commands because they do not have typed server RPC routes. The
-current routed planning path is:
+## Help
 
-- `aimee delegate plan <proposal.md> [--json] [--output PATH] [--launch] [--parallel N]`: generate read-only work packets from a proposal.
-- `aimee delegate launch <plan.json> [--json] [--parallel N]`: queue a reviewed packet plan into a coordinated job.
-- `aimee job status <id>`: inspect queued packet progress.
+```bash
+aimee --help
+aimee help --all
+aimee help <command>
+aimee <command> --help
+```
 
-Commands that return "has no typed server RPC route" are implementation work in
-progress, not part of the installed CLI contract.
-
-### Code Index
-
-- `aimee index find <identifier>`: find a symbol or identifier.
-- `aimee index list`: list indexed projects.
-- `aimee index overview`: alias for `index list`.
-- `aimee index scan [--force]`: scan workspaces and rebuild the code index.
-- `aimee index blast-radius <file>`: show files affected by changing a file.
-- `aimee index structure <file>`: show file structure.
-- `aimee index callers <symbol>`: find callers of a symbol.
-- `aimee code audit [dir] [--json] [--fix]`: run local file-health checks. `--fix` is intentionally non-mutating for now and reports that no safe automatic fixes are available.
-- `aimee code audit --graph [--project P] [--json]`: request graph-derived dead-export, import-cycle, exact-clone, and near-clone findings from `aimee-server`/`aimee-kb`. Thin clients need a configured remote and an indexed project.
-
-### Chat
-
-There is no built-in interactive chat client; bare `aimee` prints usage. Reach the
-primary agent through any OpenAI-compatible front end pointed at
-`POST /v1/chat/completions`, the web chat, or `aimee acp-serve` from an ACP editor.
-The server still owns provider routing, primary session IDs, memory, guardrails,
-and tool execution.
-
-Direct Codex and Mistral primary sessions use server-side structured
-conversation state; explicit legacy routes such as `codex-cli` still use the
-provider CLI path. Claude delegates run the installed `claude` CLI in tmux,
-while `mistral-cli` and `mistral-plan` bridge to native HTTP adapters behind
-provider-CLI-compatible config.
-
-### Delegation
-
-- `aimee delegate <role> <prompt>`: delegate a task through `aimee-server`.
-- `aimee delegate plan <proposal.md> [--output PATH] [--launch]`: generate reviewed work packets.
-- `aimee delegate launch <plan.json> [--parallel N]`: queue a packet plan into a coordinated job.
-- `aimee delegate aggregate "<task>"`: run one Mixture-of-Agents fan-out and synthesis over `ensemble.reference_models`.
-- `aimee delegate roundtable "<task>" [--roundtable PRESET] [--mode draft|review] [--turns parallel|sequential] [--rounds N] [--brief TEXT] [--brief-json JSON] [--apply]`: run a bounded multi-round collaborative draft or review.
-- `aimee delegate status <job_id> [job_id...]`: inspect background delegate status.
-- `aimee delegate log` / `aimee delegate history`: show delegation episodes.
-- `aimee delegate --list-roles`: list configured delegate roles.
-
-Useful flags:
-
-- `--tools`: allow tool-use mode for the delegate.
-- `--prompt-file PATH`: read the prompt body from a file.
-- `--max-tokens N`: pass a token budget hint.
-
-### Skills and Toolsets
-
-- `aimee skill list`: list available skills.
-- `aimee skill show <name>`: print a skill body or support file.
-- `aimee skill lint`, `skill eval`: validate or evaluate skills.
-- `aimee skill create`, `edit`, `patch`, `archive`, `pin`, `unpin`, `lifecycle`, `autostub`: mutate skill state through routed RPCs.
-- `aimee toolset list`, `toolset show <name>`, `toolset resolve <name>`: inspect composable toolsets.
-
-### MCP Registry and Insights
-
-- `aimee mcp audit`: list registered MCP servers and last OSV verdict.
-- `aimee mcp recheck [name]`: force a fresh OSV query.
-- `aimee insights [--days N]`: show token usage totals over the last N days.
-
-### Knowledge Base
-
-- `aimee kb search <query>`: search the KB through `aimee-server` and `aimee-kb`.
-- `aimee kb status`: show KB/vector health.
-- `aimee kb build [--path DIR] [--project NAME] [--force]`: build an index from a tree.
-- `aimee kb update`: run an incremental KB update.
-- `aimee kb docs push [--scope SCOPE] <file>...`: stage docs for ingest.
-- `aimee kb ingest <file>` and `aimee kb ingest status`: queue and inspect ingest work.
-
-## Advanced Commands
-
-- `aimee session list [--limit N]`: list recent sessions through the server.
-- `aimee session show <session-id>`: show one session through the server.
-- `aimee session close <session-id>`: close one session through the server.
-- `aimee session brief [--limit-tokens N]`: show the persisted session-start brief.
-- `aimee status`: show `aimee-server` health. It requires an already-running
-  server; use `systemctl --user start aimee-server` on systemd systems or
-  `aimee server start` as the unmanaged fallback.
-- `aimee hud`: show current session telemetry.
-- `aimee workers`: show server/KB worker-pool state.
-- `aimee server start`: explicitly spawn a server in unmanaged environments.
-- `aimee server restart`: terminate the running server and spawn a fresh one.
-- `aimee server status` / `server health`: aliases for server health.
-- `aimee workspace add <path>`, `workspace list`, `workspace remove <path>`: manage indexed workspace roots.
-- `aimee remote set <url> [token]`, `remote enroll`, `remote trust`, `remote status`,
-  `remote clear`: point the thin client at a remote `aimee-server` over TCP. `set`
-  persists the target to `<aimee_home>/remote.conf` and, for `https://`, pins the
-  server's self-signed cert (trust-on-first-use); `status` shows the resolved
-  transport plus a `GET /v1/health` probe; `trust` re-pins after a cert rotation;
-  `clear` reverts to the local Unix socket. Precedence: `--server`/`--server-token=`
-  flags > `AIMEE_SERVER_URL`/`AIMEE_SERVER_TOKEN` env > persisted `remote.conf`.
-  `https://` is supported on Linux/macOS (OpenSSL, cert-verified;
-  `AIMEE_TLS_INSECURE=1` to skip); Windows builds refuse it.
-  - **Bootstrap enrollment:** the aimee-server image seeds a well-known one-time
-    bearer `aimee-local-dev`. Connecting with it (`aimee remote set <url>
-    aimee-local-dev`) auto-runs enrollment: the server mints a strong random
-    per-deployment bearer (`api.rotate_bearer`), the client adopts it in
-    `remote.conf`, and the bootstrap token immediately stops working, so the
-    shared default is never a standing credential. `aimee remote enroll` forces a
-    fresh rotation on the configured remote at any time. To skip the bootstrap
-    entirely, set `AIMEE_API_BEARER_TOKEN` on the server (secret store) to pin your
-    own bearer; an explicit env token disables the auto-rotation.
-- `aimee worktree gc [--days N] [--force] [--dry-run]`: garbage-collect abandoned session worktrees.
-- `aimee jobs list [--limit N]`: list recent durable delegate jobs.
-- `aimee jobs status <job-id>`: show one durable delegate job.
-- `aimee jobs logs <job-id>`: print the recorded result/log body for one durable delegate job.
-- `aimee jobs cancel <job-id>`: cancel a queued or running durable delegate job.
-- `aimee job start <plan-id>`, `job list`, `job status <id>`, `job cancel <id>`: manage coordinated packet-plan jobs.
-- `aimee delegate-backend list`, `delegate-backend exec ...`: inspect or drive local/SSH/docker delegate backends.
-- `aimee agent list`, `add`, `local`, `remove`, `enable`, `disable`, `probe`, `setup`, `episodes`, `token`: manage delegate agents and credentials.
-- `aimee provider list [--available] [--json]`: list registered model providers and credential availability.
-- `aimee provider show <name>`: show one provider profile.
-- `aimee provider models <name> [--json]`: fetch a provider model catalog.
-- `aimee provider test <name>`: probe provider credentials and model-listing connectivity.
-- `aimee provider quota [name]`: inspect credential-pool quota state.
-- `aimee provider <name>` or `aimee use <name>`: switch the active provider profile.
-- `aimee model list`, `model show <model>`, `model refresh`: inspect model capability metadata.
-- `aimee graph sync-code`, `graph explain`: run code graph sync/explanation helpers.
-- `aimee trajectory export`, `trajectory batch`: export or batch-generate trajectory data.
-- `aimee aux`, `aux config show`, `aux test`: inspect or test auxiliary-model routing.
-- `aimee optimize run --suite <suite> [--arm <arm>]`: run the `memory.benchmark` RPC for retrieval suites. Synchronous suites are `code-graph-fusion`, `memory`, `corpus`, `memory-retrieval`, and `live`; dataset and judge-style suites return an `async-only` pointer to the CLI/delegate benchmark path. Registered decision points include `briefing_style` and `guardrail_strictness`; these static points are promotion/replay driven while online exploration remains default-off via `intelligence.bandit.live_decision_enabled`.
-- `aimee identity show`, `snapshot`, `diff`: inspect charter/local-operator/working-profile state.
-- `aimee dogfood tag`, `review`, `report`: label and report dogfood review data.
-- `aimee eval run <suite_dir>`, `eval results [suite]`: run or inspect eval suites.
-- `aimee trigger fire`, `list`, `status`, `cancel`: manage event-triggered runs.
-- `aimee cron list`, `add`, `show`, `history`, `run`, `enable`, `disable`, `remove`: manage server-side cron/watchdog jobs.
-- `aimee profile create`, `list`, `show`, `delete`, `current`: manage profile-specific config roots.
-
-The hidden `hooks` command is used by configured editor/agent integrations:
-
-- `aimee hooks pre`
-- `aimee hooks post`
-
-## Admin Commands
-
-- `aimee git verify`: verify current changes before merge.
-- `aimee clean [--force]`: remove local aimee configuration and client integrations.
-
-## Webchat
-
-- `aimee-runtime-web --port 8080`: ask `aimee-server` to host the browser webchat surface.
-
-`aimee-runtime-web` is also a thin client. It does not read storage directly.
-
-## MCP Server
-
-The MCP bridge runs as `aimee mcp-serve`. It is built into
-`aimee`, speaks stdio JSON-RPC 2.0 to MCP-compatible clients, and
-forwards tool calls to `aimee-server`.
-
-Tools exposed:
-
-- `search_memory`: server-backed retrieval over stored facts.
-- `list_facts`: list stored facts.
-- `get_host`: look up a host by name.
-- `list_hosts`: list all hosts and networks.
-- `find_symbol`: search code index for symbol locations.
-- `delegate`: delegate a task to a sub-agent.
-- `preview_blast_radius`: show file dependency impact.
-- `record_attempt`: log a delegation attempt.
-- `list_attempts`: list recent delegation history.
-- `delegate_reply`: follow up on a prior delegation.
+Installed help is authoritative for the installed binary. The generated reference is authoritative
+for this checkout.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,163 +1,94 @@
-# Compatibility Reference
+# Compatibility
 
-This document summarizes the environments, integrations, and external interfaces supported by aimee.
+## Platforms
 
-Status terms used throughout this document:
+| Component | Linux | macOS | Windows |
+| --- | --- | --- | --- |
+| thin client, MCP, ACP | supported | supported universal binary | supported x86-64 binary |
+| native TLS | OpenSSL | Secure Transport | Schannel |
+| server, KB, workflow plane | supported | development use | use Docker or WSL2 |
+| event-bus host | supported | not in v0 | not in v0 |
+| delegate container backend | supported | through Docker | through Docker/WSL2 |
 
-- Tested: Confirmed through direct use on the listed platform, tool, or provider.
-- Expected: Not verified as part of routine testing, but expected to work based on matching protocols, compatible toolchains, or equivalent runtime behavior.
+Debian 13 x86-64 is the main development and deployment target. Ubuntu 22.04+, Proxmox VE 8+, and
+other current glibc distributions use the same server build. The native macOS and Windows products
+are thin clients; POSIX process, PAM, `memfd`, and service-manager features remain server-side.
 
-## Primary Agent Support
+Linux client enrollment can create an mTLS certificate automatically. macOS and Windows use their
+native TLS stacks but currently need an explicitly provisioned client certificate when mTLS is
+required.
 
-These are the primary AI coding tools that aimee integrates with for memory injection, guardrails, and session management. Tools can also point their front end at aimee's wire-format ingress and run every turn on aimee's configured primary model (any provider), instead of the tool's built-in vendor; see [MANUAL §25](../MANUAL.md#25-integrations).
+## Coding tools
 
-| Primary agent | Integration points | Run on any model (ingress) | Tested versions | Support level | Notes |
-|---|---|---|---:|---|---|
-| Claude Code | `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd` | Anthropic Messages, `POST /v1/messages` | 1.x | Full | Full hook coverage; `aimee claude-proxy enable` reroutes to any primary model. |
-| Codex CLI | `PreToolUse`, `PostToolUse`, `SessionStart`, local plugin, MCP | OpenAI Responses, `POST /v1/responses` | 1.x | Full | Hooks + MCP; `~/.codex/config.toml` model provider runs any primary model, incl. the function-call tool loop. |
-| OpenCode | OpenAI-compatible front end | OpenAI-compatible, `POST /v1/chat/completions` | 2.x | Full | Front end onto aimee's primary model over the OpenAI-compatible ingress. |
-| Mistral Vibe-compatible Mistral | native HTTP adapter using Vibe-compatible defaults | Provider CLI | 2.9.6 source-compatible defaults | Expected | Used by Aimee's built-in primary chat and `mistral-plan` delegate route without launching `vibe`. |
+| Tool | Hooks | MCP | Other path |
+| --- | --- | --- | --- |
+| Claude Code | session, pre-tool, post-tool | yes | Anthropic Messages ingress |
+| Codex CLI | session and tool hooks where supported | local plugin | OpenAI Responses ingress |
+| VS Code | no native hook contract | yes | ACP and OpenAI-compatible model endpoint |
+| GitHub Copilot | supported hook subset | yes | — |
+| Claude Desktop | — | yes | — |
+| OpenCode and similar front ends | — | optional | OpenAI Chat Completions ingress |
 
-## Platform Support
+Client setup updates detected registrations without duplicating them. Set
+`AIMEE_NO_CLIENT_INTEGRATIONS=1` to opt out.
 
-### Operating Systems
+Hook coverage is limited by the client. MCP and server-side tool policy still apply when a client
+does not expose a pre-tool hook.
 
-| Platform | Architecture | Build status | Runtime status | Notes |
-|---|---|---|---|---|
-| Debian 13 (trixie) | x86_64 | Tested | Tested | Primary development platform. |
-| Ubuntu 22.04 and newer | x86_64 | Expected | Expected | Expected to work with the same general toolchain as Debian. |
-| Proxmox VE 8.x | x86_64 | Tested | Tested | Deployed in production. |
-| macOS 14 and newer | arm64 | Expected | Expected | Requires Homebrew-managed dependencies. |
-| Windows via WSL2 | x86_64 | Expected | Expected | Recommended Windows runtime environment. |
-| Native Windows (experimental) | x86_64 | Tested | Expected | CMake + MinGW builds and portable unit tests run in CI, but many runtime features are still POSIX-first. |
+## Provider protocols
 
-### Shell Environments
+aimee has native translations for:
 
-| Shell | Hook execution status | Notes |
-|---|---|---|
-| `bash` | Tested | Primary shell environment. |
-| `zsh` | Expected | Common default shell for Claude Code on macOS. |
-| `sh` (`dash`) | Expected | Minimal POSIX shell environment. |
+- OpenAI Chat Completions and Responses;
+- Anthropic Messages;
+- Gemini;
+- Mistral;
+- AWS Bedrock Converse/EventStream;
+- local OpenAI-compatible endpoints, including Ollama-style servers;
+- Codex OAuth and supported local provider CLIs.
 
-## Build Dependencies
+All routes use the canonical IR, but a model still needs the capability requested by the task:
+tools, images, reasoning, streaming, or a sufficient context window. Use `aimee model show` and
+`aimee provider test` instead of assuming protocol compatibility means model compatibility.
 
-These dependencies are required to build or run major aimee components.
+Local CLI agents need their executable, login, and terminal runtime on the machine that executes
+them. A remote workspace can run a CLI agent through the thin-client runner so the login stays on
+the client.
 
-| Dependency | Minimum version | Debian package | Required for | Notes |
-|---|---:|---|---|---|
-| `gcc` | 10+ | `build-essential` | All binaries | Required C compiler toolchain. |
-| `make` | 4.0+ | `build-essential` | Build system | Used for project build orchestration. |
-| SQLite3 | 3.35+ with FTS5 | `libsqlite3-dev` | Server-local storage | FTS5 is required for local session/window indexes. |
-| `libcurl` | 7.68+ | `libcurl4-openssl-dev` | Delegate agent HTTP, server | Required for outbound HTTP integrations. |
-| OpenSSL | 1.1+ | `libssl-dev` | Webchat TLS | Provides TLS support. |
-| PAM | System version | `libpam0g-dev` | Webchat authentication | Uses the host platform PAM implementation. |
+## MCP and ACP
 
-### Server SQLite Requirement
+`aimee mcp-serve` uses JSON-RPC 2.0 over stdio and supports tool, resource, and prompt discovery.
+HTTP/SSE MCP is not the primary client transport. The optional in-daemon MCP adapter is a module for
+running registered integrations; it does not change the thin-client stdio contract.
 
-FTS5 support is required by local server indexes. Most system SQLite packages include FTS5, but it should be verified on minimal or custom builds.
+ACP uses the local stdio bridge. Exact methods and tools depend on the installed build; inspect the
+client with `aimee help --all` and the protocol handshake.
 
-Example check:
+## Build requirements
 
-```bash
-sqlite3 :memory: "SELECT fts5();" 2>&1 | grep -q "wrong number" && echo "FTS5 available"
-```
+Server builds need a C11 toolchain, GNU Make, SQLite with FTS5, libcurl, OpenSSL, pthreads, PAM on
+Linux, and libpq for the KB build. Go builds cover the workflow and browser services. PostgreSQL 18,
+pgvector, and pgvectorscale are included in the default KB container.
 
-## Delegate Providers
+The Makefile is canonical for Linux development. CMake carries portable thin-client and test builds.
 
-These are the API providers that delegate agents can connect to for task offloading. Codex and Mistral can also use the same provider layer through primary-session adapters; other primary-agent integrations happen through hooks, MCP, or remaining provider CLI routes.
+## Stability
 
-| Provider | API format | Authentication | Models tested | Notes |
-|---|---|---|---|---|
-| OpenAI | `/chat/completions` | Bearer token | `gpt-4o`, `gpt-4o-mini` | OpenAI-compatible chat completions support. |
-| ChatGPT (Codex) | `/backend-api/codex/responses` | OAuth device flow | `gpt-5.4`, `gpt-5.4-mini` | Uses Codex-specific backend API format. |
-| Anthropic | `/v1/messages` | `x-api-key` header | `claude-sonnet-4-6`, `claude-haiku-4-5` | Native Anthropic messages API support. |
-| Mistral AI | `/v1/chat/completions` | Bearer token | `mistral-large-latest`, `mistral-small-latest`, `mistral-vibe-cli-latest` | Direct HTTP provider profile; `mistral-plan` uses Vibe-compatible defaults without launching Vibe. |
-| Ollama | `/v1/chat/completions` | None | `llama3.2`, any local model | Local provider with no built-in auth requirement. |
-| Groq | `/openai/v1` | Bearer token | `llama-3.3-70b-versatile` | OpenAI-compatible API variant. |
+| Surface | Contract |
+| --- | --- |
+| core CLI commands | deprecate before removal |
+| named `/v1` routes | additive within a major; breaking changes use a new prefix |
+| config descriptors | unknown keys rejected; documented migrations for removed keys |
+| event-bus wire | frozen vectors and version negotiation |
+| workflow definitions | canonical version hash and immutable run snapshot |
+| proposals and validation reports | historical records, not compatibility promises |
 
-Provider-CLI delegates can also route through installed CLIs. `aimee agent setup
-codex-cli` creates the legacy Codex CLI route. `aimee agent setup mistral-cli`
-and `mistral-plan` create provider-CLI-compatible entries that
-bridge to native HTTP adapters instead of launching provider binaries.
+## Known limits
 
-## MCP Protocol
-
-The MCP server (`aimee mcp-serve`) exposes aimee knowledge and actions to primary agents that support MCP. It is built into the `aimee` binary.
-
-| MCP capability | Version or scope | Status | Details |
-|---|---|---|---|
-| JSON-RPC 2.0 | `2024-11-05` | Implemented | Core RPC protocol support. |
-| `stdio` transport | Standard input/output | Implemented | Primary supported transport. |
-| `tools/list` | Tool discovery | Implemented | Exposes `search_memory`, `list_facts`, `get_host`, `list_hosts`, `find_symbol`, `delegate`, `preview_blast_radius`, `record_attempt`, `list_attempts`, and `delegate_reply`. |
-| `tools/call` | Tool invocation | Implemented | Full tool execution support. |
-| `resources/*` | MCP resources | Implemented | Resource endpoints are available. |
-| `prompts/*` | MCP prompts | Implemented | Prompt endpoints are available. |
-| HTTP SSE transport | Server-sent events | Not implemented | No HTTP transport support at this time. |
-
-## Client Registration
-
-This section covers how the aimee MCP server is registered with supported clients.
-
-`install.sh` and `configure-hooks.sh` automatically detect installed clients and register
-`aimee mcp-serve` for each one found. Running the installer is idempotent: if a client is
-already configured, the registration is refreshed and reported as such rather than duplicated.
-In the recommended Docker deployment (services in containers, thin client per machine),
-each developer runs `configure-hooks.sh` directly to register hooks + MCP locally; the
-hooks call the thin client, which reaches the configured `aimee-server`.
-
-| Client | Detection method | Hook config path | MCP config path | Registration status |
-|---|---|---|---|---|
-| Claude Code | `~/.claude/` directory or `claude` in PATH | `~/.claude/settings.json` | `~/.claude/settings.json` | Implemented |
-| Codex CLI | `~/.codex/` directory or `codex` in PATH | `~/.codex/hooks.json` | `~/.codex/mcp-config.json` | Implemented |
-| GitHub Copilot | `~/.copilot/` directory or `copilot` in PATH | `~/.copilot/config.json` | `~/.copilot/mcp-config.json` | Implemented |
-| Claude Desktop | Config directory exists at OS-specific path | N/A (MCP only) | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `~/.config/Claude/claude_desktop_config.json` (Linux) | Implemented |
-| VS Code | `code` in PATH or user config dir (`~/.config/Code/User/`, macOS `~/Library/Application Support/Code/User/`); Insiders and VSCodium variants detected | N/A (no hooks) | User-level `mcp.json` (uses the `servers` key, not `mcpServers`) | Implemented (MCP); also an ACP agent (`aimee acp-serve`) and an OpenAI-compatible model, see [VSCODE.md](VSCODE.md) |
-
-### Hook events registered per client
-
-| Client | Session start | Pre-tool | Post-tool | Matched tools |
-|---|---|---|---|---|
-| Claude Code | `SessionStart` | `PreToolUse` | `PostToolUse` | Pre: `Edit\|Write\|MultiEdit\|Bash\|Read\|Glob\|Grep`; Post: `Edit\|Write\|MultiEdit` |
-| Codex CLI | `SessionStart` | `PreToolUse` | `PostToolUse` | Pre: `Bash`; Post: `Bash` |
-| GitHub Copilot | `SessionStart` | `PreToolUse` | `PostToolUse` | Pre: `Bash\|Edit\|Write`; Post: `Edit\|Write` |
-| Claude Desktop | n/a | n/a | n/a | MCP only; no hook events |
-| VS Code | n/a | n/a | n/a | MCP / ACP / OpenAI-compatible model; no hook events |
-
-### Installer output
-
-The installer reports per-client registration outcomes:
-
-- **Configured:** client was detected and aimee was newly registered.
-- **Refreshed (already configured):** client was detected and registration already existed; config was updated.
-- **Not detected:** no config directory and no binary found for the client; skipped silently.
-
-Re-running `install.sh` or `configure-hooks.sh` is safe at any time and will not create duplicate entries.
-When `install.sh` runs without an interactive TTY (for example in CI), it keeps the
-current provider or default selections and skips optional prompts that would otherwise block.
-
-## Command Tier Stability
-
-Commands are grouped into three tiers with different stability expectations:
-
-| Tier | Examples | Shown in | Stability |
-|---|---|---|---|
-| Core | `memory`, `wm`, `rules`, `index`, `delegate` | `aimee --help` | Stable. Breaking changes require a deprecation cycle. |
-| Advanced | `status`, `hud` | `aimee help --all` | Stable. Flags and subcommand names may evolve with notice. |
-| Admin | `git verify`, `clean` | `aimee help --all` | Best-effort. Use in scripts at your own risk. |
-
-**Visibility rules:**
-- `aimee --help` (or `aimee` with no arguments followed by `--help`) shows only Core commands.
-- `aimee --advanced` or `aimee help --all` shows Core, Advanced, and Admin commands grouped by tier.
-- A command appears in client help only after it has either a local client implementation or a typed `aimee-server` RPC route.
-
-**Adding new commands:** New top-level commands should first add a typed server route (or a strictly local client implementation), then opt into the help table at the appropriate tier.  This prevents the DB-free client surface from advertising server-internal or unported commands.
-
-## Known Limitations
-
-| Area | Limitation | Impact |
-|---|---|---|
-| Native Windows | Build coverage exists, but support is still incomplete. | WSL2 remains the recommended Windows runtime until more POSIX-only runtime paths are ported. |
-| macOS packaging | Homebrew-managed dependencies are required. | Manual dependency setup is needed outside Debian-like environments. |
-| Server SQLite builds | FTS5 must be present. | Local text indexes are unavailable without FTS5. |
-| Claude Desktop hooks | Claude Desktop is MCP-only. | Hook-based session events are not available for Claude Desktop. |
-| MCP transport | HTTP SSE transport is not implemented. | MCP support is limited to available implemented transports, primarily `stdio`. |
+- The event-bus v0 host uses Linux `memfd` and `SCM_RIGHTS`.
+- Observational capture does not provide deterministic module execution replay.
+- Native Windows does not host the full server stack.
+- Automatic mTLS CSR enrollment is Linux-only today.
+- Claude Desktop is MCP-only and has no coding-tool hooks.
+- A local provider's claimed OpenAI compatibility may omit tools, usage, or streaming details.
+- External PostgreSQL, KMS, PKCS#11, and witness deployments remain operator-owned integrations.

--- a/docs/CURATOR_PIPELINE.md
+++ b/docs/CURATOR_PIPELINE.md
@@ -1,119 +1,55 @@
 # Curator pipeline
 
-The **curator pipeline** turns ingested content (docs, code) into curated,
-retrievable knowledge — searchable claims, resolved entities, contradiction links,
-a projection graph — in the background, after the fast 0.6B embedder has made the
-raw corpus searchable. It runs entirely inside `aimee-kb` on a drain thread; there
-is no separate scheduler.
+The curator turns committed source into reviewed, linked knowledge in the background. It runs inside
+`aimee-kb`; DB2 is the queue and source of truth.
 
-Since the modular-pipeline refactor it is a **data-driven stage registry**, not a
-hardcoded chain. Each stage is one entry in an ordered list; the drain flows work
-through the enabled stages. This is what makes the pipeline composable (different
-applications enable different stages) and lane-separated (CPU work runs concurrently
-with GPU work).
+## Lanes
 
-## The stage registry
+| Lane | Work |
+| --- | --- |
+| model | document/code extraction, entity resolution, synthesis, entity promotion |
+| index | narrative/claim/code embedding, contradiction detection, artifact linking, document and evidence indexing |
 
-Defined in `src/modules/kb-synthesis/kb_curator_pipeline.h` and populated in `src/modules/kb-synthesis/kb_curator_drain.c`
-(`CURATOR_STAGES[]`). Each stage is:
+The lanes run independently. Index work can drain while a model call is in flight. Workers claim
+rows with database locking and a bounded batch, then back off when idle or on error.
 
-```c
-typedef struct {
-   const char *name;   /* stable id / config + GUI key, e.g. "index_claims" */
-   const char *label;  /* human status label */
-   int (*enabled)(const config_t *cfg);            /* NULL => always on */
-   int (*run)(const kb_curator_extract_opts_t *);  /* one unit: 1=did work, 0=idle, <0=error */
-   int budget;                                     /* max units per pass (<=0 => 1) */
-   kb_curator_lane_t lane;                         /* LLM (GPU) or INDEX (CPU) */
-} kb_curator_stage_desc_t;
+## Stage contract
+
+Each stage has a stable name, enable predicate, lane, batch budget, and one-unit worker. A unit
+returns work done, idle, or error. An error stops that pass and leaves durable work for retry.
+
+The ordered registry owns scheduling. Adding a stage should not add another private drain loop.
+
+## Normal flow
+
+```text
+source commit
+  -> chunk and lexical index
+  -> extract claims/entities/code units
+  -> resolve canonical entities
+  -> embed artifacts
+  -> detect duplicates and contradictions
+  -> link evidence and code
+  -> synthesize or promote reviewed knowledge
 ```
 
-`kb_curator_pipeline_run_pass(stages, n, lane_filter, cfg, opts, set_status)` walks
-the registry: for each enabled stage whose lane matches the filter, it runs the
-stage up to `budget` times (or until the stage's queue empties), in order, stopping
-at the first stage that returns an error. It returns `1` if any stage did work
-(caller loops), `0` if all idle (caller sleeps), `-1` on a stage error (caller backs
-off). It is dependency-free and unit-tested with mock stages
-(`test_curator_pipeline_sched`).
+For a contradiction, both claims remain. The pipeline links them, preserves their sources, and lets
+review/policy decide the current value. It does not overwrite the older claim silently.
 
-## Resource lanes
+## Configuration
 
-Stages bottleneck on different hardware, so they run on **two worker threads** with
-independent cadences (`kb_curator_drain_init` spawns both):
+Curator stages and worker counts are descriptor-backed settings. Use
+[generated configuration](gen/configuration.md). Disabling a stage stops new work for that stage; it
+does not delete its existing artifacts.
 
-| Lane | Hardware | Cadence | Stages |
-|------|----------|---------|--------|
-| **`KB_CURATOR_LANE_LLM`** | GPU / LLM | one unit per pass (each is a multi-second model call) | extract_docs, extract_code, resolve_entities, synthesize, promote_entity |
-| **`KB_CURATOR_LANE_INDEX`** | CPU (0.6B embedder / SQL) | drains its queue each pass, loops hot | index_narrative, index_claims, detect_contradictions, index_code_unit, link_artifacts, embed_code, ingest_docs, embed_evidence |
+## Add a stage
 
-The **main drain thread** runs the LLM lane (`run_pass(..., KB_CURATOR_LANE_LLM, ...)`)
-plus a few global bookkeeping sweeps (cross-repo cold-start, decision-revisit,
-typed-facts, projection-graph). The **index-lane thread**
-(`kb_curator_index_lane_main`) runs the INDEX lane and backs off `INDEX_LANE_POLL_SECS`
-when idle. Because they are separate threads, CPU indexing proceeds **while the GPU
-is mid-extraction** — a document's claims get embedded and contradiction-checked
-while the next document is still being extracted, using CPU that would otherwise
-idle during each LLM call.
+1. Define the input queue/state and idempotent unit of work.
+2. Add the stage descriptor with lane and bounded budget.
+3. Return explicit idle/error status.
+4. Preserve source and scope on every derived artifact.
+5. Add retry, concurrent claim, malformed output, and shutdown tests.
+6. Expose honest health and backlog metrics.
 
-The lanes touch mostly disjoint data; where they meet (the `artifacts` table) it is
-producer/consumer — the LLM lane INSERTs proposed artifacts, the INDEX lane
-SELECTs + UPDATEs them — which is safe under Postgres MVCC and the existing
-`FOR UPDATE SKIP LOCKED` claim.
-
-## The stages
-
-In registry order (the pass order). Each has a `kb_curator_<name>_enabled` config
-flag (default on) — see below.
-
-**LLM lane (GPU):**
-- **extract_docs** — LLM-extract a document chunk into claims / entities / doc_summary artifacts (`{status:"ok", artifacts:[{kind,payload}]}`, enforced by a json-schema so the reasoning model returns fence-free JSON).
-- **extract_code** — extract a code symbol into a code_unit artifact.
-- **resolve_entities** — resolve entity-mention artifacts against the canonical entity graph.
-- **synthesize** — synthesize a topic summary from committed artifacts.
-- **promote_entity** — promote a recurrent entity to the canonical registry.
-
-**INDEX lane (CPU):**
-- **index_narrative** — embed doc_summary / narrative text.
-- **index_claims** — embed each `claim` artifact's `subject/attribute/value` into `curator_claim_vectors`.
-- **detect_contradictions** — self-join `curator_claim_vectors`: same `subject`+`attribute`, different `value` → write a `contradicts` artifact_link.
-- **index_code_unit** — embed code_unit artifacts.
-- **link_artifacts** — link related artifacts (implements / relates-to).
-- **embed_code** — embed changed files into `code_embeddings` (the code-vector layer).
-- **ingest_docs** — chunk + embed prose/doc files into `kb_documents` (the in-ingest replacement for `kb build`); self-heals missing embeddings and reconciles the dim-change re-embed marker.
-- **embed_evidence** — fill `evidence_vectors` for the neighbourhood builder.
-
-## Enabling / reordering stages
-
-Every stage's `enabled` predicate reads a config flag
-(`kb.curator.<stage>.enabled`, all default-on via `config_kb_curator_defaults`).
-Toggling a flag turns a stage into a no-op without touching code. The registry order
-is the pass order. This is the surface a **GUI pipeline editor** drives: an
-application composes its own pipeline by toggling stages — e.g. a doc-QA app runs
-extract_docs → index_claims → detect_contradictions; a code-intel app runs
-extract_code → index_code_unit; a story-world app runs an extract_story variant.
-
-## End-to-end: how a contradiction is found
-
-1. `ingest_docs` chunks + embeds a doc into `kb_documents`.
-2. The ingest hook (or the drain backfill `kb_curator_queue_docs_all_projects`) enqueues an `extract_doc` job.
-3. `extract_docs` (LLM lane) turns the chunk into `claim` artifacts `{subject,attribute,value}` (state `proposed`).
-4. `index_claims` (INDEX lane) embeds each claim into `curator_claim_vectors`.
-5. `detect_contradictions` (INDEX lane) self-joins the vectors; two claims with the same subject+attribute but different value get a `contradicts` link.
-
-Because the INDEX lane runs concurrently, steps 4–5 proceed for one document while
-step 3 runs for the next.
-
-## Adding a stage
-
-1. Write a worker `int kb_curator_<name>_one(const kb_curator_extract_opts_t *opts)` returning `1`/`0`/`-1` (or an adapter wrapping an existing per-project drain — see `stage_embed_code` etc. in `kb_curator_drain.c`).
-2. Add an `en_<name>` predicate reading its config flag.
-3. Add one row to `CURATOR_STAGES[]` with the right lane + budget (LLM stages: budget 1; cheap INDEX stages: a larger budget so they drain their queue each pass).
-
-No drain-loop code changes are needed — the registry drives it.
-
-## Source map
-
-- `src/modules/kb-synthesis/kb_curator_pipeline.{h,c}` — stage descriptor + `run_pass`.
-- `src/modules/kb-synthesis/kb_curator_drain.c` — the registry (`CURATOR_STAGES[]`), the two lane workers, the stage adapters.
-- `src/tests/test_curator_pipeline_sched.c` — `run_pass` scheduling (lane filter / budget / error-stop).
-- `src/tests/test_curator_pipeline.c` — end-to-end curator chain over the sqlite shim.
+Model output needs a schema and negative tests. Never parse a fenced prose answer as a committed
+artifact.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,136 +1,47 @@
-# Dashboard & Logs (browser UI)
+# Browser workspace
 
-The **Dashboard** and **Logs** tabs of [`aimee-runtime-web`](../MANUAL.md#23-webchat-and-the-browser-ui)
-give an operator an at-a-glance view of what **`aimee-server`** is doing. They
-are served by the webchat thin client (default `https://<host>:8443`) which
-holds no state and proxies to `aimee-server` over its `/v1` HTTP surface.
+The browser is a client of `aimee-server`, `aimee-wfe`, and `aimee-kb`. It owns login and UI session
+state; it does not own product data.
 
-## Design principle: server-incurred metrics only
+## Pages
 
-The dashboard shows **things aimee-server incurs**: its delegations, tool
-calls, token spend, guardrail verdicts, configured agents, active sessions, and
-readiness. It deliberately does **not** monitor `aimee-kb`-internal events
-(memory-curation audits, KB decision logs). **`aimee-kb` has its own dashboard**
-for those; duplicating them here would blur the boundary between the two
-services. The one exception is a state overview the server relies on, the
-**Memory** panel (tier counts), which is available but off by default.
+- **Chat:** server-owned conversations and tools.
+- **Dashboard:** server-incurred agent, token, cost, latency, cache, guardrail, and readiness metrics.
+- **Projects:** git accounts, clones, workspaces, and per-page project selection.
+- **Agents / Roundtables:** roster, probes, role coverage, presets, and seats.
+- **Edit Workflows:** visual definition editor.
+- **Workflow Actions:** start and operate durable runs.
+- **Graph:** code and relationship exploration.
+- **Logs:** action/audit views for the selected service.
+- **Settings:** allowlisted typed configuration.
+- **Editor:** per-user VS Code through the authenticated proxy.
 
-A field is "server-incurred" if the server's own agents/workflows produce it,
-even when the record is physically stored behind the KB (e.g. delegate token
-spend). It is *not* server-incurred if the KB curator produces it.
+Each page keeps its own project selection. Selecting a project does not grant authority; every server
+route checks the current principal and scope.
 
-## Tabs
+## Dashboard metrics
 
-### Dashboard (`/dashboard`)
+Panels are based on work the server incurred: delegations, role/agent success, tokens, cost,
+latency, cache efficiency, provider mix, tool activity, guardrail actions, sessions, and readiness.
+Users can hide and reorder panels; layout is browser preference, not server state.
 
-A customizable grid of metric panels. The default set fills the viewport in a
-clean 3-column layout; you add more from a catalog via **⚙ Customize**.
+The Logs page is separate because audit rows and operational logs have different retention and
+access rules. The KB has its own internal administration surface.
 
-### Logs (`/logs`)
+## Settings
 
-The server's **tool-action audit ledger**: one row per tool call the agent
-makes, with the guardrail **verdict** (`allow` / `block` / `rewrite` /
-`approval_required`), the actor (`primary` / `delegate`), the tool, mode, and
-reason. Filter by verdict, actor, or tool name. This is `aimee-server`'s own
-audit stream (`/var/lib/aimee/audit.log` via `audit_ledger_read`), **not** the
-KB's logs.
+The Settings page edits the same field descriptors as `aimee config`. It cannot expose secrets or a
+raw YAML editor. See [Settings](SETTINGS.md).
 
-## Panels
+## Managed deploy
 
-Every panel is derived from data the server incurs. Panels marked *default* are
-shown by default; the rest are opt-in via **⚙ Customize**.
+The setup wizard can start KB and inference containers when the server has the Docker socket. That
+is Docker-host authority. Use the split stack when the browser must not control deployment.
 
-| Panel | Default | Source |
-|-------|:------:|--------|
-| Readiness | ✓ | Synthesized health report (`onboard`): DB/agents/delegations/LSP |
-| Agents | ✓ | Configured provider roster (`agents`) |
-| Active Sessions | ✓ | Live webchat sessions (injected by webchat) |
-| Delegations | ✓ | Recent delegations (`delegations`) with human-formatted latency |
-| Metrics | ✓ | Per-role totals/success/latency/tokens (`metrics`) |
-| Cost / Tokens | ✓ | Realized token spend rolled up per role (`token_audit`) |
-| Guardrail Actions | ✓ | Verdict mix over the tool-action audit (`audit`) |
-| Execution Plans | ✓ | Active execution plans (`plans`) |
-| Traces | ✓ | Recent tool-call traces (`traces`) |
-| Success by Agent | — | Success rate + volume per agent (from `delegations`) |
-| Latency by Role | — | p50 / p95 / max per role (from `delegations`) |
-| Top Tools | — | Most-invoked tools (from `traces`) |
-| Tokens by Agent | — | Token spend per agent (from `token_audit`) |
-| Cache Efficiency | — | Cache-read share of input tokens (from `token_audit`) |
-| Failures | — | Recent unsuccessful delegations (from `delegations`) |
-| Provider Mix | — | Configured agents grouped by provider (from `agents`) |
-| Confidence | — | Average delegate confidence per role (from `delegations`) |
-| Memory | — | Memory tier/kind counts (`memory_stats.tier_kinds`), a KB state overview |
-| LSP Health | — | LSP diagnostics summary (`lsp`) |
+## Security
 
-Latency is rendered human-readably (`482ms`, `4.7s`, `2m 7s`), not raw
-milliseconds; token counts are compact (`4.4M`); cost is USD with a sub-cent
-floor (`<$0.01`).
+Browser requests need login, secure cookies, CSRF checks for mutation, and principal propagation.
+The proxy uses deny-by-default route families. Credentials stay in the server vault.
 
-## Customization
-
-Click **⚙ Customize** (top-right of the Dashboard) to toggle any panel on/off
-and reorder the enabled ones (↑/↓). **Reset** restores the defaults.
-
-The layout is persisted in the browser's `localStorage` under
-`aimee_dash_layout_v1` (an ordered list of panel ids). It is therefore
-**per-browser**, not per-user across devices; a server-persisted layout would be
-a future enhancement.
-
-## Layout & sizing
-
-The dashboard fills its pane **exactly** (`box-sizing: border-box`; no
-negative-margin hacks). The grid is `repeat(3, minmax(0, 1fr))` columns with
-`minmax(200px, 1fr)` rows, so:
-
-- it **never** scrolls horizontally;
-- with the default panel count it fits the viewport with no scrollbar;
-- if you add enough panels to exceed the viewport, only the grid scrolls
-  vertically.
-
-## Data architecture
-
-```
-browser ──/api/dashboard──> aimee-runtime-web ──dashboard.all──> aimee-server
-        <────── JSON ───────              <──── payload ─────
-browser ──/api/audit───────> aimee-runtime-web ──dashboard.audit─> aimee-server
-```
-
-### `dashboard.all` (the `/api/dashboard` payload)
-
-Built by `handle_dashboard_all` (`src/server/server_state.c`). Server-incurred
-fields: `delegations`, `metrics`, `traces`, `plans`, `agents`, `token_audit`,
-`decisions`, `memory_stats`, `lsp`, plus a synthesized `onboard` readiness
-report and a recent `audit` summary (last 300 tool-action rows). The webchat's
-`handleDashboardAll` then injects `sessions` (webchat-owned) before returning.
-
-### `dashboard.audit` (the `/api/audit` payload, Logs page)
-
-Backed by the `dashboard.audit` dispatch method → `/v1/dashboard/audit` route →
-`audit_ledger_read`, returning up to 5000 most-recent tool-action rows.
-
-### Frontend normalization contract
-
-The server returns some fields in shapes a panel cannot consume directly
-(`memory_stats` is an object whose rows live under `tier_kinds`; `onboard` may
-be an `{error}` stub; `agents` is the config roster). `toDashData` in
-`frontend/src/pages/Dashboard.tsx` normalizes the raw payload into the panel
-shapes. That contract is unit-tested against a **captured live payload** in
-`frontend/src/pages/Dashboard.test.ts` (run `npm test` in `frontend/`), so a
-server shape change that would blank a panel fails a test instead.
-
-## Adding a panel (developer note)
-
-Panels are a registry in `Dashboard.tsx`. To add one:
-
-1. Write a `function MyPanel({ data }: { data: T[] }) { … }` deriving its view
-   from an existing `DashData` field (prefer deriving over adding server
-   fields).
-2. Add an entry to the `PANELS` array: `{ id, title, defaultOn, render }`.
-3. If it needs a new server-incurred field, add it to `dashboard.all`
-   (`handle_dashboard_all`), thread it through `RawDashboard` + `DashData` +
-   `toDashData`, and extend the fixture/tests.
-
-Adding a new `/v1` route (as `dashboard.audit` did) also requires:
-`scripts/gen-cli-v1-routes.py` (regenerates `src/cli_v1_routes_d.c`) and an
-entry in `api/openapi-server-v1.yaml`; verify with
-`scripts/check-cli-v1-routes.py` and `scripts/check-api-conformance-server.py`.
+See [Web git security](WEBCHAT_GIT_SECURITY.md), [Workflow Actions](WORKFLOW_ACTIONS.md), and
+[VS Code](VSCODE.md).

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -1,739 +1,212 @@
-# Delegate Agents
+# Delegates
 
-> **Delegates ship configured.** A default roster (local + subscription-backed
-> tier-0 agents) and the roundtable panel ship enabled, so
-> `aimee delegate …` and `aimee delegate roundtable …` work on a fresh install
-> with nothing to set up. This page is for adding your own providers, changing
-> the panel, or understanding the routing.
-
-## Quick Start
-
-Delegation already works on a fresh install (see the note above), `aimee
-delegate …` routes to the shipped roster. Use these commands only to **add your
-own** local provider on top of the defaults:
+A delegate is a bounded agent selected for one role. It runs through aimee's admission, credential,
+workspace, tool, budget, and audit paths.
 
 ```bash
-# 1) Add a local delegate provider (optional, defaults already work)
-aimee agent local local http://localhost:8080 --model MODEL --slots 4 --ctx 131072
-
-# 2) Inspect the registered delegates and their routing data
-aimee --json agent list
-
-# Optional auto-detect helper for local Ollama/llama.cpp
-./add-local-delegate.sh
-
-# 3) Use aimee normally; the primary agent routes delegateable work automatically.
-# See the Usage section below for realistic delegation scenarios.
+aimee delegate review --persona reviewer "Review the current diff"
+aimee delegate diagnose --persona engineer "Find the cause of this failure"
+aimee delegate code --persona engineer "Implement the accepted fix"
 ```
 
-`aimee` supports two kinds of agent:
+## Roles and personas
 
-- **Primary agent**: the AI coding surface you interact with directly, such as Claude Code, Gemini CLI, direct Codex, direct Mistral, or Codex CLI legacy mode
-- **Delegate agents**: sub-agents used for offloaded work
+The role says what the delegate may do. The persona says how it should approach the work.
 
-The primary agent does not need delegate configuration. It integrates with `aimee` through hooks, provider adapters, remaining provider CLI routes, or direct primary-session adapters that inject memory, enforce guardrails, and manage session isolation. Delegate agents are optional and are configured separately.
+Common roles:
 
-## Primary Agent Constraint
+| Role | Normal use | Tools |
+| --- | --- | --- |
+| `review` | code, plan, security, or documentation review | read-only |
+| `diagnose` | trace a failure and identify the cause | read and verify |
+| `explain` | summarize code or a decision | read-only |
+| `search` | repository or knowledge research | read-only |
+| `draft` | prose, proposal, or structured artifact | limited write when requested |
+| `code` | implementation | read, write, verify |
+| `refactor` | bounded structural change | read, write, verify |
+| `validate` | tests and acceptance checks | read and execute |
+| `execute` | operator-defined task | explicit toolset |
 
-Provider-native sub-agent tools are not Aimee delegation. Primary agents must
-not use Codex `spawn_agent`, Claude `Agent`/`Task`, or similar remote-agent
-launchers for delegated or parallel work. Use the Aimee MCP `delegate` tool or
-`aimee delegate <role> "<task>"` instead.
+Aliases such as `implement` → `code` and `test` → `validate` are normalized by the CLI. Use the
+installed help for the exact list.
 
-The guard is always on: when a client surfaces a sub-agent tool through hooks
-(including Claude Code's `Task`), Aimee blocks the call and points the agent at
-`aimee delegate <role> --persona <persona>` or
-`aimee delegate roundtable "<task>" --mode review`. Routing through Aimee
-delegates keeps the work inside Aimee's session state, worktree isolation,
-depth/spawn limits, routing, and audit trail.
-
-## How It Works
-
-Delegation exists so the primary agent can spend its attention on work that actually requires its strongest reasoning. Lower-cost or local delegate agents can handle routine work such as summarization, formatting, boilerplate generation, simple code review, and file transformations.
-
-This reduces cost and keeps the primary agent focused on complex tasks.
-
-Delegation saves primary-agent tokens in several ways:
-
-- **Direct offloading**: when the primary agent delegates a summarization task, the full prompt and completion cost moves to the delegate. If that delegate is tier-0, the marginal cost is effectively zero.
-- **Smaller context budget**: delegate agents receive a 16KB context budget, compared with 32KB for the primary agent, so each delegated call carries less background context.
-- **Parallel execution**: multiple delegated tasks can run at the same time. The primary agent receives compact results instead of individually processing each input.
-- **Automatic cheapest-model routing**: the router selects the cheapest enabled delegate that can satisfy the requested role.
-
-For broader token-saving mechanisms beyond delegation, including memory injection, code index usage, project descriptions, and anti-pattern detection, see the [root README](../README.md#what-aimee-does).
-
-### Routing flow
-
-```mermaid
-flowchart LR
-    A[Primary agent request] --> B[Delegate router]
-    B --> C{Enabled delegates for role}
-    C --> D[Pick cheapest matching delegate]
-    D --> E[Run delegated task]
-    C -->|None available or invocation fails| F[Fallback path]
-    F --> G[Primary agent handles task or uses alternate delegate]
-```
-
-### Primary agent delegation flow
-
-```mermaid
-flowchart TD
-    A[Primary agent receives task] --> B{Is this work delegateable?}
-    B -->|No| C[Primary agent performs work directly]
-    B -->|Yes| D[Select role for subtask]
-    D --> E[Router chooses cheapest enabled delegate]
-    E --> F[Delegate executes subtask]
-    F --> G[Return compact result]
-    G --> H[Primary agent integrates result into main task]
-```
-
-## Setup
-
-### Configuration
-
-> **Credential storage:** API keys and Codex/OAuth tokens are sealed in the
-> server's **vault** (encrypted at rest), not held on clients. `aimee agent add
-> <name> <endpoint> <model> --key K` seals `K` into the vault and refuses
-> plaintext storage; the server's `agents.json` keeps the definition only. Codex
-> tokens are vaulted via `aimee agent setup codex-oauth`. Configure agents once
-> on the server, the vault is shared across clients. Migrate any leftover
-> client-held `~/.config/aimee/agent-keys.json` with `aimee agent key import`
-> (scrubs the plaintext copy by default; `--keep` to retain). See [THIN_CLIENT.md](THIN_CLIENT.md) and
-> [SECURITY.md](SECURITY.md#agent-credential-custody-thin-client).
-
-Use `aimee agent local` for local or LAN OpenAI-compatible runtimes such as
-`llama-server` and Ollama. The command is idempotent: re-running it updates the
-same delegate, probes `/v1/models`, probes llama.cpp `/slots` when available,
-and writes both the delegate entry and the per-model concurrency limit.
-
-```bash
-# llama.cpp or another OpenAI-compatible endpoint
-aimee agent local gemma http://192.168.1.103:8080 \
-  --model gemma-4-26B-A4B-it-UD-Q5_K_XL.gguf \
-  --slots 4 \
-  --ctx 131072 \
-  --default
-
-# Auto-detect local runtime, recommend a model, then call aimee agent local
-./add-local-delegate.sh
-
-# Verify endpoint, model availability, slots, and a short completion
-aimee agent probe gemma
-```
-
-> **Registering the deployment's own `aimee-kb-*` synth:** use the gateway port and the
-> `aimee-synth` alias, not a raw GGUF filename:
-> `aimee agent local local-synth http://<gw>:8742/v1 --model aimee-synth --provider openai`.
-> The gateway runs auth-off on the internal bridge (`auth_type: none`). See
-> [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
-
-Each delegate entry records:
-
-- endpoint
-- authentication
-- model
-- roles
-- cost tier
-
-in `~/.config/aimee/agents.json`.
-
-`aimee agent local` also updates:
-
-```text
-~/.config/aimee/aimee.yaml
-```
-
-with `concurrency.per_model.<model> = <slots>`, so `aimee-server` can run
-multiple delegate slots without hand-editing configuration. Running servers
-refresh delegate concurrency when `agents.json` or `aimee.yaml` changes.
-
-## Roles and Tiers
-
-Every delegate agent is assigned one or more **roles** describing the kinds of tasks it can handle.
-
-| Role | Description | Example use |
-|------|-------------|-------------|
-| `code` | Write or edit code | Implementation tasks |
-| `review` | Analyze code or plans | Code review, anti-pattern extraction |
-| `explain` | Explain concepts | Documentation, teaching |
-| `refactor` | Restructure code | Cleanup, optimization |
-| `draft` | Generate content | Test plans, commit messages |
-| `execute` | Run agentic tasks | Multi-turn tool-use loops |
-| `summarize` | Compress text | Session fold, window compaction |
-| `format` | Reformat data | Context assembly when budget is tight |
-| `search` | Find information | Documentation lookup |
-| `reason` | Complex reasoning | Higher-difficulty analysis |
-
-Delegates are also assigned a **cost tier**. Routing prefers the lowest-cost enabled delegate that matches the requested role.
-
-| Tier | Meaning | Typical examples |
-|------|---------|------------------|
-| `0` | Free or subscription-backed | Local Ollama, Codex OAuth, Gemini OAuth, `mistral-plan`, MiniMax |
-| `1` | Low-cost API | Cheap hosted models |
-| `2` | Mid-cost API | Stronger general-purpose models |
-| `3` | Expensive API | Premium reasoning-capable models |
-
-This tiering allows `aimee` to send lightweight work to inexpensive models while still allowing stronger delegates for more demanding roles. A tier is a routing pool: when multiple enabled delegates at the same tier match the role, they remain eligible independently, and retryable failures can fall through to same-tier peers even if the explicit fallback chain is stale.
-
-## Free-Delegate Economics
-
-Aimee reports coordinated delegate runs using the
-`free_delegate_expensive_supervisor` cost model. Under this model, tier-0
-delegates are abundant compute and the primary supervising agent is the scarce
-resource. A run can be token-negative overall while still being useful if it
-reduces paid supervisor attention, manual integration, or serial review time.
-
-The shared cost authority (`token_estimate_cost`) prices the self-hosted /
-open-weight delegates aimee runs locally, minimax, mistral, and mimo, at a
-**known zero**: free, but explicitly *priced* rather than *unknown*. This matters
-because the delegate-economics path flat-rates only genuinely unknown models; a
-known-zero price keeps these local delegates out of that fallback, so their
-realized cost is reported as the $0 it actually is. A deployment that pays per
-token for a hosted variant still overrides the zero with a real model-registry /
-models.dev price.
-
-The report is intentionally approximate. It separates estimated delegate tokens
-from estimated supervisor prompt tokens, records tier distribution, structured
-handoff validity, focused tests, manual integration markers, reviewer blocking
-findings, and a plain-language verdict:
-
-```text
-Delegation report
-  Cost model: free delegates, expensive supervisor
-  Delegates: 5 total, 4 tier-0, 1 tier-1, 0 tier-2, 0 tier-3
-  Delegate tokens estimated: 145000
-  Supervisor prompt tokens estimated: 18000
-  Focused tests run by delegates: 4/5
-  Structured handoffs valid: 4/5 (invalid 1)
-  Manual integration events: 3
-  Verdict: likely net supervisor-token win
-```
-
-Tier-0-heavy runs may recommend broader delegation and redundant validation
-when task risk warrants it. Mixed or expensive-only runs are reported more
-conservatively so costly delegates are not used speculatively.
+Personas are named instruction sets such as engineer, reviewer, security, architect, or QA. They
+also staff roundtable seats and workflow nodes. A persona does not add capabilities the role lacks.
 
 ## Routing
 
-The router's job is to reach **the cheapest delegate that can actually do the work**. A model that costs less but cannot do the task is never a saving. Selection proceeds in this order:
+For an unpinned request, the router:
 
-1. **Role match**: the delegate must support the requested role.
-2. **Enabled state**: only enabled delegates are considered.
-3. **Capability gate**: a delegate that cannot meet the task's requirements — context window, required modalities (vision, tools), or a declared scope ceiling — is excluded *before* cost is looked at. Capability comes before price.
-4. **Health**: a delegate the health catalog has marked DOWN is excluded; a DEGRADED one is deprioritized (see [Health-based demotion](#health-based-demotion) below).
-5. **Cost tier**: among the delegates that survive the gate, the cheapest is selected.
+1. finds enabled agents serving the role;
+2. removes agents that are down, saturated, over budget, or incompatible with the required tools;
+3. prefers the configured route;
+4. dispatches and records the attempt;
+5. retries another viable agent when the failure is retryable.
 
-In practice, tasks such as `summarize`, `format`, and `draft` usually route to tier-0 delegates first, so the primary agent often pays only for issuing the delegation request and reading the result.
+The old fixed fallback chain is not authoritative. Routing follows current viability.
 
-If no suitable delegate is available, or if the delegate invocation fails, the system falls back rather than blocking the main task.
+A pinned agent or model is different: it either runs that exact target or fails. This keeps a
+roundtable seat, benchmark, or controlled workflow from changing identity silently.
 
-### Scope ceilings — `max_scope` and `--scope`
+Global and per-workflow admission limits apply before provider work starts. A stuck delegate cannot
+hold a slot forever; heartbeat and reap recover abandoned admission.
 
-Some delegates can handle a bounded, well-specified change but not a whole open-ended task. Declare that limit per agent with `max_scope` in `agents.json`:
-
-```json
-{ "name": "local-coder", "max_scope": "bounded", ... }
-```
-
-- `bounded` — the agent may only be given work already scoped to a specific change.
-- `whole_task` — the agent may take an open-ended task (the default when unset).
-
-A caller states the scope of a specific packet with `--scope`:
+## Configure agents
 
 ```bash
-aimee delegate code "fix the null check in auth.c:42" --persona engineer --scope bounded
+aimee agent list
+aimee agent add --help
+aimee agent local --help
+aimee agent probe <name>
+aimee agent enable <name>
+aimee agent disable <name>
+aimee agent remove <name>
 ```
 
-Routing **never relaxes** a scope ceiling: a `--scope whole_task` packet is refused for a `bounded`-only agent even if it is the cheapest, and a run that no eligible seat can serve fails cleanly rather than misplacing the work. `--scope` is enforced server-side, so it applies whether the delegate runs locally or against a remote `aimee-server`. Omit it and the packet is unconstrained.
+`agent local` registers an OpenAI-compatible endpoint such as Ollama or llama.cpp. `agent add`
+handles API providers, OAuth-backed adapters, local CLI agents, SSH, and configured container
+backends. Probe checks the endpoint, model, execution slots, and a short completion.
 
-### Preferring free local delegates — `routing.prefer_local`
-
-With `routing.prefer_local` enabled, routing shifts work to any eligible **local** (free) delegate before considering paid remote seats, even when a remote seat is at a cheaper tier — since a local seat costs nothing, the tier comparison no longer applies. It still respects the capability gate and the scope ceiling, so "prefer free" never becomes "misplace work onto a model that cannot do it".
+Provider and model inspection:
 
 ```bash
-aimee config set routing.prefer_local true
+aimee provider list --available
+aimee provider show <name>
+aimee provider test <name>
+aimee model show <model>
 ```
 
-### Health-based demotion
+Keep agent routing data in `agents.json`. Keep secrets in the vault.
 
-A delegate that keeps failing is demoted so it stops absorbing work it cannot complete:
+## Credentials
 
-- After a short streak of consecutive failures its health becomes **DEGRADED**. A degraded delegate is still usable, so routing **prefers a healthy peer** when one can serve the role and only falls back to the degraded seat when none can.
-- After enough consecutive failures the circuit breaker opens and health becomes **DOWN**: the delegate is excluded from routing entirely.
-- The breaker half-opens after a cooldown so a recovered delegate returns automatically, without a restart. The cooldown **grows** each time a recovery probe fails again (60s, doubling to a 30-minute cap), so a delegate that is down for hours — an exhausted quota, say — stops re-entering the routable set every minute. One success resets it.
-
-This is why an out-of-quota or wedged delegate does not keep winning selection and failing: it is demoted below its healthy peers and backed off. The DOWN transition is logged with the failure class and the current cooldown, so a persistent outage is visible as a growing cooldown rather than a silent retry loop.
-
-## Usage
-
-### Planning delegate work packets
-
-Use `aimee delegate plan` to turn a proposal into reviewable work packets before
-launching any delegates:
+The server resolves API keys and OAuth tokens only after it admits the turn. Plaintext agent keys in
+client files are refused.
 
 ```bash
-aimee delegate plan docs/proposals/pending/foo.md
-aimee delegate plan docs/proposals/pending/foo.md --json
-aimee delegate launch .aimee/delegate-plans/foo.json --parallel 4
+aimee vault unlock
+aimee vault set <agent> <name> <secret>
+aimee vault list
 ```
 
-The read-only planner writes a JSON plan to `.aimee/delegate-plans/` by default.
-Each implementation packet includes owned files, read context, acceptance
-criteria, verification commands, and `handoff_schema: delegate_result_v1`. Medium
-and larger proposals also get a read-only reviewer packet with
-`handoff_schema: delegate_review_v1`. `delegate launch` reads the reviewed JSON,
-creates an execution plan, and enqueues implementation packets into a coord job
-with each packet's `owned_files` as the task conflict set.
+The workflow engine, prompt, delegate container, and result never receive vault material unless an
+explicit tool contract grants one credential. Vault reads are audited through the event bus.
 
-Durable one-off delegates are listed with `aimee jobs list`; inspect one with
-`aimee jobs status <job-id>` and print its recorded result body with
-`aimee jobs logs <job-id>`.
+Local CLI agents use a different boundary. Their installed binary and login remain on the execution
+host. For a detached remote workspace, aimee can send the command to the thin-client runner so the
+working tree and login stay on the client.
 
-Coordinated implementation packets must use `handoff_schema: delegate_result_v1`.
-Direct one-off delegates can opt into the same validation:
+Claude CLI is primary-only by default. Set `claude_cli_delegate_enabled` only after checking the
+provider's terms for unattended use.
 
-```bash
-aimee delegate code "Implement the focused change." --handoff-json
-```
+## Source authority
 
-With `--handoff-json`, the delegate is instructed to return only
-`delegate_result_v1` JSON. Aimee validates the final response, retries once with
-a repair prompt if the JSON is malformed, downgrades `status=done` to `partial`
-when no passed focused verification is reported, and marks files outside
-`owned_files` as `needs_supervisor_review`. `aimee job status` includes compact
-handoff counts for done, partial, blocked, failed, and needs-supervisor packets.
+A delegate gets one of these source views:
 
-### Source Authority
+- current read-only worktree;
+- isolated writable worktree;
+- detached workspace served by an authorized thin client;
+- explicitly configured SSH or container workspace.
 
-Delegates still use `find_symbol`, `code_search`, `aimee index`, and memory
-search as the authoritative discovery layer. Those tools locate symbols, likely
-files, prior decisions, and blast radius context.
+Write authority is not inferred from the prompt. It comes from the role, session/workflow, remote
+grant, and backend. Canonical path checks keep access inside the assigned root.
 
-Read-only delegates use the parent session worktree as their source checkout.
-This includes review, validate, diagnose, explain, summarize, and other
-inspection-only tasks. Only write-capable delegates get isolated sibling
-delegate worktrees; branch-specific delegate checkouts are therefore a
-write-delegate feature, not a read-only review mechanism.
+Write-capable delegates branch from the current accepted base. A session or workflow owns the
+worktree; unrelated delegates do not share it. Garbage collection removes abandoned worktrees after
+the configured age, never an active one.
 
-A delegate with its own worktree can also be sandboxed: with `delegate_sandbox`
-enabled it runs its file and shell tools inside a network-none container, and
-you control the image it uses per project. See
-[Delegate Sandbox](DELEGATE_SANDBOX.md).
+## Sandbox
 
-File contents use a stricter authority order. Current source wins over derived
-index snippets: source packets from `--files`, `--context-file`,
-`--context-dir`, preloaded symbol context, and `read_file` from the delegate
-worktree are authoritative when they conflict with indexed snippets.
-Index-backed delegate tools annotate results with provenance/freshness metadata
-where possible. `source_packet_current` means the hit came from source supplied
-to the delegate. `worktree_differs_from_main` means the hit's file diverges
-from the indexed main baseline, so the indexed hit is only a lead and the
-delegate should inspect current source before editing or making content claims.
-Main checkouts are force-scanned when their HEAD differs from the last
-successfully indexed HEAD, and that marker advances only after the KB scan
-succeeds.
+The container backend defaults to:
 
-`aimee job status` also includes a read-only patch coordinator brief for
-delegate-launched coord jobs. The brief reports each implementation packet's
-patch state, focused verification evidence, ownership violations, overlapping
-changed files, stale-base metadata when delegates provide it, reviewer status,
-and the recommended next command before manual integration. Reporting is
-advisory: patches are not automatically accepted into the supervisor branch.
+- no network;
+- no ambient provider or git credentials;
+- a narrow workspace mount;
+- bounded processes, memory, CPU, and time;
+- an explicit image and toolchain;
+- mediated package access.
 
-### When delegation helps
+Package requests go through a cache and policy gate. Custom images, package sets, and Dockerfiles are
+operator inputs, not something an untrusted agent gets to build with the host Docker socket.
 
-Delegation is most useful when the primary agent would otherwise spend expensive tokens on work that does not require top-tier reasoning.
+If isolation cannot be applied, execution fails unless the deployment explicitly permits a degraded
+mode. Degradation publishes an audit event.
 
-Common examples:
+See [Delegate sandbox](DELEGATE_SANDBOX.md).
 
-- summarizing long logs before the main agent decides what matters
-- reformatting generated data into a compact structure
-- drafting commit messages or test plans
-- reviewing multiple files in parallel for obvious issues
-- doing simple transformations across a large set of files
+## Tool loop
 
-### Realistic scenarios
-
-#### Scenario: summarize several large outputs before planning a fix
-
-You are investigating a failing build with multiple long log files. Instead of reading every log in full with the primary agent, delegate `summarize` work for each log, then let the primary agent compare the summaries and choose a remediation strategy.
-
-This reduces primary-agent context usage and lets summaries run in parallel.
-
-#### Scenario: use a local model to draft repetitive artifacts
-
-You need a first pass at release notes, commit messages, and a test checklist after a refactor. A tier-0 local or subscription-backed `draft` delegate can generate those artifacts cheaply, and the primary agent can review and refine only the final output.
-
-#### Scenario: parallel review of touched files
-
-A change touches ten source files. Rather than having the primary agent inspect them sequentially, delegate `review` tasks across the files to collect likely issues, suspicious patterns, or missing tests. The primary agent then synthesizes the results and decides what to fix.
-
-#### Scenario: context compaction during a long session
-
-During a long coding session, use a `summarize` delegate to fold older context into a compact working summary. The primary agent keeps the essential facts without carrying the entire previous transcript.
-
-### Practical usage notes
-
-- Prefer tier-0 delegates for routine roles like `summarize`, `format`, and `draft`.
-- Reserve higher-tier delegates for roles such as `reason` when the task genuinely benefits from stronger reasoning.
-- Assign multiple roles to a delegate only when the model is actually suitable for those tasks.
-- Keep at least one low-cost delegate enabled to maximize the benefit of automatic routing; keep multiple tier-0 delegates enabled when you want the zero-cost layer to absorb rate limits or provider-specific failures.
-
-## Roundtable and ensemble (MoA)
-
-> These are two of the three **ensemble** modes (a panel of agents). See
-> [Ensembles](ENSEMBLE.md) for the full picture, including the templated
-> turn-based session mode and how a delegate feeds a running session.
-
-Two commands run a panel of models instead of one delegate and synthesize a
-single answer. Both ship configured; the panel and aggregator are on by
-default. They are also reachable under the `ensemble` verb —
-`aimee ensemble aggregate` / `aimee ensemble roundtable`.
-
-```bash
-# Mixture-of-agents: fan out to diverse models, one aggregator synthesizes
-aimee delegate aggregate "Design a migration plan for the auth schema"
-
-# Multi-round collaborative drafting/review (review mode for a diff)
-aimee delegate roundtable "Is this migration plan sound?" --mode review
-```
-
-`aggregate` runs the reference panel in parallel and an aggregator folds their
-answers into one. `roundtable` runs multiple rounds, each round's panel sees the
-prior round, and returns the best round's artifact. Both run through the delegate
-core, so the work stays inside Aimee's session state, cost accounting, and audit
-trail (not the host AI's own sub-agent tools, which are blocked).
-
-> **Use `aimee delegate roundtable --mode review` (or the MCP `delegate.roundtable`
-> tool) for a multi-model review gate, not hand-run per-model `aimee delegate
-> review` jobs.** The roundtable panel runs each model **without file tools** and
-> gives each panelist a **distinct persona** (security, architect, QA, contrarian
-> reviewer, constructive reviewer), so weaker models review the artifact you give
-> them instead of wandering the filesystem, and tool-less models (e.g. codex) can
-> participate. `aimee delegate review --via M` is a *single, exploratory* review
-> that runs tools-on so the reviewer can read the surrounding code, the right
-> tool for "review the auth module", the wrong tool for a panel gate. The panel
-> skips agents that cannot run as a server-side HTTP delegate and any agent
-> flagged **Primary Agent Only** (`primary_only`), and falls back to another panelist if the
-> aggregator model fails, so one flaky model does not collapse the synthesis.
-
-The panel is configured under `ensemble` in `aimee.yaml`:
-
-| Field | Meaning |
-|-------|---------|
-| `reference_models` | Positive must-use model/agent pins; runtime fills all other enabled, eligible `max_parallel` seats, provider-diversity first |
-| `aggregator` | Agent that synthesizes the panel's answers |
-| `min_successful` | Minimum panelists that must answer before degrading (default 2) |
-| `max_cost_usd` | Optional per-run cost cap in USD. **Unset/0 means no limit (the default).** Set a positive value to cap a run |
-
-Cost is folded onto the originating session, so a roundtable run shows up in the
-same cost accounting as the rest of that session's work.
-
-### Partial-failure and degradation metadata
-
-Large panels can lose participants mid-run (a provider 429s, a model times out).
-Both `aggregate` and `roundtable` keep running on the survivors and report what
-happened in the result rather than silently dropping the failures:
-
-| Field | Meaning |
-|-------|---------|
-| `participants_total` | Reference models fanned out (the panel size) |
-| `participants_failed` | Participants that returned no usable response (for `roundtable`, the count from the round whose artifact was selected, the `best_round`) |
-| `participants_required_failed` *(roundtable)* | Failed participants in the adopted best round's caller-authored required prefix; always less than or equal to `participants_failed` |
-| `degraded` | The run returned the best single candidate instead of a synthesized answer (e.g. fewer than `min_successful` answered) |
-| `cost_capped` | The run stopped early because the observed cost reached `max_cost_usd` |
-| `deadline_hit` *(roundtable)* | The per-run `deadline_ms` elapsed; the best artifact so far is returned |
-
-`participants_failed > 0` with `degraded = 0` means only best-effort capacity
-seats failed while every required participant answered. Their failures remain
-observable but do not turn a complete required panel into a failed gate.
-`degraded` is run-level and sticky across roundtable rounds, so an earlier
-truncation, required-seat failure, or verification degradation cannot be hidden
-by selecting a later artifact.
-
-## Configuration Reference
-
-Delegates are stored in:
+A tool-capable turn repeats:
 
 ```text
-~/.config/aimee/agents.json
+canonical request -> model -> canonical tool call -> schema/policy check
+                  -> backend execution -> bounded canonical result -> model
 ```
 
-The configuration contains each delegate's:
+Tool calls and outcomes are audited through the event bus. Output limits come from the model
+registry. Large command output is condensed when the economizer permits it; the full output is
+spilled for recovery.
 
-- provider type
-- backend
-- endpoint
-- authentication
-- model
-- roles
-- cost tier
-- enabled state
+Retries preserve the tool contract. A retry does not remove tools just because a provider returned
+an empty or malformed response.
 
-### Provider types
+## Durable jobs
 
-The supported setup/provider names are:
-
-- `codex` / `codex-oauth` (direct Codex OAuth adapter)
-- `codex-cli` (legacy provider CLI route)
-- `gemini-cli` (native Gemini adapter behind provider-CLI-compatible config)
-- `gemini-oauth`
-- `claude` / `claude-code` (tmux session running the installed `claude` CLI)
-- `mistral` (direct Mistral HTTP adapter)
-- `mistral-cli` (native Mistral adapter behind provider-CLI-compatible config)
-- `mistral-plan` (native Mistral Vibe-compatible route)
-- `minimax` (OpenAI-compatible HTTP delegate, commonly registered with `aimee agent add`)
-- `gemini`
-- `copilot`
-- `openai`
-- local delegates registered through `./add-local-delegate.sh`
-
-### Local-CLI agents on a thin client
-
-`claude` (a `--provider claude` agent runs the **standard `claude` CLI over
-tmux**) needs the CLI executable, its login, tmux, and the working tree **on the
-same machine as execution**. On a co-located server that is the server host. On
-a **remote/containerized `aimee-server` driven by a thin client**, none of those
-live on the server, they live on your machine.
-
-So when the active workspace is `detached` (a thin client is serving it over the
-reverse channel, see workspace client-push), aimee runs the standard `claude`
-CLI over tmux **on the client**: the tmux session driver marshals its tmux
-commands (`new-session`/`paste-buffer`/`capture-pane`/…) over the runner reverse
-channel, so the session, the `claude` process, and its `~/.claude` login all live
-on your machine, against your working tree. No Claude credential is ever sent to
-or stored on the server. Co-located deployments are unchanged (the tmux session
-runs locally). (`claude -p` print mode is **not** used.)
-
-Practical notes:
-- Configure it with `--provider claude` (which sets the tmux-cli backend, the
-  endpoint argument is a placeholder and the model becomes `claude --model <m>`):
-
-  ```bash
-  aimee agent add claude claude sonnet --provider claude   # tmux-cli claude agent
-  aimee config set provider claude                          # use it as the primary
-  ```
-
-  (`aimee agent setup` is reserved for the four built-in providers, `openai`,
-  `anthropic`, `codex-oauth`, `claude-oauth`, so add a tmux-cli claude with
-  `agent add --provider claude`.) The thin-client routing is automatic when the
-  workspace is `detached`.
-- If no client is currently serving the workspace, the CLI agent cannot run
-  (there is nowhere with the binary), start the client for
-  that root, or use an HTTP provider.
-
-#### Claude via the CLI is primary-only by default
-
-Claude run via the `claude` CLI / tmux login, authenticated by the **interactive
-Claude subscription login, not an API key**, is **primary-only by default**. When
-you add a claude-oauth subscription in the Web GUI, the **Primary Agent Only**
-checkbox is pre-checked, which sets the per-agent `primary_only` flag in
-`agents.json`. A primary-only agent can be your interactive primary (via the web
-chat or `acp-serve`), but it is **not** eligible as a delegate (neither
-auto-routed nor `aimee delegate … --via claude`). Attempting to use it as a
-delegate fails with a message pointing you here.
-
-**Primary Agent Only** is a per-agent choice available to any agent (it replaced
-the former global `claude_cli_delegate_enabled` opt-in); it is simply pre-checked
-for a claude-oauth subscription and left off for every other agent, so API-key /
-HTTP agents (`minimax`, `openai`, `anthropic` with a key, `gemini-cli`,
-`mistral`, …) and other CLI agents (e.g. the Codex CLI) delegate normally.
-
-> ⚠️ **Anthropic account-risk warning.** Using a personal **Claude subscription**
-> (Pro/Max) to drive **automated / headless delegation** may violate Anthropic's
-> terms of service and can result in **suspension or termination of your
-> account**. The terms generally distinguish interactive use of a subscription
-> from programmatic/automation use, which is what delegate fan-out is. For
-> automated or delegated Claude workloads, use an **Anthropic API key** (billed
-> per token) instead, add an `anthropic` agent with `--key`.
-
-To allow a claude-oauth agent to act as a delegate anyway, at your own risk,
-**uncheck Primary Agent Only** for it in the Agents tab (or run
-`aimee agent set claude --primary-only off`). With that flag off, Claude-via-CLI
-may be routed to / selected as a delegate (and, on a thin client, runs on the
-client exactly like the primary path above). Re-check it to restore the
-primary-only default.
-
-### Provider-general registration
-
-You can register a **provider** once and let `aimee` expand it into one routable
-delegate per model, instead of writing an entry for every model by hand. Add a
-`"models"` list to a single agent entry:
-
-```json
-{
-  "name": "codex",
-  "provider": "openai",
-  "endpoint": "https://chatgpt.com/backend-api/codex",
-  "auth_type": "none",
-  "roles": ["all"],
-  "models": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
-}
-```
-
-This registration expands at load time into three routable seats —
-`codex:gpt-5.6-sol`, `codex:gpt-5.6-terra`, `codex:gpt-5.6-luna` — each carrying
-its own catalog identity, display name (e.g. *GPT-5.6 Sol*), and resolved price.
-Their cost tiers are **derived from the catalog prices**, so a registration whose
-models span cheap-to-premium splits into per-model tiers automatically rather
-than sharing one.
-
-- Use `"models": "auto"` to expand every routable model the catalog lists for the
-  provider, without naming them.
-- Do **not** set both `"model"` and `"models"` on one entry — that is ambiguous
-  and is rejected at load.
-- Anywhere a specific model is selected — roundtable seats in particular — the
-  expanded seats appear as `provider:model` (so a Codex roundtable shows Sol,
-  Terra, and Luna as distinct choices), not as a single opaque `codex`.
-
-A plain single-model entry (no `"models"`) is unchanged; provider-general
-registration is opt-in.
-
-### Config format
-
-The exact file content depends on the providers you register. `codex` and
-`mistral` use direct HTTP adapters. `codex-cli` uses the provider CLI path.
-`claude` runs the installed `claude` CLI in tmux. `gemini-cli`, `mistral-cli`,
-and `mistral-plan` keep the provider-CLI configuration shape for routing
-compatibility, but execute through native HTTP adapters without launching
-`gemini`, `mistral`, or `vibe`.
-Gemini native routes use `GEMINI_API_KEY` or `GOOGLE_API_KEY`; Mistral native
-routes use `MISTRAL_API_KEY` or `~/.vibe/.env`.
-
-A representative shape looks like this:
-
-Provider-CLI entries are delegate agents for bounded offloaded work. Some
-entries still spawn a local CLI; Gemini and Mistral entries bridge into Aimee's
-native provider loop. Routing only requires `cli_cmd` for entries that still
-spawn a CLI; native Gemini and Mistral routes are routable without a provider
-binary on `PATH`.
-
-```json
-{
-  "agents": [
-    {
-      "name": "local-summarizer",
-      "provider": "openai",
-      "endpoint": "http://localhost:11434/v1",
-      "model": "qwen2.5-coder:7b",
-      "roles": ["summarize", "draft", "format"],
-      "tier": 0,
-      "enabled": true,
-      "auth": {
-        "type": "none"
-      }
-    },
-    {
-      "name": "codex",
-      "provider": "chatgpt",
-      "endpoint": "https://chatgpt.com/backend-api/codex",
-      "model": "gpt-5.4",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute", "summarize", "format", "diagnose", "validate"],
-      "tier": 0,
-      "enabled": true,
-      "auth": {
-        "type": "codex-oauth"
-      }
-    },
-    {
-      "name": "claude",
-      "provider": "claude",
-      "backend": "tmux-cli",
-      "cli_cmd": "claude",
-      "roles": ["review", "reason", "explain"],
-      "tier": 2,
-      "enabled": true
-    },
-    {
-      "name": "gemini-cli",
-      "provider": "gemini",
-      "backend": "provider-cli",
-      "cli_kind": "gemini",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "tier": 0,
-      "enabled": true
-    },
-    {
-      "name": "mistral-cli",
-      "provider": "mistral",
-      "backend": "provider-cli",
-      "cli_kind": "mistral",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "tier": 0,
-      "enabled": true
-    },
-    {
-      "name": "mistral-plan",
-      "provider": "mistral",
-      "backend": "provider-cli",
-      "cli_kind": "mistral-plan",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "tier": 0,
-      "enabled": true
-    }
-  ]
-}
-```
-
-The important routing fields are:
-
-- `provider`
-- `backend`
-- `cli_kind`
-- `cli_cmd`
-- `endpoint`
-- `model`
-- `roles`
-- `tier`
-- `enabled`
-- `auth`
-
-If you register a local delegate through `aimee agent local` or
-`./add-local-delegate.sh`, Aimee writes this file for you. Routine lifecycle
-operations are server-routed as well:
+Long tasks have durable state and heartbeat:
 
 ```bash
-aimee agent add remote https://example.invalid/v1 model-id --auth-type bearer --key "$API_KEY"
-aimee agent disable remote
-aimee agent enable remote
-aimee agent remove remote
+aimee jobs list
+aimee jobs status <job-id>
+aimee jobs logs <job-id>
+aimee jobs cancel <job-id>
 ```
 
-## Cross-Verification
+Cancellation is cooperative, then bounded by backend cleanup. Container and process reapers clean up
+leaks even when the runtime cannot filter them by name.
 
-To verify a delegate setup, check both configuration and behavior.
+Coordinated packet plans use `delegate plan`, `delegate launch`, and `job`. Workflows are preferred
+when the job needs typed artifacts, gates, forge operations, and restart recovery.
 
-### 1. Confirm the config file exists and contains the expected delegates
+## Roundtables
 
 ```bash
-aimee --json agent list
+aimee ensemble aggregate --help
+aimee ensemble roundtable --help
 ```
 
-Verify that:
+Roundtables run through the same delegate core. Seats execute in parallel, require evidence, and may
+pin a model or choose a random viable reviewer. Cost folds into the originating session or workflow.
 
-- the delegate is present
-- the expected roles are assigned
-- `enabled` is set correctly
-- the tier matches the intended routing priority
-- endpoint and authentication values are correct
+See [Roundtables](ENSEMBLE.md).
 
-### 2. Confirm role coverage
+## When to delegate
 
-Make sure the roles you expect to delegate are actually represented in the configured delegates. A low-cost delegate with `summarize`, `draft`, and `format` is usually the most immediately useful baseline.
+Good delegate work has a bounded output and a clear acceptance condition:
 
-### 3. Confirm routing intent
+- inspect a subsystem and report evidence;
+- review a diff from one lens;
+- reproduce a failure;
+- write tests for an established contract;
+- implement one independent slice;
+- summarize a long artifact;
+- compare provider or benchmark results.
 
-Review the configured tiers and ensure the cheapest appropriate delegate will be selected for each role. For example, if both a local summarizer and a premium reasoning model support `summarize`, the local summarizer should have the lower tier.
+Keep authority with the primary when the task needs an unresolved product decision, broad production
+access, or constant cross-slice coordination.
 
-### 4. Confirm fallback expectations
+## Failure behavior
 
-If a delegate is disabled or unavailable, the system should still allow work to continue through fallback handling. Verify that your setup does not depend on a single fragile delegate for all roles.
+| Failure | Result |
+| --- | --- |
+| no eligible agent | explicit admission failure |
+| random target fails | retry another viable target within budget |
+| pinned target fails | fail; no substitution |
+| provider returns no usable content | diagnostic plus bounded retry |
+| tool schema or policy fails | tool denied and audited |
+| workspace path escapes | hard deny |
+| sandbox isolation fails | fail or explicitly audited degradation |
+| heartbeat stops | attempt reaped; durable job remains inspectable |
+| budget or rate exhausted | no new dispatch; job fails or parks by owner contract |
 
-### 5. Probe the live endpoint
-
-```bash
-aimee agent probe <name>
-```
-
-The probe checks model listing, slot discovery, and a short completion. Use
-`--no-run` when you only want configuration and HTTP discovery checks.
+Use `aimee agent probe`, `aimee jobs status`, provider diagnostics, and the server audit log. Preserve
+the first failed attempt; later retries can hide the original cause.

--- a/docs/DELEGATE_SANDBOX.md
+++ b/docs/DELEGATE_SANDBOX.md
@@ -1,186 +1,84 @@
-# Delegate Sandbox
+# Delegate sandbox
 
-When `delegate_sandbox` is enabled, a server-executed delegate — a coord job,
-a roundtable panelist, or an autonomy run, anything that gets its own worktree —
-runs its file and shell/script tools inside a Docker container instead of in
-aimee-server's own process. This page covers what that container can reach and
-how you pick the image it runs.
+Write-capable delegates run in an assigned worktree and, when configured, a container with no
+network or ambient credentials. The sandbox bounds damage after a model or dependency makes a bad
+decision; it does not make arbitrary host mounts safe.
 
-Turn it on with the `delegate_sandbox` config key (off by default); it needs a
-reachable Docker daemon. See the key's entry in the
-[configuration reference](gen/configuration.md).
+## Default container posture
 
-## The execution model
+- network disabled;
+- no Docker socket;
+- no provider, vault, git, or host SSH credentials;
+- workspace mounted at the declared root only;
+- read-only system filesystem where the runtime permits it;
+- bounded CPU, memory, process count, time, and output;
+- explicit image and toolchain;
+- cleanup and leaked-container reap.
 
-The sandbox container runs `--network none`. The delegate has no IP egress. Its
-only outward channel is the bound `aimee-http.sock` back to aimee-server.
+The agent's role and workflow still decide whether the worktree is writable. A container is not a
+write grant.
 
-Anything that needs the network or a credential — git, web search, package
-fetches — runs **server-side, on the delegate's behalf**, never inside the
-container. aimee performs those operations itself and hands the delegate the
-result over the bound socket. What stays inside the container is the delegate's
-own local work: reading and writing files in its worktree, and running build,
-test, and `verify` commands.
+## Source authority
 
-That has one consequence you have to plan for: **the toolchain must already be
-in the image.** A `--network none` container cannot install anything at run
-time. A Rust repo needs `cargo` baked in, a C repo needs `gcc`/`make`, a docs
-repo needs nothing. Because that toolchain is per-project, the image is resolved
-per delegate.
+The server resolves the workspace and canonical worktree before launch. Absolute paths are accepted
+only when they remain inside that root. Symlinks, `..`, alternate git worktree paths, and host mounts
+cannot expand authority.
 
-## How the image is chosen
+Container-bound worktrees are allowed outside the parent checkout when the managed worktree root
+owns them. Arbitrary sibling paths are not.
 
-At the point a delegate is bound to its container, aimee resolves an image from
-the delegate's working directory, **most specific first**:
+## Packages and network
 
-1. The repo's `<git-root>/.aimee/project.yaml` `sandbox:` block — the toolchain
-   travels with the code that needs it.
-2. A per-workspace `sandbox_image` override in `aimee.yaml`, for the workspace
-   whose root contains the delegate's directory (longest matching root wins).
-3. The global `delegate_sandbox_image` in `aimee.yaml`.
-4. The built-in default, `ubuntu:22.04`.
+Delegates do not reach public package registries directly. Package requests use a mediated proxy or
+prebuilt cache with allowlist, vulnerability, integrity, size, and audit policy.
 
-The first scope that yields a usable image wins. A `.aimee/project.yaml` spec
-that is declared but fails to build does **not** silently fall through to a
-lower scope's image with no signal — the build failure surfaces through Docker's
-own build logs.
+If a task needs network, grant the narrow destination and protocol. Do not switch the whole backend
+to host networking for one dependency.
 
-## The `.aimee/project.yaml` `sandbox:` block
+## Images
 
-The in-repo block is the primary, per-project control. It takes one of three
-forms.
+An operator may choose:
 
-### `image:` — use a pre-baked image as-is
+- the default delegate image;
+- a pinned custom image;
+- an image extended with an approved package set;
+- a reviewed Dockerfile built by the provisioning service;
+- a learned toolchain image produced from verified project requirements.
 
-```yaml
-sandbox:
-  image: ghcr.io/acme/ci-toolchain:2026-06
-```
+The agent does not receive the host Docker socket or permission to replace the policy wrapper.
+Record the final image digest with the job.
 
-aimee runs that image directly. No build step.
+## Credentials
 
-### `from:` + `packages:` — build a derived image
+No credential is mounted by default. When one tool needs one credential, grant it through that tool's
+contract and keep it out of the process environment where possible. The vault access is attributed
+and audited.
 
-```yaml
-sandbox:
-  from: ubuntu:22.04
-  packages: [gcc, make, python3]
-```
+Local CLI-provider logins stay on the thin client and do not enter the container.
 
-aimee generates a two-line Dockerfile — `FROM <base>` plus a single
-`apt-get install` layer — and builds it.
+## Isolation failure
 
-`packages:` is an **apt shortcut**: it works only on a Debian/Ubuntu base and
-installs *system* packages. That includes the language runtimes themselves —
-`nodejs`, `npm`, `python3`, `cargo`, `golang`. For a non-apt base (Alpine and
-the like), or to bake in ecosystem dependencies, use `dockerfile:` instead.
+Fail closed when the requested namespace, mount, network, or resource boundary cannot be created.
+An operator may configure a documented degraded mode for a trusted host; every degraded launch emits
+a sandbox audit event with the missing boundary.
 
-Package names are validated against `[A-Za-z0-9][A-Za-z0-9._+:-]*`. A name
-containing shell metacharacters is rejected and the spec does not build.
+Never silently fall back from container to host shell.
 
-### `dockerfile:` — build a project-provided Dockerfile
+## Lifecycle
 
-```yaml
-sandbox:
-  dockerfile: .aimee/sandbox.Dockerfile
-```
+1. admit role, principal, budget, and agent slot;
+2. resolve worktree and source authority;
+3. select and verify image/toolchain;
+4. construct mounts, limits, network, and package policy;
+5. launch and record backend identity;
+6. audit tool calls and completion;
+7. stop, collect bounded results, remove container;
+8. reap leaks after crashes or runtimes with weak filtering.
 
-The escape hatch: any base, any package manager, and — because a build has
-network access — ecosystem dependencies baked at build time.
+## Configure
 
-```dockerfile
-FROM node:22-slim
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-```
+Use [generated configuration](gen/configuration.md) for current sandbox, image, package, network,
+resource, and worktree fields. Deployment-specific images and credentials belong in secret-aware
+environment/configuration, not the repository.
 
-The path is resolved relative to the git root (or taken as-is if absolute).
-
-### Build and cache behavior
-
-For the `from:`+`packages:` and `dockerfile:` forms, aimee runs `docker build`
-with network available at build time and tags the result by the content hash of
-its Dockerfile: `aimee-sbx:<hash>`. The build happens **once** and is reused
-across turns and delegates; it only rebuilds when the spec changes. The delegate
-then **runs** that image `--network none`.
-
-## `aimee.yaml` scopes
-
-The operator-facing overrides in `aimee.yaml` accept the `image:` (pre-baked)
-form only — a bare image reference. They do not build from a spec; use
-`.aimee/project.yaml` for that.
-
-### Per-workspace override
-
-A workspace entry can be a bare path string or a `{path, ...}` object; add a
-`sandbox_image` field (an object entry — a bare string carries no override):
-
-```yaml
-workspaces:
-  - path: /srv/repos/backend
-    sandbox_image: ghcr.io/acme/rust-toolchain:1.81
-```
-
-The override applies to a delegate whose directory is at or under that
-workspace root. When roots nest, the longest matching root wins.
-
-### Global default
-
-A top-level key sets the default for every delegate not covered by a more
-specific scope:
-
-```yaml
-delegate_sandbox_image: ghcr.io/acme/base-toolchain:latest
-```
-
-## Worked example
-
-A C project that needs a compiler, `make`, and Python for a test harness — and
-nothing from the network at run time:
-
-`<repo>/.aimee/project.yaml`
-
-```yaml
-sandbox:
-  from: ubuntu:22.04
-  packages: [gcc, make, python3, python3-pytest]
-
-# (verify steps, env_check, etc. as documented in agent.md)
-verify:
-  steps:
-    - name: build
-      run: make
-    - name: test
-      run: python3 -m pytest
-```
-
-On the delegate's first turn aimee builds `FROM ubuntu:22.04` plus the four
-packages, tags it `aimee-sbx:<hash>`, and runs the delegate against it
-`--network none`. Later turns reuse the built image until the `sandbox:` block
-changes.
-
-## Installing dependencies: build time, not run time
-
-Because the running sandbox is `--network none`, install every toolchain and
-dependency at **build time**:
-
-- System tools and language runtimes → `packages:` (apt) or a `dockerfile:`.
-- Ecosystem dependencies (`npm ci`, `pip install -r requirements.txt`,
-  `cargo fetch`) → a `dockerfile:` `RUN` step, which has network during the
-  build.
-
-A config-selectable **runtime package-access policy**
-(`delegate_sandbox_package_access`) — which would let aimee proxy package-manager
-fetches on the delegate's behalf while the container itself stays network-none —
-is designed but **not yet shipped**. See the
-[proposal](proposals/pending/delegate-sandbox-image-customization.md) for the
-planned modes. Until it ships, bake what the delegate needs into the image.
-
-## See also
-
-- [`.aimee/project.yaml` conventions and `verify` steps](agent.md)
-- [Delegates: roster, routing, and economics](DELEGATES.md)
-- [Configuration reference](gen/configuration.md) — `delegate_sandbox`,
-  `delegate_sandbox_image`, and the workspaces `sandbox_image` key
-- [Design proposal](proposals/pending/delegate-sandbox-image-customization.md)
+See [Sandbox verification](DELEGATE_SANDBOX_VERIFY.md) before changing the posture.

--- a/docs/DELEGATE_SANDBOX_VERIFY.md
+++ b/docs/DELEGATE_SANDBOX_VERIFY.md
@@ -1,122 +1,61 @@
-# Verifying in the delegate sandbox
+# Sandbox verification
 
-> **Autonomous verify runs where the toolchain is.** When the workflow engine
-> gates an `implement` unit on `aimee git verify`, the verify steps now run
-> **inside the delegate's `--network none` sandbox** — the same per-project,
-> toolchain-baked image the engineer delegate builds against — instead of in the
-> `aimee-server` process. The slim server runtime image ships no `gcc`/`make`/
-> `node`, so an in-process verify there can never build a real project; running
-> verify in the sandbox is what lets an autonomous run reach a green gate.
+Verify the boundary from inside the launched delegate, not from the command used to create it.
 
-## Why this exists
+## Required negative checks
 
-An autonomous `build` run decomposes a proposal into slices and, for each slice,
-runs `implement → freeze → roundtable → PR → CI → merge`. The `implement` block
-ends with a **mandatory mechanical verify** (`wfe_implement_verify_ok`): the
-change must pass `aimee git verify` before it can advance, and the gate is
-**fail-closed** — if verify cannot run, the unit does not advance, it loops.
+The delegate must fail to:
 
-The `aimee-server` binary ships in a **slim runtime image** (the final stage of
-`Dockerfile.server` is `debian:bookworm-slim` with the compiled binaries and
-runtime libraries only — no compiler, no build tools). Running the verify steps
-in that process therefore fails for any project that has to be compiled or
-tested: the build tool isn't there. Fail-closed then turns into an **infinite
-re-implement loop** that burns the unit's wall-clock budget and parks the run,
-never reaching the review roundtable.
+- reach the public network or undeclared deployment services;
+- read provider, git, vault, SSH, cloud, or Docker credentials;
+- open the Docker socket;
+- read or write outside the assigned workspace;
+- escape through a symlink, `..`, alternate worktree path, or absolute path;
+- mount a new filesystem or create a privileged namespace;
+- exceed process, memory, CPU, output, or time limits;
+- install an unapproved package or bypass the package proxy;
+- keep a container/process alive after cancellation or daemon restart.
 
-The delegate **sandbox** is the environment that *does* carry the project
-toolchain: a `--network none` container whose image is resolved per project and
-whose build tools are baked in (see [Delegates](DELEGATES.md) and the delegate
-sandbox image spec below). Verify belongs there, next to the toolchain and the
-worktree the delegate just edited — not in the daemon.
+## Required positive checks
 
-## How it works
+The delegate must be able to:
 
-When the live verify provider runs a work item's mechanical gate
-(`wfe_live_delegate.c`):
+- read the intended source;
+- write only when the role grants it;
+- run the declared compiler/test tools;
+- use approved cached packages;
+- produce a commit in its own worktree;
+- return bounded logs and results;
+- shut down normally and release admission.
 
-1. **Resolve the verify steps** for the worktree (`verify_load_config`) — from
-   the project's `verify.yaml`/`project.yaml`, or auto-generated from a
-   recognized build file.
-2. **Resolve the sandbox image** for the worktree
-   (`delegate_sandbox_resolve_image`) — honoring a per-project `sandbox:` spec
-   (below), falling back to the backend default.
-3. **Acquire the sandbox** through the `docker` delegate backend
-   (`--network none`, worktree bind-mounted, the package-egress proxy armed).
-4. **Run each verify step inside the sandbox** (`exec`), collecting each step's
-   exit code.
-5. **Synthesize the verdict** — `{"verdict":"passed"|"failed","steps":[…]}` — the
-   same shape the implement gate consumes.
+## Degradation check
 
-If no sandbox is available — no `docker` backend registered, no resolvable verify
-steps, or the sandbox fails to start — verify **falls back to the in-process
-gate**, so the CLI (`aimee git verify`) and non-sandboxed deployments are
-unchanged.
+Force one isolation primitive to fail. The launch must either fail or take the explicitly enabled
+degraded path. The latter must create an event-bus audit row naming the missing boundary. A plain
+warning in a transient container log is not enough.
 
-## Specifying a custom base image
+## Cleanup check
 
-The sandbox toolchain is **per project**, because a Rust repo needs `cargo`, a C
-repo needs `gcc`/`make`, and a docs repo needs nothing. Declare it in the
-project's sandbox spec (resolved most-specific-first: project, then workspace,
-then the global default). Three forms:
+Kill the delegate, runtime, and server at different points. After the configured reap interval:
 
-```yaml
-# a pre-baked image, used as-is (you maintain the toolchain)
-sandbox:
-  image: ghcr.io/acme/build-tools:latest
+- no process/container remains;
+- no agent slot remains held;
+- no worktree is marked active by the dead attempt;
+- no arena or event-bus client reference remains;
+- the durable job records interruption rather than success.
 
-# aimee builds a derived image: your base + these apt packages
-sandbox:
-  from: ubuntu:24.04
-  packages: [build-essential, clang, make, pkg-config]
+## Image and package check
 
-# aimee builds this Dockerfile (repo-relative or absolute)
-sandbox:
-  dockerfile: .aimee/sandbox.Dockerfile
-```
+- verify the image digest recorded on the job;
+- mutate a pinned executable and confirm the build/launch refuses it;
+- request a blocked or vulnerable package and confirm denial;
+- corrupt a cached package and confirm its digest is checked;
+- run with the registry offline and confirm only verified cache entries work.
 
-Point `from`/`image` at whatever base you like and aimee bakes your dependencies
-into the sandbox image; verify then runs against exactly that toolchain.
+## Sanitizers and races
 
-## Learned dependencies
+Run the narrow sandbox/backend tests under ASAN/UBSAN. Run concurrency, cancellation, cleanup, and
+event publication under TSAN where supported. Container integration tests still matter; a unit test
+cannot prove the host runtime applied a namespace or mount.
 
-You do not have to enumerate every package up front. When a verify step (or a
-delegate) runs `apt-get install <pkgs>` inside the sandbox, aimee **captures the
-package names** (`sandbox_learned_observe`) and records them against the project.
-The **next** sandbox image build pre-bakes the learned set in, so the tools are
-present immediately with no runtime install.
-
-This is the intended **B → A** progression:
-
-- **B (first runs):** the sandbox has the package-egress proxy, so a step that
-  installs a missing build dependency succeeds over aimee's egress.
-- **A (steady state):** those installs are learned and pre-baked, so subsequent
-  verify runs need no network for dependencies — they run against the baked-in
-  toolchain offline.
-
-The learned set is a best-effort JSON sidecar under `$AIMEE_HOME`
-(`sandbox-learned.json`); it only recognizes `apt`/`apt-get install`, matching
-the apt-based image builder.
-
-## Prerequisites and limits
-
-- **A resolvable verify config.** Verify runs the steps `verify_load_config`
-  resolves. A repo whose build file the auto-generator does not recognize (for
-  example, aimee's own Makefile lives at `src/Makefile`, not the repo root) needs
-  an explicit `verify.yaml`/`project.yaml` declaring its steps, or there are no
-  steps to run and verify has nothing to gate on.
-- **The `docker` delegate backend must be engaged.** The sandbox path is used
-  when the `docker` backend is registered and a sandbox can be acquired for the
-  worktree. A deployment whose delegates run on the in-process/`local` backend
-  does not build a sandbox, so verify falls back to in-process (and inherits that
-  environment's toolchain, or lack of one).
-- **The verdict is pass/fail by step exit code.** A step's non-zero exit — or a
-  transport failure acquiring/exec'ing in the sandbox — counts as a failed step;
-  any failed step fails the verdict.
-
-## See also
-
-- [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md) — the implement → verify →
-  re-delegate loop the mechanical gate lives in.
-- [Workflows](WORKFLOWS.md) — the `implement`/`slice` blocks and their gates.
-- [Delegates](DELEGATES.md) — delegate execution backends and the sandbox.
+Record runtime version, kernel, image digest, config, commands, and results with the verification.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,90 @@
+# Deployment
+
+## Managed server
+
+```bash
+docker compose -f compose.server-managed.yaml up -d
+```
+
+The browser wizard launches the KB and inference containers. This requires the host Docker socket,
+which gives the server Docker-host authority.
+
+Use it for a trusted single-host install where browser-managed setup matters more than that larger
+boundary.
+
+## Split stack
+
+```bash
+docker compose -f deploy/compose/aimee.yaml up -d
+```
+
+Server, KB, and inference are declared together and no browser action needs to create them. This is
+the safer default when the server must not control Docker.
+
+## External PostgreSQL
+
+Set `AIMEE_DB2_URL` for the KB. The operator owns:
+
+- PostgreSQL availability and backups;
+- TLS and service identity;
+- pgvector/pgvectorscale versions;
+- connection limits and latency;
+- migration and restore testing.
+
+Only `aimee-kb` receives DB2 credentials.
+
+## Inference
+
+`aimee-llm` serves embedding, reranking, and synthesis. Select a CPU or GPU tier with the deployment
+settings. GPU models live in a persistent model volume; the CPU offline image may bake its model.
+
+The KB must report explicit degradation when a configured inference stage is unavailable. It cannot
+claim a dense, reranked, or synthesized result after silently skipping that stage.
+
+## Network ports
+
+Use the compose files and generated configuration as the source of truth. Typical defaults are:
+
+| Service | Port | Exposure |
+| --- | ---: | --- |
+| browser | 8443 | user network, HTTPS |
+| server `/v1` | 8743 | enrolled clients only |
+| KB `/v1` | 8741 | deployment network only |
+| inference | 8742 | deployment network only |
+
+Do not publish PostgreSQL or inference ports unless a separate host needs them. Apply TLS and service
+identity before crossing a trusted container network.
+
+## Volumes and backup
+
+Back up:
+
+- server config and DB1;
+- workflow SQLite and artifacts;
+- KB PostgreSQL;
+- vault root-key or external custody metadata;
+- TLS enrollment and revocation state;
+- WORM ledger, seals, and off-host anchor state;
+- workspace mirrors when rebuilding them is expensive.
+
+Use the KB export helper for the embedded database. Test a restore. `docker compose down -v` deletes
+named volumes.
+
+## Hardening
+
+- change bootstrap browser credentials;
+- keep server and KB networks private;
+- verify TLS fingerprints and issue one client identity per machine;
+- configure server ID, team ID, and the root-owned management-JWKS trust bundle;
+- grant remote users individually and review revoked rows;
+- use the split stack if the Docker socket is not required;
+- keep delegates networkless by default;
+- move provider, git, database, and witness secrets into their owning vault/secret manager;
+- ship WORM evidence to an off-host witness when host compromise is in scope;
+- alert on failed health, audit verification, witness lag, bus drops, database pressure, and agent
+  reaping.
+
+## Upgrade
+
+See [Upgrading from v0.2.192](UPGRADING.md). Deployment topology changes are data migrations, not
+just compose edits.

--- a/docs/ENSEMBLE.md
+++ b/docs/ENSEMBLE.md
@@ -1,168 +1,81 @@
-# Ensembles
+# Roundtables and ensembles
 
-An **ensemble** is a panel of agents collaborating on one task instead of a
-single delegate. aimee runs ensembles in three modes that share one concept, one
-config namespace (`ensemble.*` / `roundtable.*`), and one `aimee ensemble` verb —
-and they **compose** (a delegate's output can feed a running session, below).
+Use an ensemble when independent answers improve the result. Use a roundtable when reviewers need a
+shared artifact, named lenses, evidence, and a verdict.
 
-| Mode | Shape | Reach it via |
-|---|---|---|
-| **aggregate** (Mixture-of-Agents) | fan out one prompt to diverse models in parallel, one aggregator synthesizes a single answer | `aimee ensemble aggregate` · `aimee delegate aggregate` · method `delegate.aggregate` |
-| **roundtable** | a configured multi-persona panel; every seat analyzes once before finalization | method `delegate.roundtable` · the workflow `gate.roundtable` block |
-| **session** | a persistent, templated, turn-based session (code-review, debate, planning, design-critique) | the `ensemble_*` MCP tools · a delegate bound to a channel · `aimee ensemble session …` |
+## Aggregate
 
-The first two are one-shot panels that return a synthesized artifact. The third
-is a stateful, multi-phase conversation that lives in the DB and advances a turn
-at a time. All three are "a group of agents working a problem together" — the
-difference is parallel-and-synthesize vs. turn-by-turn.
-
-> Naming: the delegate Mixture-of-Agents / roundtable subsystem
-> ([`src/modules/roundtable/delegate_ensemble.c`](../src/modules/roundtable/delegate_ensemble.c)) and the
-> templated session store ([`src/db1/ensemble.c`](../src/db1/ensemble.c)) are two
-> expressions of the same "ensemble" concept, deliberately sharing the name and
-> the `aimee ensemble` command, not a collision.
-
-## aggregate — Mixture-of-Agents
-
-Fan one prompt out to the reference panel in parallel; an aggregator folds their
-answers into one. Weak or partial panels degrade to the best single candidate
-rather than failing.
+An aggregate run sends the same task to several eligible agents, then asks an aggregator to produce
+one answer. It is useful for drafting, research, and questions with several plausible approaches.
 
 ```bash
-aimee ensemble aggregate "Design a migration plan for the auth schema"
-# equivalent, back-compat alias:
-aimee delegate aggregate "Design a migration plan for the auth schema"
+aimee ensemble aggregate --help
 ```
 
-Configured by `ensemble.*` (see [Settings](SETTINGS.md)):
+The run keeps partial-failure metadata. A missing seat does not become an empty vote. The aggregator
+sees the successful answers and the declared degradation.
 
-- Saved roundtable seats are the complete panel. The roundtable name is
-  required: an omitted name resolves nothing and is an error, never an implicit
-  panel. A named preset may contain any supported number of seats; its exact
-  count is authoritative and is never expanded from the eligible roster.
-- `ensemble.reference_models` is retained as the preset's applied compatibility
-  representation; it does not authorize an unconfigured panel.
-- `ensemble.reference_personas` — optional per-reference persona overrides.
-- `ensemble.aggregator` — the agent that synthesizes the final answer.
-- `ensemble.min_successful` — min references that must succeed before degrading (default 2).
-- `ensemble.max_cost_usd` — optional per-run USD cap (0 / unset = no cap).
+## Roundtable
 
-## roundtable — review / debate panel
-
-Runs one independent analysis per configured seat before finalization. Review
-panelists get read-only Aimee index tools and a
-diverse persona lineup (original-request alignment, security, architect, QA,
-contrarian, constructive reviewer).
-
-When a saved roundtable enables **Discussion mode**, the same successful seats
-compare their independent reports once before deterministic synthesis. Nits,
-suggestions, and ordinary blocking findings always stop after that one cycle.
-A foundational finding also stops after one cycle when the seats agree or one
-position already has a strict majority. Only an explicitly disputed
-foundational finding may continue to another cycle, and subsequent cycles carry
-only those contested stable issue IDs. Discussion ends when a strict majority
-forms; deadline or quorum loss parks the workflow visibly for scheduler retry
-rather than fabricating consensus. Deterministic synthesis retains findings unless a strict majority
-rejects them.
-The denominator is the successful seated participants that return a complete,
-valid ballot in that discussion cycle. Abstentions remain in that denominator
-but do not by themselves count as disagreement or extend discussion. The saved
-`deadline_ms` is the overall analysis-plus-Discussion-plus-Chairman budget; an
-omitted or zero value is normalized to 600 seconds.
-The runtime treats that overall deadline as one work-conserving budget shared by
-analysis, Discussion, and Chairman. It does not divide the deadline into equal
-phase slices: enabled providers can have materially different normal latency,
-and a healthy seat must not be cancelled before the configured overall deadline
-merely because downstream phases are enabled. Later phases receive the remaining
-budget, and the single overall deadline remains the hard upper bound.
-The C compatibility proxy derives its finite receive timeout from that acquired
-preset deadline and adds only transport grace; it does not impose a shorter
-fixed deadline or wait without a bound.
-
-An unavailable or unusable independent-analysis seat is recorded as failed and
-makes the result degraded. It parks the roundtable only when the remaining
-complete reports are below the preset's `min_successful`; a satisfied configured
-minimum proceeds to discussion or deterministic synthesis without hiding the
-failed seat.
-
-After deterministic synthesis, a preset may optionally require a **chairman**.
-The chairman is one configured, enabled review agent selected visibly in the
-Roundtable GUI. It receives the original request, reviewed artifact, independent
-reports, and deterministic feedback, then submits one final structured verdict.
-There is no chairman retry across the roster: an unavailable chairman, malformed
-verdict, stage mismatch, or contradictory verdict parks the workflow visibly for
-scheduler retry with a new execution version. A valid `changes` verdict with
-`drifted` or `unclear` alignment is refinement feedback, not an execution failure.
-With the chairman disabled, deterministic synthesis is final.
-
-Every review must explicitly report `original_request_alignment` as `aligned`,
-`drifted`, or `unclear`, with a comparison to the originating request. A useful
-refinement remains aligned; substituting an unrelated goal or deliverable is
-drift. WFE gates fail closed on `drifted`, `unclear`, or an omitted assessment,
-so implementation quality cannot accidentally earn approval for work that does
-not answer the request.
-
-Roundtable participation metadata follows three rules:
-
-- `participants_failed` counts unusable responses in the adopted best round;
-  `participants_required_failed` counts the subset in its caller-authored,
-  required prefix. The latter is additive response metadata.
-- Every configured seat is attempted and remains visible in the total. There are
-  no automatically filled capacity seats.
-- `required_participants == 0` preserves the legacy all-required behavior. A
-  value larger than the effective panel fails closed before invoking a model.
-
-`degraded` describes the run as a whole and is intentionally sticky: truncation,
-a failed required seat, insufficient successful responses,
-an aggregator failure, or verification degradation cannot be hidden merely by
-selecting a later artifact. Consequently, an adopted round with zero required
-failures does not clear an earlier run-level degradation.
-
-The execution deadline is tuned by `roundtable.deadline_ms`. The workflow engine's
-`gate.roundtable` block ([Workflows](WORKFLOWS.md)) is the same panel used as a
-pass/fail review gate inside a run.
-
-Prefer `aimee ensemble roundtable --mode review` (or the `delegate.roundtable`
-tool) for a multi-model review **gate**; use `aimee delegate review --via M` for
-a single, exploratory, tools-on review of live code. See
-[Delegates](DELEGATES.md).
-
-## session — templated, turn-based
-
-A persistent session where a template lays out phases and roles, and agents take
-turns. Ships with `code-review`, `debate`, `planning`, and `design-critique`
-templates; drop a project-local template in `ensemble_templates/` (the legacy
-`session_templates/` path still resolves). State lives in the DB1 `ensembles`
-table.
-
-Agents drive sessions with the **MCP tools** `ensemble_start`, `ensemble_status`,
-`ensemble_pause`, `ensemble_advance`, and `ensemble_list` (the `session_*` names
-remain as hidden aliases). Each `ensemble_advance` records a turn and returns the
-next expected participant and prompt.
-
-```jsonc
-// ensemble_start
-{ "template": "code-review", "channel": "pr-482",
-  "assignments": { "reviewer": ["claude-1", "gemini"], "author": ["me"] } }
+```bash
+aimee ensemble roundtable --help
 ```
 
-`aimee ensemble session <start|status|pause|advance|list>` is the human-facing
-counterpart; today it points at the MCP path (thin-client session control over
-`/v1` is a pending enhancement).
+A roundtable has:
 
-## How the modes compose
+- a named preset;
+- seats with personas;
+- a pinned model or `$random` per seat;
+- a review or drafting mode;
+- parallel or sequential turns;
+- quorum, round, deadline, and cost limits;
+- an optional reasoning chair.
 
-A delegate that runs on a **channel** advances the session ensemble bound to that
-channel with its output: after the delegate replies, aimee looks up the current
-ensemble for the channel
-([`db1_ensemble_find_current_by_channel`](../src/db1/ensemble.h)) and calls
-`ensemble_advance` with the delegate's result as that turn. So an aggregate or
-roundtable run can *be a turn* in a longer templated session — the one-shot panel
-feeds the stateful one.
+Parallel review is the normal path. Every lens runs at once under the compute and agent-admission
+limits. Sequential turns are for discussions where a later seat must read earlier arguments.
 
-## See also
+## Seat selection
 
-- [Delegates](DELEGATES.md) — the delegate core aggregate/roundtable run on.
-- [Workflows](WORKFLOWS.md) — `gate.roundtable` uses the same review panel.
-- [Personas](personas.md) — the reviewer personas panelists run as.
-- [Settings](SETTINGS.md) — the `ensemble.*` / `roundtable.*` keys.
+A pinned seat is a hard requirement. If its agent is disabled, unroutable, saturated, or fails, the
+seat fails. aimee does not substitute a different model and pretend the panel stayed the same.
+
+A random seat chooses any viable review-capable agent not already seated. A failed random seat may
+retry on another eligible agent. Agents whose role list excludes `review` are never seated.
+
+If the required panel cannot be formed, a workflow gate parks as `panel_degraded`.
+
+## Evidence and verdicts
+
+Reviewers must point to repository evidence: paths, symbols, diffs, tests, logs, or a specific
+contract. Unsupported findings are weak evidence, not blockers.
+
+The chair receives the seat outputs and can:
+
+- merge duplicates;
+- remove claims without evidence;
+- distinguish blockers from debt;
+- preserve disagreement;
+- state the smallest change needed for approval.
+
+An unusable response abstains. It is never counted as approval. Quorum is evaluated from valid
+verdicts only.
+
+## Workflow gates
+
+`gate.roundtable` names a preset in `params.roundtable` and binds a proposal, plan, or frozen diff.
+The gate persists its findings. A failed gate sends those findings back to the authoring or
+implementation loop so the next pass addresses the actual objections.
+
+Each gate may use a different preset: plan, security, acceptance, and documentation reviews need not
+share a panel.
+
+## Cost and audit
+
+Seat usage, latency, cost, retries, model identity, evidence, chair output, and final verdict belong
+to the originating session or workflow. A positive cost ceiling stops dispatch before the next seat
+would exceed it; zero means no ensemble-specific ceiling.
+
+Tool and model activity follow the normal audit path. Roundtable artifacts remain distinct from the
+proposal, plan, and diff they reviewed.
+
+See [Personas](personas.md), [Delegates](DELEGATES.md), and [Workflows](WORKFLOWS.md).

--- a/docs/EVENT_BUS.md
+++ b/docs/EVENT_BUS.md
@@ -1,0 +1,127 @@
+# Event bus
+
+The event bus is the new spine inside `aimee-server` and `aimee-kb`. It replaces scattered
+in-process side channels with one typed, ordered, bounded transport.
+
+Today it carries observability and audit traffic. It is also the contract that lets C and Go
+modules attach without sharing implementation details.
+
+## Why it exists
+
+Before the bus, every new module needed its own queue, callback, logging path, and shutdown rules.
+Completeness depended on finding every call site.
+
+The bus gives each daemon one host and one full-stream tap:
+
+```text
+producer -> private outbound ring -> host -> private inbound ring -> consumer
+                                  |
+                                  +-> ordered capture and audit tap
+```
+
+That buys us:
+
+- one place to order, observe, meter, and audit inter-module work;
+- C and pure-Go clients with byte-for-byte conformance tests and no cgo;
+- bounded backpressure instead of unbounded queues;
+- point-to-point request/reply, fan-out events, cancellation, and typed capability errors;
+- large payloads by shared-arena lease instead of another copy;
+- capture files that preserve the accepted stream for inspection and audit replay;
+- a clean path for policy checks, workflow events, telemetry, and separately shipped modules.
+
+The last item is an extension surface, not a claim that every subsystem has moved already.
+
+## What is on it now
+
+The server and KB publish these through the observability bridge:
+
+- governed action audit rows;
+- semantic guardrail decisions;
+- server- and KB-side memory mutations;
+- vault credential access;
+- sandbox isolation degradation;
+- MCP and tool-call activity;
+- tool completion outcomes.
+
+Those bridges use two wire kinds: governed actions and semantic guardrail events. The action row is
+PII-bounded; memory identities are fingerprinted before publication. The consumer drains accepted
+events to their durable sinks. Graceful shutdown stops publishers, drains the rings, flushes
+capture, then tears down the host.
+
+A full queue is never a silent success. Publishers retry bounded backpressure; a stuck consumer
+increments a visible drop counter and logs the failure.
+
+## Ordering and delivery
+
+The host assigns a monotonic sequence number before routing. The tap sees accepted events in that
+order. Producers keep FIFO order; consumers only receive event kinds they subscribed to.
+
+`publish` success means the producer ring accepted the event. It does not mean a consumer has
+finished its work. Callers that need read-after-write behavior use the bridge flush point.
+
+Requests and replies use a correlation ID. A missing server returns `capability_absent`. A reply
+goes only to its requester. Notifications fan out to the authorized observers registered for that
+kind.
+
+Each client has its own queue pair. One slow consumer does not create an unbounded host queue.
+Kinds declare whether they block or may shed under pressure. Sheds become typed overflow records in
+the ordered tap.
+
+## Payloads
+
+Small payloads ride inside a ring slot. Large payloads use a lease in the shared arena:
+
+1. the producer allocates and fills a span;
+2. the frame carries its offset, length, and generation;
+3. the host assigns references to the destination set;
+4. each consumer releases its reference after reading;
+5. the last release reclaims the span.
+
+Generation checks reject stale references. Client reap releases abandoned references. Capture
+materializes arena bytes into the record, so replay never depends on a live arena.
+
+Arena allocation is currently for trusted code co-located with the host. A follow-on branch adds
+cross-process attachment for inline events; it does not expose arena allocation or lease resolution.
+
+## Capture and replay
+
+The host tap writes CRC-checked, length-framed capture files under the aimee config directory. A
+record contains the original frame and materialized payload. Retention keeps the newest capture
+sessions and prunes older files when a new capture starts.
+
+Replay is observational: it presents the exact accepted stream to an inspector. It does not execute
+tools or drive a module again.
+
+The durable WORM audit ledger remains the security record. Capture is the ordered diagnostic and
+replay layer above it. An off-host witness or anchor is still required for evidence against a fully
+compromised host.
+
+## Trust boundary
+
+The v0 bus is Linux-only. The host creates anonymous `memfd` regions and admits clients over a Unix
+`SOCK_SEQPACKET` socket, passing descriptors with `SCM_RIGHTS` only after admission.
+
+The control region is read-only. Every admitted client maps only its queue pair plus the shared
+arena; it cannot enumerate or map another client's rings. The arena is cooperative isolation for
+trusted native modules, not a sandbox for hostile code.
+
+The bus is intra-daemon. Traffic between `aimee-server`, `aimee-kb`, browsers, thin clients, and
+providers still uses the authenticated `/v1` network surfaces.
+
+## Adding a consumer
+
+Keep the contract small:
+
+- assign a stable event kind and bounded schema;
+- choose notification or correlated request/reply;
+- declare block or shed behavior;
+- register only the observers that need the kind;
+- keep action policy before delivery and storage off the hot path;
+- add C/Go vectors when the wire contract changes;
+- test shutdown, queue exhaustion, malformed frames, client reap, and capture replay.
+
+Use `bus_client_publish` for inline events. Use the arena only when a real payload can exceed the
+inline budget.
+
+Code lives under `src/modules/bus/`. The public C client is `bus_client.h`; the pure-Go client is
+under `server-go/bus/`. The source headers hold the wire and arena invariants.

--- a/docs/KB_CONSOLE.md
+++ b/docs/KB_CONSOLE.md
@@ -1,171 +1,34 @@
-# aimee-kb web console
+# KB console
 
-`kb-console` is a standalone Go thin-client that fronts a shared **aimee-kb**'s
-`/v1` surface directly, so a company-wide KB is administrable from a browser with
-**no colocated `aimee-server`**. It mirrors `aimee-runtime-web`'s shape (auto-TLS
-HTTPS, SQLite sessions, an `/api/*` proxy, a vendored-SmoothGUI single-file SPA)
-but uses **no PAM**: login is OIDC, and it holds a scoped credential the kb
-enforces server-side.
+The KB console, called `control-web` in newer trees, is a separate administration client for
+`aimee-kb`. It does not reuse the runtime browser's PAM trust or server routes.
 
-Surfaces: **Dashboard** (kb health/throughput), **Accounts** (client enrollment,
-certificate revocation, scopes, OIDC config), **Governance** (decision records,
-the policy-verdict action audit), **Pipeline** (the curator stage registry — per-stage
-toggles, lane ordering, presets, composed custom stages), **Typed facts** (the
-typed-fact layer's knobs and its provisional-relation promotion queue), **Settings**
-(the rest of the config the kb owns: the embedder, the reranker, the synth tier, and
-the knowledge base itself).
-This document is the trust model + operations guide (see `docs/proposals/done/kb-web-console.md` and its `.plan.md` for the design).
+## Boundary
 
-## Status
+- OIDC identifies an administrator; an explicit presence flag controls break-glass login.
+- Sessions are bound to issuer and subject.
+- CSRF protects mutations.
+- A deny-by-default allowlist limits the proxy to console-admin KB routes.
+- The KB repeats the allowlist and remains authoritative.
+- Administration actions write a console audit record and the owning KB audit path.
 
-**Shipped, default-off.** The console is a separate opt-in service (its own
-`Dockerfile.kb-console` + the compose `console` profile) that only runs when
-launched with a console-admin credential file, bound to `127.0.0.1` by default.
-The Dashboard, Accounts (enroll / revoke / scopes / OIDC config), Governance
-(decisions / action audit), Pipeline (curator stages), Typed facts, and Settings
-(kb-owned config) surfaces are all live. Pipeline and Settings live here rather than in the aimee webchat
-GUI because the kb owns what they configure — the curator, and the embedder/reranker/
-synth tiers — and both are served in-process from `/v1/console/*`. The ownership split
-is by which BINARY reads a key, not by key prefix: `kb_mode`, `kb_client_url`,
-`kb_client_bearer_token` and `kb_evidence_emit_enabled` stay on aimee-server's Settings
-page because aimee-server reads them to reach a kb. The curator review queue is the
-one deferred surface (it needs a separate curator-scoped credential).
+The console credential file is private and read-only to the process. The browser never receives the
+KB service bearer.
 
-## Trust model
+## Deploy
 
-The console is a **privilege-escalation surface** and is treated as fail-closed,
-not merely "semi-trusted".
+Place the console near the KB, expose only its HTTPS listener, and keep the KB origin private. Pin
+OIDC issuer, audience, signing algorithms, JWKS behavior, and the admin claim. Do not enable
+break-glass permanently.
 
-- **Scoped console-admin credential, not owner.** The console holds a
-  `scope:console-admin:<id>:<secret>` bearer whose route allowlist the **kb
-  enforces server-side** (`src/kb/http/kb_route_acl.c`): only
-  `POST /v1/enroll` (mint), `/v1/console/overview`, `/v1/enrollments` (+ revoke),
-  `/v1/config/oidc`, `/v1/scopes`, `/v1/decisions` (+ sub-actions), and
-  `/v1/audit/actions`. A compromised console is bounded to that allowlist. It may
-  mint client enrollments, but the kb **refuses to mint an owner or privileged
-  scope for a console-admin caller**: the requested scope must be a proper
-  `<kind>:<id>` and the kind may not be `owner`/`console-admin`/`curator`, so the
-  console cannot escalate by minting. `/v1/review` is **not** in the set: review
-  accept/reject is a separate `curator` scope. (The console is on the kb's compose
-  network, so other services on it can reach the console port, but every action
-  still requires a valid console session: OIDC or break-glass.)
-- **Deny-by-default proxy.** `/api/*` maps 1:1 to the allowlisted `/v1` routes and
-  re-checks the same allowlist in Go (`acl.go`) before forwarding, defence in
-  depth with the kb's server-side check. The browser's own token is never
-  forwarded; only the console-admin bearer, server-side.
-- **Login = OIDC primary.** The console verifies a browser-presented OIDC JWT
-  itself (RS256 only, `iss`/`aud`/`exp`/`nbf` checked, JWKS by `kid`) and requires
-  a pinned admin claim. This is a port of `src/kb/auth_oidc.c`; a parity test
-  locks the claim mapping.
-- **Break-glass is off by default.** A static console-admin bearer login is
-  enabled only when the operator drops a presence-flag file
-  (`$KB_CONSOLE_HOME/.break_glass`, mode 0600). Break-glass sessions are capped at
-  **300 s** and audited (console-local record now; a kb-side `audit_events` row is
-  added with the auth endpoints in S2a). Used to recover from an OIDC
-  misconfiguration lockout.
-- **Sessions + CSRF.** Cookies are `HttpOnly; Secure; SameSite=Strict`; every
-  mutating `/api/*` call requires the per-session CSRF token in an `X-CSRF-Token`
-  header, compared server-side to the session's stored token (a synchronizer-token
-  pattern: the `SameSite=Strict` cookie is the primary CSRF defence, the header is
-  defence-in-depth). Login is rate-limited per source IP. A
-  session is bound to `(iss, sub)`, not `sub` alone, so it is not portable
-  across IdPs, and revoking a principal's enrollment invalidates its sessions.
-  Idle (30 min) and absolute (8 h) timeouts apply. The SQLite session DB is mode
-  0600.
-- **Credential storage.** The console-admin bearer is read from
-  `KB_CONSOLE_CRED_FILE` (mode 0600); the console **refuses to start** if the file
-  is group/world-readable, or if an inline `KB_CONSOLE_CRED` env var is set.
-- **CSP.** The SPA is served with a strict Content-Security-Policy: `default-src
-  'self'`, no `'unsafe-inline'`, no `*`. The single-file bundle's inline
-  script/style are allowed by pinning their exact sha256 hashes (computed once at
-  startup); the only non-self entries are the IdP origin (for the OIDC flow).
-- **Fail-fast startup.** On boot the console probes `GET /v1/console/overview`
-  with its credential and refuses to start unless it 200s (credential + ACL +
-  route all wired).
+## Verify
 
-## Certificate revocation semantics (S2a)
+- unauthenticated and non-admin users cannot reach proxy routes;
+- cross-site mutation fails CSRF;
+- a route absent from either allowlist is denied;
+- session reuse under another issuer/subject fails;
+- OIDC key rotation works without accepting an unexpected issuer;
+- break-glass is off after recovery;
+- audit rows identify the administrator and operation.
 
-Revoking an enrollment (`POST /v1/enrollments/{id}/revoke`) sets `revoked_at` in
-DB2 (the **source of truth**) and the mTLS seam rejects a revoked client cert on
-its next request (matched by the sha256 fingerprint of the cert DER). Two deliberate
-trade-offs:
-
-- **Fail-open on a DB outage, for unknown certs only.** If DB2 is unreachable, an
-  *unknown* fingerprint is treated as not-revoked so a transient DB blip cannot lock
-  every mTLS client out of the shared kb. A **known** revocation still holds through
-  an outage: `revoke` primes the in-process cache with the revoked verdict, which is
-  checked before the DB. Every fail-open is logged (throttled) as a `WARN`.
-- **Single-instance cache.** The is-revoked cache is per-process with a 30 s TTL; a
-  revoke is reflected immediately in the process that served it. Running multiple kb
-  instances means a revoke can take up to the TTL to be seen by the others. Run a
-  single kb instance, or shorten the TTL, for a tight revocation window.
-
-Certs issued before S2a (no enrollment row) are **backfilled** as `legacy` rows on
-their first authenticated request, so they become listable and revocable.
-
-## Running (dev)
-
-```bash
-# 1. Mint a console-admin enrollment on the kb (owner credential):
-#    POST /v1/enroll {"scope":"console-admin", ...}  ->  the scoped bearer.
-printf '%s' "$CONSOLE_ADMIN_BEARER" > console.cred && chmod 600 console.cred
-
-# 2. (optional) OIDC config file:
-cat > oidc.json <<'JSON'
-{ "issuer": "https://idp.example.com", "audience": "aimee-kb-console",
-  "jwks_url": "https://idp.example.com/jwks", "admin_claim": "groups",
-  "admin_values": ["aimee-admins"] }
-JSON
-
-# 3. Run (localhost-only, auto-TLS):
-kb-console -kb https://aimee-kb:8741 -cred console.cred -oidc oidc.json
-```
-
-Without an OIDC file the console runs **break-glass-only**: create
-`$KB_CONSOLE_HOME/.break_glass` (0600) to enable the recovery login.
-
-## Deploy (compose)
-
-The console is a **default-off** compose service under the `console` profile. A
-stock `docker compose up` never starts it. To enable it:
-
-```bash
-# 1. Mint a console-admin enrollment on the kb (owner credential) and save it:
-printf '%s' "$CONSOLE_ADMIN_BEARER" > console.cred && chmod 600 console.cred
-
-# 2. Bring the stack up WITH the console profile:
-docker compose --profile console up -d
-#   The console is published on 127.0.0.1:8744 (localhost-only), fronts the kb at
-#   http://aimee-kb:8741, and reads ./console.cred (override KB_CONSOLE_CRED_FILE).
-```
-
-Image: `Dockerfile.kb-console` (a Node stage builds the SPA, a Go stage builds the
-binary, a slim runtime). Override `AIMEE_KB_CONSOLE_IMAGE` to pin a published tag.
-
-Configure OIDC login through the **Accounts → OIDC login config** editor (stored in
-the kb's DB2); **restart the console** to apply. Until OIDC is configured the
-console is break-glass-only (drop `$KB_CONSOLE_HOME/.break_glass`, mode 0600).
-
-## The curator review queue (not in the console)
-
-The curator review queue (`GET /v1/review`, `POST /v1/review/{id}/accept|reject`)
-is **not** exposed by the console: it is a **curator-scope** action, and folding it
-into the console-admin credential would break the separation of duties (a
-console-admin could self-approve changes to the very config it administers). The
-kb's built-in verifier derives scope from the single configured bearer, so a
-distinct curator scope only exists over **mTLS** today. There is no clean
-curator-credential path over the console's HTTP+bearer transport.
-
-Until the kb gains multiple scoped bearers, work the review queue directly with a
-curator credential (an mTLS client cert whose CN is `curator:<id>`):
-
-```bash
-# list pending review items
-curl -fsS --cert curator.pem --key curator.key https://aimee-kb:8743/v1/review
-# accept / reject one
-curl -fsS -X POST --cert curator.pem --key curator.key \
-  https://aimee-kb:8743/v1/review/<id>/accept
-```
-
-A console **OIDC config** change (Accounts → OIDC login config) applies on the
-next **console restart**. There is no live reload.
+Source builds live under `control-web/` in current trees and `kb-console/` in older checkouts.

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -1,120 +1,62 @@
-# aimee-kb LLM backends: embedding, reranking & synthesis
+# KB inference backends
 
-How to point `aimee-kb` at the model backend that does its **embedding**,
-**reranking**, and **synthesis**.
+`aimee-kb` runs no model. It stores source and derived records, schedules work, and calls an inference
+service for embedding, reranking, extraction, or synthesis.
 
-## Principle: the kb runs no model
+The standard backend is `aimee-llm` on the deployment network.
 
-`aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
-in-process. It *calls* one over HTTP. Inference lives in a separate **`aimee-llm`
-container** (the unified Vulkan llama.cpp stack, deployed as the SmoothNAS
-`aimee-llm` plugin) or any external OpenAI-compatible endpoint. `aimee-llm` is a
-**model-less** image: the **tier** (`cpu` / `small` / `mid` / `large`) is
-chosen at runtime via `AIMEE_LLM_TIER` and the models are downloaded on first
-boot. (For offline CPU-only deploys a pre-baked **`aimee-llm-cpu`** variant ships
-the cpu tier's models in the image; either way the kb just sees a container at
-`aimee-llm:8742`.) You only ever give the kb a **URL**. The tiers themselves are documented in
-[AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
+## Required operations
 
-## Tiers: what each backend provides
-
-All served by the one `aimee-llm` image; `AIMEE_LLM_TIER` picks which models it
-downloads on first boot. "Model download" is the first-boot fetch into the
-`/models` volume (the image itself is small and model-less).
-
-| `AIMEE_LLM_TIER` | Embedding / reranking | Synthesis | Embedding dim | Model download |
-| --- | --- | --- | --- | --- |
-| **`cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** | ~6.5 GB |
-| **`small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) | ~11.4 GB |
-| **`mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B, 24 GB card, 2 slots) | **2560** (set explicitly) | ~17.8 GB |
-| **`large`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (same 26B-A4B, 32 GB card, 4 slots × 256 K) | **2560** (set explicitly) | ~17.8 GB |
-| **External LLM** | per the endpoint | per the endpoint | per the endpoint | — |
-
-`small`, `mid`, and `large` share the 2560-dim embedder, so a KB moves between them
-with no re-embed. `large` is identical to `mid` bar `SYNTH_SLOTS=4` (4 concurrent
-agents for a 32 GB card). Pick by synth need + card size, not by the KB — switching
-is a `AIMEE_LLM_TIER` change (the new tier downloads to its own `/models` subdir).
-
-*Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
-resolve-entities, contradictions, **synthesize**, promote). A small CPU model is
-deliberately **not** allowed to run Tier-B (the weak-model-poisons-the-graph
-guard), so CPU-only deployments get retrieval + Tier-A synthesis; Tier-B turns on
-when you point the kb at a capable container via `AIMEE_LLM_URL`.
-
-## Zero-config default
-
-If **no** LLM is configured, the kb deployment brings up a **cpu-tier `aimee-llm`
-container beside it** (`AIMEE_LLM_TIER=cpu`) and points itself at it: embedding,
-reranking, and Tier-A synthesis work with nothing to set. The operator only opts
-*up*: set `AIMEE_LLM_TIER=small|mid|large` (with a GPU) or point at an external LLM
-and the CPU sibling is not started.
-
-> The default CPU sibling is owned by the **deploy unit** (the smoothnas plugin /
-> compose), not the kb process. The kb never touches a container runtime.
-
-## Config surface
-
-All optional. Precedence is **per service**: an explicit per-service URL wins,
-then `AIMEE_LLM_URL`, then the zero-config CPU default.
-
-| Variable | Drives | Default |
+| Operation | Used for | Required |
 | --- | --- | --- |
-| `AIMEE_LLM_URL` | embedding **+** reranking **+** synthesis (Tier-A + Tier-B, at `{url}/v1`) | the auto CPU sibling |
-| `AIMEE_EMBEDDER_URL` | embedding (`/embed`, `/embed_batch`) | `AIMEE_LLM_URL` |
-| `AIMEE_RERANKER_URL` | reranking (`/rerank`) | `AIMEE_EMBEDDER_URL` → `AIMEE_LLM_URL` |
-| `AIMEE_EMBEDDING_DIM` | pgvector schema width | `1024` (CPU); set `2560` for the GPU tier |
-| `AIMEE_LLM_MODEL` | model label sent to `AIMEE_LLM_URL` | `aimee-synth` (gateways ignore it) |
-| `LLM_ENDPOINT` | **Tier-A synth only** (small-model interface) | unset |
+| embed / batch embed | dense memory, docs, code, evidence | for dense retrieval |
+| rerank | refine fused top-k | optional |
+| chat/synthesis | curator extraction, summaries, answer synthesis | optional by pipeline |
 
-- **`AIMEE_LLM_URL` is the one knob.** Point it at a container and embedding,
-  reranking, and synthesis all use it. `{AIMEE_LLM_URL}` serves `/embed`,
-  `/embed_batch`, `/rerank`; `{AIMEE_LLM_URL}/v1` serves chat completions for the
-  curator. Give the base URL **without** `/v1` (a trailing `/v1` or `/` is
-  tolerated).
-- **Split a service out** by setting `AIMEE_EMBEDDER_URL` and/or
-  `AIMEE_RERANKER_URL`. They override `AIMEE_LLM_URL` for just that service.
-- **Auth:** the kb sends **no bearer** on the embed/rerank/synth path, so the
-  container must run **auth-off** (empty `AIMEE_LLM_AUTH_TOKEN`). This is safe on
-  the internal deployment network (the `aimee-llm` gateway is not exposed
-  off-host).
+A stage reports degradation when its operation is unavailable. Lexical retrieval can still work
+without embedding; it must not claim dense or reranked results.
 
-### Embedding dimension
+## Configure
 
-The dim is **explicit**, not auto-detected:
+Set the inference base URL for the KB, normally through `AIMEE_EMBEDDER_URL` or the matching
+descriptor-backed key. Configure one embedding model identity and one dimension for the deployment.
 
-- **Unset → 1024**: the CPU / Qwen3-0.6B tier.
-- **GPU / 4B tier → set `AIMEE_EMBEDDING_DIM=2560`.**
+Use [generated configuration](gen/configuration.md) for current names. Container environment values
+override file values where documented.
 
-Changing the dim against a **populated** kb is a **drop-and-rebuild re-embed**:
-1024 and 2560 are a different model identity *and* width, and the `kb_meta` drift
-guard refuses to serve a new embedder against a mismatched corpus. Plan a
-re-embed (snapshot → drop dim-sized `halfvec` tables → rebuild at the new dim →
-parity gate) when moving between CPU and GPU tiers. See
-[runbooks/unified-llm-cutover.md](runbooks/unified-llm-cutover.md).
+## Dimension
 
-## Examples
+The model output and DB2 vector-column dimension must match. The KB records the schema dimension and
+refuses startup on drift.
 
-**GPU container (this deployment's `.254`):**
-```
-AIMEE_LLM_URL=http://10.100.0.1:8742      # embed + rerank + Tier-A&B synth
-AIMEE_EMBEDDING_DIM=2560                   # GPU / 4B tier
-```
+Changing to another model with the same width requires a controlled re-embed. Changing width also
+requires rebuilding the derived vector tables. See [Retrieval stack](retrieval-stack.md).
 
-**External embedder, GPU for synth:**
-```
-AIMEE_LLM_URL=http://10.100.0.1:8742       # synth (+ rerank, unless split)
-AIMEE_EMBEDDER_URL=https://embed.internal  # pin embedding elsewhere
-AIMEE_EMBEDDING_DIM=<that model's dim>
-```
+## Custom backend
 
-**Default (nothing set):** the deploy brings up the cpu-tier `aimee-llm` sibling
-(`AIMEE_LLM_TIER=cpu`); retrieval + Tier-A synthesis work at 1024-dim with no
-configuration.
+A custom service must provide:
 
-## Notes for plugin / compose operators
+- bounded request and response bodies;
+- stable model identity and dimension;
+- timeouts and cancellation;
+- deterministic error classification;
+- batch behavior that preserves input order;
+- health and readiness separate from process liveness;
+- no silent fallback to a different model.
 
-The `aimee-kb` smoothnas plugin and the compose topologies expose `AIMEE_LLM_URL`
-/ `AIMEE_EMBEDDER_URL` / `AIMEE_RERANKER_URL` / `AIMEE_EMBEDDING_DIM` as config.
-The kb image carries **no** baked embedder/LLM endpoint defaults. An unset
-backend falls back to the 384-dim builtin embedder (test/shim only), so a real
-deployment either relies on the default CPU sibling or sets one of the URLs above.
+Keep credentials and provider endpoints in the owning deployment, not KB documents or workflow
+artifacts.
+
+## Validate
+
+Before enabling traffic:
+
+1. probe health and model identity;
+2. embed a fixed string and verify dimension;
+3. run a batch and verify order/count;
+4. rerank a fixed candidate set;
+5. run one structured curator response through its schema;
+6. stop the backend and confirm honest degradation;
+7. restart it and confirm queued work resumes.
+
+See [Inference tiers](AIMEE_KB_SYNTH_TIERS.md).

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -1,223 +1,120 @@
-# How aimee learns, and becomes your company's knowledge base
+# Knowledge
 
-aimee is the institutional memory of an organization: one self-learning knowledge
-base that distills what everyone knows across engineering, product, sales, support,
-operations, legal, and finance, and makes it queryable by anyone in the terms of
-whatever domain they work in.
+`aimee-kb` turns sessions, documents, code, and explicit user facts into scoped durable knowledge.
+It stores source evidence as well as the record derived from it.
 
-It starts small and useful, as persistent memory for your AI coding tool, and the
-same substrate scales up to a company-wide knowledge base. Nothing about the model
-changes between "remember my database host" and "what are the engineering
-implications of the new billing policy?". It is the same ingest, the same graph,
-and the same retrieval at a different scope.
+## Scope
 
-This document explains the mechanisms behind that. Most of the substrate ships
-today: memory tiers, the curator extraction pipeline, the scope lattice, the
-knowledge graph, idle reflection, and delegation. The full all-domain reach and the
-deepest cross-domain synthesis are where the architecture is headed. Each capability
-below summarizes the machinery that backs it.
+Knowledge is scoped as global, workspace, project, or user. Scope is an authorization boundary.
+Promotion into a broader scope is an explicit audited write; sharing a KB does not make every private
+record global.
 
----
+Use one KB for any corpus whose members should share retrieval and curation policy. Separate KBs when
+retention, trust, or legal scope differs.
 
-## 1. One knowledge base, every domain
+## Record types
 
-A shared `aimee-kb` is the organization's collective memory. The curator ingests
-any document: prose, code, API specs, runbooks, design docs, tickets, meeting
-notes, and policies. It extracts structured knowledge from each one. The pipeline
-is domain-agnostic. It treats a document from an engineer and a document from a
-sales lead the same way, pulling out entities, facts, decisions, and relationships
-from both.
+The KB can hold:
 
-- **Backed by:** a doc-and-code extraction pipeline (the "deep curator") turns each
-  ingested document into structured entities, facts, decisions, and relationships,
-  running inside a single shared `aimee-kb` service that many users and projects
-  connect to.
+- memories and rules;
+- typed facts and relationships;
+- documents, chunks, pages, tables, and assets;
+- entities, claims, decisions, and contradictions;
+- code symbols, references, calls, dependencies, and co-change;
+- retrieval evidence, provenance, feedback, and lifecycle state.
 
-Knowledge is organized by a scope lattice, `global > workspace > project > user`,
-so the same store holds company-wide truth, team context, and private notes without
-them bleeding into each other.
+Raw text is not treated as a fact merely because a model extracted it. Derived records keep source,
+confidence, class, time, and review state.
 
-- **Backed by:** a memory scope lattice with an audited public access contract
-  governs what each scope (`global`/`workspace`/`project`/`user`) can read and
-  write, so promotion outward is an explicit, recorded change.
+## Ingest and curation
 
----
-
-## 2. Knowledge distills two ways
-
-**Outward, the whole org compounds.** Everyone who works against a shared
-`aimee-kb` inherits everyone else's distilled knowledge. A fix one engineer
-learned, a constraint legal flagged, a customer pattern support noticed: once it is
-in a shared scope, every future query by every person benefits from it. The team's
-knowledge stops living in individual heads and chat logs and starts accumulating in
-one place.
-
-**Inward, aimee learns you.** The more you use aimee, the more it distills your
-knowledge, preferences, decisions, and recurring patterns into durable memory and
-an evolving personal profile. Your private (`user`-scoped) knowledge stays yours;
-what you choose to share promotes outward through an audited scope-change.
-
-- **Backed by:** a cross-source learning pipeline distills sessions and documents
-  into durable memory and an evolving personal profile, splitting episodic
-  experience from semantic fact and keeping a stable per-user identity that improves
-  as you use it.
-
----
-
-## 3. It learns, not just stores
-
-Knowledge moves through a pipeline that actively improves it:
-
-```
-ingest → extract → synthesize → judge → link → promote
+```text
+content -> validate -> store source -> chunk/index -> extract candidates
+        -> resolve/link -> contradict/dedupe -> review/promote -> maintain/decay
 ```
 
-- **Extract** structured facts/entities/decisions from raw documents and sessions.
-- **Synthesize** higher-order knowledge from many low-level signals.
-- **Judge** candidates for quality before they become durable.
-- **Link** them into the knowledge graph (§4).
-- **Promote** the ones that prove useful; **decay** the ones that don't.
+The fast path commits usable source and lexical evidence. Background workers add embeddings, typed
+artifacts, links, contradiction checks, and synthesis. Workers claim durable DB2 queue rows, so a
+restart or second KB process does not duplicate the same unit.
 
-It tunes itself: promotion thresholds are calibrated from outcomes, routing and
-ranking policies are learned from feedback, and it runs reflection passes on idle
-time to consolidate what it has seen, without you asking.
+Curator stages are independently enabled and split between model-bound and index-bound lanes. A
+missing optional model degrades that stage; it does not relabel unprocessed content as curated.
 
-- **Backed by:** idle-time reflection passes synthesize new knowledge from what
-  aimee has seen; Bayesian calibration tunes promotion thresholds from outcomes;
-  contextual-bandit routers learn ranking and routing from feedback; and lifecycle
-  states plus scheduled maintenance cycles promote what proves useful and decay what
-  doesn't.
+See [Curator pipeline](CURATOR_PIPELINE.md).
 
----
+## Recall
 
-## 4. Pattern recognition across all domains
+Recall can combine:
 
-Everything aimee ingests lands in one typed knowledge graph. Recall is a **hybrid
-vector-graph**, not plain vector search: the embeddings, the graph's entities and relations,
-and a lexical signal are ranked together by reciprocal-rank fusion, so a query resolves
-through meaning, structure, and keywords at once. That is what lets it draw conclusions no
-single document states, by connecting entities, edges, and evidence that originated in
-different teams, formats, and domains.
+- lexical matches;
+- dense similarity;
+- entity and relationship graph;
+- code graph;
+- scope, recency, confidence, and lifecycle state;
+- cross-encoder reranking;
+- optional synthesis.
 
-This is the core of the company-wide design. A product spec, the code that
-implements it, the support tickets about it, and the contract that governs it all
-resolve to the same entities in the same graph, so aimee can reason across the
-boundary between any two domains. For example:
+The result keeps the evidence needed to explain why it ranked. A query with weak support can abstain.
+Synthesis does not erase its citations or turn an inference into a user-stated fact.
 
-- Turn a **business/product document** into concrete **engineering implications**
-  ("this billing change requires these services to handle proration").
-- Answer a deep **technical/implementation** question for a **non-technical
-  audience** in plain language ("is the data deletion request actually honored?
-  yes, here's where, in terms a lawyer can act on").
-- Connect a **support** pattern to the **engineering** root cause, or a **sales**
-  commitment to the **roadmap** that has to deliver it.
+See [Retrieval stack](retrieval-stack.md).
 
-Business and engineering is one pair; the same machinery spans every domain in the
-company.
+## Typed facts
 
-- **Backed by:** a typed knowledge-graph ontology with case-based recall and
-  contradiction logic, PageRank-based context pruning, per-entity profile cards,
-  and citation-backed synthesized recall (`memory_ask`) that returns answers with a
-  confidence signal.
+Typed facts are relationship triples checked against an ontology. A relation declares allowed
+subject/object kinds, inverse or symmetry, correction policy, and sensitivity.
 
-Answers come with citations and a confidence signal, so a cross-domain conclusion
-can be traced back to the documents it was drawn from.
+Candidates pass one write gate:
 
----
+- a known relation with valid kinds can commit;
+- a kind mismatch is rejected;
+- a novel relation stays provisional until it earns promotion;
+- a failed write is deferred, never reported as stored.
 
-## 5. Delegation that cuts cost
+Provenance classes protect authority. An inferred correction cannot delete a user-stated fact.
+Superseded values remain auditable. Sensitive or unknown relations fail toward the restrictive
+context policy.
 
-A company-scale knowledge base does real work (synthesis, extraction, review, code
-changes), and that work costs inference. aimee keeps the bill down by routing each
-task to the cheapest model that can actually do it:
+Typed facts are gated by configuration. See the generated reference for the current key.
 
-- **Local models (Ollama)** cost nothing.
-- **Subscription-plan delegates** (ChatGPT Plus, `mistral-plan`) cost nothing
-  extra; you've already paid for the seat.
-- Work reaches a **pay-per-token** API only when a task needs it.
+## Memory lifecycle
 
-The router picks the cheapest capable delegate, runs it (in parallel where it
-helps), and hands the primary agent a compact result instead of making it process
-raw content, so you save both on the delegate and on the primary agent's context.
-The economics layer tracks cost and success per delegate so routing improves over
-time.
+Session context begins as local DB1 evidence. Durable, shareable knowledge belongs in DB2 after the
+owning write or promotion contract accepts it. Useful records strengthen through recall and feedback;
+stale or contradicted records can decay without deleting their history.
 
-- **Backed by:** the delegate router and economics layer (`src/server/delegate_*.c`,
-  `delegate_economics.c`); see [Setting Up Delegates](DELEGATES.md).
+Working memory is not a lower-quality KB. It is session scratch and should not be promoted by
+accident.
+
+## Commands
 
 ```bash
-aimee delegate review "Review this PR"        # cheapest capable delegate
-aimee delegate code --tools "Add tests"       # write-capable, isolated worktree
-aimee agent list                              # configured delegates + slots
+aimee memory store <kind> <text>
+aimee memory search <query>
+aimee memory list
+aimee memory get <id>
+aimee memory read
+
+aimee kb docs push <file>
+aimee kb ingest status
+aimee curator contradictions
 ```
 
----
+Remote file commands upload content from the thin client. The server never opens a path on the
+client's machine.
 
-## 6. The foundation it all rides on
+## Audit and privacy
 
-| Layer | What it gives the knowledge base |
-|-------|----------------------------------|
-| 4-tier scoped memory (L0-L3) | Fast scratch to durable facts, with automatic promotion and decay |
-| Guardrails | Sensitive-file blocking and anti-pattern detection on the hot path |
-| Session isolation | Parallel sessions in isolated git worktrees that never clobber each other |
-| Zero-cloud | Runs fully local; hosted inference is opt-in, not required |
-| Speed | Sub-10ms session start and hook checks |
+Memory mutations publish through the owning daemon's event bus. Agent-controlled keys are
+fingerprinted before audit so a key cannot inject personal data or forged log lines. The source
+record itself remains subject to its KB scope and retention policy.
 
-See the [Architecture](ARCHITECTURE.md) for how `aimee-server` (hot path, DB1) and
-`aimee-kb` (knowledge, DB2) split this work, and the [Manual](../MANUAL.md) for
-the day-to-day commands.
+External inference receives only the evidence allowed by the configured provider and egress policy.
+Run local inference when the corpus must not leave the deployment.
 
----
+## What exists now
 
-## 7. Typed facts: a validated relationship layer
-
-Beyond free-text memory, aimee can record typed facts: relationships with real
-semantics, validated before they are stored. "Alice `works_for` Acme" and "the
-laptop `device_has_ip` 10.0.0.3" are not just sentences; they are triples checked
-against an ontology of what each relation means.
-
-- **An ontology defines each relation.** A `rel_types` table is the single source
-  of truth: every relation (`works_for`, `spouse`, `lives_in`, `device_has_ip`, …)
-  declares its allowed subject/object kinds (`PERSON`, `DEVICE`, `PLACE`, `ORG`,
-  `IP`, `SCALAR`, …), whether it is symmetric, its inverse, a correction policy,
-  and a PII sensitivity tier. A seed ontology ships in code (so it works during a
-  DB outage); the live table can be extended by operators or grown automatically by
-  promotion. Nothing rejects "the printer `works_for` the kernel" today; the
-  typed-fact gate does, because the kinds don't match.
-- **The write gate is the single commit point.** Every candidate triple, from
-  pattern extraction, model rewrite, or the curator, passes through one gate before
-  it becomes a stored edge. A known relation with valid kinds is committed; a kind
-  mismatch is rejected; a relation that is novel (not in the seed) is staged
-  provisionally and counts toward promotion. A relation already active in the live
-  ontology is treated as known even if it isn't in the seed. If the write itself
-  fails, the gate reports *defer* (never a false success) so the fact is retried,
-  not silently lost.
-- **Confidence classes track provenance.** A fact a user states is **Class A**; a
-  model inference consistent with the ontology is **Class B**; a novel/speculative
-  relation is **Class C**. Classes drive decay and durability: speculative facts
-  expire if never confirmed; confirmed model facts become durable.
-- **Corrections respect authority.** Each relation has a correction policy
-  (`supersede`, `hard_delete`, or `immutable`). A model or inferred retraction can
-  never delete a user-stated (Class-A) fact; only the user can retract their own
-  facts, and a model correction that contradicts the user is refused. Retractions
-  can target a specific old value or all values of a relation, and corrected facts
-  are archived (retained and auditable), never erased.
-- **PII is gated per relation.** Each relation carries a sensitivity tier so
-  personal facts can be withheld from contexts that shouldn't see them; an
-  unknown/learned relation fails closed to the restrictive tier.
-
-Typed facts are off by default; enable them with `typed_facts_enabled: true` in
-config. Validated facts join the same `<aimee-context>` envelope as the rest of the
-knowledge base, so recall and injection are unchanged.
-
----
-
-## Where this is today vs. where it's heading
-
-The substrate is real and shipping: the four-tier memory, the curator extraction
-pipeline, the scope lattice, the typed knowledge graph and graph retrieval, idle
-reflection, calibration/bandit learning, and delegation all exist in the current
-build. The all-domain, whole-company reach, ingesting every team's documents into
-one shared graph and synthesizing freely across them, is the direction the
-architecture charts. This page describes that destination and the mechanisms
-already carrying us there; [Feature Status](STATUS.md) tracks what's live today.
+Scoped memory, typed facts, hybrid retrieval, curation, graph links, contradiction handling,
+evidence, and local inference are implemented. Connectors for every company data source and free-form
+cross-domain synthesis are not automatic; they need an ingest connector, scope policy, and evidence
+contract.

--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -1,236 +1,54 @@
 # Proposals
 
-This index reflects the actual proposal tree under
-[`docs/proposals/`](proposals/). The authoritative state is the directory
-listing itself; this file is a navigable summary of it. Ordering within a
-section does not imply global priority.
+Proposals record design decisions and delivery contracts. They are evidence, not the user manual.
 
-| State | Folder | Count |
-| --- | --- | --- |
-| Shipped | [`proposals/done/`](proposals/done/) | 210 |
-| Pending | [`proposals/pending/`](proposals/pending/) | 56 |
-| Accepted (locked, unimplemented) | `proposals/accepted/` | 0 |
-| Deferred | `proposals/deferred/` | 0 |
-| Rejected | `proposals/rejected/` | 0 |
-| Review notes | `proposals/reviews/` | 0 |
+## States
 
-> **Reconciliation note (2026-07-07).** A prior version of this index described a
-> ~40-item "charter-spine" roadmap (curator, corpus stages, cross-source learning,
-> statistical decision systems, MDL synthesis, Bayesian calibration, contextual
-> bandits, planning/MCTS/SMT, the skills library, the hermes-agent intake) and
-> claimed `done/` held 17 proposals. An audit confirmed that roadmap was **real and
-> is now shipped in code** — its proposal files were removed from the tree and the
-> index was never regenerated, so it drifted into describing an empty `accepted/`
-> folder and undercounting `done/` by ~48. This rewrite restores the index to the
-> tree. Orphaned design docs cited by shipped code are tracked under
-> [Documentation integrity](#documentation-integrity).
+- `pending/`: under design, review, implementation, or reconciliation;
+- `done/`: implemented and accepted, or preserved as the decision record for shipped work.
 
-## Governing contracts
+A pending proposal can describe code that does not exist. A done proposal can retain names or
+constraints that later changed. Current product behavior belongs in the guide for that feature.
 
-Three platform-wide contracts govern every intelligence-surface change. They are
-realized in code and enforced in review; their standalone proposal documents are
-**not currently in the tree** (see [Documentation integrity](#documentation-integrity)):
+## Required shape
 
-1. **Architecture Charter** — fixes role division across neural, symbolic,
-   statistical, planning, and deterministic passes (Recall / Rerank / Rewrite /
-   Extract / Synthesize / Judge / Reflect / Classify-Score / Plan-Search / Reason /
-   Rank-Fuse / Calibrate / Detect-Cluster / Constrain-Verify / Evaluate-Optimize /
-   Gate-Promote / Enforce), one artifact schema, one audit schema, the sidecar
-   protocol, and evaluation/calibration discipline. Any new intelligence-surface
-   proposal must name its charter role(s).
-2. **Two-DB Split** — DB1 (SQLite, local user store) and DB2 (Postgres, shared
-   knowledge store) with a tier-pinned Data Access Layer; the boundary is
-   compile-enforced. The vector tier lives **inside DB2** as a pgvector extension
-   (folded in from a former Qdrant sidecar in #1575) — vectors share the same
-   connection and transaction domain as the rows they embed. See
-   [`STORAGE_TIERS.md`](STORAGE_TIERS.md).
-3. **Memory Public Contract** — the caller-facing memory contract (scope, filters,
-   typed mutation verbs, profile packs, stable `--explain`) shared across CLI, MCP,
-   and the aimee-kb `/v1/` API.
+A proposal should state:
 
-## Pending (57)
+- problem and boundary;
+- decision and non-goals;
+- owners and dependencies;
+- threat/failure model where relevant;
+- compatibility and migration;
+- bounded slices;
+- mechanical and integration acceptance checks;
+- status and supersession links.
 
-The complete 2026-07-26 reconciliation, including source/test/commit evidence for all 79 original files, is in [`PENDING_AUDIT_2026-07-26.md`](proposals/PENDING_AUDIT_2026-07-26.md). The directory listing remains authoritative.
+Plans may live beside the proposal when execution ordering needs its own artifact. Validation reports
+belong under `docs/validation/` and must name the commit, environment, and commands they proved.
 
-- [Proposal: Agentic supervised SWE-bench — a true, tool-using, Reddit-parity claim](proposals/pending/agentic-supervised-swebench.md)
-- [Proposal: define Aimee's required core capability contract](proposals/pending/aimee-core-capability-contract.md)
-- [Proposal: appliance state-recovery runbook](proposals/pending/appliance-state-recovery-runbook.md)
-- [Proposal: Document proposal-trigger blob deduplication](proposals/pending/automatic-wfe-trigger-blob-dedup-runbook.md)
-- [Proposal: Effective agent tool scoping through aimee's existing toolset seams](proposals/pending/capability-scoped-agent-execution.md)
-- [Capability-thresholded delegate routing: residual work](proposals/pending/capability-thresholded-delegate-routing-residual.md)
-- [Proposal: the code graph should carry the architecture, not just the symbols](proposals/pending/code-graph-architecture-surface.md)
-- [Compaction quality: committed baseline](proposals/pending/compaction-quality-baseline.md)
-- [Config descriptor table: generic save residual](proposals/pending/config-field-descriptor-save-residual.md)
-- [Core substrate and module boundaries: residual work](proposals/pending/core-substrate-and-source-module-boundaries-residual.md)
-- [Proposal: a dedicated extraction model for the curator Tier-A](proposals/pending/dedicated-extraction-model-curator-tier-a.md)
-- [Proposal: Delegate sandbox — aimee-server as the sole egress](proposals/pending/delegate-sandbox-aimee-sole-egress.md)
-- [Proposal: Per-project delegate sandbox image customization](proposals/pending/delegate-sandbox-image-customization.md)
-- [Dynamic tool egress: authenticated registration identity](proposals/pending/dynamic-tool-egress-registration-identity.md)
-- [Proposal: govern and capture the module event bus as one uniform seam](proposals/pending/event-bus-governance-and-capture.md)
-- [Spec: Aimee shared-memory event bus — wire and segment specification (v0)](proposals/pending/event-bus-wire-spec.md)
-- [Proposal: audit feature liveness and remove the background skill curator](proposals/pending/feature-liveness-and-background-curator-removal.md)
-- [Proposal: front-end development module — runtime UI verification and design/visual QA](proposals/pending/frontend-development-module.md)
-- [Proposal: unify embedding + Tier-A synth on one Gemma-4 base; a dedicated EuroBERT reranker](proposals/pending/gemma4-unified-embed-rerank-synth-base.md)
-- [Git core contract: runtime adoption residual](proposals/pending/git-core-contract-runtime-residual.md)
-- [Proposal: Per-agent identity, delegation chains, fleet registry, and signed executable artifacts](proposals/pending/governance-agent-identity-and-artifact-trust.md)
-- [Proposal: Attestable enforcement — complete the WORM trust anchor and make every verdict provable](proposals/pending/governance-attestable-enforcement.md)
-- [Proposal: One governance policy surface — posture profiles, gate completion, and oversight defaults](proposals/pending/governance-policy-surface-and-posture.md)
-- [IR sole path: response and legacy-path residual](proposals/pending/ir-sole-path-residual.md)
-- [KB hybrid outcome wiring: residual work](proposals/pending/kb-hybrid-outcome-wiring-residual.md)
-- [KB ingest: content-push, default-tree indexing, and monotonic delta ordering](proposals/pending/kb-ingest-content-push-deltas.md)
-- [Proposal: deliver the modular refactor safely and measurably](proposals/pending/large-refactor-delivery-and-compatibility.md)
-- [Proposal: Local-first memory & trust patterns — concepts to adopt](proposals/pending/local-first-memory-and-trust-patterns.md)
-- [MCP adapter: general bus routing residual](proposals/pending/mcp-adapter-bus-routing-residual.md)
-- [Proposal: Memory auto-population — feedback→rules, promotion, gated extraction (Proposal 2 Phase 4)](proposals/pending/memory-auto-population-phase4.md)
-- [Proposal: unify memory, learning, skills, and inference boundaries](proposals/pending/memory-learning-and-inference-boundaries.md)
-- [Proposal: `module-loader` — load and host external and user-authored modules](proposals/pending/module-loader.md)
-- [Module runtime ownership and build: residual work](proposals/pending/module-runtime-source-ownership-and-build-residual.md)
-- [mTLS transport performance: rollout evidence](proposals/pending/mtls-transport-rollout-evidence.md)
-- [Operator audit activity: unified surface residual](proposals/pending/operator-audit-activity-residual.md)
-- [Proposal: Org-data connectors — the source-ingestion on-ramp for the every-domain KB](proposals/pending/org-data-connectors-and-source-ingestion.md)
-- [Per-query ranking feature persistence](proposals/pending/per-query-feature-persistence-residual.md)
-- [Proposal: Per-user `remote_writes` authorization](proposals/pending/per-user-remote-writes-authz.md)
-- [Persona-authored outputs: residual work](proposals/pending/persona-authored-outputs-residual.md)
-- [Proposal: split Runtime and Control Plane governance, web modules, and config surfaces](proposals/pending/product-governance-web-and-config.md)
-- [Proposal: Evidence provenance-tier contract — classify + gate Tier-3 (untrusted) memory as an anti-poisoning defense](proposals/pending/proposal-evidence-provenance-tiers.md)
-- [Proposal: Binding retrieval context-contract for agents + a survey of context-engine ideas](proposals/pending/proposal-retrieval-context-contract.md)
-- [Proposal: Proposal-supersession hygiene — same-commit move + a documented rule](proposals/pending/proposal-supersession-hygiene.md)
-- [Remote session start: workspace context residual](proposals/pending/remote-session-start-workspace-context.md)
-- [Route descriptor single source: residual work](proposals/pending/route-descriptor-single-source-of-truth-residual.md)
-- [Proposal: Standing LoCoMo / LongMemEval benchmark cadence](proposals/pending/standing-benchmark-cadence.md)
-- [Proposal: the registration chain and the static thin client](proposals/pending/thin-client-capability-advertisement.md)
-- [Tiered LLM offering: remaining program scope](proposals/pending/tiered-llm-offering-residual.md)
-- [P2b residual: KB forwarding and true streaming](proposals/pending/tiered-llm-p2b-forwarding-and-streaming.md)
-- [P6 residual: native InvokeModel families and pricing](proposals/pending/tiered-llm-p6-native-invokemodel-and-pricing.md)
-- [P9 residual: telemetry forwarding and OTLP](proposals/pending/tiered-llm-p9-forwarding-and-otlp.md)
-- [Turn-scoped change sets and safe workspace restore](proposals/pending/transactional-turn-rewind-and-session-recovery.md)
-- [User-selectable fusion: surface and policy residual](proposals/pending/user-selectable-fusion-surface-residual.md)
-- [Proposal: Close out platform phase 7 — v1 API stability tag + distributed-mode validation](proposals/pending/v1-stability-and-distributed-validation.md)
-- [Design brief: multi-engine fanout, circuit-breaking, provenance, accounting](proposals/pending/web-search-fanout-resilience-accounting.md)
-- [Proposal: webchat project lifecycle — org-scoped clones and true delete/purge](proposals/pending/webchat-project-lifecycle.md)
+## Lifecycle
 
-## Done (209)
+1. Draft in `pending/`.
+2. Review the contract before implementation.
+3. Record amendments instead of silently changing an accepted premise.
+4. Land slices with the proposal's checks.
+5. Reconcile shipped behavior, docs, and unresolved gaps.
+6. Move to `done/` when no promised slice remains pending.
+7. Link any residual proposal rather than calling partial work complete.
 
-The [`proposals/done/`](proposals/done/) directory holds 209 shipped proposals.
-Grouped by theme:
+Moving a file does not prove implementation. Acceptance commands and the integrated code do.
 
-- **Universal gateway, ingress & protocol.**
-  [universal LLM gateway](proposals/done/aimee-universal-gateway.md),
-  [canonical IR](proposals/done/aimee-canonical-ir.md),
-  [Anthropic ingress `/v1/messages`](proposals/done/anthropic-ingress.md),
-  [Codex ingress `/v1/responses`](proposals/done/codex-frontend-ingress.md),
-  [context pre-injection + confidence-gated retrieval for ingresses](proposals/done/context-preinjection-ingress.md),
-  [envelope compression + cache-prefix alignment](proposals/done/ingress-compression-and-cache-alignment.md),
-  [ingress cost accounting + request optimizations](proposals/done/ingress-cost-accounting-and-optimizations.md),
-  [`/v1` dispatch migration](proposals/done/v1-dispatch-migration.md) (+ [finish](proposals/done/v1-dispatch-migration-finish.md)),
-  [server-owned turn lifecycle](proposals/done/server-owned-turn-lifecycle.md).
-- **Economizer & context reduction.**
-  [gateway mutation / primary-agent context reduction](proposals/done/economizer-gateway-mutation.md),
-  [unified economizer with two-tier safety](proposals/done/unified-economizer-two-tier-safety.md),
-  [deterministic context folding](proposals/done/deterministic-context-folding.md),
-  [deterministic tool-output condensation](proposals/done/deterministic-tool-output-condensation.md),
-  [optimization surface](proposals/done/optimization-surface.md) (+ [residual](proposals/done/optimization-surface-residual.md)).
-- **Thin client, server, TLS & credentials.**
-  [self-sufficient thin client](proposals/done/self-sufficient-thin-client.md) (+ [data plane](proposals/done/self-sufficient-thin-client-data-plane.md)),
-  [native TLS thin-client backends](proposals/done/native-tls-thin-client-backends.md),
-  [mTLS client identity](proposals/done/mtls-client-identity.md),
-  [server-hosted OAuth CLI agents](proposals/done/server-hosted-oauth-cli-agents.md),
-  [auto vault provisioning at server standup](proposals/done/auto-vault-provisioning-at-server-standup.md),
-  [credential-vault consolidation](proposals/done/cred-vault-consolidation.md),
-  [delegate refactor — async + credential vault](proposals/done/delegate-refactor-async-and-credential-vault.md),
-  [live config reload](proposals/done/live-config-reload.md).
-- **Autonomous development, workflows & delegation.**
-  [autonomous-dev execution substrate](proposals/done/autonomous-dev-execution-substrate.md),
-  [full autonomous development](proposals/done/full-autonomous-development.md),
-  [aimee workflows — autonomy-first dev engine](proposals/done/aimee-dev-lifecycle-workflow.md),
-  [config-extensible workflow blocks](proposals/done/workflow-config-blocks.md),
-  [primary-as-manager enforced workflows](proposals/done/primary-as-manager-enforced-workflows.md),
-  [on-demand delegate execution](proposals/done/delegate-ondemand-execution.md),
-  [four-part harness taxonomy](proposals/done/four-part-harness-taxonomy.md).
-- **Roundtable, review & verification.**
-  [agent roundtable — collaborative drafting](proposals/done/agent-roundtable-collaborative-drafting.md)
-  (+ [residual](proposals/done/agent-roundtable-collaborative-drafting-residual.md),
-  [authoring pipeline](proposals/done/agent-roundtable-authoring-pipeline.md)),
-  [agent-directed PR review](proposals/done/agent-directed-pr-review.md),
-  [roundtable panel composition](proposals/done/roundtable-panel-composition.md),
-  [roundtable reliability](proposals/done/roundtable-reliability.md),
-  [replayable-evidence verification + deepening sweep](proposals/done/replayable-verification-and-deepening-sweep.md).
-- **Code-graph intelligence.**
-  [code-graph intelligence](proposals/done/code-graph-intelligence.md),
-  [graph-derived code-health audit](proposals/done/code-health-audit.md),
-  [cross-repo dependency graph](proposals/done/cross-repo-dependency-graph.md)
-  (+ [precision hardening](proposals/done/cross-repo-precision-hardening.md),
-  [recall recovery](proposals/done/cross-repo-recall-recovery.md)),
-  [C++ class/method extraction](proposals/done/cpp-class-method-extraction.md),
-  [CSS migration assistant](proposals/done/css-migration-assistant.md),
-  [graph feedback — self-audit + learning](proposals/done/graph-feedback-self-audit-and-learning.md).
-- **Knowledge base, curator & retrieval.**
-  [auditable correctness for the KB](proposals/done/auditable-correctness-for-the-kb.md),
-  [pluggable curator LLM backend](proposals/done/curator-llm-backend.md),
-  [aimee-kb LLM endpoints + default CPU container](proposals/done/kb-llm-endpoints-and-default-cpu.md),
-  [aimee-kb web console](proposals/done/kb-web-console.md),
-  [embedder runtime fetch + auto-dimension](proposals/done/embedder-runtime-fetch-autodim.md),
-  [ingest restoration + recall contract](proposals/done/ingest-restoration-and-recall-contract.md),
-  [recall economy progressive disclosure](proposals/done/recall-economy-progressive-disclosure.md),
-  [recall abstention confidence gate](proposals/done/retrieval-abstention-confidence-gate.md),
-  [typed-fact knowledge layer](proposals/done/typed-fact-knowledge-layer.md),
-  [LLM-sidecar productionization — curator extraction + idle reflection](proposals/done/llm-sidecar-productionization-curator-and-reflection.md),
-  [generalise the `memory.benchmark` RPC](proposals/done/memory-benchmark-suite-generalisation.md).
-- **Structured PDF & evidence.**
-  [structured PDF ingestion + coordinate-anchored evidence](proposals/done/structured-pdf-ingestion-and-evidence-layer.md),
-  [structured-PDF tables → typed facts, visual evidence, OCR](proposals/done/structured-pdf-tables-visual-and-ocr.md).
-- **Governance, audit & memory interception.**
-  [governance — decision records + per-action policy-verdict audit](proposals/done/governance-decision-records-and-action-audit.md),
-  [per-service auditable WORM metrics/logs store](proposals/done/auditable-worm-audit-store.md),
-  [central agent-memory interception](proposals/done/central-agent-memory-interception.md).
-- **LLM container & UI.**
-  [one unified `aimee-llm` container](proposals/done/unified-llm-container.md),
-  [webchat git projects + in-browser VSCode](proposals/done/webchat-git-projects-and-vscode.md),
-  [dedicated Proposals web page](proposals/done/proposals-ui-page.md).
+## Event-bus records
 
-For the full chronological record, see the directory listing or
-`git log -- docs/proposals/done/`.
+The detailed event-bus decisions and feature tree preserve the v0 wire, regions, leases, routing,
+flow control, capture, conformance, and performance rationale. [Event bus](EVENT_BUS.md) is the
+current reader/developer guide; use the design records only when changing those contracts.
 
-## Documentation integrity
+## Integrity
 
-Cleanup surfaced while regenerating this index:
+`make -C src proposal-links-check` checks links. Reconciliation checks catch stale states and missing
+residuals. Keep filenames stable after review so commits, audit rows, and external discussion remain
+traceable.
 
-- **`three-db-split` fully purged (this change).** The former three-tier framing
-  (DB1 / DB2 / DB3-Qdrant) is gone: the vector tier is a pgvector extension inside
-  DB2, full stop. All `docs/proposals/{accepted,pending,done}/three-db-*.md`
-  citations and `DB3` / `db3` mentions in source comments and docs were repointed
-  to [`STORAGE_TIERS.md`](STORAGE_TIERS.md) or reworded to the DB1/DB2 vocabulary.
-- **Empty state folders.** `accepted/`, `deferred/`, `rejected/`, and `reviews/`
-  contain no proposals (only `.gitkeep`). Prior index prose describing rejected /
-  deferred items and an Accepted queue has been removed as unbacked.
-- **Orphaned design docs cited by shipped, verified code.** Source headers cite
-  `docs/proposals/accepted/*.md` documents absent from the tree, even though the
-  code they describe is demonstrably shipped and tested. Verified examples:
-  - **Contextual bandits** — `db2/bandit.c` + `kb/kb_bandit.c` (789 LOC),
-    `bandit_decisions` table (`db2/schema.sql`), `test_bandit.c` +
-    `tools/bandit_replay.py`, endpoints `/v1/intelligence/bandit/{export,replay-record,sample}`.
-  - **Statistical decision systems** — `kb_ranker.c`, `kb_features.c`,
-    `kb_detect.c`, `db2/feature_rows.c`, `kb/kb_ranker_fit.c` + `scripts/rank-fit.py`
-    (the [LTR weight-fitting proposal](proposals/done/learning-to-rank-weight-fitting.md)
-    shipped the Calibrate half — fitter + benchmark gate, default-off, bench-only
-    until the outcome-wiring prerequisite).
-  - **Graph reasoning / case recall** — `kb_reasoning.c` (474 LOC), `db2/cases.sql`.
-  - **MDL-guided synthesis** — `kb_mdl.c` (239 LOC).
-  - **Deliberate planning** — `kb_planner.c` + `scripts/mcts-planner.py`.
-  - Plus `neural-assisted-guardrails`, `ingest-poison-gate` (`integrity_gate.c`),
-    `prompt-cache-aware-deferred-payload-rewrite`, `memory-public-contract`
-    (`memory_effective.c`), `aimee-kb-service-and-public-api`,
-    `aimee-unified-presence`, and the placeholder `example.md` (cited by two tests).
-  - *Stale-but-present:* `agent-roundtable-authoring-pipeline.md` exists in `done/`;
-    its `See docs/proposals/accepted/…` header just needs repointing to `done/`.
-  - Recommended follow-up: restore the orphaned design docs to `done/` as post-hoc
-    records of shipped work, or replace each header comment with the shipped
-    filename. Tracked separately from this index refresh.
-
-## Notes
-
-- The pending list is small by design. Proposals that ship move to `done/`.
-- The Architecture Charter is the review gate for any new intelligence-surface
-  proposal (neural, symbolic, statistical, planning, or deterministic): it must
-  name its charter role(s). The Memory Public Contract is the review gate for any
-  new caller-facing memory surface (CLI flag, MCP tool shape, or HTTP endpoint).
+Do not rewrite historical review findings to sound current. Add a dated correction or superseding
+record.

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,226 +1,102 @@
-# aimee-kb Public API: Stability Contract
+# Public API
 
-The **aimee-kb `/v1` HTTP API** is the sole, public, versioned interface to the
-aimee knowledge base. aimee-server is its primary client; third parties consume
-the same endpoints with no access to aimee source.
+aimee exposes two versioned HTTP surfaces:
 
-- **Source of truth:** [`api/openapi-v1.yaml`](../api/openapi-v1.yaml)
-  (OpenAPI 3.1). The running service serves the identical document at
-  `GET /v1/openapi.json` and `GET /v1/openapi.yaml`; CI checks byte-for-byte
-  parity.
-- **Human reference:** [`docs/gen/api-v1.md`](gen/api-v1.md), generated from the
-  spec (`make docs-gen`).
-- **Client SDKs:** generated under [`api/sdks/`](../api/sdks/) for eight
-  languages; see [SDKs](#sdks).
+- `aimee-server /v1` for clients, browsers, sessions, agents, tools, workflows, config, and
+  OpenAI/Anthropic-compatible ingress;
+- `aimee-kb /v1` for memory, documents, code, retrieval, curation, and KB administration.
 
-This document is the **stability contract**. It applies from the first tagged
-release; pre-release `/v1` may still iterate freely.
+The generated references are authoritative:
 
----
+- [Server and KB routes](gen/api-v1.md)
+- [`aimee-kb` OpenAPI](../api/openapi-v1.yaml)
+- [`aimee-server` OpenAPI](../api/openapi-server-v1.yaml)
+- [Route descriptor](gen/v1-route-descriptor.json)
 
-## Versioning
+## Stability
 
-- **URL-prefixed.** Every endpoint lives under `/v1`. The version is visible to
-  clients, routers, and proxies.
-- **Additive within a major.** New endpoints, new optional request fields, and
-  new response fields may be added to `/v1` at any time; these are non-breaking
-  by construction. Clients MUST ignore unknown response fields.
-- **Breaking changes get a new prefix.** A backward-incompatible change is
-  introduced as `/v2` alongside `/v1` during an overlap window. The deprecation
-  cycle for a retired major is **≥ 6 months**.
-- **Stable identifiers.** `operationId`s in the spec are stable and drive the
-  generated SDK method names; they are not renamed within a major version.
+- A stable route is prefixed with `/v1` and has a stable operation ID.
+- New routes, optional request fields, and response fields may be added within v1.
+- Clients must ignore unknown response fields.
+- A breaking request or response change uses a new major prefix with an overlap period.
+- `/v1/internal/*`, explicitly experimental operations, browser proxy routes, and diagnostic fields
+  are not public compatibility promises.
 
-What is **not** covered by the stability contract: `/v1/internal/*` routes,
-unversioned aliases, and any endpoint explicitly marked experimental in the
-spec.
-
----
+The generic `POST /v1/rpc` endpoint is retired. Use named operations.
 
 ## Transport
 
-- HTTP/1.1 and HTTP/2. JSON request/response bodies; `multipart/form-data` for
-  uploads (`POST /v1/docs`). WebSocket for live job/invalidation streams
-  (`GET /v1/jobs/{id}/stream`).
-- **TLS is required for any non-loopback bind.** Loopback / Unix-socket
-  deployments may run without TLS.
-- The service is enabled by setting `kb.api.http_port` in aimee-kb config;
-  bearer auth is enabled by setting `kb.api.bearer_token`.
+Local clients use the server Unix socket. Remote clients use HTTPS. KB traffic is HTTP inside a
+declared deployment boundary or HTTPS across hosts.
 
-### WebSocket streams (Phase-2)
+JSON is the normal body format. Upload routes accept bounded raw or multipart content as described
+by their OpenAPI operation. Streaming routes declare their framing in the generated reference.
 
-Two `/v1` endpoints upgrade to a WebSocket (RFC 6455) instead of returning a
-single JSON body. Both authenticate with the same bearer as REST routes; server
-frames are unmasked text JSON.
+Every response has a status code. Errors return a small JSON object with a stable machine signal;
+human wording may change. When present, `X-Request-ID` ties the response to logs and downstream
+calls.
 
-| Endpoint | Stream |
-|----------|--------|
-| `GET /v1/jobs/{id}/stream` | live job-status frames until the job is terminal (done/failed), then a close frame |
-| `GET /v1/events` | a `{"type":"subscribed"}` greeting, then `{"type":"invalidation","kind":...,"scope_kind":...,"scope_id":...,"ts":...}` events whenever cached retrieval state changes (a **release** is promoted/rolled back, or a **doc** is ingested) |
+Use cursors where an operation exposes pagination. Do not infer numeric offsets.
 
-The invalidation stream lets aimee-server drop cached search/entity/index
-results on signal rather than waiting for TTL expiry (the cache itself is a
-separate aimee-server concern). A client reconnects by re-opening the stream;
-the kb closes streams cleanly on shutdown. `make v1-ws-test` (a stdlib-only
-client, `src/tests/test_v1_ws.py`) exercises both against a live kb.
+## Authentication
 
----
+| Caller | Authentication |
+| --- | --- |
+| local thin client | Unix-socket filesystem ownership |
+| remote thin client | TLS pin plus bearer or mTLS client identity |
+| browser | authenticated web session and CSRF protection |
+| server → KB | configured service bearer and TLS where required |
+| workflow → resource plane | supervised local peer and narrow internal route |
 
-## Authentication & authorization
+Authentication identifies the principal. Each route then checks capabilities, scope, and write tier.
+The shared bearer is read-only; writes use a KB-signed identity and exact subject grant.
 
-There are exactly two trust boundaries (charter §Service Topology):
+Send remote bearer credentials as:
 
-| Boundary | Transport | Auth |
-|----------|-----------|------|
-| clients ↔ aimee-server | Unix socket / loopback | filesystem permissions on the socket |
-| aimee-server ↔ aimee-kb | UDS (same host) or TLS (remote) | none on UDS; **bearer token** on TLS |
-
-### Bearer tokens (remote)
-
-Send `Authorization: Bearer <token>`. A configured token may be
-**self-describing**:
-
-```
-scope:<kind>:<id>:<secret>     scoped token   (e.g. scope:project:foo:s3cr3t)
-<secret>                       unscoped/admin token (full access)
+```http
+Authorization: Bearer <token>
 ```
 
-- `<kind>` is one of `global` / `workspace` / `project` / `user`.
-- **Authentication** (does the presented secret match the configured token) is
-  separate from **authorization** (may a token scoped `<kind>:<id>` touch a
-  resource at a different scope).
-- A scoped token is denied with **403** on cross-scope access. Example: a token
-  scoped `project:X` cannot read or write artifacts at `workspace:Y`. Admin
-  (unscoped) tokens bypass the scope check.
-- The request's target scope is taken from `scope=` / `project=` / `workspace=`
-  query parameters or the `scope_kind` + `scope_id` / `scope_user` body fields.
+Do not put tokens in query strings.
 
-The pure decision logic lives in `src/kb/kb_scope.c` and is unit-tested in
-`src/tests/test_kb_scope.c`.
+## Scope and writes
 
-### Token lifecycle (v1, intentionally minimal)
+KB operations can be global, workspace, project, or user scoped. The target scope comes from the
+operation's typed fields, not from a free-form path. A scoped principal cannot cross into another
+scope even when it knows an object ID.
 
-- Opaque 256-bit tokens, base64url-encoded. aimee-kb stores only
-  `sha256(token)` + metadata; operators keep cleartext in a root-owned
-  `kb_token_file` on each aimee-server host.
-- `aimee-kb token issue` prints once; `token rotate` supports a grace window;
-  `token revoke` flips `active=false`.
-- OIDC and refresh flows are deferred to a later distributed-mode auth proposal.
+Remote writes are split into data and full authority. Data covers memory, documents, and index
+ingestion. Full also covers runner and workspace mutation. The route descriptor declares the class
+for each operation.
 
----
+File commands from a thin client upload bytes. A server route must never interpret a client path as
+a local path.
 
-## Request & response conventions
+## Discovery and health
 
-- **Errors:** standard HTTP status plus a JSON body
-  `{"error": "<message>"}`. The status code is the stable signal; the `message`
-  text may change. The per-request correlation id is returned in the
-  `X-Request-ID` response header (see below), not the body.
-- **Pagination:** opaque cursors only; responses carry `next_cursor`, pass it
-  back as `?cursor=<value>`. There are **no** numeric offsets.
-- **Observability:** every response echoes `X-Request-ID` (client-supplied or
-  server-generated as `<pid>-<counter>`), and the service logs it at INFO with
-  method, path, and status. `GET /v1/health` reports dependency status.
-- **Rate limiting:** none in v1. The scaffold exists for future per-token
-  quotas.
+Use the documented health, version, capability, and OpenAPI operations for feature detection. Do not
+derive server capability from a version string alone.
 
-### Discovery endpoints
-
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /v1/health` | liveness + dependency status |
-| `GET /v1/version` | `api_version`, `model_version`, `prompt_version` |
-| `GET /v1/capabilities` | configured extractors, normalizers, scope levels |
-| `GET /v1/openapi.json` / `GET /v1/openapi.yaml` | the live OpenAPI document |
-
----
+The running service may serve its OpenAPI document. CI checks route descriptors, handlers, and specs
+for drift. `make docs-gen-check` checks the human reference.
 
 ## SDKs
 
-Day-one SDKs are **generated from the spec**, never hand-written. They are
-**not committed**, `api/sdks/<lang>/` is gitignored and regenerated on demand
-(locally or in CI, see [`.github/workflows/sdk-gen.yml`](../.github/workflows/sdk-gen.yml)):
+SDKs are generated from OpenAPI for C, C++, C#, Go, Java, Python, Rust, and TypeScript. They are build
+artifacts, not hand-maintained clients.
 
-```
-c  cpp  csharp  go  java  python  rust  typescript
-```
-
-Regenerate them with:
-
-```sh
-scripts/gen-sdks.sh            # all languages
-scripts/gen-sdks.sh python go  # a subset
+```bash
+scripts/gen-sdks.sh
+scripts/gen-sdks.sh python go
+make -C src sdk-parity-check
+make -C src api-conformance-check
 ```
 
-The script is self-bootstrapping: it uses a system `java` if present, otherwise
-it downloads a portable Temurin JRE and the pinned `openapi-generator-cli` jar
-into `~/.cache/aimee-sdkgen` (no root required). Regenerating from an unchanged
-spec is a **byte-for-byte no-op**, so regeneration is deterministic.
+The generator and toolchain requirements live in `scripts/gen-sdks.sh`. Run live SDK smoke tests
+against the deployment before publishing an SDK package.
 
-Two gates guard the SDKs:
+## Event bus is not public HTTP
 
-- `scripts/check-sdk-parity.py`: every `operationId` in the spec is covered by
-  every generated SDK (`make sdk-parity-check`). Run after `make gen-sdks` in the
-  SDK-gen CI workflow (the SDKs are no longer committed, so this is not part of
-  the fast `make lint` target).
-- `scripts/check-api-conformance.py`: every spec path is routed by the
-  aimee-kb server (`make api-conformance-check`, wired into `make lint`).
-
-Running each SDK against a live aimee-kb is automated by `scripts/sdk-smoke.sh`
-(`make v1-sdk-smoke`): it builds a minimal consumer per language that calls the
-service through the generated client and reports PASS/SKIP/FAIL, skipping
-languages whose toolchain/deps aren't present and self-skipping when no kb is
-reachable. Run it on any host with the toolchains installed (the per-language
-list is in the script header) and point it at a deployed kb with `KB_BASE_URL` /
-`KB_BEARER_TOKEN`; no CI service required.
-
-Validated live on a Debian-12 host with all toolchains: **go, typescript,
-python, java, c, cpp, csharp PASS**; rust requires a newer cargo than Debian 12
-ships (the runner is correct and passes on cargo ≥ 1.74). The generated
-cpp-restsdk client has no bearer-auth support, so cpp is exercised against an
-unauthenticated kb. See also [Integration testing](#integration-testing).
-
----
-
-## Integration testing
-
-A language-agnostic smoke test that uses only `curl` + `jq` exercises the
-core client journey (ingest → search → fetch artifact → subscribe to the
-invalidation/job stream) against a running service:
-
-```sh
-KB_BASE_URL=http://127.0.0.1:8090/v1 \
-KB_BEARER_TOKEN=<token-if-remote> \
-  src/tests/test_v1_third_party.sh
-```
-
-It skips (exit 0, SKIP) when no service is reachable, so it is safe
-in CI; point it at a deployed aimee-kb to validate the stability contract.
-
----
-
-## Deploy modes
-
-The same `/v1` contract serves all three charter deploy modes; only the
-transport differs.
-
-| mode | aimee-kb | server ↔ kb |
-|------|----------|-------------|
-| install-today (default) | localhost | Unix socket |
-| services-split | remote | TLS + bearer |
-| full-distributed | remote Postgres too | TLS + bearer |
-
-Switching aimee-server from local to remote kb is a **config change, not a code
-change**: set `kb_client_url` to the remote kb's `https://` **origin**
-(`scheme://host:port`, without a `/v1` suffix; the client appends the versioned
-path) and `kb_client_bearer_token` to a token the remote kb accepts.
-aimee-server exports these into
-`AIMEE_KB_API_URL` / `AIMEE_KB_API_BEARER_TOKEN`, which the kb_client transport
-honors. See [`config/aimee-server.yaml.example`](../config/aimee-server.yaml.example)
-and [`config/aimee-kb.yaml.example`](../config/aimee-kb.yaml.example).
-
----
-
-## References
-
-- [`api/openapi-v1.yaml`](../api/openapi-v1.yaml): the contract.
-- [`docs/gen/api-v1.md`](gen/api-v1.md): generated reference.
+The shared-memory event bus is an intra-daemon module contract. It does not accept remote clients,
+replace route authorization, or expose capture files over `/v1`. A future external bus adapter still
+needs its own admission and public compatibility contract.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,32 +1,11 @@
-# aimee Quickstart
+# Quickstart
 
-This guide takes you from nothing to a working aimee install in four parts:
+Run the services on one machine. Install only the thin client where you write code.
 
-1. **[Run the server](#part-1-run-the-server-in-docker)**, deploy the single `aimee-server` container and let the setup wizard bring up the self-contained knowledge base and LLM for you.
-2. **[Install the Linux client](#part-2--linux-client)**, install the thin `aimee` binary, point it at your server, and set up workspaces and agents.
-3. **[Install the Windows client](#part-3--windows-client)**, same, for Windows.
-4. **[Install the macOS client](#part-4--macos-client)**, same, for macOS.
+## 1. Start the managed server
 
-The model is the same on every developer machine: **the services run in Docker (or on a Linux/macOS host); each developer installs only the thin `aimee` client and points it at the server.** The client holds no database, it talks to the server over the `/v1` HTTP API.
-
----
-
-## Part 1, Run the server (in Docker)
-
-You start **one container — `aimee-server`** — with the host Docker socket mounted. Everything else is handled in the browser: the setup wizard's **Deploy** step brings up `aimee-kb` (with its bundled PostgreSQL DB2 + pgvector) and `aimee-llm` for you, on CPU or GPU. There is no second compose command or database container.
-
-Advanced operators who prefer to run each service as its own long-lived container (the manual split stack — `deploy/compose/aimee.yaml` and friends) still can; see [1.5](#15-managing-the-stack) and [MANUAL.md](../MANUAL.md). This guide takes the self-deploying path.
-
-### Prerequisites
-
-- Docker Engine + the Docker Compose plugin (`docker compose`, v2).
-- `git`, `curl` and `jq` — used by the commands below. A stock server image may have none of them (`apt-get install git curl jq`).
-- Host Docker socket access — `compose.server-managed.yaml` mounts it so the server can launch the other containers. It's root-equivalent, so run this only on a host you trust the server on.
-- **~25 GB free disk.** Measured on a clean Debian 13 host after a full CPU deploy: 11.7 GB of images + 7 GB of volumes ≈ 19 GB of Docker data, ~20 GB total with the OS and checkout. Most of it is `aimee-llm-cpu`, an 11 GB image with the embed/rerank/synth weights **baked in** — the CPU tier downloads no models at deploy time and mounts no model volume. (The GPU `aimee-llm` image is small and fetches its tier into a volume on first boot instead.)
-- **8 GB RAM works; 16 GB is comfortable.** The model weights are mmap'd, so most of the LLM container's footprint is reclaimable page cache — on a 16 GB host the idle stack sits at ~4 GB resident plus ~5 GB cache.
-- No credentials or API keys needed for the default build.
-
-### 1.1 Start the server
+You need Docker with Compose v2. The managed server mounts the Docker socket so its browser wizard
+can start the KB and inference containers.
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
@@ -34,525 +13,243 @@ cd aimee
 docker compose -f compose.server-managed.yaml up -d
 ```
 
-Starts `aimee-server` only (webchat built in). `/v1` is on `:8743` (native TLS, self-signed; plaintext `:8740` is loopback-only, not published); webchat is on `:8443`. Nothing else is up yet.
+Open <https://localhost:8443> and sign in with:
 
-### 1.2 Run the setup wizard
-
-Open **https://localhost:8443** (accept the self-signed cert) and log in as `aimee` / `aimee-local-dev`. That single account gates the whole browser experience — the setup wizard, webchat, and the dashboards.
-
-The wizard covers:
-
-- **Primary provider** — which agent aimee drives.
-- **Knowledge base** — a local one (default), or an existing remote `aimee-kb`.
-- **Deploy topology** — where the embedder / reranker / synthesizer run (CPU by default, or a GPU).
-- **Shared store** — PostgreSQL bundled inside `aimee-kb` (default; nothing to enter), or an existing external database.
-- **Connection** — connect a git host so aimee can clone your repos. Pick one auth method and the wizard shows only its fields: **OAuth sign-in** (GitHub, GitLab, Gitea/Forgejo), an **access token** (HTTPS, any host including Bitbucket), or an **SSH key** (private key for `git@host:owner/repo.git`). Public repos clone without any of them. Optional — you can connect a host later.
-- **Workspaces & projects** — point at an owner/org, list its repos, and bulk-clone them into a workspace.
-
-The final **Deploy** launches `aimee-kb` + the LLM container and shows their status. On first boot, the KB initializes PostgreSQL inside its own container. On the default CPU topology the LLM container is `aimee-llm-cpu`, whose weights are baked into the image, so the wait is the 11 GB image pull rather than a model download; later boots are fast — state lives in named volumes.
-
-#### Your login account
-
-The browser login is a real PAM account the container creates on startup from **`AIMEE_WEBCHAT_USER`** / **`AIMEE_WEBCHAT_PASSWORD`** (defaults `aimee` / `aimee-local-dev`) — **set your own in the compose file for anything past local dev.** The username must be a valid Linux name: **lowercase letters, digits, `-`, `_`, and not starting with a digit** (so `admin` or `web-user`, not `Admin` or `bob.smith`). For more than one login, set `AIMEE_WEBCHAT_USERS` to a comma-separated `user:password` list. If a login is rejected, check the container logs for `[webchat]` lines — they report exactly which account was created or why it couldn't be.
-
-Each provisioned account is mirrored (username + its `/etc/shadow` hash, never the plaintext) to `AIMEE_HOME/webchat/logins` on the data volume and restored on every start, so browser logins survive a container rebuild or a host reboot even if the runtime stops re-injecting `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD`.
-
-### 1.3 Verify it's healthy
-
-`aimee-local-dev` is a **one-time bootstrap bearer**: it authorizes exactly one call,
-the rotation below, and nothing else. Using it on an ordinary route returns `401`
-with `"the one-time bootstrap bearer must be rotated before use"` — that is the
-expected response, not a broken server. Rotate it once, then use the token you get
-back. (`-k` accepts the self-signed cert.)
-
-```bash
-# One-time: exchange the bootstrap bearer for a real one and keep it private.
-ROTATED=$(curl -k -fsS -X POST \
-  -H 'Authorization: Bearer aimee-local-dev' -H 'Content-Type: application/json' \
-  https://localhost:8743/v1/api/rotate_bearer -d '{}' | jq -er '.bearer_token')
-(umask 077 && printf '%s\n' "$ROTATED" > .aimee-server-bearer)
-
-# Now /v1 answers. Both of these should print 200:
-curl -k -sS -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $ROTATED" \
-  https://localhost:8743/v1/health
-curl -k -sS -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $ROTATED" \
-  https://localhost:8743/v1/kb/status
+```text
+user:     aimee
+password: aimee-local-dev
 ```
 
-`aimee remote set https://<host>:8743 <token>` does this rotation for you and stores
-the result, so the thin client in [Part 2](#part-2-linux-client) needs no manual step;
-`aimee remote enroll` re-runs it on its own.
+Run the setup wizard. Choose the primary agent, CPU or GPU inference, git accounts, and workspaces.
+The final **Deploy** step starts:
 
-Until the wizard's **Deploy** step has run, `/v1/health` returns `200` but
-`/v1/kb/status` reports `"available": false` — the knowledge base container is not up
-yet. That is expected at this point. After Deploy:
+- `aimee-kb`, including private PostgreSQL 18, pgvector, and pgvectorscale;
+- `aimee-llm`, with the selected inference tier.
+
+Change `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` before exposing this host. The defaults are
+for local setup only.
+
+Check the containers:
 
 ```bash
-docker ps    # aimee-server, aimee-kb, and the LLM container
+docker compose -f compose.server-managed.yaml ps
+docker compose -f compose.server-managed.yaml logs --tail=100 aimee-server
 ```
 
-The LLM container is **`aimee-llm-cpu`** on the default CPU topology and `aimee-llm`
-when a role is placed on a GPU; both answer to the network name `aimee-llm`.
-
-### 1.4 Before you expose it on a network
-
-- **Rotate the bootstrap bearer** ([1.3](#13-verify-its-healthy)) before anything reaches the network — until you do, `/v1` is unusable anyway. For a real deployment also mount your own `aimee.yaml` at `/var/lib/aimee/aimee.yaml` with your own bearer, and terminate TLS at a reverse proxy.
-- **Remote writes are off by default, and are authorized per user.** Over the network a
-  remote bearer is **read/query only**. Holding the bearer no longer grants write
-  access to anyone: each subject that may write needs its own **write-tier grant**,
-  and the tier comes from the caller's own kb-signed identity token, not from a
-  server-wide switch.
-  - `data`, data-plane writes (`memory store`, `work …`, `rules …`, `skill …`).
-  - `full`, also exec/control (`delegate`, `agent`, `provider`, `cron`). **Trusted
-    users only**, a `full` grant permits remote code execution as that subject.
-
-  Grants live in `kb_write_tier_grant` and are administered with
-  `kb_write_tier_grant_set` / `kb_write_tier_grant_revoke` (`aimee kb grant
-  set|list|revoke --server <id> --team <n>`, local UDS only). A user obtains an
-  identity token by logging in to kb (OIDC, or PAM when no OIDC profile is
-  configured). See [UPGRADING.md](UPGRADING.md) for granting the first user, the
-  exact subject spelling, and how to tell "no grant" apart from "wrong subject".
-
-  **A grant is not enough on its own.** The server can only resolve a caller's tier
-  once it knows who it is and which keys to trust, so all three of these must be set
-  on `aimee-server` or *every* `/v1` write is denied regardless of grants:
-
-  | Variable | What it is |
-  |---|---|
-  | `AIMEE_SERVER_TEAM_ID` | the kb team this server is enrolled in |
-  | `AIMEE_SERVER_ID` | this server's id — the identity token's audience |
-  | `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE` | path to the root-owned `0600` trust bundle pinning kb's signing keys |
-
-  **`compose.server-managed.yaml` does not set these**, so a stock Docker install
-  cannot enable remote writes until you add them — see
-  [#2026](https://github.com/RakuenSoftware/aimee/issues/2026). The server says so at
-  startup, and that line is the fastest way to confirm the cause:
-
-  ```
-  ERROR server.http: AIMEE_SERVER_TEAM_ID is unset or invalid: reads continue, but
-  every /v1 write will be denied with no_team_configured until it is set to this
-  server's team id
-  ```
-
-  (Workspace registration over the network, `workspace add/serve/remove`, is a
-  deliberate, bearer-gated exception and works with no grant at all.)
-
-> **`aimee.api.remote_writes` no longer authorizes anything.** It is still parsed,
-> so an old config loads, but it grants nothing: the server warns at startup and
-> counts the requests it would formerly have allowed in
-> `remote_writes.global_ignored` (visible via `aimee api status`). If writes are
-> refused after an upgrade, the cause is a missing grant, not this setting.
-
-### 1.5 Managing the stack
+If the server must not control Docker, use the split stack instead:
 
 ```bash
-docker compose -f compose.server-managed.yaml logs -f              # server logs
-docker compose -f compose.server-managed.yaml restart aimee-server # restart the server
-docker compose -f compose.server-managed.yaml down                 # stop the server (managed containers keep running)
-docker compose -f compose.server-managed.yaml up -d --pull always  # update the server image
+docker compose -f deploy/compose/aimee.yaml up -d
 ```
 
-The wizard-deployed services (`aimee-kb`, `aimee-llm`) run as their own Docker project — use `docker ps` / `docker logs`, or re-run the wizard's **Deploy** to reconcile them after a config change. KB and embedded-DB2 state live together in the `aimee-managed-kb-home` volume; removing it erases the knowledge base.
+The old combined image is gone.
 
-Advanced: you can run each service as its own container instead of letting the server orchestrate them (`compose.server.yaml`, `compose.yaml`) — see [MANUAL.md](../MANUAL.md).
+## 2. Install the client
 
----
+Download the binary for your platform from the latest GitHub release.
 
-## Part 2, Linux client
-
-On Linux you can build and run the whole stack from source, but as a **client against a Docker/remote server** you only need the thin `aimee` binary, which talks to your `aimee-server` over `/v1`. The Linux build links OpenSSL, so it supports `https://` servers (verified against the system trust store), as do the prebuilt Windows and macOS clients via their native TLS backends (see [TLS support by build](#tls-support-by-build)).
-
-### 2.1 Install `aimee`
-
-**Option A, prebuilt binary (no build):**
+### Linux
 
 ```bash
-# Download aimee-linux-x86_64 (or aimee-linux-arm64) from the latest GitHub release, then:
-chmod +x aimee-linux-x86_64
-mkdir -p ~/.local/bin
-mv aimee-linux-x86_64 ~/.local/bin/aimee
-# ensure ~/.local/bin is on your PATH (add to ~/.bashrc / ~/.zshrc if needed):
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-**Option B, build the thin client from source** (needs a C compiler, `make`, `libsqlite3-dev`, and `zlib1g-dev`; add `libssl-dev` to keep `https://` support):
-
-```bash
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee/src
-make -j"$(nproc)" ../aimee     # produces ./aimee at the repo root
-cp ../aimee ~/.local/bin/aimee # or anywhere on your PATH
-```
-
-(Want the full server + kb running locally on this host instead of in Docker? Run `./install-deps.sh` then `./install.sh` from the checkout, that builds everything, bootstraps Postgres, and installs systemd user units. For the client-against-Docker setup in this guide, the thin client above is all you need.)
-
-Confirm the install:
-
-```bash
+install -Dm755 aimee-linux-x86_64 ~/.local/bin/aimee
+export PATH="$PATH:$HOME/.local/bin"
 aimee version
 ```
 
-### 2.2 Point the client at your server
+Use `aimee-linux-arm64` on ARM64.
+
+### macOS
 
 ```bash
-# If you have NOT rotated the bootstrap bearer yet, pass it and the client rotates
-# it for you (and pins the cert + enrols an mTLS client certificate):
-aimee remote set https://YOUR_SERVER:8743 aimee-local-dev
-
-# If you DID follow 1.3, that token is already spent — pass the rotated one instead:
-aimee remote set https://YOUR_SERVER:8743 "$(cat .aimee-server-bearer)"
-
-aimee remote status     # resolved transport + /v1/health probe
-aimee status            # server, DB1, and knowledge-base health
+install -m755 aimee-macos-universal ~/.local/bin/aimee
+xattr -d com.apple.quarantine ~/.local/bin/aimee 2>/dev/null || true
+export PATH="$PATH:$HOME/.local/bin"
+aimee version
 ```
 
-`aimee-local-dev` only works **once per server**, so passing it after a previous
-client (or [1.3](#13-verify-its-healthy)) already enrolled fails — `aimee remote set`
-exits non-zero and tells you where the real bearer is. `aimee remote status` likewise
-distinguishes "reachable but not authorized" (a bad or spent token) from unreachable,
-and exits non-zero for both, so it is safe to use as a setup check in a script.
+### Windows
 
-On a new default install, `remote set` pins the self-signed certificate, prints its
-SHA-256 fingerprint for out-of-band verification, enrolls a client mTLS identity,
-and rotates the public bootstrap bearer. `aimee-local-dev` then stops working. Use
-your provisioned token instead if the operator disabled bootstrap enrollment.
-Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`,
-or pass `--server https://YOUR_SERVER:8743 --server-token=...` per command.
-Precedence is `--server` flag > env > persisted `remote.conf`.
-
-### 2.3 Configure your AI coding tool
-
-aimee wires itself into every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot) automatically — the first `aimee` command you run registers the SessionStart / PreToolUse / PostToolUse hooks (which call `aimee`) and the `aimee mcp-serve` MCP server into each tool's user config. To do it explicitly, or from the cloned checkout at install time, run:
-
-```bash
-./configure-hooks.sh
-```
-
-Opt out of the global registration with `AIMEE_NO_CLIENT_INTEGRATIONS=1` (or set `client_integrations_enabled: false` in `aimee.yaml`); per-project wiring via `aimee setup` still works.
-
-### 2.4 Set up workspaces
-
-A workspace is a set of repositories aimee indexes and works across as one unit.
-
-```bash
-aimee workspace add /path/to/your/repo   # register this host's checkout (see the note below on indexing)
-aimee workspace list                     # list roots and the projects under each
-```
-
-You can also drop an `aimee.workspace.yaml` manifest in a directory and run `aimee setup` to clone, install dependencies, index, and generate starter rules for a multi-repo workspace in one shot, see [Workspace Management](WORKSPACES.md).
-
-> Indexing and memory writes are server-side mutations, so over the network they need a **write-tier grant of at least `data` for your own subject** (see [1.4](#14-before-you-expose-it-on-a-network)); `aimee.api.remote_writes` no longer authorizes them.
->
-> Registering a workspace is exempt and lands with no grant — but the **indexing it
-> then kicks off is not**. Without a grant `aimee workspace add` reports
-> `workspace registered`, then `index ingest batch failed … capabilities beyond the
-> presented token's scope` and `ingested 0 file(s)`, and exits non-zero. The
-> workspace is registered; nothing is indexed until a grant exists.
->
-> The `agent` family (§2.5) is exec/control rather than a data write, so it needs a
-> `full` grant — that includes reads like `aimee agent list`.
->
-> **Cloning a repo onto the server** is a browser-side operation, not a CLI one:
-> the setup wizard's *Workspaces & projects* step clones into the server's own
-> workspace tree. `aimee workspace add --repo <url>` exists only in a local
-> (same-host) install — against a remote server it refuses and points you here,
-> because the clone route requires a browser login rather than a bearer.
->
-> Without a grant these return `403 … requires capabilities beyond the presented
-> token's scope`, so on a brand-new install your first `aimee memory store` or
-> `aimee kb ingest` **will fail** until one is issued.
->
-> The server's local Unix socket is exempt (same-user trusted peer), so on a
-> single-machine install the quickest way to write is to run the command there:
->
-> ```bash
-> docker compose -f compose.server-managed.yaml exec -u aimee aimee-server \
->   aimee memory store my-key "some fact"
-> ```
->
-> For writes **from another machine**, that client's subject needs a write-tier
-> grant — `data` for memory/index writes, `full` to also allow exec/control.
-> Grants are keyed by `(server_id, team_id, subject)` and issued on the server:
->
-> ```bash
-> aimee kb grant set --subject <subject> --server <server-id> --team <team-id> --tier data
-> aimee kb grant list --server <server-id> --team <team-id>      # confirm it landed
-> ```
->
-> [UPGRADING.md](UPGRADING.md) is the reference for the two parts that are easy to
-> get wrong: how a subject is spelled for each login mode (a grant for the wrong
-> spelling is silently a grant for nobody), and why the operator installs its own
-> context with team `0`.
-
-### 2.5 Add agents (delegates)
-
-Delegates are cheaper/local models aimee routes routine work to. Configure them once:
-
-```bash
-aimee agent setup <provider>          # OAuth/device-flow setup for subscription providers (e.g. chatgpt, mistral-plan)
-aimee agent add <name> --provider openai --model <model> --api-key <key>   # direct API key
-aimee agent local local http://YOUR_LLM_HOST:8080 --model MODEL --slots 4  # local OpenAI-compatible runtime (Ollama / llama.cpp)
-aimee agent list                      # inspect registered agents + routing data
-```
-
-Agent/provider control commands are exec/control operations, so over the network they need a **write-tier grant of `full` for your subject** (see [1.4](#14-before-you-expose-it-on-a-network)). The primary agent (Claude Code, Codex, …) then routes delegateable work automatically; you can also call `aimee delegate <role> "<task>"` directly. See [Setting Up Delegates](DELEGATES.md) for the full agent schema and routing details.
-
-### 2.6 Interactive chat
-
-`aimee acp-serve` and the web chat work against a remote server. When the client is pointed at a remote `/v1` endpoint, it registers your current directory as a **detached workspace** and opens a reverse channel back to it: the agent loop runs on the server, and its file and tool actions reach back into your local working tree over that channel. The client still holds no engine and no database, it renders the session and serves its own tree. Run `aimee chat` from inside the repository you want the agent to work in.
-
-Because `launch`/`chat` are exec/control operations, a remote session needs a **write-tier grant of `full` for your subject** (see [1.4](#14-before-you-expose-it-on-a-network)). You can also drive aimee from your AI coding tool (configured in [2.3](#23-configure-your-ai-coding-tool)), or use the browser webchat at `https://YOUR_SERVER:8443`.
-
----
-
-## Part 3, Windows client
-
-On Windows aimee runs as the **thin client only**: a single `aimee.exe` that talks to your remote `aimee-server` over `/v1`. The server and kb run in Docker (Part 1) or on a Linux/macOS host, never on Windows.
-
-> **TLS note:** the Windows client now speaks `https://` natively via **Schannel**, verifying the chain and hostname against the **Windows certificate store**, no OpenSSL and no bundled CA bundle, just the single self-contained `aimee.exe`. Both the prebuilt release binary and the `install.ps1` build enable it. Set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert.
-
-### 3.1 Install `aimee.exe`
-
-**Option A, prebuilt binary (no build):**
-
-1. Download **`aimee-windows-x86_64.exe`** from the [latest GitHub release](https://github.com/RakuenSoftware/aimee/releases).
-2. Rename it to `aimee.exe` and put it in a folder on your `PATH` (e.g. `%LOCALAPPDATA%\aimee\bin`, then add that folder to your user PATH).
-
-**Option B, build from source** (needs Git, CMake, and a C compiler, Visual Studio Build Tools `cl.exe` or MinGW `gcc`):
-
-```powershell
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee
-.\install.ps1
-```
-
-`install.ps1` builds the thin client and installs it to `%LOCALAPPDATA%\aimee\bin`, adding that directory to your user `PATH`.
-
-**Open a new PowerShell or Command Prompt** so the PATH change takes effect, then confirm:
+Rename the download to `aimee.exe`, put it in a directory on `PATH`, then open a new PowerShell:
 
 ```powershell
 aimee version
 ```
 
-### 3.2 Point the client at your server
+The client is DB-free. It does not need PostgreSQL, SQLite, the KB, or model libraries.
 
-```powershell
-aimee remote set https://YOUR_SERVER:8743 aimee-local-dev
-aimee remote status     # shows the resolved transport + a /v1/health probe
-aimee status            # server, DB1, and knowledge-base health
-```
+## 3. Enroll the client
 
-Use your real bearer token instead of `aimee-local-dev` if you changed it. The server's `/v1` is TLS-only off-loopback; `https://` works with certificate verification on by default (Schannel against the Windows cert store), so set `AIMEE_TLS_INSECURE=1` for the auto-provisioned self-signed cert (or trust/pin it). Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` environment variables, or pass `--server https://YOUR_SERVER:8743 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
-
-### 3.3 Configure your AI coding tool
-
-aimee wires itself into every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot) automatically — the first `aimee.exe` command registers the SessionStart / PreToolUse / PostToolUse hooks (which call `aimee.exe`) and the `aimee mcp-serve` MCP server into each tool's user config. To do it explicitly, run:
-
-```powershell
-.\configure-hooks.ps1
-```
-
-Opt out of the global registration with `AIMEE_NO_CLIENT_INTEGRATIONS=1` (or set `client_integrations_enabled: false` in `aimee.yaml`); per-project wiring via `aimee setup` still works.
-
-### 3.4 Set up workspaces
-
-A workspace is a set of repositories aimee indexes and works across as one unit.
-
-```powershell
-aimee workspace add C:\path\to\your\repo   # register this host's checkout (see the note below on indexing)
-aimee workspace list                            # list roots and the projects under each
-```
-
-> Indexing and memory writes are server-side mutations, so over the network they need a **write-tier grant of at least `data` for your own subject** (see [1.4](#14-before-you-expose-it-on-a-network)); `aimee.api.remote_writes` no longer authorizes them.
->
-> Registering a workspace is exempt and lands with no grant — but the **indexing it
-> then kicks off is not**. Without a grant `aimee workspace add` reports
-> `workspace registered`, then `index ingest batch failed … capabilities beyond the
-> presented token's scope` and `ingested 0 file(s)`, and exits non-zero. The
-> workspace is registered; nothing is indexed until a grant exists.
->
-> The `agent` family (§2.5) is exec/control rather than a data write, so it needs a
-> `full` grant — that includes reads like `aimee agent list`.
->
-> **Cloning a repo onto the server** is a browser-side operation, not a CLI one:
-> the setup wizard's *Workspaces & projects* step clones into the server's own
-> workspace tree. `aimee workspace add --repo <url>` exists only in a local
-> (same-host) install — against a remote server it refuses and points you here,
-> because the clone route requires a browser login rather than a bearer.
->
-> Without a grant these return `403 … requires capabilities beyond the presented
-> token's scope`, so on a brand-new install your first `aimee memory store` or
-> `aimee kb ingest` **will fail** until one is issued.
->
-> The server's local Unix socket is exempt (same-user trusted peer), so on a
-> single-machine install the quickest way to write is to run the command there:
->
-> ```bash
-> docker compose -f compose.server-managed.yaml exec -u aimee aimee-server \
->   aimee memory store my-key "some fact"
-> ```
->
-> For writes **from another machine**, that client's subject needs a write-tier
-> grant — `data` for memory/index writes, `full` to also allow exec/control.
-> Grants are keyed by `(server_id, team_id, subject)` and issued on the server:
->
-> ```bash
-> aimee kb grant set --subject <subject> --server <server-id> --team <team-id> --tier data
-> aimee kb grant list --server <server-id> --team <team-id>      # confirm it landed
-> ```
->
-> [UPGRADING.md](UPGRADING.md) is the reference for the two parts that are easy to
-> get wrong: how a subject is spelled for each login mode (a grant for the wrong
-> spelling is silently a grant for nobody), and why the operator installs its own
-> context with team `0`.
-
-### 3.5 Add agents (delegates)
-
-Delegates are cheaper/local models aimee routes routine work to. Configure them once:
-
-```powershell
-aimee agent setup <provider>          # OAuth/device-flow setup for subscription providers (e.g. chatgpt, mistral-plan)
-aimee agent add <name> --provider openai --model <model> --api-key <key>   # direct API key
-aimee agent local local http://YOUR_LLM_HOST:8080 --model MODEL --slots 4  # local OpenAI-compatible runtime (Ollama / llama.cpp)
-aimee agent list                      # inspect registered agents + routing data
-```
-
-Agent/provider control commands are exec/control operations, so over the network they need a **write-tier grant of `full` for your subject** (see [1.4](#14-before-you-expose-it-on-a-network)). The primary agent (Claude Code, Codex, …) then routes delegateable work automatically; you can also call `aimee delegate <role> "<task>"` directly.
-
-### 3.6 Interactive chat
-
-`aimee acp-serve` and the web chat work against a remote server. Pointed at a remote `/v1` endpoint, the client registers your current directory as a **detached workspace** and opens a reverse channel: the agent runs on the server while its file and tool actions reach back into your local working tree (the reverse channel is supported on the Windows client). Run `aimee chat` from inside the repository you want the agent to work in.
-
-Because `launch`/`chat` are exec/control operations, a remote session needs a **write-tier grant of `full` for your subject** (see [1.4](#14-before-you-expose-it-on-a-network)). You can also drive aimee from your AI coding tool (configured in [3.3](#33-configure-your-ai-coding-tool)), or use the browser webchat at `https://YOUR_SERVER:8443`.
-
----
-
-## Part 4, macOS client
-
-macOS uses the same **thin client** model as Linux and Windows: install `aimee`, point it at your Docker/Linux server, and set up workspaces and agents.
-
-### 4.1 Install `aimee`
-
-**Option A, prebuilt binary (no build):**
+Use the server URL and the one-use bootstrap bearer:
 
 ```bash
-# Download aimee-macos-universal from the latest GitHub release, then:
-chmod +x aimee-macos-universal
-xattr -d com.apple.quarantine aimee-macos-universal 2>/dev/null || true   # clear Gatekeeper quarantine
-mkdir -p ~/.local/bin
-mv aimee-macos-universal ~/.local/bin/aimee
-# ensure ~/.local/bin is on your PATH (add to ~/.zshrc if needed):
-export PATH="$HOME/.local/bin:$PATH"
+aimee remote set https://server.example:8743 aimee-local-dev
+aimee remote status
 ```
 
-The prebuilt macOS binary is a universal (arm64 + x86_64) build and speaks `https://` natively via **Secure Transport**, evaluating trust against the **Keychain**, no OpenSSL and no bundled CA bundle. Set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert.
+`remote set`:
 
-**Option B, build the thin client from source** (needs Xcode Command Line Tools + CMake; TLS uses Secure Transport/Keychain, so no OpenSSL is required):
+1. connects to the private server certificate;
+2. prints and stores its fingerprint;
+3. trades the bootstrap bearer for a deployment bearer;
+4. enrolls an individual mTLS certificate on Linux;
+5. writes private state to `~/.config/aimee/remote.conf`.
+
+Verify the fingerprint against the server through a second channel. Do not accept an unexpected
+change. The bootstrap bearer stops authorizing ordinary routes after enrollment.
+
+For a self-signed certificate during local setup, set `AIMEE_TLS_INSECURE=1` only for the enrollment
+command. The stored fingerprint is the trust anchor after that. Do not leave insecure TLS enabled.
+
+macOS uses Secure Transport and Windows uses Schannel. Automatic CSR enrollment is currently the
+Linux path; configure the client certificate explicitly on the other platforms when the server
+requires mTLS.
+
+## 4. Verify the stack
 
 ```bash
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee
-cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
-      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=ON \
-      -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"   # drop for a host-arch-only build
-cmake --build build --target aimee
-cp build/aimee ~/.local/bin/aimee      # or anywhere on your PATH
+aimee status       # server, DB1, and KB health
+aimee kb status    # detailed store, vector, ingest, and curator state
+aimee audit verify
 ```
 
-(Want the full server + kb running locally on the Mac instead of in Docker? Run `./install-deps.sh` then `./install.sh`, that builds everything and registers launchd agents. For the client-against-Docker setup in this guide, the thin client above is all you need.)
+### Remote write setup
 
-Confirm the install:
+The rotated shared bearer authorizes reads only. Remote writes need a short-lived, KB-signed user
+identity and a grant keyed by `(server_id, team_id, subject)`. The server must also have these set:
+
+- `AIMEE_SERVER_ID`;
+- `AIMEE_SERVER_TEAM_ID`;
+- `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE`, pointing to the root-owned trust bundle for the KB signing
+  keys.
+
+The stock managed compose file does not set them. It remains remotely read-only until the server is
+enrolled with the KB and these values are added. A local Unix-socket operator cannot be locked out.
+
+Grant administration is local-socket only. Run it on the server, using the exact subject returned by
+the user's PAM or OIDC login:
 
 ```bash
-aimee version
+aimee kb grant set --server <server-id> --team <team-id> --subject <subject> --tier data
+aimee kb grant show --server <server-id> --team <team-id> --subject <subject>
 ```
 
-### 4.2 Point the client at your server
+Use `data` for memory, document, and index writes. Use `full` only for users who also need agent,
+delegate, runner, or workspace-control operations. See [Upgrading](UPGRADING.md#restore-remote-writes)
+for subject forms, first-grant recovery, and refusal reasons.
+
+After the grant and user login, test a durable write and read:
 
 ```bash
-aimee remote set https://YOUR_SERVER:8743 aimee-local-dev
-aimee remote status     # resolved transport + /v1/health probe
-aimee status            # server, DB1, and knowledge-base health
+aimee memory store quickstart "Enrollment works"
+aimee memory search "Enrollment works"
 ```
 
-Both the prebuilt universal binary and a source build speak `https://` with certificate verification on by default (Secure Transport against the Keychain); set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. As on the other platforms, you can use `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` or `--server` instead of `aimee remote set`.
+`aimee.api.remote_writes` is a retired global authorizer. It remains parsed for compatibility, but
+changing it does not make this write succeed.
 
-### 4.3 Configure your AI coding tool
+## 5. Add a workspace
 
-aimee registers its hooks + MCP server into every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot) automatically on the first `aimee` command. To do it explicitly, run:
+Run this on the machine that holds the source tree:
 
 ```bash
-./configure-hooks.sh
+cd /path/to/project
+aimee workspace add .
+aimee index scan .
+aimee index overview
+aimee index find main
 ```
 
-Opt out of the global registration with `AIMEE_NO_CLIENT_INTEGRATIONS=1` (or `client_integrations_enabled: false` in `aimee.yaml`); per-project wiring via `aimee setup` still works.
+The client uploads content to the server and KB. The remote server never reads `/path/to/project`
+directly.
 
-### 4.4 Set up workspaces
+Workspace registration itself is bearer-gated and can succeed without a grant. Its index upload
+cannot: without `data`, `workspace add` reports the registered workspace, then exits non-zero after
+ingesting zero files. Run the index commands after the grant.
+
+Large repositories ingest in chunks. Use `aimee kb status` and `aimee kb ingest status` to follow
+the queue.
+
+## 6. Connect a coding tool
+
+Client setup registers the local MCP server and supported hooks. To keep global tool configuration
+unchanged:
 
 ```bash
-aimee workspace add /path/to/your/repo   # register this host's checkout (see the note below on indexing)
-aimee workspace list
+export AIMEE_NO_CLIENT_INTEGRATIONS=1
 ```
 
-You can also drop an `aimee.workspace.yaml` manifest in a directory and run `aimee setup` to clone, install dependencies, index, and generate starter rules for a multi-repo workspace in one shot, see [Workspace Management](WORKSPACES.md). As on the other platforms, indexing/memory writes require a **write-tier grant of at least `data`** for your subject.
+For manual MCP setup, use a stdio server with:
 
-### 4.5 Add agents (delegates)
+```text
+aimee mcp-serve
+```
+
+The process inherits the enrolled remote target. It exposes memory, index, delegation, and other
+allowed tools while all state remains on the server.
+
+Use `aimee api status` for OpenAI- or Anthropic-compatible endpoint snippets. ACP editors use the
+ACP bridge. The removed `aimee chat` TUI is not part of current builds.
+
+## 7. Add delegates
+
+List the seeded roster:
 
 ```bash
-aimee agent setup <provider>          # OAuth/device-flow for subscription providers
-aimee agent add <name> --provider openai --model <model> --api-key <key>
-aimee agent local local http://YOUR_LLM_HOST:8080 --model MODEL --slots 4   # local Ollama / llama.cpp
 aimee agent list
+aimee provider list --available
 ```
 
-Agent/provider control over the network requires a **write-tier grant of `full`** for your subject. See [Setting Up Delegates](DELEGATES.md) for the full agent schema and routing details.
+Remote agent and delegate commands require a `full` grant, including `aimee agent list`.
 
-### 4.6 Interactive chat
-
-As on the other platforms, `aimee acp-serve` and the web chat work against a remote server: the client registers your current directory as a **detached workspace** and opens a reverse channel, so the agent runs server-side while its file and tool actions act on your local tree. Run `aimee chat` from inside the repository you want the agent to work in, with a **write-tier grant of `full`** for your subject (see [1.4](#14-before-you-expose-it-on-a-network)). You can also drive aimee from your AI coding tool, or use the browser webchat at `https://YOUR_SERVER:8443`.
-
-To verify that the client sends local document bytes to the remote KB—the server
-does not need access to the client's filesystem—stage a small document twice and
-confirm the second upload is deduplicated:
+Probe an agent before relying on it:
 
 ```bash
-aimee kb docs push --scope onboarding README.md
-aimee kb docs push --scope onboarding README.md # reports the document skipped
-aimee memory store onboarding.check "remote memory is working" --tier L2 --kind fact
-aimee memory search "remote memory"
+aimee agent probe <name>
 ```
 
-`kb docs push` stages corpus documents for review/release processing. Its upload
-counter and second-run skip counter validate transport and content deduplication;
-staging does not make a document immediately searchable.
+Run one task:
 
----
+```bash
+aimee delegate review --persona reviewer "Review the current diff"
+```
 
-## Where things live
+Local API or OAuth credentials belong in the server vault, not `agents.json` or the project:
 
-| Path | What |
-|------|------|
-| `<aimee_home>/remote.conf` | Persisted thin-client remote target (`aimee remote set`). `aimee_home` is `~/.config/aimee` on Linux/macOS; `%LOCALAPPDATA%\aimee` on Windows. |
-| `aimee.yaml` | Server config (bearer, `remote_writes`, kb wiring, agents). In Docker this is inside the `*-home` volume at `/var/lib/aimee/aimee.yaml`. |
-| Named Docker volumes | `*-kb-home` (KB + embedded DB2), `*-server-home`, and `*-workspaces`. A downloadable LLM service also uses `*-llm-models` for its GGUF cache. |
+```bash
+aimee vault unlock
+aimee vault set <agent> <credential-name> <secret>
+```
 
-## TLS support by build
+See [Delegates](DELEGATES.md) for local endpoints, API providers, CLI agents, roles, and sandbox
+policy.
 
-Every supported client now speaks `https://`, each using its platform's native trust store, no bundled CA bundle. Certificate verification is on by default; set `AIMEE_TLS_INSECURE=1` to skip it for a self-signed dev cert.
+## 8. Back up before changing topology
 
-| Client | `https://` support | TLS backend / trust store |
-|--------|--------------------|---------------------------|
-| Linux, prebuilt release binary or `make` build | Yes | OpenSSL, system trust store |
-| macOS, prebuilt `aimee-macos-universal` or source build | Yes | Secure Transport, Keychain |
-| Windows, prebuilt or `install.ps1` build | Yes | Schannel, Windows certificate store |
+The embedded KB database lives in the KB home volume. Export it before moving to external
+PostgreSQL or replacing compose files:
 
-For per-client cryptographic identity (beyond a shared bearer), the server also supports **mTLS client certificates**, clients present a cert from `<aimee_home>/tls/client.{crt,key}` and the server maps it to a `cert:<CN>` principal. Issue and manage them with the `aimee cert` CLI (`/v1/cert/issue|list|revoke`); see the [Manual](../MANUAL.md) for setup.
+```bash
+./deploy/container/aimee-kb-db-export.sh --help
+```
 
-## Next steps
+Also back up `~/.config/aimee/` from the server volume. Never run `docker compose down -v` while a
+named volume is your only copy.
 
-- **[Manual](../MANUAL.md)**, the complete command and configuration reference.
-- **[Workspace Management](WORKSPACES.md)**, manifests, multi-repo workspaces, session isolation.
-- **[Setting Up Delegates](DELEGATES.md)**, configure delegate agents and routing.
-- **[Architecture](ARCHITECTURE.md)**, processes, storage boundaries, and deployment topologies.
-- **Run on any model**, point Claude Code (`aimee claude-proxy enable`), Codex, or any OpenAI-compatible tool at aimee and run every turn on your chosen primary model; see the [README](../README.md#any-model-behind-your-front-end).
-- **Get help**, join the official aimee Discord at <https://discord.gg/FjGjvcgAqz> for questions and discussion.
+## Service commands
+
+```bash
+docker compose -f compose.server-managed.yaml ps
+docker compose -f compose.server-managed.yaml logs -f
+docker compose -f compose.server-managed.yaml restart
+docker compose -f compose.server-managed.yaml down
+```
+
+`down` keeps named volumes. `down -v` deletes them.
+
+## Next
+
+- [Manual](../MANUAL.md)
+- [Event bus](EVENT_BUS.md)
+- [Security](SECURITY.md)
+- [Workflows](WORKFLOWS.md)
+- [What's new since v0.2.192](WHATS_NEW.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,73 @@
+# Documentation
+
+Start here:
+
+| If you want to… | Read |
+| --- | --- |
+| install aimee | [Quickstart](QUICKSTART.md) |
+| deploy or upgrade services | [Deployment](DEPLOYMENT.md) and [upgrading](UPGRADING.md) |
+| use the CLI and browser | [Manual](../MANUAL.md) |
+| understand the system | [Architecture](ARCHITECTURE.md) |
+| understand the new runtime spine | [Event bus](EVENT_BUS.md) |
+| configure a deployment | [Settings](SETTINGS.md) and [generated configuration](gen/configuration.md) |
+| call the API | [Public API](PUBLIC_API.md) and [generated routes](gen/api-v1.md) |
+| find a command | [Generated command reference](gen/cli-commands.md) |
+| operate delegates and workflows | [Delegates](DELEGATES.md), [sandbox](DELEGATE_SANDBOX.md), and [workflows](WORKFLOWS.md) |
+| understand memory and retrieval | [Knowledge](KNOWLEDGE.md), [curator](CURATOR_PIPELINE.md), and [retrieval](retrieval-stack.md) |
+| check support or feature state | [Compatibility](COMPATIBILITY.md) and [status](STATUS.md) |
+| diagnose a failure | [Troubleshooting](TROUBLESHOOTING.md) |
+| upgrade from the last release | [What's new](WHATS_NEW.md) |
+| work on aimee itself | [Technical reference](../src/README.md) and [owners](../OWNERS.md) |
+
+## Product guides
+
+- [Code intelligence](CODE_INTELLIGENCE.md)
+- [Roundtables](ENSEMBLE.md)
+- [Workflows](WORKFLOWS.md) and [workflow actions](WORKFLOW_ACTIONS.md)
+- [Autonomous development](AUTONOMOUS_DEVELOPMENT.md)
+- [Workspaces](WORKSPACES.md)
+- [Personas](personas.md)
+- [Anchored editing](anchored-editing.md)
+- [Structured PDF ingestion](STRUCTURED_PDF.md)
+- [KB inference](KB_LLM_BACKENDS.md) and [synthesis tiers](AIMEE_KB_SYNTH_TIERS.md)
+- [Embedder selection](embedder-sweep.md)
+- [CSS render sidecar](../deploy/css-render/README.md)
+- [Browser workspace](DASHBOARD.md), [VS Code](VSCODE.md), and [KB console](KB_CONSOLE.md)
+
+## Security and operations
+
+- [Security model](SECURITY.md)
+- [Storage ownership](STORAGE_TIERS.md)
+- [Thin clients](THIN_CLIENT.md)
+- [Web git security](WEBCHAT_GIT_SECURITY.md)
+- [Sandbox verification](DELEGATE_SANDBOX_VERIFY.md)
+- [Benchmarks](BENCHMARKS.md)
+- [Vault key rotation](runbooks/vault-master-key-rotation.md)
+- [Witness evidence and egress gate](runbooks/witness-evidence-and-egress-gate.md)
+- [Workflow autonomy](wfe-autonomy-runbook.md)
+
+## Engineering
+
+- [Module contracts](modules/README.md)
+- [Technical reference](../src/README.md)
+- [Go rewrite direction](dev/GO_REWRITE.md)
+- [Workflow ownership](dev/WFE_OWNERSHIP.md)
+- [Sanitizer call-site register](SANITIZER_CALL_SITES.md)
+- [Route parity](v1-op-parity-buildout.md)
+- [Lean refactor audit](lean-refactor-audit.md)
+- [Refactor baselines](refactor-baselines.md)
+
+## Source of truth
+
+Generated files under `docs/gen/` come from the command registry, configuration descriptors, and
+route descriptors. Change the source, then run:
+
+```bash
+make -C src docs-gen
+make -C src docs-gen-check
+```
+
+`docs/proposals/` records design work. A file under `done/` explains why a feature was built; it is
+not the user manual. A file under `pending/` may describe work that has not shipped. Benchmark and
+validation reports preserve the conditions and results of a particular run. Current behavior lives
+in the guides above and, finally, in the code and generated references.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,176 +1,53 @@
-# Roadmap: storage, retrieval, curator, operational closeouts
+# Roadmap
 
-This document captures the current ordered plan for the storage-layer
-maturation and the retrieval/curator arc built on top of it, *in what order*
-to land the work.
+This is the remaining direction after v0.2.192. Accepted implementation detail lives in proposals;
+current behavior lives in product guides and generated references.
 
-Last revised: 2026-04-29.
+## 1. Finish the event-bus move
 
-## Single thread
+- route workflow trigger firings through the bus;
+- land external inline client attachment with admission and lifecycle proof;
+- move the remaining inter-module observability paths off private callbacks;
+- add uniform pre-delivery policy for action-class events;
+- expose bounded telemetry without granting another full-stream observer;
+- keep module replay separate from observational capture.
 
-aimee is walking a deliberate line: **one owner per storage tier, one
-typed API per owner, and no backend knowledge outside the owning
-directory.** DB1 owns local user/session state for the local
-`aimee-server`; DB2 owns durable project/workspace/global knowledge plus
-the dense vector indexes derived from it (pgvector extension, in-process).
-DB2 can be local or shared depending on the `aimee-kb` deployment, so
-promotion into DB2 must match the configured KB scope. With that boundary
-treated as the baseline, the deep-curator
-work takes the next natural step: lift curator + knowledge into
-`aimee-kb` behind a versioned public HTTP API. Dynamic-alpha fusion and
-ingest-lab are retrieval-quality polish on that stack. Three
-operational closeouts need calendar time and run in parallel, with the
-**working profile** earmarked as the proving ground for the
-retroactive-review pattern the curator depends on.
+## 2. Complete module ownership
 
-## Critical path: in flight
+- finish source-module decomposition and public headers;
+- make descriptors own dependencies, config, routes, capabilities, and event kinds;
+- remove retired C workflow code and arbitrary plugin-loader residue;
+- keep C/Go conformance and one writer during every migration.
 
-### Storage-boundary enforcement
+## 3. Continue the Go service cutover
 
-The DB1 sqlite / DB2 postgres storage split landed; the vector tier,
-originally a separate Qdrant sidecar, was folded into DB2 as a pgvector
-extension (#1575) so vectors live in the same Postgres instance as the
-rest of DB2 knowledge. The active work is no longer subsystem migration
-planning; it is boundary enforcement and cleanup. Each storage tier
-already has an owning source directory (`src/db1/`, `src/db2/`), and the
-current audit removes stale public surface, docs, comments, route names,
-config names, and lifecycle calls that would let old ownership
-assumptions re-enter.
+- move remaining DB1 API families behind one Go owner at a time;
+- isolate provider, policy, vault, and tool resources before changing ownership;
+- preserve `/v1` compatibility and crash recovery;
+- keep native code only where the boundary and evidence justify it.
 
-- **DB1:** keep user-local/session-local state behind `src/db1/`.
-- **DB2:** keep project, workspace, and global knowledge, including
-  the dense vector indexes (pgvector tables) derived from it, behind
-  `src/db2/`; `aimee-kb` owns DB2 lifecycle outside shutdown/startup
-  unwind. Vector transport (`src/db2/pgvec_*.c`) sits inside DB2 since
-  pgvector is a Postgres extension running in-process; there is no
-  separate sidecar.
-- **Guards:** `scripts/check_tier_deps.sh` is the executable contract
-  for the split and should grow whenever the audit removes another
-  stale surface.
+## 4. Close distributed trust
 
-Greenfield rule: once a boundary is clean, do not add compatibility
-branches, migration-era aliases, or backend-named public surfaces. They
-count as debt to delete, not steady-state architecture.
+- finish per-user remote-write rollout and grant tooling;
+- harden mTLS enrollment on macOS and Windows;
+- complete external witness/anchor operations and operator evidence surfaces;
+- keep egress, budgets, catalogs, and identity consistent across server and KB.
 
-## Parallel to Boundary Enforcement
+## 5. Recovery and operations
 
-These land alongside storage-boundary enforcement and do **not** depend
-on its completion.
+- transactional turn rewind and browser recovery;
+- appliance state recovery runbooks;
+- config descriptor and route descriptor completion;
+- repeatable restore, scale, and failure-injection gates;
+- honest health for every optional inference or sidecar dependency.
 
-### Phase 0 of deep-curator: embedder-sidecar retrieval lift
+## 6. Knowledge breadth
 
-Carve-out from the full curator work. Ships the MiniLM sidecar and
-`aimee kb repair` against the current KB pipeline. Target: raise
-`kb_search` mean P@5 from 0.268 → ≥ 0.45 on the 44-query POC set.
-Reversible in one config flip + repair. This is the single biggest
-near-term retrieval win.
+- organization data connectors with scope and provenance;
+- curator extraction quality and benchmark cadence;
+- retrieval fusion selection and evidence contracts;
+- better code-graph architecture surfaces;
+- corpus-scale indexing without weakening scope or citation.
 
-### Operational closeouts: calendar-bound, scheduled
-
-Each of these now has a named owner, a week-by-week schedule, and a
-**close-or-promote deadline** so they stop accumulating in `pending/`
-indefinitely.
-
-- **Working profile:** Baseline 2026-04-22, first-field enablement 2026-05-20, dogfood
-  decision 2026-06-20, close-by 2026-06-30. **Also the proving ground
-  for the retroactive-review pattern** before deep-curator generalises
-  it.
-- **Dogfood auto-label:** Flag flips start 2026-04-22, first month-end artefact 2026-05-07,
-  derived PR 2026-05-21, close-by 2026-06-07.
-- **Learning-signals router phase 2 fixtures:** Labelled corpus 2026-05-22, first detectors land, simulation traces
-  by 2026-06-22, close-by 2026-07-15.
-
-### Ingest-lab (read-only tooling surface)
-
-The validation-surface / strategy-comparison half is pure tooling that
-does not write to DB2; it can ship against the current KB pipeline. The
-DB2-facing parts (facet writes, canonical text promotion) wait on an
-explicit DB2 ingestion contract.
-
-## Gated on Storage-Boundary Enforcement
-
-### aimee-kb service + public API: platform phases
-
-Platform half of the former deep-curator work. Owns process split,
-`/v1/` API, OpenAPI, SDKs, install-today profile picker, corpus
-staging. Phased:
-
-1. Service scaffold + OpenAPI v1 skeleton.
-2. Install-today profile picker.
-3. Ingest normalization + `POST /v1/docs`.
-4. Corpus staging + release gating.
-5. Retrieval endpoints (served against artifacts from the extraction
-   work below).
-6. Reflection HTTP surface. Gated on the working-profile operational
-   cycle above (proving ground for the retroactive-review pattern).
-7. Distributed-mode validation + v1 API stability tag.
-
-### Deep-curator doc + code extraction: neural phases
-
-Neural half of the former deep-curator work. Runs inside the
-aimee-kb service above. Phased:
-
-1. Curator infra + schema + embedder sidecar inside aimee-kb.
-2. `extract_doc` + N-attempt reducer. Publishes `doc_summary` +
-   `claim`; feeds `POST /v1/search`.
-3. `resolve_entities` + canonical entity graph + mention links.
-4. `cognify_code_unit` structural stage. Feeds `/v1/code/*`.
-5. `cognify_code_unit` semantic stage + `implements` links. Feeds
-   `/v1/implements`.
-6. `detect_contradictions`. Feeds `/v1/contradictions`.
-7. `synthesize_topic`. Feeds `/v1/synthesize`.
-
-### Dynamic-alpha KB fusion
-
-**Conditional.** Runs only if the Stage-A offline benchmark on aimee's
-own corpus beats the retrieval-quality bar set by deep-curator Phases
-0 + 2 + 4. Not a default flip; gated on evidence.
-
-## Independent feature stream
-
-### Conversation branching
-
-Moved from `accepted/` to `pending/`. Dependencies (slash-commands,
-worktree) have both landed, so it is technically unblocked, but it has
-been accepted-and-dormant; the move back to pending reflects that
-status honestly and leaves the decision to pick it up to whoever has
-the cycles.
-
-## Cross-cutting items not yet tracked
-
-The following are real gaps that are not tracked anywhere yet. Each deserves an
-owner when someone is ready to pick it up.
-
-- **Developer onboarding:** as external services accumulate (DB2 with
-  pgvector, Python embedder sidecar, LLM endpoint for curator), the
-  "fresh-Debian to green-test-suite" story stops fitting in anyone's
-  head. A `setup.sh` that handles all of it is worth a week of effort
-  and has no technical blocker.
-- **Standing LoCoMo / LongMemEval cadence:** too many acceptance
-  criteria cite "within ±0.005 of baseline," but the benchmarks don't
-  run on a cadence. Either put them on nightly/weekly CI (with a
-  retention policy for the artefacts) or stop citing parity
-  criteria that nobody measures.
-- **Proposal-supersession hygiene rule:** the PR that supersedes a
-  proposal should move the old one (to `rejected/`, `deferred/`, or
-  wherever it belongs) **in the same commit**. Drift like the
-  pluggable-db proposal sitting in `pending/` after being deleted by
-  its successor is how `pending/` becomes stale signal. Worth a short
-  `CONTRIBUTING.md` addition alongside the PR template.
-- **Dedicated operator audit surface:** the data is all there
-  (`operator_id` on every shareable row, `content_hash`, timestamps),
-  but a CLI verb rendering per-operator / per-scope activity in a
-  legible way does not exist. Flagged as a known gap in the
-  DB1/DB2 storage-boundary work.
-- **Distributed-mode auth design:** the deep-curator token lifecycle
-  is deliberately minimum-viable (opaque bearer, config-file seeded,
-  per-token audit). OIDC, short-lived tokens with refresh, per-user
-  login flows, and token-management endpoints are all deferred until
-  a real multi-tenant deployment motivates them. When that lands, it
-  deserves its own tracking item.
-
-## What this roadmap does not cover
-
-The broader backlog, roughly a hundred tracked items across agent runtime,
-delegation, memory-quality pillars, UX, reliability, and platform work, flows
-on its own cadence and is intentionally outside this roadmap's scope.
+See [Proposals](PROPOSALS.md) for current design records and [Feature status](STATUS.md) for what is
+integrated.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,306 +1,233 @@
-# Security Model
+# Security model
 
-## Overview
+aimee assumes models, prompts, retrieved text, tool arguments, repositories, MCP packages, and
+remote networks can all be hostile. Enforcement lives in the services and execution backends, not
+in a prompt asking a model to behave.
 
-This document describes the security model for `aimee`, including its trust boundaries, principals, attack surfaces, capability model, enforcement path, token handling, and known non-goals.
+## Guarantees
 
-aimee runs primarily as same-user, local-machine operation. Its strongest protections apply to local clients connecting to the local `aimee-server` over a Unix domain socket, where the server validates the caller's operating-system identity with `SO_PEERCRED`.
+- A thin client cannot open DB1 or DB2.
+- A server process cannot query DB2 directly; a KB process cannot query DB1.
+- Remote routes require an authenticated principal and declared capabilities.
+- Remote writes need a KB-signed user identity and a per-user grant.
+- Tool calls pass schema, path, policy, worktree, and backend checks before execution.
+- Agent credentials are resolved inside the server and are not returned to workflows or delegates.
+- Migrated action paths enter one ordered event-bus audit seam.
+- The audit store detects deletion, reordering, modification, and checkpoint mismatch.
 
-The model distinguishes clearly between what is protected and what is not:
-
-- Protected:
-  - Separation between same-UID and different-UID local processes on the host
-  - Separation between authenticated and unauthenticated clients
-  - Restriction of delegated operations to explicitly granted capabilities
-  - Mediation of sensitive operations through server-side guardrails
-- Not fully protected:
-  - Compromise by processes already running as the same local user
-  - Full confidentiality or integrity of content sent to external delegate providers
-  - Browser access as a hardened Internet-facing security boundary
-  - Administrative isolation equivalent to a multi-tenant remote service
-
-## Trust Boundaries
-
-```mermaid
-flowchart TB
-  subgraph TZ[Trusted Zone: same-user local machine]
-    PA[Primary Agent\nClaude / Gemini / Codex]
-    CLI[aimee thin client]
-    SRV[aimee-server]
-    DB[DB1 local store]
-    DA[Delegate agents\nsub-agents via HTTP]
-
-    PA <--> |Unix socket\nSO_PEERCRED + auth token| SRV
-    CLI --> |hooks via stdin/stdout| PA
-    SRV --> |fork/exec| DA
-    SRV --> DB
-  end
-
-  subgraph STZ[Semi-Trusted Zone]
-    WEB[aimee-server webchat]
-    BROWSER[Browser]
-    WEB <--> |HTTPS + PAM\nself-signed TLS| BROWSER
-  end
-
-  subgraph UTZ[Untrusted Zone]
-    HTTP[Delegate agent HTTP client]
-    PROVIDERS[OpenAI / Anthropic / Gemini]
-    HTTP --> |HTTPS\nAPI key / OAuth| PROVIDERS
-  end
-```
-
-Boundary summary:
-
-- Trusted zone:
-  - Local same-user components on the same machine
-  - Trust is based largely on OS-level same-UID identity and local process assumptions
-- Semi-trusted zone:
-  - Browser-facing webchat path protected by HTTPS and PAM
-  - Useful for authenticated operation, but not treated as equivalent to the local Unix-socket boundary
-- Untrusted zone:
-  - External model providers and any network path used to reach them
-  - Requests may be authenticated, but remote systems are outside the local trust domain
+These guarantees do not make arbitrary native code safe and do not protect a host after full root
+compromise without an external witness.
 
 ## Principals
 
-| Principal | Identity | Trust Level |
-|-----------|----------|-------------|
-| Local user | `SO_PEERCRED` UID match | Full (same-user) |
-| Authenticated client | Capability token | Operational (no admin) |
-| Unauthenticated same-UID | `SO_PEERCRED` only | Read-only |
-| Different-UID local process | Different OS identity | Untrusted |
-| Browser user | PAM-authenticated session | Semi-trusted |
-| External delegate provider | API key or OAuth to remote service | Untrusted |
+Every remote or browser operation resolves to a principal:
 
-Principal distinctions:
+- a local Unix-socket user;
+- an enrolled thin client;
+- an OIDC or PAM user;
+- a browser session;
+- the supervised workflow peer;
+- a service identity;
+- an agent acting for one of the above.
 
-- Local user:
-  - A process connecting over the Unix socket with a matching UID is the most trusted operational principal in the system.
-- Authenticated client:
-  - A holder of a valid capability token can perform only the actions explicitly granted by that token.
-  - This principal is operational, not administrative.
-- Unauthenticated same-UID:
-  - Same-user identity alone may permit limited read-only behavior, but does not imply full access.
-- Different-UID local process:
-  - A different local OS user is not trusted merely for being on the same machine.
-- Browser user:
-  - PAM-backed browser access is authenticated, but the browser path is treated as less trusted than the Unix-socket path.
-- External delegate provider:
-  - External AI providers are required for some delegated operations but are outside the trusted computing base.
+Audit records keep the originating principal when work crosses a delegate, workflow, KB, or tool
+boundary. Falling back to a generic server identity is reserved for autonomous internal work that
+has no user principal.
 
-## Attack Surfaces
+## Trust boundaries
 
-The primary attack surfaces are:
+| Boundary | Enforcement |
+| --- | --- |
+| local client → server | filesystem ownership and Unix-socket permissions |
+| remote client → server | TLS, certificate pin, bearer or mTLS identity, route capabilities |
+| user → write route | signed identity token, server/team trust, per-user write grant, replay check |
+| browser → web service | login, secure cookie, CSRF checks, principal propagation |
+| server → KB | service authentication, TLS where configured, typed `/v1` routes |
+| workflow → resource plane | direct supervised peer, kernel identity, narrow internal operations |
+| agent → workspace | assigned root, worktree, path normalization, write authority |
+| delegate → host | process or container isolation, resource limits, explicit mounts and egress |
+| service → provider | vault lookup, catalog, budget, rate, and egress policy |
+| module → event bus | admission, private rings, subscription authorization, bounded credits |
 
-1. Unix socket interface
-   - Local IPC endpoint to `aimee-server`
-   - Protected primarily by filesystem permissions, local host access, and `SO_PEERCRED`
-   - Main concern: unauthorized local access, confused-deputy behavior, or misuse by same-user processes
+The managed deployment mounts the host Docker socket in `aimee-server`. Anyone who controls that
+server can control the Docker host. Use the split stack when that is outside the intended trust
+boundary.
 
-2. Capability tokens
-   - Used to authorize operational actions
-   - Main concern: token theft, overbroad grants, replay within the valid lifetime, or incorrect scope enforcement
+## Remote access
 
-3. Browser webchat
-   - HTTPS endpoint with PAM-backed authentication and self-signed TLS
-   - Main concern: session misuse, local browser trust assumptions, and weaker guarantees than the Unix-socket channel
+`aimee remote set` pins the server certificate and rotates the bootstrap bearer. On Linux it also
+enrolls a client certificate. Verify the printed fingerprint out of band.
 
-4. Delegate execution path
-   - Server fork/exec of delegate agents and sub-agent orchestration
-   - Main concern: privilege misuse, unsafe parameter forwarding, or unintended expansion of allowed actions
+The shared bearer is read-only. Remote write authority comes from a short-lived, single-use,
+KB-signed identity token whose `(server, team, subject)` has a live grant. `data` permits memory,
+document, and index writes. `full` also permits agent, delegate, runner, and workspace control.
 
-5. Delegate HTTP client to external providers
-   - Outbound HTTPS to OpenAI, Anthropic, Gemini, or similar providers using API keys or OAuth
-   - Main concern: disclosure of prompts, metadata, or outputs to third parties; dependency on remote provider security and policy
+The server pins the signing authority through `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE` and enforces its
+configured server and team IDs. Token replay, unknown keys, wrong audience/team, expired grants, and
+unavailable replay storage fail closed. Grant administration is local-Unix-socket only.
 
-6. DB1-backed local state
-   - Local persistence used by the server
-   - Main concern: tampering by same-user processes, accidental over-retention, or unauthorized reads on a compromised host account
+`aimee.api.remote_writes` is still parsed so old configuration loads, but it no longer authorizes a
+user write. A non-off value produces a warning and the `remote_writes.global_ignored` diagnostic.
 
-7. aimee-server `/v1` HTTP listener (optional, off by default)
-   - A loopback-only TCP endpoint (`http://127.0.0.1:<port>/v1`) turned on with `aimee api enable`; it exposes the OpenAI-compatible surface to local editors
-   - Bearer-authenticated, per-bearer rate-limited, and gated by token scope; a scoped token is denied with `403` when it requests an action outside its grant
-   - Main concern: bearer theft by a same-host process, overbroad token scope, or exposing the port past loopback through a misconfigured proxy
+Enrollment material in `remote.conf` is mode `0600`, opened without following symlinks. Do not copy
+one client's certificate to another machine. Revoke the old identity and enroll the replacement.
 
-8. aimee-kb (DB2) transport
-   - The knowledge store is reached over a same-host Unix socket, or over TLS to a shared host
-   - The Unix-socket path leans on the local OS boundary; the remote path requires TLS (mutual TLS where configured) plus a bearer or scope-bound token, and denies cross-scope access with `403`
-   - Main concern: weak transport configuration on the remote path, token theft, or scope confusion between projects and workspaces. See [PUBLIC_API.md](PUBLIC_API.md) for the full TLS and token model
+## Event bus
 
-These protections are scoped narrowly. They resist different-UID local misuse better than same-UID local compromise. If an attacker already controls the same local user account, many protections reduce to best-effort mediation rather than strong isolation.
+The bus is an intra-daemon trust boundary, not a network perimeter. The Linux host creates anonymous
+memory regions, admits a client over `SOCK_SEQPACKET`, then passes only that client's queue pair and
+the shared arena.
 
-## Capability Model
+- the control region is read-only;
+- a client cannot map or enumerate another client's rings;
+- observers receive only registered event kinds;
+- requests and replies are correlation-bound;
+- queues and arena leases are bounded;
+- client reap releases held references;
+- the full-stream tap is reserved for core audit and governance.
 
-Capabilities are the core authorization mechanism for operational actions. A client may identify as the same local user, but access to non-read-only actions still depends on possession of a valid capability token and successful guardrail checks.
+The arena assumes admitted native modules are trusted. It prevents accidental cross-client queue
+access; it is not hostile-code isolation. Run untrusted extensions out of process behind a narrower
+contract.
 
-```mermaid
-flowchart LR
-  P[Principal] --> I[Identity established]
-  I --> C{Capability token present and valid?}
-  C -- No --> RO[Same-UID read-only access only]
-  C -- Yes --> S[Scoped capabilities]
-  S --> A1[Allowed operational action]
-  S --> A2[Allowed delegated action]
-  S --> D[Denied if action outside scope]
+See [Event bus](EVENT_BUS.md).
+
+## Guardrails and tool policy
+
+Guardrails run before a tool or write reaches the backend. They cover:
+
+- secret and production paths;
+- writes outside the assigned worktree;
+- planning or read-only mode;
+- destructive or unsupported operations;
+- direct sub-agent launchers when delegates are required;
+- MCP package health and allowlists;
+- tool schema and capability requirements;
+- semantic risk and anti-pattern signals.
+
+A model cannot override a hard deny in prose. A soft warning may require explicit operator or
+workflow handling. Semantic guardrails produce a structured decision that is audited through the
+event bus.
+
+Path checks use canonical workspace roots. A symlink, `..`, alternate spelling, or client-local path
+must not escape the assigned authority.
+
+## Delegate isolation
+
+Write-capable delegates use isolated worktrees. Container delegates default to:
+
+- no network;
+- no provider or git credentials;
+- a narrow workspace mount;
+- bounded CPU, memory, process count, and lifetime;
+- an explicit base image and toolchain;
+- mediated package access.
+
+Custom images and packages expand the trusted computing base. Build them outside the agent's
+control, pin what you can, scan them, and keep the Docker socket out of the container.
+
+If the requested isolation cannot be applied, the default is to fail. An explicitly configured
+degraded path emits a sandbox degradation audit record.
+
+See [Delegate sandbox](DELEGATE_SANDBOX.md).
+
+## Credential custody
+
+The server vault is the source of truth for provider keys, OAuth tokens, git credentials, and other
+agent secrets. A turn resolves a credential only after principal, provider, agent, and policy checks.
+
+The vault supports local root-key custody and hardened backends such as TPM 2, PKCS#11, or KMS.
+Rotation and reseal operations have recovery records. Locking evicts the cached key; it does not
+rewrite every stored secret.
+
+Do not store secrets in:
+
+- `agents.json`;
+- workflow definitions or artifacts;
+- prompts, memory, or project documentation;
+- delegate container environments unless the policy explicitly grants that one credential;
+- client-side key files.
+
+Local CLI agents may use a login that remains on the thin client when execution runs there. The
+server sends commands over the authorized runner channel; it does not copy the login.
+
+Every vault access emits an audit event with a bounded secret fingerprint, never the secret.
+
+## MCP and package supply chain
+
+The MCP registry records installed servers and their package source. The OSV gate checks known
+vulnerabilities and can block an unhealthy package. Recheck before enabling a stale or changed
+server:
+
+```bash
+aimee mcp audit
+aimee mcp recheck <name>
 ```
 
-Capability properties preserved by this model:
+MCP tool arguments, outcomes, and completion state are audited. Installing an adapter into the
+server or KB does not grant it full database access; it receives the module and route contracts it
+declares.
 
-- Capabilities grant operations explicitly, not implicitly.
-- Holding a token does not make a client administrative.
-- Same-user identity and token possession are distinct signals.
-- Read-only behavior may be available to unauthenticated same-UID callers, but broader actions require a token.
-- Requests outside the token scope must be denied even if the caller is local and authenticated.
+## Browser and git
 
-What the capability model protects:
+Browser sessions are per user. Project selection is not authorization by itself; server routes
+recheck the principal.
 
-- Accidental or unauthorized use of operational APIs without an explicit grant
-- Lateral use of the server as a confused deputy for actions not covered by a token
-- Expansion from authenticated status to unrestricted access
+Git tokens and SSH keys live in the vault. SSH clones use a short-lived agent and a per-principal
+`known_hosts`. First contact uses trust on first use; later connections require the recorded host
+key. Verify a new host key through another channel when the repository is sensitive.
 
-What it does not protect:
+VS Code runs per user and is proxied through the authenticated browser service. It still has the
+authority of that user over the selected workspace.
 
-- Misuse by a same-user attacker who can steal or invoke a valid token
-- Actions that are intentionally within the granted token scope
-- Content confidentiality once data is intentionally sent to an external delegate provider
+See [Web git security](WEBCHAT_GIT_SECURITY.md).
 
-## Guardrail Enforcement
+## Audit
 
-Sensitive operations are mediated server-side. The enforcement chain combines transport identity, token validation, and action-level checks before work is executed.
+The WORM store is append-only and hash-chained. Checkpoints commit the current head. A seal exports
+a verifiable snapshot. Retrieval traces, provenance, fidelity, policy decisions, and action rows use
+the same verification surface.
 
-```mermaid
-flowchart TD
-  REQ[Client request] --> ID[Establish caller identity\nSO_PEERCRED or web auth]
-  ID --> TOK[Validate capability token]
-  TOK --> SCOPE[Check requested action against scope]
-  SCOPE --> RULES[Apply server-side guardrails]
-  RULES --> DECISION{Allowed?}
-  DECISION -- Yes --> EXEC[Execute local action or delegate]
-  DECISION -- No --> DENY[Deny request]
+```bash
+aimee audit verify
+aimee audit checkpoint
+aimee audit seal --help
 ```
 
-Enforcement expectations:
+The event-bus capture stream preserves accepted order and materializes large payloads. It is for
+inspection and observational replay; it never runs a captured tool call.
 
-- Identity is established first.
-- Capability validation happens before operational execution.
-- Scope checks are performed before local actions or delegation.
-- Guardrails are enforced on the server side, not delegated to clients.
-- Denial is the expected outcome when identity, token state, or requested capability does not satisfy policy.
+A local ledger cannot prove integrity against an attacker who controls the host, the process, and
+its keys. Use the out-of-process sealer and off-host witness/anchor for that threat. Alert on witness
+lag, anchor failure, WORM verification failure, bus drops, or an uncovered enforcement path.
 
-This model protects against clients claiming authority they do not have. It does not protect against arbitrary actions by a fully compromised same-user environment.
+## Data and privacy
 
-## Token Lifecycle
+Nothing phones home by default. Network calls happen for configured providers, git hosts, package
+sources, vulnerability checks, telemetry exporters, or other explicit integrations.
 
-Capability tokens are lifecycle-managed security artifacts on the active authorization boundary.
+Memory and document ingestion can retain sensitive source text. Scope the KB, configure retention,
+and avoid sending restricted evidence to an external reranker or synthesis provider. Memory audit
+uses fingerprints for keys that can contain personal data.
 
-Lifecycle stages:
+## Non-goals
 
-1. Issuance
-   - A token is created with explicit operational scope.
-   - The token represents a bounded authorization grant, not blanket trust.
+- protecting a host after root compromise without an external trust anchor;
+- treating an admitted native module as hostile code;
+- making provider terms permit unattended use;
+- preventing an authorized user from reading data their grant allows;
+- replacing repository review, backups, or normal host hardening;
+- claiming deterministic module execution from observational capture.
 
-2. Presentation
-   - The client presents the token when requesting protected actions.
-   - Presence of a token supplements, but does not replace, transport or session identity.
+## Operator checklist
 
-3. Validation
-   - The server verifies that the token is recognized, valid, and suitable for the requested operation.
-   - Invalid, missing, or insufficiently scoped tokens must result in denial.
-
-4. Use
-   - Actions are limited to the token's granted capabilities.
-   - Delegated work is still subject to server-side checks.
-
-5. Expiry or revocation
-   - A token should cease to authorize actions once expired or no longer accepted by the server.
-   - Expired or revoked tokens must not continue to permit operational access.
-
-Security implications:
-
-- Token secrecy matters because possession enables the granted operations.
-- Token scope matters because overbroad tokens enlarge the blast radius of theft or misuse.
-- Server-side validation matters because local identity alone is insufficient for broader operations.
-
-## Agent Credential Custody (thin client)
-
-Third-party agent/delegate API keys (and Codex/OAuth tokens) are sealed in the
-server's **credential vault**, encrypted at rest, and are the server's single,
-permanent credential store. The legacy client-held model (client keyring + a
-RAM-only per-session push) was retired.
-
-- **Storage of record is the server vault.** Keys are sealed under the server
-  principal, encrypted at rest; `aimee agent add … --key K` writes `K` into the
-  vault and **refuses plaintext storage**. The server's `agents.json` holds
-  definitions (endpoint, model, roles) only, never the key. Codex/OAuth tokens
-  are vaulted the same way (a legacy plaintext token is migrated and scrubbed on
-  first use).
-- **Autonomous unseal, no interactive unlock.** Each data-encryption key is
-  wrapped twice, once for an interactive principal and once under a server
-  master key (`.vault/.server-master.key`), so the server can decrypt a
-  credential on its own to run a turn without a human unlocking the vault.
-  Credentials are resolved per turn from the vault (the turn's attested
-  principal, falling back to the server principal).
-- **No client custody, no RAM keyring.** The client-held keyring
-  (`~/.config/aimee/agent-keys.json`) and the per-session push (`POST
-  /v1/session/credentials`) are gone; `aimee agent key import` migrates any
-  leftover client keys into the vault. Agents are configured **once on the
-  server** and shared across every client.
-- **Trade-off.** The server is now a durable secret store, so the protection
-  boundary is the server host and especially `.vault/.server-master.key` (the
-  root of the autonomous-unseal capability), restrict its file mode and host
-  access and threat-model the server host accordingly.
-- **Transport.** `agent add --key` sends the key over the same authenticated
-  `/v1` channel as other requests; on a plaintext-HTTP LAN deployment it is only
-  as confidential as that network. Use TLS / a trusted network for the server
-  endpoint.
-
-See [THIN_CLIENT.md](THIN_CLIENT.md) for operational details.
-
-## Local-CLI agent execution stays on the client
-
-A `--provider claude` agent runs the standard `claude` CLI in a tmux session,
-which executes where the binary and login live, the **client**, even when it
-is driven through a remote `aimee-server`. On a detached workspace the tmux
-session driver marshals its tmux commands over the runner reverse channel and the
-client runs them locally, with `claude` authenticating via the client's own login
-(`~/.claude`). (`claude -p` print mode is not used.)
-
-- No Claude credential is transmitted to or stored on the server; the server only
-  relays the prompt and reads back the captured session output.
-- The CLI runs against the client's working tree, under the client user's
-  identity, the server gains no new ability to execute binaries it does not have.
-- This keeps the server from being a place where third-party agent logins
-  accumulate (a `claude` CLI subscription login is not an API key and is not
-  vaulted; it stays on the client; see [DELEGATES.md](DELEGATES.md)). On a
-  plaintext-HTTP
-  LAN deployment, the prompt relayed to the server is only as confidential as
-  that network, use TLS / a trusted network for the server endpoint.
-- Claude run via the `claude` CLI login (not an API key) is **primary-only by
-  default**, see [DELEGATES.md](DELEGATES.md#claude-via-the-cli-is-primary-only-by-default)
-  for the account-risk rationale and the per-agent **Primary Agent Only**
-  (`primary_only`) flag that governs it.
-
-## Explicit Non-Goals
-
-This security model does not aim to provide:
-
-- Protection against a hostile process already running as the same local user with the ability to inspect local process state, files, or tokens
-- Internet-hardened exposure for the browser interface comparable to a public SaaS perimeter
-- End-to-end confidentiality from the local system to external AI providers once prompts or outputs are intentionally sent over delegate HTTP APIs
-- Strong multi-tenant isolation between mutually untrusted users on the same host beyond the documented local-user and token boundaries
-- Administrative privilege separation equivalent to a dedicated sandbox, VM, or MAC-enforced isolation layer
-
-These non-goals are intentional design constraints.
-
-## Audit History
-
-This document covers:
-
-- Trusted, semi-trusted, and untrusted zones
-- The principal classes and their trust levels
-- The Unix socket, browser, delegate, token, and DB1 local-state attack surfaces
-- Capability-scoped operational authorization
-- Server-side guardrail enforcement before execution
-- Token-based authorization as distinct from local transport identity
-
-No separate historical audit record exists yet. This section is the baseline for future audit updates.
+- change browser bootstrap credentials;
+- verify certificate fingerprints before enrollment;
+- configure server/team/JWKS trust before enabling remote users;
+- grant users individually and review grants regularly;
+- keep the Docker socket out of deployments that do not need managed launch;
+- use the vault, never plaintext config, for credentials;
+- keep delegate network off unless the task needs it;
+- run `aimee audit verify` and monitor bus drops;
+- back up DB1, DB2, workflow state, vault custody, TLS state, and audit anchors;
+- test revocation and restore procedures before an incident.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,131 +1,85 @@
-# Settings (web page)
+# Settings
 
-The **Settings** page (aimee web UI, left nav → ⚙️ Settings, route `/settings`) is a typed
-editor over the server's runtime configuration. It exposes the allowlisted config fields
-**that no other tab owns** (the same `config.show` / `config.set` surface the `aimee config`
-CLI uses) as a grouped, filterable form with per-field **Save** and **Reset**.
+The browser Settings page and `aimee config` edit the same allowlisted configuration fields.
 
-It is a thin surface over machinery that already exists: each control maps 1:1 to a
-`config_t` field in [`src/config_fields.c`](../src/config_fields.c). Adding a field to that
-table makes it appear here automatically; there is no per-field frontend code. Changes
-persist to `aimee.yaml` and take effect on the next turn (the server reloads config per
-request), unless noted otherwise below.
+```bash
+aimee config show
+aimee config get <key>
+aimee config set <key> <value>
+```
 
-- **Nav / route:** `/settings` (`frontend/src/App.tsx`), page
-  `frontend/src/pages/Settings.tsx`.
-- **Data path:** `GET /api/config` → `config.show` (all fields + values); `POST
-  /api/config/set {key,value}` → `config.set` (the server validates the key against
-  `config_fields` and persists `aimee.yaml`). The webchat proxy (`webchat/config_api.go`)
-  is the only network hop; there are no server changes per field.
-- **Control inference:** the control type is inferred from the value's JSON type: a
-  **boolean → toggle**, a **number → number field**, a **string → text field**. Grouping is
-  by the dotted key prefix (e.g. everything under `reduce.` forms one section).
-- **One owner per option.** An option that another tab configures is **not listed here** —
-  a second editable copy silently loses edits (the Roundtable keys are the clearest case:
-  activating a preset runs `preset_overlay_config`, which overwrites them). The map lives in
-  `frontend/src/pages/settingsHelp.ts` (`OWNED_ELSEWHERE`) with the grounding for each key,
-  and the page names the owning tab. The keys stay fully settable from `aimee.yaml` and the
-  CLI. Current owners: the **Roundtable** tab (`roundtable.*`), the kb console's **Pipeline**
-  page (`kb_curator_*`, `kb_evidence_embed_enabled`), the kb console's **Settings** page
-  (the embedder, reranker and synth tiers — `embedding_*`, `llm_embed_*`, `llm_rerank_*`,
-  `llm_synth_*` — plus the knowledge base's own `kb_*` and ingest-sidecar keys; `typed_facts_enabled`
-  belongs to that console's **Typed facts** page), the **Agents** tab (`provider`, `claude_model`, `openai_*`), and
-  **Chat**/**Personas** (`default_persona`). The kb split is by which binary READS the
-  key: `kb_mode`, `kb_client_url`, `kb_client_bearer_token` and `kb_evidence_emit_enabled`
-  stay here, because aimee-server reads them to reach a kb.
-- **No gear menu.** The top-bar quick-settings dropdown has been removed; the Settings page
-  and the owning tabs are the only places runtime options are edited.
+The exact field list, defaults, bounds, environment overrides, and restart behavior are generated in
+[Configuration reference](gen/configuration.md).
 
-> **Allowlist, not raw config.** The page can only read/write keys in `config_fields`.
-> Sensitive values (endpoints, `*_key_cmd`, `db2_url`, and **secrets**) are deliberately
-> *not* in that allowlist and never appear here. In particular the CI-webhook secret
-> (`AIMEE_CI_WEBHOOK_SECRET`) is an environment secret, not a Settings field.
+## Browser behavior
 
----
+The Settings page is at `/settings`. It groups fields by dotted prefix and chooses a toggle, number,
+or text control from the field type. Save writes one key; Reset restores its descriptor default.
 
-## Option groups added recently
+It is an allowlist, not a raw YAML editor. Secrets, credential commands, sensitive endpoints, and
+fields without a safe runtime setter do not appear. Put credentials in the vault and deployment
+secrets in the environment or secret manager.
 
-### Context economizer: `economizer.mode`
+## Precedence
 
-The economizer has one mode control:
+From highest to lowest:
+
+1. an explicit environment override;
+2. the active profile's `aimee.yaml` value;
+3. the descriptor default.
+
+Most runtime fields reload on the next request. Process topology, listeners, storage, custody, and
+some workflow controls need a restart. The generated reference marks those fields.
+
+## High-impact settings
+
+### Economizer
 
 ```yaml
-economizer:
-  mode: safe             # off | safe | aggressive (default: safe)
+economizer: safe   # off | safe | aggressive
 ```
 
-| Mode | What it does |
-| --- | --- |
-| `off` | Disables economizer transforms. |
-| `safe` (default) | Deterministically compacts strict JSON from a fresh local tool result before its first provider dispatch. It does not rewrite history or cache controls. |
-| `aggressive` | Adds the existing lossy history and tool-output reducers on supported OpenAI-family routes. Native Anthropic history is not mutated. |
+- `off`: provider payload passes through without reduction.
+- `safe`: lossless cache alignment, folding, and tool-output condensation with recoverable spills.
+- `aggressive`: adds lossy compression or ingress mutation where the provider contract permits it.
 
-`modules.economizer: false` is an authoritative hard-kill that forces the effective mode to
-`off`. Provider cache controls are never changed, and retries reuse the selected exact-length wire
-snapshot. `safe` is JSON-semantic rather than byte-preserving: it removes only insignificant
-whitespace from a fresh strict JSON tool result, and otherwise passes the original through.
-`aggressive` is explicitly lossy and does not guarantee a lower provider bill. See
-[The aimee Economizer](features/economizer.md) for request-path behavior, provider cache constraints,
-limits, API configuration, and troubleshooting.
+`modules.economizer: false` is the hard off switch. See [Economizer](features/economizer.md).
 
-### Autonomous-development pipeline: `autonomy.*`
-
-The autonomous-development knobs were historically environment-only (`AIMEE_AUTONOMY_*`).
-They are now typed config fields on the Settings page. A `config` value is **bridged to the
-matching env var at server startup**, so an explicitly-exported `AIMEE_AUTONOMY_*`
-environment variable still **overrides** the config value, and **a Settings change to these
-knobs applies on the next server start** (they are deployment-level pipeline tuning, not
-per-turn toggles). Values are clamped to sane bounds.
-
-| Setting | Default | Bounds | What it does |
-| --- | --- | --- | --- |
-| `autonomy.skeptics` | 0 (off) | 0–32 | N adversarial skeptics on the implement gate (0 disables the tier). |
-| `autonomy.fanout` | off | — | Engine-level fan-out manager loop (vs a single implement dispatch). |
-| `autonomy.unit_retry` | 2 | 0–10 | Per-unit retry-different-delegate cap under fan-out. |
-| `autonomy.unit_max` | 16 | 1–256 | Maximum fan-out units (a larger decomposition parks for a human). |
-| `autonomy.ci_retry_max` | 2 | 0–20 | Per-work-item red-CI retry cap before parking. |
-
----
-
-### Sub-agent ban: `subagent_ban_enabled`
-
-| Key | Default | Effect |
-|-----|---------|--------|
-| `subagent_ban_enabled` | `true` | When on **and** usable delegates are configured, blocks the primary agent's own sub-agent tools (`Task`/`Agent`/`spawn_agent`/`RemoteTrigger`) and redirects to `aimee delegate`, so delegation stays inside aimee's guardrail + memory + KB model. Set `false` to allow provider-native sub-agents. |
-
-What this key gates: the **server guardrail block** (honors `subagent_ban_enabled: false`
-as an opt-out) and the **Claude Code harness enforcement** — a `subagent-guard` PreToolUse
-hook plus a `permissions.deny [Task, Agent]` backstop that aimee's client setup
-auto-installs. The harness gate is evaluated once per client setup / session-start (config
-opt-out is read locally; a one-shot `agent.list` probe decides whether usable delegates
-exist), so changing this key — or adding/removing delegates — re-materializes the hook and
-deny list at the next setup. Independently, the `/v1` **gateway tool-strip** removes
-sub-agent tools from what aimee hands its *own* delegate agents; that strip is always-on
-and is not affected by this key.
-
----
-
-## Choosing an economizer mode
-
-The economizer defaults to `safe`. Select any tier with `economizer.mode`:
+### Remote writes
 
 ```yaml
-economizer:
-  mode: safe
+aimee:
+  api:
+    remote_writes: off   # off | data | full
 ```
 
-```sh
-aimee config set economizer.mode safe
-```
+This legacy value is still parsed so old files load. It no longer authorizes user `/v1` writes;
+non-off values warn and feed `remote_writes.global_ignored`. Configure server identity trust and
+per-user grants instead. See [Security](SECURITY.md#remote-access).
 
-Use `off` for economizer pass-through or `aggressive` when lossy context reduction and possible
-provider-cache churn are acceptable.
-See [features/economizer.md](features/economizer.md) for the provider and safety boundaries.
+### Delegate isolation
 
-## When a change takes effect
+Sandbox, source authority, network, package, image, worktree, and concurrency fields change what a
+delegate can touch. Treat them as security policy. See [Delegate sandbox](DELEGATE_SANDBOX.md).
 
-- **Immediately (next turn):** `economizer.mode` and most other fields. The
-  server reloads config per request.
-- **On next server start:** the `autonomy.*` knobs: they are bridged to `AIMEE_AUTONOMY_*`
-  environment variables at startup so the workflow engine (which reads them across a module
-  boundary) sees them; an explicitly-set env var always wins.
+### Autonomous workflows
+
+`autonomy.*` fields set retry, fan-out, agent, and gate budgets. They never authorize a human gate.
+Some are copied into the Go workflow process at startup and therefore need a restart.
+
+### Sub-agent ban
+
+`subagent_ban_enabled` routes sub-work through aimee delegates when usable delegates exist. It
+controls server guardrails and client setup for supported tools. The internal delegate tool strip is
+independent and stays on.
+
+## Editing YAML
+
+Use `aimee config set` for ordinary scalar changes. It validates the key and updates only that field.
+If you edit `aimee.yaml` directly:
+
+- preserve unknown sections owned by newer components;
+- quote strings that YAML could parse as booleans or numbers;
+- keep the file private;
+- restart the owning process when required;
+- run `aimee config show` afterward to inspect the resolved value.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,144 +1,86 @@
-# Feature Status
+# Feature status
 
-This document tracks implemented features in the codebase. It is a
-feature-tracking reference rather than a complete roadmap.
+This page describes the current testing tree. `Done` means the path is implemented and covered by
+its normal tests. `Gated` means it ships behind configuration or deployment requirements. `Next`
+means the contract or branch exists but is not part of the integrated path yet.
 
-## Core System
+## Runtime
 
-| Feature | Status | Description | Key files |
-|---------|--------|-------------|-----------|
-| Tool registry with JSON schema validation | Done | Registers tools centrally and validates tool inputs against JSON schemas before execution. | agent_policy.c, db2/tool_registry.c |
-| Plan IR (structured execution plans for delegates) | Done | Represents delegate work as structured plans so execution can be reasoned about and inspected consistently. | agent_plan.c |
-| Execution transactions (file checkpoints, rollback) | Done | Protects file-editing operations with checkpoints and rollback support for safer execution. | agent_tools.c |
-| Policy-as-code guardrails (primary + delegate agents) | Done | Applies codified safety and workflow rules to both primary and delegated agent execution. | agent.c |
-| Deterministic replay (delegate execution trace) | Done | Records delegate execution traces so runs can be replayed and debugged deterministically. | agent.c |
-| Eval harness with task suites | Done | Provides a repeatable evaluation harness for running the agent against defined task suites. | agent_eval.c |
-| Confidence calibration and abstention | Done | Lets the agent estimate confidence and abstain when reliability is too low. | agent.c |
-| Prometheus metrics (textfile collector) | Done | Exposes operational metrics in Prometheus textfile format for external scraping. | agent.c |
-| Repo contract (.aimee/project.yaml) | Done | Loads per-project build, test, lint, and risk-path rules from a repository contract file. | agent.c |
-| Environment introspection | Done | Detects available tools, platform details, and execution environment capabilities at runtime. | agent.c |
-| Change manifests | Done | Produces structured records of changes made during an execution session. | agent.c |
-| Hard/soft/session directives | Done | Supports multiple directive scopes so durable rules and per-session guidance can coexist. | agent_coord.c, cmd_rules.c |
-| Two-phase plan mode (--plan) | Done | Supports planning-first execution with an explicit plan mode before acting. | agent_plan.c |
-| ChatGPT backend endpoint (delegate provider) | Done | Integrates a ChatGPT-backed provider for delegate agent execution. | cmd_agent.c, agent_context.c, agent.c |
-| Model fallback (delegate: gpt-5.4 -> gpt-5.4-mini) | Done | Falls back to a secondary model when the preferred delegate model is unavailable. | agent_context.c, agent.c |
-| Extra HTTP headers (ChatGPT-Account-ID) | Done | Sends required account-scoped HTTP headers for backend requests. | agent_http.c, agent_types.h |
-| JWT claim extraction (account_id) | Done | Extracts account identity from JWT claims for downstream request handling. | cmd_agent.c |
-| Workspace manifest (YAML) | Done | Stores workspace configuration in YAML for discovery and management commands. | workspace.c |
-| No-subcommand launch (exec primary agent) | Done | Allows the default CLI entrypoint to launch the primary agent directly without an extra subcommand. | main.c |
-| Setup/quickstart provisioning | Done | Provides setup flows to provision the local environment for first use. | cmd_core.c |
-| Workspace add/remove | Done | Adds and removes repositories from the managed workspace set. | cmd_core.c |
-| Bootstrap script (setup.sh) | Done | Includes a bootstrap script for initial environment and dependency setup. | setup.sh |
-| Standalone Go webchat | Done | `aimee-runtime-web` serves the browser UI, handles auth/session storage, and proxies live work to `aimee-server`. | webchat/, server.c |
-| Network inventory | Done | Loads configured network host inventory for delegate routing. | cmd_agent.c, agents.json |
-| Personas (8 built-in + custom) | Done | Named identity/voice + delegate policy, settable per session and used to staff roundtable panels and workflow steps. See [personas.md](personas.md). | persona.c, prompts.c |
-| Webchat top-nav + per-tab projects | Done | One tab per tool (Chat/Dashboard/Edit Workflows/Workflow Actions/Delegates/Projects/Graph/Editor); each tab selects its own git project. | frontend/src/App.tsx, frontend/src/components/ProjectPicker.tsx |
-| Webchat git projects + per-host credentials | Done | Clone repos (HTTPS or SSH-form URLs normalized to HTTPS); per-host tokens + GitHub OAuth device flow stored in the server vault. | git_project.c, git_host_cred.c, git_oauth_github.c |
-| In-app VS Code editor | Done | Per-user `code-server` supervised by the server, reverse-proxied at `/vscode/`, opened on the selected project. Default-on. | webuser_editor.c, webchat/vscode.go |
-| Workflow engine (authoring + execution) | Partial | Block catalog, typed-graph validation, canonical versioning, advance/gates/roundtable/human-approval, and the webchat composer are done; **no user-facing run trigger yet**. See [WORKFLOWS.md](WORKFLOWS.md). | src/workflow/wfe_*.c |
+| Feature | State | Boundary |
+| --- | --- | --- |
+| Shared-memory event bus | Done | One host per daemon; typed routing, private queue pairs, backpressure, arena leases, capture. Linux v0. |
+| C and pure-Go bus clients | Done | Shared golden vectors and cross-language conformance; no cgo. |
+| Audit and observability on the bus | Done | Actions, memory writes, guardrails, vault, sandbox, MCP, and tool outcomes. |
+| External bus clients | Next | Inline cross-process attachment exists on a follow-on branch; not the integrated runtime path. |
+| Workflow triggers on the bus | Next | Trigger event contracts and routing exist on a follow-on branch. |
+| Module replay | Next | Capture replay is observational; it does not re-execute modules. |
+| Source-module boundaries | In progress | Owned headers, descriptors, dependency gates, and attested docs are landing by module. |
+| Go workflow control plane | Done | Go owns workflow scheduling; C owns runtime, storage, tools, and policy seams. |
+| Versioned `/v1` operations | Done | Named routes replace the generic RPC endpoint. |
 
-## Memory System
+## Memory and code
 
-| Feature | Status | Description | Key files |
-|---------|--------|-------------|-----------|
-| Artifact-aware memory (linking, staleness) | Done | Associates memories with artifacts and tracks when recalled information may be stale. | cmd_memory.c, memory_core.c, db2/memory_payload.c |
-| Workspace-scoped memory recall | Done | Restricts memory recall to the active workspace so unrelated repositories do not pollute context. | cmd_hooks.c |
-| DB2 memory lexical search | Done | Adds DB2-owned lexical indexing so stored memories can be searched efficiently by content. | db2/memory_query.c, memory_core_search.inc |
+| Feature | State | Boundary |
+| --- | --- | --- |
+| Persistent typed memory | Done | Facts, rules, decisions, episodes, provenance, contradiction, and staleness. |
+| DB1/DB2 ownership | Done | Server owns SQLite; KB owns PostgreSQL and pgvector; thin clients own neither. |
+| Embedded KB PostgreSQL | Done | Default container path; external PostgreSQL remains supported. |
+| Hybrid retrieval | Done | Lexical, dense, graph, evidence, rerank, synthesis, and abstention stages. |
+| Cross-repo code graph | Done | Symbols, calls, imports, dependencies, co-change, callers, and blast radius. |
+| Client-side content push | Done | Remote clients upload bytes; server paths never name client files. |
+| Structured PDF evidence | Gated | Coordinates are the base; vectors, tables, assets, and OCR have separate gates. |
+| Autonomous curation | Done | Extract, dedupe, contradict, decay, reflect, and promote through bounded workers. |
 
-## Delegate Agent System
+## Agents and workflows
 
-| Feature | Status | Description | Key files |
-|---------|--------|-------------|-----------|
-| Delegate agent tool-use loop | Done | Runs delegated agents through a full tool-using execution loop rather than a single response pass. | agent.c |
-| Delegate tool execution (bash, read, write, list, verify, git_log) | Done | Exposes the core execution toolset needed for delegated agents to inspect and modify repositories. | agent_tools.c |
-| Ephemeral SSH (delegate agents) | Done | Provides short-lived SSH material to delegates so remote access stays scoped to the task. | agent.c |
-| Context injection (primary agent via hooks, delegate agents via agent_context) | Done | Injects execution context differently for primary and delegated agents while preserving the same working model. | agent.c, cmd_hooks.c |
-| Multi-delegate coordination (planner/critic/worker) | Done | Coordinates multiple delegate roles so planning, critique, and implementation can be split across agents. | agent_coord.c |
-| Quorum voting (across delegate agents) | Done | Compares outputs from multiple delegates and resolves decisions through quorum-based agreement. | agent_coord.c |
-| Roundtable / ensemble (MoA) | Done | `aimee delegate aggregate` fans out to a panel and an aggregator synthesizes one answer; `aimee delegate roundtable` runs multiple rounds. Runs through the delegate core; cost folds onto the originating session. Panel/aggregator ship configured. | delegate_ensemble.c |
-| Sub-agent tool block (delegates, not agents) | Done | Blocks the host AI's own sub-agent launchers (Claude `Task`/`Agent`, Codex `spawn_agent`) and points the agent at `aimee delegate`. Enforced at three layers: the always-on gateway tool-strip (aimee's own agents, independent of config), the server guardrail path, and — new — a Claude Code `subagent-guard` PreToolUse hook + `permissions.deny [Task, Agent]` auto-installed by client setup. `subagent_ban_enabled` (default on) opts out the guardrail + harness layers; the harness layer additionally requires usable delegates (one-shot `agent.list` probe). | guardrails_orchestrator.c, cli_main.c (`subagent-guard`), client_integrations.c, gateway_policy.c |
-| Model-derived output limits | Done | Delegate/ingress output token caps come from the model registry rather than a fixed default. | model_registry.c |
-| Durable delegate jobs (create, heartbeat, resume) | Done | Persists delegate job state so work can survive interruptions and be resumed later. | agent_jobs.c |
-| Per-turn heartbeat updates (delegate agents) | Done | Emits heartbeat updates during delegate execution so long-running work remains observable. | agent.c, agent_jobs.c |
-| Project descriptions (via delegate agent) | Done | Uses a delegate agent to generate or refresh project descriptions from repository context. | cmd_describe.c, workspace.c |
+| Feature | State | Boundary |
+| --- | --- | --- |
+| Role/persona delegate routing | Done | Viable-agent retry; explicit pins fail instead of silently changing model. |
+| Isolated delegate worktrees | Done | Created on first write and bounded to the assigned workspace. |
+| Networkless delegate sandbox | Done | Default container posture; custom images and mediated packages are supported. |
+| Roundtables | Done | Parallel seats, per-seat models, evidence, retry, chair, and cost accounting. |
+| Typed workflows | Done | Validation, version hashes, retries, loops, gates, and durable run state. |
+| Parallel workflow slices | Done | Agent admission and per-workflow limits prevent oversubscription. |
+| Triggers and cron | Done | Start runs in autonomous or interactive mode. Human gates always park. |
+| Live forge and PR completion | Done | Branch, implement, verify, review, merge, and PR steps have terminal failure states. |
+| Transactional turn rewind | Proposed | Design exists; not a shipped recovery path. |
 
-## Session Isolation
+## Providers and context
 
-| Feature | Status | Description | Key files |
-|---------|--------|-------------|-----------|
-| Per-session state files | Done | Stores transient session state in isolated files rather than sharing one global state blob. | config.c, cmd_hooks.c |
-| Git worktree isolation (primary + delegate agents) | Done | Keeps read-only delegates in the parent worktree and gives write-capable delegates isolated sibling worktrees to reduce interference and conflicts. | cmd_hooks.c, guardrails.c |
-| Session-scoped tier state | Done | Tags DB1/DB2-backed state with session identifiers so concurrent sessions stay isolated. | db1/session_state.c, db2/memory_payload.c |
-| Worktree path enforcement | Done | Enforces path boundaries so agents only operate within their assigned worktree locations. | guardrails.c |
-| Stale session pruning | Done | Cleans up expired session state and abandoned worktrees to keep the environment healthy. | cmd_hooks.c |
-| Session management CLI (list, show, close) | Done | `aimee session list` shows active sessions; `aimee session show <id>` reads one session; `aimee session close <id>` closes a session through the server. | cmd_infra.c |
-| Worktree base-branch detection | Done | New worktrees branch from the workspace's current checked-out branch instead of always defaulting to main. | workspace.c |
-| Configurable stale-session threshold | Done | Stale-session cleanup threshold defaults to 4 hours and is configurable via sessions.stale_threshold_secs. | config.c, cmd_hooks.c |
-| Active-session and worktree caps | Done | sessions.max_sessions and sessions.max_worktrees caps trigger proactive cleanup then warn when still exceeded. | config.c, cmd_hooks.c, workspace.c |
+| Feature | State | Boundary |
+| --- | --- | --- |
+| Canonical request/response IR | Done | Provider wire formats end at translation modules. |
+| OpenAI, Anthropic, Gemini, Mistral, Bedrock, local endpoints | Done | Availability still depends on credentials and provider capability. |
+| Provider catalogs and model registry | Done | Context, output, price, capability, quota, and deprecation metadata. |
+| Context economizer | Done | Folding, cache alignment, and tool-output condensation are independently configurable. |
+| Local inference service | Done | CPU/GPU tiers serve embedding, rerank, and synthesis outside the KB process. |
 
-| Memory search includes facts | Done | Ensures memory search results include L2 facts alongside conversation windows. | cmd_memory.c, memory_core_search.inc, db2/memory_query.c, server_state.c |
-| Delegation pattern promotion | Done | Auto-promotes recurring delegation patterns from agent_log to L2 facts. | memory_logic.c |
-| Richer delegation feedback | Done | Captures detailed feedback from delegate executions for pattern learning. | agent.c |
-| Enhanced session-start context (primary agent) | Done | Expands session-start injection with project context, delegation history, and capabilities. | cmd_hooks.c |
+## Security and operations
 
-## Code Intelligence
+| Feature | State | Boundary |
+| --- | --- | --- |
+| Sealed credential vault | Done | Server-side source of truth; use TPM, PKCS#11, KMS, or local root-key custody. |
+| Thin-client mTLS | Gated | Linux enrollment is automatic; other clients use their native TLS stores and configured certs. |
+| Per-user remote writes | Done | KB-signed identity, server/team/JWKS trust, and an exact subject grant. |
+| WORM audit chain | Done | Hash chain, checkpoints, verification, seal, and evidence exports. |
+| External witness and anchor | Gated | Needed for evidence against a compromised host. |
+| Org budgets and rate limits | Done | Catalog, admission, spend, and quota surfaces. |
+| Browser workspace | Done | Chat, projects, agents, workflows, graph, logs, settings, and VS Code. |
+| Managed container deploy | Done | Browser can launch KB and inference through the mounted Docker socket. |
+| Split deploy | Done | Server, KB, and inference can run without Docker-socket delegation. |
+| Native thin clients | Done | Linux, macOS, and Windows; no database linkage. |
 
-| Feature | Status | Description | Key files |
-|---------|--------|-------------|-----------|
-| C/C++ extractor | Done | Extracts C and C++ code structure for symbol-aware analysis and navigation. | extractors_extra.c |
-| Lua extractor | Done | Extracts Lua code structure for the same symbol-aware analysis pipeline. | extractors_extra.c |
-| Extractor test suite | Done | Verifies extractor behavior with automated tests covering supported language parsers. | tests/test_extractors.c |
+## Removed
 
-## MCP and Integration
+| Surface | Replacement |
+| --- | --- |
+| `aimee chat` and the built-in TUI | Browser, MCP, ACP, or compatible API client. |
+| `aimee work` queue | Workflows, triggers, coordinated jobs, and durable delegate jobs. |
+| `aimee migrate v2` | Normal schema migration at daemon startup. |
+| Generic `/v1/rpc` | Named, versioned `/v1` routes. |
+| Combined appliance image | Managed or split container stack. |
+| Client-held agent keys | Server-sealed vault. |
+| KB socket autostart | Explicit KB `/v1` service. |
 
-| Feature | Status | Description | Key files |
-|---------|--------|-------------|-----------|
-| MCP server (`aimee mcp-serve`) | Done | Stdio JSON-RPC 2.0 server exposing memory, index, and delegation tools to MCP-compatible primary agents. Built into the aimee client binary. | server_mcp.c, cli_mcp_serve.c |
-| MCP auto-config (.mcp.json) | Done | Auto-generates MCP configuration for Claude Code and Codex CLI workspace integration. | cmd_core.c |
-| Codex CLI local plugin | Done | Registers aimee as a local Codex CLI plugin via marketplace, plugin cache, and config.toml. | install.sh, cmd_core.c |
-| Binary split (server architecture) | Done | Splits monolith into a thin client and full server. MCP is built into the client and server-side git MCP handlers run in-process. | see Server Architecture |
-| Makefile install target | Done | Provides `make install` for building and installing all binaries to /usr/local/bin/. | src/Makefile |
-| Deferred worktree creation | Done | Defers git worktree creation until first write access, keeping session-start fast. | guardrails.c, cmd_hooks.c |
-| Local observability dashboard | Done | Embedded HTTP dashboard for viewing metrics, delegation history, and session state. | dashboard.c |
-
-## Server Architecture
-
-The shipped artifacts are four binaries: `aimee`, `aimee-runtime-web`, `aimee-server`, and `aimee-kb`. Common runtime code and git MCP handlers are linked directly into the binaries that need them instead of being shipped as separate executables or shared libraries. Long-running work uses `aimee-server`'s in-process compute pool; there is no separate worker binary.
-
-| Binary | Libraries | External deps |
-|--------|-----------|---------------|
-| `aimee` | Thin CLI transport + MCP stdio bridge | pthread |
-| `aimee-runtime-web` | DB-free webchat launcher; talks only to `aimee-server` through `webchat.serve` | pthread |
-| `aimee-server` | Local DB1 daemon, agent/runtime orchestration, KB RPC client | sqlite3, ssl, crypto, pam |
-| `aimee-kb` | Local-or-shared DB2 RPC service + memory/KB pipeline (incl. pgvector) | libpq, ssl, crypto |
-
-```mermaid
-flowchart TD
-    CLI[aimee\nCLI + MCP stdio] -->|JSON RPC| SRV[aimee-server\nDB1 + compute pool]
-    WEB[aimee-runtime-web\nbrowser-facing client] -->|JSON RPC| SRV
-    SRV -->|typed KB /v1 HTTP| KB[aimee-kb\nDB2 + pgvector]
-    SRV --> DB1[src/db1/*]
-    KB --> DB2[src/db2/*]
-```
-
-## Refactoring
-
-All planned structural refactoring is complete.
-
-| Item | Status |
-|------|--------|
-| Command registry (command_t table) | Done |
-| Agent.c decomposition (7 modules) | Done |
-| Narrow agent headers (8 focused .h files) | Done |
-| App context injection (app_ctx_t) | Done |
-| DB stmt cache (FNV-1a hash keyed) | Done |
-| Option parser (opt_parse) | Done |
-| Global elimination (g_json_output etc.) | Done |
-| Subcommand dispatch tables | Done |
-| Migration registration cleanup | Done |
-| agent_result_to_json() | Done |
-| ctx_db_open/close helpers | Done |
-| Session context builder extraction | Done |
-| cmd_*.c module split | Done |
-| Architecture comments on all .c files | Done |
-| CLI integration tests | Done |
+Generated [commands](gen/cli-commands.md), [configuration](gen/configuration.md), and
+[routes](gen/api-v1.md) are the exact surface for this checkout.

--- a/docs/STORAGE_TIERS.md
+++ b/docs/STORAGE_TIERS.md
@@ -1,26 +1,35 @@
-# Storage Tiers
+# Storage tiers
 
-aimee uses two pinned storage tiers. They are not user-selectable runtime
-backends.
+aimee has two product data tiers. They are ownership boundaries, not interchangeable backends.
 
-| Tier | Ownership | Contents |
-|------|-----------|----------|
-| DB1 | `src/db1/` | Local user and session information, credentials, checkpoints, multi-agent ensembles, local caches, local interaction/learning signals, and other same-user state. Backed by SQLite, owned by the local `aimee-server`. |
-| DB2 | `src/db2/` | Durable knowledge for the configured KB scope: memories, rules, KB metadata, task and decision records, code index metadata, coordination records, and the dense vector indexes for that knowledge (pgvector extension, in-process). Backed by Postgres, owned by `aimee-kb`, and deployable as either a local single-user KB or a shared KB. |
+| Tier | Owner | Engine | Contents |
+| --- | --- | --- | --- |
+| DB1 | `aimee-server` | SQLite | sessions, working memory, agent jobs, local policy/audit state, caches, same-user runtime data |
+| DB2 | `aimee-kb` | PostgreSQL + pgvector | durable memories, documents, facts, evidence, code graph, embeddings, curation state |
 
-Code outside a tier must call typed APIs instead of depending on a tier's
-storage handles or provider vocabulary. The tier-boundary check in
-`scripts/check_tier_deps.sh` enforces the public surface that has been cleaned
-up so far.
+The Go workflow control plane has its own SQLite store for definitions, immutable snapshots, work
+items, artifacts, parks, and lifecycle events. That store is not DB1 or DB2 and has one writer:
+`aimee-wfe`.
 
-Operationally, DB1 is local to the user profile and belongs to one
-`aimee-server` process. It is where private runtime state and local evidence are
-captured first. DB2 is the durable knowledge source for project, workspace, and
-global facts plus their dense embeddings; it may be local to the same machine or
-shared by multiple servers. Shared deployments should receive only information
-appropriate for that shared scope, through the memory, learning, reflection, and
-KB APIs that promote or reflect local server evidence into durable knowledge.
+## Rules
 
-The vector tier was originally a separate Qdrant sidecar; it was folded
-into DB2 as a pgvector extension in #1575, vectors live in the same Postgres
-instance as the rest of DB2 and need no separate connection or service.
+- `aimee-server` never links libpq or sends SQL to DB2.
+- `aimee-kb` never links SQLite or opens DB1.
+- thin clients and browser clients open neither store.
+- cross-tier work uses typed `/v1` operations.
+- provider vocabulary and storage handles stop at the owning module.
+- the shared WORM chain primitive may cross the boundary only while it remains pure hashing.
+
+Build and dependency checks enforce these rules.
+
+## Deployment
+
+DB1 belongs to one server profile. DB2 can serve one user, a team, or a company, but its contents
+must match that scope.
+
+The default KB container runs a private PostgreSQL 18 cluster with pgvector and pgvectorscale. An
+external PostgreSQL server is still DB2; changing its location does not change ownership. Use the KB
+export helper or `pg_dump` before moving it.
+
+Dense vectors live in DB2 beside their source rows. The old Qdrant sidecar is not part of the
+current topology.

--- a/docs/STRUCTURED_PDF.md
+++ b/docs/STRUCTURED_PDF.md
@@ -1,239 +1,82 @@
-# Structured PDF: coordinate-anchored evidence, tables, crops, and OCR
+# Structured PDF
 
-aimee-kb can ingest a PDF as **coordinate-anchored evidence** instead of a flat
-blob of text. Every retrieved snippet carries the page and bounding box it came
-from, so an answer can be traced back to the exact place on the page. On top of
-that spine the KB optionally recognises **table cells**, renders **visual crops**
-of figures/tables/pages, and **OCRs scanned pages**, each behind its own
-capability flag, each degrading to the layer below when its dependency is
-absent.
+Structured PDF ingestion keeps evidence that plain text extraction loses: page coordinates, reading
+order, tables, visual regions, OCR, and page-linked citations.
 
-Everything here lives entirely in **aimee-kb** (the personal `aimee-server` holds only
-thin `kb_client` calls). It is **off by default**: a PDF upload is handled by the legacy
-flat-text path until you enable the structured extractor, and each higher layer is a
-separate opt-in.
+## Layers
 
----
+The base spine stores page text and coordinates. Optional layers add:
 
-## What you get
+| Layer | Setting | Result |
+| --- | --- | --- |
+| dense PDF retrieval | `kb_pdf_vector_enabled` | isolated PDF vectors and answerability signal |
+| table recognition | `kb_pdf_tsr_enabled` | cells and table lookup |
+| visual assets | `kb_pdf_assets_enabled` | content-addressed page/figure/table crops |
+| OCR | `kb_pdf_ocr_enabled` | scanned-page text through the same citation path |
 
-| Layer | Capability | Surfaced as |
-|-------|-----------|-------------|
-| **Spine** | Text + per-line geometry; page-boundary chunks; line-level `{page_no, bbox, quote}` citations | `pdf_search_chunks`, `pdf_open_page`, `pdf_open_neighbors`, `pdf_inspect_structure` |
-| **§A retrieval** | Vector candidates over an **isolated** PDF-only embedding relation + per-query **answerability** signal | the same `pdf_search_chunks` (now lexical **and** vector), with `score` / `matched_via` / `answerability` |
-| **§B tables** | Table-structure recognition → structured `{row, col, text, confidence}` cells | `pdf_lookup_table` |
-| **§C visual** | Figure/table/page crops in a content-addressed blob store | `pdf_list_assets`, `pdf_open_asset` |
-| **§D OCR** | Scanned / image-only pages → text + geometry through the **same** citation path | When OCR recovers text it is transparent (the spine surfaces above carry it; upload reports `text_layer='ocr'`); when OCR is off/absent the upload reports `text_layer='none'` + `asset_only` |
+Each layer has its own dependency and failure state. Enabling assets does not imply OCR or tables.
+Use [generated configuration](gen/configuration.md) for current sidecar commands and bounds.
 
-Every read surface honours the **same access control** as the spine
-(`document_key`-level check + quarantine), and table cells / crops are gated at read
-time by a join to the authoritative document, never by a cached flag. Structured-PDF
-content is reachable **only** through these `pdf_*` tools. It is deliberately kept out
-of the general `/v1/search` (both the vector path and the convention/derived-artifact
-sweeps), so a PDF cannot leak into an unscoped search.
-
----
-
-## Enabling it
-
-Each capability is a config flag (set with `aimee config set <key> <value>` or in
-`aimee.yaml`); the recognition layers also need a local sidecar or poppler binary.
-**Defaults are off.** Two kinds of dependency: the **poppler binaries**
-(`pdftotext`, `pdftoppm`) are *hard*: if a flag that needs one is on but the binary
-is missing, that step **errors** (e.g. a PDF upload returns an extraction error)
-rather than silently degrading; the **sidecars/embedder** are *soft*: when absent
-the feature degrades to the layer below (see [Degradation](#degradation)).
+## Upload
 
 ```bash
-aimee config set kb_pdf_ingest_enabled true
-aimee config set kb_pdf_vector_enabled true
-aimee config set kb_pdf_tsr_enabled    true
-aimee config set tsr_command           https://tsr.local:9000/recognize   # an HTTP URL
-aimee config set kb_pdf_assets_enabled true
-aimee config set kb_pdf_ocr_enabled    true
-aimee config set ocr_command           https://ocr.local:9000/recognize   # an HTTP URL
+aimee kb docs push ./document.pdf
+aimee kb ingest status
 ```
 
-| Flag | Default | What it turns on | Needs |
-|------|---------|------------------|-------|
-| `kb_pdf_ingest_enabled` | off | Route `.pdf` uploads through the structured extractor (geometry spine) instead of flat `pdftotext` | `pdftotext` (poppler) |
-| `kb_pdf_vector_enabled` | off | Embed PDF chunks into the isolated `kb_pdf_embeddings` relation + add the vector leg to `search_chunks` | the deployment's embedder |
-| `kb_pdf_tsr_enabled` + `tsr_command` | off | Run the table-structure-recognition sidecar at ingest → `kb_table_cells` | a TSR sidecar (`AIMEE_TSR_URL` env fallback) |
-| `kb_pdf_assets_enabled` | off | Render figure/table/page crops to the blob store + `kb_doc_assets` | `pdftoppm` (poppler) |
-| `kb_pdf_ocr_enabled` + `ocr_command` | off | OCR scanned / no-text-layer PDFs and ingest the text + geometry through the normal path | an OCR sidecar (`AIMEE_OCR_URL` env fallback) |
+The thin client uploads bytes. The KB validates type, size, scope, and content hash before commit.
+Temporary extraction files stay outside the corpus and are removed after the bounded job.
 
-Blob-store / reconciliation knobs (Phase §C):
+## Evidence model
 
-| Flag | Default | Meaning |
-|------|---------|---------|
-| `kb_pdf_blob_dir` | `<kb-config-dir>/kb-blobs` | Blob store root override (`<kb-config-dir>` is the aimee-kb config dir under `AIMEE_HOME`) |
-| `kb_pdf_blob_recon_secs` | `3600` | Orphan-blob reconciliation sweep interval (`<=0` disables) |
-| `kb_pdf_blob_orphan_alarm_mb` | `1024` | Warn when reclaimable orphan blob bytes exceed this many MB (`<=0` disables) |
+A cited span keeps:
 
-A typical full-feature deployment sets all five capability flags on and points
-`tsr_command` / `ocr_command` (or `AIMEE_TSR_URL` / `AIMEE_OCR_URL`) at the local
-sidecars, with `pdftotext` + `pdftoppm` installed in the aimee-kb image.
+- document and content hash;
+- page number;
+- bounding box and reading order;
+- extracted or OCR text;
+- table/cell identity where present;
+- linked asset digest where present;
+- extractor/model identity and confidence.
 
-### The sidecars
+Text, table, and image records point back to the same immutable source version. Re-ingesting changed
+bytes creates a new version; it does not move old coordinates under a new file.
 
-TSR and OCR are **optional local HTTP sidecars**, deployed the same way as the
-embedder/reranker, a service aimee-kb POSTs to. Despite the `_command` suffix
-(inherited from `embedding_command`), `tsr_command` / `ocr_command` take the
-sidecar's **HTTP URL**, not a binary path (the `AIMEE_TSR_URL` / `AIMEE_OCR_URL`
-env vars are the fallback).
+## Retrieval
 
-These sidecars must be **deployed inside the KB trust perimeter**: the operator runs
-them with no external network and no document-content retention. That is a deploy-time
-obligation, not something aimee enforces at runtime: aimee-kb hands the sidecar
-document-derived content (page text/geometry, or a rendered page image), so a sidecar
-that egresses or retains is a data-exposure path. aimee never links or bundles them.
+Normal document search can return PDF spans. Structured tools add table lookup and guarded asset
+opening. Answerability states whether the retrieved PDF evidence is strong enough for the question;
+it does not manufacture an answer when coverage is weak.
 
-`pdftotext` and `pdftoppm` are operator-installed poppler binaries run as hardened
-subprocesses (separate process, `RLIMIT_CPU/AS/FSIZE`, a wall-clock deadline + output
-byte-cap, `setsid` + process-group kill on timeout, and `0600` scratch unlinked on
-every path. `RLIMIT_AS` is what bounds an image/decompression-bomb before output is
-written). aimee never links or bundles them either.
-
----
-
-## Uploading
-
-`POST /v1/kb/docs` (multipart) with `file`, a `scope` (project), and (**required** for
-a PDF under `kb_pdf_ingest_enabled`) a `sensitivity_class` of `public`, `internal`, or
-`restricted` (a PDF upload with a missing/invalid class is a 400, no rows written). A
-`.pdf` whose bytes are not a real PDF (no `%PDF-` header) is rejected. A document's
-identity is `(scope, document_key)` where `document_key` is its file path, so
-re-uploading under the same scope + name **replaces** the prior version in place
-(re-extraction; the layers re-derive).
-
-A `restricted` document is **quarantined** (`quarantine_state='pending'`, withheld from
-every read surface) until an **owner** releases it:
-
-```
-POST /v1/pdf/quarantine   { "project": "...", "document_key": "...",
-                            "action": "confirm" }   # release (now retrievable)
-                                  # or "reject"     # purge the document + its derived rows
-```
-
-Owner authorization is enforced before the handler runs; the response reports the
-number of pending chunks acted on.
-
-The upload response reports what was ingested, including the §D status:
-
-```json
-{ "doc_kind": "pdf", "chunks": 12, "regions": 480, "assets": 12,
-  "text_layer": "native", "asset_only": false, "sensitivity_class": "internal" }
-```
-
-- `text_layer` ∈ `native` (real text layer) | `ocr` (recovered by the OCR sidecar) |
-  `none` (scanned, no text recovered).
-- `asset_only` is `true` when a scanned PDF yielded **no text** but **did** yield
-  visual crops, so an operator is never misled into thinking a scanned contract is
-  text-searchable. Re-uploading once OCR is deployed upgrades it in place.
-
----
-
-## Retrieval surface
-
-Read-only, access-gated. Reachable over `/v1` and as project-scoped MCP tools (the
-caller's token scope is enforced before dispatch; restricted/quarantined documents
-are withheld).
-
-| MCP tool | `/v1` route | Returns |
-|----------|-------------|---------|
-| `pdf_search_chunks` | `GET /v1/pdf/search` | Matching chunks with line-level `{page_no, bbox, quote}` citations, a relevance `score`, `matched_via` (`lexical`\|`vector`), `has_citation`, and a per-query `answerability` object |
-| `pdf_open_page` | `GET /v1/pdf/page` | Every region on one page, ordered by line |
-| `pdf_open_neighbors` | `GET /v1/pdf/neighbors` | The prev/next reading-order chunks of a hit |
-| `pdf_inspect_structure` | `GET /v1/pdf/structure` | The document's chunk/page outline |
-| `pdf_lookup_table` | `GET /v1/pdf/lookup_table` | Recognised table cells `{row, col, text, tsr_confidence}` + a `tsr_status` marker (`ran` \| `not_a_table` \| `unavailable`) |
-| `pdf_list_assets` | `GET /v1/pdf/assets` | A document's visual crops, each an **opaque `asset_id`** + page/bbox/kind/caption |
-| `pdf_open_asset` | `GET /v1/pdf/open_asset` | One crop's image bytes (base64) for an opaque `asset_id` |
-| — | `POST /v1/pdf/quarantine` | Owner-only: confirm (release) or reject (purge) a pending restricted document |
-
-### Answerability
-
-`pdf_search_chunks` returns a per-query-over-corpus **answerability** judgment
-("given *this* query, how well can the KB answer it") as a `score ∈ [0,1]` plus a
-`label ∈ {NONE, LOW, MEDIUM, HIGH}` (default cutoffs `<0.15`→NONE, `<0.40`→LOW,
-`<0.66`→MEDIUM, else HIGH; config-overridable). It is a **KB-side shared signal**,
-deliberately a
-*distinct field* from any server-side per-user confidence tier. Clients must not
-conflate the two. The combiner is a documented deterministic function of query-scoped
-inputs (top relevance, query-term coverage, hit saturation) so the same `(query,
-corpus state)` always yields the same score.
-
----
-
-## Access control & security
-
-- **Sensitivity + quarantine.** Every upload carries a `sensitivity_class`; it is
-  stamped on each chunk/region/cell/asset row. `restricted` documents are withheld
-  until an owner confirms them. Region-level (sub-document) access control is out of
-  scope; the `document_key` is the access unit.
-- **PDF vectors are structurally isolated.** PDF chunk embeddings live in a
-  **dedicated `kb_pdf_embeddings` relation that the general `/v1/search` transport
-  never reads**: isolation by schema/module boundary, not a runtime `WHERE` filter
-  (which would be a classification, not an access, boundary). A `quarantine_state`
-  predicate rides inside the PDF surface as defense-in-depth.
-- **Table cells and crops gate on the live document.** `lookup_table`,
-  `open_asset`, and the asset list resolve through a join to the authoritative
-  `kb_documents` row (`doc_kind='pdf'` + quarantine + project, bound to the real
-  `file_path`). A guessed/foreign/withheld key returns empty, never the cached
-  denormalised value.
-- **The blob store never exposes the hash.** Crops are content-addressed by sha256
-  (free dedup), but the sha is a **KB-internal identifier**: never returned to a
-  client, never in a URL/log/error, and the blob directory is served by **no** file
-  route. The sole read path is `open_asset`, keyed on the **opaque `kb_doc_assets`
-  row id** (never the hash), which applies the document ACL and writes a structured
-  access audit log entry (allowed/denied) before streaming bytes. (Today that entry
-  is a structured log line; a durable/WORM, hash-chained audit store is a tracked
-  enhancement; see the limits below.) Content-addressed dedup never widens access. The
-  gating is on the per-document asset row, not the shared bytes.
-- **Sidecars are not an egress path.** TSR/OCR and `pdftoppm` run inside the
-  perimeter with no external network and no content retention.
-
-PII posture: access control + uploader-declared sensitivity is the control;
-automated PII detection is not in scope.
-
----
+Assets are opened through an access-checked, audited route. A result never returns an arbitrary
+filesystem path.
 
 ## Degradation
 
-Each layer is independent. A **flag off** falls back to the layer below; a **soft
-dep** (embedder/sidecar) absent degrades; a **hard dep** (poppler binary) absent
-errors that step.
+| Missing dependency | Behavior |
+| --- | --- |
+| vector backend | coordinate/lexical evidence remains; dense signal marked absent |
+| table recognizer | page text remains; no table structure claim |
+| renderer | text remains; no asset URL |
+| OCR | born-digital text remains; scanned page may be asset-only |
+| synthesis | evidence returns without generated answer |
 
-| Condition | Result |
-|-----------|--------|
-| `kb_pdf_ingest_enabled` off | PDF goes through the legacy flat-text path (no geometry) |
-| `kb_pdf_ingest_enabled` on, `pdftotext` **absent** | The PDF upload returns an extraction error (422); no rows written (hard dep) |
-| `kb_pdf_vector_enabled` off, or embedder absent | `search_chunks` is lexical-only (still cited) |
-| `kb_pdf_tsr_enabled` off, or TSR sidecar unreachable | Table regions stay normal text chunks; `lookup_table` reports `tsr_status='unavailable'` |
-| `kb_pdf_assets_enabled` off | No visual crops; text retrieval unaffected |
-| `kb_pdf_assets_enabled` on, `pdftoppm` **absent** | No crops are produced (rendering fails best-effort); text/ingest unaffected (hard dep, but non-fatal here) |
-| `kb_pdf_ocr_enabled` off (or OCR sidecar unreachable) on a scanned PDF | Ingested **asset-only** if crops were rendered (`text_layer='none'`, `asset_only=true`); otherwise text-less with no crops (`text_layer='none'`, `asset_only=false`) |
-| `kb_pdf_ocr_enabled` on, sidecar recovers text | Text + geometry ingest transparently, same chunks/regions/citations as native text (`text_layer='ocr'`) |
+A stage error remains visible in ingest status and can be retried. The base document should not be
+discarded because one optional layer failed.
 
----
+## Security
 
-## Operational notes & current limits
+PDFs are untrusted input. Extraction runs with body, page, pixel, time, memory, process, and output
+bounds. External sidecars receive only their required file/version and no provider or database
+credentials.
 
-These ship today but are **gated to default-off** pending deploy-tier validation:
+OCR text and visual assets inherit the document's scope. Asset IDs are content-addressed but not
+public. Every open checks the current principal and writes an audit record.
 
-- **Sidecar/binary deploys.** The TSR + OCR models and the poppler binaries are
-  deployed on the aimee-kb image; recognition/render quality is validated on the
-  deploy target (the code paths degrade safely when they are absent, but their
-  output is not exercised in code-only CI).
-- **Corpus-scale geometry volume.** Per-line `kb_doc_regions` (and `kb_table_cells`)
-  volume grows with the corpus; measure it on the target corpus and take a
-  partition/archive decision **before** flipping a capability default-on.
-- **Engine-level privilege boundary.** The in-code structural isolation of
-  `kb_pdf_embeddings` / `kb_doc_assets` is the load-bearing control; a hardened
-  deploy additionally provisions a least-privilege DB role and/or a row-security
-  policy on those relations (both layers present, neither alone trusted).
-- **`open_asset` transfer.** Crops are returned inline as base64 with a size cap; a
-  binary-streaming path for very large crops, and a durable/WORM access-audit store,
-  are tracked enhancements.
-- **Re-ingest is the upgrade path.** Re-uploading a document once a higher layer
-  (OCR, TSR) is deployed upgrades it in place; the original PDF is retained so
-  extraction can be re-run.
+## Operations
+
+- Keep source PDFs until derived evidence has passed verification.
+- Monitor queue age, page failures, OCR rate, asset bytes, and vector backfill.
+- Rebuild derived layers after extractor or embedding changes; do not rewrite source identity.
+- Test rotated pages, multi-column text, malformed xrefs, image-only scans, large tables, and mixed
+  scripts before enabling a corpus.

--- a/docs/THIN_CLIENT.md
+++ b/docs/THIN_CLIENT.md
@@ -1,207 +1,115 @@
-# Thin Client: Workspaces, Agents & Credentials
+# Thin client
 
-This document describes how the `aimee` thin client works against a **remote**
-`aimee-server` (e.g. a shared server reached over `tcp:`), covering three things
-specific to remote operation:
+`aimee` is a DB-free client for Linux, macOS, and Windows. It owns client-local work—hooks, stdio
+protocols, source reads, uploads, and local CLI-agent execution. The server owns state, policy,
+credentials, and model calls.
 
-1. **Workspaces** are ingested *from the client* (the server never reads the
-   client's filesystem), the client still owns the working tree.
-2. **Agent/delegate credentials live in the server's sealed vault**, encrypted
-   at rest and decryptable by the server autonomously. They are **not** held on
-   the client and there is **no** RAM session keyring (the legacy client-held
-   keyring + per-session push were retired; the vault is the single store).
-3. The **attention guard** is inert by default.
+## Connect
 
-It complements [WORKSPACES.md](WORKSPACES.md), [DELEGATES.md](DELEGATES.md), and
-[SECURITY.md](SECURITY.md).
+```bash
+aimee remote set https://host:8743 <bootstrap-bearer>
+aimee remote status
+```
 
-## What runs where
+The enrollment path pins the server certificate and rotates the bootstrap bearer. Linux also
+enrolls a client mTLS certificate. Verify the printed fingerprint out of band.
 
-| Concern | Thin client (your machine) | aimee-server (remote) |
+Connection precedence is:
+
+1. per-command transport flags;
+2. `AIMEE_SERVER_URL` and token/certificate environment;
+3. `~/.config/aimee/remote.conf`;
+4. the local Unix socket.
+
+`aimee remote clear` removes the persisted remote target and returns to the local socket.
+
+## What stays on the client
+
+- the checked-out working tree;
+- local paths and filesystem handles;
+- supported coding-tool hook and MCP/ACP configuration;
+- native TLS trust state;
+- installed provider CLIs and their local logins;
+- runner execution explicitly delegated back to this client.
+
+The client does not hold DB1, DB2, server vault keys, workflow state, or KB credentials.
+
+## Workspaces and uploads
+
+```bash
+cd /path/to/project
+aimee workspace add .
+aimee index scan .
+aimee kb docs push ./docs/design.pdf
+```
+
+The client reads and uploads bytes. The server records a detached workspace and sends content to the
+KB. It never tries to open `/path/to/project` on its own filesystem.
+
+Uploads are bounded and chunked where the operation permits it. A source change during an upload is
+detected through size/hash metadata rather than accepted as one coherent file.
+
+## Remote writes
+
+The shared bearer is read-only. A remote write needs a short-lived KB-signed identity plus a grant
+for the exact server, team, and subject. `data` covers memory, document, and index writes. `full`
+also covers agent, delegate, runner, and workspace control.
+
+The server refuses every remote write until its server ID, team ID, and management-JWKS trust bundle
+are configured. The old `aimee.api.remote_writes` value is not an authorizer.
+
+## Local CLI agents
+
+Some providers are local programs rather than HTTP APIs. They need the local executable, terminal,
+working tree, and login. When a remote workspace selects one, the server sends a bounded execution
+request over the client runner channel.
+
+The provider login stays on the client. The server receives output and status, not the credential.
+Runner and workspace writes require full remote-write authority.
+
+Claude CLI delegation is disabled by default. Enable it only after checking the provider's terms for
+unattended use.
+
+## Credentials
+
+API keys, server-side OAuth tokens, git credentials, and delegate secrets belong in the server vault.
+Do not keep them in `agents.json` or push them once per session.
+
+Legacy client key files should be imported, verified, and removed using the installed agent/vault
+commands. Keep a secure backup until the first successful provider probe.
+
+## Client integrations
+
+Setup can register:
+
+- Claude Code hooks and MCP;
+- the Codex local plugin, hooks, and MCP;
+- supported Copilot hooks and MCP;
+- VS Code MCP/ACP/model endpoints;
+- Claude Desktop MCP.
+
+Set `AIMEE_NO_CLIENT_INTEGRATIONS=1` before setup to skip global changes. Registrations point to the
+local `aimee` binary, which inherits the remote target.
+
+## TLS by platform
+
+| Platform | Backend | Automatic certificate enrollment |
 | --- | --- | --- |
-| Your working tree / files | yes | no (never reads client fs) |
-| Agent API keys / Codex OAuth | not stored here | **sealed vault**, encrypted at rest |
-| Interactive CLI logins (Claude CLI, Codex CLI) | login lives here | runs against the client's login (see below) |
-| Engine, agent loop, DB1/DB2, KB |, | yes |
-| Code index, memory, chat/delegate execution |, | yes |
+| Linux | OpenSSL | yes |
+| macOS | Secure Transport | no; provision explicitly when required |
+| Windows | Schannel | no; provision explicitly when required |
 
-Point the client at the server once:
+`AIMEE_TLS_INSECURE=1` is only for first contact with a known self-signed server. Confirm and pin the
+fingerprint, then remove it.
 
-```sh
-aimee remote set https://SERVER:8743 <bearer-token>
-# or per-invocation: --server / AIMEE_SERVER_URL (+ --server-token / AIMEE_SERVER_TOKEN)
-```
+## Failure behavior
 
-The server's `/v1` is TLS-only off-loopback (`:8743`, auto-provisioned self-signed
-cert; plaintext `:8740` is loopback-only). Set `AIMEE_TLS_INSECURE=1` for the
-self-signed cert, or trust/pin it.
+- A changed certificate pin stops the connection.
+- An expired or revoked client identity returns an authentication error.
+- A missing, `off`, or insufficient grant returns `403` for writes.
+- An unavailable client runner fails the local-CLI attempt; the server does not move that login to
+  itself.
+- A partial upload is not committed as a complete object.
+- A server/client operation mismatch returns a typed unsupported-operation error.
 
-A remote endpoint is "tcp" (`http(s)://host:port`) vs. a co-located unix socket.
-The behaviors below activate only for a **remote tcp** endpoint; co-located use
-is unchanged.
-
-### Exclusive transport selection
-
-A configured remote is an **exclusive** choice for a thin-client command that
-reaches the `/v1` API: the request goes to the remote, with no probe of a
-co-located unix socket and no fallback between them. One such invocation cannot
-be served partly by the remote and partly by a local server.
-
-Ordinary `/v1` command routing was already remote-aware; this closes the gap for
-the commands that were still pinned to the local socket:
-
-| Command | With a remote configured |
-| --- | --- |
-| `aimee hooks pre` / `hooks post` | dispatched to the remote |
-| `aimee session-start` | served by the remote, selected before any local availability probe |
-| `aimee optimize points\|baseline\|replay\|run\|compare` | dispatched to the remote |
-| delegate-availability probe (ordinary startup) | dispatched to the remote |
-
-When the remote is **unreachable**:
-
-- `aimee optimize …` fails. It does not fall back to a co-located server, so a
-  mistyped or down endpoint surfaces as an error rather than silently reporting
-  some other server's data.
-- `aimee hooks …` still **fails open** (the tool call is allowed). That is the
-  established policy-server-unavailable behavior, not a local fallback — no
-  local socket is contacted either way.
-
-For local execution, clear the remote (`aimee remote clear`, or drop `--server` /
-`AIMEE_SERVER_URL` / `AIMEE_API_ENDPOINT` from the environment).
-
-The memory-file guard is unaffected. On a remote-only host the pre-tool hook used
-to run a narrowed local path that enforced only the `memory_redirect` check,
-because the full `pre_tool_check` needed local session state. The full check now
-runs on the remote instead, so the guard is enforced by the server rather than
-partially reimplemented on the client.
-
-### Server write posture
-
-Mutating `/v1` calls require the server to allow remote writes. Set it in the
-server's `aimee.yaml` (`aimee.api.remote_writes: off|data|full`) **or** via the
-`AIMEE_API_REMOTE_WRITES` environment variable (deploy truth, applied even when
-the config file is read-only or absent, e.g. a containerized server). `full`
-grants the LAN bearer the capabilities needed for workspace add and ingest; use
-it only on trusted networks.
-
-## Workspaces (client-push ingest)
-
-On a thin client the workspace root lives on *your* machine, which the server
-cannot read. `aimee workspace add <path>` therefore:
-
-1. resolves `<path>` locally,
-2. registers it on the server as a **`detached`** workspace (the server stores
-   the path verbatim and does not try to scan its own filesystem),
-3. collects the source files locally and pushes them to `POST /v1/index/ingest`,
-   which relays them to aimee-kb's code index.
-
-```sh
-aimee workspace add ~/dev          # register + ingest from this machine
-aimee workspace list               # shows dev as [detached] + indexed projects
-aimee index scan [path]            # re-push one path, or every detached workspace
-aimee index find <symbol>          # query the code index
-```
-
-Notes:
-- The push is **chunked** to stay under aimee-kb's 1 MB request-body cap; large
-  trees are split across several batches.
-- A single `workspace add` collects up to `CODE_COLLECT_MAX_FILES` (4096) files
-  and logs when a tree is truncated; re-run `index scan` from the client to
-  re-push after changes.
-- VCS/build/hidden directories (`.git`, `node_modules`, `target`, `dist`, …) and
-  binary/oversized files are skipped.
-
-## Agents & credentials (server vault)
-
-Credentials for delegates and the primary provider, API keys and Codex/OAuth
-tokens, live in the server's **sealed vault**: encrypted at rest, keyed by
-agent, and decryptable by the server autonomously (a dual-access wrap lets the
-server unseal them without an interactive unlock). They are **not** held on the
-client, and there is **no** per-session RAM keyring or credential push. The
-vault is the single, permanent store. See [SECURITY.md](SECURITY.md).
-
-- `agent add` stores the **definition** (name, endpoint, model, roles, provider)
-  and, with `--key`, seals the **key into the vault** under the server principal.
-  Plaintext key storage is refused, the key only ever lands encrypted.
-- Every chat/delegate turn resolves the agent's credential from the vault (the
-  in-flight turn's attested principal, falling back to the server principal). No
-  credential is pushed per session and none is cached on the client.
-
-### Adding an agent
-
-```sh
-aimee agent add minimax https://api.minimax.io/v1/chat/completions MiniMax-M3 \
-      --key "$MINIMAX_KEY" --provider openai --default \
-      --roles "code,review,explain,refactor,draft,execute,summarize,format,diagnose,validate"
-```
-
-`--key K` sends `K` to the server once, where it is sealed into the vault; it is
-never stored on the client and never written to disk in plaintext. Set the
-primary chat provider to any configured agent:
-
-```sh
-aimee config set provider minimax
-```
-
-You configure agents **once on the server**, the vault is shared across every
-client that reaches it, so there is no per-machine key setup.
-
-### Migrating legacy client-held keys
-
-If an older client left keys in `~/.config/aimee/agent-keys.json`, move them into
-the vault:
-
-```sh
-aimee agent key import --dry-run   # preview what would be vaulted; changes nothing
-aimee agent key import             # vault each leftover key AND scrub it from the
-                                   # plaintext agent-keys.json (scrub is the default)
-aimee agent key import --keep      # vault but retain the local plaintext copy
-```
-
-Keys belong only in the encrypted server vault, so `import` deletes each plaintext
-entry once its vault store is confirmed. Pass `--keep` only if you deliberately want
-an offline plaintext backup.
-
-This is the **only** remaining use of `agent-keys.json`; new keys go straight to
-the vault. Run it on the server host over the Unix socket, or from a connection
-holding the `vault:write:server` capability.
-
-### Codex (ChatGPT OAuth)
-
-Codex/OAuth tokens are stored in the vault too, so a Codex agent authenticates
-server-side with no per-session push from the client. Use the server-hosted
-OAuth setup, which installs the CLI and seals the token into the vault:
-
-```sh
-aimee agent setup codex-oauth       # server-hosted OAuth → token sealed in the vault
-aimee config set provider codex      # optional: use Codex as the primary
-```
-
-`provider codex` is the Codex adapter (provider `chatgpt`, `auth_type`
-`codex-oauth`, the responses-wire delegate driver). A legacy plaintext token
-(from an older db1/secrets store) is migrated into the vault and scrubbed on
-first use.
-
-## Attention guard
-
-The PreToolUse attention guard (`aimee attention-guard`, used by the Claude Code
-integration) is **inert by default**: recursive raw scans (`grep -r`, `Grep`,
-`Glob`, …) are allowed unless you set a positive `ingress_max_raw_scans` cap in
-`aimee.yaml`, after which a session may run that many raw scans before further
-ones are redirected toward the indexed tools. The destructive-file guard (it
-blocks a hard-destructive command on a file the session has actively edited) is
-always on. `AIMEE_GUARD=0` disables the guard entirely.
-
-The client's Claude Code integration (MCP server + hooks) is registered at the
-**installed** binary path and self-heals: running the installed client rewrites
-any stale hook/MCP command (e.g. one left pointing at an old build directory) to
-the resolved binary.
-
-## New `/v1` endpoints
-
-| Method | Endpoint | Purpose |
-| --- | --- | --- |
-| POST | `/v1/index/ingest` | Index client-pushed `{rel_path, content}` files for a workspace the server cannot see (relays to aimee-kb). |
-
-Both `/v1/index/scan` and `/v1/index/ingest` run as synchronous handlers under
-the async op-run worker (poll `GET /v1/runs/{id}`).
+Use `aimee remote status`, then `aimee status`, then the failing command with `--json` when available.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,78 @@
+# Troubleshooting
+
+Start at the first broken boundary.
+
+```bash
+aimee remote status
+aimee status
+aimee kb status
+aimee audit verify
+```
+
+## Client cannot connect
+
+Check URL, DNS, port, server health, certificate fingerprint, bearer rotation, client certificate,
+and revocation. A changed pin is a stop, not a warning to bypass.
+
+For local use, check the Unix socket, service manager, server log, and config-directory ownership.
+
+## Reads work; writes fail
+
+Check `AIMEE_SERVER_ID`, `AIMEE_SERVER_TEAM_ID`, the management-JWKS trust bundle, the exact subject
+spelling and grant tier, and the identity-token refusal reason. `aimee.api.remote_writes` cannot fix
+the denial. Use the structured `403` and request ID; do not widen every user to test one grant.
+
+## KB is unavailable
+
+Check `AIMEE_KB_API_URL`, service bearer, TLS, KB health, PostgreSQL readiness, extensions, disk, and
+connection limits. The server does not autostart a missing KB.
+
+## Search returns nothing
+
+Check scope, ingest status, document commit, code-index freshness, embedder readiness, and filters.
+An honest degraded lexical result differs from an empty ingest.
+
+## Delegate fails
+
+Run `aimee agent probe <name>`. Then inspect admission, provider auth, model capability, agent limit,
+workspace authority, worktree, sandbox image, package gate, network policy, and the first attempt log.
+
+No network is the container default. Add the narrow egress the task needs; do not disable isolation
+globally.
+
+## Workflow parks
+
+Read the named park reason and latest artifact. Common causes are a human gate, no valid panel,
+repeated feedback, agent saturation, missing commit, failed verification, merge conflict, lost replay,
+forge identity, or spend limit.
+
+Repair the condition and resume the same run so its evidence is preserved.
+
+## Audit or capture gap
+
+Check the event-bus drop counter, sink write errors, free disk, capture classification, and whether the
+daemon shut down cleanly. `publish` success means accepted into the producer ring, not yet durable.
+Graceful stop drains; a crash may leave the last capture classified open or truncated.
+
+Do not rewrite or prune the WORM store while investigating. Seal a copy first.
+
+## Browser deploy fails
+
+Check the Docker socket mount, daemon access, image pulls, volume ownership, port conflicts, and the
+managed server log. If Docker authority is intentionally absent, use the split stack.
+
+## Report a useful failure
+
+Include:
+
+- version and commit;
+- deployment shape and platform;
+- operation/request ID;
+- exact command and structured error;
+- first relevant log error;
+- health output with secrets removed;
+- whether the failure survives restart;
+- the smallest reproduction.
+
+Never attach tokens, client keys, vault material, database URLs with passwords, or raw memory that
+contains private data.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,437 +1,107 @@
-# Upgrading aimee
+# Upgrading from v0.2.192
 
-Notable user-facing changes, newest first. Each entry says what changed, whether
-it can break an existing deployment, and what to do about it.
+Read [What's new](WHATS_NEW.md) first. This cycle changes deployment, storage, credentials, remote
+identity, workflows, and removed commands.
 
----
+## Before
 
-## 0.3.0 — `/v1` writes are authorized per user, not per deployment
+1. Stop starting new workflows and wait for active writes to finish.
+2. Run `aimee audit checkpoint` and `aimee audit verify`.
+3. Back up the server config directory, DB1, workflow store, vault custody, TLS state, and audit
+   witness material.
+4. Dump DB2 with `pg_dump` or the KB export helper.
+5. Export old `work_queue` rows if you need them; the upgrade removes those tables.
+6. Record current compose files, image digests, environment, external endpoints, and volume names.
 
-**This is why the release is 0.3.0 and not 0.2.x.** Two things that authorize
-writes today stop authorizing them. An appliance that upgrades without acting
-will accept reads and refuse every remote write. That is deliberate — the
-alternative is silently carrying a deployment-wide write switch into a release
-that claims per-user authorization — but it is not a change you want to discover
-from a monitoring alert.
+Do not rely on a raw copy of a live SQLite main file. Take a consistent backup with its WAL state.
 
-**What changed.** `aimee.api.remote_writes` was a single process-global switch:
-set it to `data` or `full` and *every* caller holding the shared bearer got that
-tier. There was no way to say "Alice may write, Bob may not". Write authority is
-now a property of the authenticated **user**, carried in a short-lived,
-kb-signed identity token and checked on every `/v1` request.
+## Deployment changes
 
-**Does this affect me?** Yes, if any of these are true:
+- Replace `aimee-combined` with the managed server or split stack.
+- New KB containers start private PostgreSQL when `AIMEE_DB2_URL` is unset.
+- The new compose topology does not import an older sibling PostgreSQL volume.
+- Keep the old database reachable and set `AIMEE_DB2_URL`, or dump and restore into the embedded
+  cluster.
+- Never use `docker compose down -v` until the new database has been verified and the backup has
+  been restored in a clean test.
 
-- you set `aimee.api.remote_writes` to `data` or `full`;
-- anything writes to `/v1` over TCP — thin clients, webchat, scripts, cron jobs,
-  CI, audit tooling;
-- you rely on the standing shared bearer (`AIMEE_API_BEARER`) for writes.
+## Identity and credentials
 
-If your deployment is read-only over TCP, or drives aimee exclusively over the
-local UDS socket, this change is transparent.
+- Move agent keys and OAuth tokens into the server vault.
+- Remove legacy client plaintext only after a successful provider probe.
+- Re-enroll each thin client. Verify the server fingerprint before accepting the pin.
+- Give each user the required remote-write grant. The old global `remote_writes` value authorizes
+  nothing.
+- Review mTLS revocation, org catalogs, budgets, rate limits, and egress policy.
 
-**What stops working.**
+## Restore remote writes
 
-| Was | Now |
-|---|---|
-| `aimee.api.remote_writes=data\|full` authorizes writes for everyone | Parsed, but authorizes nothing. Startup warns; `remote_writes.global_ignored` counts requests that would formerly have been allowed by it |
-| Standing shared bearer / `AIMEE_API_BEARER` authorizes writes | Authorizes **reads only**. The reads it permits today are unaffected |
-| No per-user distinction | Each `(server, team, subject)` carries its own tier: `off`, `data`, or `full` |
+The shared bearer is read-only after this upgrade. `aimee.api.remote_writes=data|full` remains
+parsed, warns at startup, and increments `remote_writes.global_ignored`; it does not authorize a
+user write.
 
-The *one-time bootstrap* bearer is untouched. It has always been rotate-only —
-`handle_api_rotate_bearer` refuses every other TCP route until it is rotated — so
-no read path ever depended on it.
+Configure the server with `AIMEE_SERVER_ID`, `AIMEE_SERVER_TEAM_ID`, and
+`AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE`. Missing team configuration returns
+`no_team_configured`; missing or stale signing trust fails closed. The managed compose file does not
+set these for you.
 
-**The local UDS operator is unaffected and cannot be locked out.** A connection
-on the unix socket is the same-user trusted peer: it returns full capability and
-never consults the per-user tier. That is the recovery path if you get the
-configuration wrong, and it is why the appliance can always be repaired from a
-shell on the host.
+Grants are keyed by server, team, and exact authenticated subject:
 
-**What to do, in order.**
-
-1. **Before upgrading**, list who actually writes over `/v1`. Every one of them
-   needs a grant or a replacement credential.
-2. **Upgrade.** No grants exist yet, so remote writes are refused. Reads continue.
-3. **Grant the users who need to write.** Grants live in `kb_write_tier_grant`,
-   keyed by `(server_id, team_id, subject)`, and are written through the
-   `kb_write_tier_grant_set` / `kb_write_tier_grant_revoke` functions — direct
-   `INSERT`/`UPDATE` is deliberately not available to the runtime role, because
-   those functions also write the tamper-evident audit record for the change.
-4. **Verify** that the users you expect appear, with the tiers you expect, before
-   you tell anyone the upgrade is done.
-
-**What a `subject` looks like.** This is the field you will get wrong if nobody
-tells you, because a grant for the wrong spelling is silently a grant for nobody.
-A subject is an authenticated identity in one of four forms:
-
-| Form | When | Example |
-|---|---|---|
-| `<username>` | the local-PAM login — a plain host account name | `alice` |
-| `oidc:<iss>:<sub>` | the OIDC login | `oidc:https%3A//idp.example:alice` |
-| `cert:<issuer>:<serial>` | a machine identity from an mTLS client certificate | `cert:CN=aimee-ca:a1b` |
-| `owner` | the single-org bearer principal | `owner` |
-
-The OIDC and cert forms are namespaced by the authority that vouched, because a
-`sub` is unique only within its issuer and a serial only within its CA — the `:`
-inside an issuer URL is percent-encoded so the delimiters stay unambiguous. A
-PAM username carries no prefix: the host is the only authority, and the two login
-modes are mutually exclusive, so there is nothing for it to collide with.
-
-**One name is reserved.** A host account named literally `owner` cannot be
-granted — it is indistinguishable from the bearer principal. If you have such an
-account, it needs a different name or a different login mode.
-
-**The first grant.** Grants are administered by an org admin or the team's lead —
-but on a freshly upgraded appliance there may be neither, so the local operator
-is the root of trust. It installs the principal `owner`, which counts as admin.
-
-One detail that will otherwise cost you an afternoon: the operator installs its
-context with **team `0`**, not the team it is about to grant into. Team
-membership is only enforced for a team greater than zero, and `owner` is a member
-of no team, so passing the real team id fails with *"team not in principal
-memberships"*. Passing `0` is what makes the operator un-lockout-able. This is
-covered by an automated test precisely so it does not regress.
-
-**Replacing non-interactive callers.** Anything that writes without a human —
-cron, CI, audit tooling, service integrations — needs a service-account token
-rather than the shared bearer: the same token type and claim set, with a service
-`sub`, a fixed tier, and a longer expiry. Give each integration its own subject
-rather than sharing one, or you lose exactly the per-user attribution this
-release exists to provide.
-
-**Interactive callers** (thin clients, webchat) obtain a token by logging in
-through the adoption wizard.
-
-**Which login a user gets is not a choice you make per user — it is a property of
-the kb.** The two modes are mutually exclusive:
-
-- **An OIDC issuer is configured** → OIDC, and PAM is off. Set
-  `AIMEE_KB_OIDC_LOGIN_CLIENT_ID`, `AIMEE_KB_OIDC_LOGIN_AUTHORIZE_URL`,
-  `AIMEE_KB_OIDC_LOGIN_TOKEN_URL`, `AIMEE_KB_OIDC_LOGIN_REDIRECT_URI` and
-  `AIMEE_KB_OIDC_ISSUER`. The issuer is shared with the bearer verifier on
-  purpose: the issuer a login trusts and the issuer a token is checked against
-  must not be able to drift apart.
-- **No OIDC issuer** → the local PAM login, which is the one already used for
-  browser sign-in.
-
-`GET /v1/identity/auth-mode` reports which one a given kb is offering. A client
-is expected to ask rather than assume, because the flows differ — one redirects
-to an identity provider, the other collects a password.
-
-The client secret is **not** an environment variable. It is vault-custodied and
-read only at the moment of the code exchange, so it is never sitting where a
-crash dump or a `ps` would reach it. Store it before anyone tries to log in:
-
-| where | value |
+| Subject | Form |
 | --- | --- |
-| vault agent | `oidc` |
-| vault cred | `oidc_login_client_secret` |
+| PAM user | `alice` |
+| OIDC user | `oidc:<percent-encoded-issuer>:<sub>` |
+| mTLS identity | `cert:<issuer>:<serial>` |
+| local single-org operator | `owner` |
 
-A kb with an OIDC profile but no stored secret answers the callback with
-`503 oidc login is not fully configured` and logs `kb.oidc.login`. That is
-deliberately distinguishable from a failed login — it is a deployment fault, not
-an authentication one, and `auth-mode` already advertises that the kb offers OIDC.
+Grant through the local Unix socket. These routes are never exposed to a remote bearer:
 
-### The login routes
-
-| route | mode | purpose |
-| --- | --- | --- |
-| `GET /v1/identity/auth-mode` | both | which mode this kb offers |
-| `POST /v1/identity/login/start` | OIDC | `{server_id, team_id}` → `{authorize_url, redirect_uri}` |
-| `GET /v1/identity/login/callback` | OIDC | the IdP's redirect; `?code=&state=` |
-| `POST /v1/identity/login/pam` | PAM | `{username, password, server_id, team_id}` |
-
-A completed login of either kind returns the filed identity intent:
-
-```json
-{"subject":"alice","server_id":"mintsrv","team_id":770001,
- "correlation_id":"<64 hex>","jti":"<64 hex>","expires_at":1780000300}
+```bash
+aimee kb grant set --server <server-id> --team <team-id> --subject <subject> --tier data
+aimee kb grant show --server <server-id> --team <team-id> --subject <subject>
+aimee kb grant list --server <server-id> --team <team-id> --include-revoked
+aimee kb grant revoke --server <server-id> --team <team-id> --subject <subject>
 ```
 
-`correlation_id` and `jti` are what the token authority mints from. They are not
-secret and authorize nothing on their own — the mint re-reads the grant, the
-registry, both enrollments and the vault epoch under its own locks — but they are
-what a caller presents to collect its token.
+`data` permits memory, document, and index writes. `full` also permits agent, delegate, runner, and
+workspace control. The first grant uses the local `owner` operator context with team `0`; the
+command's `--team` still names the target team. Interactive users obtain their write identity by
+the KB's configured PAM or OIDC login. Give unattended callers separate service subjects.
 
-**`team_id` is supplied at login START, not at the callback.** For OIDC it is
-retained server-side with the state, nonce and PKCE verifier. This is deliberate: an
-intent's authorization is a grant on `(server_id, team_id, subject)`, so a callback
-allowed to name its own team could point a completed login at a team the user never
-chose.
+Common refusal reasons are `absent`, `invalid`, `unknown_kid`, `wrong_team`,
+`no_team_configured`, `replay`, and `replay_unavailable`. Use the structured `403`, request ID, and
+server log. A grant for the wrong spelling is a grant for nobody.
 
-Two refusals are distinct from an authentication failure, because at that point the
-caller has already proved who it is:
+## Removed surfaces
 
-| status | meaning |
-| --- | --- |
-| `403 not a member of that team` | authenticated, but not on `team_id` |
-| `403 no write-tier grant for that subject on that server` | on the team, but no live grant |
-| `503 this kb cannot issue write tokens right now` | no active management instance for the team, or the JWKS publication is outside its validity window |
+- `aimee chat`
+- `aimee work` and its routes/tools/tables
+- `aimee migrate v2`
+- generic `/v1/rpc`
+- the combined image
+- KB Unix-socket autostart
+- per-session credential push
 
-The `503` is a **deployment** state, not a user error: provision the token authority
-(see below) and check that the team has exactly one `active` management instance.
+Update scripts to use named `/v1` routes, workflows/jobs, and browser/MCP/ACP/API chat surfaces.
 
-All four are **pre-auth** by necessity — they are how a caller with no credential
-gets one.
+## After
 
-**The modes are enforced, not just reported.** A kb with a working OIDC profile
-answers `POST /v1/identity/login/pam` with `409` and never consults PAM. This
-matters if you are migrating: the moment an OIDC profile becomes valid, host
-passwords stop working as a way in, by design. If they still worked, an IdP's MFA,
-lockout and account-disable policy would be bypassable by anyone with a local
-account. Conversely a kb with no OIDC profile answers the two OIDC routes with
-`503`, so a client that guessed wrong gets a clear answer rather than a hang.
-
-**Callback failures are deliberately coarse**, and there are exactly three answers.
-Anything finer would tell an unauthenticated caller which check failed:
-
-| response | when |
-| --- | --- |
-| `400 invalid callback` | the query is malformed, a parameter is duplicated, or the `state` is absent, malformed, or matches no pending login |
-| `401 the identity provider refused the login` | the IdP returned `error=` **and** a valid `state` for a live pending login |
-| `401 the login could not be completed` | everything after that: the code exchange failed, the signature failed, the nonce belonged to another login, or no usable principal came out |
-
-Note the second row's condition. An `error=` callback that cannot be tied to a
-pending login gets the generic `400`, not the distinct message — otherwise a
-stranger could tell a kb with a login in flight from one without.
-
-The password route is coarser still: a wrong password, an unknown account, a locked
-account and a username outside the subject grammar all answer
-`401 authentication failed`.
-
-**If you are debugging a login, the log is the only place the reason exists** —
-`kb.oidc.login`, `kb.pam.login`, and `kb.pam.login.fallback` for a kb serving
-passwords because its OIDC profile is broken.
-
-**The password route is not rate limited.** kb's limiter is applied on the
-bearer-gated path, and this route is pre-auth. If you expose a PAM-mode kb beyond
-a trusted network, put throttling in front of `POST /v1/identity/login/pam`.
-
-If an OIDC profile is configured but unusable — a typo in the endpoint, a
-cleartext `http://` URL — the kb falls back to the PAM login and logs a warning
-naming the problem. It does not report a mode nobody can complete a login with.
-Check the kb log for `kb.oidc.login` if a deployment you configured for OIDC is
-offering passwords.
-
-**Tokens are short-lived and single-use.** A token is bound to one server
-(`aud`), carries its own `jti`, and is consumed on first use — a captured token
-cannot be replayed, and the server refuses if its replay store cannot confirm
-freshness. Clients are expected to obtain tokens as needed rather than caching
-one.
-
-**Provisioning the token authority needs a raised `RLIMIT_MEMLOCK`.** Tokens are
-signed under vault custody, so the authority has to be provisioned before any
-user can be issued one. The two tools that do it —
-`aimee-kb-token-roots-provision` and `aimee-kb-jwks-publish` — `mlockall()` at
-startup so signing key material can never reach swap, and that call fails with
-`ENOMEM` whenever `RLIMIT_MEMLOCK` is below the process size. A libpq + OpenSSL
-binary needs more than the common 8MB default, so on a stock container both tools
-exit immediately.
-
-Raise it on whatever host runs them:
-
-| Host | What to do |
-|---|---|
-| bare metal / VM | `ulimit -l unlimited` in the unit or shell that invokes them (systemd: `LimitMEMLOCK=infinity`) |
-| LXC / Proxmox container | add `lxc.prlimit.memlock: unlimited` to `/etc/pve/lxc/<ctid>.conf` and restart the container — the limit cannot be raised from inside |
-| Docker | `--ulimit memlock=-1:-1` |
-
-They report `hardening (mlockall; raise RLIMIT_MEMLOCK)` when this is the cause,
-so you do not have to guess which of the startup locks failed.
-
-Three more requirements of those tools, none of them obvious from a usage line
-and all of them deliberate:
-
-- **The KMS helper and its HWM public key must be root-owned files on a path
-  whose every parent directory is root-owned and not group- or other-writable.**
-  That rules out `/tmp` (mode `1777`). It stops an unprivileged user substituting
-  the helper under a path root is about to execute.
-- **The helper's own configuration must be baked into the file**, not passed in
-  the environment: both tools `clearenv()` down to the four `AIMEE_VAULT_KMS_*`
-  variables before forking it. That is why the setting names a *file* rather than
-  a command line.
-- **They connect as a login role that is a member of `aimee_kb_migrate`**, then
-  `SET ROLE` to their own provisioning role. `aimee_kb_migrate` is itself
-  `NOLOGIN` — DDL authority is deliberately not something you can log in as — and
-  the schema creates no login role for you, because naming it is your choice.
-
-`scripts/run-identity-mint-e2e.sh` is a worked example of all of the above,
-including a signed-HWM helper standing in for a hardware signer. Note that each
-custody key needs its **own** monotonic HWM counter: the tools provision three
-roots, and a shared counter makes the second root observe the first one's advance
-and fail verification.
-
-**Set `AIMEE_SERVER_TEAM_ID`.** This release adds one required variable: the id
-of the team this server serves, the same registry row `AIMEE_SERVER_ID` comes
-from. Set them together.
-
-If it is unset the server still **starts and serves reads**, and denies every
-write — deliberately, because refusing to boot would take reads down over a
-write-authorization setting and would disable the local-operator recovery path
-you may need. It logs an error naming the variable at startup, and every denial
-reports `no_team_configured` rather than blaming the caller's token.
-
-**If writes are still refused after granting**, the server distinguishes the
-reasons rather than returning a single opaque denial. Each is logged with the
-request id. Check for:
-
-| Reason | Meaning |
-|---|---|
-| `absent` | no identity token presented (an ordinary read-only caller) |
-| `invalid` | malformed, bad signature, wrong `iss`/`aud`, or outside its validity window |
-| `unknown_kid` | signed by a key this server has not fetched yet |
-| `wrong_team` | a valid token for a team this server does not serve |
-| `no_team_configured` | **this server** is missing `AIMEE_SERVER_TEAM_ID` — not a token problem |
-| `replay` | this token's `jti` was already used |
-| `replay_unavailable` | the replay store could not confirm freshness, so the write was refused rather than assumed safe |
-
-`aimee api status` reports `remote_writes.global_ignored` once it is non-zero:
-the number of requests refused that the retired global would formerly have
-allowed. It counts only those, not denials in general, so it measures what this
-cutover is actually costing you.
-
----
-
-## 0.3.0 — PAM authentication now actually compiles in (Linux)
-
-**What changed.** aimee auto-detects `libpam` and sets `-DWITH_PAM` when it is
-present. On Linux that detection has never fired: the probe piped an
-`#include` line to the compiler, and inside make's `$(shell ...)` the escaped
-`\#` reached the compiler as a literal backslash, so the test failed regardless
-of what the host had installed. `-DWITH_PAM` was therefore never set, and no
-shipped binary linked `libpam` even though `-lpam` was on the link line.
-
-**Does this affect me?** Only if you use the **local dashboard's HTTP Basic
-Auth** on Linux. That path validates credentials through PAM, and with PAM
-compiled out it took the "PAM not available — reject all credentials" branch, so
-it rejected every login. It failed closed, not open: nobody got in who should not
-have. But if you had concluded the dashboard's Basic Auth was broken or
-unusable, this is why.
-
-**What to do.** Nothing, unless you had worked around it. After upgrading, the
-dashboard authenticates against the host's `aimee` PAM service as originally
-intended, so an account that was previously refused will now succeed. If you
-relied on the dashboard being effectively closed to everyone, gate it at the
-network instead — that was never the intent of the setting.
-
-Builds on hosts *without* `libpam` are unchanged: PAM stays compiled out and the
-credential check still rejects everything rather than degrading to something
-weaker.
-
----
-
-## 2026-07 — The `aimee-kb` image runs its own pgvector when you configure none
-
-**What changed.** The `aimee-kb` image now ships PostgreSQL 18 with the `pgvector`
-extension (18.4 + pgvector 0.8.5, from PGDG — the current stable major). If
-`AIMEE_DB2_URL` is **unset**, the container initialises and runs its own cluster
-under `$AIMEE_HOME/postgres`, reachable only over a local socket. If
-`AIMEE_DB2_URL` is **set**, nothing is started and the external server is used
-exactly as before — that path is fully supported and is still the right choice for
-a shared, backed-up, or managed database.
-
-**pgvectorscale** (StreamingDiskANN indexes) ships in the same image. There is no
-separate build or image variant: it costs about 1 MB, needs PostgreSQL 18 which the
-image now uses, and the kb already chooses the index type at **runtime** —
-`pgvec_vectorscale_available()` probes for the extension and falls back to HNSW with
-a warning when it is missing. Making it a build flag would have turned the index
-type into a property of which image you pulled. Configure the index type as you
-always have; nothing about the image selects it.
-
-The image no longer bakes `AIMEE_DB2_URL=postgresql://aimee:aimee@postgres:5432/aimee_shared`.
-That default made "the operator configured nothing" indistinguishable from "use the
-sibling container", so the container could not tell when to run its own database —
-and a bare `docker run` inherited a `postgres` hostname that does not resolve.
-
-**Does this affect me?** Not if you use `compose.yaml`, `compose.server.yaml`, the
-SmoothNAS units, or `deploy/`. All of them already set `AIMEE_DB2_URL` explicitly,
-so they keep their own `postgres` service and their existing volume untouched.
-Nothing to do, and no data moves.
-
-You are affected only if you ran the `aimee-kb` image **without** setting
-`AIMEE_DB2_URL` and relied on the baked default to reach a container named
-`postgres`. Set it explicitly to keep that behaviour:
-
-```
-docker run -e AIMEE_DB2_URL=postgresql://aimee:aimee@postgres:5432/aimee_shared ...
+```bash
+aimee remote status
+aimee status
+aimee kb status
+aimee audit verify
+aimee memory store upgrade-smoke "write ok"
+aimee memory search "write ok"
 ```
 
-**Why.** An unconfigured deployment previously had no working vector store, and the
-default pulled `pgvector/pgvector` from Docker Hub at run time — an anonymous pull,
-subject to a shared per-IP quota that fails as a hung connection rather than a clear
-error. Shipping the engine in the image removes a third-party registry from the
-production start path.
+Then:
 
-**Moving to an external server.** The image ships `aimee-kb-db-export` for exactly
-this:
+- ingest one small source tree and check caller lookup;
+- run one delegate probe and read its audit row;
+- validate a workflow and inspect the Go workflow service;
+- verify capture files are created and the event-bus drop counter is zero;
+- restart the stack once and confirm active state recovers cleanly;
+- restore the backup into a disposable deployment.
 
-```
-docker exec aimee-kb aimee-kb-db-export postgresql://user:pw@host:5432/aimee_shared
-docker exec aimee-kb aimee-kb-db-export --wipe postgresql://user:pw@host:5432/aimee_shared
-```
-
-It refuses to start if the target is unreachable or lacks the `vector` extension,
-dumps and restores, then compares the row count of every user table and **aborts
-leaving the internal data intact** if they differ. `--wipe` removes the internal
-data directory only after that comparison passed. Set `AIMEE_DB2_URL` to the target
-afterwards and the container stops starting its own cluster.
-
----
-
-## 2026-07 — The `plugin-loader` is removed
-
-**What changed.** aimee's built-in `plugin-loader` subsystem has been removed
-entirely. There is no longer a plugin discovery/registry/enable-disable
-mechanism inside aimee, and the endpoints, config keys, and CLI that drove it are
-gone. Extensibility in aimee is delivered through **hooks**, **MCP tools**, and
-**skills** (all documented in `MANUAL.md`) and, for maintainers, through
-first-class **modules** — not through a separate plugin loader.
-
-**Does this affect me?** Only if you actively used the plugin loader. Concretely,
-you are affected if any of these applied to your deployment:
-
-- you set `AIMEE_ENABLE_PROJECT_PLUGINS`;
-- you shipped a project-local plugin manifest or plugin directory for aimee to
-  discover;
-- you called the plugin HTTP routes — `GET /v1/plugins`, `POST /v1/plugins/enable`,
-  `POST /v1/plugins/disable`, or `GET /v1/dashboard/plugins`;
-- you scripted the plugin management subcommands.
-
-If none of those applied, this change is transparent — a normal upgrade needs no
-action.
-
-**What was removed.**
-
-| Removed | Replacement |
-|---|---|
-| `AIMEE_ENABLE_PROJECT_PLUGINS` env var | — (no equivalent; use a mechanism below) |
-| `GET /v1/plugins`, `POST /v1/plugins/{enable,disable}` | — (now `404`) |
-| `GET /v1/dashboard/plugins` | — (now `404`) |
-| Plugin discovery of project-local plugin manifests | MCP tools / hooks / skills |
-| Plugin management CLI | — |
-
-The `/v1/openapi.yaml` served by `aimee-server` no longer lists any plugin route,
-so generated clients pick the change up automatically.
-
-**What to do instead.** Pick the mechanism that matches what your plugin did:
-
-- **You added a tool the model could call.** Expose it over **MCP** and register
-  the MCP server with aimee. This is the supported way to add callable tools and
-  works with every client. See *§16 Skills and toolsets* and the MCP integration
-  notes in `MANUAL.md`.
-- **You intercepted or post-processed tool calls / injected context.** Use the
-  client **hooks** aimee already registers — `SessionStart`, `PreToolUse`,
-  `PostToolUse` — described under *Hooks* in `MANUAL.md`. These cover the
-  interception and context-injection cases the plugin `pre-LLM` hook was used for.
-- **You bundled reusable prompts/procedures.** Package them as a **skill**
-  (`AIMEE_BUNDLED_SKILLS_DIR` still overrides the bundled-skills location).
-- **You are a maintainer extending aimee's own binary.** Add a first-class
-  **module** under `src/modules/<id>/` with a `module.yaml` descriptor, rather
-  than a loadable plugin. See `docs/modules/` and `docs/refactor-baselines.md`.
-
-**Note on Codex.** The "local plugin" line for the Codex CLI in `MANUAL.md` /
-`docs/COMPATIBILITY.md` refers to *Codex's own* plugin mechanism, not aimee's
-plugin-loader, and is unaffected.
-
----
+Keep the old volumes read-only until these checks pass.

--- a/docs/VSCODE.md
+++ b/docs/VSCODE.md
@@ -1,182 +1,44 @@
-# Using aimee with VS Code
+# VS Code
 
-aimee integrates with VS Code through surfaces that already ship in the
-binaries, no extra protocol, no plugin build required. There are three ways to
-wire it, and they are complementary:
+aimee works with VS Code in three ways:
 
-| You want… | Use | What VS Code gets |
-|---|---|---|
-| aimee's **tools** (memory, guardrails, `find_symbol`, `delegate`) inside Copilot Chat | **MCP** (Path A) | aimee tools callable in agent mode |
-| aimee itself **as the chat model** (delegate-routed, memory + guardrails) | **OpenAI `/v1` endpoint** (Path B) | "aimee" as a selectable model |
-| aimee itself **as the chat agent** over stdio, no TCP listener or token | **ACP** (Path C) | "aimee" as an ACP agent |
+1. MCP tools for memory, code, and delegates;
+2. ACP as an editor agent;
+3. the aimee extension/model provider over `/v1`.
 
-For the deeper, native-extension experience (aimee in the model picker, an
-`@aimee` chat participant, a docked webchat panel), a dedicated VS Code
-extension lives in [`editors/vscode/`](../editors/vscode/), phase 1 ships the
-`@aimee` chat participant + a server-health status item (sideload it per its
-[README](../editors/vscode/README.md)). The two integration paths below also
-work today without the extension.
+The browser deployment also offers a per-user code-server editor. That is separate from the native
+extension.
 
-> Requires a running `aimee-server` (`aimee status` to confirm) and `aimee` on
-> your `PATH`. VS Code MCP support is GA in VS Code 1.102+.
+## Native client setup
 
----
+Run normal aimee client setup or register `aimee mcp-serve` in the VS Code user `mcp.json`. VS Code
+uses a `servers` object. The local process inherits `remote.conf` and reaches the enrolled server.
 
-## Path A, aimee tools via MCP (Copilot Chat agent mode)
+For ACP, register `aimee acp-serve` where the editor supports it.
 
-VS Code reads MCP servers from a workspace `.vscode/mcp.json` or a user-level
-`mcp.json`. Note VS Code uses the `servers` key (the CLI tools use
-`mcpServers`, they are not interchangeable).
+Use `aimee api status` for the model endpoint. Prefer an enrolled HTTPS URL and a narrowly scoped
+credential.
 
-Create `.vscode/mcp.json` in your workspace:
+## Extension
 
-```jsonc
-{
-  "servers": {
-    "aimee": {
-      "type": "stdio",
-      "command": "aimee",
-      "args": ["mcp-serve"]
-    }
-  }
-}
-```
+The extension adds an `@aimee` participant, an aimee model in the native picker, memory/KB search,
+health status, and a docked panel. It keeps the server response/session identifier between turns;
+conversation state remains on the server.
 
-Or register it globally via the Command Palette → **MCP: Open User
-Configuration**, adding the same `aimee` entry.
+Build instructions are in [the extension README](../editors/vscode/README.md).
 
-Then open **Copilot Chat**, switch to **Agent** mode, and the aimee tools
-(`search_memory`, `list_facts`, `find_symbol`, `delegate`,
-`preview_blast_radius`, …) become available. Ask, e.g., *"search my aimee
-memory for the database host"* and the model will call `search_memory`.
+## Browser editor
 
-The full tool list is in [COMPATIBILITY.md](COMPATIBILITY.md#mcp-protocol).
+The browser starts one code-server process per authenticated user and proxies it under the same web
+origin. The selected project determines the workspace, but the server still checks user/project
+authority. A code-server process has that user's source access and should be treated as an
+interactive shell.
 
----
+## Troubleshooting
 
-## Path B, aimee as the chat model (OpenAI-compatible `/v1`)
-
-aimee-server exposes a complete OpenAI-compatible API. Any VS Code extension
-that accepts a custom OpenAI base URL, **Continue**, **Cline**, **Roo Code**,
-or Copilot's own **Manage Models → OpenAI-compatible**, can use aimee as the
-model. Requests are routed through aimee's delegate fabric with memory and
-guardrails applied.
-
-### 1. Enable the localhost TCP listener
-
-The `/v1` surface is always served over the Unix socket; to reach it from a
-VS Code extension you enable the optional loopback TCP listener. It refuses to
-bind without a bearer token.
-
-The quickest way is to let the CLI write the config and mint a token for you:
-
-```bash
-aimee api enable            # picks port 8910, generates a bearer, rate-limit 60
-aimee api enable --vscode   # same, plus ready-to-paste VS Code / Continue / Cline snippets
-```
-
-`aimee api enable` persists the block below to `~/.config/aimee/aimee.yaml`
-and prints the generated bearer token once. (`aimee api disable` turns the
-listener back off.) Or edit the file by hand:
-
-```yaml
-aimee:
-  api:
-    http_port: 8910
-    bearer_token: "<generate-a-long-random-secret>"
-    rate_limit_per_min: 60
-```
-
-Either way, restart the server (`aimee server restart`) and verify:
-
-```bash
-curl -s http://127.0.0.1:8910/v1/models \
-  -H "Authorization: Bearer <your-token>"
-```
-
-Or check the listener config and get ready-to-paste provider snippets without
-touching `curl`:
-
-```bash
-aimee api status
-```
-
-`aimee api status` reports whether the loopback `/v1` listener is enabled, its
-port, whether a bearer is configured (never the secret itself), and the
-rate limit; when enabled it prints the per-extension base-URL / key / model
-snippets below. When disabled it shows the `aimee.yaml` block to add.
-
-The listener binds `127.0.0.1` only. Exposing it beyond loopback is the
-operator's choice (reverse proxy) and always requires the bearer.
-
-### 2. Point your extension at it
-
-| Setting | Value |
-|---|---|
-| Base / API URL | `http://127.0.0.1:8910/v1` |
-| API key | your `bearer_token` |
-| Model | `aimee` |
-
-**Continue** (`~/.continue/config.yaml`):
-
-```yaml
-models:
-  - name: aimee
-    provider: openai
-    model: aimee
-    apiBase: http://127.0.0.1:8910/v1
-    apiKey: <your-token>
-```
-
-**Cline / Roo Code:** API Provider → *OpenAI Compatible* → Base URL
-`http://127.0.0.1:8910/v1`, API Key = your token, Model ID = `aimee`.
-
-### Endpoints available
-
-`/v1/chat/completions` (streaming + non-streaming), `/v1/completions`,
-`/v1/embeddings`, `/v1/responses` (stateful, continues an aimee session via
-`previous_response_id`), and `/v1/runs` (async). See
-[MANUAL.md §24](../MANUAL.md#24-the-http-v1-api) for the full list and auth
-conventions.
-
-> Tip: issue a **`project:`-scoped** bearer so the editor can read and chat but
-> cannot perform admin mutations.
-
----
-
-## Path C, aimee as an ACP agent (`aimee acp-serve`)
-
-aimee speaks the [Agent Client Protocol](https://agentclientprotocol.com)
-(ACP): newline-delimited JSON-RPC 2.0 over stdio. A VS Code extension that
-speaks ACP launches `aimee acp-serve`, and aimee runs each turn on its primary
-model with memory and guardrails applied, streaming the reply back as
-`session/update` notifications. Like Path B this makes aimee the agent, but over
-stdio instead of the OpenAI endpoint, so it needs no TCP listener and no bearer.
-
-Point your ACP extension at the command:
-
-```jsonc
-{
-  "command": "aimee",
-  "args": ["acp-serve"]
-}
-```
-
-aimee advertises its slash commands (`/help`, `/skill`, `/personality`,
-`/compact`, `/reset`, `/stop`, `/queue`) in the ACP `initialize` handshake.
-ACP turns run the agent against a local `aimee-server`; a network `/v1` remote
-cannot serve them.
-
----
-
-## Which path should I use?
-
-- **Stack them.** Path A gives the model you already use (e.g. Copilot's
-  GPT/Claude) access to aimee's memory and guardrails as tools. Path B and
-  Path C both make aimee *itself* the agent (Path B over the OpenAI endpoint,
-  Path C over ACP). Run Path B or C with aimee as the model **and** Path A so
-  that model can also reach aimee's tools.
-- For the tightest native experience (aimee in the model picker + `@aimee`
-  participant + docked webchat), use the dedicated VS Code extension in
-  [`editors/vscode/`](../editors/vscode/) (phase 1 ships the `@aimee` chat
-  participant); Path A and Path B above also work without it.
+- check `aimee remote status` from VS Code's environment;
+- use an absolute `aimee` path if GUI PATH differs from the shell;
+- check the MCP JSON key and stdio logs;
+- verify endpoint TLS and credential scope;
+- confirm the selected model supports tools if the client requests them;
+- for browser editor failures, check per-user process state, project path, proxy auth, and port.

--- a/docs/WEBCHAT_GIT_SECURITY.md
+++ b/docs/WEBCHAT_GIT_SECURITY.md
@@ -1,168 +1,46 @@
-# Webchat git credential security model
+# Browser git security
 
-How aimee-runtime-web handles a webuser's git forge credentials (at rest, in transit
-to git, and inside the in-browser editor) and where exposure is and isn't
-closed. This is the reference for the `webchat git projects + in-browser VSCode`
-feature (proposal in `docs/proposals/done/webchat-git-projects-and-vscode.md`).
+The browser can register git accounts and clone HTTPS or SSH repositories. Credentials belong to the
+authenticated principal and stay in the server vault.
 
-## Threat model
+## HTTPS
 
-A webchat user (`webuser:<name>` principal) connects their own git credentials
-(HTTPS PAT/token, GitHub OAuth, or an SSH key) and performs git operations and
-in-browser editing on the server. The credentials are **theirs**, but aimee is
-multi-user and server-hosted, so the goals are:
+Access tokens and OAuth results are sealed in the vault. Git receives a credential only for the
+matching host and operation. The token is not written into the clone URL, repository config, logs,
+or workflow artifact.
 
-1. **At rest:** never plaintext on disk; encrypted per-principal.
-2. **Cross-tenant:** one webuser can never read another's credential or files.
-3. **In transit to git:** on the **API git paths** (clone/fetch/pull/push,
-   status/log/diff/branch, and PR creation) the token must not leak into a child
-   process's environment (`/proc/<pid>/environ`), argv, logs, or a named file,
-   where a co-located process could read it. The **in-browser editor is
-   explicitly out of scope for this invariant today**; see the editor section
-   for the one remaining (bounded) exposure and the socket-askpass fix that would
-   close it.
-4. **No server-secret bleed:** the editor must never see aimee-server's own
-   secrets (DB password, server token, provider keys).
+## SSH
 
-## At rest: the per-principal vault
+Private keys stay in sealed runtime storage and are loaded into a short-lived ssh-agent. Git runs
+with batch mode, a bounded connection timeout, and a per-principal `known_hosts` file.
 
-Credentials live only in the encrypted per-principal vault
-(`server_vault.c`, `vault_service.c`, `vault_store.c`), keyed by the
-`webuser:<name>` principal and sealed under the server master key
-(`.server-master.key`, dual-access wrap), so the co-located server can read them
-autonomously while they are never plaintext on disk and never returned to the
-browser. Intake routes (`/v1/git/credentials`, `/v1/git/sshkey`,
-`/v1/git/oauth/github/*`) are write-only. A `test_webchat_git_leak` check asserts
-the credential's plaintext appears in **no** file under `$AIMEE_HOME`, and that a
-second principal cannot read it (cross-principal denial).
+First contact uses trust on first use. Verify the host key through another channel for sensitive
+repositories. A changed key is a hard failure.
 
-The credential-resolution precedence is centralized in **one** policy
-(`git_cred_inject_build_env_for_repo` / `git_cred_inject_resolve_token`); a lint
-gate (`git-cred-centralized-check`) forbids any caller from hand-rolling the
-ladder.
+The browser accepts ordinary SSH URL forms without rewriting them to HTTPS when the account uses an
+SSH key.
 
-## In transit to git: the token is out of `/proc/<pid>/environ`
+## Repository confinement
 
-For **every API git path** (clone, fetch, pull, push, status/log/diff/branch, and
-PR creation), the forge token does **not** appear in any child process's
-environment:
+Clone destinations are derived from the managed workspace root and canonical repository identity.
+User input cannot choose an arbitrary host path. Existing repositories are checked for origin and
+ownership before reuse.
 
-- **git operations + clone** use an **fd-fed askpass**. The resolved HTTPS token
-  is written to an anonymous **`memfd`** (MFD_CLOEXEC; never a named path). A
-  `safe_exec` variant `dup2`s it onto a fixed fd (`GIT_CRED_TOKEN_TARGET_FD`) in
-  the forked git child with CLOEXEC cleared; the env carries
-  `AIMEE_GIT_TOKEN_FD=<n>` (a *number*, not the secret) instead of `GH_TOKEN`.
-  The `GIT_ASKPASS` shim reads the token from `/proc/self/fd/<n>` (re-readable,
-  `cat` reopens the memfd at offset 0). The source memfd is CLOEXEC in the
-  parent, so a concurrent exec on another thread can't inherit it; `memfd_create`
-  failure fails **closed** (drops the token) rather than falling back to env.
-  Binding invariant, proven in `test_git_cred_inject`: a child run with this env
-  reads the token via `/proc/self/fd/<n>` but its `/proc/self/environ` contains
-  only the fd *number*, never the token.
+Workflow forge operations are narrower still: the supervised peer names a typed operation, while the
+server derives repository identity, branch namespace, destination, and credential from the managed
+worktree.
 
-- **Opening a PR** is an **in-process GitHub REST call** (`git_pr_api.c`), not a
-  child exec: aimee-server POSTs to `/repos/{owner}/{repo}/pulls` with the token
-  in the `Authorization` header, in server memory only, wiped after the call,
-  never logged (the HTTP client logs host + byte counts, never headers). The
-  origin host is parsed **exactly** (rejects `evilgithub.com`,
-  `github.com.evil.com`, …); GitHub remotes only. (This replaced an earlier
-  `gh pr create`, which read `GH_TOKEN` from the child env.)
+## Browser boundary
 
-- **SSH keys** are loaded into a per-user **in-memory `ssh-agent`** (`memfd`,
-  `RLIMIT_CORE=0`, `DUMPABLE=0`, key buffer zeroed after load); git uses it via
-  `SSH_AUTH_SOCK`. The agent socket lives under a **tmpfs-mandatory**,
-  fail-closed per-principal runtime dir (`webuser_runtime.c`). The **decrypted
-  private key never touches disk** — only the agent's memory holds it (the
-  sealed vault persists only the *encrypted* key). Because the server has no
-  seeded `known_hosts`, every SSH git op also forces
-  `GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=<runtime-dir>/known_hosts"`:
-  `BatchMode` keeps it non-interactive (no TTY, no password prompts), and
-  `accept-new` is **trust-on-first-use** — on first contact with a new host
-  (e.g. `bitbucket.org`) SSH appends the remote's **public** host key and
-  verifies it strictly thereafter, so a first-time connection that would
-  otherwise die on "Host key verification failed" succeeds. `UserKnownHostsFile`
-  pins that TOFU state to the **per-principal** tmpfs runtime dir (beside the
-  agent socket), never the OS account's shared `~/.ssh/known_hosts`, so one
-  principal's first-use trust cannot bleed to another. It is **tmpfs-backed and
-  therefore per-server-lifetime**: TOFU re-establishes after a restart. (`git://`
-  remotes stay anonymous and are unaffected; only real SSH transports — `ssh://…`
-  or scp-like `git@host:owner/repo.git` — use the agent.)
+- login and CSRF protect mutation;
+- every account/project route checks the principal;
+- account lists return metadata, never secret values;
+- project selection is not authorization;
+- OAuth polling requires a fresh, unexpired token;
+- SSH and token failures are audited without logging the secret.
 
-## Cross-tenant isolation
+## Remove an account
 
-Every `/v1` workspace/git route resolves its target from the **attested**
-`webuser:` principal (never a client-supplied path) through `workspace_scope`
-(`realpath` + `openat`/`O_NOFOLLOW` containment), and rejects roots outside the
-caller's own tree. The git surface can be disabled wholesale with
-`AIMEE_WEBCHAT_GIT=0` (all git routes → 503); the editor independently with
-`AIMEE_WEBCHAT_EDITOR=0`. Both default on.
-
-## The in-browser editor (code-server): residual exposure
-
-The editor process env is curated of the server's own secrets (e.g. `AIMEE_DB2_URL`,
-`AIMEE_SERVER_TOKEN`, provider keys) and hardened (`no_new_privs`,
-`DUMPABLE=0`, `RLIMIT_CORE=0`, loopback-only, behind the authed proxy, git's
-on-disk `credential.helper` disabled). **However**, unlike the API git paths, the
-editor still injects the HTTPS token as **`GH_TOKEN` in the code-server
-environment.** This is the one remaining spot the token is in a child's
-`/proc/<pid>/environ`. It is a **bounded** exposure: it is the user's *own*
-token, in their *own* editor, but it is readable by **any same-UID code-server
-descendant**: the extension host and its children (chiefly an extension the user
-installs), the integrated terminal, and any shell or git it spawns. It is not yet
-closed. Three pieces remain, and the key technical facts behind them were
-established empirically:
-
-### Why the editor can't use the fd-askpass (must use a socket)
-
-The fd-askpass that works for the API git paths does **not** work for the editor.
-Measured against a real code-server 4.126 / Node 24 on a test host:
-
-- VS Code's **SCM "Git" view** runs git in the **extension host** via
-  `child_process.spawn`, which **does** forward an inherited extra fd, so an
-  fd-askpass would work there.
-- The **integrated terminal** spawns its shell via **`node-pty`**, which **does
-  not** forward the inherited fd (the dup2'd fd is not open in the pty child; node-pty does not inherit it).
-
-So switching the editor to fd-mode would silently **break terminal git** (the
-askpass would find no fd and, with no `GH_TOKEN` to fall back to, fail auth). The
-correct fix is a **socket-fed askpass**: a per-principal unix-domain socket
-(0700, in the tmpfs runtime dir, like the ssh-agent) served from aimee-server's
-in-memory broker; the askpass connects and reads the token, which works
-regardless of fd inheritance. This is scoped but unimplemented.
-
-### Extension-host containment is not a selective env-strip
-
-The proposal's "strip `GIT_ASKPASS`/`SSH_AUTH_SOCK` from the extension host but
-keep them for the integrated terminal **and SCM**" is **internally
-contradictory**: VS Code's SCM Git provider *runs in the extension host*, so
-those are the same trust boundary. There is no knob to give the built-in Git
-extension the credential env while denying it to a third-party extension in the
-same host. The realistic mitigations are: the secret-free curated env (done, no server
-secrets reach any extension), an operational posture of Open-VSX-only with no
-preinstalled third-party extensions (a deployment policy, not code-enforced), and
-treating any extension the user installs as having access to the user's *own* git
-credential by design.
-
-### OS-jail (namespace / seccomp / cgroup) is future work
-
-The editor terminal currently runs as the server UID with the server `PATH`
-(`no_new_privs` already neuters setuid escalation such as `sudo`, and the
-non-root UID denies `docker`/`nsenter`). A stronger jail (a `bwrap`/`unshare`
-bind-mount namespace confining the terminal to the workspace subtree, a `seccomp`
-filter denying `mount`/`pivot_root`/`setns`, and cgroup CPU/mem limits) is
-future work; it requires `bubblewrap` in the image and iterative validation
-against a live editor.
-
-## Status summary
-
-| Surface | Token in `/proc/<pid>/environ`? | Mechanism |
-|---|---|---|
-| clone, fetch, pull, push, status/log/diff/branch | **No** | memfd fd-askpass |
-| open PR | **No** | in-process GitHub REST (`Authorization` header) |
-| SSH git | **No** | in-memory ssh-agent (`SSH_AUTH_SOCK`) |
-| in-browser editor (code-server) | **Yes** (bounded: user's own token) | `GH_TOKEN` in env; fix = socket-fed askpass (scoped) |
-
-**Remaining hardening** (all editor-scoped, all needing a live code-server to
-implement+validate): socket-fed askpass for the editor; the bwrap/seccomp/cgroup
-jail. Extension-host "containment" is resolved as a documented limitation rather
-than an (infeasible) selective env-strip.
+Deleting an account removes its vault records and runtime agent state. Existing clones remain source
+data but cannot fetch private changes without another authorized credential. Revoke the credential at
+the git host as well.

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,288 +1,171 @@
-# What's New
+# What's new
 
-Each section covers one release. The CLI reads the section matching the
-current version and prints it once after an upgrade.
+This is the current testing tree compared with **v0.2.192**, the last public release.
 
----
+## Event bus
 
-## Unreleased (testing)
+Every daemon now has a bounded shared-memory event bus. It is the largest architectural change in
+this cycle.
 
-- **Removed: the interactive chat client and `aimee chat`.** Bare `aimee` now
-  prints usage instead of launching a TUI. The OpenCode frontend bridge and the
-  native fallback loop are gone. Reach the primary agent through any
-  OpenAI-compatible front end pointed at `POST /v1/chat/completions` (OpenCode,
-  VS Code, custom clients — unchanged), the web chat, or `aimee acp-serve` from
-  an ACP editor such as Zed. The `/persona` slash command lived in the removed
-  bridge; use `aimee persona use <name>` instead.
-- **Removed: the `aimee work` queue.** `work add|add-batch|claim|complete|fail|
-  list|board|cancel|release|clear|gc|sync-proposals|stats`, the `/v1/work/*`
-  routes, and the `work_list` / `work_board` MCP tools are gone. **Upgrading drops
-  the `work_queue` and `work_queue_log` tables**, including any rows still in
-  them: nothing reads that data any more, and leaving the tables behind would
-  make an upgraded database permanently different from a fresh install. If you
-  still need the contents, dump them before upgrading.
-- **Removed: `aimee migrate v2`.** The server side was retired some time ago and
-  answers `UNKNOWN_METHOD`; the command could not do anything but fail. The
-  client plumbing is now gone too.
+- One C host routes typed events between private client queue pairs.
+- C and pure-Go clients share frozen wire vectors; Go needs no cgo.
+- Small payloads stay inline. Large payloads use generation-checked arena leases.
+- Requests, replies, cancellation, fan-out, backpressure, overflow, and client reap have explicit
+  contracts.
+- The host stamps one sequence before routing and exposes one full-stream tap.
+- Capture materializes payloads into CRC-checked records for exact observational replay.
+- The measured dispatch path is about 134 ns per event against a 2,000 ns gate on the reference
+  host.
 
-- **Connection reuse is now the default.** Server→KB mTLS pooling
-  (`transport.kb_pool_enabled`) and resident thin-client HTTPS keep-alive
-  (`transport.server_keepalive_enabled`) both default **on** after live
-  three-node validation: pooling took warm p50 from 4.762 ms to 1.589 ms, and
-  keep-alive took p50 from 4.900 ms to 0.109 ms. Each rolls back independently —
-  set the config key false, or `AIMEE_TRANSPORT_KB_POOL_ENABLED=0` /
-  `AIMEE_TRANSPORT_SERVER_KEEPALIVE_ENABLED=0`. Short-lived CLI invocations are
-  unchanged (a process-local socket can't outlive the process). Both gzip
-  settings stay **off**: the same capture cut a request from 51,592 to 18,110
-  wire bytes but raised latency from 2.849 ms to 4.766 ms, which fails the
-  latency gate. See [BENCHMARKS.md](BENCHMARKS.md).
+The audit path is the first load-bearing consumer. Governed actions, memory mutations, semantic
+guardrail events, vault access, sandbox isolation degradation, MCP activity, and tool outcomes now
+use the bus instead of direct side logs. Accepted events drain to the WORM ledger or their typed
+store. Graceful shutdown drains the rings and flushes capture; queue failure is counted and logged.
 
-- **A configured remote is now an exclusive transport.** When a remote endpoint
-  is set, the thin client no longer probes or falls back to a co-located unix
-  socket for `hooks`, `session-start`, `optimize`, or the delegate-availability
-  probe — those went to the local socket before, so one invocation could contact
-  both servers. **Behavior change:** `aimee optimize …` against an unreachable
-  remote now fails instead of quietly answering from a local server. `aimee
-  hooks …` still fails open when the policy server is unavailable, as before.
-  Clear the remote for local execution. See [THIN_CLIENT.md](THIN_CLIENT.md).
+The same contract opens the next set of changes: separately shipped modules, external attachment,
+workflow events, uniform policy checks, and full-stream telemetry. Those consumers land separately;
+the bus does not pretend they are all complete today.
 
-- **Roundtable panels run in parallel**: the workflow `gate.roundtable` now
-  dispatches all reviewers concurrently (bounded by the compute-thread ceiling,
-  with a per-round deadline so one hung model can't wedge the panel) instead of
-  one at a time. Each lens still gets a distinct review agent (diverse panel), and
-  a second parallel round retries any lens whose agent failed on a different agent.
-  Cuts a review pass from ~N×(model latency) to ~one model latency.
+See [Event bus](EVENT_BUS.md).
 
-- **Generalized delegate dispatch (viable delegate for a role, retry until one works)**:
-  `agent_run_ex` no longer walks a configured `fallback_chain` — it routes to the
-  preferred agent for the role, then retries other **viable** agents (enabled,
-  routable, serving the role; a DOWN agent is skipped) at random until one
-  succeeds. The roundtable panel is now just N `review` delegate requests: it
-  dispatches by the `review` role (the persona rides in the prompt as the lens),
-  excludes agents already seated for a **diverse** panel, and retries a flaky
-  agent onto a different one instead of degrading the gate. Non-review agents
-  (e.g. `gpu-mid`, which lacks the `review` role) are never seated. A specific
-  agent is used only when explicitly pinned.
+## Runtime and module boundaries
 
-- **Roundtable seats: pin a model or set it Random**: each seat in the roundtable
-  preset (the panel the GUI edits) now honors its model two ways. A **specific**
-  model is dispatched to that **exact** agent — if it can't be reached (disabled,
-  unroutable, or its dispatch fails), the workflow run **fails** rather than
-  silently swapping in another model. A seat set to **Random** (`$random`) picks
-  any review-capable agent and retries a different one until one is accepted. The
-  workflow `gate.roundtable` resolves each required persona to its matching seat's
-  model this way; the interactive `aimee delegate roundtable` (ensemble) path
-  honors the same two kinds. The Roundtable page gains a **🎲 Random** toggle per
-  seat so you can choose per seat in the GUI.
+- The C core is being split into owned source modules with narrow public headers, dependency
+  checks, descriptors, and generated module documentation.
+- The workflow control plane moved to Go. The C server remains the runtime and storage owner while
+  Go owns workflow scheduling and browser control-plane work.
+- The old plugin loader is gone. Optional modules attach through explicit contracts instead of
+  loading arbitrary code into the core.
+- The MCP adapter can be installed into either server or KB and reports tool activity through the
+  event bus.
+- Configuration fields, `/v1` operations, and provider messages are moving to table-driven,
+  versioned contracts instead of duplicate switch statements.
 
-Thin-client + credential hardening, the client owns the working tree; agent
-credentials live in the server's **sealed vault**; see
-[THIN_CLIENT.md](THIN_CLIENT.md).
+## Audit, identity, and policy
 
-- **Roundtable ↔ planner now refine together**: when a `gate.roundtable` requests
-  changes, the panel's blockers are captured and persisted for the work item, and
-  the next `author.proposal`/`author.plan` pass folds them into its prompt — so the
-  re-author addresses the actual objections instead of re-authoring blind. Before
-  this, the panel's critique was discarded (only the pass/fail enum survived), so
-  the plan↔gate loop couldn't converge and churned until the per-node `max_iters`
-  backstop parked the run. The build workflow's `plan` step also gets a larger
-  `max_iters` so a genuinely converging refinement loop isn't cut off early.
+- The action audit store is hash-chained and checkpointed. Verification, sealing, snapshots,
+  provenance, retrieval traces, and fidelity checks use the same WORM surface.
+- Capture coverage moved from scattered call-site logging to the event-bus tap for migrated paths.
+- Vault reads, sandbox posture, MCP calls, tool completion, and memory writes now carry a principal,
+  verdict, and bounded evidence into the audit path.
+- The credential vault is the single server-side store for agent keys and OAuth tokens. Plaintext
+  agent-key files and per-session credential pushes are retired.
+- mTLS enrollment issues an identity per thin client. Revocation is checked per request.
+- Remote user writes now require a KB-signed identity, server/team/JWKS trust, and an exact subject
+  grant. The old global `remote_writes` setting authorizes nothing.
+- Organization catalogs add model allowlists, budgets, rates, spend reports, AWS Bedrock, and
+  egress authority.
+- TPM 2, PKCS#11, KMS, reseal recovery, and external WORM witnesses are available for hardened
+  deployments.
 
-- **`author.proposal` accepts a pre-supplied proposal**: an autonomous run whose
-  proposal is already complete (the proposals trigger materializes a finished,
-  merged proposal — the merge is the approval) no longer loops the `draft` step to
-  `max_iters`. When the author delegate makes no change, `author.proposal` now
-  advances on the existing non-empty proposal instead of treating the no-op as a
-  failure. The guard is strict: with no proposal on disk yet, a failed author
-  dispatch still loops, and `author.plan`/code roles still treat a no-op as the
-  real failure it is.
-- **Trigger `mode` (autonomous by default)**: `trigger_rules` now take a `mode`
-  field selecting how a triggered run executes — `autonomous` (the default: the
-  autonomy scheduler drives it hands-off, right for "merging a proposal *is* the
-  approval") or `interactive` (file it and park for a human to drive in the
-  webchat). The `proposals` source now files its runs `autonomous` by default, so
-  a merged proposal builds out end-to-end without further sign-off. In-flight
-  human gates remain a property of the *workflow* you name (`gate.human`),
-  independent of the trigger's `mode`. See
-  [WORKFLOWS.md § Triggers](WORKFLOWS.md#triggers).
-- **Human gates are inviolable**: a `gate.human` step can no longer be
-  auto-satisfied in autonomous mode. The autonomy driver's preauthorized/optional
-  auto-pass is removed — an autonomous run now **parks at every human gate** until
-  a person acts, and workflow validation **rejects** `policy: preauthorized` /
-  `optional: true` on a human gate so an overridable one can't even be authored.
-  The only way past a human gate remains a human's signed approval via
-  `POST /v1/workflow/items/<id>/gate` (operator-gated `CAP_WORKFLOW_ADMIN`,
-  attributed to the caller's attested principal, HMAC-signed and content-hash-bound).
-  See [WORKFLOWS.md](WORKFLOWS.md) and [AUTONOMOUS_DEVELOPMENT.md](AUTONOMOUS_DEVELOPMENT.md).
+## Workflows and autonomous development
 
-- **Dashboard overhaul + Logs tab**: the web UI **Dashboard** is now a customizable
-  grid of **server-incurred** metric panels: delegations, per-role metrics, token/cost,
-  guardrail actions, agents, active sessions, readiness, plus opt-in panels (success by
-  agent, latency percentiles, top tools, cache efficiency, failures, provider mix,
-  confidence). Toggle/reorder panels via **⚙ Customize** (persisted per-browser); latency
-  and token counts are human-formatted; the grid fills the pane with no scrollbars. The
-  audit/log view moved to its own **Logs** tab backed by the server's tool-action audit
-  ledger (`aimee-kb` keeps its own dashboard for KB-internal events). See
-  [DASHBOARD.md](DASHBOARD.md).
-- **Web Settings page for the full typed config**: the web UI **⚙️ Settings** page
-  (`/settings`) edits every allowlisted runtime config field (grouped, filterable, with
-  per-field save/reset) over the same `config.show`/`config.set` surface as the CLI. Newly
-  exposed groups: the context-economizer levers (`reduce.*`) and the autonomous-development
-  pipeline knobs (`autonomy.*`, previously environment-only; a change applies on the next
-  server start, and an exported `AIMEE_AUTONOMY_*` still overrides). Secrets and endpoints
-  are deliberately not in the allowlist. See [SETTINGS.md](SETTINGS.md).
-- **Tool-output condensation** (default-ON, `reduce.command_filter`): a deterministic,
-  command-aware context-economizer lever that condenses recognized command output at the
-  delegate tool seam (test-runner failures and compiler diagnostics kept, passing
-  transcripts and build progress dropped), with the full output spilled for lossless
-  recovery. Fail-open and byte-identical when off. Toggle it in the web Settings page. See
-  [features/tool-output-condensation.md](features/tool-output-condensation.md).
-- **Retired: the `aimee-combined` all-in-one appliance image.** The single image
-  that bundled `aimee-server` + `aimee-kb` + a CPU LLM (models baked in) is gone —
-  `Dockerfile.combined`, `compose.combined.yaml`, and `combined-entrypoint.sh` are
-  removed. Use the **split stack** instead: `docker compose -f deploy/compose/aimee.yaml up -d`
-  brings up `aimee-server` + self-contained `aimee-kb` + a CPU `aimee-llm` in one command
-  (add `-f deploy/compose/aimee.gpu.yaml` for a GPU synth tier). The self-deploying
-  server is unchanged — the setup wizard still provisions `aimee-kb` + a CPU
-  `aimee-llm` on demand over the mounted Docker socket. The pure-CPU appliance LLM
-  is now the pre-baked **`aimee-llm-cpu`** image (cpu-tier GGUFs baked in; serves
-  offline with no first-boot download and no `/models` volume). See
-  [QUICKSTART.md](QUICKSTART.md).
-- **Compose database topology changed.** New installs no longer create a separate
-  `postgres` service: PostgreSQL 18, pgvector, and pgvectorscale run privately
-  inside `aimee-kb`, and their data persists in the existing KB home volume.
-  Upgrades from a split-stack release that used the old sibling PostgreSQL do
-  **not** import that old named volume automatically. Back it up before changing
-  manifests, then either keep the database reachable and set `AIMEE_DB2_URL`
-  explicitly or dump/restore it into the new embedded cluster. Do not run
-  `docker compose down -v` while the old volume is your only copy.
-- **Self-hosted GPU inference tiers**: the `aimee-llm` inference image is a
-  **model-less** image whose **tier** is chosen at runtime via `AIMEE_LLM_TIER` — the models
-  download on first boot into a `/models` volume, so there is nothing baked and no per-tier
-  image to pull. `cpu` runs retrieval on any host (~6.5 GB download), `small` a Gemma 4 12B
-  synth (~11.4 GB, 16 GB card), `mid` a Gemma 4 26B-A4B synth that fits a 24 GB card fully
-  resident (~17.8 GB, 2 slots), and `large` reuses that synth on a 32 GB card with 4
-  concurrent agents at the full 256 K window (only `SYNTH_SLOTS=4`). The GPU tiers build on a
-  Mesa 25 base so RADV uses the RDNA3 matrix cores. The default split stack
-  (`compose.server.yaml`) runs this image as its `aimee-llm` service and downloads the cpu tier on first boot. The local
-  synth also registers as a free delegate. See [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
-- **Cross-repo code graph**: the symbol and call graph resolves dependency edges across the
-  repositories in your workspace, so blast radius and caller lookups cross repo boundaries.
-  Ask in three directions: what a project depends on, what depends on it, or both. See
-  [CODE_INTELLIGENCE.md](CODE_INTELLIGENCE.md).
-- **Structured-PDF tables, visual crops & OCR** (default-off, opt-in per layer):
-  on top of the coordinate-anchored PDF spine, aimee-kb can now embed PDF chunks
-  into a structurally-isolated vector relation with a per-query answerability
-  signal (`kb_pdf_vector_enabled`), recognise table cells via an optional TSR
-  sidecar (`kb_pdf_tsr_enabled`, surfaced by `pdf_lookup_table`), render
-  figure/table/page crops into a content-addressed blob store served by the
-  access-gated, audited `pdf_open_asset` (`kb_pdf_assets_enabled`), and OCR
-  scanned PDFs through the same citation path with an asset-only fallback
-  (`kb_pdf_ocr_enabled`). Each layer degrades when its sidecar/binary is
-  absent. See [STRUCTURED_PDF.md](STRUCTURED_PDF.md).
+- The Go workflow engine schedules parallel slices, retries, review loops, live forge work, and
+  merge recovery.
+- Typed workflow blocks replace implicit pipeline steps. Validation checks edges, inputs, loops,
+  gates, and version hashes before a run starts.
+- Triggers and cron can create runs. Trigger mode chooses autonomous or interactive handling.
+- A human gate always parks. Autonomous mode cannot approve one.
+- Roundtable findings feed the next author pass instead of disappearing at a boolean verdict.
+- A complete pre-supplied proposal can advance without being rewritten; a failed attempt with no
+  proposal still fails.
+- Agent admission limits apply globally and per workflow. Saturated agents are routed around.
+- A merge conflict, missing commit, lost replay, or exhausted gate returns a named terminal or
+  parked state instead of silently advancing.
 
-- **Server-sealed credential vault (single store)**: agent/delegate API keys and
-  Codex/OAuth tokens are sealed in the server's vault, encrypted at rest, keyed
-  by agent, and decryptable by the server autonomously (a dual-access wrap, no
-  interactive unlock). `aimee agent add … --key K` seals `K` into the vault;
-  plaintext storage is refused. Every turn resolves the credential from the vault
-  (the turn's attested principal, falling back to the server principal). The
-  legacy **client-held keyring and the RAM per-session push (`POST
-  /v1/session/credentials`) are gone**. Migrate any leftover
-  `~/.config/aimee/agent-keys.json` with `aimee agent key import` (which scrubs the plaintext copy by default; `--keep` to retain it).
-- **Codex OAuth in the vault**: `aimee agent setup codex-oauth` runs the
-  server-hosted OAuth flow and seals the token into the vault; a Codex agent then
-  authenticates server-side as a primary provider or delegate, with no
-  per-session push from the client. A legacy plaintext token is migrated and
-  scrubbed on first use.
-- **SSH-key clones for private / SSH-only repos, plus a single wizard for git
-  account setup**: when you connect a git account with an SSH key, cloning an
-  `ssh://…` or `git@host:owner/repo.git` URL (e.g. a corporate Bitbucket) now
-  actually uses that key, instead of being silently rewritten to HTTPS. git runs
-  with `GIT_SSH_COMMAND` forcing `BatchMode=yes, ConnectTimeout=5,
-  StrictHostKeyChecking=accept-new`: trust-on-first-use records the remote's
-  **public** host key on first contact (and verifies it strictly thereafter) in
-  a **per-principal** `known_hosts` under the sealed tmpfs runtime dir, not the
-  shared `~/.ssh/known_hosts`; the private key still never leaves the in-memory
-  ssh-agent. The setup wizard's Connection step now picks **one** auth method
-  (OAuth sign-in / access token / SSH key) and shows only that method's fields,
-  and the Projects page's duplicated inline auth UI is replaced with a single
-  **+ Connect git account** button that opens the same wizard flow in a modal.
-- **Workspaces ingested from the client**: `aimee workspace add <path>` resolves
-  the path locally, registers it as `detached`, and pushes the files to the
-  server (`POST /v1/index/ingest`, chunked under aimee-kb's body cap), the
-  server never reads the client filesystem. `aimee index scan [path]` re-pushes.
-- **Claude runs on the thin client (standard `claude` CLI over tmux)**: a
-  `--provider claude` agent runs the standard `claude` CLI in a tmux session, it
-  needs the `claude` binary, tmux, its login, and the working tree, none of which
-  exist on a remote/containerized `aimee-server`. When the active workspace is
-  `detached` (a thin client is serving it), aimee now runs that tmux session **on
-  the client** by marshalling its tmux commands over the existing runner reverse
-  channel, against the client's tree with the client's `~/.claude` login. No
-  Claude credential is sent to or stored on the server, and `claude -p` print
-  mode is not used. Co-located deployments are unchanged. See
-  [DELEGATES.md](DELEGATES.md).
-- **Claude via the CLI is primary-only by default**: Claude run via the `claude`
-  CLI / tmux login (authenticated by the Claude subscription login, not an API
-  key) can be your interactive primary but is **not** usable as a delegate unless
-  you opt in with `aimee config set claude_cli_delegate_enabled true`. Driving a
-  personal Claude subscription as an automated delegate may violate Anthropic's
-  terms and risk account action; enabling the flag prints that warning once. This
-  gate is Claude-CLI-specific, all other agents (API-key/HTTP, and other CLI
-  agents like the Codex CLI) are unaffected.
-- **Attention guard inert by default**: recursive raw scans flow freely unless a
-  positive `ingress_max_raw_scans` cap is configured; the destructive-file guard
-  is unchanged. The Claude Code integration also re-points stale hook/MCP command
-  paths to the installed binary on reinstall.
-- **`AIMEE_API_REMOTE_WRITES` env** lets a containerized server set its TCP write
-  posture (`off|data|full`) without a writable `aimee.yaml`.
-- **Fixes**: remote `/v1/index/scan` (and `/v1/index/ingest`) no longer fail with
-  "rpc produced no response" (synchronous handlers under the op-run worker);
-  `aimee agent add … --provider codex` is accepted as an alias for the Codex
-  adapter.
+## Delegates and roundtables
 
-Delegation defaults and the roundtable, see [DELEGATES.md](DELEGATES.md).
+- New installs get a usable default delegate roster and roundtable instead of an empty shell.
+- Delegates route by role and persona, then retry another viable agent unless a seat is pinned.
+- Roundtable seats run in parallel, can pin a model or choose randomly, and require repository
+  evidence. A reasoning chair removes unsupported findings before the final result.
+- Model context and output limits come from the registry. Retry preserves the tool contract.
+- Write-capable delegates get isolated worktrees. Container delegates default to no network, no
+  credentials, bounded processes, and an explicit toolchain.
+- Package installation goes through a mediated cache and policy gate. Custom delegate images,
+  package sets, and Dockerfiles are supported without giving the agent the Docker socket.
+- Local CLI agents execute on the thin client when the workspace is remote. Their login and working
+  tree stay there.
+- Claude CLI delegation is opt-in because unattended use may not fit a personal subscription's
+  terms.
+- The host AI's own sub-agent launchers can be blocked so delegated work keeps the same policy,
+  budget, worktree, and audit path.
+- Roundtable cost caps are optional. When set, they include every seat and chair call.
 
-- **Delegates work by default**: a default agent roster, the ensemble panel,
-  and `remote_writes=full` ship seeded, so `aimee delegate …` and the roundtable
-  run on a fresh install with no setup.
-- **Roundtable runs through the delegate core**: `aimee delegate aggregate`
-  (mixture-of-agents) and `aimee delegate roundtable` fan out to a panel and an
-  aggregator synthesizes one answer; the run executes through the delegate path,
-  so it stays inside session state, cost accounting, and the audit trail. Cost is
-  folded onto the originating session.
-- **Use delegates, not agents**: the host AI's own sub-agent tool is blocked
-  (Claude Code's `Task` included), always on. The block points the agent at
-  `aimee delegate <role>` / `aimee delegate roundtable … --mode review`.
-- **Output limits come from the model**: token caps are derived from the model
-  registry instead of a hardcoded 4096, so large-context models use their real
-  ceiling.
-- **`ensemble.max_cost_usd` is optional**: a per-run cost cap is now opt-in,
-  unset (or 0) means no limit, the default. Set a positive value to cap a run.
+## Models, routing, and context
 
----
+- All provider traffic passes through one canonical request and response IR.
+- OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, Gemini, Mistral, Bedrock, and local
+  OpenAI-compatible servers share the same policy and accounting stages.
+- Response parsing accepts provider-specific wire shapes only at the edge. The core sees canonical
+  text, reasoning, tool calls, usage, and errors.
+- The economizer adds deterministic folding, provider-aware cache alignment, and command-aware tool
+  output condensation. Full output is spilled for recovery.
+- Model metadata, provider catalogs, quota, cost, cache, and fallback decisions are visible through
+  the CLI and dashboard.
 
-## v0.2.0
+## Knowledge and code
 
-- **Docker-first deployment**: run `aimee-server` + `aimee-kb` as containers, brought up
-  together via the split stack (`compose.server.yaml`, recommended), and install only the
-  thin client on each developer
-  machine. See the README "Run in Docker" and Manual §27.1.
-- **Cross-platform thin client**: the `aimee` CLI now drives a remote server over
-  HTTP from Linux, macOS, and Windows. Point it with `--server` /
-  `AIMEE_SERVER_URL` (+ `--server-token` / `AIMEE_SERVER_TOKEN`), or persist it
-  with `aimee remote set`. Prebuilt thin-client binaries ship with each release;
-  build just the client with `-DAIMEE_THIN_CLIENT=ON`.
-- **KB is HTTP-only**: `aimee-server` reaches `aimee-kb` exclusively over its `/v1`
-  HTTP API (`AIMEE_KB_API_URL`); the legacy Unix-socket KB transport and on-demand
-  autostart were retired. Deploys must run `aimee-kb --http-port=8741` (or its
-  service unit / container).
-- **Self-update notifier**: aimee now tells you what changed after each upgrade
-  and warns when the binary is older than the source tree.
-- **Stale binary detection**: a one-line warning appears when the binary predates
-  the latest commit. Run `make` to rebuild.
-- **Lean build profile** (`make lean`): a size-optimised, stripped binary pair for
-  minimal deployments, capped at 1.5 MB.
-- **Autonomous mode**: drive work without per-step prompts via `aimee auto` (roadmap dispatch loop) and `aimee autopilot` (end-to-end pipeline).
-- **Slash command registry**: extensible `/command` system in aimee chat.
-- **Event notifications**: fired at delegation and verification boundaries.
+- The KB container can own a private PostgreSQL 18 cluster with pgvector and pgvectorscale. An
+  export helper moves that data to an external PostgreSQL server.
+- The KB owns embedding, retrieval, curation, and code-index storage; inference stays in the
+  separate `aimee-llm` service.
+- Cross-repository symbol and dependency edges now feed caller lookup, search, and blast radius.
+- CSS migration analysis adds a style graph, dead/conflicting-rule checks, and an optional isolated
+  Chromium sidecar for computed-style verification.
+- Thin clients push workspace and document bytes. The server does not read a remote client's path.
+- Structured PDF ingestion can preserve coordinates, tables, visual crops, OCR, assets, and page
+  citations behind separate feature gates.
+- Retrieval gained typed facts, contradiction tracking, abstention, evidence audits, progressive
+  disclosure, and configurable fusion.
+
+## Deployment and clients
+
+- The all-in-one `aimee-combined` image is retired. Use the managed server or the split server, KB,
+  and inference stack.
+- New KB containers run PostgreSQL privately when `AIMEE_DB2_URL` is not set. Existing external
+  databases remain supported.
+- `aimee-llm` chooses CPU or GPU tiers at runtime. CPU images can be pre-baked for offline use; GPU
+  tiers keep models in a persistent volume.
+- Linux, macOS, and Windows use the same DB-free thin client and native TLS backend.
+- Server-to-KB mTLS pooling and resident thin-client HTTPS keep-alive now default on. The measured
+  compression flags remain off because they saved bytes but missed the latency gate.
+- A configured remote is exclusive. The client no longer falls back to a local Unix socket for a
+  subset of hooks, optimization, or delegate probes.
+- `aimee remote set` pins the server certificate, rotates the bootstrap bearer, and enrolls Linux
+  mTLS clients. Verify the fingerprint out of band.
+- The browser adds projects, git credentials, OAuth, SSH cloning, workflows, logs, settings, a live
+  graph, and per-user VS Code.
+- The dashboard is panel-based and user-configurable; operational logs moved to their own page.
+  Settings now edits the allowlisted typed config instead of a copied subset.
+- Remote index and workspace operations upload content from the thin client. Claude CLI execution
+  can stay on that client with its existing login and worktree.
+- The attention guard is inert unless enabled. Remote writes are fail-closed until identity trust
+  and per-user grants are configured.
+
+## Removed
+
+- Interactive `aimee chat` and the bare-command TUI. Use the browser, MCP, ACP, or a compatible API
+  front end.
+- The `aimee work` queue and its routes, tools, and database tables. Export old rows before upgrade
+  if you need them.
+- `aimee migrate v2`, whose server operation had already been removed.
+- The combined appliance image and its compose file.
+- The legacy KB Unix-socket autostart path.
+- Client-held plaintext agent credentials and the session credential-push endpoint.
+- The generic `/v1/rpc` transport. Named `/v1` routes are authoritative.
+
+## Upgrade notes
+
+1. Back up DB1, the KB database, `aimee.yaml`, `agents.json`, vault material, and TLS state.
+2. Dump the old sibling PostgreSQL volume before moving to the embedded KB database. The compose
+   change does not import it.
+3. Export any old work-queue rows before starting the new server; the migration removes the tables.
+4. Replace combined-image deployments with the managed or split stack.
+5. Re-enroll thin clients and verify the presented certificate fingerprint.
+6. Configure server/team/JWKS trust, then grant remote write tiers per exact subject.
+7. Run `aimee audit verify`, `aimee status`, `aimee kb status`, and one read/write smoke test after
+   the upgrade.
+
+See the [Quickstart](QUICKSTART.md), [Security model](SECURITY.md), and
+[generated configuration reference](gen/configuration.md) for the current contracts.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,502 +1,199 @@
 # Workflows
 
-A **workflow** is a declarative graph that encodes a development lifecycle,
-*propose → review → approve → plan → implement → freeze → review → PR → merge*,
-as composable, typed steps. aimee ships one default composition (`build`), and
-you can clone and edit it or author your own. The engine that advances a
-workflow run is the same one that drives delegates, roundtable reviews, and
-human approval gates.
+A workflow is a typed graph that turns an admitted request into versioned artifacts and, normally,
+a pull request. The Go control plane owns definitions, scheduling, retries, gates, worktrees, forge
+operations, and recovery.
 
-> **Status (current):** authoring and validating workflows is fully supported
-> (CLI + the webchat **Edit Workflows** tab); starting a run and watching its
-> status/history live on the **Workflow Actions** tab
-> ([`WORKFLOW_ACTIONS.md`](WORKFLOW_ACTIONS.md)). The execution engine,
-> stepping a run through its gates, roundtables, and approvals, is implemented,
-> tested, and reachable: `POST /v1/dev/submit` seeds a proposal, creates an
-> autonomous work item on the chosen workflow (default `build`), and the
-> scheduler drives it server-side. See
-> [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md). The chosen `workflow` is
-> authoritative, so **any** saved workflow starts this way, not only `build`.
-> You can start a run from the CLI with `aimee workflow run <name> --proposal
-> <file>` (or `--message`, or `-` for stdin) and watch it with `aimee workflow
-> status <id> --watch`; agents can start one over MCP with the `workflow_run`
-> tool. Both go through the same capped/audited intake as `POST /v1/dev/submit`,
-> so a proposal is still required (the run is framed as *propose → … → PR*). See
-> [Limitations](#current-limitations).
+## The contract
 
-## Mental model
+A definition has:
 
-A workflow definition (`wfe_def_t`, [src/workflow/wfe_def.h](../src/workflow/wfe_def.h))
-is a named graph:
+- a name and start node;
+- nodes, each naming one block;
+- control edges: `next`, `on_pass`, and `on_fail`;
+- typed input bindings from an earlier node's output;
+- bounded parameters for retries, fan-out, panels, and spend.
 
-- **nodes**, each node is one **step**: an `id`, a **block** (the step's type),
-  optional `params`, and typed inputs (`in`).
-- **blocks**, a block is the *kind* of work a step does (write a proposal, run a
-  roundtable, open a PR, …). The catalog is fixed in code; you can also define
-  **custom blocks**. See [Block catalog](#block-catalog).
-- **control edges**, how the run moves between steps:
-  - `next`, unconditional successor.
-  - `on_pass` / `on_fail`, a **gate**'s two outcomes (a gate produces a verdict
-    or approval; pass takes one edge, fail the other).
-- **data edges** (`in`), bind a step's typed input slot to an upstream step's
-  output (`<producer_id>.<output>`, default output handle `out`). These are
-  *type-checked*: e.g. `implement` only accepts a `plan`, `merge` only a `pr`.
-- **start**, the entry node id (defaults to the first node).
-
-Every block declares the **artifact type** it produces and the types it accepts,
-so the validator rejects a graph that wires a proposal into a step expecting a
-PR. The pipeline of artifact types is:
-
-```
-proposal → plan → branch → frozen_diff → pr → (merged)
-                     │
-   roundtable/CI/mergeable gates emit a `verdict`
-   human gates emit an `approval`
-```
-
-## Block catalog
-
-From the catalog in [src/workflow/wfe_def.c](../src/workflow/wfe_def.c)
-(`aimee workflow blocks` prints the live list):
-
-| Block | Produces | Accepts (input) | Kind | What it does |
-|---|---|---|---|---|
-| `trigger.watch-dir` | proposal |, (no input) | **trigger** | The arming entry node: watch a repo dir; each new file files one run (see [Triggers as blocks](#triggers-as-blocks-armed-workflows)). |
-| `author.proposal` | proposal |, (no input; optionally a trigger's proposal) | action | A delegate drafts a proposal. The usual entry point. |
-| `author.plan` | plan | proposal | action | A delegate turns the proposal into an implementation plan. |
-| `implement` | branch | plan | action | Delegates implement the plan onto a branch (`params.fanout: max` parallelizes). |
-| `document` | branch | branch | action | A delegate writes docs onto the branch. Composes between implement and freeze. |
-| `source.archive` | branch | branch | action | Retires the run's triggering file: moves it from the watch dir (`params.from`, default `docs/proposals/pending`) to a done dir (`params.to`, default `docs/proposals/done`), committed on the run branch. No-op for runs without a trigger artifact. |
-| `freeze` | frozen_diff | branch | action | Freezes the branch to an immutable diff for review. |
-| `gate.roundtable` | verdict | proposal · plan · frozen_diff | **gate** | Runs a multi-persona review **panel**; pass/fail on quorum. |
-| `gate.human` | approval | proposal · plan · branch · frozen_diff · pr | **gate** | Parks for a human decision — **inviolable**; never auto-satisfied in autonomous mode. |
-| `pr.open` | pr | proposal · frozen_diff | action | Opens a pull request. |
-| `merge` |, (terminal) | pr | action | Merges the PR. |
-| `gate.ci` | verdict | pr | **gate** | Polls the PR's CI; **fail-closed** (no green → fail). |
-| `check.mergeable` | verdict | pr | **gate** | Refuses on a merge conflict. |
-| `custom` | declared | declared | either | A config-defined block (command or delegate), see [Custom blocks](#custom-blocks). |
-
-**Gates** are the blocks that branch: they take `on_pass`/`on_fail` instead of a
-single `next`. Everything else takes `next`.
-
-## The default `build` workflow
-
-[config/workflows/build.yaml](../config/workflows/build.yaml) is the reference
-composition, the full two-gate development lifecycle. The control flow:
-
-```
-draft (author.proposal, with_user)
-  └─next→ proposal_gate (roundtable: security, architect, qa, reviewer; quorum 4)
-            ├─pass→ proposal_pr (pr.open) ─next→ proposal_approve (human: pr_review)
-            │                                        └─next→ plan (author.plan)
-            └─fail→ draft                                       └─next→ plan_gate (roundtable)
-                                                                          ├─pass→ impl (implement, fanout max)
-                                                                          └─fail→ plan
-impl ─next→ document ─next→ freeze ─next→ impl_gate (roundtable)
-                                            ├─pass→ code_pr (pr.open) ─next→ pr_passfail (human)
-                                            └─fail→ impl                        ├─pass→ check_mergeable
-                                                                                └─fail→ impl
-check_mergeable ─pass→ gate_ci ─pass→ merge        (any gate fail → back to impl)
-```
-
-A roundtable node carries its panel in `params`:
+The validator rejects unknown blocks, dangling edges, cycles without a declared budget, missing
+ports, and artifact type mismatches. The canonical definition is hashed. A run keeps the exact
+snapshot it started with even if the file changes later.
 
 ```yaml
-- id: proposal_gate
-  block: gate.roundtable
-  in:
-    src: draft.out          # bind this gate's input to draft's output
-  params:
-    panel:
-      required: [security, architect, qa, reviewer]   # persona names
-      eligible: [contrarian]                           # may join if available
-    quorum: 4
-  on_pass: proposal_pr
-  on_fail: draft
-```
-
-Panel entries are **persona** names, see [Personas](personas.md). Each configured
-seat performs one independent analysis in parallel. The gate passes when the
-roundtable's configured minimum succeeds with no blocking finding.
-
-If Discussion mode is enabled on that preset, all successful seats compare the
-independent reports once. Nits, suggestions, and ordinary defects cannot extend
-discussion beyond that cycle. Only disagreement about a foundational issue may
-continue, carrying just the contested stable issue IDs until a strict majority
-forms. Deadline or quorum loss parks the gate instead of inventing consensus;
-the scheduler retries that execution-owned pause after a bounded backoff with a
-new durable execution version. Work-item cost and turn caps remain the safety
-backstops, while operator and convergence parks are never auto-resumed.
-Strict majority is measured over successful seats returning a complete valid
-ballot in that cycle; abstentions remain in the denominator but do not alone
-extend discussion. The preset's `deadline_ms` covers analysis, Discussion, and
-Chairman together, with zero/omitted values normalized to 600 seconds.
-That deadline is one work-conserving budget: the runtime waits for every analysis
-seat to return, fail, or reach the configured deadline instead of silently
-dividing it into much shorter phase slices. Later phases receive the remaining
-time, and the configured deadline remains the hard bound for the whole table.
-The compatibility proxy uses the acquired preset deadline plus bounded
-transport grace, so its socket timeout cannot preempt valid configured work.
-An unavailable independent-analysis seat remains visible as degraded
-participation, but it parks the gate only when complete reports fall below the
-preset's `min_successful`; meeting that configured minimum continues normally.
-
-An optional configured chairman runs once after deterministic synthesis and
-submits the final structured feedback. The chairman is a positive, visible agent
-selection, not an exclusion rule. Transport failure, malformed output, wrong
-artifact stage, or a contradictory verdict parks the gate for scheduler retry;
-it never triggers a roster-wide fallback. A valid `changes` verdict with
-`drifted` or `unclear` alignment becomes structured refinement feedback rather
-than an execution pause. When disabled, deterministic synthesis is final.
-
-Roundtable presets are execution policy. Agents and automation may read and use
-them, but create, edit, delete, and default-selection operations require the
-attested `webuser:admin` appliance administrator. Generic API capabilities,
-other authenticated web users, and local Unix-socket access do not authorize
-those mutations.
-
-**Which models review the artifact** comes from the roundtable preset the gate
-names. Its exact seats are the complete panel; required personas are
-review/verdict dimensions and do not create additional seats:
-
-- a **specific pinned model** is dispatched to that **exact** agent. If that model
-  is not enabled/routable for the `review` role — or its dispatch fails — the run
-  **fails** (a pinned model is a hard requirement, never silently swapped);
-- a **`$random`** seat picks an available review-capable agent;
-- when the named preset cannot be loaded, the gate parks `panel_unreachable`.
-  There is no fallback panel: a review nobody configured is not a review.
-
-Set a seat to a specific model or to *Random* in the Roundtable page of the GUI.
-An agent is "review-capable" unless its `exec_roles` explicitly omit `review`
-(e.g. a specialized `gpu-mid` is never seated). If no panel of reviewers can be
-composed at all the gate parks `panel_degraded` for a human.
-
-A `gate.roundtable` node **must** name its preset with `params.roundtable`; a
-workflow that omits it fails validation. Different gates in one workflow name
-different panels, and the shipped workflows do exactly that (`plan`,
-`implementation`, `acceptance`, `documentation`, seeded from
-`config/roundtables/`):
-
-```yaml
-- id: plan_gate
-  block: gate.roundtable
-  params:
-    roundtable: security-review     # required: convene this preset's seats
-    panel:
-      required: [security, architect, qa, reviewer]
-    quorum: 4
-```
-
-If the named preset does not exist, the gate parks with a configuration error;
-it never silently substitutes another panel.
-
-There is **no engine privilege** over a user-authored workflow: `build` is just
-one composition of the same catalog you compose from. Clone it and edit freely.
-
-## Authoring
-
-### Definition format
-
-A workflow is YAML: a `name`, a `start` node id, and a `nodes` list. Each node:
-
-```yaml
-name: my-workflow
-start: draft
+name: review-change
+start: proposal
 nodes:
-  - id: draft
+  - id: proposal
     block: author.proposal
-    params: { with_user: true }
+    next: plan
+    on_fail: proposal
+
+  - id: plan
+    block: author.plan
+    in:
+      proposal: proposal.out
     next: review
+    on_fail: plan
 
   - id: review
     block: gate.roundtable
-    in: { src: draft.out }          # input slot ← producer.output
+    in:
+      src: plan.out
     params:
-      panel: { required: [reviewer, qa] }
-      quorum: 2
-    on_pass: pr
-    on_fail: draft                  # loop back to revise
+      roundtable: plan
+      quorum: 3
+      max_rounds: 6
+    on_pass: implement
+    on_fail: plan
 
-  - id: pr
-    block: pr.open
-    in: { src: draft.out }
+  - id: implement
+    block: implement
+    in:
+      plan: plan.out
 ```
 
-Definitions are **content-addressed**: the engine computes a canonical form and a
-SHA-256 `version` over it ([wfe_canonical.c](../src/workflow/wfe_canonical.c)), so
-a run is pinned to the exact graph it started on.
+## Built-in blocks
 
-### CLI
+Run `aimee workflow blocks` for the live catalog.
 
+| Block | Purpose | Output |
+| --- | --- | --- |
+| `trigger.watch-dir` | file a run from a committed file | proposal |
+| `author.proposal` | normalize or draft a proposal | proposal |
+| `understand` | turn a request into bounded intent | intent |
+| `author.plan` | plan against a proposal | plan |
+| `split` | divide intent or plan into packets | plan |
+| `branch.open` | create the durable feature branch | branch |
+| `implement` | implement one plan | branch |
+| `foreach.workflow` | run a child workflow for each packet | branch |
+| `document` | update documentation on a branch | branch |
+| `source.archive` | move the triggering source into its done location | branch |
+| `freeze` | make an immutable review artifact | frozen diff |
+| `review` | review a branch or frozen diff | verdict |
+| `gate.roundtable` | convene a named panel | verdict |
+| `gate.human` | park for a signed human decision | approval |
+| `check.mergeable` | reject a conflicting PR | verdict |
+| `gate.ci` | wait for required checks | verdict |
+| `gate.deliver` | enforce the delivery verdict | none |
+| `pr.open` | open a pull request | PR |
+| `merge` | merge an approved PR | none |
+
+## Default build
+
+The shipped `build` workflow:
+
+```text
+request -> proposal -> feature branch -> plan -> plan roundtable
+        -> split -> parallel slice workflows -> acceptance roundtable
+        -> documentation -> documentation roundtable -> archive source
+        -> open feature PR against the repository default branch
 ```
-aimee workflow blocks               # list the composable block catalog
-aimee workflow new <file.yaml>      # scaffold a starter workflow
-aimee workflow validate <file.yaml> # typed-graph validation (does it wire up?)
-aimee workflow show <file.yaml>     # print the canonical form + version
-aimee workflow list                 # list workflows under $AIMEE_HOME/workflows
-```
 
-Workflow files live under `$AIMEE_HOME/workflows/`. `validate` runs the same
-type-checker the engine uses: it catches dangling edges, a step fed the wrong
-artifact type, or a missing required input.
+Each slice implements, freezes, reviews, verifies, and merges into the feature branch. The feature PR
+is opened against the forge's authoritative default branch and left for normal human review.
 
-### Webchat: Edit Workflows tab
+Roundtable rejection feeds its blockers into the next author or split pass. The loop parks when it
+repeats without progress or reaches its declared round budget.
 
-The browser **Edit Workflows** tab (route `/edit-workflows`) is a visual composer
-over the same definitions. Authoring a run, watching its status/history, and
-deciding human gates live on the separate **Workflow Actions** tab
-(`/workflow-actions`, see [`WORKFLOW_ACTIONS.md`](WORKFLOW_ACTIONS.md)):
+## Run state
 
-- A **blocks rail** to add steps, a **canvas** that lays the graph out
-  left-to-right by depth with colored edges (solid = `next`, green = `on pass`,
-  red = `on fail`, faint = data dependency), and an **inspector** to set a step's
-  title, block, params, per-step **persona/delegate** assignment, and its
-  `next`/`on_pass`/`on_fail` edges.
-- **Personas** can be created and edited from the same tab (it proxies
-  `/api/chat/personas`).
-- **Validate** and **Save** persist the def server-side via `/api/workflow/*`.
-- Each top-nav tab (including Edit Workflows) selects its own git **project**.
+The control plane persists a transition before dispatching external work. A work item records:
 
-> Note: adding a step from the blocks rail drops it onto the canvas
-> **disconnected**, you wire it into the sequence by selecting it and setting
-> its `next`/`on_pass`/`on_fail` in the inspector. To start and watch a run, use the Workflow Actions tab.
+- admitted request and immutable proposal;
+- workflow name, version, and current node;
+- repository, worktree, feature branch, and slice branches;
+- plan, diff, review, documentation, and forge artifacts;
+- retry, loop, agent, and spend budgets;
+- state, park reason, gate evidence, and lifecycle events.
 
-### Custom blocks
+A provider, agent, runner, or compatibility worker can fail without corrupting the run. Restart
+recovery reads the durable transition and retries or parks according to the node contract.
 
-Beyond the built-in catalog you can declare custom blocks in
-`$AIMEE_HOME/workflows/blocks.yaml`
-([wfe_custom.c](../src/workflow/wfe_custom.c)). A custom block has a name, a typed
-I/O signature (so it type-checks like a built-in), and an executor that is either
-a **command** (`WFE_EXEC_COMMAND`, an argv) or a **delegate**
-(`WFE_EXEC_DELEGATE`). The validator and artifact-type system consult the
-registry, so custom and built-in blocks compose identically.
+## Failure behavior
 
-## Execution model
+- A delegate failure follows `on_fail` or parks if the graph has no recovery edge.
+- A missing implementation commit cannot advance.
+- A merge conflict is terminal for that attempt.
+- A slice branches from the current merged feature tip, not stale `origin/HEAD`.
+- A lost roundtable replay invokes reservation recovery instead of pretending the review passed.
+- A saturated agent is skipped; global and per-workflow limits stay enforced.
+- Exhausted or repeated no-progress loops park with the last blocker.
+- A malformed or unusable reviewer abstains; it is not counted as approval.
 
-When a run exists, it is a **work-item** (the `lifecycle_work_item` table,
-[src/db1/wfe_store.c](../src/db1/wfe_store.c)) carrying: the workflow name and
-pinned `version`, the target `repo`, `current_stage`, `content_hash`, `state`,
-`mode` (`interactive` | `autonomous`), `pause_reason`, and accumulated cost.
+## Human gates
 
-The engine advances it one step at a time
-([wfe_engine.c](../src/workflow/wfe_engine.c) `wfe_engine_advance`):
+`gate.human` always parks. Autonomous mode cannot approve it, and validation rejects a supposedly
+optional or preauthorized human gate.
 
-- An **action** block runs (often dispatching a delegate with a persona) and
-  advances along `next`.
-- A **gate** evaluates and takes `on_pass` or `on_fail`.
-- A **roundtable** gate runs its persona panel as delegates and passes on quorum.
-- A **human gate** **parks** the run (`WFE_STEP_PENDING`) until a human approval is
-  recorded — and this is **inviolable**. In `autonomous` mode the driver
-  ([wfe_autonomy.c](../src/workflow/wfe_autonomy.c)) **never** auto-satisfies a
-  human gate; authoring one as auto-satisfiable (`policy: preauthorized` or
-  `optional: true`) is rejected at validation. Only a human's signed approval
-  clears it.
-- Approvals are **signed** ([wfe_approval.c](../src/workflow/wfe_approval.c)) and
-  recorded against the step's content hash, so an approval is bound to the exact
-  artifact it approved.
+The approval records the principal, node, current artifact hash, verdict, and signature. Editing the
+artifact invalidates the decision.
 
-A step resolves the working repository from the work item's own `repo` when it
-names a local directory (a trigger rule's `pipeline.workspace` binds the run to
-that repository), falling back to `$AIMEE_WORKFLOW_REPO`, then the process cwd.
-See [Limitations](#current-limitations) for the forge-side residue of the old
-process-global behavior.
-
-## Inspecting runs
-
-When work-items exist, they are readable (the Workflow Actions tab (see [`WORKFLOW_ACTIONS.md`](WORKFLOW_ACTIONS.md)) and
-the API):
-
-- CLI: `aimee cancel <work-item-id>` cancels a run.
-- Webchat: `GET /api/workflow/items` (and `/items/<id>`) list run state; a run
-  bound to a chat channel can be paused via
-  `POST /api/sessions/workflows/<id>/pause`.
-- Server `/v1/workflow/*` ([server_workflow_api.c](../src/server/server_workflow_api.c))
-  exposes the def read/author surface and the work-item read surface.
+An out-of-band forge review of the final PR is separate from `gate.human`; use either or both based
+on the workflow.
 
 ## Triggers
 
-A **trigger** is the *first step* that starts a workflow run — the thing that
-decides *when* a run begins and *which* workflow it begins. A trigger is
-deliberately generic: the event that fires it can be autonomous (a new proposal
-appears in a repo, a schedule elapses, a webhook arrives) or a person (clicking
-**Run** on the Workflow Actions tab is itself a trigger). The intent is a small
-set of generic trigger sources that you wire to whatever workflow you want —
-the trigger starts the run; what happens next is entirely the workflow's design.
-
-Sources are a registry in
-[src/server/trigger_scheduler.c](../src/server/trigger_scheduler.c): each entry
-is `{name, due, fire}` — `due` decides whether this tick should fire (a repo
-scanner polls every pass; cron matches its schedule), `fire` matches events and
-materializes artifacts, and files each run through the shared
-`trigger_file_run` back half (work item on the rule's pipeline + workspace +
-mode, per-run USD ceiling from `max_spend_usd` or the intake-wide default,
-audit log line). The tick loop owns the rest — per-rule rate limiting and the
-global `trigger.max_concurrent` — so adding a source is one table row plus its
-`fire`.
-
-Triggers are configured as a `trigger_rules` list in `aimee.yaml`. Each rule
-names a **source** (what fires it), how the filed run should execute (**mode**),
-and the **pipeline** (which workflow, in which repo):
+Triggers create the same admitted work item as a browser submission. Sources include manual fire,
+watch-directory/proposal scans, cron, and configured webhook sources.
 
 ```yaml
 trigger:
-  max_concurrent: 1          # cap on concurrently-executing triggered runs
+  max_concurrent: 1
 
 trigger_rules:
-  - source: watch-dir              # scan a repo dir for new files (alias: proposals)
-    event: docs/proposals/pending  # repo-relative dir to watch (this is the default)
-    schedule: main                 # git ref/branch to read (default: auto-detected origin HEAD)
-    mode: autonomous               # autonomous (default) | interactive
+  - source: watch-dir
+    event: docs/proposals/pending
+    schedule: main
+    mode: autonomous
     pipeline:
-      template: build              # the workflow to start for each new proposal
-      workspace: /srv/repos/myproject   # absolute path of the git repo to scan
+      template: build
+      workspace: /srv/repos/project
+      max_spend_usd: 5
 ```
 
-### Rule fields
+`autonomous` starts scheduling immediately. `interactive` files the run and parks for a person.
+Neither mode changes gates inside the workflow.
 
-| Field | Meaning |
-| --- | --- |
-| `source` | What fires the rule: `watch-dir` (alias `proposals`), `cron`, or a webhook source. |
-| `event` | Source-specific match. For `watch-dir`/`proposals`, the repo-relative directory to scan (default `docs/proposals/pending`). |
-| `schedule` | For `cron`, the cron expression. For `watch-dir`/`proposals`, the git ref/branch to read (default: auto-detected `origin` HEAD, then `HEAD`). |
-| `mode` | Execution mode stamped on the filed work item — see below. `autonomous` (default) or `interactive`. |
-| `pipeline.template` | The workflow to start (any saved workflow name, e.g. `build`). |
-| `pipeline.workspace` | Absolute path of the git repo the run operates in (and, for `watch-dir`/`proposals`, the repo to scan). |
-| `pipeline.max_spend_usd` | Optional per-run spend cap. |
+Watch-directory triggers read a named git ref, materialize the file, deduplicate it, bind the run to
+the configured repository, and defer rather than drop when the trigger concurrency limit is full.
 
-### `mode`: autonomous vs. interactive
+The current scheduler owns trigger delivery directly. Publishing all trigger firings through the
+event bus is the next integration step, not an existing guarantee.
 
-`mode` selects **how the run executes once the trigger files it**, independent
-of the workflow it names:
+## Custom blocks
 
-- **`autonomous`** (the default) — the autonomy scheduler drives the run
-  hands-off, start to finish. Use this when the trigger event *is* the approval:
-  merging a proposal into the watched branch, for example, is itself the decision
-  to build it, so no further human sign-off is wanted.
-- **`interactive`** — the run is filed and then **parks for a human** to drive in
-  the webchat (Workflow Actions tab). Use this when someone should review before
-  anything runs.
+Custom blocks live in the workflow `blocks.yaml`. A block declares its input and output type, then
+uses either a delegate or an operator-managed command.
 
-This is distinct from **gating inside the workflow**. A `gate.human` step (or an
-`author.proposal` node marked `with_user`) parks *that step* for a person
-regardless of `mode` — it is a property of the workflow you build, not of the
-trigger. So you can compose either shape: an `autonomous` trigger into a
-workflow that still pauses at a human gate partway through, or an `interactive`
-trigger into a fully hands-off workflow. Pick the trigger `mode` for the
-*start* decision; put in-flight gates in the *workflow*.
+Delegate blocks require a persona and prompt. Command blocks are disabled unless the operator opts
+in; the executable must be absolute, hash-pinned, and bounded by a timeout. A custom block cannot
+shadow a built-in.
 
-### The `watch-dir` source (alias: `proposals`)
+## Author and operate
 
-The `watch-dir` source turns "a file was committed into a watched directory"
-into a workflow run — `proposals` is the original alias for the same scanner,
-whose default directory (`docs/proposals/pending`) is just one configuration. On
-each scan (roughly once a minute) it lists the proposal directory at the
-configured git ref, and for every proposal it has not seen before it:
+```bash
+aimee workflow blocks
+aimee workflow new ~/.config/aimee/workflows/change.yaml
+aimee workflow validate ~/.config/aimee/workflows/change.yaml
+aimee workflow show ~/.config/aimee/workflows/change.yaml
+aimee workflow list
 
-1. materializes the proposal's content under `$AIMEE_HOME/triggers/proposals/`,
-2. files exactly one work item on `pipeline.template`, in `pipeline.workspace`,
-   with the configured `mode` (default `autonomous`),
-3. de-duplicates by proposal, so re-scanning the same tree never files twice,
-4. stamps the run's USD ceiling — the rule's `max_spend_usd` if set, else the
-   same default every autonomous intake gets ($5.00; `AIMEE_AUTONOMY_MAX_USD`
-   overrides, `0` disables) — and wakes the autonomy scheduler so the run
-   starts immediately rather than on its next backstop sweep.
-
-`trigger.max_concurrent` is enforced at filing time: when that many
-trigger-filed runs are still active, further proposals are deferred (not
-dropped — the dedup key is the materialized proposal, so they file on a later
-scan once a slot frees). The work item's `repo` is the rule's
-`pipeline.workspace`, and every per-step block resolves its working directory
-from it, so the run executes in the watched repository.
-
-Merging a new proposal onto the watched branch is therefore all it takes to
-kick off a build — and with `mode: autonomous`, that build runs to its PR
-without further intervention. Point the rule at a different `template` to run
-any other workflow you have authored.
-
-> The filed run still enters through the same capped, audited intake as every
-> other run (see [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)); the trigger
-> supplies the proposal text, so the *propose → … → PR* framing below still holds.
-
-### Triggers as blocks (armed workflows)
-
-`trigger_rules` arms *someone else's* workflow from config. The graph-native
-form puts the trigger **in the workflow itself**: make `trigger.watch-dir` the
-start node and the saved workflow is **armed** — the trigger scheduler
-enumerates saved workflows whose start is a trigger block every tick and files
-runs through the exact same intake (dedup, per-run USD ceiling,
-`trigger.max_concurrent`, audit) as an equivalent rule. One YAML file then
-states *watch this dir, in this repo, and run this graph*:
-
-```yaml
-name: build-triggered
-start: watch
-nodes:
-  - id: watch
-    block: trigger.watch-dir
-    params:
-      dir: docs/proposals/pending        # repo-relative dir to watch (default)
-      workspace: /srv/repos/myproject    # REQUIRED to arm: the repo to watch/run in
-      # ref: main                        # git ref to read (default: origin HEAD)
-      # mode: autonomous                 # or interactive
-      # max_spend_usd: 2
-    next: draft
-  - id: draft
-    block: author.proposal
-    in:
-      proposal: watch.out                # the trigger's artifact, as a data edge
-    ...
+aimee trigger fire --help
+aimee trigger list
+aimee trigger status <id>
+aimee trigger cancel <id>
 ```
 
-The validator enforces trigger placement: a trigger block must be the start
-node, at most one per workflow, with no inbound edges and no `in` bindings.
-At run time the trigger node advances instantly (the scheduler already
-materialized the watched file as the run's proposal); without
-`params.workspace` the workflow saves fine but stays disarmed (one warning is
-logged). Deleting the workflow disarms it. The shipped
-[`build-triggered`](../config/workflows/build-triggered.yaml) template is this
-composition: watch → author → plan → gate → slices → accept → document →
-**archive (pending → done)** → final PR.
+The **Edit Workflows** page edits definitions. **Workflow Actions** starts, watches, parks, resumes,
+and gates runs. A new visual node is disconnected until its control and data edges are set.
 
-A GUI interaction is a trigger too: creating a proposal in the webchat writes
-it into the watched directory, so the same armed workflow picks it up — every
-run starts with a trigger, whether a person or an event fired it.
+## Boundaries
 
-## Current limitations
+- Go is the only workflow lifecycle writer.
+- The C server owns agents, credentials, general tools, and policy resources used by a run.
+- Forge operations are confined to the managed worktree root and exact feature/slice namespace.
+- Credential material never returns to the workflow process.
+- The event bus is the internal observability spine, but workflow trigger events are not yet on the
+  integrated bus path.
 
-These are real today and worth knowing before you lean on workflows:
-
-1. **Every run is still framed as a proposal.** Runs start through the capped,
-   audited intake behind `POST /v1/dev/submit` (see
-   [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)). The `workflow` field is
-   authoritative, so **any** saved workflow starts this way, not just `build`.
-   That intake is now reachable three ways — the **Workflow Actions** tab, the
-   `aimee workflow run <name>` CLI command, and the `workflow_run` MCP tool for
-   agents — but all of them require a `proposal_md`: there is still no way to
-   start a workflow whose entry node isn't `author.proposal` without supplying
-   proposal text. (There is still no Run button on the **Edit Workflows** page.)
-2. **Forge binding requires a local-path `repo`.** Every stage — the per-work-item
-   worktree, each step's working directory, *and* the forge half (`git push`,
-   the GitHub REST create/CI/merge, and the vaulted credential) — resolves its
-   directory from the work-item's `repo` via `wfe_repo_local()`. When `repo`
-   names a **local directory** (a trigger rule's absolute `pipeline.workspace`,
-   or an explicit dev-submit path) that repo wins end-to-end: the run's branch is
-   created in *that* checkout, pushed from *that* checkout, and the PR is opened
-   against the slug read from *that* checkout's `origin` — so a triggered
-   `watch-dir` run reaches a real PR in its configured workspace. The residual
-   gap is only when `repo` is **not** a local path — a bare `owner/name`
-   identifier or a clone URL — for which `wfe_repo_local()` falls back to
-   `$AIMEE_WORKFLOW_REPO`/cwd (the server's own checkout). So a dev-submit that
-   names a repo the server hasn't checked out is not yet workspace-isolated;
-   point the run at an absolute `pipeline.workspace`/`repo` path to bind it.
-3. **Composer ergonomics.** New steps are added disconnected; you wire order in
-   the inspector. The **Edit Workflows** page has no live run/progress view — you
-   start and watch runs on the separate **Workflow Actions** tab.
-
-## See also
-
-- [Personas](personas.md), the identities that staff roundtable panels and steps.
-- [Delegates](DELEGATES.md), how steps dispatch model work.
-- [Architecture](ARCHITECTURE.md), where the workflow engine sits.
-
-Autonomous runs are gated: only work that passes review advances.
+See [Autonomous development](AUTONOMOUS_DEVELOPMENT.md), [Workflow Actions](WORKFLOW_ACTIONS.md),
+and [Roundtables](ENSEMBLE.md).

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -1,283 +1,79 @@
-# Workflow Actions (web page)
+# Workflow Actions
 
-The **Workflow Actions** page (aimee web UI, left nav → 📝 Workflow Actions) carries a change from
-an empty editor to a merged PR: **author** a proposal (from scratch or
-delegate-drafted), hand it to the **autonomous-development** engine to implement, and
-**watch** it, a scrollable status/history you can scroll back through to see
-everything that happened.
+The browser's **Workflow Actions** page starts and operates workflow runs. **Edit Workflows** changes
+definitions; it does not operate live work.
 
-It is deliberately a thin surface over machinery that already exists: the wfe
-autonomy engine (see [`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). A
-proposal is still just *markdown + a `lifecycle_work_item`*; its history *is* the
-`lifecycle_event` log. **No new database tables or columns were added.**
+## Start a run
 
-- **Nav / route:** `/workflow-actions` (`frontend/src/App.tsx`), page
-  `frontend/src/pages/WorkflowActions.tsx`.
-- **Separation of concerns:** the **Edit Workflows** page (`/edit-workflows`) is now the
-  workflow-*definition* editor only (author/validate/save graphs, assign personas).
-  All run/submit/status concerns live on **Workflow Actions**.
+Choose:
 
----
+- project/repository;
+- saved workflow;
+- proposal or request;
+- interactive or autonomous mode;
+- optional spend ceiling.
 
-## User flow
+Submission validates the input, creates the durable work item, snapshots the workflow, and returns
+the item ID. The request, proposal, plan, implementation, reviews, and documentation remain separate
+artifacts.
 
-1. **Author**: click **+ New proposal**. Fill in a title, a Markdown body (a
-   Goal / Motivation / Approach / Risks / Tests scaffold is pre-filled), pick a
-   workflow (the picker is populated from the saved workflow definitions,
-   `GET /api/workflow/defs`; it defaults to `build`, the standard end-to-end
-   proposal→PR→merge workflow), and optionally a repo. Optionally click
-   **✨ Draft with a delegate** to have a delegate expand your title + notes into a
-   polished proposal, previewed for you to accept.
-2. **Submit**: posts the proposal to the autonomous-development intake. The page
-   switches to the new run's status view.
-3. **Watch**: the detail view shows the current stage, a lifecycle badge, cumulative
-   vs. cap cost, a PR link, and a **scrollable timeline** of every lifecycle event.
-   It polls while the run is active and stops at a terminal state.
-4. **Decide**: when the run parks at a human gate, **Approve / Reject** in place.
+## Read a run
 
----
+The page shows:
 
-## Architecture
+- state and current node;
+- feature and slice branches;
+- latest artifact and content hash;
+- delegates, retries, and admission waits;
+- roundtable evidence and verdicts;
+- spend and configured limit;
+- CI, merge, forge, and park state;
+- the append-only lifecycle history.
 
-The browser never talks to the C server directly. Two servers:
+The UI polls or streams read models from the Go workflow API. It does not reconstruct state from
+browser events.
 
-```
-browser ──/api/*──▶ webchat (Go)  ──/v1/*, UDS──▶ aimee-server (C)  ──▶ DB1 (sqlite)
-                     v1RequestWebuser                lifecycle_work_item / lifecycle_event
-                     (X-Aimee-Webuser + server.token)  wfe scheduler (autonomy engine)
-```
+## Act on a run
 
-- The Go webchat proxies each `/api/*` call to the C server's `/v1/*` HTTP surface
-  over a trusted unix socket, asserting the caller's identity with the
-  `X-Aimee-Webuser` header + `server.token` bearer (`v1RequestWebuser`). This is how
-  the C server resolves the caller's `webuser:<subject>` principal, which the
-  read endpoints use for ownership scoping (below).
-- The C server owns all state. Submitting writes the proposal markdown to
-  `$AIMEE_HOME/edit-workflows/workflow-actions/wi-*.md` and a `lifecycle_work_item` row; the wfe
-  scheduler drives that item through its workflow, appending a `lifecycle_event` per
-  transition.
+Depending on state, an authorized user can:
 
----
+- start or resume scheduling;
+- pause or cancel;
+- approve or reject a human gate;
+- retry a recoverable parked step;
+- open the current artifact or forge link.
 
-## Backend endpoints
+A gate decision is bound to the principal, node, and current artifact hash. If the artifact changes,
+the old decision cannot advance the run.
 
-All C routes are in `src/server/server_http_routes.inc`; handlers in
-`src/server/server_workflow_api.c` (run-state) and `src/server/server_agent.c`
-(drafting). Every Go proxy is registered in `webchat/server.go`.
+Autonomous mode never passes a human gate. It only drives non-human steps until completion, failure,
+or a named park.
 
-### Run-state reads (Slice 0)
+## Authorization
 
-| Browser (`/api`) | Server (`/v1`) | Cap | Returns |
-|---|---|---|---|
-| `GET /api/workflow/items` | `GET /v1/workflow/items` | `CAP_DASHBOARD_READ` | the caller's **own** items (submitter-scoped) |
-| `GET /api/workflow/items/all` | `GET /v1/workflow/items/all` | `CAP_WORKFLOW_ADMIN` | **all** items (operator view) |
-| `GET /api/workflow/items/<id>` | `GET /v1/workflow/items/<id>` | `CAP_DASHBOARD_READ` | one item (owner-only) |
-| `GET /api/workflow/items/<id>/events` | `GET /v1/workflow/items/<id>/events` | `CAP_DASHBOARD_READ` | paginated lifecycle timeline (owner-only) |
-| `GET /api/workflow/items/<id>/proposal` | `GET /v1/workflow/items/<id>/proposal` | `CAP_DASHBOARD_READ` | source proposal markdown (owner-only) |
+Reads require workflow-read authority. Starting, retrying, canceling, or deciding a gate requires the
+corresponding workflow-admin capability and user write grant. Browser project selection is not an
+authorization grant; the owning service checks every request.
 
-- **Enriched item** (`item_to_json`): the existing keys (`id, workflow, version,
-  stage, state, mode, pause_reason, repo`) plus additive `proposal_name`, `pr_ref`,
-  `submitter`, `cum_cost_usd`, `work_item_max_cost_usd`, `override_count`. Additive
-  only, so the Edit Workflows page (which reads the same endpoint) is unaffected.
-- **Timeline**: `{events:[{id, stage, kind, actor, detail, cost_usd, created_at}],
-  next_after}`, oldest-first, paginated by `?after=<event id>&limit=<n≤200>`
-  (default 200). `next_after` is the id of the **last returned** event, so the page
-  fetches the tail once and polls with `after=next_after` to append only new events.
-  Correctness rests on the scheduler being single-writer-per-item (concurrency 1) and
-  event ids being monotonic, so `id > after` never skips or duplicates a row.
-- **Proposal read-back**: `{proposal_md, truncated}`. The file is read **race-free**:
-  the fixed proposals dir is opened, then `openat(dirfd, basename, O_NOFOLLOW)`. Since
-  `proposal_path` is a flat, server-minted file in one directory, there are no
-  mid-path components to race and no symlink is followed (`ELOOP → 403`). Non-regular
-  files are refused; the read is capped at 1 MB with `truncated` set rather than
-  rejected.
+Forge credentials stay in the server vault. The workflow process requests a narrow mechanical forge
+operation and never receives the secret.
 
-### Drafting (Slice 3)
+## Failure states
 
-| Browser (`/api`) | Server (`/v1`) | Cap | Returns |
-|---|---|---|---|
-| `POST /api/proposal/draft` | `POST /v1/agent/draft` | `CAP_DELEGATE` | `{text, agent}` |
+The page keeps the reason instead of flattening every stop into “failed.” Common states include:
 
-- Request `{prompt, model?}`; response `{text, agent}` where `text` is the generated
-  proposal markdown and `agent` is the **name of the configured delegate** that
-  produced it (the caller's `model` preference if it named a usable non-CLI delegate,
-  otherwise the default or first eligible one, surfaced so the operator can see who
-  drafted it). `handle_agent_draft` (`server_agent.c`) runs one **tool-free** LLM
-  completion via `agent_generate` (below) and returns the text.
-  `CAP_DELEGATE` is satisfied by the `agent.*` capability prefix
-  (`src/server/server_auth.c`).
-- The call is **synchronous**: there is no async job to orphan. A worker thread runs
-  the single completion to completion (bounded by the model and the draft token cap)
-  and returns. If the browser gives up, the worker still finishes that one
-  completion; nothing lingers as a pollable job. Because an LLM completion can exceed
-  the webchat default 10 s timeout, the proxy uses `v1RequestWebuserT` (a
-  timeout-parameterized variant of `v1RequestWebuser`, `webchat/vault.go`) with a 95 s
-  budget.
-- **Errors** (`handle_agent_draft`): a missing/short prompt → `400`; no non-CLI
-  delegate configured, or the completion failing (model error, timeout, empty
-  response) → a `{"error": …}` body the composer surfaces inline next to the button.
+- human approval required;
+- no eligible agent or agent limit reached;
+- panel degraded or no valid quorum;
+- convergence limit or repeated no progress;
+- missing commit or empty implementation;
+- verification failure;
+- merge conflict;
+- lost review replay;
+- forge or CI failure;
+- spend limit reached.
 
-### Reused, unchanged
+Fix the named condition, then use the offered action. Do not restart a new run merely to lose the
+evidence from the first one.
 
-- **Submit:** `POST /api/dev/submit {proposal_md, workflow, repo}` → the existing
-  autonomous-development intake (`/v1/dev/submit`, `CAP_DELEGATE`).
-- **Gate:** `POST /api/workflow/items/<id>/gate {decision}` → the existing operator
-  gate (`CAP_WORKFLOW_ADMIN`); the gate is always the row's parked stage, never
-  trusted from the request.
-
----
-
-## Security model
-
-- **Ownership scoping (per-item reads).** `/events`, `/proposal`, and the single-item
-  GET are owner-only, enforced *in the C handler* (`wf_owns`): the row's `submitter`
-  must string-equal the caller's `server_http_identity_principal()` (`webuser:<subj>`).
-  A NULL/empty `submitter` (CLI/legacy/system rows) is owned by nobody, so those reads
-  fail closed. This is why the Go proxies use `v1RequestWebuser` (not the un-attested
-  `v1Request`), otherwise the principal would be empty and every read would 403.
-- **List scoping.** `GET /v1/workflow/items` returns only the caller's own rows; the
-  unscoped operator view is a separate route, `GET /v1/workflow/items/all`, statically
-  gated by `CAP_WORKFLOW_ADMIN`. The `/all` route is deliberately *not* owner-filtered,
-  so it is the only surface on which NULL/empty-`submitter` rows (CLI/legacy/system
-  items, invisible to the owner-scoped reads) appear.
-- **How capabilities are acquired.** Browser users authenticate to the webchat; the
-  webchat→server hop is over the filesystem-trusted UDS, and the C server treats that
-  channel as the operator (this is the established single-trusted-operator webchat
-  model, the same one that guards the vault and the workflow gate). The per-route
-  `CAP_*` values are the transport/route gates; the *per-user* narrowing that matters
-  for this feature is the in-handler ownership check on `submitter`, which is why the
-  proxies must forward the webuser identity.
-- **Path confinement.** The proposal read-back is dirfd + `openat(O_NOFOLLOW)` on a
-  server-minted basename: no traversal, no symlink follow, no TOCTOU (details above).
-- **Delegate drafting is tool-free.** `agent_generate` (`src/server/agent_runtime.c`)
-  selects a single **non-CLI** (HTTP-provider) delegate and calls the plain-completion
-  **`agent_execute()` directly**. The tool-execution loop lives only in the *separate*
-  `agent_execute_with_tools_for_role()`, which `agent_generate` never calls, so a
-  draft returns text and nothing else, regardless of the agent's `tools_enabled`: no
-  tools, no worktree, no writes, no repo access. It refuses if only CLI (agentic)
-  agents exist. The user's title/notes are the *subject*, framed by a fixed system
-  prompt that tells the model to treat them as data. **Residual risk (bounded, not
-  zero):** because there are no tools there is no *server-side* side effect, but the
-  model can still produce misleading or malicious *markdown* (e.g. a phishing link) in
-  the draft. That draft is shown as a preview and the user must explicitly accept it.
-  The human reviewer owns the same trust judgment they would for any hand-written
-  proposal. The rendered preview cannot inject script (it goes through the escaping
-  `renderMd`, below), and an accepted draft only becomes a normal proposal the user
-  then submits.
-- **No admin bypass on per-item reads.** `wf_owns` is strictly `submitter == caller`;
-  there is *no* `CAP_WORKFLOW_ADMIN` override for `/events`, `/proposal`, or the
-  single-item GET. An admin's extra reach is the `/all` *list* only (item rows, which
-  do not include event `detail` or the proposal body). Consequently
-  **`lifecycle_event.detail`** (served verbatim, not sanitized in v1) is visible only
-  to the **owner** of the item. (Cross-user admin inspection of another user's timeline
-  or proposal is deliberately deferred; use the CLI/DB for that.)
-
-Where these are stated as guarantees they are *design properties of this code path*,
-not absolutes: the tool-free property holds as long as the draft path calls
-`agent_execute()` (not the tools variant); the path-confinement property holds because
-the proposals directory is server-owned (created `0700`) and only server-minted
-basenames are opened.
-
----
-
-## Frontend behavior (`WorkflowActions.tsx`)
-
-- **Timeline polling.** Keyed on the selected id alone; each tick appends only events
-  past the cursor (idempotent: it filters `id > lastId`), and the interval self-stops
-  once the item reaches a **terminal** `state`. The terminal set is exactly the
-  non-`active` values of the authoritative work-item `state` enum:
-  `active | accepted | rejected | abandoned` (`db1_work_item_t`; see
-  [`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)), i.e. `accepted`,
-  `rejected`, `abandoned`. A **parked** run is *not* a separate state: it stays
-  `active` with a non-empty `pause_reason` (`pending_human`, `failed`,
-  `budget_exceeded`, …), so the page keeps polling it every ~4 s (an operator can still
-  resume or override a park); polling stops only when the item actually reaches one of
-  the three terminal states. `openProposal` guards its async loads with a monotonic
-  request token so a rapid re-selection can't let a stale fetch clobber the current
-  proposal. A transient poll error is swallowed and retried on the next tick; a
-  list/detail load error surfaces a status message.
-- **Proposal markdown** (both the run's source and a draft preview) is rendered with
-  the shared `renderMd`. It is not a general HTML sanitizer: it escapes the raw source
-  (`&`, `<`, `>`) and then emits only a fixed, closed set of tags (headings,
-  paragraphs, lists, blockquotes, inline emphasis/code, fenced code, and `<a>` links
-  restricted to `http(s)` targets), so no author-supplied HTML, event handler, or
-  `javascript:`/SVG payload reaches the DOM. Practically: LLM- or user-authored
-  markdown cannot inject script into the page.
-- **Composer draft.** The in-progress draft is persisted in `localStorage`
-  (`aimee_proposal_draft`), restored on mount, and cleared on a successful submit and
-  on logout (`App.tsx`). `localStorage` is origin-wide, so a draft persists on the
-  device until one of those clears runs. The cross-account protection is "logout
-  clears it," not per-user isolation. A server-side per-user draft store is a noted
-  non-goal.
-- **Draft-with-a-delegate** shows the result as a **preview**; the body is replaced
-  only on an explicit **Use this draft** (never silently). The action is
-  re-entrancy-guarded and the composer inputs are disabled while a draft or submit is
-  in flight.
-- **Gate.** Approve/Reject appears only when `pause_reason == pending_human`; a 403
-  (caller lacks `CAP_WORKFLOW_ADMIN`) surfaces its message rather than pre-disabling.
-
----
-
-## Slices (all merged to `testing`)
-
-Built slice-by-slice, each design-and-code roundtable-reviewed before merge:
-
-- **Slice 0: backend read surfaces** (PR #954): the timeline/proposal/enriched-item
-  endpoints + owner scoping. Behavioral unit tests in `test_wfe_webapi.c`
-  (ownership allow+deny, pagination cursor, proposal read-back, symlink→403,
-  `/all` enrichment).
-- **Slice 1: Workflow Actions page + Edit Workflows de-scope** (PR #956): the list + status/
-  history detail; removes the Runs/Run-state/gate panels from Edit Workflows.
-- **Slice 2: author-from-scratch composer** (PR #959): the composer + client-side
-  draft; removes the Submit-proposal panel from Edit Workflows. (This PR also repaired
-  pre-existing `testing` breakage from an unrelated merge, a clang-format violation
-  and an `audit_args_hash`/`wfe_sha256_raw` test-link `undefined reference`.)
-- **Slice 3: delegate-assisted drafting** (PR #963): `agent_generate` + `/v1/agent/draft`
-  + the composer's Draft button.
-
-PRs (github.com/RakuenSoftware/aimee): [#954](https://github.com/RakuenSoftware/aimee/pull/954),
-[#956](https://github.com/RakuenSoftware/aimee/pull/956),
-[#959](https://github.com/RakuenSoftware/aimee/pull/959),
-[#963](https://github.com/RakuenSoftware/aimee/pull/963). The design proposal and
-implementation plan are under [`docs/workflow-actions/`](proposals/) (`proposals-ui-page.md`,
-`proposals-ui-page.plan.md`).
-
----
-
-## Configuration & operation
-
-The page is read/UI only; the behavior it drives is governed by existing config:
-
-- **Drafting** needs at least one enabled **non-CLI** (HTTP-provider) delegate in the
-  agent config (see [`DELEGATES.md`](DELEGATES.md)); with only CLI delegates, the draft
-  endpoint returns an error and the button surfaces it.
-- **Autonomous execution** is governed by the wfe engine
-  ([`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). The **live forge is
-  default-on** (`wfe_live_forge_enabled`); set it to `false` to exercise the page
-  without real pushes — a run then advances and parks at gates instead of opening a
-  PR. Even on, the merge-target rail bounds every op (PRs open-only against the
-  trunk; merges only to the unprotected autonomous base).
-- **Submit** is bounded by the intake's existing caps (a 1 MB proposal body cap and the
-  intake-auth per-principal rate/concurrency limits); the user-supplied `repo` is
-  handled by the same `/v1/dev/submit` intake that the CLI uses; its validation and
-  authorization are the intake's concern, unchanged by this feature.
-- **To exercise it end to end** on a running instance: open `/workflow-actions`, **+ New
-  proposal**, optionally **Draft with a delegate**, **Submit**, then watch the timeline
-  advance and (with live forge off) park at the first human gate, where **Approve**
-  resumes it.
-
----
-
-## Known limits / non-goals
-
-- **No per-delegate drill-down inside a stage.** `agent_jobs` / `token_audit` /
-  `execution_trace` do not carry `work_item_id`, so the timeline's granularity is the
-  stage-level `lifecycle_event` (with its `detail`/`cost_usd`).
-- **Cost is cumulative at the item level** (`cum_cost_usd`), not per-delegate.
-- **No server-side draft store** (client-side localStorage only) and **no streaming**
-  of the draft (the final result is returned in one call).
-- **Synchronous drafting holds a worker** for the LLM latency (≤95 s), consistent with
-  the server's other LLM-backed endpoints (chat, delegate).
-- **Verification:** each slice's `e2e-docker` CI (full stack) is green and the backend
-  read paths have behavioral unit tests; a headless browser click-through of the live
-  UI is the remaining manual step.
+See [Workflows](WORKFLOWS.md) and [Autonomous development](AUTONOMOUS_DEVELOPMENT.md).

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -1,180 +1,58 @@
-# Workspace Management
+# Workspaces
 
-A workspace is a set of repositories aimee indexes and works across as one unit. You can register one directly with `aimee workspace add`, or describe it in an `aimee.workspace.yaml` manifest and let `aimee setup` provision it for you.
+A workspace groups one or more repositories under one memory and code-graph scope. It is not a path
+alias and does not grant write authority.
 
-The manifest describes:
+## Add a local workspace
 
-- the repositories that make up the workspace
-- the dependencies each one needs
-- the credentials you have to supply before it will build
+```bash
+cd /path/to/repo
+aimee workspace add .
+aimee workspace list
+aimee index scan .
+```
 
-`aimee setup` reads the manifest, clones what is missing, installs the dependencies, indexes the projects, and writes a starter `.aimee-rules`. Every session then runs in its own per-project git worktree, so two sessions never clobber each other.
+On a thin client, `workspace add` registers a detached workspace and uploads source content. The
+server does not read the client path.
 
 ## Manifest
 
-Put an `aimee.workspace.yaml` file at the root of the directory you run `aimee setup` from.
+`aimee.workspace.yaml` names repositories and workspace metadata. Per-repository build, test, lint,
+and risk rules live in `.aimee/project.yaml`.
 
-```yaml
-# aimee.workspace.yaml
-repos:
-  - url: git@github.com:org/backend.git
-    path: backend            # clone destination, relative to this file; derived from the URL when omitted
-  - url: git@github.com:org/frontend.git
+Keep repository identity stable. Moving a checkout does not need to create a second project if the
+origin and manifest identify the same repository.
 
-dependencies:
-  python:
-    apt: [libpq-dev]
-    pip: [requests, psycopg2-binary]
-  node:
-    npm: []                  # an empty list runs a bare `npm install`
-  rust:
-    cargo: [serde, tokio]
+## Cross-repo graph
 
-secrets:
-  - name: GITHUB_TOKEN
-    description: PAT with repo scope for the private mirrors
+All repositories in a workspace can share symbol, import, dependency, and memory edges. That lets
+caller and blast-radius queries cross from a library into its consumers.
 
-quickstart:
-  index: true                # index the discovered projects (default: true)
-  generate_rules: true       # write .aimee-rules from the detected stacks (default: true)
-```
+Exclude vendored trees, generated output, caches, and secrets before ingest. A shared workspace scope
+should contain only knowledge appropriate for every member.
 
-Every section is optional. A manifest with only a `repos:` block is enough to clone and index a multi-repo workspace.
+## Writes and worktrees
 
-### `repos`
+Sessions and delegates do not write directly into a shared base checkout when isolation is required.
+The server or workflow plane creates a managed worktree and branch on first write.
 
-The repositories to clone. Each entry needs a `url`; `path` is an optional clone destination resolved against the manifest's directory. When `path` is absent, the destination is derived from the URL (the trailing path component, with any `.git` suffix stripped). A repository that already exists on disk is left untouched.
-
-### `dependencies`
-
-Install commands, grouped by language for readability. The grouping key (`python`, `node`, `rust`, ...) is for your eyes only; aimee reads the package-manager keys underneath it and builds one command per manager:
-
-| Key | Command |
-|-----|---------|
-| `apt` / `apt-get` | `apt-get install -y <packages>` |
-| `pip` / `pip3` | `pip install <packages>` |
-| `npm` | `npm install <packages>` (an empty list, or the bare entry `install`, runs `npm install` on its own) |
-| `cargo` | `cargo add <packages>` |
-| `brew` | `brew install <packages>` |
-| anything else | `<manager> install <packages>` |
-
-`aimee setup` runs these in order. A non-zero exit is reported as a warning rather than aborting the rest of provisioning.
-
-### `secrets`
-
-Credentials the workspace needs but that aimee will not create for you: API tokens, deploy keys, and the like. Each entry has a `name` and an optional `description`. `aimee setup` prints them as a checklist so you know what to put in place before the build will work. It does not store or fetch them.
-
-### `quickstart`
-
-Two booleans, both on by default:
-
-- `index`: index the discovered projects into the code index.
-- `generate_rules`: detect the project's stacks and write a starter `.aimee-rules`.
-
-## Commands
-
-Two commands manage workspaces day to day.
-
-### `aimee setup` (alias `aimee quickstart`)
-
-Run it from a directory that contains an `aimee.workspace.yaml`. It:
-
-1. Initializes DB1 and config if they are missing.
-2. Clones the repos declared in the manifest, skipping any that already exist.
-3. Prints the required credentials so you can supply them.
-4. Runs the dependency install commands.
-5. Registers the current directory as a workspace if none is configured yet.
-6. Discovers and indexes the projects under every registered workspace.
-7. Writes `.aimee-rules` from the detected stacks, unless `generate_rules: false`.
-
-With no manifest present it still works as a one-shot bootstrap: it registers the current directory, indexes whatever projects it finds, and generates rules.
-
-### `aimee workspace`
-
-Manage the registered workspace roots directly, without a manifest:
+Remote workspace control needs a full user grant. Index and document uploads need data. Workspace
+registration can succeed with the read bearer, but its automatic ingest exits non-zero until the
+user has data authority.
 
 ```bash
-aimee workspace add <path>                         # register an existing directory and index its projects
-aimee workspace add --repo <url> [--path <dest>]   # clone a repo, then register and index it
-aimee workspace list                               # list workspace roots and the projects under each
-aimee workspace remove <path>                      # unregister a root (the checkout on disk is left alone)
+aimee worktree gc --dry-run
+aimee worktree gc --days 14
 ```
 
-Registered roots live in `aimee.yaml` under `workspaces:`. Removing one only drops it from that list; it never deletes your checkout.
+Garbage collection skips active ownership. Use `--force` only after verifying the target is
+abandoned.
 
-#### Thin client (remote server)
+## Remove
 
-When the `aimee` CLI targets a **remote** `aimee-server`, the workspace root is on
-*your* machine, which the server cannot read. `aimee workspace add <path>` then
-resolves the path locally, registers it as a `detached` workspace, and **pushes
-the source files to the server** (`POST /v1/index/ingest`, chunked) to populate
-the code index; `aimee index scan [path]` re-pushes. The server never reads the
-client filesystem. See [THIN_CLIENT.md](THIN_CLIENT.md).
-
-## Session Isolation
-
-Each session gets its own git worktree for every project in the workspace, its own state file, and its own branch. Two concurrent sessions do not clobber each other.
-
-This isolation applies to all session activity, including:
-
-- file edits made by the primary agent
-- delegate agent executions performed with `--tools`
-- git operations carried out during the session
-
-### Isolation model
-
-```mermaid
-flowchart TD
-    U[User shell in workspace] --> A[Aimee session launcher]
-    A --> S[Session context\nstate file + branch mapping]
-    S --> W1[Project worktree: backend\nsession-specific path]
-    S --> W2[Project worktree: frontend\nsession-specific path]
-    S --> WN[Project worktree: additional projects]
-    W1 --> P[Primary agent CLI]
-    W2 --> P
-    WN --> P
-    P --> D[Delegate agents]
+```bash
+aimee workspace remove /path/to/repo
 ```
 
-### What happens when a session starts
-
-When a session starts, aimee:
-
-1. Creates a per-session worktree for each workspace project.
-2. Maps the user's current directory to the matching worktree path for that session.
-3. Launches the primary agent CLI with hooks active inside the worktree.
-
-Read-only delegates invoked during the session use the parent session worktree directly, so review, validate, diagnose, explain, and summarize tasks see the exact checkout the primary agent is working in. Write-capable delegates get isolated sibling delegate worktrees rooted from that parent checkout, and their accepted changes are applied back to the parent worktree.
-
-## Worktree Lifecycle
-
-A workspace session uses git worktrees as disposable, isolated working copies for each project.
-
-### Creation
-
-At session start, aimee creates one worktree per project in the workspace. Each worktree is specific to the current session and is paired with session-local state and branch information.
-
-This means different sessions can operate on the same repository at the same time without colliding in the same checkout.
-
-### Usage
-
-During the session, all repository operations are redirected into the session's worktree:
-
-- the primary agent edits files in the worktree
-- read-only delegate agents inherit and use the same parent worktree paths
-- write-capable delegate agents use isolated sibling delegate worktrees
-- hooks and git commands run against the worktree, not the shared base clone
-
-aimee also maps the directory the user started from into the corresponding project worktree so commands continue to behave as expected from the user's perspective.
-
-### Cleanup
-
-When the session ends, the per-session worktrees can be removed without affecting the underlying repository clones.
-
-Because each session has its own isolated copy, cleanup is straightforward: session-specific worktrees, branches, and state can be discarded independently of any other active session.
-
-## Delegate Agents Across Workspaces
-
-Delegate agents are configured globally, not per workspace. A single `agents.json` file defines all available delegate agents, and any workspace can use them.
-
-Memory and rules are also shared across workspaces, with workspace-scoped recall for project-specific facts. That means delegates can use the broader knowledge base regardless of which workspace they are invoked from, while still preserving workspace-specific context where appropriate.
+Removal unregisters the workspace. It does not silently delete source, git repositories, or durable
+KB knowledge. Use explicit retention and purge operations for data deletion.

--- a/docs/anchored-editing.md
+++ b/docs/anchored-editing.md
@@ -1,196 +1,56 @@
-# Anchored (hashline) editing
+# Anchored editing
 
-## Overview
+Anchored editing addresses a span by content-derived line anchors instead of trusting line numbers
+from an earlier read. It makes a stale edit fail before it changes the wrong text.
 
-aimee's file editing historically relied on a `str_replace` model: the caller
-supplies an exact `old_string` and a `new_string`, and the server swaps the
-first (or every) occurrence. That design forces the model to re-emit content it
-already read—whitespace, surrounding context, and all—with no stable identifier
-for the lines it wants to change. The resulting failure modes ("old_string not
-found", "occurs N times", stale-file wrong-apply) are structural and hit cheap
-local/open-weight delegates hardest.
+## Read
 
-Hashline editing replaces this with **anchored, transactional edits**. Every
-line read from a file is stamped with a deterministic composite anchor
-(`LINE:HASH`). Edits reference those anchors instead of re-emitting text. The
-server verifies freshness, owns all offset arithmetic, and applies batches
-atomically. The result is fewer tokens, stronger safety guarantees, and
-deterministic success on collision and drift scenarios where `str_replace`
-silently mis-applies.
+An anchored read returns each line with a short hash tied to its current content. The caller keeps
+the anchors around the intended edit.
 
-## Anchored reads
+## Edit
 
-`read_file` returns each line prefixed with a composite anchor:
+An edit names the expected anchor range and replacement. The server:
 
-```
-LINE:HASH| <line content>
-```
+1. resolves the file inside the assigned workspace;
+2. rereads current bytes;
+3. verifies the anchors and adjacency;
+4. applies the replacement atomically;
+5. returns new anchors or a conflict.
 
-- **HASH** is a 2-hex display tag derived from a full FNV-1a-64 digest over the
-  line's canonical bytes (trailing CR/LF and a line-1 UTF-8 BOM excluded).
-- Each anchored read mints an immutable **snapshot** (`snapshot_id`) that
-  records every line's full digest plus the file's dominant line-ending, BOM,
-  and trailing-newline shape. Snapshots are TTL/LRU evicted. Concurrent reads
-  mint independent snapshots—no clobber.
-- `raw: true` returns un-anchored bytes (for grep pipelines, binary sniffing).
-- `mode: "outline"` returns a tree-sitter symbol skeleton (signatures +
-  anchors, no bodies)—one cheap call to map a large file.
+If another writer changed the span, the edit fails. The caller rereads and decides again. It must not
+search for a vaguely similar block and write there.
 
-**Example anchored read output:**
+## Properties
 
-```
-1:a3| import os
-2:7b|
-3:c4| def main():
-4:0a|     print("hello")
-```
+- line insertions elsewhere do not invalidate the target;
+- edits to the target do invalidate it;
+- duplicate text needs surrounding anchors to disambiguate;
+- newline style and final newline are preserved;
+- the path and write authority are checked before content matching;
+- an empty or over-broad match is refused.
 
-## Anchored edits
-
-`edit_file` supports a primary anchored path: pass the `snapshot_id` from a
-prior read plus an `edits[]` batch. Each edit specifies:
-
-| Field        | Description                                                   |
-|--------------|---------------------------------------------------------------|
-| `op`         | One of `replace`, `replace_range`, `insert_after`, `delete_range` |
-| `at`         | A `LINE:HASH` anchor (for single-line ops)                    |
-| `from` / `to`| `LINE:HASH` anchors delimiting a range (for range ops)       |
-| `text`       | The replacement or insertion content                          |
-
-**Example call shape:**
-
-```json
-{
-  "path": "src/main.py",
-  "snapshot_id": "snap_abc123",
-  "edits": [
-    { "op": "replace", "at": "4:0a", "text": "    print(\"world\")" }
-  ]
-}
-```
-
-### Key properties
-
-- **Ordinal as primary key.** The line ordinal disambiguates identical lines;
-  the full digest verifies freshness. Each op is verified against the
-  snapshot's recorded digest before any write.
-- **All-or-nothing.** The batch is applied atomically—no edit renumbers
-  another; the server owns all offset arithmetic.
-- **Drift handling.** If the file changed since the snapshot was taken, the
-  call returns a structured `stale_anchor` payload with re-anchored context
-  and a fresh `snapshot_id`. The model retries without a blind re-read.
-- **Dry run.** `dry_run: true` previews the unified diff and structural blast
-  radius without writing.
-- **Byte preservation.** Unchanged lines are written back verbatim. Only edited
-  regions are normalized to the file's dominant terminator. A no-final-newline
-  file keeps that property.
-- **Display-tag stripping.** If a model echoes the `LINE:HASH| ` display prefix
-  into `text`, the server strips it—the tag is display-only.
-- **Steering advisory (additive, optional).** On a successful commit, the
-  response may include an extra optional string field `advisory` when an op
-  rewrote a large span (see Migration). It never changes the edit outcome and is
-  absent for ordinary edits; consumers should treat it as an optional field.
+Anchors are conflict detectors, not signatures or authorization.
 
 ## Adjacent tools
 
-The same philosophy of stable references and server-side resolution extends to
-several related tools:
+Exact symbol reads can return anchored spans. Search and code-graph results locate candidates; an
+anchored read fixes the exact revision before write. Blast-radius checks remain separate.
 
-| Tool                   | Purpose                                                                                      |
-|------------------------|----------------------------------------------------------------------------------------------|
-| `read_symbol`          | Fetch just a symbol's definition span, anchored.                                             |
-| `edit_symbol`          | Rewrite a whole function or type by name. The server resolves the span and swaps it; overloaded or shadowed names return candidates (never a blind resolve). |
-| `grep` (`anchored: true`) | Search hits become ready edit anchors, grouped under a per-file `snapshot=...` header.    |
-| `run_tests`            | Returns structured `{passed, exit_code, output}` with framework summary and failures kept; the full log is spillable via `tool_output_get`. |
+Lean web search applies the same economy to network evidence: fetch the bounded text needed for a
+claim, preserve the URL and retrieval metadata, and avoid copying a whole page into model context.
 
-## Lean websearch
+Network fetches enforce scheme, DNS/IP, redirect, body, time, and content-type policy to prevent
+SSRF and unbounded downloads.
 
-The websearch tools are designed to keep page fetches server-side and return
-only query-relevant spans:
+## Migration
 
-- **`web_search`** registers `r1..rN` handles for its results.
-- **`web_read(ref, query, span, mode)`** fetches a page once server-side and
-  returns only query-relevant spans, cited by id and fenced as untrusted. A
-  **mandatory literal leg** guarantees exact needles (API names, error strings,
-  versions) appear in the result above a lexical term-overlap leg.
-  `span=N` or `mode: "full"` recover dropped spans.
+Legacy line-number edits remain compatibility inputs only where the route says so. New agent and
+tool contracts should use anchored spans. A provider does not need to know the hash algorithm; it
+only needs to return the anchors it was given.
 
-### SSRF-safe egress
+## Verify
 
-All fetches are http/https only. The host is resolved once, the resolved IP is
-validated against a private/reserved/link-local/metadata deny-list (IPv4 +
-IPv6), and the connection is **pinned** to that IP (no re-resolution) to defeat
-DNS rebinding. Redirects are not followed—they are returned to the caller.
-
-> **Note:** The neural-embedder "semantic" ranking leg is deferred. The shipped
-> path uses the mandatory literal leg + a lexical term-overlap leg.
-
-## Migration & compatibility
-
-The legacy `old_string` / `new_string` / `replace_all` path on `edit_file` is
-**retained as a deprecated fallback**. It has not been removed. Agents that have
-not adopted anchored edits continue to work, but will not benefit from collision
-safety, drift recovery, or token savings. Every use is logged (`edit_deprecated`)
-so removal can be driven by measured usage.
-
-**Recommended migration path:**
-
-1. Switch `read_file` calls to default (anchored) mode. Use `raw: true` only
-   when you need un-anchored bytes.
-2. Replace `old_string`/`new_string` edits with `snapshot_id` + `edits[]`
-   batches referencing `LINE:HASH` anchors.
-3. For whole-function or whole-type rewrites, prefer `edit_symbol` over
-   hand-built `replace_range`—the server resolves the span, avoiding the
-   multi-line anchor fumble observed with smaller models. As a guardrail, an
-   anchored `replace_range`/`delete_range` covering **≥ 8 lines** returns an
-   `advisory` recommending `edit_symbol`.
-
-**When does `old_string` get removed?** Not on a calendar. It is removed only
-when a numeric gate is met — the weakest delegate's whole-function pass@k
-recovers to within 10 pp of `str_replace` (via `edit_symbol`), the agentic gate
-stays green across ≥ 3 runs, `edit_deprecated` telemetry shows negligible
-residual usage, and the request-shape change is documented as a deliberate
-breaking change. See `benchmarks/hashline/RESULTS.md` for the full criteria.
-
-## Evaluation & status
-
-### Gating harnesses
-
-Two harnesses gate the transition before `old_string` is removed:
-
-1. **`unit-test-hashline-gate`** — a deterministic CI test proving
-   model-independent properties: hashline applies every fixture, stays safe
-   under collision and drift where `str_replace` silently mis-applies, and
-   reproduces zero already-read bytes.
-2. **`tools/hashline_agentic_eval.py`** — a multi-turn agentic eval over a
-   realistic mutation corpus generated from real repo files
-   (`tools/hashline_corpus_gen.py`): collision-at-scale, deep-indent,
-   whole-function rewrites, and drift. It renders the real anchored format and
-   feeds real tool errors back so retries are measured.
-
-### Live results
-
-Three delegates (mimo-v2.5-pro, MiniMax-M3, codex) × 3 runs on 19 tasks. Gate
-criterion: `pass@k ≥ str_replace` AND net token-negative.
-
-- **Gate passes on all three.** Collision is the decisive, consistent win:
-  `str_replace` 33–40% pass@k vs hashline 100%, at ~5–15× fewer tokens.
-  Token savings are large and consistent even where `str_replace` also succeeds
-  (codex: 62 vs 313 tokens at identical 100% pass@k).
-- **Caveat:** On MiniMax-M3, whole-function rewrites regressed (pass@k 87% →
-  53%)—the smaller model fumbles multi-line anchored ranges. This is why
-  `edit_symbol` (server-resolved span) is the recommended path for whole-symbol
-  edits, and why `old_string` removal (P5) waits.
-
-### Merge status
-
-Merged to the `testing` branch across:
-
-| PR   | Content                          |
-|------|----------------------------------|
-| #1396| Edit core + websearch            |
-| #1400| Deterministic gate               |
-| #1405| Format hardening + fair harness  |
-| #1410| Realistic corpus                 |
-
-`old_string` is retained pending whole-function handling via `edit_symbol`.
+Test concurrent insertion, target mutation, duplicate blocks, CRLF/LF, Unicode, symlink escape,
+partial writes, and file replacement between read and commit. Measure incorrect-edit rate, not only
+tool success rate.

--- a/docs/embedder-sweep.md
+++ b/docs/embedder-sweep.md
@@ -1,98 +1,56 @@
-# Embedder Sweep and Selection
+# Embedder sweep
 
-## Overview
+The sweep compares embedding models on LoCoMo and LongMemEval direct-retrieval tests. Candidates
+read text on stdin and write a JSON float array on stdout, so the harness is hardware- and
+provider-neutral.
 
-The embedder sweep compares multiple embedding models on the LoCoMo and
-LongMemEval direct-retrieval benchmarks and produces a comparative summary.
-The sweep is hardware-neutral: any model that can be wrapped as a command
-accepting text on stdin and returning a JSON float array on stdout is
-supported.
+## Run it
 
-## Running a Sweep
-
-1. Copy the candidate list template and fill in your commands:
-
-   ```bash
-   cp benchmarks/embedder-candidates.txt.example benchmarks/embedder-candidates.txt
-   # Edit benchmarks/embedder-candidates.txt
-   ```
-
-2. Run the sweep:
-
-   ```bash
-   ./benchmarks/embedder-sweep.sh
-   # or with a subset for a quick sanity check:
-   ./benchmarks/embedder-sweep.sh --max-samples 50 --max-cases 50
-   ```
-
-3. Results land in `benchmarks/results/embedder-sweep/` and a summary is
-   printed to stdout and saved as `summary_<timestamp>.txt`.
-
-## Candidate List Format
-
-File: `benchmarks/embedder-candidates.txt` (gitignored by default)
-
+```bash
+cp benchmarks/embedder-candidates.txt.example benchmarks/embedder-candidates.txt
+# edit the commands
+./benchmarks/embedder-sweep.sh
 ```
-# name   command (reads stdin, writes JSON float array to stdout)
+
+For a short smoke run:
+
+```bash
+./benchmarks/embedder-sweep.sh --max-samples 50 --max-cases 50
+```
+
+Candidate file:
+
+```text
 baseline  python3 scripts/embed.py --model all-MiniLM-L6-v2
 mpnet     python3 scripts/embed.py --model all-mpnet-base-v2
 bge_small python3 scripts/embed.py --model BAAI/bge-small-en-v1.5
-bge_large python3 scripts/embed.py --model BAAI/bge-large-en-v1.5
 ```
 
-The `<name>` becomes part of the result filename so keep it short and
-filesystem-safe.
+Keep names short and filesystem-safe. Results land in
+`benchmarks/results/embedder-sweep/`; the command also prints and saves a timestamped summary.
 
-## Methodology
+## What it measures
 
-For each candidate the sweep:
+For each candidate the harness:
 
-1. Sets `AIMEE_EMBEDDING_COMMAND` to the candidate command.
-2. Runs `bench_aimee_direct.py` on LoCoMo and LongMemEval.
-3. Calls `verify_scores.py` and appends the summary to the run log.
+1. sets `AIMEE_EMBEDDING_COMMAND`;
+2. runs the LoCoMo and LongMemEval direct-retrieval adapters;
+3. validates each result with `benchmarks/verify_scores.py`.
 
-The direct benchmark uses the aimee retrieval pipeline with embeddings
-enabled; it does not route through an LLM for answer generation, so results
-reflect retrieval quality (Recall\@K, MRR) and latency rather than
-end-to-end answer accuracy.
+No answer-generation model runs. The result covers retrieval quality and latency: Recall@K, MRR,
+ingest time, and query time.
 
-## Selecting a Winner
+## Selection bar
 
-A candidate wins the sweep if:
+Change the default only when a candidate:
 
-- It shows **material aggregate lift** (≥ 1pp Recall\@5 or MRR) over the
-  current baseline on both LoCoMo and LongMemEval.
-- Ingest and query latency remain within budget (see `docs/BENCHMARKS.md`).
-- The embedding dimension is compatible with the current versioned pgvector
-  layout. If the dimension changes, an online re-embed and a versioned pgvector
-  index cutover are required: rebuild into a new index version, then switch reads
-  over atomically once the backfill completes.
+- improves Recall@5 or MRR by at least one percentage point on both corpora;
+- stays inside the latency budget in [Benchmarks](BENCHMARKS.md);
+- has an acceptable license and deployment footprint;
+- fits the current pgvector layout, or ships with a versioned re-embed and atomic index cutover.
 
-If no candidate meets the bar, keep the current baseline and document why in
-`benchmarks/results/embedder-sweep/`.
+If the vector dimension changes, build a new index version, backfill it, then switch reads. Keep the
+old index until the new one passes. If no candidate clears the bar, keep the baseline and record why.
 
-## Hardware Notes
-
-Sweep results are sensitive to hardware (CPU/GPU, memory bandwidth, model
-quantisation). Always record the hardware and date alongside result artefacts.
-Results from different hardware are not directly comparable.
-
-## Committed Results
-
-Sweep result artefacts are stored under `benchmarks/results/embedder-sweep/`
-and committed when a winner is selected or when a baseline regression is
-detected. Intermediate exploration results need not be committed.
-
-## Candidate Addition Checklist
-
-When adding a new candidate:
-
-- [ ] Confirm the command emits a JSON float array of the correct dimension.
-- [ ] Rebuild embeddings through the server/kb maintenance path after switching the
-      command, then cut over the versioned pgvector index when the backfill is complete.
-      If the new version regresses, roll back by switching reads to the prior
-      pgvector index version (the previous embeddings stay intact until the cutover
-      is finalized).
-- [ ] Record the model name, dimension, and licence in the sweep summary.
-- [ ] If the model requires a GPU, note minimum VRAM in the candidate list
-      comment.
+Record the date, hardware, model, dimension, quantization, license, and command with committed
+results. Runs from different hardware are not directly comparable.

--- a/docs/features/economizer.md
+++ b/docs/features/economizer.md
@@ -1,274 +1,64 @@
-# The aimee Economizer
+# Economizer
 
-The economizer controls whether aimee changes provider-bound context to reduce its size. Its first
-rule is that declining to economize is better than making a request more expensive. The public
-surface is deliberately small:
+The economizer reduces provider context and cost after the request has become canonical IR. It must
+preserve tool semantics, recoverability, and provider cache behavior.
 
-```yaml
-economizer:
-  mode: safe             # off | safe | aggressive (default: safe)
-```
+## Tiers
 
-```sh
-aimee config set economizer.mode safe
-aimee config get economizer.mode
-```
-
-The same setting is available on the web **Settings** page and through the authenticated
-`POST /v1/config/set` operation. Changes are hot and apply to the next request or agent turn.
-
-## Mode summary
-
-| Mode | Fresh local tool result | Existing history | Native Anthropic history | Lossy |
-| --- | --- | --- | --- | --- |
-| `off` | Unchanged by the economizer | Unchanged | Unchanged | No |
-| `safe` (default) | Strict JSON whitespace may be removed before first dispatch | Unchanged | Unchanged | No |
-| `aggressive` | Includes `safe` | Eligible tool-result bodies and older context may be reduced on supported OpenAI-family paths | Unchanged | **Yes** |
-
-`safe` is the normal choice. Select `off` when the economizer must do absolutely no work on the
-request. Select `aggressive` only when lower context size is more important than preserving every
-detail and the effect on provider cache reuse is acceptable.
-
-## What `safe` guarantees
-
-Safe has one live transform: deterministic whitespace compaction of a newly produced local tool
-result when that result is one complete, strict JSON value.
-
-It runs immediately after local tool execution and before the result is added to the conversation.
-The provider therefore never received the whitespace-heavy version. There is no previously cached
-provider prefix containing those original bytes to invalidate.
-
-The compactor:
-
-- removes only RFC 8259 whitespace outside JSON strings;
-- retains every other input byte in its original order;
-- never changes whitespace or escapes inside strings;
-- accepts arrays, objects, strings, numbers, booleans, and `null`;
-- requires valid UTF-8, valid JSON syntax, and unique decoded object keys;
-- accepts at most 16 MiB, 64 levels of nesting, and 65,536 members in one object;
-- emits a result only when it is shorter than the input; and
-- returns the original result unchanged on every rejection or internal failure.
-
-This is JSON-semantic preservation, not byte preservation: insignificant whitespace is the only
-textual difference. Safe does not promise that a provider tokenizer will report fewer tokens for
-every compacted result, or that the bill for an individual request will decrease. It avoids the
-more dangerous operation: rewriting content that has already participated in a cache prefix.
-
-Safe does **not** summarize, truncate, fold history, condense command output, call another model,
-rehydrate content, call a token-counting endpoint, infer a cache breakpoint, or alter
-provider/client cache controls.
-
-Non-JSON text, malformed JSON, duplicate keys, invalid Unicode, oversized/deep input, and JSON
-that cannot be made shorter pass through unchanged. Duplicate keys are rejected because parsers can
-disagree about which value wins; silently normalizing them would not be a safe transform.
-
-### Safe example
-
-This fresh tool result:
-
-```json
-{
-  "status": "ok",
-  "items": [1, 2, 3],
-  "message": "spaces inside this string stay"
-}
-```
-
-is presented on first dispatch as:
-
-```json
-{"status":"ok","items":[1,2,3],"message":"spaces inside this string stay"}
-```
-
-If the same text were already part of conversation history, safe would leave it alone.
-
-## What `aggressive` does
-
-Aggressive includes safe compaction and opts into aimee's existing lossy context reducer on
-supported OpenAI-family routes. Depending on the request path and conversation shape, it may:
-
-- shorten older tool-result bodies while retaining configured head and tail excerpts; and
-- fold eligible older history while retaining a recent-message tail.
-
-The reducer works on a copied view. A failed allocation, unsupported structure, parsing failure, or
-internal error bypasses the transform. The gateway applies a candidate only when its local token
-estimate is strictly smaller and a structural check finds no orphaned tool-call/tool-result pairs.
-Requests without a resolvable session identity bypass gateway mutation. These checks reduce risk;
-they do not make aggressive lossless or prove provider-side savings.
-
-The exact effect depends on the seam:
-
-| Request path | Aggressive behavior |
+| Tier | Behavior |
 | --- | --- |
-| aimee agent loop to an OpenAI-compatible Chat Completions endpoint | Tool-result compression and eligible older-history folding |
-| aimee agent loop to an OpenAI Responses/ChatGPT endpoint | Tool-result compression; history folding is not applied on that path |
-| OpenAI-family gateway egress | Compress-only candidate; applies only after shrink and structure gates |
-| Native Anthropic/Claude egress | No history or gateway-body reduction |
+| `off` | no reduction or cache mutation |
+| `safe` | lossless folding, stable cache boundaries, command-aware condensation with spills |
+| `aggressive` | safe tier plus configured lossy compression/mutation on supported provider families |
 
-Aggressive can omit details the model later needs. It can also replace a prefix the provider would
-otherwise have read from cache. Use it for workloads where lossy reduction is an explicit tradeoff,
-not as a guaranteed cost-saving switch.
+`modules.economizer: false` is the hard off switch.
 
-The older command-aware spill-and-recall helper is not called by production request paths. See
-[Tool-output condensation](tool-output-condensation.md) for its retired status; aggressive uses the
-general context reducer instead.
+## Order
 
-## Provider cache and pricing realities
-
-Both OpenAI and Anthropic reward stable prefixes. A smaller serialized request is not automatically
-a cheaper request: changing an already cached prefix can turn discounted cache reads into cache
-writes or uncached input.
-
-### OpenAI and GPT-5.6
-
-OpenAI documents implicit and explicit prompt caching for GPT-5.6. Explicit cache breakpoints are a
-client/provider contract; aimee does not discover or move them. As documented in July 2026, OpenAI
-explicitly bills GPT-5.6 cache writes at 1.25 times the uncached input rate, while cached input is
-discounted. The same documentation tells clients to track `cached_tokens` and
-`cache_write_tokens`. Requests above 272,000 input tokens use long-context pricing for the whole
-request: twice the standard input price and 1.5 times the standard output price. These are OpenAI's
-GPT-5.6 terms, not an Anthropic pricing attribution. See OpenAI's current
-[GPT-5.6 model page](https://developers.openai.com/api/docs/models/gpt-5.6-sol) and
-[latest-model guide](https://developers.openai.com/api/docs/guides/latest-model) before making a
-pricing decision; provider terms can change.
-
-Avoiding the 272K boundary can be valuable in principle, but aimee does not claim that it has done
-so. The API does not provide a mandatory, exact pre-dispatch token count or future cache outcome.
-Provider usage fields arrive after dispatch and are accounting evidence, not permission to rewrite a
-request beforehand.
-
-### Anthropic and Claude
-
-Anthropic caching also depends on matching prefixes and cache-breakpoint placement. Its documented
-hierarchy considers tools, system content, and messages, so changing tool definitions or earlier
-content can invalidate later cached content. Anthropic offers automatic caching and explicit
-`cache_control`; aimee preserves the caller's placement and native Anthropic history in every mode.
-See Anthropic's current
-[prompt-caching guide](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) and
-[tool-use caching guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching).
-
-As documented in July 2026, Anthropic's default ephemeral cache lasts five minutes and is refreshed
-without another write charge when it is read. A one-hour TTL is also available. Anthropic lists the
-general prompt-cache multipliers as 1.25 times base input for a five-minute write, 2 times for a
-one-hour write, and 0.1 times for a cache read; actual per-token prices are model-specific and other
-pricing modifiers can stack. Responses distinguish `cache_read_input_tokens` from
-`cache_creation_input_tokens`, with five-minute and one-hour creation detail. Check the current
-model table in the prompt-caching guide rather than embedding a particular Claude model's dollar
-rate in policy.
-
-Anthropic's token-counting endpoint is free but documented as an estimate that can differ from
-actual input usage. The economizer does not add a counting preflight. See
-[Token counting](https://platform.claude.com/docs/en/build-with-claude/token-counting).
-
-## Request and retry behavior
-
-When `safe` or `aggressive` is active, aimee freezes each selected provider request body into an
-immutable, exact-length in-memory snapshot before sending it. Ordinary HTTP retries for that request
-reuse the same bytes. This prevents retry serialization drift; it does not add or change provider
-cache directives.
-
-If the snapshot cannot be created, aimee does not send an unfenced request under an enabled mode.
-The request fails locally. `off` does not allocate the economizer snapshot.
-
-Model fallback is a new request constructed for the fallback model and receives its own snapshot.
-The normal agent-loop context-overflow recovery is independent of the economizer and may remove old
-messages before a new attempt. The economizer itself performs no restore-and-resend cycle and never
-rehydrates reduced material.
-
-## Configuration surfaces
-
-### YAML
-
-```yaml
-economizer:
-  mode: safe
+```text
+provider ingress -> canonical IR -> invariant/policy checks
+                 -> folding and tool condensation
+                 -> provider cache alignment
+                 -> provider translation
 ```
 
-Only `off`, `safe`, and `aggressive` are accepted, case-insensitively. An omitted setting defaults
-to `safe`. Unknown values, malformed sections, and legacy `economizer.enabled` or
-`economizer.aggressive` fields fail configuration loading rather than silently selecting a mode.
+Provider-specific JSON is not the economizer's working format. Anthropic, OpenAI Responses, Chat
+Completions, Gemini, Mistral, and Bedrock share the canonical stages; translation handles wire
+differences at the edge.
 
-An administrator can enforce a separate module-level hard kill:
+## Safe tier
 
-```yaml
-modules:
-  economizer: false
+- Stable old context can be folded into a recoverable summary/reference.
+- Recognized command output keeps failures and diagnostics while dropping repeated progress/noise.
+- Full tool output is written to a bounded spill with a recovery pointer.
+- Cache breakpoints are placed where provider semantics permit them.
+- A disabled or failed reducer returns the original IR.
+
+Lossless means the system can recover the omitted bytes, not that every provider receives them in
+the first request.
+
+## Aggressive tier
+
+Lossy operations need an explicit provider and content contract. They must not alter tool-call IDs,
+arguments, result pairing, system/developer authority, current user intent, or required evidence.
+
+Unsupported provider families stay on the safe path. A global tier does not justify mutating a wire
+format that has no tested adapter.
+
+## Accounting
+
+Telemetry records input bytes/tokens before and after each stage, spill bytes, cache decisions,
+avoided cost, recovery, and fallback. Do not count a reduction twice when folding and provider cache
+alignment touch the same prefix.
+
+```bash
+aimee economizer stats
 ```
 
-That switch forces the effective mode to `off`, regardless of `economizer.mode`.
+## Verify
 
-### CLI
+Test byte-identical off mode, tool-call/result pairing, retry, streaming, Unicode, large outputs,
+spill recovery, cache boundaries, provider round trips, and failures in each stage. Quality gates
+must compare task outcomes, not only token counts.
 
-```sh
-aimee config set economizer.mode off
-aimee config set economizer.mode safe
-aimee config set economizer.mode aggressive
-aimee config get economizer.mode
-aimee config show
-```
-
-### HTTP API
-
-The authenticated local/control-plane configuration operation accepts the same scalar value:
-
-```http
-POST /v1/config/set
-Content-Type: application/json
-
-{"key":"economizer.mode","value":"safe"}
-```
-
-Read it with `POST /v1/config/get` and `{"key":"economizer.mode"}`. Normal aimee transport
-authentication and remote-write policy still apply; do not expose the management API merely to set
-this option.
-
-### Web Settings
-
-Open **Settings**, search for `economizer.mode`, select the mode, and save. The field is generated
-from the same typed configuration schema used by the CLI and API.
-
-## Choosing a mode
-
-- Use `safe` for the default operational posture. It changes only fresh strict JSON before first
-  provider exposure and fails open to the original tool result.
-- Use `off` for comparison testing, exact economizer pass-through, or a policy that prohibits even
-  JSON whitespace normalization.
-- Use `aggressive` only with explicit acceptance of lost detail and possible cache churn. Evaluate
-  it against the actual provider, route, conversation distribution, and cache metrics.
-
-For cost experiments, compare provider-reported uncached input, cache-write input, cache-read input,
-output, and billed cost across representative multi-turn sessions. Comparing only serialized bytes
-or total input tokens can incorrectly label a cache-busting transform as a saving. For GPT-5.6,
-OpenAI directs clients to track `cached_tokens` and `cache_write_tokens`; Anthropic reports
-`cache_creation_input_tokens` and `cache_read_input_tokens`. Treat those post-call values as
-measurements, never as a precondition the economizer can know exactly.
-
-## Troubleshooting
-
-**A formatted JSON result did not shrink.** It may not be one complete strict JSON value, may have
-duplicate keys or invalid Unicode, may exceed a safety limit, or may already be compact. Passthrough
-is expected.
-
-**Aggressive did not change a request.** The request may be on native Anthropic, lack a gateway
-session identity, contain no eligible old tool results/history, fail the structure check, or produce
-no estimated reduction. Aggressive is opportunistic.
-
-**Aggressive did not reduce Claude history.** That is intentional. Native Anthropic history and the
-gateway body are excluded from aggressive's lossy reducers to preserve the exact-prefix cache
-contract. Aggressive still includes safe, so a newly produced strict-JSON local tool result may have
-insignificant whitespace removed before its first Claude dispatch.
-
-**The configured value is safe/aggressive but behavior is off.** Check `modules.economizer`. An
-explicit `false` is authoritative.
-
-**Costs rose despite a smaller prompt.** Inspect cache-read and cache-creation/uncached usage, route
-selection, and whether the request crossed a provider pricing tier. Aggressive offers no billing
-guarantee; return to `safe` or `off` when it is not a measured net improvement.
-
-## Validation coverage
-
-The shipped tests cover mode parsing/defaults and the hard kill; strict JSON syntax, Unicode,
-duplicate keys, depth/size behavior, determinism, and no-gain passthrough; OpenAI-versus-Anthropic
-route gates; gateway identity and structural bypasses; immutable wire snapshots; and live-surface
-activation. The implementation remains intentionally independent of undocumented provider cache
-breakpoints or exact preflight token counts.
+See [Tool-output condensation](tool-output-condensation.md).

--- a/docs/features/ir-only-response-parsing.md
+++ b/docs/features/ir-only-response-parsing.md
@@ -1,81 +1,36 @@
-# IR-only response parsing
+# Canonical response parsing
 
-The canonical IR (`aimee_request_t` / `aimee_response_t`, with typed blocks
-`TEXT`, `TOOL_USE`, `THINKING`) is now the **sole response parser on every wire**
-(`anthropic`, `openai-chat`, `responses`/`codex`). The legacy per-wire
-translators — `agent_parse_response_openai`, `agent_parse_response_anthropic`,
-and `agent_parse_response_responses` in `server/agent_bridge.c` — are gone.
+Provider adapters parse wire responses directly into canonical IR. Core routing, retries, tools,
+accounting, economizer stages, and clients do not inspect provider JSON.
 
-This completes the "legacy-translator deletion (Slice 5)" deferred in
-`docs/proposals/done/aimee-canonical-ir.md`. Every existing response path now
-flows through one IR, one parser family, one block taxonomy.
+The canonical response can contain:
 
-## What changed
+- text segments;
+- reasoning segments and signatures where the provider exposes them;
+- tool calls with stable IDs and structured arguments;
+- usage and cache accounting;
+- finish/stop reason;
+- provider error and retry class;
+- streaming deltas that assemble into the same final IR.
 
-The migration shipped as six staged, CI-gated, shadow-validated PRs, each
-removing a piece of the dual-parser world:
+## Rules
 
-1. **JSON wires go IR-only in the delegate runtime.** Removed the legacy
-   fallback and the legacy-vs-IR response shadow comparator for
-   `anthropic` and `openai-chat`; deleted the dead `AIMEE_IR_RESPONSE_PATH`
-   flag. (#1398)
-2. **New IR parser for the `responses` / SSE codex wire**
-   (`agent_ir_parse_responses`): extracts the response object from the SSE
-   stream, parses via `responses_backend_parse`, owns the XML tool-call
-   rescue, and sets `assistant_message` to the output-item array for
-   multi-turn replay. The codex wire becomes IR-primary. (#1399)
-3. **Delegate driver** (`server/delegate_openai.c`) parses via the IR.
-   (#1407)
-4. **Gateway proxy no-driver fallbacks** (`server/anthropic_http.c`) parse
-   via the IR. (#1412)
-5. **Simple completion runtime** (`server/agent_runtime.c` `agent_execute`)
-   parses via the IR. (#1412)
-6. **Legacy parsers and dead helpers deleted.** `strip_thinking_blocks`,
-   `openai_content_to_text`, `parse_capture_model`, and the three
-   `agent_parse_response_*` translators — ~342 lines removed. (#1412)
+- Keep provider aliases and quirks in its translator.
+- Preserve unknown but bounded metadata only when a later contract needs it.
+- Reject malformed tool calls instead of converting them to prose.
+- A body that parses but yields no usable content is a typed empty-response error with a bounded
+  diagnostic of the received shape.
+- Retry preserves the requested tool surface.
+- Serialize public responses from canonical IR, never by forwarding provider bytes.
 
-## Reasoning is stored, not stripped
+## Add a provider
 
-Reasoning models on the openai wire embed chain-of-thought inline in
-content: as a `<think>...</think>` prefix, as `thinking` / `reasoning`
-items in a content-parts array, or in a `reasoning_content` field. The
-legacy parser **stripped and discarded** all of it. The IR openai parser
-now **splits** it:
+1. map canonical request to the provider wire;
+2. parse non-streaming and streaming responses into the same IR;
+3. map tool IDs, arguments, usage, cache, stop, and errors;
+4. add fixtures for text, reasoning, tools, mixed content, empty content, malformed bodies, and rate
+   errors;
+5. round-trip through public OpenAI/Anthropic ingress where applicable;
+6. verify economizer and policy stages remain provider-neutral.
 
-- the chain-of-thought is **stored** as an `AIMEE_BLK_THINKING` block;
-- the answer is stored as a `TEXT` block;
-- the content accessor excludes `THINKING`, so callers continue to see
-  only the answer — but the reasoning is preserved as structured data,
-  available to anything that opts into the IR.
-
-The split also closed real gaps that had shipped unnoticed: malformed
-content-as-array handling (e.g. Mistral-style shapes) and scaffold
-stripping had never been exercised by the shadow because the `.254` test
-box is codex-only, so the legacy-vs-IR comparator never saw those openai
-edge cases. With the IR as the sole parser, those shapes now flow through
-one well-tested path.
-
-## What was kept
-
-Deleting the legacy translators did not mean deleting their neighbors:
-
-- **SSE helper subtree** + `agent_responses_sse_response_object` — kept;
-  shared with the IR `responses` extractor.
-- **`server/delegate_xml_fallback.c`** — kept; the XML dialect parser the
-  IR rescue depends on.
-- **`server/shadow_mirror.c`** — kept; the #1382 shadow-traffic mirror
-  still records traffic.
-
-Only the legacy parse-comparator was removed. The shadow traffic mirror
-remains available for future wire regressions.
-
-## Follow-ups
-
-- **Reasoning → history.** Reasoning now lives in the IR
-  `aimee_response_t`, but the transitional legacy `parsed_response_t`
-  bridge has no `THINKING` field, so the reasoning is dropped at that
-  boundary. Surfacing it end-to-end (persisting thinking to history) is
-  a follow-up.
-- **Read the shadow parity metrics.** `aimee_ir_metric_get` currently
-  has no callers, so the shadow parity metrics are write-only. Wiring
-  a reader is a follow-up.
+Fixtures under `src/tests/fixtures/ir/` are the contract.

--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -1,114 +1,42 @@
-# Tool-output condensation (retired from live requests)
+# Tool-output condensation
 
-> **Current status:** the command-aware spill-and-recall helper remains isolated from production
-> request paths. Neither `off` nor `safe` enables it. `aggressive` uses the general lossy context
-> reducer, not this retired helper. A retrieval pointer is not
-> mechanically equivalent to presenting the original bytes to the model, and page-back cost cannot
-> be bounded before dispatch. Re-enablement requires a separately reviewed transform contract and
-> signed registry entry.
+Tool-output condensation keeps the part of a command result that changes the next decision and
+stores the full result for recovery.
 
-Tool output (test-runner logs, compiler/linter dumps, build progress) is the largest and
-most signal-sparse contributor to a coding agent's context. Most of that volume is not
-signal: progress bars, passing-test transcripts, boilerplate, repeated lines.
+It runs on canonical tool results before the next model request. It never changes the tool's exit
+status, ID, timing, or pairing.
 
-**Tool-output condensation** is a context-economizer lever that condenses **recognized**
-command output at the tool-execution seam, using **deterministic, command-aware rules** (no
-LLM, so it is ~free). It knows that a test runner's value is its *failures*, a compiler's is
-its *diagnostics*, and drops the rest, **losslessly**: the full raw output is spilled to
-disk and a recovery pointer is left in the condensed result, so nothing is destroyed.
+## Recognized output
 
-The remainder of this page describes the retired implementation for historical and test context. It
-is not the current runtime behavior.
+Command-aware filters can remove repeated build progress, passing-test detail, dependency chatter,
+and duplicate lines while preserving:
 
-## Configuration
+- failing tests and their diagnostics;
+- compiler errors and nearby context;
+- command, exit status, signal, and truncation state;
+- warnings required by policy;
+- the tail or summary needed to understand success;
+- a pointer to the full spill.
 
-There is no configuration that activates condensation. The current economizer surface is:
+Unknown output uses a conservative generic bound or passes through. A filter failure returns the
+original bounded result.
 
-```yaml
-economizer:
-  mode: safe             # off | safe | aggressive
-```
+## Spills
 
-Off and safe leave non-JSON tool output pristine; safe may remove insignificant whitespace from a
-strict JSON result before first dispatch. See [SETTINGS.md](../SETTINGS.md) and
-[the economizer overview](economizer.md).
+The full result is stored under the configured aimee home with private permissions, a content hash,
+size, expiry, and job/session owner. Recovery rechecks the principal and scope. A spill path is not a
+public filesystem capability.
 
-## What it does
+## Safety
 
-Applied at the **delegate bash-tool seam** ([`tool_bash`](../../src/posix/agent_tools.c)),
-before the size-based compression:
+- off mode is byte-identical;
+- ANSI/control bytes are sanitized for display without changing the stored raw evidence;
+- secret redaction runs before either model context or operator display;
+- condensation cannot turn a failed command into success;
+- truncation and missing spill are explicit;
+- retention is bounded by age and bytes.
 
-1. **Recognize** the command. Compound/piped/substituted lines and unknown commands pass
-   through unchanged (fail-open). Common wrappers are unwrapped (`env`, `sudo`, `time`,
-   `npx`, `uv run`, `poetry run`, `pnpm exec`, …). `xargs`, `make`, shell scripts, and **any
-   path-prefixed invocation** (`./git`, `/tmp/cargo`) are treated as opaque. A family rule
-   only ever applies to a bare command name.
-2. **Condense** by family:
-   - **Test runners** (`pytest`/`jest`/`vitest`/`ctest`/`cargo|go|npm|… test`): keep the
-     summary + **every failure verbatim**, drop passing-case transcripts.
-   - **Compilers / linters** (`tsc`/`eslint`/`ruff`/`mypy`/`gcc`/`clang`/`rustc`/`cmake`,
-     and `cargo|go|dotnet|npm|… build/check/clippy/vet/lint`): keep every error/warning/note
-     and diagnostic, drop the `Compiling…/Downloading…/Checking…` progress.
-3. **Spill + point.** The full raw output is **atomically** written to
-   `<aimee_home>/tool-spills/<ref>.out` (temp → `fsync` → rename → dir `fsync`, mode `0600`,
-   so a partial write is never promoted) and the condensed result ends with a pointer
-   carrying the opaque `ref`. The agent retrieves the full original with the dedicated
-   **`tool_output_get`** tool (P2): one recovery handle, not a raw filesystem path. The
-   spill store is kept under a 64 MB budget by oldest-first (mtime) eviction.
+## Observe
 
-## Safety contract
-
-- Production request paths do not call this helper in any economizer mode.
-- **Lossless-on-demand.** A condensed body is only ever produced when the full raw output
-  was **durably spilled** first; a failed spill, no spill dir, or a would-be-truncated
-  recovery pointer all fall through to passthrough. Nothing is dropped without a backstop.
-- **Never hide a failure.** A test runner or build with a **non-zero exit and no recognized
-  failure line** passes through verbatim rather than risk eliding the cause.
-- **Fail-open everywhere.** An unrecognized command, an over-ceiling body (> 2 MB), or any
-  filter error degrades to passthrough (or, on the aggressive tier, the size-based body
-  compression), never a crash or a dropped
-  result.
-- **No masquerade.** A path-prefixed command whose basename matches a known tool (`./git`)
-  never inherits that tool's family filter.
-- **Not a redaction layer.** Condensation does not *widen* exposure beyond what the raw
-  tool result already showed the model, but it does not scrub secrets from the output or the
-  spill. Spill files are per-user (`0700` directory) and excluded from log/trace exports by
-  default.
-
-## Observability + recovery cost (P4)
-
-Process-wide counters accumulate realized savings **and recovery cost** on live traffic
-([`tool_condense_stats_snapshot`](../../src/modules/economizer/tool_condense.c)): `recognized`, `applied`,
-`applied_raw` vs `applied_final` bytes, per-family (`test`, `diag`) counts, and the
-**recovery-cost** side: `recovered` (successful `tool_output_get` page-backs) and
-`recovered_bytes` (bytes re-injected). Two derived fields make the promotion-gate metric
-explicit:
-
-- `saved_bytes` = `applied_raw − applied_final` (gross condensation saving);
-- **`net_saved_bytes`** = `saved_bytes − recovered_bytes` (**net of recovery**).
-
-`net_saved_bytes` is the net after recovery: if the agent keeps paging spilled output back in,
-`recovered_bytes` rises toward `saved_bytes` and the net collapses, the signal that the
-lever is not net-saving on that workload. Each condensation logs its `raw→final` delta and
-each recall logs `tool_output_get recovered N bytes` under the `tool_condense` module, so the
-two sides are greppable together. (This precise per-call channel exists because
-`tool_output_get` is the single dedicated recovery handle from P2; `history_fold`/`compress`
-recovery via fold-recall remains best-effort, not byte-exact.)
-
-## Historical scope
-
-It previously shipped as the **delegate surface**, **default-ON** (the safe-tier lever): when on, the
-delegate bash seam captures the full output (up to a 2 MB ceiling) so the lever sees all of
-it, condenses recognized families losslessly, and spills the raw for recovery. Set
-the live caller has since been removed.
-
-The **default-ON** flip landed in unified-economizer **P1c**, justified by the deterministic
-gate (lossless-on-demand + fail-open + a no-over-reduction audit); it replaces the old lossy
-32 KB read-cap truncation with lossless-recoverable condensation.
-
-The dedicated **`tool_output_get`** retrieval tool + the atomic-write / bounded-eviction
-recovery contract landed in unified-economizer **P2**.
-
-**Carried follow-ups** (not yet shipped): the **primary-agent** surface (a client-side
-hook); additional command families (VCS `git`, file/dir ops, package managers); and folding
-the fold-recall / `code_span_get` recovery flows through the same `tool_output_get` handle.
+`aimee economizer stats` reports original, retained, spilled, recovered, and estimated token/cost
+counts. Measure task outcomes and recovery rate before changing a filter.

--- a/docs/gen/cli-commands.md
+++ b/docs/gen/cli-commands.md
@@ -5,7 +5,7 @@
 
 `aimee` is a thin client: each command either runs a small local operation or forwards a typed request to `aimee-server`. Server-backed commands accept `--json` for machine-readable output. Run `aimee help <command>` for per-command help, or `aimee help --all` for every tier.
 
-Total commands: 61
+Total commands: 66
 
 ## Core commands
 
@@ -65,6 +65,7 @@ Subcommands:
   overview         List indexed projects
   list             List indexed projects
   scan             Scan workspaces and (re)build the index (--force)
+  watch <name> <root>  Install git hooks that re-index after branch changes
   blast-radius     Show files affected by changes to a file
   structure        Show file structure
   callers          Find callers of a symbol
@@ -91,6 +92,10 @@ Subcommands:
   ingest           Ingest documents (status: ingest status)
   status           Show knowledge-base status
   docs push        Push docs into the knowledge base
+  grant set        Set one subject's write tier (--server, --team, --subject, --tier)
+  grant show       Show one subject's grant (--server, --team, --subject)
+  grant list       List grants (--server, --team, [--include-revoked])
+  grant revoke     Revoke one subject's grant (--server, --team, --subject)
 ```
 
 ### `aimee manuscript`
@@ -122,6 +127,20 @@ Subcommands:
   read             Assemble current memory context
 ```
 
+### `aimee persona`
+
+Persona management.
+
+Subcommands:
+
+```
+  list             List available personas
+  show <name>      Print one persona
+  edit <name>      Edit or create a persona in $EDITOR
+  add <name>       Alias for edit
+  rm <name>        Reset a built-in or remove a custom persona
+```
+
 ### `aimee rules`
 
 Rule management (list, generate, delete).
@@ -132,6 +151,19 @@ Subcommands:
   list             List active rules
   generate         Generate a rules prompt
   delete           Delete one rule
+```
+
+### `aimee self-update`
+
+Update this thin client to the server release.
+
+Subcommands:
+
+```
+  --check          Report whether an update is available
+  --version vX.Y.Z  Install a specific release without downgrading
+  --yes            Do not ask before replacing the binary
+  --require-verify  Fail if the published SHA-256 cannot be verified
 ```
 
 ### `aimee session-start`
@@ -206,6 +238,7 @@ Subcommands:
 ```
   list             List configured delegates
   add              Add or update a delegate provider
+  setup            Run an agent provider's attended OAuth setup
   local            Register/update a local OpenAI-compatible delegate
                    (--provider openai|llama-eval for request shaping)
   remove           Remove a configured delegate
@@ -282,6 +315,16 @@ Subcommands:
                          requires a configured server, kb, and code index
 ```
 
+### `aimee codex`
+
+Codex OAuth recovery.
+
+Subcommands:
+
+```
+  reauth           Re-authenticate Codex after refresh is rejected
+```
+
 ### `aimee cron`
 
 Cron jobs and watchdog runs.
@@ -297,6 +340,22 @@ Subcommands:
   enable <id>      Enable a cron job
   disable <id>     Disable a cron job (--all for rollback)
   remove <id>      Remove a cron job
+```
+
+### `aimee css`
+
+CSS migration analysis and render verification.
+
+Subcommands:
+
+```
+  report           Show a CSS-health overview
+  dead-rules | conflicts | duplicate-declarations | duplicate-selectors
+  unresolved | important-audit | high-specificity | unused-vars | token-candidates
+  migrate-enumerate | migrate-list | rules-doc | assert-conventions | conventions
+  render-store <project> <unit> <before|after> <snapshot.json>
+  render-capture <project> <unit> <before|after> <html-file> <css-file>
+  render-verify <project> <unit>
 ```
 
 ### `aimee curator`
@@ -522,8 +581,23 @@ Subcommands:
 
 ```
   set <url> [token]  Persist a remote server target
+  enroll            Rotate the bearer and enroll this client certificate
+  trust             Pin the configured server certificate again
   status             Show the resolved transport and a health probe
   clear              Revert to the local Unix socket
+```
+
+### `aimee roles`
+
+Delegate role templates.
+
+Subcommands:
+
+```
+  list             List role templates
+  show <role>      Print one role template
+  edit <role>      Edit or create a template in $EDITOR
+  rm <role>        Reset a built-in or remove a custom template
 ```
 
 ### `aimee roundtable`
@@ -621,6 +695,7 @@ Subcommands:
   add <path>       Register a directory as a workspace and index its projects
   list             List configured workspaces and their indexed projects
   remove <path>    Unregister a workspace
+  serve <id>       Run the authorized remote-workspace request loop
 ```
 
 ### `aimee worktree`

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -28,7 +28,7 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `audit_action_enabled` | bool | — |
+| `audit_action_enabled` | bool | Publish governed tool-action audit rows (default on); disabling it creates an audit coverage gap. |
 | `audit_worm_enabled` | bool | Dual-write governed-action audit rows into the append-only, hash-chained WORM store alongside audit.log (default off). |
 | `autonomous` | bool | Run autonomously (auto-advance machine gates; human gates always park) vs interactive. |
 | `cache_aware_rewrite_enabled` | bool | Rewrite prompts to align with the provider's prompt cache. |
@@ -36,7 +36,7 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 | `claude_model` | string | Default Claude model (empty = CLI default). |
 | `client_integrations_enabled` | bool | Auto-register aimee (MCP server, hooks, slash commands) into detected AI-tool user configs — Claude Code (~/.claude), Gemini, Copilot, Codex. Default-ON; set false, or export AIMEE_NO_CLIENT_INTEGRATIONS, to keep aimee out of every tool's global config and wire a single project by hand. |
 | `code_cochange_git_enabled` | bool | Mine git history at `index scan` time into co_edited edges (files that change together in a commit), which blast radius already reads. Incremental and idempotent via a per-project HEAD marker; bulk commits (>25 code files) are skipped. Default on. |
-| `code_trust_actuation_enabled` | bool | — |
+| `code_trust_actuation_enabled` | bool | Use earned code-graph trust lessons only as an equal-score retrieval tiebreak (default off). |
 | `cost_reward_enabled` | bool | Factor token cost into the reward signal. |
 | `cost_reward_ref_usd_milli` | int | Reference cost (USD-milli) normalizing the cost reward. |
 | `cross_verify` | bool | Enable cross-model verification of outputs. |
@@ -61,7 +61,7 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 | `guardrail_mode` | string | Guardrail enforcement mode (off / warn / block). |
 | `guardrails_blast_radius_advisory_enabled` | bool | Surface a structural blast-radius advisory (graph-impacted files) before an edit (advisory, fail-open). |
 | `guardrails_semantic_command` | string | External semantic-guardrail classifier command. |
-| `guardrails_semantic_mode` | string | — |
+| `guardrails_semantic_mode` | string | Semantic guardrail mode: off, dry_run, advisory, or enforce. |
 | `identity_working_profile_injection_enabled` | bool | Inject the working-profile identity into prompts. |
 | `ingress_audit_async` | bool | Audit ingress requests asynchronously. |
 | `ingress_max_raw_scans` | int | Max raw-content scans per ingress request. |
@@ -72,16 +72,16 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 | `integrity_enabled` | bool | Enable the integrity gate. |
 | `kb_api_bearer_token` | string | Bearer token for the aimee-kb API. |
 | `kb_api_http_port` | int | HTTP port the aimee-kb API listens on. |
-| `kb_client_bearer_token` | string | — |
-| `kb_client_url` | string | — |
-| `kb_curator_extract_code_workers` | int | — |
-| `kb_curator_extract_docs_workers` | int | — |
+| `kb_client_bearer_token` | string | Server-to-KB bearer token; secret, restart required. |
+| `kb_client_url` | string | Remote aimee-kb API base URL used by aimee-server; restart required. |
+| `kb_curator_extract_code_workers` | int | Parallel curator code-extraction workers, bounded to the synthesis service slot count. |
+| `kb_curator_extract_docs_workers` | int | Parallel curator document-extraction workers, bounded to the synthesis service slot count. |
 | `kb_curator_tier` | string | KB curator pipeline preset: off | lite (core extract+index) | full (all stages, default). |
-| `kb_evidence_embed_enabled` | bool | — |
+| `kb_evidence_embed_enabled` | bool | Drain evidence-index operations into evidence vectors. |
 | `kb_evidence_emit_enabled` | bool | Emit evidence records from KB ingest. |
 | `kb_fusion_mode` | string | KB retrieval fusion mode: rrf (default), static_alpha, or dynamic_alpha. |
 | `kb_mining_enabled` | bool | Enable background KB mining. |
-| `kb_mode` | string | — |
+| `kb_mode` | string | Setup/deploy mode: local starts a KB, remote connects to kb_client_url. |
 | `kb_pdf_tier` | string | Structured-PDF pipeline preset: off (plain pdftotext, default) | basic (ingest+vector) | full (all stages). |
 | `learning_router_enabled` | bool | Enable the learning router. |
 | `max_iterations` | int | Per-turn iteration cap for interactive chat (default 15). |
@@ -106,17 +106,15 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 | `subagent_ban_enabled` | bool | Prevent provider-native sub-agent tools when an aimee delegate is available, and install the matching client guardrails (default on). |
 | `tsr_command` | string | TSR sidecar endpoint/command for structured-PDF table recognition (resolves like embedding_command; AIMEE_TSR_URL env fallback). |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
-| `verify_cmd` | string | — |
+| `verify_cmd` | string | Command run after a delegated fix to verify it. |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |
 | `verify_enabled` | bool | Master gate for `aimee git verify` (default off). |
-| `verify_prompt` | string | — |
-| `verify_role` | string | — |
+| `verify_prompt` | string | Prompt template given to the cross-verification delegate. |
+| `verify_role` | string | Delegate role used for cross-verification. |
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 | `wfe_live_forge_enabled` | bool | Gate for the autonomous live forge (default-ON). When off, the forge provider is not registered and every forge op fails closed, so an autonomous run can never open or merge a real PR. Even on, each op re-checks this flag and the merge-target rail. |
-| `wfe_proposals_autoscan_enabled` | bool | — |
-
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `guardrails_semantic_mode`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_extract_code_workers`, `kb_curator_extract_docs_workers`, `kb_evidence_embed_enabled`, `kb_mode`, `verify_cmd`, `verify_prompt`, `verify_role`, `wfe_proposals_autoscan_enabled`
+| `wfe_proposals_autoscan_enabled` | bool | Automatically scan watched proposal directories; off requires explicit trigger.fire. |
 
 ### Deploy-time keys (15)
 
@@ -124,21 +122,21 @@ Consumed once by `config_emit_deploy_env` to stand up the aimee-llm container (`
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `llm_embed_backend` | string | — |
-| `llm_embed_gpu` | string | — |
-| `llm_embed_host` | string | — |
-| `llm_embed_tier` | string | — |
-| `llm_rerank_backend` | string | — |
-| `llm_rerank_endpoint` | string | — |
-| `llm_rerank_gpu` | string | — |
-| `llm_rerank_host` | string | — |
-| `llm_rerank_tier` | string | — |
-| `llm_synth_backend` | string | — |
-| `llm_synth_endpoint` | string | — |
-| `llm_synth_gpu` | string | — |
-| `llm_synth_host` | string | — |
-| `llm_synth_model` | string | — |
-| `llm_synth_tier` | string | — |
+| `llm_embed_backend` | string | Deploy-time embedding backend: local or external. |
+| `llm_embed_gpu` | string | Deploy-time GPU selector for the local embedding backend. |
+| `llm_embed_host` | string | Deploy-time host selector for the local embedding backend. |
+| `llm_embed_tier` | string | Deploy-time local embedding tier: cpu, small, mid, or large. |
+| `llm_rerank_backend` | string | Deploy-time reranking backend: local, external, or off. |
+| `llm_rerank_endpoint` | string | External reranking endpoint used when the rerank backend is external. |
+| `llm_rerank_gpu` | string | Deploy-time GPU selector for the local reranking backend. |
+| `llm_rerank_host` | string | Deploy-time host selector for the local reranking backend. |
+| `llm_rerank_tier` | string | Deploy-time local reranking tier. |
+| `llm_synth_backend` | string | Deploy-time synthesis backend: local, external, or off. |
+| `llm_synth_endpoint` | string | External synthesis endpoint used when the synth backend is external. |
+| `llm_synth_gpu` | string | Deploy-time GPU selector for the local synthesis backend. |
+| `llm_synth_host` | string | Deploy-time host selector for the local synthesis backend. |
+| `llm_synth_model` | string | Model label sent to the configured synthesis endpoint. |
+| `llm_synth_tier` | string | Deploy-time local synthesis tier: cpu, small, mid, or large. |
 
 ### Advanced tuning keys (77)
 
@@ -163,21 +161,21 @@ Expert scalars with sensible defaults; settable in the config file but off the e
 | `ingress_compress_min_chars` | int | Minimum code-snippet length (chars) before it is folded to a file:line reference (default 80). |
 | `ingress_preinject_anthropic_enabled` | bool | Inject the `<aimee-context>` envelope on the Anthropic-native /v1/messages passthrough too (default off). |
 | `ingress_usage_accounting_enabled` | bool | Account token usage on ingress requests. |
-| `kb_curator_cross_repo_graph_enabled` | bool | — |
-| `kb_curator_custom_stages` | string | — |
-| `kb_curator_detect_contradictions_enabled` | bool | — |
-| `kb_curator_extract_code_enabled` | bool | — |
-| `kb_curator_extract_docs_enabled` | bool | — |
-| `kb_curator_index_claims_enabled` | bool | — |
-| `kb_curator_index_code_unit_enabled` | bool | — |
-| `kb_curator_index_narrative_enabled` | bool | — |
-| `kb_curator_link_artifacts_enabled` | bool | — |
-| `kb_curator_projection_graph_enabled` | bool | — |
-| `kb_curator_promote_entity_enabled` | bool | — |
-| `kb_curator_resolve_entities_enabled` | bool | — |
-| `kb_curator_stage_order` | string | — |
-| `kb_curator_synthesize_enabled` | bool | — |
-| `kb_curator_user_presets` | string | — |
+| `kb_curator_cross_repo_graph_enabled` | bool | Resolve and maintain cross-repository dependency edges. |
+| `kb_curator_custom_stages` | string | JSON definitions that recompose vetted curator operations with bounded budgets. |
+| `kb_curator_detect_contradictions_enabled` | bool | Link claims that disagree on the same subject and attribute. |
+| `kb_curator_extract_code_enabled` | bool | Extract typed curator artifacts from indexed code. |
+| `kb_curator_extract_docs_enabled` | bool | Extract typed curator artifacts from documents. |
+| `kb_curator_index_claims_enabled` | bool | Embed claim subject/attribute/value records. |
+| `kb_curator_index_code_unit_enabled` | bool | Embed extracted code-unit artifacts. |
+| `kb_curator_index_narrative_enabled` | bool | Embed summaries and synthesis narratives. |
+| `kb_curator_link_artifacts_enabled` | bool | Link related document, entity, claim, and code artifacts. |
+| `kb_curator_projection_graph_enabled` | bool | Publish the typed code projection graph for changed projects. |
+| `kb_curator_promote_entity_enabled` | bool | Promote well-supported entities one step up the scope lattice. |
+| `kb_curator_resolve_entities_enabled` | bool | Resolve proposed mentions against canonical entities. |
+| `kb_curator_stage_order` | string | Comma-separated curator stage order; invalid dependency order falls back safely. |
+| `kb_curator_synthesize_enabled` | bool | Create evidence-backed topic synthesis with the configured reasoning tier. |
+| `kb_curator_user_presets` | string | JSON array of operator-defined curator stage presets. |
 | `kb_fusion_static_alpha` | float | Lexical/dense blend weight (0-1) for the static_alpha fusion mode. |
 | `kb_mining_min_poll_s` | int | Minimum interval (s) between KB mining polls. |
 | `kb_pdf_assets_enabled` | bool | Render structured-PDF figure/table crops to the content-addressed blob store + kb_doc_assets at ingest, served via open_asset (default off; needs pdftoppm). |
@@ -318,6 +316,7 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_HOME` | Root of the per-user state/config store (config, DB1, `workflows/`, keys). Overrides the platform default. |
 | `AIMEE_MODELS_DEV_SNAPSHOT` | Path to an offline models.dev catalog snapshot. |
 | `AIMEE_PACK_DIR` | Directory of memory profile packs. |
+| `AIMEE_RUNTIME_DIR` | Private runtime directory for sockets, temporary credentials, and process state. |
 | `AIMEE_TOOLSETS_CONFIG` | Path to a toolsets config file (overrides the default tool allowlists). |
 | `AIMEE_WORKSPACES_DIR` | Root directory for mirrored/registered workspaces. |
 
@@ -329,11 +328,14 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_API_BEARER` | Bearer token for the `/v1` API endpoint. |
 | `AIMEE_API_ENDPOINT` | Override the `/v1` API endpoint used by the client RPC layer. |
 | `AIMEE_ATTACH_ID` | Presence attach id used when joining an existing session. |
+| `AIMEE_CLIENT_TYPE` | Calling client type used for integration-specific request shaping. |
 | `AIMEE_HOOK_CLIENT` | Identifies the calling hook client (e.g. claude/codex) for hook routing. |
 | `AIMEE_MODE` | Operating-mode override (e.g. interactive / autonomous). |
 | `AIMEE_NO_AUTOSTART` | If set, the client does not auto-start a local aimee-server. |
 | `AIMEE_NO_CLIENT_INTEGRATIONS` | If set (to any value other than 0/false), aimee does not auto-register itself into detected AI-tool user configs (Claude Code, Gemini, Copilot, Codex). Overrides the client_integrations_enabled config; honored by the aimee binary and by install.sh/configure-hooks.sh. |
+| `AIMEE_PRIMARY_CLI_INGESTOR` | Name of the primary CLI integration that owns session-ingest events. |
 | `AIMEE_PROFILE` | Active working-profile name. |
+| `AIMEE_PROJECT_ID` | Explicit project identity for an integration request. |
 | `AIMEE_SERVER_TOKEN` | Bearer token presented to aimee-server over TCP. |
 | `AIMEE_SERVER_URL` | aimee-server endpoint the thin client connects to (UDS path or `tcp:host:port`). |
 | `AIMEE_SESSION_ID` | Pre-set the session id (enables non-blocking session attach). |
@@ -346,20 +348,41 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
-| `AIMEE_API_REMOTE_WRITES` | Gate remote (TCP) write methods: `off` | `data` | `full`. |
+| `AIMEE_API_BEARER_TOKEN` | Bearer token for the public server API listener; secret. |
+| `AIMEE_API_REMOTE_WRITES` | Legacy value: `off`, `data`, or `full`. Still parsed, but no longer authorizes user writes; non-off values warn and feed `remote_writes.global_ignored`. |
 | `AIMEE_BACKGROUND_THREADS` | Background worker thread count. |
 | `AIMEE_COMPUTE_THREADS` | Compute-pool thread count. |
 | `AIMEE_DEPLOY_COMPOSE_FILE` | Path to the managed compose file the server-orchestrated deploy runs (default /opt/aimee/deploy/aimee-managed.compose.yaml). |
 | `AIMEE_DEPLOY_ENABLED` | Set to 1 to enable the server-orchestrated deploy: the setup wizard runs `docker compose up -d` for the managed sibling services (aimee-kb + aimee-llm) via a mounted Docker socket. Off unless the deploy compose sets it. |
 | `AIMEE_GITHUB_OAUTH_CLIENT_ID` | Client ID of a GitHub OAuth App for the webchat "Sign in with GitHub" button; populates the github.com git credential. Public. Overrides the built-in default baked in via oauth_defaults.h. |
-| `AIMEE_GITHUB_OAUTH_CLIENT_SECRET` | Client secret of the GitHub OAuth App. Enables the seamless web (redirect) sign-in; without it the button falls back to the device-code flow. Secret — set per deployment, never baked into an image. |
+| `AIMEE_GITHUB_OAUTH_CLIENT_SECRET` | Client secret of the GitHub OAuth App. Enables browser redirect sign-in; without it the button falls back to the device-code flow. Secret — set per deployment, never baked into an image. |
 | `AIMEE_GITLAB_OAUTH_CLIENT_ID` | Client ID of a GitLab OAuth application (device flow enabled) for the webchat "Sign in with GitLab" button on gitlab.com. Public. Overrides the built-in default baked in via oauth_defaults.h. |
 | `AIMEE_INGRESS_PROXY_SECRET` | Shared secret authenticating a trusted ingress proxy's identity headers. |
+| `AIMEE_MGMT_STATUS_KEY_ID` | Identifier of the management-status verification key. |
+| `AIMEE_MGMT_STATUS_PUBLIC_KEY` | Hex-encoded Ed25519 key used to verify management-status staples. |
+| `AIMEE_MODULE_ROUNDTABLE` | Enable the optional roundtable module; invalid values fail closed to off. |
 | `AIMEE_SEARCH_ALLOW_PRIVATE_ENDPOINT` | Permit the operator-configured search backend (`search.searxng_url`) to resolve to a private, loopback, or link-local address. Off by default: every outbound fetch is validated and pinned, so a self-hosted SearXNG on a LAN address is refused unless this is set. Deliberately an environment variable rather than a config key, because `config.set` is reachable from inside the running system and pointing the search backend at a cloud metadata address would exfiltrate instance credentials through a tool that looks like search. Set to exactly `1`; any other value is off. Never widens fetches of model-supplied or search-result URLs, which stay denied. |
 | `AIMEE_SERVER_HTTP_BIND` | TCP bind address for the server `/v1` HTTP listener (else UDS-only). |
+| `AIMEE_SERVER_MGMT_BIND` | Bind address that enables the server management listener when its full TLS configuration is present. |
+| `AIMEE_SERVER_MGMT_ISSUER` | Expected issuer for management-plane bearer identities. |
+| `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE` | Root-owned trust bundle used to verify signed management JWKS publications. |
+| `AIMEE_SERVER_MGMT_STATUS_SECONDARY_LEAF_PIN` | Secondary management-status TLS leaf pin accepted during certificate rotation. |
 | `AIMEE_SERVER_STARTUP_FD` | Inherited fd for startup-readiness signalling (service launch). |
 | `AIMEE_SESSION_THREADS` | Per-session worker thread count. |
 | `AIMEE_SOCK` | Sandbox helper socket path. |
+| `AIMEE_STAGE_GOVERNANCE` | Enable the governance stage in the canonical request pipeline. |
+| `AIMEE_STAGE_MEMORY` | Enable the memory stage in the canonical request pipeline. |
+| `AIMEE_VAULT_KMS_HELPER` | Executable implementing the configured external KMS wrap/unwrap contract. |
+| `AIMEE_VAULT_KMS_HWM_DOMAIN` | Domain separator for KMS high-water-mark signatures. |
+| `AIMEE_VAULT_KMS_HWM_PUBKEY` | Public key used to verify KMS high-water-mark records. |
+| `AIMEE_VAULT_KMS_KEY_ID` | External KMS key identifier used for vault wrapping. |
+| `AIMEE_VAULT_PKCS11_LABEL` | PKCS#11 object label used for vault custody. |
+| `AIMEE_VAULT_PKCS11_MODULE` | Path to the PKCS#11 provider module. |
+| `AIMEE_VAULT_PKCS11_PIN` | PKCS#11 user PIN; secret. |
+| `AIMEE_VAULT_PKCS11_SLOT` | PKCS#11 slot identifier used for vault custody. |
+| `AIMEE_VAULT_TPM2_BLOB_PATH` | Path to the sealed TPM 2 vault-key blob. |
+| `AIMEE_VAULT_TPM2_NV_INDEX` | TPM 2 NV index used for anti-rollback state. |
+| `AIMEE_VAULT_TPM2_TCTI` | TPM 2 TCTI selector. |
 | `AIMEE_WEBCHAT_EDITOR` | Per-webuser in-browser code-server editor (on by default; set to 0 to disable; needs a code-server binary, shipped by WITH_VSCODE images). |
 | `AIMEE_WEBCHAT_EDITOR_BIN` | Override path to the code-server binary used for the in-browser editor. |
 | `AIMEE_WEBCHAT_EDITOR_IDLE_SECS` | Idle timeout in seconds before a per-webuser code-server editor is reaped. Default 1800 (30 min); positive values are clamped to [60, 604800]; 0 disables idle reaping; malformed/negative/overflow values fall back to the default. An actively-open editor is kept alive by the proxy keepalive, so it is not reaped mid-session. |
@@ -372,6 +395,7 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_CODE_INDEX_SOURCE` | Source label recorded for code-index ingestion. |
 | `AIMEE_EMBEDDER_URL` | Embedder endpoint override (/embed, /embed_batch); takes precedence over AIMEE_LLM_URL for embedding. |
 | `AIMEE_KB_API_BEARER_TOKEN` | Bearer token for the aimee-kb API. |
 | `AIMEE_KB_API_CA_BUNDLE` | CA bundle path for verifying the aimee-kb TLS certificate. |
@@ -380,7 +404,12 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_KB_CONN` | KB connection string (mTLS transport). |
 | `AIMEE_KB_EMIT_ENROLL` | Emit a client enrollment token on KB start. |
 | `AIMEE_KB_EMIT_SCOPE` | Scope for the emitted enrollment token. |
+| `AIMEE_KB_HARDENED` | Require the hardened KB custody and transport posture at startup. |
 | `AIMEE_KB_HTTP_BIND` | aimee-kb HTTP listener bind address. |
+| `AIMEE_KB_JWKS_MANIFEST_ROOT_CUSTODY_ID` | Custody identifier for the key that signs JWKS manifests. |
+| `AIMEE_KB_JWKS_PUBLICATION_HWM_CUSTODY_ID` | Custody identifier for the JWKS publication high-water mark. |
+| `AIMEE_KB_JWKS_PUBLISH_DSN` | Provisioning database URL used by the JWKS publisher; secret. |
+| `AIMEE_KB_MGMT_STATUS_SECONDARY_LEAF_PIN` | Secondary TLS leaf pin accepted during management-status certificate rotation. |
 | `AIMEE_KB_MTLS_HOST` | aimee-kb mTLS listener host. |
 | `AIMEE_KB_MTLS_PORT` | aimee-kb mTLS listener port. |
 | `AIMEE_KB_OIDC_AUDIENCE` | OIDC audience for KB API auth. |
@@ -391,21 +420,38 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_KB_OIDC_LOGIN_REDIRECT_URI` | This kb's OIDC callback URL (https, or http on loopback only). |
 | `AIMEE_KB_OIDC_LOGIN_SCOPE` | Space-delimited OIDC scopes for the login request; defaults to openid. |
 | `AIMEE_KB_OIDC_LOGIN_TOKEN_URL` | IdP token endpoint for the code exchange (https, default port only). |
+| `AIMEE_KB_OIDC_MAX_TOKEN_AGE` | Maximum accepted age in seconds for a KB OIDC token. |
 | `AIMEE_KB_OIDC_SCOPE_CLAIM` | OIDC claim carrying the scope. |
 | `AIMEE_KB_OIDC_SCOPE_KIND` | OIDC scope-kind interpretation. |
+| `AIMEE_KB_RUNTIME_UID` | Numeric runtime user allowed to receive the management token-authority socket. |
+| `AIMEE_KB_STATUS_BIND` | Bind address for the management-status authority. |
+| `AIMEE_KB_STATUS_DSN` | Runtime database URL used by the management-status authority; secret. |
+| `AIMEE_KB_STATUS_PORT` | Listen port for the management-status authority. |
+| `AIMEE_KB_STATUS_PROVISION_DSN` | Provisioning database URL used to initialize management-status state; secret. |
+| `AIMEE_KB_TOKEN_AUTHORITY_DSN` | Database URL used by the management token authority; secret. |
+| `AIMEE_KB_TOKEN_AUTHORITY_SOCKET_GID` | Group allowed to connect to the management token-authority socket. |
+| `AIMEE_KB_TOKEN_ROOTS_PROVISION_DSN` | Provisioning database URL used to initialize token roots; secret. |
+| `AIMEE_KB_TOKEN_ROOT_CUSTODY_ID` | Custody identifier for the management token signing root. |
+| `AIMEE_KB_VAULT_OPERATOR_ENABLED` | Enable the dedicated KB vault-operator runtime. |
+| `AIMEE_KB_VAULT_ORCHESTRATOR_URL` | Operator-configured vault orchestrator endpoint. |
 | `AIMEE_LLM_MODEL` | Model label sent to AIMEE_LLM_URL's chat endpoint (single-model gateways ignore it). Default 'aimee-synth'. |
 | `AIMEE_LLM_URL` | One knob: base URL of the aimee-llm container the kb calls for embedding (/embed), reranking (/rerank) AND synthesis (curator Tier-A + Tier-B at {url}/v1). The kb runs no model itself. AIMEE_EMBEDDER_URL/AIMEE_RERANKER_URL override per service. See docs/KB_LLM_BACKENDS.md. |
+| `AIMEE_OCR_URL` | Structured-PDF OCR sidecar endpoint. |
 | `AIMEE_SERVER_ID` | Registry identity used by the server mTLS heartbeat. |
 | `AIMEE_SERVER_TEAM_ID` | The team this server serves, from the same registry row as AIMEE_SERVER_ID. Required for per-user /v1 write authorization: unset, the server still starts and serves reads but denies every write with no_team_configured. |
 | `AIMEE_TRANSPORT_KB_POOL_ENABLED` | Override server-to-KB mTLS connection pooling. The config default is on; set to 0 for one-shot connections. |
+| `AIMEE_TSR_URL` | Structured-PDF table-recognition sidecar endpoint. |
 | `AIMEE_VECTOR_KB_BATCH_SIZE` | Embedding batch size for KB vector ingest. |
 
 ### Database & vectors
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_DB2_EVAL_URL` | Separate DB2 URL used by evaluation harnesses; never the production default. |
+| `AIMEE_DB2_POOL_SIZE` | DB2 connection-pool size override. |
 | `AIMEE_DB2_STATEMENT_TIMEOUT_MS` | Per-connection `statement_timeout` in ms. Defaults to the pool's stuck-lease ceiling (`DB2_POOL_HOLD_CEILING_MS`, 300000), because a statement must not outlive the duration that defines a lease as stuck — the pool can report such a lease but cannot reclaim it. The value must be canonical decimal digits with no sign, surrounding whitespace or leading zero. Exactly `0` disables the bound — a deliberate opt-out for genuinely long work — and every other spelling of zero (`00`, `+0`, `-0`, ` 0`) is treated as malformed. Anything malformed or out-of-range falls back to the default and never to unlimited, so no typo can silently remove the bound. |
 | `AIMEE_DB2_URL` | Postgres (DB2) connection URL for the KB store. |
+| `AIMEE_DIM_PROBE_BUDGET_MS` | Time budget for probing an embedder's output dimension. |
 | `AIMEE_EMBEDDING_DIM` | Embedding dimension (drives halfvec column sizing). |
 | `AIMEE_PGVEC_SLOW_QUERY_MS` | Slow-query log threshold (ms) for the pgvector transport. |
 
@@ -430,8 +476,12 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_ALLOW_MAIN_CHECKOUT` | Allow an explicitly authorized delegate path to use the main checkout instead of a managed worktree. |
+| `AIMEE_CODEX_REFRESH_SKEW` | Seconds before Codex OAuth expiry at which the server refreshes the token. |
 | `AIMEE_DELEGATE_DEPTH` | Current delegation depth (recursion guard). |
 | `AIMEE_DELEGATE_HEARTBEAT_MONITOR` | Enable the delegate heartbeat monitor. |
+| `AIMEE_DELEGATE_MAX_INFLIGHT` | Process-wide maximum number of admitted delegate attempts. |
+| `AIMEE_DELEGATE_SANDBOX` | Enable the configured delegate sandbox backend. |
 | `AIMEE_DELEGATE_SOURCE_AUTHORITY` | Enable source-authority gating for delegate edits. |
 | `AIMEE_DELEGATE_SOURCE_PATHS` | Allowed source paths for delegate edits. |
 | `AIMEE_DELEGATE_WORKTREE_ROOT` | Root directory for delegate worktrees. |
@@ -440,6 +490,7 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_FORWARDER_PORT` | Loopback port the in-sandbox aimee-forwarder listens on (default 3129); set by aimee when it starts the forwarder in a proxy-mode delegate container. |
 | `AIMEE_FORWARDER_SOCK` | UNIX socket the in-sandbox aimee-forwarder bridges to (default /run/aimee/aimee-http.sock, the bound aimee UDS). |
 | `AIMEE_PARENT_DELEGATION_ID` | Parent delegation id (threading). |
+| `AIMEE_SANDBOX_HOST_MOUNTS` | Operator allowlist of host mounts available to the sandbox backend. |
 | `AIMEE_SSH_BIN` | SSH delegate-backend binary. |
 
 ### Forge (GitHub App / tokens)
@@ -474,9 +525,26 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_AUTONOMY_BASE` | Integration branch used by autonomous workflow work; distinct from the repository default branch. |
+| `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL` | Maximum active autonomous work items for one authenticated principal. |
+| `AIMEE_AUTONOMY_MAX_USD` | Default USD ceiling for an autonomous work item; 0 disables this default ceiling. |
 | `AIMEE_AUTONOMY_PANEL_RETRIES` | Per-(work item, stage) budget for auto-retrying a TRANSIENT roundtable park (`panel_degraded`/`panel_unreachable`) in an autonomous run, one retry per scheduler backstop sweep, before it escalates to a human. Default 6. An explicit `0` disables auto-retry (a degraded panel escalates immediately — the pre-feature behavior, useful during a known provider incident); a malformed/negative value floors to the default so a typo can't silently disable the rail. |
+| `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN` | Autonomous-submission rate limit per principal. |
+| `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS` | Window used by the autonomous-submission rate limiter. |
+| `AIMEE_AUTONOMY_USD_PER_SEC` | Fallback spend estimator for autonomous admission when exact provider cost is unavailable. |
+| `AIMEE_CI_WEBHOOK_SECRET` | HMAC secret authenticating inbound CI webhook events. |
 | `AIMEE_DEFAULT_BRANCH` | Override the target repo's real default branch (its trunk) that a `base:trunk` `branch.open`/`pr.open` resolves to; else read from `git origin/HEAD`. Distinct from `AIMEE_AUTONOMY_BASE` (the aimee integration branch). A final feature PR opens against this branch (open-only, never auto-merged). |
+| `AIMEE_ORCH_DELEGATES` | Enable delegate resource use by the orchestration plane. |
+| `AIMEE_ORCH_WORKFLOWS` | Enable workflow orchestration surfaces. |
+| `AIMEE_PANEL_SEAT_WAIT_SECS` | Maximum wait for a roundtable seat to acquire an eligible agent. |
+| `AIMEE_WFE_ENGINE` | Workflow runtime selector; current server images require `go`. |
+| `AIMEE_WFE_HTTP_SOCKET` | Unix socket for the Go workflow control plane. |
+| `AIMEE_WFE_WORKTREE_GC_GRACE_SECS` | Grace period before an unowned workflow worktree can be collected. |
+| `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER` | Enable automatic scheduling of admitted autonomous work items. |
 | `AIMEE_WORKFLOW_BASE` | Base branch for the engine's freeze/diff. |
+| `AIMEE_WORKFLOW_BRANCH` | Explicit workflow feature branch for a compatibility or test runner. |
+| `AIMEE_WORKFLOW_ENFORCE_STAGE` | Require runner requests to match the persisted workflow stage. |
+| `AIMEE_WORKFLOW_LEASE_TTL_SECS` | Lifetime of a workflow execution lease before recovery may reclaim it. |
 | `AIMEE_WORKFLOW_REPO` | Local repository directory the workflow engine operates on. |
 
 ### Git verify / MCP
@@ -498,7 +566,14 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_KB_MTLS_MAX_CONNECTIONS` | Maximum concurrent connections accepted by the KB mTLS listener. |
+| `AIMEE_KB_STATUS_TLS_CA` | CA file used by the management-status authority. |
+| `AIMEE_KB_STATUS_TLS_CERT` | TLS certificate for the management-status authority. |
+| `AIMEE_KB_STATUS_TLS_KEY` | TLS private key for the management-status authority; secret. |
 | `AIMEE_NET_DEBUG` | Verbose network debug logging. |
+| `AIMEE_TLS_CLIENT_P12_PASS` | Password for an explicitly provisioned client PKCS#12 bundle; secret. |
+| `AIMEE_TLS_CN` | Common Name used when generating a local TLS certificate. |
+| `AIMEE_TLS_EXTRA_SAN` | Additional subject-alternative names for a generated TLS certificate. |
 | `AIMEE_TLS_INSECURE` | Disable TLS certificate verification (development only). |
 
 ### Diagnostics & misc
@@ -506,13 +581,14 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 | Variable | Description |
 |----------|-------------|
 | `AIMEE_ANTIPATTERNS_BYPASS` | Bypass the guardrail antipattern checks. |
+| `AIMEE_IR_PATH` | Diagnostic path for recording canonical request IR. |
+| `AIMEE_IR_RESP_PATH` | Diagnostic path for recording canonical response IR. |
+| `AIMEE_IR_SHADOW` | Run the canonical IR path in comparison/shadow mode. |
+| `AIMEE_IR_STREAM_RELAY` | Enable the canonical streaming-response relay. |
 | `AIMEE_LOG_LEVEL` | Log level: `error` | `warn` | `info` | `debug`. |
-
-### Undocumented (add to `ENV_DESC` in gen-reference-docs.py)
-
-> These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
-
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_EVAL_URL`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DELEGATE_SANDBOX`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_RESP_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_KB_HARDENED`, `AIMEE_KB_JWKS_MANIFEST_ROOT_CUSTODY_ID`, `AIMEE_KB_JWKS_PUBLICATION_HWM_CUSTODY_ID`, `AIMEE_KB_JWKS_PUBLISH_DSN`, `AIMEE_KB_MGMT_STATUS_SECONDARY_LEAF_PIN`, `AIMEE_KB_MTLS_MAX_CONNECTIONS`, `AIMEE_KB_OIDC_MAX_TOKEN_AGE`, `AIMEE_KB_RUNTIME_UID`, `AIMEE_KB_STATUS_BIND`, `AIMEE_KB_STATUS_DSN`, `AIMEE_KB_STATUS_PORT`, `AIMEE_KB_STATUS_PROVISION_DSN`, `AIMEE_KB_STATUS_TLS_CA`, `AIMEE_KB_STATUS_TLS_CERT`, `AIMEE_KB_STATUS_TLS_KEY`, `AIMEE_KB_TOKEN_AUTHORITY_DSN`, `AIMEE_KB_TOKEN_AUTHORITY_SOCKET_GID`, `AIMEE_KB_TOKEN_ROOTS_PROVISION_DSN`, `AIMEE_KB_TOKEN_ROOT_CUSTODY_ID`, `AIMEE_KB_VAULT_OPERATOR_ENABLED`, `AIMEE_KB_VAULT_ORCHESTRATOR_URL`, `AIMEE_MGMT_STATUS_KEY_ID`, `AIMEE_MGMT_STATUS_PUBLIC_KEY`, `AIMEE_MODULE_ROUNDTABLE`, `AIMEE_OCR_URL`, `AIMEE_ORCH_DELEGATES`, `AIMEE_ORCH_WORKFLOWS`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_SANDBOX_HOST_MOUNTS`, `AIMEE_SERVER_MGMT_BIND`, `AIMEE_SERVER_MGMT_ISSUER`, `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE`, `AIMEE_SERVER_MGMT_STATUS_SECONDARY_LEAF_PIN`, `AIMEE_STAGE_GOVERNANCE`, `AIMEE_STAGE_MEMORY`, `AIMEE_TEST_PG_URL`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_VAULT_KMS_HELPER`, `AIMEE_VAULT_KMS_HWM_DOMAIN`, `AIMEE_VAULT_KMS_HWM_PUBKEY`, `AIMEE_VAULT_KMS_KEY_ID`, `AIMEE_VAULT_PKCS11_LABEL`, `AIMEE_VAULT_PKCS11_MODULE`, `AIMEE_VAULT_PKCS11_PIN`, `AIMEE_VAULT_PKCS11_SLOT`, `AIMEE_VAULT_TPM2_BLOB_PATH`, `AIMEE_VAULT_TPM2_NV_INDEX`, `AIMEE_VAULT_TPM2_TCTI`, `AIMEE_WFE_ENGINE`, `AIMEE_WFE_HTTP_SOCKET`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WITNESS_CADENCE_TEST_S`, `AIMEE_WITNESS_HARNESS_ROLE`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+| `AIMEE_TEST_PG_URL` | PostgreSQL URL used only by live test harnesses. |
+| `AIMEE_WITNESS_CADENCE_TEST_S` | Test-only override that shortens witness checkpoint and verification cadence. |
+| `AIMEE_WITNESS_HARNESS_ROLE` | Restricted PostgreSQL role used by the witness live harness. |
 
 ## External & provider environment
 
@@ -526,6 +602,7 @@ Standard and third-party environment variables aimee honors (scanned non-`AIMEE_
 | `GEMINI_API_KEY` | Google Gemini API key (read via the agent's `api_key_env`). |
 | `GEMINI_API_KEY_AUTH_MECHANISM` | Selects the Gemini key auth mechanism. |
 | `GOOGLE_API_KEY` | Google API key fallback for Gemini (via `api_key_env`). |
+| `LLM_API_KEY` | Bearer credential used by the generic llm-chat sidecar; prefer the vault or a secret command. |
 | `MINIMAX_API_KEY` | MiniMax API key. |
 | `MISTRAL_API_KEY` | Mistral API key. |
 | `OPENAI_API_KEY` | OpenAI API key (default for OpenAI-family agents). |
@@ -536,6 +613,8 @@ Standard and third-party environment variables aimee honors (scanned non-`AIMEE_
 | Variable | Description |
 |----------|-------------|
 | `LLAMA_HOST` | llama.cpp server host/URL. |
+| `LLM_ENDPOINT` | OpenAI-compatible base URL used by the generic llm-chat sidecar. |
+| `LLM_MODEL` | Model requested by the generic llm-chat sidecar. |
 | `OLLAMA_HOST` | Ollama server host/URL for local models. |
 
 ### Network / proxy
@@ -562,13 +641,9 @@ Standard and third-party environment variables aimee honors (scanned non-`AIMEE_
 | `CODEX_SANDBOX` | Codex sandbox mode. |
 | `CODEX_THREAD_ID` | Codex conversation/thread id. |
 
-### Undocumented (add to `EXT_DESC`/`EXT_OS_IGNORE` in gen-reference-docs.py)
-
-`LISTEN_FDS`, `LISTEN_PID`, `LLM_API_KEY`, `LLM_ENDPOINT`, `LLM_MODEL`
-
 ## Workflow engine
 
-Workflows are block-composed YAML definitions under `$AIMEE_HOME/workflows/<name>.yaml`, authored with the `aimee workflow` CLI or the web visual composer and saved in canonical form. A run is a DB1 work item pinned to a definition version.
+Workflows are block-composed YAML definitions under `$AIMEE_HOME/workflows/<name>.yaml`, authored with the `aimee workflow` CLI or the web visual composer and saved in canonical form. The Go workflow engine owns execution. A run is a durable work item pinned to a definition version.
 
 ### Workflow definition schema
 
@@ -634,8 +709,7 @@ blocks:
 
 ### Run-level controls (not in the definition)
 
-- **Per-stage loop cap** — a node that loops back via `on_fail` is retried at most `max_rounds` times (per-node param, default `20`); on the cap its `on_max` policy resolves the loop: `human` parks (default), `fail` is a terminal reject, `pass` forces the flow forward via `on_pass`/`next`.
-- **Gate-override cap** — a parked human gate may be overridden at most `2` times (`WFE_MAX_OVERRIDES`) before the run is forced terminal.
+- **Per-stage loop cap** — `params.max_rounds` bounds retries for a node that loops through `on_fail` (default `20`). Exhaustion parks the run with `retry_limit` or a more specific convergence reason. The retired `max_iters` and `on_max` fields are ignored by the Go engine.
 - **Cost cap** — an optional per-work-item USD ceiling set at run creation (`work_item_max_cost_usd`); the engine parks the run when cumulative cost reaches it.
 - **Trigger / autonomy mode** — `interactive` vs `autonomous`, set when the run is created.
 
@@ -677,12 +751,14 @@ Beyond the config store, aimee reads a few standalone JSON/policy files (paths u
 | `endpoint` | Provider endpoint URL. |
 | `exec_roles` | Roles this agent may execute with tools. |
 | `exec_system_prompt` | System prompt for exec/tool runs. |
+| `exp` | OAuth token expiry as a Unix timestamp. |
 | `extra_headers` | Extra HTTP headers for requests. |
 | `fallback_chain` | Ordered fallback agent chain. |
 | `fallback_model` | Fallback model on failure. |
 | `hosts` | Allowed hosts (relay / tunnel). |
 | `inject_respond_tool` | Inject the `respond` tool. |
 | `ip` | Bind/target IP (relay / tunnel). |
+| `is_server_hosted` | Whether the provider session is hosted by the aimee server. |
 | `max_parallel` | Max concurrent calls to this agent. |
 | `max_reconnects` | Max reconnect attempts (streaming / relay). |
 | `max_scope` | Largest task scope this agent may be given (`bounded` or `whole_task`). Routing never relaxes this. |
@@ -699,9 +775,11 @@ Beyond the config store, aimee reads a few standalone JSON/policy files (paths u
 | `price_cached_per_mtok` | Cached-input price, USD per million tokens. Overrides the catalog price. |
 | `price_in_per_mtok` | Input price, USD per million tokens. Overrides the catalog price. |
 | `price_out_per_mtok` | Output price, USD per million tokens. Overrides the catalog price. |
+| `primary_only` | Restrict this agent to primary sessions; do not use it for delegates. |
 | `provider` | Provider name. |
 | `recommended_sampling` | Provider-recommended sampling parameters. |
 | `reconnect_delay` | Delay between reconnects (ms). |
+| `refresh_token` | OAuth refresh token for the endpoint. |
 | `registration` | Name of the provider registration this agent was expanded from. Set automatically; used to prefer same-provider peers during fallback. |
 | `relay_key` | Relay auth key. |
 | `relay_ssh` | SSH relay config. |
@@ -719,8 +797,6 @@ Beyond the config store, aimee reads a few standalone JSON/policy files (paths u
 | `tunnel` | Tunnel config. |
 | `tunnels` | Tunnel definitions. |
 | `user` | Remote user (ssh backend). |
-
-> **Undocumented agent fields** (add to `AGENT_FIELD_DESC`): `exp`, `is_server_hosted`, `primary_only`, `refresh_token`
 
 ### Toolsets — `AIMEE_TOOLSETS_CONFIG` (or the config `toolsets` map)
 

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -1,0 +1,30 @@
+# Modules
+
+Module documents describe ownership and contracts, not every implementation file. The descriptor and
+public header remain authoritative.
+
+A module document should cover:
+
+- responsibility and non-responsibility;
+- public API and event kinds;
+- dependencies and consumers;
+- configuration and capabilities;
+- data, trust, and failure boundaries;
+- required tests and generated/attested status.
+
+Current contracts:
+
+- [audit](audit.md), [event bus](bus.md), [config](config.md), and
+  [module runtime](module-runtime.md);
+- [memory](memory.md), [learning](learning.md), [KB synthesis](kb-synthesis.md), and
+  [benchmarks](benchmarks.md);
+- [delegates](delegates.md), [roundtables](roundtable.md), [routing](routing.md),
+  [execution policy](execution-policy.md), and [governance](governance.md);
+- [tools](tools.md), [skills](skills.md), [git](git.md), [workspace](workspace.md), and
+  [workflows](workflows.md);
+- [IR](ir.md), [translation](translation.md), [response composition](response-composition.md),
+  and [protocols](protocols.md);
+- [gateway](gateway.md), [runtime web](runtime-web.md), [control web](control-web.md), and
+  [vault](vault.md).
+
+See the [technical reference](../../src/README.md) for the process and source map.

--- a/docs/modules/bus.md
+++ b/docs/modules/bus.md
@@ -1,0 +1,47 @@
+# Event-bus module
+
+**Owner:** runtime core
+**Paths:** `src/modules/bus/`, `server-go/bus/`
+
+## Owns
+
+- wire frame and version negotiation;
+- control, private queue-pair, and arena layouts;
+- SPSC rings and bounded credits;
+- client admission and reap;
+- publish, subscribe, request/reply, cancellation, and typed absence;
+- host sequence, observer routing, and full-stream tap;
+- capture format and observational replay;
+- C/Go vectors and conformance.
+
+## Does not own
+
+- network transport between services;
+- module business schemas beyond stable kind registration;
+- credential or user authentication policy;
+- WORM storage or external witnessing;
+- workflow scheduling;
+- deterministic module execution replay;
+- hostile-code sandboxing.
+
+## Contracts
+
+Per-source FIFO is guaranteed. The host stamps global accepted order before routing. `publish` success
+means accepted into the producer ring, not consumed or durable. Backpressure is bounded and declared
+per kind. Arena references use generation and holder checks and are released on consumer completion
+or reap.
+
+The tap is the only core full-stream observer. Ordinary clients receive only authorized kinds.
+
+## Required checks
+
+- wire unit tests and corrupt-frame rejection;
+- C/Go golden vectors and live conformance;
+- ring/arena ASAN and TSAN lanes;
+- admission and cross-client isolation;
+- flow control, overflow, cancellation, and reap;
+- capture classification and byte-exact arena materialization;
+- audit durability, retention, replay, and shutdown race;
+- dispatch performance gate.
+
+See [Event bus](../EVENT_BUS.md) for the working guide.

--- a/docs/observability/virtual-context-alerts.md
+++ b/docs/observability/virtual-context-alerts.md
@@ -1,89 +1,34 @@
-# Virtual-Context Assembly: Operations & Alerts
+# Virtual-context alerts
 
-The virtual-context-assembly feature coalesces long tool/event streams into
-stubbed chain segments before they hit the model, reducing token spend and
-latency. The `session_context_status` MCP tool exposes the live health
-counters under its `metrics` object; this doc defines the canonical alert
-rules and the safe rollback path for the feature toggle
-`session.virtual_context.enabled`.
+Virtual context replaces old tool-event chains with compact references while keeping raw turns
+recoverable. Alert on loss of recovery, not merely on low compression.
 
-The companion dashboard is [`virtual-context-dashboard.json`](virtual-context-dashboard.json)
-(import into Grafana, pick the scrape datasource for the `$datasource`
-template var).
+## Signals
 
-## Metrics
+| Signal | Healthy |
+| --- | --- |
+| pending events | returns toward zero after a burst |
+| segments created vs. stubbed | track each other |
+| bytes saved | grows during long tool sessions |
+| compression ratio | above the configured quality gate |
+| expansion errors | below 1% over a useful window |
+| assembly latency | within the interactive budget |
 
-These are surfaced by `tool_session_context_status` (`metrics` object) and the
-per-session `event_count` / `chain_count` / `pending_events` fields.
+## Pages
 
-| Metric | Type | Meaning | Healthy range |
-|---|---|---|---|
-| `session_context_segments_total` | gauge | Tool-chains created for the session | monotonic; tracks active tool-heavy sessions |
-| `session_tool_chains_stubbed_total` | gauge | Chains collapsed into a deterministic stub | equals `segments_total` (every chain is stubbed) |
-| `session_context_bytes_saved` | gauge | `raw_bytes_total - stub_bytes_total` | > 0 and growing during long sessions |
-| `compression_ratio` | gauge | `raw_bytes_total / stub_bytes_total` | ≥ 1.7 (gate floor is 40% reduction ≈ 1.7x); typically 25-45x |
-| `session_context_expand_total` | counter (labels: `result={ok,error}`) | `session_context_expand` calls recovering raw turns | error ratio < 1% over 10m |
-| `session_context_assembly_ms` | histogram | Wall time to assemble a stubbed working set | p95 < 50ms, p99 < 150ms |
-| `pending_events` | gauge | Tool events not yet flushed into a chain | drains toward 0; auto-flush at 10 |
+- Page when raw expansion fails for more than 5% of attempts over five minutes. Users can lose tool
+  evidence.
+- Warn when pending events stay far above the auto-flush threshold for ten minutes while no segments
+  are created. The assembler is stalled or starved.
+- Warn when compression collapses below its gate after a config/model change, but do not page if raw
+  recovery and latency remain healthy.
 
-## Alert Rules
+Use the metric names emitted by `session_context_status`; do not copy a PromQL name into deployment
+alerts until the exporter exposes it with that exact prefix and labels.
 
-### 1. RebuildBacklog: auto-flush falling behind
+## Roll back
 
-Fires when pending (un-stubbed) tool events accumulate faster than they are
-flushed into chains, i.e. the assembler is not keeping up with ingestion.
+Disable `session.virtual_context.enabled` and restart the server. Raw turns remain the source of
+truth, so rollback trades token savings for direct context without deleting session data.
 
-```promql
-# pending_events is the per-session gauge exposed by session_context_status
-(
-  rate(session_context_segments_total[5m]) == 0
-  and
-  avg_over_time(aimee_session_context_pending_events[5m]) > 200
-)
-for: 10m
-labels:
-  severity: warning
-annotations:
-  summary: "Virtual-context rebuild backlog growing"
-  description: "Pending tool events > 200 for 10m while no segments are being emitted. Auto-flush is stalled; expect raw-turn fallback or memory pressure."
-```
-
-**Rationale.** A sustained non-zero pending queue with zero segment emission
-means the flusher is wedged or starved. 10 minutes survives a normal burst
-(model round-trips, GC pauses) but catches a real regression before the queue
-grows unbounded. The auto-flush threshold is 10 pending events
-(`AUTO_FLUSH_THRESHOLD`), so a steady-state queue of 200 is well above normal.
-
-### 2. ExpandFailure: raw recovery is failing
-
-Fires when lazy expansion of a stub back into raw turns returns `ok=false`
-at an elevated rate, meaning the recovery path itself is broken.
-
-```promql
-(
-  sum(rate(session_context_expand_total{result="error"}[5m]))
-  /
-  sum(rate(session_context_expand_total[5m]))
-) > 0.05
-for: 5m
-labels:
-  severity: critical
-annotations:
-  summary: "Virtual-context expansion error rate > 5%"
-  description: "More than 5% of session_context_expand calls have failed over the last 5 minutes. Raw-turn recovery is broken; affected sessions will see missing tool output."
-```
-
-**Rationale.** Expansion only runs when a model request needs the raw tool
-output, so a high error rate here directly degrades response quality. 5% over
-5 minutes is well above the natural noise floor (<0.1%) and short enough to
-page before users hit multiple broken expansions per session.
-
-## Rollback
-
-The feature is gated by `session.virtual_context.enabled` in the active
-`aimee.yaml` (under the aimee home dir / `AIMEE_HOME`). Set it to `false` and
-restart the server; every session reverts to raw turns on the next request.
-The flag is read at the chain/assembly boundary, so already-recorded events
-remain queryable and **raw turns stay the source of truth, with no data loss**.
-The only cost is the temporary loss of token savings while a regression is
-investigated.
+Before re-enabling, reproduce expansion, backlog, and assembly latency with the failed session shape.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,166 +1,57 @@
 # Personas
 
-A **persona** is the primary agent's identity, its system-prompt voice, craft
-principles, session-brief hints, the delegate roles it advertises, and its
-**delegate policy**. Personas are server-owned and user-extensible: aimee ships
-nine built-ins and seeds them as editable files, and you can add your own.
+A persona is a named review or working perspective. It changes instructions and preferences, not
+capabilities, credentials, tools, or workspace authority.
 
-## Built-in personas
+Built-in personas cover engineering, architecture, security, QA, review, contrarian review, and
+technical writing. List the running catalog instead of relying on a copied count.
 
-| Persona | Role | Delegate policy |
-|---|---|---|
-| `engineer` (default) | Autonomous software engineer | **full**, must delegate multi-file/infra/parallel work |
-| `novel` | Fiction author / worldbuilder | **readonly**, writes prose itself; read-only delegates only (continuity, beat-check, review) |
-| `songwriter` | Songwriter / lyricist | **none**, does all the work itself; no delegates |
-| `qa` | Senior QA / test reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
-| `security` | Senior application-security reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
-| `reviewer` | Senior **contrarian** code reviewer (thorough, comprehensive) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
-| `reviewer-constructive` | Senior **constructive** code reviewer (assess as written) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
-| `architect` | Software-architecture reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
-| `technical-writer` | Senior technical writer / documentation reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
+## Contents
 
-The six reviewer personas (`qa`, `security`, `reviewer`,
-`reviewer-constructive`, `architect`, `technical-writer`) reframe the agent as a read-only senior
-reviewer: it investigates and surfaces findings with evidence, never editing the
-code. They share a common **Review Principles** block and each carry their own
-review methodology. `reviewer` and `reviewer-constructive` are a deliberate pair
-,  the former is adversarial (tries to refute), the latter assesses the work as
-written, so a roundtable panel can blend both stances. `technical-writer`
-judges the documentation of a change — accuracy against the code, completeness,
-clarity, runnable examples — and is an eligible seat on the default `build`
-workflow's documentation gate. It writes and reviews to a human standard:
-brevity first, and machine-sounding prose (AI clichés, filler, padded
-sentences) is itself a finding.
+A persona can define:
 
-## Where personas live
+- name and short purpose;
+- principles and review lens;
+- expected evidence and output shape;
+- role preferences;
+- optional model/agent routing hints.
 
-Single markdown files, resolved project → user → built-in:
+Keep it specific. “Be thorough” is not a persona. “Check trust-boundary changes, negative auth tests,
+and secret handling” is.
 
-- Project: `<project>/.aimee/personas/<name>.md`
-- User: `~/.config/aimee/personas/<name>.md`
-- Built-in fallback
-  (engineer/novel/songwriter/qa/security/reviewer/reviewer-constructive/architect/technical-writer)
+## Use
 
-`aimee init` seeds the built-ins as editable files under
-`~/.config/aimee/personas/` (idempotent, it never overwrites an existing file),
-so they are self-documenting starting points you can copy and edit.
-
-## File format
-
-YAML frontmatter + markdown sections:
-
-```markdown
----
-name: noir-detective
-description: Hard-boiled detective narrator
-delegates: readonly          # full | readonly | none  (default: full)
-roles: [continuity, beat-check, review, research]
-check_role: continuity       # done-gate delegate for `aimee manuscript check`
-check_marker: CONTINUITY      # verdict stem (CONTINUITY: PASS|FAIL)
----
-## Persona
-You are a hard-boiled detective novelist working in %s.
-Write in terse, atmospheric first-person...
-
-## Principles
-# Craft Principles
-- Keep the voice clipped and cynical...
-
-## Brief
-- Recall the case facts before writing a scene.
+```bash
+aimee delegate review --persona security "Review the current diff"
+aimee delegate code --persona engineer "Implement this accepted slice"
 ```
 
-- `%s` in **Persona** is replaced with the working directory.
-- All sections and frontmatter keys are optional; sensible defaults apply
-  (an unknown persona resolves to `engineer`; an omitted `delegates` is `full`).
+Delegate commands require a persona where the help says so. A persona used with a write role still
+needs normal write authority.
 
-## Delegate policy (config-controlled)
+## Roundtables
 
-The `delegates` frontmatter key controls whether and how the agent may use
-`aimee delegate`. It is enforced two ways, a strong instruction in the agent's
-prompt, **and** a hard refusal at the command:
+Roundtable presets assign personas to seats. The seat then pins a model or selects a random eligible
+review agent. The persona is the lens; the seat/model is the identity that ran it.
 
-- **`full`**, the agent is told it MUST delegate multi-file changes,
-  infrastructure, deployments, and parallel work. All roles allowed.
-- **`readonly`**, the agent does writing/editing itself and may use **read-only
-  delegates only** (review/checks). `aimee delegate <write-role>` is refused.
-- **`none`**, `aimee delegate` is refused entirely; the agent does all work
-  itself.
+Workflow `gate.roundtable` names a preset and can require particular personas. If the panel cannot be
+formed, the gate parks rather than lowering quorum silently.
 
-In every persona the **Agent tool is disabled** (it is removed from the agent's
-toolset); aimee delegates are the only sub-agent mechanism.
+## Custom personas
 
-## Using a persona
+Store custom persona files in the configured persona directory and manage them through the browser
+or typed persona API where available. Validate the name, keep files private when they contain
+organization policy, and version changes that affect workflow review.
 
-- **From the CLI:** `aimee persona use <name>` switches the session's persona;
-  `aimee persona list` shows the available personas. (The `/persona` slash command
-  lived in the OpenCode TUI bridge, which has been removed.)
-  `/engineer`, `/novel`, `/songwriter` are aliases. The persona is stored
-  per-session on the server.
-- **In webchat:** the persona is per-session too. The webchat server exposes
-  `GET /api/chat/personas` (the selector list) and `GET`/`POST /api/chat/persona`
-  (read / set the session's persona), proxied to aimee-server's `/v1` API over
-  its Unix socket. A set persona is sticky for that browser session, so both the
-  chat system prompt and delegate-policy enforcement honor it, exactly like a
-  TUI session.
-- **Durable default:** `aimee init --novel` / `--songwriter` sets the default
-  persona for the install (written to `~/.config/aimee/mode`).
-- **Inspect:** over the V1 API (below), `GET /v1/personas`.
+Do not put credentials, private user data, or unbounded project context in a persona.
 
-## Assigning a persona to a delegate (required)
+## Design rules
 
-Every delegate runs **as a persona**; it is **required**, not optional. The
-persona sets the delegate's identity and principles; for a non-engineer
-built-in or a custom persona, its identity prose (the "You are …" body) is
-layered onto the role template, so e.g. a `review` delegate run as `security`
-reviews with the security reviewer's methodology rather than the generic
-engineer framing.
+- one clear lens per persona;
+- observable evidence requirements;
+- no claims of authority the runtime does not grant;
+- no provider-specific tricks unless the persona is explicitly provider-bound;
+- stable names for workflow and roundtable references;
+- short enough to leave room for the actual task and evidence.
 
-- **CLI:** `aimee delegate <role> --persona <name> "prompt"`. Omitting
-  `--persona` is an error. An unknown persona name warns and falls back to the
-  engineer principles.
-- **MCP `delegate` tool:** `persona` is a **required** property alongside `role`
-  and `prompt`.
-
-The persona name resolves from the built-ins or a user-level persona file (the
-same set as the rest of the persona surface). The delegate's *role* still
-governs tool access and write capability; the *persona* governs its identity and
-principles, and they compose.
-
-## Personas in roundtables and workflows
-
-A **roundtable** review panel is staffed by personas: each panelist is a persona
-run on a delegate model, and the panel pairs personas to models reproducibly run
-to run (the contrarian `reviewer` and constructive `reviewer-constructive` make a
-natural adversarial/constructive split). The default review panel is
-`security`, `architect`, `qa`, `reviewer`.
-
-In a [workflow](WORKFLOWS.md), a `gate.roundtable` step names its panel by
-persona, and any action step can be assigned a persona/delegate pair:
-
-```yaml
-- id: review
-  block: gate.roundtable
-  params:
-    panel:
-      required: [security, architect, qa, reviewer]
-    quorum: 4
-```
-
-The webchat **Workflows** tab includes a persona manager (create/edit personas)
-and a per-step persona picker, both backed by `/api/chat/personas`. So the same
-eight built-ins, plus any you add, are the vocabulary for chat identity,
-delegate assignment, roundtable panels, and per-step workflow roles alike.
-
-## V1 HTTP API
-
-Personas are reached over aimee-server's `/v1` HTTP API (Unix socket
-`~/.config/aimee/aimee-http.sock`), clients never read the files directly:
-
-| Method & path | Returns |
-|---|---|
-| `GET /v1/personas` | list (`name`, `description`, `builtin`) |
-| `GET /v1/personas/<name>` | full persona (roles, check_role, check_marker, delegates, builtin) |
-| `GET /v1/persona` | the active durable-default persona |
-| `GET /v1/sessions/<id>/persona` | the session's persona (else durable default) |
-| `POST /v1/sessions/<id>/persona` `{"name":...}` | set the session's persona |
+See [Delegates](DELEGATES.md) and [Roundtables](ENSEMBLE.md).

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -1,217 +1,83 @@
-# Retrieval Stack: Embedding + Reranking
+# Retrieval stack
 
-aimee's semantic memory, KB document/code RAG, and deep-curator vector stores
-all share a **single embedder per deployment**. There is no two-tier (fast +
-deep) arrangement, one model embeds everything, and every vector column is
-sized to that model's output dimension.
+Retrieval is hybrid. Lexical, dense, graph, code, scope, recency, and confidence signals produce a
+candidate set; optional reranking and synthesis refine it.
 
-Retrieval is a **hybrid vector-graph**, not a vector store. Vector recall is fused with a
-typed knowledge graph (entities, relations, PageRank) and, for code, the call graph, plus a
-lexical BM25 signal, and the signals are combined by reciprocal-rank fusion (`memory_bm25_weight`,
-`semantic_weight`, and the `code_hybrid_weight_*` knobs). The embedder below feeds the vector
-half; the graph and lexical halves run beside it. That fusion is what lets recall cross a
-keyword gap or a repo boundary that plain vector search would miss.
-
-## The embedder
-
-Embedding and reranking are served by the `aimee-llm` container (Qwen3-Embedding + an
-Ettin cross-encoder reranker) over HTTP (`/embed`, `/embed_batch`, `/rerank` on
-the gateway `:8742`). The KB calls them; it runs no model. See
-[AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md) for the tiers and
-[KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md) for pointing the KB at one. (The reranker emits a
-scalar score, so its size is a quality choice, not a dimension constraint.)
-
-Two embedding widths ship:
-
-| `AIMEE_LLM_TIER` | Embedder (`embedding_dim`) | Reranker |
-|------|----------------------------|----------|
-| `cpu` | Qwen3-Embedding-0.6B (`1024`) | ettin-68m |
-| `small` / `mid` / `large` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
-
-The 4B/2560 tier has better recall on large or meaning-heavy corpora; the 0.6B/1024 tier is
-the low-footprint default. The retrieval pipeline (hybrid search, reranking, fusion) is
-identical either way. Only the model sizes differ.
-
-### Switching tiers
-
-Switch by setting `AIMEE_LLM_TIER` on the `aimee-llm` container (one model-less image; the
-new tier downloads on first boot) and setting the width to match:
-
-```bash
-AIMEE_LLM_TIER=small       # cpu | small | mid | large
-AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
+```text
+query -> normalize/rewrite -> parallel candidate sources -> fuse
+      -> evidence build -> rerank -> confidence/abstain -> optional synthesis
 ```
 
-All GPU tiers are 2560-dim, so moving between `small`, `mid`, and `large` needs no re-embed.
-Moving between 1024 and 2560 is a model-identity **and** width change: on an **empty** DB
-just set the dim; on a **populated** one it's a drop-and-rebuild re-embed (the `halfvec`
-columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces. See
-[Switching embedders on an existing database](#switching-embedders-on-an-existing-database).
+No stage may claim it ran when its dependency was unavailable. Degraded results state which signals
+were used.
 
-## Configuration
+## Embedding
 
-Two config keys define the embedder:
+One embedder identity and dimension applies to a deployment. The KB stores derived vectors in DB2;
+`aimee-llm` serves the model.
 
-- `embedding_command`, the command that produces embeddings.
-- `embedding_dim`, the dimension that command emits (1024 for the default image,
-  2560 for the 4b image; any value for a custom-built image). This is the
-  single source of truth for vector-column dimensions.
+The standard tiers use:
 
-Keep the two in sync: `embedding_dim` must equal the dimension
-`embedding_command` actually returns, or vector inserts will be rejected by
-Postgres.
+| Tier | Embedding width | Reranker |
+| --- | ---: | --- |
+| CPU | 1024 | small cross-encoder |
+| GPU tiers | 2560 | larger cross-encoder |
 
-`AIMEE_EMBEDDING_DIM` overrides `embedding_dim` from the environment, useful for
-a containerized deploy with no writable `aimee.yaml` (set it alongside
-`AIMEE_EMBEDDER_IMAGE` when pinning the 0.6b tier: `AIMEE_EMBEDDING_DIM=1024`).
+Check [Inference tiers](AIMEE_KB_SYNTH_TIERS.md) for the current model names and hardware estimates.
 
-## How the dimension flows into the schema
+The configured dimension must equal the model output. DB2 records the dimension used to create its
+vector columns and refuses startup on drift. Silent empty vector search is worse than a hard start
+failure.
 
-The DB2 schema (`src/db2/schema.sql`) declares its embedding columns with a
-`halfvec(__EMBED_DIM__)` placeholder rather than a hard-coded dimension:
+## Changing dimension
 
-```sql
-CREATE TABLE IF NOT EXISTS memory_embeddings (
-    point_id  BIGINT PRIMARY KEY,
-    embedding halfvec(__EMBED_DIM__),
-    ...
-);
-```
+A same-dimension model change can re-embed in place. Moving between 1024 and 2560 requires rebuilding
+the dimensioned vector tables from source rows.
 
-At startup the server / aimee-kb call `db2_set_embedding_dim(cfg.embedding_dim)`
-(from the loaded config) before `db2_init()`. When `db2_init()` applies the
-schema, `db_apply_schema_postgres()` substitutes the placeholder with the
-configured dimension, the one place the schema is materialized, so every
-`halfvec` column (`memory_embeddings`, `kb_embeddings`, and the
-`curator_*_vectors` tables) is created at the right size. An unset or
-out-of-range value falls back to the `1024` default (the default embedder is the
-0.6B) rather than emitting invalid DDL.
+Before changing it:
 
-`halfvec` (fp16) is used throughout: it halves index memory versus `vector`
-(fp32) at negligible recall cost, and it lifts the index dimension ceiling from
-2000 to 4000, required for the 4B's 2560 dims. This needs pgvector ≥ 0.7 (the
-version bundled in `aimee-kb` satisfies it); older pgvector caps at 2000.
+1. back up DB2;
+2. stop KB writers;
+3. record the old model, dimension, and row counts;
+4. drop only the derived vector tables named by the migration/runbook for that build;
+5. clear the recorded schema dimension in the same transaction;
+6. set the new model and dimension;
+7. start the KB and let backfill finish;
+8. compare source counts, vector counts, recall, and latency before reopening traffic.
 
-The code-side embedding buffers are sized by `EMBED_MAX_DIM` (2560 in
-`src/headers/aimee.h`), large enough to hold either model's output; the embed
-helpers store whatever dimension the embedder actually returns.
+Do not merely delete vector rows. The PostgreSQL column still has its old dimension. Do not clear the
+dimension marker without rebuilding the columns.
 
-### The dimension-drift guard
+Use the checked-in migration for the exact table list. Hand-written lists go stale as new evidence
+tables are added.
 
-Sizing the columns at one dimension and then *serving* queries at another is the
-worst failure mode: queries embed at the new dimension, the corpus is stored at
-the old one, and vector search silently returns nothing, no error, just empty
-results. To make that impossible, the first schema-apply records the dimension it
-materialized the columns at in a small `kb_meta(key, value)` table
-(`schema_embedding_dim`), and every later apply checks against it.
+## Fusion
 
-`db_apply_schema_postgres()`, right after the DDL applies, calls
-`db2_embedding_dim_record_or_check()`. That function first rejects a non-positive
-configured dimension, returning an error *before* it touches `kb_meta`, so an
-invalid dimension can never be written as the authoritative value, and then
-performs a single atomic statement:
+Lexical search covers exact names and identifiers. Dense search bridges wording. Entity and code
+graphs carry structure. Reciprocal-rank or the configured fusion mode combines ranked lists without
+pretending their raw scores share one scale.
 
-```sql
-INSERT INTO kb_meta (key, value) VALUES ('schema_embedding_dim', :dim)
-  ON CONFLICT (key) DO UPDATE SET value = kb_meta.value
-  RETURNING value;
-```
-
-The `DO UPDATE SET value = kb_meta.value` clause deliberately writes the existing
-value back unchanged (not `EXCLUDED.value`), so on a row that already exists the
-recorded dimension is *preserved* and `RETURNING` yields it; on a fresh row the
-just-inserted dimension is returned. The function then compares that returned
-value to the configured dimension:
-
-- **First apply**, no row yet: the configured dimension is inserted and
-  returned, so it matches; the apply succeeds.
-- **Matching apply**, the recorded dimension equals the configured one: no-op,
-  the apply succeeds.
-- **Mismatch**, the recorded dimension differs: the function returns an error,
-  so `db2_init()` fails and the server/kb refuses to start, with a remediation
-  message naming both dimensions and pointing at the migration procedure below
-  ("Switching embedders on an existing database").
-
-Because the record-and-read is one atomic upsert, there is no SELECT-then-INSERT
-window: a deployment is never able to record one dimension while another is
-already stored, so a misconfigured second start reads the committed dimension and
-is refused rather than silently proceeding at the wrong dimension. If the
-`kb_meta` value is ever corrupt or non-numeric (e.g. hand-edited), the function
-returns an error reporting it for manual repair rather than silently treating it
-as "no recorded dimension" and overwriting it. The check is written against the
-`aimee_pg_*` abstraction layer, so the same logic runs on Postgres in production
-and is exercised against the SQLite test shim; see
-`src/tests/test_embedding_dim.c`.
-
-## Switching embedders on an existing database
-
-`db2_init()` never reshapes an existing column (a routine schema-apply must not
-touch the corpus). Changing `embedding_dim` against a populated database to a
-**different dimension** is now refused at startup by the dimension-drift guard
-above, the server/kb will not come up until the corpus and the config agree,
-precisely because the alternative (booting and serving) silently breaks search.
-Switching dimension (0.6b 1024 ⇆ 4b 2560) therefore requires **re-embedding** the
-corpus at the new dimension. Note that the schema-apply uses
-`CREATE TABLE IF NOT EXISTS`, so it will **not** alter an existing table, simply
-deleting the vector *rows* leaves the `halfvec` columns at their old dimension. To
-move the dimension the dim-sized tables must be **dropped** so the next
-schema-apply recreates them at the new `embedding_dim`. Each one is a derived
-embedding/index table (a `point_id` key plus the `halfvec` vector and denormalized
-lookup columns); their contents are rebuilt by re-embedding from the source rows
-(`kb_documents`, memories, code units, and the curator artifacts), so dropping
-them loses only the derived vectors, not the source corpus.
-
-Back up DB2 first, then, with the kb **stopped** (so nothing reads or rewrites the
-columns mid-migration):
-
-1. Set the new `embedding_dim` (config or `AIMEE_EMBEDDING_DIM`).
-2. In a single transaction, drop every dim-sized table and clear the recorded
-   dimension so the next start re-records it:
-
-   ```sql
-   BEGIN;
-   DROP TABLE IF EXISTS
-       kb_embeddings,
-       memory_embeddings,
-       code_embeddings,
-       curator_entity_vectors,
-       curator_narrative_vectors,
-       curator_claim_vectors,
-       curator_code_unit_vectors,
-       evidence_vectors,
-       exemplar_vectors;
-   DELETE FROM kb_meta WHERE key = 'schema_embedding_dim';
-   COMMIT;
-   ```
-
-   (Drop the tables and clear `schema_embedding_dim` together: leaving the row set
-   makes the next start refuse, while clearing it without dropping the tables would
-   re-record the new dimension against columns still sized at the old one, exactly
-   the drift the guard exists to prevent.)
-3. Start the kb. With the tables gone the schema-apply recreates them at the new
-   `embedding_dim`, and with the `kb_meta` row gone the guard treats this as a
-   first apply and re-records the new dimension. The curator drain then re-embeds,
-   backfilling any source row missing a vector.
-
-Chunk text and `file_contents` are untouched throughout. A same-dimension
-`vector → halfvec` change is different: it only needs an in-place cast
-(`deploy/migrations/2026-embed-halfvec.sql`) and leaves `schema_embedding_dim`
-unchanged, since the dimension has not moved.
+Scope and authorization apply before candidates reach the result. A later filter is not sufficient
+because ranking and timing can leak excluded data.
 
 ## Reranking
 
-An optional cross-encoder reranker refines the top-k of a recall before it is
-returned. It is served by the same `aimee-llm` container and sized to match the embedder: the
-GPU tiers (`small` / `mid` / `large`) use `cross-encoder/ettin-reranker-400m-v1`; the `cpu`
-tier uses ettin-68m. Each is a pre-converted encoder GGUF + Dense head the container downloads
-on first boot per `AIMEE_LLM_TIER` (published by `publish-rerank-artifacts.yml`).
+The cross-encoder scores `(query, candidate)` text pairs and does not depend on embedding dimension.
+It runs on a bounded top-k after fusion. If unavailable, the response returns the fused order and an
+explicit degradation signal.
 
-It is configured independently of the embedder dimension:
+## Evidence and abstention
 
-- `memory_rerank_enabled`, master toggle.
-- `memory_rerank_command`, the reranker command (the Ettin cross-encoder served
-  by the inference gateway, via `rerank-remote.py`).
-- `memory_rerank_mode`, `memory_rerank_top_k`, strategy and depth.
+The evidence builder keeps source IDs, spans/pages, relationship paths, freshness, and score
+components. Confidence considers coverage and contradictions, not only the top similarity score.
 
-The reranker is dimension-agnostic, it scores `(query, candidate)` text pairs
-directly and is unaffected by the embedder choice above.
+A weak or conflicting set may return an abstention. Optional synthesis receives the bounded evidence
+and must cite it.
+
+## Configuration and checks
+
+Use the [generated configuration](gen/configuration.md) for embedder URL, dimension, fusion,
+reranking, top-k, and evidence gates.
+
+After a retrieval change, run lexical-only, dense-only, fused, degraded, scope-negative, dimension
+drift, and benchmark cases. Record corpus hash, model identity, config, and latency with the result.

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -1,143 +1,55 @@
-# Runbook: cut over to the unified `aimee-llm` container
+# Cut over to `aimee-llm`
 
-The unified-llm-container migration (P7). **Operator-gated**: the production flip
-(deploy + corpus re-embed) is a deliberate maintenance op, never automatic. P1–P6 ship the
-pieces; this runbook is the order of operations + the gates.
+This maintenance operation moves embedding, reranking, and synthesis to the unified inference
+service. A model or embedding-width change requires controlled corpus re-embedding.
 
-Validated before this runbook (`.253`/`.254`, see `benchmarks/results/unified-llm/`):
-the images build, serve `/embed`+`/rerank`(ettin encoder + gateway
-head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 99`).
+## Gate in staging
 
-> **Naming update (post-cutover):** the images built here were renamed
-> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small` (+ `gpu-mid`/`gpu-large`),
-> and have since been **collapsed back into one model-less `aimee-llm` image**: the tier is
-> chosen at runtime via `AIMEE_LLM_TIER` (`cpu`/`small`/`mid`/`large`) and the models download
-> on first boot — there are no baked per-tier images anymore. The steps below keep the original
-> names as a record; for the current image, tiers, and env knobs see
-> [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
+- pin the image and model digests;
+- reproduce the old retrieval baseline on the real corpus;
+- require the new stack to meet the declared nDCG/MRR/rank-agreement floor;
+- verify structured curator output, degradation, restart, and mixed-load slot stability;
+- rehearse forward and rollback migrations from a fresh database restore.
 
-## 0. What changes
+Do not cut over after a failed quality gate.
 
-- **From:** torch `aimee-embedder` (pplx-embed + ettin via sentence-transformers) + the
-  stock `llm` llama.cpp container (gemma synth).
-- **To:** one model-less `aimee-llm` image: Vulkan llama.cpp serving embed
-  (Qwen3-Embedding) + rerank (ettin encoder + the gateway Dense head) + synth (gemma). The
-  tier (`AIMEE_LLM_TIER`) selects the models, which download on first boot into `/models`.
-- **Corpus re-embed required:** `pplx-embed` → `Qwen3-Embedding` is a **`model_id` change**
-  (and 0.6B→1024 / 4B→2560 a possible **dim** change), so the `kb_meta` drift guard (P1,
-  now activated, `db2_set_embedder_model_id`) will **refuse** to serve the new embedder
-  against the old corpus. The re-embed is the controlled drop-and-rebuild below.
+## Prepare
 
-## 1. Pre-cutover ship-floor gate (staging, BEFORE the production flip)
+1. Back up DB2 and verify the backup.
+2. Record source/vector row counts, model identity, dimension, config, and baseline queries.
+3. Put KB writes into maintenance.
+4. Start `aimee-llm` on the deployment network with the chosen tier.
+5. Probe the exact model identity and embedding dimension at the URL the KB will use.
 
-The ship-floor gate is a **pre-cutover precondition** (proposal §2): the new
-embed+rerank+fusion stack must hit **≥95%** of the pplx/ettin baseline (nDCG@10 / MRR@10 +
-top-k rank-agreement ≥0.95) on the real corpus, in staging, against the checked-in fixture
-`tests/fixtures/pplx_baseline.json`. **Gate fail → freeze, investigate, do NOT cut over.**
-Because the gate is upstream of the cutover, pplx/ettin is removed *completely* in the
-release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollback (§5).
+An internal unauthenticated inference endpoint must remain private. Use service auth before exposing
+it beyond the trusted deployment network.
 
-## 2. Build + publish the images
+## Re-embed
 
-CI builds + publishes the **one** model-less `aimee-llm` image as part of the normal cycle
-(no per-tier images — the tier is a runtime env, not a build):
-- **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds `aimee-llm`
-  on every release and tags it `:<version>` + `:latest`. It is in both the `build` and `merge`
-  matrices; the merge step applies the tags. Multi-arch amd64+arm64 (the llama.cpp Vulkan
-  tarball is TARGETARCH-mapped in the Dockerfile).
-- **testing:** `.github/workflows/publish-llm-testing.yml` builds `aimee-llm` on `testing`
-  pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts, tagged `:testing`
-  (+ `:testing-<sha>`, amd64).
-- **rerank artifacts (automatic):** `.github/workflows/publish-rerank-artifacts.yml` converts
-  the ettin rerankers and uploads them to the `rerank-artifacts-v1` GitHub release, which the
-  supervisor fetches on first boot. Both publish workflows above CALL it as a prerequisite
-  (`needs`), so a container image is never published without the release existing — no manual
-  step. It is idempotent: the expensive conversion runs only when an asset is missing (first
-  run, or after you delete the release / dispatch it with `force=true` to bump the reranker);
-  every other run just confirms the assets are present and skips.
+Use the checked-in migration/runbook for the exact derived vector tables:
 
-To build out-of-band (e.g. on a PVE CT with docker) — one model-less image, no model build-args:
+1. drop and recreate the dimensioned derived tables in one controlled migration;
+2. update the recorded model identity and dimension only with the schema change;
+3. replay source rows through the new embedder in bounded batches;
+4. keep the KB degraded/maintenance until parity passes.
 
-```
-docker build -f Dockerfile.aimee-llm -t aimee-llm .
-# then at run time pick the tier:  docker run -e AIMEE_LLM_TIER=small ... aimee-llm
-```
-(The tier selects the models the supervisor downloads on first boot; see the tiers doc.)
+Deleting rows alone does not change a PostgreSQL vector column's dimension.
 
-## 3. Deploy to `.254` (tierd / LXC, GPU)
+## Verify
 
-`.254` runs containers via **tierd** (LXC), not raw docker, with GPU passthrough via the
-Vulkan/RADV render path (**not** ROCm/`kfd`). Deploy the GPU image as a tierd plugin
-(manifest-swap, per the `.254` deploy memory) + `AIMEE_LLM_NGL=99`. The in-repo manifest is
-`deploy/smoothnas/aimee-llm.plugin.yaml` (pin its image to `:testing` for staging,
-`:latest`/`:<version>` for production). GPU passthrough uses the **built-in `gpu-amd`
-profile** (compiled into tierd, the one Wolf/Steam use), so there is no custom profile to
-install and no node path to pin; verified on .254 the container enumerates `Vulkan0 : AMD
-Radeon Graphics (RADV GFX1100)` and offloads to VRAM. The gateway is host-published on
-**:8742** (NOT :8080, since Wolf's WolfLeash UI host-publishes 8080, and two plugins on one host
-port silently collide: the runtime DNATs both, one wins and the other is unreachable though
-"running"). Point the kb at it: `AIMEE_EMBEDDER_URL=http://10.100.0.1:8742` (the gateway preserves the
-`/embed`+`/embed_batch`+`/rerank` contract, so `embed-remote.py`/`rerank-remote.py` are
-untouched). Set the kb's `embedding_model` to the new identity (activates the P1 guard) and
-`embedding_dim` to the tier's dim (2560 for the 4B GPU tier). **Verify the URL actually
-serves the named model before re-embedding**: a misrouted `AIMEE_EMBEDDER_URL` (still
-pointing at the old embedder) would silently embed under the new identity and the guard
-would not catch it (it checks identity-vs-corpus, not URL-vs-identity). **Auth on the embed
-path:** the kb embeds/reranks with NO bearer (`memory_embed_http_post` sends a NULL auth
-header), so when this gateway backs `AIMEE_EMBEDDER_URL` it MUST run **auth-off**: leave
-`AIMEE_LLM_AUTH_TOKEN` empty/unset. The gateway treats an empty token as "auth disabled,"
-acceptable here because it is `expose:false` (internal bridge only; deployment network is the
-boundary). Only set `AIMEE_LLM_AUTH_TOKEN` when the gateway serves *only* bearer-capable
-callers (e.g. curator `tier_b` synth); if so it comes from the secret store (vault / Docker
-secret / `.gitignore`d per-host `.env`), **never a checked-in plaintext value**.
+- source and vector counts match expected coverage;
+- every vector has the new dimension and no NaN/all-zero value;
+- sampled source IDs map to the correct vector rows;
+- baseline recall stays above the quality gate;
+- reranking and synthesis identify the intended models;
+- a killed inference child produces explicit degradation and recovery;
+- queue backlog drains after restart;
+- latency and resident memory remain within the tier budget.
 
-## 4. Corpus re-embed (controlled drop-and-rebuild, the `maintenance` window)
+## Roll back
 
-In-place `halfvec` type changes against a live kb are forbidden. The migration:
+Rollback needs the old service image/model and a reverse re-embed from source or verified snapshot.
+It is another maintenance operation, not an environment toggle. Keep the old image and snapshot for
+the same declared window and rehearse the reverse path before production cutover.
 
-1. **Snapshot** the current vector tables.
-2. Gate the kb to **`maintenance`**.
-3. **Drop** the dim-sized `halfvec` tables; **recreate** at the new `(model_id, dim)` (the
-   schema applies at the new dim; `db2_embedding_model_record_or_check` records the new
-   identity on the fresh `kb_meta`).
-4. **Replay** the source rows through the new embedder (bounded batch).
-5. **Parity gate:** pre-drop vs post-backfill counts must match **and** a sampled
-   value-check must pass (row counts alone miss silent corruption: wrong rows re-embedded,
-   off-by-one batch, wrong prompt template, a dim swap). Over a held-out sample (≥1% or 10k
-   rows, whichever is larger): every vector has the expected `array_length`, no NaN/all-zero
-   rows, and, where a stable subset is re-embeddable from the snapshot, cosine vs the
-   snapshot is within tolerance for the *same* model (and `kb_meta.schema_embedder_model_id`
-   is the new identity). Any divergence → `degraded`, hold. On parity → lift `maintenance`.
-
-Plan the window from the corpus size × the new embedder's throughput (record peak RSS per
-inner `llama-server`; the embed model is offloaded so it's GPU-bound).
-
-## 5. Rollback (one-time safety net, initial cutover only)
-
-The ship-floor gate (§1) means a regression never ships. If a post-cutover issue still
-demands it: deploy-tag **rollback to the prior release tag** (which still contains
-pplx/ettin) **+** the **reverse re-embed** (a checked-in, idempotent schema-revert migration
-restoring the prior dim-sized `halfvec` from the §4 snapshot, CI round-tripped before
-cutover). This is a gated maintenance op, not an instant toggle. Once the first
-post-cutover release is validated, no prior tag contains pplx/ettin and rollback is no
-longer deploy-tag-based; retain the prior tag in the registry for a defined window (e.g. 6
-months). **Snapshot retention ≥ tag retention**: the §4 snapshot is the only rollback
-input once the tag ages out, so it must outlive the tag, with a checksum and an expiry
-review. Pre-cutover checklist (all must be true before §3): snapshot present + checksum
-verified; reverse-migration **rehearsed in staging** (round-trips to the prior dim/identity);
-ship-floor gate green.
-
-## 6. Retire the old surfaces
-
-After validation: remove `Dockerfile.embedder` + the `embedder`/`llm` compose/deploy
-services + the `codex-auth`/pplx-ettin references. (Kept until here so the prior tag is a
-working rollback target, §5.)
-
-## Gates summary
-
-| Gate | When | Pass |
-|------|------|------|
-| ship-floor ≥95% | staging, pre-cutover | nDCG/MRR ≥95% of pplx fixture + rank-agreement ≥0.95 |
-| drift guard | kb startup post-deploy | `kb_meta` records the new `(model_id, dim)`; refuses a stale mismatch |
-| parity | post-re-embed | pre-drop == post-backfill counts; else `degraded` |
-| kill-a-child smoke | post-deploy | one inner llama-server killed; others keep serving |
+See [Inference tiers](../AIMEE_KB_SYNTH_TIERS.md) and [Retrieval](../retrieval-stack.md).

--- a/docs/runbooks/vault-master-key-rotation.md
+++ b/docs/runbooks/vault-master-key-rotation.md
@@ -1,90 +1,46 @@
-# Runbook: rotate the vault `.server-master.key`
+# Rotate the vault master key
 
-Rotate the server-sealed master key that protects the credential vault (D13 of the
-[cred-vault-consolidation](../proposals/done/cred-vault-consolidation.md) proposal).
-**Operator-gated, offline maintenance op**: never automatic.
+This is offline, operator-gated maintenance. It rewraps credential data keys; it does not change the
+provider secrets themselves.
 
-## 0. What this does (and does not)
+## Before
 
-The 32-byte `.server-master.key` lives `0600` beside the vault at
-`<AIMEE_HOME>/.vault/.server-master.key`. The **server KEK** is HKDF-derived from it and
-wraps every server-decryptable credential's data-encryption key (DEK):
+- stop `aimee-server` and prevent another instance from starting;
+- verify `AIMEE_HOME` and the vault are owned only by the runtime user;
+- take an encrypted, access-controlled backup of the full vault;
+- record the backup checksum and restore command;
+- confirm you can reissue provider credentials if restore fails.
 
-- the **server principal** (`server`) holds the server KEK as its **primary** wrap
-  (`wrapped_dek`). These are the shared delegate keys (minimax/mistral/glm/codex…);
-- every **user principal** that has a dual-access entry holds it in `wrapped_dek_server`.
+The server caches its key. Never rotate against a live process.
 
-Rotation mints a fresh master key and **re-wraps** those DEKs from the old server KEK to the
-new one. It is a **re-wrap, not a re-encrypt**: no credential plaintext, nonce, ciphertext or
-tag is touched, and the per-user zero-knowledge `wrapped_dek` (under a user/login KEK) is
-left untouched. Rotation defeats a leaked/suspected-compromised *master key file*; it is
-**not** key-per-credential rotation and does not change the provider secrets themselves
-(rotate those at the provider, then `aimee agent key import`).
+## Rotate
 
-Trust boundary is unchanged: the new master key is still a `0600` file on the server volume
-(no HSM/KMS), defeating backup/disk theft, not host root.
+Run as the server runtime user with the real `AIMEE_HOME`:
 
-## 1. Why it is offline
-
-`aimee-server` caches one process-wide server KEK. A *live* rotation would leave autonomous
-decrypts failing for the window between re-wrapping a credential and swapping the key. Every
-delegate would 401 mid-rotation. So rotation runs with the **server stopped**, against the
-on-disk vault, and exits.
-
-## 2. Preconditions
-
-- **Server stopped.** `--rotate-master-key` refuses to run if an `aimee-server` instance is
-  live for the default socket (the server caches the old KEK and could write a credential
-  under it during the re-wrap window; see §1). Stop the server first.
-- **`AIMEE_HOME` permissions.** The pre-rotation backup is written under `AIMEE_HOME` as a
-  `0700` directory of `0600` files, but it inherits the *parent* directory's reachability.
-  Ensure `AIMEE_HOME` is writable only by the server's runtime UID; otherwise the backup
-  (which holds old-key ciphertext) sits in a directory others can traverse.
-
-## 3. Procedure
-
-```sh
-# 1. Stop the server (so nothing reads/writes the vault during rotation).
-systemctl stop aimee-server          # or: docker compose stop aimee-server
-
-# 2. Rotate. Runs as the server's runtime user, with the same AIMEE_HOME.
-#    Backs up the whole .vault/ directory FIRST, then re-wraps, then swaps the key.
-sudo -u aimee AIMEE_HOME=/var/lib/aimee aimee-server --rotate-master-key
-
-#    Example output:
-#    aimee-server: master key rotated — re-wrapped 5 credential(s) across 1 principal(s).
-#      Pre-rotation backup: /var/lib/aimee/.vault.rotate-bak.12345
-#      Verify delegates authenticate, then remove the backup.
-
-# 3. Restart and verify a delegate authenticates from the vault.
-systemctl start aimee-server
-aimee delegate minimax "ping" --persona engineer    # or any vaulted agent
-
-# 4. Once verified, remove the pre-rotation backup (it holds the OLD-key ciphertext).
-shred -u /var/lib/aimee/.vault.rotate-bak.12345/* 2>/dev/null || true
-rm -rf /var/lib/aimee/.vault.rotate-bak.12345
+```bash
+aimee-server --rotate-master-key
 ```
 
-## 4. Safety / failure handling
+The command creates its own private pre-rotation backup, rewraps every server-decryptable data key,
+and writes the new master key last with atomic replace and sync. A present but unreadable or short
+key is an error; it is never overwritten.
 
-- **Atomic + reversible.** The entire `.vault/` is copied to `.vault.rotate-bak.<pid>` (0700)
-  **before** any mutation. If any principal's re-wrap fails (wrong key / tamper) **or** the
-  new master key cannot be persisted, the vault is **restored from that backup** and the
-  command aborts non-zero with the vault unchanged, never a new-wrapped vault under an old
-  master, nor the reverse.
-- **Crash mid-run.** The new master key is written **last** (atomic tmp+rename+fsync), only
-  after every re-wrap has succeeded. A crash before that leaves the old master + old wraps
-  intact; a crash after is a fully-rotated, consistent vault. If in doubt, restore the
-  `.vault.rotate-bak.<pid>` directory over `.vault/` and retry.
-- **Fail-closed key reads.** A present-but-unreadable/short master key is **never**
-  overwritten (it aborts), so a transient IO error cannot orphan the vault.
-- **No master key yet?** If the vault has never had a server-principal write,
-  `--rotate-master-key` reports "nothing to rotate" and exits 0 (the key is minted lazily on
-  the first write).
+## Verify
 
-## 5. Verification checklist
+1. Check exit status and the reported rewrap count.
+2. Start the server.
+3. Probe one credential from each provider/agent class.
+4. Run `aimee audit verify`.
+5. Check the new key owner, mode `0600`, and modification time.
+6. Restart once more and repeat a probe to prove the key was persisted, not only cached.
 
-- [ ] command exited 0 and reported a non-zero re-wrap count (matching your agent count);
-- [ ] `aimee delegate <agent> …` authenticates from the vault after restart;
-- [ ] `<AIMEE_HOME>/.vault/.server-master.key` mtime is fresh and the file is `0600`;
-- [ ] pre-rotation backup removed once delegates are verified.
+Keep the pre-rotation backup until all checks pass. Then remove it through the deployment's approved
+secure-retention process. It contains old-key ciphertext and remains sensitive.
+
+## Failure
+
+If the command fails, leave the server stopped. Restore the complete vault and key from one backup as
+a unit, verify permissions, then retry. Never combine a new key with old wraps or the reverse.
+
+A leaked provider credential still needs rotation at the provider followed by a vault update. Master
+key rotation alone does not revoke it.

--- a/docs/v1-op-parity-buildout.md
+++ b/docs/v1-op-parity-buildout.md
@@ -1,97 +1,35 @@
-# `/v1` op-parity buildout: route→method map and wave plan
+# `/v1` route parity
 
-> Working tracker for **P1 / WP1.x / WP1.fin** of the aimee `/v1` hub-migration plan.
-> Goal: **every NDJSON RPC method gets a dedicated `/v1` HTTP route** (or a
-> documented, deliberate exclusion). The generic `POST /v1/rpc` passthrough is
-> retired; this buildout gave each method a dedicated, self-documenting,
-> OpenAPI-listed route.
+The named `/v1` migration is complete. The generic RPC passthrough is retired.
 
-## Mechanism (already landed: WP0.2, #2531)
+## Contract
 
-The `/v1` surface is a declarative table in
-`src/server/server_http_routes.inc`. Adding a dedicated route is:
+Every public operation has:
 
-1. **One table row.** For a single-response method that takes a **JSON-object
-   body**, the row is `{"POST", "/v1/<family>/<verb>", NULL, RM_EXACT,
-   "<family>.<verb>", 0, rh_dispatch_op}`. The `op` twin both dispatches the
-   call (via the `server_dispatch` loopback bridge) **and** derives the required
-   capability from `server_capability_for_method`, so `caps` stays `0`.
-2. **One OpenAPI path** in `src/api/openapi-server-v1.yaml` (the conformance
-   gate is spec→code: every documented path must be routed; `make
-   server-api-conformance-check`).
-3. Nothing else. No bespoke handler for the common case.
+- one named route;
+- one stable operation ID;
+- declared authentication, capabilities, scope, write tier, body bounds, and execution class;
+- a handler in the owning service;
+- OpenAPI and generated reference coverage;
+- a thin-client route when the CLI exposes it.
 
-### When a row is **not** enough
+No-argument reads use `GET` where the response is a resource view. Parameterized reads and mutations
+use typed JSON bodies. Long work returns a run/job handle or uses a declared stream; it does not block
+the listener indefinitely.
 
-- **Positional `args`-array methods** (e.g. `workspace.*`) need a small bespoke
-  adapter; see `ws_dispatch_args` in the registry. Most CLI methods marshal a
-  JSON **object** (named fields / `marshal_no_args`), so they take the trivial
-  `rh_dispatch_op` row.
-- **Streaming or foreground-blocking methods** must **not** use
-  `rh_dispatch_op` (the buffered HTTP listener cannot block). These need a
-  dedicated streaming handler (cf. `/v1/chat/stream`, `/v1/runs/{id}/events`) or
-  are routed as async `runs`.
+Internal hooks, runner channels, primary-session operations, tool execution, and workflow resource
+routes have dedicated privileged paths. They are not public merely because they use `/v1`.
 
-## Path / verb convention
+## Gates
 
-- `family.verb` → `/v1/<family>/<verb>`.
-- **GET** for genuinely no-arg reads (`marshal_no_args` methods: list/status/
-  stats/board/…). `rh_dispatch_op` only reads the body, never the query string,
-  so any read that needs params is **POST** with a JSON body.
-- **POST** for all mutations and all param-bearing calls.
-- One route per RPC method. Existing dashboard read-views (`GET /v1/agents`,
-  `GET /v1/models`, `GET /v1/kb/status`, backed by `route_json_provider`) are a
-  *different* curated surface and coexist with the per-method routes below.
+```bash
+make -C src api-conformance-check
+make -C src server-api-conformance-check
+make -C src v1-method-coverage-check
+make -C src cli-v1-routes-check
+make -C src v1-route-order-check
+make -C src docs-gen-check
+```
 
-## Deliberate exclusions (NOT given a dedicated route)
-
-| Method(s) | Why |
-|---|---|
-| `hooks.pre`, `hooks.post`, `hooks.session_start` | Internal harness lifecycle hooks; now dedicated privileged routes at `/v1/hooks/*`, gated by `CAP_TOOL_EXECUTE`. |
-| `runner.poll`, `runner.respond` | Already dedicated (`/v1/runner/*`, workspace detached reverse channel). |
-| `primary.get/set/clear` | Already dedicated via `/v1/sessions/{id}/primary`. |
-| `tool.execute` | Internal tool-execution path at `/v1/tools/execute` (workspace plane); gated by `CAP_TOOL_EXECUTE`, not a public verb. |
-
-> **Inline-dispatch latency budget.** Dispatch-op routes run inline on the
-> listener thread, so any routed method blocks other `/v1` callers for its
-> duration. Sub-second and bounded-network methods (e.g. `agent.probe`,
-> `provider.test`) are fine. **Long-running / LLM methods** (`kb.build`,
-> `kb.ingest`, `kb.update`, `graph.sync_code`, `index.scan`, `memory.benchmark`,
-> `curator.synthesize`, `rules.generate`, `eval.run`) are *not* inline-dispatched;
-> they are routed **async** via `rh_dispatch_op_async`: the POST returns a
-> queued run handle and a detached worker drives the loopback RPC to completion;
-> poll status/result at `GET /v1/runs/{id}`. So they keep the listener free
-> while still being dedicated `/v1` routes.
-
-`server.health`/`server.info` and `model.list` overlap the existing
-`/v1/health`, `/v1/version`, `/v1/models` read-views; the owning wave maps them
-to the existing route (no duplicate) and notes it.
-
-## Family → wave map
-
-Counts are methods needing a *new* dedicated route (after exclusions). Each
-wave is one delegated packet (`aimee delegate code --persona engineer --verify
-"cd src && make server-api-conformance-check && make unit-tests"`), with the
-registry + handler files + `--files` preloaded. **Waves are serialized** (each
-rebased on `origin/feat/v1-op-parity`) because they all edit
-`server_http_routes.inc` + `openapi-server-v1.yaml`; parallel apply-backs to the
-same files collide.
-
-| Wave | Families | ~Methods |
-|---|---|---|
-| **1 (pattern)** | `cron.*` | 8 |
-| **2** | `delegate.*`, `job.*`, `jobs.*`, `agent.*`, `episode.list` | ~25 |
-| **3** | `provider.*`, `model.*`, `api.*` | ~15 |
-| **4** | `dashboard.*`, `insights.overview`, `identity.*`, `dogfood.*`, `lsp.diagnostics_summary` | ~17 |
-| **5** | `kb.*`, `curator.*`, `graph.*`, `memory.benchmark`, `index.scan`, `trajectory.batch` | ~12 |
-| **6** | `work.*`, `wm.*`, `skill.*`, `session.*`, `toolset.resolve`, `rules.generate`, `blast_radius.preview`, `mcp.*`, `workspace.context`, `worktree.gc`, `aux.test`, `eval.*`, `trigger.*`, `init.run`, `launch.run` | ~40 |
-
-(Method shapes, object vs positional-args vs streaming, are confirmed by the
-owning delegate against the preloaded handler; the default is the trivial
-`rh_dispatch_op` row.)
-
-## WP1.fin: coverage gate
-
-After the waves, add a conformance gate that walks `server_dispatch_table[]` and
-asserts every method has a `/v1` route **or** is on the exclusion list above,
-so parity can never silently regress. Wire into `make lint`.
+A new operation lands only when descriptor, handler, OpenAPI, client exposure, auth tests, and
+generated docs agree.

--- a/docs/wfe-autonomy-runbook.md
+++ b/docs/wfe-autonomy-runbook.md
@@ -1,23 +1,38 @@
-# WFE Autonomy Runbook
+# Workflow autonomy runbook
 
-The WFE (Workflow Engine) autonomous lifecycle turns a written proposal into a
-merged change with no operator in the loop. When a proposal is submitted it is
-intake-scoped into a work item, planned, optionally reviewed at a roundtable
-gate, then implemented in slices, verified, and finally opened as a PR — all
-under the server-side `build` workflow. Human gates (e.g. the roundtable and
-the PR-open step) are the only points that may pause the run.
+Use this when an autonomous workflow stops or behaves unexpectedly.
 
-## Pipeline stages
+## Triage
 
-- proposal intake
-- plan
-- roundtable gate
-- implement (per-slice)
-- verify
-- PR open
+1. Open the work item in **Workflow Actions**.
+2. Record state, current node, park reason, workflow version, artifact hash, repository, and spend.
+3. Read the last lifecycle events and the first failed external attempt.
+4. Check agent admission, provider, worktree, verification, and forge health for that node.
+5. Repair the named condition and resume the same work item.
 
-## Where to look
+The default build opens a final PR; it does not merge the repository default branch automatically.
 
-For a live trace of any work item, read its server-pushed event stream via the
-canonical endpoint: `GET /v1/runs/{id}/events`. The same stream backs the
-Workflows tab in the webchat UI.
+## Never force past
+
+- a human gate;
+- a missing or changed artifact hash;
+- a failed or missing implementation commit;
+- a merge conflict;
+- non-green required CI;
+- a degraded panel without quorum;
+- a forge identity or branch-confinement failure.
+
+## Recovery
+
+The Go control plane persists transitions before dispatch. Restart is safe when the process is
+wedged: supervision stops both server peers, then startup reconciles reservations and active items.
+Inspect the item after restart before retrying manually.
+
+Repeated feedback or exhausted rounds parks by design. Narrow the request, fix the workflow, or make
+a human decision; raising every limit usually spends more without creating progress.
+
+## Evidence
+
+Keep the work-item ID, request IDs, lifecycle events, artifacts, provider attempt, verification log,
+and audit result. Tool and credential paths are audited through the event bus; trigger delivery is
+not yet an integrated bus consumer.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,59 +1,37 @@
-# aimee: VS Code extension
+# VS Code extension
 
-Chat with **aimee** inside VS Code. Prompts are routed through `aimee-server`'s
-OpenAI-compatible `/v1` API, so they go through aimee's delegate fabric with
-memory and guardrails applied, with no new server protocol, just the surface that
-already ships (see [docs/VSCODE.md](../../docs/VSCODE.md) and
-[the proposal](../../docs/proposals/pending/vscode-integration.md)).
+The extension connects VS Code to `aimee-server` through existing `/v1` APIs. It adds:
 
-> **Status: Tier 3 complete (phases 1-5).** Ships the `@aimee` chat participant
-> (**stateful** - streams `/v1/responses` and threads `previous_response_id`, so
-> aimee's session memory persists across turns), a server-health status item,
-> command-palette queries (**aimee: Recall from memory** -> `/v1/memory/recall`,
-> **aimee: Search knowledge base** -> `/v1/kb/search`, results in the *aimee*
-> output channel), a **Language Model Chat Provider** registering "aimee" in the
-> native model picker (select it as the model for any chat; streams
-> `/v1/chat/completions`; requires VS Code 1.104+, the rest works on older
-> builds), and a **docked chat panel** (**aimee: Open chat panel**). Reusing the
-> full `frontend/` React webchat as the panel is a possible future refinement.
+- an `@aimee` chat participant;
+- an aimee language-model provider in the model picker;
+- memory and KB search commands;
+- a server-health status item;
+- a docked chat panel.
 
-## Setup
+Conversation turns keep the server response/session identifier so memory and tool state continue
+across turns. The extension owns no server state.
 
-1. Enable the aimee-server loopback `/v1` listener and get a token:
+## Configure
 
-   ```bash
-   aimee api status
-   ```
+Run:
 
-   If it reports *disabled*, add to `~/.config/aimee/aimee.yaml`:
+```bash
+aimee api status
+```
 
-   ```yaml
-   aimee:
-     api:
-       http_port: 8910
-       bearer_token: "<generate-a-long-random-secret>"
-       rate_limit_per_min: 60
-   ```
+Set the reported API base and an appropriately scoped credential in VS Code settings. Prefer an
+enrolled HTTPS endpoint; use loopback HTTP only for a local server.
 
-   then `aimee server restart`. A `project:`-scoped bearer is recommended so the
-   editor can read and chat but not perform admin mutations.
-
-2. In VS Code settings, set:
-   - `aimee.apiBase`: default `http://127.0.0.1:8910/v1`
-   - `aimee.bearerToken`: your `bearer_token`
-
-3. Open **Copilot Chat** and type `@aimee <your prompt>`.
-
-The status-bar item (right side) shows whether aimee-server is reachable; click
-it (or run **aimee: Show server status**) to re-check.
-
-## Build (sideload)
+## Build
 
 ```bash
 cd editors/vscode
 npm install
-npm run compile        # tsc -> out/extension.js
-# package a .vsix with: npx @vscode/vsce package
+npm run check
+npm run compile
 ```
 
-`npm run check` type-checks without emitting.
+Package with `npx @vscode/vsce package` when the extension manifest and target VS Code version are
+ready.
+
+See [VS Code](../../docs/VSCODE.md).

--- a/runtime-web/SESSION_PERSISTENCE.md
+++ b/runtime-web/SESSION_PERSISTENCE.md
@@ -1,125 +1,22 @@
-# Per-user persistent chat sessions
+# Browser session persistence
 
-Webchat now persists, **per logged-in user**, the list of chat sessions (one per
-browser tab) so a user can reopen their browser after a crash and restore every
-tab. Conversation history itself already lives on aimee-server keyed by the
-session id; webchat stores only *ownership* and lightweight metadata (title,
-cwd, timestamps) in its SQLite DB (`webchat.db`, table `chat_sessions`).
+The browser service stores each user's chat-tab ownership and lightweight metadata. Conversation
+history stays in `aimee-server` under the session ID.
 
-This document is the **backend contract** the frontend SPA
-(`RakuenSoftware/smoothgui`) integrates against. The Go backend is complete; the
-SPA changes described under "Frontend integration" live in that separate repo.
+Stored metadata:
 
-## Identity
+- session ID;
+- title;
+- working directory/project hint;
+- created and last-active time;
+- authenticated owner.
 
-- A **session** == one tab's conversation, identified by the aimee-server
-  conversation id, the same value the SPA already sends as `aimee_session_id`
-  on `POST /api/chat/send` and that aimee-server echoes back in the `session`
-  stream event.
-- All endpoints are gated by the existing login session cookie (`requireAuth`)
-  and scoped to the authenticated username. A user only ever sees, restores, or
-  deletes their own sessions.
+Users can list, reopen, rename, and forget only their own sessions. Sending a turn upserts the
+record, so a tab survives a crash even when the frontend did not pre-register it.
 
-## Endpoints
+The browser may cache the focused tab for fast reload, but the service is authoritative for which
+tabs exist. Deleting a tab removes its browser ownership record; it does not rewrite the server's
+audit history.
 
-### `GET /api/chat/sessions`
-
-Returns the user's sessions, most-recently-active first (bare JSON array).
-(Distinct from `/api/chat/threads`, which is the unrelated, not-yet-implemented
-in-tab conversation-branch surface.)
-
-```json
-[
-  {
-    "id": "web-ab12cd34",
-    "title": "fix the login redirect bug",
-    "cwd": "/home/me/proj",
-    "created_at": "2026-06-04T10:00:00Z",
-    "last_active": "2026-06-04T11:30:00Z"
-  }
-]
-```
-
-Empty list is `[]`. Use this on app load to render the restorable tab list.
-
-### `GET /api/chat/session?sid=<id>`
-
-Returns one session's metadata, plus back-compat bootstrap fields the SPA
-already consumes:
-
-```json
-{
-  "session_id": "web-ab12cd34",
-  "csrf": "",
-  "prompt_tier": "standard",
-  "exists": true,
-  "title": "fix the login redirect bug",
-  "cwd": "/home/me/proj",
-  "created_at": "...",
-  "last_active": "..."
-}
-```
-
-For an unknown / not-yet-persisted `sid`, `exists` is `false` and the metadata
-fields are omitted (the other fields still return so existing bootstrap logic is
-unaffected).
-
-### `POST /api/chat/session`
-
-Create or update (rename) a session. Body:
-
-```json
-{ "id": "web-ab12cd34", "title": "optional explicit title", "cwd": "/optional" }
-```
-
-`id` may also be sent as `sid` or `aimee_session_id`. An explicitly supplied
-non-empty `title` **overwrites** the stored title (this is the rename path); an
-empty/absent title leaves any existing title untouched. Returns the stored
-record (same shape as a `threads` element). `401` if unauthenticated, `400` if
-no id.
-
-### `DELETE /api/chat/session?sid=<id>`
-
-Forget a session (close a tab). Returns `{"status":"ok","deleted":true}`.
-Scoped to the user, deleting another user's id is a no-op.
-
-## Automatic recording
-
-The SPA does **not** have to explicitly register a session for it to persist:
-`POST /api/chat/send` records the session automatically on every turn. It bumps
-`last_active`, fills `cwd` from the turn, and derives the `title` from the first
-user message (first line, truncated). The id used is the one aimee-server minted
-for a brand-new tab (delivered in the `session` stream event) when the SPA did
-not supply one. So even a tab that crashed mid-first-message is restorable.
-
-`POST /api/chat/session` is therefore only needed for **explicit** actions:
-rename, or pre-registering a tab before its first turn.
-
-## Frontend integration (smoothgui repo)
-
-1. **On app load**, call `GET /api/chat/sessions`. Render each entry as a
-   restorable tab/thread in the sidebar. Clicking one re-opens that
-   conversation by reusing its `id` as the `aimee_session_id` on subsequent
-   `POST /api/chat/send` calls (aimee-server replays history for that id).
-2. **Stop relying on `localStorage`/`sessionStorage`** as the source of truth
-   for the tab list, the server is now authoritative, so the list survives a
-   device crash or a switch to another machine. (You may still cache the
-   *currently focused* session id client-side for fast reload.)
-3. **Per-tab id**: keep generating a stable per-tab id (e.g. `web-<rand>`) and
-   send it as `aimee_session_id`; it becomes the session's `id`. Each tab gets
-   its own id so each persists independently.
-4. **Rename**: `POST /api/chat/session` with `{id, title}`.
-5. **Close/forget a tab**: `DELETE /api/chat/session?sid=<id>`.
-6. The thread endpoints (`/api/chat/threads`, `/branch`, `/switch-thread`,
-   `/rewind`) remain stubs; in-tab conversation-branch management is a separate
-   feature, out of scope for per-user tab restore.
-
-## Frontend status (aimee/frontend)
-
-The aimee web SPA (`frontend/src/pages/Chat.tsx`) integrates this as of the
-session-frontend change: on mount it fetches `GET /api/chat/sessions` and merges
-any server-side sessions the local `localStorage` cache is missing (restoring
-tabs after a crash or on a fresh device), and `closeTab` issues
-`DELETE /api/chat/session?sid=` so a closed tab does not reappear. `localStorage`
-is retained as a fast local cache (it also holds per-tab message history); the
-server is authoritative for *which* tabs exist.
+Thread branching and transactional turn rewind are separate contracts and must not be inferred from
+tab persistence.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,132 +1,58 @@
-# scripts/
+# Scripts
 
-Helper scripts that aimee can shell out to.  Installable anywhere, but
-they're kept here so they track the schema of the APIs they plumb into.
+Scripts are build gates, generators, deployment helpers, smoke tests, benchmarks, and narrow
+sidecars. Keep each one tied to a source contract and safe to run from the repository root unless its
+header says otherwise.
 
-## `check_tier_deps.sh`, enforce DB1/DB2 tier boundaries
+## Main groups
 
-Validates dependency boundaries for the two-database architecture (DB1 = local
-SQLite owned by `aimee-server`; DB2 = shared Postgres owned by `aimee-kb`,
-including the in-process pgvector extension):
+| Prefix | Purpose |
+| --- | --- |
+| `check_*` | static or mechanical contract gate |
+| `test_*` | live integration/conformance harness |
+| `gen-*` / `gen_*` | generated docs, APIs, schemas, SDKs, fixtures |
+| `aimee-*` | deployment, packaging, or end-to-end helper |
+| benchmark/eval scripts | reproduce a named benchmark artifact |
 
-- `sqlite3.h` only in `src/db1/`
-- `libpq-fe.h` only in `src/db2/`
-- `aimee_stores_` / `aimee_stores_t` / `PGconn` / `PGresult` / `PQ*` helper symbols / `sqlite3_` only in tier-owned source trees
-- no legacy `project_store_` lifecycle aliases outside `src/db2`
-- no legacy DB2 backend selector outside `src/db2`
-- DB2 transitional SQLite lifecycle names stay inside `src/db2`
-- DB2 public lifecycle headers hide SQLite backend knowledge
-- DB2 public lifecycle headers hide shim backend vocabulary
-- DB2 shared-store lifecycle APIs expose neutral names outside `src/db2`
-- DB2 transaction primitives stay inside `src/db2`
-- Legacy/helper vocabulary outside `src/db1` avoids SQLite names
-- Worker-shell comments outside `src/db1` avoid SQLite names
-- Vector verify row-count fields expose DB2 names instead of SQLite names
-- Doctor DB output exposes DB2 names instead of Postgres names
-- Non-DB2 source comments avoid Postgres/libpq implementation names
-- No Qdrant HTTP collection/points URL paths in `src/` (vector store is now
-  pgvector inside DB2, in-process, no HTTP sidecar)
+`make -C src lint` runs the fast required checks. Long live-service and benchmark harnesses remain
+explicit targets.
 
-Most checks scan `src/**/*.c`, `src/**/*.h`, and `src/**/*.inc` outside
-`src/db1`, `src/db2`, `src/tests`, and `src/webchat`.
+## Important gates
 
-Run manually:
+- `check_tier_deps.sh`: DB1/DB2 ownership and forbidden storage vocabulary.
+- route/API checks: descriptor, handler, OpenAPI, and thin-client parity.
+- module checks: public headers, dependencies, descriptors, and documentation.
+- event-bus checks: wire conformance, one host, isolation, flow control, capture, blast radius, and
+  performance.
+- container packaging checks: required files, users, entrypoints, database/inference ownership.
+
+## Generation
 
 ```bash
-./scripts/check_tier_deps.sh
+make -C src docs-gen
+make -C src docs-gen-check
+make -C src gen-sdks
 ```
 
-The `lint` CI job also runs this check.
+Change the source descriptor, not the generated output. Generators must be deterministic for an
+unchanged input.
 
-Binary ownership is checked by `cd src && make check-linking`; that target
-verifies the process boundary:
+## Sidecars
 
-- `aimee-client` and `aimee-runtime-web` stay DB-free (`libsqlite3` and `libpq` absent).
-- `aimee-server` stays DB1-only (`libsqlite3` present, `libpq` absent, no
-  DB2 symbols).
-- `aimee-kb` stays DB2-only (`libpq` present, `libsqlite3` absent, no
-  DB1/sqlite symbols).
+`llm-chat.py` is a small OpenAI-compatible client used by experiments and command-backed stages.
+`llm-rewrite.py` adapts it to the query-rewrite JSON contract. Configure endpoints and credentials
+through the owning deployment; do not commit them or print them in diagnostics.
 
-## `llm-chat.py`, generic OpenAI-compat chat client
+Sidecars read bounded input from stdin, emit the exact documented output on stdout, keep logs on
+stderr, time out, and fail with an explicit degraded result. They do not become hidden storage or
+policy owners.
 
-Reads a prompt from `--prompt`, a positional argument, or stdin; posts to
-an OpenAI-compat `/v1/chat/completions`; writes the reply's content to
-stdout.  Works with any endpoint that speaks the OpenAI chat spec:
+## Adding a script
 
-- OpenAI (`https://api.openai.com/v1`)
-- Local `llama-server` (e.g. `http://host:8080/v1`)
-- Ollama (`http://host:11434/v1`)
-- vLLM, LM Studio, Together, Groq, …
-
-All config via env vars (set once in aimee config) with CLI-flag overrides:
-
-| Variable | Purpose |
-|---|---|
-| `LLM_ENDPOINT` | base URL (default `https://api.openai.com/v1`) |
-| `LLM_MODEL` | model id (**required**) |
-| `LLM_API_KEY` | bearer token; `cmd:<shell>` runs a command and uses its stdout |
-| `LLM_SYSTEM` | default system prompt |
-| `LLM_TEMPERATURE` | default `0.0` |
-| `LLM_MAX_TOKENS` | default `2048` |
-| `LLM_NO_THINKING` | `1` to disable Qwen-family hybrid-thinking tokens |
-| `LLM_TIMEOUT` | seconds, default `120` |
-| `LLM_RETRIES` | default `2` (5xx + network retries with backoff) |
-
-Example, local Qwen3.6 via llama-server:
-
-```bash
-export LLM_ENDPOINT=http://192.168.0.115:8080/v1
-export LLM_MODEL=qwen3.6
-export LLM_NO_THINKING=1
-
-echo "Summarise: typed extraction beats semantic-only by 0.16 P@5" \
-    | ./scripts/llm-chat.py
-```
-
-Example, OpenAI with a secret manager:
-
-```bash
-export LLM_MODEL=gpt-4o-mini
-export LLM_API_KEY="cmd:op read 'op://vault/openai/key'"
-./scripts/llm-chat.py --prompt "ping"
-```
-
-Stdlib-only Python; runs on any 3.9+.
-
-## `llm-rewrite.py`, `memory_rewrite_command` wrapper
-
-Plugs an OpenAI-compat endpoint into aimee's query-rewrite pipeline
-(HyDE + decomposition; see `src/memory_core_search.inc:memory_query_rewrite`).
-Reads aimee's request JSON on stdin, calls `llm-chat.py`, returns the
-rewrite JSON on stdout.  Silent fallback to `{}` on any error so a flaky
-endpoint doesn't spam aimee's log with rewrite failures.
-
-### Wiring
-
-```bash
-aimee config set memory_rewrite_command "python3 $(pwd)/scripts/llm-rewrite.py"
-aimee config set memory_rewrite_enabled 1
-aimee config set memory_rewrite_hyde 1
-aimee config set memory_rewrite_decompose 1
-```
-
-(Env vars from `llm-chat.py` apply, same `LLM_ENDPOINT` / `LLM_MODEL` / …
-that any other sidecar call uses.  Set them in `aimee-server`'s
-environment or via your shell profile.)
-
-Inherits the same generic config surface, nothing Qwen-specific in the
-config path, except `LLM_NO_THINKING=1` for thinking-capable models that
-would otherwise burn their token budget on `<think>` content.
-
-## Writing your own sidecar
-
-Any aimee config that expects a CLI (`memory_rewrite_command`,
-`memory_query_expansion_command`, `embedding_command`, …) can be backed
-by a small wrapper that:
-
-1. Reads whatever JSON aimee pipes in on stdin (see the grep in
-   `src/memory_core_search.inc` or the doc comment above the caller).
-2. Constructs a prompt and calls `llm-chat.py`.
-3. Parses the reply and emits the JSON the caller expects on stdout.
-
-Keep the wrapper small; let `llm-chat.py` do the HTTP + retry work.
+- state cwd, inputs, outputs, exit codes, network use, and destructive behavior in the header;
+- use strict shell mode where appropriate;
+- quote paths and reject an empty or broad destructive target;
+- keep secrets out of argv and output;
+- provide `--help` and a self-test for a reusable tool;
+- wire a required gate into the owning Make target;
+- add it here only when it creates a new category or public operator surface.

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -104,6 +104,52 @@ CFG_KEY_DESC = {
     "kb_pdf_tier": "Structured-PDF pipeline preset: off (plain pdftotext, default) | basic (ingest+vector) | full (all stages).",
     "kb_curator_tier": "KB curator pipeline preset: off | lite (core extract+index) | full (all stages, default).",
 
+    "audit_action_enabled": "Publish governed tool-action audit rows (default on); disabling it creates an audit coverage gap.",
+    "code_trust_actuation_enabled": "Use earned code-graph trust lessons only as an equal-score retrieval tiebreak (default off).",
+    "guardrails_semantic_mode": "Semantic guardrail mode: off, dry_run, advisory, or enforce.",
+    "kb_client_bearer_token": "Server-to-KB bearer token; secret, restart required.",
+    "kb_client_url": "Remote aimee-kb API base URL used by aimee-server; restart required.",
+    "kb_curator_extract_code_workers": "Parallel curator code-extraction workers, bounded to the synthesis service slot count.",
+    "kb_curator_extract_docs_workers": "Parallel curator document-extraction workers, bounded to the synthesis service slot count.",
+    "kb_evidence_embed_enabled": "Drain evidence-index operations into evidence vectors.",
+    "kb_mode": "Setup/deploy mode: local starts a KB, remote connects to kb_client_url.",
+    "verify_cmd": "Command run after a delegated fix to verify it.",
+    "verify_prompt": "Prompt template given to the cross-verification delegate.",
+    "verify_role": "Delegate role used for cross-verification.",
+    "wfe_proposals_autoscan_enabled": "Automatically scan watched proposal directories; off requires explicit trigger.fire.",
+
+    "llm_embed_backend": "Deploy-time embedding backend: local or external.",
+    "llm_embed_gpu": "Deploy-time GPU selector for the local embedding backend.",
+    "llm_embed_host": "Deploy-time host selector for the local embedding backend.",
+    "llm_embed_tier": "Deploy-time local embedding tier: cpu, small, mid, or large.",
+    "llm_rerank_backend": "Deploy-time reranking backend: local, external, or off.",
+    "llm_rerank_endpoint": "External reranking endpoint used when the rerank backend is external.",
+    "llm_rerank_gpu": "Deploy-time GPU selector for the local reranking backend.",
+    "llm_rerank_host": "Deploy-time host selector for the local reranking backend.",
+    "llm_rerank_tier": "Deploy-time local reranking tier.",
+    "llm_synth_backend": "Deploy-time synthesis backend: local, external, or off.",
+    "llm_synth_endpoint": "External synthesis endpoint used when the synth backend is external.",
+    "llm_synth_gpu": "Deploy-time GPU selector for the local synthesis backend.",
+    "llm_synth_host": "Deploy-time host selector for the local synthesis backend.",
+    "llm_synth_model": "Model label sent to the configured synthesis endpoint.",
+    "llm_synth_tier": "Deploy-time local synthesis tier: cpu, small, mid, or large.",
+
+    "kb_curator_cross_repo_graph_enabled": "Resolve and maintain cross-repository dependency edges.",
+    "kb_curator_custom_stages": "JSON definitions that recompose vetted curator operations with bounded budgets.",
+    "kb_curator_detect_contradictions_enabled": "Link claims that disagree on the same subject and attribute.",
+    "kb_curator_extract_code_enabled": "Extract typed curator artifacts from indexed code.",
+    "kb_curator_extract_docs_enabled": "Extract typed curator artifacts from documents.",
+    "kb_curator_index_claims_enabled": "Embed claim subject/attribute/value records.",
+    "kb_curator_index_code_unit_enabled": "Embed extracted code-unit artifacts.",
+    "kb_curator_index_narrative_enabled": "Embed summaries and synthesis narratives.",
+    "kb_curator_link_artifacts_enabled": "Link related document, entity, claim, and code artifacts.",
+    "kb_curator_projection_graph_enabled": "Publish the typed code projection graph for changed projects.",
+    "kb_curator_promote_entity_enabled": "Promote well-supported entities one step up the scope lattice.",
+    "kb_curator_resolve_entities_enabled": "Resolve proposed mentions against canonical entities.",
+    "kb_curator_stage_order": "Comma-separated curator stage order; invalid dependency order falls back safely.",
+    "kb_curator_synthesize_enabled": "Create evidence-backed topic synthesis with the configured reasoning tier.",
+    "kb_curator_user_presets": "JSON array of operator-defined curator stage presets.",
+
     "autonomous": "Run autonomously (auto-advance machine gates; human gates always park) vs interactive.",
     "economizer": "Context economizer tier: `off` (verbatim passthrough), `safe` (default; Anthropic prompt caching + lossless, freeze-guarded reduction), or `aggressive` (adds lossy compression + live OpenAI-side mutation; Anthropic context is never mutated). See docs/features/economizer.md.",
     "cache_aware_rewrite_enabled": "Rewrite prompts to align with the provider's prompt cache.",
@@ -600,7 +646,7 @@ ENV_DESC = {
     # Server runtime
     "AIMEE_SERVER_HTTP_BIND": ("Server runtime", "TCP bind address for the server `/v1` HTTP listener (else UDS-only)."),
     "AIMEE_SERVER_STARTUP_FD": ("Server runtime", "Inherited fd for startup-readiness signalling (service launch)."),
-    "AIMEE_API_REMOTE_WRITES": ("Server runtime", "Gate remote (TCP) write methods: `off` | `data` | `full`."),
+    "AIMEE_API_REMOTE_WRITES": ("Server runtime", "Legacy value: `off`, `data`, or `full`. Still parsed, but no longer authorizes user writes; non-off values warn and feed `remote_writes.global_ignored`."),
     "AIMEE_SEARCH_ALLOW_PRIVATE_ENDPOINT": (
         "Server runtime",
         "Permit the operator-configured search backend (`search.searxng_url`) to resolve to a "
@@ -618,7 +664,7 @@ ENV_DESC = {
     "AIMEE_WEBCHAT_EDITOR_IDLE_SECS": ("Server runtime", "Idle timeout in seconds before a per-webuser code-server editor is reaped. Default 1800 (30 min); positive values are clamped to [60, 604800]; 0 disables idle reaping; malformed/negative/overflow values fall back to the default. An actively-open editor is kept alive by the proxy keepalive, so it is not reaped mid-session."),
     "AIMEE_WEBCHAT_EDITOR_UID": ("Server runtime", "Dedicated service user the per-webuser code-server drops to (defence in depth; only honoured when aimee-server runs as root)."),
     "AIMEE_GITHUB_OAUTH_CLIENT_ID": ("Server runtime", "Client ID of a GitHub OAuth App for the webchat \"Sign in with GitHub\" button; populates the github.com git credential. Public. Overrides the built-in default baked in via oauth_defaults.h."),
-    "AIMEE_GITHUB_OAUTH_CLIENT_SECRET": ("Server runtime", "Client secret of the GitHub OAuth App. Enables the seamless web (redirect) sign-in; without it the button falls back to the device-code flow. Secret — set per deployment, never baked into an image."),
+    "AIMEE_GITHUB_OAUTH_CLIENT_SECRET": ("Server runtime", "Client secret of the GitHub OAuth App. Enables browser redirect sign-in; without it the button falls back to the device-code flow. Secret — set per deployment, never baked into an image."),
     "AIMEE_GITLAB_OAUTH_CLIENT_ID": ("Server runtime", "Client ID of a GitLab OAuth application (device flow enabled) for the webchat \"Sign in with GitLab\" button on gitlab.com. Public. Overrides the built-in default baked in via oauth_defaults.h."),
     "AIMEE_DEPLOY_ENABLED": ("Server runtime", "Set to 1 to enable the server-orchestrated deploy: the setup wizard runs `docker compose up -d` for the managed sibling services (aimee-kb + aimee-llm) via a mounted Docker socket. Off unless the deploy compose sets it."),
     "AIMEE_DEPLOY_COMPOSE_FILE": ("Server runtime", "Path to the managed compose file the server-orchestrated deploy runs (default /opt/aimee/deploy/aimee-managed.compose.yaml)."),
@@ -772,6 +818,90 @@ ENV_DESC = {
     # Diagnostics & misc
     "AIMEE_ANTIPATTERNS_BYPASS": ("Diagnostics & misc", "Bypass the guardrail antipattern checks."),
     "AIMEE_LOG_LEVEL": ("Diagnostics & misc", "Log level: `error` | `warn` | `info` | `debug`."),
+    "AIMEE_ALLOW_MAIN_CHECKOUT": ("Delegates & backends", "Allow an explicitly authorized delegate path to use the main checkout instead of a managed worktree."),
+    "AIMEE_API_BEARER_TOKEN": ("Server runtime", "Bearer token for the public server API listener; secret."),
+    "AIMEE_AUTONOMY_BASE": ("Workflow engine", "Integration branch used by autonomous workflow work; distinct from the repository default branch."),
+    "AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL": ("Workflow engine", "Maximum active autonomous work items for one authenticated principal."),
+    "AIMEE_AUTONOMY_MAX_USD": ("Workflow engine", "Default USD ceiling for an autonomous work item; 0 disables this default ceiling."),
+    "AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN": ("Workflow engine", "Autonomous-submission rate limit per principal."),
+    "AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS": ("Workflow engine", "Window used by the autonomous-submission rate limiter."),
+    "AIMEE_AUTONOMY_USD_PER_SEC": ("Workflow engine", "Fallback spend estimator for autonomous admission when exact provider cost is unavailable."),
+    "AIMEE_CI_WEBHOOK_SECRET": ("Workflow engine", "HMAC secret authenticating inbound CI webhook events."),
+    "AIMEE_CLIENT_TYPE": ("Client & session", "Calling client type used for integration-specific request shaping."),
+    "AIMEE_CODEX_REFRESH_SKEW": ("Delegates & backends", "Seconds before Codex OAuth expiry at which the server refreshes the token."),
+    "AIMEE_CODE_INDEX_SOURCE": ("Knowledge base (aimee-kb)", "Source label recorded for code-index ingestion."),
+    "AIMEE_DB2_EVAL_URL": ("Database & vectors", "Separate DB2 URL used by evaluation harnesses; never the production default."),
+    "AIMEE_DB2_POOL_SIZE": ("Database & vectors", "DB2 connection-pool size override."),
+    "AIMEE_DELEGATE_MAX_INFLIGHT": ("Delegates & backends", "Process-wide maximum number of admitted delegate attempts."),
+    "AIMEE_DELEGATE_SANDBOX": ("Delegates & backends", "Enable the configured delegate sandbox backend."),
+    "AIMEE_DIM_PROBE_BUDGET_MS": ("Database & vectors", "Time budget for probing an embedder's output dimension."),
+    "AIMEE_IR_PATH": ("Diagnostics & misc", "Diagnostic path for recording canonical request IR."),
+    "AIMEE_IR_RESP_PATH": ("Diagnostics & misc", "Diagnostic path for recording canonical response IR."),
+    "AIMEE_IR_SHADOW": ("Diagnostics & misc", "Run the canonical IR path in comparison/shadow mode."),
+    "AIMEE_IR_STREAM_RELAY": ("Diagnostics & misc", "Enable the canonical streaming-response relay."),
+    "AIMEE_KB_HARDENED": ("Knowledge base (aimee-kb)", "Require the hardened KB custody and transport posture at startup."),
+    "AIMEE_KB_JWKS_MANIFEST_ROOT_CUSTODY_ID": ("Knowledge base (aimee-kb)", "Custody identifier for the key that signs JWKS manifests."),
+    "AIMEE_KB_JWKS_PUBLICATION_HWM_CUSTODY_ID": ("Knowledge base (aimee-kb)", "Custody identifier for the JWKS publication high-water mark."),
+    "AIMEE_KB_JWKS_PUBLISH_DSN": ("Knowledge base (aimee-kb)", "Provisioning database URL used by the JWKS publisher; secret."),
+    "AIMEE_KB_MGMT_STATUS_SECONDARY_LEAF_PIN": ("Knowledge base (aimee-kb)", "Secondary TLS leaf pin accepted during management-status certificate rotation."),
+    "AIMEE_KB_MTLS_MAX_CONNECTIONS": ("TLS & networking", "Maximum concurrent connections accepted by the KB mTLS listener."),
+    "AIMEE_KB_OIDC_MAX_TOKEN_AGE": ("Knowledge base (aimee-kb)", "Maximum accepted age in seconds for a KB OIDC token."),
+    "AIMEE_KB_RUNTIME_UID": ("Knowledge base (aimee-kb)", "Numeric runtime user allowed to receive the management token-authority socket."),
+    "AIMEE_KB_STATUS_BIND": ("Knowledge base (aimee-kb)", "Bind address for the management-status authority."),
+    "AIMEE_KB_STATUS_DSN": ("Knowledge base (aimee-kb)", "Runtime database URL used by the management-status authority; secret."),
+    "AIMEE_KB_STATUS_PORT": ("Knowledge base (aimee-kb)", "Listen port for the management-status authority."),
+    "AIMEE_KB_STATUS_PROVISION_DSN": ("Knowledge base (aimee-kb)", "Provisioning database URL used to initialize management-status state; secret."),
+    "AIMEE_KB_STATUS_TLS_CA": ("TLS & networking", "CA file used by the management-status authority."),
+    "AIMEE_KB_STATUS_TLS_CERT": ("TLS & networking", "TLS certificate for the management-status authority."),
+    "AIMEE_KB_STATUS_TLS_KEY": ("TLS & networking", "TLS private key for the management-status authority; secret."),
+    "AIMEE_KB_TOKEN_AUTHORITY_DSN": ("Knowledge base (aimee-kb)", "Database URL used by the management token authority; secret."),
+    "AIMEE_KB_TOKEN_AUTHORITY_SOCKET_GID": ("Knowledge base (aimee-kb)", "Group allowed to connect to the management token-authority socket."),
+    "AIMEE_KB_TOKEN_ROOTS_PROVISION_DSN": ("Knowledge base (aimee-kb)", "Provisioning database URL used to initialize token roots; secret."),
+    "AIMEE_KB_TOKEN_ROOT_CUSTODY_ID": ("Knowledge base (aimee-kb)", "Custody identifier for the management token signing root."),
+    "AIMEE_KB_VAULT_OPERATOR_ENABLED": ("Knowledge base (aimee-kb)", "Enable the dedicated KB vault-operator runtime."),
+    "AIMEE_KB_VAULT_ORCHESTRATOR_URL": ("Knowledge base (aimee-kb)", "Operator-configured vault orchestrator endpoint."),
+    "AIMEE_MGMT_STATUS_KEY_ID": ("Server runtime", "Identifier of the management-status verification key."),
+    "AIMEE_MGMT_STATUS_PUBLIC_KEY": ("Server runtime", "Hex-encoded Ed25519 key used to verify management-status staples."),
+    "AIMEE_MODULE_ROUNDTABLE": ("Server runtime", "Enable the optional roundtable module; invalid values fail closed to off."),
+    "AIMEE_OCR_URL": ("Knowledge base (aimee-kb)", "Structured-PDF OCR sidecar endpoint."),
+    "AIMEE_ORCH_DELEGATES": ("Workflow engine", "Enable delegate resource use by the orchestration plane."),
+    "AIMEE_ORCH_WORKFLOWS": ("Workflow engine", "Enable workflow orchestration surfaces."),
+    "AIMEE_PANEL_SEAT_WAIT_SECS": ("Workflow engine", "Maximum wait for a roundtable seat to acquire an eligible agent."),
+    "AIMEE_PRIMARY_CLI_INGESTOR": ("Client & session", "Name of the primary CLI integration that owns session-ingest events."),
+    "AIMEE_PROJECT_ID": ("Client & session", "Explicit project identity for an integration request."),
+    "AIMEE_RUNTIME_DIR": ("Paths & assets", "Private runtime directory for sockets, temporary credentials, and process state."),
+    "AIMEE_SANDBOX_HOST_MOUNTS": ("Delegates & backends", "Operator allowlist of host mounts available to the sandbox backend."),
+    "AIMEE_SERVER_MGMT_BIND": ("Server runtime", "Bind address that enables the server management listener when its full TLS configuration is present."),
+    "AIMEE_SERVER_MGMT_ISSUER": ("Server runtime", "Expected issuer for management-plane bearer identities."),
+    "AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE": ("Server runtime", "Root-owned trust bundle used to verify signed management JWKS publications."),
+    "AIMEE_SERVER_MGMT_STATUS_SECONDARY_LEAF_PIN": ("Server runtime", "Secondary management-status TLS leaf pin accepted during certificate rotation."),
+    "AIMEE_STAGE_GOVERNANCE": ("Server runtime", "Enable the governance stage in the canonical request pipeline."),
+    "AIMEE_STAGE_MEMORY": ("Server runtime", "Enable the memory stage in the canonical request pipeline."),
+    "AIMEE_TEST_PG_URL": ("Diagnostics & misc", "PostgreSQL URL used only by live test harnesses."),
+    "AIMEE_TLS_CLIENT_P12_PASS": ("TLS & networking", "Password for an explicitly provisioned client PKCS#12 bundle; secret."),
+    "AIMEE_TLS_CN": ("TLS & networking", "Common Name used when generating a local TLS certificate."),
+    "AIMEE_TLS_EXTRA_SAN": ("TLS & networking", "Additional subject-alternative names for a generated TLS certificate."),
+    "AIMEE_TSR_URL": ("Knowledge base (aimee-kb)", "Structured-PDF table-recognition sidecar endpoint."),
+    "AIMEE_VAULT_KMS_HELPER": ("Server runtime", "Executable implementing the configured external KMS wrap/unwrap contract."),
+    "AIMEE_VAULT_KMS_HWM_DOMAIN": ("Server runtime", "Domain separator for KMS high-water-mark signatures."),
+    "AIMEE_VAULT_KMS_HWM_PUBKEY": ("Server runtime", "Public key used to verify KMS high-water-mark records."),
+    "AIMEE_VAULT_KMS_KEY_ID": ("Server runtime", "External KMS key identifier used for vault wrapping."),
+    "AIMEE_VAULT_PKCS11_LABEL": ("Server runtime", "PKCS#11 object label used for vault custody."),
+    "AIMEE_VAULT_PKCS11_MODULE": ("Server runtime", "Path to the PKCS#11 provider module."),
+    "AIMEE_VAULT_PKCS11_PIN": ("Server runtime", "PKCS#11 user PIN; secret."),
+    "AIMEE_VAULT_PKCS11_SLOT": ("Server runtime", "PKCS#11 slot identifier used for vault custody."),
+    "AIMEE_VAULT_TPM2_BLOB_PATH": ("Server runtime", "Path to the sealed TPM 2 vault-key blob."),
+    "AIMEE_VAULT_TPM2_NV_INDEX": ("Server runtime", "TPM 2 NV index used for anti-rollback state."),
+    "AIMEE_VAULT_TPM2_TCTI": ("Server runtime", "TPM 2 TCTI selector."),
+    "AIMEE_WFE_ENGINE": ("Workflow engine", "Workflow runtime selector; current server images require `go`."),
+    "AIMEE_WFE_HTTP_SOCKET": ("Workflow engine", "Unix socket for the Go workflow control plane."),
+    "AIMEE_WFE_WORKTREE_GC_GRACE_SECS": ("Workflow engine", "Grace period before an unowned workflow worktree can be collected."),
+    "AIMEE_WITNESS_CADENCE_TEST_S": ("Diagnostics & misc", "Test-only override that shortens witness checkpoint and verification cadence."),
+    "AIMEE_WITNESS_HARNESS_ROLE": ("Diagnostics & misc", "Restricted PostgreSQL role used by the witness live harness."),
+    "AIMEE_WORKFLOW_AUTONOMOUS_ROUTER": ("Workflow engine", "Enable automatic scheduling of admitted autonomous work items."),
+    "AIMEE_WORKFLOW_BRANCH": ("Workflow engine", "Explicit workflow feature branch for a compatibility or test runner."),
+    "AIMEE_WORKFLOW_ENFORCE_STAGE": ("Workflow engine", "Require runner requests to match the persisted workflow stage."),
+    "AIMEE_WORKFLOW_LEASE_TTL_SECS": ("Workflow engine", "Lifetime of a workflow execution lease before recovery may reclaim it."),
 }
 
 
@@ -849,6 +979,7 @@ EXT_OS_IGNORE = {
     "HOME", "PATH", "PWD", "TEMP", "TMP", "TMPDIR", "LOCALAPPDATA", "APPDATA",
     "USER", "USERNAME", "USERPROFILE", "SHELL", "PYTHONPATH", "LANG",
     "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_RUNTIME_DIR",
+    "LISTEN_FDS", "LISTEN_PID",
 }
 # provider keys resolved via per-agent api_key_env (not getenv literals) — added so
 # the reference lists them even though the static scan can't see them
@@ -880,6 +1011,9 @@ EXT_DESC = {
     "CODEX_CWD": ("Codex / Claude integration", "Working directory reported by the Codex frontend."),
     "CODEX_THREAD_ID": ("Codex / Claude integration", "Codex conversation/thread id."),
     "CLAUDE_SESSION_ID": ("Codex / Claude integration", "Claude Code session id when aimee runs as its backend."),
+    "LLM_API_KEY": ("Provider credentials", "Bearer credential used by the generic llm-chat sidecar; prefer the vault or a secret command."),
+    "LLM_ENDPOINT": ("Provider endpoints", "OpenAI-compatible base URL used by the generic llm-chat sidecar."),
+    "LLM_MODEL": ("Provider endpoints", "Model requested by the generic llm-chat sidecar."),
 }
 
 
@@ -953,22 +1087,21 @@ def parse_block_catalog():
     return cat
 
 
-def parse_engine_consts():
-    dfn = (SRC / "modules" / "workflows" / "wfe_def.h").read_text(encoding="utf-8")
-    auto = (SRC / "modules" / "workflows" / "wfe_autonomy.h").read_text(encoding="utf-8")
-    att = re.search(r'#define\s+WFE_DEFAULT_MAX_ITERS\s+(\d+)', dfn)
-    ovr = re.search(r'#define\s+WFE_MAX_OVERRIDES\s+(\d+)', auto)
-    return (att.group(1) if att else "?"), (ovr.group(1) if ovr else "?")
+def parse_engine_default_rounds():
+    engine = (ROOT / "server-go" / "internal" / "engine" / "engine.go").read_text(
+        encoding="utf-8")
+    rounds = re.search(r'const\s+defaultMax\s*=\s*(\d+)', engine)
+    return rounds.group(1) if rounds else "?"
 
 
-def render_workflow(catalog, consts):
-    max_att, max_ovr = consts
+def render_workflow(catalog, default_rounds):
     out = ["## Workflow engine",
            "",
            "Workflows are block-composed YAML definitions under "
            "`$AIMEE_HOME/workflows/<name>.yaml`, authored with the `aimee workflow` "
-           "CLI or the web visual composer and saved in canonical form. A run is a "
-           "DB1 work item pinned to a definition version.",
+           "CLI or the web visual composer and saved in canonical form. The Go "
+           "workflow engine owns execution. A run is a durable work item pinned to "
+           "a definition version.",
            "",
            "### Workflow definition schema",
            "",
@@ -1027,12 +1160,10 @@ def render_workflow(catalog, consts):
         "",
         "### Run-level controls (not in the definition)",
         "",
-        f"- **Per-stage loop cap** — a node that loops back via `on_fail` is retried at "
-        f"most `max_rounds` times (per-node param, default `{max_att}`); on the cap its "
-        f"`on_max` policy resolves the loop: `human` parks (default), `fail` is a "
-        f"terminal reject, `pass` forces the flow forward via `on_pass`/`next`.",
-        f"- **Gate-override cap** — a parked human gate may be overridden at most "
-        f"`{max_ovr}` times (`WFE_MAX_OVERRIDES`) before the run is forced terminal.",
+        "- **Per-stage loop cap** — `params.max_rounds` bounds retries for a node "
+        f"that loops through `on_fail` (default `{default_rounds}`). Exhaustion parks "
+        "the run with `retry_limit` or a more specific convergence reason. The "
+        "retired `max_iters` and `on_max` fields are ignored by the Go engine.",
         "- **Cost cap** — an optional per-work-item USD ceiling set at run creation "
         "(`work_item_max_cost_usd`); the engine parks the run when cumulative cost "
         "reaches it.",
@@ -1063,6 +1194,8 @@ AGENT_FIELD_DESC = {
     "api_key": "Inline API key (prefer `api_key_env` or the vault).",
     "api_key_env": "Env var name holding the agent's API key.",
     "access_token": "Static auth token for the endpoint.",
+    "refresh_token": "OAuth refresh token for the endpoint.",
+    "exp": "OAuth token expiry as a Unix timestamp.",
     "auth_cmd": "Command that prints an auth token.",
     "auth_type": "Auth scheme (bearer / oauth / none).",
     "credentials": "Credential block / reference.",
@@ -1099,6 +1232,8 @@ AGENT_FIELD_DESC = {
     "session_reuse": "Reuse a session across calls.",
     "cli_cmd": "CLI command for a cli-backend agent.",
     "cli_kind": "CLI agent kind (claude / codex / opencode).",
+    "is_server_hosted": "Whether the provider session is hosted by the aimee server.",
+    "primary_only": "Restrict this agent to primary sessions; do not use it for delegates.",
     "cli_idle_timeout_ms": "Idle timeout (ms) for a CLI agent.",
     "ssh_entry": "SSH entry point (ssh backend).",
     "ssh_key": "SSH key path (ssh backend).",
@@ -1217,7 +1352,7 @@ def main():
     cfg = (cfg.rstrip() + "\n\n"
            + render_env(parse_env_vars()).rstrip() + "\n\n"
            + render_external_env(parse_external_env()).rstrip() + "\n\n"
-           + render_workflow(parse_block_catalog(), parse_engine_consts()).rstrip() + "\n\n"
+           + render_workflow(parse_block_catalog(), parse_engine_default_rounds()).rstrip() + "\n\n"
            + render_config_files(parse_agent_fields()).rstrip() + "\n\n"
            + render_limitations())
     targets = {GEN / "cli-commands.md": cli, GEN / "configuration.md": cfg}

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -1,48 +1,29 @@
-# Harness analysis tools
+# Harness analysis
 
-Tooling for the **four-part harness** framing: every agent runtime is *loop +
-tool interface + context management + control*. When an agent misbehaves it is
-almost always one part, not "the model"; and as models improve, the parts that
-bet against the model should shrink. See
-[`docs/proposals/pending/four-part-harness-taxonomy.md`](../../docs/proposals/pending/four-part-harness-taxonomy.md)
-for the full design, the subsystem map, and the durable-vs-delete classification.
+The harness model has four parts: loop, tools, context, and control. Diagnose a failure against the
+part that owned it instead of treating every failure as a model problem.
 
-Both tools are pure analysis — no build, no running aimee server required.
+## Classify failures
 
-## `classify_failures.py` — attribute failures to one of the four parts
-
-Reads execution-trace rows (the shape `src/trace_analysis.c` mines) and tags each
-detected failure as **loop**, **tool**, **context**, or **control**, then prints
-the distribution. Turns "context is our biggest tax" into a measured number.
-
-```sh
-python3 classify_failures.py --self-test            # red/green: one plan per part + edge cases
-python3 classify_failures.py traces.json            # classify a trace dump
-aimee trajectory export --json | python3 classify_failures.py -
-python3 classify_failures.py traces.json --json     # machine-readable
+```bash
+python3 scripts/harness/classify_failures.py --self-test
+python3 scripts/harness/classify_failures.py traces.json
+aimee trajectory export --json | python3 scripts/harness/classify_failures.py -
 ```
 
-Heuristics mirror the constants in `src/trace_analysis.c` (retry-loop threshold,
-error indicators) so the in-process C port stays faithful. This script is the
-reference that port must match.
+The classifier mirrors the in-process trace heuristics and can emit JSON. It is attribution, not a
+causal proof; inspect the tagged trace before changing the harness.
 
-## `delete_pressure.py` — rank scaffolding for deletion as models improve
+## Find deletion pressure
 
-Scores the per-tool prompt augmentations in `src/tool_prompts/` by per-turn token
-tax and *doubt density* (imperative hedges that encode "the model won't do this
-unless told"). High score = re-test against a current model, then likely trim.
-
-```sh
-python3 delete_pressure.py                          # scan src/tool_prompts/
-python3 delete_pressure.py --json
-python3 delete_pressure.py --anti-patterns export.json   # fold in runtime hit-rate
-python3 delete_pressure.py --self-test
+```bash
+python3 scripts/harness/delete_pressure.py
+python3 scripts/harness/delete_pressure.py --json
+python3 scripts/harness/delete_pressure.py --anti-patterns export.json
 ```
 
-Doubt density is a deliberately weak, whole-word-matched heuristic (it counts
-imperative hedges), not a measurement. Static pressure only **nominates**
-candidates. The authoritative signal is whether *removing* a scaffold changes an
-outcome — anti-pattern hit-rate (`--anti-patterns`,
-needs `aimee guardrails anti-patterns export --json`) or a scaffold A/B against the
-`tool` failure rate from `classify_failures.py`. The static score points the
-camera; the runtime signal pulls the trigger.
+The score finds high-token prompt scaffolding built around assumptions about weak models. It only
+nominates an A/B test. Delete a scaffold when measured outcomes stay flat or improve without it.
+
+The design record is
+[Four-part harness taxonomy](../../docs/proposals/done/four-part-harness-taxonomy.md).

--- a/src/README.md
+++ b/src/README.md
@@ -1,1338 +1,241 @@
-# aimee: Technical Reference
+# Technical reference
 
-Architecture, internals, and build instructions. For usage and getting started,
-see the [root README](../README.md) and the full [Manual](../MANUAL.md). For the
-system-level architecture (process topology, trust/storage boundaries, request
-lifecycles) see [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md). This document is
-the code-level companion: module map, server internals, the RPC and HTTP
-surfaces, the KB split, the build system, and testing.
+This is the code map. Start with the [architecture](../docs/ARCHITECTURE.md) for process and trust
+boundaries and the [manual](../MANUAL.md) for use.
 
-aimee's core services are written in C11 for performance and minimal footprint. The current tree is a large C codebase (hundreds of `.c` files, plus generated headers and split `*.inc` units), shipped with the standalone Go `aimee-runtime-web` service plus `aimee`, `aimee-server`, and `aimee-kb`. Runtime DB ownership is pinned: clients are DB-free, the local server owns DB1 (sqlite), and KB owns DB2 (postgres + pgvector), which can be local or shared by deployment. MCP support is built into `aimee mcp-serve`.
+## Runtime artifacts
 
-## Architecture overview
+| Artifact | Language | Owner |
+| --- | --- | --- |
+| `aimee` | C11 | DB-free thin CLI, hooks, MCP/ACP stdio, local transport |
+| `aimee-server` | C11 | DB1, resource API, agents, tools, policy, vault, provider calls |
+| `aimee-kb` | C11 | DB2, memory, documents, code graph, retrieval, curation |
+| `aimee-wfe` | Go | workflow definitions, lifecycle, artifacts, scheduler, worktrees, forge |
+| `aimee-runtime-web` | Go | authenticated browser proxy and UI service |
+| `aimee-llm` | container service | embedding, reranking, and synthesis inference |
 
-aimee supports two agent roles. The **primary agent** is the AI coding surface the user interacts with (Claude Code, Gemini CLI, direct Codex, direct Mistral, Codex CLI legacy mode, Mistral Vibe, GitHub Copilot). aimee integrates through hooks, provider-CLI adapters, or direct primary-session adapters, intercepting tool calls, injecting memory and rules, enforcing guardrails, and managing session isolation. **Delegate agents** are sub-agents configured in `agents.json` that handle offloaded work via `aimee delegate <role> <prompt>`.
+The server image supervises `aimee-server` and `aimee-wfe` as peers. Workflow lifecycle has one
+writer: Go. The C server supplies typed agent, credential, policy, and forge resources; it does not
+advance workflow state.
 
-```mermaid
-graph TB
-    subgraph Primary["Primary Agent Integration"]
-        PA[Claude Code / Gemini / Codex / Vibe / Copilot]
-        SS[SessionStart<br/>Load rules, assemble context,<br/>create worktrees]
-        Pre[PreToolUse<br/>Classify path, check plan mode,<br/>worktree enforce, anti-patterns]
-        Post[PostToolUse<br/>Re-index edited files]
-    end
+## Source map
 
-    subgraph Core["aimee Core"]
-        Mem[(DB2 Knowledge<br/>local/shared KB scope<br/>memories, rules, tasks)]
-        Vec[(pgvector<br/>memory + KB indexes)]
-        Guard[Guardrails<br/>Path classification,<br/>sensitive file blocking]
-        Idx[Code Index<br/>Symbol lookup,<br/>blast radius]
-        Rules[Rules Engine<br/>Feedback-derived rules]
-        WM[DB1 Local State<br/>sessions, windows, caches]
-    end
+```text
+src/
+  cli_*                 thin-client commands and transport
+  server/               server listeners, handlers, agent/resource plane
+  kb/                   KB daemon and HTTP surface
+  db1/                  server SQLite owner
+  db2/                  KB PostgreSQL/pgvector owner
+  modules/              owned C modules and public include trees
+    bus/                shared-memory event bus
+    audit/              WORM audit, replay, observability bridge
+    sandbox/            delegate isolation
+  tests/                C unit and integration tests
 
-    subgraph Delegate["Delegate Agent System"]
-        Router[Agent Router<br/>Cost-based selection]
-        Loop[Tool-use Loop<br/>bash, read, write]
-        HTTP[HTTP Client<br/>OpenAI / ChatGPT / Anthropic]
-    end
+server-go/
+  bus/                   pure-Go event-bus client and conformance
+  internal/wfe/          definitions, catalog, canonical snapshots
+  internal/engine/       scheduler, runners, worktrees, forge, roundtables
+  internal/db1/          Go-owned workflow store
+  internal/api/          workflow/control-plane routes
 
-    subgraph Server["Server"]
-        Srv[aimee-server<br/>HTTP /v1<br/>UDS + optional TCP]
-        MCP[aimee mcp-serve<br/>Stdio MCP server]
-    end
-
-    PA --> SS
-    PA --> Pre
-    PA --> Post
-    SS --> Mem
-    SS --> Rules
-    Pre --> Guard
-    Pre --> Idx
-    Post --> Idx
-    Mem --> Vec
-    Router --> HTTP
-    Router --> Loop
-    Srv --> Core
-    MCP --> Core
+runtime-web/             Go browser service
+frontend/                browser application
+api/                     OpenAPI sources and SDK generation
+scripts/                 checks, generation, deployment, smoke tests
 ```
 
-### Knowledge flow
+## Event bus
 
-```mermaid
-flowchart LR
-    M[DB2 knowledge<br/>memories + rules<br/>local/shared KB scope] -->|session-start| CTX[Context Assembly<br/>facts + rules + network]
-    V[pgvector] -->|recall| CTX
-    AJ[agents.json] -->|delegate context| DCTX[Delegate Context<br/>hosts, SSH, networks]
-    AL[agent_log] -->|auto-promote| DP[Delegation Patterns<br/>L2 facts]
-    MCP2[aimee mcp-serve] -->|tools| TOOLS[search, hosts,<br/>symbols, delegate]
-    PD[project descriptions] -->|inject| CTX
-    PD -->|inject| DCTX
-```
+`src/modules/bus/` provides the intra-daemon transport:
 
-## Module map
+| File | Contract |
+| --- | --- |
+| `bus_wire.*` | fixed little-endian frame codec and version validation |
+| `bus_ring.*` | SPSC bounded ring with release/acquire publication |
+| `bus_region.*` | read-only control, private queue pair, shared arena regions |
+| `bus_arena.*` | generation-checked leases and consumer references |
+| `bus_host.*` | admission, sequence, routing, correlation, flow control, reap, tap |
+| `bus_client.*` | C attach, publish, subscribe, request/reply, poll |
+| `bus_capture.*` | ordered CRC-checked capture and observational replay |
 
-### Shared runtime (linked into owning binaries only)
+One host owns all `memfd` creation. An admitted client receives only its queue pair and shared arena.
+The host stamps `seq` before routing and invokes the tap for every accepted event. Per-source FIFO is
+guaranteed; consumers see sparse global sequence numbers because they receive only authorized kinds.
 
-These modules are linked only where their ownership boundary allows them. The
-thin `aimee` and `aimee-runtime-web` targets do not link database,
-`kb_client`, command, data, or agent objects.
+The observability bridge under `modules/audit/` is the current production consumer. It serializes
+governed actions and semantic guardrail events, drains them asynchronously to typed stores, and
+flushes capture. Server and KB bridges map memory, vault, sandbox, MCP, and tool activity into that
+contract.
 
-| File | Responsibility |
-|------|----------------|
-| `config.c` | App config, `session_id()`, atomic writes |
-| `util.c` | Core utilities, option parsing, security helpers |
-| `text.c` | Text similarity, stemming, tokenization, search |
-| `render.c` | JSON output, struct-to-JSON converters |
-| `log.c` | Structured logging with level control |
-| `platform_*.c` | Platform abstractions (events, IPC, random, process) |
-| `client_integrations.c` | AI tool detection and hook registration |
-| `mcp_tools.c` | MCP tool definitions and dispatch |
-| `cJSON.c` | Vendored JSON parser |
+The Go client consumes the same golden wire vectors and links no C. Wire or layout changes require
+version negotiation, regenerated vectors only when the wire changes, and cross-language conformance.
 
-### KB-owned data layer (linked into `aimee-kb`)
+See [Event bus](../docs/EVENT_BUS.md).
 
-| File | Responsibility |
-|------|----------------|
-| `db2/db2.h` | DB2 project/workspace/global knowledge API |
-| `db2/vector_status.h` | pgvector status and repair API |
-| `memory_core.c` | High-level memory orchestration over DB2 + pgvector |
-| `memory_logic.c` | Promotion, demotion, expiry, conflict detection, delegation pattern synthesis |
-| `memory_assemble.c` | Context assembly, cache, compaction |
-| `memory_scan.c` | Conversation scanning, JSONL parsing |
-| `db2/memory_entity_graph.c` | Entity-relationship graph queries behind DB2 |
-| `memory_advanced.c` | Anti-patterns, style learning, compaction |
-| `cmd_index.c` | Code indexing CLI through aimee-kb |
-| `extractors.c`, `extractors_extra.c` | Tree-sitter symbol and reference extraction across C, C++, C#, Python, Go, JavaScript, TypeScript, Rust, Java, Ruby, PHP, Kotlin, Swift, Dart, Lua, Bash, and CSS |
-| `db2/cross_repo_resolver.c`, `db2/cross_repo_deps.c` | Cross-repo dependency resolution for the code graph |
-| `db2/rules.c` | Rule storage and tier classification behind DB2 |
-| `db2/feedback.c` | Feedback recording and reinforcement behind DB2 |
-| `guardrails.c` | Path classification, pre-tool safety checks, worktree enforcement |
-| `workspace.c` | Workspace manifest parsing, provisioning, context generation |
-| `db1/wm.c` | Session-scoped key-value store with TTL |
-| `db2/tasks.c` | Project/workspace task graph |
-| `db1/checkpoints.c` | Local checkpoints |
+## Storage ownership
 
-### Agent layer (directly linked into `aimee-server`)
+DB1 and DB2 cannot call through each other's storage layer.
 
-| File | Responsibility |
-|------|----------------|
-| `server/agent_runtime.c`, `server/agent_loop.c` | Core delegate runtime and tool-use loop |
-| `server/agent_policy.c` | Tool validation, policy, trace, metrics, env, manifest, contract |
-| `server/delegate_prompt.c`, `server/delegate_routing.c` | Delegate prompt/context shaping and route selection |
-| `server/agent_config.c` | Delegate config loading, routing, auth resolution |
-| `server/vault_service.c` | Server-sealed credential vault (agent and delegate keys, Codex OAuth) |
-| `context_fold.c`, `gateway_delegate.c` | Context economizer: deterministic context folding and ingress compression on the delegate and gateway path |
-| `server/agent_tools.c` | Tool execution (bash, read, write), checkpoints |
-| `modules/delegates/delegate_plan.c` | Delegate packet planning |
-| `agent_eval.c` | Eval harness, task suites |
-| `agent_coord.c` | Multi-delegate coordination, voting, directives |
-| `server/server_compute*.c`, `server/server_jobs_aux.c` | Durable/background delegate jobs and compute dispatch |
-| `server/delegate_openai.c`, `server/http_retry.c` | Provider HTTP shaping, retry, fallback |
+- Server builds define the DB2-disabled boundary and never link `libpq`.
+- KB builds define the DB1-disabled boundary and never link SQLite.
+- The thin client links neither database.
+- Cross-tier operations use typed `/v1` clients.
+- `scripts/check_tier_deps.sh`, link checks, and symbol checks enforce the boundary.
 
-### Server-side and legacy command modules (not linked into clients)
+The shared WORM chain primitive is pure hashing. It may be used by both stores only while it remains
+free of SQLite, libpq, handles, and storage policy.
 
-| File | Responsibility |
-|------|----------------|
-| `cmd_core.c`, `cmd_init.c`, `cmd_infra.c` | Core setup, lifecycle, and infrastructure helpers |
-| `cmd_memory*.c` | Memory subsystem handlers and legacy/maintenance surfaces |
-| `cmd_index.c`, `cmd_graph.c`, `cmd_kb*.c` | Code index, graph, and KB command handlers |
-| `cmd_rules.c`, `cmd_review.c` | Rules and review-surface helpers |
-| `cmd_hooks.c` | Primary agent integration: hooks, session-start context, wrapup |
-| `cmd_roadmap.c`, `cmd_auto.c`, `cmd_autopilot.c` | Roadmap/autonomous implementation modules; not all are routed in the thin CLI |
-| `cmd_skill.c`, `cmd_job.c`, `cmd_trigger.c` | Skill, coordinated-job, and automation helpers |
-| `cmd_util.c` | Shared helpers: db open/close, subcommand dispatch |
-| `dashboard.c` | Embedded HTTP dashboard server |
+The Go workflow SQLite store is separately owned and never dual-written by C.
 
-### Server binaries
+## Modules
 
-| File | Responsibility |
-|------|----------------|
-| `cli_main.c` | Thin client entry point and local command fallbacks |
-| `posix/cli_client.c`, `windows/cli_client.c` | Socket client libraries and explicit server start/restart fallback |
-| `cli_mcp_serve.c` | MCP server entry point |
-| `server/server.c` | dispatch table + server_dispatch (shared by the /v1 surface) |
-| `server/server_main.c` | aimee-server entry point, signal handling |
-| `server/server_auth.c` | Authentication (peer credentials, capability tokens) |
-| `server_session.c` | Session management |
-| `server_state.c` | Handlers: memory, index, rules, working memory, dashboard |
-| `server_compute.c` | Async compute pool for delegate execution and tool calls |
-| `compute_pool.c` | Thread pool |
+An owned module has:
 
-### Header policy
+- a narrow public header under its include tree;
+- private implementation files;
+- a descriptor naming dependencies, capabilities, config, event kinds, and routes;
+- focused tests;
+- current module documentation generated or attested from the descriptor.
 
-`aimee.h` includes shared types and non-agent subsystem headers. Agent headers are NOT in `aimee.h`. Each `.c` file includes only the narrow agent headers it needs (`agent_types.h`, `agent_config.h`, `agent_exec.h`, etc.).
+Dependency direction matters more than physical directory. A lower owner does not include a higher
+owner to reach state. Cross-owner calls use the public contract.
 
-### Command pattern
+The old arbitrary plugin loader is retired. Optional modules attach through declared module or event
+contracts; loading code into the core is not an extension API.
 
-Commands are registered in `main.c` as a `command_t` table. All handlers take `(app_ctx_t *ctx, int argc, char **argv)`. Complex commands use `subcmd_t` subtables with `subcmd_dispatch()`.
+## HTTP and CLI contracts
 
-### Module decomposition roadmap
+Named `/v1` routes are described once and checked against handlers, OpenAPI, the thin-client route
+table, and generated docs. The generic `/v1/rpc` path is gone.
 
-The largest source files are tracked for decomposition in waves (split the biggest modules first while preserving their public APIs).
+Commands follow the same rule: implement the local operation or typed server route, add canonical
+help, then expose it in the command registry. Do not advertise server-internal handlers from the
+DB-free client.
 
-**Current hotspots (>1000 lines, approximate):**
+Configuration scalar fields come from the field descriptor table. Defaults, parsing, schema, CLI,
+browser settings, and generated docs must agree.
 
-| File | Lines | Target wave |
-|------|-------|-------------|
-| `server/server_mcp.c` | ~1999 | Wave 3, split remaining MCP tool families from dispatch |
-| `server/agent_tools.c` | ~1825 | Wave 2, split schema generation from tool execution |
-| `modules/kb_client/kb_client.c` | ~1781 | Wave 4, split remaining KB client families |
-| `modules/kb_client/kb_client_memory.c` | ~1457 | Wave 4, split remaining memory RPC wrappers |
-| `memory_advanced.c` | ~1079 |, (single responsibility, acceptable size) |
-| `posix/cli_client.c` | ~1073 |, (single responsibility, acceptable size) |
+Provider-specific request and response JSON ends in translation modules. Core stages operate on
+canonical IR.
 
-**Wave sequence:** Wave 1 (abstractions) → Wave 2 (tools/hooks) → Wave 3 (service/UI) → Wave 4 (data layer). Each wave is an independent PR.
+## Build
 
-## Memory system
-
-```mermaid
-graph TD
-    L0[L0: Session Memory<br/>Scratch, in-progress state<br/>Lifetime: session only]
-    L1[L1: Recent Memory<br/>Decisions, context, checkpoints<br/>Lifetime: 30 days]
-    L2[L2: Long-term Memory<br/>Stable facts, preferences, patterns<br/>Lifetime: persistent]
-    L3[L3: Episodic Memory<br/>Past attempts, outcomes, failures<br/>Lifetime: persistent with decay]
-
-    L0 -->|accordion fold<br/>at session end| L1
-    L1 -->|3 reuses or<br/>confidence >= 0.9| L2
-    L2 -->|unused 60 days +<br/>confidence < 0.7| L1
-    L3 -.->|auto from<br/>session end| L3
-
-    AL[agent_log] -->|delegation patterns<br/>auto-synthesized| L2
-```
-
-### Memory kinds
-
-| Kind | Description | Example |
-|------|-------------|---------|
-| `fact` | Verified information | "PostgreSQL runs on port 5432" |
-| `preference` | User style/behavior | "User prefers concise responses" |
-| `decision` | Choice with rationale | "Chose JWT over sessions: stateless" |
-| `episode` | Past attempt narrative | "Session: refactored auth module" |
-| `task` | Work item or goal | "Implement user authentication" |
-| `scratch` | Temporary working data | Current task state |
-
-### Deduplication pipeline
-
-New memories pass through canonicalization before storage to prevent duplicates:
-
-```mermaid
-flowchart TD
-    Input[New memory input] --> Norm[1. Normalize<br/>lowercase, strip fillers,<br/>collapse whitespace]
-    Norm --> Exact{2. Exact key match<br/>through DB2 memory API?}
-    Exact -->|yes| Merge1[Merge: keep higher confidence,<br/>increment use_count]
-    Exact -->|no| Trigram{3. Trigram similarity >= 0.7<br/>vs top 100 same-kind?}
-    Trigram -->|yes| Merge2[Merge into existing]
-    Trigram -->|no| Insert[4. Insert new memory<br/>with tier, kind, confidence,<br/>provenance]
-```
-
-### Contradiction detection
-
-When memories conflict, aimee detects the contradiction via negation asymmetry analysis and word similarity. Both conflicting memories get their confidence reduced (`*= 0.7`), with the conflict recorded in `memory_conflicts`.
-
-### Temporal fact versioning
-
-Facts change over time. The KB-side memory pipeline can supersede a fact: the old version gets a `#vN` suffix and `valid_until` timestamp, and the new version takes the canonical key with `valid_from`. Thin clients see this through routed memory responses rather than a direct storage command.
-
-## Search
-
-### Fact search
-
-Fact search uses the high-level memory pipeline: DB2 supplies lexical and structured candidates, pgvector (inside DB2) supplies dense vector candidates, and the caller sees a ranked result set without depending on either path's query primitives.
-
-### Window search
-
-Conversation history search combines four scoring signals:
-
-```mermaid
-flowchart TD
-    Q[Query] --> TM[Term Match<br/>exact lowercase match<br/>through DB1 API]
-    Q --> LM[DB1 Lexical Match<br/>summary-token recall<br/>through DB1 API]
-    Q --> GB[Graph Boost<br/>2-hop entity edges<br/>decay by 1/hop]
-
-    TM --> Combine[Combine scores]
-    LM --> Combine
-    GB --> Combine
-
-    Combine --> TD2[Apply time decay<br/>1 / 1 + days * 0.02]
-    TD2 --> TW[Apply tier weight<br/>raw:1.0 summary:0.7 fact:0.4]
-    TW --> Final[Final score<br/>sorted, top N]
-```
-
-## Guardrails
-
-Before every tool call from the primary agent or delegate agents, aimee classifies the target path:
-
-```mermaid
-flowchart TD
-    TC[Tool call: Edit/Write/Bash] --> Classify[Classify target path]
-    Classify --> Sensitive{Sensitive file?<br/>.env, credentials, keys}
-    Sensitive -->|yes| Block1[BLOCK exit 2]
-    Sensitive -->|no| WTCheck{Real workspace path<br/>has worktree?}
-    WTCheck -->|yes| Block2[BLOCK + redirect<br/>to worktree path]
-    WTCheck -->|no| PlanMode{Planning mode<br/>active?}
-    PlanMode -->|yes, write op| Block3[BLOCK writes]
-    PlanMode -->|no| AntiPat[Check anti-patterns<br/>WARN on stderr]
-    AntiPat --> Drift[Check drift detection<br/>WARN if off-scope]
-    Drift --> Allow[ALLOW exit 0]
-```
-
-### Guardrail modes
-
-| Mode | Yellow/Amber | Red/Block |
-|------|-------------|-----------|
-| `approve` (default) | Silently allow | Block + inform |
-| `prompt` | Block + inform | Block + inform |
-| `deny` | Silently block | Silently block |
-
-### Planning mode
-
-When active, blocks all write operations (Edit, Write, MultiEdit, destructive commands). Read-only operations always allowed.
-
-## Anti-pattern detection
-
-aimee maintains a database of known bad patterns extracted from negative feedback rules (weight >= 50), failed decisions, and manual additions. Before every tool call, the pre-hook checks for matches and emits warnings on stderr (non-blocking).
-
-## Drift detection
-
-When a task is active (`state = "in_progress"`), aimee monitors whether tool calls stay within the task's scope. Scope is determined from key terms in the task title, referenced projects, and subtask titles. Off-scope edits trigger warnings on stderr.
-
-## Task graph
-
-```mermaid
-graph LR
-    A[Design auth API<br/>done] -->|depends_on| B[Implement auth<br/>in_progress]
-    B -->|depends_on| C[Write unit tests<br/>todo]
-```
-
-Edge types: `depends_on`, `supersedes`, `decided_by`, `evidence_for`, `failed_because`, `blocks`. Decisions are logged with rationale and assumptions.
-
-## Context assembly
-
-aimee assembles different context for the primary agent and delegate agents. By injecting pre-assembled facts, rules, project descriptions, and network info at session start, agents avoid spending tokens on re-discovery.
-
-### Primary agent context (32KB buffer)
-
-Assembled by `build_session_context()` in `cmd_session_lifecycle.c`, printed to stdout at session start.
-The default brief is scoped to the hook client's current working directory so it stays focused on
-the active project. Set `AIMEE_SESSION_START_VERBOSE=1` to include broad diagnostic sections.
-
-| Section | Source | Content |
-|---------|--------|---------|
-| Code Principles | `prompt_code_principles_text()` | Engineering rules that should apply everywhere |
-| Aimee Context | hardcoded tips | Short reminders for index, memory, delegation, and brief inspection |
-| Rules | `db2_rules_generate()` | Behavioral rules from feedback |
-| Project Context | DB2 memory scope APIs | Project-scoped facts |
-| Delegation | agent config | Delegate instructions + examples |
-| Key Facts | `memory_list(L2, fact)` | Verbose only: top global facts |
-| Network | `agents.json` | Verbose only: SSH entry, hosts, networks |
-| Shared Context | DB2 memory scope APIs | Verbose only: global/shared memories |
-| Recent Delegations | `agent_log` (last 5) | Verbose only: delegate success/failure history |
-| Project Descriptions | `workspace_build_context()` | Verbose only: all indexed workspace descriptions |
-| Capabilities | `build_capabilities_text()` | Verbose only: available aimee commands |
-
-### Delegate agent context (16KB budget)
-
-Assembled by `agent_build_exec_context()` / `agent_build_exec_context_ex()` in
-the platform agent runtime, sent as system prompt:
-
-| Section | Source | Content |
-|---------|--------|---------|
-| Custom Prompt | caller-provided | Task-specific instructions |
-| Rules | `db2_rules_generate()` | Behavioral rules |
-| Relevant Memory | `memory_find_facts()` | Top matching facts |
-| Code Index | aimee-kb index RPCs | Relevant symbols |
-| Network Access | `agents.json` | All hosts, SSH entry, networks |
-| Working Memory | `wm_assemble_context()` | Session key-values |
-| Active Tasks | `db2_task_list()` | In-progress work |
-| Recent Failures | `agent_log` (5min window) | Last 3 failures |
-
-## MCP server
-
-The `aimee mcp-serve` command exposes knowledge as JSON-RPC 2.0 tools over stdio for MCP-compatible primary agents:
-
-| Tool | Source | Returns |
-|------|--------|---------|
-| `search_memory` | `memory_find_facts()` (DB2 lexical + pgvector dense recall + reranking) | Matching facts by keyword and phrase |
-| `list_facts` | `memory_list(L2, fact)` | All stored L2 facts |
-| `memory_briefing` / `memory_recall` | KB memory briefing/recall RPCs | Structured task/session memory bundles |
-| `get_host` | `agents.json` | Single host by name |
-| `list_hosts` | `agents.json` | All hosts + networks |
-| `find_symbol` | DB2 code-index API / aimee-kb RPC | Code symbol locations |
-| `ast_grep_search` | bundled `sg` binary | Structural code-search matches |
-| `preview_blast_radius` | DB2 code-index API / aimee-kb RPC | File dependency impact |
-| `learning_review` / `session_search` / `autopilot` | server-side tools | Learning review, local session search, and internal autopilot actions |
-| `ast_grep_search` | `sg --json` | Structural AST pattern matches |
-| `delegate` | `popen("aimee delegate")` | Delegation result |
-| `preview_blast_radius` | `index_blast_radius()` | File dependency impact |
-| `record_attempt` | `agent_log` | Log a delegation attempt |
-| `list_attempts` | `agent_log` | Recent delegation history |
-| `delegate_reply` | `agent_log` | Follow-up on prior delegation |
-
-Codex CLI legacy support is layered on top of the same `aimee mcp-serve`
-command. When `~/.codex` is present, `install.sh` and `update.sh` refresh a
-local marketplace entry, mirror the plugin payload, and write an activation
-entry in `~/.codex/config.toml`. Direct Codex primary sessions use the
-server-side primary session adapter instead of the CLI.
-
-## Interaction style learning
-
-aimee analyzes negative feedback for recurring patterns:
-
-| Keywords detected 2+ times | Auto-generated preference |
-|----------------------------|--------------------------|
-| "verbose", "too long", "wordy" | "User prefers concise responses" |
-| "too short", "more detail" | "User prefers detailed explanations" |
-| "format", "structure" | "User wants consistent formatting" |
-
-Learned preferences are stored as L2 memories and injected into both primary and delegate agent contexts.
-
-## Delegate agent system
-
-```mermaid
-flowchart TD
-    PA[Primary Agent] -->|aimee delegate role prompt| CLI[aimee CLI]
-    CLI --> Route[agent_route<br/>find cheapest for role]
-    Route --> D1[Ollama<br/>tier 0, free]
-    Route --> D2[Codex / ChatGPT<br/>tier 0, subscription]
-    Route --> D3[OpenAI-compatible<br/>tier N]
-
-    D2 -->|HTTP 400?| FB[Retry with<br/>fallback_model]
-    D1 -->|failure?| Chain[Next in<br/>fallback chain]
-    D3 -->|--retry N?| Retry[Auto-retry<br/>transient failures]
-```
-
-### Provider types
-
-| Provider | Endpoint | Request format |
-|----------|----------|---------------|
-| `openai` (default) | `/v1/chat/completions` | `messages` array, `max_tokens` |
-| `chatgpt` | `/backend-api/codex/responses` | `input` array, `instructions` |
-| `anthropic` | `/v1/messages` | `messages` array, `system` (top-level) |
-
-### Authentication
-
-| Auth type | Config | Use case |
-|-----------|--------|----------|
-| `none` | `"auth_type": "none"` | Local Ollama |
-| `bearer` | `"api_key": "$OPENAI_API_KEY"` | OpenAI, Together, Groq |
-| `oauth` | provider-managed token file or helper | Codex/Gemini subscription |
-| `x-api-key` | `"auth_cmd": "cat ~/.config/aimee/claude.key"` | Anthropic Claude |
-
-### Delegate roles
-
-| Role | Description |
-|------|-------------|
-| `code` | Write or edit code |
-| `review` | Analyze code/plans |
-| `explain` | Explain concepts |
-| `refactor` | Restructure code |
-| `draft` | Generate content |
-| `execute` | Run agentic tasks (multi-turn tool-use) |
-| `summarize` | Compress text |
-| `format` | Reformat data |
-| `search` | Find information |
-| `reason` | Complex reasoning |
-
-### Delegate options
-
-| Flag | Description |
-|------|-------------|
-| `--tools` | Enable tool-use mode (bash, read_file, write_file) |
-| `--retry N` | Auto-retry on transient failures |
-| `--verify CMD` | Run CMD after delegation; exit 3 on failure |
-| `--context-dir DIR` | Bundle directory into prompt |
-| `--prompt-file PATH` | Read prompt from file |
-| `--files F` | Pre-load comma-separated file contents |
-| `--background` | Create a server-owned job and return job_id immediately |
-| `--timeout N` | Override per-call timeout (ms) |
-
-### Cross-verification
-
-| Direction | Trigger | Action |
-|-----------|---------|--------|
-| Verify delegate output | Automatic after `aimee delegate` | Runs `verify_cmd` (build/test) |
-| Delegate reviews supervisor diff | `aimee verify` | Sends diff to delegate for review |
-
-## Database schema
-
-```
-Tier-owned schemas:
-
-DB1: local sessions, windows, checkpoints, caches, delegate jobs, eval
-     results, local secrets, local interaction/learning signals, and
-     same-user runtime state owned by the local aimee-server.
-DB2: memories, rules, KB metadata, tasks, decisions, code index metadata,
-     learning records, project/workspace/global facts, and the pgvector
-     collections + payload indexes derived from those records. DB2 belongs to
-     aimee-kb and can be local or shared; local evidence is reflected or
-     promoted there only when it is appropriate for the configured KB scope.
-```
-
-## Server architecture
-
-```mermaid
-graph TD
-    subgraph Binaries
-        Client["aimee<br/>thin CLI + MCP serve"]
-        Webchat["aimee-runtime-web<br/>DB-free browser client"]
-        Server["aimee-server<br/>DB1 + compute pool"]
-        KB["aimee-kb<br/>DB2 + pgvector<br/>local/shared KB"]
-    end
-
-    subgraph Libraries
-        Core["Core runtime objects<br/>db, config, util, text,<br/>render, cJSON, platform,<br/>MCP git handlers"]
-        Data["Server-linked data layer<br/>memory, index, rules, tasks,<br/>guardrails, workspace"]
-        Agent["Server-linked agent layer<br/>delegate loop, tools, HTTP,<br/>policy, plan, eval"]
-        Cmd["Server-linked RPC handlers<br/>session, compute, MCP,<br/>dashboard"]
-    end
-
-    Client -.->|socket| Server
-    Webchat -.->|socket| Server
-    Client -->|mcp-serve| Core
-    Server --> Core
-    Server --> Data
-    Server --> Agent
-    Server --> Cmd
-    Server -.->|typed KB /v1 HTTP| KB
-    Core --> Data
-    Data --> Agent
-    Agent --> Cmd
-```
-
-Each layer depends only on layers below it. No circular dependencies.
-
-### Server features
-
-- HTTP `/v1` surface over `~/.config/aimee/aimee-http.sock` (+ optional localhost TCP)
-- per-connection worker threads for the HTTP listener (never blocks the accept loop)
-- 8-thread bounded compute pool for delegate executions, chat, and tool calls
-- `SO_PEERCRED` authentication with 16 capability flags
-- Trust levels: unattested (read-only), attested (full access via capability token)
-- Rate limiting on auth failures
-- Request dispatch through tier-owned DB APIs
-- Graceful shutdown with SIGTERM
-
-### Protocol methods (27+)
-
-| Category | Methods |
-|----------|---------|
-| Server | `server.info`, `server.health` |
-| Auth | `auth` |
-| Hooks | `hooks.pre`, `hooks.post` |
-| Sessions | `session.create`, `session.list`, `session.get`, `session.close` |
-| Memory | `memory.search`, `memory.store`, `memory.list`, `memory.get` |
-| Index | `index.find`, `index.blast_radius`, `index.list` |
-| Rules | `rules.list`, `rules.generate` |
-| Working memory | `wm.set`, `wm.get`, `wm.list`, `wm.context` |
-| Dashboard | `dashboard.metrics`, `dashboard.delegations` |
-| Workspace | `workspace.context` |
-| Tool execution | `tool.execute` |
-| Delegation | `delegate` |
-| Streaming chat | `chat.send_stream` |
-
-### Server lifecycle
-
-The server is normally owned by service management: `install.sh` installs and enables systemd user units on Linux and launchd plists on macOS. The thin client no longer auto-spawns a server for ordinary RPC commands; `aimee server start` is an explicit unmanaged fallback, and `aimee server restart` is the explicit version-drift recovery path.
-
-## Delegate agent configuration
-
-Delegates are defined in `~/.config/aimee/agents.json`. Codex, Gemini, and
-Mistral can use direct HTTP adapters. `codex-cli` and Claude use installed
-provider CLIs, while `gemini-cli`, `mistral-cli`, and `mistral-plan` keep the
-provider-CLI configuration shape but execute through native HTTP adapters
-instead of launching the provider binaries. Gemini uses `GEMINI_API_KEY` or
-`GOOGLE_API_KEY`; Mistral routes use `MISTRAL_API_KEY` or `~/.vibe/.env`.
-These entries are still delegate agents; the user-facing primary agent is
-configured separately by the launch, CLI chat, or webchat surface.
-Provider-CLI routes that still launch a local CLI are available only when
-`cli_cmd` resolves to an executable on `PATH` or an executable absolute path.
-Native Gemini and Mistral routes are routable without a CLI on `PATH`.
-
-```json
-{
-  "agents": [
-    {
-      "name": "codex",
-      "provider": "codex",
-      "backend": "provider-cli",
-      "cli_kind": "codex",
-      "cli_cmd": "codex",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "cost_tier": 0,
-      "enabled": true
-    },
-    {
-      "name": "claude",
-      "provider": "claude",
-      "backend": "tmux-cli",
-      "cli_cmd": "claude",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "cost_tier": 1,
-      "enabled": true
-    },
-    {
-      "name": "gemini-cli",
-      "provider": "gemini",
-      "backend": "provider-cli",
-      "cli_kind": "gemini",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "cost_tier": 0,
-      "enabled": true
-    },
-    {
-      "name": "mistral-cli",
-      "provider": "mistral",
-      "backend": "provider-cli",
-      "cli_kind": "mistral",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "cost_tier": 0,
-      "enabled": true
-    },
-    {
-      "name": "mistral-plan",
-      "provider": "mistral",
-      "backend": "provider-cli",
-      "cli_kind": "mistral-plan",
-      "roles": ["code", "review", "explain", "refactor", "draft", "execute"],
-      "cost_tier": 0,
-      "enabled": true
-    },
-    {
-      "name": "local-llama",
-      "endpoint": "http://localhost:11434/v1",
-      "model": "llama3.2",
-      "auth_type": "none",
-      "roles": ["summarize", "format", "draft"],
-      "cost_tier": 0,
-      "enabled": true
-    }
-  ],
-  "default_agent": "codex",
-  "fallback_chain": ["codex", "claude", "local-llama"]
-}
-```
-
-## Storage paths
-
-```
-~/.config/aimee/
-  aimee.yaml                # Workspaces, guardrail mode, primary agent provider
-  agents.json               # Delegate agent config + network inventory
-  aimee.db                  # DB1 local server/user/session state
-  aimee-http.sock           # aimee-server /v1 HTTP Unix socket
-  server.log                # Server debug log
-  session-<id>.state        # Per-session state
-  worktrees/<id>/<project>/ # Per-session git worktrees
-  projects/<name>.md        # Auto-generated project descriptions
-  tls/cert.pem, key.pem    # Self-signed TLS certs (webchat)
-
-<project>/.mcp.json           # MCP server config (auto-generated)
-<project>/.aimee/project.yaml # Per-project metadata (build, test, lint)
-```
-
-## Building
+From the repository root:
 
 ```bash
-cd src
-make                # Build DB-free clients (-> ../aimee, ../aimee-runtime-web)
-make server         # Build server and KB binaries (-> ../aimee-server, ../aimee-kb)
-make                # MCP serve is built into the aimee binary
-make install        # Install aimee, aimee-runtime-web, aimee-server, and aimee-kb
-make lint           # Check clang-format
-make format         # Auto-fix formatting
-make unit-tests     # Build and run all tests
-make clean          # Remove build artifacts
+make -C src -j4
 ```
 
-### Dependencies
+Useful targets:
 
-| Library | Purpose | Linking | Platform |
-|---------|---------|---------|----------|
-| SQLite3 | DB1 local store | `-lsqlite3` | `aimee-server` only |
-| libpq | DB2 service access (incl. pgvector) | discovered with `pkg-config` | `aimee-kb` only |
-| libm | Math functions | `-lm` | All |
-| libpthread | Parallel delegates, server | `-lpthread` | Linux/macOS |
-| libpam | PAM authentication | `-lpam` | Linux |
-| libssl/libcrypto | TLS and auth provider support | `-lssl -lcrypto` | `aimee-server`, `aimee-kb` |
-| libcurl | HTTP client (delegates) | `-lcurl` | `aimee-server` |
-| cJSON | JSON parsing | Compiled in (vendored) | All |
+| Target | Result |
+| --- | --- |
+| `all` | client, web service, server, KB, gateway/forwarder targets for this checkout |
+| `server` | server, KB, and required service artifacts |
+| `kb` | KB only |
+| `lean` | stripped size-gated build |
+| `frontend` | browser assets |
+| `install` | install built artifacts |
+| `clean` | remove generated build output |
 
-### Code style
+The GNU Make build is canonical for Linux. Keep CMake in sync for native thin-client and portable
+test builds.
 
-Enforced by `.clang-format`:
-
-- 3-space indentation, no tabs
-- Allman brace style
-- `snake_case` functions, `SCREAMING_CASE` constants
-- Right-aligned pointers (`char *str`)
-- 100-character line limit
-- No automatic include sorting
-
-## Deployment and operations
-
-Operator-facing install, Docker topologies, remote operation, scaling, and the
-performance budget. (For getting started, see the
-[root README](../README.md#get-started) and the
-[Quickstart](../docs/QUICKSTART.md).)
-
-aimee ships four artifacts: `aimee`, `aimee-runtime-web`, `aimee-server`, and
-`aimee-kb`. The client and webchat talk only to the local `aimee-server`; runtime
-state stays in server-owned DB1, knowledge lives behind `aimee-kb` in DB2 (local or
-shared Postgres). The intended deployment runs the **services in Docker** and
-installs only the **thin `aimee` CLI** on each developer machine, pointed at the
-server.
-
-### Performance
-
-Hook checks sit in the critical path between the AI and every file edit, so they
-must be fast.
-
-| Operation | p50 | p99 |
-|-----------|-----|-----|
-| Hook pre-tool check | 1ms | 19ms |
-| Session startup | 8ms | 13ms |
-| Memory search | 7ms | 18ms |
-
-### Install
-
-#### 1. Run the server (Docker)
-
-The split stack (`compose.server.yaml`) brings `aimee-server` and `aimee-kb` up
-together as separate services. Postgres (pgvector) comes up alongside them, and the
-CPU inference gateway runs as the `aimee-llm` service:
+## Tests and checks
 
 ```bash
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee
-docker compose -f compose.server.yaml up --build -d
+make -C src unit-tests
+make -C src lint
+make -C src check-linking
+make -C src integration-tests
 ```
 
-The server fronts `/v1` over native TLS on `:8743` (default bearer `aimee-local-dev`;
-self-signed cert, plaintext `:8740` is loopback-only) and reaches the kb over HTTP at
-`http://aimee-kb:8741`. Confirm it's live (`-k` accepts the self-signed cert):
+Run the narrow unit executable while iterating. Test names follow `unit-test-<area>` under the build
+object tree.
+
+High-value gates:
+
+| Gate | Protects |
+| --- | --- |
+| tier and link checks | DB1/DB2/thin-client ownership |
+| module boundary checks | public-header and dependency contracts |
+| route/API checks | descriptor, handler, OpenAPI, and client parity |
+| CLI help coverage | command implementation and help parity |
+| docs generation check | generated reference drift |
+| proposal reconciliation | pending/done state and links |
+| sanitizer call-site check | required allocator/concurrency test coverage |
+| build variants | compile-time feature boundaries |
+| event-bus conformance | C/Go wire and behavior parity |
+| event-bus perf gate | bounded dispatch overhead |
+
+Use ASAN/UBSAN for ownership and parsing changes. Use TSAN for rings, arena leases, publishers,
+shutdown, worker pools, and any new cross-thread lifetime.
 
 ```bash
-curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
-curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/kb/status
+make -C src unit-tests \
+  OBJDIR=build/obj-asan \
+  EXTRA_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -O1" \
+  EXTRA_L_FLAGS="-fsanitize=address,undefined"
 ```
 
-**One stack, split services.** `compose.server.yaml` runs `aimee-server` and
-`aimee-kb` as separate containers brought up together, so you can scale, update, or
-place them independently (many servers → one shared kb) while a single compose file
-stands the whole stack up. See [Run in Docker](#run-in-docker) for every topology.
-
-> Set a real bearer for anything but local dev. `aimee-local-dev` is a loopback
-> convenience; override it (and consider TLS termination) on any networked
-> deployment.
-
-#### 2. Install the thin client
-
-Each developer installs only the `aimee` CLI and points it at the server. Prebuilt
-binaries for **Linux, macOS, and Windows** are attached to every GitHub release;
-download one, put it on your `PATH`, and skip the build. To build it yourself,
-configure with `-DAIMEE_THIN_CLIENT=ON` (a C compiler is the only dependency; no
-Go, libpq, or zstd); see [Build just the thin client](#build-just-the-thin-client).
-
-Point the client at the server per-invocation, via the environment, or persist it:
+Go work runs with the race detector for scheduler, store, bus, API, and recovery changes:
 
 ```bash
-# Per-invocation:
-aimee --server https://my-host:8743 --server-token=aimee-local-dev status
-
-# Or via environment (applies to every command):
-export AIMEE_SERVER_URL=https://my-host:8743
-export AIMEE_SERVER_TOKEN=aimee-local-dev
-aimee status
-
-# Or persist it (stored in <aimee_home>/remote.conf):
-aimee remote set https://my-host:8743 aimee-local-dev
-aimee remote status   # shows the resolved transport + a /v1/health probe
-aimee remote clear    # revert to a local Unix socket
+cd server-go
+go test -race ./...
 ```
 
-Precedence is `--server` flag > `AIMEE_SERVER_URL` env > persisted `remote.conf`.
-
-`https://` URLs are supported on Linux/macOS builds (OpenSSL), with certificate
-verification on by default. For a self-signed/private server, `aimee remote set`
-pins its certificate on first use (trust-on-first-use) so verification then passes
-with no further configuration; `aimee remote trust` re-pins after a cert rotation.
-The Windows thin client is built without TLS and refuses `https://`; terminate TLS
-at a reverse proxy and use its `http://` address.
-
-**What a remote thin client can and can't do.** The remote transport drives the
-**data/RPC plane**: `memory`, `kb`, `rules`, `index`, `sessions`, `notes`, and so
-on. Interactive front ends (**web chat**, `acp-serve`) need a *co-located* server: they
-run the agent and its tools on the client host and chdir into a local worktree, so
-they refuse a remote endpoint. **Writes are off by default over the network**
-(leaked-bearer protection): a remote bearer is read/query only until the server opts
-in via `aimee.api.remote_writes`; see
-[Drive a remote server with the CLI](#drive-a-remote-server-with-the-cli).
-
-#### 3. Configure your AI coding tool
-
-On each developer machine, run `./configure-hooks.sh` (or `configure-hooks.ps1` on
-Windows) from a checkout to register aimee's SessionStart/PreToolUse/PostToolUse
-hooks and MCP server for every detected tool (Claude Code, Gemini CLI, Codex CLI,
-GitHub Copilot). The hooks call the thin client, which reaches your server. The
-source install (below) does this for you as its last step.
-
-#### Single-box source install (no Docker)
-
-To build and run everything on one host without containers:
+## Generated documentation and APIs
 
 ```bash
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee
-./install-deps.sh   # system packages + PostgreSQL bootstrap (uses sudo)
-./install.sh        # build + install + configure (no sudo)
+make -C src docs-gen
+make -C src docs-gen-check
+make -C src api-conformance-check
+make -C src server-api-conformance-check
+make -C src gen-sdks
+make -C src sdk-parity-check
 ```
 
-`install-deps.sh` installs the system packages aimee builds against and bootstraps
-the `aimee_shared` PostgreSQL database. Those are the only steps that need root.
-`install.sh`
-builds from source, installs binaries to `~/.local/bin/`, installs service units
-where supported (systemd user units on Linux, launchd agents on macOS), enables
-`aimee-kb` then `aimee-server`, and configures hooks + MCP for every detected tool.
-If a dependency is missing, `install.sh` stops and points you back at
-`install-deps.sh`. On **Windows**, aimee runs as the thin client only (server + kb
-run in Docker or on Linux/macOS): run `install.ps1`, point it at your server with
-`aimee remote set https://host:8743 <token>` (the server's `/v1` is TLS-only
-off-loopback with a self-signed cert, which `remote set` pins automatically),
-and run `configure-hooks.ps1`.
-
-The C services (`aimee`, `aimee-server`, `aimee-kb`) need no Go. The browser UI
-(`aimee-runtime-web`) is the only Go artifact and is **optional**: `install.sh` builds
-it when a suitable Go toolchain is on `PATH` (see `webchat/go.mod` for the version)
-and otherwise skips it with a note.
-
-Source-build prerequisites (only needed if installing dependencies by hand):
-
-| Package | Debian/Ubuntu | macOS |
-|---------|---------------|-------|
-| C compiler | `apt install build-essential` | Xcode CLT |
-| pkg-config | `apt install pkg-config` | `brew install pkg-config` |
-| SQLite3 (FTS5) | `apt install libsqlite3-dev sqlite3` | System SQLite |
-| libpq | `apt install libpq-dev` | `brew install libpq` |
-| libzstd | `apt install libzstd-dev` | `brew install zstd` |
-| libcurl | `apt install libcurl4-openssl-dev` | `brew install curl` |
-| PAM (webchat) | `apt install libpam0g-dev` | built-in |
-| PostgreSQL + pgvector | `apt install postgresql postgresql-NN-pgvector` | `brew install postgresql pgvector` |
-| ripgrep, universal-ctags | `apt install ripgrep universal-ctags` | `brew install ripgrep universal-ctags` |
-| Go (optional, `aimee-runtime-web` only) | see `webchat/go.mod` | `brew install go` |
-
-**Local or remote knowledge base.** `install.sh` asks whether to run `aimee-kb`
-**locally** (default, backed by the local Postgres) or point at an existing
-**remote** `aimee-kb` over HTTP. Remote persists `kb_client_url` (and an optional
-bearer) to `aimee.yaml`, skips the local sidecar and Postgres, and `aimee-server`
-reaches the remote kb on every launch. For a remote-only host, also skip the
-database bootstrap: `AIMEE_KB_MODE=remote ./install-deps.sh`.
-
-#### Verify
-
-```bash
-aimee version
-aimee status
-```
-
-`aimee status` reports server, DB1, and kb health. Against a Docker server, set
-`AIMEE_SERVER_URL`/`AIMEE_SERVER_TOKEN` (or `aimee remote set`) first. On a source
-install, if `aimee status` can't reach the socket, start the service with
-`systemctl --user start aimee-server` (systemd) or `aimee server start` (the
-cross-platform fallback).
-
-#### Build just the thin client
-
-For packaging hosts that ship only the `aimee` CLI (no server, kb, gateway, or
-webchat), configure with `-DAIMEE_THIN_CLIENT=ON`. That restricts the build to the
-`aimee` target, so the box needs only a C compiler. Combine with `-DAIMEE_LEAN=ON`
-for the size-optimized strip. Add OpenSSL on Linux/macOS to keep `https://` support;
-skip it on Windows and terminate TLS at a reverse proxy.
-
-**Linux / macOS:**
-
-```bash
-cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
-      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF
-cmake --build build --target aimee
-```
-
-**macOS (Homebrew OpenSSL is keg-only; point CMake at it):**
-
-```bash
-cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
-      -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
-      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF
-cmake --build build --target aimee
-```
-
-**Windows (MinGW, no TLS; use a TLS-terminating proxy for `https://`):**
-
-```bash
-cmake -B build -G "MinGW Makefiles" \
-      -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
-      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=OFF
-cmake --build build --target aimee
-```
-
-Point the resulting binary at a remote server with `--server http://host:port` or
-`AIMEE_SERVER_URL`; precedence and TLS behavior match above.
-
-### Scaling and multi-user deployment
-
-Scaling follows the storage boundary: per-user state and shared knowledge live in
-different processes and scale differently.
-
-```mermaid
-graph TB
-    subgraph Users["Many users / machines"]
-        S1["aimee-server (user A)<br/>DB1 · SQLite (local)"]
-        S2["aimee-server (user B)<br/>DB1 · SQLite (local)"]
-        S3["aimee-server (user C)<br/>DB1 · SQLite (local)"]
-    end
-    LB["Load balancer<br/>HTTP :8741"]
-    subgraph KB["aimee-kb replicas (stateless)"]
-        K1["aimee-kb"]
-        K2["aimee-kb"]
-        K3["aimee-kb"]
-    end
-    PG[("PostgreSQL · aimee_shared<br/>pgvector → pgvectorscale at scale")]
-
-    S1 --> LB
-    S2 --> LB
-    S3 --> LB
-    LB --> K1
-    LB --> K2
-    LB --> K3
-    K1 --> PG
-    K2 --> PG
-    K3 --> PG
-```
-
-- **`aimee-server` is 1:1 with a user.** It owns local same-user state (DB1/SQLite)
-  and authenticates by peer UID, so each developer runs exactly one server on their
-  own machine. Single-tenant and local by design; never sharded or replicated.
-- **`aimee-kb` is the shared, horizontally-scalable tier.** All durable state lives
-  in Postgres; a KB process is otherwise a stateless request server plus background
-  workers. One KB deployment serves many `aimee-server` instances; scale it by
-  running **multiple `aimee-kb` replicas behind a load balancer** on HTTP `:8741`.
-  The ingest/curator workers coordinate purely through Postgres
-  (`FOR UPDATE SKIP LOCKED`), so adding replicas needs no external coordinator.
-- **The database is standard Postgres.** Knowledge rows and their vector embeddings
-  live in one database (`aimee_shared`) with the `pg_trgm` and `vector` (pgvector)
-  extensions. Scale it like any Postgres: bigger instance, pooling, read replicas.
-  For large vector corpora add **`pgvectorscale`** (StreamingDiskANN) on top of
-  pgvector, with identical data and queries, so switching is a reindex, not a migration.
-  Small and local installs stay on plain pgvector (HNSW).
-
-See the [Manual](../MANUAL.md#275-scaling-and-multi-user-deployment) and
-[Architecture](../docs/ARCHITECTURE.md) for full deployment topologies, and
-[Scaling model](#scaling-model) below for the ingest-coordination internals.
-
-### Run in Docker
-
-Containers are the recommended deployment (developers then install only the
-[thin client](#2-install-the-thin-client)). Three compose files ship; pick by
-topology. They build from two images: **`aimee-server`** (`Dockerfile.server`) and
-**`aimee-kb`** (`Dockerfile`).
-For a new install, PostgreSQL + pgvector (DB2) run inside `aimee-kb` and persist
-with the KB home volume; no database sidecar is required. Set `AIMEE_DB2_URL`
-only to select an external database. The KB auto-applies its DB2 schema on first
-boot. The stacks run the
-`aimee-llm` inference gateway (embeddings, reranking, and synthesis) as a service,
-which downloads its cpu-tier models on first boot, so embedding and reranking work with
-nothing external. The tier is chosen by `AIMEE_LLM_TIER`: `cpu` serves
-Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers (`small`, `mid`, `large`) serve
-Qwen3-Embedding-4B at 2560 dims and add a GPU synth. To
-run a standalone embedder or curator LLM instead, use the
-`curator-llm` compose profile. Backends and tiers:
-[KB_LLM_BACKENDS.md](../docs/KB_LLM_BACKENDS.md) and
-[AIMEE_KB_SYNTH_TIERS.md](../docs/AIMEE_KB_SYNTH_TIERS.md).
-
-> **`docker compose ... up --build` needs no credentials.** The browser UI
-> (`aimee-runtime-web`) is built into every image and on by default. Its frontend
-> dependency (`@rakuensoftware/smoothgui`) is vendored in-repo
-> (`frontend/vendor/`), so the build pulls nothing from a private registry and needs
-> no npm token. Build with `--build-arg WITH_RUNTIME_WEB=0` to ship server + kb only.
-> At runtime the UI is on unless you set `AIMEE_RUNTIME_WEB_ENABLED=0` (provide
-> `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` for a PAM login). It serves HTTPS on
-> `:8443`.
-
-| File | Brings up | Use when |
-|------|-----------|----------|
-| `compose.server.yaml` | `aimee-server` + self-contained `aimee-kb` + the `aimee-llm` inference gateway | **Recommended default**: the full split stack brought up together; server `/v1` over TLS on `:8743` (plaintext `:8740` loopback-only), kb `:8741`; scale/update/place server and kb independently |
-| `compose.yaml` | Self-contained `aimee-kb` (embedded PostgreSQL/pgvector) + the `aimee-llm` inference gateway | The knowledge service (DB2 + vectors) on its own: building block for a shared/scaled kb |
-| `compose.server-standalone.yaml` | `aimee-server` only (SQLite DB1, no kb) | DB1-backed `/v1` endpoints with no shared knowledge |
-
-#### Server + kb split stack (recommended)
-
-```bash
-docker compose -f compose.server.yaml up --build -d
-```
-
-`aimee-server` and `aimee-kb` run as separate containers (many servers → one shared
-kb). The server fronts `/v1` over native TLS on `:8743` (plaintext `:8740` is
-loopback-only) and reaches the kb over HTTP
-(`AIMEE_KB_API_URL=http://aimee-kb:8741`); the kb owns Postgres and reaches the
-`aimee-llm` inference gateway:
-
-```bash
-curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
-curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/kb/status
-```
-
-The `aimee-server` container mounts a dedicated **`aimee-server-workspaces`** volume at
-`AIMEE_WORKSPACES_DIR` (`/var/lib/aimee-workspaces`). A detached/`mirror` workspace
-keeps its server-side bare mirror and reconstructed worktree there, so checkouts
-survive container recreation; the image declares it a `VOLUME`, so even a plain
-`docker run` persists them.
-
-#### Knowledge base only
-
-```bash
-docker compose -f compose.yaml up --build -d
-```
-
-Brings up self-contained `aimee-kb` + the `aimee-llm` gateway, serving `/v1` on `:8741`: the
-building block behind a shared or horizontally-scaled kb that many servers point at:
-
-```bash
-curl http://localhost:8741/v1/health
-curl 'http://localhost:8741/v1/health?status=1'   # DB + pgvector store status
-curl http://localhost:8741/v1/capabilities
-```
-
-The LLM-backed synthesis/curator passes are wired but disabled until you point an
-OpenAI-compatible endpoint at them: bring up a local llama.cpp server with
-`docker compose -f compose.yaml --profile llm up` (the same flag works with the
-split stack).
-
-#### Managing the containers
-
-The binaries run as **long-lived container processes** (PID 1), supervised by
-Docker's restart policy:
-
-```bash
-docker compose -f compose.server.yaml up -d        # start (detached); add --build after a code change
-docker compose -f compose.server.yaml ps           # container + health status
-docker compose -f compose.server.yaml logs -f      # follow logs (add a service name to scope)
-docker compose -f compose.server.yaml restart aimee-server aimee-kb
-docker compose -f compose.server.yaml down         # stop + remove containers (named volumes persist)
-docker compose -f compose.server.yaml down -v      # also drop the data volumes (DESTROYS DB2 + state)
-docker compose -f compose.server.yaml pull && \
-  docker compose -f compose.server.yaml up -d           # update: pull the latest published image + recreate
-docker compose -f compose.server.yaml up -d --build     # alternative: rebuild from local source
-```
-
-The compose services point at the published `ghcr.io/rakuensoftware/aimee-*` images
-(built and pushed on every merge to `main`), so `pull` fetches the latest release
-without a local build. Pin a version (or a fork/registry) by overriding
-`AIMEE_SERVER_IMAGE` / `AIMEE_KB_IMAGE` / `AIMEE_EMBEDDER_IMAGE` (e.g.
-`AIMEE_SERVER_IMAGE=ghcr.io/rakuensoftware/aimee-server:v0.2.41`).
-
-Each container runs as a non-root user. Durable state lives in **named volumes**,
-so `down`/recreate is safe and `down -v` is the only thing that erases data:
-
-| Volume | Holds |
-|--------|-------|
-| `*-postgres` | DB2 (`aimee_shared`): all shared knowledge + vectors |
-| `*-home` (`/var/lib/aimee`) | server/kb runtime state (DB1 SQLite, config) |
-| `*-workspaces` (`/var/lib/aimee-workspaces`) | mirror-tier bare mirrors + reconstructed worktrees |
-| `*-embedder-models` / `*-llm-models` | cached model weights |
-
-The server's worker threads need a 64 MB stack, so every server container sets
-`ulimits.stack: 67108864` (a plain `docker run` must pass
-`--ulimit stack=67108864`). Override the baked `aimee-local-dev` bearer and any
-config by mounting your own `aimee.yaml` at `/var/lib/aimee/aimee.yaml`.
-
-#### Verify a stack end to end
-
-Each stack ships a smoke test that brings it up, waits for health, exercises the
-live surface, then tears down. `e2e-matrix.sh` runs several at once and prints one
-pass/fail table (run it on a Docker host):
-
-```bash
-scripts/aimee-kb-docker-smoke.sh --up --down                  # T1 kb-only
-scripts/aimee-server-docker-smoke.sh --up --down              # T2 server + kb split
-scripts/aimee-server-standalone-docker-smoke.sh --up --down   # T3 server standalone
-scripts/e2e-matrix.sh --only T1,T2,T3                         # all Docker topologies
-```
-
-`e2e-matrix.sh` also covers the local-install topologies (T5/T6) and the
-cross-platform thin-client smoke; run `scripts/e2e-matrix.sh --help` for the list.
-
-### Drive a remote server with the CLI
-
-The [`--server` / `AIMEE_SERVER_URL`](#2-install-the-thin-client) path above is the
-simplest way to reach a remote server. The same connection is also expressible at
-the transport layer (used by `aimee workspace serve` and persisted `aimee.yaml`):
-
-```bash
-export AIMEE_API_CLIENT_TRANSPORT=http
-export AIMEE_API_ENDPOINT=tcp:HOST:8740     # or unix:/path/to/aimee-http.sock
-export AIMEE_API_BEARER=aimee-local-dev     # must match the server's bearer
-aimee session list
-aimee memory search "<query>"
-```
-
-The same settings persist in `aimee.yaml` (`aimee.api.client_transport`,
-`aimee.api.client_endpoint`, `aimee.api.bearer_token`); the environment variables
-override them. The TCP host may be a DNS name or an IPv4/IPv6 literal
-(`tcp:[::1]:8740`).
-
-This drives the **data/RPC plane** (`memory`, `kb`, `rules`, `index`, `sessions`,
-`notes`, …). Interactive front ends (web chat, `acp-serve`) need a co-located server**:
-they run the agent and its tools on the client host and chdir into a local worktree,
-so they refuse a remote `tcp:` endpoint with a clear message.
-
-**Remote writes are off by default** (leaked-bearer protection): over the TCP
-listener a bearer is read/query/chat only, so mutating commands return 403. The
-server opts in per `aimee.api.remote_writes`:
-
-| `aimee.api.remote_writes` | Over the TCP listener |
-|---------------------------|-----------------------|
-| `off` (default) | **reads only**: any route needing a non-read capability is local-UDS-only (the detached-workspace plane, `workspace serve`/`add`/`remove`, is the deliberate exception, still bearer-gated) |
-| `data` | + data-plane writes (`memory store`, `work …`, `rules delete`, `skill …`) |
-| `full` | + exec/control (`delegate`, `cron`, `agent`, `provider`, `api`, …) and the `/v1/rpc` delegate/tool bridge (`CAPS_ALL`). **Trusted networks only**: a leaked bearer then permits remote code execution. |
-
-The capability gate is fail-closed: a route is reachable over TCP only if its
-required capability is satisfied *and* the tier permits its class. A scoped
-`scope:…` bearer is query-only regardless of tier. The UDS path (a co-located
-client) is always full access regardless of this setting.
-
-## Repository layout
-
-The C source lives in `src/`; the rest of the repository supports building,
-testing, deploying, and documenting it.
-
-| Path | Contents |
-|------|----------|
-| `src/` | All C sources. Hundreds of `.c` files plus generated headers and `*.inc` split units. |
-| `src/db1/` | DB1 (SQLite) data layer, owned by `aimee-server`. |
-| `src/db2/` | DB2 (Postgres + pgvector) data layer, owned by `aimee-kb`. |
-| `src/server/` | `aimee-server` internals: event loop, auth, sessions, compute pool, HTTP /v1, KB client. |
-| `src/kb/` | `aimee-kb` internals: service dispatch, ingest/curator workers, KB HTTP. |
-| `src/gateway/` | Optional `aimee-gateway` (ambient presence: Telegram/ntfy/webhook, STT/TTS). |
-| `src/linux/`, `src/mac/`, `src/windows/`, `src/posix/` | Platform abstractions (events, IPC, paths, process). |
-| `src/headers/`, `src/shared/`, `src/vendor/` | Internal headers, shared helpers, vendored libs (cJSON). |
-| `src/tests/` | C unit tests (`test_*.c`), `fuzz_corpus/`, `support/`, and `test_build_integrity.sh`. |
-| `webchat/` | Standalone Go browser service (thin client to `aimee-server`). |
-| `frontend/` | React 19 + Vite UI, bundled to a single HTML file for webchat. |
-| `api/` | OpenAPI specs (`openapi-server-v1.yaml`, `openapi-v1.yaml`), the API contract. |
-| `skills/` | Bundled process skills (markdown + frontmatter). |
-| `session_templates/` | Multi-agent session templates (code-review, debate, design-critique, planning). |
-| `plugins/` | Plugin interface + example plugin manifest. |
-| `benchmarks/`, `tools/`, `data/` | Eval suites (`catalog.toml`, `suite/`, `targets/`), replay harnesses, dataset cache. |
-| `scripts/` | Sidecars (embeddings, LLM chat, curator, synthesis, ranker, planner) + build/boundary check scripts. |
-| `systemd/`, `service/`, `deploy/` | systemd user units, macOS launchd plists, container deploy config. |
-| `docs/` | Reference docs + the `proposals/` lifecycle (`pending` → `reviews`/`accepted` → `done`/`rejected`). |
-
-Generated headers (checked in, regenerated on build): `schema_data.h` (DB schema
-constants), `agent_help_data.h` (CLI help text), `tool_prompts_data.h` (tool
-prompt templates). The generators are the `gen_*.py` scripts in `src/`.
-
-## Server internals
-
-`aimee-server` fronts its `/v1` HTTP surface with a per-connection-worker accept
-loop and a bounded compute pool. The accept loop only hands each connection to a
-worker; any handler that may block runs on the compute pool.
-
-### Listener and connections
-
-- The HTTP listener (`src/server/server_http.c`) owns the accept loop over the
-  `/v1` UDS (`~/.config/aimee/aimee-http.sock`) and the optional localhost TCP
-  port, handing each accepted connection to its own detached worker thread.
-- `server_run()` (`src/server/server.c`) no longer runs an accept loop (the
-  legacy NDJSON RPC socket was removed) and simply parks until shutdown. The
-  `server_conn_t` buffered read/write helpers (`conn_flush()` etc.) survive
-  because the in-process `/v1` dispatch bridge reuses them with a stack-allocated
-  connection.
-- `--socket=PATH` is accepted for compatibility but ignored (only the pid file is
-  derived from it); the server always serves `/v1` over `aimee-http.sock`.
-
-### Concurrency model
-
-- **HTTP listener threads:** the accept loop hands each connection to its own
-  detached worker, so a slow or streaming request never blocks the listener.
-- **Compute pool:** bounded worker threads run handlers that touch DB, network,
-  subprocesses, or delegate inference. Sizing is tunable
-  (`compute_threads`/`worker_threads`/`background_threads`/`session_threads`).
-- **Compute budget gate:** `server_compute_budget_acquire/release` serializes
-  heavyweight inference so concurrent delegates cannot exhaust resources.
-
-### Authentication and capabilities
-
-The local `/v1` UDS (`aimee-http.sock`) is filesystem-permission gated and fully
-trusted: it reaches the entire dispatch surface with no token. The optional TCP
-listener requires a configured bearer token (`server_http_authorize`,
-constant-time compare). Authorization is a 16-bit capability mask declared per
-method in a registry (`src/server/server_auth.c`); unknown methods default to
-deny, and TCP connections are capability-scoped.
-
-| Flag | Bit | Grants |
-|------|-----|--------|
-| `CAP_CHAT` | 0x0001 | chat streaming |
-| `CAP_DELEGATE` | 0x0002 | delegate / inference |
-| `CAP_TOOL_EXECUTE` | 0x0004 | tool invocation |
-| `CAP_TOOL_BASH` | 0x0008 | bash tool |
-| `CAP_TOOL_WRITE` | 0x0010 | file-write tools |
-| `CAP_MEMORY_READ` | 0x0020 | memory recall/search |
-| `CAP_MEMORY_WRITE` | 0x0040 | memory store |
-| `CAP_RULES_READ` | 0x0080 | rules list |
-| `CAP_RULES_ADMIN` | 0x0100 | rules delete/approve |
-| `CAP_DESCRIBE_READ` | 0x0200 | graph describe |
-| `CAP_DESCRIBE_ADMIN` | 0x0400 | graph describe mutation |
-| `CAP_INDEX_READ` | 0x0800 | code-index reads |
-| `CAP_INDEX_ADMIN` | 0x1000 | index scan/rebuild |
-| `CAP_SESSION_READ` | 0x2000 | session / wm reads |
-| `CAP_SESSION_ADMIN` | 0x4000 | session / tool mutation |
-| `CAP_DASHBOARD_READ` | 0x8000 | dashboard metrics |
-
-Composite sets exist for authenticated (all-but-index-admin) and read-only
-callers. Auth failures are rate-limited per UID (5 / 60 s → cooldown); the HTTP
-surface can rate-limit per source. SIGTERM/SIGINT drain pending I/O and record
-unclean-exit forensics (`shutdown_forensics.c`) to DB1.
-
-## RPC method catalog
-
-The dispatch table in `src/server/server.c` currently registers 162 typed server
-methods; the thin CLI maps supported commands to them in `cli_v1_routes.inc`
-(144 routes/aliases at this revision). Commands implemented only in legacy
-`cmd_*` modules are not user-facing until they have a typed route. By family:
-
-| Family | Representative methods |
-|--------|------------------------|
-| Server / meta | `server.info`, `server.health`, `hud.status`, `workers` |
-| Auth / launch | `auth`, `launch.run`, `init.run` |
-| Sessions | `session.create/list/get/close/brief` |
-| Memory | `memory.search/store/list/get/read`, `memory.recall` |
-| Index / graph | `index.scan/find/list/blast_radius/structure/find_callers`, `graph.sync_code/explain`, `blast_radius.preview` |
-| Knowledge base | `kb.search/build/update/status`, `kb.docs.push`, `kb.ingest(.status)` |
-| Rules / collab | `rules.list/generate/delete`, `collab_rules.list(_active)/approve/reject/retire` |
-| Skills / toolsets | `skill.list/show/lint/eval/create/edit/patch/archive/pin/unpin/lifecycle/autostub`, `toolset.list/show/resolve` |
-| Working memory | `wm.set/get/list/context` |
-| Work queue | `work.add/add_batch/claim/complete/fail/list/board/cancel/release/clear/gc/sync_proposals/stats` |
-| Agents / delegation | `agent.list/add/local/remove/enable/disable/probe/setup(_poll)/episodes`, `delegate(.launch/.status/.log/.reply/.backend_list/.backend_exec)` |
-| Chat | `chat.send_stream` |
-| Jobs | `jobs.list/status/logs/cancel`, `job.start/list/status/cancel` |
-| Attempts / episodes | `attempt.record/list`, `episode.list` |
-| Dashboard / LSP | `dashboard.*`, `lsp.diagnostics_summary` |
-| Workspace | `workspace.context/add/list/remove`, `worktree.gc` |
-| Eval / dogfood | `eval.run/results`, `dogfood.tag/review/report` |
-| Identity / config | `identity.show/snapshot/diff`, `aux.config_show/test` |
-| Tools / MCP | `tool.execute`, `mcp.tools_list/audit/recheck/call` |
-| Triggers / cron | `trigger.fire/list/status/cancel`, `cron.list/add/show/history/run/enable/disable/remove` |
-| Providers / models | `provider.list/show/models/test/quota/get/set`, `provider.slot_acquire/release`, `model.list/show/refresh` |
-| Insights | `insights.overview` |
-
-Request shape: `{"method": "...", "protocol_version": 2, ...params}`. Success:
-`{"status": "ok", ...data}`. Error: `{"status": "error", "error": "...",
-"message": "..."}`. Streaming methods emit NDJSON events ending in a final status
-object. `auth` must precede any capability-gated call.
-
-## HTTP /v1 seam
-
-`src/server/server_http.c` and `server_api.c` implement a native HTTP /v1 REST
-surface (OpenAI-compatible inference, run management, and read surfaces). UDS
-callers authenticate by peer UID; TCP callers present a bearer token (optionally
-`scope:`-prefixed to constrain capabilities, a scoped token is denied on
-inference with 403). `X-Request-ID` is echoed and access-logged. The contract
-lives in `api/openapi-server-v1.yaml`. `docs/gen/api-v1.md` is the generated
-reference for the separate KB API (`api/openapi-v1.yaml`). See the
-[Manual §24](../MANUAL.md#24-the-http-v1-api) for the server endpoint list.
-
-## The KB split
-
-`aimee-server` owns no DB2 SQL. It reaches DB2 through the **KB client**
-(`src/modules/kb_client/kb_client*.c`), typed wrappers (memory, index, docs, agent,
-dashboard, roadmap, notes, curiosity, status) that call `aimee-kb` over its
-HTTP `/v1` API (`AIMEE_KB_API_URL`, port 8741). The legacy Unix-socket transport
-was retired in #2747; HTTP is now the only KB transport. DB1 remains local to the server;
-DB2 can be a local single-user KB or a shared KB, and server-side reflection or
-promotion flows send only scoped knowledge artifacts across that boundary.
-`aimee-kb` (`src/kb/`) owns the DB2 schema, the memory inference pipeline, the
-vector collections, the code index, document ingest, and the curator. It exposes
-43 HTTP /v1 endpoints
-(`/v1/code/*`, `/v1/docs/*`, `/v1/search`, `/v1/ingest/*`, `/v1/entities/*`,
-`/v1/reflections/*`, `/v1/maintenance/*`, `/v1/releases/*`), see
-`api/openapi-v1.yaml`. The server no longer auto-starts the KB: `AIMEE_KB_API_URL`
-must point at an already-running `aimee-kb` (started by its service unit, container,
-or `aimee-kb --http-port`). `AIMEE_KB_NO_AUTOSTART` is now a deprecated no-op.
-
-## Scaling model
-
-The scaling boundary is the storage boundary: the per-user server and the shared
-knowledge service scale independently and in different ways.
-
-**`aimee-server` is 1:1 with a user.** It owns DB1 (local SQLite, same-user
-runtime state) and authenticates by `SO_PEERCRED` peer UID, so it is single-tenant
-and local by construction: one per OS login, never sharded or load-balanced. Its
-only scaling axis is *vertical*: the compute pool and concurrency knobs
-(`compute_threads` / `worker_threads` / `background_threads` / `session_threads`,
-`concurrency.per_model`) raise a single user's in-flight delegate and tool-call
-throughput.
-
-**`aimee-kb` is the horizontally-scalable, many-user tier.** All durable state
-lives in DB2 (Postgres); a KB process holds only connection pools and worker
-loops, making each instance an effectively stateless request server over a shared
-database. Many `aimee-server` instances (many users) reach one KB over HTTP `:8741`
-(`AIMEE_KB_API_URL`). Critically, the background pipeline claims work straight off
-DB2 with `FOR UPDATE SKIP LOCKED` (`db2_kb_ingest_queue_claim_next` in
-`src/kb/kb_ingest_workers.c`; the curator drain in `src/modules/kb-synthesis/kb_curator_extract_code.c`), so
-concurrent KB replicas never double-claim a row; Postgres is the only
-coordinator. The scale-out recipe is therefore: **run N `aimee-kb` replicas behind
-a load balancer over one Postgres.**
-
-**DB2 is standard Postgres.** It is one `aimee_shared` database with `pg_trgm` +
-`vector` (pgvector), scaled with the normal Postgres playbook (instance sizing,
-pooling, read replicas; `db2_pool_size` bounds each instance's pool, 1-32). Vector
-search scales inside it: pgvector HNSW by default (and always for memory vectors),
-with **pgvectorscale (StreamingDiskANN)** as an additive, opt-in scale-up for large
-corpus tables. The index type is chosen per corpus table by
-`db2.vector.corpus_index` (`auto`|`hnsw`|`diskann`) /
-`db2.vector.corpus_diskann_threshold` (`pgvec_corpus_index_choose` in
-`src/db2/pgvec_transport.c`); because the `vector` column and queries are identical
-across index types, switching is an index-only reindex
-(`aimee kb repair --reindex-corpus`), never a data migration. See the
-[Manual §27.5](../MANUAL.md#275-scaling-and-multi-user-deployment).
-
-## Build system internals
-
-`src/Makefile` is canonical; `CMakeLists.txt` mirrors it for Windows (MinGW) and
-macOS. Objects are partitioned into sets and linked into only their owning
-binary:
-
-| Binary | Object sets | Link flags |
-|--------|-------------|------------|
-| `aimee` | client + support + platform | `-lpthread` (no SQLite, no libpq) |
-| `aimee-server` | server + kb_client + agent + data + cmd-stubs + core + db1 + platform + mcp_git | `-lsqlite3 -lssl -lcrypto -lpam` (no libpq); built `-DAIMEE_DB2_DISABLED` |
-| `aimee-kb` | kb + kb-data + db2-pg + db2 + core + platform | `-lpq -lzstd -lssl -lcrypto` (no SQLite); built `-DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM` |
-| `aimee-runtime-web` | (Go) | `cd webchat && go build` |
-| `aimee-gateway` | gateway + platform | `-lpthread -lssl -lcrypto` |
-
-Common flags: `-Os -flto -ffunction-sections -fdata-sections -Wl,--gc-sections
--s`, `-Wall -Wextra -Werror`, dependency generation (`-MMD -MP`). Optional
-features are pkg-config-gated: `-DWITH_PAM`, `-DWITH_LIBSECRET`. The version
-string is embedded from `git describe`.
-
-Boundary gates (run in CI): `make check-linking` (no SQLite in client, no libpq
-in server, no SQLite in KB, verified with `ldd`/`otool` and `readelf` symbol
-checks), `make module-boundary-check`, `make kb-target-isolation-check`,
-`make kb-container-packaging-check`, plus `scripts/check_tier_deps.sh` and
-`scripts/check-module-boundary.py`. Layer-include violations are caught by
-`src/tests/test_build_integrity.sh` against the exemption table in
-[OWNERS.md](../OWNERS.md).
-
-## Testing and CI
-
-- **Unit tests:** `make unit-tests` builds and runs `src/tests/test_*.c`.
-- **Fuzzing:** `src/tests/fuzz_corpus/` seeds AFL/libFuzzer targets; the
-  `fuzz-nightly.yml` workflow runs them on a schedule.
-- **Build integrity:** `test_build_integrity.sh` enforces layering; the
-  `make` boundary gates enforce storage isolation.
-- **Benchmarks:** `benchmarks/` (driven by `catalog.toml`, `suite/runner.py`)
-  and the replay harnesses in `tools/` cover memory recall, planning, reasoning,
-  guardrails, and KB quality; `bench-smoke.yml` runs a smoke subset in CI. See
-  [docs/BENCHMARKS.md](../docs/BENCHMARKS.md).
-- **CI workflows:** `.github/workflows/`, `ci.yml` (build + tests + boundary
-  gates), `bench-smoke.yml`, `fuzz-nightly.yml`, `release.yml`.
+Do not hand-edit `docs/gen/` or generated SDKs. Change the registry, descriptor, or OpenAPI source.
+
+## Adding a route
+
+1. Choose the owning service.
+2. Define the operation, auth, scope, write tier, bounds, and error contract.
+3. Add the canonical descriptor and OpenAPI operation.
+4. Implement the handler and typed client path.
+5. Add negative auth/scope/body tests and one success test.
+6. Regenerate docs and run route parity checks.
+
+Internal workflow resource routes also need peer identity and worktree/forge confinement tests.
+
+## Adding an event
+
+1. Assign a stable kind and bounded schema.
+2. Choose notification or correlated request/reply.
+3. Declare block or shed behavior.
+4. Register the minimum observer set.
+5. Keep action authorization before delivery and storage off the hot path.
+6. Test malformed frames, queue full, client reap, shutdown drain, and capture replay.
+7. Update C/Go vectors if the wire changed.
+
+Use inline payloads unless the real schema can exceed the inline budget. Arena producers must be
+co-located with the host today.
+
+## Adding configuration
+
+Add one field descriptor with type, default, bounds, persistence, environment override, secret
+classification, and restart behavior. Table-driven parsing and schema generation should pick it up.
+Add custom code only when the field is not a flat scalar.
+
+## Debugging
+
+- Use request IDs across client, server, KB, workflow, and provider logs.
+- Preserve the first failing delegate attempt.
+- Inspect workflow lifecycle state before restarting a parked run.
+- Treat a nonzero bus drop counter as lost observability, not harmless load.
+- Classify capture as complete, open, truncated, or corrupt before replay.
+- Run `aimee audit verify` before modifying audit state.
+- Check the owner boundary before fixing a symptom in the wrong process.

--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -16,6 +16,8 @@
      "  disable               Restore Claude Code to its default endpoint\n"},
     {"remote", "Point the thin client at a remote aimee-server", CLIENT_TIER_ADVANCED, 0,
      "  set <url> [token]  Persist a remote server target\n"
+     "  enroll            Rotate the bearer and enroll this client certificate\n"
+     "  trust             Pin the configured server certificate again\n"
      "  status             Show the resolved transport and a health probe\n"
      "  clear              Revert to the local Unix socket\n"},
     {"wm", "Working memory (session-scoped scratch)", CLIENT_TIER_CORE, 0,
@@ -27,13 +29,15 @@
      "  overview         List indexed projects\n"
      "  list             List indexed projects\n"
      "  scan             Scan workspaces and (re)build the index (--force)\n"
+     "  watch <name> <root>  Install git hooks that re-index after branch changes\n"
      "  blast-radius     Show files affected by changes to a file\n"
      "  structure        Show file structure\n"
      "  callers          Find callers of a symbol\n"},
     {"workspace", "Workspace management (add, list, remove)", CLIENT_TIER_ADVANCED, 0,
      "  add <path>       Register a directory as a workspace and index its projects\n"
      "  list             List configured workspaces and their indexed projects\n"
-     "  remove <path>    Unregister a workspace\n"},
+     "  remove <path>    Unregister a workspace\n"
+     "  serve <id>       Run the authorized remote-workspace request loop\n"},
     {"memory", "Stored memory", CLIENT_TIER_CORE, 0,
      "  search           Search stored memory\n"
      "  store            Store a memory\n"
@@ -122,12 +126,26 @@
     {"agent", "Sub-agent management", CLIENT_TIER_ADVANCED, 0,
      "  list             List configured delegates\n"
      "  add              Add or update a delegate provider\n"
+     "  setup            Run an agent provider's attended OAuth setup\n"
      "  local            Register/update a local OpenAI-compatible delegate\n"
      "                   (--provider openai|llama-eval for request shaping)\n"
      "  remove           Remove a configured delegate\n"
      "  enable           Enable a configured delegate\n"
      "  disable          Disable a configured delegate\n"
      "  probe            Probe delegate endpoint, slots, and execution\n"},
+    {"codex", "Codex OAuth recovery", CLIENT_TIER_ADVANCED, 0,
+     "  reauth           Re-authenticate Codex after refresh is rejected\n"},
+    {"persona", "Persona management", CLIENT_TIER_CORE, 0,
+     "  list             List available personas\n"
+     "  show <name>      Print one persona\n"
+     "  edit <name>      Edit or create a persona in $EDITOR\n"
+     "  add <name>       Alias for edit\n"
+     "  rm <name>        Reset a built-in or remove a custom persona\n"},
+    {"roles", "Delegate role templates", CLIENT_TIER_ADVANCED, 0,
+     "  list             List role templates\n"
+     "  show <role>      Print one role template\n"
+     "  edit <role>      Edit or create a template in $EDITOR\n"
+     "  rm <role>        Reset a built-in or remove a custom template\n"},
     {"provider", "Model provider profiles and catalogs", CLIENT_TIER_ADVANCED, 0,
      "  list             List registered providers (--available, --json)\n"
      "  show <name>      Show provider profile details\n"
@@ -135,6 +153,11 @@
      "  test <name>      Probe provider credentials and connectivity\n"
      "  quota [name]     Show process-local credential pool quota state\n"},
     {"version", "Print version", CLIENT_TIER_CORE, 0, NULL},
+    {"self-update", "Update this thin client to the server release", CLIENT_TIER_CORE, 0,
+     "  --check          Report whether an update is available\n"
+     "  --version vX.Y.Z  Install a specific release without downgrading\n"
+     "  --yes            Do not ask before replacing the binary\n"
+     "  --require-verify  Fail if the published SHA-256 cannot be verified\n"},
     {"help", "Show help for a command", CLIENT_TIER_CORE, 1, NULL},
 
     {"status", "System health overview", CLIENT_TIER_ADVANCED, 0, NULL},
@@ -230,10 +253,22 @@
      "  update           Update the knowledge base\n"
      "  ingest           Ingest documents (status: ingest status)\n"
      "  status           Show knowledge-base status\n"
-     "  docs push        Push docs into the knowledge base\n"},
+     "  docs push        Push docs into the knowledge base\n"
+     "  grant set        Set one subject's write tier (--server, --team, --subject, --tier)\n"
+     "  grant show       Show one subject's grant (--server, --team, --subject)\n"
+     "  grant list       List grants (--server, --team, [--include-revoked])\n"
+     "  grant revoke     Revoke one subject's grant (--server, --team, --subject)\n"},
     {"graph", "Code-graph projection and explain", CLIENT_TIER_ADVANCED, 0,
      "  sync-code        Project the code graph\n"
      "  explain          Explain a code-graph relationship\n"},
+    {"css", "CSS migration analysis and render verification", CLIENT_TIER_ADVANCED, 0,
+     "  report           Show a CSS-health overview\n"
+     "  dead-rules | conflicts | duplicate-declarations | duplicate-selectors\n"
+     "  unresolved | important-audit | high-specificity | unused-vars | token-candidates\n"
+     "  migrate-enumerate | migrate-list | rules-doc | assert-conventions | conventions\n"
+     "  render-store <project> <unit> <before|after> <snapshot.json>\n"
+     "  render-capture <project> <unit> <before|after> <html-file> <css-file>\n"
+     "  render-verify <project> <unit>\n"},
     {"optimize", "Bandit optimization loop", CLIENT_TIER_ADVANCED, 0,
      "  points                          List registered decision points\n"
      "  baseline --point <name>         Show current arm posteriors for a point\n"

--- a/src/kb/README.md
+++ b/src/kb/README.md
@@ -1,96 +1,53 @@
 # aimee-kb
 
-This directory is the ownership boundary and implementation home for the
-`aimee-kb` service, the knowledge tier that owns **DB2** (Postgres + pgvector)
-and everything derived from it. For the system-level picture see
-[`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md); for the code-level module map
-see the [Technical Reference](../README.md).
+This directory owns the knowledge service and DB2: PostgreSQL, pgvector, memory, documents, code
+graph, retrieval, curation, and KB administration.
 
-## What aimee-kb is
+It does not own DB1, workflow state, client paths, or model serving.
 
-`aimee-kb` is a single C11 process that owns the DB2 schema and all knowledge
-operations: the memory inference pipeline (dedup, contradiction detection,
-temporal versioning, promotion/decay), the vector collections, the code index,
-document ingest, and the curator. `aimee-server` holds **no** DB2 SQL; it reaches
-all of this through the typed KB client over a Unix socket or HTTP. KB service
-entry, dispatcher, background workers, mining, curator, ingest, and the HTTP
-surface live here (`kb_main.c`, `kb_service*.c`, `kb_ingest_workers.c`,
-`kb_curator_*.c`, `kb_background.c`, `http/`); remaining KB-owned flat modules
-move here incrementally behind the same build targets.
+## Boundaries
 
-It links `-lpq` (plus `-lzstd`/`-lssl`/`-lcrypto`) and is built with
-`-DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM`: it **never** links SQLite.
-The boundary is compile-enforced (`make check-linking`, `readelf` symbol checks,
-`scripts/check_tier_deps.sh`).
+- links libpq, never SQLite;
+- accepts typed `/v1` operations from server and authorized KB clients;
+- owns every DB2 transaction and background queue claim;
+- calls `aimee-llm` for embedding, reranking, and synthesis;
+- publishes KB-side memory and tool audit through its own event bus;
+- treats scope as authorization, not a search filter applied after the query.
 
-## Scaling contract: the many-user, horizontally-scalable tier
+## Storage
 
-Where `aimee-server` is strictly 1:1 with a user, **`aimee-kb` is the shared tier
-that scales out to serve many users at once.** Three properties make this work:
+The default container starts private PostgreSQL 18 with pgvector and pgvectorscale when
+`AIMEE_DB2_URL` is unset. External PostgreSQL uses the same schema and ownership.
 
-1. **All durable state lives in DB2 (Postgres).** A KB process keeps only
-   transient state: connection pools, in-flight request buffers, worker loops.
-   The knowledge itself (memories, rules, code index, tasks, embeddings) is in
-   Postgres. A KB instance is therefore an effectively **stateless request server
-   over a shared database**.
-2. **It is reachable over the network.** Besides the local Unix socket, KB serves
-   its full contract over HTTP on `:8741` (`AIMEE_KB_API_URL`, optional bearer
-   token). Many independent `aimee-server` instances (i.e. many users on many
-   machines) can point at one KB endpoint.
-3. **Concurrent instances are safe with no external coordinator.** The background
-   pipeline (ingest, curator, embedding, index-update) claims work straight off
-   DB2 queues using `FOR UPDATE SKIP LOCKED`
-   (`db2_kb_ingest_queue_claim_next`, `kb_curator_extract_code.c`), so two workers
-   never claim the same row. Postgres *is* the coordinator.
+HNSW is the normal dense index. Large corpus tables may use pgvectorscale's disk-backed index when
+configured and available. Changing index type rebuilds the index; it does not re-embed source rows.
 
-Consequently you scale the KB the way you scale any stateless web tier: **run N
-`aimee-kb` replicas behind a load balancer**, all pointed at one Postgres. Read
-and query traffic (search, recall, index lookups, the hot path the servers hit)
-fans out across replicas freely; the background workers on each replica drain the
-shared DB2 queues cooperatively.
+Workers claim DB2 queue rows with database locking so several KB workers do not process the same
+item. Horizontal replicas still need sane database connection limits and one shared schema version.
 
-### The database is just standard Postgres
+## Main areas
 
-There is no bespoke datastore. DB2 is one ordinary Postgres database
-(`aimee_shared` by default) with two extensions: `pg_trgm` (lexical) and `vector`
-(pgvector, for dense embeddings). You scale it with the standard Postgres
-playbook (vertical sizing, connection pooling such as PgBouncer, and read
-replicas for query fan-out), and `db2_pool_size` (1-32, default 8) bounds each KB
-instance's connection pool.
+| Area | Responsibility |
+| --- | --- |
+| `http/` | public route boundary, auth, scopes, body limits, OpenAPI |
+| ingest | content validation, staging, document/PDF pipeline, commit |
+| memory | store, recall, dedupe, contradiction, temporal state, promotion/decay |
+| vectors | embedding records, index choice, reconcile and repair |
+| code | extraction, symbols, calls, cross-repo edges, blast radius |
+| curator | typed fact extraction, review, reflection, lifecycle |
+| background | bounded DB2-backed workers and health |
+| audit bridge | PII-safe mutation identity and tool outcome publication |
 
-Vector search rides inside the same Postgres, so it scales with it:
+## Checks
 
-- **pgvector HNSW is the default** for memory vectors (always) and for all
-  small-to-medium corpora. No extra extension required.
-- **pgvectorscale (StreamingDiskANN) is the opt-in scale-up** for large corpora.
-  It is *additive*: built on top of pgvector, same `vector` column type and same
-  distance operators, adding only the `USING diskann` index access method, which
-  is disk-backed with bounded build memory. Selected per corpus table by
-  `db2.vector.corpus_index` (`auto` | `hnsw` | `diskann`); `auto` flips to diskann
-  once a table exceeds `db2.vector.corpus_diskann_threshold` (default 1,000,000
-  rows) *and* the extension is present, and falls back to HNSW with a notice when
-  it is not (`pgvec_corpus_index_choose` in `db2/pgvec_transport.c`).
-- **Switching is a reindex, not a migration.** Data and queries are identical
-  across index types; `aimee kb repair --reindex-corpus` rebuilds corpus indexes
-  to the configured/auto type with no re-embedding and no query rewrite. Hot-path
-  `memory_embeddings` / `kb_embeddings` stay HNSW unconditionally.
+```bash
+make -C src kb
+make -C src check-linking
+make -C src kb-target-isolation-check
+make -C src kb-container-packaging-check
+make -C src api-conformance-check
+make -C src unit-tests
+```
 
-## Responsibilities
-
-| Area | Modules | Notes |
-|------|---------|-------|
-| Service dispatch | `kb_service*.c`, `kb_main.c`, `http/` | Unix-socket + HTTP `/v1` request handling (~43 endpoints). |
-| Memory pipeline | `kb_memory_embed.c`, `memory_*` (KB-linked), `db2/` | Store/recall/search, dedup, contradiction, temporal versioning, promotion/decay. |
-| Vectors | `db2/pgvec_transport.c`, `kb_*_embed.c` | pgvector collections, index strategy (HNSW/diskann), repair/reconcile. |
-| Code index | `kb_service_index.c`, `kb_service_code_embed.c`, extractors | Symbol extraction, `find_symbol`, callers, structure, blast radius. |
-| Ingest + curator | `kb_ingest_*.c`, `kb_curator_*.c` | Staged document ingest, structured-knowledge extraction, review queue. |
-| Background workers | `kb_background.c`, `kb_ingest_workers.c`, `kb_service_workers.c` | Drain DB2-backed queues via `FOR UPDATE SKIP LOCKED`. |
-| Learning / mining | `kb_learning_synth.c`, `kb_mining.c`, `kb_reflection.c`, `kb_calibrate.c` | Implicit learning, reflection, calibration. |
-
-## Boundary rules
-
-Server code must not include KB internals directly; it speaks only the KB client
-contract. KB code must not link SQLite or reach DB1. The build gates
-(`make check-linking`, `make kb-target-isolation-check`,
-`make kb-container-packaging-check`, `scripts/check_tier_deps.sh`) enforce both
-directions.
+See [Knowledge](../../docs/KNOWLEDGE.md), [Storage tiers](../../docs/STORAGE_TIERS.md), and
+[Public API](../../docs/PUBLIC_API.md).

--- a/src/kb/http/README.md
+++ b/src/kb/http/README.md
@@ -1,6 +1,10 @@
-# aimee-kb HTTP Boundary
+# KB HTTP boundary
 
-This directory contains the public `/v1/` HTTP surface owned by `aimee-kb`.
+This directory owns the public `aimee-kb /v1` handlers, listener, authentication, scope checks, body
+limits, TLS, health, and OpenAPI serving.
 
-New HTTP handlers should land here instead of the legacy flat `src/` module
-area.
+Add new KB HTTP behavior here. Define the OpenAPI operation and route descriptor first; call a typed
+KB owner below the handler. Do not put SQL, server internals, browser policy, or client-path reads in
+the HTTP layer.
+
+Run `make -C src api-conformance-check` and the narrow KB route tests after a change.

--- a/src/modules/sandbox/README.md
+++ b/src/modules/sandbox/README.md
@@ -1,12 +1,10 @@
-# modules/sandbox
+# Sandbox module
 
-The **delegate-image / package-proxy** sandbox: `sandbox_learned.c` (learned
-toolchain image provisioning) and `sandbox_pkg_proxy[_core].c` (the package
-download proxy used while building delegate images).
+This module owns delegate image/toolchain provisioning and the mediated package proxy.
 
-This is deliberately **separate** from the *process-isolation* sandbox in
-`src/posix/sandbox.c` + `src/headers/sandbox.h` (`DEC_SANDBOX_H`,
-`SANDBOX_MODE_OFF/WORKSPACE_ONLY/ALLOWLIST` — the Linux user/mount-namespace
-jail). The two share the `sandbox_` name prefix but are unrelated concerns and
-must not be re-merged: the namespace jail is platform (`posix/`) tier, this
-module is the delegate-provisioning tier that consumes it.
+It does not own the Linux process-isolation jail. That boundary lives in the platform sandbox code
+and controls user/mount namespaces, workspace roots, and allowlists. Provisioning consumes that
+isolation contract; it must not duplicate or weaken it.
+
+Changes need package-policy, cache-integrity, no-network, no-credential, degraded-isolation audit,
+and cleanup tests.

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,80 +1,53 @@
 # aimee-server
 
-This directory is the ownership boundary and implementation home for
-`aimee-server`, the persistent local hub that every thin client talks to.
-For the system-level picture see [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md);
-for the code-level module map and RPC catalog see the
-[Technical Reference](../README.md).
+This directory owns the C resource plane: DB1, sessions, agents, tools, policy, vault, provider
+calls, KB clients, and the public server `/v1` surface.
 
-## What aimee-server is
+It does not own DB2 or workflow lifecycle.
 
-`aimee-server` is a single C11 process that owns **DB1** (local SQLite), runs the
-bounded compute pool, routes delegates, serves the lifecycle hooks, and exposes
-the public HTTP `/v1` surface (its only client transport). The thin clients
-(`aimee`, `aimee-webchat`) hold no database; they reach this process over `/v1`
-(local `aimee-http.sock` or remote TCP) and forward typed requests. The expensive
-state (open DB handles, a
-warm KB connection, the worker pool) lives here, in a warm long-running process,
-which is what keeps CLI startup under 10 ms and a pre-tool hook check around 1 ms.
+## Boundaries
 
-It links `-lsqlite3` (plus `-lssl`/`-lcrypto`/`-lpam`) and is built with
-`-DAIMEE_DB2_DISABLED`: it **never** links libpq and holds no DB2 SQL. All
-knowledge operations go through the typed **KB client** (`kb_client*.c`) to
-`aimee-kb`. The storage boundary is compile-enforced (`make check-linking`,
-`readelf` symbol checks).
+- links SQLite, never libpq;
+- reaches DB2 only through the typed KB client;
+- returns `410 Gone` for retired C workflow lifecycle routes;
+- serves local clients over a filesystem-protected Unix socket;
+- serves remote clients through TLS, identity, capabilities, scope, and write-tier checks;
+- exposes narrow internal resource operations to the supervised Go workflow peer.
 
-## Scaling contract: one server per user
+## Main areas
 
-**`aimee-server` is strictly 1:1 with a user.** This is a design invariant, not a
-deployment choice:
+| Area | Responsibility |
+| --- | --- |
+| HTTP/listeners | parse, authenticate, route, stream, request IDs, shutdown |
+| DB1/state | sessions, working memory, jobs, policy/audit state, caches |
+| compute | bounded blocking work and provider calls |
+| agents | admission, role routing, canonical IR, tool loop, retries, accounting |
+| policy/tools | schemas, guardrails, worktree/path checks, backend execution |
+| vault | credential resolution, custody, rotation, access audit |
+| KB client | typed server-to-KB operations; no SQL |
+| observability bus | action and guardrail publication, durable sink, capture |
+| forge resource | confined mechanical operations requested by `aimee-wfe` |
 
-- It owns **local, same-user runtime state** in DB1: sessions, working memory,
-  conversation windows, checkpoints, durable delegate jobs, secrets. That state is
-  private to one OS user on one host.
-- It authenticates callers by **`SO_PEERCRED`** (the connecting process's UID).
-  The trust model is "same Unix user = same principal"; there is no notion of a
-  remote tenant.
-- It is therefore **single-tenant and local by construction**. You do not shard
-  it, replicate it, or put it behind a load balancer. Each developer (each OS
-  login) runs exactly one `aimee-server` on their own machine, normally as a
-  systemd user unit or launchd agent.
+## Concurrency
 
-Scale-out happens **below** the server, in the shared tier: many independent
-`aimee-server` instances (= many users) point at one shared `aimee-kb`/Postgres
-deployment. The server is the per-user front; the KB is the many-user back. See
-[`src/kb/README.md`](../kb/README.md) for that side of the boundary.
+Listeners hand blocking work to bounded pools. Heavy provider work also passes an admission budget.
+Event-bus publishers are serialized per SPSC producer; a dedicated consumer pumps, drains, writes
+typed sinks, and flushes capture. Shutdown rejects new work, waits for in-flight publishers, drains,
+then destroys the bus and database state.
 
-## Internals at a glance
+Do not add an unbounded queue or a second workflow writer to solve local pressure.
 
-| Concern | Where | Notes |
-|---------|-------|-------|
-| Event loop | `server.c` (`server_run`) | Single epoll thread: read, parse, dispatch, and **never blocks**. Per-connection buffered I/O; `EPOLLOUT` added only while a write is pending. |
-| Entry / signals | `server_main.c` | Startup handshake, SIGTERM/SIGINT graceful drain, unclean-exit forensics to DB1. |
-| Auth | `server_auth.c` | Capability lookup + a 16-bit capability mask declared per method (unknown methods default to deny). The local `/v1` UDS is filesystem-trusted (full surface); the optional TCP listener is bearer-gated (`server_http_authorize`, constant-time compare via `server_ct_equal`). |
-| Sessions | `server_session.c` | Session create/list/get/close, per-session worktrees and state. |
-| State handlers | `server_state.c` | Fast handlers: memory, index, rules, working memory, dashboard (routed to tier-owned APIs). |
-| Compute pool | `server_compute*.c`, `compute_pool.c`, `server_jobs_aux.c` | Bounded worker threads for anything that blocks (DB, network, subprocess, delegate inference); a compute-budget gate serializes heavyweight inference. Durable/background delegate jobs survive client disconnect. |
-| KB client | `kb_client*.c` | Typed RPC wrappers (memory, index, docs, agent, dashboard, roadmap, notes, curiosity, status) to `aimee-kb` over a Unix socket or HTTP (`AIMEE_KB_API_URL`, port 8741). The server holds **no** DB2 SQL. |
-| Delegation | `agent_runtime.c`, `agent_loop.c`, `agent_policy.c`, `agent_tools.c`, `delegate_routing.c`, `delegate_openai.c`, `http_retry.c` | Cost-based route selection, tool-use loop (bash/read/write), provider HTTP shaping, retry/fallback. |
-| HTTP `/v1` | `server_http.c`, `server_api.c` | OpenAI-compatible inference, run management, read/control surfaces. UDS callers auth by peer UID; TCP callers present a bearer token (optionally `scope:`-prefixed). Contract: [`api/openapi-server-v1.yaml`](../../api/openapi-server-v1.yaml). |
+## Checks
 
-## Concurrency model
+```bash
+make -C src check-linking
+make -C src module-boundary-check
+make -C src server-api-conformance-check
+make -C src unit-tests
+```
 
-- **Event-loop thread** owns socket I/O and dispatch and never blocks.
-- **Compute pool** runs blocking handlers; sizes are tunable in `aimee.yaml`
-  (`compute_threads` / `worker_threads` / `background_threads` / `session_threads`).
-- **Compute-budget gate** (`server_compute_budget_acquire/release`) bounds
-  concurrent heavyweight inference so a burst of delegates cannot exhaust the host.
+New remote routes need negative authentication, capability, scope, and write-tier tests. New internal
+forge operations also need peer identity, repository, worktree, branch, and argument confinement.
 
-These knobs scale a single user's server *vertically* (more in-flight delegates,
-more parallel tool calls). They do **not** make the server multi-user; that
-remains the KB tier's job.
-
-## Boundary rules
-
-Server code talks to `aimee-kb` only through the KB client contract; KB code must
-not include server internals. New server-only implementation files belong under
-this directory. The build gates (`make check-linking`,
-`make module-boundary-check`, `scripts/check_tier_deps.sh`) fail the build if a
-`db2_*`/`PQ*` symbol appears here, or if code outside a tier reaches a tier's
-storage handles directly.
+See [Architecture](../../docs/ARCHITECTURE.md), [Security](../../docs/SECURITY.md), and
+[Technical reference](../README.md).

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -1,7 +1,7 @@
-# Shared Module Boundary
+# Shared contracts
 
-This directory is reserved for source-level contracts shared by `aimee-server`
-and `aimee-kb`.
+Only source-level contracts intentionally shared by `aimee-server` and `aimee-kb` belong here:
+bounded DTOs, transport envelopes, and ownership-free utilities.
 
-Only DTOs, transport envelopes, and utilities that are intentionally public to
-both services belong here.
+No database handles, provider clients, credentials, policy decisions, process globals, or storage
+fallbacks. Shared does not mean unowned.


### PR DESCRIPTION
## Summary

- rewrite the active documentation against v0.2.192 and the current testing tree
- lead with the event bus, its audit path, and the module, policy, capture, and telemetry work it unlocks
- separate what is live today from follow-on bus consumers
- add the documentation index, event-bus reference, deployment guide, troubleshooting guide, module index, and contributor guide
- update CLI help and regenerate the command and configuration references from source
- remove retired behavior and describe the Go workflow engine's current contract

## Checks

- `make -C src docs-gen-check`
- `make -C src cli-help-coverage-check`
- `make -C src build/obj/cli_main.o`
- local-link check across all 69 changed Markdown files
- release-marker and stock-phrasing scan across all changed Markdown files
- `git diff --check origin/testing...HEAD`
