### PR TITLE
fix(git): resolve the PR repository through the workspace runner

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "421f519c6c88a4819c3cce28d364b5b1643218efb1805d1fb9e3ec4bef720d82",
+      "source_sha256": "96c884b511e07471c93099285a1c3bcc920f85f97768530a78f17711df7bc168",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -189,6 +189,48 @@ static int gh_ctx_resolve(const char *principal, const char *repo_dir, gh_ctx_t 
    return 0;
 }
 
+/* As gh_ctx_resolve, but from an "owner/repo" slug the CALLER resolved, for the
+ * callers with no server-visible checkout to run git in. The credential is looked
+ * up against the slug's canonical https remote so per-host resolution still works;
+ * repo_dir is NULL because there is no such directory here. */
+static int gh_ctx_resolve_slug(const char *principal, const char *slug, gh_ctx_t *cx, char *err,
+                               size_t errlen)
+{
+   memset(cx, 0, sizeof(*cx));
+   if (!slug || !slug[0])
+   {
+      snprintf(err, errlen, "no repository");
+      return -1;
+   }
+   const char *sl = strchr(slug, '/');
+   if (!sl || sl == slug || !sl[1] || strchr(sl + 1, '/'))
+   {
+      snprintf(err, errlen, "requires an owner/repo slug");
+      return -1;
+   }
+   size_t ol = (size_t)(sl - slug);
+   if (ol >= sizeof(cx->owner) || strlen(sl + 1) >= sizeof(cx->repo))
+   {
+      snprintf(err, errlen, "repository name too long");
+      return -1;
+   }
+   memcpy(cx->owner, slug, ol);
+   cx->owner[ol] = '\0';
+   snprintf(cx->repo, sizeof(cx->repo), "%s", sl + 1);
+
+   char remote[512];
+   snprintf(remote, sizeof(remote), "https://github.com/%s/%s.git", cx->owner, cx->repo);
+   if (git_cred_inject_resolve_token(principal, remote, NULL, NULL, cx->token, sizeof(cx->token)) !=
+           1 ||
+       !cx->token[0])
+   {
+      wipe(cx->token, sizeof(cx->token));
+      snprintf(err, errlen, "no github credential — connect one in the Git panel");
+      return -1;
+   }
+   return 0;
+}
+
 static void gh_ctx_done(gh_ctx_t *cx)
 {
    wipe(cx->token, sizeof(cx->token));
@@ -411,6 +453,38 @@ int git_pr_create_via_api_ex_draft(const char *principal, const char *repo_dir, 
       else
          title = head;
    }
+
+   /* Everything above needed the checkout; the request itself does not. Hand the
+    * resolved slug to the no-checkout path so there is one copy of the POST. The
+    * token is resolved again there, which costs one vault read and keeps this
+    * function from having to hand a live credential across the boundary. */
+   char slug[264];
+   snprintf(slug, sizeof(slug), "%s/%s", cx.owner, cx.repo);
+   gh_ctx_done(&cx);
+   return git_pr_create_via_api_slug(principal, slug, head, base, title, body, draft, out, out_cap,
+                                     err, errlen);
+}
+
+int git_pr_create_via_api_slug(const char *principal, const char *slug, const char *head,
+                               const char *base, const char *title, const char *body, int draft,
+                               char *out, size_t out_cap, char *err, size_t errlen)
+{
+   if (out && out_cap)
+      out[0] = '\0';
+   if (err && errlen)
+      err[0] = '\0';
+
+   /* No checkout to infer these from, and guessing is how a PR lands on the wrong
+    * base. Refuse instead. */
+   if (!head || !head[0] || !base || !base[0] || !title || !title[0])
+   {
+      snprintf(err, errlen, "head, base and title are required without a checkout");
+      return -1;
+   }
+
+   gh_ctx_t cx;
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
+      return -1;
 
    /* Standing directive: no AI co-authorship / "Generated with" attribution in
     * PR bodies — strip a copy before it reaches GitHub. */

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -55,6 +55,27 @@ int git_pr_create_via_api_ex_draft(const char *principal, const char *repo_dir, 
                                    const char *base, const char *title, const char *body, int draft,
                                    char *out, size_t out_cap, char *err, size_t errlen);
 
+/* Open a PR for an owner/repo slug ("owner/repo") with NO local checkout.
+ *
+ * Every function above resolves the repository by running git in `repo_dir`, in
+ * aimee-server's own process. That is right for webchat and the workflow forge,
+ * whose repo_dir is a path the server holds. It is WRONG for the MCP git tools:
+ * those run against the caller's checkout through the workspace provider, and a
+ * DETACHED workspace keeps the filesystem on the client, so the server cannot see
+ * that path at all -- `git config --get remote.origin.url` there reports "no
+ * origin remote" and the create fails outright (regression #2386, reverted).
+ *
+ * Such a caller resolves owner/repo through the same runner it runs every other
+ * git command with, and hands the slug here. head, base and title are REQUIRED:
+ * there is no checkout to infer a current branch, an origin/HEAD or a last commit
+ * subject from, and guessing them is how a PR lands on the wrong base.
+ *
+ * The credential ladder is unchanged -- the token is resolved for the slug's host
+ * and rides the Authorization header in this process only. */
+int git_pr_create_via_api_slug(const char *principal, const char *slug, const char *head,
+                               const char *base, const char *title, const char *body, int draft,
+                               char *out, size_t out_cap, char *err, size_t errlen);
+
 /* Find the existing open PR for an exact head/base pair. Returns 1 + URL,
  * 0 when absent, or -1 on API/validation failure. */
 int git_pr_find_open_via_api(const char *principal, const char *repo_dir, const char *head,

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -4,6 +4,8 @@
 #include "config.h"
 #include "guardrails.h"
 #include "git_verify.h"
+#include "git_pr_api.h"   /* git_pr_create_via_api_slug */
+#include "agent_config.h" /* agent_get_request_vault_principal */
 #include "mcp_git.h"
 #include "util.h"
 #include "branch_ownership.h"
@@ -465,78 +467,62 @@ cJSON *handle_git_pr(cJSON *args)
       if (cJSON_IsString(jbody))
          strip_ai_attribution(jbody->valuestring);
 
-      char *esc_title = shell_escape(jtitle->valuestring);
-      char *esc_body = shell_escape(cJSON_IsString(jbody) ? jbody->valuestring : "");
       const char *base = cJSON_IsString(jbase) ? jbase->valuestring : "main";
-      char *esc_base = shell_escape(base);
 
-      /* In worktree mode, gh pr create infers the branch from HEAD, which is the
-       * session branch (aimee/session/<id>). Pass --head explicitly with the owned branch. */
-      /* Size the command buffer to the escaped fields (see the edit path above):
-       * a fixed buffer silently truncates a long PR body, corrupting the created
-       * PR's description (and risks the same accumulation overflow). */
-      char *esc_head = NULL;
+      /* Resolve the repository through mcp_git_run, the SAME runner every other git
+       * command here goes through, and hand the slug to the API. The API's
+       * repo_dir-based entry points run git in aimee-server's own process, which is
+       * wrong for this tool: a DETACHED workspace keeps the checkout on the client,
+       * so the server cannot see that path and every create failed with "no origin
+       * remote" (#2386, reverted in #2391). */
+      char slug[264];
+      if (get_origin_repo_slug(slug, sizeof(slug)) != 0)
+         return mcp_text("error: cannot resolve a github.com origin for this checkout");
+
+      /* HEAD is the session branch (aimee/session/<id>) in worktree mode, not the
+       * branch the work belongs to, so name the owned branch explicitly. Otherwise
+       * ask the runner which branch is checked out -- again not this process. */
+      char head[256];
       if (mcp_git_get_worktree())
       {
-         char owned_branch[256];
-         if (branch_own_get_session_branch(owned_branch, sizeof(owned_branch)) != 0)
-         {
-            free(esc_title);
-            free(esc_body);
-            free(esc_base);
+         if (branch_own_get_session_branch(head, sizeof(head)) != 0)
             return mcp_text("error: in worktree mode but no owned branch found. "
                             "Use git_branch action=create to create and register a branch first.");
+      }
+      else
+      {
+         int hrc;
+         char *hout = mcp_git_run("git rev-parse --abbrev-ref HEAD 2>/dev/null", &hrc);
+         if (hrc != 0 || !hout || !hout[0])
+         {
+            free(hout);
+            return mcp_text("error: cannot determine the current branch");
          }
-         esc_head = shell_escape(owned_branch);
-      }
-      size_t cmdcap = 160 + strlen(esc_title) + strlen(esc_body) + strlen(esc_base) +
-                      (esc_head ? strlen(esc_head) : 0);
-      char *cmd = malloc(cmdcap);
-      if (!cmd)
-      {
-         free(esc_title);
-         free(esc_body);
-         free(esc_base);
-         free(esc_head);
-         return mcp_text("error: out of memory building gh command");
-      }
-      if (esc_head)
-         snprintf(cmd, cmdcap, "gh pr create --title '%s' --body '%s' --base '%s' --head '%s' 2>&1",
-                  esc_title, esc_body, esc_base, esc_head);
-      else
-         snprintf(cmd, cmdcap, "gh pr create --title '%s' --body '%s' --base '%s' 2>&1", esc_title,
-                  esc_body, esc_base);
-      free(esc_head);
-      free(esc_title);
-      free(esc_body);
-      free(esc_base);
-
-      int rc;
-      char *out = mcp_git_run(cmd, &rc);
-      free(cmd);
-      if (rc != 0)
-      {
-         cJSON *r = mcp_error("error: gh pr create failed: %s", out ? out : "unknown");
-         free(out);
-         return r;
+         size_t hl = strlen(hout);
+         while (hl > 0 && isspace((unsigned char)hout[hl - 1]))
+            hout[--hl] = '\0';
+         if (!hout[0] || strcmp(hout, "HEAD") == 0)
+         {
+            free(hout);
+            return mcp_text("error: not on a branch (detached HEAD)");
+         }
+         snprintf(head, sizeof(head), "%s", hout);
+         free(hout);
       }
 
-      /* Output from gh pr create is typically just the URL */
-      char result[1024];
-      if (out)
-      {
-         /* Trim trailing newline */
-         size_t len = strlen(out);
-         while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r'))
-            out[--len] = '\0';
-         snprintf(result, sizeof(result), "created: \"%s\"\nurl: %s\nbase: %s", jtitle->valuestring,
-                  out, base);
-      }
-      else
-      {
-         snprintf(result, sizeof(result), "created: \"%s\" (base: %s)", jtitle->valuestring, base);
-      }
-      free(out);
+      char url[1024];
+      char err[512];
+      url[0] = '\0';
+      err[0] = '\0';
+      if (git_pr_create_via_api_slug(agent_get_request_vault_principal(), slug, head, base,
+                                     jtitle->valuestring,
+                                     cJSON_IsString(jbody) ? jbody->valuestring : "", 0, url,
+                                     sizeof(url), err, sizeof(err)) != 0)
+         return mcp_error("error: pr create failed: %s", err[0] ? err : "unknown");
+
+      char result[1280];
+      snprintf(result, sizeof(result), "created: \"%s\"\nurl: %s\nbase: %s", jtitle->valuestring,
+               url, base);
       return mcp_text(result);
    }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2816,7 +2816,7 @@ $(TESTPREFIX)/unit-test-trace-analysis: $(OBJDIR)/tests/test_trace_analysis.o $(
 $(TESTPREFIX)/unit-test-cmd-branch: $(OBJDIR)/tests/test_cmd_branch.o $(OBJDIR)/cmd_branch.o \
                            $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                            $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                           $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o
+                           $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-core: $(OBJDIR)/tests/test_cmd_core.o $(TEST_DATA_OBJS) \
@@ -2825,14 +2825,14 @@ $(TESTPREFIX)/unit-test-cmd-core: $(OBJDIR)/tests/test_cmd_core.o $(TEST_DATA_OB
                          $(OBJDIR)/cmd_infra.o \
                          $(OBJDIR)/cmd_init.o \
                          $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                         $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o
+                         $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-client-integrations: $(OBJDIR)/tests/test_client_integrations.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                        $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/modules/git/git_verify.o $(OBJDIR)/modules/git/git_verify_state.o $(OBJDIR)/modules/git/git_verify_config.o \
+                        $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_verify.o $(OBJDIR)/modules/git/git_verify_state.o $(OBJDIR)/modules/git/git_verify_config.o \
                         $(OBJDIR)/modules/git/git_verify_jobs.o $(OBJDIR)/modules/git/git_verify_hook.o $(OBJDIR)/modules/git/git_verify_ops.o \
                         $(OBJDIR)/modules/git/git_verify_select.o $(OBJDIR)/modules/git/git_verify_step.o $(OBJDIR)/server/compute_pool.o \
                         $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
@@ -3847,7 +3847,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
                             $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                             $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o
+                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
@@ -3858,7 +3858,7 @@ $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
                             $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
                             $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o
+                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-diff: $(OBJDIR)/tests/test_diff.o $(OBJDIR)/diff.o $(OBJDIR)/dstr.o \

--- a/src/tests/support/git_pr_api_stub.c
+++ b/src/tests/support/git_pr_api_stub.c
@@ -8,6 +8,27 @@
 #include <stddef.h>
 #include <stdio.h>
 
+/* The no-checkout variant mcp_git_pr.c's create action calls after resolving the
+ * slug through the workspace runner. Refuses like the wrapper below: these
+ * binaries assert on routing and validation, never on a created PR. */
+int git_pr_create_via_api_slug(const char *principal, const char *slug, const char *head,
+                               const char *base, const char *title, const char *body, int draft,
+                               char *out, size_t out_cap, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)head;
+   (void)base;
+   (void)title;
+   (void)body;
+   (void)draft;
+   if (out && out_cap)
+      out[0] = '\0';
+   if (err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return -1;
+}
+
 int git_pr_create_via_api(const char *principal, const char *repo_dir, const char *title,
                           const char *body, char *out, size_t out_cap, char *err, size_t errlen)
 {

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -723,6 +723,51 @@ static void test_git_pr_create_missing_title(void)
    system(cmd);
 }
 
+/* create must resolve the repository through the workspace runner and refuse
+ * cleanly when there is no github.com origin.
+ *
+ * #2386 instead let the API resolve `origin` in aimee-server's own process. That
+ * looks identical on a co-located checkout and fails on every remote one -- a
+ * DETACHED workspace keeps the filesystem on the client, so the server saw no
+ * such path and reported "no origin remote" for repositories that have one. This
+ * pins the refusal to the runner-resolved path: the message is about THIS
+ * checkout's origin, and it arrives before any API call. */
+static void test_git_pr_create_without_github_origin(void)
+{
+   char tmpdir[] = "/tmp/aimee-test-pr-noorigin-XXXXXX";
+   assert(mkdtemp(tmpdir) != NULL);
+
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd),
+            "cd '%s' && git init -q && git config user.email test@test && "
+            "git config user.name test && echo x > f.txt && "
+            "git add f.txt && git commit -q -m 'init'",
+            tmpdir);
+   assert(system(cmd) == 0);
+
+   char saved_cwd[4096];
+   assert(getcwd(saved_cwd, sizeof(saved_cwd)) != NULL);
+   assert(chdir(tmpdir) == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "create");
+   cJSON_AddStringToObject(args, "title", "a title");
+   cJSON *resp = handle_git_pr(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") != NULL);
+   /* Not "no origin remote": that string is the API's in-process lookup, which
+    * this path must no longer reach. */
+   assert(strstr(text, "origin") != NULL);
+   assert(strstr(text, "no origin remote") == NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   assert(chdir(saved_cwd) == 0);
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   system(cmd);
+}
+
 static void test_git_pr_edit_missing_number(void)
 {
    cJSON *args = cJSON_CreateObject();
@@ -2601,6 +2646,7 @@ int main(void)
    test_git_pr_missing_action();
    test_git_pr_unknown_action();
    test_git_pr_create_missing_title();
+   test_git_pr_create_without_github_origin();
    test_git_pr_edit_missing_number();
    test_git_pr_edit_requires_fields();
    test_git_pr_checks_missing_number();


### PR DESCRIPTION
Second attempt at #2386, which was reverted in #2391. Same goal, correct seam.

## What #2386 got wrong

It called `git_pr_create_via_api_ex`, which resolves the repository by running git **in aimee-server's own process**:

```c
git_cap(repo_dir, "config --get remote.origin.url", ...)
```

Right for webchat and the workflow forge — their `repo_dir` is a path the server holds. Wrong for the MCP git tools: they run against the caller's checkout through the workspace provider, and a **DETACHED** workspace keeps the filesystem on the client. The server had no such path, so every create failed with `no origin remote` on repositories that have one.

`git_forge_vault.h` already warns about precisely this, about identity resolution:

> The config lookup must run WHERE THE COMMIT WILL RUN. A caller whose git commands go through a workspace provider (the MCP git tools) does NOT execute in the server process's own working directory, so resolving config in-process would consult a directory that is not the checkout — and silently find nothing.

## This change

Resolve the repository the way this tool resolves everything else — `mcp_git_run`, which routes per provider (server for SHARED/CONTAINER, marshalled to the client for DETACHED) — and hand the slug to a new no-checkout entry point:

```c
git_pr_create_via_api_slug(principal, "owner/repo", head, base, title, body, draft, ...)
```

`head`, `base` and `title` are **required** there. With no checkout there is no current branch, no `origin/HEAD` and no last-commit subject to infer from, and guessing a base is how a PR lands on the wrong one. The caller supplies all three — head from the owned branch in worktree mode, else `rev-parse --abbrev-ref HEAD` *through the runner*.

`git_pr_create_via_api_ex_draft` keeps its behaviour and now delegates, so the POST and the credential ladder have exactly one copy. It resolves the token twice (once for the default-branch lookup, once in the slug path): one extra vault read in exchange for not handing a live credential across the boundary.

The credential ladder is unchanged — `preferred → per-host vault → principal vault → server identity`, looked up against the slug's canonical https remote, riding the `Authorization` header in server memory only.

## Why the original problem is worth another attempt

`gh pr create` authenticates as whatever ambient credential the environment exposes, and puts the token in a child's argv/environ — the exposure `git_pr_api` exists to close. Observed against `JBailes/infrastructure`: `gh pr list` succeeds (read) while create returns `Resource not accessible by personal access token`, because the request is never made with the vaulted token.

## Verification — read this before merging

Ran locally and clean:
- `gcc -fsyntax-only -Wall -Wextra` on every changed TU
- `clang-format-19 --dry-run --Werror`
- `check_c_repository_lock.py` (pins resynced; digest recomputed with the exporter's own `module_owned_files`/`digest_files`)
- Stub wired into all five targets linking `mcp_git_pr.o` — the link error CI caught on #2386

New test: create in a repo with **no** github origin must refuse through the runner-resolved path and must **not** emit `no origin remote`, that string being the in-process lookup this path no longer reaches.

**What is NOT verified, and it is the important part:** the DETACHED end-to-end — a successful create against a checkout the server cannot see. This workstation has no cmake and no container runtime, so I could not run the shards or a real create. The unit test covers the *refusal*, not the success path, and the success path is exactly what #2386 broke.

Green CI is necessary but not sufficient here. #2386 had green `build` and still failed the moment it met a real DETACHED workspace. This wants a validation deploy to a `:testing` server and an actual `git_pr` create before it is trusted.
