### PR TITLE
kb: count corpus vectors under the name they are actually written with

### DIFF
--- a/src/db2/kb_service_backend.c
+++ b/src/db2/kb_service_backend.c
@@ -700,7 +700,19 @@ int db2_kb_service_collect_project_status(const char *project, db2_kb_service_pr
                            "SELECT COUNT(*) FROM vector_index_ops q"
                            " JOIN kb_documents d ON d.id = q.point_id"
                            " JOIN projects p ON p.name=d.project"
-                           " WHERE (?1='' OR d.project=?1) AND q.collection = 'kb_chunks'"
+                           /* BOTH NAMES. The writer records general-corpus vectors under
+                            * 'kb_embeddings'; 'kb_chunks' is the older name and still
+                            * appears in existing stores, which is why
+                            * code_project_lifecycle.c matches the pair too. Matching only
+                            * the legacy name made this count ZERO on every current
+                            * deployment: `aimee kb health` reported embedding_count 0
+                            * beside pgvec_vectors 2, `aimee kb smoke` concluded
+                            * "0 embeddings; lexical search only" on a kb that was
+                            * embedding correctly, and hud.c warned forever because
+                            * embeddings < chunks*9/10 is always true at zero. Three
+                            * surfaces telling an operator the embedder was broken. */
+                           " WHERE (?1='' OR d.project=?1)"
+                           "   AND q.collection IN ('kb_chunks','kb_embeddings')"
                            "   AND p.lifecycle_state='current'"
                            "   AND d.generation=p.current_generation"
                            "   AND q.status = 'ok'",


### PR DESCRIPTION
Three surfaces told operators the embedder was broken while it was working correctly.

`db2_kb_service_collect_project_status` counted `vector_index_ops` rows `WHERE collection = 'kb_chunks'`. The writer records general-corpus vectors under **`kb_embeddings`**; `kb_chunks` is the older name — which is why `code_project_lifecycle.c` matches the *pair* rather than either alone. So this count was zero on every current deployment and stayed zero however much was indexed:

| surface | what it said |
|---|---|
| `aimee kb health` | `"pgvec_vectors":2 … "chunk_count":2 … "embedding_count":0` |
| `aimee kb smoke` | `SKIP  corpus is embedded — 0 embeddings; lexical search only` |
| `hud.c:68` | warns whenever `chunk_count > 0`, since `embeddings < chunk_count*9/10` is always true at zero |

The middle one is the expensive one: *"lexical search only"* is precisely what a broken embedder looks like — reported on a kb that had just embedded its corpus at the correct width. Chasing that sentence is how this was found.

## Verification

On CT 302 against the published `:testing` images, same corpus either side of the change:

| | `embedding_count` | `aimee kb smoke` |
|---|---|---|
| before | 0 | 4 passed, 1 skipped — "lexical search only" |
| after | 2 | **5 passed, 0 skipped** — "corpus is embedded" |

`pgvec_vectors` was 2 and `kb_embeddings` held 2 rows at dim 384 throughout, so only the reporting changed.