### PR TITLE
Inspect and, only if necessary, minimally update the existing `Automatic proposal admission` section in…

### DIFF
--- a/docs/wfe-autonomy-runbook.md
+++ b/docs/wfe-autonomy-runbook.md
@@ -60,7 +60,7 @@ each pending proposal is eligible for a new run. The decisions are governed by f
    identity, which makes the proposal eligible for a new run on the next scan.
 4. **Admission cap queues eligible proposals.** The live trigger admission cap can queue an
    otherwise eligible proposal when the cap is reached on a given scan. The cap is edited in
-   **Edit Workflows → Run policy**; an otherwise eligible proposal that exceeds the cap is held
+   **Workflows → Run policy**; an otherwise eligible proposal that exceeds the cap is held
    for a later scan instead of being admitted or rejected.
 5. **Cap-queued proposals stay eligible on later scans.** A proposal queued by the cap remains
    eligible on a later scan; the watcher does not require manual firing to retry a proposal that

--- a/docs/wfe-autonomy-runbook.md
+++ b/docs/wfe-autonomy-runbook.md
@@ -51,8 +51,8 @@ The autonomous pending-proposal watcher scans the watched branch on every poll a
 each pending proposal is eligible for a new run. The decisions are governed by five behaviors:
 
 1. **Identity derivation.** Pending-proposal identity is derived from the complete proposal file
-   bytes together with workflow and mode. The watched-branch commit is not part of the identity
-   and is therefore not sufficient on its own to identify a pending proposal.
+   bytes together with workflow and mode. The moving watched-branch commit is not part of
+   the identity, so commit SHA alone is not sufficient to identify a pending proposal.
 2. **No duplicate runs on branch-only advances.** Advancing the watched branch without changing the
    proposal bytes does not start a duplicate run. The watcher treats the unchanged bytes as the
    same pending proposal and leaves its prior run status intact.


### PR DESCRIPTION
## Summary

Inspect and, only if necessary, minimally update the existing `Automatic proposal admission` section in….

This implementation slice is part of the parent feature branch and remains subject to its configured CI and merge gates.

## Workflow context

- Workflow: `slice` (`d2450224a6b72e249a1024d6dbe3603bfff5b9693caf12796c578e3ca537f028`)
- Work item: `wi_0285f9ea86111e04a372026aa7e39079.sa3ce493828.g0.0`
- Branches: `aimee/wi/wi_0285f9ea86111e04a372026aa7e39079.sa3ce493828.g0.0` → `aimee/feat/wi_0285f9ea86111e04a372026aa7e39079`

## Changes

```text
docs/wfe-autonomy-runbook.md | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

## Integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Original request</summary>

{"packet_id":"p1","summary":"Inspect and, only if necessary, minimally update the existing `Automatic proposal admission` section in `docs/wfe-autonomy-runbook.md` so it accurately documents production pending-proposal watcher deduplication behavior without changing any other files.","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["Open `docs/wfe-autonomy-runbook.md` and locate the existing `Automatic proposal admission` section, expected around line 48, or the closest equivalent section if the heading has changed.","Review the existing section for coverage of proposal identity, watched branch advancement behavior, proposal byte changes, live trigger admission cap behavior, and queued proposal behavior.","If the existing section already satisfies AC1 and AC2, make no content edit and record in implementation notes that no documentation change was needed after inspection.","If the existing section does not satisfy AC1 and AC2, revise that section in place only; do not add a duplicate section when the topic is already documented.","The section explicitly states that pending proposal identity is based on complete proposal file bytes, workflow, and mode.","The section explicitly states that pending proposal identity is not based on the moving watched branch commit and is not commit SHA alone.","The section explicitly states that advancing the watched branch without changing proposal file bytes does not start a duplicate run.","The section explicitly states that changing proposal bytes makes the proposal eligible for a new run.","The section explicitly states that the live trigger admission cap can queue otherwise eligible proposals.","The section explicitly states that operators edit the live trigger admission cap in `Workflows → Run policy`.","The section explicitly states that queued proposals remain eligible on later scans without manual firing.","Remove or rewrite wording that implies a commit SHA alone identifies a proposal, including wording equivalent to `identified by commit`, `deduplicated by commit SHA`, or `same commit means same proposal`.","If commits are mentioned, clarify that commits may move while proposal identity remains tied to complete proposal file bytes, workflow, and mode.","Keep the change minimal: do not introduce new documentation structure beyond the existing relevant section unless no such section exists.","Do not add examples, diagrams, tables, operational procedures, or implementation details unless necessary to state the requested behavior precisely.","Do not modify source code, workflow definitions, generated documentation, runtime configuration, tests, fixtures, settings, flags, or any file other than `docs/wfe-autonomy-runbook.md`.","Confirm the final diff contains changes only to `docs/wfe-autonomy-runbook.md`, or no file changes if the existing section already satisfies the criteria.","Run the repository’s existing documentation check command if discoverable from project documentation or package scripts.","If no dedicated documentation check is discoverable, explicitly state that no dedicated docs check exists and run the closest existing docs or markdown validation available.","Record the exact validation command run and its result in final implementation notes.","Existing documentation checks or the closest available docs/markdown validation pass."]}

</details>