### PR TITLE
fix: a delegate asked to write code gets a filesystem

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -77,7 +77,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "23cefc02f3c592495e8e142a3078d7cf0d36475806b9f12e7ab3730d003b5357"
+      "source_sha256": "803f69e31915b0eb50fa3571de0a65f7d5312a0c5b4227b2921c95f3d7db7d12"
     },
     {
       "id": "gateway",
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "711a7e82f900e1a61c7bc72acc87a4c89770b603227e12af08412a1954a524bf",
+      "source_sha256": "4f2f2eaea1576a2820abbd872961fa4a2beda0c012cef8c71daab27630e5377f",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/src/modules/delegates/delegate_role.c
+++ b/src/modules/delegates/delegate_role.c
@@ -127,9 +127,13 @@ int delegate_role_enable_tools_by_default(const char *role)
       return 0;
 
    role = delegate_role_canonicalize(role);
-   return strcmp(role, "review") == 0 || strcmp(role, "search") == 0 ||
-          strcmp(role, "execute") == 0 || strcmp(role, "diagnose") == 0 ||
-          strcmp(role, "validate") == 0 ||
+   /* A write role cannot do its job without a filesystem, and left tools-off it
+    * cannot fail visibly either: asked to implement, an agent with no file tools
+    * returns a per-file diff summary of code it never wrote. Tools-on is the
+    * only honest default here; an explicit --no-tools still overrides it. */
+   return delegate_role_is_write(role) || strcmp(role, "review") == 0 ||
+          strcmp(role, "search") == 0 || strcmp(role, "execute") == 0 ||
+          strcmp(role, "diagnose") == 0 || strcmp(role, "validate") == 0 ||
           /* Novel-mode read-only checks inspect the world bible by default. */
           strcmp(role, "continuity") == 0 || strcmp(role, "beat-check") == 0;
 }

--- a/src/modules/protocols/mcp/mcp_tools.c
+++ b/src/modules/protocols/mcp/mcp_tools.c
@@ -657,8 +657,9 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
               "delegate",
               "Delegate a task to an aimee delegate agent instead of provider-native "
               "sub-agent tools (spawn_agent/Agent). Always async: returns a job_id; "
-              "poll delegate_status for the result. Has SSH to homelab hosts and full tool "
-              "execution. If already a sub-agent, return findings.",
+              "poll delegate_status for the result. Write and inspection roles run with full "
+              "tool execution, including SSH to homelab hosts; see `tools`. If already a "
+              "sub-agent, return findings.",
               cJSON_Parse(
                   "{\"type\":\"object\",\"properties\":{"
                   "\"role\":{\"type\":\"string\",\"description\":\"Delegation role (e.g. code, "
@@ -670,7 +671,11 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
                   "qa, security, reviewer, architect, or custom); sets the delegate's identity "
                   "and principles.\"},"
                   "\"cwd\":{\"type\":\"string\",\"description\":\"Optional cwd to anchor delegate "
-                  "worktree isolation; defaults to the active MCP session worktree.\"}},"
+                  "worktree isolation; defaults to the active MCP session worktree.\"},"
+                  "\"tools\":{\"type\":\"boolean\",\"description\":\"Give the delegate file and "
+                  "shell tools. Write and inspection roles enable these on their own; pass true "
+                  "to add them to a role that would otherwise run text-only, or false to force a "
+                  "text-only run.\"}},"
                   "\"required\":[\"role\",\"prompt\",\"persona\"]}")));
    }
    /* delegate_status */

--- a/src/server/server_mcp_delegate.c
+++ b/src/server/server_mcp_delegate.c
@@ -43,6 +43,7 @@ int handle_mcp_delegate_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *args
    cJSON *jb = cJSON_GetObjectItemCaseSensitive(args, "branch");
    cJSON *jdcwd = cJSON_GetObjectItemCaseSensitive(args, "cwd");
    cJSON *jpersona = cJSON_GetObjectItemCaseSensitive(args, "persona");
+   cJSON *jtools = cJSON_GetObjectItemCaseSensitive(args, "tools");
    /* A persona is required for every delegate (it sets the delegate's identity
     * and principles). */
    if (!cJSON_IsString(jpersona) || !jpersona->valuestring[0])
