### PR TITLE
kb: load the synthesis identity on first use, not at startup

### DIFF
--- a/src/posix/agent_bridge.c
+++ b/src/posix/agent_bridge.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <pthread.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
@@ -45,6 +46,7 @@ static SSL_CTX *s_ssl_ctx;
 static SSL_CTX *s_synth_ssl_ctx;
 static char s_synth_host[256];
 static int s_synth_port;
+static pthread_mutex_t s_synth_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* Defined below parse_url, which it needs; the signature keeps parsed_url_t out of
  * the forward declaration. Called from agent_http_init, once, before any worker
@@ -166,25 +168,25 @@ static int parse_url(const char *url, parsed_url_t *out)
  * FAIL LOUD, NOT QUIET. If the files are named but unusable this logs an error and
  * leaves s_synth_ssl_ctx NULL, so the hop falls back to the default context and
  * fails the handshake -- the same outcome as before, but now with a line that says
- * which file could not be loaded instead of a bare "unknown ca" from OpenSSL. */
-static void synth_ssl_ctx_init(void)
+ * which file could not be loaded instead of a bare "unknown ca" from OpenSSL.
+ *
+ * THE FILES DO NOT EXIST YET AT INIT, which is why the load is deferred to the
+ * first request rather than done here. In the kb, agent_http_init() runs during
+ * startup and kb_synthesis_identity_ensure() mints this material LATER in the same
+ * startup -- 81 seconds later on a first boot of CT 302, because Postgres has to
+ * come up in between. Loading eagerly read three files that did not exist, left the
+ * context NULL, and disabled synthesis for the life of the process; it only looked
+ * right when the container was restarted with the material already on disk.
+ *
+ * So init records WHERE the sidecar is, and the first request to that host:port
+ * loads the material. By then the kb has issued it. */
+static void synth_ssl_ctx_load_locked(void)
 {
-   const char *endpoint = getenv("SYNTHESIS_ENDPOINT");
    const char *ca = getenv("SYNTHESIS_CA_FILE");
    const char *cert = getenv("SYNTHESIS_CERT_FILE");
    const char *key = getenv("SYNTHESIS_KEY_FILE");
-   if (!endpoint || !endpoint[0] || !ca || !ca[0] || !cert || !cert[0] || !key || !key[0])
+   if (!ca || !cert || !key)
       return;
-
-   parsed_url_t pu;
-   if (parse_url(endpoint, &pu) != 0 || !pu.use_ssl)
-   {
-      aimee_log(LOG_WARN, "synthesis_mtls",
-                "SYNTHESIS_ENDPOINT (%s) is not an https URL; the client identity in "
-                "SYNTHESIS_CERT_FILE will not be used",
-                endpoint);
-      return;
-   }
 
    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
    if (!ctx)
@@ -211,21 +213,58 @@ static void synth_ssl_ctx_init(void)
    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
 
    s_synth_ssl_ctx = ctx;
-   snprintf(s_synth_host, sizeof(s_synth_host), "%s", pu.host);
-   s_synth_port = pu.port;
    aimee_log(LOG_INFO, "synthesis_mtls", "client identity loaded for %s:%d", s_synth_host,
              s_synth_port);
 }
 
+/* Record which peer the identity is for. The material itself is loaded on first use
+ * (see synth_ssl_ctx_load_locked): at this point in startup it does not exist yet. */
+static void synth_ssl_ctx_init(void)
+{
+   const char *endpoint = getenv("SYNTHESIS_ENDPOINT");
+   const char *ca = getenv("SYNTHESIS_CA_FILE");
+   const char *cert = getenv("SYNTHESIS_CERT_FILE");
+   const char *key = getenv("SYNTHESIS_KEY_FILE");
+   if (!endpoint || !endpoint[0] || !ca || !ca[0] || !cert || !cert[0] || !key || !key[0])
+      return;
+
+   parsed_url_t pu;
+   if (parse_url(endpoint, &pu) != 0 || !pu.use_ssl)
+   {
+      aimee_log(LOG_WARN, "synthesis_mtls",
+                "SYNTHESIS_ENDPOINT (%s) is not an https URL; the client identity in "
+                "SYNTHESIS_CERT_FILE will not be used",
+                endpoint);
+      return;
+   }
+   snprintf(s_synth_host, sizeof(s_synth_host), "%s", pu.host);
+   s_synth_port = pu.port;
+}
+
 /* The sidecar identity is for the sidecar, and for nothing else. Host AND port must
  * both match what SYNTHESIS_ENDPOINT named: matching on host alone would present the
- * kb's client certificate to any other service that happens to share the name. */
+ * kb's client certificate to any other service that happens to share the name.
+ *
+ * The load happens here, once, under a lock: worker threads call this concurrently,
+ * and the curator runs several. A failed load is retried on the next request rather
+ * than latched -- the material appears partway through startup, so "not there yet"
+ * is a normal state to pass through, not a permanent verdict. */
 static SSL_CTX *ssl_ctx_for(const parsed_url_t *url)
 {
-   if (s_synth_ssl_ctx && s_synth_host[0] && url->port == s_synth_port &&
-       strcasecmp(url->host, s_synth_host) == 0)
-      return s_synth_ssl_ctx;
-   return s_ssl_ctx;
+   if (!s_synth_host[0] || url->port != s_synth_port ||
+       strcasecmp(url->host, s_synth_host) != 0)
+      return s_ssl_ctx;
+
+   pthread_mutex_lock(&s_synth_lock);
+   if (!s_synth_ssl_ctx)
+      synth_ssl_ctx_load_locked();
+   SSL_CTX *ctx = s_synth_ssl_ctx;
+   pthread_mutex_unlock(&s_synth_lock);
+
+   /* No context means the material is unreadable, and the error above says which
+    * file. Falling back to the default context here would present no certificate
+    * and fail the handshake anyway, so return it and let the TLS error stand. */
+   return ctx ? ctx : s_ssl_ctx;
 }
 
 /* ---- Socket I/O with timeout ---- */

