### PR TITLE
fix(wfe): cancel routed pending delegate jobs

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -260,10 +260,14 @@ func (s *Store) ForgetDelegateJobIfMatches(ctx context.Context, key string, jobI
 }
 
 // CancelUnassignedDelegateJob returns true only when this call atomically moves
-// an expired, nonterminal, unassigned job to cancelled. The C compatibility
-// worker can mark a row running before assignment, so status alone is not
-// admission. Its db1_agent_job_set_agent update is reciprocal (`WHERE id = ? AND
-// status != 'cancelled'`): whichever SQLite update wins prevents the other.
+// an expired job without a worker lease to cancelled. Routing may persist an
+// agent name while the row is still pending, so a pending row remains
+// unassigned regardless of agent_name. Once the worker moves it to running, a
+// non-empty agent_name proves assignment and protects it from this lease.
+//
+// Both worker transitions are reciprocal: taking the lease requires pending,
+// and assigning an agent rejects cancelled rows. Whichever SQLite update wins
+// prevents a later transition from reviving a cancelled job.
 func (s *Store) CancelUnassignedDelegateJob(ctx context.Context, jobID int, reason string, minAge time.Duration) (bool, error) {
 	if jobID <= 0 {
 		return false, errors.New("delegate job id is required")
@@ -278,8 +282,7 @@ SET status='cancelled',
     cancel_reason=?,
     updated_at=datetime('now')
 WHERE id=?
-  AND status IN ('pending','running')
-  AND trim(agent_name)=''
+  AND (status='pending' OR (status='running' AND trim(agent_name)=''))
   AND COALESCE(NULLIF(heartbeat_at,''),created_at) <= ?`, reason, jobID, cutoff)
 	if err != nil {
 		return false, fmt.Errorf("cancel unassigned delegate job: %w", err)

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -585,25 +585,81 @@ func TestCancelUnassignedDelegateJobPredicateTruthTable(t *testing.T) {
 	if _, err := store.db.Exec(`UPDATE agent_jobs SET created_at=datetime('now','-2 hours'), heartbeat_at=CASE WHEN status='running' THEN datetime('now','-2 hours') ELSE '' END`); err != nil {
 		t.Fatal(err)
 	}
-	for _, id := range []int{41, 44, 45} {
+	for _, id := range []int{41, 42, 44, 45} {
 		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired", time.Hour)
 		if err != nil || !cancelled {
 			t.Fatalf("cancel unassigned job %d: cancelled=%v err=%v", id, cancelled, err)
 		}
 	}
-	for _, id := range []int{42, 43, 46, 47, 48} {
+	for _, id := range []int{43, 46, 47, 48} {
 		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired", time.Hour)
 		if err != nil || cancelled {
 			t.Fatalf("job %d assignment/terminal guard: cancelled=%v err=%v", id, cancelled, err)
 		}
 	}
-	for _, id := range []int{41, 44, 45} {
+	for _, id := range []int{41, 42, 44, 45} {
 		var status, reason string
 		if err := store.db.QueryRow(`SELECT status,cancel_reason FROM agent_jobs WHERE id=?`, id).Scan(&status, &reason); err != nil {
 			t.Fatal(err)
 		}
 		if status != "cancelled" || reason != "lease expired" {
 			t.Fatalf("job %d status=%q reason=%q", id, status, reason)
+		}
+	}
+}
+
+func TestCancelUnassignedDelegateJobRacesRoutedPendingWorker(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.db.Exec(`CREATE TABLE agent_jobs (
+		id INTEGER PRIMARY KEY, agent_name TEXT NOT NULL DEFAULT '', status TEXT NOT NULL,
+		heartbeat_at TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '',
+		cancelled_at TEXT DEFAULT '', cancel_reason TEXT DEFAULT '', updated_at TEXT DEFAULT '')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for id := 150; id < 200; id++ {
+		if _, err := store.db.Exec(`INSERT INTO agent_jobs(id,status,agent_name,heartbeat_at,created_at)
+			VALUES (?,'pending','codex','','2000-01-01 00:00:00')`, id); err != nil {
+			t.Fatal(err)
+		}
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		var cancelled bool
+		var cancelErr, leaseErr error
+		var leased int64
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			cancelled, cancelErr = store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired", time.Hour)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := store.db.ExecContext(t.Context(), `UPDATE agent_jobs
+				SET status='running', heartbeat_at=datetime('now') WHERE id=? AND status='pending'`, id)
+			leaseErr = err
+			if err == nil {
+				leased, leaseErr = result.RowsAffected()
+			}
+		}()
+		close(start)
+		wg.Wait()
+		if cancelErr != nil || leaseErr != nil {
+			t.Fatalf("iteration %d cancel_err=%v lease_err=%v", id, cancelErr, leaseErr)
+		}
+		if (cancelled && leased != 0) || (!cancelled && leased != 1) {
+			t.Fatalf("iteration %d cancelled=%v leased=%d", id, cancelled, leased)
+		}
+		var status, agent string
+		if err := store.db.QueryRow(`SELECT status,agent_name FROM agent_jobs WHERE id=?`, id).Scan(&status, &agent); err != nil {
+			t.Fatal(err)
+		}
+		if cancelled && (status != "cancelled" || agent != "codex") {
+			t.Fatalf("iteration %d cancelled final status=%q agent=%q", id, status, agent)
+		}
+		if !cancelled && (status != "running" || agent != "codex") {
+			t.Fatalf("iteration %d leased final status=%q agent=%q", id, status, agent)
 		}
 	}
 }


### PR DESCRIPTION
## What changed

- treat every expired `pending` delegate job as unassigned even when routing has already populated `agent_name`
- continue protecting assigned `running` jobs
- extend the predicate truth table for routed-pending jobs
- add a 50-iteration race test covering cancellation versus the worker's `pending` → `running` lease transition

## Why

The WFE poller correctly recognizes a routed-but-still-pending job as unassigned, but the DB cancellation predicate required an empty `agent_name`. That mismatch caused expiry to return `no longer pending and unassigned` while leaving the job pending forever and retaining its durable mapping. A later workflow attempt could start newer work while the stale row remained queued.

The new predicate mirrors the worker lifecycle: `pending` means no worker lease regardless of routing, while `running` plus a non-empty agent is protected. The atomic status update ensures either cancellation or worker admission wins, never both.

## Validation

- `go test ./internal/db1 ./internal/engine`
- `git diff --check`
- reproduced in disposable CT331 during workflow `wi_173b0bfa3302c7188268229454781bda` with routed pending jobs 268 and 269
