### PR TITLE
wfe: verify committed implementation repairs before redispatch

### DIFF
--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -278,7 +278,17 @@ func (a *rejectDelegateAgents) Delegate(_ context.Context, _ DelegateRequest) (D
 	return DelegateResult{}, errors.New("delegate must not run for an already-repaired reviewed tree")
 }
 
-func TestDocumentResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *testing.T) {
+type recordingVerifier struct {
+	calls int
+	err   error
+}
+
+func (v *recordingVerifier) Verify(context.Context, string) error {
+	v.calls++
+	return v.err
+}
+
+func TestReviewResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *testing.T) {
 	root := t.TempDir()
 	repo := filepath.Join(root, "repo")
 	if err := os.MkdirAll(repo, 0o755); err != nil {
@@ -338,7 +348,34 @@ func TestDocumentResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *tes
 	gitRun(t, workdir, "add", "runbook.md")
 	gitRun(t, workdir, "commit", "-m", "human repair")
 	agents.calls = 0
-	result, err := runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "document"},
+	verifier := &recordingVerifier{err: errors.New("repair still fails verification")}
+	runner.verifier = verifier
+	implementationRequest := StepRequest{WorkItem: item, Node: wfe.Node{ID: "impl"},
+		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}
+	result, err := runner.mutate(ctx, implementationRequest, false)
+	if err != nil || result.Status != StepChanges ||
+		!strings.Contains(result.Detail, "repair still fails verification") {
+		t.Fatalf("unverified implementation repair result=%+v err=%v", result, err)
+	}
+	if agents.calls != 0 || verifier.calls != 1 {
+		t.Fatalf("unverified repair delegate calls=%d verifier calls=%d", agents.calls, verifier.calls)
+	}
+
+	verifier.err = nil
+	result, err = runner.mutate(ctx, implementationRequest, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agents.calls != 0 || verifier.calls != 2 {
+		t.Fatalf("verified repair delegate calls=%d verifier calls=%d", agents.calls, verifier.calls)
+	}
+	if result.Status != StepAdvanced || result.Artifact != branch ||
+		!strings.Contains(result.Detail, "verified and re-freezing exact repair") {
+		t.Fatalf("implementation repair result=%+v", result)
+	}
+
+	agents.calls = 0
+	result, err = runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "document"},
 		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}, true)
 	if err != nil {
 		t.Fatal(err)

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -583,13 +583,15 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 				Detail: "conflict merging aimee/feat/" + req.WorkItem.ParentID + " into slice"}, nil
 		}
 	}
-	// A documentation gate can be resumed after a human repair commit. The
+	// A review gate can be resumed after a human repair commit. The
 	// reviewed hash then remains on both the work item and feedback artifact,
 	// while the clean exact frozen diff has changed. Send that new diff back through
 	// freeze + roundtable rather than demanding that a delegate invent another
-	// edit solely to satisfy its "owned files changed" contract. This does not
-	// bypass review, and feedback left by an earlier gate cannot trigger it.
-	if docs && req.Feedback != nil && req.WorkItem.ContentHash != "" &&
+	// edit solely to satisfy its "owned files changed" contract. Implementation
+	// repairs must also pass the same mechanical verifier used after a delegate.
+	// This does not bypass review, and feedback left by an earlier gate cannot
+	// trigger it.
+	if req.Feedback != nil && req.WorkItem.ContentHash != "" &&
 		req.WorkItem.ContentHash == req.Feedback.ArtifactHash {
 		diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
 		if diffErr != nil {
@@ -601,12 +603,21 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		}
 		if status == "" && strings.TrimSpace(diff) != "" &&
 			wfe.Hash([]byte(diff)) != req.Feedback.ArtifactHash {
+			if !docs {
+				if err := r.verifier.Verify(ctx, workdir); err != nil {
+					return StepResult{Status: StepChanges, Detail: err.Error()}, nil
+				}
+			}
 			head, headErr := gitText(ctx, workdir, "rev-parse", "HEAD")
 			if headErr != nil {
 				return StepResult{}, headErr
 			}
+			detail := "reviewed worktree advanced; re-freezing exact repair"
+			if !docs {
+				detail = "reviewed worktree advanced; verified and re-freezing exact repair"
+			}
 			return StepResult{Status: StepAdvanced, ArtifactType: "branch", Artifact: branch,
-				ContentHash: head, Detail: "reviewed worktree advanced; re-freezing exact repair"}, nil
+				ContentHash: head, Detail: detail}, nil
 		}
 	}
 	prompt := "Implement the complete approved task in this worktree, run the repository verification, fix failures, and leave the accepted changes in the worktree."


### PR DESCRIPTION
When an implementation roundtable requests changes and a human commits the repair, resuming the item currently launches another full coding delegate before verification. A no-change delegate can then consume the entire lease or loop indefinitely even though the repaired tree already passes.

Extend the existing documentation repair fast path to implementation repairs. The runner only skips redispatch when the reviewed artifact identity matches, the worktree is clean, the exact diff is non-empty and changed, and the mechanical verifier passes. Freeze and roundtable still review the new exact diff.

Verified with:
- `go test ./internal/engine -run TestReviewResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit -count=1`
- `go test ./internal/engine`
- `go test ./...`