### PR TITLE
Bootstrap first wizard user and managed KB-to-LLM auth

### DIFF
--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -49,6 +49,10 @@ services:
       # to BOTH sides. This is not the wizard user's bearer: it is the KB's own
       # identity for every embed, rerank, and synth request to its LLM.
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+      # Managed clients must never downgrade to keyless requests if credential
+      # injection is broken. Standalone/external deployments remain compatible
+      # unless they opt into this invariant themselves.
+      AIMEE_LLM_AUTH_REQUIRED: ${AIMEE_LLM_AUTH_REQUIRED:-0}
       # Legacy curator sidecars consume the generic OpenAI-compatible name.
       LLM_API_KEY: ${AIMEE_LLM_AUTH_TOKEN:-}
       # One stable model label is shared with the unified gateway. The gateway is
@@ -104,6 +108,9 @@ services:
       AIMEE_LLM_SYNTH_TIER: ${AIMEE_LLM_SYNTH_TIER:-cpu}
       AIMEE_LLM_SYNTH_URL: ${AIMEE_LLM_SYNTH_URL:-}
       AIMEE_LLM_SYNTH_MODEL: ${AIMEE_LLM_MODEL:-aimee-synth}
+      # Empty means derive the model's native dimension at runtime. A wizard or
+      # operator pin reaches both sides and the gateway rejects model drift.
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       # A local managed LLM is never allowed to start keyless. deploy_apply.c
       # generates/persists this before Compose sees the service.
       # Keep interpolation profile-safe: Compose expands inactive profiles too.

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -7,19 +7,25 @@ The standard backend is `aimee-llm` on the deployment network.
 
 In a wizard-managed deployment, starting the local LLM is also an identity transaction. The server
 generates a persistent 256-bit `AIMEE_LLM_AUTH_TOKEN`, passes it to the KB and LLM only, and configures
-the KB's unified endpoint and selected role tiers. Every embed, batch, rerank, and chat request carries
+`AIMEE_LLM_AUTH_REQUIRED=1` on the KB so none of its clients can silently downgrade to keyless access.
+It also configures the KB's unified endpoint and selected role tiers. Every embed, batch, rerank, and chat request carries
 that bearer. The gateway starts with its unauthenticated wildcard-bind guard enforced, so a missing
 credential fails deployment instead of silently trusting every container on the bridge. This service
 identity is distinct from browser login, first-user enrollment, and server-to-KB credentials.
 Setup reports success only after executing an authenticated `/auth/verify` request from inside the KB
 container, using the endpoint and bearer that the KB actually received.
 
+An external-only topology does not create this local service identity and defaults
+`AIMEE_LLM_AUTH_REQUIRED` to `0`; an operator may still set it to `1` together with the external
+gateway's bearer. This prevents the local-LLM security rule from disabling intentionally keyless
+external endpoints.
+
 The managed contract is explicit:
 
 | Consumer | Configuration received | Request surface |
 | --- | --- | --- |
 | `aimee-kb` | `AIMEE_LLM_URL=http://aimee-llm:8742`, `AIMEE_LLM_AUTH_TOKEN`, `AIMEE_LLM_MODEL` (default `aimee-synth`), and an optional pinned `AIMEE_EMBEDDING_DIM` | `/embed`, `/embed_batch`, `/rerank`, `/v1/chat/completions`, `/auth/verify` |
-| `aimee-llm` | the same `AIMEE_LLM_AUTH_TOKEN`; `AIMEE_LLM_{EMBED,RERANK,SYNTH}_{MODE,TIER,URL}`; `AIMEE_LLM_SYNTH_MODEL`; and the runtime GPU settings | serves a local role, proxies its configured external URL, or rejects an `off` role |
+| `aimee-llm` | the same `AIMEE_LLM_AUTH_TOKEN`; `AIMEE_LLM_{EMBED,RERANK,SYNTH}_{MODE,TIER,URL}`; `AIMEE_LLM_SYNTH_MODEL`; optional `AIMEE_EMBEDDING_DIM`; and the runtime GPU settings | serves a local role, proxies its configured external URL, or rejects an `off` role; rejects an embedding-dimension mismatch when pinned |
 | legacy KB curator sidecars | `LLM_API_KEY` aliasing the same service bearer | the unified gateway's OpenAI-compatible `/v1` surface |
 
 The role configuration and credential form one deployment transaction. The server does not report a

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -303,7 +303,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 218 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. Secrets and tokens should be supplied through the environment or credential vault, never committed.
+The binaries read 219 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. Secrets and tokens should be supplied through the environment or credential vault, never committed.
 
 ### Paths & assets
 
@@ -600,6 +600,7 @@ The binaries read 218 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_LLM_AUTH_REQUIRED` | Set to 1 on wizard-managed KBs so embed, rerank, and synthesis clients refuse to contact the unified LLM when its bearer service identity is missing. |
 | `AIMEE_LLM_AUTH_TOKEN` | Bearer service identity shared by aimee-kb and its aimee-llm gateway for embed, rerank, and synthesis requests. Wizard-managed deploys generate and persist a 256-bit value automatically. This is separate from user/server bearers. |
 | `AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE` | Explicit migration/adoption override for an existing wizard-managed LLM credential. Ordinary inherited AIMEE_LLM_AUTH_TOKEN is ignored by managed credential creation so stale child-service state cannot win. Must be a 32..512 character RFC 6750 b64token. |
 

--- a/docs/proposals/pending/wizard-first-user-bootstrap.md
+++ b/docs/proposals/pending/wizard-first-user-bootstrap.md
@@ -90,7 +90,8 @@ model and producing misleading diagnostics. The image and seeded config now pin 
    removes any inherited empty/stale duplicate, and passes one authoritative value to Compose.
 10. Compose gives the bearer and endpoint to the KB, requires the bearer for the LLM, enforces the
     gateway bind guard, and orders KB startup behind LLM health. Native embedding, batch embedding,
-    reranking, Tier-A extraction, and Tier-B synthesis all use the credential.
+    reranking, Tier-A extraction, and Tier-B synthesis all use the credential and fail closed if it
+    is absent. A pinned embedding dimension reaches both services and is enforced by the gateway.
 11. Before reporting deploy success, the orchestrator executes an authenticated `/auth/verify` from
     inside the KB container. This proves the actual endpoint and bearer installed in the KB, without
     putting the secret in the host command line or browser response.
@@ -101,12 +102,14 @@ model and producing misleading diagnostics. The image and seeded config now pin 
 | --- | --- | --- |
 | `aimee-kb` | `AIMEE_LLM_URL=http://aimee-llm:8742` | unified embed/rerank/synth base |
 | `aimee-kb` | `AIMEE_LLM_AUTH_TOKEN=<stable 256-bit bearer>` | service identity on every inference request |
+| `aimee-kb` | `AIMEE_LLM_AUTH_REQUIRED=1` | missing service identity is a configuration failure, never a keyless downgrade |
 | `aimee-kb` | `AIMEE_LLM_MODEL` (default `aimee-synth`) | chat/synthesis model label |
 | `aimee-kb` | `LLM_API_KEY=$AIMEE_LLM_AUTH_TOKEN` | compatibility alias for curator sidecars |
 | `aimee-kb` | `AIMEE_EMBEDDING_DIM` when pinned | DB2 vector width; otherwise derived from gateway health |
 | `aimee-llm` | same `AIMEE_LLM_AUTH_TOKEN`, `AIMEE_LLM_STRICT_BIND=1` | same identity and fail-closed wildcard bind |
 | `aimee-llm` | `AIMEE_LLM_{EMBED,RERANK,SYNTH}_{MODE,TIER,URL}` | per-role local/external/off routing and selected artifact tier |
 | `aimee-llm` | `AIMEE_LLM_SYNTH_MODEL=$AIMEE_LLM_MODEL` | shared model label |
