### PR TITLE
fix: say why roundtable review is unavailable, not a cause that is false

### DIFF
--- a/src/server/roundtable_review_bus.c
+++ b/src/server/roundtable_review_bus.c
@@ -100,9 +100,31 @@ static char *build_review_body(const cJSON *request, const char *resolved_panel)
 int handle_roundtable_review(server_ctx_t *ctx, server_conn_t *conn, cJSON *request)
 {
    (void)ctx;
+   /* "No server for kind 9474" has two very different causes, and reporting the
+    * wrong one costs an operator the whole diagnosis.
+    *
+    * The module declares deliberate and chunk-plan unconditionally, but declares
+    * REVIEW only when its process can actually convene a panel -- it needs
+    * AIMEE_HOME for the saved roundtables and an agent resource plane
+    * (AIMEE_AGENT_SERVICE_SOCKET or AIMEE_AGENT_SERVICE_URL) to seat them. When it
+    * cannot, it deliberately leaves the kind undeclared and logs why to its own
+    * stdout, so the daemon reports the module as not serving review, which is
+    * true. Saying "not attached to the event bus" then names a cause that is
+    * false and sends the operator looking at the supervisor instead of at the
+    * module's environment.
+    *
+    * Deliberate (9473) separates the two: if it is served, the module is up. */
    if (!obs_bus_module_available(AIMEE_ROUNDTABLE_EVENT_REVIEW))
-      return server_send_error(conn, "roundtable review module is not attached to the event bus",
-                               NULL);
+      return server_send_error(
+          conn,
+          obs_bus_module_available(AIMEE_ROUNDTABLE_EVENT_DELIBERATE)
+              ? "roundtable module is attached but is not serving review: its process could not "
+                "convene a panel. Check AIMEE_HOME and AIMEE_AGENT_SERVICE_SOCKET / "
+                "AIMEE_AGENT_SERVICE_URL on the module process, and its log for "
+                "\"roundtable review stage unavailable\""
+              : "roundtable module is not attached to the event bus (it is optional and off by "
+                "default; start the server with AIMEE_MODULE_ROUNDTABLE=1)",
+          NULL);
 
    const cJSON *preset = cJSON_GetObjectItemCaseSensitive(request, "roundtable");
    char resolved[ROUNDTABLE_REVIEW_PANEL_NAME_MAX] = "";


### PR DESCRIPTION
Asking for a review returned:

```
aimee: roundtable review module is not attached to the event bus
```

**The module was attached.** The message named the wrong cause, and that cost the
entire diagnosis — it points at the supervisor when the thing to look at is the
module process's environment.

## Why the message is wrong

The check is `obs_bus_module_available(AIMEE_ROUNDTABLE_EVENT_REVIEW)`, which
answers *"does anything serve kind 9474"* — not *"is the module attached"*. Those
differ **by design**, per `server-go/cmd/aimee-module/main.go`:

```go
// Deliberate is a pure rubric and always available. Review convenes real
// agents, so it is served only when this process can actually reach the
// delegate plane and the saved roundtables. Declaring the stage anyway
// would make an unreachable review look like a failing one; leaving it
// undeclared makes the daemon report the module as not serving that kind,
// which is what is true.
if reviewer, err := roundtableReviewer(); err != nil {
    log.Printf("roundtable review stage unavailable: %v", err)
} else { ...declare EventReview... }
```

`roundtableReviewer()` requires `AIMEE_HOME` for the saved roundtables and an
agent resource plane (`AIMEE_AGENT_SERVICE_SOCKET` or `AIMEE_AGENT_SERVICE_URL`)
to seat them. Without either it returns `"no agent resource plane is configured"`
or `"AIMEE_HOME is unset"`, leaves the kind undeclared, and logs the reason to its
**own stdout**.

So the daemon was reporting a correct state with an incorrect explanation.

## The fix

`deliberate` (9473) is declared unconditionally, so it separates the two cases:

| Condition | Message |
|---|---|
| 9473 served, 9474 not | module is attached but not serving review — check `AIMEE_HOME` and `AIMEE_AGENT_SERVICE_SOCKET`/`_URL` on the module process, and its log for `"roundtable review stage unavailable"` |
| Neither served | module is not attached — it is optional and off by default, start with `AIMEE_MODULE_ROUNDTABLE=1` |

Each now names what to actually go and look at.

## What this deliberately does not do

The module's real reason still only reaches its own stdout. Carrying it back to
the caller means the module reporting *why* a kind is undeclared, and the wire has
no field for that. This fixes the misdirection without inventing one — that is a
separate change with a contract implication.

## Verification

- `make -C src all` links
- **full unit suite passes** (`All tests passed.`)
- bus boundary, repository lock, refactor baselines, source ownership, descriptors — all pass
- `test_server_mcp_roundtable` stubs this exact string as a canned RPC response to
  check MCP error propagation, so it does not exercise this path and still passes

## Context

Found while trying to run a `bus-review` roundtable on an event-bus finding.
`aimee status` reports `aimee-server: ok` and `aimee-kb: ok`, and the `bus-review`
preset is present with architect/reviewer/qa/security seats — everything looked
healthy, and the one diagnostic available pointed at the wrong subsystem.
