### PR TITLE
Curator sidecars shipped a hardcoded LAN address as their LLM endpoint

### DIFF
--- a/scripts/check-sidecar-clients.py
+++ b/scripts/check-sidecar-clients.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -170,11 +171,54 @@ def check_llm_chat_reasoning_split() -> None:
     print("  llm-chat.py reasoning split: ok")
 
 
+def check_no_baked_endpoint_defaults() -> None:
+    """No sidecar may carry a baked-in network address as its endpoint default.
+
+    Three of them shipped `env.setdefault("LLM_ENDPOINT", "http://<a LAN IP>")`.
+    Where nothing owned that address, every curator code-extraction job failed
+    `No route to host` and the queue never drained — silently, because doc
+    extraction used a different path and kept working. Where something DID own
+    it, the sidecar would post the user's code and prompts to a stranger's
+    machine. embed-remote.py had already removed its equivalent fallback; these
+    outlived that cleanup, so pin the rule down here.
+
+    An endpoint must come from the environment (AIMEE_LLM_URL / LLM_ENDPOINT) or
+    fail closed. Literal loopback is fine — it addresses only this host.
+    """
+    host_literal = re.compile(
+        r"""setdefault\(\s*["'](?:LLM_ENDPOINT|AIMEE_LLM_URL|LLM_BASE_URL)["']\s*,\s*["']([^"']+)["']"""
+    )
+    offenders = []
+    self_name = Path(__file__).name
+    for path in sorted(SCRIPTS.glob("*.py")):
+        if path.name == self_name:
+            continue  # this file quotes the banned pattern to describe it
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            m = host_literal.search(line)
+            if not m:
+                continue
+            value = m.group(1)
+            if "127.0.0.1" in value or "localhost" in value:
+                continue
+            offenders.append(f"{path.name}:{lineno}: baked endpoint default {value!r}")
+
+    if offenders:
+        for o in offenders:
+            print(f"  FAIL {o}")
+        raise AssertionError(
+            "sidecar endpoints must come from the environment or fail closed; "
+            "a baked address either breaks every deployment that does not own it "
+            "or leaks user code to whoever does"
+        )
+    print("  no baked endpoint defaults: ok")
+
+
 def main() -> int:
     print("sidecar-clients:")
     check_embed_remote()
     check_llm_chat()
     check_llm_chat_reasoning_split()
+    check_no_baked_endpoint_defaults()
     print("sidecar-clients: ok")
     return 0
 

--- a/scripts/curator-extract.py
+++ b/scripts/curator-extract.py
@@ -27,6 +27,31 @@ import textwrap
 MAX_INPUT_CHARS = int(os.environ.get("CURATOR_MAX_INPUT_CHARS", "24000"))
 
 
+def resolve_llm_endpoint(env) -> tuple[str, str | None]:
+    """OpenAI-compatible base URL for the sidecar, or an error to report.
+
+    LLM_ENDPOINT wins when set; otherwise derive it from AIMEE_LLM_URL, the one
+    endpoint the kb is actually configured with (the container sets it, and the
+    Dockerfile's own comment says "endpoints come from env").
+
+    There is deliberately NO baked-in default. This used to fall back to a
+    hardcoded LAN address, which failed two ways: where nothing owned that IP,
+    every curator code-extraction job failed `No route to host` and the queue
+    never drained; and where something DID own it, the sidecar posted the
+    user's code and prompts to a machine that just happened to hold that
+    address. embed-remote.py already removed its equivalent fallback for the
+    same reason. Fail closed instead.
+    """
+    endpoint = env.get("LLM_ENDPOINT", "").strip()
+    if endpoint:
+        return endpoint, None
+    base = env.get("AIMEE_LLM_URL", "").strip().rstrip("/")
+    if not base:
+        return "", ("no LLM endpoint configured: set AIMEE_LLM_URL (preferred) "
+                    "or LLM_ENDPOINT for the curator sidecar")
+    return (base if base.endswith("/v1") else base + "/v1"), None
+
+
 def _cap(text: str) -> str:
     if not text or len(text) <= MAX_INPUT_CHARS:
         return text
