### PR TITLE
feat(git): take PR checks off `gh`, format derived from its output

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "4e63c137311bbbd994434867133c6bd3226c9604327fb65be8671adab39f2127",
+      "source_sha256": "7294a7fb7d0bde5e483538fb3b614f170df8714885e77e59498505b75f0b9562",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -712,6 +712,160 @@ int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number
    return 0;
 }
 
+/* Seconds since the epoch for "YYYY-MM-DDTHH:MM:SSZ", or -1 if it does not parse.
+ *
+ * Done by arithmetic rather than strptime/timegm: neither is available on every
+ * target this builds for (there is a Windows build), and the input is a fixed UTC
+ * format, so a civil-days conversion is both portable and exact. */
+static long long gh_iso8601_secs(const char *s)
+{
+   int y, mo, d, h, mi, se;
+   if (!s || sscanf(s, "%4d-%2d-%2dT%2d:%2d:%2dZ", &y, &mo, &d, &h, &mi, &se) != 6)
+      return -1;
+   /* days_from_civil (Howard Hinnant): shift the year so March starts the era,
+    * which removes the leap-day special case entirely. */
+   y -= mo <= 2;
+   long long era = (y >= 0 ? y : y - 399) / 400;
+   unsigned yoe = (unsigned)(y - era * 400);
+   unsigned doy = (unsigned)((153 * (mo + (mo > 2 ? -3 : 9)) + 2) / 5 + d - 1);
+   unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+   long long days = era * 146097 + (long long)doe - 719468;
+   return days * 86400 + h * 3600 + mi * 60 + se;
+}
+
+/* gh printed a bare "0" for anything not completed or of zero length, "<n>s"
+ * under a minute, and "<m>m<s>s" above it. */
+static void gh_elapsed(const char *started, const char *completed, int completed_state, char *out,
+                       size_t cap)
+{
+   long long a = gh_iso8601_secs(started), b = gh_iso8601_secs(completed);
+   if (!completed_state || a < 0 || b < 0 || b <= a)
+   {
+      snprintf(out, cap, "0");
+      return;
+   }
+   long long d = b - a;
+   if (d >= 60)
+      snprintf(out, cap, "%lldm%llds", d / 60, d % 60);
+   else
+      snprintf(out, cap, "%llds", d);
+}
+
+/* GitHub's conclusion vocabulary mapped to the four words gh printed. Anything
+ * unrecognised reports "pending" rather than inventing a word: a caller polling
+ * for completion keeps polling, which is the safe direction to be wrong in. */
+static const char *gh_check_word(const char *status, const char *conclusion)
+{
+   if (!status || strcmp(status, "completed") != 0)
+      return "pending";
+   if (!conclusion)
+      return "pending";
+   if (strcmp(conclusion, "success") == 0)
+      return "pass";
+   if (strcmp(conclusion, "failure") == 0 || strcmp(conclusion, "timed_out") == 0 ||
+       strcmp(conclusion, "action_required") == 0 || strcmp(conclusion, "startup_failure") == 0 ||
+       strcmp(conclusion, "cancelled") == 0)
+      return "fail";
+   if (strcmp(conclusion, "neutral") == 0 || strcmp(conclusion, "skipped") == 0 ||
+       strcmp(conclusion, "stale") == 0)
+      return "skipping";
+   return "pending";
+}
+
+/* By name, as gh listed them. A repository can run two checks under ONE name
+ * (observed: `pins` twice on the same commit), and qsort is not stable, so ties
+ * break on the details url to keep the output identical between two calls on
+ * unchanged data. gh's own ordering for a duplicate pair is undefined, so that
+ * one case may differ from it -- deterministic here is worth more than matching
+ * an order gh does not guarantee either. */
+static int gh_check_cmp(const void *a, const void *b)
+{
+   const git_pr_check_t *x = a, *y = b;
+   int c = strcmp(x->name, y->name);
+   return c ? c : strcmp(x->url, y->url);
+}
+
+int git_pr_checks_via_api_slug(const char *principal, const char *slug, int number, int max,
+                               git_pr_check_t *out, int *count, char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
+   if (count)
+      *count = 0;
+   if (!out || !count || max <= 0 || number <= 0)
+   {
+      snprintf(err, errlen, "invalid PR checks request");
+      return -1;
+   }
+
+   /* The checks belong to the head COMMIT, so the PR has to be read first. */
+   git_pr_info_t info;
+   if (git_pr_info_via_api_slug(principal, slug, number, &info, err, errlen) != 0)
+      return -1;
+   if (!info.head_sha[0])
+   {
+      snprintf(err, errlen, "pull request has no head commit");
+      return -1;
+   }
+
+   gh_ctx_t cx;
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
+      return -1;
+   char path[160];
+   snprintf(path, sizeof(path), "commits/%s/check-runs?per_page=100", info.head_sha);
+   char *resp = NULL;
+   int st = gh_get(&cx, path, &resp);
+   gh_ctx_done(&cx);
+   if (st < 200 || st >= 300 || !resp)
+   {
+      gh_err(resp, st, "pr checks", err, errlen);
+      free(resp);
+      return -1;
+   }
+   cJSON *j = cJSON_Parse(resp);
+   free(resp);
+   const cJSON *runs = j ? cJSON_GetObjectItem(j, "check_runs") : NULL;
+   if (!cJSON_IsArray(runs))
+   {
+      cJSON_Delete(j);
+      snprintf(err, errlen, "github API: unparseable check runs");
+      return -1;
+   }
+   int n = 0;
+   const cJSON *r = NULL;
+   cJSON_ArrayForEach(r, runs)
+   {
+      if (n >= max)
+         break;
+      const cJSON *name = cJSON_GetObjectItem(r, "name");
+      if (!cJSON_IsString(name) || !name->valuestring)
+         continue; /* an unnamed check cannot be reported usefully */
+      const cJSON *status = cJSON_GetObjectItem(r, "status");
+      const cJSON *concl = cJSON_GetObjectItem(r, "conclusion");
+      const cJSON *started = cJSON_GetObjectItem(r, "started_at");
+      const cJSON *done = cJSON_GetObjectItem(r, "completed_at");
+      const cJSON *url = cJSON_GetObjectItem(r, "details_url");
+      const char *status_s = cJSON_IsString(status) ? status->valuestring : NULL;
+      git_pr_check_t *row = &out[n];
+      memset(row, 0, sizeof(*row));
+      snprintf(row->name, sizeof(row->name), "%s", name->valuestring);
+      snprintf(row->status, sizeof(row->status), "%s",
+               gh_check_word(status_s, cJSON_IsString(concl) ? concl->valuestring : NULL));
+      gh_elapsed(cJSON_IsString(started) ? started->valuestring : NULL,
+                 cJSON_IsString(done) ? done->valuestring : NULL,
+                 status_s && strcmp(status_s, "completed") == 0, row->elapsed,
+                 sizeof(row->elapsed));
+      if (cJSON_IsString(url) && url->valuestring)
+         snprintf(row->url, sizeof(row->url), "%s", url->valuestring);
+      n++;
+   }
+   cJSON_Delete(j);
+   if (n > 1)
+      qsort(out, (size_t)n, sizeof(out[0]), gh_check_cmp); /* gh listed them by name */
+   *count = n;
+   return 0;
+}
+
 int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int limit,
                                   git_pr_list_item_t *out, int *count, char *err, size_t errlen)
 {

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -97,6 +97,23 @@ int git_pr_update_via_api_slug(const char *principal, const char *slug, int numb
 int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number, const char *title,
                              const char *body, const char *base, char *err, size_t errlen);
 
+/* One CI check for a PR's head commit, in the shape `gh pr checks` printed it.
+ * The field values and their spelling were derived from gh's actual output rather
+ * than from its source: 85 rows across three PRs render byte-identically. */
+typedef struct
+{
+   char name[256];
+   char status[16];  /* pass / fail / pending / skipping */
+   char elapsed[16]; /* "45s", "2m54s", or "0" when pending or zero-length */
+   char url[512];    /* details_url */
+} git_pr_check_t;
+
+/* Checks for PR `number`'s head commit into out[], at most `max`, count in
+ * *count, sorted by name as gh sorted them. Returns 0 on success (including no
+ * checks at all), -1 with `err` set otherwise. Caller supplies the array. */
+int git_pr_checks_via_api_slug(const char *principal, const char *slug, int number, int max,
+                               git_pr_check_t *out, int *count, char *err, size_t errlen);
+
 /* One row of an open-PR listing. */
 typedef struct
 {

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -111,21 +111,36 @@ cJSON *handle_git_pr(cJSON *args)
          return mcp_text("error: blocking PR check waits are disabled; call action=checks with "
                          "wait=false and poll with a bounded client-side interval");
 
-      char cmd[256];
-      snprintf(cmd, sizeof(cmd), "gh pr checks %d%s 2>&1", jnum->valueint,
-               watch_checks ? " --watch" : "");
+      char slug[264];
+      if (get_origin_repo_slug(slug, sizeof(slug)) != 0)
+         return mcp_text("error: cannot resolve a github.com origin for this checkout");
 
-      int rc;
-      char *out = mcp_git_run(cmd, &rc);
-      if (rc != 0 && rc != 1 && rc != 8)
-      {
-         cJSON *r = mcp_error("error: gh pr checks failed: %s", out ? out : "unknown");
-         free(out);
-         return r;
-      }
+      git_pr_check_t rows[100];
+      int n = 0;
+      char err[512];
+      err[0] = '\0';
+      if (git_pr_checks_via_api_slug(agent_get_request_vault_principal(), slug, jnum->valueint,
+                                     (int)(sizeof(rows) / sizeof(rows[0])), rows, &n, err,
+                                     sizeof(err)) != 0)
+         return mcp_error("error: pr checks failed: %s", err[0] ? err : "unknown");
+      if (n == 0)
+         return mcp_text("(no checks output)");
 
-      cJSON *r = mcp_text(out && out[0] ? out : "(no checks output)");
-      free(out);
+      /* gh printed one TAB-separated row per check and left a trailing empty
+       * column, so each line ends with a tab before the newline. Reproduced
+       * exactly: callers parse this by field. */
+      size_t cap = (size_t)n * (sizeof(rows[0].name) + sizeof(rows[0].status) +
+                                sizeof(rows[0].elapsed) + sizeof(rows[0].url) + 8) +
+                   1;
+      char *text = malloc(cap);
+      if (!text)
+         return mcp_text("error: out of memory rendering checks");
+      size_t pos = 0;
+      for (int i = 0; i < n && pos < cap; i++)
+         pos += (size_t)snprintf(text + pos, cap - pos, "%s\t%s\t%s\t%s\t\n", rows[i].name,
+                                 rows[i].status, rows[i].elapsed, rows[i].url);
+      cJSON *r = mcp_text(text);
+      free(text);
       return r;
    }
 
@@ -209,10 +224,16 @@ cJSON *handle_git_pr(cJSON *args)
             snprintf(match, sizeof(match), " --match-head-commit %s", h);
       }
 
