### PR TITLE
Name the worker that leaked the DB2 pool lease

### DIFF
--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -574,7 +574,7 @@ static void *db2_thread_acquire(void)
    return conn;
 }
 
-void *db2_conn(void)
+void *db2_conn_at(const char *site)
 {
    pthread_once(&g_thread_conn_key_once, thread_conn_key_init);
    db2_thread_lease_t *L = (db2_thread_lease_t *)pthread_getspecific(g_thread_conn_key);
@@ -583,9 +583,23 @@ void *db2_conn(void)
    /* The db2_init() owner thread uses its dedicated g_conn directly. */
    if (!g_init_thread_set || pthread_equal(pthread_self(), g_init_thread))
       return g_conn;
+   /* Attribute a LAZY acquire (depth 0, outside any db2_lease_begin scope). That
+    * is the shape that leaks: a long-lived worker takes a connection here and
+    * never calls db2_lease_release_idle, pinning a pool member for its lifetime.
+    * Only db2_lease_begin used to record a site, so precisely this case reached
+    * the reaper "unattributed". Set only when no scope owns the thread, so an
+    * explicit begin keeps its own attribution. */
+   if (!g_lease_site && site)
+      g_lease_site = site;
    /* Every other thread leases from the pool (lazily; returned on thread exit
     * by the destructor, or sooner via db2_lease_end at a job boundary). */
    return db2_thread_acquire();
+}
+
+/* Kept for any translation unit that does not see the db2_conn() macro. */
+void *(db2_conn)(void)
+{
+   return db2_conn_at(NULL);
 }
 
 void db2_lease_begin_at(const char *site)
@@ -621,6 +635,7 @@ void db2_lease_end(void)
          L->conn = NULL;
          L->pooled = 0;
       }
+      g_lease_site = NULL;
    }
 }
 
@@ -646,6 +661,7 @@ void db2_lease_release_idle(void)
       L->conn = NULL;
       L->pooled = 0;
    }
+   g_lease_site = NULL;
 }
 
 void *db2_thread_conn_open(char *errbuf, size_t errlen)

--- a/src/db2/db2_internal.h
+++ b/src/db2/db2_internal.h
@@ -35,7 +35,7 @@ extern "C"
     * or a non-init thread cannot acquire its own connection. The process-global
     * init connection is never shared across threads: libpq forbids concurrent
     * use of one PGconn. */
-   void *db2_conn(void);
+   void *(db2_conn)(void);
 
    /* Bracket a unit of work so the thread's pooled connection is returned to the
     * pool between units (refcounted; see lifecycle.h). */

--- a/src/db2/db2_pool.c
+++ b/src/db2/db2_pool.c
@@ -321,6 +321,9 @@ int db2_pool_reaper_sweep(void)
 {
    int stuck = 0, live = 0, waiters = 0;
    char reason[256] = "";
+   /* Who held the first stuck member, so the fatal line names a code location
+    * instead of only a count. */
+   const char *first_site = NULL;
    pthread_mutex_lock(&g_mtx);
    int64_t now = mono_ms();
    for (int i = 0; i < g_size; i++)
@@ -332,6 +335,8 @@ int db2_pool_reaper_sweep(void)
       {
          stuck++;
          g_stuck++;
+         if (!first_site)
+            first_site = g_members[i].site;
          POOL_LOG("member %d leased %lldms (> %lldms ceiling) by %s — missed lease_end?", i,
                   (long long)(now - g_members[i].lease_ms), (long long)g_hold_ceiling_ms,
                   g_members[i].site ? g_members[i].site : "unattributed");
@@ -360,8 +365,9 @@ int db2_pool_reaper_sweep(void)
       g_starved_sweeps++;
       snprintf(reason, sizeof(reason),
                "all %d pool members stuck past the %lldms ceiling with %d waiter(s) for %d "
-               "consecutive sweeps — lease leak, unrecoverable in-process",
-               g_size, (long long)g_hold_ceiling_ms, waiters, g_starved_sweeps);
+               "consecutive sweeps — lease leak, unrecoverable in-process; first holder: %s",
+               g_size, (long long)g_hold_ceiling_ms, waiters, g_starved_sweeps,
+               first_site ? first_site : "unattributed");
    }
    else
       g_starved_sweeps = 0;

