### PR TITLE
read the live config in config_sandbox, not the file

### DIFF
--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1907,10 +1907,12 @@ void config_sandbox(sandbox_config_t *out)
    if (!out)
       return;
    memset(out, 0, sizeof(*out));
-   config_t *cfg = calloc(1, sizeof(*cfg));
-   if (!cfg)
-      return;
-   if (config_load(cfg) == 0)
-      *out = cfg->sandbox;
-   free(cfg);
+   /* Read the LIVE config, like every generated accessor: config_field_read
+    * prefers the pinned snapshot and heap-loads only when none is live. Loading a
+    * whole config_t here instead made this the one read accessor that bypassed the
+    * snapshot -- so a delegated shell could be gated on file state the live
+    * snapshot had not adopted, and every such call paid a full config load on a
+    * hot path. Leaves *out zeroed when the config cannot be read, which is the
+    * all-defaults-off shape callers already relied on. */
+   config_field_read(offsetof(config_t, sandbox), sizeof(*out), out);
 }


### PR DESCRIPTION
## What

`config_sandbox()` is the only **read** accessor in the config module that loads a whole `config_t` instead of reading the live config:

```c
config_t *cfg = calloc(1, sizeof(*cfg));
if (config_load(cfg) == 0)
    *out = cfg->sandbox;
```

#2201 moved `config_load` inside the module — which satisfies the encapsulation ratchet — but this call site kept the old behaviour instead of adopting the snapshot.

## Why it matters

**The snapshot stops being the single source of truth for this field.** `config_field_read` prefers the pinned snapshot, so every *generated* accessor sees published config, while `config_sandbox` saw whatever was last written to the file. Those can differ: `config_reload` publishes only when the content-hash token changes, and `config_reload_if_changed` reconciles on a tick.

That matters because `sandbox.mode` **gates whether a delegated shell may run at all** (`agent_tools.c`: a delegate is refused when the mode is OFF, because an unsandboxed shell on the aimee-server host is a root escalation with the docker socket mounted). Authorizing or refusing that on file state the live snapshot has not adopted is the wrong basis for a containment decision.

**And it is on the hot path.** Every delegated shell command paid a `calloc` plus a full config load to read one POD member.

## The fix

Use the module's own primitive, documented for exactly this:

> `config_field_read(offset, size, dst)` — "copy `size` bytes at `offset` out of the live config, **preferring the pinned snapshot** and heap-loading when none is live."

The documented zero-on-failure contract is preserved: `*out` is `memset` first and left zeroed when the read fails, which is the all-defaults-off value callers already relied on.

## Scope

The other `config_load` calls in `config_save.c` are **writers** — `config_set_model_concurrency`, `config_remove_model_concurrency`, `config_persist_defaults` — where load/mutate/save is correct. Unchanged.

## Verification

`gcc -fsyntax-only` clean. Behaviour is covered by CI (`unit-tests`, `config-encapsulation`, `e2e-docker`); no behavioural change is intended when a snapshot is live and the file agrees, which is the steady state.

Found while investigating why a delegated shell was refused on a live appliance: the refusal traced to `sandbox.mode` being unset, which led to this accessor.