### PR TITLE
fix: harden canonical text and mTLS identity boundaries

### DIFF
--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -200,9 +200,10 @@ static int ci_file_modified_since(void *conn, int64_t project_id, const char *re
 
 /* ---- File body replacement (transactional) --------------------- */
 
-/* Returns 0 on success, -1 when the write was aborted at its commit point
- * because a purge fence is active for `project` (webchat-project-lifecycle
- * slice 2) — callers must stop the scan for that project. */
+/* Returns 0 on success, -1 when the transactional replacement fails or is
+ * aborted at its commit point by a purge fence. Callers must stop the scan for
+ * that project: continuing on the same Postgres connection after an aborted
+ * transaction would only turn the original error into misleading follow-ons. */
 static int ci_replace_file_data(void *conn, const char *project, int64_t file_id, const char *ext,
                                 const char *content)
 {
@@ -211,7 +212,7 @@ static int ci_replace_file_data(void *conn, const char *project, int64_t file_id
    if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
    {
       LOG_WARN(CI_LOG_TAG, "BEGIN failed: %s", err);
-      return 0;
+      return -1;
    }
 
    db2_exec_conn_int64(conn, "DELETE FROM file_exports WHERE file_id = ?1", file_id);
@@ -240,13 +241,22 @@ static int ci_replace_file_data(void *conn, const char *project, int64_t file_id
                            "INSERT INTO file_contents (file_id, content) VALUES (?1, ?2) "
                            "ON CONFLICT (file_id) DO UPDATE SET content = EXCLUDED.content",
                            err, sizeof(err));
-      if (st)
+      if (!st)
       {
-         aimee_pg_bind_int64(st, "?1", file_id);
-         aimee_pg_bind_text(st, "?2", content);
-         aimee_pg_step(st, err, sizeof(err));
-         aimee_pg_finalize(st);
+         LOG_WARN(CI_LOG_TAG, "file content prepare failed: %s", err);
+         aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+         return -1;
       }
+      aimee_pg_bind_int64(st, "?1", file_id);
+      aimee_pg_bind_text(st, "?2", content);
+      if (aimee_pg_step(st, err, sizeof(err)) != AIMEE_PG_DONE)
+      {
+         LOG_WARN(CI_LOG_TAG, "file content write failed: %s", err);
+         aimee_pg_finalize(st);
+         aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+         return -1;
+      }
+      aimee_pg_finalize(st);
    }
 
    /* Exports. */
@@ -397,6 +407,7 @@ static int ci_replace_file_data(void *conn, const char *project, int64_t file_id
    {
       LOG_WARN(CI_LOG_TAG, "COMMIT failed: %s", err);
       aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
    }
    return 0;
 }
@@ -1284,6 +1295,10 @@ int canonical_index_scan_project(const char *name, const char *root, int force, 
          free(list.paths[i]);
          continue;
       }
+      /* Source files are arbitrary bytes even when their extension is textual.
+       * Canonical indexing stores the complete body in a Postgres TEXT column
+       * and derives more rows from it, so normalize once before either path. */
+      (void)text_sanitize_utf8(content);
 
       int64_t file_id = ci_upsert_file(conn, project_id, rel, ts);
       if (file_id < 0)
@@ -1356,20 +1371,32 @@ int canonical_index_scan_files(const char *name, const char *root_label,
       if (!rel || !rel[0] || rel[0] == '/' || ci_path_ingest_excluded(rel) || !content)
          continue;
 
+      /* Remote/durable input is caller-owned. Keep it immutable while enforcing
+       * the same Postgres UTF-8 boundary as the filesystem scanner. */
+      char *clean_content = strdup(content);
+      if (!clean_content)
+         return -1;
+      (void)text_sanitize_utf8(clean_content);
+
       inspected++;
       int64_t file_id = ci_upsert_file(conn, project_id, rel, ts);
       if (file_id < 0)
+      {
+         free(clean_content);
          continue;
+      }
 
       const char *css_ext = ci_get_extension(rel);
-      if (ci_replace_file_data(conn, name, file_id, css_ext, content) != 0)
+      if (ci_replace_file_data(conn, name, file_id, css_ext, clean_content) != 0)
       {
          /* Purge fence: abort the whole scan for this project. */
+         free(clean_content);
          if (inspected_out)
             *inspected_out = inspected;
          return -1;
       }
-      ci_css_index_file(file_id, css_ext, content, css_on);
+      ci_css_index_file(file_id, css_ext, clean_content, css_on);
+      free(clean_content);
       scanned++;
    }
 

--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -7,9 +7,11 @@
 #include "db2.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
+#include "util.h"
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define CIDX_ERRBUF 256
@@ -635,9 +637,17 @@ int db2_code_index_file_replace(int64_t file_id, const code_index_file_data_t *d
    if (!conn)
       return -1;
 
+   char *clean_content = strdup(data->content ? data->content : "");
+   if (!clean_content)
+      return -1;
+   (void)text_sanitize_utf8(clean_content);
+
    char err[CIDX_ERRBUF] = "";
    if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
+   {
+      free(clean_content);
       return -1;
+   }
 
    int rc = 0;
    if (db2_exec_conn_int64(conn, "DELETE FROM file_exports WHERE file_id = ?1", file_id) != 0)
@@ -658,7 +668,7 @@ int db2_code_index_file_replace(int64_t file_id, const code_index_file_data_t *d
       if (st)
       {
          aimee_pg_bind_int64(st, "?1", file_id);
-         aimee_pg_bind_text(st, "?2", data->content ? data->content : "");
+         aimee_pg_bind_text(st, "?2", clean_content);
          if (aimee_pg_step(st, err, sizeof(err)) != AIMEE_PG_DONE)
             rc = -1;
          aimee_pg_finalize(st);
@@ -784,9 +794,16 @@ int db2_code_index_file_replace(int64_t file_id, const code_index_file_data_t *d
    }
 
    if (rc == 0)
-      aimee_pg_exec(conn, "COMMIT", err, sizeof(err));
+   {
+      if (aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+      {
+         aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+         rc = -1;
+      }
+   }
    else
       aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+   free(clean_content);
    return rc;
 }
 

--- a/src/headers/kb_pki.h
+++ b/src/headers/kb_pki.h
@@ -30,6 +30,8 @@ extern "C"
 #define KB_PKI_CERT_PEM_MAX 4096 /* PEM cert (RSA-2048) ~1.2 KB + slack */
 #define KB_PKI_KEY_PEM_MAX  4096 /* PEM PKCS#8 key (RSA-2048) ~1.7 KB + slack */
 #define KB_PKI_FP_HEX       65   /* sha256 lowercase hex (64) + NUL */
+#define KB_PKI_ISSUER_MAX   600  /* supported OpenSSL one-line issuer DN bytes */
+#define KB_PKI_SERIAL_MAX   128  /* supported uppercase-hex serial bytes */
 
    /* An internal CA: its self-signed certificate and private key, both PEM. */
    typedef struct

--- a/src/headers/kb_tls.h
+++ b/src/headers/kb_tls.h
@@ -10,8 +10,12 @@
 #ifndef DEC_KB_TLS_H
 #define DEC_KB_TLS_H
 
+#include "kb_pki.h"
 #include <openssl/ssl.h>
 #include <stddef.h>
+
+#define KB_TLS_PEER_ISSUER_MAX KB_PKI_ISSUER_MAX
+#define KB_TLS_PEER_SERIAL_MAX KB_PKI_SERIAL_MAX
 
 #ifdef __cplusplus
 extern "C"
@@ -42,7 +46,7 @@ extern "C"
 
    /* Peer cert issuer DN + serial (uppercase hex) — the (issuer, serial) immutable
     * revocation-key inputs for a transport (cert:CN) principal (P1 I5). Return 0 on
-    * success, -1 if no peer cert / extraction fails. */
+    * success, -1 if no peer cert, extraction fails, or the value does not fit. */
    int kb_tls_peer_issuer(SSL *ssl, char *out, size_t cap);
    int kb_tls_peer_serial(SSL *ssl, char *out, size_t cap);
 

--- a/src/kb/http/kb_http_bootstrap.c
+++ b/src/kb/http/kb_http_bootstrap.c
@@ -71,7 +71,9 @@ static int enroll_redeem_route(const char *method, const char *path, const char 
       }
       /* Persist the issuer/serial and mTLS certificate-DER SHA-256. Fail closed
        * rather than release an authority the enrollment database cannot revoke. */
-      char fp[KB_PKI_FP_HEX] = "", issuer[256] = "", raw_serial[128] = "", serial[128] = "";
+      char fp[KB_PKI_FP_HEX] = "", issuer[KB_PKI_ISSUER_MAX + 1] = "";
+      char raw_serial[KB_PKI_SERIAL_MAX + 1] = "";
+      char serial[KB_PKI_SERIAL_MAX + 1] = "";
       char expires_at[32] = "";
       if (kb_pki_ca_fingerprint(cert, fp, sizeof(fp)) != 0 ||
           kb_pki_cert_metadata(cert, issuer, sizeof(issuer), raw_serial, sizeof(raw_serial)) != 0 ||

--- a/src/kb/http/kb_tls.c
+++ b/src/kb/http/kb_tls.c
@@ -117,12 +117,22 @@ int kb_tls_peer_cn(SSL *ssl, char *out, size_t cap)
 {
    if (!ssl || !out || cap == 0)
       return -1;
+   out[0] = '\0';
    X509 *peer = SSL_get1_peer_certificate(ssl);
    if (!peer)
       return -1;
-   int n = X509_NAME_get_text_by_NID(X509_get_subject_name(peer), NID_commonName, out, (int)cap);
+   X509_NAME *name = X509_get_subject_name(peer);
+   int required = X509_NAME_get_text_by_NID(name, NID_commonName, NULL, 0);
+   int n = required > 0 && (size_t)required < cap
+               ? X509_NAME_get_text_by_NID(name, NID_commonName, out, (int)cap)
+               : -1;
    X509_free(peer);
-   return n > 0 ? 0 : -1;
+   if (n != required)
+   {
+      out[0] = '\0';
+      return -1;
+   }
+   return 0;
 }
 
 int kb_tls_peer_fingerprint(SSL *ssl, char *hex_out, size_t cap)
@@ -154,6 +164,7 @@ int kb_tls_peer_issuer(SSL *ssl, char *out, size_t cap)
 {
    if (!ssl || !out || cap == 0)
       return -1;
+   out[0] = '\0';
    X509 *peer = SSL_get1_peer_certificate(ssl);
    if (!peer)
       return -1;
@@ -161,9 +172,13 @@ int kb_tls_peer_issuer(SSL *ssl, char *out, size_t cap)
    int rc = -1;
    if (dn)
    {
-      snprintf(out, cap, "%s", dn);
+      size_t n = strlen(dn);
+      if (n < cap)
+      {
+         memcpy(out, dn, n + 1);
+         rc = 0;
+      }
       OPENSSL_free(dn);
-      rc = 0;
    }
    X509_free(peer);
    return rc;
@@ -175,6 +190,7 @@ int kb_tls_peer_serial(SSL *ssl, char *out, size_t cap)
 {
    if (!ssl || !out || cap == 0)
       return -1;
+   out[0] = '\0';
    X509 *peer = SSL_get1_peer_certificate(ssl);
    if (!peer)
       return -1;
@@ -186,9 +202,13 @@ int kb_tls_peer_serial(SSL *ssl, char *out, size_t cap)
       char *hex = BN_bn2hex(bn);
       if (hex)
       {
-         snprintf(out, cap, "%s", hex);
+         size_t n = strlen(hex);
+         if (n < cap)
+         {
+            memcpy(out, hex, n + 1);
+            rc = 0;
+         }
          OPENSSL_free(hex);
-         rc = 0;
       }
       BN_free(bn);
    }

--- a/src/kb/http/kb_tls_serve.c
+++ b/src/kb/http/kb_tls_serve.c
@@ -341,8 +341,9 @@ static int mtls_renew(const char *scope_cn, const char *old_fp, const char *old_
       snprintf(resp, (size_t)cap, "{\"error\":\"renew failed: bad CSR\"}");
       return 400;
    }
-   char new_fp[KB_PKI_FP_HEX] = "", new_issuer[256] = "", raw_serial[128] = "";
-   char new_serial[128] = "";
+   char new_fp[KB_PKI_FP_HEX] = "", new_issuer[KB_PKI_ISSUER_MAX + 1] = "";
+   char raw_serial[KB_PKI_SERIAL_MAX + 1] = "";
+   char new_serial[KB_PKI_SERIAL_MAX + 1] = "";
    int metadata_ok = kb_pki_ca_fingerprint(cert, new_fp, sizeof(new_fp)) == 0 &&
                      kb_pki_cert_metadata(cert, new_issuer, sizeof(new_issuer), raw_serial,
                                           sizeof(raw_serial)) == 0 &&
@@ -492,7 +493,8 @@ void kb_tls_serve_conn(int fd, SSL_CTX *ctx)
        * to an active enrollment. Unknown, revoked, and authority-error outcomes
        * all fail closed before routing; active use gets a debounced last-seen bump. */
       int cert_authority = 0;
-      char fp[65] = "", issuer[256] = "", serial[128] = "";
+      char fp[65] = "", issuer[KB_TLS_PEER_ISSUER_MAX + 1] = "";
+      char serial[KB_TLS_PEER_SERIAL_MAX + 1] = "";
       kb_principal_t transport;
       memset(&transport, 0, sizeof(transport));
       if (have_cert)
@@ -581,8 +583,7 @@ void kb_tls_serve_conn(int fd, SSL_CTX *ctx)
             status = 405;
          }
          else
-            status = mtls_management_jwks(transport.issuer, transport.subject, fp, resp,
-                                          KB_TLS_RESP_MAX);
+            status = mtls_management_jwks(issuer, transport.subject, fp, resp, KB_TLS_RESP_MAX);
          if (status == 403 || status == 503)
             close_after_response = 1;
       }
@@ -597,8 +598,7 @@ void kb_tls_serve_conn(int fd, SSL_CTX *ctx)
          }
          else
          {
-            status = mtls_renew(cn, fp, transport.issuer, transport.subject, body, resp,
-                                KB_TLS_RESP_MAX);
+            status = mtls_renew(cn, fp, issuer, transport.subject, body, resp, KB_TLS_RESP_MAX);
          }
       }
       else if (have_cert && strcmp(cpath, "/v1/server/heartbeat") == 0)

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -582,6 +582,54 @@ int main(void)
       assert(strcmp(body, gitmod_body) == 0);
    }
 
+   /* --- malformed bytes are normalized before either canonical ingest path
+    * reaches Postgres TEXT; pushed buffers remain caller-owned and immutable. --- */
+   {
+      char *invalid_dir = malloc(PATH_MAX);
+      assert(invalid_dir != NULL);
+      snprintf(invalid_dir, PATH_MAX, "%s/aimee-test-index-utf8-XXXXXX", platform_tmpdir());
+      assert(platform_mkdtemp(invalid_dir) != NULL);
+
+      char path[PATH_MAX];
+      snprintf(path, sizeof(path), "%s/legacy.c", invalid_dir);
+      FILE *f = fopen(path, "wb");
+      assert(f != NULL);
+      const char invalid_disk[] = "void legacy_\x92symbol(void) {} /* \xed\xa0\x80 */\n";
+      assert(fwrite(invalid_disk, 1, sizeof(invalid_disk) - 1, f) == sizeof(invalid_disk) - 1);
+      fclose(f);
+
+      int inspected = 0;
+      assert(canonical_index_scan_project("utf8disk", invalid_dir, 1, &inspected) == 1);
+      assert(inspected == 1);
+      char stored[256];
+      file_content("utf8disk", "legacy.c", stored, sizeof(stored));
+      assert(strcmp(stored, "void legacy_?symbol(void) {} /* ??? */\n") == 0);
+
+      const char invalid_push[] = "int pushed_\x94value = 1; /* \x80 */\n";
+      canonical_index_file_input_t input = {"pushed.c", invalid_push};
+      assert(canonical_index_scan_files("utf8push", "remote", &input, 1, 1, &inspected) == 1);
+      file_content("utf8push", "pushed.c", stored, sizeof(stored));
+      assert(strcmp(stored, "int pushed_?value = 1; /* ? */\n") == 0);
+      assert((unsigned char)invalid_push[11] == 0x94);
+
+      const char invalid_adapter[] = "adapter \x92"
+                                     "body \xed\xa0\x80";
+      int64_t pid = db2_code_index_project_upsert("utf8adapter", "/remote");
+      assert(pid > 0);
+      int64_t fid = db2_code_index_file_upsert(pid, "adapter.c", "2026-07-28T00:00:00Z");
+      assert(fid > 0);
+      code_index_file_data_t data = {.content = invalid_adapter};
+      assert(db2_code_index_file_replace(fid, &data) == 0);
+      file_content("utf8adapter", "adapter.c", stored, sizeof(stored));
+      assert(strcmp(stored, "adapter ?body ???") == 0);
+      assert((unsigned char)invalid_adapter[8] == 0x92);
+
+      char cmd[PATH_MAX + 16];
+      snprintf(cmd, sizeof(cmd), "rm -rf %s", invalid_dir);
+      (void)system(cmd);
+      free(invalid_dir);
+   }
+
    /* --- production co-change path: canonical scan populates co_edited edges from
     * git history, the bulk gate holds, re-scan is idempotent, and blast radius
     * surfaces a co-edited file with no structural import link. This guards the

--- a/src/tests/test_kb_tls.c
+++ b/src/tests/test_kb_tls.c
@@ -29,8 +29,15 @@ static void *server_thread(void *a)
    SSL_set_fd(ssl, s->fd);
    if (SSL_accept(ssl) == 1)
    {
-      s->ok = 1;
-      kb_tls_peer_cn(ssl, s->peer_cn, sizeof(s->peer_cn));
+      char issuer[KB_TLS_PEER_ISSUER_MAX + 1] = "";
+      char serial[KB_TLS_PEER_SERIAL_MAX + 1] = "";
+      char tiny[2] = "x";
+      s->ok = kb_tls_peer_cn(ssl, s->peer_cn, sizeof(s->peer_cn)) == 0 &&
+              kb_tls_peer_issuer(ssl, issuer, sizeof(issuer)) == 0 && issuer[0] &&
+              kb_tls_peer_serial(ssl, serial, sizeof(serial)) == 0 && serial[0] &&
+              kb_tls_peer_cn(ssl, tiny, sizeof(tiny)) == -1 && tiny[0] == '\0' &&
+              kb_tls_peer_issuer(ssl, tiny, sizeof(tiny)) == -1 && tiny[0] == '\0' &&
+              kb_tls_peer_serial(ssl, tiny, sizeof(tiny)) == -1 && tiny[0] == '\0';
    }
    SSL_shutdown(ssl);
    SSL_free(ssl);


### PR DESCRIPTION
## Summary
- sanitize malformed UTF-8 before every canonical file-content write, including filesystem, pushed, and adapter ingestion paths
- roll back canonical/code-index transactions on content or commit failures so the original database error is preserved
- reject truncated mTLS CN, issuer, and serial identities and align certificate metadata buffers with the database contract

## Validation
- full unit suite with TEST_RUN_JOBS=1 (all passed)
- unit-test-index
- unit-test-kb-tls
- unit-test-kb-http-routes
- unit-test-kb-workload-proof
- make lint
- make all server

## Live failure reproduced
The prior immutable candidate returned 500 from POST /v1/code/build when a source file contained legacy malformed UTF-8. kb_documents succeeded, but canonical file_contents rejected byte 0x92 and left the transaction aborted. This closes that second storage path and adds exact regressions.