### PR TITLE
deploy: detect when a host drifts off the published image channel

### DIFF
--- a/deploy/systemd/aimee-image-drift.service
+++ b/deploy/systemd/aimee-image-drift.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Warn when aimee containers drift off the published image channel
+Documentation=https://github.com/RakuenSoftware/aimee
+
+[Service]
+Type=oneshot
+# Non-zero means drift. Treat it as success for the unit so the timer keeps
+# running and the journal carries a standing record, rather than one alert that
+# scrolls away and a unit stuck in "failed".
+SuccessExitStatus=0 1
+ExecStart=/usr/local/bin/check-deployed-image.sh

--- a/deploy/systemd/aimee-image-drift.timer
+++ b/deploy/systemd/aimee-image-drift.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodic aimee deployed-image drift check
+Documentation=https://github.com/RakuenSoftware/aimee
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/check-deployed-image.sh
+++ b/scripts/check-deployed-image.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# check-deployed-image.sh: is this host running the image it is supposed to be?
+#
+# A deployment drifts off its published channel in two ways, and both are silent:
+#
+#   1. A local pin. Setting AIMEE_SERVER_IMAGE to a locally built tag takes the
+#      host off the registry entirely. `docker compose pull` then fails with
+#      "pull access denied for aimee-server, repository does not exist" and the
+#      host keeps serving whatever it already had. Four such pins appeared on one
+#      box in a single day; it sat two hours on a build that predated the fix it
+#      was supposed to be running.
+#
+#   2. A recreate without a pull. `docker compose up -d` reuses the cached image,
+#      so a container restarted after a publish comes back on the OLD build. The
+#      tag still reads :testing and everything looks correct.
+#
+# Neither shows up in `docker ps`, which reports the tag rather than the digest.
+# This compares what is RUNNING against what the registry currently publishes.
+#
+# Usage: check-deployed-image.sh [service...]      (default: aimee-server aimee-kb)
+#   AIMEE_IMAGE_TAG   channel to check against (default: testing)
+#   AIMEE_IMAGE_REPO  registry prefix           (default: ghcr.io/rakuensoftware)
+#
+# Exit: 0 all services current, 1 drift found, 2 could not determine.
+set -uo pipefail
+
+TAG="${AIMEE_IMAGE_TAG:-testing}"
+REPO="${AIMEE_IMAGE_REPO:-ghcr.io/rakuensoftware}"
+SERVICES=("${@:-}")
+[ -z "${SERVICES[0]:-}" ] && SERVICES=(aimee-server aimee-kb)
+
+command -v docker >/dev/null || { echo "check-deployed-image: docker not found"; exit 2; }
+
+rc=0
+for svc in "${SERVICES[@]}"; do
+   container=$(docker ps --filter "name=${svc}" --format '{{.Names}}' | head -1)
+   if [ -z "$container" ]; then
+      echo "check-deployed-image: ${svc}: not running — skipped"
+      continue
+   fi
+
+   image=$(docker inspect "$container" --format '{{.Config.Image}}' 2>/dev/null)
+   want="${REPO}/${svc}:${TAG}"
+
+   # A pin to anything that is not the published repo is drift by definition:
+   # the host can no longer receive a published build at all.
+   case "$image" in
+      "${REPO}/"*) ;;
+      *)
+         echo "check-deployed-image: ${svc}: PINNED to '${image}', not '${want}'"
+         echo "  this host cannot pull published builds while pinned; remove"
+         echo "  AIMEE_SERVER_IMAGE (or equivalent) from the compose .env"
+         rc=1
+         continue
+         ;;
+   esac
+
+   running=$(docker inspect "$container" --format '{{.Image}}' 2>/dev/null)
+   # RepoDigests is what the registry served; empty means a local build.
+   published=$(docker image inspect "$want" --format '{{index .RepoDigests 0}}' 2>/dev/null || true)
+   if [ -z "$published" ]; then
+      echo "check-deployed-image: ${svc}: local image '${want}' has no registry digest"
+      echo "  it was built here rather than pulled; run 'docker compose pull ${svc}'"
+      rc=1
+      continue
+   fi
+
+   local_id=$(docker image inspect "$want" --format '{{.Id}}' 2>/dev/null || true)
+   if [ "$running" != "$local_id" ]; then
+      echo "check-deployed-image: ${svc}: STALE — running an older image than the"
+      echo "  local '${want}'. A container was recreated without a pull, or the tag"
+      echo "  moved after it started. Run 'docker compose pull ${svc} && up -d ${svc}'."
+      rc=1
+      continue
+   fi
+
+   built=$(docker image inspect "$want" --format '{{.Created}}' 2>/dev/null)
+   echo "check-deployed-image: ${svc}: ok (${want}, built ${built})"
+done
+
+exit $rc


### PR DESCRIPTION
## Problem

A deployment leaves its published channel in two ways, and **both are silent**.

**1. A local pin.** Setting `AIMEE_SERVER_IMAGE` to a locally built tag takes the host
off the registry entirely:

```
$ docker compose pull aimee-server
Error response from daemon: pull access denied for aimee-server,
repository does not exist or may require 'docker login'
```

The host then keeps serving whatever it already had. Four such pins appeared on one
box in a single day (`toolfix`, `ptfix2`, `ptfix3`, `attr`). It sat **two hours** on a
build that predated the very fix it was supposed to be running, while a newer image
was published and waiting.

**2. A recreate without a pull.** `docker compose up -d` reuses the cached image, so a
container restarted after a publish comes back on the **old** build. This one is
nastier: the tag still reads `:testing` and `docker ps` looks entirely correct,
because it reports the *tag*, not the digest.

## Fix

`scripts/check-deployed-image.sh` compares what is **running** against what is
**published**, plus a systemd timer so it actually runs.

- pinned to a non-published repo → reported, with the remedy
- image has no registry digest (built here, not pulled) → reported
- running image older than the local tag → reported
- service not running → skipped, not an error

Drift exits 1; the unit uses `SuccessExitStatus=0 1` so the timer keeps running and
the journal carries a standing record instead of one alert that scrolls away and a
unit stuck in `failed`.

## Verification

Run against the live production host:

```
=== clean state ===
aimee-server: ok (ghcr.io/rakuensoftware/aimee-server:testing, built 2026-08-01T18:46:11Z)
aimee-kb:     ok (ghcr.io/rakuensoftware/aimee-kb:testing,     built 2026-08-01T18:46:25Z)
exit=0

=== container on a non-published image ===
shotter: PINNED to 'zenika/alpine-chrome:latest', not 'ghcr.io/rakuensoftware/shotter:testing'
  this host cannot pull published builds while pinned; remove
  AIMEE_SERVER_IMAGE (or equivalent) from the compose .env
exit=1

=== service not running ===
aimee-nonexistent: not running — skipped
exit=0
```

Timer installed and firing on that host (15 min interval), logging to the journal.

**Not verified:** the stale-digest and built-locally branches are reviewed by reading
only. Reproducing them means deliberately regressing a production host onto an old
image, which is not worth the coverage.
