### PR TITLE
fix: make an unreachable knowledge service visible, and repairable

### DIFF
--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -798,7 +798,9 @@ static int kb_cmd_managed_server_identity(int argc, char **argv)
    if (argc < 3 || strcmp(argv[2], "install") != 0)
    {
       fputs("Usage: aimee-kb managed-server-identity install --server-home=PATH "
-            "--host=HOST --port=N --endpoint=URL --uid=N\n",
+            "--host=HOST --port=N --endpoint=URL --uid=N [--force]\n"
+            "  --force  re-issue the client certificate even when a stored identity\n"
+            "           already matches this KB (repairs trust the KB no longer accepts)\n",
             stderr);
       return 1;
    }
@@ -826,6 +828,8 @@ static int kb_cmd_managed_server_identity(int argc, char **argv)
          if (kb_parse_unsigned(argv[i] + 6, (unsigned long long)(uid_t)-1, &owner) != 0)
             owner_seen = -1;
       }
+      else if (strcmp(argv[i], "--force") == 0 && !options.force)
+         options.force = 1;
       else
       {
          fprintf(stderr, "aimee-kb managed-server-identity: invalid or duplicate option: %s\n",

--- a/src/kb/managed_server_identity_install.c
+++ b/src/kb/managed_server_identity_install.c
@@ -215,26 +215,70 @@ int kb_managed_server_identity_install(const kb_managed_server_identity_install_
        kb_pki_ca_load_custodied(ca_dir, &ca) != 0)
       goto done;
 
+   /* Every precondition below used to be one silent `goto done`: the process
+    * exited 1 with no reason, so an operator repairing broken trust could not
+    * tell a rotated CA from an unreadable file from a wrong --host. Name the
+    * cause on stderr; none of these strings carry key material. */
    struct stat identity_stat;
-   if (lstat(identity_path, &identity_stat) == 0)
+   int have_identity = lstat(identity_path, &identity_stat) == 0;
+   int reissue = 0;
+   if (have_identity)
    {
-      if (!S_ISREG(identity_stat.st_mode) ||
-          kb_managed_server_identity_load(identity_path, options->owner, &identity) != 0 ||
-          strcmp(identity.host, options->host) != 0 || identity.port != options->port ||
-          strcmp(identity.endpoint, options->endpoint) != 0 ||
-          strcmp(identity.ca, ca.cert_pem) != 0)
+      if (!S_ISREG(identity_stat.st_mode))
+      {
+         fputs("managed-server-identity: stored identity is not a regular file\n", stderr);
          goto done;
+      }
+      if (kb_managed_server_identity_load(identity_path, options->owner, &identity) != 0)
+      {
+         fputs("managed-server-identity: stored identity could not be loaded (wrong owner or "
+               "corrupt file); re-run with --force to replace it\n",
+               stderr);
+         goto done;
+      }
+      int targets_differ = strcmp(identity.host, options->host) != 0 ||
+                           identity.port != options->port ||
+                           strcmp(identity.endpoint, options->endpoint) != 0;
+      int ca_differs = strcmp(identity.ca, ca.cert_pem) != 0;
+      if ((targets_differ || ca_differs) && !options->force)
+      {
+         fprintf(stderr,
+                 "managed-server-identity: stored identity %s; re-run with --force to re-issue\n",
+                 targets_differ ? "targets a different KB endpoint"
+                                : "was issued by a different CA");
+         goto done;
+      }
+      reissue = options->force;
    }
-   else
+   else if (errno != ENOENT)
    {
-      if (errno != ENOENT)
+      perror("managed-server-identity: cannot stat stored identity");
+      goto done;
+   }
+
+   if (!have_identity || reissue)
+   {
+      /* Keep the server on the team it already belongs to. Re-selecting could
+       * silently re-home an enrolled server when the owner has several. */
+      int64_t team_id = reissue ? identity.team_id : 0;
+      if (team_id <= 0 && select_team(&owner, &team_id) != 0)
+      {
+         fputs("managed-server-identity: no team available for the bootstrap owner\n", stderr);
          goto done;
-      int64_t team_id = 0;
-      if (select_team(&owner, &team_id) != 0 ||
-          kb_managed_server_identity_generate(&ca, options->host, options->port, options->endpoint,
-                                              team_id, &identity) != 0 ||
-          kb_managed_server_identity_save(identity_path, options->owner, &identity) != 0)
+      }
+      kb_managed_server_identity_clear(&identity);
+      memset(&identity, 0, sizeof(identity));
+      if (kb_managed_server_identity_generate(&ca, options->host, options->port, options->endpoint,
+                                              team_id, &identity) != 0)
+      {
+         fputs("managed-server-identity: could not generate a server identity\n", stderr);
          goto done;
+      }
+      if (kb_managed_server_identity_save(identity_path, options->owner, &identity) != 0)
+      {
+         fputs("managed-server-identity: could not persist the server identity\n", stderr);
+         goto done;
+      }
    }
 
    /* Loading a pending identity is the normal crash-recovery path. Older

--- a/src/kb/managed_server_identity_install.h
+++ b/src/kb/managed_server_identity_install.h
@@ -10,6 +10,11 @@ typedef struct
    int port;
    const char *endpoint;
    uid_t owner;
+   /* Re-issue the client certificate even when a stored identity already
+    * matches this KB. Without it the installer reuses whatever is on disk and
+    * reports readiness, so an identity the KB no longer accepts — a rotated CA,
+    * a revoked or expired cert, a lost registry row — has no supported repair. */
+   int force;
 } kb_managed_server_identity_install_options_t;
 
 /* Install or resume the wizard-managed server's durable mTLS identity. DB2 must

--- a/src/modules/kb_client/kb_client.c
+++ b/src/modules/kb_client/kb_client.c
@@ -12,6 +12,7 @@
 #include "platform_path.h"
 #include "runtime_secret.h"
 #include "dependency_breaker.h"
+#include "log.h"
 #include "cJSON.h"
 #include <ctype.h>
 #include <errno.h>
@@ -61,6 +62,7 @@ static __declspec(thread) int64_t g_kb_last_current_generation;
 static __declspec(thread) int64_t g_kb_last_observed_dimension;
 static __declspec(thread) int64_t g_kb_last_current_dimension;
 static __declspec(thread) int64_t g_kb_last_retry_after_ms;
+static __declspec(thread) int g_kb_last_suppressed;
 #else
 static _Thread_local kb_client_result_status_t g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
 static _Thread_local char g_kb_last_dependency[32] = "kb";
@@ -69,6 +71,9 @@ static _Thread_local int64_t g_kb_last_current_generation;
 static _Thread_local int64_t g_kb_last_observed_dimension;
 static _Thread_local int64_t g_kb_last_current_dimension;
 static _Thread_local int64_t g_kb_last_retry_after_ms;
+/* Set when the local breaker refused the call, so the typed error can say the
+ * KB was never contacted instead of blaming the operation the caller asked for. */
+static _Thread_local int g_kb_last_suppressed;
 #endif
 
 static int64_t kb_dependency_now_ms(void)
@@ -257,9 +262,19 @@ static int kb_transport_begin(int *status_out)
    g_kb_last_observed_dimension = 0;
    g_kb_last_current_dimension = 0;
    g_kb_last_retry_after_ms = 0;
+   g_kb_last_suppressed = 0;
+   int64_t now_ms = kb_dependency_now_ms();
    int64_t retry_after = 0;
-   if (dependency_breaker_allow(&g_kb_dependency, kb_dependency_now_ms(), &retry_after))
+   if (dependency_breaker_allow(&g_kb_dependency, now_ms, &retry_after))
       return 1;
+
+   /* Carry the breaker's own retry window into the typed error. Discarding it
+    * made every suppressed call report the synthetic base-delay floor that
+    * kb_typed_error_json() substitutes for a missing hint, so an operator could
+    * not tell a one-second wait from a thirty-second one — or even tell that the
+    * breaker, rather than the KB, produced the refusal. */
+   g_kb_last_retry_after_ms = retry_after;
+   g_kb_last_suppressed = 1;
    if (status_out)
       *status_out = 503;
    return 0;
@@ -291,6 +306,19 @@ static void kb_capture_result_metadata(const char *response)
    cJSON_Delete(root);
 }
 
