### PR TITLE
fix: point slice 58's evidence at the archived proposal

### DIFF
--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -1718,7 +1718,7 @@
       "independent_review": "Delegate review MiniMax-M3 job 12215 assessed the decomposition; the roundtable-approved proposal memory-learning-and-inference-boundaries.md mandates the benchmarks name.",
       "evidence": [
         "docs/validation/core-modularization-slice-58-benchmarks-migration.md",
-        "docs/proposals/pending/memory-learning-and-inference-boundaries.md"
+        "docs/proposals/done/memory-learning-and-inference-boundaries.md"
       ]
     },
     {


### PR DESCRIPTION
`9b22517afd docs: reconcile pending proposal lifecycle` moved
`memory-learning-and-inference-boundaries.md` from `docs/proposals/pending/` to
`docs/proposals/done/` without updating the cleanup ledger that cites it as
slice 58's evidence, so `check_cleanup_ledger.py` has been failing:

```
check_cleanup_ledger: error: slice 58 evidence does not exist:
  docs/proposals/pending/memory-learning-and-inference-boundaries.md
```

Nobody noticed because the only workflow that runs that check
(`module-inventory.yml`) filters its triggers to `feature/core-modularization`
and so never fires for a PR into `testing`. See #2385.

The proposal is unchanged, only relocated. This repoints the one stale
reference — `grep -c` confirms a single occurrence in the ledger.

## Verification

```
$ python3 -c "import json; json.load(open('tests/baselines/refactor/cleanup-ledger.json'))"
json ok
$ python3 -I -S scripts/check_cleanup_ledger.py
check_cleanup_ledger: ok (tests/baselines/refactor/cleanup-ledger.json)
```

This clears one of the two blockers on #2385. The remaining blocker there is
`refactor_baselines.py`: 34 of 393 frozen surface files have drifted, including
three deletions of frozen public surface. That one needs an owner to adjudicate
and is deliberately not touched here.
