### PR TITLE
Run CI on slice sub-PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, testing, feature/core-modularization]
+    branches: [main, testing, feature/core-modularization, 'aimee/feat/**']
     # `edited` re-runs the gate when a PR title/body is edited after open, so
     # attribution can't be added post-hoc without failing CI.
     types: [opened, synchronize, reopened, edited]


### PR DESCRIPTION
## Slice outcome

Run CI on slice sub-PRs

## What changed

- Implement the complete approved plan as one reviewable change.
- Do not add deferred, post-adoption, or otherwise out-of-scope deliverables.

### Files in this PR

- Updated `.github/workflows/ci.yml`.

### Representative concrete edits

- `.github/workflows/ci.yml`: changed `branches: [main, testing, feature/core-modularization]` to `branches: [main, testing, feature/core-modularization, 'aimee/feat/**']`.

<details>
<summary>Diffstat</summary>

```text
.github/workflows/ci.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_69a033a3f0be9f4447dc1a74195de204.sf5f77641fb.g0.0`
- Branches: `aimee/wi/wi_69a033a3f0be9f4447dc1a74195de204.sf5f77641fb.g0.0` → `aimee/feat/wi_69a033a3f0be9f4447dc1a74195de204`

</details>

<details>
<summary>Original request</summary>

{"acceptance_criteria":["Implement the complete approved plan as one reviewable change.","Do not add deferred, post-adoption, or otherwise out-of-scope deliverables."],"approved_plan":"# Implementation Plan\n\n## Scope\n\nImplement approved option 1: run the complete existing CI workflow for slice sub-PRs targeting `aimee/feat/**`.\n\n## Pre-adoption baseline\n\n1. Before enabling the new trigger, use GitHub Actions PR-run timestamps to record the queue wait for 10 existing PR runs.\n2. Calculate and record the median queue wait as `Q0` in the tracking record for this proposal.\n3. Record how queue wait was derived so the same calculation is used for `Q1`.\n\n## Workflow change\n\n1. Update `.github/workflows/ci.yml`.\n2. Add `aimee/feat/**` to the existing `pull_request.branches` list.\n3. Preserve the existing `main`, `testing`, and `feature/core-modularization` targets unchanged.\n4. Do not add or modify workflow files, job definitions, matrices, job conditions, or runner selections.\n\n## Verification\n\n1. Validate that `.github/workflows/ci.yml` remains valid GitHub Actions YAML and that `aimee/feat/**` is interpreted as a pull-request base-branch pattern.\n2. Confirm the diff is confined to the `ci.yml` trigger list.\n3. Open or observe a slice sub-PR whose base branch matches `aimee/feat/**` and verify:\n   - A `ci.yml` workflow run is created for the sub-PR.\n   - The sub-PR reports check runs rather than `GIT_PR_CI_NONE`.\n   - Every job definition and every matrix expansion present in `ci.yml` at implementation time is included in the slice gate; do not verify against the proposal’s stale historical job counts.\n   - A failed gated execution makes the slice gate non-green, so the failure is attributed to the slice sub-PR.\n4. Confirm that a pull request targeting `testing` still triggers the same complete, unmodified gate.\n5. Confirm no reduced build-and-unit-test-only path or separate slice workflow was introduced.\n\n## Post-adoption measurement\n\n1. Over the first 10 pipeline runs after slice CI is enabled, record:\n   - Total elapsed time for each slice gate.\n   - Peak concurrent job executions for each pipeline run and the overall maximum, `Cmax`.\n   - Queue wait for unrelated PR runs, using the same calculation as the baseline, and the resulting median `Q1`.\n   - The account’s documented concurrent-job ceiling at measurement time.\n2. Reconsider option 2 if any of these conditions is met:\n   - `Q1 \u003e= Q0 + 2 minutes`.\n   - Slice-gate elapsed time exceeds 20 minutes in at least 3 of the 10 runs.\n   - The documented concurrent-job ceiling is reached in at least 2 of the 10 runs.\n3. If no condition is met, close the measurement task and record that observed concurrency was adequate.\n\n## Acceptance criteria\n\n- A slice sub-PR targeting `aimee/feat/**` reports at least one check run.\n- The slice sub-PR receives the complete CI gate as it exists at implementation time, including all e2e, Docker, platform, and matrix executions.\n- Failure of any gated execution prevents the slice gate from becoming green.\n- The final feature-to-`testing` pull request continues to run the complete gate unchanged.\n- The committed change is confined to the existing `ci.yml` pull-request trigger list.\n\n## Non-goals and deferred follow-up\n\n- Do not change `GIT_PR_CI_NONE` or the merge-permitting behavior in `src/modules/workflows/wfe_live_forge.c`.\n- Do not create a reduced slice-specific CI configuration.\n- Do not add workflow jobs, branch-protection rules, measurement automation, or new reporting formats.\n- Option 2 remains deferred unless a post-adoption threshold is reached; if reached, assess it separately using the collected concurrency and latency data.","dependencies":[],"original_request":"# Proposal: run CI on slice sub-PRs\n\n- **State:** approved — single slice.\n\n## Problem\n\nThe build-e2e workflow merges each slice through a sub-PR whose stated gate is\n\"sub-PR -\u003e GREEN CI -\u003e merge into the feature branch\". In practice no CI runs.\n\n`.github/workflows/ci.yml` triggers on:\n\n```yaml\npull_request:\n  branches: [main, testing, feature/core-modularization]\n```\n\nSlice sub-PRs target `aimee/feat/\u003cwork_item_id\u003e`, which is not in that list.\nObserved on PR #2011, opened and merged by the pipeline: `check-runs` total_count\n= 0. The engine correctly advanced — `wfe_live_forge.c` deliberately treats\n`GIT_PR_CI_NONE` as merge-permitting so an intermediate PR cannot park forever —\nso the gate passed because there was nothing to check.\n\nConsequence: a slice sub-PR whose target branch is not in the trigger list merges\ninto the feature branch with no check runs. A slice can break the build and the\nfinal feature-\u003etesting PR is the first gate that would discover it, with no\nattribution to the slice that caused it.\n\n## Established\n\nBy direct observation:\n\n- `ci.yml`'s `pull_request.branches` list does not include `aimee/feat/**`.\n- PR #2011 merged with `check-runs` total_count = 0.\n- `GIT_PR_CI_NONE` is defined at `src/modules/git/git_pr_api.h:75`\n  (`GIT_PR_CI_NONE = 0, /* no CI reported for the head commit */`), and\n  `src/modules/workflows/wfe_live_forge.c:197` handles that case with the\n  rationale recorded in the comment at line 201 — the engine \"already treats\n  `GIT_PR_CI_NONE` as merge-permitting\". This is verified design intent, cited to\n  file and line, not inferred from behaviour.\n- **`RakuenSoftware/aimee` is a public repository** (`gh repo view`:\n  `\"visibility\":\"PUBLIC\"`). GitHub-hosted *standard* runners are free for public\n  repositories; the per-OS billing multipliers (Linux 1x, Windows 2x, macOS 10x)\n  apply to private-repo minute consumption, not here.\n- **Job structure:** `ci.yml` defines **15 jobs**. One of them, `e2e-docker`,\n  carries `matrix: topology: [T1, T2, T3]` and expands to 3 executions, giving\n  **17 job executions per run**. Every job targets `ubuntu-latest`,\n  `windows-latest` or `macos-latest` — all standard hosted runners, all free-tier\n  for this repo. The table below and the concurrency figures are stated in\n  *executions* (17), not definitions (15), since executions are what consume\n  runner slots.\n\n### Measured job durations\n\nElapsed wall-clock per job, from the Actions jobs API for the two most recent\ncomplete `ci.yml` runs. These are **elapsed minutes, not billed minutes** — see\nabove; nothing here is billed.\n\n| Job | Runner | Run 30221629787 | Run 30221474744 |\n|---|---|---|---|\n| no-coauthor-trailers | ubuntu | 0.16 | 0.16 |\n| lint | ubuntu | 0.96 | 1.03 |\n| build | ubuntu | 1.96 | 2.06 |\n| build-integrity | ubuntu | 4.90 | 4.90 |\n| unit-tests | ubuntu | 5.86 | 5.83 |\n| init-migrate-service-test | ubuntu | 1.16 | 1.20 |\n| windows-cmake | windows | 4.20 | 4.06 |\n| windows-build | windows | 3.36 | 3.51 |\n| macos-build | macos | 0.61 | 0.53 |\n| memory-retrieval-eval | ubuntu | 0.76 | 0.56 |\n| bench-check | ubuntu | 0.68 | 0.63 |\n| treesitter | ubuntu | 0.96 | 1.13 |\n| vault-pkcs11-token | ubuntu | 0.48 | 0.38 |\n| e2e-adoption | ubuntu | 1.80 | 1.83 |\n| e2e-docker (T1) | ubuntu | 8.05 | 8.00 |\n| e2e-docker (T2) | ubuntu | 9.73 | 10.01 |\n| e2e-docker (T3) | ubuntu | 3.00 | 3.18 |\n| **Sum of all jobs** | | **48.63** | **49.00** |\n| `build` + `unit-tests` only | | **7.82** | **7.89** |\n| Longest single job (= wall-clock floor) | | 9.73 (e2e-docker T2) | 10.01 (e2e-docker T2) |\n\nDerivation: the \"sum\" rows add the column above them; the option-2 row adds only\n`build` and `unit-tests`. Jobs run concurrently, so the sum is total machine\noccupancy, not elapsed time — elapsed time is bounded below by the longest job.\n\n**n = 2.** These are point estimates from two runs. They do not characterise\nvariance, which for hosted runners is driven largely by queue and runner\navailability. Treat the figures as indicative, not as a cost model.\n\n## What the measurements actually show\n\nSince minutes are free for this repo, the sum-of-jobs figure is **not a cost**.\nThe real costs of adding slice CI are:\n\n1. **Wall-clock added per slice.** The full gate's *total workflow elapsed time*\n   is measured, from three complete runs:\n\n   | run | elapsed |\n   |---|---|\n   | 30223112295 (`e161dd34`, dispatched) | 9m45s |\n   | 30221629787 | 10m07s |\n   | 30221474744 | 10m21s |\n\n   So a full slice gate costs **~10 minutes** of wall-clock (n=3).\n\n   The corresponding figure for option 2 is **not measured** — that\n   configuration does not exist, so no run of it can be timed. Its elapsed time\n   is bounded *below* by its longest job (`unit-tests`, ~5.85 min) plus queue and\n   setup overhead, which the job table does not capture. Consequently the saving\n   from option 2 is **at most ~4 minutes per slice, and probably less**. Treat\n   that as an indicative upper bound on the benefit, not a measured difference.\n2. **Runner concurrency.** A 5-slice run adds 5 x 17 = **85 job executions**\n   (17 executions per run, see Job structure above) competing for the account's\n   concurrent-job allowance against all other CI in flight. This is the one\n   genuine scarcity, and it is **not quantified here**: the account's concurrency\n   ceiling and its current utilisation were not measured. If slice CI is adopted\n   and other PRs start queueing behind it, this is the cause to look at first.\n\n## Options\n\n1. Add `aimee/feat/**` to the `ci.yml` `pull_request.branches` list. Slices get\n   the full existing gate.\n2. Add a reduced job (build + unit tests only) for `aimee/feat/**`, deferring\n   e2e/docker legs to the final PR.\n3. Leave as-is and rely on the final PR.\n\n## Recommendation\n\n**Option 1.**\n\nThe case for option 2 was cost, and for this repository that cost does not\nexist: minutes are free. What option 2 actually buys is at most ~4 minutes of\nlatency\nper slice and a reduction in concurrent job slots. What it costs is real:\npartial attribution (e2e-only and cross-slice regressions still surface only at\nthe final PR) and a second CI configuration that must be kept in sync with the\nfirst — a standing source of drift where the slice gate and the delivery gate\nsilently diverge.\n\nTrading complete attribution and a single source of truth for four minutes is a\nbad trade when nothing is being billed. Option 1 also needs no new job\ndefinitions: it is one line added to an existing trigger list.\n\nIf runner concurrency later proves to be the binding constraint — the one cost\nabove that is real but unmeasured — option 2 remains available as a targeted\nremedy, and should be revisited with concurrency data in hand rather than\nadopted pre-emptively now.\n\n**Post-adoption measurement, with an explicit trigger for reconsidering.**\nBecause concurrency is knowingly unquantified at decision time, adopting option 1\ncarries an obligation to measure it afterwards rather than leave it open:\n\nBaseline first: before enabling slice CI, record the median queue wait of PR\nruns over 10 runs; call it `Q0`. Then, over the first 10 pipeline runs with slice\nCI enabled, record: maximum concurrent job executions reached (`Cmax`); median\nqueue wait of *unrelated* PR runs (`Q1`); and total elapsed time of each slice\ngate.\n\n**Reconsider option 2 if any of these is true** (each mechanically checkable):\n\n- `Q1 \u003e= Q0 + 2 minutes`, measured as the median over those 10 runs; **or**\n- slice gate elapsed time exceeds **20 minutes** in **3 or more** of the 10 runs\n  (against the measured ~10-minute standalone figure); **or**\n- `Cmax` reaches the account's documented concurrent-job ceiling in **2 or more**\n  of the 10 runs. (The ceiling must be read from the account's plan limits at\n  measurement time; it is not known here, which is precisely why it is recorded\n  rather than assumed.)\n\nIf none of the three fir…

_Content truncated; use the proposal path or workflow artifacts for the complete document._

</details>