### PR TITLE
ops: enforce retrieval readiness contract

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,5 +1,8 @@
 # Troubleshooting
 
+For server/KB liveness, retrieval readiness, breaker diagnostics, queue depth, and
+safe dependency recovery, see [Retrieval readiness and recovery](runbooks/retrieval-readiness-and-recovery.md).
+
 Start at the first broken boundary.
 
 ```bash

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -756,6 +756,18 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   embedder/vector-store outage does not poison its transport breaker, local coding remains
   independent, and no agent-facing memory/index reader converts an outage into an empty result. Its
   frozen implementation diff receives a separate roundtable gate before PR.
+- **E5b deployment-readiness candidate:** server liveness remains independent of recoverable
+  dependency failure, while readiness now fails closed on the complete retrieval contract and
+  reports the failed boundary, E5a breaker state/retry delay, and last successful query/ingest.
+  Shipped Compose restart policy remains `unless-stopped` with liveness healthchecks; the operator
+  runbook pins separate readiness admission, queue diagnostics, evidence preservation, and safe
+  dependency-specific recovery. Its frozen implementation diff receives a separate roundtable gate
+  before PR.
+- **E5b final exact-diff review — 2026-07-30 — APPROVED and converged, 3/3 participants, not
+  degraded.** The final runbook, explicit dependency boundary, JSON-safe diagnostics, and
+  retrieval-only/null-diagnostics regressions received no findings. Roundtable run:
+  `oprun_g6a6b1ed93980fd5d_1785408651_7` (artifact
+  `0f0e27dbb596f737174e815004baf9a71b904127185a7af05809c747bdceb8e0`).
 - **E5a implementation round 1 — 2026-07-30 — changes requested, 3/3 participants, not
   degraded.** The implementation received no bounded-slice technical ruling because the review
   brief exposed the unfinished parent E5/E6 program. The next review explicitly binds the frozen

--- a/docs/runbooks/retrieval-readiness-and-recovery.md
+++ b/docs/runbooks/retrieval-readiness-and-recovery.md
@@ -1,0 +1,51 @@
+# Retrieval readiness and recovery
+
+Use `GET /v1/health` only as the process liveness probe. It returns success while a
+dependency outage is recoverable, so the supervisor does not restart-loop a healthy
+server. Use `GET /v1/ready` to admit or drain retrieval-bearing traffic. Readiness is
+false until DB1, KB transport, the KB schema/vector collection, the embedder, and the
+E5a dependency breaker can serve the advertised retrieval contract.
+
+The shipped Compose files use `restart: unless-stopped` and intentionally healthcheck
+`/v1/health`. Orchestrators with separate probes should configure liveness at
+`/v1/health` and readiness at `/v1/ready`. A 503 from readiness is an operational
+signal, not a reason to kill the process.
+
+## Diagnose
+
+Run these from a host that can reach the relevant listeners (add authentication or TLS
+options for the deployment):
+
+```sh
+curl -fsS http://127.0.0.1:8740/v1/health
+curl -sS http://127.0.0.1:8740/v1/ready
+curl -fsS http://127.0.0.1:8741/v1/health
+curl -fsS http://127.0.0.1:8741/v1/pipeline/status
+```
+
+The readiness `dependencies` object names the failed boundary. Its `diagnostics`
+object reports the E5a breaker state, bounded retry delay, last successful query time
+(Unix milliseconds), and KB's last successful ingest timestamp. Pipeline status
+reports `queue_depth` and pending/running/failed counts. Preserve all four responses
+with UTC time, image digest, and server version before recovery.
+
+## Recover safely
+
+1. If `db1=fail`, verify the server volume is mounted and writable. Restore the mount
+   or credentials, then restart only `aimee-server`.
+2. If `kb=fail`, verify `aimee-kb` liveness and network/DNS reachability. Recover KB;
+   do not repeatedly restart the server. The breaker permits one half-open probe after
+   `retry_after_ms`.
+3. If `retrieval=fail` with `kb=ok`, inspect KB health fields (`db2_ok`,
+   `db2_kb_tables_ok`, `pgvec_ok`, `pgvec_collection_ok`, `embed_ok`). Repair the named
+   store/embedder dependency. Never clear or recreate vector data merely to make the
+   probe green.
+4. If queue depth is growing, stop new ingest, retain failed-job evidence, repair the
+   worker dependency, and let the normal queue drain. Use the documented pipeline
+   drain endpoint only after preserving status and confirming the operation's limit.
+5. Wait at least one readiness sampling interval (default 15 seconds), then require
+   `/v1/ready` HTTP 200 and a successful scoped retrieval before restoring traffic.
+
+Do not delete queues, DB volumes, benchmark artifacts, or breaker evidence as a
+recovery shortcut. Escalate if the breaker repeatedly reopens or the last successful
+ingest/query timestamps do not advance after the dependency is healthy.

--- a/docs/validation/indexing-effectiveness-e5b.md
+++ b/docs/validation/indexing-effectiveness-e5b.md
@@ -1,0 +1,46 @@
+# E5b deployment readiness validation
+
+- Base: `origin/testing` at `ada6d21d9ac4461b9a144acdc1d8b5c1b43718c3`
+- Environment: Linux x86_64, 2026-07-30 UTC
+- Scope: retrieval readiness, restart/liveness policy, diagnostics, recovery runbook
+
+Commands:
+
+```sh
+make build/obj/tests/unit-test-server-ready
+build/obj/tests/unit-test-server-ready
+git diff --check
+```
+
+The focused unit test passes. It proves unsampled/stale snapshots fail closed,
+liveness dependencies are named, retrieval failure drains traffic, and breaker retry
+and last-success diagnostics remain visible. The deployment audit confirms all shipped
+split-stack services use `restart: unless-stopped`; server Docker healthchecks remain
+on `/v1/health`, while the runbook assigns `/v1/ready` to traffic admission.
+
+## Frozen-diff review
+
+- Runs `oprun_g6a6b1ed93980fd5d_1785407513_2` and
+  `oprun_g6a6b1ed93980fd5d_1785407524_3` received empty payloads because the
+  replacement host lacked the expected JSON utility. They are invalid transport
+  attempts and are not review evidence.
+- Run `oprun_g6a6b1ed93980fd5d_1785407534_4` converged with all three participants
+  and requested changes. It found that the untracked runbook was absent from the
+  frozen artifact, collapsed retrieval diagnostics did not identify the failed
+  boundary, dependency text was not JSON-escaped, and retrieval-only failure lacked
+  a direct renderer regression. New files are now included in the frozen artifact;
+  the exact failed boundary is reported; diagnostic strings are escaped; and both
+  retrieval-only failure and hostile diagnostic text have regressions.
+- Run `oprun_g6a6b1ed93980fd5d_1785407898_5` is invalid review evidence. Its artifact
+  was generated against the moving `origin/testing` ref after unrelated PR #2174
+  advanced that ref, so it mixed the E5b patch with a reverse diff of upstream Vault
+  changes. The panel correctly rejected that out-of-scope mixed artifact. Subsequent
+  review artifacts are generated against immutable branch base `HEAD`.
+- Run `oprun_g6a6b1ed93980fd5d_1785408285_6` reviewed the correct seven-file
+  artifact and found one remaining JSON boundary: a fresh render with missing
+  diagnostics could interpolate uninitialized escape buffers. The escaper now
+  initializes every nonzero-capacity destination before accepting a null source,
+  and a fresh/null-diagnostics regression proves deterministic fail-closed JSON.
+- Run `oprun_g6a6b1ed93980fd5d_1785408651_7` approved and converged with all three
+  participants, no degradation, and no findings. Frozen artifact SHA-256:
+  `0f0e27dbb596f737174e815004baf9a71b904127185a7af05809c747bdceb8e0`.

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -480,8 +480,17 @@ extern "C"
     * roll-up and staleness behavior can be tested by passing a clock instead of
     * sleeping past a real interval. db1_ok/kb_ok: 1 ok, 0 fail, -1 unknown.
     * Writes the JSON body and returns the HTTP status (200 ready / 503 not). */
-   int server_ready_render(int db1_ok, int kb_ok, long sampled_at, long now, int stale_secs,
-                           char *resp, int cap);
+   typedef struct
+   {
+      int retrieval_ok; /* 1 usable, 0 failed, -1 unknown */
+      const char *failed_boundary;
+      const char *breaker_state;
+      long long retry_after_ms;
+      long long last_success_query_ms;
+      const char *last_ingest_at;
+   } server_ready_diagnostics_t;
+   int server_ready_render(int db1_ok, int kb_ok, const server_ready_diagnostics_t *diagnostics,
+                           long sampled_at, long now, int stale_secs, char *resp, int cap);
 
    void server_native_register(void);
 

--- a/src/server/server_ready.c
+++ b/src/server/server_ready.c
@@ -14,14 +14,10 @@
  *          make the readiness endpoint its own source of load.
  *   kb   — kb_client_health(). One HTTP call to aimee-kb, off the request path.
  *
- * aimee-llm is intentionally NOT sampled, and this endpoint makes NO claim
- * about it. The dependency chain is server -> aimee-kb -> aimee-llm and the
- * server holds no llm configuration, so it has nothing to probe. Note what this
- * does *not* mean: the kb check below reads kb_health_t.process_ok, which is
- * aimee-kb liveness only. It is not a transitive guarantee that aimee-kb can
- * reach aimee-llm, and readiness must not be read as one. If llm-path readiness
- * is ever required, it belongs to aimee-kb's own readiness surface, reported
- * through an explicit field — not inferred here.
+ * The retrieval contract additionally requires the KB schema/vector collection
+ * and embedder advertised by KB health, plus a non-open E5a transport breaker.
+ * This is readiness, not liveness: a recoverable dependency outage drains work
+ * without asking the supervisor to restart a healthy server process.
  *
  * Fail-closed rules:
  *   - before the first sample completes, every dependency is `unknown` and the
@@ -58,6 +54,12 @@ typedef struct
 {
    dep_state_t db1;
    dep_state_t kb;
+   dep_state_t retrieval;
+   char failed_boundary[32];
+   char breaker_state[16];
+   long long retry_after_ms;
+   long long last_success_query_ms;
+   char last_ingest_at[64];
    long sampled_at; /* epoch seconds; 0 = never sampled */
 } ready_snapshot_t;
 
@@ -114,6 +116,41 @@ static const char *dep_name(dep_state_t s)
    }
 }
 
+static void json_escape(const char *src, char *dst, size_t cap)
+{
+   size_t used = 0;
+   if (cap == 0)
+      return;
+   dst[0] = '\0';
+   if (!src)
+      return;
+   for (const unsigned char *p = (const unsigned char *)src; *p && used + 1 < cap; p++)
+   {
+      const char *escape = NULL;
+      char unicode[7];
+      if (*p == '"')
+         escape = "\\\"";
+      else if (*p == '\\')
+         escape = "\\\\";
+      else if (*p < 0x20)
+      {
+         snprintf(unicode, sizeof(unicode), "\\u%04x", *p);
+         escape = unicode;
+      }
+      if (escape)
+      {
+         size_t n = strlen(escape);
+         if (used + n >= cap)
+            break;
+         memcpy(dst + used, escape, n);
+         used += n;
+      }
+      else
+         dst[used++] = (char)*p;
+   }
+   dst[used] = '\0';
+}
+
 /* Sample every dependency into a local snapshot, then publish it under the
  * lock in one assignment so a concurrent reader sees the previous snapshot or
  * this one, never a half-written mix. */
@@ -127,6 +164,25 @@ void server_ready_sample_now(void)
    kb_health_t h;
    memset(&h, 0, sizeof(h));
    s.kb = (kb_client_health(&h) == 0 && h.process_ok) ? DEP_OK : DEP_FAIL;
+   kb_client_dependency_health_t dependency;
+   kb_client_dependency_health(&dependency);
+   snprintf(s.breaker_state, sizeof(s.breaker_state), "%s", dependency.state);
+   s.retry_after_ms = dependency.retry_after_ms;
+   s.last_success_query_ms = dependency.last_success_ms;
+   snprintf(s.last_ingest_at, sizeof(s.last_ingest_at), "%s", h.last_ingest_at);
+   s.retrieval = (s.kb == DEP_OK && h.db2_ok && h.db2_kb_tables_ok && h.pgvec_ok &&
+                  h.pgvec_collection_ok && h.embed_ok && strcmp(dependency.state, "open") != 0)
+                     ? DEP_OK
+                     : DEP_FAIL;
+   const char *failed = s.kb != DEP_OK                          ? "kb_transport"
+                        : !h.db2_ok                             ? "db2"
+                        : !h.db2_kb_tables_ok                   ? "kb_schema"
+                        : !h.pgvec_ok                           ? "pgvector"
+                        : !h.pgvec_collection_ok                ? "vector_collection"
+                        : !h.embed_ok                           ? "embedder"
+                        : strcmp(dependency.state, "open") == 0 ? "kb_breaker"
+                                                                : "";
+   snprintf(s.failed_boundary, sizeof(s.failed_boundary), "%s", failed);
 
    s.sampled_at = (long)time(NULL);
 
@@ -150,11 +206,14 @@ static void *ready_sampler_main(void *arg)
  * globals, no locks, no I/O. Split out so staleness and roll-up behavior can be
  * tested deterministically by passing a `now` rather than sleeping past a real
  * interval. `db1_ok`/`kb_ok` are 1 ok, 0 fail, -1 unknown/not-sampled. */
-int server_ready_render(int db1_ok, int kb_ok, long sampled_at, long now, int stale_secs,
-                        char *resp, int cap)
+int server_ready_render(int db1_ok, int kb_ok, const server_ready_diagnostics_t *diagnostics,
+                        long sampled_at, long now, int stale_secs, char *resp, int cap)
 {
    dep_state_t db1 = (db1_ok > 0) ? DEP_OK : (db1_ok == 0 ? DEP_FAIL : DEP_UNKNOWN);
    dep_state_t kb = (kb_ok > 0) ? DEP_OK : (kb_ok == 0 ? DEP_FAIL : DEP_UNKNOWN);
+   int retrieval_ok = diagnostics ? diagnostics->retrieval_ok : -1;
+   dep_state_t retrieval =
+       (retrieval_ok > 0) ? DEP_OK : (retrieval_ok == 0 ? DEP_FAIL : DEP_UNKNOWN);
 
    long age = (sampled_at > 0) ? (now - sampled_at) : -1;
 
@@ -166,22 +225,43 @@ int server_ready_render(int db1_ok, int kb_ok, long sampled_at, long now, int st
    {
       db1 = DEP_UNKNOWN;
       kb = DEP_UNKNOWN;
+      retrieval = DEP_UNKNOWN;
    }
 
-   int ready = (db1 == DEP_OK && kb == DEP_OK);
+   int ready = (db1 == DEP_OK && kb == DEP_OK && retrieval == DEP_OK);
    const char *status = ready ? "ok" : (stale ? "unknown" : "degraded");
 
    if (stale && (sampled_at <= 0 || age < 0))
       snprintf(resp, (size_t)cap,
                "{\"ready\":false,\"status\":\"unknown\",\"service\":\"aimee-server\","
                "\"sampled_at\":null,\"age_seconds\":null,"
-               "\"dependencies\":{\"db1\":\"unknown\",\"kb\":\"unknown\"}}");
+               "\"dependencies\":{\"db1\":\"unknown\",\"kb\":\"unknown\","
+               "\"retrieval\":\"unknown\"},\"diagnostics\":{\"breaker_state\":\"unknown\","
+               "\"failed_boundary\":\"unknown\",\"retry_after_ms\":0,"
+               "\"last_success_query_ms\":0,\"last_ingest_at\":\"\"}}");
    else
+   {
+      char escaped_boundary[64];
+      char escaped_breaker[64];
+      char escaped_ingest[256];
+      json_escape(diagnostics ? diagnostics->failed_boundary : NULL, escaped_boundary,
+                  sizeof(escaped_boundary));
+      json_escape(diagnostics ? diagnostics->breaker_state : NULL, escaped_breaker,
+                  sizeof(escaped_breaker));
+      json_escape(diagnostics ? diagnostics->last_ingest_at : NULL, escaped_ingest,
+                  sizeof(escaped_ingest));
       snprintf(resp, (size_t)cap,
                "{\"ready\":%s,\"status\":\"%s\",\"service\":\"aimee-server\","
                "\"sampled_at\":%ld,\"age_seconds\":%ld,"
-               "\"dependencies\":{\"db1\":\"%s\",\"kb\":\"%s\"}}",
-               ready ? "true" : "false", status, sampled_at, age, dep_name(db1), dep_name(kb));
+               "\"dependencies\":{\"db1\":\"%s\",\"kb\":\"%s\",\"retrieval\":\"%s\"},"
+               "\"diagnostics\":{\"failed_boundary\":\"%s\",\"breaker_state\":\"%s\","
+               "\"retry_after_ms\":%lld,"
+               "\"last_success_query_ms\":%lld,\"last_ingest_at\":\"%s\"}}",
+               ready ? "true" : "false", status, sampled_at, age, dep_name(db1), dep_name(kb),
+               dep_name(retrieval), escaped_boundary, escaped_breaker,
+               diagnostics ? diagnostics->retry_after_ms : 0,
+               diagnostics ? diagnostics->last_success_query_ms : 0, escaped_ingest);
+   }
 
    return ready ? 200 : 503;
 }
@@ -195,9 +275,17 @@ static int ready_provider(char *resp, int cap)
 
    int db1_ok = (s.db1 == DEP_UNKNOWN) ? -1 : (s.db1 == DEP_OK);
    int kb_ok = (s.kb == DEP_UNKNOWN) ? -1 : (s.kb == DEP_OK);
+   server_ready_diagnostics_t diagnostics = {
+       .retrieval_ok = (s.retrieval == DEP_UNKNOWN) ? -1 : (s.retrieval == DEP_OK),
+       .failed_boundary = s.failed_boundary,
+       .breaker_state = s.breaker_state,
+       .retry_after_ms = s.retry_after_ms,
+       .last_success_query_ms = s.last_success_query_ms,
+       .last_ingest_at = s.last_ingest_at,
+   };
 
-   return server_ready_render(db1_ok, kb_ok, s.sampled_at, (long)time(NULL), ready_stale_secs(),
-                              resp, cap);
+   return server_ready_render(db1_ok, kb_ok, &diagnostics, s.sampled_at, (long)time(NULL),
+                              ready_stale_secs(), resp, cap);
 }
 
 /* Start the sampler and register the provider. The first sample is taken by the

--- a/src/tests/test_server_ready.c
+++ b/src/tests/test_server_ready.c
@@ -30,46 +30,87 @@ void server_http_set_ready_provider(server_http_ready_fn fn)
    (void)fn;
 }
 
+void kb_client_dependency_health(kb_client_dependency_health_t *out)
+{
+   memset(out, 0, sizeof(*out));
+   snprintf(out->state, sizeof(out->state), "closed");
+}
+
 #define NOW 1000000L
 
 int main(void)
 {
    char resp[2048];
+   server_ready_diagnostics_t ok = {1, "", "closed", 0, 999000, "2026-07-30T00:00:00Z"};
+   server_ready_diagnostics_t failed = {0,    "kb_breaker", "open",
+                                        1200, 998000,       "2026-07-30T00:00:00Z"};
 
    /* Never sampled ⇒ unknown, not ready, and a null age rather than a
     * fabricated one. An unsampled server must never read as ready. */
    {
-      int st = server_ready_render(-1, -1, 0, NOW, 60, resp, sizeof(resp));
+      int st = server_ready_render(-1, -1, NULL, 0, NOW, 60, resp, sizeof(resp));
       assert(st == 503);
       assert(strstr(resp, "\"ready\":false"));
       assert(strstr(resp, "\"status\":\"unknown\""));
       assert(strstr(resp, "\"sampled_at\":null"));
       assert(strstr(resp, "\"age_seconds\":null"));
    }
+   {
+      int st = server_ready_render(1, 1, &failed, NOW - 5, NOW, 60, resp, sizeof(resp));
+      assert(st == 503);
+      assert(strstr(resp, "\"status\":\"degraded\""));
+      assert(strstr(resp, "\"kb\":\"ok\""));
+      assert(strstr(resp, "\"retrieval\":\"fail\""));
+      assert(strstr(resp, "\"failed_boundary\":\"kb_breaker\""));
+   }
+
+   /* Dependency text cannot break the JSON diagnostics object. */
+   {
+      server_ready_diagnostics_t escaped = ok;
+      escaped.last_ingest_at = "quote\" slash\\ newline\n";
+      int st = server_ready_render(1, 1, &escaped, NOW - 5, NOW, 60, resp, sizeof(resp));
+      assert(st == 200);
+      assert(strstr(resp, "quote\\\" slash\\\\ newline\\u000a"));
+   }
 
    /* Fresh sample, everything ok ⇒ ready. */
    {
-      int st = server_ready_render(1, 1, NOW - 5, NOW, 60, resp, sizeof(resp));
+      int st = server_ready_render(1, 1, &ok, NOW - 5, NOW, 60, resp, sizeof(resp));
       assert(st == 200);
       assert(strstr(resp, "\"ready\":true"));
       assert(strstr(resp, "\"status\":\"ok\""));
       assert(strstr(resp, "\"db1\":\"ok\""));
       assert(strstr(resp, "\"kb\":\"ok\""));
+      assert(strstr(resp, "\"retrieval\":\"ok\""));
+      assert(strstr(resp, "\"last_success_query_ms\":999000"));
       assert(strstr(resp, "\"age_seconds\":5"));
+   }
+
+   /* A fresh snapshot with missing diagnostics fails closed with valid,
+    * deterministic JSON rather than exposing uninitialized stack text. */
+   {
+      int st = server_ready_render(1, 1, NULL, NOW - 5, NOW, 60, resp, sizeof(resp));
+      assert(st == 503);
+      assert(strstr(resp, "\"retrieval\":\"unknown\""));
+      assert(strstr(resp, "\"failed_boundary\":\"\""));
+      assert(strstr(resp, "\"breaker_state\":\"\""));
+      assert(strstr(resp, "\"last_ingest_at\":\"\""));
    }
 
    /* One dependency down ⇒ not ready, degraded, and the failing dependency is
     * named rather than hidden behind a roll-up. */
    {
-      int st = server_ready_render(1, 0, NOW - 5, NOW, 60, resp, sizeof(resp));
+      int st = server_ready_render(1, 0, &failed, NOW - 5, NOW, 60, resp, sizeof(resp));
       assert(st == 503);
       assert(strstr(resp, "\"ready\":false"));
       assert(strstr(resp, "\"status\":\"degraded\""));
       assert(strstr(resp, "\"db1\":\"ok\""));
       assert(strstr(resp, "\"kb\":\"fail\""));
+      assert(strstr(resp, "\"breaker_state\":\"open\""));
+      assert(strstr(resp, "\"retry_after_ms\":1200"));
    }
    {
-      int st = server_ready_render(0, 1, NOW - 5, NOW, 60, resp, sizeof(resp));
+      int st = server_ready_render(0, 1, &ok, NOW - 5, NOW, 60, resp, sizeof(resp));
       assert(st == 503);
       assert(strstr(resp, "\"db1\":\"fail\""));
    }
@@ -77,7 +118,7 @@ int main(void)
    /* A stale snapshot degrades to unknown even when every dependency sampled
     * ok — a wedged sampler must not leave "ready" standing forever. */
    {
-      int st = server_ready_render(1, 1, NOW - 61, NOW, 60, resp, sizeof(resp));
+      int st = server_ready_render(1, 1, &ok, NOW - 61, NOW, 60, resp, sizeof(resp));
       assert(st == 503);
       assert(strstr(resp, "\"ready\":false"));
       assert(strstr(resp, "\"status\":\"unknown\""));
@@ -87,7 +128,7 @@ int main(void)
 
    /* Exactly at the bound is still fresh (the bound is inclusive). */
    {
-      int st = server_ready_render(1, 1, NOW - 60, NOW, 60, resp, sizeof(resp));
+      int st = server_ready_render(1, 1, &ok, NOW - 60, NOW, 60, resp, sizeof(resp));
       assert(st == 200);
       assert(strstr(resp, "\"ready\":true"));
    }
@@ -95,7 +136,7 @@ int main(void)
    /* A snapshot stamped in the future means the clock moved; the age is
     * meaningless, so fail closed rather than report a negative age as fresh. */
    {
-      int st = server_ready_render(1, 1, NOW + 30, NOW, 60, resp, sizeof(resp));
+      int st = server_ready_render(1, 1, &ok, NOW + 30, NOW, 60, resp, sizeof(resp));
       assert(st == 503);
       assert(strstr(resp, "\"status\":\"unknown\""));
    }


### PR DESCRIPTION
## Summary
- keep process liveness independent from recoverable retrieval outages
- fail readiness closed on the complete KB/vector/embedder/breaker contract with bounded diagnostics
- document restart policy, queue diagnosis, evidence preservation, and safe recovery

## Validation
- full local unit suite: passed
- `make all`: passed
- `make lint`: passed
- proposal/API/method coverage checks: passed
- frozen roundtable `oprun_g6a6b1ed93980fd5d_1785408651_7`: approved 3/3, no findings

E5c and E6 remain separate dependent slices.