### PR TITLE
feat(git): merge PRs through the vaulted token, keeping every option

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "38e9a43c03fd1de4038ca5ab7afa5ea8c5a702a548b1cb77de4f1a5b9c36e843",
+      "source_sha256": "57cea3045013ceba1b869f372d8cf4d08b0759a764796accb4fe3fe022dcc2ae",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -1112,18 +1112,72 @@ int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number
 int git_pr_merge_via_api_slug(const char *principal, const char *slug, int number, char *err,
                               size_t errlen)
 {
+   /* The squash-with-empty-body form the workflow forge and webchat rely on. */
+   return git_pr_merge_via_api_slug_ex(principal, slug, number, "squash", NULL, NULL, 0, err,
+                                       errlen);
+}
+
+int git_pr_merge_via_api_slug_ex(const char *principal, const char *slug, int number,
+                                 const char *merge_method, const char *expected_head_sha,
+                                 char *out_sha, size_t out_sha_cap, char *err, size_t errlen)
+{
    if (err && errlen)
       err[0] = '\0';
+   if (out_sha && out_sha_cap)
+      out_sha[0] = '\0';
    if (number <= 0)
       return -1;
+
+   /* Default to a real merge commit. Silently squashing would rewrite history the
+    * caller did not ask to rewrite, so an unrecognised method is refused rather
+    * than coerced. */
+   const char *method = (merge_method && merge_method[0]) ? merge_method : "merge";
+   if (strcmp(method, "merge") != 0 && strcmp(method, "squash") != 0 &&
+       strcmp(method, "rebase") != 0)
+   {
+      snprintf(err, errlen, "unsupported merge_method '%s' (merge|squash|rebase)", method);
+      return -1;
+   }
+
    gh_ctx_t cx;
    if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
+
+   cJSON *j = cJSON_CreateObject();
+   cJSON_AddStringToObject(j, "merge_method", method);
+   /* Only a squash synthesizes a body from the child commits, which is where the
+    * attribution trailers protected branches reject come back in -- see
+    * GIT_PR_SQUASH_MERGE_JSON. A merge or rebase has nothing to synthesize. */
+   if (strcmp(method, "squash") == 0)
+      cJSON_AddStringToObject(j, "commit_message", "");
+   /* Drift safety: GitHub refuses the merge if the head has moved. */
+   if (expected_head_sha && expected_head_sha[0])
+      cJSON_AddStringToObject(j, "sha", expected_head_sha);
+   char *payload = cJSON_PrintUnformatted(j);
+   cJSON_Delete(j);
+   if (!payload)
+   {
+      gh_ctx_done(&cx);
+      snprintf(err, errlen, "internal error");
+      return -1;
+   }
+
    char path[64];
    snprintf(path, sizeof(path), "pulls/%d/merge", number);
    char *resp = NULL;
-   int st = gh_put(&cx, path, GIT_PR_SQUASH_MERGE_JSON, &resp);
+   int st = gh_put(&cx, path, payload, &resp);
+   free(payload);
    gh_ctx_done(&cx);
+
+   /* The 200 body carries the merge commit, so the caller needs no second lookup. */
+   if (st >= 200 && st < 300 && resp && out_sha && out_sha_cap)
+   {
+      cJSON *jr = cJSON_Parse(resp);
+      const cJSON *sha = jr ? cJSON_GetObjectItem(jr, "sha") : NULL;
+      if (cJSON_IsString(sha) && sha->valuestring)
+         snprintf(out_sha, out_sha_cap, "%s", sha->valuestring);
+      cJSON_Delete(jr);
+   }
    int res;
    if (st >= 200 && st < 300)
       res = 0; /* merged */

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -234,4 +234,22 @@ int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number
 int git_pr_merge_via_api_slug(const char *principal, const char *slug, int number, char *err,
                               size_t errlen);
 
+/* The general merge: choose the method, optionally pin the head, and get the merge
+ * commit back. Same 0/1/2/3/-1 contract as above.
+ *
+ * merge_method is merge (the default when NULL/empty), squash or rebase; an
+ * unrecognised value is REFUSED, never coerced -- silently squashing would rewrite
+ * history the caller did not ask to rewrite. commit_message is emptied only for a
+ * squash, which is the only method that synthesizes a body.
+ *
+ * expected_head_sha, when given, becomes REST's `sha`: GitHub refuses the merge if
+ * the head moved since the caller looked. out_sha receives the merge commit from
+ * the 200 body, so no follow-up read is needed to record it.
+ *
+ * git_pr_merge_via_api{,_slug} keep their squash-with-empty-body behaviour and
+ * delegate here -- the workflow forge and webchat depend on that exact form. */
+int git_pr_merge_via_api_slug_ex(const char *principal, const char *slug, int number,
+                                 const char *merge_method, const char *expected_head_sha,
+                                 char *out_sha, size_t out_sha_cap, char *err, size_t errlen);
+
 #endif /* GIT_PR_API_H */

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -208,10 +208,13 @@ cJSON *handle_git_pr(cJSON *args)
             mflag = "--rebase";
       }
       char match[160] = {0};
