### PR TITLE
Drop the aimee-llm volumes and endpoint default the purge left behind

### DIFF
--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -38,9 +38,11 @@ services:
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-1024}
       AIMEE_KB_HTTP_BIND: "1"
       # The curator synth sidecar (curator-extract.py) reads LLM_ENDPOINT, NOT
-      # AIMEE_LLM_URL — without it the sidecar exits 256 and code-unit synthesis
-      # never drains. Point it at the same aimee-llm gateway (/v1).
-      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://aimee-llm:8742/v1}
+      # AIMEE_LLM_URL. Defaulted empty for the same reason as AIMEE_LLM_URL above:
+      # the aimee-llm container is retired, so the old http://aimee-llm:8742/v1
+      # default pointed every deploy at a host that can never resolve. Set it to
+      # your own synth endpoint (/v1) to drain code-unit synthesis.
+      LLM_ENDPOINT: ${LLM_ENDPOINT:-}
       LLM_MODEL: ${LLM_MODEL:-aimee-synth}
     command: ["--http-port=8741"]
     ports:
@@ -90,4 +92,3 @@ volumes:
   aimee-kb-home:
   aimee-server-home:
   aimee-server-workspaces:
-  aimee-llm-models:

--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -137,7 +137,6 @@ services:
 
 volumes:
   aimee-managed-kb-home:
-  aimee-managed-llm-models:
   aimee-managed-authority-home:
   aimee-server-workspaces:
     external: true

--- a/deploy/smoothnas/aimee.compose.yaml
+++ b/deploy/smoothnas/aimee.compose.yaml
@@ -94,5 +94,3 @@ volumes:
     x-smoothnas: { tier: aimee-data }
   aimee-server-workspaces:
     x-smoothnas: { tier: aimee-data }
-  aimee-llm-models:
-    x-smoothnas: { tier: aimee-data }


### PR DESCRIPTION
Retiring `aimee-llm` (#2178) removed the service but left residue:

- three manifests still declared a models volume **no service mounts** —
  `deploy/container/aimee-managed.compose.yaml`, `deploy/compose/aimee.yaml`,
  `deploy/smoothnas/aimee.compose.yaml`;
- `deploy/compose/aimee.yaml` still defaulted `LLM_ENDPOINT` to
  `http://aimee-llm:8742/v1` — a hostname that can never resolve now, so the
  curator synth sidecar fails against a dead host instead of being cleanly
  unconfigured.

Default it empty, matching the `AIMEE_LLM_URL` treatment already applied in the
same files.

## Deliberately NOT changed

- `compose.yaml` keeps `aimee-llm-models`: that volume is mounted by the live
  `llm:` llama.cpp curator service (profile `curator-llm`), which is **not** the
  retired container.
- The smoothnas manifests pointing at `10.100.0.1:8742` are a real external GPU
  gateway, not residue.

Verified: all four manifests still parse, and a declared-vs-mounted check now
reports zero orphaned volumes in each.