### PR TITLE
Harden KB ingest and DB connection exhaustion for 0.3.0

### DIFF
--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -388,9 +388,13 @@ static void handle_tools_call(cJSON *id, cJSON *req)
 
    /* Check server response status */
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
-   if (status && cJSON_IsString(status) && strcmp(status->valuestring, "error") == 0)
+   cJSON *error = cJSON_GetObjectItemCaseSensitive(resp, "error");
+   if ((cJSON_IsString(status) && strcmp(status->valuestring, "error") == 0) ||
+       cJSON_IsObject(error))
    {
       cJSON *msg = cJSON_GetObjectItemCaseSensitive(resp, "message");
+      if (!cJSON_IsString(msg) && cJSON_IsObject(error))
+         msg = cJSON_GetObjectItemCaseSensitive(error, "message");
       const char *errmsg = (msg && cJSON_IsString(msg)) ? msg->valuestring : "server error";
       /* Server-side delegation handlers already attach actionable Fix
        * guidance for known error patterns (see delegation_error_guidance),

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -291,7 +291,9 @@ static int g_init_thread_set = 0;
  * pool is exhausted/unavailable, a private overflow connection (pooled=0).
  * Stored in g_thread_conn_key; the destructor returns/closes it on thread exit
  * (this is the reliable reclaim-on-thread-death the pool reaper deliberately
- * leaves to us). g_lease_depth refcounts db2_lease_begin/_end so nested units
+ * leaves to us). A failed acquisition never falls back to g_conn: libpq forbids
+ * concurrent use of one PGconn, and g_conn belongs exclusively to the init
+ * thread. g_lease_depth refcounts db2_lease_begin/_end so nested units
  * reuse one lease. */
 typedef struct
 {
@@ -495,8 +497,8 @@ static int db2_verify_pre_provisioned(void *conn, int expected_dim, char *err, s
 /* Acquire this thread's connection: a pool lease, or — if the pool is
  * unavailable/exhausted — a private overflow connection. Stores it in the
  * thread key so the destructor returns/closes it on thread exit. Caller holds
- * no lock. Returns NULL only if everything fails (then db2_conn falls back to
- * g_conn as a last resort). */
+ * no lock. Returns NULL if both the pool lease and overflow connection fail;
+ * the caller must fail the operation rather than sharing g_conn. */
 static void *db2_thread_acquire(void)
 {
    void *conn = NULL;
@@ -532,7 +534,15 @@ static void *db2_thread_acquire(void)
             aimee_pg_close(conn);
          return NULL;
       }
-      pthread_setspecific(g_thread_conn_key, L);
+      if (pthread_setspecific(g_thread_conn_key, L) != 0)
+      {
+         free(L);
+         if (pooled)
+            db2_pool_return(conn);
+         else
+            aimee_pg_close(conn);
+         return NULL;
+      }
    }
    L->conn = conn;
    L->pooled = pooled;
@@ -550,8 +560,7 @@ void *db2_conn(void)
       return g_conn;
    /* Every other thread leases from the pool (lazily; returned on thread exit
     * by the destructor, or sooner via db2_lease_end at a job boundary). */
-   void *c = db2_thread_acquire();
-   return c ? c : g_conn;
+   return db2_thread_acquire();
 }
 
 void db2_lease_begin(void)
@@ -622,19 +631,48 @@ void *db2_thread_conn_open(char *errbuf, size_t errlen)
       return NULL;
    }
    void *conn = aimee_pg_open(url, errbuf, errlen);
