### PR TITLE
feat: make code intelligence discoverable and project scoped

### DIFF
--- a/benchmarks/code-agent-effectiveness/README.md
+++ b/benchmarks/code-agent-effectiveness/README.md
@@ -14,6 +14,10 @@ This directory holds the attribution-safe red/green fixtures accepted by
 Each case preserves the untreated observation and the post-fix contract. Later slices reuse these
 same fixtures; they must not replace the red observation with a passing treatment result.
 
+Treatment records are additive. The first is
+[`docs/validation/agent-facing-code-intelligence-e1.md`](../../docs/validation/agent-facing-code-intelligence-e1.md),
+covering capability discovery, schemas, installed guidance, and active-project request defaults.
+
 Validate the checked-in structure without a live KB:
 
 ```bash

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -1,7 +1,6 @@
 # Proposal: Agent-facing code intelligence effectiveness
 
-- **State:** IN PROGRESS — accepted design; E0 complete; local-first amendment roundtable-approved
-  and PR pending (file remains pending until E1–E6 close)
+- **State:** IN PROGRESS — E1 implementation underway; E1-memory–E6 remain
 - **Author:** JBailes
 - **Date:** 2026-07-29
 - **Charter roles:** Recall, Rank-Fuse, Calibrate / Evaluate-Optimize, Enforce, Gate-Promote
@@ -518,3 +517,6 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   and remaining seat completed and approved the artifact. Roundtable run:
   `oprun_g6a69bd8011459d99_1785336851_93` (artifact
   `c4b68b07f28c23817533b1c66a41bac88ea60c7b79c2181090babc184f728351`).
+- **Local-first amendment PR:** PR #2150 merged to `testing` as
+  `e9626cda560b7e9b1bbf96e48c05c94b62a72c8a` after all 23 CI checks passed. E1 applies the same
+  pre-limit rule to code discovery; E1-memory applies it to every ordered memory surface.

--- a/docs/validation/agent-facing-code-intelligence-e1.md
+++ b/docs/validation/agent-facing-code-intelligence-e1.md
@@ -1,0 +1,77 @@
+# Agent-facing code-intelligence E1 validation
+
+- **Slice:** E1 — truthful capability catalog
+- **Based on:** E0 merge `352b4682205800ed41714ce7bdd53b4f081f81db` and local-first
+  amendment merge `e9626cda560b7e9b1bbf96e48c05c94b62a72c8a`
+- **Untreated control:**
+  [`agent-facing-code-intelligence-red-baseline.md`](agent-facing-code-intelligence-red-baseline.md)
+- **Scope:** discovery, schemas, active-project defaults, installed guidance, and MCP proxy adoption
+
+## Treatment
+
+E1 establishes one public vocabulary for the agent-facing code routes used by generated guidance.
+`preview_blast_radius` remains directly advertised in the lean profile while
+`index({"command":"preview"})` remains compatible. Its description is discoverable by both
+`blast radius` and `preview`; `project` is optional because the MCP proxy supplies `cwd`.
+
+`find_symbol`, callers, and blast preview now default to the project resolved from explicit
+`project` or the request cwd. Cross-project symbol and caller lookup requires `scope:"all"`.
+Blast preview intentionally rejects all-project scope because its result must describe one indexed
+project. Generated Codex, Claude, session-start, attention-guard, and ingress guidance now names
+`index({"command":"hybrid"})` for code exploration; `search_graph` remains available for its actual
+memory-graph purpose and is not removed as a wire route.
+
+The implementation retains one bounded transitional constraint for a later accepted slice:
+
+- E1 derives the current project from cwd's basename; E2 replaces path-keyed identity with the
+  stable workspace project identity and lifecycle contract.
+
+`find_symbol` carries the resolved project through the client and HTTP route into the canonical
+index query. The project predicate is applied before the query limit; a one-result regression with
+an alphabetically earlier duplicate project proves unrelated namespaces cannot crowd out the active
+project. `scope:"all"` retains the compatibility path through the unscoped query.
+
+## Mechanical and installed-surface evidence
+
+The registry contract verifies that:
+
+- the lean profile directly contains `preview_blast_radius`;
+- the collapsed and compatibility routes retain matching schemas;
+- exact case-insensitive discovery queries `blast radius` and `preview` match the canonical tool;
+- only `paths` is required for preview, while `project` and `scope` are admitted;
+- `find_symbol` and callers admit `project` plus explicit scope; and
+- cwd, explicit project, current/all scope, and invalid scope resolve deterministically.
+
+The client-integration contract rejects `search_graph` in generated code-exploration prompts and
+requires `find_symbol`, `ast_grep_search`, and `index`/`hybrid`. The stdio MCP proxy smoke invokes
+`preview_blast_radius` with only a path list and proves the canonical name, paths, top-level cwd, and
+argument cwd arrive at the server request seam.
+
+Run the E1 checks:
+
+```bash
+make -C src build/obj/tests/unit-test-mcp-client-registry
+make -C src build/obj/tests/unit-test-client-integrations
+make -C src build/obj/tests/unit-test-ingress-preinject
+make -C src build/obj/tests/unit-test-cli-mcp-serve
+make -C src build/obj/tests/unit-test-kb-client-search
+make -C src build/obj/tests/unit-test-kb-http-routes
+make -C src build/obj/tests/unit-test-index
+src/build/obj/tests/unit-test-mcp-client-registry
+src/build/obj/tests/unit-test-client-integrations
+src/build/obj/tests/unit-test-ingress-preinject
+src/build/obj/tests/unit-test-cli-mcp-serve
+src/build/obj/tests/unit-test-kb-client-search
+src/build/obj/tests/unit-test-kb-http-routes
+src/build/obj/tests/unit-test-index
+python3 benchmarks/code-agent-effectiveness/validate_fixtures.py --verify-sources
+python3 -m unittest benchmarks.tests.test_agent_code_intelligence_fixtures
+make -C src proposal-links-check
+make -C src line-check
+make -C src lint
+make -C src check-linking
+make -C src unit-tests
+```
+
+This slice does not claim the E2 duplicate-suppression acceptance gate, E3 Python dependency repair,
+E4 retrieval lift, E5 resilience, or E6 promotion result.

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -17,6 +17,7 @@
 #include "cli_attention_guard.h"
 #include "cli_session_start.h" /* read_stdin */
 #include "aimee_home.h"
+#include "agent_code_capabilities.h"
 #include "platform_path.h"
 #include "cJSON.h"
 #include <ctype.h>
@@ -1059,8 +1060,9 @@ int handle_attention_guard(void)
          {
             fprintf(stderr,
                     "aimee attention-guard: this session has hit its raw-scan cap (%d). Aimee "
-                    "indexes this repo — explore through it instead: find_symbol, "
-                    "ast_grep_search, search_graph, or get_context_block. Raise "
+                    "indexes this repo — explore through it instead: " AIMEE_CODE_TOOL_FIND_SYMBOL
+                    ", " AIMEE_CODE_TOOL_AST_GREP_SEARCH ", " AIMEE_CODE_TOOL_INDEX
+                    " command=" AIMEE_CODE_INDEX_COMMAND_HYBRID ", or get_context_block. Raise "
                     "ingress_max_raw_scans in aimee.yaml to raise or lift the cap.\n",
                     ingress_max_raw_scans);
             exit_code = 2;

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -8,6 +8,7 @@
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
 #include "cmd_self_update.h"     /* aimee_self_update_notice */
+#include "agent_code_capabilities.h"
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -599,8 +600,9 @@ int handle_user_prompt_submit(void)
       struct ss_sbuf ctx = {0};
       ss_add(&ctx, "<aimee-context>\n");
       ss_add(&ctx, b.p);
-      ss_add(&ctx, "explore-with: find_symbol, lsp_references, ast_grep_search, search_graph, "
-                   "get_context_block\n");
+      ss_add(&ctx, "explore-with: " AIMEE_CODE_TOOL_FIND_SYMBOL
+                   ", lsp_references, " AIMEE_CODE_TOOL_AST_GREP_SEARCH ", " AIMEE_CODE_TOOL_INDEX
+                   " command=" AIMEE_CODE_INDEX_COMMAND_HYBRID ", get_context_block\n");
       ss_add(&ctx, "</aimee-context>");
 
       cJSON *out = cJSON_CreateObject();

--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -1,5 +1,6 @@
 #include "client_constants.h"
 #include "client_integrations.h"
+#include "agent_code_capabilities.h"
 #include "aimee_home.h"
 #include "yaml.h"
 #include "platform_path.h"
@@ -229,12 +230,20 @@ static const char *codex_skill_markdown(void)
           "\n"
           "- Prefer local file inspection first for nearby code.\n"
           "- Use `search_memory` for stored project facts or prior decisions.\n"
-          "- Use `find_symbol` when the local search surface is missing indexed context.\n"
-          "- Use `preview_blast_radius` before broad multi-file edits.\n"
+          "- Use `" AIMEE_CODE_TOOL_FIND_SYMBOL
+          "` when the local search surface is missing indexed context.\n"
+          "- Use `" AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS "` before broad multi-file edits.\n"
           "- Do not call provider-native sub-agent tools such as `spawn_agent`; use "
           "the aimee `delegate` MCP tool for every delegated or parallel sub-task.\n"
           "- Use `delegate` only for bounded sub-tasks that materially advance the "
           "current work.\n";
