### PR TITLE
never leave an upgraded appliance with no way to sign in

### DIFF
--- a/deploy/container/runtime-web-lib.sh
+++ b/deploy/container/runtime-web-lib.sh
@@ -211,13 +211,48 @@ webchat_provision_bootstrap_account() {
     return 0
 }
 
+# 0 when at least one member of the managed login group is an account a human can
+# ACTUALLY sign in with: present in passwd, and holding a usable password hash.
+#
+# Membership alone does not mean that. Retiring the bootstrap account through the
+# wizard locks its shadow entry ("!$y...") and leaves the name in the group, so a
+# group with members can describe an account nobody can authenticate as.
+webchat_has_usable_login() {
+    _wc_members=$(getent group "$WEBCHAT_LOGIN_GROUP" 2>/dev/null | cut -d: -f4 | tr ',' ' ')
+    for _wc_u in $_wc_members; do
+        [ -n "$_wc_u" ] || continue
+        getent passwd "$_wc_u" >/dev/null 2>&1 || continue
+        _wc_h=$(getent shadow "$_wc_u" 2>/dev/null | cut -d: -f2)
+        # Empty, "!"-locked, or "*"-disabled are all unusable for PAM auth.
+        case "$_wc_h" in
+            '' | '!'* | '*'*) continue ;;
+        esac
+        _wc_members="" _wc_u="" _wc_h=""
+        return 0
+    done
+    _wc_members="" _wc_u="" _wc_h=""
+    return 1
+}
+
 # 1 when this appliance still has no way for a human to sign in.
 #
-# An explicit pair wins and needs nothing generated. Otherwise: a marker from an
-# earlier boot, a completed wizard replacement, or any live member of the managed
-# group all mean a login already exists — regenerating then would change the
-# password out from under the operator on every restart and spam the log with
-# credentials that are not the working one.
+# An explicit pair wins and needs nothing generated. Otherwise the question is
+# answered by what EXISTS, not by what a marker remembers.
+#
+# The markers used to answer it, and that locked operators out of upgraded
+# appliances. PAM identities live in the container's writable layer -- /etc/passwd
+# and /etc/shadow are on no volume -- while the markers live in $AIMEE_HOME, which
+# is. So `docker compose up --force-recreate` onto a new image destroyed every
+# account and kept the markers that say one exists, leaving the appliance with no
+# login and no way to mint another. Reproduced on a running appliance: after an
+# ordinary image upgrade the volume still recorded webchat/bootstrap-replaced =
+# the operator's name while the container held exactly one uid>=1000 account, the
+# service account. Nothing in the Vault could restore it either; only session_hmac
+# and tls_key survive there, no account or hash.
+#
+# Regenerating still must not fire while a working login exists -- that would
+# change the password out from under the operator on every restart -- which is
+# what webchat_has_usable_login establishes.
 webchat_bootstrap_login_needed() {
     # Same source as provisioning: an operator-supplied pair that reached us via
     # the Vault transport must suppress generation just as an environment one
@@ -228,9 +263,7 @@ webchat_bootstrap_login_needed() {
         return 1
     fi
     wc_seed_user="" wc_seed_pass=""
-    [ -f "$WEBCHAT_BOOTSTRAP_USER" ] && return 1
-    [ -f "$WEBCHAT_BOOTSTRAP_REPLACED" ] && return 1
-    [ -n "$(getent group "$WEBCHAT_LOGIN_GROUP" 2>/dev/null | cut -d: -f4)" ] && return 1
+    webchat_has_usable_login && return 1
     return 0
 }
 
@@ -273,6 +306,11 @@ webchat_generate_bootstrap_login() {
         return 0
     fi
     mkdir -p "$(dirname "$WEBCHAT_BOOTSTRAP_USER")" 2>/dev/null || true
+    # Reaching here means no usable login existed, so any surviving marker is
+    # stale -- it names an account this container no longer has. Left in place,
+    # bootstrap-replaced would tell the wizard setup is already finished while the
+    # only working credential is the one being printed below.
+    rm -f "$WEBCHAT_BOOTSTRAP_REPLACED" 2>/dev/null || true
     printf 'generated:%s\n' "$_gen_user" > "$WEBCHAT_BOOTSTRAP_USER" 2>/dev/null || {
         webchat_log "ERROR: could not record the generated first-boot login"
         _gen_user="" _gen_pass=""

--- a/scripts/check-webchat-bootstrap-login.sh
+++ b/scripts/check-webchat-bootstrap-login.sh
@@ -54,9 +54,32 @@ id() {
   [[ -n ${1:-} ]] || return 0
   grep -Fxq "$1" "$existing_users"
 }
+# The account table the guard now reads. `getent group` alone was never enough to
+# answer "can a human sign in?": a wizard-retired account keeps its group
+# membership and loses only its shadow verifier, and a container recreate drops
+# the accounts while the group definition ships in the image.
+group_members="$test_dir/group-members"
+# A FRESH appliance: the group ships in the image with no members. The old stub
+# answered only for "aimee", never the login group, so this matches what the
+# generation checks below have always seen.
+printf '' > "$group_members"
+shadow_hashes="$test_dir/shadow-hashes"   # "<user> <hash>"; absent => a usable hash
+: > "$shadow_hashes"
 getent() {
-  case ${1:-}:${2:-} in
-    group:aimee) printf 'aimee:x:999:operator,legacy\n' ;;
+  case ${1:-} in
+    group)
+      [[ ${2:-} == "${WEBCHAT_LOGIN_GROUP:-aimee}" ]] || return 1
+      printf '%s:x:999:%s\n' "$2" "$(cat "$group_members")"
+      ;;
+    passwd)
+      grep -Fxq "${2:-}" "$existing_users" || return 1
+      printf '%s:x:1001:1001::/home/%s:/bin/sh\n' "$2" "$2"
+      ;;
+    shadow)
+      grep -Fxq "${2:-}" "$existing_users" || return 1
+      _h=$(awk -v u="${2:-}" '$1==u{print $2}' "$shadow_hashes")
+      printf '%s:%s:19000:0:99999:7:::\n' "$2" "${_h:-\$6\$salt\$usableverifier}"
+      ;;
     *) return 1 ;;
   esac
 }