-   if (conn)
-      pthread_setspecific(g_thread_conn_key, conn);
+   if (!conn)
+      return NULL;
+   db2_thread_lease_t *L = (db2_thread_lease_t *)pthread_getspecific(g_thread_conn_key);
+   if (!L)
+   {
+      L = (db2_thread_lease_t *)calloc(1, sizeof(*L));
+      if (!L)
+      {
+         aimee_pg_close(conn);
+         return NULL;
+      }
+      if (pthread_setspecific(g_thread_conn_key, L) != 0)
+      {
+         free(L);
+         aimee_pg_close(conn);
+         return NULL;
+      }
+   }
+   if (L->conn)
+   {
+      if (L->pooled)
+         db2_pool_return(L->conn);
+      else
+         aimee_pg_close(L->conn);
+   }
+   L->conn = conn;
+   L->pooled = 0;
    return conn;
 }
 
 void db2_thread_conn_close(void)
 {
    pthread_once(&g_thread_conn_key_once, thread_conn_key_init);
-   void *conn = pthread_getspecific(g_thread_conn_key);
-   if (conn)
+   db2_thread_lease_t *L = (db2_thread_lease_t *)pthread_getspecific(g_thread_conn_key);
+   if (L && L->conn)
    {
-      aimee_pg_close(conn);
-      pthread_setspecific(g_thread_conn_key, NULL);
+      if (L->pooled)
+         db2_pool_return(L->conn);
+      else
+         aimee_pg_close(L->conn);
+      L->conn = NULL;
+      L->pooled = 0;
    }
 }
 

--- a/src/db2/db2_internal.h
+++ b/src/db2/db2_internal.h
@@ -31,11 +31,10 @@ extern "C"
       strftime(buf, len, "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
    }
 
-   /* Returns the module-private Postgres connection, or NULL if
-    * db2_init has not been called (or db2_shutdown has been called).
-    * Returns the calling thread's dedicated connection (opened via
-    * db2_thread_conn_open) if one has been established, otherwise the
-    * process-global connection. */
+   /* Returns the calling thread's Postgres connection, or NULL if DB2 is closed
+    * or a non-init thread cannot acquire its own connection. The process-global
+    * init connection is never shared across threads: libpq forbids concurrent
+    * use of one PGconn. */
    void *db2_conn(void);
 
    /* Bracket a unit of work so the thread's pooled connection is returned to the

--- a/src/db2/kb_service_backend_ingest.c
+++ b/src/db2/kb_service_backend_ingest.c
@@ -162,9 +162,9 @@ int db2_kb_ingest_queue_complete(int64_t job_id, int files_indexed, int chunks_a
    aimee_pg_bind_int(s, "?2", files_indexed);
    aimee_pg_bind_int(s, "?3", chunks_added);
    aimee_pg_bind_int(s, "?4", embeddings_added);
-   (void)aimee_pg_step(s, err, sizeof(err));
+   int step = aimee_pg_step(s, err, sizeof(err));
    aimee_pg_finalize(s);
-   return 0;
+   return step == AIMEE_PG_DONE ? 0 : -1;
 }
 
 int db2_kb_ingest_queue_fail(int64_t job_id, const char *error_message)

--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -182,6 +182,12 @@ const char *text_split_reasoning_prefix(const char *text, const char **reasoning
  * non-ASCII. A string that ends on a complete character is left untouched. */
 void text_trim_partial_utf8(char *s);
 
+/* Replace malformed UTF-8 bytes in a NUL-terminated string with ASCII '?', in
+ * place. Valid code points are unchanged and the byte length never grows, so
+ * callers may safely use this on fixed buffers before sending text to a strict
+ * UTF-8 boundary such as Postgres. Returns the number of bytes replaced. */
+size_t text_sanitize_utf8(char *s);
+
 /* Basic Porter-like stemming. Result written to buf. Returns buf. */
 char *stem_word(const char *word, char *buf, size_t buf_len);
 

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -474,6 +474,10 @@ int chunk_stream(FILE *f, text_chunk_t *chunks, int max_chunks)
    while (fgets(line, sizeof(line), f) != NULL)
    {
       line_num++;
+      /* Repositories sometimes contain CP-1252 prose or otherwise malformed
+       * bytes in nominally textual files. Postgres TEXT is strict UTF-8; make
+       * the chunk boundary safe instead of aborting the whole file transaction. */
+      (void)text_sanitize_utf8(line);
       size_t line_len = strlen(line);
       int lvl = heading_level(line);
 
@@ -641,11 +645,19 @@ int kb_purge_fenced_txn_commit(void)
 int kb_file_index_upsert_fenced(const char *project, const char *file_path, const char *hash,
                                 const char *content)
 {
-   if (kb_purge_fenced_txn_begin(project) != 1)
+   char *clean_content = content ? strdup(content) : NULL;
+   if (content && !clean_content)
       return -1;
-   int rc = db2_kb_file_index_upsert(project, file_path, hash, content);
+   (void)text_sanitize_utf8(clean_content);
+   if (kb_purge_fenced_txn_begin(project) != 1)
+   {
+      free(clean_content);
+      return -1;
+   }
+   int rc = db2_kb_file_index_upsert(project, file_path, hash, clean_content);
    if (kb_purge_fenced_txn_commit() != 0)
       rc = -1;
+   free(clean_content);
    return rc;
 }
 
@@ -979,6 +991,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
       return;
    }
    int64_t prev_doc_id = 0;