+      char expected_head[72] = {0};
       cJSON *jhead = cJSON_GetObjectItemCaseSensitive(args, "expected_head_sha");
       if (cJSON_IsString(jhead) && jhead->valuestring[0])
       {
-         /* only allow a hex SHA to flow into the shell command. */
+         /* only allow a hex SHA to flow into the shell command. The same validation
+          * guards the API path: it goes into a JSON body rather than a command line,
+          * but a caller handing us a non-SHA is a caller bug either way. */
          const char *h = jhead->valuestring;
          int ok = 1;
          for (const char *p = h; *p; p++)
@@ -220,98 +223,119 @@ cJSON *handle_git_pr(cJSON *args)
                ok = 0;
                break;
             }
-         if (ok && h[0])
+         if (ok && h[0] && strlen(h) < sizeof(expected_head))
+         {
             snprintf(match, sizeof(match), " --match-head-commit %s", h);
+            snprintf(expected_head, sizeof(expected_head), "%s", h);
+         }
       }
 
-      /* CI must be fully green before the merge (operator ruling 2026-07-15). Still
-       * its own `gh pr checks` read, relying on that command's 0/1/8 tri-state exit
-       * code. action=checks NO LONGER shares this path -- it reads the Checks API
-       * in-process -- so the two are now independent and this one inherits the `gh`
-       * problem: `gh` in the aimee-server image has no credential, and mcp_git_run
-       * hands children the token on a memfd rather than as GH_TOKEN, so this gate
-       * only works from a DETACHED workspace where the client holds its own creds.
-       * Migrating it means replacing the exit-code verdict with git_pr_ci_permits_merge
-       * over git_pr_ci_via_api_slug, which is a change to a MERGE gate and wants its
-       * own review rather than riding along with the read migrations.
+      /* CI must be fully green before the merge (operator ruling 2026-07-15). Now read
+       * through the Checks API in-process, so the verdict comes from the vaulted token
+       * and the gate works from any workspace -- `gh` in the aimee-server image has no
+       * credential at all, which left this gate dead for a SHARED or CONTAINER
+       * session.
        *
-       * Fails CLOSED on anything it cannot positively classify. In particular the
-       * verdict is taken from gh's EXIT CODE, never inferred from parsed counters:
-       * a zero count means "no rows parsed", which is equally true of genuinely
-       * zero checks and of output we failed to understand (or a NULL from an alloc
-       * failure) — merging on that would be a fail-open. Only gh's own explicit
-       * "no checks reported" is accepted as genuinely zero, which the operator
-       * ruling says may merge (nothing to fail). */
+       * Still fails CLOSED, and the mapping preserves that exactly. Where the gh
+       * version read an exit code, this reads git_pr_ci_permits_merge:
+       *
+       *   gh exit 0  (all passed)          -> SUCCESS  merges
+       *   "no checks reported"             -> NONE     merges: nothing to fail
+       *   gh exit 8  (pending)             -> PENDING  refuses, unless auto_merge
+       *   gh exit 1  (a check failed)      -> FAILURE  refuses
+       *   anything unclassifiable         -> ERROR    refuses
+       *
+       * The last line is the important one: "unknown" is never "pass". The old comment
+       * warned against inferring a verdict from parsed counters because a zero count
+       * is equally "no rows" and "no checks"; git_pr_ci_via_api_slug removes that
+       * ambiguity by reporting NONE and ERROR as distinct values rather than both as
+       * an absence. */
+      char merge_slug[264];
+      if (get_origin_repo_slug(merge_slug, sizeof(merge_slug)) != 0)
+         return mcp_text("error: cannot resolve a github.com origin for this checkout");
+      const char *principal = agent_get_request_vault_principal();
+
       {
-         char ccmd[128];
-         snprintf(ccmd, sizeof(ccmd), "gh pr checks %d 2>&1", pr_num);
-         int crc = 0;
-         char *cout = mcp_git_run(ccmd, &crc);
+         char cerr[512];
+         cerr[0] = '\0';
+         git_pr_ci_t ci = git_pr_ci_via_api_slug(principal, merge_slug, pr_num, cerr, sizeof(cerr));
          const char *why = NULL;
-         if (!cout)
-            why = "could not read CI status (no output)";
-         else if (strstr(cout, "no checks reported"))
-            why = NULL; /* genuinely zero checks -> nothing to fail -> merge */
-         else if (crc == 0)
-            why = NULL; /* gh: every check passed */
-         else if (crc == 8 && auto_merge)
+         if (ci == GIT_PR_CI_PENDING && auto_merge)
             why = NULL; /* branch protection keeps an auto-merge pending until green */
-         else if (crc == 8)
-            why = "CI has not finished; re-try once checks settle";
-         else if (crc == 1)
-            why = "CI is not green (at least one check failed)";
-         else
-            why = "could not read CI status";
+         else if (!git_pr_ci_permits_merge(ci))
+            why = ci == GIT_PR_CI_PENDING   ? "CI has not finished; re-try once checks settle"
+                  : ci == GIT_PR_CI_FAILURE ? "CI is not green (at least one check failed)"
+                                            : "could not read CI status";
+         /* GIT_PR_CI_NONE permits: no CI reported has nothing to fail (operator
+          * ruling). GIT_PR_CI_ERROR does not -- "unknown" is never "pass", which is
+          * the same fail-closed rule the gh exit-code version enforced. */
          if (why)
          {
-            char msg[320];
+            char msg[512];
             snprintf(msg, sizeof(msg),
-                     "error: merge blocked — %s. A merge requires fully green CI.", why);
-            free(cout);
+                     "error: merge blocked — %s. A merge requires fully green CI.%s%s", why,
+                     cerr[0] ? " detail: " : "", cerr[0] ? cerr : "");
             return mcp_text(msg);
          }
