### PR TITLE
Harden replayed KB chunks and legacy curator attempts

### DIFF
--- a/scripts/curator-extract.py
+++ b/scripts/curator-extract.py
@@ -26,6 +26,14 @@ import textwrap
 # default with room for prompt + output); raise via env on big-context deployments.
 MAX_INPUT_CHARS = int(os.environ.get("CURATOR_MAX_INPUT_CHARS", "24000"))
 
+# The native sidecar watchdog is 300 seconds. Leave it 15 seconds to terminate
+# and reap the process tree while giving the bundled CPU model substantially
+# longer than llm-chat.py's generic 120-second default. Curator jobs already
+# have durable retry/backoff; nested HTTP retries only create overlapping
+# abandoned generations after a timeout.
+CURATOR_LLM_TIMEOUT_DEFAULT = 285
+CURATOR_LLM_TIMEOUT_MAX = 285
+
 
 def resolve_llm_endpoint(env) -> tuple[str, str | None]:
     """OpenAI-compatible base URL for the sidecar, or an error to report.
@@ -256,14 +264,19 @@ def call_llm(prompt: str, max_tokens: int) -> tuple[str | None, str | None]:
     env["LLM_ENDPOINT"] = endpoint
     env.setdefault("LLM_MODEL",    "qwen3")
 
-    timeout_s = int(env.get("LLM_TIMEOUT", "120"))
+    timeout_s = min(
+        max(int(env.get("LLM_TIMEOUT", str(CURATOR_LLM_TIMEOUT_DEFAULT))), 1),
+        CURATOR_LLM_TIMEOUT_MAX,
+    )
+    env["LLM_TIMEOUT"] = str(timeout_s)
+    env["LLM_RETRIES"] = "0"
     try:
         result = subprocess.run(
             ["python3", llm_script],
             input=prompt,
             capture_output=True,
             text=True,
-            timeout=timeout_s,
+            timeout=timeout_s + 5,
             env=env,
         )
         if result.returncode != 0:

--- a/scripts/curator-synthesize.py
+++ b/scripts/curator-synthesize.py
@@ -27,6 +27,13 @@ import subprocess
 import sys
 
 
+# Keep one curator attempt inside the native sidecar's 300-second watchdog.
+# Durable curator jobs own retries; the generic llm-chat retry loop must not
+# leave multiple CPU generations running for one job.
+CURATOR_LLM_TIMEOUT_DEFAULT = 285
+CURATOR_LLM_TIMEOUT_MAX = 285
+
+
 def resolve_llm_endpoint(env) -> tuple[str, str | None]:
     """OpenAI-compatible base URL for the sidecar, or an error to report.
 
@@ -122,14 +129,19 @@ def call_llm(prompt: str, max_tokens: int) -> tuple:
     env["LLM_ENDPOINT"] = endpoint
     env.setdefault("LLM_MODEL", "qwen3")
 
-    timeout_s = int(env.get("LLM_TIMEOUT", "120"))
+    timeout_s = min(
+        max(int(env.get("LLM_TIMEOUT", str(CURATOR_LLM_TIMEOUT_DEFAULT))), 1),
+        CURATOR_LLM_TIMEOUT_MAX,
+    )
+    env["LLM_TIMEOUT"] = str(timeout_s)
+    env["LLM_RETRIES"] = "0"
     try:
         result = subprocess.run(
             ["python3", llm_script],
             input=prompt,
             capture_output=True,
             text=True,
-            timeout=timeout_s,
+            timeout=timeout_s + 5,
             env=env,
         )
         if result.returncode != 0:

--- a/scripts/tests/test_curator_strip_fences.py
+++ b/scripts/tests/test_curator_strip_fences.py
@@ -23,9 +23,12 @@ import json
 import os
 import sys
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _EXTRACT = os.path.join(_HERE, "..", "curator-extract.py")
+_SYNTHESIZE = os.path.join(_HERE, "..", "curator-synthesize.py")
 
 
 def _load():
@@ -39,6 +42,13 @@ def _load():
         pass
     finally:
         sys.argv = argv
