### PR TITLE
ci: gate pull requests that target agent/ integration branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,21 @@ on:
   push:
     branches: [main, testing, feature/core-modularization]
   pull_request:
-    branches: [main, testing, feature/core-modularization, 'aimee/feat/**']
-    # Slice sub-PRs target aimee/feat/<work-item-id>; include them so each slice
-    # must pass the same complete gate as the final feature PR.
+    branches: [main, testing, feature/core-modularization, 'aimee/feat/**', 'agent/**']
+    # NOTE this filter matches the BASE branch, so anything missing from it does
+    # not get a weaker gate — it gets NO gate, and merges with zero checks
+    # recorded. That is not hypothetical: PRs based on agent/<topic> integration
+    # branches ran no CI at all and merged a broken build.
+    #
+    # Slice sub-PRs target aimee/feat/<work-item-id>; agent/<topic> branches are
+    # used the same way, as integration bases that sub-PRs stack onto before the
+    # whole thing reaches testing. Both are included so every sub-PR passes the
+    # same complete gate as the final feature PR.
+    #
+    # Adding 'agent/**' here does NOT double-run anything: a PR FROM agent/x INTO
+    # testing already matched on its base. This only adds PRs whose base is an
+    # agent branch, which previously matched nothing.
+    #
     # `edited` re-runs the gate when a PR title/body is edited after open, so
     # attribution can't be added post-hoc without failing CI.
     types: [opened, synchronize, reopened, edited]


### PR DESCRIPTION
## PRs into `agent/**` branches run no CI at all

`ci.yml` filters `pull_request` by the **base** branch:

```yaml
pull_request:
  branches: [main, testing, feature/core-modularization, 'aimee/feat/**']
```

A base branch missing from that list does not get a weaker gate — it gets **no gate**. The workflow never triggers, so the PR merges with **zero checks recorded**, and because nothing is pending there is nothing to block the merge either.

This is not hypothetical:

- **#2372** targeted `agent/human-trigger-workflows`, merged with zero checks, and broke that branch's unit-test build (`undefined reference to vault_audit_bridge_server_write`).
- **#2376** against the same base reproduced it exactly — `no checks reported`, and `gh run list --branch ...` shows zero runs.

## Fix

Add `'agent/**'` to the `pull_request` base filter. `agent/<topic>` branches are used the same way as `aimee/feat/<work-item-id>` — integration bases that sub-PRs stack onto before the whole thing reaches `testing` — so their sub-PRs should pass the same complete gate.

This does **not** double-run anything: a PR *from* `agent/x` *into* `testing` already matched on its base. This only adds PRs whose base is an agent branch, which previously matched no workflow at all.

## What I deliberately did not change

`push.branches` stays `[main, testing, feature/core-modularization]`. It lists integration *tips*, and `agent/**` cannot distinguish an integration base from an ordinary working branch — adding it there would run the full gate on every push to every agent branch. That is a cost decision worth making explicitly rather than as a side effect of this fix.

## Verified behaviour worth knowing

I tested whether the fix could be applied from the PR side instead: I pushed this same `ci.yml` change to the **head** of #2376 and watched. Still zero runs.

So for `pull_request`, GitHub evaluates the `on:` filter from the **base branch's** workflow file, not the merge commit. Consequences:

1. Merging this into `testing` gates PRs whose base is `testing` — but **not** PRs into `agent/human-trigger-workflows`. That branch needs the change on itself; a companion PR does that.
2. A PR that fixes this can never gate *itself*. Expect this one to show fewer checks than a normal PR.

## Related, unverified

`gh api repos/.../branches/testing/protection` returns **403** for this token, so I could not confirm whether status checks are actually *required* to merge. If they are not, a PR can still merge red even once triggering is fixed. Worth confirming separately.

Validated: the file parses and all 22 jobs load.
