### PR TITLE
workspace add: let registration return without walking the tree

### DIFF
--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -454,12 +454,24 @@ static cJSON *marshal_workspace_add(int argc, char **argv)
    if (!req)
       return NULL;
    rpc_opts_t opts;
-   rpc_parse(argc, argv, NULL, &opts);
+   /* --no-scan takes no value, so it must be declared boolean: rpc_parse would
+    * otherwise treat the following argument as its value, and swallow the flag
+    * entirely when it is last. */
+   static const char *ws_bool_flags[] = {"no-scan", NULL};
+   rpc_parse(argc, argv, ws_bool_flags, &opts);
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "root", opts.positional[0]);
    const char *prov = rpc_get(&opts, "provider");
    if (prov)
       cJSON_AddStringToObject(req, "provider", prov);
+   /* --no-scan registers the workspace and returns instead of walking every
+    * discovered project first. On a large tree the eager scan makes this RPC
+    * take minutes, so a caller with a timeout abandons a registration that
+    * already succeeded; the background ingest timer indexes them regardless.
+    * Omitted (not sent as true) by default, so an older server sees exactly the
+    * body it saw before. */
+   if (rpc_has_flag(&opts, "no-scan"))
+      cJSON_AddBoolToObject(req, "scan", 0);
    return req;
 }
 

--- a/src/server/server_runner_endpoints.c
+++ b/src/server/server_runner_endpoints.c
@@ -199,8 +199,18 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
     * background ingest timer reconciles the workspace registry and indexes every
     * discovered project on its own. We only kick an eager scan here when kb is
     * already live, so a down kb never blocks this RPC on a 15s autostart — the
-    * background worker picks the projects up once the service is available. */
-   int kb_live = kb_client_is_live();
+    * background worker picks the projects up once the service is available.
+    *
+    * The eager scan is a convenience, and on a large tree it is an expensive one:
+    * it walks every discovered project before this RPC answers, so registering a
+    * 4,000-file repository takes minutes and a caller with a timeout gives up on
+    * a registration that already succeeded. `scan: false` registers and returns,
+    * leaving the projects to the background ingest timer that would have
+    * reconciled them anyway. Default stays true: an interactive
+    * `aimee workspace add` should still say whether the index is populated. */
+   const cJSON *scan_req = cJSON_GetObjectItemCaseSensitive(req, "scan");
+   int eager_scan = cJSON_IsBool(scan_req) ? cJSON_IsTrue(scan_req) : 1;
+   int kb_live = eager_scan && kb_client_is_live();
    cJSON *resp = jo_ok();
    jo_add_str(resp, "path", abs);
    cJSON *arr = cJSON_AddArrayToObject(resp, "projects");
@@ -216,7 +226,12 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       if (!kb_live)
       {
          cJSON_AddBoolToObject(p, "indexed", 0);
-         jo_add_str(p, "reason", "knowledge service offline — queued for background ingest");
+         /* Say which of the two it was. Reporting "knowledge service offline"
+          * for a scan the caller asked us to skip would be a false diagnosis of
+          * a healthy kb. */
+         jo_add_str(p, "reason",
+                    eager_scan ? "knowledge service offline — queued for background ingest"
+                               : "scan not requested — queued for background ingest");
          cJSON_AddItemToArray(arr, p);
          continue;
       }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1189,6 +1189,17 @@ $(TESTPREFIX)/unit-test-cli-v1-delegate: $(OBJDIR)/tests/test_cli_v1_delegate.o 
                                   $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/platform_path.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
+# The test INCLUDES cli_v1_routes_b.c to reach a static marshaller, so that
+# object must not also be linked here or every symbol in it is duplicate.
+TEST_TARGETS += $(TESTPREFIX)/unit-test-workspace-add-noscan
+$(TESTPREFIX)/unit-test-workspace-add-noscan: $(OBJDIR)/tests/test_workspace_add_noscan.o \
+                                  $(OBJDIR)/cli_v1_routes.o \
+                                  $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o \
+                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+                                  $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
 $(TESTPREFIX)/unit-test-cli-v1-subcommands: $(OBJDIR)/tests/test_cli_v1_subcommands.o \
                                   $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o \
                                   $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o \

