### PR TITLE
fix: name the root when verify finds no config

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "035cfc25059b8925a06105077ac35410fe2dc6bf59b2ae71cc5173c6836c8c84",
+      "source_sha256": "9cb5bd93417c410b6d4b3eb9de379d2435434089df8dfa102196110b622be83d",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_verify.c
+++ b/src/modules/git/git_verify.c
@@ -466,6 +466,56 @@ int project_primary_branch(const char *project_root, char *out, size_t out_len)
    return found ? 0 : -1;
 }
 
+/* Say WHY there is no verify config, on the error path only.
+ *
+ * generate_project_yaml collapses five distinct causes into a single -1: no
+ * resolvable root, no Makefile, make not runnable, no recognised targets, and a
+ * config that could not be written. The message shown to operators asserted two
+ * of them ("no Makefile found, or no recognized targets") and named neither the
+ * root it searched nor which of the two it actually hit.
+ *
+ * That message is wrong far more often than it looks. Measured in this repo,
+ * which HAS src/Makefile and a verify-local target that find_makefile_subdir
+ * handles explicitly: `aimee git verify` reports "no Makefile found" from both
+ * the repository root and src/. The Makefile was never the problem. verify_root
+ * comes from the server's thread-local cwd via the session's worktree mapping,
+ * so when that mapping does not cover the caller's checkout, verify resolves a
+ * DIFFERENT directory and truthfully finds no Makefile in it. An operator
+ * reading "no Makefile found" goes looking at a Makefile that is sitting right
+ * there, which is the one place the answer is not.
+ *
+ * So name the path. A wrong root is obvious the moment it is printed, and
+ * unguessable until then. Re-deriving the cause here rather than threading an
+ * out-param through verify_load_config keeps the cost on the failure path,
+ * where a few stat() calls are free and a diagnosis is the entire point. */
+void verify_config_unavailable_reason(const char *verify_root, char *out, size_t out_len)
+{
+   if (!verify_root || !verify_root[0])
+   {
+      snprintf(out, out_len,
+               "no repository root could be resolved for this session, so there was nowhere "
+               "to look for a Makefile.");
+      return;
+   }
+
+   char subdir[MAX_PATH_LEN];
+   if (find_makefile_subdir(verify_root, subdir, sizeof(subdir)) != 0)
+   {
+      snprintf(out, out_len,
+               "no Makefile at %s/Makefile or %s/src/Makefile. If that is not the repository "
+               "you meant, verify resolved it from this session's worktree mapping rather "
+               "than your shell's directory -- pass path=<repo> to target it explicitly.",
+               verify_root, verify_root);
+      return;
+   }
+
+   snprintf(out, out_len,
+            "%s%s%s/Makefile exists but declares no target aimee recognises (verify-local, "
+            "lint, all, check-linking, unit-tests, test, build-integrity), or `make -pn` "
+            "could not be run there.",
+            verify_root, subdir[0] ? "/" : "", subdir);
+}
+
 /* Open the project.yaml for the given project. Looks only at
  * ~/.config/aimee/projects/<name>/project.yaml. If the file does not
  * exist, attempts to auto-generate it from the project's Makefile and
@@ -1702,9 +1752,14 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
    {
       if (json_out)
          return verify_json_status("unavailable", "no-verify-config", 0);
-      return mcp_text("error: no verify config available — auto-generation failed (no Makefile "
-                      "found, or no recognized targets). Create "
-                      "~/.config/aimee/projects/<project>/project.yaml manually.");
+      char why[768];
+      verify_config_unavailable_reason(verify_root, why, sizeof(why));
+      char msg[1024];
+      snprintf(msg, sizeof(msg),
+               "error: no verify config available — %s Create "
+               "~/.config/aimee/projects/<project>/project.yaml manually to override.",
+               why);
+      return mcp_text(msg);
    }
 
    if (is_async && server_ctx)

--- a/src/modules/git/git_verify.h
+++ b/src/modules/git/git_verify.h
@@ -49,6 +49,12 @@ typedef struct
  * verify section found. project_root may be NULL (uses cwd). */
 int verify_load_config(const char *project_root, verify_config_t *cfg);
 
