### PR TITLE
Scope workflow documentation delegates

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -533,6 +533,23 @@ func (r *NativeRunner) branchOpen(ctx context.Context, req StepRequest) (StepRes
 	return StepResult{Status: StepAdvanced, ArtifactType: "branch", Artifact: branch, ContentHash: wfe.Hash([]byte(branch))}, nil
 }
 
+// documentDelegatePrompt anchors documentation work to the same immutable
+// request and exact branch diff that the acceptance gate reviewed. A branch
+// name alone invites the delegate to mine unrelated history for undocumented
+// changes and expand the final PR after acceptance.
+func documentDelegatePrompt(ctx context.Context, req StepRequest, workdir string) (string, error) {
+	acceptedDiff, err := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
+	if err != nil {
+		return "", err
+	}
+	return "Document only the accepted implementation of the original request below. " +
+		"Do not infer work from unrelated repository history or document pre-existing changes. " +
+		"Update appropriate user or developer documentation and inline comments only when the " +
+		"accepted implementation needs it; if its documentation is already complete, leave the " +
+		"worktree unchanged.\n\nORIGINAL REQUEST:\n" + req.Proposal +
+		"\n\nACCEPTED IMPLEMENTATION DIFF:\n" + acceptedDiff, nil
+}
+
 func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (StepResult, error) {
 	workdir, branch, err := r.worktrees.Ensure(ctx, req.WorkItem, req.WorkItem.ParentID == "")
 	if err != nil {
@@ -583,7 +600,10 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	}
 	prompt := "Implement the complete approved task in this worktree, run the repository verification, fix failures, and leave the accepted changes in the worktree."
 	if docs {
-		prompt = "Document the complete implemented change in this worktree. Update the appropriate user and developer documentation and inline comments; leave the accepted changes in the worktree."
+		prompt, err = documentDelegatePrompt(ctx, req, workdir)
+		if err != nil {
+			return StepResult{}, err
+		}
 	}
 	if task := paramString(req.Node, "task", ""); task != "" {
 		prompt += "\n\nWORKFLOW STEP INSTRUCTIONS:\n" + task

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -62,6 +62,48 @@ func TestDefaultVerifyCommandUsesGitVerifyKeyValueSyntax(t *testing.T) {
 	}
 }
 
+func TestDocumentPromptIsScopedToOriginalRequestAndAcceptedDiff(t *testing.T) {
+	repo := t.TempDir()
+	gitRun(t, repo, "init", "-b", "trunk")
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("unrelated pre-existing subsystem\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "README")
+	gitRun(t, repo, "commit", "-m", "initial")
+	gitRun(t, repo, "remote", "add", "origin", repo)
+	gitRun(t, repo, "update-ref", "refs/remotes/origin/trunk", "HEAD")
+	gitRun(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+
+	if err := os.WriteFile(filepath.Join(repo, "accepted.md"), []byte("accepted change\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "accepted.md")
+	gitRun(t, repo, "commit", "-m", "accepted implementation")
+
+	request := StepRequest{
+		WorkItem: db1.WorkItem{Repo: repo},
+		Proposal: "Document only the self-update limitation.",
+	}
+	prompt, err := documentDelegatePrompt(t.Context(), request, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, required := range []string{
+		"ORIGINAL REQUEST:\nDocument only the self-update limitation.",
+		"ACCEPTED IMPLEMENTATION DIFF:",
+		"+accepted change",
+		"Do not infer work from unrelated repository history",
+	} {
+		if !strings.Contains(prompt, required) {
+			t.Fatalf("document prompt missing %q:\n%s", required, prompt)
+		}
+	}
+	if strings.Contains(prompt, "unrelated pre-existing subsystem") {
+		t.Fatalf("document prompt included pre-existing base content:\n%s", prompt)
+	}
+}
+
 func TestCommandVerifierSerializesAcrossInstances(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "verify.lock")
 	first := CommandVerifier{LockFile: lockPath}


### PR DESCRIPTION
## What changed

- Scope the final documentation delegate to the immutable original request.
- Include the exact accepted implementation diff in its prompt.
- Explicitly prohibit inferring documentation work from unrelated repository history.
- Add regression coverage proving pre-existing base content is excluded while the accepted diff is included.

## Why

During a live `build` workflow, the accepted artifact was a narrow self-update documentation note. The later documentation delegate received only the feature-branch name, mined unrelated history, and added five MCP-profile documentation changes after the acceptance gate. The documentation roundtable correctly rejected the drift, but recovery required multiple review/delegate cycles and 95+ unnecessary model turns.

This change anchors the documentation stage to the same request and branch diff the acceptance gate reviewed, preventing post-acceptance scope expansion while preserving the existing no-op path when documentation is already complete.

## Validation

- `go test ./internal/engine -count=1`
- `go test ./... -count=1`
- `git diff --check`
- `aimee git verify format=json` was unavailable in this standalone worktree because it has no verify configuration (`no-verify-config`).
