### PR TITLE
Fix onboarding account, project readiness, and managed deploy

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -18,16 +18,16 @@ on:
     # Only rebuild when something that affects the image changes.
     paths:
       - "src/**"
-      # The Go WFE/API service is compiled into aimee-server. Go-only migration
-      # fixes must publish a deployable testing image just like C server changes.
+      # The Go WFE/API service and browser runtime are compiled into aimee-server.
+      # Go-only fixes must publish a deployable testing image just like C changes.
       - "server-go/**"
+      - "runtime-web/**"
       - "config/**"
       - "deploy/container/**"
       - "scripts/**"
       # The images bundle the webchat UI (frontend/ SPA + webchat/ Go server) —
       # see the frontend-build/webchat-build stages in Dockerfile.server.
       - "frontend/**"
-      - "webchat/**"
       - "Dockerfile"
       - "Dockerfile.server"
       - "Dockerfile.authority-bootstrap"

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ cd aimee
 docker compose -f compose.server-managed.yaml up -d
 ```
 
-Open <https://localhost:8443> and sign in as `aimee` / `aimee-local-dev`. The wizard picks the
-primary agent, inference tier, git hosts, and workspaces. Its last step starts:
+Open <https://localhost:8443> and sign in as `aimee` / `aimee-local-dev`. The wizard first replaces
+that published development login with your persistent operator username and password, then picks
+the primary agent, inference tier, git hosts, and workspaces. Its last step starts:
 
 - `aimee-kb`, with private PostgreSQL 18, pgvector, and pgvectorscale inside the container;
 - `aimee-llm`, on CPU or GPU.
@@ -72,9 +73,9 @@ It also displays the one client-enrollment command for the signed-in first user.
 For a local inference tier, setup separately provisions an authenticated KB-to-LLM service identity;
 no inference credential needs to be copied from the browser.
 
-Change `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` before putting it on a network. The
-managed compose file mounts the Docker socket; that gives aimee-server control of the host Docker
-daemon. Use the regular split stack if you do not want that.
+Finish the wizard's account step before putting it on a network. The managed compose file mounts the
+Docker socket; that gives aimee-server control of the host Docker daemon. Use the regular split stack
+if you do not want that.
 
 Install the `aimee` release binary on your development machine, then copy the exact command shown by
 the wizard:

--- a/compose.server-managed.yaml
+++ b/compose.server-managed.yaml
@@ -18,6 +18,12 @@
 # The published image has AIMEE_DEPLOY_ENABLED unset — orchestration is off until
 # this file turns it on together with the socket mount.
 
+# The managed sibling compose references this stack's volumes by their canonical
+# aimee_* names. Pinning the project in the manifest is essential: setting
+# COMPOSE_PROJECT_NAME inside the server container does not affect the host-side
+# `docker compose up` that creates this first container.
+name: aimee
+
 # Shared network the server + every managed service join, so they resolve each
 # other by name (aimee-kb:8741, aimee-llm:8742). The managed compose
 # references this as `external` — it must exist, so define it here with a fixed name.

--- a/deploy/container/runtime-web-lib.sh
+++ b/deploy/container/runtime-web-lib.sh
@@ -38,6 +38,11 @@ WEBCHAT_GROUP="${AIMEE_WEBCHAT_GROUP:-aimee}"
 # start. $AIMEE_HOME IS a persistent volume, so the login survives reboots even when
 # the env that originally created it is no longer injected. Root-owned, 0600.
 WEBCHAT_LOGIN_STORE="${WEBCHAT_HOME}/webchat/logins"
+# Written by POST /api/setup/account after the onboarding wizard creates a real
+# operator login. The image still contains the unprivileged `aimee` service UID,
+# but this marker prevents the published development password from being applied
+# to that UID again after a container recreate.
+WEBCHAT_BOOTSTRAP_REPLACED="${WEBCHAT_HOME}/webchat/bootstrap-replaced"
 
 # Record (or replace) the "user:hash" line for $1 in the durable store, reading the
 # crypt hash straight from /etc/shadow so we persist the encrypted form, not the
@@ -68,9 +73,9 @@ webchat_persist_login() {
 # Recreate any persisted login that is missing from the container's PAM database,
 # restoring its exact crypt hash (chpasswd -e). Runs on every start BEFORE the
 # env-based bootstrap, so a fresh container rootfs regains every previously
-# provisioned account; the env bootstrap then still runs afterwards and can update
-# a password the operator changed. An account that already exists is left untouched
-# (only its group membership is re-asserted) — the live /etc/shadow wins.
+# provisioned account. The env bootstrap can update its password until onboarding
+# retires it. An account that already exists is left untouched (only its group
+# membership is re-asserted) — the live /etc/shadow wins.
 webchat_restore_logins() {
     [ -f "$WEBCHAT_LOGIN_STORE" ] || return 0
     getent group "$WEBCHAT_GROUP" >/dev/null 2>&1 || groupadd --system "$WEBCHAT_GROUP" || true
@@ -171,11 +176,14 @@ webchat_bootstrap_extra_users() {
 webchat_bootstrap_user() {
     # First bring back any account provisioned on an earlier boot — this is what
     # makes login survive a reboot/recreate when the runtime does not re-inject
-    # AIMEE_WEBCHAT_USER/PASSWORD. The env bootstrap below still runs and wins.
+    # AIMEE_WEBCHAT_USER/PASSWORD. The env bootstrap below wins until onboarding
+    # writes the retirement marker.
     webchat_restore_logins
     _wc_user="${AIMEE_WEBCHAT_USER:-}"
     _wc_pass="${AIMEE_WEBCHAT_PASSWORD:-}"
-    if [ -z "$_wc_user" ] || [ -z "$_wc_pass" ]; then
+    if [ -f "$WEBCHAT_BOOTSTRAP_REPLACED" ]; then
+        webchat_log "bootstrap login retired by onboarding; skipping AIMEE_WEBCHAT_USER/AIMEE_WEBCHAT_PASSWORD"
+    elif [ -z "$_wc_user" ] || [ -z "$_wc_pass" ]; then
         webchat_log "AIMEE_WEBCHAT_USER/AIMEE_WEBCHAT_PASSWORD unset; skipping primary login bootstrap (AIMEE_WEBCHAT_USERS may still provision accounts)"
     else
         webchat_provision_user "$_wc_user" "$_wc_pass"

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -20,7 +20,11 @@ user:     aimee
 password: aimee-local-dev
 ```
 
-Run the setup wizard. Choose the primary agent, CPU or GPU inference, git accounts, and workspaces.
+The wizard first creates your operator username and password, disables the published development
+login, and moves the current browser session to the new account. The password hash and bootstrap
+retirement marker live on the persistent server volume, so `aimee / aimee-local-dev` does not return
+after an image update. Then choose the primary agent, CPU or GPU inference, git accounts, and
+workspaces.
 The final **Deploy** step starts:
 
 - `aimee-kb`, including private PostgreSQL 18, pgvector, and pgvectorscale;
@@ -55,8 +59,8 @@ to both containers, then the KB uses that credential for embedding, reranking, a
 automatic; do not copy the user's enrollment bearer into the LLM configuration. The managed LLM
 refuses to start if its service credential is missing.
 
-Change `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` before exposing this host. The defaults are
-for local setup only.
+Complete the account step before exposing the host. Deployments that inject a non-default
+`AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` are already considered secured and skip that step.
 
 ### Choosing an image channel
 

--- a/frontend/src/components/ProjectPicker.tsx
+++ b/frontend/src/components/ProjectPicker.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Picker } from '@rakuensoftware/smoothgui';
 import type { GitProjectsResponse } from '../setup/ownerUrl';
