### PR TITLE
Resolve sibling frozen-diff comparison against sibling worktree

### DIFF
--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -62,6 +62,53 @@ func frozenSiblingCreatedFiles(ctx context.Context, workdir, siblingBase, head s
 	return freezeCreatedFiles(ctx, workdir, siblingBase, head)
 }
 
+// resolveSiblingCompareDir picks a directory in which the sibling's
+// freeze-base and freeze-head commits are resolvable for the diff. When
+// sibling freezes land on a distinct worktree, those commits live behind the
+// sibling's per-worktree branch ref and are not reachable from the current
+// workdir by construction, so naively diffing against base...head in workdir
+// conflates "genuine cannot compare" with "genuine identical create" and
+// surfaces a false freeze_create_create_collision.
+//
+// We resolve the sibling's commits in two steps:
+//  1. Prefer the sibling's recorded Worktree: when it is set and points at a
+//     directory in which both commits resolve, the sibling's own branch ref
+//     makes the comparison decidable without any network or fetch.
+//  2. Otherwise try fetching the sibling's branch into the current workdir's
+//     shared bare mirror (origin) so the commits become reachable there. This
+//     covers the case where the sibling's on-disk Worktree has been pruned
+//     but the remote / mirror still holds the branch.
+//
+// When neither step exposes the commits we return an error so the caller can
+// surface the residual freezeSiblingUncomparableError (the genuine "cannot
+// compare" case) instead of a false collision rejection.
+func resolveSiblingCompareDir(ctx context.Context, sibling db1.WorkItem, workdir, siblingBase, siblingHead string) (string, error) {
+	siblingBase = strings.TrimSpace(siblingBase)
+	siblingHead = strings.TrimSpace(siblingHead)
+	if siblingBase == "" || siblingHead == "" {
+		return "", errors.New("frozen sibling is missing its base or head commit")
+	}
+	candidateSibling := strings.TrimSpace(sibling.Worktree)
+	candidateCurrent := strings.TrimSpace(workdir)
+	if candidateCurrent != "" && candidateCurrent != candidateSibling {
+		// Bring the sibling branch into the current workdir via the shared
+		// bare mirror so its commits become reachable there. Errors here are
+		// non-fatal: we fall through to the per-candidate probe below.
+		branch := "aimee/wi/" + sibling.ID
+		_, _ = gitText(ctx, candidateCurrent, "fetch", "--quiet", "origin",
+			"+refs/heads/"+branch+":refs/remotes/origin/"+branch)
+	}
+	for _, dir := range []string{candidateSibling, candidateCurrent} {
+		if dir == "" {
+			continue
+		}
+		if _, err := gitText(ctx, dir, "diff", "--name-only", siblingBase+"..."+siblingHead); err == nil {
+			return dir, nil
+		}
+	}
+	return "", errors.New("sibling freeze commits are not reachable from the sibling's worktree or the current workdir")
+}
+
 // siblingStageHasFrozenDiff distinguishes a durable freeze from both an orphan
 // marker (process death after writing the artifact but before Move) and a stale
 // marker after a review/CI loop returned the sibling to implementation.
