### PR TITLE
fix(embedder): an empty EMBEDDER_THREADS kills the embedder, and with it the KB

### DIFF
--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -169,7 +169,31 @@ def parse_input_type(value):
     if value is None or value == "":
         return INPUT_TYPE_DEFAULT
     return value if value in INPUT_TYPES else None
-PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
+def _env_int(name, default, fallback=None):
+    """Integer from the environment, treating EMPTY as unset.
+
+    Compose passes an unset variable through as an EMPTY STRING --
+    `EMBEDDER_THREADS: "${EMBEDDER_THREADS:-}"` yields "", not absence -- so
+    os.environ.get(name, "0") returns "" and int("") raises. That killed the
+    embedder at import on every deployment that did not explicitly set the
+    variable: the KB never bound its port, its health check failed forever, and
+    the wizard reported a KB that would not come up. The traceback named this
+    line, but the value looked unset, which is what made it puzzling.
+
+    A junk value is treated the same way. An embedder that refuses to start is
+    worse than one that ignores EMBEDDER_THREADS=banana and logs the default.
+    """
+    raw = (os.environ.get(name) or "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            print("embedder-server: %s=%r is not an integer; using the default"
+                  % (name, raw), file=sys.stderr, flush=True)
+    return default() if callable(default) else default
+
+
+PORT = _env_int("EMBEDDER_PORT", 8080)
 # CPU serving tuning. A single short embed does not scale past ~8 intra-op
 # threads — on a 32-core host pplx-embed-0.6b is 269ms at 32 threads but 189ms at
 # 8 (per-call thread overhead dominates the tiny workload). Cap to a sane default;
@@ -193,7 +217,7 @@ def _usable_cpus():
         return os.cpu_count() or 1
 
 
-EMBEDDER_THREADS = int(os.environ.get("EMBEDDER_THREADS", "0")) or min(8, _usable_cpus())
+EMBEDDER_THREADS = _env_int("EMBEDDER_THREADS", lambda: min(8, _usable_cpus()))
 # onnx | torch | auto. "auto" prefers onnx and falls back; "onnx" refuses to serve
 # on the slow path, which is what a benchmark host wants -- silently serving fp32
 # torch is how a 50x regression went unnoticed.
@@ -392,8 +416,8 @@ def embed(text: str, input_type=INPUT_TYPE_DEFAULT):
 # The window is short (default 15 ms) because it is pure added latency for a
 # request that arrives when the queue is empty -- an interactive query embed must
 # not wait meaningfully. Set EMBEDDER_BATCH_WINDOW_MS=0 to disable coalescing.
-EMBEDDER_BATCH_WINDOW_MS = int(os.environ.get("EMBEDDER_BATCH_WINDOW_MS", "15"))
-EMBEDDER_BATCH_MAX = int(os.environ.get("EMBEDDER_BATCH_MAX", "128"))
+EMBEDDER_BATCH_WINDOW_MS = _env_int("EMBEDDER_BATCH_WINDOW_MS", 15)
+EMBEDDER_BATCH_MAX = _env_int("EMBEDDER_BATCH_MAX", 128)
 
 _batch_lock = threading.Lock()
 _batch_cv = threading.Condition(_batch_lock)

