### PR TITLE
docs: remove em dashes from SYNTHESIS_MODELS, and run the docs check when docs change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
+      # Separate from docs_only on purpose: see the documentation step below.
+      docs_changed: ${{ steps.classify.outputs.docs_changed }}
     steps:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
@@ -48,21 +50,25 @@ jobs:
           # Protected-branch pushes and manual runs always receive the full gate.
           if [ "$EVENT_NAME" != pull_request ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "docs_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # This allowlist is intentionally narrow. Anything executable,
           # generated from executable sources, or operational takes the full path.
           docs_only=true
+          docs_changed=false
           file_count=0
           while IFS= read -r -d '' path; do
             file_count=$((file_count + 1))
             case "$path" in
               README.md|CONTRIBUTING.md|MANUAL.md|OWNERS.md|docs/*.md|docs/images/*|docs/gen/*.json)
+                docs_changed=true
                 ;;
               */README.md)
                 case "$path" in
                   control-web/*|data/*|deploy/*|editors/*|runtime-web/*|scripts/*|server-go/*|src/*)
+                    docs_changed=true
                     ;;
                   *)
                     docs_only=false
@@ -81,6 +87,7 @@ jobs:
             docs_only=false
           fi
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "docs_changed=$docs_changed" >> "$GITHUB_OUTPUT"
           echo "docs_only=$docs_only ($file_count changed file(s))"
 
   no-coauthor-trailers:
@@ -187,10 +194,30 @@ jobs:
       - name: Check managed authority packaging boundary
         if: needs.change-scope.outputs.docs_only != 'true'
         run: python3 scripts/check-managed-authority-packaging.py
+      # Runs unconditionally: it costs no network and no build, and the thing it guards
+      # is the gating logic itself, which is exactly the part a conditional step cannot
+      # be trusted to check.
+      - name: Test the CI change classifier
+        run: python3 -I scripts/tests/test_ci_change_scope.py
+
+      # docs_CHANGED, not docs_only. Gated on docs_only, this never ran for a pull
+      # request that touched documentation AND anything else -- which is most of them,
+      # and is how six em-dash violations reached testing in #2280: that PR edited
+      # docs/SYNTHESIS_MODELS.md plus one frontend file, so it was not docs-only, this
+      # step was skipped, lint reported success, and the violation then failed every
+      # branch cut from testing afterwards. The next docs-only PR ran the check and
+      # inherited someone else's failure, which is the worst way to find out.
+      #
+      # docs-gen-check and `git diff --check` stay on docs_only: the first needs a build
+      # and the second is about whitespace in the diff, and both already run in the full
+      # gate that a non-docs-only PR takes.
       - name: Check documentation
+        if: needs.change-scope.outputs.docs_changed == 'true'
+        run: python3 scripts/check-docs.py
+
+      - name: Check generated docs and diff hygiene
         if: needs.change-scope.outputs.docs_only == 'true'
         run: |
-          python3 scripts/check-docs.py
           make -C src docs-gen-check
           git diff --check
 

--- a/docs/SYNTHESIS_MODELS.md
+++ b/docs/SYNTHESIS_MODELS.md
@@ -20,13 +20,14 @@ distinction this page replaces.
 
 **The two images do not carry the same quant, and the asymmetry is the point.** On
 the 69-note gold set, dropping Q6 to Q4 costs E4B 0.0862 F1 (95% CI
-[+0.010, +0.181] — significant) and costs E2B 0.0012 (95% CI [-0.063, +0.069] —
-undecidable at this n). So E4B's quant is settled by measurement, and E2B's is not:
+[+0.010, +0.181], which is significant) and costs E2B 0.0012 (95% CI
+[-0.063, +0.069], undecidable at this n). So E4B's quant is settled by measurement,
+and E2B's is not:
 its tie is broken by the role E2B exists for. On the small box where you would pick
 E2B at all, Q4 is 1.70 GB of VRAM and 2.68 GB of host RSS against 2.30 and 3.86 at
 Q6, and the F1 difference is smaller than one gold triple.
 
-Be careful reading that as "Q4 is free for E2B". It is not measured to be equal — it
+Be careful reading that as "Q4 is free for E2B". It is not measured to be equal. It
 is measured to be *indistinguishable*, which is a statement about the set as much as
 the model, and `QUANT_DECISION.md` argues the opposite call on a directional prior
 (pooled P(Q6 > Q4) = 0.946). The full six-arm table, the memory figures, and what
@@ -140,7 +141,7 @@ difference is insignificant. The paired test is the one to read.
 now measured rather than assumed.** Every number in this section was taken at
 Q8_0; the images ship UD-Q4_K_XL for E2B and UD-Q6_K_XL for E4B.
 `bench/tier-a/QUANT_DECISION.md` measures all six arms on the same gold set, and
-the shipped pair scores 0.7206 (E2B Q4) and 0.8062 (E4B Q6) — so the Q8_0 table
+the shipped pair scores 0.7206 (E2B Q4) and 0.8062 (E4B Q6), so the Q8_0 table
 overstates E4B slightly and understates E2B by more than a little. Prefer the
 QUANT_DECISION numbers when the question is "what will I get", and this section
 when the question is "how do the two models compare on one lane".
@@ -215,7 +216,7 @@ flags).
 
 **The model-to-repo mapping is fixed at build time, not resolved at run time.**
 `gemma-4-E2B-it` maps to `unsloth/gemma-4-E2B-it-GGUF` at `UD-Q4_K_XL` and
-`gemma-4-E4B-it` to `unsloth/gemma-4-E4B-it-GGUF` at `UD-Q6_K_XL` — per-model
+`gemma-4-E4B-it` to `unsloth/gemma-4-E4B-it-GGUF` at `UD-Q6_K_XL`: per-model
 quants, decided by measurement (see QUANT_DECISION.md), with
 `scripts/synthesis-model-table.sh` as the single source of truth for the pairing
 and both digests. Each is fetched by exact filename and checked against its
@@ -301,8 +302,8 @@ It buys an operational property too. The sidecar holds no data, so moving betwee
 synthesis to a running deployment, or removing it, is a container swap with the kb left running. The
 embedder is still a one-way door; synthesis is not.
 
-Weights are baked per-model — 7.46 GB for E4B at UD-Q6_K_XL, 2.97 GB for E2B at
-UD-Q4_K_XL — from unsloth's GGUF repos, which is where the UD quants are published.
+Weights are baked per-model, 7.46 GB for E4B at UD-Q6_K_XL and 2.97 GB for E2B at
+UD-Q4_K_XL, from unsloth's GGUF repos, which is where the UD quants are published.
 The quant is a property of the model, not of the channel; see
 `scripts/synthesis-model-table.sh`.
 

--- a/scripts/tests/test_ci_change_scope.py
+++ b/scripts/tests/test_ci_change_scope.py
@@ -1,0 +1,117 @@
+"""The CI change classifier: docs_only vs docs_changed.
+
+Extracted from .github/workflows/ci.yml and run as a shell script, rather than copied,
+so it cannot drift from what CI executes -- which is the failure this test exists to
+prevent a second time.
+
+The distinction is load-bearing. docs_only decides whether to SKIP the expensive gate;
+docs_changed decides whether to RUN the documentation check. Conflating them meant a
+pull request touching docs plus one other file had its documentation checked by nothing,
+and six em-dash violations reached testing that way (#2280).
+"""
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def extract_classifier():
+    """Pull the classify step's shell body out of ci.yml."""
+    text = CI.read_text(encoding="utf-8")
+    m = re.search(r"id: classify\n(.*?)\n  [a-z-]+:", text, re.S)
+    if not m:
+        sys.exit("could not find the classify step in ci.yml")
+    block = m.group(1)
+    run = re.search(r"run: \|\n(.*)", block, re.S)
+    if not run:
+        sys.exit("classify step has no run: block")
+    body = run.group(1)
+    # Strip the YAML block indentation.
+    lines = [l[10:] if l.startswith(" " * 10) else l for l in body.splitlines()]
+    return "\n".join(lines)
+
+
+BODY = extract_classifier()
+
+
+def classify(paths, event="pull_request"):
+    """Run the real classifier over a NUL-separated file list."""
+    with tempfile.TemporaryDirectory() as d:
+        out = pathlib.Path(d) / "out"
+        out.touch()
+        script = pathlib.Path(d) / "classify.sh"
+        # The classifier reads the changed files from a `git diff -z` on stdin; feed the
+        # same shape without needing a repository.
+        listing = "".join(p + "\0" for p in paths)
+        stdin = pathlib.Path(d) / "files"
+        stdin.write_text(listing, encoding="utf-8")
+        # Swap only the `git diff ...` command for a `cat` of the fixture, leaving the
+        # surrounding `< <( ... )` process substitution -- and every branch of the
+        # classifier -- exactly as CI runs it.
+        body, n = re.subn(r"git diff\b[^\n)]*", f"cat {stdin} ", BODY)
+        if n != 1:
+            sys.exit(f"expected exactly one git diff in the classifier, found {n}")
+        script.write_text(body, encoding="utf-8")
+        env = {"EVENT_NAME": event, "GITHUB_OUTPUT": str(out),
+               "BASE_SHA": "a", "HEAD_SHA": "b", "PATH": "/usr/bin:/bin"}
+        r = subprocess.run(["bash", str(script)], env=env, capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit(f"classifier failed: {r.stderr[-400:]}")
+        kv = {}
+        for line in out.read_text(encoding="utf-8").splitlines():
+            if "=" in line:
+                k, v = line.split("=", 1)
+                kv[k] = v
+        return kv
+
+
+def expect(paths, want_only, want_changed, why):
+    got = classify(paths)
+    ok = got.get("docs_only") == want_only and got.get("docs_changed") == want_changed
+    print(("  ok    " if ok else "  FAIL  ") +
+          f"{why}: docs_only={got.get('docs_only')} docs_changed={got.get('docs_changed')}")
+    if not ok:
+        print(f"        expected docs_only={want_only} docs_changed={want_changed}")
+    return ok
+
+
+def main():
+    fails = 0
+
+    # Docs alone: skip the heavy gate, and check the docs.
+    fails += not expect(["docs/SYNTHESIS_MODELS.md"], "true", "true", "docs only")
+    fails += not expect(["README.md", "docs/images/x.svg"], "true", "true", "docs + image")
+
+    # THE REGRESSION. Docs plus code: the heavy gate must run AND the docs must be
+    # checked. Before docs_changed existed this returned docs_only=false and nothing
+    # looked at the documentation.
+    fails += not expect(["docs/SYNTHESIS_MODELS.md", "frontend/src/setup/deployTopology.ts"],
+                        "false", "true", "docs + code (this is #2280)")
+    fails += not expect(["docs/QUICKSTART.md", "src/kb/kb_service.c"],
+                        "false", "true", "docs + C")
+
+    # Code alone: full gate, no docs check to run.
+    fails += not expect(["src/kb/kb_service.c"], "false", "false", "code only")
+    fails += not expect(["Dockerfile"], "false", "false", "Dockerfile only")
+
+    # A nested README under an allowlisted directory is documentation.
+    fails += not expect(["src/README.md"], "true", "true", "nested allowlisted README")
+
+    # Pushes and manual runs take the full gate and always check docs.
+    got = classify(["anything"], event="push")
+    ok = got.get("docs_only") == "false" and got.get("docs_changed") == "true"
+    print(("  ok    " if ok else "  FAIL  ") +
+          f"push: docs_only={got.get('docs_only')} docs_changed={got.get('docs_changed')}")
+    fails += not ok
+
+    if fails:
+        sys.exit(f"test_ci_change_scope: {fails} failure(s)")
+    print("test_ci_change_scope: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Removes six em-dash voice violations from `docs/SYNTHESIS_MODELS.md`, and fixes the CI gap that let them reach `testing`.

## Why the dashes landed

They are mine, from #2280. `ci.yml` gated the "Check documentation" step on `docs_only == 'true'`; #2280 edited `docs/SYNTHESIS_MODELS.md` alongside `frontend/src/setup/deployTopology.ts`, so the change was not docs-only, the step was skipped, and lint reported success. The violation then failed lint on every branch cut from `testing` afterwards, so the next docs-only PR inherited someone else's failure.

Confirmed with `git log -S`: the em-dash rule predates the dashes (it came in with #2240).

## Changes

- Rewrote the six clauses with colons, commas and full stops. Not hyphen substitution, which would preserve the sentence shape the rule discourages.
- `change-scope` now emits **two** outputs. `docs_only` still decides whether to *skip* the expensive gate. New `docs_changed` decides whether to *run* the documentation check. `docs-gen-check` and `git diff --check` stay on `docs_only`, because both already run in the full gate a non-docs-only PR takes.
- New `scripts/tests/test_ci_change_scope.py`. It **extracts** the classifier's shell body out of `ci.yml` and executes it over synthetic file lists, rather than reimplementing it, so the test cannot drift from what CI runs. Eight cases including the exact #2280 shape (docs + one frontend file). Wired into `lint` unconditionally: it needs no network and no build, and a conditional step is not a trustworthy place to verify the conditions.

## Verification

Red before green, against the pre-fix `ci.yml` from `origin/testing`:

```
FAIL  docs + code (this is #2280): docs_only=false docs_changed=None
FAIL  docs + C: docs_only=false docs_changed=None
FAIL  code only: docs_only=false docs_changed=None
...
test_ci_change_scope: 8 failure(s)
```

Green on this branch:

```
ok    docs only: docs_only=true docs_changed=true
ok    docs + image: docs_only=true docs_changed=true
ok    docs + code (this is #2280): docs_only=false docs_changed=true
ok    docs + C: docs_only=false docs_changed=true
ok    code only: docs_only=false docs_changed=false
ok    Dockerfile only: docs_only=false docs_changed=false
ok    nested allowlisted README: docs_only=true docs_changed=true
ok    push: docs_only=false docs_changed=true
test_ci_change_scope: ok
```

`python3 scripts/check-docs.py` → `ok (571 Markdown files, 108 maintained guides, 2 OpenAPI sources, 4 local images)`. YAML parses.

This PR is itself the new path: it touches docs *and* a workflow *and* a script, so it is not docs-only, and the documentation check should now run on it. That is the observable proof.

Unblocks the `lint` failure on #2288.
