### PR TITLE
fix: apply the guardrail's shell rewrite (root cause of the delegate shell failure)

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -184,7 +184,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "c5242c84b5f7f4b81cf5af14604ac3d60c52f0d1515fefcc1adba27e6cc0f762",
+      "source_sha256": "1e3fba6a7f7ecd4c8824150485f04bc6064f0ab7a9746b6a513268bc3e508723",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 11,
@@ -203,7 +203,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "76c50254227109b7b6c7a999bba69ecf38b22383a25dce377ec260e30e5d2083",
+      "source_sha256": "15415dbbe8ac78491997bc258de427e37cfb7a67ae5bc2294cdda0e2e73c057b",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,

--- a/src/modules/tools/agent_tools_dispatch.c
+++ b/src/modules/tools/agent_tools_dispatch.c
@@ -2214,6 +2214,39 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
          if (fp_arg)
             cJSON_SetValuestring(fp_arg, msg);
       }
+      else if (rc == 3 && msg[0])
+      {
+         /* Shell COMMAND rewrite: the guardrail redirected this command into the
+          * session worktree and returned the rewritten line ("cd <worktree> && …"),
+          * exactly as it does for a path with rc==1. cmd_hooks.c applies both
+          * ("rc==1: edit tool file_path rewrite, rc==3: bash command rewrite").
+          *
+          * This path applied only rc==1, so a rewrite arrived here as "not 0" and
+          * was reported as a refusal — with the rewritten command as the reason.
+          * Every shell command a delegate ran came back "guardrail blocked: cd
+          * <worktree> && <cmd>", including `pwd` and `echo hello`, because the
+          * rewrite fires on every shell call whose cwd sits outside the worktree.
+          * A delegate could therefore edit files and never run one command.
+          *
+          * Rewrite the same field the guardrail read (command / cmd / body — see
+          * guardrails_command_item) so the tool runs the redirected line. */
+         cJSON *cmd_arg = cJSON_GetObjectItem(args, "command");
+         if (!cmd_arg || !cJSON_IsString(cmd_arg))
+            cmd_arg = cJSON_GetObjectItem(args, "cmd");
+         if (!cmd_arg || !cJSON_IsString(cmd_arg))
+            cmd_arg = cJSON_GetObjectItem(args, "body");
+         if (cmd_arg && cJSON_IsString(cmd_arg))
+            cJSON_SetValuestring(cmd_arg, msg);
+         else
+         {
+            /* Nothing to rewrite: refusing beats running the original command in
+             * a directory the guardrail just said it must not run in. */
+            cJSON_Delete(args);
+            td_outcome_set("refused", "guardrail");
+            return safe_strdup("error: guardrail requires a worktree rewrite but the tool carries "
+                               "no rewritable command field");
+         }
+      }
       else if (rc != 0)
       {
          /* Tool blocked by guardrails */

--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -256,6 +256,35 @@ int workspace_turn_resolve_mirror_cwd(const char *cwd, char *out, size_t out_cap
    return 0;
 }
 
+int workspace_turn_resolve_detached_mirror_cwd(const char *cwd, char *out, size_t out_cap)
+{
+   if (out && out_cap)
+      out[0] = '\0';
+   if (!cwd || !cwd[0] || !out || out_cap == 0)
+      return 0;
+   for (int i = 0; i < config_workspace_count(); i++)
+   {
+      if (!cwd_in_workspace(cwd, config_workspaces(i)))
+         continue;
+      ws_provider_kind_t kind = config_workspace_providers(i)[0]
+                                    ? ws_provider_kind_from_string(config_workspace_providers(i))
+                                    : WS_PROVIDER_SHARED;
+      if (kind != WS_PROVIDER_DETACHED)
+         return 0; /* mirror workspaces use the resolver above; shared needs nothing */
+      /* Copied out of the accessor buffers for the same reason as the mirror
+       * resolver: the runner ctx outlives a config read underneath it. */
+      char root[MAX_PATH_LEN], remote[512], head[64];
+      snprintf(root, sizeof(root), "%s", config_workspaces(i));
+      snprintf(remote, sizeof(remote), "%s", config_workspace_vcs_remote(i));
+      snprintf(head, sizeof(head), "%s", config_workspace_vcs_head(i));
+      if (!remote[0] || !head[0])
+         return 0; /* never synced: there is no recorded state to reconstruct */
+      ws_mirror_drift_t v;
+      return mirror_reconstruct_cwd(cwd, root, remote, head, out, out_cap, NULL, 0, &v);
+   }
+   return 0;
+}
+
 int workspace_turn_bind_active(const char *cwd)
 {
    t_turn_bound = 0;

--- a/src/modules/workspace/workspace_turn.h
+++ b/src/modules/workspace/workspace_turn.h
@@ -95,6 +95,21 @@ const char *workspace_turn_drift_notice(void);
  * is in a mirror workspace; 0 otherwise (out emptied). */
 int workspace_turn_resolve_mirror_cwd(const char *cwd, char *out, size_t out_cap);
 
+/* Same resolution, for a `detached` workspace that also carries mirror inputs.
+ *
+ * A detached workspace is served by its client, so a job running with no client
+ * attached (a background delegate) cannot reach it at all. When such a workspace
+ * has recorded a `remote` and a `head` — a client ran `workspace mirror-sync` —
+ * the server can still reconstruct an equivalent tree from its own bare mirror
+ * and run there instead of having nowhere to go.
+ *
+ * That tree is the LAST SYNCED state, not the client's current one, so this is
+ * deliberately a separate entry point rather than a widening of the mirror
+ * resolver: a caller must choose the stale-but-real tree knowingly, and say so.
+ * Returns 1 and fills out[out_cap] when `cwd` is in a detached workspace with
+ * both inputs recorded; 0 otherwise (out emptied). */
+int workspace_turn_resolve_detached_mirror_cwd(const char *cwd, char *out, size_t out_cap);
+
 /* AC #6 — the worktree_cwd-trust hole. A turn carries a client-supplied `cwd`.
  * For a co-located peer (trusted_local) it is a real server-side path; for a
  * detached workspace (detached_bound) it is acted on via the provider on the

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1473,6 +1473,29 @@ void delegate_worker(void *arg)
    char ephemeral_ws[MAX_PATH_LEN] = "";
    if (detached_bound && cctx->background_job_id > 0)
    {
+      /* Before falling back to a repo-less scratch dir: if this detached
+       * workspace has recorded a remote and head (a client ran
+       * `workspace mirror-sync`), the server can reconstruct an equivalent tree
+       * from its own bare mirror and run there. That tree is the LAST SYNCED
+       * state, not the client's current one, so it is announced rather than
+       * assumed -- a delegate working against a stale tree needs to be able to
+       * tell, and so does whoever reads the run afterwards. */
+      char mirror_cwd[MAX_PATH_LEN] = "";
+      if (workspace_turn_resolve_detached_mirror_cwd(cwd, mirror_cwd, sizeof(mirror_cwd)) &&
+          mirror_cwd[0])
+      {
+         workspace_turn_unbind_active();
+         detached_bound = 0;
+         run_cmd_set_cwd(mirror_cwd);
+         aimee_log(LOG_WARN, "delegate",
+                   "delegate %s: detached workspace has no client for this background job; "
+                   "running in the server-side mirror reconstruction at %s, which is the last "
+                   "state synced by `aimee workspace mirror-sync` and may be behind the client",
+                   deleg_id, mirror_cwd);
+      }
+   }
+   if (detached_bound && cctx->background_job_id > 0)
+   {
       if (delegate_ephemeral_ws_create(deleg_id, ephemeral_ws, sizeof(ephemeral_ws)) == 0 &&
           ephemeral_ws[0])
       {

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1490,14 +1490,18 @@ void delegate_worker(void *arg)
           * destructive, and their file tools still reach the real workspace. */
          if (delegate_allows_writes)
          {
-            char errmsg[640];
+            char errmsg[1024];
             snprintf(errmsg, sizeof(errmsg),
                      "refusing to run write-capable delegate %s: its detached (client) workspace "
                      "cannot be served by a background job, so its shell would run in ephemeral "
                      "workspace '%s', which contains no checkout. The delegate could edit the "
                      "repository through its file tools but could not build or test the result. "
-                     "Run this delegate in the foreground with `aimee workspace serve`, or use a "
-                     "workspace whose provider is not 'detached'.",
+                     "A detached workspace is served by its client, so a background job cannot "
+                     "reach it at all. Either keep the client serving it -- run this delegate in "
+                     "the foreground with `aimee workspace serve` -- or register the repository "
+                     "as a mirror workspace (`aimee workspace add <path> --provider mirror "
+                     "--remote <url>`), which the server reconstructs from its own bare mirror at "
+                     "the recorded head and can therefore serve with no client present.",
                      deleg_id, ephemeral_ws);
             aimee_log(LOG_ERROR, "delegate", "%s", errmsg);
             delegate_ephemeral_ws_remove(ephemeral_ws);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1365,6 +1365,52 @@ static void test_detached_skips_worktree_rewrite(void)
           rc_detached);
 }
 
+/* The guardrail redirects a shell command into the session worktree by returning
+ * 3 with the rewritten line ("cd <worktree> && <cmd>") — the command-shaped twin
+ * of the rc==1 path rewrite. cmd_hooks.c applies both; the delegate tool dispatch
+ * applied only rc==1, so a rewrite arrived as "not 0" and was reported as a
+ * refusal, with the rewritten command as the reason. Every shell command a
+ * delegate ran came back "guardrail blocked: cd <worktree> && <cmd>" — `pwd` and
+ * `echo hello` included — so a delegate could edit files and never run one
+ * command. This pins the verdict and that it is applied, not refused. */
+static void test_shell_worktree_rewrite_is_applied_not_refused(void)
+{
+   char repo[256];
+   snprintf(repo, sizeof(repo), "/tmp/shell_wt_rw.XXXXXX");
+   assert(mkdtemp(repo) != NULL);
+   char shellcmd[512];
+   snprintf(shellcmd, sizeof(shellcmd), "git init -q '%s' >/dev/null 2>&1", repo);
+   (void)system(shellcmd);
+
+   session_state_t state;
+   memset(&state, 0, sizeof(state));
+   strcpy(state.guardrail_mode, MODE_APPROVE);
+
+   workspace_provider_clear_active();
+   char msg[1024] = "";
+   int rc = pre_tool_check("bash", "{\"command\":\"pwd\"}", &state, MODE_APPROVE, repo, msg,
+                           sizeof(msg));
+
+   if (rc == 3)
+   {
+      /* The verdict carries a rewritten command, not a refusal reason. */
+      assert(strncmp(msg, "cd ", 3) == 0);
+      assert(strstr(msg, ".aimee") != NULL);
+      assert(strstr(msg, "pwd") != NULL);
+      printf("  shell_worktree_rewrite: rc=3 rewrite=[%.60s...]\n", msg);
+   }
+   else
+   {
+      /* Not every environment reaches the rewrite (it needs a session worktree
+       * to redirect into). Say so rather than pass silently on a case that never
+       * exercised the contract. */
+      printf("  shell_worktree_rewrite: skipped (rc=%d, no worktree to redirect into)\n", rc);
+   }
+
+   snprintf(shellcmd, sizeof(shellcmd), "rm -rf '%s'", repo);
+   (void)system(shellcmd);
+}
+
 static void test_tool_read_file(void)
 {
    /* Write a temp file */
@@ -3561,6 +3607,7 @@ int main(void)
    test_compact_system_role();
    test_delegation_error_guidance();
    test_cancelled_durable_job_blocks_tool_dispatch();
+   test_shell_worktree_rewrite_is_applied_not_refused();
    test_delegate_bash_cancel_kills_running_tool();
    test_parent_write_guard_readonly_large_find();
    test_agent_trace_log_uses_db1_execution_trace();

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1397,7 +1397,34 @@ static void test_shell_worktree_rewrite_is_applied_not_refused(void)
       assert(strncmp(msg, "cd ", 3) == 0);
       assert(strstr(msg, ".aimee") != NULL);
       assert(strstr(msg, "pwd") != NULL);
-      printf("  shell_worktree_rewrite: rc=3 rewrite=[%.60s...]\n", msg);
+
+      /* End to end: the dispatch must APPLY that rewrite, not report it. Create
+       * the worktree the guardrail wants to redirect into, then run the same
+       * tool call through the real dispatch and require both that it was not
+       * refused and that the command actually ran there. Before the fix this
+       * returned "error: guardrail blocked: cd ... && pwd". */
+      char target[768] = "";
+      const char *start = msg + 3; /* past "cd " */
+      const char *end = strstr(start, " && ");
+      assert(end != NULL && (size_t)(end - start) < sizeof(target));
+      memcpy(target, start, (size_t)(end - start));
+      target[end - start] = '\0';
+      snprintf(shellcmd, sizeof(shellcmd), "mkdir -p '%s'", target);
+      assert(system(shellcmd) == 0);
+
+      run_cmd_set_cwd(repo);
+      char *out = dispatch_tool_call("bash", "{\"command\":\"pwd\"}", 10000);
+      run_cmd_set_cwd(NULL);
+      assert(out != NULL);
+      if (strstr(out, "guardrail blocked") != NULL)
+      {
+         fprintf(stderr, "  dispatch refused the rewrite instead of applying it: %s\n", out);
+         assert(0 && "shell worktree rewrite was reported as a refusal");
+      }
+      /* pwd ran inside the redirected worktree, so its output names that path. */
+      assert(strstr(out, target) != NULL);
+      free(out);
+      printf("  shell_worktree_rewrite: rc=3 applied; pwd ran in %.48s...\n", target);
    }
    else
    {

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -2931,7 +2931,8 @@ static void bg_detached_delegate_case(const char *role, const char *prompt, int 
        * ways out, not merely decline. */
       assert(strstr(result, "delegate-ws") != NULL);
       assert(strstr(result, "aimee workspace serve") != NULL);
-      assert(strstr(result, "not 'detached'") != NULL);
+      /* and the server-side route that works without a client at all */
+      assert(strstr(result, "--provider mirror") != NULL);
    }
    db1_agent_job_free(&job);
 

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -2860,7 +2860,8 @@ static cJSON *sci_drive_delegate(cJSON *req)
  * a 2157-line file and reporting no error. That combination is refused; a
  * read-only delegate in the same position is not, because inspection with no
  * checkout is useless rather than destructive. */
-static void bg_detached_delegate_case(const char *role, const char *prompt, int expect_refusal)
+static void bg_detached_delegate_case(const char *role, const char *prompt, int expect_refusal,
+                                      int with_mirror_inputs)
 {
    reset_last_response();
    char tmpdir[512];
@@ -2885,9 +2886,32 @@ static void bg_detached_delegate_case(const char *role, const char *prompt, int 
    assert(system(cfgdir) == 0);
    char cfgpath[700];
    snprintf(cfgpath, sizeof(cfgpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+   /* A detached workspace that has been mirror-synced records a remote and a
+    * head; the server can then reconstruct an equivalent tree with no client
+    * present. A local repository stands in for the remote so this stays offline. */
+   char remote[700] = "", head[64] = "";
+   if (with_mirror_inputs)
+   {
+      snprintf(remote, sizeof(remote), "%s/origin", tmpdir);
+      char gitcmd[1800];
+      snprintf(gitcmd, sizeof(gitcmd),
+               "git init -q %s && cd %s && git config user.email t@t && git config user.name t && "
+               "echo seed > seed.txt && git add -A && git commit -q -m seed",
+               remote, remote);
+      assert(system(gitcmd) == 0);
+      snprintf(gitcmd, sizeof(gitcmd), "git -C %s rev-parse HEAD", remote);
+      FILE *rp = popen(gitcmd, "r");
+      assert(rp != NULL);
+      assert(fgets(head, sizeof(head), rp) != NULL);
+      pclose(rp);
+      head[strcspn(head, "\n")] = '\0';
+      assert(head[0]);
+   }
    FILE *cf = fopen(cfgpath, "w");
    assert(cf != NULL);
    fprintf(cf, "workspaces:\n  - path: %s\n    provider: detached\n", ws);
+   if (with_mirror_inputs)
+      fprintf(cf, "    remote: %s\n    head: %s\n", remote, head);
    fclose(cf);
    config_reload();
    assert(config_workspace_count() == 1);
@@ -2948,14 +2972,26 @@ static void test_bg_detached_write_delegate_is_refused(void)
 {
    /* Write intent: delegate_prompt_allows_writes() reads it from the prompt. */
    bg_detached_delegate_case(
-       "code", "implement the fix: edit native_runner.go and write a clarifying sentence", 1);
+       "code", "implement the fix: edit native_runner.go and write a clarifying sentence", 1, 0);
    printf("  PASS: test_bg_detached_write_delegate_is_refused\n");
+}
+
+/* A detached workspace that HAS been mirror-synced records a remote and a head,
+ * so the server reconstructs an equivalent tree from its own bare mirror and runs
+ * the delegate there instead of refusing it. That tree is the last synced state,
+ * which the run announces; what matters here is that the delegate is no longer
+ * stranded with nowhere to work. */
+static void test_bg_detached_write_delegate_uses_mirror_when_synced(void)
+{
+   bg_detached_delegate_case(
+       "code", "implement the fix: edit native_runner.go and write a clarifying sentence", 0, 1);
+   printf("  PASS: test_bg_detached_write_delegate_uses_mirror_when_synced\n");
 }
 
 static void test_bg_detached_readonly_delegate_still_runs(void)
 {
    bg_detached_delegate_case("validate",
-                             "read-only: review the current diff for correctness and report", 0);
+                             "read-only: review the current diff for correctness and report", 0, 0);
    printf("  PASS: test_bg_detached_readonly_delegate_still_runs\n");
 }
 
@@ -3395,6 +3431,7 @@ int main(void)
    test_create_compute_ctx_threads_vault_identity();
    test_bg_detached_write_delegate_is_refused();
    test_bg_detached_readonly_delegate_still_runs();
+   test_bg_detached_write_delegate_uses_mirror_when_synced();
    db1_shutdown();
    reset_last_response();
    printf("server_compute: all tests passed\n");


### PR DESCRIPTION
Four commits that landed after #2427 merged. The headline is the **root cause** of the delegate-shell failure that started this whole investigation.

## Root cause: a guardrail verdict nobody implemented

The appliance log named it, in a line I had not grepped for:

```
INFO guardrails: worktree rewrite (bash):
  cd /var/lib/aimee/delegate-ws/deleg-492-.../.aimee/worktrees/7c548df2-.../main && pwd
```

`pre_tool_check` returns **3** to mean *"allow, with the command rewritten to this"* — the command-shaped twin of the `rc==1` path rewrite. `agent_tools_dispatch.c` handled only `rc==1`:

```c
if (rc == 1 && msg[0])   { ...apply path rewrite... }
else if (rc != 0)        { return "error: guardrail blocked: <msg>"; }
```

So verdict 3 fell into the refusal branch and **the rewritten command was reported as the reason it was blocked**.

That accounts for every symptom:

| Symptom | Explanation |
|---|---|
| Even `pwd` and `echo hello` blocked | The rewrite fires on *every* shell call whose cwd is outside the worktree |
| The "blocked path" looked mangled | It was never a diagnosis — it was the rewrite being echoed back |
| Files editable, no command runnable | File tools take the `rc==1` path, which *was* implemented |

`cmd_hooks.c` already had it right — *"rc==1: edit tool file_path rewrite, rc==3: bash command rewrite"* — and applies both. The delegate dispatch never implemented its half.

**The fix** applies `rc==3` to the same field the guardrail read (`command`/`cmd`/`body`, per `guardrails_command_item`), and refuses only when there is no rewritable field — running the original command in a directory the guardrail just excluded would be worse than refusing.

## Proved end to end, and non-vacuous

The test creates the worktree the guardrail redirects into, sets the thread-local cwd the dispatch reads, and runs the real `dispatch_tool_call`. It requires both that the call was not refused **and** that `pwd` actually ran inside the redirected worktree.

Disabling the `rc==3` branch reproduces the appliance failure verbatim in a unit test:

```
dispatch refused the rewrite instead of applying it:
  error: guardrail blocked: cd /tmp/shell_wt_rw.../.aimee/worktrees/unittest-.../main && pwd
```

Same shape as the delegate log that started this.

## Also here: the provisioning gap closed

`workspace_turn_resolve_detached_mirror_cwd()` — when a detached workspace has a recorded `remote` and `head` (a client ran `workspace mirror-sync`), the server reconstructs an equivalent tree from its own bare mirror and the delegate runs there instead of in a repo-less scratch dir.

Deliberately a **separate** entry point rather than widening the existing mirror resolver: the reconstructed tree is the *last synced state*, not the client's current one, so a caller must choose it knowingly — and the run announces it rather than working against stale code silently.

The fallback is attempted **before** the ephemeral workspace is created, so the refusal from #2427 now applies only where there is genuinely nothing to reconstruct.

Three directions, each proved non-vacuous by disabling the code under test:

- write + detached + never synced → refused
- read-only + detached + never synced → still runs
- write + detached + mirror-synced → **runs in the reconstruction** (drives the real git lifecycle against a local repo in the test's tmpdir; no network)

## Supersedes three retracted claims

This root cause supersedes three causal claims I published and withdrew in `delegate-shell-cwd-diverges-from-file-tools.md`: the `server.c:713` prefix-replacement, a "silent no-op", and "cwd is empty in the worker". All three are listed there so nobody re-derives them.

## Verification

`make lint` — all 48 checks pass locally. `unit-test-agent` and `unit-test-server-compute` green.

**Not verified:** a real delegate re-run on the appliance against a build carrying this fix. That needs a new image; until then the appliance behaviour is unchanged.
