### PR TITLE
feat(index): resolve exact graph identities

### DIFF
--- a/api/openapi-v1.yaml
+++ b/api/openapi-v1.yaml
@@ -622,16 +622,36 @@ components:
           type: string
           nullable: true
 
-    BlastRadiusEdge:
+    BlastRadiusDependentEdge:
       type: object
-      required: [provenance, confidence, project, generation, freshness]
+      required: [path, provenance, confidence, project, generation, freshness]
       properties:
         path:
           type: string
-          description: Dependent file path; present on dependent edges.
+          description: Dependent file path.
+        provenance:
+          type: string
+          description: Comma-separated structural evidence (`import`, `call`, `projection`, or `cross_repo`).
+        confidence:
+          type: string
+          enum: [high, medium, low]
+        project:
+          type: string
+        generation:
+          type: integer
+          format: int64
+          minimum: 1
+        freshness:
+          type: string
+          enum: [current]
+
+    BlastRadiusDependencyEdge:
+      type: object
+      required: [identity, provenance, confidence, project, generation, freshness]
+      properties:
         identity:
           type: string
-          description: Normalized import identity; present on dependency edges.
+          description: Normalized import identity.
         provenance:
           type: string
           description: Comma-separated structural evidence (`import`, `call`, `projection`, or `cross_repo`).
@@ -675,7 +695,7 @@ components:
         dependent_edges:
           type: array
           items:
-            $ref: "#/components/schemas/BlastRadiusEdge"
+            $ref: "#/components/schemas/BlastRadiusDependentEdge"
         dependencies:
           type: array
           items:
@@ -685,7 +705,7 @@ components:
         dependency_edges:
           type: array
           items:
-            $ref: "#/components/schemas/BlastRadiusEdge"
+            $ref: "#/components/schemas/BlastRadiusDependencyEdge"
 
     CodeScanRequest:
       type: object

--- a/api/openapi-v1.yaml
+++ b/api/openapi-v1.yaml
@@ -622,23 +622,70 @@ components:
           type: string
           nullable: true
 
+    BlastRadiusEdge:
+      type: object
+      required: [provenance, confidence, project, generation, freshness]
+      properties:
+        path:
+          type: string
+          description: Dependent file path; present on dependent edges.
+        identity:
+          type: string
+          description: Normalized import identity; present on dependency edges.
+        provenance:
+          type: string
+          description: Comma-separated structural evidence (`import`, `call`, `projection`, or `cross_repo`).
+        confidence:
+          type: string
+          enum: [high, medium, low]
+        project:
+          type: string
+        generation:
+          type: integer
+          format: int64
+          minimum: 1
+        freshness:
+          type: string
+          enum: [current]
+
     BlastRadiusResponse:
       type: object
+      required: [file, project, generation, freshness, resolved, dependents, dependent_count,
+                 dependent_edges, dependencies, dependency_count, dependency_edges]
       properties:
         file:
           type: string
+        project:
+          type: string
+        generation:
+          type: integer
+          format: int64
+          minimum: 1
+        freshness:
+          type: string
+          enum: [current]
+        resolved:
+          type: boolean
         dependents:
           type: array
           items:
             type: string
         dependent_count:
           type: integer
+        dependent_edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/BlastRadiusEdge"
         dependencies:
           type: array
           items:
             type: string
         dependency_count:
           type: integer
+        dependency_edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/BlastRadiusEdge"
 
     CodeScanRequest:
       type: object
@@ -3044,7 +3091,7 @@ paths:
             type: string
       responses:
         "200":
-          description: Blast radius
+          description: Current-generation blast radius with provenance-bearing edges
           content:
             application/json:
               schema:

--- a/benchmarks/bucket3-defaults/blast_radius_corpus.json
+++ b/benchmarks/bucket3-defaults/blast_radius_corpus.json
@@ -1,12 +1,13 @@
 {
   "version": 1,
   "flag": "guardrails_blast_radius_advisory_enabled",
-  "description": "Deterministic validation corpus for the code-graph blast-radius advisory (db2_code_index_blast_radius, src/db2/code_index.c). No LLM in the loop: each fixture is a small code graph (files with their exports + imports), and each case is an edited file with the ground-truth dependent + dependency sets. A harness loads a fixture into an isolated temp schema (INSERT into files / file_exports / file_imports), runs db2_code_index_blast_radius(project, edited_file), and scores precision/recall of the advised dependents against `expected_dependents`.",
+  "description": "Deterministic validation corpus for exact, generation-fenced code-graph blast radius. No LLM is involved: each fixture supplies files, exports, normalized extractor imports, and optional calls; the harness runs the shipping resolver in an isolated Postgres schema and scores dependent/dependency precision, recall, provenance, and freshness.",
   "computation_notes": [
-    "DEPENDENTS = other files whose file_imports.name LIKE '%<edited_file_path>%', but ONLY when the edited file itself has >=1 row in file_exports (the has_exports gate). A file with no exports yields NO dependents even if others import it.",
+    "DEPENDENTS = current-generation files whose language-normalized import identity resolves exactly to the edited file, plus uniquely resolved direct call edges and route-gated cross-repository edges.",
     "The edited file is excluded from its own dependent list.",
-    "DEPENDENCIES = DISTINCT file_imports.name for the edited file (raw import strings, not resolved to files).",
-    "Import names are matched by substring against the edited path, so an import must contain the edited file's path to count as a dependent edge."
+    "DEPENDENCIES = distinct normalized import identities owned by the edited file.",
+    "Every edge records provenance, confidence, project, generation, and freshness; an unknown or retired target is an error rather than a valid empty graph.",
+    "Unescaped substring matching is never authoritative."
   ],
   "pass_bar": "recall(dependents) = 1.0 (never miss a real dependent) AND precision(dependents) >= 0.8, aggregated across all cases.",
   "fixtures": [
@@ -28,14 +29,14 @@
     },
     {
       "project": "br_no_exports_gate",
-      "description": "helper.c has NO exports but IS imported by two files. The has_exports gate must suppress its dependents (advisory only fires for files that export a public surface).",
+      "description": "Import relationships do not disappear merely because a lightweight extractor found no exports in the target.",
       "files": [
         {"path": "src/helper.c", "exports": [], "imports": []},
         {"path": "src/one.c", "exports": ["one"], "imports": ["src/helper.c"]},
         {"path": "src/two.c", "exports": ["two"], "imports": ["src/helper.c"]}
       ],
       "cases": [
-        {"edited": "src/helper.c", "expected_dependents": [], "expected_dependencies": [], "notes": "no exports -> gate suppresses dependents despite two importers"}
+        {"edited": "src/helper.c", "expected_dependents": ["src/one.c", "src/two.c"], "expected_dependencies": [], "expected_provenance": {"src/one.c": "import", "src/two.c": "import"}, "notes": "exact imports remain authoritative without an exports gate"}
       ]
     },
     {
@@ -64,6 +65,22 @@
       ],
       "cases": [
         {"edited": "src/db.c", "expected_dependents": ["src/store.c"], "expected_dependencies": [], "notes": "direct importer only; app.c is transitive and must NOT appear"}
+      ]
+    },
+    {
+      "project": "br_python",
+      "description": "Python module and package-relative imports resolve to app/dates.py; a similarly prefixed module is a negative control, and a unique direct call is merged without duplicating an import edge.",
+      "files": [
+        {"path": "app/dates.py", "exports": ["billing_period_days"], "imports": ["app.calendar"]},
+        {"path": "app/billing.py", "exports": ["bill"], "imports": ["app.dates"]},
+        {"path": "app/invoices.py", "exports": ["invoice"], "imports": [".dates"]},
+        {"path": "app/reports.py", "exports": ["report"], "imports": ["app.dates"], "calls": ["billing_period_days"]},
+        {"path": "app/caller_only.py", "exports": ["preview"], "imports": [], "calls": ["billing_period_days"]},
+        {"path": "app/collision.py", "exports": ["collision"], "imports": ["app.dates_extra"]}
+      ],
+      "cases": [
+        {"edited": "app/dates.py", "expected_dependents": ["app/billing.py", "app/invoices.py", "app/reports.py", "app/caller_only.py"], "expected_dependencies": ["app.calendar"], "expected_provenance": {"app/billing.py": "import", "app/invoices.py": "import", "app/reports.py": "import", "app/caller_only.py": "call"}, "notes": "three exact Python importers, one call-only edge, no dates_extra collision"},
+        {"edited": "app/missing.py", "expected_dependents": [], "expected_dependencies": [], "expected_error": true, "notes": "unknown target is not a valid empty graph"}
       ]
     }
   ]

--- a/docs/CODE_INTELLIGENCE.md
+++ b/docs/CODE_INTELLIGENCE.md
@@ -49,6 +49,14 @@ basename is not a project identity and is never used as a fallback.
 Caller and blast-radius results cross repository boundaries after dependencies have been resolved.
 Vendored code, caches, generated trees, and configured excludes stay out of the project graph.
 
+Blast radius resolves the target in the current project generation before returning an empty graph.
+Python imports use dotted module identities (`app/dates.py` → `app.dates`), including explicit
+`from app import dates`, package `__init__`, and imports relative to the importing file. Exact
+normalized equality replaces path-substring matching. Direct call edges are included only when the
+export is unique in the current project; cross-project edges require an existing structural route.
+Each returned edge identifies its `provenance`, `confidence`, `project`, `generation`, and
+`freshness`. Local current-project edges are emitted before any route-gated cross-project tail.
+
 `ast_grep_search` is advertised only when its helper readiness contract passes. An unavailable helper
 returns unsupported; it does not fall back to a different search and label it AST-aware.
 

--- a/docs/gen/api-v1.md
+++ b/docs/gen/api-v1.md
@@ -124,7 +124,7 @@ Blast-radius computation for a file
 
 Responses:
 
-- `200` — Blast radius
+- `200` — Current-generation blast radius with provenance-bearing edges
 - `400` — Missing required parameters
 - `401` — Unauthorized
 - `404` — Project is detached/unknown or the file is not indexed

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -674,3 +674,12 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   projection with a route-gated external import and asserts that no local edge follows an external
   edge. Roundtable run: `roundtable-5d582db9c64174793488f921` (artifact
   `a309798e4843249ac313deecef3b9749cc318845c4b95498325216b374f3d4b1`).
+- **E3 implementation round 2 — 2026-07-30 — changes requested, 3/3 participants, not
+  degraded.** The corrected local-first ordering was accepted. The synthesis repeated a projection
+  capacity concern that was already bounded by both loop conditions; E3 nevertheless adds the same
+  guard at each insertion site so the invariant survives future loop refactors. A valid finding
+  showed that the client accepted legacy-only arrays with empty metadata. New E3 clients now require
+  resolved top-level identity plus complete structured edge arrays and fail closed on legacy-only or
+  partial metadata; servers continue emitting legacy arrays additively for older consumers.
+  Roundtable run: `roundtable-15472c66ae1dccd6620b4b97` (artifact
+  `a8e925f87312534a4092416d4dec985621f5e0053be367bbab37d15b5be889fe`).

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -1,6 +1,6 @@
 # Proposal: Agent-facing code intelligence effectiveness
 
-- **State:** PENDING — E2–E6 remain; E0, E1, and E1-memory history is recorded below
+- **State:** PENDING — E3–E6 remain; E0 through E2 history is recorded below
 - **Author:** JBailes
 - **Date:** 2026-07-29
 - **Charter roles:** Recall, Rank-Fuse, Calibrate / Evaluate-Optimize, Enforce, Gate-Promote
@@ -654,3 +654,16 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   release-plus-kind-plus-project regressions prove both positive projects and a mismatched kind.
   Roundtable run: `roundtable-d6b5adead972ca968a7132e5` (artifact
   `068609efd696a07bdd62a7cceaeb02ff97cc8298b4c1f703348f107de936635c`).
+- **E2 final exact-diff review — 2026-07-30 — APPROVED and converged, 3/3 participants, not
+  degraded.** The final operator-health and explicit-scope smoke repairs received no blocking
+  findings. Roundtable run: `roundtable-0b8300caa27872843d839e63` (artifact
+  `96a646d79a1169a6f0d810b879f4db3ea4eaed6af66b9e286319a1f574161da6`).
+- **E2 current-project identity slice:** PR #2161 merged to `testing` as
+  `a70ebc23e1facd0cc199fbfacd2c13e2a38b1dca` after all 23 CI checks passed. Stable identity,
+  active-project-first code/knowledge/memory ordering, generation fencing, explicit all-project
+  scope, and audited detach/purge/GC are now the base for E3–E6.
+- **E3 graph-resolution candidate:** the implementation replaces path-substring blast matching
+  with exact normalized Python module identities, merges unique-symbol call edges without
+  duplicates, admits cross-project tails only through resolved structural routes, resolves legacy
+  projection basenames uniquely, and emits provenance/confidence/project/generation/freshness for
+  every edge. Its frozen implementation diff receives a separate roundtable gate before PR.

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -667,3 +667,10 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   duplicates, admits cross-project tails only through resolved structural routes, resolves legacy
   projection basenames uniquely, and emits provenance/confidence/project/generation/freshness for
   every edge. Its frozen implementation diff receives a separate roundtable gate before PR.