--- a/src/tests/test_workspace_add_noscan.c
+++ b/src/tests/test_workspace_add_noscan.c
@@ -1,0 +1,93 @@
+/* `aimee workspace add --no-scan` must register without walking the tree.
+ *
+ * workspace.add registers the workspace and then, when kb is live, eagerly scans
+ * every discovered project before answering. On a 4,000-file repository that
+ * turns a registration RPC into a multi-minute one: a caller with a timeout
+ * abandons a registration that had already succeeded, and the projects it was
+ * waiting on get indexed by the background ingest timer regardless.
+ *
+ * Observed on a benchmark host with load ~4 (i.e. not contention): three cells
+ * lost to `aimee workspace add` exceeding a 180s client timeout.
+ *
+ * The flag has to reach the server as a request field, so this pins the
+ * marshalling: --no-scan sets scan:false, and its absence sends nothing at all
+ * (so an older server, which ignores the unknown field, keeps today's
+ * behaviour). */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "cJSON.h"
+
+/* The marshaller is static; the suite's convention for those is to include the
+ * translation unit (see test_anthropic_http.c and friends). */
+#include "../cli_v1_routes_b.c"
+
+static cJSON *marshal(int argc, char **argv)
+{
+   cJSON *req = marshal_workspace_add(argc, argv);
+   assert(req != NULL);
+   return req;
+}
+
+static void test_no_scan_sets_scan_false(void)
+{
+   char *argv[] = {"/srv/repo", "--no-scan"};
+   cJSON *req = marshal(2, argv);
+
+   const cJSON *scan = cJSON_GetObjectItemCaseSensitive(req, "scan");
+   assert(cJSON_IsBool(scan));
+   assert(cJSON_IsFalse(scan));
+
+   /* The root must still be carried: skipping the scan is not skipping the
+    * registration. */
+   const cJSON *root = cJSON_GetObjectItemCaseSensitive(req, "root");
+   assert(cJSON_IsString(root));
+   assert(strcmp(root->valuestring, "/srv/repo") == 0);
+
+   cJSON_Delete(req);
+   printf("  --no-scan sets scan:false and keeps root\n");
+}
+
+static void test_default_sends_no_scan_field(void)
+{
+   char *argv[] = {"/srv/repo"};
+   cJSON *req = marshal(1, argv);
+
+   /* Absent, not `true`: an older server that does not know the field must see
+    * exactly the body it saw before, and keep scanning eagerly. */
+   assert(cJSON_GetObjectItemCaseSensitive(req, "scan") == NULL);
+
+   const cJSON *root = cJSON_GetObjectItemCaseSensitive(req, "root");
+   assert(cJSON_IsString(root));
+   assert(strcmp(root->valuestring, "/srv/repo") == 0);
+
+   cJSON_Delete(req);
+   printf("  default omits the field (unchanged wire body)\n");
+}
+
+static void test_no_scan_composes_with_provider(void)
+{
+   char *argv[] = {"/srv/repo", "--provider", "git", "--no-scan"};
+   cJSON *req = marshal(4, argv);
+
+   const cJSON *scan = cJSON_GetObjectItemCaseSensitive(req, "scan");
+   assert(cJSON_IsBool(scan) && cJSON_IsFalse(scan));
+   const cJSON *prov = cJSON_GetObjectItemCaseSensitive(req, "provider");
+   assert(cJSON_IsString(prov));
+   assert(strcmp(prov->valuestring, "git") == 0);
+
+   cJSON_Delete(req);
+   printf("  --no-scan composes with --provider\n");
+}
+
+int main(void)
+{
+   printf("workspace add --no-scan:\n");
+   test_no_scan_sets_scan_false();
+   test_default_sends_no_scan_field();
+   test_no_scan_composes_with_provider();
+   printf("workspace add --no-scan: OK\n");
+   return 0;
+}


### PR DESCRIPTION
`workspace.add` registers the workspace and then, when kb is live, eagerly scans
every discovered project **before it answers**. The comment directly above that
scan already says registration is all that is strictly required, and that
aimee-kb's background ingest timer reconciles the registry on its own.

On a large tree the convenience is expensive: registering a 4,000-file repository
takes minutes, so a caller with a timeout abandons a registration that had
already succeeded.

Observed on an otherwise idle host — load ~4, so not contention — five benchmark
runs lost to `aimee workspace add` exceeding a 180s client timeout, on workspaces
that were in fact registered.

### The change

`--no-scan` sets `scan: false` on the request. The server then skips the eager
scan and reports each project as queued for background ingest — which is what the
ingest timer was going to do anyway.

Default is unchanged, and the field is **omitted** rather than sent as `true`, so
an older server receives exactly the body it received before and keeps scanning
eagerly. An interactive `aimee workspace add` still tells you whether the index
is populated.

### Two details worth naming

**The queued reason distinguishes the two cases.** The existing not-indexed path
reports "knowledge service offline — queued for background ingest". Reusing that
for a scan the caller asked us to skip would be a false diagnosis of a healthy
kb, so `--no-scan` reports "scan not requested — queued for background ingest".

**`--no-scan` is declared boolean.** `rpc_parse` treats an undeclared flag as
taking a value, so the first cut consumed the following argument as the flag's
value and swallowed the flag entirely when it came last. That is exactly how it
failed its own test before the fix — the test is in the PR because it caught a
real mistake, not to decorate one.

### Testing

`unit-test-workspace-add-noscan` covers the marshalling contract: `--no-scan`
sets `scan:false` and still carries `root`; the default omits the field entirely;
and the flag composes with `--provider`. Red before green, verified by reverting
the marshaller and watching the first assertion fail.

`make lint` — all 41 checks pass. `unit-test-server-dispatch` passes.

The test includes `cli_v1_routes_b.c` to reach a static marshaller, following the
existing convention in this suite, so its link rule deliberately omits
`cli_v1_routes_b.o`.
