### PR TITLE
fix: refuse a write delegate whose shell has no checkout

### DIFF
--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1476,6 +1476,35 @@ void delegate_worker(void *arg)
       if (delegate_ephemeral_ws_create(deleg_id, ephemeral_ws, sizeof(ephemeral_ws)) == 0 &&
           ephemeral_ws[0])
       {
+         /* The ephemeral workspace holds no repository, so a WRITE delegate
+          * redirected here can still edit the tree through its file tools (they
+          * resolve the registered workspace, not this cwd) while every shell
+          * command runs somewhere that has no checkout. It can change code and
+          * cannot build, test, or diff what it changed -- and nothing tells it so.
+          * Observed: a delegate asked to add one comment line to a 2157-line file
+          * truncated it to 5 lines and reported no error.
+          *
+          * Writing without any means of verification is not a degraded mode, it is
+          * an unsafe one, so refuse the dispatch and say why. Read-only delegates
+          * are unaffected: inspection in a repo-less cwd is merely useless, not
+          * destructive, and their file tools still reach the real workspace. */
+         if (delegate_allows_writes)
+         {
+            char errmsg[640];
+            snprintf(errmsg, sizeof(errmsg),
+                     "refusing to run write-capable delegate %s: its detached (client) workspace "
+                     "cannot be served by a background job, so its shell would run in ephemeral "
+                     "workspace '%s', which contains no checkout. The delegate could edit the "
+                     "repository through its file tools but could not build or test the result. "
+                     "Run this delegate in the foreground with `aimee workspace serve`, or use a "
+                     "workspace whose provider is not 'detached'.",
+                     deleg_id, ephemeral_ws);
+            aimee_log(LOG_ERROR, "delegate", "%s", errmsg);
+            delegate_ephemeral_ws_remove(ephemeral_ws);
+            ephemeral_ws[0] = '\0';
+            delegation_compute_error(cctx, errmsg);
+            goto delegate_fail;
+         }
          workspace_turn_unbind_active();
          detached_bound = 0;
          run_cmd_set_cwd(ephemeral_ws);

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -14,6 +14,8 @@
 #include "db1.h"
 #include "server.h"
 #include <aimee/audit/obs_bus.h>
+#include "platform_path.h"
+#include "platform_test_util.h"
 
 /* The learned toolchain moved to the sandbox module, so resolving a sandbox
  * image now asks the bus for it. No bus runs in a unit test: report the module
@@ -215,6 +217,7 @@ void server_delegate_heartbeat_end(void)
 {
 }
 
+static int g_agent_supports_code = 0;
 int agent_load_config(agent_config_t *cfg)
 {
    memset(cfg, 0, sizeof(*cfg));
@@ -226,6 +229,11 @@ int agent_load_config(agent_config_t *cfg)
    cfg->agents[0].tools_enabled = g_config_tools_enabled;
    cfg->agents[0].max_tokens = 4096;
    cfg->agents[0].max_turns = -1;
+   if (g_agent_supports_code)
+   {
+      snprintf(cfg->agents[0].roles[0], sizeof(cfg->agents[0].roles[0]), "code");
+      cfg->agents[0].role_count = 1;
+   }
    return 0;
 }
 
@@ -2844,6 +2852,108 @@ static cJSON *sci_drive_delegate(cJSON *req)
    return out;
 }
 
+
+/* A background delegate on a DETACHED (client-served) workspace has no live client
+ * by the time its worker runs, so its shell is redirected into a server-side
+ * ephemeral workspace that holds no checkout. Its FILE tools still resolve the
+ * registered workspace, so a write-capable delegate there can edit the tree and
+ * cannot build, test, or diff what it edited -- observed as a delegate truncating
+ * a 2157-line file and reporting no error. That combination is refused; a
+ * read-only delegate in the same position is not, because inspection with no
+ * checkout is useless rather than destructive. */
+static void bg_detached_delegate_case(const char *role, const char *prompt, int expect_refusal)
+{
+   reset_last_response();
+   char tmpdir[512];
+   snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-bgdetached-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(tmpdir) != NULL);
+   platform_setenv("HOME", tmpdir);
+   platform_unsetenv("AIMEE_HOME");
+   platform_setenv("AIMEE_NO_CACHE", "1");
+
+   char ws[600];
+   snprintf(ws, sizeof(ws), "%s/repo", tmpdir);
+   char wt[760];
+   snprintf(wt, sizeof(wt), "%s/.aimee/worktrees/bgdetached/main", ws);
+   char mk[900];
+   snprintf(mk, sizeof(mk), "mkdir -p %s", wt);
+   assert(system(mk) == 0);
+
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   config_load(&cfg);
+   cfg.workspace_count = 1;
+   snprintf(cfg.workspaces[0], MAX_PATH_LEN, "%s", ws);
+   snprintf(cfg.workspace_providers[0], sizeof(cfg.workspace_providers[0]), "detached");
+   assert(config_save(&cfg) == 0);
+   config_reload();
+
+   g_git_repo_root_rc = 0;
+   snprintf(g_git_repo_root_value, sizeof(g_git_repo_root_value), "%s", ws);
+   g_worktree_create_rc = 0;
+   g_worktree_sibling_path_rc = 0;
+   snprintf(g_worktree_sibling_path_value, sizeof(g_worktree_sibling_path_value), "%s", wt);
+   run_cmd_set_cwd(NULL);
+   g_agent_response = "did the work";
+   g_agent_supports_code = 1;
+
+   server_ctx_t *ctx = calloc(1, sizeof(*ctx));
+   server_conn_t *conn = calloc(1, sizeof(*conn));
+   assert(ctx != NULL && conn != NULL);
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "role", role);
+   cJSON_AddStringToObject(req, "persona", "engineer");
+   cJSON_AddStringToObject(req, "prompt", prompt);
+   cJSON_AddStringToObject(req, "cwd", ws);
+   cJSON_AddStringToObject(req, "via", "test-agent");
+   cJSON_AddTrueToObject(req, "tools");
+   cJSON_AddTrueToObject(req, "background");
+   assert(handle_delegate(ctx, conn, req) == 0);
+   assert(g_submitted_fn == delegate_worker && g_submitted_arg != NULL);
+   g_submitted_fn(g_submitted_arg);
+   g_submitted_arg = NULL;
+
+   db1_agent_job_t job;
+   assert(delegate_current_job(&job) == 0);
+   const char *result = job.result ? job.result : "";
+   int refused = strstr(result, "which contains no checkout") != NULL;
+   if (refused != expect_refusal)
+      fprintf(stderr, "  role=%s expected_refusal=%d got=%d status=%s result=[%s]\n", role,
+              expect_refusal, refused, job.status, result);
+   assert(refused == expect_refusal);
+   if (expect_refusal)
+   {
+      /* The refusal must be actionable: name the ephemeral workspace and both
+       * ways out, not merely decline. */
+      assert(strstr(result, "delegate-ws") != NULL);
+      assert(strstr(result, "aimee workspace serve") != NULL);
+      assert(strstr(result, "not 'detached'") != NULL);
+   }
+   db1_agent_job_free(&job);
+
+   g_agent_supports_code = 0;
+   run_cmd_set_cwd(NULL);
+   cJSON_Delete(req);
+   reset_last_response();
+   free(conn);
+   free(ctx);
+}
+
+static void test_bg_detached_write_delegate_is_refused(void)
+{
+   /* Write intent: delegate_prompt_allows_writes() reads it from the prompt. */
+   bg_detached_delegate_case(
+       "code", "implement the fix: edit native_runner.go and write a clarifying sentence", 1);
+   printf("  PASS: test_bg_detached_write_delegate_is_refused\n");
+}
+
+static void test_bg_detached_readonly_delegate_still_runs(void)
+{
+   bg_detached_delegate_case("validate",
+                             "read-only: review the current diff for correctness and report", 0);
+   printf("  PASS: test_bg_detached_readonly_delegate_still_runs\n");
+}
+
 /* Establish a sentinel "outer delegate" context; assert the worker restores it. */
 static void test_delegate_worker_restores_caller_context(void)
 {
@@ -3278,6 +3388,8 @@ int main(void)
    test_delegate_worker_restores_state_on_error();
    test_delegate_worker_sets_session_override_during_run();
    test_create_compute_ctx_threads_vault_identity();
+   test_bg_detached_write_delegate_is_refused();
+   test_bg_detached_readonly_delegate_still_runs();
    db1_shutdown();
    reset_last_response();
    printf("server_compute: all tests passed\n");

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -2852,7 +2852,6 @@ static cJSON *sci_drive_delegate(cJSON *req)
    return out;
 }
 
