### PR TITLE
fix: size the signing-inventory test from the committed inventory

### DIFF
--- a/scripts/tests/test_sign_module_docs.py
+++ b/scripts/tests/test_sign_module_docs.py
@@ -48,9 +48,17 @@ class SignModuleDocsTests(unittest.TestCase):
             callback()
 
     def test_committed_inventory_is_the_only_signing_inventory(self) -> None:
+        # Sizes come from the committed inventory, not literals. A literal here is
+        # a second copy of a number nothing keeps in step: adding `sandbox` as an
+        # eighth optional module broke this test rather than the signer.
+        baseline = json.loads(
+            (REPO_ROOT / "tests/baselines/modules/canonical-inventory.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
         required, optional = signer._inventory(REPO_ROOT)
-        self.assertEqual(len(required), 18)
-        self.assertEqual(len(optional), 7)
+        self.assertEqual(len(required), len(baseline["required"]))
+        self.assertEqual(len(optional), len(baseline["optional"]))
         self.assertFalse(required & optional)
 
     def test_public_key_input_cannot_be_a_private_key(self) -> None:


### PR DESCRIPTION
The last mechanical blocker on #2385.

`test_sign_module_docs.py` asserted the literal `7` optional modules while the
committed inventory has `8`:

```
FAIL: test_committed_inventory_is_the_only_signing_inventory
AssertionError: 8 != 7
```

Adding `sandbox` as the eighth optional module broke this test, not the signer.
Nothing caught it because the only workflow that runs it (`module-inventory.yml`)
filters its triggers to `feature/core-modularization` and never fires for a PR
into `testing` — see #2385.

This is the same defect and the same fix as the count literals in
`test_check_module_inventory.py` (#2388): the literal was a second copy of a
number nothing keeps in step, so both sizes now derive from
`tests/baselines/modules/canonical-inventory.yaml`.

## Verification

The whole `module-doc-contract` job, run locally:

```
$ python3 -I scripts/tests/test_module_doc_contract.py      # 24/24 OK
$ python3 -I scripts/tests/test_module_doc_git_snapshot.py  # 12/12 OK
$ python3 -I scripts/tests/test_sign_module_docs.py         #   9/9 OK
```

## Where this leaves #2385

With this merged, every job in `module-inventory.yml` passes except
`proposal-ordering`, which is not fixable by editing files:

```
rule=git-contract-ordering: signal at c1a6925b6e does not follow approved
Slice 2 contract: path:M:src/modules/git/mcp_git_query.c
```

That commit modified git-module source on a topic branch and arrived via a merge,
so its first parent is off the mainline first-parent chain the rule requires. The
contract's `historical_cutoff` knob cannot reach it — the checker requires the
cutoff to precede the Slice 2 anchor, and this commit came after it. Resolving it
is a governance decision about the rule, not a code fix.
