### PR TITLE
Expose code dependency status and recovery

### DIFF
--- a/docs/CODE_INTELLIGENCE.md
+++ b/docs/CODE_INTELLIGENCE.md
@@ -76,9 +76,15 @@ when it is linked to accepted code. Every code item carries project, path, gener
 provenance, and a line-or-file span.
 
 A query without sufficient current-project code evidence returns HTTP 200 with
-`status: no_answer`, empty `results`, and empty `why`. It does not substitute global episodic
+`status: abstained`, an `answerability.decision` of `no_answer`, empty `results`, and empty `why`.
+It does not substitute global episodic
 memory. The same local-first policy applies to the older hybrid memory annotations: project memory
 is selected before workspace/shared memory and broad scope is never implicit.
+
+Hybrid code responses always include `vector_status`: `disabled`, `ok`, `empty`, `stale`,
+`unavailable`, or `unauthorized`. When the vector leg is stale, unavailable, or unauthorized,
+dependency and dimension/retryability metadata are included; lexical and graph results remain usable
+when they independently answer the query.
 
 Ingress rollout is controlled by `code_context_mode`:
 
@@ -88,8 +94,30 @@ Ingress rollout is controlled by `code_context_mode`:
 - `on` injects a packet only on the first turn of a session task or a low-overlap task change.
 
 `on` does not repeat context for an ordinary follow-up and does not broaden after `no_answer` or an
-unavailable KB. If the request working directory cannot resolve a durable active-project identity,
-agent ingress suppresses code and memory recall rather than issuing an unscoped query.
+unavailable KB. An unavailable first/new-task lookup rearms only its exact session/project marker,
+so a related follow-up can use the dependency breaker's single recovery probe; successful,
+genuinely empty, stale, and abstained results remain consumed. If the request working directory
+cannot resolve a durable active-project identity, agent ingress suppresses code and memory recall
+rather than issuing an unscoped query.
+
+## Dependency status and recovery
+
+Agent-facing retrieval preserves six outcomes: `ok`, `empty`, `abstained`, `stale`, `unavailable`,
+and `unauthorized`. `empty` is emitted only after a valid response; an outage or malformed response
+is never converted to an empty list. Stale results carry the observed/current generation or vector
+dimension when available. Unavailable results name the failed dependency, say whether retry is
+safe, and include a bounded retry delay.
+
+The server-side KB client and the KB-side external embedder each use a process-local circuit
+breaker. Three consecutive transient failures open it with bounded exponential backoff and jitter.
+Calls during the delay are suppressed, then exactly one half-open recovery probe is admitted.
+Success closes the breaker without restarting the client. A reachable KB reporting its own
+embedder or vector-store outage does not open the KB transport breaker, so unrelated KB operations
+remain usable. Built-in local embeddings bypass the external dependency breaker.
+
+Local inspection, editing, and tests do not depend on KB recovery. Clients may fall back to those
+local operations on `unavailable`, but must not silently retry without a bound or report an
+Aimee-assisted result for the failed turn.
 
 ## Audits
 

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -1,6 +1,6 @@
 # Proposal: Agent-facing code intelligence effectiveness
 
-- **State:** PENDING — E4–E6 remain; E0 through E3 history is recorded below
+- **State:** PENDING — E5–E6 remain; E0 through E4 history is recorded below
 - **Author:** JBailes
 - **Date:** 2026-07-29
 - **Charter roles:** Recall, Rank-Fuse, Calibrate / Evaluate-Optimize, Enforce, Gate-Promote
@@ -745,3 +745,37 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   failures rather than speculative widening. Named policy constants are a readability follow-up.
   Roundtable run: `oprun_g6a69bd8011459d99_1785391948_125` (artifact
   `abdfa92e2489d4c73cdb05c18ec067fb8463296c5ed45eb376fe66bb70e986ac`).
+- **E4 task-conditioned retrieval slice:** PR #2171 merged to `testing` as
+  `7a8a20753c37eba57fefdbe91fd256b2b81e0f91` after all 24 CI checks passed. Strict current-project
+  context, explicit abstention, bounded observe/on ingress, complete provenance, and automatic
+  suppression are now the base for E5–E6; `observe` remains the shipping default.
+- **E5a dependency-status candidate:** the implementation adds exact `ok|empty|abstained|stale|
+  unavailable|unauthorized` classification, independent KB-transport and external-embedder circuit
+  breakers, bounded exponential jitter, one half-open recovery probe, dependency-specific outage
+  metadata, and exact session/project retry after an unavailable first-turn lookup. A reachable KB's
+  embedder/vector-store outage does not poison its transport breaker, local coding remains
+  independent, and no agent-facing memory/index reader converts an outage into an empty result. Its
+  frozen implementation diff receives a separate roundtable gate before PR.
+- **E5a implementation round 1 — 2026-07-30 — changes requested, 3/3 participants, not
+  degraded.** The implementation received no bounded-slice technical ruling because the review
+  brief exposed the unfinished parent E5/E6 program. The next review explicitly binds the frozen
+  diff to E5a as the independently mergeable slice required by §6. Roundtable run:
+  `oprun_g6a69bd8011459d99_1785396259_129`.
+- **E5a implementation round 2 — 2026-07-30 — changes requested, 2/3 participants used,
+  degraded.** The scoped review found that the status envelope omitted a concrete bounded retry
+  delay and that vector-dimension staleness evidence was lost across the KB client boundary. E5a now
+  carries both contracts end to end with regressions. Roundtable run:
+  `oprun_g6a69bd8011459d99_1785396774_130`.
+- **E5a implementation round 3 — 2026-07-30 — changes requested, 3/3 participants, not
+  degraded.** Four remaining boundary findings were accepted: valid no-answer is `abstained`, retry
+  delays have a one-second floor, an exact memory miss remains distinct from transport failure, and
+  vector-status documentation applies unconditionally. The fixtures and docs now enforce all four.
+  Roundtable run: `oprun_g6a69bd8011459d99_1785397781_131`.
+- **E5a implementation round 4 — 2026-07-30 — changes requested, 2/3 participants used,
+  degraded.** The panel found three concrete non-2xx/parser gaps: mTLS GET/POST bodies could bypass
+  HTTP status rejection, a malformed project-list object could become an empty list, and external
+  embedder 401/403 could become transient unavailability. E5a now preserves the typed mTLS status
+  while rejecting its body, requires a real `projects` array, and returns non-retryable embedder
+  unauthorized without poisoning the transient-failure breaker. Adversarial fixtures cover each
+  transport. Roundtable run: `oprun_g6a69bd8011459d99_1785399544_132` (artifact
+  `0691c47bbc47d1854c00df172d01745bd29eab47956d43e22bca01fe3462d812`).

--- a/docs/validation/agent-facing-code-intelligence-e5a-dependency-recovery.md
+++ b/docs/validation/agent-facing-code-intelligence-e5a-dependency-recovery.md
@@ -1,0 +1,124 @@
+# E5a dependency status and recovery validation
+
+- **Date:** 2026-07-30 UTC
+- **Slice:** E5a of `agent-facing-code-intelligence-effectiveness.md`
+- **Base:** `testing` at `f889a05b9` after the final pre-publication rebase
+- **Candidate branch:** `agent/indexing-e5a-dependency-recovery`
+- **Environment:** Linux x86_64, GCC with `-Werror`, clang-format 19.1.7
+
+## Contract exercised
+
+The checked-in fixtures cover the dependency boundary independently of deployment policy:
+
+1. Agent-facing retrieval classifies exactly `ok`, `empty`, `abstained`, `stale`, `unavailable`,
+   or `unauthorized`; a transport failure or invalid response cannot become an empty result.
+2. The KB transport and external embedder have independent process-local breakers. Three
+   consecutive transient failures open a breaker with bounded exponential jitter; further calls
+   are suppressed until exactly one half-open probe is eligible.
+3. A successful half-open probe closes the breaker without a client/process restart. Failed probes
+   reopen it with a larger delay capped at 30 seconds.
+4. A reachable KB's typed embedder or vector-store outage preserves that dependency identity and
+   does not trip the KB transport breaker or suppress unrelated KB routes.
+5. External embedder failure and vector-dimension mismatch are distinct from a valid no-answer:
+   unavailable returns HTTP 503 and stale returns HTTP 409 with dimension evidence.
+6. Agent-facing code and memory readers preserve typed failures instead of rendering them as an
+   empty index, `[]`, “not found,” or an abstention.
+7. An unavailable first/new-task retrieval rearms only the exact session/project marker. A related
+   follow-up can use the breaker's recovery probe, while successful/empty/abstained results retain
+   the existing no-repeat behavior.
+8. Built-in local embeddings and all local inspection/edit/test paths bypass these optional-service
+   breakers.
+
+E5b separately owns process liveness versus retrieval readiness, deployment restart policy,
+operator diagnostics, and the recovery runbook. E5c owns infrastructure-invalid benchmark cells
+and checkpoint/resume semantics.
+
+## Focused commands and results
+
+```text
+make -C src build/obj/tests/unit-test-dependency-breaker \
+  build/obj/tests/unit-test-kb-client-search \
+  build/obj/tests/unit-test-kb-client-memory \
+  build/obj/tests/unit-test-ingress-preinject \
+  build/obj/tests/unit-test-memory \
+  build/obj/tests/unit-test-memory-embed-http-auth \
+  build/obj/tests/unit-test-kb-http-routes -j4
+
+src/build/obj/tests/unit-test-dependency-breaker
+src/build/obj/tests/unit-test-kb-client-search
+src/build/obj/tests/unit-test-kb-client-memory
+src/build/obj/tests/unit-test-ingress-preinject
+src/build/obj/tests/unit-test-memory
+src/build/obj/tests/unit-test-memory-embed-http-auth
+src/build/obj/tests/unit-test-kb-http-routes
+```
+
+All seven binaries passed. The dependency fixture proves bounded jitter, suppression, one half-open
+probe, increasing retry delay, and recovery. The KB-client fixture proves all six statuses,
+unauthorized non-retryability, dependency metadata, transport suppression, recovery, and identical
+non-2xx handling for HTTP and mTLS transports. Its mTLS raw-body fixture also proves multipart
+content type is preserved without falling through to the URL transport. The KB-memory fixture proves
+unreachable and healthy-empty reads remain distinct across an opened breaker. The ingress fixture
+proves retry after an unavailable first lookup. The memory fixtures prove the same breaker lifecycle
+for an external command embedder and preserve external HTTP 401/403 as unauthorized without
+poisoning that breaker. The HTTP fixture proves embedder outage, embedder authorization failure,
+vector-store outage, and dimension staleness are not reported as `no_answer`.
+
+## Project verification
+
+```text
+make -C src kb server -j4
+make -C src lint
+make -C src proposal-links-check api-conformance-check v1-method-coverage-check
+make -C src -j4 unit-tests TEST_RUN_JOBS=4
+python3 benchmarks/code-agent-effectiveness/validate_fixtures.py --verify-sources
+git diff --check
+```
+
+The shipping KB/server build, complete lint suite, proposal links, documented-endpoint conformance,
+and dispatch-method coverage all passed. The complete unit suite passed with four-way execution.
+The PostgreSQL RLS isolation gate was not run locally because `AIMEE_TEST_PG_URL` is unset; its
+required CI job runs against pgvector on every push. `git diff --check` passed.
+
+## Frozen-diff review trail
+
+The review gate was scoped to E5a. It reviewed implementation and failure semantics, not Ponytail
+task quality, and none of its verdicts are benchmark evidence.
+
+- Run `oprun_g6a69bd8011459d99_1785396259_129` converged without approval. It identified that the
+  submitted brief exposed the unfinished parent E5/E6 program instead of binding the review to the
+  independently mergeable E5a slice; the next review was explicitly scoped to the E5a contract.
+- Run `oprun_g6a69bd8011459d99_1785396774_130` converged without approval with two of three seats.
+  It identified missing retry-delay metadata and missing vector-dimension evidence at the client
+  boundary. Both contracts and their regressions were added.
+- Run `oprun_g6a69bd8011459d99_1785397781_131` converged without approval with all three seats. It
+  identified valid no-answer classification, bounded retry-delay floors, exact memory-miss versus
+  transport-failure behavior, and unconditional vector-status documentation. Those findings were
+  incorporated.
+- Run `oprun_g6a69bd8011459d99_1785399544_132` converged without approval with two of three seats.
+  It found three remaining transport boundaries: mTLS non-2xx bodies could reach result parsers,
+  malformed project-list responses could look empty, and external embedder 401/403 could look
+  unavailable. mTLS now rejects non-2xx bodies after preserving typed status, the list parser
+  requires a real `projects` array, and embedder authorization is a non-retryable unauthorized
+  result that does not advance the transient-failure breaker.
+- Runs `oprun_g6a69bd8011459d99_1785401243_133` and
+  `oprun_g6a69bd8011459d99_1785401479_134` converged without approval because an incorrect HTTP
+  artifact field delivered only the review brief, not the frozen diff. They made no code finding
+  and were discarded; the subsequent reviews use the transport's actual artifact field.
+- Run `oprun_g6a69bd8011459d99_1785403230_135` converged without approval with all three seats. It
+  found that raw-body POSTs used by documentation uploads lacked the mTLS branch and could falsely
+  advance the KB transport breaker. The helper now preserves the caller's content type over mTLS,
+  rejects typed non-2xx responses, and has a fail-fast regression proving it cannot fall through to
+  the URL transport in an mTLS-only deployment.
+- Run `oprun_g6a69bd8011459d99_1785404088_136` began the closure review but was interrupted by a
+  server replacement before producing an aggregate. Replacement run
+  `oprun_g6a6b1ed93980fd5d_1785405189_1` reviewed the recovered identical frozen artifact
+  (`2e85eb22015472171720d38cbc1efb9880173681c9dd85d639c0d7d148c79520`), converged with two of
+  three seats, and approved it with no findings. One participant failed, so the approved aggregate
+  is marked degraded.
+
+## Evidence boundary
+
+This slice verifies truthful failure and recovery mechanics; it does not claim a coding-quality
+improvement. The interrupted Ponytail artifacts remain historical red evidence and are not used or
+spliced into this validation. E6 must run a fresh pinned matrix after E5a–E5c merge.

--- a/src/headers/dependency_breaker.h
+++ b/src/headers/dependency_breaker.h
@@ -1,0 +1,199 @@
+/* dependency_breaker.h: small process-local circuit breaker for optional services.
+ *
+ * Callers own the state and the clock. The breaker performs no retries itself:
+ * after consecutive failures it suppresses calls for a bounded, jittered
+ * exponential delay, then grants exactly one half-open recovery probe. This
+ * keeps request paths bounded while allowing recovery without a process restart.
+ *
+ * The implementation is header-only so the same C11 primitive can be used by
+ * the server-side KB client and the KB-side embedder without adding a new link
+ * dependency to the many focused unit-test binaries that exercise those paths. */
+#ifndef DEC_DEPENDENCY_BREAKER_H
+#define DEC_DEPENDENCY_BREAKER_H 1
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
+
+#define DEPENDENCY_BREAKER_DEFAULT_THRESHOLD 3U
+#define DEPENDENCY_BREAKER_DEFAULT_BASE_MS   1000LL
+#define DEPENDENCY_BREAKER_DEFAULT_MAX_MS    30000LL
+
+typedef struct
+{
+   atomic_flag lock;
+   unsigned failure_streak;
+   unsigned open_count;
+   int probe_inflight;
+   int64_t opened_at_ms;
+   int64_t retry_at_ms;
+   int64_t last_success_ms;
+   int64_t last_failure_ms;
+   uint64_t suppressed_calls;
+} dependency_breaker_t;
+
+#define DEPENDENCY_BREAKER_INITIALIZER {ATOMIC_FLAG_INIT, 0U, 0U, 0, 0, 0, 0, 0, 0U}
+
+typedef struct
+{
+   unsigned failure_streak;
+   unsigned open_count;
+   int open;
+   int probe_inflight;
+   int64_t retry_after_ms;
+   int64_t last_success_ms;
+   int64_t last_failure_ms;
+   uint64_t suppressed_calls;
+} dependency_breaker_snapshot_t;
+
+static inline void dependency_breaker_lock(dependency_breaker_t *breaker)
+{
+   while (atomic_flag_test_and_set_explicit(&breaker->lock, memory_order_acquire))
+      ;
+}
+
+static inline void dependency_breaker_unlock(dependency_breaker_t *breaker)
+{
+   atomic_flag_clear_explicit(&breaker->lock, memory_order_release);
+}
+
+/* Return true for ordinary closed-state calls and for the single caller that
+ * claims an eligible half-open probe. retry_after_ms is populated on denial. */
+static inline int dependency_breaker_allow(dependency_breaker_t *breaker, int64_t now_ms,
+                                           int64_t *retry_after_ms)
+{
+   if (retry_after_ms)
+      *retry_after_ms = 0;
+   if (!breaker)
+      return 1;
+
+   dependency_breaker_lock(breaker);
+   int allow = 1;
+   if (breaker->retry_at_ms > 0)
+   {
+      /* A backward wall-clock jump must not extend a bounded outage forever. */
+      int eligible = now_ms >= breaker->retry_at_ms || now_ms < breaker->opened_at_ms;
+      if (eligible && !breaker->probe_inflight)
+         breaker->probe_inflight = 1;
+      else
+      {
+         allow = 0;
+         breaker->suppressed_calls++;
+         if (retry_after_ms && !eligible)
+            *retry_after_ms = breaker->retry_at_ms - now_ms;
+      }
+   }
+   dependency_breaker_unlock(breaker);
+   return allow;
+}
+
+static inline int64_t dependency_breaker_delay_ms(unsigned open_count, int64_t now_ms,
+                                                  int64_t base_ms, int64_t max_ms)
+{
+   if (base_ms < 1)
+      base_ms = 1;
+   if (max_ms < base_ms)
+      max_ms = base_ms;
+
+   int64_t delay = base_ms;
+   for (unsigned i = 0; i < open_count && delay < max_ms; i++)
+      delay = delay > max_ms / 2 ? max_ms : delay * 2;
+
+   int64_t jitter_cap = delay / 4;
+   if (jitter_cap > max_ms - delay)
+      jitter_cap = max_ms - delay;
+   if (jitter_cap > 0)
+   {
+      uint64_t mixed = (uint64_t)now_ms ^ ((uint64_t)(open_count + 1U) * 0x9e3779b97f4a7c15ULL);
+      delay += (int64_t)(mixed % (uint64_t)(jitter_cap + 1));
+   }
+   return delay;
+}
+
+static inline void dependency_breaker_report_success(dependency_breaker_t *breaker, int64_t now_ms)
+{
+   if (!breaker)
+      return;
+   dependency_breaker_lock(breaker);
+   breaker->failure_streak = 0;
+   breaker->open_count = 0;
+   breaker->probe_inflight = 0;
+   breaker->opened_at_ms = 0;
+   breaker->retry_at_ms = 0;
+   breaker->last_success_ms = now_ms;
+   dependency_breaker_unlock(breaker);
+}
+
+/* Release a claimed half-open probe when a local preflight error prevented any
+ * dependency call. Neither success nor failure may be inferred from that. */
+static inline void dependency_breaker_cancel_probe(dependency_breaker_t *breaker)
+{
+   if (!breaker)
+      return;
+   dependency_breaker_lock(breaker);
+   breaker->probe_inflight = 0;
+   dependency_breaker_unlock(breaker);
+}
+
+static inline void dependency_breaker_report_failure(dependency_breaker_t *breaker, int64_t now_ms,
+                                                     unsigned threshold, int64_t base_ms,
+                                                     int64_t max_ms)
+{
+   if (!breaker)
+      return;
+   if (threshold < 1U)
+      threshold = 1U;
+   dependency_breaker_lock(breaker);
+   if (breaker->failure_streak < UINT32_MAX)
+      breaker->failure_streak++;
+   breaker->last_failure_ms = now_ms;
+   breaker->probe_inflight = 0;
+   if (breaker->failure_streak >= threshold)
+   {
+      int64_t delay = dependency_breaker_delay_ms(breaker->open_count, now_ms, base_ms, max_ms);
+      breaker->opened_at_ms = now_ms;
+      breaker->retry_at_ms = now_ms + delay;
+      if (breaker->open_count < UINT32_MAX)
+         breaker->open_count++;
+   }
+   dependency_breaker_unlock(breaker);
+}
+
+static inline void dependency_breaker_snapshot(dependency_breaker_t *breaker, int64_t now_ms,
+                                               dependency_breaker_snapshot_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   if (!breaker)
+      return;
+   dependency_breaker_lock(breaker);
+   out->failure_streak = breaker->failure_streak;
+   out->open_count = breaker->open_count;
+   out->open = breaker->retry_at_ms > 0;
+   out->probe_inflight = breaker->probe_inflight;
+   if (breaker->retry_at_ms > now_ms && now_ms >= breaker->opened_at_ms)
+      out->retry_after_ms = breaker->retry_at_ms - now_ms;
+   out->last_success_ms = breaker->last_success_ms;
+   out->last_failure_ms = breaker->last_failure_ms;
+   out->suppressed_calls = breaker->suppressed_calls;
+   dependency_breaker_unlock(breaker);
+}
+
+static inline void dependency_breaker_reset(dependency_breaker_t *breaker)
+{
+   if (!breaker)
+      return;
+   dependency_breaker_lock(breaker);
+   breaker->failure_streak = 0;
+   breaker->open_count = 0;
+   breaker->probe_inflight = 0;
+   breaker->opened_at_ms = 0;
+   breaker->retry_at_ms = 0;
+   breaker->last_success_ms = 0;
+   breaker->last_failure_ms = 0;
+   breaker->suppressed_calls = 0;
+   dependency_breaker_unlock(breaker);
+}
+
+#endif /* DEC_DEPENDENCY_BREAKER_H */

