### PR TITLE
Tighten freeze lock scope to (RootID, WorkflowName) with timeout

### DIFF
--- a/server-go/internal/engine/completion_lock_test.go
+++ b/server-go/internal/engine/completion_lock_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,7 +75,17 @@ func setupCompletionLockHarness(t *testing.T) (workflowDir string, defA, defB wf
 	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	alphaDef := []byte("name: alpha\nstart: freeze\nnodes:\n  - id: freeze\n    block: freeze\n")
+	alphaDef := []byte("name: alpha\nstart: source\nnodes:\n" +
+		"  - id: source\n" +
+		"    block: understand\n" +
+		"    next: impl\n" +
+		"  - id: impl\n" +
+		"    block: implement\n" +
+		"    in:\n      plan: source.out\n" +
+		"    next: freeze\n" +
+		"  - id: freeze\n" +
+		"    block: freeze\n" +
+		"    in:\n      branch: impl.out\n")
 	if err := os.WriteFile(filepath.Join(workflowDir, "alpha.yaml"), alphaDef, 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -110,11 +121,14 @@ func TestFreezeLockKeyedOnWorkflowName(t *testing.T) {
 	workflowDir, defA, defB, store, artifacts := setupCompletionLockHarness(t)
 
 	create := func(id, wfName, version, stage string) db1.CreateWorkItem {
-		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: "p", WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
+		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: id, WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
 		if err := store.CreateWorkItem(t.Context(), item); err != nil {
 			t.Fatal(err)
 		}
 		if err := artifacts.PutProposal(id, []byte("p")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := artifacts.PutNodeArtifact(id, "impl", "branch", []byte("head")); err != nil {
 			t.Fatal(err)
 		}
 		return item
@@ -143,12 +157,19 @@ func TestFreezeLockKeyedOnWorkflowName(t *testing.T) {
 
 	freezeErr := make(chan error, 1)
 	go func() {
-		_, err := eng.Advance(t.Context(), alphaItem.ID)
+		result, err := eng.Advance(t.Context(), alphaItem.ID)
+		if err == nil && !result.Ran {
+			stored, _ := store.WorkItem(t.Context(), alphaItem.ID)
+			events, _ := store.Events(t.Context(), alphaItem.ID, 0, 20)
+			err = fmt.Errorf("freeze did not run: result=%+v stored=%+v events=%+v", result, stored, events)
+		}
 		freezeErr <- err
 	}()
 
 	select {
 	case <-freezeRunner.started:
+	case err := <-freezeErr:
+		t.Fatalf("freeze advance returned before runner entry: %v", err)
 	case <-time.After(2 * time.Second):
 		close(freezeRunner.release)
 		t.Fatal("freeze runner never entered")
@@ -183,7 +204,10 @@ func TestFreezeLockSerializesSameWorkflow(t *testing.T) {
 	workflowDir, defA, _, store, artifacts := setupCompletionLockHarness(t)
 
 	create := func(id, wfName, version, stage string) db1.CreateWorkItem {
-		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: "p", WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
+		if _, err := artifacts.PutNodeArtifact(id, "impl", "branch", []byte("head")); err != nil {
+			t.Fatal(err)
+		}
+		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: id, WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
 		if err := store.CreateWorkItem(t.Context(), item); err != nil {
 			t.Fatal(err)
 		}
@@ -250,7 +274,10 @@ func TestFreezeLockWatchdogReleasesOnContextCancel(t *testing.T) {
 	workflowDir, defA, _, store, artifacts := setupCompletionLockHarness(t)
 
 	create := func(id, wfName, version, stage string) db1.CreateWorkItem {
-		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: "p", WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
+		if _, err := artifacts.PutNodeArtifact(id, "impl", "branch", []byte("head")); err != nil {
+			t.Fatal(err)
+		}
+		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: id, WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
 		if err := store.CreateWorkItem(t.Context(), item); err != nil {
 			t.Fatal(err)
 		}

--- a/server-go/internal/engine/completion_lock_test.go
+++ b/server-go/internal/engine/completion_lock_test.go
@@ -1,0 +1,329 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"testing"
+	"time"
+
+	"github.com/JBailes/aimee/server-go/internal/db1"
+	"github.com/JBailes/aimee/server-go/internal/wfe"
+)
+
+// hungFreezeRunner blocks inside Run until release is closed. It pins a
+// freeze runner in flight so we can observe the lock state from a parallel
+// invocation.
+type hungFreezeRunner struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (r *hungFreezeRunner) Run(ctx context.Context, req StepRequest) (StepResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	case <-ctx.Done():
+		return StepResult{}, ctx.Err()
+	}
+	select {
+	case <-r.release:
+		return StepResult{Status: StepAdvanced}, nil
+	case <-ctx.Done():
+		return StepResult{}, ctx.Err()
+	}
+}
+
+// instantRunner returns immediately on each call and signals that it ran.
+type instantRunner struct {
+	started chan struct{}
+}
+
+func (r *instantRunner) Run(ctx context.Context, req StepRequest) (StepResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	return StepResult{Status: StepAdvanced}, nil
+}
+
+// multiplexRunner dispatches Run to a per-block Runner so a single engine can
+// hold a freeze runner that hangs while a non-freeze sibling completes freely.
+type multiplexRunner struct {
+	routes map[string]Runner
+}
+
+func (m *multiplexRunner) Run(ctx context.Context, req StepRequest) (StepResult, error) {
+	r, ok := m.routes[req.Node.Block]
+	if !ok {
+		return StepResult{}, errors.New("multiplexRunner: no route for block " + req.Node.Block)
+	}
+	return r.Run(ctx, req)
+}
+
+// setupCompletionLockHarness builds a fresh engine, db, and artifact store
+// with two workflows under the same parent: "alpha" starts at freeze, "beta"
+// starts at work. The returned setup is suitable for exercises that need
+// siblings targeting different (RootID, WorkflowName) pairs.
+func setupCompletionLockHarness(t *testing.T) (workflowDir string, defA, defB *wfe.Definition, store *db1.Store, artifacts *wfe.ArtifactStore) {
+	t.Helper()
+	root := t.TempDir()
+	workflowDir = filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alphaDef := []byte("name: alpha\nstart: freeze\nnodes:\n  - id: freeze\n    block: freeze\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "alpha.yaml"), alphaDef, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	betaDef := []byte("name: beta\nstart: work\nnodes:\n  - id: work\n    block: author.proposal\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "beta.yaml"), betaDef, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var err error
+	defA, err = wfe.ParseDefinition(alphaDef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defB, err = wfe.ParseDefinition(betaDef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err = db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	artifacts, err = wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return workflowDir, defA, defB, store, artifacts
+}
+
+// TestFreezeLockKeyedOnWorkflowName verifies that a freeze on workflow "alpha"
+// does not block a sibling on workflow "beta" under the same RootID, because
+// the completion lock is now keyed on (RootID, WorkflowName).
+func TestFreezeLockKeyedOnWorkflowName(t *testing.T) {
+	workflowDir, defA, defB, store, artifacts := setupCompletionLockHarness(t)
+
+	create := func(id, wfName, version, stage string) db1.CreateWorkItem {
+		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: "p", WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
+		if err := store.CreateWorkItem(t.Context(), item); err != nil {
+			t.Fatal(err)
+		}
+		if err := artifacts.PutProposal(id, []byte("p")); err != nil {
+			t.Fatal(err)
+		}
+		return item
+	}
+	parent := db1.CreateWorkItem{ID: "wi_parent", Repo: "repo", ProposalPath: "p", WorkflowName: "alpha", WorkflowVersion: defA.Version, StartStage: "freeze"}
+	if err := store.CreateWorkItem(t.Context(), parent); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal(parent.ID, []byte("p")); err != nil {
+		t.Fatal(err)
+	}
+	alphaItem := create("wi_parent.alpha", "alpha", defA.Version, "freeze")
+	betaItem := create("wi_parent.beta", "beta", defB.Version, "work")
+
+	freezeRunner := &hungFreezeRunner{started: make(chan struct{}, 1), release: make(chan struct{})}
+	betaRunner := &instantRunner{started: make(chan struct{}, 1)}
+	multi := &multiplexRunner{routes: map[string]Runner{
+		"freeze":          freezeRunner,
+		"author.proposal": betaRunner,
+	}}
+
+	eng, err := New(store, artifacts, workflowDir, multi)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	freezeErr := make(chan error, 1)
+	go func() {
+		_, err := eng.Advance(t.Context(), alphaItem.ID)
+		freezeErr <- err
+	}()
+
+	select {
+	case <-freezeRunner.started:
+	case <-time.After(2 * time.Second):
+		close(freezeRunner.release)
+		t.Fatal("freeze runner never entered")
+	}
+
+	betaDone := make(chan error, 1)
+	go func() {
+		_, err := eng.Advance(t.Context(), betaItem.ID)
+		betaDone <- err
+	}()
+
+	select {
+	case <-betaRunner.started:
+	case <-time.After(2 * time.Second):
+		close(freezeRunner.release)
+		t.Fatal("beta sibling waited on freeze lock — keys are not split by WorkflowName")
+	}
+
+	close(freezeRunner.release)
+	if err := <-freezeErr; err != nil {
+		t.Fatalf("freeze advance error: %v", err)
+	}
+	if err := <-betaDone; err != nil {
+		t.Fatalf("beta advance error: %v", err)
+	}
+}
+
+// TestFreezeLockSerializesSameWorkflow verifies that two freezes on the same
+// (RootID, WorkflowName) still serialize. Only one freeze runner should be
+// in-flight at a time.
+func TestFreezeLockSerializesSameWorkflow(t *testing.T) {
+	workflowDir, defA, _, store, artifacts := setupCompletionLockHarness(t)
+
+	create := func(id, wfName, version, stage string) db1.CreateWorkItem {
+		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: "p", WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
+		if err := store.CreateWorkItem(t.Context(), item); err != nil {
+			t.Fatal(err)
+		}
+		if err := artifacts.PutProposal(id, []byte("p")); err != nil {
+			t.Fatal(err)
+		}
+		return item
+	}
+	parent := db1.CreateWorkItem{ID: "wi_parent", Repo: "repo", ProposalPath: "p", WorkflowName: "alpha", WorkflowVersion: defA.Version, StartStage: "freeze"}
+	if err := store.CreateWorkItem(t.Context(), parent); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal(parent.ID, []byte("p")); err != nil {
+		t.Fatal(err)
+	}
+	first := create("wi_parent.a", "alpha", defA.Version, "freeze")
+	second := create("wi_parent.b", "alpha", defA.Version, "freeze")
+
+	runner := &hungFreezeRunner{started: make(chan struct{}, 1), release: make(chan struct{})}
+	eng, err := New(store, artifacts, workflowDir, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := eng.Advance(t.Context(), first.ID)
+		firstErr <- err
+	}()
+
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		close(runner.release)
+		t.Fatal("first freeze runner never entered")
+	}
+
+	// Second caller should be blocked while the first holds the lock.
+	secondCtx, secondCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer secondCancel()
+	_, secondErr := eng.Advance(secondCtx, second.ID)
+	if secondErr == nil {
+		close(runner.release)
+		t.Fatal("second freeze runner entered while first held the lock — same-workflow serialization is broken")
+	}
+	if !errors.Is(secondErr, context.DeadlineExceeded) &&
+		!strings.Contains(secondErr.Error(), "context deadline exceeded") {
+		close(runner.release)
+		t.Fatalf("second freeze error = %v, want context.DeadlineExceeded", secondErr)
+	}
+
+	close(runner.release)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first freeze advance error: %v", err)
+	}
+}
+
+// TestFreezeLockWatchdogReleasesOnContextCancel verifies that when a freeze
+// runner never releases, a concurrent freeze invocation with a bounded
+// context surfaces the contention via the existing error path instead of
+// blocking forever, and that the lock is released so subsequent callers
+// can proceed once the stuck freeze is cleared.
+func TestFreezeLockWatchdogReleasesOnContextCancel(t *testing.T) {
+	workflowDir, defA, _, store, artifacts := setupCompletionLockHarness(t)
+
+	create := func(id, wfName, version, stage string) db1.CreateWorkItem {
+		item := db1.CreateWorkItem{ID: id, Repo: "repo", ProposalPath: "p", WorkflowName: wfName, WorkflowVersion: version, StartStage: stage, ParentID: "wi_parent"}
+		if err := store.CreateWorkItem(t.Context(), item); err != nil {
+			t.Fatal(err)
+		}
+		if err := artifacts.PutProposal(id, []byte("p")); err != nil {
+			t.Fatal(err)
+		}
+		return item
+	}
+	parent := db1.CreateWorkItem{ID: "wi_parent", Repo: "repo", ProposalPath: "p", WorkflowName: "alpha", WorkflowVersion: defA.Version, StartStage: "freeze"}
+	if err := store.CreateWorkItem(t.Context(), parent); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal(parent.ID, []byte("p")); err != nil {
+		t.Fatal(err)
+	}
+	first := create("wi_parent.a", "alpha", defA.Version, "freeze")
+	third := create("wi_parent.c", "alpha", defA.Version, "freeze")
+
+	runner := &hungFreezeRunner{started: make(chan struct{}, 1), release: make(chan struct{})}
+	eng, err := New(store, artifacts, workflowDir, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstCtx, firstCancel := context.WithCancel(t.Context())
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := eng.Advance(firstCtx, first.ID)
+		firstErr <- err
+	}()
+
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		firstCancel()
+		close(runner.release)
+		t.Fatal("freeze runner never entered")
+	}
+
+	// Second caller has a short, bounded context. The watchdog must give up
+	// rather than block forever while the first freeze holds the lock.
+	second := create("wi_parent.b", "alpha", defA.Version, "freeze")
+	secondCtx, secondCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer secondCancel()
+	secondResult, secondErr := eng.Advance(secondCtx, second.ID)
+	if secondErr == nil {
+		close(runner.release)
+		t.Fatalf("second freeze should have failed, got result=%+v", secondResult)
+	}
+	if !errors.Is(secondErr, context.DeadlineExceeded) &&
+		!strings.Contains(secondErr.Error(), "context deadline exceeded") {
+		close(runner.release)
+		t.Fatalf("second freeze error = %v, want context.DeadlineExceeded", secondErr)
+	}
+	// The runner should not have been invoked for the second caller.
+	select {
+	case <-runner.started:
+		close(runner.release)
+		t.Fatal("second freeze runner started despite the watchdog rejecting acquisition")
+	default:
+	}
+
+	// Cleanup: release the first freeze and confirm it returns.
+	close(runner.release)
+	firstCancel()
+	if err := <-firstErr; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("first freeze unexpected error: %v", err)
+	}
+
+	// Now the watchdog must have released the lock; a fresh third caller
+	// under the same (RootID, WorkflowName) should be able to acquire it.
+	thirdResult, thirdErr := eng.Advance(t.Context(), third.ID)
+	if thirdErr != nil {
+		t.Fatalf("third freeze after watchdog release failed: %v (result=%+v)", thirdErr, thirdResult)
+	}
+}

--- a/server-go/internal/engine/completion_lock_test.go
+++ b/server-go/internal/engine/completion_lock_test.go
@@ -67,7 +67,7 @@ func (m *multiplexRunner) Run(ctx context.Context, req StepRequest) (StepResult,
 // with two workflows under the same parent: "alpha" starts at freeze, "beta"
 // starts at work. The returned setup is suitable for exercises that need
 // siblings targeting different (RootID, WorkflowName) pairs.
-func setupCompletionLockHarness(t *testing.T) (workflowDir string, defA, defB *wfe.Definition, store *db1.Store, artifacts *wfe.ArtifactStore) {
+func setupCompletionLockHarness(t *testing.T) (workflowDir string, defA, defB wfe.Definition, store *db1.Store, artifacts *wfe.ArtifactStore) {
 	t.Helper()
 	root := t.TempDir()
 	workflowDir = filepath.Join(root, "workflows")

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -126,25 +126,27 @@ func (e *Engine) rootCompletionLock(rootID, workflowName string) *sync.Mutex {
 	return lock
 }
 
-// acquireCompletionLock races a sync.Mutex.Lock against ctx. The watcher ensures
-// a stuck freeze cannot hold the lock indefinitely: if ctx is cancelled or
-// reaches its deadline before Lock returns, the helper waits for the in-flight
-// Lock to complete (so the mutex is not orphaned) and then immediately releases
-// it. acquired is true only when the caller now owns the lock and must arrange
+// acquireCompletionLock races a sync.Mutex.TryLock against ctx. The
+// watchdog ensures a stuck freeze cannot hold the lock indefinitely: while
+// the mutex is contended, the helper polls against ctx and returns
+// context.Canceled / DeadlineExceeded as soon as the caller's bound elapses.
+// acquired is true only when the caller now owns the lock and must arrange
 // to Unlock it.
 func (e *Engine) acquireCompletionLock(ctx context.Context, lock *sync.Mutex) (acquired bool, err error) {
-	done := make(chan struct{})
-	go func() {
-		lock.Lock()
-		close(done)
-	}()
-	select {
-	case <-done:
+	if lock.TryLock() {
 		return true, nil
-	case <-ctx.Done():
-		<-done
-		lock.Unlock()
-		return false, ctx.Err()
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-ticker.C:
+			if lock.TryLock() {
+				return true, nil
+			}
+		}
 	}
 }
 
@@ -255,7 +257,11 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		completionLock = e.rootCompletionLock(budget.RootID, item.WorkflowName)
 		acquired, err := e.acquireCompletionLock(ctx, completionLock)
 		if err != nil {
-			return out, e.parkOnError(ctx, item, "freeze_lock_unavailable", err)
+			// Park so an operator can re-drive the freeze once the contention clears,
+			// but surface the watchdog error to the caller so it stops the
+			// delegation cleanly instead of looping on a transient rate.
+			_ = e.parkOnError(context.WithoutCancel(ctx), item, "freeze_lock_unavailable", err)
+			return out, err
 		}
 		if acquired {
 			completionLocked = true

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -104,23 +104,48 @@ type Engine struct {
 	invocationSeq uint64
 }
 
-// rootCompletionLock returns the existing short per-root serialization lock.
-// Freeze acquires the same lock before invoking its runner and holds it through
-// the freeze runner and its artifact writes (publication and Move), so that the
-// freeze runner plus its artifact writes execute atomically with respect to
-// sibling completion work and no second parent-lock implementation is needed.
-// Capped-work runners are intentionally invoked outside this lock — the lock is
-// only taken once the capped runner returns, to order the actual-cost
-// reconciliation and lifecycle commit per root.
-func (e *Engine) rootCompletionLock(rootID string) *sync.Mutex {
+// rootCompletionLock returns the existing short per-(root, workflow) serialization
+// lock. Freeze acquires the same lock before invoking its runner and holds it
+// through the freeze runner and its artifact writes (publication and Move), so
+// that the freeze runner plus its artifact writes execute atomically with respect
+// to sibling completion work and no second parent-lock implementation is needed.
+// The key is (RootID, WorkflowName) so concurrent freezes on the same workflow
+// still serialize, but a freeze in flight on one workflow cannot block non-freeze
+// peers under the same root. Capped-work runners are intentionally invoked outside
+// this lock — the lock is only taken once the capped runner returns, to order the
+// actual-cost reconciliation and lifecycle commit per (root, workflow).
+func (e *Engine) rootCompletionLock(rootID, workflowName string) *sync.Mutex {
 	e.budgetMu.Lock()
 	defer e.budgetMu.Unlock()
-	lock := e.budgetLocks[rootID]
+	key := rootID + "\x00" + workflowName
+	lock := e.budgetLocks[key]
 	if lock == nil {
 		lock = &sync.Mutex{}
-		e.budgetLocks[rootID] = lock
+		e.budgetLocks[key] = lock
 	}
 	return lock
+}
+
+// acquireCompletionLock races a sync.Mutex.Lock against ctx. The watcher ensures
+// a stuck freeze cannot hold the lock indefinitely: if ctx is cancelled or
+// reaches its deadline before Lock returns, the helper waits for the in-flight
+// Lock to complete (so the mutex is not orphaned) and then immediately releases
+// it. acquired is true only when the caller now owns the lock and must arrange
+// to Unlock it.
+func (e *Engine) acquireCompletionLock(ctx context.Context, lock *sync.Mutex) (acquired bool, err error) {
+	done := make(chan struct{})
+	go func() {
+		lock.Lock()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true, nil
+	case <-ctx.Done():
+		<-done
+		lock.Unlock()
+		return false, ctx.Err()
+	}
 }
 
 func New(db *db1.Store, artifacts *wfe.ArtifactStore, workflowDir string, runner Runner) (*Engine, error) {
@@ -227,16 +252,20 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 	var completionLock *sync.Mutex
 	completionLocked := false
 	if node.Block == "freeze" {
-		completionLock = e.rootCompletionLock(budget.RootID)
-		completionLock.Lock()
-		completionLocked = true
+		completionLock = e.rootCompletionLock(budget.RootID, item.WorkflowName)
+		acquired, err := e.acquireCompletionLock(ctx, completionLock)
+		if err != nil {
+			return out, e.parkOnError(ctx, item, "freeze_lock_unavailable", err)
+		}
+		if acquired {
+			completionLocked = true
+		}
 	}
 	defer func() {
 		if completionLocked {
 			completionLock.Unlock()
 		}
 	}()
-
 	stopHeartbeat := make(chan struct{})
 	heartbeatDone := make(chan struct{})
 	if !budget.ReplayOnly {
@@ -267,9 +296,9 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 	// above); here we only need to take it for capped-work reconciliation and
 	// lifecycle commit, which intentionally run outside the runner call so that
 	// capped siblings can execute concurrently while only the short accounting
-	// step remains ordered per root.
+	// step remains ordered per (root, workflow).
 	if budget.MaxUSD > 0 && !completionLocked {
-		completionLock = e.rootCompletionLock(budget.RootID)
+		completionLock = e.rootCompletionLock(budget.RootID, item.WorkflowName)
 		completionLock.Lock()
 		completionLocked = true
 	}


### PR DESCRIPTION
## Slice outcome

Tighten freeze lock scope to (RootID, WorkflowName) with timeout

## What changed

- the per-root completion lock in server-go/internal/engine/engine.go (around line 227-238) is keyed on (budget.RootID, WorkflowName) instead of budget.RootID alone
- non-freeze siblings remain concurrent with a freeze in flight under the new keying
- pre-runner acquisition of the freeze lock is wrapped with a context-aware timeout/watchdog so a stuck freeze cannot block peers indefinitely

### Files in this PR

- Added `server-go/internal/engine/completion_lock_test.go`.
- Updated `server-go/internal/engine/engine.go`.

### Representative concrete edits

- `server-go/internal/engine/engine.go`: changed `lock := e.budgetLocks[rootID]` to `key := rootID + "\x00" + workflowName lock := e.budgetLocks[key]`.
- `server-go/internal/engine/engine.go`: changed `e.budgetLocks[rootID] = lock` to `e.budgetLocks[key] = lock`.
- `server-go/internal/engine/engine.go`: changed `// step remains ordered per root.` to `// step remains ordered per (root, workflow).`.
- `server-go/internal/engine/engine.go`: changed `completionLock = e.rootCompletionLock(budget.RootID)` to `completionLock = e.rootCompletionLock(budget.RootID, item.WorkflowName)`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/completion_lock_test.go | 356 ++++++++++++++++++++++
 server-go/internal/engine/engine.go               |  69 +++--
 2 files changed, 408 insertions(+), 17 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.2`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.2` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p3","summary":"Tighten freeze lock scope to (RootID, WorkflowName) with timeout","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["the per-root completion lock in server-go/internal/engine/engine.go (around line 227-238) is keyed on (budget.RootID, WorkflowName) instead of budget.RootID alone","non-freeze siblings remain concurrent with a freeze in flight under the new keying","pre-runner acquisition of the freeze lock is wrapped with a context-aware timeout/watchdog so a stuck freeze cannot block peers indefinitely"]}

</details>