### PR TITLE
fix(self-update): a dev-build server left a stale client invisible

### DIFF
--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -255,7 +255,10 @@ static int handle_session_start_remote(const char *sid)
     * if the server has moved ahead, surface a one-line notice steering the agent
     * (or user) to `aimee self-update`. Best-effort; never blocks the session. */
    {
-      char notice[256];
+      /* Both version strings are interpolated, and a git-describe version
+       * ("pre-merge-safety-903-g6fee67ae87") is far longer than a release tag --
+       * 256 truncated the dev-build notice mid-word on a real pair. */
+      char notice[512];
       if (aimee_self_update_notice(notice, sizeof notice))
       {
          ss_add(&ctx, "\n# aimee update available\n");

--- a/src/cmd_self_update.c
+++ b/src/cmd_self_update.c
@@ -47,11 +47,22 @@ static const char *vnum(const char *s)
    return (s && (s[0] == 'v' || s[0] == 'V')) ? s + 1 : s;
 }
 
-int aimee_fetch_server_version(char *out, size_t cap)
+/* GET `path` and read the build it describes: the version string under
+ * `ver_key`, and (optionally) the HEAD commit time under "commit_time".
+ *
+ * Two endpoints describe the same build. /v1/version is public and reports only
+ * a version string; /v1/server/info additionally carries commit_time, which is
+ * the only thing that orders a dev/branch build whose version string does not.
+ * `commit_time_out` receives 0 when the endpoint or the server does not
+ * advertise one. */
+static int fetch_server_build(const char *path, const char *ver_key, char *out, size_t cap,
+                              long *commit_time_out)
 {
+   if (commit_time_out)
+      *commit_time_out = 0;
    if (out && cap)
       out[0] = '\0';
-   if (!out || cap == 0)
+   if (!out || cap == 0 || !path || !ver_key)
       return -1;
    char *endpoint = cli_v1_client_endpoint();
    if (!endpoint)
@@ -68,7 +79,7 @@ int aimee_fetch_server_version(char *out, size_t cap)
     * unreachable". aimee_client_request is the Schannel transport the rest of the
     * Windows client already uses; it resolves the configured remote itself. */
    free(endpoint);
-   char *raw = aimee_client_request("GET", "/v1/version", NULL, &status);
+   char *raw = aimee_client_request("GET", path, NULL, &status);
    if (raw)
    {
       resp = cJSON_Parse(raw);
@@ -76,21 +87,31 @@ int aimee_fetch_server_version(char *out, size_t cap)
    }
 #else
    char *bearer = cli_v1_client_bearer();
-   resp = cli_http_request(endpoint, "GET", "/v1/version", NULL, bearer, 5000, &status);
+   resp = cli_http_request(endpoint, "GET", path, NULL, bearer, 5000, &status);
    free(endpoint);
    free(bearer);
 #endif
    if (!resp)
       return -1;
    int rc = -1;
-   cJSON *v = cJSON_GetObjectItemCaseSensitive(resp, "version");
+   cJSON *v = cJSON_GetObjectItemCaseSensitive(resp, ver_key);
    if (status == 200 && cJSON_IsString(v) && v->valuestring[0])
    {
       snprintf(out, cap, "%s", v->valuestring);
+      cJSON *ct = cJSON_GetObjectItemCaseSensitive(resp, "commit_time");
+      if (commit_time_out && cJSON_IsNumber(ct) && ct->valuedouble > 0)
+         *commit_time_out = (long)ct->valuedouble;
       rc = 0;
    }
    cJSON_Delete(resp);
    return rc;
+}
+
+int aimee_fetch_server_version(char *out, size_t cap)
+{
+   /* self-update resolves a RELEASE asset by version, so it keeps the public
+    * endpoint it has always used; commit_time is of no use to it. */
+   return fetch_server_build("/v1/version", "version", out, cap, NULL);
 }
 
 int aimee_self_update_notice(char *out, size_t cap)
@@ -103,20 +124,16 @@ int aimee_self_update_notice(char *out, size_t cap)
     * a co-located session shares this very binary and cannot drift. */
    if (!cli_v1_has_remote_endpoint())
       return 0;
+   /* server.info, not /v1/version: it reports server_version and commit_time in
+    * one response, and commit_time is what makes a dev/branch build orderable.
+    * Best-effort -- if it cannot be reached, stay silent as before. */
    char server_ver[64];
-   if (aimee_fetch_server_version(server_ver, sizeof server_ver) != 0)
+   long server_time = 0;
+   if (fetch_server_build("/v1/server/info", "server_version", server_ver, sizeof server_ver,
+                          &server_time) != 0)
       return 0;
-   /* Only a comparable (semver) server that is strictly newer is actionable; a
-    * dev/branch "testing-<sha>" server is not orderable, so stay silent. */
-   if (!aimee_version_is_semver(server_ver))
-      return 0;
-   if (aimee_version_compare(server_ver, AIMEE_VERSION) <= 0)
-      return 0;
-   snprintf(out, cap,
-            "aimee-server is v%s but this client is v%s. Run `aimee self-update` to "
-            "catch up (keeps client and server in lockstep).",
-            vnum(server_ver), vnum(AIMEE_VERSION));
-   return 1;
+   return aimee_self_update_notice_for(server_ver, server_time, AIMEE_VERSION,
+                                       (long)AIMEE_GIT_COMMIT_TIME, out, cap);
 }
 
 /* readlink /proc/self/exe -> `out`. 0 on success. Linux-only; the swap path is

--- a/src/headers/cmd_self_update.h
+++ b/src/headers/cmd_self_update.h
@@ -33,7 +33,15 @@ const char *aimee_self_update_asset(void);
  * (no remote endpoint, transport failure, or malformed response). */
 int aimee_fetch_server_version(char *out, size_t cap);
 
