### PR TITLE
A slice that already committed its work must not retry forever

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -400,7 +400,17 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	// still the freeze no-op path.
 	if result.Partial && baseHeadErr == nil {
 		head, headErr := gitText(ctx, workdir, "rev-parse", "HEAD")
-		if headErr == nil && head == baseHead {
+		// baseHead is HEAD at the start of THIS attempt, so on a redispatch it
+		// already contains whatever earlier attempts committed. A delegate that
+		// correctly finds the work done then leaves no new commit and looks
+		// identical to one that did nothing at all -- and the slice retried until
+		// its wall cap, forever. Observed on wi_e51e37cf slice g0.0: two "wfe:
+		// impl" commits carrying the whole change, and every redispatch reporting
+		// "no owned files changed; result treated as incomplete".
+		//
+		// So only fail when the BRANCH carries no work either. Ask the branch, not
+		// this attempt.
+		if headErr == nil && head == baseHead && !branchHasWorkOverBase(ctx, workdir, req.WorkItem.ParentID) {
 			detail := strings.TrimSpace(result.Response)
 			if detail == "" {
 				detail = "delegate returned a partial result and produced no commit"
@@ -517,6 +527,32 @@ func commitChanges(ctx context.Context, workdir, stage string) error {
 // clean worktree, and returns the park reason "base_integration_conflict" so the
 // slice surfaces distinctly instead of masquerading as convergence_no_progress or
 // poisoning the reused worktree.
+// branchHasWorkOverBase reports whether this slice's branch carries any commit
+// beyond the feature base it was cut from -- i.e. whether the slice has already
+// produced work, regardless of what the current attempt did.
+//
+// Answers false when the base cannot be resolved. That preserves the existing
+// stricter behaviour rather than letting an unresolved base excuse a genuinely
+// empty slice: an unverifiable claim of work is not work.
+func branchHasWorkOverBase(ctx context.Context, workdir, parentID string) bool {
+	if parentID == "" {
+		return false
+	}
+	base := "aimee/feat/" + parentID
+	// Prefer the remote tip for the same reason the worktree does: slices merge
+	// through the forge, so the local ref can lag behind what has landed.
+	if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", "origin/"+base+"^{commit}"); err == nil {
+		base = "origin/" + base
+	} else if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", base+"^{commit}"); err != nil {
+		return false
+	}
+	count, err := gitText(ctx, workdir, "rev-list", "--count", base+"..HEAD")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(count) != "" && strings.TrimSpace(count) != "0"
+}
+
 func integrateFeatureBase(ctx context.Context, workdir, parentID string) (string, error) {
 	base := "aimee/feat/" + parentID
 	// The feature branch may not exist yet (first generation, before any slice has

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1931,3 +1931,57 @@ func TestMergeStepFailsTerminallyOnConflictButStillPendsOnLostRace(t *testing.T)
 		})
 	}
 }
+
+// A slice whose earlier attempt already committed the work must not be retried
+// forever. baseHead is HEAD at the start of the CURRENT attempt, so once a prior
+// attempt committed, a delegate that correctly finds nothing left to do leaves
+// head == baseHead and looked identical to one that did nothing at all. Observed
+// on wi_e51e37cf slice g0.0: two "wfe: impl" commits carrying the entire change,
+// and every redispatch reporting "no owned files changed". Ask the BRANCH whether
+// work exists, not the attempt.
+func TestBranchHasWorkOverBaseSeesCommitsFromEarlierAttempts(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	git := func(dir string, args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	git(root, "init", "-b", "trunk", repo)
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git(repo, "add", "README")
+	git(repo, "commit", "-m", "init")
+	git(repo, "branch", "aimee/feat/wi_parent")
+	ctx := context.Background()
+
+	// Cut from the base with nothing done yet: the slice has produced no work.
+	git(repo, "checkout", "-q", "-b", "aimee/wi/slice", "aimee/feat/wi_parent")
+	if branchHasWorkOverBase(ctx, repo, "wi_parent") {
+		t.Fatal("a slice with no commits over its base must not count as work")
+	}
+
+	// An earlier attempt commits the implementation.
+	if err := os.WriteFile(filepath.Join(repo, "impl.txt"), []byte("done\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git(repo, "add", "impl.txt")
+	git(repo, "commit", "-m", "wfe: impl")
+	if !branchHasWorkOverBase(ctx, repo, "wi_parent") {
+		t.Fatal("a slice carrying a commit over its base must count as work")
+	}
+
+	// No parent (a root item) is not a slice and must stay strict.
+	if branchHasWorkOverBase(ctx, repo, "") {
+		t.Fatal("an item with no parent must not be treated as having slice work")
+	}
+	// An unresolvable base must stay strict rather than excuse an empty slice.
+	if branchHasWorkOverBase(ctx, repo, "wi_does_not_exist") {
+		t.Fatal("an unresolved base must not count as work")
+	}
+}


### PR DESCRIPTION
#2010 made a partial implement that produced no commit fail instead of advancing — correct, because advancing turned it into an empty diff at freeze that read as *"already in the base"*. But it compares `HEAD` against `baseHead`, and **`baseHead` is HEAD at the start of the current attempt**.

On a redispatch that already contains whatever earlier attempts committed. So a delegate that correctly finds the work done leaves no new commit, `head == baseHead`, and it is indistinguishable from a delegate that did nothing. The slice returns `StepChanges`, is retried, finds the work done again, and repeats until its wall cap — forever.

## Observed live

`wi_e51e37cf` slice `g0.0`, stuck in `impl` for over two hours:

```
git log  -> 2 commits, "wfe: impl", carrying the entire change
            (server.go +19, server_test.go +66, version.go +12)
events   -> every redispatch: "no owned files changed; result treated as incomplete"
            then "wall_cap: context deadline exceeded"
```

The work existed the whole time. Only the *current attempt* had nothing to add.

## The fix

Ask the branch instead of the attempt: fail only when the slice carries no commit over the feature base it was cut from.

- prefers `origin/aimee/feat/<parent>` for the same reason the worktree does (#2023) — slices merge through the forge, so the local ref lags
- an unresolved base answers **false** and keeps the stricter behaviour: an unverifiable claim of work is not work
- an item with no parent is not a slice and stays strict

#2010's actual guarantee is preserved: a slice that genuinely produced nothing still fails.

## Verification

Four cases pinned: no commits over base → not work; a commit over base → work; no parent → strict; unresolvable base → strict.

`go build`, `go vet`, `gofmt -l` clean; `go test ./...` all packages pass.