### PR TITLE
LLM gateway returned 500 for a malformed request body

### DIFF
--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -662,6 +662,16 @@ def build_server():
                 if path == "/v1/chat/completions":
                     audit("chat", SCOPE_DEFAULT, "error", code=ge.body["error"]["code"])
                 self._send(ge.status, ge.body)
+            except json.JSONDecodeError as exc:
+                # A body this gateway cannot parse is the CALLER's error. It used to
+                # fall through to the blanket handler below and come back as 500
+                # "internal", which tells an operator their inference gateway broke
+                # when in fact the request was malformed — and makes a client's retry
+                # logic treat it as a transient server fault worth retrying, forever.
+                if path == "/v1/chat/completions":
+                    audit("chat", SCOPE_DEFAULT, "error", code="bad_request")
+                self._send(400, {"error": {"code": "bad_request",
+                                           "message": f"invalid JSON body: {exc}"}})
             except Exception as exc:  # noqa: BLE001
                 self._send(500, {"error": {"code": "internal", "message": str(exc)}})
 

--- a/scripts/tests/test_gateway.py
+++ b/scripts/tests/test_gateway.py
@@ -4,8 +4,12 @@
 numpy-guarded do_rerank test against a mocked encoder. No model, no network.
 """
 import importlib.util
+import json
 import os
+import threading
 import unittest
+import urllib.error
+import urllib.request
 from unittest import mock
 
 GW = os.path.join(os.path.dirname(__file__), "..", "aimee_llm_gateway.py")
@@ -312,6 +316,55 @@ class SynthDeviceLost(unittest.TestCase):
         with self.assertRaises(OSError):
             self.gw.do_synth({"messages": [{"role": "user", "content": "hi"}]})
         self.assertEqual(called, [])
+
+
+class MalformedBodyStatus(unittest.TestCase):
+    """A body the gateway cannot parse is the CALLER's error, not a fault here.
+
+    It used to fall through to the blanket handler and come back 500 "internal",
+    which tells an operator their inference gateway is broken when the request
+    was simply malformed — and invites a client to retry a permanent error
+    forever. Exercised over real HTTP because the bug lived in the request
+    handler, not in the pure functions the rest of this file covers.
+    """
+
+    def setUp(self):
+        # STUB so no upstream llama-server is needed for the well-formed case.
+        with mock.patch.dict(os.environ, {"AIMEE_LLM_STUB": "1", "AIMEE_LLM_PORT": "0"},
+                             clear=False):
+            self.gw = _gw()
+        self.srv = self.gw.build_server()
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def _post(self, path, raw: bytes):
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}{path}", data=raw,
+            headers={"Content-Type": "application/json"}, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.status, resp.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read()
+
+    def test_malformed_json_is_400_not_500(self):
+        for path in ("/v1/chat/completions", "/embed_batch", "/rerank"):
+            for raw in (b"{not json", b"{", b"[1,", b'{"a":}'):
+                status, body = self._post(path, raw)
+                self.assertEqual(
+                    status, 400,
+                    f"{path} with {raw!r} returned {status}, body={body!r}")
+                self.assertEqual(json.loads(body)["error"]["code"], "bad_request")
+
+    def test_well_formed_body_still_succeeds(self):
+        status, _ = self._post(
+            "/v1/chat/completions",
+            json.dumps({"messages": [{"role": "user", "content": "hi"}]}).encode())
+        self.assertEqual(status, 200)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`json.loads()` on the request body raises `JSONDecodeError`, which fell through to the handler's blanket `except Exception` and came back as:

```
HTTP 500 {"error":{"code":"internal","message":"Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"}}
```

Two costs:

- An operator reading that concludes their **inference gateway is broken**, when the caller simply sent bad JSON.
- A client with ordinary retry logic sees a 5xx, treats a permanently-invalid request as a transient server fault, and **retries it forever**.

## Fix

The gateway already models caller errors — `GatewayError(400, "bad_request", …)` guards the empty `/embed` body — so this is the existing convention, not a new one. Catch `JSONDecodeError` ahead of the blanket handler and return **400 `bad_request`** with the parse position, on every POST route that parses a body: `/v1/chat/completions`, `/embed_batch`, `/rerank`.

The chat path keeps its audit record, now coded `bad_request` instead of disappearing into the generic 500.

## How it was found

Sweeping the deployed stack — every malformed body sent to the gateway came back 500.

Worth noting: while chasing this I *also* thought the gateway was rejecting its own advertised `aimee-synth` model. That turned out to be my harness (`docker exec` without `-i` silently wrote empty request files), not a product bug. The 500-for-malformed-JSON reproduces independently and is real.

## Tests

`test_gateway.py` gains `MalformedBodyStatus`: stands the real handler up on an ephemeral port and asserts 400 + `code: "bad_request"` across the three parsing routes × four malformed bodies, plus a well-formed request still returning 200.

This is the **first HTTP-level test** in that file — the existing tests exercise pure functions, and this bug lived in the request handler where none of them reach.

Confirmed red: reverting the `except` clause fails the suite (exit 1); passes with the fix. Full suite: 48 tests, OK.