### PR TITLE
docs: record that a delegate's shell and file tools resolve different roots

### DIFF
--- a/docs/proposals/pending/delegate-shell-cwd-diverges-from-file-tools.md
+++ b/docs/proposals/pending/delegate-shell-cwd-diverges-from-file-tools.md
@@ -1,0 +1,93 @@
+# A delegate's shell and its file tools resolve different roots
+
+- **State:** PENDING — measured on a live appliance 2026-08-08; no fix implemented.
+
+## Problem
+
+A background `code` delegate can read and write repository files but cannot run a
+single shell command, so it can change code and has no way to check the change.
+The two halves of the same delegate resolve the same session worktree against
+**different roots**.
+
+Measured on the validation appliance with a server-side checkout at
+`/var/lib/aimee-workspaces/aimee`:
+
+- **File tools resolve against the repository.** `read_file`, `list_files` and
+  `git_log` all succeeded, operating in the session worktree
+  `/var/lib/aimee-workspaces/aimee/.aimee/worktrees/7c548df2-b127074c54171e76/main`.
+
+- **Shell resolves against the ephemeral workspace.** Every `bash` and
+  `execute_script` call was refused, with the composed command showing the root it
+  had actually been given:
+
+      error: guardrail blocked: cd /var/lib/aimee/delegate-ws/deleg-492-1786193373307793551-17/.aimee/worktrees/7c548df2-b127074c54171e76/main && pwd
+
+  Same worktree id, different root: the *ephemeral* workspace prefix with the
+  session-worktree suffix appended. That path does not exist, so the guardrail
+  refuses it — correctly. Even `pwd` and `echo hello` fail this way.
+
+The ephemeral workspace is created at `src/server/server_compute.c:1473`, which
+calls `run_cmd_set_cwd(ephemeral_ws)`; `run_cmd()` then prefixes every shell line
+with `cd <tl_run_cwd> && …` (`src/util.c:715`). The file tools do not go through
+that path, which is why only one half moves.
+
+That site already records the underlying gap:
+
+> The ephemeral workspace does NOT contain the client's repo (it drops an
+> AIMEE_WORKSPACE_NOTE.txt saying so); a background *code* delegate that must edit
+> the client tree needs it provisioned server-side (follow-up).
+
+Provisioning the repo server-side is necessary but **not sufficient**: with a real
+checkout present and passed as `cwd`, the file tools found it and the shell still
+did not.
+
+## Why this is worse than a delegate that cannot run
+
+A delegate with no shell is not merely limited, it is unable to verify itself, and
+it does not know that. Asked to add one comment line to a 2157-line Go file, a
+`code` delegate **truncated the file to 5 lines** — 2152 deletions — and could not
+compile, test, or `gofmt` to notice. Writes are permitted; verification is not.
+
+That combination should not be reachable. Either a delegate can check its own work
+or it should not be able to write.
+
+## Proposal
+
+1. **One root per delegate turn.** The shell and the file tools must resolve the
+   same session worktree. Whichever root the file tools bind, `run_cmd_set_cwd()`
+   receives that same root — not the ephemeral workspace with the worktree suffix
+   pasted on.
+
+2. **Refuse the incoherent combination.** When a delegate is write-capable but its
+   shell cannot execute in its own worktree, fail the dispatch with that reason
+   instead of running it. An unverifiable write delegate is a configuration error,
+   and it currently presents as a successful edit.
+
+3. **Say which root was used.** The refusal above is readable only because it
+   happened to echo the composed `cd`. The delegate's bound root, and whether it is
+   the repository or an ephemeral workspace, belong in the turn's diagnostics.
+
+## Deliberately not proposed
+
+**Provisioning policy for server-side checkouts.** Which repository a remote
+delegate should get, and who clones it, is an operator decision. This proposal is
+only that the two halves of one delegate must agree on where they are.
+
+## Acceptance criteria
+
+- A background `code` delegate given a server-visible checkout runs `pwd` and
+  `go test` in the same worktree its file tools write to.
+- A delegate whose shell cannot execute in its bound worktree is refused before it
+  can write, with a diagnostic naming the root it was given.
+- A test covers the divergence directly: file-tool root and shell root for one
+  delegate turn are asserted equal.
+- The turn diagnostic names the bound root and whether it is a repository checkout
+  or an ephemeral workspace.
+
+## Evidence
+
+Delegate jobs 36 (read-only probe) and 38 (write probe) against
+`aimee-server:testing` in container `aimee-aimee-server-1`, appliance
+`192.168.1.210`, 2026-08-08. Job 36 recorded the working file tools and the blocked
+shell with the verbatim path above; job 38 produced the 2152-line deletion. The
+truncated file was restored and nothing was committed or pushed.


