### PR TITLE
AIMEE_IMAGE_TAG: pick the image channel for the whole stack in one knob

### DIFF
--- a/compose.server-managed.yaml
+++ b/compose.server-managed.yaml
@@ -31,7 +31,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.server
-    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:${AIMEE_IMAGE_TAG:-latest}}
     networks: [aimee]
     ulimits:
       stack: 67108864
@@ -60,11 +60,20 @@ services:
       AIMEE_DEPLOY_ENABLED: "1"
       AIMEE_DEPLOY_COMPOSE_FILE: /opt/aimee/deploy/aimee-managed.compose.yaml
       COMPOSE_PROJECT_NAME: aimee
+      # The image channel for the WHOLE stack, in one knob: AIMEE_IMAGE_TAG=testing
+      # runs a tested-but-unreleased build without hand-setting an image variable
+      # per service. It is forwarded into the server's own environment because the
+      # server re-runs compose for the managed services (deploy_apply.c copies
+      # environ), so the tag has to survive that hop or the wizard's Deploy would
+      # silently fall back to :latest for the kb and llm while the server itself
+      # ran :testing — a split-version stack, which is how a kb with no `dim` in
+      # /health got paired with a server that expected one.
+      AIMEE_IMAGE_TAG: ${AIMEE_IMAGE_TAG:-latest}
       # Passed through to the managed services when a role is placed local (tier,
       # images). ONE LLM image serves every tier — it is model-less and downloads
       # what the wizard selected — so there is no separate CPU image to override.
-      AIMEE_LLM_IMAGE: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
-      AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
+      AIMEE_LLM_IMAGE: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:${AIMEE_IMAGE_TAG:-latest}}
+      AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
       AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
       # "Sign in with OAuth" client IDs (public; see oauth_defaults.h). Set the

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -30,7 +30,7 @@ services:
     # Published image (built + pushed to ghcr on every merge to main): `docker
     # compose pull` fetches it; `up --build` rebuilds locally and tags it the same.
     # Override AIMEE_SERVER_IMAGE to pin a version or use a fork/registry.
-    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:${AIMEE_IMAGE_TAG:-latest}}
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
     ulimits:

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -24,7 +24,7 @@ services:
     profiles: ["legacy-embedder"]
     # Published image (pushed to ghcr on every merge to main); override
     # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
-    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -57,7 +57,7 @@ services:
     restart: unless-stopped
     # Published image (pushed to ghcr on every merge to main); override
     # AIMEE_KB_IMAGE to pin a version or use a fork/registry.
-    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: Dockerfile
@@ -99,7 +99,7 @@ services:
     restart: unless-stopped
     # Published image (pushed to ghcr on every merge to main); override
     # AIMEE_SERVER_IMAGE to pin a version or use a fork/registry.
-    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: Dockerfile.server
@@ -208,7 +208,7 @@ services:
   # CI/dev: AIMEE_LLM_DOCKERFILE=Dockerfile.aimee-llm-stub + AIMEE_LLM_STUB=1.
   aimee-llm:
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: ${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm}

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     profiles: ["legacy-embedder"]
     # Published image (pushed to ghcr on every merge to main); override
     # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
-    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -42,7 +42,7 @@ services:
     restart: unless-stopped
     # Published image (pushed to ghcr on every merge to main); override
     # AIMEE_KB_IMAGE to pin a version or use a fork/registry.
-    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: Dockerfile
@@ -93,7 +93,7 @@ services:
   #   cred the container idles healthy with a clear log rather than crash-looping.
   aimee-control-web:
     restart: unless-stopped
-    image: ${AIMEE_CONTROL_WEB_IMAGE:-ghcr.io/rakuensoftware/aimee-control-web:latest}
+    image: ${AIMEE_CONTROL_WEB_IMAGE:-ghcr.io/rakuensoftware/aimee-control-web:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: Dockerfile.control-web
@@ -166,7 +166,7 @@ services:
     # all-external / remote-kb stack never starts it. CI opts it in via
     # COMPOSE_PROFILES=llm (see e2e-matrix.sh) to exercise the kb->gateway contract.
     profiles: ["llm"]
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:${AIMEE_IMAGE_TAG:-latest}}
     build:
       context: .
       dockerfile: ${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm}

--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -30,7 +30,7 @@ services:
   aimee-kb:
     profiles: ["kb"]
     restart: unless-stopped
-    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
     networks: [aimee]
     # The kb's worker threads need a 64 MB stack (the 8 MB default SIGSEGVs on real
     # kb queries). Matches systemd's LimitSTACK=67108864.
