### PR TITLE
Fix account-scoped webchat session persistence

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -142,6 +142,10 @@ function LogoutButton() {
     e.preventDefault();
     localStorage.removeItem('aimee_chat_tabs');
     localStorage.removeItem('aimee_active_chat_tab');
+    localStorage.removeItem('aimee_sessions');
+    localStorage.removeItem('aimee_active_session');
+    localStorage.removeItem('aimee_server_sessions_authoritative_v1');
+    localStorage.removeItem('aimee_sessions_owner');
     localStorage.removeItem('aimee_proposal_draft');
     fetch('/logout', {
       method: 'POST',

--- a/frontend/src/SessionContext.test.tsx
+++ b/frontend/src/SessionContext.test.tsx
@@ -1,0 +1,59 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionProvider, useSessions } from './SessionContext';
+
+function SessionProbe() {
+  const { sessions } = useSessions();
+  return <div data-testid="sessions">{sessions.map(session => session.name).join(',')}</div>;
+}
+
+function cacheSession(name: string) {
+  localStorage.setItem('aimee_sessions', JSON.stringify([{
+    id: 'ui-secret',
+    name,
+    projectRoot: '/private/project',
+    projectName: 'project',
+    claudeSid: 'provider-secret',
+    aimeeSid: 'web-secret',
+    attachId: '',
+    messages: [{ role: 'user', text: 'private message' }],
+  }]));
+}
+
+describe('SessionProvider bootstrap cache ownership', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not reveal cached chats when identity verification fails', async () => {
+    cacheSession('Private chat');
+    localStorage.setItem('aimee_sessions_owner', 'alice');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    render(<SessionProvider><SessionProbe /></SessionProvider>);
+
+    expect((await screen.findByTestId('sessions')).textContent).toBe('Session 1');
+  });
+
+  it('keeps an account-owned cache when identity succeeds but session restore is offline', async () => {
+    cacheSession('Alice chat');
+    localStorage.setItem('aimee_sessions_owner', 'alice');
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ username: 'alice' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockRejectedValueOnce(new Error('sessions offline'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<SessionProvider><SessionProbe /></SessionProvider>);
+
+    expect((await screen.findByTestId('sessions')).textContent).toBe('Alice chat');
+  });
+});

