### PR TITLE
fix: `workspace add --provider mirror` stops refusing its own caller

### DIFF
--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -465,6 +465,20 @@ static cJSON *marshal_workspace_add(int argc, char **argv)
    const char *prov = rpc_get(&opts, "provider");
    if (prov)
       cJSON_AddStringToObject(req, "provider", prov);
+   /* The mirror coordinates need surfacing for the same reason root and provider
+    * do. This body reaches the server through POST /v1/workspaces -- including
+    * locally, over the HTTP UDS -- and that route reads top-level fields, not
+    * `args`. Left in args only, they were silently dropped, so
+    * `aimee workspace add <path> --provider mirror --remote <url>` came back with
+    * "--provider mirror requires --remote <url>" while staring at the flag the
+    * user had just typed. The socket dispatch still parses argv, so both paths
+    * now carry them. */
+   const char *rem = rpc_get(&opts, "remote");
+   if (rem)
+      cJSON_AddStringToObject(req, "remote", rem);
+   const char *hd = rpc_get(&opts, "head");
+   if (hd)
+      cJSON_AddStringToObject(req, "head", hd);
    /* --no-scan registers the workspace and returns instead of walking every
     * discovered project first. On a large tree the eager scan makes this RPC
     * take minutes, so a caller with a timeout abandons a registration that

--- a/src/tests/test_workspace_add_noscan.c
+++ b/src/tests/test_workspace_add_noscan.c
@@ -82,12 +82,52 @@ static void test_no_scan_composes_with_provider(void)
    printf("  --no-scan composes with --provider\n");
 }
 
+/* A `mirror` registration is refused without --remote, so the flags have to
+ * reach the server as TOP-LEVEL fields: this body is delivered through POST
+ * /v1/workspaces (including locally, over the HTTP UDS), and that route reads
+ * the body, not `args`. Left in args alone they were dropped in transit, and
+ * `aimee workspace add <path> --provider mirror --remote <url>` was answered
+ * with "--provider mirror requires --remote <url>" — the server refusing over a
+ * flag the caller had supplied. */
+static void test_mirror_coordinates_are_surfaced(void)
+{
+   char *argv[] = {"/srv/repo", "--provider", "mirror", "--remote", "git@github.com:o/r.git",
+                   "--head",    "abc123"};
+   cJSON *req = marshal(7, argv);
+
+   const cJSON *prov = cJSON_GetObjectItemCaseSensitive(req, "provider");
+   assert(cJSON_IsString(prov) && strcmp(prov->valuestring, "mirror") == 0);
+   const cJSON *rem = cJSON_GetObjectItemCaseSensitive(req, "remote");
+   assert(cJSON_IsString(rem) && strcmp(rem->valuestring, "git@github.com:o/r.git") == 0);
+   const cJSON *head = cJSON_GetObjectItemCaseSensitive(req, "head");
+   assert(cJSON_IsString(head) && strcmp(head->valuestring, "abc123") == 0);
+
+   cJSON_Delete(req);
+   printf("  --remote/--head are surfaced for a mirror registration\n");
+}
+
+/* Absent flags send nothing, so a shared/detached registration keeps exactly the
+ * body it had before and an older server sees no unknown fields. */
+static void test_absent_coordinates_send_nothing(void)
+{
+   char *argv[] = {"/srv/repo", "--provider", "detached"};
+   cJSON *req = marshal(3, argv);
+
+   assert(cJSON_GetObjectItemCaseSensitive(req, "remote") == NULL);
+   assert(cJSON_GetObjectItemCaseSensitive(req, "head") == NULL);
+
+   cJSON_Delete(req);
+   printf("  absent --remote/--head send nothing\n");
+}
+
 int main(void)
 {
    printf("workspace add --no-scan:\n");
    test_no_scan_sets_scan_false();
    test_default_sends_no_scan_field();
    test_no_scan_composes_with_provider();
+   test_mirror_coordinates_are_surfaced();
+   test_absent_coordinates_send_nothing();
    printf("workspace add --no-scan: OK\n");
    return 0;
 }


### PR DESCRIPTION
```
$ aimee workspace add /repo --provider mirror --remote git@host:o/r.git
aimee: workspace: --provider mirror requires --remote <url>
```

The flag was right there.

`workspace.add` is delivered through `POST /v1/workspaces` — including locally, over the HTTP UDS — and that route reads the request **body**, while `--remote` and `--head` only ever reached `args`. The marshaller already surfaced `root` and `provider` as top-level fields for exactly this reason; the mirror coordinates were never added when the provider was.

So the only way to register a mirror workspace by hand was to POST the JSON yourself. The reverse channel was unaffected — it builds the body directly — which is why this survived: the automatic path worked and the manual one didn't.

## The fix

Surface `remote`/`head` alongside `root`/`provider`. Absent flags still send nothing, so a `shared`/`detached` registration keeps the body it had and an older server sees no unknown fields.

## Verification

- **Red first:** against the previous marshaller the new assertion fails on the missing `remote`. Pinned in `test_workspace_add_noscan.c`, which already includes the TU to reach this static marshaller.
- **On real hardware:** against an `aimee-server` on a second host, the command now registers and the registry reports `provider: mirror` with the remote and head.
- `make lint` 47/47, full unit suite, plus baselines, pins, descriptors, cleanup-ledger and source-ownership.

Found while verifying #2413 end to end. Independent of it — this is the manual command; #2413 is the automatic path.
