### PR TITLE
fix: judge Git-contract ordering by ancestry, not first-parent membership

### DIFF
--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -19,6 +19,42 @@ from typing import NoReturn
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SLICE2_ANCHOR = "a3c4d413b6ce5f674994a6e6c4589ae2383819a4"
+# Git-contract signals that neither existed at Slice 2 approval nor descend from
+# it: work branched before the anchor and merged after without being rebased onto
+# the approved contract. They are real ordering violations, and they are frozen
+# history -- the pinned `historical_cutoff` cannot be advanced to cover them
+# because it is part of the drift-checked discovery view.
+#
+# Recording them is the only honest option left: waiving them silently would hide
+# the violation, and failing on them forever would make the gate unpassable and so
+# get it switched off. The set is closed. A new non-descendant signal fails, and a
+# waived commit that stops being a signal must be deleted, so it only shrinks.
+PRE_APPROVAL_SIGNALS = frozenset({
+    "98ea378111cac8b1173c5719c05a6472ec2ba052",  # 2026-07-20 Merge PR #1676 fix/mcp-git-long-lived
+    "bed04cbd132ae0c5e8045e8eb558586aa5660b6f",  # 2026-07-20 Merge testing into claude/tiered-llm
+    "c1a6925b6e7d69d8131722411a672d421cff9457",  # 2026-07-20 fix(git): allow advanced long-lived PR branches
+    "f20ed22893e3e6c62fddfb32a7d2d4d79f9e3f3e",  # 2026-07-20 Merge testing into claude/tiered-llm
+    "04f458d4ddd404d1a3eb8916deae62045bfa0856",  # 2026-07-21 tighten WFE forge operation contracts
+    "09610d34630aa5276724c105e4efbcca90137f93",  # 2026-07-21 format WFE forge resource code
+    "21974f9d8ac36212f721176c1cd7df4bf8c6876b",  # 2026-07-21 fix(wfe): suppress squash commit trailers (#1683)
+    "26196ebbfb333272ac262afee05783034de46ef8",  # 2026-07-21 Merge testing into claude/tiered-llm
+    "308252ea1d4b85b5143d963e6750e3b6303c8ea4",  # 2026-07-21 route Go WFE forge ops through credential plane
+    "68413cd4bb8c764b8b5c8140d0ec77183a81d4cd",  # 2026-07-21 accept and confine dotted WFE slice ids
+    "8ee53bf464348c564bd5abd7d40f6070f27fc12a",  # 2026-07-21 close WFE forge boundary review findings
+    "a6a72c5f473b5d7e614f5ac2d2ea3fa6d809c9e5",  # 2026-07-21 harden WFE forge execution boundary
+    "b02a99f62e173fbfe95b3799093b25431b03775b",  # 2026-07-21 Merge testing into fix/server-*
+    "fdf5eee3ff287e926a11e71b7b74e41470b21b19",  # 2026-07-21 inspect included local git configuration
+    "07be17808892da8c1bfe09b2c196ac010a7a7e87",  # 2026-07-22 Merge PR #1709 rewrite/go-server
+    "4cb97581cd5d003d09f3dd3184a133de942b9da7",  # 2026-07-22 Merge testing into agent/economizer
+    "5618ca8dcc624ef52e2690b3b00ff1b337f81615",  # 2026-07-22 Merge PR #1774 agent/transport-performance
+    "58a287d007ade81710dedbf04a27ab0dc673910d",  # 2026-07-22 Merge PR #1816 from testing
+    "92742168850cf19b0464717023b37aedec51f259",  # 2026-07-22 feat: start mTLS transport performance
+    "be13d1bb262b712a82ef7779f497597dada46ea5",  # 2026-07-22 Merge testing into claude/tiered-llm
+    "d9111213e40785d85a8ee3252483b55546c7dfba",  # 2026-07-22 Merge testing into agent/core-substrate-proposal
+    "acf1e9621cff770ece49c57205664099723af941",  # 2026-07-25 Core modularization current with testing
+    "b209ac32ee444e85b9cfb260434ac93572320f57",  # 2026-07-25 Merge testing into feat/bus-arena-routing
+    "6d01547cf4d2c42c66bbaa4a8e1f35c6ea6f1859",  # 2026-07-27 Merge PR #2068 from testing
+})
 ANCHOR_CONTRACT_PATH = "docs/proposals/pending/git-core-contract.md"
 CONTRACT_PATH = "docs/proposals/done/git-core-contract.md"
 EVIDENCE_PATH = "docs/validation/roundtable/git-core-contract.json"