@@ -61,6 +62,10 @@ int handle_mcp_delegate_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *args
       cJSON_AddStringToObject(dreq, "branch", jb->valuestring);
    if (cJSON_IsString(jpersona) && jpersona->valuestring[0])
       cJSON_AddStringToObject(dreq, "persona", jpersona->valuestring);
+   /* Only a stated boolean is forwarded: absent must stay absent so the role's
+    * own tools default decides, exactly as it does for the CLI. */
+   if (cJSON_IsBool(jtools))
+      cJSON_AddBoolToObject(dreq, "tools", cJSON_IsTrue(jtools));
    if (sid && sid[0])
       cJSON_AddStringToObject(dreq, "session_id", sid);
    if (cJSON_IsString(jdcwd) && jdcwd->valuestring[0])

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -589,6 +589,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-ingest-worker-cap \
                $(TESTPREFIX)/unit-test-kb-dense-vector-scope \
                $(TESTPREFIX)/unit-test-mcp-roundtable-contract \
+               $(TESTPREFIX)/unit-test-mcp-delegate-contract \
                $(TESTPREFIX)/unit-test-workspace-prune-dead \
                $(TESTPREFIX)/unit-test-workspace-add-idempotent \
                $(TESTPREFIX)/unit-test-kb-doc-pdf \
@@ -6302,6 +6303,11 @@ $(TESTPREFIX)/unit-test-p3b-spend: $(OBJDIR)/tests/test_p3b_spend.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-mcp-roundtable-contract: $(OBJDIR)/tests/test_mcp_roundtable_contract.o \
+                                     $(OBJDIR)/modules/protocols/mcp/mcp_tools.o \
+                                     $(OBJDIR)/cJSON.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-mcp-delegate-contract: $(OBJDIR)/tests/test_mcp_delegate_contract.o \
                                      $(OBJDIR)/modules/protocols/mcp/mcp_tools.o \
                                      $(OBJDIR)/cJSON.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -356,7 +356,13 @@ static void test_role_default_tools(void)
    assert(delegate_role_enable_tools_by_default("test") == 1);
    assert(delegate_role_enable_tools_by_default("check") == 1);
    assert(delegate_role_enable_tools_by_default("research") == 1);
-   assert(delegate_role_enable_tools_by_default("code") == 0);
+   /* Write roles need a filesystem to do the job at all. This asserted 0 until a
+    * `code` delegate with no file tools answered with a per-file diff summary of
+    * code it never wrote -- see test_delegate_role.c. */
+   assert(delegate_role_enable_tools_by_default("code") == 1);
+   assert(delegate_role_enable_tools_by_default("refactor") == 1);
+   /* Prose generation is not a write role. */
+   assert(delegate_role_enable_tools_by_default("draft") == 0);
    assert(delegate_role_enable_tools_by_default(NULL) == 0);
    assert(delegate_role_enable_tools_by_default("") == 0);
    printf("  PASS: test_role_default_tools\n");

--- a/src/tests/test_delegate_role.c
+++ b/src/tests/test_delegate_role.c
@@ -371,6 +371,37 @@ static void test_auto_tools_policy(void)
    printf("  PASS: test_auto_tools_policy\n");
 }
 
