### PR TITLE
ci: run the module gates on testing, not a dead branch [BLOCKED]

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -5,11 +5,15 @@ name: Module inventory
 # classic Team-plan check, their workflow/script definitions are reviewable PR
 # content. Do not present proposal-ordering as an isolated trusted executor; a
 # stronger guarantee requires Enterprise required workflows or an external app.
+# These filters match the BASE branch. `feature/core-modularization` alone meant
+# every gate below ran on nothing for a PR into `testing` -- not a weaker gate, no
+# gate at all, which is the exact failure ci.yml warns about in its own filter.
+# Module work now merges to `testing`, so this list tracks ci.yml's.
 on:
   pull_request:
-    branches: [feature/core-modularization]
+    branches: [main, testing, feature/core-modularization, 'aimee/feat/**', 'agent/**']
   push:
-    branches: [feature/core-modularization]
+    branches: [main, testing, feature/core-modularization]
   workflow_dispatch:
 
 concurrency:

--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -61,6 +61,14 @@ EVIDENCE_PATH = "docs/validation/roundtable/git-core-contract.json"
 HANDOFF_PATH = "docs/validation/core-modularization-slice-2.md"
 CHECKER_PATH = "scripts/check_git_core_contract.py"
 FEATURE_BRANCH = "feature/core-modularization"
