### PR TITLE
pass the TLS SAN knob through to the server

### DIFF
--- a/compose.server-managed.yaml
+++ b/compose.server-managed.yaml
@@ -45,6 +45,18 @@ services:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB1_URL: sqlite:///var/lib/aimee/aimee.db
       AIMEE_SERVER_HTTP_BIND: "1"
+      # Reachable address(es) to place in the self-signed cert's SANs, for clients
+      # that verify by NAME rather than TOFU-pinning the leaf (generic HTTPS
+      # tooling: curl, browsers, probes). Empty keeps the default container
+      # hostname + loopback set. pki.c reads this from the process environment, so
+      # without this passthrough the documented knob reaches the binary from
+      # nowhere and setting it appears to do nothing.
+      #
+      # It also pins the cert's CN (pki_resolve_server_cn), which is what keeps a
+      # self-signed cert STABLE across container recreates — so set it before first
+      # start. Changing it later does not re-issue an existing cert (one is minted
+      # only when absent), and forcing a re-issue breaks every TOFU-pinned client.
+      AIMEE_TLS_EXTRA_SAN: ${AIMEE_TLS_EXTRA_SAN:-}
       # Browser webchat (the wizard lives here). Credentials are streamed into
       # Vault by scripts/aimee-compose-vault-bootstrap.sh before `up`; never add
       # them to this long-lived service's persistent container environment.

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -132,6 +132,13 @@ services:
       AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE: ${AIMEE_SERVER_MGMT_JWKS_TRUST_BUNDLE:-/run/aimee/management/jwks-trust-bundle.json}
       # The one-time AIMEE_KB_CONN enrollment credential is streamed into Vault.
       AIMEE_SERVER_HTTP_BIND: "1"
+      # Reachable address(es) for the self-signed cert's SANs, for clients that
+      # verify by NAME instead of TOFU-pinning the leaf. Empty keeps the default
+      # container hostname + loopback set. pki.c reads it from the environment, so
+      # without this passthrough the knob cannot reach the binary at all. It also
+      # pins the CN, which keeps the cert stable across recreates — set it before
+      # first start; a later change does not re-issue an existing cert.
+      AIMEE_TLS_EXTRA_SAN: ${AIMEE_TLS_EXTRA_SAN:-}
       # Browser webchat (HTTPS on :8443). ON by default — it is a first-class
       # surface whose binary is built into the image. Set
       # AIMEE_RUNTIME_WEB_ENABLED=0 to ship server-only. Set both variables on


### PR DESCRIPTION
`AIMEE_TLS_EXTRA_SAN` is read by `pki.c` from the process environment (`pki.c:684`, `pki_resolve_server_cn`), and `deploy/smoothnas/aimee-server.plugin.yaml` advertises it as an operator-facing setting — but neither compose file defining `aimee-server` passed it through. An operator who set it saw no effect, because the value reached the binary from nowhere.

Found while investigating why `curl` rejects a deployment dialed by IP:

```
curl: (60) SSL: no alternative certificate subject name matches target ipv4 address '192.168.1.210'
```

The pinning thin client is unaffected (it verifies by exact leaf match, which is strictly stronger), so this only bites clients that verify by name — generic HTTPS tooling, browsers, probes.

The variable does two jobs, and the second is the less obvious one: it also pins the cert's **CN**, which is what keeps a self-signed cert stable across container recreates (otherwise `gethostname()` returns the per-container ID and the cert rotates on every restart).

## Caveat, documented in the comment

A cert is minted only when absent, so setting this on an existing deployment does **not** re-issue the cert — and forcing a re-issue would break every client that has already TOFU-pinned the leaf. It should be set before first start.

## Verification

- Both files parse; `AIMEE_TLS_EXTRA_SAN` resolves to `${AIMEE_TLS_EXTRA_SAN:-}` in the `aimee-server` service of each
- `check-vault-only-container-env.py`: ok
- `check-managed-authority-packaging.py`: ok
- `check-kb-container-packaging.py`: ok

No behavior change for anyone who does not set the variable.