+- **E3 implementation round 1 — 2026-07-30 — changes requested, 3/3 participants, not
+  degraded.** All three seats found that local co-edit projection edges were appended after the
+  resolver's cross-project tail. A shared stable local-first partition now runs after additive
+  projections in both public blast-radius paths, and an adversarial fixture combines a local-only
+  projection with a route-gated external import and asserts that no local edge follows an external
+  edge. Roundtable run: `roundtable-5d582db9c64174793488f921` (artifact
+  `a309798e4843249ac313deecef3b9749cc318845c4b95498325216b374f3d4b1`).

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -683,3 +683,10 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   partial metadata; servers continue emitting legacy arrays additively for older consumers.
   Roundtable run: `roundtable-15472c66ae1dccd6620b4b97` (artifact
   `a8e925f87312534a4092416d4dec985621f5e0053be367bbab37d15b5be889fe`).
+- **E3 implementation round 3 — 2026-07-30 — APPROVED and converged, 2/3 participants used,
+  degraded.** The panel reported no blocking findings. E3 immediately adopts its schema-accuracy
+  suggestion by splitting dependent/path and dependency/identity OpenAPI edge types so the required
+  identity field matches the client validation contract. Its distinct CLI error-class suggestion is
+  assigned to the accepted E5 typed-status slice. Roundtable run:
+  `roundtable-a2953bf8d139a351d64af27d` (artifact
+  `ce370ec61931cdfb91c1e73417de930af801280d5a486ab2de9cd7adec98ae85`).

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -690,3 +690,8 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   assigned to the accepted E5 typed-status slice. Roundtable run:
   `roundtable-a2953bf8d139a351d64af27d` (artifact
   `ce370ec61931cdfb91c1e73417de930af801280d5a486ab2de9cd7adec98ae85`).
+- **E3 final exact-diff review — 2026-07-30 — APPROVED and converged, 2/3 participants used,
+  degraded.** The schema-aligned frozen diff received no findings; the chairman confirmed the
+  earlier ordering, capacity, complete-metadata, exact-resolution, route-gating, and concrete edge
+  identity findings remain closed. Roundtable run: `roundtable-327db1be95dc7e7c3abd2035`
+  (artifact `ebe90912dc8e54a133c45453fd1c8b376c0c5845954acf66fe37134f1e0b17e4`).

--- a/docs/validation/agent-facing-code-intelligence-e3-graph-resolution.md
+++ b/docs/validation/agent-facing-code-intelligence-e3-graph-resolution.md
@@ -22,7 +22,8 @@ Validation performed:
   dependents, one call-only dependent, merged provenance, exact dependencies, and unresolved-target
   failure;
 - route-gated cross-project coverage proving an identical un-routed distractor is excluded;
-- unique co-edit projection coverage with explicit `projection` provenance;
+- unique co-edit projection coverage with explicit `projection` provenance, including a combined
+  local-projection/cross-project fixture that proves every local edge precedes the external tail;
 - KB HTTP and client round-trip coverage for edge metadata;
 - successful `aimee-kb` and `aimee-blast-radius-eval` builds; and
 - the checked-in deterministic corpus updated to make exact identities, provenance, freshness, and

--- a/docs/validation/agent-facing-code-intelligence-e3-graph-resolution.md
+++ b/docs/validation/agent-facing-code-intelligence-e3-graph-resolution.md
@@ -25,6 +25,7 @@ Validation performed:
 - unique co-edit projection coverage with explicit `projection` provenance, including a combined
   local-projection/cross-project fixture that proves every local edge precedes the external tail;
 - KB HTTP and client round-trip coverage for edge metadata;
+- client fail-closed coverage for legacy-only blast responses that cannot prove edge metadata;
 - successful `aimee-kb` and `aimee-blast-radius-eval` builds; and
 - the checked-in deterministic corpus updated to make exact identities, provenance, freshness, and
   zero substring collisions the acceptance contract.

--- a/docs/validation/agent-facing-code-intelligence-e3-graph-resolution.md
+++ b/docs/validation/agent-facing-code-intelligence-e3-graph-resolution.md
@@ -1,0 +1,37 @@
+# Agent-facing code intelligence E3: exact graph resolution
+
+Validated: 2026-07-30
+
+E3 removes authoritative `%file_path%` matching from both canonical and direct DB2 blast-radius
+paths. The shared extractor/query identity layer maps Python file paths to dotted modules and
+resolves normal, explicit `from`-pair, package-relative, and `__init__` forms against the importing
+file. Non-Python imports remain exact slash-normalized identities; additional language resolvers can
+be added without reintroducing substring authority.
+
+The graph result now proves that the target resolved in the requested current generation. Local
+import edges are followed by uniquely resolvable direct calls, uniquely resolved co-edit
+projections, and then route-gated cross-project imports. Edge deduplication is project plus path, so
+same-path files in different projects stay distinct. Every edge carries provenance, confidence,
+project, generation, and freshness through HTTP, the KB client, CLI JSON, and blast-preview JSON.
+
+Validation performed:
+
+- extractor unit coverage for `import app.dates`, `from app import dates`, relative imports,
+  package `__init__`, and `app.dates_extra` collision rejection;
+- SQLite-backed canonical index coverage for the fixed `app/dates.py` fixture, three import
+  dependents, one call-only dependent, merged provenance, exact dependencies, and unresolved-target
+  failure;
+- route-gated cross-project coverage proving an identical un-routed distractor is excluded;
+- unique co-edit projection coverage with explicit `projection` provenance;
+- KB HTTP and client round-trip coverage for edge metadata;
+- successful `aimee-kb` and `aimee-blast-radius-eval` builds; and
+- the checked-in deterministic corpus updated to make exact identities, provenance, freshness, and
+  zero substring collisions the acceptance contract.
+
+Repository-wide validation also passed all 39 lint checks and the complete local unit-test suite.
+Tests that require live PostgreSQL or signed KMS fixtures reported their expected environment skips;
+the protected CI jobs provide those services.
+
+The standalone Postgres corpus binary was not run locally because this checkout has no
+`AIMEE_DB2_EVAL_URL` or local Postgres client. CI owns that disposable-Postgres execution; the same
+resolver is exercised locally through the repository's SQLite PostgreSQL shim.

--- a/src/cmd_index.c
+++ b/src/cmd_index.c
@@ -524,23 +524,43 @@ static void idx_blast_radius(app_ctx_t *ctx, int argc, char **argv)
       fatal("index blast-radius requires an active or explicit project");
    blast_radius_t br;
    if (kb_client_index_blast_radius(project, file_path, &br) != 0)
-   {
-      if (!ctx->json_output)
-         fprintf(stderr,
-                 "aimee: knowledge service unavailable — cannot compute canonical blast radius\n");
-      memset(&br, 0, sizeof(br));
-      snprintf(br.file, sizeof(br.file), "%s", file_path);
-   }
+      fatal("knowledge service could not resolve the current-generation blast radius");
    if (ctx->json_output)
    {
       cJSON *j = cJSON_CreateObject();
       cJSON_AddStringToObject(j, "file", br.file);
+      cJSON_AddStringToObject(j, "project", br.project);
+      cJSON_AddNumberToObject(j, "generation", (double)br.generation);
+      cJSON_AddStringToObject(j, "freshness", br.freshness);
+      cJSON_AddBoolToObject(j, "resolved", br.resolved);
       cJSON *deps = cJSON_AddArrayToObject(j, "dependents");
+      cJSON *dependent_edges = cJSON_AddArrayToObject(j, "dependent_edges");
       for (int i = 0; i < br.dependent_count; i++)
+      {
          cJSON_AddItemToArray(deps, cJSON_CreateString(br.dependents[i]));
+         cJSON *edge = cJSON_CreateObject();
+         cJSON_AddStringToObject(edge, "path", br.dependents[i]);
+         cJSON_AddStringToObject(edge, "provenance", br.dependent_meta[i].provenance);
+         cJSON_AddStringToObject(edge, "confidence", br.dependent_meta[i].confidence);
+         cJSON_AddStringToObject(edge, "project", br.dependent_meta[i].project);
+         cJSON_AddNumberToObject(edge, "generation", (double)br.dependent_meta[i].generation);
+         cJSON_AddStringToObject(edge, "freshness", br.dependent_meta[i].freshness);
+         cJSON_AddItemToArray(dependent_edges, edge);
+      }
       cJSON *ddeps = cJSON_AddArrayToObject(j, "dependencies");
+      cJSON *dependency_edges = cJSON_AddArrayToObject(j, "dependency_edges");
       for (int i = 0; i < br.dependency_count; i++)
+      {
          cJSON_AddItemToArray(ddeps, cJSON_CreateString(br.dependencies[i]));
+         cJSON *edge = cJSON_CreateObject();
+         cJSON_AddStringToObject(edge, "identity", br.dependencies[i]);
+         cJSON_AddStringToObject(edge, "provenance", br.dependency_meta[i].provenance);
+         cJSON_AddStringToObject(edge, "confidence", br.dependency_meta[i].confidence);
+         cJSON_AddStringToObject(edge, "project", br.dependency_meta[i].project);
+         cJSON_AddNumberToObject(edge, "generation", (double)br.dependency_meta[i].generation);
+         cJSON_AddStringToObject(edge, "freshness", br.dependency_meta[i].freshness);
+         cJSON_AddItemToArray(dependency_edges, edge);
+      }
       emit_json_ctx(j, ctx->json_fields, ctx->response_profile);
       return;
    }
@@ -550,13 +570,18 @@ static void idx_blast_radius(app_ctx_t *ctx, int argc, char **argv)
    {
       printf("  Dependents (%d):\n", br.dependent_count);
       for (int i = 0; i < br.dependent_count; i++)
-         printf("    %s\n", br.dependents[i]);
+         printf("    %s [%s, %s, %s@%lld, %s]\n", br.dependents[i], br.dependent_meta[i].provenance,
+                br.dependent_meta[i].confidence, br.dependent_meta[i].project,
+                br.dependent_meta[i].generation, br.dependent_meta[i].freshness);
    }
    if (br.dependency_count > 0)
    {
       printf("  Dependencies (%d):\n", br.dependency_count);
       for (int i = 0; i < br.dependency_count; i++)
-         printf("    %s\n", br.dependencies[i]);
+         printf("    %s [%s, %s, %s@%lld, %s]\n", br.dependencies[i],
+                br.dependency_meta[i].provenance, br.dependency_meta[i].confidence,
+                br.dependency_meta[i].project, br.dependency_meta[i].generation,
+                br.dependency_meta[i].freshness);
    }
    if (br.dependent_count == 0 && br.dependency_count == 0)
       printf("  No dependents or dependencies found.\n");

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -1661,6 +1661,8 @@ int canonical_index_blast_radius(const char *project, const char *file_path, bla
       }
    }
 
