### PR TITLE
ci: publish all three kb embedder variants to the testing channel

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -3,10 +3,11 @@
 # testing branch can be deployed/validated (e.g. on .254) WITHOUT promoting to
 # main.
 #
-# Builds the split images and the isolated one-shot authority bootstrap so a managed
-# stack can pull a single coherent `:testing` channel. Synthesis is NOT here: it is
-# its own image on its own trigger (publish-llm.yml), rebuilt when the model changes
-# rather than when kb code does.
+# Builds the split images, ALL THREE kb embedder variants, and the isolated one-shot
+# authority bootstrap, so a managed stack can pull a single coherent `:testing`
+# channel whichever embedder the wizard selected. Synthesis is NOT here: it is its own
+# image on its own trigger (publish-llm.yml), rebuilt when the model changes rather
+# than when kb code does.
 # Versioned + `:latest` publishing of the full image set
 # stays owned by main (auto-release.yml -> publish-images.yml). Keeping testing on
 # a `:testing` tag — never a version number — avoids confusing a tested-but-
@@ -66,10 +67,20 @@ jobs:
         # beside the kb, rebuilt only when the model or the model list changes. The
         # weights stay baked — that property is why they were baked in the first
         # place — they are just baked into the image whose inputs are stable.
+        #
+        # ALL THREE EMBEDDER VARIANTS, not a subset. An earlier version of this matrix
+        # carried the bekko legs only, on the reasoning that nomic is a one-way choice
+        # this channel had never deployed. That reasoning was wrong: a variant absent
+        # from the channel cannot be deployed FROM the channel, so an operator who
+        # selects nomic on a :testing stack gets a manifest that does not exist. The
+        # deploy layer now picks the image from the embedder choice
+        # (AIMEE_KB_VARIANT), so every choice it can emit has to be publishable here.
         image:
           - { name: aimee-server,    dockerfile: Dockerfile.server }
           - { name: aimee-kb,        dockerfile: Dockerfile, args: "AIMEE_EMBEDDER=none" }
           - { name: aimee-kb-a25m,   dockerfile: Dockerfile, args: "AIMEE_EMBEDDER=bekko-a25m" }
+          - { name: aimee-kb-nomic,  dockerfile: Dockerfile,
+              args: "AIMEE_EMBEDDER=nomic-embed-text-v2-moe" }
           - { name: aimee-authority-bootstrap, dockerfile: Dockerfile.authority-bootstrap }
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `:testing` matrix carried the bekko legs only, on my reasoning that nomic is a one-way choice the channel had never deployed. **That reasoning was wrong**, and #2262 makes it concrete: a variant absent from the channel cannot be deployed *from* the channel.

`config_emit_deploy_env` now selects the kb image from the embedder choice (`AIMEE_KB_VARIANT`), so a `:testing` stack whose wizard selects nomic resolves `ghcr.io/rakuensoftware/aimee-kb-nomic:testing` — a manifest that does not exist. Choosing a supported option would have failed at pull, with nothing indicating the channel just lacked the image.

The rule is now all three rather than a subset:

| tag | embedder | size |
| --- | --- | --- |
| `aimee-kb` | none | 373 MB |
| `aimee-kb-a25m` | bekko-a25m, 384 | 1.95 GB |
| `aimee-kb-nomic` | nomic-v2-moe, 768 | 3.34 GB |

Sizes measured from local builds of the same Dockerfile, and nomic has been booted: it loads at `dim=768` and DB2 derives that width on a fresh database.

**Cost:** one more leg per push to `testing` that touches the image paths. It is the same kb build under its own cache scope. The expensive axis was synthesis, and that left this channel when the sidecar did — a push now builds three lean kb images instead of two kb images plus two 6.7–9.4 GB bundled ones.

## Verification

`make lint` 41 checks · matrix parsed and asserted with `yaml.safe_load`.

**Not verified:** the nomic leg has never run in this workflow. Its first execution is the merge of this PR.