### PR TITLE
ci: stop PR runs from evicting the e2e image cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1153,25 +1153,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Bake targets built by each compose file. The cache scope is keyed by
+          # IMAGE, not by topology: T1 and T2 build aimee-kb from the same
+          # Dockerfile, and T2 and T3 build aimee-server from the same
+          # Dockerfile.server. Per-topology scopes stored those identical layers
+          # twice and denied each shard the other's work.
           - topology: T1
             compose_file: compose.yaml
-            cache_set: |
-              aimee-kb.cache-from=type=gha,scope=e2e-T1-aimee-kb
-              aimee-kb.cache-to=type=gha,scope=e2e-T1-aimee-kb,mode=max
-              aimee-control-web.cache-from=type=gha,scope=e2e-T1-aimee-control-web
-              aimee-control-web.cache-to=type=gha,scope=e2e-T1-aimee-control-web,mode=max
+            images: aimee-kb aimee-control-web
           - topology: T2
             compose_file: compose.server.yaml
-            cache_set: |
-              aimee-kb.cache-from=type=gha,scope=e2e-T2-aimee-kb
-              aimee-kb.cache-to=type=gha,scope=e2e-T2-aimee-kb,mode=max
-              aimee-server.cache-from=type=gha,scope=e2e-T2-aimee-server
-              aimee-server.cache-to=type=gha,scope=e2e-T2-aimee-server,mode=max
+            images: aimee-kb aimee-server
           - topology: T3
             compose_file: compose.server-standalone.yaml
-            cache_set: |
-              aimee-server.cache-from=type=gha,scope=e2e-T3-aimee-server
-              aimee-server.cache-to=type=gha,scope=e2e-T3-aimee-server,mode=max
+            images: aimee-server
     name: e2e-docker (${{ matrix.topology }})
     steps:
       - uses: actions/checkout@v4
@@ -1183,15 +1178,41 @@ jobs:
           docker compose version
           docker buildx version
           df -h / | tail -1
+      # A GitHub Actions cache is readable only by the ref that wrote it and by
+      # that ref's base branch. Cache written from a PR run therefore lands under
+      # refs/pull/N/merge, where NO other run can ever read it — while still
+      # counting against the repo's 10 GB quota and evicting the shared
+      # refs/heads/testing entries by LRU. That is what happened here: 9.5 GB of
+      # unreadable PR blobs pushed the repo to 14 GB, every e2e image build
+      # missed cache completely, and each shard rebuilt postgres, rust, the
+      # python venv and the C tree from scratch (12-18 min a shard).
+      #
+      # So: every run READS the shared per-image scope, only pushes to the
+      # default branch WRITE it. That also drops the mode=max export (~7 min a
+      # shard) from the PR path entirely.
+      - name: Resolve bake cache flags
+        id: cache_flags
+        env:
+          IMAGES: ${{ matrix.images }}
+          WRITE_CACHE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/testing' }}
+        run: |
+          {
+            echo 'set<<CACHE_FLAGS_EOF'
+            for img in $IMAGES; do
+              echo "${img}.cache-from=type=gha,scope=e2e-${img}"
+              if [ "$WRITE_CACHE" = "true" ]; then
+                echo "${img}.cache-to=type=gha,scope=e2e-${img},mode=max"
+              fi
+            done
+            echo CACHE_FLAGS_EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Build topology images with persistent cache
         uses: docker/bake-action@v7
         with:
           source: .
           files: ${{ matrix.compose_file }}
           load: true
-          # Each image gets a distinct scope. Sharing one wildcard scope lets
-          # parallel Bake targets overwrite each other's exported cache.
-          set: ${{ matrix.cache_set }}
+          set: ${{ steps.cache_flags.outputs.set }}
       - name: Run Docker deploy topology ${{ matrix.topology }}
         # The aimee-server image builds webchat's SPA from its vendored
         # @rakuensoftware/smoothgui dependency — no npm token needed.


### PR DESCRIPTION
## What was slow

`e2e-docker` is the whole critical path of CI. On a recent run the shards took **18m (T2) / 12m (T1) / 6m (T3)**; every other job in the workflow finished in 4m or less.

Essentially all of that was image building, not testing:

| step | T1 | T2 | T3 |
|---|---|---|---|
| Build topology images | 12m | **17.6m** | 5.5m |
| Actually run the topology | 0.5m | 0.7m | 0.1m |

## Why the cache never helped

The buildx GHA cache was configured, and it was doing nothing. In the logs the manifest import resolves to nothing:

```
#12 [aimee-server] importing cache manifest from gha:14463555554273586333
#12 DONE 0.0s
```

and **zero** layers came back `CACHED` — including `apt-get install` layers that have no source dependency at all and must hit on any repeat run. Meanwhile the `mode=max` export cost 141s + 292s (~7 min) per shard, every run. Same result on the default branch, so this was not PR-vs-base branch scoping.

The cause was storage, not configuration. A GHA cache entry is readable only by the ref that wrote it and by that ref's base branch, so cache written during a PR run lands under `refs/pull/N/merge` where **no other run can ever read it**. Those write-only blobs still consume the repo's 10 GB quota. At the time of investigation:

```
 4.76 GB   87  refs/pull/2285/merge
 4.43 GB   87  refs/heads/testing
 3.80 GB   29  refs/pull/2291/merge
 0.89 GB   39  refs/pull/2292/merge
```

14.1 GB against a 10 GB limit, two thirds of it unreadable by construction — and it was evicting the one scope everything *could* read (`refs/heads/testing`) by LRU before any run got to reuse it. Hence a 0% hit rate and a full cold rebuild of postgres, rust, the python venv and the C tree on every shard of every run.

## The fix

**Only the default branch writes cache; every run reads it.** This removes the write-only PR blobs that were causing the eviction, and takes the ~7 min `mode=max` export off the PR path entirely.

**Cache scope is keyed by image, not by topology.** `aimee-kb` is built from the same `Dockerfile` in both T1 and T2, and `aimee-server` from the same `Dockerfile.server` in both T2 and T3 — verified identical context, dockerfile and build args. Per-topology scopes were storing those layers twice and denying each shard the other's work.

## Housekeeping

The PR-scoped caches were purged (421 entries / 27.5 GB — it had grown from 14 GB to 27 GB over the course of the investigation, which is its own sign of how fast this was churning). The repo is now at 6.62 GB, all under `refs/heads/testing`.

## Verification

- The flag generator was executed for all three matrix entries in both the read-only and read-write case, under `bash -e`, and produces the expected flags with exit 0.
- The workflow parses and the job structure was checked after the edit.
- **Not verified end-to-end:** cache hit rates can only be confirmed by real runs on GitHub. Expect the first merge to `testing` to be a cold build that seeds the new scopes — the scope names changed, so the existing 6.62 GB seeds nothing. The run *after* that is the one to judge.

## Note for after merge

The 6.62 GB currently under `testing` is written against the old `e2e-T*-` scope names and becomes unreadable once this lands. It will age out by LRU, but purging it after the first seeding run would avoid re-crowding the 10 GB limit.