### PR TITLE
deploy: wire the wizard to the images it now has to choose between

### DIFF
--- a/compose.server-managed.yaml
+++ b/compose.server-managed.yaml
@@ -89,7 +89,7 @@ services:
       # The managed KB image contains any model role placed inside that KB.
       # Remote role endpoints and credentials remain owned by the KB; there is no
       # separate inference-service image to select here.
-      AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
+      AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb${AIMEE_KB_VARIANT:+-${AIMEE_KB_VARIANT}}:${AIMEE_IMAGE_TAG:-latest}}
       # Separate one-shot image containing the offline root provisioner and JWKS
       # publisher. These binaries never enter the ordinary KB/server images.
       AIMEE_AUTHORITY_BOOTSTRAP_IMAGE: ${AIMEE_AUTHORITY_BOOTSTRAP_IMAGE:-ghcr.io/rakuensoftware/aimee-authority-bootstrap:${AIMEE_IMAGE_TAG:-latest}}

--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -32,7 +32,7 @@ services:
   aimee-kb:
     profiles: ["kb"]
     restart: unless-stopped
-    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb${AIMEE_KB_VARIANT:+-${AIMEE_KB_VARIANT}}:${AIMEE_IMAGE_TAG:-latest}}
     networks: [aimee]
     # The kb's worker threads need a 64 MB stack (the 8 MB default SIGSEGVs on real
     # kb queries). Matches systemd's LimitSTACK=67108864.
@@ -112,7 +112,7 @@ services:
   # volumes, so no key, enrollment token, or trust material crosses host argv.
   aimee-server-identity:
     profiles: ["identity-bootstrap"]
-    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:${AIMEE_IMAGE_TAG:-latest}}
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb${AIMEE_KB_VARIANT:+-${AIMEE_KB_VARIANT}}:${AIMEE_IMAGE_TAG:-latest}}
     user: "0:0"
     networks: [aimee]
     environment:
@@ -165,7 +165,7 @@ services:
   aimee-llm:
     profiles: ["llm"]
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm-e4b:${AIMEE_IMAGE_TAG:-latest}}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm-${AIMEE_LLM_VARIANT:-e4b}:${AIMEE_IMAGE_TAG:-latest}}
     networks: [aimee]
     environment:
       AIMEE_LLM_IDENTITY_DIR: /var/lib/aimee-llm/tls

--- a/src/modules/config/config_database.c
+++ b/src/modules/config/config_database.c
@@ -276,15 +276,26 @@ void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
    } while (0)
 
    const int remote_kb = strcmp(cfg->kb_mode, "remote") == 0;
+   /* Local synthesis is a MODEL WITH NO ENDPOINT, which is the contract the wizard
+    * writes (synthesisToConfig in deployTopology.ts): "bundled" sets synthesis_model
+    * and leaves synthesis_endpoint empty, "external" sets the endpoint, "off" sets
+    * neither. Read it here rather than adding a mode field the two could disagree
+    * about. */
+   const int local_synthesis = !remote_kb && cfg->synthesis_model[0] && !cfg->synthesis_endpoint[0];
 
-   /* COMPOSE_PROFILES: a remote kb deploys nothing; a local kb runs the "kb" service
-    * and that is all. There is no longer an inference service to gate a profile on —
-    * the kb embeds in-container from baked weights and the reranker is gone, so the
-    * "llm" profile has nothing behind it. Synthesis resolves an external endpoint,
-    * which is configuration rather than a deployed service. */
+   /* COMPOSE_PROFILES: a remote kb deploys nothing; a local kb runs "kb", and adds
+    * "llm" when synthesis runs on this host.
+    *
+    * The "llm" profile came back. It was dropped when the old aimee-llm container was
+    * retired, and deploy_apply.c kept its managed-inference mechanism alive against a
+    * stub profile precisely because synthesis was expected to become a managed service
+    * again. It has: aimee-llm-e{2,4}b carries llama.cpp and one baked GGUF beside the
+    * kb. Without this emission the service exists in Compose and nothing ever starts
+    * it, so a wizard selecting a local model produced a deployment with no synthesis
+    * and no error. */
    char profiles[64] = "";
    if (!remote_kb)
