### PR TITLE
document 0.3.0 as the release it actually is

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `aimee` CLI is a thin client. Linux, macOS, and Windows builds talk to the s
 - **Any model, any provider.** OpenAI Chat Completions, OpenAI Responses, Anthropic Messages,
   Gemini, Mistral, local OpenAI-compatible servers, and AWS Bedrock all pass through one internal
   request format. Switch the primary model without switching tools.
-- **In-container embedding.** The KB embeds from weights baked into its own image — no inference
+- **In-container embedding.** The KB embeds from weights baked into its own image. No inference
   container, no first-boot model download. Point it at an external endpoint for a wider model, or
   for synthesis. See [Inference](docs/KB_LLM_BACKENDS.md).
 - **Document ingestion.** Push source trees, Markdown, text, and PDFs. Structured PDF mode keeps

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -105,8 +105,8 @@ The DB1/DB2 boundary is compile-enforced:
 - thin clients link neither;
 - calls across the boundary use public typed APIs.
 
-The WORM hash primitive is the narrow exception shared by both stores. It contains hashing only—no
-database handles or queries—so both stores produce the same chain format.
+The WORM hash primitive is the narrow exception shared by both stores. It contains hashing only, with no
+database handles or queries, so both stores produce the same chain format.
 
 New KB containers run a private PostgreSQL 18 cluster when no external `AIMEE_DB2_URL` is set. It is
 still DB2, still owned by the KB, and still independently exportable.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -25,9 +25,9 @@ required.
 | Claude Code | session, pre-tool, post-tool | yes | Anthropic Messages ingress |
 | Codex CLI | session and tool hooks where supported | local plugin | OpenAI Responses ingress |
 | VS Code | no native hook contract | yes | ACP and OpenAI-compatible model endpoint |
-| GitHub Copilot | supported hook subset | yes | — |
-| Claude Desktop | — | yes | — |
-| OpenCode and similar front ends | — | optional | OpenAI Chat Completions ingress |
+| GitHub Copilot | supported hook subset | yes | none |
+| Claude Desktop | none | yes | none |
+| OpenCode and similar front ends | none | optional | OpenAI Chat Completions ingress |
 
 Client setup updates detected registrations without duplicating them. Set
 `AIMEE_NO_CLIENT_INTEGRATIONS=1` to opt out.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -4,7 +4,7 @@ The browser is a client of `aimee-server`, `aimee-wfe`, and `aimee-kb`. It owns 
 state; it does not own product data.
 
 Login is a **local PAM account** in the `aimee-webchat` group, checked through the `aimee` PAM
-service — the same stack the KB's `/v1/identity/login/pam` uses. Accounts outside that group are
+service, the same stack the KB's `/v1/identity/login/pam` uses. Accounts outside that group are
 never dashboard logins, so the container's own system users cannot sign in. An unavailable PAM stack
 is reported as such rather than as a wrong password.
 

--- a/docs/DELEGATE_SANDBOX.md
+++ b/docs/DELEGATE_SANDBOX.md
@@ -65,7 +65,7 @@ a sandbox audit event with the missing boundary.
 
 Never silently fall back from container to host shell.
 