+}
+
+static const char *codex_code_exploration_prompt(void)
+{
+   return "Explore the codebase through aimee's tools (" AIMEE_CODE_TOOL_FIND_SYMBOL
+          ", " AIMEE_CODE_TOOL_AST_GREP_SEARCH ", " AIMEE_CODE_TOOL_INDEX
+          " command=" AIMEE_CODE_INDEX_COMMAND_HYBRID ") instead of raw grep/read";
 }
 
 static void ensure_codex_marketplace(const char *path)
@@ -742,8 +751,7 @@ static void ensure_codex_plugin_files(const char *home)
             "    \"termsOfServiceURL\": \"https://github.com/RakuenSoftware/aimee\",\n"
             "    \"defaultPrompt\": [\n"
             "      \"Search aimee memory before answering repo-specific questions\",\n"
-            "      \"Explore the codebase through aimee's tools (find_symbol, "
-            "ast_grep_search, search_graph) instead of raw grep/read\",\n"
+            "      \"%s\",\n"
             "      \"Preview the blast radius before editing multiple files\",\n"
             "      \"%s\",\n"
             "      \"Delegate bounded work through aimee delegate, not provider sub-agents\"\n"
@@ -752,7 +760,7 @@ static void ensure_codex_plugin_files(const char *home)
             "    \"screenshots\": []\n"
             "  }\n"
             "}\n",
-            AIMEE_VERSION, codex_delegate_policy_prompt());
+            AIMEE_VERSION, codex_code_exploration_prompt(), codex_delegate_policy_prompt());
 
    char compat_plugin_buf[4096];
    snprintf(compat_plugin_buf, sizeof(compat_plugin_buf),
@@ -788,8 +796,7 @@ static void ensure_codex_plugin_files(const char *home)
             "    \"termsOfServiceURL\": \"https://github.com/RakuenSoftware/aimee\",\n"
             "    \"defaultPrompt\": [\n"
             "      \"Search aimee memory before answering repo-specific questions\",\n"
-            "      \"Explore the codebase through aimee's tools (find_symbol, "
-            "ast_grep_search, search_graph) instead of raw grep/read\",\n"
+            "      \"%s\",\n"
             "      \"Preview the blast radius before editing multiple files\",\n"
             "      \"%s\",\n"
             "      \"Delegate bounded work through aimee delegate, not provider sub-agents\"\n"
@@ -798,7 +805,7 @@ static void ensure_codex_plugin_files(const char *home)
             "    \"screenshots\": []\n"
             "  }\n"
             "}\n",
-            AIMEE_VERSION, codex_delegate_policy_prompt());
+            AIMEE_VERSION, codex_code_exploration_prompt(), codex_delegate_policy_prompt());
 
    char mcp_buf[MAX_PATH_LEN + 256];
    format_mcp_json(mcp_buf, sizeof(mcp_buf), aimee_bin);
@@ -1339,7 +1346,8 @@ static void ensure_claude_code_commands(const char *home)
    write_text_file(path,
                    "Preview the blast radius of a multi-file edit before making changes.\n"
                    "\n"
-                   "Use the aimee MCP tool `preview_blast_radius` for: $ARGUMENTS\n"
+                   "Use the aimee MCP tool `" AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS
+                   "` for: $ARGUMENTS\n"
                    "\n"
                    "This shows which files and symbols would be affected by the change,\n"
                    "helping you understand the impact before editing.\n",

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -1470,6 +1470,7 @@ static const char *ci_find_sql = "SELECT p.name, f.path, t.line, t.kind"
                                  " JOIN files f ON f.id = t.file_id"
                                  " JOIN projects p ON p.id = f.project_id"
                                  " WHERE t.name = ?1"
+                                 "   AND (?3 = '' OR p.name = ?3)"
                                  "   AND f.path NOT LIKE '.%'"
                                  "   AND f.path NOT LIKE '%/.%'"
                                  "   AND p.root NOT LIKE '%/.%'"
@@ -1483,6 +1484,7 @@ static const char *ci_find_like_sql = "SELECT p.name, f.path, t.line, t.kind"
                                       " JOIN files f ON f.id = t.file_id"
                                       " JOIN projects p ON p.id = f.project_id"
                                       " WHERE t.name LIKE ?1 ESCAPE '\\'"
+                                      "   AND (?3 = '' OR p.name = ?3)"
                                       "   AND f.path NOT LIKE '.%'"
                                       "   AND f.path NOT LIKE '%/.%'"
                                       "   AND p.root NOT LIKE '%/.%'"
@@ -1510,7 +1512,8 @@ static int ci_drain_term_hits(aimee_pg_stmt_t *st, term_hit_t *out, int max, cha
    return count;
 }
 
-int canonical_index_find(const char *identifier, term_hit_t *out, int max)
+int canonical_index_find_project(const char *project, const char *identifier, term_hit_t *out,
+                                 int max)
 {
    void *conn = ci_conn();
    if (!conn)
@@ -1522,6 +1525,7 @@ int canonical_index_find(const char *identifier, term_hit_t *out, int max)
       return -1;
    aimee_pg_bind_text(st, "?1", identifier);
    aimee_pg_bind_int(st, "?2", max);
+   aimee_pg_bind_text(st, "?3", project && project[0] ? project : "");
    int count = ci_drain_term_hits(st, out, max, err, sizeof(err));
    aimee_pg_finalize(st);
 
@@ -1538,10 +1542,16 @@ int canonical_index_find(const char *identifier, term_hit_t *out, int max)
          break;
       aimee_pg_bind_text(st2, "?1", pattern);
       aimee_pg_bind_int(st2, "?2", max);
+      aimee_pg_bind_text(st2, "?3", project && project[0] ? project : "");
       count = ci_drain_term_hits(st2, out, max, err, sizeof(err));
       aimee_pg_finalize(st2);
    }
    return count;
+}
+
+int canonical_index_find(const char *identifier, term_hit_t *out, int max)
+{
+   return canonical_index_find_project(NULL, identifier, out, max);
 }
 
 int canonical_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out)

--- a/src/db2/canonical_index.h
+++ b/src/db2/canonical_index.h
@@ -55,6 +55,11 @@ extern "C"
    /* Find an identifier across all projects. Returns count, or -1 on error. */
    int canonical_index_find(const char *identifier, term_hit_t *out, int max);
 
+   /* Find an identifier inside one project. The project predicate is applied by the backing query
+    * before its LIMIT, so unrelated namespaces cannot crowd out current-project hits. */
+   int canonical_index_find_project(const char *project, const char *identifier, term_hit_t *out,
+                                    int max);
+
    /* Compute blast radius for a file. Returns 0 on success, -1 on error. */
    int canonical_index_blast_radius(const char *project, const char *file_path,
                                     blast_radius_t *out);

