### PR TITLE
commit as the installed operator, or refuse

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -48,6 +48,19 @@ persists in the container's `Config.Env` for the life of the deployment and is r
 `docker inspect`. The script streams them into Vault through a one-shot container instead, so
 `docker compose up` on its own never sees them and would leave you with a generated login.
 
+aimee also needs a git identity, sealed the same way. Without it every commit aimee makes has no
+author and git refuses it, so `aimee git commit`, delegate commits and workflow commits all fail:
+
+```bash
+export AIMEE_GIT_AUTHOR_NAME='Your Name'
+export AIMEE_GIT_AUTHOR_EMAIL='you@example.com'
+scripts/aimee-compose-vault-bootstrap.sh -f compose.server-managed.yaml server
+```
+
+There is deliberately no default. aimee points `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at
+`/dev/null` so a commit cannot silently inherit the machine's identity, and it will not invent a bot
+author: a commit that cannot say who made it is not made.
+
 Those variables are first-boot transport, not runtime configuration. On first boot the entrypoint
 reads that sealed pair and provisions it as a real local PAM account, then the appliance
 authenticates against PAM from the first login onward. There is no parallel credential store, and

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -30,6 +30,28 @@ type CommandVerifier struct {
 
 const defaultCommandVerifyLock = "aimee-wfe-command-verify.lock"
 
+// gitIdentityArgs returns the `-c user.name=... -c user.email=...` the WFE commits
+// under, read from the identity aimee was installed with.
+//
+// aimee has no ambient identity to fall back on: the server's git paths point
+// GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM at /dev/null, so a commit carries the
+// identity aimee supplies or it has no author and git refuses it.
+//
+// The WFE used to supply an aimee-wfe persona instead. That is worse than
+// untidy: GitHub adds a Co-authored-by trailer to the squash of any PR whose
+// commits carry two distinct authors, and the standing directive forbids those.
+// One author, no trailer.
+//
+// Empty means the deployment configured none; callers refuse rather than commit
+// anonymously.
+func gitIdentityArgs() []string {
+	name, email := os.Getenv("AIMEE_GIT_AUTHOR_NAME"), os.Getenv("AIMEE_GIT_AUTHOR_EMAIL")
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(email) == "" {
+		return nil
+	}
+	return []string{"-c", "user.name=" + name, "-c", "user.email=" + email}
+}
+
 func defaultVerifyCommand() []string {
 	// `git verify` is a key=value-style infrastructure command. Its machine
 	// format is selected with format=json; `--json` is parsed as a value-taking
@@ -722,7 +744,11 @@ func commitChanges(ctx context.Context, workdir, stage string) error {
 	} else if exit, ok := err.(*exec.ExitError); !ok || exit.ExitCode() != 1 {
 		return err
 	}
-	_, err := gitText(ctx, workdir, "-c", "user.name=aimee-wfe", "-c", "user.email=wfe@aimee.local", "commit", "-m", "wfe: "+stage)
+	ident := gitIdentityArgs()
+	if len(ident) == 0 {
+		return fmt.Errorf("no git identity configured: seal AIMEE_GIT_AUTHOR_NAME and AIMEE_GIT_AUTHOR_EMAIL at install")
+	}
+	_, err := gitText(ctx, workdir, append(ident, "commit", "-m", "wfe: "+stage)...)
 	return err
 }
 
@@ -860,8 +886,7 @@ func integrateFeatureBase(ctx context.Context, workdir, parentID string) (string
 	if _, err := gitText(ctx, workdir, "merge-base", "--is-ancestor", base, "HEAD"); err == nil {
 		return "", nil
 	}
-	if _, err := gitText(ctx, workdir, "-c", "user.name=aimee-wfe", "-c", "user.email=wfe@aimee.local",
-		"merge", "--no-edit", base); err == nil {
+	if _, err := gitText(ctx, workdir, append(gitIdentityArgs(), "merge", "--no-edit", base)...); err == nil {
 		return "", nil
 	}
 	// Merge failed (conflict or otherwise): restore a clean worktree before parking.
@@ -1682,8 +1707,7 @@ func refreshPullRequestBase(ctx context.Context, workdir, base string) (bool, st
 	if _, err := gitText(ctx, workdir, "fetch", "--no-tags", "origin", refspec); err != nil {
 		return false, "", fmt.Errorf("refresh pull request base: %w", err)
 	}
-	if _, err := gitText(ctx, workdir, "-c", "user.name=aimee-wfe", "-c",
-		"user.email=wfe@aimee.local", "merge", "--no-edit", baseRef); err != nil {
+	if _, err := gitText(ctx, workdir, append(gitIdentityArgs(), "merge", "--no-edit", baseRef)...); err != nil {
 		lower := strings.ToLower(err.Error())
 		if strings.Contains(lower, "conflict") || strings.Contains(lower, "automatic merge failed") {
 			_, _ = gitText(ctx, workdir, "merge", "--abort")

--- a/src/modules/git/git_forge_vault.c
+++ b/src/modules/git/git_forge_vault.c
@@ -42,3 +42,26 @@ int git_forge_vault_server_token(char *out, size_t out_len)
       return 0;
    return -1;
 }
+
+int git_identity_get(char *name_out, size_t name_len, char *email_out, size_t email_len)
+{
+   if (name_out && name_len)
+      name_out[0] = '\0';
+   if (email_out && email_len)
+      email_out[0] = '\0';
+   if (!name_out || !name_len || !email_out || !email_len)
+      return -1;
+
+   vault_status_t ns = vault_service_get_server_principal(GIT_FORGE_VAULT_AGENT,
+                                                          GIT_AUTHOR_NAME_CRED, name_out, name_len);
+   vault_status_t es = vault_service_get_server_principal(
+       GIT_FORGE_VAULT_AGENT, GIT_AUTHOR_EMAIL_CRED, email_out, email_len);
+   if (ns == VAULT_OK && es == VAULT_OK && name_out[0] && email_out[0])
+      return 1;
+   /* Fail closed on a real error; report "not configured" for a missing or
+    * half-written pair so the caller can say so plainly. */
+   int err = (ns != VAULT_OK && ns != VAULT_NO_ENTRY) || (es != VAULT_OK && es != VAULT_NO_ENTRY);
+   name_out[0] = '\0';
+   email_out[0] = '\0';
+   return err ? -1 : 0;
+}

--- a/src/modules/git/git_forge_vault.h
+++ b/src/modules/git/git_forge_vault.h
@@ -38,4 +38,22 @@ int git_forge_vault_sshkey(const char *principal, char *out, size_t out_len);
  * Same 1/0/-1 contract as the per-principal accessors. */
 int git_forge_vault_server_token(char *out, size_t out_len);
 
+/* The commit identity, under the same "git" agent, in the SERVER principal's
+ * vault. Supplied at installation as AIMEE_GIT_AUTHOR_NAME / _EMAIL and sealed by
+ * the first-boot env bootstrap, like every other install-time secret.
+ *
+ * aimee cannot fall back to the machine's git config: git_ops.c points
+ * GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM at /dev/null on purpose, so a commit
+ * carries the identity aimee supplies or it carries none and fails. This is that
+ * identity. */
+#define GIT_AUTHOR_NAME_CRED  "author_name"
+#define GIT_AUTHOR_EMAIL_CRED "author_email"
+
+/* Read the configured commit identity. Returns 1 when BOTH a name and an email
+ * were written, 0 when the identity is not configured, -1 on a fail-closed
+ * crypto/IO error. Both buffers are empty on a non-1 return: a half-configured
+ * identity is not an identity, so it reports 0 rather than committing as half a
+ * person. */
+int git_identity_get(char *name_out, size_t name_len, char *email_out, size_t email_len);
+
 #endif /* GIT_FORGE_VAULT_H */

--- a/src/modules/git/mcp_git_write.c
+++ b/src/modules/git/mcp_git_write.c
@@ -7,6 +7,7 @@
 #include "mcp_git.h"
 #include "util.h"
 #include "branch_ownership.h"
+#include "git_forge_vault.h"
 #include <dirent.h>
 #include <sys/stat.h>
 #include <stdio.h>
@@ -145,11 +146,34 @@ cJSON *handle_git_commit(cJSON *args)
       free(out);
    }
 
-   /* Commit */
+   /* Commit AS THE CONFIGURED OPERATOR, or not at all.
+    *
+    * git_ops points GIT_CONFIG_GLOBAL/SYSTEM at /dev/null, so git has no ambient
+    * identity to fall back on here: aimee supplies one or the commit has no
+    * author. Refuse rather than invent a persona. A bot author is not free
+    * either, since GitHub adds a Co-authored-by trailer to the squash of any PR
+    * whose commits carry two distinct authors, and the standing directive
+    * forbids those. */
+   char author_name[256] = "", author_email[256] = "";
+   int have_identity = git_identity_get(author_name, sizeof(author_name), author_email,
+                                        sizeof(author_email));
+   if (have_identity < 0)
+      return mcp_text("error: could not read the git identity from the vault");
+   if (have_identity == 0)
+      return mcp_text("error: no git identity is configured, so this commit would have no author. "
+                      "Seal AIMEE_GIT_AUTHOR_NAME and AIMEE_GIT_AUTHOR_EMAIL into the vault at "
+                      "install time (both, or neither takes effect).");
+
    char *esc_msg = shell_escape(jmsg->valuestring);
+   char *esc_name = shell_escape(author_name);
+   char *esc_email = shell_escape(author_email);
    char commit_cmd[8192];
-   snprintf(commit_cmd, sizeof(commit_cmd), "git commit -m '%s' 2>&1", esc_msg);
+   snprintf(commit_cmd, sizeof(commit_cmd),
+            "git -c user.name='%s' -c user.email='%s' commit -m '%s' 2>&1", esc_name, esc_email,
+            esc_msg);
    free(esc_msg);
+   free(esc_name);
+   free(esc_email);
 
    int rc;
    char *out = mcp_git_run(commit_cmd, &rc);

--- a/src/modules/git/mcp_git_write.c
+++ b/src/modules/git/mcp_git_write.c
@@ -155,8 +155,8 @@ cJSON *handle_git_commit(cJSON *args)
     * whose commits carry two distinct authors, and the standing directive
     * forbids those. */
    char author_name[256] = "", author_email[256] = "";
-   int have_identity = git_identity_get(author_name, sizeof(author_name), author_email,
-                                        sizeof(author_email));
+   int have_identity =
+       git_identity_get(author_name, sizeof(author_name), author_email, sizeof(author_email));
    if (have_identity < 0)
       return mcp_text("error: could not read the git identity from the vault");
    if (have_identity == 0)

--- a/src/modules/vault/vault_env_bootstrap.c
+++ b/src/modules/vault/vault_env_bootstrap.c
@@ -52,7 +52,8 @@ static int name_span_is_credential(const char *name, size_t len, int include_del
        (len == strlen("AIMEE_WEBCHAT_USER") && memcmp(name, "AIMEE_WEBCHAT_USER", len) == 0) ||
        (len == strlen("AIMEE_WEBCHAT_USERS") && memcmp(name, "AIMEE_WEBCHAT_USERS", len) == 0) ||
        (len == strlen("AIMEE_KB_CONN") && memcmp(name, "AIMEE_KB_CONN", len) == 0) ||
-       (len == strlen("AIMEE_GIT_AUTHOR_NAME") && memcmp(name, "AIMEE_GIT_AUTHOR_NAME", len) == 0) ||
+       (len == strlen("AIMEE_GIT_AUTHOR_NAME") &&
+        memcmp(name, "AIMEE_GIT_AUTHOR_NAME", len) == 0) ||
        (len == strlen("AIMEE_GIT_AUTHOR_EMAIL") &&
         memcmp(name, "AIMEE_GIT_AUTHOR_EMAIL", len) == 0) ||
        (len == strlen("DATABASE_URL") && memcmp(name, "DATABASE_URL", len) == 0) ||

--- a/src/modules/vault/vault_env_bootstrap.c
+++ b/src/modules/vault/vault_env_bootstrap.c
@@ -52,6 +52,9 @@ static int name_span_is_credential(const char *name, size_t len, int include_del
        (len == strlen("AIMEE_WEBCHAT_USER") && memcmp(name, "AIMEE_WEBCHAT_USER", len) == 0) ||
        (len == strlen("AIMEE_WEBCHAT_USERS") && memcmp(name, "AIMEE_WEBCHAT_USERS", len) == 0) ||
        (len == strlen("AIMEE_KB_CONN") && memcmp(name, "AIMEE_KB_CONN", len) == 0) ||
+       (len == strlen("AIMEE_GIT_AUTHOR_NAME") && memcmp(name, "AIMEE_GIT_AUTHOR_NAME", len) == 0) ||
+       (len == strlen("AIMEE_GIT_AUTHOR_EMAIL") &&
+        memcmp(name, "AIMEE_GIT_AUTHOR_EMAIL", len) == 0) ||
        (len == strlen("DATABASE_URL") && memcmp(name, "DATABASE_URL", len) == 0) ||
        (len == strlen("AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE") &&
         memcmp(name, "AIMEE_MANAGED_LLM_AUTH_TOKEN_OVERRIDE", len) == 0))
@@ -84,6 +87,16 @@ int vault_env_has_credential_environment(void)
          continue;
       size_t len = (size_t)(eq - *entry);
       if (!name_span_is_credential(*entry, len, 1))
+         continue;
+      /* The commit identity is SEALED like a credential but is not one: a name
+       * and an email are published in every commit this server makes. Leave them
+       * in the environment so the Go WFE, which the entrypoint starts as a
+       * sibling AFTER this scrub, can author its commits with them. The vault
+       * copy stays the store of record for the C paths. */
+      if ((len == strlen("AIMEE_GIT_AUTHOR_NAME") &&
+           memcmp(*entry, "AIMEE_GIT_AUTHOR_NAME", len) == 0) ||
+          (len == strlen("AIMEE_GIT_AUTHOR_EMAIL") &&
+           memcmp(*entry, "AIMEE_GIT_AUTHOR_EMAIL", len) == 0))
          continue;
       return len < ENV_NAME_MAX ? 1 : -1;
    }
@@ -350,6 +363,22 @@ static void slot_for_env(const char *name, const char **agent, const char **cred
    {
       *agent = "git";
       *cred = "forge_token";
+      return;
+   }
+   /* The commit identity lives beside the forge token: same agent, same
+    * first-boot transport. aimee cannot read the machine's git config (git_ops
+    * points GIT_CONFIG_GLOBAL/SYSTEM at /dev/null), so a commit uses this or it
+    * has no author at all. */
+   if (strcmp(name, "AIMEE_GIT_AUTHOR_NAME") == 0)
+   {
+      *agent = "git";
+      *cred = "author_name";
+      return;
+   }
+   if (strcmp(name, "AIMEE_GIT_AUTHOR_EMAIL") == 0)
+   {
+      *agent = "git";
+      *cred = "author_email";
       return;
    }
    *agent = ENV_AGENT;

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -17,6 +17,7 @@
  * functionality. Registration alone runs nothing — a run only begins when intake
  * creates a work item and the autonomy driver advances it. */
 #include "aimee.h"
+#include "git_forge_vault.h"
 
 #include "wfe_live_delegate.h"
 
@@ -225,10 +226,29 @@ static void wfe_commit_worktree_changes(const char *workdir)
    free(run_cmd(cmd, &rc));
    if (rc == 0)
       return; /* nothing staged: a genuine no-op or an already-committing delegate */
+   /* Commit as the installed operator identity, never a wfe persona. The identity
+    * is sealed at installation (git/author_name + git/author_email); a deployment
+    * without it would produce a commit with no author, which git refuses, so this
+    * refuses first and says what to configure. The old aimee-wfe author also made
+    * GitHub attach a Co-authored-by trailer to the squash of every PR carrying
+    * both authors, which the standing directive forbids. */
+   char au_name[256] = "", au_email[256] = "";
+   if (git_identity_get(au_name, sizeof au_name, au_email, sizeof au_email) != 1)
+   {
+      aimee_log(LOG_WARN, "wfe-delegate",
+                "no git identity configured; refusing to commit in %s (seal "
+                "AIMEE_GIT_AUTHOR_NAME/_EMAIL at install)",
+                workdir);
+      return;
+   }
+   char *qn = shell_escape(au_name);
+   char *qe = shell_escape(au_email);
    snprintf(cmd, sizeof cmd,
-            "git -C '%s' -c user.name='aimee-wfe' -c user.email='wfe@aimee.local' commit -q "
+            "git -C '%s' -c user.name='%s' -c user.email='%s' commit -q "
             "-m 'wfe: apply implement changes' 2>&1",
-            workdir);
+            workdir, qn ? qn : "", qe ? qe : "");
+   free(qn);
+   free(qe);
    char *out = run_cmd(cmd, &rc);
    if (rc != 0)
       aimee_log(LOG_WARN, "wfe-delegate", "implement commit failed in %s: %s", workdir,

--- a/src/tests/support/git_cred_inject_stub.c
+++ b/src/tests/support/git_cred_inject_stub.c
@@ -9,6 +9,7 @@
 #include "git_cred_inject.h"
 
 #include <stddef.h>
+#include <stdio.h>
 
 char **git_cred_inject_build_env_for_repo(const char *principal, const char *remote_url,
                                           const char *repo_dir, const char *preferred_token,
@@ -44,4 +45,21 @@ void git_cred_inject_free_env(char **envp)
 int git_cred_forge_configured(void)
 {
    return 0;
+}
+
+/* The commit identity comes from the vault via git_forge_vault.o, which these
+ * binaries do not link (it would pull the whole vault in for tests that exercise
+ * routing, not credentials). Report a configured identity so the commit path
+ * proceeds to the behaviour under test: a stub returning "not configured" would
+ * make every commit test assert the refusal instead. Binaries that test the
+ * refusal link the real object. */
+int git_identity_get(char *name_out, size_t name_len, char *email_out, size_t email_len);
+
+int git_identity_get(char *name_out, size_t name_len, char *email_out, size_t email_len)
+{
+   if (!name_out || !name_len || !email_out || !email_len)
+      return -1;
+   snprintf(name_out, name_len, "%s", "Test Operator");
+   snprintf(email_out, email_len, "%s", "operator@example.test");
+   return 1;
 }


### PR DESCRIPTION
## aimee had no commit identity

`git_ops.c:116-117` points `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at `/dev/null`, so nothing aimee commits can inherit the machine's identity. The only identity in the tree was the `aimee-wfe <wfe@aimee.local>` persona the WFE forced onto its own commits. Every other path ran `git commit` bare and worked only where something outside aimee happened to supply an author. On the appliance it does not: `git commit` there fails with `Author identity unknown`.

