### PR TITLE
kb: register the serving-identity probe for the builtin embedder too

### DIFF
--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -122,6 +122,11 @@ void db2_set_embedder_probe(db2_embedder_probe_fn fn)
    g_embedder_probe = fn;
 }
 
+int db2_embedder_probe_registered(void)
+{
+   return g_embedder_probe != NULL;
+}
+
 void db2_set_dim_probe_budget_ms(int ms)
 {
    if (ms > 0)
@@ -169,6 +174,11 @@ static db2_embedder_serving_probe_fn g_embedder_serving_probe = NULL;
 void db2_set_embedder_serving_probe(db2_embedder_serving_probe_fn fn)
 {
    g_embedder_serving_probe = fn;
+}
+
+int db2_embedder_serving_probe_registered(void)
+{
+   return g_embedder_serving_probe != NULL;
 }
 static char g_embedding_compat[1024] = ""; /* CSV of "old_id->new_id" transitions */
 

--- a/src/db2/lifecycle.h
+++ b/src/db2/lifecycle.h
@@ -165,6 +165,13 @@ extern "C"
    typedef int (*db2_embedder_serving_probe_fn)(char *out, size_t out_len, char *err,
                                                 size_t errlen);
    void db2_set_embedder_serving_probe(db2_embedder_serving_probe_fn fn);
+   /* Whether each probe seam is currently registered. The bug these exist for was a
+    * registration decision no test could see: the caller skipped BOTH probes for the
+    * builtin embedder because the DIM probe cannot work against it, which silently
+    * disabled the serving-identity guard in the one transition it was written to catch.
+    * A seam that decides whether a guard runs has to be observable. */
+   int db2_embedder_probe_registered(void);
+   int db2_embedder_serving_probe_registered(void);
    void db2_set_embedding_compat(const char *compat_csv);
    const char *db2_embedding_compat(void);
 

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -1842,15 +1842,16 @@ int main(int argc, char **argv)
    /* unified-llm-container §2: activate the model-identity drift guard (the kb applies
     * the schema, so this is the load-bearing site). Empty embedding_model => no-op. */
    db2_set_embedder_model_id(config_embedder_model());
-   /* §2b: on a FRESH DB with no pin, let db2_init derive the dim from the running
-    * embedder's /health instead of the default — but only when a REAL remote embed
-    * command is configured (the lexical "builtin" has no /health and a fixed dim,
-    * so probing it would never succeed and would stall the retry loop). */
-   {
-      const char *embed_cmd = config_embedder_command_current(NULL);
-      if (embed_cmd && strcmp(embed_cmd, "builtin") != 0)
-         embedder_probe_register(embed_cmd);
-   }
+   /* §2b: register the embedder probes. Unconditionally, for whatever embed command is
+    * configured: embedder_probe_register decides which probes that command supports.
+    *
+    * This gate used to live here and excluded "builtin", because the DIM probe cannot
+    * work against the lexical embedder. That silently disabled the serving-identity
+    * probe too, which needs no /health and reports the builtin's space from a constant,
+    * and so left the builtin-to-model transition undetectable -- both are 384-dim, so
+    * the dim guard cannot see it either. The distinction belongs to the module that
+    * knows what each probe requires, not to its caller. */
+   embedder_probe_register(config_embedder_command_current(NULL));
    /* Size the DB2 connection pool (leased by worker threads) before db2_init. */
    db2_set_pool_size(aimee_resolve_db2_pool_size(config_db2_connection_pool_size()));
 

--- a/src/server/embedder_probe.c
+++ b/src/server/embedder_probe.c
@@ -153,9 +153,34 @@ void embedder_probe_register(const char *embed_command)
       return;
    }
    snprintf(g_embed_cmd, sizeof(g_embed_cmd), "%s", embed_command);
