### PR TITLE
Fix workflow authorization and trigger reliability

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -7,6 +7,12 @@ Use **Edit Workflows** to define the graph. Use **Workflows** to submit a propos
 run. Definitions are instance-wide files under `$AIMEE_HOME/workflows`. The project picker changes
 browser context, not the definition namespace.
 
+All signed-in users can inspect definitions and validate an in-browser draft. Because definitions
+and custom blocks affect every future run on the instance, only the appliance administrator can
+persist, delete, or edit them globally. The editor marks persistence and custom-block mutation
+controls unavailable for other users, who may still inspect or validate an unsaved local draft;
+both the web proxy and workflow service enforce the global-write boundary.
+
 ![The Edit Workflows page with a four-node review graph, the block palette, and colored transition edges](images/workflow-editor-graph.png)
 
 ## Choose a shipped workflow
@@ -271,7 +277,8 @@ Other source names can be displayed by the UI but are reported as unsupported by
 You can configure a watched directory in either place:
 
 - select **Workflows → Triggers → + New trigger** as the appliance administrator, then choose the
-  repository, saved workflow, watched directory, optional branch/ref, mode, and spend cap;
+  repository or an absolute server-visible checkout path, saved workflow, watched directory,
+  optional branch/ref, mode, and spend cap;
 - add a rule under `trigger_rules` in `aimee.yaml` when repairing an invalid registry or managing it
   as configuration;
 - make `trigger.watch-dir` the workflow's start node and set its `params.workspace`.