--- a/src/headers/kb_tls.h
+++ b/src/headers/kb_tls.h
@@ -122,6 +122,14 @@ extern "C"
                                   const char *body, const char *authorization, int close_after,
                                   char *resp_out, size_t resp_cap, int *status_out,
                                   int *reusable_out);
+   /* As above, but preserve an explicit caller-owned Content-Type header for
+    * non-JSON bodies such as documentation multipart uploads. NULL selects the
+    * existing application/json default. */
+   int kb_tls_client_conn_request_with_type(kb_tls_client_conn_t *conn, const char *method,
+                                            const char *path, const char *body,
+                                            const char *authorization, const char *content_type,
+                                            int close_after, char *resp_out, size_t resp_cap,
+                                            int *status_out, int *reusable_out);
    void kb_tls_client_conn_close(kb_tls_client_conn_t *conn);
 
    /* TOFU bootstrap: fetch the kb's CA certificate from GET /v1/enroll/ca and

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -958,6 +958,23 @@ int memory_graph_normalize(void);
 
 int memory_embed(int64_t memory_id, const char *command);
 int memory_embed_text(const char *text, const char *command, float *out, int max_dim);
+
+typedef struct
+{
+   char state[16]; /* closed | open | half_open */
+   int available;
+   unsigned failure_streak;
+   unsigned recovery_attempt;
+   int64_t retry_after_ms;
+   int64_t last_success_ms;
+   int64_t last_failure_ms;
+   uint64_t suppressed_calls;
+} memory_embedder_health_t;
+
+void memory_embedder_health(memory_embedder_health_t *out);
+int memory_embedder_last_result_unauthorized(void);
+void memory_embedder_dependency_reset_for_tests(void);
+void memory_embedder_dependency_set_clock_for_tests(int64_t (*now_ms)(void));
 double cosine_similarity(const float *a, const float *b, int dim);
 
 /* Test hooks for the per-recall query-embedding memo (memory_core_helpers.inc).

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -1,4 +1,5 @@
 #include "kb_http_code.h"
+#include "kb_http_code_vector_status.h"
 #include "aimee.h"
 #include "config.h"
 #include "kb_curator_queue.h"
@@ -1163,6 +1164,7 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
     * simply empty and the route degrades to code+graph. w_vector<=0 disables it. */
    int nv = 0;
    int nvector = 0;
+   kb_code_vector_status_t vector_status = KB_CODE_VECTOR_STATUS_INITIALIZER;
    /* The vector API returns paths without owning projects. It is therefore safe
     * only with an active project, which is also the bucket queried here. */
    if (w_vector > 0.0 && project[0])
@@ -1172,8 +1174,10 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       int qdim = memory_embed_text(query, embed_cmd, qvec, EMBED_MAX_DIM);
       if (qdim > 0 && qdim == db2_embedding_dim())
       {
-         nv = pgvec_code_search_paths(proj, qvec, qdim, HYBRID_PER_SIGNAL, (char *)vpaths,
-                                      (int)sizeof(vpaths[0]), vscores, HYBRID_PER_SIGNAL);
+         int vector_rc =
+             pgvec_code_search_paths(proj, qvec, qdim, HYBRID_PER_SIGNAL, (char *)vpaths,
+                                     (int)sizeof(vpaths[0]), vscores, HYBRID_PER_SIGNAL);
+         nv = vector_rc;
          if (nv < 0)
             nv = 0;
          for (int i = 0; i < nv; i++)
@@ -1185,9 +1189,12 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
             hybrid_candidate_key(id, vector_items[nvector].id, sizeof(vector_items[nvector].id));
             vector_items[nvector++].structural_weight = 0;
          }
+         kb_code_vector_status_store(&vector_status, vector_rc, nv);
       }
+      else
+         kb_code_vector_status_embed(&vector_status, embed_cmd, qdim, db2_embedding_dim(),
+                                     memory_embedder_last_result_unauthorized());
    }
-
    /* Signal D — cross-session memory / knowledge graph (§6 fusion). Symbol-anchored
     * like the graph leg: seed the symbol's entity node and walk its incident
     * knowledge-graph edges (built by the curator across sessions), resolving each
@@ -1318,6 +1325,7 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       return 500;
    }
    cJSON_AddStringToObject(resp, "status", "ok");
+   kb_code_vector_status_add_json(resp, &vector_status);
    cJSON_AddStringToObject(resp, "query", query);
    if (symbol[0])
       cJSON_AddStringToObject(resp, "symbol", symbol);

--- a/src/kb/http/kb_http_code_context.c
+++ b/src/kb/http/kb_http_code_context.c
@@ -6,6 +6,7 @@
  * structural evidence leads, weak vector-only rows are rejected, and memory is
  * additive only after code evidence made the task answerable. */
 #include "kb_http_code.h"
+#include "kb_http_code_vector_status.h"
 #include "canonical_index.h"
 #include "code_index.h"
 #include "memory.h"
@@ -316,7 +317,61 @@ int handle_get_code_context(const char *query_string, char *out_buf, int out_cap
    }
 
    int answerable = cJSON_GetArraySize(results) > 0;
-   cJSON_AddStringToObject(response, "status", answerable ? "ok" : "no_answer");
+   const cJSON *vector_status = cJSON_GetObjectItemCaseSensitive(source, "vector_status");
+   if (!answerable && cJSON_IsString(vector_status) &&
+       (strcmp(vector_status->valuestring, "unavailable") == 0 ||
+        strcmp(vector_status->valuestring, "stale") == 0 ||
+        strcmp(vector_status->valuestring, "unauthorized") == 0))
+   {
+      const char *status = vector_status->valuestring;
+      int stale = strcmp(status, "stale") == 0;
+      int unauthorized = strcmp(status, "unauthorized") == 0;
+      const cJSON *vector_dependency =
+          cJSON_GetObjectItemCaseSensitive(source, "vector_dependency");
+      const char *dependency =
+          cJSON_IsString(vector_dependency) ? vector_dependency->valuestring : "embedder";
+      cJSON *failure = cJSON_CreateObject();
+      if (!failure)
+      {
+         cJSON_Delete(response);
+         cJSON_Delete(source);
+         snprintf(out_buf, (size_t)out_cap,
+                  "{\"status\":\"unavailable\",\"dependency\":\"embedder\","
+                  "\"retryable\":true,\"retry_after_ms\":%d}",
+                  KB_CODE_VECTOR_RETRY_AFTER_MS);
+         return 503;
+      }
+      cJSON_AddStringToObject(failure, "status", status);
+      cJSON_AddStringToObject(failure, "dependency", dependency);
+      cJSON_AddBoolToObject(failure, "retryable", !stale && !unauthorized);
+      if (!stale && !unauthorized)
+      {
+         const cJSON *retry_after =
+             cJSON_GetObjectItemCaseSensitive(source, "vector_retry_after_ms");
+         int retry_after_ms = cJSON_IsNumber(retry_after) && retry_after->valuedouble > 0
+                                  ? (int)retry_after->valuedouble
+                                  : KB_CODE_VECTOR_RETRY_AFTER_MS;
+         cJSON_AddNumberToObject(failure, "retry_after_ms", retry_after_ms);
+      }
+      cJSON_AddStringToObject(failure, "project", project);
+      cJSON_AddNumberToObject(failure, "generation", (double)generation);
+      const cJSON *observed_dim =
+          cJSON_GetObjectItemCaseSensitive(source, "vector_observed_dimension");
+      const cJSON *current_dim =
+          cJSON_GetObjectItemCaseSensitive(source, "vector_current_dimension");
+      if (cJSON_IsNumber(observed_dim))
+         cJSON_AddNumberToObject(failure, "observed_dimension", observed_dim->valuedouble);
+      if (cJSON_IsNumber(current_dim))
+         cJSON_AddNumberToObject(failure, "current_dimension", current_dim->valuedouble);
+      char *failure_json = cJSON_PrintUnformatted(failure);
+      snprintf(out_buf, (size_t)out_cap, "%s", failure_json ? failure_json : "{}");
+      free(failure_json);
+      cJSON_Delete(failure);
+      cJSON_Delete(response);
+      cJSON_Delete(source);
+      return stale ? 409 : (unauthorized ? 401 : 503);
+   }
+   cJSON_AddStringToObject(response, "status", answerable ? "ok" : "abstained");
    cJSON_AddNumberToObject(response, "item_count", accepted);
    cJSON *answerability = cJSON_AddObjectToObject(response, "answerability");
    cJSON_AddStringToObject(answerability, "decision", answerable ? "answerable" : "no_answer");

--- a/src/kb/http/kb_http_code_vector_status.h
+++ b/src/kb/http/kb_http_code_vector_status.h
@@ -1,0 +1,65 @@
+#ifndef DEC_KB_HTTP_CODE_VECTOR_STATUS_H
+#define DEC_KB_HTTP_CODE_VECTOR_STATUS_H 1
+
+#include "cJSON.h"
+
+#include <string.h>
+
+typedef struct
+{
+   const char *status;
+   const char *dependency;
+   int observed_dimension;
+   int current_dimension;
+   int retry_after_ms;
+} kb_code_vector_status_t;
+
+#define KB_CODE_VECTOR_RETRY_AFTER_MS     1000
+#define KB_CODE_VECTOR_STATUS_INITIALIZER {"disabled", NULL, 0, 0, 0}
+
+static inline void kb_code_vector_status_store(kb_code_vector_status_t *state, int query_rc,
+                                               int result_count)
+{
+   if (query_rc < 0)
+   {
+      state->status = "unavailable";
+      state->dependency = "vector_store";
+      state->retry_after_ms = KB_CODE_VECTOR_RETRY_AFTER_MS;
+   }
+   else
+      state->status = result_count > 0 ? "ok" : "empty";
+}
+
+static inline void kb_code_vector_status_embed(kb_code_vector_status_t *state, const char *command,
+                                               int observed_dimension, int current_dimension,
+                                               int unauthorized)
+{
+   state->status = observed_dimension <= 0 ? (command && strcmp(command, "builtin") == 0
+                                                  ? "disabled"
+                                                  : (unauthorized ? "unauthorized" : "unavailable"))
+                                           : "stale";
+   if (strcmp(state->status, "disabled") != 0)
+   {
+      state->dependency = "embedder";
+      state->observed_dimension = observed_dimension;
+      state->current_dimension = current_dimension;
+      if (strcmp(state->status, "unavailable") == 0)
+         state->retry_after_ms = KB_CODE_VECTOR_RETRY_AFTER_MS;
+   }
+}
+
+static inline void kb_code_vector_status_add_json(cJSON *object,
+                                                  const kb_code_vector_status_t *state)
+{
+   cJSON_AddStringToObject(object, "vector_status", state->status);
+   if (state->dependency)
+      cJSON_AddStringToObject(object, "vector_dependency", state->dependency);
+   if (state->observed_dimension > 0)
+      cJSON_AddNumberToObject(object, "vector_observed_dimension", state->observed_dimension);
+   if (state->current_dimension > 0)
+      cJSON_AddNumberToObject(object, "vector_current_dimension", state->current_dimension);
+   if (state->retry_after_ms > 0)
+      cJSON_AddNumberToObject(object, "vector_retry_after_ms", state->retry_after_ms);
+}
+
+#endif /* DEC_KB_HTTP_CODE_VECTOR_STATUS_H */

--- a/src/kb/http/kb_tls.c
+++ b/src/kb/http/kb_tls.c
@@ -488,9 +488,11 @@ SSL_SESSION *kb_tls_client_conn_get1_session(const kb_tls_client_conn_t *conn)
    return conn && conn->ssl ? SSL_get1_session(conn->ssl) : NULL;
 }
 
