### PR TITLE
fix: avoid phantom verify dependencies

### DIFF
--- a/src/modules/git/git_verify.c
+++ b/src/modules/git/git_verify.c
@@ -272,6 +272,7 @@ static int generate_project_yaml(const char *project_root, const char *output_pa
    dstr_append_str(&yaml, "  steps:\n");
 
    int emitted = 0;
+   int has_build = 0;
    int has_unit_tests = 0;
    if (make_output_has_target(out, "verify-local"))
    {
@@ -317,11 +318,18 @@ static int generate_project_yaml(const char *project_root, const char *output_pa
           * build-integrity also runs isolated make builds internally, so keep it
           * behind unit-tests when they exist; otherwise it can race with the
           * verify unit-test wave on generated build artifacts. */
-         if (strcmp(target, "unit-tests") == 0 || strcmp(target, "test") == 0)
+         if ((strcmp(target, "unit-tests") == 0 || strcmp(target, "test") == 0) && has_build)
             dstr_appendf(&yaml, "      after: build\n");
          else if (strcmp(target, "build-integrity") == 0)
-            dstr_appendf(&yaml, "      after: %s\n", has_unit_tests ? "unit-tests" : "build");
+         {
+            if (has_unit_tests)
+               dstr_appendf(&yaml, "      after: unit-tests\n");
+            else if (has_build)
+               dstr_appendf(&yaml, "      after: build\n");
+         }
 
+         if (strcmp(step_name, "build") == 0)
+            has_build = 1;
          if (strcmp(target, "unit-tests") == 0 || strcmp(target, "test") == 0)
             has_unit_tests = 1;
          emitted++;

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -1437,6 +1437,34 @@ static void test_verify_load_config_prefers_check_linking_for_build(void)
    verify_test_teardown(tmpdir, fake_home);
 }
 
+/* A small repository may expose only `make test`. The generated test step must
+ * not depend on a build step that was never emitted, or the wave scheduler can
+ * never submit it and reports exit -1 before running the repository's tests. */
+static void test_verify_load_config_test_only_has_no_missing_build_dependency(void)
+{
+   char tmpdir[256], fake_home[256];
+   verify_test_setup_repo(tmpdir, sizeof(tmpdir), "aimee-test-verify-test-only");
+   verify_test_set_fake_home(fake_home, sizeof(fake_home));
+
+   char makefile_path[512];
+   snprintf(makefile_path, sizeof(makefile_path), "%s/Makefile", tmpdir);
+   FILE *f = fopen(makefile_path, "w");
+   assert(f != NULL);
+   fputs(".PHONY: test\n"
+         "test:\n"
+         "\t@echo tests\n",
+         f);
+   fclose(f);
+
+   verify_config_t cfg;
+   assert(verify_load_config(tmpdir, &cfg) == 0);
+   assert(cfg.count == 1);
+   assert(strcmp(cfg.steps[0].name, "test") == 0);
+   assert(cfg.steps[0].after[0] == '\0');
+
+   verify_test_teardown(tmpdir, fake_home);
+}
+
 static void test_verify_load_config_normalizes_build_integrity_order(void)
 {
    char tmpdir[256], fake_home[256];
@@ -2448,6 +2476,7 @@ int main(void)
    test_verify_load_config_emits_parallel_steps();
    test_verify_load_config_collapses_generated_pipeline_to_verify_local();
    test_verify_load_config_prefers_check_linking_for_build();
+   test_verify_load_config_test_only_has_no_missing_build_dependency();
    test_verify_load_config_normalizes_build_integrity_order();
    test_verify_load_config_falls_back_to_verify_local();
    test_verify_load_config_old_flat_format_ignored();


### PR DESCRIPTION
## Summary
- only make generated test steps depend on `build` when a build step was emitted
- make `build-integrity` depend on the strongest emitted predecessor, or none
- cover test-only Make repositories with a regression test

## Validation
- `make -j2 build/obj/tests/unit-test-mcp-git && ./build/obj/tests/unit-test-mcp-git`
- `make bus-blast-radius-check` (all 7 shipping binaries inspected)
- `git diff --check`

## Live reproduction
Found while running the 0.3.0/testing E2E workflow in the isolated CT331 environment on 192.168.1.253. A test-only fixture generated a test step with `after: build` even though no build step existed, so workflow verification could never schedule the test.