### PR TITLE
embedder: two sidecar images, over mTLS, proven on real containers

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -86,6 +86,11 @@ jobs:
         # function that only ever runs where a failure costs a whole image build.
       - name: Test Dockerfile hub-fetch retry
         run: python3 -I scripts/tests/test_dockerfile_hub_retry.py
+        # The embedder sidecar's bake: its retry, its refusal of an unknown model, and
+        # the auto_map follow that stops a trust_remote_code model reaching the Hub at
+        # first use. No network, and it guards code that only runs inside an image build.
+      - name: Test embedder bake script
+        run: python3 -I scripts/tests/test_bake_embedder.py
       - name: Enforce individual module documentation
         run: python3 -I -S scripts/check_module_docs.py
       - name: Test module-documentation failure modes

--- a/.github/workflows/publish-embedder.yml
+++ b/.github/workflows/publish-embedder.yml
@@ -1,0 +1,187 @@
+# Publish the aimee-embedder sidecars.
+#
+# TWO IMAGES, ONE MODEL EACH. There is no third image for "no embedder" -- that
+# deployment runs no embedder container and the server points EMBEDDER_URL at whatever
+# the operator provides. An image whose purpose is to not be used would be a tag to
+# maintain, a build to pay for, and a thing to get wrong.
+#
+# THIS MUST NOT REBUILD BECAUSE KB CODE CHANGED, which is the whole reason the embedder
+# left the kb image. Baked in, it put CPU torch and a gigabyte of weights into every kb
+# tag -- including the ones deployed against an external embedder -- and, worse, sat
+# behind the compiled binary in the layer order, so every C change re-downloaded the
+# weights. Four fetches per publish, and Hugging Face answered 429.
+#
+# The guarantee is enforced twice, exactly as publish-llm.yml does it, because a path
+# filter is one careless edit away from being wrong:
+#
+#   1. A narrow trigger: only the files that determine these images.
+#   2. A skip-if-already-published check keyed on a hash of those same files, so even a
+#      broad or accidental trigger costs one `docker manifest inspect` and stops.
+#
+# (2) is what makes it robust rather than aspirational: correctness does not depend on
+# the path list staying right.
+name: Publish aimee-embedder
+
+on:
+  push:
+    branches: [testing]
+    paths:
+      - "Dockerfile.embedder"
+      - "deploy/container/aimee-embedder-entrypoint.sh"
+      - "scripts/bake-embedder.py"
+      - "scripts/embedder-server.py"
+      - "scripts/embedders.json"
+      - ".github/workflows/publish-embedder.yml"
+  # DELIBERATELY NARROWER THAN THE PUSH TRIGGER: no workflow file here. A PR build never
+  # pushes, so the skip check cannot engage on one -- the tag it looks for only appears
+  # at merge -- and every triggered PR therefore pays a full build. Editing this workflow
+  # is not a change to the image, so it must not cost two of them.
+  pull_request:
+    paths:
+      - "Dockerfile.embedder"
+      - "deploy/container/aimee-embedder-entrypoint.sh"
+      - "scripts/bake-embedder.py"
+      - "scripts/embedder-server.py"
+      - "scripts/embedders.json"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Rebuild even when the tag already exists'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-embedder-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: aimee-embedder-a25m, model: bekko-a25m }
+          - { name: aimee-embedder-nomic, model: nomic-embed-text-v2-moe }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize owner to lowercase
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The immutable tag must name EVERY input that changes the artefact, or the skip
+      # becomes a trap. Keyed on the model name alone, a change to Dockerfile.embedder,
+      # the entrypoint, the bake script or the registry would find the tag published,
+      # skip the build, and leave :testing on the old image while the run reported
+      # success. publish-llm.yml records that this is exactly how the mTLS fix in the
+      # synthesis sidecar would have failed to ship.
+      #
+      # So the sources are hashed into the tag: content-addressed, rebuilding exactly
+      # when something that lands in the image changed and never otherwise. The
+      # registry revision is included because it carries the pooling, prefixes and
+      # dim -- a prefix change rewrites every vector while leaving the model name and
+      # the width alone, which is the drift embedder-server.py's serving_id exists to
+      # make detectable.
+      - name: Has this exact build already been published?
+        id: have
+        env:
+          FORCE: ${{ inputs.force }}
+        run: |
+          rev=$(cat Dockerfile.embedder \
+                    deploy/container/aimee-embedder-entrypoint.sh \
+                    scripts/bake-embedder.py \
+                    scripts/embedder-server.py \
+                    scripts/embedders.json | sha256sum | cut -c1-12)
+          pinned="ghcr.io/${OWNER}/${{ matrix.name }}:${rev}"
+          echo "embedder sources hash to $rev"
+          echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
+          if [ "${FORCE:-false}" = "true" ]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "forced rebuild requested; ignoring any published $pinned"
+            exit 0
+          fi
+          if docker manifest inspect "$pinned" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "$pinned already published; nothing to build"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.have.outputs.exists != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # A PULL REQUEST BUILDS BUT NEVER PUSHES: publishing is a merge-time act. The PR
+      # still proves the image builds AND that its model loads offline at the declared
+      # width, because Dockerfile.embedder asserts both in its final stage -- so a
+      # weightless or mis-sized image fails here rather than at first search.
+      - name: Build ${{ matrix.name }}
+        if: steps.have.outputs.exists != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.embedder
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          provenance: false
+          cache-from: type=gha,scope=${{ matrix.name }}-amd64
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}-amd64
+          build-args: |
+            AIMEE_EMBEDDER=${{ matrix.model }}
+          tags: |
+            ${{ steps.have.outputs.pinned }}
+            ghcr.io/${{ env.OWNER }}/${{ matrix.name }}:testing
+
+      # The hop test on the image that was just built. It mints its own CA, so it needs
+      # no kb: it proves the sidecar refuses to start without an identity, requires a
+      # client certificate, and actually embeds at the width the registry declares.
+      #
+      # On a pull request the image is loaded locally rather than pushed, so this runs
+      # against the local tag; on a push the same digest has just been published.
+      - name: Load ${{ matrix.name }} locally for the hop test
+        if: steps.have.outputs.exists != 'true' && github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.embedder
+          platforms: linux/amd64
+          load: true
+          provenance: false
+          cache-from: type=gha,scope=${{ matrix.name }}-amd64
+          build-args: |
+            AIMEE_EMBEDDER=${{ matrix.model }}
+          tags: ${{ matrix.name }}:cihop
+
+      - name: mTLS hop test
+        if: steps.have.outputs.exists != 'true'
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            img="${{ matrix.name }}:cihop"
+          else
+            img="${{ steps.have.outputs.pinned }}"
+            docker pull -q "$img"
+          fi
+          dim=$(python3 -c "import json;print(json.load(open('scripts/embedders.json'))['embedders']['${{ matrix.model }}']['dim'])")
+          bash scripts/test-embedder-mtls-hop.sh "$img" "$dim"
+
+      - name: Report
+        run: |
+          if [ "${{ steps.have.outputs.exists }}" = "true" ]; then
+            echo "skipped: ${{ steps.have.outputs.pinned }} already published"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "built ${{ matrix.name }} (pull request: not pushed)"
+          else
+            echo "published ${{ steps.have.outputs.pinned }} and :testing"
+          fi

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -1,0 +1,137 @@
+# aimee-embedder: the bundled embedder, as its own image.
+#
+# TWO TAGS, ONE MODEL EACH: aimee-embedder-a25m and aimee-embedder-nomic. There is no
+# third tag for "no embedder" -- the absence of this container IS that case, and the
+# server resolves it by pointing EMBEDDER_URL at whatever the operator runs. A tag
+# carrying no model would be an image whose only purpose is to not be used.
+#
+# WHY THIS LEFT aimee-kb. It was baked in, which put CPU torch, sentence-transformers
+# and a gigabyte of weights into every kb image -- including the ones deployed against
+# an external embedder, which load none of it. Worse for CI: the weights were fetched
+# inside the kb build, behind the compiled binary, so every C change invalidated that
+# layer and re-downloaded them. Four fetches per publish, and Hugging Face answered
+# 429.
+#
+# The kb image now carries no model and no torch, and this tag's inputs -- the model,
+# the registry entry, the venv -- change on the order of never.
+#
+# THE EMBEDDER IS STILL A PROPERTY OF THE INSTALL, not a layer to swap under a running
+# one. Switching it means dropping the embedded corpus and rebuilding: a 384-wide store
+# cannot be read by a 768-wide embedder, and scripts/embedder-server.py's serving_id
+# additionally makes a pooling or prefix change detectable when the width and the model
+# name both stay the same. Splitting the image does not soften that; it only stops the
+# weights being rebuilt alongside unrelated code.
+ARG AIMEE_EMBEDDER=bekko-a25m
+
+# ---- the weights ----------------------------------------------------------------
+# BUILDPLATFORM-pinned: the payload is architecture-independent, so a
+# linux/amd64 + linux/arm64 build fetches ONCE and both manifests reference the same
+# layer, rather than downloading the same gigabytes twice to produce identical bytes.
+# Same reasoning as Dockerfile.model.
+FROM --platform=$BUILDPLATFORM debian:trixie-slim AS weights
+ARG AIMEE_EMBEDDER
+ENV EMBEDDER_VENV=/opt/aimee/embedder-venv
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# CPU-only torch: the CUDA wheels are ~2GB of accelerator runtime this image never uses.
+RUN set -eux; \
+    python3 -m venv "$EMBEDDER_VENV"; \
+    "$EMBEDDER_VENV/bin/pip" install --no-cache-dir --quiet \
+        --index-url https://download.pytorch.org/whl/cpu torch; \
+    "$EMBEDDER_VENV/bin/pip" install --no-cache-dir --quiet \
+        "sentence-transformers>=3.3" "transformers>=5.2" einops; \
+    find "$EMBEDDER_VENV" -name '__pycache__' -type d -prune -exec rm -rf {} +; \
+    rm -rf /root/.cache/pip
+
+COPY scripts/embedders.json /opt/aimee/embedders.json
+COPY scripts/bake-embedder.py /usr/local/bin/bake-embedder.py
+ENV HF_HOME=/opt/aimee/models
+# The fetch retries, because the Hub rate-limits: several variants build in parallel
+# and each wants the same files. Retried statuses only -- a bad revision fails on the
+# first attempt. See scripts/bake-embedder.py.
+RUN --mount=type=cache,target=/root/.cache/huggingface \
+    AIMEE_EMBEDDER="$AIMEE_EMBEDDER" "$EMBEDDER_VENV/bin/python" \
+        /usr/local/bin/bake-embedder.py
+# The bake runs as root and huggingface_hub writes its tree-cache metadata 0600, so a
+# non-root runtime user cannot read it; the weights themselves land world-readable, so
+# the model still loads and merely logs a corrupt-tree-cache warning on every start.
+# a+rX: readable everywhere, traversable on directories, no file gains +x.
+RUN chmod -R a+rX /opt/aimee/models
+
+# ---- runtime --------------------------------------------------------------------
+FROM debian:trixie-slim
+ARG AIMEE_EMBEDDER
+
+# stunnel terminates mTLS in front of the embedder, exactly as it does for aimee-llm.
+# It is a distro package rather than code this project owns, deliberately: termination
+# is security-critical, its failure mode is silent exposure, and a hand-rolled TLS
+# listener would take on a vendoring burden for no gain.
+#
+# curl is the healthcheck client. python3 runs the server; the venv carries torch.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl libgomp1 python3 stunnel4 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV EMBEDDER_VENV=/opt/aimee/embedder-venv \
+    HF_HOME=/opt/aimee/models \
+    HF_HUB_OFFLINE=1 \
+    EMBEDDERS_FILE=/opt/aimee/embedders.json \
+    AIMEE_EMBEDDER_PORT=8762 \
+    AIMEE_EMBEDDER_LOOPBACK_PORT=8760
+COPY --from=weights /opt/aimee/embedder-venv /opt/aimee/embedder-venv
+COPY --from=weights /opt/aimee/models /opt/aimee/models
+COPY --from=weights /opt/aimee/embedders.json /opt/aimee/embedders.json
+COPY scripts/embedder-server.py /opt/aimee/scripts/embedder-server.py
+COPY deploy/container/aimee-embedder-entrypoint.sh /usr/local/bin/aimee-embedder-entrypoint.sh
+RUN chmod +x /usr/local/bin/aimee-embedder-entrypoint.sh
+
+# trust_remote_code compiles fetched modelling code into a writable module cache, which
+# defaults inside HF_HOME and is read-only here. nomic needs it; point it at a writable
+# path or the model fails to load with "Permission denied: /opt/aimee/models/modules".
+ENV HF_MODULES_CACHE=/var/lib/aimee-embedder/.cache/huggingface/modules
+RUN useradd --system --home-dir /var/lib/aimee-embedder --create-home \
+        --shell /usr/sbin/nologin aimee \
+    && install -d -o aimee -g aimee -m 0700 /var/lib/aimee-embedder/tls \
+    && install -d -o aimee -g aimee -m 0700 "$HF_MODULES_CACHE"
+
+# Prove the model is present and loadable IN THIS IMAGE. A server that cannot find its
+# weights otherwise fails at first embed, which reaches the operator as a retrieval
+# outage rather than a build error -- the same reason Dockerfile.llm asserts its blobs.
+ENV AIMEE_EMBEDDER=${AIMEE_EMBEDDER}
+RUN set -eux; \
+    test -d /opt/aimee/models; \
+    EMBEDDER_MODEL="$AIMEE_EMBEDDER" "$EMBEDDER_VENV/bin/python" - <<'PYCHECK'
+import json, os, sys
+sel = os.environ["EMBEDDER_MODEL"]
+with open("/opt/aimee/embedders.json", encoding="utf-8") as fh:
+    table = json.load(fh)["embedders"]
+if sel not in table:
+    sys.exit(f"AIMEE_EMBEDDER={sel!r} is not in the registry: {sorted(table)}")
+# Load offline from the baked cache. This is the assertion: it fails the build if the
+# weights are absent, incomplete, or need the network.
+os.environ["HF_HUB_OFFLINE"] = "1"
+from sentence_transformers import SentenceTransformer
+spec = table[sel]
+m = SentenceTransformer(spec["repo"], revision=spec.get("revision") or "main",
+                        trust_remote_code=True)
+dim = m.get_sentence_embedding_dimension()
+if dim != spec["dim"]:
+    sys.exit(f"{sel}: registry says dim={spec['dim']}, model serves {dim}")
+print(f"baked {sel}: {spec['repo']} dim={dim}", flush=True)
+PYCHECK
+
+USER aimee
+EXPOSE 8762
+
+# READY MEANS THE MODEL CAN EMBED, not that the port is open. embedder-server.py binds
+# immediately and loads in a background thread, answering /health with its state and
+# 200 only when "ok" -- so probing loopback is what distinguishes "listening" from
+# "usable". start_period covers the load, which for nomic is the slow part.
+HEALTHCHECK --interval=15s --timeout=5s --start-period=300s --retries=3 \
+    CMD curl -fsS -m 4 "http://127.0.0.1:${AIMEE_EMBEDDER_LOOPBACK_PORT}/health" || exit 1
+
+ENTRYPOINT ["/usr/local/bin/aimee-embedder-entrypoint.sh"]

