### PR TITLE
keep the operator's own login across an image upgrade

### DIFF
--- a/deploy/container/runtime-web-lib.sh
+++ b/deploy/container/runtime-web-lib.sh
@@ -7,6 +7,10 @@ WEBCHAT_SPA="${AIMEE_WEBCHAT_SPA:-/usr/local/share/aimee-runtime-web/index.html}
 WEBCHAT_BOOTSTRAP_REPLACED="${WEBCHAT_HOME}/webchat/bootstrap-replaced"
 WEBCHAT_BOOTSTRAP_USER="${WEBCHAT_HOME}/webchat/bootstrap-user"
 WEBCHAT_BOOTSTRAP_CREDENTIALS="${WEBCHAT_HOME}/webchat/bootstrap-credentials"
+# "<user>:<shadow verifier>" per line, written by runtime-web after every account
+# mutation so the logins survive the container being replaced. Must match
+# identityRecordPath() in runtime-web/identity_persist.go.
+WEBCHAT_IDENTITIES="${WEBCHAT_HOME}/webchat/identities"
 WEBCHAT_LEGACY_TLS_KEY="${WEBCHAT_HOME}/webchat.key"
 # Dashboard logins are local PAM accounts, scoped to this group so runtime-web
 # can only see and manage the logins it provisioned — never the container's own
@@ -199,7 +203,55 @@ webchat_read_seeded_credentials() {
     [ -n "$wc_seed_user" ] && [ -n "$wc_seed_pass" ]
 }
 
