### PR TITLE
deploy: mint and seal the kb bearer on first install

### DIFF
--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -30,6 +30,7 @@ extern char **environ;
 #define DEPLOY_OUT_CAP         8192                    /* tail of compose output kept for the UI */
 #define DEPLOY_LLM_TOKEN_FILE  ".managed-kb-llm-token" /* legacy migration only */
 #define DEPLOY_LLM_TOKEN_HEX   64                      /* 256-bit opaque bearer */
+#define DEPLOY_KB_BEARER_HEX   64                      /* 256-bit opaque kb bearer */
 
 /* Background-deploy state (one at a time; the wizard drives a single stack). */
 static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -166,6 +167,38 @@ static int deploy_llm_token(char *out, size_t cap)
    if (platform_random_hex(proposed, DEPLOY_LLM_TOKEN_HEX) != 0)
       return -1;
    if (vault_runtime_secret_set("AIMEE_LLM_AUTH_TOKEN", proposed) != 0)
+   {
+      runtime_secret_wipe(proposed, sizeof(proposed));
+      return -1;
+   }
+   snprintf(out, cap, "%s", proposed);
+   runtime_secret_wipe(proposed, sizeof(proposed));
+   return 0;
+}
+
+/* The kb bearer, minted once and persisted on first deploy.
+ *
+ * Without this the kb serves every privileged route unauthenticated: auth is
+ * enforced only when a bearer is configured, and nothing configured one. Leaving
+ * that to a documented manual step means every new install ships open, so the
+ * wizard mints it here and seals it on both sides — the server's own Vault via
+ * vault_runtime_secret_set (the server sends this bearer), and the KB's Vault
+ * through the first-boot bootstrap below (the KB requires it).
+ *
+ * Mint-once: an already-sealed value is reused, so re-running a deploy does not
+ * rotate the credential out from under a running KB. */
+static int deploy_kb_bearer(char *out, size_t cap)
+{
+   if (!out || cap < DEPLOY_KB_BEARER_HEX + 1)
+      return -1;
+   out[0] = '\0';
+   if (runtime_secret_get("AIMEE_KB_API_BEARER_TOKEN", out, cap) && out[0])
+      return 0;
+
+   char proposed[DEPLOY_KB_BEARER_HEX + 1];
+   if (platform_random_hex(proposed, DEPLOY_KB_BEARER_HEX) != 0)
+      return -1;
+   if (vault_runtime_secret_set("AIMEE_KB_API_BEARER_TOKEN", proposed) != 0)
    {
       runtime_secret_wipe(proposed, sizeof(proposed));
       return -1;
@@ -654,19 +687,45 @@ static void *deploy_worker(void *arg)
       /* The server is already running this worker. Start KB next and LLM last.
        * Model downloads continue inside the LLM container after this deploy
        * finishes; KB initialization and CPU indexing do not wait for them. */
-      if (managed_kb && managed_llm)
+      /* Seal the KB's first-boot credentials. Runs whenever the KB is managed:
+       * the kb bearer must be sealed even on a deploy with no managed LLM, or
+       * the KB comes up serving every privileged route unauthenticated. The
+       * record is NUL-separated, matching the `env -0` the bootstrap reads. */
+      if (managed_kb)
       {
-         const char *token = deploy_env_value(envp, "AIMEE_LLM_AUTH_TOKEN");
-         char record[sizeof("AIMEE_LLM_AUTH_TOKEN=") + 512];
-         int record_len =
-             token ? snprintf(record, sizeof(record), "AIMEE_LLM_AUTH_TOKEN=%s", token) : -1;
+         char kb_bearer[DEPLOY_KB_BEARER_HEX + 1] = "";
+         int have_kb_bearer = deploy_kb_bearer(kb_bearer, sizeof(kb_bearer)) == 0;
+         const char *token = managed_llm ? deploy_env_value(envp, "AIMEE_LLM_AUTH_TOKEN") : NULL;
+
+         char record[1024];
+         size_t record_len = 0;
+         int record_ok = 1;
+         if (managed_llm)
+         {
+            int n = token ? snprintf(record, sizeof(record), "AIMEE_LLM_AUTH_TOKEN=%s", token) : -1;
+            if (n <= 0 || (size_t)n >= sizeof(record))
+               record_ok = 0;
+            else
+               record_len = (size_t)n + 1; /* keep the NUL: it separates entries */
+         }
+         if (record_ok && have_kb_bearer)
+         {
+            int n = snprintf(record + record_len, sizeof(record) - record_len,
+                             "AIMEE_KB_API_BEARER_TOKEN=%s", kb_bearer);
+            if (n <= 0 || (size_t)n >= sizeof(record) - record_len)
+               record_ok = 0;
+            else
+               record_len += (size_t)n + 1;
+         }
+         runtime_secret_wipe(kb_bearer, sizeof(kb_bearer));
+
          const char *bootstrap_argv[16];
          int bootstrap_code = -1;
          used = strlen(out);
-         if (record_len <= 0 || (size_t)record_len >= sizeof(record) ||
+         if (!record_ok || record_len == 0 || !have_kb_bearer ||
              deploy_kb_vault_bootstrap_argv(
                  file, bootstrap_argv, sizeof(bootstrap_argv) / sizeof(bootstrap_argv[0])) < 0 ||
-             run_capture_input(bootstrap_argv, envp, record, (size_t)record_len + 1, out + used,
+             run_capture_input(bootstrap_argv, envp, record, record_len, out + used,
                                sizeof(out) - used, &bootstrap_code) != 0 ||
              bootstrap_code != 0)
          {
@@ -674,7 +733,7 @@ static void *deploy_worker(void *arg)
             used = strlen(out);
             if (used < sizeof(out) - 1)
                snprintf(out + used, sizeof(out) - used,
-                        "deploy: failed to seal the managed LLM credential into the KB Vault\n");
+                        "deploy: failed to seal the KB first-boot credentials into the KB Vault\n");
          }
          memset(record, 0, sizeof(record));
       }

--- a/src/tests/test_deploy_apply.c
+++ b/src/tests/test_deploy_apply.c
@@ -93,6 +93,39 @@ static int envp_key_count(char **envp, const char *key)
    return count;
 }
 
+/* The kb bearer must exist after a managed deploy: auth is enforced only when
+ * one is configured, so a deploy that mints nothing leaves the kb serving every
+ * privileged route unauthenticated. It must also be minted ONCE — a re-apply
+ * that rotated it would leave a running kb holding a bearer the server no
+ * longer sends. */
+static void test_managed_kb_bearer_minted_once(void)
+{
+   char tmp[] = "/tmp/aimee-deploy-kb-bearer-XXXXXX";
+   assert(mkdtemp(tmp) != NULL);
+   assert(setenv("AIMEE_HOME", tmp, 1) == 0);
+   runtime_secret_remove("AIMEE_KB_API_BEARER_TOKEN");
+   unsetenv("AIMEE_KB_API_BEARER_TOKEN");
+
+   g_stub_random_hex = 'c';
+   char first[DEPLOY_KB_BEARER_HEX + 1] = "";
+   assert(deploy_kb_bearer(first, sizeof(first)) == 0);
+   assert(strlen(first) == DEPLOY_KB_BEARER_HEX);
+   for (size_t i = 0; i < DEPLOY_KB_BEARER_HEX; i++)
+      assert(first[i] == 'c');
+
+   /* Re-apply reads the sealed value instead of rotating it. */
+   g_stub_random_hex = 'd';
+   char second[DEPLOY_KB_BEARER_HEX + 1] = "";
+   assert(deploy_kb_bearer(second, sizeof(second)) == 0);
+   assert(strcmp(first, second) == 0);
+
+   /* A buffer too small to hold the credential is refused, never truncated. */
+   char tiny[8];
+   assert(deploy_kb_bearer(tiny, sizeof(tiny)) == -1);
+
+   runtime_secret_remove("AIMEE_KB_API_BEARER_TOKEN");
+}
+
 static void test_managed_llm_service_credential(void)
 {
    char tmp[] = "/tmp/aimee-deploy-llm-token-XXXXXX";
@@ -448,6 +481,7 @@ int main(void)
 {
    printf("test_deploy_apply\n");
    test_managed_llm_service_credential();
+   test_managed_kb_bearer_minted_once();
    test_deploy_argv_is_orderable_and_has_no_remove_orphans();
    test_managed_kb_credential_bootstrap_is_stdin_only();
    test_managed_identity_bootstrap_runs_inside_kb_without_secret_argv();


### PR DESCRIPTION
Stacked on #2250 — review that first; this PR is the last commit only.

## Problem

#2250 makes the kb bearer *possible* to provision safely. It does not make it *happen*. Closing the hole still depended on an operator reading a note and running a helper by hand, which means **every new install ships open**.

## Fix

The wizard's deploy already seals the managed LLM credential into the KB Vault through the disposable bootstrap helper. Mint the kb bearer the same way, using the primitives already in that file a few lines above (`platform_random_hex`, `vault_runtime_secret_set`), and seal it on **both** sides:

- the **server's** Vault — the server sends this bearer
- the **KB's** Vault, through the bootstrap — the KB requires it

Two behaviours worth naming:

**Mint once.** An already-sealed value is reused, so re-applying a deploy does not rotate the credential out from under a running kb. Same rule the LLM token follows; the test asserts it.

**Seal whenever the KB is managed, not only when an LLM is too.** The previous block ran under `managed_kb && managed_llm`. A deploy with a managed KB and no managed LLM would skip the bootstrap entirely and leave the kb with no bearer at all — the exact case this PR exists to prevent.

## Verification

`unit-test-deploy-apply` passes on the build toolchain, including the new case:

```
test_deploy_apply: all passed
```

covering: a bearer is minted and is the full 64 hex chars; a second deploy **reuses** it rather than rotating; and a buffer too small to hold the credential is refused rather than truncated.

`make lint` 40/40. Compiles clean under `-Wall -Wextra -Werror`.

## Net effect, with #2250

| | before | after |
|---|---|---|
| fresh install | kb serves privileged routes unauthenticated | authenticated by default |
| existing install | unauthenticated | warns until sealed, then ratcheted closed |
| bearer lost after sealing | silently reopens | refuses to bind |
