### PR TITLE
build: install pgvectorscale from upstream's release, don't compile it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,78 +35,58 @@ ARG AIMEE_VERSION=""
 RUN sh scripts/fetch-treesitter.sh \
     && make -C src ../aimee-kb -j"$(nproc)" AIMEE_TREESITTER=1 ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
 
-# pgvectorscale (StreamingDiskANN). Always built: it adds ~1 MB to the image, and
-# the kb already decides at RUNTIME whether to use it -- pgvec_vectorscale_available()
+# pgvectorscale (StreamingDiskANN). Always installed: it adds ~1 MB to the image,
+# and the kb already decides at RUNTIME whether to use it -- pgvec_vectorscale_available()
 # probes pg_extension and falls back to HNSW with a warning when it is absent
 # (src/db2/pgvec_transport.c). Gating it at build time would defeat that and make
 # the index type a property of which image you happened to pull.
 #
-# The Rust toolchain and pgrx live only in this stage; the runtime image receives
-# the built extension files and none of the build chain. CI caches this layer
-# (cache-from/to type=gha,mode=max), so it recompiles only when the pins below move.
+# Upstream ships the built extension as a .deb per (version, pg major, arch), so
+# this stage FETCHES it rather than compiling it. It used to build the crate from
+# source with rustup + cargo-pgrx, which cost ~7 min of Rust compilation on the
+# critical path of every CI shard -- for a ~1 MB artifact pinned to two ARGs and
+# with no dependency on this repo's source at all. The old comment here claimed CI
+# cached the layer; it never did (the buildx GHA cache was thrashing its quota and
+# restored nothing), so the compile ran in full on every single run.
 FROM debian:trixie-slim AS pgvectorscale-build
 ARG PG_MAJOR
 ARG PGVECTORSCALE_VERSION
-# Same retry as the runtime stage: one transient TLS reset here fails the build.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
-    && install -d /usr/share/postgresql-common/pgdg \
-    && for a in 1 2 3 4 5; do \
-         curl -fsS --connect-timeout 10 --max-time 60 \
-           -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
-           https://www.postgresql.org/media/keys/ACCC4CF8.asc && break; \
-         echo "pgdg key fetch failed (attempt $a/5); backing off"; sleep $((a * 5)); \
-       done \
-    && test -s /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
-    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" \
-        > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        build-essential clang git pkg-config libssl-dev \
-        "postgresql-${PG_MAJOR}" "postgresql-server-dev-${PG_MAJOR}" \
-    && rm -rf /var/lib/apt/lists/*
-ENV CARGO_HOME=/usr/local/cargo
-ENV PATH=/usr/local/cargo/bin:$PATH
-# cargo-pgrx must match the pgrx the crate depends on, so it is read from the
-# checkout's Cargo.toml rather than pinned separately here.
-# BOTH FETCHES RETRY, for the same reason the pgdg key above does. This clone failed
-# a build with
-#   fatal: unable to access 'https://github.com/timescale/pgvectorscale.git/':
-#   The requested URL returned error: 503
-# during a forge wobble that also took fetch-treesitter.sh and the Hugging Face
-# weights fetch. Those two were given backoff first and this one was missed, so the
-# next build simply failed one line earlier -- an unretried fetch is a coin flip
+# TARGETARCH is supplied by buildx and is exactly the token upstream uses in the
+# asset name (amd64 / arm64).
+ARG TARGETARCH
+# Digests are per-arch and must move with PGVECTORSCALE_VERSION above. A release
+# asset is mutable in a way a git tag build was not, so it is pinned by content.
+ARG PGVECTORSCALE_SHA256_amd64=7a5450b81a7403ca20ff5e5a2f81aa13c81795ddd1fdfe9b986c42c48b12ed67
+ARG PGVECTORSCALE_SHA256_arm64=8d0916df999f082ceb3d019bdfa72f5df395c31b152f7906de59e429ee11edc7
+# Same retry as everywhere else in this file: an unretried fetch is a coin flip
 # wherever it sits.
