### PR TITLE
send the one temperature a model accepts

### DIFF
--- a/src/headers/model_sampling.h
+++ b/src/headers/model_sampling.h
@@ -20,6 +20,16 @@ typedef struct
 
 int model_sampling_get(const char *model_key, model_sampling_row_t *out);
 
+/* The ONE temperature a model will accept, or -1 when it accepts a range.
+ *
+ * Distinct from model_provider_t.fixed_temperature, which is a FALLBACK used
+ * only when nobody supplied a temperature. This is a constraint of the model
+ * itself: sending anything else is a hard 4xx, so it must override the caller,
+ * the sampling row, and the provider fallback alike. Keyed on the agent (not a
+ * bare model string) because the constraint is vendor-scoped — it takes the
+ * catalog vendor to tell moonshotai's "k3" from anyone else's. */
+double model_sampling_required_temperature(const agent_t *agent);
+
 void model_sampling_apply_openai(const agent_t *agent, struct cJSON *req,
                                  double caller_temperature);
 void model_sampling_apply_anthropic(const agent_t *agent, struct cJSON *req,

--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -191,12 +191,10 @@ cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *
 
    cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
    if (agent_is_mistral_vibe_model(agent))
-   {
       cJSON_AddStringToObject(req, "reasoning_effort", "high");
-      cJSON_AddNumberToObject(req, "temperature", 1.0);
-   }
-   else
-      model_sampling_apply_openai(agent, req, temperature);
+   /* The temperature=1 this model requires now comes from the shared
+    * required-temperature table, so the other request builder gets it too. */
+   model_sampling_apply_openai(agent, req, temperature);
    if (agent_is_local_llama_compat(agent) && !agent_request_prefers_no_think_prompt(agent))
    {
       cJSON *kwargs = cJSON_AddObjectToObject(req, "chat_template_kwargs");

--- a/src/server/model_sampling.c
+++ b/src/server/model_sampling.c
@@ -37,6 +37,38 @@ int model_sampling_get(const char *model_key, model_sampling_row_t *out)
    return 0;
 }
 
+/* Models that accept exactly one temperature and 4xx on anything else.
+ * |vendor| is the catalog vendor (agent_t.catalog_provider), which is derived
+ * from the endpoint host, so this still applies to an agents.json entry that
+ * names no wire provider at all — the case that made kimi-k3 fail every
+ * delegate with "invalid temperature: only 1 is allowed for this model". */
+static const struct
+{
+   const char *vendor;
+   const char *model_key;
+   double temperature;
+} g_required_temperature[] = {
+    {"moonshotai", "k3", 1.0},
+    {"mistral", "mistral-vibe-cli", 1.0},
+    {NULL, NULL, -1},
+};
+
+double model_sampling_required_temperature(const agent_t *agent)
+{
+   if (!agent || !agent->model[0])
+      return -1;
+   for (int i = 0; g_required_temperature[i].model_key; i++)
+   {
+      const char *vendor = g_required_temperature[i].vendor;
+      if (vendor && strcmp(agent->catalog_provider, vendor) != 0 &&
+          strcmp(agent->provider, vendor) != 0)
+         continue;
+      if (str_contains_ci(agent->model, g_required_temperature[i].model_key))
+         return g_required_temperature[i].temperature;
+   }
+   return -1;
+}
+
 static double provider_fixed_temperature(const agent_t *agent)
 {
    if (!agent || !agent->provider[0])
@@ -73,6 +105,9 @@ void model_sampling_apply_openai(const agent_t *agent, struct cJSON *req, double
    model_sampling_row_t row;
    int has_row = sampling_for_agent(agent, &row);
 
+   /* First writer wins (add_number_if_missing), so the model's hard constraint
+    * goes in ahead of the caller's preference rather than losing to it. */
+   add_number_if_missing(req, "temperature", model_sampling_required_temperature(agent));
    if (caller_temperature >= 0)
       add_number_if_missing(req, "temperature", caller_temperature);
    else if (has_row && row.temperature >= 0)
@@ -94,6 +129,7 @@ void model_sampling_apply_anthropic(const agent_t *agent, struct cJSON *req,
    model_sampling_row_t row;
    int has_row = sampling_for_agent(agent, &row);
 
+   add_number_if_missing(req, "temperature", model_sampling_required_temperature(agent));
    if (caller_temperature >= 0)
       add_number_if_missing(req, "temperature", caller_temperature);
    else if (has_row && row.temperature >= 0)

--- a/src/tests/test_agent_http.c
+++ b/src/tests/test_agent_http.c
@@ -348,6 +348,42 @@ static void test_openai_provider_fixed_temperature_fallback(void)
    printf("openai_provider_fixed_temperature_fallback OK\n");
 }
 
+/* A model that accepts exactly one temperature must get that value even when
+ * the caller asked for another. kimi-k3 names no wire provider in agents.json,
+ * so the constraint has to resolve off the catalog vendor; sending the caller's
+ * temperature instead failed every delegate with HTTP 400 "invalid temperature:
+ * only 1 is allowed for this model". */
+static void test_openai_required_temperature_overrides_caller(void)
+{
+   agent_t agent;
+   memset(&agent, 0, sizeof(agent));
+   snprintf(agent.catalog_provider, sizeof(agent.catalog_provider), "moonshotai");
+   snprintf(agent.model, sizeof(agent.model), "k3-256k");
+   assert(model_sampling_required_temperature(&agent) == 1.0);
+
+   cJSON *messages = cJSON_CreateArray();
+   cJSON *req = agent_build_request_openai(&agent, messages, NULL, 1024, 0.2);
+   assert(req != NULL);
+   assert(cJSON_GetObjectItem(req, "temperature")->valuedouble == 1.0);
+   cJSON_Delete(req);
+   cJSON_Delete(messages);
+
+   /* An unconstrained model still honours the caller. */
+   agent_t other;
+   memset(&other, 0, sizeof(other));
+   snprintf(other.provider, sizeof(other.provider), "openai");
+   snprintf(other.model, sizeof(other.model), "unknown-local-model");
+   assert(model_sampling_required_temperature(&other) < 0);
+
+   messages = cJSON_CreateArray();
+   req = agent_build_request_openai(&other, messages, NULL, 1024, 0.2);
+   assert(req != NULL);
+   assert(cJSON_GetObjectItem(req, "temperature")->valuedouble == 0.2);
+   cJSON_Delete(req);
+   cJSON_Delete(messages);
+   printf("openai_required_temperature_overrides_caller OK\n");
+}
+
 static void test_agent_config_recommended_sampling_roundtrip(void)
 {
    char tmpdir[512];
@@ -1054,6 +1090,7 @@ int main(void)
    test_openai_sampling_opt_out_unchanged();
    test_openai_sampling_unknown_opt_in_unchanged();
    test_openai_provider_fixed_temperature_fallback();
+   test_openai_required_temperature_overrides_caller();
    test_agent_config_recommended_sampling_roundtrip();
    test_parse_response_openai_sanitizes_invalid_tool_arguments();
    test_parse_response_captures_provider_model();


### PR DESCRIPTION
## What

`kimi-k3` failed **every** delegate on prod with:

```
invalid temperature: only 1 is allowed for this model
```

Found while validating the four configured delegates on `.210` after the `:testing` redeploy. `minimax` and `codex` passed; `claude` is correctly `delegate_ineligible` (Primary Agent Only); `kimi-k3` was a real defect.

## Why the existing mechanism could not cover it

Two independent reasons:

1. **No wire provider.** The agents.json entry sets only `endpoint`/`model`, so `agent->provider` is empty and `provider_fixed_temperature()` returns `-1` at its first guard — nothing to pin with.
2. **`fixed_temperature` is a fallback, not a pin.** It is consulted only in the `else` branch, after `caller_temperature`. That is correct for a *default* and wrong for a *constraint*: the caller's 0.2 wins, and the request 400s.

Note the header comment reads `-1 = caller chooses; >= 0 = pinned`, but the tested behaviour (`test_openai_provider_fixed_temperature_fallback`) is a fallback. I did **not** change those semantics — an existing test pins them, and a default and a constraint genuinely are different things. This adds the missing second concept rather than overloading the first.

## Change

A model-level required-temperature table, keyed on the **catalog vendor** (`agent_t.catalog_provider`) — derived from the endpoint host, so it resolves even when no wire provider is named, which is exactly the failing case. Applied ahead of the caller, the sampling row, and the provider fallback; `add_number_if_missing` makes those later writes no-ops.

Also folds in `mistral-vibe-cli`, which had the identical constraint solved ad hoc **inline in `agent_bridge.c`** — meaning the other request builder, `agent_request_build.c`, sent an unconstrained temperature for it. That second path is now fixed too. Its `reasoning_effort: high` stays where it was.

## Verification

Red-before-green against the stock path, via a focused harness on `model_sampling.c`:

| | fix disabled | fix enabled |
|---|---|---|
| kimi-k3 wire temperature | **0.20** (the 400) | **1.00** |
| unconstrained model | 0.20 | 0.20 (unchanged) |

`test_openai_required_temperature_overrides_caller` is registered in `test_agent_http.c` and asserts both halves through the real `agent_build_request_openai`.

**Validation-pending:** no cmake in this environment, so the registered test itself was not executed locally — CI runs it. The logic it covers was exercised directly by the harness above. The end-to-end delegate re-run against the live kimi endpoint is pending a build carrying this commit.