### PR TITLE
ci: publish the bundled-synthesis images to the channel deployments pull

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -3,8 +3,9 @@
 # testing branch can be deployed/validated (e.g. on .254) WITHOUT promoting to
 # main.
 #
-# Builds the split images plus the isolated one-shot authority bootstrap so a
-# managed stack can pull a single coherent `:testing` channel.
+# Builds the split images, the isolated one-shot authority bootstrap, and the two
+# bekko `-llm` variants that carry bundled synthesis, so a managed stack can pull a
+# single coherent `:testing` channel — including one that runs synthesis locally.
 # Versioned + `:latest` publishing of the full image set
 # stays owned by main (auto-release.yml -> publish-images.yml). Keeping testing on
 # a `:testing` tag — never a version number — avoids confusing a tested-but-
@@ -31,6 +32,8 @@ on:
       - "Dockerfile"
       - "Dockerfile.server"
       - "Dockerfile.authority-bootstrap"
+      # Carries the bundled synthesis weights the -llm legs copy from.
+      - "Dockerfile.model"
       - ".github/workflows/publish-testing.yml"
   workflow_dispatch:
 
@@ -42,20 +45,102 @@ permissions:
   contents: read
   packages: write
 
+env:
+  # The quant the -llm images bake, and the TAG of the aimee-model-* images that
+  # carry it. Must match publish-images.yml: both channels share those model
+  # images, and a mismatch here silently re-downloads from Hugging Face.
+  MODEL_QUANT: UD-Q6_K_XL
+
 jobs:
+  # The bundled synthesis weights, as their own image, so the -llm legs below copy
+  # a registry layer instead of pulling ~7.5GB from Hugging Face on every push to
+  # testing. Skips itself when the tag already exists, so a push that changes
+  # neither the model nor the quant fetches nothing.
+  #
+  # BOTH PLATFORMS, even though this channel publishes amd64 only. The payload is
+  # architecture-independent, and if testing published an amd64-only model tag then
+  # the release pipeline's "is it already published?" check would skip it and the
+  # arm64 half of the release matrix would have no model layer to copy.
+  models:
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [gemma-4-E2B-it, gemma-4-E4B-it]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize owner to lowercase
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Is it already published?
+        id: have
+        env:
+          SYNTH: ${{ matrix.model }}
+        run: |
+          # A repository name must be lowercase; a TAG may not be, which is why
+          # only the name half is folded and MODEL_QUANT is left alone.
+          ref="ghcr.io/${OWNER}/aimee-model-${SYNTH,,}:${MODEL_QUANT}"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          if docker manifest inspect "$ref" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "$ref already published; skipping the Hugging Face fetch"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.have.outputs.exists != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push the model image
+        if: steps.have.outputs.exists != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.model
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          tags: ${{ steps.have.outputs.ref }}
+          build-args: |
+            AIMEE_SYNTHESIS_MODEL=${{ matrix.model }}
+
   build:
+    needs: models
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         # Same image set + Dockerfiles as the release pipeline
-        # (publish-images.yml), minus the embedder/llm/css legs that testing does
-        # not redeploy. Cache scopes match publish-images so testing reuses the
-        # release layer cache and never restarts the LTO C build from scratch.
+        # (publish-images.yml), minus the css leg that testing does not redeploy.
+        # Cache scopes match publish-images so testing reuses the release layer
+        # cache and never restarts the LTO C build from scratch.
+        #
+        # The -llm legs are what a deployment pulls to run synthesis on its own
+        # box. WITHOUT THEM THIS CHANNEL CANNOT DEPLOY SYNTHESIS AT ALL: the six
+        # image matrix landed in publish-images.yml, which fires on `v*` tags and
+        # dispatch, so `aimee-kb-llm-e4b:testing` had no trigger that would ever
+        # create it while :testing is what the managed stack pulls.
+        #
+        # The bekko legs only. The nomic axis is a different embedder and a
+        # one-way choice for a populated database; publishing it here would double
+        # the build for a variant this channel has never deployed.
         image:
           - { name: aimee-server,    dockerfile: Dockerfile.server }
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-authority-bootstrap, dockerfile: Dockerfile.authority-bootstrap }
+          - { name: aimee-kb-llm-e2b, dockerfile: Dockerfile, synthesis: gemma-4-E2B-it,
+              args: "AIMEE_WITH_LLAMACPP=1" }
+          - { name: aimee-kb-llm-e4b, dockerfile: Dockerfile, synthesis: gemma-4-E4B-it,
+              args: "AIMEE_WITH_LLAMACPP=1" }
     steps:
       - uses: actions/checkout@v4
 
