### PR TITLE
recover from a server-refused client certificate

### DIFF
--- a/src/aimee_tls.c
+++ b/src/aimee_tls.c
@@ -71,8 +71,21 @@ int aimee_tls_client_cert_eligible(const char *home, char *crt, size_t crt_n, ch
  * mutual TLS, when both files exist. Absent => plain client TLS (the server may
  * not require a client cert). Once either identity file is configured, unsafe
  * permissions, malformed PEM, or a key mismatch fail the connection closed. */
+/* Process-local; see aimee_tls_suppress_client_cert in aimee_tls.h. */
+static int g_suppress_client_cert = 0;
+
+void aimee_tls_suppress_client_cert(int on)
+{
+   g_suppress_client_cert = on ? 1 : 0;
+}
+
 static int aimee_tls_present_client_cert(SSL_CTX *ctx)
 {
+   /* Checked ahead of the eligibility gate on purpose: the caller is probing
+    * whether the STORED identity is what the server refuses, so a refused-but-
+    * present cert must not fail the probe closed before it can be tested. */
+   if (g_suppress_client_cert)
+      return 0;
    char crt[600], key[600];
    int eligible = aimee_tls_client_cert_eligible(aimee_home(), crt, sizeof(crt), key, sizeof(key));
    if (eligible == 0)

--- a/src/aimee_tls_schannel.c
+++ b/src/aimee_tls_schannel.c
@@ -428,8 +428,18 @@ static int pem_to_der(const unsigned char *pem, DWORD pem_len, unsigned char **d
  * 0 (no material configured), or -1 (present but failed to load). The server's
  * key is PKCS#8 (OpenSSL PEM_write_bio_PrivateKey), so NCRYPT_PKCS8_PRIVATE_KEY_BLOB
  * imports it directly. (NTFS ACLs, not POSIX mode bits, govern key secrecy here.) */
+/* Process-local; see aimee_tls_suppress_client_cert in aimee_tls.h. */
+static int g_suppress_client_cert = 0;
+
+void aimee_tls_suppress_client_cert(int on)
+{
+   g_suppress_client_cert = on ? 1 : 0;
+}
+
 static int schannel_load_client_identity(aimee_tls_t *t)
 {
+   if (g_suppress_client_cert)
+      return 0; /* diagnostic probe: answer as if no identity were configured */
    const char *home = aimee_home();
    if (!home || !*home)
       return 0;

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -493,6 +493,13 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    return t;
 }
 
+/* No-op: this backend never presents a client certificate, so there is nothing to
+ * suppress. Defined so `aimee remote set/trust` can call it unconditionally. */
+void aimee_tls_suppress_client_cert(int on)
+{
+   (void)on;
+}
+
 int aimee_tls_write_all(aimee_tls_t *t, const void *buf, size_t len)
 {
    if (!t || !t->ctx)

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -10,6 +10,7 @@
 #include "aimee_home.h"
 #include "aimee_tls.h"
 #include "cJSON.h"
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -175,6 +176,51 @@ static void remote_ca_path(char *out, size_t out_sz)
    snprintf(out, out_sz, "%s/remote-ca.pem", aimee_home());
 }
 
+/* Move a refused client identity out of the active path, into
+ * <aimee_home>/tls/refused-<UTC stamp>/, and report that directory in |dir_out|.
+ * Never deletes: the certificate is the only record of what this client was
+ * previously paired to, and an operator reconstructing a re-provisioning needs
+ * it. Everything present moves, or the function fails: leaving part of a refused
+ * identity behind would keep failing the connection closed on partial material.
+ * Portable (no OpenSSL), so Windows can clear the same wedge even where minting a
+ * replacement is unavailable. Returns 0 on success. */
+static int remote_archive_client_cert(char *dir_out, size_t dir_n)
+{
+   char tls_dir[600];
+   snprintf(tls_dir, sizeof(tls_dir), "%s/tls", aimee_home());
+   time_t now = time(NULL);
+   struct tm utc;
+#ifdef _WIN32
+   struct tm *utcp = gmtime(&now); /* MinGW has no gmtime_r; this path is single-threaded */
+   if (!utcp)
+      return -1;
+   utc = *utcp;
+#else
+   if (!gmtime_r(&now, &utc))
+      return -1;
+#endif
+   char stamp[32];
+   if (strftime(stamp, sizeof(stamp), "%Y%m%dT%H%M%SZ", &utc) == 0)
+      return -1;
+   snprintf(dir_out, dir_n, "%s/refused-%s", tls_dir, stamp);
+   if (AIMEE_MKDIR(dir_out) != 0)
+      return -1;
+   static const char *const names[] = {"client.crt", "client.key"};
+   for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++)
+   {
+      char from[1400], to[1400];
+      snprintf(from, sizeof(from), "%s/%s", tls_dir, names[i]);
+      snprintf(to, sizeof(to), "%s/%s", dir_out, names[i]);
+      /* A half-written identity (only one of the pair) is one of the states worth
+       * recovering from, so a missing file is success, not failure. Any other
+       * rename error is real: leaving part of a refused identity in the active
+       * path would keep failing the connection closed. */
+      if (rename(from, to) != 0 && errno != ENOENT)
+         return -1;
+   }
+   return 0;
+}
+
 #ifdef __linux__
 static int write_sync_file(const char *path, const char *data, size_t len, mode_t mode)
 {
@@ -327,35 +373,6 @@ done:
    return rc;
 }
 
-/* Move a refused client identity out of the active path, into
- * <aimee_home>/tls/refused-<UTC stamp>/, and report that directory in |dir_out|.
- * Never deletes: the certificate is the only record of what this client was
- * previously paired to, and an operator reconstructing a re-provisioning needs
- * it. Both files move or the function fails — a half-moved identity would leave
- * the connection path failing closed on partial material. Returns 0 on success. */
-static int remote_archive_client_cert(char *dir_out, size_t dir_n)
-{
-   char tls_dir[600];
-   snprintf(tls_dir, sizeof(tls_dir), "%s/tls", aimee_home());
-   time_t now = time(NULL);
-   struct tm utc;
-   char stamp[32];
-   if (!gmtime_r(&now, &utc) || strftime(stamp, sizeof(stamp), "%Y%m%dT%H%M%SZ", &utc) == 0)
-      return -1;
-   snprintf(dir_out, dir_n, "%s/refused-%s", tls_dir, stamp);
-   if (AIMEE_MKDIR(dir_out) != 0)
-      return -1;
-   static const char *const names[] = {"client.crt", "client.key"};
-   for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++)
-   {
-      char from[1400], to[1400];
-      snprintf(from, sizeof(from), "%s/%s", tls_dir, names[i]);
-      snprintf(to, sizeof(to), "%s/%s", dir_out, names[i]);
-      if (rename(from, to) != 0)
-         return -1;
-   }
-   return 0;
-}
 #else
 static int remote_enroll_client_cert(int quiet)
 {
@@ -363,12 +380,6 @@ static int remote_enroll_client_cert(int quiet)
    return -1;
 }
 
-static int remote_archive_client_cert(char *dir_out, size_t dir_n)
-{
-   if (dir_n)
-      dir_out[0] = '\0';
-   return -1;
-}
 #endif
 
 /* Probe GET /v1/health over the currently-active remote (verifying TLS). Returns
@@ -381,6 +392,34 @@ static int remote_health_ok(void)
    int ok = (body != NULL && st >= 200 && st < 500);
    free(body);
    return ok;
+}
+
+/* Is a client identity stored at all? Deliberately does NOT reuse the TLS
+ * backend's eligibility gate: that helper is declared in the shared header but
+ * defined only by the OpenSSL backend, so calling it here fails to link on macOS
+ * (Secure Transport) and Windows (Schannel). Duplicating the gate into each
+ * backend would fork a security-relevant check three ways, so ask the simpler
+ * portable question instead.
+ *
+ * PRESENCE, not validity, is what matters: a malformed, partial, or
+ * loose-permission identity is precisely what the probe below needs to test.
+ * Either file counts — a partial identity fails the connection closed just as a
+ * refused one does, and is equally worth recovering. */
+static int remote_client_cert_present(void)
+{
+   static const char *const names[] = {"client.crt", "client.key"};
+   for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++)
+   {
+      char p[700];
+      snprintf(p, sizeof(p), "%s/tls/%s", aimee_home(), names[i]);
+      FILE *f = fopen(p, "rb"); /* fopen, not stat: portable without extra headers */
+      if (f)
+      {
+         fclose(f);
+         return 1;
+      }
+   }
+   return 0;
 }
 
 /* Re-probe with the stored mTLS identity suppressed, to tell two failures apart
@@ -400,8 +439,7 @@ static int remote_health_ok(void)
 static int remote_probe_without_client_cert(void)
 {
 #ifdef WITH_TLS
-   char crt[700], key[700];
-   if (aimee_tls_client_cert_eligible(aimee_home(), crt, sizeof(crt), key, sizeof(key)) == 0)
+   if (!remote_client_cert_present())
       return 0;
    aimee_tls_suppress_client_cert(1);
    aimee_client_suppress_conn_errors(1);

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #ifdef __linux__
 #include <openssl/evp.h>
 #include <openssl/pem.h>
@@ -325,10 +326,47 @@ done:
    EVP_PKEY_CTX_free(kctx);
    return rc;
 }
+
+/* Move a refused client identity out of the active path, into
+ * <aimee_home>/tls/refused-<UTC stamp>/, and report that directory in |dir_out|.
+ * Never deletes: the certificate is the only record of what this client was
+ * previously paired to, and an operator reconstructing a re-provisioning needs
+ * it. Both files move or the function fails — a half-moved identity would leave
+ * the connection path failing closed on partial material. Returns 0 on success. */
+static int remote_archive_client_cert(char *dir_out, size_t dir_n)
+{
+   char tls_dir[600];
+   snprintf(tls_dir, sizeof(tls_dir), "%s/tls", aimee_home());
+   time_t now = time(NULL);
+   struct tm utc;
+   char stamp[32];
+   if (!gmtime_r(&now, &utc) || strftime(stamp, sizeof(stamp), "%Y%m%dT%H%M%SZ", &utc) == 0)
+      return -1;
+   snprintf(dir_out, dir_n, "%s/refused-%s", tls_dir, stamp);
+   if (AIMEE_MKDIR(dir_out) != 0)
+      return -1;
+   static const char *const names[] = {"client.crt", "client.key"};
+   for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++)
+   {
+      char from[1400], to[1400];
+      snprintf(from, sizeof(from), "%s/%s", tls_dir, names[i]);
+      snprintf(to, sizeof(to), "%s/%s", dir_out, names[i]);
+      if (rename(from, to) != 0)
+         return -1;
+   }
+   return 0;
+}
 #else
 static int remote_enroll_client_cert(int quiet)
 {
    (void)quiet;
+   return -1;
+}
+
+static int remote_archive_client_cert(char *dir_out, size_t dir_n)
+{
+   if (dir_n)
+      dir_out[0] = '\0';
    return -1;
 }
 #endif
