### PR TITLE
curator: the provider deadline was shorter than an E4B extraction

### DIFF
--- a/src/modules/config/config_kb_curator.c
+++ b/src/modules/config/config_kb_curator.c
@@ -87,12 +87,12 @@ void config_kb_curator_defaults(config_t *cfg)
    /* SIZED FOR A MODEL THAT THINKS BEFORE IT ANSWERS, which 512 was not.
     *
     * 512 came from a 2-4 tokens/s bundled synth with no reasoning pass, chosen to
-    * stay inside the five-minute provider deadline. The bundled synth is now gemma-4
-    * E2B/E4B, which reasons before emitting content: on the shipped extract prompt it
-    * spent ~290 tokens reasoning and then had the JSON envelope cut off mid-object at
-    * exactly 512. cJSON_Parse failed, the job was marked "sidecar returned non-JSON",
-    * and it retried into permanent failure -- every extract_doc job, every time, on
-    * the default configuration.
+    * stay inside the provider deadline of the day, then five minutes -- see
+    * KB_CURATOR_PROVIDER_TIMEOUT_MS, which E4B's measured rate has since moved. The bundled synth
+    * is now gemma-4 E2B/E4B, which reasons before emitting content: on the shipped extract prompt
+    * it spent ~290 tokens reasoning and then had the JSON envelope cut off mid-object at exactly
+    * 512. cJSON_Parse failed, the job was marked "sidecar returned non-JSON", and it retried into
+    * permanent failure -- every extract_doc job, every time, on the default configuration.
     *
     * 4096 IS THE SAME NUMBER bench/tier-a ALREADY ARRIVED AT, and arriving at it a
     * second time by a shorter route is the whole argument for the comment. Its

--- a/src/modules/kb-synthesis/kb_curator_llm.c
+++ b/src/modules/kb-synthesis/kb_curator_llm.c
@@ -9,7 +9,35 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define KB_CURATOR_PROVIDER_TIMEOUT_MS 300000
+/* THE CEILING HAS TO CLEAR THE SLOWEST SIDECAR WE SHIP, and at 300000 it did not.
+ *
+ * The history below already records 120s being shorter than a normal extraction on
+ * the bundled CPU model. 300s is the same mistake one size up, and E4B is where it
+ * shows: measured on the deployed aimee-llm-e4b sidecar, one realistic document
+ * paragraph costs 1768 completion tokens at 4.98 tokens/s -- 375 seconds, with
+ * multi-token prediction already accepting 78% of drafts. Every non-trivial
+ * extraction on E4B was cut off by this deadline, retried, and failed for good,
+ * while E2B (1087 tokens at ~10 tokens/s, 118s) fit and looked fine.
+ *
+ * 600s, and the ceiling is set by the STALE-LEASE REAPER, not by the token budget.
+ * CE_STALE_LEASE / CCU_STALE_LEASE reclaim a job whose lease is older than 15
+ * minutes, so a deadline at or near 900s would let the reaper hand a still-running
+ * document to a second worker and pay for the same extraction twice. 600s sits
+ * clearly inside that window and clears the measured 375s by 60%.
+ *
+ * That leaves a gap worth naming: 4096 tokens at E4B's 4.98 tokens/s is ~825s, so a
+ * document that reasons all the way to the cap still exceeds this. That direction is
+ * survivable and the other is not -- a deadline overrun is a transport error, which
+ * kb_curator_error_is_provider_unavailable retries with backoff, while truncating at
+ * the token cap yields invalid JSON and fails permanently. Raising both the deadline
+ * and the lease windows together is the way to close it, and it needs the reaper
+ * thought about rather than a constant nudged.
+ *
+ * None of this lets a dead peer hold a worker for ten minutes. agent_http keeps
+ * SO_RCVTIMEO at min(timeout, 30s) per recv, so a peer that stops answering fails in
+ * 30s; this wall-clock ceiling only extends while tokens are still arriving -- that
+ * is, while the model is genuinely working. */
+#define KB_CURATOR_PROVIDER_TIMEOUT_MS 600000
 
 /* Build [{role:system, content:system_prompt}?, {role:user, content:request_json}]. */
 static cJSON *build_messages(const char *system_prompt, const char *request_json)
