### PR TITLE
Consolidate freeze base+diff computation and remove legacy frozenWorktreeDiff

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -542,7 +542,17 @@ func documentDelegatePrompt(ctx context.Context, req StepRequest, workdir string
 	if err != nil {
 		return "", err
 	}
-	acceptedDiff, err := frozenWorktreeDiff(ctx, workdir, base)
+	resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)
+	if err != nil {
+		return "", err
+	}
+	resolvedBase = strings.TrimSpace(resolvedBase)
+	head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	head = strings.TrimSpace(head)
+	acceptedDiff, err := frozenWorktreeDiff(ctx, workdir, resolvedBase, head)
 	if err != nil {
 		return "", err
 	}
@@ -599,7 +609,17 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 		if baseErr != nil {
 			return StepResult{}, baseErr
 		}
-		diff, diffErr := frozenWorktreeDiff(ctx, workdir, base)
+		resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)
+		if err != nil {
+			return StepResult{}, err
+		}
+		resolvedBase = strings.TrimSpace(resolvedBase)
+		head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
+		if err != nil {
+			return StepResult{}, err
+		}
+		head = strings.TrimSpace(head)
+		diff, diffErr := frozenWorktreeDiff(ctx, workdir, resolvedBase, head)
 		if diffErr != nil {
 			return StepResult{}, diffErr
 		}
@@ -1029,7 +1049,7 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		return StepResult{}, err
 	}
 	head = strings.TrimSpace(head)
-	diff, err := frozenWorktreeDiff(ctx, workdir, base)
+	diff, err := frozenWorktreeDiff(ctx, workdir, resolvedBase, head)
 	if err != nil {
 		return StepResult{}, err
 	}
@@ -1073,13 +1093,14 @@ func freezeBase(ctx context.Context, item db1.WorkItem, workdir string) (string,
 	return "origin/" + trunk, nil
 }
 
-// frozenWorktreeDiff computes the merged diff between a resolved base ref and
-// HEAD for the given workdir. Base resolution (parent feature tip vs origin
-// trunk) lives in freezeBase; this helper is the single seam that turns that
-// ref into a diff, used by freeze() and by callers that need the accepted diff
-// (documentDelegatePrompt, the review-correctness path in mutate).
-func frozenWorktreeDiff(ctx context.Context, workdir, base string) (string, error) {
-	diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"...HEAD")
+// frozenWorktreeDiff computes the merged diff between two resolved commit
+// SHAs in the given workdir. Base resolution (parent feature tip vs origin
+// trunk) lives in freezeBase; each caller rev-parses both ends before
+// invoking this helper so the diff, the validation, and the recorded commit
+// artifacts all describe the same snapshot. Used by freeze(),
+// documentDelegatePrompt, and the review-correctness path in mutate.
+func frozenWorktreeDiff(ctx context.Context, workdir, base, head string) (string, error) {
+	diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"..."+head)
 	if err != nil {
 		return "", err
 	}

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -538,7 +538,11 @@ func (r *NativeRunner) branchOpen(ctx context.Context, req StepRequest) (StepRes
 // name alone invites the delegate to mine unrelated history for undocumented
 // changes and expand the final PR after acceptance.
 func documentDelegatePrompt(ctx context.Context, req StepRequest, workdir string) (string, error) {
-	acceptedDiff, err := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
+	base, err := freezeBase(ctx, req.WorkItem, workdir)
+	if err != nil {
+		return "", err
+	}
+	acceptedDiff, err := frozenWorktreeDiff(ctx, workdir, base)
 	if err != nil {
 		return "", err
 	}
@@ -591,7 +595,11 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	// bypass review, and feedback left by an earlier gate cannot trigger it.
 	if docs && req.Feedback != nil && req.WorkItem.ContentHash != "" &&
 		req.WorkItem.ContentHash == req.Feedback.ArtifactHash {
-		diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
+		base, baseErr := freezeBase(ctx, req.WorkItem, workdir)
+		if baseErr != nil {
+			return StepResult{}, baseErr
+		}
+		diff, diffErr := frozenWorktreeDiff(ctx, workdir, base)
 		if diffErr != nil {
 			return StepResult{}, diffErr
 		}
@@ -1011,24 +1019,24 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 	if err != nil {
 		return StepResult{}, err
 	}
-	base, err = gitText(ctx, workdir, "rev-parse", base)
+	resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)
 	if err != nil {
 		return StepResult{}, err
 	}
-	base = strings.TrimSpace(base)
+	resolvedBase = strings.TrimSpace(resolvedBase)
 	head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
 	if err != nil {
 		return StepResult{}, err
 	}
 	head = strings.TrimSpace(head)
-	diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"..."+head)
+	diff, err := frozenWorktreeDiff(ctx, workdir, base)
 	if err != nil {
 		return StepResult{}, err
 	}
 	if strings.TrimSpace(diff) == "" {
 		return StepResult{Status: StepAccepted, Detail: "no-op: empty diff vs base"}, nil
 	}
-	if err := r.rejectDivergentSiblingCreates(ctx, item, workdir, base, head); err != nil {
+	if err := r.rejectDivergentSiblingCreates(ctx, item, workdir, resolvedBase, head); err != nil {
 		return StepResult{Status: StepFailed, Detail: err.Error()}, nil
 	}
 	if r.artifacts != nil && req.Node.ID != "" {
@@ -1038,7 +1046,7 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-head", "commit", []byte(head)); err != nil {
 			return StepResult{}, err
 		}
-		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-base", "commit", []byte(base)); err != nil {
+		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-base", "commit", []byte(resolvedBase)); err != nil {
 			return StepResult{}, err
 		}
 	}
