### PR TITLE
Gate the integration branch tip, not only the PRs that build it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main, testing, feature/core-modularization]
   pull_request:
     branches: [main, testing, feature/core-modularization]
     # `edited` re-runs the gate when a PR title/body is edited after open, so

--- a/docs/proposals/pending/gate-the-integration-tip.md
+++ b/docs/proposals/pending/gate-the-integration-tip.md
@@ -175,17 +175,18 @@ Record the certification as an auditable table with one row per attached check r
 The table must enumerate the actual check runs attached to the release SHA; a
 summary count or a link without the names and conclusions is insufficient.
 
-On the implementation pull request, verify that each configured pull-request
-event still starts CI for `main`, `testing`, and
-`feature/core-modularization`, and that `no-coauthor-trailers`, `bench-check`, and
-all other PR jobs continue under their existing conditions with unchanged
-conclusions. After merge to `testing`, record the resulting tip SHA, verify that
-GitHub Actions starts the `push` run without `workflow_dispatch`, and verify its
-head SHA exactly matches the tip. Query that SHA's check runs, enumerate every
-name and conclusion, confirm all push-applicable checks passed, and record
-`no-coauthor-trailers` and `bench-check` as skipped for the reasons above. The
-exact SHA, automatic workflow-run reference, and complete passed/skipped list
-are the release certification evidence.
+On the implementation pull request, verify that the existing `opened`,
+`synchronize`, `reopened`, and `edited` pull-request events still start CI for
+`main`, `testing`, and `feature/core-modularization`, and that
+`no-coauthor-trailers`, `bench-check`, and all other PR jobs continue under their
+existing conditions with unchanged conclusions. After merge to `testing`, record
+the resulting tip SHA, verify that GitHub Actions starts the `push` run without
+`workflow_dispatch`, and verify its head SHA exactly matches the tip. Query that
+SHA's check runs, enumerate every name and conclusion, confirm all
+push-applicable checks passed, and record `no-coauthor-trailers` and `bench-check`
+as skipped for the reasons above. The exact SHA, automatic workflow-run
+reference, and complete passed/skipped list are the release certification
+evidence.
 
 ## Acceptance
 

--- a/docs/proposals/pending/gate-the-integration-tip.md
+++ b/docs/proposals/pending/gate-the-integration-tip.md
@@ -164,16 +164,18 @@ checks alone are not certification. Because the intentional skips remain, the
 result must not be described as a "full gate." A manually dispatched run cannot
 substitute for the automatic push run.
 
-Record the certification as an auditable table with one row per attached check run:
+Record certification as auditable evidence that includes one row per attached
+check run:
 
 | Evidence | Required value |
 | --- | --- |
 | Release commit | Exact full SHA |
-| Automatic CI run | Push-triggered workflow-run URL/ID and matching head SHA |
-| Check runs | Each check-run name, conclusion, and—when skipped—the skip reason |
+| Automatic CI run | Successful push-triggered workflow-run URL/ID and matching head SHA |
+| Check run | One row per attached check-run name and conclusion; include the reason for each skipped check |
 
-The table must enumerate the actual check runs attached to the release SHA; a
-summary count or a link without the names and conclusions is insufficient.
+Repeat the check-run row until every check attached to the release SHA is
+enumerated. A summary count or a link without the names and conclusions is
+insufficient.
 
 On the implementation pull request, verify that the existing `opened`,
 `synchronize`, `reopened`, and `edited` pull-request events still start CI for

--- a/docs/proposals/pending/gate-the-integration-tip.md
+++ b/docs/proposals/pending/gate-the-integration-tip.md
@@ -4,7 +4,7 @@
 
 ## Problem
 
