### PR TITLE
fix: put shared-vault write, delete and list on the audit bus with the human actor

### DIFF
--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -324,6 +324,11 @@ int handle_vault_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                                           (int)(sizeof(entries) / sizeof(entries[0])), &count);
    if (st != VAULT_OK)
       return vault_send_status_error(conn, st);
+   /* As with delete: the underlying row is attributed to the server vault, so the
+    * human who enumerated the shared credential names would otherwise appear in no
+    * audit record at all. Enumeration of credential names is a real disclosure
+    * event, so it gets an attributed row like the mutations do. */
+   vault_audit_bridge_server_list(conn->vault_principal, count);
 
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
@@ -360,6 +365,11 @@ int handle_vault_delete(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       return vault_send_status_error(conn, st);
    audit_log("VAULT_SERVER_DELETE", "by=%s agent=%s cred=%s", conn->vault_principal,
              ja->valuestring, jc->valuestring);
+   /* ...and onto the bus. The vault_service row for this delete is attributed to
+    * VAULT_SERVER_PRINCIPAL (the vault the credential lives in), so it cannot answer
+    * WHO deleted it — that identity existed only in the audit_log line above, i.e.
+    * in a local file with no ordered tap, capture/replay, or WORM ledger. */
+   vault_audit_bridge_server_delete(conn->vault_principal, ja->valuestring, jc->valuestring);
 
    cJSON *resp = cJSON_CreateObject();
    if (!resp)

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -4,10 +4,10 @@
  * the response. All policy + crypto lives below in vault_service. */
 #include "server.h" /* server_conn_t, server_send_*, handle_vault_* decls */
 #include "vault_service.h"
-#include "vault_store.h"      /* legacy actor-vault existence check */
-#include "vault_crypto.h"     /* VAULT_ROOT_KEY_LEN */
-#include "vault_capability.h" /* vault:write:server gate (D2c) */
-#include "log.h"               /* audit_log dedicated 0600 audit sink (D2/D2c) */
+#include "vault_store.h"        /* legacy actor-vault existence check */
+#include "vault_crypto.h"       /* VAULT_ROOT_KEY_LEN */
+#include "vault_capability.h"   /* vault:write:server gate (D2c) */
+#include "log.h"                /* audit_log dedicated 0600 audit sink (D2/D2c) */
 #include "vault_audit_bridge.h" /* publish server-principal writes onto the audit bus */
 #include "cJSON.h"
 #include <openssl/crypto.h>
@@ -197,8 +197,7 @@ void vault_audit_server_write(const server_conn_t *conn, const char *agent, cons
       transport = "unknown";
       break;
    }
-   const char *principal =
-      (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)";
+   const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)";
 
    /* D2/D2c: server-principal writes go to the dedicated append-only 0600 audit
     * sink (audit_log), NOT the operator-readable general server log — preserving

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -7,7 +7,8 @@
 #include "vault_store.h"      /* legacy actor-vault existence check */
 #include "vault_crypto.h"     /* VAULT_ROOT_KEY_LEN */
 #include "vault_capability.h" /* vault:write:server gate (D2c) */
-#include "log.h"              /* audit_log dedicated 0600 audit sink (D2/D2c) */
+#include "log.h"               /* audit_log dedicated 0600 audit sink (D2/D2c) */
+#include "vault_audit_bridge.h" /* publish server-principal writes onto the audit bus */
 #include "cJSON.h"
 #include <openssl/crypto.h>
 #include <openssl/sha.h>
@@ -196,12 +197,20 @@ void vault_audit_server_write(const server_conn_t *conn, const char *agent, cons
       transport = "unknown";
       break;
    }
+   const char *principal =
+      (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)";
+
    /* D2/D2c: server-principal writes go to the dedicated append-only 0600 audit
     * sink (audit_log), NOT the operator-readable general server log — preserving
     * tamper-evidence + access separation. Never logs the key (fingerprint only). */
