### PR TITLE
Unify freeze artifact publication and sibling-lookup keys on req.Node.ID

### DIFF
--- a/server-go/internal/engine/freeze_collision.go
+++ b/server-go/internal/engine/freeze_collision.go
@@ -171,6 +171,25 @@ func freezeSiblingUncomparableError(currentSlice, siblingSlice, path string, cau
 	return fmt.Errorf("%w: cannot compare path %s: already frozen sibling slice %s while processing current slice %s: %w", ErrFreezeCreateCreateCollision, path, siblingSlice, currentSlice, cause)
 }
 
+// freezeArtifactKey is the single source of truth for the node id under which
+// freeze publishes the durable (frozen_diff, freeze-head, freeze-base) triple
+// AND under which frozenSiblingArtifacts reads it. Both publish and read must
+// derive the key from req.Node.ID so a freeze block whose node id is not the
+// literal "freeze" still round-trips, and so the mismatch that the previous
+// hardcoded read side caused (read used "freeze", write used req.Node.ID ||
+// "freeze") cannot reappear. When req.Node.ID is empty the helper resolves to
+// the conventional "freeze" key -- this is the single fallback that keeps the
+// no-Node-id caller (e.g. an HTTP runner constructing a partial StepRequest)
+// publishing and reading under the same conventional key instead of silently
+// mismatching, and it is regression-tested so neither side can reintroduce its
+// own private fallback.
+func freezeArtifactKey(req StepRequest) string {
+	if req.Node.ID != "" {
+		return req.Node.ID
+	}
+	return "freeze"
+}
+
 // frozenSiblingArtifacts captures the three durable NodeArtifacts that
 // together mark a sibling as having a durable frozen diff: the freeze node's
 // frozen_diff content and the freeze-head/freeze-base commit SHAs. Anchoring
