### PR TITLE
curator: raise the extract budget to 4096, the number the bench already found

### DIFF
--- a/src/modules/config/config_kb_curator.c
+++ b/src/modules/config/config_kb_curator.c
@@ -8,7 +8,7 @@
  *     extract_code:
  *       enabled: false
  *     extract_command: ""
- *     extract_max_tokens: 1024
+ *     extract_max_tokens: 4096
  *     max_attempts: 3
  */
 
@@ -86,23 +86,39 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_synthesize_k = 8;
    /* SIZED FOR A MODEL THAT THINKS BEFORE IT ANSWERS, which 512 was not.
     *
-    * 512 came from a 2-4 tokens/s bundled synth, chosen to stay inside the
-    * five-minute provider deadline. The bundled synth is now gemma-4 E2B/E4B, which
-    * emits a reasoning pass before any content: on the shipped extract prompt it
-    * spent ~290 tokens reasoning and then had the JSON envelope cut off mid-object
-    * at exactly 512. cJSON_Parse then failed, the job was marked
-    * "sidecar returned non-JSON", and it retried into permanent failure -- every
-    * extract_doc job, every time, on the default configuration.
+    * 512 came from a 2-4 tokens/s bundled synth with no reasoning pass, chosen to
+    * stay inside the five-minute provider deadline. The bundled synth is now gemma-4
+    * E2B/E4B, which reasons before emitting content: on the shipped extract prompt it
+    * spent ~290 tokens reasoning and then had the JSON envelope cut off mid-object at
+    * exactly 512. cJSON_Parse failed, the job was marked "sidecar returned non-JSON",
+    * and it retried into permanent failure -- every extract_doc job, every time, on
+    * the default configuration.
     *
-    * 1024 comes from measurement, not roundness: that prompt completes in 767
-    * tokens with finish_reason "stop" and parseable JSON, so this is the observed
-    * requirement plus a third again. The deadline still holds -- the sidecar runs
-    * 6-13 tokens/s with multi-token prediction, so 1024 tokens is 80-170s against a
-    * 300s budget, where 2048 would not have been safe at the low end.
+    * 4096 IS THE SAME NUMBER bench/tier-a ALREADY ARRIVED AT, and arriving at it a
+    * second time by a shorter route is the whole argument for the comment. Its
+    * Defect 16: run_b.py capped completions at 1024, "with thinking left on, models
+    * spend 400-1000 tokens reasoning before a short answer", gemma-4-12B truncated on
+    * one topic, scored zero, and the truncation was reported as a model finding. The
+    * fix there was a 4096 cap and a scorer that refuses to score a truncated row.
     *
-    * Turning synthesis_thinking off is the other half of the trade and belongs to
-    * the operator: the same extraction then finishes in ~94 tokens. */
-   cfg->kb_curator_extract_max_tokens = 1024;
+    * The measurement here, on the deployed E2B sidecar with thinking on: a
+    * one-sentence document needs 767 tokens, a single realistic paragraph needs 1087.
+    * A 1024 cap is therefore below what an ordinary document costs -- it is inside the
+    * band the log says reasoning ALONE occupies.
+    *
+    * THE CAP IS A CEILING, NOT AN EXPECTED COST, and the two ways of exceeding it are
+    * not equally bad. Truncating at the cap yields invalid JSON, which is permanent
+    * after max_attempts. Exceeding the 300s provider deadline is a transport error,
+    * which kb_curator_error_is_provider_unavailable treats as retryable with backoff.
+    * A generous cap degrades gracefully; a tight one fails for good. At the measured
+    * ~10 tokens/s a typical extraction is 118s, and only a document that reasoned past
+    * ~3000 tokens would reach the deadline at all.
+    *
+    * Do NOT "fix" the cost by turning synthesis_thinking off. That was measured too:
+    * bench/tier-a records disable_thinking costing E4B 0.09 F1 against a 0.582
+    * baseline, and its Defect 24 is a whole sweep that ran reasoning models with
+    * reasoning suppressed and wrongly concluded they were worse. */
+   cfg->kb_curator_extract_max_tokens = 4096;
    cfg->kb_curator_max_attempts = 3;
    cfg->kb_curator_provider_base_url[0] = '\0';
    cfg->kb_curator_provider_model[0] = '\0';
@@ -549,7 +565,7 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_projection_graph_enabled || cfg->kb_curator_synthesize_enabled ||
        cfg->kb_curator_promote_entity_enabled || cfg->kb_curator_extract_command[0] ||
        cfg->kb_curator_judge_command[0] || cfg->kb_curator_synthesize_command[0] ||
-       cfg->kb_curator_extract_max_tokens != 1024 || cfg->kb_curator_max_attempts != 3 ||
+       cfg->kb_curator_extract_max_tokens != 4096 || cfg->kb_curator_max_attempts != 3 ||
        cfg->kb_curator_synthesize_k != 8 || cfg->kb_curator_promote_min_sources != 3 ||
        cfg->kb_curator_provider_base_url[0] || cfg->kb_curator_provider_model[0];
    int cross_repo_nondefault =
@@ -672,7 +688,7 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
             cJSON_AddStringToObject(cur, "judge_command", cfg->kb_curator_judge_command);
          if (cfg->kb_curator_synthesize_command[0])
             cJSON_AddStringToObject(cur, "synthesize_command", cfg->kb_curator_synthesize_command);
-         if (cfg->kb_curator_extract_max_tokens != 1024)
+         if (cfg->kb_curator_extract_max_tokens != 4096)
             cJSON_AddNumberToObject(cur, "extract_max_tokens", cfg->kb_curator_extract_max_tokens);
          if (cfg->kb_curator_max_attempts != 3)
             cJSON_AddNumberToObject(cur, "max_attempts", cfg->kb_curator_max_attempts);

