### PR TITLE
fix: don't enqueue or drain curator work that has no provider to do it

### DIFF
--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -2177,21 +2177,12 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
       return 503;
    }
 
-   /* CURATION IS NOT ENQUEUED HERE ANY MORE.
-    *
-    * The pipeline order is indexed -> embedded -> curated, and this point is only
-    * "indexed". Enqueuing here handed the curator a project whose vectors did not
-    * exist yet, so curation and embedding raced on every scan.
-    *
-    * It was also expensive in the worst possible place: this is the synchronous
-    * path of /v1/code/scan and the enqueue inserts one row per symbol. Measured on
-    * a 4,018-file corpus, ~173,000 rows and ~215s added to a request the client
-    * times out at 300s.
-    *
-    * The enqueue now belongs to the embed stage, which runs it for a project only
-    * once that project is fully embedded (see stage_embed_code). Nothing is lost
-    * for a thin-client push either: the embed sweep visits every project by name,
-    * not by filesystem path. */
+   /* Curation is not enqueued here. The pipeline is indexed -> embedded -> curated,
+    * and this point is only indexed; the old call raced curation against vectors
+    * that did not exist yet. It also inserted one row per symbol synchronously:
+    * ~173,000 rows and ~215s for 4,018 files against a 300s client timeout.
+    * stage_embed_code now enqueues after full project embedding. Thin-client pushes
+    * remain covered because the embed sweep visits projects by name, not path. */
 
    /* Record the scanned default-branch SHA so the next !force scan can no-op when the
     * branch hasn't moved (sha_now is set only on the local-scan path that resolved it). */

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -2177,14 +2177,21 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
       return 503;
    }
 
-   /* Queue code units for the deep curator on BOTH paths — a local scan and a
-    * thin-client push (which sends `files`). The queue reads code units from DB2
-    * by project name (it ignores root_path, so the server need not see the
-    * client's filesystem) and self-gates on kb_curator_extract_code_enabled.
-    * Previously this ran only for `!pushed_files`, so workspaces ingested from a
-    * thin client were never queued for curation. The 0.6B embed pass is driven
-    * separately by the curator drain. */
-   kb_curator_queue_code_units_for_project(project, root_path);
+   /* CURATION IS NOT ENQUEUED HERE ANY MORE.
+    *
+    * The pipeline order is indexed -> embedded -> curated, and this point is only
+    * "indexed". Enqueuing here handed the curator a project whose vectors did not
+    * exist yet, so curation and embedding raced on every scan.
+    *
+    * It was also expensive in the worst possible place: this is the synchronous
+    * path of /v1/code/scan and the enqueue inserts one row per symbol. Measured on
+    * a 4,018-file corpus, ~173,000 rows and ~215s added to a request the client
+    * times out at 300s.
+    *
+    * The enqueue now belongs to the embed stage, which runs it for a project only
+    * once that project is fully embedded (see stage_embed_code). Nothing is lost
+    * for a thin-client push either: the embed sweep visits every project by name,
+    * not by filesystem path. */
 
    /* Record the scanned default-branch SHA so the next !force scan can no-op when the
     * branch hasn't moved (sha_now is set only on the local-scan path that resolved it). */

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -132,6 +132,81 @@ static int ce_flush_batch(ce_pending_t *pend, int n, const char **texts, float *
       }
    }
    return ok;