--- a/frontend/src/SessionContext.tsx
+++ b/frontend/src/SessionContext.tsx
@@ -1,18 +1,23 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import {
+  cacheBelongsToAccount,
+  legacyProviderAliasIDs,
+  mergePersistedSessions,
+  sessionsForLocalCache,
+  sessionsMissingFromServer,
+  shouldOfferOwnerlessCacheImport,
+  type PersistedChatSession,
+  type SessionMessage,
+  type SessionRecord,
+} from './sessionPersistence';
 
 /* A "session" is the app-level unit of work: one chat conversation bound to one
- * git project (plus the provider session ids that carry that conversation). It
- * is shown as a tab at the very top of the app; the vertical tool nav (Chat /
- * Editor / Workflows / …) all operate on the ACTIVE session's project. */
-export interface Session {
-  id: string;          // stable local id (also the React key)
-  name: string;        // tab label
-  projectRoot: string; // workspace root of the bound project ("" = none)
-  projectName: string; // project (repo) name within the root ("" = none)
-  claudeSid: string;   // claude provider session id (for --resume); reset by Clear
-  aimeeSid: string;    // aimee session id (server-side per-session state)
-  attachId: string;    // unified-presence attachment id (minted on first send)
+ * git project (plus the provider session ids that carry that conversation). The
+ * authenticated server account is authoritative; localStorage is only a fast
+ * cache and a one-time migration source for pre-server transcripts. */
+export interface Session extends SessionRecord {
+  messages: SessionMessage[];
 }
 
 interface SessionCtx {
@@ -29,16 +34,57 @@ interface SessionCtx {
 
 const SESSIONS_KEY = 'aimee_sessions';
 const ACTIVE_KEY = 'aimee_active_session';
+const SERVER_SYNC_KEY = 'aimee_server_sessions_authoritative_v1';
+const CACHE_OWNER_KEY = 'aimee_sessions_owner';
+const LEGACY_TABS_KEY = 'aimee_chat_tabs';
 
-let _idSeq = 0;
-function newId(): string {
-  // Unique without Math.random/Date — monotonic counter + a per-load base.
-  _idSeq += 1;
-  return `s${_idSeq}-${performance.now().toString(36).replace('.', '')}`;
+function newAimeeSessionID(): string {
+  try {
+    if (globalThis.crypto?.randomUUID) return `web-${globalThis.crypto.randomUUID()}`;
+  } catch { /* ignore */ }
+  return `web-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 function blankSession(name: string): Session {
-  return { id: newId(), name, projectRoot: '', projectName: '', claudeSid: '', aimeeSid: '', attachId: '' };
+  const id = newAimeeSessionID();
+  return {
+    id,
+    name,
+    projectRoot: '',
+    projectName: '',
+    claudeSid: '',
+    aimeeSid: id,
+    attachId: '',
+    messages: [],
+  };
+}
+
+interface LegacyTab {
+  sessionId?: string;
+  aimeeSid?: string;
+  sid?: string;
+  messages?: SessionMessage[];
+}
+
+function loadLegacyTabs(): Map<string, LegacyTab> {
+  const out = new Map<string, LegacyTab>();
+  try {
+    const parsed = JSON.parse(localStorage.getItem(LEGACY_TABS_KEY) || '[]') as LegacyTab[];
+    if (Array.isArray(parsed)) {
+      for (const tab of parsed) if (tab?.sessionId) out.set(tab.sessionId, tab);
+    }
+  } catch { /* ignore */ }
+  return out;
+}
+
+function normalizeMessages(value: unknown): SessionMessage[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((message): message is SessionMessage => {
+    if (!message || typeof message !== 'object') return false;
+    const candidate = message as Partial<SessionMessage>;
+    return (candidate.role === 'user' || candidate.role === 'assistant' || candidate.role === 'narration') &&
+      typeof candidate.text === 'string';
+  });
 }
 
 function loadSessions(): Session[] {
@@ -47,80 +93,295 @@ function loadSessions(): Session[] {
     if (raw) {
       const parsed = JSON.parse(raw) as Partial<Session>[];
       if (Array.isArray(parsed) && parsed.length) {
-        return parsed.map((s, i) => ({
-          id: typeof s.id === 'string' && s.id ? s.id : newId(),
-          name: typeof s.name === 'string' && s.name ? s.name : `Session ${i + 1}`,
-          projectRoot: typeof s.projectRoot === 'string' ? s.projectRoot : '',
-          projectName: typeof s.projectName === 'string' ? s.projectName : '',
-          claudeSid: typeof s.claudeSid === 'string' ? s.claudeSid : '',
-          aimeeSid: typeof s.aimeeSid === 'string' ? s.aimeeSid : '',
-          attachId: typeof s.attachId === 'string' ? s.attachId : '',
-        }));
+        const legacyTabs = loadLegacyTabs();
+        return parsed.map((session, i) => {
+          const legacy = typeof session.id === 'string' ? legacyTabs.get(session.id) : undefined;
+          const aimeeSid = (typeof session.aimeeSid === 'string' && session.aimeeSid) ||
+            legacy?.aimeeSid || newAimeeSessionID();
+          return {
+            id: typeof session.id === 'string' && session.id ? session.id : aimeeSid,
+            name: typeof session.name === 'string' && session.name ? session.name : `Session ${i + 1}`,
+            projectRoot: typeof session.projectRoot === 'string' ? session.projectRoot : '',
+            projectName: typeof session.projectName === 'string' ? session.projectName : '',
+            claudeSid: (typeof session.claudeSid === 'string' && session.claudeSid) || legacy?.sid || '',
+            aimeeSid,
+            // Presence attachments are browser-process-local and cannot be resumed.
+            attachId: '',
+            messages: normalizeMessages(session.messages).length
+              ? normalizeMessages(session.messages)
+              : normalizeMessages(legacy?.messages),
+          };
+        });
       }
     }
   } catch { /* ignore */ }
   return [blankSession('Session 1')];
 }
 
+async function persistSession(session: Session, legacyProviderAliasID = ''): Promise<boolean> {
+  try {
+    const response = await fetch('/api/chat/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window._csrf || '' },
+      body: JSON.stringify({
+        id: session.aimeeSid,
+        title: session.name,
+        cwd: session.projectRoot,
+        legacy_provider_alias_id: legacyProviderAliasID || undefined,
+        // The backend imports this only when its transcript is still empty.
+        // Provider ids are opaque resume credentials and are never imported
+        // directly from browser storage. During the one-time legacy upgrade the
+        // optional alias only asks the backend to transfer a binding already
+        // present in this authenticated user's server-owned legacy row.
+        messages: session.messages,
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false; // offline: the local cache remains available
+  }
+}
+
+async function forgetSessionRequest(aimeeSid: string): Promise<boolean> {
+  if (!aimeeSid) return true;
+  try {
+    const response = await fetch(`/api/chat/session?sid=${encodeURIComponent(aimeeSid)}`, {
+      method: 'DELETE',
+      headers: { 'X-CSRF-Token': window._csrf || '' },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function forgetSession(aimeeSid: string): void {
+  void forgetSessionRequest(aimeeSid);
+}
+
 const Ctx = createContext<SessionCtx | null>(null);
 
 export function SessionProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<Session[]>(loadSessions);
+  const sessionsRef = useRef<Session[]>(sessions);
+  const [restored, setRestored] = useState(false);
   const [activeId, setActiveId] = useState<string>(() => {
-    const stored = localStorage.getItem(ACTIVE_KEY);
-    return stored || '';
+    try { return localStorage.getItem(ACTIVE_KEY) || ''; } catch { return ''; }
   });
+
+  useEffect(() => { sessionsRef.current = sessions; }, [sessions]);
 
   // Keep an always-valid active id.
   useEffect(() => {
     if (!sessions.length) return;
-    if (!sessions.some(s => s.id === activeId)) setActiveId(sessions[0].id);
+    if (!sessions.some(session => session.id === activeId)) setActiveId(sessions[0].id);
   }, [sessions, activeId]);
 
-  // Persist.
+  // Persist the fast browser cache. The account-scoped server remains the source
+  // of truth after bootstrap succeeds.
   useEffect(() => {
-    try { localStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions)); } catch { /* ignore */ }
+    try { localStorage.setItem(SESSIONS_KEY, JSON.stringify(sessionsForLocalCache(sessions))); } catch { /* ignore */ }
   }, [sessions]);
   useEffect(() => {
     try { localStorage.setItem(ACTIVE_KEY, activeId); } catch { /* ignore */ }
   }, [activeId]);
 
+  const refreshFromServer = useCallback(async () => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 10_000);
+    let cacheVerified = false;
+    const replaceUnverifiedCache = () => {
+      if (cacheVerified) return;
+      const next = [blankSession('Session 1')];
+      sessionsRef.current = next;
+      setSessions(next);
+    };
+    try {
+      // allSettled lets a successful identity response validate an owned cache
+      // even when the sessions request is temporarily offline. A rejected
+      // identity request can never authorize data loaded from browser storage.
+      const [identityResult, sessionsResult] = await Promise.allSettled([
+        fetch('/api/auth/me', { signal: controller.signal }),
+        fetch('/api/chat/sessions', { signal: controller.signal }),
+      ]);
+      if (identityResult.status !== 'fulfilled' || !identityResult.value.ok) {
+        replaceUnverifiedCache();
+        return;
+      }
+      const identity = await identityResult.value.json() as { username?: string };
+      const username = identity.username?.trim() || '';
+
+      let cachedOwner = '';
+      try { cachedOwner = localStorage.getItem(CACHE_OWNER_KEY) || ''; } catch { /* ignore */ }
+      let trustedCache = cacheBelongsToAccount(username, cachedOwner);
+      cacheVerified = trustedCache;
+      if (sessionsResult.status !== 'fulfilled') {
+        replaceUnverifiedCache();
+        return;
+      }
+      const response = sessionsResult.value;
+      if (!trustedCache && !response.ok) {
+        // Never render another account's cache just because session restore is
+        // temporarily unavailable. A fresh placeholder is safe and stays local.
+        replaceUnverifiedCache();
+      }
+      if (!response.ok) return;
+      const body = await response.json() as unknown;
+      if (!Array.isArray(body)) return;
+      const remote = body as PersistedChatSession[];
+
+      // Pre-account browser caches have no trustworthy owner. Never attach one
+      // silently to the first person who logs in on a shared browser. Offer a
+      // one-time, explicit binding only when there is real legacy state; a
+      // mismatched stamped owner is never eligible for this path.
+      if (shouldOfferOwnerlessCacheImport(username, cachedOwner, sessionsRef.current)) {
+        const confirmed = window.confirm(
+          `Import chats stored in this browser into the account “${username}”? ` +
+          'Only continue if these chats belong to you.',
+        );
+        if (confirmed) {
+          cachedOwner = username;
+          trustedCache = true;
+          cacheVerified = true;
+          try { localStorage.setItem(CACHE_OWNER_KEY, username); } catch { /* ignore */ }
+        }
+      }
+      let alreadyAuthoritative = false;
+      try {
+        const marker = localStorage.getItem(SERVER_SYNC_KEY) || '';
+        alreadyAuthoritative = !trustedCache ||
+          (username ? marker === username : marker === '1');
+      } catch { /* ignore */ }
+
+      // A cache owned by a different authenticated account is never a migration
+      // source. Only the server's account-scoped rows participate in this merge.
+      const local = trustedCache ? sessionsRef.current : [];
+      const aliasIDs = alreadyAuthoritative ? [] : legacyProviderAliasIDs(local, remote);
+      const aliases = new Set(aliasIDs);
+      const canonicalRemote = remote.filter(session => !aliases.has(session.id));
+      const legacy = alreadyAuthoritative ? [] : sessionsMissingFromServer(local, canonicalRemote);
+      const merged = mergePersistedSessions(local, canonicalRemote, !alreadyAuthoritative);
+      const next = merged.length ? merged : [blankSession('Session 1')];
+      sessionsRef.current = next;
+      setSessions(next);
+
+      // One-time upgrade path: seed server rows/transcripts that only existed in
+      // localStorage before account-scoped persistence became authoritative.
+      if (!alreadyAuthoritative) {
+        const uploaded = await Promise.all(legacy.map(session => persistSession(
+          session,
+          aliases.has(session.claudeSid) ? session.claudeSid : '',
+        )));
+        const deleted = uploaded.every(Boolean)
+          ? await Promise.all(aliasIDs.map(forgetSessionRequest))
+          : [false];
+        if (uploaded.every(Boolean) && deleted.every(Boolean)) {
+          try {
+            localStorage.setItem(SERVER_SYNC_KEY, username || '1');
+            if (username) localStorage.setItem(CACHE_OWNER_KEY, username);
+          } catch { /* ignore */ }
+        }
+        return;
+      }
+      try {
+        localStorage.setItem(SERVER_SYNC_KEY, username || '1');
+        if (username) localStorage.setItem(CACHE_OWNER_KEY, username);
+      } catch { /* ignore */ }
+    } catch {
+      // Parsing failures and aborts are equivalent to an unavailable identity:
+      // never expose an unverified cache after the loading gate is released.
+      replaceUnverifiedCache();
+    }
+    finally {
+      window.clearTimeout(timeout);
+      setRestored(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshFromServer();
+  }, [refreshFromServer]);
+
+  // Pull in sessions created, renamed, or closed on another device during a
+  // long-lived browser session. The server remains authoritative; focus and a
+  // transition back to a visible tab are cheap reconciliation points.
+  useEffect(() => {
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === 'visible') void refreshFromServer();
+    };
+    window.addEventListener('focus', refreshWhenVisible);
+    document.addEventListener('visibilitychange', refreshWhenVisible);
+    return () => {
+      window.removeEventListener('focus', refreshWhenVisible);
+      document.removeEventListener('visibilitychange', refreshWhenVisible);
+    };
+  }, [refreshFromServer]);
+
   const addSession = useCallback((name?: string) => {
-    const s = blankSession(name && name.trim() ? name.trim() : `Session ${Date.now() % 100000}`);
-    setSessions(prev => [...prev, s]);
-    setActiveId(s.id);
-    return s.id;
+    const session = blankSession(name && name.trim() ? name.trim() : `Session ${Date.now() % 100000}`);
+    setSessions(previous => [...previous, session]);
+    setActiveId(session.id);
+    void persistSession(session);
+    return session.id;
   }, []);
 
   const closeSession = useCallback((id: string) => {
-    setSessions(prev => {
-      const next = prev.filter(s => s.id !== id);
-      const result = next.length ? next : [blankSession('Session 1')];
-      setActiveId(cur => (cur === id ? result[0].id : cur));
-      return result;
+    const target = sessionsRef.current.find(session => session.id === id);
+    if (target) forgetSession(target.aimeeSid);
+    setSessions(previous => {
+      const remaining = previous.filter(session => session.id !== id);
+      const next = remaining.length ? remaining : [blankSession('Session 1')];
+      setActiveId(current => current === id ? next[0].id : current);
+      return next;
     });
   }, []);
 
   const selectSession = useCallback((id: string) => setActiveId(id), []);
 
   const renameSession = useCallback((id: string, name: string) => {
-    const n = name.trim();
-    if (!n) return;
-    setSessions(prev => prev.map(s => (s.id === id ? { ...s, name: n } : s)));
+    const normalized = name.trim();
+    if (!normalized) return;
+    setSessions(previous => previous.map(session => {
+      if (session.id !== id) return session;
+      const next = { ...session, name: normalized };
+      void persistSession(next);
+      return next;
+    }));
   }, []);
 
   const patchSession = useCallback((id: string, patch: Partial<Session>) => {
-    setSessions(prev => prev.map(s => (s.id === id ? { ...s, ...patch } : s)));
+    setSessions(previous => previous.map(session => {
+      if (session.id !== id) return session;
+      const next = { ...session, ...patch };
+      if (next.aimeeSid !== session.aimeeSid) forgetSession(session.aimeeSid);
+      void persistSession(next);
+      return next;
+    }));
   }, []);
 
-  const active = useMemo(() => sessions.find(s => s.id === activeId) || sessions[0] || null, [sessions, activeId]);
+  const active = useMemo(
+    () => sessions.find(session => session.id === activeId) || sessions[0] || null,
+    [sessions, activeId],
+  );
 
   const value = useMemo<SessionCtx>(() => ({
-    sessions, activeId: active?.id ?? '', active,
-    addSession, closeSession, selectSession, renameSession, patchSession,
+    sessions,
+    activeId: active?.id ?? '',
+    active,
+    addSession,
+    closeSession,
+    selectSession,
+    renameSession,
+    patchSession,
   }), [sessions, active, addSession, closeSession, selectSession, renameSession, patchSession]);
 
-  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+  return (
+    <Ctx.Provider value={value}>
+      {restored ? children : (
+        <div style={{ padding: 24, fontFamily: 'system-ui', color: '#888' }}>Loading chats…</div>
+      )}
+    </Ctx.Provider>
+  );
 }
 
 export function useSessions(): SessionCtx {

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -4,6 +4,7 @@ import { BootstrapBanner, DiffBlock, Message, RewindMarker, ThinkingBlock, ToolB
 import { renderWithMentions } from './chat/markdown';
 import ProjectPicker from '../components/ProjectPicker';
 import { useSessions } from '../SessionContext';
+import { reconcileSessionMessages } from '../sessionPersistence';
 
 /* ---- Types ---- */
 
@@ -236,9 +237,8 @@ function flushPendingTabs(): void {
   if (pendingTabsToPersist) writePendingTabs();
 }
 
-/* Conversation/tab persistence is local (localStorage) and mirrors the top
- * SessionContext, which owns the session/tab list. Each tab's aimeeSid still
- * ties to its server-side session state for continuity within a session. */
+/* localStorage is a fast cache. SessionContext reconciles it with the
+ * authenticated user's server-owned session list and transcript. */
 
 function rulesBannerDismissedKey(root: string): string {
   return root ? `${RULES_BANNER_DISMISSED_KEY}:${root}` : RULES_BANNER_DISMISSED_KEY;
@@ -303,9 +303,8 @@ interface ActiveStreamRefs {
   /* aimeeSid of the tab that owns this stream. Captured at send time so SSE
    * events (notably the provider `session` id) are applied to the originating
    * tab — never to whatever tab happens to be active when the event arrives.
-   * Without this, switching tabs mid-stream cross-writes the provider sid onto
-   * the wrong tab, and since claude_session_id outranks aimee_session_id on the
-   * server the two conversations then merge into one. */
+   * Without this, switching tabs mid-stream cross-writes provider metadata onto
+   * the wrong tab and corrupts the browser's restored-session cache. */
   originSid: string;
 }
 
@@ -1337,20 +1336,47 @@ export default function Chat() {
   const activeSessionId = activeSession?.id ?? '';
   const sessionProject = activeSession?.projectRoot ?? '';
 
-  // Keep one conversation tab per session: adopt an existing tab (preserving its
-  // messages/sids), migrate a legacy untagged tab, or create a fresh one.
+  // Keep one conversation tab per account-scoped session. Match both the UI id
+  // and stable aimee id so legacy browser-only tabs migrate without duplication.
   useEffect(() => {
     if (!sessions.length) return;
     setTabs(prev => {
       const byId = new Map(prev.filter(t => t.sessionId).map(t => [t.sessionId as string, t]));
+      const byAimeeId = new Map(prev.filter(t => t.aimeeSid).map(t => [t.aimeeSid, t]));
       const untagged = prev.filter(t => !t.sessionId);
       let u = 0;
       const next = sessions.map((s, i) => {
-        const existing = byId.get(s.id);
-        if (existing) return existing.title === s.name ? existing : { ...existing, title: s.name };
+        const existing = byId.get(s.id) ?? byAimeeId.get(s.aimeeSid);
+        if (existing) {
+          const messages = reconcileSessionMessages(existing.messages, s.messages);
+          if (existing.sessionId === s.id && existing.title === s.name &&
+              existing.aimeeSid === s.aimeeSid && messages === existing.messages &&
+              (!s.claudeSid || existing.sid === s.claudeSid)) return existing;
+          return {
+            ...existing,
+            sessionId: s.id,
+            title: s.name,
+            messages,
+            sid: s.claudeSid || existing.sid,
+            aimeeSid: s.aimeeSid,
+          };
+        }
         const adopt = untagged[u++];
-        if (adopt) return { ...adopt, sessionId: s.id, title: s.name };
-        return normalizeTab({ sessionId: s.id, title: s.name, messages: [], sid: '' }, i);
+        if (adopt) return {
+          ...adopt,
+          sessionId: s.id,
+          title: s.name,
+          messages: reconcileSessionMessages(adopt.messages, s.messages),
+          sid: s.claudeSid || adopt.sid,
+          aimeeSid: s.aimeeSid,
+        };
+        return normalizeTab({
+          sessionId: s.id,
+          title: s.name,
+          messages: s.messages,
+          sid: s.claudeSid,
+          aimeeSid: s.aimeeSid,
+        }, i);
       });
       // No-op if unchanged (avoid a render loop).
       if (next.length === prev.length && next.every((t, i) => t === prev[i])) return prev;
@@ -1525,9 +1551,9 @@ export default function Chat() {
     };
     // Always flush the coalesced tabs write when the page goes away or is hidden
     // — NOT just on beforeunload. bfcache navigation (back/forward) and OS
-    // background-kill on mobile don't fire beforeunload, and since the transcript
-    // restores SOLELY from localStorage, a dropped write shows up as a gap on
-    // reload. visibilitychange→hidden catches a backgrounded tab before a kill.
+    // background-kill on mobile don't fire beforeunload. Keeping this fast cache
+    // current also avoids waiting for a server refresh after bfcache navigation.
+    // visibilitychange→hidden catches a backgrounded tab before a kill.
     // Detach presence only on a GENUINE unload: a tab going to the background — or
     // entering bfcache (pagehide persisted=true, restored without re-mounting) —
     // is still an active session and must stay attached.
@@ -1755,9 +1781,8 @@ export default function Chat() {
     saveTabs(tabs);
   }, [tabs]);
 
-  /* (Server-session-as-tab-list restore was removed: the top SessionContext is
-   * now the source of truth for the session/tab list, mirrored locally. Each
-   * tab's aimeeSid still ties to its server-side session state.) */
+  /* SessionContext restores and refreshes the authenticated user's server-side
+   * session list; the reconciliation effect above maps it onto chat tabs. */
 
   useEffect(() => {
     if (activeIdx >= tabs.length) {
@@ -2081,6 +2106,28 @@ export default function Chat() {
     setStreamMsgs(msgs);
   }, [activeIdx]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // A server refresh can hydrate the currently selected session without
+  // changing its tab index (the normal fresh-browser case). Load that account-
+  // scoped transcript directly; later local stream updates do not retrigger this
+  // effect because SessionContext's server snapshot is unchanged.
+  useEffect(() => {
+    const serverMessages = activeSession?.messages;
+    if (!serverMessages) return;
+    const tab = tabsRef.current.find(candidate => candidate.sessionId === activeSessionId);
+    // A non-empty shorter snapshot can be a focus refresh racing an active
+    // stream. An explicit empty transcript, however, is authoritative and must
+    // clear stale browser history restored from the local cache.
+    if (!tab || (serverMessages.length > 0 && serverMessages.length < tab.messages.length)) return;
+    if (sameTabMessages(tab.messages, serverMessages) &&
+        sameTabMessages(streamToTabMessages(streamMsgsRef.current), serverMessages)) return;
+    const hydrated = serverMessages.map(message => ({
+      id: nextId(), type: message.role, text: message.text,
+    }));
+    streamMsgsRef.current = hydrated;
+    renderedSidRef.current = tab.aimeeSid;
+    setStreamMsgs(hydrated);
+  }, [activeSessionId, activeSession?.messages, tabs[activeIdx]?.sessionId]);
+
   /* Save current tab messages back to tabs state */
   const saveTabMessages = useCallback((tabIndex: number, msgs: StreamMsg[]) => {
     const saved = streamToTabMessages(msgs);
@@ -2279,15 +2326,18 @@ export default function Chat() {
    * provider session (empty claude session id + new aimee session id) so the next
    * turn starts clean — no resume of a stale/gone session. */
   function clearChat() {
+    const nextAimeeSid = newAimeeSessionId();
     setStreamMsgs([]);
     setTabs(prev => {
       const next = [...prev];
       if (next[activeIdx]) {
-        next[activeIdx] = { ...next[activeIdx], sid: '', aimeeSid: newAimeeSessionId(), attachId: undefined, messages: [] };
+        next[activeIdx] = { ...next[activeIdx], sid: '', aimeeSid: nextAimeeSid, attachId: undefined, messages: [] };
       }
       return next;
     });
-    if (activeSession) patchSession(activeSession.id, { claudeSid: '', aimeeSid: '', attachId: '' });
+    if (activeSession) patchSession(activeSession.id, {
+      claudeSid: '', aimeeSid: nextAimeeSid, attachId: '', messages: [],
+    });
   }
 
   async function pauseWorkflow() {
@@ -2470,12 +2520,14 @@ export default function Chat() {
       (sendQueuesRef.current.get(activeSidForTitle)?.length ?? 0) > 0;
     if (!hasExistingMessages) {
       const title = text.substring(0, 30) + (text.length > 30 ? '…' : '');
+      const sessionId = tabsRef.current[idx]?.sessionId;
       setTabs(prev => {
         const next = [...prev];
         if (next[idx]) next[idx] = { ...next[idx], title };
         tabsRef.current = next;
         return next;
       });
+      if (sessionId) patchSession(sessionId, { name: title });
     }
 
     const userMsgId = nextId();
@@ -2579,7 +2631,6 @@ export default function Chat() {
         body: JSON.stringify({
           message: text,
           aimee_session_id: aimeeSid,
-          claude_session_id: activeTab?.sid ?? '',
           attach_id: attachId,
           cwd: projectRootRef.current,
         }),
@@ -2810,10 +2861,11 @@ export default function Chat() {
         const sid = String(data.id ?? '');
         // Apply the provider session id to the tab that OWNS this stream, located
         // by its stable aimeeSid — not activeIdxRef, which may have moved if the
-        // user switched tabs mid-turn. Cross-writing it merges two conversations
-        // because claude_session_id outranks aimee_session_id server-side.
+        // user switched tabs mid-turn. This is display/cache metadata only; the
+        // backend resumes from its authenticated server-side binding.
         const owner = streamRefs.originSid;
         if (owner) {
+          const sessionId = tabsRef.current.find(t => t.aimeeSid === owner)?.sessionId;
           setTabs(prev => {
             const idx = prev.findIndex(t => t.aimeeSid === owner);
             if (idx < 0) return prev;
@@ -2822,6 +2874,7 @@ export default function Chat() {
             tabsRef.current = next;
             return next;
           });
+          if (sessionId && sid) patchSession(sessionId, { claudeSid: sid });
         }
         break;
       }

--- a/frontend/src/sessionPersistence.test.ts
+++ b/frontend/src/sessionPersistence.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cacheBelongsToAccount,
+  legacyProviderAliasIDs,
+  mergePersistedSessions,
+  reconcileSessionMessages,
+  sessionsForLocalCache,
+  sessionsMissingFromServer,
+  shouldOfferOwnerlessCacheImport,
+  type SessionRecord,
+} from './sessionPersistence';
+
+function local(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'ui-1',
+    name: 'Local chat',
+    projectRoot: '/work/project',
+    projectName: 'project',
+    claudeSid: 'provider-old',
+    aimeeSid: 'web-stable',
+    attachId: 'browser-only-attachment',
+    messages: [{ role: 'user', text: 'hello' }],
+    ...overrides,
+  };
+}
+
+describe('account-scoped session persistence', () => {
+  it('never trusts an ownerless or differently-owned browser cache', () => {
+    expect(cacheBelongsToAccount('alice', '')).toBe(false);
+    expect(cacheBelongsToAccount('alice', 'bob')).toBe(false);
+    expect(cacheBelongsToAccount('', 'alice')).toBe(false);
+    expect(cacheBelongsToAccount('alice', 'alice')).toBe(true);
+  });
+
+  it('offers explicit ownerless import only for real legacy state', () => {
+    const pristine = local({
+      name: 'Session 1', projectRoot: '', projectName: '', claudeSid: '', messages: [],
+    });
+    expect(shouldOfferOwnerlessCacheImport('alice', '', [local()])).toBe(true);
+    expect(shouldOfferOwnerlessCacheImport('alice', '', [pristine])).toBe(false);
+    expect(shouldOfferOwnerlessCacheImport('alice', 'bob', [local()])).toBe(false);
+    expect(shouldOfferOwnerlessCacheImport('', '', [local()])).toBe(false);
+  });
+
+  it('hydrates a fresh browser with transcript and provider resume id', () => {
+    const got = mergePersistedSessions([], [{
+      id: 'web-stable',
+      title: 'Server chat',
+      cwd: '/work/project',
+      provider_session_id: 'provider-new',
+      messages: [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi back' },
+      ],
+    }], false);
+
+    expect(got).toEqual([{
+      id: 'web-stable',
+      name: 'Server chat',
+      projectRoot: '/work/project',
+      projectName: 'project',
+      claudeSid: 'provider-new',
+      aimeeSid: 'web-stable',
+      attachId: '',
+      messages: [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi back' },
+      ],
+    }]);
+  });
+
+  it('uses an explicit empty server transcript to clear stale browser history', () => {
+    const [got] = mergePersistedSessions([local()], [{
+      id: 'web-stable',
+      cwd: '/work/project',
+      messages: [],
+    }], false);
+
+    expect(got.messages).toEqual([]);
+    expect(reconcileSessionMessages(local().messages, [])).toEqual([]);
+  });
+
+  it('keeps a longer live transcript during a non-empty stale server refresh', () => {
+    const live = [
+      { role: 'user' as const, text: 'hello' },
+      { role: 'assistant' as const, text: 'still streaming' },
+    ];
+    expect(reconcileSessionMessages(live, [live[0]])).toBe(live);
+  });
+
+  it('preserves the local UI key while refreshing stable server state', () => {
+    const got = mergePersistedSessions([local()], [{
+      id: 'web-stable',
+      title: 'Renamed elsewhere',
+      provider_session_id: 'provider-new',
+      messages: [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi back' },
+      ],
+    }], false);
+
+    expect(got[0].id).toBe('ui-1');
+    expect(got[0].name).toBe('Renamed elsewhere');
+    expect(got[0].claudeSid).toBe('provider-new');
+    expect(got[0].attachId).toBe('');
+    expect(got[0].messages).toHaveLength(2);
+  });
+
+  it('drops local sessions deleted on another browser after migration', () => {
+    expect(mergePersistedSessions([local()], [], false)).toEqual([]);
+  });
+
+  it('identifies legacy browser-only chats for one-time upload', () => {
+    const missing = sessionsMissingFromServer([local()], []);
+    expect(missing.map(session => session.aimeeSid)).toEqual(['web-stable']);
+  });
+
+  it('seeds an existing metadata-only server row from the legacy browser transcript', () => {
+    const missing = sessionsMissingFromServer([local()], [{ id: 'web-stable', messages: [] }]);
+    expect(missing.map(session => session.aimeeSid)).toEqual(['web-stable']);
+  });
+
+  it('does not upload a pristine default tab during first-device restore', () => {
+    const pristine = local({
+      name: 'Session 1', projectRoot: '', projectName: '', claudeSid: '', messages: [],
+    });
+    expect(sessionsMissingFromServer([pristine], [])).toEqual([]);
+  });
+
+  it('drops a pristine placeholder alongside real legacy sessions', () => {
+    const pristine = local({
+      id: 'placeholder', aimeeSid: 'placeholder', name: 'Session 1', projectRoot: '',
+      projectName: '', claudeSid: '', messages: [],
+    });
+    expect(mergePersistedSessions([pristine, local()], [{ id: 'server-chat' }], true)
+      .map(session => session.aimeeSid)).toEqual(['server-chat', 'web-stable']);
+  });
+
+  it('bounds transcripts written to the browser cache', () => {
+    const messages = Array.from({ length: 250 }, (_, i) => ({
+      role: 'user' as const,
+      text: `${i}:` + 'x'.repeat(40_000),
+    }));
+    const [cached] = sessionsForLocalCache([local({ messages })]);
+    expect(cached.messages).toHaveLength(200);
+    expect(cached.messages[0].text.length).toBe(32 * 1024);
+    expect(cached.messages.at(-1)?.text.length).toBe(32 * 1024);
+  });
+
+  it('recognizes the provider-id rows written by older webchat builds', () => {
+    expect(legacyProviderAliasIDs([local()], [
+      { id: 'provider-old', title: 'legacy wrong-key row' },
+      { id: 'another-session' },
+    ])).toEqual(['provider-old']);
+  });
+});

--- a/frontend/src/sessionPersistence.ts
+++ b/frontend/src/sessionPersistence.ts
@@ -1,0 +1,162 @@
+export interface SessionMessage {
+  role: 'user' | 'assistant' | 'narration';
+  text: string;
+}
+
+export interface SessionRecord {
+  id: string;
+  name: string;
+  projectRoot: string;
+  projectName: string;
+  claudeSid: string;
+  aimeeSid: string;
+  attachId: string;
+  messages: SessionMessage[];
+}
+
+export interface PersistedChatSession {
+  id: string;
+  title?: string;
+  cwd?: string;
+  provider_session_id?: string;
+  messages?: SessionMessage[];
+  created_at?: string;
+  last_active?: string;
+}
+
+const cacheMessageLimit = 200;
+const cacheMessageTextLimit = 32 * 1024;
+
+// localStorage is only a fast/offline cache. Keep it bounded so an
+// account-scoped server transcript cannot exhaust the browser quota and make
+// every subsequent cache write fail silently.
+export function sessionsForLocalCache(sessions: SessionRecord[]): SessionRecord[] {
+  return sessions.map(session => ({
+    ...session,
+    messages: session.messages.slice(-cacheMessageLimit).map(message => ({
+      ...message,
+      text: message.text.slice(-cacheMessageTextLimit),
+    })),
+  }));
+}
+
+function validMessages(value: unknown): SessionMessage[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((message): message is SessionMessage => {
+    if (!message || typeof message !== 'object') return false;
+    const candidate = message as Partial<SessionMessage>;
+    return (candidate.role === 'user' || candidate.role === 'assistant' || candidate.role === 'narration') &&
+      typeof candidate.text === 'string';
+  });
+}
+
+// Reconcile a server snapshot with a live browser buffer. A non-empty shorter
+// snapshot can be a refresh racing an in-flight stream, but an explicit empty
+// snapshot is authoritative (for example, history cleared on another device).
+export function reconcileSessionMessages<T>(local: T[], server: T[]): T[] {
+  return server.length === 0 || server.length >= local.length ? server : local;
+}
+
+function preferMessages(local: SessionMessage[], server: unknown): SessionMessage[] {
+  if (!Array.isArray(server)) return local;
+  const remote = validMessages(server);
+  // Preserve the distinction between an absent transcript and an explicit
+  // empty transcript before applying the live-refresh race guard above.
+  return reconcileSessionMessages(local, remote);
+}
+
+function projectNameFromRoot(root: string): string {
+  const trimmed = root.replace(/[\\/]+$/, '');
+  const parts = trimmed.split(/[\\/]/);
+  return parts[parts.length - 1] || '';
+}
+
+export function isPristineDefaultSession(session: SessionRecord): boolean {
+  return session.messages.length === 0 && !session.projectRoot && !session.claudeSid &&
+    (session.name === 'Session 1' || session.name === 'Chat');
+}
+
+// Browser storage from older builds carried no username. It is never a safe
+// migration source on a shared browser: only a cache already stamped with the
+// currently authenticated account may be uploaded or merged as legacy state.
+export function cacheBelongsToAccount(username: string, cachedOwner: string): boolean {
+  return !!username && !!cachedOwner && username === cachedOwner;
+}
+
+export function shouldOfferOwnerlessCacheImport(
+  username: string,
+  cachedOwner: string,
+  sessions: SessionRecord[],
+): boolean {
+  return !!username && !cachedOwner && sessions.some(session => !isPristineDefaultSession(session));
+}
+
+// Reconcile the browser cache with the authenticated account's server state.
+// After the one-time legacy migration, absence on the server means deletion on
+// another browser and local-only rows are therefore dropped.
+export function mergePersistedSessions(
+  local: SessionRecord[],
+  server: PersistedChatSession[],
+  includeLegacyLocal: boolean,
+): SessionRecord[] {
+  const localByAimeeID = new Map(local.filter(s => s.aimeeSid).map(s => [s.aimeeSid, s]));
+  const merged: SessionRecord[] = [];
+
+  for (const remote of server) {
+    if (!remote.id || merged.some(s => s.aimeeSid === remote.id)) continue;
+    const cached = localByAimeeID.get(remote.id);
+    const projectRoot = remote.cwd || cached?.projectRoot || '';
+    merged.push({
+      id: cached?.id || remote.id,
+      name: remote.title?.trim() || cached?.name || 'Chat',
+      projectRoot,
+      projectName: remote.cwd
+        ? projectNameFromRoot(remote.cwd)
+        : cached?.projectName || projectNameFromRoot(projectRoot),
+      claudeSid: remote.provider_session_id || cached?.claudeSid || '',
+      aimeeSid: remote.id,
+      // Attachments are live browser surfaces and must never cross devices.
+      attachId: '',
+      messages: preferMessages(cached?.messages || [], remote.messages),
+    });
+    localByAimeeID.delete(remote.id);
+  }
+
+  if (includeLegacyLocal) {
+    for (const session of local) {
+      if (!localByAimeeID.has(session.aimeeSid)) continue;
+      if (server.length > 0 && isPristineDefaultSession(session)) continue;
+      merged.push(session);
+    }
+  }
+
+  return merged;
+}
+
+export function sessionsMissingFromServer(
+  local: SessionRecord[],
+  server: PersistedChatSession[],
+): SessionRecord[] {
+  const byID = new Map(server.map(session => [session.id, session]));
+  return local.filter(session => {
+    if (!session.aimeeSid || isPristineDefaultSession(session)) return false;
+    const remote = byID.get(session.aimeeSid);
+    if (!remote) return true;
+    const remoteMessages = validMessages(remote.messages);
+    return session.messages.length > 0 && remoteMessages.length === 0;
+  });
+}
+
+// Older webchat builds accidentally stored the provider-emitted thread id as
+// the session's primary key. A legacy local tab is the only place where both ids
+// still coexist, so identify those aliases during the one-time migration.
+export function legacyProviderAliasIDs(
+  local: SessionRecord[],
+  server: PersistedChatSession[],
+): string[] {
+  const providerIDs = new Set(local.map(session => session.claudeSid).filter(Boolean));
+  const stableIDs = new Set(local.map(session => session.aimeeSid).filter(Boolean));
+  return server
+    .map(session => session.id)
+    .filter(id => id && providerIDs.has(id) && !stableIDs.has(id));
+}

--- a/runtime-web/chat.go
+++ b/runtime-web/chat.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/RakuenSoftware/smoothgui/auth"
 )
 
 // pathWithin reports whether child is parent or a descendant of it (both cleaned).
@@ -133,26 +131,58 @@ func (s *server) handleChatSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	username := currentUser(r)
+	stableSID := strings.TrimSpace(req.AimeeSessionID)
+	providerSessionID := ""
+	// Bind the stable aimee session handle to the authenticated user before it
+	// crosses the trusted UDS boundary. A provider-native session event is a
+	// different id and must never replace this ownership key. The browser's
+	// claude_session_id field is retained for wire compatibility but is never a
+	// source of authority: resume metadata is loaded only from this user's
+	// server-side stable-session record.
+	if s.db != nil && stableSID != "" {
+		owned, exists, oerr := s.chatSessionOwned(username, stableSID)
+		if oerr != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to verify session")
+			return
+		}
+		if exists && !owned {
+			writeJSONError(w, http.StatusForbidden, "session belongs to another user")
+			return
+		}
+		if err := s.touchChatSession(username, stableSID, cwd, req.Message); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to persist session")
+			return
+		}
+		providerSessionID, err = s.chatSessionProviderID(username, stableSID)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to load session runtime")
+			return
+		}
+		if err := s.appendChatMessage(username, stableSID, "user", req.Message); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to persist message")
+			return
+		}
+	}
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
 	doneSent := false
-	// effectiveSID tracks the aimee conversation id for this turn: the one the
-	// SPA supplied, or the one aimee-server mints (delivered as a "session"
-	// event) for a brand-new tab. It is persisted against the logged-in user
-	// after the turn so the tab can be restored later.
-	effectiveSID := req.AimeeSessionID
+	var runtimePersistErr error
+	var assistantText strings.Builder
 	// Stream the chat over aimee-server's /v1 HTTP transport (native
 	// POST /v1/chat/stream); the legacy NDJSON socket helper (chatStream)
 	// remains available as a fallback.
-	err = chatStreamHTTP(r.Context(), s.cfg.socketPath, req.Message, req.AimeeSessionID,
-		req.ClaudeSessionID, cwd, req.AttachID, func(evt streamEvent) {
+	err = chatStreamHTTP(r.Context(), s.cfg.socketPath, req.Message, stableSID,
+		providerSessionID, cwd, req.AttachID, func(evt streamEvent) {
 			switch evt.Event {
 			case "turn_start":
 				sseWrite(w, "turn_start", map[string]any{})
 			case "text":
+				assistantText.WriteString(evt.Content)
 				sseWrite(w, "text", map[string]string{"content": evt.Content})
 			case "thinking":
 				sseWrite(w, "thinking", map[string]string{"content": evt.Content})
@@ -160,7 +190,19 @@ func (s *server) handleChatSend(w http.ResponseWriter, r *http.Request) {
 				sseWrite(w, "turn_end", map[string]any{})
 			case "session":
 				if evt.ID != "" {
-					effectiveSID = evt.ID
+					// The streamed id is trusted server output. Bind it before
+					// exposing the session event (and therefore before `done`) so
+					// an immediately queued next turn cannot race into a fresh
+					// provider conversation.
+					if stableSID != "" {
+						if uerr := s.setChatSessionRuntime(username, stableSID, evt.ID); uerr != nil {
+							runtimePersistErr = uerr
+							log.Printf("aimee-webchat: persist runtime for %q: %v", stableSID, uerr)
+							sseWrite(w, "error", map[string]string{"message": "failed to persist session runtime"})
+							return
+						}
+					}
+					providerSessionID = evt.ID
 				}
 				sseWrite(w, "session", map[string]string{"id": evt.ID})
 			case "usage":
@@ -175,8 +217,10 @@ func (s *server) handleChatSend(w http.ResponseWriter, r *http.Request) {
 					"usage_kind": kind,
 				})
 			case "done":
-				doneSent = true
-				sseWrite(w, "done", map[string]any{})
+				if runtimePersistErr == nil {
+					doneSent = true
+					sseWrite(w, "done", map[string]any{})
+				}
 			case "error":
 				msg := evt.Message
 				if msg == "" {
@@ -189,21 +233,23 @@ func (s *server) handleChatSend(w http.ResponseWriter, r *http.Request) {
 			}
 		})
 
+	// Store the visible assistant turn and the provider-native resume id under
+	// the stable, user-owned aimee session id. This is best-effort because the
+	// response may already have streamed, but failures are visible in logs.
+	if stableSID != "" {
+		if text := assistantText.String(); text != "" {
+			if uerr := s.appendChatMessage(username, stableSID, "assistant", text); uerr != nil {
+				log.Printf("aimee-webchat: persist reply for %q: %v", stableSID, uerr)
+			}
+		}
+	}
 	if r.Context().Err() != nil {
 		return
-	}
-	// Record this tab's session against the logged-in user so it survives a
-	// browser/laptop crash and can be restored from /api/chat/threads. The
-	// conversation itself already lives on aimee-server; this only persists the
-	// ownership + lightweight metadata. Best-effort: a failure here must not
-	// break the chat response that already streamed.
-	if uerr := s.touchChatSession(currentUser(r), effectiveSID, cwd, req.Message); uerr != nil {
-		log.Printf("aimee-runtime-web: persist session %q: %v", effectiveSID, uerr)
 	}
 	if err != nil {
 		sseWrite(w, "error", map[string]string{"message": err.Error()})
 	}
-	if !doneSent {
+	if !doneSent && runtimePersistErr == nil {
 		sseWrite(w, "done", map[string]any{})
 	}
 }
@@ -505,9 +551,9 @@ func isAPIPath(path string) bool {
 	return len(path) >= 4 && path[:4] == "/api"
 }
 
-// handleMe returns the authenticated user's info.
+// handleMe returns the authenticated identity used to scope chat persistence
+// and browser-cache ownership. requireAuth injects this trusted value.
 func (s *server) handleMe(w http.ResponseWriter, r *http.Request) {
-	username := auth.GetUsername(r)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"username": username})
+	json.NewEncoder(w).Encode(map[string]string{"username": currentUser(r)})
 }

--- a/runtime-web/chat_sessions.go
+++ b/runtime-web/chat_sessions.go
@@ -4,19 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 )
 
 // Per-user chat-session persistence. A "session" here is one browser tab's
-// conversation: identified by the aimee-server conversation id (the same value
-// the SPA sends as aimee_session_id and aimee-server echoes back in the
-// "session" stream event). The conversation history itself lives on
-// aimee-server; this table is webchat's durable record of WHICH sessions belong
-// to WHICH logged-in user, so a user can reopen their browser after a crash and
-// restore every tab they had open. Rows are scoped by the authenticated
-// username so users only ever see and restore their own tabs.
+// conversation: identified by the stable id the SPA sends as aimee_session_id.
+// The provider-native id emitted by the "session" stream event is separate and
+// is persisted only as resume metadata. Rows are scoped by the authenticated
+// username so users only ever see and restore their own tabs and transcript.
 
 type ctxKey string
 
@@ -46,6 +44,24 @@ var chatSessionMigrations = []string{
 		last_active TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_chat_sessions_user ON chat_sessions(username, last_active DESC)`,
+	`CREATE TABLE IF NOT EXISTS chat_session_runtime (
+		session_id          TEXT PRIMARY KEY,
+		username            TEXT NOT NULL,
+		provider_session_id TEXT NOT NULL DEFAULT ''
+	)`,
+	`CREATE TABLE IF NOT EXISTS chat_session_messages (
+		id         INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		username   TEXT NOT NULL,
+		role       TEXT NOT NULL,
+		text       TEXT NOT NULL,
+		created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+	)`,
+	`CREATE INDEX IF NOT EXISTS idx_chat_session_messages
+		ON chat_session_messages(username, session_id, id)`,
+	`CREATE TABLE IF NOT EXISTS chat_session_schema_migrations (
+		version INTEGER PRIMARY KEY
+	)`,
 }
 
 func applyChatSessionMigrations(db *sql.DB) error {
@@ -54,16 +70,53 @@ func applyChatSessionMigrations(db *sql.DB) error {
 			return err
 		}
 	}
-	return nil
+	return migrateLegacyChatSessionRuntime(db)
+}
+
+// Version 1 upgrades rows written by the old webchat implementation. That
+// implementation replaced the stable browser id with the provider-emitted id
+// before inserting chat_sessions, so each pre-existing row id is trusted
+// provider resume metadata already captured by the server. Snapshot those rows
+// exactly once; rerunning this migration must never classify a newly-created
+// stable web id as a provider id.
+func migrateLegacyChatSessionRuntime(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var applied int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM chat_session_schema_migrations
+		WHERE version = 1`).Scan(&applied); err != nil {
+		return err
+	}
+	if applied == 0 {
+		if _, err := tx.Exec(`INSERT OR IGNORE INTO chat_session_runtime
+			(session_id, username, provider_session_id)
+			SELECT id, username, id FROM chat_sessions`); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`INSERT INTO chat_session_schema_migrations (version) VALUES (1)`); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // chatSession is the durable record of one tab's session for a user.
 type chatSession struct {
-	ID         string `json:"id"`
-	Title      string `json:"title"`
-	Cwd        string `json:"cwd,omitempty"`
-	CreatedAt  string `json:"created_at"`
-	LastActive string `json:"last_active"`
+	ID                string        `json:"id"`
+	Title             string        `json:"title"`
+	Cwd               string        `json:"cwd,omitempty"`
+	ProviderSessionID string        `json:"provider_session_id,omitempty"`
+	Messages          []chatMessage `json:"messages"`
+	CreatedAt         string        `json:"created_at"`
+	LastActive        string        `json:"last_active"`
+}
+
+type chatMessage struct {
+	Role string `json:"role"`
+	Text string `json:"text"`
 }
 
 const sessionTitleMaxLen = 80
@@ -104,6 +157,237 @@ func (s *server) touchChatSession(username, id, cwd, firstMessage string) error 
 	return err
 }
 
+// chatSessionOwned reports whether id exists and belongs to username. Session
+// ids are bearer-like handles at the aimee-server boundary, so webchat must bind
+// each handle to the authenticated account before it forwards a continuation.
+func (s *server) chatSessionOwned(username, id string) (owned, exists bool, err error) {
+	if s == nil || s.db == nil || username == "" || id == "" {
+		return false, false, nil
+	}
+	var owner string
+	err = s.db.QueryRow(`SELECT username FROM chat_sessions WHERE id = ?`, id).Scan(&owner)
+	switch err {
+	case nil:
+		return owner == username, true, nil
+	case sql.ErrNoRows:
+		return false, false, nil
+	default:
+		return false, false, err
+	}
+}
+
+// setChatSessionRuntime persists the provider-native thread/session id needed to
+// resume a restored chat on another computer. The stable web session id remains
+// the chat_sessions key; provider ids must never replace it.
+func (s *server) setChatSessionRuntime(username, id, providerSessionID string) error {
+	if s == nil || s.db == nil || username == "" || id == "" {
+		return nil
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO chat_session_runtime (session_id, username, provider_session_id)
+		SELECT ?, ?, ?
+		 WHERE EXISTS (SELECT 1 FROM chat_sessions WHERE id = ? AND username = ?)
+		ON CONFLICT(session_id) DO UPDATE SET
+			provider_session_id = CASE
+				WHEN excluded.provider_session_id != '' THEN excluded.provider_session_id
+				ELSE chat_session_runtime.provider_session_id END
+		WHERE chat_session_runtime.username = excluded.username`,
+		id, username, providerSessionID, id, username)
+	return err
+}
+
+// chatSessionProviderID returns resume metadata only when it is already bound
+// to the authenticated user's stable session. Provider-native ids are opaque
+// bearer-like handles, so callers must never substitute a value supplied by the
+// browser here.
+func (s *server) chatSessionProviderID(username, id string) (string, error) {
+	if s == nil || s.db == nil || username == "" || id == "" {
+		return "", nil
+	}
+	var providerSessionID string
+	err := s.db.QueryRow(`SELECT provider_session_id FROM chat_session_runtime
+		WHERE session_id = ? AND username = ?`, id, username).Scan(&providerSessionID)
+	switch err {
+	case nil:
+		return providerSessionID, nil
+	case sql.ErrNoRows:
+		return "", nil
+	default:
+		return "", err
+	}
+}
+
+// upsertChatSessionWithLegacyRuntime atomically creates/updates a stable target
+// row and moves a provider binding from an old provider-keyed row. The browser
+// supplies only the alias selector; the provider id itself comes from the
+// server's one-shot legacy migration and must equal that owned alias row.
+// Invalid aliases roll the whole operation back, so a rejected migration cannot
+// strand a ghost target session.
+func (s *server) upsertChatSessionWithLegacyRuntime(username, targetID, aliasID, title, cwd, now string) (bool, error) {
+	if s == nil || s.db == nil || username == "" || targetID == "" || aliasID == "" || targetID == aliasID {
+		return false, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	var providerSessionID string
+	err = tx.QueryRow(`SELECT runtime.provider_session_id
+		FROM chat_sessions AS legacy
+		JOIN chat_session_runtime AS runtime
+		  ON runtime.session_id = legacy.id AND runtime.username = legacy.username
+		WHERE legacy.id = ? AND legacy.username = ?
+		  AND runtime.provider_session_id = legacy.id`, aliasID, username).Scan(&providerSessionID)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var targetOwner string
+	err = tx.QueryRow(`SELECT username FROM chat_sessions WHERE id = ?`, targetID).Scan(&targetOwner)
+	if err != nil && err != sql.ErrNoRows {
+		return false, err
+	}
+	if err == nil && targetOwner != username {
+		return false, nil
+	}
+	if _, err := tx.Exec(`INSERT INTO chat_sessions
+		(id, username, title, cwd, created_at, last_active)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			last_active = excluded.last_active,
+			cwd   = CASE WHEN excluded.cwd   != '' THEN excluded.cwd   ELSE chat_sessions.cwd   END,
+			title = CASE WHEN excluded.title != '' THEN excluded.title ELSE chat_sessions.title END
+		WHERE chat_sessions.username = excluded.username`,
+		targetID, username, title, cwd, now, now); err != nil {
+		return false, err
+	}
+	result, err := tx.Exec(`INSERT INTO chat_session_runtime
+		(session_id, username, provider_session_id)
+		SELECT ?, ?, ? WHERE EXISTS
+		(SELECT 1 FROM chat_sessions WHERE id = ? AND username = ?)
+		ON CONFLICT(session_id) DO UPDATE SET
+			provider_session_id = CASE
+				WHEN chat_session_runtime.provider_session_id = '' THEN excluded.provider_session_id
+				ELSE chat_session_runtime.provider_session_id END
+		WHERE chat_session_runtime.username = excluded.username`,
+		targetID, username, providerSessionID, targetID, username)
+	if err != nil {
+		return false, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if changed == 0 {
+		return false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *server) appendChatMessage(username, id, role, text string) error {
+	if s == nil || s.db == nil || username == "" || id == "" || text == "" {
+		return nil
+	}
+	if role != "user" && role != "assistant" && role != "narration" {
+		return nil
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO chat_session_messages (session_id, username, role, text)
+		SELECT ?, ?, ?, ?
+		 WHERE EXISTS (SELECT 1 FROM chat_sessions WHERE id = ? AND username = ?)`,
+		id, username, role, text, id, username)
+	return err
+}
+
+const (
+	chatSessionSeedMaxMessages = 2000
+	chatSessionSeedMaxBytes    = 8 * 1024 * 1024
+)
+
+// seedChatMessages imports a legacy browser-only transcript once. Existing
+// server history always wins, which prevents a stale browser from overwriting a
+// conversation that another browser has advanced.
+func (s *server) seedChatMessages(username, id string, messages []chatMessage) error {
+	if s == nil || s.db == nil || username == "" || id == "" || len(messages) == 0 {
+		return nil
+	}
+	if len(messages) > chatSessionSeedMaxMessages {
+		return fmt.Errorf("too many messages")
+	}
+	total := 0
+	for _, msg := range messages {
+		if msg.Role != "user" && msg.Role != "assistant" && msg.Role != "narration" {
+			return fmt.Errorf("invalid message role")
+		}
+		total += len(msg.Text)
+		if total > chatSessionSeedMaxBytes {
+			return fmt.Errorf("transcript too large")
+		}
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM chat_session_messages
+		WHERE session_id = ? AND username = ?`, id, username).Scan(&count); err != nil {
+		return err
+	}
+	if count != 0 {
+		return tx.Commit()
+	}
+	stmt, err := tx.Prepare(`INSERT INTO chat_session_messages
+		(session_id, username, role, text)
+		SELECT ?, ?, ?, ? WHERE EXISTS
+		(SELECT 1 FROM chat_sessions WHERE id = ? AND username = ?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	for _, msg := range messages {
+		if msg.Text == "" {
+			continue
+		}
+		if _, err := stmt.Exec(id, username, msg.Role, msg.Text, id, username); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *server) loadChatSessionDetails(username string, cs *chatSession) error {
+	if s == nil || s.db == nil || cs == nil {
+		return nil
+	}
+	cs.Messages = []chatMessage{}
+	_ = s.db.QueryRow(`SELECT provider_session_id FROM chat_session_runtime
+		WHERE session_id = ? AND username = ?`, cs.ID, username).Scan(&cs.ProviderSessionID)
+	rows, err := s.db.Query(`SELECT role, text FROM (
+		SELECT id, role, text FROM chat_session_messages
+		 WHERE session_id = ? AND username = ? ORDER BY id DESC LIMIT ?
+	) ORDER BY id`, cs.ID, username, chatSessionSeedMaxMessages)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var msg chatMessage
+		if err := rows.Scan(&msg.Role, &msg.Text); err != nil {
+			return err
+		}
+		cs.Messages = append(cs.Messages, msg)
+	}
+	return rows.Err()
+}
+
 // getChatSession loads one session owned by the user, or (nil, nil) if absent.
 func (s *server) getChatSession(username, id string) (*chatSession, error) {
 	if s == nil || s.db == nil || username == "" || id == "" {
@@ -115,6 +399,9 @@ func (s *server) getChatSession(username, id string) (*chatSession, error) {
 	var cs chatSession
 	switch err := row.Scan(&cs.ID, &cs.Title, &cs.Cwd, &cs.CreatedAt, &cs.LastActive); err {
 	case nil:
+		if err := s.loadChatSessionDetails(username, &cs); err != nil {
+			return nil, err
+		}
 		return &cs, nil
 	case sql.ErrNoRows:
 		return nil, nil
@@ -144,7 +431,18 @@ func (s *server) listChatSessions(username string) ([]chatSession, error) {
 		}
 		out = append(out, cs)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+	if err := rows.Close(); err != nil {
+		return out, err
+	}
+	for i := range out {
+		if err := s.loadChatSessionDetails(username, &out[i]); err != nil {
+			return out, err
+		}
+	}
+	return out, nil
 }
 
 // handleChatSessionsList (GET /api/chat/sessions) returns the authenticated
@@ -200,6 +498,8 @@ func (s *server) handleChatSessionGet(w http.ResponseWriter, r *http.Request) {
 		out["exists"] = true
 		out["title"] = cs.Title
 		out["cwd"] = cs.Cwd
+		out["provider_session_id"] = cs.ProviderSessionID
+		out["messages"] = cs.Messages
 		out["created_at"] = cs.CreatedAt
 		out["last_active"] = cs.LastActive
 	}
@@ -209,11 +509,13 @@ func (s *server) handleChatSessionGet(w http.ResponseWriter, r *http.Request) {
 func (s *server) handleChatSessionUpsert(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var req struct {
-		ID             string `json:"id"`
-		Sid            string `json:"sid"`
-		AimeeSessionID string `json:"aimee_session_id"`
-		Title          string `json:"title"`
-		Cwd            string `json:"cwd"`
+		ID             string         `json:"id"`
+		Sid            string         `json:"sid"`
+		AimeeSessionID string         `json:"aimee_session_id"`
+		Title          string         `json:"title"`
+		Cwd            string         `json:"cwd"`
+		LegacyAliasID  string         `json:"legacy_provider_alias_id"`
+		Messages       *[]chatMessage `json:"messages"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "bad request")
@@ -229,22 +531,54 @@ func (s *server) handleChatSessionUpsert(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
+	owned, exists, err := s.chatSessionOwned(username, id)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to verify session")
+		return
+	}
+	if exists && !owned {
+		writeJSONError(w, http.StatusConflict, "session id belongs to another user")
+		return
+	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	// Explicit upsert: unlike the send-path touch, an explicitly supplied title
 	// overwrites (this is the rename path). An empty title leaves any existing
 	// title untouched.
-	if _, err := s.db.Exec(`
-		INSERT INTO chat_sessions (id, username, title, cwd, created_at, last_active)
-		VALUES (?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
-			last_active = excluded.last_active,
-			cwd   = CASE WHEN excluded.cwd   != '' THEN excluded.cwd   ELSE chat_sessions.cwd   END,
-			title = CASE WHEN excluded.title != '' THEN excluded.title ELSE chat_sessions.title END
-		WHERE chat_sessions.username = excluded.username`,
+	aliasID := strings.TrimSpace(req.LegacyAliasID)
+	if aliasID != "" {
+		transferred, err := s.upsertChatSessionWithLegacyRuntime(username, id, aliasID,
+			strings.TrimSpace(req.Title), req.Cwd, now)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to migrate session runtime")
+			return
+		}
+		if !transferred {
+			writeJSONError(w, http.StatusConflict, "legacy session alias is not owned by this user")
+			return
+		}
+	} else if _, err := s.db.Exec(`
+			INSERT INTO chat_sessions (id, username, title, cwd, created_at, last_active)
+			VALUES (?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				last_active = excluded.last_active,
+				cwd   = CASE WHEN excluded.cwd   != '' THEN excluded.cwd   ELSE chat_sessions.cwd   END,
+				title = CASE WHEN excluded.title != '' THEN excluded.title ELSE chat_sessions.title END
+			WHERE chat_sessions.username = excluded.username`,
 		id, username, strings.TrimSpace(req.Title), req.Cwd, now, now); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to save session")
 		return
+	}
+	owned, _, err = s.chatSessionOwned(username, id)
+	if err != nil || !owned {
+		writeJSONError(w, http.StatusConflict, "session id belongs to another user")
+		return
+	}
+	if req.Messages != nil {
+		if err := s.seedChatMessages(username, id, *req.Messages); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 
 	cs, err := s.getChatSession(username, id)
@@ -263,8 +597,20 @@ func (s *server) handleChatSessionDelete(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if s.db != nil {
-		if _, err := s.db.Exec(`DELETE FROM chat_sessions WHERE id = ? AND username = ?`,
-			sid, currentUser(r)); err != nil {
+		username := currentUser(r)
+		tx, err := s.db.Begin()
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to delete session")
+			return
+		}
+		defer tx.Rollback()
+		if _, err = tx.Exec(`DELETE FROM chat_session_messages WHERE session_id = ? AND username = ?`, sid, username); err == nil {
+			_, err = tx.Exec(`DELETE FROM chat_session_runtime WHERE session_id = ? AND username = ?`, sid, username)
+		}
+		if err == nil {
+			_, err = tx.Exec(`DELETE FROM chat_sessions WHERE id = ? AND username = ?`, sid, username)
+		}
+		if err != nil || tx.Commit() != nil {
 			writeJSONError(w, http.StatusInternalServerError, "failed to delete session")
 			return
 		}

--- a/runtime-web/chat_sessions_test.go
+++ b/runtime-web/chat_sessions_test.go
@@ -33,6 +33,43 @@ func asUser(r *http.Request, username string) *http.Request {
 	return withUser(r, username)
 }
 
+func TestApplyChatSessionMigrationsPromotesOnlyPreexistingLegacyRows(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE chat_sessions (
+		id TEXT PRIMARY KEY, username TEXT NOT NULL, title TEXT NOT NULL DEFAULT '',
+		cwd TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, last_active TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("old schema: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO chat_sessions
+		(id, username, created_at, last_active) VALUES
+		('legacy-provider-id', 'alice', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("legacy row: %v", err)
+	}
+	if err := applyChatSessionMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	s := &server{db: db}
+	if got, err := s.chatSessionProviderID("alice", "legacy-provider-id"); err != nil || got != "legacy-provider-id" {
+		t.Fatalf("legacy runtime = %q, err=%v", got, err)
+	}
+
+	if err := s.touchChatSession("alice", "web-stable-id", "", "new chat"); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	if err := applyChatSessionMigrations(db); err != nil {
+		t.Fatalf("repeat migrate: %v", err)
+	}
+	if got, err := s.chatSessionProviderID("alice", "web-stable-id"); err != nil || got != "" {
+		t.Fatalf("new stable id was misclassified as provider id: %q, err=%v", got, err)
+	}
+}
+
 func TestTouchAndListChatSessions(t *testing.T) {
 	s := newSessionTestServer(t)
 
@@ -112,6 +149,57 @@ func TestTouchChatSessionScopedByUser(t *testing.T) {
 	}
 }
 
+func TestChatSessionRestoresTranscriptAndProviderID(t *testing.T) {
+	s := newSessionTestServer(t)
+	if err := s.touchChatSession("alice", "stable-web-id", "/proj", "hello"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	if err := s.setChatSessionRuntime("alice", "stable-web-id", "provider-thread-7"); err != nil {
+		t.Fatalf("runtime: %v", err)
+	}
+	if err := s.appendChatMessage("alice", "stable-web-id", "user", "hello"); err != nil {
+		t.Fatalf("append user: %v", err)
+	}
+	if err := s.appendChatMessage("alice", "stable-web-id", "assistant", "hi back"); err != nil {
+		t.Fatalf("append assistant: %v", err)
+	}
+
+	cs, err := s.getChatSession("alice", "stable-web-id")
+	if err != nil || cs == nil {
+		t.Fatalf("get: %v %+v", err, cs)
+	}
+	if cs.ProviderSessionID != "provider-thread-7" {
+		t.Fatalf("provider session = %q", cs.ProviderSessionID)
+	}
+	if len(cs.Messages) != 2 || cs.Messages[0].Role != "user" || cs.Messages[0].Text != "hello" ||
+		cs.Messages[1].Role != "assistant" || cs.Messages[1].Text != "hi back" {
+		t.Fatalf("messages = %+v", cs.Messages)
+	}
+	if bob, err := s.getChatSession("bob", "stable-web-id"); err != nil || bob != nil {
+		t.Fatalf("bob read alice session: err=%v session=%+v", err, bob)
+	}
+}
+
+func TestSeedChatMessagesDoesNotOverwriteServerHistory(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "sess-1", "", "server turn")
+	if err := s.seedChatMessages("alice", "sess-1", []chatMessage{
+		{Role: "user", Text: "legacy user"},
+		{Role: "assistant", Text: "legacy answer"},
+	}); err != nil {
+		t.Fatalf("initial seed: %v", err)
+	}
+	if err := s.seedChatMessages("alice", "sess-1", []chatMessage{
+		{Role: "user", Text: "stale overwrite"},
+	}); err != nil {
+		t.Fatalf("repeat seed: %v", err)
+	}
+	cs, _ := s.getChatSession("alice", "sess-1")
+	if cs == nil || len(cs.Messages) != 2 || cs.Messages[0].Text != "legacy user" {
+		t.Fatalf("server transcript overwritten: %+v", cs)
+	}
+}
+
 func TestHandleChatSessionsListReturnsUserSessions(t *testing.T) {
 	s := newSessionTestServer(t)
 	_ = s.touchChatSession("alice", "sess-1", "/a", "hello there")
@@ -175,6 +263,99 @@ func TestHandleChatSessionUpsertAndGet(t *testing.T) {
 	}
 }
 
+func TestHandleChatSessionUpsertSeedsCrossBrowserStateWithoutTrustingProviderID(t *testing.T) {
+	s := newSessionTestServer(t)
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/session", strings.NewReader(
+		`{"id":"stable-id","title":"My chat","provider_session_id":"provider-id",`+
+			`"messages":[{"role":"user","text":"question"},{"role":"assistant","text":"answer"}]}`)), "alice")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rr.Code, rr.Body.String())
+	}
+	var got chatSession
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != "stable-id" || got.ProviderSessionID != "" || len(got.Messages) != 2 {
+		t.Fatalf("restorable session = %+v", got)
+	}
+}
+
+func TestHandleChatSessionUpsertTransfersServerTrustedLegacyAlias(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "legacy-provider-id", "", "old chat")
+	_ = s.setChatSessionRuntime("alice", "legacy-provider-id", "legacy-provider-id")
+
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/session", strings.NewReader(
+		`{"id":"web-stable-id","legacy_provider_alias_id":"legacy-provider-id",`+
+			`"messages":[{"role":"user","text":"old chat"}]}`)), "alice")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rr.Code, rr.Body.String())
+	}
+	cs, err := s.getChatSession("alice", "web-stable-id")
+	if err != nil || cs == nil || cs.ProviderSessionID != "legacy-provider-id" || len(cs.Messages) != 1 {
+		t.Fatalf("transferred session: err=%v session=%+v", err, cs)
+	}
+}
+
+func TestHandleChatSessionUpsertRejectsUntrustedLegacyAlias(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "unbound-alias", "", "old chat")
+
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/session", strings.NewReader(
+		`{"id":"web-stable-id","legacy_provider_alias_id":"unbound-alias"}`)), "alice")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (%s)", rr.Code, rr.Body.String())
+	}
+	if got, err := s.chatSessionProviderID("alice", "web-stable-id"); err != nil || got != "" {
+		t.Fatalf("untrusted alias established runtime %q, err=%v", got, err)
+	}
+	if cs, err := s.getChatSession("alice", "web-stable-id"); err != nil || cs != nil {
+		t.Fatalf("rejected alias left a target row: err=%v session=%+v", err, cs)
+	}
+}
+
+func TestHandleChatSessionUpsertRejectsAnotherUsersLegacyAlias(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "alice-provider-id", "", "alice chat")
+	_ = s.setChatSessionRuntime("alice", "alice-provider-id", "alice-provider-id")
+
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/session", strings.NewReader(
+		`{"id":"bob-stable-id","legacy_provider_alias_id":"alice-provider-id"}`)), "bob")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (%s)", rr.Code, rr.Body.String())
+	}
+	if got, err := s.chatSessionProviderID("bob", "bob-stable-id"); err != nil || got != "" {
+		t.Fatalf("cross-user alias established runtime %q, err=%v", got, err)
+	}
+	if cs, err := s.getChatSession("bob", "bob-stable-id"); err != nil || cs != nil {
+		t.Fatalf("cross-user alias left a target row: err=%v session=%+v", err, cs)
+	}
+}
+
+func TestHandleChatSessionUpsertRejectsAnotherUsersID(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "shared-id", "", "alice")
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/session",
+		strings.NewReader(`{"id":"shared-id","title":"hijacked"}`)), "bob")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (%s)", rr.Code, rr.Body.String())
+	}
+	cs, _ := s.getChatSession("alice", "shared-id")
+	if cs == nil || cs.Title == "hijacked" {
+		t.Fatalf("alice session mutated: %+v", cs)
+	}
+}
+
 func TestHandleChatSessionRenameOverwritesTitle(t *testing.T) {
 	s := newSessionTestServer(t)
 	_ = s.touchChatSession("alice", "sess-1", "/a", "auto derived title")
@@ -195,6 +376,8 @@ func TestHandleChatSessionRenameOverwritesTitle(t *testing.T) {
 func TestHandleChatSessionDelete(t *testing.T) {
 	s := newSessionTestServer(t)
 	_ = s.touchChatSession("alice", "sess-1", "/a", "to be deleted")
+	_ = s.setChatSessionRuntime("alice", "sess-1", "provider-1")
+	_ = s.appendChatMessage("alice", "sess-1", "user", "to be deleted")
 
 	rr := httptest.NewRecorder()
 	req := asUser(httptest.NewRequest(http.MethodDelete, "/api/chat/session?sid=sess-1", nil), "alice")
@@ -204,6 +387,12 @@ func TestHandleChatSessionDelete(t *testing.T) {
 	}
 	if cs, _ := s.getChatSession("alice", "sess-1"); cs != nil {
 		t.Fatalf("session not deleted: %+v", cs)
+	}
+	var messages, runtime int
+	_ = s.db.QueryRow(`SELECT COUNT(*) FROM chat_session_messages WHERE session_id = 'sess-1'`).Scan(&messages)
+	_ = s.db.QueryRow(`SELECT COUNT(*) FROM chat_session_runtime WHERE session_id = 'sess-1'`).Scan(&runtime)
+	if messages != 0 || runtime != 0 {
+		t.Fatalf("child state remains: messages=%d runtime=%d", messages, runtime)
 	}
 }
 

--- a/runtime-web/chat_test.go
+++ b/runtime-web/chat_test.go
@@ -21,6 +21,18 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+type observingResponseRecorder struct {
+	*httptest.ResponseRecorder
+	onWrite func([]byte)
+}
+
+func (r *observingResponseRecorder) Write(p []byte) (int, error) {
+	if r.onWrite != nil {
+		r.onWrite(p)
+	}
+	return r.ResponseRecorder.Write(p)
+}
+
 func TestHandleChatInitRulesCreatesRulesFile(t *testing.T) {
 	tmp := t.TempDir()
 
@@ -423,6 +435,34 @@ func TestOpenAIProxyTrustedSessionStampsPAMUser(t *testing.T) {
 	}
 }
 
+func TestHandleMeReturnsAuthenticatedUsername(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	for _, migration := range auth.Migrations {
+		if _, err := db.Exec(migration); err != nil {
+			t.Fatalf("auth migration: %v", err)
+		}
+	}
+	store := auth.NewSessionStore(db, time.Hour)
+	token, err := store.CreateSession("alice")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	s := &server{sessions: store}
+	handler := s.requireAuth(s.handleMe)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: token})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || strings.TrimSpace(rr.Body.String()) != `{"username":"alice"}` {
+		t.Fatalf("status=%d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
 func TestOpenAIProxyNoSecretStampsNothing(t *testing.T) {
 	// Without the configured secret, the proxy must NOT stamp trusted identity —
 	// and must still strip any spoofed X-Aimee-* headers so nothing untrusted
@@ -647,6 +687,115 @@ func TestChatStreamHTTPReadsNDJSONEvents(t *testing.T) {
 	// the stream and is not delivered as an event.
 	if len(events) != 5 {
 		t.Fatalf("events = %v, want 5", events)
+	}
+}
+
+func TestHandleChatSendPersistsStableUserSession(t *testing.T) {
+	workspace := t.TempDir()
+	var forwardedProviderID string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/workspace/projects", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"root":%q}`, workspace)
+	})
+	mux.HandleFunc("/v1/chat/stream", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode stream request: %v", err)
+		}
+		forwardedProviderID = body["claude_session_id"]
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"event":"turn_start"}`)
+		fmt.Fprintln(w, `{"event":"session","id":"provider-thread"}`)
+		fmt.Fprintln(w, `{"event":"text","content":"hello "}`)
+		fmt.Fprintln(w, `{"event":"text","content":"again"}`)
+		fmt.Fprintln(w, `{"event":"done"}`)
+		fmt.Fprintln(w, `{"status":"ok"}`)
+	})
+	cfg := startFakeV1(t, mux)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"), []byte("test-token\n"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	s := newSessionTestServer(t)
+	s.cfg = cfg
+
+	runtimeAtSessionEvent := ""
+	rr := &observingResponseRecorder{ResponseRecorder: httptest.NewRecorder()}
+	rr.onWrite = func(p []byte) {
+		if strings.Contains(string(p), "event: session") {
+			runtimeAtSessionEvent, _ = s.chatSessionProviderID("alice", "stable-web-id")
+		}
+	}
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/send", strings.NewReader(
+		`{"aimee_session_id":"stable-web-id","claude_session_id":"attacker-thread","message":"question"}`)), "alice")
+	s.handleChatSend(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rr.Code, rr.Body.String())
+	}
+
+	cs, err := s.getChatSession("alice", "stable-web-id")
+	if err != nil || cs == nil {
+		t.Fatalf("stable session missing: %v %+v", err, cs)
+	}
+	if cs.ProviderSessionID != "provider-thread" {
+		t.Fatalf("provider session = %q", cs.ProviderSessionID)
+	}
+	if forwardedProviderID != "" {
+		t.Fatalf("new session trusted client provider id %q", forwardedProviderID)
+	}
+	if runtimeAtSessionEvent != "provider-thread" {
+		t.Fatalf("runtime at browser session event = %q", runtimeAtSessionEvent)
+	}
+	if len(cs.Messages) != 2 || cs.Messages[0].Text != "question" || cs.Messages[1].Text != "hello again" {
+		t.Fatalf("messages = %+v", cs.Messages)
+	}
+	if wrong, _ := s.getChatSession("alice", "provider-thread"); wrong != nil {
+		t.Fatalf("provider id incorrectly became the stable key: %+v", wrong)
+	}
+}
+
+func TestHandleChatSendUsesOnlyServerBoundProviderSession(t *testing.T) {
+	workspace := t.TempDir()
+	var forwardedProviderID string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/workspace/projects", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"root":%q}`, workspace)
+	})
+	mux.HandleFunc("/v1/chat/stream", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode stream request: %v", err)
+		}
+		forwardedProviderID = body["claude_session_id"]
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"event":"done"}`)
+		fmt.Fprintln(w, `{"status":"ok"}`)
+	})
+	cfg := startFakeV1(t, mux)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"), []byte("test-token\n"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	s := newSessionTestServer(t)
+	s.cfg = cfg
+	if err := s.touchChatSession("alice", "stable-web-id", workspace, "first turn"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	if err := s.setChatSessionRuntime("alice", "stable-web-id", "trusted-provider-thread"); err != nil {
+		t.Fatalf("runtime: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/send", strings.NewReader(
+		`{"aimee_session_id":"stable-web-id","claude_session_id":"attacker-thread","message":"continue"}`)), "alice")
+	s.handleChatSend(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rr.Code, rr.Body.String())
+	}
+	if forwardedProviderID != "trusted-provider-thread" {
+		t.Fatalf("forwarded provider id = %q, want server-bound id", forwardedProviderID)
+	}
+	cs, err := s.getChatSession("alice", "stable-web-id")
+	if err != nil || cs == nil || cs.ProviderSessionID != "trusted-provider-thread" {
+		t.Fatalf("server runtime binding changed: err=%v session=%+v", err, cs)
 	}
 }
 

--- a/runtime-web/server.go
+++ b/runtime-web/server.go
@@ -183,7 +183,9 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/chat/rewind", s.requireAuth(s.handleChatRewind))
 
 	// User/auth management (session required)
-	mux.HandleFunc("/api/auth/me", auth.RequireAuth(s.sessions, http.HandlerFunc(s.handleMe)).ServeHTTP)
+	// Use the same middleware/context as the account-scoped chat endpoints so
+	// cache ownership and persistence are always keyed by the same principal.
+	mux.HandleFunc("/api/auth/me", s.requireAuth(s.handleMe))
 	mux.HandleFunc("/api/auth/password", auth.RequireAuth(s.sessions, http.HandlerFunc(s.authH.ChangePassword)).ServeHTTP)
 	mux.HandleFunc("/api/users", auth.RequireAuth(s.sessions, http.HandlerFunc(s.authH.ListUsers)).ServeHTTP)
 


### PR DESCRIPTION
## Summary

- persist webchat sessions and transcripts in SQLite under the authenticated account so chats restore across browsers and computers
- keep stable Aimee session IDs separate from server-owned provider resume IDs, including safe migration of legacy rows and browser caches
- reconcile account-scoped sessions in the frontend, including authoritative deletion/empty-history behavior, bounded local caching, and safe bootstrap identity verification
- cover ownership isolation, runtime binding order, migration, restore behavior, cache privacy, and transcript reconciliation

## Validation

- `env GOCACHE=/tmp/aimee-runtime-web-go-cache go test ./...` (from `runtime-web`)
- `npm run check`
- `npm test` — 132 tests passed
- `npm run build`
- `git diff --check`

## Roundtable

Remote `default` preset approved with no findings.

- Run: `oprun_g6a69bd8011459d99_1785351654_118`
- Artifact: `b4f8ed4bb79154f798f43456f8778e0ceda8db936ca7a4eae8a2c917226a1e07`
- Converged: yes
- Reviewers: 3/3; not degraded; no deadline hit