+   db2_code_index_blast_radius_local_first(project, out);
+
    return 0;
 }
 

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -1604,75 +1604,16 @@ int canonical_index_find(const char *identifier, term_hit_t *out, int max)
 
 int canonical_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out)
 {
-   void *conn = ci_conn();
-   if (!conn)
+   if (!project || !file_path || !out)
       return -1;
-
    memset(out, 0, sizeof(*out));
    snprintf(out->file, sizeof(out->file), "%s", file_path);
-
-   int64_t project_id = ci_resolve_project_id(conn, project);
-   if (project_id < 0)
+   if (db2_code_index_blast_radius(project, file_path, out) != 0)
       return -1;
 
-   int64_t file_id = ci_resolve_file_id(conn, project_id, file_path);
-   char err[CI_ERRBUF] = "";
-
-   /* Dependents: files in the project whose imports match this file's path. */
-   {
-      aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
-                                             "SELECT DISTINCT f.path FROM file_imports fi"
-                                             " JOIN files f ON f.id = fi.file_id"
-                                             " JOIN projects p ON p.id=f.project_id"
-                                             " WHERE f.project_id = ?1 AND fi.name LIKE ?2"
-                                             " AND p.lifecycle_state='current'"
-                                             " AND f.generation=p.current_generation",
-                                             err, sizeof(err));
-      if (st)
-      {
-         char pattern[MAX_PATH_LEN];
-         snprintf(pattern, sizeof(pattern), "%%%s%%", file_path);
-         aimee_pg_bind_int64(st, "?1", project_id);
-         aimee_pg_bind_text(st, "?2", pattern);
-         while (out->dependent_count < CI_MAX_DEPS &&
-                aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
-         {
-            const char *p = aimee_pg_column_text(st, 0);
-            if (p && strcmp(p, file_path) != 0)
-            {
-               snprintf(out->dependents[out->dependent_count], MAX_PATH_LEN, "%s", p);
-               out->dependent_count++;
-            }
-         }
-         aimee_pg_finalize(st);
-      }
-   }
-
-   /* Dependencies: imports declared by this file. */
-   if (file_id >= 0)
-   {
-      aimee_pg_stmt_t *st = aimee_pg_prepare(
-          conn, "SELECT DISTINCT name FROM file_imports WHERE file_id = ?1", err, sizeof(err));
-      if (st)
-      {
-         aimee_pg_bind_int64(st, "?1", file_id);
-         while (out->dependency_count < CI_MAX_DEPS &&
-                aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
-         {
-            const char *t = aimee_pg_column_text(st, 0);
-            if (t)
-            {
-               snprintf(out->dependencies[out->dependency_count], MAX_PATH_LEN, "%s", t);
-               out->dependency_count++;
-            }
-         }
-         aimee_pg_finalize(st);
-      }
-   }
-
    /* Expand with co_edited graph edges (weight > 3): files that historically
-    * change together but have no structural import edge. Basename-keyed to match
-    * how the backfill and the in-session co-edit path write these edges. */
+    * change together but have no structural import edge. Basename-keyed legacy
+    * projections are admitted only when they resolve to one current file. */
    {
       const char *slash = strrchr(file_path, '/');
       const char *match_name = slash ? slash + 1 : file_path;
@@ -1684,21 +1625,39 @@ int canonical_index_blast_radius(const char *project, const char *file_path, bla
          const char *related = co_buf[b];
          if (!related[0] || strcmp(related, match_name) == 0)
             continue;
-         int dup = 0;
+         char resolved[MAX_PATH_LEN];
+         if (db2_code_index_unique_file_basename(project, related, resolved, sizeof(resolved)) !=
+                 1 ||
+             strcmp(resolved, file_path) == 0)
+            continue;
+         int found = -1;
          for (int d = 0; d < out->dependent_count; d++)
          {
-            if (strstr(out->dependents[d], related))
+            if (strcmp(out->dependents[d], resolved) == 0 &&
+                strcmp(out->dependent_meta[d].project, project) == 0)
             {
-               dup = 1;
+               found = d;
                break;
             }
          }
-         if (!dup)
+         if (found < 0)
          {
-            snprintf(out->dependents[out->dependent_count], MAX_PATH_LEN, "%s (co-edited)",
-                     related);
-            out->dependent_count++;
+            found = out->dependent_count++;
+            snprintf(out->dependents[found], MAX_PATH_LEN, "%s", resolved);
+            snprintf(out->dependent_meta[found].project, sizeof(out->dependent_meta[found].project),
+                     "%s", project);
+            out->dependent_meta[found].generation = out->generation;
+            snprintf(out->dependent_meta[found].freshness,
+                     sizeof(out->dependent_meta[found].freshness), "current");
+            snprintf(out->dependent_meta[found].confidence,
+                     sizeof(out->dependent_meta[found].confidence), "low");
          }
+         char *provenance = out->dependent_meta[found].provenance;
+         if (provenance[0] && !strstr(provenance, "projection"))
+            strncat(provenance, ",projection",
+                    sizeof(out->dependent_meta[found].provenance) - strlen(provenance) - 1);
+         else if (!provenance[0])
+            snprintf(provenance, sizeof(out->dependent_meta[found].provenance), "projection");
       }
    }
 

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -1642,6 +1642,8 @@ int canonical_index_blast_radius(const char *project, const char *file_path, bla
          }
          if (found < 0)
          {
+            if (out->dependent_count >= CI_MAX_DEPS)
+               continue;
             found = out->dependent_count++;
             snprintf(out->dependents[found], MAX_PATH_LEN, "%s", resolved);
             snprintf(out->dependent_meta[found].project, sizeof(out->dependent_meta[found].project),

--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -389,77 +389,244 @@ int db2_code_index_blast_radius(const char *project, const char *file_path, blas
    if (project_id < 0)
       return -1;
    int64_t file_id = code_index_resolve_file(conn, project_id, file_path);
+   if (file_id < 0)
+      return -1;
 
-   /* Stage 1: file's exports (only used to gate dependent search). */
-   int has_exports = 0;
-   if (file_id >= 0)
+   int64_t generation = 0;
+   if (db2_code_index_project_current_generation(project, &generation) != 0)
+      return -1;
+   snprintf(out->project, sizeof(out->project), "%s", project);
+   out->generation = (long long)generation;
+   snprintf(out->freshness, sizeof(out->freshness), "current");
+   out->resolved = 1;
+
+   char err[CIDX_ERRBUF] = "";
+
+   /* Local imports are examined in C because relative Python identities need
+    * the importing path. Exact normalized equality is the authority; SQL LIKE
+    * and unescaped substring matching are deliberately absent. */
    {
-      static const char *exp_sql = "SELECT name FROM file_exports WHERE file_id = ?1 LIMIT 1";
-      char err[CIDX_ERRBUF] = "";
-      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, exp_sql, err, sizeof(err));
-      if (st)
+      static const char *sql = "SELECT f.path, fi.name FROM file_imports fi"
+                               " JOIN files f ON f.id=fi.file_id"
+                               " JOIN projects p ON p.id=f.project_id"
+                               " WHERE f.project_id=?1 AND p.lifecycle_state='current'"
+                               " AND f.generation=p.current_generation ORDER BY f.path,fi.name";
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+      if (!st)
+         return -1;
+      aimee_pg_bind_int64(st, "?1", project_id);
+      while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
       {
-         aimee_pg_bind_int64(st, "?1", file_id);
-         if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
-            has_exports = 1;
-         aimee_pg_finalize(st);
+         const char *importer = aimee_pg_column_text(st, 0);
+         const char *raw = aimee_pg_column_text(st, 1);
+         if (!importer || !raw || strcmp(importer, file_path) == 0 ||
+             !code_import_resolves_path(importer, raw, file_path))
+            continue;
+         int found = -1;
+         for (int i = 0; i < out->dependent_count; i++)
+            if (strcmp(out->dependents[i], importer) == 0 &&
+                strcmp(out->dependent_meta[i].project, project) == 0)
+               found = i;
+         if (found < 0 && out->dependent_count < 64)
+         {
+            found = out->dependent_count++;
+            snprintf(out->dependents[found], MAX_PATH_LEN, "%s", importer);
+            snprintf(out->dependent_meta[found].project, sizeof(out->dependent_meta[found].project),
+                     "%s", project);
+            out->dependent_meta[found].generation = (long long)generation;
+            snprintf(out->dependent_meta[found].freshness,
+                     sizeof(out->dependent_meta[found].freshness), "current");
+         }
+         if (found >= 0)
+         {
+            snprintf(out->dependent_meta[found].provenance,
+                     sizeof(out->dependent_meta[found].provenance), "import");
+            snprintf(out->dependent_meta[found].confidence,
+                     sizeof(out->dependent_meta[found].confidence), "high");
+         }
       }
+      aimee_pg_finalize(st);
    }
 
-   /* Stage 2: dependents — other files in this project that import
-    * something matching the file_path. */
-   if (has_exports)
+   /* Direct calls are authoritative only for exports unique in the current
+    * project; ambiguous same-name exports cannot be resolved by code_calls. */
    {
-      static const char *dep_sql = "SELECT DISTINCT f.path FROM file_imports fi"
-                                   " JOIN files f ON f.id = fi.file_id"
-                                   " JOIN projects p ON p.id=f.project_id"
-                                   " WHERE f.project_id = ?1 AND fi.name LIKE ?2"
-                                   " AND p.lifecycle_state='current'"
-                                   " AND f.generation=p.current_generation";
-      char err[CIDX_ERRBUF] = "";
-      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, dep_sql, err, sizeof(err));
-      if (st)
+      static const char *sql =
+          "SELECT DISTINCT f.path FROM code_calls cc"
+          " JOIN files f ON f.id=cc.file_id JOIN projects p ON p.id=f.project_id"
+          " JOIN file_exports target ON target.file_id=?1 AND target.name=cc.callee"
+          " WHERE f.project_id=?2 AND f.id<>?1 AND p.lifecycle_state='current'"
+          " AND f.generation=p.current_generation"
+          " AND (SELECT COUNT(*) FROM file_exports other"
+          " JOIN files ofile ON ofile.id=other.file_id JOIN projects op ON op.id=ofile.project_id"
+          " WHERE ofile.project_id=?2 AND op.lifecycle_state='current'"
+          " AND ofile.generation=op.current_generation AND other.name=cc.callee)=1"
+          " ORDER BY f.path";
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+      if (!st)
+         return -1;
+      aimee_pg_bind_int64(st, "?1", file_id);
+      aimee_pg_bind_int64(st, "?2", project_id);
+      while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
       {
-         char pattern[MAX_PATH_LEN];
-         snprintf(pattern, sizeof(pattern), "%%%s%%", file_path);
-         aimee_pg_bind_int64(st, "?1", project_id);
-         aimee_pg_bind_text(st, "?2", pattern);
-         while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW && out->dependent_count < 64)
+         const char *caller = aimee_pg_column_text(st, 0);
+         if (!caller)
+            continue;
+         int found = -1;
+         for (int i = 0; i < out->dependent_count; i++)
+            if (strcmp(out->dependents[i], caller) == 0 &&
+                strcmp(out->dependent_meta[i].project, project) == 0)
+               found = i;
+         if (found < 0 && out->dependent_count < 64)
          {
-            const char *p = aimee_pg_column_text(st, 0);
-            if (p && strcmp(p, file_path) != 0)
-            {
-               snprintf(out->dependents[out->dependent_count], MAX_PATH_LEN, "%s", p);
-               out->dependent_count++;
-            }
+            found = out->dependent_count++;
+            snprintf(out->dependents[found], MAX_PATH_LEN, "%s", caller);
+            snprintf(out->dependent_meta[found].project, sizeof(out->dependent_meta[found].project),
+                     "%s", project);
+            out->dependent_meta[found].generation = (long long)generation;
+            snprintf(out->dependent_meta[found].freshness,
+                     sizeof(out->dependent_meta[found].freshness), "current");
          }
-         aimee_pg_finalize(st);
+         if (found >= 0)
+         {
+            char *provenance = out->dependent_meta[found].provenance;
+            if (provenance[0] && !strstr(provenance, "call"))
+               strncat(provenance, ",call",
+                       sizeof(out->dependent_meta[found].provenance) - strlen(provenance) - 1);
+            else if (!provenance[0])
+               snprintf(provenance, sizeof(out->dependent_meta[found].provenance), "call");
+            snprintf(out->dependent_meta[found].confidence,
+                     sizeof(out->dependent_meta[found].confidence), "high");
+         }
       }
+      aimee_pg_finalize(st);
    }
 
-   /* Stage 3: dependencies — what this file imports. */
-   if (file_id >= 0)
+   /* Dependencies preserve normalized identities owned by the target file. */
    {
-      static const char *imp_sql = "SELECT DISTINCT name FROM file_imports WHERE file_id = ?1";
-      char err[CIDX_ERRBUF] = "";
-      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, imp_sql, err, sizeof(err));
-      if (st)
+      aimee_pg_stmt_t *st = aimee_pg_prepare(
+          conn, "SELECT DISTINCT name FROM file_imports WHERE file_id=?1 ORDER BY name", err,
+          sizeof(err));
+      if (!st)
+         return -1;
+      aimee_pg_bind_int64(st, "?1", file_id);
+      while (out->dependency_count < 64 && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
       {
-         aimee_pg_bind_int64(st, "?1", file_id);
-         while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW && out->dependency_count < 64)
-         {
-            const char *t = aimee_pg_column_text(st, 0);
-            if (t)
-            {
-               snprintf(out->dependencies[out->dependency_count], MAX_PATH_LEN, "%s", t);
-               out->dependency_count++;
-            }
-         }
-         aimee_pg_finalize(st);
+         const char *raw = aimee_pg_column_text(st, 0);
+         char identity[MAX_PATH_LEN];
+         if (!raw || code_import_identity(file_path, raw, identity, sizeof(identity)) != 0)
+            continue;
+         int found = -1;
+         for (int i = 0; i < out->dependency_count; i++)
+            if (strcmp(out->dependencies[i], identity) == 0)
+               found = i;
+         if (found >= 0)
+            continue;
+         found = out->dependency_count++;
+         snprintf(out->dependencies[found], MAX_PATH_LEN, "%s", identity);
+         snprintf(out->dependency_meta[found].provenance,
+                  sizeof(out->dependency_meta[found].provenance), "import");
+         snprintf(out->dependency_meta[found].confidence,
+                  sizeof(out->dependency_meta[found].confidence), "high");
+         snprintf(out->dependency_meta[found].project, sizeof(out->dependency_meta[found].project),
+                  "%s", project);
+         out->dependency_meta[found].generation = (long long)generation;
+         snprintf(out->dependency_meta[found].freshness,
+                  sizeof(out->dependency_meta[found].freshness), "current");
       }
+      aimee_pg_finalize(st);
+   }
+
+   /* Cross-project tails are admitted only through a previously resolved
+    * structural route, after all local edges, and still require exact import
+    * identity resolution to this target. */
+   {
+      static const char *sql =
+          "SELECT DISTINCT cp.name,cp.current_generation,f.path,fi.name,cr.confidence"
+          " FROM cross_repo_route cr JOIN projects cp ON cp.name=cr.caller_project"
+          " JOIN files f ON f.project_id=cp.id JOIN file_imports fi ON fi.file_id=f.id"
+          " WHERE cr.definer_project=?1 AND cp.lifecycle_state='current'"
+          " AND f.generation=cp.current_generation ORDER BY cp.name,f.path";
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+      if (!st)
+         return -1;
+      aimee_pg_bind_text(st, "?1", project);
+      while (out->dependent_count < 64 && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         const char *caller_project = aimee_pg_column_text(st, 0);
+         long long caller_generation = (long long)aimee_pg_column_int64(st, 1);
+         const char *caller_path = aimee_pg_column_text(st, 2);
+         const char *raw = aimee_pg_column_text(st, 3);
+         const char *confidence = aimee_pg_column_text(st, 4);
+         if (!caller_project || !caller_path || !raw ||
+             !code_import_resolves_path(caller_path, raw, file_path))
+            continue;
+         int found = -1;
+         for (int i = 0; i < out->dependent_count; i++)
+            if (strcmp(out->dependents[i], caller_path) == 0 &&
+                strcmp(out->dependent_meta[i].project, caller_project) == 0)
+               found = i;
+         if (found < 0)
+         {
+            found = out->dependent_count++;
+            snprintf(out->dependents[found], MAX_PATH_LEN, "%s", caller_path);
+            snprintf(out->dependent_meta[found].project, sizeof(out->dependent_meta[found].project),
+                     "%s", caller_project);
+            out->dependent_meta[found].generation = caller_generation;
+            snprintf(out->dependent_meta[found].freshness,
+                     sizeof(out->dependent_meta[found].freshness), "current");
+         }
+         snprintf(out->dependent_meta[found].provenance,
+                  sizeof(out->dependent_meta[found].provenance), "cross_repo");
+         snprintf(out->dependent_meta[found].confidence,
+                  sizeof(out->dependent_meta[found].confidence), "%s",
+                  confidence && confidence[0] ? confidence : "medium");
+      }
+      aimee_pg_finalize(st);
    }
 
    return 0;
+}
+
+int db2_code_index_unique_file_basename(const char *project, const char *basename, char *out,
+                                        size_t out_cap)
+{
+   if (!project || !basename || !out || out_cap == 0)
+      return -1;
+   out[0] = '\0';
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   int64_t project_id = code_index_resolve_project(conn, project);
+   if (project_id < 0)
+      return -1;
+   char err[CIDX_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn,
+                        "SELECT f.path FROM files f JOIN projects p ON p.id=f.project_id"
+                        " WHERE f.project_id=?1 AND p.lifecycle_state='current'"
+                        " AND f.generation=p.current_generation ORDER BY f.path",
+                        err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", project_id);
+   int matches = 0;
+   while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *path = aimee_pg_column_text(st, 0);
+      const char *base = path ? strrchr(path, '/') : NULL;
+      base = base ? base + 1 : path;
+      if (base && strcmp(base, basename) == 0)
+      {
+         matches++;
+         if (matches == 1)
+            snprintf(out, out_cap, "%s", path);
+      }
+   }
+   aimee_pg_finalize(st);
+   if (matches != 1)
+      out[0] = '\0';
+   return matches == 1 ? 1 : 0;
 }
 
 int64_t db2_code_index_project_upsert(const char *name, const char *root)

