### PR TITLE
Enforce reviewable final workflow handoffs

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -5184,23 +5184,27 @@ paths:
                     - { type: string, maxLength: 89, pattern: '^aimee/wi/wi_[A-Za-z0-9_]+\.s[0-9a-f]{10}\.g[0-9]+\.[0-9]+$' }
                 base: { type: string }
                 title: { type: string, minLength: 1, maxLength: 256 }
+                body: { type: string, minLength: 1, maxLength: 60000 }
+                draft:
+                  type: boolean
+                  description: Must be true for final feature-to-trunk handoffs and false for slice PRs.
                 number: { type: integer, minimum: 1 }
               oneOf:
                 - required: [head]
                   properties: { op: { enum: [push] } }
                   not:
-                    anyOf: [{ required: [base] }, { required: [title] }, { required: [number] }]
-                - required: [head, base, title]
+                    anyOf: [{ required: [base] }, { required: [title] }, { required: [body] }, { required: [draft] }, { required: [number] }]
+                - required: [head, base, title, body, draft]
                   properties: { op: { enum: [open] } }
                   not: { required: [number] }
                 - required: [number]
                   properties: { op: { enum: [info, ci] } }
                   not:
-                    anyOf: [{ required: [head] }, { required: [base] }, { required: [title] }]
+                    anyOf: [{ required: [head] }, { required: [base] }, { required: [title] }, { required: [body] }, { required: [draft] }]
                 - required: [base, number]
                   properties: { op: { enum: [merge] } }
                   not:
-                    anyOf: [{ required: [head] }, { required: [title] }]
+                    anyOf: [{ required: [head] }, { required: [title] }, { required: [body] }, { required: [draft] }]
       responses:
         "200":
           description: Mechanical forge operation completed

--- a/config/workflows/build-triggered.yaml
+++ b/config/workflows/build-triggered.yaml
@@ -147,6 +147,8 @@ nodes:
     in:
       branch: document.out
     next: final_pr
+  # Terminal human handoff: the feature->trunk PR is created as a draft. The
+  # workflow never marks it ready or merges it.
   - id: final_pr
     block: pr.open
     in:

--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -9,8 +9,8 @@
 #      freeze -> roundtable -> sub-PR -> GREEN CI -> merge into the feature branch)
 #   -> freeze + roundtable {acceptance: proposal completed? quality? missing tests?}  (loop)
 #   -> document + freeze + roundtable {documentation quality}  (loop) -> pushed to the feature branch
-#   -> PR (feature branch -> the repo's DEFAULT branch).  Opened, NOT merged: the workflow ends
-#      at the human-reviewed PR (review + merge happen out-of-band on the forge).
+#   -> draft PR (feature branch -> the repo's DEFAULT branch). Opened, never marked ready or merged:
+#      the workflow ends at the human handoff (review + merge happen out-of-band on the forge).
 #
 # The roundtable always sees the originating proposal alongside the artifact under
 # review (the engine supplies it from the run's proposal), so the plan gate, the
@@ -172,8 +172,8 @@ nodes:
       branch: document.out
     next: final_pr
   # Open the final PR: feature branch -> the repo's DEFAULT branch. Terminal: the
-  # workflow ends here. pr.open only OPENS the PR (base:trunk, never merged); a human
-  # reviews and merges it on the forge.
+  # workflow ends here. pr.open creates a DRAFT PR (base:trunk, never marked ready
+  # or merged); a human reviews, marks ready, and decides whether to merge on the forge.
   - id: final_pr
     block: pr.open
     in:

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -29,8 +29,15 @@ Each slice gets a branch and worktree, implements one packet, verifies it, freez
 runs review before merge into the feature branch. New slices branch from the current merged feature
 tip.
 
-The final PR targets the forge's authoritative default branch. The default workflow opens it and
-stops; normal repository review controls the merge.
+The final PR targets the forge's authoritative default branch. The default workflow opens it as a
+draft and stops. Its title comes from the admitted proposal, and its body carries the original
+request, approved plan, changed-file summary, slice PRs, completed workflow gates, and explicit
+human-review instructions. Automation must not mark this PR ready, approve it, or merge it.
+
+Draft state makes the handoff explicit and prevents an ordinary accidental merge, but it is not a
+human identity system. A production deployment must also keep the workflow forge credential away
+from general-purpose agents and enforce the repository's human-review policy. If a human and an
+agent share the same writable GitHub identity, GitHub cannot prove which one performed an action.
 
 ## Persistence and recovery
 
@@ -98,6 +105,7 @@ Fields under `autonomy.*` tune these limits. Some load at workflow-process start
 - Remote workspace mutation requires full per-user write authority.
 - Tool and credential activity is audited through the event bus.
 - Autonomous mode cannot approve a human gate.
+- Autonomous mode cannot mark a final workflow PR ready or merge it.
 
 ## Observe
 

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -43,6 +43,10 @@ Depending on state, an authorized user can:
 - retry a recoverable parked step;
 - open the current artifact or forge link.
 
