### PR TITLE
openai ingress: relay caller tools on /v1/chat/completions

### DIFF
--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -70,6 +70,26 @@ extern "C"
                                       char **instructions_out, struct cJSON **messages_out,
                                       struct cJSON **tools_out, int *stream_out);
 
+   /* Split an OpenAI chat-completions request into the three pieces the provider
+    * drivers take separately: leading system turn -> *instructions_out (NULL if
+    * absent; caller frees), remaining turns -> *messages_out verbatim (assistant
+    * `tool_calls` and `role:"tool"` results preserved, so a client-driven tool
+    * loop converges), and `function`-type tools -> *tools_out (NULL if none —
+    * never an empty array). Returns 0 on success, -1 on invalid JSON or an empty
+    * messages array. On success the caller cJSON_Delete()s both arrays. */
+   int openai_split_chat_request(const char *body, char **instructions_out,
+                                 struct cJSON **messages_out, struct cJSON **tools_out);
+
+   /* Build a chat.completion whose assistant turn carries tool_calls[] rather
+    * than content, with finish_reason "tool_calls" — the shape an agentic client
+    * (OpenCode, Codex, the OpenAI SDK) requires before it will execute a tool.
+    * `arguments` is emitted as a JSON string, per the wire contract. Returns
+    * bytes written (excluding NUL), or -1 if it does not fit or there are no
+    * calls to report. */
+   int openai_format_chat_completion_tool_calls(const char *id, const char *model,
+                                                const parsed_response_t *parsed, long created,
+                                                char *resp, int cap);
+
    /* Build an OpenAI Responses object into resp[cap]:
     * {"id":…,"object":"response","created_at":…,"model":…,"status":"completed",
     *  "output":[{"id":…,"type":"message","status":"completed","role":"assistant",

--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -90,6 +90,22 @@ extern "C"
                                                 const parsed_response_t *parsed, long created,
                                                 char *resp, int cap);
 
+   /* Build a chat.completion.chunk carrying `delta.tool_calls[]` (each entry
+    * indexed, `arguments` a JSON string). The upstream reply is buffered before
+    * chunking, so each call's arguments are complete and ship in one delta;
+    * clients accumulate by `index` either way. finish_reason is null — pair this
+    * with openai_format_chat_chunk_finish(…, "tool_calls", …). Returns bytes
+    * written (excluding NUL), or -1 if it does not fit or there are no calls. */
+   int openai_format_chat_chunk_tool_calls(const char *id, const char *model, long created,
+                                           const parsed_response_t *parsed, char *resp, int cap);
+
+   /* Build the terminal chat.completion.chunk with an empty delta and an
+    * explicit finish_reason ("stop", "tool_calls", …). openai_format_chat_chunk's
+    * finish frame always says "stop"; a tool-call turn must not. Returns bytes
+    * written (excluding NUL), or -1 if it does not fit. */
+   int openai_format_chat_chunk_finish(const char *id, const char *model, long created,
+                                       const char *reason, char *resp, int cap);
+
    /* Build an OpenAI Responses object into resp[cap]:
     * {"id":…,"object":"response","created_at":…,"model":…,"status":"completed",
     *  "output":[{"id":…,"type":"message","status":"completed","role":"assistant",

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -821,6 +821,68 @@ static int chat_stream_handler(const char *body, server_http_sse_emit emit, void
    double temperature = openai_request_double(body, "temperature", OPENAI_CHAT_TEMPERATURE, 2.0);
    int max_tokens = openai_request_int(body, "max_tokens", OPENAI_CHAT_MAX_TOKENS, 32768);
 
+   /* Tool relay, streaming half. Agentic clients stream by default, so without
+    * this the buffered relay in run_completion would never be reached by them.
+    * Same statelessness contract as that branch. This handler already computes
+    * the whole reply before chunking it, so the calls ship in a single delta
+    * followed by a tool_calls finish frame. */
+   {
+      char *instructions = NULL;
+      cJSON *messages = NULL, *tools = NULL;
+      if (openai_split_chat_request(body, &instructions, &messages, &tools) == 0 && tools)
+      {
+         parsed_response_t parsed;
+         int trc = agent_execute_messages(ag, messages, tools, instructions, max_tokens,
+                                          temperature, &parsed);
+         free(instructions);
+         cJSON_Delete(messages);
+         cJSON_Delete(tools);
+         free(prompt);
+
+         emit_chunk(emit, ctx, id, model, created, 1, NULL, 0); /* role frame */
+         if (trc != 0)
+         {
+            emit_chunk(emit, ctx, id, model, created, 0, "completion failed", 0);
+            emit_chunk(emit, ctx, id, model, created, 0, NULL, 1);
+            agent_free_parsed_response(&parsed);
+            return 0;
+         }
+
+         if (agent_ingress_accounting_enabled())
+            agent_ingress_record_cost(ag->name, ag->model, model, parsed.stop_reason,
+                                      parsed.prompt_tokens, parsed.completion_tokens,
+                                      parsed.cache_write_tokens, parsed.cache_read_tokens,
+                                      "openai-ingress", NULL);
+
+         if (parsed.is_tool_call && parsed.call_count > 0 && gateway_prevent_subagents_enabled())
+            (void)gw_response_run_governance(&parsed, openai_governance_enabled());
+
+         if (parsed.is_tool_call && parsed.call_count > 0)
+         {
+            char frame[4096];
+            if (parsed.content && parsed.content[0])
+               emit_chunk(emit, ctx, id, model, created, 0, parsed.content, 0);
+            if (openai_format_chat_chunk_tool_calls(id, model, created, &parsed, frame,
+                                                    sizeof(frame)) > 0)
+               emit(ctx, frame);
+            if (openai_format_chat_chunk_finish(id, model, created, "tool_calls", frame,
+                                                sizeof(frame)) > 0)
+               emit(ctx, frame);
+         }
+         else
+         {
+            /* Policing may have dropped every call; fall back to a text turn. */
+            emit_chunk(emit, ctx, id, model, created, 0, parsed.content ? parsed.content : "", 0);
+            emit_chunk(emit, ctx, id, model, created, 0, NULL, 1);
+         }
+         agent_free_parsed_response(&parsed);
+         return 0;
+      }
+      free(instructions);
+      cJSON_Delete(messages);
+      cJSON_Delete(tools);
+   }
+
    agent_result_t result;
    memset(&result, 0, sizeof(result));
    /* P1 pre-injection: prepend the <aimee-context> envelope as the system

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -133,6 +133,13 @@ static int dedup_eligible(char *key, size_t key_cap, const agent_t *ag, const ch
    return 1;
 }
 
+/* Defined below, after the gateway pipeline they depend on; the chat tool-relay
+ * branch in run_completion is their first caller. */
+static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *tools,
+                                  const char *system_prompt, int max_tokens, double temperature,
+                                  parsed_response_t *out);
+static int openai_governance_enabled(void);
+
 /* Shared body for both endpoints. chat != 0 selects the chat.completion shape
  * (and chat-request parse); otherwise the legacy text_completion shape. */
 static int run_completion(int chat, const char *body, char *resp, int cap)
