### PR TITLE
point the config-reload check at the log that has the line

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -51,12 +51,15 @@ hand edit of `aimee.yaml`, and an autonomous write all take effect the same way.
 send `SIGHUP`.
 
 The reload validates before it publishes. A file that does not parse or does not validate is
-**rejected and the running configuration is kept**, which the log says plainly:
+**rejected and the running configuration is kept**, which `$AIMEE_HOME/server.log` says plainly:
 
 ```text
-config: config file change: reloaded
-config: config file change: rejected (kept running config)
+2026-08-01T00:07:00Z INFO  config: config file change: reloaded
+2026-08-01T00:07:00Z WARN  config: config file change: rejected (kept running config)
 ```
+
+That file, not `docker logs`. The container's stdout carries the entrypoint and the browser service;
+the C server logs to `$AIMEE_HOME/server.log`.
 
 A rejected reload is not a failed start. The server keeps serving the last good configuration, so a
 bad edit degrades to "your change did nothing" rather than to an outage. Check the log if a change

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -80,10 +80,11 @@ unsandboxed shell there is a host-root escalation. Give the delegate a workspace
 
 ## A settings change seems to have been ignored
 
-Read the log before assuming the field needs a restart:
+Read the log before assuming the field needs a restart. The C server writes to a file, not to the
+container's stdout, so `docker logs` will not show this:
 
 ```bash
-docker logs <server> 2>&1 | grep '^config: config file change'
+docker exec <server> grep 'config file change' /var/lib/aimee/server.log | tail -3
 ```
 
 `rejected (kept running config)` means the file did not validate and the previous configuration is


### PR DESCRIPTION
I documented that check in #2214 and #2216 without running it. Running it found the command finds nothing.

## What was wrong

```bash
docker logs <server> 2>&1 | grep '^config: config file change'
```

Two faults. The C server logs to `$AIMEE_HOME/server.log`, **not** the container's stdout, so `docker logs` never carries this line. And the anchor is wrong regardless: the line begins with a timestamp and level.

The real line, and the real place:

```
$ docker exec <server> grep 'config file change' /var/lib/aimee/server.log
2026-08-01T00:07:00Z INFO  config: config file change: reloaded
```

## The behaviour is right, and now verified

Also previously unverified. Appending a key to `aimee.yaml` by hand on a running server produced that line within the second, with **no restart and no SIGHUP**, and the new value was live. `POST /v1/config/get` in the same log confirms the read went to the server rather than the CLI reading the file itself, so the value really did change in the running snapshot.

## The distinction behind the mistake

`SETTINGS.md` now states it once: the container's stdout carries the entrypoint and the browser service; the C server writes to its own log.

That is also why the delegate sandbox host-map check a few sections earlier in `TROUBLESHOOTING.md` **does** use `docker logs` and is correct to. It reads a `[server-entrypoint]` line, which is shell output. I verified that one on `.210` when I wrote it; I did not verify this one, which is how the two ended up inconsistent.