### PR TITLE
fix: mirror the commits the developer has not pushed

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "fd6a1c7ec567386847c9d6ba6468dda2cda5aa6763635b3e92f079af686a65f3"
+      "source_sha256": "64c507d06509147711d2271ead07f7762d0a831ed04336b7fec3cd013a5984f3"
     },
     {
       "id": "ir",
@@ -203,7 +203,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "b29a54915051bf53a3bfd91826909f131d8a3a1ea4d2aba477c7a8a65a34a055",
+      "source_sha256": "76c50254227109b7b6c7a999bba69ecf38b22383a25dce377ec260e30e5d2083",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,

--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -488,17 +488,29 @@ static cJSON *marshal_workspace_mirror_sync(int argc, char **argv)
       return NULL;
    }
    const char *root = argv[0];
-   char *patch = workspace_client_diff_compute(root);
+   /* The patch and the commit it applies to are one fact, so both are sent. The
+    * base is the newest ancestor of HEAD that a remote has: unpushed commits
+    * cannot be fetched server-side, so they travel inside the patch instead. */
+   char base[64] = "";
+   if (workspace_client_mirror_base(root, base, sizeof(base)) != 0)
+   {
+      fprintf(stderr,
+              "aimee: %s has no commit that exists on a remote, so the server has nothing to "
+              "reconstruct from. Push a commit (even an old one) and retry.\n",
+              root);
+      return NULL;
+   }
+   char *patch = workspace_client_diff_compute(root, base);
    if (!patch)
       fprintf(stderr,
-              "warning: could not compute a diff for %s (not a git repo / no HEAD?); "
-              "shipping an empty diff\n",
-              root);
+              "warning: could not compute a diff for %s against %.10s; shipping an empty diff\n",
+              root, base);
 
    cJSON *req = marshal_no_args("workspace.mirror-sync");
    cJSON *args = cJSON_CreateArray();
    cJSON_AddItemToArray(args, cJSON_CreateString(root));
    cJSON_AddItemToObject(req, "args", args);
+   cJSON_AddStringToObject(req, "head", base);
    cJSON_AddStringToObject(req, "diff", patch ? patch : "");
    free(patch);
    return req;

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1763,6 +1763,37 @@ int config_workspace_add(const char *path, const char *provider, const char *rem
                   head ? head : "");
          rc = config_save(cfg);
       }
+      else if (rc == -2)
+      {
+         /* Already registered: REFRESH the coordinates the caller supplied.
+          *
+          * These are not static properties of a path — a mirror workspace's head
+          * is whichever commit the client's patch applies to, and it moves every
+          * time the developer commits or pushes. Leaving the first value frozen
+          * meant a re-attaching client shipped a patch against one commit while
+          * the server still checked out another, and `git apply` failed on a
+          * tree that had been fine at first attach.
+          *
+          * Only non-NULL arguments are written, so a caller that supplies just a
+          * head (workspace.mirror-sync) does not erase the remote. Still returns
+          * -2, which callers treat as idempotent success. */
+         for (int i = 0; i < cfg->workspace_count; i++)
+         {
+            if (strcmp(cfg->workspaces[i], path) != 0)
+               continue;
+            if (provider)
+               snprintf(cfg->workspace_providers[i], sizeof(cfg->workspace_providers[i]), "%s",
+                        strcmp(provider, "shared") != 0 ? provider : "");
+            if (remote)
+               snprintf(cfg->workspace_vcs_remote[i], sizeof(cfg->workspace_vcs_remote[i]), "%s",
+                        remote);
+            if (head)
+               snprintf(cfg->workspace_vcs_head[i], sizeof(cfg->workspace_vcs_head[i]), "%s", head);
+            if (provider || remote || head)
+               (void)config_save(cfg);
+            break;
+         }
+      }
    }
    free(cfg);
    return rc;

--- a/src/modules/workspace/cli_workspace_serve.c
+++ b/src/modules/workspace/cli_workspace_serve.c
@@ -336,14 +336,13 @@ static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *h
       rc_chomp(remote);
    }
    free(out);
