### PR TITLE
A new install listed seven providers nobody had configured

### DIFF
--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -680,7 +680,7 @@ static cJSON *marshal_provider_set(int argc, char **argv)
 
 static cJSON *marshal_provider_list(int argc, char **argv)
 {
-   static const char *bool_flags[] = {"available", "json", NULL};
+   static const char *bool_flags[] = {"available", "all", "json", NULL};
    rpc_opts_t opts;
    rpc_parse(argc, argv, bool_flags, &opts);
    cJSON *req = marshal_no_args("provider.list");
@@ -688,6 +688,8 @@ static cJSON *marshal_provider_list(int argc, char **argv)
       return NULL;
    if (rpc_get(&opts, "available"))
       cJSON_AddTrueToObject(req, "available_only");
+   if (rpc_get(&opts, "all"))
+      cJSON_AddTrueToObject(req, "all");
    if (rpc_get(&opts, "json"))
       cJSON_AddTrueToObject(req, "json");
    return req;

--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -1963,6 +1963,19 @@ void pt_print_provider_list(const char *method, cJSON *resp)
    }
    else if (cJSON_IsArray(providers))
    {
+      /* An empty list is the normal state of a new install: nothing is
+       * configured until the operator configures it. Say that, rather than
+       * printing a bare header that reads like a broken query. */
+      if (cJSON_GetArraySize(providers) == 0)
+      {
+         if (cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(resp, "all")))
+            printf("no providers known\n");
+         else if (cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(resp, "available_only")))
+            printf("no providers available\n");
+         else
+            printf("no providers configured — `aimee provider list --all` shows what can be\n");
+         return;
+      }
       printf("%-20s  %-24s  %-10s  %s\n", "provider", "display", "auth", "status");
       cJSON *p;
       cJSON_ArrayForEach(p, providers)

--- a/src/cmd_provider.c
+++ b/src/cmd_provider.c
@@ -70,33 +70,71 @@ static int provider_models_cached(model_provider_t *p, char ***models_out, int *
    return db1_model_catalog_get(p->name, models_out, n_out);
 }
 
+/* Has the OPERATOR configured this provider, as opposed to aimee merely knowing
+ * it exists? A credential actually present is the only evidence we have of a
+ * deliberate choice. auth_type "none" (ollama, llama_native) is NOT evidence:
+ * those need no key, so they would report configured on a machine where nothing
+ * is installed or running. */
+static int provider_is_configured(const model_provider_t *p)
+{
+   if (!p || !p->env_vars)
+      return 0;
+   for (int i = 0; p->env_vars[i]; i++)
+   {
+      const char *val = getenv(p->env_vars[i]);
+      if (val && val[0])
+         return 1;
+   }
+   return 0;
+}
+
 static void provider_list(app_ctx_t *ctx, int argc, char **argv)
 {
    (void)ctx;
-   int only_available = 0;
+   int only_available = 0, show_all = 0;
    for (int ai = 0; ai < argc; ai++)
    {
       if (strcmp(argv[ai], "--available") == 0)
          only_available = 1;
+      else if (strcmp(argv[ai], "--all") == 0)
+         show_all = 1;
    }
 
    model_provider_t *providers[64];
    int n = model_provider_list(providers, 64);
-   if (n == 0)
-   {
-      printf("no providers registered\n");
-      return;
-   }
+
+   /* Default: only what the operator configured. This used to print the whole
+    * built-in catalogue — seven rows, every one "[no key]" — under a heading
+    * that reads like a registration table, so a brand-new install looked
+    * pre-populated with providers nobody had chosen. Nothing was installed or
+    * configured; they were just names aimee knows. `--all` shows that catalogue
+    * for anyone who wants to see what can be configured, and `--available`
+    * still answers the different question of what is usable right now
+    * (including the local, no-key providers). */
+   int shown = 0;
    for (int i = 0; i < n; i++)
    {
       const model_provider_t *p = providers[i];
       int available = provider_has_credentials(p);
       if (only_available && !available)
          continue;
+      if (!show_all && !only_available && !provider_is_configured(p))
+         continue;
       const char *key_var = provider_first_env_var(p);
       printf("%-20s  %-24s  %-10s  %s\n", p->name, p->display_name ? p->display_name : "",
              p->auth_type ? p->auth_type : "",
              key_var ? (available ? "[key set]" : "[no key]") : "[local]");
+      shown++;
+   }
+
+   if (shown == 0)
+   {
+      if (show_all)
+         printf("no providers known\n");
+      else if (only_available)
+         printf("no providers available\n");
+      else
+         printf("no providers configured — `aimee provider list --all` shows what can be\n");
    }
 }
 