+/* The project's content signature at |generation|: file count, the ACTIVE embedding
+ * dimension, and a digest over every file id:hash. Recorded by a pass that embedded
+ * the whole file set, and compared on the next pass to skip an unchanged project.
+ *
+ * The dimension is part of it on purpose: the same files at a different width are
+ * different vectors, so a dim change must invalidate the signature rather than read
+ * as "already embedded". */
+static void ce_project_signature(void *conn, int64_t proj_id, int64_t generation, char *out,
+                                 size_t out_len)
+{
+   if (!out || out_len == 0)
+      return;
+   out[0] = '\0';
+   if (!conn)
+      return;
+   int sc_dim = db2_embedding_dim();
+   if (sc_dim <= 0 || sc_dim > CE_EMBED_MAX_DIM)
+      sc_dim = 1024;
+   char err[CE_ERRBUF] = "";
+   static const char *sig_sql = "SELECT count(*), coalesce(md5(string_agg(id::text || ':' || "
+                                "hash, ',' ORDER BY id)), '') "
+                                "FROM files WHERE project_id = ?1 AND generation = ?2";
+   aimee_pg_stmt_t *sst = aimee_pg_prepare(conn, sig_sql, err, sizeof(err));
+   if (!sst)
+      return;
+   aimee_pg_bind_int64(sst, "?1", proj_id);
+   aimee_pg_bind_int64(sst, "?2", generation);
+   if (aimee_pg_step(sst, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      int64_t fcount = aimee_pg_column_int64(sst, 0);
+      const char *fhash = aimee_pg_column_text(sst, 1);
+      snprintf(out, out_len, "%lld:%d:%s", (long long)fcount, sc_dim, fhash ? fhash : "");
+   }
+   aimee_pg_finalize(sst);
+}
+
+int kb_code_embed_project_fully_embedded(const char *project)
+{
+   if (!project || !project[0])
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+
+   char err[CE_ERRBUF] = "";
+   static const char *proj_sql = "SELECT id, current_generation FROM projects"
+                                 " WHERE name = ?1 AND lifecycle_state='current' LIMIT 1";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, proj_sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_bind_text(st, "?1", project);
+   int64_t proj_id = -1;
+   int64_t generation = 0;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      proj_id = aimee_pg_column_int64(st, 0);
+      generation = aimee_pg_column_int64(st, 1);
+   }
+   aimee_pg_finalize(st);
+   /* Not indexed is not embedded. An unknown project answers 0 rather than
+    * "vacuously complete", which would let curation start on nothing. */
+   if (proj_id < 0)
+      return 0;
+
+   char sig_now[160] = "";
+   ce_project_signature(conn, proj_id, generation, sig_now, sizeof(sig_now));
+   if (!sig_now[0])
+      return 0;
+
+   char sig_key[320];
+   snprintf(sig_key, sizeof(sig_key), "code_embed_sig:%s", project);
+   char stored[160] = "";
+   if (db2_kb_runtime_state_get(sig_key, stored, sizeof(stored)) != 0)
+      return 0;
+   return stored[0] && strcmp(stored, sig_now) == 0;
 }
 
 static unsigned long long ce_fnv1a_update(unsigned long long h, unsigned char c)
@@ -435,26 +510,7 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
    char sig_now[160] = "";
    if (!paths && !dry_run && strcmp(out->scope, "changed_files") == 0)
    {
-      int sc_dim = db2_embedding_dim();
-      if (sc_dim <= 0 || sc_dim > CE_EMBED_MAX_DIM)
-         sc_dim = 1024;
-      static const char *sig_sql = "SELECT count(*), coalesce(md5(string_agg(id::text || ':' || "
-                                   "hash, ',' ORDER BY id)), '') "
-                                   "FROM files WHERE project_id = ?1 AND generation = ?2";
-      aimee_pg_stmt_t *sst = aimee_pg_prepare(conn, sig_sql, err, sizeof(err));
-      if (sst)
-      {
-         aimee_pg_bind_int64(sst, "?1", proj_id);
-         aimee_pg_bind_int64(sst, "?2", generation);
-         if (aimee_pg_step(sst, err, sizeof(err)) == AIMEE_PG_ROW)
-         {
-            int64_t fcount = aimee_pg_column_int64(sst, 0);
-            const char *fhash = aimee_pg_column_text(sst, 1);
-            snprintf(sig_now, sizeof(sig_now), "%lld:%d:%s", (long long)fcount, sc_dim,
-                     fhash ? fhash : "");
-         }
-         aimee_pg_finalize(sst);
-      }
+      ce_project_signature(conn, proj_id, generation, sig_now, sizeof(sig_now));
       if (sig_now[0])
       {
          char sig_key[320];

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -132,6 +132,8 @@ static int ce_flush_batch(ce_pending_t *pend, int n, const char **texts, float *
       }
    }
    return ok;
+}
+
 /* The project's content signature at |generation|: file count, the ACTIVE embedding
  * dimension, and a digest over every file id:hash. Recorded by a pass that embedded
  * the whole file set, and compared on the next pass to skip an unchanged project.

--- a/src/kb/kb_service_code_embed.h
+++ b/src/kb/kb_service_code_embed.h
@@ -41,4 +41,15 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
                           int path_count, int batch_size, int max_points, int dry_run,
                           kb_code_embed_result_t *out);
 
+/* 1 when every file of |project|'s CURRENT generation has been embedded at the
+ * active embedding dimension, 0 otherwise (including an unknown project, an
+ * unindexed one, or a store that cannot be read).
+ *
+ * This is the "embedded" step of indexed -> embedded -> curated, and it is the
+ * same signature kb_code_embed_refresh records when a pass completes the whole
+ * file set -- deliberately one definition, because a second reader that computed
+ * "fully embedded" differently would let curation start on a half-embedded
+ * project exactly when the two disagreed. */
+int kb_code_embed_project_fully_embedded(const char *project);
+
 #endif /* KB_SERVICE_CODE_EMBED_H */

