### PR TITLE
offer "Deploy" on a box that has never deployed

### DIFF
--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -4,6 +4,7 @@
 #include "deploy_apply.h"
 
 #include "aimee_home.h"      /* one-shot legacy credential migration path */
+#include "cJSON.h"           /* scope `docker compose ps` to the managed services */
 #include "config.h"          /* config_t, config_load */
 #include "config_database.h" /* config_emit_deploy_env */
 #include "platform_random.h" /* 256-bit managed kb -> llm bearer */
@@ -808,6 +809,98 @@ void deploy_apply_state(int *running, int *last_exit, char *out, size_t out_cap)
    pthread_mutex_unlock(&g_lock);
 }
 
+/* Keep only the containers the MANAGED compose file defines.
+ *
+ * `docker compose -f <managed file> ps` does NOT scope to the services in that
+ * file — it scopes to COMPOSE_PROJECT_NAME. aimee-server is started from
+ * compose.server-managed.yaml under the same project "aimee", so an unfiltered
+ * `ps` reports the orchestrator alongside the services it manages. This is the
+ * same project-vs-file blind spot documented for --remove-orphans above; there it
+ * deleted the server, here it merely made a never-deployed install look deployed:
+ * the wizard counts the returned services to label its button, so a clean box
+ * offered "Re-deploy" for a knowledge base that did not exist yet.
+ *
+ * Filtering by the compose `project.config_files` label — rather than by passing
+ * service names to `ps` — is what keeps this correct: every managed service sits
+ * behind a profile (kb, identity-bootstrap, authority-bootstrap), so enumerating
+ * them with `config --services` returns nothing unless the matching profiles are
+ * active, and a profile-gated name passed to `ps` is an error rather than an
+ * empty result. The label is present on every container regardless of profile.
+ *
+ * Emits a JSON array (a shape parse_ps already accepts). On any parse failure the
+ * input is left untouched: a wrong service list is worse than an unfiltered one. */
+static void deploy_filter_managed_ps(char *ps, size_t ps_cap, const char *file)
+{
+   const char *trimmed = ps;
+   while (*trimmed == ' ' || *trimmed == '\n' || *trimmed == '\r' || *trimmed == '\t')
+      trimmed++;
+   if (!*trimmed)
+      return;
+
+   char want[600];
+   snprintf(want, sizeof(want), "com.docker.compose.project.config_files=%s", file);
+
+   cJSON *keep = cJSON_CreateArray();
+   if (!keep)
+      return;
+
+   /* compose emits either a JSON array or newline-delimited objects. */
+   int recognized = 0;
+   cJSON *arr = cJSON_Parse(trimmed);
+   if (arr && cJSON_IsArray(arr))
+   {
+      recognized = 1;
+      cJSON *it = NULL;
+      cJSON_ArrayForEach(it, arr)
+      {
+         const cJSON *l = cJSON_GetObjectItemCaseSensitive(it, "Labels");
+         if (cJSON_IsString(l) && l->valuestring && strstr(l->valuestring, want))
+            cJSON_AddItemToArray(keep, cJSON_Duplicate(it, 1));
+      }
+   }
+   else
+   {
+      char *copy = strdup(trimmed);
+      if (copy)
+      {
+         /* Recognized only once a line actually parses. Marking the shape valid
+          * up front turns unparseable output into an empty array — reporting a
+          * torn-down stack for one this code simply could not read. */
+         for (char *p = copy; p && *p;)
+         {
+            char *nl = strchr(p, '\n');
+            if (nl)
+               *nl = '\0';
+            if (*p)
+            {
+               cJSON *o = cJSON_Parse(p);
+               if (o)
+               {
+                  recognized = 1;
+                  const cJSON *l = cJSON_GetObjectItemCaseSensitive(o, "Labels");
+                  if (cJSON_IsString(l) && l->valuestring && strstr(l->valuestring, want))
+                     cJSON_AddItemToArray(keep, cJSON_Duplicate(o, 1));
+                  cJSON_Delete(o);
+               }
+            }
+            p = nl ? nl + 1 : NULL;
+         }
+         free(copy);
+      }
+   }
+   cJSON_Delete(arr);
+
+   if (recognized)
+   {
+      char *s = cJSON_PrintUnformatted(keep);
+      /* Only replace when the result fits; a truncated array would not parse. */
+      if (s && strlen(s) < ps_cap)
+         snprintf(ps, ps_cap, "%s", s);
+      free(s);
+   }
+   cJSON_Delete(keep);
+}
+
 int deploy_apply_status(char *out, size_t out_cap, int *exit_code)
 {
    char file[512];
@@ -818,5 +911,7 @@ int deploy_apply_status(char *out, size_t out_cap, int *exit_code)
    char **envp = build_deploy_envp(NULL, 0, NULL, NULL, NULL);
    int rc = run_capture(argv, envp, out, out_cap, exit_code);
    free_envp(envp);
+   if (rc == 0 && exit_code && *exit_code == 0)
+      deploy_filter_managed_ps(out, out_cap, file);
    return rc;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3797,8 +3797,10 @@ $(TESTPREFIX)/unit-test-coord-jobs: $(OBJDIR)/tests/test_coord_jobs.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # deploy_apply.c is #included by the test for its statics, and the two config
-# symbols it calls are stubbed there — so this links nothing else.
-$(TESTPREFIX)/unit-test-deploy-apply: $(OBJDIR)/tests/test_deploy_apply.o
+# symbols it calls are stubbed there — so this links nothing else but cJSON,
+# which deploy_apply.c uses to scope `docker compose ps` to the managed services.
+$(TESTPREFIX)/unit-test-deploy-apply: $(OBJDIR)/tests/test_deploy_apply.o \
+                                      $(OBJDIR)/cJSON.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL) -lpthread
 
 $(TESTPREFIX)/unit-test-plan-waves: $(OBJDIR)/tests/test_plan_waves.o \

