### PR TITLE
deploy: the wizard's embedder choice never reached the managed kb

### DIFF
--- a/compose.server-managed.yaml
+++ b/compose.server-managed.yaml
@@ -86,10 +86,27 @@ services:
       # :testing — a split-version stack, which is how a kb with no `dim` in
       # /health got paired with a server that expected one.
       AIMEE_IMAGE_TAG: ${AIMEE_IMAGE_TAG:-latest}
-      # The managed KB image contains any model role placed inside that KB.
-      # Remote role endpoints and credentials remain owned by the KB; there is no
-      # separate inference-service image to select here.
-      AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb${AIMEE_KB_VARIANT:+-${AIMEE_KB_VARIANT}}:${AIMEE_IMAGE_TAG:-latest}}
+      # FORWARDED ONLY WHEN THE OPERATOR PINNED ONE. Resolving the default here
+      # instead — as this did — quietly disabled the wizard's embedder choice.
+      #
+      # AIMEE_KB_VARIANT is decided INSIDE the server, by config_emit_deploy_env,
+      # from the saved wizard configuration. It is unset in the shell that brings
+      # THIS file up, so resolving the default here collapsed to a bare
+      # `aimee-kb:<tag>` and baked that into the server's environment. deploy_apply
+      # copies environ, so the explicit AIMEE_KB_IMAGE then won over the variant the
+      # server had just computed, in the managed compose's own
+      # ${AIMEE_KB_IMAGE:-...aimee-kb${AIMEE_KB_VARIANT:+-...}} default.
+      #
+      # The result was silent and total: selecting bekko-a25m deployed the
+      # embedderless image, which logs "'bekko-a25m' selected but this image has no
+      # bundled embedder" and serves lexical-only search. Every gate passed --
+      # the deploy exits 0, the kb is healthy, `kb smoke` reports "vector store
+      # ready" -- because nothing here is broken except which image was chosen.
+      #
+      # Empty is correct for the unpinned case: the managed compose uses `:-`, which
+      # treats an empty value as absent and falls through to its own variant-aware
+      # default.
+      AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-}
       # Separate one-shot image containing the offline root provisioner and JWKS
       # publisher. These binaries never enter the ordinary KB/server images.
       AIMEE_AUTHORITY_BOOTSTRAP_IMAGE: ${AIMEE_AUTHORITY_BOOTSTRAP_IMAGE:-ghcr.io/rakuensoftware/aimee-authority-bootstrap:${AIMEE_IMAGE_TAG:-latest}}

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -63,6 +63,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      # First boot runs postgres initdb and, on the embedder-bearing images, loads
+      # the weights before /v1/health answers -- longer than retries*interval, so
+      # without this the kb reads as unhealthy while it is still starting normally.
+      # See deploy/container/aimee-managed.compose.yaml for what that broke.
+      start_period: 300s
     volumes:
       - aimee-kb-home:/var/lib/aimee
       # kb.build/update receive server workspace paths; mount the same durable

--- a/compose.yaml
+++ b/compose.yaml
@@ -45,6 +45,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      # First boot runs postgres initdb and, on the embedder-bearing images, loads
+      # the weights before /v1/health answers -- longer than retries*interval, so
+      # without this the kb reads as unhealthy while it is still starting normally.
+      # See deploy/container/aimee-managed.compose.yaml for what that broke.
+      start_period: 300s
     volumes:
       - aimee-kb-home:/var/lib/aimee
       - aimee-server-workspaces:/var/lib/aimee-workspaces:ro

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -57,6 +57,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      # First boot runs postgres initdb and, on the embedder-bearing images, loads
+      # the weights before /v1/health answers -- longer than retries*interval, so
+      # without this the kb reads as unhealthy while it is still starting normally.
+      # See deploy/container/aimee-managed.compose.yaml for what that broke.
+      start_period: 300s
     volumes:
       - aimee-kb-home:/var/lib/aimee
       - aimee-server-workspaces:/var/lib/aimee-workspaces:ro

