### PR TITLE
fix: resolve cwd to a project that is actually indexed

### DIFF
--- a/src/server/server_active_project.c
+++ b/src/server/server_active_project.c
@@ -86,14 +86,43 @@ int server_active_project_from_cwd(const char *cwd, char *out, size_t outlen)
    if (!cwd || !cwd[0] || !out || outlen == 0)
       return -1;
 
-   /* Co-located caller: the working tree is readable here, so keep the durable
-    * repo identity exactly as before. */
-   if (workspace_repo_identity(cwd, out, outlen, NULL, 0) == 0 && out[0])
-      return 0;
-   out[0] = '\0';
+   /* Co-located caller: the working tree is readable here, so prefer the durable
+    * repo identity. */
+   char identity[MAX_PATH_LEN] = "";
+   int have_identity =
+       workspace_repo_identity(cwd, identity, sizeof(identity), NULL, 0) == 0 && identity[0];
 
    project_info_t projects[128];
    int count = kb_client_index_list(projects, (int)(sizeof(projects) / sizeof(projects[0])));
+
+   /* An identity is only useful if it NAMES SOMETHING INDEXED. `index scan <name>
+    * <root>` lets a caller name the project, while this resolution returns the
+    * repo's persisted identity — a UUID for a repo with no remote. The two need
+    * not agree, and when they disagree every cwd-scoped query silently addressed
+    * a project that does not exist: a freshly scanned workspace answered
+    * "code index lookup failed" while the same lookup with an explicit project
+    * name returned hits. Verify before trusting it, and otherwise fall back to
+    * the registered root, which by construction names a real project. */
+   if (have_identity && count > 0)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         if (strcmp(projects[i].name, identity) != 0)
+            continue;
+         snprintf(out, outlen, "%s", identity);
+         return 0;
+      }
+   }
+   else if (have_identity && count < 0)
+   {
+      /* The project list is unavailable, so the identity cannot be checked.
+       * Returning it unverified preserves the previous behaviour for a
+       * co-located caller rather than failing a lookup that used to work. */
+      snprintf(out, outlen, "%s", identity);
+      return 0;
+   }
+
+   out[0] = '\0';
    if (count <= 0)
       return -1;
    return server_active_project_match(cwd, projects, count, out, outlen);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -651,6 +651,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-mgmt-token \
                $(TESTPREFIX)/unit-test-kb-identity-token \
                $(TESTPREFIX)/unit-test-workspace-scan-indexed \
+               $(TESTPREFIX)/unit-test-server-active-project \
                $(TESTPREFIX)/unit-test-kb-login-throttle \
                $(TESTPREFIX)/unit-test-server-identity-token \
                $(TESTPREFIX)/unit-test-server-write-tier-db1 \
@@ -2148,6 +2149,12 @@ $(TESTPREFIX)/unit-test-kb-mgmt-token: $(OBJDIR)/tests/test_kb_mgmt_token.o \
 
 $(TESTPREFIX)/unit-test-workspace-scan-indexed: $(OBJDIR)/tests/test_workspace_scan_indexed.o \
                                             $(OBJDIR)/server/server_workspace_scan.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
+
+# Resolution order only: the workspace and kb calls are driven from the test, so
+# this links the one TU under test and nothing else.
+$(TESTPREFIX)/unit-test-server-active-project: $(OBJDIR)/tests/test_server_active_project.o \
+                                            $(OBJDIR)/server/server_active_project.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-kb-login-throttle: $(OBJDIR)/tests/test_kb_login_throttle.o \

--- a/src/tests/test_server_active_project.c
+++ b/src/tests/test_server_active_project.c
@@ -12,10 +12,16 @@
 int server_active_project_match(const char *cwd, const project_info_t *projects, int count,
                                 char *out, size_t outlen);
 
