### PR TITLE
feat: make workflow triggers human-editable

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -270,8 +270,17 @@ Other source names can be displayed by the UI but are reported as unsupported by
 
 You can configure a watched directory in either place:
 
-- **Configure a rule.** Add it under `trigger_rules` in `aimee.yaml` or use the **Workflows** trigger panel.
-- **Configure the graph.** Make `trigger.watch-dir` the start node and set `params.workspace`.
+- select **Workflows → Triggers → + New trigger** as the appliance administrator, then choose the
+  repository, saved workflow, watched directory, optional branch/ref, mode, and spend cap;
+- add a rule under `trigger_rules` in `aimee.yaml` when repairing an invalid registry or managing it
+  as configuration;
+- make `trigger.watch-dir` the workflow's start node and set its `params.workspace`.
+
+The browser keeps a new trigger as a draft until an explicit save succeeds, uses optimistic
+versioning to avoid overwriting another operator, and makes graph-native triggers read-only. Other
+users can inspect automatic starts but cannot change the global registry. The registry accepts at
+most 32 rules and rejects repository traversal, option-shaped Git refs, invalid run modes, and
+negative or non-finite spend caps.
 
 A graph-native trigger without `params.workspace` is saved but disarmed. `params.dir` defaults to
 `docs/proposals/pending`; `params.ref` defaults to the refreshed remote default ref; and

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -12,8 +12,9 @@ pinned to work already in flight.
 
 1. **Open the composer.** Select **+ New proposal**.
 2. **Write the request.** Enter a title and proposal body, then choose a saved workflow.
-3. **Name the checkout.** Enter the repository path visible to the server. Although the field says
-   optional, the Go submit endpoint rejects a blank repository.
+3. **Choose the checkout.** Choose a managed repository or enter a custom checkout path visible to
+   the server. The form
+   requires this before it sends the proposal.
 4. **Use project help if needed.** **Draft with a delegate** and **Load from project** both show a preview before
    replacing the proposal body.
 5. **Submit the run.** The page opens it and begins polling.
@@ -84,14 +85,25 @@ The **Triggers** panel shows what can file a run automatically.
 
 ![The Workflows trigger list beside the expanded Run policy controls](images/workflow-actions-triggers-policy.png)
 
-- **Edit config triggers.** Config-origin rules can be added, saved, and removed in this panel.
-- **Edit graph triggers at the source.** A trigger from a saved workflow's `trigger.watch-dir` node is read-only in this
+- The appliance administrator can select **+ New trigger** and choose a managed repository (or
+  enter a custom server-visible checkout path), a saved workflow, the repository-relative
+  Markdown directory to watch, and an optional branch/ref, run mode, and per-run spend cap.
+- New and edited rules stay as browser drafts until **Save trigger** succeeds. The form validates
+  repository confinement and Git-ref safety before changing the shared registry, and a concurrent
+  edit reloads the current registry instead of overwriting it.
+- Non-administrators can inspect active triggers but do not see mutation controls. A malformed
+  on-disk registry is reported and held read-only so the browser cannot erase rules it failed to
+  parse.
+- A trigger originating from a saved workflow's `trigger.watch-dir` start node is read-only in this
   panel. Edit that node in **Edit Workflows** to change or disarm it.
-- **Use a supported scanner.** Go executes `watch-dir` and the compatibility name `proposals`. Other displayed source names
-  are not executed by this scanner.
+- The current Go scanner creates `watch-dir` rules; `proposals` remains a compatibility spelling for
+  existing configuration. Other source names are not offered by the browser because this scanner
+  cannot execute them.
 
 A watch rule needs a server-visible workspace, a saved workflow, a repository-relative proposal
 directory, and an optional git ref. Leaving the ref blank resolves the refreshed remote default ref.
