### PR TITLE
fix(vault): gate the shared store on attestation, and make storing a credential possible

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -283,7 +283,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "3d495b2745248b255ce1c416b4bf2062f0246e2ffabf1d691cc346236c90c756"
+      "source_sha256": "a5443825a19a5c1c1a2994cf4ddf76640362f72c6b5c999d830a0e791f1aa7c5"
     },
     {
       "id": "execution-policy",

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -283,7 +283,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "964f773c058c7e14c0f72459aa196703b7aa0d86854de1b9ee07f603e07e515a"
+      "source_sha256": "3d495b2745248b255ce1c416b4bf2062f0246e2ffabf1d691cc346236c90c756"
     },
     {
       "id": "execution-policy",

--- a/src/modules/vault/vault_capability.c
+++ b/src/modules/vault/vault_capability.c
@@ -246,8 +246,42 @@ int vault_capability_server_write_allowed(attested_transport_t transport, const 
     * contrast, must hold an explicitly granted vault:write:server capability. */
    if (transport == ATTEST_TLS_BEARER)
       return 1;
-   int attested = (transport == ATTEST_UDS_PEERCRED || transport == ATTEST_WEBCHAT_TRUSTED);
+
+   /* A verified mTLS client is ATTESTED -- its cert chain verifies against aimee's
+    * client CA and yields a real cert:<CN> principal -- but attestation is not
+    * authority. It was previously absent from BOTH sets, so on an mTLS-REQUIRED
+    * server (where vault_principal_resolve's mTLS branch wins first, and no remote
+    * conn is ever TLS_BEARER) the server-principal path was unreachable by
+    * construction: no grant could open it, because the store was never consulted.
+    *
+    * It belongs with UDS/webchat rather than with the bearer above. Possessing an
+    * enrolled client cert is the ordinary state of every thin client; it is what
+    * gets you ONTO /v1, not what should get you into the credential store. Holding
+    * cert:<CN> makes the grant expressible per client, which a bearer -- carrying no
+    * principal at all -- cannot be.
+    *
+    * ATTEST_TCP_BEARER remains refused: D2b, a server credential is never minted
+    * over an unencrypted channel. */
+   int attested = (transport == ATTEST_UDS_PEERCRED || transport == ATTEST_WEBCHAT_TRUSTED ||
+                   transport == ATTEST_MTLS_CLIENT);
    return attested && vault_capability_has(principal);
+}
+
+int vault_capability_server_read_allowed(attested_transport_t transport, const char *principal)
+{
+   /* Host-local authority enumerates without a grant. The browser GUI lists
+    * credentials on an ordinary page load over the root-owned webchat hop; gating
+    * that on a per-user capability -- mintable only over UDS -- would make an
+    * operator shell into the host once per webuser before the page renders. That
+    * cost buys nothing: the webchat hop is already kernel-attested, and a local UDS
+    * peer could read the store directly regardless. */
+   if (transport == ATTEST_UDS_PEERCRED || transport == ATTEST_WEBCHAT_TRUSTED ||
+       transport == ATTEST_TLS_BEARER)
+      return 1;
+   /* A client cert is a NETWORK credential handed to arbitrary remote machines, so
+    * it enumerates only with an explicit grant -- the same one the write gate wants.
+    * Everything else (plaintext bearer, un-attested) is refused. */
+   return transport == ATTEST_MTLS_CLIENT && vault_capability_has(principal);
 }
 
 int vault_agent_key_server_seal_allowed(attested_transport_t transport)

--- a/src/modules/vault/vault_capability.h
+++ b/src/modules/vault/vault_capability.h
@@ -46,6 +46,24 @@ extern "C"
     * holds vault:write:server. The single source of truth for the gate. */
    int vault_capability_server_write_allowed(attested_transport_t transport, const char *principal);
 
+   /* May this connection ENUMERATE the shared store's credential names (never
+    * values)? Narrower than the write gate in what it protects and wider in who it
+    * admits, deliberately:
+    *
+    * A local UDS peer, the root-owned webchat hop, and the operator's own native-TLS
+    * bearer are all HOST-LOCAL authority — the browser GUI lists credentials on an
+    * ordinary page load, and making that wait on a per-user grant minted only over
+    * UDS would mean an operator shelling into the host for every webuser before the
+    * page renders at all.
+    *
+    * ATTEST_MTLS_CLIENT is the exception and still needs vault:write:server. A
+    * client cert is a NETWORK credential issued to arbitrary remote machines; that
+    * is the population enumeration must not be open to by default. Possessing one is
+    * what reaches /v1, not what opens the credential store.
+    *
+    * ATTEST_TCP_BEARER and un-attested are refused (D2b), as everywhere here. */
+   int vault_capability_server_read_allowed(attested_transport_t transport, const char *principal);
+
    /* May a connection with this attested transport seal an agent's OWN api key into
     * the shared server vault (`agent add`/`agent set --key`)? A delegate defined in
     * agents.json is SHARED server config whose key resolves from the server vault at

--- a/src/modules/vault/vault_principal.c
+++ b/src/modules/vault/vault_principal.c
@@ -103,11 +103,26 @@ attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_u
 
    if (!is_tcp)
    {
-      /* Local UDS peer. A kernel-attested uid > 0 owns a uid: vault. uid 0
-       * (root) and an unknown uid (-1) get NO principal: an un-attested or
-       * zeroed conn reads as uid 0, so granting it would collapse to acting as
-       * root on a missed hop. Fail-closed -> empty principal, vault refuses. */
-      if (peer_uid > 0)
+      /* Local UDS peer: a kernel-attested uid owns the matching uid: vault.
+       *
+       * uid 0 is included. It was excluded to stop a "missed hop" from acting as
+       * root, but the sentinel for a missed hop is -1, not 0: the caller
+       * (server_http_identity_capture) initialises peer_uid to -1 and overwrites it
+       * ONLY when platform_ipc_peer_cred succeeds, so 0 here means the kernel said
+       * root. A zeroed server_conn_t is caught by a different guard -- ATTEST_NONE
+       * is the enum's zero value, so such a conn never classifies as
+       * UDS_PEERCRED at all.
+       *
+       * Excluding it did not make root safe, only mute: the local root operator
+       * owns .vault/.server-master.key on disk and can decrypt the store offline
+       * regardless. What it actually did was leave `aimee vault set-server` refusing
+       * every root caller -- the ordinary case inside the server container -- while
+       * naming principal "(unknown)" in the remediation, telling the operator to run
+       * `aimee vault capability grant (unknown)`. Unusable advice for an
+       * unreachable path.
+       *
+       * An unknown uid (-1) still gets NO principal and still fails closed. */
+      if (peer_uid >= 0)
          snprintf(out, out_len, "uid:%ld", peer_uid);
       return ATTEST_UDS_PEERCRED;
    }