+    return mod
+
+
+def _load_path(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
     return mod
 
 
@@ -82,6 +92,44 @@ class StripFencesTest(unittest.TestCase):
         resp = '{"status":"ok","artifacts":[{"payload":{"body_excerpt":"if (x) { y(\\"}\\"); }"}}]}'
         parsed = json.loads(self.mod.strip_fences(resp))
         self.assertIn("{", parsed["artifacts"][0]["payload"]["body_excerpt"])
+
+
+class CuratorTimeoutTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.extract = _load()
+        cls.synthesize = _load_path("curator_synthesize", _SYNTHESIZE)
+
+    def _assert_one_bounded_attempt(self, module):
+        completed = SimpleNamespace(returncode=0, stdout='{"status":"ok"}\n', stderr="")
+        with mock.patch.dict(os.environ, {"LLM_ENDPOINT": "http://llm.test/v1", "LLM_RETRIES": "9"}, clear=True):
+            with mock.patch.object(module.subprocess, "run", return_value=completed) as run:
+                output, error = module.call_llm("prompt", 128)
+        self.assertIsNone(error)
+        self.assertIn('"status":"ok"', output)
+        kwargs = run.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], 290)
+        self.assertEqual(kwargs["env"]["LLM_TIMEOUT"], "285")
+        self.assertEqual(kwargs["env"]["LLM_RETRIES"], "0")
+
+    def test_extract_uses_one_bounded_attempt(self):
+        self._assert_one_bounded_attempt(self.extract)
+
+    def test_synthesize_uses_one_bounded_attempt(self):
+        self._assert_one_bounded_attempt(self.synthesize)
+
+    def test_operator_shorter_timeout_is_preserved(self):
+        completed = SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        with mock.patch.dict(
+            os.environ,
+            {"LLM_ENDPOINT": "http://llm.test/v1", "LLM_TIMEOUT": "60"},
+            clear=True,
+        ):
+            with mock.patch.object(self.extract.subprocess, "run", return_value=completed) as run:
+                output, error = self.extract.call_llm("prompt", 128)
+        self.assertEqual((output, error), ("ok", None))
+        self.assertEqual(run.call_args.kwargs["timeout"], 65)
+        self.assertEqual(run.call_args.kwargs["env"]["LLM_TIMEOUT"], "60")
 
 
 if __name__ == "__main__":