+   int inserted = 0;
    for (int ci = 0; ci < n_chunks; ci++)
    {
       doc_ids[ci] = db2_kb_documents_insert_chunk(c->project, c->files[fi].rel_path, hash, ci,
@@ -986,16 +999,23 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
                                                   c->chunks[ci].line_start, c->chunks[ci].line_end,
                                                   c->chunks[ci].content, c->chunks[ci].token_count);
       if (doc_ids[ci] < 0)
-         continue;
+      {
+         LOG_WARN("kb_build", "project=%s path=%s: chunk %d insert failed; rolling back file",
+                  c->project ? c->project : "?", c->files[fi].rel_path, ci);
+         db2_kb_txn_rollback();
+         free(doc_ids);
+         return;
+      }
       db2_kb_documents_link_neighbours(doc_ids[ci], prev_doc_id);
       prev_doc_id = doc_ids[ci];
-      c->stats->chunks_added++;
+      inserted++;
    }
    if (kb_purge_fenced_txn_commit() != 0)
    {
       free(doc_ids);
       return;
    }
+   c->stats->chunks_added += inserted;
 
    /* Phase 2: embed each committed chunk (sync or async). */
    for (int ci = 0; ci < n_chunks; ci++)

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -582,7 +582,12 @@ int kb_ingest_doc_content(const char *project, const char *source_path, const ch
           project, source_path, hash, ci, chunks[ci].heading_path, chunks[ci].line_start,
           chunks[ci].line_end, chunks[ci].content, chunks[ci].token_count);
       if (doc_ids[ci] < 0)
-         continue;
+      {
+         db2_kb_txn_rollback();
+         free(doc_ids);
+         free(chunks);
+         return -1;
+      }
       db2_kb_documents_link_neighbours(doc_ids[ci], prev_doc_id);
       prev_doc_id = doc_ids[ci];
    }

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -336,6 +336,11 @@ static int mf_process_one(const config_t *cfg, const mf_job_t *job)
    char sys_prompt[2560];
    mf_build_system_prompt(sys_prompt, sizeof(sys_prompt));
 
+   /* The job row and source memory are already copied locally. Release the
+    * worker's lazy pool lease before the potentially multi-minute LLM call;
+    * retry/done writes below safely re-acquire it. */
+   db2_lease_release_idle();
+
    char err[MF_ERRBUF] = "";
    char *resp = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, sys_prompt, request_json,
                                    NULL, "", MF_LLM_OUT_CAP, err, sizeof(err));

--- a/src/modules/kb-synthesis/kb_curator_extract.c
+++ b/src/modules/kb-synthesis/kb_curator_extract.c
@@ -537,6 +537,11 @@ int kb_curator_extract_one(const kb_curator_extract_opts_t *opts)
    aimee_log(LOG_INFO, "kb.curator.extract", "invoking curator LLM for doc %lld (cmd fallback: %s)",
              (long long)job.document_id, cmd);
 