--- a/src/server/server_cert.c
+++ b/src/server/server_cert.c
@@ -8,10 +8,50 @@
 #include "pki.h"
 #include "server_http.h"
 #include "server_http_identity.h"
-#include "vault_principal.h" /* attested_transport_t */
+#include "vault_principal.h"  /* attested_transport_t, cert:<CN> principal form */
+#include "vault_capability.h" /* the grant issued with the cert and revoked with it */
 #include "cJSON.h"
 #include <openssl/crypto.h> /* OPENSSL_cleanse */
 #include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+/* The vault principal a connection presenting this CN will resolve to, built the
+ * same way vault_principal_resolve builds it so the grant and the request agree.
+ * Returns 0 when the CN cannot sanitize: no principal will ever be formed for it,
+ * so there is nothing to grant and nothing to revoke. */
+static int cert_vault_principal(const char *cn, char *out, size_t out_len)
+{
+   char san[VAULT_CERT_CN_MAX + 1];
+   if (out && out_len)
+      out[0] = '\0';
+   if (!cn || !vault_principal_name_sanitize(cn, san, sizeof(san)) || !out ||
+       out_len < VAULT_PRINCIPAL_MAX)
+      return 0;
+   snprintf(out, out_len, VAULT_CERT_PRINCIPAL_PREFIX "%s", san);
+   return 1;
+}
+
+/* Find the CN a serial was issued to. Revocation names only the serial, but the
+ * vault grant is keyed by cert:<CN>, so the roster is the only bridge between
+ * them. */
+typedef struct
+{
+   const char *serial;
+   char cn[VAULT_CERT_CN_MAX + 1];
+} cert_cn_lookup_t;
+
+static void cert_cn_lookup_cb(void *ctx, const char *serial, const char *cn, long issued_at,
+                              long expires_at, int revoked)
+{
+   cert_cn_lookup_t *lk = (cert_cn_lookup_t *)ctx;
+   (void)issued_at;
+   (void)expires_at;
+   (void)revoked;
+   if (!lk || lk->cn[0] || !serial || !cn || strcmp(serial, lk->serial) != 0)
+      return;
+   snprintf(lk->cn, sizeof(lk->cn), "%s", cn);
+}
 
 /* Cert issuance/revocation is an operator action: only a kernel-attested local
  * peer (UDS) or a confidential native-TLS+bearer connection may perform it. A
@@ -52,6 +92,20 @@ int handle_cert_issue(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                  sizeof(serial)) != 0)
       return server_send_error(
           conn, "cert: issuance failed (invalid/unsanitizable CN, or CA unavailable)", NULL);
+
+   /* Same grant as the CSR path below: this cert is just as much an enrolled
+    * client, and leaving it out would mean an operator-issued client still needed
+    * a second, manual `vault capability grant` — the exact step this removes.
+    * Revoke on failure so a cert never exists without its grant. */
+   char vprincipal[VAULT_PRINCIPAL_MAX];
+   if (cert_vault_principal(jcn->valuestring, vprincipal, sizeof(vprincipal)) &&
+       vault_capability_grant(vprincipal) != 0)
+   {
+      OPENSSL_cleanse(key, sizeof(key));
+      (void)pki_revoke(serial);
+      return server_send_error(conn, "cert: could not record the vault grant for this client",
+                               NULL);
+   }
 
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
@@ -108,6 +162,29 @@ int handle_cert_sign(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                                            : "cert: could not persist the first-user write grant",
                                NULL);
    }
