### PR TITLE
Restore frozen_diff ContentHash on freeze StepAdvanced

### DIFF
--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -374,13 +374,9 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		if artifactType == "" {
 			artifactType = block.Produces
 		}
-		artifact, artifactErr := e.artifacts.PutNodeArtifact(item.ID, node.ID, artifactType,
-			[]byte(step.Artifact))
-		if artifactErr != nil {
+		if _, artifactErr := e.artifacts.PutNodeArtifact(item.ID, node.ID, artifactType,
+			[]byte(step.Artifact)); artifactErr != nil {
 			return out, e.parkAfterSpend(ctx, item, "artifact_write_failed", artifactErr, step.CostUSD)
-		}
-		if step.ContentHash == "" {
-			step.ContentHash = artifact.Hash
 		}
 	}
 	switch step.Status {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1042,7 +1042,7 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 			return StepResult{}, err
 		}
 	}
-	return StepResult{Status: StepAdvanced, ArtifactType: "frozen_diff", Artifact: diff}, nil
+	return StepResult{Status: StepAdvanced, ArtifactType: "frozen_diff", Artifact: diff, ContentHash: wfe.Hash([]byte(diff))}, nil
 }
 
 func freezeBase(ctx context.Context, item db1.WorkItem, workdir string) (string, error) {


### PR DESCRIPTION
## Slice outcome

Restore frozen_diff ContentHash on freeze StepAdvanced

## What changed

- native_runner.go freeze() returns a StepResult whose ContentHash equals wfe.Hash([]byte(diff)) for non-empty diffs; engine no longer relies on an engine-side recompute to populate the work item's ContentHash; existing merge correctness checks that key off ContentHash see the same value as before.

### Files in this PR

- Updated `server-go/internal/engine/engine.go`.
- Updated `server-go/internal/engine/native_runner.go`.

### Representative concrete edits

- `server-go/internal/engine/native_runner.go`: changed `return StepResult{Status: StepAdvanced, ArtifactType: "frozen_diff", Artifact: diff}, nil` to `return StepResult{Status: StepAdvanced, ArtifactType: "frozen_diff", Artifact: diff, ContentHash: wfe.Hash([]byte(diff))}, nil`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/engine.go        | 8 ++------
 server-go/internal/engine/native_runner.go | 2 +-
 2 files changed, 3 insertions(+), 7 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.0`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.0` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p1","summary":"Restore frozen_diff ContentHash on freeze StepAdvanced","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["native_runner.go freeze() returns a StepResult whose ContentHash equals wfe.Hash([]byte(diff)) for non-empty diffs; engine no longer relies on an engine-side recompute to populate the work item's ContentHash; existing merge correctness checks that key off ContentHash see the same value as before."]}

</details>