+   /* The model can legitimately take minutes on the bundled CPU backend. The
+    * durable job is already claimed, and every remaining DB operation can
+    * re-acquire lazily, so do not pin a pool member across the network call. */
+   db2_lease_release_idle();
+
    char sidecar_err[512] = "";
    const char *sys_prompt = novel_mode ? CE_SYSTEM_PROMPT : CE_EXTRACT_DOC_PROMPT;
    cJSON *extract_schema = ce_build_extract_schema();

--- a/src/modules/kb-synthesis/kb_curator_llm.c
+++ b/src/modules/kb-synthesis/kb_curator_llm.c
@@ -9,6 +9,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define KB_CURATOR_PROVIDER_TIMEOUT_MS 300000
+
 /* Build [{role:system, content:system_prompt}?, {role:user, content:request_json}]. */
 static cJSON *build_messages(const char *system_prompt, const char *request_json)
 {
@@ -50,6 +52,15 @@ char *kb_curator_llm_run(const config_t *cfg, kb_curator_stage_t stage, const ch
    provider_def_t def;
    if (cfg && kb_curator_provider_for_stage(cfg, stage, &def))
    {
+      /* Curator work is already retried by its durable job queue. Keep one
+       * provider attempt bounded by the same five-minute ceiling as the legacy
+       * sidecar instead of nesting the provider client's three retries. The old
+       * 120s default was shorter than a normal constrained extraction on the
+       * bundled CPU model and created overlapping abandoned generations. */
+      if (def.timeout_ms <= 0)
+         def.timeout_ms = KB_CURATOR_PROVIDER_TIMEOUT_MS;
+      if (def.max_attempts <= 0)
+         def.max_attempts = 1;
       cJSON *msgs = build_messages(system_prompt, request_json);
       if (!msgs)
       {

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -306,6 +306,16 @@ cJSON *cli_v1_dispatch_local(cJSON *request, int timeout_ms)
          return resp;
       }
 
+      /* HTTP auth failures use the server's standard nested error envelope. */
+      if (strcmp(tool, "permission_tool") == 0)
+      {
+         cJSON *resp = cJSON_CreateObject();
+         cJSON *error = cJSON_AddObjectToObject(resp, "error");
+         cJSON_AddStringToObject(error, "message", "write-tier grant required");
+         cJSON_AddStringToObject(error, "type", "permission_error");
+         return resp;
+      }
+
       if (strcmp(tool, "session_status") == 0)
       {
          cJSON *resp = cJSON_CreateObject();
@@ -757,6 +767,30 @@ static void test_tools_call_server_error(void)
    cJSON_Delete(req);
 }
 
+static void test_tools_call_nested_http_error(void)
+{
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "jsonrpc", "2.0");
+   cJSON_AddNumberToObject(req, "id", 13.25);
+   cJSON_AddStringToObject(req, "method", "tools/call");
+   cJSON *params = cJSON_AddObjectToObject(req, "params");
+   cJSON_AddStringToObject(params, "name", "permission_tool");
+   cJSON_AddObjectToObject(params, "arguments");
+
+   cJSON *resp = capture_response(req);
+   cJSON *result = cJSON_GetObjectItemCaseSensitive(resp, "result");
+   assert(cJSON_IsObject(result));
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(result, "isError")));
+   cJSON *content = cJSON_GetObjectItemCaseSensitive(result, "content");
+   cJSON *block = cJSON_IsArray(content) ? cJSON_GetArrayItem(content, 0) : NULL;
+   cJSON *text = block ? cJSON_GetObjectItemCaseSensitive(block, "text") : NULL;
+   assert(cJSON_IsString(text));
+   assert(strstr(text->valuestring, "write-tier grant required") != NULL);
+
+   cJSON_Delete(resp);
+   cJSON_Delete(req);
+}
+
 static void test_tools_call_structured_content_passthrough(void)
 {
    cJSON *req = cJSON_CreateObject();
@@ -964,6 +998,7 @@ int main(void)
    test_tools_list_preserves_server_error();
    test_tools_call_success();
    test_tools_call_server_error();
+   test_tools_call_nested_http_error();
    test_tools_call_structured_content_passthrough();
    test_tools_call_get_help_without_arguments();
    test_tools_call_get_help_with_empty_object_arguments();

--- a/src/tests/test_db2.c
+++ b/src/tests/test_db2.c
@@ -1,10 +1,12 @@
 #include <assert.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 
 #include "db_postgres.h"
 #include "db2.h"
 #include "db2_internal.h"
+#include "db2_pool.h"
 #include "db2/db_schema.h"  /* §2b: db2_dim_read_t / DB2_DIM_* for the dim-read stub */
 #include "../headers/log.h" /* log_level_t for the aimee_log stub below */
 #include <stdarg.h>
@@ -467,6 +469,30 @@ static void test_health_probe_fails_without_init_or_query_failure(void)
    assert(db2_health_probe(&schema_ok, &have_pg_trgm) == -1);
 }
 
