### PR TITLE
fix: agent instructions — the index replaces the search, and listed tools are directly callable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,13 +97,35 @@ include_directories(
     "${AIMEE_SRC_DIR}/modules/response-composition/include"
     "${AIMEE_SRC_DIR}/modules/skills/include"
     "${AIMEE_SRC_DIR}/modules/routing/include"
-    # workflows keeps its headers flat beside its sources rather than under an
-    # include/ subdir, so it needs the module directory itself. src/Makefile has
-    # carried -Imodules/workflows all along; without the same entry here the
-    # thin-client CMake build compiled modules/workflows/*.c but could not find
-    # wfe_def.h from cmd_workflow.c -- breaking macos-build and windows-cmake
-    # while the Make build stayed green.
-    "${AIMEE_SRC_DIR}/modules/workflows")
+    # MODULES THAT KEEP THEIR HEADERS FLAT, beside their sources, rather than
+    # under an include/ subdir. src/Makefile has carried -I for every one of
+    # these all along; CMake had only the include/-style modules, so the
+    # thin-client build compiled these modules' sources while being unable to
+    # find their headers. That is why macos-build and windows-cmake failed on
+    # 'wfe_def.h' and then 'guardrails.h' (the latter reached from
+    # src/headers/aimee.h, so it broke translation units that never named a
+    # module at all) while the Make build stayed green.
+    #
+    # Listed to match src/Makefile rather than added one at a time as each new
+    # missing header surfaces: an unused -I costs nothing, and the next flat
+    # header should not be another red CI run.
+    "${AIMEE_SRC_DIR}/modules/workflows"
+    "${AIMEE_SRC_DIR}/modules/guardrails"
+    "${AIMEE_SRC_DIR}/modules/config"
+    "${AIMEE_SRC_DIR}/modules/economizer"
+    "${AIMEE_SRC_DIR}/modules/roadmap"
+    "${AIMEE_SRC_DIR}/modules/sandbox"
+    "${AIMEE_SRC_DIR}/modules/lsp"
+    "${AIMEE_SRC_DIR}/modules/css"
+    "${AIMEE_SRC_DIR}/modules/webuser"
+    "${AIMEE_SRC_DIR}/modules/governance"
+    "${AIMEE_SRC_DIR}/modules/vault"
+    "${AIMEE_SRC_DIR}/modules/roundtable"
+    "${AIMEE_SRC_DIR}/modules/kb_client"
+    "${AIMEE_SRC_DIR}/modules/kb-synthesis"
+    "${AIMEE_SRC_DIR}/modules/benchmarks"
+    "${AIMEE_SRC_DIR}/modules/aws"
+    "${AIMEE_SRC_DIR}/pipeline")
 
 # LTO / IPO: must be set BEFORE any target is declared so the setting takes
 # effect uniformly across aimee-core/data/agent/cmd and every test binary.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,14 @@ include_directories(
     "${AIMEE_SRC_DIR}/modules/git/include"
     "${AIMEE_SRC_DIR}/modules/response-composition/include"
     "${AIMEE_SRC_DIR}/modules/skills/include"
-    "${AIMEE_SRC_DIR}/modules/routing/include")
+    "${AIMEE_SRC_DIR}/modules/routing/include"
+    # workflows keeps its headers flat beside its sources rather than under an
+    # include/ subdir, so it needs the module directory itself. src/Makefile has
+    # carried -Imodules/workflows all along; without the same entry here the
+    # thin-client CMake build compiled modules/workflows/*.c but could not find
+    # wfe_def.h from cmd_workflow.c -- breaking macos-build and windows-cmake
+    # while the Make build stayed green.
+    "${AIMEE_SRC_DIR}/modules/workflows")
 
 # LTO / IPO: must be set BEFORE any target is declared so the setting takes
 # effect uniformly across aimee-core/data/agent/cmd and every test binary.

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -5,8 +5,8 @@
     "repository": "https://github.com/RakuenSoftware/aimee-core-c.git",
     "ref": "v0.4.0",
     "version": "0.4.0",