--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -588,6 +588,37 @@ int db2_code_index_blast_radius(const char *project, const char *file_path, blas
    return 0;
 }
 
+void db2_code_index_blast_radius_local_first(const char *project, blast_radius_t *out)
+{
+   if (!project || !project[0] || !out || out->dependent_count < 2)
+      return;
+
+   int first_external = -1;
+   for (int i = 0; i < out->dependent_count; i++)
+   {
+      const int local = strcmp(out->dependent_meta[i].project, project) == 0;
+      if (!local)
+      {
+         if (first_external < 0)
+            first_external = i;
+         continue;
+      }
+      if (first_external < 0)
+         continue;
+
+      char path[MAX_PATH_LEN];
+      blast_edge_meta_t meta = out->dependent_meta[i];
+      memcpy(path, out->dependents[i], sizeof(path));
+      memmove(&out->dependents[first_external + 1], &out->dependents[first_external],
+              (size_t)(i - first_external) * sizeof(out->dependents[0]));
+      memmove(&out->dependent_meta[first_external + 1], &out->dependent_meta[first_external],
+              (size_t)(i - first_external) * sizeof(out->dependent_meta[0]));
+      memcpy(out->dependents[first_external], path, sizeof(path));
+      out->dependent_meta[first_external] = meta;
+      first_external++;
+   }
+}
+
 int db2_code_index_unique_file_basename(const char *project, const char *basename, char *out,
                                         size_t out_cap)
 {

--- a/src/db2/code_index.h
+++ b/src/db2/code_index.h
@@ -39,15 +39,17 @@ extern "C"
     * (>=0) on success, -1 on DB / connection error. */
    int db2_code_index_term_find(const char *identifier, term_hit_t *out, int max);
 
-   /* Fill out->dependents and out->dependencies for the given
-    * (project, file_path) by reading file_exports and file_imports.
-    * out->file is left untouched (caller stamps it). The caller
-    * is responsible for memset()ing |out| beforehand. Returns 0 on
-    * success, -1 on DB / connection / project-not-found error. The
-    * file may exist in projects without a row in `files` (never
-    * scanned) — in that case dependent_count and dependency_count
-    * stay 0 and the call still returns 0. */
+   /* Fill exact current-generation structural edges for (project,file_path).
+    * Import identities are language-normalized; direct callers and resolved
+    * cross-repo routes are merged without path-only deduplication. Every edge
+    * carries provenance/confidence/project/generation/freshness metadata.
+    * Returns -1 unless the target resolves in the current generation. */
    int db2_code_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out);
+
+   /* Resolve basename to a current-generation file only when exactly one file
+    * in project has that basename. Used to make projection edges authoritative. */
+   int db2_code_index_unique_file_basename(const char *project, const char *basename, char *out,
+                                           size_t out_cap);
 
    /* List terms with kind='definition' for the (project, file_path),
     * ordered by line. Capped at |max|. Returns count (>=0) on
@@ -146,8 +148,7 @@ extern "C"
                                   int max, int enrich);
    /* As above, but search every current project except |excluded_project|;
     * exclusion happens in SQL before the result limit. */
-   int db2_code_index_code_search_excluding_project(const char *query,
-                                                    const char *excluded_project,
+   int db2_code_index_code_search_excluding_project(const char *query, const char *excluded_project,
                                                     code_search_hit_t *out, int max, int enrich);
 
 #ifdef __cplusplus

--- a/src/db2/code_index.h
+++ b/src/db2/code_index.h
@@ -46,6 +46,10 @@ extern "C"
     * Returns -1 unless the target resolves in the current generation. */
    int db2_code_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out);
 
+   /* Stable-partition dependent edges so every active-project edge precedes
+    * every cross-project tail. Call after additive local projections. */
+   void db2_code_index_blast_radius_local_first(const char *project, blast_radius_t *out);
+
    /* Resolve basename to a current-generation file only when exactly one file
     * in project has that basename. Used to make projection edges authoritative. */
    int db2_code_index_unique_file_basename(const char *project, const char *basename, char *out,

--- a/src/extractors.c
+++ b/src/extractors.c
@@ -358,31 +358,186 @@ static void py_import_line(const char *line, int lineno, void *ctx)
 
    (void)lineno;
 
-   /* from . import ... or from .module import ... */
+   /* import app.dates [as dates], app.money */
+   if (strncmp(p, "import ", 7) == 0)
+   {
+      p += 7;
+      while (*p && *p != '#')
+      {
+         while (*p == ' ' || *p == '\t' || *p == ',')
+            p++;
+         const char *start = p;
+         while (isalnum((unsigned char)*p) || *p == '_' || *p == '.')
+            p++;
+         size_t len = (size_t)(p - start);
+         if (len > 0 && len < 512)
+         {
+            char buf[512];
+            memcpy(buf, start, len);
+            buf[len] = '\0';
+            ic->count = add_str(ic->out, ic->count, ic->max, buf);
+         }
+         while (*p && *p != ',' && *p != '#')
+            p++;
+      }
+      return;
+   }
+
+   /* Keep both the imported module and explicit module/member pair. The latter
+    * is what lets `from app import dates` resolve exactly to app/dates.py while
+    * the former keeps `from app.dates import symbol` attached to app.dates. */
    if (strncmp(p, "from ", 5) == 0)
    {
       p += 5;
       p = skip_ws(p);
-      if (*p == '.')
+      const char *module = p;
+      while (isalnum((unsigned char)*p) || *p == '_' || *p == '.')
+         p++;
+      size_t module_len = (size_t)(p - module);
+      p = skip_ws(p);
+      if (module_len > 0 && strncmp(p, "import ", 7) == 0)
       {
-         /* Relative import */
-         const char *start = p;
-         while (*p == '.')
-            p++;
-         /* Get module name if any */
-         char buf[512];
-         size_t len = 0;
-         while (isalnum((unsigned char)p[len]) || p[len] == '_' || p[len] == '.')
-            len++;
-         size_t total = (size_t)(p - start) + len;
-         if (total > 0 && total < sizeof(buf))
+         int module_has_name = 0;
+         for (size_t i = 0; i < module_len; i++)
+            if (isalnum((unsigned char)module[i]) || module[i] == '_')
+               module_has_name = 1;
+         if (module_has_name && module_len < 512)
          {
-            memcpy(buf, start, total);
-            buf[total] = '\0';
+            char buf[512];
+            memcpy(buf, module, module_len);
+            buf[module_len] = '\0';
             ic->count = add_str(ic->out, ic->count, ic->max, buf);
+         }
+
+         p += 7;
+         while (*p && *p != '#')
+         {
+            while (*p == ' ' || *p == '\t' || *p == ',' || *p == '(' || *p == ')')
+               p++;
+            const char *member = p;
+            while (isalnum((unsigned char)*p) || *p == '_')
+               p++;
+            size_t member_len = (size_t)(p - member);
+            if (member_len > 0 && !(member_len == 1 && member[0] == '*'))
+            {
+               char buf[512];
+               int needs_dot = module_len > 0 && module[module_len - 1] != '.';
+               if (module_len + (size_t)needs_dot + member_len < sizeof(buf))
+               {
+                  memcpy(buf, module, module_len);
+                  size_t off = module_len;
+                  if (needs_dot)
+                     buf[off++] = '.';
+                  memcpy(buf + off, member, member_len);
+                  buf[off + member_len] = '\0';
+                  ic->count = add_str(ic->out, ic->count, ic->max, buf);
+               }
+            }
+            while (*p && *p != ',' && *p != '#')
+               p++;
          }
       }
    }
+}
+
+static void slash_normalize(const char *in, char *out, size_t out_cap)
+{
+   if (!out || out_cap == 0)
+      return;
+   out[0] = '\0';
+   if (!in)
+      return;
+   while (in[0] == '.' && (in[1] == '/' || in[1] == '\\'))
+      in += 2;
+   size_t n = 0;
+   while (*in && n + 1 < out_cap)
+   {
+      char c = *in++;
+      out[n++] = c == '\\' ? '/' : c;
+   }
+   out[n] = '\0';
+}
+
+int code_path_import_identity(const char *path, char *out, size_t out_cap)
+{
+   if (!path || !out || out_cap == 0)
+      return -1;
+   char normalized[MAX_PATH_LEN];
+   slash_normalize(path, normalized, sizeof(normalized));
+   size_t len = strlen(normalized);
+   if (len > 3 && strcmp(normalized + len - 3, ".py") == 0)
+   {
+      normalized[len - 3] = '\0';
+      len -= 3;
+      if (len >= 9 && strcmp(normalized + len - 9, "/__init__") == 0)
+         normalized[len - 9] = '\0';
+      for (char *p = normalized; *p; p++)
+         if (*p == '/')
+            *p = '.';
+   }
+   snprintf(out, out_cap, "%s", normalized);
+   return out[0] ? 0 : -1;
+}
+
+int code_import_identity(const char *importer_path, const char *raw_import, char *out,
+                         size_t out_cap)
+{
+   if (!raw_import || !out || out_cap == 0)
+      return -1;
+   out[0] = '\0';
+   size_t importer_len = importer_path ? strlen(importer_path) : 0;
+   int python = importer_len > 3 && strcmp(importer_path + importer_len - 3, ".py") == 0;
+   if (!python || raw_import[0] != '.')
+   {
+      slash_normalize(raw_import, out, out_cap);
+      return out[0] ? 0 : -1;
+   }
+
+   char package[MAX_PATH_LEN];
+   slash_normalize(importer_path, package, sizeof(package));
+   char *slash = strrchr(package, '/');
+   if (slash)
+      *slash = '\0';
+   else
+      package[0] = '\0';
+   for (char *p = package; *p; p++)
+      if (*p == '/')
+         *p = '.';
+
+   size_t dots = 0;
+   while (raw_import[dots] == '.')
+      dots++;
+   for (size_t level = 1; level < dots && package[0]; level++)
+   {
+      char *last = strrchr(package, '.');
+      if (last)
+         *last = '\0';
+      else
+         package[0] = '\0';
+   }
+   const char *suffix = raw_import + dots;
+   if (package[0] && suffix[0])
+      snprintf(out, out_cap, "%s.%s", package, suffix);
+   else
+      snprintf(out, out_cap, "%s%s", package, suffix);
+   return out[0] ? 0 : -1;
+}
+
+int code_import_resolves_path(const char *importer_path, const char *raw_import,
+                              const char *target_path)
+{
+   if (!importer_path || !raw_import || !target_path)
+      return 0;
+   char import_id[MAX_PATH_LEN];
+   char target_id[MAX_PATH_LEN];
+   if (code_import_identity(importer_path, raw_import, import_id, sizeof(import_id)) != 0 ||
+       code_path_import_identity(target_path, target_id, sizeof(target_id)) != 0)
+      return 0;
+   if (strcmp(import_id, target_id) == 0)
+      return 1;
+   size_t target_len = strlen(target_id);
+   return target_len + 9 < sizeof(target_id) && strncmp(import_id, target_id, target_len) == 0 &&
+          strcmp(import_id + target_len, ".__init__") == 0;
 }
 
 static void py_export_line(const char *line, int lineno, void *ctx)

--- a/src/headers/index.h
+++ b/src/headers/index.h
@@ -18,11 +18,26 @@ typedef struct
 
 typedef struct
 {
+   char provenance[48];
+   char confidence[16];
+   char project[128];
+   long long generation;
+   char freshness[16];
+} blast_edge_meta_t;
+
+typedef struct
+{
    char file[MAX_PATH_LEN];
    char dependents[64][MAX_PATH_LEN];
    int dependent_count;
    char dependencies[64][MAX_PATH_LEN];
    int dependency_count;
+   char project[128];
+   long long generation;
+   char freshness[16];
+   int resolved;
+   blast_edge_meta_t dependent_meta[64];
+   blast_edge_meta_t dependency_meta[64];
 } blast_radius_t;
 
 typedef struct
