### PR TITLE
fix: stop kb status hiding backlog and degradation on a thin client

### DIFF
--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -1630,17 +1630,57 @@ void pt_print_kb_ingest_status(const char *method, cJSON *resp)
       }
    }
 }
+/* Renders what kb_service_kb.c actually sends. Three fields used to be dropped
+ * on the floor, and each omission read as good news:
+ *
+ *   summary_status  the server's OWN degraded/maintenance verdict (vector down,
+ *                   re-embed stuck). Omitting it makes a degraded kb look fine.
+ *   queue           the real backlog. A kb with thousands pending and hundreds
+ *                   failed rendered as "Background ingest: 0 pending", because
+ *                   ingest_queue is a DIFFERENT queue that is legitimately 0.
+ *   vector          points live nested under it; the old code read a top-level
+ *                   "vector_points" this route has never emitted, so the line
+ *                   was dead and the store always looked empty.
+ *
+ * A status command that hides backlog and degradation is worse than no status
+ * command: it is consulted precisely when someone suspects trouble. */
 void pt_print_kb_status(const char *method, cJSON *resp)
 {
    cJSON *proj = cJSON_GetObjectItemCaseSensitive(resp, "project");
    cJSON *chunks = cJSON_GetObjectItemCaseSensitive(resp, "chunks");
-   cJSON *vpts = cJSON_GetObjectItemCaseSensitive(resp, "vector_points");
+   cJSON *summary = cJSON_GetObjectItemCaseSensitive(resp, "summary_status");
    if (cJSON_IsString(proj))
       printf("project: %s\n", proj->valuestring);
+   if (cJSON_IsString(summary))
+      printf("status:        %s\n", summary->valuestring);
    if (cJSON_IsNumber(chunks))
       printf("chunks:        %d\n", (int)chunks->valuedouble);
-   if (cJSON_IsNumber(vpts))
-      printf("vector points: %d\n", (int)vpts->valuedouble);
+
+   cJSON *vec = cJSON_GetObjectItemCaseSensitive(resp, "vector");
+   if (cJSON_IsObject(vec))
+   {
+      cJSON *kbp = cJSON_GetObjectItemCaseSensitive(vec, "kb_points");
+      cJSON *memp = cJSON_GetObjectItemCaseSensitive(vec, "memory_points");
+      if (cJSON_IsNumber(kbp) || cJSON_IsNumber(memp))
+         printf("vector points: %d kb, %d memory\n",
+                cJSON_IsNumber(kbp) ? (int)kbp->valuedouble : 0,
+                cJSON_IsNumber(memp) ? (int)memp->valuedouble : 0);
+   }
+
+   /* Printed whenever the server sent it, including all-zero: "0 failed" is a
+    * fact an operator wants confirmed, not an absence to be inferred. */
+   cJSON *q = cJSON_GetObjectItemCaseSensitive(resp, "queue");
+   if (cJSON_IsObject(q))
+   {
+      cJSON *qp = cJSON_GetObjectItemCaseSensitive(q, "pending");
+      cJSON *qr = cJSON_GetObjectItemCaseSensitive(q, "running");
+      cJSON *qf = cJSON_GetObjectItemCaseSensitive(q, "failed");
+      printf("Queue:     %d pending, %d running, %d failed\n",
+             cJSON_IsNumber(qp) ? (int)qp->valuedouble : 0,
+             cJSON_IsNumber(qr) ? (int)qr->valuedouble : 0,
+             cJSON_IsNumber(qf) ? (int)qf->valuedouble : 0);
+   }
+
    cJSON *iq = cJSON_GetObjectItemCaseSensitive(resp, "ingest_queue");
    if (cJSON_IsObject(iq))
    {

--- a/src/tests/test_cli_v1_subcommands.c
+++ b/src/tests/test_cli_v1_subcommands.c
@@ -13,9 +13,13 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
+#include "cJSON.h"
 #include "cli_client.h"
+#include "cli_v1_routes_internal.h"
 
 /* A command that is not in the table at all: must report zero and must not walk
  * into the NULL sentinel. This is the segfault guard. */
@@ -98,6 +102,61 @@ static void test_bare_and_matchany_rows_excluded(void)
    printf("  bare / match-any rows excluded\n");
 }
 
+/* `aimee kb status` against a remote server dropped the three fields that carry
+ * bad news. The payload below is the real one observed from a deployment whose
+ * kb had a 5601-job backlog with 75 failures: it rendered as
+ *
+ *   project: aimee
+ *   chunks:        0
+ *   Background ingest: 0 pending, 0 done last 24h
+ *
+ * i.e. idle and healthy. ingest_queue is a genuinely different queue and was
+ * genuinely 0; the backlog lives in `queue`, which was never read. */
+static void test_kb_status_reports_backlog_and_degradation(void)
+{
+   static const char *payload =
+       "{\"summary_status\":\"degraded\",\"project\":\"aimee\",\"files\":0,\"chunks\":0,"
+       "\"queue\":{\"pending\":5601,\"running\":0,\"done\":362,\"failed\":75,\"total\":6038},"
+       "\"vector\":{\"memory_points\":640,\"kb_points\":5983,\"status\":\"ok\"},"
+       "\"ingest_queue\":{\"pending\":0,\"running\":0,\"done_last_24h\":0}}";
+   cJSON *resp = cJSON_Parse(payload);
+   assert(resp);
+
+   char path[] = "/tmp/aimee-kbstatus-XXXXXX";
+   int fd = mkstemp(path);
+   assert(fd >= 0);
+   fflush(stdout);
+   int saved = dup(STDOUT_FILENO);
+   assert(saved >= 0);
+   assert(dup2(fd, STDOUT_FILENO) >= 0);
+
+   pt_print_kb_status("kb.status", resp);
+
+   fflush(stdout);
+   assert(dup2(saved, STDOUT_FILENO) >= 0);
+   close(saved);
+   close(fd);
+
+   FILE *f = fopen(path, "r");
+   assert(f);
+   char out[2048] = "";
+   size_t n = fread(out, 1, sizeof(out) - 1, f);
+   out[n] = '\0';
+   fclose(f);
+   unlink(path);
+   cJSON_Delete(resp);
+
+   /* The backlog and the failures must both be visible. */
+   assert(strstr(out, "5601") != NULL);
+   assert(strstr(out, "75") != NULL);
+   /* The server's own verdict must not be silently dropped. */
+   assert(strstr(out, "degraded") != NULL);
+   /* Vector points live nested under `vector`, not at the top level. */
+   assert(strstr(out, "5983") != NULL);
+   assert(strstr(out, "640") != NULL);
+   printf("  kb status surfaces backlog, failures, and degraded verdict\n");
+}
+
 int main(void)
 {
    printf("test_cli_v1_subcommands\n");
@@ -106,6 +165,7 @@ int main(void)
    test_list_formatting();
    test_small_buffer_does_not_overflow();
    test_bare_and_matchany_rows_excluded();
+   test_kb_status_reports_backlog_and_degradation();
    printf("test_cli_v1_subcommands: all passed\n");
    return 0;
 }


### PR DESCRIPTION
## Problem

`aimee kb status` against a remote server drops the three response fields that carry bad news — and every omission reads as good news.

`kb_service_kb.c:57-78` sends:

- `summary_status` — the server's **own** verdict, flipped to `degraded`/`maintenance` when the vector store is down or a re-embed is stuck
- `queue` — the real job backlog (`pending`/`running`/`failed`/`total`)
- `vector` — points, **nested** (`kb_points`, `memory_points`)

`pt_print_kb_status` (`cli_v1_routes_c.c`) read none of them. It read a top-level `vector_points` that this route has never emitted — dead code, so the store always looked empty — and printed `ingest_queue`, a *different* queue that is legitimately zero here.

On a live deployment whose kb had **5601 jobs pending and 75 failed**, the entire human-readable output was:

```
project: aimee
chunks:        0
Background ingest: 0 pending, 0 done last 24h
```

Idle and healthy. The backlog, the failures, and any degraded verdict were invisible; only `--json` showed them.

A status command is consulted precisely when someone suspects trouble. Hiding trouble is worse than printing nothing — this is the same failure mode the codebase already guards against elsewhere, where reporting one condition as another "sends them to check the wrong thing."

## Change

Render what the server actually sends: `summary_status`, the `queue` counters, and vector points from their nested location.

The queue line prints even when all zero — "0 failed" is a fact an operator wants confirmed, not an absence to be inferred from a missing line.

## Tests

No test covered this renderer, which is why it shipped. The new case in `test_cli_v1_subcommands` pins the **real observed payload** and asserts the backlog, failure count, degraded verdict, and both point counts all appear.

Verified red-before-green: against the original renderer it fails at
`test_kb_status_reports_backlog_and_degradation: Assertion 'strstr(out, "5601") != NULL' failed`.

`make lint` — 38 checks pass.