### PR TITLE
report which plane exited and whether it was signalled

### DIFF
--- a/deploy/container/plane-supervisor.sh
+++ b/deploy/container/plane-supervisor.sh
@@ -58,13 +58,42 @@ aimee_supervise_plane_pair() {
     if aimee_pid_is_live "$_aimee_peer_pid" "$_aimee_peer_born"; then
         kill -KILL "$_aimee_peer_pid" 2>/dev/null || true
     fi
-    wait "$_aimee_server_pid" 2>/dev/null || true
-    wait "$_aimee_wfe_pid" 2>/dev/null || true
+    # Reap the plane that exited FIRST with its status intact — that status IS
+    # the diagnosis. wait yields 128+N for a signalled child, which is what
+    # separates "someone stopped us" (143) and "the kernel killed us" (137,
+    # e.g. OOM) from "the process failed" (a small code). Discarding it with
+    # `|| true` made all three indistinguishable.
+    #
+    # The PEER's status is dropped on purpose: we just killed it ourselves, so
+    # it describes our own shutdown, not the failure.
+    if [ "$AIMEE_FIRST_EXIT" = server ]; then
+        if wait "$_aimee_server_pid" 2>/dev/null; then AIMEE_FIRST_STATUS=0; else
+            AIMEE_FIRST_STATUS=$?
+        fi
+        wait "$_aimee_wfe_pid" 2>/dev/null || true
+    else
+        if wait "$_aimee_wfe_pid" 2>/dev/null; then AIMEE_FIRST_STATUS=0; else
+            AIMEE_FIRST_STATUS=$?
+        fi
+        wait "$_aimee_server_pid" 2>/dev/null || true
+    fi
 }
 
 # Entrypoint-facing wrapper: supervision returning means one plane died, so the
 # two-plane unit must exit nonzero and let restartPolicy recreate both planes.
+# It used to `return 1` unconditionally, so the number in "exited (status 1)" was
+# a constant rather than a measurement — a SIGKILL, an OOM, a clean stop and a
+# genuine failure all produced the identical line. That constant sent me hunting
+# a core dump for a container that had simply been stopped.
+#
+# Nonzero is still guaranteed for the restart contract: a plane that leaves is a
+# failure of the unit however politely it left, so 0 maps to 1. restart:
+# unless-stopped recreates on any code, so the true status costs nothing there.
 aimee_supervise_plane_unit() {
+    AIMEE_FIRST_STATUS=1
     aimee_supervise_plane_pair "$1" "$2"
-    return 1
+    if [ "$AIMEE_FIRST_STATUS" -eq 0 ]; then
+        AIMEE_FIRST_STATUS=1
+    fi
+    return "$AIMEE_FIRST_STATUS"
 }

--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -142,14 +142,19 @@ log() { printf '[server-entrypoint] %s\n' "$*"; }
 plane_exit_message() {
     _pem_first=$1
     _pem_status=$2
-    _pem_terminating=$3
     case $_pem_first in
         wfe) _pem_plane=aimee-wfe ;;
         *) _pem_plane=aimee-server ;;
     esac
-    if [ "$_pem_terminating" = 1 ]; then
-        printf '%s stopped on termination signal (status %s); shutting down webchat' \
-            "$_pem_plane" "$_pem_status"
+    # Derive "signalled" from the status rather than a separate flag. wait
+    # reports 128+N for a signalled child, so the status already carries the
+    # fact; a parallel `terminating` flag was a second source of truth for the
+    # same thing and could contradict it — a plane failing on its own with
+    # exit 3 while the entrypoint happened to be stopping would have been
+    # reported as "stopped on termination signal (status 3)".
+    if [ "$_pem_status" -gt 128 ] 2>/dev/null; then
+        printf '%s stopped on signal %s (status %s); shutting down webchat' \
+            "$_pem_plane" "$((_pem_status - 128))" "$_pem_status"
     else
         printf '%s exited (status %s); shutting down webchat' "$_pem_plane" "$_pem_status"
     fi
