### PR TITLE
fix clones failing rc=127 and landing under the wrong org

### DIFF
--- a/src/posix/util.c
+++ b/src/posix/util.c
@@ -64,6 +64,24 @@ int safe_exec_capture_cwd_env_fd_timeout(const char *const argv[], const char *c
       sigset_t empty;
       sigemptyset(&empty);
       sigprocmask(SIG_SETMASK, &empty, NULL);
+      /* Pin the working directory FIRST, before any dup2 below can renumber the
+       * fds it may name. Callers pass cwd as "/proc/self/fd/<n>" to pin a
+       * destination by descriptor rather than by an attacker-influencable path
+       * string (git_project_clone does exactly this). If <n> collides with
+       * target_fd -- or with STDOUT/STDERR -- the dup2 replaces that descriptor
+       * and the chdir then resolves to the WRONG object, or to a non-directory,
+       * and the child dies 127.
+       *
+       * That is not hypothetical: git_project_clone pins the clone destination
+       * this way and passes the credential memfd at GIT_CRED_TOKEN_TARGET_FD
+       * (21). Whenever the destination fd landed on 21 -- which depends on how
+       * many descriptors the server happens to hold, so it varies run to run --
+       * the clone failed with "git clone failed (rc=127)" while git itself was
+       * fine. Bulk-cloning an org hit it repeatedly and unpredictably.
+       *
+       * A failed chdir must NOT silently fall back to the parent cwd. */
+      if (cwd && cwd[0] && chdir(cwd) != 0)
+         _exit(127);
       /* redirect stdout/stderr to pipe, close stdin */
       close(pipefd[0]);
       dup2(pipefd[1], STDOUT_FILENO);
@@ -86,11 +104,6 @@ int safe_exec_capture_cwd_env_fd_timeout(const char *const argv[], const char *c
             _exit(127);
          }
       }
-      /* Pin the working directory before exec so the command runs in the caller's
-       * chosen dir (e.g. the work-item repo), not the engine's inherited cwd. A
-       * failed chdir must NOT silently fall back to the parent cwd. */
-      if (cwd && cwd[0] && chdir(cwd) != 0)
-         _exit(127);
       /* REPLACE (not augment) the child's environment when envp is given: assigning
        * environ makes execvp pass exactly envp, so ONLY envp's entries survive and
        * every inherited variable — including engine secrets (AIMEE_APPROVAL_KEY,

--- a/src/server/server_http_routes_git.c
+++ b/src/server/server_http_routes_git.c
@@ -234,11 +234,19 @@ int rh_workspace_clone_org(const route_req_t *rq, char *resp, int cap)
       return err_json(resp, cap, 400, "too many repos (max 100 per request)");
    }
 
-   /* The org: the request's `owner` field — the wizard already knows which
-    * org it is bulk-cloning (this was previously parsed and dropped). Every
-    * repo in the batch lands under it. */
+   /* The org the operator was BROWSING, used only as a fallback. It is not the
+    * owner of every repo in the batch: enumerating an account returns repos it
+    * merely has access to, so a games-on-whales repo can arrive in a batch the
+    * wizard labelled JBailes. Filing all of them under the browsed owner put 15
+    * repos in the wrong org directory on a real appliance —
+    * webusers/admin/JBailes/discowolf whose remote is games-on-whales/discowolf,
+    * a repo JBailes does not own at all. The Projects page groups by that
+    * directory, so it then reported the wrong org for those repos and the org it
+    * was browsing looked as though the clone had never happened.
+    *
+    * Each repo's real owner is in its own clone_url; derive it per repo below. */
    const cJSON *jowner = cJSON_GetObjectItemCaseSensitive(body, "owner");
-   const char *owner =
+   const char *browsed_owner =
        (cJSON_IsString(jowner) && jowner->valuestring[0]) ? jowner->valuestring : NULL;
 
    cJSON *out = cJSON_CreateObject();
@@ -258,8 +266,16 @@ int rh_workspace_clone_org(const route_req_t *rq, char *resp, int cap)
        * also name a real remote, so one crafted clone_url cannot smuggle a
        * local path in through the bulk route. */
       int remote_ok = util_url_is_remote(url);
+      /* This repo's own owner, from its own URL. Falls back to the browsed owner
+       * only when the URL yields no single-segment owner (a GitLab subgroup),
+       * which is the case git_project_clone flattens by design. */
+      char repo_org[GIT_PROJECT_NAME_MAX];
+      int multi = 0;
+      const char *org = browsed_owner;
+      if (remote_ok && git_project_derive_org(url, repo_org, sizeof(repo_org), &multi) == 0)
+         org = repo_org;
       /* token=NULL → the host's stored credential (or server identity) is used. */