+
    /* Registered, not called: the identity is fetched inside db2_init, once the embedder
-    * has had the dim probe's patience applied to it. */
+    * has had the dim probe's patience applied to it.
+    *
+    * ALWAYS, INCLUDING FOR THE BUILTIN, and that is the whole point of this function
+    * owning the decision. The caller used to skip this call entirely for the builtin
+    * lexical embedder, correctly reasoning that the DIM probe cannot work against it --
+    * it has no /health and a fixed width, so probing would never succeed and would
+    * stall the retry loop. But skipping the call skipped BOTH probes, and the serving
+    * identity needs no /health at all: memory_embed_serving_id answers "builtin" from a
+    * constant, locally, instantly.
+    *
+    * The cost of conflating them was the exact transition the serving-id guard exists
+    * to catch. A corpus embedded by the builtin recorded no identity, because no probe
+    * was registered to report one. Selecting the bundled model then found kb_meta empty
+    * and adopted the model's identity over lexically-embedded vectors -- same 384 width,
+    * so the dim guard stayed silent, and the guard that would have refused was never
+    * asked. db2_embedder_serving_record_or_check's tests assert it catches exactly this;
+    * nothing ever told it. */
    db2_set_embedder_serving_probe(embedder_probe_serving_id);
+
+   if (strcmp(embed_command, "builtin") == 0)
+   {
+      LOG_INFO("db2", "builtin lexical embedder: dim probe skipped (fixed width, no /health); "
+                      "vector-space guard active");
+      return;
+   }
+
    const char *env = getenv("AIMEE_DIM_PROBE_BUDGET_MS");
    if (env && env[0])
    {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -388,6 +388,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-entity-registry \
                $(TESTPREFIX)/unit-test-fact-lifecycle \
                $(TESTPREFIX)/unit-test-embedding-dim \
+               $(TESTPREFIX)/unit-test-embedder-probe-register \
                $(TESTPREFIX)/unit-test-ontology-evolution \
                $(TESTPREFIX)/unit-test-extract-patterns \
                $(TESTPREFIX)/unit-test-fact-ingest $(TESTPREFIX)/unit-test-decision-log \
@@ -4067,6 +4068,14 @@ $(TESTPREFIX)/unit-test-fact-lifecycle: $(OBJDIR)/tests/test_fact_lifecycle.o \
 # embedder-runtime-fetch-autodim §2: kb_meta dim record + refuse-on-mismatch, shim.
 $(TESTPREFIX)/unit-test-embedding-dim: $(OBJDIR)/tests/test_embedding_dim.o \
                                $(OBJDIR)/db2/db_schema.o $(TEST_DATA_OBJS_MOCK)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Which probes embedder_probe_register installs for which embed command. Guards a
+# registration decision, not a computation: skipping the serving-identity probe along
+# with the dim probe is what made the builtin -> model switch undetectable.
+$(TESTPREFIX)/unit-test-embedder-probe-register: $(OBJDIR)/tests/test_embedder_probe_register.o \
+                               $(OBJDIR)/server/embedder_probe.o \
+                               $(OBJDIR)/modules/memory/memory_core_helpers_b.o $(TEST_DATA_OBJS_MOCK)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # typed-fact P4: self-extending ontology promotion pipeline (§2), shim.

--- a/src/tests/test_embedder_probe_register.c
+++ b/src/tests/test_embedder_probe_register.c
@@ -1,0 +1,124 @@
+/* test_embedder_probe_register.c: which probes get registered for which embed command.
+ *
+ * This tests a registration DECISION, not a computation, because that decision is where
+ * the vector-space guard was lost.
+ *
+ * The chain is four links: kb_main registers the probes -> db2_init calls the serving
+ * probe -> the probe asks memory_embed_serving_id what space is being served -> the guard
+ * records or refuses. Only the last link was tested. It was also the only link that was
+ * never broken: test_embedding_dim.c asserts by name that the guard refuses a
+ * builtin -> bundled-model switch.
+ *
+ * Link one was broken. kb_main skipped embedder_probe_register ENTIRELY when the
+ * configured embedder was "builtin", on the correct grounds that the DIM probe cannot
+ * work against a fixed-width embedder with no /health -- it would spin for its whole
+ * budget on every boot. One call registered two probes, so the serving-identity probe,
+ * which answers for the builtin from a constant with no network at all, went down with
+ * it. A corpus embedded by the builtin therefore recorded no identity, and selecting the
+ * bundled model found kb_meta empty and adopted the model's identity over lexical
+ * vectors. Both are 384-dim, so the dim guard is silent by construction, and the guard
+ * written for exactly this case was never asked.
+ *
+ * WHAT EACH ASSERTION BELOW IS WORTH, honestly:
+ *
+ *   - "no dim probe for the builtin" FAILS against the unmodified module. It is the
+ *     enabling change: it is what makes an unconditional call site safe, and without it
+ *     removing kb_main's gate would stall every builtin boot on the dim probe.
+ *   - "the serving probe IS registered for the builtin" PASSES against the unmodified
+ *     module, because embedder_probe_register was always right about it. It is a
+ *     characterization test: it pins down behavior that was correct but unreachable, so
+ *     that reintroducing a caller-side gate has something to break.
+ *
+ * The defect itself lived at the call site, where kb_main now makes no decision at all,
+ * so there is nothing left there for a unit test to hold. What these tests can and do
+ * establish is that the module is safe to call unconditionally for every embed command,
+ * which is the property the fix depends on.
+ */
+#include "../db2/lifecycle.h"
+#include "../modules/memory/memory_core_internal.h"
+#include "embedder_probe.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+static void check(int ok, const char *what)
+{
+   printf(ok ? "  ok    %s\n" : "  FAIL  %s\n", what);
+   if (!ok)
+      failures++;
+}
+
+/* Registration is global state on the db2 side, so each case starts from nothing.
+ * Without this a later case could pass on an earlier one's registration. */
+static void reset(void)
+{
+   embedder_probe_unregister();
+   assert(!db2_embedder_probe_registered());
+   assert(!db2_embedder_serving_probe_registered());
+}
+
+int main(void)
+{
+   printf("no embed command configured\n");
+   reset();
+   embedder_probe_register(NULL);
+   check(!db2_embedder_probe_registered(), "NULL command registers no dim probe");
+   check(!db2_embedder_serving_probe_registered(), "NULL command registers no serving probe");
+
+   reset();
+   embedder_probe_register("");
+   check(!db2_embedder_probe_registered(), "empty command registers no dim probe");
+   check(!db2_embedder_serving_probe_registered(), "empty command registers no serving probe");
+
+   printf("the builtin lexical embedder\n");
+   reset();
+   embedder_probe_register("builtin");
+   /* The dim probe genuinely cannot work here: no /health, fixed width, and the retry
+    * loop would spin for its whole budget on every boot. Registering it would be the
+    * bug in the other direction. */
+   check(!db2_embedder_probe_registered(), "no dim probe: nothing to probe, and it would stall");
+   /* Characterization, not regression: always true of this module. What was missing is a
+    * caller that reached it. */
+   check(db2_embedder_serving_probe_registered(),
+         "serving probe IS registered: the builtin has a vector space and declares it");
+
+   /* Link three, so the chain from registration to a recordable identity is closed by
+    * tests rather than by assumption. An empty answer here would make the guard a
+    * documented no-op, which is what the builtin used to look like from db2's side. */
+   {
+      char sid[160] = "zzz";
+      check(memory_embed_serving_id("builtin", sid, sizeof(sid)) == 0,
+            "the builtin answers a serving-identity probe");
+      check(sid[0] != '\0', "and the answer is NOT empty (empty would re-disable the guard)");
+      check(strcmp(sid, "builtin/lexical-v1") == 0, "it names the lexical space specifically");
+   }
+
+   printf("a sidecar embed command\n");
+   reset();
+   embedder_probe_register("python3 /opt/aimee/scripts/embed-remote.py");
+   check(db2_embedder_probe_registered(), "dim probe registered");
+   check(db2_embedder_serving_probe_registered(), "serving probe registered");
+
+   printf("an http endpoint\n");
+   reset();
+   embedder_probe_register("http://127.0.0.1:8760");
+   check(db2_embedder_probe_registered(), "dim probe registered");
+   check(db2_embedder_serving_probe_registered(), "serving probe registered");
+
+   printf("unregister clears both seams\n");
+   /* Both point at embedder_probe.c's statics, so leaving either registered would hand
+    * db2 a callback over a cleared command. */
+   embedder_probe_unregister();
+   check(!db2_embedder_probe_registered(), "dim probe cleared");
+   check(!db2_embedder_serving_probe_registered(), "serving probe cleared");
+
+   if (failures)
+   {
+      printf("\nembedder_probe_register: %d check(s) failed\n", failures);
+      return 1;
+   }
+   printf("\nembedder_probe_register: ok\n");
+   return 0;
+}


### PR DESCRIPTION
## A guard that could not fire

The vector-space drift guard could not fire on the one transition it was written to catch.

The guard itself is fine. `db2_embedder_serving_record_or_check` is correct, and `test_embedding_dim.c` asserts by name that it refuses a builtin → bundled-model switch. Nothing ever asked it.

`kb_main` skipped `embedder_probe_register` **entirely** when the configured embedder was `builtin`:

```c
const char *embed_cmd = config_embedder_command_current(NULL);
if (embed_cmd && strcmp(embed_cmd, "builtin") != 0)
   embedder_probe_register(embed_cmd);
```

The reasoning is right about the **dim** probe — the lexical embedder has no `/health` and a fixed width, so probing never succeeds and spins for the whole retry budget on every boot. But one call registered *two* probes, and the serving-identity probe needs no `/health` at all: `memory_embed_serving_id` answers for the builtin from a constant, locally, instantly. That function even carries a comment saying this is precisely the case nothing else can see.

So the sequence was:

1. Corpus embedded by the builtin. No probe registered → no identity recorded.
2. Operator selects the bundled model. `kb_meta` is empty, so the guard takes its documented `nothing recorded -> adopt current` branch and records the model's identity.
3. Model vectors are now mixed into a lexically-embedded corpus. Both are 384-dim, so the dim guard is silent **by construction**.

This is the second guard-that-cannot-fire found in this area tonight; the first one I deleted in #2289 with a comment explaining why the obvious check compared two copies of the same value.

## The fix

Moved the decision into `embedder_probe_register`, which is the code that knows what each probe requires: the serving probe registers for every command, the dim probe skips the builtin. `kb_main` now calls it unconditionally and makes no decision of its own.

Added `db2_embedder_probe_registered` / `db2_embedder_serving_probe_registered`. The defect was a registration decision no test could observe, and a seam that decides whether a guard runs has to be observable.

## What the tests are actually worth

New `unit-test-embedder-probe-register`, 15 checks across NULL, empty, builtin, sidecar and http commands. Being precise about which assertions have teeth, since this is exactly where I could fool myself:

- **`no dim probe for the builtin` — FAILS against the unmodified module.** Verified by rebuilding the test against `origin/testing`'s `embedder_probe.c`: `1 check(s) failed`. This is the enabling change; without it, removing `kb_main`'s gate would stall every builtin boot on the dim probe.
- **`the serving probe IS registered for the builtin` — PASSES against the unmodified module.** `embedder_probe_register` was always right about this. It is a *characterization* test: it pins down behavior that was correct but unreachable, so that reintroducing a caller-side gate has something to break. Labelling it a regression test would be a lie, and the test file says so.

The defect lived at the call site, where `kb_main` now makes no decision, so there is nothing left there for a unit test to hold. What these tests establish is the property the fix depends on: the module is safe to call unconditionally for every embed command.

Also asserts `memory_embed_serving_id("builtin")` returns a non-empty `builtin/lexical-v1`, closing link three so the chain from registration to a recordable identity rests on tests rather than on reading.

`make lint` clean (41/41), `unit-test-embedding-dim` still passes, `aimee-kb` links.

## Validation-pending

That a real builtin boot **records** `builtin/lexical-v1`, and that a subsequent model selection is then **refused**, is not verified end to end. It needs a kb boot against Postgres with a locally built binary, and hot-swapping one into CT 302 crashloops on a `GLIBC_2.38` mismatch — I did that earlier tonight and had to recreate the container.

Every link in the chain is unit-tested. The composition is not. That is the part I am most likely to be wrong about, and it is verifiable as soon as this is in a published image.
