### PR TITLE
WFE: keep unchanged review corrections in implementation

### DIFF
--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -491,6 +491,41 @@ func TestPartialImplementWithNoCommitDoesNotAdvance(t *testing.T) {
 	if !strings.Contains(out.Detail, "was not created by delegate") {
 		t.Fatalf("delegate's own diagnosis must survive into the step detail: %q", out.Detail)
 	}
+
+	// Existing branch work must not excuse a later partial correction attempt
+	// when the exact reviewed artifact still carries blocking feedback. Without
+	// this check the old commit made branchHasWorkOverBase true, so the unchanged
+	// retry advanced to freeze and immediately re-served the same findings.
+	workdir, _, err := manager.Ensure(ctx, child, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "implementation.go"), []byte("package implementation\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, workdir, "add", "implementation.go")
+	gitRun(t, workdir, "commit", "-m", "initial reviewed implementation")
+	child, _ = store.WorkItem(ctx, "wi_child")
+	reviewedDiff, err := frozenWorktreeDiff(ctx, child, workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewedHash := wfe.Hash([]byte(reviewedDiff))
+	verifier := &recordingVerifier{}
+	runner.verifier = verifier
+	out, err = runner.mutate(ctx, StepRequest{WorkItem: child, Node: wfe.Node{ID: "impl"},
+		Feedback: &wfe.ReviewFeedback{ArtifactHash: reviewedHash, Findings: []wfe.Finding{{
+			ID: "still-broken", Severity: "blocking", Summary: "the reviewed implementation is still broken",
+		}}}}, false)
+	if err != nil {
+		t.Fatalf("review correction mutate: %v", err)
+	}
+	if out.Status != StepChanges {
+		t.Fatalf("partial correction of unchanged reviewed artifact status=%q, want changes", out.Status)
+	}
+	if verifier.calls != 0 {
+		t.Fatalf("unchanged partial correction reached verifier: calls=%d", verifier.calls)
+	}
 }
 
 func TestDocumentPartialNoChangeAdvancesUnchangedHead(t *testing.T) {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -759,13 +759,27 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		// "no owned files changed; result treated as incomplete".
 		//
 		// So only fail when the BRANCH carries no work either. Ask the branch, not
-		// this attempt.
+		// this attempt. Review correction is stricter: an older implementation commit
+		// cannot excuse a partial retry when its current diff is still byte-identical
+		// to the artifact carrying blocking findings. That exact failure advanced
+		// wi_57186250 from impl to freeze without addressing its second review, then
+		// immediately exhausted the roundtable convergence limit.
 		// A document no-op is the requested outcome when the accepted diff is
 		// already documented. Freeze the exact unchanged HEAD so doc_freeze and
-		// doc_gate still review it; all other empty partials remain failures.
+		// doc_gate still review it; blocking review feedback overrides that exemption.
 		documentedNoop := docs && delegatePartialIsNoChange(result.Response)
-		if headErr == nil && head == baseHead && !documentedNoop &&
-			!branchHasWorkOverBase(ctx, workdir, req.WorkItem.ParentID) {
+		blockingReviewUnchanged := false
+		if headErr == nil && head == baseHead && feedbackHasBlockingFinding(req.Feedback) &&
+			req.Feedback.ArtifactHash != "" {
+			diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
+			if diffErr != nil {
+				return StepResult{}, diffErr
+			}
+			blockingReviewUnchanged = wfe.Hash([]byte(diff)) == req.Feedback.ArtifactHash
+		}
+		if headErr == nil && head == baseHead &&
+			(blockingReviewUnchanged || (!documentedNoop &&
+				!branchHasWorkOverBase(ctx, workdir, req.WorkItem.ParentID))) {
 			detail := strings.TrimSpace(result.Response)
 			if detail == "" {
 				detail = "delegate returned a partial result and produced no commit"
@@ -784,6 +798,20 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		return StepResult{}, err
 	}
 	return StepResult{Status: StepAdvanced, ArtifactType: "branch", Artifact: branch, ContentHash: head, CostUSD: cost, CostUnknown: costUnknown}, nil
+}
+
+func feedbackHasBlockingFinding(feedback *wfe.ReviewFeedback) bool {
+	if feedback == nil {
+		return false
+	}
+	for _, finding := range feedback.Findings {
+		switch strings.ToLower(strings.TrimSpace(finding.Severity)) {
+		case "suggestion", "nit":
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 func (r *NativeRunner) review(ctx context.Context, req StepRequest) (StepResult, error) {


### PR DESCRIPTION
## What changed

- Treat a partial/no-commit correction as unresolved when the frozen diff is still identical to an artifact with blocking review findings.
- Preserve legitimate no-op behavior for documentation and approved suggestion/nit feedback.
- Add a regression covering a slice that already has an implementation commit but makes no progress on later blocking feedback.

## Root cause

The partial-result guard accepted any slice with prior branch work. During a review correction, that meant an older implementation commit counted as progress even though the reviewed diff had not changed. The workflow advanced to freeze, re-served the same findings, and exhausted its roundtable convergence limit.

## Impact

Cancelled or partial correction attempts can no longer silently advance unchanged blocking work to another review round. The implementation stage remains active and can retry with the persisted diagnostics.

## Validation

- go test ./internal/engine
- go test ./...
- go vet ./...
- git diff --check