@@ -287,6 +294,10 @@ A graph-native trigger without `params.workspace` is saved but disarmed. `params
 `params.max_spend_usd` sets the admitted run's spend ceiling. The scanner reads committed, visible
 Markdown files from the selected git ref, deduplicates the proposal bytes with workflow and mode,
 and retries admission on a later scan when the concurrency cap is full.
+
+The definition validator checks graph-native trigger parameter types, directory confinement, Git
+ref safety, run mode, and spend cap when the workflow is authored. Invalid trigger nodes therefore
+fail **Validate** or **Save** instead of becoming a repeating scanner error.
 
 Setting `trigger.max_concurrent` to `0` pauses new trigger and browser-submit admission. It does not
 remove the cap.

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -12,8 +12,8 @@ pinned to work already in flight.
 
 1. **Open the composer.** Select **+ New proposal**.
 2. **Write the request.** Enter a title and proposal body, then choose a saved workflow.
-3. **Choose the checkout.** Choose a managed repository or enter a custom checkout path visible to
-   the server. The form
+3. **Choose the checkout.** Choose a managed repository or enter an absolute custom checkout path
+   visible to the server. The form
    requires this before it sends the proposal.
 4. **Use project help if needed.** **Draft with a delegate** and **Load from project** both show a preview before
    replacing the proposal body.
@@ -46,6 +46,11 @@ The left rail lists runs and their derived status labels. Selecting one shows:
 The selected run is polled every four seconds while it remains open. Event reads use an incremental
 cursor, so the page appends new history instead of reconstructing state from browser events.
 
+The normal list, detail, proposal, and event views are scoped to the person who submitted the root
+run. Child slices inherit that root ownership even when an older child record has no submitter of
+its own. The appliance administrator can select **Show all (operator)** to inspect every user's run
+and trigger-origin runs, which have no browser owner. Other users are not offered that view.
+
 The current page does not expose every stored plan, diff, review, branch, slice, or worktree artifact.
 Use the PR, event detail, CLI status, and server-side artifact store when that deeper evidence is
 needed.
@@ -65,6 +70,11 @@ Controls depend on the current state:
 
 There is no separate **Retry** button in the current page. Fix the named condition and use **Start**
 when the pause reason is resumable. A human gate must use **Approve** or **Reject** instead.
+
+The root submitter can pause, resume, stop, or delete their own run tree. **Approve** and **Reject**
+are operator decisions and are available only to the appliance administrator. The service enforces
+the same ownership and operator checks as the browser; knowing another work-item ID does not grant
+access to its details, artifacts, history, or controls.
 
 The current human-gate record is a hashed approval artifact plus lifecycle transition. It is not a
 signed principal-and-artifact attestation. Do not treat it as a cryptographic approval record.
@@ -86,7 +96,7 @@ The **Triggers** panel shows what can file a run automatically.
 ![The Workflows trigger list beside the expanded Run policy controls](images/workflow-actions-triggers-policy.png)
 
 - The appliance administrator can select **+ New trigger** and choose a managed repository (or
-  enter a custom server-visible checkout path), a saved workflow, the repository-relative
+  enter an absolute custom server-visible checkout path), a saved workflow, the repository-relative
   Markdown directory to watch, and an optional branch/ref, run mode, and per-run spend cap.
 - New and edited rules stay as browser drafts until **Save trigger** succeeds. The form validates
   repository confinement and Git-ref safety before changing the shared registry, and a concurrent

--- a/frontend/src/pages/EditWorkflows.tsx
+++ b/frontend/src/pages/EditWorkflows.tsx
@@ -343,6 +343,7 @@ interface BlockForm {
 export default function EditWorkflows() {
   const [defs, setDefs] = useState<DefRow[]>([]);
   const [blocks, setBlocks] = useState<BlockDef[]>([]);
+  const [editable, setEditable] = useState(false);
   const [graph, setGraph] = useState<GraphDef | null>(null);
   const [version, setVersion] = useState("");
   const [pos, setPos] = useState<Record<string, { x: number; y: number }>>({});
@@ -368,6 +369,18 @@ export default function EditWorkflows() {
       .catch(() => {});
   }, []);
 
+  const refreshBlocks = useCallback(() => {
+    getJSON<{ blocks: BlockDef[]; editable?: boolean }>("/api/workflow/blocks")
+      .then((d) => {
+        setBlocks(d.blocks || []);
+        setEditable(d.editable === true);
+      })
+      .catch(() => {
+        setBlocks([]);
+        setEditable(false);
+      });
+  }, []);
+
   // The persona list feeds both the per-step persona pickers and the manager;
   // refreshed after any persona create/edit/delete.
   const refreshPersonas = useCallback(() => {
@@ -377,9 +390,7 @@ export default function EditWorkflows() {
   }, []);
 
   useEffect(() => {
-    getJSON<{ blocks: BlockDef[] }>("/api/workflow/blocks")
-      .then((d) => setBlocks(d.blocks || []))
-      .catch(() => {});
+    refreshBlocks();
     // Delegate suggestions: registered agents. Free text is also accepted, so an
     // empty list (no agents connected) never blocks assigning a delegate.
     getJSON<{ agents: AgentInfo[] }>("/api/agents")
@@ -387,7 +398,7 @@ export default function EditWorkflows() {
       .catch(() => {});
     refreshPersonas();
     refreshLists();
-  }, [refreshLists, refreshPersonas]);
+  }, [refreshBlocks, refreshLists, refreshPersonas]);
 
   const openDef = useCallback((name: string) => {
     setLoading(true);
@@ -485,6 +496,10 @@ export default function EditWorkflows() {
 
   const saveBlock = useCallback(async () => {
     if (!editBlock) return;
+    if (!editable) {
+      setBlockStatus("administrator access is required to save custom blocks");
+      return;
+    }
     const name = editBlock.name.trim();
     if (!/^[a-z0-9][a-z0-9_.-]*$/i.test(name)) {
       setBlockStatus("name must be alphanumeric, - _ or .");
@@ -507,15 +522,20 @@ export default function EditWorkflows() {
     if (st >= 200 && st < 300) {
       setBlockStatus("");
       setEditBlock(null);
+      refreshBlocks();
       refreshLists();
     } else {
       setBlockStatus(`save failed (${st})`);
     }
-  }, [editBlock, refreshLists]);
+  }, [editBlock, editable, refreshBlocks, refreshLists]);
 
   const deleteBlock = useCallback(async () => {
     if (!editBlock || editBlock.isNew) {
       setEditBlock(null);
+      return;
+    }
+    if (!editable) {
+      setBlockStatus("administrator access is required to delete custom blocks");
       return;
     }
     if (!window.confirm(`Delete custom block “${editBlock.name}”?`)) return;
@@ -525,11 +545,12 @@ export default function EditWorkflows() {
     );
     if (st >= 200 && st < 300) {
       setEditBlock(null);
+      refreshBlocks();
       refreshLists();
     } else {
       setBlockStatus(`delete failed (${st})`);
     }
-  }, [editBlock, refreshLists]);
+  }, [editBlock, editable, refreshBlocks, refreshLists]);
 
   const deleteNode = useCallback(
     (id: string) => {
@@ -564,6 +585,10 @@ export default function EditWorkflows() {
 
   const save = useCallback(async () => {
     if (!graph) return;
+    if (!editable) {
+      setStatus({ kind: "err", msg: "administrator access is required to save workflows" });
+      return;
+    }
     const res = await postJSON<{
       name?: string;
       version?: string;
@@ -592,7 +617,7 @@ export default function EditWorkflows() {
         msg: res.data.error || `save failed (${res.status})`,
       });
     }
-  }, [graph, version, refreshLists]);
+  }, [editable, graph, version, refreshLists]);
 
   /* node dragging */
   const onNodeDown = (id: string, e: React.MouseEvent) => {
@@ -680,7 +705,12 @@ export default function EditWorkflows() {
         }}
       >
         <Panel title="Workflows" count={defs.length}>
-          <Button onClick={newDef} size="md" title="Create a new workflow definition and open it in the editor.">
+          <Button
+            onClick={newDef}
+            disabled={!editable}
+            size="md"
+            title={editable ? "Create a new workflow definition and open it in the editor." : "Administrator access is required to create workflows."}
+          >
             + New
           </Button>
           <div style={{ marginTop: 6 }}>
@@ -704,9 +734,19 @@ export default function EditWorkflows() {
           </div>
         </Panel>
         <Panel title="Blocks" count={blocks.length}>
-          <Button onClick={newBlock} size="md" title="Create a new custom delegate block.">
+          <Button
+            onClick={newBlock}
+            disabled={!editable}
+            size="md"
+            title={editable ? "Create a new custom delegate block." : "Administrator access is required to create custom blocks."}
+          >
             + New
           </Button>
+          {!editable && (
+            <div style={{ fontSize: 11, color: "#777", lineHeight: 1.4, marginTop: 6 }}>
+              Administrator access is required to save workflows or custom blocks. You can still inspect and validate definitions.
+            </div>
+          )}
           <div style={{ marginTop: 6 }}>
             {blocks.map((b) => (
               <div
@@ -717,7 +757,7 @@ export default function EditWorkflows() {
               >
                 <span>{b.name}</span>
                 <span style={{ display: "flex", gap: 4, alignItems: "center" }}>
-                  {b.custom && b.executor === "delegate" && (
+                  {editable && b.custom && b.executor === "delegate" && (
                     <Button
                       size="sm"
                       onClick={(e) => {
@@ -794,13 +834,14 @@ export default function EditWorkflows() {
                 />
               </label>
               <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-                <Button onClick={saveBlock} size="md" title="Save this custom block definition.">
+                <Button onClick={saveBlock} disabled={!editable} size="md" title="Save this custom block definition.">
                   Save
                 </Button>
                 <Button
                   variant="danger"
                   size="md"
                   onClick={deleteBlock}
+                  disabled={!editable && !editBlock.isNew}
                   title={editBlock.isNew ? "Discard this new block." : "Delete this custom block."}
                 >
                   {editBlock.isNew ? "Cancel" : "Delete"}
@@ -836,8 +877,8 @@ export default function EditWorkflows() {
             variant="primary"
             size="md"
             onClick={save}
-            disabled={!graph}
-            title="Save the workflow definition (fails if the on-disk version changed)."
+            disabled={!graph || !editable}
+            title={editable ? "Save the workflow definition (fails if the on-disk version changed)." : "Administrator access is required to save workflows."}
           >
             Save
           </Button>

--- a/frontend/src/pages/WorkflowActions.test.ts
+++ b/frontend/src/pages/WorkflowActions.test.ts
@@ -32,6 +32,7 @@ describe("human-authored workflow triggers", () => {
     expect(triggerValidationError({ ...valid, event: "../secrets" })).toContain("inside the repository");
     expect(triggerValidationError({ ...valid, event: "docs\\requests" })).toContain("forward slashes");
     expect(triggerValidationError({ ...valid, workspace: "" })).toContain("Choose a repository");
+    expect(triggerValidationError({ ...valid, workspace: "relative/repo" })).toContain("absolute server-visible");
     expect(triggerValidationError({ ...valid, schedule: "--all" })).toContain("cannot start");
   });
 

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -46,6 +46,7 @@ export interface Trigger {
 interface TriggerRegistryResponse {
   triggers: Trigger[];
   version: string;
+  operator?: boolean;
   editable?: boolean;
   max_rules?: number;
   registry_error?: string;
@@ -120,11 +121,7 @@ async function postJSON<T>(url: string, body: unknown): Promise<{ status: number
 }
 
 async function loadWorkflowConfig(): Promise<Record<string, unknown>> {
-  try {
-    return (await getJSON<{ config: Record<string, unknown> }>("/api/workflow/config")).config || {};
-  } catch {
-    return {};
-  }
+  return (await getJSON<{ config: Record<string, unknown> }>("/api/workflow/config")).config || {};
 }
 
 async function saveWorkflowConfig(key: string, value: unknown, previousVersion?: string): Promise<{ ok: boolean; status: number; value?: unknown; error?: string }> {
@@ -238,6 +235,7 @@ export default function WorkflowActions() {
   const [triggers, setTriggers] = useState<Trigger[]>([]);
   const [triggerVersion, setTriggerVersion] = useState("");
   const [triggerEditable, setTriggerEditable] = useState(false);
+  const [workflowOperator, setWorkflowOperator] = useState(false);
   const [triggerMaxRules, setTriggerMaxRules] = useState(32);
   const [triggerRegistryError, setTriggerRegistryError] = useState("");
   const [triggerLoadError, setTriggerLoadError] = useState("");
@@ -269,6 +267,7 @@ export default function WorkflowActions() {
         setTriggers(d.triggers || []);
         setTriggerVersion(d.version || "");
         setTriggerEditable(d.editable === true);
+        setWorkflowOperator(d.operator === true);
         setTriggerMaxRules(d.max_rules || 32);
         setTriggerRegistryError(d.registry_error || "");
         setTriggerLoadError("");
@@ -276,6 +275,7 @@ export default function WorkflowActions() {
       .catch((e: Error) => {
         setTriggers([]);
         setTriggerEditable(false);
+        setWorkflowOperator(false);
         setTriggerLoadError(`Could not load triggers: ${e.message}`);
       });
     // Offer managed repositories by name. A custom server-visible path remains
@@ -494,7 +494,7 @@ export default function WorkflowActions() {
     [selId, acting, refreshList, openProposal],
   );
 
-  const canDecide = !!detail && isHumanGatePause(detail.pause_reason);
+  const canDecide = workflowOperator && !!detail && isHumanGatePause(detail.pause_reason);
   // Which lifecycle controls apply to the current item.
   const term = !!detail && isTerminal(detail.state);
   const paused = !!detail && !term && !!detail.pause_reason;
@@ -534,13 +534,15 @@ export default function WorkflowActions() {
         >
           + New proposal
         </Button>
-        <label
-          style={{ fontSize: 12, color: "#666", display: "flex", alignItems: "center", gap: 6 }}
-          title="Show every run across all users, not just your own."
-        >
-          <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
-          Show all (operator)
-        </label>
+        {workflowOperator && (
+          <label
+            style={{ fontSize: 12, color: "#666", display: "flex", alignItems: "center", gap: 6 }}
+            title="Show every run across all users, not just your own."
+          >
+            <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
+            Show all (operator)
+          </label>
+        )}
         {status && (
           <div style={{ marginTop: 6 }}>
             <InlineStatus status={status} />
@@ -560,7 +562,7 @@ export default function WorkflowActions() {
           open={triggersOpen}
           onToggle={() => setTriggersOpen((v) => !v)}
         />
-        <RunPolicyPanel />
+        <RunPolicyPanel editable={workflowOperator} />
         <div style={{ marginTop: 8 }}>
           {items.length === 0 && (
             <EmptyState message="No proposals yet." inline />
@@ -717,7 +719,7 @@ const RUN_POLICY_FIELDS: { key: string; label: string; help: string; kind: "int"
     key: "trigger.max_concurrent",
     label: "Trigger admission cap",
     kind: "int",
-    help: "Maximum active runs admitted across configured triggers. New proposals remain queued for a later scheduler pass when the cap is reached. Default 2. 0 = uncapped.",
+    help: "Maximum active runs admitted across configured triggers. New proposals remain queued for a later scheduler pass when the cap is reached. Default 2. 0 pauses new admission.",
   },
   {
     key: "trigger.scan_interval_secs",
@@ -759,7 +761,7 @@ const RUN_POLICY_FIELDS: { key: string; label: string; help: string; kind: "int"
     key: "autonomy.concurrency",
     label: "Concurrency",
     kind: "int",
-    help: "Max autonomous runs driven concurrently per scheduler sweep. Default 2.",
+    help: "Max autonomous runs driven concurrently per scheduler sweep. Default 5.",
   },
   {
     key: "autonomy.delegate_pending_secs",
@@ -773,13 +775,25 @@ const RUN_POLICY_FIELDS: { key: string; label: string; help: string; kind: "int"
 
 // Collapsible run-policy editor: loads the autonomy.* config on first open and writes
 // each change back via the same /api/config/set the Settings page uses.
-function RunPolicyPanel() {
+function RunPolicyPanel({ editable }: { editable: boolean }) {
   const [open, setOpen] = useState(false);
   const [cfg, setCfg] = useState<Record<string, unknown> | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   useEffect(() => {
-    if (open && cfg === null) loadWorkflowConfig().then(setCfg);
+    if (!open || cfg !== null) return;
+    let cancelled = false;
+    setErr(null);
+    loadWorkflowConfig()
+      .then((value) => {
+        if (!cancelled) setCfg(value);
+      })
+      .catch((error: Error) => {
+        if (!cancelled) setErr(`Could not load run policy: ${error.message}`);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open, cfg]);
   const save = async (key: string, value: unknown) => {
     setSaving(key);
@@ -801,12 +815,16 @@ function RunPolicyPanel() {
       </div>
       {open && (
         <div style={{ marginTop: 6 }}>
-          {cfg === null ? (
+          {cfg === null && !err ? (
             <div style={{ fontSize: 12, color: "#999" }}>Loading…</div>
+          ) : cfg === null ? (
+            <div style={{ fontSize: 11, color: "#c00" }}>{err}</div>
           ) : (
             <>
               <div style={{ fontSize: 11, color: "#999", lineHeight: 1.4, marginBottom: 6 }}>
-                Admission, safety caps, and auto-resume for autonomous runs. Changes apply live.
+                {editable
+                  ? "Admission, safety caps, and auto-resume for autonomous runs. Changes apply live."
+                  : "Read-only. Administrator access is required to change global run policy."}
               </div>
               {RUN_POLICY_FIELDS.map((f) => (
                 <div
@@ -819,6 +837,7 @@ function RunPolicyPanel() {
                     <input
                       type="checkbox"
                       checked={!!cfg?.[f.key]}
+                      disabled={!editable || saving !== null}
                       onChange={(e) => save(f.key, e.target.checked)}
                     />
                   ) : (
@@ -827,6 +846,7 @@ function RunPolicyPanel() {
                       min={f.min}
                       max={f.max}
                       defaultValue={Number(cfg?.[f.key] ?? 0)}
+                      disabled={!editable || saving !== null}
                       style={{
                         width: 90,
                         fontFamily: "ui-monospace, monospace",
@@ -861,7 +881,11 @@ function RunPolicyPanel() {
 }
 
 export function triggerValidationError(trigger: Trigger): string {
-  if (!trigger.workspace.trim()) return "Choose a repository or enter its server-visible checkout path.";
+  const workspace = trigger.workspace.trim();
+  if (!workspace) return "Choose a repository or enter its server-visible checkout path.";
+  if (!workspace.startsWith("/") || /[\u0000-\u001f\u007f]/.test(workspace)) {
+    return "Enter an absolute server-visible checkout path (for example /srv/repos/project).";
+  }
   if (!trigger.template.trim()) return "Choose a saved workflow.";
   const directory = trigger.event.trim();
   if (!directory) return "Enter the repository-relative directory to watch.";

--- a/frontend/src/pages/WorkflowTriggers.test.tsx
+++ b/frontend/src/pages/WorkflowTriggers.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { TriggersPanel, type Trigger } from "./WorkflowActions";
+import WorkflowActions, { TriggersPanel, type Trigger } from "./WorkflowActions";
 
 afterEach(() => {
   cleanup();
@@ -93,5 +93,60 @@ describe("TriggersPanel", () => {
     expect(screen.getByRole("alert").textContent).toContain("browser writes are disabled");
     expect(screen.queryByRole("button", { name: "+ New trigger" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+  });
+});
+
+describe("workflow operator capabilities", () => {
+  function mockWorkflowPage(editable: boolean, configResponse?: Response, operator = editable) {
+    return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === "/api/workflow/items") return Response.json({ items: [] });
+      if (url === "/api/workflow/defs") return Response.json({ defs: [] });
+      if (url === "/api/workflow/triggers") {
+        return Response.json({ operator, editable, version: "v1", triggers: [] });
+      }
+      if (url === "/api/git/projects") return Response.json({ root: "/srv/repos", projects: [] });
+      if (url === "/api/workflow/config") {
+        return configResponse || Response.json({
+          config: {
+            "trigger.max_concurrent": 2,
+            "trigger.scan_interval_secs": 5,
+            "autonomy.auto_resume_cap_parks": true,
+            "autonomy.concurrency": 5,
+          },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+  }
+
+  it("hides operator-only controls and makes global policy read-only for ordinary users", async () => {
+    mockWorkflowPage(false);
+    render(<WorkflowActions />);
+    await screen.findByText(/Only the appliance administrator/);
+    expect(screen.queryByText("Show all (operator)")).toBeNull();
+
+    fireEvent.click(screen.getByText("⚙ Run policy"));
+    await screen.findByText(/Read-only\. Administrator access is required/);
+    for (const input of screen.getAllByRole("spinbutton")) expect((input as HTMLInputElement).disabled).toBe(true);
+    for (const input of screen.getAllByRole("checkbox")) expect((input as HTMLInputElement).disabled).toBe(true);
+    expect(screen.getByTitle(/0 pauses new admission/)).toBeTruthy();
+    expect(screen.getByTitle(/Max autonomous runs.*Default 5/)).toBeTruthy();
+  });
+
+  it("shows a load failure instead of editable zero values", async () => {
+    mockWorkflowPage(true, Response.json({ error: "policy offline" }, { status: 503 }));
+    render(<WorkflowActions />);
+    await screen.findByText("Show all (operator)");
+    fireEvent.click(screen.getByText("⚙ Run policy"));
+    expect(await screen.findByText("Could not load run policy: policy offline")).toBeTruthy();
+    expect(screen.queryByRole("spinbutton")).toBeNull();
+  });
+
+  it("keeps operator run access when trigger mutation is unavailable", async () => {
+    mockWorkflowPage(false, undefined, true);
+    render(<WorkflowActions />);
+    expect(await screen.findByText("Show all (operator)")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "+ New trigger" })).toBeNull();
   });
 });

--- a/runtime-web/vault.go
+++ b/runtime-web/vault.go
@@ -21,13 +21,24 @@ import (
 // v1RequestWebuser is v1Request plus X-Aimee-Webuser. aimee-server accepts that
 // assertion only from the kernel-attested root peer on its Unix socket.
 func (s *server) v1RequestWebuser(ctx context.Context, username, method, path string, body []byte) (int, []byte, error) {
-	return s.v1RequestWebuserT(ctx, username, method, path, body, socketCallTimeout)
+	return s.v1RequestWebuserTCapability(ctx, username, method, path, body, socketCallTimeout, false)
+}
+
+// v1RequestWorkflowOperator carries an explicit operator capability resolved
+// by isAdmin at this trusted boundary. Keeping it separate from the username
+// prevents a literal account named "admin" from acquiring operator authority.
+func (s *server) v1RequestWorkflowOperator(ctx context.Context, username, method, path string, body []byte) (int, []byte, error) {
+	return s.v1RequestWebuserTCapability(ctx, username, method, path, body, socketCallTimeout, true)
 }
 
 // v1RequestWebuserT is v1RequestWebuser with an explicit client timeout, for the
 // few endpoints that legitimately hold the request open longer than the default
 // socketCallTimeout (e.g. a synchronous one-shot LLM draft).
 func (s *server) v1RequestWebuserT(ctx context.Context, username, method, path string, body []byte, timeout time.Duration) (int, []byte, error) {
+	return s.v1RequestWebuserTCapability(ctx, username, method, path, body, timeout, false)
+}
+
+func (s *server) v1RequestWebuserTCapability(ctx context.Context, username, method, path string, body []byte, timeout time.Duration, workflowOperator bool) (int, []byte, error) {
 	if username == "" {
 		return http.StatusUnauthorized, nil, errNoVaultTrust
 	}
@@ -52,6 +63,9 @@ func (s *server) v1RequestWebuserT(ctx context.Context, username, method, path s
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("X-Aimee-Webuser", username)
+	if workflowOperator {
+		req.Header.Set("X-Aimee-Workflow-Operator", "true")
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err

--- a/runtime-web/workflow.go
+++ b/runtime-web/workflow.go
@@ -59,7 +59,11 @@ func (s *server) proxyWorkflow(w http.ResponseWriter, r *http.Request, method, v
 
 // GET /api/workflow/blocks — the block palette catalog.
 func (s *server) handleWorkflowBlocks(w http.ResponseWriter, r *http.Request) {
-	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/blocks", "")
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	s.webuserPassAuthorized(w, r, s.isAdmin(r), http.MethodGet, "/v1/workflow/blocks", nil)
 }
 
 // PUT/DELETE /api/workflow/blocks/<name> — create/edit or delete a custom
@@ -67,6 +71,10 @@ func (s *server) handleWorkflowBlocks(w http.ResponseWriter, r *http.Request) {
 // handler forwards PUT bodies itself; seg-validated + body-capped, then handed
 // to the admin-gated /v1 route (which refuses command executors).
 func (s *server) handleWorkflowBlockItem(w http.ResponseWriter, r *http.Request) {
+	if !s.isAdmin(r) {
+		writeJSONError(w, http.StatusForbidden, "administrator access required")
+		return
+	}
 	seg := strings.TrimPrefix(r.URL.Path, "/api/workflow/blocks/")
 	if seg == "" || strings.Contains(seg, "/") || strings.Contains(seg, "..") || strings.Contains(seg, "%") {
 		writeJSONError(w, http.StatusBadRequest, "bad block name")
@@ -88,17 +96,7 @@ func (s *server) handleWorkflowBlockItem(w http.ResponseWriter, r *http.Request)
 		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
-	defer cancel()
-	st, data, err := s.v1Request(ctx, method, "/v1/workflow/blocks/"+seg, body)
-	w.Header().Set("Content-Type", "application/json")
-	if err != nil {
-		w.WriteHeader(http.StatusBadGateway)
-		fmt.Fprintf(w, `{"error":"workflow service unreachable"}`)
-		return
-	}
-	w.WriteHeader(st)
-	w.Write(data)
+	s.webuserPassAuthorized(w, r, true, method, "/v1/workflow/blocks/"+seg, body)
 }
 
 // GET /api/workflow/defs        — list definitions
@@ -120,13 +118,8 @@ func (s *server) handleWorkflowTriggers(w http.ResponseWriter, r *http.Request) 
 	// The Go registry response includes whether this principal may edit global
 	// triggers, so this read must carry the attested web identity too. The runtime
 	// owns the appliance-admin lookup (the bootstrap account is renamed during
-	// setup); normalize that capability to the Go control plane's internal admin
-	// principal after the trusted check instead of forwarding a literal username.
-	user := currentUser(r)
-	if s.isAdmin(r) {
-		user = "admin"
-	}
-	s.webuserPassAs(w, r, user, http.MethodGet, "/v1/workflow/triggers", nil)
+	// setup); attest that capability separately from the literal username.
+	s.webuserPassAuthorized(w, r, s.isAdmin(r), http.MethodGet, "/v1/workflow/triggers", nil)
 }
 
 func (s *server) handleWorkflowConfig(w http.ResponseWriter, r *http.Request) {
@@ -134,6 +127,10 @@ func (s *server) handleWorkflowConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleWorkflowConfigSet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
 	// Global run policy affects every user's autonomous work. The appliance's
 	// bootstrap administrator is the only web identity allowed to mutate it;
 	// per-user submission and lifecycle endpoints remain available to all users.
@@ -145,7 +142,7 @@ func (s *server) handleWorkflowConfigSet(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	s.webuserPassAs(w, r, "admin", http.MethodPost, "/v1/workflow/config/set", body)
+	s.webuserPassAuthorized(w, r, true, http.MethodPost, "/v1/workflow/config/set", body)
 }
 
 // POST /api/workflow/validate — validate posted YAML without saving.
@@ -155,7 +152,19 @@ func (s *server) handleWorkflowValidate(w http.ResponseWriter, r *http.Request) 
 
 // POST /api/workflow/save — canonical-normalize + save (optimistic lock).
 func (s *server) handleWorkflowSave(w http.ResponseWriter, r *http.Request) {
-	s.proxyWorkflow(w, r, http.MethodPost, "/v1/workflow/save", "")
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.isAdmin(r) {
+		writeJSONError(w, http.StatusForbidden, "administrator access required")
+		return
+	}
+	body, ok := readBoundedBody(w, r, 1<<20)
+	if !ok {
+		return
+	}
+	s.webuserPassAuthorized(w, r, true, http.MethodPost, "/v1/workflow/save", body)
 }
 
 // Work-item run-state surface. Every call goes through v1RequestWebuser so the
@@ -179,7 +188,11 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.URL.Path == "/api/workflow/items/all" && r.Method == http.MethodGet {
-		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/all", nil)
+		if !s.isAdmin(r) {
+			writeJSONError(w, http.StatusForbidden, "administrator access required")
+			return
+		}
+		s.webuserPassAuthorized(w, r, true, http.MethodGet, "/v1/workflow/items/all", nil)
 		return
 	}
 
@@ -199,30 +212,35 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
 		return
 	}
+	operator := s.isAdmin(r)
 
 	switch {
 	case suffix == "/gate" && r.Method == http.MethodPost:
+		if !s.isAdmin(r) {
+			writeJSONError(w, http.StatusForbidden, "administrator access required")
+			return
+		}
 		body, ok := readBoundedBody(w, r, 64<<10)
 		if !ok {
 			return
 		}
-		s.webuserPass(w, r, http.MethodPost, "/v1/workflow/items/"+id+"/gate", body)
+		s.webuserPassAuthorized(w, r, true, http.MethodPost, "/v1/workflow/items/"+id+"/gate", body)
 	case suffix == "/events" && r.Method == http.MethodGet:
 		path := "/v1/workflow/items/" + id + "/events"
 		if r.URL.RawQuery != "" { // forward ?after=&limit= to the paginating handler
 			path += "?" + r.URL.RawQuery
 		}
-		s.webuserPass(w, r, http.MethodGet, path, nil)
+		s.webuserPassAuthorized(w, r, operator, http.MethodGet, path, nil)
 	case suffix == "/proposal" && r.Method == http.MethodGet:
-		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id+"/proposal", nil)
+		s.webuserPassAuthorized(w, r, operator, http.MethodGet, "/v1/workflow/items/"+id+"/proposal", nil)
 	// Lifecycle mutations (body-less). The /v1 handlers enforce owner-or-operator
 	// and the legal state transitions; we just forward under the webuser identity.
 	case (suffix == "/pause" || suffix == "/resume" || suffix == "/stop") && r.Method == http.MethodPost:
-		s.webuserPass(w, r, http.MethodPost, "/v1/workflow/items/"+id+suffix, nil)
+		s.webuserPassAuthorized(w, r, operator, http.MethodPost, "/v1/workflow/items/"+id+suffix, nil)
 	case suffix == "" && r.Method == http.MethodDelete:
-		s.webuserPass(w, r, http.MethodDelete, "/v1/workflow/items/"+id, nil)
+		s.webuserPassAuthorized(w, r, operator, http.MethodDelete, "/v1/workflow/items/"+id, nil)
 	case suffix == "" && r.Method == http.MethodGet:
-		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id, nil)
+		s.webuserPassAuthorized(w, r, operator, http.MethodGet, "/v1/workflow/items/"+id, nil)
 	default:
 		http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
 	}
@@ -231,16 +249,23 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 // webuserPass proxies to an aimee-server /v1 path under the caller's webuser
 // identity (so ownership scoping resolves) and streams the envelope back verbatim.
 func (s *server) webuserPass(w http.ResponseWriter, r *http.Request, method, v1path string, body []byte) {
-	s.webuserPassAs(w, r, currentUser(r), method, v1path, body)
+	s.webuserPassAuthorized(w, r, false, method, v1path, body)
 }
 
-// webuserPassAs is reserved for identities resolved at this trusted runtime
-// boundary, notably the appliance administrator capability. Ordinary workflow
-// ownership calls use webuserPass and retain the signed-in username unchanged.
-func (s *server) webuserPassAs(w http.ResponseWriter, r *http.Request, user, method, v1path string, body []byte) {
+// webuserPassAuthorized keeps identity and operator capability separate. The
+// latter is resolved by isAdmin at this trusted runtime boundary; a username
+// that happens to be "admin" remains an ordinary owner without the capability.
+func (s *server) webuserPassAuthorized(w http.ResponseWriter, r *http.Request, operator bool, method, v1path string, body []byte) {
 	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
 	defer cancel()
-	st, data, err := s.v1RequestWebuser(ctx, user, method, v1path, body)
+	var st int
+	var data []byte
+	var err error
+	if operator {
+		st, data, err = s.v1RequestWorkflowOperator(ctx, currentUser(r), method, v1path, body)
+	} else {
+		st, data, err = s.v1RequestWebuser(ctx, currentUser(r), method, v1path, body)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		w.WriteHeader(http.StatusBadGateway)

--- a/runtime-web/workflow_test.go
+++ b/runtime-web/workflow_test.go
@@ -19,12 +19,134 @@ func TestWorkflowGlobalConfigRequiresAdministrator(t *testing.T) {
 	}
 }
 
+func TestWorkflowGlobalConfigRejectsWrongMethod(t *testing.T) {
+	s := &server{}
+	req := withUser(httptest.NewRequest(http.MethodPut, "/api/workflow/config/set",
+		strings.NewReader(`{"key":"trigger.max_concurrent","value":2}`)), "admin")
+	rec := httptest.NewRecorder()
+	s.handleWorkflowConfigSet(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWorkflowGlobalDefinitionWritesRequireAdministrator(t *testing.T) {
+	s := &server{}
+	for _, tc := range []struct {
+		name, method, target, body string
+		handler                    func(http.ResponseWriter, *http.Request)
+	}{
+		{"save", http.MethodPost, "/api/workflow/save", `{}`, s.handleWorkflowSave},
+		{"put-block", http.MethodPut, "/api/workflow/blocks/custom.test", `{}`, s.handleWorkflowBlockItem},
+		{"delete-block", http.MethodDelete, "/api/workflow/blocks/custom.test", ``, s.handleWorkflowBlockItem},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := withUser(httptest.NewRequest(tc.method, tc.target, strings.NewReader(tc.body)), "alice")
+			rec := httptest.NewRecorder()
+			tc.handler(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestWorkflowBlocksAndWritesCarryAdministratorCapability(t *testing.T) {
+	var calls []string
+	mux := http.NewServeMux()
+	for _, route := range []string{"/v1/workflow/blocks", "/v1/workflow/blocks/custom.test", "/v1/workflow/save"} {
+		route := route
+		mux.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, r.Method+":"+r.URL.Path+":"+r.Header.Get("X-Aimee-Webuser")+":"+r.Header.Get("X-Aimee-Workflow-Operator"))
+			_, _ = w.Write([]byte(`{"ok":true,"blocks":[]}`))
+		})
+	}
+	s := &server{cfg: startFakeV1(t, mux)}
+	for _, tc := range []struct {
+		method, target, user, body string
+		handler                    func(http.ResponseWriter, *http.Request)
+	}{
+		{http.MethodGet, "/api/workflow/blocks", "alice", ``, s.handleWorkflowBlocks},
+		{http.MethodGet, "/api/workflow/blocks", "admin", ``, s.handleWorkflowBlocks},
+		{http.MethodPut, "/api/workflow/blocks/custom.test", "admin", `{}`, s.handleWorkflowBlockItem},
+		{http.MethodPost, "/api/workflow/save", "admin", `{}`, s.handleWorkflowSave},
+	} {
+		req := withUser(httptest.NewRequest(tc.method, tc.target, strings.NewReader(tc.body)), tc.user)
+		rec := httptest.NewRecorder()
+		tc.handler(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s %s status=%d body=%s", tc.method, tc.target, rec.Code, rec.Body.String())
+		}
+	}
+	want := []string{
+		"GET:/v1/workflow/blocks:alice:",
+		"GET:/v1/workflow/blocks:admin:true",
+		"PUT:/v1/workflow/blocks/custom.test:admin:true",
+		"POST:/v1/workflow/save:admin:true",
+	}
+	if len(calls) != len(want) {
+		t.Fatalf("calls=%v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("calls=%v, want %v", calls, want)
+		}
+	}
+}
+
+func TestWorkflowOperatorItemRoutesRejectOrdinaryUsersBeforeProxy(t *testing.T) {
+	proxied := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		proxied = true
+		w.WriteHeader(http.StatusOK)
+	})
+	s := &server{cfg: startFakeV1(t, mux)}
+	for _, tc := range []struct {
+		method, target, body string
+	}{
+		{http.MethodGet, "/api/workflow/items/all", ``},
+		{http.MethodPost, "/api/workflow/items/wi123/gate", `{"decision":"approve"}`},
+	} {
+		req := withUser(httptest.NewRequest(tc.method, tc.target, strings.NewReader(tc.body)), "alice")
+		rec := httptest.NewRecorder()
+		s.handleWorkflowItems(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("%s status=%d body=%s", tc.target, rec.Code, rec.Body.String())
+		}
+	}
+	if proxied {
+		t.Fatal("ordinary-user operator request reached the control plane")
+	}
+}
+
+func TestWorkflowOperatorCapabilityCannotBeSpoofedByBrowserHeader(t *testing.T) {
+	gotOperator := "unset"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/workflow/items/wi123", func(w http.ResponseWriter, r *http.Request) {
+		gotOperator = r.Header.Get("X-Aimee-Workflow-Operator")
+		_, _ = w.Write([]byte(`{"id":"wi123"}`))
+	})
+	s := &server{cfg: startFakeV1(t, mux)}
+	req := withUser(httptest.NewRequest(http.MethodGet, "/api/workflow/items/wi123", nil), "alice")
+	req.Header.Set("X-Aimee-Workflow-Operator", "true")
+	rec := httptest.NewRecorder()
+	s.handleWorkflowItems(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotOperator != "" {
+		t.Fatalf("spoofed operator capability was forwarded: %q", gotOperator)
+	}
+}
+
 func TestWorkflowTriggersReadCarriesWebuserIdentity(t *testing.T) {
-	var gotMethod, gotUser string
+	var gotMethod, gotUser, gotOperator string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/workflow/triggers", func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotUser = r.Header.Get("X-Aimee-Webuser")
+		gotOperator = r.Header.Get("X-Aimee-Workflow-Operator")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"editable":true,"triggers":[]}`))
 	})