@@ -1065,11 +1073,12 @@ func freezeBase(ctx context.Context, item db1.WorkItem, workdir string) (string,
 	return "origin/" + trunk, nil
 }
 
-func frozenWorktreeDiff(ctx context.Context, item db1.WorkItem, workdir string) (string, error) {
-	base, err := freezeBase(ctx, item, workdir)
-	if err != nil {
-		return "", err
-	}
+// frozenWorktreeDiff computes the merged diff between a resolved base ref and
+// HEAD for the given workdir. Base resolution (parent feature tip vs origin
+// trunk) lives in freezeBase; this helper is the single seam that turns that
+// ref into a diff, used by freeze() and by callers that need the accepted diff
+// (documentDelegatePrompt, the review-correctness path in mutate).
+func frozenWorktreeDiff(ctx context.Context, workdir, base string) (string, error) {
 	diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"...HEAD")
 	if err != nil {
 		return "", err
@@ -2323,3 +2332,4 @@ func validateStructured(kind string, doc []byte) error {
 	}
 	return nil
 }
+test

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -2332,4 +2332,3 @@ func validateStructured(kind string, doc []byte) error {
 	}
 	return nil
 }
-test

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -538,21 +538,7 @@ func (r *NativeRunner) branchOpen(ctx context.Context, req StepRequest) (StepRes
 // name alone invites the delegate to mine unrelated history for undocumented
 // changes and expand the final PR after acceptance.
 func documentDelegatePrompt(ctx context.Context, req StepRequest, workdir string) (string, error) {
-	base, err := freezeBase(ctx, req.WorkItem, workdir)
-	if err != nil {
-		return "", err
-	}
-	resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)
-	if err != nil {
-		return "", err
-	}
-	resolvedBase = strings.TrimSpace(resolvedBase)
-	head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
-	if err != nil {
-		return "", err
-	}
-	head = strings.TrimSpace(head)
-	acceptedDiff, err := frozenWorktreeDiff(ctx, workdir, resolvedBase, head)
+	_, _, acceptedDiff, err := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
 	if err != nil {
 		return "", err
 	}
@@ -605,21 +591,7 @@ func (r *NativeRunner) mutate(ctx context.Context, req StepRequest, docs bool) (
 	// bypass review, and feedback left by an earlier gate cannot trigger it.
 	if docs && req.Feedback != nil && req.WorkItem.ContentHash != "" &&
 		req.WorkItem.ContentHash == req.Feedback.ArtifactHash {
-		base, baseErr := freezeBase(ctx, req.WorkItem, workdir)
-		if baseErr != nil {
-			return StepResult{}, baseErr
-		}
-		resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)
-		if err != nil {
-			return StepResult{}, err
-		}
-		resolvedBase = strings.TrimSpace(resolvedBase)
-		head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
-		if err != nil {
-			return StepResult{}, err
-		}
-		head = strings.TrimSpace(head)
-		diff, diffErr := frozenWorktreeDiff(ctx, workdir, resolvedBase, head)
+		_, _, diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)
 		if diffErr != nil {
 			return StepResult{}, diffErr
 		}
@@ -1035,21 +1007,7 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		return StepResult{}, err
 	}
 
-	base, err := freezeBase(ctx, item, workdir)
-	if err != nil {
-		return StepResult{}, err
-	}
-	resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)
-	if err != nil {
-		return StepResult{}, err
-	}
-	resolvedBase = strings.TrimSpace(resolvedBase)
-	head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
-	if err != nil {
-		return StepResult{}, err
-	}
-	head = strings.TrimSpace(head)
-	diff, err := frozenWorktreeDiff(ctx, workdir, resolvedBase, head)
+	resolvedBase, head, diff, err := frozenWorktreeDiff(ctx, item, workdir)
 	if err != nil {
 		return StepResult{}, err
 	}