@@ -225,7 +250,10 @@ def call_llm(prompt: str, max_tokens: int) -> tuple[str | None, str | None]:
     env["LLM_NO_THINKING"] = "1"
     env["LLM_JSON_MODE"]   = "1"
     env["LLM_MAX_TOKENS"]  = str(max_tokens)
-    env.setdefault("LLM_ENDPOINT", "http://192.168.1.122:8080")
+    endpoint, endpoint_err = resolve_llm_endpoint(env)
+    if endpoint_err:
+        return None, endpoint_err
+    env["LLM_ENDPOINT"] = endpoint
     env.setdefault("LLM_MODEL",    "qwen3")
 
     timeout_s = int(env.get("LLM_TIMEOUT", "120"))

--- a/scripts/curator-synthesize.py
+++ b/scripts/curator-synthesize.py
@@ -27,6 +27,31 @@ import subprocess
 import sys
 
 
+def resolve_llm_endpoint(env) -> tuple[str, str | None]:
+    """OpenAI-compatible base URL for the sidecar, or an error to report.
+
+    LLM_ENDPOINT wins when set; otherwise derive it from AIMEE_LLM_URL, the one
+    endpoint the kb is actually configured with (the container sets it, and the
+    Dockerfile's own comment says "endpoints come from env").
+
+    There is deliberately NO baked-in default. This used to fall back to a
+    hardcoded LAN address, which failed two ways: where nothing owned that IP,
+    every curator code-extraction job failed `No route to host` and the queue
+    never drained; and where something DID own it, the sidecar posted the
+    user's code and prompts to a machine that just happened to hold that
+    address. embed-remote.py already removed its equivalent fallback for the
+    same reason. Fail closed instead.
+    """
+    endpoint = env.get("LLM_ENDPOINT", "").strip()
+    if endpoint:
+        return endpoint, None
+    base = env.get("AIMEE_LLM_URL", "").strip().rstrip("/")
+    if not base:
+        return "", ("no LLM endpoint configured: set AIMEE_LLM_URL (preferred) "
+                    "or LLM_ENDPOINT for the curator sidecar")
+    return (base if base.endswith("/v1") else base + "/v1"), None
+
+
 def emit_error(msg: str) -> None:
     json.dump({"version": 1, "status": "error", "error": msg}, sys.stdout)
     sys.stdout.write("\n")
@@ -91,7 +116,10 @@ def call_llm(prompt: str, max_tokens: int) -> tuple:
     env = os.environ.copy()
     env["LLM_NO_THINKING"] = "1"
     env["LLM_MAX_TOKENS"] = str(max_tokens)
-    env.setdefault("LLM_ENDPOINT", "http://192.168.1.122:8080")
+    endpoint, endpoint_err = resolve_llm_endpoint(env)
+    if endpoint_err:
+        return None, endpoint_err
+    env["LLM_ENDPOINT"] = endpoint
     env.setdefault("LLM_MODEL", "qwen3")
 
     timeout_s = int(env.get("LLM_TIMEOUT", "120"))

--- a/scripts/learning-synthesize.py
+++ b/scripts/learning-synthesize.py
@@ -54,6 +54,31 @@ ALLOWED_KINDS = [
 ]
 
 