--- a/src/db2/lifecycle.h
+++ b/src/db2/lifecycle.h
@@ -171,6 +171,21 @@ extern "C"
 #define DB2_LEASE_SITE_(f, l)   f ":" DB2_LEASE_STRINGIFY_(l)
 #define db2_lease_begin()       db2_lease_begin_at(DB2_LEASE_SITE_(__FILE__, __LINE__))
 #endif
+
+   /* db2_conn() with the caller's file:line, so a LAZY acquire (outside any
+    * db2_lease_begin scope) can be attributed too.
+    *
+    * That is the leak the reaper most needs to name: a long-lived worker that
+    * takes a connection via db2_conn() at depth 0 and never calls
+    * db2_lease_release_idle pins a pool member for its whole lifetime. Only
+    * db2_lease_begin recorded a site, so exactly this case logged as
+    * "unattributed" -- a prod kb sat with all 16 members held ~15h and the
+    * reaper could not say by whom. The site is stored only when a connection is
+    * actually acquired, not on every call. */
+   void *db2_conn_at(const char *site);
+#ifndef db2_conn
+#define db2_conn() db2_conn_at(DB2_LEASE_SITE_(__FILE__, __LINE__))
+#endif
    void db2_lease_end(void);
 
    int db2_fork_conn_url(char *out, size_t cap);
@@ -182,7 +197,7 @@ extern "C"
     * aimee_pg_* primitives directly. Production callers should prefer
     * the typed db2_* domain functions; this is exposed for KB-owned
     * migration tooling that copies arbitrary tables row-by-row. */
-   void *db2_conn(void);
+   void *(db2_conn)(void); /* parenthesised: the db2_conn() macro must not expand here */
 
    /* Postgres-native diagnostics for `aimee doctor`. Each out parameter
     * is set to -1 on probe failure; returns 0 when the connection is

--- a/src/tests/test_curator_promote.c
+++ b/src/tests/test_curator_promote.c
@@ -13,7 +13,7 @@
 #include "db2_test_shim.h"
 #include "kb_curator_promote.h"
 
-void *db2_conn(void);
+void *(db2_conn)(void);
 
 static void test_scope_lattice(void)
 {

--- a/src/tests/test_curator_synthesize.c
+++ b/src/tests/test_curator_synthesize.c
@@ -14,7 +14,7 @@
 #include "db2_test_shim.h"
 #include "kb_curator_synthesize.h"
 
-void *db2_conn(void);
+void *(db2_conn)(void);
 
 static void seed(sqlite3 *db, const char *sql)
 {

--- a/src/tests/test_db2_code_audit.c
+++ b/src/tests/test_db2_code_audit.c
@@ -62,9 +62,17 @@ static const fake_clone_row_t fake_clones[] = {
     {"h4", "extraB", "src/extra2.c", "{\"line_count\":8}"},
 };
 
-void *db2_conn(void)
+void *(db2_conn)(void)
 {
    return (void *)0x1;
+}
+
+/* Real code reaches the pool through the db2_conn() macro, which expands to
+ * db2_conn_at(site) so a lazy acquire can be attributed. Route the stub. */
+void *db2_conn_at(const char *site)
+{
+   (void)site;
+   return (db2_conn)();
 }
 
 aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, size_t errlen)

--- a/src/tests/test_db2_pool.c
+++ b/src/tests/test_db2_pool.c
@@ -285,6 +285,7 @@ static void test_starved_pool_gives_up_so_it_can_be_restarted(void)
 
    void *a = db2_pool_lease(1000), *b = db2_pool_lease(1000);
    assert(a && b); /* every member leased, and never returned */
