### PR TITLE
feat(git): take PR list and edit off `gh`

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "460cc795d4aa4205914bd4781526d5c300f6fdade29be8792ea1b7fd77f0803f",
+      "source_sha256": "4e63c137311bbbd994434867133c6bd3226c9604327fb65be8671adab39f2127",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -647,7 +647,23 @@ int git_pr_update_via_api_slug(const char *principal, const char *slug, int numb
 {
    if (err && errlen)
       err[0] = '\0';
-   if (number <= 0 || !title || !title[0] || !body || !body[0])
+   if (!title || !title[0] || !body || !body[0])
+   {
+      snprintf(err, errlen, "invalid PR update");
+      return -1;
+   }
+   return git_pr_edit_via_api_slug(principal, slug, number, title, body, NULL, err, errlen);
+}
+
+int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number, const char *title,
+                             const char *body, const char *base, char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
+   int has_title = title && title[0];
+   int has_body = body && body[0];
+   int has_base = base && base[0];
+   if (number <= 0 || (!has_title && !has_body && !has_base))
    {
       snprintf(err, errlen, "invalid PR update");
       return -1;
@@ -656,13 +672,21 @@ int git_pr_update_via_api_slug(const char *principal, const char *slug, int numb
    if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
 
-   char *clean = strdup(body);
-   if (clean)
-      strip_ai_attribution(clean);
+   /* Only the fields the caller supplied go in the payload: sending an empty
+    * string would blank the PR's title or body rather than leave it alone. */
    cJSON *json = cJSON_CreateObject();
-   cJSON_AddStringToObject(json, "title", title);
-   cJSON_AddStringToObject(json, "body", clean ? clean : body);
-   free(clean);
+   if (has_title)
+      cJSON_AddStringToObject(json, "title", title);
+   if (has_body)
+   {
+      char *clean = strdup(body);
+      if (clean)
+         strip_ai_attribution(clean);
+      cJSON_AddStringToObject(json, "body", clean ? clean : body);
+      free(clean);
+   }
+   if (has_base)
+      cJSON_AddStringToObject(json, "base", base);
    char *payload = cJSON_PrintUnformatted(json);
    cJSON_Delete(json);
    if (!payload)
@@ -685,6 +709,81 @@ int git_pr_update_via_api_slug(const char *principal, const char *slug, int numb
       return -1;
    }
    free(response);
+   return 0;
+}
+
+int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int limit,
+                                  git_pr_list_item_t *out, int *count, char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
+   if (count)
+      *count = 0;
+   if (!out || !count || limit <= 0)
+   {
+      snprintf(err, errlen, "invalid PR list request");
+      return -1;
+   }
+   if (limit > 100) /* one page; GitHub caps per_page at 100 */
+      limit = 100;
+
+   gh_ctx_t cx;
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
+      return -1;
+   char path[96];
+   snprintf(path, sizeof(path), "pulls?state=open&sort=updated&direction=desc&per_page=%d", limit);
+   char *resp = NULL;
+   int st = gh_get(&cx, path, &resp);
+   gh_ctx_done(&cx);
+   if (st < 200 || st >= 300 || !resp)
+   {
+      gh_err(resp, st, "pr list", err, errlen);
+      free(resp);
+      return -1;
+   }
+   cJSON *arr = cJSON_Parse(resp);
+   free(resp);
+   if (!cJSON_IsArray(arr))
+   {
+      cJSON_Delete(arr);
+      snprintf(err, errlen, "github API: unparseable pr list");
+      return -1;
+   }
+   int n = 0;
+   const cJSON *item = NULL;
+   cJSON_ArrayForEach(item, arr)
+   {
+      if (n >= limit)
+         break;
+      const cJSON *num = cJSON_GetObjectItem(item, "number");
+      const cJSON *state = cJSON_GetObjectItem(item, "state");
+      const cJSON *title = cJSON_GetObjectItem(item, "title");
+      const cJSON *headj = cJSON_GetObjectItem(item, "head");
+      const cJSON *headref = headj ? cJSON_GetObjectItem(headj, "ref") : NULL;
+      const cJSON *mat = cJSON_GetObjectItem(item, "merged_at");
+      if (!cJSON_IsNumber(num) || num->valueint <= 0)
+         continue; /* a row without a number is not addressable; skip it */
+      git_pr_list_item_t *row = &out[n];
+      memset(row, 0, sizeof(*row));
+      row->number = num->valueint;
+      /* gh spelled the state upper-case, and reported MERGED in place of the
+       * closed state a merged PR actually carries. */
+      if (cJSON_IsString(mat) && mat->valuestring)
+         snprintf(row->state, sizeof(row->state), "MERGED");
+      else if (cJSON_IsString(state) && state->valuestring)
+      {
+         snprintf(row->state, sizeof(row->state), "%s", state->valuestring);
+         for (char *p = row->state; *p; p++)
+            *p = (char)toupper((unsigned char)*p);
+      }
+      if (cJSON_IsString(headref) && headref->valuestring)
+         snprintf(row->head, sizeof(row->head), "%s", headref->valuestring);
+      if (cJSON_IsString(title) && title->valuestring)
+         snprintf(row->title, sizeof(row->title), "%s", title->valuestring);
+      n++;
+   }
+   cJSON_Delete(arr);
+   *count = n;
    return 0;
 }
 

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -86,6 +86,32 @@ int git_pr_find_open_via_api_slug(const char *principal, const char *slug, const
 int git_pr_update_via_api_slug(const char *principal, const char *slug, int number,
                                const char *title, const char *body, char *err, size_t errlen);
 
+/* PATCH a PR with ANY SUBSET of title/body/base -- a NULL or empty field is left
+ * out of the payload rather than sent empty, so editing a title cannot blank a
+ * body. At least one must be present. `base` retargets the PR.
+ *
+ * git_pr_update_via_api{,_slug} above demand BOTH title and body and cannot touch
+ * base; they stay as they are because the workflow forge relies on that
+ * all-or-nothing contract for idempotent replays. This is the general form and
+ * they delegate to it, so there is one PATCH. */
+int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number, const char *title,
+                             const char *body, const char *base, char *err, size_t errlen);
+
+/* One row of an open-PR listing. */
+typedef struct
+{
+   int number;
+   char state[16];  /* OPEN / CLOSED / MERGED, gh's spelling */
+   char head[128];  /* head.ref */
+   char title[512]; /* PR title */
+} git_pr_list_item_t;
+
+/* The `limit` most recently updated OPEN PRs into out[], writing how many landed
+ * to *count. Returns 0 on success (including zero PRs), -1 with `err` set
+ * otherwise. Caller supplies the array; nothing is allocated. */
+int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int limit,
+                                  git_pr_list_item_t *out, int *count, char *err, size_t errlen);
+
 /* Find the existing open PR for an exact head/base pair. Returns 1 + URL,
  * 0 when absent, or -1 on API/validation failure. */
 int git_pr_find_open_via_api(const char *principal, const char *repo_dir, const char *head,

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -358,80 +358,64 @@ cJSON *handle_git_pr(cJSON *args)
        * would then run pos past the end and wrap (cap - pos) to a huge size_t on
        * the next write — an out-of-bounds (stack) write. Sizing the buffer to
        * fit avoids both the overflow and silently truncating a long body. */
-      char *esc_title = has_title ? shell_escape(jtitle->valuestring) : NULL;
-      char *esc_body = has_body ? shell_escape(jbody->valuestring) : NULL;
-      char *esc_base = has_base ? shell_escape(jbase->valuestring) : NULL;
-      size_t cmdcap = strlen(repo_slug) + 160 + (esc_title ? strlen(esc_title) : 0) +
-                      (esc_body ? strlen(esc_body) : 0) + (esc_base ? strlen(esc_base) : 0);
-      char *cmd = malloc(cmdcap);
-      if (!cmd)
-      {
-         free(esc_title);
-         free(esc_body);
-         free(esc_base);
-         return mcp_text("error: out of memory building gh command");
-      }
+      const char *principal = agent_get_request_vault_principal();
+      char err[512];
+      err[0] = '\0';
+      if (git_pr_edit_via_api_slug(principal, repo_slug, jnum->valueint,
+                                   has_title ? jtitle->valuestring : NULL,
+                                   has_body ? jbody->valuestring : NULL,
+                                   has_base ? jbase->valuestring : NULL, err, sizeof(err)) != 0)
+         return mcp_error("error: pr edit failed: %s", err[0] ? err : "unknown");
+
+      /* Read back what the edit produced, as the gh --template did. A failure here
+       * means the PATCH landed but the confirmation did not: say so rather than
+       * reporting the edit itself as failed. */
+      git_pr_info_t info;
+      err[0] = '\0';
+      if (git_pr_info_via_api_slug(principal, repo_slug, jnum->valueint, &info, err, sizeof(err)) !=
+          0)
+         return mcp_error("updated PR, but reading it back failed: %s", err[0] ? err : "unknown");
+
+      char result[1600];
       int pos =
-          snprintf(cmd, cmdcap, "gh api -X PATCH repos/%s/pulls/%d", repo_slug, jnum->valueint);
-      if (esc_title)
-         pos += snprintf(cmd + pos, cmdcap - (size_t)pos, " -f title='%s'", esc_title);
-      if (esc_body)
-         pos += snprintf(cmd + pos, cmdcap - (size_t)pos, " -f body='%s'", esc_body);
-      if (esc_base)
-         pos += snprintf(cmd + pos, cmdcap - (size_t)pos, " -f base='%s'", esc_base);
-      snprintf(cmd + pos, cmdcap - (size_t)pos, " 2>&1");
-      free(esc_title);
-      free(esc_body);
-      free(esc_base);
-
-      int rc;
-      char *out = mcp_git_run(cmd, &rc);
-      free(cmd);
-      if (rc != 0)
-      {
-         cJSON *r = mcp_error("error: gh api pull update failed: %s", out ? out : "unknown");
-         free(out);
-         return r;
-      }
-      free(out);
-
-      char view_cmd[512];
-      snprintf(view_cmd, sizeof(view_cmd),
-               "gh pr view %d --json title,state,url,baseRefName,headRefName,mergedAt "
-               "--template 'updated PR #%d\\ntitle: {{.title}}\\n"
-               "base: {{.baseRefName}} <- {{.headRefName}}\\nurl: {{.url}}"
-               "{{if .mergedAt}}\\nmerged: {{.mergedAt}}{{end}}' 2>&1",
-               jnum->valueint, jnum->valueint);
-
-      out = mcp_git_run(view_cmd, &rc);
-      if (rc != 0)
-      {
-         cJSON *r = mcp_error("error: gh pr view failed after edit: %s", out ? out : "unknown");
-         free(out);
-         return r;
-      }
-
-      cJSON *r = mcp_text(out ? out : "updated");
-      free(out);
-      return r;
+          snprintf(result, sizeof(result), "updated PR #%d\ntitle: %s\nbase: %s <- %s\nurl: %s",
+                   jnum->valueint, info.title, info.base, info.head, info.html_url);
+      if (info.merged_at[0] && pos > 0 && (size_t)pos < sizeof(result))
+         snprintf(result + pos, sizeof(result) - (size_t)pos, "\nmerged: %s", info.merged_at);
+      return mcp_text(result);
    }
 
    if (strcmp(action, "list") == 0)
    {
-      int rc;
-      char *out = mcp_git_run(
-          "gh pr list --limit 20 --json number,title,state,headRefName "
-          "--template '{{range .}}#{{.number}} [{{.state}}] {{.headRefName}}: {{.title}}\n{{end}}' "
-          "2>&1",
-          &rc);
-      if (rc != 0)
-      {
-         cJSON *r = mcp_error("error: gh pr list failed: %s", out ? out : "unknown");
-         free(out);
-         return r;
-      }
-      cJSON *r = mcp_text(out && out[0] ? out : "(no open PRs)");
-      free(out);
+      char slug[264];
+      if (get_origin_repo_slug(slug, sizeof(slug)) != 0)
+         return mcp_text("error: cannot resolve a github.com origin for this checkout");
+
+      git_pr_list_item_t rows[20];
+      int n = 0;
+      char err[512];
+      err[0] = '\0';
+      if (git_pr_list_open_via_api_slug(agent_get_request_vault_principal(), slug,
+                                        (int)(sizeof(rows) / sizeof(rows[0])), rows, &n, err,
+                                        sizeof(err)) != 0)
+         return mcp_error("error: pr list failed: %s", err[0] ? err : "unknown");
+      if (n == 0)
+         return mcp_text("(no open PRs)");
+
+      /* One line per PR, as the gh template rendered them. Sized for 20 rows of
+       * the struct's own maxima plus the fixed decoration. */
+      size_t cap =
+          (size_t)n * (sizeof(rows[0].title) + sizeof(rows[0].head) + sizeof(rows[0].state) + 32) +
+          1;
+      char *text = malloc(cap);
+      if (!text)
+         return mcp_text("error: out of memory rendering PR list");
+      size_t pos = 0;
+      for (int i = 0; i < n && pos < cap; i++)
+         pos += (size_t)snprintf(text + pos, cap - pos, "#%d [%s] %s: %s\n", rows[i].number,
+                                 rows[i].state, rows[i].head, rows[i].title);
+      cJSON *r = mcp_text(text);
+      free(text);
       return r;
    }
 