-   audit_log("VAULT_SERVER_WRITE", "by=%s transport=%s agent=%s cred=%s fp=%s",
-             (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)", transport,
-             agent ? agent : "?", cred ? cred : "?", fp);
+   audit_log("VAULT_SERVER_WRITE", "by=%s transport=%s agent=%s cred=%s fp=%s", principal,
+             transport, agent ? agent : "?", cred ? cred : "?", fp);
+
+   /* ...and onto the audit event bus, so this write joins the same ordered tap,
+    * capture/replay stream, and WORM ledger as every vault ACCESS row. Without
+    * this the highest-privilege vault op — storing a client-supplied secret under
+    * the server principal — was the only one absent from the replayable trail. */
+   vault_audit_bridge_server_write(principal, agent, cred, fp, transport);
 }
 
 /* POST /v1/vault/set_server — store a CLIENT-SUPPLIED credential under the

--- a/src/server/vault_audit_bridge.c
+++ b/src/server/vault_audit_bridge.c
@@ -46,17 +46,22 @@ static const char *verdict_of(vault_status_t st)
    return "deny";
 }
 
-/* vault_audit_hook_fn: publish one credential-access audit row over the bus
- * (KIND_AUDIT_ACTION -> the audit ledger + capture/replay). NON-SECRET only:
- * principal (actor), op (tool), the (agent, cred) identity (command), the
- * transport (mode), and the outcome (verdict + the precise status as reason). No
- * task association -> task_id 0 (the "no task" sentinel). */
-static void on_vault_access(const char *op, const char *principal, const char *agent,
-                            const char *cred, attested_transport_t transport, vault_status_t st)
+/* Publish one vault audit row over the bus (KIND_AUDIT_ACTION -> the audit ledger
+ * + capture/replay). NON-SECRET only: principal (actor), op (tool), the
+ * (agent, cred) identity (command), the transport (mode), and the outcome
+ * (verdict + reason). No task association -> task_id 0 (the "no task" sentinel). */
+static void emit_vault_row(const char *principal, const char *op, const char *agent,
+                           const char *cred, const char *transport, const char *reason,
+                           const char *verdict)
 {
+   if (!agent)
+      agent = "";
+   if (!cred)
+      cred = "";
+
    /* The (agent, cred) identity is non-secret and rides HUMAN-READABLE in the
-    * command field — this is the correlation key for vault-access rows (query the
-    * ledger by actor+tool+command). It is never the secret value. */
+    * command field — this is the correlation key for vault rows (query the ledger
+    * by actor+tool+command). It is never the secret value. */
    char command[256];
    if (agent[0] || cred[0])
       snprintf(command, sizeof command, "%s/%s", agent, cred);
@@ -72,8 +77,35 @@ static void on_vault_access(const char *op, const char *principal, const char *a
    snprintf(args_hash, sizeof args_hash, "v1-");
    audit_args_hash(op, NULL, args_hash, sizeof args_hash);
 
-   obs_bus_emit(principal, op, args_hash, command, transport_label(transport), vault_status_str(st),
-                verdict_of(st), /*task_id=*/0);
+   obs_bus_emit(principal, op, args_hash, command, transport, reason, verdict, /*task_id=*/0);
+}
+
+/* vault_audit_hook_fn: publish one credential-ACCESS audit row over the bus. */
+static void on_vault_access(const char *op, const char *principal, const char *agent,
+                            const char *cred, attested_transport_t transport, vault_status_t st)
+{
+   emit_vault_row(principal, op, agent, cred, transport_label(transport), vault_status_str(st),
+                  verdict_of(st));
+}
+
+/* Server-principal credential WRITE (POST /v1/vault/set_server and the agent
+ * API-key writes). These do not pass through vault_service's access hook — they
+ * are a distinct, higher-privilege op: a CLIENT-SUPPLIED secret stored under the
+ * server-owned principal for autonomous decrypt. Without this they reached only
+ * the local audit_log file and never the ordered tap, capture/replay, or the WORM
+ * ledger that every other vault row lands in.
+ *
+ * `fingerprint` is the caller's non-secret key fingerprint and rides in the
+ * reason field; the plaintext secret is never in scope here. Reaching this
+ * function means the write was authorized and performed, so the verdict is
+ * "allow" — denials are rejected upstream before any write occurs. */
+void vault_audit_bridge_server_write(const char *principal, const char *agent, const char *cred,
+                                     const char *fingerprint, const char *transport)
+{
+   char reason[64];
+   snprintf(reason, sizeof reason, "fp=%s", fingerprint ? fingerprint : "?");
+   emit_vault_row(principal, "vault.set_server", agent, cred, transport ? transport : "unknown",
+                  reason, "allow");
 }
 
 void vault_audit_bridge_install(void)

--- a/src/server/vault_audit_bridge.c
+++ b/src/server/vault_audit_bridge.c
@@ -108,6 +108,30 @@ void vault_audit_bridge_server_write(const char *principal, const char *agent, c
                   reason, "allow");
 }
 