-      snprintf(profiles, sizeof(profiles), "kb");
+      snprintf(profiles, sizeof(profiles), local_synthesis ? "kb,llm" : "kb");
    EMITF("COMPOSE_PROFILES=%s\n", profiles);
 
    if (remote_kb)
@@ -298,6 +309,30 @@ void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
     * serves the selected model itself, so all the deploy layer passes on is WHICH model
     * (the wizard's choice, which the kb resolves from its registry) and, for an external
     * embedder, the endpoint to use instead. */
+   /* WHICH KB IMAGE. The embedder is baked, so the choice is an image, not just a
+    * setting: aimee-kb carries none, aimee-kb-a25m carries bekko, aimee-kb-nomic
+    * carries nomic. Emitting only EMBEDDER_MODEL told the kb to start a model whose
+    * weights its image might not contain.
+    *
+    * That was a live regression rather than a missing feature: `aimee-kb` used to mean
+    * "bekko baked in" and now means "no embedder", so an existing managed deployment
+    * pulling a new tag would be handed EMBEDDER_MODEL=bekko-a25m and an image with no
+    * bekko in it.
+    *
+    * Only the VARIANT is emitted; Compose composes the reference, so the registry and
+    * the tag stay in one place instead of being rebuilt in C. Empty means plain
+    * aimee-kb, which is also the right image for an external embedder: it carries
+    * neither PyTorch nor weights. */
+   const char *kb_variant = "";
+   if (!cfg->embedder_url[0])
+   {
+      if (strcmp(cfg->embedder_model, "bekko-a25m") == 0)
+         kb_variant = "a25m";
+      else if (strcmp(cfg->embedder_model, "nomic-embed-text-v2-moe") == 0)
+         kb_variant = "nomic";
+   }
+   EMITF("AIMEE_KB_VARIANT=%s\n", kb_variant);
+
    if (cfg->embedder_model[0])
       EMITF("EMBEDDER_MODEL=%s\n", cfg->embedder_model);
    /* A non-empty URL IS the external embedder — there is no separate backend
@@ -316,6 +351,30 @@ void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
       EMITF("SYNTHESIS_ENDPOINT=%s\n", cfg->synthesis_endpoint);
    if (cfg->synthesis_model[0])
       EMITF("SYNTHESIS_MODEL=%s\n", cfg->synthesis_model);
+
+   /* The sidecar hop. A bundled model leaves synthesis_endpoint empty by contract, so
+    * the endpoint has to be supplied here or the kb has a deployed sidecar it never
+    * calls -- synthesis "configured" and idle, which is the failure this whole design
+    * set out to remove.
+    *
+    * AIMEE_LLM_HOST is what makes the kb mint the mTLS identities at startup, and it
+    * doubles as the certificate's DNS name, so it must equal the Compose service name.
+    *
+    * The three TLS paths are inside the kb container, on the volume the kb writes and
+    * the sidecar reads. They are emitted ONLY for the local sidecar:
+    * SYNTHESIS_CA_FILE replaces the system trust store for that request, so setting
+    * them alongside an external https endpoint would reject a certificate that is
+    * perfectly valid. */
+   if (local_synthesis)
+   {
+      const char *variant = strstr(cfg->synthesis_model, "E2B") ? "e2b" : "e4b";
+      EMITF("AIMEE_LLM_VARIANT=%s\n", variant);
+      EMITF("AIMEE_LLM_HOST=aimee-llm\n");
+      EMITF("SYNTHESIS_ENDPOINT=https://aimee-llm:8761/v1\n");
+      EMITF("SYNTHESIS_CA_FILE=%s\n", "/var/lib/aimee/synthesis-tls/ca.pem");
+      EMITF("SYNTHESIS_CERT_FILE=%s\n", "/var/lib/aimee/synthesis-tls/client.pem");
+      EMITF("SYNTHESIS_KEY_FILE=%s\n", "/var/lib/aimee/synthesis-tls/client.key");
+   }
    /* embedder_api_key and synthesis_api_key are deliberately NOT emitted. A
     * credential in a long-lived service environment is exactly what
     * check-vault-only-container-env forbids: Config.Env persists, so anything

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -2550,11 +2550,20 @@ int main(void)
       snprintf(cfg.synthesis_endpoint, sizeof(cfg.synthesis_endpoint), "https://api.x/v1");
       config_emit_deploy_env(&cfg, env, sizeof(env));
       assert(strstr(env, "COMPOSE_PROFILES=kb\n") != NULL);
-      assert(strstr(env, ",llm") == NULL); /* the retired container takes its profile */
+      /* An EXTERNAL endpoint deploys no sidecar: nothing local serves synthesis. */
+      assert(strstr(env, ",llm") == NULL);
       assert(strstr(env, "EMBEDDER_MODEL=bekko-a25m\n") != NULL);
+      /* The embedder is BAKED, so the choice picks an image, not just a setting.
+       * Emitting the model alone told the kb to start weights its image might not
+       * contain -- and `aimee-kb` changed meaning from "bekko" to "no embedder", so
+       * that combination was a live regression rather than a missing feature. */
+      assert(strstr(env, "AIMEE_KB_VARIANT=a25m\n") != NULL);
       assert(strstr(env, "SYNTHESIS_ENDPOINT=https://api.x/v1\n") != NULL);
-      /* Every retired spelling stays gone. */
-      assert(strstr(env, "AIMEE_LLM_") == NULL);
+      /* No sidecar, so no client identity: SYNTHESIS_CA_FILE REPLACES the system trust
+       * store, and pointing it at our CA while the endpoint is external would reject a
+       * perfectly valid certificate. */
+      assert(strstr(env, "SYNTHESIS_CA_FILE") == NULL);
+      assert(strstr(env, "AIMEE_LLM_HOST") == NULL);
       assert(strstr(env, "EMBEDDER_DIMS") == NULL); /* in-container => derived */
       assert(strstr(env, "EMBEDDER_URL") == NULL);  /* no URL => the bundled model */
 
@@ -2566,13 +2575,40 @@ int main(void)
       assert(strstr(env, "COMPOSE_PROFILES=kb\n") != NULL);
       assert(strstr(env, "SYNTHESIS_ENDPOINT") == NULL);
       assert(strstr(env, "SYNTHESIS_MODEL") == NULL);
+      assert(strstr(env, "AIMEE_LLM_HOST") == NULL);
+      /* No embedder selected either: the plain aimee-kb image is correct, and it is
+       * the one that carries neither PyTorch nor weights. */
+      assert(strstr(env, "AIMEE_KB_VARIANT=\n") != NULL);
 
-      /* A BUNDLED model is just a loopback endpoint plus a model name. */
+      /* A BUNDLED model is a DEPLOYED SIDECAR, not a loopback endpoint. It used to be
+       * in-process in the kb; it is aimee-llm-e{2,4}b beside the kb now, reached over
+       * mTLS. Every line below is load-bearing: without the profile the service exists
+       * in Compose and nothing starts it, without AIMEE_LLM_HOST the kb never mints the
+       * identity the sidecar refuses to start without, and without the endpoint the kb
+       * has a running sidecar it never calls. Each failure is silent. */
       memset(&cfg, 0, sizeof(cfg));
       snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "local");
