### PR TITLE
refactor(webuser): take the runtime dir name rule off workspace's private header

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e9dc737c35aa562cdb043cbbeac92aba4ca5014152f90790ecf75da9ca42e1d7",
+      "source_sha256": "38e9a43c03fd1de4038ca5ab7afa5ea8c5a702a548b1cb77de4f1a5b9c36e843",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/scripts/check_module_bus_boundary.py
+++ b/scripts/check_module_bus_boundary.py
@@ -81,7 +81,6 @@ PRIVATE_HEADER_REACH = {
     ("src/modules/webuser/webuser_editor.c", "modules/git/forge_credentials.h"),
     ("src/modules/webuser/webuser_editor.c", "modules/git/git_cred_inject.h"),
     ("src/modules/webuser/webuser_editor.c", "modules/workspace/workspace_scope.h"),
-    ("src/modules/webuser/webuser_runtime.c", "modules/workspace/workspace_scope.h"),
     ("src/modules/workflows/wfe_live_forge.c", "modules/git/git_cred_inject.h"),
     ("src/modules/workflows/wfe_live_forge.c", "modules/git/git_pr_api.h"),
     ("src/modules/workspace/workspace_turn.c", "modules/git/forge_credentials.h"),

--- a/src/modules/webuser/webuser_runtime.c
+++ b/src/modules/webuser/webuser_runtime.c
@@ -1,6 +1,5 @@
 /* webuser_runtime.c — shared environment tmpfs runtime dir (fail-closed). */
 #include "webuser_runtime.h"
-#include "modules/workspace/workspace_scope.h" /* ws_scope_name_valid */
 
 #include <dirent.h>
 #include <errno.h>
@@ -22,6 +21,33 @@
 #endif
 
 #define WR_NAME_MAX 64
+
+static webuser_name_validator_fn g_name_validator;
+
+void webuser_runtime_register_name_validator(webuser_name_validator_fn validator)
+{
+   g_name_validator = validator;
+}
+
+/* Fail-closed, matching ws_scope_project_ref_valid: with no validator registered
+ * there is no local answer to fall back to, and this file's whole contract is to
+ * refuse rather than degrade. An unvalidated name would become a directory under
+ * the runtime dir.
+ *
+ * The separator is rejected here rather than delegated. Workspace's validator
+ * admits a reference, which is legitimately `owner/project`; a runtime dir name
+ * is a single component, and accepting a slash would let `webuser:a/b` name a
+ * path. With the separator excluded the delegated answer is exactly workspace's
+ * name rule, which is the part worth keeping in one place. */
+static int name_allowed(const char *name, size_t len)
+{
+   if (!g_name_validator || !name || len == 0 || len > WR_NAME_MAX)
+      return 0;
+   if (memchr(name, '/', len))
+      return 0;
+   int allowed = 0;
+   return g_name_validator(name, len, &allowed) == 0 && allowed;
+}
 
 int webuser_runtime_is_tmpfs(const char *path)
 {
@@ -46,7 +72,7 @@ static int principal_name(const char *principal, char *name, size_t cap)
       return -1;
    const char *u = principal + pl;
    size_t ul = strlen(u);
-   if (ul == 0 || ul >= cap || !ws_scope_name_valid(u))
+   if (ul == 0 || ul >= cap || !name_allowed(u, ul))
       return -1;
    memcpy(name, u, ul + 1);
    return 0;

--- a/src/modules/webuser/webuser_runtime.h
+++ b/src/modules/webuser/webuser_runtime.h
@@ -20,6 +20,18 @@
  * any other filesystem, -1 if it cannot be stat'd. Pure-ish (a syscall). */
 int webuser_runtime_is_tmpfs(const char *path);
 
+/* Decide whether `name` (length `len`) is a safe single path component, writing
+ * 1 or 0 to `allowed`. Returns 0 when the decision was reached.
+ *
+ * The rule belongs to `workspace`, which owns what a project reference may be;
+ * this file used to reach into its private header for it. The seam lets core
+ * inject the workspace module's own answer over the event bus instead, so the
+ * rule stays in one place without this becoming a direct module-to-module call.
+ * The signature matches workspace's ref validator so core can register one
+ * implementation for both. */
+typedef int (*webuser_name_validator_fn)(const char *name, size_t len, int *allowed);
+void webuser_runtime_register_name_validator(webuser_name_validator_fn validator);
+
 /* Validate the `webuser:` actor, then resolve/create the shared 0700 environment
  * runtime dir into out[cap]. FAIL-CLOSED:
  * returns -1 (and creates nothing under it) if the runtime base is not tmpfs, or

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -11,6 +11,7 @@
 #include "response_dedup.h"
 #include "server_error_kind.h"
 #include "modules/skills/skill_trigger_policy.h"
+#include "modules/webuser/webuser_runtime.h"
 #include "modules/workspace/workspace_scope.h"
 #include <aimee/audit/obs_bus.h>
 #include <aimee/benchmarks/module_api.h>
@@ -312,6 +313,10 @@ void server_module_stage_adapters_configure(void)
    delegate_role_register_canonicalizer(delegate_canonicalize);
    agent_tools_register_classifier(tool_classify);
    ws_scope_register_ref_validator(workspace_validate);
+   /* Same decision, same owner: webuser's runtime dir names a single path
+    * component, and workspace owns what a reference may be. One registration
+    * serves both seams so the rule cannot drift between them. */
+   webuser_runtime_register_name_validator(workspace_validate);
    git_ops_register_classifier(git_classify);
    git_ops_register_ref_validator(git_validate_ref);
    gw_response_governance_register_provider(governance_evaluate);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3923,7 +3923,8 @@ $(TESTPREFIX)/unit-test-workspace-provider-detached: \
 $(TESTPREFIX)/unit-test-webuser-runtime: \
                       $(OBJDIR)/tests/test_webuser_runtime.o \
                       $(OBJDIR)/modules/webuser/webuser_runtime.o \
-                      $(OBJDIR)/modules/workspace/workspace_scope.o \
+                      $(OBJDIR)/tests/support/webuser_name_validator.o \
+                      $(OBJDIR)/tests/module_handlers/workspace.o \
                       $(OBJDIR)/aimee_home.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
@@ -5291,7 +5292,7 @@ $(TESTPREFIX)/unit-test-git-project: $(OBJDIR)/tests/test_git_project.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-webchat-git-leak: $(OBJDIR)/tests/test_webchat_git_leak.o \
-                              $(OBJDIR)/modules/git/git_cred_inject.o $(OBJDIR)/modules/git/git_ssh_agent.o $(OBJDIR)/modules/webuser/webuser_runtime.o $(OBJDIR)/modules/workspace/workspace_scope.o $(OBJDIR)/modules/git/git_forge_vault.o \
+                              $(OBJDIR)/modules/git/git_cred_inject.o $(OBJDIR)/modules/git/git_ssh_agent.o $(OBJDIR)/modules/webuser/webuser_runtime.o $(OBJDIR)/tests/support/webuser_name_validator.o $(OBJDIR)/tests/module_handlers/workspace.o $(OBJDIR)/modules/git/git_forge_vault.o \
                               $(OBJDIR)/modules/git/git_host_cred.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/util_url.o $(OBJDIR)/posix/util.o $(OBJDIR)/util.o \
                               $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/aimee_home.o \
                               $(OBJDIR)/modules/vault/vault_service.o $(OBJDIR)/modules/vault/vault_store.o $(OBJDIR)/modules/vault/vault_kek_check.o \
@@ -5302,7 +5303,7 @@ $(TESTPREFIX)/unit-test-webchat-git-leak: $(OBJDIR)/tests/test_webchat_git_leak.
 
 $(TESTPREFIX)/unit-test-git-ssh-agent: $(OBJDIR)/tests/test_git_ssh_agent.o \
                               $(OBJDIR)/modules/git/git_ssh_agent.o $(OBJDIR)/modules/git/git_forge_vault.o \
-                              $(OBJDIR)/modules/webuser/webuser_runtime.o $(OBJDIR)/modules/workspace/workspace_scope.o \
+                              $(OBJDIR)/modules/webuser/webuser_runtime.o $(OBJDIR)/tests/support/webuser_name_validator.o $(OBJDIR)/tests/module_handlers/workspace.o \
                               $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/aimee_home.o \
                               $(OBJDIR)/modules/vault/vault_service.o $(OBJDIR)/modules/vault/vault_store.o $(OBJDIR)/modules/vault/vault_kek_check.o \
                               $(OBJDIR)/modules/vault/vault_crypto.o $(OBJDIR)/modules/vault/vault_kek_cache.o \
@@ -5311,7 +5312,7 @@ $(TESTPREFIX)/unit-test-git-ssh-agent: $(OBJDIR)/tests/test_git_ssh_agent.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-git-cred-inject: $(OBJDIR)/tests/test_git_cred_inject.o \
-                              $(OBJDIR)/modules/git/git_cred_inject.o $(OBJDIR)/modules/git/git_ssh_agent.o $(OBJDIR)/modules/webuser/webuser_runtime.o $(OBJDIR)/modules/workspace/workspace_scope.o $(OBJDIR)/modules/git/git_forge_vault.o \
+                              $(OBJDIR)/modules/git/git_cred_inject.o $(OBJDIR)/modules/git/git_ssh_agent.o $(OBJDIR)/modules/webuser/webuser_runtime.o $(OBJDIR)/tests/support/webuser_name_validator.o $(OBJDIR)/tests/module_handlers/workspace.o $(OBJDIR)/modules/git/git_forge_vault.o \
                               $(OBJDIR)/modules/git/git_host_cred.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/util_url.o $(OBJDIR)/posix/util.o $(OBJDIR)/util.o \
                               $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/aimee_home.o \
                               $(OBJDIR)/modules/vault/vault_service.o $(OBJDIR)/modules/vault/vault_store.o $(OBJDIR)/modules/vault/vault_kek_check.o \

--- a/src/tests/support/webuser_name_validator.c
+++ b/src/tests/support/webuser_name_validator.c
@@ -1,0 +1,48 @@
+/* webuser_name_validator — install webuser_runtime's name validator for tests.
+ *
+ * webuser_runtime fails closed until core registers a validator, because the
+ * rule for what may name a directory belongs to `workspace`, not to webuser. A
+ * test that exercises the runtime dir therefore has to install one, and the
+ * honest thing to install is workspace's own answer over its wire contract --
+ * the same decision the server registers -- rather than a stub that could agree
+ * with nothing real.
+ *
+ * The separator case is deliberately left to webuser: workspace admits
+ * `owner/project`, a runtime dir name is one component, and webuser rejects the
+ * slash before delegating.
+ */
+#include "webuser_runtime.h"
+
+#include <aimee/core/event_bus/module_runtime.h>
+#include <aimee/workspace/module_api.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern aimee_module_status_t aimee_workspace_module_handler(const aimee_module_invocation_t *,
+                                                            const uint8_t *, uint32_t, uint8_t *,
+                                                            uint32_t, uint32_t *, void *);
+
+int aimee_module_invocation_cancelled(const aimee_module_invocation_t *invocation)
+{
+   (void)invocation;
+   return 0;
+}
+
+static int validate_name_via_module(const char *name, size_t len, int *allowed)
+{
+   uint8_t request[AIMEE_WORKSPACE_REQUEST_LEN], response[AIMEE_WORKSPACE_RESPONSE_LEN];
+   uint32_t response_len = 0;
+   aimee_module_invocation_t invocation = {.stage_id = AIMEE_WORKSPACE_STAGE_ACCESS};
+   return aimee_workspace_request_encode(name, len, request, sizeof(request)) == 0 &&
+                  aimee_workspace_module_handler(&invocation, request, sizeof(request), response,
+                                                 sizeof(response), &response_len,
+                                                 NULL) == AIMEE_MODULE_STATUS_OK
+              ? aimee_workspace_response_decode(response, response_len, allowed)
+              : -1;
+}
+
+void webuser_test_install_name_validator(void)
+{
+   webuser_runtime_register_name_validator(validate_name_via_module);
+}

--- a/src/tests/test_git_cred_inject.c
+++ b/src/tests/test_git_cred_inject.c
@@ -64,8 +64,13 @@ static int fd_token(int fd, char *out, size_t cap)
    return out[0] != '\0';
 }
 
