### PR TITLE
a merge to main is not consent to release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,17 +1,36 @@
-# Auto-release on every push to main.
+# Release on push to main, AFTER a human approves the version.
+#
+# `:testing` is the automated channel (publish-testing.yml, no approval). `main`
+# is not. This workflow used to tag and publish on every push to `main`, and
+# under the testing->main promote flow that made a merge into a release: it
+# invented the next version, pushed the tag, built thin clients for four
+# platforms, published the images and moved `:latest`, with nobody intending
+# any of it. v0.2.196 and v0.2.192+1 were published that way mid-cycle on
+# 2026-07-27 and 2026-07-28 while v0.2.192 remained the last release anyone
+# meant to make.
+#
+# Inference is kept, because computing the next patch from the tags is right
+# almost always. What was missing is consent. The version is now computed in a
+# job that changes nothing, published to the run summary, and everything that
+# has an effect waits behind the `release` environment. The approver sees the
+# exact number before it exists.
+#
+# NOTE: this is only a gate if the `release` environment has required reviewers
+# configured in repository settings. Without them GitHub approves it
+# automatically and the old behaviour returns.
 #
 # On each push to `main` (which, under the testing->main promote flow, is a
 # promote merge) this uses a higher version declared in aimee_version.h (for a
 # planned major/minor release), otherwise computes the next semver PATCH from
-# the highest existing `v*` tag. It creates and pushes that tag, then cuts a
-# full release by calling the reusable build workflows:
+# the highest existing `v*` tag. After approval it creates and pushes that tag,
+# then cuts a full release by calling the reusable build workflows:
 #   - release-thin-client.yml  -> aimee CLI binaries (Linux/macOS/Windows) on the GitHub Release
 #   - publish-images.yml       -> aimee-server / aimee-kb multi-arch images, tagged :<version> + :latest
 #
 # Reusable workflows are invoked directly (workflow_call), so this works with the
 # default GITHUB_TOKEN -- no PAT needed (a tag pushed by GITHUB_TOKEN would not,
 # by design, re-trigger the tag-on:push workflows, hence the direct call).
-name: Auto release
+name: Release (main, approval required)
 
 on:
   push:
@@ -75,16 +94,54 @@ jobs:
           echo "version=$next" >> "$GITHUB_OUTPUT"
           echo "Next version: v${next} (latest ${latest:-<none>}, declared v${declared})"
 
-      - name: Create and push tag
+      - name: Publish the proposed version for the approver
         run: |