+For the default build, the terminal forge link is a draft PR with a proposal-derived title and a
+review body containing the request, plan, diff summary, slice PRs, and completed gates. Marking that
+PR ready and merging it are deliberately outside autonomous workflow actions.
+
 A gate decision is bound to the principal, node, and current artifact hash. If the artifact changes,
 the old decision cannot advance the run.
 
@@ -57,6 +61,10 @@ authorization grant; the owning service checks every request.
 
 Forge credentials stay in the server vault. The workflow process requests a narrow mechanical forge
 operation and never receives the secret.
+
+Do not expose a repository-write credential used for human review to autonomous or general-purpose
+agents. Draft state records the handoff, but a shared GitHub identity cannot distinguish a person
+from software using that person's token.
 
 ## Failure states
 

--- a/docs/wfe-autonomy-runbook.md
+++ b/docs/wfe-autonomy-runbook.md
@@ -10,7 +10,14 @@ Use this when an autonomous workflow stops or behaves unexpectedly.
 4. Check agent admission, provider, worktree, verification, and forge health for that node.
 5. Repair the named condition and resume the same work item.
 
-The default build opens a final PR; it does not merge the repository default branch automatically.
+The default build opens a draft final PR; it does not mark the PR ready or merge the repository
+default branch automatically. The draft must have a proposal-derived title and include the original
+request, approved plan, diff summary, slice PRs, completed gates, and human-review boundary.
+
+If a final PR is non-draft, has a work-item ID for a title, lacks that review context, or was merged
+without the explicit human handoff, treat the run as failed even when its lifecycle row says
+`accepted`. Preserve the PR and lifecycle audit trail, revoke any agent-accessible write credential,
+and verify repository protection before running another live workflow.
 
 ## Never force past
 
@@ -21,6 +28,7 @@ The default build opens a final PR; it does not merge the repository default bra
 - non-green required CI;
 - a degraded panel without quorum;
 - a forge identity or branch-confinement failure.
+- the draft state of a final workflow PR.
 
 ## Recovery
 

--- a/server-go/internal/engine/forge.go
+++ b/server-go/internal/engine/forge.go
@@ -21,6 +21,17 @@ type PullRequest struct {
 	Base string
 	Head string
 }
