### PR TITLE
deploy: check the image the host runs, not the one its service name implies

### DIFF
--- a/scripts/check-deployed-image.sh
+++ b/scripts/check-deployed-image.sh
@@ -17,6 +17,11 @@
 # Neither shows up in `docker ps`, which reports the tag rather than the digest.
 # This compares what is RUNNING against what the registry currently publishes.
 #
+# The expected repository is read from the running container, NOT built from the
+# service name: the aimee-kb service legitimately runs any of the six published kb
+# repositories, whichever AIMEE_KB_IMAGE selected. What is checked is the tag (this
+# host is on this channel) and the digest (it has what the registry currently serves).
+#
 # Usage: check-deployed-image.sh [service...]      (default: aimee-server aimee-kb)
 #   AIMEE_IMAGE_TAG   channel to check against (default: testing)
 #   AIMEE_IMAGE_REPO  registry prefix           (default: ghcr.io/rakuensoftware)
@@ -40,20 +45,45 @@ for svc in "${SERVICES[@]}"; do
    fi
 
    image=$(docker inspect "$container" --format '{{.Config.Image}}' 2>/dev/null)
-   want="${REPO}/${svc}:${TAG}"
 
    # A pin to anything that is not the published repo is drift by definition:
    # the host can no longer receive a published build at all.
    case "$image" in
       "${REPO}/"*) ;;
       *)
-         echo "check-deployed-image: ${svc}: PINNED to '${image}', not '${want}'"
+         echo "check-deployed-image: ${svc}: PINNED to '${image}', which is not under ${REPO}/"
          echo "  this host cannot pull published builds while pinned; remove"
          echo "  AIMEE_SERVER_IMAGE (or equivalent) from the compose .env"
          rc=1
          continue
          ;;
    esac
+
+   # The image REPOSITORY is not derivable from the service name. One service name
+   # maps to several published repositories: the aimee-kb service runs whichever of
+   # aimee-kb / aimee-kb-llm-e2b / aimee-kb-llm-e4b / aimee-kb-nomic* the operator
+   # selected via AIMEE_KB_IMAGE, all equally on-channel. Building the expected
+   # reference as "${REPO}/${svc}:${TAG}" reported a host running
+   # aimee-kb-llm-e4b:testing as drifted every 15 minutes — against a repository it
+   # was never supposed to be running.
+   #
+   # So the reference the container actually runs IS the expected reference, and what
+   # gets verified is the two things that constitute drift: that it names this
+   # channel's tag, and that the running layers match what the registry serves for it.
+   want="$image"
+   # Tag as it appears AFTER the last '/', so a registry host carrying a port
+   # (localhost:5000/x) is not mistaken for a tag.
+   case "${image##*/}" in
+      *:*) got_tag="${image##*:}" ;;
+      *)   got_tag="" ;;
+   esac
+   if [ "$got_tag" != "$TAG" ]; then
+      echo "check-deployed-image: ${svc}: OFF-CHANNEL — running '${image}',"
+      echo "  whose tag is '${got_tag:-<none>}' rather than '${TAG}'. A digest pin or a"
+      echo "  stale tag here means published ${TAG} builds never reach this host."
+      rc=1
+      continue
+   fi
 
    running=$(docker inspect "$container" --format '{{.Image}}' 2>/dev/null)
    # RepoDigests is what the registry served; empty means a local build.