The persona also cost something concrete. GitHub adds a `Co-authored-by:` trailer to the squash of any PR whose commits carry two distinct authors, so every PR mixing WFE and human commits landed one, and the standing directive forbids them. **Two are in `testing` right now blocking the v0.3.1 promote** (#2223).

## The identity lives in the vault

`AIMEE_GIT_AUTHOR_NAME` and `AIMEE_GIT_AUTHOR_EMAIL` are sealed at first boot by the same bootstrap that seals every other install-time value, under the **existing `git` agent** that already holds `forge_token`.

They are sealed but **not scrubbed** from the environment, unlike a real credential. A name and an email are published in every commit aimee makes, and the Go WFE is started by the entrypoint as a *sibling, after* the scrub, so it needs them there. The vault copy is the store of record for the C paths.

## Both paths use it, and refuse without it

- `handle_git_commit` passes `-c user.name/-c user.email` and returns a message naming what to configure when the identity is absent.
- The WFE logs the same and declines the commit.

No fallback persona anywhere. Inventing an author to keep the commit flowing is what produced the trailers.

## Verification status

**Not built and not run.** The C toolchain is unavailable in this environment: the four changed C files were `gcc -fsyntax-only` clean, and the Go side builds (`go build ./...`). CI compiles the rest.

What still has to be proved on a live install before trusting this:

1. sealing both variables at first boot puts them under `git/author_name` and `git/author_email`;
2. `aimee git commit` produces a commit authored by that identity;
3. an install with no identity gets the refusal, not a broken commit;
4. the WFE path does the same.

I will run those against a fresh install and report before this is treated as done.