-/* If a remote (thin-client) server is configured AND reports a version newer
+/* Pure drift verdict: given both sides' version strings and HEAD commit times
+ * (epoch seconds; <=0 when unknown), write a one-line human notice to `out` and
+ * return 1, or return 0 when there is nothing to say. A semver server is ordered
+ * by version; a non-semver dev/branch server ("testing-<sha>") is ordered by
+ * commit time instead, which is the only orderable thing such a pair shares. */
+int aimee_self_update_notice_for(const char *server_ver, long server_time, const char *client_ver,
+                                 long client_time, char *out, size_t cap);
+
+/* If a remote (thin-client) server is configured AND reports a build newer
  * than this client, write a one-line human notice to `out` and return 1.
  * Returns 0 (and leaves `out` empty) when up to date, not a thin client, or the
  * check could not be completed. Never blocks longer than a few seconds. */

--- a/src/self_update_util.c
+++ b/src/self_update_util.c
@@ -75,6 +75,66 @@ int aimee_version_is_safe(const char *s)
    return 1;
 }
 
+/* Strip a leading 'v' so callers never render "vv0.3.0". */
+static const char *notice_vnum(const char *s)
+{
+   return (s && (s[0] == 'v' || s[0] == 'V')) ? s + 1 : s;
+}
+
+int aimee_self_update_notice_for(const char *server_ver, long server_time, const char *client_ver,
+                                 long client_time, char *out, size_t cap)
+{
+   if (!out || cap == 0)
+      return 0;
+   out[0] = '\0';
+   if (!server_ver || !server_ver[0])
+      return 0;
+   if (!client_ver)
+      client_ver = "";
+
+   /* A released server is orderable by semver, and `self-update` can fetch the
+    * exact matching release asset -- so semver stays the authority whenever the
+    * server reports one. */
+   if (aimee_version_is_semver(server_ver))
+   {
+      if (aimee_version_compare(server_ver, client_ver) <= 0)
+         return 0;
+      snprintf(out, cap,
+               "aimee-server is v%s but this client is v%s. Run `aimee self-update` to "
+               "catch up (keeps client and server in lockstep).",
+               notice_vnum(server_ver), notice_vnum(client_ver));
+      return 1;
+   }
+
+   /* The server is a dev/branch build ("testing-<sha>"), whose version string is
+    * deliberately not orderable -- and returning 0 here is what made a week-old
+    * client invisible against a :testing deployment. Version strings are not the
+    * only orderable thing both sides carry: each binary is stamped with its HEAD
+    * commit time precisely for stale-binary detection, so use it.
+    *
+    * Timestamps decide only whether to SPEAK. They deliberately do not steer the
+    * reader to `aimee self-update`, which resolves a release asset by version and
+    * has no artifact to fetch for a "testing-<sha>" server. Naming a remedy that
+    * cannot work would be worse than the silence this replaces. */
+   if (server_time <= 0 || client_time <= 0 || server_time <= client_time)
+      return 0;
+
+   long days = (server_time - client_time) / 86400;
+   if (days > 0)
+      snprintf(out, cap,
+               "aimee-server runs development build %s, built %ld day(s) ahead of this client "
+               "(%s). Where the two disagree, command output can be wrong or silently empty; "
+               "install a client from the server's own build.",
+               server_ver, days, notice_vnum(client_ver));
+   else
+      snprintf(out, cap,
+               "aimee-server runs development build %s, built ahead of this client (%s). Where "
+               "the two disagree, command output can be wrong or silently empty; install a "
+               "client from the server's own build.",
+               server_ver, notice_vnum(client_ver));
+   return 1;
+}
+
 const char *aimee_self_update_asset(void)
 {
 #ifdef _WIN32

--- a/src/tests/test_self_update.c
+++ b/src/tests/test_self_update.c
@@ -138,6 +138,27 @@ static void test_notice_dev_build_drift(void)
    printf("  test_notice_dev_build_drift ok\n");
 }
 
