### PR TITLE
fix(workflows): preserve repair context and bound fallback retries

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -1203,12 +1203,31 @@ func (s *Store) StageAttemptCount(ctx context.Context, workItemID, stage string)
 // LatestStageRetryDetail returns the diagnostic that caused the current stage
 // retry. A loop is preferred over later transient runner pauses so cancellation
 // recovery does not hide the verifier failure the next delegate must repair.
-// The pause fallback covers stages configured with a one-attempt retry limit.
+// When an operator resumes a retry-limit park, the park diagnostic is retained
+// while the numeric attempt budget starts fresh. A successful advance is the
+// boundary that makes all earlier diagnostics stale.
 func (s *Store) LatestStageRetryDetail(ctx context.Context, workItemID, stage string) (string, error) {
+	var boundary, reset int64
+	attempts, err := s.StageAttemptCount(ctx, workItemID, stage)
+	if err != nil {
+		return "", err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id),0) FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='advance'`, workItemID, stage).Scan(&boundary); err != nil {
+		return "", err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id),0) FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='resume' AND detail='retry_limit' AND id>?`, workItemID, stage, boundary).Scan(&reset); err != nil {
+		return "", err
+	}
+	if attempts == 0 && reset <= boundary {
+		return "", nil
+	}
 	var detail string
