### PR TITLE
accept a six-character password

### DIFF
--- a/frontend/src/setup/CreateAccount.tsx
+++ b/frontend/src/setup/CreateAccount.tsx
@@ -9,6 +9,9 @@ function csrf(): string {
   }
 }
 
+/** Mirror of setupAccountMinPassword (runtime-web/setup_account.go). */
+const MIN_PASSWORD = 6;
+
 export default function CreateAccount({ onCreated }: { onCreated: (username: string) => void }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -26,8 +29,11 @@ export default function CreateAccount({ onCreated }: { onCreated: (username: str
       setError('Choose a username other than aimee.');
       return;
     }
-    if (password.length < 8) {
-      setError('Password must be at least 8 characters.');
+    // Keep in step with setupAccountMinPassword in runtime-web/setup_account.go:
+    // the server rejects independently, and a client limit that is stricter than
+    // the server's just refuses a password the deployment would have accepted.
+    if (password.length < MIN_PASSWORD) {
+      setError(`Password must be at least ${MIN_PASSWORD} characters.`);
       return;
     }
     if (password !== confirmation) {

--- a/runtime-web/setup_account.go
+++ b/runtime-web/setup_account.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultBootstrapUsername = "aimee"
-	setupAccountMinPassword  = 8
+	setupAccountMinPassword  = 6
 )
 
 // setupAccountSystem isolates account mutations so the onboarding transaction
@@ -284,7 +284,8 @@ func (s *server) handleSetupAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(req.Password) < setupAccountMinPassword {
-		writeJSONError(w, http.StatusBadRequest, "password must be at least 8 characters")
+		writeJSONError(w, http.StatusBadRequest,
+			fmt.Sprintf("password must be at least %d characters", setupAccountMinPassword))
 		return
 	}
 	if strings.ContainsAny(req.Password, "\x00\r\n") {

--- a/runtime-web/setup_account_test.go
+++ b/runtime-web/setup_account_test.go
@@ -314,7 +314,7 @@ func TestSetupAccountValidatesBootstrapCallerAndCredentials(t *testing.T) {
 	}{
 		{"bootstrap caller required", "someone", `{"username":"virant","password":"long enough","password_confirmation":"long enough"}`, http.StatusForbidden},
 		{"new username required", "aimee", `{"username":"aimee","password":"long enough","password_confirmation":"long enough"}`, http.StatusBadRequest},
-		{"password minimum", "aimee", `{"username":"virant","password":"short","password_confirmation":"short"}`, http.StatusBadRequest},
+		{"password below the minimum", "aimee", `{"username":"virant","password":"short","password_confirmation":"short"}`, http.StatusBadRequest},
 		{"password confirmation", "aimee", `{"username":"virant","password":"long enough","password_confirmation":"different"}`, http.StatusBadRequest},
 		{"password newline", "aimee", "{\"username\":\"virant\",\"password\":\"long enough\\nroot:hijack\",\"password_confirmation\":\"long enough\\nroot:hijack\"}", http.StatusBadRequest},
 	}
@@ -411,5 +411,43 @@ func TestReplacementMarkerIsReadableByTheServerProcess(t *testing.T) {
 	}
 	if strings.TrimSpace(string(body)) != "virant" {
 		t.Fatalf("marker content = %q; want the replacement username", string(body))
+	}
+}
+
+// The minimum itself, from both sides. "Something short is rejected" does not say
+// where the line is, so a change to setupAccountMinPassword can pass unnoticed;
+// this fails until the number is updated deliberately.
+//
+// It gets its own server because a successful creation retires the bootstrap
+// account, and every later case in a shared table then answers 409.
+func TestSetupAccountPasswordMinimumBoundary(t *testing.T) {
+	// Pin the NUMBER, not just the constant. Deriving both passwords from
+	// setupAccountMinPassword makes the test self-consistent at any value, so it
+	// would pass just as happily if the minimum drifted back to 8 and locked
+	// operators out of six-character passwords again.
+	if setupAccountMinPassword != 6 {
+		t.Fatalf("the account minimum is 6 characters; got %d", setupAccountMinPassword)
+	}
+	const short = "abcde"  // 5
+	const exact = "abcdef" // 6
+
+	s, _ := newSetupAccountTestServer(t)
+	body := `{"username":"virant","password":"` + short + `","password_confirmation":"` + short + `"}`
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/setup/account", strings.NewReader(body)), "aimee")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rr := httptest.NewRecorder()
+	s.handleSetupAccount(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("%d characters must be refused: code=%d body=%s", len(short), rr.Code, rr.Body.String())
+	}
+
+	s2, _ := newSetupAccountTestServer(t)
+	body = `{"username":"virant","password":"` + exact + `","password_confirmation":"` + exact + `"}`
+	req = withUser(httptest.NewRequest(http.MethodPost, "/api/setup/account", strings.NewReader(body)), "aimee")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rr = httptest.NewRecorder()
+	s2.handleSetupAccount(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("exactly %d characters must be accepted: code=%d body=%s", len(exact), rr.Code, rr.Body.String())
 	}
 }

--- a/runtime-web/vault_auth_handlers.go
+++ b/runtime-web/vault_auth_handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -108,7 +109,9 @@ func (s *server) handleAuthPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(req.NewPassword) < setupAccountMinPassword || strings.ContainsAny(req.NewPassword, "\x00\r\n") {
-		authError(w, http.StatusBadRequest, "new password must be at least 8 characters and contain no line breaks", "auth.new_password_invalid")
+		authError(w, http.StatusBadRequest,
+			fmt.Sprintf("new password must be at least %d characters and contain no line breaks",
+				setupAccountMinPassword), "auth.new_password_invalid")
 		return
 	}
 	if err := s.identity.UpdatePassword(currentUser(r), req.CurrentPassword, req.NewPassword); err != nil {


### PR DESCRIPTION
The wizard's account step refused anything under **8** characters. The line this deployment wants is **6**.

## What changed

| Place | Was |
| --- | --- |
| `setupAccountMinPassword` (`runtime-web/setup_account.go`) | `8` → `6` |
| its error string | hardcoded "at least 8 characters" → derived from the constant |
| password-change handler (`vault_auth_handlers.go`) | hardcoded "at least 8 characters" → derived from the constant |
| browser check (`CreateAccount.tsx`) | `password.length < 8` → `MIN_PASSWORD`, named and pointed at the server's constant |

The number was written out separately in four places, so the server could have told an operator "at least 8" while enforcing something else. The two Go strings now come from the constant. The browser keeps its own copy because it cannot read a Go constant, and a mismatch there only costs a refusal the server would have allowed, never the reverse.

## The test now pins the number, not just the behaviour

The existing table asserted `"short"` is rejected, which says nothing about where the line falls.

My first attempt derived both passwords from `setupAccountMinPassword`, which made it self-consistent at **any** value: I put `8` back and it still passed. It would not have noticed the minimum drifting back and locking operators out again.

It now asserts the constant is 6 outright, plus the behaviour from both sides: five characters refused, six accepted. Verified red-before-green — with `8` restored:

```
--- FAIL: TestSetupAccountPasswordMinimumBoundary
    setup_account_test.go:429: the account minimum is 6 characters; got 8
```

and green at 6.

It uses its own servers because a successful creation retires the bootstrap account, and every later case in the shared table then answers 409 — which is how I found that the success case cannot live in that table.

`go build`, `go vet` and the full `runtime-web` suite pass. The frontend change is not compiled here (no `node_modules`); CI covers it.