+import { notifySetupUpdated } from '../setup/setupState';
 
 /* ProjectPicker — a compact "select or clone a project" control embedded in each
  * tool tab. Each tab passes its own storageKey so its selected project persists
@@ -87,6 +88,7 @@ export default function ProjectPicker({ storageKey, onChange }: {
       setUrl(''); setToken(''); setCloneOpen(false);
       await load();
       if (d.name) select(d.name);
+      notifySetupUpdated();
     } finally { setBusy(false); }
   }
 

--- a/frontend/src/components/SetupChip.tsx
+++ b/frontend/src/components/SetupChip.tsx
@@ -1,23 +1,30 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSessions } from '../SessionContext';
 import { loadConfig, type ConfigMap } from '../setup/configApi';
 import { computeReadiness, stepsRemaining } from '../setup/readiness';
+import { fetchHostCount, fetchProjectCount, fetchSetupAccountReady } from '../setup/setupSignals';
 import { requestOpenWizard, isDismissed, SETUP_UPDATED_EVENT } from '../setup/setupState';
 
 /* Header chip: "Setup — N left". Reads GET /api/config once (and again whenever
  * the wizard reports a change or the window regains focus), computes readiness
- * against the active session's project, and shows how many required steps remain.
+ * against the cloned project inventory, and shows how many required steps remain.
  * Hidden entirely once ready. Clicking it opens the wizard. On first load, if the
  * instance is not ready and the wizard hasn't been dismissed, it auto-opens the
  * wizard once. All heavy lifting is in the tested setup/ modules. */
 
 export default function SetupChip() {
-  const { active } = useSessions();
-  const hasProject = !!active?.projectName;
   const [cfg, setCfg] = useState<ConfigMap | null>(null);
+  const [accountReady, setAccountReady] = useState(false);
+  const [projectCount, setProjectCount] = useState(0);
+  const [hostsConnected, setHostsConnected] = useState(0);
 
   const load = useCallback(() => {
-    loadConfig().then(setCfg);
+    Promise.all([loadConfig(), fetchSetupAccountReady(), fetchProjectCount(), fetchHostCount()])
+      .then(([config, account, projects, hosts]) => {
+        setCfg(config);
+        setAccountReady(account);
+        setProjectCount(projects);
+        setHostsConnected(hosts);
+      });
   }, []);
 
   useEffect(() => { load(); }, [load]);
@@ -33,15 +40,12 @@ export default function SetupChip() {
   }, [load]);
 
   const readiness = useMemo(
-    () => (cfg ? computeReadiness(cfg, hasProject) : null),
-    [cfg, hasProject],
+    () => (cfg ? computeReadiness(cfg, { accountReady, projectCount, hostsConnected }) : null),
+    [cfg, accountReady, projectCount, hostsConnected],
   );
 
   // Auto-open the wizard once per page load when unconfigured and not dismissed.
   const autoOpened = useRef(false);