--- a/deploy/container/aimee-embedder-entrypoint.sh
+++ b/deploy/container/aimee-embedder-entrypoint.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# aimee-embedder-entrypoint.sh: the embedder on loopback, mTLS on the network interface.
+#
+# THE SHAPE, and it is deliberately the same as aimee-llm's:
+#
+#   network :8762  ->  stunnel (verifies the client certificate)  ->  127.0.0.1:8760
+#
+# embedder-server.py never binds a network interface. Loopback inside this container's
+# own namespace is unreachable from any other container, so the terminator is the only
+# path in -- and the server has no authentication of its own, so that is not defence in
+# depth, it is the whole of it.
+#
+# THIS CONTAINER DOES NOT MINT ITS OWN IDENTITY. The kb owns the CA and the kb is the
+# client on this hop, so the kb issues this server's certificate. Deployment order
+# guarantees the material exists before this starts: server, wizard, kb, then the
+# sidecars. A missing identity is a real error and is reported as one rather than waited
+# out -- a half-started sidecar is worse than a stopped one, because the kb then either
+# reaches an unterminated port or hangs against a terminator with nothing behind it, and
+# both look like "embedding is slow".
+set -eu
+
+IDENTITY_DIR="${AIMEE_EMBEDDER_IDENTITY_DIR:-/var/lib/aimee-embedder/tls}"
+CA_FILE="${AIMEE_EMBEDDER_CA_FILE:-$IDENTITY_DIR/ca.pem}"
+CERT_FILE="${AIMEE_EMBEDDER_CERT_FILE:-$IDENTITY_DIR/server.pem}"
+KEY_FILE="${AIMEE_EMBEDDER_KEY_FILE:-$IDENTITY_DIR/server.key}"
+: "${AIMEE_EMBEDDER_PORT:=8762}"
+: "${AIMEE_EMBEDDER_LOOPBACK_PORT:=8760}"
+
+PY="${EMBEDDER_VENV:-/opt/aimee/embedder-venv}/bin/python"
+SERVER=/opt/aimee/scripts/embedder-server.py
+
+log() { echo "aimee-embedder: $*" >&2; }
+
+if [ ! -s "$SERVER" ]; then
+    log "no server at $SERVER; this image is broken rather than unconfigured"
+    exit 1
+fi
+
+# The registry in this image holds exactly one embedder, so embedder-server.py's
+# single-entry default resolves it and EMBEDDER_MODEL is optional. Set it anyway when
+# the build recorded one, so the log names the model rather than leaving the reader to
+# infer it from the tag.
+if [ -z "${EMBEDDER_MODEL:-}" ] && [ -n "${AIMEE_EMBEDDER:-}" ]; then
+    EMBEDDER_MODEL="$AIMEE_EMBEDDER"
+    export EMBEDDER_MODEL
+fi
+
+# Fail closed, and say which piece is missing. Starting the server with no terminator
+# would leave a working embedder on a port nobody can reach; starting the terminator
+# with no server would accept connections and answer nothing.
+missing=""
+[ -r "$CA_FILE" ]   || missing="$missing $CA_FILE"
+[ -r "$CERT_FILE" ] || missing="$missing $CERT_FILE"
+[ -r "$KEY_FILE" ]  || missing="$missing $KEY_FILE"
+if [ -n "$missing" ]; then
+    log "refusing to start: mTLS identity missing:$missing"
+    log "The kb issues this identity when an embedder sidecar is deployed. If this"
+    log "container started before the kb, start it again once the kb is connected."
+    exit 1
+fi
+
+STUNNEL_CONF=/tmp/aimee-embedder-stunnel.conf
+cat > "$STUNNEL_CONF" <<EOF
+foreground = yes
+# stunnel's own log to stderr, so container logs carry handshake failures rather than
+# swallowing them into a file nobody reads.
+output = /dev/stderr
+debug = 4
+pid =
+
+[embedder]
+accept = 0.0.0.0:$AIMEE_EMBEDDER_PORT
+connect = 127.0.0.1:$AIMEE_EMBEDDER_LOOPBACK_PORT
+cert = $CERT_FILE
+key = $KEY_FILE
+CAfile = $CA_FILE
+# verifyChain, and deliberately NOT verifyPeer. They are not two strengths of one
+# check: verifyChain verifies the client certificate against CAfile, which is what this
+# hop wants, while verifyPeer matches it against a local REPOSITORY of known peer
+# certificates -- pinning -- and setting both rejects a correctly issued client with
+#   CERT: Certificate not found in local repository
+# which is what the synthesis hop did until it met a real kb. verifyChain alone still
+# REQUIRES a certificate: an anonymous client is refused with
+# "tlsv13 alert certificate required".
+verifyChain = yes
+sslVersionMin = TLSv1.3
+EOF
+
+cleanup() {
+    [ -n "${srv_pid:-}"     ] && kill "$srv_pid"     2>/dev/null || true
+    [ -n "${stunnel_pid:-}" ] && kill "$stunnel_pid" 2>/dev/null || true
+}
+trap cleanup TERM INT
+
+log "starting embedder (${EMBEDDER_MODEL:-registry default}) on 127.0.0.1:$AIMEE_EMBEDDER_LOOPBACK_PORT"
+EMBEDDER_PORT="$AIMEE_EMBEDDER_LOOPBACK_PORT" "$PY" "$SERVER" >&2 &
+srv_pid=$!
+
+log "starting mTLS terminator on :$AIMEE_EMBEDDER_PORT (client certificate required)"
+stunnel "$STUNNEL_CONF" >&2 &
+stunnel_pid=$!
+
+# Either process dying takes the container with it, so the healthcheck and any
+# depends_on gate see a stopped container rather than a half-up one.
+while :; do
+    if ! kill -0 "$srv_pid" 2>/dev/null; then
+        log "embedder-server exited; stopping"
+        cleanup
+        wait "$srv_pid" 2>/dev/null || true
+        exit 1
+    fi
+    if ! kill -0 "$stunnel_pid" 2>/dev/null; then
+        log "stunnel exited; stopping (the embedder is only reachable through it)"
+        cleanup
+        wait "$stunnel_pid" 2>/dev/null || true
+        exit 1
+    fi
+    sleep 5
+done

