### PR TITLE
Harden runtime web and clean fuzz artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/build/
 src/*.a
 src/server.log
 src/tests/unit-test-*
+src/tests/fuzz_kb_mgmt_token_authority_ipc
 src/tests/fuzz_server_mgmt_read_config
 /build/
 /build-*/

--- a/runtime-web/pages.go
+++ b/runtime-web/pages.go
@@ -102,6 +102,7 @@ func (s *server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	w.Header().Set("Content-Security-Policy", s.loginCSP)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprint(w, loginHTML)
 }
@@ -131,6 +132,7 @@ func (s *server) handleLogout(w http.ResponseWriter, r *http.Request) {
 // broken until the cache was manually cleared). Force revalidation so a redeploy
 // is always picked up on the next navigation.
 func (s *server) handleSPA(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Security-Policy", s.spaCSP)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Header().Set("Pragma", "no-cache")

--- a/runtime-web/security.go
+++ b/runtime-web/security.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+var inlineScript = regexp.MustCompile(`(?s)<script[^>]*>(.*?)</script>`)
+
+// contentSecurityPolicy pins the executable content in the single-file pages.
+// Styles remain inline-compatible because rendered chat markdown and several UI
+// components intentionally apply style attributes at runtime.
+func contentSecurityPolicy(html []byte) string {
+	script := "'self'"
+	for _, match := range inlineScript.FindAllSubmatch(html, -1) {
+		sum := sha256.Sum256(match[1])
+		script += " 'sha256-" + base64.StdEncoding.EncodeToString(sum[:]) + "'"
+	}
+	return strings.Join([]string{
+		"default-src 'self'",
+		"script-src " + script,
+		"script-src-attr 'none'",
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' data: blob:",
+		"font-src 'self' data:",
+		"connect-src 'self'",
+		"frame-src 'self'",
+		"frame-ancestors 'self'",
+		"form-action 'self'",
+		"base-uri 'self'",
+		"object-src 'none'",
+	}, "; ")
+}
+
+// securityHeaders applies response hardening that is safe for every route,
+// including the same-origin /vscode iframe and WebSocket proxy. HSTS is omitted
+// deliberately: the appliance defaults to a self-signed certificate and may be
+// served by a TLS-terminating proxy; that proxy owns HSTS for its public name.
+func (s *server) securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Permissions-Policy", "geolocation=(), microphone=(), camera=(), usb=()")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/runtime-web/security_test.go
+++ b/runtime-web/security_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	s := &server{}
+	h := s.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	r := httptest.NewRecorder()
+	h.ServeHTTP(r, httptest.NewRequest(http.MethodGet, "/login", nil))
+
+	want := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "SAMEORIGIN",
+		"Referrer-Policy":        "no-referrer",
+		"Permissions-Policy":     "geolocation=(), microphone=(), camera=(), usb=()",
+	}
+	for name, value := range want {
+		if got := r.Header().Get(name); got != value {
+			t.Errorf("%s=%q, want %q", name, got, value)
+		}
+	}
+}
+
+func TestContentSecurityPolicyPinsInlineScripts(t *testing.T) {
+	csp := contentSecurityPolicy([]byte(`<html><script>safe()</script><style>x{color:red}</style></html>`))
+	for _, want := range []string{
+		"default-src 'self'",
+		"script-src 'self' 'sha256-",
+		"script-src-attr 'none'",
+		"style-src 'self' 'unsafe-inline'",
+		"frame-src 'self'",
+		"frame-ancestors 'self'",
+		"object-src 'none'",
+	} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("CSP %q does not contain %q", csp, want)
+		}
+	}
+	if strings.Contains(csp, "script-src 'self' 'unsafe-inline'") {
+		t.Fatalf("inline scripts must be hash-pinned: %s", csp)
+	}
+}
+
+func TestPageHandlersSetContentSecurityPolicy(t *testing.T) {
+	s := &server{
+		loginCSP: contentSecurityPolicy([]byte(loginHTML)),
+		spaCSP:   contentSecurityPolicy(spaHTML),
+	}
+
+	login := httptest.NewRecorder()
+	s.handleLogin(login, httptest.NewRequest(http.MethodGet, "/login", nil))
+	if got := login.Header().Get("Content-Security-Policy"); got == "" {
+		t.Fatal("login response is missing Content-Security-Policy")
+	}
+
+	spa := httptest.NewRecorder()
+	s.handleSPA(spa, httptest.NewRequest(http.MethodGet, "/chat", nil))
+	if got := spa.Header().Get("Content-Security-Policy"); got == "" {
+		t.Fatal("SPA response is missing Content-Security-Policy")
+	}
+}

--- a/runtime-web/server.go
+++ b/runtime-web/server.go
@@ -33,6 +33,8 @@ type server struct {
 	rl       *auth.RateLimiter
 	users    *auth.UserManager
 	authH    *auth.Handler
+	spaCSP   string
+	loginCSP string
 }
 
 func run(cfg *config) error {
@@ -65,16 +67,19 @@ func run(cfg *config) error {
 		rl:       rl,
 		users:    users,
 		authH:    authH,
+		spaCSP:   contentSecurityPolicy(spaHTML),
+		loginCSP: contentSecurityPolicy([]byte(loginHTML)),
 	}
 
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
+	handler := s.securityHeaders(mux)
 
 	addr := fmt.Sprintf(":%d", cfg.port)
 
 	if !cfg.tlsEnabled() {
 		log.Printf("aimee-runtime-web: http on %s", addr)
-		return http.ListenAndServe(addr, mux)
+		return http.ListenAndServe(addr, handler)
 	}
 
 	cert, key, err := ensureTLSCert(cfg)
@@ -94,7 +99,7 @@ func run(cfg *config) error {
 
 	srv := &http.Server{
 		Addr:      addr,
-		Handler:   mux,
+		Handler:   handler,
 		TLSConfig: tlsCfg,
 	}
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1667,9 +1667,10 @@ clean:
 	       tests/unit-test-* tests/bench-perf tests/fuzz_extractors tests/fuzz_json_parse \
 	       tests/fuzz_config_load tests/fuzz_memory_search tests/fuzz_message_frame tests/fuzz_acl_parse \
 	       tests/fuzz_kb_workload_wire tests/fuzz_server_mgmt_token tests/fuzz_kb_mgmt_token \
+	       tests/fuzz_kb_mgmt_token_authority_ipc \
 	       tests/fuzz_kb_mgmt_jwks_publication \
 	       tests/fuzz_kb_mgmt_checkpoint tests/fuzz_kb_management_action \
-	       tests/fuzz_server_mgmt_action \
+	       tests/fuzz_server_mgmt_action tests/fuzz_server_mgmt_read_config \
 	       coverage.info coverage-report agent_help_data.h tool_prompts_data.h
 
 # Pinned clang-format version. Must match what CI installs so `make lint`


### PR DESCRIPTION
## Summary
- add centrally applied anti-sniffing, same-origin framing, referrer, and permissions headers to runtime-web
- add hash-pinned CSPs for executable inline content on the login and single-file SPA pages
- preserve the same-origin embedded editor and intentionally leave HSTS to a trusted public TLS proxy because the appliance default is self-signed
- remove all generated fuzz executables from make clean and ignore the missing token-authority fuzz artifact

## Validation
- go test ./... in runtime-web
- go test -race ./... in runtime-web
- 110 frontend tests, TypeScript check, and production Vite build
- built both affected fuzz targets, ran make clean, and verified neither remained
- git diff --check