--- a/src/modules/kb-synthesis/kb_curator_drain.c
+++ b/src/modules/kb-synthesis/kb_curator_drain.c
@@ -860,8 +860,12 @@ static void *drain_thread_main(void *arg)
       memset(&opts, 0, sizeof(opts));
       snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
                config_kb_curator_extract_command());
-      opts.max_tokens =
-          config_kb_curator_extract_max_tokens() > 0 ? config_kb_curator_extract_max_tokens() : 512;
+      /* 4096, matching the config default: this fallback reintroduced the exact
+       * truncation bug it looks harmless next to -- 512 is below the tokens a
+       * reasoning model spends before it emits any content. */
+      opts.max_tokens = config_kb_curator_extract_max_tokens() > 0
+                            ? config_kb_curator_extract_max_tokens()
+                            : 4096;
       opts.max_attempts =
           config_kb_curator_max_attempts() > 0 ? config_kb_curator_max_attempts() : 3;
 
@@ -942,8 +946,12 @@ static void *kb_curator_code_worker_main(void *arg)
       memset(&opts, 0, sizeof(opts));
       snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
                config_kb_curator_extract_command());
-      opts.max_tokens =
-          config_kb_curator_extract_max_tokens() > 0 ? config_kb_curator_extract_max_tokens() : 512;
+      /* 4096, matching the config default: this fallback reintroduced the exact
+       * truncation bug it looks harmless next to -- 512 is below the tokens a
+       * reasoning model spends before it emits any content. */
+      opts.max_tokens = config_kb_curator_extract_max_tokens() > 0
+                            ? config_kb_curator_extract_max_tokens()
+                            : 4096;
       opts.max_attempts =
           config_kb_curator_max_attempts() > 0 ? config_kb_curator_max_attempts() : 3;
 
@@ -981,8 +989,12 @@ static void *kb_curator_doc_worker_main(void *arg)
       memset(&opts, 0, sizeof(opts));
       snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
                config_kb_curator_extract_command());
-      opts.max_tokens =
-          config_kb_curator_extract_max_tokens() > 0 ? config_kb_curator_extract_max_tokens() : 512;
+      /* 4096, matching the config default: this fallback reintroduced the exact
+       * truncation bug it looks harmless next to -- 512 is below the tokens a
+       * reasoning model spends before it emits any content. */
+      opts.max_tokens = config_kb_curator_extract_max_tokens() > 0
+                            ? config_kb_curator_extract_max_tokens()
+                            : 4096;
       opts.max_attempts =
           config_kb_curator_max_attempts() > 0 ? config_kb_curator_max_attempts() : 3;
 
@@ -1009,8 +1021,12 @@ static void *kb_curator_index_lane_main(void *arg)
       memset(&opts, 0, sizeof(opts));
       snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
                config_kb_curator_extract_command());
-      opts.max_tokens =
-          config_kb_curator_extract_max_tokens() > 0 ? config_kb_curator_extract_max_tokens() : 512;
+      /* 4096, matching the config default: this fallback reintroduced the exact
+       * truncation bug it looks harmless next to -- 512 is below the tokens a
+       * reasoning model spends before it emits any content. */
+      opts.max_tokens = config_kb_curator_extract_max_tokens() > 0
+                            ? config_kb_curator_extract_max_tokens()
+                            : 4096;
       opts.max_attempts =
           config_kb_curator_max_attempts() > 0 ? config_kb_curator_max_attempts() : 3;
 


### PR DESCRIPTION
The **1024** default I set in #2274 is below what an ordinary document costs, and I picked it from a single sample on a one-sentence input. Measured on the deployed E2B sidecar with thinking on:

| input | completion tokens |
|---|---:|
| one sentence | 767 |
| one realistic paragraph | **1087** ← over the cap |

So the first real document would have truncated mid-JSON and failed permanently — the same failure 512 produced, reached from a shorter distance.

## The bench already found this

`bench/tier-a` settled on **4096**. Its Defect 16:

> `run_b.py --max-tokens` defaulted to 1024 … with thinking left on, models spend 400-1000 tokens reasoning before a short answer, so `gemma-4-12B` truncated on one topic and scored zero on it … Fixed: cap is 4096

1024 sits *inside* the band that log says reasoning alone occupies.

## Why generous is the right direction

The cap is a ceiling, not an expected cost, and the two overruns are not equally bad:

- **truncate at the cap** → invalid JSON → permanent after `max_attempts`
- **exceed the 300s deadline** → transport error → already retryable via `kb_curator_error_is_provider_unavailable`

At the measured ~10 tok/s a typical extraction is 118s; only a document reasoning past ~3000 tokens reaches the deadline at all.

Also fixes the four `: 512` fallbacks in the drain, which would have reintroduced the original bug had the accessor returned 0.

## Correcting my own advice

I suggested `synthesis_thinking=false` as a speed trade. That was wrong and the comment now says so where the next person will look: `bench/tier-a` measured `disable_thinking` costing E4B **0.09 F1** against a 0.582 baseline, and its **Defect 24** is an entire sweep that ran reasoning models with reasoning suppressed and wrongly concluded they were worse. I had measured only tokens.

## Verification

CT 302, a full design document through `docs push` and all 14 pipeline stages: both `extract_doc` jobs **done on the first attempt**, with real output — 3 claims, 5 entities, 2 doc_summaries, 11 term_mappings.