--- a/src/tests/support/git_pr_api_stub.c
+++ b/src/tests/support/git_pr_api_stub.c
@@ -30,6 +30,36 @@ int git_pr_create_via_api_slug(const char *principal, const char *slug, const ch
    return -1;
 }
 
+/* The edit action's PATCH and the list action's read. Same contract as the rest:
+ * these binaries assert on routing and validation, never on a real forge call. */
+int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number, const char *title,
+                             const char *body, const char *base, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)number;
+   (void)title;
+   (void)body;
+   (void)base;
+   if (err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return -1;
+}
+
+int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int limit,
+                                  git_pr_list_item_t *out, int *count, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)limit;
+   (void)out;
+   if (count)
+      *count = 0;
+   if (err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return -1;
+}
+
 /* The view action's read, for the same reason: routing and validation only. */
 int git_pr_info_via_api_slug(const char *principal, const char *slug, int number,
                              git_pr_info_t *out, char *err, size_t errlen)


### PR DESCRIPTION
Continues #2393 → #2395 → #2397. Closes two of the three API gaps #2395 enumerated.

## Why these were blocked

`gh` in the aimee-server image is authenticated with **nothing**, and `mcp_git_run` hands children the token on a memfd (FD mode) rather than as `GH_TOKEN` — deliberately, per `git_cred_inject.h`, so it never reaches `/proc/<pid>/environ`. `gh` can only read a token from the environment or its own config, so it sees none.

