### PR TITLE
fix: the module supervisor test stops racing its own pid file

### DIFF
--- a/src/tests/support/fake_module_process.sh
+++ b/src/tests/support/fake_module_process.sh
@@ -7,8 +7,12 @@ set -eu
 count=0
 [ ! -r "$AIMEE_TEST_MODULE_COUNT" ] || read -r count < "$AIMEE_TEST_MODULE_COUNT"
 count=$((count + 1))
-printf '%s\n' "$count" > "$AIMEE_TEST_MODULE_COUNT"
+# The count is what the test waits on, so it is published last: once the test
+# can see this start, the pid for that same start is already durable. Bumping
+# the count first would let the test read the pid file while it is still being
+# rewritten (empty) or still holding the previous, dead process's pid.
 printf '%s\n' "$$" > "$AIMEE_TEST_MODULE_PID"
+printf '%s\n' "$count" > "$AIMEE_TEST_MODULE_COUNT"
 
 # The first process simulates an isolated module crash. The supervisor must
 # restart it without involving the daemon or another module.

--- a/src/tests/test_module_supervisor.sh
+++ b/src/tests/test_module_supervisor.sh
@@ -44,7 +44,13 @@ while :; do
     sleep 0.1
 done
 
-read -r restarted_pid < "$module_pid_file"
+restarted_pid=""
+read -r restarted_pid < "$module_pid_file" || true
+[ -n "$restarted_pid" ] || { echo "module-supervisor: restarted module wrote no pid" >&2; exit 1; }
+# The shutdown check below only proves something if this pid is the live
+# restarted child. A dead pid here would make that check pass without testing
+# anything, so refuse to continue on one.
+kill -0 "$restarted_pid" 2>/dev/null || { echo "module-supervisor: restarted module pid $restarted_pid is not alive" >&2; exit 1; }
 kill "$supervisor_pid"
 wait "$supervisor_pid" 2>/dev/null || true
 supervisor_pid=""


### PR DESCRIPTION
`pins` failed on #2415 with no explanation:

```
[module-supervisor:server] starting memory
[module-supervisor:server] memory exited (status 7); restarting
[module-supervisor:server] starting memory
##[error]Process completed with exit code 1
```

134ms after the restart, exit 1, no message. Every timeout branch in that test prints a reason and takes 5s, so it was none of them. #2415 touches only CLI routes, and this test is untouched on that branch.

The same commit `0d9f9cb` **passed** this job on its push event and **failed** it on its pull_request event.

## The race

The test waits on the start-count file, then reads the pid file. The fake module wrote the count *first*:

```sh
printf '%s\n' "$count" > "$AIMEE_TEST_MODULE_COUNT"   # test's wait loop unblocks here
printf '%s\n' "$$"     > "$AIMEE_TEST_MODULE_PID"      # pid written only after
```

Nothing orders those, so `read -r restarted_pid < "$module_pid_file"` can land in two bad places:

1. **Between the pid file's truncate and its write** → empty file → `read` returns non-zero → `set -e` ends the test with a bare `exit 1`. This is the CI failure.
2. **Before the rewrite** → the previous, already-dead pid → `kill -0` is instantly false → the shutdown check passes *without testing anything*.

Mode 2 is the worse one: it is not a flake, it is a silent hole in what the test claims to verify.

## Measured, not theorised

Brute force does not reach it — 60 stock runs idle and 40 under CPU saturation all passed. The window is the microseconds between two `printf`s, against a 100ms poll.

So I widened each window in a scratch copy, leaving the stock test unmodified, and got both modes on demand:

| widened window | stock test result |
|---|---|
| pid-write delayed past the count | `EXIT=0` — passed vacuously on a dead pid |
| truncate/write of the pid file separated | `EXIT=1`, no message — **exactly the CI signature** |

## Fix

Publish the count **last**, so it is the barrier it was already being used as: once a start is visible in the count, that start's pid is already durable. Both widened windows now pass.

Then stop the test trusting that value silently — an unreadable or dead pid fails loudly instead of exiting 1 with no message, or green-lighting a check that proves nothing.

Against a helper that regresses to leaving a stale pid:

```
old test: module-supervisor: ok (crash restarted; child stopped with supervisor)   EXIT=0
new test: module-supervisor: restarted module pid 2438067 is not alive             EXIT=1
```

## Verification

- 40/40 clean on the normal path; both widened-window variants pass.
- Guards confirmed to fire — not dead code (above).
- Other `pins` steps pass locally: `validate_module_process_contracts` (26 components, 17 processes), `check_c_repository_lock` (1 core, 26 modules).
- Run under `dash`, same as the CI runner's `/bin/sh`.
- `shellcheck` is not installed here, so shell lint is **validation-pending** on CI.

Unblocks #2415, which needs no change of its own.
