### PR TITLE
document the guardrail_mode values that actually exist

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -58,7 +58,7 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 | `fidelity_check_enabled` | bool | Run the answer-fidelity judge on terminal-text turns (default off; requires kb_evidence_emit_enabled + ingress_preinject_enabled). |
 | `gateway_pin_model` | bool | Gateway forces the proxied /v1/messages served model to the configured primary's model, overriding the client-requested model. Default off (the passthrough honors the client model); enable for single-model Anthropic-compatible shims. |
 | `gateway_prevent_subagents` | bool | Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off. |
-| `guardrail_mode` | string | Guardrail enforcement mode (off / warn / block). |
+| `guardrail_mode` | string | Guardrail enforcement mode: approve (default; a tool call needs approval, so an unattended delegate is blocked), prompt, or deny. |
 | `guardrails_blast_radius_advisory_enabled` | bool | Surface a structural blast-radius advisory (graph-impacted files) before an edit (advisory, fail-open). |
 | `guardrails_semantic_command` | string | External semantic-guardrail classifier command. |
 | `guardrails_semantic_mode` | string | Semantic guardrail mode: off, dry_run, advisory, or enforce. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -178,7 +178,7 @@ CFG_KEY_DESC = {
     "embedding_model": "Embeddings model name.",
     "fidelity_check_enabled": "Run the answer-fidelity judge on terminal-text turns "
     "(default off; requires kb_evidence_emit_enabled + ingress_preinject_enabled).",
-    "guardrail_mode": "Guardrail enforcement mode (off / warn / block).",
+    "guardrail_mode": "Guardrail enforcement mode: approve (default; a tool call needs approval, so an unattended delegate is blocked), prompt, or deny.",
     "code_hybrid_weight_code": "RRF weight for the lexical-code signal in /v1/code/hybrid (default 1.0; <=0 disables it).",
     "code_hybrid_weight_graph": "RRF weight for the structural call-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it).",
     "code_hybrid_weight_vector": "RRF weight for the embedding-similarity signal in /v1/code/hybrid (default 1.0; <=0 disables it; auto-skips when no dim-matched embedder).",


### PR DESCRIPTION
## What

`docs/gen/configuration.md` documented `guardrail_mode` as **"off / warn / block"**. None of those three is a value the code defines:

- `src/headers/aimee.h:127-129` — `MODE_APPROVE "approve"`, `MODE_PROMPT "prompt"`, `MODE_DENY "deny"`
- `guardrails_orchestrator.c:1198` — falls back to `MODE_APPROVE` when no mode is supplied
- `config_fields.c:664` — `{"guardrail_mode", "approve"}` is the shipped default

So the documented set omitted the value every deployment actually runs, and listed three that do not exist.

## Why it matters

Under `approve`, a tool call needs an approver. A background delegate job has none, so **every** delegated shell is blocked — including a trivial one:

```
TOOLFAIL guardrail blocked: cd <worktree> && pwd && printf ... && cat probe.txt
```

That is correct enforcement, not a bug. But an operator reading "off / warn / block" had no way to predict it, or to know which value to set for unattended delegate work.

Found while diagnosing why tool-using delegates could not run on a live appliance. The sandbox and worktree binding were fine; `guardrail_mode: approve` was the actual gate.

## Change

Corrected the description in `scripts/gen-reference-docs.py` (the canonical source — the page is generated) and regenerated. Diff is one line in each file.