Consequence: every `gh`-backed action is **dead for SHARED/CONTAINER workspaces** and only appears to work from a DETACHED one, where the client happens to have its own credential. That's why this surfaced as a bug report from another session rather than in my own testing.

Re-authenticating cannot fix it. Migrating is the only fix that doesn't put the secret back in the environment.

## The two gaps closed

**`git_pr_edit_via_api_slug`** — PATCH with **any subset** of title/body/base. A NULL or empty field is omitted from the payload rather than sent empty, so editing a title cannot blank a body. `git_pr_update_via_api{,_slug}` keep their both-required, no-base contract (the workflow forge relies on it for idempotent replays) and now delegate here, so there is one PATCH.

**`git_pr_list_open_via_api_slug`** — the `limit` most recently updated open PRs into a caller-supplied array, nothing allocated. `gh pr list` defaults to open and sorts by recency, so the query matches: `state=open&sort=updated&direction=desc`.

## Output unchanged

```
list   #<n> [<STATE>] <head>: <title>        one per line; "(no open PRs)" when empty
edit   updated PR #<n> / title / base <- head / url / [merged]
```

Two fidelity details worth flagging for review:

- State is upper-cased to gh's spelling, and a row carrying `merged_at` reports `MERGED` rather than the `closed` REST returns for a merged PR. gh conflated those and callers read that spelling.
- `edit`'s read-back is now a second in-process call. If the PATCH lands but the read-back fails it reports `updated PR, but reading it back failed` rather than reporting the edit as failed — the latter would invite retrying a write that already succeeded.

