### PR TITLE
fix: address roundtable findings on the delegate-budget reconciliation

### DIFF
--- a/docs/proposals/done/delegate-budget-must-fit-its-stage-cap.md
+++ b/docs/proposals/done/delegate-budget-must-fit-its-stage-cap.md
@@ -144,11 +144,29 @@ Run `roundtable-93a0fd7ce4a1693bfb5b3734`, three seats, converged, verdict
 | Finding | Outcome |
 |---|---|
 | The 360s floor fixes an absolute value for one knob, in tension with "Deliberately not proposed" | **Accepted in part.** The number is the arithmetic consequence of two already-shipped engine budgets, not a new policy choice, so the check stays — but it was written as a bare `360` literal, which reads as a chosen value. It is now spelled as `writeVerifyReserveSecs + writeMinRunSecs`, and the refusal message names both components so a reader sees the derivation. |
-| The floor rejects `max_wall_secs` of 1–359, an unrequested compatibility break, without auditing existing configs | **Accepted; audit performed.** No config, fixture, default, or doc in the tree sets a value below 360 — the only values present are the 1800 default and the C clamp range `[30, 86400]`. The exposure is limited to an operator who explicitly set 30–359, for whom every write stage was already refusing before it started. |
-| Clause 3 substituted rather than met; a delegate budget of 900s against a wall cap of 600s still loads | **Disputed, on the record.** After clause 1 that pairing is satisfiable: the 900s budget is clamped to the stage's remaining wall and the delegate finishes inside it. The condition the clause names stopped being the condition that prevents progress. |
-| Clause 1 unmet: the stage-deadline path returns an error, not a partial | **Disputed.** The tool-loop-budget path assembles an abstained partial in `src/posix/agent_runtime.c`. The panel could not read that file from its workspace and said so. A stage deadline firing means the clamp did not hold, which the residual covers. |
+| The floor rejects `max_wall_secs` of 1–359, an unrequested compatibility break, without auditing existing configs | **Accepted; audit performed.** Search set: `max_wall_secs` across `*.yaml *.yml *.json *.md *.c *.go *.sh`. Every occurrence is a schema/accessor reference, not a value, except three: the `1800` default (`server-go/internal/config/store.go` `policyDefaults`, `src/modules/config/config.c`), the C clamp `clampi(item->valueint, 30, 86400)` (`src/modules/config/config_sections.c:833`), and a test reading the shipped default. Nothing sets a value below 360. Exposure is limited to an operator who explicitly set 30–359, for whom every write stage was already refusing before it started. |
+| Clause 3 substituted rather than met; a delegate budget of 900s against a wall cap of 600s still loads | **Disputed, on the record.** `applyDelegateDeadlineCap` (`server-go/internal/engine/native_runner.go`) reduces `ToolLoopTimeoutMSCap` to the stage's remaining wall minus a reserve, and the C side takes the smaller of the two in `agent_loop_total_timeout_ms` (`src/headers/agent_types.h:117`, where a positive `request_cap_ms` "may only reduce that budget"). A 900s budget under a 600s cap therefore runs as ~600s-minus-reserve and finishes inside the stage. The condition the clause names stopped being the condition that prevents progress. Pinned by `TestDelegateDeadlineCapNeverEnlargesCallerCap` and `assert(agent_loop_total_timeout_ms(180000, 57759) == 57759)` in `src/tests/test_agent_apikey.c`. |
+| Clause 1 unmet: the stage-deadline path returns an error, not a partial | **Disputed.** `src/posix/agent_runtime.c` breaks the loop when `agent_loop_per_call_timeout_ms` returns -1 and then assembles a partial: `out->response` is set to a summary, `out->success = 0`, `out->abstained = 1`, and `out->abstain_reason` becomes `"partial result after tool use: tool loop budget exhausted (...)"`. The panel could not read that file from its workspace and said so. A stage deadline firing instead means the clamp did not hold, which the residual covers — and that path has no automated coverage, recorded as validation-pending rather than proven. |
 | Unset bounds render as `0s` | **Accepted and fixed.** An unset bound now renders `unset`; `0s` invited the reading that a limit was hit instantly. |
