### PR TITLE
fix a fresh deploy serving lexical-only search behind a false kb banner

### DIFF
--- a/frontend/src/setup/DeployTopology.test.tsx
+++ b/frontend/src/setup/DeployTopology.test.tsx
@@ -134,6 +134,31 @@ describe('DeployTopology embedder picker', () => {
     expect(writes.find((w) => w.key === 'embedding_model')?.value).toBe('bekko-a25m');
   });
 
+  it('a fresh install saves a concrete embedder instead of nothing', async () => {
+    // The regression this pins: the picker defaulted to '' labelled "(deployment
+    // default)", so an operator who accepted the default wrote no embedding_model.
+    // buildDesiredConfig then omitted the key, config_emit_deploy_env omitted
+    // EMBEDDER_MODEL, and the kb entrypoint logged "no embedder selected" and served
+    // the builtin lexical embedder forever — a deployment that had already downloaded
+    // the weights it never selected, reporting retrieval:"fail" behind a permanent
+    // "aimee is not fully functional" banner.
+    const { writes } = await renderPage({});
+    expect(embedderSelect().value).toBe('nomic-embed-text-v2-moe');
+    save();
+    await waitFor(() => expect(writes.some((w) => w.key === 'embedding_model')).toBe(true));
+    expect(writes.find((w) => w.key === 'embedding_model')?.value).toBe('nomic-embed-text-v2-moe');
+  });
+
+  it('still offers "no embedder", named for what it actually does', async () => {
+    // Opting out stays available — the kb degrades honestly to lexical — but it may
+    // not masquerade as a sensible default that someone else picked.
+    await renderPage({});
+    const blank = Array.from(embedderSelect().options).find((o) => o.value === '');
+    expect(blank).toBeTruthy();
+    expect(blank!.textContent || '').not.toMatch(/default/i);
+    expect(blank!.textContent || '').toMatch(/degraded|lexical/i);
+  });
+
   it('a local choice never pins embedding_dim', async () => {
     const { writes } = await renderPage({});
     fireEvent.change(embedderSelect(), { target: { value: 'bekko-a25m' } });

--- a/frontend/src/setup/DeployTopology.tsx
+++ b/frontend/src/setup/DeployTopology.tsx
@@ -110,8 +110,19 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
       if (!alive) return;
       setCfg(c);
       setHosts(h);
-      setEmbedModel(String(c.embedding_model ?? ''));
-      setEmbedModelSaved(String(c.embedding_model ?? ''));
+      // An unset embedding_model is NOT "the deployment default" — there is no
+      // default downstream. buildDesiredConfig omits the key, config_emit_deploy_env
+      // omits EMBEDDER_MODEL, and the kb entrypoint leaves the bundled model
+      // unloaded and serves the builtin lexical embedder forever. The instance then
+      // reports retrieval:"fail" and shows a permanent degraded banner, having
+      // downloaded the weights it never selected. Seed the shipped local model so
+      // the operator who accepts the default gets a working embedder.
+      //
+      // embedModelSaved keeps the RAW saved value, so embedderChangeImpact still
+      // sees from:'' on a fresh install and correctly charges nothing for this.
+      const savedModel = String(c.embedding_model ?? '');
+      setEmbedModel(savedModel || emb.find((e) => e.local)?.id || '');
+      setEmbedModelSaved(savedModel);
       setEmbedDim(c.embedding_dim == null ? '' : String(c.embedding_dim));
 
       // Seed the host from any local role that names one, else the local host.
@@ -301,7 +312,10 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
                     <>
                       <select style={input} value={embedModel}
                         onChange={(e) => { setEmbedModel(e.target.value); setConfirmText(''); }}>
-                        <option value="">(deployment default)</option>
+                        {/* Named for what it DOES. "(deployment default)" read as
+                            "someone sensible chose for me" and delivered no embedder
+                            at all — semantic search silently degraded to lexical. */}
+                        <option value="">(none — lexical only, search degraded)</option>
                         {localEmbedders.map((e) => (
                           <option key={e.id} value={e.id}>
                             {e.id} — {e.dim}-dim, {e.context} ctx{e.prefixed ? '' : ', no prefixes'}

--- a/runtime-web/ready.go
+++ b/runtime-web/ready.go
@@ -30,35 +30,58 @@ func (s *server) handleReady(w http.ResponseWriter, r *http.Request) {
 	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodGet, "/v1/ready", nil)
 	w.Header().Set("Content-Type", "application/json")
 
-	// A server we cannot reach at all IS the degraded case the banner exists to
-	// report — surface it as such rather than as an opaque error, so the UI has
-	// something true to show instead of failing closed into silence.
-	if err != nil || st != http.StatusOK {
+	// Not having ASKED is not the same as having been told "no". This used to
+	// answer every failure with kb:"fail", which renders as "the knowledge
+	// service is unreachable" — a specific claim about a specific dependency
+	// that this handler has no evidence for. On a fresh instance the common
+	// cause is v1RequestWebuser's own 401 (no webchat session established yet),
+	// so a healthy deployment accused its KB of being down for the whole of the
+	// setup wizard, and the one banner that must stay credible was the one
+	// lying.
+	//
+	// 401 means we could not ask with authority: report nothing rather than
+	// guess. healthBanner() treats "unknown" as "no banner", which is right —
+	// a user without a session is not reading search results yet.
+	if st == http.StatusUnauthorized {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ready":  false,
-			"status": "degraded",
+			"status": "unknown",
 			"dependencies": map[string]string{
-				"kb": "fail", "db1": "unknown", "retrieval": "unknown",
+				"kb": "unknown", "db1": "unknown", "retrieval": "unknown",
 			},
 		})
 		return
 	}
 
+	// A degraded aimee-server answers /v1/ready with HTTP 503 AND a complete
+	// dependency body. That is a VERDICT, not a failure to answer. Treating any
+	// non-200 as unreachable threw that body away and substituted a fabricated
+	// kb:"fail" — which is how an instance whose kb was demonstrably healthy got
+	// reported as "the knowledge service is unreachable" when the real fault was
+	// an embedder that never loaded. Trust any parseable dependency payload,
+	// whatever the status code carrying it.
 	var up struct {
 		Ready        bool              `json:"ready"`
 		Status       string            `json:"status"`
 		Dependencies map[string]string `json:"dependencies"`
 	}
-	if json.Unmarshal(data, &up) != nil {
+	if err == nil && json.Unmarshal(data, &up) == nil && len(up.Dependencies) > 0 {
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ready": false, "status": "unknown",
-			"dependencies": map[string]string{},
+			"ready":        up.Ready,
+			"status":       up.Status,
+			"dependencies": up.Dependencies,
 		})
 		return
 	}
+
+	// Nothing usable came back, so the user's results really are untrustworthy
+	// and the banner must fire. Say only what we can stand behind: retrieval is
+	// unavailable. We never reached the kb and cannot vouch for it either way.
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"ready":        up.Ready,
-		"status":       up.Status,
-		"dependencies": up.Dependencies,
+		"ready":  false,
+		"status": "degraded",
+		"dependencies": map[string]string{
+			"kb": "unknown", "db1": "unknown", "retrieval": "fail",
+		},
 	})
 }

