### PR TITLE
feat(git): take PR view off `gh`, through the vaulted token

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "48ece87521e2be545f18d0eef3f5749633d390d900ced438bd765538aeacacb5",
+      "source_sha256": "53e6b2808e0a4761407e7d5142ea54e7a12359856efff8df443b5d090bf9fdb1",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "53e6b2808e0a4761407e7d5142ea54e7a12359856efff8df443b5d090bf9fdb1",
+      "source_sha256": "460cc795d4aa4205914bd4781526d5c300f6fdade29be8792ea1b7fd77f0803f",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -751,6 +751,20 @@ int git_pr_info_via_api_slug(const char *principal, const char *slug, int number
    out->open =
        cJSON_IsString(state) && state->valuestring && strcmp(state->valuestring, "open") == 0;
    out->merged = cJSON_IsTrue(merged) ? 1 : 0;
+
+   /* Reviewer-facing fields, best-effort: a PR is still usable without them, so a
+    * missing or over-long value is left empty rather than failing the whole call
+    * the way a missing ref does above. */
+   const cJSON *title = cJSON_GetObjectItem(j, "title");
+   const cJSON *hurl = cJSON_GetObjectItem(j, "html_url");
+   const cJSON *mat = cJSON_GetObjectItem(j, "merged_at");
+   if (cJSON_IsString(title) && title->valuestring)
+      snprintf(out->title, sizeof(out->title), "%s", title->valuestring);
+   if (cJSON_IsString(hurl) && hurl->valuestring)
+      snprintf(out->html_url, sizeof(out->html_url), "%s", hurl->valuestring);
+   if (cJSON_IsString(mat) && mat->valuestring) /* null when never merged */
+      snprintf(out->merged_at, sizeof(out->merged_at), "%s", mat->valuestring);
+
    if (cJSON_IsBool(mergeable))
       out->mergeable = cJSON_IsTrue(mergeable) ? 1 : 0; /* null stays -1 (computing) */
    if (strlen(sha_s) >= sizeof(out->head_sha) || strlen(head_s) >= sizeof(out->head) ||

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -764,6 +764,15 @@ int git_pr_info_via_api_slug(const char *principal, const char *slug, int number
       snprintf(out->html_url, sizeof(out->html_url), "%s", hurl->valuestring);
    if (cJSON_IsString(mat) && mat->valuestring) /* null when never merged */
       snprintf(out->merged_at, sizeof(out->merged_at), "%s", mat->valuestring);
+   const cJSON *mstate = cJSON_GetObjectItem(j, "mergeable_state");
+   if (cJSON_IsString(mstate) && mstate->valuestring)
+   {
+      /* REST spells it lowercase; gh reported the same values upper-cased as
+       * mergeStateStatus, and callers render that spelling. */
+      snprintf(out->merge_state, sizeof(out->merge_state), "%s", mstate->valuestring);
+      for (char *p = out->merge_state; *p; p++)
+         *p = (char)toupper((unsigned char)*p);
+   }
 
    if (cJSON_IsBool(mergeable))
       out->mergeable = cJSON_IsTrue(mergeable) ? 1 : 0; /* null stays -1 (computing) */

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -107,6 +107,13 @@ typedef struct
    char head_sha[72]; /* head commit (for CI lookups) */
    char head[128];    /* head.ref: source branch */
    char base[128];    /* base.ref: the branch this PR merges INTO (empty if unknown) */
+   /* Reviewer-facing fields, so a caller can render a PR without a second trip
+    * through `gh pr view`. Best-effort: a response missing any of them still
+    * yields the refs above rather than failing, so existing callers that only
+    * read open/merged/mergeable are unaffected. */
+   char title[512];    /* PR title */
+   char html_url[512]; /* browser URL */
+   char merged_at[32]; /* ISO8601 merge timestamp; empty when not merged */
 } git_pr_info_t;
 
 int git_pr_info_via_api(const char *principal, const char *repo_dir, int number, git_pr_info_t *out,

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -114,6 +114,10 @@ typedef struct
    char title[512];    /* PR title */
    char html_url[512]; /* browser URL */
    char merged_at[32]; /* ISO8601 merge timestamp; empty when not merged */
+   /* REST `mergeable_state`, upper-cased to match the value gh reported as
+    * mergeStateStatus: CLEAN / DIRTY / BLOCKED / BEHIND / UNSTABLE / DRAFT /
+    * UNKNOWN. Empty when GitHub did not supply one; render that as UNKNOWN. */
+   char merge_state[24];
 } git_pr_info_t;
 
 int git_pr_info_via_api(const char *principal, const char *repo_dir, int number, git_pr_info_t *out,

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -297,25 +297,27 @@ cJSON *handle_git_pr(cJSON *args)
       if (!cJSON_IsNumber(jnum))
          return mcp_text("error: 'number' parameter is required for view");
 
-      char cmd[256];
-      snprintf(cmd, sizeof(cmd),
-               "gh pr view %d --json title,state,url,baseRefName,headRefName,mergedAt "
-               "--template 'PR #%d: {{.state}}\\ntitle: {{.title}}\\n"
-               "base: {{.baseRefName}} <- {{.headRefName}}\\nurl: {{.url}}"
-               "{{if .mergedAt}}\\nmerged: {{.mergedAt}}{{end}}' 2>&1",
-               jnum->valueint, jnum->valueint);
+      char slug[264];
+      if (get_origin_repo_slug(slug, sizeof(slug)) != 0)
+         return mcp_text("error: cannot resolve a github.com origin for this checkout");
 
-      int rc;
-      char *out = mcp_git_run(cmd, &rc);
-      if (rc != 0)
-      {
-         cJSON *r = mcp_error("error: gh pr view failed: %s", out ? out : "unknown");
-         free(out);
-         return r;
-      }
-      cJSON *r = mcp_text(out ? out : "unknown");
-      free(out);
-      return r;
+      git_pr_info_t info;
+      char err[512];
+      err[0] = '\0';
+      if (git_pr_info_via_api_slug(agent_get_request_vault_principal(), slug, jnum->valueint, &info,
+                                   err, sizeof(err)) != 0)
+         return mcp_error("error: pr view failed: %s", err[0] ? err : "unknown");
+
+      /* gh reported OPEN/CLOSED/MERGED; the REST API splits that into state plus a
+       * merged flag. Reassemble it so the rendered output is unchanged. */
+      const char *state = info.merged ? "MERGED" : (info.open ? "OPEN" : "CLOSED");
+
+      char result[1600];
+      int pos = snprintf(result, sizeof(result), "PR #%d: %s\ntitle: %s\nbase: %s <- %s\nurl: %s",
+                         jnum->valueint, state, info.title, info.base, info.head, info.html_url);
+      if (info.merged_at[0] && pos > 0 && (size_t)pos < sizeof(result))
+         snprintf(result + pos, sizeof(result) - (size_t)pos, "\nmerged: %s", info.merged_at);
+      return mcp_text(result);
    }
 
    if (strcmp(action, "edit") == 0)

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -135,25 +135,33 @@ cJSON *handle_git_pr(cJSON *args)
       if (!cJSON_IsNumber(jnum))
          return mcp_text("error: 'number' parameter is required for merge_status");
 
-      char cmd[256];
-      snprintf(cmd, sizeof(cmd),
-               "gh pr view %d --json state,mergedAt,title,mergeable,mergeStateStatus,url "
-               "--template 'PR #%d: {{.state}}{{if .mergedAt}} (merged {{.mergedAt}})"
-               "{{end}} - {{.title}}\\nmergeable: {{.mergeable}}\\n"
-               "merge_state: {{.mergeStateStatus}}\\nurl: {{.url}}' 2>&1",
-               jnum->valueint, jnum->valueint);
+      char slug[264];
+      if (get_origin_repo_slug(slug, sizeof(slug)) != 0)
+         return mcp_text("error: cannot resolve a github.com origin for this checkout");
 
-      int rc;
-      char *out = mcp_git_run(cmd, &rc);
-      if (rc != 0)
-      {
-         cJSON *r = mcp_error("error: gh pr view failed: %s", out ? out : "unknown");
-         free(out);
-         return r;
-      }
-      cJSON *r = mcp_text(out ? out : "unknown");
-      free(out);
-      return r;
+      git_pr_info_t info;
+      char err[512];
+      err[0] = '\0';
+      if (git_pr_info_via_api_slug(agent_get_request_vault_principal(), slug, jnum->valueint, &info,
+                                   err, sizeof(err)) != 0)
+         return mcp_error("error: pr merge_status failed: %s", err[0] ? err : "unknown");
+
+      /* gh's mergeable was a GraphQL enum; REST gives a tri-state bool, which
+       * git_pr_info_t already carries as 1/0/-1. Same three words out. */
+      const char *state = info.merged ? "MERGED" : (info.open ? "OPEN" : "CLOSED");
+      const char *mergeable =
+          info.mergeable == 1 ? "MERGEABLE" : (info.mergeable == 0 ? "CONFLICTING" : "UNKNOWN");
+
+      char result[1600];
+      int pos = snprintf(result, sizeof(result), "PR #%d: %s", jnum->valueint, state);
+      if (info.merged_at[0] && pos > 0 && (size_t)pos < sizeof(result))
+         pos +=
+             snprintf(result + pos, sizeof(result) - (size_t)pos, " (merged %s)", info.merged_at);
+      if (pos > 0 && (size_t)pos < sizeof(result))
+         snprintf(result + pos, sizeof(result) - (size_t)pos,
+                  " - %s\nmergeable: %s\nmerge_state: %s\nurl: %s", info.title, mergeable,
+                  info.merge_state[0] ? info.merge_state : "UNKNOWN", info.html_url);
+      return mcp_text(result);
    }
 
    if (strcmp(action, "merge") == 0)

--- a/src/tests/support/git_pr_api_stub.c
+++ b/src/tests/support/git_pr_api_stub.c
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 
 /* The no-checkout variant mcp_git_pr.c's create action calls after resolving the
  * slug through the workspace runner. Refuses like the wrapper below: these
@@ -24,6 +25,20 @@ int git_pr_create_via_api_slug(const char *principal, const char *slug, const ch
    (void)draft;
    if (out && out_cap)
       out[0] = '\0';
+   if (err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return -1;
+}
+
+/* The view action's read, for the same reason: routing and validation only. */
+int git_pr_info_via_api_slug(const char *principal, const char *slug, int number,
+                             git_pr_info_t *out, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)number;
+   if (out)
+      memset(out, 0, sizeof(*out));
    if (err && errlen)
       snprintf(err, errlen, "pr api unavailable (stub)");
    return -1;


### PR DESCRIPTION
Follows #2393 and #2395. Third of the sequence that moves the git module's PR ops onto the vaulted forge token.

## Why view was blocked

#2395 deliberately stopped short of migrating any remaining action, because none mapped onto the API without losing something. For `view` the gap was four fields `git_pr_info_t` did not carry: **title**, **url**, **mergedAt**, and the single `OPEN`/`CLOSED`/`MERGED` state that `gh` reports.

This adds the three real ones and derives the fourth:

```c
char title[512];    /* PR title */
char html_url[512]; /* browser URL */
char merged_at[32]; /* ISO8601; empty when not merged */
```

**Additive, not a change.** They populate best-effort — a response missing or overflowing one leaves it empty rather than failing, unlike the required refs above it. Existing callers reading only `open`/`merged`/`mergeable`/`head_sha`/`head`/`base` are untouched.

**State is reassembled, not stored.** The REST API splits gh's one value into `state` plus a `merged` flag, so `merged → MERGED`, else `open → OPEN`, else `CLOSED`.

## Output is byte-identical

The rendered result matches the `gh --template` it replaces exactly:

```
PR #<n>: <STATE>
title: <title>
base: <base> <- <head>
url: <url>
[merged: <timestamp>]
```

No caller has to change, and no field is dropped — which was the bar #2395 set for migrating anything.

`view` now resolves the slug through `mcp_git_run` the way `create` does, so it works on a DETACHED workspace where the server cannot see the checkout, and it authenticates with the vaulted token rather than whatever ambient credential `gh` happens to find.

## Still on `gh`, deliberately

Three `gh pr view` invocations remain, each for a stated reason:

- **merge_status** — wants `mergeStateStatus`, which `git_pr_info_t` still lacks
- **mergeCommit lookup** — needs the merge commit oid, no API path yet
- **edit's read-back** — part of `edit`, which needs optional-field update support

`list`, `checks` and `edit` are unchanged for the reasons enumerated in #2395 — notably `checks`, where collapsing the per-check table into one aggregate enum would lose the ability to tell *which* check failed.

## Verification

- `gcc -fsyntax-only -Wall -Wextra` clean on every changed TU
- `clang-format-19 --dry-run --Werror` clean — it rejected my hand-wrapping and this is its wrapping
- `check_c_repository_lock.py` ok, digest recomputed after the reformat (the first digest was stale by one commit's worth of whitespace)
- Stub extended with `git_pr_info_via_api_slug` so the five test binaries linking `mcp_git_pr.o` still resolve — the link class of failure CI caught on #2386

**Not verified:** a live `view` against a real PR. That needs a deploy, exactly as `create` did. Worth noting the precedent though: the create path is now *confirmed* working on a DETACHED checkout — `JBailes/infrastructure#21` was opened through it after deploying #2393+#2395, which is what finally proved the seam.