@@ -1093,18 +1051,28 @@ func freezeBase(ctx context.Context, item db1.WorkItem, workdir string) (string,
 	return "origin/" + trunk, nil
 }
 
-// frozenWorktreeDiff computes the merged diff between two resolved commit
-// SHAs in the given workdir. Base resolution (parent feature tip vs origin
-// trunk) lives in freezeBase; each caller rev-parses both ends before
-// invoking this helper so the diff, the validation, and the recorded commit
-// artifacts all describe the same snapshot. Used by freeze(),
-// documentDelegatePrompt, and the review-correctness path in mutate.
-func frozenWorktreeDiff(ctx context.Context, workdir, base, head string) (string, error) {
-	diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"..."+head)
+// frozenWorktreeDiff resolves the immutable base and HEAD snapshots and computes
+// the merged diff between them.
+func frozenWorktreeDiff(ctx context.Context, item db1.WorkItem, workdir string) (string, string, string, error) {
+	base, err := freezeBase(ctx, item, workdir)
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
-	return diff, nil
+	resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)
+	if err != nil {
+		return "", "", "", err
+	}
+	resolvedBase = strings.TrimSpace(resolvedBase)
+	head, err := gitText(ctx, workdir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", "", "", err
+	}
+	head = strings.TrimSpace(head)
+	diff, err := gitText(ctx, workdir, "--no-pager", "diff", resolvedBase+"..."+head)
+	if err != nil {
+		return "", "", "", err
+	}
+	return resolvedBase, head, diff, nil
 }
 
 type panelFinding struct {


### PR DESCRIPTION
## Slice outcome

Consolidate freeze base+diff computation and remove legacy frozenWorktreeDiff

## What changed

- native_runner.go freeze() uses a single source of truth for base resolution and diff computation (either calling frozenWorktreeDiff or an equivalent helper, not duplicating it inline); frozenWorktreeDiff is deleted if no longer used, with no dead code remaining.

### Files in this PR

- Updated `server-go/internal/engine/native_runner.go`.

### Representative concrete edits

- `server-go/internal/engine/native_runner.go`: changed `acceptedDiff, err := frozenWorktreeDiff(ctx, req.WorkItem, workdir)` to `_, _, acceptedDiff, err := frozenWorktreeDiff(ctx, req.WorkItem, workdir)`.
- `server-go/internal/engine/native_runner.go`: changed `diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)` to `_, _, diff, diffErr := frozenWorktreeDiff(ctx, req.WorkItem, workdir)`.
- `server-go/internal/engine/native_runner.go`: changed `if err := r.rejectDivergentSiblingCreates(ctx, item, workdir, base, head); err != nil {` to `if err := r.rejectDivergentSiblingCreates(ctx, item, workdir, resolvedBase, head); err != nil {`.
- `server-go/internal/engine/native_runner.go`: changed `if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-base", "commit", []byte(base)); err != nil {` to `if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-base", "commit", []byte(resolvedBase)); err != nil {`.
- `server-go/internal/engine/native_runner.go`: changed `func frozenWorktreeDiff(ctx context.Context, item db1.WorkItem, workdir string) (string, error) {` to `// frozenWorktreeDiff resolves the immutable base and HEAD snapshots and computes // the merged diff between them. func frozenWorktreeDiff(ctx context.Context, item db1.WorkItem, workdir string) (string, string, string, error) {`.
- `server-go/internal/engine/native_runner.go`: changed `return "", err` to `return "", "", "", err`.
- `server-go/internal/engine/native_runner.go`: changed `diff, err := gitText(ctx, workdir, "--no-pager", "diff", base+"...HEAD")` to `resolvedBase, err := gitText(ctx, workdir, "rev-parse", base)`.
- `server-go/internal/engine/native_runner.go`: changed `return diff, nil` to `return resolvedBase, head, diff, nil`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/native_runner.go | 46 ++++++++++++++----------------
 1 file changed, 22 insertions(+), 24 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.3`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.3` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p4","summary":"Consolidate freeze base+diff computation and remove legacy frozenWorktreeDiff","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["native_runner.go freeze() uses a single source of truth for base resolution and diff computation (either calling frozenWorktreeDiff or an equivalent helper, not duplicating it inline); frozenWorktreeDiff is deleted if no longer used, with no dead code remaining."]}

</details>