-`.github/workflows/ci.yml` triggers on:
+Before this proposal was implemented, `.github/workflows/ci.yml` triggered on:
 
 ```yaml
 on:
@@ -104,7 +104,8 @@ certified, rather than from the historical job count above.
 
 Established:
 
-- The trigger list contains no `push` (read from `ci.yml`).
+- Before implementation, the trigger list contained no `push` (read from
+  `ci.yml`).
 - `e161dd34` has 2 check runs, both image builds (API, quoted above).
 - The full gate on the tip *can* be dispatched manually: `workflow_dispatch` is
   configured, and doing so for `e161dd34` produced run `30223112295`.
@@ -162,6 +163,17 @@ runs, never from a fixed job count. CI gate checks must be present; image-build
 checks alone are not certification. Because the intentional skips remain, the
 result must not be described as a "full gate." A manually dispatched run cannot
 substitute for the automatic push run.
+
+Record the certification as an auditable table with one row per attached check run:
+
+| Evidence | Required value |
+| --- | --- |
+| Release commit | Exact full SHA |
+| Automatic CI run | Push-triggered workflow-run URL/ID and matching head SHA |
+| Check runs | Each check-run name, conclusion, and—when skipped—the skip reason |
+
+The table must enumerate the actual check runs attached to the release SHA; a
+summary count or a link without the names and conclusions is insufficient.
 
 On the implementation pull request, verify that each configured pull-request
 event still starts CI for `main`, `testing`, and

--- a/docs/proposals/pending/gate-the-integration-tip.md
+++ b/docs/proposals/pending/gate-the-integration-tip.md
@@ -74,13 +74,12 @@ The two are not equivalent in importance:
   checked at integration level — which is exactly the class of problem this
   proposal exists to catch.
 
-Any option below that relies on the `push` event must therefore also decide what
-to do about `bench-check`: either relax its `if:` to run on the tip (and give it
-a meaningful baseline to compare against, which on a push is not the PR base),
-or accept explicitly that integration-level performance is ungated. This
-proposal does not resolve that; it is called out so the gap is not mistaken for
-coverage. Note that a green tip run means "15 of 17 jobs passed", and any
-release certification should say so rather than claiming a full gate.
+The approved option accepts that integration-level performance is ungated. A push
+has no PR base and therefore no meaningful benchmark baseline, so `bench-check`
+remains intentionally restricted to pull requests. This is a known, accepted
+integration-level performance coverage gap, not tip-gate coverage. The set of
+expected checks must be derived from the workflow at the exact commit being
+certified, rather than from the historical job count above.
 
 ## Options
 
@@ -135,16 +134,57 @@ a separate decision informed by how often option 1 actually goes red. If it
 never goes red over a meaningful number of merges, the stronger options are not
 worth their friction.
 
+## Approved implementation and release certification
+
+CI runs automatically on pushes to `main`, `testing`, and
+`feature/core-modularization`. The existing pull-request branch and event filters
+remain unchanged, as does `workflow_dispatch`.
+
+The two event-conditioned jobs remain intentionally PR-only:
+
+- `no-coauthor-trailers` requires the pull request's `base..head` commit range,
+  which does not exist for a push event.
+- `bench-check` requires a PR-base benchmark comparison. No push baseline is
+  defined, so its exclusion is a known, accepted integration-level performance
+  coverage gap. This change does not add such a baseline.
+
+Release certification must record:
+
+1. the exact release commit SHA;
+2. the successful, automatically push-triggered CI workflow run whose head SHA
+   exactly equals that release SHA;
+3. every check run attached to that exact commit, by name and conclusion; and
+4. the reason for every skipped check, including the two PR-only checks above.
+
+Every check applicable to the push event must pass. The expected check set must
+be derived from the workflow at the exact release commit and the resulting check
+runs, never from a fixed job count. CI gate checks must be present; image-build
+checks alone are not certification. Because the intentional skips remain, the
+result must not be described as a "full gate." A manually dispatched run cannot
+substitute for the automatic push run.
+
+On the implementation pull request, verify that each configured pull-request
+event still starts CI for `main`, `testing`, and
+`feature/core-modularization`, and that `no-coauthor-trailers`, `bench-check`, and
+all other PR jobs continue under their existing conditions with unchanged
+conclusions. After merge to `testing`, record the resulting tip SHA, verify that
+GitHub Actions starts the `push` run without `workflow_dispatch`, and verify its
+head SHA exactly matches the tip. Query that SHA's check runs, enumerate every
+name and conclusion, confirm all push-applicable checks passed, and record
+`no-coauthor-trailers` and `bench-check` as skipped for the reasons above. The
+exact SHA, automatic workflow-run reference, and complete passed/skipped list
+are the release certification evidence.
+
 ## Acceptance
 
-- A merge to `testing` produces a CI run against the resulting tip commit.
-- That run's check runs are visible on the tip commit
-  (`gh api repos/{owner}/{repo}/commits/<tip>/check-runs` returns the gate jobs,
-  not just the image builds).
-- A release can be certified by pointing at a green run on the exact commit
-  being released, with no manual `workflow_dispatch` step.
-- The certification states which jobs ran and which were skipped. A tip run that
-  skips `bench-check` is not described as a full gate.
-- `bench-check` on the tip is either enabled with a defined baseline, or its
-  absence is recorded as a known, accepted gap — not left to be discovered.
-- PR-triggered runs are unchanged.
+- A merge to `testing` produces an automatic CI `push` run against the resulting
+  tip commit, with no manual `workflow_dispatch` step.
+- That run's check runs are visible on the exact tip commit and include the CI
+  gate checks, not just image builds.
+- Certification records the exact tip SHA, automatic run reference, and complete
+  check-run names, conclusions, and skip reasons.
+- Every push-applicable check passes; intentional PR-only skips are not described
+  as a full gate.
+- The absent push benchmark baseline is explicitly retained as a known, accepted
+  integration-level performance coverage gap.
+- PR-triggered runs and job behavior are unchanged.


### PR DESCRIPTION
## Slice outcome

Gate the integration branch tip, not only the PRs that build it

## What changed

- Implement the complete approved plan as one reviewable change.
- Do not add deferred, post-adoption, or otherwise out-of-scope deliverables.

### Files in this PR

- Updated `.github/workflows/ci.yml`.
- Updated `docs/proposals/pending/gate-the-integration-tip.md`.

### Representative concrete edits

- `docs/proposals/pending/gate-the-integration-tip.md`: changed ```.github/workflows/ci.yml` triggers on:`` to ``Before this proposal was implemented, `.github/workflows/ci.yml` triggered on:``.

<details>
<summary>Diffstat</summary>

```text
.github/workflows/ci.yml                           |  2 +
 docs/proposals/pending/gate-the-integration-tip.md | 95 +++++++++++++++++-----
 2 files changed, 77 insertions(+), 20 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_cdd8bcf338a0ee80656b28a695284d58.sef71ea6c5b.g0.0`
- Branches: `aimee/wi/wi_cdd8bcf338a0ee80656b28a695284d58.sef71ea6c5b.g0.0` → `aimee/feat/wi_cdd8bcf338a0ee80656b28a695284d58`

</details>

<details>
<summary>Original request</summary>

{"acceptance_criteria":["Implement the complete approved plan as one reviewable change.","Do not add deferred, post-adoption, or otherwise out-of-scope deliverables."],"approved_plan":"# Implementation Plan\n\n## 1. Add integration-tip CI triggers\n\nUpdate `.github/workflows/ci.yml`:\n\n- Add a `push` trigger for:\n  - `main`\n  - `testing`\n  - `feature/core-modularization`\n- Preserve the existing `pull_request` branch and event filters unchanged.\n- Preserve `workflow_dispatch`.\n- Do not change job definitions or PR-specific conditions:\n  - Keep `no-coauthor-trailers` limited to `pull_request`; it requires a PR base-to-head commit range.\n  - Keep `bench-check` limited to `pull_request` for this slice because no meaningful push baseline has been defined.\n\n## 2. Record certification requirements and the accepted benchmark gap\n\nUpdate `docs/proposals/pending/gate-the-integration-tip.md` with durable release-certification guidance:\n\n- Require certification to identify:\n  - The exact release commit SHA.\n  - The successful push-triggered CI workflow run for that SHA.\n  - Every check-run name and conclusion reported on that commit.\n  - Every skipped check, with the reason it was skipped.\n- Require every check applicable to a push-triggered run to pass.\n- Do not use a fixed expected job count; derive the check list from the workflow and the check runs attached to the exact release SHA.\n- State that a run with skipped checks must not be described as a “full gate.”\n- Record the current intentional exclusions:\n  - `no-coauthor-trailers` is skipped because it is meaningful only for a PR commit range and has already run before merge.\n  - `bench-check` is skipped because an integration-tip comparison baseline is not defined.\n- Explicitly identify the missing integration-level performance check as a known, accepted gap.\n- State that release certification must use the automatic push run, not a manually dispatched substitute.\n\n## 3. Validate the workflow configuration\n\nBefore merging:\n\n- Validate that `.github/workflows/ci.yml` remains valid YAML and is accepted by the repository’s existing workflow/configuration checks.\n- Confirm the effective trigger configuration contains `push`, `pull_request`, and `workflow_dispatch`.\n- Confirm the `push` and `pull_request` branch lists contain exactly `main`, `testing`, and `feature/core-modularization`.\n- Confirm the existing `pull_request.types` list is unchanged.\n- Confirm no job conditions or dependencies changed as part of the trigger-only workflow modification.\n\n## 4. Verify the integration-tip run\n\nAfter the change is merged to `testing`:\n\n- Record the resulting `testing` tip SHA.\n- Confirm GitHub Actions automatically starts the CI workflow with:\n  - Event: `push`\n  - Head SHA: the exact `testing` tip SHA\n- Confirm no manual `workflow_dispatch` run is needed.\n- Query the tip’s check runs with:\n\n  ```bash\n  gh api repos/{owner}/{repo}/commits/\u003ctip\u003e/check-runs\n  ```\n\n- Verify the commit exposes the CI gate checks rather than only the image-build checks.\n- Enumerate the actual check-run names and conclusions:\n  - Confirm every push-applicable gate check passes.\n  - Confirm every skipped check is explicitly identified.\n  - Confirm `no-coauthor-trailers` and `bench-check` are reported as the documented PR-only exclusions.\n- Use the exact SHA, automatic workflow-run reference, and complete passed/skipped check list to demonstrate that the commit can be certified under the documented procedure.\n\n## 5. Confirm PR behavior is unchanged\n\nOn the implementation PR:\n\n- Confirm the workflow still starts for the existing `pull_request` events on the configured target branches.\n- Confirm PR-only jobs, including `no-coauthor-trailers` and `bench-check`, continue to run under their existing conditions.\n- Confirm the trigger addition does not alter the conclusions or execution conditions of the existing PR gate.\n\n## Technical debt and deferred follow-up\n\n- Integration-tip `bench-check` coverage remains deferred until a meaningful push-event performance baseline is designed. No baseline storage, fixtures, or supporting hooks are added in this slice.\n- Push gating reports a broken integration tip after merge; it does not prevent the merge. Branch up-to-date enforcement and GitHub merge queue adoption remain separate workflow decisions.\n- The independent slice sub-PR CI gap described in `ci-on-slice-subprs.md` is not addressed by this change.","dependencies":[],"original_request":"# Proposal: gate the integration branch tip, not only the PRs that build it\n\n- **State:** approved — single slice.\n\n## Problem\n\n`.github/workflows/ci.yml` triggers on:\n\n```yaml\non:\n  pull_request:\n    branches: [main, testing, feature/core-modularization]\n    types: [opened, synchronize, reopened, edited]\n  workflow_dispatch:\n```\n\nThere is no `push` trigger. CI therefore runs against a PR's *merge preview*,\nnever against the branch tip that results from merging it.\n\nMeasured on the current release tip, `testing` @ `e161dd34`:\n\n```\n$ gh api repos/{owner}/{repo}/commits/e161dd34/check-runs\ntotal_count = 2\n  build (aimee-server, Dockerfile.server)  success\n  build (aimee-kb, Dockerfile)             success\n```\n\nTwo image builds. None of the 17 gate jobs — `unit-tests`, `build-integrity`,\n`e2e-docker` T1/T2/T3, `lint`, the Windows/macOS legs — has ever run against\nthis commit. The same is true of every previous tip.\n\n## Why this is not merely theoretical\n\nEach of the 14 commits in this release (#1994–#2010) was gated in isolation,\nagainst the tip as it stood when that PR was opened. Nothing re-checks the\ncombination. The failure mode this misses is the semantic conflict: two PRs that\neach pass alone and break in combination — one renames a helper while another\nadds a caller, one changes a default while another adds a test asserting the old\none. Textual conflicts are caught by git; semantic ones are caught only by\nrunning the gate on the merged result, which never happens.\n\nGitHub's merge-queue and \"require branches to be up to date before merging\"\nsettings exist precisely to close this gap. Neither is in use here: PRs merge\nagainst whatever base they were opened on.\n\nNote that this is the same class of hole as the slice sub-PR gap described in\n[ci-on-slice-subprs.md](ci-on-slice-subprs.md) — work merging through a gate\nthat did not actually run. They are independent instances and can be fixed\nindependently, but a fix for one does not address the other.\n\n## A push trigger alone does not give a complete gate\n\nTwo jobs are conditioned on the event type:\n\n```yaml\nno-coauthor-trailers:\n  if: github.event_name == 'pull_request'\nbench-check:\n  if: github.event_name == 'pull_request'\n```\n\nConfirmed empirically: the manually dispatched run `30223112295` on `e161dd34`\nreported **success**, but with those two jobs `skipped` — 15 of 17 jobs actually\nran. A `push`-triggered run would skip them for the same reason.\n\nThe two are not equivalent in importance:\n\n- `no-coauthor-trailers` scans a PR's new commits (`base..head`). On a tip gate\n  there is no such range, so skipping it is correct, and the check has already\n  done its job on the way in.\n- **`bench-check` is a genuine gap.** It is skipped on a tip gate, so\n  performance regressions arising from the *combination* of merged PRs are not\n  checked at integration level — which is exactly the class of problem this\n  proposal exists to catch.\n\nAny option below that relies on the `push` event must therefore also decide what\nto do about `bench-check`: either relax its `if:` to run on the tip (and give it\na meaningful baseline to compare against, which on a push is not the PR base),\nor accept explicitly that integration-level performance is ungated. This\nproposal does not resolve that; it is called out so the gap is not mistaken for\ncoverage. Note that a green tip run means \"15 of 17 jobs passed\", and any\nrelease certification should say so rather than claiming a full gate.\n\n## Options\n\n1. **Add a `push` trigger** for `main`, `testing`, `feature/core-modularization`.\n   The tip is gated on every merge. Cost: one extra full run per merge; a\n   failure is discovered post-merge, so it reports rather than prevents.\n2. **Require branches up to date before merging** (branch protection). Forces a\n   rebase/merge-from-base before a PR can land, so the gated merge preview is\n   the tip. Cost: re-runs CI on every PR each time the base moves; on a busy\n   base this serialises merges and is the setting most likely to cause friction.\n3. **GitHub merge queue.** Gates the prospective merged result and only lands it\n   if green. Strongest guarantee, prevents rather than reports. Cost: most\n   configuration; changes how everything merges.\n4. **Scheduled gate on the tip** (e.g. nightly `schedule:` on `testing`). Cheap\n   to add, catches combination breakage within a day. Cost: not tied to a merge,\n   so attribution to a specific PR is weaker and detection is delayed.\n5. **Leave as-is**, and rely on the release-time full run being dispatched by\n   hand — which is what was done for this release, and only because the gap was\n   noticed.\n\n## Established vs. assumed\n\nEstablished:\n\n- The trigger list contains no `push` (read from `ci.yml`).\n- `e161dd34` has 2 check runs, both image builds (API, quoted above).\n- The full gate on the tip *can* be dispatched manually: `workflow_dispatch` is\n  configured, and doing so for `e161dd34` produced run `30223112295`.\n\nAssumed, NOT established:\n\n- **That a semantic conflict has actually shipped.** No historical incident is\n  cited here. The argument is that the gap exists and is unguarded, not that it\n  has already caused a specific failure. If the decision hinges on demonstrated\n  harm rather than exposure, that evidence has not been gathered.\n- **Merge frequency and its interaction with option 2's serialisation cost.**\n  Not measured.\n\n## Recommendation\n\nOption 1, and it should be uncontroversial: the repo is public, so the extra run\ncosts no billed minutes (see the cost analysis in\n[ci-on-slice-subprs.md](ci-on-slice-subprs.md)), and it is a two-line change to\nan existing trigger block.\n\nOption 1 reports rather than prevents — a broken tip is found minutes after the\nmerge, not before it. That is a genuine weakness, and options 2 and 3 are\nstrictly stronger. But they change how every PR merges, which is a workflow\ndecision with human cost, whereas option 1 is additive and reversible. The\nrecommendation is to take option 1 now to get visibility, and treat option 3 as\na separate decision informed by how often option 1 actually goes red. If it\nnever goes red over a meaningful number of merges, the stronger options are not\nworth their friction.\n\n## Acceptance\n\n- A merge to `testing` produces a CI run against the resulting tip commit.\n- That run's check runs are visible on the tip commit\n  (`gh api repos/{owner}/{repo}/commits/\u003ctip\u003e/check-runs` returns the gate jobs,\n  not just the image builds).\n- A release can be certified by pointing at a green run on the exact commit\n  being released, with no manual `workflow_dispatch` step.\n- The certification states which jobs ran and which were skipped. A tip run that\n  skips `bench-check` is not described as a full gate.\n- `bench-check` on the tip is either enabled with a defined baseline, or its\n  absence is recorded as a known, accepted gap — not left to be discovered.\n- PR-triggered runs are unchanged.\n","packet_id":"p1","summary":"Gate the integration branch tip, not only the PRs that build it","target_blocks":["implement"]}

</details>