+   db2_pool_note_lease_site(a, "leaky_worker.c:123");
    usleep(120 * 1000);
 
    pthread_t w;
@@ -300,6 +301,10 @@ static void test_starved_pool_gives_up_so_it_can_be_restarted(void)
    (void)db2_pool_reaper_sweep();
    assert(g_starved_calls == 1);
    assert(strstr(g_starved_reason, "lease leak") != NULL);
+   /* The fatal line must name a holder, not just a count: an operator reading it
+    * needs to know WHICH code leaked. Unattributed is still reported explicitly
+    * rather than omitted, so the gap is visible instead of silent. */
+   assert(strstr(g_starved_reason, "leaky_worker.c:123") != NULL);
 
    pthread_join(w, NULL);
    db2_pool_return(a);

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -44,9 +44,17 @@ int aimee_pg_is_shim(void)
 {
    return 1;
 }
-void *db2_conn(void)
+void *(db2_conn)(void)
 {
    return NULL;
+}
+
+/* Real code reaches the pool through the db2_conn() macro, which expands to
+ * db2_conn_at(site) so a lazy acquire can be attributed. Route the stub. */
+void *db2_conn_at(const char *site)
+{
+   (void)site;
+   return (db2_conn)();
 }
 /* The real symbol is db2_lease_begin_at; db2_lease_begin is a macro in db2.h
  * that records the caller's file:line for stuck-lease attribution. */

--- a/src/tests/test_kb_tenancy_shim_guard.c
+++ b/src/tests/test_kb_tenancy_shim_guard.c
@@ -21,9 +21,17 @@ int aimee_pg_is_shim(void)
 {
    return 1;
 }
-void *db2_conn(void)
+void *(db2_conn)(void)
 {
    return NULL;
+}
+
+/* Real code reaches the pool through the db2_conn() macro, which expands to
+ * db2_conn_at(site) so a lazy acquire can be attributed. Route the stub. */
+void *db2_conn_at(const char *site)
+{
+   (void)site;
+   return (db2_conn)();
 }
 /* The real symbol is db2_lease_begin_at; db2_lease_begin is a macro in db2.h
  * that records the caller's file:line for stuck-lease attribution. */

--- a/src/tests/test_management_action_journal.c
+++ b/src/tests/test_management_action_journal.c
@@ -65,9 +65,17 @@ void db2_tenant_scope_rollback(void)
    mock_rollback_count++;
 }
 
-void *db2_conn(void)
+void *(db2_conn)(void)
 {
    return &mock_stmt;
+}
+
+/* Real code reaches the pool through the db2_conn() macro, which expands to
+ * db2_conn_at(site) so a lazy acquire can be attributed. Route the stub. */
+void *db2_conn_at(const char *site)
+{
+   (void)site;
+   return (db2_conn)();
 }
 
 aimee_pg_stmt_t *aimee_pg_prepare_ex(void *conn, const char *sql, aimee_pg_prepare_error_t *kind,

--- a/src/tests/test_management_client_instance.c
+++ b/src/tests/test_management_client_instance.c
@@ -26,9 +26,17 @@ int db2_tenant_require_pg(void)
 {
    return mock_guard;
 }
-void *db2_conn(void)
+void *(db2_conn)(void)
 {
    return &mock_stmt;
+}
+
+/* Real code reaches the pool through the db2_conn() macro, which expands to
+ * db2_conn_at(site) so a lazy acquire can be attributed. Route the stub. */
+void *db2_conn_at(const char *site)
+{
+   (void)site;
+   return (db2_conn)();
 }
 aimee_pg_stmt_t *aimee_pg_prepare_ex(void *c, const char *sql, aimee_pg_prepare_error_t *kind,
                                      char *err, size_t len)

--- a/src/tests/test_management_identity_journal.c
+++ b/src/tests/test_management_identity_journal.c
@@ -73,9 +73,17 @@ void db2_tenant_scope_rollback(void)
    mock_rollback_count++;
 }
 
