### PR TITLE
fix(wfe): harden unattended workflow delegates

### DIFF
--- a/src/modules/delegates/delegate_role.c
+++ b/src/modules/delegates/delegate_role.c
@@ -170,3 +170,18 @@ void delegate_apply_max_turns_policy(agent_config_t *cfg, const char *role, int 
          cfg->agents[i].max_turns = default_cap;
    }
 }
+
+void delegate_apply_max_turns_cap(agent_config_t *cfg, const char *role, int cap)
+{
+   if (!cfg || !role || !role[0] || cap <= 0)
+      return;
+
+   const char *canonical_role = delegate_role_canonicalize(role);
+   for (int i = 0; i < cfg->agent_count; i++)
+   {
+      if (!delegate_agent_supports_role(&cfg->agents[i], canonical_role))
+         continue;
+      if (cfg->agents[i].max_turns <= 0 || cfg->agents[i].max_turns > cap)
+         cfg->agents[i].max_turns = cap;
+   }
+}

--- a/src/modules/delegates/include/aimee/delegates/delegate_role.h
+++ b/src/modules/delegates/include/aimee/delegates/delegate_role.h
@@ -38,6 +38,11 @@ int delegate_final_after_turns_for_role(const char *role);
  * budget before returning useful signal. */
 void delegate_apply_max_turns_policy(agent_config_t *cfg, const char *role, int max_turns);
 
+/* Apply a per-invocation safety ceiling without raising a stricter agent/role
+ * limit. Unlike an explicit max_turns override, this converts unlimited
+ * (-1/0) to `cap` and clamps only eligible agents above it. */
+void delegate_apply_max_turns_cap(agent_config_t *cfg, const char *role, int cap);
+
 /* Canonicalize a delegate role name.  Returns the canonical name if role is
  * a known alias (e.g. "implement" -> "code"), otherwise returns role unchanged.
  * Never returns NULL.  The returned pointer is either role itself or a string

--- a/src/modules/roundtable/delegate_ensemble.c
+++ b/src/modules/roundtable/delegate_ensemble.c
@@ -2020,6 +2020,12 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
                                           local.brief, local.context, results)
                    : run_round_parallel(acfg, cfg, task, artifact, peer_notes, local.mode, round,
                                         local.brief, local.context, results, panel_deadline_ms);
+      /* The parallel runner enforces the wall bound inside an in-flight provider
+       * call. Record that terminal fact immediately; a one-round panel otherwise
+       * exits before the loop-top deadline check and can look fully valid even
+       * though one or more seats were cancelled at the deadline. */
+      if (local.deadline_ms > 0 && monotonic_ms() - start_ms >= local.deadline_ms)
+         out->deadline_hit = 1;
       if (rc != 0)
       {
          for (int i = 0; i < ref_count; i++)

--- a/src/modules/workflows/wfe_blocks.c
+++ b/src/modules/workflows/wfe_blocks.c
@@ -622,9 +622,20 @@ static int node_bool(const wfe_node_t *node, const char *key)
  * the step's assigned agent (or "$random", or "" to route by role). out_cost (may
  * be NULL) receives the server-side wall-clock USD estimate for the turn (WP-5
  * budget). Returns:
- *   1  provider ran and succeeded,
- *   0  no provider installed (caller falls back to its fail-closed path),
- *  -1  provider ran and failed (caller should loop/retry). */
+ *   1  provider ran and changed the requested artifact/worktree,
+ *   0  no provider installed (caller falls back to its legacy path),
+ *  -1  provider ran and failed (caller should loop/retry),
+ *  -2  provider completed but proved the requested write was a no-op. */
+#define WFE_DISPATCH_NO_CHANGE (-2)
+
+int wfe_delegate_error_is_no_change(const char *error)
+{
+   if (!error || !strstr(error, "result treated as incomplete"))
+      return 0;
+   return strstr(error, "no file changes detected") != NULL ||
+          strstr(error, "no owned files changed") != NULL;
+}
+
 static int wfe_delegate_dispatch(const char *workdir, const char *role, const char *prompt,
                                  const char *artifact_path, char out_commit_sha[64],
                                  double *out_cost)
@@ -645,7 +656,11 @@ static int wfe_delegate_dispatch(const char *workdir, const char *role, const ch
       *out_cost = (ok0 && ok1) ? wfe_autonomy_cost_estimate((double)(t1.tv_sec - t0.tv_sec) +
                                                             (double)(t1.tv_nsec - t0.tv_nsec) / 1e9)
                                : 0.0;
-   return rc == 0 ? 1 : -1;
+   if (rc == WFE_DELEGATE_OK)
+      return 1;
+   if (rc == WFE_DELEGATE_NO_CHANGE)
+      return WFE_DISPATCH_NO_CHANGE;
+   return -1;
 }
 
 /* Attach the measured delegate cost to a result, so a turn's wall-clock cost is
@@ -1023,64 +1038,18 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
                   base_prompt, feedback);
       else
          snprintf(prompt, sizeof prompt, "%s", base_prompt);
-      /* Snapshot HEAD so a NO-OP dispatch is detectable below. */
-      char pre_head[64] = "";
-      {
-         const char *argv[] = {"git", "-C", wd, "rev-parse", "HEAD", NULL};
-         char *o = NULL;
-         if (git_capture(argv, &o) == 0 && o)
-         {
-            chomp(o);
-            snprintf(pre_head, sizeof pre_head, "%s", o);
-         }
-         free(o);
-      }
       int impl_rc = wfe_delegate_dispatch(wd, "engineer", prompt, NULL, commit, &cost);