--- a/src/tests/test_deploy_apply.c
+++ b/src/tests/test_deploy_apply.c
@@ -379,6 +379,70 @@ static void test_compose_file_default(void)
    printf("  compose file default ok\n");
 }
 
+/* --- `docker compose ps` is scoped to the managed services --- */
+
+/* `ps` scopes to COMPOSE_PROJECT_NAME, not to the -f file, so it also reports
+ * aimee-server (started by compose.server-managed.yaml under the same project).
+ * The wizard counts these entries to choose its button label, so leaving the
+ * orchestrator in the list made a never-deployed box offer "Re-deploy". Labels
+ * are abbreviated to the one key the filter reads. */
+#define PS_SERVER_ENTRY                                                                            \
+   "{\"Name\":\"aimee-aimee-server-1\",\"State\":\"running\",\"Labels\":\"com.docker.compose."      \
+   "project=aimee,com.docker.compose.project.config_files=/opt/aimee-src/compose.server-managed."   \
+   "yaml\"}"
+#define PS_KB_ENTRY                                                                                \
+   "{\"Name\":\"aimee-aimee-kb-1\",\"State\":\"running\",\"Labels\":\"com.docker.compose."          \
+   "project=aimee,com.docker.compose.project.config_files=/opt/aimee/deploy/aimee-managed.compose." \
+   "yaml\"}"
+
+static const char *k_managed = "/opt/aimee/deploy/aimee-managed.compose.yaml";
+
+static void test_ps_drops_the_orchestrator_from_the_service_list(void)
+{
+   /* NDJSON shape (newer compose). */
+   char ps[4096];
+   snprintf(ps, sizeof(ps), "%s\n%s\n", PS_KB_ENTRY, PS_SERVER_ENTRY);
+   deploy_filter_managed_ps(ps, sizeof(ps), k_managed);
+   assert(strstr(ps, "aimee-aimee-kb-1") != NULL);
+   assert(strstr(ps, "aimee-aimee-server-1") == NULL);
+
+   /* JSON array shape (older compose). */
+   snprintf(ps, sizeof(ps), "[%s,%s]", PS_SERVER_ENTRY, PS_KB_ENTRY);
+   deploy_filter_managed_ps(ps, sizeof(ps), k_managed);
+   assert(strstr(ps, "aimee-aimee-kb-1") != NULL);
+   assert(strstr(ps, "aimee-aimee-server-1") == NULL);
+   printf("  ps drops the orchestrator from the managed service list ok\n");
+}
+
+/* The regression itself: before any deploy, the only container in project
+ * "aimee" is the server running the wizard. That has to leave an EMPTY list, or
+ * the finish screen labels its button "Re-deploy" for a KB that does not exist. */
+static void test_ps_is_empty_before_the_first_deploy(void)
+{
+   char ps[4096];
+   snprintf(ps, sizeof(ps), "%s\n", PS_SERVER_ENTRY);
+   deploy_filter_managed_ps(ps, sizeof(ps), k_managed);
+   assert(strstr(ps, "aimee-aimee-server-1") == NULL);
+   /* an empty array, which parse_ps renders as zero services */
+   assert(strcmp(ps, "[]") == 0);
+   printf("  ps is empty before the first deploy ok\n");
+}
+
+/* A shape the filter cannot parse must pass through untouched — an unfiltered
+ * list is recoverable, a wrongly-emptied one silently misreports the stack. */
+static void test_ps_passes_through_unparseable_output(void)
+{
+   char ps[256];
+   snprintf(ps, sizeof(ps), "not json at all");
+   deploy_filter_managed_ps(ps, sizeof(ps), k_managed);
+   assert(strcmp(ps, "not json at all") == 0);
+
+   snprintf(ps, sizeof(ps), "   ");
+   deploy_filter_managed_ps(ps, sizeof(ps), k_managed);
+   assert(strcmp(ps, "   ") == 0);
+   printf("  unparseable ps output passes through ok\n");
+}
+
 int main(void)
 {
    printf("test_deploy_apply\n");
@@ -389,6 +453,9 @@ int main(void)
    test_managed_authority_bootstrap_is_isolated_and_secret_free();
    test_retire_targets_legacy_cpu_container();
    test_compose_file_default();
+   test_ps_drops_the_orchestrator_from_the_service_list();
+   test_ps_is_empty_before_the_first_deploy();
+   test_ps_passes_through_unparseable_output();
    printf("test_deploy_apply: all passed\n");
    return 0;
 }