-      /* CI must be fully green before the merge (operator ruling 2026-07-15). Reuses
-       * the same `gh pr checks` read (and its 0/1/8 tri-state) as action=checks, so
-       * this stays correct for a detached workspace, where the command is marshalled
-       * to the client that holds the creds.
+      /* CI must be fully green before the merge (operator ruling 2026-07-15). Still
+       * its own `gh pr checks` read, relying on that command's 0/1/8 tri-state exit
+       * code. action=checks NO LONGER shares this path -- it reads the Checks API
+       * in-process -- so the two are now independent and this one inherits the `gh`
+       * problem: `gh` in the aimee-server image has no credential, and mcp_git_run
+       * hands children the token on a memfd rather than as GH_TOKEN, so this gate
+       * only works from a DETACHED workspace where the client holds its own creds.
+       * Migrating it means replacing the exit-code verdict with git_pr_ci_permits_merge
+       * over git_pr_ci_via_api_slug, which is a change to a MERGE gate and wants its
+       * own review rather than riding along with the read migrations.
        *
        * Fails CLOSED on anything it cannot positively classify. In particular the
        * verdict is taken from gh's EXIT CODE, never inferred from parsed counters:

--- a/src/tests/support/git_pr_api_stub.c
+++ b/src/tests/support/git_pr_api_stub.c
@@ -46,6 +46,21 @@ int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number
    return -1;
 }
 
+int git_pr_checks_via_api_slug(const char *principal, const char *slug, int number, int max,
+                               git_pr_check_t *out, int *count, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)number;
+   (void)max;
+   (void)out;
+   if (count)
+      *count = 0;
+   if (err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return -1;
+}
+
 int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int limit,
                                   git_pr_list_item_t *out, int *count, char *err, size_t errlen)
 {


### PR DESCRIPTION
The last **read** still shelling out. Completes #2393 → #2395 → #2397 → #2399.

## Why this one was held back

#2399 deliberately excluded it: `gh pr checks` is a raw passthrough of gh's own table, and tooling parses it by field — I parsed it myself today to diagnose #2386's CI. A guessed format is a silent breakage, not a cosmetic one.

So I didn't guess. I derived the format from gh's actual output, then verified against it.

## What observation established — none of which I'd have got right by assumption

- The row is `name \t status \t elapsed \t url \t` — **five** fields, the fifth empty, so **every line ends with a tab** before the newline.
- `elapsed` is a bare `0` for anything not completed **and** for a completed run of zero length; `<n>s` under a minute; `<m>m<s>s` above.
- gh orders rows **by name**.
- Status words are `pass` / `fail` / `pending` / `skipping`.

## Verification, done before writing the C

**Format** — reconstructed every line from the Checks API payload and diffed against `gh pr checks` across three PRs spanning pass/pending/skipping: **85 rows, byte-identical.** That pass is what surfaced the zero-length case (a completed *skipped* run prints `0`, not `0s`), which would otherwise have shipped wrong.

**Date arithmetic** — checked independently: **170 timestamps** through the exact integer formula this commit uses, against a reference implementation. Zero disagreements. Implemented as civil-days arithmetic rather than `strptime`/`timegm` because neither is available on every target here (there's a Windows build) and the input is a fixed UTC format.

## A finding worth keeping

Two mismatches in that pass turned out to be **my harness, not the code**: a repository can run two checks under **one name** — `pins`, twice on the same commit — and I'd keyed rows by name, so it compared the wrong pair.

The duplicate is real though, and `qsort` isn't stable, so ties now break on the details url to keep output identical between two calls on unchanged data. gh doesn't guarantee an order for a duplicate pair either, so that single case may differ from it — deterministic here is worth more than matching an order gh doesn't promise.

## Deliberate conservatism

Unrecognised conclusions report `pending` rather than a coined word: a caller polling for completion keeps polling, which is the safe direction to be wrong in. `cancelled`, `timed_out`, `action_required`, `startup_failure` and `stale` are mapped from GitHub's documented vocabulary but were **not observed** — the sample had no such runs.

## `action=merge` untouched, and its comment corrected

The merge CI gate keeps its own `gh pr checks` read. Its comment claimed to share this read with `action=checks` — no longer true, so it's fixed. Stale comments in exactly this area misled me twice today (`mcp_git_query.c:102` on `GH_TOKEN` injection being the other), so leaving it seemed worse than the diff noise.

That gate now inherits the `gh` credential problem alone. Replacing its exit-code verdict with `git_pr_ci_permits_merge` over `git_pr_ci_via_api_slug` is a change to a **merge** gate and wants its own review, not a rider on read migrations.

## State after this

Every PR **read** — `create`, `view`, `merge_status`, `list`, `edit`, `checks` — runs in-process on the vaulted token. Remaining `gh` in `mcp_git_pr.c` is confined to `action=merge`: its CI gate, `gh pr merge` itself, and the mergeCommit oid lookup.

Verified: `-Wall -Wextra` clean, clang-format clean, pins resynced, stub extended. Not verified live — needs the deploy, as each predecessor did (and each was then confirmed).