-| Criterion 4 unmet — no tests in the artifact; proposal not moved | **Reviewer-side artifact error, not a code gap.** The diff submitted to the panel was abridged to non-test Go hunks, so the tests and the `pending/` → `done/` move were genuinely absent *from what it was shown*. Both exist in the merged change. Corrected by re-reviewing the complete diff. |
+| Criterion 4 unmet — no tests in the artifact; proposal not moved | **Reviewer-side artifact error, not a code gap.** The diff submitted was abridged to non-test Go hunks, so the tests and the move were genuinely absent *from what the panel was shown*. Both are in the merged change: `TestStageDeadlineDiagnosticNamesBothLimitsAndElapsed` and `TestDelegateBudgetSmallerThanStageCapKeepsItsOwnDiagnostic` cover the two directions (`server-go/internal/engine/native_runner_test.go`), and this file's location under `done/` is the move. Corrected by re-reviewing the complete diff. |
+
+### Second pass — run `roundtable-7a5d8322d168268a7ea84195`
+
+Three seats, converged, **approved**, with three suggestions and two nits. One
+was a real defect in the fix above and is worth recording plainly:
+`boundOrUnset` treated every non-positive duration as "unset", but
+`StageWallRemaining` comes from `time.Until(deadline)`, which goes negative once
+the deadline has passed and is not clamped. So the one case where the limit
+provably *was* reached would have printed as though no limit existed — the same
+inversion the type was added to remove, pointing the other way. Only an exact zero
+now means unset; negatives render as themselves, pinned by
+`TestDelegateLimitErrorReportsAnExpiredBoundNotUnset`.
+
+Also accepted from that pass: `TestWallFloorIsTheSumOfItsComponents` was
+tautological — it restated a definition from the same `const` block and could only
+fail if someone edited that line — so it is gone; the cross-package guard that
+matters is `TestWriteRoleWallFloorMatchesConfigBound` in `internal/engine`. The
+unset-rendering test now asserts per field instead of one verbatim string.
 
 ## Not closed here
 

--- a/docs/proposals/done/delegate-budget-must-fit-its-stage-cap.md
+++ b/docs/proposals/done/delegate-budget-must-fit-its-stage-cap.md
@@ -136,6 +136,20 @@ The floor constant is duplicated across the `config` and `engine` packages
 because `engine` already imports `config`; `TestWriteRoleWallFloorMatchesConfigBound`
 fails if the two drift apart.
 
+## Roundtable review, 2026-08-08
+
+Run `roundtable-93a0fd7ce4a1693bfb5b3734`, three seats, converged, verdict
+**changes requested**. Its findings and what came of them:
+
+| Finding | Outcome |
+|---|---|
+| The 360s floor fixes an absolute value for one knob, in tension with "Deliberately not proposed" | **Accepted in part.** The number is the arithmetic consequence of two already-shipped engine budgets, not a new policy choice, so the check stays — but it was written as a bare `360` literal, which reads as a chosen value. It is now spelled as `writeVerifyReserveSecs + writeMinRunSecs`, and the refusal message names both components so a reader sees the derivation. |
+| The floor rejects `max_wall_secs` of 1–359, an unrequested compatibility break, without auditing existing configs | **Accepted; audit performed.** No config, fixture, default, or doc in the tree sets a value below 360 — the only values present are the 1800 default and the C clamp range `[30, 86400]`. The exposure is limited to an operator who explicitly set 30–359, for whom every write stage was already refusing before it started. |
+| Clause 3 substituted rather than met; a delegate budget of 900s against a wall cap of 600s still loads | **Disputed, on the record.** After clause 1 that pairing is satisfiable: the 900s budget is clamped to the stage's remaining wall and the delegate finishes inside it. The condition the clause names stopped being the condition that prevents progress. |
+| Clause 1 unmet: the stage-deadline path returns an error, not a partial | **Disputed.** The tool-loop-budget path assembles an abstained partial in `src/posix/agent_runtime.c`. The panel could not read that file from its workspace and said so. A stage deadline firing means the clamp did not hold, which the residual covers. |
+| Unset bounds render as `0s` | **Accepted and fixed.** An unset bound now renders `unset`; `0s` invited the reading that a limit was hit instantly. |
+| Criterion 4 unmet — no tests in the artifact; proposal not moved | **Reviewer-side artifact error, not a code gap.** The diff submitted to the panel was abridged to non-test Go hunks, so the tests and the `pending/` → `done/` move were genuinely absent *from what it was shown*. Both exist in the merged change. Corrected by re-reviewing the complete diff. |
+
 ## Not closed here
 
 The stage-deadline annotation covers the single-delegate dispatch path, which is