+      snprintf(cfg.embedder_model, sizeof(cfg.embedder_model), "nomic-embed-text-v2-moe");
       snprintf(cfg.synthesis_model, sizeof(cfg.synthesis_model), "gemma-4-E4B-it");
       config_emit_deploy_env(&cfg, env, sizeof(env));
       assert(strstr(env, "SYNTHESIS_MODEL=gemma-4-E4B-it\n") != NULL);
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm\n") != NULL);
+      assert(strstr(env, "AIMEE_LLM_VARIANT=e4b\n") != NULL);
+      assert(strstr(env, "AIMEE_LLM_HOST=aimee-llm\n") != NULL);
+      assert(strstr(env, "SYNTHESIS_ENDPOINT=https://aimee-llm:8761/v1\n") != NULL);
+      assert(strstr(env, "SYNTHESIS_CA_FILE=/var/lib/aimee/synthesis-tls/ca.pem\n") != NULL);
+      assert(strstr(env, "SYNTHESIS_CERT_FILE=/var/lib/aimee/synthesis-tls/client.pem\n") != NULL);
+      assert(strstr(env, "SYNTHESIS_KEY_FILE=/var/lib/aimee/synthesis-tls/client.key\n") != NULL);
+      /* The embedder axis is independent of the synthesis axis now. */
+      assert(strstr(env, "AIMEE_KB_VARIANT=nomic\n") != NULL);
+
+      /* E2B selects the other sidecar tag. */
+      memset(&cfg, 0, sizeof(cfg));
+      snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "local");
+      snprintf(cfg.synthesis_model, sizeof(cfg.synthesis_model), "gemma-4-E2B-it");
+      config_emit_deploy_env(&cfg, env, sizeof(env));
+      assert(strstr(env, "AIMEE_LLM_VARIANT=e2b\n") != NULL);
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm\n") != NULL);
 
       /* Remote kb: connect out, deploy nothing. */
       memset(&cfg, 0, sizeof(cfg));


