### PR TITLE
kb: the corpus pipeline reported no-ops as work

### DIFF
--- a/src/cmd_kb.c
+++ b/src/cmd_kb.c
@@ -715,6 +715,13 @@ static void kb_cmd_pipeline(app_ctx_t *ctx, int argc, char **argv)
    printf("Corpus pipeline: %s\n", cJSON_IsString(state) ? state->valuestring : "unknown");
    if (cJSON_IsNumber(processed))
       printf("  processed: %d\n", (int)processed->valuedouble);
+   /* Named "no-op" rather than "skipped" because that is what it means to the person
+    * reading it: the stage advanced and did nothing. Most of the 14 stages have no
+    * local handler, so a document can reach "complete" having only been classified,
+    * sectioned, term-normalised and gap-checked. */
+   int skipped = kb_cmd_json_int(resp, "skipped", 0);
+   printf("  no-op:     %d%s\n", skipped,
+          skipped > 0 ? "   (stages with no local handler; nothing was written)" : "");
    printf("  pending:   %d\n", kb_cmd_json_int(resp, "pending", 0));
    printf("  running:   %d\n", kb_cmd_json_int(resp, "running", 0));
    printf("  complete:  %d\n", kb_cmd_json_int(resp, "done", 0));

--- a/src/db2/corpus_jobs.c
+++ b/src/db2/corpus_jobs.c
@@ -383,6 +383,18 @@ int db2_corpus_pipeline_status(db2_corpus_pipeline_stats_t *out)
          out->complete += count;
    }
    aimee_pg_finalize(st);
+
+   /* Cumulative skipped transitions, from the event log rather than the job row:
+    * the job row only knows where a document got to, not how much of the journey
+    * was a no-op. See db2_corpus_pipeline_stats_t.skipped. */
+   st = aimee_pg_prepare(conn, "SELECT COUNT(*) FROM corpus_stage_events WHERE outcome = 'skipped'",
+                         err, sizeof(err));
+   if (st)
+   {
+      if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+         out->skipped = aimee_pg_column_int(st, 0);
+      aimee_pg_finalize(st);
+   }
    return 0;
 }
 
@@ -462,6 +474,7 @@ static int corpus_run_stage_handler(int64_t doc_id, const char *next_stage, char
 int db2_corpus_pipeline_drain(int limit, db2_corpus_pipeline_stats_t *out)
 {
    int processed = 0;
+   int skipped = 0;
    int max_steps = limit > 0 ? limit : 10000;
 
    while (processed < max_steps)
@@ -502,11 +515,19 @@ int db2_corpus_pipeline_drain(int limit, db2_corpus_pipeline_stats_t *out)
       if (db2_corpus_job_advance(doc_id, hrc > 0 ? "skipped" : "advanced", detail) != 0)
          return -1;
       processed++;
+      if (hrc > 0)
+         skipped++;
    }
 
    if (out && db2_corpus_pipeline_status(out) != 0)
       return -1;
    if (out)
+   {
       out->processed = processed;
+      /* This drain's own skips, which is what the caller asked about. The cumulative
+       * figure from db2_corpus_pipeline_status would answer a different question and
+       * would make a fresh drain of an already-skipped corpus look busy. */
+      out->skipped = skipped;
+   }
    return 0;
 }

--- a/src/db2/corpus_jobs.h
+++ b/src/db2/corpus_jobs.h
@@ -32,6 +32,22 @@ extern "C"
       int failed;
       int complete;
       int processed;
+      /* Stage transitions this corpus recorded as SKIPPED, cumulative.
+       *
+       * processed counts every step the drain took, and most steps take the
+       * "no local handler" path: of the 14 stages, only classified, sectioned,
+       * references_extracted, terms_normalized and gaps_detected do work. A drain
+       * that reported {processed: 14, failed: 0, state: complete} therefore looked
+       * like a fully processed document and was in fact eight no-ops -- including
+       * chunked, summarized, entities_extracted and claims_extracted, which is why
+       * a pushed document ends up with no chunks and no claims while its pipeline
+       * says complete.
+       *
+       * The information was already in corpus_stage_events.outcome. Nothing read it,
+       * which made an empty run indistinguishable from a real one -- the failure mode
+       * docs/BENCHMARKS.md names when it says a suite "must not report a pass from an
+       * empty run". */
+      int skipped;
    } db2_corpus_pipeline_stats_t;
 
    typedef struct

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -489,6 +489,11 @@ static void kb_http_corpus_pipeline_json(char *out_buf, int out_cap,
        stats->failed > 0 ? "failed" : (stats->pending + stats->running > 0 ? "active" : "idle"));
    if (stats->processed > 0)
       cJSON_AddNumberToObject(root, "processed", stats->processed);
