### PR TITLE
fix(workflows): redispatch failed repair verification

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -1190,6 +1190,16 @@ func (s *Store) StageLoopCount(ctx context.Context, workItemID, stage string) (i
 	return count, err
 }
 
+// StageAttemptCount reports the current consecutive retry count for a stage.
+// Unlike StageLoopCount, this counter is cleared when the stage advances, so it
+// distinguishes a newly reviewed repair from a verifier failure that has just
+// looped back to the same implementation stage.
+func (s *Store) StageAttemptCount(ctx context.Context, workItemID, stage string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COALESCE((SELECT attempts FROM lifecycle_stage_attempt WHERE work_item_id=? AND stage=?), 0)`, workItemID, stage).Scan(&count)
+	return count, err
+}
+
 // Park records the stable pause reason as both item state and event detail.
 // Call ParkWithDetail when an operator-safe diagnostic should accompany it.
 func (s *Store) Park(ctx context.Context, workItemID, stage, reason string, costUSD float64) error {

--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -374,6 +374,30 @@ func TestReviewResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *testi
 		t.Fatalf("implementation repair result=%+v", result)
 	}
 
+	// A failed mechanical repair verification loops back to implementation.
+	// That retry must call a delegate; otherwise the fast path just reruns the
+	// identical failing verifier until retry_limit without giving anything a
+	// chance to fix the checkout.
+	if err := store.Move(ctx, item.ID, "document", "impl", "advance", "", reviewedHash, 0); err != nil {
+		t.Fatal(err)
+	}
+	if parked, err := store.RecordRetry(ctx, item.ID, "impl", "impl", "verify failed", 3, 0); err != nil || parked {
+		t.Fatalf("record implementation retry: parked=%v err=%v", parked, err)
+	}
+	item, _ = store.WorkItem(ctx, item.ID)
+	item.ContentHash = reviewedHash
+	item.Worktree = workdir
+	agents.calls = 0
+	verifierCalls := verifier.calls
+	_, err = runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "impl"},
+		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}, false)
+	if err == nil || agents.calls != 1 {
+		t.Fatalf("failed verification retry bypassed delegate: calls=%d err=%v", agents.calls, err)
+	}
+	if verifier.calls != verifierCalls {
+		t.Fatalf("failed verification retry replayed verifier: calls=%d, want %d", verifier.calls, verifierCalls)
+	}
+
 	agents.calls = 0
 	result, err = runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "document"},
 		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}, true)

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -591,7 +591,21 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	// repairs must also pass the same mechanical verifier used after a delegate.
 	// This does not bypass review, and feedback left by an earlier gate cannot
 	// trigger it.
-	if req.Feedback != nil && req.WorkItem.ContentHash != "" &&
+	repairFastPath := true
+	if !docs {
+		attempts, attemptErr := r.db.StageAttemptCount(ctx, req.WorkItem.ID, req.Node.ID)
+		if attemptErr != nil {
+			return StepResult{}, attemptErr
+		}
+		// The first pass after review may verify a clean committed repair without
+		// asking a delegate to make a meaningless extra edit. Once that verifier
+		// has failed, however, RecordRetry has incremented this stage counter. A
+		// later pass must dispatch an implementation delegate so it can actually
+		// repair the failure instead of replaying the same verifier until the
+		// retry limit parks the workflow.
+		repairFastPath = attempts == 0
+	}
+	if repairFastPath && req.Feedback != nil && req.WorkItem.ContentHash != "" &&
 		req.WorkItem.ContentHash == req.Feedback.ArtifactHash {
 		diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
 		if diffErr != nil {


### PR DESCRIPTION
## Summary

- distinguish a newly reviewed implementation repair from a verifier retry
- after the repair fast-path verifier fails, dispatch an implementation delegate instead of replaying the same failing verifier
- add regression coverage for the retry path

## Why

Exploratory E2E run `wi_57186250728b511961573e5afb37cc93` exposed a failure loop: a committed roundtable repair failed clang-format verification, then the workflow ran the identical verifier three times without giving an agent a chance to fix it and parked at `retry_limit`.

## Verification

- `go test ./...` in `server-go`
- `git diff --check`
- complete GitHub CI matrix passed on the identical commit in #2342