+   /* Enrolling IS the authorization. `aimee remote enroll` is the one command a
+    * user runs to attach a machine, and it lands here; making the vault grant a
+    * second, separate step would mean every operator shelling into the host over
+    * UDS before that machine could use a credential at all — and doing it again
+    * for the next machine. Mint it here, with the cert, so enrollment is the only
+    * thing anyone performs.
+    *
+    * This is not a widening of who may enroll: cert_op_allowed already restricts
+    * signing to an attested operator channel, so the authority to reach this line
+    * is strictly greater than the grant it confers.
+    *
+    * Fail the whole issuance if the grant cannot be recorded, revoking the cert as
+    * the bind failure above does. A cert that exists without its grant is exactly
+    * the silent half-provisioned state this change is meant to abolish. */
+   char vprincipal[VAULT_PRINCIPAL_MAX];
+   if (cert_vault_principal(jcn->valuestring, vprincipal, sizeof(vprincipal)) &&
+       vault_capability_grant(vprincipal) != 0)
+   {
+      (void)pki_revoke(serial);
+      return server_send_error(conn, "cert: could not record the vault grant for this client",
+                               NULL);
+   }
+
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
       return server_send_error(conn, "cert: out of memory", NULL);
@@ -128,8 +205,25 @@ int handle_cert_revoke(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    cJSON *js = cJSON_GetObjectItemCaseSensitive(req, "serial");
    if (!cJSON_IsString(js) || !js->valuestring[0])
       return server_send_error(conn, "cert: 'serial' is required", NULL);
+   /* Resolve the CN BEFORE revoking: the grant is keyed by cert:<CN> while
+    * revocation names only the serial, and the roster is the sole bridge. */
+   cert_cn_lookup_t lk;
+   memset(&lk, 0, sizeof(lk));
+   lk.serial = js->valuestring;
+   (void)pki_list(cert_cn_lookup_cb, &lk);
+
    if (pki_revoke(js->valuestring) != 0)
       return server_send_error(conn, "cert: revocation failed", NULL);
+
+   /* The cert and its vault grant are issued together, so they must die together.
+    * Leaving the grant behind would let a REISSUED cert for the same CN inherit
+    * vault authority it was never granted — silently, since nothing in the reissue
+    * path would mention it. Idempotent, so a cert issued before this existed (or
+    * whose CN never sanitized) revokes cleanly with nothing to remove. */
+   char vprincipal[VAULT_PRINCIPAL_MAX];
+   if (lk.cn[0] && cert_vault_principal(lk.cn, vprincipal, sizeof(vprincipal)))
+      (void)vault_capability_revoke(vprincipal);
+
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
       return server_send_error(conn, "cert: out of memory", NULL);

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -165,13 +165,19 @@ static void vault_cred_fingerprint(const char *secret, char *out, size_t out_len
 }
 
 /* True iff the connection is an attested transport — local UDS, trusted webchat,
- * or native-TLS+bearer — never a plaintext TCP bearer. The D2b precondition for
- * any server-principal write. */
+ * native-TLS+bearer, or a verified mTLS client — never a plaintext TCP bearer.
+ * The D2b precondition for any server-principal write: TLS on the connection is
+ * mandatory for every network path here, and mTLS is the stronger form of it.
+ *
+ * Must stay in step with vault_capability_server_write_allowed(); omitting
+ * ATTEST_MTLS_CLIENT here made this function report "unattested" for the strongest
+ * identity the server accepts, so the refusal named the wrong reason. */
 static int vault_conn_is_attested(const server_conn_t *conn)
 {
    return conn && (conn->attested_transport == ATTEST_UDS_PEERCRED ||
                    conn->attested_transport == ATTEST_WEBCHAT_TRUSTED ||
-                   conn->attested_transport == ATTEST_TLS_BEARER);
+                   conn->attested_transport == ATTEST_TLS_BEARER ||
+                   conn->attested_transport == ATTEST_MTLS_CLIENT);
 }
 
 void vault_audit_server_write(const server_conn_t *conn, const char *agent, const char *cred,
@@ -230,7 +236,9 @@ int handle_vault_set_server(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    {
       if (!vault_conn_is_attested(conn))
          return server_send_error(
-             conn, "vault: server-principal write requires an attested (UDS/webchat) connection",
+             conn,
+             "vault: server-principal write requires an attested connection (local UDS, trusted "
+             "webchat, or TLS/mTLS) — a plaintext TCP bearer is never accepted",
              NULL);
       /* Name the caller's resolved principal so the operator grants the RIGHT one
        * — a UDS peer is `uid:<N>`, not the unix username, which is a common
@@ -317,6 +325,32 @@ int handle_vault_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
    (void)req;
+   /* Enumeration previously took no gate beyond the route capability, and
+    * CAP_DELEGATE is inside CAPS_AUTHENTICATED — the LOWER of the two mTLS tiers —
+    * so any unrevoked client cert listed every server credential name.
+    *
+    * The read gate, not the write one: host-local authority (UDS, the root-owned
+    * webchat hop, the operator's own TLS bearer) enumerates without a grant, so the
+    * browser GUI's credential page keeps working with no operator action. A client
+    * cert — a network credential on arbitrary remote machines — still needs the
+    * grant. See vault_capability_server_read_allowed. */
+   if (!vault_capability_server_read_allowed(conn->attested_transport, conn->vault_principal))
+   {
+      if (!vault_conn_is_attested(conn))
+         return server_send_error(
+             conn,
+             "vault: listing shared credentials requires an attested connection (local UDS, "
+             "trusted webchat, or TLS/mTLS) — a plaintext TCP bearer is never accepted",
+             NULL);
+      char msg[256];
+      const char *who = (conn && conn->vault_principal[0]) ? conn->vault_principal : "(unknown)";
+      snprintf(msg, sizeof(msg),
+               "vault: listing shared credentials requires vault:write:server for %s — an "
+               "operator grants it locally with `aimee vault capability grant %s`",
+               who, who);
+      return server_send_error(conn, msg, NULL);
+   }
+
    vault_store_entry_t entries[64];
    int count = 0;
    vault_status_t st = vault_service_list(VAULT_SERVER_PRINCIPAL, entries,

--- a/src/server/server_vault_bootstrap.c
+++ b/src/server/server_vault_bootstrap.c
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "vault_service.h"
 #include "vault_store.h"
+#include "vault_capability.h" /* the local root operator's standing grant */
 #include "log.h"
 #include <openssl/crypto.h>
 #include <ctype.h>
@@ -350,8 +351,34 @@ static void migrate_legacy_oauth(prov_counts_t *c)
    migrate_legacy_db1_oauth(c);
 }
 
+/* The local root operator holds vault:write:server from first boot.
+ *
+ * A kernel-attested UDS peer running as root is the machine's owner: it already
+ * owns .vault/.server-master.key and can decrypt the whole store offline, so the
+ * grant confers nothing it lacked. Without it `aimee vault set-server` refuses
+ * every root caller -- the ordinary case inside the server container -- and the
+ * operator must discover and run a capability grant before storing a single
+ * credential. That is the manual step this removes.
+ *
+ * Recorded rather than special-cased in the gate so it is VISIBLE in `aimee vault
+ * capability list` and revocable by an operator who wants it gone. Idempotent, so
+ * every boot converges and a deliberate revoke is not silently undone within the
+ * same run. */
+static void grant_local_root_operator(void)
+{
+   if (vault_capability_has("uid:0"))
+      return;
+   if (vault_capability_grant("uid:0") != 0)
+      LOG_WARN("vault.bootstrap",
+               "could not grant vault:write:server to uid:0 (local root operator); "
+               "`aimee vault set-server` will refuse root until it is granted by hand");
+   else
+      LOG_INFO("vault.bootstrap", "granted vault:write:server to uid:0 (local root operator)");
+}
+
 int server_vault_bootstrap(void)
 {
+   grant_local_root_operator();
    const char *forge_token = getenv(VAULT_BOOTSTRAP_FORGE_TOKEN_ENV);
    int have_forge_token = forge_token && forge_token[0];
    int have_env = 0;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -5463,6 +5463,7 @@ $(TESTPREFIX)/unit-test-vault-bootstrap: $(OBJDIR)/tests/test_vault_bootstrap.o 
                               $(OBJDIR)/modules/vault/vault_service.o $(OBJDIR)/modules/vault/vault_store.o $(OBJDIR)/modules/vault/vault_kek_check.o \
                               $(OBJDIR)/modules/vault/vault_crypto.o $(OBJDIR)/modules/vault/vault_kek_cache.o \
                               $(OBJDIR)/modules/vault/vault_server_key.o \
+                              $(OBJDIR)/modules/vault/vault_capability.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -473,6 +473,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-capability \
                $(TESTPREFIX)/unit-test-agent-key-import \
                $(TESTPREFIX)/unit-test-vault-audit \
+               $(TESTPREFIX)/unit-test-server-vault-gate \
                $(TESTPREFIX)/unit-test-prompts \
                $(TESTPREFIX)/unit-test-cmd-session \
                $(TESTPREFIX)/unit-test-model-registry \
@@ -5507,6 +5508,14 @@ $(TESTPREFIX)/unit-test-vault-capability: $(OBJDIR)/tests/test_vault_capability.
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-vault-audit: $(OBJDIR)/tests/test_vault_audit.o \
+                              $(OBJDIR)/server/server_vault.o \
+                              $(OBJDIR)/modules/vault/vault_service.o $(OBJDIR)/modules/vault/vault_store.o $(OBJDIR)/modules/vault/vault_kek_check.o \
+                              $(OBJDIR)/modules/vault/vault_crypto.o $(OBJDIR)/modules/vault/vault_kek_cache.o \
+                              $(OBJDIR)/modules/vault/vault_server_key.o $(OBJDIR)/modules/vault/vault_capability.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-server-vault-gate: $(OBJDIR)/tests/test_server_vault_gate.o \
                               $(OBJDIR)/server/server_vault.o \
                               $(OBJDIR)/modules/vault/vault_service.o $(OBJDIR)/modules/vault/vault_store.o $(OBJDIR)/modules/vault/vault_kek_check.o \
                               $(OBJDIR)/modules/vault/vault_crypto.o $(OBJDIR)/modules/vault/vault_kek_cache.o \

--- a/src/tests/test_server_vault_gate.c
+++ b/src/tests/test_server_vault_gate.c
@@ -1,0 +1,145 @@
+/* test_server_vault_gate.c: the transport gate on /v1/vault/list, driven through
+ * handle_vault_list itself rather than through the predicate it calls.
+ *
+ * This level matters. The predicates were fully covered while the HANDLER was
+ * wired to the wrong one, which silently regressed the browser GUI's credential
+ * page for every webuser: runtime-web reaches /v1/vault/list over the root-owned
+ * webchat hop, and runtime-web's own tests MOCK that endpoint, so they exercise
+ * the relay and never the gate. Nothing in either suite could see it.
+ *
+ * The assertions below are deliberately about WHICH gate the handler consults,
+ * not about the vault's contents: a refusal is identified by its message, and an
+ * admitted caller is identified by the ABSENCE of one. That keeps the test free of
+ * a real credential store — an admitted caller may still fail downstream on an
+ * uninitialised store, which is not what is under test here. */
+#include "cJSON.h"
+#include "server.h"
+#include "vault_capability.h"
+#include "vault_principal.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static char g_message[1024];
+static int g_was_error;
+
+/* server_send_ok is a static inline over server_send_response, so this one stub
+ * captures both outcomes. */
+int server_send_response(server_conn_t *conn, cJSON *response)
+{
+   (void)conn;
+   g_was_error = 0;
+   g_message[0] = '\0';
+   cJSON *err = response ? cJSON_GetObjectItemCaseSensitive(response, "error") : NULL;
+   if (cJSON_IsString(err))
+   {
+      g_was_error = 1;
+      snprintf(g_message, sizeof(g_message), "%s", err->valuestring);
+   }
+   return 0;
+}
+
+int server_send_error(server_conn_t *conn, const char *message, const char *request_id)
+{
+   (void)conn;
+   (void)request_id;
+   g_was_error = 1;
+   snprintf(g_message, sizeof(g_message), "%s", message ? message : "");
+   return 0;
+}
+
+/* The enumeration audit sink. Stubbed rather than linked: it drags the audit
+ * stack in, and what is under test here is which callers reach the store at all.
+ * Counted so the ordering stays honest — a refused caller must not have been
+ * audited as having enumerated anything. */
+static int g_audited;
+void vault_audit_bridge_server_list(const char *principal, int count)
+{
+   (void)principal;
+   (void)count;
+   g_audited++;
+}
+
+/* True iff the handler refused at its own gate, as opposed to getting past it.
+ * Both refusals name themselves; nothing downstream produces these strings. */
+static int refused_by_gate(void)
+{
+   return g_was_error && (strstr(g_message, "vault:write:server") != NULL ||
+                          strstr(g_message, "requires an attested connection") != NULL);
+}
+
+static int list_refused(attested_transport_t transport, const char *principal)
+{
+   server_conn_t conn;
+   memset(&conn, 0, sizeof(conn));
+   conn.attested_transport = transport;
+   snprintf(conn.vault_principal, sizeof(conn.vault_principal), "%s", principal ? principal : "");
+   g_was_error = 0;
+   g_message[0] = '\0';
+   cJSON *req = cJSON_CreateObject();
+   assert(req != NULL);
+   (void)handle_vault_list(NULL, &conn, req);
+   cJSON_Delete(req);
+   return refused_by_gate();
+}
+
+int main(void)
+{
+   char path[] = "/tmp/aimee-vault-gate-XXXXXX";
+   int fd = mkstemp(path);
+   assert(fd >= 0);
+   close(fd);
+   vault_capability_set_path_for_test(path);
+
+   /* Host-local authority enumerates with NO grant. The webchat case is the one
+    * whose absence broke the GUI: an ordinary logged-in webuser holds no grant,
+    * and gating this like a write meant an operator had to mint one per user,
+    * over UDS, before the credential page would render at all. */
+   assert(!list_refused(ATTEST_WEBCHAT_TRUSTED, "webuser:alice"));
+   assert(!list_refused(ATTEST_WEBCHAT_TRUSTED, ""));
+   assert(!list_refused(ATTEST_UDS_PEERCRED, "uid:1000"));
+   assert(!list_refused(ATTEST_UDS_PEERCRED, "uid:0"));
+   assert(!list_refused(ATTEST_TLS_BEARER, ""));
+
+   /* A client cert is a network credential on arbitrary remote machines. It is
+    * what reaches /v1, not what opens the credential store — so it enumerates
+    * only with an explicit grant. This is the `curl --cert` case. */
+   assert(list_refused(ATTEST_MTLS_CLIENT, "cert:thin-abc"));
+   assert(vault_capability_grant("cert:thin-abc") == 0);
+   assert(!list_refused(ATTEST_MTLS_CLIENT, "cert:thin-abc"));
+   assert(vault_capability_revoke("cert:thin-abc") == 0);
+   assert(list_refused(ATTEST_MTLS_CLIENT, "cert:thin-abc"));
+
+   /* An unsanitizable CN keeps the MTLS classification with NO principal, so no
+    * grant can ever name it: refused, and it must not inherit the bearer's
+    * admission. */
+   assert(list_refused(ATTEST_MTLS_CLIENT, ""));
+
+   /* D2b: never over an unencrypted channel, however well-granted. */
+   assert(vault_capability_grant("webuser:alice") == 0);
+   assert(list_refused(ATTEST_TCP_BEARER, "webuser:alice"));
+   assert(list_refused(ATTEST_NONE, "webuser:alice"));
+
+   /* The plaintext refusal is the transport one, not the capability one — the
+    * message must not tell an operator to grant their way out of D2b. */
+   (void)list_refused(ATTEST_TCP_BEARER, "webuser:alice");
+   assert(strstr(g_message, "requires an attested connection") != NULL);
+   assert(strstr(g_message, "vault:write:server") == NULL);
+
+   /* The gate runs BEFORE the store is touched. A refused caller must not appear
+    * in the enumeration audit trail as having listed anything — an ordering the
+    * predicate tests cannot observe, since they never reach the handler. */
+   g_audited = 0;
+   assert(list_refused(ATTEST_MTLS_CLIENT, "cert:never-granted"));
+   assert(list_refused(ATTEST_TCP_BEARER, "webuser:alice"));
+   assert(g_audited == 0);
+
+   vault_capability_set_path_for_test(NULL);
+   unlink(path);
+   printf("PASS: server_vault_gate list gate per transport (webchat/UDS/TLS admit, "
+          "mTLS needs a grant, plaintext refused)\n");
+   return 0;
+}

--- a/src/tests/test_vault_capability.c
+++ b/src/tests/test_vault_capability.c
@@ -48,6 +48,53 @@ int main(void)
    assert(vault_capability_server_write_allowed(ATTEST_UDS_PEERCRED, "uid:1000") == 0);
    assert(vault_capability_server_write_allowed(ATTEST_UDS_PEERCRED, "") == 0);
 
+   /* The unscoped bearer over native TLS is the operator's own authority and needs
+    * no grant -- asserted with an UNGRANTED principal so that stays deliberate. */
+   assert(vault_capability_server_write_allowed(ATTEST_TLS_BEARER, "uid:1000") == 1);
+
+   /* mTLS is ATTESTED but not authorized: an enrolled client cert is the ordinary
+    * state of every thin client, so it must still hold the grant. Previously absent
+    * from both sets, which made this unreachable on an mTLS-REQUIRED server -- no
+    * conn is ever TLS_BEARER there, and the store was never consulted. */
+   assert(vault_capability_server_write_allowed(ATTEST_MTLS_CLIENT, "cert:thin-abc") == 0);
+   assert(vault_capability_grant("cert:thin-abc") == 0);
+   assert(vault_capability_server_write_allowed(ATTEST_MTLS_CLIENT, "cert:thin-abc") == 1);
+   assert(vault_capability_revoke("cert:thin-abc") == 0);
+   assert(vault_capability_server_write_allowed(ATTEST_MTLS_CLIENT, "cert:thin-abc") == 0);
+
+   /* An unsanitizable CN keeps the MTLS_CLIENT classification with NO principal
+    * (vault_principal_resolve). No principal means no grant can name it, so it is
+    * refused -- fail-closed, and it must never inherit the bearer's auto-allow.
+    *
+    * D2b is asserted above: ATTEST_TCP_BEARER is refused even for the GRANTED
+    * webuser:alice, so TLS on the connection is mandatory for every network path. */
+   assert(vault_capability_server_write_allowed(ATTEST_MTLS_CLIENT, "") == 0);
+
+   /* The READ gate: enumeration of credential NAMES. Host-local authority needs no
+    * grant, so the browser GUI's credential page renders on an ordinary login --
+    * webuser:alice is granted here, but uid:1000 is NOT, and both must pass. Gating
+    * this like a write regressed that page for every webuser, and no test saw it:
+    * runtime-web mocks /v1/vault/list, so it exercises the relay, not the gate. */
+   assert(vault_capability_server_read_allowed(ATTEST_WEBCHAT_TRUSTED, "uid:1000") == 1);
+   assert(vault_capability_server_read_allowed(ATTEST_UDS_PEERCRED, "uid:1000") == 1);
+   assert(vault_capability_server_read_allowed(ATTEST_TLS_BEARER, "uid:1000") == 1);
+   assert(vault_capability_server_read_allowed(ATTEST_WEBCHAT_TRUSTED, "") == 1);
+
+   /* A client cert is a network credential on arbitrary remote machines, so it
+    * enumerates only with the grant -- this is what keeps a bare enrolled cert (any
+    * `curl --cert`) out of the credential store. */
+   assert(vault_capability_server_read_allowed(ATTEST_MTLS_CLIENT, "cert:thin-abc") == 0);
+   assert(vault_capability_grant("cert:thin-abc") == 0);
+   assert(vault_capability_server_read_allowed(ATTEST_MTLS_CLIENT, "cert:thin-abc") == 1);
+   assert(vault_capability_revoke("cert:thin-abc") == 0);
+   assert(vault_capability_server_read_allowed(ATTEST_MTLS_CLIENT, "cert:thin-abc") == 0);
+   assert(vault_capability_server_read_allowed(ATTEST_MTLS_CLIENT, "") == 0);
+
+   /* D2b holds on the read path too: never over an unencrypted channel, however
+    * well-granted the principal. */
+   assert(vault_capability_server_read_allowed(ATTEST_TCP_BEARER, "webuser:alice") == 0);
+   assert(vault_capability_server_read_allowed(ATTEST_NONE, "webuser:alice") == 0);
+
    /* the agent-key server-seal gate: purely transport-based, NO grant needed
     * (deliberately wider than the server-write gate above), so a default install
     * seals a GUI/CLI-added delegate key without provisioning a capability first.

--- a/src/tests/test_vault_principal.c
+++ b/src/tests/test_vault_principal.c
@@ -67,17 +67,23 @@ static void test_distinct_uids_distinct_principals(void)
    printf("  PASS: test_distinct_uids_distinct_principals\n");
 }
 
-/* uid 0 (root) and unknown uid (-1) get NO principal: a zeroed/un-attested conn
- * reads as uid 0, so it must never collapse to acting as root. Fail-closed. */
-static void test_uid_zero_and_unknown_refused(void)
+/* uid 0 is a real kernel attestation and gets uid:0. The missed-hop sentinel is
+ * -1, NOT 0 -- server_http_identity_capture initialises to -1 and overwrites only
+ * on a successful peer-cred lookup -- and a zeroed conn is caught by ATTEST_NONE
+ * being the enum's zero value, so it never reaches this branch as UDS_PEERCRED.
+ * Excluding root left `vault set-server` refusing every root caller, the ordinary
+ * case inside the server container, while offering "grant (unknown)" as the fix.
+ *
+ * An unknown uid still gets NO principal and still fails closed. */
+static void test_uid_zero_named_unknown_refused(void)
 {
    char p[VAULT_PRINCIPAL_MAX];
    assert(resolve(0, 0, NULL, 0, p) == ATTEST_UDS_PEERCRED);
-   assert(p[0] == '\0'); /* no "uid:0" */
+   assert(strcmp(p, "uid:0") == 0);
 
    assert(resolve(0, -1, NULL, 0, p) == ATTEST_UDS_PEERCRED);
    assert(p[0] == '\0');
-   printf("  PASS: test_uid_zero_and_unknown_refused\n");
+   printf("  PASS: test_uid_zero_named_unknown_refused\n");
 }
 
 /* Plain TCP is bearer-authorized but has no OS-user attestation -> no vault. */
@@ -267,7 +273,7 @@ int main(void)
 {
    test_uds_peer_uid_gets_principal();
    test_distinct_uids_distinct_principals();
-   test_uid_zero_and_unknown_refused();
+   test_uid_zero_named_unknown_refused();
    test_tcp_gets_no_principal();
    test_webuser_with_token_honored();
    test_webuser_without_token_refused();


### PR DESCRIPTION
Three defects that between them made the shared credential vault unwritable from anywhere a person actually stands, while leaving it readable by anything holding a client cert.

Found while trying to store one API key. None of it was reachable by reading the code alone — each was confirmed against a running server.

## 1. `vault set-server` refused every root caller

```
vault: caller (principal (unknown)) lacks the vault:write:server capability
(grant it over UDS with `aimee vault capability grant (unknown)`)
```

`vault_principal_resolve` gave a UDS peer a principal only for `uid > 0`, so root — the ordinary case **inside the server container** — resolved to no principal, failed `vault_capability_has("")`, and was told to grant `(unknown)`. An unreachable path advertising an unusable fix. Storing a credential from the container was impossible.

uid 0 was excluded to stop a missed hop acting as root, but the missed-hop sentinel is **-1**, not 0: `server_http_identity_capture` initialises to -1 and overwrites only on a successful `platform_ipc_peer_cred`. A zeroed `server_conn_t` is caught separately — `ATTEST_NONE` is the enum's zero value, so it never classifies as `UDS_PEERCRED`. Unknown uid still fails closed.

Excluding root never made root safe, only mute: a local root peer owns `.vault/.server-master.key` and can decrypt the store offline regardless.

The grant is recorded at boot so nobody runs a capability command to store their first credential — recorded rather than special-cased in the gate, so it is visible in `aimee vault capability list` and revocable.

## 2. mTLS was absent from the write gate

On an mTLS-**required** server the server-principal write was unreachable from every remote client. `vault_principal_resolve`'s mTLS branch wins *before* the `TLS_BEARER` one, so no remote conn is ever `TLS_BEARER` there — and no grant could open the path, because the capability store was never consulted on it. `vault_conn_is_attested` then reported "unattested" for the strongest identity the server accepts, so the refusal named the wrong reason.

## 3. `vault.list` was open to any client cert

It took no gate beyond its route capability, and `CAP_DELEGATE` sits inside `CAPS_AUTHENTICATED` — the **lower** of the two mTLS tiers. So any unrevoked cert enumerated every server credential name, while `delete` and `set_server` beside it demanded an explicit grant.

Verified with curl against a live server: a client cert alone, **no bearer**, returned the full credential set.

## Reads and writes now take different gates

| Transport | list (names) | write |
|---|---|---|
| UDS peer | no grant | grant (`uid:N`, and `uid:0` granted at boot) |
| webchat hop (browser GUI) | **no grant** | grant |
| operator TLS bearer | no grant | no grant |
| mTLS client cert | grant | grant |
| plaintext TCP bearer | refused (D2b) | refused (D2b) |

Gating `list` like a write **regressed the browser GUI's credential page** for every webuser — `runtime-web` reaches `/v1/vault/list` over the webchat hop, so an operator would have had to shell into the host once per user before the page rendered. Host-local authority reads without a grant; a client cert, being a network credential on arbitrary remote machines, does not.

`D2b` is untouched throughout: `ATTEST_TCP_BEARER` is refused on both paths.

## Enrollment provisions the client

`aimee remote enroll` → `/v1/cert/sign` now mints `vault:write:server` for `cert:<CN>` with the cert. Both issue paths do it, since `cert.issue` yields an equally valid client and omitting it would leave the manual step in place.

Not a widening: `cert_op_allowed` already restricts both handlers to an attested operator channel, so the authority to reach those lines exceeds the grant they confer.

**Revocation removes it.** The grant is keyed by `cert:<CN>` while revocation names only a serial, so the CN is resolved via `pki_list` *before* `pki_revoke`. Without this the stores drift and a **reissued cert for the same CN silently inherits vault authority nobody granted it**.

Either issuance fails closed: if the grant cannot be recorded, the cert is revoked and the call errors.

## Verification — and its limits

Full unit suite green (`PASS=12 FAIL=0`), `-Wall -Wextra -Werror` clean, clang-format clean, pins resynced. New assertions cover every transport against both gates, including the webchat and UDS reads that must pass **without** a grant — the case whose absence hid the GUI regression.

Read this next part before trusting the green checks:

**Nothing in the test suite compiles `server_cert.o`.** The enrollment grant and its revocation are backed *only* by an end-to-end run against a throwaway server. CI will pass without exercising a line of it.

```
capability list                      -> principals: ""
cert issue thin-e2etest              -> ok, serial F2858A7A...
capability list                      -> principals: "cert:thin-e2etest"
cert revoke F2858A7A...              -> ok
capability list                      -> principals: ""
```

and from an empty `AIMEE_HOME`:

```
capability list                      -> principals: "uid:0"   (automatic)
vault set-server meshy api_key <x>   -> ok    (no grant command run)
vault list                           -> meshy/api_key
vault delete meshy api_key           -> ok, list empty
```

That run also executed `handle_vault_list`'s new gate over UDS. There is still **no test driving `handle_vault_list` through a connection** — that blind spot is what hid the GUI regression from both suites (`runtime-web` mocks `/v1/vault/list`, so its tests exercise the relay, not the gate), and it is worth closing separately.

## Operator impact

A thin client needs `vault:write:server` for either operation — provisioned automatically at enrollment from now on, but **certs issued before this change have no grant** and need one until reissued. Browser users and local operators see no change.