### PR TITLE
The dispatch bridge discarded replies from deferred handlers

### DIFF
--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -955,7 +955,22 @@ int loopback_rpc(const char *body, int body_len, char *resp, int resp_cap, uint3
 
    pthread_mutex_destroy(&fake.mutex);
    pthread_cond_destroy(&fake.can_close);
-   shutdown(sp[1], SHUT_WR);
+
+   /* Do NOT shut the write end before reading. A handler that hands its work to a
+    * worker replies LATER through a dup of this socketpair (create_compute_ctx dups
+    * conn->fd rather than retaining the conn), and shutdown() applies to the socket
+    * — so it killed the dup's write too. That is why /v1/tools/execute answered 502
+    * "rpc produced no response" for every input, valid or not.
+    *
+    * Bound the read instead, so a handler that never replies cannot hang the
+    * adapter. Inline handlers have already written by the time server_dispatch
+    * returns, so they hit the newline break on the first pass and are unchanged.
+    * loopback_rpc runs on the per-connection worker (conn_worker -> handle_conn),
+    * not the listener, so waiting blocks only the connection that asked. */
+   {
+      struct timeval rcv = {LOOPBACK_REPLY_TIMEOUT_SECS, 0};
+      (void)setsockopt(sp[0], SOL_SOCKET, SO_RCVTIMEO, &rcv, sizeof(rcv));
+   }
 
    size_t total = 0;
    for (;;)


### PR DESCRIPTION
**#2037 shipped the constant for this change but not the change.** The patch script
raised before writing the file, so `testing` currently has an unused
`LOOPBACK_REPLY_TIMEOUT_SECS` and none of the behaviour — and a commit message that
describes behaviour that isn't there. This PR is the actual fix, verified by
reading the file back and re-testing against a built binary rather than trusting
the edit.

## The bug

`loopback_rpc` shut the socketpair's write end before reading:

```c
shutdown(sp[1], SHUT_WR);
/* then read sp[0] until newline or EOF */
```

A handler that hands its work to a worker replies *later*, through a **dup** of that
socketpair — `create_compute_ctx` dups `conn->fd` rather than retaining the conn.
`shutdown()` applies to the socket, not the descriptor, so it killed the dup's write
too. The reply went nowhere and the bridge read EOF.

`/v1/tools/execute` therefore answered `502 {"error":"rpc produced no response"}` for
**every** input, valid or not. It is the only handler with that pattern
(`server_compute.c`: *"Response will be sent by worker thread"*), reached via a
dedicated session-pool lane that `test_tool_execute_dispatch_uses_dedicated_lane`
asserts.

## Why this fix and not the alternatives

- **Route it async** — tried, tested, failed. Both sync and async dispatch go through
  this same `loopback_rpc` (`server_http_routes.c:1223` and `:1311`), so it returns a
  run handle and then the run fails identically.
- **Inline it like the kb handlers** — would delete the dedicated lane that exists so
  tools cannot starve other work, and break the test asserting it.
- **Wire the dead `refcount`/`can_close` scaffolding** — needs the worker to hold the
  conn pointer, which is precisely what the dup avoids. Likely why it was never wired.

Bounding the read is the one option that fixes the class without changing any
handler's design.

## Safety

Inline handlers have already written by the time `server_dispatch` returns, so they
hit the existing newline break on the first pass — timing-identical. And
`loopback_rpc` runs on the per-connection worker (`conn_worker → handle_conn`), not
the listener, so waiting blocks only the connection that asked; it cannot stall `/v1`
serving.

## Verified

| request | before | after |
|---|---|---|
| `/v1/tools/execute` valid body | 502 | **200, 0s** |
| `/v1/tools/execute` `""` and `{}` | 502 | **200, 0s** |
| `/v1/tools/execute` `[]` | 400 | 400, 0s (rejected inline) |
| `/v1/kb/search`, `/v1/memory/list` | 200 | 200, unchanged |

No request paid the timeout: the handler does reply, it just replies late.