@@ -32,8 +154,8 @@ func TestWorkflowTriggersReadCarriesWebuserIdentity(t *testing.T) {
 	req := withUser(httptest.NewRequest(http.MethodGet, "/api/workflow/triggers", nil), "admin")
 	rr := httptest.NewRecorder()
 	s.handleWorkflowTriggers(rr, req)
-	if rr.Code != http.StatusOK || gotMethod != http.MethodGet || gotUser != "admin" {
-		t.Fatalf("code=%d method=%q user=%q body=%s", rr.Code, gotMethod, gotUser, rr.Body.String())
+	if rr.Code != http.StatusOK || gotMethod != http.MethodGet || gotUser != "admin" || gotOperator != "true" {
+		t.Fatalf("code=%d method=%q user=%q operator=%q body=%s", rr.Code, gotMethod, gotUser, gotOperator, rr.Body.String())
 	}
 }
 
@@ -49,12 +171,24 @@ func TestWorkflowPolicyMapsReplacementAdministratorToControlPlaneCapability(t *t
 	var calls []string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/workflow/triggers", func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser"))
+		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser")+":"+r.Header.Get("X-Aimee-Workflow-Operator"))
 		_, _ = w.Write([]byte(`{"editable":true,"triggers":[]}`))
 	})
 	mux.HandleFunc("/v1/workflow/config/set", func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser"))
+		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser")+":"+r.Header.Get("X-Aimee-Workflow-Operator"))
 		_, _ = w.Write([]byte(`{"ok":true,"key":"trigger_rules"}`))
+	})
+	mux.HandleFunc("/v1/workflow/items/all", func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser")+":"+r.Header.Get("X-Aimee-Workflow-Operator"))
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+	mux.HandleFunc("/v1/workflow/items/wi1/gate", func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser")+":"+r.Header.Get("X-Aimee-Workflow-Operator"))
+		_, _ = w.Write([]byte(`{"id":"wi1"}`))
+	})
+	mux.HandleFunc("/v1/workflow/items/wi1", func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+":"+r.Header.Get("X-Aimee-Webuser")+":"+r.Header.Get("X-Aimee-Workflow-Operator"))
+		_, _ = w.Write([]byte(`{"id":"wi1"}`))
 	})
 	cfg := startFakeV1(t, mux)
 	cfg.dbPath = filepath.Join(root, "webchat.db")