+/* Explain why verify_load_config found nothing, for the error path. Writes a
+ * sentence naming the root that was searched: the previous message asserted "no
+ * Makefile found" for five different causes and never said WHERE it looked, which
+ * is the one fact that distinguishes a missing Makefile from a wrong root. */
+void verify_config_unavailable_reason(const char *verify_root, char *out, size_t out_len);
+
 /* Verify scope gate. Returns 1 if target_repo_root is in scope for
  * verification — either cross-project verify is enabled in config, or the
  * target resolves to the same canonical main repo as one of the session's

--- a/src/tests/test_git_verify_contract.c
+++ b/src/tests/test_git_verify_contract.c
@@ -16,6 +16,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 static verify_step_t mk_step(const char *name, const char *tier)
 {
@@ -139,6 +141,60 @@ static void test_cancelled_unavailable(void)
    printf("  PASS: cancelled -> unavailable (distinct from passed)\n");
 }
 
+/* "no Makefile found" was asserted for five different causes and never named the
+ * directory it searched. In this very repository -- which has src/Makefile, a case
+ * find_makefile_subdir handles explicitly -- `aimee git verify` reported exactly
+ * that, because verify_root resolved to a different checkout via the session's
+ * worktree mapping. The Makefile was never missing.
+ *
+ * The fix is not a better guess, it is naming the path. Assert the root appears in
+ * every branch, so a wrong root stays diagnosable from the message alone. */
+static void test_unavailable_reason_names_the_root(void)
+{
+   char why[768];
+
+   /* A directory with no Makefile: say so, and say where. */
+   char tmpl[] = "/tmp/aimee-verify-reason-XXXXXX";
+   char *dir = mkdtemp(tmpl);
+   assert(dir != NULL);
+   verify_config_unavailable_reason(dir, why, sizeof(why));
+   assert(strstr(why, dir) != NULL);
+   assert(strstr(why, "no Makefile") != NULL);
+   /* And point at the real cause of the observed failure, which is not the file. */
+   assert(strstr(why, "worktree mapping") != NULL);
+
+   /* A Makefile under src/ is FOUND, so the message must not claim otherwise --
+    * this is the exact shape of this repo, and the case that was misreported. */
+   char sub[512];
+   snprintf(sub, sizeof(sub), "%s/src", dir);
+   assert(mkdir(sub, 0755) == 0);
+   char mk[600];
+   snprintf(mk, sizeof(mk), "%s/Makefile", sub);
+   FILE *f = fopen(mk, "w");
+   assert(f != NULL);
+   fputs("nothing-aimee-knows:\n\t@true\n", f);
+   fclose(f);
+
+   verify_config_unavailable_reason(dir, why, sizeof(why));
+   assert(strstr(why, "no Makefile") == NULL); /* it exists; do not lie about it */
+   assert(strstr(why, dir) != NULL);
+   assert(strstr(why, "src") != NULL);
+   assert(strstr(why, "recognise") != NULL);
+
+   unlink(mk);
+   rmdir(sub);
+   rmdir(dir);
+
+   /* No resolvable root at all: distinct from "no Makefile", because there was
+    * nowhere to look rather than nothing to find. */
+   verify_config_unavailable_reason("", why, sizeof(why));
+   assert(strstr(why, "no repository root") != NULL);
+   verify_config_unavailable_reason(NULL, why, sizeof(why));
+   assert(strstr(why, "no repository root") != NULL);
+
+   printf("  test_unavailable_reason_names_the_root: PASS\n");
+}
+
 int main(void)
 {
    printf("git_verify_contract:\n");
@@ -146,6 +202,7 @@ int main(void)
    test_one_fail();
    test_skip();
    test_cancelled_unavailable();
+   test_unavailable_reason_names_the_root();
    printf("ok\n");
    return 0;
 }


### PR DESCRIPTION
## The defect

`aimee git verify` reports:

> error: no verify config available — auto-generation failed (**no Makefile found**, or no recognized targets).

It reports this from both the root and `src/` of **this repository**, which has `src/Makefile` and a `verify-local` target — a case `find_makefile_subdir` handles explicitly. The Makefile was never missing.

`verify_root` comes from the server's thread-local cwd via the session's worktree mapping. When that mapping does not cover the caller's checkout, verify resolves a *different directory* and truthfully finds no Makefile in it. The message then sends the operator to inspect a Makefile that is sitting right there — the one place the answer is not.

`generate_project_yaml` collapses **five** causes into a single `-1`: no resolvable root, no Makefile, `make` not runnable, no recognised targets, and a config that could not be written. The message asserted two of them as fact, and never said *where it looked* — which is the single fact separating "missing Makefile" from "wrong root".

Same family as the kb health verdict fix (#2319): the evidence existed and the summary did not carry it.

## The fix

Derive the reason on the error path and name the path in every branch. A wrong root is obvious the moment it is printed and unguessable until then.

Re-deriving the cause at the failure site rather than threading an out-param through `verify_load_config` keeps the cost where a diagnosis is the entire point — a few `stat()` calls on a path that is already failing.

Before:
```
no verify config available — auto-generation failed (no Makefile found, or no recognized targets).
```
After (no Makefile):
```
no verify config available — no Makefile at /x/Makefile or /x/src/Makefile. If that is not
the repository you meant, verify resolved it from this session's worktree mapping rather than
your shell's directory -- pass path=<repo> to target it explicitly.
```

## Verification

Test asserts the root appears in **every** branch, that a Makefile under `src/` is not reported missing (the exact shape of this repo, and the case that was misreported), and that "no resolvable root" stays distinct from "no Makefile". **Red verified first** against the old message — it fails on `strstr(why, dir)`, i.e. precisely "does it name the root".

Second commit resyncs `dependencies/aimee-repositories.lock.json`: `src/modules/git` is a vendored mirror, so editing it moves that module's `source_sha256`. Only the git module drifted; `commit` pins are untouched, as they point at upstream repositories and are not derived from monorepo contents.

**Gate:** clang-format → `make lint` (41/41) → `check-docs.py` → `check_c_repository_lock.py` — all green.