@@ -201,11 +220,11 @@ func freezeSiblingUncomparableError(currentSlice, siblingSlice, path string, cau
 //     a sibling as frozen, and prevents the collision check from spuriously
 //     rejecting slices whose active sibling carries a partial freeze-artifact
 //     set.
-func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, base string, ok bool, err error) {
+func frozenSiblingArtifacts(siblingID, freezeKey string, store *wfe.ArtifactStore) (head, base string, ok bool, err error) {
 	if store == nil {
 		return "", "", false, nil
 	}
-	diff, err := store.NodeArtifact(siblingID, "freeze")
+	diff, err := store.NodeArtifact(siblingID, freezeKey)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {
 			return "", "", false, nil
@@ -215,7 +234,7 @@ func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, b
 	if diff.Type != "frozen_diff" || strings.TrimSpace(string(diff.Content)) == "" {
 		return "", "", false, nil
 	}
-	headArt, err := store.NodeArtifact(siblingID, "freeze-head")
+	headArt, err := store.NodeArtifact(siblingID, freezeKey+"-head")
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {
 			return "", "", false, nil
@@ -225,7 +244,7 @@ func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, b
 	if headArt.Type != "commit" {
 		return "", "", false, nil
 	}
-	baseArt, err := store.NodeArtifact(siblingID, "freeze-base")
+	baseArt, err := store.NodeArtifact(siblingID, freezeKey+"-base")
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) || errors.Is(err, wfe.ErrArtifactNotExist) {
 			return "", "", false, nil
@@ -238,7 +257,7 @@ func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, b
 	return string(headArt.Content), string(baseArt.Content), true, nil
 }
 
-func (r *NativeRunner) rejectDivergentSiblingCreates(ctx context.Context, item db1.WorkItem, workdir, base, head string) error {
+func (r *NativeRunner) rejectDivergentSiblingCreates(ctx context.Context, item db1.WorkItem, freezeKey, workdir, base, head string) error {
 	if item.ParentID == "" {
 		return nil
 	}
@@ -260,7 +279,7 @@ func (r *NativeRunner) rejectDivergentSiblingCreates(ctx context.Context, item d
 		if sibling.ID == item.ID || sibling.State != "active" {
 			continue
 		}
-		siblingHead, siblingBase, frozen, readErr := frozenSiblingArtifacts(sibling.ID, r.artifacts)
+		siblingHead, siblingBase, frozen, readErr := frozenSiblingArtifacts(sibling.ID, freezeKey, r.artifacts)
 		if readErr != nil {
 			return freezeSiblingUncomparableError(item.ID, sibling.ID, freezeUncomparablePathIdentifier(creates), readErr)
 		}

--- a/server-go/internal/engine/freeze_collision_test.go
+++ b/server-go/internal/engine/freeze_collision_test.go
@@ -121,7 +121,7 @@ func TestRejectDivergentSiblingCreatesComparesEmptyWorktreeFromFreezeCommits(t *
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("missing-worktree sibling with freeze commits should still compare non-overlapping creates, got: %v", err)
 	}
 }
@@ -145,7 +145,7 @@ func TestRejectDivergentSiblingCreatesRejectsCollisionWithoutWorktree(t *testing
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
 }
 
@@ -169,7 +169,7 @@ func TestRejectDivergentSiblingCreatesRejectsCollisionWithMissingWorktreeDir(t *
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
 }
 
@@ -193,7 +193,7 @@ func TestRejectDivergentSiblingCreatesStillRejectsWithWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
 }
 
@@ -217,7 +217,7 @@ func TestRejectDivergentSiblingCreatesAllowsIdenticalCreateWithoutWorktree(t *te
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("identical create without sibling worktree should pass, got: %v", err)
 	}
 }
@@ -252,7 +252,7 @@ func TestRejectDivergentSiblingCreatesAllowsCurrentSliceEditingExistingFile(t *t
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("edit-only current slice should pass, got: %v", err)
 	}
 }
@@ -302,7 +302,7 @@ func TestRejectDivergentSiblingCreatesAllowsSiblingWithEmptyCreateSet(t *testing
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("sibling with empty frozen create set should not collide with current slice create, got: %v", err)
 	}
 }
@@ -337,7 +337,7 @@ func TestRejectDivergentSiblingCreatesSkipsSiblingWithInvalidFreezeHeadType(t *t
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("sibling without the durable freeze triple must be skipped, got: %v", err)
 	}
 }
@@ -371,7 +371,7 @@ func TestRejectDivergentSiblingCreatesSkipsSiblingWithMissingFreezeArtifacts(t *
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("sibling without the durable freeze triple must be skipped, got: %v", err)
 	}
 }
@@ -415,7 +415,7 @@ func TestRejectDivergentSiblingCreatesUsesDurableArtifactsWithoutWorkflowRegistr
 	// Deliberately omit workflows: durable freeze artifacts alone must drive the
 	// collision check, so the divergent sibling freeze is rejected.
 	runner := &NativeRunner{db: store, artifacts: artifacts}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
 }
 
@@ -456,7 +456,7 @@ func TestRejectDivergentSiblingCreatesRecognizesFrozenSiblingRoutedBackToImpleme
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
 }
 
@@ -513,7 +513,7 @@ func TestRejectDivergentSiblingCreatesAllowsIdenticalCreateFromDistinctSiblingWo
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("identical create on distinct sibling worktree should pass, got: %v", err)
 	}
 }
@@ -566,7 +566,7 @@ func TestRejectDivergentSiblingCreatesStillRejectsDivergenceFromDistinctSiblingW
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
 }
 
@@ -623,7 +623,7 @@ func TestRejectDivergentSiblingCreatesReportsLexicographicallySmallestCollision(
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	// All three creates collide; the diagnostic must name "alpha.txt" because
 	// it is the smallest colliding path. A non-deterministic implementation
 	// would surface "frozen.txt" or "zeta.txt" on some runs and fail this
@@ -695,7 +695,7 @@ func TestRejectDivergentSiblingCreatesReportsDeterministicCollisionAcrossRuns(t 
 				t.Fatal(err)
 			}
 			runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-			err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+			err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 			assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
 			seen = append(seen, err.Error())
 		})