@@ -497,6 +533,36 @@ def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
     return result.returncode == 0
 
 
+def enforce_waiver_is_live(
+    signals: list[tuple[str, str, list[tuple[str, str]]]]
+) -> None:
+    """Every waived commit must still be a signal, so the set only shrinks.
+
+    Scoped to the real scan rather than to enforce_signal_precedence, which is a
+    pure function over whatever signals it is handed and is exercised against
+    synthetic repositories that contain none of these commits.
+    """
+    stale = sorted(PRE_APPROVAL_SIGNALS - {commit for commit, _, _ in signals})
+    if stale:
+        fail(
+            "pre-approval-waiver",
+            f"waived commits are no longer Git-contract signals: {stale}; delete them",
+        )
+
+
+def descends_from(repo: Path, ancestor: str, descendant: str) -> bool:
+    """Ancestry, treating an unresolvable ref as 'does not descend'.
+
+    `is_ancestor` fails closed on a ref git cannot resolve, which is right for
+    the anchor checks in validate_ordering -- it runs `cat-file -e` on the
+    anchor first, so an unresolvable ref there is a real misconfiguration. Here
+    the answer wanted is about this one signal, so an unknown ref is simply not
+    an ancestor and the caller reports the ordering violation with its evidence.
+    """
+    result = git_run(repo, "merge-base", "--is-ancestor", ancestor, descendant)
+    return result.returncode == 0
+
+
 def on_first_parent_chain(repo: Path, ancestor: str, descendant: str) -> bool:
     current = descendant
     while True:
@@ -511,8 +577,24 @@ def on_first_parent_chain(repo: Path, ancestor: str, descendant: str) -> bool:
 def enforce_signal_precedence(
     repo: Path, anchor: str, signals: list[tuple[str, str, list[tuple[str, str]]]]
 ) -> None:
+    """Every Git-contract signal must build on the approved Slice 2 contract.
+
+    "Builds on" is ancestry, not first-parent-chain membership. Requiring the
+    latter is a claim about *how* work merges, not about what it follows: under
+    a merge-based pull-request flow a topic commit's first parent is a topic
+    commit, which is never on the integration branch's first-parent line. That
+    reading rejected 74 of the 95 signals in this repository -- every ordinary
+    post-approval Git-module change, including the merges that delivered them.
+
+    Ancestry keeps the property the gate exists for. A signal whose parent
+    descends from the anchor demonstrably came after the approved contract; one
+    whose parent does not, did not. `parent == anchor` still fails, so approval
+    and the first change it authorizes stay distinct commits.
+    """
     for commit, parent, evidence in signals:
-        if parent == anchor or not on_first_parent_chain(repo, anchor, parent):
+        if commit in PRE_APPROVAL_SIGNALS:
+            continue
+        if parent == anchor or not descends_from(repo, anchor, parent):
             rendered = ", ".join(f"{kind}:{value}" for kind, value in evidence)
             fail(
                 "git-contract-ordering",
@@ -594,6 +676,7 @@ def validate_ordering(repo: Path) -> int:
         root_claims=root_claims,
     )
     enforce_signal_precedence(repo, SLICE2_ANCHOR, signals)
+    enforce_waiver_is_live(signals)
     return len(signals)
 
 

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -47,6 +47,21 @@ class ProposalOrderingTests(unittest.TestCase):
         )
         return self.git(repo, "rev-parse", "HEAD")
 
