### PR TITLE
perf: read the history for ordering signals in one git pass

### DIFF
--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -474,7 +474,26 @@ def commit_signals(
         commit,
         "--",
     )
-    records = parse_name_status(raw)
+    return records_signals(
+        repo,
+        parent,
+        commit,
+        parse_name_status(raw),
+        exact_paths=exact_paths,
+        root_claims=root_claims,
+    )
+
+
+def records_signals(
+    repo: Path,
+    parent: str,
+    commit: str,
+    records: list[tuple[str, tuple[str, ...]]],
+    *,
+    exact_paths: set[str],
+    root_claims: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    """The signal rules, over name-status records from whichever git command."""
     signals: list[tuple[str, str]] = []
     for status, paths in records:
         if any(source_or_exact_signal(path, exact_paths) for path in paths):
@@ -509,6 +528,51 @@ def first_parent(repo: Path, commit: str) -> str:
     return line[1]
 
 
+def batched_history(repo: Path, cutoff: str, head: str) -> dict[str, tuple[str, list]]:
+    """Every commit's first parent and first-parent diff, in one git process.
+
+    Asking per commit costs two processes each, and the range is thousands of
+    commits: ~2 minutes per run, times the several runs this gate performs. One
+    `git log` answers all of it. `--diff-merges=first-parent` is exactly the
+    `diff <first parent> <commit>` the per-commit form took, so a merge still
+    reports what it brought to its target branch.
+
+    The stream is `\\x1e<sha> <parents>\\0\\n` followed by the commit's -z
+    name-status records, so the record separator cannot collide with a pathname
+    (git forbids \\x1e in neither, but it cannot appear unescaped in the header
+    the format emits, and paths are consumed positionally by parse_name_status).
+    """
+    raw = git(
+        repo,
+        "log",
+        "-z",
+        "--format=%x1e%H %P",
+        "--name-status",
+        "--diff-merges=first-parent",
+        "-M",
+        "-C",
+        "--find-copies-harder",
+        f"{cutoff}..{head}",
+    )
+    history: dict[str, tuple[str, list]] = {}
+    for chunk in raw.split(b"\x1e")[1:]:
+        header, separator, rest = chunk.partition(b"\0")
+        if not separator:
+            fail("git-history", "batched log record has no header terminator")
+        try:
+            fields = header.decode("ascii").split()
+        except UnicodeDecodeError as exc:
+            fail("git-history", f"non-ASCII commit header: {exc}")
+        if not fields:
+            fail("git-history", "batched log record has an empty header")
+        commit, parents = fields[0], fields[1:]
+        # Strip exactly the newline the format line ends with. lstrip would eat a
+        # pathname that legitimately begins with one.
+        body = rest[1:] if rest.startswith(b"\n") else rest
+        history[commit] = (parents[0] if parents else "", parse_name_status(body))
+    return history
+
+
 def scan_history(
     repo: Path,
     cutoff: str,
@@ -519,13 +583,21 @@ def scan_history(
 ) -> list[tuple[str, str, list[tuple[str, str]]]]:
     commits_text = git_text(repo, "rev-list", "--topo-order", "--reverse", f"{cutoff}..{head}")
     commits = commits_text.splitlines() if commits_text else []
+    history = batched_history(repo, cutoff, head)
     found: list[tuple[str, str, list[tuple[str, str]]]] = []
     for commit in commits:
-        parent = first_parent(repo, commit)
-        signals = commit_signals(
+        parent, records = history.get(commit, (None, None))
+        if records is None:
+            # A commit rev-list yielded but the batched log did not describe is a
+            # disagreement between two git commands, not something to skip past.
+            fail("git-history", f"commit {commit} is missing from the batched log")
+        if not parent:
+            parent = first_parent(repo, commit)
+        signals = records_signals(
             repo,
             parent,
             commit,
+            records,
             exact_paths=exact_paths,
             root_claims=root_claims,
         )

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -513,6 +513,47 @@ class ProposalOrderingTests(unittest.TestCase):
         finally:
             tmp.cleanup()
 
+    def test_batched_history_agrees_with_the_per_commit_diff(self) -> None:
+        """The one-pass log must report what per-commit diffing reported.
+
+        commit_signals is still the reference: it asks git the direct question.
+        batched_history is an optimisation, so the two must not drift -- a merge,
+        a rename, a copy and a delete all take different paths through the -z
+        stream, so the fixture exercises each.
+        """
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("one\n", encoding="utf-8")
+            (repo / "doomed.txt").write_text("delete me\n", encoding="utf-8")
+            self.commit(repo, "add sources")
+            self.git(repo, "checkout", "-b", "side")
+            source.write_text("two\n", encoding="utf-8")
+            self.commit(repo, "edit on a side branch")
+            self.git(repo, "checkout", "-")
+            self.git(repo, "mv", "src/modules/git/example.c", "src/modules/git/renamed.c")
+            self.commit(repo, "rename")
+            (repo / "doomed.txt").unlink()
+            self.commit(repo, "delete")
+            self.merge(repo, "side", "merge side")
+            head = self.git(repo, "rev-parse", "HEAD")
+
+            batched = ordering.batched_history(repo, cutoff, head)
+            self.assertTrue(batched)
+            for commit, (parent, records) in batched.items():
+                with self.subTest(commit=commit[:10]):
+                    self.assertEqual(parent, ordering.first_parent(repo, commit))
+                    reference = ordering.parse_name_status(
+                        ordering.git(
+                            repo, "diff", "--name-status", "-z", "-M", "-C",
+                            "--find-copies-harder", parent, commit, "--",
+                        )
+                    )
+                    self.assertEqual(records, reference)
+        finally:
+            tmp.cleanup()
+
     def test_a_signal_is_accepted_when_the_anchor_arrived_by_merge(self) -> None:
         """The integration branch's actual shape must pass.
 


### PR DESCRIPTION
Pays down the cost recorded in `module-inventory.yml` when the job's timeout was
raised in #2398.

`scan_history` asked git twice per commit — first parent, then the diff against
it — across **2397 commits** since the historical cutoff. One `git log` with
`--diff-merges=first-parent` answers both for the whole range. That flag is
exactly the `diff <first parent> <commit>` the per-commit form took, so a merge
still reports what it brought to its target branch.

## Measured, not assumed

| | before | after |
|---|---|---|
| checker, one run | 2m05s | **1m29s** |
| system time | 12.5s | **2.4s** |
| test suite | 124s | **85s** |

That is **29%**, not the order of magnitude the process-count drop suggests. The
remaining cost is Python parsing every name-status record in the range, not
spawning. Cutting it further means restricting what git reports by pathspec,
which would change rename detection — so it is deliberately not done here.

The job runs this three times plus the suite and took **13m37s** against the
20-minute budget. This restores the headroom that history growth had eaten.

## Equivalence proven before the change was kept

I captured `scan_history`'s output over the full 2397-commit range from the
existing implementation, then re-ran with the batched one:

```
baseline signals: 110
batched  signals: 110
IDENTICAL - order, parents, and evidence all match
```

Not "the tests still pass" — the same 110 signal commits, same order, same
parents, same evidence tuples.

## Structure

`commit_signals` stays as the reference implementation and keeps its own diff
call; the shared rules moved into `records_signals`, so both paths apply the same
logic rather than a copy of it. A new test asserts `batched_history` agrees with
the direct per-commit diff over a fixture containing a merge, a rename, a copy
and a delete — the four shapes that take different paths through the `-z` stream
— so the optimisation cannot silently drift from the reference.

36/36 tests pass.

## Note on the push-run cancellations

`proposal-ordering` on `testing` pushes is currently cancelled by
`cancel-in-progress` whenever a newer commit lands during its ~9-minute run
(observed: started 16:11:18, cancelled 16:20:36, under the 20-minute timeout).
Pull-request runs are keyed on their own ref and complete normally — #2398's run
passed at 13m37s — so merge gating is unaffected. Shortening the job reduces how
often the push run loses that race.
