### PR TITLE
Drop whitespace trim on freezeCreatedFiles blob comparison

### DIFF
--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -49,7 +49,7 @@ func freezeCreatedFiles(ctx context.Context, workdir, base, head string) (map[st
 		if err != nil {
 			return nil, fmt.Errorf("resolve created blob %s: %w", path, err)
 		}
-		creates[path] = freezeCreate{Path: path, Blob: strings.TrimSpace(blob)}
+		creates[path] = freezeCreate{Path: path, Blob: blob}
 	}
 	return creates, nil
 }

--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -45,7 +45,12 @@ func freezeCreatedFiles(ctx context.Context, workdir, base, head string) (map[st
 			return nil, fmt.Errorf("unexpected created-file status %q for %s", fields[i], fields[i+1])
 		}
 		path := fields[i+1]
-		blob, err := gitText(ctx, workdir, "rev-parse", head+":"+path)
+		// Resolve the canonical blob byte-for-byte via gitTextRaw so the
+		// comparison against the sibling's canonical blob does not silently
+		// absorb trailing whitespace. Trimming here would let two creates
+		// whose contents differ only by trailing whitespace be treated as
+		// identical and suppress a genuine freeze_create_create_collision.
+		blob, err := gitTextRaw(ctx, workdir, "rev-parse", head+":"+path)
 		if err != nil {
 			return nil, fmt.Errorf("resolve created blob %s: %w", path, err)
 		}

--- a/server-go/internal/engine/freeze_collision_test.go
+++ b/server-go/internal/engine/freeze_collision_test.go
@@ -706,3 +706,35 @@ func TestRejectDivergentSiblingCreatesReportsDeterministicCollisionAcrossRuns(t 
 		}
 	}
 }
+
+// TestRejectDivergentSiblingCreatesRejectsTrailingWhitespaceDivergence
+// guards the byte-exact comparison contract: when the current slice and the
+// frozen sibling create the same path with contents that differ only by
+// trailing whitespace, the canonical blobs must still be treated as distinct
+// and the freeze_create_create_collision must surface. Previously the blob
+// resolution path applied strings.TrimSpace to the canonical blob, which
+// silently collapsed two distinct trailing-whitespace creates into identical
+// strings and suppressed a genuine collision.
+func TestRejectDivergentSiblingCreatesRejectsTrailingWhitespaceDivergence(t *testing.T) {
+	ctx, store, artifacts, registry, _, slicedir, base, _ := setupFreezeCollisionHarness(t)
+
+	if err := store.SetWorktree(ctx, "wi_s0", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	gitRun(t, slicedir, "checkout", "-q", "-B", "aimee/wi/wi_child", base)
+	if err := os.WriteFile(filepath.Join(slicedir, "frozen.txt"), []byte("frozen sibling blob   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, slicedir, "add", "frozen.txt")
+	gitRun(t, slicedir, "commit", "-m", "frozen create with trailing whitespace")
+	currentHead := strings.TrimSpace(gitRun(t, slicedir, "rev-parse", "HEAD"))
+
+	item, err := store.WorkItem(ctx, "wi_s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
+	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
+}

--- a/server-go/internal/engine/worktree.go
+++ b/server-go/internal/engine/worktree.go
@@ -232,6 +232,12 @@ func repoIntegrationBranch(ctx context.Context, repo string) (string, error) {
 	return branch, nil
 }
 
+// gitText runs git and returns its stdout trimmed of leading/trailing
+// whitespace. Most callers consume git output that is followed by a single
+// newline (commit IDs, branch names, porcelain status), so trimming is the
+// safe default there. Callers that need byte-exact preservation of the
+// command output (for example a blob resolved via rev-parse, where trailing
+// whitespace is part of the content) must use gitTextRaw instead.
 func gitText(ctx context.Context, repo string, args ...string) (string, error) {
 	commandArgs := append([]string{"-C", repo}, args...)
 	cmd := exec.CommandContext(ctx, "git", commandArgs...)
@@ -240,4 +246,17 @@ func gitText(ctx context.Context, repo string, args ...string) (string, error) {
 		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(output)))
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// gitTextRaw runs git and returns its stdout without any whitespace trimming.
+// Use this when the caller needs byte-exact git output (for example a blob
+// resolved via rev-parse, where trailing whitespace is meaningful content).
+func gitTextRaw(ctx context.Context, repo string, args ...string) (string, error) {
+	commandArgs := append([]string{"-C", repo}, args...)
+	cmd := exec.CommandContext(ctx, "git", commandArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
 }


### PR DESCRIPTION
## Slice outcome

Drop whitespace trim on freezeCreatedFiles blob comparison

## What changed

- strings.TrimSpace is removed from the resolved blob before comparison in freezeCreatedFiles (server-go/internal/engine/freeze_collision.go around lines 36-40)
- sanitization of stray whitespace, if needed, is applied to the gitText input separately rather than the canonical blob
- divergent creates whose contents differ only by trailing whitespace are no longer reported as identical

### Files in this PR

- Updated `server-go/internal/engine/freeze_collision.go`.
- Updated `server-go/internal/engine/freeze_collision_test.go`.
- Updated `server-go/internal/engine/worktree.go`.

### Representative concrete edits

- `server-go/internal/engine/freeze_collision.go`: changed `creates[path] = freezeCreate{Path: path, Blob: strings.TrimSpace(blob)}` to `creates[path] = freezeCreate{Path: path, Blob: blob}`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/freeze_collision.go      |  9 ++++--
 server-go/internal/engine/freeze_collision_test.go | 32 ++++++++++++++++++++++
 server-go/internal/engine/worktree.go              | 19 +++++++++++++
 3 files changed, 58 insertions(+), 2 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.11`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s080af80d84.g3.11` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p12","summary":"Drop whitespace trim on freezeCreatedFiles blob comparison","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["strings.TrimSpace is removed from the resolved blob before comparison in freezeCreatedFiles (server-go/internal/engine/freeze_collision.go around lines 36-40)","sanitization of stray whitespace, if needed, is applied to the gitText input separately rather than the canonical blob","divergent creates whose contents differ only by trailing whitespace are no longer reported as identical"]}

</details>