### PR TITLE
Fix the clean-install wizard Deploy failure (first-user bootstrap)

### DIFF
--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -2123,6 +2123,19 @@ int config_reload(void)
       pthread_mutex_unlock(&g_snap_wlock);
       return -1; /* parse failure -> keep the running snapshot */
    }
+   /* The published snapshot must equal what config_load() returns, and config_load
+    * is config_load_file + this. Without it a reload publishes a snapshot with every
+    * Vault-only secret blanked, because config_load_file may serve the process cache
+    * and skip the parse that rehydrates them.
+    *
+    * That is not hypothetical: the server mints the API primary bearer AFTER its
+    * first config_load, so the cache still holds the pre-mint config. The 1s
+    * config_reload_if_changed tick then republished that stale copy over the good
+    * snapshot seeded by config_snapshot_init, leaving server_api_bearer_token empty
+    * and failing first-user bootstrap on every clean install (the wizard's Deploy
+    * step returned 500). Applied before the token so an unchanged reload stays a
+    * no-op rather than churning the snapshot. */
+   config_apply_runtime_secrets(&fresh);
    uint64_t tok = config_snapshot_token(&fresh);
    if (atomic_load_explicit(&g_snap_inited, memory_order_acquire) && tok == g_snap_token)
    {

--- a/src/server/server_bearer_auth.c
+++ b/src/server/server_bearer_auth.c
@@ -17,6 +17,7 @@
 
 #include "config.h"
 #include "db1/remote_client_grant.h"
+#include "log.h"
 #include "platform_random.h"
 #include "runtime_secret.h"
 #include "vault_config_bootstrap.h"
@@ -185,13 +186,24 @@ static int first_user_bootstrap_locked(const char *principal, char *bearer, size
       bearer[0] = '\0';
    if (!principal || strncmp(principal, "webuser:", 8) != 0 || !principal[8] || !bearer ||
        bearer_cap < 65)
+   {
+      aimee_log(LOG_ERROR, "first_user", "bootstrap rejected: caller is not a webchat user");
       return -1;
+   }
 
    char configured[AIMEE_API_BEARER_EXTRA_MAX][256];
    int configured_count = configured_bearer_snapshot(configured);
    if (configured_count < 0 || !config_server_api_bearer_token()[0] ||
        config_server_api_mtls() <= 0)
+   {
+      /* Name the specific precondition: all three used to fail identically and
+       * silently, which is what made a clean-install failure undiagnosable. */
+      aimee_log(LOG_ERROR, "first_user",
+                "bootstrap rejected: extras_snapshot=%d primary_bearer=%s mtls=%d",
+                configured_count, config_server_api_bearer_token()[0] ? "present" : "MISSING",
+                config_server_api_mtls());
       return -1;
+   }
 
    /* A proposed value is required by the atomic DB1 claim even when this call
     * discovers an earlier pending/bound record. It is never published unless
@@ -199,7 +211,12 @@ static int first_user_bootstrap_locked(const char *principal, char *bearer, size
    char proposed[65] = "";
    char proposed_hash[65] = "";
    if (platform_random_hex(proposed, 64) != 0 || bearer_sha256(proposed, proposed_hash) != 0)
+   {
+      aimee_log(LOG_ERROR, "first_user",
+                "bootstrap failed: could not generate the enrollment "
+                "bearer (RNG or digest failure)");
       goto done;
+   }
 
    db1_remote_client_grant_t grant;
    db1_remote_client_claim_result_t claimed =
@@ -226,13 +243,21 @@ static int first_user_bootstrap_locked(const char *principal, char *bearer, size
        * never authenticated and is safe to abandon; retry once with the newly
        * generated value rather than leaving setup permanently wedged. */
       if (db1_remote_client_abandon(grant.bearer_sha256) != 0)
+      {
+         aimee_log(LOG_ERROR, "first_user",
+                   "bootstrap failed: could not abandon the stale unbound grant in DB1");
          goto done;
+      }
       claimed = db1_remote_client_claim(principal, proposed_hash, (int64_t)time(NULL), &grant);
    }
    if (claimed != DB1_REMOTE_CLIENT_CLAIM_NEW || configured_count >= AIMEE_API_BEARER_EXTRA_MAX)
    {
       if (claimed == DB1_REMOTE_CLIENT_CLAIM_NEW)
          (void)db1_remote_client_abandon(proposed_hash);
+      aimee_log(LOG_ERROR, "first_user",
+                "bootstrap failed: DB1 claim=%d (expected NEW=%d), configured_extras=%d/%d",
+                (int)claimed, (int)DB1_REMOTE_CLIENT_CLAIM_NEW, configured_count,
+                AIMEE_API_BEARER_EXTRA_MAX);
       goto done;
    }
 
@@ -241,6 +266,8 @@ static int first_user_bootstrap_locked(const char *principal, char *bearer, size
    if (vault_runtime_secret_set(vault_name, proposed) != 0)
    {
       (void)db1_remote_client_abandon(proposed_hash);
+      aimee_log(LOG_ERROR, "first_user",
+                "bootstrap failed: Vault refused to seal the enrollment bearer as %s", vault_name);
       goto done;
    }
    publish_configured_bearers();

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -12,6 +12,12 @@
 #include "config_sections.h"
 #include "platform_path.h"
 #include "platform_test_util.h"
+#include "runtime_secret.h"
+
+/* One staging buffer shared by the cases that must hand a whole config to
+ * config_snapshot_init. Reused rather than redeclared: config_t is ~750 KB and
+ * every mention of the type is tracked debt (check-config-encapsulation.py). */
+static config_t g_stage;
 
 /* P3 re-applier probe. */
 static _Atomic int g_reapply_calls = 0;
@@ -190,10 +196,9 @@ int main(void)
    /* --- init + get roundtrip --- */
    write_marker(1, 1111);
    {
-      static config_t c0;
-      memset(&c0, 0, sizeof c0);
-      config_load(&c0);
-      config_snapshot_init(&c0);
+      memset(&g_stage, 0, sizeof g_stage);
+      config_load(&g_stage);
+      config_snapshot_init(&g_stage);
       config_t got;
       assert(config_snapshot_get(&got) == 0);
       assert(got.economizer_mode == ECON_MODE_SAFE);
@@ -214,6 +219,45 @@ int main(void)
    }
    /* reloading the same file again is a no-op */
    assert(config_reload() == 0);
+
+   /* --- a reload must not blank Vault-only secrets in the published snapshot ---
+    *
+    * These live only in the runtime secret store, never in aimee.yaml, so they are
+    * reapplied by config_load. config_reload published config_load_file's result
+    * directly, and config_load_file may serve the process cache and skip the parse
+    * that rehydrates them — so a reload republished a snapshot with the secret
+    * blank. On the appliance that emptied the minted API primary bearer one second
+    * after boot and failed first-user bootstrap on every clean install.
+    *
+    * The store is seeded AFTER the snapshot is initialised on purpose: that is the
+    * real ordering (server_main mints the primary after its first config_load). */
+   {
+      /* The file-read cache must be live: it is the thing that skips the parse.
+       * The rest of this test disables it for determinism. */
+      platform_unsetenv("AIMEE_NO_CACHE");
+      write_marker(1, 4444); /* file and cache now agree, with no bearer in either */
+
+      /* Mint exactly as server_main does AFTER that load: into the runtime store
+       * and into the config it seeds the snapshot with, but never into aimee.yaml. */
+      assert(runtime_secret_store("AIMEE_API_BEARER_TOKEN", "vault-only-primary") == 0);
+      assert(config_snapshot_get(&g_stage) == 0);
+      snprintf(g_stage.server_api_bearer_token, sizeof(g_stage.server_api_bearer_token), "%s",
+               "vault-only-primary");
+      config_snapshot_init(&g_stage);
+      assert(strcmp(config_server_api_bearer_token(), "vault-only-primary") == 0);
+
+      /* The 1s tick reloads with the file UNCHANGED, so config_load_file serves the
+       * cached pre-mint copy and never re-parses. Publishing that blanked the bearer. */
+      config_reload();
+      assert(config_snapshot_get(&g_stage) == 0);
+      assert(g_stage.coord_closet_budget_bytes == 4444); /* still the reloaded config */
+      assert(strcmp(g_stage.server_api_bearer_token, "vault-only-primary") == 0);
+      /* first-user bootstrap gates on the accessor, so assert that path too. */
+      assert(strcmp(config_server_api_bearer_token(), "vault-only-primary") == 0);
+
+      runtime_secret_remove("AIMEE_API_BEARER_TOKEN");
+      platform_setenv("AIMEE_NO_CACHE", "1");
+   }
 
    /* --- P3 re-applier registry: a hook fires after a changed reload, with the NEW config --- */
    {


### PR DESCRIPTION
A from-scratch appliance install could not complete the setup wizard.
`POST /v1/deploy/apply` returned 500, `could not provision the first user
(bearer, mTLS, and full-write grant)`, and produced **no diagnostic at all** —
every failure path in `first_user_bootstrap_locked` was a bare `goto` with no
log line. It only started working after `aimee api enable`, an unrelated
recovery command no operator would think to run.

## Root cause

Observed on a clean `.211` install, not inferred:

```
parse_server_api runtime_secret_get=0       <- the first real parse, BEFORE the mint
config_load_file CACHE HIT, bearer=MISSING  <- the 1s reload tick
config: config file change: reloaded        <- publishes the empty-bearer config
first_user: bootstrap rejected: extras_snapshot=0 primary_bearer=MISSING mtls=1
```

`server_main` mints the API primary bearer *after* its first `config_load`, so
the process-wide file cache still holds the pre-mint config. The mint lands in
Vault, the runtime secret store and the local `config_t`, and
`config_snapshot_init` seeds a correct snapshot — but one second later the
`config_reload_if_changed` tick calls `config_load_file`, which serves that
cached copy and **skips the parse** that rehydrates Vault-only values. Publishing
it blanks `server_api_bearer_token` in the live snapshot, and
`first_user_bootstrap_locked` gates on exactly that field.

`aimee api enable` masked it by calling `config_save`, which rewrites `aimee.yaml`
and invalidates the cache, so the next reload genuinely re-parses.

## The fix

Apply the runtime secrets to the reloaded config before publishing, so the
published snapshot equals what `config_load` returns. This covers **every**
Vault-only secret, not just the bearer — `db2_url`, the kb and telemetry tokens
and the curator keys were all blanked in the snapshot by the same path. Applied
before the token computation so an unchanged reload stays a no-op.

The first commit gives each `first_user` failure path a distinct reason, so the
next failure here is diagnosable instead of silent.

## Verification

- New assertion in `test_config_snapshot` fails without the fix
  (`Assertion 'strcmp(got.server_api_bearer_token, "vault-only-primary") == 0' failed`)
  and passes with it. It models the real ordering: seed the file cache, mint
  after it, reload with the file unchanged.
- `unit-test-config`, `unit-test-config-accessors`, `unit-test-config-snapshot`,
  `unit-test-config-snapshot-race` all pass.
- End-to-end on a torn-down-to-nothing `.211` (all containers and volumes
  removed): wizard Deploy now returns **200** `{"ok":true,"status":"started"}`
  with enrollment `ready`, where the same clean boot returned 500 before.