@@ -67,12 +90,18 @@ usermod() {
     return 0
   fi
   printf '%s\n' "$*" >> "$cleared_users"
+  # -aG <group> <user>: reflect the membership so getent group agrees.
+  if [[ ${1:-} == -aG ]]; then
+    printf '%s,%s\n' "$(cat "$group_members")" "${3:-}" > "$group_members"
+  fi
 }
 useradd() {
   printf 'useradd %s\n' "$*" >> "$cleared_users"
   # the last argument is the account name
   for _u in "$@"; do :; done
   printf '%s\n' "$_u" >> "$existing_users"
+  # Provisioning adds the supplementary group separately (usermod -aG); model
+  # that here so group membership reflects what actually happened.
 }
 groupadd() { :; }
 chpasswd() { cat >/dev/null; printf 'chpasswd\n' >> "$cleared_users"; }
@@ -130,6 +159,13 @@ rm -rf "$AIMEE_HOME/webchat"
 mkdir -p "$AIMEE_HOME/webchat"
 unset AIMEE_WEBCHAT_USER AIMEE_WEBCHAT_PASSWORD
 : > "$cleared_users"
+# CLEAN install means the accounts too, not just $AIMEE_HOME. The migration
+# section above provisioned a real login and put it in the group; leaving it
+# there would (correctly) suppress generation and this section would be testing
+# nothing. The old stub hid that by never answering for the login group.
+printf '%s\n' operator legacy aimee "$USER" > "$existing_users"
+printf '' > "$group_members"
+: > "$shadow_hashes"
 
 gen_log=$(webchat_provision_bootstrap_account 2>&1)
 
@@ -166,6 +202,56 @@ marker_mode=$(stat -c %a "$WEBCHAT_BOOTSTRAP_USER")
 # lock the operator out of the account they were just handed.
 second_log=$(webchat_provision_bootstrap_account 2>&1)
 ! grep -Fq 'FIRST-BOOT DASHBOARD LOGIN' <<<"$second_log"