-      /* A dispatch that reports no new work (impl_rc < 0 — e.g. the write-role
-       * delegate produced no diff, flagged by delegate_detect_noop_write) is a
-       * FAILED attempt on a roundtable on_fail RETRY (feedback present): looping
-       * re-dispatches a different agent rather than re-running the panel on an
-       * unchanged tree. On the FIRST pass (no feedback) the SAME no-diff dispatch
-       * instead means a PRIOR implement iteration already committed the work and
-       * advanced HEAD, but the slice looped back here (e.g. a transient verify
-       * failure); this delegate correctly finds nothing left to do. Do NOT loop on
-       * that — fall through to the mandatory verify below so a now-passing committed
-       * tree advances instead of spinning to the attempt cap. A genuine no-op with
-       * no committed work still fails verify there and loops, so unverified work is
-       * never advanced. (Without this, once any iteration commits the artifact every
-       * later delegate no-ops -> impl_rc < 0 -> the slice loops forever, never
-       * reaching the verify that would let the committed tree pass — observed live.) */
-      if (impl_rc < 0)
-      {
-         if (feedback[0])
-            return with_cost(wfe_step_looped(), cost);
-         db1_lifecycle_event_add(wfe_ctx_work_item(ctx), node->id, "loop", "engine",
-                                 "impl no-op dispatch (first pass): verifying committed tree", "",
-                                 cost);
-      }
-      /* A dispatch that changed NOTHING (reply-only, no tool edits, so the
-       * provider's add+commit no-opped and HEAD is unchanged) is a FAILED
-       * attempt, not an advance: freezing the identical tree re-runs verify and
-       * a full 4-seat panel on a diff the panel already rejected. Observed
-       * live: whole review rounds burned on byte-identical artifacts. Loop so
-       * the retry re-dispatches (a $random re-roll picks a different agent). */
-      if (pre_head[0] && commit[0] && strcmp(pre_head, commit) == 0 && feedback[0])
-      {
-         /* A no-op is a failed attempt only on a roundtable on_fail RETRY (feedback
-          * present): re-advancing the identical, already-rejected diff would re-run
-          * the 4-seat panel on a byte-identical artifact forever. On the FIRST pass
-          * (no feedback) a no-op instead means a PRIOR implement iteration already
-          * committed the work and advanced HEAD, but its mechanical verify failed
-          * transiently (e.g. the sandbox could not acquire a container) and looped
-          * back; this iteration's delegate correctly finds nothing left to do. Do
-          * NOT loop on that — fall through to the mandatory verify below so a
-          * now-passing committed tree can advance instead of spinning to the attempt
-          * cap. A genuine no-op with no committed work still fails verify there and
-          * loops, so this never advances unverified work. */
-         db1_lifecycle_event_add(wfe_ctx_work_item(ctx), node->id, "loop", "engine",
-                                 "impl no-op: delegate made no edits (post-review)", "", cost);
+      if (impl_rc == -1)
          return with_cost(wfe_step_looped(), cost);
-      }
+      /* NO_CHANGE is an outcome, not a failed execution. The packet may already
+       * be satisfied by an earlier slice or retry, including after a roundtable
+       * requested a correction that another slice landed. Let the mandatory
+       * mechanical and adversarial gates below decide. If the unchanged tree is
+       * still deficient, those gates fail and the engine retries as before. */
+      if (impl_rc == WFE_DISPATCH_NO_CHANGE)
+         db1_lifecycle_event_add(wfe_ctx_work_item(ctx), node->id, "noop", "engine",
+                                 "implement delegate made no changes; verifying current tree", "",
+                                 cost);
    }
 
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
@@ -1113,11 +1082,19 @@ static wfe_step_result_t exec_document(wfe_ctx *ctx, const wfe_node_t *node)
    resolve_workdir(ctx, wd, sizeof wd);
    char commit[64] = "";
    double cost = 0.0;
-   if (wfe_delegate_dispatch(wd, "engineer",
-                             "Document the change on the work-item branch (README/CHANGELOG/docs "
-                             "+ inline comments), then commit.",
-                             NULL, commit, &cost) < 0)
+   int doc_rc = wfe_delegate_dispatch(
+       wd, "engineer",
+       "Document the change on the work-item branch (README/CHANGELOG/docs + inline comments), "
+       "then commit.",
+       NULL, commit, &cost);
+   if (doc_rc == -1)
       return with_cost(wfe_step_looped(), cost);
+   /* Documentation can already be complete (especially after merged slices).
+    * Freeze the unchanged tree and let the downstream documentation roundtable
+    * judge completeness instead of requiring a meaningless edit. */
+   if (doc_rc == WFE_DISPATCH_NO_CHANGE)
+      db1_lifecycle_event_add(wfe_ctx_work_item(ctx), node->id, "noop", "engine",
+                              "document delegate made no changes; freezing current tree", "", cost);
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
       return with_cost(wfe_step_failed_class(WFE_FAIL_CORRUPTION, 0), cost); /* worktree/git */

--- a/src/modules/workflows/wfe_blocks.h
+++ b/src/modules/workflows/wfe_blocks.h
@@ -47,6 +47,16 @@ typedef enum
    WFE_MERGE_ERROR          /* forge error -> fail closed */
 } wfe_merge_result_t;
 
