### PR TITLE
Say where the gate lives, what startup was waiting for, and that the upgrade is one-way

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -328,7 +328,18 @@ if [ "$AIMEE_WFE_ENGINE" = go ]; then
         sleep 0.1
     done
     if ! kill -0 "$server_pid" 2>/dev/null || [ ! -S "$AIMEE_HOME/aimee-http.sock" ]; then
-        log "fatal: C agent resource plane did not become ready"
+        # Say which of the two it was and how long we waited. These fail for very
+        # different reasons -- a dead process means the server exited (its own log
+        # says why), while a live process with no socket means startup is blocked
+        # before it listens, typically on a dependency such as an unresponsive kb.
+        # The bare message sent me looking at the wrong one for some time.
+        if kill -0 "$server_pid" 2>/dev/null; then
+            log "fatal: aimee-server is running but never created $AIMEE_HOME/aimee-http.sock after $((_wait / 10))s"
+            log "  startup is blocked before the listener; check $AIMEE_HOME/server.log for the last"
+            log "  step reached, and whether a dependency (e.g. aimee-kb) is reachable"
+        else
+            log "fatal: aimee-server exited during startup after $((_wait / 10))s; see $AIMEE_HOME/server.log"
+        fi
         shutdown
         exit 1
     fi

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -34,6 +34,28 @@ Do not rely on a raw copy of a live SQLite main file. Take a consistent backup w
   user the required remote-write grant. The old global `remote_writes` value authorizes nothing.
 - Review mTLS revocation, org catalogs, budgets, rate limits, and egress policy.
 
+## This upgrade is one-way
+
+Once a server volume has been booted by this release, **an older image will not start on it again**.
+It crash-loops with:
+
+```
+[webchat] ERROR: browser UI requires a complete first-boot login sealed in Vault
+```
+
+Older images gate startup on `aimee-server --webchat-vault-check`, which requires the vault to hold
+a webchat login — the sealed `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` pair, or one of the
+`legacy_primary` / `legacy_hashes` / `accounts` records. This release deliberately holds none of
+them: PAM owns the accounts and the first-boot password is never sealed, which is the point of the
+change described below. There is nothing for the old check to find.
+
+So rolling the image back is not an escape hatch here. Verify the upgrade on a disposable copy of
+the volume first, and keep the backups from *Before* — restoring a pre-upgrade volume is the only
+way back.
+
+Reproduced by running the previous image against a volume created by this release, with a healthy
+KB: it crash-looped, while the same image on its own volume was fine.
+
 ## Browser logins become PAM accounts
 
 The dashboard now authenticates against local PAM rather than credentials held in the server vault.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -34,27 +34,25 @@ Do not rely on a raw copy of a live SQLite main file. Take a consistent backup w
   user the required remote-write grant. The old global `remote_writes` value authorizes nothing.
 - Review mTLS revocation, org catalogs, budgets, rate limits, and egress policy.
 
-## This upgrade is one-way
+## This upgrade is one-way, by design
 
-Once a server volume has been booted by this release, **an older image will not start on it again**.
-It crash-loops with:
+0.3.0 does not preserve backwards compatibility, and that includes the image itself: once a server
+volume has been booted by this release, an older image will not start on it again. It crash-loops
+with:
 
 ```
 [webchat] ERROR: browser UI requires a complete first-boot login sealed in Vault
 ```
 
-Older images gate startup on `aimee-server --webchat-vault-check`, which requires the vault to hold
-a webchat login — the sealed `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` pair, or one of the
-`legacy_primary` / `legacy_hashes` / `accounts` records. This release deliberately holds none of
-them: PAM owns the accounts and the first-boot password is never sealed, which is the point of the
-change described below. There is nothing for the old check to find.
+Older images gate startup on `aimee-server --webchat-vault-check`, which wants the vault to hold a
+webchat login — the sealed `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` pair, or one of the
+`legacy_primary` / `legacy_hashes` / `accounts` records. This release holds none of them on purpose:
+PAM owns the accounts and the first-boot password is never sealed (see below). There is nothing for
+the old check to find, and adding something for it to find would mean persisting a password this
+release deliberately does not keep.
 