-	err := s.db.QueryRowContext(ctx, `SELECT detail FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='loop' ORDER BY id DESC LIMIT 1`, workItemID, stage).Scan(&detail)
+	err = s.db.QueryRowContext(ctx, `SELECT detail FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='loop' AND id>? ORDER BY id DESC LIMIT 1`, workItemID, stage, max(boundary, reset)).Scan(&detail)
+	if errors.Is(err, sql.ErrNoRows) && reset > boundary {
+		err = s.db.QueryRowContext(ctx, `SELECT detail FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='pause' AND detail!='manual' AND id>? AND id<? ORDER BY id DESC LIMIT 1`, workItemID, stage, boundary, reset).Scan(&detail)
+	}
 	if errors.Is(err, sql.ErrNoRows) {
-		err = s.db.QueryRowContext(ctx, `SELECT detail FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='pause' AND detail!='manual' ORDER BY id DESC LIMIT 1`, workItemID, stage).Scan(&detail)
+		err = s.db.QueryRowContext(ctx, `SELECT detail FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='pause' AND detail!='manual' AND id>? ORDER BY id DESC LIMIT 1`, workItemID, stage, boundary).Scan(&detail)
 	}
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
@@ -1284,6 +1303,14 @@ func (s *Store) Resume(ctx context.Context, workItemID string) error {
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE lifecycle_work_item SET pause_reason='', paused_state='', updated_at=datetime('now') WHERE work_item_id=? AND state='active'`, workItemID); err != nil {
 		return err
+	}
+	if reason == "retry_limit" {
+		// A human resume is an explicit request for another bounded repair cycle.
+		// Keeping the exhausted value made the very next failed repair park again,
+		// effectively reducing recovery to one attempt per manual resume.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM lifecycle_stage_attempt WHERE work_item_id=? AND stage=?`, workItemID, stage); err != nil {
+			return err
+		}
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO lifecycle_event (work_item_id, stage, kind, actor, detail) VALUES (?, ?, 'resume', 'operator', ?)`, workItemID, stage, reason); err != nil {
 		return err

--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -1200,6 +1200,22 @@ func (s *Store) StageAttemptCount(ctx context.Context, workItemID, stage string)
 	return count, err
 }
 
+// LatestStageRetryDetail returns the diagnostic that caused the current stage
+// retry. A loop is preferred over later transient runner pauses so cancellation
+// recovery does not hide the verifier failure the next delegate must repair.
+// The pause fallback covers stages configured with a one-attempt retry limit.
+func (s *Store) LatestStageRetryDetail(ctx context.Context, workItemID, stage string) (string, error) {
+	var detail string
+	err := s.db.QueryRowContext(ctx, `SELECT detail FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='loop' ORDER BY id DESC LIMIT 1`, workItemID, stage).Scan(&detail)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = s.db.QueryRowContext(ctx, `SELECT detail FROM lifecycle_event WHERE work_item_id=? AND stage=? AND kind='pause' AND detail!='manual' ORDER BY id DESC LIMIT 1`, workItemID, stage).Scan(&detail)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return detail, err
+}
+
 // Park records the stable pause reason as both item state and event detail.
 // Call ParkWithDetail when an operator-safe diagnostic should accompany it.
 func (s *Store) Park(ctx context.Context, workItemID, stage, reason string, costUSD float64) error {

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -297,6 +297,58 @@ func TestExecutedTurnCountExcludesAdministrativeEvents(t *testing.T) {
 	}
 }
 
+func TestRetryLimitResumeStartsFreshBudgetAndKeepsDiagnostic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	if err := store.CreateWorkItem(ctx, CreateWorkItem{ID: "wi_retry_resume", Repo: "repo", ProposalPath: "retry", WorkflowName: "build", StartStage: "impl"}); err != nil {
+		t.Fatal(err)
+	}
+	if parked, err := store.RecordRetry(ctx, "wi_retry_resume", "impl", "impl", "verify failed: stale docs", 1, 0); err != nil || !parked {
+		t.Fatalf("initial retry: parked=%v err=%v", parked, err)
+	}
+	if err := store.Resume(ctx, "wi_retry_resume"); err != nil {
+		t.Fatal(err)
+	}
+	if attempts, err := store.StageAttemptCount(ctx, "wi_retry_resume", "impl"); err != nil || attempts != 0 {
+		t.Fatalf("attempts after retry-limit resume=%d err=%v, want fresh budget", attempts, err)
+	}
+	if detail, err := store.LatestStageRetryDetail(ctx, "wi_retry_resume", "impl"); err != nil || detail != "verify failed: stale docs" {
+		t.Fatalf("retry detail=%q err=%v", detail, err)
+	}
+	if parked, err := store.RecordRetry(ctx, "wi_retry_resume", "impl", "impl", "verify failed again", 3, 0); err != nil || parked {
+		t.Fatalf("first retry in fresh budget: parked=%v err=%v", parked, err)
+	}
+	if attempts, err := store.StageAttemptCount(ctx, "wi_retry_resume", "impl"); err != nil || attempts != 1 {
+		t.Fatalf("attempts after fresh failure=%d err=%v", attempts, err)
+	}
+	if detail, err := store.LatestStageRetryDetail(ctx, "wi_retry_resume", "impl"); err != nil || detail != "verify failed again" {
+		t.Fatalf("new retry detail=%q err=%v", detail, err)
+	}
+	if err := store.Move(ctx, "wi_retry_resume", "impl", "review", "advance", "verified", "hash", 0); err != nil {
+		t.Fatal(err)
+	}
+	if detail, err := store.LatestStageRetryDetail(ctx, "wi_retry_resume", "impl"); err != nil || detail != "" {
+		t.Fatalf("completed-stage retry detail=%q err=%v, want stale detail cleared", detail, err)
+	}
+}
+
+func TestTransientPauseIsNotRepairContext(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	if err := store.CreateWorkItem(ctx, CreateWorkItem{ID: "wi_transient", Repo: "repo", ProposalPath: "transient", WorkflowName: "build", StartStage: "impl"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ParkWithDetail(ctx, "wi_transient", "impl", "runner_unavailable", "delegate service restarting", 0); err != nil {
+		t.Fatal(err)
+	}
+	if resumed, err := store.ResumeTransient(ctx, "runner_unavailable", 0); err != nil || resumed != 1 {
+		t.Fatalf("resume transient=%d err=%v", resumed, err)
+	}
+	if detail, err := store.LatestStageRetryDetail(ctx, "wi_transient", "impl"); err != nil || detail != "" {
+		t.Fatalf("transient pause leaked as repair detail=%q err=%v", detail, err)
+	}
+}
+
 func TestWorkflowBudgetAggregatesChildrenAndParksWholeTree(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -194,15 +194,11 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 	}
 	req := StepRequest{WorkItem: item, Node: node, Proposal: string(proposal), CostLimitUSD: budget.Amount, ReplayOnly: budget.ReplayOnly}
 	req.Block = block
-	if attempts, attemptErr := e.db.StageAttemptCount(ctx, item.ID, item.Stage); attemptErr != nil {
-		return out, attemptErr
-	} else if attempts > 0 {
-		retryDetail, detailErr := e.db.LatestStageRetryDetail(ctx, item.ID, item.Stage)
-		if detailErr != nil {
-			return out, detailErr
-		}
-		req.RetryDetail = retryDetail
+	retryDetail, detailErr := e.db.LatestStageRetryDetail(ctx, item.ID, item.Stage)
+	if detailErr != nil {
+		return out, detailErr
 	}
+	req.RetryDetail = retryDetail
 	if len(node.In) > 0 {
 		req.Inputs = make(map[string]wfe.Artifact, len(node.In))
 		for inputName, binding := range node.In {

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -39,7 +39,11 @@ type StepRequest struct {
 	Proposal string                  `json:"proposal"`
 	Inputs   map[string]wfe.Artifact `json:"inputs,omitempty"`
 	Feedback *wfe.ReviewFeedback     `json:"feedback,omitempty"`
-	Block    wfe.BlockDefinition     `json:"block_definition"`
+	// RetryDetail is the durable diagnostic from the immediately preceding
+	// failure of this stage. It lets a repair delegate address a known verifier
+	// failure instead of rediscovering it from scratch.
+	RetryDetail string              `json:"retry_detail,omitempty"`
+	Block       wfe.BlockDefinition `json:"block_definition"`
 	// CostLimitUSD is the durable reservation granted to this invocation. A
 	// capped runner must pass it to every billable resource-plane call and must
 	// not return a cost above it.
@@ -190,6 +194,15 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 	}
 	req := StepRequest{WorkItem: item, Node: node, Proposal: string(proposal), CostLimitUSD: budget.Amount, ReplayOnly: budget.ReplayOnly}
 	req.Block = block
+	if attempts, attemptErr := e.db.StageAttemptCount(ctx, item.ID, item.Stage); attemptErr != nil {
+		return out, attemptErr
+	} else if attempts > 0 {
+		retryDetail, detailErr := e.db.LatestStageRetryDetail(ctx, item.ID, item.Stage)
+		if detailErr != nil {
+			return out, detailErr
+		}
+		req.RetryDetail = retryDetail
+	}
 	if len(node.In) > 0 {
 		req.Inputs = make(map[string]wfe.Artifact, len(node.In))
 		for inputName, binding := range node.In {

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -98,6 +98,12 @@ type artifactRoutingRunner struct {
 
 type recoveringRunner struct{ calls int }
 
+type retryDetailRunner struct {
+	t      *testing.T
+	calls  int
+	detail string
+}
+
 type blockingSiblingRunner struct {
 	started chan StepRequest
 	release chan struct{}
@@ -124,6 +130,60 @@ func (r *recoveringRunner) Run(_ context.Context, _ StepRequest) (StepResult, er
 		return StepResult{}, errors.New("temporary runner outage")
 	}
 	return StepResult{Status: StepAdvanced}, nil
+}
+
+func (r *retryDetailRunner) Run(_ context.Context, req StepRequest) (StepResult, error) {
+	r.calls++
+	if r.calls == 1 {
+		return StepResult{Status: StepChanges, Detail: r.detail}, nil
+	}
+	if req.RetryDetail != r.detail {
+		r.t.Fatalf("retry detail=%q, want %q", req.RetryDetail, r.detail)
+	}
+	return StepResult{Status: StepAdvanced}, nil
+}
+
+func TestRetryPassesPreviousFailureDetailToRunner(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte("name: retry-detail\nstart: work\nnodes:\n  - id: work\n    block: author.proposal\n    on_fail: work\n    params:\n      max_rounds: 3\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "retry-detail.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := db1.CreateWorkItem{ID: "wi_retry_detail", Repo: "repo", ProposalPath: "proposal", WorkflowName: "retry-detail", WorkflowVersion: def.Version, StartStage: "work"}
+	if err := store.CreateWorkItem(t.Context(), item); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal(item.ID, []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	runner := &retryDetailRunner{t: t, detail: "verify failed: clang-format violation"}
+	workflowEngine, err := New(store, artifacts, workflowDir, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result, err := workflowEngine.Advance(t.Context(), item.ID); err != nil || result.Parked || result.NextStage != "work" {
+		t.Fatalf("first advance result=%+v err=%v", result, err)
+	}
+	if result, err := workflowEngine.Advance(t.Context(), item.ID); err != nil || !result.Terminal || result.State != "accepted" {
+		t.Fatalf("retry advance result=%+v err=%v", result, err)
+	}
 }
 
 func testSiblingStepsRunConcurrently(t *testing.T, maxUSD, stepCostUSD float64) {

--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -271,10 +271,14 @@ func (a partialNoCommitAgents) DelegateGroup(_ context.Context, requests []Deleg
 	return out
 }
 
-type rejectDelegateAgents struct{ calls int }
+type rejectDelegateAgents struct {
+	calls int
+	last  DelegateRequest
+}
 
-func (a *rejectDelegateAgents) Delegate(_ context.Context, _ DelegateRequest) (DelegateResult, error) {
+func (a *rejectDelegateAgents) Delegate(_ context.Context, request DelegateRequest) (DelegateResult, error) {
 	a.calls++
+	a.last = request
 	return DelegateResult{}, errors.New("delegate must not run for an already-repaired reviewed tree")
 }
 
@@ -390,9 +394,12 @@ func TestReviewResumeRefreezesHumanRepairWithoutMeaninglessDelegateEdit(t *testi
 	agents.calls = 0
 	verifierCalls := verifier.calls
 	_, err = runner.mutate(ctx, StepRequest{WorkItem: item, Node: wfe.Node{ID: "impl"},
-		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}}, false)
+		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash}, RetryDetail: "verify failed: clang-format violation"}, false)
 	if err == nil || agents.calls != 1 {
 		t.Fatalf("failed verification retry bypassed delegate: calls=%d err=%v", agents.calls, err)
+	}
+	if !strings.Contains(agents.last.Prompt, "PREVIOUS ATTEMPT FAILURE TO FIX:\nverify failed: clang-format violation") {
+		t.Fatalf("repair delegate did not receive verifier failure: %q", agents.last.Prompt)
 	}
 	if verifier.calls != verifierCalls {
 		t.Fatalf("failed verification retry replayed verifier: calls=%d, want %d", verifier.calls, verifierCalls)

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -651,20 +651,12 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	// repairs must also pass the same mechanical verifier used after a delegate.
 	// This does not bypass review, and feedback left by an earlier gate cannot
 	// trigger it.
-	repairFastPath := true
-	if !docs {
-		attempts, attemptErr := r.db.StageAttemptCount(ctx, req.WorkItem.ID, req.Node.ID)
-		if attemptErr != nil {
-			return StepResult{}, attemptErr
-		}
-		// The first pass after review may verify a clean committed repair without
-		// asking a delegate to make a meaningless extra edit. Once that verifier
-		// has failed, however, RecordRetry has incremented this stage counter. A
-		// later pass must dispatch an implementation delegate so it can actually
-		// repair the failure instead of replaying the same verifier until the
-		// retry limit parks the workflow.
-		repairFastPath = attempts == 0
-	}
+	// The first pass after review may verify a clean committed repair without
+	// asking a delegate to make a meaningless extra edit. Once that verifier has
+	// failed, the engine supplies its diagnostic and a later pass must dispatch an
+	// implementation delegate. RetryDetail remains present across an operator
+	// retry-budget reset, unlike the numeric attempt counter.
+	repairFastPath := docs || req.RetryDetail == ""
 	if repairFastPath && req.Feedback != nil && req.WorkItem.ContentHash != "" &&
 		req.WorkItem.ContentHash == req.Feedback.ArtifactHash {
 		diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -610,6 +610,17 @@ func delegatePartialIsNoChange(response string) bool {
 			strings.Contains(response, "no file changes detected"))
 }
 
+func retryDetailForPrompt(detail string) string {
+	detail = strings.TrimSpace(safeDiagnostic(detail))
+	const maxRunes = 24_000
+	runes := []rune(detail)
+	if len(runes) <= maxRunes {
+		return detail
+	}
+	const headRunes = 8_000
+	return string(runes[:headRunes]) + "\n...[retry diagnostic truncated]...\n" + string(runes[len(runes)-(maxRunes-headRunes):])
+}
+
 func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (StepResult, error) {
 	workdir, branch, err := r.worktrees.Ensure(ctx, req.WorkItem, req.WorkItem.ParentID == "")
 	if err != nil {
@@ -699,6 +710,9 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	if req.Feedback != nil {
 		encoded, _ := json.Marshal(req.Feedback)
 		prompt += "\n\nREVIEW FEEDBACK TO RESOLVE:\n" + string(encoded)
+	}
+	if retryDetail := retryDetailForPrompt(req.RetryDetail); retryDetail != "" {
+		prompt += "\n\nPREVIOUS ATTEMPT FAILURE TO FIX:\n" + retryDetail
 	}
 	var cost float64
 	costUnknown := false


### PR DESCRIPTION
## Summary
- pass the last mechanical verifier diagnostic into implementation repair prompts
- reset an exhausted stage retry budget when an operator explicitly resumes a retry-limit park
- retain the failure context across that reset while excluding transient runner pauses
- prevent clean-repair fast paths from replaying a known failing verifier instead of dispatching an agent
- enforce one monotonic workflow tool-loop deadline across credential retries and provider/same-tier fallbacks instead of restarting the cap per fallback

## Live E2E findings
A slice repair exhausted its retry budget on verifier-only replays. After redispatch was fixed, the next agent repaired part of the failure, but the single remaining verifier failure immediately re-parked because the old exhausted counter survived the operator resume. The following repair also crossed providers under one logical request, exposing that each retry/fallback received a fresh timeout budget.

These changes give an operator-resumed repair cycle a fresh bounded budget, deliver the exact remaining failure, and keep the delegated request inside the workflow original wall-clock allowance.

## Verification
- go test ./... (server-go)
- make -C src lint
- src/build/obj/tests/unit-test-server-compute
- live workflow confirmed retry context reaches the repair prompt, a new repair is dispatched after retry-limit resume, and the mandatory verifier starts on the resulting commit