-   out = NULL;
-   const char *rp[] = {"git", "-C", root, "rev-parse", "HEAD", NULL};
-   if (safe_exec_capture(rp, &out, 128) == 0 && out)
-   {
-      snprintf(head, hcap, "%s", out);
-      rc_chomp(head);
-   }
-   free(out);
+   /* The head we register is the mirror BASE — the newest ancestor of HEAD that
+    * a remote already has — not HEAD itself. The server reconstructs by fetching
+    * this commit, so registering an unpushed HEAD would name something it can
+    * never resolve. Local commits are not lost: they ride along in the patch
+    * shipped below, which is computed against this same base. */
+   if (workspace_client_mirror_base(root, head, hcap) != 0)
+      head[0] = '\0';
    return remote[0] && head[0];
 }
 #else
@@ -358,15 +357,23 @@ static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *h
 }
 #endif
 
-/* Ship the client's uncommitted working-tree patch for `root` so the server's
- * reconstruct matches what the client actually has. Without it the reconstruct
- * is a clean checkout at head and every uncommitted change is silently missing
- * from the tree the agent works in — the failure this whole path exists to
- * avoid. Best-effort: a failure here is reported, never fatal, because a tree at
- * head is still a usable (if stale) sandbox and the drift report will say so. */
-static void rc_ship_client_diff(const char *endpoint, const char *bearer, const char *root)
+/* Ship the client's working-tree patch for `root` so the server's reconstruct
+ * matches what the client actually has: everything between `base` and the
+ * working tree, which is unpushed commits AND uncommitted edits AND untracked
+ * files. Without it the reconstruct is a clean checkout at base and all of that
+ * is silently missing from the tree the agent works in — the failure this whole
+ * path exists to avoid.
+ *
+ * `base` is the commit just registered as the workspace head. Passed in rather
+ * than re-resolved so the patch cannot be computed against a different commit
+ * than the one the server will check out; a patch and its base are one fact.
+ *
+ * Best-effort: a failure is reported, never fatal, because a tree at base is
+ * still a usable (if stale) sandbox and the drift report will say so. */
+static void rc_ship_client_diff(const char *endpoint, const char *bearer, const char *root,
+                                const char *base)
 {
-   char *patch = workspace_client_diff_compute(root);
+   char *patch = workspace_client_diff_compute(root, base);
    cJSON *req = cJSON_CreateObject();
    if (!req)
    {
@@ -377,6 +384,7 @@ static void rc_ship_client_diff(const char *endpoint, const char *bearer, const 
    cJSON *args = cJSON_CreateArray();
    cJSON_AddItemToArray(args, cJSON_CreateString(root));
    cJSON_AddItemToObject(req, "args", args);
+   cJSON_AddStringToObject(req, "head", base ? base : "");
    cJSON_AddStringToObject(req, "diff", patch ? patch : "");
    free(patch);
    char *body = cJSON_PrintUnformatted(req);
@@ -499,7 +507,7 @@ int cli_workspace_reverse_channel_start(void)
     * and an absent one is a silent clean checkout at head. Runs on the attach
     * path too ("already registered"), because a re-attaching client's tree has
     * usually moved on since the registration that created it. */
-   rc_ship_client_diff(endpoint, bearer, cwd);
+   rc_ship_client_diff(endpoint, bearer, cwd, ws_head);
 
    struct rc_args *a = calloc(1, sizeof(*a));
    if (!a)

--- a/src/modules/workspace/include/aimee/workspace/client_diff.h
+++ b/src/modules/workspace/include/aimee/workspace/client_diff.h
@@ -1,27 +1,64 @@
 #ifndef AIMEE_WORKSPACE_CLIENT_DIFF_H
 #define AIMEE_WORKSPACE_CLIENT_DIFF_H 1
 
+#include <stddef.h>
+
 /* The client's working-tree patch, as shipped to the server's mirror tier.
  *
- * The mirror reconstructs a server-side worktree by checking out the client's
- * head and applying this patch on top (workspace_mirror_reconstruct). Without
- * it the reconstruct is a clean checkout at head, so every uncommitted change
- * the client holds is silently absent from the tree an agent then works in.
+ * The mirror reconstructs a server-side worktree by checking out a commit it can
+ * FETCH and applying this patch on top (workspace_mirror_reconstruct). Both
+ * halves have to agree on the same base, which is why resolving the base and
+ * computing the patch live together here.
  *
- * Shared because two callers need the same patch and it must be computed the
- * same way for both: `aimee workspace mirror-sync` (explicit) and the reverse
- * channel's registration (automatic, on attach). */
+ * Shared because two callers need the identical pair: `aimee workspace
+ * mirror-sync` (explicit) and the reverse channel's registration (automatic, on
+ * attach). A second implementation that picked a different base would produce a
+ * patch the server cannot apply. */
 
-/* Compute the client's FULL working-tree patch vs HEAD for the repository at
- * `root` — tracked modifications, deletions, AND untracked (non-ignored) files
- * as additions — without touching the client's real index: stage everything into
- * a throwaway index (GIT_INDEX_FILE) seeded from HEAD, then
- * `diff --cached --binary HEAD`. git's --binary patch format is ASCII (base85
+/* Resolve the mirror BASE for the repository at `root`: the newest ancestor of
+ * HEAD that exists on some remote, i.e. the newest commit the server can
+ * actually `git fetch`.
+ *
+ * HEAD itself is the wrong answer whenever the developer has local commits that
+ * were never pushed — the server cannot fetch them, so the reconstruct fails and
+ * the delegate gets nothing. Resolving to the last pushed ancestor instead lets
+ * those commits ride along inside the patch as ordinary working-tree content,
+ * which is what a delegate needs to build against. (Their commit HISTORY is not
+ * reproduced server-side; the file contents are.)
+ *
+ * Returns 0 and writes a 40-hex commit id into out[out_cap] on success. Returns
+ * -1 when no ancestor of HEAD exists on any remote — an unpushed-only repository
+ * that no server could reconstruct — and the caller must refuse rather than
+ * guess. POSIX-only; the thin Windows client cannot fork git and always gets -1. */
+int workspace_client_mirror_base(const char *root, char *out, size_t out_cap);
+
+/* Compute the client's FULL working-tree patch against `base` for the repository
+ * at `root` — tracked modifications, deletions, AND untracked (non-ignored)
+ * files as additions — without touching the client's real index: stage
+ * everything into a throwaway index (GIT_INDEX_FILE) seeded from `base`, then
+ * `diff --cached --binary <base>`. git's --binary patch format is ASCII (base85
  * hunks), so the result is JSON-safe even for binary files.
  *
- * Returns a malloc'd patch the caller frees, which may be "" for a clean tree,
- * or NULL when `root` is not a repo / has no HEAD. POSIX-only (the thin Windows
- * client cannot fork git); Windows always returns NULL. */
-char *workspace_client_diff_compute(const char *root);
+ * `base` must be what workspace_client_mirror_base returned for the same root,
+ * and must be the same commit registered as the workspace's head — the patch is
+ * meaningless against any other commit.
+ *
+ * Returns a malloc'd patch the caller frees, which may be "" for a tree that
+ * matches `base` exactly, or NULL when `root` is not a repo or `base` is
+ * unreadable. POSIX-only; Windows always returns NULL. */
+char *workspace_client_diff_compute(const char *root, const char *base);
+
+/* The decision inside workspace_client_mirror_base, separated from running git
+ * so it can be tested directly: given the output of
+ * `git rev-list --boundary HEAD --not --remotes` and the resolved HEAD id,
+ * choose the base.
+ *
+ *   no output            -> nothing unpushed, base = `head`
+ *   a "-<sha>" line      -> base = that boundary commit (the last pushed one)
+ *   output, no "-" line  -> unpushed with no fetchable ancestor -> -1
+ *
+ * Returns 0 on success, -1 when the caller must refuse. */
+int workspace_client_mirror_base_select(const char *revlist_out, const char *head, char *out,
+                                        size_t out_cap);
 
 #endif /* AIMEE_WORKSPACE_CLIENT_DIFF_H */

--- a/src/modules/workspace/workspace_client_diff.c
+++ b/src/modules/workspace/workspace_client_diff.c
@@ -1,19 +1,130 @@
-/* workspace_client_diff.c: the client's working-tree patch for the mirror tier.
- * See include/aimee/workspace/client_diff.h. Moved here verbatim from the
- * `workspace mirror-sync` marshaller so the reverse channel can ship the same
- * patch on attach without computing it a second, divergent way. */
+/* workspace_client_diff.c: the client's mirror base + working-tree patch.
+ * See include/aimee/workspace/client_diff.h. */
 #include <aimee/workspace/client_diff.h>
 
-#include "util.h" /* safe_exec_capture_env */
+#include "util.h" /* safe_exec_capture, safe_exec_capture_env */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
+
+/* A commit id as git prints it. */
+#define GIT_OID_HEX 40
+
+static int is_hex_oid(const char *s, size_t n)
+{
+   if (n != GIT_OID_HEX)
+      return 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      char c = s[i];
+      if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+         return 0;
+   }
+   return 1;
+}
+
+int workspace_client_mirror_base_select(const char *revlist_out, const char *head, char *out,
+                                        size_t out_cap)
+{
+   if (!out || out_cap <= GIT_OID_HEX)
+      return -1;
+   out[0] = '\0';
+
+   /* Scan for a boundary line ("-<sha>"): the newest ancestor of HEAD that a
+    * remote already has. Boundary lines can appear anywhere in the output, so
+    * the whole thing is scanned rather than just the tail. */
+   int saw_line = 0;
+   for (const char *p = revlist_out ? revlist_out : ""; *p;)
+   {
+      const char *nl = strchr(p, '\n');
+      size_t len = nl ? (size_t)(nl - p) : strlen(p);
+      /* Tolerate CRLF and stray padding. */
+      while (len > 0 && (p[len - 1] == '\r' || p[len - 1] == ' ' || p[len - 1] == '\t'))
+         len--;
+      if (len > 0)
+      {
+         if (p[0] == '-' && is_hex_oid(p + 1, len - 1))
+         {
+            memcpy(out, p + 1, GIT_OID_HEX);
+            out[GIT_OID_HEX] = '\0';
+            return 0;
+         }
+         saw_line = 1;
+      }
+      if (!nl)
+         break;
+      p = nl + 1;
+   }
+
+   /* Output we could not resolve to a boundary. Either unpushed commits with
+    * nothing beneath them on any remote, or something we do not understand --
+    * and the two are indistinguishable from here. Both mean we cannot name a
+    * commit the server is able to fetch, so refuse. Falling back to HEAD would
+    * register exactly the unfetchable commit this function exists to avoid. */
+   if (saw_line)
+      return -1;
+
+   /* Nothing unpushed at all — HEAD itself is on a remote. */
+   if (!head || !is_hex_oid(head, strlen(head)))
+      return -1;
+   memcpy(out, head, GIT_OID_HEX);
+   out[GIT_OID_HEX] = '\0';
+   return 0;
+}
 
 #if !defined(_WIN32) && !defined(_WIN64)
 extern char **environ;
-char *workspace_client_diff_compute(const char *root)
+
+/* Trim one captured git line in place. */
+static void chomp(char *s)
 {
+   size_t n = strlen(s);
+   while (n > 0 && (s[n - 1] == '\n' || s[n - 1] == '\r' || s[n - 1] == ' ' || s[n - 1] == '\t'))
+      s[--n] = '\0';
+}
+
+int workspace_client_mirror_base(const char *root, char *out, size_t out_cap)
+{
+   if (!root || !root[0] || !out || out_cap <= GIT_OID_HEX)
+      return -1;
+   out[0] = '\0';
+
+   char *head_buf = NULL;
+   const char *rp[] = {"git", "-C", root, "rev-parse", "HEAD", NULL};
+   if (safe_exec_capture(rp, &head_buf, 128) != 0 || !head_buf)
+   {
+      free(head_buf);
+      return -1; /* not a repo, or no commit yet */
+   }
+   chomp(head_buf);
+
+   /* Every ancestor of HEAD that no remote has, with the boundary beneath them.
+    * Generous cap: a long-lived unpushed branch is ~41 bytes per commit, and
+    * truncating would hide the boundary and silently pick the wrong base. */
+   char *rl = NULL;
+   const char *bl[] = {"git",  "-C",    root,        "rev-list", "--boundary",
+                       "HEAD", "--not", "--remotes", NULL};
+   int rc = safe_exec_capture(bl, &rl, 16 * 1024 * 1024);
+   if (rc != 0)
+   {
+      /* A repository with no remotes at all makes this fail on some git
+       * versions; either way we cannot prove a fetchable ancestor. */
+      free(head_buf);
+      free(rl);
+      return -1;
+   }
+   int sel = workspace_client_mirror_base_select(rl ? rl : "", head_buf, out, out_cap);
+   free(head_buf);
+   free(rl);
+   return sel;
+}
+
+char *workspace_client_diff_compute(const char *root, const char *base)
+{
+   if (!root || !root[0] || !base || !base[0])
+      return NULL;
    char idx[] = "/tmp/aimee-msync-idx-XXXXXX";
    int fd = mkstemp(idx);
    if (fd < 0)
@@ -37,7 +148,7 @@ char *workspace_client_diff_compute(const char *root)
    envp[n + 1] = NULL;
 
    char *out = NULL;
-   const char *rt[] = {"git", "-C", root, "read-tree", "HEAD", NULL};
+   const char *rt[] = {"git", "-C", root, "read-tree", base, NULL};
    int rc = safe_exec_capture_env(rt, envp, &out, 4096);
    free(out);
    out = NULL;
@@ -48,17 +159,26 @@ char *workspace_client_diff_compute(const char *root)
       safe_exec_capture_env(add, envp, &out, 4096);
       free(out);
       out = NULL;
-      const char *df[] = {"git", "-C", root, "diff", "--cached", "--binary", "HEAD", NULL};
+      const char *df[] = {"git", "-C", root, "diff", "--cached", "--binary", base, NULL};
       safe_exec_capture_env(df, envp, &patch, 16 * 1024 * 1024);
    }
    free(envp);
    unlink(idx);
-   return patch; /* may be "" (clean tree) */
+   return patch; /* may be "" (tree matches base exactly) */
 }
 #else
