### PR TITLE
kb: close the unauthenticated plain listener, end to end

### DIFF
--- a/scripts/aimee-compose-vault-bootstrap.sh
+++ b/scripts/aimee-compose-vault-bootstrap.sh
@@ -4,11 +4,12 @@
 set -eu
 
 usage() {
-    printf 'usage: %s -f COMPOSE_FILE {server|kb|all}\n' "$0" >&2
+    printf 'usage: %s [-p PROJECT] -f COMPOSE_FILE {server|kb|all}\n' "$0" >&2
     exit 2
 }
 
 compose_file=
+project=
 while [ "$#" -gt 0 ]; do
     case "$1" in
         -f|--file)
@@ -20,6 +21,11 @@ while [ "$#" -gt 0 ]; do
             shift
             break
             ;;
+        -p|--project)
+            [ "$#" -ge 2 ] || usage
+            project=$2
+            shift 2
+            ;;
         -*) usage ;;
         *) break ;;
     esac
@@ -28,11 +34,50 @@ done
 [ "$#" -eq 1 ] || usage
 target=$1
 
+# Seal into the project the deployment ACTUALLY uses.
+#
+# `docker compose -f FILE` derives the project name from the directory holding
+# FILE, not from where the operator runs the stack. A deployment brought up as
+# project "aimee" from a file under deploy/container/ is project "container"
+# here — so the credential is sealed into an orphan volume the long-lived
+# service never reads, and this script still prints "Vault bootstrap complete".
+# That happened: a kb was left with no bearer after a seal that reported success.
+#
+# If a project is already running this compose file, use it. Otherwise fall back
+# to compose's own default, which is correct for a first install (the stack is
+# started the same way straight after). An explicit -p always wins, and
+# COMPOSE_PROJECT_NAME is honoured by compose itself.
+if [ -z "$project" ] && [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
+    running=$(docker compose -f "$compose_file" ls --format json 2>/dev/null \
+        | tr ',' '\n' | sed -n 's/.*"Name":"\([^"]*\)".*/\1/p' | sort -u)
+    count=$(printf '%s' "$running" | grep -c . || true)
+    if [ "$count" -gt 1 ]; then
+        printf 'error: several compose projects use %s:\n%s\nre-run with -p PROJECT.\n' \
+            "$compose_file" "$running" >&2
+        exit 2
+    fi
+    [ "$count" -eq 1 ] && project=$running
+fi
+
 compose() {
-    docker compose -f "$compose_file" "$@"
+    if [ -n "$project" ]; then
+        docker compose -p "$project" -f "$compose_file" "$@"
+    else
+        docker compose -f "$compose_file" "$@"
+    fi
+}
+
+announce_project() {
+    if [ -n "$project" ]; then
+        printf 'Sealing into compose project %s (verify: docker compose -p %s ps).\n' \
+            "$project" "$project"
+    else
+        printf '%s\n' 'Sealing into the default compose project for this file (no running project found).'
+    fi
 }
 
 bootstrap_server() {
+    announce_project
     printf '%s\n' 'Sealing server first-boot credentials into Vault (values are not logged or stored in container metadata).'
     env -0 | compose run --rm --no-deps -T \
         --entrypoint /usr/sbin/runuser aimee-server \
@@ -40,6 +85,7 @@ bootstrap_server() {
 }
 
 bootstrap_kb() {
+    announce_project
     printf '%s\n' 'Sealing KB first-boot credentials into Vault (values are not logged or stored in container metadata).'
     env -0 | compose run --rm --no-deps -T \
         --entrypoint /usr/local/bin/aimee-kb aimee-kb \

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -641,6 +641,22 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
     * "scope:<kind>:<id>:<secret>") and yields the verified scope. Per verify-then-trust, the
     * cross-scope check uses that verified scope, never the caller's. `vr` is function-scoped so
     * owner-only routes (e.g. /v1/enroll) tell an unscoped owner credential from a scoped one. */
+   /* The container healthcheck must keep working once a bearer is sealed. It is
+    * a LOOPBACK GET of /v1/health with no query string, from inside the
+    * container, and presents no credential — it cannot, since the bearer lives
+    * in the Vault.
+    *
+    * The exemption is deliberately three conditions, not one. /v1/health also
+    * answers ?status=1&project=<p>, whose scope is enforced against the CLIENT
+    * CERTIFICATE, so a cross-scope query must still be refused (test_mtls_serve);
+    * and a wrong bearer on /v1/health must still be 401 for any non-local caller
+    * (test_scope_token_secret_auth). An unknown peer is not local, so a direct
+    * router call — every unit test, and the mTLS listener — is never exempt. */
+   int local_liveness_probe = (strcmp(method, "GET") == 0 || strcmp(method, "HEAD") == 0) &&
+                              strcmp(path, "/v1/health") == 0 &&
+                              (!query_string || !query_string[0]) &&
+                              kb_login_throttle_peer_is_loopback();
+
    kb_verify_result_t vr;
    memset(&vr, 0, sizeof(vr));
    /* Reset any prior request's actor on this worker thread; a request that fails
@@ -650,7 +666,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
    /* No owner actor is manufactured in auth-off mode: the tenancy mutation routes
     * require a real authenticated principal, so an auth-off deployment cannot make
     * anonymous admin writes. */
-   if (bearer_token && bearer_token[0])
+   if (!local_liveness_probe && bearer_token && bearer_token[0])
    {
       const char *presented =
           (auth_header && strncmp(auth_header, "Bearer ", 7) == 0) ? auth_header + 7 : "";

--- a/src/kb/http/kb_http_listener.c
+++ b/src/kb/http/kb_http_listener.c
@@ -4,6 +4,8 @@
 #include "db2/db2.h"
 #include "kb/kb_login_throttle.h"
 #include "log.h"
+#include <sys/stat.h>
+#include "kb_paths.h"
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -178,6 +180,63 @@ static void *listener_thread(void *arg)
    return NULL;
 }
 
+/* Marker recording that this deployment has had a kb bearer. Written the first
+ * time one is present; its existence turns a later missing bearer from a
+ * warning into a refusal. Best-effort: if it cannot be written we degrade to
+ * warning rather than refusing to serve. */
+static void bearer_marker_path(char *out, size_t n)
+{
+   snprintf(out, n, "%s/kb-bearer-sealed", kb_default_config_dir());
+}
+
+/* Warn while this deployment has never been sealed; refuse once it has.
+ * Returns 0 to continue binding, -1 to refuse. */
+static int enforce_bearer_ratchet(int port)
+{
+   char marker[MAX_PATH_LEN];
+   bearer_marker_path(marker, sizeof(marker));
+
+   if (g_bearer_token[0])
+   {
+      /* Sealed. Record it so a later boot without a bearer is a hard failure. */
+      struct stat st;
+      if (stat(marker, &st) != 0)
+      {
+         int fd = open(marker, O_WRONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0600);
+         if (fd >= 0)
+         {
+            close(fd);
+            LOG_INFO("kb_http",
+                     "kb bearer present; recorded %s — a later boot without a bearer "
+                     "will now refuse to bind a non-loopback plain listener",
+                     marker);
+         }
+      }
+      return 0;
+   }
+
+   struct stat st;
+   if (stat(marker, &st) == 0)
+   {
+      LOG_ERROR("kb_http",
+                "refusing to bind 0.0.0.0:%d: this deployment was sealed with a kb bearer (%s "
+                "exists) but none is configured now, so every privileged route would answer "
+                "unauthenticated. Re-seal AIMEE_KB_API_BEARER_TOKEN through the first-boot Vault "
+                "bootstrap, or remove that marker to deliberately return to an unauthenticated "
+                "listener.",
+                port, marker);
+      return -1;
+   }
+
+   LOG_ERROR("kb_http",
+             "binding 0.0.0.0:%d with NO bearer configured: this socket serves privileged routes "
+             "unauthenticated to anything that can reach it. Seal a kb bearer "
+             "(AIMEE_KB_API_BEARER_TOKEN, through the first-boot Vault bootstrap), or unset "
+             "AIMEE_KB_HTTP_BIND to keep the plain listener on loopback.",
+             port);
+   return 0;
+}
+
 int kb_http_start(int port, const char *bearer_token)
 {
    if (port <= 0)
@@ -205,13 +264,25 @@ int kb_http_start(int port, const char *bearer_token)
     * credentials at all returned 200 with stored memory, to anything that could
     * route to the container. Fail closed instead: a non-loopback bind requires a
     * bearer. The mTLS listener is unaffected — it authenticates by certificate. */
-   if (baddr == INADDR_ANY && !g_bearer_token[0])
-      LOG_ERROR("kb_http",
-                "binding 0.0.0.0:%d with NO bearer configured: this socket serves privileged "
-                "routes unauthenticated to anything that can reach it. Seal a kb bearer "
-                "(AIMEE_KB_API_BEARER_TOKEN, first-boot -> Vault), or unset AIMEE_KB_HTTP_BIND to "
-                "keep the plain listener on loopback.",
-                port);
+   /* Auth is enforced only when a bearer is configured (kb_http.c gates on a
+    * non-empty bearer). With none, this socket answers every route
+    * unauthenticated — fine for the loopback default, not fine once it is
+    * reachable off-host.
+    *
+    * Ratchet rather than a flat refusal. A flat refusal would break every
+    * deployment that has not been sealed yet, which today is all of them; a flat
+    * warning would let a sealed deployment silently lose its bearer and reopen
+    * the hole. So: warn while a deployment has never been sealed, and refuse
+    * once it has. The marker is written the first time a bearer is present, and
+    * lives beside the rest of the kb's state so it persists exactly as long as
+    * the vault it corresponds to. */
+   if (baddr == INADDR_ANY && enforce_bearer_ratchet(port) != 0)
+   {
+      close(g_listen_fd);
+      g_listen_fd = -1;
+      return -1;
+   }
+
    struct sockaddr_in sa;
    memset(&sa, 0, sizeof(sa));
    sa.sin_family = AF_INET;

--- a/src/kb/kb_login_throttle.c
+++ b/src/kb/kb_login_throttle.c
@@ -1,6 +1,7 @@
 /* kb_login_throttle.c — see kb_login_throttle.h. */
 
 #include "kb_login_throttle.h"
+#include "cleartext_guard.h" /* one shared definition of "loopback" */
 
 #include <pthread.h>
 #include <stdint.h>
@@ -266,6 +267,14 @@ static const char *peer_or_unknown(void)
 void kb_login_throttle_set_peer(const char *peer_ip)
 {
    snprintf(g_peer_ip, sizeof(g_peer_ip), "%s", peer_ip ? peer_ip : "");
+}
+
+int kb_login_throttle_peer_is_loopback(void)
+{
+   /* Same loopback rule the credential guards use, so "local" means one thing
+    * across the codebase. An empty peer is NOT local: a caller we could not
+    * identify must not get the local exemption. */
+   return g_peer_ip[0] ? cleartext_host_is_loopback(g_peer_ip) : 0;
 }
 
 /* A negative clock is not a real time; treat it as the epoch rather than letting

--- a/src/kb/kb_login_throttle.h
+++ b/src/kb/kb_login_throttle.h
@@ -54,6 +54,13 @@ extern "C"
     * single shared bucket rather than as "no limit". */
    void kb_login_throttle_set_peer(const char *peer_ip);
 
+   /* 1 when the peer for the request being served is loopback, 0 otherwise
+    * (including when no peer was recorded — an unknown peer is never treated as
+    * local). The plain listener records the peer for every accepted connection;
+    * callers that reach the router directly, and the mTLS listener, leave it
+    * unset and are therefore never considered local. */
+   int kb_login_throttle_peer_is_loopback(void);
+
    /* May this attempt proceed? Returns 0 to allow, or a POSITIVE Retry-After in
     * seconds to refuse. Checks the peer budget and the username budget and
     * returns the longer wait of the two. Purely a query — it records nothing, so


### PR DESCRIPTION
Closes the hole #2248 documented but deliberately left open.

## Problem

The kb enforces auth only when a bearer is configured (`kb_http.c` gates on a non-empty bearer), nothing configured one, and the plain listener binds the **container network** rather than loopback:

```
POST /v1/actions/memory.find_facts     (no credentials at all)
-> 200, with stored memory facts
```

Anything able to route to the container could read the knowledge base.

## Provisioning needed no new code

`scripts/aimee-compose-vault-bootstrap.sh` already seals first-boot credentials into the Vault, and `vault_env_bootstrap` already classifies `AIMEE_KB_API_BEARER_TOKEN` by its `_TOKEN` suffix:

```
INFO vault.env: sealed 1 first-boot credential environment value(s)
```

The earlier attempt in #2248 to put the credential in the compose services was both **wrong** (`build-integrity`: *container definitions persist credentials outside Vault*) and **redundant**.

Three changes make that existing provisioning actually usable.

### 1. The helper seals into the project the deployment actually uses

`docker compose -f FILE` derives the project name from the **directory holding FILE**, not from where the stack runs. Sealing against a file under `deploy/container/` wrote to project `container` while the stack ran as `aimee` — an orphan volume the live kb never reads — and still printed *"Vault bootstrap complete."*

That is not hypothetical; both volumes exist on my test host after I hit it:

```
aimee_aimee-managed-kb-home        <- the real one
container_aimee-managed-kb-home    <- where the first seal went
```

It now asks compose which project is running that file and seals there, announces the choice, refuses when several match, and accepts `-p/--project`.

### 2. The container healthcheck keeps working

The healthcheck is a **loopback** `GET /v1/health` with **no query** and **no credential** — it cannot have one, the bearer lives in the Vault. The exemption is those three conditions together, not the path alone, because:

- `/v1/health` also answers `?status=1&project=<p>`, whose scope is enforced against the **client certificate** — a cross-scope query must still be refused (`test_mtls_serve`)
- a wrong bearer must still be `401` for any non-local caller (`test_scope_token_secret_auth`)

An unknown peer is never "local", so direct router calls (every unit test) and the mTLS listener are never exempt. A blanket path exemption broke **both** of those tests — that is how the constraint was found.

### 3. A ratchet, not a flat refusal

Refusing to bind without a bearer would break every deployment not yet sealed — today, all of them. A bare warning would let a sealed deployment silently lose its bearer and reopen the hole. So: **warn while never sealed → record a marker on first seal → refuse once the marker exists and the bearer is gone.** Deleting the marker is the documented way back.

## Verification

All on a **disposable stack** (dedicated LXC, own server + kb). Production was never used.

Auth matrix, on the code in this PR, container healthy:

```
loopback health noauth : 200    healthcheck works
remote   health noauth : 401
remote   action noauth : 401    the hole, closed
remote   action w/auth : 200    server<->kb intact
```

Ratchet, all three states:

```
1. never sealed        -> WARN, starts, Up (healthy)
2. sealed              -> "recorded /var/lib/aimee/kb-bearer-sealed"
3. sealed, bearer gone -> "refusing to bind 0.0.0.0:8741: this deployment was
                          sealed with a kb bearer ... but none is configured now"
```

Helper auto-detection, with nothing pinned:

```
Sealing into compose project aimee (verify: docker compose -p aimee ps)
-> restart -> loopback 200 / remote noauth 401 / remote w/auth 200
```

`make lint` 40/40; `check-vault-only-container-env` ok; `unit-test-kb-http-routes` and `unit-test-kb-http-client` pass on the build toolchain.

## Note for deployment

Existing deployments are unaffected until sealed — they warn and keep running. To close the hole on one: export `AIMEE_KB_API_BEARER_TOKEN`, run the bootstrap helper against the deployment's compose file, unset it, restart the kb. From then on the ratchet holds it closed.
