### PR TITLE
fix: invalidate the agent config cache on save, never seed it

### DIFF
--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1949,17 +1949,21 @@ static int agent_save_config_impl(const agent_config_t *cfg, int emptied_by_remo
       return -1;
    }
    chmod(agent_config_path(), 0600);
-   {
-      struct stat st;
-      if (stat(agent_config_path(), &st) == 0)
-      {
-         pthread_mutex_lock(&g_agent_config_cache_lock);
-         memcpy(&g_agent_config_cache, cfg, sizeof(g_agent_config_cache));
-         agent_config_stat_remember(&st);
-         g_agent_config_cached = 1;
-         pthread_mutex_unlock(&g_agent_config_cache_lock);
-      }
-   }
+   /* INVALIDATE, never populate. A caller-built config has not been through
+    * agent_load_config()'s normalisation — provider defaulting, the MiniMax wire
+    * rewrite, agent_derive_catalog_provider() and the cost-tier/capability pass
+    * all run there, not here. Caching |cfg| verbatim while stamping it with the
+    * file's fresh stat made every later load a cache HIT on that unnormalised
+    * struct, so the derived fields stayed empty for the whole process lifetime
+    * and only a restart recovered them. That is what left a wizard-added agent
+    * with an empty catalog_provider: it silently lost its required-temperature
+    * row (sending temperature=0.3 to a model that accepts only 1) and its
+    * catalog capability lookup (so it advertised no tools). Dropping the entry
+    * costs one re-parse of a small file on the next load, which then caches the
+    * fully normalised result itself. */
+   pthread_mutex_lock(&g_agent_config_cache_lock);
+   g_agent_config_cached = 0;
+   pthread_mutex_unlock(&g_agent_config_cache_lock);
    free(json);
    return 0;
 }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -3363,6 +3363,67 @@ static void test_agent_config_deletion_guard(void)
    printf("  PASS: agent_config_deletion_guard\n");
 }
 
