### PR TITLE
fix(wfe): clean up worktrees whose repository is gone

### DIFF
--- a/server-go/internal/engine/worktree.go
+++ b/server-go/internal/engine/worktree.go
@@ -198,6 +198,22 @@ func (m *WorktreeManager) Cleanup(ctx context.Context, item db1.WorkItem) error 
 	} else if statErr != nil {
 		return fmt.Errorf("stat managed worktree: %w", statErr)
 	}
+	// The repository can be gone while its worktrees remain -- a deleted webuser
+	// workspace leaves exactly that. Every `git -C <repo>` below then fails with
+	// "cannot change to <repo>", Cleanup returns an error forever, and the item
+	// never reaches a terminal state: observed on a live server retrying one work
+	// item ~92 times a minute against a repo directory that no longer existed.
+	//
+	// There is nothing to deregister in that case. The administrative entry lived
+	// in the repo's .git/worktrees and went with it, so the checkout is an orphan
+	// and removing the directory IS the cleanup. Safe because abs was already
+	// validated to sit inside the managed root above.
+	if _, repoErr := os.Stat(item.Repo); errors.Is(repoErr, os.ErrNotExist) {
+		if rmErr := os.RemoveAll(abs); rmErr != nil {
+			return fmt.Errorf("remove orphaned worktree %s: %w", abs, rmErr)
+		}
+		return nil
+	}
 	// Ensure creates every managed tree with --lock so external GC cannot race a
 	// live workflow. Explicit lifecycle deletion owns this path, so unlock it
 	// before the validated removal; a missing lock is harmless.

--- a/server-go/internal/engine/worktree_test.go
+++ b/server-go/internal/engine/worktree_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,6 +83,55 @@ func TestCleanupIsIdempotentAfterManagedPathWasRemoved(t *testing.T) {
 	item.Worktree = filepath.Join(root, "outside-managed-root")
 	if err := manager.Cleanup(t.Context(), item); err == nil {
 		t.Fatal("missing path outside the managed root bypassed scope validation")
+	}
+}
+
+func TestCleanupRemovesOrphanedWorktreeWhenTheRepoIsGone(t *testing.T) {
+	// A deleted workspace leaves its worktrees behind. Every `git -C <repo>` then
+	// fails with "cannot change to <repo>", so Cleanup used to return an error
+	// forever and the work item never reached a terminal state -- observed on a
+	// live server retrying one item ~92 times a minute.
+	root := t.TempDir()
+	store, err := db1.Open(filepath.Join(root, "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	manager, err := NewWorktreeManager(store, filepath.Join(root, "trees"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The checkout exists; the repository it belonged to does not.
+	tree := filepath.Join(root, "trees", "wi_orphan")
+	if err := os.MkdirAll(tree, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tree, "file"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	item := db1.WorkItem{ID: "wi_orphan", Repo: filepath.Join(root, "repo-that-was-deleted"),
+		Worktree: tree}
+
+	if err := manager.Cleanup(t.Context(), item); err != nil {
+		t.Fatalf("cleanup with a missing repo must succeed, got: %v", err)
+	}
+	if _, err := os.Stat(tree); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("orphaned worktree still present after cleanup: %v", err)
+	}
+
+	// Scope validation still applies: a missing repo is not a licence to delete
+	// anything outside the managed root.
+	outside := filepath.Join(root, "outside-managed-root")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	item.Worktree = outside
+	if err := manager.Cleanup(t.Context(), item); err == nil {
+		t.Fatal("a missing repo bypassed managed-root scope validation")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("path outside the managed root was removed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## The failure

`WorktreeManager.Cleanup` tolerates a missing **worktree** but not a missing **repository**.

When a workspace is deleted while its managed worktrees remain, every `git -C <repo>` fails:

```
git worktree remove --force /var/lib/aimee/wfe-worktrees/wi_36d92dad...:
  fatal: cannot change to '/var/lib/aimee-workspaces/webusers/admin/rakuensoftware/aimee-workflow':
  No such file or directory
```

`Cleanup` returns that error forever and the work item never reaches a terminal state.

## Observed live

On a running server, one `accepted` work item (stage `final_pr`) whose repo directory no longer
existed retried **~92 times per minute**, with **five orphaned worktrees** stuck under the managed
root and no path to convergence.

## The fix

There is nothing to deregister when the repository is gone — the administrative entry lived in its
`.git/worktrees` and went with it. The checkout is an orphan, so removing the directory *is* the
cleanup.

Scope validation still runs first, so a missing repository is not a licence to delete anything
outside the managed root. The test pins both halves.

## Verification

- `TestCleanupRemovesOrphanedWorktreeWhenTheRepoIsGone` — new
- **Mutation-checked**: without the fix the test fails with the exact error string seen in
  production; with it, it passes
- `go test ./internal/engine/` green, `go vet` clean, `gofmt` clean

## Scope

Unrelated to the event-bus migration (#2336) — this is engine worktree lifecycle. Found while
validating that deployment.