-int kb_tls_client_conn_request(kb_tls_client_conn_t *conn, const char *method, const char *path,
-                               const char *body, const char *authorization, int close_after,
-                               char *resp_out, size_t resp_cap, int *status_out, int *reusable_out)
+int kb_tls_client_conn_request_with_type(kb_tls_client_conn_t *conn, const char *method,
+                                         const char *path, const char *body,
+                                         const char *authorization, const char *content_type,
+                                         int close_after, char *resp_out, size_t resp_cap,
+                                         int *status_out, int *reusable_out)
 {
    if (reusable_out)
       *reusable_out = 0;
@@ -501,8 +503,12 @@ int kb_tls_client_conn_request(kb_tls_client_conn_t *conn, const char *method, c
    int bodyless = strcmp(method, "GET") == 0 || strcmp(method, "HEAD") == 0;
    if (bodyless && blen != 0)
       return -1;
+   const char *type_header =
+       content_type && content_type[0] ? content_type : "Content-Type: application/json";
+   if (strchr(type_header, '\r') || strchr(type_header, '\n'))
+      return -1;
    size_t cap = strlen(method) + strlen(path) + strlen(conn->host) + blen +
-                (authorization ? strlen(authorization) : 0) + 192;
+                (authorization ? strlen(authorization) : 0) + strlen(type_header) + 192;
    char *req = malloc(cap);
    if (!req)
       return -1;
@@ -510,10 +516,10 @@ int kb_tls_client_conn_request(kb_tls_client_conn_t *conn, const char *method, c
                                 method, path, conn->host, authorization ? authorization : "",
                                 close_after ? "close" : "keep-alive")
                      : snprintf(req, cap,
-                                "%s %s HTTP/1.1\r\nHost: %s\r\n%sContent-Type: application/json\r\n"
+                                "%s %s HTTP/1.1\r\nHost: %s\r\n%s%s\r\n"
                                 "Content-Length: %zu\r\nConnection: %s\r\n\r\n%s",
-                                method, path, conn->host, authorization ? authorization : "", blen,
-                                close_after ? "close" : "keep-alive", b);
+                                method, path, conn->host, authorization ? authorization : "",
+                                type_header, blen, close_after ? "close" : "keep-alive", b);
    int rc =
        (rn > 0 && (size_t)rn < cap && ssl_write_all(conn->ssl, req, (size_t)rn) == 0)
            ? read_content_length_response(conn->ssl, resp_out, resp_cap, status_out, reusable_out)
@@ -522,6 +528,15 @@ int kb_tls_client_conn_request(kb_tls_client_conn_t *conn, const char *method, c
    if (close_after && reusable_out)
       *reusable_out = 0;
    return rc;
+}
+
+int kb_tls_client_conn_request(kb_tls_client_conn_t *conn, const char *method, const char *path,
+                               const char *body, const char *authorization, int close_after,
+                               char *resp_out, size_t resp_cap, int *status_out, int *reusable_out)
+{
+   return kb_tls_client_conn_request_with_type(conn, method, path, body, authorization, NULL,
+                                               close_after, resp_out, resp_cap, status_out,
+                                               reusable_out);
 }
 
 void kb_tls_client_conn_close(kb_tls_client_conn_t *conn)

--- a/src/modules/kb_client/kb_client.c
+++ b/src/modules/kb_client/kb_client.c
@@ -11,6 +11,7 @@
 #include "platform_ipc.h"
 #include "platform_path.h"
 #include "runtime_secret.h"
+#include "dependency_breaker.h"
 #include "cJSON.h"
 #include <ctype.h>
 #include <errno.h>
@@ -19,12 +20,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
 #ifdef AIMEE_POSIX
 #include <poll.h>
 #include <pthread.h>
 #include <sys/file.h>
 #include <sys/wait.h>
-#include <time.h>
 #include <unistd.h>
 #endif
 
@@ -48,6 +49,331 @@ __attribute__((weak)) char *kb_client_mtls_request(const char *method, const cha
    if (status_out)
       *status_out = -1;
    return NULL;
+}
+
+static dependency_breaker_t g_kb_dependency = DEPENDENCY_BREAKER_INITIALIZER;
+static int64_t (*g_kb_dependency_clock)(void);
+#if defined(_MSC_VER)
+static __declspec(thread) kb_client_result_status_t g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
+static __declspec(thread) char g_kb_last_dependency[32] = "kb";
+static __declspec(thread) int64_t g_kb_last_observed_generation;
+static __declspec(thread) int64_t g_kb_last_current_generation;
+static __declspec(thread) int64_t g_kb_last_observed_dimension;
+static __declspec(thread) int64_t g_kb_last_current_dimension;
+static __declspec(thread) int64_t g_kb_last_retry_after_ms;
+#else
+static _Thread_local kb_client_result_status_t g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
+static _Thread_local char g_kb_last_dependency[32] = "kb";
+static _Thread_local int64_t g_kb_last_observed_generation;
+static _Thread_local int64_t g_kb_last_current_generation;
+static _Thread_local int64_t g_kb_last_observed_dimension;
+static _Thread_local int64_t g_kb_last_current_dimension;
+static _Thread_local int64_t g_kb_last_retry_after_ms;
+#endif
+
+static int64_t kb_dependency_now_ms(void)
+{
+   if (g_kb_dependency_clock)
+      return g_kb_dependency_clock();
+   return (int64_t)time(NULL) * 1000;
+}
+
+kb_client_result_status_t kb_client_last_result_status(void)
+{
+   return g_kb_last_result;
+}
+
+const char *kb_client_result_status_name(kb_client_result_status_t status)
+{
+   switch (status)
+   {
+   case KB_CLIENT_RESULT_OK:
+      return "ok";
+   case KB_CLIENT_RESULT_EMPTY:
+      return "empty";
+   case KB_CLIENT_RESULT_ABSTAINED:
+      return "abstained";
+   case KB_CLIENT_RESULT_STALE:
+      return "stale";
+   case KB_CLIENT_RESULT_UNAUTHORIZED:
+      return "unauthorized";
+   default:
+      return "unavailable";
+   }
+}
+
+int kb_client_result_status_retryable(kb_client_result_status_t status)
+{
+   return status == KB_CLIENT_RESULT_UNAVAILABLE;
+}
+
+void kb_client_dependency_health(kb_client_dependency_health_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   dependency_breaker_snapshot_t snap;
+   dependency_breaker_snapshot(&g_kb_dependency, kb_dependency_now_ms(), &snap);
+   const char *state =
+       !snap.open ? "closed"
+                  : (snap.probe_inflight || snap.retry_after_ms == 0 ? "half_open" : "open");
+   snprintf(out->state, sizeof(out->state), "%s", state);
+   out->failure_streak = snap.failure_streak;
+   out->recovery_attempt = snap.open_count;
+   out->retry_after_ms = snap.retry_after_ms;
+   out->last_success_ms = snap.last_success_ms;
+   out->last_failure_ms = snap.last_failure_ms;
+   out->suppressed_calls = snap.suppressed_calls;
+}
+
+void kb_client_dependency_reset_for_tests(void)
+{
+   dependency_breaker_reset(&g_kb_dependency);
+   g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
+   snprintf(g_kb_last_dependency, sizeof(g_kb_last_dependency), "%s", "kb");
+   g_kb_last_observed_generation = 0;
+   g_kb_last_current_generation = 0;
+   g_kb_last_observed_dimension = 0;
+   g_kb_last_current_dimension = 0;
+   g_kb_last_retry_after_ms = 0;
+}
+
+void kb_client_dependency_set_clock_for_tests(int64_t (*now_ms)(void))
+{
+   g_kb_dependency_clock = now_ms;
+}
+
+static int kb_json_primary_empty(const cJSON *root, const char *path)
+{
+   const char *field = NULL;
+   if (path && strcmp(path, "/v1/search") == 0)
+      field = "result";
+   else if (path && (strstr(path, "/v1/code/find?") || strstr(path, "/v1/code/callers?") ||
+                     strstr(path, "/v1/code/search?")))
+      field = "hits";
+   else if (path && strstr(path, "/v1/code/structure?"))
+      field = "definitions";
+   else if (path && strstr(path, "/v1/code/context?"))
+      field = "results";
+   else if (path && strstr(path, "/v1/code/projects?"))
+      field = "projects";
+   if (field)
+   {
+      const cJSON *value = cJSON_GetObjectItemCaseSensitive(root, field);
+      return (cJSON_IsArray(value) && cJSON_GetArraySize(value) == 0) ||
+             (cJSON_IsString(value) && !value->valuestring[0]);
+   }
+
+   /* RPC actions share one transport path, so classify only known top-level
+    * primary result fields. Auxiliary arrays (warnings, citations, trace data)
+    * are deliberately absent: an empty auxiliary list cannot make a successful
+    * answer empty. */
+   static const char *const primary_fields[] = {
+       "facts",        "memories",    "results",    "relations", "edges",
+       "prospectives", "directives",  "provenance", "history",   "items",
+       "episodes",     "definitions", "hits",       "projects",  NULL,
+   };
+   int saw_primary_array = 0;
+   for (int i = 0; primary_fields[i]; i++)
+   {
+      const cJSON *value = cJSON_GetObjectItemCaseSensitive(root, primary_fields[i]);
+      if (cJSON_IsArray(value))
+      {
+         saw_primary_array = 1;
+         if (cJSON_GetArraySize(value) > 0)
+            return 0;
+      }
+   }
+   if (saw_primary_array)
+      return 1;
+   const cJSON *facts = cJSON_GetObjectItemCaseSensitive(root, "facts");
+   return cJSON_IsString(facts) && !facts->valuestring[0];
+}
+
+static kb_client_result_status_t kb_classify_json_result(const char *path, const char *json,
+                                                         int *valid_out)
+{
+   if (valid_out)
+      *valid_out = 0;
+   cJSON *root = json ? cJSON_Parse(json) : NULL;
+   if (!root)
+      return KB_CLIENT_RESULT_UNAVAILABLE;
+   if (valid_out)
+      *valid_out = 1;
+   if (cJSON_IsArray(root))
+   {
+      kb_client_result_status_t result =
+          cJSON_GetArraySize(root) == 0 ? KB_CLIENT_RESULT_EMPTY : KB_CLIENT_RESULT_OK;
+      cJSON_Delete(root);
+      return result;
+   }
+
+   const cJSON *status = cJSON_GetObjectItemCaseSensitive(root, "status");
+   const cJSON *summary = cJSON_GetObjectItemCaseSensitive(root, "summary_status");
+   const cJSON *freshness = cJSON_GetObjectItemCaseSensitive(root, "freshness");
+   const cJSON *error = cJSON_GetObjectItemCaseSensitive(root, "error");
+   const cJSON *message = cJSON_GetObjectItemCaseSensitive(root, "message");
+   const cJSON *no_answer = cJSON_GetObjectItemCaseSensitive(root, "no_answer");
+   const char *name = cJSON_IsString(status) ? status->valuestring : NULL;
+   if (cJSON_IsString(summary) && strcmp(summary->valuestring, "unavailable") == 0)
+      name = "unavailable";
+   if (cJSON_IsObject(error))
+   {
+      const cJSON *type = cJSON_GetObjectItemCaseSensitive(error, "type");
+      if (cJSON_IsString(type) && strcmp(type->valuestring, "project_not_current") == 0)
+         name = "stale";
+   }
+
+   kb_client_result_status_t result = KB_CLIENT_RESULT_OK;
+   if ((cJSON_IsBool(no_answer) && cJSON_IsTrue(no_answer)) ||
+       (name && (strcmp(name, "no_answer") == 0 || strcmp(name, "abstained") == 0)))
+      result = KB_CLIENT_RESULT_ABSTAINED;
+   else if ((name && (strcmp(name, "empty") == 0 || strcmp(name, "not_found") == 0)) ||
+            (name && strcmp(name, "error") == 0 && cJSON_IsString(message) &&
+             strstr(message->valuestring, "not found")))
+      result = KB_CLIENT_RESULT_EMPTY;
+   else if (name && strcmp(name, "stale") == 0)
+      result = KB_CLIENT_RESULT_STALE;
+   else if (name && strcmp(name, "unauthorized") == 0)
+      result = KB_CLIENT_RESULT_UNAUTHORIZED;
+   else if (name && (strcmp(name, "unavailable") == 0 || strcmp(name, "error") == 0))
+      result = KB_CLIENT_RESULT_UNAVAILABLE;
+   else if (cJSON_IsString(freshness) && strcmp(freshness->valuestring, "current") != 0)
+      result = KB_CLIENT_RESULT_STALE;
+   else if (kb_json_primary_empty(root, path))
+      result = KB_CLIENT_RESULT_EMPTY;
+   cJSON_Delete(root);
+   return result;
+}
+
+static int kb_transport_begin(int *status_out)
+{
+   if (status_out)
+      *status_out = -1;
+   g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
+   snprintf(g_kb_last_dependency, sizeof(g_kb_last_dependency), "%s", "kb");
+   g_kb_last_observed_generation = 0;
+   g_kb_last_current_generation = 0;
+   g_kb_last_observed_dimension = 0;
+   g_kb_last_current_dimension = 0;
+   g_kb_last_retry_after_ms = 0;
+   int64_t retry_after = 0;
+   if (dependency_breaker_allow(&g_kb_dependency, kb_dependency_now_ms(), &retry_after))
+      return 1;
+   if (status_out)
+      *status_out = 503;
+   return 0;
+}
+
+static void kb_capture_result_metadata(const char *response)
+{
+   cJSON *root = response ? cJSON_Parse(response) : NULL;
+   if (!root)
+      return;
+   const cJSON *dependency = cJSON_GetObjectItemCaseSensitive(root, "dependency");
+   const cJSON *observed = cJSON_GetObjectItemCaseSensitive(root, "observed_generation");
+   const cJSON *current = cJSON_GetObjectItemCaseSensitive(root, "current_generation");
+   const cJSON *observed_dimension = cJSON_GetObjectItemCaseSensitive(root, "observed_dimension");
+   const cJSON *current_dimension = cJSON_GetObjectItemCaseSensitive(root, "current_dimension");
+   const cJSON *retry_after = cJSON_GetObjectItemCaseSensitive(root, "retry_after_ms");
+   if (cJSON_IsString(dependency) && dependency->valuestring[0])
+      snprintf(g_kb_last_dependency, sizeof(g_kb_last_dependency), "%s", dependency->valuestring);
+   if (cJSON_IsNumber(observed))
+      g_kb_last_observed_generation = (int64_t)observed->valuedouble;
+   if (cJSON_IsNumber(current))
+      g_kb_last_current_generation = (int64_t)current->valuedouble;
+   if (cJSON_IsNumber(observed_dimension))
+      g_kb_last_observed_dimension = (int64_t)observed_dimension->valuedouble;
+   if (cJSON_IsNumber(current_dimension))
+      g_kb_last_current_dimension = (int64_t)current_dimension->valuedouble;
+   if (cJSON_IsNumber(retry_after) && retry_after->valuedouble > 0)
+      g_kb_last_retry_after_ms = (int64_t)retry_after->valuedouble;
+   cJSON_Delete(root);
+}
+
+static void kb_transport_complete(const char *path, const char *response, int http_status)
+{
+   int64_t now_ms = kb_dependency_now_ms();
+   int valid = 0;
+   kb_client_result_status_t classified = kb_classify_json_result(path, response, &valid);
+   if (valid)
+      kb_capture_result_metadata(response);
+   if (http_status == 401 || http_status == 403)
+   {
+      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      g_kb_last_result = KB_CLIENT_RESULT_UNAUTHORIZED;
+      return;
+   }
+   if (valid && classified == KB_CLIENT_RESULT_UNAVAILABLE &&
+       strcmp(g_kb_last_dependency, "kb") != 0)
+   {
+      /* The KB is reachable and truthfully reported one of its own optional
+       * dependencies. Keep that typed outage from suppressing unrelated KB
+       * operations through the transport breaker. */
+      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      g_kb_last_result = classified;
+      return;
+   }
+   if (http_status >= 200 && http_status < 300 && response && valid)
+   {
+      /* A typed unavailable body means the KB answered but one of its own
+       * dependencies did not; do not trip the KB transport breaker. */
+      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      g_kb_last_result = classified;
+      return;
+   }
+   if (http_status >= 400 && http_status < 500 && http_status != 408 && http_status != 425 &&
+       http_status != 429)
+   {
+      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      g_kb_last_result = valid ? classified : KB_CLIENT_RESULT_UNAVAILABLE;
+      return;
+   }
+   dependency_breaker_report_failure(&g_kb_dependency, now_ms, DEPENDENCY_BREAKER_DEFAULT_THRESHOLD,
+                                     DEPENDENCY_BREAKER_DEFAULT_BASE_MS,
+                                     DEPENDENCY_BREAKER_DEFAULT_MAX_MS);
+   g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
+}
+
+static char *kb_typed_error_json(kb_client_result_status_t status, const char *message)
+{
+   cJSON *obj = cJSON_CreateObject();
+   if (!obj)
+      return strdup("{\"status\":\"unavailable\"}");
+   cJSON_AddStringToObject(obj, "status", kb_client_result_status_name(status));
+   cJSON_AddBoolToObject(obj, "retryable", kb_client_result_status_retryable(status));
+   if (status == KB_CLIENT_RESULT_UNAVAILABLE || status == KB_CLIENT_RESULT_STALE)
+      cJSON_AddStringToObject(obj, "dependency",
+                              g_kb_last_dependency[0] ? g_kb_last_dependency : "kb");
+   if (status == KB_CLIENT_RESULT_UNAVAILABLE)
+   {
+      kb_client_dependency_health_t health;
+      kb_client_dependency_health(&health);
+      int64_t retry_after_ms =
+          g_kb_last_retry_after_ms > 0 ? g_kb_last_retry_after_ms : health.retry_after_ms;
+      if (retry_after_ms <= 0)
+         retry_after_ms = DEPENDENCY_BREAKER_DEFAULT_BASE_MS;
+      if (retry_after_ms > DEPENDENCY_BREAKER_DEFAULT_MAX_MS)
+         retry_after_ms = DEPENDENCY_BREAKER_DEFAULT_MAX_MS;
+      cJSON_AddNumberToObject(obj, "retry_after_ms", (double)retry_after_ms);
+   }
+   if (status == KB_CLIENT_RESULT_STALE && g_kb_last_observed_generation > 0)
+      cJSON_AddNumberToObject(obj, "observed_generation", (double)g_kb_last_observed_generation);
+   if (status == KB_CLIENT_RESULT_STALE && g_kb_last_current_generation > 0)
+      cJSON_AddNumberToObject(obj, "current_generation", (double)g_kb_last_current_generation);
+   if (status == KB_CLIENT_RESULT_STALE && g_kb_last_observed_dimension > 0)
+      cJSON_AddNumberToObject(obj, "observed_dimension", (double)g_kb_last_observed_dimension);
+   if (status == KB_CLIENT_RESULT_STALE && g_kb_last_current_dimension > 0)
+      cJSON_AddNumberToObject(obj, "current_dimension", (double)g_kb_last_current_dimension);
+   cJSON_AddStringToObject(obj, "message", message ? message : "knowledge service unavailable");
+   char *json = cJSON_PrintUnformatted(obj);
+   cJSON_Delete(obj);
+   return json ? json : strdup("{\"status\":\"unavailable\"}");
+}
+
+char *kb_client_last_result_json(const char *message)
+{
+   return kb_typed_error_json(kb_client_last_result_status(), message);
 }
 
 static char *kb_v1_action_request_timeout(const char *action, cJSON *req, int timeout_ms,
@@ -82,17 +408,17 @@ char *kb_client_query_escape(const char *s)
 
 static char *kb_status_unavailable_json(const char *message)
 {
-   cJSON *obj = cJSON_CreateObject();
+   char *json = kb_typed_error_json(KB_CLIENT_RESULT_UNAVAILABLE, message);
+   cJSON *obj = json ? cJSON_Parse(json) : NULL;
+   free(json);
    if (!obj)
-      return strdup("{}");
-   cJSON_AddStringToObject(obj, "status", "error");
+      return strdup("{\"status\":\"unavailable\"}");
    cJSON_AddStringToObject(obj, "summary_status", "unavailable");
    cJSON_AddStringToObject(obj, "owner", "knowledge-service");
    cJSON_AddBoolToObject(obj, "available", 0);
-   cJSON_AddStringToObject(obj, "message", message ? message : "knowledge service unavailable");
-   char *json = cJSON_PrintUnformatted(obj);
+   json = cJSON_PrintUnformatted(obj);
    cJSON_Delete(obj);
-   return json ? json : strdup("{}");
+   return json ? json : strdup("{\"status\":\"unavailable\"}");
 }
 
 static char *kb_vector_unavailable_json(const char *message)
@@ -114,7 +440,10 @@ int kb_client_is_live(void)
    /* A configured remote endpoint owns its own reachability/timeout, so treat
     * it as "live" and let the actual call apply its timeout rather than probing
     * twice here. */
-   return kb_client_v1_base_url() != NULL;
+   kb_client_dependency_health_t health;
+   kb_client_dependency_health(&health);
+   return (kb_client_v1_base_url() != NULL || kb_client_mtls_configured()) &&
+          strcmp(health.state, "open") != 0;
 }
 
 char *kb_client_health_json(void)
@@ -782,9 +1111,10 @@ static char *kb_v1_action_request_timeout(const char *action, cJSON *req, int ti
       char msg[160];
       snprintf(msg, sizeof(msg), "knowledge service action %s returned HTTP %d", action,
                http_status);
-      return error_json(msg);
+      return kb_typed_error_json(kb_client_last_result_status(), msg);
    }
-   return error_json("knowledge service action did not respond");
+   return kb_typed_error_json(kb_client_last_result_status(),
+                              "knowledge service action did not respond");
 }
 
 /* Shared with kb_client_memory.c — keep external linkage. */
