### PR TITLE
fix: a roundtable review that produced nothing stops reporting success

### DIFF
--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -2313,11 +2313,56 @@ void pt_print_roundtable_review(const char *method, cJSON *resp)
    cJSON *art = cJSON_GetObjectItemCaseSensitive(resp, "artifact");
    if (cJSON_IsString(art) && art->valuestring[0])
       printf("%s\n", art->valuestring);
+   else
+   {
+      /* A review that produced no artifact is the case that matters most, and it
+       * printed NOTHING while exiting 0 -- so asking for a review, getting none,
+       * and being told nothing was indistinguishable from an approval. The panel
+       * reports exactly why in status/pause_reason/detail; say it.
+       *
+       * Measured against a real server: a review with no saved roundtable
+       * returned status=pending, pause_reason=panel_unreachable, detail="a
+       * roundtable review must name a saved roundtable" -- and the operator saw
+       * a silent success. */
+      cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+      cJSON *reason = cJSON_GetObjectItemCaseSensitive(resp, "pause_reason");
+      cJSON *detail = cJSON_GetObjectItemCaseSensitive(resp, "detail");
+      const char *st = cJSON_IsString(status) ? status->valuestring : "";
+      const char *rs = cJSON_IsString(reason) ? reason->valuestring : "";
+      const char *dt = cJSON_IsString(detail) ? detail->valuestring : "";
+      if (st[0] || rs[0] || dt[0])
+      {
+         fprintf(stderr, "aimee: roundtable produced no review");
+         if (st[0])
+            fprintf(stderr, " (%s)", st);
+         if (rs[0])
+            fprintf(stderr, ": %s", rs);
+         fprintf(stderr, "\n");
+         if (dt[0])
+            fprintf(stderr, "  %s\n", dt);
+      }
+      else
+         fprintf(stderr, "aimee: roundtable produced no review and gave no reason\n");
+   }
    cJSON *rounds = cJSON_GetObjectItemCaseSensitive(resp, "rounds_run");
    cJSON *converged = cJSON_GetObjectItemCaseSensitive(resp, "converged");
    if (cJSON_IsNumber(rounds))
       fprintf(stderr, "[roundtable: %d round(s)%s]\n", (int)rounds->valuedouble,
               cJSON_IsTrue(converged) ? ", converged" : "");
+}
+
+/* A review is a failure for exit-status purposes unless it actually produced
+ * one. `pending` (the panel could not be reached or seated) and any error status
+ * both mean no review happened, and a caller that gates on the exit code -- a
+ * pre-merge hook, CI, an agent -- must not read that as approval. */
+int roundtable_review_response_is_failure(cJSON *resp)
+{
+   if (!resp)
+      return 1;
+   cJSON *art = cJSON_GetObjectItemCaseSensitive(resp, "artifact");
+   if (cJSON_IsString(art) && art->valuestring[0])
+      return 0;
+   return 1;
 }
 
 /* --- kb grant printers. These four commands succeeded but printed NOTHING in text

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -1838,6 +1838,11 @@ static int cli_v1_finish_response(const cli_v1_route_t *route, cJSON *resp, int 
    {
       exit_rc = 1;
    }
+   else if (strcmp(route->method, "roundtable.review") == 0 &&
+            roundtable_review_response_is_failure(resp))
+   {
+      exit_rc = 1;
+   }
 
    if (!effective_json_output && strcmp(route->method, "delegate") == 0)
    {

--- a/src/headers/cli_v1_routes_internal.h
+++ b/src/headers/cli_v1_routes_internal.h
@@ -146,6 +146,10 @@ void pt_print_delegate(const char *method, cJSON *resp);
 void pt_print_delegate_launch(const char *method, cJSON *resp);
 void pt_print_delegate_log(const char *method, cJSON *resp);
 void pt_print_roundtable_review(const char *method, cJSON *resp);
+/* 1 when the response carries no review artifact, so the caller's exit status
+ * reports "no review happened" rather than success. Defined beside the printer
+ * because both answer the same question about the same response. */
+int roundtable_review_response_is_failure(cJSON *resp);
 void pt_print_delegate_status(const char *method, cJSON *resp);
 void pt_print_dogfood_report(const char *method, cJSON *resp);
 void pt_print_dogfood_tag(const char *method, cJSON *resp);

--- a/src/tests/test_cli_v1_delegate.c
+++ b/src/tests/test_cli_v1_delegate.c
@@ -833,6 +833,36 @@ static void test_server_status_route_lookup(void)
    printf("  PASS: test_server_status_route_lookup\n");
 }
 
