### PR TITLE
Fix workflow access to sealed Git identity

### DIFF
--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -160,6 +160,7 @@ Read the pause reason and the last events before acting. Common current reasons 
 | `fanout_limit` | reduce packets or raise the node's bounded `max_children` |
 | `budget_cap`, `turn_cap`, `wall_cap` | inspect cost and run policy before allowing more work |
 | `base_integration_conflict` | update or resolve the integration branch before resuming |
+| `git_identity_missing` | seal `AIMEE_GIT_AUTHOR_NAME` and `AIMEE_GIT_AUTHOR_EMAIL` through the install-time Vault bootstrap, then start the run |
 | `workflow_definition_invalid`, `workflow_block_unavailable` | restore the pinned definition or block version; editing only the current definition is insufficient |
 
 Do not file a replacement run merely to hide the evidence on the first one. Stop only when the run

--- a/server-go/internal/engine/crash_isolation_test.go
+++ b/server-go/internal/engine/crash_isolation_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,6 +16,12 @@ type crashingRunner struct{}
 
 func (crashingRunner) Run(context.Context, StepRequest) (StepResult, error) {
 	return StepResult{}, errors.New("worker process connection disappeared")
+}
+
+type missingGitIdentityRunner struct{}
+
+func (missingGitIdentityRunner) Run(context.Context, StepRequest) (StepResult, error) {
+	return StepResult{}, fmt.Errorf("commit changes: %w", ErrGitIdentityMissing)
 }
 
 func TestRunnerCrashCannotAbandonOrCrashControlPlane(t *testing.T) {
@@ -69,5 +76,60 @@ func TestRunnerCrashCannotAbandonOrCrashControlPlane(t *testing.T) {
 	item, err = store.WorkItem(t.Context(), "wi_crash")
 	if err != nil || item.State != "active" || item.PauseReason != "" {
 		t.Fatalf("recoverable item after resume: item=%+v err=%v", item, err)
+	}
+}
+
+func TestMissingGitIdentityParksWithoutTransientRetry(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte("name: build\nstart: impl\nnodes:\n  - id: impl\n    block: author.proposal\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "build.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal("wi_identity", []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateWorkItem(t.Context(), db1.CreateWorkItem{
+		ID: "wi_identity", Repo: "repo", ProposalPath: "proposal", WorkflowName: "build",
+		WorkflowVersion: def.Version, StartStage: "impl", Mode: "autonomous",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	engine, err := New(store, artifacts, workflowDir, missingGitIdentityRunner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := engine.Advance(t.Context(), "wi_identity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Parked || result.PauseReason != "git_identity_missing" {
+		t.Fatalf("result = %+v, want persistent git_identity_missing park", result)
+	}
+	item, err := store.WorkItem(t.Context(), "wi_identity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.State != "active" || item.PauseReason != "git_identity_missing" {
+		t.Fatalf("item = %+v, want active/git_identity_missing", item)
+	}
+	if resumed, err := store.ResumeTransient(t.Context(), "runner_unavailable", 0); err != nil || resumed != 0 {
+		t.Fatalf("runner retry resumed persistent identity park: count=%d err=%v", resumed, err)
 	}
 }

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -266,7 +266,12 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		}
 		reason := "runner_unavailable"
 		capacity := isCapacityBackpressure(err)
-		if capacity {
+		if errors.Is(err, ErrGitIdentityMissing) {
+			// This cannot heal on the scheduler's five-second runner backoff. Park
+			// until an operator seals the documented install-time identity and
+			// explicitly resumes the run.
+			reason = "git_identity_missing"
+		} else if capacity {
 			// The provider refused the dispatch outright; no delegate ran. Park
 			// on a distinct transient reason so this waits out the throttle on a
 			// longer backoff instead of burning the runner-failure bound.

--- a/server-go/internal/engine/forge.go
+++ b/server-go/internal/engine/forge.go
@@ -22,6 +22,19 @@ type PullRequest struct {
 	Head string
 }
 
+type GitIdentity struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// GitIdentityProvider is the narrow resource-plane seam used by workflow
+// commits. Author identity is sealed in the C server's Vault and deliberately
+// absent from the long-lived Go process environment, so production resolves it
+// just in time over the local root-owned Unix socket.
+type GitIdentityProvider interface {
+	Identity(context.Context, string) (GitIdentity, error)
+}
+
 // PullRequestSpec is the review contract the workflow hands to the forge. A
 // root workflow always sets Draft: automation may assemble and publish the
 // handoff, but making it reviewable and merging it are human actions. Slice PRs
@@ -70,6 +83,21 @@ func (f *HTTPForge) Push(ctx context.Context, repo, workdir, head string) error 
 	}
 	var ignored map[string]any
 	return f.execute(ctx, map[string]any{"op": "push", "workdir": workdir, "head": head}, &ignored)
+}
+
+func (f *HTTPForge) Identity(ctx context.Context, workdir string) (GitIdentity, error) {
+	var result struct {
+		Configured bool   `json:"configured"`
+		Name       string `json:"name"`
+		Email      string `json:"email"`
+	}
+	if err := f.execute(ctx, map[string]any{"op": "identity", "workdir": workdir}, &result); err != nil {
+		return GitIdentity{}, err
+	}
+	if !result.Configured || strings.TrimSpace(result.Name) == "" || strings.TrimSpace(result.Email) == "" {
+		return GitIdentity{}, ErrGitIdentityMissing
+	}
+	return GitIdentity{Name: result.Name, Email: result.Email}, nil
 }
 func (unavailableForge) CI(context.Context, string, string) (CIState, error) {
 	return CIPending, errors.New("forge resource plane is unavailable")

--- a/server-go/internal/engine/forge_test.go
+++ b/server-go/internal/engine/forge_test.go
@@ -49,6 +49,59 @@ func TestHTTPForgeExecuteUsesUnixResourcePlane(t *testing.T) {
 	}
 }
 
+func TestHTTPForgeIdentityUsesSealedResourcePlaneResult(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "forge.sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request["op"] != "identity" || request["workdir"] != "/managed/worktree" {
+			t.Fatalf("unexpected identity request: %#v", request)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"configured":true,"name":"Operator","email":"operator@example.test"}`))
+	})}
+	go server.Serve(listener)
+	defer server.Close()
+	forge, err := NewHTTPForge(HTTPForgeConfig{UnixSocket: socket})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := forge.Identity(t.Context(), "/managed/worktree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Name != "Operator" || identity.Email != "operator@example.test" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+func TestHTTPForgeIdentityReportsMissingPair(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "forge.sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"configured":false}`))
+	})}
+	go server.Serve(listener)
+	defer server.Close()
+	forge, err := NewHTTPForge(HTTPForgeConfig{UnixSocket: socket})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := forge.Identity(t.Context(), "/managed/worktree"); !errors.Is(err, ErrGitIdentityMissing) {
+		t.Fatalf("identity error = %v, want ErrGitIdentityMissing", err)
+	}
+}
+
 func TestHTTPForgePushRejectsUnmanagedBranchAndMismatchedOrigin(t *testing.T) {
 	forge := &HTTPForge{}
 	if err := forge.Push(t.Context(), t.TempDir(), t.TempDir(), "main"); err == nil ||

--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -81,6 +81,28 @@ func TestIntegrateFeatureBasePicksUpSiblingMerge(t *testing.T) {
 	}
 }
 