@@ -343,6 +381,52 @@ static int remote_health_ok(void)
    int ok = (body != NULL && st >= 200 && st < 500);
    free(body);
    return ok;
+}
+
+/* Re-probe with the stored mTLS identity suppressed, to tell two failures apart
+ * that are otherwise identical at the client (both surface as "no HTTP status"):
+ *
+ *   a) the server is genuinely unreachable, versus
+ *   b) the server is fine but REFUSES this client's certificate — the usual cause
+ *      being a re-provisioned server whose new client-CA did not issue it.
+ *
+ * TLS 1.3 makes (b) look like (a): client auth is verified only after the
+ * client's handshake completes, so aimee_tls_connect() reports success and the
+ * following read dies on the server's alert with no status to report.
+ *
+ * Returns 1 only when the server answers WITHOUT the identity — which is
+ * positive proof of (b). Returns 0 when nothing is stored (so the failure cannot
+ * be an identity problem) or when the probe still gets no answer. */
+static int remote_probe_without_client_cert(void)
+{
+#ifdef WITH_TLS
+   char crt[700], key[700];
+   if (aimee_tls_client_cert_eligible(aimee_home(), crt, sizeof(crt), key, sizeof(key)) == 0)
+      return 0;
+   aimee_tls_suppress_client_cert(1);
+   aimee_client_suppress_conn_errors(1);
+   int ok = remote_health_ok();
+   aimee_client_suppress_conn_errors(0);
+   aimee_tls_suppress_client_cert(0); /* scoped to the probe — never left set */
+   return ok;
+#else
+   return 0;
+#endif
+}
+
+/* Recover from a refused client identity: archive it, then mint a replacement.
+ * Only called once remote_probe_without_client_cert() has PROVEN the stored cert
+ * is the blocker, so this never discards an identity that was working. Returns 1
+ * when the identity is out of the active path (|dir_out| names the archive), 0 if
+ * it could not be moved. Re-enrollment is best effort: a server that cannot sign
+ * a new cert still leaves a working bearer-only channel, which beats the wedged
+ * state the refused cert caused. */
+static int remote_recover_client_cert(char *dir_out, size_t dir_n, int json_output)
+{
+   if (remote_archive_client_cert(dir_out, dir_n) != 0)
+      return 0;
+   remote_enroll_client_cert(json_output /* quiet under --json */);
+   return 1;
 }
 
 /* A TLS peer can be reachable and verified while still rejecting the supplied
@@ -472,7 +556,8 @@ static int remote_set(const char *url, const char *token, int json_output)
     * Verification is forced strict (env var suspended) so a self-signed/private
     * server is always pinned even if AIMEE_TLS_INSECURE happens to be set. */
    int is_https = (strncmp(url, "https://", 8) == 0);
