### PR TITLE
give delegate sandboxes a workspace mount that is not empty

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -310,6 +310,44 @@ for _dsock in /var/run/docker.sock /run/docker.sock; do
     break
 done
 
+# Delegate sandbox host-path translation.
+#
+# aimee-server drives a SIBLING docker daemon through the socket above, so a bind
+# SOURCE like /var/lib/aimee/<workspace> — which exists in THIS container — does
+# not exist on the daemon's host. Docker then creates it empty rather than
+# failing, and the delegate gets a sandbox whose workspace mount is an empty
+# directory: its worktree is simply not there, so every file tool answers
+# "cannot open" for files that plainly exist.
+#
+# docker_translate_host_source() already handles this, but only when
+# AIMEE_SANDBOX_HOST_MOUNTS names the mapping. The plugin deploys set it from
+# their own bind mounts; the COMPOSE deploys never did, which is why the managed
+# topology could not run a tool-using delegate at all.
+#
+# Derive it from this container's own mounts instead of hardcoding a path: the
+# volume host paths depend on docker's data-root and the compose project name,
+# neither of which belongs in an image. Skip entries whose source equals its
+# destination (a plain host bind such as the docker socket needs no translation).
+# Any failure leaves the variable unset, which is exactly the previous behaviour.
+if [ -z "${AIMEE_SANDBOX_HOST_MOUNTS:-}" ] && [ -S "${_dsock:-/var/run/docker.sock}" ]; then
+    _self=$(hostname 2>/dev/null || true)
+    if [ -n "$_self" ]; then
+        _map=$(docker inspect "$_self" \
+                   --format '{{range .Mounts}}{{.Destination}}={{.Source}}{{println}}{{end}}' \
+                   2>/dev/null |
+               awk -F= 'NF == 2 && $1 != $2 && $1 ~ /^\// && $2 ~ /^\// {
+                            printf "%s%s=%s", sep, $1, $2; sep = ","
+                        }')
+        if [ -n "$_map" ]; then
+            export AIMEE_SANDBOX_HOST_MOUNTS="$_map"
+            log "delegate sandbox: derived host-path map from own mounts ($_map)"
+        else
+            log "delegate sandbox: could not derive a host-path map; delegate workspace mounts may be empty if this daemon is a sibling"
+        fi
+    fi
+    unset _self _map 2>/dev/null || true
+fi
+
 log "starting aimee-server (socket=$SERVER_SOCK) as user aimee"
 rm -f "$AIMEE_HOME/aimee-http.sock" "$AIMEE_WFE_HTTP_SOCKET"
 runuser -u aimee -- sh -c 'set -eu; ulimit -c 0 2>/dev/null || true; exec aimee-server --socket="$1"' sh "$SERVER_SOCK" &


### PR DESCRIPTION
## The bug

A tool-using delegate could not run **at all** on a compose deploy. Every file tool answered `cannot open` for files that plainly existed in the delegate's own worktree.

The sandbox mounted the workspace from a path that exists inside `aimee-server`'s container but **not on the docker daemon's host**. Docker creates a missing bind source as an empty directory rather than failing, so the delegate got a sandbox whose workspace mount was empty.

## Why the existing mechanism did not cover it

`docker_translate_host_source()` exists for exactly this and says so:

> *"Needed when aimee-server itself runs in a container and drives a SIBLING daemon (docker-in-docker / SmoothNAS LXC2Docker)... binding `src:dst` with the container path silently mounts the wrong (or an empty) directory. The mapping comes from `AIMEE_SANDBOX_HOST_MOUNTS`... **the deploy sets it from the plugin's own bind mounts**."*

The plugin deploys set it. The **compose** deploys never did — so `compose.server-managed.yaml`, the topology the quickstart documents, silently had no working delegate sandbox.

## The fix

Derive the map from the container's own mounts in `server-entrypoint.sh`, rather than writing a path into the image — the volume host paths depend on docker's data-root and the compose project name, neither of which an image can know:

```
docker inspect "$(hostname)" --format '{{range .Mounts}}{{.Destination}}={{.Source}}{{println}}{{end}}'
```

- Entries whose source equals its destination are skipped (a plain host bind, e.g. the docker socket, needs no translation).
- Any failure leaves the variable unset → behaviour exactly as before.
- An explicit operator-supplied `AIMEE_SANDBOX_HOST_MOUNTS` still wins.
- Longest-prefix matching in the existing C code already handles `/var/lib/aimee` vs `/var/lib/aimee-workspaces`, and the derived map contains both.

## Verification — live managed appliance

**Before** — delegate container:
```
MOUNT /var/lib/aimee/scratch-ws -> /var/lib/aimee/scratch-ws
$ ls .../worktrees/*/main   ->  No such file or directory
Result: TOOLFAIL error: cannot open .../main/probe.txt
```

**With the mapping supplied**:
```
MOUNT /var/lib/docker/volumes/aimee_aimee-server-home/_data/scratch-ws -> /var/lib/aimee/scratch-ws
$ ls .../worktrees/*/main   ->  probe.txt
Result: TOKEN=SANDBOX_PROBE_TOKEN_7Q4Xn
```

Byte-exact (the file is 25 bytes including a literal trailing `n`), so the delegate genuinely read it.

The derivation added here reproduces that same map from the running container's mounts — verified by running the `inspect` + `awk` against the live server:

```
/var/lib/aimee-workspaces=/var/lib/docker/volumes/aimee_aimee-server-workspaces/_data,/var/lib/aimee=/var/lib/docker/volumes/aimee_aimee-server-home/_data,/run/aimee/management=/opt/aimee-src/server-management
```

**Validation-pending:** the entrypoint change itself has not been run inside a built image — the proof above used the same map supplied via the environment. CI's image build plus a post-merge run on the appliance is the remaining check. `sh -n` clean.