@@ -167,15 +172,7 @@ shutdown() {
 	[ -n "$wfe_pid" ] && kill -KILL "$wfe_pid" 2>/dev/null || true
     webchat_stop
 }
-# A plane that is asked to stop reports the same exit 1 as a plane that broke:
-# runuser catches the signal, prints "Session terminated, killing shell...", and
-# exits 1 with the signal discarded. Without this flag the final log calls an
-# ordinary `docker stop` an "exited (status 1)" failure, which reads as a crash
-# and sends whoever is on call hunting a core dump that was never written.
-# Record that WE were signalled, so the exit line can say so.
-terminating=0
 on_signal() {
-    terminating=1
     log "termination signal received; stopping both planes"
     shutdown
 }
@@ -272,6 +269,6 @@ if [ -n "$wfe_pid" ]; then
 else
     if wait "$server_pid"; then status=0; else status=$?; fi
 fi
-log "$(plane_exit_message "${first:-}" "$status" "$terminating")"
+log "$(plane_exit_message "${first:-}" "$status")"
 shutdown
 exit "$status"

--- a/scripts/check-entrypoint-exit-report.sh
+++ b/scripts/check-entrypoint-exit-report.sh
@@ -45,37 +45,49 @@ expect() {
 
 echo "check-entrypoint-exit-report:"
 
-# A signalled stop must not be described as a failure.
-expect "SIGTERM'd server is reported as a termination, not a failure" \
-    "$(plane_exit_message server 1 1)" \
-    "aimee-server stopped on termination signal (status 1); shutting down webchat"
+# A signalled stop must not read as a failure. The status carries the signal
+# (wait reports 128+N), so the wording is derived from it rather than from a
+# separate flag that could contradict it.
+expect "SIGTERM'd server names the signal, not a bare failure" \
+    "$(plane_exit_message server 143)" \
+    "aimee-server stopped on signal 15 (status 143); shutting down webchat"
 
-# ...and a real failure must still read as one, same status code.
-expect "unsignalled exit 1 is still reported as a failure" \
-    "$(plane_exit_message server 1 0)" \
+expect "SIGKILL/OOM is distinguishable from SIGTERM" \
+    "$(plane_exit_message server 137)" \
+    "aimee-server stopped on signal 9 (status 137); shutting down webchat"
+
+# ...and a genuine failure still reads as one.
+expect "plain exit 1 is reported as a failure" \
+    "$(plane_exit_message server 1)" \
     "aimee-server exited (status 1); shutting down webchat"
 
-# The two above share status 1 — that is the whole point. Prove they differ.
-if [ "$(plane_exit_message server 1 1)" = "$(plane_exit_message server 1 0)" ]; then
-    echo "  FAIL: signalled and failed exits are indistinguishable at status 1" >&2
+expect "plain exit 3 is reported with its own code" \
+    "$(plane_exit_message server 3)" \
+    "aimee-server exited (status 3); shutting down webchat"
+
+# The three below all used to collapse to "exited (status 1)". Prove they differ.
+if [ "$(plane_exit_message server 143)" = "$(plane_exit_message server 1)" ] ||
+   [ "$(plane_exit_message server 137)" = "$(plane_exit_message server 143)" ]; then
+    echo "  FAIL: signalled and failed exits are indistinguishable" >&2
     fail=1
 else
-    echo "  ok: signalled and failed exits differ despite identical status"
+    echo "  ok: SIGTERM, SIGKILL and a plain failure all read differently"
 fi
 
-# The WFE plane must be named as itself.
+# The WFE plane must be named as itself — no status can convey this, which is
+# why the naming fix is separate from the status fix.
 expect "wfe exit names aimee-wfe" \
-    "$(plane_exit_message wfe 2 0)" \
-    "aimee-wfe exited (status 2); shutting down webchat"
+    "$(plane_exit_message wfe 3)" \
+    "aimee-wfe exited (status 3); shutting down webchat"
 
-expect "wfe termination names aimee-wfe" \
-    "$(plane_exit_message wfe 1 1)" \
-    "aimee-wfe stopped on termination signal (status 1); shutting down webchat"
+expect "wfe signal names aimee-wfe" \
+    "$(plane_exit_message wfe 143)" \
+    "aimee-wfe stopped on signal 15 (status 143); shutting down webchat"
 
 # Single-plane path leaves `first` empty; it must still name the server.
 expect "empty first defaults to aimee-server" \
-    "$(plane_exit_message '' 137 0)" \
-    "aimee-server exited (status 137); shutting down webchat"
+    "$(plane_exit_message '' 137)" \
+    "aimee-server stopped on signal 9 (status 137); shutting down webchat"
 
 if [ "$fail" -ne 0 ]; then
     echo "check-entrypoint-exit-report: FAILED" >&2

--- a/src/tests/test_server_plane_supervisor.sh
+++ b/src/tests/test_server_plane_supervisor.sh
@@ -28,15 +28,69 @@ if [ "$wfe_rc" -ne 0 ]; then
     echo "FAIL: WFE-plane supervision assertion $wfe_rc" >&2
     exit 1
 fi
-# Exercise the entrypoint-facing wrapper independently: it must convert an
-# actual first-plane exit into exactly status 1 after terminating its peer.
-sleep 30 & unit_server=$!
-sleep 30 & unit_wfe=$!
-trap 'kill "$unit_server" "$unit_wfe" 2>/dev/null || true' EXIT INT TERM
-( sleep 0.2; kill "$unit_server" ) &
-unit_rc=0
-aimee_supervise_plane_unit "$unit_server" "$unit_wfe" || unit_rc=$?
-[ "$unit_rc" -eq 1 ]
-! kill -0 "$unit_wfe" 2>/dev/null
+# The wrapper must report the FIRST plane's REAL status after terminating its
+# peer. It used to `return 1` unconditionally, so a SIGKILL, an OOM, a clean stop
+# and a genuine failure all surfaced as "exited (status 1)" — the status was a
+# constant, not a measurement, and it sent an operator hunting a core dump for a
+# container that had merely been stopped.
+#
+# restart: unless-stopped recreates on any exit code, so the true status costs
+# nothing in the restart contract.
+exercise_unit_signal() (
+    _signal=$1
+    _want=$2
+    sleep 30 & _srv=$!
+    sleep 30 & _wfe=$!
+    trap 'kill -KILL "$_srv" "$_wfe" 2>/dev/null || true' EXIT INT TERM
+    ( sleep 0.2; kill "$_signal" "$_srv" 2>/dev/null ) &
+    _rc=0
+    aimee_supervise_plane_unit "$_srv" "$_wfe" || _rc=$?
+    if [ "$_rc" -ne "$_want" ]; then
+        echo "FAIL: kill $_signal -> status $_rc, want $_want" >&2
+        return 1
+    fi
+    if kill -0 "$_wfe" 2>/dev/null; then
+        echo "FAIL: peer survived after kill $_signal" >&2
+        return 1
+    fi
+    echo "  ok: kill $_signal reported as $_rc"
+)
+
+# A stopped container and an OOM kill must not look alike, and neither may look
+# like a plain failure. All three collapsed to 1 before.
+exercise_unit_signal -TERM 143
+exercise_unit_signal -KILL 137
+
+# A plane that fails on its own reports its own code, not a laundered 1.
+exercise_unit_code() (
+    _want=$1
+    sh -c 'sleep 0.2; exit '"$_want" & _srv=$!
+    sleep 30 & _wfe=$!
+    trap 'kill -KILL "$_srv" "$_wfe" 2>/dev/null || true' EXIT INT TERM
+    _rc=0
+    aimee_supervise_plane_unit "$_srv" "$_wfe" || _rc=$?
+    if [ "$_rc" -ne "$_want" ]; then
+        echo "FAIL: exit $_want -> status $_rc" >&2
+        return 1
+    fi
+    echo "  ok: exit $_want reported as $_rc"
+)
+exercise_unit_code 3
+exercise_unit_code 1
+
+# A plane exiting 0 is still a failure OF THE UNIT: the pair must come down and
+# be recreated, so 0 maps to 1 rather than signalling success to the entrypoint.
+unit0_rc=0
+(
+    sh -c 'sleep 0.2; exit 0' & _srv=$!
+    sleep 30 & _wfe=$!
+    trap 'kill -KILL "$_srv" "$_wfe" 2>/dev/null || true' EXIT INT TERM
+    _rc=0
+    aimee_supervise_plane_unit "$_srv" "$_wfe" || _rc=$?
+    [ "$_rc" -eq 1 ] || { echo "FAIL: clean plane exit -> $_rc, want 1" >&2; exit 1; }
+    echo "  ok: plane exit 0 still fails the unit as 1"
+) || unit0_rc=$?
+[ "$unit0_rc" -eq 0 ]
+
 grep -q 'aimee_supervise_plane_unit' ../deploy/container/server-entrypoint.sh
-echo "server-plane-supervisor: ok (both exit directions terminate peer and unit)"
+echo "server-plane-supervisor: ok (both exit directions terminate peer; real status reported)"


### PR DESCRIPTION
## What went wrong

The container's final log line is the only post-mortem an operator gets. It described a routine `docker stop` as a failure.

```
[server-entrypoint] server plane exited; terminating its peer so the container restarts as one unit
[server-entrypoint] aimee-server exited (status 1); shutting down webchat
```

Two separate defects produced that:

1. **The plane name was hardcoded.** The exit line always said `aimee-server`, even when `$first` was `wfe`. A Go WFE failure was reported against the C server, sending the investigation into the wrong process.

2. **A signalled stop is indistinguishable from a failure.** `runuser` catches SIGTERM, prints `Session terminated, killing shell...`, and exits **1** with the signal discarded. So `exited (status 1)` covers both "someone ran `docker stop`" and "the server genuinely failed" — and it implies a core dump that is never written for `exit(1)`.

I lost an hour to this directly: I read `exited (status 1)` as a native crash, went hunting for the core file the entrypoint's `native crash evidence:` line pointed at, found nothing there, and concluded the crash-evidence pipeline was broken. It wasn't. Nothing had crashed — the container had been stopped, and `Created=10:05:45 / StartedAt=10:13:30 / Restarts=0` confirmed an external stop/start.

## Change

- Set a `terminating` flag in the TERM/INT trap so an intentional stop is reported as one.
- Name the plane that actually exited (`aimee-server` / `aimee-wfe`).
- Extract `plane_exit_message` as a **pure function** — args in, string out, no globals — because the entrypoint bootstraps PAM users and launches daemons and so cannot be sourced in a test.

The status code is unchanged; only the description of it changes. A real `exit 1` still reads as a failure.

## Test

`scripts/check-entrypoint-exit-report.sh`, wired into `LINT_CHECKS`. The entrypoint had **no test coverage at all** before this.

The load-bearing case is the third one: signalled and failed exits both carry status 1, so the test asserts the two messages *differ* — the property that was missing.

Red-before-green: reverted to the old behaviour, 4 of 6 assertions fail (both hardcoded-name cases, the signalled case, and the differ-despite-identical-status case); restored, all pass.

## Verification

- `make -C src lint` → `lint: all 37 checks passed`, exit 0.
- `bash -n` clean.

## Scope

This fixes the **reporting**, not any crash — there was no crash to fix. What made the incident expensive was being told a stop was a failure, in the wrong process, with a pointer to evidence that does not exist for a clean exit.

One note on what I did **not** change: `core_pattern` on the host is the bare relative string `core` with no `%p`, so successive crashes would overwrite one file with no PID attribution. `core-storage.sh` already warns about this in its non-required branch. That is worth a separate look, but it is a host-level sysctl and out of scope here.