-#
-# --depth 1 --branch is a tag, so a retry fetches the same commit; and cargo pgrx
-# below verifies the build. A retry cannot land different sources than a first-attempt
-# success would have.
-RUN for a in 1 2 3 4 5; do \
-        curl -fsS --connect-timeout 10 --max-time 300 https://sh.rustup.rs \
-          | sh -s -- -y --profile minimal --default-toolchain stable && break; \
-        echo "rustup fetch failed (attempt $a/5); backing off"; sleep $((a * 5)); \
-      done \
-    && test -x "$CARGO_HOME/bin/cargo" \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && zip="pgvectorscale-${PGVECTORSCALE_VERSION}-pg${PG_MAJOR}-${TARGETARCH}.zip" \
+    && case "$TARGETARCH" in \
+         amd64) want="$PGVECTORSCALE_SHA256_amd64" ;; \
+         arm64) want="$PGVECTORSCALE_SHA256_arm64" ;; \
+         *) echo "pgvectorscale: no pinned digest for arch '$TARGETARCH'" >&2; exit 1 ;; \
+       esac \
     && for a in 1 2 3 4 5; do \
-         git clone --depth 1 --branch "${PGVECTORSCALE_VERSION}" \
-           https://github.com/timescale/pgvectorscale.git /src/pgvectorscale && break; \
-         echo "pgvectorscale clone failed (attempt $a/5); backing off"; \
-         rm -rf /src/pgvectorscale; sleep $((a * 5)); \
+         curl -fsSL --connect-timeout 10 --max-time 300 -o "/tmp/$zip" \
+           "https://github.com/timescale/pgvectorscale/releases/download/${PGVECTORSCALE_VERSION}/${zip}" \
+           && break; \
+         echo "pgvectorscale asset fetch failed (attempt $a/5); backing off"; \
+         rm -f "/tmp/$zip"; sleep $((a * 5)); \
        done \
-    && test -d /src/pgvectorscale/pgvectorscale \
-    && cd /src/pgvectorscale/pgvectorscale \
-    && pgrx_version="$(awk -F'"' '/^pgrx[[:space:]]*=/{print $2; exit}' Cargo.toml)" \
-    && echo "building pgvectorscale ${PGVECTORSCALE_VERSION} against pgrx ${pgrx_version}" \
-    && cargo install --locked cargo-pgrx --version "${pgrx_version}" \
-    && cargo pgrx init "--pg${PG_MAJOR}=/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config" \
-    && cargo pgrx install --release --pg-config "/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"
-# Collect only the installed extension artifacts, at the paths the runtime uses.
-RUN mkdir -p "/pgvectorscale/usr/lib/postgresql/${PG_MAJOR}/lib" \
-        "/pgvectorscale/usr/share/postgresql/${PG_MAJOR}/extension" \
-    && cp "/usr/lib/postgresql/${PG_MAJOR}/lib/vectorscale"*.so \
-        "/pgvectorscale/usr/lib/postgresql/${PG_MAJOR}/lib/" \
-    && cp "/usr/share/postgresql/${PG_MAJOR}/extension/vectorscale"* \
-        "/pgvectorscale/usr/share/postgresql/${PG_MAJOR}/extension/"
+    && echo "${want}  /tmp/${zip}" | sha256sum -c - \
+    && unzip -j "/tmp/$zip" -d /tmp/pgvs \
+    && deb="$(find /tmp/pgvs -name '*.deb' ! -name '*dbgsym*' -print -quit)" \
+    && test -n "$deb" \
+    && echo "installing pgvectorscale ${PGVECTORSCALE_VERSION} (pg${PG_MAJOR}/${TARGETARCH}) from ${deb##*/}" \
+    && dpkg-deb -x "$deb" /pgvectorscale \
+    && rm -rf /pgvectorscale/usr/share/doc "/tmp/$zip" /tmp/pgvs
+# Fail here rather than shipping a kb that silently falls back to HNSW: the .deb
+# lays the files down at the paths the runtime reads, so assert they arrived.
+RUN test -n "$(find "/pgvectorscale/usr/lib/postgresql/${PG_MAJOR}/lib" -name 'vectorscale*.so' -print -quit)" \
+    && test -s "/pgvectorscale/usr/share/postgresql/${PG_MAJOR}/extension/vectorscale.control"
 
 # Runtime must match the build stage: libpq5 here has to provide at least the
 # PostgreSQL 17 symbols the kb was linked against (PGDG's libpq 18 does).