--- a/scripts/bake-embedder.py
+++ b/scripts/bake-embedder.py
@@ -1,0 +1,110 @@
+"""Fetch exactly the files the torch path loads for ONE embedder, into HF_HOME.
+
+A FILE RATHER THAN A DOCKERFILE HEREDOC, on purpose. The kb's version of this lived
+inside a `RUN ... <<'PYBAKE'`, which cost a build failure the first time someone put an
+`if` around it (Docker ends the RUN at the heredoc terminator, so the trailing `fi`
+parsed as an instruction: "unknown instruction: fi") and could not be tested without
+building an image. Here it is importable and its retry logic has a unit test.
+
+FETCH ONLY WHAT THE LOADER READS. snapshot_download takes the whole repo by default,
+and a repo may publish the same weights several times over: bekko ships an onnx/ tree
+(nine variants, ~2.2GB) and an openvino/ tree beside its safetensors, none of which
+sentence-transformers touches. Excluding the alternate runtimes and the legacy .bin
+duplicates keeps this to the safetensors and tokenizer the loader actually opens.
+"""
+import json
+import os
+import sys
+import time
+
+from huggingface_hub import snapshot_download
+
+REGISTRY = os.environ.get("EMBEDDERS_FILE", "/opt/aimee/embedders.json")
+
+SKIP = [
+    "onnx/*", "openvino/*", "*.onnx", "*.onnx_data",      # alternate runtimes
+    "*.bin", "*.h5", "*.msgpack", "*.tflite", "*.ckpt",   # duplicate/legacy formats
+    "*.gguf",                                             # not this runtime either
+]
+
+# Statuses worth another attempt. A bad revision or a repo that does not exist is NOT
+# on this list: waiting sixty seconds to repeat a permanent error just moves the failure
+# further from its cause.
+TRANSIENT = ("429", "500", "502", "503", "504", "Too Many Requests",
+             "ReadTimeout", "ConnectionError", "IncompleteRead")
+
+
+def fetch(repo, **kw):
+    """snapshot_download with backoff, because the Hub rate-limits.
+
+    Several image variants build in parallel and each wants the same files, so a bare
+    call turns any 429 into a failed image build -- which happened three times in one
+    evening, on the publish lane and twice on e2e.
+    """
+    delay = 15
+    for attempt in range(1, 6):
+        try:
+            return snapshot_download(repo, **kw)
+        except Exception as exc:  # noqa: BLE001 - the Hub raises several types here
+            text = f"{type(exc).__name__}: {exc}"
+            if not any(s in text for s in TRANSIENT) or attempt == 5:
+                raise
+            print(f"  hub fetch of {repo} failed ({text[:120]}); "
+                  f"retry {attempt}/4 in {delay}s", flush=True)
+            time.sleep(delay)
+            delay *= 2
+    raise AssertionError("unreachable")
+
+
+def code_repos(snapshot_dir):
+    """Repos holding this model's custom modelling code, from config.json auto_map.
+
+    A trust_remote_code model does not necessarily carry its own code -- auto_map may
+    point every class at a SEPARATE repo. Fetching only the weights then leaves the
+    loader reaching for the Hub at first use, which fails closed under HF_HUB_OFFLINE
+    and defeats the point of baking. So follow the references.
+    """
+    out = set()
+    cfg = os.path.join(snapshot_dir, "config.json")
+    if not os.path.exists(cfg):
+        return out
+    with open(cfg, encoding="utf-8") as handle:
+        auto_map = json.load(handle).get("auto_map") or {}
+    for target in auto_map.values():
+        if isinstance(target, str) and "--" in target:
+            out.add(target.split("--", 1)[0])
+        elif isinstance(target, (list, tuple)):
+            for item in target:
+                if isinstance(item, str) and "--" in item:
+                    out.add(item.split("--", 1)[0])
+    return out
+
+
+def main():
+    selected = (os.environ.get("AIMEE_EMBEDDER") or "").strip()
+    with open(REGISTRY, encoding="utf-8") as handle:
+        table = json.load(handle)["embedders"]
+
+    # An unknown name is a BUILD failure, not a silently-empty image: a container with
+    # no weights starts fine and then cannot embed, which surfaces as a retrieval
+    # outage rather than a build error. `none` is not valid here either -- that
+    # deployment runs no embedder container at all.
+    if selected not in table:
+        sys.exit(f"AIMEE_EMBEDDER={selected!r} is not in the registry. "
+                 f"Known: {', '.join(sorted(table))}. "
+                 f"(An external embedder deploys no embedder container.)")
+
+    spec = table[selected]
+    repo, revision = spec["repo"], spec.get("revision") or "main"
+    print(f"baking {selected}: {repo}@{revision}", flush=True)
+    local = fetch(repo, revision=revision, ignore_patterns=SKIP)
+    # Code repos are referenced by name only -- auto_map carries no revision -- so these
+    # take the default branch. A looser pin than the weights get; a model whose code must
+    # be pinned needs its auto_map repo added to the registry explicitly.
+    for code_repo in sorted(code_repos(local)):
+        print(f"  + code: {code_repo}", flush=True)
+        fetch(code_repo, allow_patterns=["*.py", "*.json", "*.txt"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-embedder-mtls-hop.sh
+++ b/scripts/test-embedder-mtls-hop.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# test-embedder-mtls-hop.sh: the embedder sidecar, on a real container, over real mTLS.
+#
+# WHY THIS EXISTS AS A SCRIPT. Its sibling for synthesis
+# (scripts/test-synthesis-mtls-hop.sh) passed 9/9 against a deployment where synthesis
+# could not work at all, because it drove `curl --cert --key` and so proved the SIDECAR
+# accepts a correct client while saying nothing about whether the kb is one. Both facts
+# need testing; this covers the sidecar half, and it covers it properly:
+#
+#   - the container REFUSES to start with no identity, rather than serving unterminated
+#   - a client presenting a certificate reaches the embedder through the terminator
+#   - an anonymous client is refused at the handshake
+#   - and it actually EMBEDS, returning a vector of the width the registry declares
+#
+# That last one is the point. A terminator that answers /health proves the plumbing; a
+# vector of the right width proves the thing behind it works.
+#
+# SELF-CONTAINED CA. It mints its own, rather than needing a kb, so this runs anywhere
+# docker does. In production the kb owns the CA and issues this certificate, because the
+# kb is the client on the hop -- that path is exercised by the deploy tests, not here.
+#
+# Usage:  scripts/test-embedder-mtls-hop.sh <embedder-image> [expected-dim]
+#   e.g.  scripts/test-embedder-mtls-hop.sh aimee-embedder-a25m:local 384
+set -uo pipefail
+
+IMAGE="${1:-}"
+WANT_DIM="${2:-}"
+if [ -z "$IMAGE" ]; then
+   echo "usage: $0 <embedder-image> [expected-dim]" >&2
+   exit 2
+fi
+command -v docker >/dev/null || { echo "docker not found"; exit 2; }
+command -v openssl >/dev/null || { echo "openssl not found"; exit 2; }
+
+NET=embhop-net
+NAME=aimee-embedder          # must match the certificate's SAN, and be resolvable
+CLIENT=embhop-client
+WORK="$(mktemp -d)"
+pass=0
+fail=0
+
+cleanup() {
+   docker rm -f "$NAME" "$CLIENT" >/dev/null 2>&1
+   docker network rm "$NET" >/dev/null 2>&1
+   rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+check() {
+   if [ "$1" = "0" ]; then
+      echo "  ok    $2"
+      pass=$((pass + 1))
+   else
+      echo "  FAIL  $2${3:+: $3}"
+      fail=$((fail + 1))
+   fi
+}
+
+# --- material -------------------------------------------------------------------
+# basicConstraints/keyUsage on the CA are NOT optional: without them OpenSSL refuses the
+# chain with "unable to get local issuer certificate", which reads like a missing file.
+echo "==> minting a CA, a server certificate for $NAME, and a client certificate"
+openssl req -x509 -newkey rsa:2048 -nodes -days 2 -subj "/CN=embhop-ca" \
+   -addext "basicConstraints=critical,CA:TRUE" \
+   -addext "keyUsage=critical,keyCertSign,cRLSign" \
+   -keyout "$WORK/ca.key" -out "$WORK/ca.pem" 2>/dev/null
+
+mint() { # mint <name> <cn> [san]
+   openssl req -newkey rsa:2048 -nodes -subj "/CN=$2" \
+      -keyout "$WORK/$1.key" -out "$WORK/$1.csr" 2>/dev/null
+   local ext="$WORK/$1.ext"
+   : > "$ext"
+   [ -n "${3:-}" ] && printf 'subjectAltName=DNS:%s\n' "$3" > "$ext"
+   openssl x509 -req -in "$WORK/$1.csr" -CA "$WORK/ca.pem" -CAkey "$WORK/ca.key" \
+      -CAcreateserial -days 2 -out "$WORK/$1.pem" \
+      ${3:+-extfile "$ext"} 2>/dev/null
+}
+mint server "$NAME" "$NAME"
+mint client "embhop-kb"
+chmod 0644 "$WORK"/*.pem "$WORK"/*.key
+
+docker network rm "$NET" >/dev/null 2>&1
+docker network create "$NET" >/dev/null
+
+# --- 1. no identity -> refuse ---------------------------------------------------
+# A sidecar that starts anyway would serve the embedder unterminated, or leave the
+# terminator down on a port the kb is about to call.
+echo "==> with no identity mounted"
+docker run --rm --name "$NAME" --network "$NET" "$IMAGE" >"$WORK/noid.log" 2>&1
+rc=$?
+[ "$rc" -ne 0 ] && grep -qi "identity missing" "$WORK/noid.log"
+check $? "refuses to start with no mTLS identity" "exit=$rc $(tail -1 "$WORK/noid.log")"
+
+# --- 2. with identity -> serves --------------------------------------------------
+echo "==> with the identity mounted"
+docker run -d --name "$NAME" --network "$NET" \
+   -v "$WORK/ca.pem:/var/lib/aimee-embedder/tls/ca.pem:ro" \
+   -v "$WORK/server.pem:/var/lib/aimee-embedder/tls/server.pem:ro" \
+   -v "$WORK/server.key:/var/lib/aimee-embedder/tls/server.key:ro" \
+   "$IMAGE" >/dev/null
+
+up=1
+for _ in $(seq 1 90); do
+   [ "$(docker inspect -f '{{.State.Health.Status}}' "$NAME" 2>/dev/null)" = "healthy" ] && { up=0; break; }
+   [ "$(docker inspect -f '{{.State.Status}}' "$NAME" 2>/dev/null)" = "exited" ] && break
+   sleep 5
+done
+check "$up" "sidecar reports healthy" "$(docker logs "$NAME" 2>&1 | tail -2 | tr '\n' ' ')"
+
+# A separate container as the client: the kb reaches this over the network, so testing
+# from inside the sidecar would prove something else entirely.
+docker run -d --name "$CLIENT" --network "$NET" \
+   -v "$WORK:/tls:ro" --entrypoint sleep debian:trixie-slim 3600 >/dev/null
+docker exec "$CLIENT" sh -c 'apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1'
+
+CURL_MTLS="curl -sS -m 30 --cacert /tls/ca.pem --cert /tls/client.pem --key /tls/client.key"
+
+code=$(docker exec "$CLIENT" sh -c "$CURL_MTLS -o /dev/null -w '%{http_code}' https://$NAME:8762/health" 2>/dev/null)
+check "$([ "$code" = 200 ] && echo 0 || echo 1)" "client certificate accepted (200)" "got $code"
+
+# --- 3. anonymous -> refused ----------------------------------------------------
+# verifyChain alone still REQUIRES a certificate; this is what keeps that honest.
+out=$(docker exec "$CLIENT" sh -c "curl -sS -m 30 --cacert /tls/ca.pem https://$NAME:8762/health" 2>&1)
+echo "$out" | grep -qiE "certificate required|alert (handshake failure|certificate)"
+check $? "anonymous client refused at the handshake" "$(echo "$out" | tail -1)"
+
+# --- 4. it actually embeds ------------------------------------------------------
+# The assertion that matters. /health only proves the terminator and the loader; this
+# proves the vector space is being served, at the width the registry declares.
+echo "==> embedding through the hop"
+health=$(docker exec "$CLIENT" sh -c "$CURL_MTLS https://$NAME:8762/health" 2>/dev/null)
+served_dim=$(printf '%s' "$health" | sed -n 's/.*"dim"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')
+vec=$(docker exec "$CLIENT" sh -c \
+   "$CURL_MTLS -X POST --data-binary 'the reconcile service matches ledger rows to bank statements' \
+    https://$NAME:8762/embed" 2>/dev/null)
+got_dim=$(printf '%s' "$vec" | tr -cd ',' | wc -c)
+got_dim=$((got_dim + 1))
+[ -n "$served_dim" ] && [ "$got_dim" = "$served_dim" ]
+check $? "embed returns a vector of the served width" "health says $served_dim, got $got_dim"
+
+if [ -n "$WANT_DIM" ]; then
+   [ "$served_dim" = "$WANT_DIM" ]
+   check $? "served width is the expected $WANT_DIM" "got $served_dim"
+fi
+
+# A serving_id is what the kb records against its corpus to detect a pooling or prefix
+# change that leaves the width and the model name alone, so it must be present.
+printf '%s' "$health" | grep -q '"serving_id"'
+check $? "health carries a serving_id for the kb to record"
+
+echo
+echo "==> Summary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1
+echo "embedder mTLS hop: ok"

--- a/scripts/tests/test_bake_embedder.py
+++ b/scripts/tests/test_bake_embedder.py
@@ -1,0 +1,136 @@
+"""scripts/bake-embedder.py: the retry, the selection, and the auto_map follow.
+
+This runs where a failure is cheap. The code it covers runs inside an image build,
+where the same failure costs the whole build and shows up as a Hugging Face traceback
+in a CI log.
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+spec = importlib.util.spec_from_file_location("bake", ROOT / "scripts" / "bake-embedder.py")
+bake = importlib.util.module_from_spec(spec)
+
+
+class FakeHub:
+    """Stands in for huggingface_hub.snapshot_download, counting calls."""
+
+    def __init__(self, script):
+        self.script = list(script)
+        self.calls = 0
+
+    def __call__(self, repo, **kw):
+        self.calls += 1
+        outcome = self.script.pop(0) if self.script else None
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome or "/cache/" + repo.replace("/", "--")
+
+
+def load():
+    # snapshot_download is imported at module scope, so stub it before exec.
+    sys.modules.setdefault("huggingface_hub", type(sys)("huggingface_hub"))
+    sys.modules["huggingface_hub"].snapshot_download = lambda *a, **k: ""
+    spec.loader.exec_module(bake)
+    bake.time = type(sys)("time")
+    bake.sleeps = []
+    bake.time.sleep = bake.sleeps.append
+    return bake
+
+
+def test_transient_is_retried():
+    m = load()
+    hub = FakeHub([Exception("429 Too Many Requests for url .../bekko"), None])
+    m.snapshot_download = hub
+    got = m.fetch("hotchpotch/bekko-embedding-v1-a25m")
+    assert got, got
+    assert hub.calls == 2, hub.calls
+    assert m.sleeps == [15], m.sleeps
+    print("  transient 429 retried, then succeeds")
+
+
+def test_permanent_is_not_retried():
+    m = load()
+    hub = FakeHub([Exception("RepositoryNotFoundError: 401 Client Error. Repository not found")])
+    m.snapshot_download = hub
+    try:
+        m.fetch("nobody/nope")
+    except Exception:
+        pass
+    else:
+        sys.exit("a permanent error must propagate")
+    # The point: no waiting. Sleeping to repeat a typo moves the failure away from its
+    # cause and slows every build that has one.
+    assert hub.calls == 1, hub.calls
+    assert m.sleeps == [], m.sleeps
+    print("  permanent error fails on the first attempt, no sleep")
+
+
+def test_exhaustion_is_bounded():
+    m = load()
+    hub = FakeHub([Exception("503 Server Error")] * 6)
+    m.snapshot_download = hub
+    try:
+        m.fetch("hotchpotch/bekko-embedding-v1-a25m")
+    except Exception:
+        pass
+    else:
+        sys.exit("an exhausted retry must propagate")
+    assert hub.calls == 5, hub.calls
+    assert m.sleeps == [15, 30, 60, 120], m.sleeps
+    print("  exhausted retries give up after 5 attempts, backing off 15/30/60/120")
+
+
+def test_unknown_embedder_is_a_build_failure():
+    """An unrecognised name must stop the build, not produce a weightless image.
+
+    A container with no weights starts fine and then cannot embed, which reaches the
+    operator as a retrieval outage rather than a build error -- the failure mode this
+    whole image split is meant to make impossible.
+    """
+    m = load()
+    with tempfile.TemporaryDirectory() as d:
+        reg = pathlib.Path(d) / "embedders.json"
+        reg.write_text(json.dumps({"embedders": {"bekko-a25m": {"repo": "x", "dim": 384}}}))
+        m.REGISTRY = str(reg)
+        import os
+        for bad in ("", "none", "bekko-a25", "nomic"):
+            os.environ["AIMEE_EMBEDDER"] = bad
+            try:
+                m.main()
+            except SystemExit as e:
+                assert "not in the registry" in str(e), str(e)
+            else:
+                sys.exit(f"AIMEE_EMBEDDER={bad!r} should have failed the build")
+    # 'none' specifically: that deployment runs NO embedder container, so it is not a
+    # value this image can be built with.
+    print("  unknown/empty/none embedder fails the build with the known list")
+
+
+def test_auto_map_code_repos_are_followed():
+    m = load()
+    with tempfile.TemporaryDirectory() as d:
+        cfg = pathlib.Path(d) / "config.json"
+        cfg.write_text(json.dumps({"auto_map": {
+            "AutoConfig": "nomic-ai/nomic-bert-2048--configuration_hf_nomic_bert.NomicBertConfig",
+            "AutoModel": ["nomic-ai/other-repo--modeling.Thing", "not-a-ref"],
+        }}))
+        got = m.code_repos(d)
+    assert got == {"nomic-ai/nomic-bert-2048", "nomic-ai/other-repo"}, got
+    # No config.json at all is not an error: most models carry their own code.
+    with tempfile.TemporaryDirectory() as d:
+        assert m.code_repos(d) == set()
+    print("  auto_map code repos are followed, missing config.json is not an error")
+
+
+if __name__ == "__main__":
+    test_transient_is_retried()
+    test_permanent_is_not_retried()
+    test_exhaustion_is_bounded()
+    test_unknown_embedder_is_a_build_failure()
+    test_auto_map_code_repos_are_followed()
+    print("test_bake_embedder: ok")


### PR DESCRIPTION
Step 2 of the [embedder proposal](docs/proposals/pending/embedder-image-split-and-rebuild.md). The embedder becomes what synthesis already is: a sidecar the kb reaches over mTLS, one model per tag.

| image | model | width |
|---|---|---|
| `aimee-embedder-a25m` | bekko-a25m | 384 |
| `aimee-embedder-nomic` | nomic-embed-text-v2-moe | 768 |

**Two images, not three.** There is no tag for "no embedder" — that deployment runs no embedder container and the server points `EMBEDDER_URL` wherever the operator says. An image whose purpose is to not be used is a tag to maintain and a build to pay for.

## What it buys

The weights leave the kb build **entirely** — Hugging Face is not contacted by it at all, not "less often". They sat behind the compiled binary in the layer order, so every C change re-downloaded them: four fetches per publish, which is what earned the 429s. And a deployment using an external embedder stops carrying CPU torch plus a gigabyte of weights it never loads.

## Same shape as aimee-llm, including the expensive lessons

The kb owns the CA and issues this server's certificate (the kb is the client on the hop); a missing identity is an error rather than something to wait out; the healthcheck probes loopback with a `start_period` long enough to load the model, because "port open" and "can embed" are minutes apart on nomic; and the terminator uses `verifyChain` and **not** `verifyPeer`, which is pinning and rejects a correctly issued client.

## The build asserts the image can embed

The final stage loads the model offline and compares the served width against the registry — so a weightless, incomplete or mis-sized image fails the **build** rather than starting fine and failing at first search. That failure mode is the reason for the split.

The bake moved to `scripts/bake-embedder.py` rather than staying a Dockerfile heredoc: the kb's version couldn't be tested without building an image, and a stray comment or conditional near it has broken this build twice before.

## Tests, both automated

- **`scripts/tests/test_bake_embedder.py`** — the retry (transient retried, permanent **not** retried and no sleep, exhaustion bounded at 15/30/60/120), an unknown or `none` model failing the build with the known list, and the `auto_map` follow. Wired into `module-inventory`.
- **`scripts/test-embedder-mtls-hop.sh`** — the sidecar on real containers, driven from a **separate** container so it crosses the network the kb will. Mints its own CA, so it needs no kb and runs anywhere docker does. Wired into `publish-embedder.yml` against the image just built.

The hop test asserts what its synthesis sibling does not: that the thing *behind* the terminator works. A health response proves plumbing; a vector of the declared width proves the vector space is served.

## Verified on CT 302 — both images, 7/7 each

```
  ok    refuses to start with no mTLS identity
  ok    sidecar reports healthy
  ok    client certificate accepted (200)
  ok    anonymous client refused at the handshake
  ok    embed returns a vector of the served width
  ok    served width is the expected 384 / 768
  ok    health carries a serving_id for the kb to record
```

Sizes: a25m 1.83 GB, nomic 3.23 GB.

## Not in this PR

The kb still bakes its own embedder until these land: kb-side identity issuance for this hop (the equivalent of `kb_synthesis_identity_ensure`), the compose service and config plumbing, removing torch and the weights from the kb image, and the two rebuild orchestrations. The proposal puts a **latency measurement** before the kb switches over, because this adds an HTTP hop to the retrieval path and embedding happens on every search.