--- a/src/headers/agent_code_capabilities.h
+++ b/src/headers/agent_code_capabilities.h
@@ -1,0 +1,23 @@
+#ifndef AIMEE_AGENT_CODE_CAPABILITIES_H
+#define AIMEE_AGENT_CODE_CAPABILITIES_H
+
+/* Canonical public vocabulary for agent-facing code intelligence.
+ *
+ * MCP descriptors, the lean presentation profile, and generated client guidance
+ * consume these names. Mechanical tests keep the existing descriptor tables in
+ * parity until they can be fully generated from one catalog. */
+#define AIMEE_CODE_TOOL_FIND_SYMBOL          "find_symbol"
+#define AIMEE_CODE_TOOL_AST_GREP_SEARCH      "ast_grep_search"
+#define AIMEE_CODE_TOOL_INDEX                "index"
+#define AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS "preview_blast_radius"
+
+#define AIMEE_CODE_INDEX_COMMAND_HYBRID  "hybrid"
+#define AIMEE_CODE_INDEX_COMMAND_PREVIEW "preview"
+
+#define AIMEE_CODE_SCOPE_CURRENT "current"
+#define AIMEE_CODE_SCOPE_ALL     "all"
+
+#define AIMEE_CODE_DISCOVERY_BLAST_RADIUS "blast radius"
+#define AIMEE_CODE_DISCOVERY_PREVIEW      "preview"
+
+#endif /* AIMEE_AGENT_CODE_CAPABILITIES_H */

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -173,7 +173,8 @@ int handle_get_code_find(const char *query_string, char *out_buf, int out_cap)
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
       return 500;
    }
-   int n = canonical_index_find(identifier, hits, max_r);
+   int n = project_filter[0] ? canonical_index_find_project(project_filter, identifier, hits, max_r)
+                             : canonical_index_find(identifier, hits, max_r);
    if (n < 0)
    {
       free(hits);

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -1124,6 +1124,8 @@ void *kb_client_index_scan_format_response(int kb_rc, const kb_client_index_scan
 /* Find an identifier in the canonical index. Returns count of hits
  * written into `out` (capped at `max`), or 0 if kb is unreachable. */
 int kb_client_index_find(const char *identifier, term_hit_t *out, int max);
+int kb_client_index_find_project(const char *project, const char *identifier, term_hit_t *out,
+                                 int max);
 
 /* List indexed projects. Returns count on success (0 = empty index),
  * or -1 if the knowledge service is unreachable. */

--- a/src/modules/kb_client/kb_client_index.c
+++ b/src/modules/kb_client/kb_client_index.c
@@ -323,7 +323,8 @@ int kb_client_index_scan(const char *name, const char *root, int force,
    return kb_client_index_scan_v1(name, root, force, out);
 }
 
-int kb_client_index_find(const char *identifier, term_hit_t *out, int max)
+int kb_client_index_find_project(const char *project, const char *identifier, term_hit_t *out,
+                                 int max)
 {
    if (!identifier || !identifier[0] || !out || max <= 0)
       return 0;
@@ -332,10 +333,30 @@ int kb_client_index_find(const char *identifier, term_hit_t *out, int max)
    char *encoded = kb_client_query_escape(identifier);
    if (!encoded)
       return 0;
-   char path[512];
-   snprintf(path, sizeof(path), "/v1/code/find?identifier=%s&max_results=%d", encoded, max);
+   char *encoded_project = NULL;
+   if (project && project[0])
+   {
+      encoded_project = kb_client_query_escape(project);
+      if (!encoded_project)
+      {
+         free(encoded);
+         return 0;
+      }
+   }
+   size_t path_len = strlen(encoded) + (encoded_project ? strlen(encoded_project) : 0) + 96;
+   char *path = malloc(path_len);
+   if (!path)
+   {
+      free(encoded_project);
+      free(encoded);
+      return 0;
+   }
+   snprintf(path, path_len, "/v1/code/find?identifier=%s&max_results=%d%s%s", encoded, max,
+            encoded_project ? "&project=" : "", encoded_project ? encoded_project : "");
+   free(encoded_project);
    free(encoded);
    char *json = kb_client_v1_get_json(path, KB_CLIENT_INDEX_READ_TIMEOUT_MS, NULL);
+   free(path);
    if (!json)
       return 0;
    cJSON *resp = cJSON_Parse(json);
@@ -343,6 +364,11 @@ int kb_client_index_find(const char *identifier, term_hit_t *out, int max)
    int count = kb_index_find_parse(resp, out, max);
    cJSON_Delete(resp);
    return count;
+}
+
+int kb_client_index_find(const char *identifier, term_hit_t *out, int max)
+{
+   return kb_client_index_find_project(NULL, identifier, out, max);
 }
 
 int kb_client_index_list(project_info_t *out, int max)

--- a/src/modules/protocols/include/aimee/protocols/mcp/mcp_tools.h
+++ b/src/modules/protocols/include/aimee/protocols/mcp/mcp_tools.h
@@ -42,6 +42,16 @@ int mcp_filter_tools_for_profile(cJSON *tools, const char *profile);
  * schema-bound MCP hosts. */
 void mcp_add_discovery_tools(cJSON *tools);
 
+/* Case-insensitive discovery matcher shared by find_tools and its contract
+ * tests. Empty queries match every descriptor. */
+int mcp_tool_matches_query(const cJSON *tool, const char *query);
+
+/* Resolve agent-facing code-search scope from MCP arguments. `project` wins;
+ * otherwise cwd's basename is the active indexed project id. The scope helper
+ * returns 0 for current/default, 1 for all, and -1 for invalid input. */
+const char *mcp_code_project_from_args(cJSON *args);
+int mcp_code_scope_all(cJSON *args);
+
 /* Resolve call_tool({name,arguments}) to the named tool and its argument object.
  * MCP hosts can only invoke schemas returned by tools/list, so this bridge is
  * what makes tools found through find_tools genuinely callable under the lean

--- a/src/modules/protocols/mcp/mcp_tool_profile.c
+++ b/src/modules/protocols/mcp/mcp_tool_profile.c
@@ -8,8 +8,10 @@
  * everything. */
 #include "cJSON.h"
 #include <aimee/protocols/mcp/mcp_tools.h>
+#include "agent_code_capabilities.h"
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 /* Tier-0 "core" presentation profile (MCP-native tool names): the high-frequency
  * tools an external MCP client is shown when AIMEE_MCP_TOOL_PROFILE=core|lean
@@ -28,9 +30,10 @@ static const char *const MCP_CORE_TOOLS[] = {
     "search_memory",
     "memory_recall",
     "get_identity", /* grounding */
-    "find_symbol",
-    "ast_grep_search", /* code intel */
-    "git",             /* all git/gh ops via one multiplexed tool (command=...) */
+    AIMEE_CODE_TOOL_FIND_SYMBOL,
+    AIMEE_CODE_TOOL_AST_GREP_SEARCH,
+    AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS, /* direct adoption-critical code intel */
+    "git", /* all git/gh ops via one multiplexed tool (command=...) */
     "delegate",
     "roundtable_review", /* multi-agent */
     "roundtable_status", /* poll asynchronous roundtable_review */
@@ -132,6 +135,56 @@ void mcp_add_discovery_tools(cJSON *tools)
       cJSON_AddItemToObject(t, "inputSchema", s);
       cJSON_AddItemToArray(tools, t);
    }
+}
+
+static int mcp_ci_contains(const char *haystack, const char *needle)
+{
+   if (!needle || !needle[0])
+      return 1;
+   if (!haystack)
+      return 0;
+   size_t nlen = strlen(needle);
+   for (const char *h = haystack; *h; h++)
+      if (strncasecmp(h, needle, nlen) == 0)
+         return 1;
+   return 0;
+}
+
+int mcp_tool_matches_query(const cJSON *tool, const char *query)
+{
+   if (!tool)
+      return 0;
+   const cJSON *name = cJSON_GetObjectItemCaseSensitive(tool, "name");
+   const cJSON *description = cJSON_GetObjectItemCaseSensitive(tool, "description");
+   return mcp_ci_contains(cJSON_IsString(name) ? name->valuestring : NULL, query) ||
+          mcp_ci_contains(cJSON_IsString(description) ? description->valuestring : NULL, query);
+}
+
+const char *mcp_code_project_from_args(cJSON *args)
+{
+   cJSON *project = cJSON_GetObjectItemCaseSensitive(args, "project");
+   if (cJSON_IsString(project) && project->valuestring[0])
+      return project->valuestring;
+   cJSON *cwd = cJSON_GetObjectItemCaseSensitive(args, "cwd");
+   if (!cJSON_IsString(cwd) || !cwd->valuestring[0])
+      return NULL;
+   const char *base = strrchr(cwd->valuestring, '/');
+   base = base ? base + 1 : cwd->valuestring;
+   return base[0] ? base : NULL;
+}
+
+int mcp_code_scope_all(cJSON *args)
+{
+   cJSON *scope = cJSON_GetObjectItemCaseSensitive(args, "scope");
+   if (!scope)
+      return 0;
+   if (!cJSON_IsString(scope))
+      return -1;
+   if (!scope->valuestring[0] || strcmp(scope->valuestring, AIMEE_CODE_SCOPE_CURRENT) == 0)
+      return 0;
+   if (strcmp(scope->valuestring, AIMEE_CODE_SCOPE_ALL) == 0)
+      return 1;
+   return -1;
 }
 
 int mcp_call_tool_demux(const char *tool, cJSON *args, const char **out_tool, cJSON **out_args)

