### PR TITLE
Prove the scoped service identity over real mTLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -717,6 +717,16 @@ jobs:
         env:
           AIMEE_DB2_URL: postgresql://aimee:aimee@127.0.0.1:5432/aimee_resid_ci
         run: bash scripts/validate-kb-authz-live.sh
+      # The check above drives BEARER tokens. Production does not use one:
+      # aimee-server presents a client certificate and the mTLS seam synthesises
+      # a credential from its CN, which nothing else exercises. This enrols for
+      # real (mint -> CSR -> /v1/enroll/redeem) and then makes genuine mTLS
+      # requests, asserting both that the scoped service CN is refused on owner
+      # routes and that the old colon-free CN would have been allowed.
+      - name: Live mTLS certificate scope
+        env:
+          AIMEE_DB2_URL: postgresql://aimee:aimee@127.0.0.1:5432/aimee_resid_ci
+        run: bash scripts/validate-kb-mtls-scope-live.sh
       - name: Postgres logs on failure
         if: failure()
         run: docker logs aimee-resid-pg 2>&1 | tail -60

--- a/scripts/validate-kb-mtls-scope-live.sh
+++ b/scripts/validate-kb-mtls-scope-live.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# validate-kb-mtls-scope-live.sh — the PRODUCTION credential path, end to end.
+#
+# WHY THIS EXISTS. Every other check of the scoped-service work drives a BEARER
+# token. Production does not use one: aimee-server presents a client CERTIFICATE,
+# and kb_tls_serve.c synthesises a credential from that certificate's CN
+# ("<kind>:<id>" -> scope:<kind>:<id>:m, a bare word -> mtls-owner). Nothing
+# exercised that translation. The neighbouring test-synthesis-mtls-hop.sh exists
+# because a hop stayed broken through 41 lint checks, a unit test and two image
+# builds; this is the same class of gap, so it gets the same treatment.
+#
+# It drives the real flow with no shortcuts: `aimee-kb enroll --scope`, a CSR
+# POSTed to /v1/enroll/redeem, then a genuine mTLS request with the issued
+# certificate.
+#
+# The two cases are deliberately red/green against each OTHER, on the real path:
+#
+#   service:aimee-server  (what aimee-server presents now) -> refused on owner
+#                         routes, allowed on the data plane
+#   p5-server-client      (what it presented BEFORE) -> no ':' in the CN, so the
+#                         seam mints mtls-owner and the SAME request succeeds
+#
+# The second case is the red: it reproduces, on the production path, the
+# authority the change removes. If it ever starts failing, either the old CN
+# stopped granting owner (fine, but this file's claim is stale) or the seam
+# changed shape.
+set -uo pipefail
+
+SRC="${AIMEE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+KB="${AIMEE_KB_BIN:-$SRC/aimee-kb}"
+# A UNIQUE directory per run, deliberately. The enrollment-token registry is a
+# Vault record named after the store PATH but encrypted with the per-AIMEE_HOME
+# master key, so reusing a fixed path after wiping AIMEE_HOME leaves an
+# undecryptable record in the shared DB2 vault and every later enrollment fails
+# with a misleading "invalid or used token". A fixed path would make this suite
+# pass once and fail forever after.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/aimee-mtls-scope.XXXXXX")"
+HTTP_PORT=8751
+MTLS_PORT=8752
+BASE="http://127.0.0.1:$HTTP_PORT"
+MBASE="https://127.0.0.1:$MTLS_PORT"
+PASS=0; FAIL=0; SKIP=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n     -> %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+skip() { printf '  \033[33mSKIP\033[0m  %s (%s)\n' "$1" "$2"; SKIP=$((SKIP+1)); }
+
+export AIMEE_HOME="$WORK/home"
+mkdir -p "$AIMEE_HOME"
+export AIMEE_KB_API_BEARER_TOKEN="owner-secret-mtls-test"
+export AIMEE_KB_MTLS_PORT="$MTLS_PORT"
+export AIMEE_DB2_URL="${AIMEE_DB2_URL:-postgresql://aimee:aimee@127.0.0.1/aimee_kb}"
+cat > "$AIMEE_HOME/aimee.yaml" <<YAML
+kb:
+  api:
+    http_port: $HTTP_PORT
+YAML
+
+cleanup() { [ -f "$WORK/kb.pid" ] && kill "$(cat "$WORK/kb.pid")" 2>/dev/null; }
+trap cleanup EXIT
+
+ulimit -s 65536
+# Same first-boot transport as the container entrypoint: the runtime reads the
+# bearer from Vault, so it must be sealed before the listener starts.
+"$KB" --bootstrap-vault-env > "$WORK/bootstrap.log" 2>&1
+nohup "$KB" > "$WORK/kb.log" 2>&1 &
+echo $! > "$WORK/kb.pid"
+
+ready=0
+for _ in $(seq 1 60); do
+  curl -s -m 2 "$BASE/v1/health" >/dev/null 2>&1 && { ready=1; break; }
+  sleep 1
+done
+if [ "$ready" != 1 ]; then
+  skip "entire suite" "aimee-kb did not become healthy; see $WORK/kb.log"
+  echo "  PASS=$PASS FAIL=$FAIL SKIP=$SKIP"; exit 0
+fi
+# The mTLS listener is separate from the HTTP one; wait for it too.
+for _ in $(seq 1 30); do
+  (exec 3<>/dev/tcp/127.0.0.1/$MTLS_PORT) 2>/dev/null && { exec 3<&- 2>/dev/null; break; }
+  sleep 1
+done
+
+# unescape_json_string: turn a JSON string value into raw PEM.
+unesc() { python3 -c 'import sys,json;print(json.loads(sys.stdin.read()))'; }
+
+# issue_cert SCOPE OUTDIR -> writes cert.pem/key.pem, echoes the cert CN
+#
+# Minting goes through the RUNNING SERVER (POST /v1/enroll, owner bearer), not
+# the `aimee-kb enroll` CLI. The single-use token registry is held in Vault, and
+# the CLI mints from a second process with its own Vault state, so a token it
+# issues while the server is up does not redeem against it. Minting in-process is
+# both the working path and the realistic one for a live kb.
+issue_cert() {
+  local scope="$1" dir="$2" conn token csr resp certjson
+  mkdir -p "$dir"
+  conn=$(curl -s -m 20 -X POST -H "Authorization: Bearer $AIMEE_KB_API_BEARER_TOKEN" \
+         -H 'Content-Type: application/json' \
+         --data "{\"host\":\"127.0.0.1\",\"port\":$MTLS_PORT,\"scope\":\"$scope\"}" \
+         "$BASE/v1/enroll" 2>/dev/null |
+         python3 -c '
+import sys,json
+try: print(json.load(sys.stdin).get("connection_string",""))
+except Exception: print("")' 2>/dev/null)
+  [ -n "$conn" ] || { echo "ENROLL_FAILED"; return 1; }
+  token="${conn##*enroll=}"
+
+  # A deliberately WRONG CN in the CSR: the issuer must overwrite it with the
+  # token's scope. If it ever honoured the client's CN, a scoped client could
+  # mint itself an owner certificate by asking for a colon-free name.
+  openssl req -new -newkey rsa:2048 -nodes -keyout "$dir/key.pem" \
+     -out "$dir/req.csr" -subj "/CN=attacker-chosen-name" >/dev/null 2>&1 || {
+     echo "CSR_FAILED"; return 1; }
+
+  csr=$(python3 -c 'import json,sys;print(json.dumps(open(sys.argv[1]).read()))' "$dir/req.csr")
+  resp=$(curl -s -m 20 -X POST -H 'Content-Type: application/json' \
+         --data "{\"token\":\"$token\",\"csr\":$csr}" "$BASE/v1/enroll/redeem" 2>/dev/null)
+  certjson=$(printf '%s' "$resp" | python3 -c '
+import sys,json
+try: print(json.dumps(json.load(sys.stdin)["client_cert"]))
+except Exception: print("")' 2>/dev/null)
+  [ -n "$certjson" ] && [ "$certjson" != '""' ] || { echo "REDEEM_FAILED:$resp"; return 1; }
+  printf '%s' "$certjson" | unesc > "$dir/cert.pem"
+  openssl x509 -in "$dir/cert.pem" -noout -subject 2>/dev/null | sed 's/.*CN *= *//'
+}
+
+# mreq PATH DIR BODY -> HTTP status over mTLS with that identity
+mreq() {
+  curl -s -o /dev/null -w '%{http_code}' -m 20 -k \
+    --cert "$2/cert.pem" --key "$2/key.pem" \
+    -X POST -H 'Content-Type: application/json' --data "$3" "$MBASE$1" 2>/dev/null
+}
+
+MAINT='/v1/maintenance/purge-project'
+MBODY='{"project":"proj-alpha","path":"/tmp/kb","generation":"g1","purge_id":"p1"}'
+
+echo ""
+echo "### A. service:aimee-server — what aimee-server presents NOW"
+CN_A=$(issue_cert "service:aimee-server" "$WORK/a")
+case "$CN_A" in
+  service:aimee-server)
+    pass "CSR's chosen CN was overridden with the token scope (CN=$CN_A)"
+    code=$(mreq "$MAINT" "$WORK/a" "$MBODY")
+    [ "$code" = "403" ] && pass "service cert REFUSED on $MAINT (403)" \
+                        || fail "service cert on $MAINT" "want 403 got $code"
+    code=$(mreq "/v1/code/build" "$WORK/a" '{"path":"/tmp/kb","project":"proj-beta"}')
+    [ "$code" != "403" ] && pass "service cert still reaches the data plane (=$code)" \
+                         || fail "service cert data plane" "403 — the server cannot do its job"
+    ;;
+  ENROLL_FAILED*|CSR_FAILED*|REDEEM_FAILED*) skip "case A" "$CN_A" ;;
+  *) fail "case A CN" "expected service:aimee-server, got '$CN_A'" ;;
+esac
+
+echo ""
+echo "### B. p5-server-client — what it presented BEFORE (the red case)"
+CN_B=$(issue_cert "p5-server-client" "$WORK/b")
+case "$CN_B" in
+  p5-server-client)
+    pass "old-style CN issued (CN=$CN_B, no ':')"
+    code=$(mreq "$MAINT" "$WORK/b" "$MBODY")
+    if [ "$code" != "403" ]; then
+      pass "old CN reaches $MAINT (=$code) — reproduces the authority now removed"
+    else
+      fail "old CN on $MAINT" "got 403; expected it to SUCCEED. Either the old CN no
+     longer grants owner (this file's premise is stale) or the mTLS seam changed."
+    fi
+    ;;
+  ENROLL_FAILED*|CSR_FAILED*|REDEEM_FAILED*) skip "case B" "$CN_B" ;;
+  *) fail "case B CN" "expected p5-server-client, got '$CN_B'" ;;
+esac
+
+echo ""
+echo "=============================================="
+echo "  PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
+echo "=============================================="
+[ "$FAIL" -eq 0 ]

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -654,7 +654,7 @@ static int kb_bootstrap_db2(int json_output)
    return ok ? 0 : 1;
 }
 