+/* A write role left tools-off cannot fail visibly. Measured: a `code` packet
+ * delegated over MCP -- which had no way to ask for tools -- came back with a
+ * per-file diff summary naming files that were never created, and the caller
+ * had to disprove it by searching the disk. `review` enabled tools by default
+ * and `code` did not, so delegation worked for inspection and fabricated for
+ * implementation: the failure distribution that builds trust before it lies. */
+static void test_write_roles_get_tools_by_default(void)
+{
+   assert(delegate_role_enable_tools_by_default("code") == 1);
+   assert(delegate_role_enable_tools_by_default("refactor") == 1);
+   /* Through the aliases a caller actually types. */
+   assert(delegate_role_auto_tools_for_invocation("implement", -1, 0) == 1);
+   assert(delegate_role_auto_tools_for_invocation("build", -1, 0) == 1);
+
+   /* Every write role, whatever the alias table holds, by the same rule. */
+   static const char *const write_roles[] = {"code", "refactor", "implement", "build"};
+   for (size_t i = 0; i < sizeof(write_roles) / sizeof(write_roles[0]); i++)
+   {
+      assert(delegate_role_is_write(write_roles[i]) == 1);
+      assert(delegate_role_auto_tools_for_invocation(write_roles[i], -1, 0) == 1);
+   }
+
+   /* The two overrides still win: a single turn cannot use tools, and an
+    * explicit --no-tools is honored (server side) as a deliberate choice. */
+   assert(delegate_role_auto_tools_for_invocation("code", 1, 0) == 0);
+
+   /* Prose generation is not a write role and stays text-only. */
+   assert(delegate_role_enable_tools_by_default("draft") == 0);
+   printf("  PASS: test_write_roles_get_tools_by_default\n");
+}
+
 int main(void)
 {
    printf("test_delegate_role\n");
@@ -399,6 +430,7 @@ int main(void)
    test_apply_max_turns_policy();
    test_apply_max_turns_cap();
    test_auto_tools_policy();
+   test_write_roles_get_tools_by_default();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -509,7 +509,7 @@ static void test_osv_offline_cache_miss_allows(void)
    "call_tool {arguments,name} req:arguments,name\n"                                               \
    "clarify {answer,command,description,session_id} req:command\n"                                 \
    "dashboard_metrics {} req:\n"                                                                   \
-   "delegate {branch,cwd,persona,prompt,role} req:persona,prompt,role\n"                           \
+   "delegate {branch,cwd,persona,prompt,role,tools} req:persona,prompt,role\n"                     \
    "delegate_reply {content,delegation_id} req:content,delegation_id\n"                            \
    "delegate_status {job_id} req:job_id\n"                                                         \
    "describe_tool {name} req:name\n"                                                               \

--- a/src/tests/test_mcp_delegate_contract.c
+++ b/src/tests/test_mcp_delegate_contract.c
@@ -1,0 +1,97 @@
+/* The delegate tool must let its caller ask for tools.
+ *
+ * `mcp__aimee__delegate` advertised exactly {role, prompt, branch, cwd, persona}
+ * -- no way to say "this one needs a filesystem" -- while the CLI had `--tools`
+ * all along. Tools were then granted by role, and `code` was not on the list.
+ *
+ * Measured: a `code` packet delegated over MCP returned a per-file diff summary
+ * for files that were never written. With no file tools and no way to request
+ * them, narrating the work is the only thing the agent can still do, and the
+ * result reads exactly like success. The caller found out by searching the disk
+ * for a filename the report claimed to have created.
+ *
+ * Two halves fix it and both must hold: the role default (see
+ * test_delegate_role.c) and this -- the parameter reaching the model at all. A
+ * server that honors `tools` while the schema hides it is the same bug wearing
+ * a fix.
+ *
+ * The other tool families drag in most of the server; stub them so this links
+ * against the schema alone, following test_mcp_roundtable_contract.c. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "cJSON.h"
+
+#include "aimee/protocols/mcp/mcp_tools.h"
+
+void mcp_add_discovery_tools(cJSON *tools)
+{
+   (void)tools;
+}
+void mcp_add_extended_tools(cJSON *tools)
+{
+   (void)tools;
+}
+void mcp_add_skill_tools(cJSON *tools)
+{
+   (void)tools;
+}
+void mcp_add_gateway_tools(cJSON *tools)
+{
+   (void)tools;
+}
+cJSON *session_search_mcp_tool(void)
+{
+   return NULL;
+}
+cJSON *mcp_client_registry_build_namespaced_tools(int timeout_ms)
+{
+   (void)timeout_ms;
+   return NULL;
+}
+
+static cJSON *schema_for(const char *tool_name)
+{
+   cJSON *tools = mcp_build_tools_list_flat();
+   assert(tools != NULL);
+   cJSON *tool = NULL;
+   cJSON_ArrayForEach(tool, tools)
+   {
+      const cJSON *name = cJSON_GetObjectItemCaseSensitive(tool, "name");
+      if (cJSON_IsString(name) && strcmp(name->valuestring, tool_name) == 0)
+         return cJSON_GetObjectItemCaseSensitive(tool, "inputSchema");
+   }
+   return NULL;
+}
+
+int main(void)
+{
+   printf("mcp_delegate_contract: ");
+   cJSON *schema = schema_for("delegate");
+   assert(schema != NULL);
+
+   const cJSON *props = cJSON_GetObjectItemCaseSensitive(schema, "properties");
+   assert(props != NULL);
+
+   /* The parameter the CLI has always had. */
+   const cJSON *tools = cJSON_GetObjectItemCaseSensitive(props, "tools");
+   assert(tools != NULL);
+
+   /* Typed, so a caller passing `false` is understood as a deliberate
+    * text-only run rather than dropped as an unparseable value. */
+   const cJSON *type = cJSON_GetObjectItemCaseSensitive(tools, "type");
+   assert(cJSON_IsString(type) && strcmp(type->valuestring, "boolean") == 0);
+
+   /* Optional: omitting it must leave the role's own default in charge, which
+    * is what makes a `code` delegate work without the caller knowing to ask. */
+   const cJSON *req = cJSON_GetObjectItemCaseSensitive(schema, "required");
+   const cJSON *item = NULL;
+   cJSON_ArrayForEach(item, req)
+   {
+      assert(!(cJSON_IsString(item) && strcmp(item->valuestring, "tools") == 0));
+   }
+
+   printf("ok\n");
+   return 0;
+}