@@ -65,7 +65,7 @@ services:
   aimee-llm:
     profiles: ["llm"]
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:${AIMEE_IMAGE_TAG:-latest}}
     networks: [aimee]
     environment:
       AIMEE_LLM_PORT: "8742"

--- a/deploy/smoothnas/aimee-kb.compose.yaml
+++ b/deploy/smoothnas/aimee-kb.compose.yaml
@@ -8,7 +8,7 @@ name: aimee-kb
 services:
   aimee-kb:
     restart: unless-stopped
-    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
     ulimits:
       stack: 67108864
     environment:

--- a/deploy/smoothnas/aimee-llm.compose.yaml
+++ b/deploy/smoothnas/aimee-llm.compose.yaml
@@ -9,7 +9,7 @@ name: aimee-llm
 services:
   aimee-llm:
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:${AIMEE_IMAGE_TAG:-latest}}
     environment:
       AIMEE_LLM_PORT: "8742"
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}

--- a/deploy/smoothnas/aimee-server.compose.yaml
+++ b/deploy/smoothnas/aimee-server.compose.yaml
@@ -6,7 +6,7 @@ name: aimee-server
 services:
   aimee-server:
     restart: unless-stopped
-    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:${AIMEE_IMAGE_TAG:-latest}}
     ulimits:
       stack: 67108864
     environment:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,6 +29,24 @@ The final **Deploy** step starts:
 Change `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` before exposing this host. The defaults are
 for local setup only.
 
+### Choosing an image channel
+
+The stack runs the released `:latest` images by default. To run a tested-but-unreleased build, set
+`AIMEE_IMAGE_TAG` once — it moves the server, the KB and the LLM together:
+
+```bash
+AIMEE_IMAGE_TAG=testing docker compose -f compose.server-managed.yaml up -d
+```
+
+Set it for the wizard's **Deploy** step too, not just the server: the server re-runs Compose for the
+managed services, so the tag has to be in its environment or the KB and LLM fall back to `:latest`
+while the server runs `:testing`. The line above already does this. Mixing versions this way is a
+real failure mode, not a theoretical one — a KB and a server from different builds can disagree
+about the inference contract and leave the KB permanently unhealthy.
+
+A single service can still be pinned individually (`AIMEE_KB_IMAGE=…`), and an explicit pin always
+wins over `AIMEE_IMAGE_TAG`.
+
 Check the containers:
 
 ```bash


### PR DESCRIPTION
## Why

Running a tested-but-unreleased build meant setting `AIMEE_SERVER_IMAGE`, `AIMEE_KB_IMAGE` **and** `AIMEE_LLM_IMAGE` by hand, each to a full ghcr path. Miss one and the stack silently splits across versions.

That is not a theoretical hazard. It is precisely how a gateway whose `/health` omits `dim` ended up paired with a kb that gates on it — the kb stayed `unhealthy` forever on a fresh install, with no error that pointed at a version mismatch.

## What

Make the *tag* the variable. Every ghcr image default across the compose files becomes:

```yaml
${AIMEE_<X>_IMAGE:-ghcr.io/rakuensoftware/<x>:${AIMEE_IMAGE_TAG:-latest}}
```

So:

```bash
AIMEE_IMAGE_TAG=testing docker compose -f compose.server-managed.yaml up -d
```

moves server, kb and llm together. Default stays `:latest`. An explicit per-image pin still wins over the tag.

**The forwarding hop matters.** `AIMEE_IMAGE_TAG` is also passed into the server's own environment, because the server re-runs Compose for the managed services and `deploy_apply.c` copies `environ`. Without it, the wizard's **Deploy** would bring up the kb and llm at `:latest` while the server ran `:testing` — reintroducing the exact split-version stack this is meant to prevent.

17 image references across `compose.yaml`, `compose.server.yaml`, `compose.server-managed.yaml`, `compose.server-standalone.yaml`, the managed deploy compose, and the three smoothnas service composes.

## Verified

With `docker compose config` on real Compose v5.3.1:

| env | server | kb | llm |
|---|---|---|---|
| (unset) | `:latest` | `:latest` | `:latest` |
| `AIMEE_IMAGE_TAG=testing` | `:testing` | `:testing` | `:testing` |
| `+ AIMEE_KB_IMAGE=my/kb:pinned` | `:testing` | `my/kb:pinned` | `:testing` |

The inner managed compose resolves correctly both from the forwarded tag alone and from the forwarded per-image variables.

`make lint` and `make docs-gen-check` pass. QUICKSTART gains a short "Choosing an image channel" section that states the forwarding requirement explicitly, since getting it wrong is silent.