### PR TITLE
fix: keep selected providers visible and preserve TLS smoke endpoints

### DIFF
--- a/docs/gen/cli-commands.md
+++ b/docs/gen/cli-commands.md
@@ -566,7 +566,7 @@ Model provider profiles and catalogs.
 Subcommands:
 
 ```
-  list             List registered providers (--available, --json)
+  list             List configured providers (--all, --available, --json)
   show <name>      Show provider profile details
   models <name>    Fetch provider model catalog (--json)
   test <name>      Probe provider credentials and connectivity

--- a/scripts/aimee-thin-client-smoke.sh
+++ b/scripts/aimee-thin-client-smoke.sh
@@ -44,8 +44,12 @@ bad()  { red   "  FAIL  $*"; FAIL=$((FAIL + 1)); }
 #  - AIMEE_SERVER_URL/_TOKEN: the cross-platform thin client (incl. Windows),
 #    which has no config_load and reads the URL straight from the environment.
 host_port="${SERVER_URL#http://}"; host_port="${host_port#https://}"; host_port="${host_port%/}"
+case "$SERVER_URL" in
+  https://*) endpoint_scheme=tls ;;
+  *)         endpoint_scheme=tcp ;;
+esac
 export AIMEE_API_CLIENT_TRANSPORT=http
-export AIMEE_API_ENDPOINT="tcp:${host_port}"
+export AIMEE_API_ENDPOINT="${endpoint_scheme}:${host_port}"
 export AIMEE_API_BEARER="${BEARER}"
 export AIMEE_SERVER_URL="${SERVER_URL}"
 export AIMEE_SERVER_TOKEN="${BEARER}"

--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -147,7 +147,7 @@
      "  edit <role>      Edit or create a template in $EDITOR\n"
      "  rm <role>        Reset a built-in or remove a custom template\n"},
     {"provider", "Model provider profiles and catalogs", CLIENT_TIER_ADVANCED, 0,
-     "  list             List registered providers (--available, --json)\n"
+     "  list             List configured providers (--all, --available, --json)\n"
      "  show <name>      Show provider profile details\n"
      "  models <name>    Fetch provider model catalog (--json)\n"
      "  test <name>      Probe provider credentials and connectivity\n"

--- a/src/cmd_provider.c
+++ b/src/cmd_provider.c
@@ -71,13 +71,17 @@ static int provider_models_cached(model_provider_t *p, char ***models_out, int *
 }
 
 /* Has the OPERATOR configured this provider, as opposed to aimee merely knowing
- * it exists? A credential actually present is the only evidence we have of a
- * deliberate choice. auth_type "none" (ollama, llama_native) is NOT evidence:
- * those need no key, so they would report configured on a machine where nothing
- * is installed or running. */
-static int provider_is_configured(const model_provider_t *p)
+ * it exists? A credential or an explicit `provider set` is evidence of a
+ * deliberate choice. auth_type "none" alone (ollama, llama_native) is NOT:
+ * those need no key, so they would otherwise report configured on a machine
+ * where nothing is installed or running. */
+static int provider_is_configured(const model_provider_t *p, const char *selected_provider)
 {
-   if (!p || !p->env_vars)
+   if (!p)
+      return 0;
+   if (selected_provider && selected_provider[0] && strcmp(p->name, selected_provider) == 0)
+      return 1;
+   if (!p->env_vars)
       return 0;
    for (int i = 0; p->env_vars[i]; i++)
    {
@@ -102,6 +106,8 @@ static void provider_list(app_ctx_t *ctx, int argc, char **argv)
 
    model_provider_t *providers[64];
    int n = model_provider_list(providers, 64);
+   config_t cfg = {0};
+   (void)config_load(&cfg);
 
    /* Default: only what the operator configured. This used to print the whole
     * built-in catalogue — seven rows, every one "[no key]" — under a heading
@@ -118,7 +124,7 @@ static void provider_list(app_ctx_t *ctx, int argc, char **argv)
       int available = provider_has_credentials(p);
       if (only_available && !available)
          continue;
-      if (!show_all && !only_available && !provider_is_configured(p))
+      if (!show_all && !only_available && !provider_is_configured(p, cfg.provider))
          continue;
       const char *key_var = provider_first_env_var(p);
       printf("%-20s  %-24s  %-10s  %s\n", p->name, p->display_name ? p->display_name : "",

--- a/src/server_provider.c
+++ b/src/server_provider.c
@@ -151,14 +151,18 @@ static cJSON *server_provider_json(const model_provider_t *p)
 }
 
 /* Has the OPERATOR configured this provider, as opposed to aimee merely knowing
- * it exists? A credential actually present is the only evidence of a deliberate
- * choice. auth_type "none" (ollama, llama_native) is NOT evidence: those need no
- * key, so they would report configured on a machine where nothing is installed
- * or running. That is the difference between this and
- * server_provider_has_credentials(), which answers "usable right now". */
-static int server_provider_is_configured(const model_provider_t *p)
+ * it exists? A credential or an explicit `provider set` is evidence of a
+ * deliberate choice. auth_type "none" alone (ollama, llama_native) is NOT:
+ * those need no key, so they would otherwise report configured on a machine
+ * where nothing is installed or running. That is the difference between this
+ * and server_provider_has_credentials(), which answers "usable right now". */
+static int server_provider_is_configured(const model_provider_t *p, const char *selected_provider)
 {
-   if (!p || !p->env_vars)
+   if (!p)
+      return 0;
+   if (selected_provider && selected_provider[0] && strcmp(p->name, selected_provider) == 0)
+      return 1;
+   if (!p->env_vars)
       return 0;
    for (int i = 0; p->env_vars[i]; i++)
    {
@@ -177,6 +181,8 @@ int handle_provider_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    int json_output = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "json"));
    model_provider_t *providers[64];
    int n = model_provider_list(providers, 64);
+   config_t cfg = {0};
+   (void)config_load(&cfg);
    cJSON *resp = cJSON_CreateObject();
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddBoolToObject(resp, "json", json_output);
@@ -192,7 +198,8 @@ int handle_provider_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
        * client renders as a registration table, so a brand-new install looked
        * pre-populated with providers nobody had chosen. Nothing was installed;
        * they were names aimee knows. `--all` still shows that catalogue. */
-      if (!show_all && !available_only && !server_provider_is_configured(providers[i]))
+      if (!show_all && !available_only &&
+          !server_provider_is_configured(providers[i], cfg.provider))
          continue;
       cJSON_AddItemToArray(arr, server_provider_json(providers[i]));
    }

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -643,6 +643,7 @@ _check_existing_shipped_artifacts() {
     provider_help_rc=$?
     if [ "$provider_help_rc" -eq 0 ] &&
        grep -q "provider" <<< "$provider_help_output" &&
+       grep -q -- "--all" <<< "$provider_help_output" &&
        ! grep -q "Unknown command" <<< "$provider_help_output"; then
         pass "server-routed provider help is client-side"
     else
@@ -792,6 +793,7 @@ _group_integ() {
     provider_help_rc=$?
     if [ "$provider_help_rc" -eq 0 ] &&
        grep -q "provider" <<< "$provider_help_output" &&
+       grep -q -- "--all" <<< "$provider_help_output" &&
        ! grep -q "Unknown command" <<< "$provider_help_output"; then
         pass "server-routed provider help is client-side"
     else

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -187,6 +187,34 @@ else
     fail "scripts reference missing make targets:$bad_script_targets"
 fi
 
+# The cross-platform smoke exports both modern URL and legacy endpoint forms.
+# Preserve the transport scheme: POSIX gives AIMEE_API_ENDPOINT precedence, so
+# mapping an https:// URL to tcp: makes a healthy TLS server look unreachable.
+smoke_tmp=$(mktemp -d "${TMPDIR:-/tmp}/aimee-smoke-endpoint.XXXXXX") || smoke_tmp=
+smoke_endpoints_ok=0
+if [ -n "$smoke_tmp" ]; then
+    printf '%s\n' '#!/bin/sh' 'test "${AIMEE_API_ENDPOINT:-}" = "${EXPECTED_ENDPOINT:?}"' \
+        > "$smoke_tmp/fake-aimee"
+    chmod +x "$smoke_tmp/fake-aimee"
+    smoke_endpoints_ok=1
+    for smoke_case in 'http://example.test:8740|tcp:example.test:8740' \
+                      'https://example.test:8743|tls:example.test:8743'; do
+        smoke_url=${smoke_case%%|*}
+        smoke_expected=${smoke_case#*|}
+        if ! AIMEE_BIN="$smoke_tmp/fake-aimee" SERVER_URL="$smoke_url" \
+             EXPECTED_ENDPOINT="$smoke_expected" FORCE_MODE=full \
+             bash ../scripts/aimee-thin-client-smoke.sh >/dev/null 2>&1; then
+            smoke_endpoints_ok=0
+        fi
+    done
+    rm -rf "$smoke_tmp"
+fi
+if [ "$smoke_endpoints_ok" = "1" ]; then
+    pass "thin-client smoke preserves HTTP/TLS endpoint schemes"
+else
+    fail "thin-client smoke endpoint scheme regression"
+fi
+
 # 7a. PreToolUse grep redirect hook must keep targeted file inspection unblocked.
 if python3 ../scripts/test-redirect-grep-hook.py >/dev/null 2>&1; then
     pass "redirect grep hook classifier"

--- a/src/tests/test_cli_v1_delegate.c
+++ b/src/tests/test_cli_v1_delegate.c
@@ -458,11 +458,12 @@ static void test_provider_routes_and_marshaling(void)
    assert(strcmp(route.method, "provider.quota") == 0);
    assert(route.skip_subcmd == 1);
 
-   char *list_argv[] = {"--available", "--json"};
-   cJSON *req = marshal_provider_list(2, list_argv);
+   char *list_argv[] = {"--available", "--all", "--json"};
+   cJSON *req = marshal_provider_list(3, list_argv);
    assert(req != NULL);
    assert(strcmp(cJSON_GetObjectItem(req, "method")->valuestring, "provider.list") == 0);
    assert(cJSON_IsTrue(cJSON_GetObjectItem(req, "available_only")));
+   assert(cJSON_IsTrue(cJSON_GetObjectItem(req, "all")));
    assert(cJSON_IsTrue(cJSON_GetObjectItem(req, "json")));
    cJSON_Delete(req);
 


### PR DESCRIPTION
## What

`provider list` now treats the provider selected by `provider set` as configured, even when it has no credential environment variable.

Without this, selecting a local provider such as `ollama` immediately made the default list claim that no provider was configured. A selected cloud provider was similarly hidden until its key was supplied. Credentials still count as configuration, and untouched no-key local providers remain hidden by default.

Also adds focused coverage that `--all` is marshalled through the v1 client.

## Verification

- full thin-client build and link
- `cmd_provider.c` and `server_provider.c` compile with warnings-as-errors
- `unit-test-cli-v1-delegate`: all tests passed
- diff check clean