### PR DESCRIPTION
A `code` packet delegated over MCP came back with a per-file diff summary — which files changed, what each change did. **None of those files existed.** The caller found out by searching the disk for a filename the report claimed to have created, then discarded the whole report.

The agent had no file tools, and no way to get them.

| | |
|---|---|
| `mcp__aimee__delegate` schema | `{role, prompt, branch, cwd, persona}` — **no `tools`** |
| `aimee delegate code --tools` (CLI) | has had it all along |
| Roles enabling tools by default | `review, search, execute, diagnose, validate, continuity, beat-check` |
| `code`, `refactor` | **not on that list** |

So the one role that exists to write files was the one role that could not, and asking was not an option either. With no tools and no way to fail, an agent handed an implementation packet does the only thing left: it narrates the implementation. That reads exactly like success.

`review` *did* enable tools by default. MCP delegation therefore worked for inspection and fabricated for implementation — the failure distribution that builds trust before it lies.

## The fix

Two halves, both required. Either alone leaves the bug reachable.

- **Write roles enable tools by default**, expressed through the existing `delegate_role_is_write()` so the rule stays one rule rather than a second list to drift. An explicit `--no-tools` still overrides it; a single-turn run is still tools-off.
- **The MCP schema takes `tools`, and the server forwards it.** Only a stated boolean is forwarded, so omitting it leaves the role default in charge — the same contract the CLI has. A server that honors `tools` while the schema hides it would be the same bug wearing a fix.

The tool description said *"full tool execution"*. That was true for review roles and false for the role it mattered most for; it now names which roles.

## Verification

- **Red before green.** With the three source files reverted and the tests kept, `unit-test-delegate-role` aborts on `delegate_role_enable_tools_by_default("code") == 1` and `unit-test-mcp-delegate-contract` aborts on the missing `tools` property. Both pass with the fix.
- Full `make unit-tests`: **All tests passed.**
- Gates: module-bus-boundary, refactor-baselines, module-test-registration, module-source-ownership, module-header-layout all clean. `clang-format-19` clean.
- `check_c_repository_lock` reports `protocols: vendored mirror differs from its repository pin` — **pre-existing**, reproduced on this branch with my `mcp_tools.c` edit stashed. Not introduced here; belongs to the periodic pin resync.

`test_cmd_delegate` asserted `code == 0`. That assertion arrived in a bulk snapshot commit with no stated rationale — it recorded the list rather than arguing for it. Updated, with the reason written down this time.

## Not fixed here

A second, independent defect from the same report: against a **remote** aimee-server, delegates land on another host in an empty sandbox workspace (`/var/lib/aimee/delegate-ws/deleg-…`) and cannot see the caller's repo at all. That one fails *honestly* — the delegate said the workspace was empty — so it is the less dangerous of the two and is left for its own change.

**Roundtable review: not run.** `aimee roundtable review` still answers `roundtable review module is not attached to the event bus` on this host, so the review this repo's workflow requires could not be performed. Flagging rather than implying it passed.
