### PR TITLE
Preserve os.ErrNotExist through ArtifactStore.NodeArtifact read

### DIFF
--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -170,7 +170,8 @@ func freezeSiblingUncomparableError(currentSlice, siblingSlice, path string, cau
 //     allow it through on a transient store error. Integrity-validation
 //     failures (NodeArtifact wrapping "node artifact failed integrity
 //     validation") are explicitly propagated here, not silently skipped.
-//   - A missing artifact (os.ErrNotExist) returns ok=false with a nil err.
+//   - A missing artifact (os.ErrNotExist / fs.ErrNotExist, also surfaced
+//     structurally as wfe.ErrArtifactNotExist) returns ok=false with a nil err.
 //     The sibling simply is not frozen (per the durable-triple definition),
 //     so the caller skips it as the previous siblingStageHasFrozenDiff
 //     continue path did.
@@ -188,7 +189,7 @@ func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, b
 	}
 	diff, err := store.NodeArtifact(siblingID, "freeze")
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {
 			return "", "", false, nil
 		}
 		return "", "", false, err
@@ -198,7 +199,7 @@ func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, b
 	}
 	headArt, err := store.NodeArtifact(siblingID, "freeze-head")
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {
 			return "", "", false, nil
 		}
 		return "", "", false, err
@@ -208,7 +209,7 @@ func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, b
 	}
 	baseArt, err := store.NodeArtifact(siblingID, "freeze-base")
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {
 			return "", "", false, nil
 		}
 		return "", "", false, err

--- a/server-go/internal/wfe/artifacts.go
+++ b/server-go/internal/wfe/artifacts.go
@@ -18,6 +18,11 @@ var (
 	ErrInvalidWorkItem    = errors.New("invalid work-item id")
 	ErrInvalidNode        = errors.New("invalid workflow node id")
 	ErrImmutable          = errors.New("immutable artifact already has different content")
+	// ErrArtifactNotExist signals that a NodeArtifact read could not find the
+	// underlying file. It is returned through %w so callers can match it
+	// structurally via errors.Is and still unwrap to os.ErrNotExist /
+	// fs.ErrNotExist when they want to branch on any "missing" cause.
+	ErrArtifactNotExist   = errors.New("artifact does not exist")
 	workItemIDPattern     = regexp.MustCompile(`^wi_[A-Za-z0-9_.-]+$`)
 	artifactNodeIDPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
 )
@@ -252,6 +257,9 @@ func (s *ArtifactStore) read(workItemID, name string) ([]byte, error) {
 	}
 	content, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("read %s: %w: %w", name, ErrArtifactNotExist, err)
+		}
 		return nil, fmt.Errorf("read %s: %w", name, err)
 	}
 	return content, nil

--- a/server-go/internal/wfe/artifacts_test.go
+++ b/server-go/internal/wfe/artifacts_test.go
@@ -2,6 +2,8 @@ package wfe
 
 import (
 	"errors"
+	"io/fs"
+	"os"
 	"strings"
 	"testing"
 )
@@ -94,5 +96,33 @@ func TestArtifactPathsRejectTraversal(t *testing.T) {
 	}
 	if err := store.PutProposal("../escape", []byte("x")); !errors.Is(err, ErrInvalidWorkItem) {
 		t.Fatalf("path traversal error = %v, want ErrInvalidWorkItem", err)
+	}
+}
+
+// TestNodeArtifactMissingSignalsFileNotExist locks down the missing-artifact
+// contract that freeze_collision.go and other callers rely on: a NodeArtifact
+// read of an absent node artifact must surface both fs.ErrNotExist
+// (equivalently os.ErrNotExist) and the package's exported ErrArtifactNotExist
+// sentinel through errors.Is. Any future read helper that loses this chain
+// would cause the sibling-collision branch to misclassify a simply-absent
+// freeze artifact as a generic I/O error and reject the current slice.
+func TestNodeArtifactMissingSignalsFileNotExist(t *testing.T) {
+	store, err := NewArtifactStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.NodeArtifact("wi_absent", "freeze")
+	if err == nil {
+		t.Fatal("expected an error from NodeArtifact on a missing work-item")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("missing NodeArtifact error does not match fs.ErrNotExist: %v", err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing NodeArtifact error does not match os.ErrNotExist: %v", err)
+	}
+	if !errors.Is(err, ErrArtifactNotExist) {
+		t.Fatalf("missing NodeArtifact error does not match ErrArtifactNotExist: %v", err)
 	}
 }


### PR DESCRIPTION
## Slice outcome

Preserve os.ErrNotExist through ArtifactStore.NodeArtifact read

## What changed

- wfe/artifacts.go verifies that the read helper preserves os.ErrNotExist (or fs.ErrNotExist) through %w, or an exported ErrArtifactNotExist sentinel is introduced that NodeArtifact returns
- freeze_collision.go callers can match the missing-artifact branch structurally (errors.Is against the sentinel or fs.ErrNotExist)
- the missing-artifact branch in rejectDivergentSiblingCreates is taken reliably when the sibling freeze artifact is absent rather than falling into the generic error path

### Files in this PR

- Updated `server-go/internal/engine/freeze_collision.go`.
- Updated `server-go/internal/wfe/artifacts.go`.
- Updated `server-go/internal/wfe/artifacts_test.go`.

### Representative concrete edits

- `server-go/internal/engine/freeze_collision.go`: changed `// - A missing artifact (os.ErrNotExist) returns ok=false with a nil err.` to `// - A missing artifact (os.ErrNotExist / fs.ErrNotExist, also surfaced // structurally as wfe.ErrArtifactNotExist) returns ok=false with a nil err.`.
- `server-go/internal/engine/freeze_collision.go`: changed `if errors.Is(err, os.ErrNotExist) {` to `if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {`.
- `server-go/internal/engine/freeze_collision.go`: changed `if errors.Is(err, os.ErrNotExist) {` to `if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {`.
- `server-go/internal/engine/freeze_collision.go`: changed `if errors.Is(err, os.ErrNotExist) {` to `if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {`.
- `server-go/internal/engine/freeze_collision.go`: changed `}` to `}`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/freeze_collision.go | 11 +++++-----
 server-go/internal/wfe/artifacts.go           |  8 +++++++
 server-go/internal/wfe/artifacts_test.go      | 30 +++++++++++++++++++++++++++
 3 files changed, 44 insertions(+), 5 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.3`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.3` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p4","summary":"Preserve os.ErrNotExist through ArtifactStore.NodeArtifact read","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["wfe/artifacts.go verifies that the read helper preserves os.ErrNotExist (or fs.ErrNotExist) through %w, or an exported ErrArtifactNotExist sentinel is introduced that NodeArtifact returns","freeze_collision.go callers can match the missing-artifact branch structurally (errors.Is against the sentinel or fs.ErrNotExist)","the missing-artifact branch in rejectDivergentSiblingCreates is taken reliably when the sibling freeze artifact is absent rather than falling into the generic error path"]}

</details>