@@ -202,6 +209,77 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
       openai_format_error_code(resp, cap, "server_error", "no agent configured",
                                AIMEE_ERR_NO_PRIMARY);
       return 503;
+   }
+
+   /* Tool relay: when the caller supplies `tools`, this endpoint must return the
+    * model's tool_calls for the CALLER to execute — the stateless half of the
+    * OpenAI contract that every agentic client depends on. Without it a client
+    * sees a provider that cannot call tools and refuses to run at all.
+    *
+    * This does NOT make the endpoint agentic: aimee still executes nothing and
+    * holds no loop state (that remains /v1/runs). agent_execute_messages is the
+    * same passthrough the /v1/responses ingress uses, so inbound tools go
+    * through the shared tool-policing stage rather than around it.
+    *
+    * Dedup is skipped here: its key does not cover `tools`, so a cached
+    * tool-free reply must never be replayed for a tool-bearing request. */
+   if (chat)
+   {
+      char *instructions = NULL;
+      cJSON *messages = NULL, *tools = NULL;
+      if (openai_split_chat_request(body, &instructions, &messages, &tools) == 0 && tools)
+      {
+         parsed_response_t parsed;
+         int trc = agent_execute_messages(
+             ag, messages, tools, instructions ? instructions : pi_env,
+             openai_request_int(body, "max_tokens", OPENAI_CHAT_MAX_TOKENS, 32768),
+             openai_request_double(body, "temperature", OPENAI_CHAT_TEMPERATURE, 2.0), &parsed);
+         free(instructions);
+         cJSON_Delete(messages);
+         cJSON_Delete(tools);
+         free(pi_env);
+         free(prompt);
+
+         if (trc != 0)
+         {
+            agent_free_parsed_response(&parsed);
+            openai_format_error(resp, cap, "upstream_error", "completion failed");
+            return 502;
+         }
+
+         if (agent_ingress_accounting_enabled())
+            agent_ingress_record_cost(ag->name, ag->model, model, parsed.stop_reason,
+                                      parsed.prompt_tokens, parsed.completion_tokens,
+                                      parsed.cache_write_tokens, parsed.cache_read_tokens,
+                                      "openai-ingress", NULL);
+
+         /* Same response-side policing the streaming path runs, so a denied
+          * subagent-spawning call cannot reach an external caller. */
+         if (parsed.is_tool_call && parsed.call_count > 0 && gateway_prevent_subagents_enabled())
+            (void)gw_response_run_governance(&parsed, openai_governance_enabled());
+
+         long tcreated = (long)time(NULL);
+         char tid[48];
+         snprintf(tid, sizeof(tid), "chatcmpl-%ld", tcreated);
+
+         int tlen;
+         if (parsed.is_tool_call && parsed.call_count > 0)
+            tlen = openai_format_chat_completion_tool_calls(tid, model, &parsed, tcreated, resp, cap);
+         else
+            tlen = openai_format_chat_completion(tid, model, parsed.content ? parsed.content : "",
+                                                 tcreated, parsed.prompt_tokens,
+                                                 parsed.completion_tokens, resp, cap);
+         agent_free_parsed_response(&parsed);
+         if (tlen < 0)
+         {
+            openai_format_error(resp, cap, "server_error", "response did not fit the buffer");
+            return 500;
+         }
+         return 200;
+      }
+      free(instructions);
+      cJSON_Delete(messages);
+      cJSON_Delete(tools);
    }
 
    /* §4 short-window dedup: serve a re-sent identical request (same account/source

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -264,7 +264,8 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
 
          int tlen;
          if (parsed.is_tool_call && parsed.call_count > 0)
-            tlen = openai_format_chat_completion_tool_calls(tid, model, &parsed, tcreated, resp, cap);
+            tlen =
+                openai_format_chat_completion_tool_calls(tid, model, &parsed, tcreated, resp, cap);
          else
             tlen = openai_format_chat_completion(tid, model, parsed.content ? parsed.content : "",
                                                  tcreated, parsed.prompt_tokens,

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -956,6 +956,103 @@ int openai_format_chat_completion_tool_calls(const char *id, const char *model,
    return (len < 0 || len >= cap) ? -1 : len;
 }
 
+/* ── openai_format_chat_chunk_tool_calls (streaming SSE delta) ───────────── */
+
+int openai_format_chat_chunk_tool_calls(const char *id, const char *model, long created,
+                                        const parsed_response_t *parsed, char *resp, int cap)
+{
+   if (!resp || cap <= 0 || !parsed || parsed->call_count <= 0)
+      return -1;
+
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return -1;
+
+   cJSON_AddStringToObject(root, "id", id ? id : "");
+   cJSON_AddStringToObject(root, "object", "chat.completion.chunk");
+   cJSON_AddNumberToObject(root, "created", (double)created);
+   cJSON_AddStringToObject(root, "model", model ? model : "");
+
+   cJSON *choices = cJSON_AddArrayToObject(root, "choices");
+   cJSON *choice = cJSON_CreateObject();
+   if (!choices || !choice)
+   {
+      cJSON_Delete(choice);
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON_AddNumberToObject(choice, "index", 0.0);
+   cJSON_AddItemToArray(choices, choice);
+
+   /* The upstream reply is buffered before it is chunked, so each call's
+    * arguments are complete and go out in a single delta. Clients accumulate
+    * by `index`, so emitting one frame per call is as valid as fragmenting. */
+   cJSON *delta = cJSON_AddObjectToObject(choice, "delta");
+   cJSON *tcs = cJSON_AddArrayToObject(delta, "tool_calls");
+   for (int i = 0; i < parsed->call_count; i++)
+   {
+      cJSON *tc = cJSON_CreateObject();
+      cJSON_AddNumberToObject(tc, "index", (double)i);
+      cJSON_AddStringToObject(tc, "id", parsed->calls[i].id);
+      cJSON_AddStringToObject(tc, "type", "function");
+      cJSON *fn = cJSON_AddObjectToObject(tc, "function");
+      cJSON_AddStringToObject(fn, "name", parsed->calls[i].name);
+      cJSON_AddStringToObject(fn, "arguments",
+                              parsed->calls[i].arguments ? parsed->calls[i].arguments : "{}");
+      cJSON_AddItemToArray(tcs, tc);
+   }
+   cJSON_AddNullToObject(choice, "finish_reason");
+
+   char *s = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!s)
+      return -1;
+
+   int len = snprintf(resp, (size_t)cap, "%s", s);
+   free(s);
+   return (len < 0 || len >= cap) ? -1 : len;
+}
+
+/* ── openai_format_chat_chunk_finish ─────────────────────────────────────── */
+
+int openai_format_chat_chunk_finish(const char *id, const char *model, long created,
+                                    const char *reason, char *resp, int cap)
+{
+   if (!resp || cap <= 0)
+      return -1;
+
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return -1;
+
+   cJSON_AddStringToObject(root, "id", id ? id : "");
+   cJSON_AddStringToObject(root, "object", "chat.completion.chunk");
+   cJSON_AddNumberToObject(root, "created", (double)created);
+   cJSON_AddStringToObject(root, "model", model ? model : "");
+
+   cJSON *choices = cJSON_AddArrayToObject(root, "choices");
+   cJSON *choice = cJSON_CreateObject();
+   if (!choices || !choice)
+   {
+      cJSON_Delete(choice);
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON_AddNumberToObject(choice, "index", 0.0);
+   cJSON_AddItemToArray(choices, choice);
+   cJSON_AddItemToObject(choice, "delta", cJSON_CreateObject());
+   cJSON_AddStringToObject(choice, "finish_reason", reason ? reason : "stop");
+
+   char *s = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!s)
+      return -1;
+
+   int len = snprintf(resp, (size_t)cap, "%s", s);
+   free(s);
+   return (len < 0 || len >= cap) ? -1 : len;
+}
+
 /* ── openai_format_chat_chunk (streaming SSE delta) ──────────────────────── */
 
 int openai_format_chat_chunk(const char *id, const char *model, long created, int role,

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -810,6 +810,152 @@ int openai_format_chat_completion(const char *id, const char *model, const char 
    return (len < 0 || len >= cap) ? -1 : len;
 }
 
+/* ── openai_split_chat_request ───────────────────────────────────────────── */
+
+int openai_split_chat_request(const char *body, char **instructions_out, cJSON **messages_out,
+                              cJSON **tools_out)
+{
+   if (!instructions_out || !messages_out || !tools_out)
+      return -1;
+   *instructions_out = NULL;
+   *messages_out = NULL;
+   *tools_out = NULL;
+
+   cJSON *root = cJSON_Parse(body ? body : "");
+   if (!cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   const cJSON *msgs = cJSON_GetObjectItemCaseSensitive(root, "messages");
+   if (!cJSON_IsArray(msgs))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+
+   /* The provider drivers take the system prompt out of band, so lift leading
+    * system turns into `instructions` and pass the rest through untouched —
+    * assistant `tool_calls` and `role:"tool"` results included, which is what
+    * makes a client-driven tool loop converge across turns. */
+   cJSON *messages = cJSON_CreateArray();
+   char *instructions = NULL;
+   const cJSON *m;
+   cJSON_ArrayForEach(m, msgs)
+   {
+      const cJSON *role = cJSON_GetObjectItemCaseSensitive(m, "role");
+      const cJSON *content = cJSON_GetObjectItemCaseSensitive(m, "content");
+      if (cJSON_IsString(role) && strcmp(role->valuestring, "system") == 0 &&
+          cJSON_IsString(content) && !instructions)
+      {
+         instructions = strdup(content->valuestring);
+         continue;
+      }
+      cJSON_AddItemToArray(messages, cJSON_Duplicate(m, 1));
+   }
+   if (cJSON_GetArraySize(messages) == 0)
+   {
+      cJSON_Delete(messages);
+      cJSON_Delete(root);
+      free(instructions);
+      return -1;
+   }
+
+   /* Only function tools survive; anything else would reach a driver that
+    * cannot express it. An empty result stays NULL — never forward `tools: []`. */
+   const cJSON *tools = cJSON_GetObjectItemCaseSensitive(root, "tools");
+   cJSON *kept = NULL;
+   if (cJSON_IsArray(tools))
+   {
+      const cJSON *t;
+      cJSON_ArrayForEach(t, tools)
+      {
+         const cJSON *type = cJSON_GetObjectItemCaseSensitive(t, "type");
+         if (cJSON_IsString(type) && strcmp(type->valuestring, "function") != 0)
+            continue;
+         if (!kept)
+            kept = cJSON_CreateArray();
+         cJSON_AddItemToArray(kept, cJSON_Duplicate(t, 1));
+      }
+   }
+
+   cJSON_Delete(root);
+   *instructions_out = instructions;
+   *messages_out = messages;
+   *tools_out = kept;
+   return 0;
+}
+
+/* ── openai_format_chat_completion_tool_calls ────────────────────────────── */
+
+int openai_format_chat_completion_tool_calls(const char *id, const char *model,
+                                             const parsed_response_t *parsed, long created,
+                                             char *resp, int cap)
+{
+   if (!resp || cap <= 0 || !parsed || parsed->call_count <= 0)
+      return -1;
+
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return -1;
+
+   cJSON_AddStringToObject(root, "id", id ? id : "");
+   cJSON_AddStringToObject(root, "object", "chat.completion");
+   cJSON_AddNumberToObject(root, "created", (double)created);
+   cJSON_AddStringToObject(root, "model", model ? model : "");
+
+   cJSON *choices = cJSON_AddArrayToObject(root, "choices");
+   cJSON *choice = cJSON_CreateObject();
+   if (!choices || !choice)
+   {
+      cJSON_Delete(choice);
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON_AddNumberToObject(choice, "index", 0.0);
+   cJSON_AddItemToArray(choices, choice);
+
+   cJSON *msg = cJSON_AddObjectToObject(choice, "message");
+   cJSON_AddStringToObject(msg, "role", "assistant");
+   /* Any prose emitted alongside the calls is preserved; OpenAI sends null when
+    * the turn is purely tool calls, and clients branch on exactly that. */
+   if (parsed->content && parsed->content[0])
+      cJSON_AddStringToObject(msg, "content", parsed->content);
+   else
+      cJSON_AddNullToObject(msg, "content");
+
+   cJSON *tcs = cJSON_AddArrayToObject(msg, "tool_calls");
+   for (int i = 0; i < parsed->call_count; i++)
+   {
+      cJSON *tc = cJSON_CreateObject();
+      cJSON_AddStringToObject(tc, "id", parsed->calls[i].id);
+      cJSON_AddStringToObject(tc, "type", "function");
+      cJSON *fn = cJSON_AddObjectToObject(tc, "function");
+      cJSON_AddStringToObject(fn, "name", parsed->calls[i].name);
+      /* `arguments` is a JSON *string* on the wire, not an object. */
+      cJSON_AddStringToObject(fn, "arguments",
+                              parsed->calls[i].arguments ? parsed->calls[i].arguments : "{}");
+      cJSON_AddItemToArray(tcs, tc);
+   }
+
+   cJSON_AddStringToObject(choice, "finish_reason", "tool_calls");
+
+   cJSON *usage = cJSON_AddObjectToObject(root, "usage");
+   cJSON_AddNumberToObject(usage, "prompt_tokens", (double)parsed->prompt_tokens);
+   cJSON_AddNumberToObject(usage, "completion_tokens", (double)parsed->completion_tokens);
+   cJSON_AddNumberToObject(usage, "total_tokens",
+                           (double)(parsed->prompt_tokens + parsed->completion_tokens));
+
+   char *s = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!s)
+      return -1;
+
+   int len = snprintf(resp, (size_t)cap, "%s", s);
+   free(s);
+   return (len < 0 || len >= cap) ? -1 : len;
+}
+
 /* ── openai_format_chat_chunk (streaming SSE delta) ──────────────────────── */
 
 int openai_format_chat_chunk(const char *id, const char *model, long created, int role,

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -239,6 +239,17 @@ static SSL_CTX *tls_build_ctx(const char *cert_path, const char *key_path, int m
    /* Advertise HTTP/1.1 over ALPN so ALPN-strict clients (e.g. Codex) don't
     * fall back to HTTP/2 on this HTTP/1.1-only server. */
    SSL_CTX_set_alpn_select_cb(ctx, alpn_select_cb, NULL);
+   /* Session resumption REQUIRES this once client certs are in play (below).
+    * OpenSSL refuses to resume a session carrying a peer certificate unless the
+    * server's session id context matches the one the session was created under;
+    * with none set it fails SSL_R_SESSION_ID_CONTEXT_UNINITIALIZED and sends an
+    * internal_error alert instead of completing the handshake. Server-side
+    * caching and TLS 1.3 tickets are both on by default here, so leaving this
+    * unset broke exactly the resuming half of a client's connections. Set it
+    * unconditionally: mTLS can be ramped on at runtime, and a stable value is
+    * correct for a non-mTLS context too. */
+   static const unsigned char sid_ctx[] = "aimee-server";
+   SSL_CTX_set_session_id_context(ctx, sid_ctx, sizeof(sid_ctx) - 1);
    int key_ok = 0;
    if (key_path && key_path[0])
       key_ok = SSL_CTX_use_PrivateKey_file(ctx, key_path, SSL_FILETYPE_PEM) == 1;

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -556,7 +556,8 @@ int main(void)
       messages = tools = NULL;
       instructions = NULL;
       assert(openai_split_chat_request("not json", &instructions, &messages, &tools) == -1);
-      assert(openai_split_chat_request("{\"messages\":[]}", &instructions, &messages, &tools) == -1);
+      assert(openai_split_chat_request("{\"messages\":[]}", &instructions, &messages, &tools) ==
+             -1);
       assert(!instructions && !messages && !tools);
    }
 
@@ -611,9 +612,8 @@ int main(void)
       assert(openai_format_chat_completion_tool_calls("i", "aimee", &p, 1, resp,
                                                       (int)sizeof(resp)) > 0);
       cJSON *root = cJSON_Parse(resp);
-      cJSON *msg =
-          cJSON_GetObjectItem(cJSON_GetArrayItem(cJSON_GetObjectItem(root, "choices"), 0),
-                              "message");
+      cJSON *msg = cJSON_GetObjectItem(cJSON_GetArrayItem(cJSON_GetObjectItem(root, "choices"), 0),
+                                       "message");
       assert(strcmp(cJSON_GetObjectItem(msg, "content")->valuestring, "let me check") == 0);
       cJSON_Delete(root);
    }

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -1,6 +1,7 @@
 /* test_openai_shape.c: unit tests for the OpenAI-compatible JSON shaping
  * helpers (pure — no sockets, no network, no agent execution). */
 #include "openai_shape.h"
+#include "agent_protocol.h" /* parsed_response_t — openai_shape.h only forward-declares it */
 #include "aimee_errors.h"
 #include "cJSON.h"
 #include <assert.h>
@@ -498,6 +499,135 @@ int main(void)
       free(instructions);
       cJSON_Delete((cJSON *)messages);
       cJSON_Delete((cJSON *)tools);
+   }
+
+   /* --- split a chat request into instructions / messages / tools ---
+    * The tool relay on /v1/chat/completions depends on this: an agentic client
+    * sends its own tools and executes the calls itself, so the loop only
+    * converges if assistant `tool_calls` and `role:"tool"` turns survive the
+    * round trip verbatim. */
+   {
+      char *instructions = NULL;
+      struct cJSON *messages = NULL, *tools = NULL;
+      int rc = openai_split_chat_request(
+          "{\"model\":\"aimee\",\"messages\":["
+          "{\"role\":\"system\",\"content\":\"be terse\"},"
+          "{\"role\":\"user\",\"content\":\"weather in Paris?\"},"
+          "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"c1\","
+          "\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{}\"}}]},"
+          "{\"role\":\"tool\",\"tool_call_id\":\"c1\",\"content\":\"12C\"}],"
+          "\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\"}},"
+          "{\"type\":\"web_search\"}]}",
+          &instructions, &messages, &tools);
+      assert(rc == 0);
+      /* leading system turn lifted out of band */
+      assert(instructions && strcmp(instructions, "be terse") == 0);
+      assert(cJSON_GetArraySize((cJSON *)messages) == 3);
+      /* the tool loop's two special turns round-trip untouched */
+      cJSON *m1 = cJSON_GetArrayItem((cJSON *)messages, 1);
+      assert(cJSON_GetObjectItem(m1, "tool_calls"));
+      cJSON *m2 = cJSON_GetArrayItem((cJSON *)messages, 2);
+      assert(strcmp(cJSON_GetObjectItem(m2, "role")->valuestring, "tool") == 0);
+      assert(strcmp(cJSON_GetObjectItem(m2, "tool_call_id")->valuestring, "c1") == 0);
+      /* only function tools survive */
+      assert(tools && cJSON_GetArraySize((cJSON *)tools) == 1);
+      free(instructions);
+      cJSON_Delete((cJSON *)messages);
+      cJSON_Delete((cJSON *)tools);
+   }
+
+   /* Absent (or wholly unsupported) tools must yield NULL, never `tools: []` —
+    * an empty array is a different request to a provider than no array. */
+   {
+      char *instructions = NULL;
+      struct cJSON *messages = NULL, *tools = NULL;
+      assert(openai_split_chat_request("{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                                       &instructions, &messages, &tools) == 0);
+      assert(tools == NULL && instructions == NULL);
+      cJSON_Delete((cJSON *)messages);
+
+      assert(openai_split_chat_request("{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],"
+                                       "\"tools\":[{\"type\":\"web_search\"}]}",
+                                       &instructions, &messages, &tools) == 0);
+      assert(tools == NULL);
+      cJSON_Delete((cJSON *)messages);
+
+      /* malformed and empty are rejected without handing back partial output */
+      messages = tools = NULL;
+      instructions = NULL;
+      assert(openai_split_chat_request("not json", &instructions, &messages, &tools) == -1);
+      assert(openai_split_chat_request("{\"messages\":[]}", &instructions, &messages, &tools) == -1);
+      assert(!instructions && !messages && !tools);
+   }
+
+   /* --- format a tool-call turn in chat.completion shape --- */
+   {
+      parsed_response_t p;
+      memset(&p, 0, sizeof(p));
+      p.is_tool_call = 1;
+      p.call_count = 2;
+      snprintf(p.calls[0].id, sizeof(p.calls[0].id), "call_a");
+      snprintf(p.calls[0].name, sizeof(p.calls[0].name), "get_weather");
+      p.calls[0].arguments = strdup("{\"city\":\"Paris\"}");
+      snprintf(p.calls[1].id, sizeof(p.calls[1].id), "call_b");
+      snprintf(p.calls[1].name, sizeof(p.calls[1].name), "get_time");
+      p.calls[1].arguments = NULL; /* must degrade to "{}", not null */
+      p.prompt_tokens = 10;
+      p.completion_tokens = 5;
+
+      int n = openai_format_chat_completion_tool_calls("chatcmpl-1", "aimee", &p, 1700000000, resp,
+                                                       (int)sizeof(resp));
+      assert(n > 0);
+      cJSON *root = cJSON_Parse(resp);
+      assert(root);
+      cJSON *choice = cJSON_GetArrayItem(cJSON_GetObjectItem(root, "choices"), 0);
+      /* the field agentic clients branch on before they will execute a tool */
+      assert(strcmp(cJSON_GetObjectItem(choice, "finish_reason")->valuestring, "tool_calls") == 0);
+      cJSON *msg = cJSON_GetObjectItem(choice, "message");
+      assert(cJSON_IsNull(cJSON_GetObjectItem(msg, "content")));
+      cJSON *tcs = cJSON_GetObjectItem(msg, "tool_calls");
+      assert(cJSON_GetArraySize(tcs) == 2);
+      cJSON *fn0 = cJSON_GetObjectItem(cJSON_GetArrayItem(tcs, 0), "function");
+      assert(strcmp(cJSON_GetObjectItem(fn0, "name")->valuestring, "get_weather") == 0);
+      /* `arguments` is a JSON *string* on the wire, not a nested object */
+      assert(cJSON_IsString(cJSON_GetObjectItem(fn0, "arguments")));
+      assert(strcmp(cJSON_GetObjectItem(fn0, "arguments")->valuestring, "{\"city\":\"Paris\"}") ==
+             0);
+      cJSON *fn1 = cJSON_GetObjectItem(cJSON_GetArrayItem(tcs, 1), "function");
+      assert(strcmp(cJSON_GetObjectItem(fn1, "arguments")->valuestring, "{}") == 0);
+      cJSON_Delete(root);
+      free(p.calls[0].arguments);
+   }
+
+   /* Prose emitted alongside the calls is preserved rather than discarded. */
+   {
+      parsed_response_t p;
+      memset(&p, 0, sizeof(p));
+      p.is_tool_call = 1;
+      p.call_count = 1;
+      p.content = (char *)"let me check";
+      snprintf(p.calls[0].id, sizeof(p.calls[0].id), "c1");
+      snprintf(p.calls[0].name, sizeof(p.calls[0].name), "f");
+      assert(openai_format_chat_completion_tool_calls("i", "aimee", &p, 1, resp,
+                                                      (int)sizeof(resp)) > 0);
+      cJSON *root = cJSON_Parse(resp);
+      cJSON *msg =
+          cJSON_GetObjectItem(cJSON_GetArrayItem(cJSON_GetObjectItem(root, "choices"), 0),
+                              "message");
+      assert(strcmp(cJSON_GetObjectItem(msg, "content")->valuestring, "let me check") == 0);
+      cJSON_Delete(root);
+   }
+
+   /* Nothing to report, or nowhere to put it, are both refusals. */
+   {
+      parsed_response_t p;
+      memset(&p, 0, sizeof(p));
+      assert(openai_format_chat_completion_tool_calls("i", "m", &p, 1, resp, (int)sizeof(resp)) ==
+             -1);
+      p.call_count = 1;
+      char tiny[8];
+      assert(openai_format_chat_completion_tool_calls("i", "m", &p, 1, tiny, (int)sizeof(tiny)) ==
+             -1);
    }
 
    printf("ok\n");

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -630,6 +630,52 @@ int main(void)
              -1);
    }
 
+   /* --- streaming: tool calls as SSE deltas + a tool_calls finish frame ---
+    * Agentic clients stream by default, so the buffered shape above is not
+    * enough on its own. */
+   {
+      parsed_response_t p;
+      memset(&p, 0, sizeof(p));
+      p.is_tool_call = 1;
+      p.call_count = 2;
+      snprintf(p.calls[0].id, sizeof(p.calls[0].id), "call_a");
+      snprintf(p.calls[0].name, sizeof(p.calls[0].name), "get_weather");
+      p.calls[0].arguments = strdup("{\"city\":\"Paris\"}");
+      snprintf(p.calls[1].id, sizeof(p.calls[1].id), "call_b");
+      snprintf(p.calls[1].name, sizeof(p.calls[1].name), "get_time");
+
+      assert(openai_format_chat_chunk_tool_calls("id1", "aimee", 1700000000, &p, resp,
+                                                 (int)sizeof(resp)) > 0);
+      cJSON *root = cJSON_Parse(resp);
+      assert(root);
+      cJSON *choice = cJSON_GetArrayItem(cJSON_GetObjectItem(root, "choices"), 0);
+      /* a delta frame must NOT terminate the turn */
+      assert(cJSON_IsNull(cJSON_GetObjectItem(choice, "finish_reason")));
+      cJSON *tcs = cJSON_GetObjectItem(cJSON_GetObjectItem(choice, "delta"), "tool_calls");
+      assert(cJSON_GetArraySize(tcs) == 2);
+      /* clients accumulate by index, so it must be present and ordered */
+      assert(cJSON_GetObjectItem(cJSON_GetArrayItem(tcs, 0), "index")->valuedouble == 0);
+      assert(cJSON_GetObjectItem(cJSON_GetArrayItem(tcs, 1), "index")->valuedouble == 1);
+      cJSON *fn1 = cJSON_GetObjectItem(cJSON_GetArrayItem(tcs, 1), "function");
+      assert(strcmp(cJSON_GetObjectItem(fn1, "arguments")->valuestring, "{}") == 0);
+      cJSON_Delete(root);
+      free(p.calls[0].arguments);
+
+      /* the terminal frame must say tool_calls, not stop */
+      assert(openai_format_chat_chunk_finish("id1", "aimee", 1700000000, "tool_calls", resp,
+                                             (int)sizeof(resp)) > 0);
+      root = cJSON_Parse(resp);
+      choice = cJSON_GetArrayItem(cJSON_GetObjectItem(root, "choices"), 0);
+      assert(strcmp(cJSON_GetObjectItem(choice, "finish_reason")->valuestring, "tool_calls") == 0);
+      cJSON_Delete(root);
+
+      /* default reason, and a refusal when there is nothing to send */
+      assert(openai_format_chat_chunk_finish("i", "m", 1, NULL, resp, (int)sizeof(resp)) > 0);
+      assert(strstr(resp, "\"finish_reason\":\"stop\""));
+      p.call_count = 0;
+      assert(openai_format_chat_chunk_tool_calls("i", "m", 1, &p, resp, (int)sizeof(resp)) == -1);
+   }
+
    printf("ok\n");
    return 0;
 }


