### PR TITLE
Fail closed when NativeRunner has no workflow registry during freeze collision check

### DIFF
--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -113,6 +113,12 @@ func (r *NativeRunner) rejectDivergentSiblingCreates(ctx context.Context, item d
 	if r.db == nil || r.artifacts == nil {
 		return nil
 	}
+	if r.workflows == nil {
+		// A workflow-less runner cannot determine which sibling stages are
+		// frozen vs. transient, so sibling collision detection cannot run.
+		// Fail closed: a colliding create must not be silently allowed.
+		return errors.New("workflow registry is required for sibling freeze collision inspection")
+	}
 	creates, err := freezeCreatedFiles(ctx, workdir, base, head)
 	if err != nil {
 		return err

--- a/server-go/internal/engine/freeze_collision_test.go
+++ b/server-go/internal/engine/freeze_collision_test.go
@@ -214,3 +214,34 @@ func TestRejectDivergentSiblingCreatesStillRejectsWithWorktree(t *testing.T) {
 		t.Fatalf("expected %s error, got: %v", freezeCreateCreateCollision, err)
 	}
 }
+
+// TestRejectDivergentSiblingCreatesFailsClosedWithoutWorkflowRegistry proves the
+// fail-closed invariant: a NativeRunner constructed without a workflow registry
+// must surface a non-nil error from rejectDivergentSiblingCreates when the
+// current slice would otherwise need a sibling-collision check. A silent return
+// would let colliding sibling freezes pass undetected.
+func TestRejectDivergentSiblingCreatesFailsClosedWithoutWorkflowRegistry(t *testing.T) {
+	ctx, store, artifacts, _, _, slicedir, base, _ := setupFreezeCollisionHarness(t)
+
+	if err := os.WriteFile(filepath.Join(slicedir, "frozen.txt"), []byte("conflicting slice blob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, slicedir, "add", "frozen.txt")
+	gitRun(t, slicedir, "commit", "-m", "divergent create")
+	currentHead := strings.TrimSpace(gitRun(t, slicedir, "rev-parse", "HEAD"))
+
+	item, err := store.WorkItem(ctx, "wi_s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately omit workflows: the runner cannot inspect sibling workflow
+	// stages, so the collision check must fail closed rather than pass silently.
+	runner := &NativeRunner{db: store, artifacts: artifacts}
+	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	if err == nil {
+		t.Fatal("expected workflow-registry error from workflow-less runner, got nil")
+	}
+	if !strings.Contains(err.Error(), "workflow registry is required") {
+		t.Fatalf("expected workflow-registry-required error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Slice outcome

Fail closed when NativeRunner has no workflow registry during freeze collision check

## What changed

- When r.workflows is nil, rejectDivergentSiblingCreates returns an error (or the construction site asserts the precondition) instead of silently skipping collision detection; colliding freezes cannot pass undetected in a workflow-less runner.

### Files in this PR

- Updated `server-go/internal/engine/freeze_collision.go`.
- Updated `server-go/internal/engine/freeze_collision_test.go`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/freeze_collision.go      |  6 +++++
 server-go/internal/engine/freeze_collision_test.go | 31 ++++++++++++++++++++++
 2 files changed, 37 insertions(+)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.2`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.2` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p3","summary":"Fail closed when NativeRunner has no workflow registry during freeze collision check","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["When r.workflows is nil, rejectDivergentSiblingCreates returns an error (or the construction site asserts the precondition) instead of silently skipping collision detection; colliding freezes cannot pass undetected in a workflow-less runner."]}

</details>