--- a/scripts/tests/test_embedder_env_parsing.py
+++ b/scripts/tests/test_embedder_env_parsing.py
@@ -1,0 +1,96 @@
+"""An EMPTY environment variable must not kill the embedder at import.
+
+Compose passes an unset variable through as an empty string, not as absence:
+
+    EMBEDDER_THREADS: "${EMBEDDER_THREADS:-}"
+
+so os.environ.get("EMBEDDER_THREADS", "0") returns "" and int("") raises
+ValueError at module scope. The embedder then dies before binding :8760, the KB
+never binds :8741, its health check fails forever, and the deployment reports a
+knowledge base that will not come up.
+
+Observed on a fresh production install: the wizard deployed aimee-kb-a25m
+correctly and it sat unhealthy through every restart. The traceback named the
+line, but the variable LOOKED unset -- it was present and empty, which is the
+one case the default argument does not cover.
+
+This is the default path. Any deployment that does not explicitly set the
+variable hits it, so it has to be tested at the value level rather than trusted
+to a default argument.
+"""
+import importlib.util
+import os
+import pathlib
+import sys
+import unittest
+
+MODULE = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "embedder-server.py"
+
+
+def load_env_int():
+    """Import _env_int alone, without the module's torch/model side effects."""
+    src = MODULE.read_text(encoding="utf-8")
+    start = src.index("def _env_int(")
+    end = src.index("PORT = ")
+    ns = {"os": os, "sys": sys}
+    exec(compile(src[start:end], str(MODULE), "exec"), ns)
+    return ns["_env_int"]
+
+
+class TestEnvInt(unittest.TestCase):
+    def setUp(self):
+        self._env_int = load_env_int()
+        self._saved = {k: os.environ.get(k) for k in ("T_PROBE",)}
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_empty_string_uses_the_default(self):
+        """The bug: present-but-empty is what compose actually passes."""
+        os.environ["T_PROBE"] = ""
+        self.assertEqual(self._env_int("T_PROBE", 15), 15)
+
+    def test_whitespace_only_uses_the_default(self):
+        os.environ["T_PROBE"] = "   "
+        self.assertEqual(self._env_int("T_PROBE", 15), 15)
+
+    def test_absent_uses_the_default(self):
+        os.environ.pop("T_PROBE", None)
+        self.assertEqual(self._env_int("T_PROBE", 15), 15)
+
+    def test_a_real_value_still_wins(self):
+        os.environ["T_PROBE"] = "7"
+        self.assertEqual(self._env_int("T_PROBE", 15), 7)
+        os.environ["T_PROBE"] = " 7 "
+        self.assertEqual(self._env_int("T_PROBE", 15), 7)
+
+    def test_junk_falls_back_rather_than_raising(self):
+        """An embedder that refuses to start is worse than one that ignores a
+        bad value and logs the default it used."""
+        os.environ["T_PROBE"] = "banana"
+        self.assertEqual(self._env_int("T_PROBE", 15), 15)
+
+    def test_callable_default_is_only_called_when_needed(self):
+        """EMBEDDER_THREADS defaults to min(8, usable_cpus()), which must not be
+        computed when the operator supplied a value."""
+        calls = []
+
+        def expensive():
+            calls.append(1)
+            return 99
+
+        os.environ["T_PROBE"] = "3"
+        self.assertEqual(self._env_int("T_PROBE", expensive), 3)
+        self.assertEqual(calls, [], "the default was computed despite an explicit value")
+
+        os.environ["T_PROBE"] = ""
+        self.assertEqual(self._env_int("T_PROBE", expensive), 99)
+        self.assertEqual(len(calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A one-line regression from #2380 that breaks the default deployment path.

## What happens

`embedder-server.py` dies at import:

```
File "/opt/aimee/scripts/embedder-server.py", line 196, in <module>
    EMBEDDER_THREADS = int(os.environ.get("EMBEDDER_THREADS", "0")) or min(8, _usable_cpus())
ValueError: invalid literal for int() with base 10: ''
```

Compose passes an **unset** variable through as an **empty string** —
`EMBEDDER_THREADS: ${EMBEDDER_THREADS:-}` yields `""`, not absence — so
`os.environ.get(name, "0")` returns `""`, the default never applies, and `int("")`
raises.

This is the default path. Any deployment that does not explicitly set the
variable hits it.

## Why it is worse than it looks

The embedder never binds `:8760`, so the KB never binds `:8741`, so its health
check fails forever and the container sits `unhealthy` through every restart.
What the operator sees is "the wizard deployed a knowledge base that will not
come up" — several layers away from a string parse.

Observed on a fresh production install: the wizard selected and deployed
`aimee-kb-a25m:testing` correctly and it never became healthy. The traceback
named the line, but the variable *looked* unset. It was present and empty, which
is the one case the default argument does not cover.

## The fix

`_env_int()` treats empty, whitespace-only and unparseable values alike and
falls back, printing which default it used when it ignores something. An
embedder that refuses to start is worse than one that ignores
`EMBEDDER_THREADS=banana` and logs the default.

Applied to all four numeric environment reads (`EMBEDDER_PORT`,
`EMBEDDER_THREADS`, `EMBEDDER_BATCH_WINDOW_MS`, `EMBEDDER_BATCH_MAX`).
`EMBEDDER_STUB_DIM` already guarded itself with `or "2560"`.

The `EMBEDDER_THREADS` default stays lazy — `min(8, _usable_cpus())` is not
computed when the operator supplied a value.

## Tests

`scripts/tests/test_embedder_env_parsing.py` covers the value cases directly
rather than trusting a default argument: empty, whitespace-only, absent, a real
value, surrounding whitespace, junk, and that a callable default is evaluated
only when needed.

Verified red against the shipped line:

```
shipped line raises ValueError: invalid literal for int() with base 10: ''
```

and green on the fix (6 tests).

## Note for deployers already on :testing

Until this ships, setting `EMBEDDER_THREADS` to any non-empty value works
around it. Because the server orchestrates the KB deploy, the variable has to be
in the SERVER container's environment for `${EMBEDDER_THREADS}` in the managed
compose to interpolate — setting it only in `.env` next to the KB compose does
nothing.
