### PR TITLE
perf: enqueue code-unit curator jobs in one statement, not one per symbol

### DIFF
--- a/src/modules/kb-synthesis/kb_curator_queue.c
+++ b/src/modules/kb-synthesis/kb_curator_queue.c
@@ -152,38 +152,72 @@ int kb_curator_queue_code_units_for_project(const char *project, const char *roo
     * per-row subquery scan — observed holding a pooled connection for minutes on a
     * large `terms` table) and is NULL-unsafe (a single NULL file_path/symbol in
     * kb_code_unit_jobs makes NOT IN drop ALL rows). NOT EXISTS fixes both. */
-   static const char *sql = "SELECT f.path, t.name, t.kind, t.line::int"
-                            " FROM terms t"
-                            " JOIN files f ON t.file_id = f.id"
-                            " JOIN projects p ON f.project_id = p.id"
-                            " WHERE p.name = ?1 AND p.lifecycle_state = 'current'"
-                            " AND f.generation = p.current_generation"
-                            " AND NOT EXISTS ("
-                            "   SELECT 1 FROM kb_code_unit_jobs j"
-                            "   WHERE j.project = ?1 AND j.status IN ('pending','running','done')"
-                            "     AND j.generation = p.current_generation"
-                            "     AND j.file_path = f.path AND j.symbol = t.name"
-                            " )";
+   /* ONE set-based INSERT, not a row-per-symbol loop. The SELECT below already
+    * names exactly the rows to enqueue, so feeding them back one INSERT at a
+    * time only bought a WAL fsync per symbol: each kb_curator_queue_code_unit()
+    * call is its own autocommit transaction.
+    *
+    * That cost dominated indexing. Measured on a 4,018-file repository: the
+    * enqueue produced ~183,000 rows, postgres sat in LWLock/WALWrite and
+    * IO/WalSync, and the /v1/code/scan request that triggered it never answered
+    * inside the client's 5-minute deadline — so scanning a mid-sized repo could
+    * not complete at all. Folding the loop into the statement makes it one
+    * transaction and one commit.
+    *
+    * DISTINCT ON is load-bearing, and is the one behaviour change the fold
+    * requires: postgres refuses "ON CONFLICT DO UPDATE" that touches the same
+    * row twice in a single statement, and `terms` can legitimately carry the
+    * same symbol name twice for one file (two definitions, different lines).
+    * Row-at-a-time tolerated that because each insert was its own statement.
+    * Ordering by line makes the survivor the first definition, deterministically,
+    * rather than whichever row the scan happened to emit first.
+    *
+    * NOT EXISTS (anti-join), not `(f.path, t.name) NOT IN (subquery)`: the
+    * row-constructor NOT IN can't be planned as a hash anti-join (it degrades to a
+    * per-row subquery scan — observed holding a pooled connection for minutes on a
+    * large `terms` table) and is NULL-unsafe (a single NULL file_path/symbol in
+    * kb_code_unit_jobs makes NOT IN drop ALL rows). NOT EXISTS fixes both. */
+   static const char *sql =
+       "INSERT INTO kb_code_unit_jobs (project, generation, file_path, symbol, line)"
+       " SELECT DISTINCT ON (f.path, t.name)"
+       "        p.name, p.current_generation, f.path, t.name, t.line::int"
+       " FROM terms t"
+       " JOIN files f ON t.file_id = f.id"
+       " JOIN projects p ON f.project_id = p.id"
+       " WHERE p.name = ?1 AND p.lifecycle_state = 'current'"
+       " AND f.generation = p.current_generation"
+       " AND NOT EXISTS ("
+       "   SELECT 1 FROM kb_code_unit_jobs j"
+       "   WHERE j.project = ?1 AND j.status IN ('pending','running','done')"
+       "     AND j.generation = p.current_generation"
+       "     AND j.file_path = f.path AND j.symbol = t.name"
+       " )"
+       " ORDER BY f.path, t.name, t.line"
+       " ON CONFLICT(project, generation, file_path, symbol) DO UPDATE SET"
+       " line=excluded.line,"
+       " updated_at=pg_now_text()";
 
    char err[CQ_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
    {
-      aimee_log(LOG_WARN, "kb.curator.queue", "failed to query terms for project '%s': %s", project,
-                err);
+      aimee_log(LOG_WARN, "kb.curator.queue", "failed to prepare code-unit enqueue for '%s': %s",
+                project, err);
       return -1;
    }
    aimee_pg_bind_text(st, "?1", project);
 
-   int enqueued = 0;
-   while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   if (rc != AIMEE_PG_DONE)
    {
-      const char *fp = aimee_pg_column_text(st, 0);
-      const char *sym = aimee_pg_column_text(st, 1);
-      int ln = aimee_pg_column_int(st, 3);
-      if (kb_curator_queue_code_unit(project, fp ? fp : "", sym ? sym : "", ln) == 0)
-         enqueued++;
+      aimee_log(LOG_WARN, "kb.curator.queue", "code-unit enqueue failed for project '%s': %s",
+                project, err);
+      aimee_pg_finalize(st);
+      return -1;
    }
+   int enqueued = aimee_pg_stmt_changes(st);
+   if (enqueued < 0)
+      enqueued = 0;
    aimee_pg_finalize(st);
 
    if (enqueued > 0)


### PR DESCRIPTION
## The bug

`kb_curator_queue_code_units_for_project` ran a `SELECT` naming exactly the rows to enqueue, then fed them back **one `INSERT` at a time**. Each `kb_curator_queue_code_unit()` call is its own autocommit transaction — so this cost **one WAL fsync per symbol**.

## Why it matters

This did not merely make indexing slow; it made it impossible. Measured on a 4,018-file repository:

- the enqueue produces **~183,000 rows**
- postgres sits in `LWLock/WALWrite` and `IO/WalSync`
- `aimee-server` waits in `read_content_length_response` on `POST /v1/code/scan`
- the request never answers inside the client's 5-minute `KB_CLIENT_INDEX_SCAN_TIMEOUT_MS`

So `aimee index scan` on a mid-sized repo failed at **exactly 300s** with `knowledge service unavailable` — a misleading message for "the KB is still inserting your rows".

Caught while working out why an aimee benchmark arm could never index its corpus.

## The fix

The `SELECT` already identifies the rows. Fold it into the `INSERT` — one statement, one transaction, one commit.

Measured on the same corpus, against the live database:

| | rows | time |
|---|---|---|
| set-based insert | 44,668 | **1.6s** |
| previously (row-per-symbol) | 44,668 | did not finish in 300s |
| re-run, nothing to do | 0 | 47ms |

## `DISTINCT ON` is load-bearing

It is the one behaviour change the fold requires. Postgres refuses an `ON CONFLICT DO UPDATE` that touches the same row twice within a statement, and `terms` legitimately carries the same symbol name twice for one file (two definitions, different lines). Row-at-a-time tolerated this because each insert was a separate statement.

The same corpus has **328** such duplicate `(file_path, symbol)` pairs. Verified by running the statement without `DISTINCT ON`:

```
ERROR:  ON CONFLICT DO UPDATE command cannot affect row a second time
HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values.
```

`ORDER BY f.path, t.name, t.line` makes the survivor the first definition, deterministically, rather than whichever row the scan happened to emit first.

## Testing

Validated live against the KB's postgres with the numbers above, including the failure mode without `DISTINCT ON` and the idempotent re-run.

Note on unit coverage: the curator tests run against a sqlite shim, and only the gate-off path of this function is covered — it returns before touching SQL. This statement was already postgres-specific (`::int`, `pg_now_text()`, `ON CONFLICT`), so that gap is pre-existing and unchanged, but I'm flagging it rather than implying CI exercises this.