+          v="v${{ steps.bump.outputs.version }}"
+          {
+            echo "## Awaiting approval to release $v"
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| version | \`$v\` |"
+            echo "| commit | \`${GITHUB_SHA}\` |"
+            echo "| pushed by | ${GITHUB_ACTOR} |"
+            echo
+            echo "Approving publishes thin clients for four platforms, publishes"
+            echo "aimee-server and aimee-kb, and moves \`:latest\`. Rejecting leaves"
+            echo "no tag and no artifacts."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=Release awaiting approval::$v from ${GITHUB_SHA}"
+
+  # Nothing above this point has an effect. Everything below waits for a
+  # reviewer on the `release` environment, and the version they are approving is
+  # in the run summary written by the job above.
+  tag:
+    needs: version
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Re-check the version is still free, then tag
+        run: |
+          tag="v${{ needs.version.outputs.version }}"
+          # Re-check after the approval wait: another release may have landed
+          # while this sat in the queue.
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "::error::$tag was created while this run waited for approval; re-run to compute a fresh version"
+            exit 1
+          fi
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          tag="v${{ steps.bump.outputs.version }}"
           git tag -a "$tag" -m "aimee $tag"
           git push origin "$tag"
 
   thin-clients:
-    needs: version
+    needs: [version, tag]
     uses: ./.github/workflows/release-thin-client.yml
     permissions:
       contents: write
@@ -92,7 +149,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
 
   images:
-    needs: version
+    needs: [version, tag]
     uses: ./.github/workflows/publish-images.yml
     permissions:
       contents: read
@@ -119,8 +176,8 @@ jobs:
   # same number instead of silently skipping it. Every step is `|| true` so this
   # cleanup can never mask the original failure, and the run still reports it.
   rollback-tag:
-    needs: [version, thin-clients, images]
-    if: always() && needs.version.result == 'success' && (needs.images.result == 'failure' || needs.images.result == 'cancelled' || needs.thin-clients.result == 'failure' || needs.thin-clients.result == 'cancelled')
+    needs: [version, tag, thin-clients, images]
+    if: always() && needs.tag.result == 'success' && (needs.images.result == 'failure' || needs.images.result == 'cancelled' || needs.thin-clients.result == 'failure' || needs.thin-clients.result == 'cancelled')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -59,40 +59,36 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Compute next patch version
+      - name: Infer the next version in the declared series
         id: bump
         run: |
-          latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-          declared=$(awk '$1 == "#define" && $2 == "AIMEE_VERSION" {gsub(/"/, "", $3); print $3; exit}' \
+          # The tree declares MAJOR.MINOR and nothing else. The patch is whatever
+          # comes next in that series, so a patch release needs no commit and
+          # cannot disagree with what was tagged. Moving series is an explicit
+          # edit of AIMEE_VERSION_SERIES, never inferred.
+          series=$(awk '$1 == "#define" && $2 == "AIMEE_VERSION_SERIES" {gsub(/"/, "", $3); print $3; exit}' \
             src/headers/aimee_version.h)
-          if ! [[ "$declared" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::invalid AIMEE_VERSION in src/headers/aimee_version.h: ${declared:-<empty>}"
+          if ! [[ "$series" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::AIMEE_VERSION_SERIES must be MAJOR.MINOR; got '${series:-<empty>}'"
             exit 1
           fi
+          # Highest patch already tagged in THIS series. Tags from other series
+          # are irrelevant: a 0.4.0 tag must not make the 0.3 line jump.
+          latest=$(git tag --list "v${series}.*" --sort=-v:refname | head -n1)
           if [ -z "$latest" ]; then
-            next="$declared"
+            next="${series}.0"
           else
-            v="${latest#v}"
-            IFS='.' read -r major minor patch <<< "$v"
-            # Guard against malformed tags; default missing components to 0.
-            major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
-            patch_next="${major}.${minor}.$((patch + 1))"
-            # The source declaration is a release floor. This permits an intentional
-            # major/minor promotion (for example 0.2.x -> 0.3.0), but an unchanged
-            # declaration after that release naturally resumes patch increments.
-            highest=$(printf '%s\n%s\n' "$v" "$declared" | sort -V | tail -n1)
-            if [ "$highest" = "$declared" ] && [ "$declared" != "$v" ]; then
-              next="$declared"
-            else
-              next="$patch_next"
-            fi
+            patch="${latest##*.}"
+            [[ "$patch" =~ ^[0-9]+$ ]] || { echo "::error::cannot read a patch number from tag ${latest}"; exit 1; }
+            next="${series}.$((patch + 1))"
           fi
           if git rev-parse -q --verify "refs/tags/v${next}" >/dev/null; then
             echo "::error::tag v${next} already exists; aborting to avoid clobbering a release"
             exit 1
           fi
           echo "version=$next" >> "$GITHUB_OUTPUT"
-          echo "Next version: v${next} (latest ${latest:-<none>}, declared v${declared})"
+          echo "series=$series" >> "$GITHUB_OUTPUT"
+          echo "Next version: v${next} (series ${series}, highest in series ${latest:-<none>})"
 
       - name: Publish the proposed version for the approver
         run: |
@@ -103,6 +99,7 @@ jobs:
             echo "| | |"
             echo "| --- | --- |"
             echo "| version | \`$v\` |"
+            echo "| series | \`${{ steps.bump.outputs.series }}\` (declared) |"
             echo "| commit | \`${GITHUB_SHA}\` |"
             echo "| pushed by | ${GITHUB_ACTOR} |"
             echo

--- a/src/headers/aimee_version.h
+++ b/src/headers/aimee_version.h
@@ -1,9 +1,23 @@
 #ifndef DEC_AIMEE_VERSION_H
 #define DEC_AIMEE_VERSION_H 1
 
-/* Version -- can be overridden at compile time via -DAIMEE_VERSION='"..."' */
+/* Release series, MAJOR.MINOR. The only version component declared in the tree.
+ *
+ * The PATCH is never written here. It is inferred at release time from the
+ * highest v<series>.* tag, so shipping 0.3.1 after 0.3.0 needs no commit to
+ * this file and cannot drift from what was actually tagged. Moving to a new
+ * series IS a decision, so it is an explicit edit of this one line and nothing
+ * infers it. */
+#ifndef AIMEE_VERSION_SERIES
+#define AIMEE_VERSION_SERIES "0.3"
+#endif
+
+/* Full version -- can be overridden at compile time via -DAIMEE_VERSION='"..."'
+ * (release and image builds inject the resolved version this way). The patch
+ * component of this fallback is a placeholder for local builds, not a release
+ * number; nothing reads it to decide what to publish. */
 #ifndef AIMEE_VERSION
-#define AIMEE_VERSION "0.3.0"
+#define AIMEE_VERSION AIMEE_VERSION_SERIES ".0"
 #endif
 
 /* HEAD commit timestamp -- embedded at build time for stale-binary detection.


### PR DESCRIPTION
## What happened

`auto-release.yml` ran on **every push to `main`**: it inferred a version, pushed the tag, built thin clients for four platforms, published `aimee-server` and `aimee-kb`, and moved `:latest`.

Under the testing→main promote flow a promote merge *is* a push to `main`. So merging was releasing, and nobody had to intend it. On 2026-07-27 and 2026-07-28 nobody did: `v0.2.196` and `v0.3.0` went out mid-cycle while **v0.2.192 remained the last release anyone meant to make**. `v0.3.0` is not an ancestor of `testing`, and its binaries have been downloaded 8 times.

The file's own comments record an earlier case of the same class: three tags in one day with no images, leaving `:latest` two weeks stale on a KB that could not bootstrap.

## Inference stays. Consent was what was missing.

Computing the next patch from the tags is right nearly every time. The failure was not a bad number, it was that nobody was asked for one. So effect is separated from calculation:

| job | environment | what it does |
| --- | --- | --- |
| `version` | none | infers the version, writes it with the commit and actor to the run summary. **No effect.** |
| `tag` | `release` | **waits for approval**, re-checks the version is still free, then tags |
| `thin-clients`, `images` | none | depend on `tag`, so they cannot run before approval |
| `rollback-tag` | none | keyed off `tag` instead of `version` |

The approver sees the exact version before it exists. Rejecting leaves no tag and no artifacts. `tag` re-checks after the wait because another release can land while a run sits in the queue.

**`:testing` is untouched and stays fully automatic.** `publish-testing.yml` is the channel for builds nobody needs to approve. `main` is not that channel.

## The patch number no longer lives in a file

The tree declared a full `"0.3.0"` and the workflow read it as a floor. The patch therefore existed in two places, a header someone had to remember and the tag that actually shipped, and the header was the one that could be wrong. It still said `0.3.0` with `v0.3.0` already published.

Now `AIMEE_VERSION_SERIES` declares **MAJOR.MINOR only**, and the patch is inferred from the highest `v<series>.*` tag:

```
series 0.3   highest=v0.3.0     -> next v0.3.1
series 0.4   highest=<none>     -> next v0.4.0
series 0.2   highest=v0.2.196   -> next v0.2.197
```

A patch release needs no commit and cannot disagree with what was tagged. Moving to a new series stays a decision: an explicit edit of one line, never inferred.

The tag search is **scoped to the declared series**, so a `0.4.0` tag cannot make the next `0.3.x` release jump the line.

`AIMEE_VERSION` still works for every caller (it is used as a string literal in `strcmp`, `printf` and JSON fields). It is the series plus a placeholder patch, and release/image builds inject the resolved version over it as they already did. Verified both paths compile and report correctly: a local build says `0.3.0`, a build with `-DAIMEE_VERSION='"0.3.1"'` says `0.3.1`.

## Required setup, already done

This is only a gate while the `release` environment has required reviewers. It did not exist; the repository had **no environments at all**. It has been created with `required_reviewers: [JBailes]`.

**Removing those reviewers silently restores the old behaviour.** The workflow cannot detect that and does not try to.