+static void *acquire_from_worker(void *arg)
+{
+   *(void **)arg = db2_conn();
+   return NULL;
+}
+
+static void test_worker_acquire_failure_never_shares_init_connection(void)
+{
+   reset_mocks();
+   assert(db2_init("postgres://db2.test/aimee") == 0);
+
+   /* Simulate an unavailable pool and a failed overflow connection. Sharing the
+    * init thread's PGconn here corrupts libpq under concurrent load. */
+   db2_pool_shutdown();
+   g_fail_open = 1;
+   void *worker_conn = &g_fake_conn;
+   pthread_t worker;
+   assert(pthread_create(&worker, NULL, acquire_from_worker, &worker_conn) == 0);
+   pthread_join(worker, NULL);
+   assert(worker_conn == NULL);
+   assert(db2_conn() == &g_fake_conn); /* the owning init thread keeps its handle */
+   db2_shutdown();
+}
+
 int main(void)
 {
    test_init_shutdown_roundtrip();
@@ -478,6 +504,7 @@ int main(void)
    test_health_probe_reports_schema_and_extension();
    test_init_fails_without_pg_trgm();
    test_health_probe_fails_without_init_or_query_failure();
+   test_worker_acquire_failure_never_shares_init_connection();
    printf("db2: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -262,6 +262,39 @@ static void test_build_single_file(void)
    printf("  PASS: build single markdown file\n");
 }
 
+static void test_build_sanitizes_malformed_utf8(void)
+{
+   char tmpdir[] = "/tmp/aimee_kb_test_utf8_XXXXXX";
+   assert(mkdtemp(tmpdir) != NULL);
+   char fpath[512];
+   snprintf(fpath, sizeof(fpath), "%s/legacy.md", tmpdir);
+   FILE *f = fopen(fpath, "wb");
+   assert(f != NULL);
+   const unsigned char body[] = "# Legacy\n\nA \x92quoted\x94 CP-1252 phrase.\n";
+   assert(fwrite(body, 1, sizeof(body) - 1, f) == sizeof(body) - 1);
+   fclose(f);
+
+   open_test_db();
+   kb_stats_t stats;
+   assert(kb_build(tmpdir, "test_utf8", NULL, 1, &stats) == 0);
+   assert(stats.files_indexed == 1);
+   assert(stats.chunks_added > 0);
+
+   char *stored = db2_kb_file_index_get_content("test_utf8", "legacy.md");
+   assert(stored != NULL);
+   assert(strcmp(stored, "# Legacy\n\nA ?quoted? CP-1252 phrase.\n") == 0);
+   free(stored);
+
+   char *result = kb_search_json("test_utf8", "quoted phrase", NULL, 3);
+   assert(result != NULL);
+   assert(strstr(result, "?quoted? CP-1252 phrase") != NULL);
+   free(result);
+   close_test_db();
+   unlink(fpath);
+   platform_test_rmrf(tmpdir);
+   printf("  PASS: malformed UTF-8 is sanitized before Postgres text boundaries\n");
+}
+
 static void test_build_incremental_update(void)
 {
    char tmpdir[] = "/tmp/aimee_kb_test_incr_XXXXXX";
@@ -1030,6 +1063,7 @@ int main(void)
    /* Build/search tests */
    test_build_empty_dir();
    test_build_single_file();
+   test_build_sanitizes_malformed_utf8();
    test_build_incremental_update();
    test_bloom_dedupe_skips_duplicate_content();
    test_minhash_shadow_signatures_persist();

--- a/src/tests/test_kb_curator_llm.c
+++ b/src/tests/test_kb_curator_llm.c
@@ -13,19 +13,35 @@
 
 static char g_seen_url[512];
 static char g_seen_body[1024];
+static int g_seen_timeout_ms;
+static int g_post_calls;
 
 static int ok_handler(const char *url, const char *auth_header, const char *body,
                       char **response_buf, int timeout_ms, const char *extra_headers)
 {
    (void)auth_header;
-   (void)timeout_ms;
    (void)extra_headers;
+   g_seen_timeout_ms = timeout_ms;
+   g_post_calls++;
    snprintf(g_seen_url, sizeof(g_seen_url), "%s", url ? url : "");
    snprintf(g_seen_body, sizeof(g_seen_body), "%s", body ? body : "");
    if (response_buf)
       *response_buf = strdup("{\"choices\":[{\"message\":{\"content\":"
                              "\"{\\\"synthesis\\\":\\\"ok\\\"}\"}}]}");
    return 200;
+}
+
+static int network_error_handler(const char *url, const char *auth_header, const char *body,
+                                 char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)response_buf;
+   (void)timeout_ms;
+   (void)extra_headers;
+   g_post_calls++;
+   return -1;
 }
 
 static int err_handler(const char *url, const char *auth_header, const char *body,
@@ -47,6 +63,8 @@ static void test_provider_path(void)
 {
    mock_agent_http_reset();
    mock_agent_http_set_post_handler(ok_handler);
+   g_seen_timeout_ms = 0;
+   g_post_calls = 0;
 
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
@@ -61,12 +79,37 @@ static void test_provider_path(void)
    assert(resp != NULL);
    assert(strcmp(resp, "{\"synthesis\":\"ok\"}") == 0);
    assert(strcmp(g_seen_url, "http://big/v1/chat/completions") == 0);
+   assert(g_seen_timeout_ms == 300000);
+   assert(g_post_calls == 1);
    /* system_prompt + request_json must reach the provider as message content. */
    assert(strstr(g_seen_body, "be-a-curator") != NULL);
    assert(strstr(g_seen_body, "\\\"topic\\\":\\\"t\\\"") != NULL || strstr(g_seen_body, "topic"));
    free(resp);
    mock_agent_http_reset();
    printf("kb_curator_llm: provider path (url + system + request in body) ok\n");
+}
+
+/* The durable curator queue owns retries. A network timeout must not trigger the
+ * provider client's default three immediate attempts (which used to leave three
+ * overlapping generations running on the bundled model). */
+static void test_provider_network_error_is_single_attempt(void)
+{
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(network_error_handler);
+   g_post_calls = 0;
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
+            "http://big/v1");
+   snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
+
+   char err[256] = "";
+   char *resp = kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, "sys", "{}", NULL, "", 16384,
+                                   err, sizeof(err));
+   assert(resp == NULL);
+   assert(g_post_calls == 1);
+   mock_agent_http_reset();
+   printf("kb_curator_llm: network failure uses one durable-queue attempt ok\n");
 }
 
 /* Provider configured but the call fails -> NULL + reason, no crash/leak. */