+int server_active_project_from_cwd(const char *cwd, char *out, size_t outlen);
+
 /* server_active_project.c's other half calls into the workspace and knowledge
- * modules, which are not in aimee-core. Stub them to the remote-topology answer
- * — the working tree is unreadable here and no projects are listed — so this
- * binary exercises the matcher alone. */
+ * modules, which are not in aimee-core. Drive both from here so the resolution
+ * order itself is testable: what the working tree claims, and what is actually
+ * indexed, are exactly the two inputs whose disagreement caused the bug. */
+static const char *g_identity;         /* NULL => the working tree cannot answer */
+static const project_info_t *g_listed; /* what kb_client_index_list reports */
+static int g_listed_count;             /* negative => the list is unavailable */
+
 int workspace_repo_identity(const char *cwd, char *project_out, size_t project_len,
                             char *workspace_out, size_t workspace_len)
 {
@@ -24,14 +30,20 @@ int workspace_repo_identity(const char *cwd, char *project_out, size_t project_l
    (void)workspace_len;
    if (project_out && project_len)
       project_out[0] = '\0';
-   return -1;
+   if (!g_identity)
+      return -1;
+   snprintf(project_out, project_len, "%s", g_identity);
+   return 0;
 }
 
 int kb_client_index_list(project_info_t *out, int max)
 {
-   (void)out;
-   (void)max;
-   return 0;
+   if (g_listed_count <= 0)
+      return g_listed_count;
+   int n = g_listed_count < max ? g_listed_count : max;
+   for (int i = 0; i < n; i++)
+      out[i] = g_listed[i];
+   return n;
 }
 
 static project_info_t mk(const char *name, const char *root)
@@ -109,6 +121,51 @@ int main(void)
       project_info_t projects[] = {mk("", "/srv/alpha")};
       assert(server_active_project_match("/srv/alpha", projects, 1, out, sizeof(out)) == -1);
       assert(out[0] == '\0');
+   }
+
+   /* ---- resolution order: the working tree vs what is actually indexed ----
+    *
+    * THE BUG: `index scan <name> <root>` names the project, while this
+    * resolution returns the repo's persisted identity — a UUID when the repo has
+    * no remote. Nothing makes those agree. A freshly scanned workspace resolved
+    * to the UUID, queried a project that does not exist, and answered
+    * "code index lookup failed", while the identical lookup with an explicit
+    * project name returned hits. */
+   {
+      project_info_t indexed[] = {mk("settle", "/srv/settle")};
+
+      /* An identity that names a real project still wins: it is the durable one,
+       * and it is what makes a repo resolve to the same project from any host. */
+      g_identity = "settle";
+      g_listed = indexed;
+      g_listed_count = 1;
+      assert(server_active_project_from_cwd("/srv/settle", out, sizeof(out)) == 0);
+      assert(strcmp(out, "settle") == 0);
+
+      /* THE REGRESSION TEST: the identity names nothing indexed, so fall through
+       * to the registered root rather than returning a project that cannot
+       * answer. */
+      g_identity = "3014e417-337b-444f-9aaf-432838cdcf82";
+      assert(server_active_project_from_cwd("/srv/settle/app", out, sizeof(out)) == 0);
+      assert(strcmp(out, "settle") == 0);
+
+      /* No identity at all (the remote-client case) still matches on root. */
+      g_identity = NULL;
+      assert(server_active_project_from_cwd("/srv/settle", out, sizeof(out)) == 0);
+      assert(strcmp(out, "settle") == 0);
+
+      /* Neither source can answer: refuse, so the caller emits scope_required. */
+      g_identity = NULL;
+      g_listed_count = 0;
+      assert(server_active_project_from_cwd("/srv/settle", out, sizeof(out)) == -1);
+      assert(out[0] == '\0');
+
+      /* The list is UNAVAILABLE rather than empty. An unverified identity is
+       * better than failing a lookup that worked before the check existed. */
+      g_identity = "settle";
+      g_listed_count = -1;
+      assert(server_active_project_from_cwd("/srv/settle", out, sizeof(out)) == 0);
+      assert(strcmp(out, "settle") == 0);
    }
 
    printf("test_server_active_project: all assertions passed\n");


### PR DESCRIPTION
`index scan <name> <root>` names the project. cwd resolution returns the repo's **persisted identity** — a UUID when the repo has no remote. Nothing makes those agree.

When they disagree, every cwd-scoped query addresses a project that does not exist:

```
$ aimee index scan settle /var/lib/aimee-workspaces/settle --force
==> Scan complete: 1 project(s), 3 file(s) re-indexed

$ aimee --json index find end_of_month          # from that workspace
{"retryable":true,"dependency":"kb","message":"code index lookup failed..."}

$ aimee --json index callers end_of_month settle # explicit project
{"result_status":"ok","hits":[...]}            # the data was there all along
```

The workspace's persisted identity was `3014e417-337b-444f-9aaf-432838cdcf82`; the index knew the project as `settle`.

This reads as an unreachable knowledge service. It is not: the kb answered the identical query over the server's own mTLS transport with HTTP 200, the transport breaker was `closed`, and `aimee status` reported the kb healthy. It is also why the ponytail benchmark's readiness gate failed with "project-scoped symbol lookup missed app/dates.py" against an index that demonstrably held the symbol.

## Fix

Verify the identity names something indexed before trusting it; otherwise fall back to the registered root, which by construction names a real project. Identity still wins when it is valid — that is what makes a repo resolve to one project from any host.

If the project list is *unavailable* (not merely empty) the identity is returned unverified, so a co-located caller keeps the behaviour it had before this check existed.

## Verification

End to end on a managed deployment, the case that failed:

```
aimee --json index find end_of_month
 -> {"result_status":"ok","hits":[{"project":"verify2","file_path":"app/dates.py",...}]}
aimee --json index callers end_of_month
 -> both call sites, correctly scoped
```

The test now drives both inputs — what the working tree claims and what is indexed — since their disagreement is the bug. Verified red-before-green: restoring the unverified-identity behaviour fails at the fallback assertion.

It was also a CMake-only test, so `make unit-tests` never ran it. Now registered in `Rules.mk`.

All 40 lint checks and the full unit suite pass.