-   int pinned = 0, verified = 0;
+   int pinned = 0, verified = 0, refused_identity = 0, recovered_identity = 0;
+   char archived_dir[700] = "";
    if (is_https)
    {
       char *saved_insecure = tls_insecure_suspend();
@@ -488,6 +573,22 @@ static int remote_set(const char *url, const char *token, int json_output)
       {
          pinned = 1;
          verified = remote_health_ok(); /* re-probe against the pinned cert */
+      }
+      /* Still no answer: before blaming the network, rule out the one local cause
+       * that mimics an unreachable server — a client certificate this server
+       * refuses. Re-pairing is exactly when that happens (the server was
+       * re-provisioned), and the stored identity is ours to replace, so recover
+       * in place rather than making the operator find and delete it by hand. */
+      if (!verified)
+      {
+         refused_identity = remote_probe_without_client_cert();
+         if (refused_identity)
+         {
+            recovered_identity =
+                remote_recover_client_cert(archived_dir, sizeof(archived_dir), json_output);
+            if (recovered_identity)
+               verified = remote_health_ok();
+         }
       }
       tls_insecure_restore(saved_insecure);
    }
@@ -519,21 +620,50 @@ static int remote_set(const char *url, const char *token, int json_output)
 
    if (json_output)
       printf("{\"ok\":%s,\"url\":\"%s\",\"token\":%s,\"pinned\":%s,\"verified\":%s,"
-             "\"enrolled\":%s,\"mtls_enrolled\":%s}\n",
+             "\"enrolled\":%s,\"mtls_enrolled\":%s,\"client_cert_refused\":%s,"
+             "\"client_cert_recovered\":%s}\n",
              remote_set_failed ? "false" : "true", url, token && *token ? "true" : "false",
              pinned ? "true" : "false", verified ? "true" : "false", enrolled ? "true" : "false",
-             mtls_enrolled ? "true" : "false");
+             mtls_enrolled ? "true" : "false", refused_identity ? "true" : "false",
+             recovered_identity ? "true" : "false");
    else
    {
       printf("Remote server set to %s%s\n", url, token && *token ? " (with token)" : "");
       if (is_https && verified)
+      {
          printf(pinned ? "  TLS: verified against the pinned certificate.\n"
                        : "  TLS: verified against the system trust store.\n");
+         if (recovered_identity)
+            printf("  mTLS: this server refused the stored client certificate (it was issued by a "
+                   "different\n"
+                   "        server instance). Archived it to %s\n"
+                   "        and enrolled a replacement.\n",
+                   archived_dir);
+      }
+      else if (is_https && refused_identity && recovered_identity)
+         printf("  mTLS: this server refused the stored client certificate; archived it to\n"
+                "        %s. The server still does\n"
+                "        not answer, so something beyond the certificate is wrong.\n",
+                archived_dir);
+      else if (is_https && refused_identity)
+         printf("  mTLS: this server refused the stored client certificate, and it could not be "
+                "moved aside.\n"
+                "        Move %s/tls/client.crt and client.key out of the way, then re-run "
+                "`aimee remote set`.\n",
+                aimee_home());
+      else if (is_https && pinned)
+         printf("  TLS: pinned this server's certificate, but it did not answer over the pinned "
+                "channel.\n"
+                "       The server is reachable (its certificate was just fetched), so this is a "
+                "rejected\n"
+                "       connection rather than a network problem — check the server log for the "
+                "reason.\n");
       else if (is_https)
-         printf(
-             "  TLS: could not establish trust (server unreachable, or cert pinning is not "
-             "available on this platform).\n"
-             "       Start the server and re-run `aimee remote set`, or `aimee remote trust`.\n");
+         printf("  TLS: could not reach %s to fetch its certificate (server down, wrong "
+                "address/port,\n"
+                "       or cert pinning is not available on this platform).\n"
+                "       Start the server and re-run `aimee remote set`, or `aimee remote trust`.\n",
+                url);
    }
    return remote_set_failed ? 1 : 0;
 }