### PR DESCRIPTION
Five merged PRs (#2242, #2253, #2259, #2261) built the synthesis sidecar and split the kb image by embedder. **Nothing connected either to the deploy layer.** `config_emit_deploy_env` still emitted `COMPOSE_PROFILES=kb`, `EMBEDDER_MODEL` and an endpoint, which was the whole contract when one kb image carried everything.

## A live regression, not just a missing feature

`AIMEE_KB_IMAGE` is not emitted, so managed Compose falls back to `aimee-kb:${AIMEE_IMAGE_TAG}`. **That tag used to mean "bekko baked in" and now means "no embedder"** — so an existing managed deployment pulling a new tag is handed `EMBEDDER_MODEL=bekko-a25m` alongside an image containing no bekko, and the kb tries to start weights that are not there.

The embedder choice now selects the image via `AIMEE_KB_VARIANT` (`a25m`, `nomic`, or empty for plain `aimee-kb` — also the right image for an external embedder, since it carries neither PyTorch nor weights).

Only the *variant* is emitted; Compose composes the reference, so the registry and tag stay in one place instead of being rebuilt in C. The nested `${VAR:+-${VAR}}` form is **verified against a real `docker compose`**, not assumed:

| | kb | llm |
| --- | --- | --- |
| unset | `aimee-kb:t` | `aimee-llm-e4b:t` |
| set | `aimee-kb-a25m:t` | `aimee-llm-e2b:t` |

## The sidecar becomes reachable from the wizard

Local synthesis is "a model with no endpoint", which is the contract `deployTopology.ts` already writes, so it is read here rather than adding a mode field the two could disagree about. It emits the `llm` profile, `AIMEE_LLM_VARIANT`, `AIMEE_LLM_HOST`, the sidecar endpoint, and the three client-certificate paths.

Each of those is load-bearing and each failure is silent:
- no profile: the service exists in Compose and nothing ever starts it
- no `AIMEE_LLM_HOST`: the kb never mints the identity the sidecar refuses to start without
- no endpoint: the kb has a running sidecar it never calls

`AIMEE_LLM_HOST` is both the mint trigger and the certificate's DNS name, so it must equal the Compose service name.

**The `llm` profile is a restoration.** `deploy_apply.c` kept its managed-inference mechanism alive against a stub profile, with a comment saying synthesis "may well be a managed service again". It is.

The TLS paths are emitted **only** for the local sidecar: `SYNTHESIS_CA_FILE` replaces the system trust store for that request, so setting them alongside an external https endpoint would reject a perfectly valid certificate.

## Tests

`test_config.c` asserted `COMPOSE_PROFILES=kb` and that no `AIMEE_LLM_` variable is ever emitted — a test that pinned the sidecar off. Rewritten to cover all four states: external endpoint (no sidecar, no client identity), off (no sidecar), bundled (the full hop), and E2B vs E4B selecting the right tag.

## Verification

`make all` · `make lint` 41 checks · `unit-test-config` passes · Compose interpolation verified on a real daemon.

**Not verified:** the wizard has not been driven end to end against this. That is the next step, and what `:testing` validation on a test host will exercise.