### PR TITLE
fix: publish server-principal vault writes onto the audit event bus

### DIFF
--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -6,7 +6,8 @@
 #include "vault_service.h"
 #include "vault_crypto.h"     /* VAULT_ROOT_KEY_LEN */
 #include "vault_capability.h" /* vault:write:server gate (D2c) */
-#include "log.h"              /* audit_log dedicated 0600 audit sink (D2/D2c) */
+#include "log.h"               /* audit_log dedicated 0600 audit sink (D2/D2c) */
+#include "vault_audit_bridge.h" /* publish server-principal writes onto the audit bus */
 #include "cJSON.h"
 #include <openssl/crypto.h>
 #include <openssl/sha.h>
@@ -205,12 +206,20 @@ void vault_audit_server_write(const server_conn_t *conn, const char *agent, cons
       transport = "unknown";
       break;
    }
+   const char *principal =
+      (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)";
+
    /* D2/D2c: server-principal writes go to the dedicated append-only 0600 audit
     * sink (audit_log), NOT the operator-readable general server log — preserving
     * tamper-evidence + access separation. Never logs the key (fingerprint only). */
-   audit_log("VAULT_SERVER_WRITE", "by=%s transport=%s agent=%s cred=%s fp=%s",
-             (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)", transport,
-             agent ? agent : "?", cred ? cred : "?", fp);
+   audit_log("VAULT_SERVER_WRITE", "by=%s transport=%s agent=%s cred=%s fp=%s", principal,
+             transport, agent ? agent : "?", cred ? cred : "?", fp);
+
+   /* ...and onto the audit event bus, so this write joins the same ordered tap,
+    * capture/replay stream, and WORM ledger as every vault ACCESS row. Without
+    * this the highest-privilege vault op — storing a client-supplied secret under
+    * the server principal — was the only one absent from the replayable trail. */
+   vault_audit_bridge_server_write(principal, agent, cred, fp, transport);
 }
 
 /* POST /v1/vault/set_server — store a CLIENT-SUPPLIED credential under the

--- a/src/server/vault_audit_bridge.c
+++ b/src/server/vault_audit_bridge.c
@@ -46,17 +46,22 @@ static const char *verdict_of(vault_status_t st)
    return "deny";
 }
 
-/* vault_audit_hook_fn: publish one credential-access audit row over the bus
- * (KIND_AUDIT_ACTION -> the audit ledger + capture/replay). NON-SECRET only:
- * principal (actor), op (tool), the (agent, cred) identity (command), the
- * transport (mode), and the outcome (verdict + the precise status as reason). No
- * task association -> task_id 0 (the "no task" sentinel). */
-static void on_vault_access(const char *op, const char *principal, const char *agent,
-                            const char *cred, attested_transport_t transport, vault_status_t st)
+/* Publish one vault audit row over the bus (KIND_AUDIT_ACTION -> the audit ledger
+ * + capture/replay). NON-SECRET only: principal (actor), op (tool), the
+ * (agent, cred) identity (command), the transport (mode), and the outcome
+ * (verdict + reason). No task association -> task_id 0 (the "no task" sentinel). */
+static void emit_vault_row(const char *principal, const char *op, const char *agent,
+                           const char *cred, const char *transport, const char *reason,
+                           const char *verdict)
 {
+   if (!agent)
+      agent = "";
+   if (!cred)
+      cred = "";
+
    /* The (agent, cred) identity is non-secret and rides HUMAN-READABLE in the
-    * command field — this is the correlation key for vault-access rows (query the
-    * ledger by actor+tool+command). It is never the secret value. */
+    * command field — this is the correlation key for vault rows (query the ledger
+    * by actor+tool+command). It is never the secret value. */
    char command[256];
    if (agent[0] || cred[0])
       snprintf(command, sizeof command, "%s/%s", agent, cred);
@@ -72,8 +77,35 @@ static void on_vault_access(const char *op, const char *principal, const char *a
    snprintf(args_hash, sizeof args_hash, "v1-");
    audit_args_hash(op, NULL, args_hash, sizeof args_hash);
 
-   obs_bus_emit(principal, op, args_hash, command, transport_label(transport), vault_status_str(st),
-                verdict_of(st), /*task_id=*/0);
+   obs_bus_emit(principal, op, args_hash, command, transport, reason, verdict, /*task_id=*/0);
+}
+
+/* vault_audit_hook_fn: publish one credential-ACCESS audit row over the bus. */
+static void on_vault_access(const char *op, const char *principal, const char *agent,
+                            const char *cred, attested_transport_t transport, vault_status_t st)
+{
+   emit_vault_row(principal, op, agent, cred, transport_label(transport), vault_status_str(st),
+                  verdict_of(st));
+}
+
+/* Server-principal credential WRITE (POST /v1/vault/set_server and the agent
+ * API-key writes). These do not pass through vault_service's access hook — they
+ * are a distinct, higher-privilege op: a CLIENT-SUPPLIED secret stored under the
+ * server-owned principal for autonomous decrypt. Without this they reached only
+ * the local audit_log file and never the ordered tap, capture/replay, or the WORM
+ * ledger that every other vault row lands in.
+ *
+ * `fingerprint` is the caller's non-secret key fingerprint and rides in the
+ * reason field; the plaintext secret is never in scope here. Reaching this
+ * function means the write was authorized and performed, so the verdict is
+ * "allow" — denials are rejected upstream before any write occurs. */
+void vault_audit_bridge_server_write(const char *principal, const char *agent, const char *cred,
+                                     const char *fingerprint, const char *transport)
+{
+   char reason[64];
+   snprintf(reason, sizeof reason, "fp=%s", fingerprint ? fingerprint : "?");
+   emit_vault_row(principal, "vault.set_server", agent, cred, transport ? transport : "unknown",
+                  reason, "allow");
 }
 
 void vault_audit_bridge_install(void)

--- a/src/server/vault_audit_bridge.h
+++ b/src/server/vault_audit_bridge.h
@@ -14,4 +14,14 @@
  * emit and drains at graceful exit. */
 void vault_audit_bridge_install(void);
 
+/* Publish a server-principal credential WRITE onto the same audit bus stream.
+ * Unlike the access ops above there is no vault_service hook to install — the
+ * server-principal write is driven from the HTTP layer, so the call site invokes
+ * this directly. Kept here, beside the access hook, so this file remains the
+ * SINGLE object depending on both the vault surface and the audit bus.
+ *
+ * NON-SECRET arguments only: `fingerprint` is a key fingerprint, never the key. */
+void vault_audit_bridge_server_write(const char *principal, const char *agent, const char *cred,
+                                     const char *fingerprint, const char *transport);
+
 #endif /* AIMEE_VAULT_AUDIT_BRIDGE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3259,6 +3259,32 @@ unit-test-bus-ring: $(TESTPREFIX)/unit-test-bus-ring
 unit-test-bus-wire: $(TESTPREFIX)/unit-test-bus-wire
 	$<
 
+# The bus tests are deliberately NOT in TEST_TARGETS -- each needs a special bus
+# link set the standard unit-tests build does not assemble, so the bench gate
+# (check_bus_perf_gate.sh) force-builds them via their .PHONY targets. That also
+# means none of them inherited the blanket `$(TEST_TARGETS): | $(CORE_CONNECTION_LIB)`
+# earlier in this file, so the ones that pull the archive through L_CORE died on a
+# clean tree with "cannot find build/obj/libaimee-core-connection.a" -- exactly the
+# gap already fixed for unit-test-code-treesitter below and for the auxiliary
+# drivers in src/Makefile. Listing all of them keeps the guarantee independent of
+# which ones happen to link L_CORE today.
+#
+# Order-only: the archive must EXIST before these link, but relinking it must not
+# force every bus test to relink.
+BUS_TEST_TARGETS := $(addprefix $(TESTPREFIX)/, \
+   unit-test-bus-memory-recall unit-test-bus-memory-upsert \
+   unit-test-bus-config-autonomy unit-test-bus-audit-durability \
+   unit-test-bus-audit-replay unit-test-bus-audit-retention \
+   unit-test-bus-audit-replay-tool unit-test-bus-guardrail-durability \
+   unit-test-bus-vault-audit unit-test-bus-sandbox-audit \
+   unit-test-bus-tool-completion unit-test-bus-memory-audit \
+   unit-test-bus-shutdown-race unit-test-bus-capture unit-test-bus-client \
+   unit-test-bus-flow unit-test-bus-route unit-test-bus-host unit-test-bus-arena \
+   unit-test-bus-region unit-test-bus-ring unit-test-bus-wire)
+
+$(BUS_TEST_TARGETS): | $(CORE_CONNECTION_LIB)
+
+
 # Render-boundary prompt sanitizer (graph-feedback §4 / P0). Pure: no DB.
 $(TESTPREFIX)/unit-test-prompt-sanitizer: $(OBJDIR)/tests/test_prompt_sanitizer.o \
                                           $(OBJDIR)/kb/prompt_sanitizer.o

--- a/src/tests/test_bus_vault_audit.c
+++ b/src/tests/test_bus_vault_audit.c
@@ -97,6 +97,14 @@ int main(void)
    assert(vault_service_delete(p, "claude", "api_key") == VAULT_OK);
    assert(vault_service_unlock(p, ATTEST_TCP_BEARER, rk, sizeof rk, T0) == VAULT_ERR_TRANSPORT);
 
+   /* The server-principal WRITE (POST /v1/vault/set_server, agent API-key writes).
+    * It is driven from the HTTP layer and does NOT pass through vault_service's
+    * access hook, so it needs its own bridge call — before that existed this row
+    * reached only the local audit_log file and never the bus, leaving the
+    * highest-privilege vault op the one op absent from the replayable trail.
+    * Only the non-secret fingerprint crosses; `so` stays out of scope entirely. */
+   vault_audit_bridge_server_write(p, "openai", "api_key", "a1b2c3d4", "webchat");
+
    obs_bus_stop(); /* drains every in-flight row into the ledger */
 
    cJSON *rows = audit_ledger_read(NULL, NULL);
@@ -130,6 +138,17 @@ int main(void)
    assert(unlock_deny);
    assert(strcmp(sval(unlock_deny, "verdict"), "deny") == 0);
    assert(strcmp(sval(unlock_deny, "reason_code"), "transport_not_allowed") == 0);
+
+   /* The server-principal write lands on the SAME bus -> ledger stream as every
+    * access row above: same actor, correlated by the same command identity, with
+    * the attesting transport as mode and the key fingerprint (never the key) as
+    * the reason. This is the row that previously existed only in a local file. */
+   cJSON *set_server = find_row(rows, "vault.set_server", "openai/api_key");
+   assert(set_server);
+   assert(strcmp(sval(set_server, "actor"), p) == 0);
+   assert(strcmp(sval(set_server, "verdict"), "allow") == 0);
+   assert(strcmp(sval(set_server, "mode"), "webchat") == 0);
+   assert(strcmp(sval(set_server, "reason_code"), "fp=a1b2c3d4") == 0);
 
    /* THE invariant: no secret plaintext leaked into ANY field of ANY row. */
    char *dump = cJSON_PrintUnformatted(rows);


### PR DESCRIPTION
## Problem

`vault_audit_server_write` recorded server-principal credential writes **only** to the local `audit_log` file (`src/log.c`, a plain file writer with no bus involvement).

Every vault *access* op already reached the bus — `vault_service.c` routes 21 call sites through `vaudit()` → `vault_audit_bridge` → `obs_bus` → ledger. So the one operation absent from the ordered tap, capture/replay and WORM ledger was the **highest-privilege** one: `handle_vault_set_server` storing a client-supplied secret under the server-owned principal for autonomous decrypt.

Affected call sites: `server_vault.c`, `server_agent.c:723`, `server_agent.c:1221`.

## Change

Add `vault_audit_bridge_server_write()` and call it from `vault_audit_server_write`, covering all three sites. The publish lives in the bridge so that file stays the single object depending on both the vault surface and the audit bus, preserving the D7 include allowlist. Only the non-secret key fingerprint crosses; the plaintext is never in scope.

The existing `audit_log` write is **kept alongside** deliberately — dropping the 0600 append-only sink changes the D2/D2c tamper-evidence posture, which is a separate decision for the owner of that invariant, not a side effect of this fix.

## Also: clean-tree build fix

None of the bus test targets are in `TEST_TARGETS` (each needs a special bus link set the standard unit-tests build doesn't assemble), so none inherited the blanket `$(TEST_TARGETS): | $(CORE_CONNECTION_LIB)`. On a clean tree they died with `cannot find build/obj/libaimee-core-connection.a`. Same gap already fixed for `unit-test-code-treesitter` and the `src/Makefile` auxiliary drivers; this applies the same order-only prerequisite to the 22 bus targets.

## Verification

- `unit-test-bus-vault-audit` passes; extended to assert the new row's actor/verdict/mode/reason.
- **Red-checked**: suppressing the emit fails the test on `assert(set_server)` — the assertions are load-bearing, not vacuous.
- Clean-tree rebuild (archive deleted) now succeeds; previously failed.
- Full shipping set builds; `check_bus_blast_radius` inspected all 7 shipping binaries, no bus symbol.
- `check_bus_perf_gate` ok — audit enqueue 142 ns (ceiling 5000), 0 dropped, all six audit trails green.

## Note for the reviewer

Two follow-on attribution bugs exist in the **uncommitted** working tree on this branch (shared-vault `delete` and `list` re-attributed to `VAULT_SERVER_PRINCIPAL`, losing the human actor — `delete` compensates with a file-only `audit_log`, `list` not at all). Fix is written and tested but depends on that uncommitted work, so it is not in this PR.