### PR DESCRIPTION
## Problem

`/v1/chat/completions` silently discarded a caller-supplied `tools` array and never
emitted `tool_calls`. Any agentic OpenAI client concludes the provider cannot call
tools and refuses to run — OpenCode surfaces this as *"Need tool access to continue;
no tools are available in this session."*

Reproduced straight against the server with mTLS, so it was not a transport artifact:

```
sent:     tools:[{function:{name:"get_weather",...}}], tool_choice:"auto"
returned: finish_reason:"stop"
          "I don't have access to a weather tool in this chat"
```

`/v1/responses` already relayed tools correctly. Only chat/completions was left
behind, with `0 /* use_tools: plain chat completion */` hardcoded at four sites and
the inbound `tools`/`tool_choice` never read.

## Fix

Relay the **caller's** tool definitions and hand back their `tool_calls` for the
caller to execute.

This does not make the endpoint agentic: aimee still executes nothing and holds no
loop state — that remains `/v1/runs` (`openai_chat.c:1386`). It reuses
`agent_execute_messages`, the same passthrough `/v1/responses` uses, so inbound
tools go **through** the shared tool-policing stage rather than around it, and
response-side governance still runs before calls reach an external caller.

Both halves are covered. Streaming matters independently: agentic clients stream by
default, so the buffered relay alone would never have been reached by them.

