### PR TITLE
refactor(git): give every PR op a no-checkout entry point

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "96c884b511e07471c93099285a1c3bcc920f85f97768530a78f17711df7bc168",
+      "source_sha256": "48ece87521e2be545f18d0eef3f5749633d390d900ced438bd765538aeacacb5",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -231,6 +231,31 @@ static int gh_ctx_resolve_slug(const char *principal, const char *slug, gh_ctx_t
    return 0;
 }
 
+/* "owner/repo" for a checkout THIS PROCESS can read. The repo_dir entry points use
+ * it to reach their _slug siblings, which hold the actual request. */
+static int gh_slug_from_repo_dir(const char *repo_dir, char *slug, size_t cap, char *err,
+                                 size_t errlen)
+{
+   char origin[1024];
+   if (git_cap(repo_dir, "config --get remote.origin.url", origin, sizeof(origin)) != 0)
+   {
+      snprintf(err, errlen, "no origin remote");
+      return -1;
+   }
+   char owner[128], repo[128];
+   if (parse_github_slug(origin, owner, sizeof(owner), repo, sizeof(repo)) != 0)
+   {
+      snprintf(err, errlen, "requires a github.com origin");
+      return -1;
+   }
+   if ((size_t)snprintf(slug, cap, "%s/%s", owner, repo) >= cap)
+   {
+      snprintf(err, errlen, "repository name too long");
+      return -1;
+   }
+   return 0;
+}
+
 static void gh_ctx_done(gh_ctx_t *cx)
 {
    wipe(cx->token, sizeof(cx->token));
@@ -553,6 +578,21 @@ int git_pr_find_open_via_api(const char *principal, const char *repo_dir, const 
       out[0] = '\0';
    if (number_out)
       *number_out = 0;
+   char slug[264];
+   if (gh_slug_from_repo_dir(repo_dir, slug, sizeof(slug), err, errlen) != 0)
+      return -1;
+   return git_pr_find_open_via_api_slug(principal, slug, head, base, out, out_cap, number_out, err,
+                                        errlen);
+}
+
+int git_pr_find_open_via_api_slug(const char *principal, const char *slug, const char *head,
+                                  const char *base, char *out, size_t out_cap, int *number_out,
+                                  char *err, size_t errlen)
+{
+   if (out && out_cap)
+      out[0] = '\0';
+   if (number_out)
+      *number_out = 0;
    if (!head || !head[0] || !base || !base[0] || strlen(head) > 200 || strlen(base) > 200 ||
        strchr(head, '&') || strchr(head, '?') || strchr(base, '&') || strchr(base, '?'))
    {
@@ -560,7 +600,7 @@ int git_pr_find_open_via_api(const char *principal, const char *repo_dir, const 
       return -1;
    }
    gh_ctx_t cx;
-   if (gh_ctx_resolve(principal, repo_dir, &cx, err, errlen) != 0)
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
    char path[700];
    snprintf(path, sizeof(path), "pulls?state=open&head=%s:%s&base=%s&per_page=1", cx.owner, head,
@@ -596,13 +636,24 @@ int git_pr_update_via_api(const char *principal, const char *repo_dir, int numbe
 {
    if (err && errlen)
       err[0] = '\0';
+   char slug[264];
+   if (gh_slug_from_repo_dir(repo_dir, slug, sizeof(slug), err, errlen) != 0)
+      return -1;
+   return git_pr_update_via_api_slug(principal, slug, number, title, body, err, errlen);
+}
+
+int git_pr_update_via_api_slug(const char *principal, const char *slug, int number,
+                               const char *title, const char *body, char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
    if (number <= 0 || !title || !title[0] || !body || !body[0])
    {
       snprintf(err, errlen, "invalid PR update");
       return -1;
    }
    gh_ctx_t cx;
-   if (gh_ctx_resolve(principal, repo_dir, &cx, err, errlen) != 0)
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
 
    char *clean = strdup(body);
@@ -642,13 +693,24 @@ int git_pr_info_via_api(const char *principal, const char *repo_dir, int number,
 {
    if (err && errlen)
       err[0] = '\0';
+   char slug[264];
+   if (gh_slug_from_repo_dir(repo_dir, slug, sizeof(slug), err, errlen) != 0)
+      return -1;
+   return git_pr_info_via_api_slug(principal, slug, number, out, err, errlen);
+}
+
+int git_pr_info_via_api_slug(const char *principal, const char *slug, int number,
+                             git_pr_info_t *out, char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
    if (!out || number <= 0)
       return -1;
    memset(out, 0, sizeof(*out));
    out->mergeable = -1;
 
    gh_ctx_t cx;
-   if (gh_ctx_resolve(principal, repo_dir, &cx, err, errlen) != 0)
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
    char path[64];
    snprintf(path, sizeof(path), "pulls/%d", number);
@@ -710,13 +772,24 @@ git_pr_ci_t git_pr_ci_via_api(const char *principal, const char *repo_dir, int n
 {
    if (err && errlen)
       err[0] = '\0';
+   char slug[264];
+   if (gh_slug_from_repo_dir(repo_dir, slug, sizeof(slug), err, errlen) != 0)
+      return GIT_PR_CI_ERROR;
+   return git_pr_ci_via_api_slug(principal, slug, number, err, errlen);
+}
+
+git_pr_ci_t git_pr_ci_via_api_slug(const char *principal, const char *slug, int number, char *err,
+                                   size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
    git_pr_info_t info;
-   if (git_pr_info_via_api(principal, repo_dir, number, &info, err, errlen) != 0 ||
+   if (git_pr_info_via_api_slug(principal, slug, number, &info, err, errlen) != 0 ||
        !info.head_sha[0])
       return GIT_PR_CI_ERROR;
 
    gh_ctx_t cx;
-   if (gh_ctx_resolve(principal, repo_dir, &cx, err, errlen) != 0)
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return GIT_PR_CI_ERROR;
    char path[160];
    snprintf(path, sizeof(path), "commits/%s/check-runs?per_page=100", info.head_sha);
@@ -750,10 +823,21 @@ int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number
 {
    if (err && errlen)
       err[0] = '\0';
+   char slug[264];
+   if (gh_slug_from_repo_dir(repo_dir, slug, sizeof(slug), err, errlen) != 0)
+      return -1;
+   return git_pr_merge_via_api_slug(principal, slug, number, err, errlen);
+}
+
+int git_pr_merge_via_api_slug(const char *principal, const char *slug, int number, char *err,
+                              size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
    if (number <= 0)
       return -1;
    gh_ctx_t cx;
-   if (gh_ctx_resolve(principal, repo_dir, &cx, err, errlen) != 0)
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
    char path[64];
    snprintf(path, sizeof(path), "pulls/%d/merge", number);

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -76,6 +76,16 @@ int git_pr_create_via_api_slug(const char *principal, const char *slug, const ch
                                const char *base, const char *title, const char *body, int draft,
                                char *out, size_t out_cap, char *err, size_t errlen);
 
+/* The read/merge ops in the same shape, for the same reason. Each repo_dir entry
+ * point below now resolves the slug and delegates to its _slug sibling, so the
+ * request bodies and the credential ladder have one copy and a caller with no
+ * server-visible checkout has a way in. See git_pr_create_via_api_slug above. */
+int git_pr_find_open_via_api_slug(const char *principal, const char *slug, const char *head,
+                                  const char *base, char *out, size_t out_cap, int *number_out,
+                                  char *err, size_t errlen);
+int git_pr_update_via_api_slug(const char *principal, const char *slug, int number,
+                               const char *title, const char *body, char *err, size_t errlen);
+
 /* Find the existing open PR for an exact head/base pair. Returns 1 + URL,
  * 0 when absent, or -1 on API/validation failure. */
 int git_pr_find_open_via_api(const char *principal, const char *repo_dir, const char *head,
@@ -101,6 +111,8 @@ typedef struct
 
 int git_pr_info_via_api(const char *principal, const char *repo_dir, int number, git_pr_info_t *out,
                         char *err, size_t errlen);
+int git_pr_info_via_api_slug(const char *principal, const char *slug, int number,
+                             git_pr_info_t *out, char *err, size_t errlen);
 
 /* Aggregate CI verdict for the PR's head commit, from the Checks API
  * (GET /commits/<sha>/check-runs) falling back to the legacy combined status
@@ -116,6 +128,8 @@ typedef enum
 
 git_pr_ci_t git_pr_ci_via_api(const char *principal, const char *repo_dir, int number, char *err,
                               size_t errlen);
+git_pr_ci_t git_pr_ci_via_api_slug(const char *principal, const char *slug, int number, char *err,
+                                   size_t errlen);
 
 /* Pure aggregation of the two API payloads (exposed for unit tests): check-runs
  * JSON first; when it lists zero runs, the combined-status JSON decides; both
@@ -157,5 +171,7 @@ int git_pr_ci_permits_merge(git_pr_ci_t ci);
 int git_pr_merge_err_is_conflict(const char *err);
 int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number, char *err,
                          size_t errlen);
+int git_pr_merge_via_api_slug(const char *principal, const char *slug, int number, char *err,
+                              size_t errlen);
 
 #endif /* GIT_PR_API_H */


### PR DESCRIPTION
Stacked on #2393 — review that first. Base retargets to `testing` once it lands.

## Why

#2393 added `git_pr_create_via_api_slug` because the MCP git tools have no server-visible `repo_dir`: they run against the caller's checkout through the workspace provider, and a **DETACHED** workspace keeps the filesystem on the client. Every other PR op still assumed otherwise — `find_open`, `update`, `info`, `ci` and `merge` each resolve `origin` by running git in this process, so a caller without a local checkout gets `no origin remote` from all five.

Same shape as create, applied across: each `repo_dir` entry point resolves the slug via `gh_slug_from_repo_dir` and delegates to a `_slug` sibling holding the request. One copy of each request body and of the credential ladder. Existing callers (webchat, the workflow forge) keep their exact behaviour — they reach the same code through one extra hop.

## What this deliberately does NOT do

I set out to also migrate `mcp_git_pr.c`'s remaining actions off `gh` — that was the stated goal — and stopped, because **none of them map to these functions without losing something.** A silent capability regression is worse than a `gh` call:

| Action | Needs | Today's API gives |
|---|---|---|
| `view` | title, url, mergedAt, mergeStateStatus | `git_pr_info_t` has open/merged/mergeable/head_sha/head/base — none of those four |
| `list` | N× {number, title, state, headRefName} | no equivalent; `find_open` answers one exact head/base pair |
| `checks` | per-check table (name, status, duration, url) | one aggregate enum — a caller could no longer tell *which* check failed |
| `edit` | any subset of title/body/base | `update` requires **both** title and body, cannot set `base` |
| `merge` | PUT + CI gate + mergeCommit lookup | the PUT maps; the surrounding reads go through `gh` |
| `mcp_git_query.c` merged lookup | search `--state merged` | `find_open` is open-only |

That `checks` row is not theoretical — I used the per-check breakdown to diagnose CI on #2386 in this very sequence. Reducing it to `FAILURE` would have made that impossible.

Each gap needs additive API work: fields on `git_pr_info_t`, a list function, per-check detail, optional update fields. That is its own change with its own review. This commit is the foundation all of it needs either way, and it stands on its own: it removes the in-process-checkout assumption from every PR entry point in the module.

## Verification

- `gcc -fsyntax-only -Wall -Wextra` clean on both changed TUs
- `clang-format-19 --dry-run --Werror` clean
- `check_c_repository_lock.py` ok, digest recomputed with the exporter's own helpers
- No stub changes needed: the new siblings live in `git_pr_api.o`, which the test binaries do not link; `mcp_git_pr.o` still references only `create_slug`, already stubbed in #2393

Behaviour-preserving for existing callers by construction. The DETACHED success path remains unproven — same caveat as #2393, and it wants a validation deploy rather than green CI alone.