--- a/src/modules/protocols/mcp/mcp_tools.c
+++ b/src/modules/protocols/mcp/mcp_tools.c
@@ -6,6 +6,7 @@
 #include "mcp_tools_gateway.h"
 #include "session_search_tool.h"
 #include "log.h"
+#include "agent_code_capabilities.h"
 #include <stdio.h>
 #include <string.h>
 static int tools_array_has_name(cJSON *tools, const char *name)
@@ -544,14 +545,27 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
       cJSON_AddStringToObject(id, "type", "string");
       cJSON_AddStringToObject(id, "description",
                               "Symbol name to find (function, class, variable, etc.)");
+      cJSON *project = cJSON_AddObjectToObject(p, "project");
+      cJSON_AddStringToObject(project, "type", "string");
+      cJSON_AddStringToObject(project, "description",
+                              "Indexed project id. Optional; defaults from the MCP request cwd.");
+      cJSON *scope = cJSON_AddObjectToObject(p, "scope");
+      cJSON_AddStringToObject(scope, "type", "string");
+      cJSON *scope_values = cJSON_AddArrayToObject(scope, "enum");
+      cJSON_AddItemToArray(scope_values, cJSON_CreateString(AIMEE_CODE_SCOPE_CURRENT));
+      cJSON_AddItemToArray(scope_values, cJSON_CreateString(AIMEE_CODE_SCOPE_ALL));
+      cJSON_AddStringToObject(scope, "description",
+                              "Search the current project (default) or explicitly all projects.");
       cJSON *req = cJSON_CreateArray();
       cJSON_AddItemToArray(req, cJSON_CreateString("identifier"));
       cJSON_AddItemToObject(s, "required", req);
       cJSON_AddItemToArray(
-          tools, mcp_tool_new("find_symbol",
-                              "Find a code symbol (function, class, variable) across all "
-                              "indexed projects. Returns file path, line number, and kind.",
-                              s));
+          tools,
+          mcp_tool_new(AIMEE_CODE_TOOL_FIND_SYMBOL,
+                       "Find a code symbol (function, class, variable) in the active indexed "
+                       "project by default. Set scope=all for labeled cross-project results. "
+                       "Returns file path, line number, and kind.",
+                       s));
    }
 
    /* ast_grep_search */
@@ -580,7 +594,7 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
       cJSON_AddItemToObject(s, "required", req);
       cJSON_AddItemToArray(
           tools,
-          mcp_tool_new("ast_grep_search",
+          mcp_tool_new(AIMEE_CODE_TOOL_AST_GREP_SEARCH,
                        "AST-aware structural code search using ast-grep. Finds code patterns "
                        "by structure rather than text, using meta-variables ($VAR, $$$). "
                        "More precise than regex for language-aware queries. "
@@ -790,15 +804,23 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
       cJSON_AddStringToObject(pi, "type", "string");
       cJSON_AddItemToObject(pp, "items", pi);
       cJSON_AddStringToObject(pp, "description", "File paths to preview blast radius for");
+      cJSON *scope = cJSON_AddObjectToObject(p, "scope");
+      cJSON_AddStringToObject(scope, "type", "string");
+      cJSON *scope_values = cJSON_AddArrayToObject(scope, "enum");
+      cJSON_AddItemToArray(scope_values, cJSON_CreateString(AIMEE_CODE_SCOPE_CURRENT));
+      cJSON_AddStringToObject(scope, "description",
+                              "Single-project preview scope; defaults to current. Cross-project "
+                              "scope=all is intentionally unsupported.");
       cJSON *req = cJSON_CreateArray();
-      cJSON_AddItemToArray(req, cJSON_CreateString("project"));
       cJSON_AddItemToArray(req, cJSON_CreateString("paths"));
       cJSON_AddItemToObject(s, "required", req);
       cJSON_AddItemToArray(
-          tools, mcp_tool_new("preview_blast_radius",
-                              "Preview the blast radius of proposed file changes before starting "
-                              "work. Returns affected files, severity, and warnings.",
-                              s));
+          tools,
+          mcp_tool_new(AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS,
+                       "Preview the blast radius of proposed file changes before starting work. "
+                       "The project defaults from the MCP request cwd. Returns affected files, "
+                       "severity, and warnings.",
+                       s));
    }
 
    /* delegate_reply */

--- a/src/modules/protocols/mcp/mcp_tools_extended.c
+++ b/src/modules/protocols/mcp/mcp_tools_extended.c
@@ -11,6 +11,7 @@
 #include "cJSON.h"
 #include "aimee/protocols/mcp/mcp_tools.h"
 #include "aimee_features.h"
+#include "agent_code_capabilities.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -72,7 +73,10 @@ void mcp_add_extended_tools(cJSON *tools)
                 "Find call sites of a symbol across the indexed code: project, file, calling "
                 "function, line.");
    ext_prop(t, "symbol", "string", "Symbol / function name to find callers of.");
-   ext_prop(t, "project", "string", "Restrict to a project (optional; omit to search all).");
+   ext_prop(t, "project", "string",
+            "Indexed project id. Optional; defaults from the MCP request cwd.");
+   ext_prop(t, "scope", "string",
+            "Search the current project (default) or explicitly all projects.");
    ext_require(t, "symbol");
 
    t = ext_tool(tools, "index_structure",
@@ -303,15 +307,15 @@ static const struct fam_def MCP_FAMILIES[] = {
       {"definition", "lsp_definition"},
       {"references", "lsp_references"},
       {NULL, NULL}}},
