### PR TITLE
say which name is taken instead of forwarding useradd's error

### DIFF
--- a/runtime-web/pam_identity.go
+++ b/runtime-web/pam_identity.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"os/user"
 	"sort"
 
 	"github.com/RakuenSoftware/smoothgui/auth"
@@ -122,9 +123,42 @@ func (p *pamAccounts) Exists(username string) bool {
 	return p.managed(username)
 }
 
+// groupLookup is os/user's group lookup, indirected so the collision check can
+// be tested without depending on which groups the test host happens to ship.
+var groupLookup = func(name string) error {
+	_, err := user.LookupGroup(name)
+	return err
+}
+
+// userLookup reports whether an account of this name already exists.
+var userLookup = func(name string) error {
+	_, err := user.Lookup(name)
+	return err
+}
+
+// errUsernameIsGroup explains a collision the operator can actually act on.
+//
+// useradd allocates a user-private group and fails with "group <name> exists"
+// and exit status 9 when one is already there. The server image ships the usual
+// Unix groups, so operator, backup, staff, users, news, mail, proxy, adm and
+// aimee itself are all taken. That list is not obscure: the wizard's first field
+// asks an operator to name their account, and "operator" is the obvious answer.
+//
+// Without this the shell error reaches the browser verbatim, doubled prefix and
+// exit status included, naming neither the real problem nor a way out.
+func errUsernameIsGroup(username string) error {
+	return fmt.Errorf("%q is already a group on this host, so it cannot also be an account name; choose another", username)
+}
+
 func (p *pamAccounts) Create(username, password string) error {
 	if err := auth.ValidateUsername(username); err != nil {
 		return err
+	}
+	// Only a collision for a name that is NOT already an account: an existing
+	// account owns a like-named private group, and reporting that as a clash
+	// would mask the real "user exists" condition the caller handles.
+	if userLookup(username) != nil && groupLookup(username) == nil {
+		return errUsernameIsGroup(username)
 	}
 	return p.users.Create(username, password)
 }

--- a/runtime-web/pam_identity_test.go
+++ b/runtime-web/pam_identity_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/RakuenSoftware/smoothgui/auth"
@@ -174,5 +175,50 @@ func TestPAMListReportsOnlyManagedLogins(t *testing.T) {
 	}
 	if len(names) != 2 || names[0] != "admin" || names[1] != "virant" {
 		t.Fatalf("List() = %v; want sorted [admin virant]", names)
+	}
+}
+
+// A username that already names a host group must be refused with a sentence an
+// operator can act on, instead of useradd's "group X exists ... exit status 9"
+// reaching the browser. The image ships operator, backup, staff, users and aimee
+// as groups, and the wizard's first field is where someone meets them.
+func TestCreateRefusesUsernameThatIsAlreadyAGroup(t *testing.T) {
+	origGroup, origUser := groupLookup, userLookup
+	defer func() { groupLookup, userLookup = origGroup, origUser }()
+
+	users := &fakeUsers{members: map[string]bool{}, created: map[string]string{}}
+	p := &pamAccounts{users: users}
+
+	// "operator" is a group and not an account.
+	groupLookup = func(name string) error {
+		if name == "operator" {
+			return nil
+		}
+		return errors.New("no such group")
+	}
+	userLookup = func(string) error { return errors.New("no such user") }
+
+	err := p.Create("operator", "irrelevant")
+	if err == nil {
+		t.Fatal("expected a refusal for a username that is already a group")
+	}
+	if !strings.Contains(err.Error(), "already a group") {
+		t.Fatalf("error should name the collision, got: %v", err)
+	}
+	if len(users.created) != 0 {
+		t.Fatalf("must not reach the user manager, created=%v", users.created)
+	}
+
+	// A free name still goes through.
+	if err := p.Create("admin", "irrelevant"); err != nil {
+		t.Fatalf("a name that is not a group should be created: %v", err)
+	}
+
+	// An EXISTING account owns a like-named private group. That must not be
+	// reported as a collision, or the caller's real "user exists" path is masked.
+	groupLookup = func(string) error { return nil }
+	userLookup = func(string) error { return nil }
+	if err := p.Create("existing", "irrelevant"); err != nil {
+		t.Fatalf("an existing account must not be refused as a group clash: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes the user-visible half of #2209.

## What happens today

The wizard's **first field** asks for an account name. Type `operator`, the obvious answer, and the browser shows:

```
useradd: useradd: group operator exists - if you want to add this user to that group, use -g.: exit status 9
```

`operator` is a group on the host, and `useradd` allocates a user-private group of the same name. The set is not obscure. The server image ships:

```
adm aimee aimee-webchat backup mail news nogroup operator proxy staff users www-data ...
```

so `backup`, `staff`, `users`, `news`, `mail`, `proxy`, `adm` and **`aimee`** itself all fail the same way. Reproduced on a from-scratch managed install of `vtesting-39c81f1`, digest asserted; `admin` succeeds immediately.

## Why refuse rather than pass `-g`

`useradd` runs inside `github.com/RakuenSoftware/smoothgui/auth`, a published dependency, so the flag is not ours to pass from here.

That is the lesser reason. The better one is that adding the dashboard account to a pre-existing system group would quietly widen what it can reach. `operator`, `adm` and `staff` are not empty names on a Unix host. That is not a decision to make on someone's behalf while they are typing a username, so this refuses and says why.

## The change

Check before delegating, and return a sentence naming the collision and the remedy.

Only for a name that is **not** already an account: an existing account owns a like-named private group, and reporting that as a clash would mask the caller's real "user exists" path. Both lookups are indirected through variables so the test does not depend on which groups the CI host ships.

## Verification

Red before green. With the guard disabled:

```
--- FAIL: TestCreateRefusesUsernameThatIsAlreadyAGroup
    pam_identity_test.go:203: expected a refusal for a username that is already a group
```

With it restored, that test and the full `runtime-web` suite pass. The test covers all three cases: a name that is a group is refused before reaching the user manager, a free name is created, and an existing account is not misreported as a collision.

## Still open in #2209

The upstream `useradd` invocation is unchanged, so a deployment that reaches it another way still gets the raw error. Worth fixing in `smoothgui/auth` as well.
