### PR TITLE
Fix wizard deployment benchmark readiness

### DIFF
--- a/docs/validation/wizard-managed-server-identity.md
+++ b/docs/validation/wizard-managed-server-identity.md
@@ -1,6 +1,7 @@
-# Wizard-managed server identity gap
+# Wizard-managed server identity acceptance
 
-**Status:** reproduced against the rolling `:testing` deployment on 2026-07-28.
+**Status:** reproduced against the rolling `:testing` deployment on 2026-07-28;
+resolved and accepted through `35f62657` on 2026-07-29.
 
 ## Expected contract
 
@@ -17,7 +18,7 @@ registry row, a single-use server-to-KB mTLS enrollment, and the public JWKS tru
 material. Private keys and enrollment tokens must remain out of browser responses
 and logs.
 
-## Reproduction
+## Original reproduction
 
 Start `compose.server-managed.yaml` with rolling `:testing`, complete every page of
 the web GUI wizard, press Deploy, enroll the first Linux client with the command
@@ -37,9 +38,10 @@ The first-user flow succeeds, but the server workload is still unprovisioned:
 The KB is healthy and already contains indexed lexical data and vectors, so this
 is not a KB or embedding-service outage.
 
-## Code path
+## Original code path
 
-`POST /v1/deploy/apply` currently performs only two operations:
+At the reproduced revision, `POST /v1/deploy/apply` performed only two
+operations:
 
 1. `server_http_first_user_bootstrap()` creates/reuses the first browser user's
    enrollment bearer and eventual certificate-bound `full` grant;
@@ -95,3 +97,44 @@ After Deploy:
 This gate is also the setup prerequisite for the Ponytail reanalysis Aimee arm:
 benchmarking a manually repaired or half-installed deployment would not measure
 Aimee's minimum standard installation.
+
+## Resolution and final-head evidence
+
+The managed-v2 wizard now performs the workload-identity transaction after the
+KB is healthy and before Deploy succeeds. It creates and persists the server and
+team identity, client certificate/key, owner/full grant, and signed JWKS trust
+through the browser-driven deployment path. The runtime reads that protected
+`kb-client-identity.json`; empty legacy `AIMEE_SERVER_ID`,
+`AIMEE_SERVER_TEAM_ID`, and `AIMEE_KB_CONN` environment variables are expected
+for this mode and are not evidence of an incomplete install.
+
+The final benchmark acceptance deployment used these exact components:
+
+- server `0.2.195-1009-g35f62657`;
+- distributed KB `v0.2.195-1007-gb0e1f2c5`;
+- thin client `v0.2.195-1003-g627c1ffc`.
+
+The server reports both its own version and the distributed KB version. Its
+wizard-generated identity is ready, bound to the default team, certificate
+authenticated, and granted owner/full. The persistent server, store, vector
+index, and embedder all report healthy.
+
+A fresh per-project acceptance cycle registers a canonical checkout, uploads a
+forced index scan, and waits for `kb build --force` to finish both code and
+document embeddings. Before an agent is allowed to start, the gate requires:
+
+1. symbol lookup for the planted `end_of_month` helper;
+2. all three callers from billing, invoices, and reports;
+3. blast-radius output for `app/dates.py`;
+4. a project-scoped semantic hit for the planted README passage;
+5. identical pre-edit Git heads and complete manifests for the indexed and
+   execution checkouts; and
+6. a connected Aimee MCP server and tool inventory in the actual agent startup
+   event.
+
+The acceptance exercise exposed additional defects after initial enrollment:
+the wizard discarded the full mTLS grant, thin-client build returned before
+project embeddings completed, background document refresh could starve later
+projects, the distributed mTLS relay ignored caller timeouts, and server health
+did not identify the distributed KB build. Those defects are covered by the
+commits after `2d068b7a`; all are required for the benchmark-ready state above.

--- a/scripts/test-wizard-first-user-bootstrap.sh
+++ b/scripts/test-wizard-first-user-bootstrap.sh
@@ -87,11 +87,14 @@ PY
 e2e_bearer=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["enrollment"]["bearer_token"])' "$e2e_tmp/apply.json")
 
 # The pending bearer authenticates enrollment but has no write tier by itself.
-e2e_body='{"persona":"wizard bootstrap E2E","description":"certificate-bound write"}'
+# Use kb.build because CAP_INDEX_ADMIN sits outside CAPS_AUTHENTICATED: an
+# ordinary mutation such as persona PUT can pass without proving that the
+# certificate-bound `full` tier survived capability derivation.
+e2e_body='{}'
 curl --silent --show-error --cacert "$e2e_tmp/server/tls/server.crt" \
   -H "Authorization: Bearer $e2e_bearer" -H 'Content-Type: application/json' \