### PR DESCRIPTION
Tracks down why code delegation cannot verify itself on a remote appliance. **Diagnosis and evidence only — no fix**, for the reason given at the bottom.

## The bug in one sentence

The two halves of the same delegate resolve the same session worktree against **different roots**.

Measured with a server-side checkout at `/var/lib/aimee-workspaces/aimee`:

| Half | Root it used | Result |
|---|---|---|
| File tools (`read_file`, `list_files`, `git_log`) | `/var/lib/aimee-workspaces/aimee/.aimee/worktrees/7c548df2…/main` | ✅ work |
| Shell (`bash`, `execute_script`) | `/var/lib/aimee/delegate-ws/deleg-492-…/.aimee/worktrees/7c548df2…/main` | ❌ every call refused |

Same worktree id, different root — the *ephemeral workspace* prefix with the session-worktree suffix pasted on. That path doesn't exist, so the guardrail refuses it, **correctly**:

```
error: guardrail blocked: cd /var/lib/aimee/delegate-ws/deleg-492-1786193373307793551-17/.aimee/worktrees/7c548df2-b127074c54171e76/main && pwd
```

Even `pwd` and `echo hello` fail this way. The guardrail is not the bug; it is refusing a path that genuinely isn't there.

`server_compute.c:1473` creates the ephemeral workspace and calls `run_cmd_set_cwd(ephemeral_ws)`; `run_cmd()` then prefixes every shell line with `cd <tl_run_cwd> && …` (`util.c:715`). The file tools don't go through that path, which is why only one half moves.

## Provisioning the repo is necessary but not sufficient

That site already records the underlying gap as a follow-up:

> The ephemeral workspace does NOT contain the client's repo … a background *code* delegate that must edit the client tree needs it provisioned server-side (follow-up).

I did provision it — cloned into the persistent workspaces volume, no compose change, no restart. **The file tools found it and the shell still did not.** So closing the documented follow-up alone would not fix this.

## Why this is worse than a delegate that can't run

A delegate with no shell isn't merely limited — it cannot verify itself, and doesn't know it. Asked to add **one comment line** to a 2157-line Go file, a `code` delegate **truncated it to 5 lines** (2152 deletions), and had no way to compile, test, or `gofmt` to notice.

Writes permitted, verification impossible. That combination shouldn't be reachable — hence the second acceptance criterion: refuse the dispatch rather than allow an unverifiable write delegate.

The file was restored and nothing was committed or pushed; the worktree is disposable.

## Why no fix here

I can't verify one. There's no local server to exercise this path, and delegates are the only thing that exercises it — they're the broken thing. Shipping a speculative change to worktree/cwd binding and calling it fixed would be exactly the "certifying on the test you skipped" failure this repo's principles warn about.

The proposal carries the reproduction, the two call sites, and four acceptance criteria so whoever picks it up can verify rather than re-derive.

## Verification of this change

`check-docs`, `check-proposal-links`, `check-proposal-reconcile`, and `check_pending_audit_manifest` all pass. Incidentally, the manifest gate fixed in #2422 handled this new post-snapshot proposal correctly — reporting it rather than failing on it, which is precisely what that fix was for.
