### PR TITLE
test: preserve code intelligence red baselines

### DIFF
--- a/benchmarks/code-agent-effectiveness/README.md
+++ b/benchmarks/code-agent-effectiveness/README.md
@@ -1,0 +1,32 @@
+# Agent-facing code-intelligence evaluation
+
+This directory holds the attribution-safe red/green fixtures accepted by
+[`agent-facing-code-intelligence-effectiveness`](../../docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md).
+
+`fixtures.json` is deliberately small and product-facing. It records five distinct failure classes:
+
+- agent tool discovery does not find the blast-radius capability named by installed guidance;
+- code lookups mix duplicate project namespaces instead of defaulting to the active project;
+- Python path/import normalization leaves blast radius empty despite caller evidence;
+- repository queries return unrelated global delegation episodes instead of abstaining; and
+- a KB outage is not yet represented by the typed, recoverable result contract.
+
+Each case preserves the untreated observation and the post-fix contract. Later slices reuse these
+same fixtures; they must not replace the red observation with a passing treatment result.
+
+Validate the checked-in structure without a live KB:
+
+```bash
+python3 benchmarks/code-agent-effectiveness/validate_fixtures.py
+```
+
+The interrupted Ponytail run is diagnostic evidence only. Minimal, non-secret extracts are tracked
+under `evidence/` and pinned by `fixtures.json`; the complete raw streams are not vendored. Their
+checksums, exact original locations, versions, exclusions, and reproduction commands are recorded in
+[`docs/validation/agent-facing-code-intelligence-red-baseline.md`](../../docs/validation/agent-facing-code-intelligence-red-baseline.md).
+
+Verify the tracked evidence bytes as well as the fixture schema:
+
+```bash
+python3 benchmarks/code-agent-effectiveness/validate_fixtures.py --verify-sources
+```

--- a/benchmarks/code-agent-effectiveness/evidence/kb-outage.json
+++ b/benchmarks/code-agent-effectiveness/evidence/kb-outage.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "observed_at": "2026-07-29",
+  "commands": [
+    "aimee status",
+    "python3 battery/codex_matrix.py --resume"
+  ],
+  "status_output": [
+    "aimee-server: ok",
+    "state: ok",
+    "aimee-kb: unreachable",
+    "the knowledge base did not answer; memory and kb search will not work"
+  ],
+  "runner_checkpoint": {
+    "score_path": "battery/codex_results/score.json",
+    "score_sha256": "ec7325e4bfb0197517d11bdad2b7837a70f3ee6e4ca8c3b8631bc1e26180f675",
+    "complete": 97,
+    "expected": 600,
+    "result_artifacts_preserved": true,
+    "resume_refused_while_kb_unreachable": true
+  },
+  "capture_note": "Reconstructed immediately from the live status probe and persisted score checkpoint because the runner had no separate outage-result artifact. This tracked record is the durable E0 source; it does not claim byte-for-byte provenance for terminal formatting."
+}