Two subtleties:
- **Dedup is skipped for tool-bearing requests** — its key does not cover `tools`, so
  a cached tool-free reply must never be replayed for one.
- **All-dropped policing degrades to a text turn** rather than an empty tool turn.

## Verification

Built and deployed to the live server, then exercised end to end.

Buffered:
```json
{"message":{"role":"assistant","content":null,
  "tool_calls":[{"id":"call_r2jvZVCErJvFIzCpmT7kRkS6","type":"function",
    "function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]},
 "finish_reason":"tool_calls"}
```

Streaming — role frame, `delta.tool_calls[]` with `index`, then a `tool_calls`
finish frame, then `[DONE]`.

Return leg — `role:"tool"` result back in produced *"Paris: 12°C, light rain."*
with `finish_reason:"stop"`.

Real OpenCode session, multi-turn, executing tools:
```
> build · aimee
← Write result.txt
  Wrote file successfully.
→ Read result.txt [offset=1, limit=10]
Confirmed: `result.txt` contains `BANANA`.
```

No regression: a request with no `tools` still returns `finish_reason:"stop"` with no
`tool_calls` key.

Unit tests added to `src/tests/test_openai_shape.c` covering both wire shapes, the
tool-loop round trip, `tools:[]` never being forwarded, `arguments` being a JSON
*string*, and the refusal paths. Verified under ASan/UBSan.

## Please review carefully: the third commit is unproven

`server tls: set the session id context` is **hardening, not a validated repair.**

`tls_build_ctx` sets `SSL_VERIFY_PEER` while leaving session caching and TLS 1.3
tickets at their defaults, and never calls `SSL_CTX_set_session_id_context` —
OpenSSL requires that pairing, so this is a real latent defect and the change is
correct on its own merits.

But I originally attributed an observed "every second request fails with
tlsv1 alert internal error" to it, and **I could not reproduce that failure**;
it later stopped occurring on its own with the unpatched server. The likely real
cause was concurrent load on the server at the time. I am not claiming this commit
fixes that symptom. It is an isolated commit and drops cleanly if you would rather
not carry an unvalidated change.

## Deployment note

The running server is currently on a locally-built image (`aimee-server:toolfix`,
pinned via `AIMEE_SERVER_IMAGE` in `/opt/aimee-src/.env`) that is **not** published
to ghcr. Once this merges and CI publishes `:testing`, that override should be
removed so the host returns to the normal image channel.