+/* Server-principal credential DELETE (POST /v1/vault/delete). vault_service's own
+ * row for this op is attributed to VAULT_SERVER_PRINCIPAL — the vault the
+ * credential lives in — so it records WHAT was removed but not WHO removed it.
+ * This publishes the human principal for the same (agent, cred), which is the
+ * attribution an operator actually needs when a shared credential disappears.
+ *
+ * Reaching this function means the capability check passed and the delete
+ * succeeded, so the verdict is "allow". */
+void vault_audit_bridge_server_delete(const char *principal, const char *agent, const char *cred)
+{
+   emit_vault_row(principal, "vault.delete_server", agent, cred, "n/a", "deleted", "allow");
+}
+
+/* Shared-credential ENUMERATION (POST /v1/vault/list). No single (agent, cred)
+ * identity applies, so the command field stays empty and the returned count rides
+ * in the reason — enough to see who enumerated the shared vault and how much they
+ * saw, without naming the credentials in the audit row. */
+void vault_audit_bridge_server_list(const char *principal, int count)
+{
+   char reason[32];
+   snprintf(reason, sizeof reason, "count=%d", count);
+   emit_vault_row(principal, "vault.list_server", "", "", "n/a", reason, "allow");
+}
+
 void vault_audit_bridge_install(void)
 {
    vault_service_set_audit_hook(on_vault_access);

--- a/src/server/vault_audit_bridge.h
+++ b/src/server/vault_audit_bridge.h
@@ -24,4 +24,13 @@ void vault_audit_bridge_install(void);
 void vault_audit_bridge_server_write(const char *principal, const char *agent, const char *cred,
                                      const char *fingerprint, const char *transport);
 
+/* Publish a shared-credential DELETE, attributed to the human principal rather
+ * than to the server vault the credential lived in. Same reason as above: the
+ * actor must reach the ordered tap and the ledger, not just a local file. */
+void vault_audit_bridge_server_delete(const char *principal, const char *agent, const char *cred);
+
+/* Publish a shared-credential enumeration, attributed to the human principal.
+ * `count` is how many names were returned; no credential names enter the row. */
+void vault_audit_bridge_server_list(const char *principal, int count);
+
 #endif /* AIMEE_VAULT_AUDIT_BRIDGE_H */

--- a/src/server/vault_audit_bridge.h
+++ b/src/server/vault_audit_bridge.h
@@ -14,4 +14,14 @@
  * emit and drains at graceful exit. */
 void vault_audit_bridge_install(void);
 
+/* Publish a server-principal credential WRITE onto the same audit bus stream.
+ * Unlike the access ops above there is no vault_service hook to install — the
+ * server-principal write is driven from the HTTP layer, so the call site invokes
+ * this directly. Kept here, beside the access hook, so this file remains the
+ * SINGLE object depending on both the vault surface and the audit bus.
+ *
+ * NON-SECRET arguments only: `fingerprint` is a key fingerprint, never the key. */
+void vault_audit_bridge_server_write(const char *principal, const char *agent, const char *cred,
+                                     const char *fingerprint, const char *transport);
+
 #endif /* AIMEE_VAULT_AUDIT_BRIDGE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3531,6 +3531,32 @@ unit-test-bus-wire: $(TESTPREFIX)/unit-test-bus-wire
 unit-test-module-protocol: $(TESTPREFIX)/unit-test-module-protocol
 	$<
 
+# The bus tests are deliberately NOT in TEST_TARGETS -- each needs a special bus
+# link set the standard unit-tests build does not assemble, so the bench gate
+# (check_bus_perf_gate.sh) force-builds them via their .PHONY targets. That also
+# means none of them inherited the blanket `$(TEST_TARGETS): | $(CORE_CONNECTION_LIB)`
+# earlier in this file, so the ones that pull the archive through L_CORE died on a
+# clean tree with "cannot find build/obj/libaimee-core-connection.a" -- exactly the
+# gap already fixed for unit-test-code-treesitter below and for the auxiliary
+# drivers in src/Makefile. Listing all of them keeps the guarantee independent of
+# which ones happen to link L_CORE today.
+#
+# Order-only: the archive must EXIST before these link, but relinking it must not
+# force every bus test to relink.
+BUS_TEST_TARGETS := $(addprefix $(TESTPREFIX)/, \
+   unit-test-bus-endpoint unit-test-bus-runtime unit-test-bus-memory-recall \
+   unit-test-bus-memory-upsert unit-test-bus-config-autonomy \
+   unit-test-bus-audit-durability unit-test-bus-audit-replay \
+   unit-test-bus-audit-retention unit-test-bus-audit-replay-tool \
+   unit-test-bus-guardrail-durability unit-test-bus-vault-audit \
+   unit-test-bus-sandbox-audit unit-test-bus-tool-completion \
+   unit-test-bus-memory-audit unit-test-bus-shutdown-race unit-test-bus-capture \
+   unit-test-bus-client unit-test-bus-flow unit-test-bus-route unit-test-bus-host \
+   unit-test-bus-arena unit-test-bus-region unit-test-bus-ring unit-test-bus-wire)
+
+$(BUS_TEST_TARGETS): | $(CORE_CONNECTION_LIB)
+
+
 # Render-boundary prompt sanitizer (graph-feedback §4 / P0). Pure: no DB.
 $(TESTPREFIX)/unit-test-prompt-sanitizer: $(OBJDIR)/tests/test_prompt_sanitizer.o \
                                           $(OBJDIR)/kb/prompt_sanitizer.o

--- a/src/tests/test_bus_vault_audit.c
+++ b/src/tests/test_bus_vault_audit.c
@@ -105,6 +105,12 @@ int main(void)
     * Only the non-secret fingerprint crosses; `so` stays out of scope entirely. */
    vault_audit_bridge_server_write(p, "openai", "api_key", "a1b2c3d4", "webchat");
 
+   /* The other two shared-vault ops whose vault_service row is attributed to
+    * VAULT_SERVER_PRINCIPAL, and so cannot say WHO acted: delete and enumerate.
+    * Both publish the human principal separately. */
+   vault_audit_bridge_server_delete(p, "openai", "api_key");
+   vault_audit_bridge_server_list(p, 3);
+
    obs_bus_stop(); /* drains every in-flight row into the ledger */
 
    cJSON *rows = audit_ledger_read(NULL, NULL);
@@ -149,6 +155,19 @@ int main(void)
    assert(strcmp(sval(set_server, "verdict"), "allow") == 0);
    assert(strcmp(sval(set_server, "mode"), "webchat") == 0);
    assert(strcmp(sval(set_server, "reason_code"), "fp=a1b2c3d4") == 0);
+
+   /* Shared-credential DELETE carries the HUMAN principal as actor — the whole
+    * point, since vault_service's own row names the server vault instead. */
+   cJSON *del_server = find_row(rows, "vault.delete_server", "openai/api_key");
+   assert(del_server);
+   assert(strcmp(sval(del_server, "actor"), p) == 0);
+   assert(strcmp(sval(del_server, "verdict"), "allow") == 0);
+
+   /* Enumeration: attributed, counted, and it must NOT name any credential. */
+   cJSON *list_server = find_row(rows, "vault.list_server", "");
+   assert(list_server);
+   assert(strcmp(sval(list_server, "actor"), p) == 0);
+   assert(strcmp(sval(list_server, "reason_code"), "count=3") == 0);
 
    /* THE invariant: no secret plaintext leaked into ANY field of ANY row. */
    char *dump = cJSON_PrintUnformatted(rows);

--- a/src/tests/test_bus_vault_audit.c
+++ b/src/tests/test_bus_vault_audit.c
@@ -97,6 +97,14 @@ int main(void)
    assert(vault_service_delete(p, "claude", "api_key") == VAULT_OK);
    assert(vault_service_unlock(p, ATTEST_TCP_BEARER, rk, sizeof rk, T0) == VAULT_ERR_TRANSPORT);
 
+   /* The server-principal WRITE (POST /v1/vault/set_server, agent API-key writes).
+    * It is driven from the HTTP layer and does NOT pass through vault_service's
+    * access hook, so it needs its own bridge call — before that existed this row
+    * reached only the local audit_log file and never the bus, leaving the
+    * highest-privilege vault op the one op absent from the replayable trail.
+    * Only the non-secret fingerprint crosses; `so` stays out of scope entirely. */
+   vault_audit_bridge_server_write(p, "openai", "api_key", "a1b2c3d4", "webchat");
+
    obs_bus_stop(); /* drains every in-flight row into the ledger */
 
    cJSON *rows = audit_ledger_read(NULL, NULL);
@@ -130,6 +138,17 @@ int main(void)
    assert(unlock_deny);
    assert(strcmp(sval(unlock_deny, "verdict"), "deny") == 0);
    assert(strcmp(sval(unlock_deny, "reason_code"), "transport_not_allowed") == 0);
+
+   /* The server-principal write lands on the SAME bus -> ledger stream as every
+    * access row above: same actor, correlated by the same command identity, with
+    * the attesting transport as mode and the key fingerprint (never the key) as
+    * the reason. This is the row that previously existed only in a local file. */
+   cJSON *set_server = find_row(rows, "vault.set_server", "openai/api_key");
+   assert(set_server);
+   assert(strcmp(sval(set_server, "actor"), p) == 0);
+   assert(strcmp(sval(set_server, "verdict"), "allow") == 0);
+   assert(strcmp(sval(set_server, "mode"), "webchat") == 0);
+   assert(strcmp(sval(set_server, "reason_code"), "fp=a1b2c3d4") == 0);
 
    /* THE invariant: no secret plaintext leaked into ANY field of ANY row. */
    char *dump = cJSON_PrintUnformatted(rows);

--- a/src/tests/test_vault_audit.c
+++ b/src/tests/test_vault_audit.c
@@ -33,6 +33,36 @@ int server_send_response(server_conn_t *conn, cJSON *resp)
    return 0;
 }
 