--- a/src/tests/test_deploy_apply.c
+++ b/src/tests/test_deploy_apply.c
@@ -387,12 +387,13 @@ static void test_compose_file_default(void)
  * orchestrator in the list made a never-deployed box offer "Re-deploy". Labels
  * are abbreviated to the one key the filter reads. */
 #define PS_SERVER_ENTRY                                                                            \
-   "{\"Name\":\"aimee-aimee-server-1\",\"State\":\"running\",\"Labels\":\"com.docker.compose."      \
-   "project=aimee,com.docker.compose.project.config_files=/opt/aimee-src/compose.server-managed."   \
+   "{\"Name\":\"aimee-aimee-server-1\",\"State\":\"running\",\"Labels\":\"com.docker.compose."     \
+   "project=aimee,com.docker.compose.project.config_files=/opt/aimee-src/compose.server-managed."  \
    "yaml\"}"
 #define PS_KB_ENTRY                                                                                \
-   "{\"Name\":\"aimee-aimee-kb-1\",\"State\":\"running\",\"Labels\":\"com.docker.compose."          \
-   "project=aimee,com.docker.compose.project.config_files=/opt/aimee/deploy/aimee-managed.compose." \
+   "{\"Name\":\"aimee-aimee-kb-1\",\"State\":\"running\",\"Labels\":\"com.docker.compose."         \
+   "project=aimee,com.docker.compose.project.config_files=/opt/aimee/deploy/"                      \
+   "aimee-managed.compose."                                                                        \
    "yaml\"}"
 
 static const char *k_managed = "/opt/aimee/deploy/aimee-managed.compose.yaml";


### PR DESCRIPTION
The setup wizard's "Deploy the knowledge base + LLM" step labelled its button **"Re-deploy"** on a clean install, telling the operator a knowledge base already existed when nothing had ever been brought up.

## Cause

The label logic in `DeployPanel.tsx` is correct:

```js
svcs.length ? 'Re-deploy' : 'Deploy'
```

But `svcs` is never empty. It comes from `docker compose -f aimee-managed.compose.yaml ps`, and **`ps` scopes to `COMPOSE_PROJECT_NAME`, not to the `-f` file**. `aimee-server` is started by `compose.server-managed.yaml` under that same project `aimee`, so an unfiltered `ps` returns the container running the wizard — and a never-deployed box counts one service.

This is the same project-vs-file blind spot already documented in `deploy_apply.c` for `--remove-orphans`, where compose called `aimee-server` an orphan of the managed file and removed the orchestrator mid-deploy. Same cause, quieter symptom: here it deletes nothing, it just makes the finish screen misreport the stack.

## Fix

Scope the status to what the managed file actually defines, filtering on the compose `project.config_files` label.

Filtering by label rather than by passing service names to `ps` is the part that matters. Every managed service sits behind a profile (`kb`, `identity-bootstrap`, `authority-bootstrap`), so enumerating them with `config --services` returns **nothing** unless the matching profiles are active — and a profile-gated name handed to `ps` is an error, not an empty result. The label is present on every container regardless of profile. Both dead ends are recorded in the comment.

Unparseable output passes through unfiltered: an empty array claims the stack is torn down, whereas the raw list is merely unfiltered and still readable.

## Verification

Validated against a live appliance (real `ps` payload, not a fixture):

```
aimee-aimee-kb-1           keep=True
aimee-aimee-server-1       keep=False
```

Three cases added to `test_deploy_apply.c` — array and NDJSON shapes, the empty-before-first-deploy regression, and unparseable pass-through; `cJSON.o` added to its link rule. All 10 tests pass, `make server` links clean under `-Wall -Wextra -Werror`.

The pass-through test caught a real flaw during development: the NDJSON branch initially marked *garbage* as recognized and rewrote it to `[]`, reporting a torn-down stack for output it merely couldn't read. It now treats the shape as recognized only once a line has actually parsed.

## Note

Unrelated and left alone: `aimee-server-identity` and `aimee-authority-bootstrap` are one-shot services that exit 0 on success, and `serviceFailed()` matches `\bexited\b` — so they render red with "failed after startup". Pre-existing and unchanged by this PR, but likely a second wrong-information bug on the same screen.