-    {"index",
+    {AIMEE_CODE_TOOL_INDEX,
      "command",
      "Code-index navigation, hybrid retrieval, and graph analytics. Set 'command'.",
      {{"find_callers", "index_find_callers"},
       {"structure", "index_structure"},
       {"span", "code_span_get"},
       {"blast_radius", "index_blast_radius"},
-      {"preview", "preview_blast_radius"},
-      {"hybrid", "index_hybrid"},
+      {AIMEE_CODE_INDEX_COMMAND_PREVIEW, AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS},
+      {AIMEE_CODE_INDEX_COMMAND_HYBRID, "index_hybrid"},
       {"hubs", "index_graph_hubs"},
       {"audit", "index_graph_audit"},
       {"diff", "index_graph_diff"},
@@ -418,6 +422,24 @@ static cJSON *family_detach_member(cJSON *tools, const char *name)
    return NULL;
 }
 
+static cJSON *family_copy_member(cJSON *tools, const char *name)
+{
+   int n = cJSON_GetArraySize(tools);
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *t = cJSON_GetArrayItem(tools, i);
+      cJSON *nm = cJSON_GetObjectItemCaseSensitive(t, "name");
+      if (cJSON_IsString(nm) && strcmp(nm->valuestring, name) == 0)
+         return cJSON_Duplicate(t, 1);
+   }
+   return NULL;
+}
+
+static int family_member_retains_direct(const char *name)
+{
+   return strcmp(name, AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS) == 0;
+}
+
 void mcp_collapse_families(cJSON *tools)
 {
    if (!tools || !cJSON_IsArray(tools))
@@ -443,7 +465,8 @@ void mcp_collapse_families(cJSON *tools)
          if (cl < sizeof(clist))
             cl += (size_t)snprintf(clist + cl, sizeof(clist) - cl, "%s%s", cl ? ", " : "",
                                    m->command);
-         cJSON *mt = family_detach_member(tools, m->tool);
+         cJSON *mt = family_member_retains_direct(m->tool) ? family_copy_member(tools, m->tool)
+                                                           : family_detach_member(tools, m->tool);
          if (!mt)
             continue;
          found++;

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -12,6 +12,7 @@
 #include "log.h"
 #include "request_context.h"
 #include "platform_random.h"
+#include "agent_code_capabilities.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -22,8 +23,9 @@
 
 /* The standing exploration policy carried in every envelope. Kept short — it is
  * advice the model weighs, not a contract we can enforce over the wire. */
-#define INGRESS_EXPLORE_WITH                                                                       \
-   "find_symbol, lsp_references, ast_grep_search, search_graph, get_context_block, memory_get"
+static const char *const INGRESS_EXPLORE_WITH = AIMEE_CODE_TOOL_FIND_SYMBOL
+    ", lsp_references, " AIMEE_CODE_TOOL_AST_GREP_SEARCH ", " AIMEE_CODE_TOOL_INDEX
+    " command=" AIMEE_CODE_INDEX_COMMAND_HYBRID ", get_context_block, memory_get";
 
 #define INGRESS_AUDIT_CONTEXT_FILE            "audit_context.txt"
 #define INGRESS_AUDIT_CONTEXT_MAX_AGE_SECONDS (6 * 60 * 60)
@@ -132,7 +134,9 @@ char *ingress_preinject_format_envelope(const char *context_block, const char *c
    dstr_append_str(&d, context_block);
    if (context_block[strlen(context_block) - 1] != '\n')
       dstr_append_str(&d, "\n");
-   dstr_append_str(&d, "explore-with: " INGRESS_EXPLORE_WITH "\n");
+   dstr_append_str(&d, "explore-with: ");
+   dstr_append_str(&d, INGRESS_EXPLORE_WITH);
+   dstr_append_str(&d, "\n");
    dstr_append_str(&d, "</aimee-context>");
    char *out = dstr_steal(&d);
    return out;

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -42,6 +42,7 @@
 #include "headers/payload_rewrite.h"
 #include "headers/session_search_tool.h"
 #include "td_search_render.h"
+#include "agent_code_capabilities.h"
 #include "cJSON.h"
 #include <string.h>
 #include <strings.h>
@@ -876,19 +877,38 @@ cJSON *smcp_tool_find_symbol(cJSON *args)
    if (!cJSON_IsString(jid))
       return text_content("error: missing 'identifier' parameter");
 
+   int all_projects = mcp_code_scope_all(args);
+   if (all_projects < 0)
+      return text_content("error: scope must be 'current' or 'all'");
+   const char *project = all_projects ? NULL : mcp_code_project_from_args(args);
+   if (!all_projects && !project)
+      return text_content("error: no active project determined from cwd; pass 'project' or "
+                          "scope='all' explicitly");
+
    term_hit_t hits[20];
-   int count = kb_client_index_find(jid->valuestring, hits, 20);
+   int count = project ? kb_client_index_find_project(project, jid->valuestring, hits, 20)
+                       : kb_client_index_find(jid->valuestring, hits, 20);
+   if (count < 0)
+      return text_content("error: knowledge service symbol index unavailable");
+   int matched = 0;
+   for (int i = 0; i < count; i++)
+      if (!project || strcmp(hits[i].project, project) == 0)
+         matched++;
 
    char buf[4096];
    int pos = 0;
-   if (count == 0)
-      pos = mcp_appendf(buf, pos, (int)sizeof(buf), "No symbol found for '%s'", jid->valuestring);
+   if (matched == 0)
+      pos = mcp_appendf(buf, pos, (int)sizeof(buf), "No symbol found for '%s'%s%s%s",
+                        jid->valuestring, project ? " in project '" : "", project ? project : "",
+                        project ? "'" : "");
    else
    {
-      pos = mcp_appendf(buf, pos, (int)sizeof(buf), "Found %d match(es) for '%s':\n\n", count,
+      pos = mcp_appendf(buf, pos, (int)sizeof(buf), "Found %d match(es) for '%s':\n\n", matched,
                         jid->valuestring);
       for (int i = 0; i < count && pos < (int)sizeof(buf) - 256; i++)
       {
+         if (project && strcmp(hits[i].project, project) != 0)
+            continue;
          /* Show the body span (line-line_end) when known, so a `file::symbol`
           * read can fetch exactly that range; fall back to the start line. */
          if (hits[i].line_end > hits[i].line)
@@ -901,19 +921,6 @@ cJSON *smcp_tool_find_symbol(cJSON *args)
       }
    }
    return text_content(buf);
-}
-
-static const char *smcp_search_project(cJSON *args)
-{
-   cJSON *project = cJSON_GetObjectItemCaseSensitive(args, "project");
-   if (cJSON_IsString(project) && project->valuestring[0])
-      return project->valuestring;
-   cJSON *cwd = cJSON_GetObjectItemCaseSensitive(args, "cwd");
-   if (!cJSON_IsString(cwd) || !cwd->valuestring[0])
-      return NULL;
-   const char *base = strrchr(cwd->valuestring, '/');
-   base = base ? base + 1 : cwd->valuestring;
-   return base[0] ? base : NULL;
 }
 
 cJSON *smcp_tool_search_docs(cJSON *args)
@@ -938,7 +945,7 @@ cJSON *smcp_tool_search_docs(cJSON *args)
     * leave selection to the KB just as we do for an empty field. */
    if (!embedding_command[0] || strcmp(embedding_command, "builtin") == 0)
       embedding_command = NULL;
-   char *envelope = kb_client_search_json(smcp_search_project(args), query->valuestring,
+   char *envelope = kb_client_search_json(mcp_code_project_from_args(args), query->valuestring,
                                           embedding_command, max_results, NULL);
    cJSON *response = envelope ? cJSON_Parse(envelope) : NULL;
    free(envelope);
@@ -953,8 +960,15 @@ cJSON *tool_preview_blast_radius(cJSON *args)
 {
    cJSON *jproj = cJSON_GetObjectItemCaseSensitive(args, "project");
    cJSON *jpaths = cJSON_GetObjectItemCaseSensitive(args, "paths");
-   if (!cJSON_IsString(jproj) || !cJSON_IsArray(jpaths))
-      return text_content("error: missing 'project' or 'paths' parameter");
+   int all_projects = mcp_code_scope_all(args);
+   if (all_projects != 0)
+      return text_content(all_projects < 0 ? "error: scope must be 'current'"
+                                           : "error: blast preview requires one project");
+   const char *project = cJSON_IsString(jproj) && jproj->valuestring[0]
+                             ? jproj->valuestring
+                             : mcp_code_project_from_args(args);
+   if (!project || !cJSON_IsArray(jpaths))
+      return text_content("error: missing 'paths' or active project; pass 'project' explicitly");
 
    int cnt = cJSON_GetArraySize(jpaths);
    if (cnt < 1 || cnt > 100)
@@ -967,7 +981,7 @@ cJSON *tool_preview_blast_radius(cJSON *args)
       paths[i] = cJSON_IsString(item) ? item->valuestring : "";
    }
 
-   char *json = kb_client_index_blast_radius_preview_json(jproj->valuestring, paths, cnt);
+   char *json = kb_client_index_blast_radius_preview_json(project, paths, cnt);
    cJSON *content = text_content(
        json ? json : "{\"status\":\"error\",\"message\":\"knowledge service unavailable\"}");
    free(json);
@@ -1534,19 +1548,6 @@ cJSON *mcp_git_run_tool(const char *tool, cJSON *args, const char *sid)
  * the presentation profile) so a lean tools/list loses no reach: the model can
  * discover any tool's name + schema and then call it by name. Read-only; they
  * return MCP `content` like any other content-producing tool. */
-static int mcp_ci_contains(const char *haystack, const char *needle)
-{
-   if (!needle || !needle[0])
-      return 1; /* empty query matches everything */
-   if (!haystack)
-      return 0;
-   size_t nlen = strlen(needle);
-   for (const char *h = haystack; *h; h++)
-      if (strncasecmp(h, needle, nlen) == 0)
-         return 1;
-   return 0;
-}
-
 static cJSON *mcp_tool_find_tools(cJSON *args)
 {
    cJSON *jq = cJSON_GetObjectItemCaseSensitive(args, "query");
@@ -1567,7 +1568,7 @@ static cJSON *mcp_tool_find_tools(cJSON *args)
       cJSON *ds = cJSON_GetObjectItemCaseSensitive(t, "description");
       const char *name = cJSON_IsString(nm) ? nm->valuestring : "";
       const char *desc = cJSON_IsString(ds) ? ds->valuestring : "";
-      if (!mcp_ci_contains(name, q) && !mcp_ci_contains(desc, q))
+      if (!mcp_tool_matches_query(t, q))
          continue;
       total++;
       if (shown >= limit)

--- a/src/server/server_mcp_call_table.c
+++ b/src/server/server_mcp_call_table.c
@@ -706,8 +706,13 @@ static cJSON *mcph_index_find_callers(struct mcp_call *c)
    cJSON *js = cJSON_GetObjectItemCaseSensitive(c->jargs, "symbol");
    if (!cJSON_IsString(js) || !js->valuestring[0])
       return text_content("error: index_find_callers requires 'symbol'");
-   cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
-   const char *project = cJSON_IsString(jp) ? jp->valuestring : NULL;
+   int all_projects = mcp_code_scope_all(c->jargs);
+   if (all_projects < 0)
+      return text_content("error: scope must be 'current' or 'all'");
+   const char *project = all_projects ? NULL : mcp_code_project_from_args(c->jargs);
+   if (!all_projects && !project)
+      return text_content("error: no active project determined from cwd; pass 'project' or "
+                          "scope='all' explicitly");
    const int max = 200;
    caller_hit_t *hits = calloc((size_t)max, sizeof(*hits));
    if (!hits)

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -11,6 +11,8 @@
 
 static char g_last_mcp_call_cwd[4096];
 static char g_last_mcp_call_arg_cwd[4096];
+static char g_last_mcp_call_tool[128];
+static int g_last_mcp_call_paths_count;
 static int g_reverse_channel_starts;
 static int g_remote_active;
 static int g_remote_http_failures;
@@ -302,11 +304,15 @@ cJSON *cli_v1_dispatch_local(cJSON *request, int timeout_ms)
       cJSON *arguments = cJSON_GetObjectItemCaseSensitive(request, "arguments");
       cJSON *jarg_cwd =
           cJSON_IsObject(arguments) ? cJSON_GetObjectItemCaseSensitive(arguments, "cwd") : NULL;
+      cJSON *jpaths =
+          cJSON_IsObject(arguments) ? cJSON_GetObjectItemCaseSensitive(arguments, "paths") : NULL;
 
+      snprintf(g_last_mcp_call_tool, sizeof(g_last_mcp_call_tool), "%s", tool);
       snprintf(g_last_mcp_call_cwd, sizeof(g_last_mcp_call_cwd), "%s",
                cJSON_IsString(jcwd) ? jcwd->valuestring : "");
       snprintf(g_last_mcp_call_arg_cwd, sizeof(g_last_mcp_call_arg_cwd), "%s",
                cJSON_IsString(jarg_cwd) ? jarg_cwd->valuestring : "");
+      g_last_mcp_call_paths_count = cJSON_IsArray(jpaths) ? cJSON_GetArraySize(jpaths) : 0;
 
       /* Simulate an error response for "fail_tool" */
       if (strcmp(tool, "fail_tool") == 0)
@@ -795,6 +801,41 @@ static void test_tools_call_success(void)
    cJSON_Delete(req);
 }
 
+/* Installed MCP smoke: the canonical blast-preview name and path-only schema
+ * survive the stdio proxy, which supplies cwd for the server's active-project
+ * default. This deliberately omits project. */
+static void test_tools_call_preview_blast_radius(void)
+{
+   g_last_mcp_call_tool[0] = '\0';
+   g_last_mcp_call_cwd[0] = '\0';
+   g_last_mcp_call_arg_cwd[0] = '\0';
+   g_last_mcp_call_paths_count = 0;
+
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "jsonrpc", "2.0");
+   cJSON_AddNumberToObject(req, "id", 12.5);
+   cJSON_AddStringToObject(req, "method", "tools/call");
+   cJSON *params = cJSON_AddObjectToObject(req, "params");
+   cJSON_AddStringToObject(params, "name", "preview_blast_radius");
+   cJSON *args = cJSON_AddObjectToObject(params, "arguments");
+   cJSON *paths = cJSON_AddArrayToObject(args, "paths");
+   cJSON_AddItemToArray(paths, cJSON_CreateString("src/server/server_mcp.c"));
+
+   cJSON *resp = capture_response(req);
+   assert(strcmp(g_last_mcp_call_tool, "preview_blast_radius") == 0);
+   assert(g_last_mcp_call_paths_count == 1);
+   char cwd[4096];
+   assert(getcwd(cwd, sizeof(cwd)) != NULL);
+   assert(strcmp(g_last_mcp_call_cwd, cwd) == 0);
+   assert(strcmp(g_last_mcp_call_arg_cwd, cwd) == 0);
+   cJSON *result = cJSON_GetObjectItemCaseSensitive(resp, "result");
+   assert(cJSON_IsObject(result));
+
+   cJSON_Delete(resp);
+   cJSON_Delete(req);
+   puts("  PASS: test_tools_call_preview_blast_radius");
+}
+
 static void test_tools_call_server_error(void)
 {
    cJSON *req = cJSON_CreateObject();
@@ -1051,6 +1092,7 @@ int main(void)
    test_tools_list_preserves_server_error();
    test_remote_discovery_retries_are_safe();
    test_tools_call_success();
+   test_tools_call_preview_blast_radius();
    test_tools_call_server_error();
    test_tools_call_nested_http_error();
    test_tools_call_structured_content_passthrough();

--- a/src/tests/test_client_integrations.c
+++ b/src/tests/test_client_integrations.c
@@ -82,6 +82,13 @@ static void test_codex_delegate_policy_is_explicit(void)
    assert(strstr(skill, "Do not call provider-native sub-agent tools") != NULL);
    assert(strstr(skill, "`spawn_agent`") != NULL);
    assert(strstr(skill, "`delegate` MCP tool") != NULL);
+
+   const char *code_prompt = codex_code_exploration_prompt();
+   assert(strstr(code_prompt, AIMEE_CODE_TOOL_FIND_SYMBOL) != NULL);
+   assert(strstr(code_prompt, AIMEE_CODE_TOOL_AST_GREP_SEARCH) != NULL);
+   assert(strstr(code_prompt, AIMEE_CODE_TOOL_INDEX) != NULL);
+   assert(strstr(code_prompt, AIMEE_CODE_INDEX_COMMAND_HYBRID) != NULL);
+   assert(strstr(code_prompt, "search_graph") == NULL);
 }
 
 static void test_mcp_config_uses_resolved_command(void)

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -509,6 +509,33 @@ int main(void)
       }
       assert(found_real);
 
+      /* Project scoping belongs inside the SQL query, before LIMIT. A globally earlier duplicate
+       * must not crowd the requested project's definition out of a one-row result set. */
+      char *crowd = malloc(PATH_MAX);
+      assert(crowd != NULL);
+      snprintf(crowd, PATH_MAX, "%s/aimee-test-index-crowd-XXXXXX", platform_tmpdir());
+      assert(platform_mkdtemp(crowd) != NULL);
+      char crowd_path[PATH_MAX];
+      snprintf(crowd_path, sizeof(crowd_path), "%s/duplicate.c", crowd);
+      FILE *crowd_file = fopen(crowd_path, "w");
+      assert(crowd_file != NULL);
+      fprintf(crowd_file, "void liveness_is_degenerate_response(void) {}\n");
+      fclose(crowd_file);
+      int crowd_inspected = 0;
+      assert(canonical_index_scan_project("aaa-crowd", crowd, 1, &crowd_inspected) == 1);
+      assert(crowd_inspected == 1);
+      count = canonical_index_find("liveness_is_degenerate_response", hits, 1);
+      assert(count == 1);
+      assert(strcmp(hits[0].project, "aaa-crowd") == 0);
+      count =
+          canonical_index_find_project("canonicalproj", "liveness_is_degenerate_response", hits, 1);
+      assert(count == 1);
+      assert(strcmp(hits[0].project, "canonicalproj") == 0);
+      char cleanup_cmd[PATH_MAX + 16];
+      snprintf(cleanup_cmd, sizeof(cleanup_cmd), "rm -rf %s", crowd);
+      (void)system(cleanup_cmd);
+      free(crowd);
+
       count = canonical_index_find("source_build_symbol", hits, 16);
       assert(count > 0);
 

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -360,7 +360,7 @@ static void test_budgeted_build_uses_memory_previews(void)
        "  - memory:102 fallback [L2/policy score=0.440 headline_missing=true]\n"
        "    > Fallback preview from content.\n"
        "context-budget: used_bytes=342 budget_bytes=1200 omitted_count=0 headline_missing_count=1\n"
-       "explore-with: find_symbol, lsp_references, ast_grep_search, search_graph, "
+       "explore-with: find_symbol, lsp_references, ast_grep_search, index command=hybrid, "
        "get_context_block, "
        "memory_get\n"
        "</aimee-context>";

--- a/src/tests/test_kb_client_search.c
+++ b/src/tests/test_kb_client_search.c
@@ -225,6 +225,15 @@ static int index_get_handler(const char *url, const char *extra_headers, char **
          *response_buf = strdup("{\"hits\":[{\"project\":\"aimee\",\"file_path\":\"src/main.c\","
                                 "\"line\":12,\"kind\":\"function\"}],\"next_cursor\":null}");
    }
+   else if (g_route_case == 34)
+   {
+      assert(strcmp(url, "http://127.0.0.1:4010/v1/code/find?identifier=target%2Ffn%3F&"
+                         "max_results=2&project=aimee%20core%2Fkb%3F") == 0);
+      if (response_buf)
+         *response_buf = strdup("{\"hits\":[{\"project\":\"aimee core/kb?\","
+                                "\"file_path\":\"src/main.c\",\"line\":12,"
+                                "\"kind\":\"function\"}],\"next_cursor\":null}");
+   }
    else if (g_route_case == 22)
    {
       assert(strcmp(url, "http://127.0.0.1:4010/v1/code/projects?max_results=2") == 0);
@@ -749,6 +758,10 @@ static void test_index_reads_use_v1_api_when_configured(void)
    assert(hits[0].line == 12);
    assert(strcmp(hits[0].kind, "function") == 0);
 
+   g_route_case = 34;
+   assert(kb_client_index_find_project("aimee core/kb?", "target/fn?", hits, 2) == 1);
+   assert(strcmp(hits[0].project, "aimee core/kb?") == 0);
+
    g_route_case = 22;
    project_info_t projects[2];
    assert(kb_client_index_list(projects, 2) == 1);
@@ -809,7 +822,7 @@ static void test_index_reads_use_v1_api_when_configured(void)
    assert(strcmp(caller_hits[0].caller, "caller_fn") == 0);
    assert(caller_hits[0].line == 44);
 
-   assert(g_get_seen == 10);
+   assert(g_get_seen == 11);
    unsetenv("AIMEE_KB_API_URL");
    mock_agent_http_reset();
    g_route_case = 0;

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -610,6 +610,8 @@ typedef struct
    char kind[32];
 } test_term_hit_t;
 
+static char g_code_find_project[128];
+
 int canonical_index_find(const char *identifier, void *out, int max)
 {
    assert(identifier);
@@ -623,6 +625,12 @@ int canonical_index_find(const char *identifier, void *out, int max)
    hits[0].line_end = 20;
    snprintf(hits[0].kind, sizeof(hits[0].kind), "function");
    return 1;
+}
+
+int canonical_index_find_project(const char *project, const char *identifier, void *out, int max)
+{
+   snprintf(g_code_find_project, sizeof(g_code_find_project), "%s", project ? project : "");
+   return canonical_index_find(identifier, out, max);
 }
 
 typedef struct
@@ -5365,6 +5373,13 @@ static void test_code_find_ok(void)
    assert(strstr(buf, "\"file_path\":\"src/main.c\"") != NULL);
    assert(strstr(buf, "\"line\":12") != NULL);
    assert(strstr(buf, "\"kind\":\"function\"") != NULL);
+
+   g_code_find_project[0] = '\0';
+   s = kb_http_route_ex("GET", "/v1/code/find", "identifier=foo&project=proj-alpha", NULL, NULL,
+                        NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strcmp(g_code_find_project, "proj-alpha") == 0);
+   assert(strstr(buf, "\"project\":\"proj-alpha\"") != NULL);
 }
 
 static void test_code_projects_wrong_method(void)

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -9,6 +9,7 @@
 #include "mcp_osv_cache.h"
 #include "aimee/protocols/mcp/mcp_client_registry.h"
 #include "aimee/protocols/mcp/mcp_tools.h"