-         free(cout);
       }
 
-      char cmd[512];
-      snprintf(cmd, sizeof(cmd), "gh pr merge %d %s%s%s 2>&1", pr_num, mflag, match,
-               auto_merge ? " --auto" : "");
-      int rc = 0;
-      char *out = mcp_git_run(cmd, &rc);
       cJSON *res = cJSON_CreateObject();
       cJSON_AddStringToObject(res, "executor", "git_pr");
-      cJSON_AddStringToObject(res, "command", cmd);
-      cJSON_AddNumberToObject(res, "exit_code", rc);
-      cJSON_AddStringToObject(res, "output", out ? out : "");
-      free(out);
-      if (rc == 0 && auto_merge)
+
+      if (auto_merge)
       {
-         /* Success means the request was accepted, not necessarily that GitHub merged
-          * it synchronously. Do not manufacture merge evidence for a queued PR. */
-         cJSON_AddBoolToObject(res, "auto_merge_enabled", 1);
+         /* Auto-merge stays on `gh` for now. Enabling it is a GraphQL mutation
+          * (enablePullRequestAutoMerge) and this module speaks only REST, so moving
+          * it means new transport rather than a swapped call. Keeping it here is not
+          * a regression -- it is how auto-merge already worked -- but it inherits the
+          * `gh` credential problem: no GH_TOKEN reaches the child (FD mode), so this
+          * branch only works from a DETACHED workspace where the client holds its own
+          * creds. Direct merges below no longer have that limitation. */
+         char cmd[512];
+         snprintf(cmd, sizeof(cmd), "gh pr merge %d %s%s --auto 2>&1", pr_num, mflag, match);
+         int rc = 0;
+         char *out = mcp_git_run(cmd, &rc);
+         cJSON_AddStringToObject(res, "command", cmd);
+         cJSON_AddNumberToObject(res, "exit_code", rc);
+         cJSON_AddStringToObject(res, "output", out ? out : "");
+         free(out);
+         /* Accepted is not merged. Do not manufacture merge evidence for a queued PR. */
+         cJSON_AddBoolToObject(res, "auto_merge_enabled", rc == 0 ? 1 : 0);
          cJSON_AddBoolToObject(res, "merged", 0);
-      }
-      else if (rc == 0)
-      {
-         /* recover the merge commit SHA for the ledger. */
-         char vcmd[128];
-         snprintf(vcmd, sizeof(vcmd), "gh pr view %d --json mergeCommit -q .mergeCommit.oid 2>&1",
-                  pr_num);
-         int vrc = 0;
-         char *vout = mcp_git_run(vcmd, &vrc);
-         if (vout)
-         {
-            char *nl = strchr(vout, '\n');
-            if (nl)
-               *nl = '\0';
-            cJSON_AddStringToObject(res, "merge_sha", vrc == 0 ? vout : "");
-            free(vout);
-         }
-         cJSON_AddBoolToObject(res, "merged", 1);
       }
       else
       {
-         cJSON_AddBoolToObject(res, "merged", 0);
+         const char *method = strcmp(mflag, "--squash") == 0   ? "squash"
+                              : strcmp(mflag, "--rebase") == 0 ? "rebase"
+                                                               : "merge";
+         char merge_sha[72];
+         char merr[512];
+         merge_sha[0] = '\0';
+         merr[0] = '\0';
+         int rc = git_pr_merge_via_api_slug_ex(principal, merge_slug, pr_num, method,
+                                               expected_head[0] ? expected_head : NULL, merge_sha,
+                                               sizeof(merge_sha), merr, sizeof(merr));
+
+         /* The ledger records the request that was made. There is no shell command
+          * now, so state the API call instead of leaving the field empty. */
+         char desc[256];
+         snprintf(desc, sizeof(desc), "PUT /repos/%s/pulls/%d/merge merge_method=%s%s%s",
+                  merge_slug, pr_num, method, expected_head[0] ? " sha=" : "",
+                  expected_head[0] ? expected_head : "");
+         cJSON_AddStringToObject(res, "command", desc);
+         cJSON_AddNumberToObject(res, "exit_code", rc);
+         cJSON_AddStringToObject(res, "output", merr);
+         cJSON_AddBoolToObject(res, "merged", rc == 0 || rc == 1);
+         if (rc == 0 || rc == 1)
+            cJSON_AddStringToObject(res, "merge_sha", merge_sha);
+         if (rc == 1)
+            cJSON_AddBoolToObject(res, "already_merged", 1);
+         /* 3 is a content conflict and identical on every retry; 2 is a lost race
+          * that a retry wins. Callers that loop must not treat them alike. */
+         if (rc == 3)
+            cJSON_AddBoolToObject(res, "conflict", 1);
+         else if (rc == 2)
+            cJSON_AddBoolToObject(res, "retryable", 1);
       }
       char *s = cJSON_PrintUnformatted(res);
       cJSON_Delete(res);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2816,7 +2816,7 @@ $(TESTPREFIX)/unit-test-trace-analysis: $(OBJDIR)/tests/test_trace_analysis.o $(
 $(TESTPREFIX)/unit-test-cmd-branch: $(OBJDIR)/tests/test_cmd_branch.o $(OBJDIR)/cmd_branch.o \
                            $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                            $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                           $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
+                           $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-core: $(OBJDIR)/tests/test_cmd_core.o $(TEST_DATA_OBJS) \
@@ -2825,14 +2825,14 @@ $(TESTPREFIX)/unit-test-cmd-core: $(OBJDIR)/tests/test_cmd_core.o $(TEST_DATA_OB
                          $(OBJDIR)/cmd_infra.o \
                          $(OBJDIR)/cmd_init.o \
                          $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                         $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
+                         $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-client-integrations: $(OBJDIR)/tests/test_client_integrations.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                        $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_verify.o $(OBJDIR)/modules/git/git_verify_state.o $(OBJDIR)/modules/git/git_verify_config.o \
+                        $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o $(OBJDIR)/modules/git/git_verify.o $(OBJDIR)/modules/git/git_verify_state.o $(OBJDIR)/modules/git/git_verify_config.o \
                         $(OBJDIR)/modules/git/git_verify_jobs.o $(OBJDIR)/modules/git/git_verify_hook.o $(OBJDIR)/modules/git/git_verify_ops.o \
                         $(OBJDIR)/modules/git/git_verify_select.o $(OBJDIR)/modules/git/git_verify_step.o $(OBJDIR)/server/compute_pool.o \
                         $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
@@ -3847,7 +3847,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
                             $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                             $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
+                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
@@ -3858,7 +3858,7 @@ $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
                             $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
                             $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
-                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o
+                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-diff: $(OBJDIR)/tests/test_diff.o $(OBJDIR)/diff.o $(OBJDIR)/dstr.o \

--- a/src/tests/support/git_pr_api_stub.c
+++ b/src/tests/support/git_pr_api_stub.c
@@ -4,6 +4,7 @@
  * client / TLS stack. The real object (server/git_pr_api.o) is linked by binaries
  * that need real behaviour and must NOT also link this TU. */
 #include "modules/git/git_pr_api.h"
+#include "tests/support/git_pr_api_stub.h"
 
 #include <stddef.h>
 #include <stdio.h>
@@ -44,6 +45,53 @@ int git_pr_edit_via_api_slug(const char *principal, const char *slug, int number
    if (err && errlen)
       snprintf(err, errlen, "pr api unavailable (stub)");
    return -1;
+}
+
+int git_pr_merge_via_api_slug_ex(const char *principal, const char *slug, int number,
+                                 const char *merge_method, const char *expected_head_sha,
+                                 char *out_sha, size_t out_sha_cap, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)number;
+   (void)merge_method;
+   (void)expected_head_sha;
+   if (out_sha && out_sha_cap)
+      out_sha[0] = '\0';
+   if (err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return -1;
+}
+
+/* The merge action's CI gate. Only the forge READ is stubbed: the ruling it feeds
+ * (git_pr_ci_permits_merge) is pure and is linked for real from git_pr_ci_grade.o,
+ * so these binaries assert against the real merge policy rather than a convenient
+ * one. A test names the verdict the forge would have returned and the gate then
+ * decides for itself.
+ *
+ * ERROR by default -- the honest verdict for "never asked the forge" -- so a gate
+ * that must fail closed proves it without any setup. */
+static git_pr_ci_t stub_ci_verdict = GIT_PR_CI_ERROR;
+
+void git_pr_api_stub_set_ci(git_pr_ci_t verdict)
+{
+   stub_ci_verdict = verdict;
+}
+
+git_pr_ci_t git_pr_ci_via_api_slug(const char *principal, const char *slug, int number, char *err,
+                                   size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)number;
+   /* Mirrors the real one: err is cleared up front and only carries a reason when
+    * the read itself failed, so a PENDING verdict does not arrive with a spurious
+    * detail string attached to it. */
+   if (err && errlen)
+      err[0] = '\0';
+   if (stub_ci_verdict == GIT_PR_CI_ERROR && err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return stub_ci_verdict;
 }
 
 int git_pr_checks_via_api_slug(const char *principal, const char *slug, int number, int max,

--- a/src/tests/support/git_pr_api_stub.h
+++ b/src/tests/support/git_pr_api_stub.h
@@ -1,0 +1,16 @@
+/* git_pr_api_stub.h: control surface for the test PR-API stub.
+ * See git_pr_api_stub.c. */
+#ifndef AIMEE_TEST_GIT_PR_API_STUB_H
+#define AIMEE_TEST_GIT_PR_API_STUB_H
+
+#include "modules/git/git_pr_api.h"
+
+/* The verdict git_pr_ci_via_api_slug() hands the merge gate. The forge read is the
+ * only part of the gate that is stubbed -- the ruling over this value is linked for
+ * real from git_pr_ci_grade.o -- so setting it drives the gate through real policy.
+ *
+ * Defaults to GIT_PR_CI_ERROR, so a test that never calls this proves the gate
+ * fails closed on an unreadable forge without any setup. */
+void git_pr_api_stub_set_ci(git_pr_ci_t verdict);
+
+#endif /* AIMEE_TEST_GIT_PR_API_STUB_H */

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -12,6 +12,7 @@
 #include "session_worktree_key.h"
 #include "modules/workspace/workspace_provider.h"
 #include "modules/git/git_verify.h"
+#include "tests/support/git_pr_api_stub.h"
 #include "cJSON.h"
 #include "db_schema.h"
 #include "../db1/db1.h"
@@ -876,8 +877,10 @@ static void test_git_pr_auto_merge_accepts_pending_checks_without_claiming_merge
    snprintf(gh_path, sizeof(gh_path), "%s/gh", tmpdir);
    FILE *fp = fopen(gh_path, "w");
    assert(fp != NULL);
+   /* Only `gh pr merge --auto` is faked now. The CI gate no longer shells out --
+    * it reads the Checks API in-process -- so a faked `gh pr checks` would never
+    * be consulted; the verdict comes from the stub below instead. */
    fputs("#!/bin/sh\n"
-         "if [ \"$1\" = pr ] && [ \"$2\" = checks ]; then exit 8; fi\n"
          "if [ \"$1\" = pr ] && [ \"$2\" = merge ]; then exit 0; fi\n"
          "exit 2\n",
          fp);
@@ -893,6 +896,11 @@ static void test_git_pr_auto_merge_accepts_pending_checks_without_claiming_merge
             old_path ? old_path : "");
    assert(setenv("PATH", new_path, 1) == 0);
 
+   /* Pending CI is the whole point of auto-merge: branch protection holds the PR
+    * until green, so the gate must NOT refuse it here. Without this exemption an
+    * auto-merge into a protected branch would refuse itself. */
+   git_pr_api_stub_set_ci(GIT_PR_CI_PENDING);
+
    cJSON *args = cJSON_CreateObject();
    cJSON_AddStringToObject(args, "action", "merge");
    cJSON_AddNumberToObject(args, "number", 123);
@@ -905,6 +913,36 @@ static void test_git_pr_auto_merge_accepts_pending_checks_without_claiming_merge
    assert(strstr(text, "\"merged\":false") != NULL);
    cJSON_Delete(resp);
    cJSON_Delete(args);
+
+   /* The exemption is for PENDING alone. An unreadable forge is not "pending", and
+    * "unknown" is never "pass" -- auto or not, that must still refuse. */
+   git_pr_api_stub_set_ci(GIT_PR_CI_ERROR);
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "merge");
+   cJSON_AddNumberToObject(args, "number", 123);
+   cJSON_AddBoolToObject(args, "auto", 1);
+   resp = handle_git_pr(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "merge blocked") != NULL);
+   assert(strstr(text, "--auto") == NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   /* A failed check refuses even with auto, for the same reason. */
+   git_pr_api_stub_set_ci(GIT_PR_CI_FAILURE);
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "merge");
+   cJSON_AddNumberToObject(args, "number", 123);
+   cJSON_AddBoolToObject(args, "auto", 1);
+   resp = handle_git_pr(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "merge blocked") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   git_pr_api_stub_set_ci(GIT_PR_CI_ERROR); /* leave the fail-closed default in place */
 
    if (saved_path[0])
       assert(setenv("PATH", saved_path, 1) == 0);


