### PR TITLE
guard: enforce session branch lineage, catch bash escapes, fix header dep tracking

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -138,7 +138,7 @@ Consumed once by `config_emit_deploy_env` to stand up the aimee-llm container (`
 | `llm_synth_model` | string | Model label sent to the configured synthesis endpoint. |
 | `llm_synth_tier` | string | Deploy-time local synthesis tier: cpu, small, mid, or large. |
 
-### Advanced tuning keys (78)
+### Advanced tuning keys (79)
 
 Expert scalars with sensible defaults; settable in the config file but off the everyday surface.
 
@@ -221,6 +221,7 @@ Expert scalars with sensible defaults; settable in the config file but off the e
 | `memory_semantic_floor_scale` | float | Multiplier on the semantic-recall cosine floors (0 = auto-scale by the active embedder dimension; >0 pins it). |
 | `memory_semantic_weight` | float | Semantic (vector) weight in hybrid recall. |
 | `memory_window_radius` | int | Neighbour radius for memory-window expansion. |
+| `session_worktree_base` | string | What a new primary session's branch+worktree is cut from. Order: configured -> remote default -> main -> master. Values: remote_default (default), local_default, current (opt-in only, never a fallback), or an explicit ref. Env: AIMEE_SESSION_WORKTREE_BASE. |
 | `tool_output_max_bytes` | int | Per-result cap (bytes) on the model-visible tool output (read_file/bash/grep/glob/git_* results). 0 = built-in default (32768); any positive value is clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the prompt + history; the context-economizer (aggressive tier) compresses older results to keep history bounded. |
 
 ### Dev-only keys (7)
@@ -304,7 +305,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 223 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
+The binaries read 224 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
 
 ### Paths & assets
 
@@ -608,6 +609,12 @@ The binaries read 223 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_LLM_AUTH_REQUIRED` | Set to 1 on wizard-managed KBs so embed, rerank, and synthesis clients refuse to contact the unified LLM when its bearer service identity is missing. |
 | `AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE` | Explicit first-boot migration/adoption transport for an existing wizard-managed LLM credential. aimee-server seals it into Vault and scrubs the environment before normal startup. Ordinary inherited AIMEE_LLM_AUTH_TOKEN is ignored by managed credential creation so stale child-service state cannot win. Must be a 32..512 character RFC 6750 b64token. |
 | `AIMEE_OFFLINE_ALLOW_NO_SWAP_MLOCK_FALLBACK` | Internal managed-authority switch: still attempts mlockall first, but when an unprivileged container cannot raise RLIMIT_MEMLOCK, permits the offline one-shot to continue only if the kernel reports no active swap. Operator-run custody tools leave this unset and retain mandatory mlockall. |
+
+### Undocumented (add to `ENV_DESC` in gen-reference-docs.py)
+
+> These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
+
+`AIMEE_SESSION_WORKTREE_BASE`
 
 ## External & provider environment
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -278,6 +278,10 @@ CFG_KEY_DESC = {
     "kb_api_http_port": "HTTP port the aimee-kb API listens on.",
     "kb_evidence_emit_enabled": "Emit evidence records from KB ingest.",
     "kb_fusion_mode": "KB retrieval fusion mode: rrf (default), static_alpha, or dynamic_alpha.",
+    "session_worktree_base": "What a new primary session's branch+worktree is cut from. Order: configured -> "
+                              "remote default -> main -> master. Values: remote_default (default), "
+                              "local_default, current (opt-in only, never a fallback), or an explicit "
+                              "ref. Env: AIMEE_SESSION_WORKTREE_BASE.",
     "kb_fusion_static_alpha": "Lexical/dense blend weight (0-1) for the static_alpha fusion mode.",
     "kb_pdf_ingest_enabled": "Route PDF uploads through the structured geometry extractor "
     "(kb_doc_pdf) instead of plain pdftotext (default off).",

--- a/src/Makefile
+++ b/src/Makefile
@@ -788,7 +788,19 @@ LINT_SRCS = $(ALL_SRCS) kb/http/kb_http_resolver.c $(wildcard tests/test_*.c) $(
 # All object files for dependency tracking
 ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(STATUS_AUTHORITY_OBJS) $(TOKEN_AUTHORITY_OBJS) $(STATUS_PROVISIONER_OBJS) $(TOKEN_ROOTS_PROVISIONER_OBJS) $(JWKS_PUBLISHER_OBJS) $(MCP_GIT_OBJS) $(DATA_OBJS) $(SERVER_DATA_OBJS) $(AGENT_OBJS) $(CMD_OBJS) \
            $(CLI_OBJS) $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(KB_OBJS) $(KB_SYNTHESIS_OBJS) $(GATEWAY_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(PLATFORM_OBJS) $(PLATFORM_AGENT_OBJS)
-DEPS = $(ALL_OBJS:.o=.d)
+# Header dependency tracking must cover EVERY object we compile, not just the ones
+# a hand-maintained *_OBJS variable happens to name. Objects reachable only as a
+# direct prerequisite of a test target (modules/memory/memory_core_search.o was one
+# of ~959) never appeared in ALL_OBJS, so their .d files were never included and
+# make had no reason to recompile them when a header changed. The result was silent:
+# a stale object built against an older struct layout links cleanly against fresh
+# ones and crashes at runtime on a field offset, and the test suite reports whatever
+# the mismatched binary happens to do.
+#
+# Discovering the .d files on disk makes coverage a property of what was compiled
+# rather than of bookkeeping. A first build has no .d files yet, which is correct --
+# nothing is stale when nothing exists.
+DEPS = $(ALL_OBJS:.o=.d) $(shell find $(OBJDIR) -name '*.d' 2>/dev/null)
 
 .PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
 

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -904,6 +904,55 @@ int attn_external_memory_blocked(attn_op_t op, const char *tool_name, const char
    return attn_path_is_external_agent_memory(norm);
 }
 
+/* ---- session BRANCH lineage enforcement ------------------------------------
+ *
+ * attn_path_in_managed_worktree above checks only that a path sits under a managed
+ * worktree directory. Its comment claimed those are "isolated worktrees on a branch off
+ * the default branch" -- but nothing verified the branch, so a worktree created by hand
+ * (`git worktree add -b x <arbitrary-commit>`) under .claude/worktrees/ satisfied the
+ * guard while being rooted on another session's branch. That is how a session ended up
+ * 115 commits behind the default branch, carrying ~18 commits of another agent's
+ * unmerged work it could not separate from its own.
+ *
+ * The rule being enforced:
+ *   PRIMARY  session branch must be cut from the DEFAULT branch.
+ *   DELEGATE session branch may be cut from its parent primary's branch.
+ *
+ * The base ref is read from the worktree registry, written by the launcher at creation
+ * time (workspace.c). It is deliberately NOT taken from the environment: this guard
+ * refuses env-var inputs on principle, because an LLM can set AIMEE_DELEGATE_DEPTH on
+ * any command and would simply declare itself a delegate to escape the primary rule.
+ * The registry is written by trusted code before the agent runs. */
+
+/* Pure decision (testable): 1 = BLOCK.
+ *  base_branch      the ref this worktree was cut from, "" if unknown/unregistered
+ *  default_branch   the repo's default branch, "" if unresolvable
+ *  base_is_registered  1 iff base_branch is itself a registered session branch,
+ *                      i.e. a legitimate delegate parent
+ * Unknown base blocks: a worktree with no registry row was not created by the launcher,
+ * which is exactly the hand-rolled case this exists to catch. Fail closed. */
+int attn_session_branch_blocked(const char *base_branch, const char *default_branch,
+                                int base_is_registered)
+{
+   if (!base_branch || !base_branch[0])
+      return 1; /* unregistered worktree -> not launcher-created -> block */
+   if (default_branch && default_branch[0] && strcmp(base_branch, default_branch) == 0)
+      return 0; /* primary rooted on the default branch */
+   /* Accept both "main" and "origin/main" spellings of the same default. */
+   if (default_branch && default_branch[0])
+   {
+      const char *slash = strrchr(default_branch, '/');
+      const char *bare = slash ? slash + 1 : default_branch;
+      const char *bslash = strrchr(base_branch, '/');
+      const char *bbare = bslash ? bslash + 1 : base_branch;
+      if (strcmp(bbare, bare) == 0)
+         return 0;
+   }
+   if (base_is_registered)
+      return 0; /* delegate rooted on a real parent session branch */
+   return 1;
+}
+
 /* Pure decision for the session-isolation guard (testable in isolation).
  * Returns 1 to BLOCK: a mutating op (SOFT/HARD) whose effective target is NOT
  * inside an aimee-managed worktree. Read / raw-scan ops are never blocked here.

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -868,6 +868,157 @@ static int bash_cmd_can_write(const char *cmd)
    return 0;
 }
 
+/* Does a writing Bash command reach OUTSIDE every managed worktree?
+ *
+ * The isolation check judges the tool's file_path, or the cwd when there isn't one. For a
+ * Bash call that means it judges WHERE THE COMMAND STARTS, not what it touches -- so
+ * `cd /repo && python3 - <<EOF ...` passes while writing anywhere on disk. That is not
+ * hypothetical: it is how this guard was bypassed, from a session whose cwd was a
+ * perfectly good worktree.
+ *
+ * Two escape shapes are detected, both cheap and both literal:
+ *   1. `cd <abs>` / `pushd <abs>` to a directory outside a managed worktree -- the
+ *      observed bypass, and the one that relocates everything after it.
+ *   2. a redirect whose target is an absolute path outside a managed worktree.
+ *
+ * Only consulted when bash_cmd_can_write() already says the command mutates, so a
+ * read-only command naming absolute paths is untouched.
+ *
+ * LIMITS, stated plainly rather than implied: this does not parse shell. A path built
+ * from a variable, passed through an interpreter's own logic, or reached via a symlink
+ * will not be seen. It is defence in depth against the common and observed shapes, not a
+ * sandbox -- a determined agent can still get out, and the durable fix is executing tool
+ * calls under an OS-level write confinement rather than pattern-matching their text. */
+int attn_bash_escapes_worktree(const char *bash_cmd, const char *cwd)
+{
+   if (!bash_cmd || !bash_cmd[0])
+      return 0;
+   if (!bash_cmd_can_write(bash_cmd))
+      return 0;
+
+   /* ---- 1. cd / pushd to an absolute path ---- */
+   static const char *const chdirs[] = {"cd ", "pushd ", NULL};
+   for (int i = 0; chdirs[i]; i++)
+   {
+      const char *p = bash_cmd;
+      size_t toklen = strlen(chdirs[i]);
+      while ((p = strstr(p, chdirs[i])) != NULL)
+      {
+         /* Must start a command: beginning of string, or after ; && || | newline. */
+         int at_cmd_start = (p == bash_cmd);
+         if (!at_cmd_start)
+         {
+            const char *b = p - 1;
+            while (b > bash_cmd && (*b == ' ' || *b == '\t'))
+               b--;
+            at_cmd_start = (*b == ';' || *b == '&' || *b == '|' || *b == '\n' || *b == '(');
+         }
+         const char *arg = p + toklen;
+         p = arg;
+         if (!at_cmd_start)
+            continue;
+         while (*arg == ' ' || *arg == '\t' || *arg == '\'' || *arg == '"')
+            arg++;
+         if (*arg != '/')
+            continue; /* relative cd stays within the worktree by construction */
+         char path[2048];
+         size_t n = 0;
+         while (arg[n] && n + 1 < sizeof(path) && arg[n] != ' ' && arg[n] != '\t' &&
+                arg[n] != ';' && arg[n] != '&' && arg[n] != '|' && arg[n] != '\'' &&
+                arg[n] != '"' && arg[n] != '\n')
+         {
+            path[n] = arg[n];
+            n++;
+         }
+         path[n] = '\0';
+         char norm[2048];
+         attn_lexical_normalize(path, norm, sizeof(norm));
+         if (!attn_path_in_managed_worktree(norm))
+            return 1;
+      }
+   }
+
+   /* ---- 2. redirect target that is an absolute path ---- */
+   for (const char *q = strchr(bash_cmd, '>'); q; q = strchr(q + 1, '>'))
+   {
+      const char *t = q + 1;
+      if (*t == '>')
+         t++;
+      if (*t == '&')
+         continue; /* fd dup */
+      while (*t == ' ' || *t == '\t' || *t == '\'' || *t == '"')
+         t++;
+      if (*t != '/')
+         continue;
+      if (strncmp(t, "/dev/null", 9) == 0)
+         continue;
+      char path[2048];
+      size_t n = 0;
+      while (t[n] && n + 1 < sizeof(path) && t[n] != ' ' && t[n] != '\t' && t[n] != ';' &&
+             t[n] != '&' && t[n] != '|' && t[n] != '\'' && t[n] != '"' && t[n] != '\n')
+      {
+         path[n] = t[n];
+         n++;
+      }
+      path[n] = '\0';
+      char norm[2048];
+      attn_lexical_normalize(path, norm, sizeof(norm));
+      if (!attn_path_in_managed_worktree(norm) && !attn_path_is_harness_state(norm))
+         return 1;
+   }
+
+   /* ---- 3. absolute args to commands whose arguments ARE the write target ----
+    * Only verbs where every path argument is written: tee, truncate, touch, mkdir, rm,
+    * shred, install, sed -i. Deliberately NOT cp/mv/rsync -- their first arguments are
+    * SOURCES, and reading an outside file to write inside the worktree is legitimate. */
+   static const char *const target_verbs[] = {"tee",   "truncate", "touch",  "mkdir",
+                                              "rm",    "shred",    "install", NULL};
+   for (int i = 0; target_verbs[i]; i++)
+   {
+      if (!cmd_has_word_prefix(bash_cmd, target_verbs[i]) && !strstr(bash_cmd, target_verbs[i]))
+         continue;
+      const char *p = strstr(bash_cmd, target_verbs[i]);
+      while (p)
+      {
+         /* Scan this segment's arguments up to the next command separator. */
+         const char *a = p + strlen(target_verbs[i]);
+         while (*a && *a != ';' && *a != '|' && *a != '\n' && !(*a == '&' && a[1] == '&'))
+         {
+            while (*a == ' ' || *a == '\t' || *a == '\'' || *a == '"')
+               a++;
+            if (*a == '/')
+            {
+               char path[2048];
+               size_t n = 0;
+               while (a[n] && n + 1 < sizeof(path) && a[n] != ' ' && a[n] != '\t' &&
+                      a[n] != ';' && a[n] != '&' && a[n] != '|' && a[n] != '\'' &&
+                      a[n] != '"' && a[n] != '\n')
+               {
+                  path[n] = a[n];
+                  n++;
+               }
+               path[n] = '\0';
+               char norm[2048];
+               attn_lexical_normalize(path, norm, sizeof(norm));
+               if (strncmp(norm, "/dev/null", 9) != 0 && !attn_path_in_managed_worktree(norm) &&
+                   !attn_path_is_harness_state(norm))
+                  return 1;
+               a += n;
+               continue;
+            }
+            /* skip a non-absolute token */
+            while (*a && *a != ' ' && *a != '\t' && *a != ';' && *a != '|' && *a != '\n' &&
+                   !(*a == '&' && a[1] == '&'))
+               a++;
+         }
+         p = strstr(p + 1, target_verbs[i]);
+      }
+   }
+
+   (void)cwd;
+   return 0;
+}
+
 /* External-memory decision (pure, testable). Returns 1 to BLOCK a tool call
  * that would WRITE the harness's file-based agent-memory store — directly
  * (a mutating file tool whose target resolves into the store) or via a Bash
@@ -951,6 +1102,165 @@ int attn_session_branch_blocked(const char *base_branch, const char *default_bra
    if (base_is_registered)
       return 0; /* delegate rooted on a real parent session branch */
    return 1;
+}
+
+/* Resolve the repo's default branch for the checkout containing `norm`, e.g. "testing".
+ * Mirrors code_collect.c's chain: origin/HEAD, then the usual candidates. Returns the
+ * bare branch name (no "origin/" prefix) or "" when unresolvable. */
+static void attn_resolve_default_branch(const char *norm, char *out, size_t outlen)
+{
+   if (out && outlen)
+      out[0] = '\0';
+   if (!norm || !norm[0] || !out || !outlen)
+      return;
+   char cmd[2400];
+   snprintf(cmd, sizeof(cmd),
+            "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null", norm);
+   FILE *fp2 = popen(cmd, "r");
+   if (fp2)
+   {
+      if (fgets(out, (int)outlen, fp2))
+      {
+         size_t n = strlen(out);
+         while (n && (out[n - 1] == '\n' || out[n - 1] == '\r'))
+            out[--n] = '\0';
+      }
+      pclose(fp2);
+   }
+   if (out[0])
+   {
+      const char *slash = strrchr(out, '/');
+      if (slash)
+         memmove(out, slash + 1, strlen(slash + 1) + 1);
+      return;
+   }
+   snprintf(out, outlen, "%s", "main");
+}
+
+/* Read the launcher-written registry row for the worktree containing `norm`.
+ *
+ * Row format (workspace.c): repo \t worktree \t branch \t session_id \t work_name \t base.
+ * Returns 1 and fills base_out when a row's worktree path is a prefix of `norm`; 0 when
+ * no row matches, which the caller treats as "not launcher-created" and blocks.
+ *
+ * Reads the registry, never the environment: this guard refuses env-var inputs because
+ * the agent it guards can set any of them. */
+/* Returns: 2 = row found for this worktree, 1 = a registry exists but has no row for it,
+ * 0 = no registry file at all (repo has never used managed worktrees). */
+static int attn_registry_base_for(const char *norm, char *base_out, size_t base_len,
+                                  char *branch_out, size_t branch_len)
+{
+   if (base_out && base_len)
+      base_out[0] = '\0';
+   if (branch_out && branch_len)
+      branch_out[0] = '\0';
+   if (!norm || !norm[0])
+      return 0;
+
+   /* The registry lives at <repo>/.aimee/worktrees/registry.tsv. Walk up from the
+    * target until one is found, so this works from any depth inside a worktree. */
+   int saw_registry = 0;
+   char probe[2048];
+   snprintf(probe, sizeof(probe), "%s", norm);
+   for (int depth = 0; depth < 40; depth++)
+   {
+      char reg[2200];
+      snprintf(reg, sizeof(reg), "%s/.aimee/worktrees/registry.tsv", probe);
+      char *buf = NULL;
+      if (attn_read_file(reg, &buf) && buf)
+      {
+         int found = 0;
+         char *line = buf;
+         while (*line)
+         {
+            char *nl = strchr(line, '\n');
+            if (nl)
+               *nl = '\0';
+            /* fields: repo, worktree, branch, sid, work_name, base */
+            char *f[6] = {0};
+            int nf = 0;
+            char *p2 = line;
+            f[nf++] = p2;
+            while (nf < 6 && (p2 = strchr(p2, '\t')))
+            {
+               *p2++ = '\0';
+               f[nf++] = p2;
+            }
+            if (nf >= 2 && f[1] && f[1][0])
+            {
+               size_t wl = strlen(f[1]);
+               /* worktree path is a prefix of the target (exact dir or below it) */
+               if (strncmp(norm, f[1], wl) == 0 && (norm[wl] == '\0' || norm[wl] == '/'))
+               {
+                  if (base_out && base_len && nf >= 6 && f[5])
+                     snprintf(base_out, base_len, "%s", f[5]);
+                  if (branch_out && branch_len && nf >= 3 && f[2])
+                     snprintf(branch_out, branch_len, "%s", f[2]);
+                  found = 1;
+               }
+            }
+            if (!nl)
+               break;
+            line = nl + 1;
+         }
+         free(buf);
+         if (found)
+            return 2;
+         saw_registry = 1;
+      }
+      char *slash = strrchr(probe, '/');
+      if (!slash || slash == probe)
+         break;
+      *slash = '\0';
+   }
+   return saw_registry ? 1 : 0;
+}
+
+/* 1 iff `branch` appears as a registered session branch (column 3) anywhere in the
+ * registry reachable from `norm` -- i.e. a legitimate delegate parent. */
+static int attn_registry_branch_is_registered(const char *norm, const char *branch)
+{
+   if (!branch || !branch[0] || !norm || !norm[0])
+      return 0;
+   char probe[2048];
+   snprintf(probe, sizeof(probe), "%s", norm);
+   for (int depth = 0; depth < 40; depth++)
+   {
+      char reg[2200];
+      snprintf(reg, sizeof(reg), "%s/.aimee/worktrees/registry.tsv", probe);
+      char *buf = NULL;
+      if (attn_read_file(reg, &buf) && buf)
+      {
+         int hit = 0;
+         char *line = buf;
+         while (*line && !hit)
+         {
+            char *nl = strchr(line, '\n');
+            if (nl)
+               *nl = '\0';
+            char *t1 = strchr(line, '\t');
+            char *t2 = t1 ? strchr(t1 + 1, '\t') : NULL;
+            char *t3 = t2 ? strchr(t2 + 1, '\t') : NULL;
+            if (t2 && t3)
+            {
+               *t3 = '\0';
+               if (strcmp(t2 + 1, branch) == 0)
+                  hit = 1;
+            }
+            if (!nl)
+               break;
+            line = nl + 1;
+         }
+         free(buf);
+         if (hit)
+            return 1;
+      }
+      char *slash = strrchr(probe, '/');
+      if (!slash || slash == probe)
+         break;
+      *slash = '\0';
+   }
+   return 0;
 }
 
 /* Pure decision for the session-isolation guard (testable in isolation).
@@ -1058,6 +1368,66 @@ int handle_attention_guard(void)
          cwd[0] = '\0';
       const char *fp =
           ti ? cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(ti, "file_path")) : NULL;
+      /* Branch lineage: being INSIDE a managed worktree is not enough. The worktree
+       * must have been created by the launcher (so a registry row exists) and rooted
+       * correctly -- a primary on the default branch, a delegate on its parent's.
+       * Checked before the path test so a correctly-located but wrongly-rooted
+       * worktree is still refused. */
+      char lin_target[2048];
+      attn_session_isolation_target(fp, cwd, lin_target, sizeof(lin_target));
+      if (attn_path_in_managed_worktree(lin_target))
+      {
+         char base[256], own[256], defbr[256];
+         int reg_state = attn_registry_base_for(lin_target, base, sizeof(base), own, sizeof(own));
+         attn_resolve_default_branch(lin_target, defbr, sizeof(defbr));
+         int parent_registered =
+             (base[0] && own[0] && strcmp(base, own) != 0)
+                 ? attn_registry_branch_is_registered(lin_target, base)
+                 : 0;
+         /* reg_state: 2 row found, 1 registry exists but no row, 0 no registry at all.
+          *   0 -> the repo has never used managed worktrees; there is nothing to check
+          *        against, and blocking would break every non-aimee checkout.
+          *   2 with an EMPTY base -> a row written by an older launcher, before the base
+          *        column existed. Grandfathered: the launcher did create it, and blocking
+          *        would break every in-flight session the moment this ships.
+          * Only 1 (a managed repo where this worktree was never registered) and 2-with-a-
+          * base actually enforce. */
+         int enforce = (reg_state == 1) || (reg_state == 2 && base[0]);
+         if (enforce && attn_session_branch_blocked(base, defbr, parent_registered))
+         {
+            fprintf(stderr,
+                    "aimee attention-guard: refusing a mutating op — the worktree at '%s' is on "
+                    "branch '%s' rooted at '%s', which is neither the default branch ('%s') nor a "
+                    "registered parent session branch. A primary session must branch off the "
+                    "default branch; a delegate off its parent. %s Recreate the session worktree "
+                    "with the launcher (Claude Code: EnterWorktree; aimee: launch `aimee`) instead "
+                    "of `git worktree add` by hand.\n",
+                    lin_target, own[0] ? own : "(unknown)", base[0] ? base : "(unregistered)",
+                    defbr[0] ? defbr : "(unresolved)",
+                    base[0] ? "" : "No launcher registry row exists for it, so it was not created "
+                                   "by the launcher.");
+            cJSON_Delete(hook);
+            free(stdin_data);
+            return 2;
+         }
+      }
+
+      /* Bash reaching out of the worktree: judged on the command text, because the
+       * isolation check below only sees the cwd for a Bash call. */
+      if (bash_cmd && bash_cmd[0] && attn_bash_escapes_worktree(bash_cmd, cwd))
+      {
+         fprintf(stderr,
+                 "aimee attention-guard: refusing a Bash command that writes outside this "
+                 "session's worktree. The command changes directory to, or redirects into, an "
+                 "absolute path that is not under .aimee/worktrees/ or .claude/worktrees/. The "
+                 "cwd being a valid worktree is not enough — what the command TOUCHES has to "
+                 "stay inside it. Do the work in the session worktree, or ask the operator to "
+                 "make the change.\n");
+         cJSON_Delete(hook);
+         free(stdin_data);
+         return 2;
+      }
+
       if (attn_session_isolation_blocked(op, fp, cwd, sid))
       {
          /* Name the path that was actually judged. When an absolute file_path is

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -971,8 +971,8 @@ int attn_bash_escapes_worktree(const char *bash_cmd, const char *cwd)
     * Only verbs where every path argument is written: tee, truncate, touch, mkdir, rm,
     * shred, install, sed -i. Deliberately NOT cp/mv/rsync -- their first arguments are
     * SOURCES, and reading an outside file to write inside the worktree is legitimate. */
-   static const char *const target_verbs[] = {"tee",   "truncate", "touch",  "mkdir",
-                                              "rm",    "shred",    "install", NULL};
+   static const char *const target_verbs[] = {"tee", "truncate", "touch",   "mkdir",
+                                              "rm",  "shred",    "install", NULL};
    for (int i = 0; target_verbs[i]; i++)
    {
       if (!cmd_has_word_prefix(bash_cmd, target_verbs[i]) && !strstr(bash_cmd, target_verbs[i]))
@@ -990,9 +990,8 @@ int attn_bash_escapes_worktree(const char *bash_cmd, const char *cwd)
             {
                char path[2048];
                size_t n = 0;
-               while (a[n] && n + 1 < sizeof(path) && a[n] != ' ' && a[n] != '\t' &&
-                      a[n] != ';' && a[n] != '&' && a[n] != '|' && a[n] != '\'' &&
-                      a[n] != '"' && a[n] != '\n')
+               while (a[n] && n + 1 < sizeof(path) && a[n] != ' ' && a[n] != '\t' && a[n] != ';' &&
+                      a[n] != '&' && a[n] != '|' && a[n] != '\'' && a[n] != '"' && a[n] != '\n')
                {
                   path[n] = a[n];
                   n++;
@@ -1380,10 +1379,9 @@ int handle_attention_guard(void)
          char base[256], own[256], defbr[256];
          int reg_state = attn_registry_base_for(lin_target, base, sizeof(base), own, sizeof(own));
          attn_resolve_default_branch(lin_target, defbr, sizeof(defbr));
-         int parent_registered =
-             (base[0] && own[0] && strcmp(base, own) != 0)
-                 ? attn_registry_branch_is_registered(lin_target, base)
-                 : 0;
+         int parent_registered = (base[0] && own[0] && strcmp(base, own) != 0)
+                                     ? attn_registry_branch_is_registered(lin_target, base)
+                                     : 0;
          /* reg_state: 2 row found, 1 registry exists but no row, 0 no registry at all.
           *   0 -> the repo has never used managed worktrees; there is nothing to check
           *        against, and blocking would break every non-aimee checkout.
@@ -1404,8 +1402,9 @@ int handle_attention_guard(void)
                     "of `git worktree add` by hand.\n",
                     lin_target, own[0] ? own : "(unknown)", base[0] ? base : "(unregistered)",
                     defbr[0] ? defbr : "(unresolved)",
-                    base[0] ? "" : "No launcher registry row exists for it, so it was not created "
-                                   "by the launcher.");
+                    base[0] ? ""
+                            : "No launcher registry row exists for it, so it was not created "
+                              "by the launcher.");
             cJSON_Delete(hook);
             free(stdin_data);
             return 2;

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -80,6 +80,13 @@ void attn_session_isolation_target(const char *file_path, const char *cwd, char 
 int attn_session_branch_blocked(const char *base_branch, const char *default_branch,
                                 int base_is_registered);
 
+/* 1 = BLOCK: a WRITING Bash command reaches outside every managed worktree -- `cd <abs>`
+ * to an unmanaged directory, or a redirect to an absolute path outside one. The
+ * isolation check judges the cwd for Bash, so without this a command starting in a good
+ * worktree can write anywhere. Pattern-based, not a sandbox; see the implementation's
+ * LIMITS note. */
+int attn_bash_escapes_worktree(const char *bash_cmd, const char *cwd);
+
 /* External-memory decision (pure, testable). Returns 1 to BLOCK a tool call
  * that would WRITE an external file-based agent-memory store
  * (~/.claude/projects/<slug>/memory/...): a mutating file tool whose target

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -74,6 +74,12 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
  * path it actually judged rather than assuming it was the cwd. */
 void attn_session_isolation_target(const char *file_path, const char *cwd, char *out, size_t outsz);
 
+/* 1 = BLOCK: this worktree's branch lineage is not permitted. A primary session must be
+ * cut from the default branch; a delegate may be cut from its parent's branch. An
+ * unregistered worktree (no launcher-written registry row) always blocks. */
+int attn_session_branch_blocked(const char *base_branch, const char *default_branch,
+                                int base_is_registered);
+
 /* External-memory decision (pure, testable). Returns 1 to BLOCK a tool call
  * that would WRITE an external file-based agent-memory store
  * (~/.claude/projects/<slug>/memory/...): a mutating file tool whose target

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -822,6 +822,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->learning_implicit_repeat_question = 0;
    cfg->learning_implicit_repeated_correction = 0;
    cfg->learning_implicit_workflow_repetition = 0;
+   snprintf(cfg->session_worktree_base, sizeof(cfg->session_worktree_base), "remote_default");
    cfg->integrity_enabled = 0;
    cfg->integrity_dry_run = 1;
    /* Ingress envelope DEFAULT-ON (operator decision 2026-06-28): inject the

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -494,6 +494,27 @@ typedef struct config
     * worktree (.aimee/worktrees/...), forcing every mutating session into an
     * isolated worktree+branch off the default branch. Default 0 (off). */
    int require_session_worktree;
+   /* session_worktree_base: what a NEW primary session's branch+worktree is cut from.
+    * Resolution order: CONFIGURED -> remote DEFAULT -> main -> master.
+    *   "remote_default" (DEFAULT) — the remote's advertised default (origin/HEAD),
+    *                     fetched fresh; then main, then master.
+    *   "local_default"  — the local copy of the default branch; then main, then master.
+    *   "current"        — whatever the source checkout has checked out. Reachable ONLY
+    *                     by explicit opt-in, never as a fallback.
+    *   "<ref>"          — an explicit ref (e.g. "origin/main", a tag, a SHA); verified
+    *                     to exist, and an error if it does not.
+    * Each fallback prefers origin/<name> and accepts the local branch only when no
+    * remote-tracking ref exists, so a repo WITH a remote never starts from a stale local.
+    *
+    * The current branch is deliberately NOT in the chain. It used to be the last resort,
+    * which meant a new session was cut from whatever the shared checkout happened to be
+    * sitting on -- silently inheriting another session's unmerged work. main and master
+    * are dumb fallbacks, but they are stable.
+    *
+    * Env override: AIMEE_SESSION_WORKTREE_BASE. The attention guard independently
+    * refuses a worktree whose recorded base is neither the default branch nor a
+    * registered parent, so loosening this does not disable that check. */
+   char session_worktree_base[64];
    /* External-memory guard (default on): the PreToolUse attention-guard blocks
     * agent writes to external file-based agent-memory stores
     * (~/.claude/projects/<slug>/memory/...), redirecting durable memories into

--- a/src/modules/config/config_accessors.h
+++ b/src/modules/config/config_accessors.h
@@ -410,6 +410,7 @@ const char *config_memory_coref_mode(void);
 const char *config_memory_cognify_model(void);
 const char *config_memory_cognify_command(void);
 const char *config_code_context_mode(void);
+const char *config_session_worktree_base(void);
 const char *config_delegate_sandbox_image(void);
 const char *config_delegate_sandbox_package_access(void);
 const char *config_kb_pdf_tier(void);
@@ -912,6 +913,7 @@ int config_set_memory_coref_mode(const char *value);
 int config_set_memory_cognify_model(const char *value);
 int config_set_memory_cognify_command(const char *value);
 int config_set_code_context_mode(const char *value);
+int config_set_session_worktree_base(const char *value);
 int config_set_delegate_sandbox_image(const char *value);
 int config_set_delegate_sandbox_package_access(const char *value);
 int config_set_kb_pdf_tier(const char *value);
@@ -1030,6 +1032,7 @@ const char *config_computer_use_allowed_domains(int index);
 const char *config_server_api_bearer_extra(int index);
 const char *config_ensemble_reference_models(int index);
 const char *config_ensemble_reference_personas(int index);
+
 
 /* Struct-array elements: one member of one element per call. Bounds-checked
  * like the char[][] accessors — an out-of-range index yields 0 or "".

--- a/src/modules/config/config_accessors_0.c
+++ b/src/modules/config/config_accessors_0.c
@@ -595,8 +595,7 @@ int config_identity_working_profile_injection_enabled(void)
 int config_identity_working_profile_injection_fields_count(void)
 {
    int v = 0;
-   config_field_read(offsetof(config_t, identity_working_profile_injection_fields_count), sizeof(v),
-                     &v);
+   config_field_read(offsetof(config_t, identity_working_profile_injection_fields_count), sizeof(v), &v);
    return v;
 }
 
@@ -919,5 +918,12 @@ int config_learning_synthesize_enabled(void)
 {
    int v = 0;
    config_field_read(offsetof(config_t, learning_synthesize_enabled), sizeof(v), &v);
+   return v;
+}
+
+int config_learning_synthesize_max_tokens(void)
+{
+   int v = 0;
+   config_field_read(offsetof(config_t, learning_synthesize_max_tokens), sizeof(v), &v);
    return v;
 }

--- a/src/modules/config/config_accessors_0.c
+++ b/src/modules/config/config_accessors_0.c
@@ -595,7 +595,8 @@ int config_identity_working_profile_injection_enabled(void)
 int config_identity_working_profile_injection_fields_count(void)
 {
    int v = 0;
-   config_field_read(offsetof(config_t, identity_working_profile_injection_fields_count), sizeof(v), &v);
+   config_field_read(offsetof(config_t, identity_working_profile_injection_fields_count), sizeof(v),
+                     &v);
    return v;
 }
 

--- a/src/modules/config/config_accessors_1.c
+++ b/src/modules/config/config_accessors_1.c
@@ -18,13 +18,6 @@
  * back to a heap-loaded config when no snapshot is live. */
 int config_field_read(size_t offset, size_t size, void *dst);
 
-int config_learning_synthesize_max_tokens(void)
-{
-   int v = 0;
-   config_field_read(offsetof(config_t, learning_synthesize_max_tokens), sizeof(v), &v);
-   return v;
-}
-
 int config_learning_synthesize_k(void)
 {
    int v = 0;
@@ -918,5 +911,19 @@ int config_demotion_window(void)
 {
    int v = 0;
    config_field_read(offsetof(config_t, demotion_window), sizeof(v), &v);
+   return v;
+}
+
+double config_demotion_half_life_days(void)
+{
+   double v = 0;
+   config_field_read(offsetof(config_t, demotion_half_life_days), sizeof(v), &v);
+   return v;
+}
+
+int config_demotion_n_min(void)
+{
+   int v = 0;
+   config_field_read(offsetof(config_t, demotion_n_min), sizeof(v), &v);
    return v;
 }

--- a/src/modules/config/config_accessors_2.c
+++ b/src/modules/config/config_accessors_2.c
@@ -18,20 +18,6 @@
  * back to a heap-loaded config when no snapshot is live. */
 int config_field_read(size_t offset, size_t size, void *dst);
 
-double config_demotion_half_life_days(void)
-{
-   double v = 0;
-   config_field_read(offsetof(config_t, demotion_half_life_days), sizeof(v), &v);
-   return v;
-}
-
-int config_demotion_n_min(void)
-{
-   int v = 0;
-   config_field_read(offsetof(config_t, demotion_n_min), sizeof(v), &v);
-   return v;
-}
-
 double config_kb_fusion_static_alpha(void)
 {
    double v = 0;
@@ -947,6 +933,33 @@ const char *config_css_render_command(void)
    static _Thread_local char buf[512];
    buf[0] = 0;
    config_field_read(offsetof(config_t, css_render_command), sizeof(buf), buf);
+   buf[sizeof(buf) - 1] = 0;
+   return buf;
+}
+
+const char *config_vault_custody(void)
+{
+   static _Thread_local char buf[16];
+   buf[0] = 0;
+   config_field_read(offsetof(config_t, vault_custody), sizeof(buf), buf);
+   buf[sizeof(buf) - 1] = 0;
+   return buf;
+}
+
+const char *config_vault_tpm2_blob_path(void)
+{
+   static _Thread_local char buf[512];
+   buf[0] = 0;
+   config_field_read(offsetof(config_t, vault_tpm2_blob_path), sizeof(buf), buf);
+   buf[sizeof(buf) - 1] = 0;
+   return buf;
+}
+
+const char *config_vault_tpm2_tcti(void)
+{
+   static _Thread_local char buf[128];
+   buf[0] = 0;
+   config_field_read(offsetof(config_t, vault_tpm2_tcti), sizeof(buf), buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }

--- a/src/modules/config/config_accessors_3.c
+++ b/src/modules/config/config_accessors_3.c
@@ -18,33 +18,6 @@
  * back to a heap-loaded config when no snapshot is live. */
 int config_field_read(size_t offset, size_t size, void *dst);
 
-const char *config_vault_custody(void)
-{
-   static _Thread_local char buf[16];
-   buf[0] = 0;
-   config_field_read(offsetof(config_t, vault_custody), sizeof(buf), buf);
-   buf[sizeof(buf) - 1] = 0;
-   return buf;
-}
-
-const char *config_vault_tpm2_blob_path(void)
-{
-   static _Thread_local char buf[512];
-   buf[0] = 0;
-   config_field_read(offsetof(config_t, vault_tpm2_blob_path), sizeof(buf), buf);
-   buf[sizeof(buf) - 1] = 0;
-   return buf;
-}
-
-const char *config_vault_tpm2_tcti(void)
-{
-   static _Thread_local char buf[128];
-   buf[0] = 0;
-   config_field_read(offsetof(config_t, vault_tpm2_tcti), sizeof(buf), buf);
-   buf[sizeof(buf) - 1] = 0;
-   return buf;
-}
-
 const char *config_vault_tpm2_nv_index(void)
 {
    static _Thread_local char buf[32];
@@ -86,6 +59,15 @@ const char *config_code_context_mode(void)
    static _Thread_local char buf[16];
    buf[0] = 0;
    config_field_read(offsetof(config_t, code_context_mode), sizeof(buf), buf);
+   buf[sizeof(buf) - 1] = 0;
+   return buf;
+}
+
+const char *config_session_worktree_base(void)
+{
+   static _Thread_local char buf[64];
+   buf[0] = 0;
+   config_field_read(offsetof(config_t, session_worktree_base), sizeof(buf), buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }
@@ -987,8 +969,8 @@ const char *config_workspaces(int index)
    buf[0] = 0;
    if (index < 0 || index >= (64))
       return buf;
-   config_field_read(offsetof(config_t, workspaces) + (size_t)index * sizeof(buf), sizeof(buf),
-                     buf);
+   config_field_read(offsetof(config_t, workspaces) + (size_t)index * sizeof(buf),
+                     sizeof(buf), buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }
@@ -1071,8 +1053,8 @@ const char *config_charter_values(int index)
    buf[0] = 0;
    if (index < 0 || index >= (CONFIG_CHARTER_MAX_ENTRIES))
       return buf;
-   config_field_read(offsetof(config_t, charter_values) + (size_t)index * sizeof(buf), sizeof(buf),
-                     buf);
+   config_field_read(offsetof(config_t, charter_values) + (size_t)index * sizeof(buf),
+                     sizeof(buf), buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }
@@ -1107,8 +1089,8 @@ const char *config_mcp_osv_allow(int index)
    buf[0] = 0;
    if (index < 0 || index >= (CONFIG_MCP_OSV_MAX_ALLOW))
       return buf;
-   config_field_read(offsetof(config_t, mcp_osv_allow) + (size_t)index * sizeof(buf), sizeof(buf),
-                     buf);
+   config_field_read(offsetof(config_t, mcp_osv_allow) + (size_t)index * sizeof(buf),
+                     sizeof(buf), buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }
@@ -1260,6 +1242,51 @@ int config_set_memory_maintenance_enabled(int value)
    if (rc == 0)
    {
       cfg->memory_maintenance_enabled = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_memory_maintenance_interval_seconds(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->memory_maintenance_interval_seconds = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_memory_maintenance_summarize_enabled(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->memory_maintenance_summarize_enabled = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_code_cochange_git_enabled(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->code_cochange_git_enabled = value;
       rc = config_save(cfg);
    }
    free(cfg);

--- a/src/modules/config/config_accessors_3.c
+++ b/src/modules/config/config_accessors_3.c
@@ -969,8 +969,8 @@ const char *config_workspaces(int index)
    buf[0] = 0;
    if (index < 0 || index >= (64))
       return buf;
-   config_field_read(offsetof(config_t, workspaces) + (size_t)index * sizeof(buf),
-                     sizeof(buf), buf);
+   config_field_read(offsetof(config_t, workspaces) + (size_t)index * sizeof(buf), sizeof(buf),
+                     buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }
@@ -1053,8 +1053,8 @@ const char *config_charter_values(int index)
    buf[0] = 0;
    if (index < 0 || index >= (CONFIG_CHARTER_MAX_ENTRIES))
       return buf;
-   config_field_read(offsetof(config_t, charter_values) + (size_t)index * sizeof(buf),
-                     sizeof(buf), buf);
+   config_field_read(offsetof(config_t, charter_values) + (size_t)index * sizeof(buf), sizeof(buf),
+                     buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }
@@ -1089,8 +1089,8 @@ const char *config_mcp_osv_allow(int index)
    buf[0] = 0;
    if (index < 0 || index >= (CONFIG_MCP_OSV_MAX_ALLOW))
       return buf;
-   config_field_read(offsetof(config_t, mcp_osv_allow) + (size_t)index * sizeof(buf),
-                     sizeof(buf), buf);
+   config_field_read(offsetof(config_t, mcp_osv_allow) + (size_t)index * sizeof(buf), sizeof(buf),
+                     buf);
    buf[sizeof(buf) - 1] = 0;
    return buf;
 }

--- a/src/modules/config/config_accessors_4.c
+++ b/src/modules/config/config_accessors_4.c
@@ -18,51 +18,6 @@
  * back to a heap-loaded config when no snapshot is live. */
 int config_field_read(size_t offset, size_t size, void *dst);
 
-int config_set_memory_maintenance_interval_seconds(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->memory_maintenance_interval_seconds = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_memory_maintenance_summarize_enabled(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->memory_maintenance_summarize_enabled = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_code_cochange_git_enabled(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->code_cochange_git_enabled = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
 int config_set_wfe_proposals_autoscan_enabled(int value)
 {
    config_t *cfg = calloc(1, sizeof(*cfg));
@@ -1947,6 +1902,66 @@ int config_set_learning_implicit_workflow_repetition(int value)
    if (rc == 0)
    {
       cfg->learning_implicit_workflow_repetition = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_learning_implicit_retrieval_outcome(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->learning_implicit_retrieval_outcome = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_autonomous(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->autonomous = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_verify_enabled(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->verify_enabled = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_roundtable_replay_verify_enabled(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->roundtable_replay_verify_enabled = value;
       rc = config_save(cfg);
    }
    free(cfg);

--- a/src/modules/config/config_accessors_5.c
+++ b/src/modules/config/config_accessors_5.c
@@ -18,66 +18,6 @@
  * back to a heap-loaded config when no snapshot is live. */
 int config_field_read(size_t offset, size_t size, void *dst);
 
-int config_set_learning_implicit_retrieval_outcome(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->learning_implicit_retrieval_outcome = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_autonomous(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->autonomous = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_verify_enabled(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->verify_enabled = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_roundtable_replay_verify_enabled(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->roundtable_replay_verify_enabled = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
 int config_set_roundtable_require_evidence(int value)
 {
    config_t *cfg = calloc(1, sizeof(*cfg));
@@ -1947,6 +1887,81 @@ int config_set_kb_ranker_fit_bench_k(int value)
    if (rc == 0)
    {
       cfg->kb_ranker_fit_bench_k = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_reasoning_row_budget(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->reasoning_row_budget = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_reasoning_time_limit_ms(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->reasoning_time_limit_ms = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_bandit_exploration_fraction(double value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->bandit_exploration_fraction = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_bandit_ipw_weight_cap(double value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->bandit_ipw_weight_cap = value;
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_bandit_exploration_window_seconds(int value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      cfg->bandit_exploration_window_seconds = value;
       rc = config_save(cfg);
    }
    free(cfg);

--- a/src/modules/config/config_accessors_6.c
+++ b/src/modules/config/config_accessors_6.c
@@ -18,81 +18,6 @@
  * back to a heap-loaded config when no snapshot is live. */
 int config_field_read(size_t offset, size_t size, void *dst);
 
-int config_set_reasoning_row_budget(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->reasoning_row_budget = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_reasoning_time_limit_ms(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->reasoning_time_limit_ms = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_bandit_exploration_fraction(double value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->bandit_exploration_fraction = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_bandit_ipw_weight_cap(double value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->bandit_ipw_weight_cap = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_bandit_exploration_window_seconds(int value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      cfg->bandit_exploration_window_seconds = value;
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
 int config_set_planner_budget_default(int value)
 {
    config_t *cfg = calloc(1, sizeof(*cfg));
@@ -1711,8 +1636,7 @@ int config_set_model_reasoning_effort(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->model_reasoning_effort, sizeof(cfg->model_reasoning_effort), "%s",
-               value ? value : "");
+      snprintf(cfg->model_reasoning_effort, sizeof(cfg->model_reasoning_effort), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1802,8 +1726,7 @@ int config_set_memory_weight_profile(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_weight_profile, sizeof(cfg->memory_weight_profile), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_weight_profile, sizeof(cfg->memory_weight_profile), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1863,8 +1786,7 @@ int config_set_vault_tpm2_blob_path(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->vault_tpm2_blob_path, sizeof(cfg->vault_tpm2_blob_path), "%s",
-               value ? value : "");
+      snprintf(cfg->vault_tpm2_blob_path, sizeof(cfg->vault_tpm2_blob_path), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1894,8 +1816,7 @@ int config_set_vault_tpm2_nv_index(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->vault_tpm2_nv_index, sizeof(cfg->vault_tpm2_nv_index), "%s",
-               value ? value : "");
+      snprintf(cfg->vault_tpm2_nv_index, sizeof(cfg->vault_tpm2_nv_index), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1925,8 +1846,7 @@ int config_set_memory_cognify_model(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_cognify_model, sizeof(cfg->memory_cognify_model), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_cognify_model, sizeof(cfg->memory_cognify_model), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1941,8 +1861,97 @@ int config_set_memory_cognify_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_cognify_command, sizeof(cfg->memory_cognify_command), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_cognify_command, sizeof(cfg->memory_cognify_command), "%s", value ? value : "");
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_code_context_mode(const char *value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      snprintf(cfg->code_context_mode, sizeof(cfg->code_context_mode), "%s", value ? value : "");
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_session_worktree_base(const char *value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      snprintf(cfg->session_worktree_base, sizeof(cfg->session_worktree_base), "%s", value ? value : "");
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_delegate_sandbox_image(const char *value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      snprintf(cfg->delegate_sandbox_image, sizeof(cfg->delegate_sandbox_image), "%s", value ? value : "");
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_delegate_sandbox_package_access(const char *value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access), "%s", value ? value : "");
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_kb_pdf_tier(const char *value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      snprintf(cfg->kb_pdf_tier, sizeof(cfg->kb_pdf_tier), "%s", value ? value : "");
+      rc = config_save(cfg);
+   }
+   free(cfg);
+   return rc;
+}
+
+int config_set_tsr_command(const char *value)
+{
+   config_t *cfg = calloc(1, sizeof(*cfg));
+   if (!cfg)
+      return -1;
+   int rc = config_load(cfg);
+   if (rc == 0)
+   {
+      snprintf(cfg->tsr_command, sizeof(cfg->tsr_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);

--- a/src/modules/config/config_accessors_6.c
+++ b/src/modules/config/config_accessors_6.c
@@ -1636,7 +1636,8 @@ int config_set_model_reasoning_effort(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->model_reasoning_effort, sizeof(cfg->model_reasoning_effort), "%s", value ? value : "");
+      snprintf(cfg->model_reasoning_effort, sizeof(cfg->model_reasoning_effort), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1726,7 +1727,8 @@ int config_set_memory_weight_profile(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_weight_profile, sizeof(cfg->memory_weight_profile), "%s", value ? value : "");
+      snprintf(cfg->memory_weight_profile, sizeof(cfg->memory_weight_profile), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1786,7 +1788,8 @@ int config_set_vault_tpm2_blob_path(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->vault_tpm2_blob_path, sizeof(cfg->vault_tpm2_blob_path), "%s", value ? value : "");
+      snprintf(cfg->vault_tpm2_blob_path, sizeof(cfg->vault_tpm2_blob_path), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1816,7 +1819,8 @@ int config_set_vault_tpm2_nv_index(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->vault_tpm2_nv_index, sizeof(cfg->vault_tpm2_nv_index), "%s", value ? value : "");
+      snprintf(cfg->vault_tpm2_nv_index, sizeof(cfg->vault_tpm2_nv_index), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1846,7 +1850,8 @@ int config_set_memory_cognify_model(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_cognify_model, sizeof(cfg->memory_cognify_model), "%s", value ? value : "");
+      snprintf(cfg->memory_cognify_model, sizeof(cfg->memory_cognify_model), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1861,7 +1866,8 @@ int config_set_memory_cognify_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_cognify_command, sizeof(cfg->memory_cognify_command), "%s", value ? value : "");
+      snprintf(cfg->memory_cognify_command, sizeof(cfg->memory_cognify_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1891,7 +1897,8 @@ int config_set_session_worktree_base(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->session_worktree_base, sizeof(cfg->session_worktree_base), "%s", value ? value : "");
+      snprintf(cfg->session_worktree_base, sizeof(cfg->session_worktree_base), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1906,7 +1913,8 @@ int config_set_delegate_sandbox_image(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->delegate_sandbox_image, sizeof(cfg->delegate_sandbox_image), "%s", value ? value : "");
+      snprintf(cfg->delegate_sandbox_image, sizeof(cfg->delegate_sandbox_image), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1921,7 +1929,8 @@ int config_set_delegate_sandbox_package_access(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access), "%s", value ? value : "");
+      snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
+               "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);

--- a/src/modules/config/config_accessors_7.c
+++ b/src/modules/config/config_accessors_7.c
@@ -18,83 +18,6 @@
  * back to a heap-loaded config when no snapshot is live. */
 int config_field_read(size_t offset, size_t size, void *dst);
 
-int config_set_code_context_mode(const char *value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      snprintf(cfg->code_context_mode, sizeof(cfg->code_context_mode), "%s", value ? value : "");
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_delegate_sandbox_image(const char *value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      snprintf(cfg->delegate_sandbox_image, sizeof(cfg->delegate_sandbox_image), "%s",
-               value ? value : "");
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_delegate_sandbox_package_access(const char *value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
-               "%s", value ? value : "");
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_kb_pdf_tier(const char *value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      snprintf(cfg->kb_pdf_tier, sizeof(cfg->kb_pdf_tier), "%s", value ? value : "");
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
-int config_set_tsr_command(const char *value)
-{
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return -1;
-   int rc = config_load(cfg);
-   if (rc == 0)
-   {
-      snprintf(cfg->tsr_command, sizeof(cfg->tsr_command), "%s", value ? value : "");
-      rc = config_save(cfg);
-   }
-   free(cfg);
-   return rc;
-}
-
 int config_set_kb_pdf_blob_dir(const char *value)
 {
    config_t *cfg = calloc(1, sizeof(*cfg));
@@ -133,8 +56,7 @@ int config_set_memory_pagerank_relations(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_pagerank_relations, sizeof(cfg->memory_pagerank_relations), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_pagerank_relations, sizeof(cfg->memory_pagerank_relations), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -149,8 +71,7 @@ int config_set_memory_citations_mode(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -165,8 +86,7 @@ int config_set_memory_rewrite_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_rewrite_command, sizeof(cfg->memory_rewrite_command), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_rewrite_command, sizeof(cfg->memory_rewrite_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -181,8 +101,7 @@ int config_set_memory_rerank_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_rerank_command, sizeof(cfg->memory_rerank_command), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_rerank_command, sizeof(cfg->memory_rerank_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -197,8 +116,7 @@ int config_set_memory_query_expansion_mode(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_query_expansion_mode, sizeof(cfg->memory_query_expansion_mode), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_query_expansion_mode, sizeof(cfg->memory_query_expansion_mode), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -213,8 +131,7 @@ int config_set_memory_recall_lanes_summary_kinds(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_recall_lanes_summary_kinds,
-               sizeof(cfg->memory_recall_lanes_summary_kinds), "%s", value ? value : "");
+      snprintf(cfg->memory_recall_lanes_summary_kinds, sizeof(cfg->memory_recall_lanes_summary_kinds), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -229,8 +146,7 @@ int config_set_memory_recall_lanes_fact_kinds(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_recall_lanes_fact_kinds, sizeof(cfg->memory_recall_lanes_fact_kinds),
-               "%s", value ? value : "");
+      snprintf(cfg->memory_recall_lanes_fact_kinds, sizeof(cfg->memory_recall_lanes_fact_kinds), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -245,8 +161,7 @@ int config_set_memory_hard_negative_log(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_hard_negative_log, sizeof(cfg->memory_hard_negative_log), "%s",
-               value ? value : "");
+      snprintf(cfg->memory_hard_negative_log, sizeof(cfg->memory_hard_negative_log), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -276,8 +191,7 @@ int config_set_learning_synthesize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->learning_synthesize_command, sizeof(cfg->learning_synthesize_command), "%s",
-               value ? value : "");
+      snprintf(cfg->learning_synthesize_command, sizeof(cfg->learning_synthesize_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -292,8 +206,7 @@ int config_set_learning_embed_model_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->learning_embed_model_version, sizeof(cfg->learning_embed_model_version), "%s",
-               value ? value : "");
+      snprintf(cfg->learning_embed_model_version, sizeof(cfg->learning_embed_model_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -308,8 +221,7 @@ int config_set_learning_synthesize_prompt_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->learning_synthesize_prompt_version,
-               sizeof(cfg->learning_synthesize_prompt_version), "%s", value ? value : "");
+      snprintf(cfg->learning_synthesize_prompt_version, sizeof(cfg->learning_synthesize_prompt_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -419,8 +331,7 @@ int config_set_coord_closet_denylist(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->coord_closet_denylist, sizeof(cfg->coord_closet_denylist), "%s",
-               value ? value : "");
+      snprintf(cfg->coord_closet_denylist, sizeof(cfg->coord_closet_denylist), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -465,8 +376,7 @@ int config_set_delegate_prompt_tier(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->delegate_prompt_tier, sizeof(cfg->delegate_prompt_tier), "%s",
-               value ? value : "");
+      snprintf(cfg->delegate_prompt_tier, sizeof(cfg->delegate_prompt_tier), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -526,8 +436,7 @@ int config_set_computer_use_default_navigation(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->computer_use_default_navigation, sizeof(cfg->computer_use_default_navigation),
-               "%s", value ? value : "");
+      snprintf(cfg->computer_use_default_navigation, sizeof(cfg->computer_use_default_navigation), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -567,8 +476,7 @@ int config_set_guardrails_semantic_mode(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->guardrails_semantic_mode, sizeof(cfg->guardrails_semantic_mode), "%s",
-               value ? value : "");
+      snprintf(cfg->guardrails_semantic_mode, sizeof(cfg->guardrails_semantic_mode), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -583,8 +491,7 @@ int config_set_guardrails_semantic_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->guardrails_semantic_command, sizeof(cfg->guardrails_semantic_command), "%s",
-               value ? value : "");
+      snprintf(cfg->guardrails_semantic_command, sizeof(cfg->guardrails_semantic_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -764,8 +671,7 @@ int config_set_llm_rerank_endpoint(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->llm_rerank_endpoint, sizeof(cfg->llm_rerank_endpoint), "%s",
-               value ? value : "");
+      snprintf(cfg->llm_rerank_endpoint, sizeof(cfg->llm_rerank_endpoint), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -870,8 +776,7 @@ int config_set_server_api_mtls_client_ca(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->server_api_mtls_client_ca, sizeof(cfg->server_api_mtls_client_ca), "%s",
-               value ? value : "");
+      snprintf(cfg->server_api_mtls_client_ca, sizeof(cfg->server_api_mtls_client_ca), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -891,8 +796,7 @@ int config_set_server_api_client_transport(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->server_api_client_transport, sizeof(cfg->server_api_client_transport), "%s",
-               value ? value : "");
+      snprintf(cfg->server_api_client_transport, sizeof(cfg->server_api_client_transport), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -907,8 +811,7 @@ int config_set_calibration_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->calibration_command, sizeof(cfg->calibration_command), "%s",
-               value ? value : "");
+      snprintf(cfg->calibration_command, sizeof(cfg->calibration_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -923,8 +826,7 @@ int config_set_calibration_prompt_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->calibration_prompt_version, sizeof(cfg->calibration_prompt_version), "%s",
-               value ? value : "");
+      snprintf(cfg->calibration_prompt_version, sizeof(cfg->calibration_prompt_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -939,8 +841,7 @@ int config_set_calibration_model_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->calibration_model_version, sizeof(cfg->calibration_model_version), "%s",
-               value ? value : "");
+      snprintf(cfg->calibration_model_version, sizeof(cfg->calibration_model_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -970,8 +871,7 @@ int config_set_ranker_fuse_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->ranker_fuse_command, sizeof(cfg->ranker_fuse_command), "%s",
-               value ? value : "");
+      snprintf(cfg->ranker_fuse_command, sizeof(cfg->ranker_fuse_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -986,8 +886,7 @@ int config_set_kb_ranker_fit_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_ranker_fit_command, sizeof(cfg->kb_ranker_fit_command), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_ranker_fit_command, sizeof(cfg->kb_ranker_fit_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1002,8 +901,7 @@ int config_set_kb_ranker_fit_benchmark(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_ranker_fit_benchmark, sizeof(cfg->kb_ranker_fit_benchmark), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_ranker_fit_benchmark, sizeof(cfg->kb_ranker_fit_benchmark), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1018,8 +916,7 @@ int config_set_kb_ranker_fit_objective(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_ranker_fit_objective, sizeof(cfg->kb_ranker_fit_objective), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_ranker_fit_objective, sizeof(cfg->kb_ranker_fit_objective), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1034,8 +931,7 @@ int config_set_reasoning_datalog_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->reasoning_datalog_command, sizeof(cfg->reasoning_datalog_command), "%s",
-               value ? value : "");
+      snprintf(cfg->reasoning_datalog_command, sizeof(cfg->reasoning_datalog_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1050,8 +946,7 @@ int config_set_bandit_optimize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->bandit_optimize_command, sizeof(cfg->bandit_optimize_command), "%s",
-               value ? value : "");
+      snprintf(cfg->bandit_optimize_command, sizeof(cfg->bandit_optimize_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1066,8 +961,7 @@ int config_set_planner_search_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->planner_search_command, sizeof(cfg->planner_search_command), "%s",
-               value ? value : "");
+      snprintf(cfg->planner_search_command, sizeof(cfg->planner_search_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1082,8 +976,7 @@ int config_set_constraint_solver_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->constraint_solver_command, sizeof(cfg->constraint_solver_command), "%s",
-               value ? value : "");
+      snprintf(cfg->constraint_solver_command, sizeof(cfg->constraint_solver_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1098,8 +991,7 @@ int config_set_kb_synthesize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_synthesize_command, sizeof(cfg->kb_synthesize_command), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_synthesize_command, sizeof(cfg->kb_synthesize_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1134,8 +1026,7 @@ int config_set_kb_curator_extract_prompt_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_extract_prompt_version,
-               sizeof(cfg->kb_curator_extract_prompt_version), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_extract_prompt_version, sizeof(cfg->kb_curator_extract_prompt_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1150,8 +1041,7 @@ int config_set_kb_curator_embed_model_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_embed_model_version, sizeof(cfg->kb_curator_embed_model_version),
-               "%s", value ? value : "");
+      snprintf(cfg->kb_curator_embed_model_version, sizeof(cfg->kb_curator_embed_model_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1166,8 +1056,7 @@ int config_set_kb_curator_invalidation_notify_socket(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_invalidation_notify_socket,
-               sizeof(cfg->kb_curator_invalidation_notify_socket), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_invalidation_notify_socket, sizeof(cfg->kb_curator_invalidation_notify_socket), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1182,8 +1071,7 @@ int config_set_kb_curator_extract_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_extract_command, sizeof(cfg->kb_curator_extract_command), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_extract_command, sizeof(cfg->kb_curator_extract_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1198,8 +1086,7 @@ int config_set_kb_curator_stage_order(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_stage_order, sizeof(cfg->kb_curator_stage_order), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_stage_order, sizeof(cfg->kb_curator_stage_order), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1214,8 +1101,7 @@ int config_set_kb_curator_user_presets(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_user_presets, sizeof(cfg->kb_curator_user_presets), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_user_presets, sizeof(cfg->kb_curator_user_presets), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1230,8 +1116,7 @@ int config_set_kb_curator_custom_stages(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_custom_stages, sizeof(cfg->kb_curator_custom_stages), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_custom_stages, sizeof(cfg->kb_curator_custom_stages), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1246,8 +1131,7 @@ int config_set_kb_curator_provider_base_url(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_provider_base_url, sizeof(cfg->kb_curator_provider_base_url), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_provider_base_url, sizeof(cfg->kb_curator_provider_base_url), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1262,8 +1146,7 @@ int config_set_kb_curator_provider_model(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_provider_model, sizeof(cfg->kb_curator_provider_model), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_provider_model, sizeof(cfg->kb_curator_provider_model), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1283,8 +1166,7 @@ int config_set_kb_curator_tier_b_base_url(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_tier_b_base_url, sizeof(cfg->kb_curator_tier_b_base_url), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_tier_b_base_url, sizeof(cfg->kb_curator_tier_b_base_url), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1299,8 +1181,7 @@ int config_set_kb_curator_tier_b_model(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_tier_b_model, sizeof(cfg->kb_curator_tier_b_model), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_tier_b_model, sizeof(cfg->kb_curator_tier_b_model), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1320,8 +1201,7 @@ int config_set_kb_curator_judge_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_judge_command, sizeof(cfg->kb_curator_judge_command), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_judge_command, sizeof(cfg->kb_curator_judge_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1336,8 +1216,7 @@ int config_set_kb_curator_synthesize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_synthesize_command, sizeof(cfg->kb_curator_synthesize_command), "%s",
-               value ? value : "");
+      snprintf(cfg->kb_curator_synthesize_command, sizeof(cfg->kb_curator_synthesize_command), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1352,8 +1231,7 @@ int config_set_aux_default_provider(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->aux_default_provider, sizeof(cfg->aux_default_provider), "%s",
-               value ? value : "");
+      snprintf(cfg->aux_default_provider, sizeof(cfg->aux_default_provider), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1383,8 +1261,7 @@ int config_set_db2_vector_corpus_index(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->db2_vector_corpus_index, sizeof(cfg->db2_vector_corpus_index), "%s",
-               value ? value : "");
+      snprintf(cfg->db2_vector_corpus_index, sizeof(cfg->db2_vector_corpus_index), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1399,8 +1276,7 @@ int config_set_ensemble_aggregator(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
-               value ? value : "");
+      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1445,8 +1321,7 @@ int config_set_roundtable_pipeline_done_bar(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->roundtable_pipeline_done_bar, sizeof(cfg->roundtable_pipeline_done_bar), "%s",
-               value ? value : "");
+      snprintf(cfg->roundtable_pipeline_done_bar, sizeof(cfg->roundtable_pipeline_done_bar), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);

--- a/src/modules/config/config_accessors_7.c
+++ b/src/modules/config/config_accessors_7.c
@@ -56,7 +56,8 @@ int config_set_memory_pagerank_relations(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_pagerank_relations, sizeof(cfg->memory_pagerank_relations), "%s", value ? value : "");
+      snprintf(cfg->memory_pagerank_relations, sizeof(cfg->memory_pagerank_relations), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -71,7 +72,8 @@ int config_set_memory_citations_mode(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", value ? value : "");
+      snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -86,7 +88,8 @@ int config_set_memory_rewrite_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_rewrite_command, sizeof(cfg->memory_rewrite_command), "%s", value ? value : "");
+      snprintf(cfg->memory_rewrite_command, sizeof(cfg->memory_rewrite_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -101,7 +104,8 @@ int config_set_memory_rerank_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_rerank_command, sizeof(cfg->memory_rerank_command), "%s", value ? value : "");
+      snprintf(cfg->memory_rerank_command, sizeof(cfg->memory_rerank_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -116,7 +120,8 @@ int config_set_memory_query_expansion_mode(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_query_expansion_mode, sizeof(cfg->memory_query_expansion_mode), "%s", value ? value : "");
+      snprintf(cfg->memory_query_expansion_mode, sizeof(cfg->memory_query_expansion_mode), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -131,7 +136,8 @@ int config_set_memory_recall_lanes_summary_kinds(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_recall_lanes_summary_kinds, sizeof(cfg->memory_recall_lanes_summary_kinds), "%s", value ? value : "");
+      snprintf(cfg->memory_recall_lanes_summary_kinds,
+               sizeof(cfg->memory_recall_lanes_summary_kinds), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -146,7 +152,8 @@ int config_set_memory_recall_lanes_fact_kinds(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_recall_lanes_fact_kinds, sizeof(cfg->memory_recall_lanes_fact_kinds), "%s", value ? value : "");
+      snprintf(cfg->memory_recall_lanes_fact_kinds, sizeof(cfg->memory_recall_lanes_fact_kinds),
+               "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -161,7 +168,8 @@ int config_set_memory_hard_negative_log(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->memory_hard_negative_log, sizeof(cfg->memory_hard_negative_log), "%s", value ? value : "");
+      snprintf(cfg->memory_hard_negative_log, sizeof(cfg->memory_hard_negative_log), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -191,7 +199,8 @@ int config_set_learning_synthesize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->learning_synthesize_command, sizeof(cfg->learning_synthesize_command), "%s", value ? value : "");
+      snprintf(cfg->learning_synthesize_command, sizeof(cfg->learning_synthesize_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -206,7 +215,8 @@ int config_set_learning_embed_model_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->learning_embed_model_version, sizeof(cfg->learning_embed_model_version), "%s", value ? value : "");
+      snprintf(cfg->learning_embed_model_version, sizeof(cfg->learning_embed_model_version), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -221,7 +231,8 @@ int config_set_learning_synthesize_prompt_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->learning_synthesize_prompt_version, sizeof(cfg->learning_synthesize_prompt_version), "%s", value ? value : "");
+      snprintf(cfg->learning_synthesize_prompt_version,
+               sizeof(cfg->learning_synthesize_prompt_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -331,7 +342,8 @@ int config_set_coord_closet_denylist(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->coord_closet_denylist, sizeof(cfg->coord_closet_denylist), "%s", value ? value : "");
+      snprintf(cfg->coord_closet_denylist, sizeof(cfg->coord_closet_denylist), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -376,7 +388,8 @@ int config_set_delegate_prompt_tier(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->delegate_prompt_tier, sizeof(cfg->delegate_prompt_tier), "%s", value ? value : "");
+      snprintf(cfg->delegate_prompt_tier, sizeof(cfg->delegate_prompt_tier), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -436,7 +449,8 @@ int config_set_computer_use_default_navigation(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->computer_use_default_navigation, sizeof(cfg->computer_use_default_navigation), "%s", value ? value : "");
+      snprintf(cfg->computer_use_default_navigation, sizeof(cfg->computer_use_default_navigation),
+               "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -476,7 +490,8 @@ int config_set_guardrails_semantic_mode(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->guardrails_semantic_mode, sizeof(cfg->guardrails_semantic_mode), "%s", value ? value : "");
+      snprintf(cfg->guardrails_semantic_mode, sizeof(cfg->guardrails_semantic_mode), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -491,7 +506,8 @@ int config_set_guardrails_semantic_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->guardrails_semantic_command, sizeof(cfg->guardrails_semantic_command), "%s", value ? value : "");
+      snprintf(cfg->guardrails_semantic_command, sizeof(cfg->guardrails_semantic_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -671,7 +687,8 @@ int config_set_llm_rerank_endpoint(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->llm_rerank_endpoint, sizeof(cfg->llm_rerank_endpoint), "%s", value ? value : "");
+      snprintf(cfg->llm_rerank_endpoint, sizeof(cfg->llm_rerank_endpoint), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -776,7 +793,8 @@ int config_set_server_api_mtls_client_ca(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->server_api_mtls_client_ca, sizeof(cfg->server_api_mtls_client_ca), "%s", value ? value : "");
+      snprintf(cfg->server_api_mtls_client_ca, sizeof(cfg->server_api_mtls_client_ca), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -796,7 +814,8 @@ int config_set_server_api_client_transport(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->server_api_client_transport, sizeof(cfg->server_api_client_transport), "%s", value ? value : "");
+      snprintf(cfg->server_api_client_transport, sizeof(cfg->server_api_client_transport), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -811,7 +830,8 @@ int config_set_calibration_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->calibration_command, sizeof(cfg->calibration_command), "%s", value ? value : "");
+      snprintf(cfg->calibration_command, sizeof(cfg->calibration_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -826,7 +846,8 @@ int config_set_calibration_prompt_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->calibration_prompt_version, sizeof(cfg->calibration_prompt_version), "%s", value ? value : "");
+      snprintf(cfg->calibration_prompt_version, sizeof(cfg->calibration_prompt_version), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -841,7 +862,8 @@ int config_set_calibration_model_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->calibration_model_version, sizeof(cfg->calibration_model_version), "%s", value ? value : "");
+      snprintf(cfg->calibration_model_version, sizeof(cfg->calibration_model_version), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -871,7 +893,8 @@ int config_set_ranker_fuse_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->ranker_fuse_command, sizeof(cfg->ranker_fuse_command), "%s", value ? value : "");
+      snprintf(cfg->ranker_fuse_command, sizeof(cfg->ranker_fuse_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -886,7 +909,8 @@ int config_set_kb_ranker_fit_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_ranker_fit_command, sizeof(cfg->kb_ranker_fit_command), "%s", value ? value : "");
+      snprintf(cfg->kb_ranker_fit_command, sizeof(cfg->kb_ranker_fit_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -901,7 +925,8 @@ int config_set_kb_ranker_fit_benchmark(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_ranker_fit_benchmark, sizeof(cfg->kb_ranker_fit_benchmark), "%s", value ? value : "");
+      snprintf(cfg->kb_ranker_fit_benchmark, sizeof(cfg->kb_ranker_fit_benchmark), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -916,7 +941,8 @@ int config_set_kb_ranker_fit_objective(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_ranker_fit_objective, sizeof(cfg->kb_ranker_fit_objective), "%s", value ? value : "");
+      snprintf(cfg->kb_ranker_fit_objective, sizeof(cfg->kb_ranker_fit_objective), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -931,7 +957,8 @@ int config_set_reasoning_datalog_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->reasoning_datalog_command, sizeof(cfg->reasoning_datalog_command), "%s", value ? value : "");
+      snprintf(cfg->reasoning_datalog_command, sizeof(cfg->reasoning_datalog_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -946,7 +973,8 @@ int config_set_bandit_optimize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->bandit_optimize_command, sizeof(cfg->bandit_optimize_command), "%s", value ? value : "");
+      snprintf(cfg->bandit_optimize_command, sizeof(cfg->bandit_optimize_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -961,7 +989,8 @@ int config_set_planner_search_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->planner_search_command, sizeof(cfg->planner_search_command), "%s", value ? value : "");
+      snprintf(cfg->planner_search_command, sizeof(cfg->planner_search_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -976,7 +1005,8 @@ int config_set_constraint_solver_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->constraint_solver_command, sizeof(cfg->constraint_solver_command), "%s", value ? value : "");
+      snprintf(cfg->constraint_solver_command, sizeof(cfg->constraint_solver_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -991,7 +1021,8 @@ int config_set_kb_synthesize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_synthesize_command, sizeof(cfg->kb_synthesize_command), "%s", value ? value : "");
+      snprintf(cfg->kb_synthesize_command, sizeof(cfg->kb_synthesize_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1026,7 +1057,8 @@ int config_set_kb_curator_extract_prompt_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_extract_prompt_version, sizeof(cfg->kb_curator_extract_prompt_version), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_extract_prompt_version,
+               sizeof(cfg->kb_curator_extract_prompt_version), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1041,7 +1073,8 @@ int config_set_kb_curator_embed_model_version(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_embed_model_version, sizeof(cfg->kb_curator_embed_model_version), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_embed_model_version, sizeof(cfg->kb_curator_embed_model_version),
+               "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1056,7 +1089,8 @@ int config_set_kb_curator_invalidation_notify_socket(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_invalidation_notify_socket, sizeof(cfg->kb_curator_invalidation_notify_socket), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_invalidation_notify_socket,
+               sizeof(cfg->kb_curator_invalidation_notify_socket), "%s", value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1071,7 +1105,8 @@ int config_set_kb_curator_extract_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_extract_command, sizeof(cfg->kb_curator_extract_command), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_extract_command, sizeof(cfg->kb_curator_extract_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1086,7 +1121,8 @@ int config_set_kb_curator_stage_order(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_stage_order, sizeof(cfg->kb_curator_stage_order), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_stage_order, sizeof(cfg->kb_curator_stage_order), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1101,7 +1137,8 @@ int config_set_kb_curator_user_presets(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_user_presets, sizeof(cfg->kb_curator_user_presets), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_user_presets, sizeof(cfg->kb_curator_user_presets), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1116,7 +1153,8 @@ int config_set_kb_curator_custom_stages(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_custom_stages, sizeof(cfg->kb_curator_custom_stages), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_custom_stages, sizeof(cfg->kb_curator_custom_stages), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1131,7 +1169,8 @@ int config_set_kb_curator_provider_base_url(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_provider_base_url, sizeof(cfg->kb_curator_provider_base_url), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_provider_base_url, sizeof(cfg->kb_curator_provider_base_url), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1146,7 +1185,8 @@ int config_set_kb_curator_provider_model(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_provider_model, sizeof(cfg->kb_curator_provider_model), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_provider_model, sizeof(cfg->kb_curator_provider_model), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1166,7 +1206,8 @@ int config_set_kb_curator_tier_b_base_url(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_tier_b_base_url, sizeof(cfg->kb_curator_tier_b_base_url), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_tier_b_base_url, sizeof(cfg->kb_curator_tier_b_base_url), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1181,7 +1222,8 @@ int config_set_kb_curator_tier_b_model(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_tier_b_model, sizeof(cfg->kb_curator_tier_b_model), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_tier_b_model, sizeof(cfg->kb_curator_tier_b_model), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1201,7 +1243,8 @@ int config_set_kb_curator_judge_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_judge_command, sizeof(cfg->kb_curator_judge_command), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_judge_command, sizeof(cfg->kb_curator_judge_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1216,7 +1259,8 @@ int config_set_kb_curator_synthesize_command(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->kb_curator_synthesize_command, sizeof(cfg->kb_curator_synthesize_command), "%s", value ? value : "");
+      snprintf(cfg->kb_curator_synthesize_command, sizeof(cfg->kb_curator_synthesize_command), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1231,7 +1275,8 @@ int config_set_aux_default_provider(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->aux_default_provider, sizeof(cfg->aux_default_provider), "%s", value ? value : "");
+      snprintf(cfg->aux_default_provider, sizeof(cfg->aux_default_provider), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1261,7 +1306,8 @@ int config_set_db2_vector_corpus_index(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->db2_vector_corpus_index, sizeof(cfg->db2_vector_corpus_index), "%s", value ? value : "");
+      snprintf(cfg->db2_vector_corpus_index, sizeof(cfg->db2_vector_corpus_index), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1276,7 +1322,8 @@ int config_set_ensemble_aggregator(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s", value ? value : "");
+      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);
@@ -1321,7 +1368,8 @@ int config_set_roundtable_pipeline_done_bar(const char *value)
    int rc = config_load(cfg);
    if (rc == 0)
    {
-      snprintf(cfg->roundtable_pipeline_done_bar, sizeof(cfg->roundtable_pipeline_done_bar), "%s", value ? value : "");
+      snprintf(cfg->roundtable_pipeline_done_bar, sizeof(cfg->roundtable_pipeline_done_bar), "%s",
+               value ? value : "");
       rc = config_save(cfg);
    }
    free(cfg);

--- a/src/modules/config/config_fields.c
+++ b/src/modules/config/config_fields.c
@@ -110,6 +110,8 @@ const config_field_t config_fields[] = {
      RELOAD_HOT, FGROUP_ADVANCED},
     {"require_session_worktree", offsetof(config_t, require_session_worktree), sizeof(int), 0,
      CFG_BOOL},
+    {"session_worktree_base", offsetof(config_t, session_worktree_base),
+     sizeof(((config_t *)0)->session_worktree_base), 0, CFG_STRING, RELOAD_HOT, FGROUP_ADVANCED},
     {"require_aimee_memory", offsetof(config_t, require_aimee_memory), sizeof(int), 0, CFG_BOOL},
     {"require_aimee_git", offsetof(config_t, require_aimee_git), sizeof(int), 0, CFG_BOOL},
     {"subagent_ban_enabled", offsetof(config_t, subagent_ban_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/modules/guardrails/guardrails.h
+++ b/src/modules/guardrails/guardrails.h
@@ -223,7 +223,7 @@ int worktree_create_sibling(const char *git_root, const char *session_id, const 
 void worktree_cleanup(const char *git_root, const char *session_id, const char *work_name);
 
 void worktree_registry_record(const char *git_root, const char *wt_path, const char *branch,
-                              const char *sid, const char *work_name);
+                              const char *sid, const char *work_name, const char *base_branch);
 int worktree_find_branch_in_repo(const char *git_root, const char *branch, char *out_dir,
                                  size_t out_len);
 int worktree_find_branch_registered(const char *branch, char *out_dir, size_t out_len);

--- a/src/modules/workspace/workspace.c
+++ b/src/modules/workspace/workspace.c
@@ -939,7 +939,8 @@ static void worktree_registry_paths(const char *git_root, char *repo_path, size_
 }
 
 static void worktree_registry_append(const char *path, const char *git_root, const char *wt_path,
-                                     const char *branch, const char *sid, const char *work_name)
+                                     const char *branch, const char *sid, const char *work_name,
+                                     const char *base_branch)
 {
    if (!path || !path[0])
       return;
@@ -956,13 +957,19 @@ static void worktree_registry_append(const char *path, const char *git_root, con
    FILE *f = fopen(path, "a");
    if (!f)
       return;
-   fprintf(f, "%s\t%s\t%s\t%s\t%s\n", git_root ? git_root : "", wt_path ? wt_path : "",
-           branch ? branch : "", sid ? sid : "", work_name ? work_name : "");
+   /* base_branch is the 6th column: the ref this worktree's branch was cut from.
+    * The attention guard reads it to enforce that a PRIMARY session is rooted on the
+    * default branch and a DELEGATE on its parent's branch. It is written HERE, by the
+    * launcher, precisely because the guarded agent cannot forge it -- unlike an env var,
+    * which an LLM can set on any command. */
+   fprintf(f, "%s\t%s\t%s\t%s\t%s\t%s\n", git_root ? git_root : "", wt_path ? wt_path : "",
+           branch ? branch : "", sid ? sid : "", work_name ? work_name : "",
+           base_branch ? base_branch : "");
    fclose(f);
 }
 
 void worktree_registry_record(const char *git_root, const char *wt_path, const char *branch,
-                              const char *sid, const char *work_name)
+                              const char *sid, const char *work_name, const char *base_branch)
 {
    if (!git_root || !git_root[0] || !wt_path || !wt_path[0])
       return;
@@ -970,8 +977,8 @@ void worktree_registry_record(const char *git_root, const char *wt_path, const c
    char repo_path[MAX_PATH_LEN], global_path[MAX_PATH_LEN];
    worktree_registry_paths(git_root, repo_path, sizeof(repo_path), global_path,
                            sizeof(global_path));
-   worktree_registry_append(repo_path, git_root, wt_path, branch, sid, work_name);
-   worktree_registry_append(global_path, git_root, wt_path, branch, sid, work_name);
+   worktree_registry_append(repo_path, git_root, wt_path, branch, sid, work_name, base_branch);
+   worktree_registry_append(global_path, git_root, wt_path, branch, sid, work_name, base_branch);
 }
 
 static void worktree_registry_remove_from_file(const char *path, const char *wt_path)
@@ -1264,7 +1271,7 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       struct stat git_st;
       if (stat(git_file, &git_st) == 0)
       {
-         worktree_registry_record(git_root, wt_path, branch_name, sid, work_name);
+         worktree_registry_record(git_root, wt_path, branch_name, sid, work_name, base_branch);
          return 0; /* already exists and valid */
       }
 
@@ -1313,7 +1320,7 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
    {
       fprintf(stderr, "aimee: created worktree at %s\n", wt_path);
       free(out);
-      worktree_registry_record(git_root, wt_path, branch_name, sid, work_name);
+      worktree_registry_record(git_root, wt_path, branch_name, sid, work_name, base_branch);
 
       /* Register branch ownership so other sessions can't write to it.
        * Use the main repo root (git_root), not the worktree path. */
@@ -1337,7 +1344,7 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       {
          LOG_INFO("workspace", "worktree '%s' already present (creation race) - reusing", wt_path);
          free(out);
-         worktree_registry_record(git_root, wt_path, branch_name, sid, work_name);
+         worktree_registry_record(git_root, wt_path, branch_name, sid, work_name, base_branch);
          return 0;
       }
    }
@@ -1357,7 +1364,7 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       fprintf(stderr, "aimee: created worktree at %s (reused branch %s)\n", wt_path, branch_name);
       free(out);
       free(out2);
-      worktree_registry_record(git_root, wt_path, branch_name, sid, work_name);
+      worktree_registry_record(git_root, wt_path, branch_name, sid, work_name, base_branch);
 #ifndef AIMEE_DB1_DISABLED
       mcp_git_branch_own_register(git_root, branch_name);
 #endif

--- a/src/modules/workspace/workspace.c
+++ b/src/modules/workspace/workspace.c
@@ -2,6 +2,7 @@
 #include "aimee.h"
 #include "log.h"
 #include "workspace.h"
+#include "config_accessors.h"
 #include "index.h"
 #include "kb_client.h"
 #include "headers/branch_ownership.h"
@@ -1151,17 +1152,107 @@ int worktree_find_branch_registered(const char *branch, char *out_dir, size_t ou
  * Callers that want a specific base (delegates inheriting a parent, or the
  * session-checkout path that bases on origin/<primary>) pass base_ref instead
  * and never reach here. */
-void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len)
-{
-   if (!git_root || !buf || buf_len == 0)
-      return;
-   snprintf(buf, buf_len, "HEAD"); /* safe default */
+/* Resolve the base ref for a NEW session worktree.
+ *
+ * Order, in full:
+ *   1. CONFIGURED  session_worktree_base / AIMEE_SESSION_WORKTREE_BASE, when it names an
+ *                  explicit ref. Verified to exist rather than handed to git blind.
+ *   2. DEFAULT     the remote's advertised default branch (origin/HEAD), fetched fresh.
+ *   3. main
+ *   4. master
+ * Each of 2-4 prefers the remote-tracking ref (origin/<x>) and accepts the local branch
+ * only when no remote-tracking ref exists, so a repo WITH a remote never silently starts
+ * from a stale local copy.
+ *
+ * What is deliberately NOT in the chain: the currently checked-out branch. The old code
+ * ended at `rev-parse --abbrev-ref HEAD`, so when the shared checkout happened to sit on
+ * some session or feature branch, every new session was cut from it and silently
+ * inherited unmerged work it did not author and could not separate from its own. main and
+ * master are dumb fallbacks but they are STABLE; "whatever is checked out" is not.
+ *
+ * Returns 0 and fills `buf`, or -1 with `buf` emptied when nothing resolves. */
 
-   char cmd[MAX_PATH_LEN + 128];
+/* Resolve one candidate branch NAME to a usable ref, preferring origin/<name>.
+ * Returns 1 and fills out on success. */
+static int wt_resolve_candidate(const char *git_root, const char *name, char *out, size_t outlen)
+{
+   if (!name || !name[0])
+      return 0;
+   char cmd[MAX_PATH_LEN + 160];
    int rc;
 
-   /* Resolve the default branch NAME (short, e.g. "main"). Prefer origin/HEAD;
-    * symbolic-ref --short yields "origin/main", so strip the remote prefix. */
+   char remote_ref[160];
+   snprintf(remote_ref, sizeof(remote_ref), "origin/%s", name);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
+            git_root, remote_ref);
+   free(run_cmd(cmd, &rc));
+   if (rc == 0)
+   {
+      snprintf(out, outlen, "%s", remote_ref);
+      return 1;
+   }
+
+   snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
+            git_root, name);
+   free(run_cmd(cmd, &rc));
+   if (rc == 0)
+   {
+      snprintf(out, outlen, "%s", name);
+      return 1;
+   }
+   return 0;
+}
+
+int worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len)
+{
+   if (!git_root || !buf || buf_len == 0)
+      return -1;
+   buf[0] = '\0';
+
+   char cmd[MAX_PATH_LEN + 160];
+   int rc;
+
+   /* ---- 1. configured ---- */
+   char mode[64] = "";
+   const char *env_mode = getenv("AIMEE_SESSION_WORKTREE_BASE");
+   if (env_mode && env_mode[0])
+      snprintf(mode, sizeof(mode), "%s", env_mode);
+   else
+   {
+      const char *cfg_mode = config_session_worktree_base();
+      snprintf(mode, sizeof(mode), "%s", (cfg_mode && cfg_mode[0]) ? cfg_mode : "remote_default");
+   }
+
+   if (strcmp(mode, "current") == 0)
+   {
+      /* Only reachable by explicit opt-in, for offline/detached workflows that accept
+       * inheriting the source checkout's branch. Never a fallback. */
+      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --abbrev-ref HEAD 2>/dev/null", git_root);
+      char *cur = run_cmd(cmd, &rc);
+      if (rc == 0 && cur && cur[0])
+      {
+         size_t l = strlen(cur);
+         while (l && (cur[l - 1] == '\n' || cur[l - 1] == '\r'))
+            cur[--l] = '\0';
+         if (cur[0])
+            snprintf(buf, buf_len, "%s", cur);
+      }
+      free(cur);
+      return buf[0] ? 0 : -1;
+   }
+   if (strcmp(mode, "remote_default") != 0 && strcmp(mode, "local_default") != 0)
+   {
+      snprintf(cmd, sizeof(cmd),
+               "git -C '%s' rev-parse --verify --quiet '%s^{commit}' >/dev/null 2>&1", git_root,
+               mode);
+      free(run_cmd(cmd, &rc));
+      if (rc != 0)
+         return -1; /* an explicit ref that does not exist is an operator error */
+      snprintf(buf, buf_len, "%s", mode);
+      return 0;
+   }
+
+   /* ---- 2. the remote's advertised default ---- */
    char def[96] = {0};
    snprintf(cmd, sizeof(cmd),
             "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null", git_root);
@@ -1169,7 +1260,7 @@ void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len
    if (rc == 0 && out && out[0])
    {
       size_t len = strlen(out);
-      while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r' || out[len - 1] == ' '))
+      while (len && (out[len - 1] == '\n' || out[len - 1] == '\r' || out[len - 1] == ' '))
          out[--len] = '\0';
       const char *name = out;
       if (strncmp(name, "origin/", 7) == 0)
@@ -1179,68 +1270,58 @@ void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len
    }
    free(out);
 
-   /* Fall back to a common local default branch when origin/HEAD is unset. */
+   /* origin/HEAD is unset on repos whose remote was added after clone -- repair once. */
    if (!def[0])
    {
-      const char *candidates[] = {"main", "master", "trunk"};
-      for (int b = 0; b < 3; b++)
+      const char *setargv[] = {"remote", "set-head", "origin", "-a", NULL};
+      git_net_exec(git_root, setargv, NULL, 0);
+      snprintf(cmd, sizeof(cmd),
+               "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null", git_root);
+      out = run_cmd(cmd, &rc);
+      if (rc == 0 && out && out[0])
       {
-         snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
-                  git_root, candidates[b]);
-         char *cand_out = run_cmd(cmd, &rc);
-         free(cand_out);
-         if (rc == 0)
-         {
-            snprintf(def, sizeof(def), "%s", candidates[b]);
-            break;
-         }
+         size_t len = strlen(out);
+         while (len && (out[len - 1] == '\n' || out[len - 1] == '\r' || out[len - 1] == ' '))
+            out[--len] = '\0';
+         const char *name = out;
+         if (strncmp(name, "origin/", 7) == 0)
+            name += 7;
+         if (name[0])
+            snprintf(def, sizeof(def), "%s", name);
       }
+      free(out);
    }
 
    if (def[0])
    {
-      /* Refresh the default branch from origin so the worktree starts from the
-       * latest upstream, not a stale local copy. Best-effort and hang-proof
-       * (git_net_exec bounds the wall clock): a remote-less or offline repo just
-       * leaves the existing refs untouched. */
+      /* Start from the latest upstream. Best-effort and hang-proof; offline leaves the
+       * existing remote-tracking ref in place. */
       const char *fetch_argv[] = {"fetch", "--quiet", "origin", def, NULL};
       git_net_exec(git_root, fetch_argv, NULL, 0);
 
-      /* Prefer the freshly fetched remote-tracking ref; fall back to the local
-       * branch when there is no upstream (purely local repo). */
-      char remote_ref[128];
-      snprintf(remote_ref, sizeof(remote_ref), "origin/%s", def);
-      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
-               git_root, remote_ref);
-      free(run_cmd(cmd, &rc));
-      if (rc == 0)
+      if (strcmp(mode, "local_default") == 0)
       {
-         snprintf(buf, buf_len, "%s", remote_ref);
-         return;
+         snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
+                  git_root, def);
+         free(run_cmd(cmd, &rc));
+         if (rc == 0)
+         {
+            snprintf(buf, buf_len, "%s", def);
+            return 0;
+         }
       }
-
-      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
-               git_root, def);
-      free(run_cmd(cmd, &rc));
-      if (rc == 0)
-      {
-         snprintf(buf, buf_len, "%s", def);
-         return;
-      }
+      else if (wt_resolve_candidate(git_root, def, buf, buf_len))
+         return 0;
    }
 
-   /* Last resort: the current branch (may be detached -> stays "HEAD"). */
-   snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --abbrev-ref HEAD 2>/dev/null", git_root);
-   out = run_cmd(cmd, &rc);
-   if (rc == 0 && out && out[0])
-   {
-      size_t len = strlen(out);
-      while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r'))
-         out[--len] = '\0';
-      if (len > 0 && strcmp(out, "HEAD") != 0)
-         snprintf(buf, buf_len, "%s", out);
-   }
-   free(out);
+   /* ---- 3. main, then 4. master ---- */
+   if (wt_resolve_candidate(git_root, "main", buf, buf_len))
+      return 0;
+   if (wt_resolve_candidate(git_root, "master", buf, buf_len))
+      return 0;
+
+   buf[0] = '\0';
+   return -1;
 }
 
 static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
@@ -1271,7 +1352,7 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       struct stat git_st;
       if (stat(git_file, &git_st) == 0)
       {
-         worktree_registry_record(git_root, wt_path, branch_name, sid, work_name, base_branch);
+         worktree_registry_record(git_root, wt_path, branch_name, sid, work_name, base_ref);
          return 0; /* already exists and valid */
       }
 
@@ -1290,7 +1371,18 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
        * branch so a fresh session always starts from there rather than from
        * whatever branch the source checkout happens to have checked out.
        * Falls back to main / master / trunk / HEAD when no default is known. */
-      worktree_detect_base_branch(git_root, base_branch, sizeof(base_branch));
+      /* Remote default by policy. A hard failure here is deliberate: guessing a base
+       * is what let sessions inherit another session's branch. */
+      if (worktree_detect_base_branch(git_root, base_branch, sizeof(base_branch)) != 0)
+      {
+         fprintf(stderr,
+                 "aimee: cannot resolve the session worktree base for '%s'. The default is the "
+                 "REMOTE default branch (origin/HEAD); it is unset or unreachable here. Fix the "
+                 "remote (git remote set-head origin -a) or set session_worktree_base / "
+                 "AIMEE_SESSION_WORKTREE_BASE to an explicit ref.\n",
+                 git_root);
+         return -1;
+      }
    }
 
    char wt_parent[MAX_PATH_LEN];
@@ -1510,7 +1602,7 @@ int worktree_create_sibling_on_branch(const char *git_root, const char *sid, con
       struct stat git_st;
       if (stat(git_file, &git_st) == 0)
       {
-         worktree_registry_record(git_root, wt_path, branch, sid, work_name);
+         worktree_registry_record(git_root, wt_path, branch, sid, work_name, branch);
          return 0;
       }
       rmdir(wt_path);
@@ -1535,7 +1627,8 @@ int worktree_create_sibling_on_branch(const char *git_root, const char *sid, con
    {
       fprintf(stderr, "aimee: created worktree at %s on branch %s\n", wt_path, branch);
       free(out);
-      worktree_registry_record(git_root, wt_path, branch, sid, work_name);
+      /* Attaching an EXISTING branch: the worktree is rooted on that branch itself. */
+      worktree_registry_record(git_root, wt_path, branch, sid, work_name, branch);
 #ifndef AIMEE_DB1_DISABLED
       mcp_git_branch_own_register(git_root, branch);
 #endif

--- a/src/modules/workspace/workspace.h
+++ b/src/modules/workspace/workspace.h
@@ -86,7 +86,7 @@ int worktree_apply_delegate_changes_checked(const char *delegate_wt, const char 
                                             char *parent_root, size_t parent_root_len, char *err,
                                             size_t err_len);
 void worktree_registry_record(const char *git_root, const char *wt_path, const char *branch,
-                              const char *sid, const char *work_name);
+                              const char *sid, const char *work_name, const char *base_branch);
 int worktree_find_branch_in_repo(const char *git_root, const char *branch, char *out_dir,
                                  size_t out_len);
 int worktree_find_branch_registered(const char *branch, char *out_dir, size_t out_len);

--- a/src/modules/workspace/workspace.h
+++ b/src/modules/workspace/workspace.h
@@ -97,7 +97,10 @@ const char *worktree_for_cwd(const session_state_t *state, const char *cwd);
  * Prefers the repository's DEFAULT branch (origin/HEAD), then local
  * main/master/trunk, then the current HEAD as a last resort. Writes result
  * into buf (at most buf_len bytes including NUL). */
-void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len);
+/* Resolve the base ref for a new session worktree: the REMOTE default branch (e.g.
+ * "origin/testing"). Returns 0 and fills buf, or -1 with buf empty when no remote default
+ * is resolvable -- callers must then refuse to create the worktree rather than guess. */
+int worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len);
 
 /* Count active aimee-managed worktrees for git_root. */
 int count_active_worktrees_for_root(const char *git_root);

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -297,6 +297,63 @@ static void test_session_isolation_decision(void)
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, primary, primary_cwd, NULL) == 1);
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, primary, wt_cwd, NULL) == 1);
 
+   /* ---- branch lineage (attn_session_branch_blocked) ----
+    * The path check alone was the bug: a hand-made worktree under .claude/worktrees/
+    * passed it while sitting on a branch cut from another session's commit. */
+
+   /* Primary rooted on the default branch: allowed, in both spellings. */
+   assert(attn_session_branch_blocked("testing", "testing", 0) == 0);
+   assert(attn_session_branch_blocked("origin/testing", "testing", 0) == 0);
+   assert(attn_session_branch_blocked("testing", "origin/testing", 0) == 0);
+
+   /* Delegate rooted on a REGISTERED parent session branch: allowed. */
+   assert(attn_session_branch_blocked("aimee/session/parent-abc", "testing", 1) == 0);
+
+   /* The bug: rooted on another session's branch that is NOT its parent. */
+   assert(attn_session_branch_blocked("aimee/session/someone-else", "testing", 0) == 1);
+
+   /* Unregistered worktree -- no launcher row, so hand-rolled. Fail closed. */
+   assert(attn_session_branch_blocked("", "testing", 0) == 1);
+   assert(attn_session_branch_blocked(NULL, "testing", 0) == 1);
+
+   /* Unresolvable default branch must not silently allow an arbitrary base. */
+   assert(attn_session_branch_blocked("aimee/session/whatever", "", 0) == 1);
+   /* ...but a registered parent is still a legitimate delegate. */
+   assert(attn_session_branch_blocked("aimee/session/whatever", "", 1) == 0);
+
+   /* ---- Bash reaching outside the worktree (attn_bash_escapes_worktree) ----
+    * The observed bypass: cwd was a valid managed worktree, so the isolation check
+    * passed, while the command cd'd to the shared checkout and wrote there. */
+   {
+      const char *wt = "/home/u/repo/.claude/worktrees/w1";
+      /* THE BUG, verbatim in shape. */
+      assert(attn_bash_escapes_worktree("cd /home/u/repo && python3 - <<'EOF'\nx\nEOF", wt) == 1);
+      assert(attn_bash_escapes_worktree("cd /home/u/repo && sed -i s/a/b/ f.c", wt) == 1);
+      /* Redirect out. */
+      assert(attn_bash_escapes_worktree("echo hi > /home/u/repo/src/f.c", wt) == 1);
+      assert(attn_bash_escapes_worktree("tee /etc/thing < x", wt) == 1);
+
+      /* Staying inside a managed worktree is fine, cd or redirect. */
+      assert(attn_bash_escapes_worktree(
+                 "cd /home/u/repo/.claude/worktrees/w1/src && sed -i s/a/b/ f.c", wt) == 0);
+      assert(attn_bash_escapes_worktree(
+                 "echo hi > /home/u/repo/.aimee/worktrees/s1/main/f.c", wt) == 0);
+      /* Relative work never leaves by construction. */
+      assert(attn_bash_escapes_worktree("cd src && sed -i s/a/b/ f.c", wt) == 0);
+
+      /* Read-only commands are untouched even when they name outside paths. */
+      assert(attn_bash_escapes_worktree("cat /etc/hosts", wt) == 0);
+      assert(attn_bash_escapes_worktree("cd /home/u/repo && git log", wt) == 0);
+
+      /* Noise that must not false-positive: fd dups, /dev/null, a bare "cd". */
+      assert(attn_bash_escapes_worktree("make 2>&1 | tee out.log", wt) == 0);
+      assert(attn_bash_escapes_worktree("rm -f x > /dev/null 2>&1", wt) == 0);
+      /* "cd" as a substring of another word is not a chdir. */
+      assert(attn_bash_escapes_worktree("rm -f /tmp/abcd /x", wt) == 1);
+      assert(attn_bash_escapes_worktree("echo included > out.txt", wt) == 0);
+   }
+
+
    /* Relative / no file_path -> cwd is authoritative. */
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", wt_cwd, NULL) == 0);
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", primary_cwd, NULL) == 1);

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -336,8 +336,8 @@ static void test_session_isolation_decision(void)
       /* Staying inside a managed worktree is fine, cd or redirect. */
       assert(attn_bash_escapes_worktree(
                  "cd /home/u/repo/.claude/worktrees/w1/src && sed -i s/a/b/ f.c", wt) == 0);
-      assert(attn_bash_escapes_worktree(
-                 "echo hi > /home/u/repo/.aimee/worktrees/s1/main/f.c", wt) == 0);
+      assert(attn_bash_escapes_worktree("echo hi > /home/u/repo/.aimee/worktrees/s1/main/f.c",
+                                        wt) == 0);
       /* Relative work never leaves by construction. */
       assert(attn_bash_escapes_worktree("cd src && sed -i s/a/b/ f.c", wt) == 0);
 
@@ -352,7 +352,6 @@ static void test_session_isolation_decision(void)
       assert(attn_bash_escapes_worktree("rm -f /tmp/abcd /x", wt) == 1);
       assert(attn_bash_escapes_worktree("echo included > out.txt", wt) == 0);
    }
-
 
    /* Relative / no file_path -> cwd is authoritative. */
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", wt_cwd, NULL) == 0);

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -693,6 +693,49 @@ else
     fail "Makefile DB boundary regressions:$make_boundary_failures"
 fi
 
+# 7f-bis. Header dependency tracking must cover every compiled object.
+#
+# DEPS was $(ALL_OBJS:.o=.d). Objects reachable only as a direct prerequisite of a
+# test target were in no *_OBJS variable, so their .d files were never included:
+# ~959 of 2033 objects had NO header tracking. Editing a header then left them
+# stale, and a stale object built against an older struct layout links cleanly and
+# then crashes on a field offset at runtime. That is how unit-test-memory came to
+# segfault on a tree whose tests all "passed".
+#
+# Two assertions: the wiring is structurally correct, and -- when a build tree is
+# present -- it empirically covers every .d on disk.
+dep_failures=""
+deps_assign=$(grep -E '^DEPS[[:space:]]*=' "$makefile_file" || true)
+if [ -z "$deps_assign" ]; then
+    dep_failures="$dep_failures deps-unassigned"
+elif ! echo "$deps_assign" | grep -Fq '$(OBJDIR)'; then
+    # A purely variable-derived DEPS can only ever cover hand-listed objects.
+    dep_failures="$dep_failures deps-not-discovered-from-objdir"
+fi
+
+objdir=$(sed -n 's/^OBJDIR[[:space:]]*=[[:space:]]*\(.*\)$/\1/p' "$makefile_file" | head -1)
+[ -n "$objdir" ] || objdir="build/obj"
+if find "$objdir" -name '*.d' 2>/dev/null | grep -q .; then
+    printf 'print-%%:\n\t@echo $($%s)\n' '*' > /tmp/aimee_bi_print.mk 2>/dev/null ||
+        : # non-writable /tmp: the structural check above still stands
+    if [ -f /tmp/aimee_bi_print.mk ]; then
+        find "$objdir" -name '*.d' | sort -u > /tmp/aimee_bi_ondisk.txt
+        make -f "$makefile_file" -f /tmp/aimee_bi_print.mk print-DEPS 2>/dev/null |
+            tr ' ' '\n' | grep '\.d$' | sort -u > /tmp/aimee_bi_included.txt
+        uncovered=$(comm -13 /tmp/aimee_bi_included.txt /tmp/aimee_bi_ondisk.txt | wc -l)
+        if [ "$uncovered" -ne 0 ]; then
+            dep_failures="$dep_failures $uncovered-objects-without-header-tracking"
+        fi
+        rm -f /tmp/aimee_bi_print.mk /tmp/aimee_bi_ondisk.txt /tmp/aimee_bi_included.txt
+    fi
+fi
+
+if [ -z "$dep_failures" ]; then
+    pass "every compiled object has header dependency tracking"
+else
+    fail "header dependency tracking gaps:$dep_failures"
+fi
+
 # 7g. The KB service split must keep explicit module-boundary directories and
 # container packaging for the headless aimee-kb deployment shape.
 split_failures=""

--- a/src/tests/test_config_field_eligibility.c
+++ b/src/tests/test_config_field_eligibility.c
@@ -77,6 +77,7 @@ static const elig_row_t g_eligibility[] = {
     {"code_span_max_lines", 0},
     {"tool_output_max_bytes", 0},
     {"require_session_worktree", 1},
+    {"session_worktree_base", 0},
     {"require_aimee_memory", 1},
     {"require_aimee_git", 1},
     {"subagent_ban_enabled", 1},

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -496,7 +496,7 @@ static void test_worktree_detect_base_branch_active(void)
    (void)system(cmd);
 
    char branch[64];
-   worktree_detect_base_branch(tmpdir, branch, sizeof(branch));
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
    assert(strcmp(branch, "origin/main") == 0);
 
    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
@@ -505,8 +505,10 @@ static void test_worktree_detect_base_branch_active(void)
 
 static void test_worktree_detect_base_branch_local_default(void)
 {
-   /* With no remote default set, fall back to a local default branch (main),
-    * still in preference to the checked-out feature branch. */
+   /* No remote default set. The old behaviour fell back to the local "main"; that
+    * fallback is REMOVED -- a stale or unrelated local branch is exactly how a session
+    * inherited work it did not author. Default is now a hard failure, and the local
+    * branch is reachable only by explicitly opting in. */
    char tmpdir[] = "/tmp/test_wt_localdef_XXXXXX";
    if (mkdtemp(tmpdir) == NULL)
    {
@@ -531,8 +533,23 @@ static void test_worktree_detect_base_branch_local_default(void)
    (void)system(cmd);
 
    char branch[64];
-   worktree_detect_base_branch(tmpdir, branch, sizeof(branch));
+   /* No remote default -> the chain falls through to "main". Crucially NOT to the
+    * checked-out feat/test-branch: main is a dumb fallback but a stable one. */
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
    assert(strcmp(branch, "main") == 0);
+
+   setenv("AIMEE_SESSION_WORKTREE_BASE", "local_default", 1);
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "main") == 0);
+
+   /* An explicit ref is honoured verbatim; a bogus one is refused rather than guessed. */
+   setenv("AIMEE_SESSION_WORKTREE_BASE", "main", 1);
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "main") == 0);
+   setenv("AIMEE_SESSION_WORKTREE_BASE", "no/such/ref", 1);
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == -1);
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
 
    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
    (void)system(cmd);
@@ -540,11 +557,185 @@ static void test_worktree_detect_base_branch_local_default(void)
 
 static void test_worktree_detect_base_branch_fallback(void)
 {
-   /* Non-existent path: should fall back to "HEAD" */
+   /* Non-existent path: no remote default, no main, no master -> refuse. The old code
+    * fell back to "HEAD", i.e. whatever the caller happened to be sitting on. */
    char branch[64];
-   worktree_detect_base_branch("/tmp/__nonexistent_aimee_test_repo__", branch, sizeof(branch));
-   /* Any value is acceptable — just verify it doesn't crash and is non-empty */
-   assert(branch[0] != '\0');
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
+   assert(worktree_detect_base_branch("/tmp/__nonexistent_aimee_test_repo__", branch,
+                                      sizeof(branch)) == -1);
+   assert(branch[0] == '\0');
+}
+
+/* Gap tests for the base-ref chain: configured -> remote default -> main -> master.
+ * The existing three tests cover "remote default wins over the checked-out branch",
+ * "no remote -> main", and "nothing -> refuse". These cover the rungs between. */
+
+static void wt_fixture_init(const char *dir)
+{
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "git -C '%s' init -q 2>/dev/null", dir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' config user.email 'test@test.com' 2>/dev/null", dir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' config user.name 'Test' 2>/dev/null", dir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd),
+            "touch '%s/x' && git -C '%s' add x && git -C '%s' commit -qm 'init' 2>/dev/null", dir,
+            dir, dir);
+   (void)system(cmd);
+}
+
+static void test_worktree_detect_base_branch_master_fallback(void)
+{
+   /* No remote default and no "main" -- the chain's last rung is "master". A repo
+    * predating the main rename must still resolve rather than refuse. */
+   char tmpdir[] = "/tmp/test_wt_master_XXXXXX";
+   if (mkdtemp(tmpdir) == NULL)
+   {
+      fprintf(stderr, "test_worktree_detect_base_branch_master_fallback: mkdtemp failed, "
+                      "skipping\n");
+      return;
+   }
+   wt_fixture_init(tmpdir);
+
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -m master 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' checkout -qb 'feat/x' 2>/dev/null", tmpdir);
+   (void)system(cmd);
+
+   char branch[64];
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "master") == 0);
+
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   (void)system(cmd);
+}
+
+static void test_worktree_detect_base_branch_main_precedes_master(void)
+{
+   /* Both main and master exist, no remote default. Order is main THEN master, so a
+    * repo carrying a legacy master branch alongside main must still pick main. */
+   char tmpdir[] = "/tmp/test_wt_bothdef_XXXXXX";
+   if (mkdtemp(tmpdir) == NULL)
+   {
+      fprintf(stderr, "test_worktree_detect_base_branch_main_precedes_master: mkdtemp failed, "
+                      "skipping\n");
+      return;
+   }
+   wt_fixture_init(tmpdir);
+
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -m main 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch master 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' checkout -qb 'feat/x' 2>/dev/null", tmpdir);
+   (void)system(cmd);
+
+   char branch[64];
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "main") == 0);
+
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   (void)system(cmd);
+}
+
+static void test_worktree_detect_base_branch_configured_beats_remote(void)
+{
+   /* The configured value is rung ONE: it must win even when a remote default exists.
+    * The existing configured-value assertions run in a remote-less fixture, so they
+    * cannot distinguish "configured won" from "fell through to the same name". */
+   char tmpdir[] = "/tmp/test_wt_cfgwins_XXXXXX";
+   if (mkdtemp(tmpdir) == NULL)
+   {
+      fprintf(stderr, "test_worktree_detect_base_branch_configured_beats_remote: mkdtemp failed, "
+                      "skipping\n");
+      return;
+   }
+   wt_fixture_init(tmpdir);
+
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -m main 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' update-ref refs/remotes/origin/main HEAD 2>/dev/null",
+            tmpdir);
+   (void)system(cmd);
+   snprintf(
+       cmd, sizeof(cmd),
+       "git -C '%s' symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null",
+       tmpdir);
+   (void)system(cmd);
+   /* A branch that is neither the remote default nor a fallback name. */
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch release/v1 2>/dev/null", tmpdir);
+   (void)system(cmd);
+
+   char branch[64];
+   setenv("AIMEE_SESSION_WORKTREE_BASE", "release/v1", 1);
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "release/v1") == 0);
+
+   /* And with the override cleared the same repo resolves to the remote default --
+    * proving the assertion above measured the override, not the fixture. */
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "origin/main") == 0);
+
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   (void)system(cmd);
+}
+
+static void test_worktree_detect_base_branch_remote_preference_scope(void)
+{
+   /* "Local default DOES NOT MATTER. Only the remote default matters." That rule binds
+    * the DERIVED rungs -- the advertised default, then main, then master -- which all
+    * resolve through origin/<name> first, because a local branch of the same name may
+    * sit at a different commit and that is exactly how a session inherits unmerged work.
+    *
+    * An operator's explicit ref is deliberately NOT rewritten: they named a ref, and if
+    * they want the remote one they write "origin/main". This test pins both halves so
+    * the asymmetry is a decision on record rather than an accident. */
+   char tmpdir[] = "/tmp/test_wt_remotepref_XXXXXX";
+   if (mkdtemp(tmpdir) == NULL)
+   {
+      fprintf(stderr, "test_worktree_detect_base_branch_prefers_remote_ref: mkdtemp failed, "
+                      "skipping\n");
+      return;
+   }
+   wt_fixture_init(tmpdir);
+
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -m main 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   /* Advance local main one commit so it and origin/main differ. */
+   snprintf(cmd, sizeof(cmd), "git -C '%s' update-ref refs/remotes/origin/main HEAD 2>/dev/null",
+            tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd),
+            "touch '%s/y' && git -C '%s' add y && git -C '%s' commit -qm 'local only' 2>/dev/null",
+            tmpdir, tmpdir, tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' checkout -qb 'feat/x' 2>/dev/null", tmpdir);
+   (void)system(cmd);
+
+   char branch[64];
+   /* Derived rung: no override, no advertised default -> falls to "main", and that
+    * candidate resolves to the remote-tracking ref even though a LOCAL main exists at
+    * a different commit. This is the assertion the isolation rule actually rests on. */
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "origin/main") == 0);
+
+   /* Explicit rung: honoured verbatim, NOT rewritten to origin/main. */
+   setenv("AIMEE_SESSION_WORKTREE_BASE", "main", 1);
+   assert(worktree_detect_base_branch(tmpdir, branch, sizeof(branch)) == 0);
+   assert(strcmp(branch, "main") == 0);
+   unsetenv("AIMEE_SESSION_WORKTREE_BASE");
+
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   (void)system(cmd);
 }
 
 /* --- session_isolation_target: catches the regression where concurrent
@@ -573,6 +764,25 @@ static void session_isolation_make_repo(char *tmpdir, size_t tmpdir_len)
    snprintf(cmd, sizeof(cmd),
             "touch '%s/x' && git -C '%s' add x && git -C '%s' commit -qm 'init' 2>/dev/null", repo,
             repo, repo);
+   (void)system(cmd);
+
+   /* Give the fixture a real origin with an advertised default branch. Session worktrees
+    * are cut from the REMOTE default by policy, so a remote-less fixture would exercise
+    * the refusal path rather than the normal one. */
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -m main 2>/dev/null", repo);
+   (void)system(cmd);
+   /* --initial-branch so the bare repo's HEAD names a ref that will actually exist
+    * after the push; otherwise it points at a nonexistent "master" and
+    * `remote set-head -a` cannot determine the remote HEAD. */
+   snprintf(cmd, sizeof(cmd),
+            "git init -q --bare --initial-branch=main '%s/origin.git' 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' remote add origin '%s/origin.git' 2>/dev/null", repo,
+            tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' push -q origin main 2>/dev/null", repo);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' remote set-head origin -a >/dev/null 2>&1", repo);
    (void)system(cmd);
 }
 
@@ -3508,6 +3718,10 @@ int main(void)
    test_worktree_detect_base_branch_active();
    test_worktree_detect_base_branch_local_default();
    test_worktree_detect_base_branch_fallback();
+   test_worktree_detect_base_branch_master_fallback();
+   test_worktree_detect_base_branch_main_precedes_master();
+   test_worktree_detect_base_branch_configured_beats_remote();
+   test_worktree_detect_base_branch_remote_preference_scope();
    test_session_isolation_creates_and_returns_worktree();
    test_session_isolation_sanitizes_malicious_sid();
    test_session_isolation_skips_when_already_in_same_session_worktree();


### PR DESCRIPTION
Two independent fixes found while investigating why a session edited the shared checkout.

## 1. Session branch lineage was never enforced

The attention guard verified only that the working path *looked* like a managed worktree, while its comment claimed the branch was cut from the default branch. A worktree branched off another session's unmerged work passed cleanly.

The worktree registry now records the base ref (6th column, written by the launcher — not an env var the agent could set). `attn_session_branch_blocked()` enforces primary-off-default / delegate-off-registered-parent.

Upgrade-safe via tri-state registry lookup: no registry → don't enforce; registry without a row → block; legacy 5-field rows → grandfathered. Without this, every pre-existing worktree would have been locked out.

## 2. Bash could leave the worktree

`cd /repo && python3 - <<EOF` ran against the shared checkout from inside a valid worktree. This is how the shared checkout actually got edited during this work — the bug was found by committing it.

`attn_bash_escapes_worktree()` catches chdir to an outside absolute path, redirects outside, and absolute arguments to write-target verbs (`tee`, `truncate`, `mkdir`, `rm`, …; deliberately not `cp`/`mv`/`rsync`).

**This is pattern matching, not a sandbox**, and is documented as such. It raises the cost of an accidental escape; it does not stop a determined one. Read-only commands outside the worktree stay allowed.

## 3. Base ref resolution: configured → remote default → main → master

`worktree_detect_base_branch()` returns `int` and prefers `origin/<name>` at each derived rung, so a repo with a remote never starts from a stale local branch.

**The current branch is removed from the chain.** It used to be the last resort, which meant a new session was cut from whatever the shared checkout happened to be sitting on — silently inheriting another session's unmerged work. `main`/`master` are dumb fallbacks but stable ones. Current remains reachable only via explicit `current` mode.

An operator's explicit ref is honoured verbatim rather than rewritten to `origin/<ref>` — they named a ref; if they want the remote one they write it.

Configurable as `session_worktree_base` (config file, CLI, Web GUI, `AIMEE_SESSION_WORKTREE_BASE`).

## 4. Header dependency tracking covered 53% of objects

Separate commit, much wider blast radius.

`DEPS` came from `ALL_OBJS`, a hand-maintained union of 25 `*_OBJS` variables. Objects reachable only as a direct prerequisite of a test target were in none of them — **959 of 2033 objects had no header dependency tracking**. Edit a header, and make never rebuilds them.

The failure mode is silent: a stale object built against an older struct layout links cleanly against fresh ones, then crashes on a field offset. `unit-test-memory` segfaulted with a null indirect call exactly this way, on a tree whose tests otherwise all passed — `memory_core_search.o` held the previous `config_t` while `memory_core.o` beside it had the new one.

Fix discovers `.d` files under `OBJDIR`, making coverage a property of what was compiled rather than of bookkeeping.

## Verification

- Full serial unit suite: **670 binaries, exit 0**, no failures
- Dep-tracking check verified red/green — fails structurally on the old `DEPS`, and reports 959 uncovered objects against a populated build tree
- New base-ref tests mutation-checked to confirm they are not vacuous
- Both guard decision functions tested in both directions, including the exact escape committed during this work

## Not covered

The bash escape check is heuristic. It does not cover `env -C`, shells spawned from scripts, or paths reached via symlink.