-So rolling the image back is not an escape hatch here. Verify the upgrade on a disposable copy of
-the volume first, and keep the backups from *Before* — restoring a pre-upgrade volume is the only
-way back.
-
-Reproduced by running the previous image against a volume created by this release, with a healthy
-KB: it crash-looped, while the same image on its own volume was fine.
+Plan accordingly rather than treating the image tag as a rollback: keep the backups from *Before*,
+and restore a pre-upgrade volume if you need to go back.
 
 ## Browser logins become PAM accounts
 

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1081,10 +1081,9 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
           * The path is what makes this message useful. */
          snprintf(out_buf, (size_t)out_cap,
                   "{\"error\":\"kb.reembed_on_dim_change is disabled; set 'kb: "
-                  "reembed_on_dim_change: true' in aimee-kb's own %s and restart it (this gate is "
-                  "read by aimee-kb, not by aimee-server, so `aimee config set` does not reach "
-                  "it)\"}",
-                  config_default_path());
+                  "reembed_on_dim_change: true' in aimee-kb's own $AIMEE_HOME/aimee.yaml and "
+                  "restart it (this gate is read by aimee-kb, not by aimee-server, so `aimee "
+                  "config set` does not reach it)\"}");
          return 403;
       }
       int confirm = kb_http_json_bool(body, "confirm", 0);

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1075,9 +1075,16 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       config_load(&rcfg);
       if (!rcfg.kb_reembed_on_dim_change)
       {
+         /* Name the file. This gate lives in aimee-kb's OWN config, not the
+          * server's, and `aimee config set` targets the server -- so an operator
+          * following the documented re-embed had no way to act on "set it true".
+          * The path is what makes this message useful. */
          snprintf(out_buf, (size_t)out_cap,
-                  "{\"error\":\"kb.reembed_on_dim_change is disabled; set it true to enable the "
-                  "attended dim-change reset\"}");
+                  "{\"error\":\"kb.reembed_on_dim_change is disabled; set 'kb: "
+                  "reembed_on_dim_change: true' in aimee-kb's own %s and restart it (this gate is "
+                  "read by aimee-kb, not by aimee-server, so `aimee config set` does not reach "
+                  "it)\"}",
+                  config_default_path());
          return 403;
       }
       int confirm = kb_http_json_bool(body, "confirm", 0);


### PR DESCRIPTION
Three findings from the `aimee-prod` migration. None is a code defect — each is correct behaviour that said nothing useful when it mattered.

## 1. The re-embed gate named a setting the operator could not reach

`kb.reembed_on_dim_change` is read by **aimee-kb from its own config**, while `aimee config set` targets **aimee-server**. The refusal said "set it true to enable the attended dim-change reset" without saying where, so following the documented procedure was impossible without reading source.

Now names the file and which process reads it.

Adding the key to the server's config surface was tried and reverted in #2196: `config_save` is a hand-written serializer that does not walk the field table, so `set` reported success and `get` returned true while persisting nothing — and the KB would not have seen it regardless.

## 2. One message covered two opposite failures

```
[server-entrypoint] fatal: C agent resource plane did not become ready
```

That fires both when the server **exited** and when the server is **alive but blocked before it listens**. Those need opposite investigations — the first has a reason in `server.log`, the second means startup is stuck on a dependency. I spent real time on the wrong one during a prod outage.

Now reports which, and how long it waited:

```
fatal: aimee-server is running but never created …/aimee-http.sock after 120s
  startup is blocked before the listener; check …/server.log for the last
  step reached, and whether a dependency (e.g. aimee-kb) is reachable
```

## 3. The one-way upgrade, documented as intentional

Once a volume has been booted by this release, an older image will not start on it:

```
[webchat] ERROR: browser UI requires a complete first-boot login sealed in Vault
```

Older images gate on `aimee-server --webchat-vault-check`, which wants a vault-held webchat login. This release holds none on purpose — PAM owns the accounts and the first-boot password is never sealed. 0.3.0 does not preserve backwards compatibility, so this is a property of the release, not a regression; the only thing missing was saying so where operators plan upgrades.

Documented in `UPGRADING.md`: don't treat the image tag as a rollback, keep the *Before* backups, restore a pre-upgrade volume if you need to go back.

Reproduced: the previous image against a volume created by this release, with a **healthy** KB, crash-looped; the same image on its own volume was fine.

## Verification

`make lint` clean except `bus-blast-radius-check` (needs all 7 shipping binaries; this worktree builds 2). `sh -n` on the entrypoint. The KB builds with the reworded gate.