-/* `aimee-kb enroll --host H --port N [--scope S]` — mint a one-time enrollment:
+/* `aimee-kb enroll --host H --port N --scope S` — mint a one-time enrollment:
  * persist/reuse the internal CA, issue a single-use token, and print the
  * `aimee://` connection string an operator hands to a client. The CA + token
  * store live under the kb config dir, so the running server can later redeem the
@@ -1735,8 +1735,10 @@ int main(int argc, char **argv)
       {
          static const char *usage =
              "Usage: aimee-kb [options]\n"
-             "       aimee-kb enroll --host=HOST --port=N [--scope=SCOPE]\n"
-             "                       Mint a one-time enrollment connection string for a client\n"
+             "       aimee-kb enroll --host=HOST --port=N --scope=SCOPE\n"
+             "                       Mint a one-time enrollment connection string for a client.\n"
+             "                       SCOPE is required: '<kind>:<id>' scopes the client, a bare\n"
+             "                       word mints the install owner.\n"
              "       aimee-kb vault status [--json]\n"
              "       aimee-kb vault start --request-id=<32-lowercase-hex> "
              "[--secret-stdin] [--json]\n"


### PR DESCRIPTION
## What this adds

`scripts/validate-kb-mtls-scope-live.sh` — the production credential path, end to end.

Everything that validated #2260/#2265 drove a **bearer token**. Production does not use one: aimee-server presents a **client certificate**, and `kb_tls_serve.c` synthesises a credential from its CN. Nothing exercised that translation, and it is what the whole change rests on.

The suite drives the real flow with no shortcuts — `POST /v1/enroll` → CSR → `/v1/enroll/redeem` → genuine mTLS requests — and asserts both halves against each other on that path:

| CN presented | `/v1/maintenance/purge-project` |
|---|---|
| `p5-server-client` (what it presented **before**) | **200 — purge succeeded** |
| `service:aimee-server` (what it presents **now**) | **403 — refused** |

The first row is the red case, reproduced on the production path. The old certificate genuinely could purge from aimee-kb; that is now demonstrated rather than argued.

It also asserts the issuer overwrites the CSR's own CN with the token's scope — without that, a scoped client could mint itself an owner certificate by asking for a colon-free name.

Wired into `authz-residual-live`, which already has the Postgres, python3 and openssl it needs.

## Also

`aimee-kb --help` still advertised `--scope` as optional after #2265 made it required. That flag decides whether you get a scoped client or the install owner, so the help should not teach otherwise.

## Validated on CT 132

Merged `testing` @ `9523da7c9`, clean-room build:

- new mTLS suite **5/5**, run twice to prove it is re-runnable
- live authz **40/40**, artifacts **17/17**
- full `make unit-tests` **RC=0**, P1 RLS gate **PASSED**

## Three pre-existing defects found, all reproduced on a stock pre-PR build

Not fixed here — reported separately. Each was verified against a build of `9bf03a370` (before #2260) to rule out this line of work as the cause.

1. **`aimee-kb enroll` mints unredeemable tokens.** The token registry is a Vault record and Vault picks its backend per process: the server has DB2 and uses Postgres, the CLI does not and uses the local `.vault` file. Same record name, different store. Every token that command prints fails redemption with "invalid or used token".
2. **Re-provisioning at the same path permanently breaks enrollment.** The record is named by a hash of the store path but encrypted with the per-`AIMEE_HOME` master key. Recreating `AIMEE_HOME` leaves an undecryptable record in the shared Postgres vault; enrollment for that path never works again. Brand-new path redeems fine, same path after a wipe fails.
3. **`scripts/aimee-local-stack-e2e.sh --mode full` cannot start aimee-server** — "first-boot credential Vault bootstrap failed", using exactly the env the script documents.

(1) and (2) matter because #2265's breaking change tells operators to re-enrol, and `aimee-kb enroll` is the command it points them at.