### PR TITLE
Isolate managed validation workspace volume

### DIFF
--- a/deploy/container/aimee-managed.validation.override.yaml
+++ b/deploy/container/aimee-managed.validation.override.yaml
@@ -6,6 +6,13 @@ networks:
     external: false
     name: ${COMPOSE_PROJECT_NAME}-network
 
+volumes:
+  # The managed compose file normally reads the server-owned workspace volume.
+  # Validation must not depend on or mount production state.
+  aimee-server-workspaces:
+    external: false
+    name: ${COMPOSE_PROJECT_NAME}-server-workspaces
+
 services:
   aimee-kb:
     volumes:


### PR DESCRIPTION
## Summary
- replace the production external workspace volume with a project-scoped disposable volume in the managed KB/LLM validation overlay
- keep live validation independent of existing Aimee deployments

## Validation
- exact merged PR #2109 source built on .253 CT101
- managed KB/LLM Compose validation passed on .253 after this override
- KB container packaging check passed
- sidecar client check passed
- git diff check passed