### PR TITLE
let a read-only kb command read instead of migrate

### DIFF
--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -720,6 +720,13 @@ void db2_thread_conn_close(void)
    }
 }
 
+/* See db2_set_schema_readonly in lifecycle.h. */
+static int g_schema_readonly;
+void db2_set_schema_readonly(int on)
+{
+   g_schema_readonly = on ? 1 : 0;
+}
+
 int db2_is_initialized(void)
 {
    return g_conn ? 1 : 0;
@@ -818,7 +825,7 @@ int db2_init(const char *libpq_url)
     * applied by a separate migrate/owner step; here we VERIFY it (read-only) and
     * skip both the probe leg (which would write a fresh dim) and the apply. The
     * dev/owner path below is unchanged. */
-   int pre_provisioned = db2_hardening_enabled() && !aimee_pg_is_shim();
+   int pre_provisioned = (db2_hardening_enabled() || g_schema_readonly) && !aimee_pg_is_shim();
 
    /* §2b fresh-DB probe leg: unpinned + nothing recorded + a probe registered. The
     * advisory lock serialises racing kb starts; FAIL-FAST on any probe/lock/read

--- a/src/db2/lifecycle.h
+++ b/src/db2/lifecycle.h
@@ -12,6 +12,17 @@ extern "C"
 #include <stdint.h>
 
    int db2_is_initialized(void);
+
+   /* Read-only schema mode for one-shot callers that do not own the schema.
+    *
+    * db2_init APPLIES the schema by default, which is right for the daemon that
+    * owns it and wrong for a CLI reading a running deployment: the DDL races the
+    * daemon's own pass and Postgres reports "tuple concurrently updated", which
+    * db2_init then reports as "DB2 not reachable" -- naming the wrong problem
+    * entirely. Set this before db2_init to VERIFY the schema instead, the same
+    * path AIMEE_KB_HARDENED already takes. Process-wide and off by default, so
+    * the daemon is unaffected. */
+   void db2_set_schema_readonly(int on);
    int db2_init(const char *libpq_url);
 
    /* Set the embedding dimension used to create the DB2 halfvec embedding

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -767,6 +767,11 @@ static int kb_cmd_tenancy_init_db2(void)
    }
    db2_set_embedding_dim_default(config_embedding_dim_default());
    db2_set_embedding_dim(config_embedding_dim_current());
+   /* These commands read a deployment somebody else is running. Applying the
+    * schema from here races the daemon's own pass, and Postgres answers "tuple
+    * concurrently updated", which surfaced below as "DB2 not reachable" against a
+    * KB that was reachable and healthy. Verify instead. */
+   db2_set_schema_readonly(1);
    if (db2_init(db2_url) != 0)
    {
       fprintf(stderr, "aimee-kb: DB2 not reachable at %s\n", db2_url);


### PR DESCRIPTION
Fixes #2217.

## The problem

Every `aimee-kb` governance verb (`team`, `project`, `models`, `spend`, `budget`, `rate`, `telemetry`) calls `db2_init`, and `db2_init` **applies the schema**. Run one against a KB that is serving and the DDL races the daemon's own pass:

```
aimee: db2_init: schema apply failed: ERROR:  tuple concurrently updated
aimee-kb: DB2 not reachable at postgresql:///aimee_shared?host=/var/lib/aimee/run&user=aimee
```

The KB was reachable and healthy; the same command succeeded on retry. The second line is the one an operator reads, and it sends them after a connection fault that does not exist.

## The fix

`db2_init` already has the path this wants. `AIMEE_KB_HARDENED` makes it **verify** the schema rather than apply it, for a runtime-role KB that does not own the schema. A CLI reading somebody else's running deployment is exactly that.

`db2_set_schema_readonly()` gives it an explicit way in, rather than making a read-only command set an environment variable about hardening it is not performing. Process-wide, off by default, so the daemon path is untouched: only the seven verbs opt in.

## Not verified against a live KB

The verify path compares the recorded embedding dim against the dim the process resolves, and if those disagree the commands fail differently rather than working:

```
hardened tier: embedding dim mismatch (kb expects %d, schema built for %d)
```

Reading the §2a precedence says an unpinned caller inherits the *recorded* dim, which is the case here, so they should agree. That is reasoning, not evidence. The C toolchain is not available in the environment this was written in, so `db2_init.c` was syntax-checked only.

**I will test this against a live KB once `:testing` carries it, and report back on the issue.** Do not treat it as done until then.