+/* Asking for a review and not getting one must not look like approval.
+ *
+ * Measured against a real aimee-server with the roundtable module attached: a
+ * review with no saved roundtable came back status=pending,
+ * pause_reason=panel_unreachable, artifact="" -- and `aimee roundtable review`
+ * printed zero bytes and exited 0. A pre-merge hook, CI job or agent gating on
+ * that exit code would have read "no review happened" as "the panel approved
+ * it", which is the one conclusion it must never draw. */
+static void test_roundtable_review_without_an_artifact_is_a_failure(void)
+{
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "pending");
+   cJSON_AddStringToObject(resp, "pause_reason", "panel_unreachable");
+   cJSON_AddStringToObject(resp, "artifact", "");
+   assert(roundtable_review_response_is_failure(resp) == 1);
+
+   /* An actual review is a success, whatever else the envelope carries. */
+   cJSON_ReplaceItemInObject(resp, "artifact", cJSON_CreateString("## Findings\n- one"));
+   assert(roundtable_review_response_is_failure(resp) == 0);
+
+   /* A missing artifact field is the same as an empty one: no review. */
+   cJSON_DeleteItemFromObject(resp, "artifact");
+   assert(roundtable_review_response_is_failure(resp) == 1);
+   cJSON_Delete(resp);
+
+   /* No response at all cannot be an approval either. */
+   assert(roundtable_review_response_is_failure(NULL) == 1);
+   printf("  PASS: a review without an artifact fails\n");
+}
+
 static void test_agent_probe_failure_controls_exit_status(void)
 {
    cJSON *resp = cJSON_CreateObject();
@@ -2080,6 +2110,7 @@ int main(void)
    test_memory_delete_and_supersede_routes();
    test_server_status_route_lookup();
    test_agent_probe_failure_controls_exit_status();
+   test_roundtable_review_without_an_artifact_is_a_failure();
    test_kb_docs_push_route_and_marshal();
    test_kb_remote_status_routes();
    test_git_verify_failure_detection();

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -359,7 +359,7 @@
         },
         {
           "path": "src/headers/cli_v1_routes_internal.h",
-          "sha256": "1c1ca8481ba04ae4ac65aa67e6b7e9cd5161113473a4bb1a29b88bd1e08b8234"
+          "sha256": "bbefaae8a455f6a1f5193ca516635d9753fb96cefbc7062b30b80f4687209d59"
         },
         {
           "path": "src/headers/client_constants.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "55b71462af2056f287e3339bed78eeaf154219a76276db984283597ef684a94d",
+      "sha256": "a351eb0069ba9bf89807214f7e72bf64142eb12e0c1f22bc3ed7963d239be5ab",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
```
$ aimee roundtable review changes.diff --original-request "..."
$ echo $?
0
```

Zero bytes, exit 0. The panel had not reviewed anything.

## What was wrong

The printer rendered only `artifact`, and a review that could not run has none. Everything explaining *why* — `status`, `pause_reason`, `detail` — was dropped, and the exit code said success.

So asking for a review, getting none, and being told nothing was **indistinguishable from an approval**. A pre-merge hook, a CI job or an agent gating on that exit code would draw the one conclusion it must never draw.

## Measured, not theorised

Against a real `aimee-server` with the roundtable module attached, a review with no saved roundtable returns:

```
status=pending   pause_reason=panel_unreachable   artifact=""
detail="no roundtable named: a roundtable review must name a saved roundtable"
```

The server said exactly what was wrong. The CLI threw it away. Now:

```
aimee: roundtable produced no review (pending): panel_unreachable
  no roundtable named: a roundtable review must name a saved roundtable
EXIT=1
```

The exit rule follows the existing precedent for `init.run` / `git.verify` / `agent.probe`: a response carrying no artifact is a failure, because no review happened. Pinned in `test_cli_v1_delegate.c` — including the missing-field and NULL-response cases, neither of which may be read as approval.

## How it was found

Bringing the module up end to end on a second host: built the Go module, installed its generated grant (`principal_ref=21`, `serve=9473,9474,9475`), attached it to a live server's module bus with the agent resource plane wired the way the container entrypoint wires it, then asked for a review.

Worth recording from that exercise — **the module and the review stage work.** The panel refused correctly and said why; only the CLI was silent.

`make lint` 47/47, full unit suite, baselines, pins, descriptors, cleanup-ledger, source-ownership — all clean locally before pushing.

## Operator note, no code change

An install seeded before the review stage existed carries `roundtable.grant` with `serve=9473` only, and cannot serve review (9474). `server-entrypoint.sh` already detects this and warns, and says the failure is otherwise silent. Anyone whose roundtable "does nothing" should check that grant's `serve=` line against the shipped `9473,9474,9475`.
