### PR TITLE
Re-review exact human workflow repairs without synthetic edits

### DIFF
--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -288,13 +288,20 @@ func TestDocumentResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *tes
 	if err := os.WriteFile(filepath.Join(workdir, "runbook.md"), []byte("reviewed and human-repaired\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	gitRun(t, workdir, "add", "runbook.md")
-	gitRun(t, workdir, "commit", "-m", "human repair")
 	item, _ = store.WorkItem(ctx, "wi_root")
 	item.ContentHash = reviewedHash
 	item.Worktree = workdir
 	agents := &rejectDelegateAgents{}
 	runner := &NativeRunner{agents: agents, worktrees: manager, db: store}
+	request := StepRequest{WorkItem: item, Node: wfe.Node{ID: "document"},
+		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}
+	if _, err := runner.mutate(ctx, request, true); err == nil || agents.calls != 1 {
+		t.Fatalf("dirty repair bypassed delegate: calls=%d err=%v", agents.calls, err)
+	}
+
+	gitRun(t, workdir, "add", "runbook.md")
+	gitRun(t, workdir, "commit", "-m", "human repair")
+	agents.calls = 0
 	result, err := runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "document"},
 		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}, true)
 	if err != nil {

--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -232,6 +233,83 @@ func (a partialNoCommitAgents) DelegateGroup(_ context.Context, requests []Deleg
 		out[i] = DelegateGroupResult{Response: "partial"}
 	}
 	return out
+}
+
+type rejectDelegateAgents struct{ calls int }
+
+func (a *rejectDelegateAgents) Delegate(_ context.Context, _ DelegateRequest) (DelegateResult, error) {
+	a.calls++
+	return DelegateResult{}, errors.New("delegate must not run for an already-repaired reviewed tree")
+}
+
+func TestDocumentResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "init", "-b", "trunk")
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "README")
+	gitRun(t, repo, "commit", "-m", "init")
+	gitRun(t, repo, "remote", "add", "origin", repo)
+	gitRun(t, repo, "update-ref", "refs/remotes/origin/trunk", "HEAD")
+	gitRun(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+
+	store, err := db1.Open(filepath.Join(root, "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := t.Context()
+	if err := store.CreateWorkItem(ctx, db1.CreateWorkItem{ID: "wi_root", Repo: repo,
+		ProposalPath: "p", WorkflowName: "build", StartStage: "document"}); err != nil {
+		t.Fatal(err)
+	}
+	manager, err := NewWorktreeManager(store, filepath.Join(root, "trees"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	item, _ := store.WorkItem(ctx, "wi_root")
+	workdir, branch, err := manager.Ensure(ctx, item, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "runbook.md"), []byte("reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, workdir, "add", "runbook.md")
+	gitRun(t, workdir, "commit", "-m", "document")
+	reviewedDiff := gitRun(t, workdir, "--no-pager", "diff", "origin/trunk...HEAD")
+	reviewedHash := wfe.Hash([]byte(strings.TrimSpace(reviewedDiff)))
+
+	if err := os.WriteFile(filepath.Join(workdir, "runbook.md"), []byte("reviewed and human-repaired\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, workdir, "add", "runbook.md")
+	gitRun(t, workdir, "commit", "-m", "human repair")
+	item, _ = store.WorkItem(ctx, "wi_root")
+	item.ContentHash = reviewedHash
+	item.Worktree = workdir
+	agents := &rejectDelegateAgents{}
+	runner := &NativeRunner{agents: agents, worktrees: manager, db: store}
+	result, err := runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "document"},
+		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agents.calls != 0 {
+		t.Fatalf("delegate calls=%d, want 0", agents.calls)
+	}
+	if result.Status != StepAdvanced || result.Artifact != branch ||
+		!strings.Contains(result.Detail, "re-freezing exact repair") {
+		t.Fatalf("result=%+v", result)
+	}
+	if head := strings.TrimSpace(gitRun(t, workdir, "rev-parse", "HEAD")); result.ContentHash != head {
+		t.Fatalf("content hash=%q, want repaired HEAD %q", result.ContentHash, head)
+	}
 }
 
 func TestPartialImplementWithNoCommitDoesNotAdvance(t *testing.T) {

--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -317,6 +317,17 @@ func TestDocumentResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *tes
 	if head := strings.TrimSpace(gitRun(t, workdir, "rev-parse", "HEAD")); result.ContentHash != head {
 		t.Fatalf("content hash=%q, want repaired HEAD %q", result.ContentHash, head)
 	}
+
+	// Removing the entire reviewed diff is not a repair to re-freeze. The normal
+	// delegate path must handle it rather than letting freeze accept an empty root
+	// diff as a no-op without another roundtable review.
+	gitRun(t, workdir, "rm", "runbook.md")
+	gitRun(t, workdir, "commit", "-m", "remove reviewed document")
+	agents.calls = 0
+	if _, err := runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "document"},
+		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}, true); err == nil || agents.calls != 1 {
+		t.Fatalf("empty repair bypassed delegate: calls=%d err=%v", agents.calls, err)
+	}
 }
 
 func TestPartialImplementWithNoCommitDoesNotAdvance(t *testing.T) {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -538,7 +538,8 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		if statusErr != nil {
 			return StepResult{}, statusErr
 		}
-		if status == "" && wfe.Hash([]byte(diff)) != req.Feedback.ArtifactHash {
+		if status == "" && strings.TrimSpace(diff) != "" &&
+			wfe.Hash([]byte(diff)) != req.Feedback.ArtifactHash {
 			head, headErr := gitText(ctx, workdir, "rev-parse", "HEAD")
 			if headErr != nil {
 				return StepResult{}, headErr

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -524,7 +524,7 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	}
 	// A documentation gate can be resumed after a human repair commit. The
 	// reviewed hash then remains on both the work item and feedback artifact,
-	// while the exact frozen diff has changed. Send that new diff back through
+	// while the clean exact frozen diff has changed. Send that new diff back through
 	// freeze + roundtable rather than demanding that a delegate invent another
 	// edit solely to satisfy its "owned files changed" contract. This does not
 	// bypass review, and feedback left by an earlier gate cannot trigger it.
@@ -534,7 +534,11 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		if diffErr != nil {
 			return StepResult{}, diffErr
 		}
-		if wfe.Hash([]byte(diff)) != req.Feedback.ArtifactHash {
+		status, statusErr := gitText(ctx, workdir, "status", "--porcelain")
+		if statusErr != nil {
+			return StepResult{}, statusErr
+		}
+		if status == "" && wfe.Hash([]byte(diff)) != req.Feedback.ArtifactHash {
 			head, headErr := gitText(ctx, workdir, "rev-parse", "HEAD")
 			if headErr != nil {
 				return StepResult{}, headErr

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -522,6 +522,27 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 				Detail: "conflict merging aimee/feat/" + req.WorkItem.ParentID + " into slice"}, nil
 		}
 	}
+	// A documentation gate can be resumed after a human repair commit. The
+	// reviewed hash then remains on both the work item and feedback artifact,
+	// while the exact frozen diff has changed. Send that new diff back through
+	// freeze + roundtable rather than demanding that a delegate invent another
+	// edit solely to satisfy its "owned files changed" contract. This does not
+	// bypass review, and feedback left by an earlier gate cannot trigger it.
+	if docs && req.Feedback != nil && req.WorkItem.ContentHash != "" &&
+		req.WorkItem.ContentHash == req.Feedback.ArtifactHash {
+		diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
+		if diffErr != nil {
+			return StepResult{}, diffErr
+		}
+		if wfe.Hash([]byte(diff)) != req.Feedback.ArtifactHash {
+			head, headErr := gitText(ctx, workdir, "rev-parse", "HEAD")
+			if headErr != nil {
+				return StepResult{}, headErr
+			}
+			return StepResult{Status: StepAdvanced, ArtifactType: "branch", Artifact: branch,
+				ContentHash: head, Detail: "reviewed worktree advanced; re-freezing exact repair"}, nil
+		}
+	}
 	prompt := "Implement the complete approved task in this worktree, run the repository verification, fix failures, and leave the accepted changes in the worktree."
 	if docs {
 		prompt = "Document the complete implemented change in this worktree. Update the appropriate user and developer documentation and inline comments; leave the accepted changes in the worktree."
@@ -852,25 +873,7 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 	if err != nil {
 		return StepResult{}, err
 	}
-	base := ""
-	if item.ParentID != "" {
-		// Slice PRs merge through the forge, which advances the remote feature
-		// branch while the local aimee/feat/<parent> ref stays at the run's
-		// starting point.  Freeze against the same fetched feature tip used by
-		// slice creation/integration; otherwise every later slice's review
-		// artifact incorrectly includes all previously merged sibling work.
-		base = featureBaseRef(ctx, workdir, item.ParentID)
-		if base == "" {
-			return StepResult{}, errors.New("parent feature branch is unavailable")
-		}
-	} else {
-		trunk, e := repoDefaultBranch(ctx, workdir)
-		if e != nil {
-			return StepResult{}, e
-		}
-		base = "origin/" + trunk
-	}
-	diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"...HEAD")
+	diff, err := frozenWorktreeDiff(ctx, item, workdir)
 	if err != nil {
 		return StepResult{}, err
 	}
@@ -883,6 +886,32 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		return StepResult{Status: StepAccepted, Detail: "no-op: empty diff vs base"}, nil
 	}
 	return StepResult{Status: StepAdvanced, ArtifactType: "frozen_diff", Artifact: diff, ContentHash: wfe.Hash([]byte(diff))}, nil
+}
+
+func frozenWorktreeDiff(ctx context.Context, item db1.WorkItem, workdir string) (string, error) {
+	base := ""
+	if item.ParentID != "" {
+		// Slice PRs merge through the forge, which advances the remote feature
+		// branch while the local aimee/feat/<parent> ref stays at the run's
+		// starting point.  Freeze against the same fetched feature tip used by
+		// slice creation/integration; otherwise every later slice's review
+		// artifact incorrectly includes all previously merged sibling work.
+		base = featureBaseRef(ctx, workdir, item.ParentID)
+		if base == "" {
+			return "", errors.New("parent feature branch is unavailable")
+		}
+	} else {
+		trunk, e := repoDefaultBranch(ctx, workdir)
+		if e != nil {
+			return "", e
+		}
+		base = "origin/" + trunk
+	}
+	diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"...HEAD")
+	if err != nil {
+		return "", err
+	}
+	return diff, nil
 }
 
 type panelFinding struct {


### PR DESCRIPTION
## Problem

A documentation roundtable can park a root workflow for human repair. After the operator commits the exact repair and resumes the item, the document node still dispatches a code delegate. The delegate sees that every finding is already resolved, makes no file change, and returns a partial/no-op result. Root items deliberately do not use the slice-only `branchHasWorkOverBase` exemption, so the node loops forever instead of reviewing the repaired tree.

This happened in the live five-proposal run after the appliance recovery runbook was repaired at an exact commit.

## What changed

- When a document node is carrying feedback for the same reviewed hash recorded on the work item, compute the current frozen diff before dispatch.
- If that exact diff changed and the worktree is clean and non-empty, advance to the existing freeze and roundtable nodes without invoking a delegate merely to manufacture another edit.
- Keep first-pass documentation strict and ignore stale feedback from earlier gates: both the work-item hash and feedback artifact hash must match.
- Refuse the shortcut for uncommitted or empty repairs; the normal delegate path remains responsible for them.
- Extract the existing frozen-diff calculation so the detection and freeze node use identical base semantics.

## Safety boundary

This does not approve or merge anything. The clean externally advanced tree is frozen and reviewed by the configured roundtable, and the final proposal PR remains human-only. Empty, unchanged, or dirty trees still follow the existing delegate path.

## Verification

- `go test ./internal/engine -count=1`
- `go test ./...`
- Regression coverage proves a dirty repair cannot bypass delegation, proves an empty repair cannot be accepted as a no-op, then proves the committed exact repair advances without a delegate call and preserves the repaired HEAD as the branch artifact.