### PR TITLE
fix: report the build version over MCP

### DIFF
--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -19,7 +19,7 @@
 
 #define MCP_LINE_MAX         65536
 #define MCP_PROTOCOL_VERSION "2024-11-05"
-#define MCP_VERSION          "0.2.0"
+#define MCP_VERSION          AIMEE_VERSION
 
 #define DEFAULT_TIMEOUT_MS  30000
 #define DELEGATE_TIMEOUT_MS 300000

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -555,8 +555,12 @@ static void test_resources_read_config(void)
    cJSON *cfg = cJSON_Parse(text->valuestring);
    assert(cfg != NULL);
    cJSON *version = cJSON_GetObjectItemCaseSensitive(cfg, "version");
+   cJSON *mcp_version = cJSON_GetObjectItemCaseSensitive(cfg, "mcpVersion");
    cJSON *session = cJSON_GetObjectItemCaseSensitive(cfg, "sessionId");
    assert(cJSON_IsString(version));
+   assert(strcmp(version->valuestring, AIMEE_VERSION) == 0);
+   assert(cJSON_IsString(mcp_version));
+   assert(strcmp(mcp_version->valuestring, AIMEE_VERSION) == 0);
    assert(cJSON_IsString(session));
    assert(strcmp(session->valuestring, "test-session") == 0);
 
@@ -671,6 +675,9 @@ static void test_initialize(void)
    assert(cJSON_IsObject(info));
    cJSON *name = cJSON_GetObjectItemCaseSensitive(info, "name");
    assert(cJSON_IsString(name) && strcmp(name->valuestring, "aimee") == 0);
+   cJSON *server_version = cJSON_GetObjectItemCaseSensitive(info, "version");
+   assert(cJSON_IsString(server_version));
+   assert(strcmp(server_version->valuestring, AIMEE_VERSION) == 0);
 
    cJSON *instructions = cJSON_GetObjectItemCaseSensitive(result, "instructions");
    assert(cJSON_IsString(instructions));


### PR DESCRIPTION
## Summary

- replace the stale hard-coded MCP implementation version with the canonical build version
- report the same exact version from MCP initialization and the `aimee://config` resource
- add regression assertions for both protocol surfaces

The 0.3.0 testing client currently advertises `0.2.0`; release-tagged builds should advertise their actual build version.

## Validation

- `git diff --check`
- `make -C src -j12 build/obj/tests/unit-test-cli-mcp-serve`
- `./src/build/obj/tests/unit-test-cli-mcp-serve`