### PR TITLE
fix: record the poison-gate fixture as a repo-relative path

### DIFF
--- a/benchmarks/memory/poison_gate.py
+++ b/benchmarks/memory/poison_gate.py
@@ -102,6 +102,24 @@ def validate_forbidden_metadata_ignored(payload: dict[str, Any]) -> list[str]:
     return errors
 
 
+def fixture_label(fixture_path: Path) -> str:
+    """Repo-relative path for the report, falling back to absolute.
+
+    The report is committed, so an absolute path made it churn on every run from
+    a different checkout -- two runs of an identical, fully deterministic gate
+    produced a diff whose only content was somebody's worktree name. That is a
+    spurious diff in review and it hides real ones.
+    """
+    resolved = fixture_path.resolve()
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        return resolved.relative_to(repo_root).as_posix()
+    except ValueError:
+        # Fixture supplied from outside the repo via --fixtures; absolute is the
+        # only meaningful label, and such a run is not the committed baseline.
+        return str(resolved)
+
+
 def run(fixture_path: Path) -> tuple[int, dict[str, Any]]:
     payload = json.loads(fixture_path.read_text())
     n_min = int(payload["n_min"])
@@ -116,7 +134,7 @@ def run(fixture_path: Path) -> tuple[int, dict[str, Any]]:
     report = {
         "version": 1,
         "benchmark": "memory_poison_resilience",
-        "fixture": str(fixture_path),
+        "fixture": fixture_label(fixture_path),
         "delta_max": delta_max,
         "accuracy_clean": clean["accuracy"],
         "accuracy_poison": poison["accuracy"],

--- a/benchmarks/results/memory_poison_report.json
+++ b/benchmarks/results/memory_poison_report.json
@@ -4,7 +4,7 @@
   "benchmark": "memory_poison_resilience",
   "delta_clean_poison": 0.0,
   "delta_max": 0.1,
-  "fixture": "/home/virant/dev/aimee/.aimee/worktrees/6ab82f0e/main/benchmarks/memory/poison_fixtures.json",
+  "fixture": "benchmarks/memory/poison_fixtures.json",
   "gate": "pass",
   "metadata_boundary": {
     "errors": [],


### PR DESCRIPTION
`benchmarks/memory/poison_gate.py` is fully deterministic, but its committed report embedded the **absolute** fixture path. Two runs of identical logic from different checkouts therefore produced a diff whose only content was somebody's worktree name:

```diff
-"fixture": ".../worktrees/6ab82f0e/main/benchmarks/memory/poison_fixtures.json"
+"fixture": ".../worktrees/81e27bec-.../main/benchmarks/memory/poison_fixtures.json"
```

That is a spurious diff in review, and a result file that always looks changed is one whose real changes stop being read.

## Change

Store the path relative to the repo root. A fixture supplied from outside the repo via `--fixtures` keeps an absolute label, since such a run is not the committed baseline and the absolute path is the only meaningful identifier for it.

The regenerated report is included. Every substantive field — `gate`, both accuracies, `delta_clean_poison`, `metadata_boundary`, `scenarios` — is byte-identical to the previous baseline; this commit changes only the path label.

## Verification

Ran `python3 benchmarks/memory/poison_gate.py` on this branch:

```
gate:                 pass
accuracy_clean:       1.0
accuracy_poison:      1.0
delta_clean_poison:   0.0    (delta_max 0.1)
metadata_boundary.errors: []
fixture:              benchmarks/memory/poison_fixtures.json
```

Both poisoned rows suppressed, both clean facts retrieved. The empty `metadata_boundary` confirms the scorer ignored `source_tag`, `declared_confidence`, `author_id` and `retrieval_frequency` — the trust signals the fixture deliberately inflates.

Re-running after the change leaves the working tree clean, which is the property this fixes: the committed artifact is now stable across checkouts.