--- a/benchmarks/code-agent-effectiveness/evidence/t06-readiness.json
+++ b/benchmarks/code-agent-effectiveness/evidence/t06-readiness.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "origin": {
+    "path": "battery/codex_results/cells/aimee__t06_semver__r1/aimee-readiness.json",
+    "sha256": "a5dd73c96bec0df3dae6f0eb7d5c44d9867fdf9089f0b036deee8755ed9ce8f3"
+  },
+  "project": "codex-t06-semver-r1-a14c49e9",
+  "runtime": {
+    "client_version": "aimee v0.2.195-1003-g627c1ffc",
+    "server_version": "testing-8bc6aa5",
+    "kb_version": "vtesting-8bc6aa5"
+  },
+  "build": {
+    "embeddings_added": 35
+  },
+  "symbol": {
+    "identifier": "end_of_month",
+    "file_path": "app/dates.py",
+    "line": 7,
+    "projects": [
+      "codex-t03-model-migration-r1-4125b941",
+      "codex-t03-model-migration-r1-dbcb04e8",
+      "codex-t06-semver-r1-a14c49e9",
+      "codex-t09-root-cause-r1",
+      "codex-t50-toposort-r1-31301348",
+      "codex-t50-toposort-r1-ec3ead31",
+      "fixture",
+      "source"
+    ]
+  },
+  "callers": {
+    "active_project_hits": [
+      {
+        "caller": "billing_period_days",
+        "file_path": "app/billing.py",
+        "line": 3
+      },
+      {
+        "caller": "invoice_due",
+        "file_path": "app/invoices.py",
+        "line": 3
+      },
+      {
+        "caller": "month_report_path",
+        "file_path": "app/reports.py",
+        "line": 6
+      }
+    ],
+    "distinct_project_count": 8
+  },
+  "blast_radius": {
+    "file": "app/dates.py",
+    "dependencies": [],
+    "dependents": []
+  }
+}

--- a/benchmarks/code-agent-effectiveness/evidence/t09-memory.json
+++ b/benchmarks/code-agent-effectiveness/evidence/t09-memory.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "origin": {
+    "path": "/tmp/ptcodex/raw/aimee__t09_root_cause__r1.jsonl",
+    "sha256": "9820b7f90b34df7c226e36649a37debd21ba78eb92323a01ee487bcfdf3c0418",
+    "item": "item_6"
+  },
+  "tool": "search_memory",
+  "arguments": {
+    "query": "billing_period_days January month length billing bug conventions"
+  },
+  "status": "completed",
+  "reported_count": 4,
+  "results": [
+    {
+      "entity": "delegate_codex_review_ok",
+      "tier": "L1",
+      "kind": "episode",
+      "topic": "roundtable chairman review"
+    },
+    {
+      "entity": "delegate_codex_unknown_ok",
+      "tier": "L1",
+      "kind": "episode",
+      "topic": "roundtable chairman review"
+    },
+    {
+      "entity": "delegate_minimax_review_fail",
+      "tier": "L1",
+      "kind": "episode",
+      "topic": "cancelled roundtable review"
+    },
+    {
+      "entity": "delegate_minimax_unknown_fail",
+      "tier": "L1",
+      "kind": "episode",
+      "topic": "cancelled roundtable review"
+    }
+  ],
+  "active_project_relevant_count": 0
+}

--- a/benchmarks/code-agent-effectiveness/evidence/t50-tool-and-scope.json
+++ b/benchmarks/code-agent-effectiveness/evidence/t50-tool-and-scope.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "origin": {
+    "path": "/tmp/ptcodex/raw/aimee__t50_toposort__r1.jsonl",
+    "sha256": "277ad99445419c3511bad01fa015876b0d87f967d28dd875130d058de9e1523b",
+    "items": [
+      "item_7",
+      "item_14"
+    ]
+  },
+  "find_symbol": {
+    "arguments": {
+      "identifier": "install_order"
+    },
+    "status": "completed",
+    "matches": [
+      {
+        "file_path": "app/graph.py",
+        "line": 16,
+        "kind": "definition",
+        "project": "codex-t03-model-migration-r1-dbcb04e8"
+      },
+      {
+        "file_path": "app/graph.py",
+        "line": 16,
+        "kind": "definition",
+        "project": "codex-t09-root-cause-r1"
+      },
+      {
+        "file_path": "app/graph.py",
+        "line": 16,
+        "kind": "definition",
+        "project": "codex-t50-toposort-r1-31301348"
+      },
+      {
+        "file_path": "app/graph.py",
+        "line": 16,
+        "kind": "definition",
+        "project": "codex-t50-toposort-r1-ec3ead31"
+      },
+      {
+        "file_path": "app/graph.py",
+        "line": 16,
+        "kind": "definition",
+        "project": "fixture"
+      },
+      {
+        "file_path": "app/graph.py",
+        "line": 16,
+        "kind": "definition",
+        "project": "source"
+      }
+    ]
+  },
+  "find_tools": {
+    "arguments": {
+      "query": "blast radius",
+      "limit": 10
+    },
+    "status": "completed",
+    "result": {
+      "tools": [],
+      "count": 0,
+      "total": 0
+    }
+  }
+}