+| `aimee-llm` | `AIMEE_EMBEDDING_DIM` when pinned | enforce the same vector width as the KB; empty derives the model-native width |
 
 The KB calls `/embed`, `/embed_batch`, `/rerank`, `/v1/chat/completions`, and `/auth/verify` on the
 unified base. If any role is external while another is local, the gateway receives and proxies that
@@ -132,6 +135,8 @@ operator decision.
 - The KB-to-LLM token is distinct from every user credential, stored mode `0600`, stable across
   redeploys, absent when no local LLM is created, and never rendered by the wizard.
 - A managed local LLM cannot start with authentication disabled.
+- A managed KB cannot issue embed, batch, rerank, or synth requests without its service bearer.
+- A pinned embedding dimension is identical on KB and LLM; model-output drift is rejected.
 
 ## User experience
 
@@ -174,6 +179,8 @@ and belongs to the same renewal/reset lifecycle scope called out below.
 
 `make -C src wizard-bootstrap-e2e` starts a fresh real server and client with isolated state and proves:
 
+- the server has no `AIMEE_SERVER_TEAM_ID`, server registry ID, or management JWKS bundle; the local
+  first-owner path is deliberately independent of the later KB-issued team-token authority;
 - wizard Deploy returns a pending bearer for `webuser:alice`;
 - bearer-only persona write is `403`;
 - `aimee remote set` generates the key/CSR and enrolls mTLS;
@@ -191,8 +198,9 @@ binary boundary checks must remain green.
 
 Managed-service tests additionally prove credential generation, `0600` persistence, restart
 stability, explicit operator override, absence outside the local-LLM profile, removal of inherited
-empty duplicates, gateway denial for absent/wrong bearers, and bearer propagation through embed,
-rerank, and curator clients.
+empty duplicates, gateway denial for absent/wrong bearers, client-side refusal when managed auth is
+missing, bearer propagation through embed, rerank, and curator clients, and embedding-dimension drift
+rejection.
 
 ### Executed validation
 
@@ -202,9 +210,13 @@ rerank, and curator clients.
   scoped, override-safe, and probed without a host-argv secret.
 - `src/build/obj/tests/unit-test-kb-curator-provider` — PASS: unified endpoint and service bearer reach
   both curator tiers.
-- `python3 scripts/check-sidecar-clients.py` — PASS: embed and rerank clients attach the bearer.
-- `python3 -m unittest -v scripts.tests.test_gateway scripts.tests.test_gateway_security` — 52 PASS,
-  2 dependency-only skips; absent/wrong managed tokens are 401 and the correct token verifies.
+- `src/build/obj/tests/unit-test-memory-embed-http-auth` — PASS: the native embed/batch client attaches
+  its bearer and refuses missing or oversized managed credentials before transport.
+- `python3 scripts/check-sidecar-clients.py` — PASS: embed and rerank clients attach the bearer and
+  fail before transport when managed auth is required but absent.
+- `python3 -m unittest -v scripts.tests.test_gateway scripts.tests.test_gateway_security` — 56 PASS,
+  2 dependency-only skips; every inference route rejects absent/wrong managed tokens, the correct
+  token succeeds, and a pinned dimension mismatch is a typed `503`.
 - `python3 scripts/check-kb-container-packaging.py --root .` and `--plant-test` — PASS: the complete
   managed role/identity contract is now a guarded packaging invariant.
 - `frontend` tests/check, `runtime-web` Go tests, `make -C src all`, `make -C src lint`,
@@ -231,4 +243,5 @@ rerank, and curator clients.
 - Regression proof: `scripts/test-wizard-first-user-bootstrap.sh`,
   `scripts/validate-managed-kb-llm-compose.sh`, `src/tests/test_remote_client_grant.c`,
   `src/tests/test_server_http.c`, `src/tests/test_deploy_apply.c`,
-  `src/tests/test_kb_curator_provider.c`, and gateway/sidecar tests.
+  `src/tests/test_kb_curator_provider.c`, `src/tests/test_memory_embed_http_auth.c`, and
+  gateway/sidecar tests.

--- a/frontend/src/setup/DeployPanel.tsx
+++ b/frontend/src/setup/DeployPanel.tsx
@@ -93,6 +93,7 @@ export default function DeployPanel({ kbMode }: { kbMode: 'local' | 'remote' }) 
   const [applying, setApplying] = useState(false);
   const [err, setErr] = useState('');
   const [enrollment, setEnrollment] = useState<Enrollment | null>(null);
+  const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const loadStatus = useCallback(async () => {
@@ -177,6 +178,15 @@ export default function DeployPanel({ kbMode }: { kbMode: 'local' | 'remote' }) 
     }
   }
 
+  async function copyEnrollment(command: string) {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+    } catch {
+      setErr('Could not copy automatically; select the command below and copy it manually.');
+    }
+  }
+
   if (kbMode !== 'local' || loading || !status) return null;
 
   // Orchestration off: hand the operator the one compose command instead.
@@ -239,7 +249,12 @@ export default function DeployPanel({ kbMode }: { kbMode: 'local' | 'remote' }) 
             locally, enrolls mTLS, and activates full write access for{' '}
             <code>{enrollment.principal}</code>.
           </div>
-          <pre style={pre}>{enrollmentCommand}</pre>
+          <div style={{ display: 'flex', alignItems: 'start', gap: 7 }}>
+            <pre style={{ ...pre, flex: 1 }}>{enrollmentCommand}</pre>
+            <Button onClick={() => copyEnrollment(enrollmentCommand)}>
+              {copied ? 'Copied' : 'Copy command'}
+            </Button>
+          </div>
           <div style={{ fontSize: 11.5, color: '#667', marginTop: 5 }}>
             The bearer alone cannot write; the full grant is bound to the enrolled client certificate.
           </div>

--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -50,9 +50,22 @@ RERANK_SEP = "</s>"
 # exercises the real kb -> gateway contract (and the /embed,/rerank,/v1/chat
 # shapes) cheaply. Vectors are deterministic per-input so retrieval is stable.
 STUB = os.environ.get("AIMEE_LLM_STUB", "") not in ("", "0", "false")
-STUB_DIM = int(os.environ.get("AIMEE_LLM_STUB_DIM")
-               or os.environ.get("EMBEDDER_STUB_DIM")
-               or "1024")
+
+
+def _optional_positive_env_int(name):
+    """Return a positive configured integer, or None to derive at runtime."""
+    try:
+        value = int(os.environ.get(name, "") or "0")
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+EXPECTED_EMBED_DIM = _optional_positive_env_int("AIMEE_EMBEDDING_DIM")
+STUB_DIM = (_optional_positive_env_int("AIMEE_LLM_STUB_DIM")
+            or _optional_positive_env_int("EMBEDDER_STUB_DIM")
+            or EXPECTED_EMBED_DIM
+            or 1024)
 
 
 def _stub_vec(text):
@@ -296,6 +309,17 @@ def embed_dim():
     return _embed_dim
 
 
+def _validate_embed_dim(vec):
+    """Enforce an optional wizard/operator pin; otherwise preserve native dim."""
+    if EXPECTED_EMBED_DIM is not None and len(vec) != EXPECTED_EMBED_DIM:
+        raise GatewayError(
+            503,
+            "embedding_dim_mismatch",
+            f"embedder returned {len(vec)} dimensions; expected {EXPECTED_EMBED_DIM}",
+        )
+    return vec
+
+
 # ---- handlers (call llama.cpp; the rerank head is the validated P2 path) ----
 
 _head = None
@@ -314,15 +338,21 @@ def _rerank_head():
 
 def do_embed(text):
     if STUB:
