### PR TITLE
fix: name an unauthenticated kb instead of calling it unreachable

### DIFF
--- a/src/modules/kb_client/kb_client_grants.c
+++ b/src/modules/kb_client/kb_client_grants.c
@@ -40,6 +40,11 @@ static kb_client_grant_result_t result_from_status(int status)
       return KB_CLIENT_GRANT_OK;
    case 400:
       return KB_CLIENT_GRANT_INVALID;
+   case 401:
+      /* kb answered, so it is neither unreachable nor unusable: it rejected this server's
+       * credential. Falling through to UNAVAILABLE sent operators to debug kb's health and
+       * the network while the actual fault — an unenrolled server — went unnamed. */
+      return KB_CLIENT_GRANT_UNAUTHENTICATED;
    case 403:
       return KB_CLIENT_GRANT_DENIED;
    case 405:

--- a/src/modules/kb_client/kb_client_grants.h
+++ b/src/modules/kb_client/kb_client_grants.h
@@ -36,7 +36,13 @@ extern "C"
       /* kb was unreachable, timed out, or answered something unusable. Deliberately NOT
        * merged with DENIED: reporting an unreachable kb as a refusal is a lie about
        * authority, and would have an operator editing grants that were never consulted. */
-      KB_CLIENT_GRANT_UNAVAILABLE
+      KB_CLIENT_GRANT_UNAVAILABLE,
+      /* kb answered 401: it is reachable and healthy, but THIS SERVER has no accepted
+       * credential for it — typically a missing or unconsumed AIMEE_KB_CONN enrollment, so
+       * $AIMEE_HOME/kb-client-identity.json was never written. Deliberately NOT merged with
+       * UNAVAILABLE: an operator told "kb is unreachable" checks the network and kb's
+       * health, both of which are fine, instead of enrolling the server. */
+      KB_CLIENT_GRANT_UNAUTHENTICATED
    } kb_client_grant_result_t;
 
    /* What a set replaced, as kb observed it atomically. */

--- a/src/server/server_http_grant_routes.c
+++ b/src/server/server_http_grant_routes.c
@@ -68,6 +68,13 @@ static int grant_status(kb_client_grant_result_t rc, char *resp, int cap)
                       "authority, and the (server, team) pair must be registered");
    case KB_CLIENT_GRANT_BACKEND:
       return err_json(resp, cap, 503, "grant administration requires kb on the postgres backend");
+   case KB_CLIENT_GRANT_UNAUTHENTICATED:
+      /* Names the server's own missing enrollment. Reported as 502 rather than 401 so it is
+       * never read as the CALLER's credential being at fault: the caller reached this route
+       * over the local UDS, and it is this server that kb refused. */
+      return err_json(resp, cap, 502,
+                      "kb refused this server's credentials: it has no kb client identity. "
+                      "Complete the AIMEE_KB_CONN enrollment and restart the server");
    case KB_CLIENT_GRANT_UNAVAILABLE:
    default:
       return err_json(resp, cap, 503, "kb is unreachable; no grant was changed");

--- a/src/tests/test_grant_composed.c
+++ b/src/tests/test_grant_composed.c
@@ -387,6 +387,9 @@ static void test_kb_failures_surface(void)
    } cases[] = {{KB_CLIENT_GRANT_DENIED, 403},
                 {KB_CLIENT_GRANT_BACKEND, 503},
                 {KB_CLIENT_GRANT_UNAVAILABLE, 503},
+                /* An unenrolled server must not read as an unreachable kb (503) nor as the
+                 * caller's own credential being refused (401). */
+                {KB_CLIENT_GRANT_UNAUTHENTICATED, 502},
                 {KB_CLIENT_GRANT_INVALID, 400}};
    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
    {

--- a/src/tests/test_kb_client_grants.c
+++ b/src/tests/test_kb_client_grants.c
@@ -154,9 +154,10 @@ static void test_status_mapping(void)
       int status;
       kb_client_grant_result_t want;
    } cases[] = {
-       {400, KB_CLIENT_GRANT_INVALID},     {403, KB_CLIENT_GRANT_DENIED},
-       {405, KB_CLIENT_GRANT_INVALID},     {503, KB_CLIENT_GRANT_BACKEND},
-       {500, KB_CLIENT_GRANT_UNAVAILABLE}, {502, KB_CLIENT_GRANT_UNAVAILABLE},
+       {400, KB_CLIENT_GRANT_INVALID},     {401, KB_CLIENT_GRANT_UNAUTHENTICATED},
+       {403, KB_CLIENT_GRANT_DENIED},      {405, KB_CLIENT_GRANT_INVALID},
+       {503, KB_CLIENT_GRANT_BACKEND},     {500, KB_CLIENT_GRANT_UNAVAILABLE},
+       {502, KB_CLIENT_GRANT_UNAVAILABLE},
    };
    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i)
    {


### PR DESCRIPTION
## Problem

`aimee kb grant set` reports **"kb is unreachable; no grant was changed"** when kb is reachable, healthy, and answering.

kb returns `401 {"error":"authentication required"}` when it rejects *this server's* credential — typically a missing or unconsumed `AIMEE_KB_CONN` enrollment, so `$AIMEE_HOME/kb-client-identity.json` was never written. `result_from_status()` had no `401` case, so it fell through `default` → `KB_CLIENT_GRANT_UNAVAILABLE` → "unreachable".

This is the exact misdiagnosis the surrounding code already guards against for `DENIED` vs `UNAVAILABLE`:

> UNAVAILABLE must not become 403 — telling somebody they lack authority when kb was simply unreachable sends them to edit grants that were never consulted.

The 401 case has the same failure mode in the other direction: the operator debugs the network and kb's health, both of which are fine, while the real fault — an unenrolled server — goes unnamed.

Observed on a live deployment, where it cost hours before the 401 was seen directly by curling the route.

## Change

- Add `KB_CLIENT_GRANT_UNAUTHENTICATED` and map `401` to it.
- Give it an operator-facing message that names the actual fix (complete the `AIMEE_KB_CONN` enrollment and restart).
- Report it as **502**, not 401, so it is never read as the *caller's* credential being at fault: the caller reached this route over the local UDS, and it is this server that kb refused.

## Tests

`test_status_mapping` covered 400/403/405/500/502/503 but **not** 401 — that gap is why this shipped. Added the 401 case there and pinned the 502 in `test_grant_composed`.

Passing locally:

- `unit-test-kb-client-grants`
- `unit-test-grant-composed`
- `unit-test-kb-http-grants`
- `unit-test-remote-client-grant`
- `make lint` (38 checks)