+typedef enum
+{
+   WFE_DELEGATE_ERROR = -1,
+   WFE_DELEGATE_OK = 0,
+   /* The delegate completed normally but the requested write was already
+    * satisfied, so it left the worktree unchanged. Producing blocks may pass
+    * the current tree to their authoritative gate instead of retrying blindly. */
+   WFE_DELEGATE_NO_CHANGE = 1
+} wfe_delegate_result_t;
+
 typedef struct
 {
    wfe_ci_status_t (*ci_status)(const char *repo, const char *pr_ref);
@@ -86,11 +96,18 @@ typedef struct
     * selection is the delegate system's routing decision (routed by `role` +
     * capabilities), not a per-step choice. If the block produces a file artifact,
     * `artifact_path` is its path (else NULL). On success returns 0 and, if a commit
-    * was made, fills out_commit_sha (else ""). Non-zero => the caller emits
-    * failed/looped, never a crash. */
+    * was made, fills out_commit_sha (else ""). Return WFE_DELEGATE_NO_CHANGE
+    * only when the delegate completed but the write-role no-op detector proved
+    * the worktree stayed unchanged; return WFE_DELEGATE_ERROR for transport,
+    * provider, or execution failures. */
    int (*run)(const char *workdir, const char *role, const char *prompt, const char *artifact_path,
               char out_commit_sha[64], char *err, size_t errlen);
 } wfe_delegate_provider_t;
+
+/* Classify the stable no-op diagnostics emitted by delegate_detect_noop_write.
+ * Kept here so the server bridge can preserve NO_CHANGE across the coord queue
+ * without treating unrelated delegate failures as acceptable no-ops. */
+int wfe_delegate_error_is_no_change(const char *error);
 
 /* Install a delegate provider (NULL restores the default fail-closed provider). */
 void wfe_set_delegate_provider(const wfe_delegate_provider_t *p);

--- a/src/posix/agent_bridge.c
+++ b/src/posix/agent_bridge.c
@@ -15,6 +15,11 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+/* The HTTP client is also used by small standalone binaries that do not link
+ * the agent runtime. In the server this resolves to the parallel worker's
+ * thread-local cancellation flag; elsewhere the weak symbol is absent. */
+int agent_request_cancelled(void) __attribute__((weak));
+
 static SSL_CTX *s_ssl_ctx;
 
 void agent_http_init(void)
@@ -135,6 +140,28 @@ static int64_t conn_now_ns(void)
 static int conn_past_deadline(const http_conn_t *conn)
 {
    return conn->deadline_ns && conn_now_ns() > conn->deadline_ns;
+}
+
+static int conn_cancelled(void)
+{
+   return agent_request_cancelled && agent_request_cancelled();
+}
+
+/* A panel deadline is shorter than an individual provider timeout. Once a
+ * connection exists, poll blocking socket/TLS operations frequently enough for
+ * the parallel worker's cancellation flag to interrupt the provider call before
+ * pthread_join can extend the panel past its wall-clock budget. */
+#define HTTP_CANCEL_POLL_MS 100
+
+static void conn_enable_cancel_poll(http_conn_t *conn)
+{
+   if (!conn || conn->fd < 0 || !agent_request_cancelled)
+      return;
+   struct timeval tv;
+   tv.tv_sec = 0;
+   tv.tv_usec = HTTP_CANCEL_POLL_MS * 1000;
+   setsockopt(conn->fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+   setsockopt(conn->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 }
 
 static int connect_with_timeout(const char *host, int port, int timeout_ms)
@@ -385,6 +412,8 @@ static int conn_open(http_conn_t *conn, const parsed_url_t *url, int timeout_ms)
       }
    }
 
