### PR TITLE
provision the first-boot login the operator actually chose

### DIFF
--- a/deploy/container/runtime-web-lib.sh
+++ b/deploy/container/runtime-web-lib.sh
@@ -174,8 +174,36 @@ webchat_provision_login() {
 # Never fatal, for the reason spelled out in webchat_generate_bootstrap_login:
 # the entrypoint calls this unguarded under `set -eu`, so a failure here would
 # take the container down instead of leaving it up without a browser login.
+# The operator-supplied first-boot pair, from wherever it survived to here.
+#
+# PAM owns user control; env vars only PRE-SEED it on first boot. Reading the
+# environment alone found nothing on either supported path: the entrypoint
+# scrubs the credential env names into Vault before provisioning runs, and the
+# managed compose deliberately never places them in the long-lived container's
+# environment at all. Both paths leave the values in the Vault records the
+# bootstrap seals, so recover them from there when the environment is empty.
+#
+# That is TRANSPORT, not a second identity store: the PAM account created from
+# these is the source of truth from the first login onward, which is the whole
+# point of webchat_provision_login above.
+webchat_read_seeded_credentials() {
+    wc_seed_user="${AIMEE_WEBCHAT_USER:-}"
+    wc_seed_pass="${AIMEE_WEBCHAT_PASSWORD:-}"
+    [ -n "$wc_seed_user" ] && [ -n "$wc_seed_pass" ] && return 0
+    _ws_export=$(runuser -u aimee -- aimee-server --webchat-vault-export 2>/dev/null) || return 1
+    wc_seed_user=$(printf '%s\n' "$_ws_export" | awk -F'\t' '$1=="user"{print $2}' |
+        base64 -d 2>/dev/null) || wc_seed_user=""
+    wc_seed_pass=$(printf '%s\n' "$_ws_export" | awk -F'\t' '$1=="password"{print $2}' |
+        base64 -d 2>/dev/null) || wc_seed_pass=""
+    _ws_export=""
+    [ -n "$wc_seed_user" ] && [ -n "$wc_seed_pass" ]
+}
+
 webchat_provision_bootstrap_account() {
-    webchat_provision_login "${AIMEE_WEBCHAT_USER:-}" "${AIMEE_WEBCHAT_PASSWORD:-}" || true
+    if webchat_read_seeded_credentials; then
+        webchat_provision_login "$wc_seed_user" "$wc_seed_pass" || true
+    fi
+    wc_seed_user="" wc_seed_pass=""
     if webchat_read_generated_credentials; then
         webchat_provision_login "$wc_generated_user" "$wc_generated_pass" || true
     fi
@@ -191,7 +219,15 @@ webchat_provision_bootstrap_account() {
 # password out from under the operator on every restart and spam the log with
 # credentials that are not the working one.
 webchat_bootstrap_login_needed() {
-    [ -n "${AIMEE_WEBCHAT_USER:-}" ] && [ -n "${AIMEE_WEBCHAT_PASSWORD:-}" ] && return 1
+    # Same source as provisioning: an operator-supplied pair that reached us via
+    # the Vault transport must suppress generation just as an environment one
+    # does, or the appliance prints a random credential the operator never asked
+    # for beside the account they did.
+    if webchat_read_seeded_credentials; then
+        wc_seed_user="" wc_seed_pass=""
+        return 1
+    fi
+    wc_seed_user="" wc_seed_pass=""
     [ -f "$WEBCHAT_BOOTSTRAP_USER" ] && return 1
     [ -f "$WEBCHAT_BOOTSTRAP_REPLACED" ] && return 1
     [ -n "$(getent group "$WEBCHAT_LOGIN_GROUP" 2>/dev/null | cut -d: -f4)" ] && return 1

--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -85,10 +85,12 @@ if [ "$#" -gt 0 ]; then
 fi
 if [ "$vault_bootstrapped" -eq 0 ] || [ "$had_credential_env" -eq 1 ]; then
     # Migrate any legacy browser credential files only after first-boot env
-    # values have been sealed and scrubbed. The new web service authenticates
-    # against fixed Vault records and never materializes a PAM verifier. Force
-    # a clean process image whenever this invocation inherited credentials,
-    # even if an external caller supplied the internal marker.
+    # values have been sealed and scrubbed. The sealed pair is first-boot
+    # transport: webchat_provision_bootstrap_account reads it back out and
+    # provisions a real PAM account, which is the only thing authentication
+    # consults thereafter. Force a clean process image whenever this invocation
+    # inherited credentials, even if an external caller supplied the internal
+    # marker.
     webchat_prepare
     exec /usr/bin/tini -- aimee-server-entrypoint --aimee-internal-vault-bootstrapped
 fi

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -24,21 +24,29 @@ The server generates a dashboard login on first boot and prints it once, in that
 
 Copy it before the log rotates. Only the username is kept on disk afterwards, so the password cannot
 be read back; if you lose it, reset that account's password inside the container or start again from
-an empty volume. To choose the credential yourself instead, set both variables before `up` — then
+an empty volume. To choose the credential yourself instead, seal it before the first `up` — then
 nothing is generated and nothing is printed:
 
 ```bash
 export AIMEE_WEBCHAT_USER=operator
 read -rsp 'Initial webchat password: ' AIMEE_WEBCHAT_PASSWORD && echo
 export AIMEE_WEBCHAT_PASSWORD
-docker compose -f compose.server-managed.yaml up -d
+scripts/aimee-compose-vault-bootstrap.sh -f compose.server-managed.yaml server
 unset AIMEE_WEBCHAT_PASSWORD
+docker compose -f compose.server-managed.yaml up -d
 ```
 
-Those variables are first-boot transport, not runtime configuration: the entrypoint encrypts them
-into the server Vault, removes them from its inherited environment, and only then starts long-lived
-services. Authentication reads only fixed Vault records through one-shot pipes; no password,
-verifier, session bearer, or TLS private key is written to the data volume or container logs.
+Run the bootstrap script; do not simply export the variables and `up`. `compose.server-managed.yaml`
+deliberately keeps these two out of the server's `environment:` block, because anything listed there
+persists in the container's `Config.Env` for the life of the deployment and is readable from
+`docker inspect`. The script streams them into Vault through a one-shot container instead, so
+`docker compose up` on its own never sees them and would leave you with a generated login.
+
+Those variables are first-boot transport, not runtime configuration. On first boot the entrypoint
+reads that sealed pair and provisions it as a real local PAM account, then the appliance
+authenticates against PAM from the first login onward — there is no parallel credential store, and
+no password, verifier, session bearer, or TLS private key is written to the data volume or
+container logs.
 
 Open <https://localhost:8443> and sign in. If you signed in with the generated login, the wizard's
 account step replaces it with a permanent one; a deployment that supplied its own pair skips that
@@ -71,8 +79,9 @@ Deploy also claims the signed-in browser account as the first remote owner. It d
 `aimee remote set ...` command that provisions that user's bearer, mTLS certificate, and explicit
 `full` write grant. Keep that page open until you run the command in step 3.
 
-Complete the account step before exposing the host. A deployment that injects both
-`AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` uses that pair and skips account replacement.
+Complete the account step before exposing the host. A deployment that seals both
+`AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` before the first `up` uses that pair and skips
+account replacement.
 Supply both or neither: a partial pair is treated as absent, and the server generates and logs a
 credential instead.
 

--- a/src/headers/model_sampling.h
+++ b/src/headers/model_sampling.h
@@ -20,6 +20,16 @@ typedef struct
 
 int model_sampling_get(const char *model_key, model_sampling_row_t *out);
 
+/* The ONE temperature a model will accept, or -1 when it accepts a range.
+ *
+ * Distinct from model_provider_t.fixed_temperature, which is a FALLBACK used
+ * only when nobody supplied a temperature. This is a constraint of the model
+ * itself: sending anything else is a hard 4xx, so it must override the caller,
+ * the sampling row, and the provider fallback alike. Keyed on the agent (not a
+ * bare model string) because the constraint is vendor-scoped — it takes the
+ * catalog vendor to tell moonshotai's "k3" from anyone else's. */
+double model_sampling_required_temperature(const agent_t *agent);
+
 void model_sampling_apply_openai(const agent_t *agent, struct cJSON *req,
                                  double caller_temperature);
 void model_sampling_apply_anthropic(const agent_t *agent, struct cJSON *req,

--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -191,12 +191,10 @@ cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *
 
    cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
    if (agent_is_mistral_vibe_model(agent))
-   {
       cJSON_AddStringToObject(req, "reasoning_effort", "high");
-      cJSON_AddNumberToObject(req, "temperature", 1.0);
-   }
-   else
-      model_sampling_apply_openai(agent, req, temperature);
+   /* The temperature=1 this model requires now comes from the shared
+    * required-temperature table, so the other request builder gets it too. */
+   model_sampling_apply_openai(agent, req, temperature);
    if (agent_is_local_llama_compat(agent) && !agent_request_prefers_no_think_prompt(agent))
    {
       cJSON *kwargs = cJSON_AddObjectToObject(req, "chat_template_kwargs");

--- a/src/server/model_sampling.c
+++ b/src/server/model_sampling.c
@@ -37,6 +37,38 @@ int model_sampling_get(const char *model_key, model_sampling_row_t *out)
    return 0;
 }
 
+/* Models that accept exactly one temperature and 4xx on anything else.
+ * |vendor| is the catalog vendor (agent_t.catalog_provider), which is derived
+ * from the endpoint host, so this still applies to an agents.json entry that
+ * names no wire provider at all — the case that made kimi-k3 fail every
+ * delegate with "invalid temperature: only 1 is allowed for this model". */
+static const struct
+{
+   const char *vendor;
+   const char *model_key;
+   double temperature;
+} g_required_temperature[] = {
+    {"moonshotai", "k3", 1.0},
+    {"mistral", "mistral-vibe-cli", 1.0},
+    {NULL, NULL, -1},
+};
+
+double model_sampling_required_temperature(const agent_t *agent)
+{
+   if (!agent || !agent->model[0])
+      return -1;
+   for (int i = 0; g_required_temperature[i].model_key; i++)
+   {
+      const char *vendor = g_required_temperature[i].vendor;
+      if (vendor && strcmp(agent->catalog_provider, vendor) != 0 &&
+          strcmp(agent->provider, vendor) != 0)
+         continue;
+      if (str_contains_ci(agent->model, g_required_temperature[i].model_key))
+         return g_required_temperature[i].temperature;
+   }
+   return -1;
+}
+
 static double provider_fixed_temperature(const agent_t *agent)
 {
    if (!agent || !agent->provider[0])
@@ -73,6 +105,9 @@ void model_sampling_apply_openai(const agent_t *agent, struct cJSON *req, double
    model_sampling_row_t row;
    int has_row = sampling_for_agent(agent, &row);
 
+   /* First writer wins (add_number_if_missing), so the model's hard constraint
+    * goes in ahead of the caller's preference rather than losing to it. */
+   add_number_if_missing(req, "temperature", model_sampling_required_temperature(agent));
    if (caller_temperature >= 0)
       add_number_if_missing(req, "temperature", caller_temperature);
    else if (has_row && row.temperature >= 0)
@@ -94,6 +129,7 @@ void model_sampling_apply_anthropic(const agent_t *agent, struct cJSON *req,
    model_sampling_row_t row;
    int has_row = sampling_for_agent(agent, &row);
 
+   add_number_if_missing(req, "temperature", model_sampling_required_temperature(agent));
    if (caller_temperature >= 0)
       add_number_if_missing(req, "temperature", caller_temperature);
    else if (has_row && row.temperature >= 0)

--- a/src/tests/test_agent_http.c
+++ b/src/tests/test_agent_http.c
@@ -348,6 +348,42 @@ static void test_openai_provider_fixed_temperature_fallback(void)
    printf("openai_provider_fixed_temperature_fallback OK\n");
 }
 
+/* A model that accepts exactly one temperature must get that value even when
+ * the caller asked for another. kimi-k3 names no wire provider in agents.json,
+ * so the constraint has to resolve off the catalog vendor; sending the caller's
+ * temperature instead failed every delegate with HTTP 400 "invalid temperature:
+ * only 1 is allowed for this model". */
+static void test_openai_required_temperature_overrides_caller(void)
+{
+   agent_t agent;
+   memset(&agent, 0, sizeof(agent));
+   snprintf(agent.catalog_provider, sizeof(agent.catalog_provider), "moonshotai");
+   snprintf(agent.model, sizeof(agent.model), "k3-256k");
+   assert(model_sampling_required_temperature(&agent) == 1.0);
+
+   cJSON *messages = cJSON_CreateArray();
+   cJSON *req = agent_build_request_openai(&agent, messages, NULL, 1024, 0.2);
+   assert(req != NULL);
+   assert(cJSON_GetObjectItem(req, "temperature")->valuedouble == 1.0);
+   cJSON_Delete(req);
+   cJSON_Delete(messages);
+
+   /* An unconstrained model still honours the caller. */
+   agent_t other;
+   memset(&other, 0, sizeof(other));
+   snprintf(other.provider, sizeof(other.provider), "openai");
+   snprintf(other.model, sizeof(other.model), "unknown-local-model");
+   assert(model_sampling_required_temperature(&other) < 0);
+
+   messages = cJSON_CreateArray();
+   req = agent_build_request_openai(&other, messages, NULL, 1024, 0.2);
+   assert(req != NULL);
+   assert(cJSON_GetObjectItem(req, "temperature")->valuedouble == 0.2);
+   cJSON_Delete(req);
+   cJSON_Delete(messages);
+   printf("openai_required_temperature_overrides_caller OK\n");
+}
+
 static void test_agent_config_recommended_sampling_roundtrip(void)
 {
    char tmpdir[512];
@@ -1054,6 +1090,7 @@ int main(void)
    test_openai_sampling_opt_out_unchanged();
    test_openai_sampling_unknown_opt_in_unchanged();
    test_openai_provider_fixed_temperature_fallback();
+   test_openai_required_temperature_overrides_caller();
    test_agent_config_recommended_sampling_roundtrip();
    test_parse_response_openai_sanitizes_invalid_tool_arguments();
    test_parse_response_captures_provider_model();


### PR DESCRIPTION
Fixes #2202.

## The bug

On a managed install, supplying `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` never took effect. A random account was provisioned every time, and the supplied name authenticated nowhere (`HTTP 401`).

## Root cause — ordering, not documentation

`deploy/container/server-entrypoint.sh`:

1. `aimee-server --bootstrap-vault-env` seals the first-boot credential env values into Vault.
2. The loop immediately after unsets every name `--list-credential-env-names` reports — which includes both webchat variables (`vault_env_bootstrap.c:378`).
3. `webchat_migrate_legacy_credentials` → `webchat_provision_bootstrap_account` then reads `${AIMEE_WEBCHAT_USER:-}` — **guaranteed empty by step 2**.

So `webchat_bootstrap_login_needed` always concluded "generate one". The supplied pair could not win on any path.

And the managed compose never placed them in the environment anyway — deliberately, since anything under `environment:` persists in `Config.Env` and is readable via `docker inspect`. Its supported path is `scripts/aimee-compose-vault-bootstrap.sh`, which streams them into Vault via a one-shot container. That means the long-lived container's environment is empty *by design*, and reading it could never have worked.

Worth noting `runtime-web/vault_identity.go` parses the sealed `user`/`password` into `PrimaryUser`/`PrimaryPass` — fields **nothing reads**. The credential went into Vault, came back out, and dead-ended.

## The fix

Recover the pair from the Vault records when the environment is empty, and provision *that* as the PAM account. PAM stays the single identity store, exactly as `webchat_provision_login`'s own comment intends — Vault is first-boot **transport**, and the PAM account it creates is the source of truth from the first login onward. The generation gate consults the same source, so a supplied pair suppresses the random account rather than printing one beside it.

Behaviour is now: **supplied pair → that PAM account; nothing supplied → random PAM account, logged once.**

## Verification — live, from-scratch managed install

Clean volumes, credential sealed via the documented script, container environment empty:

```
[webchat] provisioned the first-boot dashboard login 'operator' (local PAM)
uid=999(operator) gid=999(aimee-webchat) groups=999(aimee-webchat)
POST /api/auth/login -> HTTP 200 {"user":{"username":"operator"}}
```

No generated account beside it. **Before** the change, the identical install produced `aimee-280d7cf22a0f` and `operator` returned `HTTP 401` — that reproduction is what opened #2202.

Note on method: verified by overlaying the patched `runtime-web-lib.sh` into the running container rather than rebuilding the image, so CI's image build is the remaining check on packaging.

## Also

- `docs/QUICKSTART.md` told operators to `export` the variables and run `docker compose up`, which silently does nothing on this compose file. Now documents the bootstrap script and explains why `environment:` is not an option.
- Drops a stale `server-entrypoint.sh` comment claiming the web service "authenticates against fixed Vault records and never materializes a PAM verifier" — that describes the retired design and contradicts the current one.