### PR TITLE
wfe: clean terminal workflow worktrees

### DIFF
--- a/server-go/cmd/aimee-server/main.go
+++ b/server-go/cmd/aimee-server/main.go
@@ -194,6 +194,7 @@ func main() {
 		handler.SetSchedulerCancel(scheduler.Cancel)
 		if worktreeManager != nil {
 			handler.SetWorktreeCleanup(worktreeManager.Cleanup)
+			scheduler.SetTerminalCleanup(worktreeManager.Cleanup)
 		}
 		go scheduler.Run(rootCtx)
 		// Trigger definitions are live UI/config state. Re-read them every scan so

--- a/server-go/internal/engine/scheduler.go
+++ b/server-go/internal/engine/scheduler.go
@@ -22,6 +22,7 @@ type Scheduler struct {
 	pollEvery         time.Duration
 	transientPauses   []transientPause
 	cancelTerminal    func(context.Context) (int, error)
+	cleanupTerminal   func(context.Context, db1.WorkItem) error
 	log               *slog.Logger
 
 	mu      sync.Mutex
@@ -86,6 +87,16 @@ func (s *Scheduler) SetTerminalCancellation(cancel func(context.Context) (int, e
 	s.Notify()
 }
 
+// SetTerminalCleanup installs the managed-worktree cleanup boundary. Terminal
+// rows remain as workflow history, but their checkouts must not accumulate
+// forever after the final transition.
+func (s *Scheduler) SetTerminalCleanup(cleanup func(context.Context, db1.WorkItem) error) {
+	s.mu.Lock()
+	s.cleanupTerminal = cleanup
+	s.mu.Unlock()
+	s.Notify()
+}
+
 type RunPolicy struct {
 	MaxTurns       int
 	MaxWall        time.Duration
@@ -146,6 +157,7 @@ func (s *Scheduler) fill(ctx context.Context) {
 	concurrencySource := s.concurrencySource
 	perWorkflowSource := s.perWorkflowSource
 	cancelTerminal := s.cancelTerminal
+	cleanupTerminal := s.cleanupTerminal
 	concurrency := s.concurrency
 	perWorkflow := s.perWorkflow
 	s.mu.Unlock()
@@ -206,15 +218,36 @@ func (s *Scheduler) fill(ctx context.Context) {
 	if perWorkflow < 1 {
 		perWorkflow = 1
 	}
+	items, err := s.db.WorkItems(ctx)
+	if err != nil {
+		s.log.Error("list workflow items", "error", err)
+		return
+	}
+	if cleanupTerminal != nil {
+		for _, item := range items {
+			terminal := item.State == "accepted" || item.State == "rejected" || item.State == "stopped"
+			if !terminal || item.Worktree == "" {
+				continue
+			}
+			s.mu.Lock()
+			_, running := s.running[item.ID]
+			s.mu.Unlock()
+			if running {
+				continue
+			}
+			if err := cleanupTerminal(ctx, item); err != nil {
+				s.log.Error("clean terminal workflow worktree", "work_item", item.ID, "error", err)
+				continue
+			}
+			if err := s.db.SetWorktree(ctx, item.ID, ""); err != nil {
+				s.log.Error("clear terminal workflow worktree", "work_item", item.ID, "error", err)
+			}
+		}
+	}
 	s.mu.Lock()
 	available := concurrency - len(s.running)
 	s.mu.Unlock()
 	if available <= 0 {
-		return
-	}
-	items, err := s.db.WorkItems(ctx)
-	if err != nil {
-		s.log.Error("list workflow items", "error", err)
 		return
 	}
 	// WorkItems is newest-first. Traverse oldest-first so continuously arriving

--- a/server-go/internal/engine/scheduler_test.go
+++ b/server-go/internal/engine/scheduler_test.go
@@ -108,6 +108,81 @@ func TestSchedulerFillsFreedSlotImmediately(t *testing.T) {
 	runner.release <- struct{}{}
 }
 
+func TestSchedulerCleansTerminalWorktreesAndRetriesFailures(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := t.Context()
+	states := map[string]string{
+		"wi_accepted": "accepted",
+		"wi_rejected": "rejected",
+		"wi_stopped":  "stopped",
+		"wi_retry":    "accepted",
+		"wi_running":  "accepted",
+	}
+	for id, state := range states {
+		if err := store.CreateWorkItem(ctx, db1.CreateWorkItem{
+			ID: id, Repo: "repo", ProposalPath: id, WorkflowName: "one",
+			StartStage: "work", Mode: "autonomous",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.SetWorktree(ctx, id, filepath.Join("/managed", id)); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Finish(ctx, id, "work", state, "done", "", 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	scheduler := NewScheduler(store, nil, 1, nil)
+	retryFails := true
+	calls := make(map[string]int)
+	scheduler.SetTerminalCleanup(func(_ context.Context, item db1.WorkItem) error {
+		calls[item.ID]++
+		if item.ID == "wi_retry" && retryFails {
+			return errors.New("temporary cleanup failure")
+		}
+		return nil
+	})
+	// A terminal transition can race the tail of its executing turn. Never remove
+	// that checkout until drive() has released it, even when all worker capacity is
+	// occupied.
+	scheduler.running["wi_running"] = struct{}{}
+	scheduler.fill(ctx)
+
+	for _, id := range []string{"wi_accepted", "wi_rejected", "wi_stopped"} {
+		item, err := store.WorkItem(ctx, id)
+		if err != nil || item.Worktree != "" || calls[id] != 1 {
+			t.Fatalf("terminal cleanup %s: item=%+v calls=%d err=%v", id, item, calls[id], err)
+		}
+	}
+	for _, id := range []string{"wi_retry", "wi_running"} {
+		item, err := store.WorkItem(ctx, id)
+		if err != nil || item.Worktree == "" {
+			t.Fatalf("premature cleanup %s: item=%+v err=%v", id, item, err)
+		}
+	}
+	if calls["wi_retry"] != 1 || calls["wi_running"] != 0 {
+		t.Fatalf("retry calls=%d running calls=%d", calls["wi_retry"], calls["wi_running"])
+	}
+
+	retryFails = false
+	delete(scheduler.running, "wi_running")
+	scheduler.fill(ctx)
+	for _, id := range []string{"wi_retry", "wi_running"} {
+		item, err := store.WorkItem(ctx, id)
+		if err != nil || item.Worktree != "" {
+			t.Fatalf("retry cleanup %s: item=%+v err=%v", id, item, err)
+		}
+	}
+	if calls["wi_retry"] != 2 || calls["wi_running"] != 1 {
+		t.Fatalf("retry calls=%d running calls=%d", calls["wi_retry"], calls["wi_running"])
+	}
+}
+
 // seedPerWorkflowItems writes a one-node "author.proposal" workflow and creates a
 // work item per id, returning a store + a blocking runner + a started scheduler.
 // Items whose ids share a prefix before the first "." belong to the same root

--- a/server-go/internal/engine/worktree.go
+++ b/server-go/internal/engine/worktree.go
@@ -189,6 +189,15 @@ func (m *WorktreeManager) Cleanup(ctx context.Context, item db1.WorkItem) error 
 	if err != nil || rel == "." || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return errors.New("refusing to clean worktree outside managed root")
 	}
+	// Cleanup is a two-step lifecycle operation: remove the checkout, then clear
+	// its durable path. If the database write fails after removal, the scheduler
+	// retries with the old row. Treat that already-completed physical step as
+	// success so the retry can finish clearing durable state.
+	if _, statErr := os.Stat(abs); errors.Is(statErr, os.ErrNotExist) {
+		return nil
+	} else if statErr != nil {
+		return fmt.Errorf("stat managed worktree: %w", statErr)
+	}
 	// Ensure creates every managed tree with --lock so external GC cannot race a
 	// live workflow. Explicit lifecycle deletion owns this path, so unlock it
 	// before the validated removal; a missing lock is harmless.

--- a/server-go/internal/engine/worktree_test.go
+++ b/server-go/internal/engine/worktree_test.go
@@ -62,6 +62,29 @@ func TestParentUsesFeatureWorktreeAndChildBranchesFromIt(t *testing.T) {
 	}
 }
 
+func TestCleanupIsIdempotentAfterManagedPathWasRemoved(t *testing.T) {
+	root := t.TempDir()
+	store, err := db1.Open(filepath.Join(root, "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	manager, err := NewWorktreeManager(store, filepath.Join(root, "trees"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := db1.WorkItem{ID: "wi_missing", Repo: filepath.Join(root, "repo"),
+		Worktree: filepath.Join(root, "trees", "wi_missing")}
+	if err := manager.Cleanup(t.Context(), item); err != nil {
+		t.Fatalf("repeat cleanup of removed managed path: %v", err)
+	}
+
+	item.Worktree = filepath.Join(root, "outside-managed-root")
+	if err := manager.Cleanup(t.Context(), item); err == nil {
+		t.Fatal("missing path outside the managed root bypassed scope validation")
+	}
+}
+
 func TestEnsureMigratesLegacySliceWorktreeAfterReplayLosesDBPath(t *testing.T) {
 	root := t.TempDir()
 	repo := filepath.Join(root, "repo")


### PR DESCRIPTION
Accepted, rejected, and stopped Go workflow items retained their real managed worktrees indefinitely. The C scheduler had an orphan sweep, but the active Go scheduler never called `WorktreeManager.Cleanup` after terminal transitions.

Add a terminal cleanup sweep that:
- removes only managed terminal worktrees;
- skips a work item while its final turn is still running;
- retries cleanup failures on later scheduler passes;
- clears the durable worktree path only after successful removal; and
- runs even when all execution capacity is occupied.

The server now wires the same validated cleanup boundary used by the API into the scheduler.

Verified with `go test ./...`.