--- a/src/modules/kb-synthesis/kb_curator_drain.c
+++ b/src/modules/kb-synthesis/kb_curator_drain.c
@@ -39,6 +39,7 @@
 #include "index.h"
 #include "aimee.h"
 #include "config.h"
+#include "config_database.h" /* config_synth_chat_endpoint_current */
 #include "kb_background.h"
 #include "cJSON.h"
 #include "log.h"
@@ -1086,7 +1087,33 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
    }
 
    ctx->stop = 0;
-   if (pthread_create(&ctx->thread, NULL, drain_thread_main, ctx) == 0)
+
+   /* NO SYNTHESIS PROVIDER => NO LLM LANE.
+    *
+    * Every stage on this thread and on the code/doc worker threads calls the
+    * synthesis sidecar. With no endpoint configured not one of them can succeed,
+    * and running them anyway is not merely idle: each pass claims rows, forks a
+    * sidecar, fails, and rewrites the row. The provider gate added for #2298 damps
+    * that to a 30s..300s probe, but the honest answer is not to start the lane.
+    *
+    * THE INDEX LANE STILL STARTS, DELIBERATELY. It is gated on the EMBEDDER, not on
+    * synthesis, and it owns stage_embed_code -- the pass that writes code_embeddings.
+    * Stopping the whole curator here would take code embedding down with it and
+    * leave a deployment indexed but never embedded, which is the opposite of what
+    * an operator running without a synth provider wants.
+    *
+    * Configured-ness, not reachability: a configured endpoint that is down is a
+    * real outage and its rows are real work, which the provider gate already
+    * handles. An unconfigured one is a steady state no retry resolves. */
+   char synth_endpoint[512];
+   int have_synth = config_synth_chat_endpoint_current(synth_endpoint, sizeof(synth_endpoint));
+   if (!have_synth)
+   {
+      aimee_log(LOG_INFO, "kb.curator.drain",
+                "no synthesis endpoint configured: LLM lane not started (extraction and "
+                "synthesis stages cannot run); index lane still serves embedding and graph");
+   }
+   else if (pthread_create(&ctx->thread, NULL, drain_thread_main, ctx) == 0)
    {
       ctx->active = 1;
       aimee_log(LOG_INFO, "kb.curator.drain", "drain thread started");
@@ -1101,8 +1128,10 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
     * synth backend serving N parallel slots actually receives N concurrent
     * sidecar extractions. Job claims are transactional (UPDATE ... SELECT ...
     * LIMIT 1), so concurrent workers never double-claim. */
+   /* Same reason as the LLM lane above: these workers only run extract_code. */
    ctx->code_active = 0;
-   if (config_kb_curator_extract_code_enabled() && config_kb_curator_extract_code_workers() > 1)
+   if (have_synth && config_kb_curator_extract_code_enabled() &&
+       config_kb_curator_extract_code_workers() > 1)
    {
       int extra = config_kb_curator_extract_code_workers() - 1;
       if (extra > KB_CURATOR_MAX_CODE_WORKERS)
@@ -1124,7 +1153,8 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
     * still contributes one doc per pass. Claims are transactional (UPDATE ...
     * SELECT ... LIMIT 1 FOR UPDATE SKIP LOCKED), so workers never double-claim. */
    ctx->doc_active = 0;
-   if (config_kb_curator_extract_docs_enabled() && config_kb_curator_extract_docs_workers() > 1)
+   if (have_synth && config_kb_curator_extract_docs_enabled() &&
+       config_kb_curator_extract_docs_workers() > 1)
    {
       int extra = config_kb_curator_extract_docs_workers() - 1;
       if (extra > KB_CURATOR_MAX_DOC_WORKERS)

--- a/src/modules/kb-synthesis/kb_curator_drain.c
+++ b/src/modules/kb-synthesis/kb_curator_drain.c
@@ -257,8 +257,21 @@ static int stage_embed_code(const kb_curator_extract_opts_t *opts)
    {
       kb_code_embed_result_t r;
       memset(&r, 0, sizeof(r));
-      if (kb_code_embed_refresh(projects[i].name, "changed_files", NULL, 0, 0, 0, 0, &r) == 0)
-         total += (int)r.embedded;
+      if (kb_code_embed_refresh(projects[i].name, "changed_files", NULL, 0, 0, 0, 0, &r) != 0)
+         continue;
+      total += (int)r.embedded;
+
+      /* indexed -> embedded -> CURATED. The scan handler used to enqueue curation
+       * the moment indexing finished, handing the curator a project whose vectors
+       * did not exist yet. The enqueue lives here instead, and only fires once this
+       * project's whole file set is embedded at the active dimension, so curation
+       * cannot claim a row for data that is not both indexed and embedded.
+       *
+       * Idempotent and cheap when there is nothing new: the enqueue anti-joins
+       * against the existing jobs, and it self-gates on the extract_code stage and
+       * on a synthesis endpoint being configured. */
+      if (kb_code_embed_project_fully_embedded(projects[i].name))
+         kb_curator_queue_code_units_for_project(projects[i].name, NULL);
    }
    if (total > 0)
       aimee_log(LOG_DEBUG, "kb.code.embed", "embedded %d code/doc vector(s) across %d project(s)",
@@ -365,11 +378,23 @@ static const struct
    const char *stage;
    const char *reqs; /* comma-separated prerequisite stage names */
 } CURATOR_STAGE_DEPS[] = {
-    {"resolve_entities", "extract_docs"}, {"index_narrative", "extract_docs"},
-    {"index_claims", "extract_docs"},     {"detect_contradictions", "index_claims"},
-    {"index_code_unit", "extract_code"},  {"link_artifacts", "extract_docs,extract_code"},
-    {"synthesize", "index_claims"},       {"promote_entity", "resolve_entities"},
-    {"embed_evidence", "index_claims"},   {"cross_repo_graph", "projection_graph"},
+    {"resolve_entities", "extract_docs"},
+    {"index_narrative", "extract_docs"},
+    {"index_claims", "extract_docs"},
+    {"detect_contradictions", "index_claims"},
+    {"index_code_unit", "extract_code"},
+    {"link_artifacts", "extract_docs,extract_code"},
+    {"synthesize", "index_claims"},
+    {"promote_entity", "resolve_entities"},
+    {"embed_evidence", "index_claims"},
+    {"cross_repo_graph", "projection_graph"},
+    /* indexed -> embedded -> curated. This edge is CROSS-LANE (embed_code is
+     * INDEX, extract_code is LLM), so the order validator above treats it as
+     * advisory and it is NOT what enforces the invariant -- stage_embed_code is,
+     * by owning the enqueue and only running it for a fully embedded project.
+     * Declared anyway so `requires` states the real contract instead of showing
+     * extract_code as having no prerequisites at all. */
+    {"extract_code", "embed_code"},
 };
 
 /* Prerequisite string for a stage (comma-separated), or "" if none. */

--- a/src/modules/kb-synthesis/kb_curator_queue.c
+++ b/src/modules/kb-synthesis/kb_curator_queue.c
@@ -11,6 +11,7 @@
 #include "kb_curator_queue.h"
 #include "aimee.h"
 #include "config.h"
+#include "config_database.h" /* config_synth_chat_endpoint_current — the one resolver */
 #include "index.h" /* index_list_projects, project_info_t */
 #include "log.h"
 #include "db2/kb_payload.h"
@@ -140,6 +141,34 @@ int kb_curator_queue_code_units_for_project(const char *project, const char *roo
       return 0;
    if (!config_kb_curator_extract_code_enabled())
       return 0;
+
+   /* ENABLING A STAGE IS NOT THE SAME AS BEING ABLE TO RUN IT.
+    *
+    * These rows exist for exactly one consumer: extract_code, which runs the
+    * synthesis sidecar. With no synthesis endpoint configured, not one of them can
+    * ever reach 'done' -- and enqueuing them is not free. This runs on the
+    * SYNCHRONOUS path of /v1/code/scan and inserts one row per symbol: measured on
+    * a 4,018-file corpus, ~173,000 rows and 100 MB of table, adding ~215s to every
+    * scan. The client's scan deadline is spent building a backlog that cannot start.
+    *
+    * It also compounds. The anti-join below scans kb_code_unit_jobs, so each scan
+    * of each new project pays for every dead row every earlier scan left behind.
+    *
+    * Configured-ness, not reachability: a configured endpoint that is temporarily
+    * down is a real outage, its rows are real work, and the drain's process-wide
+    * provider gate already idles the queue instead of spinning. An UNCONFIGURED
+    * endpoint is a steady state that no retry can resolve. Resolved through the
+    * same accessor the sidecar uses, so the two cannot disagree about what an
+    * operator's value means. */
+   char synth_endpoint[512];
+   if (!config_synth_chat_endpoint_current(synth_endpoint, sizeof(synth_endpoint)))
+   {
+      aimee_log(LOG_INFO, "kb.curator.queue",
+                "code-unit enqueue skipped for '%s': no synthesis endpoint configured, so "
+                "extract_code cannot consume these rows (set SYNTHESIS_ENDPOINT to enable)",
+                project);
+      return 0;
+   }
 
    (void)root_path;
 

--- a/src/modules/kb-synthesis/kb_curator_queue.c
+++ b/src/modules/kb-synthesis/kb_curator_queue.c
@@ -12,7 +12,7 @@
 #include "aimee.h"
 #include "config.h"
 #include "config_database.h" /* config_synth_chat_endpoint_current — the one resolver */
-#include "index.h" /* index_list_projects, project_info_t */
+#include "index.h"           /* index_list_projects, project_info_t */
 #include "log.h"
 #include "db2/kb_payload.h"
 #include "db2/db2_internal.h"

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -1552,6 +1552,24 @@ else
 fi
 
 echo ""
+# NOTE: `set -e` is active here, and `grep -c` exits 1 on zero matches -- hence
+# `|| true` below. Without it this block silently ended the run.
+# indexed -> embedded -> curated. The scan handler must NOT enqueue curator work:
+# at that point the project is indexed and its vectors do not exist yet, so
+# curation would race embedding. The enqueue belongs to the embed stage, gated on
+# the project being fully embedded. It also kept a one-row-per-symbol INSERT on
+# the synchronous path of /v1/code/scan (~173,000 rows, ~215s on a 4,018-file
+# corpus, against a 300s client deadline), so a drift back here is both a
+# correctness and a latency regression.
+scan_enqueues=$(grep -c 'kb_curator_queue_code_units_for_project' ../src/kb/http/kb_http_code.c 2>/dev/null || true)
+embed_enqueues=$(grep -c 'kb_curator_queue_code_units_for_project' ../src/modules/kb-synthesis/kb_curator_drain.c 2>/dev/null || true)
+embed_gated=$(grep -c 'kb_code_embed_project_fully_embedded' ../src/modules/kb-synthesis/kb_curator_drain.c 2>/dev/null || true)
+if [ "$scan_enqueues" -eq 0 ] && [ "$embed_enqueues" -ge 1 ] && [ "$embed_gated" -ge 1 ]; then
+    pass "curator work is enqueued by the embed stage, not by the scan handler"
+else
+    fail "curation must be enqueued after embedding, not during scan (scan=$scan_enqueues, embed=$embed_enqueues, gated=$embed_gated)"
+fi
+
 if [ "$FAIL" = "0" ]; then
     if [ "$MODE" = "--build-variants" ]; then
         echo "All build variant checks passed."
@@ -1566,3 +1584,4 @@ else
     fi
     exit 1
 fi
+

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -27,6 +27,20 @@
  * with the extract gates disabled so the real config_load() the queue functions
  * call reports the gate off deterministically (and the run never touches the
  * developer's real ~/.config/aimee). */
+/* The single place this test binary names config_t. Every case that needs a
+ * different extract-code gate goes through here rather than loading its own copy:
+ * config_t is a secret of the config module, and one reader is the budget. */
+static void ccu_set_extract_code_gate(int on)
+{
+   config_t cfg;
+   config_load(&cfg);
+   cfg.kb_curator_extract_code_enabled = on;
+   cfg.kb_curator_extract_docs_enabled = 0;
+   if (!on)
+      cfg.synthesis_endpoint[0] = '\0';
+   config_save(&cfg);
+}
+
 static void test_force_curator_gate_off(void)
 {
    static char dir[] = "/tmp/aimee-curtest-XXXXXX";
@@ -36,11 +50,7 @@ static void test_force_curator_gate_off(void)
    done = 1;
    if (mkdtemp(dir))
       setenv("AIMEE_HOME", dir, 1);
-   config_t cfg;
-   config_load(&cfg);
-   cfg.kb_curator_extract_code_enabled = 0;
-   cfg.kb_curator_extract_docs_enabled = 0;
-   config_save(&cfg);
+   ccu_set_extract_code_gate(0);
 }
 
 /* Forward declarations (headers live in src/, not src/headers/). The opts struct
@@ -831,11 +841,7 @@ static void test_queue_code_units_skipped_without_synthesis_endpoint(void)
                        " VALUES (1,'fn_one','definition',1),(1,'fn_two','definition',2)",
                        NULL, NULL, NULL) == SQLITE_OK);
 
-   config_t cfg;
-   config_load(&cfg);
-   cfg.kb_curator_extract_code_enabled = 1;
-   cfg.synthesis_endpoint[0] = '\0';
-   config_save(&cfg);
+   ccu_set_extract_code_gate(1);
    unsetenv("SYNTHESIS_ENDPOINT");
 
    /* The fixture really does have rows to enqueue, so "nothing was enqueued" below
@@ -859,9 +865,7 @@ static void test_queue_code_units_skipped_without_synthesis_endpoint(void)
    assert(ccu_count(db, "SELECT count(*) FROM kb_code_unit_jobs") == 0);
    unsetenv("SYNTHESIS_ENDPOINT");
 
-   config_load(&cfg);
-   cfg.kb_curator_extract_code_enabled = 0;
-   config_save(&cfg);
+   ccu_set_extract_code_gate(0);
    db2_test_shim_close();
    printf("  PASS: code-unit enqueue skipped when no synthesis endpoint can consume the rows\n");
 }

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -794,6 +794,78 @@ static void test_stale_generation_job_is_not_claimed(void)
    printf("  PASS: stale-generation code-unit job is not claimed for a re-added path\n");
 }
 
+static int ccu_count(sqlite3 *db, const char *sql)
+{
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   int n = (sqlite3_step(st) == SQLITE_ROW) ? sqlite3_column_int(st, 0) : -1;
+   sqlite3_finalize(st);
+   return n;
+}
+
+/* The rows this enqueue writes have exactly one consumer: extract_code, which runs
+ * the synthesis sidecar. With the stage ENABLED but no endpoint configured, not one
+ * of them can ever reach 'done' -- and the enqueue is not free. It runs on the
+ * synchronous path of /v1/code/scan and inserts one row per symbol: measured on a
+ * 4,018-file corpus, ~173,000 rows and 100 MB of table, adding ~215s to every scan
+ * for work that cannot start. It compounds too, since the enqueue's anti-join scans
+ * the table every later scan keeps growing.
+ *
+ * Both halves matter. Asserting only "nothing was enqueued" would pass just as well
+ * if the fixture were wrong and there had been nothing to enqueue in the first
+ * place, so the same corpus is enqueued again WITH an endpoint configured. */
+static void test_queue_code_units_skipped_without_synthesis_endpoint(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   assert(db != NULL);
+   assert(sqlite3_exec(db,
+                       "INSERT INTO projects"
+                       " (id,name,root,scanned_at,lifecycle_state,current_generation)"
+                       " VALUES (1,'p','/p','t','current',1);"
+                       "INSERT INTO files"
+                       " (id,project_id,generation,path,scanned_at)"
+                       " VALUES (1,1,1,'a.c','t');"
+                       "INSERT INTO terms (file_id,name,kind,line)"
+                       " VALUES (1,'fn_one','definition',1),(1,'fn_two','definition',2)",
+                       NULL, NULL, NULL) == SQLITE_OK);
+
+   config_t cfg;
+   config_load(&cfg);
+   cfg.kb_curator_extract_code_enabled = 1;
+   cfg.synthesis_endpoint[0] = '\0';
+   config_save(&cfg);
+   unsetenv("SYNTHESIS_ENDPOINT");
+
+   /* The fixture really does have rows to enqueue, so "nothing was enqueued" below
+    * cannot pass for the trivial reason that there was nothing to insert. */
+   assert(ccu_count(db, "SELECT count(*) FROM terms") == 2);
+
+   assert(kb_curator_queue_code_units_for_project("p", "/p") == 0);
+   assert(ccu_count(db, "SELECT count(*) FROM kb_code_unit_jobs") == 0);
+
+   /* Configured (not necessarily reachable): the rows become real work again, and a
+    * transient outage is the drain's provider gate to handle, not this one's.
+    *
+    * Asserted as "gets past the gate", not "inserts 2 rows": the enqueue is one
+    * PostgreSQL statement (DISTINCT ON, ::int) that the sqlite shim cannot prepare,
+    * so it returns -1 here. That still separates the two paths exactly where it
+    * matters -- unconfigured short-circuits BEFORE the statement (0, no DB touched),
+    * configured reaches it (-1 from prepare). Coverage that the statement itself
+    * enqueues correctly belongs on a PostgreSQL-backed test, not this shim. */
+   setenv("SYNTHESIS_ENDPOINT", "http://synth.invalid:8742", 1);
+   assert(kb_curator_queue_code_units_for_project("p", "/p") == -1);
+   assert(ccu_count(db, "SELECT count(*) FROM kb_code_unit_jobs") == 0);
+   unsetenv("SYNTHESIS_ENDPOINT");
+
+   config_load(&cfg);
+   cfg.kb_curator_extract_code_enabled = 0;
+   config_save(&cfg);
+   db2_test_shim_close();
+   printf("  PASS: code-unit enqueue skipped when no synthesis endpoint can consume the rows\n");
+}
+
 int main(void)
 {
    printf("curator_code_unit:\n");
@@ -826,6 +898,7 @@ int main(void)
 
    test_queue_counts_surface_failures();
    test_stale_generation_job_is_not_claimed();
+   test_queue_code_units_skipped_without_synthesis_endpoint();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -4984,7 +4984,13 @@ static void test_code_scan_ok(void)
    assert(strcmp(g_code_scan_project, "proj-alpha") == 0);
    assert(strcmp(g_code_scan_root_path, "/tmp/repo") == 0);
    assert(g_code_scan_force == 1);
-   assert(g_curator_code_queued == 1);
+   /* A scan INDEXES; it does not curate. Curation is enqueued by the embed stage
+    * once the project is fully embedded, so the pipeline order is
+    * indexed -> embedded -> curated rather than indexed -> curated (racing embed).
+    * Enqueuing here also put a one-row-per-symbol INSERT on the synchronous path
+    * of this request -- ~173,000 rows and ~215s on a 4,018-file corpus, against a
+    * client that times out at 300s. */
+   assert(g_curator_code_queued == 0);
 }
 
 static void test_code_project_lifecycle_routes(void)
@@ -5079,10 +5085,11 @@ static void test_code_scan_pushed_files_ok(void)
    assert(strcmp(g_code_scan_file_rel, "src/a.c") == 0);
    assert(strstr(g_code_scan_file_content, "pushed") != NULL);
    assert(g_code_scan_files_force == 1);
-   /* The push path now queues code units for the curator just like a local scan
-    * (the queue reads from DB2 by project name and self-gates on the curator
-    * flag), so with the stubbed config_load reporting the gate on, it enqueues. */
-   assert(g_curator_code_queued == 1);
+   /* Same for a thin-client push: it indexes, it does not curate. The embed sweep
+    * reaches these projects by NAME, so nothing is lost by not enqueuing here --
+    * the push path never needed its own enqueue, it needed the embed stage to own
+    * one. */
+   assert(g_curator_code_queued == 0);
 }
 
 static void test_code_scan_pushed_files_rejects_invalid_item(void)


### PR DESCRIPTION
## The shape of the bug

Enabling a stage is not the same as being able to run it. Both the code-unit enqueue and the curator's LLM lane ran whenever their config gate was ON, with no check that the synthesis provider those rows exist for was configured at all.

On a deployment with no `SYNTHESIS_ENDPOINT`, that builds a backlog which cannot start.

## Measured on a bench box

| | |
|---|--:|
| `kb_code_unit_jobs` rows | **173,458** |
| table size | **100 MB** |
| `terms` | 175,138 |
| `code_unit_done` | **0** |
| `code_unit_pending` growth | ~25/sec |

Roughly one dead job per symbol, and **not one had ever succeeded**.

`index scan` of a 1,000-file subset, same box, same image, curator the only variable:

| curator | scan |
|---|--:|
| enabled | **300s** |
| `tier: off` | **85s** |

That ~215s is the enqueue itself. `kb_curator_queue_code_units_for_project` runs on the **synchronous path of `/v1/code/scan`** and inserts one row per symbol.

It also compounds: the enqueue's `NOT EXISTS` anti-join scans `kb_code_unit_jobs`, so every later scan of every later project pays for the dead rows each earlier scan left behind. On a benchmark that creates a fresh project per cell attempt, that is quadratic.

## The fix

Gate both the enqueue and the LLM lane on a synthesis endpoint being configured.

**The index lane deliberately keeps running.** It is gated on the *embedder*, not synthesis, and it owns `stage_embed_code` — the pass that writes `code_embeddings`. Stopping the whole curator when synthesis is absent would take code embedding down with it and leave a deployment *indexed but never embedded*, which is the opposite of what an operator running without a synth provider wants. Only the LLM lane and its `extract_code`/`extract_docs` workers are withheld.

**Configured-ness, not reachability.** A configured endpoint that is temporarily down is a real outage, its rows are real work, and the process-wide provider gate from #2298 already idles the queue instead of spinning. An *unconfigured* endpoint is a steady state no retry can resolve. Both call sites resolve it through `config_synth_chat_endpoint_current` — the same accessor the sidecar uses — so the two cannot disagree about what an operator's value means.

This is complementary to #2298, not a replacement: that classified the error correctly once it happened; this stops the work being created.

## Verification

New test asserts the enqueue writes nothing when unconfigured **while the fixture demonstrably has rows to enqueue** (so it cannot pass for the trivial reason), and that a configured endpoint gets *past* the gate to the statement. Confirmed **red before green**. Full curator unit suite passes; tree builds clean under `-Werror`.

## Note for a follow-up

PR #2300 merged the set-based enqueue but its regression test (`test_curator_enqueue_batching.c`) did not land in `testing` — the guard against regressing to one INSERT per symbol is currently absent. Worth bringing over separately.