@@ -214,7 +261,12 @@ func (r *NativeRunner) rejectDivergentSiblingCreates(ctx context.Context, item d
 		if baseArtifact.Type != "commit" {
 			return freezeSiblingUncomparableError(item.ID, sibling.ID, freezeUncomparablePathIdentifier(creates), nil)
 		}
-		siblingCreates, err := frozenSiblingCreatedFiles(ctx, workdir,
+		siblingDir, err := resolveSiblingCompareDir(ctx, sibling, workdir,
+			string(baseArtifact.Content), string(headArtifact.Content))
+		if err != nil {
+			return freezeSiblingUncomparableError(item.ID, sibling.ID, freezeUncomparablePathIdentifier(creates), err)
+		}
+		siblingCreates, err := frozenSiblingCreatedFiles(ctx, siblingDir,
 			string(baseArtifact.Content), string(headArtifact.Content))
 		if err != nil {
 			return freezeSiblingUncomparableError(item.ID, sibling.ID, freezeUncomparablePathIdentifier(creates), err)

--- a/server-go/internal/engine/freeze_collision_test.go
+++ b/server-go/internal/engine/freeze_collision_test.go
@@ -381,7 +381,11 @@ func TestRejectDivergentSiblingCreatesAllowsIdenticalCreateFromDistinctSiblingWo
 	// slicedir. This is the production layout for two simultaneous sibling
 	// slices whose durable Worktrees live behind separate git directory
 	// boundaries — slicedir cannot see the sibling-only objects.
-	siblingDir := filepath.Join(t.TempDir(), "sibling")
+	root := t.TempDir()
+	siblingDir := filepath.Join(root, "sibling")
+	if err := os.MkdirAll(siblingDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	gitRun(t, siblingDir, "clone", repo, ".")
 	gitRun(t, siblingDir, "checkout", "-q", "-B", "aimee/wi/wi_s0", base)
 	if err := os.WriteFile(filepath.Join(siblingDir, "frozen.txt"), []byte("frozen sibling blob\n"), 0o600); err != nil {
@@ -430,7 +434,11 @@ func TestRejectDivergentSiblingCreatesStillRejectsDivergenceFromDistinctSiblingW
 
 	// Sibling frozen in a clone of the repo so the post-clone sibling-only
 	// commits are unreachable from the current slicedir.
-	siblingDir := filepath.Join(t.TempDir(), "sibling")
+	root := t.TempDir()
+	siblingDir := filepath.Join(root, "sibling")
+	if err := os.MkdirAll(siblingDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	gitRun(t, siblingDir, "clone", repo, ".")
 	gitRun(t, siblingDir, "checkout", "-q", "-B", "aimee/wi/wi_s0", base)
 	if err := os.WriteFile(filepath.Join(siblingDir, "frozen.txt"), []byte("frozen sibling blob\n"), 0o600); err != nil {

--- a/server-go/internal/engine/freeze_collision_test.go
+++ b/server-go/internal/engine/freeze_collision_test.go
@@ -364,3 +364,105 @@ func TestRejectDivergentSiblingCreatesFailsClosedWithoutWorkflowRegistry(t *test
 		t.Fatalf("expected workflow-registry-required error, got: %v", err)
 	}
 }
+
+// TestRejectDivergentSiblingCreatesAllowsIdenticalCreateFromDistinctSiblingWorktree
+// exercises the case the false-positive rejection guarded against: the sibling
+// was frozen on its OWN worktree (so the sibling's commits are reachable from
+// the sibling's recorded Worktree, not from the current workdir). When the
+// current slice creates the same file with the same blob, the resolver must
+// resolve the sibling's commits against the sibling's worktree so the diff
+// succeeds and the identical create is allowed.
+func TestRejectDivergentSiblingCreatesAllowsIdenticalCreateFromDistinctSiblingWorktree(t *testing.T) {
+	ctx, store, artifacts, registry, repo, slicedir, base, _ := setupFreezeCollisionHarness(t)
+
+	// Put the sibling's frozen commits in a clone of the repo so the commits
+	// are reachable from the sibling's recorded Worktree but the
+	// post-clone sibling-only commits are not reachable from the current
+	// slicedir. This is the production layout for two simultaneous sibling
+	// slices whose durable Worktrees live behind separate git directory
+	// boundaries — slicedir cannot see the sibling-only objects.
+	siblingDir := filepath.Join(t.TempDir(), "sibling")
+	gitRun(t, siblingDir, "clone", repo, ".")
+	gitRun(t, siblingDir, "checkout", "-q", "-B", "aimee/wi/wi_s0", base)
+	if err := os.WriteFile(filepath.Join(siblingDir, "frozen.txt"), []byte("frozen sibling blob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, siblingDir, "add", "frozen.txt")
+	gitRun(t, siblingDir, "commit", "-m", "frozen create")
+	siblingHead := strings.TrimSpace(gitRun(t, siblingDir, "rev-parse", "HEAD"))
+
+	if _, err := artifacts.PutNodeArtifact("wi_s0", "freeze-head", "commit", []byte(siblingHead)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := artifacts.PutNodeArtifact("wi_s0", "freeze-base", "commit", []byte(base)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetWorktree(ctx, "wi_s0", siblingDir); err != nil {
+		t.Fatal(err)
+	}
+
+	gitRun(t, slicedir, "checkout", "-q", "-B", "aimee/wi/wi_child", base)
+	if err := os.WriteFile(filepath.Join(slicedir, "frozen.txt"), []byte("frozen sibling blob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, slicedir, "add", "frozen.txt")
+	gitRun(t, slicedir, "commit", "-m", "identical create")
+	currentHead := strings.TrimSpace(gitRun(t, slicedir, "rev-parse", "HEAD"))
+
+	item, err := store.WorkItem(ctx, "wi_s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+		t.Fatalf("identical create on distinct sibling worktree should pass, got: %v", err)
+	}
+}
+
+// TestRejectDivergentSiblingCreatesStillRejectsDivergenceFromDistinctSiblingWorktree
+// guards the regression-sensitive behavior: when the sibling has its own
+// worktree AND the current slice creates the same file with a different
+// blob, the function must still raise freezeCreateCreateCollision. The
+// sibling-worktree resolution path is only meant to make the comparison
+// decidable, not to disable divergence rejection.
+func TestRejectDivergentSiblingCreatesStillRejectsDivergenceFromDistinctSiblingWorktree(t *testing.T) {
+	ctx, store, artifacts, registry, repo, slicedir, base, _ := setupFreezeCollisionHarness(t)
+
+	// Sibling frozen in a clone of the repo so the post-clone sibling-only
+	// commits are unreachable from the current slicedir.
+	siblingDir := filepath.Join(t.TempDir(), "sibling")
+	gitRun(t, siblingDir, "clone", repo, ".")
+	gitRun(t, siblingDir, "checkout", "-q", "-B", "aimee/wi/wi_s0", base)
+	if err := os.WriteFile(filepath.Join(siblingDir, "frozen.txt"), []byte("frozen sibling blob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, siblingDir, "add", "frozen.txt")
+	gitRun(t, siblingDir, "commit", "-m", "frozen create")
+	siblingHead := strings.TrimSpace(gitRun(t, siblingDir, "rev-parse", "HEAD"))
+
+	if _, err := artifacts.PutNodeArtifact("wi_s0", "freeze-head", "commit", []byte(siblingHead)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := artifacts.PutNodeArtifact("wi_s0", "freeze-base", "commit", []byte(base)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetWorktree(ctx, "wi_s0", siblingDir); err != nil {
+		t.Fatal(err)
+	}
+
+	gitRun(t, slicedir, "checkout", "-q", "-B", "aimee/wi/wi_child", base)
+	if err := os.WriteFile(filepath.Join(slicedir, "frozen.txt"), []byte("conflicting slice blob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, slicedir, "add", "frozen.txt")
+	gitRun(t, slicedir, "commit", "-m", "divergent create")
+	currentHead := strings.TrimSpace(gitRun(t, slicedir, "rev-parse", "HEAD"))
+
+	item, err := store.WorkItem(ctx, "wi_s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
+	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
+}


### PR DESCRIPTION
## Slice outcome

Resolve sibling frozen-diff comparison against sibling worktree

## What changed

- siblingCreates in server-go/internal/engine/freeze_collision.go resolves sibling base/head commits against the sibling's own recorded worktree (or a shared bare mirror / after fetching the sibling's branch) so a genuine 'cannot compare' is distinguishable from a genuine identical create whose objects happen not to be present in the current workdir
- the function no longer surfaces a false freeze_create_create_collision rejection when sibling freezes landed on distinct worktrees and the sibling's commits are not reachable from the current workdir
- freezeSiblingUncomparableError is returned only when comparison is genuinely impossible after the new resolution path is exercised

### Files in this PR

- Updated `server-go/internal/engine/freeze_collision.go`.
- Updated `server-go/internal/engine/freeze_collision_test.go`.

### Representative concrete edits

- `server-go/internal/engine/freeze_collision.go`: changed `}` to `}`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/freeze_collision.go      |  56 ++++++++++-
 server-go/internal/engine/freeze_collision_test.go | 110 +++++++++++++++++++++
 2 files changed, 164 insertions(+), 2 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.0`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.0` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p1","summary":"Resolve sibling frozen-diff comparison against sibling worktree","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["siblingCreates in server-go/internal/engine/freeze_collision.go resolves sibling base/head commits against the sibling's own recorded worktree (or a shared bare mirror / after fetching the sibling's branch) so a genuine 'cannot compare' is distinguishable from a genuine identical create whose objects happen not to be present in the current workdir","the function no longer surfaces a false freeze_create_create_collision rejection when sibling freezes landed on distinct worktrees and the sibling's commits are not reachable from the current workdir","freezeSiblingUncomparableError is returned only when comparison is genuinely impossible after the new resolution path is exercised"]}

</details>