### PR TITLE
deploy: never resolve an embedderless kb by accident

### DIFF
--- a/src/modules/config/config_database.c
+++ b/src/modules/config/config_database.c
@@ -323,14 +323,29 @@ void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
     * the tag stay in one place instead of being rebuilt in C. Empty means plain
     * aimee-kb, which is also the right image for an external embedder: it carries
     * neither PyTorch nor weights. */
-   const char *kb_variant = "";
-   if (!cfg->embedder_url[0])
-   {
-      if (strcmp(cfg->embedder_model, "bekko-a25m") == 0)
-         kb_variant = "a25m";
-      else if (strcmp(cfg->embedder_model, "nomic-embed-text-v2-moe") == 0)
-         kb_variant = "nomic";
-   }
+   /* THE EMPTY VARIANT MEANS "DELIBERATELY EXTERNAL", NEVER "NOTHING CHOSEN".
+    *
+    * aimee-kb carries no embedder at all, which is right when EMBEDDER_URL points
+    * somewhere and wrong in every other case: a deployment with no model AND no URL
+    * cannot embed, and cannot be repaired by setting a config key, because the weights
+    * are not in the image. It needs a different image.
+    *
+    * So an unselected embedder resolves to a25m rather than to nothing. That is not a
+    * new default, it is the OLD one: `aimee-kb` meant "bekko baked in" until #2261
+    * split the axis, so this is what an existing deployment already had. Resolving it
+    * to the embedderless image instead would take working deployments to lexical-only
+    * on their next pull, silently.
+    *
+    * The wizard is being changed to require an explicit choice (external, a25m or
+    * nomic). This is the other half of that: the deploy layer must not be able to
+    * produce an embedderless deployment even if something upstream forgets to ask. */
+   const char *kb_variant;
+   if (cfg->embedder_url[0])
+      kb_variant = ""; /* external endpoint: the image with no weights is correct */
+   else if (strcmp(cfg->embedder_model, "nomic-embed-text-v2-moe") == 0)
+      kb_variant = "nomic";
+   else
+      kb_variant = "a25m"; /* selected bekko, or nothing selected yet */
    EMITF("AIMEE_KB_VARIANT=%s\n", kb_variant);
 
    if (cfg->embedder_model[0])

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -2622,9 +2622,11 @@ int main(void)
       assert(strstr(env, "SYNTHESIS_ENDPOINT") == NULL);
       assert(strstr(env, "SYNTHESIS_MODEL") == NULL);
       assert(strstr(env, "AIMEE_LLM_HOST") == NULL);
-      /* No embedder selected either: the plain aimee-kb image is correct, and it is
-       * the one that carries neither PyTorch nor weights. */
-      assert(strstr(env, "AIMEE_KB_VARIANT=\n") != NULL);
+      /* NOTHING SELECTED MUST NOT YIELD THE EMBEDDERLESS IMAGE. aimee-kb carries no
+       * weights, so that combination cannot embed and cannot be repaired by setting a
+       * key -- it needs a different image. a25m is what `aimee-kb` meant before the
+       * axis was split, so an unconfigured deployment keeps what it already had. */
+      assert(strstr(env, "AIMEE_KB_VARIANT=a25m\n") != NULL);
 
       /* A BUNDLED model is a DEPLOYED SIDECAR, not a loopback endpoint. It used to be
        * in-process in the kb; it is aimee-llm-e{2,4}b beside the kb now, reached over
@@ -2680,6 +2682,8 @@ int main(void)
       snprintf(cfg.synthesis_api_key, sizeof(cfg.synthesis_api_key), "syn-key");
       config_emit_deploy_env(&cfg, env, sizeof(env));
       assert(strstr(env, "COMPOSE_PROFILES=kb\n") != NULL);
+      /* An external endpoint is the ONE case the embedderless image is right for. */
+      assert(strstr(env, "AIMEE_KB_VARIANT=\n") != NULL);
       assert(strstr(env, "EMBEDDER_URL=https://emb.x/v1\n") != NULL);
       /* Credentials are NEVER emitted into a long-lived service environment:
        * Config.Env persists and shows up in `docker inspect`. They are sealed into


### PR DESCRIPTION
Raised from another session: **with no embedder the system does not work**, so "none"
cannot be an option the wizard offers. This is the deploy-layer half of that.

## The defect

`AIMEE_KB_VARIANT` resolved to empty — the `aimee-kb` image, which carries no embedder
at all — whenever no model was selected. That deployment cannot embed, and unlike
before it **cannot be repaired by setting a config key**, because the weights are not
in the image. It needs a different image.

## It is also an upgrade hazard

`aimee-kb` *meant* "bekko baked in" until #2261 split the embedder onto its own axis.
An existing deployment with nothing explicitly selected therefore had bekko available.
Resolving that same state to the embedderless image would take it to lexical-only on
its next pull, silently.

**Every managed deployment is currently in that state**, because #2264's bug made
selecting an embedder impossible until it landed — including aimee-prod.

## The fix

The empty variant now means exactly one thing, *deliberately external*, and is emitted
only when an external URL is set:

| config | variant | image |
| --- | --- | --- |
| `EMBEDDER_URL` set | (empty) | `aimee-kb` — no weights, correct here |
| `nomic-embed-text-v2-moe` | `nomic` | `aimee-kb-nomic` |
| `bekko-a25m`, **or nothing selected** | `a25m` | `aimee-kb-a25m` |

a25m for the unselected case is not a new default. It is what the default tag already
carried, so an unconfigured deployment keeps exactly what it had.

## Why not fail closed

Refusing to deploy would be louder, and I considered it. But it would break every
currently-unconfigured deployment, and they are unconfigured *because* the config
surface was broken until #2264. Preserving the historical default is the
behaviour-compatible choice; the wizard requiring an explicit choice is what prevents
the state arising going forward.

## Tests

Nothing-selected yields `a25m` rather than empty; an external URL still yields empty,
which is the one case the embedderless image is right for.

## Verification

`make all` · `make lint` 41 checks · `unit-test-config`.

**Not in this PR:** the wizard change requiring an explicit choice
(`deployTopology.ts`). This makes the deploy layer safe even when something upstream
forgets to ask.
