### PR TITLE
Publish freeze artifacts when Node.ID is empty using 'freeze' producer

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1030,14 +1030,23 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		}
 		return res, nil
 	}
-	if r.artifacts != nil && req.Node.ID != "" {
-		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID, "frozen_diff", []byte(diff)); err != nil {
+	// Publish durable frozen_diff / freeze-head / freeze-base artifacts. Downstream
+	// review stages key on the literal node id "freeze" to find frozen_diff; if the
+	// workflow node id is missing here (e.g. a caller that constructs a StepRequest
+	// without populating Node), fall back to that literal so the artifact is still
+	// published under the conventional key instead of being silently skipped.
+	nodeID := req.Node.ID
+	if nodeID == "" {
+		nodeID = "freeze"
+	}
+	if r.artifacts != nil {
+		if _, err := r.artifacts.PutNodeArtifact(item.ID, nodeID, "frozen_diff", []byte(diff)); err != nil {
 			return StepResult{}, err
 		}
-		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-head", "commit", []byte(head)); err != nil {
+		if _, err := r.artifacts.PutNodeArtifact(item.ID, nodeID+"-head", "commit", []byte(head)); err != nil {
 			return StepResult{}, err
 		}
-		if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-base", "commit", []byte(resolvedBase)); err != nil {
+		if _, err := r.artifacts.PutNodeArtifact(item.ID, nodeID+"-base", "commit", []byte(resolvedBase)); err != nil {
 			return StepResult{}, err
 		}
 	}


### PR DESCRIPTION
## Slice outcome

Publish freeze artifacts when Node.ID is empty using 'freeze' producer

## What changed

- freeze in server-go/internal/engine/native_runner.go (around lines 1025-1035) either documents the invariant that req.Node.ID is required to publish durable artifacts, or falls back to the literal 'freeze' producer when Node.ID is empty so frozen_diff/freeze-head/freeze-base artifacts are still published
- TestFreezeUsesMergedRemoteFeatureTip continues to pass
- downstream review stages that read by producer='freeze' see the frozen_diff artifact regardless of whether Node.ID was supplied

### Files in this PR

- Updated `server-go/internal/engine/native_runner.go`.

### Representative concrete edits

- `server-go/internal/engine/native_runner.go`: changed `if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-head", "commit", []byte(head)); err != nil {` to `if _, err := r.artifacts.PutNodeArtifact(item.ID, nodeID+"-head", "commit", []byte(head)); err != nil {`.
- `server-go/internal/engine/native_runner.go`: changed `if _, err := r.artifacts.PutNodeArtifact(item.ID, req.Node.ID+"-base", "commit", []byte(resolvedBase)); err != nil {` to `if _, err := r.artifacts.PutNodeArtifact(item.ID, nodeID+"-base", "commit", []byte(resolvedBase)); err != nil {`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/native_runner.go | 17 +++++++++++++----
 1 file changed, 13 insertions(+), 4 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.9`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.9` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p10","summary":"Publish freeze artifacts when Node.ID is empty using 'freeze' producer","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["freeze in server-go/internal/engine/native_runner.go (around lines 1025-1035) either documents the invariant that req.Node.ID is required to publish durable artifacts, or falls back to the literal 'freeze' producer when Node.ID is empty so frozen_diff/freeze-head/freeze-base artifacts are still published","TestFreezeUsesMergedRemoteFeatureTip continues to pass","downstream review stages that read by producer='freeze' see the frozen_diff artifact regardless of whether Node.ID was supplied"]}

</details>