### PR TITLE
build: gate direct module-to-module coupling

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -70,6 +70,10 @@ jobs:
         run: python3 -I -S scripts/check_module_source_ownership.py
       - name: Test module source ownership failure modes
         run: python3 -I scripts/tests/test_check_module_source_ownership.py -v
+      - name: Enforce module bus boundary
+        run: python3 -I -S scripts/check_module_bus_boundary.py
+      - name: Test module bus-boundary failure modes
+        run: python3 -I scripts/tests/test_check_module_bus_boundary.py -v
       - name: Enforce panel contract boundary
         run: python3 -I -S scripts/check_panel_contract_boundary.py
       - name: Test panel contract boundary failure modes

--- a/scripts/check_module_bus_boundary.py
+++ b/scripts/check_module_bus_boundary.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Keep modules off each other's headers: peers meet on the event bus."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+MODULES = "src/modules"
+# The shared core contract every module is allowed to depend on. It is not a
+# peer module and carries no peer's domain types.
+CORE = "core"
+# The two include roots that name a module. `aimee/<id>/` is a module's public
+# API; `modules/<id>/` reaches past it into the owner's private headers, which
+# the build still resolves through -Isrc. Both are counted: a peer is a peer
+# whichever root and whichever bracket style names it.
+MODULE_ROOTS = ("aimee", "modules")
+# Including a bus client header IS bus communication, not direct coupling.
+# Scoped to the exact header: audit_action.h and audit_worm.h are the audit
+# module's own domain API and stay debt below.
+BUS_TRANSPORT_HEADERS = {"aimee/audit/obs_bus.h"}
+# Exact direct module-to-module coupling on testing, each entry a peer header a
+# module reaches for in-process instead of over the bus. Closed list: nothing may
+# join it, and an entry whose include is gone must be deleted, so it only shrinks.
+#
+# The aimee/ir/ entries are a different debt from the rest. aimee_request_t is
+# the pipeline's shared data contract rather than a peer service call; retiring
+# them depends on docs/proposals/pending/ir-sole-path-and-pluggable-stages.md,
+# not on moving a call onto the bus.
+IR_SHARED_TYPE = {
+    ("src/modules/delegates/aimee_ir_rescue.c", "aimee/ir/aimee_ir_metrics.h"),
+    ("src/modules/delegates/include/aimee/delegates/aimee_ir_rescue.h", "aimee/ir/aimee_ir.h"),
+    ("src/modules/delegates/include/aimee/delegates/panel_provider.h", "aimee/ir/panel_result.h"),
+    ("src/modules/memory/gw_stage_memory.c", "aimee/ir/aimee_ir.h"),
+    ("src/modules/memory/gw_stage_memory.h", "aimee/ir/aimee_ir.h"),
+    ("src/modules/translation/include/aimee/translation/aimee_backend.h", "aimee/ir/aimee_ir.h"),
+    ("src/modules/translation/include/aimee/translation/aimee_frontend.h", "aimee/ir/aimee_ir.h"),
+    ("src/modules/translation/include/aimee/translation/aimee_ir_stream.h", "aimee/ir/aimee_ir.h"),
+}
+# A peer service called directly in process. Each one must become bus traffic.
+PENDING_BUS_MIGRATION = {
+    ("src/modules/delegates/delegate_openai.c", "aimee/tools/agent_tools.h"),
+    ("src/modules/delegates/delegate_run_phases.c", "aimee/workspace/workspace.h"),
+    ("src/modules/delegates/delegate_xml_fallback.c", "aimee/tools/agent_tools.h"),
+    ("src/modules/execution-policy/execution_policy.c", "aimee/protocols/mcp/mcp_client_registry.h"),
+    ("src/modules/guardrails/guardrails_action_audit.c", "aimee/audit/audit_action.h"),
+    ("src/modules/guardrails/guardrails_action_audit.c", "aimee/audit/audit_worm.h"),
+    ("src/modules/guardrails/guardrails_orchestrator.c", "aimee/skills/skill.h"),
+    ("src/modules/memory/gw_stage_memory.h", "aimee/gateway/gateway_pipeline.h"),
+    ("src/modules/memory/memory_assemble.c", "aimee/workspace/workspace.h"),
+    ("src/modules/roadmap/roadmap_auto.c", "aimee/delegates/delegate_launch.h"),
+    ("src/modules/roundtable/delegate_ensemble.c", "aimee/delegates/delegate_credentials.h"),
+    ("src/modules/tools/agent_tools.c", "aimee/delegates/delegate_ephemeral_ws.h"),
+    ("src/modules/tools/agent_tools.c", "aimee/protocols/mcp/mcp_client_registry.h"),
+    ("src/modules/tools/agent_tools.c", "aimee/workspace/workspace.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "aimee/delegates/delegate_ephemeral_ws.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "aimee/protocols/mcp/mcp_client_registry.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "aimee/workspace/workspace.h"),
+    ("src/modules/workspace/workspace_provider_container.h", "aimee/delegates/delegate_backend.h"),
+}
+# Worse than the above: these reach past a peer's public API into its private
+# headers, so the coupling is not even to a published contract. Retiring one
+# means the owner grows a bus stage for what the caller needs, not that the
+# caller switches to the peer's public header.
+PRIVATE_HEADER_REACH = {
+    ("src/modules/git/git_ops.c", "modules/workspace/workspace_scope.h"),
+    ("src/modules/git/git_project.c", "modules/workspace/workspace_scope.h"),
+    ("src/modules/git/mcp_git_query.c", "modules/workspace/workspace_provider.h"),
+    ("src/modules/guardrails/guardrails.c", "modules/git/git_verify.h"),
+    ("src/modules/guardrails/guardrails_orchestrator.c", "modules/git/git_verify.h"),
+    ("src/modules/guardrails/guardrails_orchestrator.c", "modules/workspace/workspace_provider.h"),
+    ("src/modules/guardrails/guardrails_orchestrator.c", "modules/workspace/workspace_turn.h"),
+    ("src/modules/guardrails/guardrails_tdd.c", "modules/git/git_verify.h"),
+    ("src/modules/memory/memory_context.c", "modules/learning/learning_evidence.h"),
+    ("src/modules/tools/agent_tools.c", "modules/workspace/workspace_provider.h"),
+    ("src/modules/tools/agent_tools_anchored.c", "modules/workspace/workspace_provider.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "modules/workspace/workspace_provider.h"),
+    ("src/modules/webuser/webuser_editor.c", "modules/git/forge_credentials.h"),
+    ("src/modules/webuser/webuser_editor.c", "modules/git/git_cred_inject.h"),
+    ("src/modules/webuser/webuser_editor.c", "modules/workspace/workspace_scope.h"),
+    ("src/modules/webuser/webuser_runtime.c", "modules/workspace/workspace_scope.h"),
+    ("src/modules/workflows/wfe_live_forge.c", "modules/git/git_cred_inject.h"),
+    ("src/modules/workflows/wfe_live_forge.c", "modules/git/git_pr_api.h"),
+    ("src/modules/workspace/workspace_turn.c", "modules/git/forge_credentials.h"),
+    ("src/modules/workspace/workspace_turn.c", "modules/git/git_cred_inject.h"),
+}
+ALLOWED = IR_SHARED_TYPE | PENDING_BUS_MIGRATION | PRIVATE_HEADER_REACH
+# Both bracket styles: a quoted include couples exactly as hard as an angled one,
+# and the tree uses quoted form for every `modules/` reach and for three
+# `aimee/protocols/` ones.
+INCLUDE = re.compile(r'^\s*#\s*include\s*[<"]([^>"]+)[>"]', re.MULTILINE)
+
+
+class CheckError(ValueError):
+    """A module reached a peer module's header instead of the event bus."""
+
+
+def owning_module(relative: str) -> str:
+    """The module a source path belongs to, by its position under src/modules."""
+    return relative.split("/")[2]
+
+
+def included_module(header: str) -> str | None:
+    """The module an include names, or None when it names no module at all.
+
+    `aimee/<id>/...` is a module's public API and `modules/<id>/...` is its
+    private tree. Everything else -- db1/, db2/, bare filenames -- is a lower
+    layer, not a peer, and is none of this check's business.
+    """
+    parts = header.split("/")
+    if len(parts) < 2 or parts[0] not in MODULE_ROOTS:
+        return None
+    return parts[1]
+
+
+def crossings(root: Path):
+    """Every (path, header) pair where a module includes a peer's header."""
+    modules = root / MODULES
+    if not modules.is_dir():
+        raise CheckError(f"rule=module-root-missing path={MODULES}")
+
+    found: set[tuple[str, str]] = set()
+    for path in sorted((*modules.rglob("*.c"), *modules.rglob("*.h"))):
+        relative = path.relative_to(root).as_posix()
+        owner = owning_module(relative)
+        for header in INCLUDE.findall(path.read_text(encoding="utf-8")):
+            if header in BUS_TRANSPORT_HEADERS:
+                continue
+            peer = included_module(header)
+            if peer is None or peer == owner or peer == CORE:
+                continue
+            found.add((relative, header))
+    return found
+
+
+def validate(root: Path) -> None:
+    found = crossings(root)
+
+    undeclared = sorted(found - ALLOWED)
+    if undeclared:
+        raise CheckError(
+            "rule=undeclared-cross-module "
+            f"crossings={[f'{path} -> {header}' for path, header in undeclared]} "
+            "(a module may only reach a peer over the event bus)"
+        )
+
+    stale = sorted(ALLOWED - found)
+    if stale:
+        raise CheckError(
+            "rule=stale-allowlist "
+            f"crossings={[f'{path} -> {header}' for path, header in stale]} "
+            "(coupling is gone; delete the entry so the list keeps shrinking)"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    args = parser.parse_args()
+    try:
+        validate(args.root.resolve())
+    except (CheckError, OSError, UnicodeError) as exc:
+        print(f"module-bus-boundary: ERROR {exc}", file=sys.stderr)
+        return 1
+    print(f"module-bus-boundary: ok ({len(ALLOWED)} declared crossings remain)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_module_bus_boundary.py
+++ b/scripts/tests/test_check_module_bus_boundary.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Mutation tests for the module bus boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO = Path(__file__).resolve().parents[2]
+CHECKER_PATH = REPO / "scripts/check_module_bus_boundary.py"
+SPEC = importlib.util.spec_from_file_location("module_bus_boundary", CHECKER_PATH)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+# A miniature module tree: `tools` reaches `workspace` in process, and that one
+# crossing is the whole declared debt. Everything else must stay clean.
+CROSSING = ("src/modules/tools/agent_tools.c", "aimee/workspace/workspace.h")
+FIXTURE = {
+    "src/modules/tools/agent_tools.c": (
+        "#include <aimee/tools/agent_tools.h>\n"
+        "#include <aimee/core/bus_client.h>\n"
+        "#include <aimee/workspace/workspace.h>\n"
+    ),
+    "src/modules/tools/include/aimee/tools/agent_tools.h": "#include <aimee/core/bus_client.h>\n",
+    "src/modules/workspace/workspace.c": "#include <aimee/core/bus_client.h>\n",
+    "src/modules/workspace/include/aimee/workspace/workspace.h": "#pragma once\n",
+}
+
+
+class ModuleBusBoundaryTests(unittest.TestCase):
+    def fixture(self, root: Path, files: dict[str, str] | None = None) -> None:
+        for relative, body in (files or FIXTURE).items():
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(body, encoding="utf-8")
+
+    def assert_fixture(self, mutate, rule: str | None, allowed=frozenset({CROSSING})) -> None:
+        """Build the miniature tree, mutate it, and assert the checker's ruling."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.fixture(root)
+            mutate(root)
+            with mock.patch.object(checker, "ALLOWED", set(allowed)):
+                if rule is None:
+                    checker.validate(root)
+                else:
+                    with self.assertRaisesRegex(checker.CheckError, f"rule={rule}"):
+                        checker.validate(root)
+
+    def append(self, relative: str, line: str):
+        def mutate(root: Path) -> None:
+            target = root / relative
+            target.write_text(target.read_text(encoding="utf-8") + line, encoding="utf-8")
+        return mutate
+
+    def test_repository_and_atomic_fixture_pass(self) -> None:
+        checker.validate(REPO)
+        self.assert_fixture(lambda root: None, None)
+
+    def test_a_new_peer_include_is_rejected(self) -> None:
+        self.assert_fixture(
+            self.append("src/modules/workspace/workspace.c", "#include <aimee/tools/agent_tools.h>\n"),
+            "undeclared-cross-module",
+        )
+
+    def test_a_second_peer_header_in_an_allowlisted_file_is_rejected(self) -> None:
+        """The debt is keyed by (path, header), not by the module pair."""
+        self.assert_fixture(
+            self.append("src/modules/tools/agent_tools.c", "#include <aimee/workspace/manifest.h>\n"),
+            "undeclared-cross-module",
+        )
+
+    def test_removing_a_declared_crossing_is_rejected(self) -> None:
+        def mutate(root: Path) -> None:
+            target = root / CROSSING[0]
+            target.write_text(
+                target.read_text(encoding="utf-8").replace(f"#include <{CROSSING[1]}>\n", ""),
+                encoding="utf-8",
+            )
+        self.assert_fixture(mutate, "stale-allowlist")
+
+    def test_core_includes_never_trip_the_check(self) -> None:
+        self.assert_fixture(
+            self.append("src/modules/workspace/workspace.c", "#include <aimee/core/module_host.h>\n"),
+            None,
+        )
+
+    def test_bus_transport_headers_never_trip_the_check(self) -> None:
+        for header in sorted(checker.BUS_TRANSPORT_HEADERS):
+            with self.subTest(header=header):
+                self.assert_fixture(
+                    self.append("src/modules/workspace/workspace.c", f"#include <{header}>\n"),
+                    None,
+                )
+
+    def test_a_peer_domain_header_beside_a_transport_header_is_still_rejected(self) -> None:
+        """obs_bus.h is exempt; the audit module's domain API is not."""
+        self.assert_fixture(
+            self.append(
+                "src/modules/workspace/workspace.c",
+                "#include <aimee/audit/obs_bus.h>\n#include <aimee/audit/audit_worm.h>\n",
+            ),
+            "undeclared-cross-module",
+        )
+
+    def test_self_includes_never_trip_the_check(self) -> None:
+        self.assert_fixture(
+            self.append("src/modules/workspace/workspace.c", "#include <aimee/workspace/manifest.h>\n"),
+            None,
+        )
+
+    def test_a_public_header_is_owned_by_its_module_not_its_include_path(self) -> None:
+        """src/modules/X/include/aimee/X/y.h is X's own, but a peer root is not."""
+        self.assert_fixture(
+            self.append(
+                "src/modules/workspace/include/aimee/workspace/workspace.h",
+                "#include <aimee/workspace/handle.h>\n",
+            ),
+            None,
+        )
+        self.assert_fixture(
+            self.append(
+                "src/modules/workspace/include/aimee/workspace/workspace.h",
+                "#include <aimee/tools/agent_tools.h>\n",
+            ),
+            "undeclared-cross-module",
+        )
+
+    def test_a_commented_out_include_is_not_a_crossing(self) -> None:
+        self.assert_fixture(
+            self.append(
+                "src/modules/workspace/workspace.c",
+                "/* #include <aimee/tools/agent_tools.h> */\n",
+            ),
+            None,
+        )
+
+    def test_a_missing_module_root_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(checker.CheckError, "rule=module-root-missing"):
+                checker.validate(Path(tmp))
+
+    def test_a_quoted_include_couples_exactly_as_hard_as_an_angled_one(self) -> None:
+        self.assert_fixture(
+            self.append('src/modules/workspace/workspace.c', '#include "aimee/tools/agent_tools.h"\n'),
+            "undeclared-cross-module",
+        )
+
+    def test_reaching_a_peers_private_tree_is_rejected(self) -> None:
+        """`modules/<id>/` bypasses the peer's public API entirely."""
+        self.assert_fixture(
+            self.append('src/modules/workspace/workspace.c', '#include "modules/tools/tools_internal.h"\n'),
+            "undeclared-cross-module",
+        )
+
+    def test_a_modules_include_of_the_owners_own_tree_is_not_a_crossing(self) -> None:
+        self.assert_fixture(
+            self.append('src/modules/workspace/workspace.c', '#include "modules/workspace/handle.h"\n'),
+            None,
+        )
+
+    def test_lower_layers_are_not_peers(self) -> None:
+        """db1/, db2/ and bare filenames name no module and are none of our business."""
+        for include in ('"db1/user_memory.h"', '"db2/artifacts.h"', '"local_helper.h"',
+                        '<stdio.h>', '"headers/util.h"'):
+            with self.subTest(include=include):
+                self.assert_fixture(
+                    self.append("src/modules/workspace/workspace.c", f"#include {include}\n"),
+                    None,
+                )
+
+    def test_every_declared_crossing_is_classified_exactly_once(self) -> None:
+        groups = (checker.IR_SHARED_TYPE, checker.PENDING_BUS_MIGRATION,
+                  checker.PRIVATE_HEADER_REACH)
+        union: set = set()
+        for group in groups:
+            self.assertEqual(union & group, set())
+            union |= group
+        self.assertEqual(union, checker.ALLOWED)
+
+    def test_private_reaches_are_recorded_under_the_private_root(self) -> None:
+        for path, header in checker.PRIVATE_HEADER_REACH:
+            with self.subTest(path=path):
+                self.assertTrue(header.startswith("modules/"), f"{path} -> {header}")
+        for path, header in checker.IR_SHARED_TYPE | checker.PENDING_BUS_MIGRATION:
+            with self.subTest(path=path):
+                self.assertTrue(header.startswith("aimee/"), f"{path} -> {header}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A module may only reach a peer over the event bus, but nothing enforced it, so
the coupling could grow silently while the migration ran.

`scripts/check_module_bus_boundary.py` closes the set at the **46** crossings
that exist on `testing`. A new one fails the build; a removed one must be
deleted from the list, so it only ever shrinks.

## Both include roots count, in either bracket style

- `aimee/<id>/...` is a peer's **public API**
- `modules/<id>/...` reaches **past it into the owner's private headers**, which
  the build still resolves through `-Isrc`

Counting only angled `aimee/` includes — which is where this PR started — would
have missed **23 of the 46**, including every single private-tree reach. Quoted
form couples exactly as hard as angled form.

Allowed without an entry: the shared `aimee/core/*` contract, a module's own
headers, lower layers that name no module (`db1/`, `db2/`, bare filenames), and
`aimee/audit/obs_bus.h` — the bus client, so including it *is* bus
communication. Scoped to that exact header: `audit_action.h` and `audit_worm.h`
are the audit module's domain API and stay recorded as debt.

## The debt, split by how it retires

| Count | Group | Meaning |
|---|---|---|
| 8 | `IR_SHARED_TYPE` | `aimee_request_t` is the pipeline's shared data contract, not a peer service call. Depends on the IR sole-path work, not on moving anything onto the bus. |
| 18 | `PENDING_BUS_MIGRATION` | A peer's published API called in process. Each becomes bus traffic. |
| 20 | `PRIVATE_HEADER_REACH` | Past the public API into the owner's private headers. Retiring one means the owner grows a bus stage for what the caller needs — not that the caller switches to the peer's public header. |

The 20 private reaches concentrate in a few places worth knowing about:
`tools`, `guardrails`, `git` and `webuser` reach into `workspace`'s provider and
scope internals; `guardrails` reaches `git_verify.h`; `workflows`, `webuser` and
`workspace` reach `git`'s credential-injection internals.

## Verification

- checker green, exit 0, and green from a non-repository CWD
- 17/17 mutation tests green
- `check_module_source_ownership.py` and `check_panel_contract_boundary.py`
  still green
- red-before-green on the real tree for **all three** include forms — appending
  each of `<aimee/vault/vault_service.h>`, `"aimee/vault/vault_service.h"` and
  `"modules/vault/vault_service.h"` to `src/modules/skills/skill.c` produced
  `rule=undeclared-cross-module` and exit 1; all reverted

## Known gap

This gate is wired into `module-inventory.yml`, whose triggers currently filter
to `feature/core-modularization` only — so it will **not** run on PRs into
`testing` yet. Fixing that trigger is #2385, deliberately held as a draft:
turning the workflow on today makes `testing` red, because two of its existing
steps already fail there.
