### PR TITLE
Restore artifact-hash fallback so non-freeze runners populate step.ContentHash

### DIFF
--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -379,9 +379,18 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		if artifactType == "" {
 			artifactType = block.Produces
 		}
-		if _, artifactErr := e.artifacts.PutNodeArtifact(item.ID, node.ID, artifactType,
-			[]byte(step.Artifact)); artifactErr != nil {
+		written, artifactErr := e.artifacts.PutNodeArtifact(item.ID, node.ID, artifactType,
+			[]byte(step.Artifact))
+		if artifactErr != nil {
 			return out, e.parkAfterSpend(ctx, item, "artifact_write_failed", artifactErr, step.CostUSD)
+		}
+		// Non-freeze runners commonly leave StepResult.ContentHash empty; the
+		// store's hash is derived from the bytes we just persisted, so adopt it
+		// whenever the runner did not pre-populate the field. Freeze already
+		// computes the same hash in its pre-write under the completion lock, so
+		// for freeze the value is identical and re-applying it here is a no-op.
+		if step.ContentHash == "" {
+			step.ContentHash = written.Hash
 		}
 	}
 	switch step.Status {


### PR DESCRIPTION
## Slice outcome

Restore artifact-hash fallback so non-freeze runners populate step.ContentHash

## What changed

- engine.go: step.ContentHash is set from the Artifact returned by PutNodeArtifact whenever the runner's StepResult.ContentHash is empty, matching the prior fallback behavior.
- The freeze runner's pre-write of freeze artifacts inside freeze() under the completion lock is preserved unchanged so the engine-side write for the freeze block remains redundant but harmless.
- Non-freeze StepAdvanced runner paths that return an Artifact without ContentHash now persist a non-empty step.ContentHash, restoring correct downstream Move/Finish and feedback correlation.
- Existing freeze behavior, sibling merge behavior, and content-merge-conflict-as-terminal tests continue to pass.

### Files in this PR

- Updated `server-go/internal/engine/engine.go`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/engine.go | 13 +++++++++++--
 1 file changed, 11 insertions(+), 2 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s4585f46a57.g2.1`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s4585f46a57.g2.1` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p2","summary":"Restore artifact-hash fallback so non-freeze runners populate step.ContentHash","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["engine.go: step.ContentHash is set from the Artifact returned by PutNodeArtifact whenever the runner's StepResult.ContentHash is empty, matching the prior fallback behavior.","The freeze runner's pre-write of freeze artifacts inside freeze() under the completion lock is preserved unchanged so the engine-side write for the freeze block remains redundant but harmless.","Non-freeze StepAdvanced runner paths that return an Artifact without ContentHash now persist a non-empty step.ContentHash, restoring correct downstream Move/Finish and feedback correlation.","Existing freeze behavior, sibling merge behavior, and content-merge-conflict-as-terminal tests continue to pass."]}

</details>