+#include "agent_code_capabilities.h"
 
 static const char *g_http_response;
 static int g_http_status = -1;
@@ -459,7 +460,7 @@ static void test_osv_offline_cache_miss_allows(void)
  * built-in tool surface (name + sorted schema property keys + required), captured
  * via the DUMP_TOOLS path in test_mcp_client_registry.c. Regenerate after an
  * intentional tool change: DUMP_TOOLS=1 ./unit-test-mcp-client-registry 2>&1. */
-#define MCP_TOOLS_GOLDEN_COUNT 53
+#define MCP_TOOLS_GOLDEN_COUNT 54
 #define MCP_TOOLS_GOLDEN                                                                           \
    "ask_user {choices,question} req:question\n"                                                    \
    "ast_grep_search {lang,path,pattern} req:lang,pattern\n"                                        \
@@ -480,7 +481,7 @@ static void test_osv_offline_cache_miss_allows(void)
    "epistemic_directive "                                                                          \
    "{anchor_entity,anchor_file,cause,command,id,limit,note,priority,question,resolution_memory_"   \
    "id,state,suppress,topic,valid_until} req:command\n"                                            \
-   "find_symbol {identifier} req:identifier\n"                                                     \
+   "find_symbol {identifier,project,scope} req:identifier\n"                                       \
    "find_tools {limit,query} req:\n"                                                               \
    "get_help {topic} req:\n"                                                                       \
    "get_identity {} req:\n"                                                                        \
