### PR TITLE
Windows thin client could not be configured at all (QUICKSTART 3.2)

### DIFF
--- a/src/aimee_home.c
+++ b/src/aimee_home.c
@@ -6,6 +6,28 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* The user's home directory, or NULL if it cannot be determined.
+ *
+ * Windows does not set HOME -- it sets USERPROFILE. Reading only HOME made
+ * aimee_home() return NULL for every Windows user, so the thin client could not
+ * locate its own config directory: `aimee remote set` failed with
+ * "cannot securely write (null)/remote.conf", which is QUICKSTART 3.2 and
+ * therefore the whole documented Windows setup. HOME still wins where it is set
+ * (MSYS/Cygwin/Git-Bash shells set it, and honouring it keeps those consistent
+ * with the POSIX builds). */
+static const char *user_home(void)
+{
+   const char *home = getenv("HOME");
+   if (home && home[0])
+      return home;
+#ifdef _WIN32
+   home = getenv("USERPROFILE");
+   if (home && home[0])
+      return home;
+#endif
+   return NULL;
+}
+
 const char *aimee_home(void)
 {
    /* Thread-local: this is a per-call scratch buffer whose pointer is returned
@@ -25,8 +47,8 @@ const char *aimee_home(void)
       return path;
    }
 
-   const char *home = getenv("HOME");
-   if (!home || !home[0])
+   const char *home = user_home();
+   if (!home)
       return NULL;
 
    /* 2. AIMEE_PROFILE selects a sibling under ~/.config/aimee/profiles/.
@@ -61,8 +83,8 @@ const char *aimee_profiles_dir(void)
       return path;
    }
 
-   const char *home = getenv("HOME");
-   if (!home || !home[0])
+   const char *home = user_home();
+   if (!home)
       return NULL;
 
    int n = snprintf(path, sizeof(path), "%s/.config/aimee/profiles", home);

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1760,11 +1760,17 @@ int main(int argc, char **argv)
       }
       /* aggregate / roundtable (and anything else) fall through to the /v1 routes. */
    }
+   /* `remote` configures the transport itself: it writes remote.conf and pins the
+    * server certificate, all locally, before any transport exists. It must stay
+    * outside the _WIN32 guard below -- it is the FIRST command a Windows thin
+    * client runs (QUICKSTART 3.2), and gating it on the Unix socket made it
+    * unreachable there ("command 'remote' has no /v1 route"), so the documented
+    * setup could not be completed at all. It needs no AF_UNIX. */
+   if (strcmp(cmd, "remote") == 0)
+      return cli_remote_cmd(sub_argc, sub_argv, json_output);
 #ifndef _WIN32
    /* manuscript mode talks to the server over the Unix-domain /v1 socket
     * (http_uds_client, AF_UNIX), which the Windows client does not build. */
-   if (strcmp(cmd, "remote") == 0)
-      return cli_remote_cmd(sub_argc, sub_argv, json_output);
    if (strcmp(cmd, "manuscript") == 0)
       return cmd_manuscript_run(sub_argc, sub_argv, json_output);
    /* persona management likewise goes over the /v1 socket (server-owned config). */


### PR DESCRIPTION
## What

The documented Windows setup could not be completed. Two independent defects, the second only reachable once the first is fixed.

**1. `aimee remote` was not dispatchable on Windows**

```
C:\> aimee.exe remote set https://192.168.0.2:8743 <token>
aimee: command 'remote' has no /v1 route; add a /v1 route
```

**2. `aimee_home()` returned NULL on Windows**

```
C:\> aimee.exe remote set https://192.168.0.2:8743 <token>
aimee: cannot securely write (null)/remote.conf
```

Both are step one of QUICKSTART section 3.2, so a new Windows user is stopped at the point where they connect to their server.

## Why

**1.** In `src/cli_main.c` the `remote` dispatch sat inside the `#ifndef _WIN32` block that also gates `manuscript`, `persona` and `roles`, under a comment explaining the guard for *manuscript*: "talks to the server over the Unix-domain /v1 socket (http_uds_client, AF_UNIX), which the Windows client does not build."

That is correct for those three. It does not apply to `remote`, which was swept in by proximity: `remote` writes `remote.conf` and pins the server certificate, entirely locally. It is the command you run *before* any transport exists, so gating it on the transport is backwards. `cli_remote.c` is already in the platform-independent `CLI_SRCS`, so it was compiled and linked into the Windows binary all along — only the dispatch was missing.

**2.** `aimee_home()` read only `HOME`. **Windows does not set `HOME`** — it sets `USERPROFILE`. Verified on the VM:

```
C:\> echo H=%HOME% U=%USERPROFILE%
H=%HOME% U=C:\Users\Administrator
```

(`%HOME%` echoes back literally, i.e. unset.) So `aimee_home()` returned NULL for every Windows user and the client could not locate its own config directory. This affects every caller, not just `remote`; it was simply unreachable while defect 1 masked it.

`HOME` still wins where set, so MSYS/Cygwin/Git-Bash shells keep behaving as the POSIX builds do. Both call sites in `aimee_home.c` now share one helper.

## Verification

Cross-compiled the thin client (MinGW, `-DAIMEE_THIN_CLIENT=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF`) and ran it on a clean unattended Windows Server 2022 install against a live server.

**Red, controlled.** Patched and unpatched binaries built from the *same* toolchain and flags, differing only in these changes, run on the same machine:

| binary | `aimee remote status` |
|---|---|
| control | `aimee: command 'remote' has no /v1 route` |
| fixed | `Transport: remote TCP -> 192.168.0.2:8743` / `Reachable: yes (GET /v1/health -> 200)` |

The stock released `aimee-windows-x86_64.exe` from v0.2.192 (asset size and md5 verified identical to the published artifact) reproduces the control behaviour, so this is not an artifact of the local build.

**Green, end to end.** Section 3.2 as written now completes:

```
  TLS: pinned server certificate (SHA-256 23:2A:B8:B8:C7:C0:3C:C6:57:98:A6:81:1E:7E:40:58:0F:E9:48:61:96:D1:F7:7F:E8:CF:EA:33:96:12:14:4E)
       -> C:\Users\Administrator/.config/aimee/remote-ca.pem
Remote server set to https://192.168.0.2:8743 (with token)
  TLS: verified against the pinned certificate.

Transport: remote TCP -> 192.168.0.2:8743
Reachable: yes (GET /v1/health -> 200)

aimee-server: ok
  state:       ok
  uptime:      6196s
```

The pinned SHA-256 is byte-identical to the one a Linux client pins against the same server, and `memory search` returns the same records on both platforms.

## Gap this leaves

The `windows-build` CI job smoke-tests `aimee.exe version` and `aimee.exe --server ... version` but never exercises `remote`, which is why this survived. Worth adding a `remote status` assertion to that smoke step; not included here to keep the fix reviewable.
