### PR TITLE
ci: cut required-check latency

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,48 @@
+name: Performance benchmark
+
+on:
+  schedule:
+    # Full performance sampling is intentionally outside the PR critical path.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: performance-benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0
+          until sudo apt-get update -q; do
+            i=$((i + 1))
+            [ "$i" -ge 5 ] && break
+            echo "apt-get update retry $i (transient repo failure)"
+            sleep $((i * 4))
+          done
+          sudo apt-get install -y -q gcc make \
+            libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
+            libp11-kit-dev libpq-dev
+      - name: Build benchmark
+        run: make -C src -j"$(nproc)" tests/bench-perf
+      - name: Run full benchmark and check committed baseline
+        run: |
+          src/tests/bench-perf \
+            --save "$RUNNER_TEMP/benchmark-current.json" \
+            --check benchmarks/baseline.json
+      - name: Upload benchmark result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-benchmark-${{ github.sha }}
+          path: ${{ runner.temp }}/benchmark-current.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libp11-kit-dev \
             libpq-dev
       - name: Build integrity
-        run: cd src && make build-integrity
+        run: cd src && make -j"$(nproc)" build-integrity
 
       # The linker is what proves a capability is absent from what ships; a source
       # grep only proves nothing calls it. These checks caught nothing by hand
@@ -286,10 +286,19 @@ jobs:
       - name: Artifact integrity (removed capabilities stay removed)
         run: bash scripts/validate-aimee-artifacts.sh
 
-  unit-tests:
+  unit-test-shards:
     needs: change-scope
     if: ${{ !cancelled() && (needs.change-scope.result != 'success' || needs.change-scope.outputs.docs_only != 'true') }}
     runs-on: ubuntu-latest
+    name: unit-tests (${{ matrix.label }}/2)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_index: 0
+            label: 1
+          - shard_index: 1
+            label: 2
     # Live Postgres sidecar so unit-test-aimee-db and unit-test-memory-postgres
     # exercise the real libpq path (placeholder rewriter, FTS5→tsvector
     # translation, ON CONFLICT targets, schema apply) instead of skipping
@@ -297,8 +306,18 @@ jobs:
     # memories_code_fts trigram index (see src/schema/postgres.sql).
     env:
       AIMEE_TEST_PG_URL: postgres://aimee:aimee@localhost:5432/aimee_test
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "true"
     steps:
       - uses: actions/checkout@v4
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: unit-ccache-v1-${{ runner.os }}-${{ matrix.shard_index }}-${{ hashFiles('src/Makefile', 'src/tests/Rules.mk') }}-${{ github.run_id }}
+          restore-keys: |
+            unit-ccache-v1-${{ runner.os }}-${{ matrix.shard_index }}-${{ hashFiles('src/Makefile', 'src/tests/Rules.mk') }}-
+            unit-ccache-v1-${{ runner.os }}-${{ matrix.shard_index }}-
       - name: Runner diagnostics
         run: |
           echo "::group::Runner environment"
@@ -335,7 +354,7 @@ jobs:
           # update with backoff so a transient mirror hiccup doesn't fail the job.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
           i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
-          sudo apt-get install -y -q gcc make \
+          sudo apt-get install -y -q gcc make ccache \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libp11-kit-dev \
             libpq-dev postgresql-client
       - name: Wait for Postgres
@@ -368,7 +387,46 @@ jobs:
           export AIMEE_TEST_TRUSTED_YES=/run/aimee-test-helpers/yes
           export AIMEE_TEST_TRUSTED_TRUE=/run/aimee-test-helpers/true
           export AIMEE_TEST_TRUSTED_ROOT_FILE=/run/aimee-test-helpers/root-file
