### PR TITLE
fix: let the proposal-ordering job finish (testing is red without this)

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -192,7 +192,17 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # scan_history walks every commit since the historical cutoff -- 2397 of them
+    # against this tip -- and spends two git subprocesses on each, so one run is
+    # about two minutes and this job performs three plus the suite. The 5-minute
+    # budget was set when the job only ran on feature/core-modularization; on
+    # testing it cancels the job mid-step. Raised to fit the real cost.
+    #
+    # This grows with history. Making scan_history a single git-log pass would
+    # remove it, but that means reimplementing rename/copy detection and the
+    # blob claim scan in a gate that governs the Git core contract, so it is
+    # deliberately left as separate, reviewable work rather than folded in here.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -571,6 +571,27 @@ def descends_from(repo: Path, ancestor: str, descendant: str) -> bool:
     return result.returncode == 0
 
 
+def anchor_descendants(repo: Path, anchor: str) -> set[str]:
+    """Every commit between the anchor and HEAD, in one command.
+
+    Asking `merge-base --is-ancestor` per signal is one process per commit, and
+    this job runs the checker four times over a hundred-plus signals: enough to
+    exceed the job's five-minute budget on its own. `rev-list --ancestry-path`
+    answers the same question once. The range excludes the anchor, so a parent
+    equal to it is correctly absent.
+    """
+    head = git_run(repo, "rev-parse", "HEAD")
+    if head.returncode != 0:
+        return set()
+    # git_run yields bytes; interpolating them raw produces a b'...' rev range
+    # that git rejects, and an empty set silently fails every signal at once.
+    revision = f"{anchor}..{head.stdout.decode('ascii', 'replace').strip()}"
+    result = git_run(repo, "rev-list", "--ancestry-path", revision)
+    if result.returncode != 0:
+        return set()
+    return set(result.stdout.decode("ascii", "replace").split())
+
+
 def on_first_parent_chain(repo: Path, ancestor: str, descendant: str) -> bool:
     current = descendant
     while True:
@@ -599,10 +620,11 @@ def enforce_signal_precedence(
     whose parent does not, did not. `parent == anchor` still fails, so approval
     and the first change it authorizes stay distinct commits.
     """
+    descendants = anchor_descendants(repo, anchor)
     for commit, parent, evidence in signals:
         if commit in PRE_APPROVAL_SIGNALS:
             continue
-        if parent == anchor or not descends_from(repo, anchor, parent):
+        if parent == anchor or parent not in descendants:
             rendered = ", ".join(f"{kind}:{value}" for kind, value in evidence)
             fail(
                 "git-contract-ordering",


### PR DESCRIPTION
**Merge this promptly — `testing` is currently red for every PR.**

#2385 merged at `8266d3bd58`, one commit short of the fix that makes the job it
enabled actually finish. The gates now run on every pull request into `testing`,
and `proposal-ordering` cannot pass:

- `scan_history` walks **2397 commits** since the historical cutoff at two git
  subprocesses each, so one run is ~2 minutes;
- the job performs three runs plus the test suite;
- `timeout-minutes` is still **5**, so the job is cancelled mid-step.

That is exactly what `proposal-ordering fail 5m14s` / `conclusion: cancelled`
was on #2385, and it now happens on every PR into `testing`.

## What this carries

**1. One command instead of one process per signal.**
`anchor_descendants` asks `rev-list --ancestry-path` once rather than
`merge-base --is-ancestor` per signal. The range excludes the anchor, so a parent
equal to it stays correctly rejected.

**2. A real correctness bug found while writing that.**
`git_run` returns **bytes**. Interpolating its output into a rev range produced a
`b'...'` range git rejects; the empty result then failed every non-waived signal
at once — a checker that looks strict while testing nothing. It surfaced only
because a commit the retired rule had accepted suddenly failed and I chased the
discrepancy instead of re-freezing around it. Decoded now; the run is back to a
full signal set.

**3. A budget that matches measured cost.** `timeout-minutes: 5` → `20`.

## What this deliberately does not do

Collapsing `scan_history` into a single `git log` pass would remove the cost
outright, but it means reimplementing rename/copy detection and the blob claim
scan **inside the gate that governs the Git core contract**. That belongs in its
own reviewed change. The measurement and the reasoning are recorded in the
workflow so the cost is visible rather than mysterious.

Flagging plainly: this bakes in ~8 minutes of CI per PR into `testing`, and it
grows with history. It should be paid down.

## Verification

```
$ python3 -c "...; print(d['jobs']['proposal-ordering']['timeout-minutes'])"
20
$ time python3 -I -S scripts/check_proposal_ordering.py
check_proposal_ordering: ok (110 post-cutoff signal commit(s))
real 2m4.619s
```

35/35 tests pass, and the checker was verified under the exact CI environment
(`GITHUB_EVENT_NAME=pull_request`, `GITHUB_BASE_REF=testing`).
