### PR TITLE
fix: say when a scan indexed nothing, and name the remedy for a dead grant

### DIFF
--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -1586,6 +1586,20 @@ void print_server_health(cJSON *resp)
    {
       const char *kbs = json_str(kb, "status");
       printf("aimee-kb: %s\n", (kbs && kbs[0]) ? kbs : "unknown");
+      /* An open transport breaker refuses every call locally, so the kb can be
+       * "ok" here while nothing works. Print it before the detail lines: this is
+       * the line that explains an index that answers "unavailable" on a server
+       * whose kb looks healthy. */
+      if (cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(kb, "queries_suppressed")))
+      {
+         cJSON *retry = cJSON_GetObjectItemCaseSensitive(kb, "retry_after_ms");
+         printf("  QUERIES SUPPRESSED: the transport breaker is open, so kb calls are being\n");
+         printf("  refused locally without reaching the kb%s.\n",
+                cJSON_IsNumber(retry) && retry->valuedouble > 0 ? "" : " (retrying shortly)");
+         if (cJSON_IsNumber(retry) && retry->valuedouble > 0)
+            printf("  next retry in %lldms; see the server log for the cause.\n",
+                   (long long)retry->valuedouble);
+      }
       if (kbs && strcmp(kbs, "ok") == 0)
       {
          cJSON *vec = cJSON_GetObjectItemCaseSensitive(kb, "vectors");

--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -10,9 +10,11 @@
 #include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
 #include "aimee_client.h" /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
 #include "code_collect.h" /* code_collect_files + code_collect_discover_repos (thin-client push) */
+/* Platform-independent, and used by print_index_scan which builds everywhere —
+ * so it must sit OUTSIDE the POSIX-only preamble below. */
+#include "workspace_scan_indexed.h" /* one verdict for "did this scan index anything" */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
-#include "workspace_scan_indexed.h" /* one verdict for "did this scan index anything" */
 #include <dirent.h>
 #include <sys/socket.h>
 #include <sys/stat.h>

--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -12,6 +12,7 @@
 #include "code_collect.h" /* code_collect_files + code_collect_discover_repos (thin-client push) */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
+#include "workspace_scan_indexed.h" /* one verdict for "did this scan index anything" */
 #include <dirent.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -518,6 +519,14 @@ static void print_index_scan(cJSON *resp)
              files, unchanged);
    else
       printf("==> Scan complete: %d project(s), %d file(s) re-indexed\n", projects, files);
+
+   /* A scan that walked a project and indexed nothing is not a success worth
+    * reporting as one. It is what a caller sees when kb cannot read the tree —
+    * a path it does not share, or one owned by another uid — and the bare
+    * "Scan complete: 1 project(s), 0 file(s)" reads as done. `workspace add`
+    * already warns in exactly this case; this makes the two agree. */
+   if (projects > 0 && !workspace_scan_indexed(0, 0, inspected, files))
+      printf("    warning: nothing was indexed — %s\n", WORKSPACE_SCAN_EMPTY_REASON);
 }
 
 static void print_index_list(cJSON *resp)
@@ -2366,12 +2375,30 @@ void pt_print_grant_set(const char *method, cJSON *resp)
 
    if (was_revoked > 0)
       printf("a previous revocation for this subject was reinstated\n");
-   if (is_member == 0)
-      fprintf(stderr, "warning: the subject is not a member of this team; the grant has no "
-                      "effect until they join\n");
-   else if (is_member < 0)
-      fprintf(stderr, "warning: team membership was not reported; the grant has no effect "
-                      "unless the subject is a member\n");
+   /* Naming the remedy is the whole point of these two, exactly as it is for the
+    * write-tier 403. Without it the operator is told the grant they just made
+    * does nothing and is left to discover that membership is a separate command
+    * on a different binary — one that `aimee kb grant` does not offer and
+    * docs/UPGRADING.md's grant section does not mention. */
+   if (is_member != 1)
+   {
+      /* An older server does not echo these; fall back to placeholders rather
+       * than printing a command with empty arguments. */
+      cJSON *jteam = cJSON_GetObjectItemCaseSensitive(resp, "team_id");
+      const char *subject = json_str(resp, "subject");
+      char team[32] = "<team-id>";
+      if (cJSON_IsNumber(jteam))
+         snprintf(team, sizeof(team), "%lld", (long long)jteam->valuedouble);
+      if (!subject || !subject[0])
+         subject = "<subject>";
+      if (is_member == 0)
+         fprintf(stderr, "warning: the subject is not a member of this team; the grant has no "
+                         "effect until they join\n");
+      else
+         fprintf(stderr, "warning: team membership was not reported; the grant has no effect "
+                         "unless the subject is a member\n");
+      fprintf(stderr, "  join with: aimee-kb team add-member %s '%s'\n", team, subject);
+   }
 }
 
 void pt_print_grant_revoke(const char *method, cJSON *resp)