-  -X PUT -d "$e2e_body" -o "$e2e_tmp/bearer-write.json" -w '%{http_code}' \
-  "https://127.0.0.1:$e2e_tls_port/v1/personas/wizard-bootstrap-e2e" \
+  -X POST -d "$e2e_body" -o "$e2e_tmp/bearer-write.json" -w '%{http_code}' \
+  "https://127.0.0.1:$e2e_tls_port/v1/kb/build" \
   >"$e2e_tmp/bearer-write.status"
 [[ $(<"$e2e_tmp/bearer-write.status") == 403 ]]
 
@@ -111,8 +114,8 @@ PY
 curl --silent --show-error --cacert "$e2e_tmp/server/tls/server.crt" \
   --cert "$e2e_tmp/client/tls/client.crt" --key "$e2e_tmp/client/tls/client.key" \
   -H "Authorization: Bearer $e2e_bearer" -H 'Content-Type: application/json' \
-  -X PUT -d "$e2e_body" -o "$e2e_tmp/mtls-write.json" -w '%{http_code}' \
-  "https://127.0.0.1:$e2e_tls_port/v1/personas/wizard-bootstrap-e2e" \
+  -X POST -d "$e2e_body" -o "$e2e_tmp/mtls-write.json" -w '%{http_code}' \
+  "https://127.0.0.1:$e2e_tls_port/v1/kb/build" \
   >"$e2e_tmp/mtls-write.status"
 [[ $(<"$e2e_tmp/mtls-write.status") == 200 ]]
 

--- a/src/headers/kb_tls.h
+++ b/src/headers/kb_tls.h
@@ -112,6 +112,10 @@ extern "C"
    kb_tls_client_conn_t *kb_tls_client_conn_open_ctx(const char *host, int port, SSL_CTX *ctx);
    kb_tls_client_conn_t *kb_tls_client_conn_open_session(const char *host, int port, SSL_CTX *ctx,
                                                          SSL_SESSION *session);
