### PR TITLE
Correct the docs that still describe a retired inference container

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -20,7 +20,8 @@ operations. Exact command and config tables are generated from source:
 - `aimee-wfe` owns workflow definitions and lifecycle state.
 - `aimee-kb` owns durable memory, documents, the code graph, retrieval, curation, PostgreSQL, and
   pgvector.
-- `aimee-llm` serves embedding and synthesis on CPU or GPU.
+- The KB embeds in-process from weights baked into its image. Synthesis is external-only: point
+  `AIMEE_LLM_URL` at an endpoint you run.
 - `aimee-runtime-web` serves the browser workspace.
 
 The server and KB each run a bounded shared-memory event bus. Governed actions, memory mutations,

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ The `aimee` CLI is a thin client. Linux, macOS, and Windows builds talk to the s
 - **Any model, any provider.** OpenAI Chat Completions, OpenAI Responses, Anthropic Messages,
   Gemini, Mistral, local OpenAI-compatible servers, and AWS Bedrock all pass through one internal
   request format. Switch the primary model without switching tools.
-- **Local inference.** One `aimee-llm` container serves embeddings and synthesis on CPU
-  or GPU. The KB runs no model itself. See [Inference](docs/KB_LLM_BACKENDS.md).
+- **In-container embedding.** The KB embeds from weights baked into its own image — no inference
+  container, no first-boot model download. Point it at an external endpoint for a wider model, or
+  for synthesis. See [Inference](docs/KB_LLM_BACKENDS.md).
 - **Document ingestion.** Push source trees, Markdown, text, and PDFs. Structured PDF mode keeps
   coordinates, tables, page crops, OCR text, and citations. See [Structured PDF](docs/STRUCTURED_PDF.md).
 - **A browser workspace.** Chat, projects, agents, workflows, the code graph, logs, settings, and
@@ -66,14 +67,11 @@ docker compose -f compose.server-managed.yaml logs aimee-server
 Unless both browser credential env vars were supplied, the logs print a random temporary username
 and password under `[webchat]`. Open <https://localhost:8443> and sign in with that pair. The wizard
 first replaces it with your persistent operator username and password, then creates the initial
-agent and picks the inference tier, git hosts, and workspaces. Its last step starts:
+agent and picks the embedder, git hosts, and workspaces. Its last step starts `aimee-kb`, with
+private PostgreSQL 18, pgvector, and pgvectorscale inside the container.
 
-- `aimee-kb`, with private PostgreSQL 18, pgvector, and pgvectorscale inside the container;
-- `aimee-llm`, on CPU or GPU.
-
-The managed deploy creates and starts KB before LLM. It does not wait for first-boot model downloads:
-KB database initialization and CPU indexing begin immediately while LLM readiness continues in the
-background. A failed LLM download remains visible in that container's status and logs.
+There is no inference container to wait for. The KB's embedder is baked into its image, so database
+initialization and indexing begin as soon as the container is up.
 
 It also displays the one client-enrollment command for the signed-in first user.
 For a local inference tier, setup separately provisions an authenticated KB-to-LLM service identity;
@@ -135,8 +133,8 @@ The current tree is a large step past the last public release. The short version
   a time behind their own contracts and tests;
 - the workflow control plane moved to Go and now schedules parallel slices, live forge work,
   triggers, retries, review loops, and human gates;
-- the combined appliance image is gone; managed and split deployments use separate server, KB,
-  and inference containers;
+- the combined appliance image is gone; managed and split deployments use separate server and KB
+  containers, and the retired `aimee-llm` container's embedding role moved into the KB;
 - the KB container now owns its PostgreSQL database and can export it to an external server;
 - delegates gained role/persona routing, stronger admission, isolated worktrees, networkless
   containers, package mediation, custom images, and learned toolchains;

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -4,32 +4,25 @@ Synthesis runs against an external OpenAI-compatible endpoint; the knowledge bas
 in-container and needs no inference service. The tiers below describe the synth model
 set and concurrency at runtime.
 
-| Tier | Intended host | Embedding width | Synthesis shape |
-| --- | --- | ---: | --- |
-| `cpu` | CPU-only host | 1024 | small local extraction/synthesis |
-| `small` | about 16 GB GPU | 2560 | Gemma 4 12B class |
-| `mid` | about 24 GB GPU | 2560 | Gemma 4 26B-A4B class, two slots |
-| `large` | about 32 GB GPU | 2560 | same class with more slots and context |
+| Tier | Intended host | Synthesis shape |
+| --- | --- | --- |
+| `cpu` | CPU-only host | small local extraction/synthesis |
+| `small` | about 16 GB GPU | Gemma 4 12B class |
+| `mid` | about 24 GB GPU | Gemma 4 26B-A4B class, two slots |
+| `large` | about 32 GB GPU | same class with more slots and context |
+
+These size the endpoint you run. Embedding width is not a tier property: it is the dimension of the
+embedder the KB serves, chosen in the wizard's Deploy topology step. See
+[Retrieval stack](retrieval-stack.md).
 
 Hardware estimates include model residency, not every driver or concurrent workload. Validate on the
 real host before promising a slot count.
 
