### PR TITLE
The next slice must integrate the feature tip the forge advanced

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -538,12 +538,9 @@ func branchHasWorkOverBase(ctx context.Context, workdir, parentID string) bool {
 	if parentID == "" {
 		return false
 	}
-	base := "aimee/feat/" + parentID
-	// Prefer the remote tip for the same reason the worktree does: slices merge
-	// through the forge, so the local ref can lag behind what has landed.
-	if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", "origin/"+base+"^{commit}"); err == nil {
-		base = "origin/" + base
-	} else if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", base+"^{commit}"); err != nil {
+	// One definition of "the feature tip" for every consumer -- see featureBaseRef.
+	base := featureBaseRef(ctx, workdir, parentID)
+	if base == "" {
 		return false
 	}
 	count, err := gitText(ctx, workdir, "rev-list", "--count", base+"..HEAD")
@@ -553,11 +550,43 @@ func branchHasWorkOverBase(ctx context.Context, workdir, parentID string) bool {
 	return strings.TrimSpace(count) != "" && strings.TrimSpace(count) != "0"
 }
 
+// featureBaseRef resolves the ref carrying the feature branch's real tip, or ""
+// when it cannot be resolved.
+//
+// A slice merges through the FORGE, which advances the remote feature branch.
+// Nothing advances the local aimee/feat/<parent> ref, so reading it locally hands
+// slice N+1 the state the run started with and every slice that already landed is
+// invisible. Measured on wi_f96d4b18: local e161dd34, remote da80f8e7, with the
+// merged file absent locally.
+//
+// #2023 fixed this for the base a slice worktree is CUT from. This is the second
+// consumer -- the merge that brings the feature branch INTO an existing slice --
+// and it had the same stale read, so the intended
+// "branch from the feature tip, merge back on completion" cycle only ever saw the
+// original tip. Fetch, then prefer the remote ref, falling back to the local one
+// when there is no remote (offline or a fresh repo).
+func featureBaseRef(ctx context.Context, workdir, parentID string) string {
+	if parentID == "" {
+		return ""
+	}
+	local := "aimee/feat/" + parentID
+	remote := "origin/" + local
+	_, _ = gitText(ctx, workdir, "fetch", "--quiet", "origin",
+		"+refs/heads/"+local+":refs/remotes/"+remote)
+	if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", remote+"^{commit}"); err == nil {
+		return remote
+	}
+	if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", local+"^{commit}"); err == nil {
+		return local
+	}
+	return ""
+}
+
 func integrateFeatureBase(ctx context.Context, workdir, parentID string) (string, error) {
-	base := "aimee/feat/" + parentID
+	base := featureBaseRef(ctx, workdir, parentID)
 	// The feature branch may not exist yet (first generation, before any slice has
 	// merged into it) — nothing to integrate.
-	if _, err := gitText(ctx, workdir, "rev-parse", "--verify", "--quiet", base+"^{commit}"); err != nil {
+	if base == "" {
 		return "", nil
 	}
 	// Already contains the base tip: merge would be a no-op.

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1985,3 +1985,79 @@ func TestBranchHasWorkOverBaseSeesCommitsFromEarlierAttempts(t *testing.T) {
 		t.Fatal("an unresolved base must not count as work")
 	}
 }
+
+// The intended slice cycle is: cut a branch from the feature tip, do the work,
+// merge back into the feature branch, and let the NEXT slice start from the
+// updated tip. That merge happens through the FORGE, which advances the remote
+// feature branch -- nothing advances the local aimee/feat/<parent> ref. Reading it
+// locally therefore hands slice N+1 the state the run began with, and every slice
+// that already landed is invisible to it. Measured on wi_f96d4b18: local
+// e161dd34, remote da80f8e7, merged file absent locally.
+func TestFeatureBaseRefPrefersTheForgeAdvancedRemoteTip(t *testing.T) {
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	repo := filepath.Join(root, "repo")
+	git := func(dir string, args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	git(root, "init", "--bare", "-b", "trunk", origin)
+	git(root, "clone", origin, repo)
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git(repo, "add", "README")
+	git(repo, "commit", "-m", "init")
+	git(repo, "push", "-u", "origin", "trunk")
+	git(repo, "branch", "aimee/feat/wi_parent")
+	git(repo, "push", "origin", "aimee/feat/wi_parent")
+
+	// Slice 0 lands through the forge: the REMOTE feature branch gains a commit
+	// while this clone's local ref deliberately stays behind.
+	landed := filepath.Join(root, "landed")
+	git(root, "clone", "-b", "aimee/feat/wi_parent", origin, landed)
+	if err := os.WriteFile(filepath.Join(landed, "slice0.txt"), []byte("landed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git(landed, "add", "slice0.txt")
+	git(landed, "commit", "-m", "slice 0")
+	git(landed, "push", "origin", "aimee/feat/wi_parent")
+
+	ctx := context.Background()
+	base := featureBaseRef(ctx, repo, "wi_parent")
+	if base != "origin/aimee/feat/wi_parent" {
+		t.Fatalf("resolved base = %q, want the fetched remote tip", base)
+	}
+	// And it must actually carry slice 0's work, which the local ref does not.
+	if out, err := exec.Command("git", "-C", repo, "cat-file", "-e",
+		base+":slice0.txt").CombinedOutput(); err != nil {
+		t.Fatalf("resolved base is missing the landed slice: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "cat-file", "-e",
+		"aimee/feat/wi_parent:slice0.txt").CombinedOutput(); err == nil {
+		t.Fatalf("local ref unexpectedly already carried the landed slice: %s", out)
+	}
+
+	// Integrating must now bring that landed work into the slice worktree.
+	git(repo, "checkout", "-q", "-b", "aimee/wi/slice1", "aimee/feat/wi_parent")
+	reason, err := integrateFeatureBase(ctx, repo, "wi_parent")
+	if err != nil || reason != "" {
+		t.Fatalf("integrate failed: reason=%q err=%v", reason, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, "slice0.txt")); statErr != nil {
+		t.Fatalf("next slice did not receive the landed work: %v", statErr)
+	}
+
+	// No parent is not a slice; an unknown parent must not resolve.
+	if featureBaseRef(ctx, repo, "") != "" {
+		t.Fatal("an item with no parent must not resolve a feature base")
+	}
+	if featureBaseRef(ctx, repo, "wi_missing") != "" {
+		t.Fatal("an unknown parent must not resolve a feature base")
+	}
+}


### PR DESCRIPTION
The intended slice cycle is: **cut a branch from the feature tip → do the work → merge back into the feature branch → next slice starts from the updated tip.**

The merge back happens through the **forge**, which advances the **remote** feature branch. Nothing advances the local `aimee/feat/<parent>` ref.

`integrateFeatureBase` — the merge that brings the feature branch *into* an existing slice worktree at code-mutating entry — read that local ref with **no fetch**. So it integrated the state the run began with, and every slice that had already landed was invisible to the next one. The cycle only ever saw the original tip.

## Why #2023 didn't cover it

#2023 fixed exactly this staleness for the base a slice worktree is **cut from**. This is the **second** consumer of the feature branch and it kept the old read — so half the cycle was still broken.

Measured on `wi_f96d4b18`:

```
local  aimee/feat/wi_f96d4b18... = e161dd34
remote origin/aimee/feat/...     = da80f8e7
the merged file: absent from the local ref entirely
```

## The change

`featureBaseRef` fetches and prefers `origin/aimee/feat/<parent>`, falling back to the local ref when there is no remote (offline / fresh repo), and returns `""` when unresolvable. It is now the **single definition of "the feature tip"** for both `integrateFeatureBase` and `branchHasWorkOverBase` (#2045), so all consumers agree.

## Verification

Red before green: with the local-only read restored, the test fails on `resolved base = "aimee/feat/wi_parent", want the fetched remote tip`, and the landed slice's file never reaches the next slice's worktree.

The test builds a real origin, lands a slice through it, and asserts the next slice both resolves the remote tip **and** actually receives the landed file — the full cycle, not just the ref string.

`go build`, `go vet`, `gofmt -l` clean; `go test ./...` all packages pass.

## Serialization

No change needed. `autonomy.per_workflow_concurrency` already defaults to `1` and the scheduler honours it (`SetPerWorkflowSource`), so a workflow runs one slice at a time as intended.