### PR TITLE
A hung sidecar must not take a server thread with it

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -303,7 +303,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. Secrets and tokens should be supplied through the environment or credential vault, never committed.
+The binaries read 216 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. Secrets and tokens should be supplied through the environment or credential vault, never committed.
 
 ### Paths & assets
 
@@ -589,6 +589,12 @@ The binaries read 215 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_TEST_PG_URL` | PostgreSQL URL used only by live test harnesses. |
 | `AIMEE_WITNESS_CADENCE_TEST_S` | Test-only override that shortens witness checkpoint and verification cadence. |
 | `AIMEE_WITNESS_HARNESS_ROLE` | Restricted PostgreSQL role used by the witness live harness. |
+
+### Agents & delegates
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_EXEC_PIPE_TIMEOUT_MS` | How long a sidecar subprocess (embed, rerank, cognify, rewrite, css render, oauth token, guardrails) may run before it is killed, in ms. Default 120000. Bounds the pathological case, not normal latency: an unbounded wait here parks the calling request thread permanently when a sidecar hangs instead of exiting, which has taken a kb offline while it still accepted connections. On expiry the child's whole process GROUP is killed, because the immediate child is /bin/sh and the work is its child. |
 
 ## External & provider environment
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -805,6 +805,16 @@ ENV_DESC = {
     "AIMEE_DEFAULT_BRANCH": ("Workflow engine", "Override the target repo's real default branch (its trunk) that a `base:trunk` `branch.open`/`pr.open` resolves to; else read from `git origin/HEAD`. Distinct from `AIMEE_AUTONOMY_BASE` (the aimee integration branch). A final feature PR opens against this branch (open-only, never auto-merged)."),
     # Git verify / MCP
     "AIMEE_VERIFY_PARALLEL": ("Git verify / MCP", "Run `aimee git verify` steps in parallel."),
+    "AIMEE_EXEC_PIPE_TIMEOUT_MS": (
+        "Agents & delegates",
+        "How long a sidecar subprocess (embed, rerank, cognify, rewrite, css render, "
+        "oauth token, guardrails) may run before it is killed, in ms. Default 120000. "
+        "Bounds the pathological case, not normal latency: an unbounded wait here parks "
+        "the calling request thread permanently when a sidecar hangs instead of exiting, "
+        "which has taken a kb offline while it still accepted connections. On expiry the "
+        "child's whole process GROUP is killed, because the immediate child is /bin/sh "
+        "and the work is its child.",
+    ),
     "AIMEE_VERIFY_STEP_TIMEOUT_MS": ("Git verify / MCP", "Per-step timeout (ms) for git verify."),
     "AIMEE_MCP_CWD": ("Git verify / MCP", "Working-directory hint for MCP git-root resolution."),
     "AIMEE_MCP_TOOL_PROFILE": ("Git verify / MCP", "MCP tools/list presentation profile: 'core'/'lean' (default — Tier-0 high-frequency tools only, with find_tools/describe_tool reaching the rest) or 'full' (present every tool upfront)."),

--- a/src/posix/platform_process.c
+++ b/src/posix/platform_process.c
@@ -2,6 +2,7 @@
 #include "platform_process.h"
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -223,6 +224,26 @@ int platform_exec_capture(const char *cmd, char **out, size_t *out_len, int time
    return platform_exec_capture_cancellable(cmd, out, out_len, timeout_ms, NULL, NULL);
 }
 
+/* How long a sidecar subprocess may take before it is killed. Generous: these
+ * are model/HTTP sidecars, not interactive calls. Overridable for operators with
+ * unusually slow sidecars, and for tests. */
+#define EXEC_PIPE_DEFAULT_TIMEOUT_MS 120000
+/* After the child closes stdout it should exit immediately; this only covers
+ * scheduling, not work. */
+#define EXEC_PIPE_EXIT_GRACE_MS 2000
+
+static int exec_pipe_timeout_ms(void)
+{
+   const char *env = getenv("AIMEE_EXEC_PIPE_TIMEOUT_MS");
+   if (env && env[0])
+   {
+      int v = atoi(env);
+      if (v > 0)
+         return v;
+   }
+   return EXEC_PIPE_DEFAULT_TIMEOUT_MS;
+}
+
 int platform_exec_pipe(const char *cmd, const char *input, size_t input_len, char **out,
                        size_t *out_len)
 {
@@ -243,6 +264,11 @@ int platform_exec_pipe(const char *cmd, const char *input, size_t input_len, cha
 
    if (pid == 0)
    {
+      /* Own process group, as platform_exec_capture already does: the child is
+       * /bin/sh, and the work (python3 embed-remote.py) is its CHILD. Killing
+       * only the shell on timeout orphans the real process, which keeps holding
+       * the endpoint it was stuck on. Kill the group or do not bother. */
+      setpgid(0, 0);
       close(stdin_pipe[1]);
       close(stdout_pipe[0]);
       dup2(stdin_pipe[0], STDIN_FILENO);
@@ -254,6 +280,7 @@ int platform_exec_pipe(const char *cmd, const char *input, size_t input_len, cha
       _exit(127);
    }
 
+   setpgid(pid, pid); /* race-free: both sides set it (see the child above) */
    close(stdin_pipe[0]);
    close(stdout_pipe[1]);
 
@@ -298,9 +325,51 @@ int platform_exec_pipe(const char *cmd, const char *input, size_t input_len, cha
       return -1;
    }
 
-   ssize_t n;
-   while ((n = read(stdout_pipe[0], buf + len, cap - len - 1)) > 0)
+   /* Bounded read. An unbounded read() here blocks the CALLING THREAD forever
+    * when the child hangs rather than exits -- a sidecar whose endpoint accepts
+    * the connection and never answers, or a stalled DNS lookup. Every caller of
+    * this function is a sidecar in a request path (embed, rerank, cognify,
+    * rewrite, css render, oauth token, guardrails), so a thread lost here is a
+    * server thread lost for good.
+    *
+    * Observed in production: a kb whose embedder was unreachable pinned a DB2
+    * pool lease for 21.8 HOURS -- one thread stuck in this read() -- and the
+    * reaper logged "missed lease_end?" 3895 times because it cannot safely
+    * reclaim a connection a live thread may still be using. Reproduced from a
+    * clean container: under six concurrent searches the worker threads were
+    * consumed one by one until /v1/health itself stopped answering and the
+    * container went unhealthy while still accepting connections.
+    *
+    * Kill the child on expiry so it cannot linger either. */
+   const int timeout_ms = exec_pipe_timeout_ms();
+   struct timespec start_ts;
+   clock_gettime(CLOCK_MONOTONIC, &start_ts);
+   int timed_out = 0;
+   for (;;)
    {
+      struct timespec now_ts;
+      clock_gettime(CLOCK_MONOTONIC, &now_ts);
+      long elapsed_ms =
+          (now_ts.tv_sec - start_ts.tv_sec) * 1000 + (now_ts.tv_nsec - start_ts.tv_nsec) / 1000000;
+      long remaining = (long)timeout_ms - elapsed_ms;
+      if (remaining <= 0)
+      {
+         timed_out = 1;
+         break;
+      }
+      struct pollfd pfd = {.fd = stdout_pipe[0], .events = POLLIN};
+      int pr = poll(&pfd, 1, (int)(remaining > 1000 ? 1000 : remaining));
+      if (pr < 0)
+      {
+         if (errno == EINTR)
+            continue;
+         break;
+      }
+      if (pr == 0)
+         continue; /* re-check the deadline */
+      ssize_t n = read(stdout_pipe[0], buf + len, cap - len - 1);
+      if (n <= 0)
+         break; /* EOF or error: the child closed stdout */
       len += (size_t)n;
       if (len + 1024 > cap)
       {
@@ -314,8 +383,47 @@ int platform_exec_pipe(const char *cmd, const char *input, size_t input_len, cha
    close(stdout_pipe[0]);
    buf[len] = '\0';
 
-   int status;
-   waitpid(pid, &status, 0);
+   if (timed_out)
+   {
+      kill(-pid, SIGKILL); /* the group: the shell AND the work it spawned */
+      kill(pid, SIGKILL);
+      waitpid(pid, NULL, 0); /* prompt: the child was just killed */
+      free(buf);
+      *out = NULL;
+      if (out_len)
+         *out_len = 0;
+      return -1;
+   }
+
+   /* The child closed stdout; it should exit promptly. Do not trust "should" --
+    * bound this too, then kill, or a child that closes stdout and hangs leaves
+    * the same wedged thread this function exists to prevent. */
+   int status = 0;
+   int reaped = 0;
+   for (int waited_ms = 0; waited_ms < EXEC_PIPE_EXIT_GRACE_MS; waited_ms += 20)
+   {
+      pid_t r = waitpid(pid, &status, WNOHANG);
+      if (r == pid)
+      {
+         reaped = 1;
+         break;
+      }
+      if (r < 0)
+         break;
+      struct timespec nap = {.tv_sec = 0, .tv_nsec = 20 * 1000 * 1000};
+      nanosleep(&nap, NULL);
+   }
+   if (!reaped)
+   {
+      kill(-pid, SIGKILL);
+      kill(pid, SIGKILL);
+      waitpid(pid, &status, 0);
+      free(buf);
+      *out = NULL;
+      if (out_len)
+         *out_len = 0;
+      return -1;
+   }
 
    *out = buf;
    if (out_len)

--- a/src/tests/test_platform_process.c
+++ b/src/tests/test_platform_process.c
@@ -1,5 +1,6 @@
 /* test_platform_process.c: tests for platform_exec_capture timeout behavior */
 #include <assert.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -101,6 +102,53 @@ static void test_exec_pipe_child_exits_without_reading(void)
    free(input);
 }
 
+/* A sidecar that HANGS rather than exits must not take the calling thread with
+ * it. Every platform_exec_pipe caller is a sidecar in a request path, so a
+ * thread lost here is a server thread lost permanently.
+ *
+ * Production: a kb whose embedder was unreachable pinned a DB2 pool lease for
+ * 21.8 hours -- one thread parked in this function's read() -- and the pool
+ * reaper logged "missed lease_end?" 3895 times, unable to reclaim a connection a
+ * live thread might still use. Reproduced from a clean container: six concurrent
+ * searches consumed the worker threads one by one until /v1/health itself stopped
+ * answering while the port still accepted connections. */
+static void test_exec_pipe_hanging_child_does_not_block_forever(void)
+{
+   platform_setenv("AIMEE_EXEC_PIPE_TIMEOUT_MS", "1500");
+
+   struct timespec t0, t1;
+   clock_gettime(CLOCK_MONOTONIC, &t0);
+   char *out = NULL;
+   size_t len = 0;
+   /* Holds stdout open and never writes or exits: exactly the wedged-sidecar
+    * shape. Without a bounded read this call never returns. */
+   int rc = platform_exec_pipe("sleep 60", NULL, 0, &out, &len);
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+
+   long elapsed_ms = (t1.tv_sec - t0.tv_sec) * 1000 + (t1.tv_nsec - t0.tv_nsec) / 1000000;
+   assert(rc != 0);            /* reported as a failure, not a silent empty result */
+   assert(elapsed_ms < 15000); /* returned on the timeout, not after the child */
+   free(out);
+
+   /* The child must be KILLED, not merely abandoned. Proven by a marker the
+    * child would create if it were still alive after we returned: the work runs
+    * as a grandchild of /bin/sh, so killing only the shell leaves it running.
+    * A process-table check is unusable here -- pgrep matches its own command
+    * line, and on a shared machine other processes' arguments collide. */
+   unlink("/tmp/aimee_exec_pipe_probe_marker");
+   out = NULL;
+   len = 0;
+   platform_setenv("AIMEE_EXEC_PIPE_TIMEOUT_MS", "800");
+   rc = platform_exec_pipe("sleep 4; touch /tmp/aimee_exec_pipe_probe_marker", NULL, 0, &out, &len);
+   assert(rc != 0);
+   free(out);
+   struct timespec settle = {.tv_sec = 6, .tv_nsec = 0};
+   nanosleep(&settle, NULL);
+   assert(access("/tmp/aimee_exec_pipe_probe_marker", F_OK) != 0);
+
+   platform_setenv("AIMEE_EXEC_PIPE_TIMEOUT_MS", "");
+}
+
 int main(void)
 {
    test_exec_capture_basic();
@@ -109,6 +157,7 @@ int main(void)
    test_exec_capture_no_timeout_fast_cmd();
    test_exec_capture_cancellable();
    test_exec_pipe_child_exits_without_reading();
+   test_exec_pipe_hanging_child_does_not_block_forever();
    printf("platform_process: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
`platform_exec_pipe` read its child's stdout with an **unbounded** `read()` and then `waitpid(pid, &status, 0)`. If the child hangs rather than exits — a sidecar whose endpoint accepts the connection and never answers, a stalled DNS lookup — the **calling thread blocks forever**.

Every caller is a sidecar in a request path: embed, rerank, cognify, rewrite, css render, oauth token, guardrails. A thread lost here is a server thread lost permanently.

## Evidence

A kb whose embedder was unreachable pinned a DB2 pool lease for **21.8 hours**. The pool reaper logged `missed lease_end?` **3,895 times** and cannot reclaim it — correctly, since libpq forbids concurrent use of a connection a live thread may still hold.

Thread inspection while wedged:

```
9 threads  hrtimer_nanosleep
4 threads  futex_do_wait
1 thread   anon_pipe_read      ← this read()
+ live child: python3 embed-remote.py
+ curl /v1/health stuck 32s    ← the healthcheck itself
```

**Reproduced from a clean container** with no embedder configured: six concurrent searches, and `/v1/health` stopped answering while the port still accepted connections — `000` at exactly the client timeout, container `unhealthy`.

## The fix

Bound both waits, and **kill the process group** on expiry. The child is `/bin/sh` and the real work is *its* child, so killing only the shell orphans the process actually stuck on the endpoint. `platform_exec_capture` already establishes its group this way; `exec_pipe` never did — my first attempt at this fix killed only the shell and the test caught it.

Default 120 s, `AIMEE_EXEC_PIPE_TIMEOUT_MS` overrides. Generous on purpose: these are model/HTTP sidecars, and the point is to bound the pathological case, not police normal latency.

## Relationship to #2064

#2064 fixes a **different cause of the same symptom** — idle client sockets holding worker slots at accept time (`kb_http_listener.c`). That is the socket side; this is the subprocess side. Neither subsumes the other and they touch different files.

I found #2064 only after building this, and I have **not** proven which of the two consumed the workers in my reproduction — plausibly both. This change stands on its own evidence: an unbounded blocking wait in a request path, plus a 21.8-hour pinned lease with a thread parked in exactly that call.

## Verification

Red before green: against the current file the test does not merely fail, it **hangs** — `exit 124` under a 45 s timeout.

The kill is proven by a marker file the child would create if it outlived the call. A process-table check is unusable here: `pgrep` matches its own command line, and on a shared machine other processes' arguments collide — which cost me two false failures before I switched approach.