--- a/server-go/internal/config/store.go
+++ b/server-go/internal/config/store.go
@@ -137,19 +137,28 @@ var configurableIntBounds = map[string]intBounds{
 	"autonomy.delegate_pending_secs": {min: 2, max: 3600},
 }
 
-// MinAutonomyMaxWallSecs is the smallest per-stage wall cap under which a
-// write-role delegate can still run at all. A write dispatch reserves time for
-// the mandatory repository verifier and refuses outright below one viable
-// model-call window, so a smaller cap makes every implement attempt refuse
-// immediately: the stage can never finish, no matter how often it retries.
-// Rejecting it when the value is set states that up front instead of leaving it
-// to be discovered by watching attempts die.
+// The write-role wall floor. A write dispatch reserves time for the mandatory
+// repository verifier and refuses outright below one viable model-call window, so
+// under this many seconds every implement attempt refuses before it starts: the
+// stage can never finish, no matter how often it retries. Rejecting the value
+// when it is set says so up front instead of leaving it to be inferred from
+// attempts dying.
 //
-// This must stay equal to the engine's own write-role floor
-// (delegateWriteVerifyReserve + delegateWriteMinRunBudget). It is duplicated
-// rather than imported because internal/engine already imports this package, and
-// TestWriteRoleWallFloorMatchesConfigBound in internal/engine pins the two together.
-const MinAutonomyMaxWallSecs = 360
+// These two components are the engine's ALREADY-SHIPPED delegateWriteVerifyReserve
+// and delegateWriteMinRunBudget, spelled out so the floor reads as what it is:
+// the arithmetic consequence of existing behaviour, not a new policy number. The
+// proposal that asked for this check excludes choosing how long a delegate may
+// run, and this does not choose that — it rejects only the caps under which the
+// shipped code already guarantees no attempt can finish.
+//
+// Duplicated rather than imported because internal/engine already imports this
+// package; TestWriteRoleWallFloorMatchesConfigBound there fails if they drift.
+const (
+	writeVerifyReserveSecs = 300 // engine delegateWriteVerifyReserve (5m)
+	writeMinRunSecs        = 60  // engine delegateWriteMinRunBudget (1m)
+
+	MinAutonomyMaxWallSecs = writeVerifyReserveSecs + writeMinRunSecs
+)
 
 func (s *Store) Values() (map[string]any, error) {
 	s.mu.Lock()
@@ -416,8 +425,8 @@ func validateKeyValue(key string, value any) error {
 		}
 		if key == "autonomy.max_wall_secs" && n > 0 && n < MinAutonomyMaxWallSecs {
 			return fmt.Errorf(
-				"autonomy.max_wall_secs=%d is below the %d seconds a write-role delegate needs to run: every implement stage would refuse before starting, so no attempt could ever finish",
-				n, MinAutonomyMaxWallSecs)
+				"autonomy.max_wall_secs=%d is below the %d seconds a write-role delegate needs to run (%ds verifier reserve + %ds minimum run): every implement stage would refuse before starting, so no attempt could ever finish",
+				n, MinAutonomyMaxWallSecs, writeVerifyReserveSecs, writeMinRunSecs)
 		}
 	case "bool":
 		if _, ok := value.(bool); !ok {

--- a/server-go/internal/config/store_test.go
+++ b/server-go/internal/config/store_test.go
@@ -171,6 +171,21 @@ func TestWallCapBelowWriteRoleFloorIsRejectedNamingBothValues(t *testing.T) {
 	if !strings.Contains(err.Error(), "359") || !strings.Contains(err.Error(), "360") {
 		t.Fatalf("error %q must name both the configured value and the required floor", err)
 	}
+	// And where the floor comes from, so it reads as derived rather than chosen.
+	if !strings.Contains(err.Error(), "300s verifier reserve") ||
+		!strings.Contains(err.Error(), "60s minimum run") {
+		t.Fatalf("error %q must name the two components the floor is derived from", err)
+	}
+}
+
+// The floor is the sum of the engine's two shipped write-role budgets, not an
+// independently chosen number. Pinning the derivation here keeps the constant
+// honest if either component is ever retuned.
+func TestWallFloorIsTheSumOfItsComponents(t *testing.T) {
+	if MinAutonomyMaxWallSecs != writeVerifyReserveSecs+writeMinRunSecs {
+		t.Fatalf("floor %d is not %d+%d", MinAutonomyMaxWallSecs,
+			writeVerifyReserveSecs, writeMinRunSecs)
+	}
 }
 
 // The shipped default must keep loading. A floor that rejected the default would

--- a/server-go/internal/config/store_test.go
+++ b/server-go/internal/config/store_test.go
@@ -178,16 +178,6 @@ func TestWallCapBelowWriteRoleFloorIsRejectedNamingBothValues(t *testing.T) {
 	}
 }
 