## `checks` is deliberately still on `gh`

Remaining in this file, all in checks/merge: `gh pr checks` (twice — the action and the merge CI gate), `gh pr merge`, and the mergeCommit oid lookup.

`checks` is a raw passthrough of gh's own table — name, status word, duration, url. Reproducing it means matching gh's status vocabulary (`pass`/`fail`/`pending`/`skipping`) and duration formatting (`45s`, `2m54s`) exactly. **Tooling parses that output** — I parsed it myself today to diagnose CI on #2386 — so a subtle mismatch is a silent breakage, not a cosmetic one. It gets its own change and its own verification rather than a guess bolted onto this one.

## Verification

- `gcc -fsyntax-only -Wall -Wextra` clean on all changed TUs
- `clang-format-19 --dry-run --Werror` clean — it rewrapped three signatures and two expressions of mine
- `check_c_repository_lock.py` ok, digest recomputed after the reformat
- Stub extended with both new symbols so the five binaries linking `mcp_git_pr.o` still resolve

**Not verified live** — needs the deploy, same as #2393/#2397 did. Note that both of those *were* then confirmed live: `create` opened `JBailes/infrastructure#21` from a DETACHED checkout, and `view`/`merge_status` were A/B'd byte-for-byte against the `gh` templates they replaced on both the OPEN and MERGED branches.

Worth having the session that reported `gh auth login` retry `list` and `edit` after this deploys — theirs is the SHARED/CONTAINER path I cannot reproduce from here.