+
+// PullRequestSpec is the review contract the workflow hands to the forge. A
+// root workflow always sets Draft: automation may assemble and publish the
+// handoff, but making it reviewable and merging it are human actions. Slice PRs
+// stay non-draft because their CI-gated merge into the private feature branch
+// is part of autonomous assembly.
+type PullRequestSpec struct {
+	Title string
+	Body  string
+	Draft bool
+}
 type CIState string
 
 const (
@@ -31,7 +42,7 @@ const (
 
 type Forge interface {
 	Push(context.Context, string, string, string) error
-	Open(context.Context, string, string, string, string, string) (PullRequest, error)
+	Open(context.Context, string, string, string, string, PullRequestSpec) (PullRequest, error)
 	CI(context.Context, string, string) (CIState, error)
 	Merge(context.Context, string, string, string) error
 }
@@ -41,7 +52,7 @@ type unavailableForge struct{}
 func (unavailableForge) Push(context.Context, string, string, string) error {
 	return errors.New("forge resource plane is unavailable")
 }
-func (unavailableForge) Open(context.Context, string, string, string, string, string) (PullRequest, error) {
+func (unavailableForge) Open(context.Context, string, string, string, string, PullRequestSpec) (PullRequest, error) {
 	return PullRequest{}, errors.New("forge resource plane is unavailable")
 }
 
@@ -99,7 +110,7 @@ func NewHTTPForge(cfg HTTPForgeConfig) (*HTTPForge, error) {
 		client: &http.Client{Transport: transport, Timeout: cfg.Timeout}}, nil
 }
 
-func (f *HTTPForge) Open(ctx context.Context, repo, workdir, head, base, title string) (PullRequest, error) {
+func (f *HTTPForge) Open(ctx context.Context, repo, workdir, head, base string, spec PullRequestSpec) (PullRequest, error) {
 	if !managedBranch(head) {
 		return PullRequest{}, fmt.Errorf("refuse push of unmanaged branch %q", head)
 	}
@@ -114,14 +125,18 @@ func (f *HTTPForge) Open(ctx context.Context, repo, workdir, head, base, title s
 	if err != nil || repoOrigin != workOrigin {
 		return PullRequest{}, errors.New("worktree origin does not match admitted repository")
 	}
-	if title == "" {
-		title = "aimee workflow " + head
+	if strings.TrimSpace(spec.Title) == "" {
+		return PullRequest{}, errors.New("pull request title is required")
+	}
+	if strings.TrimSpace(spec.Body) == "" {
+		return PullRequest{}, errors.New("pull request body is required")
 	}
 	var result struct {
 		URL string `json:"url"`
 	}
 	if err := f.execute(ctx, map[string]any{"op": "open", "workdir": workdir,
-		"head": head, "base": base, "title": title}, &result); err != nil {
+		"head": head, "base": base, "title": spec.Title, "body": spec.Body,
+		"draft": spec.Draft}, &result); err != nil {
 		return PullRequest{}, err
 	}
 	if result.URL == "" {

--- a/server-go/internal/engine/forge_test.go
+++ b/server-go/internal/engine/forge_test.go
@@ -74,6 +74,54 @@ func TestHTTPForgePushRejectsUnmanagedBranchAndMismatchedOrigin(t *testing.T) {
 	}
 }
 
+func TestHTTPForgeOpenCarriesCompleteDraftHandoff(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "forge.sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	var request map[string]any
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"url":"https://github.com/acme/one/pull/7"}`))
+	})}
+	go server.Serve(listener)
+	defer server.Close()
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	worktree := filepath.Join(root, "worktree")
+	for _, dir := range []string{repo, worktree} {
+		if output, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+			t.Fatalf("git init %s: %v: %s", dir, err, output)
+		}
+		if output, err := exec.Command("git", "-C", dir, "remote", "add", "origin", "https://github.com/acme/one.git").CombinedOutput(); err != nil {
+			t.Fatalf("add repo origin: %v: %s", err, output)
+		}
+	}
+	forge, err := NewHTTPForge(HTTPForgeConfig{UnixSocket: socket})
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := PullRequestSpec{Title: "Describe the completed feature", Body: "## Summary\n\nReview this.", Draft: true}
+	pr, err := forge.Open(t.Context(), repo, worktree, "aimee/feat/wi_example", "testing", spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.URL != "https://github.com/acme/one/pull/7" {
+		t.Fatalf("PR = %+v", pr)
+	}
+	for key, want := range map[string]any{"op": "open", "title": spec.Title, "body": spec.Body,
+		"draft": true, "head": "aimee/feat/wi_example", "base": "testing"} {
+		if request[key] != want {
+			t.Fatalf("request[%q] = %#v, want %#v; request=%#v", key, request[key], want, request)
+		}
+	}
+}
+
 func TestPullNumber(t *testing.T) {
 	for _, input := range []string{"42", "https://github.com/acme/repo/pull/42"} {
 		number, err := pullNumber(input)

--- a/server-go/internal/engine/native_e2e_test.go
+++ b/server-go/internal/engine/native_e2e_test.go
@@ -83,18 +83,24 @@ func (r *transientGateRunner) Run(ctx context.Context, request StepRequest) (Ste
 	return r.next.Run(ctx, request)
 }
 
-type e2eForge struct{}
+type e2eForge struct {
+	mu    sync.Mutex
+	opens []PullRequestSpec
+}
 
-func (e2eForge) Push(ctx context.Context, _, workdir, branch string) error {
+func (*e2eForge) Push(ctx context.Context, _, workdir, branch string) error {
 	_, err := gitText(ctx, workdir, "push", "-u", "origin", branch)
 	return err
 }
 
-func (e2eForge) Open(_ context.Context, _ string, _ string, head, base, _ string) (PullRequest, error) {
+func (f *e2eForge) Open(_ context.Context, _ string, _ string, head, base string, spec PullRequestSpec) (PullRequest, error) {
+	f.mu.Lock()
+	f.opens = append(f.opens, spec)
+	f.mu.Unlock()
 	return PullRequest{Ref: "pr:" + head, URL: "pr:" + head, Head: head, Base: base}, nil
 }
-func (e2eForge) CI(context.Context, string, string) (CIState, error) { return CIPassed, nil }
-func (e2eForge) Merge(ctx context.Context, workdir, _ string, base string) error {
+func (*e2eForge) CI(context.Context, string, string) (CIState, error) { return CIPassed, nil }
+func (*e2eForge) Merge(ctx context.Context, workdir, _ string, base string) error {
 	_, err := gitText(ctx, workdir, "push", "origin", "HEAD:refs/heads/"+base)
 	return err
 }
@@ -266,7 +272,8 @@ nodes:
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner, err := NewNativeRunner(store, worktrees, &e2eAgents{}, passVerifier{}, artifacts, registry, e2eForge{})
+	forge := &e2eForge{}
+	runner, err := NewNativeRunner(store, worktrees, &e2eAgents{}, passVerifier{}, artifacts, registry, forge)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,6 +314,25 @@ nodes:
 			recoveringRunner.mu.Unlock()
 			if remainingFailures != 0 {
 				t.Fatalf("%d transient roundtable failures were not exercised", remainingFailures)
+			}
+			forge.mu.Lock()
+			opens := append([]PullRequestSpec(nil), forge.opens...)
+			forge.mu.Unlock()
+			if len(opens) != 2 {
+				t.Fatalf("opened %d PRs, want slice + final: %+v", len(opens), opens)
+			}
+			if opens[0].Draft || opens[0].Title != "Implement feature" {
+				t.Fatalf("slice handoff = %+v, want meaningful non-draft slice PR", opens[0])
+			}
+			final := opens[1]
+			if !final.Draft || final.Title != "Build feature" {
+				t.Fatalf("final handoff = %+v, want meaningful draft PR", final)
+			}
+			for _, marker := range []string{"## Human review boundary", "intentionally a draft",
+				"## Changes", "Original request", "Approved implementation plan", rootID} {
+				if !strings.Contains(final.Body, marker) {
+					t.Fatalf("final PR body missing %q:\n%s", marker, final.Body)
+				}
 			}
 			events, err := store.Events(context.Background(), rootID, 0, 1000)
 			if err != nil {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1414,11 +1414,14 @@ func (r *NativeRunner) prOpen(ctx context.Context, req StepRequest) (StepResult,
 	default:
 		base = baseKind
 	}
-	title := paramString(req.Node, "title", "aimee: "+req.WorkItem.ID)
+	spec, err := r.pullRequestSpec(ctx, req, item, workdir, head, base)
+	if err != nil {
+		return StepResult{}, err
+	}
 	if err := r.ensureRunnable(ctx, item.ID); err != nil {
 		return StepResult{}, err
 	}
-	pr, err := r.forge.Open(ctx, item.Repo, workdir, head, base, title)
+	pr, err := r.forge.Open(ctx, item.Repo, workdir, head, base, spec)
 	if err != nil {
 		return StepResult{}, err
 	}

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -1851,7 +1851,7 @@ func TestReviewersAreToldBlockedIsAboutTheRequestNotTheArtifact(t *testing.T) {
 type conflictForge struct{}
 
 func (conflictForge) Push(context.Context, string, string, string) error { return nil }
-func (conflictForge) Open(context.Context, string, string, string, string, string) (PullRequest, error) {
+func (conflictForge) Open(context.Context, string, string, string, string, PullRequestSpec) (PullRequest, error) {
 	return PullRequest{}, nil
 }
 func (conflictForge) CI(context.Context, string, string) (CIState, error) { return CIPassed, nil }
@@ -1864,7 +1864,7 @@ func (conflictForge) Merge(context.Context, string, string, string) error {
 type raceForge struct{}
 
 func (raceForge) Push(context.Context, string, string, string) error { return nil }
-func (raceForge) Open(context.Context, string, string, string, string, string) (PullRequest, error) {
+func (raceForge) Open(context.Context, string, string, string, string, PullRequestSpec) (PullRequest, error) {
 	return PullRequest{}, nil
 }
 func (raceForge) CI(context.Context, string, string) (CIState, error) { return CIPassed, nil }

--- a/server-go/internal/engine/pull_request_handoff.go
+++ b/server-go/internal/engine/pull_request_handoff.go
@@ -1,0 +1,238 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/JBailes/aimee/server-go/internal/db1"
+)
+
+const (
+	maxPullRequestTitleRunes = 120
+	maxRequestBodyBytes      = 16_000
+	maxPlanBodyBytes         = 12_000
+	maxPullRequestBodyBytes  = 55_000
+)
+
+// pullRequestTitle turns the admitted request into a reviewer-facing title.
+// Packet JSON has a required summary; Markdown proposals conventionally have a
+// first-level heading. Plain interactive requests fall back to their first
+// substantive line. A machine work-item identifier is never a useful title.
+func pullRequestTitle(request string) (string, error) {
+	var object map[string]any
+	if json.Unmarshal([]byte(request), &object) == nil {
+		for _, key := range []string{"summary", "title", "name"} {
+			if value, ok := object[key].(string); ok {
+				if title := normalizePullRequestTitle(value); title != "" {
+					return title, nil
+				}
+			}
+		}
+	}
+
+	lines := strings.Split(strings.ReplaceAll(request, "\r\n", "\n"), "\n")
+	inFrontmatter := false
+	var fallback string
+	for index, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "---" && (index == 0 || inFrontmatter) {
+			inFrontmatter = !inFrontmatter
+			continue
+		}
+		if inFrontmatter || line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			if title := normalizePullRequestTitle(strings.TrimSpace(line[2:])); title != "" {
+				return title, nil
+			}
+		}
+		if fallback == "" && substantiveTitleLine(line) {
+			fallback = line
+		}
+	}
+	if title := normalizePullRequestTitle(fallback); title != "" {
+		return title, nil
+	}
+	return "", errors.New("admitted request has no meaningful pull request title")
+}
+
+func substantiveTitleLine(line string) bool {
+	if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "|") ||
+		strings.HasPrefix(line, "```") || strings.HasPrefix(line, ">") {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(strings.TrimLeft(line, "-* ")))
+	lower = strings.ReplaceAll(lower, "**", "")
+	for _, prefix := range []string{"state:", "author:", "date:", "parent:", "owns:",
+		"charter roles:", "implementation dependency:"} {
+		if strings.HasPrefix(lower, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizePullRequestTitle(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimSpace(strings.Trim(value, "#*_`"))
+	for _, prefix := range []string{"proposal:", "title:"} {
+		if len(value) >= len(prefix) && strings.EqualFold(value[:len(prefix)], prefix) {
+			value = strings.TrimSpace(value[len(prefix):])
+		}
+	}
+	value = strings.Join(strings.Fields(value), " ")
+	if value == "" || strings.HasPrefix(strings.ToLower(value), "wi_") {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) > maxPullRequestTitleRunes {
+		cut := maxPullRequestTitleRunes - 1
+		for cut > maxPullRequestTitleRunes/2 && !unicode.IsSpace(runes[cut]) {
+			cut--
+		}
+		runes = append([]rune(strings.TrimSpace(string(runes[:cut]))), '…')
+	}
+	if len(runes) > 0 {
+		runes[0] = unicode.ToUpper(runes[0])
+	}
+	return string(runes)
+}
+
+func boundedMarkdown(value string, maxBytes int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= maxBytes {
+		return value
+	}
+	const suffix = "…\n\n_Content truncated; use the proposal path or workflow artifacts for the complete document._"
+	cut := maxBytes - len(suffix)
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return strings.TrimSpace(value[:cut]) + suffix
+}
+
+func reviewProposalPath(item db1.WorkItem) string {
+	path := filepath.ToSlash(strings.TrimSpace(item.SourcePath))
+	if path == "" || filepath.IsAbs(path) || strings.HasPrefix(path, "../") {
+		return ""
+	}
+	return strings.Replace(path, "/proposals/pending/", "/proposals/done/", 1)
+}
+
+func (r *NativeRunner) pullRequestSpec(ctx context.Context, req StepRequest, item db1.WorkItem,
+	workdir, head, base string) (PullRequestSpec, error) {
+	title := strings.TrimSpace(paramString(req.Node, "title", ""))
+	if title == "" {
+		var err error
+		title, err = pullRequestTitle(req.Proposal)
+		if err != nil {
+			return PullRequestSpec{}, err
+		}
+	} else {
+		title = normalizePullRequestTitle(title)
+		if title == "" {
+			return PullRequestSpec{}, errors.New("configured pull request title is not meaningful")
+		}
+	}
+
+	baseRef := "refs/remotes/origin/" + base
+	if _, err := gitText(ctx, workdir, "rev-parse", "--verify", baseRef); err != nil {
+		baseRef = base
+	}
+	stat, err := gitText(ctx, workdir, "diff", "--stat", "--find-renames", baseRef+"...HEAD")
+	if err != nil {
+		return PullRequestSpec{}, fmt.Errorf("build pull request change summary: %w", err)
+	}
+	if stat == "" {
+		return PullRequestSpec{}, errors.New("refuse pull request handoff with an empty diff")
+	}
+
+	draft := item.ParentID == ""
+	var approvedPlan []byte
+	if draft {
+		approvedPlan, err = r.artifacts.Plan(item.ID)
+		if err != nil {
+			return PullRequestSpec{}, fmt.Errorf("load approved plan for pull request: %w", err)
+		}
+		if strings.TrimSpace(string(approvedPlan)) == "" {
+			return PullRequestSpec{}, errors.New("refuse final pull request handoff without an approved plan")
+		}
+	}
+	var body strings.Builder
+	body.WriteString("## Summary\n\n")
+	body.WriteString(title)
+	last, _ := utf8.DecodeLastRuneInString(title)
+	if !strings.ContainsRune(".?!", last) {
+		body.WriteString(".")
+	}
+	body.WriteString("\n\n")
+	if draft {
+		body.WriteString("This is the terminal handoff from the autonomous workflow. The complete admitted request and approved plan are included below so review does not depend on workflow-internal identifiers.\n")
+	} else {
+		body.WriteString("This implementation slice is part of the parent feature branch and remains subject to its configured CI and merge gates.\n")
+	}
+
+	body.WriteString("\n## Workflow context\n\n")
+	if path := reviewProposalPath(item); path != "" {
+		fmt.Fprintf(&body, "- Proposal: `%s`\n", path)
+	}
+	fmt.Fprintf(&body, "- Workflow: `%s`", item.WorkflowName)
+	if item.WorkflowVersion != "" {
+		fmt.Fprintf(&body, " (`%s`)", item.WorkflowVersion)
+	}
+	fmt.Fprintf(&body, "\n- Work item: `%s`\n- Branches: `%s` → `%s`\n", item.ID, head, base)
+
+	body.WriteString("\n## Changes\n\n```text\n")
+	body.WriteString(stat)
+	body.WriteString("\n```\n")
+
+	if draft {
+		children, err := r.db.Children(ctx, item.ID)
+		if err != nil {
+			return PullRequestSpec{}, fmt.Errorf("load implementation slices for pull request: %w", err)
+		}
+		body.WriteString("\n## Automated verification\n\n")
+		fmt.Fprintf(&body, "- Approved implementation plan completed.\n- %d implementation slice(s) completed their review, CI, and feature-branch integration gates.\n", len(children))
+		for _, child := range children {
+			if strings.TrimSpace(child.PRRef) != "" {
+				label := child.ID
+				if proposal, proposalErr := r.artifacts.Proposal(child.ID); proposalErr == nil {
+					if meaningful, titleErr := pullRequestTitle(string(proposal)); titleErr == nil {
+						label = meaningful
+					}
+				}
+				if strings.HasPrefix(child.PRRef, "https://") {
+					fmt.Fprintf(&body, "  - [%s](%s)\n", label, child.PRRef)
+				} else {
+					fmt.Fprintf(&body, "  - %s: %s\n", label, child.PRRef)
+				}
+			}
+		}
+		body.WriteString("- The assembled diff passed the acceptance roundtable.\n- The documentation diff passed the documentation roundtable.\n- Final-branch CI runs on this PR and must be checked by the human reviewer.\n")
+
+		body.WriteString("\n## Human review boundary\n\n")
+		body.WriteString("This PR is intentionally a draft. The autonomous workflow stops here and must not mark it ready, approve it, or merge it. A human must review the request, diff, and final CI, then explicitly mark the PR ready and decide whether to merge.\n")
+	} else {
+		body.WriteString("\n## Integration boundary\n\n")
+		body.WriteString("This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.\n")
+	}
+
+	body.WriteString("\n<details>\n<summary>Original request</summary>\n\n")
+	body.WriteString(boundedMarkdown(req.Proposal, maxRequestBodyBytes))
+	body.WriteString("\n\n</details>\n")
+
+	if draft {
+		body.WriteString("\n<details>\n<summary>Approved implementation plan</summary>\n\n")
+		body.WriteString(boundedMarkdown(string(approvedPlan), maxPlanBodyBytes))
+		body.WriteString("\n\n</details>\n")
+	}
+
+	return PullRequestSpec{Title: title, Body: boundedMarkdown(body.String(), maxPullRequestBodyBytes), Draft: draft}, nil
+}

--- a/server-go/internal/engine/pull_request_handoff_test.go
+++ b/server-go/internal/engine/pull_request_handoff_test.go
@@ -1,0 +1,38 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPullRequestTitleUsesProposalMeaningInsteadOfWorkItemID(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		request string
+		want    string
+	}{
+		{name: "proposal heading", request: "# Proposal: appliance state-recovery runbook\n\n- **State:** pending", want: "Appliance state-recovery runbook"},
+		{name: "plain request", request: "document automatic proposal admission in three implementation slices", want: "Document automatic proposal admission in three implementation slices"},
+		{name: "slice packet", request: `{"packet_id":"p1","summary":"add the admission identity test"}`, want: "Add the admission identity test"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := pullRequestTitle(test.request)
+			if err != nil || got != test.want {
+				t.Fatalf("pullRequestTitle() = %q, %v; want %q", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestPullRequestTitleRejectsBookkeepingAndBoundsProse(t *testing.T) {
+	if _, err := pullRequestTitle("wi_42ca22355e8a97e3ab6bbe9f8de7702c"); err == nil {
+		t.Fatal("work-item identifier was accepted as a PR title")
+	}
+	got, err := pullRequestTitle(strings.Repeat("meaningful words ", 30))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len([]rune(got)) > maxPullRequestTitleRunes || !strings.HasSuffix(got, "…") {
+		t.Fatalf("long title was not bounded cleanly: %q", got)
+	}
+}

--- a/server-go/internal/engine/shipped_workflows_e2e_test.go
+++ b/server-go/internal/engine/shipped_workflows_e2e_test.go
@@ -101,7 +101,7 @@ func runExactShippedWorkflow(t *testing.T, workflowName, wantState, wantPause st
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner, err := NewNativeRunner(store, worktrees, &e2eAgents{}, passVerifier{}, artifacts, registry, e2eForge{})
+	runner, err := NewNativeRunner(store, worktrees, &e2eAgents{}, passVerifier{}, artifacts, registry, &e2eForge{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -344,6 +344,14 @@ int git_pr_create_via_api_ex(const char *principal, const char *repo_dir, const 
                              const char *base_in, const char *title, const char *body, char *out,
                              size_t out_cap, char *err, size_t errlen)
 {
+   return git_pr_create_via_api_ex_draft(principal, repo_dir, head_in, base_in, title, body, 0, out,
+                                         out_cap, err, errlen);
+}
+
+int git_pr_create_via_api_ex_draft(const char *principal, const char *repo_dir, const char *head_in,
+                                   const char *base_in, const char *title, const char *body,
+                                   int draft, char *out, size_t out_cap, char *err, size_t errlen)
+{
    if (out && out_cap)
       out[0] = '\0';
    if (err && errlen)
@@ -401,6 +409,7 @@ int git_pr_create_via_api_ex(const char *principal, const char *repo_dir, const 
    cJSON_AddStringToObject(j, "head", head);
    cJSON_AddStringToObject(j, "base", base);
    cJSON_AddStringToObject(j, "body", bclean ? bclean : "");
+   cJSON_AddBoolToObject(j, "draft", draft ? 1 : 0);
    free(bclean);
    char *jbody = cJSON_PrintUnformatted(j);
    cJSON_Delete(j);

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -47,6 +47,14 @@ int git_pr_create_via_api_ex(const char *principal, const char *repo_dir, const 
                              const char *base, const char *title, const char *body, char *out,
                              size_t out_cap, char *err, size_t errlen);
 
+/* Explicit-draft variant used by workflow handoffs. Final feature->trunk PRs
+ * are created as drafts so automation cannot accidentally merge them as soon
+ * as CI turns green; a human must perform the separately audited ready action.
+ * Slice->feature PRs pass draft=0 and retain their autonomous CI-gated path. */
+int git_pr_create_via_api_ex_draft(const char *principal, const char *repo_dir, const char *head,
+                                   const char *base, const char *title, const char *body, int draft,
+                                   char *out, size_t out_cap, char *err, size_t errlen);
+
 /* Find the existing open PR for an exact head/base pair. Returns 1 + URL,
  * 0 when absent, or -1 on API/validation failure. */
 int git_pr_find_open_via_api(const char *principal, const char *repo_dir, const char *head,

--- a/src/modules/workflows/wfe_live_forge.c
+++ b/src/modules/workflows/wfe_live_forge.c
@@ -411,8 +411,9 @@ static int live_open(const char *repo, const char *branch, const char *base, con
       return -1;
    /* git_pr_create_via_api_ex strips AI attribution from the body itself. */
    char url[512] = "", err[200] = "";
-   if (git_pr_create_via_api_ex(NULL, dir, branch, base, title ? title : "", body ? body : "", url,
-                                sizeof url, err, sizeof err) != 0)
+   int draft = wfe_base_is_protected(base);
+   if (git_pr_create_via_api_ex_draft(NULL, dir, branch, base, title ? title : "", body ? body : "",
+                                      draft, url, sizeof url, err, sizeof err) != 0)
    {
       aimee_log(LOG_WARN, "wfe-forge", "pr create for %s failed: %s", branch, err);
       return -1;

--- a/src/server/server_http_routes_git.c
+++ b/src/server/server_http_routes_git.c
@@ -558,7 +558,8 @@ static int wfe_default_base(const char *principal, const char *repo, const char 
 
 static int wfe_forge_body_fields_valid(const cJSON *body)
 {
-   static const char *const allowed[] = {"op", "workdir", "head", "base", "title", "number", NULL};
+   static const char *const allowed[] = {"op",   "workdir", "head",   "base", "title",
+                                         "body", "draft",   "number", NULL};
    for (const cJSON *field = body ? body->child : NULL; field; field = field->next)
    {
       int index = -1;
@@ -573,7 +574,10 @@ static int wfe_forge_body_fields_valid(const cJSON *body)
       for (const cJSON *prior = body->child; prior != field; prior = prior->next)
          if (prior->string && strcmp(prior->string, field->string) == 0)
             return 0;
-      if ((index == 5 && !cJSON_IsNumber(field)) || (index != 5 && !cJSON_IsString(field)))
+      int valid_type = index == 7   ? cJSON_IsNumber(field)
+                       : index == 6 ? cJSON_IsBool(field)
+                                    : cJSON_IsString(field);
+      if (!valid_type)
          return 0;
    }
    return 1;
@@ -596,19 +600,25 @@ static int wfe_slice_ref_matches_workdir(const char *workdir, const char *prefix
 }
 
 static int wfe_forge_operation_valid(const char *op, const char *head, const char *base,
-                                     const char *title, const cJSON *jnumber, int number)
+                                     const char *title, const char *body, const cJSON *jdraft,
+                                     int draft, const cJSON *jnumber, int number)
 {
    int has_number = jnumber != NULL;
+   int has_draft = jdraft != NULL;
    if (has_number && (!cJSON_IsNumber(jnumber) || jnumber->valuedouble != (double)number))
       return 0;
    if (strcmp(op, "push") == 0)
-      return head && !base && !title && !has_number;
+      return head && !base && !title && !body && !has_draft && !has_number;
    if (strcmp(op, "open") == 0)
-      return head && base && title && title[0] && !has_number;
+   {
+      int final_head = head && strncmp(head, "aimee/feat/wi_", 14) == 0;
+      return head && base && title && title[0] && body && body[0] && has_draft &&
+             cJSON_IsBool(jdraft) && draft == final_head && !has_number;
+   }
    if (strcmp(op, "info") == 0 || strcmp(op, "ci") == 0)
-      return !head && !base && !title && has_number && number > 0;
+      return !head && !base && !title && !body && !has_draft && has_number && number > 0;
    if (strcmp(op, "merge") == 0)
-      return !head && base && !title && has_number && number > 0;
+      return !head && base && !title && !body && !has_draft && has_number && number > 0;
    return 0;
 }
 
@@ -627,12 +637,15 @@ int rh_internal_forge_execute(const route_req_t *rq, char *resp, int cap)
    const char *head = route_json_string(body, "head");
    const char *base = route_json_string(body, "base");
    const char *title = route_json_string(body, "title");
+   const char *pr_body = route_json_string(body, "body");
+   const cJSON *jdraft = body ? cJSON_GetObjectItemCaseSensitive(body, "draft") : NULL;
+   int draft = cJSON_IsTrue(jdraft) ? 1 : 0;
    const cJSON *jnumber = body ? cJSON_GetObjectItemCaseSensitive(body, "number") : NULL;
    int number = cJSON_IsNumber(jnumber) ? jnumber->valueint : 0;
    if (!body || !wfe_forge_body_fields_valid(body) || !op || !workdir_in ||
        (head && !wfe_ref_valid(head)) || (base && !wfe_ref_valid(base)) ||
-       (title && strlen(title) > 256) ||
-       !wfe_forge_operation_valid(op, head, base, title, jnumber, number))
+       (title && strlen(title) > 256) || (pr_body && strlen(pr_body) > 60000) ||
+       !wfe_forge_operation_valid(op, head, base, title, pr_body, jdraft, draft, jnumber, number))
    {
       cJSON_Delete(body);
       return err_json(resp, cap, 400, "invalid forge operation request");
@@ -685,9 +698,9 @@ int rh_internal_forge_execute(const route_req_t *rq, char *resp, int cap)
             int found = git_pr_find_open_via_api(principal, trusted_repo, head, base, url,
                                                  sizeof(url), err, sizeof(err));
             if (found == 0)
-               rc = git_pr_create_via_api_ex(principal, trusted_repo, head, base, title,
-                                             "Automated workflow output ready for human review.",
-                                             url, sizeof(url), err, sizeof(err));
+               rc = git_pr_create_via_api_ex_draft(principal, trusted_repo, head, base, title,
+                                                   pr_body, draft, url, sizeof(url), err,
+                                                   sizeof(err));
             else
                rc = found == 1 ? 0 : -1;
             if (rc == 0)

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -207,6 +207,15 @@ int git_pr_create_via_api_ex(const char *principal, const char *repo_dir, const 
    return -1;
 }
 
+int git_pr_create_via_api_ex_draft(const char *principal, const char *repo_dir, const char *head,
+                                   const char *base, const char *title, const char *body, int draft,
+                                   char *out, size_t out_cap, char *err, size_t errlen)
+{
+   (void)draft;
+   return git_pr_create_via_api_ex(principal, repo_dir, head, base, title, body, out, out_cap, err,
+                                   errlen);
+}
+
 int git_pr_find_open_via_api(const char *principal, const char *repo_dir, const char *head,
                              const char *base, char *out, size_t out_cap, char *err, size_t errlen)
 {


### PR DESCRIPTION
## Summary

- derive workflow PR titles from the admitted proposal or slice packet instead of a work-item ID;
- build a reviewable PR body containing the original request, approved plan, diff summary, slice PRs, completed gates, and the final review boundary;
- create root feature-to-default-branch PRs as drafts while keeping CI-gated slice-to-feature PRs non-draft;
- enforce the non-empty body and root-draft invariant again in the C forge resource plane.

## Incident and root cause

PR #2133 was opened with a machine identifier for its title and only “Automated workflow output ready for human review.” for its body. It was not a draft, had no review or comments, and a separate automated Codex session merged it after refreshing CI.

The workflow engine correctly limited its own merge operation to slice PRs targeting `aimee/feat/...`, but the handoff itself had no mechanical ready-for-review boundary. The repository also has required checks but no required-review rule, and a general-purpose agent had access to the user's writable GitHub identity.

## Behavior after this change

A root workflow can publish the final handoff, but GitHub will reject an ordinary merge while the PR remains draft. The workflow does not mark it ready, approve it, or merge it. A human must explicitly mark it ready after reviewing the request, approved plan, diff, slice history, and final CI.

This is an explicit handoff barrier, not a human identity proof. If people and agents share one writable GitHub credential, GitHub cannot distinguish them; credential separation and repository review policy remain deployment requirements.

## Validation

- `go test ./...` in `server-go`
- `make -C src lint` — all 39 checks passed
- `unit-test-server-http`
- `unit-test-wfe-sliced-build`
- compiled `git_pr_api.o` and `wfe_live_forge.o` with warnings as errors
- validated `config/workflows/build.yaml` and `build-triggered.yaml`
- `git diff --check`
