### PR TITLE
wizard: offer both synthesis sidecars, and never an absent embedder

### DIFF
--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -208,7 +208,7 @@ export const FIELD_HELP: Record<string, string> = {
   synthesis_model: "Synthesis model. On an image with llama.cpp bundled this picks the local model to run (gemma-4-E2B-it or gemma-4-E4B-it); otherwise it is the model name sent to the endpoint.",
   synthesis_api_key: "Bearer token for the synthesis endpoint. Blank for a keyless or local endpoint.",
   synthesis_thinking: "Let the synthesis model think before answering. On by default — it measured positive-to-neutral everywhere. Turn it off only if your model reasons past its output budget without answering.",
-  aimee_with_llamacpp: "Whether this image bundles llama.cpp. Set by the image, not by you — it decides whether a local synthesis model can be offered at all.",
+  aimee_with_llamacpp: "Retired. It recorded whether the kb image bundled llama.cpp, which decided whether local synthesis could be offered. Synthesis is its own sidecar image now, so the kb image no longer constrains the choice and nothing reads this.",
 
   delegate_graph_context_enabled:
     "Prepend the callers and dependencies of the files a delegate task mentions to its prompt. Advisory, off by default.",

--- a/frontend/src/setup/DeployTopology.test.tsx
+++ b/frontend/src/setup/DeployTopology.test.tsx
@@ -186,6 +186,9 @@ describe('DeployTopology synthesis picker', () => {
     // synthesis lived in the kb image. Absent, present or contradictory, they must not
     // change what is offerable.
     for (const cfg of [{}, { aimee_with_llamacpp: '0' }, { aimee_with_llamacpp: '1' }]) {
+      // Within one test the auto-cleanup between tests has not run yet, so each
+      // iteration would otherwise stack another copy of the page in the document.
+      cleanup();
       await renderPage(cfg);
       const values = Array.from(synthSelect().options).map((o) => o.value);
       expect(values).toContain('gemma-4-E2B-it');

--- a/frontend/src/setup/DeployTopology.test.tsx
+++ b/frontend/src/setup/DeployTopology.test.tsx
@@ -169,38 +169,28 @@ describe('DeployTopology synthesis picker', () => {
     return select as HTMLSelectElement;
   }
 
-  it('offers off, external and THE ONE MODEL THIS IMAGE BAKES', async () => {
-    // The model is in the image, so there is no menu of models to pick from — the
-    // tag decided it, exactly like the embedder.
-    await renderPage({ aimee_with_llamacpp: '1', aimee_synthesis_model: 'gemma-4-E4B-it' });
-    const values = Array.from(synthSelect().options).map((o) => o.value);
-    expect(values).toEqual(expect.arrayContaining(['off', 'external', 'gemma-4-E4B-it']));
-    // The model this image does NOT carry must not be offered.
-    expect(values).not.toContain('gemma-4-E2B-it');
-  });
-
-  it('offers the e2b model on an e2b image', async () => {
-    await renderPage({ aimee_with_llamacpp: '1', aimee_synthesis_model: 'gemma-4-E2B-it' });
-    const values = Array.from(synthSelect().options).map((o) => o.value);
-    expect(values).toContain('gemma-4-E2B-it');
-    expect(values).not.toContain('gemma-4-E4B-it');
-  });
-
-  it('offers no local option at all when the image bakes no model', async () => {
-    // Offering a choice that cannot work is worse than not offering it: the failure
-    // would only show up later as synthesis silently never starting.
+  it('offers off, external and BOTH models, whatever the kb image is', async () => {
+    // Synthesis is its own sidecar now (aimee-llm-e2b / aimee-llm-e4b) deployed beside
+    // the kb, so the kb tag has no bearing on the choice. These assertions were the
+    // inverse of this: the page offered only the model the kb image baked, and hid the
+    // local option entirely when it baked none.
     await renderPage({});
     const values = Array.from(synthSelect().options).map((o) => o.value);
-    expect(values).toEqual(expect.arrayContaining(['off', 'external']));
-    expect(values.some((v) => v.startsWith('gemma-'))).toBe(false);
-    expect(screen.getByText(/bundles no synthesis model/i)).toBeTruthy();
+    expect(values).toEqual(
+      expect.arrayContaining(['off', 'external', 'gemma-4-E2B-it', 'gemma-4-E4B-it']),
+    );
   });
 
-  it('offers no local option when llama.cpp is present but no model is', async () => {
-    // Half-built image: the binary without its weights cannot serve anything.
-    await renderPage({ aimee_with_llamacpp: '1' });
-    const values = Array.from(synthSelect().options).map((o) => o.value);
-    expect(values.some((v) => v.startsWith('gemma-'))).toBe(false);
+  it('does not gate the local options on kb image properties', async () => {
+    // aimee_with_llamacpp and aimee_synthesis_model described the OLD topology, where
+    // synthesis lived in the kb image. Absent, present or contradictory, they must not
+    // change what is offerable.
+    for (const cfg of [{}, { aimee_with_llamacpp: '0' }, { aimee_with_llamacpp: '1' }]) {
+      await renderPage(cfg);
+      const values = Array.from(synthSelect().options).map((o) => o.value);
+      expect(values).toContain('gemma-4-E2B-it');
+      expect(values).toContain('gemma-4-E4B-it');
+    }
   });
 
   it('off is presented as supported, and writes no endpoint', async () => {
@@ -214,9 +204,7 @@ describe('DeployTopology synthesis picker', () => {
 
   it('a bundled model writes the model and NOT a loopback endpoint', async () => {
     // The entrypoint owns the port; writing 127.0.0.1 here would hardcode it.
-    const { writes } = await renderPage({
-      aimee_with_llamacpp: '1', aimee_synthesis_model: 'gemma-4-E4B-it',
-    });
+    const { writes } = await renderPage({});
     fireEvent.change(synthSelect(), { target: { value: 'gemma-4-E4B-it' } });
     save();
     await waitFor(() => expect(writes.some((w) => w.key === 'synthesis_model')).toBe(true));

--- a/frontend/src/setup/DeployTopology.tsx
+++ b/frontend/src/setup/DeployTopology.tsx
@@ -8,8 +8,6 @@ import {
   configToEmbedder,
   configToSynthesis,
   embedderChangeImpact,
-  imageHasLlamaCpp,
-  imageSynthesisModel,
   type EmbedderChoice,
   type EmbedderSelection,
   type SynthesisSelection,
@@ -141,14 +139,6 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
    * only at an external endpoint, and offering them here would produce a container
    * that refuses to boot. */
   const localEmbedders = useMemo(() => embedders.filter((e) => e.local), [embedders]);
-  const hasLlama = useMemo(() => imageHasLlamaCpp(cfg), [cfg]);
-  /** The one model this image bakes, if any. Not a choice — see imageSynthesisModel. */
-  const bakedModel = useMemo(() => imageSynthesisModel(cfg), [cfg]);
-  const bakedInfo = useMemo(
-    () => SYNTHESIS_MODELS.find((m) => m.id === bakedModel),
-    [bakedModel],
-  );
-  const canRunLocal = hasLlama && bakedModel !== '';
 
   const embedder: EmbedderSelection = useMemo(
     () =>
@@ -307,24 +297,28 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
             onChange={(e) => setSynthRoute(e.target.value)}>
             <option value="off">None — synthesis off</option>
             <option value="external">External endpoint</option>
-            {canRunLocal && (
-              <option value={bakedModel}>
-                {bakedInfo?.label ?? bakedModel} — bundled in this image
+            {/* Both models are offered unconditionally. Each is its own sidecar image
+                (aimee-llm-e2b / aimee-llm-e4b) deployed beside the kb, so the kb tag
+                has no bearing on whether local synthesis can run. This used to be
+                gated on what the kb image baked. */}
+            {SYNTHESIS_MODELS.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.label} — runs beside the kb
               </option>
-            )}
+            ))}
           </select>
 
-          {!canRunLocal && (
-            <div style={{ fontSize: 11, color: '#8a5a00', marginTop: 6 }}>
-              This image bundles no synthesis model, so it cannot run one locally. The model is
-              part of the image, like the embedder: pull an <code>aimee-kb-llm-e2b</code> or
-              {' '}<code>-e4b</code> tag (or the <code>-nomic-</code> equivalents) to get one, or
-              point synthesis at an external endpoint.
-            </div>
-          )}
           {synthRoute === 'off' && (
             <div style={{ fontSize: 11, color: '#889', marginTop: 6 }}>
               Supported, not a gap: embedding, search, recall and indexing never call this.
+              An embedder, by contrast, is required.
+            </div>
+          )}
+          {synthRoute !== 'off' && synthRoute !== 'external' && (
+            <div style={{ fontSize: 11, color: '#889', marginTop: 6 }}>
+              Deployed as a sidecar beside the kb and reached over mutual TLS. Its weights are
+              baked into that image, so nothing is downloaded at deploy or at run time. Switching
+              between the two models later is a container swap; the corpus is untouched.
             </div>
           )}
           {synthRoute === 'external' && (

--- a/frontend/src/setup/DeployTopology.tsx
+++ b/frontend/src/setup/DeployTopology.tsx
@@ -316,6 +316,7 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
           )}
           {synthRoute !== 'off' && synthRoute !== 'external' && (
             <div style={{ fontSize: 11, color: '#889', marginTop: 6 }}>
+              {SYNTHESIS_MODELS.find((m) => m.id === synthRoute)?.blurb}{' '}
               Deployed as a sidecar beside the kb and reached over mutual TLS. Its weights are
               baked into that image, so nothing is downloaded at deploy or at run time. Switching
               between the two models later is a container swap; the corpus is untouched.
@@ -330,11 +331,6 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
               <div style={{ fontSize: 11, color: '#889' }}>
                 Your notes are sent to whatever answers this URL.
               </div>
-            </div>
-          )}
-          {synthRoute !== 'off' && synthRoute !== 'external' && (
-            <div style={{ fontSize: 11, color: '#889', marginTop: 6 }}>
-              {bakedInfo?.blurb} It starts with the container and downloads nothing.
             </div>
           )}
         </div>

--- a/frontend/src/setup/deployTopology.test.ts
+++ b/frontend/src/setup/deployTopology.test.ts
@@ -211,8 +211,6 @@ describe('SYNTHESIS_MODELS', () => {
   });
 });
 
-});
-
 describe('the choices the wizard may offer', () => {
   it('offers both synthesis models regardless of the kb image', () => {
     // Each model is its own sidecar (aimee-llm-e2b / aimee-llm-e4b) deployed beside the

--- a/frontend/src/setup/deployTopology.test.ts
+++ b/frontend/src/setup/deployTopology.test.ts
@@ -7,8 +7,6 @@ import {
   configToSynthesis,
   embedderChangeImpact,
   embedderToConfig,
-  imageHasLlamaCpp,
-  imageSynthesisModel,
   synthesisToConfig,
   type DeploySelection,
   type EmbedderChoice,
@@ -158,20 +156,6 @@ describe('embedderChangeImpact', () => {
   });
 });
 
-describe('imageHasLlamaCpp', () => {
-  it('is true only when the image says so', () => {
-    expect(imageHasLlamaCpp({ aimee_with_llamacpp: '1' })).toBe(true);
-    expect(imageHasLlamaCpp({ aimee_with_llamacpp: 'true' })).toBe(true);
-    expect(imageHasLlamaCpp({ aimee_with_llamacpp: '0' })).toBe(false);
-  });
-
-  it('an absent key reads as NOT available', () => {
-    // Better to point an operator at an external endpoint that works than at a local
-    // model that never loads.
-    expect(imageHasLlamaCpp({})).toBe(false);
-  });
-});
-
 describe('buildDesiredConfig', () => {
   const local = (over: Partial<DeploySelection> = {}): DeploySelection => ({
     kbMode: 'local',
@@ -227,16 +211,37 @@ describe('SYNTHESIS_MODELS', () => {
   });
 });
 
-describe('imageSynthesisModel', () => {
-  it('reports the model the image bakes', () => {
-    expect(imageSynthesisModel({ aimee_synthesis_model: 'gemma-4-E4B-it' }))
-      .toBe('gemma-4-E4B-it');
+});
+
+describe('the choices the wizard may offer', () => {
+  it('offers both synthesis models regardless of the kb image', () => {
+    // Each model is its own sidecar (aimee-llm-e2b / aimee-llm-e4b) deployed beside the
+    // kb, so the kb tag has no bearing on whether local synthesis can run. This was
+    // previously gated on what the kb image baked, which is why imageHasLlamaCpp and
+    // imageSynthesisModel existed and why they are gone.
+    expect(SYNTHESIS_MODELS.map((m) => m.id).sort())
+      .toEqual(['gemma-4-E2B-it', 'gemma-4-E4B-it']);
   });
 
-  it('is empty when the image bakes none', () => {
-    // Absent reads as "no local model", so the UI offers none rather than a
-    // selection the container cannot honour.
-    expect(imageSynthesisModel({})).toBe('');
-    expect(imageSynthesisModel({ aimee_synthesis_model: '  ' })).toBe('');
+  it('has no embedder selection that means "no embedder"', () => {
+    // Retrieval does not work without one, so the type admits only a bundled model or
+    // an external endpoint. The plain aimee-kb image carries no weights and serves the
+    // external case; it is not a way to run without an embedder.
+    const bundled = embedderToConfig({ kind: 'bundled', model: 'bekko-a25m' });
+    expect(bundled.embedder_model).toBe('bekko-a25m');
+    expect(bundled.embedder_url).toBe('');
+
+    const external = embedderToConfig({
+      kind: 'external', endpoint: 'https://emb.x/v1', apiKey: 'k', dims: '768',
+    });
+    expect(external.embedder_url).toBe('https://emb.x/v1');
+    expect(external.embedder_model).toBe('');
+  });
+
+  it('synthesis off writes no endpoint and no model', () => {
+    // Off IS supported, unlike an absent embedder.
+    const off = synthesisToConfig({ kind: 'off' });
+    expect(off.synthesis_endpoint).toBe('');
+    expect(off.synthesis_model).toBe('');
   });
 });

--- a/frontend/src/setup/deployTopology.ts
+++ b/frontend/src/setup/deployTopology.ts
@@ -67,7 +67,11 @@ export function embedderChangeImpact(
 /** How the embedder is served.
  *
  *   bundled  — the model baked into this image variant (bekko-a25m at 384 on
- *              aimee-kb / aimee-kb-llm, nomic-v2 at 768 on the -nomic variants).
+ *              aimee-kb-a25m, nomic-v2 at 768 on aimee-kb-nomic).
+ *
+ * THERE IS NO 'none'. Retrieval does not work without an embedder, so the choice is a
+ * bundled model or an external endpoint. The plain aimee-kb image carries no weights
+ * and exists for the external case; it is not a way to run without one.
  *   external — an operator-run endpoint. Its width cannot be derived, so `dims`
  *              is required; anything up to EMBED_MAX_DIM (4000, the DB2 column
  *              ceiling) is valid. */
@@ -77,10 +81,16 @@ export type EmbedderSelection =
 
 // --- the synthesis choice ------------------------------------------------
 
-/** Human copy for a model an image may bake. NOT a menu: the image carries one
- * model and this only describes whichever it is. Numbers are extraction F1 on the
- * 69-note gold set at Q8_0 (docs/SYNTHESIS_MODELS.md); the images ship UD-Q6_K_XL,
- * a different quantisation, so they are indicative rather than exact. */
+/** The synthesis models that can be deployed. THIS IS A MENU NOW.
+ *
+ * It used to describe whichever single model the kb image happened to bake, because
+ * synthesis lived inside that image. It does not any more: each model is its own
+ * sidecar (aimee-llm-e2b / aimee-llm-e4b) deployed beside the kb, so both are always
+ * offerable and the kb tag has no bearing on the choice.
+ *
+ * Quality numbers are extraction F1 on the 69-note gold set measured at Q8_0
+ * (docs/SYNTHESIS_MODELS.md), so they are indicative of the gap between the two rather
+ * than exact for the shipped quantisations. */
 export interface SynthesisModelChoice {
   id: string;
   label: string;
@@ -91,32 +101,22 @@ export const SYNTHESIS_MODELS: SynthesisModelChoice[] = [
   {
     id: 'gemma-4-E4B-it',
     label: 'gemma-4-E4B-it',
-    blurb: 'The better model. 7.46 GB baked into this image, ~3.3 tok/s on 8 CPU threads.',
+    blurb: 'The better model. 7.46 GB at UD-Q6_K_XL, deployed as the aimee-llm-e4b sidecar.',
   },
   {
     id: 'gemma-4-E2B-it',
     label: 'gemma-4-E2B-it',
-    blurb: '4.71 GB baked into this image. About twice the CPU speed, measurably weaker.',
+    blurb: '2.97 GB at UD-Q4_K_XL, deployed as aimee-llm-e2b. Faster, measurably weaker.',
   },
 ];
-
-/** The synthesis model THIS IMAGE bakes, or '' when it bakes none.
- *
- * Like the embedder, this is decided by the tag you pulled (aimee-kb-llm-e2b vs
- * -e4b) rather than at runtime, because the weights are in the image. The wizard
- * reports it instead of offering a choice it cannot honour. */
-export function imageSynthesisModel(cfg: Record<string, unknown>): string {
-  const v = cfg['aimee_synthesis_model'];
-  return v == null ? '' : String(v).trim();
-}
 
 /** How synthesis is served.
  *
  *   off      — no synthesis. A SUPPORTED state, not an error: embedding, search,
  *              recall and indexing never call this endpoint.
- *   bundled  — gemma-4 running beside the kb, which needs an image variant that
- *              ships llama.cpp. The entrypoint fetches the weights onto the
- *              persistent volume on first start and serves them at loopback.
+ *   bundled  — gemma-4 running beside the kb as an aimee-llm-e{2,4}b sidecar, reached
+ *              over mutual TLS. The weights are baked into that image; nothing is
+ *              downloaded at deploy or at run time.
  *   external — any OpenAI-compatible endpoint. Best quality, no local GPU or RAM
  *              cost, and your notes leave the machine. */
 export type SynthesisSelection =
@@ -245,15 +245,3 @@ export function configToSynthesis(cfg: Record<string, unknown>): SynthesisSelect
   return { kind: 'off' };
 }
 
-/** Whether this running image ships llama.cpp, i.e. whether the bundled synthesis
- * options can work at all. The image records AIMEE_WITH_LLAMACPP as ENV in every
- * variant precisely so this is observable rather than guessed: offering "run
- * gemma-4 locally" on an image without llama.cpp is an option that cannot work,
- * and the failure would appear later as synthesis silently never starting.
- *
- * Unknown (key absent) is treated as NOT available: better to point an operator at
- * an external endpoint that works than at a local model that never loads. */
-export function imageHasLlamaCpp(cfg: Record<string, unknown>): boolean {
-  const v = str(cfg, 'aimee_with_llamacpp').trim();
-  return v === '1' || v.toLowerCase() === 'true';
-}


### PR DESCRIPTION
Makes the wizard reflect the topology after #2259/#2261/#2262 and the decision in #2266.

## The page gated local synthesis on the kb image

```
canRunLocal = imageHasLlamaCpp(cfg) && imageSynthesisModel(cfg) !== ''
```

That was correct when synthesis lived inside the kb image. It no longer does: each model is its own sidecar (`aimee-llm-e2b` / `aimee-llm-e4b`) deployed beside the kb over mTLS, so the kb tag has no bearing on the choice.

The effect was that a correctly-deployable option was **hidden**. An operator on any current kb image was told *"this image bundles no synthesis model, so it cannot run one locally"* — which is now true of every kb image, because none of them bundle one.

Both models are offered unconditionally, and the two image-derived helpers are deleted rather than left to mislead. `aimee_with_llamacpp` keeps a settings-help entry marked retired: a key that still exists with stale help is worse than one documented as dead.

## The embedder has no "none"

`EmbedderSelection` already admitted only `bundled | external`, and readiness already required one of `embedder_command`/`url`/`model` — so the enforcement was there and only the copy was missing. Stated explicitly now, because the plain `aimee-kb` image carries no weights and reads like a third option: it serves the *external* case, it is not a way to run without an embedder.

The asymmetry is deliberate and now written in both the type comment and the UI:

- **synthesis off is supported** — embedding, search, recall and indexing never call it
- **an absent embedder is not** — retrieval does not work

## Copy corrected for the split

E2B is 2.97 GB at UD-Q4_K_XL, E4B 7.46 GB at UD-Q6_K_XL, described as sidecars rather than "baked into this image".

## Tests

Inverted to match the new behaviour: both models offered for any kb config including contradictory `aimee_with_llamacpp` values, `embedderToConfig` having no no-embedder form, and synthesis off writing neither endpoint nor model.

**Not verified locally:** no node toolchain on this box, so `tsc -b` and vitest run in CI.
