### PR TITLE
Fail remote setup on rejected credentials

### DIFF
--- a/scripts/test-wizard-first-user-bootstrap.sh
+++ b/scripts/test-wizard-first-user-bootstrap.sh
@@ -98,6 +98,27 @@ curl --silent --show-error --cacert "$e2e_tmp/server/tls/server.crt" \
   >"$e2e_tmp/bearer-write.status"
 [[ $(<"$e2e_tmp/bearer-write.status") == 403 ]]
 
+# Reaching and pinning the right TLS peer is not a successful setup when that
+# peer rejects the supplied credential. The command used to exit zero here and
+# leave `remote status` to reveal the 401 on the next invocation.
+mkdir -p "$e2e_tmp/invalid-client"
+set +e
+AIMEE_HOME="$e2e_tmp/invalid-client" AIMEE_NO_CLIENT_INTEGRATIONS=1 \
+  "$client_bin" --json remote set "https://127.0.0.1:$e2e_tls_port" invalid-bearer \
+  >"$e2e_tmp/invalid-remote-set.json"
+e2e_invalid_remote_rc=$?
+set -e
+[[ $e2e_invalid_remote_rc -ne 0 ]]
+python3 - "$e2e_tmp/invalid-remote-set.json" <<'PY'
+import json
+import pathlib
+import sys
+
+result = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert result["ok"] is False and result["verified"] is True
+assert result["mtls_enrolled"] is False
+PY
+
 AIMEE_HOME="$e2e_tmp/client" AIMEE_NO_CLIENT_INTEGRATIONS=1 \
   "$client_bin" --json remote set "https://127.0.0.1:$e2e_tls_port" "$e2e_bearer" \
   >"$e2e_tmp/remote-set.json"

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -355,6 +355,18 @@ static int remote_health_ok(void)
    return ok;
 }
 
+/* A TLS peer can be reachable and verified while still rejecting the supplied
+ * bearer.  `remote set` is the quickstart's pairing command, so accepting a 401
+ * here creates a false-success setup that fails on the very next command. */
+static int remote_authorized_ok(void)
+{
+   int st = 0;
+   char *body = aimee_client_request("GET", "/v1/health", NULL, &st);
+   int ok = (body != NULL && st >= 200 && st < 400);
+   free(body);
+   return ok;
+}
+
 /* Trust-on-first-use pin: fetch |url|'s leaf cert (no verification), write it to
  * <aimee_home>/remote-ca.pem, and report its SHA-256 fingerprint so the operator
  * can confirm it out-of-band. aimee_tls_connect then verifies against it (chain +
@@ -554,6 +566,19 @@ static int remote_set(const char *url, const char *token, int json_output)
    }
    else if (verified && token && token[0] && remote_enroll_client_cert(json_output) == 0)
       mtls_enrolled = 1;
+
+   /* Trust establishment proves only that we reached the intended TLS peer.
+    * When the caller supplied a credential, also prove that the resulting
+    * bearer/certificate combination is authorized before reporting success.
+    * This still permits platforms without automatic mTLS enrollment while the
+    * server is optional-mTLS: a valid bearer makes the probe succeed. */
+   if (verified && token && token[0] && !remote_authorized_ok())
+   {
+      remote_set_failed = 1;
+      if (!json_output)
+         fprintf(stderr, "  auth: the server rejected the supplied credential; remote setup is not "
+                         "complete\n");
+   }
 
    if (json_output)
       printf("{\"ok\":%s,\"url\":\"%s\",\"token\":%s,\"pinned\":%s,\"verified\":%s,"


### PR DESCRIPTION
## What
- verify an authenticated `/v1/health` request before `aimee remote set` reports success
- return a failing exit status when the pinned server rejects the supplied bearer
- retain bearer-only compatibility on optional-mTLS platforms when the credential is valid
- extend the first-user bootstrap E2E with an invalid-bearer regression

## Why
CT341 reproduced `aimee remote set` exiting 0 after pinning the intended server with an obsolete bearer; the immediately following `aimee remote status` returned 401. The quickstart pairing command must not claim setup succeeded when authentication failed.

## Validation
- `make -C src wizard-bootstrap-e2e`
- `make -C src build/obj/tests/unit-test-cli-remote`
- `src/build/obj/tests/unit-test-cli-remote`
- `git diff --check`

The E2E now proves invalid-bearer rejection, valid first-user mTLS enrollment, certificate-bound full writes, and revocation.