@@ -491,7 +492,8 @@ static void test_osv_offline_cache_miss_allows(void)
    "graph {command,entity,episode_key,limit,query} req:command\n"                                  \
    "host {command,name} req:command\n"                                                             \
    "index "                                                                                        \
-   "{command,file_path,judge,line_end,line_start,max_results,node,paths,project,query,symbol} "    \
+   "{command,file_path,judge,line_end,line_start,max_results,node,paths,project,query,scope,"      \
+   "symbol} "                                                                                      \
    "req:command\n"                                                                                 \
    "job {command,job_id,max_concurrent,plan_id} req:command\n"                                     \
    "learning "                                                                                     \
@@ -515,6 +517,7 @@ static void test_osv_offline_cache_miss_allows(void)
    "pipeline "                                                                                     \
    "{artifact,base_branch,brief,command,done_bar,head_branch,idea,operator_principal,"             \
    "pipeline_id,questions,reason,remote,repo_root,state,verdict,worktree_path} req:command\n"      \
+   "preview_blast_radius {paths,project,scope} req:paths\n"                                        \
    "prospective_memory "                                                                           \
    "{action_text,anchor_entity,anchor_file,command,id,limit,recurrence,state,trigger_text,valid_"  \
    "until} req:command\n"                                                                          \
@@ -630,6 +633,7 @@ static void test_tool_profile_filter(void)
                                       "get_identity",
                                       "find_symbol",
                                       "ast_grep_search",
