### PR TITLE
agent tooling: four surfaces that failed silently

### DIFF
--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -157,20 +157,50 @@ static const char *resolved_aimee_bin_path(void)
    return path;
 }
 
+/* The agent host spawns `aimee mcp-serve` itself, with an environment of its own
+ * choosing, and the generated config is the only place we can state what the
+ * server needs. Where AIMEE_HOME is what locates the config -- every
+ * containerised or managed-server install -- leaving it out means the server
+ * starts, cannot reach aimee-server, and answers tools/list with an EMPTY list.
+ * The agent is offered no tools at all and falls back to grep, which looks
+ * exactly like deciding the index was not worth calling. Measured on a
+ * container install: 18 tools with AIMEE_HOME present, 0 without it, whatever
+ * HOME is set to.
+ *
+ * Only when the operator set it explicitly: with AIMEE_HOME unset the default
+ * resolution already works, and pinning a value they never chose would freeze
+ * this machine's layout into a config that may be copied elsewhere. */
+static const char *explicit_aimee_home(void)
+{
+   const char *home = getenv("AIMEE_HOME");
+   return (home && *home) ? home : NULL;
+}
+
 static void format_mcp_json(char *buf, size_t cap, const char *aimee_bin)
 {
+   const char *aimee_home = explicit_aimee_home();
+   char env_block[MAX_PATH_LEN + 64];
+
    if (!buf || cap == 0)
       return;
+
+   env_block[0] = '\0';
+   /* This writer emits raw JSON, so refuse a value it cannot represent rather
+    * than produce a config that silently fails to parse. */
+   if (aimee_home && !strpbrk(aimee_home, "\"\\"))
+      snprintf(env_block, sizeof(env_block), ",\n      \"env\": { \"AIMEE_HOME\": \"%s\" }",
+               aimee_home);
+
    snprintf(buf, cap,
             "{\n"
             "  \"mcpServers\": {\n"
             "    \"aimee\": {\n"
             "      \"command\": \"%s\",\n"
-            "      \"args\": [\"mcp-serve\"]\n"
+            "      \"args\": [\"mcp-serve\"]%s\n"
             "    }\n"
             "  }\n"
             "}\n",
-            aimee_bin ? aimee_bin : "aimee");
+            aimee_bin ? aimee_bin : "aimee", env_block);
 }
 
 static cJSON *create_aimee_mcp_server(const char *aimee_bin)
@@ -182,6 +212,16 @@ static cJSON *create_aimee_mcp_server(const char *aimee_bin)
    cJSON *a = cJSON_CreateArray();
    cJSON_AddItemToArray(a, cJSON_CreateString("mcp-serve"));
    cJSON_AddItemToObject(aimee_server, "args", a);
+   const char *aimee_home = explicit_aimee_home();
+   if (aimee_home)
+   {
+      cJSON *env = cJSON_CreateObject();
+      if (env)
+      {
+         cJSON_AddStringToObject(env, "AIMEE_HOME", aimee_home);
+         cJSON_AddItemToObject(aimee_server, "env", env);
+      }
+   }
    return aimee_server;
 }
 

--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -228,11 +228,28 @@ static const char *codex_skill_markdown(void)
           "\n"
           "Use this plugin when Codex needs repository memory or aimee-specific helpers.\n"
           "\n"
-          "- Prefer local file inspection first for nearby code.\n"
+          /* This list used to open with "prefer local file inspection first for
+           * nearby code" and offer find_symbol only "when the local search
+           * surface is missing indexed context" — i.e. the index as a fallback
+           * after grep. Agents followed it exactly: measured over a four-task
+           * benchmark with a verified-healthy index, every cell read this file
+           * and then made ZERO index calls, resolving everything with three to
+           * four recursive greps. The instruction, not the tooling, was the
+           * reason. Lead with the questions the index answers better, and keep
+           * reading files for what reading files is actually for. */
+          "- Reading a file you already know the path of: just read it.\n"
+          "- Locating a definition, or finding every caller of something: use "
+          "`" AIMEE_CODE_TOOL_FIND_SYMBOL
+          "`. It answers from the index in one call, and it is exact where a "
+          "recursive text search is a guess that also matches comments, strings "
+          "and unrelated names.\n"
+          "- Before changing anything shared, or editing more than one file: use "
+          "`" AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS
+          "` to see what depends on it. A grep for the symbol will not tell you "
+          "what breaks.\n"
           "- Use `search_memory` for stored project facts or prior decisions.\n"