+   /* ALWAYS emitted, including zero. "processed: 14, failed: 0" read as a fully
+    * processed document when eight of those fourteen transitions did nothing; an
+    * absent field would leave the same impression for anyone who did not know to
+    * look for it. See db2_corpus_pipeline_stats_t.skipped. */
+   cJSON_AddNumberToObject(root, "skipped", stats->skipped);
    cJSON_AddNumberToObject(root, "pending", stats->pending);
    cJSON_AddNumberToObject(root, "running", stats->running);
    cJSON_AddNumberToObject(root, "done", stats->complete);

--- a/src/tests/test_corpus_jobs.c
+++ b/src/tests/test_corpus_jobs.c
@@ -104,7 +104,21 @@ static void test_drain_advances_to_complete_with_events(void)
    assert(strcmp(job.stage, "complete") == 0);
    assert(strcmp(job.stage_status, "complete") == 0);
    assert(query_int("SELECT COUNT(*) FROM corpus_stage_events WHERE doc_id = 1") >= 14);
-   assert(query_int("SELECT COUNT(*) FROM corpus_stage_events WHERE outcome = 'skipped'") > 0);
+
+   /* THE SKIPS MUST BE REPORTED, not merely recorded. This assertion used to stop at
+    * the line below -- it knew most stages are no-ops and checked only that the event
+    * log said so, while the stats the API actually returns had no way to express it.
+    * {processed: 14, failed: 0, complete: 1} then read as a fully processed document
+    * that had in fact been chunked, summarized, entity- and claim-extracted by
+    * nobody. */
+   int logged_skips =
+       query_int("SELECT COUNT(*) FROM corpus_stage_events WHERE outcome = 'skipped'");
+   assert(logged_skips > 0);
+   assert(stats.skipped == logged_skips);
+   /* And the no-ops must outnumber the real work, because that is the current shape
+    * of the pipeline: five stages have a handler and the rest do not. If this ever
+    * flips, the comment above is stale and the reporting matters less. */
+   assert(stats.skipped > stats.processed - stats.skipped);
    assert(query_int("SELECT COUNT(*) FROM document_sections WHERE doc_id = 1") == 2);
    assert(query_int("SELECT COUNT(*) FROM document_references WHERE from_doc_id = 1") >= 1);
 


### PR DESCRIPTION
`POST /v1/corpus/pipeline/drain` answered `{processed: 14, failed: 0, done: 1}` for a document it had barely touched.

**Nine of those fourteen transitions took the "no local handler" path.** Of the pipeline's stages, only `classified`, `sectioned`, `references_extracted`, `terms_normalized` and `gaps_detected` do anything in this build. `chunked`, `summarized`, `entities_extracted`, `claims_extracted`, `relationships_mapped` and `conflicts_detected` advance and write nothing:

```
 doc_id |      from_stage      |       to_stage       | outcome  |     detail
      1 | terms_normalized     | summarized           | skipped  | no local handler
      1 | summarized           | questions_generated  | skipped  | no local handler
      1 | questions_generated  | entities_extracted   | skipped  | no local handler
      1 | entities_extracted   | claims_extracted     | skipped  | no local handler
```

So a pushed document reaches stage `complete` with no chunks, no summary, no claims and no entities, and the API's answer is indistinguishable from a document that was fully processed. **I read that response myself earlier in this session and concluded "the pipeline is fine, it just needs driving"** (#2275). It is not fine — driving it produces five stages of work out of fourteen.

## The information was already there

`db2_corpus_job_advance` has recorded `outcome='skipped'` in `corpus_stage_events` since it was written, and nothing read it. That is the failure `docs/BENCHMARKS.md` names in another context: a run *"must not report a pass from an empty run"*.

| surface | now reports |
|---|---|
| `drain` | **this** drain's skips, so re-draining an already-skipped corpus doesn't look busy |
| `status` | the cumulative count from the event log — how much of this corpus was no-op'd |
| CLI | `no-op:  9   (stages with no local handler; nothing was written)` |

Emitted even when zero: an absent field leaves exactly the impression the missing number left before.

## The test knew

`test_drain_advances_to_complete_with_events` already asserted `corpus_stage_events` contained skipped rows — then asserted nothing about whether the *caller* could see them. It now requires `stats.skipped` to equal the logged count, and requires the no-ops to outnumber the real work since that is the pipeline's current shape. Zeroing the field fails it.

## Verification

CT 302, freshly pushed document:

```
{"state":"idle","processed":14,"skipped":9,"pending":0,"done":2,"failed":0,...}
 outcome  | count
 advanced |    10
 skipped  |    18
```

**This does not implement the missing stages** — that is the open question in #2275, and it is a product decision about how much the stage should do. It stops the pipeline claiming it did.