+def resolve_llm_endpoint(env) -> tuple[str, str | None]:
+    """OpenAI-compatible base URL for the sidecar, or an error to report.
+
+    LLM_ENDPOINT wins when set; otherwise derive it from AIMEE_LLM_URL, the one
+    endpoint the kb is actually configured with (the container sets it, and the
+    Dockerfile's own comment says "endpoints come from env").
+
+    There is deliberately NO baked-in default. This used to fall back to a
+    hardcoded LAN address, which failed two ways: where nothing owned that IP,
+    every curator code-extraction job failed `No route to host` and the queue
+    never drained; and where something DID own it, the sidecar posted the
+    user's code and prompts to a machine that just happened to hold that
+    address. embed-remote.py already removed its equivalent fallback for the
+    same reason. Fail closed instead.
+    """
+    endpoint = env.get("LLM_ENDPOINT", "").strip()
+    if endpoint:
+        return endpoint, None
+    base = env.get("AIMEE_LLM_URL", "").strip().rstrip("/")
+    if not base:
+        return "", ("no LLM endpoint configured: set AIMEE_LLM_URL (preferred) "
+                    "or LLM_ENDPOINT for the curator sidecar")
+    return (base if base.endswith("/v1") else base + "/v1"), None
+
+
 def emit_error(msg: str) -> None:
     json.dump({"version": 1, "status": "error", "error": msg}, sys.stdout)
     sys.stdout.write("\n")
@@ -119,7 +144,10 @@ def call_llm(prompt: str, max_tokens: int) -> tuple[str | None, str | None]:
     env = os.environ.copy()
     env["LLM_NO_THINKING"] = "1"
     env["LLM_MAX_TOKENS"] = str(max_tokens)
-    env.setdefault("LLM_ENDPOINT", "http://192.168.1.122:8080")
+    endpoint, endpoint_err = resolve_llm_endpoint(env)
+    if endpoint_err:
+        return None, endpoint_err
+    env["LLM_ENDPOINT"] = endpoint
     env.setdefault("LLM_MODEL", "qwen3")
 
     try:


### PR DESCRIPTION
## What

Three shipped sidecars each carried:

```python
env.setdefault("LLM_ENDPOINT", "http://192.168.1.122:8080")
```

`curator-extract.py`, `curator-synthesize.py`, `learning-synthesize.py`. The kb sets **`AIMEE_LLM_URL`**, not `LLM_ENDPOINT` — so on a stock install this default fires and curator traffic goes to whatever machine happens to hold that address on the user's network.

## Found on a fresh CPU deployment

```
kb.curator.extract_code: sidecar failed for job 3 (attempt 3/3):
  llm-chat: request to http://192.168.1.122:8080/chat/completions
  failed after 3 tries: <urlopen error [Errno 113] No route to host>
```

41,485 code units queued, none draining. **Silent from the outside** — doc extraction uses a different path and kept working, so `aimee status` showed `aimee-kb: ok` while code indexing was completely dead.

The case where nothing owns that address is the *benign* one. Where something does own it, the sidecar posts the user's source and prompts to a stranger's machine.

## Fix

Resolve the endpoint rather than bake one:

1. `LLM_ENDPOINT` when set;
2. else derive from `AIMEE_LLM_URL` (appending `/v1` only when absent);
3. else **fail closed**, naming both variables.

This is what the Dockerfile already promised — its COPY comment reads *"endpoints come from env"*. `embed-remote.py` removed its equivalent fallback previously and documents why; these three outlived that cleanup.

## Regression guard

`check-sidecar-clients.py` now scans for a `setdefault` of `LLM_ENDPOINT` / `AIMEE_LLM_URL` / `LLM_BASE_URL` to any non-loopback literal. Loopback is allowed (it addresses only the local host).

Confirmed red by reintroducing the original line (gate exits 1), green after restoring.

## Verified live

Fixed scripts pushed into the running `aimee-kb` on a real deployment: the `No route to host` failures stop and the sidecar reaches the configured `aimee-llm`.

## Explicitly NOT fixed here

CPU-tier throughput. With the address corrected, the synth model generates at **~3.6 tok/s**, so jobs now exceed the 120 s sidecar timeout instead of failing instantly. A 41k-unit backlog is not completable on a CPU tier at that rate. That is a capacity/expectation problem and needs its own decision — a longer timeout, a smaller extraction model, or not queueing code units on CPU. Filing separately rather than smuggling a policy change in here.