--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -96,6 +96,22 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      # FIRST BOOT IS SLOWER THAN retries*interval, so without this the kb is
+      # declared unhealthy while it is still coming up correctly. Postgres initdb
+      # and the extensions run once, and the embedder-bearing images then load
+      # their weights before /v1/health answers.
+      #
+      # That is not cosmetic: the authority/JWKS bootstrap has
+      # `depends_on: aimee-kb: service_healthy`, and Compose fails a dependency the
+      # moment it goes unhealthy rather than waiting. The whole deploy exited 1 with
+      # "dependency failed to start: container aimee-aimee-kb-1 is unhealthy" against
+      # a kb that was healthy a few seconds later. The embedderless image hid this by
+      # having nothing to load -- fixing which image gets deployed is what surfaced it.
+      #
+      # Failures inside the window do not count against `retries`, and a healthy
+      # answer during it marks the container healthy immediately, so a generous
+      # value costs nothing on a fast host.
+      start_period: 300s
     volumes:
       - aimee-managed-kb-home:/var/lib/aimee
       # compose.server-managed owns this volume under the fixed `aimee` project.

--- a/deploy/smoothnas/aimee.compose.yaml
+++ b/deploy/smoothnas/aimee.compose.yaml
@@ -63,6 +63,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      # First boot runs postgres initdb and, on the embedder-bearing images, loads
+      # the weights before /v1/health answers -- longer than retries*interval, so
+      # without this the kb reads as unhealthy while it is still starting normally.
+      # See deploy/container/aimee-managed.compose.yaml for what that broke.
+      start_period: 300s
     volumes:
       - aimee-kb-home:/var/lib/aimee
       - aimee-server-workspaces:/var/lib/aimee-workspaces:ro

--- a/scripts/check-deploy-env-consumed.py
+++ b/scripts/check-deploy-env-consumed.py
@@ -179,12 +179,83 @@ def kb_env_failures(root: Path, emitted: list[str]) -> list[str]:
     return failures
 
 
+# The Compose file that starts aimee-server itself, and the service within it. The
+# server re-runs Compose for the managed siblings and copies its own environ, so
+# anything set here is inherited by that child.
+SERVER_COMPOSE = "compose.server-managed.yaml"
+SERVER_SERVICE = "aimee-server"
+
+
+def server_env_shadow_failures(root: Path, emitted: list[str]) -> list[str]:
+    """The rule that catches an emitted key OVERRIDDEN before it can be read.
+
+    Consumed-somewhere is not enough, and neither is reaching the container. A key
+    can be emitted, plumbed, read — and still lose, because a DIFFERENT variable
+    forwarded into aimee-server's own environment already answers the question.
+
+    That is what AIMEE_KB_IMAGE did. compose.server-managed.yaml set
+
+        AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-...aimee-kb${AIMEE_KB_VARIANT:+-${AIMEE_KB_VARIANT}}:...}
+
+    and AIMEE_KB_VARIANT is decided INSIDE the server by config_emit_deploy_env, from
+    the saved wizard configuration. It is unset in the shell that brings the server
+    up, so this collapsed to a bare `aimee-kb:<tag>` and baked it into the server's
+    environment. deploy_apply copies environ, so the managed compose's own
+    variant-aware default was pre-empted by the explicit value and the wizard's
+    embedder choice could not change the image. Selecting bekko-a25m deployed the
+    embedderless kb, which serves lexical-only search and says so in one log line
+    nobody reads. Nothing failed: not the deploy, not the healthcheck, not `kb smoke`.
+
+    So: no variable forwarded to aimee-server may resolve a default that interpolates
+    a key the deploy layer emits. Forward it empty (`${KEY:-}`) and let the managed
+    Compose file, which runs with the emitted value in its environment, resolve it.
+    """
+    if yaml is None:
+        return ["PyYAML is required to validate the aimee-server service environment"]
+    path = root / SERVER_COMPOSE
+    if not path.exists():
+        return [f"{SERVER_COMPOSE} is missing — it starts the server that re-runs Compose"]
+    try:
+        model = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [f"{SERVER_COMPOSE}: invalid YAML ({exc.__class__.__name__})"]
+    service = ((model or {}).get("services") or {}).get(SERVER_SERVICE)
+    if not isinstance(service, dict):
+        return [f"{SERVER_COMPOSE}: no {SERVER_SERVICE} service"]
+    env = service.get("environment")
+    if not isinstance(env, dict):
+        return [f"{SERVER_COMPOSE}: {SERVER_SERVICE} has no mapping-form environment"]
+
+    failures: list[str] = []
+    for name, value in env.items():
+        if not isinstance(value, str):
+            continue
+        # Only the DEFAULT half can shadow: `${NAME:-<default>}`. A bare `${NAME}`
+        # forwards whatever the operator set and resolves nothing on its own.
+        default = re.match(r"^\$\{%s:-(.*)\}$" % re.escape(str(name)), value.strip())
+        if not default:
+            continue
+        for key in emitted:
+            if key == name:
+                continue
+            if re.search(r"\$\{?%s\b" % re.escape(key), default.group(1)):
+                failures.append(
+                    f"{SERVER_COMPOSE}: {SERVER_SERVICE} resolves a default for {name} "
+                    f"that reads {key}, which config_emit_deploy_env decides inside the "
+                    f"server and which is unset here — the default collapses and then "
+                    f"overrides the value the server computes. Forward it as "
+                    f"${{{name}:-}} and let the managed Compose file resolve it"
+                )
+    return failures
+
+
 def check(root: Path) -> list[str]:
     failures: list[str] = []
     keys = emitted_keys(root)
     if not keys:
         return ["found no EMITF keys — has the emitter moved?"]
     failures.extend(kb_env_failures(root, keys))