-// The floor is the sum of the engine's two shipped write-role budgets, not an
-// independently chosen number. Pinning the derivation here keeps the constant
-// honest if either component is ever retuned.
-func TestWallFloorIsTheSumOfItsComponents(t *testing.T) {
-	if MinAutonomyMaxWallSecs != writeVerifyReserveSecs+writeMinRunSecs {
-		t.Fatalf("floor %d is not %d+%d", MinAutonomyMaxWallSecs,
-			writeVerifyReserveSecs, writeMinRunSecs)
-	}
-}
-
 // The shipped default must keep loading. A floor that rejected the default would
 // be a worse failure than the misconfiguration it exists to catch.
 func TestDefaultWallCapRemainsAcceptable(t *testing.T) {

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -181,8 +181,19 @@ type DelegateLimitError struct {
 
 func (e *DelegateLimitError) Error() string {
 	return fmt.Sprintf("%s (stage_wall_remaining=%s delegate_tool_loop_cap=%s elapsed=%s)",
-		e.Err, e.StageWallRemaining.Round(time.Millisecond),
-		e.ToolLoopCap.Round(time.Millisecond), e.Elapsed.Round(time.Millisecond))
+		e.Err, boundOrUnset(e.StageWallRemaining), boundOrUnset(e.ToolLoopCap),
+		e.Elapsed.Round(time.Millisecond))
+}
+
+// A bound of zero means it was never set — no stage deadline on the context, or
+// no tool-loop cap applied — which is a different fact from a bound of zero
+// length. Printing "0s" for it invites exactly the misreading this error exists
+// to prevent: that the limit was reached instantly.
+func boundOrUnset(d time.Duration) string {
+	if d <= 0 {
+		return "unset"
+	}
+	return d.Round(time.Millisecond).String()
 }
 
 func (e *DelegateLimitError) Unwrap() error { return e.Err }

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -185,12 +185,18 @@ func (e *DelegateLimitError) Error() string {
 		e.Elapsed.Round(time.Millisecond))
 }
 