--- a/scripts/test-check-deployed-image.sh
+++ b/scripts/test-check-deployed-image.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# test-check-deployed-image.sh: prove check-deployed-image.sh reaches the right
+# verdict, including the one it used to get wrong.
+#
+# That check drives a 15-minute systemd timer on a production host, and it had no
+# test. It also had a false positive that mattered: it built the expected image
+# reference from the SERVICE name, so a host legitimately running
+# aimee-kb-llm-e4b:testing was reported as drifted against aimee-kb:testing forever.
+# A monitor that alarms constantly gets ignored, which costs exactly the two hours
+# of stale deployment it exists to prevent.
+#
+# `docker` is stubbed rather than run: the point is the check's DECISION for a given
+# registry/container state, and every state below (locally built, digest-pinned,
+# recreated without a pull) is awkward to arrange for real and trivial to describe.
+set -uo pipefail
+
+CHECK="$(cd "$(dirname "$0")" && pwd)/check-deployed-image.sh"
+[ -x "$CHECK" ] || { echo "FAIL: $CHECK not executable"; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+pass=0
+fail=0
+
+# Each case writes the world into these files, and the stub answers from them.
+#   RUNNING_IMAGE  what .Config.Image reports for the container
+#   RUNNING_ID     the image ID the container is actually running
+#   LOCAL_ID       the image ID the local tag now resolves to
+#   REPO_DIGEST    RepoDigests[0] for the local tag; empty = built here
+cat > "$tmp/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+. "$STATE"
+case "$1" in
+  ps)
+    # Any filter matches: the check only uses this to learn the container name.
+    echo "prod-${RUNNING_SVC}-1"
+    ;;
+  inspect)
+    case "$*" in
+      *.Config.Image*) echo "$RUNNING_IMAGE" ;;
+      *'{{.Image}}'*)  echo "$RUNNING_ID" ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  image)
+    # docker image inspect <ref> --format ...
+    case "$*" in
+      *RepoDigests*)
+        [ -n "$REPO_DIGEST" ] || exit 1
+        echo "$REPO_DIGEST"
+        ;;
+      *'{{.Id}}'*)     echo "$LOCAL_ID" ;;
+      *'{{.Created}}'*) echo "2026-08-02T00:00:00Z" ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$tmp/bin/docker"
+
+# want_rc: expected exit status. want_re: regex the output must match.
+run_case() {
+   local name="$1" want_rc="$2" want_re="$3"
+   local out rc
+   out=$(PATH="$tmp/bin:$PATH" STATE="$tmp/state" bash "$CHECK" aimee-kb 2>&1)
+   rc=$?
+   if [ "$rc" != "$want_rc" ]; then
+      echo "  FAIL  $name: exit $rc, expected $want_rc"
+      echo "        output: $out"
+      fail=$((fail + 1))
+      return
+   fi
+   if ! printf '%s' "$out" | grep -Eq "$want_re"; then
+      echo "  FAIL  $name: output did not match /$want_re/"
+      echo "        output: $out"
+      fail=$((fail + 1))
+      return
+   fi
+   echo "  PASS  $name"
+   pass=$((pass + 1))
+}
+
+state() {
+   cat > "$tmp/state" <<EOF
+RUNNING_SVC=aimee-kb
+RUNNING_IMAGE=$1
+RUNNING_ID=$2
+LOCAL_ID=$3
+REPO_DIGEST=$4
+EOF
+}
+
+echo "==> check-deployed-image verdicts"
+
+# The plain image, current. The baseline that always worked.
+state ghcr.io/rakuensoftware/aimee-kb:testing sha256:aaa sha256:aaa \
+      ghcr.io/rakuensoftware/aimee-kb@sha256:dddd
+run_case "plain aimee-kb, current -> ok" 0 'ok \(ghcr.io/rakuensoftware/aimee-kb:testing'
+
+# THE REGRESSION. A -llm variant is a legitimate on-channel choice, and naming the
+# expected repository after the service reported it as drift against a repository
+# this host was never meant to run.
+state ghcr.io/rakuensoftware/aimee-kb-llm-e4b:testing sha256:bbb sha256:bbb \
+      ghcr.io/rakuensoftware/aimee-kb-llm-e4b@sha256:eeee
+run_case "aimee-kb-llm-e4b, current -> ok (not drift)" 0 \
+         'ok \(ghcr.io/rakuensoftware/aimee-kb-llm-e4b:testing'
+
+# A nomic variant is equally on-channel.
+state ghcr.io/rakuensoftware/aimee-kb-nomic-llm-e2b:testing sha256:ccc sha256:ccc \
+      ghcr.io/rakuensoftware/aimee-kb-nomic-llm-e2b@sha256:ffff
+run_case "aimee-kb-nomic-llm-e2b, current -> ok" 0 'ok \('
+
+# Drift mode 1: a local pin off the published repo entirely.
+state aimee-kb:local sha256:ddd sha256:ddd ""
+run_case "local pin off the repo -> PINNED" 1 'PINNED'
+
+# Still drift mode 1, subtler: on the right repo, wrong channel. A published build
+# of :testing can never reach this host.
+state ghcr.io/rakuensoftware/aimee-kb:latest sha256:eee sha256:eee \
+      ghcr.io/rakuensoftware/aimee-kb@sha256:1111
+run_case "right repo, wrong tag -> OFF-CHANNEL" 1 'OFF-CHANNEL'
+
+# An on-channel tag that was built here rather than pulled: no registry digest.
+state ghcr.io/rakuensoftware/aimee-kb-llm-e4b:testing sha256:fff sha256:fff ""
+run_case "built locally, no registry digest -> drift" 1 'no registry digest'
+
+# Drift mode 2: recreated without a pull, so the tag moved and the container did not.
+state ghcr.io/rakuensoftware/aimee-kb-llm-e4b:testing sha256:old sha256:new \
+      ghcr.io/rakuensoftware/aimee-kb-llm-e4b@sha256:2222
+run_case "recreated without a pull -> STALE" 1 'STALE'
+
+echo
+echo "==> Summary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1
+echo "check-deployed-image: all verdicts correct"

