### PR TITLE
fix: satisfy the vault-audit unit test link (branch is currently broken)

### DIFF
--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -4,9 +4,9 @@
  * the response. All policy + crypto lives below in vault_service. */
 #include "server.h" /* server_conn_t, server_send_*, handle_vault_* decls */
 #include "vault_service.h"
-#include "vault_crypto.h"     /* VAULT_ROOT_KEY_LEN */
-#include "vault_capability.h" /* vault:write:server gate (D2c) */
-#include "log.h"               /* audit_log dedicated 0600 audit sink (D2/D2c) */
+#include "vault_crypto.h"       /* VAULT_ROOT_KEY_LEN */
+#include "vault_capability.h"   /* vault:write:server gate (D2c) */
+#include "log.h"                /* audit_log dedicated 0600 audit sink (D2/D2c) */
 #include "vault_audit_bridge.h" /* publish server-principal writes onto the audit bus */
 #include "cJSON.h"
 #include <openssl/crypto.h>
@@ -206,8 +206,7 @@ void vault_audit_server_write(const server_conn_t *conn, const char *agent, cons
       transport = "unknown";
       break;
    }
-   const char *principal =
-      (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)";
+   const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)";
 
    /* D2/D2c: server-principal writes go to the dedicated append-only 0600 audit
     * sink (audit_log), NOT the operator-readable general server log — preserving

--- a/src/tests/test_vault_audit.c
+++ b/src/tests/test_vault_audit.c
@@ -33,6 +33,24 @@ int server_send_response(server_conn_t *conn, cJSON *resp)
    return 0;
 }
 
+/* vault_audit_server_write() also publishes the row onto the audit event bus.
+ * That is a SEPARATE control with its own end-to-end test — test_bus_vault_audit.c
+ * drives the real bridge onto a real bus and reads the ledger back. This test pins
+ * only the D2/D2c 0600 file sink, and linking the bridge here would drag the whole
+ * event bus into a test that has nothing to say about it.
+ *
+ * NOTE this is deliberately a no-op, not an assertion: a change that stops
+ * publishing must fail in test_bus_vault_audit, which owns that behavior, not here. */
+void vault_audit_bridge_server_write(const char *principal, const char *agent, const char *cred,
+                                     const char *fingerprint, const char *transport)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   (void)fingerprint;
+   (void)transport;
+}
+
 static char *slurp(const char *path, size_t *len_out)
 {
    FILE *f = fopen(path, "rb");


### PR DESCRIPTION
## This branch is currently broken

`agent/human-trigger-workflows` does not build its unit tests right now:

```
/usr/bin/ld: undefined reference to `vault_audit_bridge_server_write'
collect2: error: ld returned 1 exit status
make: *** [tests/Rules.mk:5132: build/obj/tests/unit-test-vault-audit] Error 1
```

I introduced this in PR #2372. `vault_audit_server_write` now publishes the audit row onto the bus, but `unit-test-vault-audit` links `server_vault.o` **without** `vault_audit_bridge.o`, so the new call is an undefined symbol at link time.

It went unnoticed because **#2372 merged with zero checks recorded** — it was merged before CI ran on it.

## Fix

`test_vault_audit.c` pins one thing: the D2/D2c control that a server-principal write lands in the dedicated append-only 0600 sink. Linking the bridge into it would drag the entire event bus into a test that has nothing to say about the bus.

So the publish is stubbed, exactly as that file already stubs `server_send_error` / `server_send_response` for the same reason — `server_vault.o` references symbols the path under test never exercises.

The stub is deliberately a **no-op, not an assertion**. A change that stops publishing must fail in `test_bus_vault_audit`, which owns that behavior end-to-end (real bridge -> real bus -> read the ledger back), not here.

Also applies clang-format to the touched files (include-block alignment).

## Verification

- `unit-test-vault-audit` — reproduced the link failure on this branch first, then confirmed it builds and passes after the fix.
- **Full local unit gate** (`make -C src unit-tests`) — exit 0, zero failures.

## Note

Merging #2374 into `testing` does **not** fix this branch — different lineage. This needs its own merge.