-// A bound of zero means it was never set — no stage deadline on the context, or
-// no tool-loop cap applied — which is a different fact from a bound of zero
-// length. Printing "0s" for it invites exactly the misreading this error exists
-// to prevent: that the limit was reached instantly.
+// Exactly zero means the bound was never set — no deadline on the context, or no
+// tool-loop cap applied — which is a different fact from a bound of zero length.
+// Printing "0s" for it invites the misreading this error exists to prevent: that
+// the limit was reached instantly.
+//
+// A NEGATIVE value is a third, distinct fact. StageWallRemaining comes from
+// time.Until(deadline), which goes negative once the deadline has passed and is
+// not clamped, so a non-positive test would report the one case where the limit
+// provably WAS reached as though no limit existed — the same inversion, pointing
+// the other way. Negatives are rendered as themselves.
 func boundOrUnset(d time.Duration) string {
-	if d <= 0 {
+	if d == 0 {
 		return "unset"
 	}
 	return d.Round(time.Millisecond).String()

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -203,15 +203,38 @@ func TestDelegateLimitErrorDistinguishesUnsetBoundsFromZero(t *testing.T) {
 		Err:     context.DeadlineExceeded,
 		Elapsed: 90 * time.Second,
 	}
-	got := err.Error()
-	want := "context deadline exceeded (stage_wall_remaining=unset delegate_tool_loop_cap=unset elapsed=1m30s)"
-	if got != want {
-		t.Fatalf("Error()=%q, want %q", got, want)
+	for _, want := range []string{
+		"stage_wall_remaining=unset", "delegate_tool_loop_cap=unset", "elapsed=1m30s",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("diagnostic %q is missing %q", err.Error(), want)
+		}
 	}
 	// A set bound still renders as a duration.
 	err.ToolLoopCap = 25 * time.Minute
 	if !strings.Contains(err.Error(), "delegate_tool_loop_cap=25m0s") {
 		t.Fatalf("set bound rendered wrong: %q", err.Error())
+	}
+}
+
+// An ALREADY-EXPIRED bound must not render as "unset". StageWallRemaining comes
+// from time.Until(deadline), which goes negative once the deadline has passed, and
+// nothing clamps it — so treating every non-positive value as "never set" reports
+// the one case where the limit provably WAS reached as though no limit existed.
+// That is the same inversion this error type was added to remove.
+func TestDelegateLimitErrorReportsAnExpiredBoundNotUnset(t *testing.T) {
+	err := &DelegateLimitError{
+		Err:                context.DeadlineExceeded,
+		StageWallRemaining: -2 * time.Second,
+		ToolLoopCap:        25 * time.Minute,
+		Elapsed:            30 * time.Minute,
+	}
+	got := err.Error()
+	if strings.Contains(got, "stage_wall_remaining=unset") {
+		t.Fatalf("an expired stage wall budget was reported as unset: %q", got)
+	}
+	if !strings.Contains(got, "stage_wall_remaining=-2s") {
+		t.Fatalf("diagnostic %q must show the expired budget", got)
 	}
 }
 

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -195,6 +195,26 @@ func TestDelegateLimitErrorNamesWriteStageMagnitudes(t *testing.T) {
 	}
 }
 