@@ -85,6 +100,15 @@ int extract_imports(const char *ext, const char *content, char **out, int max);
  * angle-bracket include (C/C++ `#include <...>`), else 0. `sys` may be NULL (then
  * behaves exactly like extract_imports). `sys` must hold at least `max` ints. */
 int extract_imports_sys(const char *ext, const char *content, char **out, int *sys, int max);
+
+/* Stable import identities shared by extractors and graph queries. Python paths
+ * use dotted module identities; relative imports resolve against importer_path.
+ * Non-Python paths remain slash-normalized exact identities. */
+int code_path_import_identity(const char *path, char *out, size_t out_cap);
+int code_import_identity(const char *importer_path, const char *raw_import, char *out,
+                         size_t out_cap);
+int code_import_resolves_path(const char *importer_path, const char *raw_import,
+                              const char *target_path);
 
 /* Extract exports from file content. Returns count. Caller frees each string. */
 int extract_exports(const char *ext, const char *content, char **out, int max);

--- a/src/headers/kb_http_code.h
+++ b/src/headers/kb_http_code.h
@@ -1,6 +1,8 @@
 #ifndef DEC_KB_HTTP_CODE_H
 #define DEC_KB_HTTP_CODE_H 1
 
+#include "cJSON.h"
+#include "index.h"
 #include <stddef.h>
 
 /* Shared route helpers (defined in kb_http_code.c), used by the graph-feedback
@@ -8,8 +10,9 @@
 int code_scan_write_error(char *out_buf, int out_cap, const char *message);
 int code_method_not_allowed(char *out_buf, int out_cap);
 int code_qparam(const char *qs, const char *key, char *out, int outsz);
-int code_request_project(const char *query_string, char *project, size_t project_cap,
-                         int allow_all, int *all_projects, char *out_buf, int out_cap);
+int code_request_project(const char *query_string, char *project, size_t project_cap, int allow_all,
+                         int *all_projects, char *out_buf, int out_cap);
+void code_blast_radius_json_fields(cJSON *response, const blast_radius_t *blast);
 
 int handle_post_code_scan(const char *body, char *out_buf, int out_cap);
 int handle_post_code_scan_route(const char *method, const char *body, char *out_buf, int out_cap);

--- a/src/index.c
+++ b/src/index.c
@@ -1025,6 +1025,8 @@ int index_blast_radius(const char *project, const char *file_path, blast_radius_
          }
          if (found < 0)
          {
+            if (out->dependent_count >= 64)
+               continue;
             found = out->dependent_count++;
             snprintf(out->dependents[found], MAX_PATH_LEN, "%s", resolved);
             snprintf(out->dependent_meta[found].project, sizeof(out->dependent_meta[found].project),

--- a/src/index.c
+++ b/src/index.c
@@ -995,7 +995,8 @@ int index_blast_radius(const char *project, const char *file_path, blast_radius_
    if (db2_code_index_blast_radius(project, file_path, out) != 0)
       return -1;
 
-   /* Expand with co_edited graph edges (weight > 3). */
+   /* Expand with co_edited graph edges only when their legacy basename key
+    * resolves to exactly one current-project file. */
    {
       const char *base = strrchr(file_path, '/');
       const char *match_name = base ? base + 1 : file_path;
@@ -1007,21 +1008,39 @@ int index_blast_radius(const char *project, const char *file_path, blast_radius_
          const char *related = co_buf[b];
          if (!related[0] || strcmp(related, match_name) == 0)
             continue;
-         int dup = 0;
+         char resolved[MAX_PATH_LEN];
+         if (db2_code_index_unique_file_basename(project, related, resolved, sizeof(resolved)) !=
+                 1 ||
+             strcmp(resolved, file_path) == 0)
+            continue;
+         int found = -1;
          for (int d = 0; d < out->dependent_count; d++)
          {
-            if (strstr(out->dependents[d], related))
+            if (strcmp(out->dependents[d], resolved) == 0 &&
+                strcmp(out->dependent_meta[d].project, project) == 0)
             {
-               dup = 1;
+               found = d;
                break;
             }
          }
-         if (!dup)
+         if (found < 0)
          {
-            snprintf(out->dependents[out->dependent_count], MAX_PATH_LEN, "%s (co-edited)",
-                     related);
-            out->dependent_count++;
+            found = out->dependent_count++;
+            snprintf(out->dependents[found], MAX_PATH_LEN, "%s", resolved);
+            snprintf(out->dependent_meta[found].project, sizeof(out->dependent_meta[found].project),
+                     "%s", project);
+            out->dependent_meta[found].generation = out->generation;
+            snprintf(out->dependent_meta[found].freshness,
+                     sizeof(out->dependent_meta[found].freshness), "current");
+            snprintf(out->dependent_meta[found].confidence,
+                     sizeof(out->dependent_meta[found].confidence), "low");
          }
+         char *provenance = out->dependent_meta[found].provenance;
+         if (provenance[0] && !strstr(provenance, "projection"))
+            strncat(provenance, ",projection",
+                    sizeof(out->dependent_meta[found].provenance) - strlen(provenance) - 1);
+         else if (!provenance[0])
+            snprintf(provenance, sizeof(out->dependent_meta[found].provenance), "projection");
       }
    }
 

--- a/src/index.c
+++ b/src/index.c
@@ -1044,6 +1044,8 @@ int index_blast_radius(const char *project, const char *file_path, blast_radius_
       }
    }
 
+   db2_code_index_blast_radius_local_first(project, out);
+
    return 0;
 #endif
 }

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -413,15 +413,7 @@ int handle_get_code_blast_radius(const char *query_string, char *out_buf, int ou
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
       return 500;
    }
-   cJSON_AddStringToObject(resp, "file", br->file);
-   cJSON *dependents = cJSON_AddArrayToObject(resp, "dependents");
-   for (int i = 0; dependents && i < br->dependent_count; i++)
-      cJSON_AddItemToArray(dependents, cJSON_CreateString(br->dependents[i]));
-   cJSON_AddNumberToObject(resp, "dependent_count", br->dependent_count);
-   cJSON *dependencies = cJSON_AddArrayToObject(resp, "dependencies");
-   for (int i = 0; dependencies && i < br->dependency_count; i++)
-      cJSON_AddItemToArray(dependencies, cJSON_CreateString(br->dependencies[i]));
-   cJSON_AddNumberToObject(resp, "dependency_count", br->dependency_count);
+   code_blast_radius_json_fields(resp, br);
    char *json = cJSON_PrintUnformatted(resp);
    snprintf(out_buf, (size_t)out_cap, "%s", json ? json : "{\"file\":\"\"}");
    free(json);

--- a/src/kb/http/kb_http_code_graphfb.c
+++ b/src/kb/http/kb_http_code_graphfb.c
@@ -30,6 +30,45 @@
 #define AUDIT_COHESION_MIN_SIZE 8
 #define AUDIT_UNVERIFIED_MIN    3 /* >= this many inferred-provenance incident edges */
 
+void code_blast_radius_json_fields(cJSON *response, const blast_radius_t *blast)
+{
+   cJSON_AddStringToObject(response, "file", blast->file);
+   cJSON_AddStringToObject(response, "project", blast->project);
+   cJSON_AddNumberToObject(response, "generation", (double)blast->generation);
+   cJSON_AddStringToObject(response, "freshness", blast->freshness);
+   cJSON_AddBoolToObject(response, "resolved", blast->resolved);
+   cJSON *dependents = cJSON_AddArrayToObject(response, "dependents");
+   cJSON *dependent_edges = cJSON_AddArrayToObject(response, "dependent_edges");
+   for (int i = 0; i < blast->dependent_count; i++)
+   {
+      cJSON_AddItemToArray(dependents, cJSON_CreateString(blast->dependents[i]));
+      cJSON *edge = cJSON_CreateObject();
+      cJSON_AddStringToObject(edge, "path", blast->dependents[i]);
+      cJSON_AddStringToObject(edge, "provenance", blast->dependent_meta[i].provenance);
+      cJSON_AddStringToObject(edge, "confidence", blast->dependent_meta[i].confidence);
+      cJSON_AddStringToObject(edge, "project", blast->dependent_meta[i].project);
+      cJSON_AddNumberToObject(edge, "generation", (double)blast->dependent_meta[i].generation);
+      cJSON_AddStringToObject(edge, "freshness", blast->dependent_meta[i].freshness);
+      cJSON_AddItemToArray(dependent_edges, edge);
+   }
+   cJSON_AddNumberToObject(response, "dependent_count", blast->dependent_count);
+   cJSON *dependencies = cJSON_AddArrayToObject(response, "dependencies");
+   cJSON *dependency_edges = cJSON_AddArrayToObject(response, "dependency_edges");
+   for (int i = 0; i < blast->dependency_count; i++)
+   {
+      cJSON_AddItemToArray(dependencies, cJSON_CreateString(blast->dependencies[i]));
+      cJSON *edge = cJSON_CreateObject();
+      cJSON_AddStringToObject(edge, "identity", blast->dependencies[i]);
+      cJSON_AddStringToObject(edge, "provenance", blast->dependency_meta[i].provenance);
+      cJSON_AddStringToObject(edge, "confidence", blast->dependency_meta[i].confidence);
+      cJSON_AddStringToObject(edge, "project", blast->dependency_meta[i].project);
+      cJSON_AddNumberToObject(edge, "generation", (double)blast->dependency_meta[i].generation);
+      cJSON_AddStringToObject(edge, "freshness", blast->dependency_meta[i].freshness);
+      cJSON_AddItemToArray(dependency_edges, edge);
+   }
+   cJSON_AddNumberToObject(response, "dependency_count", blast->dependency_count);
+}
+
 /* FNV-1a 32-bit over a string → 8 hex chars. Deterministic stable id for the
  * §1↔§3 finding-outcome loop (a finding's id must not drift run-to-run). */
 static void audit_finding_id(const char *prefix, const char *key, char *out, size_t out_len)