@@ -247,7 +285,8 @@ static void provider_quota(app_ctx_t *ctx, int argc, char **argv)
 }
 
 static const subcmd_t provider_subcmds[] = {
-    {"list", "List registered providers and key status", provider_list},
+    {"list", "List configured providers (--all: every known one, --available: usable now)",
+     provider_list},
     {"show", "Show provider profile detail", provider_show},
     {"models", "Fetch live model catalog from provider", provider_models},
     {"test", "Probe provider connectivity", provider_test},

--- a/src/server_provider.c
+++ b/src/server_provider.c
@@ -150,20 +150,49 @@ static cJSON *server_provider_json(const model_provider_t *p)
    return obj;
 }
 
+/* Has the OPERATOR configured this provider, as opposed to aimee merely knowing
+ * it exists? A credential actually present is the only evidence of a deliberate
+ * choice. auth_type "none" (ollama, llama_native) is NOT evidence: those need no
+ * key, so they would report configured on a machine where nothing is installed
+ * or running. That is the difference between this and
+ * server_provider_has_credentials(), which answers "usable right now". */
+static int server_provider_is_configured(const model_provider_t *p)
+{
+   if (!p || !p->env_vars)
+      return 0;
+   for (int i = 0; p->env_vars[i]; i++)
+   {
+      const char *val = getenv(p->env_vars[i]);
+      if (val && val[0])
+         return 1;
+   }
+   return 0;
+}
+
 int handle_provider_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
    int available_only = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "available_only"));
+   int show_all = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "all"));
    int json_output = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "json"));
    model_provider_t *providers[64];
    int n = model_provider_list(providers, 64);
    cJSON *resp = cJSON_CreateObject();
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddBoolToObject(resp, "json", json_output);
+   cJSON_AddBoolToObject(resp, "all", show_all);
+   cJSON_AddBoolToObject(resp, "available_only", available_only);
    cJSON *arr = cJSON_CreateArray();
    for (int i = 0; i < n; i++)
    {
       if (available_only && !server_provider_has_credentials(providers[i]))
+         continue;
+      /* Default is what the operator CONFIGURED. This returned the whole
+       * built-in catalogue — seven entries, every one "[no key]" — which the
+       * client renders as a registration table, so a brand-new install looked
+       * pre-populated with providers nobody had chosen. Nothing was installed;
+       * they were names aimee knows. `--all` still shows that catalogue. */
+      if (!show_all && !available_only && !server_provider_is_configured(providers[i]))
          continue;
       cJSON_AddItemToArray(arr, server_provider_json(providers[i]));
    }


### PR DESCRIPTION
## What

`aimee provider list` printed the entire built-in catalogue on a brand-new install:

```
provider              display                   auth        status
openai                OpenAI                    api_key     [no key]
anthropic             Anthropic                 x-api-key   [no key]
ollama                Ollama (local)            none        [local]
llama_native          llama.cpp (local)         none        [local]
openrouter            OpenRouter                api_key     [no key]
mistral               Mistral AI                api_key     [no key]
minimax               MiniMax                   api_key     [no key]
```

Nothing was installed and nothing was configured — those are names aimee knows about. But under a header that reads like a registration table, a new install looks pre-populated with seven provider accounts.

## Behaviour

```
aimee provider list              only providers with a credential present
aimee provider list --all        the catalogue: what CAN be configured
aimee provider list --available  what is usable right now (incl. local)
```

**"Configured" means a credential actually set.** `auth_type: none` (ollama, llama_native) does *not* count — those need no key, so they'd report configured on a machine where neither is installed or running, which is precisely the false impression being removed.

That's the distinction between the new `server_provider_is_configured()` and the existing `server_provider_has_credentials()`, which still answers "usable now" and still drives `--available` unchanged.

The filter is **server-side**, because the server holds the credentials — a key in the client's environment is not the server's configuration.

An empty list now says so rather than printing a bare header, and names the flag that shows the catalogue.

## Verified against a running server

| case | result |
|---|---|
| no keys | `no providers configured — ...--all shows what can be` |
| `--all` | all 7 |
| `--available` | `ollama`, `llama_native` |
| server started with `OPENAI_API_KEY` | `openai ... [key set]` |
| key in the **client** env only | still blank — correct, config is server-side |

## Note

`cmd_provider.c` carries the same rule. That path is *not* what `aimee provider list` reaches — the CLI routes through `/v1` to `handle_provider_list` — but leaving the two disagreeing would be a trap for whoever finds it next.