### PR TITLE
fix(entrypoint): refresh unmodified module grants, keep operator edits

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -202,11 +202,54 @@ chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspac
 # missing grants so an operator may tighten a persisted policy without the next
 # image start overwriting it.
 mkdir -p "$AIMEE_HOME/modules.d/server"
-for module_grant in /opt/aimee/module-grants/server/*.grant; do
+# Overridable ONLY so the seeding rules can be tested against a fixture
+# directory; production always uses the image path.
+AIMEE_MODULE_GRANT_SRC="${AIMEE_MODULE_GRANT_SRC:-/opt/aimee/module-grants/server}"
+
+# >>> module-grant-seeding (extracted by src/tests/test_module_grants.sh)
+# Telling a STALE IMAGE DEFAULT apart from an OPERATOR'S POLICY.
+#
+# Seeding deliberately never overwrites a persisted grant, so a module that
+# gains a stage cannot serve it until someone edits the file by hand — and the
+# failure is silent at the bus (the kind is simply refused). Blindly adopting
+# the shipped stage list would fix that by trampling deliberate policy, which is
+# a privilege expansion and strictly worse.
+#
+# The two cases are distinguishable if we record what the image wrote at seed
+# time: a file still byte-identical to what we seeded was never touched by an
+# operator, so replacing it restores an image default rather than overriding a
+# decision. Anything else keeps the warning and waits for a human.
+#
+# Note this is only knowable going forward. A grant seeded by an older image has
+# no record, so it is treated as operator-owned (warn, do not touch) — the
+# conservative side of the ambiguity.
+# Recorded under .seeded/<name>, the same convention seed_managed_defaults uses
+# above. The policy loader selects entries by a ".grant" suffix, so this
+# subdirectory is skipped rather than parsed -- worth stating, because the loader
+# rejects the WHOLE directory on one bad entry.
+grant_seed_record() { printf '%s/.seeded/%s\n' "$(dirname "$1")" "$(basename "$1")"; }
+
+grant_record_seed() {
+    command -v sha256sum >/dev/null 2>&1 || return 0
+    _rec=$(grant_seed_record "$1")
+    mkdir -p "$(dirname "$_rec")" 2>/dev/null || return 0
+    sha256sum "$1" | cut -d' ' -f1 > "$_rec" 2>/dev/null || return 0
+    chmod 0600 "$_rec" 2>/dev/null || true
+}
+
+grant_untouched_since_seed() {
+    command -v sha256sum >/dev/null 2>&1 || return 1
+    _rec=$(grant_seed_record "$1")
+    [ -f "$_rec" ] || return 1
+    [ "$(sha256sum "$1" | cut -d' ' -f1)" = "$(cat "$_rec" 2>/dev/null)" ]
+}
+
+for module_grant in "$AIMEE_MODULE_GRANT_SRC"/*.grant; do
     [ -f "$module_grant" ] || continue
     grant_target="$AIMEE_HOME/modules.d/server/$(basename "$module_grant")"
     if [ ! -e "$grant_target" ]; then
         cp "$module_grant" "$grant_target"
+        grant_record_seed "$grant_target"
         continue
     fi
     # A module that gains a stage in a new image cannot serve it under a grant
@@ -214,16 +257,32 @@ for module_grant in /opt/aimee/module-grants/server/*.grant; do
     # simply reports the module as not serving that kind. Copying over the
     # operator's file would defeat the whole point of seeding only what is
     # missing, so say so instead and let them decide.
+    # No record yet but already byte-identical to what this image ships: adopt it
+    # as managed so a LATER image can refresh it. Existing installs come under
+    # management this way instead of staying unmanageable forever.
+    if [ ! -f "$(grant_seed_record "$grant_target")" ] && cmp -s "$module_grant" "$grant_target"; then
+        grant_record_seed "$grant_target"
+    fi
     shipped_serve=$(grep '^serve=' "$module_grant" 2>/dev/null || true)
     persisted_serve=$(grep '^serve=' "$grant_target" 2>/dev/null || true)
     if [ "$shipped_serve" != "$persisted_serve" ]; then
         # log() is not defined this early in the script, so match its format.
-        printf '[server-entrypoint] warning: %s grant differs from this image\n' \
-            "$(basename "$module_grant" .grant)" >&2
-        printf '[server-entrypoint]   persisted: %s\n' "${persisted_serve:-<none>}" >&2
-        printf '[server-entrypoint]   shipped:   %s\n' "${shipped_serve:-<none>}" >&2
-        printf '[server-entrypoint]   stages only in the shipped grant are refused until %s is updated\n' \
-            "$grant_target" >&2
+        if grant_untouched_since_seed "$grant_target"; then
+            # Still exactly what this installation seeded, so the difference is
+            # image drift and adopting it overrides nobody.
+            printf '[server-entrypoint] %s grant is an unmodified image default and this image ships %s; adopting it\n' \
+                "$(basename "$module_grant" .grant)" "${shipped_serve:-<none>}" >&2
+            cp "$module_grant" "$grant_target"
+            grant_record_seed "$grant_target"
+        else
+            printf '[server-entrypoint] warning: %s grant differs from this image\n' \
+                "$(basename "$module_grant" .grant)" >&2
+            printf '[server-entrypoint]   persisted: %s\n' "${persisted_serve:-<none>}" >&2
+            printf '[server-entrypoint]   shipped:   %s\n' "${shipped_serve:-<none>}" >&2
+            printf '[server-entrypoint]   this file was edited after seeding, so it is treated as operator policy\n' >&2
+            printf '[server-entrypoint]   stages only in the shipped grant are refused until %s is updated\n' \
+                "$grant_target" >&2
+        fi
     fi
 done
 
@@ -245,17 +304,21 @@ for grant_target in "$AIMEE_HOME"/modules.d/server/*.grant; do
     [ -f "$grant_target" ] || continue
     pinned=$(sed -n 's/^executable=//p' "$grant_target" | head -1)
     [ -n "$pinned" ] && [ ! -x "$pinned" ] || continue
-    shipped="/opt/aimee/module-grants/server/$(basename "$grant_target")"
+    shipped="$AIMEE_MODULE_GRANT_SRC/$(basename "$grant_target")"
     if [ -f "$shipped" ]; then
         printf '[server-entrypoint] %s grant pins %s, which this image does not ship; adopting the shipped grant
 '             "$(basename "$grant_target" .grant)" "$pinned" >&2
         cp "$shipped" "$grant_target"
+        # Now byte-identical to the image default again, so a later stage change
+        # is recognisable as drift rather than as an operator edit.
+        grant_record_seed "$grant_target"
     else
         printf '[server-entrypoint] %s grant pins %s and this image ships no such module; removing the stale grant
 '             "$(basename "$grant_target" .grant)" "$pinned" >&2
-        rm -f "$grant_target"
+        rm -f "$grant_target" "$(grant_seed_record "$grant_target")"
     fi
 done
+# <<< module-grant-seeding
 # The root entrypoint creates modules.d before dropping to the aimee user.  The
 # daemon must be able to traverse that 0700 parent in order to load the strict
 # grant policy; owning only its server child leaves the parent root-only and
@@ -429,6 +492,34 @@ server_pid=$!
 # plane declines to serve the review stage rather than failing reviews one at a
 # time, so without this the stage is simply never offered.
 export AIMEE_AGENT_SERVICE_SOCKET="${AIMEE_AGENT_SERVICE_SOCKET:-$AIMEE_HOME/aimee-http.sock}"
+
+# An optional module is left out of the shipped manifest, which is decided when
+# the image is built and cannot know what this operator turned on. roundtable is
+# the case that matters: the daemon has no other implementation of
+# roundtable.review since the proxy was deleted, so with the module absent the
+# review route reports the module as not attached however the operator has
+# configured the feature.
+#
+# modules.roundtable / AIMEE_MODULE_ROUNDTABLE is already the canonical
+# activation control for roundtable. Honour that same control here, at startup,
+# so one switch governs both the feature and the process that serves it.
+case "$(printf '%s' "${AIMEE_MODULE_ROUNDTABLE:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|on|yes)
+        if ! grep -q '^roundtable[[:space:]]' "$MODULE_MANIFEST" 2>/dev/null; then
+            _rt_bin=/usr/local/libexec/aimee-modules/aimee-module-roundtable
+            if [ -x "$_rt_bin" ]; then
+                _effective_manifest="$AIMEE_HOME/server.modules"
+                cp "$MODULE_MANIFEST" "$_effective_manifest"
+                printf 'roundtable\t%s\n' "$_rt_bin" >> "$_effective_manifest"
+                chown aimee:aimee "$_effective_manifest" 2>/dev/null || true
+                MODULE_MANIFEST="$_effective_manifest"
+                log "roundtable module enabled by configuration; serving review over the bus"
+            else
+                log "warning: AIMEE_MODULE_ROUNDTABLE is set but $_rt_bin is not in this image"
+            fi
+        fi
+        ;;
+esac
 runuser -u aimee -- env AIMEE_HOME="$AIMEE_HOME" \
     AIMEE_AGENT_SERVICE_SOCKET="$AIMEE_AGENT_SERVICE_SOCKET" \
     module-supervisor.sh server "$AIMEE_MODULE_BUS_SOCKET" "$MODULE_MANIFEST" &

--- a/src/Makefile
+++ b/src/Makefile
@@ -1127,6 +1127,12 @@ init-migrate-service-test: $(BINARY) $(SERVER)
 kb-entrypoint-test:
 	./tests/test_kb_entrypoint.sh
 
+# The server entrypoint's module-grant seeding rules: stale image default vs
+# operator policy, and the stale-pin reconciliation that once bricked a live
+# server. Needs no image -- it runs the entrypoint's own block against fixtures.
+module-grants-test:
+	./tests/test_module_grants.sh
+
 index-scan-e2e-test: $(BINARY) $(SERVER)
 	./tests/test_index_scan_e2e.sh
 

--- a/src/tests/test_module_grants.sh
+++ b/src/tests/test_module_grants.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# Module-grant seeding: telling a stale image default from an operator's policy.
+#
+# Seeding never overwrites a persisted grant, so a module that gains a stage
+# cannot serve it under an older grant -- and the bus fails SILENTLY, refusing
+# the kind with the daemon otherwise healthy. Blindly adopting the shipped stage
+# list would fix that by trampling deliberate policy, which is a privilege
+# expansion and worse than the bug.
+#
+# The rules under test:
+#   1. a missing grant is seeded, and what was seeded is recorded
+#   2. an UNMODIFIED seeded grant is refreshed when the image ships new stages
+#   3. an OPERATOR-EDITED grant is never touched, only warned about
+#   4. a grant identical to the shipped one is adopted as managed, so existing
+#      installs come under management instead of staying stuck forever
+#   5. a grant pinning an executable the image no longer ships is reconciled
+#      (the upgrade that took a live server down)
+#
+# Runs the REAL block out of the entrypoint rather than a copy of its logic:
+# the region between the module-grant-seeding sentinels is extracted verbatim.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+entrypoint="$root/deploy/container/server-entrypoint.sh"
+[ -f "$entrypoint" ] || { echo "missing $entrypoint" >&2; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+block="$tmp/seeding.sh"
+sed -n '/^# >>> module-grant-seeding/,/^# <<< module-grant-seeding/p' "$entrypoint" > "$block"
+[ -s "$block" ] || { echo "could not extract the seeding block; sentinels moved?" >&2; exit 1; }
+
+fail=0
+ok()  { echo "  ok    $1"; }
+bad() { echo "  FAIL  $1" >&2; fail=1; }
+
+# Each case gets a fresh AIMEE_HOME and a fresh "image" grants directory.
+setup() {
+    caseno=$((caseno + 1))
+    AIMEE_HOME="$tmp/home$caseno"
+    AIMEE_MODULE_GRANT_SRC="$tmp/image$caseno"
+    export AIMEE_HOME AIMEE_MODULE_GRANT_SRC
+    mkdir -p "$AIMEE_HOME/modules.d/server" "$AIMEE_MODULE_GRANT_SRC"
+}
+caseno=0
+
+# The executable a grant pins must exist, or the reconciliation loop rewrites it.
+real_exe="$tmp/aimee-wfe"
+printf '#!/bin/sh\n' > "$real_exe"
+chmod 0755 "$real_exe"
+
+write_grant() { # <path> <executable> <serve>
+    cat > "$1" <<EOF
+version=1
+principal_class=1
+principal_ref=20
+uid=self
+executable=$2
+publish=
+subscribe=
+request=
+serve=$3
+EOF
+}
+
+run_seeding() { sh "$block" 2>"$tmp/err$caseno"; }
+serve_of() { sed -n 's/^serve=//p' "$1"; }
+
+echo "1. a missing grant is seeded and recorded"
+setup
+write_grant "$AIMEE_MODULE_GRANT_SRC/workflows.grant" "$real_exe" "9217,9218"
+run_seeding
+target="$AIMEE_HOME/modules.d/server/workflows.grant"
+[ -f "$target" ] && ok "seeded" || bad "grant was not seeded"
+[ -f "$AIMEE_HOME/modules.d/server/.seeded/workflows.grant" ] && ok "seed recorded" || bad "no seed record"
+
+echo "2. an unmodified seeded grant adopts new stages from a later image"
+write_grant "$AIMEE_MODULE_GRANT_SRC/workflows.grant" "$real_exe" "9217,9218,9219"
+run_seeding
+if [ "$(serve_of "$target")" = "9217,9218,9219" ]; then ok "adopted the shipped stages"
+else bad "stale default was not refreshed (serve=$(serve_of "$target"))"; fi
+
+echo "3. an operator-edited grant is never overwritten"
+setup
+write_grant "$AIMEE_MODULE_GRANT_SRC/workflows.grant" "$real_exe" "9217,9218"
+run_seeding
+target="$AIMEE_HOME/modules.d/server/workflows.grant"
+write_grant "$target" "$real_exe" "9217"          # operator tightens policy
+write_grant "$AIMEE_MODULE_GRANT_SRC/workflows.grant" "$real_exe" "9217,9218,9219"
+run_seeding
+if [ "$(serve_of "$target")" = "9217" ]; then ok "operator policy preserved"
+else bad "operator policy was overwritten (serve=$(serve_of "$target"))"; fi
+if grep -q 'treated as operator policy' "$tmp/err$caseno"; then ok "warned instead"
+else bad "no warning explaining the refusal"; fi
+
+echo "4. a grant identical to the shipped one is adopted as managed"
+setup
+write_grant "$AIMEE_MODULE_GRANT_SRC/workflows.grant" "$real_exe" "9217"
+target="$AIMEE_HOME/modules.d/server/workflows.grant"
+write_grant "$target" "$real_exe" "9217"          # pre-existing, never recorded
+run_seeding
+[ -f "$AIMEE_HOME/modules.d/server/.seeded/workflows.grant" ] && ok "adopted as managed" \
+    || bad "identical pre-existing grant stayed unmanaged"
+write_grant "$AIMEE_MODULE_GRANT_SRC/workflows.grant" "$real_exe" "9217,9218"
+run_seeding
+if [ "$(serve_of "$target")" = "9217,9218" ]; then ok "now refreshable"
+else bad "still not refreshable (serve=$(serve_of "$target"))"; fi
+
+echo "5. a grant pinning a vanished executable is reconciled, not left to brick boot"
+setup
+write_grant "$AIMEE_MODULE_GRANT_SRC/workflows.grant" "$real_exe" "9217,9218"
+target="$AIMEE_HOME/modules.d/server/workflows.grant"
+write_grant "$target" "$tmp/removed-by-this-image" "9217"
+run_seeding
+if grep -q "^executable=$real_exe$" "$target"; then ok "adopted the shipped grant"
+else bad "stale pin survived: $(sed -n 's/^executable=//p' "$target")"; fi
+
+echo "6. a module the image no longer ships loses its grant"
+setup
+target="$AIMEE_HOME/modules.d/server/gone.grant"
+write_grant "$target" "$tmp/removed-by-this-image" "9999"
+run_seeding
+[ -f "$target" ] && bad "grant for a removed module survived" || ok "stale grant removed"
+
+[ "$fail" -eq 0 ] && echo "test_module_grants: ok"
+exit "$fail"


### PR DESCRIPTION
Follow-up to the deployment validation of #2336. Closes the stage-gap that validation surfaced.

## The trap

Seeding never overwrites a persisted grant — deliberately, so an operator can tighten policy. But
that means a module which *gains* a stage cannot serve it under a grant written before that stage
existed, and the failure is **silent**: the bus refuses the kind while the daemon looks healthy.

Reproduced on a test deployment: with `serve=9217` persisted and `serve=9217,9218` shipped, workflow
control returned `503 workflow control module is not attached to the event bus` with no other signal.

## Why not just adopt the shipped list

That would trample deliberate policy — a privilege expansion, and worse than the bug.

The two cases are distinguishable if the image records what it seeded. A grant still byte-identical
to what was seeded was never touched by an operator, so replacing it restores an image default
rather than overriding a decision. Anything else keeps the warning, which now says which of the two
it decided and why.

## Notes

- Uses the `.seeded/<name>` convention `seed_managed_defaults` already uses in this file, including
  its *"already identical to the shipped default → adopt as managed"* step — so installs whose
  grants were never edited come under management rather than staying stuck forever.
- The policy loader selects entries by a `.grant` suffix, so the subdirectory is skipped rather than
  parsed. That matters: the loader rejects the **whole directory** on one bad entry.
- The shipped-grants path becomes overridable purely so the rules can be tested against a fixture.

## Verification

New `src/tests/test_module_grants.sh` (make target `module-grants-test`) runs the entrypoint's
**real** block — extracted verbatim between sentinels — over six cases: seed+record, refresh an
unmodified default, preserve an operator edit, adopt-as-managed, reconcile a vanished pin, and drop
a removed module's grant.

- **Mutation-checked**: with the adopt branch disabled, the two refresh cases fail.
- `sh -n` clean; `test_build_integrity.sh` fully green (it asserts on this entrypoint).
