### PR TITLE
Three webchat turn defects: delegate budget on primary turns, unvalidated provider writes, doubled replies

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1430,10 +1430,6 @@ export default function Chat() {
   const tabsRef = useRef<TabData[]>(tabs);
   const activeIdxRef = useRef(activeIdx);
   const projectRootRef = useRef(projectRoot);
-  // Live `working` for the presence-event effect: lets turn_done decide whether
-  // THIS surface originated the turn (skip persist) or is merely observing a
-  // turn that ran/completed while detached (persist it into history).
-  const workingRef = useRef(working);
   // Live mirror of remoteTurnActive so sendMessage can synchronously tell whether
   // a server/foreign turn (e.g. a steer auto-continue) is in flight for the tab.
   const remoteTurnActiveRef = useRef(false);
@@ -1507,7 +1503,6 @@ export default function Chat() {
       if (!live.has(sid)) bgStreamsRef.current.delete(sid);
     }
   }, [tabs]);
-  useEffect(() => { workingRef.current = working; }, [working]);
   // Cancel any pending stream-flush timer on unmount.
   useEffect(() => () => { if (flushTimerRef.current !== null) window.clearTimeout(flushTimerRef.current); }, []);
 
@@ -1610,9 +1605,25 @@ export default function Chat() {
     const turnIdOf = (raw: string): string => {
       try { return (JSON.parse(raw) as { turn_id?: string }).turn_id || ''; } catch { return ''; }
     };
+    // Did THIS surface originate the turn? Read the send refs directly rather
+    // than the `working` render state: `working` is derived from workBySid
+    // (recomputeWorkCounts -> setWorkBySid -> re-render), so a ref synced to it
+    // in a useEffect lags the POST by a render + effect flush. turn_started
+    // routinely arrives inside that window, the surface's OWN turn was then
+    // classified as foreign, and turn_done appended a SECOND assistant message
+    // beside the one pollLiveTurn was already rendering — the doubled replies.
+    // activeSendAbortRefs is populated synchronously before the POST, so it is
+    // already accurate when the first ring event lands.
+    const hasLocalSendFor = (sid: string): boolean => {
+      for (const owner of activeSendAbortRefs.current.values())
+        if (owner === sid) return true;
+      for (const q of sendQueuesRef.current.values())
+        for (const it of q) if (it.originSid === sid) return true;
+      return false;
+    };
     es.addEventListener('turn_started', (ev: MessageEvent<string>) => {
       saveCursor(ev);
-      curTurnId = turnIdOf(ev.data); observed = ''; wasWorking = workingRef.current;
+      curTurnId = turnIdOf(ev.data); observed = ''; wasWorking = hasLocalSendFor(activeAimeeSid);
       // A steer continuation is server-initiated: render it even if this surface
       // still looks "working" from the just-cancelled turn's closing stream. Only
       // for the session this events stream is bound to (the one we steered).
@@ -1647,10 +1658,11 @@ export default function Chat() {
       const tid = turnIdOf(ev.data) || curTurnId; // turn_started always carries turn_id
       const text = observed;
       // Persist a turn observed-while-detached EXACTLY ONCE. Gates:
-      //  - wasWorking: snapshot at turn_started — THIS surface originated the turn
-      //    (its own send path stores the assistant message). This is the sole
-      //    "did I originate it" gate; a NEW local send mid-observation must NOT
-      //    drop a foreign turn, so the live workingRef is deliberately not used.
+      //  - wasWorking: snapshot at turn_started (see hasLocalSendFor) — THIS
+      //    surface originated the turn, and its own send path already renders and
+      //    stores the assistant message. This is the sole "did I originate it"
+      //    gate, and it is snapshotted, not re-read: a NEW local send mid-
+      //    observation must NOT make us drop a foreign turn.
       //  - cursor resume (above) means a fresh mount / auto-reconnect does NOT
       //    replay already-seen turns, so the ring no longer re-emits a completed
       //    turn. persistedTurnsRef (turn_id dedup) + the content-tail guard remain

--- a/src/Makefile
+++ b/src/Makefile
@@ -470,6 +470,9 @@ SERVER_SRCS += server/memory_audit_bridge.c
 # The sole object linking the tools dispatcher to the audit bus (agent_tools stays
 # bus-free — it exposes only a NULL-default completion hook). Server-only.
 SERVER_SRCS += server/tool_completion_audit_bridge.c
+# Pure policy: which provider names may be persisted as the durable primary
+# (unit tested standalone, so it stays out of the server_provider.c handler TU).
+SERVER_SRCS += server/provider_settable.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) modules/guardrails/guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -188,6 +188,11 @@ task_type_t task_type_classify(const char *prompt);
 /* Resolve the effective max-turns limit for an agent invocation.
  * Primary sessions (role == NULL) ignore agent->max_turns; only delegates cap. */
 int agent_resolve_max_turns(const agent_t *agent, const char *role);
+
+/* Map a routing role to the role a run is BUDGETED as: NULL (i.e. "primary,
+ * uncapped") for a primary turn, otherwise `role` unchanged. See the definition
+ * in posix/agent_max_turns.c. */
+const char *agent_budget_role(const char *role);
 const char *task_type_name(task_type_t type);
 
 /* Context assembly */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -8,6 +8,13 @@
 #include "compute_pool.h"
 #include "platform_event.h"
 #include "provider_catalog.h"
+
+/* True when `name` is a provider the chat path can resolve: a built-in CLI
+ * provider, a known adapter, or an agent in `acfg` (matched by name or by
+ * provider). Gates the durable primary write in handle_provider_set so a
+ * mistyped `aimee provider <word>` cannot brick every later chat turn.
+ * `acfg` may be NULL to check only the built-in/adapter sets. */
+int provider_name_settable(const char *name, const agent_config_t *acfg);
 #include "vault_principal.h"
 
 /* Forward declaration */

--- a/src/posix/agent_max_turns.c
+++ b/src/posix/agent_max_turns.c
@@ -1,6 +1,7 @@
 /* posix/agent_max_turns.c: max-turn resolution for primary vs delegate sessions. */
 #include "aimee.h"
 #include "agent_exec.h"
+#include "agent_config.h"
 #include "agent_types.h"
 #include "config.h"
 
@@ -20,4 +21,17 @@ int agent_resolve_max_turns(const agent_t *agent, const char *role)
    config_load(&iter_cfg);
    int cap = role ? iter_cfg.max_iterations_delegate : iter_cfg.max_iterations;
    return cap > 0 ? cap : INT_MAX;
+}
+
+/* The role an invocation is BUDGETED as, which is not always the role it is
+ * ROUTED as. The webchat/primary chat turn runs through agent_run_with_tools
+ * with a nominal role ("code") so the routing layer can pick a seat, but it is
+ * not a delegate: the user can always send another message, so it must never be
+ * capped by the delegate budget nor told its tool budget is exhausted. The
+ * caller already marks the turn with agent_routing_set_primary_turn() (thread-
+ * local, so delegations the turn spawns on other threads stay policed), so
+ * budget policy keys off that flag rather than off the routing role. */
+const char *agent_budget_role(const char *role)
+{
+   return agent_routing_primary_turn() ? NULL : role;
 }

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -555,9 +555,14 @@ native_provider_http:
     * discard an otherwise healthy panelist. Preserve tools for the normal run,
     * but make the one bounded degenerate-response retry a synthesis-only turn. */
    int tok = agent_request_max_tokens(agent, max_tokens);
-   int max_t = agent_resolve_max_turns(agent, role);
+   /* Turn-budget policy keys off the BUDGET role, not the routing role: the
+    * primary webchat turn is routed as "code" (server_compute.c) but must be
+    * budgeted as a primary session — uncapped, and never told its tool budget is
+    * exhausted. `budget_role` is NULL exactly when this is a primary turn. */
+   const char *budget_role = agent_budget_role(role);
+   int max_t = agent_resolve_max_turns(agent, budget_role);
    int initial_max_t = max_t;
-   int final_after_turns = delegate_final_after_turns_for_role(role);
+   int final_after_turns = delegate_final_after_turns_for_role(budget_role);
 
    /* Stuck detection state */
    char last_tool_sig[256] = {0};
@@ -588,7 +593,7 @@ native_provider_http:
    rtr_tracker_t rtr;
    memset(&rtr, 0, sizeof(rtr));
 
-   int mw_max_turns = role ? max_t : 0;
+   int mw_max_turns = budget_role ? max_t : 0;
    mw_pipeline_t mw_pipeline;
    mw_pipeline_cfgs_t mw_cfgs;
    mw_pipeline_build(&mw_pipeline, &mw_cfgs, &agent->middleware, mw_max_turns, agent->model);
@@ -640,7 +645,7 @@ native_provider_http:
          mw_ctx.tool_calls = total_calls;
          mw_ctx.consecutive_errors = consecutive_errors;
 
-         mw_pipeline_cfgs_set_max_turns(&mw_cfgs, role ? max_t : 0);
+         mw_pipeline_cfgs_set_max_turns(&mw_cfgs, budget_role ? max_t : 0);
          mw_result_t mw_res = mw_pipeline_run(&mw_pipeline, &mw_ctx);
 
          if (mw_res.action == MW_STOP)
@@ -718,10 +723,11 @@ native_provider_http:
 
       maybe_compact_before_request(&fb_agent, messages, (chatgpt || anthropic) ? sys : NULL);
 
-      /* Primary sessions (role == NULL) never close the tool budget — the user
-       * can always send another message.  Pass max_turns=0 so HARD never fires. */
-      liveness_final_response_mode_t final_mode =
-          liveness_final_response_mode(turn, role ? max_t : 0, total_calls, final_after_turns);
+      /* Primary sessions never close the tool budget — the user can always send
+       * another message.  budget_role is NULL for them (including the webchat
+       * turn, which is ROUTED as "code"), so max_turns=0 and HARD never fires. */
+      liveness_final_response_mode_t final_mode = liveness_final_response_mode(
+          turn, budget_role ? max_t : 0, total_calls, final_after_turns);
       int final_instruction_turn = final_mode != LIVENESS_FINAL_RESPONSE_NONE;
       int final_text_only_turn = !liveness_final_response_allows_tools(final_mode);
       /* A final-only turn cannot satisfy an evidence gate. Keep read-only tools

--- a/src/server/provider_settable.c
+++ b/src/server/provider_settable.c
@@ -46,4 +46,3 @@ int provider_name_settable(const char *name, const agent_config_t *acfg)
          return 1;
    return 0;
 }
-

--- a/src/server/provider_settable.c
+++ b/src/server/provider_settable.c
@@ -1,0 +1,49 @@
+/* server/provider_settable.c: which provider names may be persisted as the
+ * durable primary. Pure policy (no I/O), so it is unit tested directly. */
+#include <string.h>
+
+#include "aimee.h"
+#include "agent_adapter.h"
+#include "agent_types.h"
+#include "server.h"
+
+/* The built-in CLI providers server_compute synthesizes on demand when no agent
+ * is configured for them (chat_agent_add_builtin_provider). Keep in sync. */
+static int provider_is_builtin_name(const char *name)
+{
+   static const char *builtins[] = {"openai",       "claude", "claude-code",
+                                    "claude-oauth", "codex",  "codex-oauth"};
+   for (size_t i = 0; i < sizeof(builtins) / sizeof(builtins[0]); i++)
+      if (strcmp(name, builtins[i]) == 0)
+         return 1;
+   return 0;
+}
+
+/* A provider is settable only if the chat path can actually RESOLVE it: a
+ * configured agent (matched by name or by provider, as chat_agent_select_provider
+ * does), a known adapter, or a built-in CLI provider.
+ *
+ * Without this check any string under 16 chars was persisted as the durable
+ * primary, and every later chat turn died with "provider '...' is not configured
+ * as an aimee agent" — with no hint of what had set it. The CLI makes that easy
+ * to trigger by accident: the route table maps `provider` with a NULL subcommand
+ * to provider.set (cli_v1_routes.c), so any unrecognized `aimee provider <word>`
+ * — e.g. a mistyped `aimee provider capability` — silently rewrote the primary
+ * instead of reporting an unknown subcommand. Validating here fixes it for every
+ * client (CLI, webchat, scripts), not just the one that happened to send it. */
+int provider_name_settable(const char *name, const agent_config_t *acfg)
+{
+   if (!name || !name[0])
+      return 0;
+   if (provider_is_builtin_name(name))
+      return 1;
+   if (agent_adapter_for_provider(name))
+      return 1;
+   if (!acfg)
+      return 0;
+   for (int i = 0; i < acfg->agent_count; i++)
+      if (strcmp(acfg->agents[i].name, name) == 0 || strcmp(acfg->agents[i].provider, name) == 0)
+         return 1;
+   return 0;
+}
+

--- a/src/server_provider.c
+++ b/src/server_provider.c
@@ -291,6 +291,16 @@ int handle_provider_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return rc;
 }
 
+/* Provider settability policy lives in server/provider_settable.c (pure, unit
+ * tested); this TU only loads the config and reports the error. */
+static int provider_name_resolvable(const char *name)
+{
+   agent_config_t acfg;
+   if (agent_load_config(&acfg) != 0)
+      return provider_name_settable(name, NULL);
+   return provider_name_settable(name, &acfg);
+}
+
 int handle_provider_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -300,6 +310,14 @@ int handle_provider_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    const char *name = jname->valuestring;
    if (strlen(name) >= 16)
       return server_send_error(conn, "provider name too long (max 15 chars)", NULL);
+   if (!provider_name_resolvable(name))
+   {
+      char err[192];
+      snprintf(err, sizeof(err),
+               "unknown provider '%s': not a configured agent, adapter, or built-in provider",
+               name);
+      return server_send_error(conn, err, NULL);
+   }
    config_t cfg;
    config_load(&cfg);
    snprintf(cfg.provider, sizeof(cfg.provider), "%s", name);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1596,7 +1596,7 @@ $(TESTPREFIX)/unit-test-acp-server: $(OBJDIR)/tests/test_acp_server.o \
                            $(OBJDIR)/cJSON.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
-$(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o $(OBJDIR)/server/server.o $(OBJDIR)/server/server_seed_config.o $(OBJDIR)/server/server_api_status.o $(OBJDIR)/server_provider.o $(OBJDIR)/server_insights.o $(OBJDIR)/server_eval.o \
+$(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o $(OBJDIR)/server/server.o $(OBJDIR)/server/server_seed_config.o $(OBJDIR)/server/server_api_status.o $(OBJDIR)/server_provider.o $(OBJDIR)/server/provider_settable.o $(OBJDIR)/server/agent_adapter.o $(OBJDIR)/server_insights.o $(OBJDIR)/server_eval.o \
 	$(OBJDIR)/server/s2_native_gate_hook.o $(OBJDIR)/modules/workflows/wfe_native_gate.o $(OBJDIR)/modules/workflows/wfe_externalization.o $(OBJDIR)/modules/workflows/tool_egress.o \
 	$(OBJDIR)/db1/wfe_binding.o $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/modules/workflows/wfe_enforce.o \
                       $(OBJDIR)/harness_memory_common.o $(OBJDIR)/modules/delegates/delegate_sandbox_image.o $(OBJDIR)/modules/sandbox/sandbox_learned.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -450,6 +450,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-conversation \
                $(TESTPREFIX)/unit-test-agent-loop \
                $(TESTPREFIX)/unit-test-agent-max-turns \
+               $(TESTPREFIX)/unit-test-provider-settable \
                $(TESTPREFIX)/unit-test-file-snapshot \
                $(TESTPREFIX)/unit-test-execution-trace \
                $(TESTPREFIX)/unit-test-diagnose \
@@ -5152,6 +5153,12 @@ $(TESTPREFIX)/unit-test-cmd-run: $(OBJDIR)/tests/test_cmd_run.o \
 
 $(TESTPREFIX)/unit-test-conversation: $(OBJDIR)/tests/test_conversation.o \
                                        $(OBJDIR)/conversation.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-provider-settable: $(OBJDIR)/tests/test_provider_settable.o \
+                                         $(OBJDIR)/server/provider_settable.o \
+                                         $(OBJDIR)/server/agent_adapter.o \
+                                         $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-agent-max-turns: $(OBJDIR)/tests/test_agent_max_turns.o \

--- a/src/tests/test_agent_max_turns.c
+++ b/src/tests/test_agent_max_turns.c
@@ -9,6 +9,12 @@
 
 static int g_max_iterations = 0;
 static int g_max_iterations_delegate = 0;
+static int g_primary_turn = 0;
+
+int agent_routing_primary_turn(void)
+{
+   return g_primary_turn;
+}
 
 int config_load(config_t *cfg)
 {
@@ -93,6 +99,50 @@ static void test_zero_means_unlimited(void)
    printf("  PASS: max_turns<=0 means infinite for both primary and delegate\n");
 }
 
+/* Regression: the primary webchat turn is ROUTED as "code" (server_compute.c
+ * calls agent_run_with_tools(&acfg, "code", ...)) but must be BUDGETED as a
+ * primary session. Before agent_budget_role() existed, a chat turn resolved the
+ * DELEGATE cap and then HARD-closed, injecting "[FINAL RESPONSE REQUIRED] The
+ * tool turn budget is exhausted" into an ordinary conversation. */
+static void test_primary_turn_is_not_budgeted_as_delegate(void)
+{
+   agent_t a = make_agent(0); /* agents.json ships max_turns: 0 */
+   g_max_iterations = 200;
+   g_max_iterations_delegate = 14;
+
+   g_primary_turn = 1;
+   const char *budget_role = agent_budget_role("code");
+   int t = agent_resolve_max_turns(&a, budget_role);
+   g_primary_turn = 0;
+
+   assert(budget_role == NULL);
+   assert(t == 200); /* the PRIMARY cap, not the 14-turn delegate cap */
+
+   g_max_iterations = 0;
+   g_max_iterations_delegate = 0;
+   printf("  PASS: primary turn routed as \"code\" is budgeted as primary\n");
+}
+
+/* A real delegate keeps the delegate budget: the flag is thread-local and is
+ * never set on the delegate worker threads a primary turn spawns. */
+static void test_delegate_turn_keeps_delegate_budget(void)
+{
+   agent_t a = make_agent(0);
+   g_max_iterations = 200;
+   g_max_iterations_delegate = 14;
+
+   g_primary_turn = 0;
+   const char *budget_role = agent_budget_role("code");
+   int t = agent_resolve_max_turns(&a, budget_role);
+
+   assert(budget_role != NULL && strcmp(budget_role, "code") == 0);
+   assert(t == 14);
+
+   g_max_iterations = 0;
+   g_max_iterations_delegate = 0;
+   printf("  PASS: delegate turn keeps the delegate budget\n");
+}
+
 int main(void)
 {
    printf("test_agent_max_turns:\n");
@@ -104,6 +154,8 @@ int main(void)
    test_delegate_falls_back_to_config();
    test_delegate_default_is_infinite();
    test_zero_means_unlimited();
+   test_primary_turn_is_not_budgeted_as_delegate();
+   test_delegate_turn_keeps_delegate_budget();
 
    printf("test_agent_max_turns: all tests passed\n");
    return 0;

--- a/src/tests/test_provider_settable.c
+++ b/src/tests/test_provider_settable.c
@@ -1,0 +1,98 @@
+/* test_provider_settable.c: unit tests for provider_name_settable().
+ *
+ * Regression: handle_provider_set persisted ANY string under 16 chars as the
+ * durable primary provider. The CLI route table maps `provider` with a NULL
+ * subcommand to provider.set, so an unrecognized `aimee provider <word>` — e.g.
+ * `aimee provider capability` — silently rewrote the primary, and every later
+ * chat turn then failed with "provider 'capability' is not configured as an
+ * aimee agent". */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "aimee.h"
+#include "agent_types.h"
+#include "server.h"
+
+static void add_agent(agent_config_t *acfg, const char *name, const char *provider)
+{
+   agent_t *a = &acfg->agents[acfg->agent_count++];
+   memset(a, 0, sizeof(*a));
+   snprintf(a->name, sizeof(a->name), "%s", name);
+   snprintf(a->provider, sizeof(a->provider), "%s", provider);
+}
+
+/* The reported failure: a non-provider token must be rejected, not persisted. */
+static void test_rejects_unknown_token(void)
+{
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   add_agent(&acfg, "MiniMax-M3", "anthropic");
+
+   assert(provider_name_settable("capability", &acfg) == 0);
+   assert(provider_name_settable("models", &acfg) == 0);
+   assert(provider_name_settable("quota", &acfg) == 0);
+   printf("  PASS: unknown token is not settable as a provider\n");
+}
+
+/* A configured agent is settable by its NAME or by its PROVIDER — the same two
+ * ways chat_agent_select_provider resolves a primary. */
+static void test_accepts_configured_agent(void)
+{
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   add_agent(&acfg, "MiniMax-M3", "anthropic");
+   add_agent(&acfg, "kimi-k2.7-code", "anthropic");
+
+   assert(provider_name_settable("MiniMax-M3", &acfg) == 1);   /* by name */
+   assert(provider_name_settable("anthropic", &acfg) == 1);    /* by provider */
+   assert(provider_name_settable("kimi-k2.7-code", &acfg) == 1);
+   printf("  PASS: a configured agent is settable by name or provider\n");
+}
+
+/* Built-in CLI providers stay settable even with no agent configured for them —
+ * server_compute synthesizes those on demand. */
+static void test_accepts_builtin_providers(void)
+{
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+
+   assert(provider_name_settable("claude", &acfg) == 1);
+   assert(provider_name_settable("claude-oauth", &acfg) == 1);
+   assert(provider_name_settable("codex-oauth", &acfg) == 1);
+   assert(provider_name_settable("openai", &acfg) == 1);
+   printf("  PASS: built-in CLI providers are settable with no agent configured\n");
+}
+
+/* A known adapter is settable even when absent from agents.json. */
+static void test_accepts_known_adapter(void)
+{
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   assert(provider_name_settable("minimax", &acfg) == 1);
+   printf("  PASS: a known adapter is settable\n");
+}
+
+static void test_rejects_empty_and_null(void)
+{
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   assert(provider_name_settable(NULL, &acfg) == 0);
+   assert(provider_name_settable("", &acfg) == 0);
+   /* A NULL config still permits built-ins, but not an agent-only name. */
+   assert(provider_name_settable("claude", NULL) == 1);
+   assert(provider_name_settable("MiniMax-M3", NULL) == 0);
+   printf("  PASS: empty/NULL names rejected; NULL config allows only built-ins\n");
+}
+
+int main(void)
+{
+   printf("test_provider_settable:\n");
+   test_rejects_unknown_token();
+   test_accepts_configured_agent();
+   test_accepts_builtin_providers();
+   test_accepts_known_adapter();
+   test_rejects_empty_and_null();
+   printf("test_provider_settable: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_provider_settable.c
+++ b/src/tests/test_provider_settable.c
@@ -44,8 +44,8 @@ static void test_accepts_configured_agent(void)
    add_agent(&acfg, "MiniMax-M3", "anthropic");
    add_agent(&acfg, "kimi-k2.7-code", "anthropic");
 
-   assert(provider_name_settable("MiniMax-M3", &acfg) == 1);   /* by name */
-   assert(provider_name_settable("anthropic", &acfg) == 1);    /* by provider */
+   assert(provider_name_settable("MiniMax-M3", &acfg) == 1); /* by name */
+   assert(provider_name_settable("anthropic", &acfg) == 1);  /* by provider */
    assert(provider_name_settable("kimi-k2.7-code", &acfg) == 1);
    printf("  PASS: a configured agent is settable by name or provider\n");
 }


### PR DESCRIPTION
Three defects reported from a single webchat session. They are independent; one commit each.

## 1. The primary webchat turn was budgeted as a delegate

`server_compute.c:870` runs the PRIMARY chat turn as `agent_run_with_tools(&acfg, "code", ...)` so the routing layer can pick a seat. `agent_execute_session` read that nominal role as "delegate" and resolved `max_iterations_delegate` instead of `max_iterations`, then passed a non-zero `max_turns` to `liveness_final_response_mode` — so the HARD branch injected `[FINAL RESPONSE REQUIRED] The tool turn budget is exhausted…` into an ordinary conversation. The model answered *that*, which is why a one-word message came back as "No changes were made. No tests or verification commands were run because the tool-turn budget was exhausted."

The comment claiming primary sessions pass `max_turns=0` held only for `role == NULL` callers; the webchat path is not one.

Fix separates the role a run is **budgeted** as from the role it is **routed** as. `agent_budget_role()` keys off `agent_routing_primary_turn()` — the thread-local flag `server_compute` already sets around the primary turn, and which delegate worker threads never inherit.

## 2. Any word could be persisted as the primary provider

`handle_provider_set` checked only that the name was under 16 characters before writing it to durable config. The CLI route table maps `provider` with a NULL subcommand to `provider.set`, so an unrecognized `aimee provider <word>` silently rewrote the primary instead of reporting an unknown subcommand.

`aimee provider capability` was enough to leave every later chat turn failing with `provider 'capability' is not configured as an aimee agent`, with nothing in the error naming the cause.

The write is now gated on the chat path's own resolution rule — a configured agent (by name or provider), a known adapter, or a built-in CLI provider. Settable now means usable, for every client rather than the one that sent it.

## 3. Webchat rendered each reply twice

The presence ring decides at `turn_started` whether this surface originated the turn; if not, `turn_done` appends the observed text as a new assistant message. That gate read `workingRef.current`, but `working` is derived render state and the ref was synced in a `useEffect` — lagging the POST by a render plus an effect flush. `turn_started` lands inside that window, the surface's own turn was classified as foreign, and a second assistant message was appended beside the one `pollLiveTurn` was already rendering.

The existing tail guard only suppresses a duplicate byte-identical to the *last* message, so it missed these: the ring's text comes from `turn_delta` frames while the live bubble comes from the db1 `webchat_live` scrape, and an intervening error bubble breaks adjacency — matching the reported transcript, where the doubles follow an error.

Now reads `activeSendAbortRefs` directly, which is populated synchronously before the POST.

## Tests

Defect 1 was reproduced **red against the unmodified tree** before any change: with `max_iterations=200` and `max_iterations_delegate=14`, a primary turn resolved 14 and `liveness_final_response_mode` returned HARD.

Run and passing:
- `unit-test-agent-max-turns` — 9 pass, 2 new
- `unit-test-provider-settable` — 5 new
- `unit-test-delegate-liveness` — pass
- `make server` — exit 0, links with the new TU

## Not verified

- **Defect 3 is unverified.** This checkout has no `node_modules` and no npm, so the frontend change is neither typechecked nor exercised. It is reasoned from the code path only and needs a real webchat run before merge.
- Full `make unit-tests`, `make lint` and `make format` were not run. clang-format is not installed here; the 100-column limit was checked by hand.

## Operator note

Fix 2 stops the bad value being set; it does not repair a config that already holds one. An operator seeing this error must reset the primary (`aimee provider claude`).