@@ -67,12 +201,24 @@ func TestWorkflowPolicyMapsReplacementAdministratorToControlPlaneCapability(t *t
 		strings.NewReader(`{"key":"trigger_rules","value":[],"previous_version":"v1"}`)), "virant")
 	writeRecorder := httptest.NewRecorder()
 	s.handleWorkflowConfigSet(writeRecorder, write)
+	all := withUser(httptest.NewRequest(http.MethodGet, "/api/workflow/items/all", nil), "virant")
+	allRecorder := httptest.NewRecorder()
+	s.handleWorkflowItems(allRecorder, all)
+	gate := withUser(httptest.NewRequest(http.MethodPost, "/api/workflow/items/wi1/gate",
+		strings.NewReader(`{"decision":"approve"}`)), "virant")
+	gateRecorder := httptest.NewRecorder()
+	s.handleWorkflowItems(gateRecorder, gate)
+	// Once the bootstrap administrator is named virant, an unrelated literal
+	// "admin" identity must remain an ordinary workflow owner.
+	literalAdmin := withUser(httptest.NewRequest(http.MethodGet, "/api/workflow/items/wi1", nil), "admin")
+	literalAdminRecorder := httptest.NewRecorder()
+	s.handleWorkflowItems(literalAdminRecorder, literalAdmin)
 
-	if readRecorder.Code != http.StatusOK || writeRecorder.Code != http.StatusOK {
-		t.Fatalf("read=%d %s write=%d %s", readRecorder.Code, readRecorder.Body.String(), writeRecorder.Code, writeRecorder.Body.String())
+	if readRecorder.Code != http.StatusOK || writeRecorder.Code != http.StatusOK || allRecorder.Code != http.StatusOK || gateRecorder.Code != http.StatusOK || literalAdminRecorder.Code != http.StatusOK {
+		t.Fatalf("read=%d %s write=%d %s all=%d %s gate=%d %s literal-admin=%d %s", readRecorder.Code, readRecorder.Body.String(), writeRecorder.Code, writeRecorder.Body.String(), allRecorder.Code, allRecorder.Body.String(), gateRecorder.Code, gateRecorder.Body.String(), literalAdminRecorder.Code, literalAdminRecorder.Body.String())
 	}
-	want := []string{"GET:admin", "POST:admin"}
-	if len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+	want := []string{"GET:virant:true", "POST:virant:true", "GET:virant:true", "POST:virant:true", "GET:admin:"}
+	if len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] || calls[2] != want[2] || calls[3] != want[3] || calls[4] != want[4] {
 		t.Fatalf("control-plane calls=%v, want %v", calls, want)
 	}
 }