--- a/src/cmd_self_update.c
+++ b/src/cmd_self_update.c
@@ -459,8 +459,26 @@ int cmd_self_update(int argc, char **argv)
          return 1;
       }
       printf("client v%s, server reports '%s'\n", vnum(AIMEE_VERSION), vnum(target));
-      printf("The server reports a non-semver (dev/branch) version, so drift cannot be "
-             "compared. Target a specific release with `aimee self-update --version vX.Y.Z`.\n");
+      printf("The server reports a non-semver (dev/branch) version, so there is no release "
+             "to fetch.\n");
+      /* "drift cannot be compared" was true only of ORDERING. Whether the two
+       * agree is the question an operator actually has, and it is answerable:
+       * identical build strings mean they match. Leaving it unanswered is how a
+       * client silently ran four days behind its server and lost a route the
+       * server had already gained -- the failure looked like a server bug. */
+      const char *cnum = vnum(AIMEE_VERSION);
+      const char *snum = vnum(target);
+      if (strcmp(cnum, snum) == 0)
+         printf("Client and server are the same build; nothing to do.\n");
+      else
+      {
+         printf("Client and server are DIFFERENT builds, so this client may be missing "
+                "routes the server already has.\n");
+         printf("On a dev/branch deployment the client ships inside the server image, so "
+                "align it from there rather than from a release:\n");
+         printf("  docker cp <server-container>:/usr/local/bin/aimee ~/.local/bin/aimee\n");
+         printf("Or target a specific release with `aimee self-update --version vX.Y.Z`.\n");
+      }
       return 0;
    }
 

--- a/src/headers/workspace_scan_indexed.h
+++ b/src/headers/workspace_scan_indexed.h
@@ -1,0 +1,37 @@
+/* workspace_scan_indexed.h: did a scan actually index anything?
+ *
+ * Header-only because both sides of the wire need the same answer and must not
+ * drift: the server decides what `workspace add` reports per project, and the
+ * CLI decides what `index scan` prints. They disagreed — `workspace add` warned
+ * that kb had seen no files while `index scan` of the same tree printed a bare
+ * "Scan complete", so the same broken state read as a failure through one
+ * command and a success through the other.
+ *
+ * kb is handed a filesystem PATH. In the managed topology aimee-server and
+ * aimee-kb are separate containers, and kb additionally reads as its own uid, so
+ * a path the server can read may be empty or unreadable for kb. kb then walks
+ * nothing, finds no files, and answers success. */
+#ifndef DEC_WORKSPACE_SCAN_INDEXED_H
+#define DEC_WORKSPACE_SCAN_INDEXED_H 1
+
+static inline int workspace_scan_indexed(int rc, int skipped, int inspected, int files)
+{
+   if (rc != 0 || skipped)
+      return 0;
+   /* `inspected` is the right test, not `files`: a project already indexed and
+    * unchanged legitimately reports files == 0 with inspected > 0, and calling
+    * that "not indexed" would be its own wrong answer. inspected == 0 means kb
+    * saw no files to consider. Older kb builds do not report inspected
+    * (documented as 0), so fall back to files rather than calling a working
+    * older kb broken. */
+   int visited = inspected > 0 ? inspected : files;
+   return visited > 0;
+}
+
+/* The one sentence a user can act on when a scan indexed nothing. Shared so the
+ * server's per-project `reason` and the CLI's scan output say the same thing. */
+#define WORKSPACE_SCAN_EMPTY_REASON                                                                \
+   "knowledge service saw no files at that path — it may not be able to read it "                  \
+   "(aimee-kb runs in its own container and does not share the server's filesystem)"
+
+#endif /* DEC_WORKSPACE_SCAN_INDEXED_H */

--- a/src/server/server_api_status.c
+++ b/src/server/server_api_status.c
@@ -107,6 +107,22 @@ void server_health_add_kb(cJSON *resp)
       return;
    int reachable = (kb_rc == 0 && kb.process_ok);
    cJSON_AddStringToObject(kbo, "status", reachable ? "ok" : "unreachable");