--- a/src/modules/kb_client/kb_client_index.c
+++ b/src/modules/kb_client/kb_client_index.c
@@ -442,9 +442,13 @@ int kb_client_index_blast_radius(const char *project, const char *file_path, bla
    snprintf(path, sizeof(path), "/v1/code/blast-radius?project=%s&file_path=%s", project_q, file_q);
    free(project_q);
    free(file_q);
-   char *json = kb_client_v1_get_json(path, KB_CLIENT_INDEX_READ_TIMEOUT_MS, NULL);
-   if (!json)
+   int status = 0;
+   char *json = kb_client_v1_get_json(path, KB_CLIENT_INDEX_READ_TIMEOUT_MS, &status);
+   if (!json || status < 200 || status >= 300)
+   {
+      free(json);
       return -1;
+   }
    cJSON *resp = cJSON_Parse(json);
    free(json);
    if (!resp)
@@ -454,9 +458,61 @@ int kb_client_index_blast_radius(const char *project, const char *file_path, bla
    if (cJSON_IsString(file))
       snprintf(out->file, sizeof(out->file), "%s", file->valuestring);
 
-   cJSON *deps = cJSON_GetObjectItemCaseSensitive(resp, "dependencies");
-   if (cJSON_IsArray(deps))
+   cJSON *error = cJSON_GetObjectItemCaseSensitive(resp, "error");
+   if (cJSON_IsString(error))
    {
+      cJSON_Delete(resp);
+      return -1;
+   }
+   cJSON *project_json = cJSON_GetObjectItemCaseSensitive(resp, "project");
+   cJSON *generation = cJSON_GetObjectItemCaseSensitive(resp, "generation");
+   cJSON *freshness = cJSON_GetObjectItemCaseSensitive(resp, "freshness");
+   cJSON *resolved = cJSON_GetObjectItemCaseSensitive(resp, "resolved");
+   if (cJSON_IsString(project_json))
+      snprintf(out->project, sizeof(out->project), "%s", project_json->valuestring);
+   if (cJSON_IsNumber(generation))
+      out->generation = (long long)generation->valuedouble;
+   if (cJSON_IsString(freshness))
+      snprintf(out->freshness, sizeof(out->freshness), "%s", freshness->valuestring);
+   out->resolved = cJSON_IsTrue(resolved);
+
+   cJSON *dependency_edges = cJSON_GetObjectItemCaseSensitive(resp, "dependency_edges");
+   if (cJSON_IsArray(dependency_edges))
+   {
+      cJSON *edge;
+      cJSON_ArrayForEach(edge, dependency_edges)
+      {
+         if (out->dependency_count >= 64)
+            break;
+         cJSON *identity = cJSON_GetObjectItemCaseSensitive(edge, "identity");
+         if (!cJSON_IsString(identity))
+            continue;
+         int i = out->dependency_count++;
+         snprintf(out->dependencies[i], MAX_PATH_LEN, "%s", identity->valuestring);
+         cJSON *v = cJSON_GetObjectItemCaseSensitive(edge, "provenance");
+         if (cJSON_IsString(v))
+            snprintf(out->dependency_meta[i].provenance, sizeof(out->dependency_meta[i].provenance),
+                     "%s", v->valuestring);
+         v = cJSON_GetObjectItemCaseSensitive(edge, "confidence");
+         if (cJSON_IsString(v))
+            snprintf(out->dependency_meta[i].confidence, sizeof(out->dependency_meta[i].confidence),
+                     "%s", v->valuestring);
+         v = cJSON_GetObjectItemCaseSensitive(edge, "project");
+         if (cJSON_IsString(v))
+            snprintf(out->dependency_meta[i].project, sizeof(out->dependency_meta[i].project), "%s",
+                     v->valuestring);
+         v = cJSON_GetObjectItemCaseSensitive(edge, "generation");
+         if (cJSON_IsNumber(v))
+            out->dependency_meta[i].generation = (long long)v->valuedouble;
+         v = cJSON_GetObjectItemCaseSensitive(edge, "freshness");
+         if (cJSON_IsString(v))
+            snprintf(out->dependency_meta[i].freshness, sizeof(out->dependency_meta[i].freshness),
+                     "%s", v->valuestring);
+      }
+   }
+   else
+   {
+      cJSON *deps = cJSON_GetObjectItemCaseSensitive(resp, "dependencies");
       cJSON *d;
       cJSON_ArrayForEach(d, deps)
       {
@@ -467,9 +523,44 @@ int kb_client_index_blast_radius(const char *project, const char *file_path, bla
                      d->valuestring);
       }
    }
-   cJSON *depts = cJSON_GetObjectItemCaseSensitive(resp, "dependents");
-   if (cJSON_IsArray(depts))
+
+   cJSON *dependent_edges = cJSON_GetObjectItemCaseSensitive(resp, "dependent_edges");
+   if (cJSON_IsArray(dependent_edges))
    {
+      cJSON *edge;
+      cJSON_ArrayForEach(edge, dependent_edges)
+      {
+         if (out->dependent_count >= 64)
+            break;
+         cJSON *edge_path = cJSON_GetObjectItemCaseSensitive(edge, "path");
+         if (!cJSON_IsString(edge_path))
+            continue;
+         int i = out->dependent_count++;
+         snprintf(out->dependents[i], MAX_PATH_LEN, "%s", edge_path->valuestring);
+         cJSON *v = cJSON_GetObjectItemCaseSensitive(edge, "provenance");
+         if (cJSON_IsString(v))
+            snprintf(out->dependent_meta[i].provenance, sizeof(out->dependent_meta[i].provenance),
+                     "%s", v->valuestring);
+         v = cJSON_GetObjectItemCaseSensitive(edge, "confidence");
+         if (cJSON_IsString(v))
+            snprintf(out->dependent_meta[i].confidence, sizeof(out->dependent_meta[i].confidence),
+                     "%s", v->valuestring);
+         v = cJSON_GetObjectItemCaseSensitive(edge, "project");
+         if (cJSON_IsString(v))
+            snprintf(out->dependent_meta[i].project, sizeof(out->dependent_meta[i].project), "%s",
+                     v->valuestring);
+         v = cJSON_GetObjectItemCaseSensitive(edge, "generation");
+         if (cJSON_IsNumber(v))
+            out->dependent_meta[i].generation = (long long)v->valuedouble;
+         v = cJSON_GetObjectItemCaseSensitive(edge, "freshness");
+         if (cJSON_IsString(v))
+            snprintf(out->dependent_meta[i].freshness, sizeof(out->dependent_meta[i].freshness),
+                     "%s", v->valuestring);
+      }
+   }
+   else
+   {
+      cJSON *depts = cJSON_GetObjectItemCaseSensitive(resp, "dependents");
       cJSON *d;
       cJSON_ArrayForEach(d, depts)
       {
@@ -531,12 +622,32 @@ static char *kb_client_index_blast_radius_preview_v1(const char *project, char *
       cJSON *file = cJSON_CreateObject();
       cJSON_AddStringToObject(file, "path", path);
       cJSON *deps = cJSON_AddArrayToObject(file, "dependents");
+      cJSON *edges = cJSON_AddArrayToObject(file, "dependent_edges");
       int dependent_count = 0;
       if (rc == 0)
       {
+         cJSON_AddStringToObject(file, "project", br.project);
+         cJSON_AddNumberToObject(file, "generation", (double)br.generation);
+         cJSON_AddStringToObject(file, "freshness", br.freshness);
+         cJSON_AddBoolToObject(file, "resolved", br.resolved);
          dependent_count = br.dependent_count;
          for (int j = 0; j < br.dependent_count; j++)
+         {
             cJSON_AddItemToArray(deps, cJSON_CreateString(br.dependents[j]));
+            cJSON *edge = cJSON_CreateObject();
+            cJSON_AddStringToObject(edge, "path", br.dependents[j]);
+            cJSON_AddStringToObject(edge, "provenance", br.dependent_meta[j].provenance);
+            cJSON_AddStringToObject(edge, "confidence", br.dependent_meta[j].confidence);
+            cJSON_AddStringToObject(edge, "project", br.dependent_meta[j].project);
+            cJSON_AddNumberToObject(edge, "generation", (double)br.dependent_meta[j].generation);
+            cJSON_AddStringToObject(edge, "freshness", br.dependent_meta[j].freshness);
+            cJSON_AddItemToArray(edges, edge);
+         }
+      }
+      else
+      {
+         cJSON_AddStringToObject(file, "status", "unavailable");
+         cJSON_AddBoolToObject(file, "resolved", 0);
       }
       cJSON_AddNumberToObject(file, "dependent_count", dependent_count);
       const char *severity = kb_index_preview_severity(dependent_count);

--- a/src/modules/kb_client/kb_client_index.c
+++ b/src/modules/kb_client/kb_client_index.c
@@ -423,6 +423,31 @@ int kb_client_index_list(project_info_t *out, int max)
    return count;
 }
 
+static int kb_index_blast_edge_valid(const cJSON *edge, const char *identity_field)
+{
+   if (!cJSON_IsObject(edge))
+      return 0;
+   cJSON *identity = cJSON_GetObjectItemCaseSensitive(edge, identity_field);
+   cJSON *provenance = cJSON_GetObjectItemCaseSensitive(edge, "provenance");
+   cJSON *confidence = cJSON_GetObjectItemCaseSensitive(edge, "confidence");
+   cJSON *project = cJSON_GetObjectItemCaseSensitive(edge, "project");
+   cJSON *generation = cJSON_GetObjectItemCaseSensitive(edge, "generation");
+   cJSON *freshness = cJSON_GetObjectItemCaseSensitive(edge, "freshness");
+   return cJSON_IsString(identity) && identity->valuestring[0] && cJSON_IsString(provenance) &&
+          provenance->valuestring[0] && cJSON_IsString(confidence) && confidence->valuestring[0] &&
+          cJSON_IsString(project) && project->valuestring[0] && cJSON_IsNumber(generation) &&
+          cJSON_IsString(freshness) && freshness->valuestring[0];
+}
+
+static int kb_index_blast_edges_valid(const cJSON *edges, const char *identity_field)
+{
+   if (!cJSON_IsArray(edges))
+      return 0;
+   cJSON *edge;
+   cJSON_ArrayForEach(edge, edges) if (!kb_index_blast_edge_valid(edge, identity_field)) return 0;
+   return 1;
+}
+
 int kb_client_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out)
 {
    if (!project || !file_path || !out)
@@ -468,107 +493,66 @@ int kb_client_index_blast_radius(const char *project, const char *file_path, bla
    cJSON *generation = cJSON_GetObjectItemCaseSensitive(resp, "generation");
    cJSON *freshness = cJSON_GetObjectItemCaseSensitive(resp, "freshness");
    cJSON *resolved = cJSON_GetObjectItemCaseSensitive(resp, "resolved");
-   if (cJSON_IsString(project_json))
-      snprintf(out->project, sizeof(out->project), "%s", project_json->valuestring);
-   if (cJSON_IsNumber(generation))
-      out->generation = (long long)generation->valuedouble;
-   if (cJSON_IsString(freshness))
-      snprintf(out->freshness, sizeof(out->freshness), "%s", freshness->valuestring);
-   out->resolved = cJSON_IsTrue(resolved);
-
    cJSON *dependency_edges = cJSON_GetObjectItemCaseSensitive(resp, "dependency_edges");
-   if (cJSON_IsArray(dependency_edges))
+   cJSON *dependent_edges = cJSON_GetObjectItemCaseSensitive(resp, "dependent_edges");
+   if (!cJSON_IsString(project_json) || !project_json->valuestring[0] ||
+       !cJSON_IsNumber(generation) || !cJSON_IsString(freshness) || !freshness->valuestring[0] ||
+       !cJSON_IsTrue(resolved) || !kb_index_blast_edges_valid(dependency_edges, "identity") ||
+       !kb_index_blast_edges_valid(dependent_edges, "path"))
    {
-      cJSON *edge;
-      cJSON_ArrayForEach(edge, dependency_edges)
-      {
-         if (out->dependency_count >= 64)
-            break;
-         cJSON *identity = cJSON_GetObjectItemCaseSensitive(edge, "identity");
-         if (!cJSON_IsString(identity))
-            continue;
-         int i = out->dependency_count++;
-         snprintf(out->dependencies[i], MAX_PATH_LEN, "%s", identity->valuestring);
-         cJSON *v = cJSON_GetObjectItemCaseSensitive(edge, "provenance");
-         if (cJSON_IsString(v))
-            snprintf(out->dependency_meta[i].provenance, sizeof(out->dependency_meta[i].provenance),
-                     "%s", v->valuestring);
-         v = cJSON_GetObjectItemCaseSensitive(edge, "confidence");
-         if (cJSON_IsString(v))
-            snprintf(out->dependency_meta[i].confidence, sizeof(out->dependency_meta[i].confidence),
-                     "%s", v->valuestring);
-         v = cJSON_GetObjectItemCaseSensitive(edge, "project");
-         if (cJSON_IsString(v))
-            snprintf(out->dependency_meta[i].project, sizeof(out->dependency_meta[i].project), "%s",
-                     v->valuestring);
-         v = cJSON_GetObjectItemCaseSensitive(edge, "generation");
-         if (cJSON_IsNumber(v))
-            out->dependency_meta[i].generation = (long long)v->valuedouble;
-         v = cJSON_GetObjectItemCaseSensitive(edge, "freshness");
-         if (cJSON_IsString(v))
-            snprintf(out->dependency_meta[i].freshness, sizeof(out->dependency_meta[i].freshness),
-                     "%s", v->valuestring);
-      }
+      cJSON_Delete(resp);
+      return -1;
    }
-   else
+   snprintf(out->project, sizeof(out->project), "%s", project_json->valuestring);
+   out->generation = (long long)generation->valuedouble;
+   snprintf(out->freshness, sizeof(out->freshness), "%s", freshness->valuestring);
+   out->resolved = 1;
+
+   cJSON *edge;
+   cJSON_ArrayForEach(edge, dependency_edges)
    {
-      cJSON *deps = cJSON_GetObjectItemCaseSensitive(resp, "dependencies");
-      cJSON *d;
-      cJSON_ArrayForEach(d, deps)
-      {
-         if (out->dependency_count >= 64)
-            break;
-         if (cJSON_IsString(d))
-            snprintf(out->dependencies[out->dependency_count++], MAX_PATH_LEN, "%s",
-                     d->valuestring);
-      }
+      if (out->dependency_count >= 64)
+         break;
+      cJSON *identity = cJSON_GetObjectItemCaseSensitive(edge, "identity");
+      int i = out->dependency_count++;
+      snprintf(out->dependencies[i], MAX_PATH_LEN, "%s", identity->valuestring);
+      cJSON *v = cJSON_GetObjectItemCaseSensitive(edge, "provenance");
+      snprintf(out->dependency_meta[i].provenance, sizeof(out->dependency_meta[i].provenance), "%s",
+               v->valuestring);
+      v = cJSON_GetObjectItemCaseSensitive(edge, "confidence");
+      snprintf(out->dependency_meta[i].confidence, sizeof(out->dependency_meta[i].confidence), "%s",
+               v->valuestring);
+      v = cJSON_GetObjectItemCaseSensitive(edge, "project");
+      snprintf(out->dependency_meta[i].project, sizeof(out->dependency_meta[i].project), "%s",
+               v->valuestring);
+      v = cJSON_GetObjectItemCaseSensitive(edge, "generation");
+      out->dependency_meta[i].generation = (long long)v->valuedouble;
+      v = cJSON_GetObjectItemCaseSensitive(edge, "freshness");
+      snprintf(out->dependency_meta[i].freshness, sizeof(out->dependency_meta[i].freshness), "%s",
+               v->valuestring);
    }
 
-   cJSON *dependent_edges = cJSON_GetObjectItemCaseSensitive(resp, "dependent_edges");
-   if (cJSON_IsArray(dependent_edges))
+   cJSON_ArrayForEach(edge, dependent_edges)
    {
-      cJSON *edge;
-      cJSON_ArrayForEach(edge, dependent_edges)
-      {
-         if (out->dependent_count >= 64)
-            break;
-         cJSON *edge_path = cJSON_GetObjectItemCaseSensitive(edge, "path");
-         if (!cJSON_IsString(edge_path))
-            continue;
-         int i = out->dependent_count++;
-         snprintf(out->dependents[i], MAX_PATH_LEN, "%s", edge_path->valuestring);
-         cJSON *v = cJSON_GetObjectItemCaseSensitive(edge, "provenance");
-         if (cJSON_IsString(v))
-            snprintf(out->dependent_meta[i].provenance, sizeof(out->dependent_meta[i].provenance),
-                     "%s", v->valuestring);
-         v = cJSON_GetObjectItemCaseSensitive(edge, "confidence");
-         if (cJSON_IsString(v))
-            snprintf(out->dependent_meta[i].confidence, sizeof(out->dependent_meta[i].confidence),
-                     "%s", v->valuestring);
-         v = cJSON_GetObjectItemCaseSensitive(edge, "project");
-         if (cJSON_IsString(v))
-            snprintf(out->dependent_meta[i].project, sizeof(out->dependent_meta[i].project), "%s",
-                     v->valuestring);
-         v = cJSON_GetObjectItemCaseSensitive(edge, "generation");
-         if (cJSON_IsNumber(v))
-            out->dependent_meta[i].generation = (long long)v->valuedouble;
-         v = cJSON_GetObjectItemCaseSensitive(edge, "freshness");
-         if (cJSON_IsString(v))
-            snprintf(out->dependent_meta[i].freshness, sizeof(out->dependent_meta[i].freshness),
-                     "%s", v->valuestring);
-      }
-   }
-   else
-   {
-      cJSON *depts = cJSON_GetObjectItemCaseSensitive(resp, "dependents");
-      cJSON *d;
-      cJSON_ArrayForEach(d, depts)
-      {
-         if (out->dependent_count >= 64)
-            break;
-         if (cJSON_IsString(d))
-            snprintf(out->dependents[out->dependent_count++], MAX_PATH_LEN, "%s", d->valuestring);
-      }
+      if (out->dependent_count >= 64)
+         break;
+      cJSON *edge_path = cJSON_GetObjectItemCaseSensitive(edge, "path");
+      int i = out->dependent_count++;
+      snprintf(out->dependents[i], MAX_PATH_LEN, "%s", edge_path->valuestring);
+      cJSON *v = cJSON_GetObjectItemCaseSensitive(edge, "provenance");
+      snprintf(out->dependent_meta[i].provenance, sizeof(out->dependent_meta[i].provenance), "%s",
+               v->valuestring);
+      v = cJSON_GetObjectItemCaseSensitive(edge, "confidence");
+      snprintf(out->dependent_meta[i].confidence, sizeof(out->dependent_meta[i].confidence), "%s",
+               v->valuestring);
+      v = cJSON_GetObjectItemCaseSensitive(edge, "project");
+      snprintf(out->dependent_meta[i].project, sizeof(out->dependent_meta[i].project), "%s",
+               v->valuestring);
+      v = cJSON_GetObjectItemCaseSensitive(edge, "generation");
+      out->dependent_meta[i].generation = (long long)v->valuedouble;
+      v = cJSON_GetObjectItemCaseSensitive(edge, "freshness");
+      snprintf(out->dependent_meta[i].freshness, sizeof(out->dependent_meta[i].freshness), "%s",
+               v->valuestring);
    }
    cJSON_Delete(resp);
    return 0;

--- a/src/tests/blast_radius_eval_main.c
+++ b/src/tests/blast_radius_eval_main.c
@@ -88,6 +88,16 @@ static void load_fixture(cJSON *fx)
                   im->valuestring, proj, path);
          xexec(sql);
       }
+      cJSON *call = NULL;
+      cJSON_ArrayForEach(call, cJSON_GetObjectItem(file, "calls"))
+      {
+         snprintf(sql, sizeof(sql),
+                  "INSERT INTO code_calls(file_id,caller,callee,line) SELECT f.id,'fixture','%s',1 "
+                  "FROM files f JOIN projects p ON p.id=f.project_id "
+                  "WHERE p.name='%s' AND f.path='%s'",
+                  call->valuestring, proj, path);
+         xexec(sql);
+      }
    }
 }
 
@@ -164,13 +174,43 @@ int main(int argc, char **argv)
             const char *edited = cJSON_GetStringValue(cJSON_GetObjectItem(c, "edited"));
             blast_radius_t br;
             memset(&br, 0, sizeof(br));
-            db2_code_index_blast_radius(proj, edited, &br);
+            int rc = db2_code_index_blast_radius(proj, edited, &br);
+            int expect_error = cJSON_IsTrue(cJSON_GetObjectItem(c, "expected_error"));
+            if (expect_error)
+            {
+               int ok = rc != 0 && br.dependent_count == 0 && br.dependency_count == 0;
+               printf("  [%s] %s: unresolved=%s\n", proj, edited, ok ? "correct" : "WRONG");
+               cases++;
+               if (!ok)
+                  fail++;
+               continue;
+            }
             int before_fn = dep_fn, before_fp = dep_fp;
             score_set(br.dependents, br.dependent_count,
                       cJSON_GetObjectItem(c, "expected_dependents"), &dep_tp, &dep_fp, &dep_fn);
             score_set(br.dependencies, br.dependency_count,
                       cJSON_GetObjectItem(c, "expected_dependencies"), &dic_tp, &dic_fp, &dic_fn);
-            int cfail = (dep_fn > before_fn); /* any missed dependent = recall miss */
+            int cfail = rc != 0 || !br.resolved || strcmp(br.project, proj) != 0 ||
+                        br.generation < 1 || strcmp(br.freshness, "current") != 0 ||
+                        (dep_fn > before_fn);
+            cJSON *expected_provenance = cJSON_GetObjectItem(c, "expected_provenance");
+            cJSON *edge = NULL;
+            cJSON_ArrayForEach(edge, expected_provenance)
+            {
+               int matched = 0;
+               for (int i = 0; i < br.dependent_count; i++)
+                  if (edge->string && strcmp(br.dependents[i], edge->string) == 0 &&
+                      strstr(br.dependent_meta[i].provenance, edge->valuestring) &&
+                      strcmp(br.dependent_meta[i].freshness, "current") == 0 &&
+                      br.dependent_meta[i].generation >= 1)
+                     matched = 1;
+               if (!matched)
+                  cfail = 1;
+            }
+            for (int i = 0; i < br.dependency_count; i++)
+               if (strcmp(br.dependency_meta[i].provenance, "import") != 0 ||
+                   strcmp(br.dependency_meta[i].freshness, "current") != 0)
+                  cfail = 1;
             printf("  [%s] %s: dependents=%d deps=%d%s\n", proj, edited, br.dependent_count,
                    br.dependency_count,
                    cfail ? "  <-- MISSED a dependent" : (dep_fp > before_fp ? "  (spurious)" : ""));

--- a/src/tests/test_extractors.c
+++ b/src/tests/test_extractors.c
@@ -67,6 +67,47 @@ static void test_c_imports(void)
       free(imports[i]);
 }
 