--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -521,6 +521,16 @@ int64_t db2_kb_documents_insert_chunk(const char *project, const char *file_path
    if (!conn)
       return -1;
 
+   /* Treat the DB adapter as the final UTF-8 trust boundary. Most ingest paths
+    * sanitize while chunking, but durable/replayed work can originate from
+    * older producers and Postgres rejects one malformed byte by aborting the
+    * entire transaction. Keep the caller's buffer immutable and bind only a
+    * validated copy. */
+   char *clean_content = strdup(content ? content : "");
+   if (!clean_content)
+      return -1;
+   (void)text_sanitize_utf8(clean_content);
+
    static const char *sql =
        "INSERT INTO kb_documents"
        " (project, file_path, file_hash, chunk_index, heading_path, line_start, line_end,"
@@ -530,7 +540,10 @@ int64_t db2_kb_documents_insert_chunk(const char *project, const char *file_path
    char err[KBP_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
+   {
+      free(clean_content);
       return -1;
+   }
    aimee_pg_bind_text(st, "?1", project ? project : "");
    aimee_pg_bind_text(st, "?2", file_path ? file_path : "");
    aimee_pg_bind_text(st, "?3", file_hash ? file_hash : "");
@@ -538,12 +551,13 @@ int64_t db2_kb_documents_insert_chunk(const char *project, const char *file_path
    aimee_pg_bind_text(st, "?5", heading_path ? heading_path : "");
    aimee_pg_bind_int(st, "?6", line_start);
    aimee_pg_bind_int(st, "?7", line_end);
-   aimee_pg_bind_text(st, "?8", content ? content : "");
+   aimee_pg_bind_text(st, "?8", clean_content);
    aimee_pg_bind_int(st, "?9", token_count);
    int64_t new_id = -1;
    if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
       new_id = aimee_pg_column_int64(st, 0);
    aimee_pg_finalize(st);
+   free(clean_content);
    return new_id;
 }
 
@@ -596,6 +610,11 @@ int64_t db2_kb_documents_insert_chunk_pdf(const char *project, const char *file_
    if (!conn)
       return -1;
 
+   char *clean_content = strdup(content ? content : "");
+   if (!clean_content)
+      return -1;
+   (void)text_sanitize_utf8(clean_content);
+
    static const char *sql =
        "INSERT INTO kb_documents"
        " (project, file_path, file_hash, chunk_index, heading_path, line_start, line_end,"
@@ -606,7 +625,10 @@ int64_t db2_kb_documents_insert_chunk_pdf(const char *project, const char *file_
    char err[KBP_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
+   {
+      free(clean_content);
       return -1;
+   }
    aimee_pg_bind_text(st, "?1", project ? project : "");
    aimee_pg_bind_text(st, "?2", file_path ? file_path : "");
    aimee_pg_bind_text(st, "?3", file_hash ? file_hash : "");
@@ -614,7 +636,7 @@ int64_t db2_kb_documents_insert_chunk_pdf(const char *project, const char *file_
    aimee_pg_bind_text(st, "?5", heading_path ? heading_path : "");
    aimee_pg_bind_int(st, "?6", line_start);
    aimee_pg_bind_int(st, "?7", line_end);
-   aimee_pg_bind_text(st, "?8", content ? content : "");
+   aimee_pg_bind_text(st, "?8", clean_content);
    aimee_pg_bind_int(st, "?9", token_count);
    aimee_pg_bind_text(st, "?10", chunk_strategy ? chunk_strategy : "heading");
    aimee_pg_bind_int(st, "?11", page_start);
@@ -625,6 +647,7 @@ int64_t db2_kb_documents_insert_chunk_pdf(const char *project, const char *file_
    if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
       new_id = aimee_pg_column_int64(st, 0);
    aimee_pg_finalize(st);
+   free(clean_content);
    return new_id;
 }
 

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -295,6 +295,23 @@ static void test_build_sanitizes_malformed_utf8(void)
    printf("  PASS: malformed UTF-8 is sanitized before Postgres text boundaries\n");
 }
 
+static void test_chunk_insert_sanitizes_replayed_malformed_utf8(void)
+{
+   open_test_db();
+   const char replayed[] = "durable \x92queue\x94 payload \xed\xa0\x80";
+   int64_t id = db2_kb_documents_insert_chunk("test_utf8_boundary", "legacy.md", "hash", 0, "", 1,
+                                              1, replayed, 4);
+   assert(id > 0);
+
+   db2_kb_document_row_t row;
+   assert(db2_kb_document_fetch(id, "test_utf8_boundary", &row) == 1);
+   assert(strcmp(row.content, "durable ?queue? payload ???") == 0);
+   /* The persistence adapter must not mutate caller-owned data. */
+   assert((unsigned char)replayed[8] == 0x92);
+   close_test_db();
+   printf("  PASS: replayed malformed UTF-8 is sanitized at chunk persistence boundary\n");
+}
+
 static void test_build_incremental_update(void)
 {
    char tmpdir[] = "/tmp/aimee_kb_test_incr_XXXXXX";
@@ -1064,6 +1081,7 @@ int main(void)
    test_build_empty_dir();
    test_build_single_file();
    test_build_sanitizes_malformed_utf8();
+   test_chunk_insert_sanitizes_replayed_malformed_utf8();
    test_build_incremental_update();
    test_bloom_dedupe_skips_duplicate_content();
    test_minhash_shadow_signatures_persist();


### PR DESCRIPTION
## Summary
- sanitize normal and PDF chunk content immediately before the Postgres TEXT bind
- keep caller-owned buffers immutable and cover durable/replayed malformed payloads
- give legacy CPU curator sidecars one bounded 285-second LLM attempt under the native 300-second watchdog
- disable nested `llm-chat.py` retries because the durable curator queue already owns retry/backoff

## Live failures reproduced
1. The immutable `testing-1c796fe` KB replayed older queued content and PostgreSQL rejected bytes `0x92`, `0x86`, `0x94`, and `0x80` in `kb_documents.content`, aborting file transactions.
2. The same deployment still timed out legacy curator generations after 120 seconds and retried them durably while the CPU backend remained saturated. The direct provider path was already fixed, but the default deployed command fallback was not.

## Validation
- focused `unit-test-kb`
- new extract/synthesize timeout and retry-policy tests
- sidecar client contract tests
- full native unit suite, serial: all tests passed
- full shipping build (`all server`)
- lint

Release blocker for v0.3.0.