@@ -565,12 +695,51 @@ static int remote_trust(int json_output)
    }
    aimee_client_set_remote(url, token[0] ? token : NULL);
    int verified = remote_health_ok();
+   /* `remote trust` is the command an operator reaches for precisely when a server
+    * was re-provisioned — the same event that invalidates the client certificate.
+    * Re-pinning alone would leave them stuck, so apply the identical recovery. */
+   int refused_identity = 0, recovered_identity = 0;
+   char archived_dir[700] = "";
+   if (!verified)
+   {
+      refused_identity = remote_probe_without_client_cert();
+      if (refused_identity)
+      {
+         recovered_identity =
+             remote_recover_client_cert(archived_dir, sizeof(archived_dir), json_output);
+         if (recovered_identity)
+            verified = remote_health_ok();
+      }
+   }
    tls_insecure_restore(saved_insecure);
    if (json_output)
-      printf("{\"ok\":true,\"pinned\":true,\"verified\":%s}\n", verified ? "true" : "false");
+      printf("{\"ok\":true,\"pinned\":true,\"verified\":%s,\"client_cert_refused\":%s,"
+             "\"client_cert_recovered\":%s}\n",
+             verified ? "true" : "false", refused_identity ? "true" : "false",
+             recovered_identity ? "true" : "false");
+   else if (verified)
+   {
+      printf("  TLS: verified against the pinned certificate.\n");
+      if (recovered_identity)
+         printf("  mTLS: this server refused the stored client certificate (it was issued by a "
+                "different\n"
+                "        server instance). Archived it to %s\n"
+                "        and enrolled a replacement.\n",
+                archived_dir);
+   }
+   else if (refused_identity && recovered_identity)
+      printf("  mTLS: this server refused the stored client certificate; archived it to\n"
+             "        %s. The server still does\n"
+             "        not answer, so something beyond the certificate is wrong.\n",
+             archived_dir);
+   else if (refused_identity)
+      printf("  mTLS: this server refused the stored client certificate, and it could not be moved "
+             "aside.\n"
+             "        Move %s/tls/client.crt and client.key out of the way, then re-run "
+             "`aimee remote trust`.\n",
+             aimee_home());
    else