+/* Saving a config must not seed the load cache with the caller's struct.
+ *
+ * Every writer (the setup wizard's /v1 agent-add included) builds an agent_t
+ * from request fields and calls agent_save_config(); NONE of them run the
+ * normalisation that agent_load_config() owns — provider defaulting, the wire
+ * rewrite, agent_derive_catalog_provider(), the tier/capability pass. The save
+ * path used to memcpy that raw struct into the cache and stamp it with the
+ * freshly written file's stat, so the very next load was a cache HIT on an
+ * unnormalised config and stayed one for the life of the process.
+ *
+ * The user-visible damage was silent: a wizard-added Kimi agent kept an empty
+ * catalog_provider, so agent_catalog_provider() fell back to the wire name
+ * "openai". That cost it the {moonshotai,k3,1.0} required-temperature row (the
+ * delegate's default 0.3 reached a model that accepts only 1, failing every
+ * call with "invalid temperature: only 1 is allowed for this model") and made
+ * model_capability_get() miss, so it advertised no tools and tool roles
+ * rejected it as unavailable. Only a restart cleared it. */
+static void test_agent_save_config_does_not_cache_underived_agents(void)
+{
+   /* The bug is invisible when the cache is bypassed, so assert on the cached
+    * path explicitly rather than inheriting whatever the harness set. */
+   platform_unsetenv("AIMEE_NO_CACHE");
+   unlink(agent_config_path());
+
+   /* Exactly what a writer hands to agent_save_config: endpoint and model set,
+    * no provider and no catalog_provider — both are load-side derivations. */
+   agent_config_t built;
+   memset(&built, 0, sizeof(built));
+   built.agent_count = 1;
+   snprintf(built.default_agent, sizeof(built.default_agent), "%s", "Kimi");
+   snprintf(built.agents[0].name, sizeof(built.agents[0].name), "%s", "Kimi");
+   snprintf(built.agents[0].endpoint, sizeof(built.agents[0].endpoint), "%s",
+            "https://api.kimi.com/coding/v1");
+   snprintf(built.agents[0].model, sizeof(built.agents[0].model), "%s", "kimi-k3");
+   snprintf(built.agents[0].auth_type, sizeof(built.agents[0].auth_type), "%s", "bearer");
+   snprintf(built.agents[0].api_key, sizeof(built.agents[0].api_key), "%s", "k");
+   snprintf(built.agents[0].roles[0], sizeof(built.agents[0].roles[0]), "%s", "review");
+   built.agents[0].role_count = 1;
+   built.agents[0].enabled = 1;
+   assert(built.agents[0].catalog_provider[0] == '\0');
+
+   assert(agent_save_config(&built) == 0);
+
+   agent_config_t loaded;
+   assert(agent_load_config(&loaded) == 0);
+   const agent_t *kimi = agent_find(&loaded, "Kimi");
+   assert(kimi != NULL);
+
+   /* The load must have re-parsed and derived. Asserting the raw field rather
+    * than agent_catalog_provider() is deliberate: the accessor falls back to
+    * ->provider, which would mask an empty field behind the wire name — and it
+    * is the RAW field that model_sampling.c's required-temperature gate reads. */
+   assert(strcmp(kimi->catalog_provider, "moonshotai") == 0);
+
+   /* The wire provider is still the load-side default, untouched by derivation. */
+   assert(strcmp(kimi->provider, "openai") == 0);
+
+   unlink(agent_config_path());
+   printf("  PASS: test_agent_save_config_does_not_cache_underived_agents\n");
+}
+
 int main(void)
 {
    char tmp_home[512];
@@ -3412,6 +3473,7 @@ int main(void)
    test_catalog_provider_explicit_round_trip();
    test_unknown_context_window_does_not_pass_min_context();
    test_context_window_table_covers_live_vendors();
+   test_agent_save_config_does_not_cache_underived_agents();
    test_catalog_provider_host_matching_is_label_anchored();
    test_catalog_provider_namespaced_model_ids();
    test_moonshot_heuristic_scopes_reasoning_to_known_families();


### PR DESCRIPTION
## Problem

`agent_save_config_impl()` memcpy'd the caller's config into the load cache and stamped it with the freshly written file's stat, so the very next `agent_load_config()` was a cache **HIT** on a struct that had never been normalised.

Writers build an `agent_t` straight from request fields — the setup wizard's agent-add in `server_agent.c` included. Provider defaulting, the MiniMax wire rewrite, `agent_derive_catalog_provider()` and the tier/capability pass all live in `agent_load_config()`, not in the writers. So the derived fields stayed empty for the whole process lifetime and **only a restart recovered them**.

## Observed on a fresh install

A wizard-added Kimi agent kept an empty `catalog_provider`, so `agent_catalog_provider()` fell back to the wire name `openai`. Two symptoms, one unset field:

1. It lost the `{moonshotai,k3,1.0}` required-temperature row, so the delegate's default `temperature=0.3` reached a model that accepts only 1 — every call failed with `invalid temperature: only 1 is allowed for this model`.
2. `model_capability_get()` missed under the wrong vendor, so it advertised no tools and tool roles rejected it with `no configured model supports required capabilities (caps=tools)`.

MiniMax was silently degraded the same way (`catalog_provider=anthropic` instead of `minimax`).

The failure is misleading: `aimee agent list` shows the agent `ON` with the correct model and endpoint, so nothing looks wrong.

## Fix

Invalidate the cache entry on save instead of populating it. The next load re-parses a small file and caches the fully normalised result itself. Both `agent_save_config()` and `agent_save_config_after_removal()` funnel through this impl, so both writer paths are covered.

This fixes the whole class, not just `catalog_provider` — provider defaulting and the wire rewrite were being dropped identically.

## Testing

New regression test `test_agent_save_config_does_not_cache_underived_agents` reproduces the wizard's exact shape (endpoint + model, no `provider`, no `catalog_provider`), saves via `agent_save_config`, then loads.

It asserts the **raw** `catalog_provider` field rather than `agent_catalog_provider()`: the accessor falls back to `->provider` and would mask the empty field behind `openai`, and the raw field is what `model_sampling.c`'s required-temperature gate reads. It also `unsetenv("AIMEE_NO_CACHE")` so it exercises the cached path where the bug lives.

Verified red → green (fix stashed, then reapplied):

- Without: `test_agent_caps.c:276: Assertion 'strcmp(kimi->catalog_provider, "moonshotai") == 0' failed`
- With: `PASS: test_agent_save_config_does_not_cache_underived_agents`

Gates run locally on this branch's base:

- `make unit-tests` — exit 0, shard 1/1, 0 assertion failures
- `make lint` — all 47 checks passed
- `make docs-gen-check` — ok (no regenerated diffs)
- Compiles clean under `-Wall -Wextra -Werror`

Fix confirmed end-to-end against a live server: with the stale cache cleared, Kimi returns `PONG` on a draft role and `TOOLS-OK` on a tool role, and both Kimi and MiniMax advertise `[tools]`.