### PR TITLE
bench: add durable resumable experiment checkpoints

### DIFF
--- a/benchmarks/code-agent-effectiveness/README.md
+++ b/benchmarks/code-agent-effectiveness/README.md
@@ -34,3 +34,19 @@ Verify the tracked evidence bytes as well as the fixture schema:
 ```bash
 python3 benchmarks/code-agent-effectiveness/validate_fixtures.py --verify-sources
 ```
+
+Fresh experiment matrices use `checkpoint_runner.py`. A new run requires a JSON plan,
+an unused artifact directory, and a stable checkpoint name:
+
+```bash
+python3 benchmarks/code-agent-effectiveness/checkpoint_runner.py \
+  --plan matrix.json --run-dir artifacts/e6-20260730 --checkpoint full-matrix
+```
+
+Resume by omitting `--plan` and naming the same run directory and checkpoint. The
+runner rejects run/plan/checkpoint provenance mismatches, never overwrites a prior
+run or cell attempt, and records command failures/timeouts as `infrastructure-invalid`
+with `score_eligible:false` while preserving stdout, stderr, timing, and return code.
+Invalid cells must not enter quality denominators and must be rerun as new attempts;
+the checkpoint does not advance past an invalid cell, and results from another run
+are never copied into a checkpoint.

--- a/benchmarks/code-agent-effectiveness/checkpoint_runner.py
+++ b/benchmarks/code-agent-effectiveness/checkpoint_runner.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Durable, non-splicing runner for code-intelligence experiment cells."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+
+def canonical(value: object) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def fsync_dir(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def durable_mkdir(path: Path) -> None:
+    path.mkdir()
+    fsync_dir(path)
+    fsync_dir(path.parent)
+
+
+def write_new(path: Path, value: object) -> None:
+    with path.open("xb") as stream:
+        stream.write(canonical(value))
+        stream.flush()
+        os.fsync(stream.fileno())
+    fsync_dir(path.parent)
+
+
+def replace(path: Path, value: object) -> None:
+    if path.parent.is_symlink() or path.parent.resolve() != path.parent.absolute():
+        raise ValueError("checkpoint directory was replaced or symlinked")
+    temporary = path.with_name(f"{path.name}.{uuid.uuid4().hex}.new")
+    with temporary.open("xb") as stream:
+        stream.write(canonical(value))
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+    fsync_dir(path.parent)
+
+
+def load(path: Path) -> object:
+    return json.loads(path.read_text())
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def safe_name(value: object, label: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", value):
+        raise ValueError(f"{label} must be a bounded path-safe string")
+    return value
+
+
+def require_plain_path(root: Path, path: Path) -> None:
+    relative = path.absolute().relative_to(root.absolute())
+    current = root.absolute()
+    for index, component in enumerate(relative.parts):
+        current /= component
+        mode = current.lstat().st_mode
+        if stat.S_ISLNK(mode):
+            raise ValueError("artifact evidence path contains a symlink")
+        if index < len(relative.parts) - 1 and not stat.S_ISDIR(mode):
+            raise ValueError("artifact evidence parent is not a directory")
+        if index == len(relative.parts) - 1 and not stat.S_ISREG(mode):
+            raise ValueError("artifact evidence is not a regular file")
+
+
+def start(plan_path: Path, run_dir: Path, checkpoint_name: str) -> tuple[dict, dict, Path]:
+    safe_name(checkpoint_name, "checkpoint name")
+    plan = load(plan_path)
+    cells = plan.get("cells") if isinstance(plan, dict) else None
+    if not isinstance(cells, list) or not cells:
+        raise ValueError("plan must contain a nonempty cells array")
+    cell_ids = [cell.get("id") for cell in cells if isinstance(cell, dict)]
+    if len(cell_ids) != len(cells) or len(set(cell_ids)) != len(cell_ids) or any(
+        not isinstance(cell_id, str) or safe_name(cell_id, "cell id") != cell_id for cell_id in cell_ids
+    ):
+        raise ValueError("cell ids must be unique, bounded, path-safe strings")
+    if any(
+        not isinstance(cell.get("command"), list)
+        or not cell["command"]
+        or any(not isinstance(part, str) or not part for part in cell["command"])
+        for cell in cells
+    ):
+        raise ValueError("every cell command must be a nonempty string array")
+    if not run_dir.parent.is_dir() or run_dir.parent.is_symlink() or run_dir.parent.resolve() != run_dir.parent.absolute():
+        raise ValueError("run directory parent must exist and contain no symlink components")
+    durable_mkdir(run_dir)
+    artifacts_root = run_dir / "artifacts"
+    durable_mkdir(artifacts_root)
+    checkpoints_root = run_dir / "checkpoints"
+    durable_mkdir(checkpoints_root)
+    plan_sha = hashlib.sha256(canonical(plan)).hexdigest()
+    run_id = f"cie-{uuid.uuid4().hex}"
+    manifest = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "checkpoint_name": checkpoint_name,
+        "plan_sha256": plan_sha,
+        "plan": plan,
+        "created_unix_ms": int(time.time() * 1000),
+    }
+    write_new(run_dir / "manifest.json", manifest)
+    checkpoint = {
+        "schema_version": 1, "run_id": run_id, "plan_sha256": plan_sha,
+        "attempts": [], "completed": {}
+    }
+    checkpoint_path = run_dir / "checkpoints" / f"{checkpoint_name}.json"
+    write_new(checkpoint_path, checkpoint)
+    return manifest, checkpoint, checkpoint_path
+
+
+def resume(run_dir: Path, checkpoint_name: str) -> tuple[dict, dict, Path]:
+    safe_name(checkpoint_name, "checkpoint name")
+    manifest_path = run_dir / "manifest.json"
+    artifacts_path = run_dir / "artifacts"
+    checkpoints_path = run_dir / "checkpoints"
+    if any(path.is_symlink() or path.resolve() != path.absolute() for path in
+           (run_dir, artifacts_path, checkpoints_path, manifest_path)):
+        raise ValueError("run artifact tree was replaced or symlinked")
+    manifest = load(manifest_path)
+    if hashlib.sha256(canonical(manifest.get("plan"))).hexdigest() != manifest.get("plan_sha256"):
+        raise ValueError("manifest plan digest mismatch; refusing result splicing")
+    checkpoint_path = run_dir / "checkpoints" / f"{checkpoint_name}.json"
+    if checkpoint_path.is_symlink() or checkpoint_path.resolve() != checkpoint_path.absolute():
+        raise ValueError("checkpoint was replaced or symlinked")
+    checkpoint = load(checkpoint_path)
+    if manifest["checkpoint_name"] != checkpoint_name:
+        raise ValueError("checkpoint name does not match immutable run manifest")
+    if checkpoint["run_id"] != manifest["run_id"] or checkpoint["plan_sha256"] != manifest["plan_sha256"]:
+        raise ValueError("checkpoint provenance mismatch; refusing result splicing")
+    completed, attempts = checkpoint.get("completed"), checkpoint.get("attempts")
+    if not isinstance(completed, dict) or not isinstance(attempts, list):
+        raise ValueError("checkpoint evidence collections are malformed")
+    artifacts_root = (run_dir / "artifacts").resolve()
+    plan_cell_ids = {cell["id"] for cell in manifest["plan"]["cells"]}
+    def verify_evidence(cell_id: str, evidence: object, require_valid: bool) -> None:
+        safe_name(cell_id, "completed cell id")
+        if cell_id not in plan_cell_ids:
+            raise ValueError("checkpoint cell is absent from immutable plan; refusing result splicing")
+        if not isinstance(evidence, dict) or not isinstance(evidence.get("files"), dict):
+            raise ValueError("completed artifact evidence is malformed")
+        resolved = {}
+        for name in ("result", "stdout", "stderr"):
+            item = evidence["files"].get(name)
+            if not isinstance(item, dict) or not isinstance(item.get("path"), str) or not isinstance(item.get("sha256"), str):
+                raise ValueError("completed artifact evidence is malformed")
+            lexical_path = (run_dir / item["path"]).absolute()
+            require_plain_path(artifacts_path, lexical_path)
+            path = lexical_path.resolve()
+            if not path.is_relative_to(artifacts_root) or file_sha256(path) != item["sha256"]:
+                raise ValueError("completed artifact digest mismatch; refusing result splicing")
+            resolved[name] = path
+        result_path = resolved["result"]
+        expected = (manifest["run_id"], manifest["plan_sha256"], checkpoint_name, cell_id)
+        for name, path in resolved.items():
+            artifact = load(path)
+            observed = (artifact.get("run_id"), artifact.get("plan_sha256"), artifact.get("checkpoint_name"), artifact.get("cell_id"))
+            if observed != expected:
+                raise ValueError("completed artifact provenance mismatch; refusing result splicing")
+            if require_valid and name == "result" and (artifact.get("status") != "valid" or artifact.get("score_eligible") is not True):
+                raise ValueError("completed artifact provenance mismatch; refusing result splicing")
+    for attempt in attempts:
+        if not isinstance(attempt, dict):
+            raise ValueError("attempt evidence is malformed")
+        verify_evidence(attempt.get("cell_id"), attempt.get("evidence"), False)
+    for cell_id, evidence in completed.items():
+        verify_evidence(cell_id, evidence, True)
+    return manifest, checkpoint, checkpoint_path
+
+
+def run(plan_path: Path | None, run_dir: Path, checkpoint_name: str) -> int:
+    if plan_path:
+        manifest, checkpoint, checkpoint_path = start(plan_path, run_dir, checkpoint_name)
+    else:
+        manifest, checkpoint, checkpoint_path = resume(run_dir, checkpoint_name)
+    completed = set(checkpoint["completed"])
+    invalid = False
+    for cell in manifest["plan"]["cells"]:
+        cell_id = cell["id"]
+        if cell_id in completed:
+            continue
+        artifacts_path = run_dir / "artifacts"
+        artifacts_root = artifacts_path.resolve()
+        if artifacts_path.is_symlink() or artifacts_root != artifacts_path.absolute():
+            raise ValueError("artifact root was replaced or symlinked")
+        cell_dir = artifacts_path / cell_id
+        if cell_dir.exists():
+            if cell_dir.is_symlink() or not cell_dir.is_dir() or not cell_dir.resolve().is_relative_to(artifacts_root):
+                raise ValueError("cell artifact directory was replaced or symlinked")
+        else:
+            durable_mkdir(cell_dir)
+        attempt_dir = cell_dir / f"attempt-{uuid.uuid4().hex}"
+        if cell_dir.is_symlink() or not attempt_dir.parent.resolve().is_relative_to(artifacts_root):
+            raise ValueError("attempt directory escapes run directory")
+        durable_mkdir(attempt_dir)
+        started = int(time.time() * 1000)
+        infrastructure_error = None
+        try:
+            result = subprocess.run(cell["command"], capture_output=True, timeout=cell.get("timeout_seconds", 900))
+            status = "valid" if result.returncode == 0 else "infrastructure-invalid"
+            returncode = result.returncode
+            stdout, stderr = result.stdout, result.stderr
+        except subprocess.TimeoutExpired as error:
+            def captured(value: str | bytes | None) -> bytes:
+                return value.encode() if isinstance(value, str) else (value or b"")
+            status, returncode = "infrastructure-invalid", None
+            stdout, stderr = captured(error.stdout), captured(error.stderr)
+            infrastructure_error = str(error)
+        except OSError as error:
+            status, returncode, stdout, stderr = "infrastructure-invalid", None, b"", b""
+            infrastructure_error = str(error)
+        artifact = {
+            "schema_version": 1,
+            "run_id": manifest["run_id"],
+            "plan_sha256": manifest["plan_sha256"],
+            "checkpoint_name": checkpoint_name,
+            "cell_id": cell_id,
+            "status": status,
+            "score_eligible": status == "valid",
+            "returncode": returncode,
+            "infrastructure_error": infrastructure_error,
+            "started_unix_ms": started,
+            "finished_unix_ms": int(time.time() * 1000),
+            "command": cell["command"],
+        }
+        write_new(attempt_dir / "result.json", artifact)
+        output_provenance = {
+            "schema_version": 1,
+            "run_id": manifest["run_id"],
+            "plan_sha256": manifest["plan_sha256"],
+            "checkpoint_name": checkpoint_name,
+            "cell_id": cell_id,
+        }
+        write_new(attempt_dir / "stdout.json", {**output_provenance, "encoding": "base64", "data": base64.b64encode(stdout).decode()})
+        write_new(attempt_dir / "stderr.json", {**output_provenance, "encoding": "base64", "data": base64.b64encode(stderr).decode()})
+        evidence = {
+            "files": {
+                name: {
+                    "path": str((attempt_dir / f"{name}.json").relative_to(run_dir)),
+                    "sha256": file_sha256(attempt_dir / f"{name}.json"),
+                }
+                for name in ("result", "stdout", "stderr")
+            }
+        }
+        checkpoint["attempts"].append({"cell_id": cell_id, "evidence": evidence})
+        replace(checkpoint_path, checkpoint)
+        invalid |= status != "valid"
+        if invalid:
+            return 2
+        checkpoint["completed"][cell_id] = evidence
+        replace(checkpoint_path, checkpoint)
+    return 2 if invalid else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan", type=Path, help="new run plan; omit only when resuming")
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--checkpoint", required=True)
+    args = parser.parse_args()
+    try:
+        return run(args.plan, args.run_dir, args.checkpoint)
+    except (FileExistsError, FileNotFoundError, KeyError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/tests/test_code_intelligence_checkpoint_runner.py
+++ b/benchmarks/tests/test_code_intelligence_checkpoint_runner.py
@@ -1,0 +1,233 @@
+import importlib.util
+import base64
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "code-agent-effectiveness" / "checkpoint_runner.py"
+SPEC = importlib.util.spec_from_file_location("checkpoint_runner", MODULE_PATH)
+runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runner)
+
+
+def make_plan(path: Path, cells: list[dict]) -> Path:
+    path.write_text(json.dumps({"pinned_commit": "abc123", "prompt_fixture": "v1", "cells": cells}))
+    return path
+
+
+def output_bytes(path: Path) -> bytes:
+    envelope = json.loads(path.read_text())
+    assert envelope["encoding"] == "base64"
+    return base64.b64decode(envelope["data"])
+
+
+class CheckpointRunnerTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_failure_is_preserved_and_excluded_from_scoring(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "broken", "command": ["sh", "-c", "printf evidence; exit 9"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "after-broken"), 2)
+        results = list(run_dir.glob("artifacts/broken/attempt-*/result.json"))
+        self.assertEqual(len(results), 1)
+        result = json.loads(results[0].read_text())
+        self.assertEqual(result["status"], "infrastructure-invalid")
+        self.assertFalse(result["score_eligible"])
+        self.assertIn(b"evidence", output_bytes(next(run_dir.glob("artifacts/broken/attempt-*/stdout.json"))))
+        checkpoint = json.loads((run_dir / "checkpoints/after-broken.json").read_text())
+        self.assertNotIn("broken", checkpoint["completed"])
+
+    def test_named_resume_runs_only_unfinished_cells(self):
+        marker = self.root / "marker"
+        source = make_plan(self.root / "plan.json", [
+            {"id": "first", "command": ["sh", "-c", f"printf x >> {marker}"]},
+            {"id": "second", "command": ["sh", "-c", "true"]},
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        self.assertEqual(runner.run(None, run_dir, "matrix-a"), 0)
+        self.assertEqual(marker.read_text(), "x")
+
+    def test_resume_refuses_checkpoint_splicing(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        checkpoint_path = run_dir / "checkpoints/matrix-a.json"
+        checkpoint = json.loads(checkpoint_path.read_text())
+        checkpoint["run_id"] = "foreign-run"
+        checkpoint_path.write_text(json.dumps(checkpoint))
+        with self.assertRaisesRegex(ValueError, "splicing"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_resume_refuses_spliced_result_artifact(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        result_path = next(run_dir.glob("artifacts/one/attempt-*/result.json"))
+        result = json.loads(result_path.read_text())
+        result["run_id"] = "foreign-run"
+        result_path.write_text(json.dumps(result))
+        with self.assertRaisesRegex(ValueError, "splicing"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_resume_refuses_modified_raw_output(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "printf original"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        stdout_path = next(run_dir.glob("artifacts/one/attempt-*/stdout.json"))
+        stdout_path.write_text(json.dumps({"text": "replacement"}))
+        with self.assertRaisesRegex(ValueError, "digest mismatch"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_resume_refuses_cross_cell_output_splicing(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "printf one"]},
+            {"id": "two", "command": ["sh", "-c", "printf two"]},
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        checkpoint_path = run_dir / "checkpoints/matrix-a.json"
+        checkpoint = json.loads(checkpoint_path.read_text())
+        checkpoint["completed"]["one"]["files"]["stdout"] = checkpoint["completed"]["two"]["files"]["stdout"]
+        checkpoint_path.write_text(json.dumps(checkpoint))
+        with self.assertRaisesRegex(ValueError, "provenance mismatch"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_checkpoint_name_cannot_escape_run_directory(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        with self.assertRaisesRegex(ValueError, "checkpoint name"):
+            runner.run(source, self.root / "run", "../foreign")
+
+    def test_timeout_preserves_captured_output(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "slow", "command": ["sh", "-c", "printf before; printf warning >&2; sleep 1"],
+             "timeout_seconds": 0.05}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 2)
+        self.assertEqual(output_bytes(next(run_dir.glob("artifacts/slow/attempt-*/stdout.json"))), b"before")
+        self.assertEqual(output_bytes(next(run_dir.glob("artifacts/slow/attempt-*/stderr.json"))), b"warning")
+        result = json.loads(next(run_dir.glob("artifacts/slow/attempt-*/result.json")).read_text())
+        self.assertIn("timed out", result["infrastructure_error"])
+        self.assertNotIn(b"timed out", output_bytes(next(run_dir.glob("artifacts/slow/attempt-*/stderr.json"))))
+
+    def test_resume_refuses_modified_manifest_plan(self):
+        marker = self.root / "ready"
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", f"test -f {marker}"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 2)
+        manifest_path = run_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["plan"]["cells"][0]["command"] = ["sh", "-c", "true"]
+        manifest_path.write_text(json.dumps(manifest))
+        with self.assertRaisesRegex(ValueError, "plan digest"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_resume_refuses_evidence_for_cell_absent_from_plan(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        checkpoint_path = run_dir / "checkpoints/matrix-a.json"
+        checkpoint = json.loads(checkpoint_path.read_text())
+        checkpoint["attempts"][0]["cell_id"] = "foreign"
+        checkpoint_path.write_text(json.dumps(checkpoint))
+        with self.assertRaisesRegex(ValueError, "absent from immutable plan"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_new_run_never_overwrites_existing_artifacts(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        with self.assertRaises(FileExistsError):
+            runner.run(source, run_dir, "matrix-a")
+
+    def test_new_run_rejects_preexisting_symlink_artifact_tree(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        run_dir = self.root / "run"
+        run_dir.mkdir()
+        (run_dir / "artifacts").symlink_to(self.root / "outside", target_is_directory=True)
+        with self.assertRaises(FileExistsError):
+            runner.run(source, run_dir, "matrix-a")
+        self.assertFalse((self.root / "outside").exists())
+
+    def test_completed_resume_rejects_replaced_artifact_root(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        artifacts = run_dir / "artifacts"
+        real_artifacts = run_dir / "real-artifacts"
+        artifacts.rename(real_artifacts)
+        artifacts.symlink_to(real_artifacts, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "replaced or symlinked"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_completed_resume_rejects_in_tree_evidence_symlink(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "printf output"]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 0)
+        stdout_path = next(run_dir.glob("artifacts/one/attempt-*/stdout.json"))
+        saved_path = stdout_path.with_name("saved-stdout.json")
+        stdout_path.rename(saved_path)
+        stdout_path.symlink_to(saved_path.name)
+        with self.assertRaisesRegex(ValueError, "contains a symlink"):
+            runner.run(None, run_dir, "matrix-a")
+
+    def test_new_run_rejects_symlinked_parent(self):
+        source = make_plan(self.root / "plan.json", [
+            {"id": "one", "command": ["sh", "-c", "true"]}
+        ])
+        real_parent = self.root / "real-parent"
+        real_parent.mkdir()
+        linked_parent = self.root / "linked-parent"
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "parent"):
+            runner.run(source, linked_parent / "run", "matrix-a")
+
+    def test_invalid_cell_is_retried_as_a_new_preserved_attempt(self):
+        marker = self.root / "dependency-ready"
+        command = f"if test -f {marker}; then exit 0; else touch {marker}; printf outage >&2; exit 8; fi"
+        source = make_plan(self.root / "plan.json", [
+            {"id": "retry", "command": ["sh", "-c", command]}
+        ])
+        run_dir = self.root / "run"
+        self.assertEqual(runner.run(source, run_dir, "matrix-a"), 2)
+        self.assertEqual(runner.run(None, run_dir, "matrix-a"), 0)
+        attempts = list(run_dir.glob("artifacts/retry/attempt-*/result.json"))
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(
+            {json.loads(attempt.read_text())["status"] for attempt in attempts},
+            {"valid", "infrastructure-invalid"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -69,3 +69,8 @@ prompt, judge, or retrieval budget. Reproduce the baseline in the same harness f
 
 Rebaseline only after an intentional contract, dependency, model, or hardware change. Preserve the
 old artifact, explain the delta, and make the acceptance decision reviewable.
+
+Code-intelligence matrix execution and resume semantics are documented in
+[`benchmarks/code-agent-effectiveness/README.md`](../benchmarks/code-agent-effectiveness/README.md).
+In particular, infrastructure failures are preserved but excluded from scoring, and
+named checkpoints are bound to one immutable run and plan to prevent result splicing.

--- a/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
+++ b/docs/proposals/pending/agent-facing-code-intelligence-effectiveness.md
@@ -768,6 +768,21 @@ residual proposal instead of declaring the intended effectiveness outcome comple
   retrieval-only/null-diagnostics regressions received no findings. Roundtable run:
   `oprun_g6a6b1ed93980fd5d_1785408651_7` (artifact
   `0f0e27dbb596f737174e815004baf9a71b904127185a7af05809c747bdceb8e0`).
+- **E5b deployment and runbook slice:** PR #2177 merged to `testing` as
+  `456444cad5a1f4b8e8595ae91e5c3923f4cef468` after all 23 CI checks passed. Liveness remains
+  restart-safe during recoverable outages; readiness now enforces the retrieval contract with
+  bounded dependency diagnostics and a safe recovery runbook.
+- **E5c resumable-experiment candidate:** a repository-owned runner binds one immutable plan,
+  run ID, and named checkpoint; writes every cell attempt before checkpoint advancement; preserves
+  stdout/stderr/timing/return code; marks failed infrastructure `score_eligible:false`; refuses
+  overwrite and cross-run checkpoint provenance; and resumes only unfinished cells. Its frozen
+  implementation diff receives a separate roundtable gate before PR.
+- **E5c final exact-diff review — 2026-07-30 — APPROVED and converged, 3/3 participants, not
+  degraded.** The final runner provides byte-lossless, digest-bound attempt evidence, durable
+  checkpoint ordering, strict plain-path/provenance/plan validation, infrastructure-invalid score
+  exclusion, and non-splicing named resume. Roundtable run:
+  `oprun_g6a6b1ed93980fd5d_1785414928_21` (artifact
+  `50dd19a6189e0cb0173910380ac9c054d4733da567603dd39db3277a18d1dfce`).
 - **E5a implementation round 1 — 2026-07-30 — changes requested, 3/3 participants, not
   degraded.** The implementation received no bounded-slice technical ruling because the review
   brief exposed the unfinished parent E5/E6 program. The next review explicitly binds the frozen

--- a/docs/validation/agent-facing-code-intelligence-e5c-resume.md
+++ b/docs/validation/agent-facing-code-intelligence-e5c-resume.md
@@ -1,0 +1,93 @@
+# E5c resumable experiment validation
+
+- **Date:** 2026-07-30 UTC
+- **Base:** `testing` at `456444cad5a1f4b8e8595ae91e5c3923f4cef468`
+- **Slice:** E5c benchmark/QA checkpoint and artifact integrity
+
+The runner creates an immutable manifest before execution and an exclusive artifact
+directory per attempt. A result is durably written before the named checkpoint advances.
+Command launch failures, timeouts, and nonzero exits are `infrastructure-invalid` and
+`score_eligible:false`; their raw output is retained. Resume requires the manifest,
+checkpoint name, run ID, and plan digest to agree and skips only cells already completed
+within that exact run.
+
+```text
+python3 -m unittest benchmarks/tests/test_code_intelligence_checkpoint_runner.py
+python3 benchmarks/code-agent-effectiveness/validate_fixtures.py --verify-sources
+git diff --check
+```
+
+The regressions cover infrastructure-invalid preservation, idempotent named resume,
+cross-run checkpoint-splice rejection, and refusal to overwrite an existing run.
+
+## Frozen-diff review
+
+- Run `oprun_g6a6b1ed93980fd5d_1785409585_8` converged with all three participants
+  and requested changes. It found timeout output loss, unchecked checkpoint path
+  names, and completed cells that were not cryptographically/provenance-bound back
+  to their preserved result artifacts; it also suggested eager command validation
+  and removal of a redundant resume load. All five findings are incorporated with
+  regressions before reconvening.
+- Run `oprun_g6a6b1ed93980fd5d_1785410134_9` converged with all three participants
+  and found two incomplete closures: skipped results were field-bound but not bound
+  to immutable result/stdout/stderr digests, and new runs still reloaded their just-
+  written state through the resume path. Checkpoint entries now hash all three
+  artifacts and resume verifies each byte stream; new runs directly retain the
+  state returned by exclusive creation.
+- Run `oprun_g6a6b1ed93980fd5d_1785410424_10` converged with all three
+  participants and found that raw output bytes were digest-bound but lacked their
+  own cell provenance, allowing a checkpoint edit to substitute another cell's
+  output and matching digest. Stdout and stderr envelopes now carry and verify the
+  same run/plan/checkpoint/cell tuple as the result; a cross-cell splice regression
+  proves rejection.
+- Run `oprun_g6a6b1ed93980fd5d_1785411063_11` converged with all three
+  participants and found that invalid attempts lacked a digest ledger entry, text
+  mode was not byte-lossless, and the embedded plan was not re-hashed on resume.
+  Every attempt is now digest-bound in the checkpoint while only valid attempts
+  enter `completed`; output envelopes are base64 over captured bytes; and resume
+  verifies the canonical plan digest before reading evidence or executing work.
+- Run `oprun_g6a6b1ed93980fd5d_1785411393_12` converged with all three
+  participants and found that timeout diagnostics were appended to captured stderr,
+  violating byte-lossless preservation. Captured stderr is now stored unchanged;
+  the runner-authored timeout message lives separately in the result envelope's
+  `infrastructure_error` field.
+- Run `oprun_g6a6b1ed93980fd5d_1785411634_13` converged with all three
+  participants and required exact-byte timeout assertions plus explicit rejection
+  of evidence for cell IDs absent from the immutable plan. The regression now
+  compares complete stdout/stderr byte strings and verifies diagnostic separation;
+  resume derives the allowed cell-ID set from the digest-verified plan.
+- Run `oprun_g6a6b1ed93980fd5d_1785411892_14` converged with all three
+  participants and required a direct regression for the already implemented
+  absent-from-plan rejection. The test injects a foreign checkpoint attempt ID
+  and proves resume rejects it before work executes.
+- Run `oprun_g6a6b1ed93980fd5d_1785412321_15` converged with two of three
+  participants and found that exclusive manifest creation did not reserve the run
+  directory itself, allowing a pre-existing symlinked artifact tree. New runs now
+  exclusively create the entire run directory and artifact root, and every attempt
+  resolves beneath that root before evidence writes. A symlink-tree regression
+  proves no outside path is created.
+- Run `oprun_g6a6b1ed93980fd5d_1785412589_16` converged with all three
+  participants and found that attempt containment was checked after directory
+  creation and that file fsync did not durably order directory entries before
+  checkpoint replacement. Artifact/cell parents are now validated before mutation;
+  directories and new evidence entries are fsynced; checkpoint temp contents are
+  fsynced before atomic replace; and the checkpoint directory is fsynced afterward.
+- Run `oprun_g6a6b1ed93980fd5d_1785412931_17` reviewed that closure artifact but
+  failed at the panel's 630-second infrastructure deadline without a verdict. It is
+  retained as failed-run evidence and replaced by an identical-diff closure run.
+- Replacement run `oprun_g6a6b1ed93980fd5d_1785413622_18` also failed from
+  provider deadlines before aggregation. Run `oprun_g6a6b1ed93980fd5d_1785414237_19`
+  completed and found unchecked checkpoint temporaries, completed-resume artifact
+  root replacement, and unchecked/undurable auto-created run parents. Checkpoint
+  temporaries are now unpredictable and exclusively created in a verified directory;
+  resume validates the complete plain artifact tree; and new runs require an existing,
+  fully resolved non-symlink parent, so no ancestor creation is hidden from fsync.
+- Run `oprun_g6a6b1ed93980fd5d_1785414625_20` converged with all three
+  participants and found that top-level validation still allowed in-tree symlinked
+  cell/attempt/evidence components. Resume now walks every lexical evidence path
+  with `lstat`, requiring plain intermediate directories and a regular final file
+  before resolving, loading, or hashing it. An in-tree evidence-symlink regression
+  proves rejection.
+- Run `oprun_g6a6b1ed93980fd5d_1785414928_21` approved and converged with all
+  three participants, no degradation, and no findings. Frozen artifact SHA-256:
+  `50dd19a6189e0cb0173910380ac9c054d4733da567603dd39db3277a18d1dfce`.


### PR DESCRIPTION
## Summary
- add a durable, resumable experiment checkpoint runner
- bind plans, attempts, streams, and results with verified provenance
- document the E5c runbook, validation trail, and approved closure review

## Validation
- `python3 -m unittest benchmarks/tests/test_code_intelligence_checkpoint_runner.py` (16 passed)
- `python3 benchmarks/code-agent-effectiveness/validate_fixtures.py` (passed)
- closure roundtable run 21: approved 3/3, no findings
- `make -C src bench-check` exercised the full matrix; unrelated local timing gate reported `pre_tool_check` at 3.01 ms vs 1.65 ms baseline