### PR TITLE
Update rootCompletionLock doc comments for freeze-under-lock semantics

### DIFF
--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -105,10 +105,13 @@ type Engine struct {
 }
 
 // rootCompletionLock returns the existing short per-root serialization lock.
-// Capped work uses it after a runner completes to order accounting and lifecycle
-// commits. Freeze acquires the same lock before inspecting sibling state and
-// holds it through artifact publication and Move, making compare-and-record
-// atomic without introducing a second parent-lock implementation.
+// Freeze acquires the same lock before invoking its runner and holds it through
+// the freeze runner and its artifact writes (publication and Move), so that the
+// freeze runner plus its artifact writes execute atomically with respect to
+// sibling completion work and no second parent-lock implementation is needed.
+// Capped-work runners are intentionally invoked outside this lock — the lock is
+// only taken once the capped runner returns, to order the actual-cost
+// reconciliation and lifecycle commit per root.
 func (e *Engine) rootCompletionLock(rootID string) *sync.Mutex {
 	e.budgetMu.Lock()
 	defer e.budgetMu.Unlock()
@@ -260,9 +263,11 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 	// terminal transition happening to move the row off 'reserved' first.
 	close(stopHeartbeat)
 	<-heartbeatDone
-	// Runner calls are deliberately outside this lock. Atomic durable reservation
-	// permits capped siblings to execute concurrently; only the short actual-cost
-	// reconciliation and lifecycle commit remain ordered per root.
+	// Freeze holds completionLock across its runner and artifact writes (set up
+	// above); here we only need to take it for capped-work reconciliation and
+	// lifecycle commit, which intentionally run outside the runner call so that
+	// capped siblings can execute concurrently while only the short accounting
+	// step remains ordered per root.
 	if budget.MaxUSD > 0 && !completionLocked {
 		completionLock = e.rootCompletionLock(budget.RootID)
 		completionLock.Lock()


### PR DESCRIPTION
## Slice outcome

Update rootCompletionLock doc comments for freeze-under-lock semantics

## What changed

- engine.go rootCompletionLock and surrounding budget-lock comments accurately state that the freeze runner and its artifact writes run under the lock while capped-work runners remain outside it; no stale 'Runner calls are deliberately outside this lock' wording remains.

### Files in this PR

- Updated `server-go/internal/engine/engine.go`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/engine.go | 19 ++++++++++++-------
 1 file changed, 12 insertions(+), 7 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.5`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.sfe2231f023.g1.5` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p6","summary":"Update rootCompletionLock doc comments for freeze-under-lock semantics","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["engine.go rootCompletionLock and surrounding budget-lock comments accurately state that the freeze runner and its artifact writes run under the lock while capped-work runners remain outside it; no stale 'Runner calls are deliberately outside this lock' wording remains."]}

</details>