### PR TITLE
Fix the env-var deployment path: zero vectors stored, and a preflight that claimed ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,6 +276,13 @@ for name, spec in table.items():
         snapshot_download(code_repo, allow_patterns=["*.py", "*.json", "*.txt"])
 PYBAKE
 
+# The bake runs as root and huggingface_hub writes its tree-cache metadata 0600, so
+# the `aimee` runtime user cannot read it. The weights themselves land world-readable,
+# so the model still loads — it just logs "Ignoring corrupted tree cache file …
+# Permission denied" on every start and re-walks what the cache existed to avoid.
+# a+rX: readable everywhere, traversable on directories, and no file gains +x.
+RUN chmod -R a+rX /opt/aimee/models
+
 # Sidecar clients (the LLM access code the kb invokes via popen).
 COPY scripts/embed-remote.py scripts/llm-chat.py \
      scripts/learning-synthesize.py scripts/curator-extract.py scripts/llm-rewrite.py \

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -34,8 +34,14 @@ services:
       # the builtin serves forever — the wizard's embedder silently never runs.
       EMBEDDER_MODEL: ${EMBEDDER_MODEL:-}
       AIMEE_EMBEDDER_URL: ${AIMEE_EMBEDDER_URL:-}
-      # Embedding dim — CPU tier default 1024; the GPU override sets 2560.
-      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-1024}
+      # Embedding dim. Leave EMPTY so the kb uses the dimension of the embedder it
+      # actually serves (the bundled bekko-a25m is 384). This carried the retired
+      # aimee-llm CPU tier's 1024: with the bundled embedder the kb came up healthy,
+      # accepted writes, and then refused every vector upsert with
+      # "dim mismatch: got 384, expected 1024" — dense retrieval silently dead.
+      # Set it ONLY for an external AIMEE_EMBEDDER_URL, whose width the kb cannot
+      # know.
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       AIMEE_KB_HTTP_BIND: "1"
       # The curator synth sidecar (curator-extract.py) reads LLM_ENDPOINT, NOT
       # AIMEE_LLM_URL. Defaulted empty for the same reason as AIMEE_LLM_URL above:

--- a/deploy/smoothnas/aimee.compose.yaml
+++ b/deploy/smoothnas/aimee.compose.yaml
@@ -45,7 +45,11 @@ services:
       # the builtin serves forever — the wizard's embedder silently never runs.
       EMBEDDER_MODEL: ${EMBEDDER_MODEL:-}
       AIMEE_EMBEDDER_URL: ${AIMEE_EMBEDDER_URL:-}
-      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-2560}
+      # Empty so the kb uses the width of the embedder it serves (bundled
+      # bekko-a25m is 384). This carried the retired aimee-llm GPU tier's 2560,
+      # which made the kb refuse every vector upsert while reporting healthy.
+      # Set it ONLY for an external AIMEE_EMBEDDER_URL.
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       AIMEE_KB_HTTP_BIND: "1"
     command: ["--http-port=8741"]
     ports:

--- a/src/db2/lifecycle.h
+++ b/src/db2/lifecycle.h
@@ -32,6 +32,16 @@ extern "C"
     * 0 means neither was supplied — treat as an error, never as a default. */
    int db2_embedding_dim(void);
 