@@ -1181,17 +1511,28 @@ static const char *kb_client_v1_auth_header(char *buf, size_t buf_len)
 
 char *kb_client_v1_post_json(const char *path, cJSON *body, int timeout_ms, int *status_out)
 {
-   if (status_out)
-      *status_out = -1;
+   if (!kb_transport_begin(status_out))
+      return NULL;
    char *body_json = body ? cJSON_PrintUnformatted(body) : strdup("{}");
    if (!body_json)
+   {
+      dependency_breaker_cancel_probe(&g_kb_dependency);
       return NULL;
+   }
 
    /* Distributed mode: route to the remote kb over mTLS (see get_json). */
    if (kb_client_mtls_configured())
    {
-      char *r = kb_client_mtls_request_timeout("POST", path, body_json, timeout_ms, status_out);
+      int local_status = -1;
+      int *wire_status = status_out ? status_out : &local_status;
+      char *r = kb_client_mtls_request_timeout("POST", path, body_json, timeout_ms, wire_status);
+      kb_transport_complete(path, r, *wire_status);
       free(body_json);
+      if (*wire_status < 200 || *wire_status >= 300 || !r)
+      {
+         free(r);
+         return NULL;
+      }
       return r;
    }
 
@@ -1204,6 +1545,7 @@ char *kb_client_v1_post_json(const char *path, cJSON *body, int timeout_ms, int 
                                    &response, timeout_ms, NULL);
       if (status_out)
          *status_out = status;
+      kb_transport_complete(path, response, status);
       free(body_json);
       free(url);
       if (status < 200 || status >= 300 || !response)
@@ -1215,6 +1557,7 @@ char *kb_client_v1_post_json(const char *path, cJSON *body, int timeout_ms, int 
    }
 
    free(body_json);
+   kb_transport_complete(path, NULL, -1);
    return NULL;
 }
 