-## Non-sandbox security — unresolved
+## Non-sandbox security, unresolved
 
 This section is a marker, not a description of shipped behavior. Tracked in
 [issue #2190](https://github.com/RakuenSoftware/aimee/issues/2190).
@@ -76,9 +76,9 @@ open:
 - **The INERT path contradicts "never silently fall back".** When the dial is on but no docker
   daemon is reachable, `delegate_sandbox_log_posture()` logs `INERT` at boot and delegates then run
   on the host. `delegate_sandbox_require_isolation` is the fail-closed guard, but it defaults to
-  off — so the default posture claims sandboxed and, on a box without docker, is not.
-- **The in-process boundary is undefined.** When there is no sandbox — no docker, a runtime that
-  ignores `--network none`, or a deliberate opt-out — what protects the host is an implicit union of
+  off, so the default posture claims sandboxed and, on a box without docker, is not.
+- **The in-process boundary is undefined.** When there is no sandbox (no docker, a runtime that
+  ignores `--network none`, or a deliberate opt-out), what protects the host is an implicit union of
   the shell-git gate, the credential strip, and the guardrails path policy. That union is not stated
   as a guarantee anywhere and is not tested as one.
 

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -6,7 +6,7 @@ out for synthesis.
 **Embedding is in-container.** The weights ship inside the KB image, so there is no inference
 container and no first-boot download. Select the model in the wizard's Deploy topology step, or set
 `embedding_model`. Until one is selected the KB serves a builtin lexical embedder and logs that it is
-doing so — retrieval works, but it is not dense.
+doing so. Retrieval works, but it is not dense.
 
 To embed against something else, set `AIMEE_EMBEDDER_URL`. That takes precedence, and the bundled
 model stays unloaded.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -17,15 +17,15 @@ docker compose -f compose.server-managed.yaml logs aimee-server
 The server generates a dashboard login on first boot and prints it once, in that log:
 
 ```text
-[webchat] FIRST-BOOT DASHBOARD LOGIN (shown once — copy it now)
+[webchat] FIRST-BOOT DASHBOARD LOGIN (shown once, copy it now)
 [webchat]     username: aimee-0a901de6e2c3
 [webchat]     password: <64 hex characters>
 ```
 
 Copy it before the log rotates. Only the username is kept on disk afterwards, so the password cannot
 be read back; if you lose it, reset that account's password inside the container or start again from
-an empty volume. To choose the credential yourself instead, seal it before the first `up` — then
-nothing is generated and nothing is printed:
+an empty volume. To choose the credential yourself instead, seal it before the first `up`. Nothing
+is then generated and nothing is printed:
 
 ```bash
 export AIMEE_WEBCHAT_USER=operator
@@ -44,7 +44,7 @@ persists in the container's `Config.Env` for the life of the deployment and is r
 
 Those variables are first-boot transport, not runtime configuration. On first boot the entrypoint
 reads that sealed pair and provisions it as a real local PAM account, then the appliance
-authenticates against PAM from the first login onward — there is no parallel credential store, and
+authenticates against PAM from the first login onward. There is no parallel credential store, and
 no password, verifier, session bearer, or TLS private key is written to the data volume or
 container logs.
 
@@ -92,12 +92,12 @@ it through the `aimee` PAM service, the same stack SmoothNAS uses and the same o
 exists. Only accounts in that group are dashboard logins: the container's own system users are never
 accepted, and the dashboard cannot see or modify them.
 
-The Vault holds aimee's own secrets — the session key, TLS material, provider credentials. A host
+The Vault holds aimee's own secrets: the session key, TLS material, provider credentials. A host
 password is not one of those and is never sealed into it.
 
 When the appliance is connected to a KB that reports `oidc`, the identity provider owns accounts and
 the wizard's account step disappears; local account creation is refused. Dashboard login itself
-remains PAM in this release — the OIDC login flow arrives in 0.4.0.
+remains PAM in this release. The OIDC login flow arrives in 0.4.0.
 
 ### Choosing an embedder
 
@@ -105,7 +105,7 @@ The wizard's **Deploy topology** step records which embedder the KB uses. Choose
 The bundled `bekko-a25m` (384-dimension) ships inside the KB image, so it needs no download and no
 second container. Point the KB at your own endpoint instead if you need a wider model.
 
-Nothing is selected on a fresh install, and an unselected KB is not broken — it falls back to a
+Nothing is selected on a fresh install, and an unselected KB is not broken. It falls back to a
 builtin lexical embedder and says so once, in the KB log:
 
 ```text
@@ -141,7 +141,7 @@ of the two a given switch costs.
 ### Choosing an image channel
 
 The stack runs the released `:latest` images by default. To run a tested-but-unreleased build, set
-`AIMEE_IMAGE_TAG` once — it moves the server and the KB together:
+`AIMEE_IMAGE_TAG` once. It moves the server and the KB together:
 
 ```bash
 AIMEE_IMAGE_TAG=testing docker compose -f compose.server-managed.yaml up -d
@@ -150,7 +150,7 @@ AIMEE_IMAGE_TAG=testing docker compose -f compose.server-managed.yaml up -d
 Set it for the wizard's **Deploy** step too, not just the server: the server re-runs Compose for the
 managed services, so the tag has to be in its environment or the KB falls back to `:latest` while the
 server runs `:testing`. The line above already does this. Mixing versions this way is a real failure
-mode, not a theoretical one — a KB and a server from different builds can disagree about the
+mode, not a theoretical one. A KB and a server from different builds can disagree about the
 contract between them and leave the KB permanently unhealthy.
 
 A single service can still be pinned individually (`AIMEE_KB_IMAGE=…`), and an explicit pin always

--- a/docs/THIN_CLIENT.md
+++ b/docs/THIN_CLIENT.md
@@ -1,6 +1,6 @@
 # Thin client
 
-`aimee` is a DB-free client for Linux, macOS, and Windows. It owns client-local work—hooks, stdio
+`aimee` is a DB-free client for Linux, macOS, and Windows. It owns client-local work: hooks, stdio
 protocols, source reads, uploads, and local CLI-agent execution. The server owns state, policy,
 credentials, and model calls.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,9 +1,18 @@
 # Upgrading from v0.2.192
 
+There is no route back. 0.3.0 rewrites storage, credentials, and remote identity, and a 0.2 server
+will not read what it leaves behind. Your backup is the rollback plan; there is no downgrade
+command. Take the backup before step one, not after the first thing goes wrong.
+
 Read [What's new](WHATS_NEW.md) first. This cycle changes deployment, storage, credentials, remote
 identity, workflows, and removed commands.
 
-## Before
+Install from `:testing` or a release later than the `v0.3.0` tag. That tag was cut part-way through
+the cycle, on 2026-07-28, and is missing the fixes listed under
+[What landed after the first 0.3.0 tag](WHATS_NEW.md#what-landed-after-the-first-030-tag). Several
+of those are cases where a fresh install came up healthy and silently did nothing useful.
+
+## Do all of this before you touch the running deployment
 
 1. Stop starting new workflows and wait for active writes to finish.
 2. Run `aimee audit checkpoint` and `aimee audit verify`.
@@ -15,7 +24,7 @@ identity, workflows, and removed commands.
 
 Do not rely on a raw copy of a live SQLite main file. Take a consistent backup with its WAL state.
 
-## Deployment changes
+## The combined image is gone, and the new stack will not adopt your old database
 
 - Replace `aimee-combined` with the managed server or split stack.
 - New KB containers start private PostgreSQL when `AIMEE_DB2_URL` is unset.
@@ -25,7 +34,7 @@ Do not rely on a raw copy of a live SQLite main file. Take a consistent backup w
 - Never use `docker compose down -v` until the new database has been verified and the backup has
   been restored in a clean test.
 
-## Identity and credentials
+## Credentials move into the vault, and clients re-enrol
 
 - Move agent keys and OAuth tokens into the server vault.
 - Remove legacy client plaintext only after a successful provider probe.
@@ -45,7 +54,7 @@ with:
 ```
 
 Older images gate startup on `aimee-server --webchat-vault-check`, which wants the vault to hold a
-webchat login — the sealed `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` pair, or one of the
+webchat login: the sealed `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` pair, or one of the
 `legacy_primary` / `legacy_hashes` / `accounts` records. This release holds none of them on purpose:
 PAM owns the accounts and the first-boot password is never sealed (see below). There is nothing for
 the old check to find, and adding something for it to find would mean persisting a password this
@@ -68,8 +77,8 @@ sealed into the vault, and the shadow verifiers behind them are no longer erased
 `webchat/logins` into the vault is in a state this upgrade cannot repair by itself: that migration
 sealed the verifiers into the vault's `legacy_hashes` record and then erased them from
 `/etc/shadow`. Those accounts therefore have no PAM credential to restore, and only the first-boot
-pair is provisioned. Any dashboard account created through the wizard on such an appliance — the
-account named in `webchat/bootstrap-replaced` — must be recreated after upgrading.
+pair is provisioned. Any dashboard account created through the wizard on such an appliance (the
+account named in `webchat/bootstrap-replaced`) must be recreated after upgrading.
 
 To tell whether you are affected:
 
@@ -157,7 +166,7 @@ Common refusal reasons are `absent`, `invalid`, `unknown_kid`, `wrong_team`,
 `no_team_configured`, `replay`, and `replay_unavailable`. Use the structured `403`, request ID, and
 server log. A grant for the wrong spelling is a grant for nobody.
 
-## Removed surfaces
+## What is gone, and what replaces it
 
 - `aimee chat`
 - `aimee work` and its routes/tools/tables
@@ -169,7 +178,7 @@ server log. A grant for the wrong spelling is a grant for nobody.
 
 Update scripts to use named `/v1` routes, workflows/jobs, and browser/MCP/ACP/API chat surfaces.
 
-## After
+## Verify these before you call the upgrade done
 
 ```bash
 aimee remote status

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -7,10 +7,11 @@ command. Take the backup before step one, not after the first thing goes wrong.
 Read [What's new](WHATS_NEW.md) first. This cycle changes deployment, storage, credentials, remote
 identity, workflows, and removed commands.
 
-Install from `:testing` or a release later than the `v0.3.0` tag. That tag was cut part-way through
-the cycle, on 2026-07-28, and is missing the fixes listed under
-[What landed after the first 0.3.0 tag](WHATS_NEW.md#what-landed-after-the-first-030-tag). Several
-of those are cases where a fresh install came up healthy and silently did nothing useful.
+Do not install from the `v0.2.196` or `v0.3.0` tags. Both were promoted in error part-way through
+this cycle and are not releases; an installation from either is an untested mid-cycle build missing
+the fixes listed under
+[If you installed from a mid-cycle tag](WHATS_NEW.md#if-you-installed-from-a-mid-cycle-tag).
+Several of those are cases where a fresh install came up healthy and silently did nothing useful.
 
 ## Do all of this before you touch the running deployment
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,8 +1,16 @@
-# What's new
+# What's new in 0.3.0
 
-This is the current testing tree compared with **v0.2.192**, the last public release.
+0.3.0 is a one-way upgrade. It removes the combined image, the work queue, the inference container,
+the interactive TUI, and the generic RPC transport, and it will not read a 0.2 deployment back.
+Read [Upgrading](UPGRADING.md) before you start, not after.
 
-## Event bus
+Everything below is measured against **v0.2.192**, the last 0.2-line release. Two later tags exist
+and neither is the release this describes: `v0.2.196` and `v0.3.0` were cut on 2026-07-27 and
+2026-07-28, the second by promoting `testing` to `main` part-way through this cycle. Work continued
+after that promotion, so an installation taken from the `v0.3.0` tag is missing the changes listed
+under [What landed after the first 0.3.0 tag](#what-landed-after-the-first-030-tag).
+
+## The event bus is the change everything else rests on
 
 Every daemon now has a bounded shared-memory event bus. It is the largest architectural change in
 this cycle.
@@ -28,7 +36,7 @@ the bus does not pretend they are all complete today.
 
 See [Event bus](EVENT_BUS.md).
 
-## Runtime and module boundaries
+## The C core is splitting into modules, and the control plane moved to Go
 
 - The C core is being split into owned source modules with narrow public headers, dependency
   checks, descriptors, and generated module documentation.
@@ -41,7 +49,7 @@ See [Event bus](EVENT_BUS.md).
 - Configuration fields, `/v1` operations, and provider messages are moving to table-driven,
   versioned contracts instead of duplicate switch statements.
 
-## Audit, identity, and policy
+## Audit is hash-chained, and remote writes are refused until identity is configured
 
 - The action audit store is hash-chained and checkpointed. Verification, sealing, snapshots,
   provenance, retrieval traces, and fidelity checks use the same WORM surface.
@@ -58,7 +66,7 @@ See [Event bus](EVENT_BUS.md).
 - TPM 2, PKCS#11, KMS, reseal recovery, and external WORM witnesses are available for hardened
   deployments.
 
-## Workflows and autonomous development
+## Workflows are typed and validated before a run starts
 
 - The Go workflow engine schedules parallel slices, retries, review loops, live forge work, and
   merge recovery.
@@ -73,7 +81,7 @@ See [Event bus](EVENT_BUS.md).
 - A merge conflict, missing commit, lost replay, or exhausted gate returns a named terminal or
   parked state instead of silently advancing.
 
-## Delegates and roundtables
+## Delegates run sandboxed, and a roundtable's findings feed the next pass
 
 - New installs create their first agent in the wizard and ship one canonical default roundtable.
 - Delegates route by role and persona, then retry another viable agent unless a seat is pinned.
@@ -92,7 +100,7 @@ See [Event bus](EVENT_BUS.md).
   budget, worktree, and audit path.
 - Roundtable cost caps are optional. When set, they include every seat and chair call.
 
-## Models, routing, and context
+## Routing is table-driven, and context is budgeted rather than truncated
 
 - All provider traffic passes through one canonical request and response IR.
 - OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, Gemini, Mistral, Bedrock, and local
@@ -104,7 +112,7 @@ See [Event bus](EVENT_BUS.md).
 - Model metadata, provider catalogs, quota, cost, cache, and fallback decisions are visible through
   the CLI and dashboard.
 
-## Knowledge and code
+## Retrieval answers with evidence, and abstains when it has none
 
 - The KB container can own a private PostgreSQL 18 cluster with pgvector and pgvectorscale. An
   export helper moves that data to an external PostgreSQL server.
@@ -120,15 +128,20 @@ See [Event bus](EVENT_BUS.md).
 - Retrieval gained typed facts, contradiction tracking, abstention, evidence audits, progressive
   disclosure, and configurable fusion.
 
-## Deployment and clients
+## One managed stack replaces the combined image
 
 - The all-in-one `aimee-combined` image is retired. Use the managed server or the split server and
   KB stack.
 - New KB containers run PostgreSQL privately when `AIMEE_DB2_URL` is not set. Existing external
   databases remain supported.
 - The server generates a dashboard login on first boot when the deployment supplies none, and prints
-  it once to the container log. Supply `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` to choose
-  your own; supply both or neither.
+  it once to the container log. That login is a real local PAM account, not a separate credential
+  store, so replacing it later is an ordinary account change.
+- To choose the login yourself, seal `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` with
+  `scripts/aimee-compose-vault-bootstrap.sh` before the first `up`. Exporting the two variables and
+  running `docker compose up` does not work on the managed compose file: it keeps them out of the
+  server's `environment:` block on purpose, because anything listed there stays in `Config.Env` for
+  the life of the deployment. Supply both or neither.
 - Linux, macOS, and Windows use the same DB-free thin client and native TLS backend.
 - Server-to-KB mTLS pooling and resident thin-client HTTPS keep-alive now default on. The measured
   compression flags remain off because they saved bytes but missed the latency gate.
@@ -145,7 +158,7 @@ See [Event bus](EVENT_BUS.md).
 - The attention guard is inert unless enabled. Remote writes are fail-closed until identity trust
   and per-user grants are configured.
 
-## Removed
+## What is gone, and what to use instead
 
 - Interactive `aimee chat` and the bare-command TUI. Use the browser, MCP, ACP, or a compatible API
   front end.
@@ -159,7 +172,40 @@ See [Event bus](EVENT_BUS.md).
 - Client-held plaintext agent credentials and the session credential-push endpoint.
 - The generic `/v1/rpc` transport. Named `/v1` routes are authoritative.
 
-## Upgrade notes
+## What landed after the first 0.3.0 tag
+
+The `v0.3.0` tag was cut on 2026-07-28 by promoting `testing` to `main`, and the cycle continued
+after it. If you installed from that tag rather than from `:testing` or a later release, you do not
+have the following. Each one was a deployment that looked healthy while doing nothing useful, which
+is why they are listed rather than folded into the sections above.
+
+- **The `aimee-llm` container is retired and the embedder is baked into the KB image.** A fresh
+  install embeds with no download and no second container. Set the embedder before you ingest:
+  changing it later re-embeds everything, and changing its dimension rebuilds the vector schema.
+- **A clean install could enrol no identity and store zero vectors.** The published config snapshot
+  did not match what `config_load` returned on the cached path, so first-user enrolment failed
+  silently and env-var deployments indexed nothing. Both are fixed, and the re-embed route that
+  repairs an affected deployment is now reachable.
+- **An operator-supplied dashboard login was ignored.** The entrypoint sealed
+  `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD` into Vault and scrubbed them from the environment
+  before the PAM account was provisioned, so every install generated a random account instead. The
+  supplied pair is now recovered from Vault and provisioned as the account you asked for.
+- **Tool-using delegates could not read their own worktree on a compose deploy.** `aimee-server`
+  drives a sibling Docker daemon, so a workspace bind source expressed in the server's own container
+  path does not exist on the daemon's host and Docker mounts an empty directory in its place. The
+  entrypoint now derives the translation from its own mounts.
+- **A model that accepts exactly one temperature was sent another.** Provider profiles could only
+  supply a default, which any caller overrode, so an agent with no wire provider named had no way to
+  pin the value its endpoint requires and every delegated call returned HTTP 400.
+- **A delegated shell was gated on config read from disk rather than the live snapshot.** The
+  sandbox accessor loaded a whole config on each call, so a containment decision could be made on
+  state the published snapshot had not adopted.
+
+Fixes for the KB connection pool, KB error surfacing, ingest durability, shared-cluster entrypoint
+reuse, agent removal, session branch enforcement and workflow branch aliasing also landed in this
+window.
+
+## Do these seven things, in this order
 
 1. Back up DB1, the KB database, `aimee.yaml`, `agents.json`, vault material, and TLS state.
 2. Dump the old sibling PostgreSQL volume before moving to the embedded KB database. The compose

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -4,11 +4,13 @@
 the interactive TUI, and the generic RPC transport, and it will not read a 0.2 deployment back.
 Read [Upgrading](UPGRADING.md) before you start, not after.
 
-Everything below is measured against **v0.2.192**, the last 0.2-line release. Two later tags exist
-and neither is the release this describes: `v0.2.196` and `v0.3.0` were cut on 2026-07-27 and
-2026-07-28, the second by promoting `testing` to `main` part-way through this cycle. Work continued
-after that promotion, so an installation taken from the `v0.3.0` tag is missing the changes listed
-under [What landed after the first 0.3.0 tag](#what-landed-after-the-first-030-tag).
+Everything below is measured against **v0.2.192**, the last public release.
+
+Two tags dated 2026-07-27 and 2026-07-28, `v0.2.196` and `v0.3.0`, appeared on the repository
+part-way through this cycle. Neither is a release. They were promoted mid-cycle in error, they were
+never announced, and the work below continued for another 536 commits after the later one. If you
+installed from either, you have an untested mid-cycle build rather than 0.3.0, and you are missing
+the fixes under [If you installed from a mid-cycle tag](#if-you-installed-from-a-mid-cycle-tag).
 
 ## The event bus is the change everything else rests on
 
@@ -172,12 +174,12 @@ See [Event bus](EVENT_BUS.md).
 - Client-held plaintext agent credentials and the session credential-push endpoint.
 - The generic `/v1/rpc` transport. Named `/v1` routes are authoritative.
 
-## What landed after the first 0.3.0 tag
+## If you installed from a mid-cycle tag
 
-The `v0.3.0` tag was cut on 2026-07-28 by promoting `testing` to `main`, and the cycle continued
-after it. If you installed from that tag rather than from `:testing` or a later release, you do not
-have the following. Each one was a deployment that looked healthy while doing nothing useful, which
-is why they are listed rather than folded into the sections above.
+The `v0.2.196` and `v0.3.0` tags were promoted in error part-way through this cycle and are not
+releases. The cycle continued for another 536 commits after the later one, so an installation taken
+from either is missing the following. Each is a case where the deployment came up healthy and did
+nothing useful, which is why they are listed here rather than folded into the sections above.
 
 - **The `aimee-llm` container is retired and the embedder is baked into the KB image.** A fresh
   install embeds with no download and no second container. Set the embedder before you ingest:

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -164,7 +164,7 @@ files are reported as `SKIP`; steps without `paths:` still run. A step may set
 `AIMEE_VERIFY_CHANGED_ALL`.
 
 `.aimee/project.yaml` also accepts a `sandbox:` block that declares the Docker
-image a sandboxed delegate runs in for this repo — a pre-baked `image:`, a
+image a sandboxed delegate runs in for this repo: a pre-baked `image:`, a
 `from:`+`packages:` build, or a `dockerfile:`. See
 [Delegate Sandbox](DELEGATE_SANDBOX.md).
 

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -18,7 +18,7 @@ and serves the model itself, from weights baked into its image. The bundled `bek
 384-dimension; an external endpoint (`AIMEE_EMBEDDER_URL`) can serve a wider one.
 
 The embedder is selected in the wizard's Deploy topology step. Until one is selected the KB serves a
-builtin lexical embedder — retrieval works, but it is keyword matching rather than vector search.
+builtin lexical embedder. Retrieval works, but it is keyword matching rather than vector search.
 
 Check [Inference tiers](AIMEE_KB_SYNTH_TIERS.md) for sizing the synthesis endpoint.
 
@@ -29,7 +29,7 @@ failure.
 ### One bundled embedder, or your own
 
 `bekko-a25m` ships inside the `aimee-kb` container, with its weights baked into the image.
-A fresh install embeds immediately — no inference service, no GPU, no model download, no
+A fresh install embeds immediately: no inference service, no GPU, no model download, no
 network. It is **384-dimensional**.
 
 | | `bekko-a25m` (bundled) |
@@ -37,7 +37,7 @@ network. It is **384-dimensional**.
 | NDCG@10 (frozen-ab-v1) | 0.5909 |
 | dimension | 384 |
 | context | 8192 |
-| prefixes | none — its card defines none, so its benchmark number carries into production unchanged |
+| prefixes | none. Its card defines none, so its benchmark number carries into production unchanged |
 | vocab | 256k, multilingual |
 
 **Above 384 dimensions, run your own embedder.** Point `AIMEE_EMBEDDER_URL` (or the
@@ -53,7 +53,7 @@ from it and cannot derive the width of an endpoint it does not serve. Nothing ap
 prefixes on that path either, so a prefix-dependent model must apply its own.
 
 Operators can declare additional models with `EMBEDDERS_EXTRA`, giving the pooling, width,
-context and prefixes — nobody can infer those for you, and each one changes the vectors.
+context and prefixes. Nobody can infer those for you, and each one changes the vectors.
 An overlay entry whose weights are not baked is reachable only as an external endpoint.
 
 **Changing the embedder is destructive.** The wizard requires a typed confirmation,
@@ -69,13 +69,13 @@ is gated up front rather than discovered at the next boot.
 ### What defines the vector space
 
 Width is not identity. Pooling and the query/document prefixes change every vector while leaving
-both the dimension and the model name untouched — well-formed vectors, right width, right name,
+both the dimension and the model name untouched: well-formed vectors, right width, right name,
 different space, collapsed recall and no error anywhere. Both have happened: nomic served with
 `last` pooling (correct for the previous Qwen3 embedder), and nomic served prefix-free, which
 measured 0.5823 NDCG@10 against 0.6075 with its card prefixes.
 
-So the gateway publishes a `serving_id` on `/health` — the model key plus a digest over pooling and
-the prefix pair — and the KB records it in `kb_meta.schema_embedder_serving_id` on first start
+So the gateway publishes a `serving_id` on `/health` (the model key plus a digest over pooling and
+the prefix pair), and the KB records it in `kb_meta.schema_embedder_serving_id` on first start
 against a corpus. A later start whose endpoint reports a different `serving_id` **refuses**, naming
 both values, and the remediation is a full re-embed:
 
@@ -90,10 +90,10 @@ limits worth knowing:
 - An endpoint that reports no `serving_id` (a legacy or third-party embedder) leaves the guard
   inactive rather than refusing, so upgrades do not strand existing deployments. The **builtin**
   lexical embedder does declare one (`builtin/lexical-v1`) because it shares the bundled model's
-  384 width — without an identity, switching between the two would be invisible to both guards.
+  384 width. Without an identity, switching between the two would be invisible to both guards.
 - A corpus embedded before the guard existed adopts the current identity on its first start, because
   it is indistinguishable from a fresh one. If such a corpus was built while prefixes were disabled,
-  re-embed it once by hand — the guard cannot detect drift it never recorded a baseline for.
+  re-embed it once by hand: the guard cannot detect drift it never recorded a baseline for.
 
 ## Changing dimension
 
@@ -129,7 +129,7 @@ because ranking and timing can leak excluded data.
 ## No cross-encoder rerank stage
 
 There is no reranker. Measured across 20 configurations and two embedders, the best cross-encoder
-result was +0.0032 NDCG@10 and most were negative — a reranker's ceiling sits below a strong dense
+result was +0.0032 NDCG@10 and most were negative. A reranker's ceiling sits below a strong dense
 ranking, so the effect shrank as the embedder improved. Hybrid BM25+RRF fusion measured +0.1168
 Recall@10 over dense alone, roughly 35x the best rerank result, which is where the remaining quality
 lives. See [the retrieval-stack report](validation/retrieval-stack-report-2026-07-30.md).


### PR DESCRIPTION
## The problem

`v0.2.196` (2026-07-27) and `v0.3.0` (2026-07-28) were promoted to the repository **in error** part-way through this cycle. They are not releases. **v0.2.192 remains the last public release.**

The cycle continued for another **536 commits** after the later tag, and `v0.3.0` is not an ancestor of `testing`. Anyone who installed from either tag has an untested mid-cycle build, and nothing in the docs said so.

## What changed

**A new section addresses that reader directly** and lists what such an installation is missing. Every item is a case where the deployment came up healthy and did nothing useful:

- no identity enrolled and zero vectors stored on a clean install
- an operator-supplied dashboard login discarded in favour of a generated one
- a delegate sandbox whose workspace mount was an empty directory
- a model sent a temperature its endpoint rejects, failing every delegated call
- a containment decision read from disk rather than the live config snapshot

**Corrected the first-boot credential instructions.** The notes claimed supplying `AIMEE_WEBCHAT_USER` and `AIMEE_WEBCHAT_PASSWORD` chooses your own login. On `compose.server-managed.yaml` it did not: those two are deliberately kept out of the server's `environment:` block, so the documented gesture silently produced a generated account. Now points at `scripts/aimee-compose-vault-bootstrap.sh` and says why the obvious approach is not the supported one.

**`UPGRADING.md` opens with the fact that there is no way back**, instead of leaving it a third of the way down, and names the tags not to install from.

**Headings assert what changed** rather than labelling a topic, so the argument survives skimming.

**Em dashes removed** from every document in `docs/` and the repository root, per the voice guide. Each was replaced with a full stop, comma, colon or brackets as the sentence wanted, not mechanically. 47 docs plus the root files are clean.

## A correction inside this PR

The first commit rewrote the "last public release" line, having inferred from the tag list that it was stale. That was wrong: the line was correct, and a tag existing is not the same as a release happening. The repository state cannot tell the difference. The second commit restores it and reframes the warning around what those tags actually are. Review the diff as a whole rather than commit by commit.

## Scope

- `benchmarks/**` still contains em dashes. Those are result records rather than prose, so I left them.
- `docs/gen/**` is generated from source strings and is not hand-edited here.
- Spelling is left as each document already had it.
