### PR TITLE
fix(kb): no embedder is a failure, not a lexical fallback; number the release 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,6 +899,13 @@ jobs:
       - name: Init/migrate service routing smoke test
         run: cd src && make -j$(nproc) init-migrate-service-test
 
+      # Cheap and image-free: the gate that decides whether a kb may start without an
+      # embedder. Getting it wrong in either direction ships a broken deploy — too
+      # loose and an unconfigured kb serves nothing usable, too tight and the
+      # server-identity one-shot cannot run.
+      - name: KB entrypoint embedder gate
+        run: cd src && make kb-entrypoint-test
+
   windows-cmake:
     needs: change-scope
     if: ${{ !cancelled() && (needs.change-scope.result != 'success' || needs.change-scope.outputs.docs_only != 'true') }}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Start at the [documentation index](docs/README.md).
 | Document | Use it for |
 |----------|------------|
 | [Quickstart](docs/QUICKSTART.md) | Install, enroll, verify. |
-| [What's new](docs/WHATS_NEW.md) | Everything 0.3.1 changed, and what it removed. |
+| [What's new](docs/WHATS_NEW.md) | Everything 0.3.0 changed, and what it removed. |
 | [Upgrading](docs/UPGRADING.md) | Move from v0.2.192. One-way, so read it first. |
 | [Manual](MANUAL.md) | Day-to-day use and operations. |
 | [Architecture](docs/ARCHITECTURE.md) | Processes, storage, trust, request flow. |

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "7e3079dd0a932b67b0b7981157cb817a671da3b441278b81fa434b5c4f96c7b0",
+      "source_sha256": "6adc2295969341e9d974f120a2f1c5c72a061edcd782c5c59f6b5b9518c94753",
       "principal_class": 1,
       "principal_ref": 7,
       "serve": [

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "9026b1b57e55b8c338a60bf9aaf04923438e1dba193bad07db3f1ad82b471abc"
+      "source_sha256": "443044c3768e0e6d53cd7cab6aacac32269f215372f86d50f68b92818b6d673a"
     },
     {
       "id": "ir",
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "a91e6338f19aa5004b76ce8f342daf2a7aa0364ecdb7b8d9a989a2308f449ae2",
+      "source_sha256": "7e3079dd0a932b67b0b7981157cb817a671da3b441278b81fa434b5c4f96c7b0",
       "principal_class": 1,
       "principal_ref": 7,
       "serve": [
@@ -421,7 +421,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "06441cb5588ae414216a7c583c1181ee7a721f95e305c16465f57f4639e9a820",
+      "source_sha256": "09bb6e206ca1ae595f9de1eae2e1923d58a1ab2614622332ed6537b5f1c60bed",
       "principal_class": 1,
       "principal_ref": 25,
       "serve": [

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -35,21 +35,23 @@
 #   EMBEDDER_URL set  -> an external embedder; start nothing.
 #   EMBEDDER_MODEL set      -> the bundled embedder; start it.
 #   embedding_model in cfg  -> same, for a hand-run container.
-#   none of the above       -> start nothing. The kb falls back to its builtin lexical
-#                              embedder, which needs no model and no port, so an
-#                              unconfigured container is idle rather than half-configured.
+#   none of the above       -> REFUSE TO START.
 #
 # When it DOES start, the loopback URL is exported as EMBEDDER_URL. That makes the
 # bundled embedder just "an embedder at a URL" and reuses one precedence rule for both
 # cases, instead of a second mechanism that can disagree with the first.
 #
-# Starting is best-effort: the kb degrades honestly when embedding is unavailable, whereas
-# an entrypoint that refuses takes the whole knowledge base down with it.
+# Refusing is the point. There used to be a builtin lexical embedder behind this, so an
+# unconfigured container came up healthy and answered every search with keyword matching
+# — a deployment could run for weeks believing it had vector retrieval. It also claimed
+# the corpus: db2 recorded the fallback as the vector space, so choosing a real embedder
+# later was a space change the guard refused, and the kb never started again. A kb with
+# no embedder cannot do the one thing it exists for, and saying so at startup is cheaper
+# than discovering it from bad answers.
 # Ask the binary, never the file. This used to parse aimee.yaml with a sed regex, which
 # hardcoded the config paths and assumed a top-level `embedding_model:` key — a second
 # reader of a setting config owns. It worked only because config_save happens to write
-# the key at root, and it failed SILENTLY: an unparsed key reads as "nothing selected",
-# so the builtin serves forever and nothing says why.
+# the key at root, and it failed SILENTLY: an unparsed key reads as "nothing selected".
 read_cfg_embedding_model() {
     aimee-kb --print-embedding-model 2>/dev/null || true
 }
@@ -63,17 +65,21 @@ start_embedder() {
         EMBEDDER_MODEL="$(read_cfg_embedding_model)"
     fi
     if [ -z "$EMBEDDER_MODEL" ]; then
-        echo "aimee-kb: no embedder selected; the bundled model stays unloaded (the builtin" \
-             "lexical embedder serves until the wizard selects one)" >&2
-        return 0
+        echo "aimee-kb: no embedder selected, and there is no fallback. Retrieval needs one." >&2
+        echo "aimee-kb:   pick a bundled model:  aimee config set embedder_model bekko-a25m" >&2
+        echo "aimee-kb:   or point at your own:  EMBEDDER_URL=http://<host>:<port>" >&2
+        echo "aimee-kb: then re-run Deploy. Refusing to start." >&2
+        exit 1
     fi
     export EMBEDDER_MODEL
 
     venv="${EMBEDDER_VENV:-/opt/aimee/embedder-venv}"
     server=/opt/aimee/scripts/embedder-server.py
     if [ ! -x "$venv/bin/python" ] || [ ! -f "$server" ]; then
-        echo "aimee-kb: '$EMBEDDER_MODEL' selected but this image has no bundled embedder" >&2
-        return 0
+        echo "aimee-kb: '$EMBEDDER_MODEL' selected but this image has no bundled embedder." >&2
+        echo "aimee-kb: the aimee-kb image carries no weights — use aimee-kb-a25m or" >&2
+        echo "aimee-kb: aimee-kb-nomic, or set EMBEDDER_URL. Refusing to start." >&2
+        exit 1
     fi
     : "${EMBEDDER_PORT:=8760}"
     export EMBEDDER_PORT

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -56,7 +56,25 @@ read_cfg_embedding_model() {
     aimee-kb --print-embedding-model 2>/dev/null || true
 }
 
+# Is this container starting the KB SERVICE, or running a one-shot subcommand?
+#
+# The service is started with flags only (`--http-port=8741`, the image CMD). A one-shot
+# passes a bare subcommand first — `managed-server-identity install ...` is the managed
+# deploy's server-enrolment job, which runs this same image against the kb's volume and
+# never serves a query. Requiring an embedder of those jobs failed server identity
+# enrolment on every clean install, which is a deploy that half-succeeded: the kb was up
+# and the server could not talk to it.
+kb_is_serving() {
+    case "${1:-}" in
+    "" | -*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
 start_embedder() {
+    if ! kb_is_serving "$@"; then
+        return 0
+    fi
     if [ -n "${EMBEDDER_URL:-}" ]; then
         echo "aimee-kb: external embedder configured ($EMBEDDER_URL); bundled model not loaded" >&2
         return 0
@@ -104,6 +122,11 @@ start_embedder() {
 #
 # The mTLS material for the sidecar hop is issued by the kb at startup, not here;
 # see kb_synthesis_identity.c.
+
+# Sourcing stops here: everything above is definitions, everything below starts a
+# container. tests/test_kb_entrypoint.sh uses this to exercise the embedder gate without
+# a PostgreSQL cluster, a Vault, or an image.
+[ -n "${AIMEE_KB_ENTRYPOINT_SOURCE_ONLY:-}" ] && return 0
 
 set -e
 
@@ -224,7 +247,7 @@ if [ "$external_db" -eq 0 ]; then
     if "$PGBIN/pg_isready" --host="$PGSOCK" --quiet 2>/dev/null; then
         echo "aimee-kb: PostgreSQL already running on $PGSOCK; using it instead of" \
              "starting a second cluster" >&2
-        start_embedder
+        start_embedder "$@"
         run_kb_with_modules "$@"
         exit $?
     fi
@@ -318,7 +341,7 @@ if [ "$external_db" -eq 0 ]; then
     fi
     AIMEE_DB2_URL="$embedded_dsn" aimee-kb --bootstrap-vault-env
 
-    start_embedder
+    start_embedder "$@"
     start_modules
 
     # Not exec: the trap above has to outlive the kb so the cluster shuts down
@@ -377,6 +400,6 @@ if [ "$external_db" -eq 0 ]; then
     exit "$rc"
 fi
 
-start_embedder
+start_embedder "$@"
 run_kb_with_modules "$@"
 exit $?

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -9,11 +9,12 @@ Each KB configures the roles independently:
 
 | Role | Internal | Remote | Off |
 | --- | --- | --- | --- |
-| embedding | Run the selected embedder inside the KB container. | Call the configured embedding endpoint. | Dense retrieval is unavailable; lexical retrieval may continue. |
+| embedding | Run the selected embedder inside the KB container. | Call the configured embedding endpoint. | Not a supported state: a KB with no embedder refuses to start. |
 | synthesis | Run the selected synthesizer inside the KB container. | Call the configured synthesis endpoint. | Curator and answer-synthesis stages report degradation. |
 
-A KB can host either role, both roles, or neither. Available internal models depend on the KB image
-and deployment profile. A remote role uses an explicit endpoint and credential owned by that KB.
+A KB hosts the embedding role internally or remotely — never neither — and may host synthesis, or
+not. Available internal models depend on the KB image and deployment profile. A remote role uses an
+explicit endpoint and credential owned by that KB.
 
 The current configuration descriptors call internal placement `local`:
 

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -12,8 +12,8 @@ Each KB configures the roles independently:
 | embedding | Run the selected embedder inside the KB container. | Call the configured embedding endpoint. | Not a supported state: a KB with no embedder refuses to start. |
 | synthesis | Run the selected synthesizer inside the KB container. | Call the configured synthesis endpoint. | Curator and answer-synthesis stages report degradation. |
 
-A KB hosts the embedding role internally or remotely — never neither — and may host synthesis, or
-not. Available internal models depend on the KB image and deployment profile. A remote role uses an
+A KB hosts the embedding role internally or remotely, never neither, and may host synthesis or not.
+Available internal models depend on the KB image and deployment profile. A remote role uses an
 explicit endpoint and credential owned by that KB.
 
 The current configuration descriptors call internal placement `local`:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -209,9 +209,14 @@ aimee config set embedder_model bekko-a25m
 Confirm the model actually loaded rather than assuming it did:
 
 ```bash
-docker compose -f compose.server-managed.yaml logs aimee-kb | grep -i embedder
+docker compose -p aimee logs aimee-kb | grep -i embedder
 aimee kb status
 ```
+
+Address the managed services by project (`-p aimee`), not by the file you started the server with.
+`compose.server-managed.yaml` declares only `aimee-server`; the server brings `aimee-kb` and
+`aimee-llm` up from its own baked manifest into the same `aimee` project, so
+`-f compose.server-managed.yaml logs aimee-kb` fails with `no such service`.
 
 A loaded embedder logs its dimension and serving identity:
 
@@ -254,7 +259,7 @@ left running.
 Confirm the sidecar actually came up, rather than assuming Deploy succeeded:
 
 ```bash
-docker compose -f compose.server-managed.yaml logs aimee-llm | grep -iE 'synthesis|terminator'
+docker compose -p aimee logs aimee-llm | grep -iE 'synthesis|terminator'
 ```
 
 A working sidecar logs both halves:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -206,6 +206,12 @@ the step, set it from the server and re-run Deploy:
 aimee config set embedder_model bekko-a25m
 ```
 
+This works while the corpus is still empty. The lexical fallback is a placeholder, so a kb that has
+embedded nothing yet adopts the model you just chose. Once anything has been embedded the placeholder
+is a real vector space like any other, the change becomes a corpus migration, and the kb refuses the
+switch rather than mixing the two — see [Change the KB embedder](runbooks/change-embedder.md).
+Choosing in the wizard, before the first Deploy, avoids the question entirely.
+
 Confirm the model actually loaded rather than assuming it did:
 
 ```bash

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -191,26 +191,28 @@ A bundled embedder needs no download and no second container.
 start when it drifts, so moving between 384 and 768 means re-embedding the whole corpus. Choose before
 you ingest anything.
 
-Nothing is selected on a fresh install, and an unselected KB is not broken. It falls back to a
-builtin lexical embedder and says so once, in the KB log:
+Nothing is selected on a fresh install, and **a KB with no embedder refuses to start**. It says so
+and exits:
 
 ```text
-aimee-kb: no embedder selected; the bundled model stays unloaded (the builtin
-lexical embedder serves until the wizard selects one)
+aimee-kb: no embedder selected, and there is no fallback. Retrieval needs one.
+aimee-kb:   pick a bundled model:  aimee config set embedder_model bekko-a25m
+aimee-kb:   or point at your own:  EMBEDDER_URL=http://<host>:<port>
+aimee-kb: then re-run Deploy. Refusing to start.
 ```
 
-Retrieval still works in that state, but it is keyword matching, not vector search. If you skipped
-the step, set it from the server and re-run Deploy:
+There used to be a lexical fallback here, so an unconfigured KB came up healthy and answered every
+search with keyword matching. A deployment could run for weeks believing it had vector retrieval. It
+is gone. If you skipped the step, set it from the server and re-run Deploy:
 
 ```bash
 aimee config set embedder_model bekko-a25m
 ```
 
-This works while the corpus is still empty. The lexical fallback is a placeholder, so a kb that has
-embedded nothing yet adopts the model you just chose. Once anything has been embedded the placeholder
-is a real vector space like any other, the change becomes a corpus migration, and the kb refuses the
-switch rather than mixing the two — see [Change the KB embedder](runbooks/change-embedder.md).
-Choosing in the wizard, before the first Deploy, avoids the question entirely.
+Once anything has been embedded, changing the embedder is a corpus migration rather than a setting,
+and the KB refuses the switch rather than mixing two vector spaces — see
+[Change the KB embedder](runbooks/change-embedder.md). Choosing in the wizard, before the first
+Deploy, avoids the question entirely.
 
 Confirm the model actually loaded rather than assuming it did:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -210,7 +210,7 @@ aimee config set embedder_model bekko-a25m
 ```
 
 Once anything has been embedded, changing the embedder is a corpus migration rather than a setting,
-and the KB refuses the switch rather than mixing two vector spaces — see
+and the KB refuses the switch rather than mixing two vector spaces. See
 [Change the KB embedder](runbooks/change-embedder.md). Choosing in the wizard, before the first
 Deploy, avoids the question entirely.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,8 +5,8 @@ A release happens when a human approves one. Merging to `main` proposes a versio
 That is a change. Until 2026-07-31 every push to `main` tagged, built thin clients for four
 platforms, published `aimee-server` and `aimee-kb`, and moved `:latest`, with no one asked. Under the
 testing to main promote flow a promote merge is a push to `main`, so merging was releasing.
-`v0.2.196` and `v0.3.0` went out that way, mid-cycle, while **v0.2.192** stayed the last release
-anyone meant to make.
+`v0.2.196` went out that way, mid-cycle, while **v0.2.192** stayed the last release anyone meant to
+make.
 
 ## The two channels are not the same
 
@@ -76,10 +76,10 @@ If a tag survives a failed run, delete it by hand before the next release or tha
 
 ## A tag is not a release
 
-The repository can carry tags that were never released. `v0.2.196` and `v0.3.0` are both marked
-prerelease for exactly that reason: they exist, they have artifacts, and they are not releases anyone
-announced. As of 2026-08-01, the next approved release, `v0.3.1`, is the result from
-`api/releases/latest`.
+The repository can carry tags that were never released. `v0.2.196` is marked prerelease for exactly
+that reason: it exists, it has artifacts, and it is not a release anyone announced. The series has no
+`v0.3.*` tag yet, so the next approved release is `v0.3.0`, and it is what
+`api/releases/latest` will report once it ships.
 
 Do not read the tag list to decide what shipped. Read the releases, and check whether the one you are
 looking at is marked prerelease.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,15 +1,14 @@
 # Upgrading from v0.2.192
 
-There is no route back. 0.3.1 rewrites storage, credentials, and remote identity, and a 0.2 server
+There is no route back. 0.3.0 rewrites storage, credentials, and remote identity, and a 0.2 server
 will not read what it leaves behind. Your backup is the rollback plan; there is no downgrade
 command. Take the backup before step one, not after the first thing goes wrong.
 
 Read [What's new](WHATS_NEW.md) first. This cycle changes deployment, storage, credentials, remote
 identity, workflows, and removed commands.
 
-Do not install from the `v0.2.196` or `v0.3.0` tags. Both were promoted in error part-way through
-this cycle and are not releases; an installation from either is an untested mid-cycle build missing
-the fixes listed under
+Do not install from the `v0.2.196` tag. It was promoted in error part-way through this cycle and is
+not a release; an installation from it is an untested mid-cycle build missing the fixes listed under
 [If you installed from a mid-cycle tag](WHATS_NEW.md#if-you-installed-from-a-mid-cycle-tag).
 Several of those are cases where a fresh install came up healthy and silently did nothing useful.
 
@@ -46,7 +45,7 @@ Do not rely on a raw copy of a live SQLite main file. Take a consistent backup w
 
 ## This upgrade is one-way, by design
 
-0.3.1 does not preserve backwards compatibility, and that includes the image itself: once a server
+0.3.0 does not preserve backwards compatibility, and that includes the image itself: once a server
 volume has been booted by this release, an older image will not start on it again. It crash-loops
 with:
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -169,10 +169,14 @@ server log. A grant for the wrong spelling is a grant for nobody.
 ## The embedder and synthesis settings are renamed, with no aliases
 
 Every setting naming the embedder or the synthesis model changed name. There is no
-alias and no fallback: an old name is simply not read. A deployment that upgrades
-without editing its environment and `aimee.yaml` **keeps running and silently loses
-those settings**: the KB falls back to its builtin lexical embedder and synthesis
-goes idle. Nothing errors.
+alias: an old name is simply not read. A deployment that upgrades without editing its
+environment and `aimee.yaml` therefore reads as having no embedder configured, and
+**the KB refuses to start** rather than coming up without one. Synthesis goes idle,
+which is a supported state and does not stop anything.
+
+Earlier builds in this cycle did fall back to a builtin lexical embedder here, so the
+KB came up healthy and answered searches with keyword matching while the renamed
+settings sat unread. That fallback is gone precisely because nothing errored.
 
 | Old | New |
 | --- | --- |
@@ -197,9 +201,9 @@ Deleted outright, because the container they configured is retired and the
 still carrying `kb.curator.tier_b.*` is not an error: the key is ignored and
 rewriting the file drops it.
 
-**Check after upgrading**: `aimee config get embedder_model` and
-`aimee config get synthesis_endpoint` return what you expect, and the KB's health
-does not report the builtin lexical embedder.
+**Check before upgrading**: `aimee config get embedder_model` returns the embedder you
+mean to keep, under its new name. If it is empty, the KB will not start. Afterwards,
+`aimee config get synthesis_endpoint` should also return what you expect.
 
 ## One synthesis role, and thinking is now a setting
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,16 +1,16 @@
-# What's new in 0.3.1
+# What's new in 0.3.0
 
-0.3.1 is a one-way upgrade. It removes the combined image, the work queue, the inference container,
+0.3.0 is a one-way upgrade. It removes the combined image, the work queue, the inference container,
 the interactive TUI, and the generic RPC transport, and it will not read a 0.2 deployment back.
 Read [Upgrading](UPGRADING.md) before you start, not after.
 
 Everything below is measured against **v0.2.192**, the last public release.
 
-Two tags dated 2026-07-27 and 2026-07-28, `v0.2.196` and `v0.3.0`, appeared on the repository
-part-way through this cycle. Neither is a release. They were promoted mid-cycle in error, they were
-never announced, and the work below continued for another 536 commits after the later one. If you
-installed from either, you have an untested mid-cycle build rather than 0.3.1, and you are missing
-the fixes under [If you installed from a mid-cycle tag](#if-you-installed-from-a-mid-cycle-tag).
+One tag dated 2026-07-27, `v0.2.196`, appeared on the repository part-way through this cycle. It is
+not a release. It was promoted mid-cycle in error, it was never announced, and the work below
+continued for another 705 commits after it. If you installed from it, you have an untested mid-cycle
+build rather than 0.3.0, and you are missing the fixes under
+[If you installed from a mid-cycle tag](#if-you-installed-from-a-mid-cycle-tag).
 
 ## The event bus is the change everything else rests on
 
@@ -182,10 +182,10 @@ See [Event bus](EVENT_BUS.md).
 
 ## If you installed from a mid-cycle tag
 
-The `v0.2.196` and `v0.3.0` tags were promoted in error part-way through this cycle and are not
-releases. The cycle continued for another 536 commits after the later one, so an installation taken
-from either is missing the following. Each is a case where the deployment came up healthy and did
-nothing useful, which is why they are listed here rather than folded into the sections above.
+The `v0.2.196` tag was promoted in error part-way through this cycle and is not a release. The cycle
+continued for another 705 commits after it, so an installation taken from it is missing the
+following. Each is a case where the deployment came up healthy and did nothing useful, which is why
+they are listed here rather than folded into the sections above.
 
 - **The `aimee-llm` container is retired.** Embedding and synthesis are owned by the selected KB and
   can run inside its container or at its configured remote endpoint. After the wizard selects the

--- a/frontend/src/setup/DeployTopology.test.tsx
+++ b/frontend/src/setup/DeployTopology.test.tsx
@@ -31,12 +31,12 @@ const EMBEDDERS = [
 ];
 
 /** A fetch double over the three endpoints the page touches, recording config writes. */
-function harness(config: Record<string, unknown>) {
+function harness(config: Record<string, unknown>, catalog = EMBEDDERS) {
   const writes: { key: string; value: unknown }[] = [];
   const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
     const body = (payload: unknown) =>
       ({ ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) }) as unknown as Response;
-    if (url.startsWith('/api/embedders')) return body({ embedders: EMBEDDERS });
+    if (url.startsWith('/api/embedders')) return body({ embedders: catalog });
     if (url.includes('/api/config/set')) {
       writes.push(JSON.parse(String(init?.body ?? '{}')));
       return body({ ok: true });
@@ -54,6 +54,17 @@ async function renderPage(config: Record<string, unknown>) {
   return { writes };
 }
 
+/** The embedderless image: aimee-kb bakes no weights, so nothing is locally hostable
+ * and the bundled route has nothing to seed itself with. */
+async function renderPageWithNoLocalEmbedders() {
+  const { writes, fetchImpl } = harness({}, [
+    { id: 'external-only', dim: 1024, context: 512, pooling: 'mean', local: false, prefixed: false },
+  ]);
+  render(<DeployTopology onSaved={() => {}} fetchImpl={fetchImpl as unknown as typeof fetch} />);
+  await waitFor(() => expect(saveButton()).toBeTruthy());
+  return { writes };
+}
+
 function embedderSelect(): HTMLSelectElement {
   const select = Array.from(document.querySelectorAll('select')).find((s) =>
     Array.from(s.options).some((o) => o.value === 'bekko-a25m'),
@@ -62,12 +73,16 @@ function embedderSelect(): HTMLSelectElement {
   return select as HTMLSelectElement;
 }
 
-function save() {
+function saveButton(): HTMLButtonElement {
   const button = Array.from(document.querySelectorAll('button')).find((b) =>
     /save & continue/i.test(b.textContent || ''),
   );
   if (!button) throw new Error('save control not found');
-  fireEvent.click(button);
+  return button as HTMLButtonElement;
+}
+
+function save() {
+  fireEvent.click(saveButton());
 }
 
 afterEach(cleanup);
@@ -157,6 +172,29 @@ describe('DeployTopology embedder picker', () => {
   it('states the one-way door at the point of choice, not in a tooltip', async () => {
     await renderPage({});
     expect(screen.getByText(/effectively permanent for this install/i)).toBeTruthy();
+  });
+  it('will not save until an embedder is actually chosen', async () => {
+    // There is no fallback embedder any more: the kb refuses to start without one and
+    // the deploy is rejected before a container runs. Saving an empty choice would only
+    // defer that refusal to a later step, so the step does not complete.
+    const { writes } = await renderPageWithNoLocalEmbedders();
+    expect(saveButton().disabled).toBe(true);
+    expect(screen.getByText(/Choose an embedder/i)).toBeTruthy();
+    save();
+    expect(writes.length).toBe(0);
+  });
+
+  it('an external endpoint needs its dimension before it counts as chosen', async () => {
+    const { writes } = await renderPageWithNoLocalEmbedders();
+    fireEvent.change(screen.getByLabelText('embedder'), { target: { value: 'external' } });
+    fireEvent.change(screen.getByLabelText('embedder endpoint'), {
+      target: { value: 'https://embed.example/v1' },
+    });
+    expect(saveButton().disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText('embedder dimension'), { target: { value: '1024' } });
+    expect(saveButton().disabled).toBe(false);
+    save();
+    await waitFor(() => expect(writes.some((w) => w.key === 'embedder_url')).toBe(true));
   });
 });
 

--- a/frontend/src/setup/DeployTopology.tsx
+++ b/frontend/src/setup/DeployTopology.tsx
@@ -103,11 +103,13 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
       if (e.kind === 'bundled') {
         // An unset embedder_model is NOT "the deployment default" — there is no
         // default downstream. buildDesiredConfig omits the key, deploy-env omits
-        // EMBEDDER_MODEL, and the kb entrypoint leaves the baked model unloaded and
-        // serves the builtin LEXICAL embedder forever: the instance comes up
-        // healthy, reports retrieval degraded, and never uses the embedder its image
-        // was built around. Seed the shipped local model so an operator who accepts
-        // the default gets a working one.
+        // EMBEDDER_MODEL, and the kb refuses to start without one, so the deploy is
+        // rejected before anything runs. Seed the shipped local model so an operator
+        // who accepts the default gets a working one rather than that refusal.
+        //
+        // (It used to be worse: the kb served a builtin lexical embedder instead, so
+        // the instance came up healthy and answered every search with keyword
+        // matching, never using the embedder its image was built around.)
         //
         // embedModelSaved keeps the RAW saved value, so embedderChangeImpact still
         // sees from:'' on a fresh install and charges nothing for this seeding.
@@ -147,6 +149,14 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
         : { kind: 'bundled', model: embedModel },
     [embedRoute, embedUrl, embedKey, embedDims, embedModel],
   );
+
+  /* The kb refuses to start without an embedder, and a deploy with none is rejected
+   * before any container runs. Saving an incomplete choice only defers that refusal to
+   * a later step, so the step will not complete until the selection is a usable one. */
+  const embedderChosen =
+    embedRoute === 'bundled'
+      ? embedModel.trim() !== ''
+      : embedUrl.trim() !== '' && embedDims.trim() !== '';
 
   const synthesis: SynthesisSelection = useMemo(() => {
     if (synthRoute === 'off') return { kind: 'off' };
@@ -356,8 +366,16 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
         </div>
       )}
 
+      {!embedderChosen && (
+        <div style={{ fontSize: 12.5, color: '#a33' }}>
+          {embedRoute === 'bundled'
+            ? 'Choose an embedder. This image bakes none, so use an external endpoint.'
+            : 'An external embedder needs both an endpoint and its dimension.'}
+        </div>
+      )}
+
       <div>
-        <Button variant="primary" disabled={saving} onClick={save}>
+        <Button variant="primary" disabled={saving || !embedderChosen} onClick={save}>
           {saving ? 'Saving…' : 'Save & continue'}
         </Button>
       </div>

--- a/src/Makefile
+++ b/src/Makefile
@@ -1122,6 +1122,11 @@ integration-tests: $(BINARY) $(SERVER)
 init-migrate-service-test: $(BINARY) $(SERVER)
 	./tests/test_init_migrate_service.sh
 
+# The kb entrypoint's embedder gate. Needs no binary, no cluster and no image: it
+# sources the entrypoint's definitions and calls them directly.
+kb-entrypoint-test:
+	./tests/test_kb_entrypoint.sh
+
 index-scan-e2e-test: $(BINARY) $(SERVER)
 	./tests/test_index_scan_e2e.sh
 

--- a/src/cli_kb_smoke.c
+++ b/src/cli_kb_smoke.c
@@ -123,10 +123,8 @@ static void check_vectors(smoke_t *s, cJSON *h)
    report(s, "vector store ready", ok, 0, detail);
 }
 
-/* Zero embeddings is not a failure: "external embedder only" is supported, and the
- * builtin lexical embedder serves until one is selected. It is reported because a
- * deployment that MEANT to embed looks identical from outside, which is how a box
- * ends up serving lexical-only search behind a healthy banner. */
+/* Zero embeddings is not a failure: a kb that has ingested nothing yet has none. It is
+ * reported because a deployment that MEANT to embed looks identical from outside. */
 static void check_embeddings(smoke_t *s, cJSON *h)
 {
    if (!h)

--- a/src/cmd_agent.c
+++ b/src/cmd_agent.c
@@ -1554,7 +1554,8 @@ void cmd_eval(app_ctx_t *ctx, int argc, char **argv)
 
       /* Try corpus-based eval first. */
       static mem_eval_case_t corpus_cases[MEM_CORPUS_MAX_CASES];
-      int n_corpus = mem_eval_load_corpus(corpus_path, corpus_cases, MEM_CORPUS_MAX_CASES);
+      int n_corpus = mem_eval_load_corpus(corpus_path, config_embedder_command_current(NULL), corpus_cases,
+                                        MEM_CORPUS_MAX_CASES);
 
       if (n_corpus > 0)
       {

--- a/src/cmd_agent.c
+++ b/src/cmd_agent.c
@@ -1554,8 +1554,8 @@ void cmd_eval(app_ctx_t *ctx, int argc, char **argv)
 
       /* Try corpus-based eval first. */
       static mem_eval_case_t corpus_cases[MEM_CORPUS_MAX_CASES];
-      int n_corpus = mem_eval_load_corpus(corpus_path, config_embedder_command_current(NULL), corpus_cases,
-                                        MEM_CORPUS_MAX_CASES);
+      int n_corpus = mem_eval_load_corpus(corpus_path, config_embedder_command_current(NULL),
+                                          corpus_cases, MEM_CORPUS_MAX_CASES);
 
       if (n_corpus > 0)
       {

--- a/src/cmd_kb.c
+++ b/src/cmd_kb.c
@@ -120,9 +120,7 @@ static void kb_cmd_update(app_ctx_t *ctx, int argc, char **argv)
       root[0] = '\0';
 
    /* Pass NULL when no local embedder is configured (the thin client has none)
-    * so the kb embeds with its OWN embedder; defaulting to "builtin" (384-dim
-    * hash) would mismatch a real-embedder corpus (1024/2560-dim) and return
-    * nothing. */
+    * so the kb embeds with its OWN embedder, whose width matches the corpus. */
    const char *embed_cmd =
        config_embedder_command_field()[0] ? config_embedder_command_field() : NULL;
 
@@ -202,9 +200,7 @@ static void kb_cmd_search(app_ctx_t *ctx, int argc, char **argv)
    const char *fusion_mode_override = opt_get(&opts, "fusion-mode");
 
    /* Pass NULL when no local embedder is configured (the thin client has none)
-    * so the kb embeds with its OWN embedder; defaulting to "builtin" (384-dim
-    * hash) would mismatch a real-embedder corpus (1024/2560-dim) and return
-    * nothing. */
+    * so the kb embeds with its OWN embedder, whose width matches the corpus. */
    const char *embed_cmd =
        config_embedder_command_field()[0] ? config_embedder_command_field() : NULL;
 
@@ -510,8 +506,7 @@ static void kb_cmd_health(app_ctx_t *ctx, int argc, char **argv)
    fprintf(stdout, fmt, "db2 kb tables:", h.db2_kb_tables_ok ? "ok" : "WARN (missing)");
    fprintf(stdout, fmt, "pgvector ext:", h.pgvec_ok ? "ok" : "FAIL");
    fprintf(stdout, fmt, "pgvec table:", h.pgvec_collection_ok ? "ok" : "FAIL");
-   fprintf(stdout, fmt, "embed model:",
-           h.embed_ok ? (h.embed_command[0] ? h.embed_command : "builtin") : "not configured");
+   fprintf(stdout, fmt, "embed model:", h.embed_ok ? h.embed_command : "not configured");
 
    char fresh_buf[80];
    if (h.freshness_days < 0)

--- a/src/cmd_memory_embed.c
+++ b/src/cmd_memory_embed.c
@@ -1601,8 +1601,8 @@ void mem_benchmark(app_ctx_t *ctx, int argc, char **argv)
          baseline_path = "tests/eval/memory_retrieval_baseline.json";
 
       mem_eval_case_t corpus_cases[MEM_CORPUS_MAX_CASES];
-      int n_corpus = mem_eval_load_corpus(corpus_path, config_embedder_command_current(NULL), corpus_cases,
-                                        MEM_CORPUS_MAX_CASES);
+      int n_corpus = mem_eval_load_corpus(corpus_path, config_embedder_command_current(NULL),
+                                          corpus_cases, MEM_CORPUS_MAX_CASES);
       if (n_corpus <= 0)
          fatal("memory benchmark corpus failed for %s", corpus_path);
 

--- a/src/cmd_memory_embed.c
+++ b/src/cmd_memory_embed.c
@@ -1601,7 +1601,8 @@ void mem_benchmark(app_ctx_t *ctx, int argc, char **argv)
          baseline_path = "tests/eval/memory_retrieval_baseline.json";
 
       mem_eval_case_t corpus_cases[MEM_CORPUS_MAX_CASES];
-      int n_corpus = mem_eval_load_corpus(corpus_path, corpus_cases, MEM_CORPUS_MAX_CASES);
+      int n_corpus = mem_eval_load_corpus(corpus_path, config_embedder_command_current(NULL), corpus_cases,
+                                        MEM_CORPUS_MAX_CASES);
       if (n_corpus <= 0)
          fatal("memory benchmark corpus failed for %s", corpus_path);
 

--- a/src/db2/db2_reembed.c
+++ b/src/db2/db2_reembed.c
@@ -25,18 +25,9 @@
  * elsewhere (kb_documents, artifacts, evidence_index_ops, memories), so dropping +
  * recreating + re-deriving loses no source data. Any halfvec table NOT on this list
  * is unknown -> the reset REFUSES rather than risk destroying source it doesn't
- * understand. Keep in sync with schema.sql's halfvec(__EMBED_DIM__) tables. */
-static const char *DERIVED_VECTOR_TABLES[] = {"kb_embeddings",
-                                              "kb_pdf_embeddings",
-                                              "memory_embeddings",
-                                              "curator_entity_vectors",
-                                              "curator_narrative_vectors",
-                                              "curator_claim_vectors",
-                                              "curator_code_unit_vectors",
-                                              "exemplar_vectors",
-                                              "evidence_vectors",
-                                              "code_embeddings",
-                                              NULL};
+ * understand. Declared in db_schema.c, which reads the same set to decide whether a
+ * corpus has been embedded at all. */
+#define DERIVED_VECTOR_TABLES DB2_DERIVED_VECTOR_TABLES
 
 static int is_known_vector_table(const char *t)
 {

--- a/src/db2/db_schema.c
+++ b/src/db2/db_schema.c
@@ -740,9 +740,10 @@ int db2_embedding_model_record_or_check(void *conn, const char *model_id, const 
    return -1;
 }
 
-/* The identity the builtin lexical embedder reports (memory_embed_serving_id). It is
- * a placeholder: the kb serves it only until an embedder is actually selected. */
-#define BUILTIN_LEXICAL_SERVING_ID "builtin/lexical-v1"
+/* The identity the retired builtin lexical embedder recorded. Nothing serves it any
+ * more — a kb with no embedder now refuses to start — but corpora created before it
+ * was removed still carry it in kb_meta, so the value has to outlive the code. */
+#define RETIRED_LEXICAL_SERVING_ID "builtin/lexical-v1"
 
 /* The tables that hold derived vectors. Every one is rebuildable from source kept
  * elsewhere, which is why db2_reembed.c may drop them; here the same set answers a
@@ -808,18 +809,19 @@ static int corpus_has_vectors(void *conn)
  *     the drift it could not have detected is the operator's to resolve (the cutover
  *     runbook says re-embed).
  *   - recorded == serving_id -> match.
- *   - recorded is the builtin lexical placeholder AND nothing has been embedded ->
- *     adopt the new identity. The placeholder serves a kb whose embedder has not been
- *     chosen yet, so the first Deploy records it before the wizard's choice can reach
- *     the container. With no vectors written there is no space to mix, and refusing
- *     here stranded a brand-new empty kb: the documented recovery is `aimee kb
- *     reembed`, which is gated behind a setting inside the kb's own container.
- *     The emptiness must be PROVEN — an unreadable corpus is treated as non-empty.
+ *   - recorded is the RETIRED lexical identity AND nothing has been embedded -> adopt
+ *     the new identity. Those corpora exist because an unconfigured kb used to serve a
+ *     builtin lexical embedder, which recorded itself as the vector space on first
+ *     init whether or not anything was ever embedded. The embedder is gone, but the
+ *     kb_meta rows are not, and without this every such deployment would refuse to
+ *     start the moment it was given the embedder it now requires. With no vectors
+ *     written there is no space to mix. Emptiness must be PROVEN — an unreadable
+ *     corpus is treated as non-empty.
  *   - recorded != serving_id -> REFUSE. There is no compat list: unlike a model swap,
  *     where cosine agreement can be measured and admitted, a pooling or prefix change
- *     is definitionally a different space. This still covers the lexical corpus that
- *     HAS vectors, which is the transition nothing else can see: the builtin is
- *     384-dim and so is the bundled model, so the dim guard stays silent.
+ *     is definitionally a different space. A lexical corpus that HAS vectors is still
+ *     refused: the builtin was 384-dim and so is the bundled model, so the dim guard
+ *     cannot see that transition and this is the only thing that can.
  */
 int db2_embedder_serving_record_or_check(void *conn, const char *serving_id, char *errbuf,
                                          size_t errlen)
@@ -847,7 +849,7 @@ int db2_embedder_serving_record_or_check(void *conn, const char *serving_id, cha
       return 0;
    }
 
-   if (strcmp(recorded, BUILTIN_LEXICAL_SERVING_ID) == 0 && corpus_has_vectors(conn) == 0)
+   if (strcmp(recorded, RETIRED_LEXICAL_SERVING_ID) == 0 && corpus_has_vectors(conn) == 0)
    {
       if (kb_meta_set(conn, "schema_embedder_serving_id", serving_id) != 0)
       {

--- a/src/db2/db_schema.c
+++ b/src/db2/db_schema.c
@@ -740,6 +740,58 @@ int db2_embedding_model_record_or_check(void *conn, const char *model_id, const 
    return -1;
 }
 
+/* The identity the builtin lexical embedder reports (memory_embed_serving_id). It is
+ * a placeholder: the kb serves it only until an embedder is actually selected. */
+#define BUILTIN_LEXICAL_SERVING_ID "builtin/lexical-v1"
+
+/* The tables that hold derived vectors. Every one is rebuildable from source kept
+ * elsewhere, which is why db2_reembed.c may drop them; here the same set answers a
+ * different question — has anything actually been embedded yet.
+ *
+ * Keep in sync with schema.sql's halfvec(__EMBED_DIM__) tables (and their
+ * schema_sqlite.sql counterparts). A table missing from this list would answer the
+ * emptiness question wrongly in the unsafe direction, so adding one is not optional. */
+const char *const DB2_DERIVED_VECTOR_TABLES[] = {"kb_embeddings",
+                                                 "kb_pdf_embeddings",
+                                                 "memory_embeddings",
+                                                 "curator_entity_vectors",
+                                                 "curator_narrative_vectors",
+                                                 "curator_claim_vectors",
+                                                 "curator_code_unit_vectors",
+                                                 "exemplar_vectors",
+                                                 "evidence_vectors",
+                                                 "code_embeddings",
+                                                 NULL};
+
+/* Does any vector table hold a row?
+ *
+ * Returns 1 (has vectors), 0 (provably empty), or -1 (could not tell). Callers must
+ * treat -1 as "has vectors": an unprovable corpus is not an empty one. A table that
+ * does not exist holds nothing, so a failed prepare is skipped rather than fatal —
+ * this runs during init, where the schema may be partly applied. */
+static int corpus_has_vectors(void *conn)
+{
+   int checked = 0;
+   for (int i = 0; DB2_DERIVED_VECTOR_TABLES[i]; i++)
+   {
+      char err[256] = "";
+      char sql[160];
+      snprintf(sql, sizeof(sql), "SELECT 1 FROM %s LIMIT 1", DB2_DERIVED_VECTOR_TABLES[i]);
+      aimee_pg_stmt_t *q = aimee_pg_prepare(conn, sql, err, sizeof(err));
+      if (!q)
+         continue; /* absent table -> nothing embedded in it */
+      aimee_pg_step_t step = aimee_pg_step(q, err, sizeof(err));
+      aimee_pg_finalize(q);
+      if (step == AIMEE_PG_ROW)
+         return 1;
+      if (step != AIMEE_PG_DONE)
+         return -1; /* a live table we could not read: do not claim it is empty */
+      checked++;
+   }
+   /* No vector table readable at all is not proof of emptiness. */
+   return checked > 0 ? 0 : -1;
+}
+
 /* Record/check the embedder's VECTOR-SPACE identity (the gateway's /health
  * serving_id: model + pooling + prefix pair, digested).
  *
@@ -756,9 +808,18 @@ int db2_embedding_model_record_or_check(void *conn, const char *model_id, const 
  *     the drift it could not have detected is the operator's to resolve (the cutover
  *     runbook says re-embed).
  *   - recorded == serving_id -> match.
+ *   - recorded is the builtin lexical placeholder AND nothing has been embedded ->
+ *     adopt the new identity. The placeholder serves a kb whose embedder has not been
+ *     chosen yet, so the first Deploy records it before the wizard's choice can reach
+ *     the container. With no vectors written there is no space to mix, and refusing
+ *     here stranded a brand-new empty kb: the documented recovery is `aimee kb
+ *     reembed`, which is gated behind a setting inside the kb's own container.
+ *     The emptiness must be PROVEN — an unreadable corpus is treated as non-empty.
  *   - recorded != serving_id -> REFUSE. There is no compat list: unlike a model swap,
  *     where cosine agreement can be measured and admitted, a pooling or prefix change
- *     is definitionally a different space.
+ *     is definitionally a different space. This still covers the lexical corpus that
+ *     HAS vectors, which is the transition nothing else can see: the builtin is
+ *     384-dim and so is the bundled model, so the dim guard stays silent.
  */
 int db2_embedder_serving_record_or_check(void *conn, const char *serving_id, char *errbuf,
                                          size_t errlen)
@@ -778,6 +839,17 @@ int db2_embedder_serving_record_or_check(void *conn, const char *serving_id, cha
    if (!recorded[0] || strcmp(recorded, serving_id) == 0)
    {
       if (!recorded[0] && kb_meta_set(conn, "schema_embedder_serving_id", serving_id) != 0)
+      {
+         if (errbuf && errlen)
+            snprintf(errbuf, errlen, "kb_meta write failed for schema_embedder_serving_id");
+         return -1;
+      }
+      return 0;
+   }
+
+   if (strcmp(recorded, BUILTIN_LEXICAL_SERVING_ID) == 0 && corpus_has_vectors(conn) == 0)
+   {
+      if (kb_meta_set(conn, "schema_embedder_serving_id", serving_id) != 0)
       {
          if (errbuf && errlen)
             snprintf(errbuf, errlen, "kb_meta write failed for schema_embedder_serving_id");

--- a/src/db2/db_schema.h
+++ b/src/db2/db_schema.h
@@ -87,11 +87,12 @@ extern "C"
     * pooling/prefix change is definitionally a different space. Returns 0
     * (recorded/match), -1 (mismatch / DB error, errbuf set).
     *
-    * One exception: a corpus still recorded against the builtin lexical placeholder,
-    * with no vectors written, adopts the incoming identity. The placeholder is what a
-    * kb serves before an embedder has been chosen, so the first deploy records it
-    * whether or not anything is ever embedded; refusing there locked an empty kb out
-    * of the choice it had not made yet. Emptiness must be proven. */
+    * One exception: a corpus recorded against the RETIRED builtin lexical embedder,
+    * with no vectors written, adopts the incoming identity. That embedder served when
+    * none was configured and recorded itself on first init whether or not anything was
+    * ever embedded. It is gone — a kb with no embedder now refuses to start — but the
+    * kb_meta rows it left behind are not, and without this every such deployment would
+    * refuse to start once given the embedder it now requires. Emptiness must be proven. */
    int db2_embedder_serving_record_or_check(void *conn, const char *serving_id, char *errbuf,
                                             size_t errlen);
 

--- a/src/db2/db_schema.h
+++ b/src/db2/db_schema.h
@@ -85,9 +85,20 @@ extern "C"
     * both the width and the name while producing a different vector space. Empty
     * serving_id -> no-op (an endpoint that reports no identity). No compat list — a
     * pooling/prefix change is definitionally a different space. Returns 0
-    * (recorded/match), -1 (mismatch / DB error, errbuf set). */
+    * (recorded/match), -1 (mismatch / DB error, errbuf set).
+    *
+    * One exception: a corpus still recorded against the builtin lexical placeholder,
+    * with no vectors written, adopts the incoming identity. The placeholder is what a
+    * kb serves before an embedder has been chosen, so the first deploy records it
+    * whether or not anything is ever embedded; refusing there locked an empty kb out
+    * of the choice it had not made yet. Emptiness must be proven. */
    int db2_embedder_serving_record_or_check(void *conn, const char *serving_id, char *errbuf,
                                             size_t errlen);
+
+   /* The derived vector tables — rebuildable from source held elsewhere. NULL-terminated.
+    * db2_reembed drops them on a dimension change; the serving-identity guard reads them
+    * to decide whether anything has been embedded yet. */
+   extern const char *const DB2_DERIVED_VECTOR_TABLES[];
 
    /* Apply the consolidated SQLite schema for DB2's libpq shim/test
     * compatibility path. Production DB2 remains Postgres-only. */

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -955,6 +955,12 @@ int memory_graph_prune(void);
 int memory_graph_normalize(void);
 
 int memory_embed(int64_t memory_id, const char *command);
+
+/* The embed command that selects the in-process lexical fixture. TEST BUILDS ONLY —
+ * it is compiled out of aimee-kb, so passing it there is an ordinary (failing) exec.
+ * There is no implicit embedder: an empty command embeds nothing and returns 0. */
+#define MEMORY_EMBED_TEST_FIXTURE "test-lexical-fixture"
+
 /* `input_type` declares which side of the embedder this text is (see
  * embed_input_type_t). It is required rather than defaulted so the compiler forces
  * every call site to state it — a query silently embedded as a document costs

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -1852,13 +1852,8 @@ int main(int argc, char **argv)
    db2_set_embedder_model_id(config_embedder_model());
    /* §2b: register the embedder probes. Unconditionally, for whatever embed command is
     * configured: embedder_probe_register decides which probes that command supports.
-    *
-    * This gate used to live here and excluded "builtin", because the DIM probe cannot
-    * work against the lexical embedder. That silently disabled the serving-identity
-    * probe too, which needs no /health and reports the builtin's space from a constant,
-    * and so left the builtin-to-model transition undetectable -- both are 384-dim, so
-    * the dim guard cannot see it either. The distinction belongs to the module that
-    * knows what each probe requires, not to its caller. */
+    * The distinction belongs to the module that knows what each probe requires, not to
+    * its caller. */
    embedder_probe_register(config_embedder_command_current(NULL));
    /* Size the DB2 connection pool (leased by worker threads) before db2_init. */
    db2_set_pool_size(aimee_resolve_db2_pool_size(config_db2_connection_pool_size()));

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -346,10 +346,10 @@ static cJSON *kb_service_health_object(void)
     * the config file OR the EMBEDDER_URL env (the deploy stack exports the
     * latter), so resolve it the same way embed_command does instead of reading the
     * raw config field — otherwise an env-configured embedder is wrongly reported
-    * embed_ok:false while embed_command shows a real URL. The "builtin" fallback
-    * (nothing configured) still reports false, as before. */
+    * embed_ok:false while embed_command shows a real URL. Nothing configured
+    * reports false — there is no fallback to report instead. */
    const char *embed_cmd = config_embedder_command_current(NULL);
-   int embed_ok = (embed_cmd[0] && strcmp(embed_cmd, "builtin") != 0) ? 1 : 0;
+   int embed_ok = embed_cmd[0] ? 1 : 0;
    cJSON_AddBoolToObject(resp, "embed_ok", embed_ok);
    cJSON_AddStringToObject(resp, "embed_command", embed_cmd);
 

--- a/src/modules/benchmarks/agent_eval.h
+++ b/src/modules/benchmarks/agent_eval.h
@@ -139,8 +139,15 @@ int mem_eval_run_with_latency(mem_eval_case_t *cases, int n_cases, mem_eval_scor
 /* Load golden corpus from JSON file, open a fresh in-memory scratch DB,
  * insert fixtures, and populate cases[] with correctly mapped expected IDs.
  * Returns the number of cases loaded (>= 0), or -1 on error.
- * On success the caller must call mem_eval_close_temp_db() once done. */
-int mem_eval_load_corpus(const char *corpus_path, mem_eval_case_t *cases, int max_cases);
+ * On success the caller must call mem_eval_close_temp_db() once done.
+ *
+ * `embed_cmd` is the embedder the fixtures are embedded with, and is required —
+ * empty or NULL is an error, because a retrieval benchmark whose corpus was never
+ * embedded measures nothing. It used to resolve this from config internally, which
+ * hid the dependency and silently fell back to the builtin lexical embedder that no
+ * longer exists. */
+int mem_eval_load_corpus(const char *corpus_path, const char *embed_cmd, mem_eval_case_t *cases,
+                         int max_cases);
 
 /* Load the code-vector-graph production corpus (queries with already-resolved
  * live DB2 memory ids in `expected_ids`). Opens NO scratch DB — cases run

--- a/src/modules/benchmarks/agent_eval_memory_support.c
+++ b/src/modules/benchmarks/agent_eval_memory_support.c
@@ -898,10 +898,17 @@ int mem_eval_load_benchmark_agent_config(agent_config_t *cfg)
    return 0;
 }
 
-int mem_eval_load_corpus(const char *corpus_path, mem_eval_case_t *cases, int max_cases)
+int mem_eval_load_corpus(const char *corpus_path, const char *embed_cmd, mem_eval_case_t *cases,
+                         int max_cases)
 {
    if (!corpus_path || !cases || max_cases <= 0)
       return -1;
+   if (!embed_cmd || !embed_cmd[0])
+   {
+      fprintf(stderr, "mem_eval_load_corpus: no embedder configured; a retrieval benchmark "
+                      "cannot embed its corpus\n");
+      return -1;
+   }
 
    char *raw = slurp_file_eval(corpus_path);
    if (!raw)
@@ -982,7 +989,6 @@ int mem_eval_load_corpus(const char *corpus_path, mem_eval_case_t *cases, int ma
       }
 
       {
-         const char *embed_cmd = config_embedder_command_current(NULL);
          if (memory_embed(m.id, embed_cmd) != 0)
          {
             fprintf(stderr, "mem_eval_load_corpus: memory_embed failed for fixture %s\n",
@@ -1252,9 +1258,9 @@ int mem_eval_open_temp_db(void)
 {
    /* Pin the embedding dim BEFORE the temp store applies its schema: the scratch
     * store's vector columns are sized by db2_embedding_dim(), and the corpus is
-    * embedded via config_embedder_command (builtin => 384-dim when no embedder is
-    * configured). Without this, db2_embedding_dim()'s 1024 default disagrees with
-    * the builtin embed and every vector insert fails. Mirrors bootstrap_db2's pin.
+    * embedded with the caller's embedder. Without this, db2_embedding_dim()'s 1024
+    * default can disagree with the embedder's width and every vector insert fails.
+    * Mirrors bootstrap_db2's pin.
     * (The sqlite shim ignores vector dim, so this only bites the real-libpq store.) */
    db2_set_embedding_dim_default(config_embedder_dims_default());
    db2_set_embedding_dim(config_resolve_embedder_dims_current());

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -2376,7 +2376,7 @@ const char *config_embedder_command_current(const char *requested)
    static _Thread_local char cached[512];
    config_t *cfg = calloc(1, sizeof(*cfg));
    if (!cfg)
-      return "builtin"; /* allocation failure must not fabricate an embedder */
+      return ""; /* allocation failure must not fabricate an embedder */
    config_load(cfg);
    snprintf(cached, sizeof(cached), "%s", config_embedder_command(cfg, NULL));
    free(cfg);

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1409,10 +1409,16 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
       return env;
    if (cfg && cfg->embedder_command[0])
       return cfg->embedder_command;
-   /* Nothing selected at all: the lexical builtin, which fills the deployment's
-    * configured width (config is the single place that is declared). Correct for a
-    * first boot before the wizard runs, and for an unconfigured shim/test setup. */
-   return "builtin";
+   /* Nothing selected at all. The honest answer is the empty string, and callers read
+    * it as "no embedder": memory_embed_text embeds nothing, the kb refuses to start,
+    * and a deploy is rejected before a container runs.
+    *
+    * This used to return "builtin", naming a lexical feature hash that served whenever
+    * nothing was configured. Returning a name for it now would be worse than the
+    * fallback ever was: nothing implements it, so the string would reach the sidecar
+    * exec path, fork `/bin/sh -c builtin` for every embed call, fail, and charge the
+    * dependency breaker for an endpoint that was never configured. */
+   return "";
 }
 
 /* --- Conversation directories --- */

--- a/src/modules/memory/memory_core_helpers_b.c
+++ b/src/modules/memory/memory_core_helpers_b.c
@@ -513,22 +513,6 @@ int memory_embed_serving_id(const char *command, char *out, size_t out_len)
    out[0] = '\0';
    if (!command || !command[0])
       return 0;
-   if (strcmp(command, "builtin") == 0)
-   {
-      /* The builtin lexical embedder DOES have a vector space, and it needs an identity
-       * for the same reason the model-backed ones do. Reporting none left the one
-       * transition nothing could catch: a corpus embedded lexically and then queried with
-       * the bundled model shares its 384 width, so the dim guard is silent, and with no
-       * recorded identity the serving_id guard recorded the model's fresh and mixed the
-       * two spaces without a word.
-       *
-       * It is a deterministic feature hash over tokens and bigrams, so the space is fixed
-       * by the code rather than by any file: hence a constant, and hence the VERSION.
-       * BUMP IT whenever memory_embed_text_builtin's hashing, weighting or width changes —
-       * that is a different space, and an unbumped identity would claim otherwise. */
-      snprintf(out, out_len, "builtin/lexical-v1");
-      return 0;
-   }
    if (!memory_embed_command_is_http(command))
    {
       /* A SIDECAR command (the shipped container's embed-remote.py) owns endpoint

--- a/src/modules/memory/memory_core_scope_embed.c
+++ b/src/modules/memory/memory_core_scope_embed.c
@@ -345,6 +345,22 @@ double cosine_similarity(const float *a, const float *b, int dim)
    return denom > 1e-9 ? dot / denom : 0.0;
 }
 
+/* A deterministic lexical feature hash, built ONLY into test binaries.
+ *
+ * This was the product's fallback embedder: it served whenever none was configured,
+ * which meant an unconfigured kb answered searches with keyword matching while
+ * reporting itself healthy, and recorded itself as the corpus vector space so that
+ * choosing a real embedder afterwards was refused forever. That behaviour is gone —
+ * a kb with no embedder now refuses to start.
+ *
+ * What remains is a test fixture. Tests need SOME embedder to exercise ingest and
+ * retrieval end to end, and a deterministic in-process hash is a better fixture than
+ * a network dependency. It is selected only by the explicit command name
+ * MEMORY_EMBED_TEST_FIXTURE, never by absence of configuration, and the
+ * AIMEE_DISABLE_DB2_SQLITE_SHIM guard keeps it out of the shipped aimee-kb entirely:
+ * there is no build of the product in which this code can run. */
+#ifndef AIMEE_DISABLE_DB2_SQLITE_SHIM
+
 static uint32_t memory_embed_hash_token(const char *tok)
 {
    uint32_t h = 2166136261u;
@@ -370,14 +386,12 @@ static void memory_embed_add_feature(float *out, int dim, const char *feature, f
       out[bucket - 1] += sign * mag * 0.10f;
 }
 
-static int memory_embed_text_builtin(const char *text, float *out, int max_dim)
+static int memory_embed_text_lexical_fixture(const char *text, float *out, int max_dim)
 {
    if (!text || !out || max_dim <= 0)
       return 0;
-   /* The builtin serves before an embedder is selected, so its vectors land in the
-    * same columns the schema was sized for. Take that width from config — the one
-    * place it is declared — rather than repeating a number here, which is how the
-    * builtin and the schema could end up disagreeing. */
+   /* Vectors land in the columns the schema was sized for, so take that width from
+    * config rather than repeating a number here. */
    int width = config_embedder_dims_current();
    int dim = max_dim < width ? max_dim : width;
    for (int i = 0; i < dim; i++)
@@ -437,6 +451,8 @@ static int memory_embed_text_builtin(const char *text, float *out, int max_dim)
    return dim;
 }
 
+#endif /* !AIMEE_DISABLE_DB2_SQLITE_SHIM */
+
 /* Run embedding command: pipes text on stdin, reads JSON float array from stdout. */
 int memory_embed_text(const char *text, const char *command, embed_input_type_t input_type,
                       float *out, int max_dim)
@@ -447,13 +463,28 @@ int memory_embed_text(const char *text, const char *command, embed_input_type_t 
       return 0;
    }
 
-   /* The builtin embedder is lexical feature hashing — it has no prefixes to apply. */
-   if (!command || !command[0] || strcmp(command, "builtin") == 0)
+   /* No embedder configured is a failure, not a mode. There used to be a lexical
+    * feature-hashing fallback here, which meant an unconfigured kb answered every
+    * search with keyword matching while reporting itself healthy — a deployment could
+    * run for weeks believing it had vector retrieval. Worse, it claimed the corpus:
+    * db2 recorded the fallback's identity as the vector space, so selecting a real
+    * embedder afterwards was a space change the guard then refused forever.
+    * Retrieval without an embedder is not a degraded answer, it is a wrong one. */
+   if (!command || !command[0])
    {
-      int dim = memory_embed_text_builtin(text, out, max_dim);
+      g_embedder_last_unauthorized = 0;
+      return 0;
+   }
+
+#ifndef AIMEE_DISABLE_DB2_SQLITE_SHIM
+   /* Test-only, and only ever by explicit name — see the fixture's comment above. */
+   if (strcmp(command, MEMORY_EMBED_TEST_FIXTURE) == 0)
+   {
+      int dim = memory_embed_text_lexical_fixture(text, out, max_dim);
       g_embedder_last_unauthorized = 0;
       return dim;
    }
+#endif
 
    int64_t retry_after_ms = 0;
    if (!dependency_breaker_allow(&g_embedder_dependency, memory_embedder_now_ms(), &retry_after_ms))

--- a/src/server/deploy_apply.c
+++ b/src/server/deploy_apply.c
@@ -37,6 +37,30 @@ static int g_running = 0;
 static int g_last_exit = INT_MIN;
 static char g_last_out[DEPLOY_OUT_CAP];
 
+/* Is NAME= present in the emitted env with a non-empty value? config_emit_deploy_env
+ * always emits the embedder keys, empty when unset, so presence alone proves nothing. */
+static int deploy_env_value_set(const char *env, const char *name)
+{
+   if (!env || !name || !name[0])
+      return 0;
+   size_t nlen = strlen(name);
+   for (const char *p = env; p && *p;)
+   {
+      const char *eol = strchr(p, '\n');
+      if (!eol)
+         eol = p + strlen(p);
+      if ((size_t)(eol - p) > nlen && strncmp(p, name, nlen) == 0 && p[nlen] == '=')
+      {
+         const char *v = p + nlen + 1;
+         while (v < eol && isspace((unsigned char)*v))
+            v++;
+         return v < eol;
+      }
+      p = (*eol == '\n') ? eol + 1 : eol;
+   }
+   return 0;
+}
+
 static int deploy_env_has_profile(const char *env, const char *profile)
 {
    if (!profile || !profile[0])
@@ -262,6 +286,20 @@ static char **build_deploy_envp(char *err, size_t err_cap, int *managed_llm_out,
                               (explicit_id && explicit_id[0] ? 1 : 0) +
                               (explicit_team && explicit_team[0] ? 1 : 0);
    runtime_secret_wipe(explicit_conn, sizeof(explicit_conn));
+   /* A managed kb with no embedder will start, print why it cannot serve retrieval, and
+    * exit — leaving a failed deploy whose reason is a line in a container log. There is
+    * no fallback to come up with instead, so refuse here, where the wizard shows it. */
+   if (managed_kb && !deploy_env_value_set(env, "EMBEDDER_MODEL") &&
+       !deploy_env_value_set(env, "EMBEDDER_URL"))
+   {
+      if (err && err_cap)
+         snprintf(err, err_cap,
+                  "no embedder selected: the knowledge base cannot serve retrieval without "
+                  "one, and there is no fallback. Choose a bundled model on the wizard's "
+                  "topology step (or `aimee config set embedder_model bekko-a25m`), or point "
+                  "EMBEDDER_URL at an external endpoint, then deploy again");
+      return NULL;
+   }
    if (managed_kb && explicit_parts != 0 && explicit_parts != 3)
    {
       if (err && err_cap)

--- a/src/server/embedder_probe.c
+++ b/src/server/embedder_probe.c
@@ -155,31 +155,15 @@ void embedder_probe_register(const char *embed_command)
    snprintf(g_embed_cmd, sizeof(g_embed_cmd), "%s", embed_command);
 
    /* Registered, not called: the identity is fetched inside db2_init, once the embedder
-    * has had the dim probe's patience applied to it.
+    * has had the dim probe's patience applied to it. Both probes register for whatever
+    * embedder is configured — the module that knows what each probe requires owns the
+    * decision, not its caller.
     *
-    * ALWAYS, INCLUDING FOR THE BUILTIN, and that is the whole point of this function
-    * owning the decision. The caller used to skip this call entirely for the builtin
-    * lexical embedder, correctly reasoning that the DIM probe cannot work against it --
-    * it has no /health and a fixed width, so probing would never succeed and would
-    * stall the retry loop. But skipping the call skipped BOTH probes, and the serving
-    * identity needs no /health at all: memory_embed_serving_id answers "builtin" from a
-    * constant, locally, instantly.
-    *
-    * The cost of conflating them was the exact transition the serving-id guard exists
-    * to catch. A corpus embedded by the builtin recorded no identity, because no probe
-    * was registered to report one. Selecting the bundled model then found kb_meta empty
-    * and adopted the model's identity over lexically-embedded vectors -- same 384 width,
-    * so the dim guard stayed silent, and the guard that would have refused was never
-    * asked. db2_embedder_serving_record_or_check's tests assert it catches exactly this;
-    * nothing ever told it. */
+    * This used to carry a case for a builtin lexical embedder, which served when none
+    * was configured. It is gone: an unconfigured kb now refuses to start rather than
+    * answering searches with keyword matching and claiming the corpus's vector space
+    * while it does so. */
    db2_set_embedder_serving_probe(embedder_probe_serving_id);
-
-   if (strcmp(embed_command, "builtin") == 0)
-   {
-      LOG_INFO("db2", "builtin lexical embedder: dim probe skipped (fixed width, no /health); "
-                      "vector-space guard active");
-      return;
-   }
 
    const char *env = getenv("AIMEE_DIM_PROBE_BUDGET_MS");
    if (env && env[0])

--- a/src/server/embedder_probe.c
+++ b/src/server/embedder_probe.c
@@ -6,7 +6,7 @@
 #include "aimee.h" /* EMBED_MAX_DIM + memory.h prerequisites */
 #include "lifecycle.h"
 #include "log.h"
-#include "memory.h"               /* memory_embed_text — in-process HTTP probe */
+#include "memory.h"                              /* memory_embed_text — in-process HTTP probe */
 #include "modules/memory/memory_core_internal.h" /* memory_embed_command_is_http */
 
 #include <stdio.h>

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -17,6 +17,7 @@
 #include "server_cli_oauth.h"     /* server-hosted OAuth CLI agent setup */
 #include "provider_cli_adapter.h" /* provider_cli_adapter_get: declared CLI caps */
 #include "config.h"               /* config_load / config_t */
+#include <errno.h>
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -519,7 +520,22 @@ int handle_agent_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
     * (it did, on the appliance). Report the failure; reserve the empty array for
     * a config that really loaded and really has zero agents. */
    if (agent_load_config(&cfg) != 0)
-      return server_send_error(conn, "failed to load agent configuration", NULL);
+   {
+      /* Still an error, never an empty roster — but say WHICH failure it is. A fresh
+       * install has no agents.json at all, and answering that with a bare "failed to
+       * load" tells a first-run user nothing about what to do next. Anything else
+       * (unreadable, malformed, truncated) is a real fault and names the file. */
+      const char *path = agent_config_path();
+      if (path && access(path, F_OK) != 0)
+         return server_send_error(conn,
+                                  "no agents are configured yet: choose a provider in the setup "
+                                  "wizard, or run `aimee provider list --available`",
+                                  NULL);
+      char msg[512];
+      snprintf(msg, sizeof(msg), "agent configuration at %s could not be read (%s)",
+               path ? path : "?", strerror(errno));
+      return server_send_error(conn, msg, NULL);
+   }
    cJSON *resp = jo_ok();
    cJSON *arr = cJSON_CreateArray();
    for (int i = 0; i < cfg.agent_count; i++)

--- a/src/tests/test_agent_max_turns.c
+++ b/src/tests/test_agent_max_turns.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 #include "agent_exec.h"
+#include "aimee.h"  /* KIND_COUNT, required by memory.h */
+#include "memory.h" /* MEMORY_EMBED_TEST_FIXTURE */
 
 static int g_max_iterations = 0;
 static int g_max_iterations_delegate = 0;
@@ -180,5 +182,5 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
       return requested;
    if (cfg && cfg->embedder_command[0])
       return cfg->embedder_command;
-   return "builtin";
+   return MEMORY_EMBED_TEST_FIXTURE;
 }

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -131,15 +131,20 @@ fi
 SH
 chmod +x "$kb_entrypoint_test_dir/aimee-kb"
 # stderr is captured separately, not folded in: the entrypoint legitimately logs
-# operator diagnostics there (which embedder it started, or why it started none),
-# and folding them into stdout would turn this into an assertion that the
-# entrypoint is silent. What must hold is that no credential VALUE reaches either
-# stream, and that the final process image is credential-free.
+# operator diagnostics there (which embedder it is using), and folding them into
+# stdout would turn this into an assertion that the entrypoint is silent. What must
+# hold is that no credential VALUE reaches either stream, and that the final process
+# image is credential-free.
+#
+# EMBEDDER_URL is set because a serving kb with no embedder refuses to start, and
+# these two checks are about credential scrubbing, not embedder selection. The gate
+# itself is covered by tests/test_kb_entrypoint.sh.
 kb_entrypoint_stderr="$kb_entrypoint_test_dir/stderr.log"
 kb_entrypoint_output=$(env -i PATH="$kb_entrypoint_test_dir:/usr/bin:/bin" \
     AIMEE_HOME="$kb_entrypoint_test_dir/home" \
     AIMEE_DB2_URL=postgresql://external.invalid/aimee \
     ENTRYPOINT_TEST_API_KEY=first-boot-only \
+    EMBEDDER_URL=http://embedder.invalid \
     sh ../deploy/container/aimee-kb-entrypoint.sh 2>"$kb_entrypoint_stderr")
 if [ "$kb_entrypoint_output" = "clean" ] &&
     ! grep -qE 'first-boot-only|external\.invalid' "$kb_entrypoint_stderr"; then
@@ -158,6 +163,7 @@ kb_marked_output=$(env -i PATH="$kb_entrypoint_test_dir:/usr/bin:/bin" \
     AIMEE_DB2_URL=postgresql://external.invalid/aimee \
     ENTRYPOINT_TEST_API_KEY=first-boot-only \
     ENTRYPOINT_BOOTSTRAP_LOG="$kb_bootstrap_log" \
+    EMBEDDER_URL=http://embedder.invalid \
     sh ../deploy/container/aimee-kb-entrypoint.sh \
     --aimee-internal-vault-bootstrapped-external-db 2>"$kb_marked_stderr")
 kb_bootstrap_count=$(wc -c <"$kb_bootstrap_log")

--- a/src/tests/test_cron_runtime.c
+++ b/src/tests/test_cron_runtime.c
@@ -442,5 +442,5 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
       return requested;
    if (cfg && cfg->embedder_command[0])
       return cfg->embedder_command;
-   return "builtin";
+   return MEMORY_EMBED_TEST_FIXTURE;
 }

--- a/src/tests/test_deploy_apply.c
+++ b/src/tests/test_deploy_apply.c
@@ -62,8 +62,8 @@ static const char *g_stub_embedder_url = "";
 void config_emit_deploy_env_current(char *buf, size_t n)
 {
    if (buf && n)
-      snprintf(buf, n, "COMPOSE_PROFILES=%s\nEMBEDDER_MODEL=%s\nEMBEDDER_URL=%s\n",
-               g_stub_profiles, g_stub_embedder_model, g_stub_embedder_url);
+      snprintf(buf, n, "COMPOSE_PROFILES=%s\nEMBEDDER_MODEL=%s\nEMBEDDER_URL=%s\n", g_stub_profiles,
+               g_stub_embedder_model, g_stub_embedder_url);
 }
 
 /* Keyless Vault double: persistence semantics are exercised through the same

--- a/src/tests/test_deploy_apply.c
+++ b/src/tests/test_deploy_apply.c
@@ -53,10 +53,17 @@ int config_present(void)
    return 1;
 }
 
+/* Emitted alongside the profiles because a managed kb without an embedder is refused.
+ * Both keys are always emitted, empty when unset — which is what the real emitter does,
+ * and why presence alone cannot be the test. */
+static const char *g_stub_embedder_model = "bekko-a25m";
+static const char *g_stub_embedder_url = "";
+
 void config_emit_deploy_env_current(char *buf, size_t n)
 {
    if (buf && n)
-      snprintf(buf, n, "COMPOSE_PROFILES=%s\n", g_stub_profiles);
+      snprintf(buf, n, "COMPOSE_PROFILES=%s\nEMBEDDER_MODEL=%s\nEMBEDDER_URL=%s\n",
+               g_stub_profiles, g_stub_embedder_model, g_stub_embedder_url);
 }
 
 /* Keyless Vault double: persistence semantics are exercised through the same
@@ -226,6 +233,52 @@ static void test_managed_llm_service_credential(void)
    unsetenv("AIMEE_SERVER_TEAM_ID");
    snprintf(g_stub_profiles, sizeof(g_stub_profiles), "kb,llm");
    printf("  managed kb -> llm credential is stable, private, and scoped ok\n");
+}
+
+/* A managed kb with no embedder is refused before anything is started. There is no
+ * fallback embedder left to come up with instead: the container would print why it
+ * cannot serve retrieval and exit, so the deploy fails either way. It fails here
+ * because this is where the wizard shows the reason, rather than a container log. */
+static void test_managed_kb_without_an_embedder_is_refused(void)
+{
+   char err[256];
+   char **envp;
+   snprintf(g_stub_profiles, sizeof(g_stub_profiles), "kb");
+   g_stub_embedder_model = "";
+   g_stub_embedder_url = "";
+
+   err[0] = '\0';
+   assert(build_deploy_envp(err, sizeof(err), NULL, NULL, NULL) == NULL);
+   assert(strstr(err, "no embedder selected") != NULL);
+   /* The message has to name a way out, not just the problem. */
+   assert(strstr(err, "embedder_model") != NULL);
+   assert(strstr(err, "EMBEDDER_URL") != NULL);
+
+   /* A bundled model satisfies it. */
+   g_stub_embedder_model = "bekko-a25m";
+   envp = build_deploy_envp(err, sizeof(err), NULL, NULL, NULL);
+   assert(envp != NULL);
+   free_envp(envp);
+
+   /* So does an external endpoint, on its own. */
+   g_stub_embedder_model = "";
+   g_stub_embedder_url = "http://embedder.example:8760";
+   envp = build_deploy_envp(err, sizeof(err), NULL, NULL, NULL);
+   assert(envp != NULL);
+   free_envp(envp);
+
+   /* A remote kb deploys no container, so the check does not apply to it. */
+   g_stub_profiles[0] = '\0';
+   g_stub_embedder_model = "";
+   g_stub_embedder_url = "";
+   envp = build_deploy_envp(err, sizeof(err), NULL, NULL, NULL);
+   assert(envp != NULL);
+   free_envp(envp);
+
+   snprintf(g_stub_profiles, sizeof(g_stub_profiles), "kb,llm");
+   g_stub_embedder_model = "bekko-a25m";
+   g_stub_embedder_url = "";
+   printf("  managed kb with no embedder is refused, with a way out named ok\n");
 }
 
 /* --- the deploy argv itself --- */
@@ -448,6 +501,7 @@ int main(void)
 {
    printf("test_deploy_apply\n");
    test_managed_llm_service_credential();
+   test_managed_kb_without_an_embedder_is_refused();
    test_deploy_argv_is_orderable_and_has_no_remove_orphans();
    test_managed_kb_credential_bootstrap_is_stdin_only();
    test_managed_identity_bootstrap_runs_inside_kb_without_secret_argv();

--- a/src/tests/test_embedder_probe_register.c
+++ b/src/tests/test_embedder_probe_register.c
@@ -72,28 +72,9 @@ int main(void)
    check(!db2_embedder_probe_registered(), "empty command registers no dim probe");
    check(!db2_embedder_serving_probe_registered(), "empty command registers no serving probe");
 
-   printf("the builtin lexical embedder\n");
-   reset();
-   embedder_probe_register("builtin");
-   /* The dim probe genuinely cannot work here: no /health, fixed width, and the retry
-    * loop would spin for its whole budget on every boot. Registering it would be the
-    * bug in the other direction. */
-   check(!db2_embedder_probe_registered(), "no dim probe: nothing to probe, and it would stall");
-   /* Characterization, not regression: always true of this module. What was missing is a
-    * caller that reached it. */
-   check(db2_embedder_serving_probe_registered(),
-         "serving probe IS registered: the builtin has a vector space and declares it");
-
-   /* Link three, so the chain from registration to a recordable identity is closed by
-    * tests rather than by assumption. An empty answer here would make the guard a
-    * documented no-op, which is what the builtin used to look like from db2's side. */
-   {
-      char sid[160] = "zzz";
-      check(memory_embed_serving_id("builtin", sid, sizeof(sid)) == 0,
-            "the builtin answers a serving-identity probe");
-      check(sid[0] != '\0', "and the answer is NOT empty (empty would re-disable the guard)");
-      check(strcmp(sid, "builtin/lexical-v1") == 0, "it names the lexical space specifically");
-   }
+   /* "builtin" was a real embedder here once — a lexical feature hash that served when
+    * nothing was configured. It is gone, and with it the idea that an unconfigured kb
+    * has a vector space at all: no command means no probes, asserted above. */
 
    printf("a sidecar embed command\n");
    reset();

--- a/src/tests/test_embedding_dim.c
+++ b/src/tests/test_embedding_dim.c
@@ -223,17 +223,44 @@ int main(void)
    assert(db2_embedder_serving_record_or_check(NULL, "nomic/aaaa", err, sizeof err) == -1);
 
    /* The builtin lexical embedder declares an identity too, and switching off it must be
-    * caught. This was the one transition nothing could see: the builtin is 384-dim and so
-    * is the bundled model, so the dim guard is silent, and while the builtin reported NO
-    * identity the guard simply recorded the model's fresh over a lexically-embedded
-    * corpus. */
+    * caught ONCE SOMETHING IS EMBEDDED. This is the one transition nothing else can see:
+    * the builtin is 384-dim and so is the bundled model, so the dim guard is silent.
+    *
+    * An EMPTY corpus is the exception. The builtin serves a kb whose embedder has not
+    * been chosen yet, so the first deploy records the placeholder before the wizard's
+    * choice can reach the container; refusing there left a brand-new kb unable to adopt
+    * the embedder it had just been given, with the documented escape (`aimee kb reembed`)
+    * gated behind a setting inside the kb's own container. */
+   err[0] = '\0';
+   assert(aimee_pg_exec(conn, "DELETE FROM kb_meta WHERE key = 'schema_embedder_serving_id'", err,
+                        sizeof err) == 0);
+   assert(aimee_pg_exec(conn, "DELETE FROM memory_embeddings", err, sizeof err) == 0);
+   assert(db2_embedder_serving_record_or_check(conn, "builtin/lexical-v1", err, sizeof err) == 0);
+   assert(db2_embedder_serving_record_or_check(conn, "builtin/lexical-v1", err, sizeof err) == 0);
+   /* Empty corpus: the placeholder yields, and the new identity is what is now recorded. */
+   assert(db2_embedder_serving_record_or_check(conn, "bekko-a25m/abcd", err, sizeof err) == 0);
+   assert(err[0] == '\0');
+   assert(db2_embedder_serving_record_or_check(conn, "bekko-a25m/abcd", err, sizeof err) == 0);
+   /* Having yielded, it is an ordinary recorded identity — the next change is refused
+    * even though the corpus is still empty. The escape is for the placeholder only. */
+   assert(db2_embedder_serving_record_or_check(conn, "bekko-a25m/zzzz", err, sizeof err) == -1);
+   assert(strstr(err, "bekko-a25m/abcd") != NULL && strstr(err, "bekko-a25m/zzzz") != NULL);
+
+   /* Same placeholder, but the corpus HAS vectors: refused, and the record is unchanged.
+    * This is the lexically-embedded corpus the guard was added for. */
    err[0] = '\0';
    assert(aimee_pg_exec(conn, "DELETE FROM kb_meta WHERE key = 'schema_embedder_serving_id'", err,
                         sizeof err) == 0);
    assert(db2_embedder_serving_record_or_check(conn, "builtin/lexical-v1", err, sizeof err) == 0);
-   assert(db2_embedder_serving_record_or_check(conn, "builtin/lexical-v1", err, sizeof err) == 0);
+   assert(aimee_pg_exec(conn, "INSERT INTO memory_embeddings (point_id) VALUES (1)", err,
+                        sizeof err) == 0);
+   err[0] = '\0';
    assert(db2_embedder_serving_record_or_check(conn, "bekko-a25m/abcd", err, sizeof err) == -1);
    assert(strstr(err, "builtin/lexical-v1") != NULL && strstr(err, "bekko-a25m/abcd") != NULL);
+   /* The refusal left the corpus on the placeholder. */
+   err[0] = '\0';
+   assert(db2_embedder_serving_record_or_check(conn, "builtin/lexical-v1", err, sizeof err) == 0);
+   assert(aimee_pg_exec(conn, "DELETE FROM memory_embeddings", err, sizeof err) == 0);
 
    /* NULL conn -> -1. */
    assert(db2_embedding_model_record_or_check(NULL, "x", NULL, err, sizeof err) == -1);

--- a/src/tests/test_evidence_embed.c
+++ b/src/tests/test_evidence_embed.c
@@ -79,7 +79,7 @@ static void test_embed_success(void)
 
    assert(db2_evidence_ops_count("pending") == 1);
 
-   int n = kb_evidence_embed_drain(8, "builtin");
+   int n = kb_evidence_embed_drain(8, MEMORY_EMBED_TEST_FIXTURE);
    assert(n == 1);
 
    /* Embedder saw the extracted "content", not the raw payload. */
@@ -102,7 +102,7 @@ static void test_embed_wrong_dim(void)
    char id[64];
    seed_evidence(id, sizeof(id), "{\"content\":\"short\"}");
 
-   int n = kb_evidence_embed_drain(8, "builtin");
+   int n = kb_evidence_embed_drain(8, MEMORY_EMBED_TEST_FIXTURE);
    assert(n == 1); /* op was handled (marked failed) */
 
    assert(db2_evidence_ops_count("ok") == 0);
@@ -129,13 +129,13 @@ static void test_embed_drain_batch(void)
    }
    assert(db2_evidence_ops_count("pending") == 5);
 
-   int n = kb_evidence_embed_drain(32, "builtin");
+   int n = kb_evidence_embed_drain(32, MEMORY_EMBED_TEST_FIXTURE);
    assert(n == 5);
    assert(db2_evidence_ops_count("ok") == 5);
    assert(db2_evidence_ops_count("pending") == 0);
 
    /* Empty queue: drain reports zero work, not an error. */
-   assert(kb_evidence_embed_drain(32, "builtin") == 0);
+   assert(kb_evidence_embed_drain(32, MEMORY_EMBED_TEST_FIXTURE) == 0);
 
    printf("  test_embed_drain_batch: PASS\n");
 }

--- a/src/tests/test_evidence_embed.c
+++ b/src/tests/test_evidence_embed.c
@@ -24,6 +24,8 @@
 #include "artifacts.h"
 #include "evidence_vectors.h"
 #include "embed_input_type.h" /* the memory_embed_text stub's polarity argument */
+#include "aimee.h"            /* KIND_COUNT, required by memory.h */
+#include "memory.h"           /* MEMORY_EMBED_TEST_FIXTURE */
 #include "db2_test_shim.h"
 #include "../kb/kb_evidence_embed.h"
 

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -730,5 +730,5 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
       return requested;
    if (cfg && cfg->embedder_command[0])
       return cfg->embedder_command;
-   return "builtin";
+   return MEMORY_EMBED_TEST_FIXTURE;
 }

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -498,7 +498,8 @@ static void test_async_embedding_queue_and_drain(void)
    assert(aimee_pg_column_int(vc_st, 0) == 0);
    aimee_pg_finalize(vc_st);
 
-   assert(db2_kb_service_async_queue_drain(MEMORY_EMBED_TEST_FIXTURE, 5, pgvec_kb_vector_collection_name(),
+   assert(db2_kb_service_async_queue_drain(MEMORY_EMBED_TEST_FIXTURE, 5,
+                                           pgvec_kb_vector_collection_name(),
                                            test_kb_vector_upsert_document, NULL, &qstats) == 0);
    assert(qstats.pending == 0);
    assert(qstats.running == 0);
@@ -685,7 +686,8 @@ static void test_search_finds_content(void)
    assert(stats.chunks_added > 0);
 
    /* Search for authentication info */
-   char *result = kb_search("test_search", "authentication bearer token", MEMORY_EMBED_TEST_FIXTURE, 3);
+   char *result =
+       kb_search("test_search", "authentication bearer token", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    /* Result should reference the file */
    assert(strstr(result, "api.md") != NULL);
@@ -754,7 +756,8 @@ static void test_search_json_structured(void)
    kb_build(tmpdir, "test_jsearch", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(stats.chunks_added > 0);
 
-   char *result = kb_search_json("test_jsearch", "bearer token authentication", MEMORY_EMBED_TEST_FIXTURE, 3);
+   char *result =
+       kb_search_json("test_jsearch", "bearer token authentication", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    /* Must be structured JSON with separate typed fields, not the legacy
     * single-string format. */
@@ -791,18 +794,16 @@ static void test_search_json_scope_all_keeps_active_project_first(void)
    assert(kb_build(local_dir, "proj-local", MEMORY_EMBED_TEST_FIXTURE, 1, NULL) == 0);
    assert(kb_build(other_dir, "proj-other", MEMORY_EMBED_TEST_FIXTURE, 1, NULL) == 0);
 
-   char *result =
-       kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval",
-                                MEMORY_EMBED_TEST_FIXTURE, 2, "rrf");
+   char *result = kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval",
+                                           MEMORY_EMBED_TEST_FIXTURE, 2, "rrf");
    assert(result);
    const char *local = strstr(result, "\"project\":\"proj-local\"");
    const char *other = strstr(result, "\"project\":\"proj-other\"");
    assert(local && other && local < other);
    free(result);
 
-   result =
-       kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval",
-                                MEMORY_EMBED_TEST_FIXTURE, 1, "rrf");
+   result = kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval",
+                                     MEMORY_EMBED_TEST_FIXTURE, 1, "rrf");
    assert(result);
    assert(strstr(result, "\"project\":\"proj-local\"") != NULL);
    assert(strstr(result, "\"project\":\"proj-other\"") == NULL);
@@ -847,7 +848,8 @@ static void test_search_max_cap_above_legacy_limit(void)
    kb_build(tmpdir, "test_cap", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(stats.chunks_added >= 10);
 
-   char *result = kb_search_json("test_cap", "section behaviour discusses", MEMORY_EMBED_TEST_FIXTURE, 20);
+   char *result =
+       kb_search_json("test_cap", "section behaviour discusses", MEMORY_EMBED_TEST_FIXTURE, 20);
    assert(result != NULL);
    /* Count '"file_path":' occurrences; must be > 8 to prove the cap lifted. */
    int hits = 0;

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -208,7 +208,7 @@ static void test_build_empty_dir(void)
 
    open_test_db();
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_empty", NULL, 1, &stats);
+   int rc = kb_build(tmpdir, "test_empty", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(rc == 0);
    assert(stats.files_scanned == 0);
    assert(stats.files_indexed == 0);
@@ -242,14 +242,14 @@ static void test_build_single_file(void)
 
    open_test_db();
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_single", NULL, 1, &stats);
+   int rc = kb_build(tmpdir, "test_single", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(rc == 0);
    assert(stats.files_scanned >= 1);
    assert(stats.files_indexed >= 1);
    assert(stats.chunks_added >= 1);
 
    /* Search for something that should be in the index */
-   char *result = kb_search("test_single", "installation", NULL, 3);
+   char *result = kb_search("test_single", "installation", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    /* Should find the Installation section */
    assert(strstr(result, "README.md") != NULL || strcmp(result, "No results found.") != 0);
@@ -277,7 +277,7 @@ static void test_build_sanitizes_malformed_utf8(void)
 
    open_test_db();
    kb_stats_t stats;
-   assert(kb_build(tmpdir, "test_utf8", NULL, 1, &stats) == 0);
+   assert(kb_build(tmpdir, "test_utf8", MEMORY_EMBED_TEST_FIXTURE, 1, &stats) == 0);
    assert(stats.files_indexed == 1);
    assert(stats.chunks_added > 0);
 
@@ -286,7 +286,7 @@ static void test_build_sanitizes_malformed_utf8(void)
    assert(strcmp(stored, "# Legacy\n\nA ?quoted? CP-1252 phrase.\n") == 0);
    free(stored);
 
-   char *result = kb_search_json("test_utf8", "quoted phrase", NULL, 3);
+   char *result = kb_search_json("test_utf8", "quoted phrase", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    assert(strstr(result, "?quoted? CP-1252 phrase") != NULL);
    free(result);
@@ -328,7 +328,7 @@ static void test_build_incremental_update(void)
    kb_stats_t stats;
 
    /* First build */
-   int rc = kb_build(tmpdir, "test_incr", NULL, 1, &stats);
+   int rc = kb_build(tmpdir, "test_incr", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(rc == 0);
    int chunks_first = stats.chunks_added;
    assert(chunks_first > 0);
@@ -369,7 +369,7 @@ static void test_bloom_dedupe_skips_duplicate_content(void)
 
    open_test_db();
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_bloom_dup", NULL, 0, &stats);
+   int rc = kb_build(tmpdir, "test_bloom_dup", MEMORY_EMBED_TEST_FIXTURE, 0, &stats);
    assert(rc == 0);
    assert(stats.files_indexed == 2);
    assert(stats.chunks_added > 0);
@@ -408,7 +408,7 @@ static void test_minhash_shadow_signatures_persist(void)
 
    open_test_db();
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_lsh_shadow", NULL, 0, &stats);
+   int rc = kb_build(tmpdir, "test_lsh_shadow", MEMORY_EMBED_TEST_FIXTURE, 0, &stats);
    assert(rc == 0);
    assert(stats.files_indexed == 1);
 
@@ -480,7 +480,7 @@ static void test_async_embedding_queue_and_drain(void)
    platform_setenv("AIMEE_MEMORY_COGNIFY_ASYNC_ENABLED", "1");
 
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_async", "builtin", 1, &stats);
+   int rc = kb_build(tmpdir, "test_async", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(rc == 0);
    assert(stats.chunks_added > 0);
    assert(stats.embeddings_added == 0);
@@ -498,7 +498,7 @@ static void test_async_embedding_queue_and_drain(void)
    assert(aimee_pg_column_int(vc_st, 0) == 0);
    aimee_pg_finalize(vc_st);
 
-   assert(db2_kb_service_async_queue_drain("builtin", 5, pgvec_kb_vector_collection_name(),
+   assert(db2_kb_service_async_queue_drain(MEMORY_EMBED_TEST_FIXTURE, 5, pgvec_kb_vector_collection_name(),
                                            test_kb_vector_upsert_document, NULL, &qstats) == 0);
    assert(qstats.pending == 0);
    assert(qstats.running == 0);
@@ -565,7 +565,7 @@ static void test_build_sync_embeddings_and_vectors(void)
    platform_setenv("AIMEE_MEMORY_COGNIFY_ASYNC_ENABLED", "0");
 
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_syncembed", "builtin", 1, &stats);
+   int rc = kb_build(tmpdir, "test_syncembed", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(rc == 0);
    assert(stats.files_indexed == 1);
    assert(stats.chunks_added > 0);
@@ -600,7 +600,7 @@ static void test_build_vector_batch_flush(void)
    platform_setenv("AIMEE_VECTOR_KB_BATCH_SIZE", "2");
 
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_batch", "builtin", 1, &stats);
+   int rc = kb_build(tmpdir, "test_batch", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(rc == 0);
    assert(stats.embeddings_added == stats.chunks_added);
    /* With batch size 2 and >2 chunks the loop flushes mid-stream and again at
@@ -634,7 +634,7 @@ static void test_build_multi_file_counts(void)
 
    open_test_db();
    kb_stats_t stats;
-   int rc = kb_build(tmpdir, "test_multi", NULL, 1, &stats);
+   int rc = kb_build(tmpdir, "test_multi", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(rc == 0);
    assert(stats.files_scanned == 3);
    assert(stats.files_indexed == 3);
@@ -643,7 +643,7 @@ static void test_build_multi_file_counts(void)
 
    /* Force rebuild re-indexes everything (clears the project first; no skips). */
    kb_stats_t s2;
-   rc = kb_build(tmpdir, "test_multi", NULL, 1, &s2);
+   rc = kb_build(tmpdir, "test_multi", MEMORY_EMBED_TEST_FIXTURE, 1, &s2);
    assert(rc == 0);
    assert(s2.files_indexed == 3);
    assert(s2.files_skipped == 0);
@@ -656,7 +656,7 @@ static void test_build_multi_file_counts(void)
 static void test_search_empty_kb(void)
 {
    open_test_db();
-   char *result = kb_search("no_such_project", "anything", NULL, 3);
+   char *result = kb_search("no_such_project", "anything", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    assert(strcmp(result, "No results found.") == 0);
    free(result);
@@ -681,11 +681,11 @@ static void test_search_finds_content(void)
 
    open_test_db();
    kb_stats_t stats;
-   kb_build(tmpdir, "test_search", NULL, 1, &stats);
+   kb_build(tmpdir, "test_search", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(stats.chunks_added > 0);
 
    /* Search for authentication info */
-   char *result = kb_search("test_search", "authentication bearer token", NULL, 3);
+   char *result = kb_search("test_search", "authentication bearer token", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    /* Result should reference the file */
    assert(strstr(result, "api.md") != NULL);
@@ -709,7 +709,7 @@ static void test_search_requires_query_embedding(void)
 
    open_test_db();
    kb_stats_t stats;
-   kb_build(tmpdir, "test_embedfail", NULL, 1, &stats);
+   kb_build(tmpdir, "test_embedfail", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(stats.chunks_added > 0);
 
    char *result =
@@ -727,7 +727,7 @@ static void test_search_requires_query_embedding(void)
 static void test_search_json_empty(void)
 {
    open_test_db();
-   char *result = kb_search_json("no_such_project", "anything", NULL, 3);
+   char *result = kb_search_json("no_such_project", "anything", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    /* Empty result set must be valid JSON with a results array and fusion_mode field. */
    assert(strstr(result, "\"results\":[]") != NULL);
@@ -751,10 +751,10 @@ static void test_search_json_structured(void)
 
    open_test_db();
    kb_stats_t stats;
-   kb_build(tmpdir, "test_jsearch", NULL, 1, &stats);
+   kb_build(tmpdir, "test_jsearch", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(stats.chunks_added > 0);
 
-   char *result = kb_search_json("test_jsearch", "bearer token authentication", NULL, 3);
+   char *result = kb_search_json("test_jsearch", "bearer token authentication", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    /* Must be structured JSON with separate typed fields, not the legacy
     * single-string format. */
@@ -788,11 +788,12 @@ static void test_search_json_scope_all_keeps_active_project_first(void)
    write_file(other_path, "# Other\n\nshared local-first retrieval evidence with extra terms\n");
 
    open_test_db();
-   assert(kb_build(local_dir, "proj-local", NULL, 1, NULL) == 0);
-   assert(kb_build(other_dir, "proj-other", NULL, 1, NULL) == 0);
+   assert(kb_build(local_dir, "proj-local", MEMORY_EMBED_TEST_FIXTURE, 1, NULL) == 0);
+   assert(kb_build(other_dir, "proj-other", MEMORY_EMBED_TEST_FIXTURE, 1, NULL) == 0);
 
    char *result =
-       kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval", NULL, 2, "rrf");
+       kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval",
+                                MEMORY_EMBED_TEST_FIXTURE, 2, "rrf");
    assert(result);
    const char *local = strstr(result, "\"project\":\"proj-local\"");
    const char *other = strstr(result, "\"project\":\"proj-other\"");
@@ -800,7 +801,8 @@ static void test_search_json_scope_all_keeps_active_project_first(void)
    free(result);
 
    result =
-       kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval", NULL, 1, "rrf");
+       kb_search_json_scoped_ex("proj-local", 1, "shared local-first retrieval",
+                                MEMORY_EMBED_TEST_FIXTURE, 1, "rrf");
    assert(result);
    assert(strstr(result, "\"project\":\"proj-local\"") != NULL);
    assert(strstr(result, "\"project\":\"proj-other\"") == NULL);
@@ -842,10 +844,10 @@ static void test_search_max_cap_above_legacy_limit(void)
 
    open_test_db();
    kb_stats_t stats;
-   kb_build(tmpdir, "test_cap", NULL, 1, &stats);
+   kb_build(tmpdir, "test_cap", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(stats.chunks_added >= 10);
 
-   char *result = kb_search_json("test_cap", "section behaviour discusses", NULL, 20);
+   char *result = kb_search_json("test_cap", "section behaviour discusses", MEMORY_EMBED_TEST_FIXTURE, 20);
    assert(result != NULL);
    /* Count '"file_path":' occurrences; must be > 8 to prove the cap lifted. */
    int hits = 0;
@@ -876,14 +878,14 @@ static void test_clear(void)
 
    open_test_db();
    kb_stats_t stats;
-   kb_build(tmpdir, "test_clear", NULL, 1, &stats);
+   kb_build(tmpdir, "test_clear", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
    assert(stats.chunks_added > 0);
 
    int deleted = db2_kb_service_clear_project("test_clear");
    assert(deleted > 0);
 
    /* Search should now return nothing */
-   char *result = kb_search("test_clear", "notes", NULL, 3);
+   char *result = kb_search("test_clear", "notes", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(result != NULL);
    assert(strcmp(result, "No results found.") == 0);
    free(result);
@@ -931,8 +933,8 @@ static void test_purge_fence_blocks_ingest(void)
    /* Writers refuse to start an ingest for a fenced project; another key is
     * unaffected. */
    kb_stats_t stats;
-   assert(kb_build(tmpdir, "fence_proj", NULL, 0, &stats) == -1);
-   assert(kb_build(other_tmpdir, "other_proj", NULL, 0, &stats) == 0);
+   assert(kb_build(tmpdir, "fence_proj", MEMORY_EMBED_TEST_FIXTURE, 0, &stats) == -1);
+   assert(kb_build(other_tmpdir, "other_proj", MEMORY_EMBED_TEST_FIXTURE, 0, &stats) == 0);
 
    /* Heartbeat: displaced ids no-op, matching ids refresh. */
    assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-0", "pid-1") == 0);
@@ -987,7 +989,7 @@ static void test_purge_fence_blocks_ingest(void)
    assert(db2_kb_purge_fence_read("fence_proj", NULL, 0, NULL, 0, NULL) == 0);
 
    /* Unfenced: the ingest goes through again. */
-   assert(kb_build(tmpdir, "fence_proj", NULL, 0, &stats) == 0);
+   assert(kb_build(tmpdir, "fence_proj", MEMORY_EMBED_TEST_FIXTURE, 0, &stats) == 0);
 
    close_test_db();
    unlink(fpath);
@@ -1016,12 +1018,12 @@ static void test_project_isolation(void)
    write_file(fp2, "# Beta Project\n\nThis is about beta features.\n");
 
    open_test_db();
-   kb_build(tmpdir1, "proj_alpha", NULL, 1, NULL);
-   kb_build(tmpdir2, "proj_beta", NULL, 1, NULL);
+   kb_build(tmpdir1, "proj_alpha", MEMORY_EMBED_TEST_FIXTURE, 1, NULL);
+   kb_build(tmpdir2, "proj_beta", MEMORY_EMBED_TEST_FIXTURE, 1, NULL);
 
    /* Searching proj_alpha should not return beta content */
-   char *r1 = kb_search("proj_alpha", "beta", NULL, 3);
-   char *r2 = kb_search("proj_beta", "alpha", NULL, 3);
+   char *r1 = kb_search("proj_alpha", "beta", MEMORY_EMBED_TEST_FIXTURE, 3);
+   char *r2 = kb_search("proj_beta", "alpha", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(r1 != NULL);
    assert(r2 != NULL);
    /* These searches should not match (different project namespaces) */
@@ -1033,7 +1035,7 @@ static void test_project_isolation(void)
 
    /* Clear one project, verify other is unaffected */
    db2_kb_service_clear_project("proj_alpha");
-   char *r3 = kb_search("proj_beta", "beta features", NULL, 3);
+   char *r3 = kb_search("proj_beta", "beta features", MEMORY_EMBED_TEST_FIXTURE, 3);
    assert(r3 != NULL);
    /* proj_beta should still have results */
    free(r3);
@@ -1060,7 +1062,7 @@ static void test_status_format(void)
    write_file(fpath, "# Hello\n\nSome content.\n");
 
    open_test_db();
-   kb_build(tmpdir, "status_test", NULL, 1, NULL);
+   kb_build(tmpdir, "status_test", MEMORY_EMBED_TEST_FIXTURE, 1, NULL);
 
    db2_kb_service_project_status_t status;
    assert(db2_kb_service_collect_project_status("status_test", &status) == 0);
@@ -1106,7 +1108,7 @@ static void test_excludes_node_modules(void)
 
    open_test_db();
    kb_stats_t stats;
-   kb_build(tmpdir, "test_excl", NULL, 1, &stats);
+   kb_build(tmpdir, "test_excl", MEMORY_EMBED_TEST_FIXTURE, 1, &stats);
 
    /* Should only have indexed the normal file */
    assert(stats.files_scanned == 1);

--- a/src/tests/test_kb_entrypoint.sh
+++ b/src/tests/test_kb_entrypoint.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# The kb entrypoint's embedder gate.
+#
+# There is no fallback embedder: a kb told to SERVE with none configured must refuse to
+# start rather than come up answering searches it cannot answer. The gate has to be
+# narrow, though — the same image is run as a one-shot for jobs that never serve a
+# query, and the managed deploy's `managed-server-identity install` is exactly that.
+# Requiring an embedder of those failed server-identity enrolment on every clean
+# install: the kb came up healthy and the server could not talk to it.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+entrypoint="$root/deploy/container/aimee-kb-entrypoint.sh"
+[ -f "$entrypoint" ] || { echo "missing $entrypoint" >&2; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+fail=0
+ok()   { echo "  ok    $1"; }
+bad()  { echo "  FAIL  $1" >&2; fail=1; }
+
+# Definitions only — no cluster, no vault, no image.
+AIMEE_KB_ENTRYPOINT_SOURCE_ONLY=1
+export AIMEE_KB_ENTRYPOINT_SOURCE_ONLY
+# shellcheck disable=SC1090
+. "$entrypoint"
+
+echo "kb_is_serving: flags mean serve, a bare word means one-shot"
+kb_is_serving            && ok "no args -> serving"            || bad "no args should serve"
+kb_is_serving --http-port=8741 && ok "--http-port -> serving"  || bad "flag should serve"
+if kb_is_serving managed-server-identity install --uid=1000; then
+    bad "a bare subcommand must NOT count as serving"
+else
+    ok "managed-server-identity -> one-shot"
+fi
+if kb_is_serving team; then bad "'team' must not count as serving"; else ok "team -> one-shot"; fi
+
+echo
+echo "start_embedder: refuses only when it is actually serving"
+# read_cfg_embedding_model shells out to the aimee-kb binary; stub it to "nothing set".
+read_cfg_embedding_model() { printf ''; }
+
+unset EMBEDDER_URL EMBEDDER_MODEL 2>/dev/null || true
+
+# Serving with nothing configured must exit non-zero and say why.
+out=$( (start_embedder --http-port=8741) 2>&1 ) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ]; then ok "serving with no embedder exits $rc"; else bad "serving with no embedder did not exit"; fi
+case "$out" in
+*"no embedder selected"*) ok "message names the problem" ;;
+*) bad "message missing: $out" ;;
+esac
+case "$out" in
+*"embedder_model"*) ok "message names the bundled fix" ;;
+*) bad "message does not name embedder_model" ;;
+esac
+case "$out" in
+*EMBEDDER_URL*) ok "message names the external fix" ;;
+*) bad "message does not name EMBEDDER_URL" ;;
+esac
+
+# The one-shot path must be untouched by the same missing configuration.
+out=$( (start_embedder managed-server-identity install --server-home=/x) 2>&1 ) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ]; then ok "one-shot with no embedder proceeds"; else bad "one-shot refused (rc=$rc): $out"; fi
+case "$out" in
+*"no embedder selected"*) bad "one-shot printed the serving refusal" ;;
+*) ok "one-shot prints no refusal" ;;
+esac
+
+# An external endpoint satisfies the gate without a bundled model.
+EMBEDDER_URL=http://embedder.example:8760
+export EMBEDDER_URL
+out=$( (start_embedder --http-port=8741) 2>&1 ) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ]; then ok "external embedder satisfies the gate"; else bad "external embedder refused: $out"; fi
+unset EMBEDDER_URL
+
+# A selected model on an image with no bundled weights must refuse, not serve silently.
+EMBEDDER_MODEL=bekko-a25m
+EMBEDDER_VENV=$tmp/absent-venv
+export EMBEDDER_MODEL EMBEDDER_VENV
+out=$( (start_embedder --http-port=8741) 2>&1 ) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ]; then ok "model selected but no bundled embedder exits $rc"; else bad "embedderless image did not refuse"; fi
+case "$out" in
+*"no bundled embedder"*) ok "message names the image mismatch" ;;
+*) bad "message missing: $out" ;;
+esac
+
+echo
+if [ "$fail" -eq 0 ]; then echo "test_kb_entrypoint: all passed"; else echo "test_kb_entrypoint: FAILED" >&2; fi
+exit "$fail"

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1452,11 +1452,11 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
    url = getenv("SYNTHESIS_ENDPOINT");
    if (url && url[0])
       return url;
-   return "builtin";
+   return ""; /* nothing selected: no embedder, no fabricated name */
 }
 
 /* The config_t-free form callers use now. Same resolution order, minus the
- * struct the caller no longer holds: request > env > builtin. */
+ * struct the caller no longer holds: request > env > nothing. */
 const char *config_embedder_command_current(const char *requested)
 {
    return config_embedder_command(NULL, requested);
@@ -4358,17 +4358,28 @@ static void test_code_context_bounded_current_project(void)
    assert(s == 200);
 }
 
-static void test_code_context_no_answer_is_explicit(void)
+/* With NO embedder configured, the route reports the missing dependency — it does not
+ * answer "nothing matched".
+ *
+ * This test used to assert the opposite, and passed only because an unconfigured kb
+ * resolved to a builtin lexical embedder: the vector leg looked live, returned nothing,
+ * and the route called that an abstention. So "I have not configured retrieval" and "I
+ * searched and found nothing" were the same answer, which is the confusion the builtin
+ * caused everywhere. There is no builtin now, and a kb with no embedder refuses to
+ * start, so the honest report is the dependency.
+ *
+ * Genuine abstention — a live embedder that matches nothing — is not reachable through
+ * this stub set: g_vec_enabled=1 returns canned hits regardless of the query. */
+static void test_code_context_without_an_embedder_reports_the_dependency(void)
 {
    char buf[2048];
    int s =
        kb_http_route_ex("GET", "/v1/code/context", "query=definitely-unrelated&project=proj-alpha",
                         NULL, NULL, NULL, 0, buf, sizeof(buf));
-   assert(s == 200);
-   assert(strstr(buf, "\"status\":\"abstained\"") != NULL);
-   assert(strstr(buf, "\"decision\":\"no_answer\"") != NULL);
-   assert(strstr(buf, "\"results\":[]") != NULL);
-   assert(strstr(buf, "\"why\":[]") != NULL);
+   assert(s == 503);
+   assert(strstr(buf, "\"dependency\":\"embedder\"") != NULL);
+   /* Never a false negative: "no answer" would tell the caller the corpus lacks it. */
+   assert(strstr(buf, "no_answer") == NULL);
 }
 
 static void test_code_context_embedder_outage_is_not_no_answer(void)
@@ -5304,7 +5315,9 @@ static void test_drain_default_embedding_command(void)
    g_drain_rc = 0;
    int s = kb_http_route_ex("POST", "/v1/drain", NULL, NULL, NULL, "{}", 2, buf, sizeof(buf));
    assert(s == 200);
-   assert(strcmp(g_drain_embed_cmd, "builtin") == 0);
+   /* No embedder configured resolves to the empty string, not to a name nothing
+    * implements — the drain then embeds nothing rather than exec'ing it. */
+   assert(g_drain_embed_cmd[0] == '\0');
 }
 
 static void test_drain_error(void)
@@ -6594,7 +6607,7 @@ int main(void)
    test_code_context_vector_store_outage_is_not_empty();
    test_code_context_dimension_mismatch_is_stale();
    test_code_context_bounded_current_project();
-   test_code_context_no_answer_is_explicit();
+   test_code_context_without_an_embedder_reports_the_dependency();
    test_code_context_embedder_outage_is_not_no_answer();
    test_code_context_embedder_auth_is_unauthorized();
    test_code_context_does_not_substitute_global_memory();

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -1692,7 +1692,7 @@ static void test_memory_embed_records_embedder_version(void)
    db2_set_embedding_dim(config_embedder_dims_current());
    memory_t mem;
    assert(memory_insert(TIER_L2, KIND_FACT, "embed-version", "test content", 0.9, "", &mem) == 0);
-   assert(memory_embed(mem.id, "builtin") == 0);
+   assert(memory_embed(mem.id, MEMORY_EMBED_TEST_FIXTURE) == 0);
 
    char vio_err[128] = "";
    aimee_pg_stmt_t *vio_st = aimee_pg_prepare(
@@ -2544,7 +2544,7 @@ int main(void)
       memory_t mem;
       memory_insert(TIER_L2, KIND_FACT, "embed-test", "test content", 0.9, "", &mem);
 
-      assert(memory_embed(mem.id, "builtin") == 0);
+      assert(memory_embed(mem.id, MEMORY_EMBED_TEST_FIXTURE) == 0);
 
       {
          static const char *sql =
@@ -2572,17 +2572,34 @@ int main(void)
       }
    }
 
-   /* --- deterministic builtin embedding fallback --- */
+   /* --- no embedder configured is a FAILURE, not a fallback ---
+    *
+    * This used to assert the opposite: an empty command embedded via a builtin lexical
+    * feature hash and returned a full-width vector. That is what let an unconfigured kb
+    * answer every search with keyword matching while reporting itself healthy, and what
+    * let the fallback record itself as the corpus vector space. Retrieval without an
+    * embedder is not a degraded answer, it is a wrong one, so it now returns 0 and the
+    * caller skips the op. */
    {
       float vec[4];
       memory_embedder_dependency_reset_for_tests();
       memory_embedder_dependency_set_clock_for_tests(embedder_test_clock);
       g_embedder_now_ms = 100000;
-      int dim = memory_embed_text("test", "", EMBED_INPUT_DOCUMENT, vec, 4);
-      assert(dim == 4);
+      for (int i = 0; i < 4; i++)
+         vec[i] = -99.0f;
 
-      dim = memory_embed_text("test", NULL, EMBED_INPUT_DOCUMENT, vec, 4);
-      assert(dim == 4);
+      assert(memory_embed_text("test", "", EMBED_INPUT_DOCUMENT, vec, 4) == 0);
+      assert(memory_embed_text("test", NULL, EMBED_INPUT_DOCUMENT, vec, 4) == 0);
+      /* And it must not have written a partial vector on the way out. */
+      for (int i = 0; i < 4; i++)
+         assert(vec[i] == -99.0f);
+
+      /* Failing to configure an embedder is not an embedder that FAILED: nothing was
+       * called, so the dependency breaker must not count it against the endpoint. */
+      memory_embedder_health_t none_health;
+      memory_embedder_health(&none_health);
+      assert(none_health.failure_streak == 0);
+      assert(strcmp(none_health.state, "closed") == 0);
    }
 
    /* --- embedding_command sidecar contract (deep-curator AC#3): a sidecar

--- a/src/tests/test_memory_embed_batch.c
+++ b/src/tests/test_memory_embed_batch.c
@@ -8,6 +8,8 @@
  * detail. */
 #include "support/mock_agent_http.h"
 #include "embed_input_type.h"
+#include "aimee.h"  /* KIND_COUNT, required by memory.h */
+#include "memory.h" /* MEMORY_EMBED_TEST_FIXTURE */
 
 #include <assert.h>
 #include <stdio.h>
@@ -147,7 +149,8 @@ int main(void)
     * caller is sent to the per-text path that computes the same vectors. */
    mock_agent_http_set_post_handler(post_batch_ok);
    s_posts = 0;
-   assert(memory_embed_texts(texts, NTEXT, MEMORY_EMBED_TEST_FIXTURE, EMBED_INPUT_DOCUMENT, out, DIM) == 0);
+   assert(memory_embed_texts(texts, NTEXT, MEMORY_EMBED_TEST_FIXTURE, EMBED_INPUT_DOCUMENT, out,
+                             DIM) == 0);
    assert(s_posts == 0);
 
    /* Degenerate inputs never reach the embedder. */

--- a/src/tests/test_memory_embed_batch.c
+++ b/src/tests/test_memory_embed_batch.c
@@ -147,7 +147,7 @@ int main(void)
     * caller is sent to the per-text path that computes the same vectors. */
    mock_agent_http_set_post_handler(post_batch_ok);
    s_posts = 0;
-   assert(memory_embed_texts(texts, NTEXT, "builtin", EMBED_INPUT_DOCUMENT, out, DIM) == 0);
+   assert(memory_embed_texts(texts, NTEXT, MEMORY_EMBED_TEST_FIXTURE, EMBED_INPUT_DOCUMENT, out, DIM) == 0);
    assert(s_posts == 0);
 
    /* Degenerate inputs never reach the embedder. */

--- a/src/tests/test_memory_retrieval_eval.c
+++ b/src/tests/test_memory_retrieval_eval.c
@@ -132,7 +132,7 @@ static void test_corpus_load_minimal(void)
 
    char *path = write_temp_corpus(corpus_json);
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus(path, cases, 16);
+   int n = mem_eval_load_corpus(path, MEMORY_EMBED_TEST_FIXTURE, cases, 16);
 
    assert(n == 1);
    assert(cases[0].n_expected == 1);
@@ -187,7 +187,7 @@ static void test_fusion_surfaces_bridged_memory(void)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed = cfg.embedder_command[0] ? cfg.embedder_command : "builtin";
+   const char *embed = cfg.embedder_command[0] ? cfg.embedder_command : MEMORY_EMBED_TEST_FIXTURE;
 
    /* Base hit: lexically/semantically matches the query. */
    memory_t base;
@@ -260,7 +260,7 @@ static void test_corpus_load_multi_expected(void)
 
    char *path = write_temp_corpus(corpus_json);
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus(path, cases, 16);
+   int n = mem_eval_load_corpus(path, MEMORY_EMBED_TEST_FIXTURE, cases, 16);
 
    assert(n == 1);
    assert(cases[0].n_expected == 2);
@@ -289,7 +289,7 @@ static void test_corpus_load_populates_local_embeddings(void)
 
    char *path = write_temp_corpus(corpus_json);
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus(path, cases, 16);
+   int n = mem_eval_load_corpus(path, MEMORY_EMBED_TEST_FIXTURE, cases, 16);
    assert(n == 1);
 
    mem_eval_close_temp_db();
@@ -301,7 +301,7 @@ static void test_corpus_load_invalid_json(void)
 {
    char *path = write_temp_corpus("{not valid json");
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus(path, cases, 16);
+   int n = mem_eval_load_corpus(path, MEMORY_EMBED_TEST_FIXTURE, cases, 16);
    assert(n == -1);
    platform_test_remove_sqlite(path);
    free(path);
@@ -310,7 +310,7 @@ static void test_corpus_load_invalid_json(void)
 static void test_corpus_load_missing_file(void)
 {
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus("/tmp/does_not_exist_xyzzy.json", cases, 16);
+   int n = mem_eval_load_corpus("/tmp/does_not_exist_xyzzy.json", MEMORY_EMBED_TEST_FIXTURE, cases, 16);
    assert(n == -1);
 }
 
@@ -331,7 +331,7 @@ static void test_corpus_load_unknown_fid(void)
 
    char *path = write_temp_corpus(corpus_json);
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus(path, cases, 16);
+   int n = mem_eval_load_corpus(path, MEMORY_EMBED_TEST_FIXTURE, cases, 16);
    /* Case has no resolvable expected IDs, so it should be dropped → 0 cases loaded */
    assert(n <= 0);
    mem_eval_close_temp_db();
@@ -358,7 +358,7 @@ static void test_mem_eval_run_finds_exact_match(void)
 
    char *path = write_temp_corpus(corpus_json);
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus(path, cases, 16);
+   int n = mem_eval_load_corpus(path, MEMORY_EMBED_TEST_FIXTURE, cases, 16);
    assert(n == 1);
 
    mem_eval_scores_t scores;
@@ -502,7 +502,7 @@ static void test_multi_hop_recall(void)
 
    char *path = write_temp_corpus(corpus_json);
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus(path, cases, 16);
+   int n = mem_eval_load_corpus(path, MEMORY_EMBED_TEST_FIXTURE, cases, 16);
    assert(n == 1);
 
    /* Seed graph edges to link the three fixtures. In production these would
@@ -535,7 +535,7 @@ static int run_corpus_regression(const char *corpus_path, const char *baseline_p
    }
 
    static mem_eval_case_t cases[MEM_CORPUS_MAX_CASES];
-   int n_cases = mem_eval_load_corpus(corpus_path, cases, MEM_CORPUS_MAX_CASES);
+   int n_cases = mem_eval_load_corpus(corpus_path, MEMORY_EMBED_TEST_FIXTURE, cases, MEM_CORPUS_MAX_CASES);
    if (n_cases <= 0)
    {
       fprintf(stderr, "FAIL: memory retrieval corpus failed for %s\n", corpus_path);

--- a/src/tests/test_memory_retrieval_eval.c
+++ b/src/tests/test_memory_retrieval_eval.c
@@ -310,7 +310,8 @@ static void test_corpus_load_invalid_json(void)
 static void test_corpus_load_missing_file(void)
 {
    mem_eval_case_t cases[16];
-   int n = mem_eval_load_corpus("/tmp/does_not_exist_xyzzy.json", MEMORY_EMBED_TEST_FIXTURE, cases, 16);
+   int n =
+       mem_eval_load_corpus("/tmp/does_not_exist_xyzzy.json", MEMORY_EMBED_TEST_FIXTURE, cases, 16);
    assert(n == -1);
 }
 
@@ -535,7 +536,8 @@ static int run_corpus_regression(const char *corpus_path, const char *baseline_p
    }
 
    static mem_eval_case_t cases[MEM_CORPUS_MAX_CASES];
-   int n_cases = mem_eval_load_corpus(corpus_path, MEMORY_EMBED_TEST_FIXTURE, cases, MEM_CORPUS_MAX_CASES);
+   int n_cases =
+       mem_eval_load_corpus(corpus_path, MEMORY_EMBED_TEST_FIXTURE, cases, MEM_CORPUS_MAX_CASES);
    if (n_cases <= 0)
    {
       fprintf(stderr, "FAIL: memory retrieval corpus failed for %s\n", corpus_path);

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -2228,5 +2228,5 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
       return requested;
    if (cfg && cfg->embedder_command[0])
       return cfg->embedder_command;
-   return "builtin";
+   return MEMORY_EMBED_TEST_FIXTURE;
 }

--- a/src/tests/test_server_jobs_aux.c
+++ b/src/tests/test_server_jobs_aux.c
@@ -336,5 +336,5 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
       return requested;
    if (cfg && cfg->embedder_command[0])
       return cfg->embedder_command;
-   return "builtin";
+   return MEMORY_EMBED_TEST_FIXTURE;
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -1310,5 +1310,5 @@ const char *config_embedder_command(const config_t *cfg, const char *requested)
       return requested;
    if (cfg && cfg->embedder_command[0])
       return cfg->embedder_command;
-   return "builtin";
+   return MEMORY_EMBED_TEST_FIXTURE;
 }


### PR DESCRIPTION
Found while testing the 0.3.0 merge end to end on a clean VM against the `:testing` images.

## The release is 0.3.0, and `v0.3.0` was never a burned tag

`WHATS_NEW.md`, `UPGRADING.md` and `RELEASING.md` called this cycle 0.3.1 and told
readers a `v0.3.0` tag had been promoted in error. No `v0.3.0` tag or release has ever
existed on the repository — only `v0.2.196`, a prerelease. The series carries no
`v0.3.*` tag, so the version the release flow infers on the next promote is 0.3.0.
Also corrected the commit count after `v0.2.196`: 705, not 536.

## An unconfigured kb answered searches it could not answer

A kb with no embedder served a builtin lexical feature hash. It came up healthy and
answered every search with keyword matching, so a deployment could run a long time
believing it had vector retrieval. It also claimed the corpus: db2 recorded
`builtin/lexical-v1` as the vector space on first init, so choosing a real embedder
afterwards was a space change the guard refused permanently — and the remedy the error
named (`aimee kb reembed`) is gated behind a setting inside the kb's own container,
which `aimee config set` cannot reach. QUICKSTART walked readers straight into it.

The fallback is gone. No embedder is a failure, reported at the earliest point that can
explain it:

- `memory_embed_text` embeds nothing when no command is configured.
- `config_embedder_command` returns `""`, not `"builtin"`. Returning a name was worse
  than the fallback once nothing implemented it: the string reached the sidecar exec
  path, forked `/bin/sh -c builtin` per embed call, failed, and charged the dependency
  breaker for an endpoint nobody configured.
- the kb entrypoint refuses to start, naming both ways out.
- deploy refuses a managed kb with no embedder **before any container runs**, where the
  wizard shows the reason instead of a container log.
- the wizard will not complete its topology step until an embedder is really chosen —
  a bundled model, or an endpoint **and** its width.

The lexical hash survives only as a test fixture: selected by the explicit
`MEMORY_EMBED_TEST_FIXTURE` command, never by absence of configuration, and
`AIMEE_DISABLE_DB2_SQLITE_SHIM` keeps it out of the shipped `aimee-kb` entirely.

### The gate has to be narrow

The first cut refused too much. The same image runs as a one-shot for jobs that never
answer a query, and the managed deploy's `aimee-server-identity` job is exactly that —
`managed-server-identity install`, with no `EMBEDDER_MODEL` because it does not need
one. A clean managed install then failed halfway: kb healthy, server identity enrolment
failed, server unable to talk to its kb. Serving is now distinguished from a one-shot by
whether the first argument is a flag, and `tests/test_kb_entrypoint.sh` covers both
directions. CI runs it.

## Migration

Corpora already recorded against `builtin/lexical-v1` — every existing `:testing`
deployment — would refuse to start the moment they were given the embedder they now
require. The serving-identity guard lets that one retired identity yield **when the
corpus is provably empty**. A lexical corpus that holds vectors is still refused: the
builtin was 384-dim and so is the bundled model, so the dim guard cannot see that
transition and this is the only thing that can.

## Also

- `docker compose -f compose.server-managed.yaml logs aimee-kb` fails with
  `no such service` — that file declares only `aimee-server`. QUICKSTART now addresses
  the project (`-p aimee`).
- `aimee agent list` said only `failed to load agent configuration` on a fresh install,
  where `agents.json` does not exist yet. A load failure is still never an empty roster,
  but it now names which failure it is.
- `mem_eval_load_corpus` takes its embedder as an argument. It resolved one from config
  internally, which hid the dependency behind the fallback; a retrieval benchmark whose
  corpus was never embedded measures nothing.

## Verification

- Full quickstart e2e on a clean Debian 13 VM against freshly built images: **27/27**.
  Covers first-boot PAM credential and login, deploy refused without an embedder and
  succeeding with one, mTLS enrolment, `audit verify`, memory store/search, the new
  `agent list` message on a genuinely fresh install, and `workspace add` / `index scan` /
  `overview` / `find`.
- Both documented embedder log lines confirmed verbatim; no `lexical` string in the kb log.
- C unit suite: 718 targets. The four failures that were mine are fixed; the other four
  are pre-existing (`code-treesitter` is gated behind `AIMEE_TREESITTER`, `kb-mgmt-live`
  needs host/CA arguments, two `-live` targets have link-line defects — reproduced on
  pristine source).
- Frontend: `tsc -b` clean, 159 tests pass (157 + 2 new).
- Every new test checked red-before-green.