+
+# --- an upgrade must never leave the appliance with no way in -----------------
+#
+# THE LOCKOUT, reproduced on a live appliance: PAM identities live in the
+# container's writable layer (/etc/passwd and /etc/shadow are on no volume) while
+# the markers live in $AIMEE_HOME, which is. `up --force-recreate` onto a new
+# image therefore destroyed every account and KEPT the markers saying one exists,
+# so provisioning declined to mint a replacement and the operator could not sign
+# in. The Vault could not help: only session_hmac and tls_key survive there.
+#
+# Model exactly that: markers intact, accounts and group membership gone.
+: > "$cleared_users"
+printf '%s\n' operator legacy aimee "$USER" > "$existing_users"   # the image's own users
+printf '' > "$group_members"                                       # group ships empty
+printf 'generated:%s\n' "$gen_user" > "$WEBCHAT_BOOTSTRAP_USER"
+printf 'jbailes\n' > "$WEBCHAT_BOOTSTRAP_REPLACED"
+upgrade_log=$(webchat_provision_bootstrap_account 2>&1)
+grep -Fq 'FIRST-BOOT DASHBOARD LOGIN' <<<"$upgrade_log"
+upgrade_user=$(sed -n 's/.*username: //p' <<<"$upgrade_log" | tr -d ' ' | head -1)
+[[ $upgrade_user =~ ^aimee-[0-9a-f]{12}$ ]]
+[[ $upgrade_user != "$gen_user" ]]
+# The stale marker must go too: left behind, it tells the wizard setup is already
+# finished while the only working credential is the one just printed.
+[[ ! -e $WEBCHAT_BOOTSTRAP_REPLACED ]]
+
+# --- a retired account is not a usable login ----------------------------------
+#
+# Replacing the bootstrap login through the wizard LOCKS its shadow entry
+# ("!$y...") and leaves the name in the group. Trusting membership alone, the
+# appliance then refuses to mint a replacement for an account nobody can
+# authenticate as — observed after deleting a probe account left exactly this.
+rm -rf "$AIMEE_HOME/webchat"; mkdir -p "$AIMEE_HOME/webchat"
+: > "$cleared_users"
+printf '%s\n' operator legacy aimee "$USER" retired-acct > "$existing_users"
+printf 'retired-acct\n' > "$group_members"
+printf 'retired-acct !$y$locked\n' > "$shadow_hashes"
+locked_log=$(webchat_provision_bootstrap_account 2>&1)
+grep -Fq 'FIRST-BOOT DASHBOARD LOGIN' <<<"$locked_log"
+
+# ...but a member with a real verifier still suppresses generation, or every
+# restart would rotate the password out from under the operator.
+rm -rf "$AIMEE_HOME/webchat"; mkdir -p "$AIMEE_HOME/webchat"
+: > "$shadow_hashes"
+usable_log=$(webchat_provision_bootstrap_account 2>&1)
+! grep -Fq 'FIRST-BOOT DASHBOARD LOGIN' <<<"$usable_log"
+
+# Restore the baseline table for the checks below.
+printf '%s\n' operator legacy aimee "$USER" > "$existing_users"
+printf '' > "$group_members"
+: > "$shadow_hashes"
 
 # An EXISTING account named by an explicit pair must still join the managed
 # group. This is the live case: the image ships `aimee` as its service account,


### PR DESCRIPTION
Upgrading the image locks the operator out of the appliance, permanently. Found by
deploying a `:testing` build over a running v0.3.1 install on a real box — the operator's
account was gone and there was no supported way back in.

## Cause

PAM identities live in the container's **writable layer**: `/etc/passwd` and `/etc/shadow`
are on no volume (`docker inspect` showed 6 mounts, none of them `/etc`). The provisioning
markers live in `$AIMEE_HOME`, which **is** a volume. So `up --force-recreate` onto a new
image destroys every account and keeps the markers saying one exists —
`webchat_bootstrap_login_needed` then declines to mint a replacement.

Measured state after an ordinary upgrade:

- volume: `webchat/bootstrap-user` = `generated:aimee-9080b15eb746`, `webchat/bootstrap-replaced` = the operator's name
- container: exactly one uid≥1000 account — the service account `aimee`
- login group: no members
- Vault: only `session_hmac` and `tls_key`; no account, no hash, nothing to restore from

## Second failure, same shape

Retiring the bootstrap login through the wizard **locks** its shadow entry (`!$y…`) and
leaves the name in the group. Membership alone was enough to suppress minting, so a group
listing an unauthenticatable account also produced a lockout. Hit this directly: creating
one account and removing it left the appliance unreachable a second time.

## Fix

Answer "is there a login?" from what exists, not from what a marker remembers — a group
member that is present in `passwd` *and* holds a usable hash (not empty, `!`-locked or
`*`-disabled). A working login still suppresses generation, so a normal restart does not
rotate the password out from under the operator. When minting does happen, the stale
`bootstrap-replaced` marker is dropped too; left behind it tells the wizard setup is
finished while the only working credential is the one just printed.

## Verification

The check's `getent` stub answered only for `"aimee"`, never the login group, so group
state was invisible and neither failure could be seen. It now models the account table —
membership, `passwd` presence, shadow verifiers. Both scenarios are pinned and both fail
against the shipped library:

```
shipped v0.3.x library: LOCKED OUT: no account exists and none was minted
with this fix:          RECOVERED: minted a login the operator can use
                        ...and cleared the stale marker
```

## Follow-up, deliberately out of scope

The operator's own account still does not survive an upgrade — they get a fresh generated
credential rather than keeping theirs. Persisting the identity (Vault-sealed, restored at
boot) is the real fix. This PR guarantees only that the appliance is never unreachable,
which seemed the more urgent half.