+   /* Set the per-request socket I/O timeout on an open client connection. The
+    * default remains 30 seconds for callers that do not opt in; long-running
+    * relays (for example kb.build) must propagate their operation timeout. */
+   int kb_tls_client_conn_set_timeout(kb_tls_client_conn_t *conn, int timeout_ms);
    int kb_tls_client_conn_session_reused(const kb_tls_client_conn_t *conn);
    SSL_SESSION *kb_tls_client_conn_get1_session(const kb_tls_client_conn_t *conn);
    int kb_tls_client_conn_request(kb_tls_client_conn_t *conn, const char *method, const char *path,

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -202,8 +202,9 @@ extern "C"
    int roundtable_policy_config_key(const char *key);
 
    /* Effective caps for a request after thin-client mTLS authentication. When
-    * mTLS is enabled, bearer fallback is a query-only floor and a durable cert
-    * gets the authenticated (but not full-trust) set. */
+    * mTLS is enabled, bearer fallback is a query-only floor. A durable cert gets
+    * the authenticated set at off/data and CAPS_ALL only when its verified
+    * per-user write tier is full. */
    /* remote_writes.global_ignored: how many requests were refused that the
     * retired aimee.api.remote_writes would formerly have allowed. Lets an
     * operator size the cutover's impact instead of inferring it from

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -17,6 +17,7 @@
 #include "kb_http_search.h"
 #include "kb_curator_serve.h"
 #include "kb_service.h"
+#include "kb/kb_service_code_embed.h"
 #include "kb_service_kb.h"
 #include "db2/kb_service_backend.h"
 #include "db2/canonical_index.h"
@@ -1523,6 +1524,32 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"canonical index scan failed\"}");
          return 500;
       }
+
+      /* A thin client pushes source into the canonical index because this KB
+       * process cannot see the client's path.  `kb build` used to stop after the
+       * inaccessible filesystem scan above and report a misleading all-zero
+       * success, leaving the requested project behind the global curator backlog.
+       * Finish this project from its canonical DB2 copy now: code vectors and
+       * prose/document vectors are part of a completed build, not eventual
+       * side-effects of unrelated background sweeps. */
+      kb_code_embed_result_t code_embed;
+      memset(&code_embed, 0, sizeof(code_embed));
+      if (kb_code_embed_refresh(project, "changed_files", NULL, 0, 0, 0, 0, &code_embed) != 0 ||
+          code_embed.embedded + code_embed.skipped_unchanged < code_embed.estimated_points)
+      {
+         snprintf(out_buf, (size_t)out_cap,
+                  "{\"error\":\"project code embedding refresh failed\"}");
+         return 503;
+      }
+      int doc_refreshed = kb_doc_refresh(project, embed_cmd, 200);
+      int doc_backfilled = kb_doc_embed_backfill(project, embed_cmd, 200);
+      if (doc_refreshed < 0 || doc_backfilled < 0)
+      {
+         snprintf(out_buf, (size_t)out_cap,
+                  "{\"error\":\"project document embedding refresh failed\"}");
+         return 503;
+      }
+      stats.embeddings_added += (int)code_embed.embedded + doc_refreshed + doc_backfilled;
       db2_kb_runtime_state_set_now("last_ingest_at");
       kb_http_write_build_stats(out_buf, out_cap, project, &stats);
       return 200;

--- a/src/kb/http/kb_tls.c
+++ b/src/kb/http/kb_tls.c
@@ -464,6 +464,20 @@ kb_tls_client_conn_t *kb_tls_client_conn_open_session(const char *host, int port
    return client_conn_open_owned_ctx(host, port, ctx, session);
 }
 
+int kb_tls_client_conn_set_timeout(kb_tls_client_conn_t *conn, int timeout_ms)
+{
+   if (!conn || conn->fd < 0 || timeout_ms <= 0)
+      return -1;
+   struct timeval timeout = {
+       .tv_sec = timeout_ms / 1000,
+       .tv_usec = (timeout_ms % 1000) * 1000,
+   };
+   if (setsockopt(conn->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0 ||
+       setsockopt(conn->fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0)
+      return -1;
+   return 0;
+}
+
 int kb_tls_client_conn_session_reused(const kb_tls_client_conn_t *conn)
 {
    return conn && conn->ssl ? SSL_session_reused(conn->ssl) : 0;

--- a/src/modules/kb-synthesis/kb_curator_drain.c
+++ b/src/modules/kb-synthesis/kb_curator_drain.c
@@ -54,6 +54,14 @@
 /* Index lane (CPU) idle backoff. It loops hot while a backlog remains, so this only
  * paces polling once its queues are empty. */
 #define INDEX_LANE_POLL_SECS 2
+/* A real server can own more projects than the old 128-entry sweep arrays (the
+ * standing benchmark alone uses 150 isolated projects).  Keep the autonomous
+ * maintenance lane above that ordinary scale; explicit project builds do not
+ * depend on this sweep. */
+#define CURATOR_PROJECT_SWEEP_MAX 512
+/* Document embedding is a remote round-trip per chunk.  Bound one project's
+ * turn so an old backfill cannot hold the sole index lane for tens of minutes. */
+#define CURATOR_DOC_SWEEP_BATCH 8
 /* Max synthesis ops processed per poll — each is an LLM round-trip. */
 #define SYNTH_DRAIN_BATCH 4
 /* Max curator jobs (extract/synth/…) drained back-to-back per poll. The per-poll
@@ -138,8 +146,8 @@ static void kb_curator_projection_sweep(void)
 {
    if (!config_kb_curator_projection_graph_enabled())
       return;
-   project_info_t projects[128];
-   int np = index_list_projects(projects, 128);
+   project_info_t projects[CURATOR_PROJECT_SWEEP_MAX];
+   int np = index_list_projects(projects, CURATOR_PROJECT_SWEEP_MAX);
    int built = 0;
    int64_t total = 0;
    for (int i = 0; i < np; i++)
@@ -243,8 +251,8 @@ static int stage_embed_code(const kb_curator_extract_opts_t *opts)
    config_load(&cfg);
    if (!cfg.embedding_command[0])
       return 0;
-   project_info_t projects[128];
-   int np = index_list_projects(projects, 128);
+   project_info_t projects[CURATOR_PROJECT_SWEEP_MAX];
+   int np = index_list_projects(projects, CURATOR_PROJECT_SWEEP_MAX);
    int total = 0;
    for (int i = 0; i < np; i++)
    {
@@ -262,25 +270,31 @@ static int stage_embed_code(const kb_curator_extract_opts_t *opts)
 static int stage_ingest_docs(const kb_curator_extract_opts_t *opts)
 {
    (void)opts;
+   /* Only the index-lane thread calls this stage, so a function-local cursor is
+    * sufficient.  Rotating one bounded project per pass prevents an early large
+    * corpus from starving every later project in lexical name order. */
+   static size_t next_project = 0;
    config_t cfg;
    config_load(&cfg);
    if (!cfg.embedding_command[0])
       return 0;
-   project_info_t projects[128];
-   int np = index_list_projects(projects, 128);
+   project_info_t projects[CURATOR_PROJECT_SWEEP_MAX];
+   int np = index_list_projects(projects, CURATOR_PROJECT_SWEEP_MAX);
+   if (np <= 0)
+      return 0;
+   size_t selected = next_project % (size_t)np;
+   next_project = (selected + 1) % (size_t)np;
    int total = 0;
-   for (int i = 0; i < np; i++)
-   {
-      int e = kb_doc_refresh(projects[i].name, cfg.embedding_command, 200);
-      if (e > 0)
-         total += e;
-      int b = kb_doc_embed_backfill(projects[i].name, cfg.embedding_command, 200);
-      if (b > 0)
-         total += b;
-   }
+   int e = kb_doc_refresh(projects[selected].name, cfg.embedding_command, CURATOR_DOC_SWEEP_BATCH);
+   if (e > 0)
+      total += e;
+   int b = kb_doc_embed_backfill(projects[selected].name, cfg.embedding_command,
+                                 CURATOR_DOC_SWEEP_BATCH);
+   if (b > 0)
+      total += b;
    if (total > 0)
-      aimee_log(LOG_DEBUG, "kb.docs.ingest", "ingested %d doc chunk(s) across %d project(s)", total,
-                np);
+      aimee_log(LOG_DEBUG, "kb.docs.ingest", "ingested %d doc chunk(s) for project '%s'", total,
+                projects[selected].name);
    /* dim-change re-embed clears its maintenance marker once the backfill has caught
     * up (a pass that embedded nothing means every chunk has a vector). */
    if (total == 0 && db2_reembed_in_progress_get(NULL, NULL) == 1)

--- a/src/modules/kb-synthesis/kb_curator_queue.c
+++ b/src/modules/kb-synthesis/kb_curator_queue.c
@@ -268,7 +268,10 @@ void kb_curator_queue_docs_all_projects(int extract_docs_enabled)
 {
    if (!extract_docs_enabled)
       return;
-   project_info_t projects[128];
+   /* The autonomous project sweeps support ordinary multi-project servers and
+    * the 150-project standing benchmark.  The former 128-entry array silently
+    * omitted every later project forever. */
+   project_info_t projects[512];
    int np = index_list_projects(projects, (int)(sizeof(projects) / sizeof(projects[0])));
    for (int i = 0; i < np; i++)
       (void)kb_curator_queue_docs_for_project(projects[i].name);

--- a/src/modules/kb_client/kb_client.c
+++ b/src/modules/kb_client/kb_client.c
@@ -311,6 +311,23 @@ int kb_client_health(kb_health_t *out)
    }
 
    cJSON_Delete(resp);
+
+   /* Health proves that the dependency is reachable; version proves which
+    * dependency answered. Keep this best-effort for compatibility with an
+    * older KB, but surface it whenever /v1/version is available so operators
+    * and benchmark harnesses can pin the complete distributed stack. */
+   int version_status = -1;
+   char *version_body =
+       kb_client_v1_get_json("/v1/version", CLIENT_DEFAULT_TIMEOUT_MS, &version_status);
+   cJSON *version_json = version_body ? cJSON_Parse(version_body) : NULL;
+   free(version_body);
+   cJSON *version = version_json ? cJSON_GetObjectItemCaseSensitive(version_json, "version") : NULL;
+   cJSON *service = version_json ? cJSON_GetObjectItemCaseSensitive(version_json, "service") : NULL;
+   if (version_status >= 200 && version_status < 300 && cJSON_IsString(version) &&
+       version->valuestring[0] && cJSON_IsString(service) &&
+       strcmp(service->valuestring, "aimee-kb") == 0)
+      snprintf(out->version, sizeof(out->version), "%s", version->valuestring);
+   cJSON_Delete(version_json);
    return 0;
 }
 

--- a/src/modules/kb_client/kb_client.c
+++ b/src/modules/kb_client/kb_client.c
@@ -1170,7 +1170,7 @@ char *kb_client_v1_post_json(const char *path, cJSON *body, int timeout_ms, int 
    /* Distributed mode: route to the remote kb over mTLS (see get_json). */
    if (kb_client_mtls_configured())
    {
-      char *r = kb_client_mtls_request("POST", path, body_json, status_out);
+      char *r = kb_client_mtls_request_timeout("POST", path, body_json, timeout_ms, status_out);
       free(body_json);
       return r;
    }
@@ -1240,7 +1240,7 @@ char *kb_client_v1_get_json(const char *path, int timeout_ms, int *status_out)
    /* Distributed mode: a configured remote kb (AIMEE_KB_CONN) is reached over
     * mTLS with the enrollment-issued client cert, ahead of HTTP-URL / socket. */
    if (kb_client_mtls_configured())
-      return kb_client_mtls_request("GET", path, NULL, status_out);
+      return kb_client_mtls_request_timeout("GET", path, NULL, timeout_ms, status_out);
 
    char *url = kb_client_v1_url(path);
    if (url)

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -18,6 +18,7 @@ typedef struct cJSON cJSON;
 typedef struct
 {
    int process_ok;          /* aimee-kb is running and responsive */
+   char version[128];       /* /v1/version, empty when an older kb omits it */
    int db2_ok;              /* DB2 schema present */
    int db2_kb_tables_ok;    /* kb_documents + kb_async_jobs present */
    int pgvec_ok;            /* pgvector extension loaded in DB2 */

--- a/src/modules/kb_client/kb_client_mtls.c
+++ b/src/modules/kb_client/kb_client_mtls.c
@@ -606,13 +606,17 @@ static void maybe_renew(void)
    pthread_mutex_unlock(&g_lock);
 }
 
-char *kb_client_mtls_request(const char *method, const char *path, const char *body,
-                             int *status_out)
+#define KB_CLIENT_MTLS_DEFAULT_TIMEOUT_MS 30000
+
+char *kb_client_mtls_request_timeout(const char *method, const char *path, const char *body,
+                                     int timeout_ms, int *status_out)
 {
    if (status_out)
       *status_out = -1;
    if (!method || !path || ensure_enrolled() != 0)
       return NULL;
+   if (timeout_ms <= 0)
+      timeout_ms = KB_CLIENT_MTLS_DEFAULT_TIMEOUT_MS;
    maybe_renew();
 
    size_t cap = 1u << 20; /* 1 MiB — covers kb /v1 responses (status/search/etc.) */
@@ -631,10 +635,13 @@ char *kb_client_mtls_request(const char *method, const char *path, const char *b
       port = g_port;
       pthread_mutex_unlock(&g_lock);
       int status = -1;
-      int rc = resp ? kb_tls_client_request_auth(host, port, ca, cert, key, method, path,
-                                                 (body && body[0]) ? body : NULL, NULL, resp, cap,
-                                                 &status)
-                    : -1;
+      int reusable = 0;
+      kb_tls_client_conn_t *conn = resp ? kb_tls_client_conn_open(host, port, ca, cert, key) : NULL;
+      int rc = conn && kb_tls_client_conn_set_timeout(conn, timeout_ms) == 0
+                   ? kb_tls_client_conn_request(conn, method, path, (body && body[0]) ? body : NULL,
+                                                NULL, 1, resp, cap, &status, &reusable)
+                   : -1;
+      kb_tls_client_conn_close(conn);
       if (status_out)
          *status_out = status;
       char *out = (rc == 0 && status >= 200 && status < 300) ? strdup(resp) : NULL;
@@ -652,14 +659,24 @@ char *kb_client_mtls_request(const char *method, const char *path, const char *b
    }
    int status = -1;
    int reusable = 0;
-   int rc = kb_tls_client_conn_request(entry->conn, method, path, (body && body[0]) ? body : NULL,
-                                       NULL, 0, resp, cap, &status, &reusable);
+   int rc =
+       kb_tls_client_conn_set_timeout(entry->conn, timeout_ms) == 0
+           ? kb_tls_client_conn_request(entry->conn, method, path, (body && body[0]) ? body : NULL,
+                                        NULL, 0, resp, cap, &status, &reusable)
+           : -1;
    pool_return(entry, rc == 0 && reusable);
    if (status_out)
       *status_out = status;
    char *out = (rc == 0 && status >= 200 && status < 300) ? strdup(resp) : NULL;
    free(resp);
    return out;
+}
+
+char *kb_client_mtls_request(const char *method, const char *path, const char *body,
+                             int *status_out)
+{
+   return kb_client_mtls_request_timeout(method, path, body, KB_CLIENT_MTLS_DEFAULT_TIMEOUT_MS,
+                                         status_out);
 }
 
 int kb_client_mtls_management_jwks(char *envelope_out, size_t envelope_cap, size_t *envelope_len)

--- a/src/modules/kb_client/kb_client_mtls.h
+++ b/src/modules/kb_client/kb_client_mtls.h
@@ -27,6 +27,11 @@ int kb_client_mtls_managed_metadata(char *server_id_out, size_t server_id_cap,
  * method is "GET"/"POST"; body is NULL for GET. */
 char *kb_client_mtls_request(const char *method, const char *path, const char *body,
                              int *status_out);
+/* As above, but propagate the caller's operation timeout to the mTLS socket.
+ * This prevents the transport's 30-second default from truncating builds whose
+ * public operation contract allows several minutes. */
+char *kb_client_mtls_request_timeout(const char *method, const char *path, const char *body,
+                                     int timeout_ms, int *status_out);
 
 /* Fetch the exact bounded P5-C2c signed envelope.  Only an authenticated 200
  * response on the fixed route is accepted; output is cleared on every error. */

--- a/src/server/server_api_status.c
+++ b/src/server/server_api_status.c
@@ -107,6 +107,8 @@ void server_health_add_kb(cJSON *resp)
    cJSON_AddBoolToObject(kbo, "vectors_ok", kb.pgvec_ok ? 1 : 0);
    cJSON_AddBoolToObject(kbo, "embed_configured", kb.embed_ok ? 1 : 0);
    cJSON_AddNumberToObject(kbo, "vectors", kb.pgvec_vectors);
+   if (kb.version[0])
+      cJSON_AddStringToObject(kbo, "version", kb.version);
 }
 
 int handle_api_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)

--- a/src/server/server_http_authz.c
+++ b/src/server/server_http_authz.c
@@ -82,7 +82,13 @@ uint32_t server_http_effective_conn_caps(int is_tcp, const char *bearer, int rem
    if (!mtls_authenticated && bearer && strcmp(bearer, AIMEE_BOOTSTRAP_BEARER) == 0)
       return (CAPS_READ_ONLY & ~(uint32_t)CAP_CHAT) | CAP_SESSION_ADMIN;
    if (mtls_authenticated)
-      return CAPS_AUTHENTICATED;
+      /* `remote_writes` is the caller's verified per-user tier by this point,
+       * not the retired process-global switch. Preserve the ordinary mTLS
+       * authenticated floor for off/data, but a certificate-bound full grant
+       * must expose the same full capability set as any other verified full
+       * identity. Otherwise CAP_INDEX_ADMIN routes such as kb.build remain
+       * impossible even for the browser wizard's enrolled owner. */
+      return remote_writes >= SERVER_REMOTE_WRITES_FULL ? CAPS_ALL : CAPS_AUTHENTICATED;
    /* Optional-mode bearer fallback is deliberately weaker than a client cert:
     * query/session reads only, with no compute or mutation capability. */
    return CAPS_READ_ONLY & ~(uint32_t)CAP_CHAT;

--- a/src/tests/test_kb_client_search.c
+++ b/src/tests/test_kb_client_search.c
@@ -22,10 +22,16 @@ static int health_get_handler(const char *url, const char *extra_headers, char *
 {
    (void)timeout_ms;
    assert(url);
-   assert(strcmp(url, "http://127.0.0.1:4010/v1/health") == 0);
    assert(extra_headers);
    assert(strcmp(extra_headers, "Authorization: Bearer test-token") == 0);
    g_get_seen++;
+   if (strcmp(url, "http://127.0.0.1:4010/v1/version") == 0)
+   {
+      if (response_buf)
+         *response_buf = strdup("{\"version\":\"v0.3.0-test\",\"service\":\"aimee-kb\"}");
+      return 200;
+   }
+   assert(strcmp(url, "http://127.0.0.1:4010/v1/health") == 0);
    if (response_buf)
       *response_buf = strdup("{\"status\":\"ok\",\"db2_ok\":true,"
                              "\"db2_kb_tables_ok\":true,\"pgvec_ok\":true,"
@@ -476,6 +482,7 @@ static void test_health_uses_v1_api_when_configured(void)
    kb_health_t health;
    assert(kb_client_health(&health) == 0);
    assert(health.process_ok == 1);
+   assert(strcmp(health.version, "v0.3.0-test") == 0);
    assert(health.db2_ok == 1);
    assert(health.db2_kb_tables_ok == 1);
    assert(health.pgvec_ok == 1);
@@ -495,7 +502,7 @@ static void test_health_uses_v1_api_when_configured(void)
    assert(strstr(health.warnings, "warn-a") != NULL);
    assert(strstr(health.warnings, "warn-b") != NULL);
 
-   assert(g_get_seen == 1);
+   assert(g_get_seen == 2);
    unsetenv("AIMEE_KB_API_URL");
    unsetenv("AIMEE_KB_API_BEARER_TOKEN");
    mock_agent_http_reset();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -2911,6 +2911,9 @@ static void test_mtls_listener(void)
    kb_tls_client_conn_t *session_one =
        kb_tls_client_conn_open_ctx("localhost", port, shared_client_ctx);
    assert(session_one);
+   assert(kb_tls_client_conn_set_timeout(NULL, 600000) == -1);
+   assert(kb_tls_client_conn_set_timeout(session_one, 0) == -1);
+   assert(kb_tls_client_conn_set_timeout(session_one, 600000) == 0);
    assert(kb_tls_client_conn_request(session_one, "GET", "/v1/health", NULL, NULL, 0, rbody,
                                      sizeof(rbody), &st, &reusable) == 0);
    assert(reusable == 1);
@@ -2993,7 +2996,7 @@ static void test_mtls_listener(void)
       setenv("AIMEE_TRANSPORT_KB_POOL_ENABLED", "0", 1);
       assert(kb_client_mtls_configured() == 1);
       int st2 = -1;
-      char *r = kb_client_mtls_request("GET", "/v1/health", NULL, &st2);
+      char *r = kb_client_mtls_request_timeout("GET", "/v1/health", NULL, 600000, &st2);
       assert(st2 == 200);
       assert(r && strstr(r, "\"status\":\"ok\""));
       free(r);
@@ -3025,7 +3028,7 @@ static void test_mtls_listener(void)
 
       /* The hot rollout flag opts this identity into reuse without a restart. */
       setenv("AIMEE_TRANSPORT_KB_POOL_ENABLED", "1", 1);
-      r = kb_client_mtls_request("GET", "/v1/health", NULL, &st2);
+      r = kb_client_mtls_request_timeout("GET", "/v1/health", NULL, 600000, &st2);
       assert(st2 == 200 && r);
       free(r);
       g_test_registry_heartbeat_allow = 1;

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -16,6 +16,7 @@
 #include "rel_types.h"              /* REL_TYPE_NAME_MAX for the db2_ontology_* stubs below */
 #include "config_fields.h"          /* config_field_t for the pipeline-console stubs below */
 #include "kb_service.h"
+#include "kb/kb_service_code_embed.h"
 #include "kb_bandit.h"
 #include "kb_service_backend.h"
 #include "kb_enroll.h"
@@ -778,6 +779,14 @@ static char g_kb_build_path[256];
 static char g_kb_build_project[256];
 static char g_kb_build_embed_cmd[64];
 static int g_kb_build_force;
+static int g_code_embed_refresh_rc;
+static int g_code_embed_estimated;
+static int g_code_embed_embedded;
+static int g_code_embed_skipped;
+static char g_code_embed_project[256];
+static int g_doc_refresh_rc;
+static int g_doc_backfill_rc;
+static char g_doc_refresh_project[256];
 static int g_kb_update_rc;
 static char g_kb_update_path[256];
 static char g_kb_update_project[256];
@@ -931,6 +940,40 @@ int kb_build(const char *root_path, const char *project, const char *embedding_c
       stats_out->embeddings_added = 5;
    }
    return g_kb_build_rc;
+}
+
+int kb_code_embed_refresh(const char *project, const char *scope, const char **paths,
+                          int path_count, int batch_size, int max_points, int dry_run,
+                          kb_code_embed_result_t *out)
+{
+   (void)scope;
+   (void)paths;
+   (void)path_count;
+   (void)batch_size;
+   (void)max_points;
+   (void)dry_run;
+   snprintf(g_code_embed_project, sizeof(g_code_embed_project), "%s", project);
+   memset(out, 0, sizeof(*out));
+   out->estimated_points = g_code_embed_estimated;
+   out->embedded = g_code_embed_embedded;
+   out->skipped_unchanged = g_code_embed_skipped;
+   return g_code_embed_refresh_rc;
+}
+
+int kb_doc_refresh(const char *project, const char *embedding_cmd, int max_docs)
+{
+   (void)embedding_cmd;
+   assert(max_docs == 200);
+   snprintf(g_doc_refresh_project, sizeof(g_doc_refresh_project), "%s", project);
+   return g_doc_refresh_rc;
+}
+
+int kb_doc_embed_backfill(const char *project, const char *embedding_cmd, int max_chunks)
+{
+   (void)embedding_cmd;
+   assert(max_chunks == 200);
+   assert(strcmp(g_doc_refresh_project, project) == 0);
+   return g_doc_backfill_rc;
 }
 
 int kb_update(const char *root_path, const char *project, const char *embedding_cmd,
@@ -4334,6 +4377,12 @@ static void test_code_build_ok(void)
    g_kb_build_rc = 0;
    g_code_scan_rc = 0;
    g_runtime_state_set_now = 0;
+   g_code_embed_refresh_rc = 0;
+   g_code_embed_estimated = 4;
+   g_code_embed_embedded = 3;
+   g_code_embed_skipped = 1;
+   g_doc_refresh_rc = 2;
+   g_doc_backfill_rc = 1;
    const char *body =
        "{\"path\":\"/tmp/kb\",\"project\":\"proj-alpha\",\"embedding_command\":\"embed-a\","
        "\"force\":true}";
@@ -4346,9 +4395,33 @@ static void test_code_build_ok(void)
    assert(strcmp(g_kb_build_project, "proj-alpha") == 0);
    assert(strcmp(g_kb_build_embed_cmd, "embed-a") == 0);
    assert(g_kb_build_force == 1);
+   assert(strcmp(g_code_embed_project, "proj-alpha") == 0);
+   assert(strcmp(g_doc_refresh_project, "proj-alpha") == 0);
    assert(g_runtime_state_set_now == 1);
    assert(strstr(buf, "\"files_scanned\":9") != NULL);
-   assert(strstr(buf, "\"embeddings_added\":5") != NULL);
+   assert(strstr(buf, "\"embeddings_added\":11") != NULL);
+}
+
+static void test_code_build_rejects_partial_project_embedding(void)
+{
+   char buf[1024];
+   g_db_initialized = 1;
+   g_pgvec_ensure_rc = 0;
+   g_kb_build_rc = 0;
+   g_code_scan_rc = 0;
+   g_code_embed_refresh_rc = 0;
+   g_code_embed_estimated = 4;
+   g_code_embed_embedded = 2;
+   g_code_embed_skipped = 1;
+   const char *body = "{\"path\":\"/client/repo\",\"project\":\"thin-client\"}";
+   int s = kb_http_route_ex("POST", "/v1/code/build", NULL, NULL, NULL, body, (int)strlen(body),
+                            buf, sizeof(buf));
+   assert(s == 503);
+   assert(strstr(buf, "project code embedding refresh failed") != NULL);
+
+   g_code_embed_estimated = 0;
+   g_code_embed_embedded = 0;
+   g_code_embed_skipped = 0;
 }
 
 static void test_code_update_ok(void)
@@ -5518,6 +5591,7 @@ int main(void)
    test_code_scan_pushed_files_rejects_invalid_item();
    test_code_scan_db_unavailable();
    test_code_build_ok();
+   test_code_build_rejects_partial_project_embedding();
    test_code_update_ok();
    test_ingest_enqueue_ok();
    test_ingest_status_ok();

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -1818,14 +1818,21 @@ int main(void)
       assert(server_http_conn_caps(1, "plain", SERVER_REMOTE_WRITES_DATA) == CAPS_AUTHENTICATED);
       assert(server_http_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL) == CAPS_ALL);
 
-      /* P8 thin-client posture is independent of the operator's generic TCP
-       * remote_writes setting: bearer fallback is query-only and a cert gains
-       * authenticated session capabilities, never CAPS_ALL. */
+      /* P8 thin-client posture uses the resolved per-user tier: bearer fallback
+       * is query-only, a cert gains authenticated session capabilities at
+       * off/data, and only a verified full grant gains CAPS_ALL. */
       uint32_t fallback = CAPS_READ_ONLY & ~(uint32_t)CAP_CHAT;
       assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL, 1, 0) ==
              fallback);
-      assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL, 1, 1) ==
+      assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_OFF, 1, 1) ==
              CAPS_AUTHENTICATED);
+      assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_DATA, 1, 1) ==
+             CAPS_AUTHENTICATED);
+      assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL, 1, 1) ==
+             CAPS_ALL);
+      assert(server_http_route_allowed_caps(
+                 1, server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL, 1, 1),
+                 "POST", "/v1/kb/build", SERVER_REMOTE_WRITES_FULL) == 1);
       assert(server_http_mtls_transport_allowed(1, 1, 0, "GET", "/v1/config") == 1);
       assert(server_http_mtls_transport_allowed(1, 2, 0, "GET", "/v1/config") == 0);
       assert(server_http_mtls_transport_allowed(1, 2, 1, "GET", "/v1/config") == 1);