+/* Report success, and log the close so an outage has a visible end as well as a
+ * visible start. Silent recovery left an operator unable to tell a healed
+ * dependency from one that simply had not been called again. */
+static void kb_transport_recovered(int64_t now_ms)
+{
+   dependency_breaker_snapshot_t before;
+   dependency_breaker_snapshot(&g_kb_dependency, now_ms, &before);
+   dependency_breaker_report_success(&g_kb_dependency, now_ms);
+   if (before.open)
+      LOG_INFO("server.kb", "knowledge service reachable again after %u open interval(s)",
+               before.open_count);
+}
+
 static void kb_transport_complete(const char *path, const char *response, int http_status)
 {
    int64_t now_ms = kb_dependency_now_ms();
@@ -300,7 +328,7 @@ static void kb_transport_complete(const char *path, const char *response, int ht
       kb_capture_result_metadata(response);
    if (http_status == 401 || http_status == 403)
    {
-      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      kb_transport_recovered(now_ms);
       g_kb_last_result = KB_CLIENT_RESULT_UNAUTHORIZED;
       return;
    }
@@ -310,7 +338,7 @@ static void kb_transport_complete(const char *path, const char *response, int ht
       /* The KB is reachable and truthfully reported one of its own optional
        * dependencies. Keep that typed outage from suppressing unrelated KB
        * operations through the transport breaker. */
-      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      kb_transport_recovered(now_ms);
       g_kb_last_result = classified;
       return;
    }
@@ -318,20 +346,37 @@ static void kb_transport_complete(const char *path, const char *response, int ht
    {
       /* A typed unavailable body means the KB answered but one of its own
        * dependencies did not; do not trip the KB transport breaker. */
-      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      kb_transport_recovered(now_ms);
       g_kb_last_result = classified;
       return;
    }
    if (http_status >= 400 && http_status < 500 && http_status != 408 && http_status != 425 &&
        http_status != 429)
    {
-      dependency_breaker_report_success(&g_kb_dependency, now_ms);
+      kb_transport_recovered(now_ms);
       g_kb_last_result = valid ? classified : KB_CLIENT_RESULT_UNAVAILABLE;
       return;
    }
+   /* This is the only branch that means the KB itself did not answer, and it was
+    * silent. A server that cannot open its mTLS connection reported exactly the
+    * same "<operation> unavailable" text as a healthy KB with an empty index, so
+    * nothing in the log distinguished a transport outage from a data problem.
+    * Log the transition into the open state — not every suppressed call — so a
+    * sustained outage costs one line per backoff window rather than one per
+    * request. */
+   dependency_breaker_snapshot_t before;
+   dependency_breaker_snapshot(&g_kb_dependency, now_ms, &before);
    dependency_breaker_report_failure(&g_kb_dependency, now_ms, DEPENDENCY_BREAKER_DEFAULT_THRESHOLD,
                                      DEPENDENCY_BREAKER_DEFAULT_BASE_MS,
                                      DEPENDENCY_BREAKER_DEFAULT_MAX_MS);
+   dependency_breaker_snapshot_t after;
+   dependency_breaker_snapshot(&g_kb_dependency, now_ms, &after);
+   if (after.open && !before.open)
+      LOG_WARN("server.kb",
+               "knowledge service unreachable (%s %s); suppressing calls for %lldms after %u "
+               "consecutive failure(s)",
+               http_status > 0 ? "http" : "transport", path && path[0] ? path : "(no path)",
+               (long long)after.retry_after_ms, after.failure_streak);
    g_kb_last_result = KB_CLIENT_RESULT_UNAVAILABLE;
 }
 
@@ -356,6 +401,11 @@ static char *kb_typed_error_json(kb_client_result_status_t status, const char *m
       if (retry_after_ms > DEPENDENCY_BREAKER_DEFAULT_MAX_MS)
          retry_after_ms = DEPENDENCY_BREAKER_DEFAULT_MAX_MS;
       cJSON_AddNumberToObject(obj, "retry_after_ms", (double)retry_after_ms);
+      /* Distinguish "we never called the KB" from "the KB answered unavailable".
+       * Both used to surface as the caller's own operation being unavailable,
+       * which sends an operator to the index when the fault is local. */
+      if (g_kb_last_suppressed)
+         cJSON_AddBoolToObject(obj, "circuit_open", 1);
    }
    if (status == KB_CLIENT_RESULT_STALE && g_kb_last_observed_generation > 0)
       cJSON_AddNumberToObject(obj, "observed_generation", (double)g_kb_last_observed_generation);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -49,7 +49,7 @@ P5B3C_LIVE_SERVER_OBJS = $(filter-out $(OBJDIR)/server/server_main.o,$(SERVER_OB
                            $(MCP_GIT_OBJS) $(OBJDIR)/aimee_client.o
 
 $(TESTPREFIX)/unit-test-server-management-listener-live: \
-    $(OBJDIR)/tests/test_server_management_listener_live.o $(P5B3C_LIVE_SERVER_OBJS)
+    $(OBJDIR)/tests/test_server_management_listener_live.o $(P5B3C_LIVE_SERVER_OBJS) $(OBJDIR)/tests/support/log_stub.o
 	$(TESTLINK) -o $@ $^ $(L_SERVER)
 
 # Common object sets for tests
@@ -1737,7 +1737,7 @@ $(TESTPREFIX)/unit-test-kb-client-search: $(OBJDIR)/tests/test_kb_client_search.
 	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
-	                                  $(PLATFORM_BASIC_OBJS)
+	                                  $(PLATFORM_BASIC_OBJS) $(OBJDIR)/tests/support/log_stub.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.o \
@@ -1749,7 +1749,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
-	                                  $(PLATFORM_BASIC_OBJS)
+	                                  $(PLATFORM_BASIC_OBJS) $(OBJDIR)/tests/support/log_stub.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \

--- a/src/tests/test_dependency_breaker.c
+++ b/src/tests/test_dependency_breaker.c
@@ -43,6 +43,52 @@ int main(void)
    dependency_breaker_reset(&g_breaker);
    dependency_breaker_snapshot(&g_breaker, started, &snap);
    assert(snap.suppressed_calls == 0 && snap.last_failure_ms == 0);
+
+   /* The KB transport logs an outage by comparing the snapshot either side of a
+    * report, so "did this failure open the breaker?" must be answerable exactly
+    * once per outage. If the open edge repeated, a sustained outage would log
+    * per request; if it never appeared, the outage stayed silent — which is how
+    * an unreachable KB previously looked identical to an empty index. */
+   dependency_breaker_snapshot_t before, after;
+   unsigned open_edges = 0, close_edges = 0;
+   const int64_t t0 = 500000;
+   for (unsigned i = 0; i < DEPENDENCY_BREAKER_DEFAULT_THRESHOLD * 3U; i++)
+   {
+      dependency_breaker_snapshot(&g_breaker, t0, &before);
+      dependency_breaker_report_failure(&g_breaker, t0, DEPENDENCY_BREAKER_DEFAULT_THRESHOLD,
+                                        DEPENDENCY_BREAKER_DEFAULT_BASE_MS,
+                                        DEPENDENCY_BREAKER_DEFAULT_MAX_MS);
+      dependency_breaker_snapshot(&g_breaker, t0, &after);
+      if (after.open && !before.open)
+         open_edges++;
+   }
+   assert(open_edges == 1);
+
+   dependency_breaker_snapshot(&g_breaker, t0, &before);
+   dependency_breaker_report_success(&g_breaker, t0);
+   dependency_breaker_snapshot(&g_breaker, t0, &after);
+   if (before.open && !after.open)
+      close_edges++;
+   assert(close_edges == 1);
+   assert(before.open_count > 0); /* the log line reports how many intervals elapsed */
+
+   /* A success while already closed is not a recovery and must not log one. */
+   dependency_breaker_snapshot(&g_breaker, t0, &before);
+   dependency_breaker_report_success(&g_breaker, t0);
+   assert(before.open == 0);
+
+   /* A denied call must hand back a usable retry window. The transport carries
+    * this into the typed error; when it was dropped, every suppressed call
+    * reported the same synthetic floor regardless of the real backoff. */
+   dependency_breaker_reset(&g_breaker);
+   for (unsigned i = 0; i < DEPENDENCY_BREAKER_DEFAULT_THRESHOLD; i++)
+      dependency_breaker_report_failure(&g_breaker, t0, DEPENDENCY_BREAKER_DEFAULT_THRESHOLD,
+                                        DEPENDENCY_BREAKER_DEFAULT_BASE_MS,
+                                        DEPENDENCY_BREAKER_DEFAULT_MAX_MS);
+   int64_t denied_retry = -1;
+   assert(dependency_breaker_allow(&g_breaker, t0, &denied_retry) == 0);
+   assert(denied_retry > 0);
+
    printf("dependency_breaker: ok\n");
    return 0;
 }


### PR DESCRIPTION
Found while trying to diagnose why a managed server could not reach its KB. The underlying outage took hours to characterise, and the reason it took hours is the bug: **an unreachable knowledge service was indistinguishable from a healthy one with nothing to return, and it logged nothing at all.**

## The symptom that motivated this

On a managed deployment the server reported:

```
$ aimee --json index find end_of_month --scope all
{"retryable":true,"dependency":"kb","retry_after_ms":1000,
 "message":"knowledge service symbol index unavailable"}
```

That message names the symbol index. The symbol index was fine. Queried directly with the *server's own stored mTLS identity*, from inside the server container, the identical query succeeded:

```
stored-cert mTLS /v1/health                        -> HTTP=200
stored-cert mTLS /v1/code/find?identifier=end_of_month -> HTTP=200, hits
```

The KB's log showed only health checks — the server never sent the request. Nothing in the server log said so. There was no way to reach that conclusion short of reading `kb_client.c`.

## 1. An unreachable KB is now visible (`kb_client.c`)

Three separate problems fed the same confusion:

**The transport failure was silent.** The final branch of `kb_transport_complete()` — the only one meaning *the KB itself did not answer* — reported failure to the breaker and returned without a word. Now it logs the transition into the open state:

```
knowledge service unreachable (transport /v1/code/find?...); suppressing calls for 1000ms after 3 consecutive failure(s)
```

Logged on the **edge**, not per call, so a sustained outage costs one line per backoff window rather than one per request. Recovery logs its own edge too, because silent healing left you unable to tell a recovered dependency from one that simply had not been retried.

**The retry hint was computed and thrown away.** `kb_transport_begin()` passed a `retry_after` out-param to `dependency_breaker_allow()`, then dropped the value:

```c
int64_t retry_after = 0;
if (dependency_breaker_allow(&g_kb_dependency, kb_dependency_now_ms(), &retry_after))
   return 1;
if (status_out) *status_out = 503;
return 0;                       /* retry_after discarded */
```

`kb_typed_error_json()` then substituted `DEPENDENCY_BREAKER_DEFAULT_BASE_MS` for the missing hint. So every suppressed call reported exactly `retry_after_ms: 1000` no matter the real backoff — which actively misleads: it looks like a breaker that never escalates. (It misled me for some time.)

**A suppressed call looked like a dependency failure.** Both produced `status: unavailable, dependency: kb`. Suppressed calls now also carry `circuit_open: true`, so a caller can tell "we never contacted the KB" from "the KB answered unavailable".

Worth flagging for follow-up, not fixed here: `g_kb_dependency` is a **single global breaker for every KB operation**, so one failing dependency suppresses reads that provably work. Narrowing it is a design change with real blast radius and wants its own review.

## 2. `managed-server-identity install` can now report and repair

This is the documented recovery path for broken server↔KB trust. Two problems:

**It failed silently.** Every precondition was one `goto done` returning -1; the process exited 1 and printed nothing beyond a generic "install failed". A rotated CA, an unreadable file, and a wrong `--host` were indistinguishable. Each now names itself on stderr (no key material in any string).

**It could not actually repair.** When a stored identity existed and host/port/endpoint/CA all matched, it reused the certificate as-is, heartbeated, and printed `{"state":"ready", ...}` — without re-issuing. A certificate the KB no longer accepts (revoked, expired, registry row lost) therefore had no supported repair, and the operator got a success message. Observed directly: two consecutive runs returned the identical `server_id` and `state: ready` while the server still could not authenticate.

`--force` re-issues. It deliberately **keeps the server on the team it already belongs to** rather than re-selecting, so forcing a repair cannot silently re-home an enrolled server when the owner has several teams.

## Tests

Extended `test_dependency_breaker.c` with the invariant the new logging depends on: the open edge must be observable exactly once across many failures (otherwise a sustained outage logs per request), the close edge exactly once, a success while already closed is not a recovery, and a denied call must hand back a usable non-zero retry window.

Verified red-before-green: regressing `dependency_breaker_allow()` to drop the retry hint — the exact defect fixed here — fails the suite at the retry-window assertion. Header restored, suite green.

## Verification

- `make -C src lint` — all 40 checks pass (clang-format 19.1.7).
- `test_dependency_breaker` passes clean under `-Wall -Wextra -Werror`.
- Both binaries build in-container: `aimee-server` via `Dockerfile.server`, `aimee-kb` via `Dockerfile` (the KB-side changes are not covered by the server image build).
- Installer argument parsing exercised in a throwaway container: `--force` accepted, duplicate `--force` and unknown flags rejected, valid arguments proceed to a named downstream failure.

**Not verified end-to-end:** the new log lines have not been observed firing against a live broken deployment, because the environment that produced the original outage is still down. The logic is edge-triggered off `dependency_breaker_snapshot()` and unit-tested, but the first real outage is what will confirm the message reads well in context.