-  // Reset the once-per-session auto-open guard when the active session changes,
-  // so a freshly-selected unconfigured session can auto-open the wizard too.
-  useEffect(() => { autoOpened.current = false; }, [active?.id]);
   useEffect(() => {
     if (readiness && !readiness.ready && !isDismissed() && !autoOpened.current) {
       autoOpened.current = true;

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, useToast } from '@rakuensoftware/smoothgui';
-import { useSessions } from '../SessionContext';
 import { loadConfig, saveConfigValue, type ConfigMap } from '../setup/configApi';
 import { visibleSteps, isRestartKey, helpFor, APPLIANCE_HIDDEN_STEPS, type WizardKbMode } from '../setup/wizardSteps';
 import { completedSteps, computeReadiness, type StepId } from '../setup/readiness';
+import { fetchAppliance, fetchHostCount, fetchProjectCount, fetchSetupAccountReady } from '../setup/setupSignals';
 import { setDismissed, notifySetupUpdated } from '../setup/setupState';
+import CreateAccount from '../setup/CreateAccount';
 import PrimaryChooser from '../setup/PrimaryChooser';
 import KnowledgeBase from '../setup/KnowledgeBase';
 import DeployTopology from '../setup/DeployTopology';
@@ -45,44 +46,8 @@ function coerce(key: string, raw: string, original: unknown): unknown {
   return raw;
 }
 
-function csrf(): string {
-  try {
-    if (typeof window !== 'undefined') return (window as { _csrf?: string })._csrf || '';
-  } catch {
-    /* ignore */
-  }
-  return '';
-}
-
-// How many git hosts have a stored credential (drives the optional connection
-// step's readiness). Network failure ⇒ 0; the step is optional so this never
-// blocks "ready".
-async function fetchHostCount(): Promise<number> {
-  try {
-    const r = await fetch('/api/git/credentials', { headers: { 'X-CSRF-Token': csrf() } });
-    const d = await r.json();
-    return r.ok && Array.isArray(d.hosts) ? d.hosts.length : 0;
-  } catch {
-    return 0;
-  }
-}
-
-// Whether this instance is the all-in-one appliance (KB + LLM + store baked in),
-// so the wizard hides the infra steps. Network failure ⇒ full wizard.
-async function fetchAppliance(): Promise<boolean> {
-  try {
-    const r = await fetch('/api/setup/appliance', { headers: { 'X-CSRF-Token': csrf() } });
-    const d = await r.json();
-    return r.ok && !!d.appliance;
-  } catch {
-    return false;
-  }
-}
-
 export default function SetupWizard({ open, onClose }: { open: boolean; onClose: () => void }) {
   const toast = useToast();
-  const { active } = useSessions();
-  const hasProject = !!active?.projectName;
 
   const [cfg, setCfg] = useState<ConfigMap>({});
   const [draft, setDraft] = useState<Record<string, string>>({});
@@ -91,6 +56,8 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
   const [pendingRestart, setPendingRestart] = useState<string[]>([]);
   const [showSummary, setShowSummary] = useState(false);
   const [hostsConnected, setHostsConnected] = useState(0);
+  const [projectCount, setProjectCount] = useState(0);
+  const [accountReady, setAccountReady] = useState(false);
   // The all-in-one appliance bakes the KB + LLM + store, so its wizard drops the
   // infra steps. Detected from a webchat signal (AIMEE_WIZARD_APPLIANCE).
   const [appliance, setAppliance] = useState(false);
@@ -121,9 +88,13 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
     setPendingRestart([]);
     setBooted(false);
     setDoneAtOpen(new Set());
-    Promise.all([loadConfig(), fetchHostCount(), fetchAppliance()]).then(([c, hosts, appl]) => {
+    Promise.all([
+      loadConfig(), fetchHostCount(), fetchProjectCount(), fetchSetupAccountReady(), fetchAppliance(),
+    ]).then(([c, hosts, projects, account, appl]) => {
       setCfg(c);
       setHostsConnected(hosts);
+      setProjectCount(projects);
+      setAccountReady(account);
       setAppliance(appl);
       const d: Record<string, string> = {};
       for (const s of visibleSteps(String(c.kb_mode) === 'remote' ? 'remote' : 'local')) {
@@ -133,12 +104,10 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
         }
       }
       setDraft(d);
-      const done = completedSteps(c, hasProject, hosts);
+      const done = completedSteps(c, { accountReady: account, projectCount: projects, hostsConnected: hosts });
       setDoneAtOpen(done);
       setBooted(true);
     });
-    // hasProject is read once at open: the done-set is a deliberate snapshot.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const close = useCallback(() => { onClose(); }, [onClose]);
@@ -152,8 +121,8 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
   }, [open, close]);
 
   const readiness = useMemo(
-    () => computeReadiness(cfg, hasProject, hostsConnected),
-    [cfg, hasProject, hostsConnected],
+    () => computeReadiness(cfg, { accountReady, projectCount, hostsConnected }),
+    [cfg, accountReady, projectCount, hostsConnected],
   );
 
   if (!open) return null;
@@ -169,6 +138,24 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
   async function handlePrimaryConfigured(provider: string) {
     const res = await saveConfigValue('provider', provider);
     setCfg((c) => ({ ...c, provider: res.ok ? res.value ?? provider : provider }));
+    notifySetupUpdated();
+    advance();
+  }
+
+  async function handleAccountCreated() {
+    setAccountReady(true);
+    // The replacement account has its own webuser-scoped workspace and git
+    // credentials. Re-read both under the new session cookie so readiness never
+    // carries the bootstrap user's inventory across the identity switch.
+    const [projects, hosts] = await Promise.all([fetchProjectCount(), fetchHostCount()]);
+    setProjectCount(projects);
+    setHostsConnected(hosts);
+    setDoneAtOpen((previous) => {
+      const next = new Set(previous);
+      if (projects === 0) next.delete('project');
+      if (hosts === 0) next.delete('connection');
+      return next;
+    });
     notifySetupUpdated();
     advance();
   }
@@ -307,7 +294,9 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
               {step.title}{step.optional ? <span style={{ color: '#9aa', fontWeight: 400, fontSize: 12 }}> · optional</span> : null}
             </div>
 
-            {step.kind === 'chooser' ? (
+            {step.kind === 'account' ? (
+              <CreateAccount onCreated={handleAccountCreated} />
+            ) : step.kind === 'chooser' ? (
               <PrimaryChooser onConfigured={handlePrimaryConfigured} />
             ) : step.kind === 'kb' ? (
               <KnowledgeBase onSaved={handleKbSaved} />
@@ -318,7 +307,7 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
             ) : step.kind === 'connection' ? (
               <ConnectHosts onDone={advance} onHostsChanged={setHostsConnected} />
             ) : step.kind === 'workspace' ? (
-              <ConnectWorkspace onDone={advance} />
+              <ConnectWorkspace onDone={advance} onProjectsChanged={setProjectCount} />
             ) : step.keys.length > 0 ? (
               <div style={{ display: 'grid', gap: 12, marginBottom: 16 }}>
                 {step.keys.map((key) => (
@@ -348,7 +337,7 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
                 {step.optional && <Button variant="default" onClick={advance}>Skip</Button>}
                 {step.keys.length > 0 ? (
                   <Button variant="primary" disabled={saving} onClick={saveStep}>{saving ? 'Saving…' : 'Save & continue'}</Button>
-                ) : step.kind === 'chooser' || step.kind === 'kb' || step.kind === 'deploy' || step.kind === 'db2' || step.kind === 'connection' || step.kind === 'workspace' ? (
+                ) : step.kind === 'account' || step.kind === 'chooser' || step.kind === 'kb' || step.kind === 'deploy' || step.kind === 'db2' || step.kind === 'connection' || step.kind === 'workspace' ? (
                   // Bespoke steps own their own primary action (they call advance()).
                   null
                 ) : (

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -3,6 +3,7 @@ import { Panel, Button } from '@rakuensoftware/smoothgui';
 import ConnectHosts from '../setup/ConnectHosts';
 import { useSessions } from '../SessionContext';
 import { groupProjectsByOrg, parseOwnerOnly, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type OwnerRef, type ProjectDetail, type ProjectDeleteResponse } from '../setup/ownerUrl';
+import { notifySetupUpdated } from '../setup/setupState';
 
 /* Git projects (webchat-git WP-F2). The page is focused on managing repos: it
  * lists the user's cloned projects, connects new ones, and runs per-project git
@@ -152,6 +153,7 @@ export default function Projects() {
         if (d.kb_indexed === false) notes.push(`not indexed in the knowledge base — ${d.kb_reason || 'knowledge service unavailable'}`);
         setCloneNotes(notes);
         await loadProjects(); await loadHosts(); setSelected(d.name || '');
+        notifySetupUpdated();
       }
     } finally { setBusy(false); }
   }
@@ -200,6 +202,7 @@ export default function Projects() {
       setOrgResults(d.results || []);
       setUrl('');
       await loadProjects();
+      notifySetupUpdated();
     } catch { setErr('aimee-server unavailable'); } finally { setBusy(false); }
   }
 
@@ -229,6 +232,7 @@ export default function Projects() {
         setNotice(`Deleted ${delRef} — ${kb}.`);
         closeDelete();
         await loadProjects();
+        notifySetupUpdated();
       } else if (r.status === 503) {
         // kb-first ordering aborted the delete: the clone is intact. Offer a
         // retry, or an explicit force (second click) that leaves the knowledge

--- a/frontend/src/setup/ConnectWorkspace.tsx
+++ b/frontend/src/setup/ConnectWorkspace.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@rakuensoftware/smoothgui';
 import { parseOwner, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type ProjectDetail } from './ownerUrl';
+import { notifySetupUpdated } from './setupState';
 
 /* Wizard — Workspaces & projects. A workspace is your collection of projects: the
  * repos under an owner/org (e.g. github.com/RakuenSoftware). Point at that owner,
@@ -51,9 +52,11 @@ interface CloneResult extends CloneKbAnnotations {
 export interface ConnectWorkspaceProps {
   /** Continue to the wizard summary. */
   onDone: () => void;
+  /** Keep setup readiness synchronized with the actual cloned inventory. */
+  onProjectsChanged?: (count: number) => void;
 }
 
-export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
+export default function ConnectWorkspace({ onDone, onProjectsChanged }: ConnectWorkspaceProps) {
   const [ownerInput, setOwnerInput] = useState('');
   const [token, setToken] = useState('');
   const [repos, setRepos] = useState<Repo[]>([]);
@@ -73,11 +76,12 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
       if (r.ok) {
         setProjects(d.projects || []);
         setDetails(d.details || []);
+        onProjectsChanged?.((d.projects || []).length);
       }
     } catch {
       /* server unavailable — leave empty */
     }
-  }, []);
+  }, [onProjectsChanged]);
 
   useEffect(() => {
     loadProjects();
@@ -147,6 +151,7 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
       }
       setResults(d.results || []);
       await loadProjects();
+      notifySetupUpdated();
     } catch {
       setErr('aimee-server unavailable');
     } finally {

--- a/frontend/src/setup/CreateAccount.tsx
+++ b/frontend/src/setup/CreateAccount.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { Button } from '@rakuensoftware/smoothgui';
+
+function csrf(): string {
+  try {
+    return (window as { _csrf?: string })._csrf || '';
+  } catch {
+    return '';
+  }
+}
+
+export default function CreateAccount({ onCreated }: { onCreated: (username: string) => void }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  async function create() {
+    const user = username.trim();
+    if (!/^[a-z][a-z0-9_-]{0,31}$/.test(user)) {
+      setError('Use 1–32 lowercase letters, digits, hyphens, or underscores; start with a letter.');
+      return;
+    }
+    if (user === 'aimee') {
+      setError('Choose a username other than aimee.');
+      return;
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+    if (password !== confirmation) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      const response = await fetch('/api/setup/account', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf() },
+        body: JSON.stringify({
+          username: user,
+          password,
+          password_confirmation: confirmation,
+        }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setError(data.error || `Could not create account (${response.status}).`);
+        return;
+      }
+      setPassword('');
+      setConfirmation('');
+      onCreated(user);
+    } catch {
+      setError('aimee-server unavailable');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: 12, marginBottom: 8 }}>
+      <div style={{ fontSize: 12.5, color: '#556', lineHeight: 1.5 }}>
+        Replace the published <code>aimee / aimee-local-dev</code> login before configuring this
+        instance. The new login is stored on the persistent volume and survives image updates.
+      </div>
+      <label>
+        <div style={labelStyle}>Username</div>
+        <input style={inputStyle} autoComplete="username" value={username}
+          onChange={(event) => setUsername(event.target.value)} placeholder="your username" />
+      </label>
+      <label>
+        <div style={labelStyle}>Password</div>
+        <input style={inputStyle} type="password" autoComplete="new-password" value={password}
+          onChange={(event) => setPassword(event.target.value)} />
+      </label>
+      <label>
+        <div style={labelStyle}>Confirm password</div>
+        <input style={inputStyle} type="password" autoComplete="new-password" value={confirmation}
+          onChange={(event) => setConfirmation(event.target.value)}
+          onKeyDown={(event) => { if (event.key === 'Enter' && !saving) create(); }} />
+      </label>
+      {error && <div style={{ color: '#c62828', fontSize: 12.5 }}>{error}</div>}
+      <div>
+        <Button variant="primary" disabled={saving || !username.trim() || !password || !confirmation}
+          onClick={create}>
+          {saving ? 'Creating…' : 'Create account & continue'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 12.5, fontWeight: 600, marginBottom: 3,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
+  border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
+};

--- a/frontend/src/setup/readiness.test.ts
+++ b/frontend/src/setup/readiness.test.ts
@@ -12,9 +12,10 @@ describe('readiness grounding', () => {
 });
 
 describe('computeReadiness (local KB path)', () => {
-  it('an empty config with no project → provider/embedding/project red, not ready', () => {
-    const r = computeReadiness({}, false);
+  it('an empty config with an unsecured login and no projects is not ready', () => {
+    const r = computeReadiness({}, { accountReady: false, projectCount: 0 });
     expect(r.ready).toBe(false);
+    expect(r.steps.account.ok).toBe(false);
     expect(r.steps.provider.ok).toBe(false);
     expect(r.steps.knowledge_base.ok).toBe(true); // local is the default; the fork is satisfied
     expect(r.steps.embedding.ok).toBe(false);
@@ -24,46 +25,48 @@ describe('computeReadiness (local KB path)', () => {
     expect(r.steps.project.ok).toBe(false);
     expect(r.steps.connection.ok).toBe(false);
     expect(r.steps.connection.optional).toBe(true);
-    // provider, embedding, project are the 3 required-incomplete steps (knowledge_base
+    // account, provider, embedding, project are the 4 required-incomplete steps (knowledge_base
     // + db2 are ok, connection is optional).
-    expect(stepsRemaining(r)).toBe(3);
+    expect(stepsRemaining(r)).toBe(4);
   });
 
   it('a db2_url reads as an existing database, still ok', () => {
-    const r = computeReadiness({ db2_url: 'postgres://x' }, false);
+    const r = computeReadiness({ db2_url: 'postgres://x' }, { accountReady: true, projectCount: 0 });
     expect(r.steps.db2.ok).toBe(true);
     expect(r.steps.db2.detail).toMatch(/existing database/i);
   });
 
   it('the built-in hash embedder (both keys blank) reads as not-ok, test-only', () => {
-    const r = computeReadiness({ embedding_command: '', embedding_endpoint: '   ' }, false);
+    const r = computeReadiness({ embedding_command: '', embedding_endpoint: '   ' }, { accountReady: true, projectCount: 0 });
     expect(r.steps.embedding.ok).toBe(false);
     expect(r.steps.embedding.detail).toMatch(/hash fallback/i);
   });
 
   it('an embedding command OR endpoint satisfies embedding', () => {
-    expect(computeReadiness({ embedding_command: 'embed.sh' }, false).steps.embedding.ok).toBe(true);
-    expect(computeReadiness({ embedding_endpoint: 'http://e' }, false).steps.embedding.ok).toBe(true);
+    expect(computeReadiness({ embedding_command: 'embed.sh' }, { accountReady: true, projectCount: 0 }).steps.embedding.ok).toBe(true);
+    expect(computeReadiness({ embedding_endpoint: 'http://e' }, { accountReady: true, projectCount: 0 }).steps.embedding.ok).toBe(true);
   });
 
   it('a fully configured local instance with a project is ready', () => {
     const cfg = { provider: 'claude', embedding_endpoint: 'http://e', db2_url: 'postgres://x' };
-    const r = computeReadiness(cfg, true);
+    const r = computeReadiness(cfg, { accountReady: true, projectCount: 1 });
     expect(r.ready).toBe(true);
     expect(stepsRemaining(r)).toBe(0);
   });
 
-  it('a connected project flips only the project step', () => {
+  it('a cloned project flips only the project step', () => {
     const base = { provider: 'claude', embedding_command: 'e.sh', db2_url: 'x' };
-    expect(computeReadiness(base, false).ready).toBe(false);
-    expect(computeReadiness(base, true).ready).toBe(true);
+    expect(computeReadiness(base, { accountReady: true, projectCount: 0 }).ready).toBe(false);
+    const ready = computeReadiness(base, { accountReady: true, projectCount: 19 });
+    expect(ready.ready).toBe(true);
+    expect(ready.steps.project.detail).toBe('19 projects cloned');
   });
 });
 
 describe('computeReadiness (remote KB path)', () => {
   it('remote KB satisfies embedding + db2 automatically; only the KB URL matters', () => {
     const cfg = { provider: 'claude', kb_mode: 'remote', kb_client_url: 'https://kb.example' };
-    const r = computeReadiness(cfg, true);
+    const r = computeReadiness(cfg, { accountReady: true, projectCount: 1 });
     expect(r.steps.knowledge_base.ok).toBe(true);
     expect(r.steps.embedding.ok).toBe(true);
     expect(r.steps.embedding.detail).toMatch(/n\/a/i);
@@ -73,7 +76,7 @@ describe('computeReadiness (remote KB path)', () => {
 
   it('remote with no KB URL blocks readiness on the knowledge_base step', () => {
     const cfg = { provider: 'claude', kb_mode: 'remote' };
-    const r = computeReadiness(cfg, true);
+    const r = computeReadiness(cfg, { accountReady: true, projectCount: 1 });
     expect(r.steps.knowledge_base.ok).toBe(false);
     expect(r.ready).toBe(false);
     expect(stepsRemaining(r)).toBe(1); // only knowledge_base is required-incomplete
@@ -83,10 +86,10 @@ describe('computeReadiness (remote KB path)', () => {
 describe('computeReadiness (connection step)', () => {
   it('is optional and reflects the connected-host count without blocking ready', () => {
     const cfg = { provider: 'claude', embedding_command: 'e.sh', db2_url: 'x' };
-    const none = computeReadiness(cfg, true, 0);
+    const none = computeReadiness(cfg, { accountReady: true, projectCount: 1, hostsConnected: 0 });
     expect(none.steps.connection.ok).toBe(false);
     expect(none.ready).toBe(true); // optional never blocks
-    const two = computeReadiness(cfg, true, 2);
+    const two = computeReadiness(cfg, { accountReady: true, projectCount: 1, hostsConnected: 2 });
     expect(two.steps.connection.ok).toBe(true);
     expect(two.steps.connection.detail).toMatch(/2 hosts/);
   });
@@ -94,39 +97,39 @@ describe('computeReadiness (connection step)', () => {
 
 describe('completedSteps (affirmative completion — hides wizard sections on reopen)', () => {
   it('a fresh install has completed NOTHING, even steps readiness marks ok-by-default', () => {
-    const done = completedSteps({}, false, 0);
+    const done = completedSteps({}, { accountReady: false, projectCount: 0, hostsConnected: 0 });
     expect(done.size).toBe(0);
     // Contrast: readiness says knowledge_base + db2 are ok on the same input.
-    const r = computeReadiness({}, false, 0);
+    const r = computeReadiness({}, { accountReady: false, projectCount: 0, hostsConnected: 0 });
     expect(r.steps.knowledge_base.ok).toBe(true);
     expect(r.steps.db2.ok).toBe(true);
   });
 
   it('each step completes on its affirmative signal', () => {
-    expect(completedSteps({ provider: 'claude' }, false).has('provider')).toBe(true);
-    expect(completedSteps({ kb_mode: 'local' }, false).has('knowledge_base')).toBe(true);
-    expect(completedSteps({ llm_embed_backend: 'local' }, false).has('embedding')).toBe(true);
-    expect(completedSteps({}, false, 1).has('connection')).toBe(true);
-    expect(completedSteps({}, true).has('project')).toBe(true);
+    expect(completedSteps({}, { accountReady: true, projectCount: 0 }).has('account')).toBe(true);
+    expect(completedSteps({ provider: 'claude' }, { accountReady: false, projectCount: 0 }).has('provider')).toBe(true);
+    expect(completedSteps({ kb_mode: 'local' }, { accountReady: false, projectCount: 0 }).has('knowledge_base')).toBe(true);
+    expect(completedSteps({ llm_embed_backend: 'local' }, { accountReady: false, projectCount: 0 }).has('embedding')).toBe(true);
+    expect(completedSteps({}, { accountReady: false, projectCount: 0, hostsConnected: 1 }).has('connection')).toBe(true);
+    expect(completedSteps({}, { accountReady: false, projectCount: 19 }).has('project')).toBe(true);
   });
 
   it('remote KB completes only once the URL makes the choice real', () => {
-    expect(completedSteps({ kb_mode: 'remote' }, false).has('knowledge_base')).toBe(false);
-    expect(completedSteps({ kb_mode: 'remote', kb_client_url: 'https://kb' }, false).has('knowledge_base')).toBe(true);
+    expect(completedSteps({ kb_mode: 'remote' }, { accountReady: false, projectCount: 0 }).has('knowledge_base')).toBe(false);
+    expect(completedSteps({ kb_mode: 'remote', kb_client_url: 'https://kb' }, { accountReady: false, projectCount: 0 }).has('knowledge_base')).toBe(true);
   });
 
   it('db2 completes via an explicit URL or the deploy walk (embed role placed)', () => {
-    expect(completedSteps({}, false).has('db2')).toBe(false);
-    expect(completedSteps({ db2_url: 'postgres://x' }, false).has('db2')).toBe(true);
-    expect(completedSteps({ llm_embed_backend: 'external' }, false).has('db2')).toBe(true);
+    expect(completedSteps({}, { accountReady: false, projectCount: 0 }).has('db2')).toBe(false);
+    expect(completedSteps({ db2_url: 'postgres://x' }, { accountReady: false, projectCount: 0 }).has('db2')).toBe(true);
+    expect(completedSteps({ llm_embed_backend: 'external' }, { accountReady: false, projectCount: 0 }).has('db2')).toBe(true);
   });
 
   it('a fully set-up instance completes every step', () => {
     const done = completedSteps(
       { provider: 'claude', kb_mode: 'local', llm_embed_backend: 'local', db2_url: '' },
-      true,
-      1,
+      { accountReady: true, projectCount: 19, hostsConnected: 1 },
     );
-    expect(done.size).toBe(6);
+    expect(done.size).toBe(7);
   });
 });

--- a/frontend/src/setup/readiness.ts
+++ b/frontend/src/setup/readiness.ts
@@ -11,19 +11,19 @@
  * repos clone without it.
  *
  * MVP scope: readiness is inferred client-side from config values, whether the
- * active session has a project bound, and how many git hosts are connected. A
+ * the workspace's cloned-project count, and how many git hosts are connected. A
  * server-side GET /api/setup/state that can additionally ping DB2/the provider is
  * a documented follow-up. */
 
 import { FIELD_HELP } from '../pages/settingsHelp';
 
-export type StepId = 'provider' | 'knowledge_base' | 'embedding' | 'db2' | 'connection' | 'project';
+export type StepId = 'account' | 'provider' | 'knowledge_base' | 'embedding' | 'db2' | 'connection' | 'project';
 
 /* The config keys readiness inspects. Exported so a test can assert each one is a
  * real, documented config field (a key rename in settingsHelp.ts that we miss
  * would otherwise silently break a rule). `connection` reads from the git-host
- * count and `project` from the session bundle — neither has a config key, so both
- * are deliberately absent here. */
+ * count, `project` from GET /api/git/projects, and `account` from
+ * GET /api/setup/account — none has a config key, so they are absent here. */
 export const READINESS_KEYS = [
   'provider',
   'embedding_command',
@@ -53,14 +53,17 @@ function asStr(cfg: Record<string, unknown>, key: string): string {
   return String(v).trim();
 }
 
-/** Classify the setup steps. `hasProject` comes from the active session (the
- * config has no project field); `hostsConnected` is how many git hosts have a
- * stored credential (GET /api/git/credentials). When kb_mode is 'remote', the
- * local embedder + DB2 steps are satisfied by connecting the remote KB. */
+export interface ReadinessSignals {
+  accountReady: boolean;
+  projectCount: number;
+  hostsConnected?: number;
+}
+
+/** Classify the setup steps. Project readiness comes from the user's cloned
+ * project inventory, not whichever chat tab happens to be active. */
 export function computeReadiness(
   cfg: Record<string, unknown>,
-  hasProject: boolean,
-  hostsConnected = 0,
+  { accountReady, projectCount, hostsConnected = 0 }: ReadinessSignals,
 ): Readiness {
   const provider = asStr(cfg, 'provider');
   const remote = asStr(cfg, 'kb_mode') === 'remote';
@@ -75,6 +78,10 @@ export function computeReadiness(
   const db2 = asStr(cfg, 'db2_url');
 
   const steps: Record<StepId, StepStatus> = {
+    account: {
+      ok: accountReady,
+      detail: accountReady ? 'login secured' : 'replace the development login',
+    },
     provider: {
       ok: provider !== '',
       detail: provider !== '' ? `primary: ${provider}` : 'no primary provider set',
@@ -112,8 +119,10 @@ export function computeReadiness(
       optional: true,
     },
     project: {
-      ok: hasProject,
-      detail: hasProject ? 'project connected' : 'no project connected',
+      ok: projectCount > 0,
+      detail: projectCount > 0
+        ? `${projectCount} project${projectCount === 1 ? '' : 's'} cloned`
+        : 'no projects cloned',
     },
   };
 
@@ -134,10 +143,10 @@ export function stepsRemaining(r: Readiness): number {
  * first run still walks every step. */
 export function completedSteps(
   cfg: Record<string, unknown>,
-  hasProject: boolean,
-  hostsConnected = 0,
+  { accountReady, projectCount, hostsConnected = 0 }: ReadinessSignals,
 ): Set<StepId> {
   const done = new Set<StepId>();
+  if (accountReady) done.add('account');
   if (asStr(cfg, 'provider') !== '') done.add('provider');
 
   // The KB fork is complete once a mode was explicitly recorded ('' = never
@@ -161,7 +170,7 @@ export function completedSteps(
   if (asStr(cfg, 'db2_url') !== '' || embConfigured) done.add('db2');
 
   if (hostsConnected > 0) done.add('connection');
-  if (hasProject) done.add('project');
+  if (projectCount > 0) done.add('project');
   return done;
 }
 

--- a/frontend/src/setup/setupSignals.ts
+++ b/frontend/src/setup/setupSignals.ts
@@ -1,0 +1,39 @@
+function csrf(): string {
+  try {
+    if (typeof window !== 'undefined') return (window as { _csrf?: string })._csrf || '';
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
+async function getJSON(path: string): Promise<{ ok: boolean; data: Record<string, unknown> }> {
+  try {
+    const response = await fetch(path, { headers: { 'X-CSRF-Token': csrf() } });
+    const data = await response.json().catch(() => ({}));
+    return { ok: response.ok, data };
+  } catch {
+    return { ok: false, data: {} };
+  }
+}
+
+/** Runtime signals that are not part of GET /api/config but still drive setup. */
+export async function fetchSetupAccountReady(): Promise<boolean> {
+  const { ok, data } = await getJSON('/api/setup/account');
+  return ok && data.complete === true;
+}
+
+export async function fetchProjectCount(): Promise<number> {
+  const { ok, data } = await getJSON('/api/git/projects');
+  return ok && Array.isArray(data.projects) ? data.projects.length : 0;
+}
+
+export async function fetchHostCount(): Promise<number> {
+  const { ok, data } = await getJSON('/api/git/credentials');
+  return ok && Array.isArray(data.hosts) ? data.hosts.length : 0;
+}
+
+export async function fetchAppliance(): Promise<boolean> {
+  const { ok, data } = await getJSON('/api/setup/appliance');
+  return ok && data.appliance === true;
+}

--- a/frontend/src/setup/setupState.ts
+++ b/frontend/src/setup/setupState.ts
@@ -5,7 +5,7 @@
 
 export const DISMISSED_KEY = 'aimee_setup_dismissed';
 export const OPEN_WIZARD_EVENT = 'aimee:open-setup-wizard';
-/** Fired after the wizard changes config so the header chip re-computes. */
+/** Fired after setup config or the cloned-project inventory changes. */
 export const SETUP_UPDATED_EVENT = 'aimee:setup-updated';
 
 export function isDismissed(): boolean {
@@ -36,7 +36,7 @@ export function requestOpenWizard(): void {
   }
 }
 
-/** Fire the event that tells the chip to re-read config after a wizard change. */
+/** Fire the event that tells the chip to re-read setup state after a mutation. */
 export function notifySetupUpdated(): void {
   try {
     if (typeof window !== 'undefined') window.dispatchEvent(new CustomEvent(SETUP_UPDATED_EVENT));

--- a/frontend/src/setup/wizardSteps.test.ts
+++ b/frontend/src/setup/wizardSteps.test.ts
@@ -7,17 +7,18 @@ import type { StepId } from './readiness';
 describe('WIZARD_STEPS structure', () => {
   it('covers every readiness StepId exactly once, in dependency order', () => {
     const ids = WIZARD_STEPS.map((s) => s.id);
-    expect(ids).toEqual<StepId[]>(['provider', 'knowledge_base', 'embedding', 'db2', 'connection', 'project']);
+    expect(ids).toEqual<StepId[]>(['account', 'provider', 'knowledge_base', 'embedding', 'db2', 'connection', 'project']);
     expect(new Set(ids).size).toBe(ids.length); // no dupes
   });
 
-  it('provider is the chooser and step 2 is the bespoke knowledge-base fork', () => {
+  it('account is first, provider is the chooser, and the KB fork follows', () => {
+    expect(WIZARD_STEPS[0].kind).toBe('account');
     const provider = WIZARD_STEPS.find((s) => s.id === 'provider')!;
     expect(provider.kind).toBe('chooser');
-    const step2 = WIZARD_STEPS[1];
-    expect(step2.id).toBe('knowledge_base');
-    expect(step2.kind).toBe('kb');
-    expect(step2.keys).toEqual([]);
+    const kb = WIZARD_STEPS[2];
+    expect(kb.id).toBe('knowledge_base');
+    expect(kb.kind).toBe('kb');
+    expect(kb.keys).toEqual([]);
   });
 
   it('deploy-topology + DB2 are local-only; the tail is connection → workspaces', () => {
@@ -46,15 +47,15 @@ describe('WIZARD_STEPS structure', () => {
   it('visibleSteps forks on kb_mode: remote hides deploy + db2', () => {
     const local = visibleSteps('local').map((s) => s.id);
     const remote = visibleSteps('remote').map((s) => s.id);
-    expect(local).toEqual(['provider', 'knowledge_base', 'embedding', 'db2', 'connection', 'project']);
-    expect(remote).toEqual(['provider', 'knowledge_base', 'connection', 'project']);
+    expect(local).toEqual(['account', 'provider', 'knowledge_base', 'embedding', 'db2', 'connection', 'project']);
+    expect(remote).toEqual(['account', 'provider', 'knowledge_base', 'connection', 'project']);
   });
 
   it('appliance mode hides the baked-infra steps (kb/deploy/db2)', () => {
     const applianceLocal = visibleSteps('local', true).map((s) => s.id);
-    expect(applianceLocal).toEqual(['provider', 'connection', 'project']);
+    expect(applianceLocal).toEqual(['account', 'provider', 'connection', 'project']);
     // Same regardless of kb mode — the appliance bakes it.
-    expect(visibleSteps('remote', true).map((s) => s.id)).toEqual(['provider', 'connection', 'project']);
+    expect(visibleSteps('remote', true).map((s) => s.id)).toEqual(['account', 'provider', 'connection', 'project']);
   });
 
   it('every keyed step references documented config keys', () => {

--- a/frontend/src/setup/wizardSteps.ts
+++ b/frontend/src/setup/wizardSteps.ts
@@ -1,7 +1,7 @@
 /* Ordered wizard step definitions + small helpers. Pure data/logic (no DOM), so
  * the ordering and restart-key classification are unit-tested.
  *
- * The wizard forks on the knowledge-base choice (step 2): connecting to a REMOTE
+ * The wizard forks on the knowledge-base choice after the account and provider:
  * aimee-kb deploys nothing locally, so the deploy-topology + shared-store (DB2)
  * steps are hidden. A step's `showWhen` predicate decides whether it appears for
  * the current kb_mode; a step with no predicate always shows. The tail is always
@@ -25,19 +25,20 @@ export interface WizardStep {
   /** One-line "what you lose if you skip", shown for optional/hand-off steps. */
   skipNote?: string;
   /** A step whose body is a bespoke component rather than the generic key inputs:
-   * 'chooser' = primary chooser, 'kb' = knowledge-base fork, 'deploy' = deploy
+   * 'account' = replacement login, 'chooser' = primary chooser, 'kb' = knowledge-base fork, 'deploy' = deploy
    * topology (LLM placement), 'db2' = shared-store (bundled vs existing Postgres),
    * 'connection' = git-host auth, 'workspace' = org enumerate + bulk clone.
    * Rendered specially by SetupWizard. */
-  kind?: 'chooser' | 'kb' | 'deploy' | 'db2' | 'connection' | 'workspace';
+  kind?: 'account' | 'chooser' | 'kb' | 'deploy' | 'db2' | 'connection' | 'workspace';
   /** When present, the step is only shown for the kb modes it returns true for.
    * Absent ⇒ always shown. */
   showWhen?: (kbMode: WizardKbMode) => boolean;
 }
 
 export const WIZARD_STEPS: WizardStep[] = [
+  { id: 'account', title: 'Secure your account', keys: [], kind: 'account' },
   { id: 'provider', title: 'Primary provider', keys: [], kind: 'chooser' },
-  // Step 2 — the knowledge-base fork. Local deploys an aimee-kb here (needs the
+  // Knowledge-base fork. Local deploys an aimee-kb here (needs the
   // deploy-topology + DB2 steps below); remote connects to an existing one and
   // skips all local infra.
   { id: 'knowledge_base', title: 'Knowledge base', keys: [], kind: 'kb' },

--- a/runtime-web/server.go
+++ b/runtime-web/server.go
@@ -32,6 +32,7 @@ type server struct {
 	sessions *auth.SessionStore
 	rl       *auth.RateLimiter
 	users    *auth.UserManager
+	accounts setupAccountSystem
 	authH    *auth.Handler
 	spaCSP   string
 	loginCSP string
@@ -66,6 +67,7 @@ func run(cfg *config) error {
 		sessions: sessions,
 		rl:       rl,
 		users:    users,
+		accounts: osSetupAccountSystem{users: users},
 		authH:    authH,
 		spaCSP:   contentSecurityPolicy(spaHTML),
 		loginCSP: contentSecurityPolicy([]byte(loginHTML)),
@@ -244,6 +246,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/deploy/apply", s.requireAuth(s.handleDeployApply))
 	mux.HandleFunc("/api/deploy/status", s.requireAuth(s.handleDeployStatus))
 	mux.HandleFunc("/api/setup/appliance", s.requireAuth(s.handleSetupAppliance))
+	mux.HandleFunc("/api/setup/account", s.requireAuth(s.handleSetupAccount))
 
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))

--- a/runtime-web/setup_account.go
+++ b/runtime-web/setup_account.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/RakuenSoftware/smoothgui/auth"
+)
+
+const (
+	defaultBootstrapUsername = "aimee"
+	defaultBootstrapPassword = "aimee-local-dev"
+	setupAccountMinPassword  = 8
+)
+
+// setupAccountSystem isolates the root-only PAM mutations so the onboarding
+// transaction is unit-testable without changing accounts on the test host.
+type setupAccountSystem interface {
+	Exists(username string) bool
+	Create(username, password string) error
+	Delete(username string) error
+	ShadowHash(username string) (string, error)
+	Lock(username string) error
+}
+
+type osSetupAccountSystem struct {
+	users *auth.UserManager
+}
+
+func (m osSetupAccountSystem) Exists(username string) bool {
+	return auth.UserExists(username)
+}
+
+func (m osSetupAccountSystem) Create(username, password string) error {
+	return m.users.Create(username, password)
+}
+
+func (m osSetupAccountSystem) Delete(username string) error {
+	return m.users.Delete(username)
+}
+
+func (m osSetupAccountSystem) ShadowHash(username string) (string, error) {
+	out, err := exec.Command("getent", "shadow", username).Output()
+	if err != nil {
+		return "", fmt.Errorf("read password hash: %w", err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), ":", 3)
+	if len(parts) < 2 || parts[1] == "" || strings.HasPrefix(parts[1], "!") ||
+		strings.HasPrefix(parts[1], "*") {
+		return "", errors.New("new account has no usable password hash")
+	}
+	return parts[1], nil
+}
+
+func (m osSetupAccountSystem) Lock(username string) error {
+	if out, err := exec.Command("usermod", "--lock", username).CombinedOutput(); err != nil {
+		return fmt.Errorf("lock bootstrap login: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (s *server) setupAccountDir() string {
+	return filepath.Join(filepath.Dir(s.cfg.dbPath), "webchat")
+}
+
+func (s *server) setupAccountMarker() string {
+	return filepath.Join(s.setupAccountDir(), "bootstrap-replaced")
+}
+
+func (s *server) setupAccountStore() string {
+	return filepath.Join(s.setupAccountDir(), "logins")
+}
+
+// configuredWithKnownBootstrap returns true only for the published development
+// credential. Operators who explicitly inject a different login do not need the
+// replacement step and must not have their account retired by it.
+func configuredWithKnownBootstrap() bool {
+	return os.Getenv("AIMEE_WEBCHAT_USER") == defaultBootstrapUsername &&
+		os.Getenv("AIMEE_WEBCHAT_PASSWORD") == defaultBootstrapPassword
+}
+
+func readReplacementUsername(marker string) (string, bool) {
+	b, err := os.ReadFile(marker)
+	if err != nil {
+		return "", false
+	}
+	username := strings.TrimSpace(string(b))
+	return username, username != ""
+}
+
+func writePrivateFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".setup-account-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// durableLoginReplacement rewrites the entrypoint-compatible username:crypt-hash
+// registry and records the bootstrap retirement marker. It returns a rollback
+// closure because the live account lock happens after persistence succeeds.
+func durableLoginReplacement(store, marker, oldUsername, newUsername, newHash string) (func(), error) {
+	originalStore, storeErr := os.ReadFile(store)
+	storeExisted := storeErr == nil
+	if storeErr != nil && !errors.Is(storeErr, os.ErrNotExist) {
+		return nil, storeErr
+	}
+	originalMarker, markerErr := os.ReadFile(marker)
+	markerExisted := markerErr == nil
+	if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
+		return nil, markerErr
+	}
+
+	lines := make([]string, 0)
+	for _, line := range strings.Split(string(originalStore), "\n") {
+		if line == "" || strings.HasPrefix(line, oldUsername+":") ||
+			strings.HasPrefix(line, newUsername+":") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	lines = append(lines, newUsername+":"+newHash)
+	updatedStore := []byte(strings.Join(lines, "\n") + "\n")
+	if err := writePrivateFile(store, updatedStore); err != nil {
+		return nil, err
+	}
+	if err := writePrivateFile(marker, []byte(newUsername+"\n")); err != nil {
+		if storeExisted {
+			_ = writePrivateFile(store, originalStore)
+		} else {
+			_ = os.Remove(store)
+		}
+		return nil, err
+	}
+
+	rollback := func() {
+		if storeExisted {
+			_ = writePrivateFile(store, originalStore)
+		} else {
+			_ = os.Remove(store)
+		}
+		if markerExisted {
+			_ = writePrivateFile(marker, originalMarker)
+		} else {
+			_ = os.Remove(marker)
+		}
+	}
+	return rollback, nil
+}
+
+func (s *server) setupAccountStatus() map[string]any {
+	if username, ok := readReplacementUsername(s.setupAccountMarker()); ok {
+		return map[string]any{"complete": true, "required": false, "username": username}
+	}
+	if !configuredWithKnownBootstrap() {
+		return map[string]any{"complete": true, "required": false, "username": currentConfiguredLogin()}
+	}
+	return map[string]any{"complete": false, "required": true, "username": defaultBootstrapUsername}
+}
+
+func currentConfiguredLogin() string {
+	return strings.TrimSpace(os.Getenv("AIMEE_WEBCHAT_USER"))
+}
+
+// GET reports whether the published development login still needs replacement.
+// POST creates and persists the replacement account, locks the development login,
+// invalidates its sessions, and moves this browser to a session for the new user.
+func (s *server) handleSetupAccount(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodGet {
+		_ = json.NewEncoder(w).Encode(s.setupAccountStatus())
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// This mutation changes a root-managed PAM account. SameSite=Strict already
+	// protects the session cookie in browsers; keep an explicit origin gate here
+	// as defense in depth for the highest-impact onboarding request.
+	if !sameOriginRequest(r) {
+		writeJSONError(w, http.StatusForbidden, "cross-origin account setup refused")
+		return
+	}
+	if _, complete := readReplacementUsername(s.setupAccountMarker()); complete ||
+		!configuredWithKnownBootstrap() {
+		writeJSONError(w, http.StatusConflict, "bootstrap account has already been replaced")
+		return
+	}
+	if currentUser(r) != defaultBootstrapUsername {
+		writeJSONError(w, http.StatusForbidden, "sign in with the bootstrap account to replace it")
+		return
+	}
+
+	var req struct {
+		Username             string `json:"username"`
+		Password             string `json:"password"`
+		PasswordConfirmation string `json:"password_confirmation"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	req.Username = strings.TrimSpace(req.Username)
+	if err := auth.ValidateUsername(req.Username); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Username == defaultBootstrapUsername {
+		writeJSONError(w, http.StatusBadRequest, "choose a username other than aimee")
+		return
+	}
+	if len(req.Password) < setupAccountMinPassword {
+		writeJSONError(w, http.StatusBadRequest, "password must be at least 8 characters")
+		return
+	}
+	if strings.ContainsAny(req.Password, "\x00\r\n") {
+		writeJSONError(w, http.StatusBadRequest, "password contains an unsupported control character")
+		return
+	}
+	if req.Password != req.PasswordConfirmation {
+		writeJSONError(w, http.StatusBadRequest, "passwords do not match")
+		return
+	}
+	if s.accounts.Exists(req.Username) {
+		writeJSONError(w, http.StatusConflict, "username already exists")
+		return
+	}
+
+	if err := s.accounts.Create(req.Username, req.Password); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	cleanupUser := true
+	defer func() {
+		if cleanupUser {
+			_ = s.accounts.Delete(req.Username)
+		}
+	}()
+
+	newHash, err := s.accounts.ShadowHash(req.Username)
+	if err != nil || strings.ContainsAny(newHash, ":\r\n") {
+		if err == nil {
+			err = errors.New("invalid password hash")
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	newToken, err := s.sessions.CreateSession(req.Username)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not create replacement session")
+		return
+	}
+	cleanupSession := true
+	defer func() {
+		if cleanupSession {
+			_ = s.sessions.DeleteSession(newToken)
+		}
+	}()
+	rollback, err := durableLoginReplacement(s.setupAccountStore(), s.setupAccountMarker(),
+		defaultBootstrapUsername, req.Username, newHash)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not persist replacement account")
+		return
+	}
+	// Invalidate every session authenticated with the published password before
+	// locking that login. A failure rolls durable state back while the PAM login
+	// still works, so the operator can sign in and retry.
+	if err := s.sessions.DeleteSessionsForUser(defaultBootstrapUsername); err != nil {
+		rollback()
+		writeJSONError(w, http.StatusInternalServerError, "could not invalidate bootstrap sessions")
+		return
+	}
+	if err := s.accounts.Lock(defaultBootstrapUsername); err != nil {
+		rollback()
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    newToken,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   s.cfg.tlsEnabled(),
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   int((24 * time.Hour) / time.Second),
+	})
+	cleanupSession = false
+	cleanupUser = false
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"complete": true, "required": false, "username": req.Username,
+	})
+}

--- a/runtime-web/setup_account_test.go
+++ b/runtime-web/setup_account_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RakuenSoftware/smoothgui/auth"
+)
+
+type fakeSetupAccounts struct {
+	users   map[string]string
+	locked  map[string]bool
+	lockErr error
+}
+
+func (f *fakeSetupAccounts) Exists(username string) bool {
+	_, ok := f.users[username]
+	return ok
+}
+
+func (f *fakeSetupAccounts) Create(username, password string) error {
+	f.users[username] = "$test$" + password
+	return nil
+}
+
+func (f *fakeSetupAccounts) Delete(username string) error {
+	delete(f.users, username)
+	return nil
+}
+
+func (f *fakeSetupAccounts) ShadowHash(username string) (string, error) {
+	return f.users[username], nil
+}
+
+func (f *fakeSetupAccounts) Lock(username string) error {
+	if f.lockErr != nil {
+		return f.lockErr
+	}
+	f.locked[username] = true
+	return nil
+}
+
+func TestSetupAccountRollsBackDurableStateWhenLockFails(t *testing.T) {
+	s, fake := newSetupAccountTestServer(t)
+	fake.lockErr = errors.New("lock failed")
+	if err := os.MkdirAll(s.setupAccountDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("aimee:$test$bootstrap\nother:$test$other\n")
+	if err := os.WriteFile(s.setupAccountStore(), original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"username":"virant","password":"correct horse","password_confirmation":"correct horse"}`
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/setup/account", strings.NewReader(body)), defaultBootstrapUsername)
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rr := httptest.NewRecorder()
+	s.handleSetupAccount(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if fake.Exists("virant") {
+		t.Fatal("failed replacement user was not removed")
+	}
+	if _, err := os.Stat(s.setupAccountMarker()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("retirement marker survived rollback: %v", err)
+	}
+	stored, err := os.ReadFile(s.setupAccountStore())
+	if err != nil || string(stored) != string(original) {
+		t.Fatalf("login store=%q err=%v", stored, err)
+	}
+}
+
+func newSetupAccountTestServer(t *testing.T) (*server, *fakeSetupAccounts) {
+	t.Helper()
+	t.Setenv("AIMEE_WEBCHAT_USER", defaultBootstrapUsername)
+	t.Setenv("AIMEE_WEBCHAT_PASSWORD", defaultBootstrapPassword)
+	dbPath := filepath.Join(t.TempDir(), "webchat.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	fake := &fakeSetupAccounts{
+		users:  map[string]string{defaultBootstrapUsername: "$test$bootstrap"},
+		locked: map[string]bool{},
+	}
+	s := &server{
+		cfg:      &config{port: 8443, dbPath: dbPath},
+		db:       db,
+		sessions: auth.NewSessionStore(db, time.Hour),
+		accounts: fake,
+	}
+	return s, fake
+}
+
+func TestSetupAccountReplacesAndPersistsBootstrapLogin(t *testing.T) {
+	s, fake := newSetupAccountTestServer(t)
+	if err := os.MkdirAll(s.setupAccountDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.setupAccountStore(), []byte("aimee:$test$bootstrap\nother:$test$other\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldToken, err := s.sessions.CreateSession(defaultBootstrapUsername)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"username":"virant","password":"correct horse","password_confirmation":"correct horse"}`
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/setup/account", strings.NewReader(body)), defaultBootstrapUsername)
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rr := httptest.NewRecorder()
+	s.handleSetupAccount(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("replace account: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if !fake.Exists("virant") || !fake.locked[defaultBootstrapUsername] {
+		t.Fatalf("replacement user/lock not applied: users=%v locked=%v", fake.users, fake.locked)
+	}
+	stored, err := os.ReadFile(s.setupAccountStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(stored), "aimee:") || !strings.Contains(string(stored), "virant:$test$correct horse") ||
+		!strings.Contains(string(stored), "other:$test$other") {
+		t.Fatalf("unexpected durable login store: %q", stored)
+	}
+	marker, err := os.ReadFile(s.setupAccountMarker())
+	if err != nil || strings.TrimSpace(string(marker)) != "virant" {
+		t.Fatalf("marker=%q err=%v", marker, err)
+	}
+	if _, err := s.sessions.ValidateSession(oldToken); err == nil {
+		t.Fatal("bootstrap session remains valid")
+	}
+	cookies := rr.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != "session" || !cookies[0].Secure {
+		t.Fatalf("replacement session cookie = %#v", cookies)
+	}
+	if username, err := s.sessions.ValidateSession(cookies[0].Value); err != nil || username != "virant" {
+		t.Fatalf("replacement session username=%q err=%v", username, err)
+	}
+
+	statusReq := withUser(httptest.NewRequest(http.MethodGet, "/api/setup/account", nil), "virant")
+	statusRR := httptest.NewRecorder()
+	s.handleSetupAccount(statusRR, statusReq)
+	var status map[string]any
+	if err := json.Unmarshal(statusRR.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status["complete"] != true || status["required"] != false || status["username"] != "virant" {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestSetupAccountValidatesBootstrapCallerAndCredentials(t *testing.T) {
+	s, _ := newSetupAccountTestServer(t)
+	tests := []struct {
+		name string
+		user string
+		body string
+		code int
+	}{
+		{"bootstrap caller required", "someone", `{"username":"virant","password":"long enough","password_confirmation":"long enough"}`, http.StatusForbidden},
+		{"new username required", "aimee", `{"username":"aimee","password":"long enough","password_confirmation":"long enough"}`, http.StatusBadRequest},
+		{"password minimum", "aimee", `{"username":"virant","password":"short","password_confirmation":"short"}`, http.StatusBadRequest},
+		{"password confirmation", "aimee", `{"username":"virant","password":"long enough","password_confirmation":"different"}`, http.StatusBadRequest},
+		{"password newline", "aimee", "{\"username\":\"virant\",\"password\":\"long enough\\nroot:hijack\",\"password_confirmation\":\"long enough\\nroot:hijack\"}", http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := withUser(httptest.NewRequest(http.MethodPost, "/api/setup/account", strings.NewReader(tc.body)), tc.user)
+			req.Header.Set("Sec-Fetch-Site", "same-origin")
+			rr := httptest.NewRecorder()
+			s.handleSetupAccount(rr, req)
+			if rr.Code != tc.code {
+				t.Fatalf("code=%d want=%d body=%s", rr.Code, tc.code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestSetupAccountRejectsCrossOriginMutation(t *testing.T) {
+	s, _ := newSetupAccountTestServer(t)
+	body := `{"username":"virant","password":"long enough","password_confirmation":"long enough"}`
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/setup/account", strings.NewReader(body)), defaultBootstrapUsername)
+	req.Header.Set("Origin", "https://evil.example")
+	req.Host = "aimee.example"
+	rr := httptest.NewRecorder()
+	s.handleSetupAccount(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("code=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSetupAccountIsCompleteForOperatorConfiguredLogin(t *testing.T) {
+	s, _ := newSetupAccountTestServer(t)
+	t.Setenv("AIMEE_WEBCHAT_USER", "operator")
+	t.Setenv("AIMEE_WEBCHAT_PASSWORD", "not-the-published-default")
+	rr := httptest.NewRecorder()
+	s.handleSetupAccount(rr, withUser(httptest.NewRequest(http.MethodGet, "/api/setup/account", nil), "operator"))
+	var status map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status["complete"] != true || status["required"] != false || status["username"] != "operator" {
+		t.Fatalf("status = %#v", status)
+	}
+}

--- a/runtime-web/vscode.go
+++ b/runtime-web/vscode.go
@@ -89,7 +89,7 @@ func (s *server) handleVSCode(w http.ResponseWriter, r *http.Request) {
 	// helps but is not an explicit gate, so reject any cross-origin request here.
 	// The editor's own assets/XHR/WebSocket all originate from our same-origin
 	// iframe, so legitimate traffic always matches; only foreign origins are cut.
-	if !sameOriginVSCode(r) {
+	if !sameOriginRequest(r) {
 		http.Error(w, "cross-origin request rejected", http.StatusForbidden)
 		return
 	}
@@ -260,7 +260,8 @@ func hostNoDefaultPort(host, scheme string) string {
 	return net.JoinHostPort(h, p)
 }
 
-// sameOriginVSCode is the cross-origin gate for the /vscode proxy. The browser
+// sameOriginRequest is the cross-origin gate for privileged browser operations,
+// including the /vscode proxy and onboarding account replacement. The browser
 // reaches webchat at forwardedProto://r.Host; a request whose Origin resolves to
 // a different scheme+host+port is cross-origin and rejected. Scheme and host are
 // compared normalized (case-insensitive, default port stripped) so a same-origin
@@ -274,7 +275,7 @@ func hostNoDefaultPort(host, scheme string) string {
 // navigations, asset GETs) or when the browser explicitly marks it same-origin
 // via Sec-Fetch-Site, so a non-safe cross-origin call that omits Origin cannot
 // slip through.
-func sameOriginVSCode(r *http.Request) bool {
+func sameOriginRequest(r *http.Request) bool {
 	origin := strings.TrimSpace(r.Header.Get("Origin"))
 	if origin == "" {
 		if isWebSocketUpgrade(r) {

--- a/runtime-web/vscode_test.go
+++ b/runtime-web/vscode_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// sameOriginVSCode is the cross-origin gate guarding the /vscode reverse proxy.
+// sameOriginRequest is the cross-origin gate guarding privileged browser requests.
 // A cookie alone is CSRF-able, so the proxy must reject any cross-origin request
 // and, for WebSocket upgrades (the editor terminal), refuse a missing Origin too
 // (browsers always send one on an upgrade). Same-origin iframe traffic — asset
@@ -69,8 +69,8 @@ func TestSameOriginVSCodeGate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := mkReq(tc.method, tc.host, tc.origin, tc.tls_, tc.xfproto, tc.secFetch, tc.ws)
-			if got := sameOriginVSCode(r); got != tc.want {
-				t.Fatalf("sameOriginVSCode = %v, want %v", got, tc.want)
+			if got := sameOriginRequest(r); got != tc.want {
+				t.Fatalf("sameOriginRequest = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -410,8 +410,10 @@ static int run_capture(const char *const argv[], char **envp, char *out, size_t 
  * stops and removes the very container running the deploy. (docker compose
  * --dry-run reports "Container aimee-aimee-server-1 Stopping/Removing".)
  *
- * Removing a container that was never up is a no-op, so failures here are not
- * fatal to the deploy; the output is appended for the wizard to show. */
+ * Removing a container that was never up is non-fatal. Docker's daemon error for
+ * that expected case is deliberately not appended to the wizard output: it used
+ * to put "retired legacy ... No such container" above the real compose failure,
+ * making operators diagnose harmless cleanup instead of the actionable error. */
 
 /* The container the retirement targets. Named, not derived, because it is no
  * longer a compose service — nothing can regenerate this string for us. */
@@ -441,9 +443,10 @@ static void deploy_retire_stale_llm(char **envp, const char *file, char *out, si
       return;
    char buf[512];
    int code = -1;
-   if (run_capture(argv, envp, buf, sizeof(buf), &code) == 0 && code == 0 && buf[0] &&
+   if (run_capture(argv, envp, buf, sizeof(buf), &code) == 0 && code == 0 &&
        out_cap > strlen(out) + 1)
-      snprintf(out + strlen(out), out_cap - strlen(out), "retired legacy aimee-llm-cpu: %s", buf);
+      snprintf(out + strlen(out), out_cap - strlen(out),
+               "retired obsolete aimee-llm-cpu container\n");
 }
 
 /* Background worker: `docker compose -f <file> up -d`.


### PR DESCRIPTION
## What changed

- adds the first wizard step to create a persistent operator login, lock the published development login, invalidate its sessions, and prevent startup from restoring it
- derives project readiness from the actual cloned-project inventory and refreshes the setup indicator after project mutations
- pins the managed Compose project to `aimee` so wizard services find the server volumes
- suppresses harmless obsolete-container cleanup noise so real deploy failures are visible
- fixes the testing-image path filter so `runtime-web` changes publish into `:testing`

## Root causes

The setup UI used the active chat tab project instead of `/api/git/projects`. The initial host-side Compose invocation had no fixed project name even though the in-container managed deploy expected `aimee_*` volumes. The browser runtime moved from `webchat/` to `runtime-web/`, but the testing publisher path filter did not.

## Validation

- `cd runtime-web && go test ./...`
- `cd frontend && npm test` (114 tests)
- `cd frontend && npm run check`
- `cd frontend && npm run build`
- `cd src && make -j$(nproc) build/obj/tests/test_deploy_apply && build/obj/tests/test_deploy_apply`
- `cd src && make lint` (38 checks)
- remote Compose config resolves project `aimee` and volume `aimee_aimee-server-workspaces`
