### PR TITLE
ci: make every main release require website approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Release controls always require the project owner's review.
 /.github/CODEOWNERS @JBailes
 /.github/workflows/auto-release.yml @JBailes
+/.github/workflows/main-merge-approval.yml @JBailes
 /.github/workflows/publish-images.yml @JBailes
 /.github/workflows/release-thin-client.yml @JBailes
 /.github/workflows/release-policy.yml @JBailes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Release controls always require the project owner's review.
+/.github/CODEOWNERS @JBailes
+/.github/workflows/auto-release.yml @JBailes
+/.github/workflows/publish-images.yml @JBailes
+/.github/workflows/release-thin-client.yml @JBailes
+/.github/workflows/release-policy.yml @JBailes
+/scripts/check-release-policy.sh @JBailes

--- a/.github/workflows/main-merge-approval.yml
+++ b/.github/workflows/main-merge-approval.yml
@@ -1,0 +1,21 @@
+name: Main merge approval
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# The default branch ruleset requires a successful deployment to this
+# environment. JBailes is its required reviewer, self-review is allowed so PRs
+# created with the owner's CLI identity remain approvable, and admin bypass is
+# disabled. The job therefore cannot complete until the owner explicitly
+# approves it on github.com.
+jobs:
+  approval:
+    environment: main-merge-approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record manual main approval
+        run: echo "Main change approved through the protected GitHub environment"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -11,23 +11,13 @@
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
 # merge-manifest pattern, on native runners (no QEMU emulation of the C build).
 #
-# Triggers:
-#   - push of a `v*` tag  -> versioned images derived from the tag
-#   - workflow_call       -> version passed in by the auto-release orchestrator
-#   - workflow_dispatch   -> optional manual version input
-# Versioned publishing on `main` is owned by auto-release.yml (which calls this
-# workflow), so there is no bare `push: branches: [main]` trigger here.
+# This workflow is deliberately reusable-only. The sole caller is
+# auto-release.yml, whose tag job is blocked by the protected `release`
+# environment. Do not add tag-push or workflow-dispatch triggers here: either
+# would create a second path to GHCR that bypasses the human release approval.
 name: Publish images
 
 on:
-  push:
-    tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version without leading v (e.g. 0.2.1)'
-        required: false
-        type: string
   workflow_call:
     inputs:
       version:
@@ -44,8 +34,8 @@ permissions:
   packages: write
 
 jobs:
-  # Resolve the version once (from the call/dispatch input or the pushed tag) so
-  # the build (binary embedding) and merge (image tags) jobs agree.
+  # Resolve and validate the approved version once so the build (binary
+  # embedding) and merge (image tags) jobs agree.
   prep:
     runs-on: ubuntu-latest
     outputs:
@@ -54,12 +44,10 @@ jobs:
       - name: Resolve version
         id: v
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            v="${{ inputs.version }}"
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            v="${GITHUB_REF_NAME#v}"
-          else
-            v=""
+          v="${{ inputs.version }}"
+          if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::approved release version must be MAJOR.MINOR.PATCH; got '${v:-<empty>}'"
+            exit 1
           fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -1,0 +1,17 @@
+name: Release policy
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  release-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify release approval topology
+        run: bash scripts/check-release-policy.sh

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -7,24 +7,13 @@
 # endpoint (AIMEE_SERVER_URL / --server); see the thin-client cross-platform
 # proposal.
 #
-# Triggers:
-#   - push of a `v*` tag      -> version derived from the tag (manual release)
-#   - workflow_call           -> version passed in by the auto-release orchestrator
-#   - workflow_dispatch       -> optional manual version input
-# When a version is supplied (call/dispatch) the matching `v<version>` tag must
-# already exist on the remote so the GitHub Release can attach to it.
+# This workflow is deliberately reusable-only. The sole caller is
+# auto-release.yml, after its tag job receives approval from the protected
+# `release` environment. Do not add tag-push or workflow-dispatch triggers here:
+# either would create a release path that bypasses the human approval.
 name: release-thin-client
 
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version without leading v (e.g. 0.2.1); blank = no release'
-        required: false
-        type: string
   workflow_call:
     inputs:
       version:
@@ -66,19 +55,21 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # Resolve the version string to embed (without leading v). From the
-      # workflow input when called/dispatched, otherwise from the pushed tag.
+      # Resolve the approved version string to embed (without leading v) and
+      # ensure the gated tag job created exactly that tag.
       - name: Resolve version
         id: ver
         shell: bash
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            v="${{ inputs.version }}"
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            v="${GITHUB_REF_NAME#v}"
-          else
-            v=""
+          v="${{ inputs.version }}"
+          if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::approved release version must be MAJOR.MINOR.PATCH; got '${v:-<empty>}'"
+            exit 1
           fi
+          git rev-parse -q --verify "refs/tags/v$v" >/dev/null || {
+            echo "::error::approved release tag v$v does not exist"
+            exit 1
+          }
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
       # --- Linux: authoritative make build of the lean thin client ---

--- a/scripts/check-release-policy.sh
+++ b/scripts/check-release-policy.sh
@@ -33,6 +33,7 @@ require_reusable_only() {
 }
 
 auto_release="$repo_root/.github/workflows/auto-release.yml"
+main_approval="$repo_root/.github/workflows/main-merge-approval.yml"
 publish_images="$repo_root/.github/workflows/publish-images.yml"
 release_client="$repo_root/.github/workflows/release-thin-client.yml"
 
@@ -52,5 +53,15 @@ grep -Fq 'uses: ./.github/workflows/publish-images.yml' "$auto_release" ||
     fail "$auto_release must call the guarded image publisher"
 grep -Fq 'uses: ./.github/workflows/release-thin-client.yml' "$auto_release" ||
     fail "$auto_release must call the guarded thin-client publisher"
+
+approval_job=$(awk '
+    /^  approval:[[:space:]]*$/ { in_approval = 1; print; next }
+    in_approval && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    in_approval { print }
+' "$main_approval")
+
+printf '%s\n' "$approval_job" |
+    grep -Eq '^    environment:[[:space:]]+main-merge-approval[[:space:]]*$' ||
+    fail "$main_approval must deploy through the protected main-merge-approval environment"
 
 echo "release-policy: approval topology is intact"

--- a/scripts/check-release-policy.sh
+++ b/scripts/check-release-policy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+fail() {
+    echo "release-policy: $*" >&2
+    exit 1
+}
+
+on_block() {
+    awk '
+        /^on:[[:space:]]*$/ { in_on = 1; next }
+        in_on && /^[A-Za-z0-9_-]+:/ { exit }
+        in_on { print }
+    ' "$1"
+}
+
+require_reusable_only() {
+    local file=$1
+    local block
+    block=$(on_block "$file")
+
+    printf '%s\n' "$block" | grep -Eq '^  workflow_call:' ||
+        fail "$file must expose workflow_call"
+
+    if printf '%s\n' "$block" |
+        awk '/^  [A-Za-z0-9_-]+:/ { key=$1; sub(/:$/, "", key); if (key != "workflow_call") exit 1 }'; then
+        :
+    else
+        fail "$file has a direct event trigger; release workflows must be reusable-only"
+    fi
+}
+
+auto_release="$repo_root/.github/workflows/auto-release.yml"
+publish_images="$repo_root/.github/workflows/publish-images.yml"
+release_client="$repo_root/.github/workflows/release-thin-client.yml"
+
+require_reusable_only "$publish_images"
+require_reusable_only "$release_client"
+
+tag_job=$(awk '
+    /^  tag:[[:space:]]*$/ { in_tag = 1; print; next }
+    in_tag && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    in_tag { print }
+' "$auto_release")
+
+printf '%s\n' "$tag_job" | grep -Eq '^    environment:[[:space:]]+release[[:space:]]*$' ||
+    fail "$auto_release tag job must use the protected release environment"
+
+grep -Fq 'uses: ./.github/workflows/publish-images.yml' "$auto_release" ||
+    fail "$auto_release must call the guarded image publisher"
+grep -Fq 'uses: ./.github/workflows/release-thin-client.yml' "$auto_release" ||
+    fail "$auto_release must call the guarded thin-client publisher"
+
+echo "release-policy: approval topology is intact"


### PR DESCRIPTION
## Incident containment

This closes the paths that allowed release artifacts to be created without an explicit GitHub-web approval.

- every change to main must deploy through the protected main-merge-approval environment
- only JBailes can approve that environment; admin bypass is disabled
- GHCR and thin-client publishers become reusable-only
- the protected release environment remains the sole version/tag publication gate
- release inputs and tags are validated before publishing
- a required release-policy check rejects direct release triggers
- CODEOWNERS covers every release-control file

Repository settings have already been hardened separately. This PR will not be merged by automation; approve the waiting environment and merge it manually on GitHub.