+    failures.extend(server_env_shadow_failures(root, keys))
     for key in keys:
         if consumers(root, key):
             continue


### PR DESCRIPTION
## What was wrong

A managed deployment ignored the embedder the wizard had just written and always started the **embedderless** `aimee-kb` image. It says so in exactly one log line —

```
aimee-kb: 'bekko-a25m' selected but this image has no bundled embedder
```

— and then serves lexical-only search for the life of the deployment.

Nothing failed. The deploy exited 0, the kb went healthy, `aimee kb smoke` reported *"vector store ready"*, and every image build and unit test was green, because none of them ask **which image** was chosen.

## Why

`compose.server-managed.yaml` forwarded:

```yaml
AIMEE_KB_IMAGE: ${AIMEE_KB_IMAGE:-...aimee-kb${AIMEE_KB_VARIANT:+-${AIMEE_KB_VARIANT}}:...}
```

`AIMEE_KB_VARIANT` is not an operator knob — `config_emit_deploy_env` computes it *inside the server* from the saved wizard configuration. It is unset in the shell that brings that file up, so the default collapsed to a bare `aimee-kb:<tag>` and was baked into the server's environment. `deploy_apply` copies `environ` when it re-runs Compose for the siblings, so that pre-resolved value then beat the managed compose's own variant-aware default.

#2266 made the emitter incapable of resolving an embedderless kb by accident. This is the layer above it doing exactly that.

## The fix

1. Forward `AIMEE_KB_IMAGE` empty and let the managed compose — which runs with the emitted value in its environment — resolve it. `:-` treats empty as absent.
2. Give the kb healthcheck a `start_period` (all five compose files). First boot runs postgres initdb and, on the embedder-bearing images, loads weights before `/v1/health` answers — longer than `retries*interval`. The authority/JWKS bootstrap has `depends_on: service_healthy`, and Compose fails a dependency the moment it goes unhealthy rather than waiting, so the deploy exited 1 against a kb that was healthy seconds later. The embedderless image hid this by having nothing to load.
3. Extend `check-deploy-env-consumed` (already in `make lint`). "Consumed" was not a sufficient invariant — `AIMEE_KB_VARIANT` was emitted, plumbed and read, and still lost. It now also rejects any variable forwarded to `aimee-server` whose default interpolates an emitted key.

## Verification

From-nothing bootstrap on CT 302 against the published `:testing` images, driven through the real wizard API (server → wizard config → deploy):

| | before | after |
|---|---|---|
| kb image | `aimee-kb:testing` | `aimee-kb-a25m:testing` |
| embedder | "no bundled embedder" | `loaded hotchpotch/bekko-embedding-v1-a25m dim=384` |
| deploy `last_exit` | 1 | 0 |
| vectors | 0 points | ingest job completed, 17 points in pgvector |

Re-breaking the compose line makes the lint check fail with that line named; the existing plant-test still passes.