@@ -735,6 +735,80 @@ func TestRejectDivergentSiblingCreatesRejectsTrailingWhitespaceDivergence(t *tes
 		t.Fatal(err)
 	}
 	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
-	err = runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead)
+	err = runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead)
 	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
+}
+
+// TestFreezeArtifactKeyResolvesEmptyNodeIDToConventionalKey is the regression
+// guard for the literal-"freeze" fallback that freeze used to apply when
+// req.Node.ID was empty. Today the helper freezeArtifactKey is the single
+// source of truth for the publish/read key on both sides, so the empty Node.ID
+// case must resolve to the same conventional key the read side expects ("freeze"
+// itself), not to "" or any other value -- otherwise the freeze would publish
+// under one key and frozenSiblingArtifacts would read under another, silently
+// skipping sibling-collision rejection. Pinning both observations here means
+// any private fallback reintroduced on either side will fail the test.
+func TestFreezeArtifactKeyResolvesEmptyNodeIDToConventionalKey(t *testing.T) {
+	if got := freezeArtifactKey(StepRequest{}); got != "freeze" {
+		t.Fatalf("freezeArtifactKey(StepRequest{}) = %q, want conventional key %q", got, "freeze")
+	}
+}
+
+// TestFreezeAndFrozenSiblingArtifactsAgreeOnConventionalKeyWhenNodeIDEmpty is
+// the end-to-end regression guard: when a caller constructs a StepRequest
+// without a Node.ID (e.g. an HTTP runner carrying a partial request), the
+// freeze block must publish the durable (frozen_diff, freeze-head,
+// freeze-base) triple under the conventional "freeze" key AND
+// frozenSiblingArtifacts must read it back from the same key. Any future
+// change that lets either side drift -- e.g. a private fallback that resolves
+// the empty Node.ID case differently on the read side -- will break this
+// test.
+func TestFreezeAndFrozenSiblingArtifactsAgreeOnConventionalKeyWhenNodeIDEmpty(t *testing.T) {
+	ctx, store, artifacts, registry, _, slicedir, base, head := setupFreezeCollisionHarness(t)
+
+	// Sanity: with Node.ID == "" the helper resolves to the conventional key
+	// both sides historically used, so the seeded sibling (key "freeze") and a
+	// current slice that publishes under "" (resolved to "freeze") land on
+	// the same key. If freezeArtifactKey ever changes its fallback, this
+	// round-trip will break and surface the drift before it ships.
+	if got := freezeArtifactKey(StepRequest{}); got != "freeze" {
+		t.Fatalf("freezeArtifactKey(StepRequest{}) = %q, want conventional key %q", got, "freeze")
+	}
+
+	item, err := store.WorkItem(ctx, "wi_s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a divergent create on the current slice; with Node.ID == "" the
+	// freeze helper resolves to "freeze" so the current slice's collision
+	// check must still see the sibling's seeded "freeze" artifact and reject.
+	if err := os.WriteFile(filepath.Join(slicedir, "frozen.txt"), []byte("conflicting slice blob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, slicedir, "add", "frozen.txt")
+	gitRun(t, slicedir, "commit", "-m", "divergent create")
+	currentHead := strings.TrimSpace(gitRun(t, slicedir, "rev-parse", "HEAD"))
+
+	runner := &NativeRunner{db: store, artifacts: artifacts, workflows: registry}
+	err = runner.rejectDivergentSiblingCreates(ctx, item, freezeArtifactKey(StepRequest{}), slicedir, base, currentHead)
+	assertFreezeCreateCollision(t, err, "frozen.txt", item.ID, "wi_s0")
+
+	// Also pin the read side directly: frozenSiblingArtifacts with the same
+	// resolved key must return ok=true for the seeded sibling (the durable
+	// triple is present), proving the publish and read keys are in sync.
+	_ = registry // keep harness symmetry
+	siblingHead, siblingBase, ok, readErr := frozenSiblingArtifacts("wi_s0", freezeArtifactKey(StepRequest{}), artifacts)
+	if readErr != nil {
+		t.Fatalf("frozenSiblingArtifacts: unexpected read error: %v", readErr)
+	}
+	if !ok {
+		t.Fatalf("frozenSiblingArtifacts: ok=false, want true (publish/read keys must match)")
+	}
+	if siblingHead != head {
+		t.Fatalf("frozenSiblingArtifacts: siblingHead=%q want %q", siblingHead, head)
+	}
+	if siblingBase != base {
+		t.Fatalf("frozenSiblingArtifacts: siblingBase=%q want %q", siblingBase, base)
+	}
 }

--- a/server-go/internal/engine/integrate_base_test.go
+++ b/server-go/internal/engine/integrate_base_test.go
@@ -947,7 +947,7 @@ nodes:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, head); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, head); err != nil {
 		t.Fatalf("identical create rejected: %v", err)
 	}
 
@@ -970,7 +970,7 @@ nodes:
 	gitRun(t, slicedir, "add", "README")
 	gitRun(t, slicedir, "commit", "-m", "current existing edit")
 	currentHead := strings.TrimSpace(gitRun(t, slicedir, "rev-parse", "HEAD"))
-	if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {
+	if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {
 		t.Fatalf("existing-file edit rejected: %v", err)
 	}
 }

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -1043,7 +1043,7 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 	if strings.TrimSpace(diff) == "" {
 		return StepResult{Status: StepAccepted, Detail: "no-op: empty diff vs base"}, nil
 	}
-	if err := r.rejectDivergentSiblingCreates(ctx, item, workdir, resolvedBase, head); err != nil {
+	if err := r.rejectDivergentSiblingCreates(ctx, item, freezeArtifactKey(req), workdir, resolvedBase, head); err != nil {
 		// rejectDivergentSiblingCreates wraps ErrFreezeCreateCreateCollision, but
 		// StepResult.Err is tagged `json:"-"` so the sentinel does not survive an
 		// HTTP-runner round trip. Tag ErrKind so engine.Advance can rehydrate the
@@ -1054,15 +1054,13 @@ func (r *NativeRunner) freeze(ctx context.Context, req StepRequest) (StepResult,
 		}
 		return res, nil
 	}
-	// Publish durable frozen_diff / freeze-head / freeze-base artifacts. Downstream
-	// review stages key on the literal node id "freeze" to find frozen_diff; if the
-	// workflow node id is missing here (e.g. a caller that constructs a StepRequest
-	// without populating Node), fall back to that literal so the artifact is still
-	// published under the conventional key instead of being silently skipped.
-	nodeID := req.Node.ID
-	if nodeID == "" {
-		nodeID = "freeze"
-	}
+	// Publish durable frozen_diff / freeze-head / freeze-base artifacts under the
+	// node id freezeArtifactKey derives from req.Node.ID. The same helper
+	// drives the read side in frozenSiblingArtifacts, so a single source of
+	// truth guarantees the publish and read paths land on the same key for
+	// every freeze block (no hardcoded "freeze" on one side and req.Node.ID
+	// on the other).
+	nodeID := freezeArtifactKey(req)
 	if r.artifacts != nil {
 		if _, err := r.artifacts.PutNodeArtifact(item.ID, nodeID, "frozen_diff", []byte(diff)); err != nil {
 			return StepResult{}, err


### PR DESCRIPTION
## Slice outcome

Unify freeze artifact publication and sibling-lookup keys on req.Node.ID

## What changed

- Freeze publishes durable frozen triple (freeze, freeze-head, freeze-base) under a key derived from req.Node.ID; sibling lookup frozenSiblingArtifacts reads the same key for every freeze block.
- The literal 'freeze' fallback is removed or covered by a regression test asserting Node.ID == '' resolves to the conventional key.
- Behavior is identical when req.Node.ID == 'freeze' (no regression in existing tests).

### Files in this PR

- Updated `server-go/internal/engine/freeze_collision.go`.
- Updated `server-go/internal/engine/freeze_collision_test.go`.
- Updated `server-go/internal/engine/integrate_base_test.go`.
- Updated `server-go/internal/engine/native_runner.go`.

### Representative concrete edits

- `server-go/internal/engine/freeze_collision.go`: changed `func frozenSiblingArtifacts(siblingID string, store *wfe.ArtifactStore) (head, base string, ok bool, err error) {` to `func frozenSiblingArtifacts(siblingID, freezeKey string, store *wfe.ArtifactStore) (head, base string, ok bool, err error) {`.
- `server-go/internal/engine/freeze_collision.go`: changed `diff, err := store.NodeArtifact(siblingID, "freeze")` to `diff, err := store.NodeArtifact(siblingID, freezeKey)`.
- `server-go/internal/engine/freeze_collision.go`: changed `headArt, err := store.NodeArtifact(siblingID, "freeze-head")` to `headArt, err := store.NodeArtifact(siblingID, freezeKey+"-head")`.
- `server-go/internal/engine/freeze_collision.go`: changed `baseArt, err := store.NodeArtifact(siblingID, "freeze-base")` to `baseArt, err := store.NodeArtifact(siblingID, freezeKey+"-base")`.
- `server-go/internal/engine/freeze_collision.go`: changed `func (r *NativeRunner) rejectDivergentSiblingCreates(ctx context.Context, item db1.WorkItem, workdir, base, head string) error {` to `func (r *NativeRunner) rejectDivergentSiblingCreates(ctx context.Context, item db1.WorkItem, freezeKey, workdir, base, head string) error {`.
- `server-go/internal/engine/freeze_collision.go`: changed `siblingHead, siblingBase, frozen, readErr := frozenSiblingArtifacts(sibling.ID, r.artifacts)` to `siblingHead, siblingBase, frozen, readErr := frozenSiblingArtifacts(sibling.ID, freezeKey, r.artifacts)`.
- `server-go/internal/engine/freeze_collision.go`: changed `}` to `}`.
- `server-go/internal/engine/freeze_collision_test.go`: changed `if err := runner.rejectDivergentSiblingCreates(ctx, item, slicedir, base, currentHead); err != nil {` to `if err := runner.rejectDivergentSiblingCreates(ctx, item, "freeze", slicedir, base, currentHead); err != nil {`.

<details>
<summary>Diffstat</summary>

```text
server-go/internal/engine/freeze_collision.go      |  33 +++++--
 server-go/internal/engine/freeze_collision_test.go | 106 +++++++++++++++++----
 server-go/internal/engine/integrate_base_test.go   |   4 +-
 server-go/internal/engine/native_runner.go         |  18 ++--
 4 files changed, 126 insertions(+), 35 deletions(-)
```

</details>

## Verification and integration boundary

This slice may be merged automatically only into its parent `aimee/feat/...` branch after the configured review and CI gates pass. It must never target or merge the repository default branch.

<details>
<summary>Workflow trace</summary>

- Workflow: `slice` (`1fef9ee546d973f8bab4e5ff97fad29b191d2e2ab40203b6a55f0793e015e848`)
- Work item: `wi_57186250728b511961573e5afb37cc93.s2e98448262.g4.0`
- Branches: `aimee/wi/wi_57186250728b511961573e5afb37cc93.s2e98448262.g4.0` → `aimee/feat/wi_57186250728b511961573e5afb37cc93`

</details>

<details>
<summary>Original request</summary>

{"packet_id":"p1","summary":"Unify freeze artifact publication and sibling-lookup keys on req.Node.ID","target_blocks":["implement"],"dependencies":[],"acceptance_criteria":["Freeze publishes durable frozen triple (freeze, freeze-head, freeze-base) under a key derived from req.Node.ID; sibling lookup frozenSiblingArtifacts reads the same key for every freeze block.","The literal 'freeze' fallback is removed or covered by a regression test asserting Node.ID == '' resolves to the conventional key.","Behavior is identical when req.Node.ID == 'freeze' (no regression in existing tests)."]}

</details>