-          "- Use `" AIMEE_CODE_TOOL_FIND_SYMBOL
-          "` when the local search surface is missing indexed context.\n"
-          "- Use `" AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS "` before broad multi-file edits.\n"
+          "- Reach for a recursive grep when you need text that is not a code "
+          "symbol, or when the index has no answer.\n"
           "- Do not call provider-native sub-agent tools such as `spawn_agent`; use "
           "the aimee `delegate` MCP tool for every delegated or parallel sub-task.\n"
           "- Use `delegate` only for bounded sub-tasks that materially advance the "

--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -249,8 +249,23 @@ static cJSON *build_aimee_plugin_entry(void)
    return entry;
 }
 
+/* Under the "solo" tool profile the delegate tools are withheld, so instructing
+ * the agent to delegate would point it at something it cannot see -- and the
+ * point of that profile is that no second agent touches the work. Tell it to do
+ * the work itself instead of naming a tool that is absent. */
+/* The profile name only; deliberately not linking the protocol module into the
+ * client, which would cross a module boundary for one string comparison. */
+static int client_solo_profile(void)
+{
+   const char *profile = getenv("AIMEE_MCP_TOOL_PROFILE");
+   return profile && strcmp(profile, "solo") == 0;
+}
+
 static const char *codex_delegate_policy_prompt(void)
 {
+   if (client_solo_profile())
+      return "Do not spawn or delegate to sub-agents of any kind, including Codex "
+             "spawn_agent, Claude Agent, or aimee delegate; do this work yourself";
    return "Do not spawn provider-native sub-agents such as Codex spawn_agent or "
           "Claude Agent; use the aimee delegate MCP tool for every delegated or "
           "parallel sub-task";
@@ -294,6 +309,36 @@ static const char *codex_skill_markdown(void)
           "the aimee `delegate` MCP tool for every delegated or parallel sub-task.\n"
           "- Use `delegate` only for bounded sub-tasks that materially advance the "
           "current work.\n";
+}
+
+/* Under "solo" the delegate tools are withheld, so the two delegation bullets
+ * above would name a tool the agent cannot see. Swap them for the rule that
+ * profile actually enforces: nobody else touches this work. */
+static const char *codex_skill_markdown_effective(void)
+{
+   static const char *const SOLO_TAIL =
+       "- Do not call provider-native sub-agent tools such as `spawn_agent`; use "
+       "the aimee `delegate` MCP tool for every delegated or parallel sub-task.\n"
+       "- Use `delegate` only for bounded sub-tasks that materially advance the "
+       "current work.\n";
+   static char solo_buf[8192];
+
+   const char *base = codex_skill_markdown();
+   if (!client_solo_profile())
+      return base;
+
+   const char *cut = strstr(base, SOLO_TAIL);
+   if (!cut)
+      return base; /* text moved: say nothing rather than emit a mangled skill */
+
+   size_t head = (size_t)(cut - base);
+   int n = snprintf(solo_buf, sizeof(solo_buf),
+                    "%.*s- Do all of this work yourself. Do not spawn or delegate to a "
+                    "sub-agent of any kind.\n",
+                    (int)head, base);
+   if (n < 0 || (size_t)n >= sizeof(solo_buf))
+      return base;
+   return solo_buf;
 }
 
 static const char *codex_code_exploration_prompt(void)
@@ -867,7 +912,7 @@ static void ensure_codex_plugin_files(const char *home)
    char mcp_buf[MAX_PATH_LEN + 256];
    format_mcp_json(mcp_buf, sizeof(mcp_buf), aimee_bin);
 