--- a/benchmarks/code-agent-effectiveness/fixtures.json
+++ b/benchmarks/code-agent-effectiveness/fixtures.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": 1,
+  "proposal": "docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md",
+  "source_snapshot": {
+    "captured_at": "2026-07-29",
+    "harness_repository": "/home/virant/dev/ponytail-codex-benchmark",
+    "harness_branch": "agent/codex-benchmark-matrix",
+    "harness_commit": "a40fe3d6a58ac4e8b14aaf75320e83912f0bfc56",
+    "results_root": "battery/codex_results",
+    "results_file_count": 986,
+    "results_tree_manifest_sha256": "93f92f6697263c54696318f566b3b19ee5732de332f7a9a0ebdd199d12736a9b",
+    "raw_root": "/tmp/ptcodex/raw",
+    "raw_file_count": 194,
+    "raw_tree_manifest_sha256": "0441626841c736f4be2c404996ec4a734b5220d9491fbdba5d8cc46b79336133",
+    "complete_cells": 97,
+    "expected_cells": 600,
+    "incomplete": true,
+    "aimee_client_version": "v0.2.195-1003-g627c1ffc",
+    "aimee_server_version": "testing-8bc6aa5",
+    "aimee_kb_version": "vtesting-8bc6aa5"
+  },
+  "cases": [
+    {
+      "id": "tool-discovery-blast-radius",
+      "class": "tool_discovery",
+      "source": {
+        "path": "benchmarks/code-agent-effectiveness/evidence/t50-tool-and-scope.json",
+        "sha256": "3aa1cd3e2ed51f2a2e9518067d8a905e6d7eb8caa4f5428925e4450af8fe7089"
+      },
+      "request": {
+        "guidance_term": "preview_blast_radius",
+        "discovery_query": "blast radius"
+      },
+      "red_observation": {
+        "tools": [],
+        "count": 0
+      },
+      "green_contract": {
+        "canonical_tool": "preview_blast_radius",
+        "discoverable_by": [
+          "blast radius",
+          "preview"
+        ],
+        "required_inputs": [
+          "paths"
+        ],
+        "optional_inputs": [
+          "project"
+        ]
+      }
+    },
+    {
+      "id": "current-project-symbol-scope",
+      "class": "project_scope",
+      "source": {
+        "path": "benchmarks/code-agent-effectiveness/evidence/t50-tool-and-scope.json",
+        "sha256": "3aa1cd3e2ed51f2a2e9518067d8a905e6d7eb8caa4f5428925e4450af8fe7089"
+      },
+      "request": {
+        "identifier": "install_order",
+        "active_project": "codex-t50-toposort-r1-ec3ead31"
+      },
+      "red_observation": {
+        "match_count": 6,
+        "distinct_project_count": 6,
+        "projects": [
+          "codex-t03-model-migration-r1-dbcb04e8",
+          "codex-t09-root-cause-r1",
+          "codex-t50-toposort-r1-31301348",
+          "codex-t50-toposort-r1-ec3ead31",
+          "fixture",
+          "source"
+        ]
+      },
+      "green_contract": {
+        "default_scope": "current",
+        "match_count": 1,
+        "project": "codex-t50-toposort-r1-ec3ead31",
+        "all_scope_is_explicit": true
+      }
+    },
+    {
+      "id": "python-module-blast-radius",
+      "class": "python_blast_radius",
+      "source": {
+        "path": "benchmarks/code-agent-effectiveness/evidence/t06-readiness.json",
+        "sha256": "a17e5bb156a69572a5889b4335698199c465d6b859f40c9ebb847879ad17036a"
+      },
+      "request": {
+        "project": "codex-t06-semver-r1-a14c49e9",
+        "file": "app/dates.py",
+        "normalized_module": "app.dates"
+      },
+      "red_observation": {
+        "dependencies": [],
+        "dependents": []
+      },
+      "positive_control": {
+        "callers": [
+          "app/billing.py",
+          "app/invoices.py",
+          "app/reports.py"
+        ]
+      },
+      "green_contract": {
+        "dependents": [
+          "app/billing.py",
+          "app/invoices.py",
+          "app/reports.py"
+        ],
+        "provenance": "import",
+        "substring_collision_false_edges": 0
+      }
+    },
+    {
+      "id": "repository-memory-abstention",
+      "class": "retrieval_abstention",
+      "source": {
+        "path": "benchmarks/code-agent-effectiveness/evidence/t09-memory.json",
+        "sha256": "3c5067f6fea90b9e9288ef1d99d25859bd800dd589e96d91c2839cb76fb7c8cc"
+      },
+      "request": {
+        "query": "billing_period_days January month length billing bug conventions",
+        "project": "codex-t09-root-cause-r1"
+      },
+      "red_observation": {
+        "status": "ok",
+        "result_count": 4,
+        "result_entities": [
+          "delegate_codex_review_ok",
+          "delegate_codex_unknown_ok",
+          "delegate_minimax_review_fail",
+          "delegate_minimax_unknown_fail"
+        ],
+        "project_relevant_count": 0
+      },
+      "green_contract": {
+        "status": "abstained",
+        "injected_result_count": 0,
+        "global_memory_fallback": false
+      }
+    },
+    {
+      "id": "kb-outage-status",
+      "class": "kb_outage",
+      "source": {
+        "path": "benchmarks/code-agent-effectiveness/evidence/kb-outage.json",
+        "sha256": "3914b7bdafdda681f774873f327227ef212c8d3ffe569bf20b03a3bf19c548d0"
+      },
+      "request": {
+        "operation": "repository retrieval while the configured KB dependency is down"
+      },
+      "red_observation": {
+        "server_status": "ok",
+        "kb_status": "unreachable",
+        "experiment_stopped_at_cells": 97
+      },
+      "green_contract": {
+        "retrieval_status": "unavailable",
+        "must_not_report": "empty",
+        "local_work_continues": true,
+        "recovery_without_client_restart": true,
+        "benchmark_cell_status": "infrastructure-invalid"
+      }
+    }
+  ]
+}

