### PR TITLE
Windows client reported every refusal as "could not reach the server"

### DIFF
--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -978,8 +978,15 @@ static cJSON *cli_v1_send(const char *remote, const char *bearer, const char *ve
    char *r = aimee_client_request(verb, path, body, &status);
    if (r)
    {
-      if (status >= 200 && status < 300)
-         resp = cJSON_Parse(r);
+      /* Parse the body whatever the status, as the POSIX branch above does. The
+       * server states WHY it refused in the body of its 4xx ({"status":"error",
+       * "message":...}), and the caller already renders that. Gating the parse on
+       * 2xx threw those bodies away and left resp==NULL, which the caller can only
+       * report as "could not reach the aimee-server /v1 endpoint (is the server
+       * running?)" -- so on Windows an authorization refusal was indistinguishable
+       * from an outage, and sent users to debug a server that had just answered.
+       * A non-JSON body still parses to NULL and falls through as before. */
+      resp = cJSON_Parse(r);
       free(r);
    }
 #endif


### PR DESCRIPTION
## What

On Windows, any `/v1` call the server *refuses* was reported as an outage. With no write-tier grant:

```
C:\> aimee.exe memory store wintest hello
aimee: 'memory.store' could not reach the aimee-server /v1 endpoint (is the server
       running? check aimee.api.client_endpoint / AIMEE_API_ENDPOINT for a remote target).
aimee: server /v1 request failed for 'memory'
```

The server was running and had answered a **read from the same binary seconds earlier**. The message sends the user to debug connectivity when the actual cause is a missing grant.

Linux, built from the same tree against the same server, prints the real reason:

```
aimee: this endpoint requires capabilities beyond the presented token's scope
```

## Why

The Windows branch of `cli_v1_send` (`src/cli_v1_routes_d.c`) parsed the response body only for 2xx:

```c
char *r = aimee_client_request(verb, path, body, &status);
if (r)
{
   if (status >= 200 && status < 300)
      resp = cJSON_Parse(r);
   free(r);
}
```

The 403 body — `{"status":"error","message":"this endpoint requires capabilities beyond the presented token's scope"}` — was fetched and then thrown away, leaving `resp == NULL`. The caller can only interpret `NULL` as "no response", so it prints the "is the server running?" hint. The POSIX branch has no such gate, which is why the two platforms disagreed.

This is the same defect class the repo already documents for kb's HTTP client in `ci.yml`: *"kb's HTTP client discarded every non-2xx body, so the token exchange's DENIED result was UNREACHABLE and every identity-provider refusal surfaced as 'unparseable response'."* Same bug, different client.

## Fix

Parse the body regardless of status, matching POSIX. The caller already renders `{"status":"error"}` bodies. A non-JSON body still parses to `NULL` and falls through exactly as before, so genuine unreachability is unchanged.

## Verification

Cross-compiled the thin client (MinGW, `-DAIMEE_THIN_CLIENT=ON`) and ran it on a clean Windows Server 2022 VM against a live server.

- **Red:** stock `testing` → the connectivity error above.
- **Green:** with this change → `aimee: this endpoint requires capabilities beyond the presented token's scope`, byte-identical to Linux.

Both observed on screen, same VM, same server, same command.

## Note

Verifying this required #2048 (without it `aimee remote` is unreachable on Windows, so the client cannot be pointed at a server at all). The two changes are independent and touch different files; this one stands alone.