+# Recreate the managed logins recorded by a previous container.
+#
+# PAM identities live in the container's writable layer, so replacing the image
+# destroys them, while $AIMEE_HOME survives -- including the operator's projects,
+# which are filed by webuser NAME. Minting a fresh generated login stops the
+# lockout but not this: a new random name leaves the whole project tree attached
+# to a user nobody signs in as. runtime-web records the managed accounts and
+# their shadow verifiers after every mutation (identity_persist.go); restore them
+# here, before anything decides a new login is needed.
+#
+# Only accounts that are actually MISSING are touched. An account that survived
+# keeps its current password: the record can be older than a password change the
+# operator made since, and restoring over it would silently roll that back.
+webchat_restore_identities() {
+    [ -f "$WEBCHAT_IDENTITIES" ] || return 0
+    _wc_restored=0
+    while IFS=: read -r _wc_u _wc_h; do
+        [ -n "$_wc_u" ] && [ -n "$_wc_h" ] || continue
+        # Mirror usableShadowHash() in identity_persist.go. A locked or disabled
+        # verifier is not a login: restoring it would recreate an account nobody
+        # can authenticate as, and its group membership would then suppress
+        # minting a real one -- the lockout, rebuilt from the record.
+        case "$_wc_h" in
+            '!'* | '*'*) continue ;;
+        esac
+        getent passwd "$_wc_u" >/dev/null 2>&1 && continue
+        if ! useradd --create-home --shell /usr/sbin/nologin "$_wc_u" >/dev/null 2>&1; then
+            webchat_log "WARNING: could not restore the login '$_wc_u'"
+            continue
+        fi
+        # -e: the field is already a hash, not a plaintext password.
+        if ! printf '%s:%s\n' "$_wc_u" "$_wc_h" | chpasswd -e >/dev/null 2>&1; then
+            webchat_log "WARNING: could not restore the verifier for '$_wc_u'"
+            userdel -r "$_wc_u" >/dev/null 2>&1 || true
+            continue
+        fi
+        usermod -aG "$WEBCHAT_LOGIN_GROUP" "$_wc_u" >/dev/null 2>&1 || true
+        _wc_restored=$((_wc_restored + 1))
+    done < "$WEBCHAT_IDENTITIES"
+    [ "$_wc_restored" -gt 0 ] && webchat_log "restored $_wc_restored dashboard login(s) after a container replacement"
+    _wc_u="" _wc_h="" _wc_restored=""
+    return 0
+}
+
 webchat_provision_bootstrap_account() {
+    # Before anything asks whether a login is needed: put back the ones this
+    # appliance already had. Without this an upgrade hands the operator a new
+    # generated account while their projects stay filed under the old name.
+    webchat_restore_identities
     if webchat_read_seeded_credentials; then
         webchat_provision_login "$wc_seed_user" "$wc_seed_pass" || true
     fi

--- a/runtime-web/identity_persist.go
+++ b/runtime-web/identity_persist.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Persist the managed login accounts so they survive the container being
+// replaced.
+//
+// PAM identities live in the container's writable layer: /etc/passwd and
+// /etc/shadow are on no volume. An image upgrade (`up --force-recreate`)
+// therefore destroys every account the operator created, while $AIMEE_HOME —
+// which holds their projects, keyed by webuser name — persists. The operator
+// came back to an appliance that had lost the account their work was filed
+// under. Minting a replacement login (the fix that stops the lockout) does not
+// help with this: a NEW generated name leaves the existing project tree attached
+// to a user nobody signs in as.
+//
+// So record the accounts, and restore them on the next boot.
+//
+// What is stored is the crypt(3) verifier, exactly what /etc/shadow already
+// holds, 0600 and root-owned, on the volume that already stores the Vault. It is
+// deliberately NOT sealed into the Vault: a host password is not one of aimee's
+// own secrets, and check-webchat-bootstrap-login.sh pins that contract. Nor is a
+// shadow verifier ever erased — the earlier design did both and broke PAM auth.
+const identityRecordName = "identities"
+
+// identityRecordPath is <home>/webchat/identities.
+func identityRecordPath(home string) string {
+	return filepath.Join(home, "webchat", identityRecordName)
+}
+
+// managedIdentity is one restorable account: the name and its shadow verifier.
+type managedIdentity struct {
+	Username string
+	Hash     string
+}
+
+// usableShadowHash reports whether a shadow field is a verifier a human can
+// authenticate against. Empty, "!"-locked and "*"-disabled are not: a retired
+// bootstrap account keeps its group membership and loses only this, so restoring
+// it would recreate an account nobody can sign in as.
+func usableShadowHash(h string) bool {
+	return h != "" && !strings.HasPrefix(h, "!") && !strings.HasPrefix(h, "*")
+}
+
+// readShadowHashes returns username -> verifier for every /etc/shadow entry.
+func readShadowHashes(shadowPath string) (map[string]string, error) {
+	f, err := os.Open(shadowPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	out := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		parts := strings.Split(sc.Text(), ":")
+		if len(parts) >= 2 && parts[0] != "" {
+			out[parts[0]] = parts[1]
+		}
+	}
+	return out, sc.Err()
+}
+
+// renderIdentityRecord formats the restorable accounts, one "user:hash" per
+// line, sorted so an unchanged set of accounts produces an unchanged file.
+func renderIdentityRecord(ids []managedIdentity) string {
+	sort.Slice(ids, func(i, j int) bool { return ids[i].Username < ids[j].Username })
+	var b strings.Builder
+	for _, id := range ids {
+		if id.Username == "" || !usableShadowHash(id.Hash) {
+			continue
+		}
+		// A colon or newline in either field would forge a second record.
+		// Neither can occur in a real passwd/shadow field; skip rather than
+		// write something the restore would misparse.
+		if strings.ContainsAny(id.Username, ":\n") || strings.ContainsAny(id.Hash, ":\n") {
+			continue
+		}
+		fmt.Fprintf(&b, "%s:%s\n", id.Username, id.Hash)
+	}
+	return b.String()
+}
+
+// parseIdentityRecord is the inverse, tolerating a truncated or empty file.
+func parseIdentityRecord(raw string) []managedIdentity {
+	var out []managedIdentity
+	for _, line := range strings.Split(raw, "\n") {
+		name, hash, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok || name == "" || !usableShadowHash(hash) {
+			continue
+		}
+		out = append(out, managedIdentity{Username: name, Hash: hash})
+	}
+	return out
+}
+
+// writeIdentityRecord replaces the record atomically: a half-written file would
+// silently drop accounts on the next boot, which is the failure this exists to
+// prevent.
+func writeIdentityRecord(path, contents string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(contents), 0o600); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// snapshotManagedIdentities records the current members of the managed group.
+//
+// Called after every account mutation rather than only at boot: the operator
+// creates their account through the wizard while the container runs, and an
+// upgrade can follow with no restart in between. Recording at boot alone would
+// miss exactly the account that matters most.
+//
+// Best-effort by design. Failing to record must never fail the account
+// operation the operator actually asked for; the appliance is merely back to the
+// old behaviour of not surviving an upgrade.
+func snapshotManagedIdentities(home string, members []string, shadowPath string) error {
+	hashes, err := readShadowHashes(shadowPath)
+	if err != nil {
+		return err
+	}
+	ids := make([]managedIdentity, 0, len(members))
+	for _, m := range members {
+		ids = append(ids, managedIdentity{Username: m, Hash: hashes[m]})
+	}
+	return writeIdentityRecord(identityRecordPath(home), renderIdentityRecord(ids))
+}

--- a/runtime-web/identity_persist_test.go
+++ b/runtime-web/identity_persist_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The record is what a replaced container restores from, so what it does NOT
+// contain matters as much as what it does.
+func TestRenderIdentityRecordKeepsOnlyRestorableAccounts(t *testing.T) {
+	got := renderIdentityRecord([]managedIdentity{
+		{Username: "admin", Hash: "$6$salt$verifier"},
+		// Retired through the wizard: group membership survives, the verifier is
+		// locked. Restoring it would recreate an account nobody can sign in as,
+		// whose membership then suppresses minting a real one.
+		{Username: "retired", Hash: "!$y$locked"},
+		{Username: "disabled", Hash: "*"},
+		{Username: "nohash", Hash: ""},
+		// A colon or newline would forge a second record on restore.
+		{Username: "evil:x", Hash: "$6$a$b"},
+		{Username: "eviln", Hash: "$6$a$b\nroot:$6$x$y"},
+	})
+	if got != "admin:$6$salt$verifier\n" {
+		t.Fatalf("record should hold only the restorable account; got %q", got)
+	}
+}
+
+// Sorted output: an unchanged set of accounts must produce an unchanged file, or
+// every mutation rewrites it and the diff is noise.
+func TestRenderIdentityRecordIsStable(t *testing.T) {
+	a := renderIdentityRecord([]managedIdentity{
+		{Username: "zoe", Hash: "$6$a$1"}, {Username: "abe", Hash: "$6$a$2"},
+	})
+	b := renderIdentityRecord([]managedIdentity{
+		{Username: "abe", Hash: "$6$a$2"}, {Username: "zoe", Hash: "$6$a$1"},
+	})
+	if a != b {
+		t.Fatalf("order of the input changed the record:\n%q\n%q", a, b)
+	}
+	if !strings.HasPrefix(a, "abe:") {
+		t.Fatalf("expected sorted output, got %q", a)
+	}
+}
+
+func TestParseIdentityRecordRoundTripsAndRejectsUnusable(t *testing.T) {
+	ids := parseIdentityRecord("admin:$6$salt$verifier\nretired:!$y$locked\n\nbroken\n")
+	if len(ids) != 1 || ids[0].Username != "admin" || ids[0].Hash != "$6$salt$verifier" {
+		t.Fatalf("parse kept the wrong entries: %#v", ids)
+	}
+}
+
+// The verifier is the same secret /etc/shadow holds; the file must not be
+// readable by anyone else, and a half-written one must never be visible.
+func TestWriteIdentityRecordIsPrivateAndReplacesAtomically(t *testing.T) {
+	home := t.TempDir()
+	path := identityRecordPath(home)
+	if err := writeIdentityRecord(path, "admin:$6$a$b\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := st.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("record must be 0600, got %o", perm)
+	}
+	if err := writeIdentityRecord(path, "other:$6$c$d\n"); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(body) != "other:$6$c$d\n" {
+		t.Fatalf("rewrite did not replace the record: %q", body)
+	}
+	// The temp file must not survive to be picked up as stray state.
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temp file left behind")
+	}
+}
+
+// The end-to-end shape the restore reads: group members in, "user:hash" out,
+// sourced from the shadow table rather than from anything the caller supplies.
+func TestSnapshotManagedIdentitiesRecordsGroupMembers(t *testing.T) {
+	home := t.TempDir()
+	shadow := filepath.Join(home, "shadow")
+	os.WriteFile(shadow, []byte(
+		"root:$6$r$oot:19000:0:99999:7:::\n"+
+			"admin:$6$salt$verifier:19000:0:99999:7:::\n"+
+			"retired:!$y$locked:19000:0:99999:7:::\n"), 0o600)
+
+	if err := snapshotManagedIdentities(home, []string{"admin", "retired", "ghost"}, shadow); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	body, err := os.ReadFile(identityRecordPath(home))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(body) != "admin:$6$salt$verifier\n" {
+		t.Fatalf("expected only the restorable member; got %q", body)
+	}
+	// root is not in the managed group and must never be recorded, however the
+	// shadow table is ordered.
+	if strings.Contains(string(body), "root") {
+		t.Fatalf("recorded an account outside the managed group: %q", body)
+	}
+}

