### PR TITLE
fix: a provider outage must not permanently fail curator jobs

### DIFF
--- a/src/kb_curator_extract.h
+++ b/src/kb_curator_extract.h
@@ -2,6 +2,7 @@
 #define DEC_KB_CURATOR_EXTRACT_H 1
 
 #include <stddef.h> /* size_t */
+#include <stdint.h> /* int64_t */
 
 typedef struct
 {
@@ -14,6 +15,18 @@ typedef struct
  * Invokes the sidecar, writes artifacts to DB2, marks job done or failed.
  * Returns 1 if a job was processed, 0 if queue is empty, -1 on hard error. */
 int kb_curator_extract_one(const kb_curator_extract_opts_t *opts);
+
+/* 1 when the failure means "the provider would not serve this right now"
+ * (503/429/transport) rather than anything about the job itself. Such a failure
+ * must not spend the job's attempt budget: the budget exists to stop a poison
+ * job looping, and an upstream outage is not a poison job. Exposed for tests. */
+int kb_curator_error_is_provider_unavailable(const char *error_msg);
+
+/* Requeue a job the provider refused, WITHOUT spending an attempt: returns the
+ * row to 'pending', gives back the increment ce_claim_job applied, and sets a
+ * backoff. Exposed for tests. */
+void kb_curator_mark_retry_provider_unavailable(int64_t job_id, int attempts,
+                                                const char *error_msg);
 
 /* Claim and process one pending extract_code_unit job from kb_code_unit_jobs.
  * Reads source file from the filesystem, invokes the sidecar with

--- a/src/modules/kb-synthesis/kb_curator_extract.c
+++ b/src/modules/kb-synthesis/kb_curator_extract.c
@@ -214,9 +214,74 @@ static void ce_mark_done(int64_t job_id)
    aimee_pg_finalize(st);
 }
 
+/* Is this failure the PROVIDER being unavailable, rather than anything about the
+ * job? 503/429 and a -1 transport failure all mean "the upstream would not serve
+ * this right now" — the document was never looked at, so the outcome carries no
+ * information about whether it can be extracted.
+ *
+ * Matched on the message because that is what the call site has: provider_client
+ * reports "provider HTTP %d" and the sidecar path forwards it verbatim. */
+int kb_curator_error_is_provider_unavailable(const char *error_msg)
+{
+   if (!error_msg || !error_msg[0])
+      return 0;
+   return strstr(error_msg, "provider HTTP 503") != NULL ||
+          strstr(error_msg, "provider HTTP 429") != NULL ||
+          strstr(error_msg, "provider HTTP -1") != NULL;
+}
+
+/* Requeue WITHOUT spending an attempt: undo the increment ce_claim_job applied,
+ * and back off.
+ *
+ * A provider outage used to burn the whole budget in seconds. The upstream
+ * gateway opens a circuit breaker and then refuses everything for its cooldown,
+ * so three claims inside one cooldown drove a job straight to terminal 'failed'
+ * — permanent, unreviewed data loss from a condition that heals itself a minute
+ * later. Observed on a live deployment: every failed row sat at exactly
+ * attempts=3 with last_error "provider HTTP 503".
+ *
+ * The budget exists to stop a POISON JOB looping forever. An outage is not a
+ * poison job, and spending the budget on it protects nothing. The row stays
+ * 'pending' for as long as the provider is down; next_attempt_at bounds the
+ * retry load, and the operator sees the backlog in `aimee kb status`. */
+void kb_curator_mark_retry_provider_unavailable(int64_t job_id, int attempts, const char *error_msg)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return;
+
+   char err[CE_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn,
+                        "UPDATE kb_async_jobs"
+                        " SET status = 'pending', last_error = ?1,"
+                        "     attempts = CASE WHEN attempts > 0 THEN attempts - 1 ELSE 0 END,"
+                        "     next_attempt_at = ?3, updated_at = pg_now_text()"
+                        " WHERE id = ?2",
+                        err, sizeof(err));
+   if (!st)
+      return;
+   char errbuf[512];
+   snprintf(errbuf, sizeof(errbuf), "%s", error_msg ? error_msg : "provider unavailable");
+   aimee_pg_bind_text(st, "?1", errbuf);
+   aimee_pg_bind_int64(st, "?2", job_id);
+   /* Back off on the attempt number we just gave back, so a long outage still
+    * lengthens the interval instead of hammering a breaker that is open. */
+   char next_at[32];
+   kb_curator_next_attempt_at(attempts > 0 ? attempts : 1, next_at, sizeof(next_at));
+   aimee_pg_bind_text(st, "?3", next_at);
+   (void)aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+}
+
 static void ce_mark_retry_or_fail(int64_t job_id, int attempts, int max_attempts,
                                   const char *error_msg)
 {
+   if (kb_curator_error_is_provider_unavailable(error_msg))
+   {
+      kb_curator_mark_retry_provider_unavailable(job_id, attempts, error_msg);
+      return;
+   }
    void *conn = db2_conn();
    if (!conn)
       return;

--- a/src/tests/test_curator_queue.c
+++ b/src/tests/test_curator_queue.c
@@ -21,6 +21,36 @@
 #include "../kb/kb_memory_facts.h"
 #include "config.h"
 
+/* An upstream outage must not be charged to the job. The gateway opens a circuit
+ * breaker and 503s everything for its cooldown, so three claims inside one
+ * cooldown used to drive a job to terminal 'failed' — permanent data loss from a
+ * condition that heals in a minute. Observed live: every failed row at exactly
+ * attempts=3, last_error "provider HTTP 503".
+ *
+ * Classification is what decides retry-vs-terminal, so pin it directly: a
+ * provider-availability failure is distinguishable from a real job failure. */
+static void test_provider_unavailable_is_not_a_job_failure(void)
+{
+   /* The breaker's own 503, and the two other ways the upstream declines. */
+   assert(kb_curator_error_is_provider_unavailable("provider HTTP 503"));
+   assert(kb_curator_error_is_provider_unavailable("provider HTTP 429"));
+   assert(kb_curator_error_is_provider_unavailable("provider HTTP -1"));
+
+   /* A 4xx that is ABOUT the request, a malformed reply, and a missing document
+    * are all real job failures: retrying them forever would be the poison-job
+    * loop the attempt budget exists to stop. */
+   assert(!kb_curator_error_is_provider_unavailable("provider HTTP 400"));
+   assert(!kb_curator_error_is_provider_unavailable("provider HTTP 422"));
+   assert(!kb_curator_error_is_provider_unavailable("sidecar returned non-JSON"));
+   assert(!kb_curator_error_is_provider_unavailable("kb_documents row not found"));
+   assert(!kb_curator_error_is_provider_unavailable("artifact write failed"));
+
+   /* Absent/empty error text must not be guessed into a retry. */
+   assert(!kb_curator_error_is_provider_unavailable(NULL));
+   assert(!kb_curator_error_is_provider_unavailable(""));
+   printf("  PASS: provider-unavailable is classified apart from job failure\n");
+}
+
 static sqlite3 *open_db(void)
 {
    db2_test_shim_open();
@@ -187,11 +217,11 @@ static void test_retry_backoff_defers_reclaim(sqlite3 *db)
    seed(db, "UPDATE kb_async_jobs SET status='done' WHERE status='pending'");
 
    seed(db, "INSERT INTO kb_documents (id,project,file_path,file_hash,chunk_index,content,doc_kind)"
-            " VALUES (9101,'p','bo.md','boh',0,'t','')");
+            " VALUES (9401,'p','bo.md','boh',0,'t','')");
    /* Backoff still running: the job is pending but must be passed over. */
    seed(db,
         "INSERT INTO kb_async_jobs (id,kind,document_id,project,status,attempts,next_attempt_at)"
-        " VALUES (9101,'extract_doc',9101,'p','pending',1,'2999-01-01 00:00:00')");
+        " VALUES (9401,'extract_doc',9401,'p','pending',1,'2999-01-01 00:00:00')");
 
    kb_curator_extract_opts_t opts;
    memset(&opts, 0, sizeof(opts));