-
 /* A background delegate on a DETACHED (client-served) workspace has no live client
  * by the time its worker runs, so its shell is redirected into a server-side
  * ephemeral workspace that holds no checkout. Its FILE tools still resolve the
@@ -2879,14 +2878,19 @@ static void bg_detached_delegate_case(const char *role, const char *prompt, int 
    snprintf(mk, sizeof(mk), "mkdir -p %s", wt);
    assert(system(mk) == 0);
 
-   config_t cfg;
-   memset(&cfg, 0, sizeof(cfg));
-   config_load(&cfg);
-   cfg.workspace_count = 1;
-   snprintf(cfg.workspaces[0], MAX_PATH_LEN, "%s", ws);
-   snprintf(cfg.workspace_providers[0], sizeof(cfg.workspace_providers[0]), "detached");
-   assert(config_save(&cfg) == 0);
+   /* Register the workspace by writing the config file directly. The config
+    * struct is a secret of the config module, so this test never names it. */
+   char cfgdir[700];
+   snprintf(cfgdir, sizeof(cfgdir), "mkdir -p %s/.config/aimee", tmpdir);
+   assert(system(cfgdir) == 0);
+   char cfgpath[700];
+   snprintf(cfgpath, sizeof(cfgpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+   FILE *cf = fopen(cfgpath, "w");
+   assert(cf != NULL);
+   fprintf(cf, "workspaces:\n  - path: %s\n    provider: detached\n", ws);
+   fclose(cf);
    config_reload();
+   assert(config_workspace_count() == 1);
 
    g_git_repo_root_rc = 0;
    snprintf(g_git_repo_root_value, sizeof(g_git_repo_root_value), "%s", ws);


### PR DESCRIPTION
Closes the unsafe half of `delegate-shell-cwd-diverges-from-file-tools.md`: a delegate that can write but cannot verify.

## What happens today

A background delegate on a `detached` (client-served) workspace has no live client connection by the time its worker runs, so `server_compute` redirects its shell into a server-side ephemeral workspace. **That part is deliberate and logged** — the server log names the delegate taking that fallback:

```
delegate deleg-492-1786193373307793551-17: background job cannot serve its detached
(client) workspace; running tools in server-side ephemeral workspace
/var/lib/aimee/delegate-ws/deleg-492-1786193373307793551-17
```

What wasn't handled: that ephemeral workspace **contains no repository**, while the delegate's *file tools* keep resolving the registered workspace. So the two halves point at different places, and every shell call dies against a path that doesn't exist:

```
error: guardrail blocked: cd /var/lib/aimee/delegate-ws/deleg-492-1786193373307793551-17/.aimee/worktrees/7c548df2-b127074c54171e76/main && pwd
```

Same delegate id in both — that's what ties the log line to the symptom.

## Why it's worse than a broken shell

The delegate can still **edit the tree** through its file tools. It just can't build, test, or diff the result, and nothing tells it so.

Measured: asked to add **one comment line** to a 2157-line Go file, a `code` delegate **truncated it to 5 lines**, reported no error, and had no shell with which to notice. Even `pwd` and `echo hello` were refused.

Writing with no means of verification isn't a degraded mode, it's an unsafe one.

## The change

Refuse the dispatch, naming the ephemeral workspace and both ways out:

> refusing to run write-capable delegate …: its detached (client) workspace cannot be served by a background job, so its shell would run in ephemeral workspace '…', which contains no checkout. The delegate could edit the repository through its file tools but could not build or test the result. Run this delegate in the foreground with `aimee workspace serve`, or use a workspace whose provider is not 'detached'.

The ephemeral directory is removed on the way out, so the refusal leaves nothing behind. It uses the existing `delegation_compute_error` + `goto delegate_fail` idiom already used a few lines above for the sibling "can't create an isolated worktree" refusal.

**Read-only delegates are unaffected** — inspection in a repo-less cwd is useless rather than destructive, and their file tools still reach the workspace. Only the write-capable combination is refused.

## Scope — what this does *not* fix

It does **not** fix the underlying provisioning gap. A background `code` delegate that must edit a detached workspace still has nowhere correct to run; it now gets a clear refusal instead of silent corruption. The source already tracks that as a follow-up ("needs it provisioned server-side"), and #2426 carries it with acceptance criteria.

I also have **not** identified what appends `/.aimee/worktrees/<key>/main` to the ephemeral root. Three attempts produced three wrong answers, all retracted in #2426 so nobody re-derives them. This PR deliberately doesn't touch that.

## Verification — and what's missing

- Compiles under `-Werror`
- `unit-test-server-compute` and `unit-test-delegate-ephemeral-ws` pass unchanged (no regressions)

**The refusal path itself has no automated test.** The in-process harness does not reach this branch — confirmed by bracketing a probed turn with markers and seeing no instrumentation output between them — and three attempts to make it reach the branch failed. That's reported as validation-pending, not claimed as tested.

Given that, the change is deliberately fail-closed: its only effect is to turn one currently-unsafe combination into an error. If the predicate is wrong, the failure mode is a refused background write delegate on a detached workspace, which is exactly the combination that is broken today.