--- a/runtime-web/pam_identity.go
+++ b/runtime-web/pam_identity.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"os/user"
 	"sort"
@@ -45,6 +46,27 @@ type pamAccounts struct {
 	authenticate func(service, username, password string) error
 	setPassword  func(username, password string) error
 	lock         func(username string) error
+	// Record the managed accounts after every mutation so they can be restored
+	// into a replaced container — see identity_persist.go. A seam because it
+	// reads /etc/shadow, which a unit test has no business doing.
+	persist func()
+}
+
+// aimeeHome is where the appliance's persistent state lives. The entrypoint
+// exports AIMEE_HOME; the default matches WEBCHAT_HOME in runtime-web-lib.sh.
+func aimeeHome() string {
+	if h := os.Getenv("AIMEE_HOME"); h != "" {
+		return h
+	}
+	return "/var/lib/aimee"
+}
+
+// recordIdentities snapshots the managed group. Best-effort: an account
+// operation must not fail because the record could not be written.
+func (p *pamAccounts) recordIdentities() {
+	if p.persist != nil {
+		p.persist()
+	}
 }
 
 func newPAMAccounts(service, group string) (*pamAccounts, error) {
@@ -55,13 +77,21 @@ func newPAMAccounts(service, group string) (*pamAccounts, error) {
 	if err := users.EnsureGroup(); err != nil {
 		return nil, fmt.Errorf("managed login group: %w", err)
 	}
-	return &pamAccounts{
+	p := &pamAccounts{
 		service:      service,
 		users:        users,
 		authenticate: auth.PAMAuthenticate,
 		setPassword:  auth.SetPassword,
 		lock:         lockSystemAccount,
-	}, nil
+	}
+	p.persist = func() {
+		names, err := p.List()
+		if err != nil {
+			return
+		}
+		_ = snapshotManagedIdentities(aimeeHome(), names, "/etc/shadow")
+	}
+	return p, nil
 }
 
 // Authenticate reports whether the credential is valid.
@@ -99,7 +129,11 @@ func (p *pamAccounts) UpdatePassword(username, current, replacement string) erro
 	if !ok {
 		return errInvalidWebchatCredential
 	}
-	return p.setPassword(username, replacement)
+	if err := p.setPassword(username, replacement); err != nil {
+		return err
+	}
+	p.recordIdentities()
+	return nil
 }
 
 func (p *pamAccounts) List() ([]string, error) {
@@ -160,11 +194,19 @@ func (p *pamAccounts) Create(username, password string) error {
 	if userLookup(username) != nil && groupLookup(username) == nil {
 		return errUsernameIsGroup(username)
 	}
-	return p.users.Create(username, password)
+	if err := p.users.Create(username, password); err != nil {
+		return err
+	}
+	p.recordIdentities()
+	return nil
 }
 
 func (p *pamAccounts) Delete(username string) error {
-	return p.users.Delete(username)
+	if err := p.users.Delete(username); err != nil {
+		return err
+	}
+	p.recordIdentities()
+	return nil
 }
 
 // Lock disables the bootstrap login once the operator has replaced it. The Vault
@@ -175,7 +217,14 @@ func (p *pamAccounts) Lock(username string) error {
 	if !p.managed(username) {
 		return nil
 	}
-	return p.lock(username)
+	if err := p.lock(username); err != nil {
+		return err
+	}
+	// Re-record so the retired bootstrap account drops out: its verifier is now
+	// locked, and restoring it into a fresh container would recreate a login
+	// nobody can authenticate as.
+	p.recordIdentities()
+	return nil
 }
 
 func lockSystemAccount(username string) error {

--- a/scripts/check-webchat-bootstrap-login.sh
+++ b/scripts/check-webchat-bootstrap-login.sh
@@ -104,7 +104,15 @@ useradd() {
   # that here so group membership reflects what actually happened.
 }
 groupadd() { :; }
-chpasswd() { cat >/dev/null; printf 'chpasswd\n' >> "$cleared_users"; }
+chpasswd() {
+  # -e means the payload is a hash, not a plaintext password (the restore path).
+  if [[ ${1:-} == -e ]]; then
+    printf 'chpasswd -e %s\n' "$(cat)" >> "$cleared_users"
+  else
+    cat >/dev/null; printf 'chpasswd\n' >> "$cleared_users"
+  fi
+}
+userdel() { :; }
 
 # shellcheck source=../deploy/container/runtime-web-lib.sh
 source "$repo_dir/deploy/container/runtime-web-lib.sh"
@@ -226,6 +234,51 @@ upgrade_user=$(sed -n 's/.*username: //p' <<<"$upgrade_log" | tr -d ' ' | head -
 # The stale marker must go too: left behind, it tells the wizard setup is already
 # finished while the only working credential is the one just printed.
 [[ ! -e $WEBCHAT_BOOTSTRAP_REPLACED ]]
+
+# --- an upgrade must give the operator back THEIR account ---------------------
+#
+# Not being locked out is only half of it. The operator's projects are filed by
+# webuser NAME under /var/lib/aimee-workspaces/webusers/<name>, so handing them a
+# fresh generated login after an upgrade leaves the whole tree attached to a user
+# nobody signs in as — the same disconnect, by a different route. runtime-web
+# records the managed accounts and their verifiers; restore them instead.
+rm -rf "$AIMEE_HOME/webchat"; mkdir -p "$AIMEE_HOME/webchat"
+: > "$cleared_users"
+printf '%s\n' operator legacy aimee "$USER" > "$existing_users"   # the image's own users
+printf '' > "$group_members"                                       # group ships empty
+printf 'admin:$6$salt$operatorverifier\n' > "$AIMEE_HOME/webchat/identities"
+printf 'generated:aimee-000000000000\n' > "$WEBCHAT_BOOTSTRAP_USER"
+printf 'admin\n' > "$WEBCHAT_BOOTSTRAP_REPLACED"
+restore_log=$(webchat_provision_bootstrap_account 2>&1)
+# The operator's own account is back, with its own verifier...
+grep -Fq 'useradd' "$cleared_users"
+grep -Fq -- "-aG $WEBCHAT_LOGIN_GROUP admin" "$cleared_users"
+grep -Fq 'chpasswd -e admin:$6$salt$operatorverifier' "$cleared_users"
+grep -Fxq admin "$existing_users"
+# ...so no replacement credential is minted, and the marker naming them stands.
+! grep -Fq 'FIRST-BOOT DASHBOARD LOGIN' <<<"$restore_log"
+[[ -f $WEBCHAT_BOOTSTRAP_REPLACED ]]
+
+# An account that SURVIVED keeps its current password: the record can be older
+# than a password change made since, and restoring over it would roll that back.
+: > "$cleared_users"
+survivor_log=$(webchat_provision_bootstrap_account 2>&1)
+! grep -q 'chpasswd' "$cleared_users"
+! grep -q 'useradd' "$cleared_users"
+! grep -Fq 'FIRST-BOOT DASHBOARD LOGIN' <<<"$survivor_log"
+
+# A record naming a LOCKED verifier is not a login: restoring it would recreate
+# an account nobody can authenticate as, and then suppress minting a real one.
+rm -rf "$AIMEE_HOME/webchat"; mkdir -p "$AIMEE_HOME/webchat"
+: > "$cleared_users"
+printf '%s\n' operator legacy aimee "$USER" > "$existing_users"
+printf '' > "$group_members"
+printf 'retired:!$y$locked\n' > "$AIMEE_HOME/webchat/identities"
+locked_record_log=$(webchat_provision_bootstrap_account 2>&1)
+! grep -Fxq retired "$existing_users"
+grep -Fq 'FIRST-BOOT DASHBOARD LOGIN' <<<"$locked_record_log"
+
+rm -f "$AIMEE_HOME/webchat/identities"
 
 # --- a retired account is not a usable login ----------------------------------
 #


### PR DESCRIPTION
#2230 stopped an upgrade from locking the operator out. It did not stop an upgrade from
taking their **account**, which is the half that actually loses their work.

## Why a new generated login is not enough

PAM identities live in the container's writable layer — neither `/etc/passwd` nor
`/etc/shadow` is on a volume — so `up --force-recreate` destroys every account and the
appliance mints a fresh generated one.

But projects are filed by webuser **name**, under
`/var/lib/aimee-workspaces/webusers/<name>`, and that tree *is* on a volume. So the
operator returns as `aimee-<random>` while their repositories sit under the old name:
present on disk, invisible in the UI. Measured on the appliance — `webusers/` held `admin`,
`jbailes` and two generated bootstrap names, with all 50 cloned repos under `admin` and the
other three empty.

## Fix

runtime-web writes `<user>:<shadow verifier>` per line to `$AIMEE_HOME/webchat/identities`
— 0600, replaced atomically — after **every** account mutation: create, password change,
delete, lock. After every mutation rather than at boot, because the operator creates their
account through the wizard while the container runs and an upgrade can follow with no
restart in between; boot-only recording would miss exactly the account that matters most.

The entrypoint restores any recorded account that is **missing**, before anything decides a
login is needed.

- An account that **survived** is never touched — the record can be older than a password
  change made since, and restoring over it would silently roll that back.
- **Locked/disabled** verifiers are skipped on both sides. A retired bootstrap account
  restored into a new container is a login nobody can authenticate as, and its group
  membership would then suppress minting a real one — the lockout, rebuilt from the record.

## On storing verifiers

What is stored is the crypt(3) verifier, exactly what `/etc/shadow` already holds, 0600 and
root-owned, on the volume that already stores the Vault. It is deliberately **not** sealed
into the Vault: a host password is not one of aimee's own secrets, and
`check-webchat-bootstrap-login.sh` pins that contract. No shadow verifier is ever erased —
the earlier design did both and broke PAM auth.

## Tests

Go: what the record keeps and drops (locked, disabled, empty, and names/hashes carrying a
colon or newline that would forge a second entry), stable ordering, 0600 with atomic
replace, and that accounts outside the managed group are never recorded.

Shell: the stubs now model the restore path (`chpasswd -e`, `userdel`) and three cases —
the operator's account returns with its own verifier and no new credential is announced; a
surviving account keeps its password; a record naming a locked verifier is not restored and
a real login is minted instead. The whole check fails against the unfixed library.

That last case caught a real gap while writing it: the shell restore was not filtering
locked verifiers the way the Go side does.