### PR TITLE
fix: stop the async tool path refusing guardrail rewrites

### DIFF
--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -203,7 +203,16 @@ static void tool_execute_worker(void *arg)
    int rc = pre_tool_check(tool, args, &state, config_guardrail_mode(), cwd, msg, sizeof(msg));
    session_state_save(&state, sid);
 
-   if (rc != 0)
+   /* 1 and 3 are ALLOW-with-rewrite verdicts, not refusals: 1 carries a rewritten
+    * path, 3 a rewritten command ("cd <worktree> && …"). Treating them as blocked
+    * refused every tool call the guardrail merely wanted to redirect into the
+    * session worktree — for rc==1 that is an ordinary Write/Edit, the common case.
+    *
+    * They are let through rather than applied here because dispatch_tool_call
+    * runs pre_tool_check again and applies both rewrites to the arguments it
+    * passes on; re-deriving them here would be a second copy of that logic, free
+    * to drift from the one that actually decides. */
+   if (rc != 0 && rc != 1 && rc != 3)
    {
       cJSON *resp = cJSON_CreateObject();
       cJSON_AddStringToObject(resp, "status", "blocked");


### PR DESCRIPTION
The last piece of the delegate-shell root cause. #2429 landed the fix for the delegate dispatch path; this is **the same defect at a second call site**, which was pushed after that PR had already merged and so never landed.

## The defect

`pre_tool_check` verdicts **1** and **3** are *allow-with-rewrite*, not refusals — 1 carries a rewritten path, 3 a rewritten command (`cd <worktree> && …`). `server_compute_async.c` runs its own guardrail pre-check before dispatching and treated every non-zero verdict as a refusal:

```c
if (rc != 0) { ...respond "blocked"... }
```

So `POST /v1/tools/execute` refused any tool call the guardrail merely wanted to redirect into the session worktree. For `rc==1` that is an ordinary `Write`/`Edit` — the common case, not an edge one. The live appliance log carries **200** such verdicts, in both forms.

## Why let through rather than apply

`dispatch_tool_call` runs `pre_tool_check` again and applies both rewrites to the arguments it passes on. Re-deriving them here would be a second copy of the deciding logic, free to drift from the one that actually decides — so this gate simply stops treating the two rewrite verdicts as refusals.

## Verification

Local: `make lint` (48/48), `check_c_repository_lock`, `validate_module_process_contracts`, `test_module_supervisor.sh`, `unit-test-server-compute`, `unit-test-agent` — all pass.

The companion fix in #2429 was additionally confirmed on a live appliance: with a build carrying it, a real delegate's `pwd` stopped returning

```
error: guardrail blocked: cd /var/lib/aimee/delegate-ws/deleg-494-.../.aimee/worktrees/20e8311e-.../main && pwd
```

and instead reached a different, legitimate gate (`delegate_sandbox` isolation). The appliance was restored to its shipped image afterwards.

This change is on the `tool.execute` API path, which that appliance probe did not exercise, so it is covered by the local suites rather than by that run.