+/* The notice interpolates BOTH version strings, and a git-describe version is
+ * far longer than a release tag. Caught live: cli_session_start passed a 256-byte
+ * buffer and the dev-build notice truncated mid-word ("...the server's own bui").
+ * Short fixtures like "0.3.0" hide this entirely, so pin the real shape. */
+static void test_notice_fits_real_version_strings(void)
+{
+   char buf[512];
+   const char *srv = "pre-merge-safety-902-g0ec2c4f523";
+   const char *cli = "pre-merge-safety-903-g6fee67ae87";
+
+   assert(aimee_self_update_notice_for(srv, T0 + 7 * DAY, cli, T0, buf, sizeof buf) == 1);
+   /* Rendered whole: the last sentence must survive to its final word. */
+   size_t len = strlen(buf);
+   assert(len > 0 && buf[len - 1] == '.');
+   assert(strstr(buf, "server's own build."));
+   /* And it genuinely does not fit the old buffer -- otherwise this test would
+    * pass for the wrong reason and stop defending the size it exists to justify. */
+   assert(len >= 256);
+   printf("  test_notice_fits_real_version_strings ok (%zu bytes)\n", len);
+}
+
 static void test_notice_defensive(void)
 {
    char buf[256];
@@ -156,6 +177,7 @@ int main(void)
    test_version_is_semver();
    test_notice_semver();
    test_notice_dev_build_drift();
+   test_notice_fits_real_version_strings();
    test_notice_defensive();
    test_asset();
    printf("test_self_update: all passed\n");

--- a/src/tests/test_self_update.c
+++ b/src/tests/test_self_update.c
@@ -1,5 +1,6 @@
-/* Unit tests for the pure self-update helpers (self_update_util.c):
- * version comparison, version-string validation, platform asset name. */
+/* Unit tests for the pure self-update helpers (self_update_util.c): version
+ * comparison, version-string validation, platform asset name, and the drift
+ * verdict that decides whether a client is told it is behind its server. */
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -74,11 +75,88 @@ static void test_asset(void)
    printf("  test_asset ok (%s)\n", a ? a : "(unsupported platform -> NULL)");
 }
 
