### PR TITLE
WFE: fit delegate budget within stage deadline

### DIFF
--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -38,6 +38,11 @@ type DelegateRequest struct {
 	// MaxTurnsCap bounds a delegate without overriding a smaller role/agent cap.
 	// It is forwarded to the resource plane as max_turns_cap.
 	MaxTurnsCap int
+	// ToolLoopTimeoutMSCap bounds the delegate's whole multi-turn tool loop
+	// without increasing a smaller configured agent budget. Workflow runners set
+	// it from the enclosing stage deadline so the resource plane can return a
+	// partial result before a hard context cancellation.
+	ToolLoopTimeoutMSCap int
 	// ReplayOnly forbids launching a replacement job when a lifecycle retry is
 	// consuming an already-billed durable result.
 	ReplayOnly bool
@@ -299,6 +304,9 @@ func (c *HTTPAgentClient) delegateOnce(ctx context.Context, request DelegateRequ
 	}
 	if request.MaxTurnsCap > 0 {
 		payload["max_turns_cap"] = request.MaxTurnsCap
+	}
+	if request.ToolLoopTimeoutMSCap > 0 {
+		payload["tool_loop_timeout_ms_cap"] = request.ToolLoopTimeoutMSCap
 	}
 	if request.ProvidedTarget {
 		payload["provided_target"] = true

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -214,7 +214,7 @@ func TestHTTPAgentClientOmitsProvidedTargetByDefault(t *testing.T) {
 	}
 }
 
-func TestHTTPAgentClientForwardsMaxTurnsCap(t *testing.T) {
+func TestHTTPAgentClientForwardsResourceCaps(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/delegate/run":
@@ -223,8 +223,14 @@ func TestHTTPAgentClientForwardsMaxTurnsCap(t *testing.T) {
 			if got := payload["max_turns_cap"]; got != float64(24) {
 				t.Errorf("max_turns_cap=%v payload=%v", got, payload)
 			}
+			if got := payload["tool_loop_timeout_ms_cap"]; got != float64(420000) {
+				t.Errorf("tool_loop_timeout_ms_cap=%v payload=%v", got, payload)
+			}
 			if _, leaked := payload["MaxTurnsCap"]; leaked {
 				t.Errorf("Go-local field name leaked in payload: %v", payload)
+			}
+			if _, leaked := payload["ToolLoopTimeoutMSCap"]; leaked {
+				t.Errorf("Go-local timeout field name leaked in payload: %v", payload)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 1})
 		case "/v1/delegate/status":
@@ -238,7 +244,7 @@ func TestHTTPAgentClientForwardsMaxTurnsCap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.Delegate(t.Context(), DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review artifact", MaxTurnsCap: 24}); err != nil {
+	if _, err := client.Delegate(t.Context(), DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review artifact", MaxTurnsCap: 24, ToolLoopTimeoutMSCap: 420000}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1138,6 +1138,41 @@ func chairmanDeadline(step context.Context, deadlineMS int) (context.Context, co
 	return context.WithTimeout(step, time.Duration(deadlineMS)*time.Millisecond)
 }
 
+// ensureRoundtableDeadlineFits avoids spending an expiring workflow window on
+// a panel that cannot possibly reach its last configured phase. Analysis and
+// discussion share one panel deadline; an enabled chairman receives a second.
+// Returning DeadlineExceeded before dispatch lets the scheduler reopen the
+// workflow with a fresh wall window instead of cancelling a billed chairman
+// and rerunning the whole panel.
+func ensureRoundtableDeadlineFits(ctx context.Context, panel roundtablecfg.Panel) error {
+	deadline, ok := ctx.Deadline()
+	if !ok || panel.DeadlineMS <= 0 {
+		return nil
+	}
+	phases := int64(1)
+	if panel.ChairmanEnabled {
+		phases++
+	}
+	maxDuration := time.Duration(1<<63 - 1)
+	maxDeadlineMS := int64(maxDuration/time.Millisecond) / phases
+	if int64(panel.DeadlineMS) > maxDeadlineMS {
+		return fmt.Errorf("roundtable deadline budget overflows duration: deadline_ms=%d phases=%d: %w",
+			panel.DeadlineMS, phases, context.DeadlineExceeded)
+	}
+	required := time.Duration(int64(panel.DeadlineMS)*phases) * time.Millisecond
+	reserve := required / 20
+	if reserve > delegateDeadlineGraceReserve {
+		reserve = delegateDeadlineGraceReserve
+	}
+	required += reserve
+	remaining := time.Until(deadline)
+	if remaining <= required {
+		return fmt.Errorf("roundtable phases do not fit workflow wall budget: remaining=%s required=%s phases=%d: %w",
+			remaining.Round(time.Millisecond), required, phases, context.DeadlineExceeded)
+	}
+	return nil
+}
+
 type panelAnalysis struct {
 	Feedback    wfe.ReviewFeedback
 	Approvals   int
@@ -1179,6 +1214,9 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 	panel, err := r.roundtables.Resolve(paramString(req.Node, "roundtable", ""), lensNames, panelPins(req.Node))
 	if err != nil {
 		return StepResult{Status: StepPending, PauseReason: "panel_unreachable", Detail: err.Error()}, nil
+	}
+	if err := ensureRoundtableDeadlineFits(ctx, panel); err != nil {
+		return StepResult{}, err
 	}
 	seats := make([]panelSeat, 0, len(panel.Seats))
 	for _, seat := range panel.Seats {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -140,9 +140,14 @@ func (r *NativeRunner) SetRoundtableStore(store *roundtablecfg.Store) { r.roundt
 const (
 	roundtableDelegateRole        = "review"
 	roundtableDelegateMaxTurnsCap = 24
+	delegateDeadlineGraceReserve  = 5 * time.Second
+	delegateWriteVerifyReserve    = 5 * time.Minute
 )
 
 func (r *NativeRunner) delegate(ctx context.Context, step StepRequest, request DelegateRequest) (DelegateResult, error) {
+	if err := applyDelegateDeadlineCap(ctx, &request); err != nil {
+		return DelegateResult{}, err
+	}
 	request.WorkItemID = step.WorkItem.ID
 	request.Stage = step.Node.ID
 	request.ExecutionVersion = step.WorkItem.UpdatedAt
@@ -156,6 +161,13 @@ func (r *NativeRunner) delegateGroup(ctx context.Context, step StepRequest, requ
 		return nil
 	}
 	for i := range requests {
+		if err := applyDelegateDeadlineCap(ctx, &requests[i]); err != nil {
+			out := make([]DelegateGroupResult, len(requests))
+			for j := range out {
+				out[j].Err = err
+			}
+			return out
+		}
 		requests[i].WorkItemID = step.WorkItem.ID
 		requests[i].Stage = step.Node.ID
 		requests[i].ExecutionVersion = step.WorkItem.UpdatedAt
@@ -176,6 +188,43 @@ func (r *NativeRunner) delegateGroup(ctx context.Context, step StepRequest, requ
 		out[i].Err = errors.New("delegate service does not support grouped delegation")
 	}
 	return out
+}
+
+// applyDelegateDeadlineCap converts the enclosing stage deadline into a
+// resource-plane tool-loop cap. Write delegates leave enough time for the
+// mandatory repository verifier; read-only delegates only need cancellation
+// and lifecycle-transition slack. The cap can only reduce the agent's own
+// configured loop budget.
+func applyDelegateDeadlineCap(ctx context.Context, request *DelegateRequest) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil
+	}
+	remaining := time.Until(deadline)
+	reserve := remaining / 20
+	if reserve > delegateDeadlineGraceReserve {
+		reserve = delegateDeadlineGraceReserve
+	}
+	if request.Role == "code" && request.Tools {
+		reserve = delegateWriteVerifyReserve
+		if remaining <= reserve {
+			return fmt.Errorf("delegate stage wall budget exhausted: remaining=%s reserve=%s: %w",
+				remaining.Round(time.Millisecond), reserve, context.DeadlineExceeded)
+		}
+	}
+	capMillis := (remaining - reserve).Milliseconds()
+	maxInt := int64(^uint(0) >> 1)
+	if capMillis > maxInt {
+		capMillis = maxInt
+	}
+	if capMillis < 1 {
+		capMillis = 1
+	}
+	capValue := int(capMillis)
+	if request.ToolLoopTimeoutMSCap <= 0 || request.ToolLoopTimeoutMSCap > capValue {
+		request.ToolLoopTimeoutMSCap = capValue
+	}
+	return nil
 }
 
 func NewNativeRunner(db *db1.Store, worktrees *WorktreeManager, agents AgentClient, verifier Verifier, artifacts *wfe.ArtifactStore, workflows *wfe.Registry, forge Forge) (*NativeRunner, error) {

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -111,6 +111,30 @@ func TestDelegateDeadlineCapPreservesShortReviewPhase(t *testing.T) {
 	}
 }
 
+func TestRoundtableDeadlineRequiresEveryConfiguredPhase(t *testing.T) {
+	panel := roundtablecfg.Panel{DeadlineMS: 100, ChairmanEnabled: true}
+	short, cancelShort := context.WithTimeout(t.Context(), 150*time.Millisecond)
+	defer cancelShort()
+	err := ensureRoundtableDeadlineFits(short, panel)
+	if !errors.Is(err, context.DeadlineExceeded) ||
+		!strings.Contains(err.Error(), "required=210ms") || !strings.Contains(err.Error(), "phases=2") {
+		t.Fatalf("short roundtable budget error=%v", err)
+	}
+
+	long, cancelLong := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancelLong()
+	if err := ensureRoundtableDeadlineFits(long, panel); err != nil {
+		t.Fatalf("complete roundtable budget rejected: %v", err)
+	}
+
+	panel.ChairmanEnabled = false
+	single, cancelSingle := context.WithTimeout(t.Context(), 150*time.Millisecond)
+	defer cancelSingle()
+	if err := ensureRoundtableDeadlineFits(single, panel); err != nil {
+		t.Fatalf("single-phase roundtable budget rejected: %v", err)
+	}
+}
+
 func TestDocumentPromptIsScopedToOriginalRequestAndAcceptedDiff(t *testing.T) {
 	repo := t.TempDir()
 	gitRun(t, repo, "init", "-b", "trunk")

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -62,6 +62,55 @@ func TestDefaultVerifyCommandUsesGitVerifyKeyValueSyntax(t *testing.T) {
 	}
 }
 
+func TestDelegateDeadlineCapLeavesWriteVerificationReserve(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+	request := DelegateRequest{Role: "code", Tools: true}
+	if err := applyDelegateDeadlineCap(ctx, &request); err != nil {
+		t.Fatal(err)
+	}
+	// Ten minutes remaining minus the five-minute verifier reserve. Allow a
+	// little wall-clock drift between creating and reading the deadline.
+	if request.ToolLoopTimeoutMSCap < 298000 || request.ToolLoopTimeoutMSCap > 300000 {
+		t.Fatalf("tool loop cap=%dms, want approximately 300000ms", request.ToolLoopTimeoutMSCap)
+	}
+}
+
+func TestDelegateDeadlineCapNeverEnlargesCallerCap(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+	request := DelegateRequest{Role: "code", Tools: true, ToolLoopTimeoutMSCap: 120000}
+	if err := applyDelegateDeadlineCap(ctx, &request); err != nil {
+		t.Fatal(err)
+	}
+	if request.ToolLoopTimeoutMSCap != 120000 {
+		t.Fatalf("smaller caller cap changed to %dms", request.ToolLoopTimeoutMSCap)
+	}
+}
+
+func TestDelegateDeadlineRefusesWriteWithoutVerificationReserve(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	request := DelegateRequest{Role: "code", Tools: true}
+	err := applyDelegateDeadlineCap(ctx, &request)
+	if !errors.Is(err, context.DeadlineExceeded) ||
+		!strings.Contains(err.Error(), "remaining=") || !strings.Contains(err.Error(), "reserve=5m0s") {
+		t.Fatalf("deadline error=%v", err)
+	}
+}
+
+func TestDelegateDeadlineCapPreservesShortReviewPhase(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	request := DelegateRequest{Role: "review"}
+	if err := applyDelegateDeadlineCap(ctx, &request); err != nil {
+		t.Fatal(err)
+	}
+	if request.ToolLoopTimeoutMSCap < 80 || request.ToolLoopTimeoutMSCap > 100 {
+		t.Fatalf("short review phase cap=%dms, want most of its 100ms deadline", request.ToolLoopTimeoutMSCap)
+	}
+}
+
 func TestDocumentPromptIsScopedToOriginalRequestAndAcceptedDiff(t *testing.T) {
 	repo := t.TempDir()
 	gitRun(t, repo, "init", "-b", "trunk")

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -1,6 +1,7 @@
 #ifndef DEC_AGENT_TYPES_H
 #define DEC_AGENT_TYPES_H 1
 
+#include <limits.h>
 #include <pthread.h>
 #include <sys/types.h>
 
@@ -98,6 +99,29 @@ static inline int agent_loop_per_call_timeout_ms(int agent_timeout_ms, int total
    if (remaining < min_call)
       return -1;
    return agent_timeout_ms < remaining ? agent_timeout_ms : remaining;
+}
+
+/* Whole tool-loop budget for one delegate. The configured per-call timeout keeps
+ * its existing four-call ceiling, while a positive request cap may only reduce
+ * that budget. Workflow callers use the cap to leave time for post-delegate
+ * verification before their stage deadline. */
+static inline int agent_loop_total_timeout_ms(int agent_timeout_ms, int request_cap_ms)
+{
+   int configured =
+       agent_timeout_ms > INT_MAX / 4 ? INT_MAX : (agent_timeout_ms > 0 ? agent_timeout_ms * 4 : 0);
+   if (request_cap_ms > 0 && (configured <= 0 || request_cap_ms < configured))
+      return request_cap_ms;
+   return configured;
+}
+
+/* Apply a positive enclosing-request cap to one backend wait. Unlike the
+ * configured timeout resolver above, a cap may replace an otherwise unbounded
+ * CLI wait but can never lengthen a shorter configured timeout. */
+static inline int agent_timeout_cap_ms(int timeout_ms, int request_cap_ms)
+{
+   if (request_cap_ms > 0 && (timeout_ms <= 0 || request_cap_ms < timeout_ms))
+      return request_cap_ms;
+   return timeout_ms;
 }
 
 /* Effective per-call timeout for a delegate run. A delegate must NEVER run with
@@ -329,6 +353,9 @@ typedef struct
    int cost_tier;
    int max_tokens;
    int timeout_ms;
+   /* Per-invocation whole tool-loop cap supplied by an enclosing workflow
+    * deadline. Runtime-only: never loaded from or written to agents.json. */
+   int tool_loop_timeout_ms_cap;
    int enabled;
    int tools_enabled;
    /* Per-invocation runtime policy (never serialized): require the first

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -410,7 +410,9 @@ native_provider_http:
 
    struct timespec loop_start;
    clock_gettime(CLOCK_MONOTONIC, &loop_start);
-   int total_timeout_ms = agent->timeout_ms * 4;
+   int configured_total_timeout_ms = agent_loop_total_timeout_ms(agent->timeout_ms, 0);
+   int total_timeout_ms =
+       agent_loop_total_timeout_ms(agent->timeout_ms, agent->tool_loop_timeout_ms_cap);
 
    /* Ephemeral SSH setup */
    char ephemeral_key[MAX_PATH_LEN] = {0};
@@ -627,7 +629,14 @@ native_provider_http:
                              (now_ts.tv_nsec - loop_start.tv_nsec) / 1000000);
       if (elapsed_ms > total_timeout_ms)
       {
-         snprintf(out->error, sizeof(out->error), "total timeout exceeded (%dms)", elapsed_ms);
+         if (agent->tool_loop_timeout_ms_cap > 0)
+            snprintf(out->error, sizeof(out->error),
+                     "tool loop total timeout exceeded (elapsed=%dms effective=%dms "
+                     "configured=%dms stage_remaining_cap=%dms)",
+                     elapsed_ms, total_timeout_ms, configured_total_timeout_ms,
+                     agent->tool_loop_timeout_ms_cap);
+         else
+            snprintf(out->error, sizeof(out->error), "total timeout exceeded (%dms)", elapsed_ms);
          break;
       }
 
@@ -848,8 +857,16 @@ native_provider_http:
           agent_loop_per_call_timeout_ms(agent->timeout_ms, total_timeout_ms, elapsed_ms);
       if (per_call < 0)
       {
-         snprintf(out->error, sizeof(out->error), "tool loop budget exhausted (%dms of %dms used)",
-                  elapsed_ms, total_timeout_ms);
+         if (agent->tool_loop_timeout_ms_cap > 0)
+            snprintf(out->error, sizeof(out->error),
+                     "tool loop budget exhausted (elapsed=%dms effective=%dms configured=%dms "
+                     "stage_remaining_cap=%dms)",
+                     elapsed_ms, total_timeout_ms, configured_total_timeout_ms,
+                     agent->tool_loop_timeout_ms_cap);
+         else
+            snprintf(out->error, sizeof(out->error),
+                     "tool loop budget exhausted (%dms of %dms used)", elapsed_ms,
+                     total_timeout_ms);
          free(body);
          break;
       }

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -253,6 +253,7 @@ static int cli_session_execute_inner(const agent_t *agent, const agent_network_t
        agent->cli_idle_timeout_ms > 0
            ? agent->cli_idle_timeout_ms
            : (agent->timeout_ms > 0 ? agent->timeout_ms : AGENT_DEFAULT_TIMEOUT_MS);
+   recv_timeout_ms = agent_timeout_cap_ms(recv_timeout_ms, agent->tool_loop_timeout_ms_cap);
    int recv_rc = cli_session_recv(&sess, raw, CLI_SESSION_BUF_MAX, recv_timeout_ms);
    if (recv_rc != 0)
    {

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -1047,6 +1047,8 @@ int provider_cli_adapter_execute(const provider_cli_adapter_t *adapter, const ag
    int timeout_ms = (agent && agent->cli_idle_timeout_ms > 0)
                         ? agent->cli_idle_timeout_ms
                         : ((agent && agent->timeout_ms > 0) ? agent->timeout_ms : -1);
+   if (agent)
+      timeout_ms = agent_timeout_cap_ms(timeout_ms, agent->tool_loop_timeout_ms_cap);
    int rc = provider_cli_collect_child(adapter, stdin_fd, stdout_fd, pid, prompt, timeout_ms,
                                        &output, out);
    free(prompt);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -710,6 +710,7 @@ void delegate_worker(void *arg)
    cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(req, "cwd");
    cJSON *jbranch = cJSON_GetObjectItemCaseSensitive(req, "branch");
    cJSON *jtimeout = cJSON_GetObjectItemCaseSensitive(req, "timeout_ms");
+   cJSON *jloop_timeout_cap = cJSON_GetObjectItemCaseSensitive(req, "tool_loop_timeout_ms_cap");
    cJSON *jmaxturns = cJSON_GetObjectItemCaseSensitive(req, "max_turns");
    cJSON *jmaxturnscap = cJSON_GetObjectItemCaseSensitive(req, "max_turns_cap");
    cJSON *jhandoff = cJSON_GetObjectItemCaseSensitive(req, "handoff_json");
@@ -735,6 +736,11 @@ void delegate_worker(void *arg)
    const char *branch =
        (cJSON_IsString(jbranch) && jbranch->valuestring[0]) ? jbranch->valuestring : NULL;
    int timeout_ms = cJSON_IsNumber(jtimeout) ? (int)jtimeout->valuedouble : 0;
+   int tool_loop_timeout_ms_cap =
+       cJSON_IsNumber(jloop_timeout_cap) && jloop_timeout_cap->valuedouble > 0
+           ? (jloop_timeout_cap->valuedouble > INT_MAX ? INT_MAX
+                                                       : (int)jloop_timeout_cap->valuedouble)
+           : 0;
    int max_turns = cJSON_IsNumber(jmaxturns) ? (int)jmaxturns->valuedouble : -1;
    int max_turns_cap = cJSON_IsNumber(jmaxturnscap) && jmaxturnscap->valuedouble > 0
                            ? (int)jmaxturnscap->valuedouble
@@ -1066,8 +1072,11 @@ void delegate_worker(void *arg)
     * forever, leaking its pool thread + concurrency slot (see
     * delegate_effective_timeout_ms). Resolve request > agent-config > default. */
    if (target_agent)
+   {
       target_agent->timeout_ms =
           delegate_effective_timeout_ms(timeout_ms, target_agent->timeout_ms);
+      target_agent->tool_loop_timeout_ms_cap = tool_loop_timeout_ms_cap;
+   }
    delegate_apply_max_turns_policy(&acfg, role, max_turns);
    delegate_apply_max_turns_cap(&acfg, role, max_turns_cap);
    if (cctx->background_job_id > 0 && target_agent)

--- a/src/tests/test_agent_apikey.c
+++ b/src/tests/test_agent_apikey.c
@@ -112,6 +112,17 @@ static void test_delegate_effective_timeout(void)
    assert(delegate_effective_timeout_ms(0, 0) == AGENT_DEFAULT_TIMEOUT_MS);
    assert(delegate_effective_timeout_ms(-1, -1) == AGENT_DEFAULT_TIMEOUT_MS);
    assert(delegate_effective_timeout_ms(0, 0) > 0);
+
+   /* A workflow stage cap may only shorten the whole four-call loop. It must
+    * preserve a smaller configured budget and saturate multiplication rather
+    * than overflowing a very large per-call timeout. */
+   assert(agent_loop_total_timeout_ms(180000, 0) == 720000);
+   assert(agent_loop_total_timeout_ms(180000, 300000) == 300000);
+   assert(agent_loop_total_timeout_ms(60000, 300000) == 240000);
+   assert(agent_loop_total_timeout_ms(INT_MAX, 0) == INT_MAX);
+   assert(agent_timeout_cap_ms(900000, 600000) == 600000);
+   assert(agent_timeout_cap_ms(180000, 600000) == 180000);
+   assert(agent_timeout_cap_ms(-1, 600000) == 600000);
 }
 
 /* otel stubs: the route-health / agent-loop paths exercised below reach

--- a/src/tests/test_provider_cli_adapter.c
+++ b/src/tests/test_provider_cli_adapter.c
@@ -182,6 +182,34 @@ static void test_claude_stream_json_does_not_duplicate_final_result(void)
    unlink(path);
 }
 
+static void test_provider_cli_honors_workflow_tool_loop_cap(void)
+{
+   char path[512];
+   snprintf(path, sizeof(path), "%s/aimee-slow-claude-XXXXXX", platform_tmpdir());
+   int fd = mkstemp(path);
+   assert(fd >= 0);
+   FILE *f = fdopen(fd, "w");
+   assert(f != NULL);
+   fputs("#!/bin/sh\ncat >/dev/null\nsleep 2\n", f);
+   fclose(f);
+   chmod(path, 0700);
+
+   agent_t agent;
+   memset(&agent, 0, sizeof(agent));
+   snprintf(agent.name, sizeof(agent.name), "slow-claude");
+   snprintf(agent.backend, sizeof(agent.backend), "%s", AGENT_BACKEND_PROVIDER_CLI);
+   snprintf(agent.cli_kind, sizeof(agent.cli_kind), "claude");
+   snprintf(agent.cli_cmd, sizeof(agent.cli_cmd), "%s", path);
+   agent.timeout_ms = 5000;
+   agent.tool_loop_timeout_ms_cap = 50;
+
+   agent_result_t out;
+   assert(provider_cli_adapter_execute(provider_cli_adapter_get("claude"), &agent, ".", "sys",
+                                       "user", &out) != 0);
+   assert(strstr(out.error, "timed out after 50 ms") != NULL);
+   unlink(path);
+}
+
 static void test_mistral_native_adapter_execution(void)
 {
    const provider_cli_adapter_t *mistral = provider_cli_adapter_get("mistral-plan");
@@ -266,6 +294,7 @@ int main(void)
    test_common_json_parse_text_tool_and_error();
    test_claude_parse_stream_json();
    test_claude_stream_json_does_not_duplicate_final_result();
+   test_provider_cli_honors_workflow_tool_loop_cap();
    test_mistral_native_adapter_execution();
    test_native_auth_cmd_uses_bearer_token_command();
    test_missing_and_invalid_cli_fail_cleanly();


### PR DESCRIPTION
## What changed

- derive a per-delegate tool-loop cap from the enclosing workflow stage deadline
- reserve five minutes for mandatory verification after write delegates
- propagate the cap through the Go resource-plane request and all C delegate backends (native HTTP, provider CLI, and tmux CLI)
- preflight all configured roundtable phases so an expiring workflow window cannot launch a panel that has no time left for its chairman
- preserve smaller configured/caller limits and short roundtable phase deadlines
- add forwarding, deadline-policy, overflow, and real process-timeout coverage

## Why

Exploratory end-to-end testing reproduced an implementation delegate running until the workflow stage wall cap. The stage then cancelled the delegate mid-change and immediately redispatched it because the resource plane's delegate budget was longer than the stage budget.

The workflow engine now gives the resource plane a shorter deadline that leaves time for mandatory repository verification and lifecycle persistence. It also makes a roundtable wait for a fresh workflow window when the remaining time cannot accommodate analysis plus an enabled chairman, avoiding a billed panel retry after a predictable chairman cancellation.

## Impact

Write delegates return before their stage expires, leaving verification time instead of being killed at the wall cap. Read/review delegates retain their existing phase behavior, including deliberately short roundtable deadlines.

## Validation

- `go test ./...` in `server-go`
- `make -C src -j2 verify-local` (all 689 native test binaries and lint/contract checks)
- `python3 scripts/check_c_repository_lock.py`
- `git diff --check`
