### PR TITLE
ci(testing): publish the thin client beside the images it talks to

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -135,3 +135,59 @@ jobs:
           tags: |
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}
+
+  # The thin client, published on the SAME cadence as the images it talks to.
+  #
+  # Without this the only obtainable client is the last GitHub Release, so a
+  # :testing deployment moves on every merge while its operators stay pinned to
+  # a release that can be weeks behind. That gap is not hypothetical: it is how a
+  # client seven days behind its server ended up rendering nothing for commands
+  # whose printers existed only server-side, and it cost a day of misdiagnosis
+  # before anyone compared build dates.
+  #
+  # ARTIFACTS, NOT A RELEASE. release-thin-client.yml is reusable-only precisely
+  # so every published Release passes the protected `release` environment; adding
+  # a Release here would route around that approval. Fetch with:
+  #   gh run download --repo <owner>/aimee -n aimee-linux-x86_64 --dir .
+  #
+  # LINUX ONLY, deliberately. macOS and Windows runners cost minutes per merge and
+  # this job runs on every push to testing; the release pipeline still owns those
+  # two platforms. Adding a leg here is a matrix entry if that trade stops holding.
+  thin-client:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: aimee-linux-x86_64
+          - os: ubuntu-24.04-arm
+            asset: aimee-linux-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deps
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q gcc make libsqlite3-dev
+
+      # Stamp the version the SERVER images in this same run are stamped with, so
+      # a client and the server it was published beside report the same build.
+      # The Makefile derives AIMEE_GIT_COMMIT_TIME from HEAD itself; that stamp is
+      # what orders a non-semver `testing-<sha>` pair, so it must not be bypassed.
+      - name: Build thin client
+        run: |
+          cd src
+          make -j"$(nproc)" GIT_VERSION="testing-${GITHUB_SHA::7}" ../aimee
+
+      - name: Stage + smoke test
+        run: |
+          cp aimee "${{ matrix.asset }}"
+          ./${{ matrix.asset }} version
+
+      - name: Upload ${{ matrix.asset }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+          retention-days: 30


### PR DESCRIPTION
## Why

The only obtainable thin client is the last GitHub Release, while a `:testing` deployment moves on **every merge**. Operators therefore run a client that can be weeks behind their server, with no way to close the gap short of cutting a release.

Not hypothetical — this is the root cause of today's detour. A client seven days behind its server rendered **nothing at all** for commands whose printers existed only server-side: exit 0, no output, no signal. It was misdiagnosed first as a vault gate bug, then as a remote read-scoping gap, before anyone compared the two build dates.

#2417 makes that drift *detectable*. Detection only helps if a current client can actually be **fetched** — which is this PR.

## What

A `thin-client` job on the same trigger as the images:

```
gh run download --repo <owner>/aimee -n aimee-linux-x86_64 --dir .
```

- **Artifacts, not a Release.** `release-thin-client.yml` is reusable-only precisely so every published Release passes the protected `release` environment. Publishing a Release here would route around that approval, so this uploads workflow artifacts instead (30-day retention).
- **Same version stamp** as the server images in the same run (`testing-<sha7>`), so a matched pair reports one build string. `AIMEE_GIT_COMMIT_TIME` still comes from HEAD via the Makefile — that stamp is what orders a non-semver pair, so it must not be bypassed.
- **Linux x86_64 + arm64 only.** macOS and Windows runners cost minutes on every push to `testing`; the release pipeline still owns those two. Adding a leg is one matrix entry if that trade stops holding.

## Verification

- Workflow YAML parses; job/matrix/steps confirmed.
- The build invocation is verified locally, not assumed: `make GIT_VERSION="testing-abc1234" ../aimee` produces a client reporting `aimee testing-abc1234`.
- The `ubuntu-24.04-arm` runner label and the `gcc make libsqlite3-dev` dependency set are copied from `release-thin-client.yml`, which already builds this target on both Linux legs.

**Not verified:** the job itself has never run — that only happens on merge to `testing`, since the trigger is a push to that branch. First run is the real check; if a leg fails it fails in isolation (`fail-fast: false`) and publishes no image, because the image `build` job is independent of it.