+The browser offers valid saved workflows and repositories already managed for the signed-in
+administrator, while retaining a custom path option. The shared registry is limited to 32 rules.
 The mode and optional spend cap are stored with the admitted run, but mode alone is not an approval
 barrier in the current scheduler. Put `gate.human` in the graph when a person must decide.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@rakuensoftware/smoothgui": "file:vendor/rakuensoftware-smoothgui-0.8.1.tgz",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.5.0"
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
@@ -2301,9 +2301,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2321,7 +2321,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2395,9 +2395,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2417,12 +2417,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@rakuensoftware/smoothgui": "file:vendor/rakuensoftware-smoothgui-0.8.1.tgz",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.5.0"
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/frontend/src/pages/WorkflowActions.test.ts
+++ b/frontend/src/pages/WorkflowActions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isHumanGatePause, isTerminal } from "./WorkflowActions";
+import { isHumanGatePause, isTerminal, proposalDraftError, triggerRulesPayload, triggerValidationError, type Trigger } from "./WorkflowActions";
 
 describe("workflow action state compatibility", () => {
   it("shows human-gate controls for both workflow engines", () => {
@@ -12,5 +12,48 @@ describe("workflow action state compatibility", () => {
     expect(isTerminal("stopped")).toBe(true);
     expect(isTerminal("accepted")).toBe(true);
     expect(isTerminal("active")).toBe(false);
+  });
+});
+
+describe("human-authored workflow triggers", () => {
+  const valid: Trigger = {
+    source: "watch-dir",
+    event: "docs/proposals/pending",
+    schedule: "testing",
+    mode: "autonomous",
+    template: "build",
+    workspace: "/srv/repos/demo",
+    origin: "config",
+    max_spend_usd: 2.5,
+  };
+
+  it("validates repository confinement before saving", () => {
+    expect(triggerValidationError(valid)).toBe("");
+    expect(triggerValidationError({ ...valid, event: "../secrets" })).toContain("inside the repository");
+    expect(triggerValidationError({ ...valid, event: "docs\\requests" })).toContain("forward slashes");
+    expect(triggerValidationError({ ...valid, workspace: "" })).toContain("Choose a repository");
+    expect(triggerValidationError({ ...valid, schedule: "--all" })).toContain("cannot start");
+  });
+
+  it("serializes only config-owned rules in the canonical registry shape", () => {
+    const payload = triggerRulesPayload([
+      valid,
+      { ...valid, template: "graph-owned", origin: "workflow" },
+    ]);
+    expect(payload).toEqual([{
+      source: "watch-dir",
+      event: "docs/proposals/pending",
+      schedule: "testing",
+      mode: "autonomous",
+      pipeline: { template: "build", workspace: "/srv/repos/demo", max_spend_usd: 2.5 },
+    }]);
+  });
+});
+
+describe("manual workflow submission", () => {
+  it("requires the server-visible repository checkout the API needs", () => {
+    const draft = { title: "Change", body: "Do the work", workflow: "build", repo: "" };
+    expect(proposalDraftError(draft)).toContain("Choose a repository checkout");
+    expect(proposalDraftError({ ...draft, repo: "/srv/repos/demo" })).toBe("");
   });
 });

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -31,7 +31,7 @@ interface WfEvent {
   created_at: string;
 }
 // A configured trigger rule (aimee.yaml `trigger_rules`) that auto-starts runs.
-interface Trigger {
+export interface Trigger {
   source: string;
   event: string;
   schedule: string;
@@ -41,6 +41,19 @@ interface Trigger {
   max_spend_usd?: number;
   origin?: "config" | "workflow";
   last_error?: string;
+}
+
+interface TriggerRegistryResponse {
+  triggers: Trigger[];
+  version: string;
+  editable?: boolean;
+  max_rules?: number;
+  registry_error?: string;
+}
+
+interface WorkspaceOption {
+  label: string;
+  value: string;
 }
 
 const POLL_MS = 4000;
@@ -56,11 +69,17 @@ const SCAFFOLD = `## Goal
 ## Tests
 `;
 
-interface Draft {
+export interface Draft {
   title: string;
   body: string;
   workflow: string;
   repo: string;
+}
+
+export function proposalDraftError(draft: Draft): string {
+  if (!draft.body.trim()) return "Proposal body is empty.";
+  if (!draft.repo.trim()) return "Choose a repository checkout before starting the workflow.";
+  return "";
 }
 const emptyDraft = (): Draft => ({ title: "", body: SCAFFOLD, workflow: "build", repo: "" });
 function loadDraft(): Draft {
@@ -75,8 +94,15 @@ function loadDraft(): Draft {
 
 async function getJSON<T>(url: string): Promise<T> {
   const r = await fetch(url, { headers: { "X-CSRF-Token": window._csrf || "" } });
-  if (!r.ok) throw new Error(`HTTP ${r.status}`);
-  return (await r.json()) as T;
+  let data: unknown = {};
+  try { data = await r.json(); } catch { /* the status still carries the failure */ }
+  if (!r.ok) {
+    const message = data && typeof data === "object" && "error" in data
+      ? String((data as { error?: unknown }).error || `HTTP ${r.status}`)
+      : `HTTP ${r.status}`;
+    throw new Error(message);
+  }
+  return data as T;
 }
 async function postJSON<T>(url: string, body: unknown): Promise<{ status: number; data: T }> {
   const r = await fetch(url, {
@@ -101,11 +127,11 @@ async function loadWorkflowConfig(): Promise<Record<string, unknown>> {
   }
 }
 
-async function saveWorkflowConfig(key: string, value: unknown, previousVersion?: string): Promise<{ ok: boolean; value?: unknown; error?: string }> {
+async function saveWorkflowConfig(key: string, value: unknown, previousVersion?: string): Promise<{ ok: boolean; status: number; value?: unknown; error?: string }> {
   const response = await postJSON<{ ok?: boolean; key?: string; value?: unknown; error?: string }>("/api/workflow/config/set", { key, value, ...(previousVersion ? { previous_version: previousVersion } : {}) });
   return response.status >= 200 && response.status < 300 && response.data.ok === true && response.data.key === key && !response.data.error
-    ? { ok: true, value: response.data.value ?? value }
-    : { ok: false, error: response.data.error || `save failed (${response.status})` };
+    ? { ok: true, status: response.status, value: response.data.value ?? value }
+    : { ok: false, status: response.status, error: response.data.error || `save failed (${response.status})` };
 }
 
 // A bare method call (POST/DELETE) with no body — used for the lifecycle actions.
@@ -211,6 +237,11 @@ export default function WorkflowActions() {
   const [defs, setDefs] = useState<string[]>([]);
   const [triggers, setTriggers] = useState<Trigger[]>([]);
   const [triggerVersion, setTriggerVersion] = useState("");
+  const [triggerEditable, setTriggerEditable] = useState(false);
+  const [triggerMaxRules, setTriggerMaxRules] = useState(32);
+  const [triggerRegistryError, setTriggerRegistryError] = useState("");
+  const [triggerLoadError, setTriggerLoadError] = useState("");
+  const [triggerWorkspaces, setTriggerWorkspaces] = useState<WorkspaceOption[]>([]);
   const [triggersOpen, setTriggersOpen] = useState(true);
   const [submitMsg, setSubmitMsg] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -228,13 +259,37 @@ export default function WorkflowActions() {
   useEffect(() => {
     refreshList();
     // Workflow choices for the composer's picker (falls back to "build").
-    getJSON<{ defs: { name: string }[] }>("/api/workflow/defs")
-      .then((d) => setDefs((d.defs || []).map((x) => x.name)))
+    getJSON<{ defs: { name: string; valid?: boolean }[] }>("/api/workflow/defs")
+      .then((d) => setDefs((d.defs || []).filter((x) => x.valid !== false).map((x) => x.name)))
       .catch(() => setDefs([]));
-    // Configured trigger rules — what auto-starts runs (read-only view).
-    getJSON<{ triggers: Trigger[]; version: string }>("/api/workflow/triggers")
-      .then((d) => { setTriggers(d.triggers || []); setTriggerVersion(d.version || ""); })
-      .catch(() => setTriggers([]));
+    // Configured trigger rules — what auto-starts runs and whether this caller
+    // may edit the global registry.
+    getJSON<TriggerRegistryResponse>("/api/workflow/triggers")
+      .then((d) => {
+        setTriggers(d.triggers || []);
+        setTriggerVersion(d.version || "");
+        setTriggerEditable(d.editable === true);
+        setTriggerMaxRules(d.max_rules || 32);
+        setTriggerRegistryError(d.registry_error || "");
+        setTriggerLoadError("");
+      })
+      .catch((e: Error) => {
+        setTriggers([]);
+        setTriggerEditable(false);
+        setTriggerLoadError(`Could not load triggers: ${e.message}`);
+      });
+    // Offer managed repositories by name. A custom server-visible path remains
+    // available for repositories outside the managed workspace root.
+    getJSON<{ root?: string; projects?: string[] }>("/api/git/projects")
+      .then((d) => {
+        const root = (d.root || "").replace(/\/+$/, "");
+        const byPath = new Map<string, string>();
+        for (const name of d.projects || []) {
+          if (root && name) byPath.set(`${root}/${name}`, name);
+        }
+        setTriggerWorkspaces([...byPath].map(([value, label]) => ({ value, label })));
+      })
+      .catch(() => setTriggerWorkspaces([]));
   }, [refreshList]);
 
   // Persist the in-progress draft locally (device-local; cleared on logout).
@@ -251,7 +306,11 @@ export default function WorkflowActions() {
     setSelId(null);
     setDetail(null);
     setSubmitMsg("");
-  }, []);
+    setDraft((current) => ({
+      ...current,
+      repo: current.repo || (triggerWorkspaces.length === 1 ? triggerWorkspaces[0].value : ""),
+    }));
+  }, [triggerWorkspaces]);
   const updateDraft = useCallback(
     (patch: Partial<Draft>) => setDraft((d) => ({ ...d, ...patch })),
     [],
@@ -304,17 +363,19 @@ export default function WorkflowActions() {
   const submitProposal = useCallback(async () => {
     const title = draft.title.trim();
     const body = draft.body.trim();
-    if (!body) {
-      setSubmitMsg("Proposal body is empty.");
+    const validation = proposalDraftError(draft);
+    if (validation) {
+      setSubmitMsg(validation);
       return;
     }
+    const repo = draft.repo.trim();
     const md = title ? `# ${title}\n\n${body}` : body;
     setSubmitting(true);
     setSubmitMsg("");
     try {
       const { status: st, data } = await postJSON<{ work_item_id?: string; error?: string }>(
         "/api/dev/submit",
-        { proposal_md: md, workflow: draft.workflow || "build", repo: draft.repo || "" },
+        { proposal_md: md, workflow: draft.workflow || "build", repo },
       );
       if (st >= 200 && st < 300 && data.work_item_id) {
         try {
@@ -490,6 +551,12 @@ export default function WorkflowActions() {
           onChange={setTriggers}
           version={triggerVersion}
           onVersion={setTriggerVersion}
+          workflows={defs}
+          workspaces={triggerWorkspaces}
+          editable={triggerEditable}
+          maxRules={triggerMaxRules}
+          registryError={triggerRegistryError}
+          loadError={triggerLoadError}
           open={triggersOpen}
           onToggle={() => setTriggersOpen((v) => !v)}
         />
@@ -536,6 +603,7 @@ export default function WorkflowActions() {
           <Composer
             draft={draft}
             defs={defs}
+            workspaces={triggerWorkspaces}
             update={updateDraft}
             onSubmit={() => void submitProposal()}
             submitting={submitting}
@@ -792,16 +860,67 @@ function RunPolicyPanel() {
   );
 }
 
+export function triggerValidationError(trigger: Trigger): string {
+  if (!trigger.workspace.trim()) return "Choose a repository or enter its server-visible checkout path.";
+  if (!trigger.template.trim()) return "Choose a saved workflow.";
+  const directory = trigger.event.trim();
+  if (!directory) return "Enter the repository-relative directory to watch.";
+  if (directory.includes("\\") || /[\u0000-\u001f\u007f]/.test(directory)) {
+    return "Use a repository path with forward slashes and no control characters.";
+  }
+  const parts = directory.split("/");
+  if (directory.startsWith("/") || parts.includes("..") || directory === ".") {
+    return "The watched directory must stay inside the repository (for example docs/proposals/pending).";
+  }
+  if (trigger.schedule.trim().startsWith("-")) return "A branch or ref cannot start with '-'.";
+  if (trigger.mode !== "autonomous" && trigger.mode !== "interactive") return "Choose a supported run mode.";
+  if (trigger.max_spend_usd !== undefined && (!Number.isFinite(trigger.max_spend_usd) || trigger.max_spend_usd < 0)) {
+    return "The spend cap must be zero or a positive dollar amount.";
+  }
+  return "";
+}
+
+export function triggerRulesPayload(triggers: Trigger[]) {
+  return triggers.filter((t) => t.origin !== "workflow").map((t) => ({
+    source: "watch-dir",
+    event: t.event.trim() || "docs/proposals/pending",
+    schedule: t.schedule.trim(),
+    mode: t.mode || "autonomous",
+    pipeline: {
+      template: t.template.trim(),
+      workspace: t.workspace.trim(),
+      ...(t.max_spend_usd && t.max_spend_usd > 0 ? { max_spend_usd: t.max_spend_usd } : {}),
+    },
+  }));
+}
+
+function emptyTrigger(workflows: string[], workspaces: WorkspaceOption[]): Trigger {
+  return {
+    source: "watch-dir",
+    event: "docs/proposals/pending",
+    schedule: "",
+    mode: "autonomous",
+    template: workflows[0] || "build",
+    workspace: workspaces.length === 1 ? workspaces[0].value : "",
+    origin: "config",
+  };
+}
+
 // The configured trigger rules that auto-start runs, rendered as a compact,
-// collapsible section above the run list. This is the GUI's answer to "what is
-// wired to fire a workflow, and which workflow does it start" — read-only; rules
-// are edited in aimee.yaml. Empty => a hint that runs start only from a manual
-// submit (the + New proposal button).
-function TriggersPanel({
+// collapsible section above the run list. Config-origin rules are edited through
+// a guarded form; graph-native triggers remain read-only and point back to the
+// workflow editor that owns them.
+export function TriggersPanel({
   triggers,
   onChange,
   version,
   onVersion,
+  workflows,
+  workspaces,
+  editable,
+  maxRules,
+  registryError,
+  loadError,
   open,
   onToggle,
 }: {
@@ -809,46 +928,90 @@ function TriggersPanel({
   onChange: (triggers: Trigger[]) => void;
   version: string;
   onVersion: (version: string) => void;
+  workflows: string[];
+  workspaces: WorkspaceOption[];
+  editable: boolean;
+  maxRules: number;
+  registryError: string;
+  loadError: string;
   open: boolean;
   onToggle: () => void;
 }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
-  const persist = async (next: Trigger[]) => {
+  const [notice, setNotice] = useState("");
+  const [editing, setEditing] = useState<number | "new" | null>(null);
+  const [draft, setDraft] = useState<Trigger>(() => emptyTrigger(workflows, workspaces));
+
+  const reload = async () => {
+    const current = await getJSON<TriggerRegistryResponse>("/api/workflow/triggers");
+    onChange(current.triggers || []);
+    onVersion(current.version || "");
+  };
+  const persist = async (next: Trigger[]): Promise<boolean> => {
     setSaving(true);
     setError("");
-    const value = next.filter((t) => t.origin !== "workflow").map((t) => ({
-      source: t.source || "watch-dir",
-      event: t.event || "docs/proposals/pending",
-      schedule: t.schedule,
-      mode: t.mode || "autonomous",
-      pipeline: {
-        template: t.template,
-        workspace: t.workspace,
-        ...(t.max_spend_usd ? { max_spend_usd: t.max_spend_usd } : {}),
-      },
-    }));
-    const result = await saveWorkflowConfig("trigger_rules", value, version);
-    setSaving(false);
-    if (!result.ok) {
-      setError(result.error || "save failed; reloading current trigger configuration");
-      try {
-        const current = await getJSON<{ triggers: Trigger[]; version: string }>("/api/workflow/triggers");
-        onChange(current.triggers || []);
-        onVersion(current.version || "");
-      } catch { /* preserve the visible error */ }
-    } else {
-      const current = await getJSON<{ triggers: Trigger[]; version: string }>("/api/workflow/triggers");
-      onChange(current.triggers || []);
-      onVersion(current.version || "");
+    setNotice("");
+    try {
+      const result = await saveWorkflowConfig("trigger_rules", triggerRulesPayload(next), version);
+      if (!result.ok) {
+        if (result.status === 409) {
+          try { await reload(); } catch { /* retain the conflict error */ }
+          setError("Triggers changed in another session. The current registry was reloaded; review your edit and save again.");
+        } else {
+          setError(result.error || "Could not save the trigger registry.");
+        }
+        return false;
+      }
+      await reload();
+      return true;
+    } catch (e) {
+      setError(`Could not save triggers: ${e instanceof Error ? e.message : "service unavailable"}`);
+      return false;
+    } finally {
+      setSaving(false);
     }
   };
-  const add = () => onChange([...triggers, { source: "watch-dir", event: "docs/proposals/pending", schedule: "", mode: "autonomous", template: "build", workspace: "" }]);
-  const remove = (index: number) => persist(triggers.filter((_, i) => i !== index));
-  const update = (index: number, patch: Partial<Trigger>) => {
-    const next = triggers.map((t, i) => i === index ? { ...t, ...patch } : t);
-    onChange(next);
+  const startAdd = () => {
+    setDraft(emptyTrigger(workflows, workspaces));
+    setEditing("new");
+    setError("");
+    setNotice("");
   };
+  const startEdit = (index: number) => {
+    setDraft({ ...triggers[index], source: "watch-dir", origin: "config" });
+    setEditing(index);
+    setError("");
+    setNotice("");
+  };
+  const saveDraft = async () => {
+    const validation = triggerValidationError(draft);
+    if (validation) {
+      setError(validation);
+      return;
+    }
+    const next = editing === "new"
+      ? [...triggers, draft]
+      : triggers.map((trigger, index) => index === editing ? draft : trigger);
+    if (await persist(next)) {
+      setEditing(null);
+      setNotice(editing === "new" ? "Trigger created. It will scan on the next scheduler pass." : "Trigger updated.");
+    }
+  };
+  const remove = async (index: number) => {
+    if (!window.confirm("Remove this automatic trigger? Existing workflow runs are not affected.")) return;
+    if (await persist(triggers.filter((_, i) => i !== index))) {
+      if (editing === index) setEditing(null);
+      setNotice("Trigger removed. Existing workflow runs were left intact.");
+    }
+  };
+  const configCount = triggers.filter((trigger) => trigger.origin !== "workflow").length;
+  const unsupportedConfigCount = triggers.filter((trigger) =>
+    trigger.origin !== "workflow" && trigger.source !== "watch-dir" && trigger.source !== "proposals",
+  ).length;
+  const canEdit = editable && !registryError && !loadError && unsupportedConfigCount === 0;
+  const atLimit = configCount >= maxRules;
+
   return (
     <div style={{ marginTop: 10, borderTop: "1px solid #eee", paddingTop: 8 }}>
       <div
@@ -858,45 +1021,184 @@ function TriggersPanel({
         <span style={{ fontSize: 11, color: "#999", width: 10 }}>{open ? "▾" : "▸"}</span>
         <span style={{ fontWeight: 600, fontSize: 13 }}>⚡ Triggers</span>
         <Badge label={`${triggers.length}`} variant="neutral" />
-        <span style={{ marginLeft: "auto", fontSize: 11, color: "#aaa" }}>auto-start</span>
+        <span style={{ marginLeft: "auto", fontSize: 11, color: "#aaa" }}>automatic starts</span>
       </div>
       {open && (
         <div style={{ marginTop: 6 }}>
+          <div style={{ fontSize: 11, color: "#777", lineHeight: 1.45, marginBottom: 8 }}>
+            Watch a Git repository folder for committed Markdown files and start a saved workflow for each new proposal.
+          </div>
+          {loadError && <div role="alert" style={triggerErrorStyle}>{loadError}</div>}
+          {registryError && (
+            <div role="alert" style={triggerErrorStyle}>
+              The saved trigger registry is invalid and cannot be safely edited here: {registryError}
+            </div>
+          )}
+          {unsupportedConfigCount > 0 && (
+            <div role="alert" style={triggerErrorStyle}>
+              {unsupportedConfigCount} config trigger{unsupportedConfigCount === 1 ? " uses" : "s use"} a source this workflow scanner cannot edit. Manage the registry in <code>aimee.yaml</code>; browser writes are disabled to preserve those rules exactly.
+            </div>
+          )}
+          {!editable && !loadError && (
+            <div style={{ fontSize: 11, color: "#777", marginBottom: 8 }}>
+              Only the appliance administrator can change automatic triggers. You can still inspect what is active.
+            </div>
+          )}
           {triggers.length === 0 ? (
             <div style={{ fontSize: 12, color: "#999", lineHeight: 1.4 }}>
               No triggers configured — runs start from a manual submit (+ New proposal).
             </div>
           ) : (
-            triggers.map((t, i) => (
-              <div key={i} style={{ marginBottom: 8 }}>
-                <TriggerCard t={t} />
-                {t.origin === "workflow" ? (
-                  <div style={{ fontSize: 11, color: "#777", marginTop: 4 }}>Configured by the saved workflow’s trigger.watch-dir start node. Edit that node to change or disarm it.</div>
-                ) : (<>
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 4, marginTop: 4 }}>
-                  <input value={t.workspace} placeholder="workspace path" style={inp} onChange={(e) => update(i, { workspace: e.target.value })} />
-                  <input value={t.template} placeholder="workflow" style={inp} onChange={(e) => update(i, { template: e.target.value })} />
-                  <input value={t.event} placeholder="docs/proposals/pending" style={inp} onChange={(e) => update(i, { event: e.target.value })} />
-                  <input value={t.schedule} placeholder="git ref (auto if blank)" style={inp} onChange={(e) => update(i, { schedule: e.target.value })} />
-                </div>
-                <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
-                  <select value={t.mode} style={inp} onChange={(e) => update(i, { mode: e.target.value })}>
-                    <option value="autonomous">autonomous</option><option value="interactive">interactive</option>
-                  </select>
-                  <Button size="sm" onClick={() => persist(triggers)} disabled={saving || !t.workspace || !t.template}>save</Button>
-                  <Button size="sm" onClick={() => remove(i)} disabled={saving}>remove</Button>
-                </div>
-                </>)}
+            triggers.map((trigger, index) => (
+              <div key={`${trigger.origin || "config"}-${trigger.source}-${trigger.workspace}-${trigger.template}-${index}`} style={{ marginBottom: 8 }}>
+                <TriggerCard t={trigger} />
+                {trigger.origin === "workflow" ? (
+                  <div style={{ fontSize: 11, color: "#777", marginTop: 4 }}>
+                    Owned by this workflow’s <code>trigger.watch-dir</code> start node. Edit that node in Edit Workflows to change or disarm it.
+                  </div>
+                ) : canEdit && editing !== index ? (
+                  <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
+                    <Button size="sm" onClick={() => startEdit(index)} disabled={saving || editing !== null}>Edit</Button>
+                    <Button size="sm" onClick={() => remove(index)} disabled={saving || editing !== null}>Remove</Button>
+                  </div>
+                ) : null}
+                {editing === index && (
+                  <TriggerEditor
+                    draft={draft}
+                    onChange={(patch) => setDraft((current) => ({ ...current, ...patch }))}
+                    workflows={workflows}
+                    workspaces={workspaces}
+                    saving={saving}
+                    onSave={saveDraft}
+                    onCancel={() => { setEditing(null); setError(""); }}
+                  />
+                )}
               </div>
             ))
           )}
-          <Button size="sm" onClick={add} disabled={saving}>+ trigger</Button>
-          {error && <div style={{ color: "#c00", fontSize: 11 }}>{error}</div>}
+          {editing === "new" && (
+            <TriggerEditor
+              draft={draft}
+              onChange={(patch) => setDraft((current) => ({ ...current, ...patch }))}
+              workflows={workflows}
+              workspaces={workspaces}
+              saving={saving}
+              onSave={saveDraft}
+              onCancel={() => { setEditing(null); setError(""); }}
+            />
+          )}
+          {canEdit && editing === null && (
+            <Button size="sm" onClick={startAdd} disabled={saving || atLimit} title={atLimit ? `At the ${maxRules}-trigger safety limit.` : "Create an automatic workflow trigger."}>
+              + New trigger
+            </Button>
+          )}
+          {atLimit && canEdit && <div style={{ fontSize: 11, color: "#777", marginTop: 4 }}>The {maxRules}-trigger safety limit has been reached.</div>}
+          {notice && <div role="status" style={{ color: "#287a3f", fontSize: 11, marginTop: 5 }}>{notice}</div>}
+          {error && <div role="alert" style={triggerErrorStyle}>{error}</div>}
         </div>
       )}
     </div>
   );
 }
+
+function TriggerEditor({
+  draft,
+  onChange,
+  workflows,
+  workspaces,
+  saving,
+  onSave,
+  onCancel,
+}: {
+  draft: Trigger;
+  onChange: (patch: Partial<Trigger>) => void;
+  workflows: string[];
+  workspaces: WorkspaceOption[];
+  saving: boolean;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const managed = workspaces.some((workspace) => workspace.value === draft.workspace);
+  const availableWorkflows = workflows.includes(draft.template) || !draft.template
+    ? workflows
+    : [draft.template, ...workflows];
+  return (
+    <div style={{ border: "1px solid #dbe5f4", background: "#f8fbff", borderRadius: 6, padding: 9, marginTop: 6 }}>
+      <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 7 }}>Watch for committed Markdown proposals</div>
+      <div style={{ display: "grid", gap: 8 }}>
+        {workspaces.length > 0 && (
+          <TriggerField label="Managed repository" help="Choose a repository Aimee already manages, or use a custom checkout path.">
+            <select
+              aria-label="Managed repository"
+              style={inp}
+              value={managed ? draft.workspace : "__custom__"}
+              onChange={(e) => onChange({ workspace: e.target.value === "__custom__" ? "" : e.target.value })}
+            >
+              <option value="__custom__">Custom server path…</option>
+              {workspaces.map((workspace) => <option key={workspace.value} value={workspace.value}>{workspace.label}</option>)}
+            </select>
+          </TriggerField>
+        )}
+        {(!managed || workspaces.length === 0) && (
+          <TriggerField label="Repository checkout" help="Absolute checkout path visible to the Aimee server, not a path on your browser device.">
+            <input aria-label="Repository checkout" value={draft.workspace} placeholder="/srv/repos/my-project" style={inp} onChange={(e) => onChange({ workspace: e.target.value })} />
+          </TriggerField>
+        )}
+        <TriggerField label="Workflow" help="The saved workflow started once for each new Markdown file.">
+          <select aria-label="Workflow" value={draft.template} style={inp} onChange={(e) => onChange({ template: e.target.value })}>
+            {!draft.template && <option value="">Choose a workflow…</option>}
+            {availableWorkflows.map((workflow) => <option key={workflow} value={workflow}>{workflow}</option>)}
+          </select>
+        </TriggerField>
+        <TriggerField label="Directory to watch" help="Repository-relative directory containing proposal Markdown files.">
+          <input aria-label="Directory to watch" value={draft.event} placeholder="docs/proposals/pending" style={inp} onChange={(e) => onChange({ event: e.target.value })} />
+        </TriggerField>
+        <TriggerField label="Branch or Git ref (optional)" help="Blank follows the refreshed origin default branch. Branch names are resolved on the remote.">
+          <input aria-label="Branch or Git ref (optional)" value={draft.schedule} placeholder="default branch" style={inp} onChange={(e) => onChange({ schedule: e.target.value })} />
+        </TriggerField>
+        <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)", gap: 8 }}>
+          <TriggerField label="Run mode" help="Interactive records the mode; use a human gate in the workflow when approval must be mandatory.">
+            <select aria-label="Run mode" value={draft.mode} style={inp} onChange={(e) => onChange({ mode: e.target.value })}>
+              <option value="autonomous">Autonomous</option>
+              <option value="interactive">Interactive metadata</option>
+            </select>
+          </TriggerField>
+          <TriggerField label="Spend cap (optional)" help="Maximum provider spend for each admitted run; blank means the workflow default.">
+            <input
+              aria-label="Spend cap (optional)"
+              type="number"
+              min="0"
+              step="0.01"
+              value={draft.max_spend_usd ?? ""}
+              placeholder="No extra cap"
+              style={inp}
+              onChange={(e) => onChange({ max_spend_usd: e.target.value === "" ? undefined : Number(e.target.value) })}
+            />
+          </TriggerField>
+        </div>
+      </div>
+      <div style={{ fontSize: 11, color: "#777", lineHeight: 1.4, marginTop: 8 }}>
+        The scanner reads committed files from Git. Uncommitted files do not fire, and unchanged proposal content is deduplicated.
+      </div>
+      <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
+        <Button variant="primary" size="sm" onClick={onSave} disabled={saving}>{saving ? "Saving…" : "Save trigger"}</Button>
+        <Button size="sm" onClick={onCancel} disabled={saving}>Cancel</Button>
+      </div>
+    </div>
+  );
+}
+
+function TriggerField({ label, help, children }: { label: string; help: string; children: React.ReactNode }) {
+  return (
+    <label title={help} style={{ display: "grid", gap: 3, fontSize: 11, color: "#555" }}>
+      <span style={{ fontWeight: 600 }}>{label}</span>
+      {children}
+      <span style={{ color: "#8a8a8a", lineHeight: 1.25 }}>{help}</span>
+    </label>
+  );
+}
+
+const triggerErrorStyle: React.CSSProperties = { color: "#a51d1d", background: "#fff3f3", border: "1px solid #ffd2d2", borderRadius: 4, padding: "5px 7px", fontSize: 11, marginTop: 5, marginBottom: 5 };
 
 // One trigger rule as a compact card: what fires it (source + event/schedule),
 // which workflow it starts, how it runs (mode), and where (workspace).
@@ -948,6 +1250,7 @@ function TriggerCard({ t }: { t: Trigger }) {
 function Composer({
   draft,
   defs,
+  workspaces,
   update,
   onSubmit,
   submitting,
@@ -955,6 +1258,7 @@ function Composer({
 }: {
   draft: Draft;
   defs: string[];
+  workspaces: WorkspaceOption[];
   update: (patch: Partial<Draft>) => void;
   onSubmit: () => void;
   submitting: boolean;
@@ -1088,15 +1392,34 @@ function Composer({
           </select>
         </L>
       </div>
-      <L label="Repo (optional)">
-        <input
-          value={draft.repo}
-          onChange={(e) => update({ repo: e.target.value })}
-          placeholder="owner/name or clone URL (blank = default)"
-          style={inp}
-          disabled={busy}
-        />
-      </L>
+      {workspaces.length > 0 && (
+        <L label="Managed repository">
+          <select
+            aria-label="Proposal repository"
+            value={workspaces.some((workspace) => workspace.value === draft.repo) ? draft.repo : "__custom__"}
+            onChange={(e) => update({ repo: e.target.value === "__custom__" ? "" : e.target.value })}
+            style={inp}
+            disabled={busy}
+            title="Repository checkout the workflow is allowed to modify."
+          >
+            <option value="__custom__">Custom server path…</option>
+            {workspaces.map((workspace) => <option key={workspace.value} value={workspace.value}>{workspace.label}</option>)}
+          </select>
+        </L>
+      )}
+      {(!workspaces.some((workspace) => workspace.value === draft.repo) || workspaces.length === 0) && (
+        <L label="Repository checkout (required)">
+          <input
+            aria-label="Repository checkout (required)"
+            value={draft.repo}
+            onChange={(e) => update({ repo: e.target.value })}
+            placeholder="/srv/repos/my-project"
+            style={inp}
+            disabled={busy}
+            title="Absolute checkout path visible to the Aimee server."
+          />
+        </L>
+      )}
       <L label="Proposal (Markdown)">
         <textarea
           value={draft.body}

--- a/frontend/src/pages/WorkflowTriggers.test.tsx
+++ b/frontend/src/pages/WorkflowTriggers.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { TriggersPanel, type Trigger } from "./WorkflowActions";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const baseProps = {
+  triggers: [] as Trigger[],
+  onChange: vi.fn(),
+  version: "version-1",
+  onVersion: vi.fn(),
+  workflows: ["build", "manual-review"],
+  workspaces: [{ label: "demo", value: "/srv/repos/demo" }],
+  editable: true,
+  maxRules: 32,
+  registryError: "",
+  loadError: "",
+  open: true,
+  onToggle: vi.fn(),
+};
+
+describe("TriggersPanel", () => {
+  it("creates a usable trigger through the browser API contract", async () => {
+    const onChange = vi.fn();
+    const onVersion = vi.fn();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.method === "POST") {
+        return new Response(JSON.stringify({ ok: true, key: "trigger_rules" }), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({
+        editable: true,
+        version: "version-2",
+        triggers: [{
+          source: "watch-dir", event: "docs/requests", schedule: "testing",
+          mode: "interactive", template: "manual-review", workspace: "/srv/repos/demo", origin: "config",
+        }],
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+
+    render(<TriggersPanel {...baseProps} onChange={onChange} onVersion={onVersion} />);
+    fireEvent.click(screen.getByRole("button", { name: "+ New trigger" }));
+    fireEvent.change(screen.getByLabelText("Workflow"), { target: { value: "manual-review" } });
+    fireEvent.change(screen.getByLabelText("Directory to watch"), { target: { value: "docs/requests" } });
+    fireEvent.change(screen.getByLabelText("Branch or Git ref (optional)"), { target: { value: "testing" } });
+    fireEvent.change(screen.getByLabelText("Run mode"), { target: { value: "interactive" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save trigger" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const post = fetchMock.mock.calls[0];
+    expect(post[0]).toBe("/api/workflow/config/set");
+    const request = JSON.parse(String(post[1]?.body));
+    expect(request).toEqual({
+      key: "trigger_rules",
+      previous_version: "version-1",
+      value: [{
+        source: "watch-dir", event: "docs/requests", schedule: "testing", mode: "interactive",
+        pipeline: { template: "manual-review", workspace: "/srv/repos/demo" },
+      }],
+    });
+    expect(onChange).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ template: "manual-review" })]));
+    expect(onVersion).toHaveBeenCalledWith("version-2");
+    expect((await screen.findByRole("status")).textContent).toContain("Trigger created");
+  });
+
+  it("keeps invalid edits local and explains how to fix them", () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    render(<TriggersPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "+ New trigger" }));
+    fireEvent.change(screen.getByLabelText("Directory to watch"), { target: { value: "../../outside" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save trigger" }));
+    expect(screen.getByRole("alert").textContent).toContain("inside the repository");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not offer global mutations to a non-administrator", () => {
+    render(<TriggersPanel {...baseProps} editable={false} />);
+    expect(screen.queryByRole("button", { name: "+ New trigger" })).toBeNull();
+    expect(screen.getByText(/Only the appliance administrator/)).toBeTruthy();
+  });
+
+  it("does not rewrite config sources the Go scanner cannot preserve", () => {
+    render(<TriggersPanel {...baseProps} triggers={[{
+      source: "cron", event: "", schedule: "0 * * * *", mode: "autonomous",
+      template: "nightly", workspace: "/srv/repos/demo", origin: "config",
+    }]} />);
+    expect(screen.getByRole("alert").textContent).toContain("browser writes are disabled");
+    expect(screen.queryByRole("button", { name: "+ New trigger" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+  });
+});

--- a/runtime-web/workflow.go
+++ b/runtime-web/workflow.go
@@ -113,7 +113,20 @@ func (s *server) handleWorkflowDefs(w http.ResponseWriter, r *http.Request) {
 
 // GET /api/workflow/triggers — the configured trigger rules that auto-start runs.
 func (s *server) handleWorkflowTriggers(w http.ResponseWriter, r *http.Request) {
-	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/triggers", "")
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	// The Go registry response includes whether this principal may edit global
+	// triggers, so this read must carry the attested web identity too. The runtime
+	// owns the appliance-admin lookup (the bootstrap account is renamed during
+	// setup); normalize that capability to the Go control plane's internal admin
+	// principal after the trusted check instead of forwarding a literal username.
+	user := currentUser(r)
+	if s.isAdmin(r) {
+		user = "admin"
+	}
+	s.webuserPassAs(w, r, user, http.MethodGet, "/v1/workflow/triggers", nil)
 }
 
 func (s *server) handleWorkflowConfig(w http.ResponseWriter, r *http.Request) {
@@ -132,7 +145,7 @@ func (s *server) handleWorkflowConfigSet(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	s.webuserPass(w, r, http.MethodPost, "/v1/workflow/config/set", body)
+	s.webuserPassAs(w, r, "admin", http.MethodPost, "/v1/workflow/config/set", body)
 }
 
 // POST /api/workflow/validate — validate posted YAML without saving.
@@ -218,9 +231,16 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 // webuserPass proxies to an aimee-server /v1 path under the caller's webuser
 // identity (so ownership scoping resolves) and streams the envelope back verbatim.
 func (s *server) webuserPass(w http.ResponseWriter, r *http.Request, method, v1path string, body []byte) {
+	s.webuserPassAs(w, r, currentUser(r), method, v1path, body)
+}
+
+// webuserPassAs is reserved for identities resolved at this trusted runtime
+// boundary, notably the appliance administrator capability. Ordinary workflow
+// ownership calls use webuserPass and retain the signed-in username unchanged.
+func (s *server) webuserPassAs(w http.ResponseWriter, r *http.Request, user, method, v1path string, body []byte) {
 	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
 	defer cancel()
-	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), method, v1path, body)
+	st, data, err := s.v1RequestWebuser(ctx, user, method, v1path, body)
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		w.WriteHeader(http.StatusBadGateway)

--- a/runtime-web/workflow_test.go
+++ b/runtime-web/workflow_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -14,6 +16,64 @@ func TestWorkflowGlobalConfigRequiresAdministrator(t *testing.T) {
 	s.handleWorkflowConfigSet(rr, req)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status=%d, want 403", rr.Code)
+	}
+}
+
+func TestWorkflowTriggersReadCarriesWebuserIdentity(t *testing.T) {
+	var gotMethod, gotUser string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/workflow/triggers", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotUser = r.Header.Get("X-Aimee-Webuser")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"editable":true,"triggers":[]}`))
+	})
+	s := &server{cfg: startFakeV1(t, mux)}
+	req := withUser(httptest.NewRequest(http.MethodGet, "/api/workflow/triggers", nil), "admin")
+	rr := httptest.NewRecorder()
+	s.handleWorkflowTriggers(rr, req)
+	if rr.Code != http.StatusOK || gotMethod != http.MethodGet || gotUser != "admin" {
+		t.Fatalf("code=%d method=%q user=%q body=%s", rr.Code, gotMethod, gotUser, rr.Body.String())
+	}
+}
+
+func TestWorkflowPolicyMapsReplacementAdministratorToControlPlaneCapability(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "webchat"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "webchat", "bootstrap-replaced"), []byte("virant\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/workflow/triggers", func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser"))
+		_, _ = w.Write([]byte(`{"editable":true,"triggers":[]}`))
+	})
+	mux.HandleFunc("/v1/workflow/config/set", func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser"))
+		_, _ = w.Write([]byte(`{"ok":true,"key":"trigger_rules"}`))
+	})
+	cfg := startFakeV1(t, mux)
+	cfg.dbPath = filepath.Join(root, "webchat.db")
+	s := &server{cfg: cfg}
+
+	read := withUser(httptest.NewRequest(http.MethodGet, "/api/workflow/triggers", nil), "virant")
+	readRecorder := httptest.NewRecorder()
+	s.handleWorkflowTriggers(readRecorder, read)
+	write := withUser(httptest.NewRequest(http.MethodPost, "/api/workflow/config/set",
+		strings.NewReader(`{"key":"trigger_rules","value":[],"previous_version":"v1"}`)), "virant")
+	writeRecorder := httptest.NewRecorder()
+	s.handleWorkflowConfigSet(writeRecorder, write)
+
+	if readRecorder.Code != http.StatusOK || writeRecorder.Code != http.StatusOK {
+		t.Fatalf("read=%d %s write=%d %s", readRecorder.Code, readRecorder.Body.String(), writeRecorder.Code, writeRecorder.Body.String())
+	}
+	want := []string{"GET:admin", "POST:admin"}
+	if len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+		t.Fatalf("control-plane calls=%v, want %v", calls, want)
 	}
 }
 

--- a/server-go/internal/api/config.go
+++ b/server-go/internal/api/config.go
@@ -3,8 +3,11 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
+
+	appconfig "github.com/JBailes/aimee/server-go/internal/config"
 )
 
 func (s *Server) configGet(w http.ResponseWriter, _ *http.Request) {
@@ -40,6 +43,10 @@ func (s *Server) configSet(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("expected key and value"))
 		return
 	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeError(w, http.StatusBadRequest, errors.New("request must contain one JSON value"))
+		return
+	}
 	if request.Key == "trigger_rules" && request.PreviousVersion == "" {
 		writeError(w, http.StatusConflict, errors.New("trigger_rules requires previous_version"))
 		return
@@ -58,13 +65,17 @@ func (s *Server) configSet(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "key": request.Key, "value": request.Value})
 }
 
-func (s *Server) workflowTriggers(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) workflowTriggers(w http.ResponseWriter, r *http.Request) {
 	if s.config == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"max_concurrent": 2, "triggers": []any{}})
+		writeJSON(w, http.StatusOK, map[string]any{
+			"editable": false, "max_concurrent": 2,
+			"max_rules": appconfig.MaxTriggerRules, "triggers": []any{},
+		})
 		return
 	}
 	rules := s.triggerRequests()
 	version, _ := s.config.Version("trigger_rules")
+	_, registryErr := s.config.TriggerRules()
 	triggers := make([]map[string]any, 0, len(rules))
 	for _, rule := range rules {
 		item := map[string]any{
@@ -83,5 +94,17 @@ func (s *Server) workflowTriggers(w http.ResponseWriter, _ *http.Request) {
 		}
 		triggers = append(triggers, item)
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"max_concurrent": s.config.Int("trigger.max_concurrent", 2), "version": version, "triggers": triggers})
+	response := map[string]any{
+		"editable":       r.Header.Get("X-Aimee-Webuser") == "admin",
+		"max_concurrent": s.config.Int("trigger.max_concurrent", 2),
+		"max_rules":      appconfig.MaxTriggerRules,
+		"version":        version,
+		"triggers":       triggers,
+	}
+	if registryErr != nil {
+		// Do not disguise a malformed registry as an empty one: the browser must
+		// not offer to overwrite config it could not faithfully load.
+		response["registry_error"] = registryErr.Error()
+	}
+	writeJSON(w, http.StatusOK, response)
 }

--- a/server-go/internal/api/server_test.go
+++ b/server-go/internal/api/server_test.go
@@ -139,6 +139,130 @@ func TestBearerAuthentication(t *testing.T) {
 	}
 }
 
+func TestWorkflowTriggerRegistryRoundTripFromBrowserContract(t *testing.T) {
+	server, _, _ := newTestServer(t)
+	configPath := filepath.Join(t.TempDir(), "aimee.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: codex\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configStore, err := appconfig.NewStore(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.SetConfigStore(configStore)
+
+	get := func(user string) map[string]any {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/v1/workflow/triggers", nil)
+		req.Header.Set("X-Aimee-Webuser", user)
+		rec := httptest.NewRecorder()
+		server.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET triggers status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var response map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		return response
+	}
+
+	initial := get("admin")
+	version, _ := initial["version"].(string)
+	if version == "" || initial["editable"] != true || initial["max_rules"] != float64(appconfig.MaxTriggerRules) {
+		t.Fatalf("initial trigger registry metadata = %#v", initial)
+	}
+	rules := []map[string]any{{
+		"source": "watch-dir", "event": "docs/requests", "schedule": "testing",
+		"mode":     "interactive",
+		"pipeline": map[string]any{"template": "build", "workspace": "/srv/repos/demo", "max_spend_usd": 4.5},
+	}}
+	body, _ := json.Marshal(map[string]any{"key": "trigger_rules", "value": rules, "previous_version": version})
+	req := httptest.NewRequest(http.MethodPost, "/v1/workflow/config/set", bytes.NewReader(body))
+	req.Header.Set("X-Aimee-Webuser", "admin")
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("save registry status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	saved := get("admin")
+	triggers, _ := saved["triggers"].([]any)
+	if len(triggers) != 1 {
+		t.Fatalf("saved triggers = %#v", saved)
+	}
+	trigger, _ := triggers[0].(map[string]any)
+	if trigger["event"] != "docs/requests" || trigger["template"] != "build" || trigger["origin"] != "config" || trigger["max_spend_usd"] != 4.5 {
+		t.Fatalf("saved trigger = %#v", trigger)
+	}
+	content, _ := os.ReadFile(configPath)
+	if !strings.Contains(string(content), "provider: codex") {
+		t.Fatalf("unrelated config was lost:\n%s", content)
+	}
+	if get("alice")["editable"] != false {
+		t.Fatal("non-administrator registry was advertised as editable")
+	}
+
+	staleReq := httptest.NewRequest(http.MethodPost, "/v1/workflow/config/set", bytes.NewReader(body))
+	staleReq.Header.Set("X-Aimee-Webuser", "admin")
+	staleRec := httptest.NewRecorder()
+	server.ServeHTTP(staleRec, staleReq)
+	if staleRec.Code != http.StatusConflict || !strings.Contains(staleRec.Body.String(), "version conflict") {
+		t.Fatalf("stale save status=%d body=%s", staleRec.Code, staleRec.Body.String())
+	}
+}
+
+func TestWorkflowTriggerRegistryRejectsUnsafeWrites(t *testing.T) {
+	server, _, _ := newTestServer(t)
+	configStore, _ := appconfig.NewStore(filepath.Join(t.TempDir(), "aimee.yaml"))
+	server.SetConfigStore(configStore)
+	version, _ := configStore.Version("trigger_rules")
+	validRule := `[{"source":"watch-dir","pipeline":{"template":"build","workspace":"/repo"}}]`
+
+	cases := []struct {
+		name, user, body string
+		status           int
+	}{
+		{"non-admin", "alice", `{"key":"trigger_rules","value":` + validRule + `,"previous_version":"` + version + `"}`, http.StatusForbidden},
+		{"unsupported-source", "admin", `{"key":"trigger_rules","value":[{"source":"webhook","pipeline":{"template":"build","workspace":"/repo"}}],"previous_version":"` + version + `"}`, http.StatusBadRequest},
+		{"trailing-json", "admin", `{"key":"trigger_rules","value":` + validRule + `,"previous_version":"` + version + `"}{}`, http.StatusBadRequest},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/workflow/config/set", strings.NewReader(test.body))
+			req.Header.Set("X-Aimee-Webuser", test.user)
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, req)
+			if rec.Code != test.status {
+				t.Fatalf("status=%d body=%s, want %d", rec.Code, rec.Body.String(), test.status)
+			}
+		})
+	}
+}
+
+func TestWorkflowTriggerRegistryReportsMalformedConfigWithoutHidingIt(t *testing.T) {
+	server, _, _ := newTestServer(t)
+	configPath := filepath.Join(t.TempDir(), "aimee.yaml")
+	bad := "trigger_rules:\n  - source: watch-dir\n    event: ../outside\n    pipeline:\n      template: build\n      workspace: /repo\n"
+	if err := os.WriteFile(configPath, []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configStore, _ := appconfig.NewStore(configPath)
+	server.SetConfigStore(configStore)
+	req := httptest.NewRequest(http.MethodGet, "/v1/workflow/triggers", nil)
+	req.Header.Set("X-Aimee-Webuser", "admin")
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"registry_error"`) ||
+		!strings.Contains(rec.Body.String(), "repository-relative") {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	content, _ := os.ReadFile(configPath)
+	if string(content) != bad {
+		t.Fatalf("malformed config was changed by a read:\n%s", content)
+	}
+}
+
 func TestProposalTriggerFilesCompleteGitBlobAndDeduplicates(t *testing.T) {
 	server, store, artifacts := newTestServer(t)
 	root := t.TempDir()

--- a/server-go/internal/config/store.go
+++ b/server-go/internal/config/store.go
@@ -5,7 +5,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -17,6 +19,11 @@ type Store struct {
 	path string
 	mu   sync.Mutex
 }
+
+// MaxTriggerRules keeps the human-editable Go registry aligned with the
+// long-standing C config schema. More rules than this are almost certainly an
+// accidental duplicate/import and would make every scheduler scan expensive.
+const MaxTriggerRules = 32
 
 // TriggerRule is the persisted trigger_rules shape exposed by the Workflows UI.
 // Pipeline remains nested in YAML; callers never need to reinterpret flattened
@@ -53,6 +60,9 @@ func (s *Store) TriggerRules() ([]TriggerRule, error) {
 	if err := node.Decode(&rules); err != nil {
 		return nil, fmt.Errorf("decode trigger_rules: %w", err)
 	}
+	if len(rules) > MaxTriggerRules {
+		return nil, fmt.Errorf("trigger_rules has %d rules; maximum is %d", len(rules), MaxTriggerRules)
+	}
 	for i := range rules {
 		if rules[i].Source == "" {
 			return nil, fmt.Errorf("trigger_rules[%d].source is required", i)
@@ -67,8 +77,17 @@ func (s *Store) TriggerRules() ([]TriggerRule, error) {
 			if rules[i].Event == "" {
 				rules[i].Event = "docs/proposals/pending"
 			}
+			if !confinedTriggerDirectory(rules[i].Event) {
+				return nil, fmt.Errorf("trigger_rules[%d].event must be a repository-relative directory", i)
+			}
+			if strings.HasPrefix(strings.TrimSpace(rules[i].Schedule), "-") {
+				return nil, fmt.Errorf("trigger_rules[%d].schedule cannot start with '-'", i)
+			}
 			if rules[i].Pipeline.Template == "" || rules[i].Pipeline.Workspace == "" {
 				return nil, fmt.Errorf("trigger_rules[%d] needs pipeline.template and pipeline.workspace", i)
+			}
+			if rules[i].Pipeline.MaxSpendUSD < 0 || math.IsNaN(rules[i].Pipeline.MaxSpendUSD) || math.IsInf(rules[i].Pipeline.MaxSpendUSD, 0) {
+				return nil, fmt.Errorf("trigger_rules[%d].pipeline.max_spend_usd must be finite and non-negative", i)
 			}
 		}
 	}
@@ -333,6 +352,9 @@ func validateKeyValue(key string, value any) error {
 		if err := node.Decode(&rules); err != nil {
 			return fmt.Errorf("trigger_rules must be a list of rules: %w", err)
 		}
+		if len(rules) > MaxTriggerRules {
+			return fmt.Errorf("trigger_rules has %d rules; maximum is %d", len(rules), MaxTriggerRules)
+		}
 		for i, rule := range rules {
 			if rule.Source != "watch-dir" && rule.Source != "proposals" {
 				return fmt.Errorf("trigger_rules[%d].source must be watch-dir or proposals", i)
@@ -340,8 +362,21 @@ func validateKeyValue(key string, value any) error {
 			if rule.Mode != "" && rule.Mode != "autonomous" && rule.Mode != "interactive" {
 				return fmt.Errorf("trigger_rules[%d].mode must be autonomous or interactive", i)
 			}
+			event := rule.Event
+			if event == "" {
+				event = "docs/proposals/pending"
+			}
+			if !confinedTriggerDirectory(event) {
+				return fmt.Errorf("trigger_rules[%d].event must be a repository-relative directory", i)
+			}
+			if strings.HasPrefix(strings.TrimSpace(rule.Schedule), "-") {
+				return fmt.Errorf("trigger_rules[%d].schedule cannot start with '-'", i)
+			}
 			if rule.Pipeline.Template == "" || rule.Pipeline.Workspace == "" {
 				return fmt.Errorf("trigger_rules[%d] needs pipeline.template and pipeline.workspace", i)
+			}
+			if rule.Pipeline.MaxSpendUSD < 0 || math.IsNaN(rule.Pipeline.MaxSpendUSD) || math.IsInf(rule.Pipeline.MaxSpendUSD, 0) {
+				return fmt.Errorf("trigger_rules[%d].pipeline.max_spend_usd must be finite and non-negative", i)
 			}
 		}
 		return nil
@@ -365,6 +400,15 @@ func validateKeyValue(key string, value any) error {
 		}
 	}
 	return nil
+}
+
+func confinedTriggerDirectory(directory string) bool {
+	directory = strings.TrimSpace(directory)
+	if strings.Contains(directory, "\\") || strings.IndexFunc(directory, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		return false
+	}
+	clean := path.Clean(directory)
+	return clean != "." && !path.IsAbs(clean) && clean != ".." && !strings.HasPrefix(clean, "../")
 }
 
 func number(value any) (int64, bool) {

--- a/server-go/internal/config/store_test.go
+++ b/server-go/internal/config/store_test.go
@@ -104,3 +104,48 @@ func TestTriggerRulesUseOptimisticVersion(t *testing.T) {
 		t.Fatal("stale trigger edit accepted")
 	}
 }
+
+func TestTriggerRulesRejectOversizedRegistry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aimee.yaml")
+	store, _ := NewStore(path)
+	version, err := store.Version("trigger_rules")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules := make([]map[string]any, MaxTriggerRules+1)
+	for i := range rules {
+		rules[i] = map[string]any{
+			"source":   "watch-dir",
+			"pipeline": map[string]any{"template": "build", "workspace": "/repo"},
+		}
+	}
+	if err := store.SetVersioned("trigger_rules", rules, version); err == nil || !strings.Contains(err.Error(), "maximum is 32") {
+		t.Fatalf("oversized registry error = %v", err)
+	}
+}
+
+func TestTriggerRulesRejectUnsafeHumanInputs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aimee.yaml")
+	store, _ := NewStore(path)
+	version, _ := store.Version("trigger_rules")
+	base := map[string]any{
+		"source": "watch-dir", "event": "docs/proposals/pending",
+		"pipeline": map[string]any{"template": "build", "workspace": "/repo"},
+	}
+	for name, mutate := range map[string]func(map[string]any){
+		"traversal":    func(rule map[string]any) { rule["event"] = "../outside" },
+		"git-option":   func(rule map[string]any) { rule["schedule"] = "--all" },
+		"negative-cap": func(rule map[string]any) { rule["pipeline"].(map[string]any)["max_spend_usd"] = -1 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			rule := map[string]any{
+				"source": base["source"], "event": base["event"],
+				"pipeline": map[string]any{"template": "build", "workspace": "/repo"},
+			}
+			mutate(rule)
+			if err := store.SetVersioned("trigger_rules", []map[string]any{rule}, version); err == nil {
+				t.Fatal("unsafe trigger rule was accepted")
+			}
+		})
+	}
+}

--- a/server-go/internal/engine/main_test.go
+++ b/server-go/internal/engine/main_test.go
@@ -1,0 +1,20 @@
+package engine
+
+import (
+	"os"
+	"testing"
+)
+
+// The production runner deliberately fails closed when its sealed Git identity
+// is absent. Engine tests create throwaway repositories and need a deterministic
+// identity of their own instead of depending on a developer's shell or global
+// gitconfig.
+func TestMain(m *testing.M) {
+	if os.Getenv("AIMEE_GIT_AUTHOR_NAME") == "" {
+		_ = os.Setenv("AIMEE_GIT_AUTHOR_NAME", "Aimee Test")
+	}
+	if os.Getenv("AIMEE_GIT_AUTHOR_EMAIL") == "" {
+		_ = os.Setenv("AIMEE_GIT_AUTHOR_EMAIL", "aimee-test@example.invalid")
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

- add a human-usable trigger editor with managed repository and workflow pickers, custom checkout support, validation, save/cancel/remove flows, and optimistic concurrency handling
- make malformed, unsupported, graph-owned, and non-admin trigger registries safely read-only instead of risking silent data loss
- enforce trigger limits and validate repository-relative directories, Git refs, run modes, spend caps, and JSON request boundaries in the Go control plane
- fix manual proposal repository selection and map trusted replacement administrators to the workflow service's internal admin capability
- make native workflow end-to-end tests hermetic when the developer shell has no Git author identity
- update workflow documentation and affected frontend dependencies

## Why

Trigger configuration was exposed as a low-level rule list that did not give an operator a practical way to select a managed checkout and saved workflow. Several failure paths could also hide malformed configuration or allow stale browser state to overwrite another operator's edits.

The runtime proxy additionally forwarded a replacement administrator's username literally, while the workflow control plane recognizes the internal `admin` capability. That made trigger writes fail after the bootstrap administrator was renamed.

## Impact

Appliance administrators can create and maintain directory-watch triggers from the browser with clear safety boundaries. Other users retain visibility without mutation controls, and graph-native or unknown trigger sources are preserved at their source.

## Validation

- `npm ci`
- `npm test` — 15 files, 166 tests
- `npm run build`
- `go test ./... -count=1 && go vet ./...` in `server-go`
- `go test ./... -count=1 && go vet ./...` in `runtime-web`