### PR DESCRIPTION
## Summary

Follow up merged PR #2122 with four defects found while making the wizard-managed deployment meet a real thin-client indexing and embedding acceptance gate.

- honor the wizard first owner's certificate-bound `full` grant on the mTLS path;
- make remote `kb build --force` a synchronous project code/document embedding barrier;
- prevent the background document sweep from starving later projects;
- propagate caller deadlines through the server-to-KB mTLS relay;
- expose the exact distributed KB version through server health;
- record the final wizard-owned identity/index/embed acceptance evidence.

This branch is based on the merge commit for #2122 and contains only the post-merge follow-up: 17 files, 298 additions, 50 deletions.

## Why this is required

The browser wizard correctly owns enrollment, server/team identity, certificate material, signed JWKS trust, and the first-owner grant. The benchmark then exercises a normal remote client: register a fresh repository, upload its canonical index, finish embeddings, and perform structural and semantic reads before an agent starts.

That path exposed cases where a nominally healthy install was not yet usable: the grant was discarded, build returned before project embeddings were queryable, later projects could starve, a 180-second caller timeout was reduced to the relay's fixed 30 seconds, and health could not pin the KB revision.

## Live acceptance

The benchmark service currently reports:

- server `0.2.195-1009-g35f62657`;
- distributed KB `v0.2.195-1007-gb0e1f2c5`;
- thin client `v0.2.195-1003-g627c1ffc`;
- server, store, vector index, and embedder healthy;
- wizard-generated managed identity ready, default-team bound, mTLS authenticated, owner/full.

A fresh per-project gate completes `workspace add`, forced index upload, and synchronous `kb build --force`, then resolves the planted symbol, all three callers, blast radius, and a project-scoped semantic README hit from identical pre-edit heads/manifests. The actual Claude startup inventory also has to show the Aimee MCP server connected.

## Verification

- `make -C src lint` — all 38 checks pass (report-only existing warnings remain);
- focused `unit-test-kb-client-search`, `unit-test-kb-http-routes`, and `unit-test-server-http` — pass;
- full `aimee-server` and `aimee-kb` builds — pass;
- live server/KB version and health provenance — pass;
- five accepted benchmark canaries completed their per-project readiness gates and hidden tests before the provider quota window closed.
- GitHub CI — **23/23 checks pass**, including lint/build/unit, identity minting,
  authorization tiers, Windows/macOS, all Docker e2e tiers, adoption, memory
  retrieval, tree-sitter, Vault token, and bench.

## Review note

The benchmark remains isolated: Aimee is installed only in the Aimee arm. Baseline and both Ponytail arms use separate config roots and a PATH that omits Aimee.