@@ -199,13 +229,13 @@ static void test_retry_backoff_defers_reclaim(sqlite3 *db)
    snprintf(opts.extract_command, sizeof(opts.extract_command), "%s", "true");
 
    (void)kb_curator_extract_one(&opts);
-   assert(job_attempts(db, 9101) == 1); /* untouched: still deferred */
-   assert(strcmp(job_status(db, 9101), "pending") == 0);
+   assert(job_attempts(db, 9401) == 1); /* untouched: still deferred */
+   assert(strcmp(job_status(db, 9401), "pending") == 0);
 
    /* Backoff elapsed: claimable again. */
-   seed(db, "UPDATE kb_async_jobs SET next_attempt_at='2000-01-01 00:00:00' WHERE id=9101");
+   seed(db, "UPDATE kb_async_jobs SET next_attempt_at='2000-01-01 00:00:00' WHERE id=9401");
    (void)kb_curator_extract_one(&opts);
-   assert(job_attempts(db, 9101) == 2); /* claimed: attempts advanced */
+   assert(job_attempts(db, 9401) == 2); /* claimed: attempts advanced */
 
    printf("  PASS: test_retry_backoff_defers_reclaim (deferred, then claimed)\n");
 }
@@ -243,6 +273,28 @@ static void test_retry_delay_curve(void)
    assert(kb_curator_retry_delay_seconds(0) == KB_CURATOR_RETRY_BASE_S);      /* degenerate */
    assert(kb_curator_retry_delay_seconds(-5) == KB_CURATOR_RETRY_BASE_S);
    printf("  PASS: test_retry_delay_curve\n");