-          cd src && make -j$(nproc) unit-tests build/obj/tests/p7-pkcs11-harness
+          ccache --max-size=750M
+          ccache --zero-stats
+          cd src
+          make -j"$(nproc)" CC="ccache gcc" \
+            GIT_VERSION=ci GIT_COMMIT_TIME=1700000000 \
+            UNIT_TEST_SHARD_COUNT=2 \
+            UNIT_TEST_SHARD_INDEX=${{ matrix.shard_index }} \
+            UNIT_TEST_SKIP_P1=1 \
+            unit-tests
+          ccache --show-stats
+
+  # Stable protected context for the sharded suite. It remains named
+  # `unit-tests`, so branch protection needs no transition window, and it also
+  # makes the already-separate real-Postgres RLS gate part of that required
+  # result instead of running it redundantly in every unit build.
+  unit-tests:
+    needs: [change-scope, unit-test-shards, p1-rls-gate]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm complete unit gate
+        env:
+          CHANGE_SCOPE_RESULT: ${{ needs.change-scope.result }}
+          DOCS_ONLY: ${{ needs.change-scope.outputs.docs_only }}
+          SHARDS_RESULT: ${{ needs.unit-test-shards.result }}
+          P1_RESULT: ${{ needs.p1-rls-gate.result }}
+        run: |
+          if [ "$CHANGE_SCOPE_RESULT" = success ] && [ "$DOCS_ONLY" = true ]; then
+            echo "Documentation-only change: unit shards and P1 gate skipped."
+            exit 0
+          fi
+          [ "$SHARDS_RESULT" = success ] || {
+            echo "Unit-test shard result: $SHARDS_RESULT" >&2
+            exit 1
+          }
+          [ "$P1_RESULT" = success ] || {
+            echo "P1 RLS gate result: $P1_RESULT" >&2
+            exit 1
+          }
+          echo "All unit-test shards and the P1 RLS gate passed."
 
   # The data-plane identity mint, end to end, against a live Postgres and a live
   # signed-HWM KMS helper.
@@ -1078,84 +1136,6 @@ jobs:
       - name: Memory retrieval eval (corpus + regression check)
         run: cd src && make -j$(nproc) memory-retrieval-eval-check
 