-## Deploy
-
-```yaml
-environment:
-  AIMEE_LLM_TIER: cpu   # cpu | small | mid | large
-```
-
-The normal image downloads models into a persistent volume on first boot. The pre-baked CPU image is
-for offline installs. Moving between GPU tiers keeps the 2560-wide embedding schema. Moving between
-CPU and GPU widths requires the DB2 re-embed procedure.
-
 ## Consumers
 
-The KB uses the gateway for curator and retrieval work. The server may also register the local
-synthesis model as a free delegate. These consumers have separate admission limits so background KB
-work cannot take every interactive slot.
+The KB uses the synth endpoint for curator work. The server may also register that model as a free
+delegate. These consumers have separate admission limits so background KB work cannot take every
+interactive slot.
 
 ## Tune
 
@@ -49,7 +42,8 @@ under the expected mixed load.
 
 ## CPU and GPU separation
 
-Cheap lexical/index work stays in PostgreSQL and KB workers. Model work goes to `aimee-llm`. GPU
-tiers use the larger synth model; the retrieval pipeline itself does not change.
+Cheap lexical/index work stays in PostgreSQL and KB workers. Embedding runs in the KB process;
+synthesis goes to the external endpoint. GPU tiers use the larger synth model; the retrieval pipeline
+itself does not change.
 
 See [KB inference backends](KB_LLM_BACKENDS.md) and [Retrieval stack](retrieval-stack.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ flowchart LR
     F -->|typed resource calls| S
     S -->|typed /v1| K[aimee-kb]
     S -->|provider API| P[model providers]
-    K -->|embed / synth| L[aimee-llm]
+    K -->|synth, when configured| X[external LLM endpoint]
     S --> D1[(DB1 SQLite)]
     F --> WF[(workflow SQLite)]
     K --> D2[(DB2 PostgreSQL + pgvector)]
@@ -27,9 +27,8 @@ flowchart LR
 | `aimee` | CLI parsing, local hooks, MCP/ACP stdio, client filesystem access | databases, server policy, provider credentials |
 | `aimee-server` | sessions, DB1, agents, tools, policy, vault, provider calls, `/v1` resource plane | DB2, workflow lifecycle |
 | `aimee-wfe` | workflow definitions, scheduling, artifacts, retries, gates, worktrees, forge lifecycle | agent credentials, KB data, general chat |
-| `aimee-kb` | DB2, memory, documents, code graph, retrieval, curation | DB1, workflow state, model serving |
+| `aimee-kb` | DB2, memory, documents, code graph, retrieval, curation, the in-process embedder | DB1, workflow state, synthesis inference |
 | `aimee-runtime-web` | browser auth, session proxying, UI delivery | product databases and workflow decisions |
-| `aimee-llm` | embedding, synthesis inference | knowledge storage and curation policy |
 
 `aimee-server` and `aimee-wfe` run as supervised peers in the server image. If either exits, the
 container terminates both and fails. The C server returns `410 Gone` for retired workflow lifecycle
@@ -142,7 +141,7 @@ The client opens no database and starts no daemon. Warm state stays in `aimee-se
 2. The server authorizes the principal and calls the KB's typed endpoint.
 3. The KB owns the transaction, lexical/dense indexes, and evidence.
 4. Mutations publish a PII-safe audit identity on the KB bus.
-5. Recall returns bounded evidence; optional synthesis goes through `aimee-llm`.
+5. Recall returns bounded evidence; optional synthesis goes to the configured external endpoint.
 
 ### Delegate turn
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,8 +6,8 @@
 docker compose -f compose.server-managed.yaml up -d
 ```
 
-The browser wizard launches the KB and inference containers. This requires the host Docker socket,
-which gives the server Docker-host authority.
+The browser wizard launches the KB container. This requires the host Docker socket, which gives the
+server Docker-host authority.
 
 Use it for a trusted single-host install where browser-managed setup matters more than that larger
 boundary.
@@ -47,8 +47,12 @@ them synchronously, and exits before the service is created.
 
 ## Inference
 
-`aimee-llm` serves embedding and synthesis. Select a CPU or GPU tier with the deployment
-settings. GPU models live in a persistent model volume; the CPU offline image may bake its model.
+The KB embeds in-process from weights baked into its image, so embedding needs no second container
+and no model download. Select the embedder in the wizard's Deploy topology step, or set
+`embedding_model`; point `AIMEE_EMBEDDER_URL` at your own endpoint for a wider model.
+
+Synthesis is external-only. `AIMEE_LLM_URL` defaults empty, so a deployment that wants synthesis
+supplies its own endpoint.
 
 The KB must report explicit degradation when a configured inference stage is unavailable. It cannot
 claim a dense or synthesized result after silently skipping that stage.

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -1,36 +1,29 @@
 # KB inference backends
 
-`aimee-kb` runs no model. It stores source and derived records, schedules work, and calls an inference
-service for embedding, extraction, or synthesis.
+`aimee-kb` stores source and derived records and schedules work. It serves its own embedder and calls
+out for synthesis.
 
-The standard backend is `aimee-llm` on the deployment network.
+**Embedding is in-container.** The weights ship inside the KB image, so there is no inference
+container and no first-boot download. Select the model in the wizard's Deploy topology step, or set
+`embedding_model`. Until one is selected the KB serves a builtin lexical embedder and logs that it is
+doing so — retrieval works, but it is not dense.
 
-In a wizard-managed deployment, starting the local LLM is also an identity transaction. The server
-generates a persistent 256-bit `AIMEE_LLM_AUTH_TOKEN`, passes it to the KB and LLM only, and configures
-`AIMEE_LLM_AUTH_REQUIRED=1` on the KB so none of its clients can silently downgrade to keyless access.
-It also configures the KB's unified endpoint and selected role tiers. Every embed, batch, and chat request carries
-that bearer. The gateway starts with its unauthenticated wildcard-bind guard enforced, so a missing
-credential fails deployment instead of silently trusting every container on the bridge. This service
-identity is distinct from browser login, first-user enrollment, and server-to-KB credentials.
-Setup reports success only after executing an authenticated `/auth/verify` request from inside the KB
-container, using the endpoint and bearer that the KB actually received.
+To embed against something else, set `AIMEE_EMBEDDER_URL`. That takes precedence, and the bundled
+model stays unloaded.
 
-An external-only topology does not create this local service identity and defaults
-`AIMEE_LLM_AUTH_REQUIRED` to `0`; an operator may still set it to `1` together with the external
-gateway's bearer. This prevents the local-LLM security rule from disabling intentionally keyless
-external endpoints.
+**Synthesis is external-only.** `AIMEE_LLM_URL` has no default, so a deployment that wants synthesis
+supplies its own OpenAI-compatible endpoint. Unset, synthesis stages report degradation rather than
+inventing a result.
 
-The managed contract is explicit:
+The `aimee-llm` container that previously served both roles is retired.
 
 | Consumer | Configuration received | Request surface |
 | --- | --- | --- |
 | `aimee-kb` | `AIMEE_LLM_URL` (synth only, no default), `AIMEE_LLM_AUTH_TOKEN`, `AIMEE_LLM_MODEL` (default `aimee-synth`). Embedding is in-container; `AIMEE_EMBEDDER_URL` overrides it with an external endpoint | `/v1/chat/completions` on the synth endpoint |
-| `aimee-llm` | the same `AIMEE_LLM_AUTH_TOKEN`; `AIMEE_LLM_{EMBED,SYNTH}_{MODE,TIER,URL}`; `AIMEE_LLM_SYNTH_MODEL`; optional `AIMEE_EMBEDDING_DIM`; and the runtime GPU settings | serves a local role, proxies its configured external URL, or rejects an `off` role; rejects an embedding-dimension mismatch when pinned |
-| legacy KB curator sidecars | `LLM_API_KEY` aliasing the same service bearer | the unified gateway's OpenAI-compatible `/v1` surface |
+| legacy KB curator sidecars | `LLM_API_KEY` aliasing the same service bearer | the endpoint's OpenAI-compatible `/v1` surface |
 
-The role configuration and credential form one deployment transaction. The server does not report a
-successful local-LLM deploy merely because both containers started: the authenticated probe must also
-succeed from the KB's own environment.
+`AIMEE_LLM_AUTH_REQUIRED` defaults to `0`. Set it to `1` with the endpoint's bearer to stop clients
+downgrading to keyless requests.
 
 ## Required operations
 
@@ -44,14 +37,10 @@ without embedding; it must not claim dense results.
 
 ## Configure
 
-Set the inference base URL for the KB, normally through `AIMEE_EMBEDDER_URL` or the matching
-descriptor-backed key. Configure one embedding model identity and one dimension for the deployment.
+Configure one embedding model identity and one dimension for the deployment. Leave
+`AIMEE_EMBEDDER_URL` unset to use the bundled model; set it to embed against your own endpoint.
 
-For a split or externally managed stack, set the same `AIMEE_LLM_AUTH_TOKEN` on `aimee-kb` and the
-`aimee-llm` gateway. The managed wizard does this automatically. To adopt an existing local gateway,
-set the deliberately separate `AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE`; ordinary inherited
-`AIMEE_LLM_AUTH_TOKEN` is ignored during managed credential creation so stale child-service state
-cannot win. The override must be a 32–512 character RFC 6750 b64token or setup fails closed.
+For synthesis, set `AIMEE_LLM_URL` and, where the endpoint authenticates, `AIMEE_LLM_AUTH_TOKEN`.
 
 Use [generated configuration](gen/configuration.md) for current names. Container environment values
 override file values where documented.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -5,34 +5,48 @@ Run the services on one machine. Install only the thin client where you write co
 ## 1. Start the managed server
 
 You need Docker with Compose v2. The managed server mounts the Docker socket so its browser wizard
-can start the KB and inference containers.
+can start the KB container.
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
 cd aimee
+docker compose -f compose.server-managed.yaml up -d
+docker compose -f compose.server-managed.yaml logs aimee-server
+```
+
+The server generates a dashboard login on first boot and prints it once, in that log:
+
+```text
+[webchat] FIRST-BOOT DASHBOARD LOGIN (shown once — copy it now)
+[webchat]     username: aimee-0a901de6e2c3
+[webchat]     password: <64 hex characters>
+```
+
+Copy it before the log rotates. Only the username is kept on disk afterwards, so the password cannot
+be read back; if you lose it, reset that account's password inside the container or start again from
+an empty volume. To choose the credential yourself instead, set both variables before `up` — then
+nothing is generated and nothing is printed:
+
+```bash
 export AIMEE_WEBCHAT_USER=operator
 read -rsp 'Initial webchat password: ' AIMEE_WEBCHAT_PASSWORD && echo
 export AIMEE_WEBCHAT_PASSWORD
 docker compose -f compose.server-managed.yaml up -d
 unset AIMEE_WEBCHAT_PASSWORD
-docker compose -f compose.server-managed.yaml logs aimee-server
 ```
 
-Open <https://localhost:8443> and sign in with that pair. The variables are first-boot transport,
-not runtime configuration: the entrypoint immediately encrypts them into the server Vault, removes
-them from its inherited environment, and only then starts long-lived services. Authentication reads
-only fixed Vault records through one-shot pipes; no password, verifier, session bearer, or TLS private
-key is written to the data volume or container logs. Then create the initial agent and choose CPU or GPU inference, git
-accounts, and workspaces.
-The final **Deploy** step starts:
+Those variables are first-boot transport, not runtime configuration: the entrypoint encrypts them
+into the server Vault, removes them from its inherited environment, and only then starts long-lived
+services. Authentication reads only fixed Vault records through one-shot pipes; no password,
+verifier, session bearer, or TLS private key is written to the data volume or container logs.
 
-- `aimee-kb`, including private PostgreSQL 18, pgvector, and pgvectorscale;
-- `aimee-llm`, with the selected inference tier.
+Open <https://localhost:8443> and sign in. If you signed in with the generated login, the wizard's
+account step replaces it with a permanent one; a deployment that supplied its own pair skips that
+step. Then work through the initial agent, deploy topology, git accounts, and workspaces.
 
-The managed worker starts KB before LLM. It waits for KB health only where the identity one-shots
-require it; it does not wait for LLM model readiness. First-boot model downloads continue in the
-LLM container after the wizard reports that the stack containers are up, while KB initialization
-and CPU indexing proceed. Check `aimee-llm` status/logs if a download later fails.
+The final **Deploy** step starts `aimee-kb`, including private PostgreSQL 18, pgvector, and
+pgvectorscale. There is no inference container: the KB embeds in-process from weights baked into its
+image, and synthesis is external-only (see [Choosing an embedder](#choosing-an-embedder)).
 
 For a local managed KB, Deploy also runs two explicit one-shot jobs before it
 reports success:
@@ -57,16 +71,10 @@ Deploy also claims the signed-in browser account as the first remote owner. It d
 `aimee remote set ...` command that provisions that user's bearer, mTLS certificate, and explicit
 `full` write grant. Keep that page open until you run the command in step 3.
 
-When the wizard creates a local `aimee-llm`, it also creates a separate, persistent 256-bit service
-identity for `aimee-kb`. The managed stack supplies the endpoint, role/tier configuration, and bearer
-to both containers, then the KB uses that credential for embedding and synthesis. This is
-automatic; do not copy the user's enrollment bearer into the LLM configuration. The managed LLM
-refuses to start if its service credential is missing.
-
-Complete the account step before exposing the host. Deployments that inject both
-`AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` use that explicit pair and skip account
-replacement. When the browser UI is enabled, set both on first boot; a missing or partial pair is
-rejected instead of generating a credential in logs.
+Complete the account step before exposing the host. A deployment that injects both
+`AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` uses that pair and skips account replacement.
+Supply both or neither: a partial pair is treated as absent, and the server generates and logs a
+credential instead.
 
 The browser login is a **local PAM account**, not an aimee credential. First boot provisions the
 supplied (or generated) pair as a real system account in the `aimee-webchat` group and authenticates
@@ -82,20 +90,59 @@ When the appliance is connected to a KB that reports `oidc`, the identity provid
 the wizard's account step disappears; local account creation is refused. Dashboard login itself
 remains PAM in this release — the OIDC login flow arrives in 0.4.0.
 
+### Choosing an embedder
+
+The wizard's **Deploy topology** step records which embedder the KB uses. Choose one before Deploy.
+The bundled `bekko-a25m` (384-dimension) ships inside the KB image, so it needs no download and no
+second container. Point the KB at your own endpoint instead if you need a wider model.
+
+Nothing is selected on a fresh install, and an unselected KB is not broken — it falls back to a
+builtin lexical embedder and says so once, in the KB log:
+
+```text
+aimee-kb: no embedder selected; the bundled model stays unloaded (the builtin
+lexical embedder serves until the wizard selects one)
+```
+
+Retrieval still works in that state, but it is keyword matching, not vector search. If you skipped
+the step, set it from the server and re-run Deploy:
+
+```bash
+aimee config set embedding_model bekko-a25m
+```
+
+Confirm the model actually loaded rather than assuming it did:
+
+```bash
+docker compose -f compose.server-managed.yaml logs aimee-kb | grep -i embedder
+aimee kb status
+```
+
+A loaded embedder logs its dimension and serving identity:
+
+```text
+aimee-kb: starting bundled embedder (bekko-a25m) on :8760
+embedder-server: loaded hotchpotch/bekko-embedding-v1-a25m dim=384 threads=8 quant=fp32
+```
+
+Decide before you ingest. Changing the embedder later re-embeds everything already indexed, and
+changing to one of a different dimension rebuilds the vector schema as well. The wizard names which
+of the two a given switch costs.
+
 ### Choosing an image channel
 
 The stack runs the released `:latest` images by default. To run a tested-but-unreleased build, set
-`AIMEE_IMAGE_TAG` once — it moves the server, the KB and the LLM together:
+`AIMEE_IMAGE_TAG` once — it moves the server and the KB together:
 
 ```bash
 AIMEE_IMAGE_TAG=testing docker compose -f compose.server-managed.yaml up -d
 ```
 
 Set it for the wizard's **Deploy** step too, not just the server: the server re-runs Compose for the
-managed services, so the tag has to be in its environment or the KB and LLM fall back to `:latest`
-while the server runs `:testing`. The line above already does this. Mixing versions this way is a
-real failure mode, not a theoretical one — a KB and a server from different builds can disagree
-about the inference contract and leave the KB permanently unhealthy.
+managed services, so the tag has to be in its environment or the KB falls back to `:latest` while the
+server runs `:testing`. The line above already does this. Mixing versions this way is a real failure
+mode, not a theoretical one — a KB and a server from different builds can disagree about the
+contract between them and leave the KB permanently unhealthy.
 
 A single service can still be pinned individually (`AIMEE_KB_IMAGE=…`), and an explicit pin always
 wins over `AIMEE_IMAGE_TAG`.

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -108,8 +108,9 @@ See [Event bus](EVENT_BUS.md).
 
 - The KB container can own a private PostgreSQL 18 cluster with pgvector and pgvectorscale. An
   export helper moves that data to an external PostgreSQL server.
-- The KB owns embedding, retrieval, curation, and code-index storage; inference stays in the
-  separate `aimee-llm` service.
+- The KB owns embedding, retrieval, curation, and code-index storage, and now serves the embedder
+  itself from weights baked into its image. Synthesis is the only remaining inference role and it is
+  external-only.
 - Cross-repository symbol and dependency edges now feed caller lookup, search, and blast radius.
 - CSS migration analysis adds a style graph, dead/conflicting-rule checks, and an optional isolated
   Chromium sidecar for computed-style verification.
@@ -121,12 +122,13 @@ See [Event bus](EVENT_BUS.md).
 
 ## Deployment and clients
 
-- The all-in-one `aimee-combined` image is retired. Use the managed server or the split server, KB,
-  and inference stack.
+- The all-in-one `aimee-combined` image is retired. Use the managed server or the split server and
+  KB stack.
 - New KB containers run PostgreSQL privately when `AIMEE_DB2_URL` is not set. Existing external
   databases remain supported.
-- `aimee-llm` chooses CPU or GPU tiers at runtime. CPU images can be pre-baked for offline use; GPU
-  tiers keep models in a persistent volume.
+- The server generates a dashboard login on first boot when the deployment supplies none, and prints
+  it once to the container log. Supply `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` to choose
+  your own; supply both or neither.
 - Linux, macOS, and Windows use the same DB-free thin client and native TLS backend.
 - Server-to-KB mTLS pooling and resident thin-client HTTPS keep-alive now default on. The measured
   compression flags remain off because they saved bytes but missed the latency gate.
@@ -151,6 +153,8 @@ See [Event bus](EVENT_BUS.md).
   if you need them.
 - `aimee migrate v2`, whose server operation had already been removed.
 - The combined appliance image and its compose file.
+- The `aimee-llm` container and the reranker. The KB embeds in-container; point `AIMEE_LLM_URL` at
+  your own endpoint for synthesis.
 - The legacy KB Unix-socket autostart path.
 - Client-held plaintext agent credentials and the session credential-push endpoint.
 - The generic `/v1/rpc` transport. Named `/v1` routes are authoritative.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -116,7 +116,7 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 
 ### Deploy-time keys (7)
 
-Consumed once by `config_emit_deploy_env` to stand up the aimee-llm container (`aimee config deploy-env`); not read at runtime. Set at deploy, not tuned day-to-day.
+Consumed once by `config_emit_deploy_env` to stand up the managed sibling services (`aimee config deploy-env`); not read at runtime. Set at deploy, not tuned day-to-day.
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -344,7 +344,7 @@ The binaries read 226 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_BACKGROUND_THREADS` | Background worker thread count. |
 | `AIMEE_COMPUTE_THREADS` | Compute-pool thread count. |
 | `AIMEE_DEPLOY_COMPOSE_FILE` | Path to the managed compose file the server-orchestrated deploy runs (default /opt/aimee/deploy/aimee-managed.compose.yaml). |
-| `AIMEE_DEPLOY_ENABLED` | Set to 1 to enable the server-orchestrated deploy: the setup wizard runs `docker compose up -d` for the managed sibling services (aimee-kb + aimee-llm) via a mounted Docker socket. Off unless the deploy compose sets it. |
+| `AIMEE_DEPLOY_ENABLED` | Set to 1 to enable the server-orchestrated deploy: the setup wizard runs `docker compose up -d` for the managed sibling service (aimee-kb) via a mounted Docker socket. Off unless the deploy compose sets it. |
 | `AIMEE_GITHUB_OAUTH_CLIENT_ID` | Client ID of a GitHub OAuth App for the webchat "Sign in with GitHub" button; populates the github.com git credential. Public. Overrides the built-in default baked in via oauth_defaults.h. |
 | `AIMEE_GITLAB_OAUTH_CLIENT_ID` | Client ID of a GitLab OAuth application (device flow enabled) for the webchat "Sign in with GitLab" button on gitlab.com. Public. Overrides the built-in default baked in via oauth_defaults.h. |
 | `AIMEE_MGMT_STATUS_KEY_ID` | Identifier of the management-status verification key. |
@@ -596,7 +596,7 @@ The binaries read 226 `AIMEE_*` environment variables (scanned from `getenv()` i
 | Variable | Description |
 |----------|-------------|
 | `AIMEE_LLM_AUTH_REQUIRED` | Set to 1 on wizard-managed KBs so synthesis clients refuse to contact the LLM when its bearer service identity is missing. |
-| `AIMEE_LLM_AUTH_TOKEN` | First-boot transport for the bearer service identity shared by aimee-kb and its aimee-llm gateway. aimee-kb synchronously seals it into Vault, scrubs the environment, and cleanly re-execs before serving; wizard-managed deploys generate the 256-bit value in Vault. This is separate from user/server bearers. |
+| `AIMEE_LLM_AUTH_TOKEN` | First-boot transport for the bearer aimee-kb presents to the external synthesis endpoint. aimee-kb synchronously seals it into Vault, scrubs the environment, and cleanly re-execs before serving; wizard-managed deploys generate the 256-bit value in Vault. This is separate from user/server bearers. |
 | `AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE` | Explicit first-boot migration/adoption transport for an existing wizard-managed LLM credential. aimee-server seals it into Vault and scrubs the environment before normal startup. Ordinary inherited AIMEE_LLM_AUTH_TOKEN is ignored by managed credential creation so stale child-service state cannot win. Must be a 32..512 character RFC 6750 b64token. |
 | `AIMEE_OFFLINE_ALLOW_NO_SWAP_MLOCK_FALLBACK` | Internal managed-authority switch: still attempts mlockall first, but when an unprivileged container cannot raise RLIMIT_MEMLOCK, permits the offline one-shot to continue only if the kernel reports no active swap. Operator-run custody tools leave this unset and retain mandatory mlockall. |
 

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -13,13 +13,14 @@ were used.
 
 ## Embedding
 
-One embedder identity and dimension applies to a deployment. The KB stores derived vectors in DB2;
-`aimee-llm` serves the model.
+One embedder identity and dimension applies to a deployment. The KB stores derived vectors in DB2
+and serves the model itself, from weights baked into its image. The bundled `bekko-a25m` is
+384-dimension; an external endpoint (`AIMEE_EMBEDDER_URL`) can serve a wider one.
 
-Every tier serves the same 768-dim embedder, so the tier is a GPU-offload choice and an
-index built under one tier is readable under another.
+The embedder is selected in the wizard's Deploy topology step. Until one is selected the KB serves a
+builtin lexical embedder — retrieval works, but it is keyword matching rather than vector search.
 
-Check [Inference tiers](AIMEE_KB_SYNTH_TIERS.md) for the current model names and hardware estimates.
+Check [Inference tiers](AIMEE_KB_SYNTH_TIERS.md) for sizing the synthesis endpoint.
 
 The configured dimension must equal the model output. DB2 records the dimension used to create its
 vector columns and refuses startup on drift. Silent empty vector search is worse than a hard start

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -545,7 +545,7 @@ def render_config(fields, sections, flat):
 
     for title, blurb, group in (
         ("Deploy-time keys", "Consumed once by `config_emit_deploy_env` to stand up the "
-         "aimee-llm container (`aimee config deploy-env`); not read at runtime. Set at "
+         "managed sibling services (`aimee config deploy-env`); not read at runtime. Set at "
          "deploy, not tuned day-to-day.", deploy),
         ("Advanced tuning keys", "Expert scalars with sensible defaults; settable in the "
          "config file but off the everyday surface.", advanced),
@@ -680,7 +680,7 @@ ENV_DESC = {
     "AIMEE_GITHUB_OAUTH_CLIENT_ID": ("Server runtime", "Client ID of a GitHub OAuth App for the webchat \"Sign in with GitHub\" button; populates the github.com git credential. Public. Overrides the built-in default baked in via oauth_defaults.h."),
     "AIMEE_GITHUB_OAUTH_CLIENT_SECRET": ("Server runtime", "First-boot transport for the GitHub OAuth App client secret. The entrypoint synchronously seals it into Vault and scrubs the environment before aimee-server starts; startup fails closed if custody cannot be established. Enables browser redirect sign-in; without it the button falls back to the device-code flow."),
     "AIMEE_GITLAB_OAUTH_CLIENT_ID": ("Server runtime", "Client ID of a GitLab OAuth application (device flow enabled) for the webchat \"Sign in with GitLab\" button on gitlab.com. Public. Overrides the built-in default baked in via oauth_defaults.h."),
-    "AIMEE_DEPLOY_ENABLED": ("Server runtime", "Set to 1 to enable the server-orchestrated deploy: the setup wizard runs `docker compose up -d` for the managed sibling services (aimee-kb + aimee-llm) via a mounted Docker socket. Off unless the deploy compose sets it."),
+    "AIMEE_DEPLOY_ENABLED": ("Server runtime", "Set to 1 to enable the server-orchestrated deploy: the setup wizard runs `docker compose up -d` for the managed sibling service (aimee-kb) via a mounted Docker socket. Off unless the deploy compose sets it."),
     "AIMEE_DEPLOY_COMPOSE_FILE": ("Server runtime", "Path to the managed compose file the server-orchestrated deploy runs (default /opt/aimee/deploy/aimee-managed.compose.yaml)."),
     "AIMEE_INGRESS_PROXY_SECRET": ("Server runtime", "First-boot transport for the shared secret authenticating trusted ingress identity headers. It is sealed into Vault and removed from the environment before the long-lived server starts."),
     "AIMEE_PARALLEL_MAX": ("Server runtime", "Maximum parallel agent fan-out."),
@@ -692,7 +692,7 @@ ENV_DESC = {
     "AIMEE_SOCK": ("Server runtime", "Sandbox helper socket path."),
     # Knowledge base
     "AIMEE_LLM_URL": ("Knowledge base (aimee-kb)", "Synthesis endpoint (curator Tier-A + Tier-B at {url}/v1). No longer selects an embedder: the kb embeds in-container, and AIMEE_EMBEDDER_URL points at an external embedder. See docs/KB_LLM_BACKENDS.md."),
-    "AIMEE_LLM_AUTH_TOKEN": ("Managed KB and inference", "First-boot transport for the bearer service identity shared by aimee-kb and its aimee-llm gateway. aimee-kb synchronously seals it into Vault, scrubs the environment, and cleanly re-execs before serving; wizard-managed deploys generate the 256-bit value in Vault. This is separate from user/server bearers."),
+    "AIMEE_LLM_AUTH_TOKEN": ("Managed KB and inference", "First-boot transport for the bearer aimee-kb presents to the external synthesis endpoint. aimee-kb synchronously seals it into Vault, scrubs the environment, and cleanly re-execs before serving; wizard-managed deploys generate the 256-bit value in Vault. This is separate from user/server bearers."),
     "AIMEE_LLM_AUTH_REQUIRED": ("Managed KB and inference", "Set to 1 on wizard-managed KBs so synthesis clients refuse to contact the LLM when its bearer service identity is missing."),
     "AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE": ("Managed KB and inference", "Explicit first-boot migration/adoption transport for an existing wizard-managed LLM credential. aimee-server seals it into Vault and scrubs the environment before normal startup. Ordinary inherited AIMEE_LLM_AUTH_TOKEN is ignored by managed credential creation so stale child-service state cannot win. Must be a 32..512 character RFC 6750 b64token."),
     "AIMEE_OFFLINE_ALLOW_NO_SWAP_MLOCK_FALLBACK": (

--- a/src/headers/deploy_apply.h
+++ b/src/headers/deploy_apply.h
@@ -6,17 +6,16 @@
 /* deploy_apply — server-orchestrated container deploy.
  *
  * When aimee-server runs with the host Docker socket mounted, the setup wizard can
- * bring up the managed sibling services (aimee-kb + aimee-llm) itself:
- * the operator deploys ONE container (aimee-server) and the finished wizard spins
- * up the rest. The wizard's page-2 config is translated by config_emit_deploy_env
- * into the compose env (COMPOSE_PROFILES + AIMEE_LLM_* + AIMEE_KB_API_* …), and
- * this module starts aimee-kb and then aimee-llm with ordered, detached Compose
- * commands against the mounted socket.
+ * bring up the managed sibling service (aimee-kb) itself: the operator deploys ONE
+ * container (aimee-server) and the finished wizard spins up the rest. The wizard's
+ * page-2 config is translated by config_emit_deploy_env into the compose env
+ * (COMPOSE_PROFILES + AIMEE_LLM_* + AIMEE_KB_API_* …), and this module starts
+ * aimee-kb with a detached Compose command against the mounted socket. There is no
+ * inference container: the KB embeds in-process from weights baked into its image.
  *
  * `up -d` may pull multi-GB images, so the apply runs on a BACKGROUND THREAD (the
  * HTTP listener is single-threaded and must not block for minutes). The wizard
- * kicks it off, then polls status. Model downloads happen inside aimee-llm after
- * the container starts and are not a wizard-completion barrier. */
+ * kicks it off, then polls status. */
 
 /* 1 iff server-orchestrated deploy is enabled: AIMEE_DEPLOY_ENABLED=1 (the deploy
  * compose mounts the Docker socket + managed compose file and sets this). */

--- a/src/modules/config/config_fields.h
+++ b/src/modules/config/config_fields.h
@@ -40,9 +40,10 @@ typedef enum
 typedef enum
 {
    FGROUP_RUNTIME = 0, /* everyday user-facing knob (default) */
-   FGROUP_DEPLOY,      /* deploy-time infra (LLM-container topology): consumed once by
-                          config_emit_deploy_env to stand up the aimee-llm container,
-                          never read at runtime. Set at deploy, not tuned day-to-day. */
+   FGROUP_DEPLOY,      /* deploy-time infra topology: consumed once by
+                          config_emit_deploy_env to stand up the managed sibling
+                          services, never read at runtime. Set at deploy, not
+                          tuned day-to-day. */
    FGROUP_ADVANCED,    /* expert tuning scalar with a good default; file-settable, off surface */
    FGROUP_DEV,         /* dev/QA-only (e.g. dogfood_*); not part of the user surface */
 } config_field_group_t;


### PR DESCRIPTION
Documentation pass over what actually ships, prompted by the clean-install work in #2191/#2192.

## The quickstart had three wrong claims, not just dated ones

1. **The credential story was inverted.** It instructed operators to export
   `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` and stated that "a missing or partial pair is
   rejected instead of generating a credential in logs" — the opposite of what #2189 shipped. The
   generated first-boot login is now the default path. Documented the real rule from
   `runtime-web-lib.sh`: both variables or neither, since `webchat_provision_login` requires both
   non-empty and `webchat_bootstrap_login_needed` only skips generation when both are set.
2. **It promised an `aimee-llm` container** that Deploy starts, plus paragraphs on LLM startup
   ordering, model downloads and a local service identity. None of that exists.
3. **It never mentioned choosing an embedder.** A fresh install selects none, silently falls back to
   the builtin lexical embedder, and says so only in the KB log. Retrieval keeps working while not
   being dense — the failure a reader is most likely to hit and least likely to notice. Added
   *Choosing an embedder* with the log line to check and the command to fix it.

## Two docs contradicted themselves

- `KB_LLM_BACKENDS.md` opened with "aimee-kb runs no model" directly above its own table saying
  embedding is in-container.
- `AIMEE_KB_SYNTH_TIERS.md` correctly said embedding is in-container, then published a tier table
  with per-tier embedding widths of 1024/2560 against a bundled 384-dim model. Embedding width is no
  longer a tier property, so that column is gone.
- `ARCHITECTURE.md`'s process table claimed `aimee-kb` does not own model serving. It does now, and
  the topology diagram still drew an `aimee-llm` node.

## Also

`README`, `MANUAL`, `DEPLOYMENT`, `retrieval-stack`, `WHATS_NEW`.

`docs/gen/configuration.md` is regenerated from corrected source strings
(`config_fields.h`, `deploy_apply.h`, `gen-reference-docs.py`), not hand-edited — the file says not
to.

## Deliberately unchanged

`docs/proposals/**`, `docs/runbooks/unified-llm-cutover.md` and `docs/validation/**` still name
`aimee-llm`. They record what was proposed and done at the time; rewriting them would falsify the
record. Happy to add a superseded banner instead if preferred.

## Verification

- `make docs-gen-check`: ok.
- Every claim traced to code. The first-boot rule, the embedder fallback and the
  `embedding_model` command were all exercised on a clean `.211` install last night.
- Not done: I have not walked the quickstart end-to-end on a fresh machine since editing it. Step 1
  matches what I ran; the rest I read rather than re-ran.