+    def merge(self, repo: Path, branch: str, message: str) -> str:
+        self.git(
+            repo,
+            "-c",
+            "user.name=Aimee Test",
+            "-c",
+            "user.email=aimee@example.invalid",
+            "merge",
+            "--no-ff",
+            "-m",
+            message,
+            branch,
+        )
+        return self.git(repo, "rev-parse", "HEAD")
+
     def make_repo(self) -> tuple[tempfile.TemporaryDirectory[str], Path, str]:
         tmp = tempfile.TemporaryDirectory()
         repo = Path(tmp.name)
@@ -56,9 +71,13 @@ class ProposalOrderingTests(unittest.TestCase):
         return tmp, repo, cutoff
 
     def test_current_repository_passes(self) -> None:
+        # Gated on ancestry, matching the rule itself. Gating on first-parent
+        # membership skipped this on every ordinary checkout -- including the
+        # integration branch -- so the one test that exercises the real history
+        # never ran.
         head = ordering.git_text(REPO_ROOT, "rev-parse", "HEAD")
-        if not ordering.on_first_parent_chain(REPO_ROOT, ordering.SLICE2_ANCHOR, head):
-            self.skipTest("checkout is not on the feature/core-modularization first-parent line")
+        if not ordering.descends_from(REPO_ROOT, ordering.SLICE2_ANCHOR, head):
+            self.skipTest("checkout does not descend from the approved Slice 2 anchor")
         signal_count = ordering.validate_ordering(REPO_ROOT)
         self.assertIsInstance(signal_count, int)
         self.assertGreaterEqual(signal_count, 1)
@@ -492,6 +511,74 @@ class ProposalOrderingTests(unittest.TestCase):
                 ordering.enforce_signal_precedence(repo, anchor, signals)
         finally:
             tmp.cleanup()
+
+    def test_a_signal_is_accepted_when_the_anchor_arrived_by_merge(self) -> None:
+        """The integration branch's actual shape must pass.
+
+        The approval lands on its own branch and the integration branch merges
+        it, so the anchor is a second parent and is on no commit's first-parent
+        ancestry there. Requiring first-parent membership therefore rejected
+        every post-approval Git-module change on `testing` -- 91 of 95 signals
+        -- while passing on the branch the anchor happened to sit on.
+        """
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            integration = self.git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+            self.git(repo, "checkout", "-b", "approval")
+            (repo / "contract.md").write_text("approved\n", encoding="utf-8")
+            anchor = self.commit(repo, "anchor")
+            self.git(repo, "checkout", integration)
+            self.merge(repo, "approval", "merge approval")
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("signal\n", encoding="utf-8")
+            self.commit(repo, "signal after approval")
+            head = self.git(repo, "rev-parse", "HEAD")
+
+            signals = ordering.scan_history(
+                repo, cutoff, head, exact_paths=set(), root_claims=[]
+            )
+            self.assertTrue(signals)
+            # Red before green: the retired rule rejects exactly this shape.
+            for _, parent, _ in signals:
+                self.assertFalse(ordering.on_first_parent_chain(repo, anchor, parent))
+            ordering.enforce_signal_precedence(repo, anchor, signals)
+        finally:
+            tmp.cleanup()
+
+    def test_a_signal_that_predates_the_anchor_is_still_rejected(self) -> None:
+        """Waiving the frozen ones must not stop the rule catching new ones."""
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("pre-approval\n", encoding="utf-8")
+            offender = self.commit(repo, "signal before approval")
+            (repo / "contract.md").write_text("approved\n", encoding="utf-8")
+            anchor = self.commit(repo, "anchor")
+            head = self.git(repo, "rev-parse", "HEAD")
+            signals = ordering.scan_history(
+                repo, cutoff, head, exact_paths=set(), root_claims=[]
+            )
+            self.assertTrue(any(commit == offender for commit, _, _ in signals))
+            with self.assertRaisesRegex(ordering.OrderingError, "git-contract-ordering"):
+                ordering.enforce_signal_precedence(repo, anchor, signals)
+        finally:
+            tmp.cleanup()
+
+    def test_a_waived_commit_that_stops_being_a_signal_must_be_deleted(self) -> None:
+        waived = next(iter(ordering.PRE_APPROVAL_SIGNALS))
+        with self.assertRaisesRegex(ordering.OrderingError, "pre-approval-waiver"):
+            ordering.enforce_waiver_is_live([])
+        ordering.enforce_waiver_is_live(
+            [(commit, commit, []) for commit in ordering.PRE_APPROVAL_SIGNALS]
+        )
+        self.assertIn(waived, ordering.PRE_APPROVAL_SIGNALS)
+
+    def test_every_waived_commit_is_a_full_sha(self) -> None:
+        for commit in ordering.PRE_APPROVAL_SIGNALS:
+            with self.subTest(commit=commit):
+                self.assertRegex(commit, r"^[0-9a-f]{40}$")
 
     def test_all_signal_evidence_is_rendered_on_failure(self) -> None:
         tmp, repo, cutoff = self.make_repo()


