### PR TITLE
fix(wfe): freeze slices against latest feature tip

### DIFF
--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -80,6 +80,89 @@ func TestIntegrateFeatureBasePicksUpSiblingMerge(t *testing.T) {
 	}
 }
 
+// A slice freeze must review only that slice's delta over the latest feature
+// tip. Forge merges advance origin/aimee/feat/<parent>, not the stale local ref;
+// using the local ref makes later slice artifacts include every landed sibling
+// and causes strict scope review to reject unrelated prerequisite work as drift.
+func TestFreezeUsesMergedRemoteFeatureTip(t *testing.T) {
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	repo := filepath.Join(root, "repo")
+	gitRun(t, root, "init", "--bare", "-b", "trunk", origin)
+	gitRun(t, root, "clone", origin, repo)
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("root\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "README")
+	gitRun(t, repo, "commit", "-m", "init")
+	gitRun(t, repo, "push", "-u", "origin", "trunk")
+
+	feature := "aimee/feat/wi_parent"
+	gitRun(t, repo, "branch", feature)
+	gitRun(t, repo, "push", "origin", feature)
+
+	store, err := db1.Open(filepath.Join(root, "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := t.Context()
+	for _, in := range []db1.CreateWorkItem{
+		{ID: "wi_parent", Repo: repo, ProposalPath: "p", WorkflowName: "build", StartStage: "feature"},
+		{ID: "wi_child", Repo: repo, ProposalPath: "c", WorkflowName: "slice", StartStage: "freeze", ParentID: "wi_parent"},
+	} {
+		if err := store.CreateWorkItem(ctx, in); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manager, err := NewWorktreeManager(store, filepath.Join(root, "trees"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.WorkItem(ctx, "wi_child")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workdir, _, err := manager.Ensure(ctx, child, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a sibling PR merging after this child worktree was created.
+	landed := filepath.Join(root, "landed")
+	gitRun(t, root, "clone", "-b", feature, origin, landed)
+	if err := os.WriteFile(filepath.Join(landed, "sibling.txt"), []byte("landed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, landed, "add", "sibling.txt")
+	gitRun(t, landed, "commit", "-m", "sibling")
+	gitRun(t, landed, "push", "origin", feature)
+	if park, err := integrateFeatureBase(ctx, workdir, "wi_parent"); err != nil || park != "" {
+		t.Fatalf("integrateFeatureBase: park=%q err=%v", park, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(workdir, "child.txt"), []byte("child\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, workdir, "add", "child.txt")
+	gitRun(t, workdir, "commit", "-m", "child")
+
+	runner := &NativeRunner{db: store, worktrees: manager}
+	result, err := runner.freeze(ctx, StepRequest{WorkItem: child})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StepAdvanced {
+		t.Fatalf("freeze status=%q detail=%q", result.Status, result.Detail)
+	}
+	if strings.Contains(result.Artifact, "sibling.txt") {
+		t.Fatalf("freeze leaked previously merged sibling work:\n%s", result.Artifact)
+	}
+	if !strings.Contains(result.Artifact, "child.txt") {
+		t.Fatalf("freeze omitted this slice's change:\n%s", result.Artifact)
+	}
+}
+
 func TestIntegrateFeatureBaseNoopWhenAlreadyCurrent(t *testing.T) {
 	repo, slicedir := setupSliceRepo(t)
 	_ = repo

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -619,7 +619,15 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 	}
 	base := ""
 	if item.ParentID != "" {
-		base = "aimee/feat/" + item.ParentID
+		// Slice PRs merge through the forge, which advances the remote feature
+		// branch while the local aimee/feat/<parent> ref stays at the run's
+		// starting point.  Freeze against the same fetched feature tip used by
+		// slice creation/integration; otherwise every later slice's review
+		// artifact incorrectly includes all previously merged sibling work.
+		base = featureBaseRef(ctx, workdir, item.ParentID)
+		if base == "" {
+			return StepResult{}, errors.New("parent feature branch is unavailable")
+		}
 	} else {
 		trunk, e := repoDefaultBranch(ctx, workdir)
 		if e != nil {


### PR DESCRIPTION
## Summary
- resolve a child slice freeze base through the fetched remote feature ref
- exclude already-merged sibling changes from later slice review artifacts
- add a regression that advances the remote feature branch after child worktree creation

## Live reproduction
Triggered build wi_336dac53920577bf399fbafb0b0a2ea6: later documentation slice repeatedly reviewed prior implementation/test work because freeze used the stale local parent feature ref.

## Validation
- go test ./... (server-go)
- make lint (src; all 37 checks passed)
- git diff --check