@@ -118,6 +161,7 @@ int main(void)
    unsetenv("LLM_API_KEY");
    test_provider_path();
    test_provider_error();
+   test_provider_network_error_is_single_attempt();
    test_idle_when_unconfigured();
    printf("kb_curator_llm: all tests passed\n");
    return 0;

--- a/src/tests/test_util.c
+++ b/src/tests/test_util.c
@@ -128,6 +128,25 @@ static void test_trim_partial_utf8(void)
    printf("  PASS: test_trim_partial_utf8\n");
 }
 
+static void test_sanitize_utf8(void)
+{
+   char cp1252[] = "legacy \x92quote\x94 and \x86mark";
+   assert(text_sanitize_utf8(cp1252) == 3);
+   assert(strcmp(cp1252, "legacy ?quote? and ?mark") == 0);
+
+   char valid[] = "caf\xc3\xa9 \xe2\x80\x94 \xf0\x9f\x98\x80";
+   assert(text_sanitize_utf8(valid) == 0);
+   assert(strcmp(valid, "caf\xc3\xa9 \xe2\x80\x94 \xf0\x9f\x98\x80") == 0);
+
+   char malformed[] = {'x', (char)0xc0, (char)0xaf, ' ',        (char)0xed, (char)0xa0, (char)0x80,
+                       ' ', (char)0xf4, (char)0x90, (char)0x80, (char)0x80, '\0'};
+   assert(text_sanitize_utf8(malformed) == 9);
+   assert(strcmp(malformed, "x?? ??? ????") == 0);
+   assert(text_sanitize_utf8(NULL) == 0);
+
+   printf("  PASS: test_sanitize_utf8\n");
+}
+
 static void test_normalize_key(void)
 {
    char buf[256];
@@ -403,6 +422,7 @@ int main(void)
    test_stem_word();
    test_is_likely_path();
    test_trim_partial_utf8();
+   test_sanitize_utf8();
    test_split_reasoning_prefix();
    test_shlex_split();
    test_split_camel_case();

--- a/src/text.c
+++ b/src/text.c
@@ -152,6 +152,54 @@ void text_trim_partial_utf8(char *s)
     * function's contract is to undo truncation, not to sanitise arbitrary bytes. */
 }
 
