### PR TITLE
docs(git): correct the checks ordering claim — row order is ours, not gh's

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e83efb713cc294edfe33bb3c57b67ab6585a0d88d134e14e9c2c94c88f9bdcad",
+      "source_sha256": "e9dc737c35aa562cdb043cbbeac92aba4ca5014152f90790ecf75da9ca42e1d7",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -772,12 +772,16 @@ static const char *gh_check_word(const char *status, const char *conclusion)
    return "pending";
 }
 
-/* By name, as gh listed them. A repository can run two checks under ONE name
- * (observed: `pins` twice on the same commit), and qsort is not stable, so ties
- * break on the details url to keep the output identical between two calls on
- * unchanged data. gh's own ordering for a duplicate pair is undefined, so that
- * one case may differ from it -- deterministic here is worth more than matching
- * an order gh does not guarantee either. */
+/* By name, then by url.
+ *
+ * This is OUR order, not a reproduction of gh's. gh was observed grouping skipped
+ * checks ahead of passing ones on one PR, sorting plain alphabetically on another,
+ * and doing neither on a third whose CI was still running -- so there is no stable
+ * order to copy. Callers read these rows by field, and two calls on unchanged data
+ * returning the same order matters more than matching something gh does not hold
+ * still. The url tiebreak is what makes that true: a repository can run two checks
+ * under ONE name (observed: `pins` twice on the same commit) and qsort is not
+ * stable, so without it the duplicate pair could swap between calls. */
 static int gh_check_cmp(const void *a, const void *b)
 {
    const git_pr_check_t *x = a, *y = b;

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -99,7 +99,13 @@ int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number
 
 /* One CI check for a PR's head commit, in the shape `gh pr checks` printed it.
  * The field values and their spelling were derived from gh's actual output rather
- * than from its source: 85 rows across three PRs render byte-identically. */
+ * than from its source: 85 rows across three PRs matched field-for-field.
+ *
+ * Row CONTENTS match; row ORDER is ours, not gh's. gh's ordering could not be
+ * reproduced and does not look reproducible: for one PR it grouped skipped checks
+ * ahead of passing ones, for another it was plain alphabetical, and for a third
+ * with CI in flight it was neither. Consumers parse these by field, so a stable
+ * order is worth more than chasing one gh does not itself hold still. */
 typedef struct
 {
    char name[256];
@@ -109,7 +115,7 @@ typedef struct
 } git_pr_check_t;
 
 /* Checks for PR `number`'s head commit into out[], at most `max`, count in
- * *count, sorted by name as gh sorted them. Returns 0 on success (including no
+ * *count, sorted by name (see above: ours, not gh's). Returns 0 on success (including no
  * checks at all), -1 with `err` set otherwise. Caller supplies the array. */
 int git_pr_checks_via_api_slug(const char *principal, const char *slug, int number, int max,
                                git_pr_check_t *out, int *count, char *err, size_t errlen);


### PR DESCRIPTION
Correcting a claim I made in #2400. Comments only, no behaviour change.

## What I got wrong

#2400 said the migrated `checks` output renders **byte-identically** to `gh pr checks`, and that rows are *"sorted by name as gh sorted them"*. The first is overstated; the second is simply wrong.

**Row contents do match** — 85 rows across three PRs, field for field. That verification stands.

**Row order does not**, and my test could not have caught it: it **sorted both sides** before comparing, so it compared *sets*, not sequences. The "gh sorts by name" claim came from eyeballing the first dozen rows of one PR — which happened to be a single status group that was alphabetical within itself.

## What gh actually does

Checked against the deployed build, after the fact:

| PR | gh's order |
|---|---|
| #2337 | all 18 `skipping` first, then all 6 `pass` — alphabetical within each |
| #2400 | plain alphabetical (all 32 `pass`) |
| #2402 | neither, with CI in flight |

That's not an order to copy. It also isn't gh echoing the API — the API's own array order differs from gh's on all three, so there's no upstream sequence to inherit either.

## What this changes

Only the comments. They now state that the name+url sort is **ours**, and why: callers read these rows by field, and two calls on unchanged data should agree with each other — which matching an unstable order would not give. The url tiebreak is what makes that hold, since a repo can run two checks under one name (`pins`, twice on one commit) and `qsort` isn't stable.

## Why raise it rather than leave it

The migration's whole justification was "don't ship a lossy migration" — I refused three actions in #2395 and #2399 on exactly those grounds. Shipping an unverified ordering claim under that banner undercuts it. And a comment asserting parity with gh would send the next person hunting for a difference that's deliberate.

Worth noting the same class of mistake twice today: a sorted-both-sides comparison here, and a name-keyed dict that collapsed duplicate `pins` rows during the original verification. Both made a real difference invisible.