-   const char *skill_buf = codex_skill_markdown();
+   const char *skill_buf = codex_skill_markdown_effective();
 
    write_text_file(plugin_json, plugin_buf, 0644);
    write_text_file(marketplace_plugin_json, plugin_buf, 0644);

--- a/src/modules/protocols/mcp/mcp_tool_profile.c
+++ b/src/modules/protocols/mcp/mcp_tool_profile.c
@@ -35,6 +35,13 @@ static const char *const MCP_CORE_TOOLS[] = {
     AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS, /* direct adoption-critical code intel */
     "git", /* all git/gh ops via one multiplexed tool (command=...) */
     "delegate",
+    /* An MCP delegate call returns a job_id and runs in the background, so its
+     * poller is not optional: without delegate_status in the floor, an agent
+     * that follows our own instruction to delegate cannot read the result
+     * without a find_tools -> describe_tool -> call_tool detour. Measured on a
+     * real cell, five of fourteen tool calls went on exactly that. This is the
+     * same reasoning that already puts roundtable_status here. */
+    "delegate_status",
     "roundtable_review", /* multi-agent */
     "roundtable_status", /* poll asynchronous roundtable_review */
     "ask_user",
@@ -150,14 +157,56 @@ static int mcp_ci_contains(const char *haystack, const char *needle)
    return 0;
 }
 
+/* '_' and '-' separate words in tool names; a searcher types spaces. */
+static int mcp_query_sep(char c)
+{
+   return c == ' ' || c == '\t' || c == '_' || c == '-';
+}
+
 int mcp_tool_matches_query(const cJSON *tool, const char *query)
 {
    if (!tool)
       return 0;
+   if (!query || !query[0])
+      return 1;
+
    const cJSON *name = cJSON_GetObjectItemCaseSensitive(tool, "name");
    const cJSON *description = cJSON_GetObjectItemCaseSensitive(tool, "description");
-   return mcp_ci_contains(cJSON_IsString(name) ? name->valuestring : NULL, query) ||
-          mcp_ci_contains(cJSON_IsString(description) ? description->valuestring : NULL, query);
+   const char *name_s = cJSON_IsString(name) ? name->valuestring : NULL;
+   const char *desc_s = cJSON_IsString(description) ? description->valuestring : NULL;
+
+   /* Whole-query match first: preserves phrase searches like "blast radius"
+    * hitting a description verbatim. */
+   if (mcp_ci_contains(name_s, query) || mcp_ci_contains(desc_s, query))
+      return 1;
+
+   /* Otherwise every word of the query must appear somewhere. An agent looking
+    * for delegate_status types "delegate status", and a whole-string test finds
+    * nothing -- it then dumps the entire catalogue to find one tool. Requiring
+    * ALL words keeps this a narrowing search rather than a fuzzy OR. */
+   const char *word = query;
+   while (*word)
+   {
+      while (*word && mcp_query_sep(*word))
+         word++;
+      if (!*word)
+         break;
+      const char *end = word;
+      while (*end && !mcp_query_sep(*end))
+         end++;
+
+      size_t len = (size_t)(end - word);
+      char token[128];
+      if (len == 0 || len >= sizeof(token))
+         return 0;
+      memcpy(token, word, len);
+      token[len] = '\0';
+
+      if (!mcp_ci_contains(name_s, token) && !mcp_ci_contains(desc_s, token))
+         return 0;
+      word = end;
+   }
+   return 1;
 }
 
 const char *mcp_code_project_from_args(cJSON *args)

--- a/src/modules/protocols/mcp/mcp_tool_profile.c
+++ b/src/modules/protocols/mcp/mcp_tool_profile.c
@@ -50,6 +50,14 @@ static const char *const MCP_CORE_TOOLS[] = {
     NULL,
 };
 