+size_t text_sanitize_utf8(char *s)
+{
+   if (!s)
+      return 0;
+
+   size_t replaced = 0;
+   for (size_t i = 0; s[i];)
+   {
+      unsigned char c = (unsigned char)s[i];
+      size_t need = 0;
+      if (c <= 0x7f)
+         need = 1;
+      else if (c >= 0xc2 && c <= 0xdf)
+         need = 2;
+      else if (c >= 0xe0 && c <= 0xef)
+         need = 3;
+      else if (c >= 0xf0 && c <= 0xf4)
+         need = 4;
+
+      int valid = need != 0;
+      for (size_t j = 1; valid && j < need; j++)
+         valid = s[i + j] && ((unsigned char)s[i + j] & 0xc0) == 0x80;
+
+      /* Exclude overlong forms, UTF-16 surrogates, and values above U+10FFFF. */
+      if (valid && need == 3)
+      {
+         unsigned char second = (unsigned char)s[i + 1];
+         if ((c == 0xe0 && second < 0xa0) || (c == 0xed && second > 0x9f))
+            valid = 0;
+      }
+      if (valid && need == 4)
+      {
+         unsigned char second = (unsigned char)s[i + 1];
+         if ((c == 0xf0 && second < 0x90) || (c == 0xf4 && second > 0x8f))
+            valid = 0;
+      }
+
+      if (valid)
+      {
+         i += need;
+         continue;
+      }
+      s[i++] = '?';
+      replaced++;
+   }
+   return replaced;
+}
+
 double trigram_similarity(const char *a, const char *b)
 {
    if (!a || !b || !a[0] || !b[0])


### PR DESCRIPTION
## Summary
- sanitize malformed UTF-8 before KB text reaches strict PostgreSQL boundaries
- roll back failed file transactions immediately instead of continuing an aborted transaction
- never share the init thread PGconn when the pool and overflow connection are unavailable
- repair dedicated per-thread connection TLS ownership
- make ingest queue completion report write failures

## Evidence
- reproduced repeated invalid UTF-8 PostgreSQL failures on the release target
- inspected an aimee-kb SIGABRT core whose corrupt libpq/malloc stack is consistent with concurrent PGconn sharing
- added focused malformed-input and pool-exhaustion regression tests
- make -C src lint
- make -C src -j8 unit-tests

This is release-blocking hardening discovered during 0.3.0 exploratory validation.