-char *workspace_client_diff_compute(const char *root)
+int workspace_client_mirror_base(const char *root, char *out, size_t out_cap)
 {
    (void)root;
+   if (out && out_cap)
+      out[0] = '\0';
+   return -1;
+}
+
+char *workspace_client_diff_compute(const char *root, const char *base)
+{
+   (void)root;
+   (void)base;
    return NULL;
 }
 #endif

--- a/src/server/server_runner_endpoints.c
+++ b/src/server/server_runner_endpoints.c
@@ -316,6 +316,24 @@ int handle_workspace_mirror_sync(server_ctx_t *ctx, server_conn_t *conn, cJSON *
       return server_send_error(
           conn, "workspace: mirror-sync requires a registered `mirror` workspace", NULL);
 
+   /* The patch and the commit it applies to arrive together, and the registry is
+    * updated from the same request. A client's base moves whenever the developer
+    * commits or pushes, so accepting the patch while keeping an older head would
+    * store a pair that cannot be applied — and the failure would surface later,
+    * during a reconstruct, far from the request that caused it. */
+   const char *client_head = jo_str(req, "head", "");
+   if (client_head && client_head[0])
+   {
+      (void)config_workspace_add(root, "mirror", NULL, client_head);
+      /* Republish the live snapshot, for the same reason workspace.add does:
+       * config_load() serves the snapshot rather than disk in the server, so
+       * without this the head sits correct on disk while every reader — the
+       * reconstruct included — keeps using the previous one until the server
+       * loop's next tick. Measured: the patch shipped against the right base and
+       * the checkout still used the stale head, so nothing reconstructed. */
+      (void)config_reload_if_changed();
+   }
+
    char base[MAX_PATH_LEN], diff_path[MAX_PATH_LEN];
    if (workspace_mirror_base(base, sizeof(base)) != 0)
       return server_send_error(conn, "workspace: cannot resolve workspaces dir", NULL);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -318,6 +318,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-forge-credentials \
                $(TESTPREFIX)/unit-test-forge-app-token \
                $(TESTPREFIX)/unit-test-workspace-mirror \
+               $(TESTPREFIX)/unit-test-workspace-client-base \
                $(TESTPREFIX)/unit-test-workspace-provider-detached \
                $(TESTPREFIX)/unit-test-workspace-runner-queue \
                $(TESTPREFIX)/unit-test-cli-kb-smoke \
@@ -3911,6 +3912,11 @@ $(TESTPREFIX)/unit-test-forge-app-token: $(OBJDIR)/tests/test_forge_app_token.o 
 $(TESTPREFIX)/unit-test-workspace-mirror: $(OBJDIR)/tests/test_workspace_mirror.o \
                       $(OBJDIR)/modules/workspace/workspace_mirror.o $(OBJDIR)/aimee_home.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-workspace-client-base: $(OBJDIR)/tests/test_workspace_client_base.o \
+                      $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/posix/util.o \
+                      $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Gated live integration test (NOT in unit-tests / verify): drives the broker
 # against a real authenticated git remote. Build + run via `make forge-cred-integration`.

--- a/src/tests/test_workspace_client_base.c
+++ b/src/tests/test_workspace_client_base.c
@@ -1,0 +1,101 @@
+/* Choosing the commit a server-side mirror reconstructs from.
+ *
+ * The mirror seeds itself by FETCHING a commit from the client's remote, so the
+ * only valid base is one the remote already has. Registering the client's HEAD
+ * is wrong the moment the developer has a commit they never pushed: the fetch
+ * cannot resolve it, the reconstruct fails, and the delegate gets nothing --
+ * which is most of the time, for anyone with work in progress.
+ *
+ * Resolving to the newest PUSHED ancestor instead lets those commits ride along
+ * inside the client patch as ordinary file content, which is what a delegate
+ * needs to build against.
+ *
+ * This pins the decision itself, fed the output `git rev-list --boundary HEAD
+ * --not --remotes` produces in each case, so it runs without a git repository. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <aimee/workspace/client_diff.h>
+
+#define PUSHED   "a4cd94f25fe510b63b6f0fe3334fd35af10905e3"
+#define LOCAL1   "cbdc6266bc9266b8de3536960aa57be7cefde4b1"
+#define LOCAL2   "863c5be557f6e1dca24827c16e92a1c69e8704a5"
+#define HEAD_SHA "863c5be557f6e1dca24827c16e92a1c69e8704a5"
+
+static void test_unpushed_commits_resolve_to_the_last_pushed_one(void)
+{
+   /* Two local-only commits above a pushed base. Verbatim shape of the real
+    * output: the excluded commits first, then the boundary marked with '-'. */
+   const char *out = LOCAL2 "\n" LOCAL1 "\n-" PUSHED "\n";
+   char base[64] = "";
+   assert(workspace_client_mirror_base_select(out, HEAD_SHA, base, sizeof(base)) == 0);
+   assert(strcmp(base, PUSHED) == 0);
+   printf("  PASS: unpushed commits resolve to the last pushed ancestor\n");
+}
+
+static void test_clean_tree_uses_head(void)
+{
+   /* Nothing unpushed: rev-list prints nothing, so HEAD is already on a remote. */
+   char base[64] = "";
+   assert(workspace_client_mirror_base_select("", HEAD_SHA, base, sizeof(base)) == 0);
+   assert(strcmp(base, HEAD_SHA) == 0);
+   printf("  PASS: a fully pushed tree uses HEAD\n");
+}
+
+static void test_no_fetchable_ancestor_is_refused(void)
+{
+   /* Commits with no boundary beneath them: nothing on any remote. There is no
+    * safe answer, so the caller must refuse rather than name an unfetchable
+    * commit and fail later inside a reconstruct. */
+   const char *out = LOCAL2 "\n" LOCAL1 "\n";
+   char base[64] = "";
+   assert(workspace_client_mirror_base_select(out, HEAD_SHA, base, sizeof(base)) == -1);
+   assert(base[0] == '\0');
+   printf("  PASS: no fetchable ancestor is refused\n");
+}
+
+static void test_boundary_found_wherever_it_appears(void)
+{
+   /* Order is git's business, not ours: the boundary is honoured first or last. */
+   char base[64] = "";
+   assert(workspace_client_mirror_base_select("-" PUSHED "\n" LOCAL1 "\n", HEAD_SHA, base,
+                                              sizeof(base)) == 0);
+   assert(strcmp(base, PUSHED) == 0);
+   /* CRLF and a missing trailing newline must not hide it. */
+   base[0] = '\0';
+   assert(workspace_client_mirror_base_select(LOCAL1 "\r\n-" PUSHED, HEAD_SHA, base,
+                                              sizeof(base)) == 0);
+   assert(strcmp(base, PUSHED) == 0);
+   printf("  PASS: the boundary is found wherever it appears\n");
+}
+
+static void test_garbage_never_becomes_a_base(void)
+{
+   char base[64] = "";
+   /* Not hex, wrong length, and an empty marker: none may be accepted as a
+    * commit id, or the server would be asked to fetch nonsense. */
+   assert(workspace_client_mirror_base_select("-notacommit\n", HEAD_SHA, base, sizeof(base)) == -1);
+   assert(workspace_client_mirror_base_select("-abc123\n", HEAD_SHA, base, sizeof(base)) == -1);
+   assert(workspace_client_mirror_base_select("-\n", HEAD_SHA, base, sizeof(base)) == -1);
+   /* An unusable HEAD cannot stand in for a base either. */
+   assert(workspace_client_mirror_base_select("", "not-a-sha", base, sizeof(base)) == -1);
+   assert(workspace_client_mirror_base_select("", "", base, sizeof(base)) == -1);
+   assert(workspace_client_mirror_base_select("", NULL, base, sizeof(base)) == -1);
+   /* A buffer that cannot hold a commit id is refused, not truncated. */
+   char tiny[8];
+   assert(workspace_client_mirror_base_select("-" PUSHED "\n", HEAD_SHA, tiny, sizeof(tiny)) == -1);
+   printf("  PASS: garbage never becomes a base\n");
+}
+
+int main(void)
+{
+   printf("test_workspace_client_base\n");
+   test_unpushed_commits_resolve_to_the_last_pushed_one();
+   test_clean_tree_uses_head();
+   test_no_fetchable_ancestor_is_refused();
+   test_boundary_found_wherever_it_appears();
+   test_garbage_never_becomes_a_base();
+   printf("All tests passed.\n");
+   return 0;
+}

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1591,7 +1591,7 @@
         },
         {
           "path": "src/modules/workspace/include/aimee/workspace/client_diff.h",
-          "sha256": "9629922120eddaa96554d55e066e0421eee7e065b9d694ffb508488f58868940"
+          "sha256": "26c8191ddb0032363781dc0a468301f81caa38fdc1945a06765604acfcd12007"
         },
         {
           "path": "src/modules/workspace/include/aimee/workspace/module_api.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "5fdfa87820dd485146647e8d447a48d9b0fa0a31d9366b81ccc09ff0a02047c5",
+      "sha256": "55b71462af2056f287e3339bed78eeaf154219a76276db984283597ef684a94d",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
Closes the last known limit of the mirror tier, carried since #2409: **the developer's unpushed commits could not be mirrored.**

## Why it was the common case, not an edge case

The mirror seeds by *fetching* the client's head from the client's remote, so registering `HEAD` only works when HEAD is already pushed. A branch of local commits — the normal state of anyone mid-task — named a commit the server could not resolve. The reconstruct failed and the delegate got an empty tree.

## The base is the newest ancestor a remote already has

```
git rev-list --boundary HEAD --not --remotes   ->   -<sha>
```

Unpushed commits are not lost: the patch is computed against that base instead of HEAD, so their **content** rides along as ordinary working-tree changes — what a delegate needs to build against. Their commit *history* is not reproduced server-side; the files are.

| Case | Base |
|---|---|
| Unpushed commits above a pushed one | the boundary — newest pushed ancestor |
| Nothing unpushed | `HEAD`, unchanged |
| Nothing on **any** remote | **refused** |

The last row matters: there is no safe base, so naming one would defer the failure into a reconstruct far from its cause. Unparseable output is refused for the same reason — an early draft fell through to HEAD there, and its own test caught it.

## Two coupling defects, both found by running it

1. **A patch and its base are one fact**, so they now travel in one request and the registry is updated from it. A client's base moves whenever the developer commits or pushes, and `config_workspace_add` ignored the coordinates on re-registration — the write block only ran for a *new* entry. A re-attaching client shipped a patch against one commit while the server still checked out another, and `git apply` failed on a tree that had been fine at first attach.
2. **That write needs `config_reload_if_changed()`**, for the reason `workspace.add` already documents: inside the server `config_load()` serves the snapshot, not disk. Without it the head was correct on disk while every reader — including the reconstruct — kept the previous one. I measured exactly that: the patch shipped against the right base and nothing reconstructed.

## Verification

End to end against a real `aimee-server` on a second host, with a client holding two unpushed commits, an uncommitted edit and an untracked file. The registered head self-corrects from the unfetchable HEAD to the pushed base, and the reconstructed tree contains all four layers:

```
pushed base line     <- fetched from the remote
LOCAL-COMMIT-1       <- unpushed, carried in the patch
LOCAL-COMMIT-2       <- unpushed, carried in the patch
UNCOMMITTED-EDIT     <- uncommitted
untracked.txt        <- untracked
```

Unit-pinned in `test_workspace_client_base.c`: the selection runs against captured `rev-list` output, so it needs no git repository — all three cases plus CRLF, boundary-ordering, garbage input, and a too-small buffer.

`make lint` 47/47; full unit suite; baselines, pins, descriptors, source-ownership, cleanup-ledger, bus-boundary and header-layout all clean locally before pushing.

## Noted, not fixed here

`aimee workspace add --provider mirror --remote <url>` still reports *"--provider mirror requires --remote"* — the **CLI** marshaller drops the flag, unlike the REST route fixed in #2412. The reverse channel uses REST, so this is a usability gap in the manual command rather than a break in the automatic path. Out of scope for this change; worth its own.