@@ -71,6 +156,32 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Point the -llm legs at the model image the `models` job just guaranteed, so
+      # the build copies a registry layer. The fetch fallback is kept for the same
+      # reason publish-images keeps it: it makes the model image an optimisation
+      # rather than a dependency, so a quant bump still builds.
+      - name: Resolve the bundled model source
+        id: model
+        env:
+          SYNTH: ${{ matrix.image.synthesis }}
+        run: |
+          if [ -z "$SYNTH" ]; then
+            echo "source=fetch"  >> "$GITHUB_OUTPUT"
+            echo "image=scratch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Lowercase the name half only — see the models job for why.
+          ref="ghcr.io/${OWNER}/aimee-model-${SYNTH,,}:${MODEL_QUANT}"
+          if docker manifest inspect "$ref" >/dev/null 2>&1; then
+            echo "using prebuilt model layer $ref"
+            echo "source=image"  >> "$GITHUB_OUTPUT"
+            echo "image=$ref"    >> "$GITHUB_OUTPUT"
+          else
+            echo "$ref not available; falling back to an inline Hugging Face fetch"
+            echo "source=fetch"  >> "$GITHUB_OUTPUT"
+            echo "image=scratch" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -88,12 +199,19 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image.name }}-amd64
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-amd64
           # WITH_RUNTIME_WEB bundles the browser UI (default for aimee-server; the
-          # aimee-kb image ignores it). The kb embeds in-container; synth resolves an
-          # external endpoint.
+          # aimee-kb image ignores it).
+          #
+          # AIMEE_SYNTHESIS_MODEL is empty on the non-llm legs, which is what the
+          # Dockerfile expects: it gates the whole llama.cpp copy on
+          # AIMEE_WITH_LLAMACPP, and asserts the baked MODEL_ID matches this value
+          # when it is set.
           build-args: |
             AIMEE_VERSION=testing-${{ env.SHA7 }}
             WITH_RUNTIME_WEB=1
-            WITH_LLM=0
+            AIMEE_SYNTHESIS_MODEL=${{ matrix.image.synthesis }}
+            AIMEE_MODEL_SOURCE=${{ steps.model.outputs.source }}
+            AIMEE_MODEL_IMAGE=${{ steps.model.outputs.image }}
+            ${{ matrix.image.args }}
           tags: |
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}


### PR DESCRIPTION
Bundled synthesis could not reach a deployment. This makes the `:testing` channel
carry the images the new docs tell operators to pull.

## What was wrong

#2242 added the six-image `aimee-kb` matrix to `publish-images.yml`. That workflow
triggers on a `v*` tag, `workflow_dispatch`, or `workflow_call` — the versioned /
`latest` release channel.

The managed stack pulls `:testing`, which is owned by `publish-testing.yml`. Its
matrix was three images — `aimee-server`, `aimee-kb`, `aimee-authority-bootstrap` —
passing `AIMEE_VERSION`, `WITH_RUNTIME_WEB=1` and `WITH_LLM=0`. No
`AIMEE_WITH_LLAMACPP`, so `aimee-kb:testing` built on the Dockerfile default of `0`:
no llama.cpp, no bundled model.

So `aimee-kb-llm-e4b:testing` did not exist, and no trigger would ever create it.
Following `docs/SYNTHESIS_MODELS.md` and pulling that tag gets a
manifest-not-found. The only remaining way to run bundled synthesis was a locally
built tag pinned into `.env` — which is exactly what `check-deployed-image.sh` and
`aimee-image-drift.timer` exist to prevent, after a pinned tag stranded a host on a
stale build for two hours.

## What changes

- The two bekko `-llm` legs join the `build` matrix. Bekko only: the nomic axis is a
  different embedder and a one-way choice for a populated database, and this channel
  has never deployed it.
- A `models` job and a "resolve the bundled model source" step, mirroring
  `publish-images.yml`, so the `-llm` legs copy the weights from an
  `aimee-model-*` registry layer instead of pulling ~7.5 GB from Hugging Face on
  every push to `testing`. It skips itself when the tag already exists.
- The model image builds for **both** architectures even though this channel
  publishes amd64 only. The payload is architecture-independent, and an amd64-only
  model tag would make the release pipeline's own already-published check skip it,
  leaving the arm64 release legs with no layer to copy from. That trap is the
  reason for the asymmetry.
- `Dockerfile.model` joins the path filter.
- `WITH_LLM=0` is dropped. The Dockerfile has zero references to it — dead since the
  `aimee-llm` container was retired.

## Cost

Two more legs on every push to `testing` that touches the image paths. They run in
parallel with the existing three, so wall-clock is the slowest leg rather than the
sum. The C build and llama.cpp layers come from the cache scope this workflow
already shares with `publish-images.yml`, and the weights come from the model image
after its first build, so a typical push downloads nothing new.

## Verification

`yaml.safe_load` over the workflow, asserting the job graph, the matrix legs and
their build-args, and the path filter. `make lint` (40 checks).

**Not verified:** this workflow only runs on a push to `testing`, so its first real
execution is the merge of this PR. The `-llm` legs have never run in this workflow,
and the `models` job has never run anywhere — `publish-images.yml` guards it with
`if: github.event_name != 'pull_request'` and has not fired on a tag since the
matrix landed, so no `aimee-model-*` image exists in the registry yet. The first
run will therefore take the Hugging Face fallback path once per model before the
layer exists to reuse.