@@ -142,11 +288,12 @@ func TestWorkflowItemsSliceIDRouting(t *testing.T) {
 		method  string
 		apiPath string
 		wantV1  string
+		user    string
 	}{
-		{"detail", http.MethodGet, "/api/workflow/items/wi123.s0", "/v1/workflow/items/wi123.s0"},
-		{"gate", http.MethodPost, "/api/workflow/items/wi123.s0/gate", "/v1/workflow/items/wi123.s0/gate"},
-		{"events", http.MethodGet, "/api/workflow/items/wi123.s0/events", "/v1/workflow/items/wi123.s0/events"},
-		{"proposal", http.MethodGet, "/api/workflow/items/wi123.s0/proposal", "/v1/workflow/items/wi123.s0/proposal"},
+		{"detail", http.MethodGet, "/api/workflow/items/wi123.s0", "/v1/workflow/items/wi123.s0", "alice"},
+		{"gate", http.MethodPost, "/api/workflow/items/wi123.s0/gate", "/v1/workflow/items/wi123.s0/gate", "admin"},
+		{"events", http.MethodGet, "/api/workflow/items/wi123.s0/events", "/v1/workflow/items/wi123.s0/events", "alice"},
+		{"proposal", http.MethodGet, "/api/workflow/items/wi123.s0/proposal", "/v1/workflow/items/wi123.s0/proposal", "alice"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -163,7 +310,7 @@ func TestWorkflowItemsSliceIDRouting(t *testing.T) {
 			if tc.method == http.MethodPost {
 				body = []byte(`{"decision":"approve"}`)
 			}
-			req := withUser(httptest.NewRequest(tc.method, tc.apiPath, strings.NewReader(string(body))), "alice")
+			req := withUser(httptest.NewRequest(tc.method, tc.apiPath, strings.NewReader(string(body))), tc.user)
 			rr := httptest.NewRecorder()
 			s.handleWorkflowItems(rr, req)
 			if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"status":"ok"`) {

--- a/server-go/internal/api/config.go
+++ b/server-go/internal/api/config.go
@@ -24,7 +24,7 @@ func (s *Server) configGet(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) configSet(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("X-Aimee-Webuser") != "admin" {
+	if !workflowOperator(r) {
 		writeError(w, http.StatusForbidden, errors.New("administrator access required"))
 		return
 	}
@@ -68,7 +68,7 @@ func (s *Server) configSet(w http.ResponseWriter, r *http.Request) {
 func (s *Server) workflowTriggers(w http.ResponseWriter, r *http.Request) {
 	if s.config == nil {
 		writeJSON(w, http.StatusOK, map[string]any{
-			"editable": false, "max_concurrent": 2,
+			"operator": workflowOperator(r), "editable": false, "max_concurrent": 2,
 			"max_rules": appconfig.MaxTriggerRules, "triggers": []any{},
 		})
 		return
@@ -95,7 +95,8 @@ func (s *Server) workflowTriggers(w http.ResponseWriter, r *http.Request) {
 		triggers = append(triggers, item)
 	}
 	response := map[string]any{
-		"editable":       r.Header.Get("X-Aimee-Webuser") == "admin",
+		"operator":       workflowOperator(r),
+		"editable":       workflowOperator(r),
 		"max_concurrent": s.config.Int("trigger.max_concurrent", 2),
 		"max_rules":      appconfig.MaxTriggerRules,
 		"version":        version,

--- a/server-go/internal/api/lifecycle.go
+++ b/server-go/internal/api/lifecycle.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 
 	"github.com/JBailes/aimee/server-go/internal/db1"
@@ -19,8 +20,16 @@ func (s *Server) workflowGate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("decision must be approve or reject"))
 		return
 	}
-	item, err := s.db.WorkItem(r.Context(), r.PathValue("id"))
-	if err != nil || item.PauseReason != "human_gate" {
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeError(w, http.StatusBadRequest, errors.New("request must contain one JSON value"))
+		return
+	}
+	item, err := s.authorizedWorkItem(r, true)
+	if err != nil {
+		writeWorkItemAccessError(w, err)
+		return
+	}
+	if item.PauseReason != "human_gate" {
 		writeError(w, http.StatusConflict, errors.New("workflow is not waiting at a human gate"))
 		return
 	}
@@ -78,6 +87,10 @@ func (s *Server) workflowGate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) workflowPause(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if _, err := s.authorizedWorkItem(r, false); err != nil {
+		writeWorkItemAccessError(w, err)
+		return
+	}
 	if err := s.db.Pause(r.Context(), id); err != nil {
 		writeError(w, http.StatusConflict, err)
 		return
@@ -89,6 +102,10 @@ func (s *Server) workflowPause(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) workflowResume(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.authorizedWorkItem(r, false); err != nil {
+		writeWorkItemAccessError(w, err)
+		return
+	}
 	if err := s.db.Resume(r.Context(), r.PathValue("id")); err != nil {
 		writeError(w, http.StatusConflict, err)
 		return
@@ -101,6 +118,10 @@ func (s *Server) workflowResume(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) workflowStop(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if _, err := s.authorizedWorkItem(r, false); err != nil {
+		writeWorkItemAccessError(w, err)
+		return
+	}
 	ids, err := s.db.StopTree(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusConflict, err)
@@ -116,12 +137,11 @@ func (s *Server) workflowStop(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) workflowDelete(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	ids, err := s.db.DescendantIDs(r.Context(), id)
-	if err != nil {
-		writeError(w, http.StatusNotFound, err)
+	if _, err := s.authorizedWorkItem(r, false); err != nil {
+		writeWorkItemAccessError(w, err)
 		return
 	}
-	_, err = s.db.WorkItem(r.Context(), id)
+	ids, err := s.db.DescendantIDs(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err)
 		return
@@ -167,9 +187,9 @@ func (s *Server) workflowDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) writeItem(w http.ResponseWriter, r *http.Request) {
-	item, err := s.db.WorkItem(r.Context(), r.PathValue("id"))
+	item, err := s.authorizedWorkItem(r, false)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err)
+		writeWorkItemAccessError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, item)

--- a/server-go/internal/api/server.go
+++ b/server-go/internal/api/server.go
@@ -130,11 +130,121 @@ func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "service": "aimee-server", "implementation": "go"})
 }
 
+var errWorkflowAccessDenied = errors.New("workflow item belongs to another user")
+
+func workflowPrincipal(r *http.Request) string {
+	return strings.TrimSpace(r.Header.Get("X-Aimee-Webuser"))
+}
+
+// workflowOperator is a capability attested separately from the username by
+// the trusted runtime. A username is data, not a role: treating the literal
+// string "admin" as authority lets a non-bootstrap account collide with the
+// control-plane sentinel after the appliance administrator is renamed.
+func workflowOperator(r *http.Request) bool {
+	return r.Header.Get("X-Aimee-Workflow-Operator") == "true"
+}
+
+// rootSubmitter follows durable parent links instead of trusting child IDs or a
+// child row's submitter. Slice rows created by older engines did not copy the
+// submitter, but they still belong to the principal that admitted the root run.
+func (s *Server) rootSubmitter(ctx context.Context, item db1.WorkItem) (string, error) {
+	seen := make(map[string]struct{})
+	for {
+		if _, duplicate := seen[item.ID]; duplicate {
+			return "", errors.New("workflow parent cycle")
+		}
+		seen[item.ID] = struct{}{}
+		if item.ParentID == "" {
+			return item.Submitter, nil
+		}
+		parent, err := s.db.WorkItem(ctx, item.ParentID)
+		if err != nil {
+			return "", err
+		}
+		item = parent
+	}
+}
+
+func rootSubmitterFromList(item db1.WorkItem, byID map[string]db1.WorkItem) (string, bool) {
+	seen := make(map[string]struct{})
+	for {
+		if _, duplicate := seen[item.ID]; duplicate {
+			return "", false
+		}
+		seen[item.ID] = struct{}{}
+		if item.ParentID == "" {
+			return item.Submitter, true
+		}
+		parent, ok := byID[item.ParentID]
+		if !ok {
+			return "", false
+		}
+		item = parent
+	}
+}
+
+// authorizedWorkItem is the shared ownership boundary for detail, artifact,
+// timeline, and lifecycle endpoints. The trusted runtime attests the appliance
+// administrator as a separate capability. Human gates are operator-only; other
+// lifecycle actions allow the root owner or the operator.
+func (s *Server) authorizedWorkItem(r *http.Request, operatorOnly bool) (db1.WorkItem, error) {
+	item, err := s.db.WorkItem(r.Context(), r.PathValue("id"))
+	if err != nil {
+		return db1.WorkItem{}, err
+	}
+	principal := workflowPrincipal(r)
+	if workflowOperator(r) {
+		return item, nil
+	}
+	if operatorOnly || principal == "" {
+		return db1.WorkItem{}, errWorkflowAccessDenied
+	}
+	owner, err := s.rootSubmitter(r.Context(), item)
+	if err != nil {
+		return db1.WorkItem{}, err
+	}
+	if owner == "" || owner != principal {
+		return db1.WorkItem{}, errWorkflowAccessDenied
+	}
+	return item, nil
+}
+
+func writeWorkItemAccessError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errWorkflowAccessDenied):
+		writeError(w, http.StatusForbidden, errWorkflowAccessDenied)
+	case errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "no rows"):
+		writeError(w, http.StatusNotFound, errors.New("work item not found"))
+	default:
+		writeError(w, http.StatusInternalServerError, err)
+	}
+}
+
 func (s *Server) items(w http.ResponseWriter, r *http.Request) {
+	all := r.URL.Path == "/v1/workflow/items/all"
+	if all && !workflowOperator(r) {
+		writeError(w, http.StatusForbidden, errors.New("operator access required"))
+		return
+	}
 	items, err := s.db.WorkItems(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
+	}
+	principal := workflowPrincipal(r)
+	if !all {
+		byID := make(map[string]db1.WorkItem, len(items))
+		for _, item := range items {
+			byID[item.ID] = item
+		}
+		visible := make([]db1.WorkItem, 0, len(items))
+		for _, item := range items {
+			owner, ok := rootSubmitterFromList(item, byID)
+			if ok && owner != "" && owner == principal {
+				visible = append(visible, item)
+			}
+		}
+		items = visible
 	}
 	if items == nil {
 		items = []db1.WorkItem{}
@@ -143,19 +253,19 @@ func (s *Server) items(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) item(w http.ResponseWriter, r *http.Request) {
-	item, err := s.db.WorkItem(r.Context(), r.PathValue("id"))
+	item, err := s.authorizedWorkItem(r, false)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "no rows") {
-			writeError(w, http.StatusNotFound, errors.New("work item not found"))
-			return
-		}
-		writeError(w, http.StatusInternalServerError, err)
+		writeWorkItemAccessError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, item)
 }
 
 func (s *Server) events(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.authorizedWorkItem(r, false); err != nil {
+		writeWorkItemAccessError(w, err)
+		return
+	}
 	after, _ := strconv.ParseInt(r.URL.Query().Get("after"), 10, 64)
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	if limit < 1 || limit > 200 {
@@ -177,9 +287,9 @@ func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) proposal(w http.ResponseWriter, r *http.Request) {
-	item, err := s.db.WorkItem(r.Context(), r.PathValue("id"))
+	item, err := s.authorizedWorkItem(r, false)
 	if err != nil {
-		writeError(w, http.StatusNotFound, errors.New("work item not found"))
+		writeWorkItemAccessError(w, err)
 		return
 	}
 	content, err := s.artifacts.Proposal(item.ID)

--- a/server-go/internal/api/server_test.go
+++ b/server-go/internal/api/server_test.go
@@ -37,6 +37,13 @@ func newTestServer(t *testing.T) (*Server, *db1.Store, *wfe.ArtifactStore) {
 	return server, store, artifacts
 }
 
+func setWorkflowIdentity(req *http.Request, user string, operator bool) {
+	req.Header.Set("X-Aimee-Webuser", user)
+	if operator {
+		req.Header.Set("X-Aimee-Workflow-Operator", "true")
+	}
+}
+
 func TestProposalEndpointImportsLegacySourceWithoutTruncation(t *testing.T) {
 	server, store, _ := newTestServer(t)
 	tail := "ACCEPTANCE_CRITERION_AFTER_ALL_PRIOR_BYTE_LIMITS"
@@ -47,12 +54,13 @@ func TestProposalEndpointImportsLegacySourceWithoutTruncation(t *testing.T) {
 	}
 	if err := store.CreateWorkItem(context.Background(), db1.CreateWorkItem{
 		ID: "wi_api", Repo: "repo", ProposalPath: source, WorkflowName: "build",
-		WorkflowVersion: strings.Repeat("a", 64), StartStage: "plan", Mode: "autonomous",
+		WorkflowVersion: strings.Repeat("a", 64), StartStage: "plan", Mode: "autonomous", Submitter: "alice",
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/workflow/items/wi_api/proposal", nil)
+	setWorkflowIdentity(req, "alice", false)
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -96,7 +104,7 @@ func TestWorkflowStopCancelsAndStopsEveryDescendant(t *testing.T) {
 	server, store, _ := newTestServer(t)
 	ctx := context.Background()
 	for _, in := range []db1.CreateWorkItem{
-		{ID: "wi_api_stop", Repo: "repo", ProposalPath: "root", WorkflowName: "build", StartStage: "slices"},
+		{ID: "wi_api_stop", Repo: "repo", ProposalPath: "root", WorkflowName: "build", StartStage: "slices", Submitter: "alice"},
 		{ID: "wi_api_stop.child", Repo: "repo", ProposalPath: "child", WorkflowName: "slice", StartStage: "impl", ParentID: "wi_api_stop"},
 	} {
 		if err := store.CreateWorkItem(ctx, in); err != nil {
@@ -106,7 +114,9 @@ func TestWorkflowStopCancelsAndStopsEveryDescendant(t *testing.T) {
 	cancelled := make(map[string]bool)
 	server.SetSchedulerCancel(func(id string) { cancelled[id] = true })
 	rec := httptest.NewRecorder()
-	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/workflow/items/wi_api_stop/stop", nil))
+	req := httptest.NewRequest(http.MethodPost, "/v1/workflow/items/wi_api_stop/stop", nil)
+	setWorkflowIdentity(req, "alice", false)
+	server.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -118,6 +128,187 @@ func TestWorkflowStopCancelsAndStopsEveryDescendant(t *testing.T) {
 		if !cancelled[id] {
 			t.Fatalf("scheduler did not cancel %s", id)
 		}
+	}
+}
+
+func TestWorkflowItemsAreScopedToRootSubmitterAndOperator(t *testing.T) {
+	server, store, _ := newTestServer(t)
+	ctx := context.Background()
+	for _, in := range []db1.CreateWorkItem{
+		{ID: "wi_alice", Repo: "repo", ProposalPath: "alice", WorkflowName: "build", StartStage: "plan", Submitter: "alice"},
+		// Older child slices have no submitter of their own. Ownership must follow
+		// the durable parent chain to the root instead of hiding or exposing them.
+		{ID: "wi_alice.s0", Repo: "repo", ProposalPath: "alice-child", WorkflowName: "slice", StartStage: "impl", ParentID: "wi_alice"},
+		{ID: "wi_bob", Repo: "repo", ProposalPath: "bob", WorkflowName: "build", StartStage: "plan", Submitter: "bob"},
+		// Trigger-origin runs have no browser submitter and are operator-only.
+		{ID: "wi_trigger", Repo: "repo", ProposalPath: "trigger", WorkflowName: "build", StartStage: "plan"},
+	} {
+		if err := store.CreateWorkItem(ctx, in); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	request := func(method, target, user, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(method, target, strings.NewReader(body))
+		setWorkflowIdentity(req, user, user == "admin")
+		rec := httptest.NewRecorder()
+		server.ServeHTTP(rec, req)
+		return rec
+	}
+	ids := func(rec *httptest.ResponseRecorder) map[string]bool {
+		t.Helper()
+		var response struct {
+			Items []db1.WorkItem `json:"items"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		result := make(map[string]bool, len(response.Items))
+		for _, item := range response.Items {
+			result[item.ID] = true
+		}
+		return result
+	}
+
+	aliceList := request(http.MethodGet, "/v1/workflow/items", "alice", "")
+	if aliceList.Code != http.StatusOK {
+		t.Fatalf("alice list status=%d body=%s", aliceList.Code, aliceList.Body.String())
+	}
+	if got := ids(aliceList); len(got) != 2 || !got["wi_alice"] || !got["wi_alice.s0"] {
+		t.Fatalf("alice visible items=%v, want root and inherited child only", got)
+	}
+	if rec := request(http.MethodGet, "/v1/workflow/items/all", "alice", ""); rec.Code != http.StatusForbidden {
+		t.Fatalf("non-operator all-items status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	// The operator role is not inferred from username data. This remains
+	// important after the bootstrap account is renamed and "admin" can be an
+	// unrelated authenticated identity.
+	literalAdmin := httptest.NewRequest(http.MethodGet, "/v1/workflow/items/wi_alice", nil)
+	setWorkflowIdentity(literalAdmin, "admin", false)
+	literalAdminRec := httptest.NewRecorder()
+	server.ServeHTTP(literalAdminRec, literalAdmin)
+	if literalAdminRec.Code != http.StatusForbidden {
+		t.Fatalf("literal admin username status=%d body=%s", literalAdminRec.Code, literalAdminRec.Body.String())
+	}
+	operatorList := request(http.MethodGet, "/v1/workflow/items/all", "admin", "")
+	if operatorList.Code != http.StatusOK || len(ids(operatorList)) != 4 {
+		t.Fatalf("operator items status=%d body=%s", operatorList.Code, operatorList.Body.String())
+	}
+	if rec := request(http.MethodGet, "/v1/workflow/items/wi_alice.s0", "alice", ""); rec.Code != http.StatusOK {
+		t.Fatalf("inherited child ownership status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := request(http.MethodGet, "/v1/workflow/items/wi_trigger", "admin", ""); rec.Code != http.StatusOK {
+		t.Fatalf("operator trigger detail status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	for _, tc := range []struct {
+		name, method, target, body string
+	}{
+		{"detail", http.MethodGet, "/v1/workflow/items/wi_alice", ""},
+		{"events", http.MethodGet, "/v1/workflow/items/wi_alice/events", ""},
+		{"proposal", http.MethodGet, "/v1/workflow/items/wi_alice/proposal", ""},
+		{"pause", http.MethodPost, "/v1/workflow/items/wi_alice/pause", ""},
+		{"resume", http.MethodPost, "/v1/workflow/items/wi_alice/resume", ""},
+		{"stop", http.MethodPost, "/v1/workflow/items/wi_alice/stop", ""},
+		{"delete", http.MethodDelete, "/v1/workflow/items/wi_alice", ""},
+	} {
+		t.Run("cross-user-"+tc.name, func(t *testing.T) {
+			if rec := request(tc.method, tc.target, "bob", tc.body); rec.Code != http.StatusForbidden {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+	if rec := request(http.MethodPost, "/v1/workflow/items/wi_alice/gate", "alice", `{"decision":"approve"}`); rec.Code != http.StatusForbidden {
+		t.Fatalf("owner gate decision status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	item, err := store.WorkItem(ctx, "wi_alice")
+	if err != nil || item.State != "active" || item.PauseReason != "" {
+		t.Fatalf("unauthorized lifecycle calls mutated item=%+v err=%v", item, err)
+	}
+}
+
+func TestWorkflowDefinitionWritesRequireAdministrator(t *testing.T) {
+	server, _, _ := newTestServer(t)
+	server.workflowDir = t.TempDir()
+
+	request := func(method, target, user, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(method, target, strings.NewReader(body))
+		setWorkflowIdentity(req, user, user == "admin")
+		rec := httptest.NewRecorder()
+		server.ServeHTTP(rec, req)
+		return rec
+	}
+	for _, user := range []string{"alice", "admin"} {
+		rec := request(http.MethodGet, "/v1/workflow/blocks", user, "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("blocks user=%q status=%d body=%s", user, rec.Code, rec.Body.String())
+		}
+		var response struct {
+			Editable bool `json:"editable"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		if response.Editable != (user == "admin") {
+			t.Fatalf("blocks user=%q editable=%t", user, response.Editable)
+		}
+	}
+	for _, tc := range []struct {
+		method, target, body string
+	}{
+		{http.MethodPut, "/v1/workflow/blocks/custom.test", `{}`},
+		{http.MethodDelete, "/v1/workflow/blocks/custom.test", ``},
+		{http.MethodPost, "/v1/workflow/save", `{}`},
+	} {
+		if rec := request(tc.method, tc.target, "alice", tc.body); rec.Code != http.StatusForbidden {
+			t.Fatalf("%s %s status=%d body=%s", tc.method, tc.target, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestWorkflowMutationBodiesAndDirectTriggersAreStrict(t *testing.T) {
+	server, _, _ := newTestServer(t)
+	server.workflowDir = t.TempDir()
+
+	for _, tc := range []struct {
+		name, method, target, user, body string
+	}{
+		{"trigger-unknown-field", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"/repo","proposal":"p.md","surprise":true}`},
+		{"trigger-trailing-json", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"/repo","proposal":"p.md"} {}`},
+		{"trigger-invalid-mode", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"/repo","proposal":"p.md","mode":"manual"}`},
+		{"trigger-relative-workspace", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"repo","proposal":"p.md"}`},
+		{"trigger-traversal", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"/repo","proposal":"p.md","event":"../private"}`},
+		{"trigger-backslash", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"/repo","proposal":"p.md","event":"docs\\private"}`},
+		{"trigger-option-ref", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"/repo","proposal":"p.md","ref":"--all"}`},
+		{"trigger-negative-spend", http.MethodPost, "/v1/trigger/fire", "admin", `{"source":"watch-dir","workspace":"/repo","proposal":"p.md","max_spend_usd":-1}`},
+		{"submit-trailing-json", http.MethodPost, "/v1/dev/submit", "alice", `{"proposal_md":"# Request","repo":"/repo"} {}`},
+		{"gate-trailing-json", http.MethodPost, "/v1/workflow/items/missing/gate", "admin", `{"decision":"approve"} {}`},
+		{"block-trailing-json", http.MethodPut, "/v1/workflow/blocks/custom.test", "admin", `{} {}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.target, strings.NewReader(tc.body))
+			setWorkflowIdentity(req, tc.user, tc.user == "admin")
+			rec := httptest.NewRecorder()
+			server.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestManualSubmissionIdempotencyIsScopedToSubmitter(t *testing.T) {
+	alice := manualSubmissionIdentity("alice", "client-request-1", "build")
+	if alice != manualSubmissionIdentity("alice", "client-request-1", "build") {
+		t.Fatal("same submitter and key did not produce a stable identity")
+	}
+	if alice == manualSubmissionIdentity("bob", "client-request-1", "build") {
+		t.Fatal("different submitters shared one idempotency identity")
+	}
+	if alice == manualSubmissionIdentity("alice", "client-request-2", "build") {
+		t.Fatal("different keys shared one idempotency identity")
 	}
 }
 
@@ -154,7 +345,7 @@ func TestWorkflowTriggerRegistryRoundTripFromBrowserContract(t *testing.T) {
 	get := func(user string) map[string]any {
 		t.Helper()
 		req := httptest.NewRequest(http.MethodGet, "/v1/workflow/triggers", nil)
-		req.Header.Set("X-Aimee-Webuser", user)
+		setWorkflowIdentity(req, user, user == "admin")
 		rec := httptest.NewRecorder()
 		server.ServeHTTP(rec, req)
 		if rec.Code != http.StatusOK {
@@ -169,7 +360,7 @@ func TestWorkflowTriggerRegistryRoundTripFromBrowserContract(t *testing.T) {
 
 	initial := get("admin")
 	version, _ := initial["version"].(string)
-	if version == "" || initial["editable"] != true || initial["max_rules"] != float64(appconfig.MaxTriggerRules) {
+	if version == "" || initial["operator"] != true || initial["editable"] != true || initial["max_rules"] != float64(appconfig.MaxTriggerRules) {
 		t.Fatalf("initial trigger registry metadata = %#v", initial)
 	}
 	rules := []map[string]any{{
@@ -179,7 +370,7 @@ func TestWorkflowTriggerRegistryRoundTripFromBrowserContract(t *testing.T) {
 	}}
 	body, _ := json.Marshal(map[string]any{"key": "trigger_rules", "value": rules, "previous_version": version})
 	req := httptest.NewRequest(http.MethodPost, "/v1/workflow/config/set", bytes.NewReader(body))
-	req.Header.Set("X-Aimee-Webuser", "admin")
+	setWorkflowIdentity(req, "admin", true)
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -199,16 +390,37 @@ func TestWorkflowTriggerRegistryRoundTripFromBrowserContract(t *testing.T) {
 	if !strings.Contains(string(content), "provider: codex") {
 		t.Fatalf("unrelated config was lost:\n%s", content)
 	}
-	if get("alice")["editable"] != false {
+	if ordinary := get("alice"); ordinary["operator"] != false || ordinary["editable"] != false {
 		t.Fatal("non-administrator registry was advertised as editable")
 	}
 
 	staleReq := httptest.NewRequest(http.MethodPost, "/v1/workflow/config/set", bytes.NewReader(body))
-	staleReq.Header.Set("X-Aimee-Webuser", "admin")
+	setWorkflowIdentity(staleReq, "admin", true)
 	staleRec := httptest.NewRecorder()
 	server.ServeHTTP(staleRec, staleReq)
 	if staleRec.Code != http.StatusConflict || !strings.Contains(staleRec.Body.String(), "version conflict") {
 		t.Fatalf("stale save status=%d body=%s", staleRec.Code, staleRec.Body.String())
+	}
+}
+
+func TestWorkflowOperatorCapabilityIsIndependentOfTriggerRegistryAvailability(t *testing.T) {
+	server, _, _ := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/v1/workflow/triggers", nil)
+	setWorkflowIdentity(req, "renamed-owner", true)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Operator bool `json:"operator"`
+		Editable bool `json:"editable"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if !response.Operator || response.Editable {
+		t.Fatalf("operator=%t editable=%t, want true/false", response.Operator, response.Editable)
 	}
 }
 
@@ -221,16 +433,19 @@ func TestWorkflowTriggerRegistryRejectsUnsafeWrites(t *testing.T) {
 
 	cases := []struct {
 		name, user, body string
+		operator         bool
 		status           int
 	}{
-		{"non-admin", "alice", `{"key":"trigger_rules","value":` + validRule + `,"previous_version":"` + version + `"}`, http.StatusForbidden},
-		{"unsupported-source", "admin", `{"key":"trigger_rules","value":[{"source":"webhook","pipeline":{"template":"build","workspace":"/repo"}}],"previous_version":"` + version + `"}`, http.StatusBadRequest},
-		{"trailing-json", "admin", `{"key":"trigger_rules","value":` + validRule + `,"previous_version":"` + version + `"}{}`, http.StatusBadRequest},
+		{"non-admin", "alice", `{"key":"trigger_rules","value":` + validRule + `,"previous_version":"` + version + `"}`, false, http.StatusForbidden},
+		{"literal-admin-without-capability", "admin", `{"key":"trigger_rules","value":` + validRule + `,"previous_version":"` + version + `"}`, false, http.StatusForbidden},
+		{"relative-workspace", "admin", `{"key":"trigger_rules","value":[{"source":"watch-dir","pipeline":{"template":"build","workspace":"repo"}}],"previous_version":"` + version + `"}`, true, http.StatusBadRequest},
+		{"unsupported-source", "admin", `{"key":"trigger_rules","value":[{"source":"webhook","pipeline":{"template":"build","workspace":"/repo"}}],"previous_version":"` + version + `"}`, true, http.StatusBadRequest},
+		{"trailing-json", "admin", `{"key":"trigger_rules","value":` + validRule + `,"previous_version":"` + version + `"}{}`, true, http.StatusBadRequest},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/v1/workflow/config/set", strings.NewReader(test.body))
-			req.Header.Set("X-Aimee-Webuser", test.user)
+			setWorkflowIdentity(req, test.user, test.operator)
 			rec := httptest.NewRecorder()
 			server.ServeHTTP(rec, req)
 			if rec.Code != test.status {
@@ -250,7 +465,7 @@ func TestWorkflowTriggerRegistryReportsMalformedConfigWithoutHidingIt(t *testing
 	configStore, _ := appconfig.NewStore(configPath)
 	server.SetConfigStore(configStore)
 	req := httptest.NewRequest(http.MethodGet, "/v1/workflow/triggers", nil)
-	req.Header.Set("X-Aimee-Webuser", "admin")
+	setWorkflowIdentity(req, "admin", true)
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"registry_error"`) ||

--- a/server-go/internal/api/submit.go
+++ b/server-go/internal/api/submit.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -19,10 +19,13 @@ func (s *Server) devSubmit(w http.ResponseWriter, r *http.Request) {
 		Workflow string `json:"workflow"`
 		Repo     string `json:"repo"`
 	}
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
+	decoder := jsonDecoder(r.Body)
 	if err := decoder.Decode(&request); err != nil {
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeError(w, http.StatusBadRequest, errors.New("request must contain one JSON value"))
 		return
 	}
 	if strings.TrimSpace(request.Proposal) == "" || request.Repo == "" {
@@ -44,7 +47,11 @@ func (s *Server) devSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 	identity := ""
 	if idempotencyKey != "" {
-		identity = fmt.Sprintf("manual:%s:%s", wfe.Hash([]byte(idempotencyKey)), request.Workflow)
+		// Idempotency belongs to the authenticated submitter, not merely the repo.
+		// Otherwise two browser users choosing the same client key would cause the
+		// second request to return the first user's work-item ID and silently skip
+		// the second proposal.
+		identity = manualSubmissionIdentity(workflowPrincipal(r), idempotencyKey, request.Workflow)
 	}
 	if identity != "" {
 		if existing, findErr := s.db.WorkItemByProposal(r.Context(), repo, identity); findErr == nil {
@@ -94,7 +101,7 @@ func (s *Server) devSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.db.AdmitRoot(r.Context(), db1.CreateWorkItem{ID: id, Repo: repo,
 		ProposalPath: identity, WorkflowName: definition.Name, WorkflowVersion: definition.Version,
-		StartStage: start, Mode: "autonomous", Submitter: r.Header.Get("X-Aimee-Webuser")}, cap); err != nil {
+		StartStage: start, Mode: "autonomous", Submitter: workflowPrincipal(r)}, cap); err != nil {
 		_ = s.artifacts.DeleteWorkItem(id)
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			if existing, findErr := s.db.WorkItemByProposal(r.Context(), repo, identity); findErr == nil {
@@ -109,4 +116,9 @@ func (s *Server) devSubmit(w http.ResponseWriter, r *http.Request) {
 		s.notify()
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "work_item_id": id})
+}
+
+func manualSubmissionIdentity(submitter, idempotencyKey, workflow string) string {
+	scope := submitter + "\x00" + idempotencyKey
+	return fmt.Sprintf("manual:%s:%s", wfe.Hash([]byte(scope)), workflow)
 }

--- a/server-go/internal/api/trigger.go
+++ b/server-go/internal/api/trigger.go
@@ -5,10 +5,11 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"os/exec"
 	"path"
@@ -145,6 +146,10 @@ func (s *Server) scanTrigger(ctx context.Context, request triggerFireRequest) er
 func confinedProposalDirectory(directory string) (string, error) {
 	if directory == "" {
 		directory = "docs/proposals/pending"
+	}
+	if directory != strings.TrimSpace(directory) || strings.Contains(directory, "\\") ||
+		strings.IndexFunc(directory, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		return "", errors.New("proposal directory must use forward slashes with no surrounding whitespace or control characters")
 	}
 	clean := path.Clean(directory)
 	if clean == "." || path.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, "../") {
@@ -289,8 +294,13 @@ type triggerFireRequest struct {
 
 func (s *Server) triggerFire(w http.ResponseWriter, r *http.Request) {
 	var request triggerFireRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	decoder := jsonDecoder(r.Body)
+	if err := decoder.Decode(&request); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("decode trigger: %w", err))
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeError(w, http.StatusBadRequest, errors.New("request must contain one JSON value"))
 		return
 	}
 	if request.Source != "proposals" && request.Source != "watch-dir" {
@@ -301,6 +311,11 @@ func (s *Server) triggerFire(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("workspace and proposal are required"))
 		return
 	}
+	if request.Workspace != strings.TrimSpace(request.Workspace) || !filepath.IsAbs(request.Workspace) ||
+		strings.IndexFunc(request.Workspace, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		writeError(w, http.StatusBadRequest, errors.New("workspace must be an absolute server path with no surrounding whitespace or control characters"))
+		return
+	}
 	if request.Ref == "" {
 		request.Ref = "HEAD"
 	}
@@ -309,6 +324,23 @@ func (s *Server) triggerFire(w http.ResponseWriter, r *http.Request) {
 	}
 	if request.Mode == "" {
 		request.Mode = "autonomous"
+	}
+	if request.Mode != "autonomous" && request.Mode != "interactive" {
+		writeError(w, http.StatusBadRequest, errors.New("mode must be autonomous or interactive"))
+		return
+	}
+	if _, err := confinedProposalDirectory(request.Event); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if request.Ref != strings.TrimSpace(request.Ref) || strings.HasPrefix(request.Ref, "-") ||
+		strings.IndexFunc(request.Ref, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		writeError(w, http.StatusBadRequest, errors.New("ref must not contain surrounding whitespace, control characters, or start with '-'"))
+		return
+	}
+	if request.MaxSpend < 0 || math.IsNaN(request.MaxSpend) || math.IsInf(request.MaxSpend, 0) {
+		writeError(w, http.StatusBadRequest, errors.New("max_spend_usd must be finite and non-negative"))
+		return
 	}
 	if s.workflowDir == "" {
 		writeError(w, http.StatusServiceUnavailable, errors.New("workflow directory is not configured"))

--- a/server-go/internal/api/workflows.go
+++ b/server-go/internal/api/workflows.go
@@ -74,7 +74,15 @@ func splitBinding(binding string) (string, string, bool) {
 	return "", "", false
 }
 
-func (s *Server) workflowBlocks(w http.ResponseWriter, _ *http.Request) {
+func requireWorkflowAdmin(w http.ResponseWriter, r *http.Request) bool {
+	if !workflowOperator(r) {
+		writeError(w, http.StatusForbidden, errors.New("administrator access required"))
+		return false
+	}
+	return true
+}
+
+func (s *Server) workflowBlocks(w http.ResponseWriter, r *http.Request) {
 	registry, err := s.workflowRegistry()
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, err)
@@ -85,20 +93,28 @@ func (s *Server) workflowBlocks(w http.ResponseWriter, _ *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"blocks": blocks})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"blocks": blocks, "editable": workflowOperator(r),
+	})
 }
 
 func (s *Server) workflowBlockPut(w http.ResponseWriter, r *http.Request) {
+	if !requireWorkflowAdmin(w, r) {
+		return
+	}
 	registry, err := s.workflowRegistry()
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, err)
 		return
 	}
 	var block wfe.BlockDefinition
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
+	decoder := jsonDecoder(r.Body)
 	if err := decoder.Decode(&block); err != nil {
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeError(w, http.StatusBadRequest, errors.New("request must contain one JSON value"))
 		return
 	}
 	block.Name = r.PathValue("name")
@@ -110,6 +126,9 @@ func (s *Server) workflowBlockPut(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) workflowBlockDelete(w http.ResponseWriter, r *http.Request) {
+	if !requireWorkflowAdmin(w, r) {
+		return
+	}
 	registry, err := s.workflowRegistry()
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, err)
@@ -195,6 +214,9 @@ func (s *Server) workflowValidate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) workflowSave(w http.ResponseWriter, r *http.Request) {
+	if !requireWorkflowAdmin(w, r) {
+		return
+	}
 	request, err := decodeWorkflowRequest(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)

--- a/server-go/internal/config/store.go
+++ b/server-go/internal/config/store.go
@@ -86,6 +86,9 @@ func (s *Store) TriggerRules() ([]TriggerRule, error) {
 			if rules[i].Pipeline.Template == "" || rules[i].Pipeline.Workspace == "" {
 				return nil, fmt.Errorf("trigger_rules[%d] needs pipeline.template and pipeline.workspace", i)
 			}
+			if !validTriggerWorkspace(rules[i].Pipeline.Workspace) {
+				return nil, fmt.Errorf("trigger_rules[%d].pipeline.workspace must be an absolute server path", i)
+			}
 			if rules[i].Pipeline.MaxSpendUSD < 0 || math.IsNaN(rules[i].Pipeline.MaxSpendUSD) || math.IsInf(rules[i].Pipeline.MaxSpendUSD, 0) {
 				return nil, fmt.Errorf("trigger_rules[%d].pipeline.max_spend_usd must be finite and non-negative", i)
 			}
@@ -375,6 +378,9 @@ func validateKeyValue(key string, value any) error {
 			if rule.Pipeline.Template == "" || rule.Pipeline.Workspace == "" {
 				return fmt.Errorf("trigger_rules[%d] needs pipeline.template and pipeline.workspace", i)
 			}
+			if !validTriggerWorkspace(rule.Pipeline.Workspace) {
+				return fmt.Errorf("trigger_rules[%d].pipeline.workspace must be an absolute server path", i)
+			}
 			if rule.Pipeline.MaxSpendUSD < 0 || math.IsNaN(rule.Pipeline.MaxSpendUSD) || math.IsInf(rule.Pipeline.MaxSpendUSD, 0) {
 				return fmt.Errorf("trigger_rules[%d].pipeline.max_spend_usd must be finite and non-negative", i)
 			}
@@ -409,6 +415,11 @@ func confinedTriggerDirectory(directory string) bool {
 	}
 	clean := path.Clean(directory)
 	return clean != "." && !path.IsAbs(clean) && clean != ".." && !strings.HasPrefix(clean, "../")
+}
+
+func validTriggerWorkspace(workspace string) bool {
+	return workspace == strings.TrimSpace(workspace) && filepath.IsAbs(workspace) &&
+		strings.IndexFunc(workspace, func(r rune) bool { return r < 0x20 || r == 0x7f }) < 0
 }
 
 func number(value any) (int64, bool) {

--- a/server-go/internal/config/store_test.go
+++ b/server-go/internal/config/store_test.go
@@ -133,9 +133,10 @@ func TestTriggerRulesRejectUnsafeHumanInputs(t *testing.T) {
 		"pipeline": map[string]any{"template": "build", "workspace": "/repo"},
 	}
 	for name, mutate := range map[string]func(map[string]any){
-		"traversal":    func(rule map[string]any) { rule["event"] = "../outside" },
-		"git-option":   func(rule map[string]any) { rule["schedule"] = "--all" },
-		"negative-cap": func(rule map[string]any) { rule["pipeline"].(map[string]any)["max_spend_usd"] = -1 },
+		"traversal":          func(rule map[string]any) { rule["event"] = "../outside" },
+		"relative-workspace": func(rule map[string]any) { rule["pipeline"].(map[string]any)["workspace"] = "repo" },
+		"git-option":         func(rule map[string]any) { rule["schedule"] = "--all" },
+		"negative-cap":       func(rule map[string]any) { rule["pipeline"].(map[string]any)["max_spend_usd"] = -1 },
 	} {
 		t.Run(name, func(t *testing.T) {
 			rule := map[string]any{

--- a/server-go/internal/wfe/definition.go
+++ b/server-go/internal/wfe/definition.go
@@ -5,8 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
+	"path"
+	"path/filepath"
 	"regexp"
+	"strings"
 
 	"go.yaml.in/yaml/v3"
 )
@@ -124,6 +128,11 @@ func (d Definition) Validate() error {
 				return err
 			}
 		}
+		if node.Block == "trigger.watch-dir" {
+			if err := validateWatchDirParams(node); err != nil {
+				return err
+			}
+		}
 		if node.Block == "gate.roundtable" {
 			panel, _ := node.Params["panel"].(map[string]any)
 			if panel != nil {
@@ -170,6 +179,55 @@ func (d Definition) Validate() error {
 	return nil
 }
 
+func validateWatchDirParams(node Node) error {
+	stringParam := func(key string) (string, bool, error) {
+		raw, present := node.Params[key]
+		if !present {
+			return "", false, nil
+		}
+		value, ok := raw.(string)
+		if !ok {
+			return "", true, fmt.Errorf("node %q param %q must be a string", node.ID, key)
+		}
+		return value, true, nil
+	}
+	if workspace, present, err := stringParam("workspace"); err != nil {
+		return err
+	} else if present && workspace != "" && (workspace != strings.TrimSpace(workspace) || !filepath.IsAbs(workspace) ||
+		strings.IndexFunc(workspace, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0) {
+		return fmt.Errorf("node %q param %q must be an absolute server path with no surrounding whitespace or control characters", node.ID, "workspace")
+	}
+	if directory, present, err := stringParam("dir"); err != nil {
+		return err
+	} else if present && directory != "" {
+		trimmed := strings.TrimSpace(directory)
+		clean := path.Clean(trimmed)
+		if directory != trimmed || strings.Contains(directory, "\\") ||
+			strings.IndexFunc(directory, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 ||
+			clean == "." || path.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, "../") {
+			return fmt.Errorf("node %q param %q must be a confined repository-relative directory", node.ID, "dir")
+		}
+	}
+	if ref, present, err := stringParam("ref"); err != nil {
+		return err
+	} else if present && (ref != strings.TrimSpace(ref) || strings.HasPrefix(ref, "-") ||
+		strings.IndexFunc(ref, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0) {
+		return fmt.Errorf("node %q param %q must not contain surrounding whitespace, control characters, or start with '-'", node.ID, "ref")
+	}
+	if mode, present, err := stringParam("mode"); err != nil {
+		return err
+	} else if present && mode != "" && mode != "autonomous" && mode != "interactive" {
+		return fmt.Errorf("node %q param %q must be autonomous or interactive", node.ID, "mode")
+	}
+	if raw, present := node.Params["max_spend_usd"]; present {
+		spend, ok := numericFloat(raw)
+		if !ok || spend < 0 || math.IsNaN(spend) || math.IsInf(spend, 0) {
+			return fmt.Errorf("node %q param %q must be finite and non-negative", node.ID, "max_spend_usd")
+		}
+	}
+	return nil
+}
+
 func (d Definition) Node(id string) (Node, bool) {
 	for _, node := range d.Nodes {
 		if node.ID == id {
@@ -203,6 +261,20 @@ func numericInt(value any) (int, bool) {
 		if n == float64(int(n)) {
 			return int(n), true
 		}
+	}
+	return 0, false
+}
+
+func numericFloat(value any) (float64, bool) {
+	switch n := value.(type) {
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case float64:
+		return n, true
 	}
 	return 0, false
 }

--- a/server-go/internal/wfe/definition_test.go
+++ b/server-go/internal/wfe/definition_test.go
@@ -2,11 +2,58 @@ package wfe
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestWatchDirectoryTriggerParamsAreValidatedWhenWorkflowIsSaved(t *testing.T) {
+	definition := func(params string) []byte {
+		return []byte(fmt.Sprintf(`
+name: watcher
+start: watch
+nodes:
+  - id: watch
+    block: trigger.watch-dir
+    params:
+%s
+`, params))
+	}
+
+	for _, tc := range []struct {
+		name, params, want string
+	}{
+		{"workspace-type", "      workspace: 12", `param "workspace" must be a string`},
+		{"workspace-relative", "      workspace: repos/demo", "absolute server path"},
+		{"directory-type", "      dir: 12", `param "dir" must be a string`},
+		{"directory-traversal", "      dir: ../private", "confined repository-relative directory"},
+		{"directory-backslash", `      dir: 'docs\\private'`, "confined repository-relative directory"},
+		{"ref-option", "      ref: --all", "start with '-'"},
+		{"mode", "      mode: manual", "autonomous or interactive"},
+		{"spend-negative", "      max_spend_usd: -1", "finite and non-negative"},
+		{"spend-type", "      max_spend_usd: lots", "finite and non-negative"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseDefinition(definition(tc.params))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	for _, params := range []string{
+		"      workspace: /srv/repos/demo\n      dir: docs/proposals/pending\n      ref: testing\n      mode: interactive\n      max_spend_usd: 1.5",
+		// A definition without a workspace is intentionally saved but disarmed;
+		// the operator can fill it in later without an invalid workflow blocking boot.
+		"      dir: docs/proposals/pending",
+	} {
+		if _, err := ParseDefinition(definition(params)); err != nil {
+			t.Fatalf("valid watch trigger rejected: %v", err)
+		}
+	}
+}
 
 func TestCurrentBuildWorkflowParses(t *testing.T) {
 	path := filepath.Join("..", "..", "..", "config", "workflows", "build.yaml")

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -2450,7 +2450,8 @@ int v1_route_dispatch(const char *method, const char *path, const char *body, in
    if ((strcmp(path, "/v1/workflow") == 0 || strncmp(path, "/v1/workflow/", 13) == 0) ||
        strcmp(path, "/v1/trigger/fire") == 0 || strcmp(path, "/v1/dev/submit") == 0)
       return wfe_http_proxy_request(method, path, server_http_identity_query(), body, body_len,
-                                    server_http_identity_principal(), resp, resp_cap);
+                                    server_http_identity_principal(),
+                                    (g_rpc_conn_caps & CAP_WORKFLOW_ADMIN) != 0, resp, resp_cap);
    char id[256];
    const http_route_t *e = route_match(method, path, id, sizeof(id));
    if (!e || !e->handler)

--- a/src/server/wfe_http_proxy.c
+++ b/src/server/wfe_http_proxy.c
@@ -12,8 +12,8 @@
 #ifdef _WIN32
 
 int wfe_http_proxy_request(const char *method, const char *path, const char *query,
-                           const char *body, int body_len, const char *principal, char *resp,
-                           int resp_cap)
+                           const char *body, int body_len, const char *principal,
+                           int workflow_operator, char *resp, int resp_cap)
 {
    (void)method;
    (void)path;
@@ -21,6 +21,7 @@ int wfe_http_proxy_request(const char *method, const char *path, const char *que
    (void)body;
    (void)body_len;
    (void)principal;
+   (void)workflow_operator;
    if (resp && resp_cap > 0)
       snprintf(resp, (size_t)resp_cap,
                "{\"error\":\"Go WFE control plane is unavailable on this platform\"}");
@@ -99,8 +100,8 @@ static char *decode_chunked(const char *body)
 }
 
 int wfe_http_proxy_request(const char *method, const char *path, const char *query,
-                           const char *body, int body_len, const char *principal, char *resp,
-                           int resp_cap)
+                           const char *body, int body_len, const char *principal,
+                           int workflow_operator, char *resp, int resp_cap)
 {
    if (!method || !path || !resp || resp_cap <= 0 || body_len < 0 || strchr(method, '\r') ||
        strchr(method, '\n') || strchr(path, '\r') || strchr(path, '\n') ||
@@ -146,7 +147,7 @@ int wfe_http_proxy_request(const char *method, const char *path, const char *que
    if (!principal)
       principal = "";
    size_t head_cap =
-       strlen(method) + strlen(path) + strlen(query) + strlen(bearer) + strlen(principal) + 512;
+       strlen(method) + strlen(path) + strlen(query) + strlen(bearer) + strlen(principal) + 576;
    char *head = malloc(head_cap);
    if (!head)
    {
@@ -157,10 +158,11 @@ int wfe_http_proxy_request(const char *method, const char *path, const char *que
    int head_len =
        snprintf(head, head_cap,
                 "%s %s%s%s HTTP/1.1\r\nHost: aimee\r\nContent-Type: application/json\r\n"
-                "Content-Length: %d\r\n%s%s%s%s%s%sConnection: close\r\n\r\n",
+                "Content-Length: %d\r\n%s%s%s%s%s%s%sConnection: close\r\n\r\n",
                 method, path, query[0] ? "?" : "", query, body_len,
                 bearer[0] ? "Authorization: Bearer " : "", bearer, bearer[0] ? "\r\n" : "",
-                principal[0] ? "X-Aimee-Webuser: " : "", principal, principal[0] ? "\r\n" : "");
+                principal[0] ? "X-Aimee-Webuser: " : "", principal, principal[0] ? "\r\n" : "",
+                workflow_operator ? "X-Aimee-Workflow-Operator: true\r\n" : "");
    runtime_secret_wipe(bearer, sizeof(bearer));
    if (head_len <= 0 || (size_t)head_len >= head_cap ||
        write_all(fd, head, (size_t)head_len) != 0 ||

--- a/src/server/wfe_http_proxy.h
+++ b/src/server/wfe_http_proxy.h
@@ -2,9 +2,11 @@
 #define AIMEE_WFE_HTTP_PROXY_H
 
 /* Forward an already-authorized public /v1 workflow request to the private Go
- * control-plane socket. Returns the upstream HTTP status and copies its JSON
+ * control-plane socket. Identity and the CAP_WORKFLOW_ADMIN decision are
+ * attested separately. Returns the upstream HTTP status and copies its JSON
  * response into resp. */
-int wfe_http_proxy_request(const char *method, const char *path, const char *query, const char *body,
-                           int body_len, const char *principal, char *resp, int resp_cap);
+int wfe_http_proxy_request(const char *method, const char *path, const char *query,
+                           const char *body, int body_len, const char *principal,
+                           int workflow_operator, char *resp, int resp_cap);
 
 #endif

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -322,7 +322,8 @@ static void test_wfe_http_proxy_round_trip(void)
       }
       if (!strstr(request, "POST /v1/dev/submit?source=release-test HTTP/1.1\r\n") ||
           !strstr(request, "Authorization: Bearer proxy-test-token\r\n") ||
-          !strstr(request, "X-Aimee-Webuser: webuser:release-test\r\n"))
+          !strstr(request, "X-Aimee-Webuser: webuser:release-test\r\n") ||
+          !strstr(request, "X-Aimee-Workflow-Operator: true\r\n"))
          _exit(12);
       const char *response = "HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\n"
                              "Content-Length: 30\r\nConnection: close\r\n\r\n"
@@ -339,7 +340,7 @@ static void test_wfe_http_proxy_round_trip(void)
    char response[256];
    const char *body = "{\"proposal_md\":\"test\"}";
    int status = wfe_http_proxy_request("POST", "/v1/dev/submit", "source=release-test", body,
-                                       (int)strlen(body), "webuser:release-test", response,
+                                       (int)strlen(body), "webuser:release-test", 1, response,
                                        sizeof(response));
    unsetenv("AIMEE_WFE_HTTP_SOCKET");
    runtime_secret_remove("AIMEE_API_BEARER_TOKEN");


### PR DESCRIPTION
## Summary

- enforce per-user ownership for workflow items, events, proposals, and lifecycle actions, including child slices
- separate trusted workflow-operator capability from usernames and gate global workflow, trigger, run-policy, and human-approval mutations
- validate trigger workspaces, refs, modes, directories, spend caps, and JSON request shape at configuration/save/fire boundaries
- make workflow and trigger controls accurately read-only for non-operators, refresh custom blocks after mutation, and correct run-policy guidance
- scope manual submission idempotency keys by authenticated submitter

## Why

Exploratory and end-to-end testing found that a signed-in user who knew another work-item ID could inspect or mutate it, global workflow definitions could be changed without operator authorization, and malformed trigger inputs were accepted until repeated scheduler failures. Operator authority was also coupled to the literal username `admin`, creating a role-collision risk after bootstrap-admin rename.

## Impact

Human users can create triggers with immediate, actionable validation and see only controls they are authorized to use. Workflow ownership and operator-only actions are now enforced at the Go control plane as well as the web runtime boundary.

## Validation

- `go test ./... -count=1 && go vet ./...` in `server-go`
- `go test ./... -count=1 && go vet ./...` in `runtime-web`
- `npm test -- --run && npm run check` (169 tests)
- frontend production build
- `make -C src lint` (41 checks)
- affected native proxy unit test
- docs checker and `git diff --check`
- real Go-server Unix-socket E2E covering owner/operator/cross-user access and malformed submissions/triggers
