### PR TITLE
Fix server startup recovery window

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -27,7 +27,12 @@ case "$AIMEE_WFE_ENGINE" in
     *) printf '[server-entrypoint] fatal: WFE is Go-only; AIMEE_WFE_ENGINE must be go\n' >&2; exit 2 ;;
 esac
 export AIMEE_WFE_HTTP_SOCKET="${AIMEE_WFE_HTTP_SOCKET:-$AIMEE_HOME/aimee-wfe-http.sock}"
-WFE_SOCKET_WAIT_TENTHS="${AIMEE_WFE_SOCKET_WAIT_TENTHS:-150}"
+# Existing appliances may need to recover SQLite WAL state and refresh seeded
+# workflow definitions before the C resource socket appears.  A real upgraded
+# volume on the supported container path takes about 30 seconds, so the former
+# 15-second default killed a healthy startup and left the persisted pid file
+# behind.  Still fail early when the child exits, but allow bounded recovery.
+WFE_SOCKET_WAIT_TENTHS="${AIMEE_WFE_SOCKET_WAIT_TENTHS:-1200}"
 
 # The server's worker threads need a 64 MB stack; the 8 MB container default
 # overflows and SIGSEGVs on real queries. Raise the soft limit here (inherited
@@ -226,9 +231,6 @@ for _dsock in /var/run/docker.sock /run/docker.sock; do
     break
 done
 
-log "pre-warming server-hosted OAuth CLIs (background)"
-runuser -u aimee -- aimee-server --prewarm-cli-oauth >/dev/null 2>&1 &
-
 log "starting aimee-server (socket=$SERVER_SOCK) as user aimee"
 rm -f "$AIMEE_HOME/aimee-http.sock" "$AIMEE_WFE_HTTP_SOCKET"
 # runuser/PAM resets selected resource limits, including RLIMIT_CORE, after the
@@ -261,6 +263,13 @@ if [ "$AIMEE_WFE_ENGINE" = go ]; then
         "$AIMEE_HOME" "$AIMEE_WFE_HTTP_SOCKET" "$AIMEE_HOME/aimee.yaml" \
         "$AIMEE_HOME/workflows" "$AIMEE_HOME/aimee-http.sock" &
     wfe_pid=$!
+
+    # Start this only after the resource plane owns the current pid file.  On a
+    # restart, a stale persisted pid can be reused by the first child.  The
+    # prewarm command is also named `aimee-server`, so launching it first made
+    # the real server mistake that helper for an already-running server.
+    log "pre-warming server-hosted OAuth CLIs (background)"
+    runuser -u aimee -- aimee-server --prewarm-cli-oauth >/dev/null 2>&1 &
 fi
 
 if [ -n "$wfe_pid" ]; then

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -62,6 +62,26 @@ else
     fail "server entrypoint leaves the workflow registry root-owned"
 fi
 
+# Upgraded persistent volumes can spend tens of seconds recovering WAL state
+# before the C resource socket appears.  The entrypoint must not kill a live
+# child at the old 15-second deadline, and the same-binary OAuth prewarm helper
+# must start only after the real server owns the persisted pid file.
+wfe_wait_tenths=$(sed -n 's/^WFE_SOCKET_WAIT_TENTHS="${AIMEE_WFE_SOCKET_WAIT_TENTHS:-\([0-9][0-9]*\)}"$/\1/p' \
+    ../deploy/container/server-entrypoint.sh)
+server_start_line=$(grep -nF 'log "starting aimee-server (socket=$SERVER_SOCK) as user aimee"' \
+    ../deploy/container/server-entrypoint.sh | cut -d: -f1)
+prewarm_line=$(grep -nF 'runuser -u aimee -- aimee-server --prewarm-cli-oauth' \
+    ../deploy/container/server-entrypoint.sh | cut -d: -f1)
+wfe_start_line=$(grep -nF 'log "starting Go WFE control plane (socket=$AIMEE_WFE_HTTP_SOCKET)"' \
+    ../deploy/container/server-entrypoint.sh | cut -d: -f1)
+if [ -n "$wfe_wait_tenths" ] && [ "$wfe_wait_tenths" -ge 1200 ] &&
+   [ -n "$server_start_line" ] && [ -n "$wfe_start_line" ] && [ -n "$prewarm_line" ] &&
+   [ "$server_start_line" -lt "$wfe_start_line" ] && [ "$wfe_start_line" -lt "$prewarm_line" ]; then
+    pass "server entrypoint tolerates volume recovery before launching same-binary helpers"
+else
+    fail "server entrypoint can time out recovery or let prewarm collide with a stale server pid"
+fi
+
 if awk '/^FROM /{runtime=($0=="FROM debian:bookworm-slim"); found=0} runtime && /build-essential/{found=1} END{exit !found}' \
     ../Dockerfile.server; then
     pass "server runtime carries the baseline workflow verification toolchain"


### PR DESCRIPTION
## What
- allow up to 120 seconds for the native resource socket during appliance startup
- launch the same-binary OAuth prewarm helper only after the real server owns the persisted PID
- add a build-integrity regression guard for both startup invariants

## Why
An upgrade test against an existing managed volume on CT341 reproduced a healthy native server taking about 30 seconds to recover SQLite WAL state and refresh workflow definitions. The old 15-second entrypoint deadline killed it. A following restart could then let the OAuth prewarm helper reuse the stale persisted PID, causing the real server to reject startup.

## Validation
- `sh -n deploy/container/server-entrypoint.sh`
- `bash -n src/tests/test_build_integrity.sh`
- `make -C src -j2 check-linking`
- `cd src && bash tests/test_build_integrity.sh`
- live derived-image upgrade on CT341: native socket ready at ~30s, Go WFE starts, OAuth prewarm follows, container becomes healthy
- HTTPS root returns 302; certless API request returns expected 401