-      int rc = remote_ok ? git_project_clone(principal, url, name, owner, NULL, dest, sizeof(dest),
+      int rc = remote_ok ? git_project_clone(principal, url, name, org, NULL, dest, sizeof(dest),
                                              pname, sizeof(pname), err, sizeof(err))
                          : -1;
       if (rc == 0)

--- a/src/tests/test_git_cred_inject.c
+++ b/src/tests/test_git_cred_inject.c
@@ -14,6 +14,7 @@
 #define STR(x)  STR2(x)
 
 #include <assert.h>
+#include <fcntl.h> /* O_DIRECTORY — the fd-collision regression below */
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -176,6 +177,53 @@ int main(void)
       free(out);
       close(tfd);
       git_cred_inject_free_env(fe);
+   }
+
+   /* A cwd pinned by descriptor must survive the credential fd landing on the
+    * SAME descriptor number.
+    *
+    * git_project_clone pins the clone destination as "/proc/self/fd/<tmpfd>" so
+    * git never resolves an attacker-influencable path string, and passes the
+    * token memfd at GIT_CRED_TOKEN_TARGET_FD. The child used to dup2 the token
+    * onto that number BEFORE chdir'ing, so whenever tmpfd happened to be 21 the
+    * dup2 replaced the directory with the memfd, chdir failed on a non-directory,
+    * and the child exited 127 -- surfacing as "git clone failed (rc=127)" while
+    * git was never even reached. Which fd number the destination gets depends on
+    * how many descriptors the server holds, so it struck unpredictably; bulk
+    * cloning an org tripped it repeatedly.
+    *
+    * Force the collision rather than hoping for it: put the directory ON the
+    * target number. */
+   {
+      char tmpl[] = "/tmp/aimee_fdclash_XXXXXX";
+      assert(mkdtemp(tmpl));
+      int dirfd = open(tmpl, O_RDONLY | O_DIRECTORY);
+      assert(dirfd >= 0);
+      assert(dup2(dirfd, GIT_CRED_TOKEN_TARGET_FD) == GIT_CRED_TOKEN_TARGET_FD);
+      close(dirfd);
+
+      int tfd = -1;
+      char **fe = git_cred_inject_build_env_for_repo(alice, "https://github.com/o/r", NULL,
+                                                     "CLASH-SECRET", parent, &tfd);
+      assert(fe && tfd >= 0);
+      char cwd[64];
+      snprintf(cwd, sizeof(cwd), "/proc/self/fd/%d", GIT_CRED_TOKEN_TARGET_FD);
+
+      /* pwd -P: the child must land in the directory the fd named, and the token
+       * must still arrive on the target descriptor. */
+      const char *argv[] = {"/bin/sh", "-c",
+                            "pwd -P; cat /proc/self/fd/" STR(GIT_CRED_TOKEN_TARGET_FD), NULL};
+      char *out = NULL;
+      int rc = safe_exec_capture_cwd_env_fd_timeout(argv, cwd, fe, &out, 1 << 16, 10000, tfd,
+                                                    GIT_CRED_TOKEN_TARGET_FD);
+      assert(rc == 0 && out); /* was 127: chdir ran after the dup2 had clobbered it */
+      assert(strstr(out, tmpl) != NULL);
+      assert(strstr(out, "CLASH-SECRET") != NULL);
+      free(out);
+      close(tfd);
+      git_cred_inject_free_env(fe);
+      close(GIT_CRED_TOKEN_TARGET_FD);
+      rmdir(tmpl);
    }
 
    /* SSH integration (WP-C2): a vaulted SSH key adds SSH_AUTH_SOCK to the env


### PR DESCRIPTION
Reported from the appliance UI: bulk-cloning an org fails some repos with `git clone
failed (rc=127)`, and retrying then reports repos as already cloned — the view does not
match what is actually on disk. Two separate defects, both reproduced on the live box.

## 1. `rc=127` never reached git

`safe_exec_capture_cwd_env_fd_timeout`'s child did `dup2(inherit_fd, target_fd)` **before**
`chdir(cwd)`. `git_project_clone` pins the clone destination as `/proc/self/fd/<tmpfd>` so
git never resolves an attacker-influencable path string, and passes the credential memfd at
`GIT_CRED_TOKEN_TARGET_FD` — **21**. When `tmpfd` landed on 21, the dup2 replaced the
directory with the memfd, `chdir` failed on a non-directory, and the child `_exit(127)`.

Which number the destination gets depends on how many descriptors the server happens to
hold, so it struck unpredictably — which is why a batch clone failed a scattered subset and
a retry failed a different one. Verified in the container that git itself is fine (`rc=0`
for both a public and a private clone), then demonstrated the ordering directly:

```
dup2 then chdir (shipped order) : rc=127
chdir then dup2 (this fix)      : rc=0
```

Fix: pin the cwd first, before any dup2 can renumber the fds it names. That also covers a
destination fd landing on STDOUT/STDERR.

## 2. Repos filed under the browsed owner, not their own

`rh_workspace_clone_org` applied the request's single `owner` to every repo in the batch.
Enumerating an account returns repos it merely has access to, so games-on-whales repos
arrive in a batch the wizard labelled `JBailes`. On the appliance that left **15** repos in
the wrong org directory — `webusers/admin/JBailes/discowolf` whose remote is
`games-on-whales/discowolf`, a repo `JBailes` does not own at all (confirmed against the
GitHub listing: 0 matches under JBailes, 1 under games-on-whales).

The Projects page groups by that directory, so it named the wrong org for those repos while
the org being browsed looked as though nothing had cloned. That is the UI/disk disagreement.

Fix: derive each repo's owner from its own `clone_url` — `git_project_clone` already does
this when given no org — keeping the browsed owner only as the fallback for a multi-segment
owner, which flattens by design.

## Test

Forces the collision rather than waiting for it: puts the destination directory **on**
`GIT_CRED_TOKEN_TARGET_FD` and asserts the child both lands in that directory and still
reads the token from the target descriptor. It fails with `rc=127` against the shipped
ordering.

## Not fixed here

The 15 already-misfiled directories on the appliance stay where they are; this only stops
new clones from landing wrong. Say the word if you want a migration that re-files them by
their `.aimee/remote` sidecar.