+static int has_import(char **imports, int count, const char *expected)
+{
+   for (int i = 0; i < count; i++)
+      if (strcmp(imports[i], expected) == 0)
+         return 1;
+   return 0;
+}
+
+static void test_python_import_identities(void)
+{
+   const char *source = "import app.dates as dates, app.money\n"
+                        "from app import dates, invoices\n"
+                        "from app.dates import billing_period_days\n"
+                        "from . import reports\n"
+                        "from ..shared import clock\n";
+   char *imports[32] = {0};
+   int count = extract_imports(".py", source, imports, 32);
+   assert(has_import(imports, count, "app.dates"));
+   assert(has_import(imports, count, "app.money"));
+   assert(has_import(imports, count, "app.invoices"));
+   assert(has_import(imports, count, ".reports"));
+   assert(has_import(imports, count, "..shared"));
+   for (int i = 0; i < count; i++)
+      free(imports[i]);
+
+   char identity[MAX_PATH_LEN];
+   assert(code_path_import_identity("app/dates.py", identity, sizeof(identity)) == 0);
+   assert(strcmp(identity, "app.dates") == 0);
+   assert(code_path_import_identity("app/dates/__init__.py", identity, sizeof(identity)) == 0);
+   assert(strcmp(identity, "app.dates") == 0);
+   assert(code_import_identity("app/billing.py", ".dates", identity, sizeof(identity)) == 0);
+   assert(strcmp(identity, "app.dates") == 0);
+   assert(code_import_identity("app/reports/monthly.py", "..dates", identity, sizeof(identity)) ==
+          0);
+   assert(strcmp(identity, "app.dates") == 0);
+   assert(code_import_resolves_path("app/billing.py", "app.dates", "app/dates.py"));
+   assert(code_import_resolves_path("app/invoices.py", ".dates", "app/dates.py"));
+   assert(!code_import_resolves_path("app/billing.py", "app.dates_extra", "app/dates.py"));
+   printf("python import identities OK\n");
+}
+
 static void test_c_exports(void)
 {
    char *exports[16];
@@ -359,6 +400,7 @@ int main(void)
 {
    test_def_end_line();
    test_c_imports();
+   test_python_import_identities();
    test_c_exports();
    test_c_definitions();
    test_c_env_var_extraction();

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -8,6 +8,7 @@
 #include "db.h"
 #include "db2.h"
 #include "canonical_index.h"
+#include "entity_edges.h"
 #include "db2_test_shim.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
@@ -688,6 +689,7 @@ int main(void)
           {"app/reports.py",
            "import app.dates\n\ndef report():\n    return billing_period_days()\n"},
           {"app/caller_only.py", "def preview():\n    return billing_period_days()\n"},
+          {"app/forecast.py", "def forecast():\n    return 30\n"},
           {"app/collision.py", "import app.dates_extra\n"},
       };
       int inspected = 0;
@@ -718,6 +720,15 @@ int main(void)
       assert(br.dependency_count == 1);
       assert(strcmp(br.dependencies[0], "app.calendar") == 0);
 
+      /* Projection-only local edges must still sort before the route-gated
+       * cross-project tail. Four bumps clear the projection weight gate. */
+      for (int bump = 0; bump < 4; bump++)
+      {
+         int added = 0;
+         assert(db2_entity_edge_upsert("dates.py", "co_edited", "forecast.py", 0, 0, 0, 0,
+                                       &added) == 0);
+      }
+
       canonical_index_file_input_t routed[] = {
           {"client/report.py", "import app.dates\n\ndef remote_report():\n    return 1\n"}};
       assert(canonical_index_scan_files("python-consumer", "/consumer", routed, 1, 1, &inspected) >=
@@ -735,9 +746,24 @@ int main(void)
                  sql_err, sizeof(sql_err)) == 0);
       assert(canonical_index_blast_radius("python-blast", "app/dates.py", &br) == 0);
       int found_cross = 0;
+      int found_projection = 0;
+      int seen_external = 0;
       for (int i = 0; i < br.dependent_count; i++)
       {
          assert(strcmp(br.dependents[i], "client/noise.py") != 0);
+         if (strcmp(br.dependent_meta[i].project, "python-blast") == 0)
+         {
+            assert(!seen_external);
+            if (strcmp(br.dependents[i], "app/forecast.py") == 0)
+            {
+               found_projection = 1;
+               assert(strstr(br.dependent_meta[i].provenance, "projection"));
+            }
+         }
+         else
+         {
+            seen_external = 1;
+         }
          if (strcmp(br.dependents[i], "client/report.py") == 0)
          {
             found_cross = 1;
@@ -746,6 +772,7 @@ int main(void)
             assert(strcmp(br.dependent_meta[i].confidence, "high") == 0);
          }
       }
+      assert(found_projection);
       assert(found_cross);
       memset(&br, 0, sizeof(br));
       assert(canonical_index_blast_radius("python-blast", "app/missing.py", &br) != 0);

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -675,6 +675,83 @@ int main(void)
       free(invalid_dir);
    }
 
