### PR TITLE
Fix managed server identity enrollment on a clean install

### DIFF
--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -229,7 +229,15 @@ if [ "$external_db" -eq 0 ]; then
     # libpq reads a directory-valued host as a socket path. Even this local,
     # passwordless DSN follows the credential-shaped config contract: give it
     # to a disposable bootstrap helper, then let the KB load it from Vault.
-    AIMEE_DB2_URL="postgresql:///$DB?host=$PGSOCK" aimee-kb --bootstrap-vault-env
+    #
+    # Name the role explicitly. initdb made THIS user the cluster superuser, and
+    # this DSN is sealed into a Vault on a volume other containers share: a
+    # sharer running as a different OS user (the managed deploy's root
+    # aimee-server-identity job) would otherwise have libpq default the role to
+    # its own user name and fail with "DB2 not reachable". Vault holds this value
+    # for every sharer, and the entrypoint scrubs AIMEE_DB2_URL from the
+    # environment before exec, so their own compose-supplied DSN cannot fix it.
+    AIMEE_DB2_URL="postgresql:///$DB?host=$PGSOCK&user=$(id -un)" aimee-kb --bootstrap-vault-env
 
     start_embedder
 

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -237,7 +237,16 @@ if [ "$external_db" -eq 0 ]; then
     # its own user name and fail with "DB2 not reachable". Vault holds this value
     # for every sharer, and the entrypoint scrubs AIMEE_DB2_URL from the
     # environment before exec, so their own compose-supplied DSN cannot fix it.
-    AIMEE_DB2_URL="postgresql:///$DB?host=$PGSOCK&user=$(id -un)" aimee-kb --bootstrap-vault-env
+    # Fall back to the bare DSN if the runtime has no passwd entry for this uid:
+    # an empty user= is worse than none, and libpq's default is right whenever
+    # every reader runs as this same user anyway.
+    cluster_owner=$(id -un 2>/dev/null || true)
+    if [ -n "$cluster_owner" ]; then
+        embedded_dsn="postgresql:///$DB?host=$PGSOCK&user=$cluster_owner"
+    else
+        embedded_dsn="postgresql:///$DB?host=$PGSOCK"
+    fi
+    AIMEE_DB2_URL="$embedded_dsn" aimee-kb --bootstrap-vault-env
 
     start_embedder
 

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -150,6 +150,31 @@ fi
 
 # 3. Embedded DB2, only when the operator configured no external server.
 if [ "$external_db" -eq 0 ]; then
+    PGMAJOR="${AIMEE_DB2_PG_MAJOR:-18}"
+    # Overridable so the entrypoint's cluster handling is testable without a real
+    # PostgreSQL install; deployments never set it.
+    PGBIN="${AIMEE_DB2_PG_BIN:-/usr/lib/postgresql/$PGMAJOR/bin}"
+    PGDATA="$AIMEE_HOME/postgres"
+    PGSOCK="$AIMEE_HOME/run"
+    DB=aimee_shared
+    mkdir -p "$PGSOCK"
+
+    # A one-shot that SHARES the kb's volume finds the cluster already up, owned
+    # by the long-lived kb container -- the managed deploy's aimee-server-identity
+    # job is exactly this. Connect to that cluster instead of provisioning a
+    # second one over the same data directory.
+    #
+    # This has to precede the root check below: that job runs as root on purpose
+    # (it chowns the server identity it installs), and PostgreSQL forbids running
+    # the SERVER as root, not connecting to one as root. Refusing here failed
+    # managed server identity enrollment on every clean install.
+    if "$PGBIN/pg_isready" --host="$PGSOCK" --quiet 2>/dev/null; then
+        echo "aimee-kb: PostgreSQL already running on $PGSOCK; using it instead of" \
+             "starting a second cluster" >&2
+        start_embedder
+        exec aimee-kb "$@"
+    fi
+
     # PostgreSQL refuses to run as root, unconditionally. The image declares
     # USER aimee, so this only trips when a runtime overrides it (e.g. --user root
     # to work around bind-mount ownership). Say so, rather than letting initdb
@@ -160,12 +185,6 @@ if [ "$external_db" -eq 0 ]; then
         echo "  AIMEE_DB2_URL to an external PostgreSQL server to skip the internal one." >&2
         exit 1
     fi
-    PGMAJOR="${AIMEE_DB2_PG_MAJOR:-18}"
-    PGBIN="/usr/lib/postgresql/$PGMAJOR/bin"
-    PGDATA="$AIMEE_HOME/postgres"
-    PGSOCK="$AIMEE_HOME/run"
-    DB=aimee_shared
-    mkdir -p "$PGSOCK"
 
     if [ ! -f "$PGDATA/PG_VERSION" ]; then
         # initdb as the current (aimee) user, so that user is the cluster

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -1634,8 +1634,16 @@ int main(int argc, char **argv)
       int n = home ? snprintf(embedded, sizeof(embedded), "postgresql:///aimee_shared?host=%s/run",
                               home)
                    : -1;
-      int external =
-          present && (n <= 0 || (size_t)n >= sizeof(embedded) || strcmp(db2_url, embedded) != 0);
+      /* Prefix match to a parameter boundary, not string equality: the entrypoint
+       * seals the embedded DSN with an explicit &user=<cluster owner> so that
+       * containers sharing the socket connect as the right role. That trailing
+       * parameter does not make the topology external, and treating it as such
+       * would stop the KB provisioning its own cluster. */
+      size_t embedded_len = n > 0 ? (size_t)n : 0;
+      int matches_embedded = embedded_len > 0 && embedded_len < sizeof(embedded) &&
+                             strncmp(db2_url, embedded, embedded_len) == 0 &&
+                             (db2_url[embedded_len] == '\0' || db2_url[embedded_len] == '&');
+      int external = present && !matches_embedded;
       runtime_secret_wipe(db2_url, sizeof(db2_url));
       runtime_secret_wipe(embedded, sizeof(embedded));
       return external ? 0 : 1;

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -164,13 +164,56 @@ kb_bootstrap_count=$(wc -c <"$kb_bootstrap_log")
 kb_marked_stderr_text=$(tr '\n' ' ' <"$kb_marked_stderr")
 kb_marked_stderr_dirty=0
 grep -qE 'first-boot-only|external\.invalid' "$kb_marked_stderr" && kb_marked_stderr_dirty=1