### PR DESCRIPTION
The last `gh`-backed path, minus auto-merge. Completes the series after #2393/#2395/#2397/#2399/#2400.

## Why

The CI gate and the merge itself both shelled out to `gh`, which in the aimee-server image has **no credential** — `mcp_git_run` hands children the token on a memfd, not as `GH_TOKEN`. So merges were dead for SHARED/CONTAINER workspaces entirely.

There's a second, sharper reason. **The shim PAT cannot merge at all:**

```
PUT /repos/RakuenSoftware/aimee/pulls/2404/merge
→ 403 Resource not accessible by personal access token
```

…while the same PAT creates and edits PRs fine. The vaulted token, by contrast, demonstrably has `contents: write` — every push this session went over an **HTTPS** origin with no client credential helper, no `~/.git-credentials`, and no `GIT_ASKPASS`. So the merge path was using the one credential that can't merge while the vault held one that can.

## Parity, not just "a merge that works"

Three things the obvious migration would have broken:

| Option | Trap | Handled |
|---|---|---|
| `merge_method` | `git_pr_merge_via_api` **hardcodes squash**; the action defaults to `merge` and offers `rebase` | new entry point takes the method and **refuses** an unrecognised value rather than coercing |
| `expected_head_sha` | gh's `--match-head-commit` | maps to REST's `sha`, same hex-only validation |
| `auto` | GitHub auto-merge is a **GraphQL** mutation; this module is REST-only | **stays on `gh`** — unchanged, so no regression, but it keeps the credential limitation |