+
+   /* `status` answers "is the kb process up", which is not the same question as
+    * "can I query it". With the transport breaker open every call is refused
+    * locally without the kb ever being contacted, and this block still said
+    * "ok" — so an operator watching status saw a healthy kb while every lookup
+    * failed, and had no way to connect the two. Report the breaker here, in both
+    * the reachable and unreachable cases, since that is where people look. */
+   kb_client_dependency_health_t dep;
+   kb_client_dependency_health(&dep);
+   cJSON_AddStringToObject(kbo, "transport_state", dep.state);
+   if (strcmp(dep.state, "open") == 0)
+   {
+      cJSON_AddBoolToObject(kbo, "queries_suppressed", 1);
+      cJSON_AddNumberToObject(kbo, "retry_after_ms", (double)dep.retry_after_ms);
+      cJSON_AddNumberToObject(kbo, "suppressed_calls", (double)dep.suppressed_calls);
+   }
    if (!reachable)
       return;
    cJSON_AddBoolToObject(kbo, "store_ok", kb.db2_ok ? 1 : 0);

--- a/src/server/server_http_grant_routes.c
+++ b/src/server/server_http_grant_routes.c
@@ -105,6 +105,11 @@ int rh_grant_set(const route_req_t *rq, char *resp, int cap)
    kb_client_grant_change_t change;
    kb_client_grant_result_t rc = kb_client_grant_set(jsrv->valuestring, team_id, jsub->valuestring,
                                                      jtier->valuestring, "owner", &change);
+   /* The response echoes the subject, so copy it out before the body that owns
+    * that string is freed. Reading jsub after the delete is a use-after-free
+    * that presents as an empty echo, not a crash. */
+   char subject[256];
+   snprintf(subject, sizeof(subject), "%s", jsub->valuestring);
    cJSON_Delete(body);
    if (rc != KB_CLIENT_GRANT_OK)
       return grant_status(rc, resp, cap);
@@ -115,6 +120,12 @@ int rh_grant_set(const route_req_t *rq, char *resp, int cap)
    if (change.had_previous)
       cJSON_AddStringToObject(out, "previous_tier", change.previous_tier);
    cJSON_AddBoolToObject(out, "is_member", change.is_member);
+   /* Echo what this grant was for. is_member=false means the grant does nothing
+    * until the subject joins, and the remedy is a command on another binary that
+    * needs exactly these two values; without them the client can only gesture at
+    * it. Additive — an older client ignores them. */
+   cJSON_AddNumberToObject(out, "team_id", (double)team_id);
+   cJSON_AddStringToObject(out, "subject", subject);
    char *text = cJSON_PrintUnformatted(out);
    int n = text ? snprintf(resp, (size_t)cap, "%s", text) : -1;
    free(text);

--- a/src/server/server_runner_endpoints.c
+++ b/src/server/server_runner_endpoints.c
@@ -2,6 +2,7 @@
  * (was server_runner_endpoints.inc, textually included only to stay under the
  * line-check ceiling). Cross-TU declarations live in the module header. */
 #include "server_state_internal.h"
+#include "workspace_scan_indexed.h"
 #include "aimee.h"
 #include "server.h"
 #include "dashboard.h"
@@ -247,10 +248,7 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          if (rc != 0 || res.skipped)
             jo_add_str(p, "reason", res.reason[0] ? res.reason : "knowledge service unavailable");
          else
-            jo_add_str(p, "reason",
-                       "knowledge service saw no files at that path — it may not be able to "
-                       "read it (aimee-kb runs in its own container and does not share the "
-                       "server's filesystem)");
+            jo_add_str(p, "reason", WORKSPACE_SCAN_EMPTY_REASON);
       }
       cJSON_AddItemToArray(arr, p);
    }

--- a/src/server/server_workspace_scan.c
+++ b/src/server/server_workspace_scan.c
@@ -10,17 +10,11 @@
  * where nothing had been indexed at all. */
 
 #include "server_state_internal.h"