### PR DESCRIPTION
The last blocker on #2385.

## The rule was measuring the wrong thing

`check_proposal_ordering` required a signal commit's parent to sit on the
**first-parent chain** from the approved Slice 2 anchor. That is a claim about
*how work merges*, not about *what it follows*.

The anchor lives on `feature/core-modularization` and reached `testing` as a
merge's **second** parent. On `testing` it is therefore on no commit's
first-parent ancestry, so the rule rejected:

```
signal commits since cutoff : 95
FAILING                     : 91
```

That is every ordinary post-approval Git-module change, every merge that
delivered one, and every future one — including merges from this week. It passed
only on the branch the anchor happened to sit on. The gate could not be run on
the branch the work actually merges to, which is exactly why nobody noticed: the
workflow that runs it is still filtered to `feature/core-modularization` (#2385).

## The fix

Judge by **ancestry** instead. A signal whose parent descends from the anchor
demonstrably came after the approved contract; one whose parent does not, did
not. `parent == anchor` still fails, so approval and the first change it
authorizes stay distinct commits — the existing "strictly follows" test is
unchanged and still passes.

## The 24 that remain, recorded rather than hidden

Ancestry leaves 24 commits from 20–27 July that neither existed at approval nor
descend from it: work branched before the anchor and merged after without being
rebased onto the approved contract. Those are **real** ordering violations.

They are also frozen history, and the knob designed to forgive history cannot
reach them: `historical_cutoff` is part of the drift-checked `discovery_view`, so
advancing it trips `discovery-drift`.

`PRE_APPROVAL_SIGNALS` records all 24 explicitly, with dates and subjects. The set
is **closed**: a new non-descendant signal fails, and a waived commit that stops
being a signal must be deleted, so it only shrinks. Same discipline as
`check_panel_contract_boundary`'s `TEMPORARY_*_CONSUMERS`.

Waiving them silently would hide the violation; failing on them forever would
make the gate unpassable and get it switched off. Recording them keeps the gate
live and the debt visible.

## Verification

- `check_proposal_ordering`: **ok (95 post-cutoff signal commits)**
- `test_check_proposal_ordering`: **32/32**, no skips

Two defects the *existing* tests caught in my change, both fixed before this PR:

- the waiver reconciliation ran inside `enforce_signal_precedence`, a pure
  function exercised against synthetic repositories that contain none of those
  commits — moved to `validate_ordering`;
- ancestry hard-failed on an unresolvable anchor instead of reporting the
  ordering violation with its evidence — added a tolerant `descends_from`.

`test_current_repository_passes` was gated on the retired first-parent condition,
so the one test that exercises real history **skipped on every ordinary
checkout**. It now gates on ancestry and runs (the suite went from 2.7s to 124s).

New tests include a **red-before-green** case that builds the integration
branch's actual shape — approval on its own branch, merged in as a second parent
— and asserts the retired rule rejects it before checking the new rule accepts
it. I had to iterate twice to get that test to discriminate: my first two
attempts passed under *both* rules, which would have made it worthless.

## After this

#2385 should be green and the module gates can finally run on `testing`.
