### PR TITLE
kb: the synthesis client never presented its certificate

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -616,7 +616,10 @@ Standard and third-party environment variables aimee honors (scanned non-`AIMEE_
 |----------|-------------|
 | `LLAMA_HOST` | llama.cpp server host/URL. |
 | `OLLAMA_HOST` | Ollama server host/URL for local models. |
+| `SYNTHESIS_CA_FILE` | CA that verifies the synthesis sidecar's certificate on the kb -> aimee-llm hop. REPLACES the system trust store for that endpoint, so set it only for a sidecar the kb's own CA issued. |
+| `SYNTHESIS_CERT_FILE` | Client certificate the kb presents to the synthesis sidecar, whose terminator requires one. Offered only to the host:port `SYNTHESIS_ENDPOINT` names. |
 | `SYNTHESIS_ENDPOINT` | OpenAI-compatible base URL used by the generic llm-chat sidecar. |
+| `SYNTHESIS_KEY_FILE` | Private key for `SYNTHESIS_CERT_FILE`. |
 | `SYNTHESIS_MODEL` | Model requested by the generic llm-chat sidecar. |
 
 ### Network / proxy

--- a/scripts/check-deploy-env-consumed.py
+++ b/scripts/check-deploy-env-consumed.py
@@ -67,6 +67,40 @@ def emitted_keys(root: Path) -> list[str]:
     return sorted(set(re.findall(r'EMITF\("([A-Z_][A-Z0-9_]*)=', text)))
 
 
+# Emitted keys whose only legitimate reader IS a Compose file, with the reason. An
+# image tag is chosen by Compose interpolation; there is no process to read it.
+# Everything else needs a reader in code, see code_consumers().
+COMPOSE_ONLY_KEYS = {
+    "AIMEE_KB_VARIANT": "selects the aimee-kb image tag; consumed by Compose interpolation.",
+    "AIMEE_LLM_VARIANT": "selects the aimee-llm image tag; consumed by Compose interpolation.",
+}
+
+# Extensions that hold something that RUNS. A Compose file is plumbing: it can hand a
+# variable to a container and prove nothing about anybody reading it.
+CODE_GLOBS = ("*.c", "*.h", "*.sh", "*.py")
+
+
+def code_consumers(root: Path, key: str) -> list[str]:
+    """Where key is read by code that runs, as opposed to YAML that forwards it.
+
+    THE DISTINCTION IS NOT PEDANTIC. SYNTHESIS_CA_FILE, SYNTHESIS_CERT_FILE and
+    SYNTHESIS_KEY_FILE were emitted by the deploy layer, listed in the aimee-kb
+    service environment, and delivered to the container -- and no line of C ever
+    called getenv on any of them. This check passed the whole time, because a
+    `${SYNTHESIS_CA_FILE:-}` in a Compose file matched its "is it consumed" regex.
+
+    What that bought: every synthesis call from the kb used the default TLS context,
+    the sidecar's certificate chained to a CA the client did not know, and the
+    handshake failed with "tlsv1 alert unknown ca". The operator saw a curator job
+    stuck at `provider HTTP -1`. The mTLS hop had a passing end-to-end test the whole
+    time -- it drove curl with the certificates, never the kb's own client.
+
+    So: forwarding is not consumption, and only a reader in something executable
+    counts.
+    """
+    return _search(root, key, CODE_GLOBS)
+
+
 def consumers(root: Path, key: str) -> list[str]:
     """Where key is READ. Setting it is not consuming it.
 
@@ -75,6 +109,10 @@ def consumers(root: Path, key: str) -> list[str]:
     are deliberately NOT matched: the whole point is that emitting a value is not the
     same as anything using it.
     """
+    return _search(root, key, ("*.c", "*.h", "*.sh", "*.py", "*.yaml", "*.yml"))
+
+
+def _search(root: Path, key: str, globs: tuple[str, ...]) -> list[str]:
     reads = [
         re.compile(r'getenv\s*\(\s*"%s"' % re.escape(key)),
         re.compile(r'runtime_secret_get\s*\(\s*"%s"' % re.escape(key)),
@@ -83,7 +121,7 @@ def consumers(root: Path, key: str) -> list[str]:
     ]
     hits: list[str] = []
     emitter_rel = EMITTER.as_posix()
-    for path in tracked(root, "*.c", "*.h", "*.sh", "*.py", "*.yaml", "*.yml"):
+    for path in tracked(root, *globs):
         rel = path.as_posix()
         if rel == emitter_rel or rel.endswith("src/tests/test_config.c"):
             continue
@@ -257,16 +295,25 @@ def check(root: Path) -> list[str]:
     failures.extend(kb_env_failures(root, keys))
     failures.extend(server_env_shadow_failures(root, keys))
     for key in keys:
-        if consumers(root, key):
+        if key in PENDING_CONSUMERS or key in COMPOSE_ONLY_KEYS:
             continue
-        if key in PENDING_CONSUMERS:
+        if not consumers(root, key):
+            failures.append(
+                f"{key} is emitted by config_emit_deploy_env but nothing reads it — a "
+                f"setting the user configures that silently does nothing. Consume it "
+                f"(for the kb, add it to the aimee-kb service environment in the "
+                f"shipped Compose files) or record it in PENDING_CONSUMERS with a reason"
+            )
             continue
-        failures.append(
-            f"{key} is emitted by config_emit_deploy_env but nothing reads it — a "
-            f"setting the user configures that silently does nothing. Consume it "
-            f"(for the kb, add it to the aimee-kb service environment in the "
-            f"shipped Compose files) or record it in PENDING_CONSUMERS with a reason"
-        )
+        if not code_consumers(root, key):
+            failures.append(
+                f"{key} is emitted and forwarded by a Compose file, but no code reads "
+                f"it — getenv/runtime_secret_get in C, or $VAR in a shell script. "
+                f"Handing a variable to a container proves nothing about anybody using "
+                f"it: this is exactly how SYNTHESIS_CA_FILE reached the kb and was "
+                f"ignored, leaving every synthesis call to fail the TLS handshake. "
+                f"Read it, or record it in COMPOSE_ONLY_KEYS with a reason"
+            )
     return failures
 
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -1118,6 +1118,9 @@ EXT_DESC = {
     "SYNTHESIS_API_KEY": ("Provider credentials", "Bearer credential used by the generic llm-chat sidecar; prefer the vault or a secret command."),
     "SYNTHESIS_ENDPOINT": ("Provider endpoints", "OpenAI-compatible base URL used by the generic llm-chat sidecar."),
     "SYNTHESIS_MODEL": ("Provider endpoints", "Model requested by the generic llm-chat sidecar."),
+    "SYNTHESIS_CA_FILE": ("Provider endpoints", "CA that verifies the synthesis sidecar's certificate on the kb -> aimee-llm hop. REPLACES the system trust store for that endpoint, so set it only for a sidecar the kb's own CA issued."),
+    "SYNTHESIS_CERT_FILE": ("Provider endpoints", "Client certificate the kb presents to the synthesis sidecar, whose terminator requires one. Offered only to the host:port `SYNTHESIS_ENDPOINT` names."),
+    "SYNTHESIS_KEY_FILE": ("Provider endpoints", "Private key for `SYNTHESIS_CERT_FILE`."),
 }
 
 

--- a/src/modules/config/config_kb_curator.c
+++ b/src/modules/config/config_kb_curator.c
@@ -8,7 +8,7 @@
  *     extract_code:
  *       enabled: false
  *     extract_command: ""
- *     extract_max_tokens: 512
+ *     extract_max_tokens: 1024
  *     max_attempts: 3
  */
 
@@ -84,10 +84,25 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_judge_command[0] = '\0';
    cfg->kb_curator_synthesize_command[0] = '\0';
    cfg->kb_curator_synthesize_k = 8;
-   /* The bundled CPU synth produces roughly 2-4 tokens/s.  Keep its default
-    * curator completion inside the five-minute provider deadline so background
-    * extraction cannot monopolize the one-slot gateway until timeout. */
-   cfg->kb_curator_extract_max_tokens = 512;
+   /* SIZED FOR A MODEL THAT THINKS BEFORE IT ANSWERS, which 512 was not.
+    *
+    * 512 came from a 2-4 tokens/s bundled synth, chosen to stay inside the
+    * five-minute provider deadline. The bundled synth is now gemma-4 E2B/E4B, which
+    * emits a reasoning pass before any content: on the shipped extract prompt it
+    * spent ~290 tokens reasoning and then had the JSON envelope cut off mid-object
+    * at exactly 512. cJSON_Parse then failed, the job was marked
+    * "sidecar returned non-JSON", and it retried into permanent failure -- every
+    * extract_doc job, every time, on the default configuration.
+    *
+    * 1024 comes from measurement, not roundness: that prompt completes in 767
+    * tokens with finish_reason "stop" and parseable JSON, so this is the observed
+    * requirement plus a third again. The deadline still holds -- the sidecar runs
+    * 6-13 tokens/s with multi-token prediction, so 1024 tokens is 80-170s against a
+    * 300s budget, where 2048 would not have been safe at the low end.
+    *
+    * Turning synthesis_thinking off is the other half of the trade and belongs to
+    * the operator: the same extraction then finishes in ~94 tokens. */
+   cfg->kb_curator_extract_max_tokens = 1024;
    cfg->kb_curator_max_attempts = 3;
    cfg->kb_curator_provider_base_url[0] = '\0';
    cfg->kb_curator_provider_model[0] = '\0';
@@ -534,7 +549,7 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_projection_graph_enabled || cfg->kb_curator_synthesize_enabled ||
        cfg->kb_curator_promote_entity_enabled || cfg->kb_curator_extract_command[0] ||
        cfg->kb_curator_judge_command[0] || cfg->kb_curator_synthesize_command[0] ||
-       cfg->kb_curator_extract_max_tokens != 512 || cfg->kb_curator_max_attempts != 3 ||
+       cfg->kb_curator_extract_max_tokens != 1024 || cfg->kb_curator_max_attempts != 3 ||
        cfg->kb_curator_synthesize_k != 8 || cfg->kb_curator_promote_min_sources != 3 ||
        cfg->kb_curator_provider_base_url[0] || cfg->kb_curator_provider_model[0];
    int cross_repo_nondefault =
@@ -657,7 +672,7 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
             cJSON_AddStringToObject(cur, "judge_command", cfg->kb_curator_judge_command);
          if (cfg->kb_curator_synthesize_command[0])
             cJSON_AddStringToObject(cur, "synthesize_command", cfg->kb_curator_synthesize_command);
-         if (cfg->kb_curator_extract_max_tokens != 512)
+         if (cfg->kb_curator_extract_max_tokens != 1024)
             cJSON_AddNumberToObject(cur, "extract_max_tokens", cfg->kb_curator_extract_max_tokens);
          if (cfg->kb_curator_max_attempts != 3)
             cJSON_AddNumberToObject(cur, "max_attempts", cfg->kb_curator_max_attempts);

--- a/src/posix/agent_bridge.c
+++ b/src/posix/agent_bridge.c
@@ -22,6 +22,35 @@ int agent_request_cancelled(void) __attribute__((weak));
 
 static SSL_CTX *s_ssl_ctx;
 
+/* THE SYNTHESIS SIDECAR IS THE ONE HOP THAT NEEDS A CLIENT CERTIFICATE.
+ *
+ * s_ssl_ctx verifies against the system trust store and presents nothing. That is
+ * right for every public provider and wrong for exactly one peer: aimee-llm, whose
+ * certificate is issued by the kb's own CA and whose stunnel terminator sets
+ * `verifyChain = yes` and therefore REQUIRES a client certificate.
+ *
+ * Without this the deploy layer's SYNTHESIS_CA_FILE / SYNTHESIS_CERT_FILE /
+ * SYNTHESIS_KEY_FILE were read by nothing at all. Every synthesis call left the kb
+ * with the default context, the sidecar's certificate chained to a CA the client had
+ * never heard of, and the handshake died with "tlsv1 alert unknown ca" -- surfacing
+ * to the operator as `provider HTTP -1` on a permanently failed curator job, and in
+ * the log as "TCP connect failed", which is what a connection that connected fine
+ * looks like from a caller that cannot tell a handshake from a connect.
+ *
+ * A SECOND CONTEXT, NOT A RELAXED FIRST ONE. Loading our CA into s_ssl_ctx would
+ * make a certificate the kb issued to itself acceptable for api.anthropic.com, and
+ * attaching the client certificate there would hand the kb's identity to every
+ * endpoint it talks to. So the identity is bound to the one host:port that
+ * SYNTHESIS_ENDPOINT names, and nothing else can reach it. */
+static SSL_CTX *s_synth_ssl_ctx;
+static char s_synth_host[256];
+static int s_synth_port;
+
+/* Defined below parse_url, which it needs; the signature keeps parsed_url_t out of
+ * the forward declaration. Called from agent_http_init, once, before any worker
+ * thread exists -- so no locking here or at the point of use. */
+static void synth_ssl_ctx_init(void);
+
 void agent_http_init(void)
 {
    /* Initialize proxy bootstrap before setting up the SSL context so that
@@ -45,6 +74,8 @@ void agent_http_init(void)
             aimee_log(LOG_DEBUG, "proxy", "loaded CA bundle: %s", pb->ca_bundle);
       }
    }
+
+   synth_ssl_ctx_init();
 }
 
 void agent_http_cleanup(void)
@@ -54,6 +85,13 @@ void agent_http_cleanup(void)
       SSL_CTX_free(s_ssl_ctx);
       s_ssl_ctx = NULL;
    }
+   if (s_synth_ssl_ctx)
+   {
+      SSL_CTX_free(s_synth_ssl_ctx);
+      s_synth_ssl_ctx = NULL;
+   }
+   s_synth_host[0] = '\0';
+   s_synth_port = 0;
 }
 
 #define HTTP_MAX_RESPONSE_SIZE (10 * 1024 * 1024) /* 10MB */
@@ -116,6 +154,78 @@ static int parse_url(const char *url, parsed_url_t *out)
       snprintf(out->path, sizeof(out->path), "/");
 
    return 0;
+}
+
+/* Build the synthesis-sidecar client context from the deploy layer's three files.
+ *
+ * All four inputs are required together. SYNTHESIS_ENDPOINT alone is the ordinary
+ * external-provider case (the operator points synthesis at a public endpoint with a
+ * public certificate), and the three files without it name no peer to trust, so both
+ * partial states correctly leave the default context in charge.
+ *
+ * FAIL LOUD, NOT QUIET. If the files are named but unusable this logs an error and
+ * leaves s_synth_ssl_ctx NULL, so the hop falls back to the default context and
+ * fails the handshake -- the same outcome as before, but now with a line that says
+ * which file could not be loaded instead of a bare "unknown ca" from OpenSSL. */
+static void synth_ssl_ctx_init(void)
+{
+   const char *endpoint = getenv("SYNTHESIS_ENDPOINT");
+   const char *ca = getenv("SYNTHESIS_CA_FILE");
+   const char *cert = getenv("SYNTHESIS_CERT_FILE");
+   const char *key = getenv("SYNTHESIS_KEY_FILE");
+   if (!endpoint || !endpoint[0] || !ca || !ca[0] || !cert || !cert[0] || !key || !key[0])
+      return;
+
+   parsed_url_t pu;
+   if (parse_url(endpoint, &pu) != 0 || !pu.use_ssl)
+   {
+      aimee_log(LOG_WARN, "synthesis_mtls",
+                "SYNTHESIS_ENDPOINT (%s) is not an https URL; the client identity in "
+                "SYNTHESIS_CERT_FILE will not be used",
+                endpoint);
+      return;
+   }
+
+   SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+   if (!ctx)
+      return;
+   /* Deliberately NO SSL_CTX_set_default_verify_paths: on this hop our CA REPLACES
+    * the system store. A public CA has no business vouching for the sidecar, and
+    * accepting one would turn a private hop into a publicly impersonable one. */
+   if (SSL_CTX_load_verify_file(ctx, ca) != 1 ||
+       SSL_CTX_use_certificate_chain_file(ctx, cert) != 1 ||
+       SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM) != 1 ||
+       SSL_CTX_check_private_key(ctx) != 1)
+   {
+      char ebuf[256] = "";
+      unsigned long e = ERR_peek_last_error();
+      if (e)
+         ERR_error_string_n(e, ebuf, sizeof(ebuf));
+      aimee_log(LOG_ERROR, "synthesis_mtls",
+                "could not load the synthesis client identity (ca=%s cert=%s key=%s)%s%s", ca, cert,
+                key, ebuf[0] ? ": " : "", ebuf);
+      SSL_CTX_free(ctx);
+      return;
+   }
+   SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+   SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+
+   s_synth_ssl_ctx = ctx;
+   snprintf(s_synth_host, sizeof(s_synth_host), "%s", pu.host);
+   s_synth_port = pu.port;
+   aimee_log(LOG_INFO, "synthesis_mtls", "client identity loaded for %s:%d", s_synth_host,
+             s_synth_port);
+}
+
+/* The sidecar identity is for the sidecar, and for nothing else. Host AND port must
+ * both match what SYNTHESIS_ENDPOINT named: matching on host alone would present the
+ * kb's client certificate to any other service that happens to share the name. */
+static SSL_CTX *ssl_ctx_for(const parsed_url_t *url)
+{
+   if (s_synth_ssl_ctx && s_synth_host[0] && url->port == s_synth_port &&
+       strcasecmp(url->host, s_synth_host) == 0)
+      return s_synth_ssl_ctx;
+   return s_ssl_ctx;
 }
 
 /* ---- Socket I/O with timeout ---- */
@@ -416,13 +526,14 @@ static int conn_open(http_conn_t *conn, const parsed_url_t *url, int timeout_ms)
 
    if (url->use_ssl)
    {
-      if (!s_ssl_ctx)
+      SSL_CTX *ctx = ssl_ctx_for(url);
+      if (!ctx)
       {
          close(conn->fd);
          conn->fd = -1;
          return -1;
       }
-      conn->ssl = SSL_new(s_ssl_ctx);
+      conn->ssl = SSL_new(ctx);
       if (!conn->ssl)
       {
          close(conn->fd);
@@ -453,6 +564,16 @@ static int conn_open(http_conn_t *conn, const parsed_url_t *url, int timeout_ms)
       }
       if (!connected)
       {
+         /* Name the handshake. The caller's only message is "TCP connect failed",
+          * which is actively misleading here: the TCP connect succeeded and TLS is
+          * what failed. Debugging the sidecar hop cost an hour to this one line --
+          * OpenSSL knew it was "tlsv1 alert unknown ca" the whole time. */
+         char ebuf[256] = "";
+         unsigned long e = ERR_peek_last_error();
+         if (e)
+            ERR_error_string_n(e, ebuf, sizeof(ebuf));
+         aimee_log(LOG_ERROR, "agent_http", "TLS handshake failed with %s:%d%s%s", url->host,
+                   url->port, ebuf[0] ? ": " : "", ebuf);
          SSL_free(conn->ssl);
          close(conn->fd);
          conn->fd = -1;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -306,6 +306,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-workspace-runner-queue \
                $(TESTPREFIX)/unit-test-cli-kb-smoke \
                $(TESTPREFIX)/unit-test-kb-synthesis-identity \
+               $(TESTPREFIX)/unit-test-synthesis-mtls-client \
                $(TESTPREFIX)/unit-test-workspace-scope \
                $(TESTPREFIX)/unit-test-workspace-migration \
                $(TESTPREFIX)/unit-test-webuser-runtime \
@@ -5671,6 +5672,21 @@ $(TESTPREFIX)/unit-test-subject-grammar: $(OBJDIR)/tests/test_subject_grammar.o 
 
 $(TESTPREFIX)/unit-test-kb-synthesis-identity: \
                      $(OBJDIR)/tests/test_kb_synthesis_identity.o \
+                     $(OBJDIR)/kb/kb_synthesis_identity.o \
+                     $(OBJDIR)/kb/pki.o \
+                     $(OBJDIR)/kb/modules/vault/vault_crypto.o \
+                     $(OBJDIR)/kb/modules/vault/vault_server_key.o \
+                     $(OBJDIR)/kb/modules/vault/vault_store.o $(OBJDIR)/kb/modules/vault/vault_kek_check.o \
+                     $(OBJDIR)/kb/modules/vault/vault_kek_cache.o \
+                     $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# The kb's own HTTP client against a peer that demands a client certificate. Links
+# the real agent_bridge, because the defect was in which SSL_CTX it chose.
+$(TESTPREFIX)/unit-test-synthesis-mtls-client: \
+                     $(OBJDIR)/tests/test_synthesis_mtls_client.o \
+                     $(OBJDIR)/posix/agent_bridge.o \
+                     $(OBJDIR)/proxy_bootstrap.o \
                      $(OBJDIR)/kb/kb_synthesis_identity.o \
                      $(OBJDIR)/kb/pki.o \
                      $(OBJDIR)/kb/modules/vault/vault_crypto.o \

--- a/src/tests/test_synthesis_mtls_client.c
+++ b/src/tests/test_synthesis_mtls_client.c
@@ -1,0 +1,200 @@
+/* test_synthesis_mtls_client.c: the kb's OWN http client against a real mTLS peer.
+ *
+ * WHY THIS EXISTS. scripts/test-synthesis-mtls-hop.sh passed 9/9 against a
+ * deployment where synthesis could not work at all. It drives `curl --cert --key`
+ * from inside the kb container, so it proves the SIDECAR accepts a correct client --
+ * and says nothing about whether the kb's own HTTP client presents one. It did not.
+ *
+ * agent_http kept a single SSL_CTX with the system trust store and no client
+ * certificate, and SYNTHESIS_CA_FILE / SYNTHESIS_CERT_FILE / SYNTHESIS_KEY_FILE were
+ * read by no line of code in the tree. Every curator call died in the handshake with
+ * "tlsv1 alert unknown ca", reported to the operator as `provider HTTP -1` on a
+ * permanently failed job, and logged as "TCP connect failed" -- on a connection whose
+ * TCP connect had succeeded.
+ *
+ * So this test drives agent_http_post itself, against an OpenSSL server that demands
+ * a client certificate, using material minted by the same issuer the kb uses in
+ * production (kb_synthesis_identity_ensure). Three properties, in order of what they
+ * would have caught:
+ *
+ *   1. with the three variables set, the request SUCCEEDS   (the bug: it did not)
+ *   2. without them, it FAILS                               (proves 1 is not vacuous)
+ *   3. with them pointing at a different port, it FAILS     (the identity is bound to
+ *      the sidecar, and is not offered to every host the kb talks to)
+ */
+#include "agent_exec.h"
+#include "kb_synthesis_identity.h"
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <netinet/in.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char g_home[512];
+/* kb_synthesis_identity_ensure() writes into <data_dir>/synthesis-tls, not into the
+ * data dir itself; g_dir is that subdirectory. */
+static char g_dir[600];
+static int g_listen_fd = -1;
+static int g_port;
+
+/* One-shot TLS server: accept exactly one connection, require a client certificate
+ * against our CA, answer 200. Mirrors what stunnel does in front of llama-server
+ * (verifyChain = yes), which is the peer behaviour the client has to satisfy. */
+static void *server_thread(void *arg)
+{
+   (void)arg;
+   char ca[600], cert[600], key[600];
+   snprintf(ca, sizeof(ca), "%s/ca.pem", g_dir);
+   snprintf(cert, sizeof(cert), "%s/server.pem", g_dir);
+   snprintf(key, sizeof(key), "%s/server.key", g_dir);
+
+   SSL_CTX *ctx = SSL_CTX_new(TLS_server_method());
+   assert(ctx);
+   assert(SSL_CTX_use_certificate_chain_file(ctx, cert) == 1);
+   assert(SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM) == 1);
+   assert(SSL_CTX_load_verify_file(ctx, ca) == 1);
+   SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+
+   /* accept() must not block forever: two of the three cases below are SUPPOSED to
+    * fail, and a test that hangs on its own success condition is worse than one that
+    * fails. SO_RCVTIMEO on a listening socket bounds accept(). */
+   struct timeval tv = {20, 0};
+   setsockopt(g_listen_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+   int fd = accept(g_listen_fd, NULL, NULL);
+   if (fd < 0)
+   {
+      SSL_CTX_free(ctx);
+      return NULL;
+   }
+   SSL *ssl = SSL_new(ctx);
+   SSL_set_fd(ssl, fd);
+   if (SSL_accept(ssl) == 1)
+   {
+      char buf[4096];
+      SSL_read(ssl, buf, sizeof(buf)); /* request; content is irrelevant here */
+      const char *resp = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                         "Content-Length: 2\r\n\r\n{}";
+      SSL_write(ssl, resp, (int)strlen(resp));
+   }
+   SSL_shutdown(ssl);
+   SSL_free(ssl);
+   close(fd);
+   SSL_CTX_free(ctx);
+   return NULL;
+}
+
+static pthread_t start_server(void)
+{
+   /* DUAL-STACK, and that is load-bearing. The client connects to the NAME
+    * "localhost" -- it has to, because the server certificate's SAN is DNS:localhost
+    * and an IP literal would fail hostname verification. On a host where localhost
+    * resolves to ::1 first, an AF_INET listener is simply not there, and the test
+    * fails with "TCP connect failed" while claiming something about TLS. */
+   g_listen_fd = socket(AF_INET6, SOCK_STREAM, 0);
+   assert(g_listen_fd >= 0);
+   int one = 1;
+   int off = 0;
+   setsockopt(g_listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+   setsockopt(g_listen_fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
+
+   struct sockaddr_in6 sa;
+   memset(&sa, 0, sizeof(sa));
+   sa.sin6_family = AF_INET6;
+   sa.sin6_addr = in6addr_any;
+   sa.sin6_port = 0; /* ephemeral: a fixed port makes this flaky under parallel CI */
+   assert(bind(g_listen_fd, (struct sockaddr *)&sa, sizeof(sa)) == 0);
+   assert(listen(g_listen_fd, 1) == 0);
+
+   socklen_t len = sizeof(sa);
+   assert(getsockname(g_listen_fd, (struct sockaddr *)&sa, &len) == 0);
+   g_port = ntohs(sa.sin6_port);
+
+   pthread_t t;
+   assert(pthread_create(&t, NULL, server_thread, NULL) == 0);
+   return t;
+}
+
+static void set_identity_env(int port)
+{
+   char v[700];
+   snprintf(v, sizeof(v), "https://localhost:%d/v1", port);
+   setenv("SYNTHESIS_ENDPOINT", v, 1);
+   snprintf(v, sizeof(v), "%s/ca.pem", g_dir);
+   setenv("SYNTHESIS_CA_FILE", v, 1);
+   snprintf(v, sizeof(v), "%s/client.pem", g_dir);
+   setenv("SYNTHESIS_CERT_FILE", v, 1);
+   snprintf(v, sizeof(v), "%s/client.key", g_dir);
+   setenv("SYNTHESIS_KEY_FILE", v, 1);
+}
+
+static int post_once(void)
+{
+   char url[700];
+   snprintf(url, sizeof(url), "https://localhost:%d/v1/chat/completions", g_port);
+   char *resp = NULL;
+   int status = agent_http_post(url, NULL, "{}", &resp, 15000, NULL);
+   free(resp);
+   return status;
+}
+
+int main(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-synth-mtls-%d", (int)getpid());
+   assert(mkdir(g_home, 0700) == 0);
+
+   /* The SAME issuer the kb uses in production. A hand-rolled CA here could drift
+    * from what kb_synthesis_identity_ensure actually emits -- and the last two bugs
+    * on this hop were both about material, not about protocol. */
+   assert(kb_synthesis_identity_ensure(g_home, "localhost") == 0);
+   snprintf(g_dir, sizeof(g_dir), "%s/synthesis-tls", g_home);
+
+   /* 1. The identity is configured: the request must get through. */
+   pthread_t t = start_server();
+   set_identity_env(g_port);
+   agent_http_init();
+   int status = post_once();
+   pthread_join(t, NULL);
+   close(g_listen_fd);
+   if (status != 200)
+      fprintf(stderr, "with the client identity configured, expected 200, got %d\n", status);
+   assert(status == 200);
+   agent_http_cleanup();
+
+   /* 2. Without it, the same request must fail. Otherwise (1) proves nothing: a
+    *    server that did not really demand a certificate would pass it too. */
+   t = start_server();
+   unsetenv("SYNTHESIS_CA_FILE");
+   unsetenv("SYNTHESIS_CERT_FILE");
+   unsetenv("SYNTHESIS_KEY_FILE");
+   agent_http_init();
+   status = post_once();
+   pthread_join(t, NULL);
+   close(g_listen_fd);
+   assert(status < 200 || status >= 300);
+   agent_http_cleanup();
+
+   /* 3. The identity belongs to the endpoint SYNTHESIS_ENDPOINT names, and to
+    *    nothing else. Point the endpoint at a different port and the certificate
+    *    must not be offered here -- otherwise the kb would hand its identity to
+    *    every host it talks to, which is a worse bug than the one being fixed. */
+   t = start_server();
+   set_identity_env(g_port + 1); /* deliberately NOT the port we are about to call */
+   agent_http_init();
+   status = post_once();
+   pthread_join(t, NULL);
+   close(g_listen_fd);
+   assert(status < 200 || status >= 300);
+   agent_http_cleanup();
+
+   printf("test_synthesis_mtls_client: ok\n");
+   return 0;
+}


### PR DESCRIPTION
## Synthesis from the kb could not work at all

Every curator call died in the TLS handshake. The deployment reported itself healthy throughout: deploy exits 0, kb healthy, sidecar healthy, `aimee kb smoke` green.

`agent_http` keeps **one** `SSL_CTX` — system trust store, no client certificate. That is correct for every public provider and wrong for exactly one peer: `aimee-llm`, whose certificate is issued by the kb's own CA and whose stunnel terminator sets `verifyChain = yes` and therefore **requires** a client certificate.

The deploy layer emits `SYNTHESIS_CA_FILE`, `SYNTHESIS_CERT_FILE`, `SYNTHESIS_KEY_FILE`; the managed compose hands all three to the kb container; **no line of code in the tree ever called `getenv` on any of them.**

From outside it looked like this:

```
kb_async_jobs: memory_facts | failed | attempts=3 | provider HTTP -1
kb  log: ERROR agent_http: TCP connect failed: aimee-llm:8761
llm log: SSL_accept: ... tlsv1 alert unknown ca: SSL alert number 48
```

The TCP connect had succeeded. OpenSSL knew the real cause the whole time; nothing asked it.

## The fix

A **second** context, not a relaxed first one. Loading our CA into the shared context would make a certificate the kb issued to itself acceptable for `api.anthropic.com`, and attaching the client certificate there would hand the kb's identity to every endpoint it talks to. The identity is bound to the exact `host:port` that `SYNTHESIS_ENDPOINT` names; everything else keeps the default context.

Plus: name the handshake when it fails, with the OpenSSL error.

## Why no test caught it

`scripts/test-synthesis-mtls-hop.sh` passed **9/9** against a deployment where this was completely broken. It drives `curl --cert --key` from inside the kb container — proving the *sidecar* accepts a correct client, never that the kb *is* one.

The new unit test drives `agent_http_post` itself against an OpenSSL server that demands a client certificate, using material from the same issuer used in production (`kb_synthesis_identity_ensure`), and asserts three things:

1. configured → the request **succeeds** (the bug: it did not)
2. not configured → it **fails** (or assertion 1 is vacuous)
3. endpoint names a different port → it **fails** (or the fix leaks the kb's identity to every host)

## Why lint didn't catch it either

`check-deploy-env-consumed` passed throughout: a `${SYNTHESIS_CA_FILE:-}` in a compose file matched its "is it consumed" regex. **Forwarding is not consumption.** It now requires a reader in something that *runs* — `getenv` in C, `$VAR` in a shell script — with image-selector variables recorded in `COMPOSE_ONLY_KEYS`, since those are genuinely Compose's business. Reverting the `getenv` calls makes it fail by name.

## Verification on CT 302 (published `:testing` images)

| | before | after |
|---|---|---|
| `memory_facts` job | 3 attempts, `provider HTTP -1`, failed | **done, first attempt** |
| kb log | `TCP connect failed` | `synthesis_mtls: client identity loaded for aimee-llm:8761` |
| sidecar log | `tlsv1 alert unknown ca` | real generation, 367 prompt / 418 generated tokens |