-void *db2_conn(void)
+void *(db2_conn)(void)
 {
    return &mock_stmt;
+}
+
+/* Real code reaches the pool through the db2_conn() macro, which expands to
+ * db2_conn_at(site) so a lazy acquire can be attributed. Route the stub. */
+void *db2_conn_at(const char *site)
+{
+   (void)site;
+   return (db2_conn)();
 }
 
 aimee_pg_stmt_t *aimee_pg_prepare_ex(void *conn, const char *sql, aimee_pg_prepare_error_t *kind,

--- a/src/tests/test_org_model_catalog_target.c
+++ b/src/tests/test_org_model_catalog_target.c
@@ -19,9 +19,17 @@ int db2_tenant_require_pg(void)
 {
    return 0;
 }
-void *db2_conn(void)
+void *(db2_conn)(void)
 {
    return &g_stmt;
+}
+
+/* Real code reaches the pool through the db2_conn() macro, which expands to
+ * db2_conn_at(site) so a lazy acquire can be attributed. Route the stub. */
+void *db2_conn_at(const char *site)
+{
+   (void)site;
+   return (db2_conn)();
 }
 aimee_pg_stmt_t *aimee_pg_prepare(void *conn, const char *sql, char *err, size_t errlen)
 {


### PR DESCRIPTION
`aimee-prod`'s KB sat with **all 16 pool members held ~15 hours**, serving nothing — 3603 consecutive failed health checks — until a restart cleared it.

## What it was not

The bounded sidecar read (`37cdca19`, *"A hung sidecar must not take a server thread with it"*) was **already in that build** — confirmed with `git merge-base --is-ancestor`. Its bound is 120s. A 120-second read cannot pin a lease for 15 hours, so the documented "unreachable embedder pins a lease" story does not explain this. It was a lease taken and never returned.

## What it was

`db2_init.c` already documents the shape, in `db2_lease_release_idle`'s own comment:

> *"Long-lived periodic workers (curator drain, maintenance timer) otherwise pin a pool connection for their whole lifetime — the reaper flags it as a stuck lease and it permanently shrinks the pool."*

A worker calling `db2_conn()` outside any `db2_lease_begin` scope acquires lazily at depth 0. If it never calls `db2_lease_release_idle`, that member is pinned for the process lifetime. Sixteen such workers exhaust the pool permanently.

**And that case was the one the reaper could not name.** Site attribution only happened here:

```c
if (conn && g_lease_site)
   db2_pool_note_lease_site(conn, g_lease_site);
```

`g_lease_site` is set *only* by `db2_lease_begin_at`. A lazy acquire has none — so the leak that actually occurs reports as `unattributed`, which is exactly what prod's logs showed.

## The change

- `db2_conn()` becomes a macro carrying the caller's `file:line`, mirroring `db2_lease_begin`. The site is stored **only when a connection is really acquired** (not per call — there are 1144 call sites) and cleared on return, so an explicit begin/end scope keeps its own attribution.
- The starvation verdict names the holder instead of only counting members.

Declarations are parenthesised (`void *(db2_conn)(void)`) so the macro does not expand at the declaration or definition.

## Verification

`unit-test-db2-pool` extended: a member with a noted site must appear in the fatal reason.

```
first holder: leaky_worker.c:123; exiting so the restart policy can recover
first holder: unattributed; exiting so the restart policy can recover
```

Both starvation paths exercised — attributed and not. `unit-test-db2` passes; all three binaries build; `make lint` clean except `bus-blast-radius-check` (needs all 7 shipping binaries, this worktree builds 2).

## Scope, honestly

**This does not stop the leak.** I could not identify which worker leaked on prod, because the build that leaked did not record the site — that is the gap being closed. What this buys: the next occurrence names its cause in the fatal line.

The self-heal that restarts a starved pool (`bc9e3d5e`) landed **after** prod's build, which is why prod sat wedged for 15h instead of recovering. Prod now runs a build with both.