### PR TITLE
kb: one axis, and an embedder you can leave out

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -82,7 +82,6 @@ env:
   # images. It IS the identity of those images: bumping the quant is a new tag, so
   # the old one is never overwritten and a rollback keeps working. Changing this
   # means changing the digests in scripts/fetch-synthesis-model.sh too.
-  MODEL_QUANT: UD-Q6_K_XL
 
 jobs:
   # Publish the bundled synthesis models as their own images, once, so the kb
@@ -96,62 +95,6 @@ jobs:
   # nothing at all. Not on a pull request either — a PR must never push. A PR
   # instead reads whatever the last merge published, and falls back to fetching
   # inline if there is nothing there yet (see "Resolve the bundled model source").
-  models:
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        model: [gemma-4-E2B-it, gemma-4-E4B-it]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Normalize owner to lowercase
-        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Is it already published?
-        id: have
-        env:
-          SYNTH: ${{ matrix.model }}
-        run: |
-          # A repository name must be lowercase; a TAG may not be, which is why
-          # only the name half is folded and MODEL_QUANT is left alone.
-          ref="ghcr.io/${OWNER}/aimee-model-${SYNTH,,}:${MODEL_QUANT}"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-          if docker manifest inspect "$ref" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "$ref already published; skipping the Hugging Face fetch"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up Docker Buildx
-        if: steps.have.outputs.exists != 'true'
-        uses: docker/setup-buildx-action@v3
-
-      # Both platforms in ONE build: the payload is architecture-independent and
-      # Dockerfile.model pins its fetch stage to BUILDPLATFORM, so this downloads
-      # the file once and both manifests reference the same layer.
-      - name: Build and push the model image
-        if: steps.have.outputs.exists != 'true'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.model
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          tags: ${{ steps.have.outputs.ref }}
-          build-args: |
-            AIMEE_SYNTHESIS_MODEL=${{ matrix.model }}
-
   # Resolve the version once (from the call/dispatch input or the pushed tag) so
   # the build (binary embedding) and merge (image tags) jobs agree.
   prep:
@@ -173,7 +116,7 @@ jobs:
 
   # Build each image for each arch on a native runner; push by digest only.
   build:
-    needs: [prep, models]
+    needs: [prep]
     # `models` is skipped on a pull request, and a skipped dependency would
     # otherwise skip this job too. Proceed as long as it did not FAIL.
     if: ${{ !cancelled() && needs.prep.result == 'success' && needs.models.result != 'failure' }}
@@ -182,22 +125,20 @@ jobs:
       matrix:
         image:
           - { name: aimee-server,    dockerfile: Dockerfile.server }
-          # The aimee-kb 2x2: embedder (bekko 384 / nomic 768) x llama.cpp.
-          # ONE Dockerfile, four tags, selected by build-args. The embedder axis is
-          # a one-way door per install (DB2 locks the vector-column width), and the
-          # llama.cpp axis decides whether synthesis can run on the same host.
-          - { name: aimee-kb,                  dockerfile: Dockerfile,
-              extra_args: "AIMEE_EMBEDDER=bekko-a25m\nAIMEE_WITH_LLAMACPP=0" }
-          - { name: aimee-kb-llm-e2b,          dockerfile: Dockerfile, synthesis: gemma-4-E2B-it,
-              extra_args: "AIMEE_EMBEDDER=bekko-a25m\nAIMEE_WITH_LLAMACPP=1\nAIMEE_SYNTHESIS_MODEL=gemma-4-E2B-it" }
-          - { name: aimee-kb-llm-e4b,          dockerfile: Dockerfile, synthesis: gemma-4-E4B-it,
-              extra_args: "AIMEE_EMBEDDER=bekko-a25m\nAIMEE_WITH_LLAMACPP=1\nAIMEE_SYNTHESIS_MODEL=gemma-4-E4B-it" }
-          - { name: aimee-kb-nomic,            dockerfile: Dockerfile,
-              extra_args: "AIMEE_EMBEDDER=nomic-embed-text-v2-moe\nAIMEE_WITH_LLAMACPP=0" }
-          - { name: aimee-kb-nomic-llm-e2b,    dockerfile: Dockerfile, synthesis: gemma-4-E2B-it,
-              extra_args: "AIMEE_EMBEDDER=nomic-embed-text-v2-moe\nAIMEE_WITH_LLAMACPP=1\nAIMEE_SYNTHESIS_MODEL=gemma-4-E2B-it" }
-          - { name: aimee-kb-nomic-llm-e4b,    dockerfile: Dockerfile, synthesis: gemma-4-E4B-it,
-              extra_args: "AIMEE_EMBEDDER=nomic-embed-text-v2-moe\nAIMEE_WITH_LLAMACPP=1\nAIMEE_SYNTHESIS_MODEL=gemma-4-E4B-it" }
+          # The aimee-kb images, on ONE axis: the embedder. Synthesis used to be a
+          # second axis here, doubling this to six tags and rebuilding llama.cpp and
+          # a multi-gigabyte GGUF on every kb code change. It is its own image now
+          # (publish-llm.yml), rebuilt only when the model does.
+          #
+          # The embedder axis IS a one-way door per install: DB2 records the
+          # vector-column width and refuses to start on drift, so moving between
+          # these means re-embedding the corpus.
+          - { name: aimee-kb,        dockerfile: Dockerfile,
+              extra_args: "AIMEE_EMBEDDER=none" }
+          - { name: aimee-kb-a25m,   dockerfile: Dockerfile,
+              extra_args: "AIMEE_EMBEDDER=bekko-a25m" }
+          - { name: aimee-kb-nomic,  dockerfile: Dockerfile,
+              extra_args: "AIMEE_EMBEDDER=nomic-embed-text-v2-moe" }
           - { name: aimee-authority-bootstrap, dockerfile: Dockerfile.authority-bootstrap }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
@@ -233,28 +174,6 @@ jobs:
       # The fallback is what keeps this an optimisation rather than a dependency:
       # bootstrapping a fresh registry, or a commit that bumps the quant before
       # the matching model image exists, still builds instead of hard-failing.