@@ -57,16 +85,17 @@ char *kb_curator_llm_run(kb_curator_stage_t stage, const char *system_prompt,
        * output budget (kb.curator.extract_max_tokens), and the legacy sidecar
        * receives it in each job payload.  Apply the same budget to the direct
        * provider path.  Without this, the managed gateway sends an unbounded
-       * generation to its single CPU synth slot: the curator times out after
-       * five minutes while llama-server keeps the slot occupied, starving
+       * generation to its single CPU synth slot: the curator times out at
+       * KB_CURATOR_PROVIDER_TIMEOUT_MS while llama-server keeps the slot occupied, starving
        * subsequent curator and interactive requests. */
       if (def->max_tokens <= 0 && config_kb_curator_extract_max_tokens() > 0)
          def->max_tokens = config_kb_curator_extract_max_tokens();
       /* Curator work is already retried by its durable job queue. Keep one
-       * provider attempt bounded by the same five-minute ceiling as the legacy
-       * sidecar instead of nesting the provider client's three retries. The old
-       * 120s default was shorter than a normal constrained extraction on the
-       * bundled CPU model and created overlapping abandoned generations. */
+       * provider attempt bounded by KB_CURATOR_PROVIDER_TIMEOUT_MS instead of
+       * nesting the provider client's three retries. The old 120s default was
+       * shorter than a normal constrained extraction on the bundled CPU model and
+       * created overlapping abandoned generations; see that constant for why 300s
+       * turned out to be the same mistake on E4B. */
       if (def->timeout_ms <= 0)
          def->timeout_ms = KB_CURATOR_PROVIDER_TIMEOUT_MS;
       if (def->max_attempts <= 0)

--- a/src/tests/test_kb_curator_llm.c
+++ b/src/tests/test_kb_curator_llm.c
@@ -81,7 +81,14 @@ static void test_provider_path(void)
    assert(resp != NULL);
    assert(strcmp(resp, "{\"synthesis\":\"ok\"}") == 0);
    assert(strcmp(g_seen_url, "http://big/v1/chat/completions") == 0);
-   assert(g_seen_timeout_ms == 300000);
+   /* The ceiling has to clear the SLOWEST sidecar we ship, and this assertion is
+    * what makes lowering it a deliberate act. It has been wrong twice: 120s was
+    * shorter than a normal constrained extraction, and 300s was shorter than an E4B
+    * one -- 1768 completion tokens at 4.98 tokens/s is 375s, measured on the
+    * deployed sidecar. See KB_CURATOR_PROVIDER_TIMEOUT_MS for why the value is 600s
+    * and not the ~825s the 4096-token budget would suggest (the 15-minute
+    * stale-lease reaper is the real ceiling). */
+   assert(g_seen_timeout_ms == 600000);
    assert(g_post_calls == 1);
    assert(!kb_curator_provider_backoff_active());
    /* system_prompt + request_json must reach the provider as message content. */


### PR DESCRIPTION
E4B synthesis could not complete a normal document. `KB_CURATOR_PROVIDER_TIMEOUT_MS` was 300s — below what the larger sidecar costs — so every non-trivial extraction was cut off mid-generation, retried, and failed for good. E2B fit inside it and looked fine, which is why this survived last night's validation.

Measured on the deployed sidecars, same prompt and same document paragraph, thinking on:

| sidecar | completion tokens | rate | wall | vs 300s |
|---|---:|---:|---:|---|
| E2B (Q4) | 1087 | ~10 tok/s | 118s | fits |
| **E4B (Q6)** | **1768** | **4.98 tok/s** | **375s** | **over** |

MTP is working on E4B — 1238/1593 drafts accepted (78%). 4.98 tok/s is what the larger model costs on CPU *with* that help.

This is the same mistake the existing comment already records one size down: 120s *"was shorter than a normal constrained extraction on the bundled CPU model"*.

## Why 600s and not the ~825s the budget implies

The binding constraint is the **stale-lease reaper**, not the token cap. `CE_STALE_LEASE` / `CCU_STALE_LEASE` reclaim a job whose lease is older than 15 minutes, so a deadline near 900s would let the reaper hand a still-running document to a second worker and pay for the same extraction twice. 600s sits clearly inside that window and clears the measured 375s by 60%.

The residual gap is named in the comment rather than papered over: a document that reasons all the way to the 4096 cap still exceeds 600s. That direction is survivable and the other is not — a deadline overrun is a transport error that `kb_curator_error_is_provider_unavailable` retries with backoff, while truncating at the token cap yields invalid JSON and fails permanently. Closing it properly means raising the deadline **and** the lease windows together, which needs the reaper thought about rather than a constant nudged.

## Not a worker-occupancy risk

`agent_http` keeps `SO_RCVTIMEO` at `min(timeout, 30s)` per recv, so a peer that stops answering fails in 30s. This wall-clock ceiling only extends while tokens are still arriving — i.e. while the model is genuinely working.