--- a/runtime-web/ready_test.go
+++ b/runtime-web/ready_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+// The banner these states drive is the only thing telling a user that an empty
+// search result is a lie. It has to be RIGHT about which dependency is down, or
+// it trains people to ignore it. handleReady used to answer every failure with
+// kb:"fail" — a specific accusation it had no evidence for.
+
+func readyDeps(t *testing.T, s *server, r *http.Request) (map[string]string, string) {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	s.handleReady(rr, r)
+	var got struct {
+		Status       string            `json:"status"`
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode %q: %v", rr.Body.String(), err)
+	}
+	return got.Dependencies, got.Status
+}
+
+// The wizard case that made this bug visible: a freshly enrolled instance has no
+// webchat session yet, so v1RequestWebuser short-circuits to 401 before it ever
+// reaches aimee-server. That is "we could not ask", not "the kb is down".
+func TestHandleReadyNoSessionAccusesNothing(t *testing.T) {
+	s := &server{cfg: startFakeV1(t, http.NewServeMux())}
+
+	deps, status := readyDeps(t, s, httptest.NewRequest(http.MethodGet, "/api/ready", nil))
+
+	if deps["kb"] == "fail" {
+		t.Fatalf("no session reported the kb as failed: %v", deps)
+	}
+	for _, dep := range []string{"kb", "db1", "retrieval"} {
+		if deps[dep] != "unknown" {
+			t.Fatalf("dep %q = %q, want unknown: %v", dep, deps[dep], deps)
+		}
+	}
+	if status != "unknown" {
+		t.Fatalf("status = %q, want unknown", status)
+	}
+}
+
+// A server we genuinely cannot reach still has to warn — the user's results are
+// untrustworthy — but in terms we can stand behind. We never reached the kb, so
+// we cannot report on it.
+func TestHandleReadyUnreachableBlamesRetrievalNotKB(t *testing.T) {
+	cfg := startFakeV1(t, http.NewServeMux())
+	cfg.socketPath = filepath.Join(t.TempDir(), "aimee.sock") // no listener behind it
+	s := &server{cfg: cfg}
+
+	deps, status := readyDeps(t, s, withUser(httptest.NewRequest(http.MethodGet, "/api/ready", nil), "admin"))
+
+	if deps["kb"] == "fail" {
+		t.Fatalf("unreachable server blamed the kb: %v", deps)
+	}
+	if deps["retrieval"] != "fail" {
+		t.Fatalf("retrieval = %q, want fail: %v", deps["retrieval"], deps)
+	}
+	if status != "degraded" {
+		t.Fatalf("status = %q, want degraded", status)
+	}
+}
+
+// The real fault on a healthy-kb instance: retrieval down because the embedder
+// never loaded. It must survive the relay verbatim, or the banner names the
+// wrong thing and the operator restarts the wrong service.
+func TestHandleReadyRelaysUpstreamVerbatim(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, `{"ready":false,"status":"degraded",`+
+			`"dependencies":{"db1":"ok","kb":"ok","retrieval":"fail"}}`)
+	})
+	s := &server{cfg: startFakeV1(t, mux)}
+
+	deps, _ := readyDeps(t, s, withUser(httptest.NewRequest(http.MethodGet, "/api/ready", nil), "admin"))
+
+	// 503 is how aimee-server reports "degraded" — an ANSWER, not a failure to
+	// answer — so the upstream verdict must survive intact. Reporting kb:"fail"
+	// here sends the operator to restart a knowledge service that is running fine.
+	if deps["kb"] != "ok" {
+		t.Fatalf("kb = %q, want ok preserved through a 503: %v", deps["kb"], deps)
+	}
+	if deps["db1"] != "ok" {
+		t.Fatalf("db1 = %q, want ok preserved through a 503: %v", deps["db1"], deps)
+	}
+	if deps["retrieval"] != "fail" {
+		t.Fatalf("retrieval = %q, want fail: %v", deps["retrieval"], deps)
+	}
+}