--- a/src/Makefile
+++ b/src/Makefile
@@ -817,7 +817,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(STATUS_AUTHORIT
 # nothing is stale when nothing exists.
 DEPS = $(ALL_OBJS:.o=.d) $(shell find $(OBJDIR) -name '*.d' 2>/dev/null)
 
-.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
+.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check deployed-image-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_RUNTIME_WEB) $(SERVER) $(KB) $(KB_RESOLVER) $(GATEWAY) $(FORWARDER)
 
@@ -1758,7 +1758,7 @@ lint: BUS_BLAST_RADIUS_FLAGS := --allow-unbuilt
 # target-specific variable on `lint`, and target-specific variables do NOT cross
 # a recursive make, so bus-blast-radius-check would otherwise lose
 # --allow-unbuilt and start demanding the whole shipping set.
-LINT_CHECKS = subject-corpus-check native-tool-parity-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check config-encapsulation-check
+LINT_CHECKS = subject-corpus-check native-tool-parity-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check config-encapsulation-check deployed-image-check
 
 lint:
 	@fail=""; n=0; \
@@ -1916,6 +1916,12 @@ deploy-env-consumed-check:
 
 sidecar-clients-check:
 	@python3 ../scripts/check-sidecar-clients.py
+
+# The drift check drives a 15-minute timer on a production host, so its verdicts
+# are worth a test. It named the expected repository after the SERVICE, which made
+# any aimee-kb-*-llm-* variant get validated against plain aimee-kb.
+deployed-image-check:
+	@bash ../scripts/test-check-deployed-image.sh
 
 # ---- .inc migration guardrail ------------------------------------------------
 # .inc files dodge line-check (LINT_SRCS globs only .c) — the cap-evasion loophole.


### PR DESCRIPTION
The deployed-image drift check validated the wrong repository once the kb image
matrix landed, and it had no test.

## What was wrong

`check-deployed-image.sh` built the reference it expected as
`"${REPO}/${svc}:${TAG}"`. That assumes one service name maps to one published
repository. Since #2242 it does not: the `aimee-kb` service legitimately runs any of
six repositories — `aimee-kb`, `aimee-kb-llm-e2b`, `aimee-kb-llm-e4b` and the three
`-nomic` variants — whichever `AIMEE_KB_IMAGE` selected. All are equally on-channel.

So a host running `aimee-kb-llm-e4b:testing` had its digest compared against
`aimee-kb:testing`, a repository it was never meant to be running. The verdict then
depended on which images happened to be present locally:

- plain `aimee-kb:testing` present → compares against **the wrong image** and can
  report a confident `ok`, or a bogus `STALE`, with equal ease
- not present → `no registry digest`, a false alarm every 15 minutes

Both are bad in the same way: this check drives `aimee-image-drift.timer` on a
production host, and it exists because a local pin once left that host two hours on
a build predating the fix it was supposed to be running. A monitor that alarms
falsely gets ignored, and one that validates the wrong artefact is worse than none.

A second gap turned up while testing: **the tag was never checked at all.** A host
on the right repository but pinned to `:latest` passed clean, despite being unable
to receive a published `:testing` build — which is drift mode 1, the exact thing the
script's own header describes.

## What changes

The reference the container actually runs *is* the expected reference. What gets
verified is what constitutes drift:

1. the repository is under `$REPO` (unchanged — an off-registry pin is still drift)
2. **the tag names this channel** (new)
3. the local tag has a registry digest, so it was pulled rather than built here
4. the running layers match what that tag now resolves to

The service-name→repository assumption is gone.

## Tests

`scripts/test-check-deployed-image.sh`, wired into `make lint` (now 41 checks). It
stubs `docker`, because the point is the check's *decision* for a given registry and
container state, and states like "built here, no digest" or "recreated without a
pull" are awkward to arrange for real and trivial to describe.

Seven verdicts: the plain image current; `-llm-e4b` current; `-nomic-llm-e2b`
current; an off-registry pin; the right repo on the wrong tag; an on-channel tag
built locally; and a recreate-without-pull.

**Run against the previous script, two of them fail** — the `-llm` variant (reported
`ok` while inspecting `aimee-kb:testing`) and the wrong-tag pin (reported `ok`). The
other five pass on both, which is what makes them a regression guard rather than a
restatement of the new behaviour.

## Verification

`make lint` — 41 checks pass, including the new one. The red-before-green run
against `origin/testing`'s copy is described above.

**Not verified:** not exercised on a real host. The stub asserts decisions, not
`docker`'s actual output format; the `docker` invocations themselves are unchanged
from the working script.
