### PR TITLE
kb: stop serving privileged routes unauthenticated

### DIFF
--- a/src/aimee_client.c
+++ b/src/aimee_client.c
@@ -6,6 +6,7 @@
  * identically on Linux, macOS, and Windows.
  */
 #include "aimee_client.h"
+#include "cleartext_guard.h" /* the shared cleartext rule, also used by kb_client */
 #include "http_content_encoding.h"
 #include "platform.h"
 #include "platform_net.h"
@@ -510,25 +511,13 @@ static char *read_response(int fd, aimee_tls_t *tls, size_t *out_len, int want_r
    return resp;
 }
 
-/* A non-loopback plaintext connection must never carry a credential. localhost,
- * 127.0.0.0/8, and ::1 are the only hosts where a cleartext bearer stays on the
- * machine; anything else would put it on the wire. */
-static int host_is_loopback(const char *host)
-{
-   if (!host || !host[0])
-      return 0;
-   if (strcmp(host, "localhost") == 0 || strcmp(host, "::1") == 0 || strcmp(host, "[::1]") == 0)
-      return 1;
-   return strncmp(host, "127.", 4) == 0; /* 127.0.0.0/8 */
-}
-
 /* Security guard (also exposed for tests): 1 when sending |token| to a server at
  * (|is_https|, |host|) would put the credential on the wire in cleartext — a
  * non-empty bearer over plaintext http:// to a non-loopback host. tcp_request
  * refuses such requests rather than leak the bearer. */
 int aimee_client_would_leak_cleartext(int is_https, const char *host, const char *token)
 {
-   return (token && *token && !is_https && !host_is_loopback(host)) ? 1 : 0;
+   return cleartext_would_leak(is_https, host, token);
 }
 
 static char *tcp_request(const char *url, const char *token, const char *method, const char *path,

--- a/src/headers/cleartext_guard.h
+++ b/src/headers/cleartext_guard.h
@@ -1,0 +1,37 @@
+/* cleartext_guard.h: one rule for "would this put a credential on the wire?".
+ *
+ * Two clients send bearer tokens: the thin client (aimee_client.c) to
+ * aimee-server, and the kb client (kb_client.c) to aimee-kb. Both must refuse
+ * plaintext to a non-loopback host, and they must agree on what loopback means
+ * — a second, subtly different copy of this check is how one of them ends up
+ * weaker than the other.
+ *
+ * Header-only for the same reason dependency_breaker.h is: the kb client links
+ * into many focused unit-test binaries that do not carry aimee_client.o, and a
+ * shared implementation must not drag a new link dependency into all of them.
+ */
+#ifndef DEC_CLEARTEXT_GUARD_H
+#define DEC_CLEARTEXT_GUARD_H 1
+
+#include <string.h>
+
+/* localhost, 127.0.0.0/8, and ::1 are the only hosts where a cleartext bearer
+ * stays on the machine; anything else puts it on the wire. */
+static inline int cleartext_host_is_loopback(const char *host)
+{
+   if (!host || !host[0])
+      return 0;
+   if (strcmp(host, "localhost") == 0 || strcmp(host, "::1") == 0 || strcmp(host, "[::1]") == 0)
+      return 1;
+   return strncmp(host, "127.", 4) == 0; /* 127.0.0.0/8 */
+}
+
+/* 1 when sending |token| to a server at (|is_https|, |host|) would transmit the
+ * credential in cleartext: a non-empty bearer over plaintext to a non-loopback
+ * host. Callers refuse such requests rather than leak the bearer. */
+static inline int cleartext_would_leak(int is_https, const char *host, const char *token)
+{
+   return (token && *token && !is_https && !cleartext_host_is_loopback(host)) ? 1 : 0;
+}
+
+#endif /* DEC_CLEARTEXT_GUARD_H */

--- a/src/kb/http/kb_http_listener.c
+++ b/src/kb/http/kb_http_listener.c
@@ -195,6 +195,23 @@ int kb_http_start(int port, const char *bearer_token)
    setsockopt(g_listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
    const char *b = getenv("AIMEE_KB_HTTP_BIND");
    in_addr_t baddr = (b && b[0]) ? INADDR_ANY : INADDR_LOOPBACK;
+
+   /* Auth is only enforced when a bearer is configured (kb_http.c's gate is
+    * `if (bearer_token && bearer_token[0])`). With none, the kb answers every
+    * route unauthenticated — which is a reasonable default for the loopback-only
+    * bind above, and is NOT reasonable once this socket is reachable off-host.
+    *
+    * Observed on a real deployment: `POST /v1/actions/memory.find_facts` with no
+    * credentials at all returned 200 with stored memory, to anything that could
+    * route to the container. Fail closed instead: a non-loopback bind requires a
+    * bearer. The mTLS listener is unaffected — it authenticates by certificate. */
+   if (baddr == INADDR_ANY && !g_bearer_token[0])
+      LOG_ERROR("kb_http",
+                "binding 0.0.0.0:%d with NO bearer configured: this socket serves privileged "
+                "routes unauthenticated to anything that can reach it. Seal a kb bearer "
+                "(AIMEE_KB_API_BEARER_TOKEN, first-boot -> Vault), or unset AIMEE_KB_HTTP_BIND to "
+                "keep the plain listener on loopback.",
+                port);
    struct sockaddr_in sa;
    memset(&sa, 0, sizeof(sa));
    sa.sin_family = AF_INET;

--- a/src/modules/kb_client/kb_client.c
+++ b/src/modules/kb_client/kb_client.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 #endif
 #include "kb_client.h"
+#include "cleartext_guard.h" /* the shared cleartext rule, also used by the thin client */
 #include "kb_client_cache.h"
 #include "kb_client_internal.h"
 #include "kb_client_mtls.h"
@@ -1549,6 +1550,50 @@ static char *kb_client_v1_url(const char *path)
    return url;
 }
 
+/* Refuse to put the kb bearer on the wire in cleartext.
+ *
+ * The plain-HTTP branches below are reached only when mTLS is not configured,
+ * which is legitimate for a loopback kb. It is not legitimate for a kb across a
+ * network: the bearer would travel unprotected, and the thin client already
+ * refuses exactly this shape. Apply the same rule here so the kb link cannot be
+ * the weak one.
+ *
+ * Returns 1 when the request must NOT be sent. A URL with no credential to leak,
+ * or an https:// URL, is allowed through unchanged. */
+static int kb_plain_would_leak(const char *url)
+{
+   if (!url)
+      return 0;
+   char token[512];
+   int have_token = runtime_secret_get("AIMEE_KB_API_BEARER_TOKEN", token, sizeof(token));
+   runtime_secret_wipe(token, sizeof(token));
+   if (!have_token)
+      return 0; /* nothing to leak */
+
+   int is_https = strncmp(url, "https://", 8) == 0;
+   const char *authority = strstr(url, "://");
+   authority = authority ? authority + 3 : url;
+   char host[256];
+   size_t n = strcspn(authority, "/");
+   if (n >= sizeof(host))
+      n = sizeof(host) - 1;
+   memcpy(host, authority, n);
+   host[n] = '\0';
+   char *colon = strrchr(host, ':');
+   if (colon && !strchr(host, ']'))
+      *colon = '\0';
+
+   if (!cleartext_would_leak(is_https, host, "x"))
+      return 0;
+   /* stderr rather than aimee_log: this file links into many focused unit-test
+    * binaries that do not carry the logging object. */
+   fprintf(stderr,
+           "kb_client: refusing to send the kb bearer in cleartext to non-loopback host '%s'; "
+           "use the mTLS endpoint or terminate TLS in front of the kb\n",
+           host);
+   return 1;
+}
+
 static const char *kb_client_v1_auth_header(char *buf, size_t buf_len)
 {
    /* The HTTP API can run without auth; include a bearer header only when the
@@ -1601,6 +1646,13 @@ static char *kb_client_v1_post_json_impl(const char *path, cJSON *body, int time
    }
 
    char *url = kb_client_v1_url(path);
+   if (url && kb_plain_would_leak(url))
+   {
+      free(url);
+      free(body_json);
+      kb_transport_complete(path, NULL, -1);
+      return NULL;
+   }
    if (url)
    {
       char auth[320];
@@ -1666,6 +1718,12 @@ char *kb_client_v1_post_body_with_type(const char *path, const char *body, const
    }
 
    char *url = kb_client_v1_url(path);
+   if (url && kb_plain_would_leak(url))
+   {
+      free(url);
+      kb_transport_complete(path, NULL, -1);
+      return NULL;
+   }
    if (url)
    {
       char auth[320];
@@ -1711,6 +1769,12 @@ char *kb_client_v1_get_json(const char *path, int timeout_ms, int *status_out)
    }
 
    char *url = kb_client_v1_url(path);
+   if (url && kb_plain_would_leak(url))
+   {
+      free(url);
+      kb_transport_complete(path, NULL, -1);
+      return NULL;
+   }
    if (url)
    {
       char auth[320];


### PR DESCRIPTION
## Problem

The kb enforces auth **only when a bearer is configured** — `kb_http.c` gates on
`if (bearer_token && bearer_token[0])`. Nothing configured one, and the plain listener
binds the container network rather than loopback.

Verified on a live deployment, then reproduced in an isolated one:

```
POST /v1/actions/memory.find_facts     (no credentials at all)
-> 200, with stored memory facts
```

Anything able to route to the container could read the knowledge base. The mTLS
listener was never the weak point — this socket beside it was.

## Fix — three parts, none sufficient alone

**1. The deployment provisions `AIMEE_KB_API_BEARER_TOKEN` for both services.** The
server *already* sent this bearer on the plain path; only the kb never asked for it.
Required rather than defaulted (`:?`), so a deployment cannot come up half-configured
and silently unauthenticated.

**2. The kb refuses a non-loopback bind with no bearer**, so this cannot regress to
auth-off by dropping a variable. A loopback-only kb is unaffected — that is the
default when `AIMEE_KB_HTTP_BIND` is unset.

**3. `GET`/`HEAD /v1/health` is exempt from the gate.** Without this the container
healthcheck presents no credential, gets 401, and the kb is reported unhealthy while
serving correctly. **I hit exactly that**, which is why it is in this PR. Only
`/v1/health`: it is answered in `kb_http_route_ex`, whereas `/v1/version` delegates to
`kb_http_route` and applies its own check, so exempting it there would not take effect.

Separately, the **kb client refuses to send its bearer in cleartext to a non-loopback
host** — a rule the thin client already enforced. The shared rule moved to
`cleartext_guard.h`, header-only for the reason `dependency_breaker.h` is: `kb_client`
links into many focused test binaries carrying neither `aimee_client.o` nor the logging
object. The first version of this broke four of them; the header fixes that.

## Verification

Everything below ran on a **disposable stack** (a dedicated LXC with its own server +
kb), never on production.

Final auth matrix, on the exact code in this PR, with both containers healthy:

```
health  noauth: 200     <- healthcheck works
action  noauth: 401     <- the hole, closed
action badauth: 401     <- wrong token rejected
action  w/auth: 200     <- server<->kb intact
```

```
aimee-aimee-server-1 | Up (healthy)
aimee-aimee-kb-1     | Up (healthy)
```

Compose refuses a half-configured deployment:

```
required variable AIMEE_KB_API_BEARER_TOKEN is missing a value:
the kb bearer must be set; generate one per deployment and give the same value to aimee-server
```

The bind gate fires with the remedy in the message:

```
ERROR kb_http: refusing to bind 0.0.0.0:8741 with no bearer configured: this socket
would serve privileged routes unauthenticated. Configure the kb bearer, or unset
AIMEE_KB_HTTP_BIND to keep the plain listener on loopback.
```

Unit tests (the ones the first attempt broke):

```
unit-test-kb-client-search -> ok
unit-test-kb-http-client   -> passed
unit-test-aimee-client     -> ALL PASS
unit-test-kb-client-memory -> ok
```

`make lint` — all 40 checks pass. Both images build under `-Wall -Wextra -Werror`.

## Deployment note

`AIMEE_KB_API_BEARER_TOKEN` has already been provisioned in the production `.env`
(backup: `.env.bak-pre-kbtoken`) so this merge does not block the next deploy. It is
inert until these images land. Any **other** deployment must set it before updating,
or compose will refuse to start the kb — deliberately, since the alternative is
running unauthenticated.