-        return _stub_vec(text)
-    return _embeddings(EMBED_URL, text)
+        vec = _stub_vec(text)
+    else:
+        vec = _embeddings(EMBED_URL, text)
+    return _validate_embed_dim(vec)
 
 
 def do_embed_batch(texts):
     validate_batch(texts)
     if STUB:
-        return [_stub_vec(t) for t in texts]
-    return _embeddings(EMBED_URL, list(texts)) if texts else []
+        vecs = [_stub_vec(t) for t in texts]
+    else:
+        vecs = _embeddings(EMBED_URL, list(texts)) if texts else []
+    for vec in vecs:
+        _validate_embed_dim(vec)
+    return vecs
 
 
 def do_rerank(obj):
@@ -635,13 +665,15 @@ def build_server():
 
         def do_POST(self):
             path = self.path.rstrip("/")
-            n = int(self.headers.get("content-length", "0") or "0")
-            raw = self.rfile.read(n) if n else b""
             try:
                 # §1a: every work request is authenticated; the scope is DERIVED from the
-                # identity (a caller-supplied X-Aimee-Scope is rejected).
+                # identity (a caller-supplied X-Aimee-Scope is rejected). Authenticate
+                # before reading the body so an untrusted bridge peer cannot hold a
+                # worker or force allocations with an unauthenticated Content-Length.
                 check_auth(self.headers.get("Authorization"))
                 scope = derive_scope(self.headers.get)
+                n = int(self.headers.get("content-length", "0") or "0")
+                raw = self.rfile.read(n) if n else b""
                 if path == "/auth/verify":
                     # Cheap deploy-time proof that the request came from a caller
                     # holding the configured service identity. No model role has

--- a/scripts/check-kb-container-packaging.py
+++ b/scripts/check-kb-container-packaging.py
@@ -395,6 +395,10 @@ def managed_kb_llm_contract_failures(text: str) -> list[str]:
     token_expr = "${AIMEE_LLM_AUTH_TOKEN:-}"
     if kb_env.get("AIMEE_LLM_AUTH_TOKEN") != token_expr:
         failures.append("managed KB must receive AIMEE_LLM_AUTH_TOKEN")
+    if kb_env.get("AIMEE_LLM_AUTH_REQUIRED") != "${AIMEE_LLM_AUTH_REQUIRED:-0}":
+        failures.append(
+            "managed KB auth-required mode must follow the local-LLM deployment transaction"
+        )
     if kb_env.get("LLM_API_KEY") != token_expr:
         failures.append("managed KB legacy curator token must alias AIMEE_LLM_AUTH_TOKEN")
     if llm_env.get("AIMEE_LLM_AUTH_TOKEN") != token_expr:
@@ -407,6 +411,8 @@ def managed_kb_llm_contract_failures(text: str) -> list[str]:
         failures.append("managed KB must receive the unified model label")
     if llm_env.get("AIMEE_LLM_SYNTH_MODEL") != "${AIMEE_LLM_MODEL:-aimee-synth}":
         failures.append("managed LLM synth model must match the KB model label")
+    if llm_env.get("AIMEE_EMBEDDING_DIM") != "${AIMEE_EMBEDDING_DIM:-}":
+        failures.append("managed LLM must receive the KB embedding-dimension pin")
 
     for role in ("EMBED", "RERANK", "SYNTH"):
         for setting, default in (("MODE", "local"), ("TIER", "cpu"), ("URL", "")):
@@ -643,6 +649,7 @@ def plant_test() -> int:
             '      AIMEE_KB_MTLS_PORT: "8745"\n'
             "      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8742}\n"
             "      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}\n"
+            "      AIMEE_LLM_AUTH_REQUIRED: ${AIMEE_LLM_AUTH_REQUIRED:-0}\n"
             "      LLM_API_KEY: ${AIMEE_LLM_AUTH_TOKEN:-}\n"
             "      AIMEE_LLM_MODEL: ${AIMEE_LLM_MODEL:-aimee-synth}\n"
             "    depends_on:\n"
@@ -660,7 +667,8 @@ def plant_test() -> int:
             "      AIMEE_LLM_SYNTH_MODE: ${AIMEE_LLM_SYNTH_MODE:-local}\n"
             "      AIMEE_LLM_SYNTH_TIER: ${AIMEE_LLM_SYNTH_TIER:-cpu}\n"
             "      AIMEE_LLM_SYNTH_URL: ${AIMEE_LLM_SYNTH_URL:-}\n"
-            "      AIMEE_LLM_SYNTH_MODEL: ${AIMEE_LLM_MODEL:-aimee-synth}\n",
+            "      AIMEE_LLM_SYNTH_MODEL: ${AIMEE_LLM_MODEL:-aimee-synth}\n"
+            "      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}\n",
             encoding="utf-8",
         )
         (root / "deploy/container/aimee-server-remote-writes.yaml").write_text(

--- a/scripts/check-sidecar-clients.py
+++ b/scripts/check-sidecar-clients.py
@@ -47,6 +47,25 @@ def _run(script: str, env: dict[str, str], stdin: str) -> str:
     return proc.stdout
 
 
+def _run_missing_managed_auth(script: str, endpoint_key: str, url: str, stdin: str) -> None:
+    env = {
+        **os.environ,
+        endpoint_key: url,
+        "AIMEE_LLM_AUTH_REQUIRED": "1",
+        "AIMEE_LLM_AUTH_TOKEN": "",
+    }
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / script)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode != 0, f"{script} accepted missing managed auth"
+    assert "AIMEE_LLM_AUTH_TOKEN is empty" in proc.stderr, proc.stderr
+
+
 def check_embed_remote() -> None:
     vector = [round(i * 0.001, 3) for i in range(384)]
     token = "kb-to-llm-test-token"
@@ -71,11 +90,16 @@ def check_embed_remote() -> None:
     try:
         out = _run(
             "embed-remote.py",
-            {"AIMEE_EMBEDDER_URL": url, "AIMEE_LLM_AUTH_TOKEN": token},
+            {
+                "AIMEE_EMBEDDER_URL": url,
+                "AIMEE_LLM_AUTH_TOKEN": token,
+                "AIMEE_LLM_AUTH_REQUIRED": "1",
+            },
             "hello world",
         )
         parsed = json.loads(out)
         assert isinstance(parsed, list) and len(parsed) == 384, f"got {len(parsed)} dims"
+        _run_missing_managed_auth("embed-remote.py", "AIMEE_EMBEDDER_URL", url, "hello")
     finally:
         server.shutdown()
     print("  embed-remote.py: ok")
@@ -104,10 +128,17 @@ def check_rerank_remote() -> None:
     try:
         out = _run(
             "rerank-remote.py",
-            {"AIMEE_RERANKER_URL": url, "AIMEE_LLM_AUTH_TOKEN": token},
+            {
+                "AIMEE_RERANKER_URL": url,
+                "AIMEE_LLM_AUTH_TOKEN": token,
+                "AIMEE_LLM_AUTH_REQUIRED": "1",
+            },
             '[["query", "candidate"]]',
         )
         assert json.loads(out) == [0.75]
+        _run_missing_managed_auth(
+            "rerank-remote.py", "AIMEE_RERANKER_URL", url, '[["query", "candidate"]]'
+        )
     finally:
         server.shutdown()
     print("  rerank-remote.py: ok")

--- a/scripts/embed-remote.py
+++ b/scripts/embed-remote.py
@@ -19,6 +19,7 @@ Config (env), in precedence order:
   AIMEE_LLM_URL       base URL of the unified aimee-llm container (one knob for
                       embed + rerank + synth); used when AIMEE_EMBEDDER_URL is unset
   AIMEE_LLM_AUTH_TOKEN bearer service identity for authenticated gateways
+  AIMEE_LLM_AUTH_REQUIRED=1 refuse requests when that identity is missing
   (unset)             no embedder configured; reported immediately so the caller
                       can use its builtin path. Pin the legacy compose service
                       with AIMEE_EMBEDDER_URL=http://embedder:8080 if wanted.