+/* The audit-bus half of these ops is a SEPARATE control with its own end-to-end
+ * test (test_bus_vault_audit.c drives the real bridge onto a real bus and reads
+ * the ledger back). This test pins only the D2/D2c file sink, and linking the
+ * bridge here would drag the whole event bus into a test that has nothing to say
+ * about it — so the publishes are stubbed out rather than exercised.
+ *
+ * NOTE these are deliberately no-ops, not assertions: a change that stops
+ * publishing would pass here and fail in test_bus_vault_audit, which is where
+ * that behavior is owned. */
+void vault_audit_bridge_server_write(const char *principal, const char *agent, const char *cred,
+                                     const char *fingerprint, const char *transport)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   (void)fingerprint;
+   (void)transport;
+}
+void vault_audit_bridge_server_delete(const char *principal, const char *agent, const char *cred)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+}
+void vault_audit_bridge_server_list(const char *principal, int count)
+{
+   (void)principal;
+   (void)count;
+}
+
 static char *slurp(const char *path, size_t *len_out)
 {
    FILE *f = fopen(path, "rb");


### PR DESCRIPTION
## Why this targets `testing`

PR #2372 landed the vault-on-bus bridge on `agent/human-trigger-workflows`. **`testing` does not have it** — but `testing` *does* already have the shared-environment vault rework. So on `testing` today the attribution gap below is live, not hypothetical.

This PR carries both commits so `testing` is fixed independently of when that branch merges.

## The gap

`handle_vault_list` and `handle_vault_delete` on `testing` call `vault_service` with `VAULT_SERVER_PRINCIPAL` — correct, that is the vault the shared credential lives in. But it means `vault_service`'s own audit row names **the vault, not the human**:

| Op | Who acted is recorded... |
|---|---|
| `set_server` | local `audit_log` file only — no tap, no replay, no ledger |
| `delete` | local `audit_log` file only (`by=%s`) |
| `list` | **nowhere at all** |

Enumerating the shared credential names is a real disclosure event and currently leaves no audit record of who did it.

## Change

Publish an attributed row over the bus for each, beside the existing rows:

- `vault.set_server` — actor = human principal, reason = key fingerprint
- `vault.delete_server` — actor = human principal, command = `agent/cred`
- `vault.list_server` — actor = human principal, reason = `count=N`, command empty so **no credential names enter the row**

All three live in `vault_audit_bridge.c`, keeping it the single object that depends on both the vault surface and the audit bus (preserving the D7 include allowlist), and all three reuse one `emit_vault_row` helper rather than adding near-duplicate row-building code.

The existing `audit_log` writes are **kept**. Dropping the 0600 append-only sink changes the D2/D2c tamper-evidence posture — that is a decision for the owner of that invariant, not a side effect of this fix.

## Also: clean-tree build fix

The bus test targets are not in `TEST_TARGETS`, so none inherited the blanket `$(TEST_TARGETS): | $(CORE_CONNECTION_LIB)` and they failed on a clean tree with `cannot find build/obj/libaimee-core-connection.a`. Same gap already fixed for `unit-test-code-treesitter` and the `src/Makefile` auxiliary drivers.

## Verification

- `unit-test-bus-vault-audit` extended to assert all three rows carry the human actor, plus `count=N` on list.
- **Red-verified**: suppressing the delete emit fails on `assert(del_server)`; suppressing the write emit fails on `assert(set_server)`.
- Existing assertion that **no secret plaintext appears in any ledger field** still holds.
- Full shipping set builds; `check_bus_blast_radius` ok; `check_bus_perf_gate` ok — 0 dropped, all six audit trails green.

## Reviewer note

The route handlers touched here have **no existing test coverage** — `grep` for `handle_vault_set|handle_vault_delete|handle_vault_list` across `src/tests/` returns nothing. The bus publishes are tested end-to-end through the real bridge, but the handler-level behavior on `testing` (the `set` → `set_server` alias, the delete capability gate) is untested. Worth a route-level test separately.