### PR TITLE
client: say which aimee answered when a command fails

### DIFF
--- a/src/aimee_client.c
+++ b/src/aimee_client.c
@@ -177,6 +177,36 @@ int aimee_client_has_remote(void)
    return (env && *env) ? 1 : 0;
 }
 
+/* A short, credential-free description of where this process actually sends
+ * requests. Failures print it, because "no remote configured" is otherwise
+ * invisible: with remote.conf absent the client silently uses the local socket
+ * and every command still answers — from a DIFFERENT aimee than the operator
+ * believes they are talking to. A whole debugging session was spent
+ * instrumenting a remote server that the failing commands were never reaching.
+ *
+ * Any userinfo in the URL is stripped: a credential must not reach a terminal,
+ * a log, or a pasted bug report. */
+const char *aimee_client_transport_label(void)
+{
+   static char label[sizeof(g_remote_url) + 32];
+   const char *url = g_remote_url[0] ? g_remote_url : getenv("AIMEE_SERVER_URL");
+   if (!url || !*url)
+      return "local Unix socket (no remote server configured)";
+
+   const char *scheme_end = strstr(url, "://");
+   const char *authority = scheme_end ? scheme_end + 3 : url;
+   const char *at = strchr(authority, '@');
+   if (!at)
+   {
+      snprintf(label, sizeof(label), "%s", url);
+      return label;
+   }
+   /* Keep the scheme, drop everything up to and including the '@'. */
+   int scheme_len = scheme_end ? (int)(scheme_end + 3 - url) : 0;
+   snprintf(label, sizeof(label), "%.*s%s", scheme_len, url, at + 1);
+   return label;
+}
+
 int aimee_client_parse_flag(char **argv, int *i, int argc, const char **url, const char **token)
 {
    const char *a = argv[*i];

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -1759,7 +1759,8 @@ static int cli_v1_finish_response(const cli_v1_route_t *route, cJSON *resp, int 
    {
       cJSON *msg = cJSON_GetObjectItemCaseSensitive(resp, "message");
       if (cJSON_IsString(msg) && msg->valuestring[0])
-         fprintf(stderr, "aimee: %s\n", msg->valuestring);
+         fprintf(stderr, "aimee: %s\n  (via %s)\n", msg->valuestring,
+                 aimee_client_transport_label());
       cJSON_Delete(resp);
       return 1;
    }
@@ -1772,9 +1773,9 @@ static int cli_v1_finish_response(const cli_v1_route_t *route, cJSON *resp, int 
    if (cJSON_IsObject(err))
    {
       cJSON *emsg = cJSON_GetObjectItemCaseSensitive(err, "message");
-      fprintf(stderr, "aimee: %s\n",
-              (cJSON_IsString(emsg) && emsg->valuestring[0]) ? emsg->valuestring
-                                                             : "request failed");
+      fprintf(stderr, "aimee: %s\n  (via %s)\n",
+              (cJSON_IsString(emsg) && emsg->valuestring[0]) ? emsg->valuestring : "request failed",
+              aimee_client_transport_label());
       cJSON_Delete(resp);
       return 1;
    }
@@ -1788,9 +1789,11 @@ static int cli_v1_finish_response(const cli_v1_route_t *route, cJSON *resp, int 
    if (http_status >= 400)
    {
       if (cJSON_IsString(err) && err->valuestring[0])
-         fprintf(stderr, "aimee: %s\n", err->valuestring);
+         fprintf(stderr, "aimee: %s\n  (via %s)\n", err->valuestring,
+                 aimee_client_transport_label());
       else
-         fprintf(stderr, "aimee: server returned HTTP %d for '%s'\n", http_status, route->method);
+         fprintf(stderr, "aimee: server returned HTTP %d for '%s'\n  (via %s)\n", http_status,
+                 route->method, aimee_client_transport_label());
       cJSON_Delete(resp);
       return 1;
    }

--- a/src/headers/aimee_client.h
+++ b/src/headers/aimee_client.h
@@ -37,6 +37,13 @@ extern "C"
     * Windows there is no UDS, so the remote path is the only one. */
    int aimee_client_has_remote(void);
 
+   /* Where this process actually sends requests, as a short credential-free
+    * string (any userinfo in the URL is stripped). Returned storage is static
+    * and overwritten by the next call. Error paths print it so a command that
+    * silently used the local socket is not mistaken for one that reached the
+    * configured server. */
+   const char *aimee_client_transport_label(void);
+
    /* Parse a single remote-server CLI flag (argv[*i]): --server=URL,
     * --server URL (advances *i), or --server-token=TOK. On a match, sets *url
     * and/or *token to point into argv and returns 1; returns 0 otherwise. */

--- a/src/tests/test_aimee_client.c
+++ b/src/tests/test_aimee_client.c
@@ -166,6 +166,39 @@ static void test_tcp_set_remote_with_token(void)
    PASS("tcp via set_remote, bearer token + body");
 }
 
+static void test_transport_label(void)
+{
+   /* No remote configured is the case that matters: with remote.conf absent the
+    * client silently uses the local socket and every command still answers --
+    * from a different aimee than the operator believes. The label makes that
+    * visible on the error path instead of leaving it to be discovered. */
+   aimee_client_set_remote(NULL, NULL);
+   unsetenv("AIMEE_SERVER_URL");
+   assert(strstr(aimee_client_transport_label(), "no remote server configured") != NULL);
+
+   aimee_client_set_remote("https://192.168.1.210:8743", NULL);
+   assert(strcmp(aimee_client_transport_label(), "https://192.168.1.210:8743") == 0);
+
+   /* Userinfo must never reach a terminal, a log, or a pasted bug report. */
+   aimee_client_set_remote("https://user:sup3rsecret@host:8743/v1", NULL);
+   assert(strstr(aimee_client_transport_label(), "sup3rsecret") == NULL);
+   assert(strcmp(aimee_client_transport_label(), "https://host:8743/v1") == 0);
+
+   /* Same stripping when the target comes from the environment. */
+   aimee_client_set_remote(NULL, NULL);
+   setenv("AIMEE_SERVER_URL", "https://tok:abc@env-host:1/", 1);
+   assert(strstr(aimee_client_transport_label(), "abc") == NULL);
+   assert(strstr(aimee_client_transport_label(), "env-host") != NULL);
+   unsetenv("AIMEE_SERVER_URL");
+
+   /* A value with no scheme is passed through rather than mangled. */
+   aimee_client_set_remote("no-scheme-host:8743", NULL);
+   assert(strcmp(aimee_client_transport_label(), "no-scheme-host:8743") == 0);
+
+   aimee_client_set_remote(NULL, NULL);
+   PASS("transport label names the target and strips credentials");
+}
+
 static void test_remote_active_reporting(void)
 {
    aimee_client_set_remote("http://example.test:8390", NULL);
@@ -398,6 +431,7 @@ int main(void)
    test_tcp_set_remote_with_token();
    test_gzip_roundtrip();
    test_remote_active_reporting();
+   test_transport_label();
    test_https_unreachable_null();
    test_cleartext_credential_guard();
 #ifdef WITH_TLS


### PR DESCRIPTION
## Problem

With no remote configured, the thin client silently falls back to the local Unix
socket — and every command still answers. From a **different aimee** than the
operator believes they are talking to. Nothing in the output says so. The only way
to find out is to run `aimee remote status` on a hunch.

## Why this matters

It cost a full debugging session. `remote.conf` was removed mid-session, and hours
went into a remote server that the failing commands were never reaching: matching its
image version, restarting its knowledge service, re-checking its mTLS trust, tracing
its syscalls. The server was healthy the entire time. A second session had already
lost time to the mirror-image version of this — chasing a dev-box problem onto the
server.

Every command answering normally while pointed somewhere unintended is the worst
shape a misconfiguration can take: it produces confident, wrong conclusions.

## Fix

Print the transport on the client's error paths — the configured target, or
`local Unix socket (no remote server configured)`:

```
aimee: knowledge service search index unavailable; server-side maintenance is required
  (via local Unix socket (no remote server configured))
```

One extra line, only on failure. Success output is unchanged, so this adds no noise
to normal use.

`aimee_client_has_remote()` already existed; this adds `aimee_client_transport_label()`
beside it and uses it in the three error printers in `cli_v1_routes_d.c` that surface
server-side errors, REST error envelopes, and bare non-2xx responses.

## Credential safety

Any userinfo in the URL is stripped, so a credential cannot reach a terminal, a log,
or a pasted bug report:

```
https://user:sup3rsecret@host:8743/v1  ->  https://host:8743/v1
```

## Verification

- `make lint` — all 40 checks pass
- Built on the server toolchain (`-Wall -Wextra -Werror`)
- **Ran** `unit-test-aimee-client`; the whole suite passes including the new case:

```
PASS: transport label names the target and strips credentials
ALL PASS
```

The new test covers: no remote configured, a plain URL, userinfo stripping via
`set_remote` and via `AIMEE_SERVER_URL`, and a value with no scheme passed through
rather than mangled.