### PR DESCRIPTION
A fresh `:testing` deploy came up reporting **"aimee is not fully functional — the knowledge service is unreachable"** while the knowledge service was demonstrably healthy. Two independent bugs, found while validating the deployment.

## 1. The embedder was never selected

The wizard's local embedder picker defaults to `""`, labelled **"(deployment default)"**. Nothing downstream supplies one:

- `buildDesiredConfig` omits `embedding_model` when blank
- `config_emit_deploy_env` omits `EMBEDDER_MODEL` (guarded on `cfg->embedding_model[0]`)
- the kb entrypoint logs `no embedder selected; the bundled model stays unloaded` and serves the builtin lexical embedder

Verified on the affected instance: stored config had `llm_embed_backend: local` with **no `embedding_model` key**, the container had `EMBEDDER_MODEL=`, and the 480MB of model weights had been downloaded but never selected. `/v1/ready` reported `retrieval:"fail"`, `failed_boundary:"embedder"` — so semantic search had silently degraded to lexical.

This is the same class as the placement bug the module already documents: *the choice looked real and wrote nothing.*

Fix: seed the shipped local model when config records none. `embedModelSaved` keeps the raw saved value so `embedderChangeImpact` still sees `from:''` on a fresh install and charges nothing for it. Opting out stays available, renamed for what it does.

## 2. `/api/ready` blamed the wrong dependency

`handleReady` answered every non-200 with a fabricated `kb:"fail"` → *"the knowledge service is unreachable"*.

aimee-server signals "degraded" with **HTTP 503 and a complete, accurate body** (confirmed live: `503`, `{"kb":"ok","retrieval":"fail"}`). Discarding it replaced a true *"retrieval is down, kb is fine"* with a specific accusation against a dependency the handler never reached — sending an operator to restart a service that was running fine.

Fix: trust any parseable dependency payload whatever status code carries it. A 401 (no webchat session yet — the normal state during setup) reports `unknown`, which `healthBanner` already treats as no banner. Only a genuinely unusable response falls back, and then to `retrieval:"fail"`, never naming the kb.

## Verification

Red-before-green proven for all 5 new tests: against the original `ready.go` all three fail with `kb:fail`; against the original wizard both new tests fail.

- `go test ./...` (runtime-web) green; `go vet` exit 0; `gofmt` clean
- 163/163 frontend tests green; `tsc --noEmit` exit 0

Confirmed on the live deployment after setting the missing value and re-applying the managed deploy: `/v1/ready` → **200**, `{"db1":"ok","kb":"ok","retrieval":"ok"}`, embedder loaded `dim=384`, and a paraphrase query with almost no shared keywords retrieves the right fact — real vector search, not lexical fallback.

## Not addressed here

- `aimee-kb --print-embedding-model` exits 1 with no output, so the entrypoint's config fallback (`|| true`) is silently dead — only the env-var path can work.
- The server cert carries no IP SAN; standard HTTPS clients reject it (the aimee client works only because it pins by fingerprint).