@@ -51,6 +52,16 @@ NO_ENDPOINT_MESSAGE = (
 )
 TIMEOUT = int(os.environ.get("AIMEE_EMBEDDER_TIMEOUT", "30"))
 AUTH_TOKEN = os.environ.get("AIMEE_LLM_AUTH_TOKEN", "")
+AUTH_REQUIRED = os.environ.get("AIMEE_LLM_AUTH_REQUIRED", "") == "1"
+
+
+def _auth_ready() -> bool:
+    if AUTH_REQUIRED and not AUTH_TOKEN:
+        sys.stderr.write(
+            "embed-remote: AIMEE_LLM_AUTH_REQUIRED=1 but AIMEE_LLM_AUTH_TOKEN is empty\n"
+        )
+        return False
+    return True
 
 
 def _headers(content_type: str) -> dict[str, str]:
@@ -74,6 +85,8 @@ def probe_dim() -> int:
     positive integer dim; exit non-zero (caller treats as 'not ready') while the
     model is still loading, on any HTTP/parse error, or on a missing/non-positive
     dim. Single GET, no embedding — cheap enough to poll."""
+    if not _auth_ready():
+        return 1
     if not ENDPOINT:
         sys.stderr.write(NO_ENDPOINT_MESSAGE)
         return 1
@@ -101,6 +114,8 @@ def probe_dim() -> int:
 def main() -> None:
     if "--dim" in sys.argv[1:]:
         sys.exit(probe_dim())
+    if not _auth_ready():
+        sys.exit(1)
     if not ENDPOINT:
         sys.stderr.write(NO_ENDPOINT_MESSAGE)
         sys.exit(1)

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -679,6 +679,7 @@ ENV_DESC = {
     # Knowledge base
     "AIMEE_LLM_URL": ("Knowledge base (aimee-kb)", "One knob: base URL of the aimee-llm container the kb calls for embedding (/embed), reranking (/rerank) AND synthesis (curator Tier-A + Tier-B at {url}/v1). The kb runs no model itself. AIMEE_EMBEDDER_URL/AIMEE_RERANKER_URL override per service. See docs/KB_LLM_BACKENDS.md."),
     "AIMEE_LLM_AUTH_TOKEN": ("Managed KB and inference", "Bearer service identity shared by aimee-kb and its aimee-llm gateway for embed, rerank, and synthesis requests. Wizard-managed deploys generate and persist a 256-bit value automatically. This is separate from user/server bearers."),
+    "AIMEE_LLM_AUTH_REQUIRED": ("Managed KB and inference", "Set to 1 on wizard-managed KBs so embed, rerank, and synthesis clients refuse to contact the unified LLM when its bearer service identity is missing."),
     "AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE": ("Managed KB and inference", "Explicit migration/adoption override for an existing wizard-managed LLM credential. Ordinary inherited AIMEE_LLM_AUTH_TOKEN is ignored by managed credential creation so stale child-service state cannot win. Must be a 32..512 character RFC 6750 b64token."),
     "AIMEE_LLM_MODEL": ("Knowledge base (aimee-kb)", "Model label sent to AIMEE_LLM_URL's chat endpoint (single-model gateways ignore it). Default 'aimee-synth'."),
     "AIMEE_EMBEDDER_URL": ("Knowledge base (aimee-kb)", "Embedder endpoint override (/embed, /embed_batch); takes precedence over AIMEE_LLM_URL for embedding."),

--- a/scripts/rerank-remote.py
+++ b/scripts/rerank-remote.py
@@ -25,6 +25,7 @@ Config (env), in precedence order:
   AIMEE_LLM_URL       base URL of the unified aimee-llm container (one knob for
                       embed + rerank + synth)
   AIMEE_LLM_AUTH_TOKEN bearer service identity for authenticated gateways
+  AIMEE_LLM_AUTH_REQUIRED=1 refuse requests when that identity is missing
   (unset)             no reranker configured; reported immediately. Pin the
                       legacy compose service explicitly if wanted.
   AIMEE_RERANK_TIMEOUT  request timeout seconds (default 30)
@@ -50,9 +51,15 @@ ENDPOINT = (
 ).rstrip("/")
 TIMEOUT = int(os.environ.get("AIMEE_RERANK_TIMEOUT", "30"))
 AUTH_TOKEN = os.environ.get("AIMEE_LLM_AUTH_TOKEN", "")
+AUTH_REQUIRED = os.environ.get("AIMEE_LLM_AUTH_REQUIRED", "") == "1"
 
 
 def main() -> None:
+    if AUTH_REQUIRED and not AUTH_TOKEN:
+        sys.stderr.write(
+            "rerank-remote: AIMEE_LLM_AUTH_REQUIRED=1 but AIMEE_LLM_AUTH_TOKEN is empty\n"
+        )
+        sys.exit(1)
     if not ENDPOINT:
         sys.stderr.write(
             "rerank-remote: no reranker configured "

--- a/scripts/tests/test_gateway.py
+++ b/scripts/tests/test_gateway.py
@@ -7,6 +7,7 @@ import importlib.util
 import io
 import json
 import os
+import socket
 import threading
 import unittest
 import urllib.error
@@ -35,6 +36,34 @@ class StartupEnvironment(unittest.TestCase):
         with mock.patch.dict(os.environ,
                              {"AIMEE_LLM_STUB_DIM": "", "EMBEDDER_STUB_DIM": "2560"}):
             self.assertEqual(_gw().STUB_DIM, 2560)
+
+    def test_embedding_dimension_pin_drives_stub_default(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "AIMEE_LLM_STUB_DIM": "",
+                "EMBEDDER_STUB_DIM": "",
+                "AIMEE_EMBEDDING_DIM": "3840",
+            },
+        ):
+            gw = _gw()
+            self.assertEqual(gw.EXPECTED_EMBED_DIM, 3840)
+            self.assertEqual(gw.STUB_DIM, 3840)
+
+    def test_embedding_dimension_drift_is_rejected(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "AIMEE_LLM_STUB": "1",
+                "AIMEE_LLM_STUB_DIM": "4",
+                "AIMEE_EMBEDDING_DIM": "3",
+            },
+        ):
+            gw = _gw()
+            with self.assertRaises(gw.GatewayError) as exc:
+                gw.do_embed("drift")
+            self.assertEqual(exc.exception.status, 503)
+            self.assertEqual(exc.exception.body["error"]["code"], "embedding_dim_mismatch")
 
     def test_empty_synth_discovery_values_use_defaults(self):
         with mock.patch.dict(os.environ,
@@ -440,6 +469,7 @@ class ManagedServiceAuth(unittest.TestCase):
                 "AIMEE_LLM_PORT": "0",
                 "AIMEE_LLM_BIND": "127.0.0.1",
                 "AIMEE_LLM_AUTH_TOKEN": "managed-kb-service-token",
+                "AIMEE_EMBEDDING_DIM": "",
             },
             clear=False,
         ):
@@ -468,12 +498,66 @@ class ManagedServiceAuth(unittest.TestCase):
         except urllib.error.HTTPError as exc:
             return exc.code, json.loads(exc.read())
 
+    def _post(self, path, payload, token=None, content_type="application/json"):
+        headers = {"Content-Type": content_type}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        data = payload if isinstance(payload, bytes) else json.dumps(payload).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}{path}",
+            data=data,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.status, json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.loads(exc.read())
+
     def test_only_the_managed_service_bearer_verifies(self):
         self.assertEqual(self._verify()[0], 401)
         self.assertEqual(self._verify("wrong")[0], 401)
         status, body = self._verify("managed-kb-service-token")
         self.assertEqual(status, 200)
         self.assertEqual(body, {"status": "ok", "scope": "curator"})
+
+    def test_unauthenticated_request_is_rejected_before_body_read(self):
+        with socket.create_connection(("127.0.0.1", self.port), timeout=2) as conn:
+            conn.settimeout(2)
+            conn.sendall(
+                b"POST /embed HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Length: 10000000\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            response = conn.recv(4096)
+        self.assertIn(b" 401 ", response.split(b"\r\n", 1)[0])
+
+    def test_all_kb_inference_routes_require_the_managed_bearer(self):
+        cases = (
+            ("/embed", b"hello", "text/plain"),
+            ("/embed_batch", ["hello", "world"], "application/json"),
+            ("/rerank", [["query", "candidate"]], "application/json"),
+            (
+                "/v1/chat/completions",
+                {"messages": [{"role": "user", "content": "hello"}]},
+                "application/json",
+            ),
+        )
+        for path, payload, content_type in cases:
+            with self.subTest(path=path):
+                self.assertEqual(self._post(path, payload, content_type=content_type)[0], 401)
+                self.assertEqual(
+                    self._post(path, payload, token="wrong", content_type=content_type)[0], 401
+                )
+                status, _ = self._post(
+                    path,
+                    payload,
+                    token="managed-kb-service-token",
+                    content_type=content_type,
+                )
+                self.assertEqual(status, 200)
 
 
 if __name__ == "__main__":

--- a/scripts/validate-managed-kb-llm-compose.sh
+++ b/scripts/validate-managed-kb-llm-compose.sh
@@ -41,6 +41,7 @@ export COMPOSE_PROFILES="kb,llm"
 export AIMEE_KB_IMAGE="$kb_base_image"
 export AIMEE_LLM_IMAGE="$llm_image"
 export AIMEE_LLM_AUTH_TOKEN="$token"
+export AIMEE_LLM_AUTH_REQUIRED="1"
 export AIMEE_LLM_MODEL="validation-synth"
 export AIMEE_LLM_EMBED_MODE="local"
 export AIMEE_LLM_EMBED_TIER="mid"
@@ -48,6 +49,7 @@ export AIMEE_LLM_RERANK_MODE="local"
 export AIMEE_LLM_RERANK_TIER="small"
 export AIMEE_LLM_SYNTH_MODE="local"
 export AIMEE_LLM_SYNTH_TIER="cpu"
+export AIMEE_EMBEDDING_DIM="1024"
 export AIMEE_VALIDATION_ROOT="$root"
 
 compose=(docker compose -f "$root/deploy/container/aimee-managed.compose.yaml" -f "$override")
@@ -59,6 +61,7 @@ compose=(docker compose -f "$root/deploy/container/aimee-managed.compose.yaml" -
 echo "managed-kb-llm: checking propagated identity and role configuration"
 "${compose[@]}" exec -T aimee-kb sh -ec '
   test "${#AIMEE_LLM_AUTH_TOKEN}" -eq 64
+  test "$AIMEE_LLM_AUTH_REQUIRED" = "1"
   test "$AIMEE_LLM_URL" = "http://aimee-llm:8742"
   test "$AIMEE_LLM_MODEL" = "validation-synth"
   test "$LLM_API_KEY" = "$AIMEE_LLM_AUTH_TOKEN"
@@ -70,6 +73,7 @@ echo "managed-kb-llm: checking propagated identity and role configuration"
   test "$AIMEE_LLM_RERANK_MODE/$AIMEE_LLM_RERANK_TIER" = "local/small"
   test "$AIMEE_LLM_SYNTH_MODE/$AIMEE_LLM_SYNTH_TIER" = "local/cpu"
   test "$AIMEE_LLM_SYNTH_MODEL" = "validation-synth"
+  test "$AIMEE_EMBEDDING_DIM" = "1024"
 '
 
 # Missing and incorrect credentials fail; the KB's actual environment succeeds.

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -93,6 +93,10 @@ int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
          base_url = synth_url;
          model = (env_model && env_model[0]) ? env_model : AIMEE_LLM_DEFAULT_MODEL;
          const char *service_token = getenv("AIMEE_LLM_AUTH_TOKEN");
+         const char *auth_required = getenv("AIMEE_LLM_AUTH_REQUIRED");
+         if (auth_required && strcmp(auth_required, "1") == 0 &&
+             (!service_token || !service_token[0]))
+            return 0; /* managed unified gateway must never receive a keyless request */
          api_key = (service_token && service_token[0]) ? service_token : "";
       }
       else if (kb_curator_stage_tier(stage) == KB_CURATOR_TIER_A)

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -1535,11 +1535,11 @@ typedef struct config
     *
     * Bounded so a compromised or looping enroller cannot grow the accepted set
     * without limit — past the cap, enrolment fails closed rather than evicting. */
-   /* 65 = 64 hex chars + NUL, the exact width server_api_mint_bearer emits.
-    * config_t is ~750 KB and is stack-allocated in hot paths, so every byte
-    * added here is multiplied across nested frames — sizing this generously
-    * would be paid for on the stack, not in the struct. */
-   char server_api_bearer_extra[AIMEE_API_BEARER_EXTRA_MAX][65];
+   /* Keep the existing configured-token width: deployments may already have
+    * manually supplied bearer_tokens_extra values longer than the 64-hex
+    * tokens minted by the enrollment API. Truncating them on upgrade would
+    * silently revoke those clients. */
+   char server_api_bearer_extra[AIMEE_API_BEARER_EXTRA_MAX][256];
    int server_api_bearer_extra_count;
    int server_api_rate_limit_per_min;
    /* server_api_max_event_streams: cap on concurrent SSE event streams
@@ -2133,7 +2133,7 @@ int config_load(config_t *cfg);
 
 /* Bounded enrolled-bearer operations owned by the config module. Callers get a
  * coherent copy or append one token without naming or copying config_t. */
-int config_server_api_bearer_extra_snapshot(char out[][65], int max);
+int config_server_api_bearer_extra_snapshot(char out[][256], int max);
 int config_server_api_bearer_extra_append(const char *bearer);
 
 /* Live config snapshot (live-config-reload P1a) — a double-buffer + seqlock holding the

--- a/src/modules/config/config_accessors_3.c
+++ b/src/modules/config/config_accessors_3.c
@@ -1118,7 +1118,7 @@ const char *config_computer_use_allowed_domains(int index)
 
 const char *config_server_api_bearer_extra(int index)
 {
-   static _Thread_local char buf[65];
+   static _Thread_local char buf[256];
    buf[0] = 0;
    if (index < 0 || index >= (AIMEE_API_BEARER_EXTRA_MAX))
       return buf;

--- a/src/modules/config/config_server_api.c
+++ b/src/modules/config/config_server_api.c
@@ -139,7 +139,7 @@ void config_parse_server_api(config_t *cfg, const cJSON *root)
    }
 }
 
-int config_server_api_bearer_extra_snapshot(char out[][65], int max)
+int config_server_api_bearer_extra_snapshot(char out[][256], int max)
 {
    if (!out || max <= 0)
       return 0;

--- a/src/modules/memory/memory_core_helpers_b.c
+++ b/src/modules/memory/memory_core_helpers_b.c
@@ -448,8 +448,13 @@ int memory_embed_http_post(const char *base, const char *path, const char *body,
    char auth[640];
    const char *auth_header = NULL;
    const char *token = getenv("AIMEE_LLM_AUTH_TOKEN");
+   const char *auth_required = getenv("AIMEE_LLM_AUTH_REQUIRED");
+   if (auth_required && strcmp(auth_required, "1") == 0 && (!token || !token[0]))
+      return -1;
    if (token && token[0])
    {
+      /* Managed tokens are capped at 512 bytes; this also rejects any longer
+       * external token instead of truncating an Authorization header. */
       int n = snprintf(auth, sizeof(auth), "Authorization: Bearer %s", token);
       if (n < 0 || (size_t)n >= sizeof(auth))
          return -1;

--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -240,7 +240,7 @@ static char **build_deploy_envp(char *err, size_t err_cap, int *managed_llm_out)
       if (*p == '\n')
          extra++;
 
-   char **envp = calloc(base + extra + (managed_llm ? 1 : 0) + 1, sizeof(char *));
+   char **envp = calloc(base + extra + (managed_llm ? 2 : 0) + 1, sizeof(char *));
    if (!envp)
    {
       if (err && err_cap)
@@ -254,7 +254,8 @@ static char **build_deploy_envp(char *err, size_t err_cap, int *managed_llm_out)
        * Do not leave an inherited empty/stale duplicate before it: getenv and
        * Compose are not required to choose the later duplicate. */
       if (deploy_env_overrides(env, *e) ||
-          (managed_llm && strncmp(*e, "AIMEE_LLM_AUTH_TOKEN=", 21) == 0))
+          (managed_llm && (strncmp(*e, "AIMEE_LLM_AUTH_TOKEN=", 21) == 0 ||
+                           strncmp(*e, "AIMEE_LLM_AUTH_REQUIRED=", 24) == 0)))
          continue;
       envp[n] = strdup(*e);
       if (!envp[n])
@@ -297,6 +298,13 @@ static char **build_deploy_envp(char *err, size_t err_cap, int *managed_llm_out)
       }
       snprintf(envp[n++], len + 1, "AIMEE_LLM_AUTH_TOKEN=%s", llm_token);
       memset(llm_token, 0, sizeof(llm_token));
+      envp[n] = strdup("AIMEE_LLM_AUTH_REQUIRED=1");
+      if (!envp[n])
+      {
+         free_envp(envp);
+         return NULL;
+      }
+      n++;
    }
    envp[n] = NULL;
    return envp;

--- a/src/server/server_bearer_auth.c
+++ b/src/server/server_bearer_auth.c
@@ -25,7 +25,7 @@
  * dispatch-backed routes run on detached connection workers, so authorization,
  * enrollment and rotation genuinely execute concurrently. One lock protects
  * both this set and the primary bearer stored by server_http.c. */
-static char g_bearer_extra[AIMEE_API_BEARER_EXTRA_MAX][65];
+static char g_bearer_extra[AIMEE_API_BEARER_EXTRA_MAX][256];
 static int g_bearer_extra_count = 0;
 static pthread_mutex_t g_bearer_lock = PTHREAD_MUTEX_INITIALIZER;
 /* The DB claim and config publication form one cross-store transaction. Serialize
@@ -150,14 +150,14 @@ static int bearer_sha256(const char *bearer, char out[65])
    return 0;
 }
 
-static int configured_bearer_snapshot(char out[][65])
+static int configured_bearer_snapshot(char out[][256])
 {
    return config_server_api_bearer_extra_snapshot(out, AIMEE_API_BEARER_EXTRA_MAX);
 }
 
 static void publish_configured_bearers(void)
 {
-   char configured[AIMEE_API_BEARER_EXTRA_MAX][65];
+   char configured[AIMEE_API_BEARER_EXTRA_MAX][256];
    const char *extra[AIMEE_API_BEARER_EXTRA_MAX];
    int count = configured_bearer_snapshot(configured);
    if (count < 0)
@@ -170,7 +170,7 @@ static void publish_configured_bearers(void)
 /* Return the configured cleartext bearer whose digest is |wanted|.  Cleartext
  * remains in the existing protected config because the HTTP authenticator needs
  * it; DB1 stores only the digest used to attach identity/grant metadata. */
-static int configured_bearer_for_hash(char configured[][65], int count, const char *wanted,
+static int configured_bearer_for_hash(char configured[][256], int count, const char *wanted,
                                       char *out, size_t out_cap)
 {
    if (!configured || count < 0 || !wanted || !out || out_cap < 65)
@@ -180,6 +180,11 @@ static int configured_bearer_for_hash(char configured[][65], int count, const ch
       char digest[65];
       if (bearer_sha256(configured[i], digest) == 0 && server_ct_equal(digest, wanted))
       {
+         if (strlen(configured[i]) + 1 > out_cap)
+         {
+            OPENSSL_cleanse(digest, sizeof(digest));
+            return 0;
+         }
          snprintf(out, out_cap, "%s", configured[i]);
          OPENSSL_cleanse(digest, sizeof(digest));
          return 1;
@@ -191,13 +196,14 @@ static int configured_bearer_for_hash(char configured[][65], int count, const ch
 
 static int first_user_bootstrap_locked(const char *principal, char *bearer, size_t bearer_cap)
 {
+   int result = -1;
    if (bearer && bearer_cap)
       bearer[0] = '\0';
    if (!principal || strncmp(principal, "webuser:", 8) != 0 || !principal[8] || !bearer ||
        bearer_cap < 65)
       return -1;
 
-   char configured[AIMEE_API_BEARER_EXTRA_MAX][65];
+   char configured[AIMEE_API_BEARER_EXTRA_MAX][256];
    int configured_count = configured_bearer_snapshot(configured);
    if (configured_count < 0 || !config_server_api_bearer_token()[0] ||
        config_server_api_mtls() <= 0)
@@ -209,44 +215,56 @@ static int first_user_bootstrap_locked(const char *principal, char *bearer, size
    char proposed[65] = "";
    char proposed_hash[65] = "";
    if (platform_random_hex(proposed, 64) != 0 || bearer_sha256(proposed, proposed_hash) != 0)
-      return -1;
+      goto done;
 
    db1_remote_client_grant_t grant;
    db1_remote_client_claim_result_t claimed =
        db1_remote_client_claim(principal, proposed_hash, (int64_t)time(NULL), &grant);
    if (claimed == DB1_REMOTE_CLIENT_CLAIM_OWNED_BY_OTHER)
-      return -2;
+   {
+      result = -2;
+      goto done;
+   }
    if (claimed == DB1_REMOTE_CLIENT_CLAIM_BOUND)
-      return 1;
+   {
+      result = 1;
+      goto done;
+   }
    if (claimed == DB1_REMOTE_CLIENT_CLAIM_UNBOUND)
    {
       if (configured_bearer_for_hash(configured, configured_count, grant.bearer_sha256, bearer,
                                      bearer_cap))
-         return 0;
+      {
+         result = 0;
+         goto done;
+      }
       /* A crash may have committed DB1 just before the config write.  That row
        * never authenticated and is safe to abandon; retry once with the newly
        * generated value rather than leaving setup permanently wedged. */
       if (db1_remote_client_abandon(grant.bearer_sha256) != 0)
-         return -1;
+         goto done;
       claimed = db1_remote_client_claim(principal, proposed_hash, (int64_t)time(NULL), &grant);
    }
    if (claimed != DB1_REMOTE_CLIENT_CLAIM_NEW || configured_count >= AIMEE_API_BEARER_EXTRA_MAX)
    {
       if (claimed == DB1_REMOTE_CLIENT_CLAIM_NEW)
          (void)db1_remote_client_abandon(proposed_hash);
-      return -1;
+      goto done;
    }
 
    if (config_server_api_bearer_extra_append(proposed) != 0)
    {
       (void)db1_remote_client_abandon(proposed_hash);
-      return -1;
+      goto done;
    }
    publish_configured_bearers();
    snprintf(bearer, bearer_cap, "%s", proposed);
+   result = 0;
+
+done:
    OPENSSL_cleanse(proposed, sizeof(proposed));
    OPENSSL_cleanse(proposed_hash, sizeof(proposed_hash));
-   return 0;
+   return result;
 }
 
 int server_http_first_user_bootstrap(const char *principal, char *bearer, size_t bearer_cap)

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -2343,18 +2343,18 @@ int server_http_start(const char *uds_path, int tcp_port, int tls_port, const ch
    {
    case SERVER_WRITE_TIER_CONFIG_NO_TEAM:
       LOG_ERROR("server.http",
-                "AIMEE_SERVER_TEAM_ID is unset or invalid: reads continue, but every /v1 write "
-                "will be denied with no_team_configured until it is set to this server's team id");
+                "AIMEE_SERVER_TEAM_ID is unset or invalid: KB-issued write tokens are denied "
+                "with no_team_configured; a verified certificate-bound first owner is unaffected");
       break;
    case SERVER_WRITE_TIER_CONFIG_NO_SERVER_ID:
       LOG_ERROR("server.http",
-                "AIMEE_SERVER_ID is unset: reads continue, but every /v1 write will be denied "
-                "with invalid until it is set to this server's enrolled registry id");
+                "AIMEE_SERVER_ID is unset: KB-issued write tokens are denied with invalid; "
+                "a verified certificate-bound first owner is unaffected");
       break;
    case SERVER_WRITE_TIER_CONFIG_NO_TRUST_BUNDLE:
       LOG_ERROR("server.http",
-                "AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE is unset: reads continue, but every /v1 "
-                "write will be denied with invalid until the management trust bundle is mounted");
+                "AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE is unset: KB-issued write tokens are denied "
+                "with invalid; a verified certificate-bound first owner is unaffected");
       break;
    case SERVER_WRITE_TIER_CONFIG_READY:
       break;

--- a/src/server/server_http_config_routes.c
+++ b/src/server/server_http_config_routes.c
@@ -923,7 +923,8 @@ static int deploy_route_guard(char *resp, int cap)
 
 /* POST /v1/deploy/apply — bring up the managed sibling services (aimee-kb +
  * aimee-llm) for the current wizard config via `docker compose up -d`
- * on a background thread. Returns {ok, status:"started"|"running"}. */
+ * on a background thread. The response also carries the authenticated first
+ * user's recoverable enrollment state and, until pairing, its bearer. */
 int rh_deploy_apply(const route_req_t *rq, char *resp, int cap)
 {
    (void)rq;

--- a/src/server/server_write_tier.c
+++ b/src/server/server_write_tier.c
@@ -41,8 +41,8 @@ static int team_is_enrolled(const server_write_tier_config_t *config, int64_t te
    return 0;
 }
 
-/* A server with no configured team authorizes nobody. That is a deployment
- * error, not a token error, and the two must not report identically. */
+/* A server with no configured team authorizes no KB-issued identity token.
+ * That is a deployment error, not a token error, and the two must not report identically. */
 static int server_has_no_team(const server_write_tier_config_t *config)
 {
    return !config->enrolled_teams || config->enrolled_team_count == 0;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -362,6 +362,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-rel-types \
                $(TESTPREFIX)/unit-test-memory-fact-gate \
                $(TESTPREFIX)/unit-test-memory-embed-dim-guard \
+               $(TESTPREFIX)/unit-test-memory-embed-http-auth \
                $(TESTPREFIX)/unit-test-rel-types-store \
                $(TESTPREFIX)/unit-test-entity-registry \
                $(TESTPREFIX)/unit-test-fact-lifecycle \
@@ -1065,6 +1066,12 @@ $(TESTPREFIX)/unit-test-memory-embed-dim-guard: $(OBJDIR)/tests/test_memory_embe
                     $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o \
                     $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o \
                     $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-memory-embed-http-auth: \
+                    $(OBJDIR)/tests/test_memory_embed_http_auth.o \
+                    $(OBJDIR)/modules/memory/memory_core_helpers_b.o \
+                    $(OBJDIR)/tests/support/mock_agent_http.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-rules: $(OBJDIR)/tests/test_rules.o $(DB1_OBJS) $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -238,8 +238,8 @@ int main(void)
       cfg.server_api_bearer_extra_count = 2;
       snprintf(cfg.server_api_bearer_extra[0], sizeof(cfg.server_api_bearer_extra[0]),
                "tok-client-one");
-      snprintf(cfg.server_api_bearer_extra[1], sizeof(cfg.server_api_bearer_extra[1]),
-               "tok-client-two");
+      memset(cfg.server_api_bearer_extra[1], 'x', 180);
+      cfg.server_api_bearer_extra[1][180] = '\0';
       cfg.server_api_rate_limit_per_min = 60;
       cfg.server_api_max_event_streams = 512;
       snprintf(cfg.server_api_client_transport, sizeof(cfg.server_api_client_transport), "http");
@@ -501,7 +501,8 @@ int main(void)
       assert(strcmp(cfg2.server_api_bearer_token, "tok-api-xyz") == 0);
       assert(cfg2.server_api_bearer_extra_count == 2);
       assert(strcmp(cfg2.server_api_bearer_extra[0], "tok-client-one") == 0);
-      assert(strcmp(cfg2.server_api_bearer_extra[1], "tok-client-two") == 0);
+      assert(strlen(cfg2.server_api_bearer_extra[1]) == 180);
+      assert(strspn(cfg2.server_api_bearer_extra[1], "x") == 180);
       assert(cfg2.server_api_rate_limit_per_min == 60);
       assert(cfg2.server_api_max_event_streams == 512);
       assert(strcmp(cfg2.server_api_client_transport, "http") == 0);

--- a/src/tests/test_deploy_apply.c
+++ b/src/tests/test_deploy_apply.c
@@ -96,6 +96,8 @@ static void test_managed_llm_service_credential(void)
    for (size_t i = 0; i < 64; i++)
       assert(token[i] == 'a');
    assert(envp_key_count(envp, "AIMEE_LLM_AUTH_TOKEN") == 1);
+   assert(strcmp(envp_value(envp, "AIMEE_LLM_AUTH_REQUIRED"), "1") == 0);
+   assert(envp_key_count(envp, "AIMEE_LLM_AUTH_REQUIRED") == 1);
    assert(setenv("COMPOSE_PROFILES", "attacker-profile", 1) == 0);
    free_envp(envp);
    envp = build_deploy_envp(NULL, 0, NULL);
@@ -118,10 +120,13 @@ static void test_managed_llm_service_credential(void)
 
    /* Inherited empty OR non-empty child state cannot shadow the managed file. */
    assert(setenv("AIMEE_LLM_AUTH_TOKEN", "stale-inherited-service-token-1234", 1) == 0);
+   assert(setenv("AIMEE_LLM_AUTH_REQUIRED", "0", 1) == 0);
    envp = build_deploy_envp(NULL, 0, NULL);
    assert(envp_key_count(envp, "AIMEE_LLM_AUTH_TOKEN") == 1);
    token = envp_value(envp, "AIMEE_LLM_AUTH_TOKEN");
    assert(token != NULL && token[0] == 'a');
+   assert(strcmp(envp_value(envp, "AIMEE_LLM_AUTH_REQUIRED"), "1") == 0);
+   assert(envp_key_count(envp, "AIMEE_LLM_AUTH_REQUIRED") == 1);
    free_envp(envp);
 
    /* A distinctly named, deliberate operator override wins exactly once. */
@@ -150,10 +155,12 @@ static void test_managed_llm_service_credential(void)
 
    /* No local LLM means no credential is invented or passed. */
    unsetenv("AIMEE_LLM_AUTH_TOKEN");
+   unsetenv("AIMEE_LLM_AUTH_REQUIRED");
    snprintf(g_stub_profiles, sizeof(g_stub_profiles), "kb");
    managed_llm = 1;
    envp = build_deploy_envp(NULL, 0, &managed_llm);
    assert(envp != NULL && envp_value(envp, "AIMEE_LLM_AUTH_TOKEN") == NULL);
+   assert(envp_value(envp, "AIMEE_LLM_AUTH_REQUIRED") == NULL);
    assert(managed_llm == 0);
    free_envp(envp);
 

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -16,6 +16,7 @@ static void clear_llm_env(void)
    unsetenv("AIMEE_LLM_URL");
    unsetenv("AIMEE_LLM_MODEL");
    unsetenv("AIMEE_LLM_AUTH_TOKEN");
+   unsetenv("AIMEE_LLM_AUTH_REQUIRED");
 }
 
 static void test_tier_classification(void)
@@ -162,6 +163,13 @@ static void test_aimee_llm_url(void)
    setenv("AIMEE_LLM_AUTH_TOKEN", "kb-to-llm-service-token", 1);
    assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 1);
    assert(b.api_key && strcmp(b.api_key, "kb-to-llm-service-token") == 0);
+
+   /* Managed mode must not silently downgrade the unified gateway to keyless. */
+   unsetenv("AIMEE_LLM_AUTH_TOKEN");
+   setenv("AIMEE_LLM_AUTH_REQUIRED", "1", 1);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 0);
+   setenv("AIMEE_LLM_AUTH_TOKEN", "kb-to-llm-service-token", 1);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 1);
 
    /* Trailing slash and an already-/v1 URL both normalize to exactly one /v1. */
    setenv("AIMEE_LLM_URL", "http://host:8742/", 1);

--- a/src/tests/test_memory_embed_http_auth.c
+++ b/src/tests/test_memory_embed_http_auth.c
@@ -1,0 +1,59 @@
+/* Native KB embed client: managed service auth must propagate and fail closed. */
+#include "support/mock_agent_http.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int memory_embed_http_post(const char *base, const char *path, const char *body, char **resp);
+
+static int s_posts;
+
+static int post_ok(const char *url, const char *auth_header, const char *body, char **response_buf,
+                   int timeout_ms, const char *extra_headers)
+{
+   (void)timeout_ms;
+   (void)extra_headers;
+   s_posts++;
+   assert(strcmp(url, "http://aimee-llm:8742/embed") == 0);
+   assert(auth_header && strcmp(auth_header, "Authorization: Bearer kb-service-token") == 0);
+   assert(strcmp(body, "probe") == 0);
+   *response_buf = strdup("[1.0]");
+   return 200;
+}
+
+int main(void)
+{
+   char *resp = NULL;
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(post_ok);
+
+   setenv("AIMEE_LLM_AUTH_REQUIRED", "1", 1);
+   setenv("AIMEE_LLM_AUTH_TOKEN", "kb-service-token", 1);
+   assert(memory_embed_http_post("http://aimee-llm:8742/", "/embed", "probe", &resp) == 0);
+   assert(resp && strcmp(resp, "[1.0]") == 0);
+   free(resp);
+   assert(s_posts == 1);
+
+   /* A managed KB never issues an unauthenticated request. */
+   unsetenv("AIMEE_LLM_AUTH_TOKEN");
+   resp = NULL;
+   assert(memory_embed_http_post("http://aimee-llm:8742", "/embed", "probe", &resp) == -1);
+   assert(resp == NULL);
+   assert(s_posts == 1);
+
+   /* Header construction must fail rather than truncate an external token. */
+   char oversized[700];
+   memset(oversized, 'a', sizeof(oversized) - 1);
+   oversized[sizeof(oversized) - 1] = '\0';
+   setenv("AIMEE_LLM_AUTH_TOKEN", oversized, 1);
+   assert(memory_embed_http_post("http://aimee-llm:8742", "/embed", "probe", &resp) == -1);
+   assert(s_posts == 1);
+
+   unsetenv("AIMEE_LLM_AUTH_REQUIRED");
+   unsetenv("AIMEE_LLM_AUTH_TOKEN");
+   mock_agent_http_reset();
+   puts("memory-embed-http-auth: bearer propagated; managed missing/oversized token denied");
+   return 0;
+}

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -912,7 +912,7 @@ int main(void)
       const char *e2 = "enrolled-two-cccccccccccccccccccccccccc";
       const char *extra[] = {e1, e2};
 
-      char hdr[128];
+      char hdr[384];
       snprintf(hdr, sizeof(hdr), "Bearer %s", primary);
       assert(server_http_authorize_multi(1, primary, extra, 2, hdr, NULL, 0) == 0);
 
@@ -966,6 +966,18 @@ int main(void)
       assert(server_http_enrolled_bearer_count() == 0);
       assert(server_http_authorize_enrolled(1, live, hdr, NULL, 0) == 401);
       assert(server_http_authorize_enrolled(1, live, "Bearer rotated-primary", NULL, 0) == 0);
+
+      /* bearer_tokens_extra predates wizard enrollment and permits existing
+       * operator-supplied values longer than the new 64-hex minted token. An
+       * upgrade must not truncate and silently revoke those clients. */
+      char long_token[192];
+      memset(long_token, 'L', sizeof(long_token) - 1);
+      long_token[sizeof(long_token) - 1] = '\0';
+      const char *long_extra[] = {long_token};
+      server_http_set_bearer_extra(long_extra, 1);
+      snprintf(hdr, sizeof(hdr), "Bearer %s", long_token);
+      assert(server_http_authorize_enrolled(1, live, hdr, NULL, 0) == 0);
+      server_http_set_bearer_extra(NULL, 0);
 
       printf("  PASS: authorize_multi accepts every enrolled client, rejects the rest\n");
    }

--- a/src/tests/test_server_management_tls.c
+++ b/src/tests/test_server_management_tls.c
@@ -1,4 +1,6 @@
-#include "config.h"
+#include <stdint.h>
+
+#include "config_accessors.h"
 #include "log.h"
 #include "pki.h"
 #include "server_conn_io.h"
@@ -25,19 +27,13 @@ const char *config_default_dir(void)
 {
    return "/nonexistent";
 }
-int config_load(config_t *cfg)
-{
-   memset(cfg, 0, sizeof(*cfg));
-   cfg->server_api_mtls = g_default_mtls_mode;
-   return 0;
-}
 int config_server_api_mtls(void)
 {
    return g_default_mtls_mode;
 }
 const char *config_server_api_mtls_client_ca(void)
 {
-   return "";
+   return "/nonexistent/tls/client-ca.crt";
 }
 int pki_ca_ensure(void)
 {


### PR DESCRIPTION
## Summary

- bootstrap the first wizard user as an immutable DB1 owner, using an enrollment-only bearer to bind a locally generated client certificate
- enforce certificate-backed write tiers, live revocation checks, bounded/serialized enrollment claims, and fail-closed bearer handling
- provision a stable private KB-to-LLM service bearer and an exact role/model/dimension contract for managed deployments
- authenticate LLM work routes before request-body reads, retain safe external-only defaults, and verify the deployed KB-to-LLM credential after Compose startup
- update the wizard UI and quickstart with a one-click enrollment command and document the managed/external backend behavior
- integrate the TLS test seam with the new config-accessor boundary introduced on testing

## Self-review fixes

- preserved compatibility for existing operator-supplied bearer values longer than newly minted tokens
- made managed local LLM auth authoritative while leaving external-only deployments opt-in
- moved gateway authentication ahead of body reads to reject unauthenticated oversized requests immediately
- check config reload before starting a deployment and cleanse temporary bearer/hash buffers on every exit path

## Validation

- `make -C src -j4 all`
- `make -C src -j4 unit-tests` (P1 PostgreSQL RLS gate skipped locally because `AIMEE_TEST_PG_URL` is unset; CI provisions pgvector)
- `make -C src lint` (all 37 checks)
- `make -C src wizard-bootstrap-e2e`
- frontend: 114 tests and TypeScript check
- gateway: 40 tests passed, 2 optional NumPy rerank tests skipped
- KB container packaging and sidecar-client checks
- `go test ./...` in runtime-web