+#include "workspace_scan_indexed.h"
 
 int server_workspace_scan_indexed(int rc, int skipped, int inspected, int files)
 {
-   if (rc != 0 || skipped)
-      return 0;
-   /* `inspected` is the right test, not `files`: a project already indexed and
-    * unchanged legitimately reports files == 0 with inspected > 0, and calling
-    * that "not indexed" would be its own wrong answer. inspected == 0 means kb
-    * saw no files to consider. Older kb builds do not report inspected
-    * (documented as 0), so fall back to files rather than calling a working
-    * older kb broken. */
-   int visited = inspected > 0 ? inspected : files;
-   return visited > 0;
+   /* The rule itself lives in workspace_scan_indexed.h so the CLI reaches the
+    * same verdict without linking the server. */
+   return workspace_scan_indexed(rc, skipped, inspected, files);
 }

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -705,6 +705,17 @@ int kb_client_health(kb_health_t *out)
    return -1;
 }
 
+/* server.health also reports the kb transport breaker, so an operator can see
+ * that calls are being refused locally while the kb itself looks fine. Same
+ * reasoning as above: report a closed breaker without linking the kb client. */
+void kb_client_dependency_health(kb_client_dependency_health_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   snprintf(out->state, sizeof(out->state), "closed");
+}
+
 int handle_kb_build(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "kb.build");

--- a/src/tests/test_workspace_scan_indexed.c
+++ b/src/tests/test_workspace_scan_indexed.c
@@ -11,6 +11,7 @@
  * nothing anywhere reports a failure. */
 
 #include "server_state_internal.h"
+#include "workspace_scan_indexed.h"
 #include <assert.h>
 #include <stdio.h>
 
@@ -37,6 +38,22 @@ int main(void)
    assert(server_workspace_scan_indexed(-1, 0, 99, 99) == 0); /* rc wins over counts */
    assert(server_workspace_scan_indexed(0, 1, 0, 0) == 0);
    assert(server_workspace_scan_indexed(0, 1, 99, 99) == 0); /* skipped wins too */
+
+   /* `workspace add` and `index scan` must reach the SAME verdict about the same
+    * scan. They did not: add warned that kb had seen no files while scan printed
+    * a bare "Scan complete: 1 project(s), 0 file(s) re-indexed", so one broken
+    * state read as a failure through one command and a success through the
+    * other. The rule now lives in a shared header that both link; this pins that
+    * the server entry point is that rule and not a second copy of it. */
+   for (int rc = -1; rc <= 0; rc++)
+      for (int skipped = 0; skipped <= 1; skipped++)
+         for (int inspected = 0; inspected <= 3; inspected++)
+            for (int files = 0; files <= 3; files++)
+               assert(server_workspace_scan_indexed(rc, skipped, inspected, files) ==
+                      workspace_scan_indexed(rc, skipped, inspected, files));
+
+   /* The one sentence both surfaces show must actually say what to look at. */
+   assert(WORKSPACE_SCAN_EMPTY_REASON[0] != '\0');
 
    printf("workspace scan indexed: ok\n");
    return 0;


### PR DESCRIPTION
Four defects found while standing up a fresh managed install and driving it headlessly. Each one is a case where aimee knew something was wrong and did not say so, or said so without naming what to do about it. All four are verified against a live managed deployment, not just unit-tested.

## 1. `index scan` reported success having indexed nothing

Reproduced on a managed stack, where `aimee-kb` mounts the workspace read-only and reads it as uid 1000. Give it a tree owned by root:

```
$ aimee index scan emptyproj /var/lib/aimee-workspaces/emptyproj --force
==> Scan complete: 1 project(s), 0 file(s) re-indexed
```

That reads as done. Nothing is indexed, every later query returns nothing, and no command says why. `chown -R 1000:1000` fixes it instantly — if you know to try it.

The uncomfortable part is that **`workspace add` already got this right** on the same tree:

```
probe (not indexed: knowledge service saw no files at that path — it may not be
able to read it (aimee-kb runs in its own container and does not share the
server's filesystem))
```

So one broken state read as a failure through one command and a success through the other. The verdict lived in `server_workspace_scan_indexed()`, which the CLI could not reach — it sits behind `server_state_internal.h`.

The rule and the sentence now live in `src/headers/workspace_scan_indexed.h`, which both link. `server_workspace_scan_indexed()` delegates to it, so there is still exactly one implementation, and the scan output warns:

```
==> Scan complete: 1 project(s), 0 file(s) re-indexed
    warning: nothing was indexed — knowledge service saw no files at that path — it
    may not be able to read it (aimee-kb runs in its own container and does not
    share the server's filesystem)
```

## 2. `kb grant set` reported a grant that does nothing as created

```
$ aimee kb grant set --server <id> --team 1 --subject cert:CN=x:deadbeef --tier data
warning: the subject is not a member of this team; the grant has no effect until they join
grant created
```