+   /* E3 exact Python module graph: normal, explicit from-pair, and relative
+    * imports converge on app/dates.py; a prefix collision is excluded and a
+    * call-only user is merged with provenance. */
+   {
+      canonical_index_file_input_t inputs[] = {
+          {"app/dates.py", "import app.calendar\n\ndef billing_period_days():\n    return 30\n"},
+          {"app/billing.py",
+           "from app import dates\n\ndef bill():\n    return dates.billing_period_days()\n"},
+          {"app/invoices.py",
+           "from . import dates\n\ndef invoice():\n    return dates.billing_period_days()\n"},
+          {"app/reports.py",
+           "import app.dates\n\ndef report():\n    return billing_period_days()\n"},
+          {"app/caller_only.py", "def preview():\n    return billing_period_days()\n"},
+          {"app/collision.py", "import app.dates_extra\n"},
+      };
+      int inspected = 0;
+      assert(canonical_index_scan_files("python-blast", "/fixture", inputs,
+                                        (int)(sizeof(inputs) / sizeof(inputs[0])), 1,
+                                        &inspected) >= 0);
+      blast_radius_t br;
+      assert(canonical_index_blast_radius("python-blast", "app/dates.py", &br) == 0);
+      const char *expected[] = {"app/billing.py", "app/invoices.py", "app/reports.py",
+                                "app/caller_only.py"};
+      for (size_t e = 0; e < sizeof(expected) / sizeof(expected[0]); e++)
+      {
+         int found = 0;
+         for (int i = 0; i < br.dependent_count; i++)
+            if (strcmp(br.dependents[i], expected[e]) == 0)
+            {
+               found = 1;
+               assert(br.dependent_meta[i].provenance[0]);
+               assert(strcmp(br.dependent_meta[i].freshness, "current") == 0);
+               assert(br.dependent_meta[i].generation >= 1);
+            }
+         assert(found);
+      }
+      for (int i = 0; i < br.dependent_count; i++)
+         assert(strcmp(br.dependents[i], "app/collision.py") != 0);
+      assert(br.resolved == 1);
+      assert(strcmp(br.project, "python-blast") == 0);
+      assert(br.dependency_count == 1);
+      assert(strcmp(br.dependencies[0], "app.calendar") == 0);
+
+      canonical_index_file_input_t routed[] = {
+          {"client/report.py", "import app.dates\n\ndef remote_report():\n    return 1\n"}};
+      assert(canonical_index_scan_files("python-consumer", "/consumer", routed, 1, 1, &inspected) >=
+             0);
+      canonical_index_file_input_t unrouted[] = {
+          {"client/noise.py", "import app.dates\n\ndef noise():\n    return 1\n"}};
+      assert(canonical_index_scan_files("python-distractor", "/distractor", unrouted, 1, 1,
+                                        &inspected) >= 0);
+      char sql_err[256] = "";
+      assert(aimee_pg_exec(
+                 db2_conn(),
+                 "INSERT INTO cross_repo_route(caller_project,definer_project,kind,confidence,"
+                 "evidence) VALUES('python-consumer','python-blast','import_module','high',"
+                 "'app.dates')",
+                 sql_err, sizeof(sql_err)) == 0);
+      assert(canonical_index_blast_radius("python-blast", "app/dates.py", &br) == 0);
+      int found_cross = 0;
+      for (int i = 0; i < br.dependent_count; i++)
+      {
+         assert(strcmp(br.dependents[i], "client/noise.py") != 0);
+         if (strcmp(br.dependents[i], "client/report.py") == 0)
+         {
+            found_cross = 1;
+            assert(strcmp(br.dependent_meta[i].project, "python-consumer") == 0);
+            assert(strcmp(br.dependent_meta[i].provenance, "cross_repo") == 0);
+            assert(strcmp(br.dependent_meta[i].confidence, "high") == 0);
+         }
+      }
+      assert(found_cross);
+      memset(&br, 0, sizeof(br));
+      assert(canonical_index_blast_radius("python-blast", "app/missing.py", &br) != 0);
+      assert(br.resolved == 0);
+   }
+
    /* --- production co-change path: canonical scan populates co_edited edges from
     * git history, the bulk gate holds, re-scan is idempotent, and blast radius
     * surfaces a co-edited file with no structural import link. This guards the
@@ -697,12 +774,15 @@ int main(void)
       assert(scanned2 >= 0);
       assert(cochange_pair_weight("a.c", "b.c") == wab);
 
-      /* Blast radius surfaces b.c as co-edited with a.c (they share no import). */
+      /* Blast radius surfaces the uniquely resolved b.c projection with explicit
+       * provenance (they share no import). */
       blast_radius_t br;
       assert(canonical_index_blast_radius("cochangeproj", "a.c", &br) == 0);
       int found_coedited = 0;
       for (int i = 0; i < br.dependent_count; i++)
-         if (strstr(br.dependents[i], "b.c") && strstr(br.dependents[i], "co-edited"))
+         if (strcmp(br.dependents[i], "b.c") == 0 &&
+             strstr(br.dependent_meta[i].provenance, "projection") &&
+             strcmp(br.dependent_meta[i].freshness, "current") == 0)
             found_coedited = 1;
       assert(found_coedited);
 

--- a/src/tests/test_kb_client_search.c
+++ b/src/tests/test_kb_client_search.c
@@ -221,6 +221,38 @@ static int intelligence_get_handler(const char *url, const char *extra_headers, 
    return 200;
 }
 
+static char *blast_hot_response(void)
+{
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "file", "src/hot.c");
+   cJSON_AddStringToObject(root, "project", "aimee");
+   cJSON_AddNumberToObject(root, "generation", 7);
+   cJSON_AddStringToObject(root, "freshness", "current");
+   cJSON_AddBoolToObject(root, "resolved", 1);
+   cJSON *dependents = cJSON_AddArrayToObject(root, "dependents");
+   cJSON *edges = cJSON_AddArrayToObject(root, "dependent_edges");
+   for (char name = 'a'; name <= 'k'; name++)
+   {
+      char path[2] = {name, '\0'};
+      cJSON_AddItemToArray(dependents, cJSON_CreateString(path));
+      cJSON *edge = cJSON_CreateObject();
+      cJSON_AddStringToObject(edge, "path", path);
+      cJSON_AddStringToObject(edge, "provenance", "import");
+      cJSON_AddStringToObject(edge, "confidence", "high");
+      cJSON_AddStringToObject(edge, "project", "aimee");
+      cJSON_AddNumberToObject(edge, "generation", 7);
+      cJSON_AddStringToObject(edge, "freshness", "current");
+      cJSON_AddItemToArray(edges, edge);
+   }
+   cJSON_AddNumberToObject(root, "dependent_count", 11);
+   cJSON_AddArrayToObject(root, "dependencies");
+   cJSON_AddNumberToObject(root, "dependency_count", 0);
+   cJSON_AddArrayToObject(root, "dependency_edges");
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   return json;
+}
+
 static int index_get_handler(const char *url, const char *extra_headers, char **response_buf,
                              int timeout_ms)
 {
@@ -262,17 +294,21 @@ static int index_get_handler(const char *url, const char *extra_headers, char **
                                 "\"root\":\"/repo/aimee\",\"scanned_at\":\"2026-05-26 00:00:00\"}],"
                                 "\"next_cursor\":null}");
    }
-   else if (g_route_case == 13 || g_route_case == 14)
+   else if (g_route_case == 13 || g_route_case == 14 || g_route_case == 38)
    {
       assert(strstr(url, "http://127.0.0.1:4010/v1/code/blast-radius?project=aimee&file_path=") ==
              url);
-      if (strstr(url, "file_path=src%2Fhot.c"))
+      if (g_route_case == 38)
+      {
+         assert(strstr(url, "file_path=src%2Flegacy.c") != NULL);
+         if (response_buf)
+            *response_buf = strdup("{\"file\":\"src/legacy.c\",\"dependents\":[\"src/app.c\"],"
+                                   "\"dependencies\":[]}");
+      }
+      else if (strstr(url, "file_path=src%2Fhot.c"))
       {
          if (response_buf)
-            *response_buf =
-                strdup("{\"file\":\"src/hot.c\",\"dependents\":[\"a\",\"b\",\"c\",\"d\",\"e\","
-                       "\"f\",\"g\",\"h\",\"i\",\"j\",\"k\"],\"dependent_count\":11,"
-                       "\"dependencies\":[],\"dependency_count\":0}");
+            *response_buf = blast_hot_response();
       }
       else
       {
@@ -837,6 +873,10 @@ static void test_index_reads_use_v1_api_when_configured(void)
    assert(strcmp(br.dependent_meta[0].provenance, "import,call") == 0);
    assert(strcmp(br.dependency_meta[0].freshness, "current") == 0);
 
+   g_route_case = 38;
+   assert(kb_client_index_blast_radius("aimee", "src/legacy.c", &br) == -1);
+   assert(br.resolved == 0);
+
    g_route_case = 14;
    char *paths[] = {"src/main.c", "src/hot.c"};
    char *preview = kb_client_index_blast_radius_preview_json("aimee", paths, 2);
@@ -889,7 +929,7 @@ static void test_index_reads_use_v1_api_when_configured(void)
    assert(kb_client_index_find_callers_scoped("aimee core/kb?", 1, "target/fn?", caller_hits, 2) ==
           0);
 
-   assert(g_get_seen == 14);
+   assert(g_get_seen == 15);
    unsetenv("AIMEE_KB_API_URL");
    mock_agent_http_reset();
    g_route_case = 0;

--- a/src/tests/test_kb_client_search.c
+++ b/src/tests/test_kb_client_search.c
@@ -278,9 +278,16 @@ static int index_get_handler(const char *url, const char *extra_headers, char **
       {
          assert(strstr(url, "file_path=src%2Fmain.c") != NULL);
          if (response_buf)
-            *response_buf = strdup("{\"file\":\"src/main.c\",\"dependents\":[\"src/app.c\"],"
-                                   "\"dependent_count\":1,\"dependencies\":[\"src/lib.c\"],"
-                                   "\"dependency_count\":1}");
+            *response_buf = strdup(
+                "{\"file\":\"src/main.c\",\"project\":\"aimee\",\"generation\":7,"
+                "\"freshness\":\"current\",\"resolved\":true,"
+                "\"dependents\":[\"src/app.c\"],\"dependent_count\":1,"
+                "\"dependent_edges\":[{\"path\":\"src/app.c\",\"provenance\":\"import,call\","
+                "\"confidence\":\"high\",\"project\":\"aimee\",\"generation\":7,"
+                "\"freshness\":\"current\"}],\"dependencies\":[\"src/lib.c\"],"
+                "\"dependency_count\":1,\"dependency_edges\":[{\"identity\":\"src/lib.c\","
+                "\"provenance\":\"import\",\"confidence\":\"high\",\"project\":\"aimee\","
+                "\"generation\":7,\"freshness\":\"current\"}]}");
       }
    }
    else if (g_route_case == 18)
@@ -824,6 +831,11 @@ static void test_index_reads_use_v1_api_when_configured(void)
    assert(strcmp(br.dependents[0], "src/app.c") == 0);
    assert(br.dependency_count == 1);
    assert(strcmp(br.dependencies[0], "src/lib.c") == 0);
+   assert(br.resolved == 1);
+   assert(strcmp(br.project, "aimee") == 0);
+   assert(br.generation == 7);
+   assert(strcmp(br.dependent_meta[0].provenance, "import,call") == 0);
+   assert(strcmp(br.dependency_meta[0].freshness, "current") == 0);
 
    g_route_case = 14;
    char *paths[] = {"src/main.c", "src/hot.c"};

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -757,11 +757,26 @@ int db2_code_index_project_current_generation(const char *project, int64_t *gene
 
 typedef struct
 {
+   char provenance[48];
+   char confidence[16];
+   char project[128];
+   long long generation;
+   char freshness[16];
+} test_blast_meta_t;
+
+typedef struct
+{
    char file[MAX_PATH_LEN];
    char dependents[64][MAX_PATH_LEN];
    int dependent_count;
    char dependencies[64][MAX_PATH_LEN];
    int dependency_count;
+   char project[128];
+   long long generation;
+   char freshness[16];
+   int resolved;
+   test_blast_meta_t dependent_meta[64];
+   test_blast_meta_t dependency_meta[64];
 } test_blast_radius_t;
 
 int canonical_index_blast_radius(const char *project, const char *file_path, void *out)
@@ -777,6 +792,16 @@ int canonical_index_blast_radius(const char *project, const char *file_path, voi
    br->dependent_count = 1;
    snprintf(br->dependencies[0], sizeof(br->dependencies[0]), "src/lib.c");
    br->dependency_count = 1;
+   snprintf(br->project, sizeof(br->project), "proj-alpha");
+   br->generation = 9;
+   snprintf(br->freshness, sizeof(br->freshness), "current");
+   br->resolved = 1;
+   snprintf(br->dependent_meta[0].provenance, sizeof(br->dependent_meta[0].provenance), "import");
+   snprintf(br->dependent_meta[0].confidence, sizeof(br->dependent_meta[0].confidence), "high");
+   snprintf(br->dependent_meta[0].project, sizeof(br->dependent_meta[0].project), "proj-alpha");
+   br->dependent_meta[0].generation = 9;
+   snprintf(br->dependent_meta[0].freshness, sizeof(br->dependent_meta[0].freshness), "current");
+   br->dependency_meta[0] = br->dependent_meta[0];
    return 0;
 }
 
@@ -4368,7 +4393,7 @@ static void test_blast_radius_not_found(void)
 
 static void test_blast_radius_ok(void)
 {
-   char buf[512];
+   char buf[2048];
    int s =
        kb_http_route_ex("GET", "/v1/code/blast-radius", "project=proj-alpha&file_path=src/main.c",
                         NULL, NULL, NULL, 0, buf, sizeof(buf));
@@ -4380,6 +4405,11 @@ static void test_blast_radius_ok(void)
    assert(strstr(buf, "\"dependencies\"") != NULL);
    assert(strstr(buf, "\"src/lib.c\"") != NULL);
    assert(strstr(buf, "\"dependency_count\":1") != NULL);
+   assert(strstr(buf, "\"resolved\":true") != NULL);
+   assert(strstr(buf, "\"generation\":9") != NULL);
+   assert(strstr(buf, "\"dependent_edges\"") != NULL);
+   assert(strstr(buf, "\"provenance\":\"import\"") != NULL);
+   assert(strstr(buf, "\"freshness\":\"current\"") != NULL);
 }
 
 /* §6 live-idempotency stubs: the scan route gates the git re-walk on the default-


### PR DESCRIPTION
## Summary
- replace substring blast-radius matching with exact normalized import identities and current-generation target resolution
- merge unique direct-call evidence, uniquely resolved co-edit projections, and route-gated cross-project tails while keeping every active-project edge first
- carry provenance, confidence, project, generation, and freshness through HTTP, client, CLI, OpenAPI, and preview output
- fail closed on unresolved targets and metadata-less/partial E3 client responses while preserving additive legacy arrays on the wire

## Validation
- all 39 lint checks
- complete local unit-test suite
- focused extractor, index, HTTP, client, KB, and blast-radius corpus builds/tests
- adversarial collision, relative-import, ambiguous-call, local-projection-before-cross-project, un-routed distractor, and legacy-only client fixtures
- final frozen-diff roundtable approved/converged: `roundtable-327db1be95dc7e7c3abd2035`

Live PostgreSQL-only tests use the protected CI service container; local shim coverage passed.