### PR TITLE
test: isolate managed validation workspace volume

### DIFF
--- a/deploy/container/aimee-managed.validation.override.yaml
+++ b/deploy/container/aimee-managed.validation.override.yaml
@@ -6,6 +6,15 @@ networks:
     external: false
     name: ${COMPOSE_PROJECT_NAME}-network
 
+# The production manifest shares the server's durable workspace volume by its
+# fixed external name. This validator does not launch a server and must not
+# depend on (or attach to) a live server project, so give the otherwise-empty
+# read-only mount its own disposable project-local volume.
+volumes:
+  aimee-server-workspaces:
+    external: false
+    name: ${COMPOSE_PROJECT_NAME}-server-workspaces
+
 services:
   aimee-kb:
     volumes:


### PR DESCRIPTION
## Summary

- override the production external workspace volume in the managed KB/LLM validation stack
- give each validation project its own disposable workspace volume
- keep validation independent from and isolated from live server deployments

## Validation

- `git diff --check`
- `python3 scripts/check-kb-container-packaging.py`
- `scripts/validate-managed-kb-llm-compose.sh` on clean CT331 against the current testing source and exact testing base images
- verified validation containers, network, and volumes are removed after completion