--- a/benchmarks/code-agent-effectiveness/validate_fixtures.py
+++ b/benchmarks/code-agent-effectiveness/validate_fixtures.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Validate the agent-facing code-intelligence red/green fixture contract."""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+FIXTURE_PATH = HERE / "fixtures.json"
+REQUIRED_CLASSES = {
+    "tool_discovery",
+    "project_scope",
+    "python_blast_radius",
+    "retrieval_abstention",
+    "kb_outage",
+}
+
+
+def fail(message: str) -> None:
+    print(f"validate-agent-code-intelligence: FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def nonempty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def validate_source(source: object, case_id: str) -> None:
+    if not isinstance(source, dict):
+        fail(f"{case_id}: source must be an object")
+    if not nonempty_string(source.get("path")) and not nonempty_string(source.get("command")):
+        fail(f"{case_id}: source needs path or command")
+    checksum = source.get("sha256")
+    if checksum is not None and (
+        not isinstance(checksum, str)
+        or len(checksum) != 64
+        or any(ch not in "0123456789abcdef" for ch in checksum)
+    ):
+        fail(f"{case_id}: sha256 must be 64 lowercase hex characters")
+
+
+def verify_source_bytes(source: dict, case_id: str) -> None:
+    source_path = pathlib.Path(source["path"])
+    if source_path.is_absolute():
+        fail(f"{case_id}: verified source paths must be repository-relative")
+    resolved = ROOT / source_path
+    if not resolved.is_file():
+        fail(f"{case_id}: source does not exist: {source_path}")
+    actual = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    if actual != source.get("sha256"):
+        fail(f"{case_id}: source sha256 mismatch: expected {source.get('sha256')}, got {actual}")
+
+
+def validate(verify_sources: bool = False) -> None:
+    with FIXTURE_PATH.open(encoding="utf-8") as handle:
+        fixture = json.load(handle)
+
+    if fixture.get("schema_version") != 1:
+        fail("schema_version must be 1")
+
+    snapshot = fixture.get("source_snapshot")
+    if not isinstance(snapshot, dict):
+        fail("source_snapshot must be an object")
+    if snapshot.get("complete_cells", 0) >= snapshot.get("expected_cells", 0):
+        fail("red snapshot must remain explicitly incomplete")
+    if snapshot.get("incomplete") is not True:
+        fail("source_snapshot.incomplete must be true")
+    for field in ("results_tree_manifest_sha256", "raw_tree_manifest_sha256"):
+        digest = snapshot.get(field, "")
+        if len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest):
+            fail(f"source_snapshot.{field} is not a sha256")
+
+    cases = fixture.get("cases")
+    if not isinstance(cases, list):
+        fail("cases must be a list")
+
+    seen_ids = set()
+    seen_classes = set()
+    for case in cases:
+        if not isinstance(case, dict):
+            fail("every case must be an object")
+        case_id = case.get("id")
+        if not nonempty_string(case_id):
+            fail("every case needs a non-empty id")
+        if case_id in seen_ids:
+            fail(f"duplicate case id: {case_id}")
+        seen_ids.add(case_id)
+        seen_classes.add(case.get("class"))
+        validate_source(case.get("source"), case_id)
+        if verify_sources:
+            verify_source_bytes(case["source"], case_id)
+        for field in ("request", "red_observation", "green_contract"):
+            if not isinstance(case.get(field), dict) or not case[field]:
+                fail(f"{case_id}: {field} must be a non-empty object")
+
+    missing = REQUIRED_CLASSES - seen_classes
+    if missing:
+        fail(f"missing required case classes: {sorted(missing)}")
+
+    canonical = json.dumps(fixture, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    print(
+        "validate-agent-code-intelligence: ok "
+        f"({len(cases)} cases, fixture sha256={hashlib.sha256(canonical).hexdigest()})"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--verify-sources",
+        action="store_true",
+        help="recompute sha256 for repository-relative evidence files",
+    )
+    args = parser.parse_args()
+    validate(verify_sources=args.verify_sources)

--- a/benchmarks/tests/test_agent_code_intelligence_fixtures.py
+++ b/benchmarks/tests/test_agent_code_intelligence_fixtures.py
@@ -1,0 +1,21 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+VALIDATOR_PATH = ROOT / "benchmarks" / "code-agent-effectiveness" / "validate_fixtures.py"
+
+
+class AgentCodeIntelligenceFixtureTests(unittest.TestCase):
+    def test_fixture_contract(self):
+        spec = importlib.util.spec_from_file_location("agent_code_fixture_validator", VALIDATOR_PATH)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        module.validate(verify_sources=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -456,4 +456,6 @@ residual proposal instead of declaring the intended effectiveness outcome comple
 - **Round 3 — 2026-07-29 — APPROVED, 3/3 participants, no findings, not degraded.** The panel
   confirmed the benchmark-validity ruling, E0 ordering, E1 end-to-end adoption smoke, and the full
   accepted scope. Roundtable run: `roundtable-ea954d6d077d0cceaa0c143e`.
-- **Proposal PR / accepted implementation scope:** pending.
+- **Proposal PR / accepted implementation scope:** PR #2147 merged to `testing` as
+  `5cdb681621c22938f6e7372ecc709e623408551e` after all 23 CI checks passed. The accepted scope is
+  E0–E6 exactly as listed in §6; E0 branches first from that merge commit.

--- a/docs/validation/agent-facing-code-intelligence-red-baseline.md
+++ b/docs/validation/agent-facing-code-intelligence-red-baseline.md
@@ -1,0 +1,105 @@
+# Agent-facing code-intelligence red baseline
+
+- **Captured:** 2026-07-29 UTC
+- **Aimee proposal:**
+  [`agent-facing-code-intelligence-effectiveness`](../proposals/pending/agent-facing-code-intelligence-effectiveness.md)
+- **Harness checkout:** `/home/virant/dev/ponytail-codex-benchmark`
+- **Harness branch / commit:** `agent/codex-benchmark-matrix` /
+  `a40fe3d6a58ac4e8b14aaf75320e83912f0bfc56`
+- **Run status:** interrupted and incomplete; 97 of 600 expected cells
+- **Purpose:** untreated diagnostic controls for E1–E6, not a comparative product claim
+
+## Environment and provenance
+
+The run used Codex CLI `0.145.0`, model `gpt-5.6-sol` at medium reasoning, Ponytail `4.8.4` at
+`16f29800fd2681bdf24f3eb4ccffe38be3baec6b`, Aimee client
+`v0.2.195-1003-g627c1ffc`, Aimee server `testing-8bc6aa5`, and KB
+`vtesting-8bc6aa5`. The fixture seed commit was
+`40af4eebffc6b2fe4b6073cecdf3ad1b744607d2`.
+
+The result checkout was intentionally left uncommitted when the KB failed. The complete source
+artifacts remain at:
+
+- results: `/home/virant/dev/ponytail-codex-benchmark/battery/codex_results/` — 986 files;
+- raw Codex streams: `/tmp/ptcodex/raw/` — 194 files; and
+- representative readiness:
+  `battery/codex_results/cells/aimee__t06_semver__r1/aimee-readiness.json`.
+
+Checksums bind this record to that mutable local evidence:
+
+| artifact | sha256 |
+| --- | --- |
+| sorted results-file sha256 manifest | `93f92f6697263c54696318f566b3b19ee5732de332f7a9a0ebdd199d12736a9b` |
+| sorted raw-file sha256 manifest | `0441626841c736f4be2c404996ec4a734b5220d9491fbdba5d8cc46b79336133` |
+| `provenance.json` | `e7be51c1c31a43feeb060fc4c49a1cca3fe97f52c648d612f6daea0f017e0b93` |
+| `red-validation.json` | `1e724d893003924fef54063c3640596baac1add0808eb58fe6e954289fd69d5d` |
+| `score.json` | `ec7325e4bfb0197517d11bdad2b7837a70f3ee6e4ca8c3b8631bc1e26180f675` |
+| representative readiness | `a5dd73c96bec0df3dae6f0eb7d5c44d9867fdf9089f0b036deee8755ed9ce8f3` |
+| root-cause canary raw stream | `9820b7f90b34df7c226e36649a37debd21ba78eb92323a01ee487bcfdf3c0418` |
+| topological-sort raw stream | `277ad99445419c3511bad01fa015876b0d87f967d28dd875130d058de9e1523b` |
+
+Recompute the tree-manifest hashes from the harness checkout:
+
+```bash
+find battery/codex_results -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum
+find /tmp/ptcodex/raw -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum
+```
+
+E0 also preserves the minimal non-secret evidence needed to audit every red fixture under
+`benchmarks/code-agent-effectiveness/evidence/`. Those tracked extracts record their original path
+and checksum, while `fixtures.json` pins the extract bytes themselves. The outage evidence explicitly
+labels itself as reconstructed from the live status probe plus the persisted runner checkpoint;
+terminal formatting was not captured byte-for-byte. The tracked evidence, rather than continued
+availability of the machine-local originals, is the durable control consumed by later slices.
+
+## Untreated observations
+
+### Product behavior
+
+1. **Tool discovery:** the installed skill named `preview_blast_radius`; in
+   `aimee__t50_toposort__r1.jsonl`, `find_tools({"query":"blast radius"})` returned zero tools.
+2. **Project scope:** `find_symbol("install_order")` in that same stream returned six identical
+   definitions across six project namespaces, including but not limited to the active project.
+3. **Python blast radius:** the representative readiness report resolved `app/dates.py` and found
+   callers in `app/billing.py`, `app/invoices.py`, and `app/reports.py`, but returned empty
+   `dependencies` and `dependents`.
+4. **Retrieval abstention:** the root-cause canary asked for billing/month-length conventions and
+   received four delegation/roundtable episodes, none relevant to the active project. The other nine
+   completed repository-specific memory searches showed the same result class.
+5. **Availability:** after 97 saved cells, `aimee-server` remained healthy while the KB endpoint was
+   unreachable. The runner stopped and preserved artifacts, but the product did not expose the full
+   typed unavailable/empty/stale/abstained contract proposed for E5a.
+
+### Adoption and outcome boundary
+
+Across 23 task cells paired between baseline and Aimee after excluding the setup canary, 13 Aimee
+cells made no Aimee MCP call. The coding agents made no semantic/hybrid code query, no caller query,
+and no successful blast preview; only one cell called `find_symbol`. Thirty-five embeddings were
+prepared per isolated fixture, but only readiness queried them.
+
+The paired task score was baseline 20/23 and Aimee 21/23. That one-task difference is not attributable
+to indexing: the two Aimee-only wins made no Aimee MCP call. MCP-using cells were costlier and slower
+in this small endogenous sample, but task mix confounds the comparison. These observations motivate
+the paired standard/observe/on/capability-ceiling design; they do not establish causal harm or lift.
+
+The traversal task's expected duplicate implementation and the audit task's undocumented event
+vocabulary are benchmark-validity exclusions. They are preserved in raw artifacts but are not Aimee
+product-fix targets.
+
+## Fixture and verification
+
+The durable extracted contract is
+[`benchmarks/code-agent-effectiveness/fixtures.json`](../../benchmarks/code-agent-effectiveness/fixtures.json).
+It separates `red_observation` from `green_contract` so later treatment cannot rewrite the control.
+
+Run the hermetic schema/integrity check:
+
+```bash
+python3 benchmarks/code-agent-effectiveness/validate_fixtures.py
+python3 benchmarks/code-agent-effectiveness/validate_fixtures.py --verify-sources
+python3 -m unittest benchmarks.tests.test_agent_code_intelligence_fixtures
+```
+
+The check does not claim a live product fix. E1–E5 must each replay their relevant case against stock
+and treatment builds, and E6 must run a fresh, pinned merged Aimee arm rather than append cells to
+this interrupted snapshot.


### PR DESCRIPTION
## Summary
- preserve five attribution-safe untreated controls for agent-facing code intelligence
- vendor minimal non-secret evidence extracts and pin their bytes with SHA-256
- add hermetic schema and evidence-integrity validation
- document incomplete-run provenance, exclusions, and replay boundary

## Accepted scope
Implements E0 of `docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md`, merged in #2147. No product behavior is changed in this slice.

## Validation
- `python3 benchmarks/code-agent-effectiveness/validate_fixtures.py`
- `python3 benchmarks/code-agent-effectiveness/validate_fixtures.py --verify-sources`
- `python3 -m unittest benchmarks.tests.test_agent_code_intelligence_fixtures`
- `git diff --check`
- `make -C src proposal-links-check`

## Roundtable
Frozen diff approved 3/3 with no blockers or substantive findings: `roundtable-4b93b4ccd85c0f984838806c`.
