### PR TITLE
server: name the dependency that actually failed on a KB miss

### DIFF
--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -12,6 +12,7 @@
 #include "db1.h"
 #include "util.h" /* is_safe_id */
 #include "kb_client.h"
+#include "log.h" /* aimee_log — name the real KB failure in the server log */
 #include "config.h"
 #include "dashboard.h"
 #include <aimee/protocols/mcp/mcp_tools.h>
@@ -1021,7 +1022,19 @@ cJSON *smcp_tool_find_symbol(cJSON *args)
    term_hit_t hits[20];
    int count = kb_client_index_find_scoped(project, all_projects, jid->valuestring, hits, 20);
    if (count < 0)
-      return kb_last_result_content("knowledge service symbol index unavailable");
+   {
+      /* Name the dependency that actually failed. "symbol index unavailable"
+       * reads as "the kb's index is broken" and sent an investigation at a
+       * healthy kb; a failed client-side auth or an unresolved scope produced
+       * the identical string with nothing in the log to correct it. */
+      aimee_log(LOG_WARN, "mcp.code_find",
+                "index_find_scoped failed: status=%s project=%s all_projects=%d",
+                kb_client_result_status_name(kb_client_last_result_status()),
+                project ? project : "(none)", all_projects);
+      return kb_last_result_content("code index lookup failed; see result_status for whether the "
+                                    "knowledge service was unreachable, unauthorized, or the "
+                                    "scope did not resolve");
+   }
    int matched = 0;
    for (int i = 0; i < count; i++)
       if (all_projects || !project || strcmp(hits[i].project, project) == 0)

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -23,6 +23,7 @@
 #include "forge_credentials.h"
 #include "db1.h"
 #include "kb_client.h"
+#include "log.h" /* aimee_log — name the real KB failure in the server log */
 #include "compute_pool.h"
 #include "cJSON.h"
 #include "json_fluent.h"
@@ -122,10 +123,29 @@ int handle_memory_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (fact_count < 0)
    {
       kb_client_memory_scope_context_clear();
-      return server_send_error(conn,
-                               "knowledge service search index unavailable; server-side "
-                               "maintenance is required",
-                               NULL);
+      /* Report the failure that ACTUALLY happened. This used to answer every
+       * cause with "search index unavailable; server-side maintenance is
+       * required", which names the wrong owner: the common case is a caller
+       * whose scope did not resolve (a remote client with no active project),
+       * and the kb is healthy. That message sent three separate investigations
+       * at the kb — restarting it, matching its image, re-checking its mTLS
+       * trust — while nothing was wrong with it. The typed result carries the
+       * real dependency and retryability, and the sibling index route already
+       * reports it this way. */
+      kb_client_result_status_t status = kb_client_last_result_status();
+      const char *detail = active_context_missing
+                               ? "memory search found no active project to scope to; pass a "
+                                 "project or cwd, or ask for scope=all"
+                               : "memory search could not reach the knowledge service";
+      aimee_log(LOG_WARN, "memory.search", "find_facts failed: status=%s scope_missing=%d",
+                kb_client_result_status_name(status), active_context_missing);
+      char *json = kb_client_last_result_json(detail);
+      cJSON *err = json ? cJSON_Parse(json) : NULL;
+      free(json);
+      if (!err)
+         return server_send_error(conn, detail, NULL);
+      cJSON_AddBoolToObject(err, "active_context_missing", active_context_missing);
+      return send_and_free(conn, err);
    }
 
    /* Search conversation windows */

--- a/src/server/server_state_index.c
+++ b/src/server/server_state_index.c
@@ -4,6 +4,7 @@
 #include "server.h"
 #include "aimee.h"
 #include "kb_client.h"
+#include "log.h" /* aimee_log — name the real KB failure in the server log */
 #include "workspace.h"
 #include "cJSON.h"
 #include "json_fluent.h"
@@ -66,8 +67,18 @@ int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    term_hit_t hits[128];
    int count = kb_client_index_find_scoped(project, all_projects, identifier, hits, 128);
    if (count < 0)
-      return send_and_free(conn,
-                           kb_last_result_object("knowledge service symbol index unavailable"));
+   {
+      /* Same misattribution as the MCP twin: say which dependency failed, and
+       * leave a log line so a healthy kb is not the first thing suspected. */
+      aimee_log(LOG_WARN, "index.find",
+                "index_find_scoped failed: status=%s project=%s all_projects=%d",
+                kb_client_result_status_name(kb_client_last_result_status()),
+                project[0] ? project : "(none)", all_projects);
+      return send_and_free(
+          conn, kb_last_result_object("code index lookup failed; see result_status for whether the "
+                                      "knowledge service was unreachable, unauthorized, or the "
+                                      "scope did not resolve"));
+   }
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "result_status", count > 0 ? "ok" : "empty");


### PR DESCRIPTION
## Problem

Three KB-backed routes answer **every** failure with a message that blames the
knowledge service's index:

```
knowledge service search index unavailable; server-side maintenance is required
knowledge service symbol index unavailable
```

The index is rarely the cause. A scope that did not resolve, an unauthorized client,
or a genuinely unreachable service all produce that same sentence. It names the wrong
owner, prescribes the wrong remedy ("server-side maintenance"), and is emitted with
**nothing in the server log** to correct it.

## Why this is worth fixing

It cost hours of real debugging today. Two separate investigations took that message
at its word and went at a healthy kb — restarting it, matching its image version,
re-checking its mTLS trust, tracing its syscalls — while the kb was serving correctly
the entire time. There was no log line anywhere to contradict the message.

## Fix

The typed result already existed and already had the answer:

- `kb_client_last_result_status()` distinguishes `UNAVAILABLE` / `UNAUTHORIZED` /
  `EMPTY`
- `kb_client_last_result_json()` serialises it with the dependency and retryability

The sibling index route already replied that way. These three did not. Now they do,
and each logs the classification alongside the scope that was in effect.

The memory route additionally reports `active_context_missing` — a flag it **already
computed and then discarded**. That one bit separates "your scope did not resolve"
from "the service is down", which is the exact confusion that burned the time.

## Scope

No behaviour change beyond what a caller is told. The same conditions still fail;
they now say which dependency failed and why.

## Verification

- `make lint` — all 40 checks pass
- Builds clean on the server toolchain (`-Wall -Wextra -Werror`)
- Deployed the built image to a live server and exercised the routes

**Not verified:** I have not reproduced a live failure that exercises the new message
end to end. The condition I was chasing turned out to be a misconfigured client on my
own box, not a server fault, so the improved text has not yet been observed in anger.
It is a strict improvement on the old string in every branch, but treat the wording as
reviewed-by-reading rather than proven-in-production.