-    "commit": "15137232452d3bd63c476306d6f1e47f4594948c",
-    "source_sha256": "0d27a34340f28138d4d5450b9b3e843836c764be872b533d2e9b14df1c82b2ab"
+    "commit": "3773ecd6cd9e0115112f5fdbd1e7316cbf913c24",
+    "source_sha256": "17657c9f953832582af32a6259c26677aac059fd268ac499b9a336f9de531292"
   },
   "modules": [
     {
@@ -15,7 +15,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-module-runtime.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "23028d2040713216813c8ef0396be795c15e41d3",
+      "commit": "788a99d516f77a6373d597140962833abb055810",
       "execution": "core",
       "placements": [
         "server",
@@ -29,13 +29,13 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-config.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "2fe9ba3f5e7a6838e3fa2e1c1fec2d3c4dbbfa24",
+      "commit": "a0827ae9836eea5a19f6f6f9062741204ef28f76",
       "execution": "core",
       "placements": [
         "server",
         "kb"
       ],
-      "source_sha256": "c29eed55823c0e3d64de053d2daae1c5fe1f956372de19e572f9e869bece7ff1"
+      "source_sha256": "9026b1b57e55b8c338a60bf9aaf04923438e1dba193bad07db3f1ad82b471abc"
     },
     {
       "id": "ir",
@@ -43,7 +43,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-ir.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "5688d824905689e576c4d67f58999db908609100",
+      "commit": "29e9e6163ce869d4ea05e32e4c6ff9b82845341d",
       "execution": "core",
       "placements": [
         "server",
@@ -57,7 +57,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-translation.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "431989fcad7f43889b45ca90a4cfd5ef66bbe1f8",
+      "commit": "38cb5ca1cf43ec9f410842f7fd0e4ef2a4e9a36e",
       "execution": "core",
       "placements": [
         "server",
@@ -71,7 +71,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-protocols.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "40586415f37b480e268088b28ff5d8811d2f9037",
+      "commit": "96ac0e0a53fac18386f1e329822fd58fe9562596",
       "execution": "core",
       "placements": [
         "server",
@@ -85,7 +85,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-gateway.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "98b8b47b3792707f0cf7557f2c4fa9b8ce039949",
+      "commit": "be6128913e2777eeb3aa1add5bd383ce567451fa",
       "execution": "core",
       "placements": [
         "server",
@@ -99,12 +99,12 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-memory.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "ae078e0df1b3bd6fa6a1627b386960ac653acf36",
+      "commit": "9f00f13fcda3d0d3f7400796c9fbd35f8cacd831",
       "execution": "process",
       "placements": [
         "server"
       ],
-      "source_sha256": "32e3983fa372a3b6a5f67a446b57c2e8a202621a22baffd3aef022e1d4e466d8",
+      "source_sha256": "a91e6338f19aa5004b76ce8f342daf2a7aa0364ecdb7b8d9a989a2308f449ae2",
       "principal_class": 1,
       "principal_ref": 7,
       "serve": [
@@ -121,12 +121,12 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-learning.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "fc35686a373ff5bc19ce94645040f2b09e68d2b1",
+      "commit": "497903f4272d4646eca64aa32ebd3dc1600a1cd5",
       "execution": "process",
       "placements": [
         "server"
       ],
-      "source_sha256": "6f6c1f747b8984ff98c278f9c1fbf8a2013c01ab2875a8b3b645b3f955c4869e",
+      "source_sha256": "6c70d4abf4439102eaffabc8e954da68f073903aa1bc35e58373684c74d8ed37",
       "principal_class": 1,
       "principal_ref": 8,
       "serve": [
@@ -139,7 +139,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-routing.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "3f31673fb175bb13df2e6ed392a746252cb26b97",
+      "commit": "846a2898d2d784f6fe5ada9e697a443abfa15e5c",
       "execution": "process",
       "placements": [
         "server"
@@ -157,12 +157,12 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-delegates.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "e889dd122c7cf956f9076c184ae60b633b1cf779",
+      "commit": "275d682de1f76768b09281253b308f8409f1e1e2",
       "execution": "process",
       "placements": [
         "server"
       ],
-      "source_sha256": "62f27026691a46e65624eb3643aac2b88bfe9fe54a5a2f8984709f433d3df632",
+      "source_sha256": "04f967b554cff9d2422936bffe5e10951657bc5f255db08e155685ee9ab707c4",
       "principal_class": 1,
       "principal_ref": 10,
       "serve": [
@@ -175,7 +175,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-tools.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "7131fc427ce9f180f9728980bedfd3c54e9af0ce",
+      "commit": "a12986da574a7b3c83a0d0e1d79239e08919f27f",
       "execution": "process",
       "placements": [
         "server"
@@ -193,12 +193,12 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-workspace.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "ed7ead7cefeb2b19bea0a82642ec3a8cf4295607",
+      "commit": "217cfb03ed1cefef8918799df8a7cadf80014b41",
       "execution": "process",
       "placements": [
         "server"
       ],
-      "source_sha256": "2df4c2b6aceeb0b95542e34bb33570aa34a1c6714dc58a3726b83a6f91781c25",
+      "source_sha256": "17110b6ca4368264b32532a70db023b420cfe46ac4edf69a3d06155a4da1cc75",
       "principal_class": 1,
       "principal_ref": 12,
       "serve": [
@@ -211,12 +211,12 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-git.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "d386534d788a64aeb2ad6d5d80ca683585087d1f",
+      "commit": "a3aa23a6079944dc16297ba439cebce59ab118c0",
       "execution": "process",
       "placements": [
         "server"
       ],
-      "source_sha256": "9e1824a878145fe94c80b0a819bb7ebacfc41bf9a1d52131d82309c3d7b909b8",
+      "source_sha256": "13399e4650b378085e74aca003b74df977efad1f5a5dfca126b0cb956ae40c9a",
       "principal_class": 1,
       "principal_ref": 13,
       "serve": [
@@ -229,7 +229,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-skills.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "53704f0f94ae2763f2d2e00e7b31707093752abf",
+      "commit": "e870ac5bdf286a878d8e8fa24379c8630fb879a4",
       "execution": "process",
       "placements": [
         "server"
@@ -247,7 +247,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-response-composition.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "0edbe3667bc3231f3bca4e098a2d52cbca186656",
+      "commit": "fbd1769f50adf5b85e467130300a902be51d2f47",
       "execution": "process",
       "placements": [
         "server"
@@ -265,7 +265,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-vault.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "7550b57cf646d47a211999f58bc57bbfe2e34233",
+      "commit": "4462becaf4c270e7f9ef26e042c5f3129f14ddee",
       "execution": "core",
       "placements": [
         "server",
@@ -279,7 +279,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-execution-policy.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "dd481160f1a3df76f3efd09ee0403cbba440afae",
+      "commit": "b3620de2672132bfdd96680b066c7c6e87a2339d",
       "execution": "core",
       "placements": [
         "server",
@@ -293,7 +293,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-audit.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "f00376abd4c92f5f7542208b75381ebac7161414",
+      "commit": "ddae341f9560fd1260b970734495b2618f331d4f",
       "execution": "core",
       "placements": [
         "server",
@@ -307,7 +307,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-governance.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "d090f44046168c760b3d517170495a28fba52273",
+      "commit": "40c5139700c6aaad562f9e57e7ba164ae95e443b",
       "execution": "process",
       "placements": [
         "server"
@@ -325,12 +325,12 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-workflows.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "25668d254a44854e3e720e0cc3bab0e5b11db308",
+      "commit": "72bcc5d8bce060c5b4d8986c4e8a1c24a61c7fab",
       "execution": "process",
       "placements": [
         "server"
       ],
-      "source_sha256": "34692581bc56530a90c2e112f42c96e647f77f9008e9a65014dcdae9bed23a75",
+      "source_sha256": "71691b081e9dd3ad5627e69c682526923911261f9a9ba07f2ec07a705a5a7c47",
       "principal_class": 1,
       "principal_ref": 20,
       "serve": [
@@ -343,7 +343,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-roundtable.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "e9a45bd0e0029bdee234901641547723d4e2017c",
+      "commit": "eb6b42918567e377fd0df45f6dd2d24606ef92e0",
       "execution": "process",
       "placements": [
         "server"
@@ -361,12 +361,12 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-kb-synthesis.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "1735c9d4003283a754eaa31f265cbc00c92d6218",
+      "commit": "a8252292880c11342f311b4739add926f776541f",
       "execution": "process",
       "placements": [
         "kb"
       ],
-      "source_sha256": "835682519c1c72181d8fecf13a1efed8ccaa69d4f322368ee222865ab2525b24",
+      "source_sha256": "b20c4b2b808f60826762b88d60dfa3be6dbf76728020719f7a83146a639ad978",
       "principal_class": 1,
       "principal_ref": 22,
       "serve": [
@@ -379,7 +379,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-runtime-web.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "2b50f7087d0b3e32e6430fcdfbb169dedfd9b63a",
+      "commit": "4b037a9c35e39b20b36e6cb8728df39fae5d2d28",
       "execution": "process",
       "placements": [
         "server"
@@ -397,7 +397,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-control-web.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "5ffa70f2a5f66c6d6ae95d7cf9cc2576a470899e",
+      "commit": "7bd29a9bb7b67dc84a0bec9cec15d10c9412ee4f",
       "execution": "process",
       "placements": [
         "kb"
@@ -415,7 +415,7 @@
       "repository": "https://github.com/RakuenSoftware/aimee-module-benchmarks.git",
       "ref": "v0.4.0",
       "version": "0.4.0",
-      "commit": "44817aa0792e142c41b415dc6a56c1d1af4610e5",
+      "commit": "ae1e67291c2ab1d688b38eea3fdff7b10031d123",
       "execution": "process",
       "placements": [
         "server",

--- a/src/Makefile
+++ b/src/Makefile
@@ -1292,6 +1292,19 @@ token-roots-provisioner-isolation-check:
 
 token-roots-provisioner-core: token-roots-provisioner-isolation-check $(KB_TOKEN_ROOTS_PROVISIONER)
 
+# THESE LINK THE CORE ARCHIVE THROUGH L_KB BUT ARE NOT IN THE PRODUCT LIST.
+#
+# $(BINARY)/$(SERVER)/$(GATEWAY) name $(CORE_CONNECTION_LIB) as a real
+# prerequisite, and tests get it from `$(TEST_TARGETS): | $(CORE_CONNECTION_LIB)`
+# in tests/Rules.mk. These auxiliary drivers got neither, so on a clean tree they
+# reached the link step before the archive existed and died with
+# "cannot find build/obj/libaimee-core-connection.a" -- which is what kept
+# identity-mint-e2e, oidc-login-live and vault-pkcs11-token red.
+#
+# Order-only: the archive must EXIST first, but relinking it should not force
+# these to relink.
+$(KB_TOKEN_ROOTS_PROVISIONER) $(KB_JWKS_PUBLISHER) ../oidc-login-live: | $(CORE_CONNECTION_LIB)
+
 $(KB_TOKEN_ROOTS_PROVISIONER): $(TOKEN_ROOTS_PROVISIONER_OBJS) \
                                $(TOKEN_ROOTS_PROVISIONER_VAULT_OBJS) \
                                $(STATUS_PROVISIONER_PLATFORM_OBJS) \

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -456,16 +456,31 @@ static void handle_initialize(cJSON *id)
    cJSON_AddStringToObject(info, "version", MCP_VERSION);
    cJSON_AddItemToObject(result, "serverInfo", info);
 
+   /* EVERY TOOL IN tools/list IS DIRECTLY CALLABLE. SAY SO FIRST.
+    *
+    * This text used to open with "call get_help() before trying anything else"
+    * and then describe find_tools -> describe_tool -> call_tool as the way to
+    * reach tools. Agents read that as the normal path and spent their tool budget
+    * on the protocol rather than the work. Measured twice now: once at five of
+    * fourteen calls, and again on a benchmark cell that made two find_tools, two
+    * describe_tool and two call_tool calls and NOT ONE direct find_symbol -- while
+    * find_symbol was in the advertised list the whole time, one call away.
+    *
+    * Discovery is for what is NOT in the list. Leading with it taxes every session
+    * to buy something almost none of them need. */
    static const char *const base_instructions =
-       "When you are unsure how aimee works — work queue, delegation, memory, git, "
-       "build, conventions — call get_help() before trying anything else. It "
-       "returns the authoritative topic index. Pass a topic name for details "
-       "(e.g. get_help(\"work queue\")). The tools/list is a curated core set; the "
-       "full catalog is larger — call find_tools(\"<keyword>\") to discover more "
-       "tools and describe_tool(\"<name>\") for a tool's full input schema, then "
-       "call call_tool with that name and matching arguments. Do "
-       "not use provider-native sub-agent tools such as spawn_agent or Agent; use "
-       "the aimee delegate tool for delegated work.";
+       "The tools in tools/list are directly callable — call them directly, by "
+       "name, with their arguments. Do not route a listed tool through call_tool, "
+       "and do not look one up before using it. find_symbol, "
+       "preview_blast_radius, search_docs and search_memory are listed: use them "
+       "as your first move on repository questions rather than after a shell "
+       "search. Only when you need a tool that is NOT listed: find_tools("
+       "\"<keyword>\") to locate it, describe_tool(\"<name>\") for its schema, "
+       "then call_tool with that name and matching arguments. get_help(\"<topic>\") "
+       "explains how aimee itself works — work queue, delegation, memory, git, "
+       "build, conventions — when you are unsure; it is not a required first step. "
+       "Do not use provider-native sub-agent tools such as spawn_agent or Agent; "
+       "use the aimee delegate tool for delegated work.";
 
    /* Isolate before serving any tool call, and tell the caller where its work
     * will land — the host's own idea of the cwd is now stale for aimee's tools. */

--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -283,28 +283,51 @@ static const char *codex_skill_markdown(void)
           "\n"
           "Use this plugin when Codex needs repository memory or aimee-specific helpers.\n"
           "\n"
-          /* This list used to open with "prefer local file inspection first for
-           * nearby code" and offer find_symbol only "when the local search
-           * surface is missing indexed context" — i.e. the index as a fallback
-           * after grep. Agents followed it exactly: measured over a four-task
-           * benchmark with a verified-healthy index, every cell read this file
-           * and then made ZERO index calls, resolving everything with three to
-           * four recursive greps. The instruction, not the tooling, was the
-           * reason. Lead with the questions the index answers better, and keep
-           * reading files for what reading files is actually for. */
-          "- Reading a file you already know the path of: just read it.\n"
+          /* TWO REVISIONS, TWO DIFFERENT FAILURES — BOTH CAUSED BY THIS TEXT.
+           *
+           * v1 opened with "prefer local file inspection first for nearby code"
+           * and offered find_symbol only "when the local search surface is
+           * missing indexed context" — the index as a fallback after grep.
+           * Agents followed it exactly: over a four-task benchmark with a
+           * verified-healthy index, every cell read this file and then made ZERO
+           * index calls, resolving everything with three to four recursive greps.
+           *
+           * v2 (leading with the questions the index answers) fixed the zero-call
+           * problem but was ADDITIVE: it said what to use the index for without
+           * saying what to stop doing. Agents then did both. Measured over eight
+           * tasks against the same corpus, the aimee arm ran 1.5-2.4x the commands
+           * of the plain-codex arm (22 vs 9 on one task) and cost up to 4.4x as
+           * much, while making 2 index calls. The extra spend was not the index:
+           * every command's output stays in the conversation and is re-sent on
+           * every later turn, so cost grows with the SQUARE of the command count.
+           * One unfiltered `rg --files` early in a run carried ~24k tokens for the
+           * rest of it.
+           *
+           * So this list has to be substitutive and it has to bound exploration.
+           * The index replacing a search is the entire point; an index used
+           * alongside the search it was meant to replace is pure overhead. */
+          "**Start from the index, not from a survey of the repository.** Do not "
+          "orient yourself by listing files, walking directories, or reading whole "
+          "files to see what is there. Every command's output stays in context for "
+          "the rest of this session, so a repo-wide listing costs more than the "
+          "answer it was meant to find.\n"
+          "\n"
           "- Locating a definition, or finding every caller of something: use "
           "`" AIMEE_CODE_TOOL_FIND_SYMBOL
           "`. It answers from the index in one call, and it is exact where a "
           "recursive text search is a guess that also matches comments, strings "
-          "and unrelated names.\n"
+          "and unrelated names. It REPLACES that search — do not also grep for "
+          "the same symbol to confirm it.\n"
           "- Before changing anything shared, or editing more than one file: use "
           "`" AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS
           "` to see what depends on it. A grep for the symbol will not tell you "
           "what breaks.\n"
           "- Use `search_memory` for stored project facts or prior decisions.\n"
-          "- Reach for a recursive grep when you need text that is not a code "
-          "symbol, or when the index has no answer.\n"
+          "- Reading a file the index has already pointed you at: just read it, "
+          "and read the range you need rather than the whole file.\n"
+          "- Recursive grep is for text that is not a code symbol, or for when the "
+          "index has no answer. Scope it to a path when you use it. Never run it "
+          "over the whole tree to find out what the tree contains.\n"
           "- Do not call provider-native sub-agent tools such as `spawn_agent`; use "
           "the aimee `delegate` MCP tool for every delegated or parallel sub-task.\n"
           "- Use `delegate` only for bounded sub-tasks that materially advance the "
@@ -343,9 +366,17 @@ static const char *codex_skill_markdown_effective(void)
 
 static const char *codex_code_exploration_prompt(void)
 {
+   /* "instead of" is load-bearing: the index is a REPLACEMENT for the search, not
+    * an addition to it. The second sentence bounds exploration, because an agent
+    * that uses the index and then surveys the tree anyway pays for both — and the
+    * survey is the expensive half, since every command's output is re-sent on every
+    * later turn. See the measurement in codex_skill_markdown(). */
    return "Explore the codebase through aimee's tools (" AIMEE_CODE_TOOL_FIND_SYMBOL
           ", " AIMEE_CODE_TOOL_AST_GREP_SEARCH ", " AIMEE_CODE_TOOL_INDEX
-          " command=" AIMEE_CODE_INDEX_COMMAND_HYBRID ") instead of raw grep/read";
+          " command=" AIMEE_CODE_INDEX_COMMAND_HYBRID
+          ") instead of raw grep/read. Do not survey the repository first: no "
+          "repo-wide file listings, no directory walks, no reading whole files to "
+          "orient. Ask the index, then read only what it points at.";
 }
 
 static void ensure_codex_marketplace(const char *path)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3511,6 +3511,12 @@ $(OBJDIR)/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/
 # Order-only dep on a fetch target so a cold checkout fetches tree_sitter/api.h before
 # this object (which includes it) is compiled (see the same note in src/Makefile).
 $(OBJDIR)/code_treesitter.o: | vendor/tree-sitter/lib/src/lib.c
+# The blanket `$(TEST_TARGETS): | $(CORE_CONNECTION_LIB)` earlier in this file
+# expands TEST_TARGETS where it is written, and this target appends itself
+# BELOW that line -- so it never inherited the dependency. It still links the
+# archive through L_CORE, so a clean tree failed with "cannot find
+# build/obj/libaimee-core-connection.a" at link time.
+$(TESTPREFIX)/unit-test-code-treesitter: | $(CORE_CONNECTION_LIB)
 $(TESTPREFIX)/unit-test-code-treesitter: $(OBJDIR)/tests/test_code_treesitter.o \
                                          $(OBJDIR)/code_treesitter.o \
                                          $(OBJDIR)/extractors.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -5287,6 +5287,9 @@ P11KIT_HARNESS_CFLAGS := -DWITH_PKCS11 $(shell pkg-config --cflags p11-kit-1 2>/
 $(OBJDIR)/tests/vault_custody_pkcs11_hsm.o: modules/vault/vault_custody_pkcs11.c
 	@mkdir -p $(dir $@)
 	$(CC) -c $(C_FLAGS) $(P11KIT_HARNESS_CFLAGS) -o $@ $<
+# Appended to TEST_TARGETS below the blanket order-only rule (or not at all), so
+# it never inherited the core-archive dependency it links through TEST_L_FLAGS.
+$(TESTPREFIX)/p7-pkcs11-harness: | $(CORE_CONNECTION_LIB)
 $(TESTPREFIX)/p7-pkcs11-harness: $(OBJDIR)/tests/test_vault_custody_pkcs11.o \
                               $(OBJDIR)/tests/vault_custody_pkcs11_hsm.o \
                               $(OBJDIR)/modules/vault/vault_crypto.o \

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -740,6 +740,25 @@ static void test_initialize(void)
    assert(strstr(instructions->valuestring, "spawn_agent") != NULL);
    assert(strstr(instructions->valuestring, "delegate tool") != NULL);
    assert(strstr(instructions->valuestring, "isolated checkout") == NULL);
+
+   /* LISTED TOOLS ARE DIRECTLY CALLABLE, AND THE TEXT MUST LEAD WITH THAT.
+    *
+    * Twice now agents have spent their tool budget on the discovery protocol
+    * instead of the work: once at five of fourteen calls, and again on a
+    * benchmark cell that made two find_tools, two describe_tool and two call_tool
+    * calls and not one direct find_symbol -- with find_symbol advertised the
+    * whole time. Pin the ordering, because the ordering is the behaviour. */
+   {
+      const char *ins = instructions->valuestring;
+      assert(strstr(ins, "directly callable") != NULL);
+      assert(strstr(ins, "Do not route a listed tool through call_tool") != NULL);
+      /* Discovery must be framed as the exception, i.e. introduced only after the
+       * direct-call rule, and explicitly for tools that are NOT listed. */
+      assert(strstr(ins, "NOT listed") != NULL);
+      assert(strstr(ins, "directly callable") < strstr(ins, "find_tools"));
+      /* get_help must not be ordered before doing any work. */
+      assert(strstr(ins, "before trying anything else") == NULL);
+   }
    assert(g_worktree_ensure_calls == 1);
    assert(g_reverse_channel_starts == 0);
 

--- a/src/tests/test_client_integrations.c
+++ b/src/tests/test_client_integrations.c
@@ -89,6 +89,31 @@ static void test_codex_delegate_policy_is_explicit(void)
    assert(strstr(code_prompt, AIMEE_CODE_TOOL_INDEX) != NULL);
    assert(strstr(code_prompt, AIMEE_CODE_INDEX_COMMAND_HYBRID) != NULL);
    assert(strstr(code_prompt, "search_graph") == NULL);
+
+   /* THE GUIDANCE MUST BE SUBSTITUTIVE, AND IT MUST BOUND EXPLORATION.
+    *
+    * Both properties have already regressed once each, and neither failure looked
+    * like a bug in the tooling:
+    *
+    *  - Offering the index as a FALLBACK after grep produced ZERO index calls
+    *    across a four-task benchmark on a verified-healthy index.
+    *  - Naming what the index is for without saying what to stop doing produced
+    *    an ADDITIVE agent: it used the index AND ran the full shell survey, 1.5
+    *    to 2.4x the commands of plain codex, for up to 4.4x the cost. Command
+    *    output is re-sent every later turn, so cost grows with the square of the
+    *    command count and the survey dominates.
+    *
+    * Pin both properties as text, because that is where they live. */
+   assert(strstr(code_prompt, "instead of raw grep/read") != NULL);
+   assert(strstr(code_prompt, "Do not survey the repository") != NULL);
+
+   /* The index replaces the search rather than confirming it. */
+   assert(strstr(skill, "REPLACES that search") != NULL);
+   /* No orienting by enumeration -- that is the expensive half. */
+   assert(strstr(skill, "Start from the index, not from a survey") != NULL);
+   assert(strstr(skill, "Never run it over the whole tree") != NULL);
+   /* The v1 phrasing that caused the zero-index-call run must not come back. */
+   assert(strstr(skill, "prefer local file inspection first") == NULL);
 }
 
 static void test_mcp_config_uses_resolved_command(void)


### PR DESCRIPTION
Two instruction defects with one root cause: text that named what aimee's tools are *for* without saying what to *stop doing*. Agents read it as additive and did both — the aimee work **and** the exploration they would have done anyway.

Measured on the ponytail benchmark: 8 tasks, same corpus, same model, same harness, aimee arm against plain codex.

## 1. The skill said what to use the index for, never what it replaces

| task | arm | commands | carried tokens | credits |
|---|---|--:|--:|--:|
| am_e1af40a0f5 | baseline | 9 | 119,060 | 16.6 |
| am_e1af40a0f5 | aimee | 22 | 1,098,837 | **72.8** |
| am_12b43fa38e | baseline | 17 | 857,806 | 43.7 |
| am_12b43fa38e | aimee | 37 | 2,589,170 | **125.6** |

The extra spend is the commands, not the index. Every command's output is re-sent on every later turn, so an early unfiltered `rg --files` carried ~24k tokens for the rest of the run.

This is the **second** regression from this text, and neither looked like a tooling bug:

- **v1** offered the index as a *fallback* after grep — produced **zero** index calls across a four-task benchmark on a verified-healthy index.
- **v2** led with the index but stayed permissive about everything else — produced the additive agent above.

Now substitutive and bounded: start from the index; `find_symbol` **REPLACES** the search rather than confirming it; read only the range the index points at; never enumerate the tree to learn what it contains. Same change to `codex_code_exploration_prompt()`.

## 2. The MCP instructions taught a discovery protocol for tools already listed

`base_instructions` opened with *"call `get_help()` before trying anything else"*, then described `find_tools` → `describe_tool` → `call_tool` as the way to reach tools. A benchmark cell then spent 2×`find_tools`, 2×`describe_tool`, 2×`call_tool` and made **not one direct `find_symbol`** — while `find_symbol` sat in the advertised `tools/list` the entire time.

`mcp_tool_profile.c` already records this failing once before, at five of fourteen calls. Adding tools to the floor does not help while the text still says to discover them. No detection is needed either: the server knows exactly what it advertised.

Now leads with the direct-call rule, names the code tools that answer repository questions, and frames discovery as the exception for tools that are **not** listed. `get_help` stays, as an explanation of how aimee works rather than a required first step.

## Result

Same task, same model, same harness; only instruction text changed between runs:

| | original | +index guidance | +MCP instructions |
|---|--:|--:|--:|
| credits | **72.8** | 39.8 | **29.6** |
| input tokens | 4,181,646 | 1,835,168 | 1,245,093 |
| carried tokens | 1,098,837 | 523,456 | 421,035 |
| commands | 22 | 18 | 18 |
| MCP calls | 2 | 6 (all discovery) | 2 (direct) |
| result | PASS | PASS | PASS |

Three cells re-run on the fixed build, all PASS: aimee **43.8 → 27.1 average (−38%)**, worst case **4.4× → 1.8×** baseline. Aimee moves from worst-in-field to level with `ponytail-instructions`.

## Verification

Both properties are pinned by tests. The MCP test asserts **ordering** — `"directly callable"` must appear before `"find_tools"` — because ordering is the behaviour; asserting presence alone would not have caught the original. The skill test also pins *out* the v1 phrasing that caused the zero-index-call run. Both confirmed **red before green** against the previous wordings.

## Limits, stated plainly

`replicates=1`. Codex is stochastic and there is no variance estimate here, so per-cell deltas cannot be separated from run-to-run noise — one of the three re-run cells came back flat (28.1 → 28.9) despite cutting commands 24%. The direction is consistent across three cells and two independent changes, but a replicate run is what would make these numbers reportable rather than indicative.

Two earlier models I offered for *why* cost scales (a fixed per-call overhead, then carried-token accumulation) were both falsified by later data and are not claimed here. What is claimed is the measured before/after.