-  bench-check:
-    needs: change-scope
-    if: ${{ github.event_name == 'pull_request' && !cancelled() && (needs.change-scope.result != 'success' || needs.change-scope.outputs.docs_only != 'true') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Runner diagnostics
-        run: |
-          echo "::group::Runner environment"
-          echo "ref: $GITHUB_REF  sha: $GITHUB_SHA  runner: $RUNNER_OS $RUNNER_ARCH"
-          uname -a
-          gcc --version 2>/dev/null || true
-          make --version 2>/dev/null | head -1 || true
-          df -h / | tail -1
-          echo "::endgroup::"
-      - name: Install dependencies
-        run: |
-          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
-          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
-          # hard — though none of our packages come from them. Drop them, then retry
-          # update with backoff so a transient mirror hiccup doesn't fail the job.
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
-          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
-          sudo apt-get install -y -q gcc make \
-            libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libp11-kit-dev \
-            libpq-dev
-      - name: Build PR benchmark binary
-        run: |
-          if cd src && make -j$(nproc) tests/bench-perf; then
-            cp tests/bench-perf /tmp/bench-pr
-          else
-            echo "::warning::PR benchmark binary failed to build; benchmarks are informational."
-            touch /tmp/bench-skip
-          fi
-      - name: Build testing baseline binary
-        run: |
-          if [ -f /tmp/bench-skip ]; then
-            echo "Skipping baseline benchmark build because PR benchmark did not build."
-            exit 0
-          fi
-          BASE_REF="${{ github.base_ref }}"
-          if [ -z "$BASE_REF" ]; then
-            BASE_REF="origin/testing"
-          else
-            BASE_REF="origin/$BASE_REF"
-          fi
-          git worktree add /tmp/bench-baseline-wt "$BASE_REF"
-          cd /tmp/bench-baseline-wt/src
-          if make -j$(nproc) tests/bench-perf; then
-            cp tests/bench-perf /tmp/bench-baseline
-            echo "binary" > /tmp/bench-baseline-mode
-          else
-            echo "::warning::Base benchmark binary failed to build; using committed benchmark baseline."
-            cp "$GITHUB_WORKSPACE/benchmarks/baseline.json" /tmp/baseline.json
-            echo "static" > /tmp/bench-baseline-mode
-          fi
-          git -C /home/runner/work/aimee/aimee worktree remove /tmp/bench-baseline-wt --force
-      - name: Run same-machine regression report
-        run: |
-          if [ -f /tmp/bench-skip ]; then
-            echo "Skipping benchmark report because PR benchmark did not build."
-            exit 0
-          fi
-          if [ "$(cat /tmp/bench-baseline-mode)" = "binary" ]; then
-            if /tmp/bench-baseline --save /tmp/baseline.json; then
-              echo "Baseline measured from base branch on same machine. Running PR check..."
-            else
-              echo "::warning::Base benchmark binary failed at runtime; using committed benchmark baseline."
-              cp benchmarks/baseline.json /tmp/baseline.json
-            fi
-          else
-            echo "Using committed benchmark baseline because the base branch benchmark does not build."
-          fi
-          /tmp/bench-pr --check /tmp/baseline.json || \
-            echo "::warning::Benchmark regression detected; benchmarks are informational and do not gate PRs."
-
   # End-to-end deploy matrix: build the images and prove every Docker topology
   # (kb-only, server+kb split, server standalone) boots and serves a usable /v1
   # surface. See
@@ -1172,18 +1152,54 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        topology: [T1, T2, T3]
+        include:
+          - topology: T1
+            compose_file: compose.yaml
+            cache_set: |
+              aimee-kb.cache-from=type=gha,scope=e2e-T1-aimee-kb
+              aimee-kb.cache-to=type=gha,scope=e2e-T1-aimee-kb,mode=max
+              aimee-control-web.cache-from=type=gha,scope=e2e-T1-aimee-control-web
+              aimee-control-web.cache-to=type=gha,scope=e2e-T1-aimee-control-web,mode=max
+          - topology: T2
+            compose_file: compose.server.yaml
+            cache_set: |
+              aimee-kb.cache-from=type=gha,scope=e2e-T2-aimee-kb
+              aimee-kb.cache-to=type=gha,scope=e2e-T2-aimee-kb,mode=max
+              aimee-server.cache-from=type=gha,scope=e2e-T2-aimee-server
+              aimee-server.cache-to=type=gha,scope=e2e-T2-aimee-server,mode=max
+          - topology: T3
+            compose_file: compose.server-standalone.yaml
+            cache_set: |
+              aimee-server.cache-from=type=gha,scope=e2e-T3-aimee-server
+              aimee-server.cache-to=type=gha,scope=e2e-T3-aimee-server,mode=max
     name: e2e-docker (${{ matrix.topology }})
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Runner diagnostics
         run: |
           docker version --format '{{.Server.Version}}'
           docker compose version
+          docker buildx version
           df -h / | tail -1
+      - name: Build topology images with persistent cache
+        uses: docker/bake-action@v7
+        with:
+          source: .
+          files: ${{ matrix.compose_file }}
+          load: true
+          # Each image gets a distinct scope. Sharing one wildcard scope lets
+          # parallel Bake targets overwrite each other's exported cache.
+          set: ${{ matrix.cache_set }}
       - name: Run Docker deploy topology ${{ matrix.topology }}
         # The aimee-server image builds webchat's SPA from its vendored
         # @rakuensoftware/smoothgui dependency — no npm token needed.
+        env:
+          # The Bake step loaded exactly the images named by the compose file.
+          # Keep the smoke scripts' local default intact while avoiding a second
+          # uncached `docker compose build` in CI.
+          AIMEE_E2E_SKIP_BUILD: "1"
         run: scripts/e2e-matrix.sh --only ${{ matrix.topology }}
       - name: Stack logs on failure
         if: failure()

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -101,7 +101,11 @@ trap cleanup EXIT
 
 if [[ "$DO_UP" == 1 ]]; then
   bold "==> Building + Vault-bootstrapping + starting the stack ($COMPOSE_FILE)"
-  "${DC[@]}" build
+  if [[ "${AIMEE_E2E_SKIP_BUILD:-0}" != "1" ]]; then
+    "${DC[@]}" build
+  else
+    bold "==> Using prebuilt topology images (AIMEE_E2E_SKIP_BUILD=1)"
+  fi
   # Port-remap overrides do not affect the persistent Vault volume. Bootstrap
   # against the base file so the disposable helper seals first-boot values
   # before any long-lived service is created.

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -128,7 +128,11 @@ trap cleanup EXIT
 
 if [[ "$DO_UP" == 1 ]]; then
   bold "==> Building + Vault-bootstrapping + starting the full stack ($COMPOSE_FILE)"
-  "${DC[@]}" build
+  if [[ "${AIMEE_E2E_SKIP_BUILD:-0}" != "1" ]]; then
+    "${DC[@]}" build
+  else
+    bold "==> Using prebuilt topology images (AIMEE_E2E_SKIP_BUILD=1)"
+  fi
   # Port-remap overrides do not affect the persistent Vault volumes. Bootstrap
   # both owners against the base file before creating either long-lived service.
   bootstrap_compose="${COMPOSE_FILE%% *}"

--- a/scripts/aimee-server-standalone-docker-smoke.sh
+++ b/scripts/aimee-server-standalone-docker-smoke.sh
@@ -93,7 +93,11 @@ trap cleanup EXIT
 
 if [[ "$DO_UP" == 1 ]]; then
   bold "==> Building + Vault-bootstrapping + starting standalone server ($COMPOSE_FILE)"
-  "${DC[@]}" build
+  if [[ "${AIMEE_E2E_SKIP_BUILD:-0}" != "1" ]]; then
+    "${DC[@]}" build
+  else
+    bold "==> Using prebuilt topology images (AIMEE_E2E_SKIP_BUILD=1)"
+  fi
   # Port-remap overrides do not affect the persistent Vault volume. Bootstrap
   # against the base file before creating the long-lived server container.
   bootstrap_compose="${COMPOSE_FILE%% *}"

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -689,7 +689,37 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-kb-mgmt-token-authority-ipc
 TEST_TARGETS += $(TESTPREFIX)/unit-test-kb-mgmt-jwks-publication
 TEST_TARGETS += $(TESTPREFIX)/unit-test-server-mgmt-jwks-cache
 TEST_TARGETS += $(TESTPREFIX)/unit-test-kb-mgmt-offline-hardening
-unit-tests: p1-rls-gate-check $(BINARY) $(TEST_TARGETS)
+
+# CI can split the suite across independent runners without changing the local
+# contract: the defaults still build and execute every test in one invocation.
+# Round-robin selection keeps adjacent families from piling into one shard and
+# preserves process isolation -- every selected target is still the same binary
+# used by the full suite.
+UNIT_TEST_SHARD_COUNT ?= 1
+UNIT_TEST_SHARD_INDEX ?= 0
+UNIT_TEST_SKIP_P1 ?= 0
+ifeq ($(UNIT_TEST_SHARD_COUNT),1)
+UNIT_TEST_TARGETS := $(TEST_TARGETS)
+else
+UNIT_TEST_TARGETS := $(shell printf '%s\n' $(TEST_TARGETS) | \
+	awk -v count='$(UNIT_TEST_SHARD_COUNT)' -v shard='$(UNIT_TEST_SHARD_INDEX)' \
+	    'count > 0 && shard >= 0 && shard < count && slot == shard { print } \
+	     { slot = slot + 1; slot %= count }')
+endif
+
+ifeq ($(UNIT_TEST_SKIP_P1),1)
+UNIT_TEST_P1_PREREQ :=
+else
+UNIT_TEST_P1_PREREQ := p1-rls-gate-check
+endif
+
+unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(UNIT_TEST_TARGETS)
+	@if ! printf '%s:%s\n' "$(UNIT_TEST_SHARD_COUNT)" "$(UNIT_TEST_SHARD_INDEX)" | \
+	     awk -F: '$$1 ~ /^[0-9]+$$/ && $$2 ~ /^[0-9]+$$/ && $$1 > 0 && $$2 < $$1 { ok=1 } END { exit !ok }'; then \
+	  echo "invalid unit-test shard $(UNIT_TEST_SHARD_INDEX)/$(UNIT_TEST_SHARD_COUNT)" >&2; \
+	  exit 2; \
+	fi
+	@echo "Unit-test shard $(UNIT_TEST_SHARD_INDEX)/$(UNIT_TEST_SHARD_COUNT): $(words $(UNIT_TEST_TARGETS)) binaries"
 	@# Point the run's HOME at a throwaway dir so a test that does NOT isolate its
 	@# own environment defaults to $$th/.config/aimee, never the developer's real
 	@# ~/.config/aimee — the dir a running aimee-server reads agents.json, config
@@ -729,7 +759,7 @@ unit-tests: p1-rls-gate-check $(BINARY) $(TEST_TARGETS)
 	export AIMEE_TEST_FAILURE_DIR="$$th"; \
 	jobs="$(TEST_RUN_JOBS)"; \
 	if [ "$$jobs" -le 1 ]; then \
-	  for t in $(TEST_TARGETS); do \
+	  for t in $(UNIT_TEST_TARGETS); do \
 	    log="$$(mktemp /tmp/aimee-test-run.XXXXXX)"; \
 	    echo "  $$t"; \
 	    "./$$t" >"$$log" 2>&1; \
@@ -739,7 +769,7 @@ unit-tests: p1-rls-gate-check $(BINARY) $(TEST_TARGETS)
 	    [ "$$rc" -eq 0 ] || exit "$$rc"; \
 	  done; \
 	else \
-	  if ! printf '%s\0' $(TEST_TARGETS) | \
+	  if ! printf '%s\0' $(UNIT_TEST_TARGETS) | \
 	    xargs -0 -n1 -P "$$jobs" sh -c 't="$$1"; log="$$(mktemp /tmp/aimee-test-run.XXXXXX)"; echo "  $$t"; "./$$t" >"$$log" 2>&1; rc="$$?"; cat "$$log"; rm -f "$$log"; if [ "$$rc" -ne 0 ]; then echo "FAILED: $$t" >&2; printf "FAILED: %s\\n" "$$t" >"$$AIMEE_TEST_FAILURE_DIR/failure.$$$$"; fi; exit "$$rc"' _; then \
 	    echo "Unit test failures:" >&2; \
 	    cat "$$th"/failure.* 2>/dev/null >&2 || true; \

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -485,20 +485,57 @@ else
     fail "config.o without platform_random.o in: $bad_targets"
 fi
 
-# 6. Every .PHONY target has a corresponding rule (catches missing targets)
-phony_targets=$(grep '^\.PHONY:' Makefile tests/Rules.mk 2>/dev/null | \
-    sed 's/^.*\.PHONY://' | tr ' ' '\n' | sort -u | grep -v '^$')
-missing_rules=""
-for target in $phony_targets; do
-    # make -n (dry run) exits non-zero if the target has no rule
-    if ! make -n "$target" >/dev/null 2>&1; then
-        missing_rules="$missing_rules $target"
-    fi
-done
+# 6. Parse the Make database once, then verify every literal .PHONY declaration
+# has a rule in the source. The previous implementation started a fresh
+# `make -n` for every phony target; reparsing this large graph 100+ times took
+# more than two minutes in CI. GNU make returns 1 from -q when the default goal
+# is merely out of date, while 2 means the database itself could not be parsed.
+make_db_rc=0
+make -qp >/dev/null 2>&1 || make_db_rc=$?
+if [ "$make_db_rc" -gt 1 ]; then
+    fail "Make database parses cleanly"
+else
+    pass "Make database parses cleanly"
+fi
+
+# Join continuations once so multi-line .PHONY declarations and target rules
+# can be compared by one awk process. This deliberately checks the source rule,
+# not the database's synthetic target: declaring `.PHONY: missing` causes GNU
+# make to manufacture a target named `missing`, which made `make -n missing`
+# report success even when no corresponding rule existed.
+missing_rules=$(
+    {
+        sed ':a; /\\$/ { N; s/\\\n/ /; ba }' Makefile
+        sed ':a; /\\$/ { N; s/\\\n/ /; ba }' tests/Rules.mk
+    } | awk '
+        /^\.PHONY:[[:space:]]/ {
+            line = $0
+            sub(/^\.PHONY:[[:space:]]*/, "", line)
+            count = split(line, names, /[[:space:]]+/)
+            for (i = 1; i <= count; i++)
+                if (names[i] != "")
+                    phony[names[i]] = 1
+            next
+        }
+        /^[^#[:space:]][^=]*:/ {
+            line = $0
+            sub(/:.*/, "", line)
+            count = split(line, names, /[[:space:]]+/)
+            for (i = 1; i <= count; i++)
+                if (names[i] != "")
+                    rules[names[i]] = 1
+        }
+        END {
+            for (target in phony)
+                if (!(target in rules))
+                    print target
+        }
+    ' | sort | tr '\n' ' '
+)
 if [ -z "$missing_rules" ]; then
     pass "all .PHONY targets have rules"
 else
-    fail ".PHONY targets with no rule:$missing_rules"
+    fail ".PHONY targets with no rule: $missing_rules"
 fi
 
 # 7. Scripts don't reference non-existent make targets


### PR DESCRIPTION
## What changed

- move the full performance benchmark out of pull-request CI into a nightly/manual workflow
- split the 676-binary unit suite into two parallel shards and persist compiler output with ccache
- preserve the required `unit-tests` context through a small aggregate gate, including the existing P1 RLS job
- replace 100+ separate Make parses in build integrity with one database parse, and compile that job in parallel
- build Docker E2E images through Buildx Bake with persistent, collision-safe GitHub Actions cache scopes
- let Docker smoke scripts consume prebuilt images in CI while retaining their local build behavior

## Why

Recent pull-request CI expanded to roughly 15 minutes. The full benchmark alone occupied the entire critical path, while Docker image rebuilds, repeated Make parsing, and a monolithic uncached unit build accounted for most of the remaining time.

The first Docker run will populate its image caches. Later runs should represent steady-state CI performance.

## Validation

- both 338-binary unit-test shards pass locally
- `make -j8 build-integrity` passes
- benchmark binary builds successfully
- `actionlint` passes for both workflows
- modified shell scripts pass `bash -n`
- `git diff --check` passes