+   conn_enable_cancel_poll(conn);
+
    if (url->use_ssl)
    {
       if (!s_ssl_ctx)
@@ -406,7 +435,23 @@ static int conn_open(http_conn_t *conn, const parsed_url_t *url, int timeout_ms)
       /* Enable hostname verification */
       SSL_set1_host(conn->ssl, url->host);
 
-      if (SSL_connect(conn->ssl) <= 0)
+      int connected = 0;
+      while (!conn_cancelled() && !conn_past_deadline(conn))
+      {
+         int rc = SSL_connect(conn->ssl);
+         if (rc == 1)
+         {
+            connected = 1;
+            break;
+         }
+         int ssl_err = SSL_get_error(conn->ssl, rc);
+         if (ssl_err == SSL_ERROR_WANT_READ || ssl_err == SSL_ERROR_WANT_WRITE ||
+             (ssl_err == SSL_ERROR_SYSCALL &&
+              (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)))
+            continue;
+         break;
+      }
+      if (!connected)
       {
          SSL_free(conn->ssl);
          close(conn->fd);
@@ -435,9 +480,29 @@ static void conn_close(http_conn_t *conn)
 
 static ssize_t conn_write(http_conn_t *conn, const void *buf, size_t len)
 {
-   if (conn->ssl)
-      return SSL_write(conn->ssl, buf, (int)len);
-   return send(conn->fd, buf, len, 0);
+   for (;;)
+   {
+      if (conn_cancelled() || conn_past_deadline(conn))
+         return -1;
+      if (conn->ssl)
+      {
+         ssize_t n = SSL_write(conn->ssl, buf, (int)len);
+         if (n > 0)
+            return n;
+         int err = SSL_get_error(conn->ssl, (int)n);
+         if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE ||
+             (err == SSL_ERROR_SYSCALL &&
+              (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)))
+            continue;
+         return -1;
+      }
+      ssize_t n = send(conn->fd, buf, len, 0);
+      if (n >= 0)
+         return n;
+      if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
+         continue;
+      return -1;
+   }
 }
 
 static ssize_t conn_read(http_conn_t *conn, void *buf, size_t len)
@@ -450,6 +515,8 @@ static ssize_t conn_read(http_conn_t *conn, void *buf, size_t len)
     * actually past. Only a real EOF or error ends the read early. */
    for (;;)
    {
+      if (conn_cancelled())
+         return -1;
       if (conn->ssl)
       {
          ssize_t n = SSL_read(conn->ssl, buf, (int)len);
@@ -462,7 +529,7 @@ static ssize_t conn_read(http_conn_t *conn, void *buf, size_t len)
              (err == SSL_ERROR_SYSCALL &&
               (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)))
          {
-            if (conn_past_deadline(conn))
+            if (conn_cancelled() || conn_past_deadline(conn))
                return -1;
             continue; /* SO_RCVTIMEO fired; peer is slow, not gone */
          }
@@ -471,8 +538,8 @@ static ssize_t conn_read(http_conn_t *conn, void *buf, size_t len)
       ssize_t n = recv(conn->fd, buf, len, 0);
       if (n >= 0)
          return n;
-      if (errno == EINTR ||
-          ((errno == EAGAIN || errno == EWOULDBLOCK) && !conn_past_deadline(conn)))
+      if (errno == EINTR || ((errno == EAGAIN || errno == EWOULDBLOCK) && !conn_cancelled() &&
+                             !conn_past_deadline(conn)))
          continue;
       return -1;
    }

--- a/src/server/http_retry.c
+++ b/src/server/http_retry.c
@@ -10,6 +10,8 @@
 #include <time.h>
 #include <unistd.h>
 
+int agent_request_cancelled(void) __attribute__((weak));
+
 /* Monotonic milliseconds for measuring how long a single attempt actually took
  * (used to distinguish a budget-consuming stall from a fast-fail before retry). */
 static int64_t retry_now_ms(void)
@@ -22,6 +24,27 @@ static int64_t retry_now_ms(void)
 /* Thread-local progress callback (see http_retry.h). Each connection/turn runs on
  * its own worker thread, so a thread-local matches the delegate run's lifetime. */
 static _Thread_local http_progress_cb_t g_progress_cb;
+
+static int retry_cancelled(void)
+{
+   return agent_request_cancelled && agent_request_cancelled();
+}
+
+static int retry_wait_ms(int delay_ms)
+{
+   while (delay_ms > 0)
+   {
+      if (retry_cancelled())
+         return -1;
+      int slice = delay_ms < 100 ? delay_ms : 100;
+      struct timespec nap = {slice / 1000, (long)(slice % 1000) * 1000000L};
+      while (nanosleep(&nap, &nap) != 0)
+         if (retry_cancelled())
+            return -1;
+      delay_ms -= slice;
+   }
+   return retry_cancelled() ? -1 : 0;
+}
 
 void http_set_progress_cb(http_progress_cb_t cb)
 {
@@ -127,13 +150,16 @@ int http_retry_post_context_bytes(const char *url, const char *auth_header, cons
 
    for (int attempt = 0; attempt < effective_max_attempts; attempt++)
    {
+      if (retry_cancelled())
+         break;
       /* Sleep before retry (not before first attempt) */
       if (attempt > 0)
       {
          int delay = http_backoff_ms(attempt - 1, base_ms, max_ms);
          aimee_log(LOG_INFO, "http_retry", "attempt %d/%d, retrying in %dms (status %d)...",
                    attempt + 1, effective_max_attempts, delay, http_status);
-         usleep((unsigned)(delay * 1000));
+         if (retry_wait_ms(delay) != 0)
+            break;
       }
 
       /* Free previous response if retrying */

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -713,6 +713,7 @@ void delegate_worker(void *arg)
    cJSON *jbranch = cJSON_GetObjectItemCaseSensitive(req, "branch");
    cJSON *jtimeout = cJSON_GetObjectItemCaseSensitive(req, "timeout_ms");
    cJSON *jmaxturns = cJSON_GetObjectItemCaseSensitive(req, "max_turns");
+   cJSON *jmaxturnscap = cJSON_GetObjectItemCaseSensitive(req, "max_turns_cap");
    cJSON *jhandoff = cJSON_GetObjectItemCaseSensitive(req, "handoff_json");
    cJSON *jtools = cJSON_GetObjectItemCaseSensitive(req, "tools");
    cJSON *jprovided_target = cJSON_GetObjectItemCaseSensitive(req, "provided_target");
@@ -737,6 +738,9 @@ void delegate_worker(void *arg)
        (cJSON_IsString(jbranch) && jbranch->valuestring[0]) ? jbranch->valuestring : NULL;
    int timeout_ms = cJSON_IsNumber(jtimeout) ? (int)jtimeout->valuedouble : 0;
    int max_turns = cJSON_IsNumber(jmaxturns) ? (int)jmaxturns->valuedouble : -1;
+   int max_turns_cap = cJSON_IsNumber(jmaxturnscap) && jmaxturnscap->valuedouble > 0
+                           ? (int)jmaxturnscap->valuedouble
+                           : 0;
    int handoff_json = cJSON_IsTrue(jhandoff);
    /* Only the JSON boolean literal true opts out; absent, false, and malformed
     * values preserve automatic evidence grounding. */
@@ -1032,6 +1036,7 @@ void delegate_worker(void *arg)
       target_agent->timeout_ms =
           delegate_effective_timeout_ms(timeout_ms, target_agent->timeout_ms);
    delegate_apply_max_turns_policy(&acfg, role, max_turns);
+   delegate_apply_max_turns_cap(&acfg, role, max_turns_cap);
    if (cctx->background_job_id > 0 && target_agent)
       db1_agent_job_set_agent(cctx->background_job_id, target_agent->name);
    /* Resolve the credential (WP-C.1 vault-FIRST + WP-C.3 per-principal cooldown):

--- a/src/server/server_coord_dispatcher.c
+++ b/src/server/server_coord_dispatcher.c
@@ -38,6 +38,11 @@ typedef struct
    int spawn_rc; /* 0 spawned, -1 refused/failed; -1 until the adapter runs */
 } coord_spawn_backing_t;
 
+/* Coord write tasks are unattended and may otherwise inherit an unlimited code
+ * role. Forty-eight turns leaves headroom above successful live runs while
+ * preventing a confused model from continuing indefinitely after useful work. */
+#define COORD_WRITE_MAX_TURNS 48
+
 /* The spawn_delegate capability for coord tasks: build the delegate request + compute ctx from
  * (role, brief) and the backing, then submit to an on-demand delegate worker. Returns 0/-1 and
  * also records it in the backing so the dispatcher can release+retry a refused claim. */
@@ -62,7 +67,10 @@ static int coord_spawn_delegate(void *ctx, const char *role, const char *brief)
     * roles already opt in via delegate_role_enable_tools_by_default; a caller can
     * still pass tools:false explicitly, which server_compute honors. */
    if (delegate_role_is_write(req_role))
+   {
       cJSON_AddTrueToObject(req, "tools");
+      cJSON_AddNumberToObject(req, "max_turns_cap", COORD_WRITE_MAX_TURNS);
+   }
    cJSON_AddStringToObject(req, "prompt", brief ? brief : "");
    /* Persona (the delegate's identity, required for every delegate) is carried on
     * the coord task now — the orchestrator that enqueued it (coord planner or the

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -52,10 +52,11 @@
 /* Block (busy-poll) until a single-task coord job reaches a terminal state, then
  * hand back the delegate's result text. WFE runs on the autonomy scheduler
  * thread; the coord DISPATCHER runs the task on its own thread through the shared
- * delegate path, so this only waits — it never executes the delegate. Returns 0
- * and fills result_out on 'done'; -1 (+err) on 'failed'/'cancelled'/timeout. */
-static int wfe_coord_task_wait(int job_id, int task_id, char *result_out, size_t result_cap,
-                               char *err, size_t errlen)
+ * delegate path, so this only waits — it never executes the delegate. Returns
+ * OK and fills result_out on 'done', NO_CHANGE for the write-role detector's
+ * stable no-op outcome, or ERROR (+err) on other failures/cancellation/timeout. */
+static wfe_delegate_result_t wfe_coord_task_wait(int job_id, int task_id, char *result_out,
+                                                 size_t result_cap, char *err, size_t errlen)
 {
    (void)task_id;              /* the job holds exactly one task */
    const int max_polls = 1600; /* 1600 * 750ms ~= 20 min, matching the delegate timeout ceiling */
@@ -69,14 +70,16 @@ static int wfe_coord_task_wait(int job_id, int task_id, char *result_out, size_t
          {
             if (result_out && result_cap)
                snprintf(result_out, result_cap, "%s", task.result);
-            return 0;
+            return WFE_DELEGATE_OK;
          }
          if (strcmp(task.status, "failed") == 0 || strcmp(task.status, "cancelled") == 0)
          {
+            if (strcmp(task.status, "failed") == 0 && wfe_delegate_error_is_no_change(task.error))
+               return WFE_DELEGATE_NO_CHANGE;
             if (err && errlen)
                snprintf(err, errlen, "wfe delegate task %s: %s", task.status,
                         task.error[0] ? task.error : "no detail");
-            return -1;
+            return WFE_DELEGATE_ERROR;
          }
       }
       struct timespec ts = {0, 750L * 1000L * 1000L};
@@ -84,7 +87,7 @@ static int wfe_coord_task_wait(int job_id, int task_id, char *result_out, size_t
    }
    if (err && errlen)
       snprintf(err, errlen, "wfe delegate task timed out");
-   return -1;
+   return WFE_DELEGATE_ERROR;
 }
 
 /* The live delegate run. Contract per wfe_delegate_provider_t.
@@ -146,8 +149,17 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
    }
 
    char result[DB1_COORD_RESULT_LEN] = "";
-   if (wfe_coord_task_wait(job_id, task_id, result, sizeof result, err, errlen) != 0)
-      return -1;
+   wfe_delegate_result_t task_result =
+       wfe_coord_task_wait(job_id, task_id, result, sizeof result, err, errlen);
+   if (task_result != WFE_DELEGATE_OK)
+   {
+      /* A timed-out/failed coord wait must not leave an admitted delegate
+       * running after the workflow has moved on. Cancellation is idempotent for
+       * an already-terminal job, and the agent loop observes it cooperatively. */
+      if (task_result == WFE_DELEGATE_ERROR)
+         db1_coord_job_cancel(job_id);
+      return task_result;
+   }
 
    /* A worktree-mutating (implement/decompose/tdd/document) delegate edits the
     * dedicated per-slice worktree in place; stage + commit its work here so the
@@ -449,10 +461,12 @@ static int wfe_live_judge_run(const char *workdir, const char *lens, char *out_v
    }
 
    char result[DB1_COORD_RESULT_LEN] = "";
-   int ok = wfe_coord_task_wait(job_id, task_id, result, sizeof result, NULL, 0);
+   wfe_delegate_result_t ok = wfe_coord_task_wait(job_id, task_id, result, sizeof result, NULL, 0);
+   if (ok == WFE_DELEGATE_ERROR)
+      db1_coord_job_cancel(job_id);
 
    int refuted = 1; /* fail-closed default */
-   if (ok == 0 && result[0])
+   if (ok == WFE_DELEGATE_OK && result[0])
    {
       /* Parse ONLY the LAST non-empty line as the verdict JSON (the delegate is told
        * to emit exactly one JSON line at the end). A substring scan of the whole

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -1908,7 +1908,9 @@ static void test_roundtable_deadline_returns_best_so_far(void)
    memset(&opts, 0, sizeof(opts));
    opts.mode = ROUNDTABLE_DRAFT;
    opts.turns = ROUNDTABLE_PARALLEL;
-   opts.max_rounds = 3;
+   /* One round exercises the post-panel deadline capture: there is no next
+    * loop-top check to set deadline_hit for us. */
+   opts.max_rounds = 1;
    opts.deadline_ms = 1;
    roundtable_result_t result;
    int rc = delegate_roundtable_run(&acfg, &cfg, "draft until deadline", &opts, &result);

--- a/src/tests/test_delegate_role.c
+++ b/src/tests/test_delegate_role.c
@@ -273,6 +273,34 @@ static void test_apply_max_turns_policy(void)
    printf("  PASS: test_apply_max_turns_policy\n");
 }
 
+static void test_apply_max_turns_cap(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 5;
+   for (int i = 0; i < 4; i++)
+   {
+      snprintf(cfg.agents[i].roles[0], sizeof(cfg.agents[i].roles[0]), "code");
+      cfg.agents[i].role_count = 1;
+   }
+   cfg.agents[0].max_turns = -1; /* inherited unlimited */
+   cfg.agents[1].max_turns = 0;  /* explicitly unlimited */
+   cfg.agents[2].max_turns = 20; /* stricter agent cap */
+   cfg.agents[3].max_turns = 200;
+   snprintf(cfg.agents[4].roles[0], sizeof(cfg.agents[4].roles[0]), "review");
+   cfg.agents[4].role_count = 1;
+   cfg.agents[4].max_turns = 200;
+
+   delegate_apply_max_turns_cap(&cfg, "code", 48);
+   assert(cfg.agents[0].max_turns == 48);
+   assert(cfg.agents[1].max_turns == 48);
+   assert(cfg.agents[2].max_turns == 20);
+   assert(cfg.agents[3].max_turns == 48);
+   assert(cfg.agents[4].max_turns == 200); /* ineligible role untouched */
+
+   printf("  PASS: test_apply_max_turns_cap\n");
+}
+
 static void test_auto_tools_policy(void)
 {
    assert(delegate_role_auto_tools_for_invocation("diagnose", -1, 0) == 1);
@@ -309,6 +337,7 @@ int main(void)
    test_culled_persona_roles_are_rejected();
    test_inspection_turn_policies();
    test_apply_max_turns_policy();
+   test_apply_max_turns_cap();
    test_auto_tools_policy();
    printf("All tests passed.\n");
    return 0;

--- a/src/tests/test_http_retry.c
+++ b/src/tests/test_http_retry.c
@@ -2,15 +2,26 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <netinet/in.h>
+#include <pthread.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 #include "aimee.h"
+#include "agent_exec.h"
 #include "failover.h"
 #include "http_retry.h"
+
+static atomic_int g_request_cancelled;
+
+int agent_request_cancelled(void)
+{
+   return atomic_load(&g_request_cancelled);
+}
 
 /* http_retry_post_context records failover events via interaction_events.o ->
  * db1_conn; this test binary doesn't link db1. Stub it to NULL so recording
@@ -90,6 +101,75 @@ static void test_stall_caps_retries(void)
    close(srv);
    assert(g_progress_calls == 2); /* 3 requested, capped to 2 after the first stall */
    printf("  PASS: test_stall_caps_retries\n");
+}
+
+typedef struct
+{
+   int listener;
+} cancel_server_t;
+
+static void sleep_ms(int ms)
+{
+   struct timespec ts = {ms / 1000, (long)(ms % 1000) * 1000000L};
+   nanosleep(&ts, NULL);
+}
+
+static int64_t monotonic_ms(void)
+{
+   struct timespec ts;
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+   return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+static void *hold_response_until_after_cancel(void *arg)
+{
+   cancel_server_t *server = arg;
+   int client = accept(server->listener, NULL, NULL);
+   assert(client >= 0);
+   char request[1024];
+   assert(recv(client, request, sizeof(request), 0) > 0);
+   sleep_ms(100);
+   atomic_store(&g_request_cancelled, 1);
+   /* Keep the peer open well beyond the client's expected return. If the HTTP
+    * transport ignores cancellation, agent_http_post blocks here until close. */
+   sleep_ms(1200);
+   close(client);
+   return NULL;
+}
+
+static void test_inflight_http_observes_parallel_cancel(void)
+{
+   int srv = socket(AF_INET, SOCK_STREAM, 0);
+   assert(srv >= 0);
+   struct sockaddr_in addr;
+   memset(&addr, 0, sizeof(addr));
+   addr.sin_family = AF_INET;
+   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   addr.sin_port = 0;
+   assert(bind(srv, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+   assert(listen(srv, 1) == 0);
+   socklen_t alen = sizeof(addr);
+   assert(getsockname(srv, (struct sockaddr *)&addr, &alen) == 0);
+
+   cancel_server_t server = {.listener = srv};
+   pthread_t thread;
+   atomic_store(&g_request_cancelled, 0);
+   assert(pthread_create(&thread, NULL, hold_response_until_after_cancel, &server) == 0);
+
+   char url[64];
+   snprintf(url, sizeof(url), "http://127.0.0.1:%d/x", ntohs(addr.sin_port));
+   char *response = NULL;
+   int64_t started = monotonic_ms();
+   int status = agent_http_post(url, NULL, "{}", &response, 5000, NULL);
+   int64_t elapsed = monotonic_ms() - started;
+   free(response);
+
+   assert(status < 0);
+   assert(elapsed < 800); /* peer remains open for 1.3s; cancellation wins */
+   pthread_join(thread, NULL);
+   close(srv);
+   atomic_store(&g_request_cancelled, 0);
+   printf("  PASS: test_inflight_http_observes_parallel_cancel (%lldms)\n", (long long)elapsed);
 }
 
 static ssize_t read_full(int fd, void *buf, size_t len)
@@ -410,6 +490,7 @@ int main(void)
    test_progress_cb_fires_per_attempt();
    test_stall_caps_retries();
    test_exact_length_body_is_identical_across_retries();
+   test_inflight_http_observes_parallel_cancel();
 
    printf("all http_retry tests passed.\n");
    return 0;

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -207,6 +207,15 @@ void delegate_apply_max_turns_policy(agent_config_t *cfg, const char *role, int 
    for (int i = 0; i < cfg->agent_count; i++)
       cfg->agents[i].max_turns = max_turns;
 }
+void delegate_apply_max_turns_cap(agent_config_t *cfg, const char *role, int cap)
+{
+   (void)role;
+   if (!cfg || cap <= 0)
+      return;
+   for (int i = 0; i < cfg->agent_count; i++)
+      if (cfg->agents[i].max_turns <= 0 || cfg->agents[i].max_turns > cap)
+         cfg->agents[i].max_turns = cap;
+}
 char *role_template_build(const char *project_root, const char *role, const char *task,
                           const char *context)
 {

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -39,6 +39,48 @@ static int mock_deleg_run(const char *workdir, const char *role, const char *pro
 }
 static const wfe_delegate_provider_t MOCK_DELEG = {mock_deleg_run};
 
+/* A completed write delegate that correctly finds the requested tree already
+ * satisfies the packet. The live bridge reports this distinctly from provider
+ * failure; this mock drives implement + document through that outcome. */
+static int g_noop_impl_calls;
+static int g_noop_doc_calls;
+static char g_noop_impl_prompt[8192];
+static int noop_stage_deleg_run(const char *workdir, const char *role, const char *prompt,
+                                const char *artifact_path, char out_commit_sha[64], char *err,
+                                size_t n)
+{
+   (void)workdir;
+   (void)role;
+   (void)err;
+   (void)n;
+   if (out_commit_sha)
+      out_commit_sha[0] = '\0';
+   if (artifact_path && artifact_path[0])
+   {
+      FILE *f = fopen(artifact_path, "wb");
+      assert(f);
+      const char *intent = "{\"schema_version\":1,\"status\":\"unconfirmed\",\"summary\":\"already "
+                           "satisfied\",\"rationale\":\"the current tree contains it\","
+                           "\"acceptance_criteria\":[\"verification passes\"]}";
+      assert(fwrite(intent, 1, strlen(intent), f) == strlen(intent));
+      fclose(f);
+      return WFE_DELEGATE_OK;
+   }
+   if (prompt && strstr(prompt, "Implement the approved plan"))
+   {
+      g_noop_impl_calls++;
+      snprintf(g_noop_impl_prompt, sizeof(g_noop_impl_prompt), "%s", prompt);
+      return WFE_DELEGATE_NO_CHANGE;
+   }
+   if (prompt && strstr(prompt, "Document the change"))
+   {
+      g_noop_doc_calls++;
+      return WFE_DELEGATE_NO_CHANGE;
+   }
+   return WFE_DELEGATE_ERROR;
+}
+static const wfe_delegate_provider_t NOOP_STAGE_DELEG = {noop_stage_deleg_run};
+
 /* ---- mock forge with open ---- */
 static int g_open_calls;
 static int g_open_rc; /* 0 success, -1 failure */
@@ -133,6 +175,22 @@ static const char *WF_TRUNK = "name: dst\nstart: au\nnodes:\n"
                               "  - id: pr\n    block: pr.open\n    in:\n      src: au.out\n"
                               "    params:\n      base: trunk\n";
 
+static const char *WF_NOOP = "name: noopwf\n"
+                             "start: scope\n"
+                             "nodes:\n"
+                             "  - id: scope\n"
+                             "    block: understand\n"
+                             "    next: impl\n"
+                             "  - id: impl\n"
+                             "    block: implement\n"
+                             "    in:\n"
+                             "      intent: scope.out\n"
+                             "    next: document\n"
+                             "  - id: document\n"
+                             "    block: document\n"
+                             "    in:\n"
+                             "      branch: impl.out\n";
+
 static int run_fresh(const char *suffix)
 {
    char id[80] = "", err[256] = "";
@@ -166,6 +224,11 @@ int main(void)
    f = fopen(p, "wb");
    assert(f);
    fputs(WF_TRUNK, f);
+   fclose(f);
+   snprintf(p, sizeof p, "%s/workflows/noopwf.yaml", home);
+   f = fopen(p, "wb");
+   assert(f);
+   fputs(WF_NOOP, f);
    fclose(f);
    setenv("AIMEE_HOME", home, 1);
    assert(db1_init(":memory:") == 0);
@@ -360,6 +423,71 @@ int main(void)
       assert(wfe_implement_verify_ok(".") == 0);
 
       wfe_set_verify_provider(NULL);
+   }
+
+   /* D1: a proven write no-op is not a provider failure. Even with persisted
+    * roundtable feedback, implement must reach the authoritative mechanical
+    * gate, and document must freeze the current tree so the downstream docs
+    * panel can judge it. This is the multi-slice case where another slice or an
+    * earlier retry already satisfied the corrective packet. */
+   {
+      assert(wfe_delegate_error_is_no_change(
+          "delegate code: no file changes detected; result treated as incomplete"));
+      assert(wfe_delegate_error_is_no_change(
+          "delegate code: no owned files changed; result treated as incomplete"));
+      assert(!wfe_delegate_error_is_no_change("provider connection failed"));
+
+      char repo[] = "/tmp/wfe_noop_repo_XXXXXX";
+      assert(wfe_test_mkdtemp(repo));
+      char cmd[800];
+      snprintf(cmd, sizeof cmd,
+               "git -C %s init -q -b testing && git -C %s -c user.email=t@t "
+               "-c user.name=t commit -q --allow-empty -m base",
+               repo, repo);
+      assert(system(cmd) == 0);
+
+      char proposal[300];
+      snprintf(proposal, sizeof proposal, "%s/noop-packet.md", home);
+      FILE *packet = fopen(proposal, "wb");
+      assert(packet);
+      fputs("The requested behavior and documentation are already present.\n", packet);
+      fclose(packet);
+
+      wfe_set_delegate_provider(&NOOP_STAGE_DELEG);
+      wfe_set_verify_provider(&MOCK_VERIFY);
+      g_verify_rc = 0;
+      snprintf(g_verdict, sizeof g_verdict, "{\"schema_version\":1,\"verdict\":\"passed\"}");
+      g_noop_impl_calls = g_noop_doc_calls = 0;
+      g_noop_impl_prompt[0] = '\0';
+
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("noopwf", repo, proposal, "interactive", id, err, sizeof err) ==
+             0);
+      assert(wfe_feedback_write(id, "## reviewer\nThe corrective packet may already be met.") == 0);
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "accepted") == 0);
+      assert(g_noop_impl_calls == 1);
+      assert(g_noop_doc_calls == 1);
+      assert(strstr(g_noop_impl_prompt, "corrective packet may already be met") != NULL);
+
+      db1_lifecycle_event_t *events = NULL;
+      int event_count = db1_lifecycle_event_list(id, &events);
+      int impl_noop = 0, doc_noop = 0;
+      for (int i = 0; i < event_count; i++)
+      {
+         if (strcmp(events[i].kind, "noop") == 0 && strcmp(events[i].stage, "impl") == 0)
+            impl_noop = 1;
+         if (strcmp(events[i].kind, "noop") == 0 && strcmp(events[i].stage, "document") == 0)
+            doc_noop = 1;
+      }
+      free(events);
+      assert(impl_noop && doc_noop);
+      wfe_feedback_clear(id);
+      wfe_set_verify_provider(NULL);
+      wfe_set_delegate_provider(&MOCK_DELEG);
    }
 
    /* D1b: TDD RED gate — after the test author commits, a genuine red must NOT


### PR DESCRIPTION
## Summary

- preserve a proven write no-op as a distinct delegate outcome, then run the current tree through the workflow's authoritative gates
- allow already-complete documentation stages to freeze and continue instead of requiring a meaningless edit
- cap unattended coord write delegates at 48 turns without raising stricter configured limits
- make provider HTTP I/O and retry backoff observe parallel cancellation, and record deadline expiry even for a one-round panel
- cancel errored or timed-out coord jobs so failed workflow waits do not leave admitted work behind

## Why

Follow-up to the live multi-slice workflow exercised while finishing #2133. That run exposed retry loops on valid no-op corrective slices, an unlimited code delegate, and a panel deadline that still blocked while an in-flight provider request completed.

## Validation

- `make lint` (38/38 checks)
- `GOFLAGS=-buildvcs=false make -j4 all server`
- `make check-linking`
- `make -j4 unit-tests`

The Go flag is only needed because this validation ran from a temporary Git worktree whose VCS stamping cannot resolve; the source build itself is clean.