--- a/src/posix/agent_bridge.c
+++ b/src/posix/agent_bridge.c
@@ -251,8 +251,7 @@ static void synth_ssl_ctx_init(void)
  * is a normal state to pass through, not a permanent verdict. */
 static SSL_CTX *ssl_ctx_for(const parsed_url_t *url)
 {
-   if (!s_synth_host[0] || url->port != s_synth_port ||
-       strcasecmp(url->host, s_synth_host) != 0)
+   if (!s_synth_host[0] || url->port != s_synth_port || strcasecmp(url->host, s_synth_host) != 0)
       return s_ssl_ctx;
 
    pthread_mutex_lock(&s_synth_lock);

--- a/src/tests/test_synthesis_mtls_client.c
+++ b/src/tests/test_synthesis_mtls_client.c
@@ -92,7 +92,9 @@ static void *server_thread(void *arg)
    return NULL;
 }
 
-static pthread_t start_server(void)
+/* Bind and pick the port WITHOUT serving yet: the ordering case below has to know
+ * the endpoint (and so the port) before any certificate exists. */
+static void bind_listener(void)
 {
    /* DUAL-STACK, and that is load-bearing. The client connects to the NAME
     * "localhost" -- it has to, because the server certificate's SAN is DNS:localhost
@@ -117,10 +119,19 @@ static pthread_t start_server(void)
    socklen_t len = sizeof(sa);
    assert(getsockname(g_listen_fd, (struct sockaddr *)&sa, &len) == 0);
    g_port = ntohs(sa.sin6_port);
+}
 
+static pthread_t spawn_server(void)
+{
    pthread_t t;
    assert(pthread_create(&t, NULL, server_thread, NULL) == 0);
    return t;
+}
+
+static pthread_t start_server(void)
+{
+   bind_listener();
+   return spawn_server();
 }
 
 static void set_identity_env(int port)
@@ -151,21 +162,32 @@ int main(void)
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-synth-mtls-%d", (int)getpid());
    assert(mkdir(g_home, 0700) == 0);
 
-   /* The SAME issuer the kb uses in production. A hand-rolled CA here could drift
-    * from what kb_synthesis_identity_ensure actually emits -- and the last two bugs
-    * on this hop were both about material, not about protocol. */
-   assert(kb_synthesis_identity_ensure(g_home, "localhost") == 0);
    snprintf(g_dir, sizeof(g_dir), "%s/synthesis-tls", g_home);
 
-   /* 1. The identity is configured: the request must get through. */
-   pthread_t t = start_server();
+   /* 1. THE MATERIAL APPEARS AFTER agent_http_init(), which is the deployment's
+    *    actual order and not a contrived one. In the kb, agent_http_init() runs
+    *    during startup and kb_synthesis_identity_ensure() mints these files later in
+    *    the same startup -- 81 seconds later on a first boot, with Postgres coming up
+    *    in between. An eager load read three absent files, gave up, and disabled
+    *    synthesis for the life of the process; it looked fine on every restart
+    *    afterwards, because by then the material was on disk.
+    *
+    *    So: configure the endpoint, initialise, and only THEN issue the identity. */
+   bind_listener();
    set_identity_env(g_port);
    agent_http_init();
+
+   /* The SAME issuer the kb uses in production. A hand-rolled CA here could drift
+    * from what kb_synthesis_identity_ensure actually emits -- and the bugs on this
+    * hop have all been about material and ordering, not about protocol. */
+   assert(kb_synthesis_identity_ensure(g_home, "localhost") == 0);
+
+   pthread_t t = spawn_server();
    int status = post_once();
    pthread_join(t, NULL);
    close(g_listen_fd);
    if (status != 200)
-      fprintf(stderr, "with the client identity configured, expected 200, got %d\n", status);
+      fprintf(stderr, "identity issued after init: expected 200, got %d\n", status);
    assert(status == 200);
    agent_http_cleanup();
 


### PR DESCRIPTION
Follow-up to #2274, which I verified on a **restarted** container — the one state where the bug it still had cannot show.

## What was still broken

`agent_http_init()` loaded the three identity files eagerly. In the kb it runs during startup, and `kb_synthesis_identity_ensure()` — which *creates* those files — runs later in the same startup, with Postgres coming up in between. On a first boot of CT 302 that gap was **81 seconds**:

```
22:42:24 ERROR synthesis_mtls: could not load the synthesis client identity
         (ca=... cert=... key=...): error:05880020:x509 ... BIO lib
22:43:45 INFO  kb_synthesis_identity: issued synthesis mTLS identities
```

The load failed, the context stayed NULL, and synthesis was disabled for the life of the process. Restarting the container fixed it — which is precisely how #2274's verification came to pass against a still-broken build.

The error line that exposed this is itself from #2274. The pre-#2274 code failed the same way, silently.

## The fix

Init records only which `host:port` the identity belongs to. The first request to that peer loads the material, under a mutex (several curator threads issue requests concurrently). A failed load is retried on the next request rather than latched — "not there yet" is a state startup passes through, not a verdict.

## The test now runs the real order

Configure the endpoint → `agent_http_init()` → **then** issue the identity. With the eager load restored it fails:

```
identity issued after init: expected 200, got -1
Assertion `status == 200' failed.
```

The previous version set the material up first, so it could not see this class of bug at all.