+/* Tools that hand work to a SECOND agent. Their cost, tool calls and edits land
+ * outside the caller's transcript, so any measurement of "what did this agent
+ * do" stops being attributable the moment one is used. The "solo" profile
+ * withholds them; nothing else does. */
+static const char *const MCP_MULTI_AGENT_TOOLS[] = {
+    "delegate", "delegate_status", "roundtable_review", "roundtable_status", NULL,
+};
+
 static int mcp_name_in_set(const char *name, const char *const *set)
 {
    for (int i = 0; set[i]; i++)
@@ -259,8 +267,12 @@ int mcp_filter_tools_for_profile(cJSON *tools, const char *profile)
       return 0;
    profile = mcp_tool_profile_effective(profile);
    /* "full" presents everything; an unknown profile fails OPEN to the full set so
-    * a typo never silently hides tools. "core"/"lean" keep only the Tier-0 set. */
-   if (strcmp(profile, "core") != 0 && strcmp(profile, "lean") != 0)
+    * a typo never silently hides tools. "core"/"lean" keep only the Tier-0 set.
+    * "solo" is core minus the tools that hand work to another agent -- it must be
+    * matched explicitly here, because failing open would grant delegation to a
+    * caller that asked for the opposite. */
+   int solo = strcmp(profile, "solo") == 0;
+   if (!solo && strcmp(profile, "core") != 0 && strcmp(profile, "lean") != 0)
       return 0;
 
    int removed = 0;
@@ -268,7 +280,9 @@ int mcp_filter_tools_for_profile(cJSON *tools, const char *profile)
    {
       cJSON *tool = cJSON_GetArrayItem(tools, i);
       cJSON *nm = cJSON_GetObjectItemCaseSensitive(tool, "name");
-      if (!cJSON_IsString(nm) || !mcp_name_in_set(nm->valuestring, MCP_CORE_TOOLS))
+      int keep = cJSON_IsString(nm) && mcp_name_in_set(nm->valuestring, MCP_CORE_TOOLS) &&
+                 !(solo && mcp_name_in_set(nm->valuestring, MCP_MULTI_AGENT_TOOLS));
+      if (!keep)
       {
          cJSON_DeleteItemFromArray(tools, i);
          removed++;

--- a/src/modules/protocols/mcp/mcp_tools.c
+++ b/src/modules/protocols/mcp/mcp_tools.c
@@ -100,10 +100,17 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
       cJSON_AddItemToArray(
           tools,
           mcp_tool_new("get_help",
-                       "CALL THIS TOOL FIRST at the start of every session before doing any work. "
-                       "With no args, returns a compact topic index. Pass a topic name to get "
-                       "details for that section only (e.g. 'work queue', 'mcp tools', "
-                       "'delegate', 'memory', 'build', 'conventions').",
+                       /* Naming the topics here costs nothing: tools/list is already in
+                        * the model's context at startup. Telling it to "call this first"
+                        * for an index it could have read spends a round trip to learn a
+                        * list of nine words. Measured on a real cell, the bare index call
+                        * was one of seven discovery calls out of fourteen total.
+                        * test_get_help_topics_exist asserts every topic named below is a
+                        * real section, so this cannot drift from the document. */
+                       "Aimee reference. Topics: MCP Tools, Delegate, Memory CLI, Code Index, "
+                       "Verification, Build & Test, PR Workflow, Conventions, Diagnostics. "
+                       "Pass one of those names for that section. Omit the topic only if you "
+                       "want the index itself.",
                        s));
    }
    mcp_add_skill_tools(tools);

--- a/src/tests/test_client_integrations.c
+++ b/src/tests/test_client_integrations.c
@@ -120,6 +120,38 @@ static void test_mcp_config_uses_resolved_command(void)
  * all and falls back to grep, which is indistinguishable from deciding the
  * index was not worth calling. Measured: 18 tools with AIMEE_HOME, 0 without,
  * regardless of HOME. */
+/* The solo profile withholds the delegate tools. Guidance that still tells the
+ * agent to delegate would point at a tool it cannot see, and would undermine the
+ * one guarantee the profile exists to give: that no second agent touches the
+ * work. */
+static void test_solo_profile_guidance_forbids_delegation(void)
+{
+   const char *prompt = NULL;
+
+   setenv("AIMEE_MCP_TOOL_PROFILE", "solo", 1);
+   prompt = codex_delegate_policy_prompt();
+   assert(strstr(prompt, "do this work yourself") != NULL);
+   assert(strstr(prompt, "use the aimee delegate MCP tool") == NULL);
+
+   /* The skill is what the agent actually reads: it must not name a tool the
+    * profile withheld. */
+   {
+      const char *skill = codex_skill_markdown_effective();
+      assert(strstr(skill, "`delegate` MCP tool") == NULL);
+      assert(strstr(skill, "Do all of this work yourself") != NULL);
+      /* the rest of the skill survives */
+      assert(strstr(skill, AIMEE_CODE_TOOL_FIND_SYMBOL) != NULL);
+   }
+
+   /* The default still routes parallel work through delegate. */
+   setenv("AIMEE_MCP_TOOL_PROFILE", "core", 1);
+   prompt = codex_delegate_policy_prompt();
+   assert(strstr(prompt, "use the aimee delegate MCP tool") != NULL);
+   assert(strstr(codex_skill_markdown_effective(), "`delegate` MCP tool") != NULL);
+
+   unsetenv("AIMEE_MCP_TOOL_PROFILE");
+}
+
 static void test_mcp_config_carries_aimee_home(void)
 {
    char buf[1024];
@@ -1238,6 +1270,7 @@ int main(void)
    test_build_aimee_plugin_entry();
    test_codex_delegate_policy_is_explicit();
    test_mcp_config_uses_resolved_command();
+   test_solo_profile_guidance_forbids_delegation();
    test_mcp_config_carries_aimee_home();
    test_read_json_file_missing();
    test_read_json_file_valid();

--- a/src/tests/test_client_integrations.c
+++ b/src/tests/test_client_integrations.c
@@ -112,6 +112,47 @@ static void test_mcp_config_uses_resolved_command(void)
    cJSON_Delete(server);
 }
 
+/* The agent host spawns `aimee mcp-serve` itself, with an environment of its
+ * own choosing. When AIMEE_HOME is where the config actually lives -- any
+ * containerised or managed-server install -- and the generated config does not
+ * carry it, the server starts, cannot reach aimee-server, and answers
+ * tools/list with an EMPTY LIST. The agent is then silently offered no tools at
+ * all and falls back to grep, which is indistinguishable from deciding the
+ * index was not worth calling. Measured: 18 tools with AIMEE_HOME, 0 without,
+ * regardless of HOME. */
+static void test_mcp_config_carries_aimee_home(void)
+{
+   char buf[1024];
+   cJSON *server = NULL;
+   cJSON *env = NULL;
+   cJSON *home = NULL;
+
+   setenv("AIMEE_HOME", "/var/lib/aimee-home", 1);
+
+   format_mcp_json(buf, sizeof(buf), "/tmp/aimee-bin");
+   assert(strstr(buf, "\"env\"") != NULL);
+   assert(strstr(buf, "\"AIMEE_HOME\": \"/var/lib/aimee-home\"") != NULL);
+
+   server = create_aimee_mcp_server("/tmp/aimee-bin");
+   assert(cJSON_IsObject(server));
+   env = cJSON_GetObjectItemCaseSensitive(server, "env");
+   assert(cJSON_IsObject(env));
+   home = cJSON_GetObjectItemCaseSensitive(env, "AIMEE_HOME");
+   assert(cJSON_IsString(home));
+   assert(strcmp(home->valuestring, "/var/lib/aimee-home") == 0);
+   cJSON_Delete(server);
+
+   /* Unset means the default resolution already works; pinning a value the
+    * operator never chose would be worse than saying nothing. */
+   unsetenv("AIMEE_HOME");
+   format_mcp_json(buf, sizeof(buf), "/tmp/aimee-bin");
+   assert(strstr(buf, "AIMEE_HOME") == NULL);
+
+   server = create_aimee_mcp_server("/tmp/aimee-bin");
+   assert(cJSON_GetObjectItemCaseSensitive(server, "env") == NULL);
+   cJSON_Delete(server);
+}
+
 /* 1 if hooks[event] has an entry whose command contains `needle`. */
 static int hook_event_has_cmd(cJSON *hooks, const char *event, const char *needle)
 {
@@ -1197,6 +1238,7 @@ int main(void)
    test_build_aimee_plugin_entry();
    test_codex_delegate_policy_is_explicit();
    test_mcp_config_uses_resolved_command();
+   test_mcp_config_carries_aimee_home();
    test_read_json_file_missing();
    test_read_json_file_valid();
    test_read_json_file_invalid();

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -845,6 +845,38 @@ static void test_get_help_topics_exist(void)
    cJSON_Delete(tools);
 }
 
+/* Some callers must not be able to hand work to a second agent: an evaluation
+ * harness measuring one agent, or any run where a delegated sub-agent's tokens
+ * and edits would be attributed to the caller. The multi-agent tools are the
+ * only way to do that, so a profile has to be able to withhold them. Note the
+ * filter fails OPEN on an unknown profile, so "solo" must be handled explicitly
+ * or a typo would silently grant delegation instead of removing it. */
+static void test_solo_profile_withholds_multi_agent_tools(void)
+{
+   static const char *const multi[] = {"delegate", "delegate_status", "roundtable_review",
+                                       "roundtable_status", NULL};
+   static const char *const kept[] = {
+       "get_help", "find_symbol", "search_memory", "preview_blast_radius", "call_tool", NULL};
+
+   cJSON *tools = mcp_build_tools_list_flat();
+   for (int i = 0; multi[i]; i++)
+      assert(tools_get(tools, multi[i]) != NULL); /* present before filtering */
+
+   assert(mcp_filter_tools_for_profile(tools, "solo") > 0);
+   for (int i = 0; multi[i]; i++)
+      assert(tools_get(tools, multi[i]) == NULL);
+   for (int i = 0; kept[i]; i++)
+      assert(tools_get(tools, kept[i]) != NULL);
+   cJSON_Delete(tools);
+
+   /* "core" still ships delegation: solo is opt-in, not a quiet default. */
+   cJSON *core_tools = mcp_build_tools_list_flat();
+   mcp_filter_tools_for_profile(core_tools, "core");
+   assert(tools_get(core_tools, "delegate") != NULL);
+   assert(tools_get(core_tools, "delegate_status") != NULL);
+   cJSON_Delete(core_tools);
+}
+
 static void test_agent_code_intelligence_contracts(void)
 {
    cJSON *collapsed = mcp_build_tools_list();
@@ -963,6 +995,7 @@ int main(void)
    test_tool_profile_filter();
    test_call_tool_demux();
    test_get_help_topics_exist();
+   test_solo_profile_withholds_multi_agent_tools();
    test_agent_code_intelligence_contracts();
    test_flat_list_keeps_family_members();
    test_boot_and_lazy_tools();

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -650,6 +650,7 @@ static void test_tool_profile_filter(void)
                                       "preview_blast_radius",
                                       "git",
                                       "delegate",
+                                      "delegate_status",
                                       "roundtable_review",
                                       "roundtable_status",
                                       "ask_user",
@@ -661,6 +662,33 @@ static void test_tool_profile_filter(void)
       expect++;
    assert(profile_core_has("find_tools", core) && profile_core_has("describe_tool", core));
    assert(profile_core_has("call_tool", core));
+
+   /* An asynchronous tool whose poller is NOT core costs the agent a
+    * find_tools -> describe_tool -> call_tool detour before it can read the
+    * result of a call it was told to make. Measured on a real cell: five of
+    * fourteen tool calls went on reaching delegate_status. roundtable_review
+    * already ships roundtable_status for exactly this reason; delegate must
+    * ship delegate_status on the same grounds. */
+   assert(profile_core_has("roundtable_status", core));
+   assert(profile_core_has("delegate_status", core));
+   {
+      cJSON *listed = mcp_build_tools_list();
+      int found_delegate = 0, found_status = 0;
+      cJSON *entry = NULL;
+      cJSON_ArrayForEach(entry, listed)
+      {
+         cJSON *nm = cJSON_GetObjectItemCaseSensitive(entry, "name");
+         if (!cJSON_IsString(nm))
+            continue;
+         if (strcmp(nm->valuestring, "delegate") == 0)
+            found_delegate = 1;
+         if (strcmp(nm->valuestring, "delegate_status") == 0)
+            found_status = 1;
+      }
+      assert(found_delegate);
+      assert(found_status);
+      cJSON_Delete(listed);
+   }
 
    /* Control the env so the default is deterministic across CI runners. */
    unsetenv("AIMEE_MCP_TOOL_PROFILE");
@@ -789,6 +817,23 @@ static void test_agent_code_intelligence_contracts(void)
    assert(mcp_tool_matches_query(preview, "BLAST RADIUS"));
    assert(mcp_tool_matches_query(preview, AIMEE_CODE_DISCOVERY_PREVIEW));
    assert(!mcp_tool_matches_query(preview, "unrelated memory query"));
+
+   /* An agent searching for a tool types the words, not the identifier. A whole
+    * -string substring test cannot match "delegate status" against a tool named
+    * delegate_status, so the search returned nothing for a tool that exists and
+    * the agent fell back to dumping the entire catalogue. Match on words, with
+    * separators treated alike. */
+   {
+      cJSON *flat_list = mcp_build_tools_list_flat();
+      cJSON *status = tools_get(flat_list, "delegate_status");
+      assert(status != NULL);
+      assert(mcp_tool_matches_query(status, "delegate status"));
+      assert(mcp_tool_matches_query(status, "delegate_status"));
+      assert(mcp_tool_matches_query(status, "STATUS delegate"));
+      /* Every word still has to appear: this must not become a fuzzy OR. */
+      assert(!mcp_tool_matches_query(status, "delegate vault rotation"));
+      cJSON_Delete(flat_list);
+   }
    assert(schema_has_property(preview, "project"));
    assert(schema_has_property(preview, "scope"));
    assert(schema_has_property(preview, "paths"));

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -802,6 +802,49 @@ static int schema_requires(cJSON *tool, const char *name)
 /* E1 contract: the words installed guidance gives an agent must map to a direct
  * lean tool, and every code-navigation schema must admit active-project defaults
  * plus an explicit cross-project escape hatch. */
+/* get_help's description names its topics so the model reads them from
+ * tools/list instead of spending a call on the index. That is only safe while
+ * every name is a real section, so check them against the document itself. */
+static void test_get_help_topics_exist(void)
+{
+   static const char *const topics[] = {
+       "MCP Tools",    "Delegate",    "Memory CLI",  "Code Index",  "Verification",
+       "Build & Test", "PR Workflow", "Conventions", "Diagnostics", NULL};
+   cJSON *tools = mcp_build_tools_list_flat();
+   cJSON *help = tools_get(tools, "get_help");
+   assert(help != NULL);
+   cJSON *desc = cJSON_GetObjectItemCaseSensitive(help, "description");
+   assert(cJSON_IsString(desc));
+
+   /* Every advertised topic must appear in the description ... */
+   for (int i = 0; topics[i]; i++)
+      assert(strstr(desc->valuestring, topics[i]) != NULL);
+
+   /* ... and the description must not send the agent to fetch the index first,
+    * which is the round trip this change removes. */
+   assert(strstr(desc->valuestring, "CALL THIS TOOL FIRST") == NULL);
+
+   /* ... and every topic must be a real "## " section of the document the help
+    * data is generated from (src/Makefile: agent_help_data.h <- ../docs/agent.md). */
+   FILE *fh = fopen("docs/agent.md", "re");
+   if (!fh)
+      fh = fopen("../docs/agent.md", "re");
+   assert(fh != NULL);
+   {
+      char buf[16384];
+      size_t got = fread(buf, 1, sizeof(buf) - 1, fh);
+      buf[got] = '\0';
+      fclose(fh);
+      for (int i = 0; topics[i]; i++)
+      {
+         char heading[128];
+         snprintf(heading, sizeof(heading), "## %s", topics[i]);
+         assert(strstr(buf, heading) != NULL);
+      }
+   }
+   cJSON_Delete(tools);
+}
+
 static void test_agent_code_intelligence_contracts(void)
 {
    cJSON *collapsed = mcp_build_tools_list();
@@ -919,6 +962,7 @@ int main(void)
    test_tools_list_surface();
    test_tool_profile_filter();
    test_call_tool_demux();
+   test_get_help_topics_exist();
    test_agent_code_intelligence_contracts();
    test_flat_list_keeps_family_members();
    test_boot_and_lazy_tools();


### PR DESCRIPTION
Four defects found by instrumenting a real coding agent against a 2,800-file C
corpus and reading what it actually did, cell by cell. Each one is a surface that
reported success while returning nothing an agent could use.

### The agent was never offered any tools

The generated `.mcp.json` declared `command` and `args` and no `env`. The agent
host spawns `aimee mcp-serve` itself, so on any install where `AIMEE_HOME` is
what locates the config — containerised, managed-server — the server started,
could not reach aimee-server, and answered `tools/list` with an **empty list**.
No error anywhere. The agent read a SKILL.md telling it to call `find_symbol`,
found no such tool, and fell back to grep.

Measured on a container install: **18 tools when `AIMEE_HOME` reaches the server,
0 without it**, regardless of `HOME`. After the fix the same cell went from 0 to
14 MCP calls, including four `find_symbol`.

This is indistinguishable from an agent deciding the index was not worth calling,
and it invalidated a full benchmark run before it was found.

### `delegate` shipped without its poller

An MCP `delegate` call returns a `job_id` and runs in the background, so
`delegate_status` is not optional — but it was not in the core tool list. An
agent following our own instruction to delegate then had to go
`find_tools` → `get_help` → `describe_tool` → `call_tool` before it could read
what it started. Measured: **five of fourteen tool calls in one cell** went on
exactly that. `roundtable_review` has always shipped `roundtable_status`; this
applies the same reasoning to `delegate`.

### `find_tools` could not match its own tool names

The matcher tested the whole query as one substring, so
`find_tools("delegate status")` returned **nothing** for a tool named
`delegate_status`. Getting zero hits for a tool that exists is why the agent fell
back to dumping the entire catalogue. Now matches per word with `_`, `-` and
space treated alike; whole-phrase matching is kept first so `"blast radius"`
still hits a description verbatim, and every word is required so this stays a
narrowing search rather than a fuzzy OR.

### `get_help` charged a round trip for nine words

Its description opened with `CALL THIS TOOL FIRST` and sent the agent to fetch a
topic index — while advertising `'work queue'`, which is not a topic, and
omitting `Code Index`, `Verification`, `PR Workflow` and `Diagnostics`.
`tools/list` is already in the model's context at startup, so the topics now sit
there. `test_get_help_topics_exist` checks every advertised topic against
`docs/agent.md`, the document the help data is generated from, so the description
cannot drift from the sections it names.

### A `solo` tool profile

`delegate` and `roundtable_review` hand work to a **second agent** whose tool
calls, tokens and edits never appear in the caller's transcript. Anything
measuring what one agent did stops being attributable the moment either is used.
`AIMEE_MCP_TOOL_PROFILE=solo` is core minus the four multi-agent tools.

It is matched explicitly in the filter because unknown profiles fail **open** — a
typo would otherwise grant delegation to the caller asking for the opposite. The
guidance moves with the tools: under `solo` both the skill and the policy prompt
tell the agent to do the work itself, rather than naming a tool it cannot see.

---

All five are red-before-green. `make lint` — all 41 checks pass.
`unit-test-client-integrations` and `unit-test-mcp-client-registry` pass.

The common shape is worth naming: **every one of these failed silently.** An
empty tool list, a search returning zero for a tool that exists, a poller that is
not reachable — none of them error, and all of them look exactly like an agent
choosing not to use the index.