+}
+
+/* The behaviour that matters: a job already AT its attempt limit must survive the
+ * provider being down. Before the fix this row went terminal 'failed' and the
+ * document left the pipeline for good. */
+static void test_provider_outage_requeues(sqlite3 *db)
+{
+   seed(db, "INSERT INTO kb_documents (id,project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES (9601,'p','out.md','oh1',0,'t','')");
+   /* attempts=3 is the exhausted budget: the next terminal decision fails it. */
+   seed(db, "INSERT INTO kb_async_jobs (id,kind,document_id,project,status,attempts,claimed_by,"
+            "claimed_at,created_at,updated_at) VALUES (9601,'extract_doc',9601,'p','running',3,"
+            "'kb.curator.drain',datetime('now'),datetime('now'),datetime('now'))");
+
+   kb_curator_mark_retry_provider_unavailable(9601, 3, "provider HTTP 503");
+
+   /* Retryable, not terminal — the outage says nothing about this document. */
+   assert(strcmp(job_status(db, 9601), "pending") == 0);
+   /* The claim's increment is given back, so a long outage cannot walk the
+    * budget to exhaustion one refused claim at a time. */
+   assert(job_attempts(db, 9601) == 2);
+   printf("  PASS: provider outage requeues at attempt limit without spending budget\n");
 }
 
 int main(void)
@@ -290,6 +342,8 @@ int main(void)
    test_retry_delay_curve();
    test_retry_backoff_defers_reclaim(db);
    test_retry_backoff_ignores_fresh_jobs(db);
+   test_provider_unavailable_is_not_a_job_failure();
+   test_provider_outage_requeues(db);
 
    printf("test_curator_queue: all tests passed\n");
    return 0;


### PR DESCRIPTION
## Problem

`extract_doc` jobs are driven to terminal `failed` by the upstream being *briefly* unavailable.

The attempt budget is incremented at claim time (`ce_claim_job`), and every provider refusal spends one. The `aimee-llm` gateway opens a circuit breaker and then 503s **every** request for its cooldown (`aimee_llm_gateway.py:477`, `provider_unavailable` / "synth upstream circuit is open"), so three claims inside one cooldown walk a job from fresh to terminal in seconds.

Observed on a live deployment:

- **111** `extract_doc` rows terminally `failed`
- all at **exactly `attempts = 3`**
- all with `last_error = "provider HTTP 503"`
- while llama.cpp had **3 of its 4 slots idle** — the refusal was the gateway's, not the model's

Those documents left the pipeline permanently, from a condition that heals itself a minute later.

## Why this is wrong

The attempt budget exists to stop a **poison job** looping forever. A provider outage is not a poison job — the document was never looked at, so the outcome carries no information about whether it can be extracted. Spending the budget on it protects nothing and converts a transient outage into permanent data loss.

## Change

Classify `503` / `429` / `-1` (transport) as provider-unavailable and requeue those **without spending an attempt**, giving back the increment the claim applied. `next_attempt_at` still backs off on the attempt number handed back, so a long outage lengthens the interval rather than hammering an open breaker.

Real job failures are unchanged and still terminal: a 4xx *about the request*, a non-JSON reply, a missing `kb_documents` row.

### Tradeoff

A job now stays `pending` for as long as the provider is down instead of failing. That is the intent — the work is deferred, not lost — and the backlog is visible in `aimee kb status` (which stopped hiding it in #2119).

## Tests

Both halves are pinned in `test_curator_queue`:

1. **Classification** — retryable vs terminal, including that `NULL`/empty error text is not guessed into a retry.
2. **DB effect** — a job at `attempts = 3` comes back `pending` at `attempts = 2`.

Verified red-before-green: with the requeue writing `'failed'` (the old behaviour) the behavioural test fails at
`Assertion 'strcmp(job_status(db, 9601), "pending") == 0' failed`.

`make lint` — 38 checks pass.

## Not fixed here

This does **not** drain the existing backlog. The deployment that produced it runs synth CPU-only at ~3 tok/s against 5598 queued jobs; that needs a capacity decision (external provider, GPU, smaller model, or disabling `extract_docs`), not a code change.