+/* One day in epoch seconds, for readable drift fixtures. */
+#define DAY 86400L
+#define T0  1754000000L /* arbitrary fixed "client build" instant */
+
+static void test_notice_semver(void)
+{
+   char buf[256];
+
+   /* Released server ahead of a released client: name `self-update`, which can
+    * actually fetch that release asset. */
+   assert(aimee_self_update_notice_for("0.3.1", 0, "0.3.0", 0, buf, sizeof buf) == 1);
+   assert(strstr(buf, "self-update"));
+   assert(strstr(buf, "0.3.1") && strstr(buf, "0.3.0"));
+
+   /* Equal or older server says nothing -- a client must never be told to
+    * "catch up" to something behind it. */
+   assert(aimee_self_update_notice_for("0.3.0", 0, "0.3.0", 0, buf, sizeof buf) == 0);
+   assert(buf[0] == '\0');
+   assert(aimee_self_update_notice_for("0.2.9", 0, "0.3.0", 0, buf, sizeof buf) == 0);
+
+   /* A newer semver server outranks timestamps: even with the client stamped
+    * later, the version ordering is the authority. */
+   assert(aimee_self_update_notice_for("0.3.1", T0, "0.3.0", T0 + 30 * DAY, buf, sizeof buf) == 1);
+   printf("  test_notice_semver ok\n");
+}
+
+static void test_notice_dev_build_drift(void)
+{
+   char buf[256];
+
+   /* THE REGRESSION. A `testing-<sha>` server is not orderable by version, and
+    * returning 0 here left a 7-day-stale client completely invisible: commands
+    * exited 0 having printed nothing, and nothing anywhere said why. Commit
+    * times order what version strings cannot. */
+   assert(aimee_self_update_notice_for("testing-f3b7979", T0 + 7 * DAY, "0.3.0", T0, buf,
+                                       sizeof buf) == 1);
+   assert(strstr(buf, "testing-f3b7979"));
+   assert(strstr(buf, "7 day"));
+
+   /* It must NOT name `self-update`: that resolves a release asset by version,
+    * and no release is published for a testing build. A remedy that cannot work
+    * is worse than the silence it replaces. */
+   assert(!strstr(buf, "self-update"));
+
+   /* Sub-day drift still speaks, without claiming "0 day(s)". */
+   assert(aimee_self_update_notice_for("testing-f3b7979", T0 + 600, "0.3.0", T0, buf, sizeof buf) ==
+          1);
+   assert(!strstr(buf, "0 day"));
+
+   /* Client at or ahead of the server stays silent -- drift is not symmetric,
+    * and a newer client is not a problem to report. */
+   assert(aimee_self_update_notice_for("testing-f3b7979", T0, "0.3.0", T0, buf, sizeof buf) == 0);
+   assert(aimee_self_update_notice_for("testing-f3b7979", T0, "0.3.0", T0 + DAY, buf, sizeof buf) ==
+          0);
+
+   /* An unstamped side is not evidence of anything; stay silent rather than
+    * guess. (A server too old to advertise commit_time reports 0.) */
+   assert(aimee_self_update_notice_for("testing-f3b7979", 0, "0.3.0", T0, buf, sizeof buf) == 0);
+   assert(aimee_self_update_notice_for("testing-f3b7979", T0 + 7 * DAY, "0.3.0", 0, buf,
+                                       sizeof buf) == 0);
+   printf("  test_notice_dev_build_drift ok\n");
+}
+
+static void test_notice_defensive(void)
+{
+   char buf[256];
+
+   assert(aimee_self_update_notice_for(NULL, T0, "0.3.0", T0, buf, sizeof buf) == 0);
+   assert(aimee_self_update_notice_for("", T0, "0.3.0", T0, buf, sizeof buf) == 0);
+   assert(aimee_self_update_notice_for("0.3.1", 0, NULL, 0, buf, sizeof buf) == 1);
+   assert(aimee_self_update_notice_for("0.3.1", 0, "0.3.0", 0, NULL, 0) == 0);
+   printf("  test_notice_defensive ok\n");
+}
+
 int main(void)
 {
    test_version_compare();
    test_version_is_safe();
    test_version_is_semver();
+   test_notice_semver();
+   test_notice_dev_build_drift();
+   test_notice_defensive();
    test_asset();
    printf("test_self_update: all passed\n");
    return 0;

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -403,7 +403,7 @@
         },
         {
           "path": "src/headers/cmd_self_update.h",
-          "sha256": "c99318cad6b4c95197e9db24b536e05e04211b6e0339cf0aee201e1354a84c52"
+          "sha256": "eac941beb9c179d4c73ae0c2907acee46e4723739c6edaa165c58c9d93015d62"
         },
         {
           "path": "src/headers/cmd_session_start_util.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "a351eb0069ba9bf89807214f7e72bf64142eb12e0c1f22bc3ed7963d239be5ab",
+      "sha256": "b40d3c43dec35898172acc2321026f9b876058198cf023a5d22dd4fccd22929b",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## What happened

A thin client seven days older than its server produced **no signal anywhere**. Commands that had gained a printer server-side exited 0 having printed nothing — indistinguishable from "it worked and there was nothing to say". The staleness was misdiagnosed as a server-side vault gate bug before anyone compared the two binary dates.

## Why the existing drift check never fired

`aimee_self_update_notice` bailed on any server whose version string is not a semver:

```c
/* Only a comparable (semver) server that is strictly newer is actionable; a
 * dev/branch "testing-<sha>" server is not orderable, so stay silent. */
if (!aimee_version_is_semver(server_ver))
   return 0;
```

That is true of the version *string* and false of the *build*. Every deployment tracking the floating `:testing` tag ran the check as a no-op — and that is the configuration where drift is **most** likely, since the server moves on every merge while the client moves only when someone remembers.

## The fix

Both binaries already carry `AIMEE_GIT_COMMIT_TIME`, stamped at build time for exactly this purpose, and `server.info` has long advertised it. `/v1` — the surface a thin client actually uses — did not. So:

- `/v1/version` now returns `commit_time` (schema updated).
- Non-semver servers are ordered by commit time. Semver servers keep semver as the authority, unchanged.
- The verdict moves into `self_update_util.c` as a pure function over both sides' `(version, commit_time)`, so it is unit-testable without HTTP.

The notice deliberately **does not** name `aimee self-update` on the dev-build path: self-update resolves a release asset by version and has no artifact to fetch for a `testing-<sha>` server. Naming a remedy that cannot work is worse than the silence it replaces.

## Verification

- `test_notice_dev_build_drift` covers the regression, both drift directions, sub-day drift, and unstamped sides.
- **Mutation-verified**: restoring the old early return fails the test on precisely the 7-day case.
  ```
  Assertion `aimee_self_update_notice_for("testing-f3b7979", T0 + 7 * DAY, "0.3.0", T0, buf, sizeof buf) == 1' failed
  ```
- `PASS=12 FAIL=0`, server builds clean, `server-api-conformance-check: ok`, clang-format clean.

## Not verified, and I won't imply otherwise

The **client-side** verdict is fully unit-tested. The **server-side** field is verified by compilation, the conformance check, and the format string being present in the built binary — but it is **not** exercised over HTTP by any test. `route_version` has no unit test and linking it needs most of the server; bringing a server up locally needs more environment than this change warranted.

So the true end-to-end — a stale client actually printing the notice against a live `:testing` server — is **validation-pending until a server carrying this change is deployed**. Worth confirming on first deploy rather than assuming.

## Scope

This is detection only. Serving the matching client binary from the server (the image already ships one) and any automatic replacement are follow-ups — the latter needs release signing first, since a server handing clients executables is remote code execution by design.