### PR TITLE
docs(git): the injected env carries a token FD, not GH_TOKEN

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "7294a7fb7d0bde5e483538fb3b614f170df8714885e77e59498505b75f0b9562",
+      "source_sha256": "e83efb713cc294edfe33bb3c57b67ab6585a0d88d134e14e9c2c94c88f9bdcad",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -84,12 +84,24 @@ char *mcp_git_run(const char *cmd, int *exit_code)
    const workspace_provider_t *exec_ws = run_on_server ? workspace_provider_shared() : ws;
 
    /* Credential injection: for a server-run command whose cwd is inside a registered
-    * workspace, run under an execve environment carrying GH_TOKEN + the GIT_ASKPASS
-    * shim so clone/fetch/push/PR authenticate — never on the command line or disk.
-    * The token is resolved through the one shared vault-first policy: a client-handed
-    * per-workspace broker token (§4) wins, else the per-host vault token for the
-    * checkout's `origin`, else the server's own forge identity (§6); no token → fall
-    * through to ambient creds (co-located dev's own gh/SSH). */
+    * workspace, run under an execve environment that authenticates git — never on the
+    * command line or disk. The token is resolved through the one shared vault-first
+    * policy: a client-handed per-workspace broker token (§4) wins, else the per-host
+    * vault token for the checkout's `origin`, else the server's own forge identity
+    * (§6); no token → fall through to ambient creds (co-located dev's own gh/SSH).
+    *
+    * This carries AIMEE_GIT_TOKEN_FD and the GIT_ASKPASS shim, NOT GH_TOKEN. The
+    * builder is called in FD mode (out_token_fd non-NULL), which puts the secret on a
+    * memfd so it never lands in the child's /proc/<pid>/environ — see
+    * git_cred_inject.h. That authenticates `git`, whose askpass reads the fd, and it
+    * does NOT authenticate `gh`, which can only take a token from the environment or
+    * its own config. So a `gh` subcommand routed through here runs with NO credential
+    * and reports "gh auth login", however well the vault is populated. That is why
+    * the PR ops read the GitHub API in-process (git_pr_api.c) instead: the raw token
+    * goes straight into an Authorization header and no child is involved.
+    *
+    * Said plainly because the previous wording claimed GH_TOKEN was injected, which
+    * sent at least one reader hunting for a broken OAuth that was never broken. */
    if (run_on_server)
    {
       const char *cwd = run_cmd_get_cwd();


### PR DESCRIPTION
Comment only. No behaviour change.

## The claim that was wrong

`mcp_git_run` said the credential policy runs the child:

> *"under an execve environment carrying **GH_TOKEN** + the GIT_ASKPASS shim so clone/fetch/push/PR authenticate"*

Only the second half holds at this call site. The builder is invoked in **FD mode** (`out_token_fd` non-NULL), which per `git_cred_inject.h` puts the secret on a memfd and exports `AIMEE_GIT_TOKEN_FD=21` **"instead of GH_TOKEN"** — deliberately, so it never reaches the child's `/proc/<pid>/environ`.

## Why it's worth a lock resync

The distinction isn't academic:

- That env **authenticates `git`** — its askpass reads the fd.
- It **cannot authenticate `gh`** — gh takes a token only from the environment or its own config.

So any `gh` subcommand routed through here runs with **no credential at all** and reports `gh auth login`, however well the vault is populated. That is exactly what a session hit on `aimee git pr merge_status 2349`, and it's why the PR ops now read the API in-process (`git_pr_api.c`), where the raw token goes into an `Authorization` header with no child process involved.

The old wording reads as "GH_TOKEN is injected, therefore gh is authenticated." I believed it on first pass and went looking for a broken GitHub OAuth — the OAuth was fine the whole time, and the operator had to tell me so before I read the FD-mode contract properly. That cost real time, and it will cost the next reader the same.

The new comment states which variable is actually set, that it authenticates `git` and not `gh`, and why the in-process API path exists — including a note that the previous wording caused precisely that misdiagnosis.