+# The branches this gate is allowed to run against. It must stay equal to the
+# base-branch filters in .github/workflows/module-inventory.yml: a branch the
+# workflow triggers on but this rejects fails every run with rule=event-base,
+# and a branch this accepts but the workflow never triggers on is dead weight.
+# Git-contract work now merges to testing, so testing is gated; the integration
+# bases are here because sub-PRs stack onto them before reaching it.
+GATED_BASES = ("main", "testing", FEATURE_BRANCH)
+GATED_BASE_PREFIXES = ("aimee/feat/", "agent/")
 GIT = shutil.which("git", path="/usr/bin:/bin") or "/usr/bin/git"
 PYTHON = shutil.which("python3", path="/usr/bin:/bin") or "/usr/bin/python3"
 TRIGGER_GROUPS = (
@@ -602,6 +610,14 @@ def enforce_signal_precedence(
             )
 
 
+def is_gated_base(name: str) -> bool:
+    """Whether this branch is one the module gates run against."""
+    return name in GATED_BASES or any(
+        name.startswith(prefix) and len(name) > len(prefix)
+        for prefix in GATED_BASE_PREFIXES
+    )
+
+
 def validate_event(head: str) -> None:
     keys = (
         "GITHUB_EVENT_NAME",
@@ -625,13 +641,14 @@ def validate_event(head: str) -> None:
     if event == "pull_request":
         if not re.fullmatch(r"refs/pull/[0-9]+/merge", ref):
             fail("event-ref", f"unsupported pull_request ref {ref!r}")
-        if context["GITHUB_BASE_REF"] != FEATURE_BRANCH:
-            fail("event-base", f"pull request must target {FEATURE_BRANCH}")
+        if not is_gated_base(context["GITHUB_BASE_REF"]):
+            fail("event-base", f"pull request must target a gated base, not {context['GITHUB_BASE_REF']!r}")
         if not context["GITHUB_HEAD_REF"]:
             fail("event-head-ref", "GITHUB_HEAD_REF is required for pull requests")
         return
-    if event in {"push", "workflow_dispatch"} and ref == f"refs/heads/{FEATURE_BRANCH}":
-        return
+    if event in {"push", "workflow_dispatch"} and ref.startswith("refs/heads/"):
+        if is_gated_base(ref[len("refs/heads/"):]):
+            return
     fail("event-ref", f"unsupported GitHub event/ref pair {event!r}/{ref!r}")
 
 

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import os
+import re
 from pathlib import Path
 import subprocess
 import tempfile
@@ -649,13 +650,79 @@ class ProposalOrderingTests(unittest.TestCase):
             "GITHUB_EVENT_NAME": "pull_request",
             "GITHUB_REF": "refs/pull/123/merge",
             "GITHUB_SHA": head,
-            "GITHUB_BASE_REF": "main",
+            "GITHUB_BASE_REF": "release/1.0",
             "GITHUB_HEAD_REF": "slice/example",
         }
         with mock.patch.dict(os.environ, wrong_base, clear=True), self.assertRaisesRegex(
             ordering.OrderingError, "event-base"
         ):
             ordering.validate_event(head)
+
+    def test_every_gated_base_is_accepted(self) -> None:
+        """The accepted set must cover every base the workflow triggers on.
+
+        `main` used to be this test's rejected example. It is a gated base now,
+        which is the point: the checker rejected a pull request into `testing`
+        with rule=event-base, so widening the workflow trigger alone left the
+        gate failing every run.
+        """
+        head = "a" * 40
+        for base in ("main", "testing", "feature/core-modularization",
+                     "aimee/feat/1234", "agent/some-topic"):
+            with self.subTest(base=base), mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_EVENT_NAME": "pull_request",
+                    "GITHUB_REF": "refs/pull/123/merge",
+                    "GITHUB_SHA": head,
+                    "GITHUB_BASE_REF": base,
+                    "GITHUB_HEAD_REF": "slice/example",
+                },
+                clear=True,
+            ):
+                ordering.validate_event(head)
+            with self.subTest(base=base, event="push"), mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_EVENT_NAME": "push",
+                    "GITHUB_REF": f"refs/heads/{base}",
+                    "GITHUB_SHA": head,
+                },
+                clear=True,
+            ):
+                ordering.validate_event(head)
+
+    def test_an_ungated_base_is_still_rejected(self) -> None:
+        head = "a" * 40
+        for base in ("release/1.0", "aimee/feat", "agent", "wip"):
+            with self.subTest(base=base), mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_EVENT_NAME": "push",
+                    "GITHUB_REF": f"refs/heads/{base}",
+                    "GITHUB_SHA": head,
+                },
+                clear=True,
+            ), self.assertRaisesRegex(ordering.OrderingError, "event-ref"):
+                ordering.validate_event(head)
+
+    def test_gated_bases_match_the_workflow_triggers(self) -> None:
+        """A base the workflow fires on but this rejects fails every run."""
+        workflow = (REPO_ROOT / ".github/workflows/module-inventory.yml").read_text(
+            encoding="utf-8"
+        )
+        triggers = re.findall(r"^\s*branches: \[(.+)\]$", workflow, re.MULTILINE)
+        self.assertTrue(triggers)
+        for line in triggers:
+            for raw in line.split(","):
+                base = raw.strip().strip("'\"")
+                if base.endswith("/**"):
+                    base = base[: -len("**")] + "example"
+                with self.subTest(base=base):
+                    self.assertTrue(
+                        ordering.is_gated_base(base),
+                        f"{base!r} triggers the workflow but validate_event rejects it",
+                    )
 
     def test_live_input_rejects_symlink(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -223,7 +223,7 @@
         },
         {
           "path": "src/headers/agent_types.h",
-          "sha256": "4931e10e410795ac6801314bc53f45e233518f64988f753a4922ab83e2aa5e08"
+          "sha256": "3350abb2b336236c03a021737364e2614afe66fcf676e99048e1baa5aa7fec0c"
         },
         {
           "path": "src/headers/aimee.h",
@@ -1600,7 +1600,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "4c760795476358fcd21db69a78559a83100e19bb1a2e6507604e95e55926ffdb",
+      "sha256": "33f34840527983a46602000a26b3ed584b27c329f03b80e0ad35be536dea17f4",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
**Draft — one blocker left. Merging before it clears makes `testing` red.**

## The problem

`module-inventory.yml` filters both its `push` and `pull_request` events to
`feature/core-modularization`. Module work merges to `testing`, so every gate in
this workflow matches no PR into `testing` and records no check at all — not a
weaker gate, *no* gate:

- canonical inventory
- module source ownership
- panel contract boundary
- **module bus boundary** (added in #2384, merged — currently not running)
- module documentation
- descriptor-declared test registration
- public-header layout
- refactor surface baselines / cleanup ledger

`ci.yml` already carries a comment warning about exactly this failure mode for
its own filter. This workflow has the bug that comment describes.

This change points the filters at `ci.yml`'s base-branch list.

## Blockers

Turning the workflow back on reveals steps that **already fail on `testing`**,
and have been failing unnoticed for as long as the trigger was dead.

### ~~1. `check_cleanup_ledger.py` — slice 58 cites evidence that moved~~ CLEARED

Fixed in #2387. The proposal had been archived `pending/` → `done/` without the
ledger being repointed.

### 2. `refactor_baselines.py` — 34 of 393 frozen surface files have drifted

**Still open. Needs an owner.**

Three are deletions of frozen public surface, which is precisely what this
baseline exists to catch:

```
MISSING  src/modules/delegates/include/aimee/delegates/panel_roster.h
MISSING  src/modules/skills/include/aimee/skills/skill_review.h
MISSING  src/Makefile#install
CHANGED  31 more, mostly public headers touched by the module migration
```

The tool's remedy is `scripts/refactor_baselines.py freeze`, but running it
asserts that all 34 changes were intended. That needs someone who owns this
surface to adjudicate — it is not a mechanical fix, and I have not done it.

## To unblock

1. ~~Repoint slice 58's evidence path~~ — done, #2387
2. Adjudicate the 34 drifted surfaces and refreeze, or repair what regressed
3. Then merge this

Once this lands, the bus-boundary gate from #2384 starts actually running on
PRs into `testing`, which is the point of the whole exercise.
