### PR TITLE
ci: gate pull requests that target this branch (companion to #2377)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,18 @@ on:
   push:
     branches: [main, testing, feature/core-modularization]
   pull_request:
-    branches: [main, testing, feature/core-modularization, 'aimee/feat/**']
+    branches: [main, testing, feature/core-modularization, 'aimee/feat/**', 'agent/**']
+    # NOTE this filter matches the BASE branch, and GitHub reads it from the BASE
+    # branch's copy of this file — not from the PR's merge commit (verified: the
+    # same change pushed to a PR head triggered nothing). So this list has to be
+    # correct on every branch used as a merge target, which is why it is fixed
+    # here as well as on testing.
+    #
+    # A base missing from the list does not get a weaker gate — it gets NO gate:
+    # the workflow never triggers, so the PR merges with zero checks recorded and
+    # nothing is pending to block it. PR #2372 merged that way and broke this
+    # branch's unit-test build; #2376 reproduced the condition.
+    #
     # Slice sub-PRs target aimee/feat/<work-item-id>; include them so each slice
     # must pass the same complete gate as the final feature PR.
     # `edited` re-runs the gate when a PR title/body is edited after open, so


### PR DESCRIPTION
Companion to **#2377** (same change against `testing`). Both are needed — this is not a duplicate.

## Why this branch needs its own copy

`ci.yml` filters `pull_request` by the **base** branch, and GitHub reads that filter from the **base branch's copy of the file**, not from the PR's merge commit.

I verified this rather than assuming it: I pushed the identical `ci.yml` change to the head of #2376 and watched. `gh run list --branch agent/fix-vault-audit-test-link` returned **zero runs**, because the base — this branch — still lacked `agent/**`.

So merging #2377 into `testing` gates PRs whose base is `testing`, but does **nothing** for PRs into `agent/human-trigger-workflows`. That is what this PR fixes.

## What is broken today

PRs into this branch run **no checks at all**. Not "fewer checks" — the workflow never triggers, so nothing is recorded and nothing is pending, which means nothing blocks the merge either.

- **#2372** merged that way and broke this branch's unit-test build (`undefined reference to vault_audit_bridge_server_write`).
- **#2376** against the same base reproduced it exactly.

## Note

This PR cannot gate itself — the base branch does not yet have the fix at the time CI would decide whether to run. Expect no checks on it. Every PR into this branch **after** it merges will be gated normally.

Validated: the file parses and all 22 jobs load.