-      - name: Resolve the bundled model source
-        id: model
-        env:
-          SYNTH: ${{ matrix.image.synthesis }}
-        run: |
-          if [ -z "$SYNTH" ]; then
-            echo "source=fetch"  >> "$GITHUB_OUTPUT"
-            echo "image=scratch" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Lowercase the name half only — see the models job for why.
-          ref="ghcr.io/${OWNER}/aimee-model-${SYNTH,,}:${MODEL_QUANT}"
-          if docker manifest inspect "$ref" >/dev/null 2>&1; then
-            echo "using prebuilt model layer $ref"
-            echo "source=image"  >> "$GITHUB_OUTPUT"
-            echo "image=$ref"    >> "$GITHUB_OUTPUT"
-          else
-            echo "$ref not available; falling back to an inline Hugging Face fetch"
-            echo "source=fetch"  >> "$GITHUB_OUTPUT"
-            echo "image=scratch" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -280,8 +199,6 @@ jobs:
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_RUNTIME_WEB=1
-            AIMEE_MODEL_SOURCE=${{ steps.model.outputs.source }}
-            AIMEE_MODEL_IMAGE=${{ steps.model.outputs.image }}
             ${{ matrix.image.extra_args }}
           # push=false on a pull_request: build only, publish nothing.
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
@@ -312,8 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-kb-llm-e2b, aimee-kb-llm-e4b,
-                aimee-kb-nomic, aimee-kb-nomic-llm-e2b, aimee-kb-nomic-llm-e4b,
+        image: [aimee-server, aimee-kb, aimee-kb-a25m, aimee-kb-nomic,
                 aimee-authority-bootstrap, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,29 +6,19 @@
 #   aimee-authority-bootstrap (Dockerfile.authority-bootstrap) ghcr.io/<owner>/aimee-authority-bootstrap
 #   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
-# plus the aimee-kb matrix, all six from the SAME Dockerfile via build-args. Both
-# the embedder AND the synthesis model are baked, so which models a deployment runs
-# is a property of the tag it pulled — never a first-run download:
+# plus the aimee-kb images, all three from the SAME Dockerfile via one build-arg.
+# The embedder is the only axis, and it is baked, so which embedder a deployment runs
+# is a property of the tag it pulled and never a first-run download:
 #
-#   aimee-kb                  bekko-a25m (384)  no llama.cpp
-#   aimee-kb-llm-e2b          bekko-a25m (384)  llama.cpp + gemma-4-E2B-it
-#   aimee-kb-llm-e4b          bekko-a25m (384)  llama.cpp + gemma-4-E4B-it
-#   aimee-kb-nomic            nomic-v2   (768)  no llama.cpp
-#   aimee-kb-nomic-llm-e2b    nomic-v2   (768)  llama.cpp + gemma-4-E2B-it
-#   aimee-kb-nomic-llm-e4b    nomic-v2   (768)  llama.cpp + gemma-4-E4B-it
+#   aimee-kb        no embedder            EMBEDDER_URL required; ~373 MB
+#   aimee-kb-a25m   bekko-a25m (384)       ~1.95 GB
+#   aimee-kb-nomic  nomic-v2   (768)       ~3.34 GB
 #
-# The external-embedder deployment shares the bekko images and overrides
-# EMBEDDER_URL at runtime; there is no separate "external" image.
-#
-# Two more images exist only to be copied FROM, never run:
-#
-#   aimee-model-gemma-4-e2b-it:<quant>   the bundled GGUF, nothing else
-#   aimee-model-gemma-4-e4b-it:<quant>
-#
-# They carry the synthesis model so the four -llm tags on two architectures share
-# one registry layer instead of each downloading the same file from Hugging Face.
-# Built by the `models` job, which skips itself when the tag already exists, so a
-# publish that does not change the model or the quant fetches nothing.
+# SYNTHESIS IS NOT HERE. It used to be a second axis, doubling this to six tags and
+# rebuilding llama.cpp and a multi-gigabyte GGUF on every push that touched src/**.
+# It is its own image on its own trigger now (publish-llm.yml), rebuilt when the
+# model changes rather than when kb code does, and the aimee-model-* layers moved
+# there with it.
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
 # merge-manifest pattern, on native runners (no QEMU emulation of the C build).
@@ -77,24 +67,7 @@ permissions:
   contents: read
   packages: write
 
-env:
-  # The quantisation the bundled models ship at, and the tag of the aimee-model-*
-  # images. It IS the identity of those images: bumping the quant is a new tag, so
-  # the old one is never overwritten and a rollback keeps working. Changing this
-  # means changing the digests in scripts/fetch-synthesis-model.sh too.
-
 jobs:
-  # Publish the bundled synthesis models as their own images, once, so the kb
-  # builds can COPY --from them instead of each pulling the same GGUF out of
-  # Hugging Face. Four -llm tags x two architectures was eight downloads of the
-  # same two files per publish — about 49 GB fetched to produce ~12 GB of
-  # distinct bytes.
-  #
-  # SKIPPED WHEN THE TAG ALREADY EXISTS, which is the normal case: the models
-  # change only when the model or quant does, so a typical publish downloads
-  # nothing at all. Not on a pull request either — a PR must never push. A PR
-  # instead reads whatever the last merge published, and falls back to fetching
-  # inline if there is nothing there yet (see "Resolve the bundled model source").
   # Resolve the version once (from the call/dispatch input or the pushed tag) so
   # the build (binary embedding) and merge (image tags) jobs agree.
   prep:

--- a/.github/workflows/publish-llm.yml
+++ b/.github/workflows/publish-llm.yml
@@ -27,13 +27,19 @@ on:
       - "scripts/fetch-synthesis-model.sh"
       - "Dockerfile.model"
       - ".github/workflows/publish-llm.yml"
+  # DELIBERATELY NARROWER THAN THE PUSH TRIGGER: no workflow file here.
+  #
+  # A PR build never pushes, so the skip-if-published check cannot engage on one --
+  # the tag it looks for only ever appears at merge. Every triggered PR therefore
+  # pays a full build, and these are the slow ones. Editing this workflow is not a
+  # change to the image, so it must not cost two of them; the push trigger below
+  # still re-evaluates on merge, where the content hash decides.
   pull_request:
     paths:
       - "Dockerfile.llm"
       - "deploy/container/aimee-llm-entrypoint.sh"
       - "scripts/fetch-synthesis-model.sh"
       - "Dockerfile.model"
-      - ".github/workflows/publish-llm.yml"
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/publish-llm.yml
+++ b/.github/workflows/publish-llm.yml
@@ -141,15 +141,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The immutable tag names every input that changes the artefact, so "does this
-      # tag exist" IS "have these inputs already been built". :testing is a moving
-      # pointer at whichever of these is current.
+      # The immutable tag must name EVERY input that changes the artefact, or the skip
+      # becomes a trap. Keyed on the model, the quant and the llama.cpp version alone,
+      # a change to Dockerfile.llm or the entrypoint would find the tag already
+      # published, skip the build, and leave :testing pointing at the old image while
+      # the run reported success. That is precisely how the mTLS fix in this image
+      # would have failed to ship.
+      #
+      # So the sidecar's own sources are hashed into the tag. Content-addressed: a
+      # rebuild happens exactly when something that lands in the image changed, and
+      # never otherwise.
       - name: Has this exact build already been published?
         id: have
         env:
           FORCE: ${{ inputs.force }}
         run: |
-          pinned="ghcr.io/${OWNER}/${{ matrix.name }}:${MODEL_QUANT}-${LLAMACPP_VERSION}"
+          rev=$(cat Dockerfile.llm deploy/container/aimee-llm-entrypoint.sh \
+                | sha256sum | cut -c1-12)
+          pinned="ghcr.io/${OWNER}/${{ matrix.name }}:${MODEL_QUANT}-${LLAMACPP_VERSION}-${rev}"
+          echo "sidecar sources hash to $rev"
           echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
           if [ "${FORCE:-false}" = "true" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-llm.yml
+++ b/.github/workflows/publish-llm.yml
@@ -25,12 +25,14 @@ on:
       - "Dockerfile.llm"
       - "deploy/container/aimee-llm-entrypoint.sh"
       - "scripts/fetch-synthesis-model.sh"
+      - "Dockerfile.model"
       - ".github/workflows/publish-llm.yml"
   pull_request:
     paths:
       - "Dockerfile.llm"
       - "deploy/container/aimee-llm-entrypoint.sh"
       - "scripts/fetch-synthesis-model.sh"
+      - "Dockerfile.model"
       - ".github/workflows/publish-llm.yml"
   workflow_dispatch:
     inputs:
@@ -56,7 +58,69 @@ env:
   LLAMACPP_VERSION: b10218
 
 jobs:
+  # The weights, as their own image, so the two sidecars copy a registry layer
+  # instead of pulling ~7.5 GB from Hugging Face per build. It lived in the kb
+  # pipelines until synthesis moved out of the kb image; nothing there consumed it
+  # any more, and a model layer belongs with the thing that bakes it.
+  #
+  # BOTH PLATFORMS even though the sidecar publishes amd64 only: the payload is
+  # architecture-independent, and an amd64-only model tag would make a later
+  # multi-arch build skip it and find nothing to copy for arm64.
+  models:
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [gemma-4-E2B-it, gemma-4-E4B-it]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize owner to lowercase
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Is it already published?
+        id: have
+        env:
+          SYNTH: ${{ matrix.model }}
+        run: |
+          # A repository name must be lowercase; a TAG may not be, which is why
+          # only the name half is folded and MODEL_QUANT is left alone.
+          ref="ghcr.io/${OWNER}/aimee-model-${SYNTH,,}:${MODEL_QUANT}"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          if docker manifest inspect "$ref" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "$ref already published; skipping the Hugging Face fetch"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.have.outputs.exists != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # Never on a pull request: publishing is a merge-time act.
+      - name: Build and push the model image
+        if: steps.have.outputs.exists != 'true' && github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.model
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          tags: ${{ steps.have.outputs.ref }}
+          build-args: |
+            AIMEE_SYNTHESIS_MODEL=${{ matrix.model }}
+
   build:
+    needs: models
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -3,9 +3,10 @@
 # testing branch can be deployed/validated (e.g. on .254) WITHOUT promoting to
 # main.
 #
-# Builds the split images, the isolated one-shot authority bootstrap, and the two
-# bekko `-llm` variants that carry bundled synthesis, so a managed stack can pull a
-# single coherent `:testing` channel — including one that runs synthesis locally.
+# Builds the split images and the isolated one-shot authority bootstrap so a managed
+# stack can pull a single coherent `:testing` channel. Synthesis is NOT here: it is
+# its own image on its own trigger (publish-llm.yml), rebuilt when the model changes
+# rather than when kb code does.
 # Versioned + `:latest` publishing of the full image set
 # stays owned by main (auto-release.yml -> publish-images.yml). Keeping testing on
 # a `:testing` tag — never a version number — avoids confusing a tested-but-
@@ -32,8 +33,6 @@ on:
       - "Dockerfile"
       - "Dockerfile.server"
       - "Dockerfile.authority-bootstrap"
-      # Carries the bundled synthesis weights the -llm legs copy from.
-      - "Dockerfile.model"
       - ".github/workflows/publish-testing.yml"
   workflow_dispatch:
 
@@ -45,74 +44,7 @@ permissions:
   contents: read
   packages: write
 
-env:
-  # The quant the -llm images bake, and the TAG of the aimee-model-* images that
-  # carry it. Must match publish-images.yml: both channels share those model
-  # images, and a mismatch here silently re-downloads from Hugging Face.
-  MODEL_QUANT: UD-Q6_K_XL
-
 jobs:
-  # The bundled synthesis weights, as their own image, so the -llm legs below copy
-  # a registry layer instead of pulling ~7.5GB from Hugging Face on every push to
-  # testing. Skips itself when the tag already exists, so a push that changes
-  # neither the model nor the quant fetches nothing.
-  #
-  # BOTH PLATFORMS, even though this channel publishes amd64 only. The payload is
-  # architecture-independent, and if testing published an amd64-only model tag then
-  # the release pipeline's "is it already published?" check would skip it and the
-  # arm64 half of the release matrix would have no model layer to copy.
-  models:
-    strategy:
-      fail-fast: false
-      matrix:
-        model: [gemma-4-E2B-it, gemma-4-E4B-it]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Normalize owner to lowercase
-        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Is it already published?
-        id: have
-        env:
-          SYNTH: ${{ matrix.model }}
-        run: |
-          # A repository name must be lowercase; a TAG may not be, which is why
-          # only the name half is folded and MODEL_QUANT is left alone.
-          ref="ghcr.io/${OWNER}/aimee-model-${SYNTH,,}:${MODEL_QUANT}"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-          if docker manifest inspect "$ref" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "$ref already published; skipping the Hugging Face fetch"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up Docker Buildx
-        if: steps.have.outputs.exists != 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push the model image
-        if: steps.have.outputs.exists != 'true'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.model
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          tags: ${{ steps.have.outputs.ref }}
-          build-args: |
-            AIMEE_SYNTHESIS_MODEL=${{ matrix.model }}
-
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -136,7 +68,8 @@ jobs:
         # place — they are just baked into the image whose inputs are stable.
         image:
           - { name: aimee-server,    dockerfile: Dockerfile.server }
-          - { name: aimee-kb,        dockerfile: Dockerfile }
+          - { name: aimee-kb,        dockerfile: Dockerfile, args: "AIMEE_EMBEDDER=none" }
+          - { name: aimee-kb-a25m,   dockerfile: Dockerfile, args: "AIMEE_EMBEDDER=bekko-a25m" }
           - { name: aimee-authority-bootstrap, dockerfile: Dockerfile.authority-bootstrap }
     steps:
       - uses: actions/checkout@v4
@@ -158,28 +91,6 @@ jobs:
       # the build copies a registry layer. The fetch fallback is kept for the same
       # reason publish-images keeps it: it makes the model image an optimisation
       # rather than a dependency, so a quant bump still builds.
-      - name: Resolve the bundled model source
-        id: model
-        env:
-          SYNTH: ${{ matrix.image.synthesis }}
-        run: |
-          if [ -z "$SYNTH" ]; then
-            echo "source=fetch"  >> "$GITHUB_OUTPUT"
-            echo "image=scratch" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Lowercase the name half only — see the models job for why.
-          ref="ghcr.io/${OWNER}/aimee-model-${SYNTH,,}:${MODEL_QUANT}"
-          if docker manifest inspect "$ref" >/dev/null 2>&1; then
-            echo "using prebuilt model layer $ref"
-            echo "source=image"  >> "$GITHUB_OUTPUT"
-            echo "image=$ref"    >> "$GITHUB_OUTPUT"
-          else
-            echo "$ref not available; falling back to an inline Hugging Face fetch"
-            echo "source=fetch"  >> "$GITHUB_OUTPUT"
-            echo "image=scratch" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -205,9 +116,7 @@ jobs:
           build-args: |
             AIMEE_VERSION=testing-${{ env.SHA7 }}
             WITH_RUNTIME_WEB=1
-            AIMEE_SYNTHESIS_MODEL=${{ matrix.image.synthesis }}
-            AIMEE_MODEL_SOURCE=${{ steps.model.outputs.source }}
-            AIMEE_MODEL_IMAGE=${{ steps.model.outputs.image }}
+            ${{ matrix.image.args }}
             ${{ matrix.image.args }}
           tags: |
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -210,6 +210,17 @@ ENV AIMEE_HOME=/var/lib/aimee
 ENV AIMEE_KB_HTTP_BIND=1
 
 RUN useradd --system --home-dir /var/lib/aimee --create-home --shell /usr/sbin/nologin aimee
+# The synthesis identity directory must exist IN THE IMAGE, owned by the runtime
+# user, because the sidecar deployment mounts a named volume over this path.
+#
+# Docker initialises an empty named volume from whatever the image has at the mount
+# point, ownership included -- but if the path does not exist in the image it creates
+# the volume root-owned, and the kb (which runs as `aimee`) cannot write into it. That
+# is not theoretical: booting this produced
+#   kb_synthesis_identity: cannot create .../synthesis-tls/server.pem: Permission denied
+# and the sidecar then refuses to start, because it has no identity to present. The
+# unit test missed it by creating the directory as the same user it then wrote as.
+RUN install -d -o aimee -g aimee -m 0700 /var/lib/aimee/synthesis-tls
 COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 COPY --from=build /src/aimee-kb-resolver /usr/local/bin/aimee-kb-resolver
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,51 +7,6 @@
 # Global build args, declared before the first FROM so every stage can use them.
 ARG PG_MAJOR=18
 ARG PGVECTORSCALE_VERSION=0.9.0
-# Selects which llama.cpp stage the final image copies from (see llamacpp-* below).
-ARG AIMEE_WITH_LLAMACPP=0
-# Which synthesis model is BAKED into a *-llm image: gemma-4-E2B-it or
-# gemma-4-E4B-it. Empty on the non-llm variants.
-#
-# BAKED, NOT FETCHED AT RUNTIME. This mirrors the embedder decision below for the
-# same reason: a first-run download is a support burden. It fails on a rate limit,
-# behind a proxy, on a flaky link, on an air-gapped host, or silently serves the
-# wrong file when a quant tag stops resolving — and every one of those surfaces to
-# the operator as "synthesis never started", long after deploy. An image either
-# has its model or it does not, and `docker pull` is the one download, with the
-# registry's own retry and resume behind it.
-#
-# The cost is image size and a model-per-tag matrix. That is the trade the
-# embedder already makes.
-ARG AIMEE_SYNTHESIS_MODEL=""
-# Optional mirror for the model file. Empty pulls from Hugging Face; set it to a
-# base URL that serves the GGUF by filename and the build fetches from there
-# instead. For an air-gapped or bandwidth-limited build site, and for rebuilding
-# the matrix without pulling ~24GB from the internet each time. The filename is
-# identical either way, so a mirror is just `cp` from a known-good copy.
-ARG AIMEE_MODEL_MIRROR=""
-# Where the bundled model comes from: "image" copies it out of a prebuilt
-# aimee-model-* tag (see Dockerfile.model), "fetch" downloads it here.
-#
-# "image" is what CI uses, and it is the whole point of splitting the model out:
-# the four -llm tags x two architectures share one registry layer instead of
-# pulling the same two files from Hugging Face eight times per publish.
-#
-# "fetch" is kept as the fallback, NOT as dead code. It is what runs when the
-# model tag does not exist yet — bootstrapping the registry, or a commit that
-# bumps the quant before the new model image has been published. Without it that
-# situation is a hard build failure on a pull request, and the cache would have
-# become a dependency rather than an optimisation.
-ARG AIMEE_MODEL_SOURCE=fetch
-# Only read when AIMEE_MODEL_SOURCE=image.
-ARG AIMEE_MODEL_IMAGE=scratch
-# Pinned llama.cpp. This version is load-bearing in three ways, all checked
-# against the tag rather than assumed:
-#   - gemma-4 / gemma-3n architecture support (b4585 had NONE — it would have
-#     built and started and then failed to load the only models we offer)
-#   - --no-mmproj and LLAMA_ARG_MMPROJ_AUTO (neither existed in b4585)
-#   - the server target lives in tools/, which sets the cmake flags below
-# Bumping this needs all three re-checked, not just a version number changed.
-ARG LLAMACPP_VERSION=b10218
 
 FROM debian:trixie-slim AS build
 
@@ -131,90 +86,6 @@ RUN mkdir -p "/pgvectorscale/usr/lib/postgresql/${PG_MAJOR}/lib" \
     && cp "/usr/share/postgresql/${PG_MAJOR}/extension/vectorscale"* \
         "/pgvectorscale/usr/share/postgresql/${PG_MAJOR}/extension/"
 
-# --- where the bundled model comes from ---------------------------------------
-# Two stages with the same output shape (/model/synthesis.gguf + /model/MODEL_ID),
-# selected by AIMEE_MODEL_SOURCE. Only the selected one is in the build graph, so
-# the unselected one costs nothing — and neither is built at all for a
-# AIMEE_WITH_LLAMACPP=0 tag, which reaches llamacpp-0 instead.
-#
-# The digest table lives in scripts/fetch-synthesis-model.sh, shared with
-# Dockerfile.model, so the two paths cannot disagree about which bytes are right.
-FROM debian:trixie-slim AS modelsrc-fetch
-ARG AIMEE_SYNTHESIS_MODEL
-ARG AIMEE_MODEL_MIRROR
-ENV AIMEE_MODEL_MIRROR=${AIMEE_MODEL_MIRROR}
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/*
-COPY scripts/fetch-synthesis-model.sh /usr/local/bin/fetch-synthesis-model.sh
-RUN sh /usr/local/bin/fetch-synthesis-model.sh "$AIMEE_SYNTHESIS_MODEL" /model
-
-# The prebuilt aimee-model-* tag. It is FROM scratch and already contains exactly
-# /model, so this stage is a rename and the layer comes straight from the registry.
-FROM ${AIMEE_MODEL_IMAGE} AS modelsrc-image
-
-FROM modelsrc-${AIMEE_MODEL_SOURCE} AS modelsrc
-
-# ---- llama.cpp, built from source (the *-llm image variants) -------------------
-# BUILT, NOT DOWNLOADED. Upstream publishes a Linux binary for x64 only — there is
-# no ubuntu-arm64 release asset, which a download-based install discovered the hard
-# way when the arm64 half of this matrix 404'd. Compiling from a pinned tag gives
-# both arches one code path, and a git tag is verifiable in a way an unchecksummed
-# release zip is not.
-#
-# THIS MAKES US THE VENDOR. Until now the deployment ran upstream's own image and
-# inherited its CVE fixes for free. LLAMACPP_VERSION is now the only thing deciding
-# which llama.cpp a user runs, and it does not move on its own.
-#
-# The .so copy takes SYMLINKS as well as regular files, with cp -a. The loader
-# resolves by SONAME — libllama-common.so.0 — which is a symlink to the versioned
-# file, so a `-type f` copy took the real file and left the name the binary
-# actually asks for behind. That failed as "cannot open shared object file" at
-# first run; the --version check in the final stage is what surfaced it at build.
-#
-# LLAMA_BUILD_TOOLS=ON is what provides the server at this tag: it lives in
-# tools/server (target llama-server), not examples/. Building with tools off
-# deletes the target and cmake fails with "No rule to make target 'llama-server'".
-# Examples stay off — nothing here needs them. Both flags are version-sensitive:
-# an older llama.cpp had the server under examples/ instead.
-#
-# Every comment stays OUTSIDE the RUN. BuildKit does strip whole-line comments
-# inside a continuation, but a stray one that is not stripped comments out the
-# rest of the joined command, which fails as a puzzling no-op rather than loudly.
-FROM debian:trixie-slim AS llamacpp-1
-ARG LLAMACPP_VERSION
-ARG AIMEE_SYNTHESIS_MODEL
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        build-essential cmake git ca-certificates curl libcurl4-openssl-dev; \
-    git clone --depth 1 --branch "$LLAMACPP_VERSION" \
-        https://github.com/ggml-org/llama.cpp.git /tmp/llamacpp-src; \
-    cmake -S /tmp/llamacpp-src -B /tmp/llamacpp-src/build \
-        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=ON \
-        -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF \
-        -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_SERVER=ON; \
-    cmake --build /tmp/llamacpp-src/build --target llama-server -j"$(nproc)"; \
-    mkdir -p /out; \
-    cp "$(find /tmp/llamacpp-src/build -name llama-server -type f -perm -u+x | head -1)" /out/; \
-    find /tmp/llamacpp-src/build \( -type f -o -type l \) -name '*.so*' \
-        -exec cp -a {} /out/ ';' ; \
-    rm -rf /tmp/llamacpp-src
-# The model, placed here so the running container never downloads anything. It
-# arrives from whichever modelsrc stage AIMEE_MODEL_SOURCE selected: a prebuilt
-# aimee-model-* layer in CI, a direct Hugging Face fetch as the fallback. Either
-# way it has already been verified against Hugging Face's own digest — the check
-# lives in scripts/fetch-synthesis-model.sh, next to the table it checks against.
-COPY --from=modelsrc /model /out/model
-
-# The non-llm variants copy an empty directory, so the COPY below stays
-# unconditional (Dockerfile has no conditional COPY) and costs them nothing.
-FROM debian:trixie-slim AS llamacpp-0
-RUN mkdir -p /out
-
-# Resolved from the global ARG: llamacpp-0 or llamacpp-1.
-FROM llamacpp-${AIMEE_WITH_LLAMACPP} AS llamacpp
-
 # Runtime must match the build stage: libpq5 here has to provide at least the
 # PostgreSQL 17 symbols the kb was linked against (PGDG's libpq 18 does).
 FROM debian:trixie-slim
@@ -250,14 +121,29 @@ RUN apt-get update \
 # place that reads them: scripts/embedders.json.
 #
 # CPU-only torch: the CUDA wheels are ~2GB of accelerator runtime this image never uses.
+#
+# AIMEE_EMBEDDER=none SKIPS ALL OF THIS. A deployment pointing EMBEDDER_URL at an
+# external endpoint still carried CPU torch, sentence-transformers and a baked model
+# it never loads: roughly a gigabyte of image to hold code that never executes. That
+# variant could not be expressed before, and it is the third kb tag now.
+#
+# A conditional RUN body rather than a conditional stage. The weights land in the
+# final image either way; there is nothing to select between, only work to skip.
+ARG AIMEE_EMBEDDER
 ENV EMBEDDER_VENV=/opt/aimee/embedder-venv
-RUN python3 -m venv "$EMBEDDER_VENV" \
-    && "$EMBEDDER_VENV/bin/pip" install --no-cache-dir --quiet \
-        --index-url https://download.pytorch.org/whl/cpu torch \
-    && "$EMBEDDER_VENV/bin/pip" install --no-cache-dir --quiet \
-        "sentence-transformers>=3.3" "transformers>=5.2" einops \
-    && find "$EMBEDDER_VENV" -name '__pycache__' -type d -prune -exec rm -rf {} + \
-    && rm -rf /root/.cache/pip
+RUN set -eux; \
+    if [ "$AIMEE_EMBEDDER" = "none" ]; then \
+      echo "AIMEE_EMBEDDER=none: no in-container embedder is baked;" \
+           "EMBEDDER_URL must be set at runtime"; \
+    else \
+      python3 -m venv "$EMBEDDER_VENV"; \
+      "$EMBEDDER_VENV/bin/pip" install --no-cache-dir --quiet \
+          --index-url https://download.pytorch.org/whl/cpu torch; \
+      "$EMBEDDER_VENV/bin/pip" install --no-cache-dir --quiet \
+          "sentence-transformers>=3.3" "transformers>=5.2" einops; \
+      find "$EMBEDDER_VENV" -name '__pycache__' -type d -prune -exec rm -rf {} +; \
+      rm -rf /root/.cache/pip; \
+    fi
 
 # DB2 engine, from PGDG rather than Debian: trixie ships PostgreSQL 17 with
 # pgvector 0.8.0, and its pgvector hard-depends on postgresql-17-jit-llvm, which
@@ -338,13 +224,17 @@ COPY scripts/embedder-server.py /opt/aimee/scripts/embedder-server.py
 # registry's revision: a floating ref would let a rebuild change the vector space
 # silently.
 #
-# AIMEE_EMBEDDER selects the registry entry. Four images come out of this file:
+# AIMEE_EMBEDDER selects the registry entry. THREE images come out of this file,
+# and the embedder is now the only axis:
 #
-#   AIMEE_EMBEDDER            AIMEE_WITH_LLAMACPP   image
-#   bekko-a25m (384)          0                     aimee-kb
-#   bekko-a25m (384)          1                     aimee-kb-llm
-#   nomic-embed-text-v2-moe   0                     aimee-kb-nomic
-#   nomic-embed-text-v2-moe   1                     aimee-kb-nomic-llm
+#   AIMEE_EMBEDDER            image            notes
+#   none                      aimee-kb         no torch, no weights; EMBEDDER_URL required
+#   bekko-a25m (384)          aimee-kb-a25m
+#   nomic-embed-text-v2-moe   aimee-kb-nomic
+#
+# Synthesis used to be a second axis here, doubling the matrix. It is its own image
+# now (aimee-llm-e2b / -e4b) deployed beside this one, because llama.cpp and a
+# multi-gigabyte GGUF have no business being rebuilt every time kb code changes.
 #
 # The registry lists both models; only the selected one is fetched. Baking both
 # would put nomic's ~1.8GB into every image, which is why these are separate tags.
@@ -372,9 +262,22 @@ ARG AIMEE_EMBEDDER=bekko-a25m
 ENV HF_HOME=/opt/aimee/models \
     HF_MODULES_CACHE=/var/lib/aimee/.cache/huggingface/modules \
     HF_HUB_OFFLINE=1
+# Skipped on AIMEE_EMBEDDER=none, which has no venv to run this with: the interpreter
+# lives in the venv the step above did not create.
+#
+# The SKIP IS THE INTERPRETER, not an `if` around the heredoc. Docker ends a RUN at
+# the heredoc terminator, so a trailing `fi` after PYBAKE is parsed as a Dockerfile
+# instruction and the build dies with "unknown instruction: fi". Choosing /bin/true
+# before the heredoc keeps this one instruction: the shell still feeds it the script,
+# and it discards it.
 RUN --mount=type=cache,target=/root/.cache/huggingface \
+    if [ "$AIMEE_EMBEDDER" = "none" ]; then \
+      echo "AIMEE_EMBEDDER=none: no weights baked"; BAKE=/bin/true; \
+    else \
+      BAKE="$EMBEDDER_VENV/bin/python"; \
+    fi; \
     AIMEE_EMBEDDER="$AIMEE_EMBEDDER" \
-    HF_HUB_OFFLINE=0 "$EMBEDDER_VENV/bin/python" - <<'PYBAKE'
+    HF_HUB_OFFLINE=0 "$BAKE" - <<'PYBAKE'
 import json, os, sys
 from huggingface_hub import snapshot_download
 with open("/opt/aimee/embedders.json", encoding="utf-8") as handle:
@@ -438,41 +341,20 @@ PYBAKE
 # so the model still loads — it just logs "Ignoring corrupted tree cache file …
 # Permission denied" on every start and re-walks what the cache existed to avoid.
 # a+rX: readable everywhere, traversable on directories, and no file gains +x.
-RUN chmod -R a+rX /opt/aimee/models
+# The directory does not exist on AIMEE_EMBEDDER=none, and chmod -R on a missing
+# path is an error rather than a no-op.
+RUN if [ -d /opt/aimee/models ]; then chmod -R a+rX /opt/aimee/models; fi
 
-# ---- bundled llama.cpp + its model --------------------------------------------
-# Built and fetched in the llamacpp stage above; that stage is EMPTY on the non-llm
-# variants, so this COPY is unconditional and costs them nothing.
+# NO BUNDLED SYNTHESIS. llama.cpp and its GGUF used to be baked here, which coupled a
+# multi-gigabyte, near-static artefact to the image rebuilt on every kb code change:
+# three kb tags under three cache scopes each rebuilding the LTO C binary, postgres,
+# pgvectorscale and torch, and pushing ~10 GB twice, for one code change.
 #
-# The model is IN THE IMAGE. SYNTHESIS_ENDPOINT points at loopback when llama.cpp
-# is present, and the running container downloads nothing.
-ARG AIMEE_WITH_LLAMACPP
-ARG LLAMACPP_VERSION
-ARG AIMEE_SYNTHESIS_MODEL
-COPY --from=llamacpp /out/ /opt/aimee/llama.cpp/
-# The shared objects ship beside the binary, which is not a default search path.
-#
-# NO trailing ${LD_LIBRARY_PATH}. Nothing sets it earlier in this image, so
-# appending it expanded to a trailing colon — and an EMPTY entry in
-# LD_LIBRARY_PATH means "search the current working directory", which would let a
-# stray .so wherever the process happens to be running take precedence over the
-# real one. BuildKit flagged it as UndefinedVar; the warning was pointing at a
-# genuine loader hazard rather than at untidiness.
-ENV LD_LIBRARY_PATH=/opt/aimee/llama.cpp
-# Prove BOTH halves in THIS image before shipping it. A server that cannot resolve
-# its own .so files, or a model file that did not survive the copy, otherwise fails
-# at first synthesis — which is exactly the class of "it deployed fine and does
-# nothing" this baking is meant to remove.
-RUN set -eux; \
-    if [ "$AIMEE_WITH_LLAMACPP" = "1" ]; then \
-      chmod +x /opt/aimee/llama.cpp/llama-server; \
-      /opt/aimee/llama.cpp/llama-server --version; \
-      test -s /opt/aimee/llama.cpp/model/synthesis.gguf; \
-      test "$(cat /opt/aimee/llama.cpp/model/MODEL_ID)" = "$AIMEE_SYNTHESIS_MODEL"; \
-    fi
-ENV AIMEE_WITH_LLAMACPP=${AIMEE_WITH_LLAMACPP} \
-    AIMEE_LLAMACPP_VERSION=${LLAMACPP_VERSION} \
-    AIMEE_SYNTHESIS_MODEL=${AIMEE_SYNTHESIS_MODEL}
+# They now live in aimee-llm-e{2,4}b, deployed beside this container and reached over
+# mTLS. The weights are still baked -- into the image whose inputs change on the order
+# of never -- so the reason they were baked is intact. The kb resolves
+# SYNTHESIS_ENDPOINT exactly as it does for any external provider; it no longer cares
+# whether the model is on the same host.
 
 # Sidecar clients (the LLM access code the kb invokes via popen).
 COPY scripts/embed-remote.py scripts/llm-chat.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,16 @@ RUN apt-get update \
 #
 # A conditional RUN body rather than a conditional stage. The weights land in the
 # final image either way; there is nothing to select between, only work to skip.
-ARG AIMEE_EMBEDDER
+# The default matches the one on the bake ARG below, and it is NOT optional: `set -u`
+# aborts on an unset variable, so declaring this bare made every build that does not
+# pass --build-arg AIMEE_EMBEDDER fail with
+#   /bin/sh: 1: AIMEE_EMBEDDER: parameter not set
+# The publish workflows always pass it; compose builds (and the e2e-docker tests that
+# use them) do not, which is why building locally never reproduced it.
+#
+# bekko rather than `none`, so a build with no build-arg behaves exactly as it did
+# before this change. `none` is opt-in.
+ARG AIMEE_EMBEDDER=bekko-a25m
 ENV EMBEDDER_VENV=/opt/aimee/embedder-venv
 RUN set -eux; \
     if [ "$AIMEE_EMBEDDER" = "none" ]; then \

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -86,66 +86,18 @@ start_embedder() {
     embedder_pid=$!
 }
 
-# ---- bundled synthesis (the *-llm image variants) ---------------------------
-# Same shape as the embedder above, and deliberately so: selection resolves to a
-# URL, and the kb then reaches a bundled model exactly as it reaches a remote one.
+# ---- synthesis --------------------------------------------------------------
+# NOTHING TO START. Synthesis used to run inside this container from a GGUF baked
+# into the *-llm image variants. It is its own image now (aimee-llm-e2b / -e4b),
+# deployed beside this one and reached over mTLS, because llama.cpp and multi-
+# gigabyte weights should not be rebuilt every time kb code changes.
 #
-#   SYNTHESIS_ENDPOINT set -> a remote endpoint; start nothing.
-#   this image has a model -> serve it, and export SYNTHESIS_ENDPOINT at loopback.
-#   neither                -> start nothing. Synthesis is OFF, which is supported:
-#                             embedding, search, recall and indexing never call it.
+# The kb therefore treats every provider the same way it has always treated a remote
+# one: SYNTHESIS_ENDPOINT names it, or synthesis is off. Off is a supported state,
+# not an error -- embedding, search, recall and indexing never call it.
 #
-# THE MODEL IS IN THE IMAGE, AND THIS NEVER DOWNLOADS. Which model is a property of
-# the tag (aimee-kb-llm-e2b vs -e4b), the same way the embedder is. A runtime fetch
-# was the earlier design and it is a support burden: it fails on a rate limit,
-# behind a proxy, on a flaky link, on an air-gapped host, or silently serves the
-# wrong file when a quant tag stops resolving — and all of those reach the operator
-# as "synthesis never started", long after deploy. `docker pull` is the one
-# download, with the registry's retry and resume behind it.
-#
-# Nothing here reads AIMEE_HOME for weights any more: no HF_HOME, no cache, no
-# partial-download state to reason about.
-SYNTHESIS_MODEL_DIR=/opt/aimee/llama.cpp/model
-
-start_synthesis() {
-    if [ -n "${SYNTHESIS_ENDPOINT:-}" ]; then
-        echo "aimee-kb: remote synthesis configured ($SYNTHESIS_ENDPOINT); bundled model not loaded" >&2
-        return 0
-    fi
-
-    llama=/opt/aimee/llama.cpp/llama-server
-    model="$SYNTHESIS_MODEL_DIR/synthesis.gguf"
-    if [ ! -x "$llama" ] || [ ! -s "$model" ]; then
-        echo "aimee-kb: this image has no bundled synthesis model; synthesis is off" \
-             "(embedding, search, recall and indexing are unaffected). Use an" \
-             "aimee-kb-*-llm-e2b/-e4b image, or set SYNTHESIS_ENDPOINT." >&2
-        return 0
-    fi
-
-    # The image records which model it carries; the kb reports it and the wizard
-    # shows it. Never guessed from the filename.
-    if [ -z "${SYNTHESIS_MODEL:-}" ] && [ -r "$SYNTHESIS_MODEL_DIR/MODEL_ID" ]; then
-        SYNTHESIS_MODEL="$(cat "$SYNTHESIS_MODEL_DIR/MODEL_ID")"
-        export SYNTHESIS_MODEL
-    fi
-
-    : "${SYNTHESIS_PORT:=8761}"
-    export SYNTHESIS_PORT
-    echo "aimee-kb: starting bundled synthesis (${SYNTHESIS_MODEL:-unknown}) on :$SYNTHESIS_PORT" >&2
-    # --no-mmproj: every benchmark run passed it and the shipped service never did,
-    # so production loaded a vision/audio projector for a text-only task that cannot
-    # use it. Only the text GGUF is baked, so there is no projector to load here —
-    # the flag keeps it that way if a future image bakes one.
-    LLAMA_ARG_MMPROJ_AUTO=false \
-        "$llama" -m "$model" --host 127.0.0.1 --port "$SYNTHESIS_PORT" \
-                 -c 8192 --no-webui --no-mmproj >&2 &
-    synthesis_pid=$!
-
-    # One precedence rule for both cases, as with the embedder: the kb reaches the
-    # bundled model the same way it would reach a remote one.
-    SYNTHESIS_ENDPOINT="http://127.0.0.1:$SYNTHESIS_PORT/v1"
-    export SYNTHESIS_ENDPOINT
-}
+# The mTLS material for the sidecar hop is issued by the kb at startup, not here;
+# see kb_synthesis_identity.c.
 
 set -e
 
@@ -309,7 +261,6 @@ if [ "$external_db" -eq 0 ]; then
     AIMEE_DB2_URL="$embedded_dsn" aimee-kb --bootstrap-vault-env
 
     start_embedder
-    start_synthesis
 
     # Not exec: the trap above has to outlive the kb so the cluster shuts down
     # cleanly. Forward the stop signal so the kb still gets its own shutdown.
@@ -368,5 +319,4 @@ if [ "$external_db" -eq 0 ]; then
 fi
 
 start_embedder
-start_synthesis
 exec aimee-kb "$@"

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -105,15 +105,20 @@ Deploy one locally, or point at an existing `aimee-kb`. A local knowledge base i
 needs nothing else installed.
 
 For a local KB, the remaining steps place its embedder and optional synthesizer, choose the bundled
-or external shared store, connect an optional Git host, and add workspaces. A model role can run
-inside the KB container or use a remote endpoint where the selected profile offers that choice. A Git
-connection can be skipped because public repositories do not require one. You can continue without a
+or external shared store, connect an optional Git host, and add workspaces. The embedder runs inside
+the KB container; synthesis runs in its own sidecar or at a remote endpoint. A Git connection can be
+skipped because public repositories do not require one. You can continue without a
 workspace, but setup remains incomplete until at least one project exists.
 
 After the numbered steps, the summary shows a **Deploy the local stack** panel. Its **Deploy** action
-starts one `aimee-kb`, including private PostgreSQL 18, pgvector, and pgvectorscale. Its selected
-model roles run inside that container or at remote endpoints; there is no separate inference
-service. See [Choosing an embedder](#choosing-an-embedder) and
+starts one `aimee-kb`, including private PostgreSQL 18, pgvector, and pgvectorscale.
+
+**The embedder runs inside that container. Synthesis does not.** Embedding is served from weights
+baked into the KB image, so it needs no second container. If you selected a local synthesis model,
+Deploy also starts an `aimee-llm` sidecar beside the KB, and the KB reaches it over mutual TLS on the
+Compose network. Choose an external endpoint instead and no sidecar is deployed at all; choose neither
+and synthesis is simply off, which is a supported state. See
+[Choosing an embedder](#choosing-an-embedder), [Local synthesis](#local-synthesis) and
 [KB model backends](KB_LLM_BACKENDS.md).
 
 For a local managed KB, Deploy also runs two explicit one-shot jobs before it
@@ -163,8 +168,22 @@ available.
 ### Choosing an embedder
 
 The wizard's **Deploy topology** step records which embedder the KB uses. Choose one before Deploy.
-The bundled `bekko-a25m` (384-dimension) ships inside the KB image, so it needs no download and no
-second container. Point the KB at your own endpoint instead if you need a wider model.
+
+Which embedder a KB can run is a property of the image you pulled, because the weights are baked in:
+
+| image | embedder | size |
+| --- | --- | --- |
+| `aimee-kb` | none; set `EMBEDDER_URL` | 373 MB |
+| `aimee-kb-a25m` | `bekko-a25m`, 384-dimension | 1.95 GB |
+| `aimee-kb-nomic` | `nomic-embed-text-v2-moe`, 768-dimension | 3.34 GB |
+
+A bundled embedder needs no download and no second container. `aimee-kb` carries none at all, which
+is the right choice when you point `EMBEDDER_URL` at your own endpoint: it omits PyTorch and the
+weights rather than shipping code it never runs.
+
+**This choice does not survive a change of mind.** DB2 records the vector-column width and refuses to
+start when it drifts, so moving between 384 and 768 means re-embedding the whole corpus. Choose before
+you ingest anything.
 
 Nothing is selected on a fresh install, and an unselected KB is not broken. It falls back to a
 builtin lexical embedder and says so once, in the KB log:
@@ -178,7 +197,7 @@ Retrieval still works in that state, but it is keyword matching, not vector sear
 the step, set it from the server and re-run Deploy:
 
 ```bash
-aimee config set embedding_model bekko-a25m
+aimee config set embedder_model bekko-a25m
 ```
 
 Confirm the model actually loaded rather than assuming it did:
@@ -200,6 +219,48 @@ the choice does not perform the migration. A different dimension needs the guard
 reset; a same-dimension model, pooling, or prefix change needs a fresh DB2 and source re-ingestion
 because the current reset command deliberately no-ops when the dimensions match. Follow
 [Change the KB embedder](runbooks/change-embedder.md) before changing an active corpus.
+
+### Local synthesis
+
+Synthesis writes curation and summaries. Unlike the embedder it is not inside the KB container: it is
+its own image, `aimee-llm-e2b` or `aimee-llm-e4b`, deployed beside the KB when the wizard selects a
+local model. Which model it carries is a property of the tag, because the weights are baked in.
+
+| image | model | weights |
+| --- | --- | --- |
+| `aimee-llm-e2b` | gemma-4-E2B-it | 4.71 GB |
+| `aimee-llm-e4b` | gemma-4-E4B-it | 7.46 GB |
+
+E4B is the better model; E2B is roughly half the resident memory and about twice the CPU speed. See
+[Choosing a synthesis model](SYNTHESIS_MODELS.md) for the measurements behind that.
+
+Three states are all supported, and `off` is not an error: embedding, search, recall and indexing
+never call synthesis.
+
+- **local**: an `aimee-llm-*` sidecar, reached over mutual TLS
+- **external**: `SYNTHESIS_ENDPOINT` at any OpenAI-compatible endpoint
+- **off**: no synthesis
+
+**Unlike the embedder, this is not a one-way door.** The sidecar holds no data, so switching between
+E2B and E4B, adding synthesis to a running deployment, or removing it is a container swap with the KB
+left running.
+
+Confirm the sidecar actually came up, rather than assuming Deploy succeeded:
+
+```bash
+docker compose -f compose.server-managed.yaml logs aimee-llm | grep -iE 'synthesis|terminator'
+```
+
+A working sidecar logs both halves:
+
+```text
+aimee-llm: starting synthesis (gemma-4-E2B-it) on 127.0.0.1:8760
+aimee-llm: starting mTLS terminator on :8761 (client certificate required)
+```
+
+The mTLS identity is issued by the KB at startup, which is why the KB is deployed first. The sidecar
+refuses to start without it rather than serving unauthenticated, so "no identity" fails loudly at
+deploy instead of quietly at the first curation call.
 
 ### Choosing an image channel
 

--- a/docs/SYNTHESIS_MODELS.md
+++ b/docs/SYNTHESIS_MODELS.md
@@ -15,8 +15,8 @@ distinction this page replaces.
 | You want | Do this | What you get |
 | --- | --- | --- |
 | **Simplest thing that works** | Point `SYNTHESIS_ENDPOINT` at an external OpenAI-compatible endpoint | Best quality, no local GPU or RAM cost, your notes leave the machine |
-| **Local, and quality matters most** | pull `aimee-kb-llm-e4b` (or `aimee-kb-nomic-llm-e4b`) | 0.82 F1 extraction, 7.46 GB of weights, 3.3 tok/s on 8 CPU threads |
-| **Local, and the box is small** | pull `aimee-kb-llm-e2b` (or `aimee-kb-nomic-llm-e2b`) | 0.69 F1 extraction, 4.71 GB of weights, 6.3 tok/s on 8 CPU threads |
+| **Local, and quality matters most** | deploy the `aimee-llm-e4b` sidecar | 0.82 F1 extraction, 7.46 GB of weights, 3.3 tok/s on 8 CPU threads |
+| **Local, and the box is small** | deploy the `aimee-llm-e2b` sidecar | 0.69 F1 extraction, 4.71 GB of weights, 6.3 tok/s on 8 CPU threads |
 
 The weight sizes are what the images actually carry: UD-Q6_K_XL, baked in. The F1
 and throughput numbers were measured at Q8_0, so read them as the shape of the
@@ -263,17 +263,22 @@ Two further warnings that are not about size:
 
 ## Running one of these locally
 
-**The model is part of the image.** You do not select it at runtime. You pull the
-tag that carries it, exactly as you do for the embedder:
+**The model is part of the image.** You do not select it at runtime. You deploy the sidecar tag that
+carries it, exactly as the embedder is a property of the kb tag:
 
-| image | embedder | synthesis |
-| --- | --- | --- |
-| `aimee-kb` | bekko-a25m (384) | none |
-| `aimee-kb-llm-e2b` | bekko-a25m (384) | gemma-4-E2B-it |
-| `aimee-kb-llm-e4b` | bekko-a25m (384) | gemma-4-E4B-it |
-| `aimee-kb-nomic` | nomic-v2 (768) | none |
-| `aimee-kb-nomic-llm-e2b` | nomic-v2 (768) | gemma-4-E2B-it |
-| `aimee-kb-nomic-llm-e4b` | nomic-v2 (768) | gemma-4-E4B-it |
+| image | model |
+| --- | --- |
+| `aimee-llm-e2b` | gemma-4-E2B-it |
+| `aimee-llm-e4b` | gemma-4-E4B-it |
+
+Synthesis used to be baked into the kb image, producing six kb tags across two axes. It is its own
+image now, deployed beside the kb, for a reason that had nothing to do with the models: llama.cpp and
+a multi-gigabyte GGUF were being rebuilt on every push that touched kb code, while their real inputs
+change on the order of never.
+
+It buys an operational property too. The sidecar holds no data, so moving between E2B and E4B, adding
+synthesis to a running deployment, or removing it, is a container swap with the kb left running. The
+embedder is still a one-way door; synthesis is not.
 
 Weights are baked at UD-Q6_K_XL (7.46 GB for E4B, 4.71 GB for E2B) from
 unsloth's GGUF repos, which is where the UD quants are published.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -222,32 +222,48 @@ without answering; `MF_LLM_OUT_CAP` bounds the damage either way.
 
 ## Choosing an aimee-kb image is a one-way door
 
-There are six `aimee-kb` images now. BOTH models are baked, so which embedder and
-which synthesis model a deployment runs is decided by the tag it pulls:
+There are three `aimee-kb` images, on one axis: the embedder. Its weights are baked,
+so which embedder a deployment runs is decided by the tag it pulls:
 
-| | no synthesis | + gemma-4-E2B-it | + gemma-4-E4B-it |
-| --- | --- | --- | --- |
-| bekko-a25m (384-dim) | `aimee-kb` | `aimee-kb-llm-e2b` | `aimee-kb-llm-e4b` |
-| nomic-v2 (768-dim) | `aimee-kb-nomic` | `aimee-kb-nomic-llm-e2b` | `aimee-kb-nomic-llm-e4b` |
+| image | embedder | size |
+| --- | --- | --- |
+| `aimee-kb` | none; `EMBEDDER_URL` required | 373 MB |
+| `aimee-kb-a25m` | bekko-a25m, 384-dim | 1.95 GB |
+| `aimee-kb-nomic` | nomic-v2, 768-dim | 3.34 GB |
 
 **The embedder axis cannot be changed after the KB has embedded anything.** DB2
 records the vector-column width and refuses to start on drift, so moving between a
 384-dim and a 768-dim image means re-embedding the whole corpus. Choose before you
-ingest. An external embedder (`EMBEDDER_URL`) shares the bekko images and may be any
-width up to 4000, the DB2 column ceiling, not 4096.
+ingest. An external embedder (`EMBEDDER_URL`) may be any width up to 4000, the DB2
+column ceiling, not 4096, and the `aimee-kb` tag exists for exactly that case: it
+carries neither PyTorch nor weights.
 
-The llama.cpp axis is not one-way: it decides only whether synthesis can run on the
-same host. The setup wizard disables the local model options on an image without it
-rather than offering a choice that cannot work.
+**Synthesis is no longer an axis here.** It was, which is why earlier drafts of this
+page described six tags. It is now its own image deployed beside the kb, so the
+matrix collapsed to the embedder alone:
 
-Bundling llama.cpp means this project now pins it, rather than inheriting upstream's
-image and its CVE fixes. `LLAMACPP_VERSION` in the Dockerfile is the single pin and
-needs deliberate bumping.
+| image | model |
+| --- | --- |
+| `aimee-llm-e2b` | gemma-4-E2B-it |
+| `aimee-llm-e4b` | gemma-4-E4B-it |
+
+If you are upgrading from an `aimee-kb-llm-*` or `aimee-kb-nomic-llm-*` tag, those no
+longer exist. Pull the matching embedder-only kb image and deploy the sidecar beside
+it: `aimee-kb-llm-e4b` becomes `aimee-kb-a25m` plus `aimee-llm-e4b`. The kb reaches
+the sidecar over mutual TLS, using an identity the kb itself issues at startup, so
+deploy the kb first.
+
+Unlike the embedder, the synthesis choice is reversible: the sidecar holds no data, so
+switching models or removing it entirely leaves the corpus untouched.
+
+Bundling llama.cpp means this project pins it, rather than inheriting upstream's image
+and its CVE fixes. `LLAMACPP_VERSION` in `Dockerfile.llm` is the single pin and needs
+deliberate bumping.
 
 ## Bundled synthesis weights are baked into the image
 
-The weights ship inside the `*-llm` images at UD-Q6_K_XL: 7.46 GB for E4B, 4.71 GB
-for E2B. The container downloads nothing at any point: an image either has its model
+The weights ship inside the `aimee-llm-*` images at UD-Q6_K_XL: 7.46 GB for E4B,
+4.71 GB for E2B. The container downloads nothing at any point: an image either has its model
 or it does not, and `docker pull` is the one download, with the registry's retry and
 resume behind it.
 


### PR DESCRIPTION
Step 5 of #2256, stacked on #2259. **Merge #2259 first** — this branch contains it,
so its diff will shrink to the kb changes once that lands.

## The kb image, on one axis

| tag | embedder | size |
| --- | --- | --- |
| `aimee-kb` | none | **373 MB** |
| `aimee-kb-a25m` | bekko-a25m (384) | **1.95 GB** |
| `aimee-kb-nomic` | nomic-v2-moe (768) | **3.34 GB** |

Six tags become three. Synthesis was the second axis and it doubled everything for an
artefact whose inputs never change; it is `aimee-llm-e{2,4}b` now. The images that axis
produced were 6.68 GB and 9.43 GB, and they rebuilt on every push touching `src/**`.
A push now rebuilds 1.95 GB instead of 6.68 GB.

**`none` is not just a smaller matrix entry.** A deployment on an external embedder
still carried CPU torch, sentence-transformers and a baked model it never loads. All
three sizes are measured on one host, not estimated — and `a25m` comes out byte-identical
in size to the currently published `aimee-kb`, which is the evidence that the conditional
does not disturb the path every existing deployment uses.

## Verified by building, because lint could not see any of it

Three defects here were found by building on a real Docker host, none by `make lint`:

- **`dockerfile parse error: unknown instruction: fi`.** Docker ends a `RUN` at the
  heredoc terminator, so a shell conditional cannot wrap one. The skip is now the
  *interpreter* (`/bin/true` vs the venv Python), chosen before the heredoc. The comment
  says so, because the next person will try the `if`.
- **A root-owned identity volume.** Docker initialises a named volume from the image's
  content at the mount point; the path was absent, so the volume came up root-owned and
  the kb runs as `aimee`. Every fresh deployment would have produced a sidecar with no
  identity to present. The unit test missed it by creating the directory as the same user
  it then wrote as.
- **`env:` with no keys.** Removing `MODEL_QUANT` left the top-level `env:` holding only
  comments. GitHub rejects a null `env:` and reports "this run likely failed because of a
  workflow file issue" with no job log. `yaml.safe_load` parses it happily, which is why
  validating with it was not enough.

## Also here

- The kb entrypoint no longer starts anything for synthesis; it resolves
  `SYNTHESIS_ENDPOINT` as it always did for a remote provider, and off stays supported.
- The `models` job moves out of both kb pipelines into `publish-llm.yml`. Nothing in the
  kb workflows consumed it once synthesis left, and a model layer belongs with what bakes it.
- `publish-images.yml`'s header corrected; it still described six tags and claimed the
  model images lived there.

## Not done, deliberately

`docs/SYNTHESIS_MODELS.md`, `docs/UPGRADING.md` and `deployTopology.ts` still describe the
old matrix. Kept out of a behaviour-changing PR to keep it reviewable; they are the next
piece of work, and #2256 records what they need to say.

## Verification

`make all` · `make lint` 41 checks · all three variants built and measured on a real
Docker host · `scripts/test-synthesis-mtls-hop.sh` 9/9 against the built images.

**Not verified:** no kb variant has been booted beyond the `a25m` container used for the
mTLS hop test, so `none` and `nomic` are build-verified only.