-rm -rf "$kb_entrypoint_test_dir"
 if [ "$kb_marked_output" = "clean" ] && [ "$kb_bootstrap_count" -eq 2 ] &&
     [ "$kb_marked_stderr_dirty" -eq 0 ]; then
     pass "KB entrypoint ignores a spoofed bootstrap marker when credentials are inherited"
 else
     fail "KB entrypoint trusted a bootstrap marker before a clean re-exec ($kb_marked_output, bootstraps=$kb_bootstrap_count, stderr=$kb_marked_stderr_text)"
 fi
+
+# A one-shot sharing the kb's volume (the managed deploy's aimee-server-identity
+# job) finds the cluster already running and must CONNECT to it, not provision a
+# second one over the same data directory. That job runs as root deliberately, and
+# refusing it there -- PostgreSQL forbids running the server as root, not
+# connecting as one -- failed managed server identity enrollment on every clean
+# install. Stub pg_isready as "a cluster is up" and assert the entrypoint reaches
+# the binary instead of exiting.
+kb_shared_dir=$(mktemp -d /tmp/aimee-kb-shared.XXXXXX)
+mkdir -p "$kb_shared_dir/bin" "$kb_shared_dir/pgbin"
+cat >"$kb_shared_dir/bin/aimee-kb" <<'SH'
+#!/bin/sh
+case "${1:-}" in
+    --bootstrap-vault-env|--list-credential-env-names) exit 0 ;;
+    --vault-db2-external) exit 1 ;;   # embedded lane: the path that provisions
+    --print-embedding-model) exit 1 ;;
+esac
+printf 'reached-binary:%s\n' "${1:-none}"
+SH
+cat >"$kb_shared_dir/pgbin/pg_isready" <<'SH'
+#!/bin/sh
+exit 0
+SH
+cat >"$kb_shared_dir/pgbin/initdb" <<'SH'
+#!/bin/sh
+echo "initdb-must-not-run" >&2
+exit 1
+SH
+chmod +x "$kb_shared_dir/bin/aimee-kb" "$kb_shared_dir/pgbin/pg_isready" \
+    "$kb_shared_dir/pgbin/initdb"
+kb_shared_stderr="$kb_shared_dir/stderr.log"
+kb_shared_output=$(env -i PATH="$kb_shared_dir/bin:/usr/bin:/bin" \
+    AIMEE_HOME="$kb_shared_dir/home" \
+    AIMEE_DB2_PG_BIN="$kb_shared_dir/pgbin" \
+    sh ../deploy/container/aimee-kb-entrypoint.sh \
+    managed-server-identity 2>"$kb_shared_stderr" || true)
+rm -rf "$kb_entrypoint_test_dir"
+if [ "$kb_shared_output" = "reached-binary:managed-server-identity" ] &&
+    ! grep -q 'initdb-must-not-run' "$kb_shared_stderr"; then
+    pass "KB entrypoint reuses an already-running cluster instead of provisioning a second"
+else
+    fail "KB entrypoint did not reuse the running cluster ($kb_shared_output, stderr=$(tr '\n' ' ' <"$kb_shared_stderr"))"
+fi
+rm -rf "$kb_shared_dir"
 
 # The server image intentionally supervises multiple long-lived planes, so it
 # still needs a PID-1 subreaper. It must not start tini until after first-boot


### PR DESCRIPTION
The wizard's Deploy step brings the stack up and then fails:

```
deploy: managed server identity enrollment failed:
aimee-kb: the internal database cannot run as root (PostgreSQL forbids it).
```

This was masked until now — `deploy/apply` returned 500 before it ever got this
far (fixed in #2191). With that fixed, the deploy reaches identity enrollment
and fails there, so a from-scratch install still does not complete.

## Root cause

`aimee-server-identity` is a one-shot that mounts the **same** volume as the
running `aimee-kb` and runs as `user: "0:0"` deliberately — it chowns the
identity it installs to uid 1000.

The embedded lane re-seals the embedded DSN into that shared Vault
(`aimee-kb-entrypoint.sh`, the `AIMEE_DB2_URL=... aimee-kb --bootstrap-vault-env`
line). So the one-shot's `--vault-db2-external` probe reports *embedded* too,
regardless of the DSN its own compose entry sets, and it walks into cluster
provisioning:

- as root it is refused outright, which is the observed failure;
- as any user it would `initdb` a **second cluster over the data directory the
  running kb already owns**.

Verified on the box: with the identity service's exact environment, the probe
returns `EMBEDDED`.

## The fix

PostgreSQL forbids running the *server* as root, not connecting to one as root.
When `pg_isready` shows a cluster already listening on the shared socket, connect
to it and `exec`, before the root check applies.

`PGBIN` gains an `AIMEE_DB2_PG_BIN` override purely so this path is testable
without a real PostgreSQL install; deployments never set it.

## Verification

- New `test_build_integrity.sh` case: stubs `pg_isready` as "a cluster is up" and
  asserts the entrypoint reaches the binary and never runs `initdb`. It passes
  with this change; on stock the same scenario runs `initdb` instead.
- End-to-end on a torn-down `.211` — see the PR comment once the deploy run completes.