### PR DESCRIPTION
Follow-up to #2296. Independent of it — different file, no conflict.

## Why we were compiling it

No good reason, as far as I can tell. The `pgvectorscale-build` stage built the crate from source with `rustup` + `cargo-pgrx`. On a pre-cache run that one stage was the critical path of the slowest CI shard:

```
 start     end     dur  stage
 126.4   543.3   427.0  #48 aimee-kb pgvectorscale-build 3/4
```

**427s of a 569s makespan — 75% of `e2e-docker (T2)`.** And it's paid twice per run, since T1 builds `aimee-kb` as well. It explains the whole shape of the matrix:

| shard | contents | baseline |
|---|---|---|
| T3 | aimee-server only | 3.3m |
| T1 | aimee-kb *(+7m pgvectorscale)* + control-web | 8m |
| T2 | aimee-kb *(+7m pgvectorscale)* + aimee-server | 10.5m |

The stage has **no `COPY` from this repo**. It takes `PG_MAJOR` and `PGVECTORSCALE_VERSION`, clones a pinned upstream tag, and produces ~1 MB of extension files. Seven minutes of Rust for a fixed artifact.

The comment above it claimed CI cached the layer so it "recompiles only when the pins below move". That was never true — the buildx GHA cache was over its 10 GB quota and restored nothing, so the compile ran in full on every run. #2296 fixes the cache; this removes the reason to care.

## What this does

Upstream publishes the built extension as a `.deb` per (version, pg major, arch) — including `pg18-amd64` and `pg18-arm64`, exactly our pins. So fetch it.

The stage keeps the same contract: same paths staged under `/pgvectorscale/`, so the `COPY --from=pgvectorscale-build` in the runtime stage is untouched. Gone: `rustup`, `cargo-pgrx`, `build-essential`, `clang`, and the PGDG `postgresql-server-dev` install that only existed to compile against.

Release assets are mutable in a way a git-tag build was not, so the zip is **pinned by sha256 per arch**. Those digests move with `PGVECTORSCALE_VERSION` (noted in-file). Nothing in the repo overrides that ARG, so they can't be silently invalidated by a caller.

Failure modes are loud rather than silent — a bad digest, an unsupported arch, or a missing `.so`/`.control` all fail the build, instead of shipping a kb that quietly falls back to HNSW.

## Verification

Ran the stage's shell logic against the real 0.9.0 assets:

- both arches resolve, verify, extract and land the expected files
- correct ELF machine per arch (`x86-64` / `ARM aarch64`)
- staged tree is the same paths as before: `vectorscale-0.9.0.so`, `vectorscale.control`, 58 migration `.sql` files
- a corrupted asset fails the digest check; an unpinned arch is rejected

**Not verified by an actual `docker build`** — there's no docker in my environment. The image build itself is proven only by this branch's CI run, so that's what to watch. The `unzip`/`dpkg-deb` invocations in particular ran locally with `dpkg-deb` but with python standing in for `unzip`.

## Expected effect

Removing that stage should take `e2e-docker (T2)` from ~10.5m to roughly **5.3m**, with T1 dropping comparably — read off the pre-cache dependency graph (next-longest chain ends at 320.7s), so treat it as an estimate until a real run lands.