Routing everything through the existing helper would have silently squashed every merge. That's the kind of quiet history rewrite that's hard to notice and impossible to undo.

`git_pr_merge_via_api{,_slug}` keep their exact squash-with-empty-body behaviour and delegate to the new function — `wfe_live_forge.c` and `server_http_routes_git.c` depend on that form. `commit_message` is still emptied for squash only, since squash is the only method that synthesizes a body.

## The gate maps one-to-one, and still fails closed

```
gh exit 0 (all passed)      -> SUCCESS  merges
"no checks reported"        -> NONE     merges — nothing to fail
gh exit 8 (pending)         -> PENDING  refuses, unless auto_merge
gh exit 1 (check failed)    -> FAILURE  refuses
anything unclassifiable     -> ERROR    refuses
```

The auto+pending exemption is preserved — without it, auto-merge into a protected branch would refuse itself.

The old comment warned against inferring a verdict from parsed counters, because a zero count is equally "no rows parsed" and "no checks exist". The API path removes that ambiguity **structurally**: `NONE` and `ERROR` are distinct values rather than both an absence.

## Ledger

Every field kept. `merge_sha` now comes from the merge response itself, so the follow-up `gh pr view --json mergeCommit` read is gone. Return codes 2 and 3 surface as `retryable` and `conflict` instead of collapsing — a content conflict reproduces on every retry, a moved head doesn't, and a looping caller must not treat them alike.

## Verification, and what I can't verify

Clean: `-Wall -Wextra`, clang-format, pins resynced, stub extended.

**A merge cannot be dry-run**, so this is the one change in the series I can't prove before deploy. What I can say: the credential reasoning is evidence-based (403 for the PAT, `contents: write` demonstrated for the vault token), and after deploy the 403-vs-405 probe against a *conflicting* PR settles it safely — `403` means no permission, `405` means permission but unmergeable, and it cannot succeed by construction.

Deliberately **not** added: a client-side guard refusing `main`. GitHub's branch protection already enforces that, and a second policy point would be free to drift from the first.
