### PR TITLE
ci: stop rebuilding multi-gigabyte images because kb code changed

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -114,7 +114,6 @@ jobs:
             AIMEE_SYNTHESIS_MODEL=${{ matrix.model }}
 
   build:
-    needs: models
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -124,23 +123,21 @@ jobs:
         # Cache scopes match publish-images so testing reuses the release layer
         # cache and never restarts the LTO C build from scratch.
         #
-        # The -llm legs are what a deployment pulls to run synthesis on its own
-        # box. WITHOUT THEM THIS CHANNEL CANNOT DEPLOY SYNTHESIS AT ALL: the six
-        # image matrix landed in publish-images.yml, which fires on `v*` tags and
-        # dispatch, so `aimee-kb-llm-e4b:testing` had no trigger that would ever
-        # create it while :testing is what the managed stack pulls.
+        # NO -llm LEGS HERE, and that is the point. An image carrying llama.cpp and
+        # multi-gigabyte weights must not be rebuilt because kb code changed, and
+        # every leg in this matrix rebuilds on every push that touches src/**. The
+        # two -llm kb variants published from here cost a full kb rebuild each —
+        # under a separate cache scope, so the LTO C build, postgres, pgvectorscale
+        # and torch were all built three times per push for one code change.
         #
-        # The bekko legs only. The nomic axis is a different embedder and a
-        # one-way choice for a populated database; publishing it here would double
-        # the build for a variant this channel has never deployed.
+        # Bundled synthesis moves to its own aimee-llm-e{2,4}b image, deployed
+        # beside the kb, rebuilt only when the model or the model list changes. The
+        # weights stay baked — that property is why they were baked in the first
+        # place — they are just baked into the image whose inputs are stable.
         image:
           - { name: aimee-server,    dockerfile: Dockerfile.server }
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-authority-bootstrap, dockerfile: Dockerfile.authority-bootstrap }
-          - { name: aimee-kb-llm-e2b, dockerfile: Dockerfile, synthesis: gemma-4-E2B-it,
-              args: "AIMEE_WITH_LLAMACPP=1" }
-          - { name: aimee-kb-llm-e4b, dockerfile: Dockerfile, synthesis: gemma-4-E4B-it,
-              args: "AIMEE_WITH_LLAMACPP=1" }
     steps:
       - uses: actions/checkout@v4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -859,6 +859,7 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_css.c
     ${AIMEE_SRC_DIR}/cli_chat_stream.c
     ${AIMEE_SRC_DIR}/cli_client.c
+    ${AIMEE_SRC_DIR}/cli_kb_smoke.c
     ${AIMEE_SRC_DIR}/cli_v1_routes.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_d.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_c.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -859,7 +859,6 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_css.c
     ${AIMEE_SRC_DIR}/cli_chat_stream.c
     ${AIMEE_SRC_DIR}/cli_client.c
-    ${AIMEE_SRC_DIR}/cli_kb_smoke.c
     ${AIMEE_SRC_DIR}/cli_v1_routes.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_d.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_c.c


### PR DESCRIPTION
Removes the two `-llm` kb legs added in #2253. They are the wrong shape, and they
cost real build minutes on every push.

## Why

Each `-llm` leg rebuilt a **full kb image** — and under its own `cache-from` scope,
so `aimee-kb`, `aimee-kb-llm-e2b` and `aimee-kb-llm-e4b` each built the LTO C
binary, postgres, pgvectorscale, torch and the embedder weights *independently*.
Three full builds per push to `testing` touching `src/**`, for one code change,
plus ~10 GB pushed twice.

The defect is coupling: an image carrying llama.cpp and multi-gigabyte weights has
no business rebuilding because kb code changed. Its inputs — the model, the quant,
the pinned llama.cpp — change on the order of never.

## Where synthesis goes instead

Its own `aimee-llm-e2b` / `aimee-llm-e4b` image, deployed beside `aimee-kb`, with
`SYNTHESIS_ENDPOINT` pointing at it over the compose network rather than loopback.
Rebuilt only when the model or the model list changes, enforced two ways: a narrow
path-filtered trigger, and a skip-if-already-published check keyed on model+quant
so even a broad trigger costs one manifest inspect.

**The weights stay baked.** #2242's reason for baking them — a first-run download
fails on a rate limit, a proxy, a flaky link or an air-gapped host, and reaches the
operator as "synthesis never started" long after deploy — has not changed. They just
move into the image whose inputs are stable.

## What is kept

The `models` job and the "resolve the bundled model source" step stay: the
`aimee-llm` work needs both, and the resolve step is inert on a leg with no
synthesis model. `needs: models` is dropped so the remaining three legs no longer
serialise behind a job nothing consumes.

The already-published `aimee-kb-llm-e{2,4}b:testing` tags are left in the registry
rather than deleted. Nothing is deployed from them.

## Evidence the synthesis path itself is sound

Worth recording, because it is what the sidecar inherits. `aimee-kb-llm-e2b:testing`
booted on a test host — the first time any `-llm` image has run anywhere:

```
aimee-kb: starting bundled synthesis (gemma-4-E2B-it) on :8761
srv  load_model: loading model '/opt/aimee/llama.cpp/model/synthesis.gguf'
srv  llama_server: model loaded            (~2.2s)
srv  llama_server: listening on http://127.0.0.1:8761
```

The llama-server invocation, the baked model and the `MODEL_ID` plumbing all work.
What changes in the sidecar is the address, not the mechanism.

It also surfaced a hazard the sidecar must fix: llama-server warns that CORS allows
all origins and no API key is set. Contained on loopback inside the kb container;
an unauthenticated inference endpoint once it moves onto a shared network.

## Verification

`yaml.safe_load` asserting the job graph and the remaining three legs. `make lint`
(40 checks — the 41st arrives with #2254).
