### PR TITLE
docs: an embedder is required; synthesis is not

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -173,13 +173,19 @@ Which embedder a KB can run is a property of the image you pulled, because the w
 
 | image | embedder | size |
 | --- | --- | --- |
-| `aimee-kb` | none; set `EMBEDDER_URL` | 373 MB |
 | `aimee-kb-a25m` | `bekko-a25m`, 384-dimension | 1.95 GB |
 | `aimee-kb-nomic` | `nomic-embed-text-v2-moe`, 768-dimension | 3.34 GB |
+| `aimee-kb` | none baked; for an external `EMBEDDER_URL` | 373 MB |
 
-A bundled embedder needs no download and no second container. `aimee-kb` carries none at all, which
-is the right choice when you point `EMBEDDER_URL` at your own endpoint: it omits PyTorch and the
-weights rather than shipping code it never runs.
+**An embedder is not optional.** Retrieval does not work without one, so the choice is
+between a bundled model and an external endpoint, never "neither". `aimee-kb` exists
+for the external case: it omits PyTorch and the weights rather than shipping code it
+will never run. It is not a way to run without an embedder.
+
+Synthesis is different and genuinely optional: local, external, or off. Off is a
+supported state because embedding, search, recall and indexing never call it.
+
+A bundled embedder needs no download and no second container.
 
 **This choice does not survive a change of mind.** DB2 records the vector-column width and refuses to
 start when it drifts, so moving between 384 and 768 means re-embedding the whole corpus. Choose before


### PR DESCRIPTION
Follows the decision in #2266: with no embedder the system does not work, so "none" is not a choice.

The quickstart listed the embedderless image **first**, described as "none; set EMBEDDER_URL", which reads as a third equal option and invites exactly the deployment that cannot work. Reordered so the bundled models lead, and it now says plainly that the small image exists for the *external* case rather than as a way to run without an embedder: it omits PyTorch and the weights rather than shipping code it will never run.

It also states the asymmetry explicitly, because it is deliberate and someone will otherwise tidy it away:

- **embedder: required** — a bundled model or an external endpoint, never neither
- **synthesis: optional** — local, external, or off; off is supported because embedding, search, recall and indexing never call it

## Verification

`scripts/check-docs.py` exits 0 · `make lint` 41 checks.