### PR TITLE
Document self-update limitations for non-semver builds in upgrade section

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -366,6 +366,12 @@ On a remote thin client, `aimee self-update --check` compares the client with it
 binary replacement is supported, `aimee self-update` downloads the matching release, verifies it,
 and swaps the executable without downgrading.
 
+Note: `aimee self-update --check` reports client and server build identifiers, but it cannot
+order or auto-install non-semver branch builds. `aimee self-update --version vX.Y.Z` installs a
+published semantic-version release and does not downgrade. Operators validating `:testing` on the
+`testing` channel must install or build the matching testing thin client separately when exercising
+client-local catalog behavior.
+
 Read [What's new](docs/WHATS_NEW.md) before changing deployment manifests.
 
 ## Troubleshooting


### PR DESCRIPTION
## Slice outcome

Document self-update limitations for non-semver builds in upgrade section

## What changed

- The existing thin-client self-update/upgrade section contains a concise note covering, in order: (1) `aimee self-update --check` reports client and server build identifiers but cannot order or auto-install non-semver branch builds; (2) `aimee self-update --version vX.Y.Z` installs a published semantic-version release and does not downgrade; (3) operators validating `:testing` must install or build the matching testing thin client separately when exercising client-local catalog behavior.
- The note is placed under the existing self-update/upgrade heading (no new section created) and references the `testing` channel by its existing name as used elsewhere in the repo.
- Wording matches the CLI's current behavior exactly; no promises of future capability; no expansion into a tutorial.
- No runtime code, generated files, release policy, or unrelated documentation are changed.
- Repository documentation checks (e.g., doc lint/build) pass after the change.

### Files in this PR

- Updated `MANUAL.md`.

<details>
<summary>Diffstat</summary>

```text
MANUAL.md | 6 ++++++
 1 file changed, 6 insertions(+)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_73a4eed8b283157e7acb3d6031c16129.s3be8be11dc.g0.0`
- Branches: `aimee/wi/wi_73a4eed8b283157e7acb3d6031c16129.s3be8be11dc.g0.0` → `aimee/feat/wi_73a4eed8b283157e7acb3d6031c16129`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p1","summary":"Document self-update limitations for non-semver builds in upgrade section","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["The existing thin-client self-update/upgrade section contains a concise note covering, in order: (1) `aimee self-update --check` reports client and server build identifiers but cannot order or auto-install non-semver branch builds; (2) `aimee self-update --version vX.Y.Z` installs a published semantic-version release and does not downgrade; (3) operators validating `:testing` must install or build the matching testing thin client separately when exercising client-local catalog behavior.","The note is placed under the existing self-update/upgrade heading (no new section created) and references the `testing` channel by its existing name as used elsewhere in the repo.","Wording matches the CLI's current behavior exactly; no promises of future capability; no expansion into a tutorial.","No runtime code, generated files, release policy, or unrelated documentation are changed.","Repository documentation checks (e.g., doc lint/build) pass after the change."]}

</details>