### PR TITLE
explain the failed jobs a default install accumulates

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -108,6 +108,33 @@ container, and every check after that silently tests the previous build. Assert 
 before drawing a conclusion. `aimee --version` reporting an older commit than your branch is normal
 for a docs-only change, because the image only rebuilds when image-affecting paths change.
 
+## `kb status` reports failed jobs and nothing says why
+
+```text
+Queue:     0 pending, 0 running, 9 failed
+```
+
+Ask the jobs, not the counter:
+
+```bash
+docker exec <kb> sh -c "/usr/lib/postgresql/18/bin/psql --host=/var/lib/aimee/run \
+  --dbname=aimee_shared --no-psqlrc -c \"select kind, left(last_error,80), count(*) \
+  from kb_async_jobs where status='failed' group by 1,2\""
+```
+
+On a default install the answer is usually one row:
+
+```text
+ memory_facts | no curator provider or command configured | 9
+```
+
+That is not a fault. Synthesis is external-only in this release, so curator work has nowhere to run
+until you give it an endpoint, and each attempt is recorded as a failure rather than skipped. The
+count grows quietly and `kb status` never says the cause.
+
+Configure a synthesis endpoint, or expect the count. `aimee kb status` shows the curator tiers as
+`configured: false` until you do. See [Inference tiers](AIMEE_KB_SYNTH_TIERS.md).
+
 ## Workflow parks
 
 Read the named park reason and latest artifact. Common causes are a human gate, no valid panel,


### PR DESCRIPTION
A healthy appliance reports failures and nothing says why:

```text
Queue:     0 pending, 0 running, 9 failed
```

Every one, on `.210` running `vtesting-651650e`:

```text
 memory_facts | no curator provider or command configured | 9
```

That is the visible edge of a 0.3.0 change. Synthesis is **external-only** now, so on an install with no endpoint the curator has nowhere to run, and each attempt is **recorded as a failure rather than skipped**. The count climbs on its own, `kb status` never names the cause, and the appliance is otherwise healthy, so it reads as damage.

Adds the query that asks the jobs rather than the counter, and says the answer is usually configuration rather than a fault.

Found while validating the quickstart's embedder checks against a live KB. Those checks are correct, including the `embedder-server: loaded ... dim=384 threads=8 quant=fp32` line quoted verbatim; this turned up beside them.