### PR TITLE
Export ErrFreezeCreateCreateCollision sentinel for errors.Is matching

### DIFF
--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -58,7 +58,14 @@ type StepResult struct {
 	Feedback     *wfe.ReviewFeedback `json:"feedback,omitempty"`
 	PauseReason  string              `json:"pause_reason,omitempty"`
 	Detail       string              `json:"detail,omitempty"`
-	Err         error               `json:"-"`
+	Err          error               `json:"-"`
+	// ErrKind carries a JSON-safe marker for the sentinel wrapped by Err. The
+	// HTTP runner serializes StepResult across a JSON boundary and `error` is
+	// tagged `json:"-"`, so the in-memory sentinel value cannot cross that
+	// boundary. Runners populate ErrKind with a stable identifier (e.g.
+	// freezeCreateCreateCollision) and engine.Advance rehydrates the typed
+	// sentinel from it before downstream errors.Is matching.
+	ErrKind      string              `json:"err_kind,omitempty"`
 	CostUSD      float64             `json:"cost_usd,omitempty"`
 	// CostUnknown means at least one billable call in this step produced no
 	// measurement. CostUSD is then a lower bound, so the engine must charge the
@@ -540,6 +547,13 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		return out, nil
 
 	case StepFailed:
+		// The HTTP runner serializes StepResult across a JSON boundary and Err is
+		// tagged `json:"-"`, so the in-memory sentinel cannot survive the round
+		// trip. Rehydrate the typed sentinel from ErrKind before downstream
+		// errors.Is matching.
+		if step.Err == nil && step.ErrKind == freezeCreateCreateCollision {
+			step.Err = ErrFreezeCreateCreateCollision
+		}
 		if errors.Is(step.Err, ErrFreezeCreateCreateCollision) {
 			out.Err = step.Err
 		}

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -58,6 +58,7 @@ type StepResult struct {
 	Feedback     *wfe.ReviewFeedback `json:"feedback,omitempty"`
 	PauseReason  string              `json:"pause_reason,omitempty"`
 	Detail       string              `json:"detail,omitempty"`
+	Err         error               `json:"-"`
 	CostUSD      float64             `json:"cost_usd,omitempty"`
 	// CostUnknown means at least one billable call in this step produced no
 	// measurement. CostUSD is then a lower bound, so the engine must charge the
@@ -170,6 +171,7 @@ type AdvanceResult struct {
 	NextStage   string
 	State       string
 	PauseReason string
+	Err         error `json:"-"`
 }
 
 func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult, error) {
@@ -538,6 +540,9 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		return out, nil
 
 	case StepFailed:
+		if errors.Is(step.Err, ErrFreezeCreateCreateCollision) {
+			out.Err = step.Err
+		}
 		if err := e.db.Finish(ctx, item.ID, node.ID, "rejected", step.Detail,
 			step.ContentHash, step.CostUSD); err != nil {
 			return out, err

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -1607,14 +1607,27 @@ func TestFreezeCollisionSentinelSurvivesHTTPRunnerJSONBoundary(t *testing.T) {
 	definition := []byte(`name: slice
 start: freeze
 nodes:
+  - id: source
+    block: understand
   - id: impl
     block: implement
+    in: {plan: source.out}
   - id: freeze
     block: freeze
     in: {branch: impl.out}
-    next: merge
+    next: pr
+  - id: pr
+    block: pr.open
+    in: {src: freeze.out}
+    next: ci
+  - id: ci
+    block: gate.ci
+    in: {pr: pr.out}
+    on_pass: merge
+    on_fail: impl
   - id: merge
     block: merge
+    in: {pr: pr.out}
 `)
 	if err := os.WriteFile(filepath.Join(workflowDir, "slice.yaml"), definition, 0o600); err != nil {
 		t.Fatal(err)

--- a/server-go/internal/engine/engine_test.go
+++ b/server-go/internal/engine/engine_test.go
@@ -1574,3 +1574,103 @@ nodes:
 		t.Fatalf("persisted state = %q, want rejected", item.State)
 	}
 }
+
+// freezeCollisionFromHTTPRunnerRunner returns StepFailed with ErrKind (and
+// Detail) but no Err, simulating exactly what HTTPRunner delivers after JSON
+// decode: StepResult.Err is tagged `json:"-"` so the typed sentinel cannot
+// cross that boundary, and the in-process Err value must be nil at this
+// point. engine.Advance is responsible for rehydrating the typed sentinel
+// from ErrKind before downstream errors.Is matching.
+type freezeCollisionFromHTTPRunnerRunner struct{}
+
+func (freezeCollisionFromHTTPRunnerRunner) Run(context.Context, StepRequest) (StepResult, error) {
+	return StepResult{
+		Status:  StepFailed,
+		Detail:  ErrFreezeCreateCreateCollision.Error() + ": path foo current slice wi_http conflicts with already frozen sibling slice wi_sibling",
+		ErrKind: freezeCreateCreateCollision,
+	}, nil
+}
+
+// TestFreezeCollisionSentinelSurvivesHTTPRunnerJSONBoundary is the regression
+// guard for the boundary defect: the typed freeze-create-create-collision
+// sentinel must remain detectable via errors.Is after the StepResult has
+// round-tripped through the HTTP runner's JSON encode/decode, where the
+// in-memory Err field is stripped. The marker field ErrKind survives the
+// round trip and engine.Advance rehydrates the typed sentinel before
+// propagating AdvanceResult.Err to the scheduler.
+func TestFreezeCollisionSentinelSurvivesHTTPRunnerJSONBoundary(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte(`name: slice
+start: freeze
+nodes:
+  - id: impl
+    block: implement
+  - id: freeze
+    block: freeze
+    in: {branch: impl.out}
+    next: merge
+  - id: merge
+    block: merge
+`)
+	if err := os.WriteFile(filepath.Join(workflowDir, "slice.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := artifacts.PutProposal("wi_http", []byte("proposal")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := artifacts.PutNodeArtifact("wi_http", "impl", "branch", []byte("branch-stub")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateWorkItem(context.Background(), db1.CreateWorkItem{ID: "wi_http",
+		Repo: "repo", ProposalPath: "p", WorkflowName: "slice",
+		WorkflowVersion: def.Version, StartStage: "freeze"}); err != nil {
+		t.Fatal(err)
+	}
+	eng, err := New(store, artifacts, workflowDir, freezeCollisionFromHTTPRunnerRunner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := eng.Advance(context.Background(), "wi_http")
+	if err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	if out.Err == nil {
+		t.Fatal("expected AdvanceResult.Err to be populated by rehydration, got nil")
+	}
+	if !errors.Is(out.Err, ErrFreezeCreateCreateCollision) {
+		t.Fatalf("expected errors.Is(out.Err, ErrFreezeCreateCreateCollision) to be true, got: %v", out.Err)
+	}
+	if !out.Terminal || out.State != "rejected" {
+		t.Fatalf("collision must finish the item rejected, got terminal=%v state=%q",
+			out.Terminal, out.State)
+	}
+	// Operator-facing detail survives end-to-end via the durable StepResult.Detail
+	// (passed to e.db.Finish and persisted on the rejected item), while the
+	// typed sentinel exposes errors.Is matching. The rehydrated sentinel itself
+	// only carries the collision marker text; the human-readable path/slice
+	// detail is preserved separately on StepResult.Detail, unchanged for callers.
+	item, err := store.WorkItem(context.Background(), "wi_http")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.State != "rejected" {
+		t.Fatalf("persisted state = %q, want rejected", item.State)
+	}
+}

--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -13,6 +13,12 @@ import (
 
 const freezeCreateCreateCollision = "freeze_create_create_collision"
 
+// ErrFreezeCreateCreateCollision is the typed sentinel for a freeze-vs-create
+// collision between sibling slices. Callers can detect it via errors.Is(err,
+// ErrFreezeCreateCreateCollision) instead of string-prefix matching. The
+// human-readable path/slice detail remains accessible via err.Error().
+var ErrFreezeCreateCreateCollision = errors.New(freezeCreateCreateCollision)
+
 type freezeCreate struct {
 	Path string
 	Blob string
@@ -113,7 +119,7 @@ func resolveSiblingCompareDir(ctx context.Context, sibling db1.WorkItem, workdir
 // freezeCreateCreateCollisionError reports a genuine create/create collision
 // on path between currentSlice and siblingSlice.
 func freezeCreateCreateCollisionError(path, currentSlice, siblingSlice string) error {
-	return fmt.Errorf("%s: path %s current slice %s conflicts with already frozen sibling slice %s", freezeCreateCreateCollision, path, currentSlice, siblingSlice)
+	return fmt.Errorf("%w: path %s current slice %s conflicts with already frozen sibling slice %s", ErrFreezeCreateCreateCollision, path, currentSlice, siblingSlice)
 }
 
 // freezeUncomparablePathIdentifier picks a stable path-equivalent identifier
@@ -133,9 +139,12 @@ func freezeUncomparablePathIdentifier(creates map[string]freezeCreate) string {
 
 // freezeSiblingUncomparableError reports that the sibling's durable freeze
 // artifacts (or the comparison itself) are unavailable, so the collision check
-// cannot establish whether the slices overlap. It uses the same
-// freeze_create_create_collision prefix as the genuine-collision error so a
-// caller matching on the prefix catches both. The path argument is a
+// cannot establish whether the slices overlap. It wraps
+// ErrFreezeCreateCreateCollision so callers matching the typed sentinel via
+// errors.Is catch both genuine and un-comparable shapes, and its message
+// starts with the same freeze_create_create_collision prefix as the
+// genuine-collision error so the operator-facing detail reads the same way.
+// The path argument is a
 // path-equivalent identifier drawn from the current slice's create set
 // (typically the first created path) so the error names the path the current
 // slice was creating when comparison became impossible; this satisfies the
@@ -146,11 +155,10 @@ func freezeUncomparablePathIdentifier(creates map[string]freezeCreate) string {
 // diagnostics honest. The current slice fails closed rather than silently
 // allowing a potentially colliding freeze.
 func freezeSiblingUncomparableError(currentSlice, siblingSlice, path string, cause error) error {
-	msg := fmt.Sprintf("%s: cannot compare path %s: already frozen sibling slice %s while processing current slice %s", freezeCreateCreateCollision, path, siblingSlice, currentSlice)
 	if cause == nil {
-		return errors.New(msg)
+		return fmt.Errorf("%w: cannot compare path %s: already frozen sibling slice %s while processing current slice %s", ErrFreezeCreateCreateCollision, path, siblingSlice, currentSlice)
 	}
-	return fmt.Errorf("%s: %w", msg, cause)
+	return fmt.Errorf("%w: cannot compare path %s: already frozen sibling slice %s while processing current slice %s: %w", ErrFreezeCreateCreateCollision, path, siblingSlice, currentSlice, cause)
 }
 
 // frozenSiblingArtifacts captures the three durable NodeArtifacts that

--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -15,8 +15,12 @@ const freezeCreateCreateCollision = "freeze_create_create_collision"
 
 // ErrFreezeCreateCreateCollision is the typed sentinel for a freeze-vs-create
 // collision between sibling slices. Callers can detect it via errors.Is(err,
-// ErrFreezeCreateCreateCollision) instead of string-prefix matching. The
-// human-readable path/slice detail remains accessible via err.Error().
+// ErrFreezeCreateCreateCollision) instead of string-prefix matching. In-process
+// callers receive a wrapped error whose Error() includes the path/slice detail;
+// runners crossing a JSON boundary carry the sentinel via StepResult.ErrKind
+// and engine.Advance rehydrates it so the typed match still works there. The
+// human-readable path/slice detail survives end-to-end through StepResult.Detail
+// (and the durable detail stored on rejection), unchanged for callers.
 var ErrFreezeCreateCreateCollision = errors.New(freezeCreateCreateCollision)
 
 type freezeCreate struct {

--- a/server-go/internal/engine/freeze_collision_test.go
+++ b/server-go/internal/engine/freeze_collision_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -317,6 +318,9 @@ func assertFreezeCreateCollision(t *testing.T, err error, path, currentSlice, si
 	t.Helper()
 	if err == nil {
 		t.Fatal("expected freezeCreateCreateCollision error, got nil")
+	}
+	if !errors.Is(err, ErrFreezeCreateCreateCollision) {
+		t.Fatalf("expected freeze_create_create_collision sentinel, got: %v", err)
 	}
 	for _, want := range []string{freezeCreateCreateCollision, path, currentSlice, siblingSlice} {
 		if !strings.Contains(err.Error(), want) {

--- a/server-go/internal/engine/http_runner_test.go
+++ b/server-go/internal/engine/http_runner_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,5 +43,46 @@ func TestHTTPRunnerTransfersCompleteArtifactsAndFeedback(t *testing.T) {
 	}
 	if result.Artifact != plan {
 		t.Fatal("runner response artifact was incomplete")
+	}
+}
+
+func TestHTTPRunnerTransportsErrKindForCollisionDetection(t *testing.T) {
+	// The HTTP runner decodes StepResult from JSON and StepResult.Err is tagged
+	// `json:"-"`, so the in-memory typed sentinel is stripped at the boundary.
+	// ErrKind must survive the round trip and engine.Advance must rehydrate
+	// ErrFreezeCreateCreateCollision from it for downstream errors.Is matching.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(StepResult{
+			Status:  StepFailed,
+			Detail:  ErrFreezeCreateCreateCollision.Error() + ": path foo current slice wi_s1 conflicts with already frozen sibling slice wi_s2",
+			ErrKind: freezeCreateCreateCollision,
+		})
+	}))
+	defer server.Close()
+	runner, err := NewHTTPRunner(HTTPRunnerConfig{Endpoint: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, runErr := runner.Run(t.Context(), StepRequest{})
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	if result.ErrKind != freezeCreateCreateCollision {
+		t.Fatalf("ErrKind did not survive the JSON round trip: got %q", result.ErrKind)
+	}
+	if result.Err != nil {
+		t.Fatalf("expected nil Err after JSON decode (Err is tagged `json:\"-\"`), got: %v", result.Err)
+	}
+	// Simulate engine.Advance rehydrating the sentinel from ErrKind.
+	if result.Err == nil && result.ErrKind == freezeCreateCreateCollision {
+		result.Err = ErrFreezeCreateCreateCollision
+	}
+	if !errors.Is(result.Err, ErrFreezeCreateCreateCollision) {
+		t.Fatalf("errors.Is failed after rehydration: %v", result.Err)
+	}
+	// Detail must remain accessible via Error() for operator-facing diagnostics.
+	if !strings.Contains(result.Detail, freezeCreateCreateCollision) {
+		t.Fatalf("expected detail to preserve collision marker text, got: %q", result.Detail)
 	}
 }

--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -1273,13 +1273,16 @@ func TestDocumentPartialNoChangeAdvancesUnchangedHead(t *testing.T) {
 	}
 }
 // assertFreezeSiblingUncomparable verifies that err is a freezeSiblingUncomparableError:
-// it carries the freeze_create_create_collision prefix (so callers matching on the
-// prefix catch both genuine and un-comparable shapes), names the requested path, and
-// names both the current slice and the frozen sibling slice.
+// it carries the freeze_create_create_collision sentinel (so callers matching on
+// errors.Is catch both genuine and un-comparable shapes), names the requested
+// path, and names both the current slice and the frozen sibling slice.
 func assertFreezeSiblingUncomparable(t *testing.T, err error, path, currentSlice, siblingSlice string) {
 	t.Helper()
 	if err == nil {
 		t.Fatal("expected freezeSiblingUncomparableError, got nil")
+	}
+	if !errors.Is(err, ErrFreezeCreateCreateCollision) {
+		t.Fatalf("expected freeze_create_create_collision sentinel, got: %v", err)
 	}
 	msg := err.Error()
 	for _, want := range []string{freezeCreateCreateCollision, path, currentSlice, siblingSlice} {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1020,7 +1020,7 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		return StepResult{Status: StepAccepted, Detail: "no-op: empty diff vs base"}, nil
 	}
 	if err := r.rejectDivergentSiblingCreates(ctx, item, workdir, resolvedBase, head); err != nil {
-		return StepResult{Status: StepFailed, Detail: err.Error()}, nil
+		return StepResult{Status: StepFailed, Detail: err.Error(), Err: err}, nil
 	}
 	if r.artifacts != nil && req.Node.ID != "" {
 		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID, "frozen_diff", []byte(diff)); err != nil {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1020,7 +1020,15 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		return StepResult{Status: StepAccepted, Detail: "no-op: empty diff vs base"}, nil
 	}
 	if err := r.rejectDivergentSiblingCreates(ctx, item, workdir, resolvedBase, head); err != nil {
-		return StepResult{Status: StepFailed, Detail: err.Error(), Err: err}, nil
+		// rejectDivergentSiblingCreates wraps ErrFreezeCreateCreateCollision, but
+		// StepResult.Err is tagged `json:"-"` so the sentinel does not survive an
+		// HTTP-runner round trip. Tag ErrKind so engine.Advance can rehydrate the
+		// typed sentinel on the consumer side.
+		res := StepResult{Status: StepFailed, Detail: err.Error(), Err: err}
+		if errors.Is(err, ErrFreezeCreateCreateCollision) {
+			res.ErrKind = freezeCreateCreateCollision
+		}
+		return res, nil
 	}
 	if r.artifacts != nil && req.Node.ID != "" {
 		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID, "frozen_diff", []byte(diff)); err != nil {

--- a/server-go/internal/engine/scheduler.go
+++ b/server-go/internal/engine/scheduler.go
@@ -325,6 +325,9 @@ func (s *Scheduler) drive(ctx context.Context, workItemID string) {
 			s.log.Error("advance workflow", "work_item", workItemID, "error", err)
 			return
 		}
+		if errors.Is(result.Err, ErrFreezeCreateCreateCollision) {
+			s.log.Info("freeze create collision detected", "work_item", workItemID, "error", result.Err)
+		}
 		if result.Terminal || result.Parked || !result.Ran {
 			return
 		}


### PR DESCRIPTION
## Slice outcome

Export ErrFreezeCreateCreateCollision sentinel for errors.Is matching

## What changed

- a typed sentinel `var ErrFreezeCreateCreateCollision = errors.New(freezeCreateCreateCollision)` is exported from server-go/internal/engine/freeze_collision.go
- callers in engine.Advance and the scheduler match the sentinel via errors.Is rather than string-prefix matching
- the human-readable path/slice detail remains available via the error's Detail field

### Files in this PR

- Updated `server-go/internal/engine/engine.go`.
- Updated `server-go/internal/engine/engine_test.go`.
- Updated `server-go/internal/engine/freeze_collision.go`.
- Updated `server-go/internal/engine/freeze_collision_test.go`.
- Updated `server-go/internal/engine/http_runner_test.go`.
- Updated `server-go/internal/engine/integrate_base_test.go`.
- Updated `server-go/internal/engine/native_runner.go`.
- Updated `server-go/internal/engine/scheduler.go`.

### Representative concrete edits

- `server-go/internal/engine/freeze_collision.go`: changed `return fmt.Errorf("%s: path %s current slice %s conflicts with already frozen sibling slice %s", freezeCreateCreateCollision, path, currentSlice, siblingSlice)` to `return fmt.Errorf("%w: path %s current slice %s conflicts with already frozen sibling slice %s", ErrFreezeCreateCreateCollision, path, currentSlice, siblingSlice)`.
- `server-go/internal/engine/freeze_collision.go`: changed `return errors.New(msg)` to `return fmt.Errorf("%w: cannot compare path %s: already frozen sibling slice %s while processing current slice %s", ErrFreezeCreateCreateCollision, path, siblingSlice, currentSlice)`.
- `server-go/internal/engine/freeze_collision.go`: changed `return fmt.Errorf("%s: %w", msg, cause)` to `return fmt.Errorf("%w: cannot compare path %s: already frozen sibling slice %s while processing current slice %s: %w", ErrFreezeCreateCreateCollision, path, siblingSlice, currentSlice, cause)`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/engine.go                |  19 ++++
 server-go/internal/engine/engine_test.go           | 113 +++++++++++++++++++++
 server-go/internal/engine/freeze_collision.go      |  26 +++--
 server-go/internal/engine/freeze_collision_test.go |   4 +
 server-go/internal/engine/http_runner_test.go      |  42 ++++++++
 server-go/internal/engine/integrate_base_test.go   |   9 +-
 server-go/internal/engine/native_runner.go         |  10 +-
 server-go/internal/engine/scheduler.go             |   3 +
 8 files changed, 215 insertions(+), 11 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.5`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.5` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p6","summary":"Export ErrFreezeCreateCreateCollision sentinel for errors.Is matching","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["a typed sentinel `var ErrFreezeCreateCreateCollision = errors.New(freezeCreateCreateCollision)` is exported from server-go/internal/engine/freeze_collision.go","callers in engine.Advance and the scheduler match the sentinel via errors.Is rather than string-prefix matching","the human-readable path/slice detail remains available via the error's Detail field"]}

</details>