### PR TITLE
fix(wfe): expire routed pending delegate jobs

### DIFF
--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -386,10 +386,12 @@ func (c *HTTPAgentClient) delegateOnce(ctx context.Context, request DelegateRequ
 			// when the status plane later fails so a retry cannot overlap the job.
 			return DelegateResult{}, delegateExecutionError(err, true, false, 0)
 		}
-		// Any nonterminal status without an assigned agent is not progress. The
-		// resource plane can mark a job running before admission assigns an agent,
-		// so status alone cannot end the unassigned lease.
-		assigned := strings.TrimSpace(status.Agent) != ""
+		// Any nonterminal status without a worker lease is not progress. The
+		// resource plane persists agent_name as soon as routing selects an agent,
+		// while the job is still pending; only its transition to running proves a
+		// worker actually started. Treating a routed pending job as assigned makes
+		// it immortal when capacity never admits it.
+		assigned := status.JobStatus == "running" && strings.TrimSpace(status.Agent) != ""
 		terminal := isTerminalDelegateStatus(status.JobStatus)
 		if !assigned && !terminal {
 			if unassignedSince.IsZero() {

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -732,6 +732,48 @@ func TestHTTPAgentClientExpiresUnassignedPendingJob(t *testing.T) {
 	}
 }
 
+func TestHTTPAgentClientExpiresRoutedPendingJob(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var cancellations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 23})
+		case "/v1/delegate/status":
+			// Routing records agent_name before a worker takes the lease. A
+			// pending row is therefore still unassigned even with this field set.
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "pending", "agent_name": "codex"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
+		PollEvery: time.Millisecond, PendingTimeout: MinDelegatePendingTimeout,
+		CancelUnassigned: func(context.Context, int, string, time.Duration) (bool, error) {
+			cancellations.Add(1)
+			return true, nil
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review",
+		Delegate: "codex", WorkItemID: "wi_routed_pending", Stage: "gate", ExecutionVersion: "v1"}
+	if _, err := client.Delegate(t.Context(), request); err == nil || !errors.Is(err, ErrDelegateUnassignedExpired) {
+		t.Fatalf("routed pending job did not expire as unassigned: %v", err)
+	}
+	if cancellations.Load() != 1 {
+		t.Fatalf("cancellations=%d, want 1", cancellations.Load())
+	}
+	if _, _, err := store.DelegateJob(t.Context(), delegateJobKey(request)); err == nil {
+		t.Fatal("expired routed pending job retained its durable mapping")
+	}
+}
+
 func TestHTTPAgentClientExpiresUnassignedRunningJob(t *testing.T) {
 	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- keep routed `pending` delegate jobs under the unassigned lease
- treat only `running` plus an agent name as proof a worker started
- add regression coverage for the routed-but-never-admitted state

## Live failure

Triggered workflow `wi_f2c5624449fc682401dc67e0012283f2` produced review job 158 with `status=pending`, `agent_name=codex`, no heartbeat, and idle delegates. It remained pending beyond `autonomy.delegate_pending_secs=120` because route selection was mistaken for worker assignment.

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- focused routed/unassigned lease tests after rebase