+func TestNativeRunnerIntegrateFeatureBaseUsesResourcePlaneIdentity(t *testing.T) {
+	t.Setenv("AIMEE_GIT_AUTHOR_NAME", "")
+	t.Setenv("AIMEE_GIT_AUTHOR_EMAIL", "")
+	repo, slicedir := setupSliceRepo(t)
+	if err := os.WriteFile(filepath.Join(slicedir, "slice.txt"), []byte("slice\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, slicedir, "add", "slice.txt")
+	gitRun(t, slicedir, "commit", "-m", "slice change")
+	advanceFeature(t, repo, "sibling.txt", "sibling\n")
+
+	runner := &NativeRunner{forge: fixedIdentityForge{}}
+	park, err := runner.integrateFeatureBase(t.Context(), slicedir, "wi_parent")
+	if err != nil || park != "" {
+		t.Fatalf("integrateFeatureBase: park=%q err=%v", park, err)
+	}
+	author := gitRun(t, slicedir, "show", "-s", "--format=%an <%ae>")
+	if strings.TrimSpace(author) != "Vault Operator <vault@example.test>" {
+		t.Fatalf("merge author = %q", author)
+	}
+}
+
 // A slice freeze must review only that slice's delta over the latest feature
 // tip. Forge merges advance origin/aimee/feat/<parent>, not the stale local ref;
 // using the local ref makes later slice artifacts include every landed sibling

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -30,6 +30,12 @@ type CommandVerifier struct {
 
 const defaultCommandVerifyLock = "aimee-wfe-command-verify.lock"
 
+// ErrGitIdentityMissing is a permanent deployment prerequisite, not a transient
+// runner outage. The engine gives it a non-auto-resumed park reason so a missing
+// install-time identity cannot launch a new implementation delegate every five
+// seconds while no commit can succeed.
+var ErrGitIdentityMissing = errors.New("git identity is not configured")
+
 // gitIdentityArgs returns the `-c user.name=... -c user.email=...` the WFE commits
 // under, read from the identity aimee was installed with.
 //
@@ -746,7 +752,8 @@ func commitChanges(ctx context.Context, workdir, stage string) error {
 	}
 	ident := gitIdentityArgs()
 	if len(ident) == 0 {
-		return fmt.Errorf("no git identity configured: seal AIMEE_GIT_AUTHOR_NAME and AIMEE_GIT_AUTHOR_EMAIL at install")
+		return fmt.Errorf("%w: seal AIMEE_GIT_AUTHOR_NAME and AIMEE_GIT_AUTHOR_EMAIL at install",
+			ErrGitIdentityMissing)
 	}
 	_, err := gitText(ctx, workdir, append(ident, "commit", "-m", "wfe: "+stage)...)
 	return err

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -36,8 +36,10 @@ const defaultCommandVerifyLock = "aimee-wfe-command-verify.lock"
 // seconds while no commit can succeed.
 var ErrGitIdentityMissing = errors.New("git identity is not configured")
 
-// gitIdentityArgs returns the `-c user.name=... -c user.email=...` the WFE commits
-// under, read from the identity aimee was installed with.
+// gitIdentityArgs returns an explicit environment-provided identity for local
+// development and tests. Production deliberately scrubs these values from the
+// long-lived Go process and resolves the sealed install identity just in time
+// through GitIdentityProvider instead.
 //
 // aimee has no ambient identity to fall back on: the server's git paths point
 // GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM at /dev/null, so a commit carries the
@@ -362,7 +364,7 @@ func (r *NativeRunner) custom(ctx context.Context, req StepRequest, block wfe.Bl
 			if err := r.ensureRunnable(ctx, req.WorkItem.ID); err != nil {
 				return StepResult{}, err
 			}
-			if err := commitChanges(ctx, workdir, req.Node.ID); err != nil {
+			if err := r.commitChanges(ctx, workdir, req.Node.ID); err != nil {
 				return StepResult{}, err
 			}
 			head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
@@ -381,7 +383,7 @@ func (r *NativeRunner) custom(ctx context.Context, req StepRequest, block wfe.Bl
 		if err := r.ensureRunnable(ctx, req.WorkItem.ID); err != nil {
 			return StepResult{}, err
 		}
-		if err := commitChanges(ctx, workdir, req.Node.ID); err != nil {
+		if err := r.commitChanges(ctx, workdir, req.Node.ID); err != nil {
 			return StepResult{}, err
 		}
 		head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
@@ -544,7 +546,7 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	// pre-step below), so this attempt sees siblings that have merged since. Not done
 	// at freeze/pr/ci/merge — those must observe a stable diff.
 	if req.WorkItem.ParentID != "" {
-		parkReason, integErr := integrateFeatureBase(ctx, workdir, req.WorkItem.ParentID)
+		parkReason, integErr := r.integrateFeatureBase(ctx, workdir, req.WorkItem.ParentID)
 		if integErr != nil {
 			return StepResult{}, integErr
 		}
@@ -609,7 +611,7 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		if err := r.ensureRunnable(ctx, req.WorkItem.ID); err != nil {
 			return StepResult{}, err
 		}
-		if err := commitChanges(ctx, workdir, req.Node.ID+" tests"); err != nil {
+		if err := r.commitChanges(ctx, workdir, req.Node.ID+" tests"); err != nil {
 			return StepResult{}, err
 		}
 		prompt += "\n\nTDD: failing tests have already been authored in the worktree. Make them pass without weakening or deleting their assertions."
@@ -627,7 +629,7 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	if err := r.ensureRunnable(ctx, req.WorkItem.ID); err != nil {
 		return StepResult{}, err
 	}
-	if err := commitChanges(ctx, workdir, req.Node.ID); err != nil {
+	if err := r.commitChanges(ctx, workdir, req.Node.ID); err != nil {
 		return StepResult{}, err
 	}
 	// A delegate that reported partial AND left no commit did not implement the
@@ -737,7 +739,35 @@ func (r *NativeRunner) checkMergeable(ctx context.Context, req StepRequest) (Ste
 	return StepResult{}, errors.New("configured forge does not support mergeability checks")
 }
 
+func (r *NativeRunner) commitChanges(ctx context.Context, workdir, stage string) error {
+	return commitChangesWithIdentity(ctx, workdir, stage, func() ([]string, error) {
+		return r.resolveGitIdentity(ctx, workdir)
+	})
+}
+
+func (r *NativeRunner) resolveGitIdentity(ctx context.Context, workdir string) ([]string, error) {
+	if ident := gitIdentityArgs(); len(ident) > 0 {
+		return ident, nil
+	}
+	provider, ok := r.forge.(GitIdentityProvider)
+	if !ok {
+		return nil, ErrGitIdentityMissing
+	}
+	identity, err := provider.Identity(ctx, workdir)
+	if err != nil {
+		return nil, err
+	}
+	return []string{"-c", "user.name=" + identity.Name, "-c", "user.email=" + identity.Email}, nil
+}
+
 func commitChanges(ctx context.Context, workdir, stage string) error {
+	return commitChangesWithIdentity(ctx, workdir, stage, func() ([]string, error) {
+		return gitIdentityArgs(), nil
+	})
+}
+
+func commitChangesWithIdentity(ctx context.Context, workdir, stage string,
+	identity func() ([]string, error)) error {
 	if _, err := gitText(ctx, workdir, "add", "-A"); err != nil {
 		return err
 	}
@@ -750,12 +780,15 @@ func commitChanges(ctx context.Context, workdir, stage string) error {
 	} else if exit, ok := err.(*exec.ExitError); !ok || exit.ExitCode() != 1 {
 		return err
 	}
-	ident := gitIdentityArgs()
+	ident, err := identity()
+	if err != nil {
+		return fmt.Errorf("resolve git identity: %w", err)
+	}
 	if len(ident) == 0 {
 		return fmt.Errorf("%w: seal AIMEE_GIT_AUTHOR_NAME and AIMEE_GIT_AUTHOR_EMAIL at install",
 			ErrGitIdentityMissing)
 	}
-	_, err := gitText(ctx, workdir, append(ident, "commit", "-m", "wfe: "+stage)...)
+	_, err = gitText(ctx, workdir, append(ident, "commit", "-m", "wfe: "+stage)...)
 	return err
 }
 
@@ -883,6 +916,19 @@ func featureBaseRef(ctx context.Context, workdir, parentID string) string {
 }
 
 func integrateFeatureBase(ctx context.Context, workdir, parentID string) (string, error) {
+	return integrateFeatureBaseWithIdentity(ctx, workdir, parentID, func() ([]string, error) {
+		return gitIdentityArgs(), nil
+	})
+}
+
+func (r *NativeRunner) integrateFeatureBase(ctx context.Context, workdir, parentID string) (string, error) {
+	return integrateFeatureBaseWithIdentity(ctx, workdir, parentID, func() ([]string, error) {
+		return r.resolveGitIdentity(ctx, workdir)
+	})
+}
+
+func integrateFeatureBaseWithIdentity(ctx context.Context, workdir, parentID string,
+	identity func() ([]string, error)) (string, error) {
 	base := featureBaseRef(ctx, workdir, parentID)
 	// The feature branch may not exist yet (first generation, before any slice has
 	// merged into it) — nothing to integrate.
@@ -893,7 +939,18 @@ func integrateFeatureBase(ctx context.Context, workdir, parentID string) (string
 	if _, err := gitText(ctx, workdir, "merge-base", "--is-ancestor", base, "HEAD"); err == nil {
 		return "", nil
 	}
-	if _, err := gitText(ctx, workdir, append(gitIdentityArgs(), "merge", "--no-edit", base)...); err == nil {
+	// A fast-forward creates no commit and therefore needs no identity.
+	if _, err := gitText(ctx, workdir, "merge", "--ff-only", base); err == nil {
+		return "", nil
+	}
+	ident, err := identity()
+	if err != nil {
+		return "", fmt.Errorf("resolve git identity: %w", err)
+	}
+	if len(ident) == 0 {
+		return "", ErrGitIdentityMissing
+	}
+	if _, err := gitText(ctx, workdir, append(ident, "merge", "--no-edit", base)...); err == nil {
 		return "", nil
 	}
 	// Merge failed (conflict or otherwise): restore a clean worktree before parking.
@@ -1664,7 +1721,7 @@ func (r *NativeRunner) prOpen(ctx context.Context, req StepRequest) (StepResult,
 	default:
 		base = baseKind
 	}
-	baseConflict, detail, err := refreshPullRequestBase(ctx, workdir, base)
+	baseConflict, detail, err := r.refreshPullRequestBase(ctx, workdir, base)
 	if err != nil {
 		return StepResult{}, err
 	}
@@ -1696,6 +1753,19 @@ func (r *NativeRunner) prOpen(ctx context.Context, req StepRequest) (StepResult,
 // conflicts. Fetch the exact target ref, integrate it into the managed head,
 // and only then compute and publish the handoff.
 func refreshPullRequestBase(ctx context.Context, workdir, base string) (bool, string, error) {
+	return refreshPullRequestBaseWithIdentity(ctx, workdir, base, func() ([]string, error) {
+		return gitIdentityArgs(), nil
+	})
+}
+
+func (r *NativeRunner) refreshPullRequestBase(ctx context.Context, workdir, base string) (bool, string, error) {
+	return refreshPullRequestBaseWithIdentity(ctx, workdir, base, func() ([]string, error) {
+		return r.resolveGitIdentity(ctx, workdir)
+	})
+}
+
+func refreshPullRequestBaseWithIdentity(ctx context.Context, workdir, base string,
+	identity func() ([]string, error)) (bool, string, error) {
 	if base == "" || strings.HasPrefix(base, "-") {
 		return false, "", fmt.Errorf("invalid pull request base %q", base)
 	}
@@ -1714,7 +1784,18 @@ func refreshPullRequestBase(ctx context.Context, workdir, base string) (bool, st
 	if _, err := gitText(ctx, workdir, "fetch", "--no-tags", "origin", refspec); err != nil {
 		return false, "", fmt.Errorf("refresh pull request base: %w", err)
 	}
-	if _, err := gitText(ctx, workdir, append(gitIdentityArgs(), "merge", "--no-edit", baseRef)...); err != nil {
+	// A fast-forward creates no commit and therefore needs no identity.
+	if _, err := gitText(ctx, workdir, "merge", "--ff-only", baseRef); err == nil {
+		return false, "", nil
+	}
+	ident, err := identity()
+	if err != nil {
+		return false, "", fmt.Errorf("resolve git identity: %w", err)
+	}
+	if len(ident) == 0 {
+		return false, "", ErrGitIdentityMissing
+	}
+	if _, err := gitText(ctx, workdir, append(ident, "merge", "--no-edit", baseRef)...); err != nil {
 		lower := strings.ToLower(err.Error())
 		if strings.Contains(lower, "conflict") || strings.Contains(lower, "automatic merge failed") {
 			_, _ = gitText(ctx, workdir, "merge", "--abort")
@@ -1811,7 +1892,7 @@ func (r *NativeRunner) archive(ctx context.Context, req StepRequest) (StepResult
 	if _, err := gitText(ctx, workdir, "mv", "-f", cleanSource, destination); err != nil {
 		return StepResult{}, err
 	}
-	if err := commitChanges(ctx, workdir, "archive proposal"); err != nil {
+	if err := r.commitChanges(ctx, workdir, "archive proposal"); err != nil {
 		return StepResult{}, err
 	}
 	head, err := gitText(ctx, workdir, "rev-parse", "HEAD")

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -2223,6 +2223,23 @@ func TestCommitChangesDropsCoreDumpAndRejectsGiantBlob(t *testing.T) {
 	}
 }
 
+func TestCommitChangesReturnsTypedMissingIdentity(t *testing.T) {
+	t.Setenv("AIMEE_GIT_AUTHOR_NAME", "")
+	t.Setenv("AIMEE_GIT_AUTHOR_EMAIL", "")
+	repo := t.TempDir()
+	cmd := exec.Command("git", "init", "-b", "testing", repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "change.md"), []byte("change\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := commitChanges(context.Background(), repo, "impl")
+	if !errors.Is(err, ErrGitIdentityMissing) {
+		t.Fatalf("commit error = %v, want ErrGitIdentityMissing", err)
+	}
+}
+
 // The intended slice cycle is: cut a branch from the feature tip, do the work,
 // merge back into the feature branch, and let the NEXT slice start from the
 // updated tip. That merge happens through the FORGE, which advances the remote

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -2240,6 +2240,37 @@ func TestCommitChangesReturnsTypedMissingIdentity(t *testing.T) {
 	}
 }
 
+type fixedIdentityForge struct{ unavailableForge }
+
+func (fixedIdentityForge) Identity(context.Context, string) (GitIdentity, error) {
+	return GitIdentity{Name: "Vault Operator", Email: "vault@example.test"}, nil
+}
+
+func TestNativeRunnerCommitUsesResourcePlaneIdentity(t *testing.T) {
+	t.Setenv("AIMEE_GIT_AUTHOR_NAME", "")
+	t.Setenv("AIMEE_GIT_AUTHOR_EMAIL", "")
+	repo := t.TempDir()
+	cmd := exec.Command("git", "init", "-b", "testing", repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "change.md"), []byte("change\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{forge: fixedIdentityForge{}}
+	if err := runner.commitChanges(t.Context(), repo, "impl"); err != nil {
+		t.Fatal(err)
+	}
+	show := exec.Command("git", "-C", repo, "show", "-s", "--format=%an <%ae>")
+	out, err := show.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git show: %v: %s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "Vault Operator <vault@example.test>" {
+		t.Fatalf("commit author = %q", out)
+	}
+}
+
 // The intended slice cycle is: cut a branch from the feature tip, do the work,
 // merge back into the feature branch, and let the NEXT slice start from the
 // updated tip. That merge happens through the FORGE, which advances the remote

--- a/src/server/server_http_routes_git.c
+++ b/src/server/server_http_routes_git.c
@@ -634,6 +634,8 @@ static int wfe_forge_operation_valid(const char *op, const char *head, const cha
       return 0;
    if (strcmp(op, "push") == 0)
       return head && !base && !title && !body && !has_draft && !has_number;
+   if (strcmp(op, "identity") == 0)
+      return !head && !base && !title && !body && !has_draft && !has_number;
    if (strcmp(op, "open") == 0)
    {
       int final_head = head && strncmp(head, "aimee/feat/wi_", 14) == 0;
@@ -699,7 +701,24 @@ int rh_internal_forge_execute(const route_req_t *rq, char *resp, int cap)
    int slice_head = head && strncmp(head, "aimee/wi/wi_", 12) == 0;
    int allowed_push_head =
        feature_head || (slice_head && wfe_slice_ref_matches_workdir(workdir, "aimee/wi/", 0, head));
-   if (strcmp(op, "push") == 0 && head && allowed_push_head)
+   if (strcmp(op, "identity") == 0)
+   {
+      char name[256], email[256];
+      int identity_rc = git_identity_resolve(workdir, name, sizeof(name), email, sizeof(email));
+      if (identity_rc < 0)
+         snprintf(err, sizeof(err), "cannot read configured git identity");
+      else
+      {
+         rc = 0;
+         cJSON_AddBoolToObject(out, "configured", identity_rc == 1);
+         if (identity_rc == 1)
+         {
+            cJSON_AddStringToObject(out, "name", name);
+            cJSON_AddStringToObject(out, "email", email);
+         }
+      }
+   }
+   else if (strcmp(op, "push") == 0 && head && allowed_push_head)
    {
       rc = git_ops_push_dir(principal, workdir, remote, head, &detail, err, sizeof(err));
    }


### PR DESCRIPTION
## What changed

- classify a missing Git author identity as the persistent `git_identity_missing` prerequisite instead of a transient runner outage
- resolve the sealed install identity just in time through the existing local, capability-gated resource plane without restoring credentials to the long-lived Go process environment
- apply that identity consistently to workflow commits, non-fast-forward slice integration, final PR-base refresh, and proposal archival
- keep fast-forward-only integrations identity-free
- document the operator recovery action and add regression coverage for durable parking, resource-plane lookup, commit authorship, and merge authorship

## Why

During a fresh live `:testing` workflow run, delegation completed and changed the worktree, but the engine could not commit it. The deployment had a valid identity sealed in Vault; the C entrypoint correctly removed it from the long-lived environment, while the Go workflow engine only knew how to read that environment. It then misclassified the permanent prerequisite as a transient runner outage and repeatedly delegated the same implementation every five seconds.

This keeps the identity sealed and exposes only the author metadata over the already-local, root-owned Unix resource plane for an authenticated managed worktree.

## Validation

- `go test ./...` in `server-go`
- `make -j2 server` in `src`
- `make lint` in `src` (all 45 checks passed)
- `python3 scripts/check-docs.py`
- `git diff --check`

Found during live `:testing` validation on work item `wi_73a4eed8b283157e7acb3d6031c16129`. The run is paused at its original commit boundary so it can be resumed against the rebuilt image after this PR lands.