+                                      "preview_blast_radius",
                                       "git",
                                       "delegate",
                                       "roundtable_review",
@@ -724,6 +728,88 @@ static int tools_have(cJSON *tools, const char *name)
    return 0;
 }
 
+static cJSON *tools_get(cJSON *tools, const char *name)
+{
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, tools)
+   {
+      cJSON *n = cJSON_GetObjectItemCaseSensitive(t, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, name) == 0)
+         return t;
+   }
+   return NULL;
+}
+
+static int schema_has_property(cJSON *tool, const char *name)
+{
+   cJSON *schema = cJSON_GetObjectItemCaseSensitive(tool, "inputSchema");
+   cJSON *properties = cJSON_GetObjectItemCaseSensitive(schema, "properties");
+   return cJSON_GetObjectItemCaseSensitive(properties, name) != NULL;
+}
+
+static int schema_requires(cJSON *tool, const char *name)
+{
+   cJSON *schema = cJSON_GetObjectItemCaseSensitive(tool, "inputSchema");
+   cJSON *required = cJSON_GetObjectItemCaseSensitive(schema, "required");
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, required) if (cJSON_IsString(item) &&
+                                          strcmp(item->valuestring, name) == 0) return 1;
+   return 0;
+}
+
+/* E1 contract: the words installed guidance gives an agent must map to a direct
+ * lean tool, and every code-navigation schema must admit active-project defaults
+ * plus an explicit cross-project escape hatch. */
+static void test_agent_code_intelligence_contracts(void)
+{
+   cJSON *collapsed = mcp_build_tools_list();
+   cJSON *flat = mcp_build_tools_list_flat();
+
+   cJSON *preview = tools_get(collapsed, AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS);
+   assert(preview != NULL);
+   cJSON *description = cJSON_GetObjectItemCaseSensitive(preview, "description");
+   assert(cJSON_IsString(description));
+   assert(strstr(description->valuestring, "blast radius") != NULL);
+   assert(strstr(description->valuestring, "Preview") != NULL);
+   assert(mcp_tool_matches_query(preview, AIMEE_CODE_DISCOVERY_BLAST_RADIUS));
+   assert(mcp_tool_matches_query(preview, "BLAST RADIUS"));
+   assert(mcp_tool_matches_query(preview, AIMEE_CODE_DISCOVERY_PREVIEW));
+   assert(!mcp_tool_matches_query(preview, "unrelated memory query"));
+   assert(schema_has_property(preview, "project"));
+   assert(schema_has_property(preview, "scope"));
+   assert(schema_has_property(preview, "paths"));
+   assert(!schema_requires(preview, "project"));
+   assert(schema_requires(preview, "paths"));
+
+   cJSON *symbol = tools_get(collapsed, AIMEE_CODE_TOOL_FIND_SYMBOL);
+   assert(symbol != NULL);
+   assert(schema_has_property(symbol, "identifier"));
+   assert(schema_has_property(symbol, "project"));
+   assert(schema_has_property(symbol, "scope"));
+
+   cJSON *callers = tools_get(flat, "index_find_callers");
+   assert(callers != NULL);
+   assert(schema_has_property(callers, "project"));
+   assert(schema_has_property(callers, "scope"));
+
+   cJSON *args = cJSON_Parse("{\"cwd\":\"/work/aimee\"}");
+   assert(strcmp(mcp_code_project_from_args(args), "aimee") == 0);
+   assert(mcp_code_scope_all(args) == 0);
+   cJSON_AddStringToObject(args, "project", "explicit-project");
+   assert(strcmp(mcp_code_project_from_args(args), "explicit-project") == 0);
+   cJSON_AddStringToObject(args, "scope", "all");
+   assert(mcp_code_scope_all(args) == 1);
+   cJSON_ReplaceItemInObject(args, "scope", cJSON_CreateString(""));
+   assert(mcp_code_scope_all(args) == 0);
+   cJSON_ReplaceItemInObject(args, "scope", cJSON_CreateString("invalid"));
+   assert(mcp_code_scope_all(args) == -1);
+   cJSON_Delete(args);
+
+   cJSON_Delete(flat);
+   cJSON_Delete(collapsed);
+   printf("  PASS: agent_code_intelligence_contracts\n");
+}
+
 /* The flat list keeps family members; the collapsed one folds them away.
  *
  * mcp_collapse_families presents coherent families as ONE multiplexed tool
@@ -772,6 +858,7 @@ int main(void)
    test_tools_list_surface();
    test_tool_profile_filter();
    test_call_tool_demux();
+   test_agent_code_intelligence_contracts();
    test_flat_list_keeps_family_members();
    test_boot_and_lazy_tools();
    test_install_target_filtering();


### PR DESCRIPTION
## Summary

- publish one canonical agent-facing code-intelligence vocabulary and make `preview_blast_radius` directly discoverable in the lean MCP surface
- default symbol/caller/blast queries to the active project resolved from explicit project or request cwd, with explicit `scope:"all"` compatibility where supported
- apply the project predicate inside the canonical symbol query before `ORDER BY`/`LIMIT`, preventing unrelated indexed projects from crowding out local results
- align generated Codex, Claude, session-start, attention-guard, and ingress guidance on `index({command:"hybrid"})` instead of the memory-graph route
- add validation documentation and adversarial regressions across registry, stdio proxy, client encoding, HTTP propagation, and canonical index selection

Depends on the accepted proposal/amendment chain: #2147, #2148, #2150. This is the bounded E1 code-intelligence slice; E1-memory follows separately for the same local-first invariant across every ordered memory surface.

## Verification

- `make -C src -j2 all`
- `make -C src -j2 lint` — all 39 checks passed
- `make -C src check-linking`
- `make -C src -j2 unit-tests` — all local tests passed; PostgreSQL RLS gate intentionally deferred to CI because `AIMEE_TEST_PG_URL` is unset
- focused MCP registry, client integration, ingress, stdio proxy, KB client, KB HTTP route, canonical index, attention-guard, and session-start tests
- benchmark fixture source verification and Python fixture unit test
- proposal link/reconcile and line checks
- `git diff --check`

## Roundtable

- round 1: approved and converged 3/3; nonblocking polish accepted, run `oprun_g6a69bd8011459d99_1785339236_94`
- final round: approved and converged 3/3, no findings, not degraded, run `oprun_g6a69bd8011459d99_1785339722_95`
- frozen artifact SHA-256: `9e3bf97b9f076365b0d5dde13de9c714de22f2f60e8d303bf51d82e4975c8325`; the rebased PR diff hashes identically