The warning is correct and the grant really is written — but membership is a separate command, on a *different binary* (`aimee-kb`, not `aimee`), which `aimee kb grant` does not offer and which `docs/UPGRADING.md`'s grant section does not mention. This codebase already treats naming the remedy as the point of a refusal (see the write-tier 403); this one did not.

`grant.set` now echoes `team_id` and `subject` (additive; an older client ignores them) so the warning can print the exact command:

```
warning: the subject is not a member of this team; the grant has no effect until they join
  join with: aimee-kb team add-member 1 'cert:CN=nobody-CA:deadbeef'
```

The client falls back to `<team-id>`/`<subject>` placeholders against a server that does not echo them, rather than printing a command with empty arguments.

## 3. `self-update` against a dev/branch server left you with no path

```
client v0.2.195-1003-g627c1ffc, server reports 'testing-29a72a4'
The server reports a non-semver (dev/branch) version, so drift cannot be compared.
```

Refusing to fetch is right — a dev build has no release. But "drift cannot be compared" is true only of *ordering*. Whether the two agree is the question actually being asked, and it is answerable by comparing the build strings.

This is not hypothetical: a client silently ran four days behind its server on a `:testing` deployment and lost a route the server had already gained. `marshal_index_find` in the old client dropped `--scope` entirely, so `index find --scope all` reproduced the *identical* `scope_required` error the message told you to fix it with. It presented as a server bug.

Now:

```
client v0.3.0, server reports 'testing-b7cee3a'
The server reports a non-semver (dev/branch) version, so there is no release to fetch.
Client and server are DIFFERENT builds, so this client may be missing routes the server already has.
On a dev/branch deployment the client ships inside the server image, so align it from
there rather than from a release:
  docker cp <server-container>:/usr/local/bin/aimee ~/.local/bin/aimee
Or target a specific release with `aimee self-update --version vX.Y.Z`.
```

Matching builds print `Client and server are the same build; nothing to do.`

## 4. `server.health` called the kb "ok" while every query was being refused

`server_health_add_kb()` answered "is the kb process up", then returned early. With the transport breaker open, every call is refused locally and the kb is never contacted — and status still said:

```
{"state":"ok","kb":{"status":"ok","store_ok":true,"vectors_ok":true,...}}
```

while every lookup failed. `server_ready.c` already computes `breaker_state` and even names a `kb_breaker` failed boundary, so the answer existed; it just was not on the surface anyone watches. I spent hours on exactly this last night with `aimee status` open in front of me.

The kb block now carries `transport_state` always, plus `queries_suppressed`, `retry_after_ms` and `suppressed_calls` when open, and `aimee status` leads with it:

```
aimee-kb: ok
  QUERIES SUPPRESSED: the transport breaker is open, so kb calls are being
  refused locally without reaching the kb.
  next retry in 4000ms; see the server log for the cause.
```

`status` keeps its existing "is the process up" semantics, so nothing branching on it changes.

## Verification

Against a live managed deployment (fresh LXC, full authority + identity bootstrap):

- **1** — reproduced with a deliberately root-owned tree; the warning fires. ✅
- **2** — grant for a non-member prints the copy-pasteable `team add-member` line with the real subject. ✅
- **3** — fixed client against a server reporting `testing-b7cee3a`; the DIFFERENT-builds branch and remedy print. ✅
- **4** — `transport_state: "closed"` present in `aimee --json status`. The suppressed-path fields are exercised by the code path but were **not** observed with a genuinely open breaker, since I could not reproduce one on demand. Flagging that honestly.

**A bug this PR's own testing caught:** the first cut of #2 read `jsub->valuestring` *after* `cJSON_Delete(body)` — a use-after-free that presents as an empty echo rather than a crash. The live test showed `join with: aimee-kb team add-member 1 '<subject>'`, which is how it was found. The subject is now copied before the body is freed.

`make -C src lint` — all 40 checks pass. Full `unit-tests` suite green.

`test_workspace_scan_indexed` gains a cross-check that `server_workspace_scan_indexed()` and the shared inline agree across the whole input matrix, so the two surfaces cannot drift apart again. Verified red-before-green: reintroducing a second copy of the rule (`files > 0`) fails the suite at the already-indexed-and-unchanged case.

`test_server_dispatch` needed a `kb_client_dependency_health` stub, matching the existing `kb_client_health` stub beside it — the dispatch test deliberately does not link the kb client.
