### PR TITLE
git: resolve the commit identity per principal, where the commit runs

### DIFF
--- a/src/modules/git/git_forge_vault.c
+++ b/src/modules/git/git_forge_vault.c
@@ -71,10 +71,19 @@ int git_identity_get(char *name_out, size_t name_len, char *email_out, size_t em
 }
 
 /* Read one git config value for |repo_dir| into |out|. Returns 1 when a
- * non-empty value was read, 0 otherwise. The ambient config nulling matches
- * git_ops.c: only the checkout's own config is consulted, so this cannot pick
- * up a system/global setting that changes how git behaves. */
-static int read_git_config(const char *repo_dir, const char *key, char *out, size_t out_len)
+ * non-empty value was read, 0 otherwise.
+ *
+ * |scope| selects how much config git may consult: SCOPE_REPO nulls the ambient
+ * files the way git_ops.c does, so only the checkout's own .git/config answers;
+ * SCOPE_ANY uses git's normal resolution, which also reaches the operator's
+ * ~/.gitconfig. Only user.name/user.email are ever read through here, and only
+ * as data to hand back via `git -c` — so widening the scope cannot let ambient
+ * config change how git BEHAVES, which is what the nulling exists to prevent. */
+#define GIT_CFG_SCOPE_REPO 0
+#define GIT_CFG_SCOPE_ANY  1
+
+static int read_git_config(const char *repo_dir, const char *key, int scope, char *out,
+                           size_t out_len)
 {
    if (!out || !out_len)
       return 0;
@@ -84,9 +93,10 @@ static int read_git_config(const char *repo_dir, const char *key, char *out, siz
    if (!dir)
       return 0;
    char cmd[4608];
-   snprintf(cmd, sizeof(cmd),
-            "GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null "
-            "git -C '%s' config --get %s 2>/dev/null",
+   snprintf(cmd, sizeof(cmd), "%sgit -C '%s' config --get %s 2>/dev/null",
+            scope == GIT_CFG_SCOPE_REPO
+                ? "GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null "
+                : "",
             dir, key);
    free(dir);
 
@@ -104,17 +114,64 @@ static int read_git_config(const char *repo_dir, const char *key, char *out, siz
    return out[0] ? 1 : 0;
 }
 
-int git_identity_resolve(const char *repo_dir, char *name_out, size_t name_len, char *email_out,
-                         size_t email_len)
+/* Reader context for the in-process (popen) path: a checkout directory. */
+static int popen_config_reader(const char *key, char *out, size_t out_len, void *ud)
 {
+   const char *repo_dir = (const char *)ud;
+   /* The checkout's own config wins — a per-repo identity is a deliberate
+    * choice — then the operator's ordinary git identity, which is where most
+    * people actually have one. */
+   if (read_git_config(repo_dir, key, GIT_CFG_SCOPE_REPO, out, out_len))
+      return 1;
+   return read_git_config(repo_dir, key, GIT_CFG_SCOPE_ANY, out, out_len);
+}
+
+/* |principal|'s own sealed author identity (server-wrapped, so it reads with no
+ * user unlock — the same autonomous path the forge token uses). 1 when BOTH
+ * fields are present, 0 when absent or half-written, -1 on a fail-closed
+ * error. */
+static int principal_identity(const char *principal, char *name_out, size_t name_len,
+                              char *email_out, size_t email_len)
+{
+   int n = read_cred(principal, GIT_AUTHOR_NAME_CRED, name_out, name_len);
+   int e = read_cred(principal, GIT_AUTHOR_EMAIL_CRED, email_out, email_len);
+   if (n < 0 || e < 0)
+   {
+      name_out[0] = '\0';
+      email_out[0] = '\0';
+      return -1;
+   }
+   if (n == 1 && e == 1 && name_out[0] && email_out[0])
+      return 1;
+   name_out[0] = '\0';
+   email_out[0] = '\0';
+   return 0;
+}
+
+int git_identity_resolve_with(const char *principal, git_config_reader_fn read_cfg, void *ud,
+                              char *name_out, size_t name_len, char *email_out, size_t email_len)
+{
+   if (!name_out || !name_len || !email_out || !email_len)
+      return -1;
+
+   /* A user sharing this server commits as themselves, not as the server. */
+   if (principal && principal[0])
+   {
+      int prc = principal_identity(principal, name_out, name_len, email_out, email_len);
+      if (prc != 0)
+         return prc;
+   }
+
    int rc = git_identity_get(name_out, name_len, email_out, email_len);
    if (rc != 0)
-      return rc; /* sealed identity, or a fail-closed vault error */
+      return rc; /* server-sealed identity, or a fail-closed vault error */
+   if (!read_cfg)
+      return 0;
 
-   /* Vault is clean. Use the identity the operator already configured for this
-    * checkout rather than stopping to demand an install-time step. */
-   int have_name = read_git_config(repo_dir, "user.name", name_out, name_len);
-   int have_email = read_git_config(repo_dir, "user.email", email_out, email_len);
+   /* Vault is clean. Use the identity the operator already configured rather
+    * than stopping to demand an install-time step. */
+   int have_name = read_cfg("user.name", name_out, name_len, ud);
+   int have_email = read_cfg("user.email", email_out, email_len, ud);
    if (have_name && have_email)
       return 1;
 
@@ -122,4 +179,11 @@ int git_identity_resolve(const char *repo_dir, char *name_out, size_t name_len, 
    name_out[0] = '\0';
    email_out[0] = '\0';
    return 0;
+}
+
+int git_identity_resolve(const char *repo_dir, char *name_out, size_t name_len, char *email_out,
+                         size_t email_len)
+{
+   return git_identity_resolve_with(NULL, popen_config_reader, (void *)repo_dir, name_out, name_len,
+                                    email_out, email_len);
 }

--- a/src/modules/git/git_forge_vault.h
+++ b/src/modules/git/git_forge_vault.h
@@ -79,4 +79,30 @@ int git_identity_get(char *name_out, size_t name_len, char *email_out, size_t em
 int git_identity_resolve(const char *repo_dir, char *name_out, size_t name_len, char *email_out,
                          size_t email_len);
 
+/* Read one git config |key| into |out|; return 1 when a non-empty value was
+ * read, 0 otherwise. |ud| is the caller's context. */
+typedef int (*git_config_reader_fn)(const char *key, char *out, size_t out_len, void *ud);
+
+/* Full resolution, in precedence order:
+ *
+ *   1. |principal|'s OWN sealed identity, if a principal is given. Distinct
+ *      users sharing one server must commit as themselves, so a per-principal
+ *      identity wins — the same layering the forge token already uses
+ *      (per-webuser credential first, server's own identity second).
+ *   2. the server's sealed identity (the single-operator install case).
+ *   3. |read_cfg|, the caller-supplied config lookup.
+ *
+ * The config lookup must run WHERE THE COMMIT WILL RUN. A caller whose git
+ * commands go through a workspace provider (the MCP git tools) does NOT execute
+ * in the server process's own working directory, so resolving config in-process
+ * would consult a directory that is not the checkout — and silently find
+ * nothing. Such a caller passes a reader routed through the same runner it
+ * commits with; a caller holding a real on-disk path can use
+ * git_identity_resolve above. Pass NULL for either to skip that tier.
+ *
+ * Same 1/0/-1 contract, and every tier is all-or-nothing: a name without an
+ * email does not resolve, and does not borrow the next tier's email. */
+int git_identity_resolve_with(const char *principal, git_config_reader_fn read_cfg, void *ud,
+                              char *name_out, size_t name_len, char *email_out, size_t email_len);
+
 #endif /* GIT_FORGE_VAULT_H */

--- a/src/modules/git/mcp_git_write.c
+++ b/src/modules/git/mcp_git_write.c
@@ -7,6 +7,7 @@
 #include "mcp_git.h"
 #include "util.h"
 #include "branch_ownership.h"
+#include "agent_config.h" /* agent_get_request_vault_principal */
 #include "git_forge_vault.h"
 #include <dirent.h>
 #include <sys/stat.h>
@@ -36,6 +37,34 @@ static cJSON *mcp_error(const char *fmt, const char *detail)
    char buf[1024];
    snprintf(buf, sizeof(buf), fmt, detail);
    return mcp_text(buf);
+}
+
+/* Read a git config value through mcp_git_run — the SAME runner the commit
+ * below uses. These tools do not execute in the server process's own working
+ * directory (a workspace provider decides where git runs, and a detached
+ * workspace runs it on the client entirely), so resolving config in-process
+ * would consult a directory that is not the checkout and silently find
+ * nothing. */
+static int mcp_git_config_reader(const char *key, char *out, size_t out_len, void *ud)
+{
+   (void)ud;
+   if (!out || !out_len)
+      return 0;
+   out[0] = '\0';
+
+   char cmd[256];
+   snprintf(cmd, sizeof(cmd), "git config --get %s 2>/dev/null", key);
+   int rc = 0;
+   char *got = mcp_git_run(cmd, &rc);
+   if (!got)
+      return 0;
+   if (rc == 0)
+   {
+      snprintf(out, out_len, "%s", got);
+      out[strcspn(out, "\r\n")] = '\0';
+   }
+   free(got);
+   return out[0] ? 1 : 0;
 }
 
 /* Return a standard error response for main branch protection.
@@ -155,8 +184,9 @@ cJSON *handle_git_commit(cJSON *args)
     * whose commits carry two distinct authors, and the standing directive
     * forbids those. */
    char author_name[256] = "", author_email[256] = "";
-   int have_identity = git_identity_resolve(NULL, author_name, sizeof(author_name), author_email,
-                                            sizeof(author_email));
+   int have_identity = git_identity_resolve_with(
+       agent_get_request_vault_principal(), mcp_git_config_reader, NULL, author_name,
+       sizeof(author_name), author_email, sizeof(author_email));
    if (have_identity < 0)
       return mcp_text("error: could not read the git identity from the vault");
    if (have_identity == 0)

--- a/src/tests/support/git_cred_inject_stub.c
+++ b/src/tests/support/git_cred_inject_stub.c
@@ -73,3 +73,17 @@ int git_identity_resolve(const char *repo_dir, char *name_out, size_t name_len, 
    (void)repo_dir; /* the stub always has a sealed identity, so no fallback runs */
    return git_identity_get(name_out, name_len, email_out, email_len);
 }
+
+int git_identity_resolve_with(const char *principal,
+                              int (*read_cfg)(const char *, char *, size_t, void *), void *ud,
+                              char *name_out, size_t name_len, char *email_out, size_t email_len);
+
+int git_identity_resolve_with(const char *principal,
+                              int (*read_cfg)(const char *, char *, size_t, void *), void *ud,
+                              char *name_out, size_t name_len, char *email_out, size_t email_len)
+{
+   (void)principal;
+   (void)read_cfg;
+   (void)ud; /* the stub always has a sealed identity, so no fallback runs */
+   return git_identity_get(name_out, name_len, email_out, email_len);
+}

--- a/src/tests/test_git_forge_vault.c
+++ b/src/tests/test_git_forge_vault.c
@@ -13,6 +13,36 @@
 #include <string.h>
 #include <unistd.h>
 
+/* Injected config readers for git_identity_resolve_with. */
+static int reader_none(const char *key, char *out, size_t out_len, void *ud)
+{
+   (void)key;
+   (void)ud;
+   if (out && out_len)
+      out[0] = '\0';
+   return 0;
+}
+
+static int reader_both(const char *key, char *out, size_t out_len, void *ud)
+{
+   (void)ud;
+   snprintf(out, out_len, "%s",
+            strcmp(key, "user.name") == 0 ? "Runner Operator" : "runner@example.test");
+   return 1;
+}
+
+static int reader_name_only(const char *key, char *out, size_t out_len, void *ud)
+{
+   (void)ud;
+   if (strcmp(key, "user.name") != 0)
+   {
+      out[0] = '\0';
+      return 0;
+   }
+   snprintf(out, out_len, "Runner Operator");
+   return 1;
+}
+
 int main(void)
 {
    char home[256];
@@ -107,12 +137,23 @@ int main(void)
     * stranded any running agent that reached a commit with a clean vault: it could
     * only stop and ask a human to re-run installation. Fall back to the identity
     * the operator already configured for the repository. */
+   /* Needs a real git binary; the injected-reader cases below cover the same
+    * resolution policy without one, so skip rather than fail where git is
+    * absent (e.g. a minimal build image). */
+   if (system("git --version >/dev/null 2>&1") != 0)
+      printf("git_forge_vault: no git binary — skipping the on-disk config cases\n");
+   else
    {
       char repo[320];
       snprintf(repo, sizeof(repo), "%s/repo", home);
       char cmd[900];
       snprintf(cmd, sizeof(cmd), "mkdir -p %s && git -C %s init -q", repo, repo);
       assert(system(cmd) == 0);
+      /* Point HOME at the sandbox: the fallback also consults the operator's
+       * ordinary git identity, so a real ~/.gitconfig on the machine running
+       * these tests would otherwise satisfy the "nothing configured" cases and
+       * make the result depend on who runs them. */
+      setenv("HOME", home, 1);
 
       char name[256], email[256];
       /* Nothing sealed, nothing configured on the checkout: still refuses, and
@@ -142,6 +183,77 @@ int main(void)
       assert(git_identity_resolve(repo, name, sizeof(name), email, sizeof(email)) == 1);
       assert(strcmp(name, "Sealed Operator") == 0);
       assert(strcmp(email, "sealed@example.test") == 0);
+   }
+
+   /* --- git_identity_resolve_with: the CALLER supplies the lookup ---
+    * The MCP git tools do not run in the server process's working directory --
+    * a workspace provider decides where git runs -- so an in-process lookup
+    * consults a directory that is not the checkout and silently finds nothing.
+    * Those callers inject a reader that routes through the same runner they
+    * commit with. */
+   {
+      char name[256], email[256];
+      /* Unseal first, or the sealed identity above would answer instead of the
+       * injected reader and these would prove nothing. */
+      assert(vault_service_delete(VAULT_SERVER_PRINCIPAL, GIT_FORGE_VAULT_AGENT,
+                                  GIT_AUTHOR_NAME_CRED) == VAULT_OK);
+      assert(vault_service_delete(VAULT_SERVER_PRINCIPAL, GIT_FORGE_VAULT_AGENT,
+                                  GIT_AUTHOR_EMAIL_CRED) == VAULT_OK);
+
+      /* A reader that finds nothing: still refuses, still no invented author. */
+      assert(git_identity_resolve_with(NULL, reader_none, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 0);
+      assert(name[0] == '\0' && email[0] == '\0');
+
+      /* A reader that answers both: resolves from the caller's context. */
+      assert(git_identity_resolve_with(NULL, reader_both, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 1);
+      assert(strcmp(name, "Runner Operator") == 0);
+      assert(strcmp(email, "runner@example.test") == 0);
+
+      /* A reader that answers only the name: half an identity is not one. */
+      assert(git_identity_resolve_with(NULL, reader_name_only, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 0);
+      assert(name[0] == '\0' && email[0] == '\0');
+
+      /* No reader at all is a refusal, not a crash. */
+      assert(git_identity_resolve_with(NULL, NULL, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 0);
+
+      /* --- per-principal identity: users sharing a server commit as themselves ---
+       * Seal alice her own author identity, server-wrapped so it reads with no
+       * unlock, exactly like her forge token. */
+      assert(vault_service_set_server_wrap(alice, GIT_FORGE_VAULT_AGENT, GIT_AUTHOR_NAME_CRED,
+                                           "Alice A") == VAULT_OK);
+      assert(vault_service_set_server_wrap(alice, GIT_FORGE_VAULT_AGENT, GIT_AUTHOR_EMAIL_CRED,
+                                           "alice@example.test") == VAULT_OK);
+      vault_kek_cache_clear(); /* autonomous read: no cached user KEK */
+      assert(git_identity_resolve_with(alice, reader_both, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 1);
+      assert(strcmp(name, "Alice A") == 0);
+      assert(strcmp(email, "alice@example.test") == 0);
+
+      /* Isolation: bob has no identity of his own, so he must NOT get alice's —
+       * he falls through to the next tier. */
+      assert(git_identity_resolve_with(bob, reader_both, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 1);
+      assert(strcmp(name, "Runner Operator") == 0);
+      assert(strcmp(email, "runner@example.test") == 0);
+
+      /* Half a per-principal identity does not resolve, and does not borrow the
+       * next tier's email — it falls through whole. */
+      assert(vault_service_set_server_wrap(carol, GIT_FORGE_VAULT_AGENT, GIT_AUTHOR_NAME_CRED,
+                                           "Carol C") == VAULT_OK);
+      vault_kek_cache_clear();
+      assert(git_identity_resolve_with(carol, reader_both, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 1);
+      assert(strcmp(name, "Runner Operator") == 0);
+      assert(strcmp(email, "runner@example.test") == 0);
+
+      /* With nothing anywhere, a principal still refuses rather than inventing. */
+      assert(git_identity_resolve_with(bob, reader_none, NULL, name, sizeof(name), email,
+                                       sizeof(email)) == 0);
+      assert(name[0] == '\0' && email[0] == '\0');
    }
 
    char clean[320];


### PR DESCRIPTION
## Problem

The checkout-local fallback added in #2237 did not work. An agent with a perfectly
good `user.name`/`user.email` on its branch still got:

> no git identity is configured

Two separate defects:

**1. It looked in the wrong place.** `mcp_git_write` resolved the identity with an
in-process lookup, but its git commands go through a workspace provider — a
shared/container workspace runs git on the server, a detached one runs it on the
client entirely. So the lookup ran in the server process's own cwd
(`/var/lib/aimee` inside the container), which is not a repository, while the
commit itself would have run in the real checkout. It could never have found
anything.

**2. It only consulted the checkout's own config.** That looks correct on a checkout
that happens to carry a local identity — which is exactly why it passed review and
its own tests — and strands every checkout that does not, which is most of them.

## Fix

**Read the config where the commit runs.** `git_identity_resolve_with` takes the
lookup from the caller; `mcp_git_write` passes one routed through `mcp_git_run`, the
same runner it commits with. `wfe_live_delegate` keeps the in-process path — it
holds a real workdir. The in-process path also now falls through to the operator's
ordinary git identity after the checkout's own.

**Resolve per principal**, so distinct users on one server commit as themselves:

1. the principal's **own** sealed identity
2. the **server's** sealed identity (the single-operator install case)
3. the caller's config lookup

This is the layering the forge token already uses (per-webuser credential first,
server's own second) and reads server-wrapped, so it needs no user unlock.

Unchanged guarantees: every tier is all-or-nothing — a name without an email does
not resolve and does **not** borrow the next tier's email; with nothing anywhere it
still refuses rather than inventing an author.

## Verification

Built **and ran** `unit-test-git-forge-vault` on the real toolchain (`-Wall -Wextra
-Werror`), with git present:

```
git version 2.39.5
git_forge_vault: all tests passed
```

Covering:
- per-principal resolution (alice gets alice's identity)
- **cross-principal isolation** — bob has none of his own and must not get alice's;
  he falls through
- half a per-principal identity falls through *whole*, borrowing nothing
- on-disk cases: repo-local wins, global fallback, half-identity refuses, sealed
  identity overrides the checkout
- injected-reader cases: none / both / name-only / no reader at all

The on-disk block now **skips** rather than failing where no git binary exists — it
hard-failed in a minimal build image, which is how I found that the earlier tests
were resolving against whatever `~/.gitconfig` the test machine happened to have.
`HOME` is now pointed at the sandbox so those cases are hermetic.

## Note on scope

I first built this for a single-operator server, then per-principal on your call.
The per-principal tier is additive: a deployment with only the server-sealed
identity behaves exactly as before.