+   /* How many vector upserts have been refused for disagreeing with that width,
+    * and the last width actually offered.
+    *
+    * A wrong AIMEE_EMBEDDING_DIM is otherwise invisible: the kb starts, reports
+    * healthy, accepts writes, and refuses every upsert with a per-row WARN, so a
+    * deployment can store zero vectors indefinitely while looking fine. Health
+    * publishes this so the condition is legible without reading kb logs. */
+   long long db2_embedding_dim_refused_count(void);
+   int db2_embedding_dim_last_offered(void);
+
    /* embedder-runtime-fetch-autodim §2a: mark whether the operator pinned the dim
     * (see config_embedding_dim_is_pinned). Call beside db2_set_embedding_dim,
     * before db2_init. When UNpinned (0, the default), db2_init prefers a recorded

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -9,6 +9,7 @@
 #include "log.h"
 
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,6 +19,21 @@ static pthread_mutex_t latency_mu = PTHREAD_MUTEX_INITIALIZER;
 static int64_t latency_total_us = 0;
 static int64_t latency_count = 0;
 static int64_t latency_max_us = 0;
+
+/* Vector upserts refused for width disagreement, and the last width offered.
+ * Relaxed: these are reported, never branched on. */
+static _Atomic long long g_dim_refused = 0;
+static _Atomic int g_dim_last_offered = 0;
+
+long long db2_embedding_dim_refused_count(void)
+{
+   return atomic_load_explicit(&g_dim_refused, memory_order_relaxed);
+}
+
+int db2_embedding_dim_last_offered(void)
+{
+   return atomic_load_explicit(&g_dim_last_offered, memory_order_relaxed);
+}
 
 static int64_t monotonic_us(void)
 {
@@ -275,6 +291,10 @@ int pgvec_memory_upsert(int64_t point_id, const float *vec, int dim, const char 
    int expect = db2_embedding_dim();
    if (expect > 0 && dim != expect)
    {
+      /* Record it as well as logging it: a per-row WARN in the kb log is invisible
+       * to anyone reading health, and this condition silently drops every vector. */
+      atomic_fetch_add_explicit(&g_dim_refused, 1, memory_order_relaxed);
+      atomic_store_explicit(&g_dim_last_offered, dim, memory_order_relaxed);
       aimee_log(
           LOG_WARN, "pgvec",
           "memory embedding dim mismatch: got %d, expected %d (point_id=%lld); refusing upsert",

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -9,6 +9,14 @@
 int agent_load_config(agent_config_t *cfg);
 int agent_save_config(const agent_config_t *cfg);
 
+/* As agent_save_config, but the caller has just removed an agent and an empty
+ * registry is therefore the intended result. The deletion guard in
+ * agent_save_config cannot tell a deliberate removal of the LAST delegate from a
+ * zeroed or failed-to-load cfg, so it refuses both; removing the only configured
+ * delegate failed with "could not save agents.json" until this existed. Only the
+ * remove handler may use it — it is the one caller that knows. */
+int agent_save_config_after_removal(const agent_config_t *cfg);
+
 /* A valid agent/model slug: 1–48 chars, starting alphanumeric, then alphanumeric
  * or . _ - . Agent names surface as model ids in /v1/models, so this keeps junk
  * (over-long or non-identifier) names out of agents.json and the model list.

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -354,6 +354,18 @@ static cJSON *kb_service_health_object(void)
    cJSON_AddBoolToObject(resp, "embed_ok", embed_ok);
    cJSON_AddStringToObject(resp, "embed_command", embed_cmd);
 
+   /* embed_ok reports only that an embedder is CONFIGURED. An embedder that runs
+    * and produces the wrong width stores nothing, so publish the refusal count
+    * too: non-zero means every vector since startup was dropped and dense
+    * retrieval is dead, however healthy the rest of this response looks. */
+   long long dim_refused = db2_embedding_dim_refused_count();
+   cJSON_AddNumberToObject(resp, "embedding_dim_refused", (double)dim_refused);
+   if (dim_refused > 0)
+   {
+      cJSON_AddNumberToObject(resp, "embedding_dim_expected", db2_embedding_dim());
+      cJSON_AddNumberToObject(resp, "embedding_dim_offered", db2_embedding_dim_last_offered());
+   }
+
    /* Curator (§4 observability): per-tier provider config + queue depth. The
     * live four-state reachability probe (ready/loading/gated/down) is deferred to
     * a follow-up — it needs a bounded async probe so the health path never blocks,

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1663,7 +1663,7 @@ static int agent_config_existing_agent_count(void)
    return n;
 }
 
-int agent_save_config(const agent_config_t *cfg)
+static int agent_save_config_impl(const agent_config_t *cfg, int emptied_by_removal)
 {
    cJSON *root = cJSON_CreateObject();
 
@@ -1887,8 +1887,13 @@ int agent_save_config(const agent_config_t *cfg)
     * file that already has none) — never as a silent wipe of configured agents.
     * This is the agents.json-deletion guard: whatever the trigger (a load that
     * came back empty, a caller with a zeroed cfg), the destruction stops here, and
-    * it stops LOUDLY so the next occurrence is diagnosable rather than invisible. */
-   if (cfg->agent_count == 0)
+    * it stops LOUDLY so the next occurrence is diagnosable rather than invisible.
+    *
+    * Removing the LAST delegate reaches zero legitimately, and looks identical
+    * from here — so that one caller declares itself instead. Without the
+    * exemption the guard refused the removal and the delegate could never be
+    * deleted. */
+   if (cfg->agent_count == 0 && !emptied_by_removal)
    {
       int existing = agent_config_existing_agent_count();
       if (existing > 0)
@@ -1958,6 +1963,16 @@ int agent_save_config(const agent_config_t *cfg)
    }
    free(json);
    return 0;
+}
+
+int agent_save_config(const agent_config_t *cfg)
+{
+   return agent_save_config_impl(cfg, 0);
+}
+
+int agent_save_config_after_removal(const agent_config_t *cfg)
+{
+   return agent_save_config_impl(cfg, 1);
 }
 
 /* --- Auth resolution --- */

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -1014,7 +1014,9 @@ int handle_agent_remove(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       snprintf(cfg.default_agent, sizeof(cfg.default_agent), "%s",
                cfg.agent_count > 0 ? cfg.agents[0].name : "");
 
-   if (agent_save_config(&cfg) != 0)
+   /* Removing the last delegate legitimately empties the registry, which the
+    * deletion guard would otherwise refuse. */
+   if (agent_save_config_after_removal(&cfg) != 0)
       return server_send_error(conn, "could not save agents.json", NULL);
    (void)server_agent_clear_model_concurrency_if_unused(&cfg, removed_model);
 

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1657,7 +1657,20 @@ void handle_conn(int fd, int is_tcp, int is_management)
       {
          const char *msg = server_http_auth_error_body(az);
          send_response(fd, az, msg, request_id);
-         LOG_INFO("server.http", "%s %s -> %d req_id=%s", method, path, az, request_id);
+         /* The container healthcheck GETs /v1/health with no credential every 10s
+          * and treats 401 as healthy (it has no bearer to present, and having one
+          * in container metadata would be worse). Logging that designed probe at
+          * INFO produced a 401 line every 10 seconds for the life of the server —
+          * noise that buries the auth failures worth reading. Demote just that
+          * shape; every other rejection still logs. */
+         int health_probe = az == 401 && strcmp(method, "GET") == 0 &&
+                            strcmp(path, "/v1/health") == 0 && !has_auth && !has_api_key &&
+                            !has_skey;
+         if (health_probe)
+            LOG_DEBUG("server.http", "%s %s -> %d req_id=%s (unauthenticated health probe)", method,
+                      path, az, request_id);
+         else
+            LOG_INFO("server.http", "%s %s -> %d req_id=%s", method, path, az, request_id);
          return;
       }
    }

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -2348,10 +2348,23 @@ int server_http_start(const char *uds_path, int tcp_port, int tls_port, const ch
                 "a verified certificate-bound first owner is unaffected");
       break;
    case SERVER_WRITE_TIER_CONFIG_NO_TRUST_BUNDLE:
-      LOG_ERROR("server.http",
-                "AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE is unset: KB-issued write tokens are denied "
-                "with invalid; a verified certificate-bound first owner is unaffected");
+   {
+      /* Name the path when one was supplied: the shipped standalone compose
+       * defaults it to a conventional location nothing mounts, so "is unset" was
+       * the one thing this could not be. */
+      const char *bundle = getenv("AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE");
+      if (bundle && bundle[0])
+         LOG_ERROR("server.http",
+                   "AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE is set to '%s' but that file is not "
+                   "readable: KB-issued write tokens are denied with invalid; a verified "
+                   "certificate-bound first owner is unaffected",
+                   bundle);
+      else
+         LOG_ERROR("server.http",
+                   "AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE is unset: KB-issued write tokens are "
+                   "denied with invalid; a verified certificate-bound first owner is unaffected");
       break;
+   }
    case SERVER_WRITE_TIER_CONFIG_READY:
       break;
    }

--- a/src/server/server_write_tier_db1.c
+++ b/src/server/server_write_tier_db1.c
@@ -14,6 +14,7 @@
 
 #include <openssl/crypto.h>
 #include <string.h>
+#include <unistd.h> /* access — startup preflight only */
 
 static const char *tier_text(kb_identity_tier_t tier)
 {
@@ -91,6 +92,18 @@ server_write_tier_config_state_t server_write_tier_config_state(void)
       return SERVER_WRITE_TIER_CONFIG_NO_SERVER_ID;
    const char *bundle_path = getenv("AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE");
    if (!bundle_path || !bundle_path[0])
+      return SERVER_WRITE_TIER_CONFIG_NO_TRUST_BUNDLE;
+   /* The variable being SET is not the input; the bundle being THERE is. The
+    * shipped standalone compose defaults this to a conventional path nothing
+    * mounts, so a deployment that never provisioned an authority reported READY
+    * while every KB-issued token was in fact denied — and the precise startup
+    * error naming this variable was suppressed in favour of a vague recurring
+    * "management JWKS authorization unavailable" warning.
+    *
+    * Readability only: this is a startup preflight answering "did the operator
+    * supply the inputs". Structural validation stays in build_config, which
+    * fails closed per request. Called once at startup, so the stat is free. */
+   if (access(bundle_path, R_OK) != 0)
       return SERVER_WRITE_TIER_CONFIG_NO_TRUST_BUNDLE;
    return SERVER_WRITE_TIER_CONFIG_READY;
 }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -3249,9 +3249,9 @@ static void test_agent_config_deletion_guard(void)
 
       agent_config_t last;
       assert(agent_load_config(&last) == 0 && last.agent_count == 1);
-      last.agent_count = 0; /* now drop the last one */
-      assert(agent_save_config(&last) != 0);                /* plain save still refuses */
-      assert(agent_save_config_after_removal(&last) == 0);  /* the removal path may */
+      last.agent_count = 0;                                /* now drop the last one */
+      assert(agent_save_config(&last) != 0);               /* plain save still refuses */
+      assert(agent_save_config_after_removal(&last) == 0); /* the removal path may */
 
       agent_config_t gone;
       assert(agent_load_config(&gone) == 0 && gone.agent_count == 0);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -3235,6 +3235,39 @@ static void test_agent_config_deletion_guard(void)
       assert(system(cmd) != 0);
    }
 
+   /* (4) Removing the LAST agent empties the registry legitimately, and the guard
+    * must not refuse it. It looks identical to case (1) from inside the save, so
+    * the remove path declares itself; without that, deleting the only configured
+    * delegate failed with "could not save agents.json" and it could never be
+    * removed. Removing one of several was unaffected, which is why this hid. */
+   {
+      assert(agent_save_config(&cfg) == 0); /* 2 agents on disk */
+      agent_config_t one;
+      assert(agent_load_config(&one) == 0 && one.agent_count == 2);
+      one.agent_count = 1; /* drop beta, as handle_agent_remove does */
+      assert(agent_save_config(&one) == 0);
+
+      agent_config_t last;
+      assert(agent_load_config(&last) == 0 && last.agent_count == 1);
+      last.agent_count = 0; /* now drop the last one */
+      assert(agent_save_config(&last) != 0);                /* plain save still refuses */
+      assert(agent_save_config_after_removal(&last) == 0);  /* the removal path may */
+
+      agent_config_t gone;
+      assert(agent_load_config(&gone) == 0 && gone.agent_count == 0);
+   }
+
+   /* (5) The exemption is scoped to removal: a zeroed cfg from any other caller is
+    * still refused over a populated file. */
+   {
+      assert(agent_save_config(&cfg) == 0);
+      agent_config_t zeroed;
+      memset(&zeroed, 0, sizeof(zeroed));
+      assert(agent_save_config(&zeroed) != 0);
+      agent_config_t after;
+      assert(agent_load_config(&after) == 0 && after.agent_count == 2);
+   }
+
    if (old_home)
       assert(platform_setenv("HOME", saved_home) == 0);
    else

--- a/src/tests/test_server_write_tier_db1.c
+++ b/src/tests/test_server_write_tier_db1.c
@@ -9,6 +9,8 @@
 #include "db1_internal.h"
 #include "server_write_tier_db1.h"
 
+#include "platform_test_util.h" /* platform_tmpdir */
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -54,7 +56,21 @@ int main(void)
    assert(server_write_tier_config_state() == SERVER_WRITE_TIER_CONFIG_NO_SERVER_ID);
    setenv("AIMEE_SERVER_ID", "managed-server", 1);
    assert(server_write_tier_config_state() == SERVER_WRITE_TIER_CONFIG_NO_TRUST_BUNDLE);
+
+   /* A path that does not exist is NOT a supplied input. The shipped standalone
+    * compose defaults this variable to a conventional location nothing mounts, so
+    * treating "set" as READY made a deployment with no authority report ready
+    * while every KB-issued token was denied. Only a readable bundle is READY. */
    setenv("AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE", "/run/aimee/management/jwks-trust-bundle.json", 1);
+   assert(server_write_tier_config_state() == SERVER_WRITE_TIER_CONFIG_NO_TRUST_BUNDLE);
+
+   char bundle[512];
+   snprintf(bundle, sizeof(bundle), "%s/aimee-trust-XXXXXX", platform_tmpdir());
+   int bundle_fd = mkstemp(bundle);
+   assert(bundle_fd >= 0);
+   assert(write(bundle_fd, "{}", 2) == 2);
+   close(bundle_fd);
+   setenv("AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE", bundle, 1);
    assert(server_write_tier_config_state() == SERVER_WRITE_TIER_CONFIG_READY);
    printf("ok: startup preflight identifies each missing Compose input\n");
 


### PR DESCRIPTION
Found while verifying the clean install, then extended after a question worth asking: **what if the deployment is script + env vars instead of the wizard?** That path was broken, and my earlier verification had only ever exercised the wizard.

## 1. The split stack stored zero vectors while reporting healthy

`deploy/compose/aimee.yaml` defaulted `AIMEE_EMBEDDING_DIM` to **1024** and `deploy/smoothnas/aimee.compose.yaml` to **2560** — the retired `aimee-llm` CPU and GPU tier widths. The bundled embedder is **384**. `deploy/container/aimee-managed.compose.yaml` was updated at the bekko cutover and these two were not, which is exactly why wizard-only testing missed it.

Observed on a clean split deploy with operator defaults:

```
pgvec: memory embedding dim mismatch: got 384, expected 1024; refusing upsert
pgvec_vectors: 0
```

while `aimee memory store` reported `stored memory 1`, search returned the record from the lexical path, and kb health reported `status: ok, pgvec_ok: true, embed_ok: true`. Dense retrieval was permanently dead and nothing said so.

Default both to empty, as the managed compose already does, so the kb uses the width of the embedder it actually serves.

## 2. That condition was invisible, which is the worse half

A per-row WARN in the kb log is not something an operator reads, and every other signal said healthy. This also breaks the invariant in `docs/DEPLOYMENT.md`: *"The KB must report explicit degradation when a configured inference stage is unavailable. It cannot claim a dense result after silently skipping that stage."*

Health now publishes `embedding_dim_refused`, plus the expected and offered widths when non-zero, so `aimee kb status` shows it. This matters beyond the defaults: an operator who pins the wrong width, or points `AIMEE_EMBEDDER_URL` at an endpoint of a different width, hits the same silent loss.

`embed_ok` is unchanged — it reports that an embedder is *configured*, which stays true.

## 3. `agent remove` could not delete the only configured delegate

The `agents.json` deletion guard refuses any save that empties a populated registry. It cannot tell a deliberate removal of the last delegate from a zeroed or failed-to-load cfg, so it refused both, as the `aimee` user and as root, with the file writable. Removing one of several worked, which is why it hid:

```
===REMOVE-ONE-OF-TWO   Delegate 'beta' removed.
===REMOVE-LAST         aimee: could not save agents.json
```

The one caller that knows the empty result is intended now says so. The guard still refuses every other zeroed save, and the test pins that scoping.

## 4. The `/v1/health` 401 log loop

The container healthcheck GETs `/v1/health` unauthenticated every 10s and treats 401 as healthy — it has no bearer to present. Logging that designed probe at INFO produced **245 identical lines in 40 minutes**. Demoted exactly that shape to DEBUG; every other rejection still logs. Verified 0 lines after, with the container still `healthy` (the healthcheck reads the HTTP status, not the log).

## 5. Baked model cache unreadable by the runtime user

The bake runs as root and `huggingface_hub` writes tree metadata `0600`, so `aimee` (uid 999) could not read it; every KB start logged `Ignoring corrupted tree cache file … Permission denied` and re-walked what the cache exists to avoid. Weights were already world-readable, so this was noise. `chmod -R a+rX` after the bake. Verified 0 denials, model still loads at `dim=384`.

## Deliberately NOT changed

`AIMEE_SERVER_TEAM_ID is unset` (ERROR) and `management JWKS authorization unavailable` (WARN) are transient on the **wizard** path — both clear once Deploy runs:

```
07:45:01 WARN  management JWKS authorization unavailable
07:45:47 INFO  management JWKS authorization ready
08:25:32 INFO  management JWKS authorization ready     <- restart, no warning
```

`server_runtime_identity_load` explains it: explicit `AIMEE_SERVER_ID`/`AIMEE_SERVER_TEAM_ID` win, and otherwise it falls back to the managed metadata that wizard enrollment writes.

On a **standalone env-var** deployment the picture differs — `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE` defaults to a path rather than empty, so that warning fires on every boot unless an authority is provisioned. It is truthful there, so I have not changed it, but it is not "transient" outside the wizard path and deserves a separate decision.

## Verification

- `test_agent_config_deletion_guard` cases (4) and (5) fail without the fix and pass with it.
- `unit-test-agent` passes; `make lint` `aimee-home-check` ok.
- Split stack deployed on a torn-down `.211` in two configurations: operator defaults, and a deliberately wrong explicit pin.


---

## 6. The write-tier preflight reported READY without the trust bundle

`server_write_tier_config_state()` checked only that `AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE` was
non-empty, never that the file existed. `compose.server-standalone.yaml` defaults it to a
conventional path nothing mounts, so a standalone env-var deployment that never provisioned an
authority reported **READY while every KB-issued write token was denied** — and because READY is the
silent branch, it suppressed the one startup line naming the variable and the consequence, leaving
only a vague recurring `management JWKS authorization unavailable`.

The existing test encoded that defect:

```c
setenv("AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE", "/run/aimee/management/jwks-trust-bundle.json", 1);
assert(server_write_tier_config_state() == SERVER_WRITE_TIER_CONFIG_READY);  // nonexistent -> READY
```

Now the preflight checks the bundle is readable, and the message names the path when one was
supplied. Readability only: this answers "did the operator supply the inputs"; structural validation
stays in `build_config`, which fails closed per request. Runs once at startup.

**No security change** — authorization already failed closed either way. This is the server telling
the truth at startup instead of claiming ready.

The conventional default is deliberately kept: mount a bundle there and it works, omit it and the
server names the file it wanted.
