### PR TITLE
build: count the coupling that reaches modules by bare filename

### DIFF
--- a/scripts/check_module_bus_boundary.py
+++ b/scripts/check_module_bus_boundary.py
@@ -87,7 +87,148 @@ PRIVATE_HEADER_REACH = {
     ("src/modules/workspace/workspace_turn.c", "modules/git/forge_credentials.h"),
     ("src/modules/workspace/workspace_turn.c", "modules/git/git_cred_inject.h"),
 }
-ALLOWED = IR_SHARED_TYPE | PENDING_BUS_MIGRATION | PRIVATE_HEADER_REACH
+# Reaches into a module the build links into core rather than supervising as a bus
+# peer (`execution: core` in the repository lock): config, vault, audit,
+# execution-policy, gateway, ir, module-runtime, protocols, translation.
+#
+# These are the invariant's real exception, and the point of listing them is that
+# it stops being unstated. A credential store cannot be a bus peer -- git_cred_inject
+# promises its token is "never logged" while the bus keeps an ordered capture and
+# audit tap -- so vault is core by necessity, not by omission. Whether every module
+# here belongs in core is a question this list is meant to make askable.
+CORE_LINKED_REACH = {
+    ("src/modules/audit/audit_ledger.c", "config/config.h"),
+    ("src/modules/audit/obs_bus.c", "config/config.h"),
+    ("src/modules/benchmarks/agent_eval.c", "config/config.h"),
+    ("src/modules/benchmarks/agent_eval_benchmarks.c", "config/config.h"),
+    ("src/modules/benchmarks/agent_eval_memory_support.c", "config/config.h"),
+    ("src/modules/benchmarks/agent_eval_memory_support.c", "config/config_database.h"),
+    ("src/modules/config/config.c", "vault/runtime_secret.h"),
+    ("src/modules/config/config_database.c", "vault/runtime_secret.h"),
+    ("src/modules/config/config_fields.c", "vault/runtime_secret.h"),
+    ("src/modules/config/config_server_api.c", "vault/runtime_secret.h"),
+    ("src/modules/css/css_render_cmd.c", "config/config.h"),
+    ("src/modules/delegates/delegate_credential_retry.c", "config/config.h"),
+    ("src/modules/delegates/delegate_credential_retry.c", "vault/runtime_secret.h"),
+    ("src/modules/delegates/delegate_credential_retry.c", "vault/vault_service.h"),
+    ("src/modules/delegates/delegate_prompt.c", "config/config.h"),
+    ("src/modules/delegates/delegate_sandbox_image.c", "config/config.h"),
+    ("src/modules/delegates/include/aimee/delegates/delegate_credentials.h", "vault/vault_principal.h"),
+    ("src/modules/economizer/gateway_mutate_wire.c", "config/config.h"),
+    ("src/modules/economizer/tool_condense.h", "config/config.h"),
+    ("src/modules/execution-policy/execution_policy.c", "config/config.h"),
+    ("src/modules/gateway/gateway_policy.c", "config/config.h"),
+    ("src/modules/git/git_forge_vault.c", "vault/vault_service.h"),
+    ("src/modules/git/git_host_cred.c", "vault/vault_service.h"),
+    ("src/modules/git/git_host_cred.c", "vault/vault_store.h"),
+    ("src/modules/git/git_oauth_device.c", "vault/vault_service.h"),
+    ("src/modules/git/git_oauth_github.c", "vault/runtime_secret.h"),
+    ("src/modules/git/git_oauth_github.c", "vault/vault_service.h"),
+    ("src/modules/git/git_verify.c", "config/config.h"),
+    ("src/modules/git/git_verify_ops.c", "config/config.h"),
+    ("src/modules/git/mcp_git_pr.c", "config/config.h"),
+    ("src/modules/git/mcp_git_query.c", "config/config.h"),
+    ("src/modules/git/mcp_git_write.c", "config/config.h"),
+    ("src/modules/guardrails/guardrails_action_audit.c", "config/config.h"),
+    ("src/modules/guardrails/guardrails_blast_radius.c", "config/config.h"),
+    ("src/modules/guardrails/guardrails_orchestrator.c", "config/config.h"),
+    ("src/modules/guardrails/guardrails_semantic.h", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_drain.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_drain.c", "config/config_database.h"),
+    ("src/modules/kb-synthesis/kb_curator_extract.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_index_claims.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_index_code_unit.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_index_narrative.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_judge.h", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_link_artifacts.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_notify.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_promote.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_queue.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_queue.c", "config/config_database.h"),
+    ("src/modules/kb-synthesis/kb_curator_resolve_entities.c", "config/config.h"),
+    ("src/modules/kb-synthesis/kb_curator_synthesize.c", "config/config.h"),
+    ("src/modules/kb_client/kb_client.c", "vault/runtime_secret.h"),
+    ("src/modules/kb_client/kb_client_mtls.c", "config/config.h"),
+    ("src/modules/kb_client/kb_client_mtls.c", "vault/runtime_secret.h"),
+    ("src/modules/kb_client/kb_client_ws.c", "vault/runtime_secret.h"),
+    ("src/modules/learning/learning_implicit.c", "config/config.h"),
+    ("src/modules/lsp/lsp_manager.c", "config/config.h"),
+    ("src/modules/memory/memory_advanced.c", "config/config.h"),
+    ("src/modules/memory/memory_core_helpers_b.c", "vault/runtime_secret.h"),
+    ("src/modules/memory/memory_core_internal.h", "config/config.h"),
+    ("src/modules/memory/memory_core_scope_embed.c", "config/config_database.h"),
+    ("src/modules/memory/memory_logic.c", "config/config.h"),
+    ("src/modules/memory/memory_rewrite_llm.h", "config/config.h"),
+    ("src/modules/protocols/include/aimee/protocols/mcp/mcp_client_registry.h", "config/config.h"),
+    ("src/modules/protocols/mcp/mcp_client_registry.c", "vault/runtime_secret.h"),
+    ("src/modules/roundtable/delegate_ensemble.c", "config/config.h"),
+    ("src/modules/roundtable/delegate_ensemble.c", "vault/runtime_secret.h"),
+    ("src/modules/roundtable/delegate_ensemble.h", "config/config.h"),
+    ("src/modules/roundtable/delegate_ensemble_review.c", "config/config.h"),
+    ("src/modules/roundtable/roundtable_preset.c", "config/config.h"),
+    ("src/modules/roundtable/roundtable_preset.h", "config/config.h"),
+    ("src/modules/roundtable/roundtable_seat_resolve.h", "config/config.h"),
+    ("src/modules/sandbox/sandbox_learned.c", "config/config.h"),
+    ("src/modules/skills/skill.c", "config/config.h"),
+    ("src/modules/tools/agent_tools.c", "config/config.h"),
+    ("src/modules/tools/agent_tools_anchored.c", "config/config.h"),
+    ("src/modules/tools/agent_tools_completion.c", "config/config.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "config/config.h"),
+    ("src/modules/vault/vault_capability.c", "config/config.h"),
+    ("src/modules/vault/vault_config_bootstrap.c", "config/config.h"),
+    ("src/modules/vault/vault_custody_tpm2.c", "config/config.h"),
+    ("src/modules/vault/vault_server_key.c", "config/config.h"),
+    ("src/modules/vault/vault_store.c", "config/config.h"),
+    ("src/modules/workflows/wfe_autonomy.c", "config/config.h"),
+    ("src/modules/workflows/wfe_blocks.c", "config/config.h"),
+    ("src/modules/workflows/wfe_live_forge.c", "config/config.h"),
+    ("src/modules/workflows/wfe_live_panel.c", "config/config.h"),
+    ("src/modules/workflows/wfe_scheduler.c", "config/config.h"),
+    ("src/modules/workspace/workspace.c", "config/config.h"),
+    ("src/modules/workspace/workspace.c", "config/config_accessors.h"),
+    ("src/modules/workspace/workspace_turn.c", "config/config.h"),
+}
+# Reaches into a module that is NOT core-linked, through the flat include root the
+# build puts on the path. Same coupling as PRIVATE_HEADER_REACH, reached by bare
+# filename instead of a prefix, and invisible until this check learned to resolve
+# names. Retiring one means the owner grows a bus stage, or the caller stops being
+# a separate module.
+FLAT_ROOT_REACH = {
+    ("src/modules/config/config_sections.c", "economizer/economizer.h"),
+    ("src/modules/delegates/delegate_prompt.c", "kb_client/kb_client.h"),
+    ("src/modules/delegates/delegate_run_phases.c", "guardrails/guardrails.h"),
+    ("src/modules/delegates/delegate_sandbox_image.c", "guardrails/guardrails.h"),
+    ("src/modules/delegates/delegate_sandbox_image.c", "sandbox/sandbox_learned.h"),
+    ("src/modules/delegates/include/aimee/delegates/panel_provider.h", "roundtable/roundtable_types.h"),
+    ("src/modules/execution-policy/execution_policy.c", "economizer/coord_closet.h"),
+    ("src/modules/execution-policy/execution_policy.c", "kb_client/kb_client.h"),
+    ("src/modules/git/git_ssh_agent.c", "webuser/webuser_runtime.h"),
+    ("src/modules/git/git_verify_ops.c", "guardrails/guardrails.h"),
+    ("src/modules/git/mcp_git_pr.c", "guardrails/guardrails.h"),
+    ("src/modules/git/mcp_git_query.c", "guardrails/guardrails.h"),
+    ("src/modules/git/mcp_git_write.c", "guardrails/guardrails.h"),
+    ("src/modules/guardrails/guardrails.c", "kb_client/kb_client.h"),
+    ("src/modules/guardrails/guardrails_blast_radius.c", "kb_client/kb_client.h"),
+    ("src/modules/guardrails/guardrails_orchestrator.c", "kb_client/kb_client.h"),
+    ("src/modules/sandbox/sandbox_learned.c", "guardrails/guardrails.h"),
+    ("src/modules/tools/agent_tools.c", "economizer/economizer.h"),
+    ("src/modules/tools/agent_tools.c", "kb_client/kb_client.h"),
+    ("src/modules/tools/agent_tools.c", "lsp/lsp.h"),
+    ("src/modules/tools/agent_tools.c", "sandbox/sandbox_learned.h"),
+    ("src/modules/tools/agent_tools_anchored.c", "economizer/economizer.h"),
+    ("src/modules/tools/agent_tools_anchored.c", "guardrails/guardrails.h"),
+    ("src/modules/tools/agent_tools_anchored.c", "kb_client/kb_client.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "economizer/economizer.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "guardrails/guardrails_blast_radius.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "kb_client/kb_client.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "lsp/lsp.h"),
+    ("src/modules/tools/agent_tools_dispatch.c", "sandbox/sandbox_learned.h"),
+    ("src/modules/workflows/wfe_live_panel.c", "roundtable/roundtable_verify.h"),
+    ("src/modules/workflows/wfe_panel_roundtable.h", "roundtable/delegate_ensemble.h"),
+    ("src/modules/workspace/workspace.c", "kb_client/kb_client.h"),
+}
+ALLOWED = (IR_SHARED_TYPE | PENDING_BUS_MIGRATION | PRIVATE_HEADER_REACH |
+           CORE_LINKED_REACH | FLAT_ROOT_REACH)
 # Both bracket styles: a quoted include couples exactly as hard as an angled one,
 # and the tree uses quoted form for every `modules/` reach and for three
 # `aimee/protocols/` ones.
@@ -103,12 +244,49 @@ def owning_module(relative: str) -> str:
     return relative.split("/")[2]
 
 
+def flat_root_owners(root: Path) -> dict[str, str]:
+    """Header basename -> the module whose directory root publishes it.
+
+    The build puts most module directories on the include path (`-Imodules/<id>`
+    or `-iquote modules/<id>`), so `#include "vault_service.h"` reaches straight
+    into vault. Counting only `aimee/` and `modules/` prefixes missed all of it:
+    122 crossings against the 45 those prefixes see.
+
+    Ownership is by basename, which is only sound while basenames are unique. A
+    collision, or a name that `src/headers` would resolve first, makes the answer
+    depend on include order rather than on the name, so it is rejected outright
+    rather than guessed at.
+    """
+    owners: dict[str, str] = {}
+    collisions: list[str] = []
+    modules = root / MODULES
+    for module_dir in sorted(path for path in modules.iterdir() if path.is_dir()):
+        for header in sorted(module_dir.glob("*.h")):
+            previous = owners.get(header.name)
+            if previous is not None:
+                collisions.append(f"{header.name} in {previous} and {module_dir.name}")
+                continue
+            owners[header.name] = module_dir.name
+    if collisions:
+        raise CheckError(
+            f"rule=ambiguous-module-header headers={sorted(collisions)} "
+            "(a bare include would resolve by search order, not by owner)"
+        )
+    shadowed = sorted(name for name in owners if (root / "src/headers" / name).exists())
+    if shadowed:
+        raise CheckError(
+            f"rule=shadowed-module-header headers={shadowed} "
+            "(src/headers resolves first, so the owner cannot be read off the name)"
+        )
+    return owners
+
+
 def included_module(header: str) -> str | None:
-    """The module an include names, or None when it names no module at all.
+    """The module a prefixed include names, or None when it names no module.
 
     `aimee/<id>/...` is a module's public API and `modules/<id>/...` is its
-    private tree. Everything else -- db1/, db2/, bare filenames -- is a lower
-    layer, not a peer, and is none of this check's business.
+    private tree. Everything else with a path -- db1/, db2/ -- is a lower layer,
+    not a peer. Bare filenames are resolved separately, by owner lookup.
     """
     parts = header.split("/")
     if len(parts) < 2 or parts[0] not in MODULE_ROOTS:
@@ -122,11 +300,20 @@ def crossings(root: Path):
     if not modules.is_dir():
         raise CheckError(f"rule=module-root-missing path={MODULES}")
 
+    owners = flat_root_owners(root)
     found: set[tuple[str, str]] = set()
     for path in sorted((*modules.rglob("*.c"), *modules.rglob("*.h"))):
         relative = path.relative_to(root).as_posix()
         owner = owning_module(relative)
         for header in INCLUDE.findall(path.read_text(encoding="utf-8")):
+            if "/" not in header:
+                # A bare include. It reaches a peer only when some module root
+                # publishes the name and the including file's own directory does
+                # not -- an own-directory header always wins for a quoted include.
+                peer = owners.get(header)
+                if peer is not None and peer != owner and not (path.parent / header).exists():
+                    found.add((relative, f"{peer}/{header}"))
+                continue
             if header in BUS_TRANSPORT_HEADERS:
                 continue
             peer = included_module(header)

--- a/scripts/tests/test_check_module_bus_boundary.py
+++ b/scripts/tests/test_check_module_bus_boundary.py
@@ -30,6 +30,9 @@ FIXTURE = {
         "#include <aimee/workspace/workspace.h>\n"
     ),
     "src/modules/tools/include/aimee/tools/agent_tools.h": "#include <aimee/core/bus_client.h>\n",
+    # A private header at the module root: the shape the build puts on the
+    # include path, so a peer can name it without any prefix.
+    "src/modules/tools/tools_internal.h": "#pragma once\n",
     "src/modules/workspace/workspace.c": "#include <aimee/core/bus_client.h>\n",
     "src/modules/workspace/include/aimee/workspace/workspace.h": "#pragma once\n",
 }
@@ -143,6 +146,69 @@ class ModuleBusBoundaryTests(unittest.TestCase):
             None,
         )
 
+    def test_a_bare_include_of_a_peers_header_is_rejected(self) -> None:
+        """The build puts module directories on the include path, so a bare name
+        reaches straight into a peer. Counting only prefixed includes missed 122
+        crossings against the 45 it saw."""
+        self.assert_fixture(
+            self.append("src/modules/workspace/workspace.c", '#include "tools_internal.h"\n'),
+            "undeclared-cross-module",
+        )
+
+    def test_a_bare_include_resolved_by_the_own_directory_is_not_a_crossing(self) -> None:
+        """A quoted include finds the including file's own directory first.
+
+        Two module roots sharing a basename is ambiguity and is refused outright,
+        so the case this rule actually covers is a file in a SUBdirectory sitting
+        beside its own copy of a name some module root also publishes.
+        """
+        def mutate(root: Path) -> None:
+            nested = root / "src/modules/workspace/sub"
+            nested.mkdir(parents=True, exist_ok=True)
+            (nested / "tools_internal.h").write_text("#pragma once\n", encoding="utf-8")
+            (nested / "nested.c").write_text('#include "tools_internal.h"\n', encoding="utf-8")
+        self.assert_fixture(mutate, None)
+
+    def test_a_bare_include_naming_no_module_is_ignored(self) -> None:
+        self.assert_fixture(
+            self.append("src/modules/workspace/workspace.c", '#include "nothing_owns_this.h"\n'),
+            None,
+        )
+
+    def test_an_ambiguous_module_header_name_is_refused(self) -> None:
+        """Two modules publishing one basename makes ownership depend on include
+        order, so the check refuses to guess rather than pick the first."""
+        def mutate(root: Path) -> None:
+            (root / "src/modules/workspace/tools_internal.h").write_text("#pragma once\n", encoding="utf-8")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.fixture(root)
+            (root / "src/modules/tools/tools_internal.h").write_text("#pragma once\n", encoding="utf-8")
+            mutate(root)
+            with self.assertRaisesRegex(checker.CheckError, "rule=ambiguous-module-header"):
+                checker.crossings(root)
+
+    def test_a_module_header_shadowed_by_src_headers_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.fixture(root)
+            (root / "src/headers").mkdir(parents=True, exist_ok=True)
+            (root / "src/headers/workspace.h").write_text("#pragma once\n", encoding="utf-8")
+            (root / "src/modules/workspace/workspace.h").write_text("#pragma once\n", encoding="utf-8")
+            with self.assertRaisesRegex(checker.CheckError, "rule=shadowed-module-header"):
+                checker.crossings(root)
+
+    def test_core_linked_reaches_name_a_core_linked_module(self) -> None:
+        """The exception is only meaningful if the group actually holds it."""
+        core_linked = {"audit", "config", "execution-policy", "gateway", "ir",
+                       "module-runtime", "protocols", "translation", "vault"}
+        for path, header in checker.CORE_LINKED_REACH:
+            with self.subTest(path=path):
+                self.assertIn(header.split("/")[0], core_linked)
+        for path, header in checker.FLAT_ROOT_REACH:
+            with self.subTest(path=path):
+                self.assertNotIn(header.split("/")[0], core_linked)
+
     def test_a_missing_module_root_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaisesRegex(checker.CheckError, "rule=module-root-missing"):
@@ -179,7 +245,8 @@ class ModuleBusBoundaryTests(unittest.TestCase):
 
     def test_every_declared_crossing_is_classified_exactly_once(self) -> None:
         groups = (checker.IR_SHARED_TYPE, checker.PENDING_BUS_MIGRATION,
-                  checker.PRIVATE_HEADER_REACH)
+                  checker.PRIVATE_HEADER_REACH, checker.CORE_LINKED_REACH,
+                  checker.FLAT_ROOT_REACH)
         union: set = set()
         for group in groups:
             self.assertEqual(union & group, set())


### PR DESCRIPTION
The gate added in #2384 certified **46** crossings while **122 more went unseen**.
It reported a number that flattered the tree by about four to one.

## What it missed

The build puts most module directories directly on the include path —
`-Imodules/<id>` and `-iquote modules/<id>` — so this reaches straight into vault:

```c
#include "vault_service.h"
```

The check only understood `aimee/<id>/` and `modules/<id>/` prefixes, so a bare
filename named no module to it and every such reach was invisible.

I found this while answering a question about whether `vault` could be optional.
It can't, and the reason was hiding in exactly the coupling the gate couldn't see.

## How ownership is resolved

By basename — which is only sound while basenames are unique. Two module roots
publishing one name, or a name `src/headers` would resolve first, makes the answer
depend on include order rather than on the name. Both are **refused outright**
(`rule=ambiguous-module-header`, `rule=shadowed-module-header`) rather than
guessed at. Neither exists today; the rules are there so that stops being luck.

A quoted include finds the including file's own directory first, so a header
sitting beside its includer is not a crossing.

## The new entries, split by what they mean

| Group | Count | Meaning |
|---|---|---|
| `CORE_LINKED_REACH` | 90 | The peer is `execution: core` in the repository lock — `config`, `vault`, `audit`, `execution-policy`, `gateway`, `ir`, `module-runtime`, `protocols`, `translation`. |
| `FLAT_ROOT_REACH` | 32 | The peer is not core-linked. Same coupling as `PRIVATE_HEADER_REACH`, reached by bare name. |

The first group is the invariant's **real exception**, and the point of listing it
is that it stops being unstated. A credential store cannot be a bus peer:
`git_cred_inject` promises its token is "never on disk, never on the command line,
never logged," while the bus keeps an ordered capture and audit tap. Vault is
core-linked by necessity, not by omission.

Recording them doesn't bless them — it makes the question askable. `config` alone
takes 71 reaches from 22 modules; whether that is a core contract or a god object
is now a visible question rather than an invisible one.

Both groups stay closed and shrink-only, like the groups beside them.

## Verification

```
module-bus-boundary: ok (168 declared crossings remain)   # was 46
```

- green from the repository and from a foreign CWD
- **23/23** tests, including red-before-green for a bare peer include, the
  own-directory case, and refusal of an ambiguous or shadowed basename
- source ownership, header layout, panel boundary, descriptors, refactor
  baselines and the repository lock all still pass

## Relationship to #2404

Independent — this branch is cut from `testing`, so it still records
`webuser_runtime.c -> workspace_scope.h`, the crossing #2404 retires. Whichever
merges second drops that line. They can land in either order.