+/* webuser_runtime fails closed until a name validator is registered; the askpass
+ * socket lives under its runtime dir. See tests/support/webuser_name_validator.c. */
+void webuser_test_install_name_validator(void);
+
 int main(void)
 {
+   webuser_test_install_name_validator();
    int fdX = -1;
    char tokbuf[4096];
    char home[256];

--- a/src/tests/test_git_ssh_agent.c
+++ b/src/tests/test_git_ssh_agent.c
@@ -53,8 +53,13 @@ static int dir_has_plaintext(const char *dir, const char *needle)
    return hit;
 }
 
+/* webuser_runtime fails closed until a name validator is registered; the agent
+ * socket lives under its runtime dir. See tests/support/webuser_name_validator.c. */
+void webuser_test_install_name_validator(void);
+
 int main(void)
 {
+   webuser_test_install_name_validator();
    if (!have("ssh-agent") || !have("ssh-add") || !have("ssh-keygen"))
    {
       printf("git_ssh_agent: SKIP (openssh tooling unavailable)\n");

--- a/src/tests/test_webuser_runtime.c
+++ b/src/tests/test_webuser_runtime.c
@@ -10,6 +10,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+/* Installs workspace's own name rule over its wire contract; see
+ * tests/support/webuser_name_validator.c. */
+void webuser_test_install_name_validator(void);
+
 int main(void)
 {
    /* --- the tmpfs gate against real mounts --- */
@@ -21,6 +25,14 @@ int main(void)
 
    char base[256];
    snprintf(base, sizeof(base), "/dev/shm/aimee-wrt-test-%d", (int)getpid());
+
+   /* Name validation fails closed until the event-bus provider is installed,
+    * matching ws_scope_project_ref_valid: there is no local copy of the rule to
+    * fall back to. */
+   setenv("AIMEE_RUNTIME_DIR", base, 1);
+   char closed[512];
+   assert(webuser_runtime_dir("webuser:alice", closed, sizeof(closed)) == -1);
+   webuser_test_install_name_validator();
 
    /* --- success path on tmpfs: one 0700 environment dir, shared by actors --- */
    setenv("AIMEE_RUNTIME_DIR", base, 1);
@@ -38,7 +50,13 @@ int main(void)
    strcpy(x, "STALE");
    assert(webuser_runtime_dir("uid:1000", x, sizeof(x)) == -1 && x[0] == '\0');
    assert(webuser_runtime_dir("webuser:..", x, sizeof(x)) == -1);
+   /* A separator must stay refused even though workspace's validator admits
+    * `owner/project`: a runtime dir name is one component, and delegating this
+    * case would let a principal name a path. */
    assert(webuser_runtime_dir("webuser:a/b", x, sizeof(x)) == -1);
+   assert(webuser_runtime_dir("webuser:../etc", x, sizeof(x)) == -1);
+   assert(webuser_runtime_dir("webuser:a/../b", x, sizeof(x)) == -1);
+   assert(webuser_runtime_dir("webuser:/abs", x, sizeof(x)) == -1);
 
    /* cleanup removes the dir (and any sockets in it) */
    char sock[600];


### PR DESCRIPTION
The first crossing retired under the gate added in #2384. **46 → 45.**

`webuser_runtime.c` included `modules/workspace/workspace_scope.h` to call
`ws_scope_name_valid` — a module reaching past a peer's public API into its
private tree, the worst of the three classes the gate records. It also made
webuser's tests link workspace's implementation.

## The rule stays where it belongs

`workspace` owns what may name a project, so the call moves onto the seam core
already uses for exactly this decision. `webuser` declares a validator hook, and
`module_stage_adapters` registers the **same** bus-backed workspace validator it
registers for `ws_scope_project_ref_valid` — one implementation, two seams, no
opportunity to drift.

Fail-closed with nothing registered, matching `ws_scope_project_ref_valid`: no
local copy of the rule to fall back to, and this file's contract is to refuse
rather than degrade.

## The separator case is the interesting part

My first attempt delegated the whole question to workspace's validator. **The
existing test caught a security regression**: workspace admits a *reference*,
which is legitimately `owner/project`, so `webuser:a/b` would have been accepted
and become a runtime directory path.

```
Assertion `webuser_runtime_dir("webuser:a/b", x, sizeof(x)) == -1' failed
```

The slash is now rejected locally — a runtime dir name is one component, which is
webuser's own requirement — and only the charset rule is delegated. With the
separator excluded, the delegated answer is exactly `ws_scope_name_valid`.
`../etc`, `a/../b` and `/abs` are asserted explicitly now rather than resting on
one incidental case.

## Blast radius, handled

`git_ssh_agent` and `git_cred_inject` both reach `webuser_runtime_dir`, so their
tests install the validator too. `tests/support/webuser_name_validator.c`
installs workspace's own answer over its wire contract — the same decision the
server registers — rather than a stub that could agree with nothing real.

All three tests now link that support object plus the workspace module handler
**instead of `workspace_scope.o`**, so the build graph loses the dependency as
well as the source.

## Verification

```
check_module_bus_boundary: ok (45 declared crossings remain)   # was 46
make -C src all                                                # links
make -C src unit-tests                                         # All tests passed.
```

Also green: header layout, descriptors, test registration, process contracts, Go
runtime bundle, module supervisor, module docs, cleanup ledger, panel contract
boundary, refactor baselines, and `check_c_repository_lock` — the git module pin
is resynced because two of its declared tests changed.

## What this does not touch

The remaining 45 are not all retirable this way. Of the 19 other private-header
reaches: 6 carry vault credential material (`git_cred_inject_build_env_for_repo`,
`forge_cred_get`) whose own header says the token is "never logged", and the bus
has an ordered capture and audit tap; 5 pass file descriptors or depend on
resolve-and-open TOCTOU closure that a process boundary would widen; 5 pass an
in-process `workspace_provider_t *`. Those need a design decision, not a
mechanical move.