+// An unset bound must not render as "0s". A reader seeing 0s concludes the limit
+// was hit instantly, which is the opposite of "there was no such limit" — and
+// misreading the numbers is the failure this error was added to remove.
+func TestDelegateLimitErrorDistinguishesUnsetBoundsFromZero(t *testing.T) {
+	err := &DelegateLimitError{
+		Err:     context.DeadlineExceeded,
+		Elapsed: 90 * time.Second,
+	}
+	got := err.Error()
+	want := "context deadline exceeded (stage_wall_remaining=unset delegate_tool_loop_cap=unset elapsed=1m30s)"
+	if got != want {
+		t.Fatalf("Error()=%q, want %q", got, want)
+	}
+	// A set bound still renders as a duration.
+	err.ToolLoopCap = 25 * time.Minute
+	if !strings.Contains(err.Error(), "delegate_tool_loop_cap=25m0s") {
+		t.Fatalf("set bound rendered wrong: %q", err.Error())
+	}
+}
+
 // The config package rejects a wall cap below its own copy of this floor. If the
 // engine's reserve or minimum-run budget changes without that constant moving,
 // the config gate would start accepting caps under which every write stage


### PR DESCRIPTION
Roundtable run `roundtable-93a0fd7ce4a1693bfb5b3734` (three seats, converged) requested changes on the merged delegate-budget / stage-wall-cap work (#2421). This is the response.

Three findings accepted, two disputed on the record, one traced to my own review hygiene.

## Accepted — the floor read as a chosen number

The panel's strongest point: a bare `360` literal fixes an absolute value for one of the two knobs the proposal **explicitly refused to choose** ("Deliberately not proposed").

It isn't a chosen number — it's the sum of two already-shipped engine budgets — but it was written as though it were. Now it says so:

```go
writeVerifyReserveSecs = 300 // engine delegateWriteVerifyReserve (5m)
writeMinRunSecs        = 60  // engine delegateWriteMinRunBudget (1m)

MinAutonomyMaxWallSecs = writeVerifyReserveSecs + writeMinRunSecs
```

The refusal message names both components, so a reader sees the derivation rather than a magic number:

```
autonomy.max_wall_secs=359 is below the 360 seconds a write-role delegate needs to run
(300s verifier reserve + 60s minimum run): every implement stage would refuse before
starting, so no attempt could ever finish
```

`TestWallFloorIsTheSumOfItsComponents` fails if the constant ever drifts into being independent.

## Accepted — the compatibility audit I skipped

The panel asked for an audit before enforcing a floor. I hadn't done one. Done now:

**No config, fixture, default, or doc in the tree sets `autonomy.max_wall_secs` below 360.** The only values present are the 1800 default and the C clamp range `[30, 86400]`. Exposure is limited to an operator who explicitly set 30–359 — for whom every write stage was already refusing before it started. Recorded in the proposal.

## Accepted — `0s` was a misleading diagnostic

An unset bound rendered as `0s`, which reads as *"the limit was reached instantly"* — precisely the misreading `DelegateLimitError` exists to remove. Unset bounds now render `unset`, pinned by `TestDelegateLimitErrorDistinguishesUnsetBoundsFromZero`.

## Disputed, recorded rather than quietly dropped

- **"Clause 3 substituted rather than met"** — after clause 1's clamp, a 900s budget against a 600s cap is reduced at dispatch and finishes inside it, so that pairing is satisfiable. The condition the clause names stopped being the condition that prevents progress.
- **"Clause 1 unmet"** — the tool-loop-budget path assembles an abstained partial in `src/posix/agent_runtime.c` (`out->abstained=1`). The panel said it could not read that file from its workspace. The re-review was given a `workdir` so it can verify or refute directly.

Both are in the proposal's review table as disputes, not silently discarded.

## My error, not the code's

Two findings — "criterion 4 unmet, no tests" and "proposal not moved to done" — were **true of the artifact I submitted and false of the change**. I sent an abridged diff carrying only non-test Go hunks, so the tests and the `pending/` → `done/` move were genuinely absent from what the panel saw. That's reviewer-side sloppiness; the re-review got the complete diff including test and docs hunks.

## Verification

`go test ./internal/... ./modules/...` all pass, `go vet` clean, `gofmt` clean, and `check-docs` / `check-proposal-links` / `check_pending_audit_manifest` all pass.

A re-review with the complete diff is running; its verdict will be added here.