-      printf(verified ? "  TLS: verified against the pinned certificate.\n"
-                      : "  TLS: pinned, but the server still does not verify — check it.\n");
+      printf("  TLS: pinned, but the server still does not verify — check it.\n");
    return verified ? 0 : 1;
 }
 

--- a/src/headers/aimee_tls.h
+++ b/src/headers/aimee_tls.h
@@ -41,6 +41,23 @@ extern "C"
    int aimee_tls_client_cert_eligible(const char *home, char *crt, size_t crt_n, char *key,
                                       size_t key_n);
 
+   /* Suppress presenting the stored mTLS identity for subsequent handshakes in
+    * this process (off by default; process-local, never touches disk).
+    *
+    * `aimee remote set/trust` uses this to retry a failed trust probe WITHOUT the
+    * stored certificate. A client cert the server refuses — typically one minted
+    * by a PREVIOUS server instance's client-CA, after the server was
+    * re-provisioned — is otherwise indistinguishable from an unreachable host:
+    * TLS 1.3 sends client-auth failures only after the client's handshake has
+    * already completed, so the connect succeeds and the *read* fails with no
+    * status. Retrying suppressed turns that ambiguity into a definite answer.
+    *
+    * This deliberately bypasses the fail-closed permission gate, so it must stay
+    * scoped to a diagnostic probe: turn it on, probe, turn it off. Never leave it
+    * set across ordinary requests, which would silently downgrade a broken mTLS
+    * deployment to bearer-only TLS — exactly what the gate exists to prevent. */
+   void aimee_tls_suppress_client_cert(int on);
+
    /* Open a fresh TLS connection to |host|:|port| WITHOUT verifying the server,
     * and return its leaf certificate as PEM (caller free()s *pem_out) plus the
     * SHA-256 fingerprint as uppercase colon-hex in |fp_out|. For `aimee remote

--- a/src/tests/test_aimee_tls_clientcert.c
+++ b/src/tests/test_aimee_tls_clientcert.c
@@ -130,6 +130,39 @@ static void test_refuse_symlinked_key(void)
    unlink(tgt);
 }
 
+/* Suppression (used by `aimee remote set/trust` to test whether the server is
+ * refusing the stored identity) must NOT be implemented by weakening this pure
+ * gate. The flag belongs in the presentation path; if a later refactor moved it
+ * in here, every fail-closed answer above would silently become dependent on
+ * process state — so pin that the verdicts are identical with it set. */
+static void test_suppression_does_not_weaken_gate(void)
+{
+   char crt[600], key[600], p[700];
+   rm_material();
+   snprintf(p, sizeof(p), "%s/tls/client.crt", g_home);
+   write_file(p, 0600);
+   snprintf(p, sizeof(p), "%s/tls/client.key", g_home);
+   write_file(p, 0644); /* loose key — must stay refused regardless of the flag */
+
+   int before = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   aimee_tls_suppress_client_cert(1);
+   int during = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   aimee_tls_suppress_client_cert(0);
+   int after = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+
+   assert(before == -1);
+   assert(during == -1); /* still fail-closed */
+   assert(after == -1);
+
+   /* And the same for the eligible case: suppression changes nothing here. */
+   snprintf(p, sizeof(p), "%s/tls/client.key", g_home);
+   assert(chmod(p, 0600) == 0);
+   aimee_tls_suppress_client_cert(1);
+   assert(aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key)) == 1);
+   aimee_tls_suppress_client_cert(0);
+   rm_material();
+}
+
 /* Empty/NULL home -> 0 (a broken env must not crash or present anything). */
 static void test_bad_home_is_none(void)
 {
@@ -147,6 +180,7 @@ int main(void)
    test_refuse_group_readable_key();
    test_refuse_symlinked_key();
    test_partial_identity_is_refused();
+   test_suppression_does_not_weaken_gate();
    test_bad_home_is_none();
    rm_material();
    printf("aimee_tls_clientcert: all tests passed\n");


### PR DESCRIPTION
## Problem

`aimee remote set` reported:

```
  TLS: pinned server certificate (SHA-256 93:A0:A9:45:...)
       -> ~/.config/aimee/remote-ca.pem
Remote server set to https://192.168.1.210:8743 (with token)
  TLS: could not establish trust (server unreachable, or cert pinning is not available on this platform).
```

Both guesses in that message were wrong. The server was up, and the pin had just succeeded — the stored cert matched the live cert byte-for-byte. The actual blocker was a stored mTLS client certificate at `~/.config/aimee/tls/client.crt`, issued by a **previous** server instance's client-CA. The server had been re-provisioned; the new client-CA didn't recognise it.

## Why it looked like unreachability

TLS 1.3 verifies client auth only *after* the client's handshake completes. So `aimee_tls_connect()` returns success, the request goes out, and the *read* dies on the server's alert. That lands on the one path in `tcp_request` that returns `NULL` with `status = 0` and prints no diagnostic — identical to a dead host.

Confirmed causally against the real server, not by inspection:

| client state | result |
|---|---|
| pin + stale `client.crt`/`.key` | `-> 0` (silent) |
| pin, no client cert | `-> 401` (server answers) |

## Fix

1. `aimee_tls_suppress_client_cert()` — scoped toggle to retry a probe without the stored identity. Implemented in all three TLS backends (OpenSSL, Schannel; Secure Transport is a no-op as it never presents a client cert).
2. `remote_probe_without_client_cert()` — on a failed trust probe, retry suppressed. An answer *without* the cert is positive proof the cert is the blocker. Returns 0 when nothing is stored, so it never fires on a genuine network failure.
3. `remote_recover_client_cert()` — archive the refused identity to `<home>/tls/refused-<UTC stamp>/` and enroll a replacement. Archives rather than deletes (it's the only record of the prior pairing); both files move or the operation fails, since a half-moved identity would wedge the connection path on partial material.
4. Applied to `remote trust` too — that's exactly the command an operator reaches for after a re-provisioning, and it had the same blind spot.
5. Failure messages no longer collapse four distinct states into one wrong sentence. A successful pin *proves* reachability, so that case can no longer blame the network.

Suppression deliberately bypasses the fail-closed permission gate, so it must stay scoped to the probe — leaking it into ordinary requests would silently downgrade a broken mTLS deployment to bearer-only TLS. A new test pins that it does not weaken that gate.

## Verification

Verified:
- **The mechanism, end-to-end against a real re-provisioned server**, with the stale cert restored:
  ```
  stale cert, suppress=0 (before):   handshake OK, read FAILED (post-handshake alert)
  stale cert, suppress=1 (fix):      HTTP/1.1 401 Unauthorized
  ```
- `test_aimee_tls_clientcert` builds and passes, including the new gate test.
- Syntax/warning clean under `-Wall -Wextra`, both `WITH_TLS` and non-TLS.

**Not verified — please confirm in CI:** `cmake` was unavailable in my environment, so I could not do a full build or run `ctest`. I also could not link `test_aimee_tls_pin` (pulls `kb/pki.c` → vault symbols). The `aimee_tls.c` change is additive (a static flag defaulting to 0, early return only when set), so that test should be unaffected by construction — but I have not executed it.