@@ -1227,8 +1570,23 @@ char *kb_client_v1_post_body(const char *path, const char *body, int timeout_ms,
 char *kb_client_v1_post_body_with_type(const char *path, const char *body, const char *content_type,
                                        int timeout_ms, int *status_out)
 {
-   if (status_out)
-      *status_out = -1;
+   if (!kb_transport_begin(status_out))
+      return NULL;
+
+   if (kb_client_mtls_configured())
+   {
+      int local_status = -1;
+      int *wire_status = status_out ? status_out : &local_status;
+      char *r = kb_client_mtls_request_timeout_with_type("POST", path, body, content_type,
+                                                         timeout_ms, wire_status);
+      kb_transport_complete(path, r, *wire_status);
+      if (*wire_status < 200 || *wire_status >= 300 || !r)
+      {
+         free(r);
+         return NULL;
+      }
+      return r;
+   }
 
    char *url = kb_client_v1_url(path);
    if (url)
@@ -1240,6 +1598,7 @@ char *kb_client_v1_post_body_with_type(const char *path, const char *body, const
                                        content_type, body ? body : "", &response, timeout_ms, NULL);
       if (status_out)
          *status_out = status;
+      kb_transport_complete(path, response, status);
       free(url);
       if (status < 200 || status >= 300 || !response)
       {
@@ -1249,18 +1608,30 @@ char *kb_client_v1_post_body_with_type(const char *path, const char *body, const
       return response;
    }
 
+   kb_transport_complete(path, NULL, -1);
    return NULL;
 }
 
 char *kb_client_v1_get_json(const char *path, int timeout_ms, int *status_out)
 {
-   if (status_out)
-      *status_out = -1;
+   if (!kb_transport_begin(status_out))
+      return NULL;
 
    /* Distributed mode: a configured remote kb (AIMEE_KB_CONN) is reached over
     * mTLS with the enrollment-issued client cert, ahead of HTTP-URL / socket. */
    if (kb_client_mtls_configured())
-      return kb_client_mtls_request_timeout("GET", path, NULL, timeout_ms, status_out);
+   {
+      int local_status = -1;
+      int *wire_status = status_out ? status_out : &local_status;
+      char *r = kb_client_mtls_request_timeout("GET", path, NULL, timeout_ms, wire_status);
+      kb_transport_complete(path, r, *wire_status);
+      if (*wire_status < 200 || *wire_status >= 300 || !r)
+      {
+         free(r);
+         return NULL;
+      }
+      return r;
+   }
 
    char *url = kb_client_v1_url(path);
    if (url)
@@ -1271,6 +1642,7 @@ char *kb_client_v1_get_json(const char *path, int timeout_ms, int *status_out)
           agent_http_get(url, kb_client_v1_auth_header(auth, sizeof(auth)), &response, timeout_ms);
       if (status_out)
          *status_out = status;
+      kb_transport_complete(path, response, status);
       free(url);
       if (status < 200 || status >= 300 || !response)
       {
@@ -1280,6 +1652,7 @@ char *kb_client_v1_get_json(const char *path, int timeout_ms, int *status_out)
       return response;
    }
 
+   kb_transport_complete(path, NULL, -1);
    return NULL;
 }
 
@@ -1318,7 +1691,13 @@ char *kb_client_search_json_scoped_ex(const char *project, int all_projects, con
    {
       char *cached = kb_cache_get(cache_key);
       if (cached)
+      {
+         int valid = 0;
+         g_kb_last_result = kb_classify_json_result("/v1/search", cached, &valid);
+         if (!valid)
+            g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
          return cached;
+      }
    }
 
    cJSON *body = cJSON_CreateObject();
@@ -1353,9 +1732,10 @@ char *kb_client_search_json_scoped_ex(const char *project, int all_projects, con
    {
       char msg[128];
       snprintf(msg, sizeof(msg), "knowledge service /v1/search returned HTTP %d", http_status);
-      return kb_error_json(msg);
+      return kb_typed_error_json(kb_client_last_result_status(), msg);
    }
-   return kb_error_json("knowledge service /v1/search did not respond");
+   return kb_typed_error_json(kb_client_last_result_status(),
+                              "knowledge service /v1/search did not respond");
 }
 
 char *kb_client_curator_implements_json(const char *topic)

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -38,6 +38,43 @@ typedef struct
    int maintenance_enabled;
 } kb_health_t;
 
+/* Every retrieval attempt has one of these six outcomes. The accessor is
+ * thread-local, so a concurrent request cannot overwrite another request's
+ * transport/result classification. Human-readable payloads remain compatible;
+ * callers that need to distinguish empty from outage read this typed result. */
+typedef enum
+{
+   KB_CLIENT_RESULT_OK = 0,
+   KB_CLIENT_RESULT_EMPTY,
+   KB_CLIENT_RESULT_ABSTAINED,
+   KB_CLIENT_RESULT_STALE,
+   KB_CLIENT_RESULT_UNAVAILABLE,
+   KB_CLIENT_RESULT_UNAUTHORIZED
+} kb_client_result_status_t;
+
+typedef struct
+{
+   char state[16]; /* closed | open | half_open */
+   unsigned failure_streak;
+   unsigned recovery_attempt;
+   int64_t retry_after_ms;
+   int64_t last_success_ms;
+   int64_t last_failure_ms;
+   uint64_t suppressed_calls;
+} kb_client_dependency_health_t;
+
+kb_client_result_status_t kb_client_last_result_status(void);
+const char *kb_client_result_status_name(kb_client_result_status_t status);
+int kb_client_result_status_retryable(kb_client_result_status_t status);
+/* Heap JSON for the current thread's last result, including dependency,
+ * retryability and breaker delay where applicable. Caller frees. */
+char *kb_client_last_result_json(const char *message);
+void kb_client_dependency_health(kb_client_dependency_health_t *out);
+
+/* Deterministic test seams; production passes NULL and uses the wall clock. */
+void kb_client_dependency_reset_for_tests(void);
+void kb_client_dependency_set_clock_for_tests(int64_t (*now_ms)(void));
+
 /* Query aimee-kb health.  Fills *out and returns 0 on success.  Returns -1
  * if aimee-kb is unreachable (out->process_ok == 0). */
 int kb_client_health(kb_health_t *out);
@@ -774,9 +811,8 @@ int kb_client_memory_explain_match(const char *query, int64_t memory_id, memory_
  * must split that flow across aimee-server and aimee-kb; do not add a client
  * or auxiliary process with both tiers linked. */
 
-/* Fetch a single memory row by id via aimee-kb.  Returns 0 on
- * success (out is filled) or -1 if kb is unreachable or the row is
- * missing.  Mirrors memory_get(). */
+/* Fetch a single memory row by id via aimee-kb. Returns 0 on success,
+ * 1 for a valid missing row, or -1 when the service/result is unavailable. */
 int kb_client_memory_get(int64_t id, memory_t *out);
 
 /* Insert a memory row via aimee-kb (the DB2 owner).  The full
@@ -923,9 +959,8 @@ char *kb_client_evidence_provenance_retrieval_event(const char *turn_id);
  * (malloc'd, caller frees; NULL on bad arg or kb error). */
 char *kb_client_evidence_fidelity_retrieval_event(const char *turn_id);
 
-/* Fetch the entity profile card via aimee-kb.  Returns 0 on success
- * (|out| filled) or -1 if kb is unreachable or the entity is missing.
- * Mirrors memory_get_entity_profile(). */
+/* Fetch the entity profile card via aimee-kb. Returns 0 on success,
+ * 1 for a valid missing entity, or -1 when the service/result is unavailable. */
 int kb_client_memory_get_entity_profile(const char *entity, memory_entity_profile_t *out);
 
 /* Fetch up to |max| graph edges for an entity via aimee-kb.  Returns
@@ -944,9 +979,8 @@ int kb_client_memory_search_graph(const char *query, int limit, memory_relation_
 int kb_client_memory_search_graph_as_of(const char *query, const char *as_of, int limit,
                                         memory_relation_t *out, int max);
 
-/* Fetch a single episode by key via aimee-kb.  Returns 0 on success
- * (out is filled) or -1 if kb is unreachable or the episode is
- * missing.  Mirrors memory_get_episode(). */
+/* Fetch a single episode by key via aimee-kb. Returns 0 on success,
+ * 1 for a valid missing episode, or -1 when the service/result is unavailable. */
 int kb_client_memory_get_episode(const char *episode_key, memory_episode_t *out);
 
 /* Run the memory Q&A pipeline via aimee-kb (the DB2 owner).  Returns
@@ -1135,8 +1169,8 @@ int kb_client_index_scan_apply_response(const void *resp, kb_client_index_scan_r
  * cJSON * (cast through void * to keep this header cJSON-free). */
 void *kb_client_index_scan_format_response(int kb_rc, const kb_client_index_scan_result_t *res);
 
-/* Find an identifier in the canonical index. Returns count of hits
- * written into `out` (capped at `max`), or 0 if kb is unreachable. */
+/* Find an identifier in the canonical index. Returns count of hits written
+ * into `out` (capped at `max`), or -1 if the KB is unavailable. */
 int kb_client_index_find(const char *identifier, term_hit_t *out, int max);
 int kb_client_index_find_project(const char *project, const char *identifier, term_hit_t *out,
                                  int max);
@@ -1166,8 +1200,8 @@ int kb_client_index_blast_radius(const char *project, const char *file_path, bla
 char *kb_client_index_blast_radius_preview_json(const char *project, char **paths, int path_count);
 
 /* List the structural definitions in a single file (function/struct/etc).
- * Returns count written into `out` (capped at `max`), or 0 if kb is
- * unreachable.  Mirrors index_structure(). */
+ * Returns count written into `out` (capped at `max`), or -1 if the KB is
+ * unavailable. Mirrors index_structure(). */
 int kb_client_index_structure(const char *project, const char *file_path, definition_t *out,
                               int max);
 

--- a/src/modules/kb_client/kb_client_index.c
+++ b/src/modules/kb_client/kb_client_index.c
@@ -49,9 +49,11 @@ static int kb_index_find_parse(cJSON *resp, term_hit_t *out, int max)
 static int kb_index_project_list_parse(cJSON *resp, project_info_t *out, int max)
 {
    if (!resp)
-      return 0;
+      return -1;
    int count = 0;
    cJSON *projects = cJSON_GetObjectItemCaseSensitive(resp, "projects");
+   if (!cJSON_IsArray(projects))
+      return -1;
    if (cJSON_IsArray(projects))
    {
       cJSON *p;
@@ -386,9 +388,11 @@ int kb_client_index_find_scoped(const char *project, int all_projects, const cha
    char *json = kb_client_v1_get_json(path, KB_CLIENT_INDEX_READ_TIMEOUT_MS, NULL);
    free(path);
    if (!json)
-      return 0;
+      return -1;
    cJSON *resp = cJSON_Parse(json);
    free(json);
+   if (!resp)
+      return -1;
    int count = kb_index_find_parse(resp, out, max);
    cJSON_Delete(resp);
    return count;
@@ -716,11 +720,11 @@ int kb_client_index_structure(const char *project, const char *file_path, defini
    free(file_q);
    char *json = kb_client_v1_get_json(path, KB_CLIENT_INDEX_READ_TIMEOUT_MS, NULL);
    if (!json)
-      return 0;
+      return -1;
    cJSON *resp = cJSON_Parse(json);
    free(json);
    if (!resp)
-      return 0;
+      return -1;
 
    int count = 0;
    cJSON *defs = cJSON_GetObjectItemCaseSensitive(resp, "definitions");
@@ -868,9 +872,11 @@ int kb_client_index_code_search_scoped(const char *query, const char *project, i
    char *json = kb_client_v1_get_json(path, KB_CLIENT_INDEX_READ_TIMEOUT_MS, NULL);
    free(path);
    if (!json)
-      return 0;
+      return -1;
    cJSON *resp = cJSON_Parse(json);
    free(json);
+   if (!resp)
+      return -1;
    int count = kb_index_code_search_parse(resp, out, max);
    cJSON_Delete(resp);
    return count;
@@ -915,9 +921,11 @@ int kb_client_index_find_callers_scoped(const char *project, int all_projects, c
    char *json = kb_client_v1_get_json(path, KB_CLIENT_INDEX_READ_TIMEOUT_MS, NULL);
    free(path);
    if (!json)
-      return 0;
+      return -1;
    cJSON *resp = cJSON_Parse(json);
    free(json);
+   if (!resp)
+      return -1;
    int count = kb_index_find_callers_parse(resp, out, max);
    cJSON_Delete(resp);
    return count;

--- a/src/modules/kb_client/kb_client_memory.c
+++ b/src/modules/kb_client/kb_client_memory.c
@@ -69,6 +69,18 @@ static void kbc_memory_add_scope_context(cJSON *req)
    kb_client_memory_scope_context_apply(req);
 }
 
+/* Single-record readers use 1 for a valid miss and -1 for an unavailable or
+ * malformed result. Keeping those outcomes distinct prevents callers from
+ * rendering a stale thread-local dependency status as a genuine not-found. */
+static int kbc_memory_single_miss(const cJSON *resp)
+{
+   const cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   const cJSON *message = cJSON_GetObjectItemCaseSensitive(resp, "message");
+   return (cJSON_IsString(status) && (strcmp(status->valuestring, "empty") == 0 ||
+                                      strcmp(status->valuestring, "not_found") == 0)) ||
+          (cJSON_IsString(message) && strstr(message->valuestring, "not found") != NULL);
+}
+
 void kbc_memory_row_from_json(cJSON *f, memory_t *m)
 {
    memset(m, 0, sizeof(*m));
@@ -1208,8 +1220,9 @@ int kb_client_memory_get(int64_t id, memory_t *out)
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
    if (!cJSON_IsString(status) || strcmp(status->valuestring, "ok") != 0)
    {
+      int miss = kbc_memory_single_miss(resp);
       cJSON_Delete(resp);
-      return -1;
+      return miss ? 1 : -1;
    }
 
    cJSON *mem_j = cJSON_GetObjectItemCaseSensitive(resp, "memory");
@@ -1309,8 +1322,9 @@ int kb_client_memory_get_entity_profile(const char *entity, memory_entity_profil
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
    if (!cJSON_IsString(status) || strcmp(status->valuestring, "ok") != 0)
    {
+      int miss = kbc_memory_single_miss(resp);
       cJSON_Delete(resp);
-      return -1;
+      return miss ? 1 : -1;
    }
    cJSON *prof = cJSON_GetObjectItemCaseSensitive(resp, "profile");
    if (!cJSON_IsObject(prof))
@@ -1631,8 +1645,9 @@ int kb_client_memory_get_episode(const char *episode_key, memory_episode_t *out)
    cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
    if (!cJSON_IsString(status) || strcmp(status->valuestring, "ok") != 0)
    {
+      int miss = kbc_memory_single_miss(resp);
       cJSON_Delete(resp);
-      return -1;
+      return miss ? 1 : -1;
    }
    cJSON *ep = cJSON_GetObjectItemCaseSensitive(resp, "episode");
    if (!cJSON_IsObject(ep))

--- a/src/modules/kb_client/kb_client_mtls.c
+++ b/src/modules/kb_client/kb_client_mtls.c
@@ -608,8 +608,9 @@ static void maybe_renew(void)
 
 #define KB_CLIENT_MTLS_DEFAULT_TIMEOUT_MS 30000
 
-char *kb_client_mtls_request_timeout(const char *method, const char *path, const char *body,
-                                     int timeout_ms, int *status_out)
+char *kb_client_mtls_request_timeout_with_type(const char *method, const char *path,
+                                               const char *body, const char *content_type,
+                                               int timeout_ms, int *status_out)
 {
    if (status_out)
       *status_out = -1;
@@ -638,8 +639,9 @@ char *kb_client_mtls_request_timeout(const char *method, const char *path, const
       int reusable = 0;
       kb_tls_client_conn_t *conn = resp ? kb_tls_client_conn_open(host, port, ca, cert, key) : NULL;
       int rc = conn && kb_tls_client_conn_set_timeout(conn, timeout_ms) == 0
-                   ? kb_tls_client_conn_request(conn, method, path, (body && body[0]) ? body : NULL,
-                                                NULL, 1, resp, cap, &status, &reusable)
+                   ? kb_tls_client_conn_request_with_type(
+                         conn, method, path, (body && body[0]) ? body : NULL, NULL, content_type, 1,
+                         resp, cap, &status, &reusable)
                    : -1;
       kb_tls_client_conn_close(conn);
       if (status_out)
@@ -659,17 +661,24 @@ char *kb_client_mtls_request_timeout(const char *method, const char *path, const
    }
    int status = -1;
    int reusable = 0;
-   int rc =
-       kb_tls_client_conn_set_timeout(entry->conn, timeout_ms) == 0
-           ? kb_tls_client_conn_request(entry->conn, method, path, (body && body[0]) ? body : NULL,
-                                        NULL, 0, resp, cap, &status, &reusable)
-           : -1;
+   int rc = kb_tls_client_conn_set_timeout(entry->conn, timeout_ms) == 0
+                ? kb_tls_client_conn_request_with_type(
+                      entry->conn, method, path, (body && body[0]) ? body : NULL, NULL,
+                      content_type, 0, resp, cap, &status, &reusable)
+                : -1;
    pool_return(entry, rc == 0 && reusable);
    if (status_out)
       *status_out = status;
    char *out = (rc == 0 && status >= 200 && status < 300) ? strdup(resp) : NULL;
    free(resp);
    return out;
+}
+
+char *kb_client_mtls_request_timeout(const char *method, const char *path, const char *body,
+                                     int timeout_ms, int *status_out)
+{
+   return kb_client_mtls_request_timeout_with_type(method, path, body, NULL, timeout_ms,
+                                                   status_out);
 }
 
 char *kb_client_mtls_request(const char *method, const char *path, const char *body,

--- a/src/modules/kb_client/kb_client_mtls.h
+++ b/src/modules/kb_client/kb_client_mtls.h
@@ -32,6 +32,9 @@ char *kb_client_mtls_request(const char *method, const char *path, const char *b
  * public operation contract allows several minutes. */
 char *kb_client_mtls_request_timeout(const char *method, const char *path, const char *body,
                                      int timeout_ms, int *status_out);
+char *kb_client_mtls_request_timeout_with_type(const char *method, const char *path,
+                                               const char *body, const char *content_type,
+                                               int timeout_ms, int *status_out);
 
 /* Fetch the exact bounded P5-C2c signed envelope.  Only an authenticated 200
  * response on the fixed route is accepted; output is cleared on every error. */

--- a/src/modules/memory/memory_core.c
+++ b/src/modules/memory/memory_core.c
@@ -638,6 +638,28 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
    return 0;
 }
 
+void memory_embedder_health(memory_embedder_health_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   snprintf(out->state, sizeof(out->state), "%s", "unavailable");
+}
+
+int memory_embedder_last_result_unauthorized(void)
+{
+   return 0;
+}
+
+void memory_embedder_dependency_reset_for_tests(void)
+{
+}
+
+void memory_embedder_dependency_set_clock_for_tests(int64_t (*now_ms)(void))
+{
+   (void)now_ms;
+}
+
 double cosine_similarity(const float *a, const float *b, int dim)
 {
    double dot = 0.0;

--- a/src/modules/memory/memory_core_helpers_b.c
+++ b/src/modules/memory/memory_core_helpers_b.c
@@ -442,7 +442,8 @@ static void memory_embed_http_url(const char *base, const char *path, char *out,
 
 /* POST body to {base}{path}; on success returns 0 with the response body in
  * *resp (caller frees). Any transport error or non-2xx leaves *resp NULL. */
-int memory_embed_http_post(const char *base, const char *path, const char *body, char **resp)
+int memory_embed_http_post_status(const char *base, const char *path, const char *body, char **resp,
+                                  int *status_out)
 {
    char url[1024];
    char auth[640] = "";
@@ -450,8 +451,14 @@ int memory_embed_http_post(const char *base, const char *path, const char *body,
    const char *auth_header = NULL;
    int have_token = runtime_secret_get("AIMEE_LLM_AUTH_TOKEN", token, sizeof(token));
    const char *auth_required = getenv("AIMEE_LLM_AUTH_REQUIRED");
+   if (status_out)
+      *status_out = -1;
    if (auth_required && strcmp(auth_required, "1") == 0 && !have_token)
+   {
+      if (status_out)
+         *status_out = 401;
       return -1;
+   }
    if (have_token)
    {
       /* Managed tokens are capped at 512 bytes; this also rejects any longer
@@ -461,6 +468,8 @@ int memory_embed_http_post(const char *base, const char *path, const char *body,
       {
          runtime_secret_wipe(token, sizeof(token));
          runtime_secret_wipe(auth, sizeof(auth));
+         if (status_out)
+            *status_out = 401;
          return -1;
       }
       auth_header = auth;
@@ -468,6 +477,8 @@ int memory_embed_http_post(const char *base, const char *path, const char *body,
    memory_embed_http_url(base, path, url, sizeof(url));
    *resp = NULL;
    int status = agent_http_post(url, auth_header, body, resp, MEMORY_EMBED_HTTP_TIMEOUT_MS, NULL);
+   if (status_out)
+      *status_out = status;
    runtime_secret_wipe(token, sizeof(token));
    runtime_secret_wipe(auth, sizeof(auth));
    if (status < 200 || status >= 300 || !*resp)
@@ -477,6 +488,11 @@ int memory_embed_http_post(const char *base, const char *path, const char *body,
       return -1;
    }
    return 0;
+}
+
+int memory_embed_http_post(const char *base, const char *path, const char *body, char **resp)
+{
+   return memory_embed_http_post_status(base, path, body, resp, NULL);
 }
 
 typedef struct

--- a/src/modules/memory/memory_core_internal.h
+++ b/src/modules/memory/memory_core_internal.h
@@ -133,6 +133,8 @@ double memory_content_surprise(const char *session_id, const char *content);
 const char *memory_effective_embedding_cmd(const char *command);
 int memory_embed_command_is_http(const char *cmd);
 int memory_embed_http_post(const char *base, const char *path, const char *body, char **resp);
+int memory_embed_http_post_status(const char *base, const char *path, const char *body, char **resp,
+                                  int *status_out);
 int memory_embed_text_runtime(const char *text, const char *command, float *out, int max_dim);
 int memory_env_int(const char *name, int fallback, int min_value, int max_value);
 double memory_env_weight(const char *name, double fallback);

--- a/src/modules/memory/memory_core_scope_embed.c
+++ b/src/modules/memory/memory_core_scope_embed.c
@@ -36,11 +36,70 @@
 #include "agent_exec.h" /* agent_http_post: in-process HTTP embedding (no fork) */
 #include "cJSON.h"
 #include "dogfood.h"
+#include "dependency_breaker.h"
 #include <ctype.h>
 #include <math.h>
 #include <time.h>
 #include <unistd.h>
 #include <pthread.h>
+
+static dependency_breaker_t g_embedder_dependency = DEPENDENCY_BREAKER_INITIALIZER;
+static int64_t (*g_embedder_dependency_clock)(void);
+#if defined(_MSC_VER)
+static __declspec(thread) int g_embedder_last_unauthorized;
+#else
+static _Thread_local int g_embedder_last_unauthorized;
+#endif
+
+static int64_t memory_embedder_now_ms(void)
+{
+   if (g_embedder_dependency_clock)
+      return g_embedder_dependency_clock();
+   return (int64_t)time(NULL) * 1000;
+}
+
+void memory_embedder_health(memory_embedder_health_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   dependency_breaker_snapshot_t snap;
+   dependency_breaker_snapshot(&g_embedder_dependency, memory_embedder_now_ms(), &snap);
+   const char *state =
+       !snap.open ? "closed"
+                  : (snap.probe_inflight || snap.retry_after_ms == 0 ? "half_open" : "open");
+   snprintf(out->state, sizeof(out->state), "%s", state);
+   out->available = !snap.open;
+   out->failure_streak = snap.failure_streak;
+   out->recovery_attempt = snap.open_count;
+   out->retry_after_ms = snap.retry_after_ms;
+   out->last_success_ms = snap.last_success_ms;
+   out->last_failure_ms = snap.last_failure_ms;
+   out->suppressed_calls = snap.suppressed_calls;
+}
+
+int memory_embedder_last_result_unauthorized(void)
+{
+   return g_embedder_last_unauthorized;
+}
+
+void memory_embedder_dependency_reset_for_tests(void)
+{
+   dependency_breaker_reset(&g_embedder_dependency);
+   g_embedder_last_unauthorized = 0;
+}
+
+void memory_embedder_dependency_set_clock_for_tests(int64_t (*now_ms)(void))
+{
+   g_embedder_dependency_clock = now_ms;
+}
+
+static void memory_embedder_failure(void)
+{
+   dependency_breaker_report_failure(
+       &g_embedder_dependency, memory_embedder_now_ms(), DEPENDENCY_BREAKER_DEFAULT_THRESHOLD,
+       DEPENDENCY_BREAKER_DEFAULT_BASE_MS, DEPENDENCY_BREAKER_DEFAULT_MAX_MS);
+}
 
 const char *memory_scope_level_name(memory_scope_level_t level)
 {
@@ -376,20 +435,49 @@ static int memory_embed_text_builtin(const char *text, float *out, int max_dim)
 int memory_embed_text(const char *text, const char *command, float *out, int max_dim)
 {
    if (!text || !out || max_dim <= 0)
+   {
+      g_embedder_last_unauthorized = 0;
       return 0;
+   }
 
    if (!command || !command[0] || strcmp(command, "builtin") == 0)
-      return memory_embed_text_builtin(text, out, max_dim);
+   {
+      int dim = memory_embed_text_builtin(text, out, max_dim);
+      g_embedder_last_unauthorized = 0;
+      return dim;
+   }
+
+   int64_t retry_after_ms = 0;
+   if (!dependency_breaker_allow(&g_embedder_dependency, memory_embedder_now_ms(), &retry_after_ms))
+   {
+      g_embedder_last_unauthorized = 0;
+      aimee_log(LOG_WARN, "memory", "embedding dependency unavailable; retry after %lld ms",
+                (long long)retry_after_ms);
+      return 0;
+   }
 
    char *buf = NULL;
    size_t buf_len = 0;
    if (memory_embed_command_is_http(command))
    {
       /* In-process HTTP embed: POST raw text to {base}/embed, no fork. */
-      if (memory_embed_http_post(command, "/embed", text, &buf) != 0 || !buf)
+      int http_status = -1;
+      if (memory_embed_http_post_status(command, "/embed", text, &buf, &http_status) != 0 || !buf)
       {
          aimee_log(LOG_WARN, "memory", "embedding HTTP request failed");
          free(buf);
+         if (http_status == 401 || http_status == 403)
+         {
+            /* Authentication failures prove the service is reachable and are
+             * non-retryable. Close any earlier transient outage: leaving a
+             * half-open breaker open would turn the next authorization result
+             * back into unavailable even though this probe reached the service. */
+            g_embedder_last_unauthorized = 1;
+            dependency_breaker_report_success(&g_embedder_dependency, memory_embedder_now_ms());
+            return 0;
+         }
+         g_embedder_last_unauthorized = 0;
+         memory_embedder_failure();
          return 0;
       }
       buf_len = strlen(buf);
@@ -401,12 +489,16 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
       {
          aimee_log(LOG_WARN, "memory", "embedding command failed (exit %d)", rc);
          free(buf);
+         g_embedder_last_unauthorized = 0;
+         memory_embedder_failure();
          return 0;
       }
    }
    if (!buf || buf_len == 0)
    {
       free(buf);
+      g_embedder_last_unauthorized = 0;
+      memory_embedder_failure();
       return 0;
    }
 
@@ -417,6 +509,8 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
    {
       cJSON_Delete(arr);
       aimee_log(LOG_WARN, "memory", "embedding command returned invalid JSON");
+      g_embedder_last_unauthorized = 0;
+      memory_embedder_failure();
       return 0;
    }
 
@@ -441,6 +535,16 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
                 "embedding truncated: model emitted %d dims > EMBED_MAX_DIM %d; recall degraded "
                 "-- raise EMBED_MAX_DIM and re-embed",
                 emitted, max_dim);
+   if (dim > 0)
+   {
+      g_embedder_last_unauthorized = 0;
+      dependency_breaker_report_success(&g_embedder_dependency, memory_embedder_now_ms());
+   }
+   else
+   {
+      g_embedder_last_unauthorized = 0;
+      memory_embedder_failure();
+   }
    return dim;
 }
 

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -183,6 +183,25 @@ static int ingress_preinject_first_task_turn(const char *session, const char *pr
    return fetch;
 }
 
+/* A first/new-task marker is claimed before retrieval so concurrent turns do
+ * not duplicate packets. If that one retrieval never reached the dependency,
+ * remove only its exact session/project marker: a related follow-up may then
+ * use the breaker's single recovery probe without restarting the client. */
+static void ingress_preinject_rearm_unavailable(const char *session, const char *project)
+{
+   if (!session || !session[0] || !project || !project[0])
+      return;
+   pthread_mutex_lock(&g_task_sessions_mu);
+   for (int i = 0; i < INGRESS_TASK_SESSION_SLOTS; i++)
+      if (strcmp(g_task_sessions[i].session, session) == 0 &&
+          strcmp(g_task_sessions[i].project, project) == 0)
+      {
+         memset(&g_task_sessions[i], 0, sizeof(g_task_sessions[i]));
+         break;
+      }
+   pthread_mutex_unlock(&g_task_sessions_mu);
+}
+
 static long ingress_elapsed_ms(const struct timespec *start, const struct timespec *end)
 {
    return (long)(end->tv_sec - start->tv_sec) * 1000L +
@@ -828,6 +847,8 @@ char *ingress_preinject_build(const char *query, int request_disabled)
       clock_gettime(CLOCK_MONOTONIC, &context_started);
       char *context_json = kb_client_code_context(query, NULL, active_project, &context_status);
       clock_gettime(CLOCK_MONOTONIC, &context_finished);
+      if (kb_client_last_result_status() == KB_CLIENT_RESULT_UNAVAILABLE)
+         ingress_preinject_rearm_unavailable(g_session_id, active_project);
       long context_latency_ms = ingress_elapsed_ms(&context_started, &context_finished);
       if (context_json && context_status == 200)
          task_packet = ingress_preinject_format_task_context(context_json, active_project,

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -95,6 +95,29 @@ cJSON *json_result_content(cJSON *result)
    free(rendered);
    return content;
 }
+
+static cJSON *kb_last_result_content(const char *message)
+{
+   char *json = kb_client_last_result_json(message);
+   cJSON *content = text_content(json ? json : "{\"status\":\"unavailable\"}");
+   free(json);
+   return content;
+}
+
+static cJSON *kb_empty_result_content(const char *message)
+{
+   cJSON *obj = cJSON_CreateObject();
+   if (!obj)
+      return text_content("{\"status\":\"empty\",\"retryable\":false}");
+   cJSON_AddStringToObject(obj, "status", "empty");
+   cJSON_AddBoolToObject(obj, "retryable", 0);
+   cJSON_AddStringToObject(obj, "message", message ? message : "no result");
+   char *json = cJSON_PrintUnformatted(obj);
+   cJSON_Delete(obj);
+   cJSON *content = text_content(json ? json : "{\"status\":\"empty\"}");
+   free(json);
+   return content;
+}
 static int send_mcp_result(server_conn_t *conn, cJSON *content)
 {
    cJSON *resp = jo_ok();
@@ -335,8 +358,7 @@ cJSON *tool_search_memory(cJSON *args)
       mcp_memory_scope_end();
    }
    if (count < 0)
-      return text_content("error: knowledge service search index unavailable; server-side "
-                          "maintenance is required");
+      return kb_last_result_content("knowledge service memory search failed");
 
    char buf[8192];
    int pos = 0;
@@ -456,11 +478,12 @@ cJSON *tool_memory_ask(cJSON *args, cJSON **structured_out)
    int ask_rc = kb_client_memory_ask(jq->valuestring, NULL, NULL, limit, &result);
    mcp_memory_scope_end();
    if (ask_rc != 0)
-      return text_content(result.error[0] ? result.error : "memory_ask failed");
+      return kb_last_result_content(result.error[0] ? result.error : "memory_ask failed");
 
    cJSON *structured = cJSON_CreateObject();
    if (!structured)
       return text_content("error: out of memory");
+   cJSON_AddStringToObject(structured, "status", result.no_answer ? "abstained" : "ok");
    cJSON_AddStringToObject(structured, "query", jq->valuestring);
    cJSON_AddStringToObject(structured, "answer", result.answer);
    cJSON_AddNumberToObject(structured, "confidence", result.confidence);
@@ -520,8 +543,7 @@ cJSON *tool_search_graph(cJSON *args)
    int count = kb_client_memory_search_graph(jq->valuestring, limit, rels, 20);
    mcp_memory_scope_end();
    if (count < 0)
-      return text_content("error: knowledge service unavailable; the memory store is unreachable "
-                          "(server-side maintenance is required)");
+      return kb_last_result_content("knowledge service memory graph search failed");
 
    char buf[8192];
    int pos = 0;
@@ -550,8 +572,11 @@ cJSON *tool_get_episode(cJSON *args)
       return text_content("error: missing 'episode_key' parameter");
 
    memory_episode_t episode;
-   if (kb_client_memory_get_episode(jk->valuestring, &episode) != 0)
-      return text_content("No episode found.");
+   int episode_rc = kb_client_memory_get_episode(jk->valuestring, &episode);
+   if (episode_rc > 0)
+      return kb_empty_result_content("memory episode not found");
+   if (episode_rc < 0)
+      return kb_last_result_content("memory episode lookup returned no result");
 
    char buf[4096];
    snprintf(buf, sizeof(buf), "Episode: %s\nSession: %s\nTime: %s\nMemory ID: %lld\n\n%s",
@@ -572,8 +597,10 @@ cJSON *tool_get_entity(cJSON *args)
    mcp_memory_scope_begin(args, &active_context_missing);
    int profile_rc = kb_client_memory_get_entity_profile(je->valuestring, &profile);
    mcp_memory_scope_end();
-   if (profile_rc != 0)
-      return text_content("No entity profile found.");
+   if (profile_rc > 0)
+      return kb_empty_result_content("memory entity profile not found");
+   if (profile_rc < 0)
+      return kb_last_result_content("memory entity profile lookup returned no result");
 
    char buf[4096];
    int pos = 0;
@@ -604,8 +631,7 @@ cJSON *tool_get_entity_edges(cJSON *args)
    int count = kb_client_memory_get_entity_edges(je->valuestring, limit, rels, 20);
    mcp_memory_scope_end();
    if (count < 0)
-      return text_content("error: knowledge service unavailable; the memory store is unreachable "
-                          "(server-side maintenance is required)");
+      return kb_last_result_content("knowledge service entity-edge lookup failed");
 
    char buf[8192];
    int pos = 0;
@@ -641,7 +667,7 @@ cJSON *tool_get_context_block(cJSON *args)
    char *ctx = kb_client_memory_context_block(jq->valuestring, block_type, limit);
    mcp_memory_scope_end();
    if (!ctx)
-      return text_content("No context block available.");
+      return kb_last_result_content("memory context block returned no result");
    char *rendered = ctx;
    if (active_context_missing)
    {
@@ -679,8 +705,11 @@ cJSON *tool_memory_get(cJSON *args)
       return text_content("error: missing memory id or memory:<id> handle");
 
    memory_t m;
-   if (kb_client_memory_get(id, &m) != 0)
-      return text_content("No memory found.");
+   int memory_rc = kb_client_memory_get(id, &m);
+   if (memory_rc > 0)
+      return kb_empty_result_content("memory not found");
+   if (memory_rc < 0)
+      return kb_last_result_content("memory lookup returned no result");
 
    dstr_t d;
    dstr_init(&d);
@@ -706,8 +735,7 @@ cJSON *tool_list_facts(cJSON *args)
    int count = kb_client_memory_list(TIER_L2, KIND_FACT, 64, facts, 64);
    mcp_memory_scope_end();
    if (count < 0)
-      return text_content("error: knowledge service unavailable; the memory store is unreachable "
-                          "(server-side maintenance is required)");
+      return kb_last_result_content("knowledge service fact list failed");
 
    char buf[8192];
    int pos = 0;
@@ -739,7 +767,7 @@ cJSON *tool_memory_briefing(cJSON *args)
    cJSON *bundle = kb_client_memory_briefing(limit_tokens);
    mcp_memory_scope_end();
    if (!bundle)
-      return text_content("error: memory_briefing failed");
+      return kb_last_result_content("memory briefing failed");
    cJSON_AddBoolToObject(bundle, "active_context_missing", active_context_missing);
 
    char *rendered = cJSON_PrintUnformatted(bundle);
@@ -793,7 +821,7 @@ cJSON *tool_list_curiosity_items(cJSON *args)
     * the agent expects, so we forward it as the tool result. */
    char *json = kb_client_curiosity_list_json(state, limit);
    if (!json)
-      return text_content("error: knowledge service unavailable for curiosity list");
+      return kb_last_result_content("knowledge service curiosity list failed");
    cJSON *content = text_content(json);
    free(json);
    return content;
@@ -880,7 +908,8 @@ cJSON *tool_list_prospective_memories(cJSON *args)
       cJSON_Delete(detached);
    }
    cJSON_Delete(resp);
-   cJSON *content = text_content(rendered ? rendered : "[]");
+   cJSON *content = rendered ? text_content(rendered)
+                             : kb_last_result_content("prospective memory list returned no result");
    free(rendered);
    return content;
 }
@@ -992,7 +1021,7 @@ cJSON *smcp_tool_find_symbol(cJSON *args)
    term_hit_t hits[20];
    int count = kb_client_index_find_scoped(project, all_projects, jid->valuestring, hits, 20);
    if (count < 0)
-      return text_content("error: knowledge service symbol index unavailable");
+      return kb_last_result_content("knowledge service symbol index unavailable");
    int matched = 0;
    for (int i = 0; i < count; i++)
       if (all_projects || !project || strcmp(hits[i].project, project) == 0)
@@ -1092,8 +1121,8 @@ cJSON *tool_preview_blast_radius(cJSON *args)
    }
 
    char *json = kb_client_index_blast_radius_preview_json(project, paths, cnt);
-   cJSON *content = text_content(
-       json ? json : "{\"status\":\"error\",\"message\":\"knowledge service unavailable\"}");
+   cJSON *content =
+       json ? text_content(json) : kb_last_result_content("knowledge service unavailable");
    free(json);
    return content;
 }

--- a/src/server/server_mcp_call_table.c
+++ b/src/server/server_mcp_call_table.c
@@ -54,6 +54,14 @@
 /* Per-call bundle passed to every handler: the request context plus the
  * out-param for tools that emit an MCP `structured` payload alongside text. */
 
+static cJSON *mcph_kb_last_result(const char *message)
+{
+   char *json = kb_client_last_result_json(message);
+   cJSON *content = text_content(json ? json : "{\"status\":\"unavailable\"}");
+   free(json);
+   return content;
+}
+
 /* ── thin wrappers: uniform signature over the existing tool_* helpers ─────── */
 
 static cJSON *mcph_get_help(struct mcp_call *c)
@@ -258,7 +266,8 @@ static cJSON *mcph_memory_alerts(struct mcp_call *c)
       cJSON_Delete(detached);
    }
    cJSON_Delete(resp);
-   cJSON *content = rendered ? text_content(rendered) : text_content("error: memory_alerts failed");
+   cJSON *content =
+       rendered ? text_content(rendered) : mcph_kb_last_result("memory alerts returned no result");
    free(rendered);
    return content;
 }
@@ -298,7 +307,7 @@ static cJSON *mcph_memory_recall(struct mcp_call *c)
    cJSON_Delete(resp);
    cJSON *content;
    if (!rendered)
-      content = text_content("error: memory_recall failed");
+      content = mcph_kb_last_result("memory recall returned no result");
    else
    {
       content = text_content(rendered);
@@ -338,7 +347,8 @@ static cJSON *mcph_list_epistemic_directives(struct mcp_call *c)
       cJSON_Delete(detached);
    }
    cJSON_Delete(resp);
-   cJSON *content = rendered ? text_content(rendered) : text_content("[]");
+   cJSON *content = rendered ? text_content(rendered)
+                             : mcph_kb_last_result("epistemic directive list returned no result");
    free(rendered);
    return content;
 }
@@ -730,9 +740,10 @@ static cJSON *mcph_index_find_callers(struct mcp_call *c)
    if (n < 0)
    {
       free(hits);
-      return text_content("error: index_find_callers failed");
+      return mcph_kb_last_result("index_find_callers failed");
    }
    cJSON *result = cJSON_CreateObject();
+   cJSON_AddStringToObject(result, "status", n > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(result, "callers");
    for (int i = 0; i < n; i++)
    {
@@ -769,9 +780,10 @@ static cJSON *mcph_index_structure(struct mcp_call *c)
    if (n < 0)
    {
       free(defs);
-      return text_content("error: index_structure failed");
+      return mcph_kb_last_result("index_structure failed");
    }
    cJSON *result = cJSON_CreateObject();
+   cJSON_AddStringToObject(result, "status", n > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(result, "definitions");
    for (int i = 0; i < n; i++)
    {
@@ -797,8 +809,9 @@ static cJSON *mcph_memory_explain_match(struct mcp_call *c)
    memory_diagnostic_t diag;
    memset(&diag, 0, sizeof(diag));
    if (kb_client_memory_explain_match(jq->valuestring, (int64_t)jid->valuedouble, &diag) != 0)
-      return text_content("error: memory_explain_match failed");
+      return mcph_kb_last_result("memory match explanation returned no result");
    cJSON *result = cJSON_CreateObject();
+   cJSON_AddStringToObject(result, "status", "ok");
    cJSON *m = cJSON_AddObjectToObject(result, "memory");
    cJSON_AddNumberToObject(m, "id", (double)diag.memory.id);
    cJSON_AddStringToObject(m, "tier", diag.memory.tier);
@@ -841,9 +854,10 @@ static cJSON *mcph_index_blast_radius(struct mcp_call *c)
    if (kb_client_index_blast_radius(project, jf->valuestring, br) < 0)
    {
       free(br);
-      return text_content("error: index_blast_radius failed");
+      return mcph_kb_last_result("index_blast_radius failed");
    }
    cJSON *result = cJSON_CreateObject();
+   cJSON_AddStringToObject(result, "status", "ok");
    cJSON_AddStringToObject(result, "file", br->file);
    cJSON *deps = cJSON_AddArrayToObject(result, "dependents");
    for (int i = 0; i < br->dependent_count && i < 64; i++)
@@ -870,9 +884,10 @@ static cJSON *mcph_memory_provenance(struct mcp_call *c)
    if (n < 0)
    {
       free(ents);
-      return text_content("error: memory_provenance failed");
+      return mcph_kb_last_result("memory provenance returned no result");
    }
    cJSON *result = cJSON_CreateObject();
+   cJSON_AddStringToObject(result, "status", n > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(result, "provenance");
    for (int i = 0; i < n; i++)
    {
@@ -904,9 +919,10 @@ static cJSON *mcph_memory_fact_history(struct mcp_call *c)
    if (n < 0)
    {
       free(mems);
-      return text_content("error: memory_fact_history failed");
+      return mcph_kb_last_result("memory fact history returned no result");
    }
    cJSON *result = cJSON_CreateObject();
+   cJSON_AddStringToObject(result, "status", n > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(result, "history");
    for (int i = 0; i < n; i++)
    {

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -362,9 +362,17 @@ int handle_memory_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          cJSON_Delete(mj);
       }
    }
-   else
+   else if (rc > 0)
    {
       resp = jo_err("memory not found");
+   }
+   else
+   {
+      char *typed = kb_client_last_result_json("memory lookup failed");
+      resp = typed ? cJSON_Parse(typed) : NULL;
+      free(typed);
+      if (!resp)
+         resp = jo_err("knowledge service unavailable");
    }
    return send_and_free(conn, resp);
 }

--- a/src/server/server_state_index.c
+++ b/src/server/server_state_index.c
@@ -19,6 +19,14 @@ static int send_and_free(server_conn_t *conn, cJSON *resp)
    return server_send_ok(conn, resp);
 }
 
+static cJSON *kb_last_result_object(const char *message)
+{
+   char *json = kb_client_last_result_json(message);
+   cJSON *result = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   return result ? result : jo_err(message);
+}
+
 int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -57,8 +65,12 @@ int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
    term_hit_t hits[128];
    int count = kb_client_index_find_scoped(project, all_projects, identifier, hits, 128);
+   if (count < 0)
+      return send_and_free(conn,
+                           kb_last_result_object("knowledge service symbol index unavailable"));
 
    cJSON *resp = jo_ok();
+   cJSON_AddStringToObject(resp, "result_status", count > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(resp, "hits");
    for (int i = 0; i < count; i++)
    {
@@ -79,8 +91,12 @@ int handle_index_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
    project_info_t projects[128];
    int count = kb_client_index_list(projects, 128);
+   if (count < 0)
+      return send_and_free(conn,
+                           kb_last_result_object("knowledge service project index unavailable"));
 
    cJSON *resp = jo_ok();
+   cJSON_AddStringToObject(resp, "result_status", count > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(resp, "projects");
    for (int i = 0; i < count; i++)
    {
@@ -117,6 +133,7 @@ int handle_index_blast_radius(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
    if (rc == 0)
    {
       resp = jo_ok();
+      cJSON_AddStringToObject(resp, "result_status", "ok");
       jo_add_str(resp, "file", br.file);
 
       cJSON *deps = cJSON_CreateArray();
@@ -130,9 +147,7 @@ int handle_index_blast_radius(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
       cJSON_AddItemToObject(resp, "dependents", depts);
    }
    else
-   {
-      resp = jo_err("blast radius lookup failed (knowledge service unavailable)");
-   }
+      resp = kb_last_result_object("blast radius lookup failed");
    return send_and_free(conn, resp);
 }
 
@@ -153,7 +168,11 @@ int handle_index_structure(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    }
    definition_t defs[256];
    int count = kb_client_index_structure(project, file_path, defs, 256);
+   if (count < 0)
+      return send_and_free(conn,
+                           kb_last_result_object("knowledge service structure index unavailable"));
    cJSON *resp = jo_ok();
+   cJSON_AddStringToObject(resp, "result_status", count > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(resp, "definitions");
    for (int i = 0; i < count; i++)
    {
@@ -202,8 +221,12 @@ int handle_index_find_callers(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
    caller_hit_t hits[128];
    int count = kb_client_index_find_callers_scoped(project, scope && strcmp(scope, "all") == 0,
                                                    symbol, hits, 128);
+   if (count < 0)
+      return send_and_free(conn,
+                           kb_last_result_object("knowledge service caller index unavailable"));
 
    cJSON *resp = jo_ok();
+   cJSON_AddStringToObject(resp, "result_status", count > 0 ? "ok" : "empty");
    cJSON *arr = cJSON_AddArrayToObject(resp, "hits");
    for (int i = 0; i < count; i++)
    {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -184,6 +184,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-web-search-fusion \
                $(TESTPREFIX)/unit-test-web-search-fuse \
                $(TESTPREFIX)/unit-test-web-search-breaker \
+               $(TESTPREFIX)/unit-test-dependency-breaker \
                $(TESTPREFIX)/unit-test-kb-rrf-purity \
                $(TESTPREFIX)/unit-test-wfe-deliver \
                $(TESTPREFIX)/unit-test-wfe-manager-flow \
@@ -1853,6 +1854,9 @@ $(TESTPREFIX)/unit-test-web-search-fuse: $(OBJDIR)/tests/test_web_search_fuse.o 
 
 $(TESTPREFIX)/unit-test-web-search-breaker: $(OBJDIR)/tests/test_web_search_breaker.o \
                                     $(OBJDIR)/server/web_search_breaker.o
+	$(TESTLINK) -o $@ $^ $(L_CORE)
+
+$(TESTPREFIX)/unit-test-dependency-breaker: $(OBJDIR)/tests/test_dependency_breaker.o
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 
 $(TESTPREFIX)/unit-test-web-page-cache: $(OBJDIR)/tests/test_web_page_cache.o \

--- a/src/tests/test_dependency_breaker.c
+++ b/src/tests/test_dependency_breaker.c
@@ -1,0 +1,48 @@
+#include "dependency_breaker.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+static dependency_breaker_t g_breaker = DEPENDENCY_BREAKER_INITIALIZER;
+
+int main(void)
+{
+   const int64_t started = 100000;
+   int64_t retry = -1;
+   dependency_breaker_snapshot_t snap;
+
+   assert(dependency_breaker_allow(&g_breaker, started, &retry) == 1);
+   for (unsigned i = 0; i < DEPENDENCY_BREAKER_DEFAULT_THRESHOLD; i++)
+      dependency_breaker_report_failure(&g_breaker, started, DEPENDENCY_BREAKER_DEFAULT_THRESHOLD,
+                                        DEPENDENCY_BREAKER_DEFAULT_BASE_MS,
+                                        DEPENDENCY_BREAKER_DEFAULT_MAX_MS);
+
+   assert(dependency_breaker_allow(&g_breaker, started, &retry) == 0);
+   assert(retry >= DEPENDENCY_BREAKER_DEFAULT_BASE_MS);
+   assert(retry <= DEPENDENCY_BREAKER_DEFAULT_BASE_MS * 5 / 4);
+   dependency_breaker_snapshot(&g_breaker, started, &snap);
+   assert(snap.open == 1 && snap.failure_streak == 3 && snap.suppressed_calls == 1);
+
+   int64_t first_retry_at = started + retry;
+   assert(dependency_breaker_allow(&g_breaker, first_retry_at, NULL) == 1);
+   assert(dependency_breaker_allow(&g_breaker, first_retry_at, NULL) == 0);
+   dependency_breaker_report_failure(
+       &g_breaker, first_retry_at, DEPENDENCY_BREAKER_DEFAULT_THRESHOLD,
+       DEPENDENCY_BREAKER_DEFAULT_BASE_MS, DEPENDENCY_BREAKER_DEFAULT_MAX_MS);
+   dependency_breaker_snapshot(&g_breaker, first_retry_at, &snap);
+   assert(snap.retry_after_ms >= DEPENDENCY_BREAKER_DEFAULT_BASE_MS * 2);
+   assert(snap.retry_after_ms <= DEPENDENCY_BREAKER_DEFAULT_BASE_MS * 5 / 2);
+
+   int64_t second_retry_at = first_retry_at + snap.retry_after_ms;
+   assert(dependency_breaker_allow(&g_breaker, second_retry_at, NULL) == 1);
+   dependency_breaker_report_success(&g_breaker, second_retry_at);
+   assert(dependency_breaker_allow(&g_breaker, second_retry_at, NULL) == 1);
+   dependency_breaker_snapshot(&g_breaker, second_retry_at, &snap);
+   assert(snap.open == 0 && snap.failure_streak == 0 && snap.last_success_ms == second_retry_at);
+
+   dependency_breaker_reset(&g_breaker);
+   dependency_breaker_snapshot(&g_breaker, started, &snap);
+   assert(snap.suppressed_calls == 0 && snap.last_failure_ms == 0);
+   printf("dependency_breaker: ok\n");
+   return 0;
+}

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -74,6 +74,10 @@ char *kb_client_code_context(const char *query, const char *symbol, const char *
       *status_out = 503;
    return NULL;
 }
+kb_client_result_status_t kb_client_last_result_status(void)
+{
+   return KB_CLIENT_RESULT_OK;
+}
 int kb_client_memory_diagnose(const char *query, int limit, memory_diagnostic_t *out, int max)
 {
    (void)query;

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -15,6 +15,7 @@ static const char *g_context_mode = "observe";
 static int g_context_calls = 0;
 static int g_facts_enabled = 0;
 static int g_facts_calls = 0;
+static kb_client_result_status_t g_context_result = KB_CLIENT_RESULT_OK;
 
 /* The kb-backed builder (ingress_preinject_build) is out of scope here; these
  * stubs satisfy the linker so the test links only the pure helpers without
@@ -63,6 +64,12 @@ char *kb_client_code_context(const char *query, const char *symbol, const char *
    (void)symbol;
    assert(project && strcmp(project, "active-project") == 0);
    g_context_calls++;
+   if (g_context_result == KB_CLIENT_RESULT_UNAVAILABLE)
+   {
+      if (status_out)
+         *status_out = 503;
+      return NULL;
+   }
    if (status_out)
       *status_out = 200;
    return strdup("{\"status\":\"ok\",\"project\":\"active-project\",\"generation\":7,"
@@ -74,6 +81,10 @@ char *kb_client_code_context(const char *query, const char *symbol, const char *
                  "\"accepted\":true,\"provenance\":[\"code\"],"
                  "\"span\":{\"kind\":\"line\",\"line_start\":12,\"line_end\":12},"
                  "\"snippet\":\"int local_answer(void);\"}],\"why\":[]}");
+}
+kb_client_result_status_t kb_client_last_result_status(void)
+{
+   return g_context_result;
 }
 int kb_client_memory_diagnose(const char *query, int limit, memory_diagnostic_t *out, int max)
 {
@@ -338,6 +349,7 @@ static void test_task_context_mode_and_first_turn_gate(void)
    g_facts_enabled = 1;
    g_facts_calls = 0;
    g_context_mode = "on";
+   g_context_result = KB_CLIENT_RESULT_OK;
 
    char *first = ingress_preinject_build("fix local resolver", 0);
    assert(first && strstr(first, "recommended (task-conditioned code") != NULL);
@@ -374,6 +386,32 @@ static void test_task_context_mode_and_first_turn_gate(void)
    g_facts_enabled = 0;
    g_context_mode = "observe";
    printf("task_context_mode_and_first_turn_gate OK\n");
+}
+
+static void test_unavailable_task_context_retries_after_recovery(void)
+{
+   ingress_preinject_task_state_reset();
+   ingress_preinject_set_session_id("session-recovery");
+   g_context_mode = "on";
+   g_context_calls = 0;
+   g_context_result = KB_CLIENT_RESULT_UNAVAILABLE;
+
+   char *outage = ingress_preinject_build("fix local resolver", 0);
+   assert(outage == NULL);
+   assert(g_context_calls == 1);
+
+   /* Same-task vocabulary is eligible again because unavailable is not an
+    * abstention/empty result. The KB breaker owns the actual retry rate. */
+   g_context_result = KB_CLIENT_RESULT_OK;
+   char *recovered = ingress_preinject_build("please fix the local resolver", 0);
+   assert(recovered && strstr(recovered, "task-conditioned code") != NULL);
+   free(recovered);
+   assert(g_context_calls == 2);
+
+   ingress_preinject_set_session_id(NULL);
+   g_context_mode = "observe";
+   g_context_result = KB_CLIENT_RESULT_OK;
+   printf("unavailable_task_context_retries_after_recovery OK\n");
 }
 
 static void test_query_from_messages(void)
@@ -666,6 +704,7 @@ int main(void)
    test_format_envelope();
    test_format_task_context_strict_contract();
    test_task_context_mode_and_first_turn_gate();
+   test_unavailable_task_context_retries_after_recovery();
    test_format_code_block();
    test_query_from_messages();
    test_apply();

--- a/src/tests/test_kb_client_memory.c
+++ b/src/tests/test_kb_client_memory.c
@@ -66,6 +66,19 @@ static int empty_ok_post_handler(const char *url, const char *auth_header, const
    return 200;
 }
 
+static int single_miss_post_handler(const char *url, const char *auth_header, const char *body,
+                                    char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   if (response_buf)
+      *response_buf = strdup("{\"status\":\"error\",\"message\":\"record not found\"}");
+   return 200;
+}
+
 static int scoped_request_count;
 
 static int scoped_ok_post_handler(const char *url, const char *auth_header, const char *body,
@@ -115,6 +128,7 @@ static void test_readers_distinguish_unreachable_from_empty(void)
    char *clusters[] = {"hello"};
 
    /* --- kb unreachable: every count-returning reader reports < 0 --- */
+   kb_client_dependency_reset_for_tests();
    mock_agent_http_set_post_handler(unreachable_post_handler);
    assert(kb_client_memory_list(NULL, NULL, 8, mems, 8) < 0);
    assert(kb_client_memory_find_facts("q", 8, mems, 8) < 0);
@@ -124,6 +138,11 @@ static void test_readers_distinguish_unreachable_from_empty(void)
    assert(kb_client_memory_list_conflicts(conflicts, 8) < 0);
 
    /* --- healthy but empty: same readers report exactly 0 (not < 0) --- */
+   /* Model dependency recovery between the two independent fixtures. Without
+    * this reset the intentionally opened process breaker correctly suppresses
+    * the healthy handler, which would test cooldown rather than empty-result
+    * classification. Breaker recovery itself is covered by kb-client-search. */
+   kb_client_dependency_reset_for_tests();
    mock_agent_http_set_post_handler(empty_ok_post_handler);
    assert(kb_client_memory_list(NULL, NULL, 8, mems, 8) == 0);
    assert(kb_client_memory_find_facts("q", 8, mems, 8) == 0);
@@ -183,6 +202,30 @@ static void test_ordered_readers_propagate_active_project_context(void)
    printf("  PASS: test_ordered_readers_propagate_active_project_context\n");
 }
 
+static void test_single_record_miss_is_not_dependency_failure(void)
+{
+   memory_t memory;
+   memory_entity_profile_t profile;
+   memory_episode_t episode;
+
+   kb_client_dependency_reset_for_tests();
+   mock_agent_http_set_post_handler(single_miss_post_handler);
+   assert(kb_client_memory_get(42, &memory) == 1);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_EMPTY);
+   assert(kb_client_memory_get_entity_profile("missing", &profile) == 1);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_EMPTY);
+   assert(kb_client_memory_get_episode("missing", &episode) == 1);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_EMPTY);
+
+   kb_client_dependency_reset_for_tests();
+   mock_agent_http_set_post_handler(unreachable_post_handler);
+   assert(kb_client_memory_get(42, &memory) < 0);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_UNAVAILABLE);
+
+   mock_agent_http_reset();
+   printf("  PASS: test_single_record_miss_is_not_dependency_failure\n");
+}
+
 static void test_explicit_scope_overrides_ambient_context(void)
 {
    memory_t mems[2];
@@ -203,6 +246,7 @@ int main(void)
    assert(runtime_secret_store("AIMEE_KB_API_BEARER_TOKEN", "test-token") == 0);
 
    test_readers_distinguish_unreachable_from_empty();
+   test_single_record_miss_is_not_dependency_failure();
    test_ordered_readers_propagate_active_project_context();
    test_explicit_scope_overrides_ambient_context();
 

--- a/src/tests/test_kb_client_search.c
+++ b/src/tests/test_kb_client_search.c
@@ -18,6 +18,62 @@ static int g_get_seen = 0;
 static int g_route_case = 0;
 static int g_search_expect_all = 0;
 static char g_push_root[512];
+static int64_t g_dependency_now_ms = 100000;
+static int g_mtls_enabled;
+static int g_mtls_status;
+static const char *g_mtls_response;
+static const char *g_mtls_expected_content_type;
+static int g_mtls_calls;
+
+int agent_http_post_content_type(const char *url, const char *auth_header, const char *content_type,
+                                 const char *body, char **response_buf, int timeout_ms,
+                                 const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)content_type;
+   (void)body;
+   (void)response_buf;
+   (void)timeout_ms;
+   (void)extra_headers;
+   assert(!"mTLS raw POST must not fall through to HTTP");
+   return -1;
+}
+
+int kb_client_mtls_configured(void)
+{
+   return g_mtls_enabled;
+}
+
+char *kb_client_mtls_request_timeout_with_type(const char *method, const char *path,
+                                               const char *body, const char *content_type,
+                                               int timeout_ms, int *status_out)
+{
+   assert(g_mtls_enabled);
+   assert(method && path && timeout_ms > 0);
+   if (strcmp(method, "GET") == 0)
+      assert(body == NULL);
+   if (g_mtls_expected_content_type)
+      assert(content_type && strcmp(content_type, g_mtls_expected_content_type) == 0);
+   else
+      assert(content_type == NULL);
+   g_mtls_calls++;
+   if (status_out)
+      *status_out = g_mtls_status;
+   return g_mtls_response ? strdup(g_mtls_response) : NULL;
+}
+
+char *kb_client_mtls_request_timeout(const char *method, const char *path, const char *body,
+                                     int timeout_ms, int *status_out)
+{
+   return kb_client_mtls_request_timeout_with_type(method, path, body, NULL, timeout_ms,
+                                                   status_out);
+}
+
+static int64_t dependency_test_clock(void)
+{
+   return g_dependency_now_ms;
+}
 
 static int health_get_handler(const char *url, const char *extra_headers, char **response_buf,
                               int timeout_ms)
@@ -124,6 +180,59 @@ static int rejecting_post_handler(const char *url, const char *auth_header, cons
    g_post_seen++;
    if (response_buf)
       *response_buf = strdup("{\"error\":\"unauthorized\"}");
+   return 401;
+}
+
+static int outage_post_handler(const char *url, const char *auth_header, const char *body,
+                               char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)response_buf;
+   (void)timeout_ms;
+   (void)extra_headers;
+   g_post_seen++;
+   return -1;
+}
+
+static int typed_result_get_handler(const char *url, const char *extra_headers, char **response_buf,
+                                    int timeout_ms)
+{
+   (void)extra_headers;
+   (void)timeout_ms;
+   assert(url);
+   assert(strcmp(url, "http://127.0.0.1:4010/v1/typed-result") == 0);
+   g_get_seen++;
+   if (g_route_case == 40)
+   {
+      *response_buf = strdup("{\"status\":\"ok\",\"facts\":[{\"id\":1}]}");
+      return 200;
+   }
+   if (g_route_case == 41)
+   {
+      *response_buf = strdup("{\"status\":\"ok\",\"facts\":[]}");
+      return 200;
+   }
+   if (g_route_case == 42)
+   {
+      *response_buf = strdup("{\"status\":\"ok\",\"no_answer\":true,\"citation_ids\":[]}");
+      return 200;
+   }
+   if (g_route_case == 43)
+   {
+      *response_buf =
+          strdup("{\"status\":\"stale\",\"observed_generation\":6,\"current_generation\":7,"
+                 "\"observed_dimension\":2560,\"current_dimension\":1024}");
+      return 409;
+   }
+   if (g_route_case == 44)
+   {
+      *response_buf = strdup("{\"status\":\"unavailable\",\"dependency\":\"embedder\"}");
+      return 503;
+   }
+   assert(g_route_case == 45);
+   *response_buf = strdup("{\"status\":\"unauthorized\"}");
    return 401;
 }
 
@@ -294,6 +403,12 @@ static int index_get_handler(const char *url, const char *extra_headers, char **
          *response_buf = strdup("{\"status\":\"ok\",\"projects\":[{\"name\":\"aimee\","
                                 "\"root\":\"/repo/aimee\",\"scanned_at\":\"2026-05-26 00:00:00\"}],"
                                 "\"next_cursor\":null}");
+   }
+   else if (g_route_case == 40)
+   {
+      assert(strcmp(url, "http://127.0.0.1:4010/v1/code/projects?max_results=2") == 0);
+      if (response_buf)
+         *response_buf = strdup("{\"status\":\"ok\"}");
    }
    else if (g_route_case == 13 || g_route_case == 14 || g_route_case == 38)
    {
@@ -568,13 +683,122 @@ static void test_search_v1_reports_http_status(void)
 
    char *resp = kb_client_search_json_ex("aimee", "split kb", NULL, 7, "json", NULL);
    assert(resp);
-   assert(strstr(resp, "\"status\":\"error\"") != NULL);
+   assert(strstr(resp, "\"status\":\"unauthorized\"") != NULL);
+   assert(strstr(resp, "\"retryable\":false") != NULL);
    assert(strstr(resp, "HTTP 401") != NULL);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_UNAUTHORIZED);
    free(resp);
 
    assert(g_post_seen == 1);
    unsetenv("AIMEE_KB_API_URL");
    mock_agent_http_reset();
+}
+
+static void test_outage_is_typed_bounded_and_recovers(void)
+{
+   g_post_seen = 0;
+   g_dependency_now_ms = 100000;
+   kb_client_dependency_reset_for_tests();
+   kb_client_dependency_set_clock_for_tests(dependency_test_clock);
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(outage_post_handler);
+   assert(setenv("AIMEE_KB_API_URL", "http://127.0.0.1:4010", 1) == 0);
+   assert(runtime_secret_store("AIMEE_KB_API_BEARER_TOKEN", "test-token") == 0);
+
+   for (int i = 0; i < 4; i++)
+   {
+      char *resp = kb_client_search_json_ex("aimee", "split kb", "embed --json", 7, "json", "rrf");
+      assert(resp && strstr(resp, "\"status\":\"unavailable\"") != NULL);
+      assert(strstr(resp, "\"retryable\":true") != NULL);
+      cJSON *typed = cJSON_Parse(resp);
+      cJSON *retry_after = typed ? cJSON_GetObjectItemCaseSensitive(typed, "retry_after_ms") : NULL;
+      assert(cJSON_IsNumber(retry_after));
+      assert(retry_after->valuedouble >= 1000 && retry_after->valuedouble <= 30000);
+      cJSON_Delete(typed);
+      free(resp);
+   }
+   /* The fourth client call is breaker-suppressed; only three reached HTTP. */
+   assert(g_post_seen == 3);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_UNAVAILABLE);
+   kb_client_dependency_health_t health;
+   kb_client_dependency_health(&health);
+   assert(strcmp(health.state, "open") == 0);
+   assert(health.retry_after_ms >= 1000 && health.retry_after_ms <= 1250);
+   assert(health.suppressed_calls == 1);
+
+   g_dependency_now_ms += health.retry_after_ms;
+   mock_agent_http_set_post_handler(search_post_handler);
+   char *recovered =
+       kb_client_search_json_ex("aimee", "split kb", "embed --json", 7, "json", "rrf");
+   assert(recovered && strstr(recovered, "\"status\":\"ok\"") != NULL);
+   free(recovered);
+   assert(g_post_seen == 4);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_OK);
+   kb_client_dependency_health(&health);
+   assert(strcmp(health.state, "closed") == 0);
+
+   kb_client_dependency_set_clock_for_tests(NULL);
+   kb_client_dependency_reset_for_tests();
+   unsetenv("AIMEE_KB_API_URL");
+   runtime_secret_remove("AIMEE_KB_API_BEARER_TOKEN");
+   mock_agent_http_reset();
+}
+
+static void test_exact_result_statuses(void)
+{
+   g_get_seen = 0;
+   kb_client_dependency_reset_for_tests();
+   mock_agent_http_reset();
+   mock_agent_http_set_get_handler(typed_result_get_handler);
+   assert(setenv("AIMEE_KB_API_URL", "http://127.0.0.1:4010", 1) == 0);
+   runtime_secret_remove("AIMEE_KB_API_BEARER_TOKEN");
+
+   const kb_client_result_status_t expected[] = {
+       KB_CLIENT_RESULT_OK,    KB_CLIENT_RESULT_EMPTY,       KB_CLIENT_RESULT_ABSTAINED,
+       KB_CLIENT_RESULT_STALE, KB_CLIENT_RESULT_UNAVAILABLE, KB_CLIENT_RESULT_UNAUTHORIZED,
+   };
+   for (int i = 0; i < 6; i++)
+   {
+      g_route_case = 40 + i;
+      int http_status = 0;
+      char *json = kb_client_v1_get_json("/v1/typed-result", 100, &http_status);
+      if (i < 3)
+         assert(json != NULL && http_status == 200);
+      else
+         assert(json == NULL);
+      free(json);
+      assert(kb_client_last_result_status() == expected[i]);
+      assert(strcmp(kb_client_result_status_name(expected[i]),
+                    (const char *[]){"ok", "empty", "abstained", "stale", "unavailable",
+                                     "unauthorized"}[i]) == 0);
+      if (i == 3 || i == 4)
+      {
+         char *typed = kb_client_last_result_json("typed result");
+         assert(typed);
+         if (i == 3)
+         {
+            assert(strstr(typed, "\"observed_generation\":6") != NULL);
+            assert(strstr(typed, "\"current_generation\":7") != NULL);
+            assert(strstr(typed, "\"observed_dimension\":2560") != NULL);
+            assert(strstr(typed, "\"current_dimension\":1024") != NULL);
+         }
+         else
+            assert(strstr(typed, "\"dependency\":\"embedder\"") != NULL);
+         free(typed);
+      }
+   }
+   assert(g_get_seen == 6);
+
+   /* An embedder 503 is a typed internal dependency outage, not evidence that
+    * the reachable KB transport itself should open. */
+   kb_client_dependency_health_t health;
+   kb_client_dependency_health(&health);
+   assert(strcmp(health.state, "closed") == 0 && health.failure_streak == 0);
+
+   unsetenv("AIMEE_KB_API_URL");
+   mock_agent_http_reset();
+   kb_client_dependency_reset_for_tests();
+   g_route_case = 0;
 }
 
 static void test_health_uses_v1_api_when_configured(void)
@@ -869,6 +1093,9 @@ static void test_index_reads_use_v1_api_when_configured(void)
    assert(strcmp(projects[0].root, "/repo/aimee") == 0);
    assert(strcmp(projects[0].scanned_at, "2026-05-26 00:00:00") == 0);
 
+   g_route_case = 40;
+   assert(kb_client_index_list(projects, 2) == -1);
+
    g_route_case = 13;
    blast_radius_t br;
    assert(kb_client_index_blast_radius("aimee", "src/main.c", &br) == 0);
@@ -947,10 +1174,68 @@ static void test_index_reads_use_v1_api_when_configured(void)
    assert(strstr(context, "\"project\":\"aimee core/kb?\"") != NULL);
    free(context);
 
-   assert(g_get_seen == 16);
+   assert(g_get_seen == 17);
    unsetenv("AIMEE_KB_API_URL");
    mock_agent_http_reset();
    g_route_case = 0;
+}
+
+static void test_mtls_non_2xx_is_not_returned_as_valid_json(void)
+{
+   unsetenv("AIMEE_KB_API_URL");
+   kb_client_dependency_reset_for_tests();
+   g_mtls_enabled = 1;
+   g_mtls_status = 503;
+   g_mtls_response = "{\"status\":\"unavailable\",\"dependency\":\"kb\",\"retryable\":true}";
+
+   project_info_t projects[2];
+   assert(kb_client_index_list(projects, 2) == -1);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_UNAVAILABLE);
+
+   g_mtls_status = 403;
+   g_mtls_response = "{\"status\":\"unauthorized\",\"retryable\":false}";
+   cJSON *request = cJSON_CreateObject();
+   assert(request != NULL);
+   int status = 0;
+   assert(kb_client_v1_post_json("/v1/search", request, 5000, &status) == NULL);
+   cJSON_Delete(request);
+   assert(status == 403);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_UNAUTHORIZED);
+
+   g_mtls_response = NULL;
+   g_mtls_status = 0;
+   g_mtls_enabled = 0;
+   kb_client_dependency_reset_for_tests();
+}
+
+static void test_mtls_raw_post_preserves_content_type_and_status(void)
+{
+   unsetenv("AIMEE_KB_API_URL");
+   kb_client_dependency_reset_for_tests();
+   g_mtls_enabled = 1;
+   g_mtls_calls = 0;
+   g_mtls_expected_content_type = "Content-Type: multipart/form-data; boundary=unit";
+   g_mtls_status = 200;
+   g_mtls_response = "{\"status\":\"ok\"}";
+
+   int status = 0;
+   char *response = kb_client_v1_post_body_with_type("/v1/docs", "--unit--",
+                                                     g_mtls_expected_content_type, 5000, &status);
+   assert(response && status == 200 && g_mtls_calls == 1);
+   free(response);
+
+   g_mtls_status = 503;
+   g_mtls_response = "{\"status\":\"unavailable\",\"dependency\":\"kb\",\"retryable\":true}";
+   response = kb_client_v1_post_body_with_type("/v1/docs", "--unit--", g_mtls_expected_content_type,
+                                               5000, &status);
+   assert(response == NULL && status == 503 && g_mtls_calls == 2);
+   assert(kb_client_last_result_status() == KB_CLIENT_RESULT_UNAVAILABLE);
+
+   g_mtls_expected_content_type = NULL;
+   g_mtls_response = NULL;
+   g_mtls_status = 0;
+   g_mtls_enabled = 0;
+   kb_client_dependency_reset_for_tests();
 }
 
 static void test_index_scan_uses_v1_api_when_configured(void)
@@ -981,6 +1266,8 @@ int main(void)
    test_status_uses_v1_api_when_configured();
    test_search_uses_v1_api_when_configured();
    test_search_v1_reports_http_status();
+   test_outage_is_typed_bounded_and_recovers();
+   test_exact_result_statuses();
    test_maintenance_uses_v1_api_when_configured();
    test_build_update_ingest_use_v1_api_when_configured();
    test_queue_status_uses_v1_api_when_configured();
@@ -990,6 +1277,8 @@ int main(void)
    test_intelligence_readiness_uses_v1_api_when_configured();
    test_action_wrappers_use_v1_api_when_configured();
    test_index_reads_use_v1_api_when_configured();
+   test_mtls_non_2xx_is_not_returned_as_valid_json();
+   test_mtls_raw_post_preserves_content_type_and_status();
    test_index_scan_uses_v1_api_when_configured();
    printf("test_kb_client_search: ok\n");
    return 0;

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -3661,6 +3661,8 @@ int db2_cross_repo_recompute_blocked_symbols(int k, int m, int len_min)
  * (g_vec_enabled=0 -> memory_embed_text returns 0 -> the leg is skipped), so the
  * existing hybrid tests are unaffected; test_code_hybrid_vector_ok flips it on. */
 static int g_vec_enabled = 0;
+static int g_vec_search_unavailable = 0;
+static int g_vec_unauthorized = 0;
 int memory_embed_text(const char *text, const char *command, float *out, int max_dim)
 {
    (void)text;
@@ -3675,6 +3677,10 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
       out[i] = 0.01f * (float)(i % 7);
    return d;
 }
+int memory_embedder_last_result_unauthorized(void)
+{
+   return g_vec_unauthorized;
+}
 int pgvec_code_search_paths(const char *project, const float *vec, int dim, int limit, char *paths,
                             int path_cap, double *scores, int max)
 {
@@ -3682,6 +3688,8 @@ int pgvec_code_search_paths(const char *project, const float *vec, int dim, int 
    (void)vec;
    (void)dim;
    (void)limit;
+   if (g_vec_search_unavailable)
+      return -1;
    if (!g_vec_enabled || !paths || path_cap <= 0 || !scores || max < 2)
       return 0;
    /* Two hits: src/search.c OVERLAPS the lexical leg (-> 2-signal consensus) and
@@ -4071,6 +4079,7 @@ static void test_code_hybrid_vector_ok(void)
    g_vec_enabled = 0;
    g_test_embedding_dim = 1024;
    assert(s == 200);
+   assert(strstr(buf, "\"vector_status\":\"ok\"") != NULL);
    /* The vector-only file appears, labeled and carrying its vector score. */
    assert(strstr(buf, "\"file_path\":\"src/semantic.c\"") != NULL);
    assert(strstr(buf, "\"vector\"") != NULL);
@@ -4090,8 +4099,45 @@ static void test_code_hybrid_vector_dim_mismatch_skips(void)
                             NULL, 0, buf, sizeof(buf));
    g_vec_enabled = 0;
    assert(s == 200);
+   assert(strstr(buf, "\"vector_status\":\"stale\"") != NULL);
    assert(strstr(buf, "\"file_path\":\"src/search.c\"") != NULL);   /* lexical still works */
    assert(strstr(buf, "\"file_path\":\"src/semantic.c\"") == NULL); /* vector leg skipped */
+}
+
+static void test_code_context_vector_store_outage_is_not_empty(void)
+{
+   g_test_embedding_dim = 2560;
+   g_vec_enabled = 1;
+   g_vec_search_unavailable = 1;
+   char buf[4096];
+   int s =
+       kb_http_route_ex("GET", "/v1/code/context", "query=definitely-unrelated&project=proj-alpha",
+                        NULL, NULL, NULL, 0, buf, sizeof(buf));
+   g_vec_search_unavailable = 0;
+   g_vec_enabled = 0;
+   g_test_embedding_dim = 1024;
+   assert(s == 503);
+   assert(strstr(buf, "\"status\":\"unavailable\"") != NULL);
+   assert(strstr(buf, "\"dependency\":\"vector_store\"") != NULL);
+   assert(strstr(buf, "\"retry_after_ms\":1000") != NULL);
+   assert(strstr(buf, "no_answer") == NULL);
+}
+
+static void test_code_context_dimension_mismatch_is_stale(void)
+{
+   g_test_embedding_dim = 1024;
+   g_vec_enabled = 1;
+   char buf[4096];
+   int s =
+       kb_http_route_ex("GET", "/v1/code/context", "query=definitely-unrelated&project=proj-alpha",
+                        NULL, NULL, NULL, 0, buf, sizeof(buf));
+   g_vec_enabled = 0;
+   assert(s == 409);
+   assert(strstr(buf, "\"status\":\"stale\"") != NULL);
+   assert(strstr(buf, "\"dependency\":\"embedder\"") != NULL);
+   assert(strstr(buf, "\"observed_dimension\":2560") != NULL);
+   assert(strstr(buf, "\"current_dimension\":1024") != NULL);
+   assert(strstr(buf, "\"retryable\":false") != NULL);
 }
 
 static void test_code_context_bounded_current_project(void)
@@ -4134,10 +4180,46 @@ static void test_code_context_no_answer_is_explicit(void)
        kb_http_route_ex("GET", "/v1/code/context", "query=definitely-unrelated&project=proj-alpha",
                         NULL, NULL, NULL, 0, buf, sizeof(buf));
    assert(s == 200);
-   assert(strstr(buf, "\"status\":\"no_answer\"") != NULL);
+   assert(strstr(buf, "\"status\":\"abstained\"") != NULL);
    assert(strstr(buf, "\"decision\":\"no_answer\"") != NULL);
    assert(strstr(buf, "\"results\":[]") != NULL);
    assert(strstr(buf, "\"why\":[]") != NULL);
+}
+
+static void test_code_context_embedder_outage_is_not_no_answer(void)
+{
+   char buf[2048];
+   assert(setenv("AIMEE_EMBEDDER_URL", "http://embedder-down", 1) == 0);
+   g_vec_enabled = 0;
+   int s =
+       kb_http_route_ex("GET", "/v1/code/context", "query=definitely-unrelated&project=proj-alpha",
+                        NULL, NULL, NULL, 0, buf, sizeof(buf));
+   unsetenv("AIMEE_EMBEDDER_URL");
+   assert(s == 503);
+   assert(strstr(buf, "\"status\":\"unavailable\"") != NULL);
+   assert(strstr(buf, "\"dependency\":\"embedder\"") != NULL);
+   assert(strstr(buf, "\"retryable\":true") != NULL);
+   assert(strstr(buf, "\"retry_after_ms\":1000") != NULL);
+   assert(strstr(buf, "no_answer") == NULL);
+}
+
+static void test_code_context_embedder_auth_is_unauthorized(void)
+{
+   char buf[2048];
+   assert(setenv("AIMEE_EMBEDDER_URL", "http://embedder-auth", 1) == 0);
+   g_vec_enabled = 0;
+   g_vec_unauthorized = 1;
+   int s =
+       kb_http_route_ex("GET", "/v1/code/context", "query=definitely-unrelated&project=proj-alpha",
+                        NULL, NULL, NULL, 0, buf, sizeof(buf));
+   g_vec_unauthorized = 0;
+   unsetenv("AIMEE_EMBEDDER_URL");
+   assert(s == 401);
+   assert(strstr(buf, "\"status\":\"unauthorized\"") != NULL);
+   assert(strstr(buf, "\"dependency\":\"embedder\"") != NULL);
+   assert(strstr(buf, "\"retryable\":false") != NULL);
+   assert(strstr(buf, "retry_after_ms") == NULL);
+   assert(strstr(buf, "no_answer") == NULL);
 }
 
 static void test_code_context_does_not_substitute_global_memory(void)
@@ -6134,8 +6216,12 @@ int main(void)
    test_code_hybrid_no_symbol();
    test_code_hybrid_vector_ok();
    test_code_hybrid_vector_dim_mismatch_skips();
+   test_code_context_vector_store_outage_is_not_empty();
+   test_code_context_dimension_mismatch_is_stale();
    test_code_context_bounded_current_project();
    test_code_context_no_answer_is_explicit();
+   test_code_context_embedder_outage_is_not_no_answer();
+   test_code_context_embedder_auth_is_unauthorized();
    test_code_context_does_not_substitute_global_memory();
    test_code_context_requires_verified_memory_anchor();
    test_code_graph_hubs_ok();

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -23,11 +23,31 @@
 #include "../db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "../db2/demotion.h"       /* retrieval_event write/read (auditable-correctness P2) */
 #include "../db2/code_index_ops.h" /* db2_code_file_hash (auditable-correctness P1.5) */
+#include "support/mock_agent_http.h"
 
 int memory_demote_from_failures(void);
 
 static char g_db_path[512];
 static char g_suite_home[512];
+static int64_t g_embedder_now_ms = 100000;
+
+static int64_t embedder_test_clock(void)
+{
+   return g_embedder_now_ms;
+}
+
+static int embedder_unauthorized_post(const char *url, const char *auth_header, const char *body,
+                                      char **response_buf, int timeout_ms,
+                                      const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   *response_buf = strdup("{\"status\":\"unauthorized\"}");
+   return 403;
+}
 
 static void memory_test_ensure_env(void)
 {
@@ -2524,6 +2544,9 @@ int main(void)
    /* --- deterministic builtin embedding fallback --- */
    {
       float vec[4];
+      memory_embedder_dependency_reset_for_tests();
+      memory_embedder_dependency_set_clock_for_tests(embedder_test_clock);
+      g_embedder_now_ms = 100000;
       int dim = memory_embed_text("test", "", vec, 4);
       assert(dim == 4);
 
@@ -2538,11 +2561,26 @@ int main(void)
    {
       float vec[4];
 
+      /* A reachable external embedder's auth refusal is non-retryable and
+       * remains distinct from transport unavailability. */
+      mock_agent_http_reset();
+      mock_agent_http_set_post_handler(embedder_unauthorized_post);
+      memory_embedder_dependency_reset_for_tests();
+      int dim = memory_embed_text("ignored", "http://embedder", vec, 4);
+      assert(dim == 0);
+      assert(memory_embedder_last_result_unauthorized());
+      memory_embedder_health_t auth_health;
+      memory_embedder_health(&auth_health);
+      assert(strcmp(auth_health.state, "closed") == 0);
+      assert(auth_health.failure_streak == 0);
+      mock_agent_http_reset();
+      memory_embedder_dependency_reset_for_tests();
+
       /* A well-behaved sidecar emitting a JSON float array is parsed verbatim,
        * proving the float32 contract end-to-end through platform_exec_pipe. */
       for (int i = 0; i < 4; i++)
          vec[i] = -99.0f;
-      int dim = memory_embed_text("ignored", "printf '[0.5, 0.25, 0.125, 0.0625]'", vec, 4);
+      dim = memory_embed_text("ignored", "printf '[0.5, 0.25, 0.125, 0.0625]'", vec, 4);
       assert(dim == 4);
       assert(fabs(vec[0] - 0.5) < 1e-6 && fabs(vec[1] - 0.25) < 1e-6);
       assert(fabs(vec[2] - 0.125) < 1e-6 && fabs(vec[3] - 0.0625) < 1e-6);
@@ -2568,6 +2606,37 @@ int main(void)
       dim = memory_embed_text("ignored", "printf 'not json at all'", vec, 4);
       assert(dim == 0);
       assert(vec[0] == -99.0f);
+
+      /* Three consecutive failures open the breaker. A good dependency is not
+       * hammered until the bounded delay expires, then one successful probe
+       * closes it without restarting this process. */
+      memory_embedder_health_t health;
+      memory_embedder_health(&health);
+      assert(strcmp(health.state, "open") == 0);
+      assert(health.retry_after_ms >= 1000 && health.retry_after_ms <= 1250);
+      dim = memory_embed_text("ignored", "printf '[1, 0, 0, 0]'", vec, 4);
+      assert(dim == 0);
+      memory_embedder_health(&health);
+      assert(health.suppressed_calls == 1);
+      g_embedder_now_ms += health.retry_after_ms;
+
+      /* A half-open probe that reaches the embedder but is refused proves the
+       * old transport outage recovered. Preserve unauthorized and close the
+       * transient breaker so the next call is not misreported as unavailable. */
+      mock_agent_http_set_post_handler(embedder_unauthorized_post);
+      dim = memory_embed_text("ignored", "http://embedder", vec, 4);
+      assert(dim == 0);
+      assert(memory_embedder_last_result_unauthorized());
+      memory_embedder_health(&health);
+      assert(strcmp(health.state, "closed") == 0 && health.failure_streak == 0);
+      mock_agent_http_reset();
+
+      dim = memory_embed_text("ignored", "printf '[1, 0, 0, 0]'", vec, 4);
+      assert(dim == 4);
+      memory_embedder_health(&health);
+      assert(strcmp(health.state, "closed") == 0 && health.available == 1);
+      memory_embedder_dependency_set_clock_for_tests(NULL);
+      memory_embedder_dependency_reset_for_tests();
    }
 
    /* --- kind_lifecycle_load: returns correct defaults for all 8 kinds --- */

--- a/src/tests/test_memory_embed_http_auth.c
+++ b/src/tests/test_memory_embed_http_auth.c
@@ -8,6 +8,8 @@
 #include <string.h>
 
 int memory_embed_http_post(const char *base, const char *path, const char *body, char **resp);
+int memory_embed_http_post_status(const char *base, const char *path, const char *body, char **resp,
+                                  int *status_out);
 
 static int s_posts;
 
@@ -24,6 +26,18 @@ static int post_ok(const char *url, const char *auth_header, const char *body, c
    return 200;
 }
 
+static int post_unauthorized(const char *url, const char *auth_header, const char *body,
+                             char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   *response_buf = strdup("{\"status\":\"unauthorized\"}");
+   return 401;
+}
+
 int main(void)
 {
    char *resp = NULL;
@@ -36,6 +50,15 @@ int main(void)
    assert(resp && strcmp(resp, "[1.0]") == 0);
    free(resp);
    assert(s_posts == 1);
+
+   mock_agent_http_set_post_handler(post_unauthorized);
+   int status = 0;
+   resp = NULL;
+   assert(memory_embed_http_post_status("http://aimee-llm:8742", "/embed", "probe", &resp,
+                                        &status) == -1);
+   assert(status == 401);
+   assert(resp == NULL);
+   mock_agent_http_set_post_handler(post_ok);
 
    /* A managed KB never issues an unauthenticated request. */
    runtime_secret_remove("AIMEE_LLM_AUTH_TOKEN");


### PR DESCRIPTION
## Summary

- preserve six typed code-retrieval outcomes across HTTP and mTLS transports
- add isolated KB/embedder circuit breakers with bounded half-open recovery
- keep active-project-first ordering and prevent outages from appearing as empty results
- document the E5a validation and independent closure review

## Validation

- focused dependency, KB-client, ingress, memory, mTLS, and HTTP route tests
- `make -C src kb server -j4`
- `make -C src lint`
- proposal-link, API-conformance, and v1-method coverage checks
- complete `unit-tests` suite (`AIMEE_TEST_PG_URL` gate deferred to required CI)
- code-intelligence fixture source verification
- roundtable closure review `oprun_g6a6b1ed93980fd5d_1785405189_1`: approved, no findings

## Scope

E5b readiness/diagnostics, E5c benchmark checkpointing, and E6 fresh benchmark claims remain separate slices.
