### PR TITLE
fix: say a request was too large instead of blaming the server

### DIFF
--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -2083,6 +2083,32 @@ int cli_v1_forward(const char *socket_path, const cli_v1_route_t *route, int jso
        * connection; a full compute queue returns {status:error,"compute queue
        * full"}) — both clear fast. */
       const char *body = http_body;
+      /* A body over the listener's cap is dropped before it is ever parsed, so
+       * the send returns nothing and the failure reads as "could not reach the
+       * endpoint (is the server running?)" — pointing at a server that is up and
+       * answering every other request. Measured on a real workspace:
+       * `workspace mirror-sync` shipped 16.8MB (a repo with 247 untracked files)
+       * against the 4MB cap and reported the server as unreachable.
+       *
+       * Refuse here instead, naming the two numbers, so the size is the finding
+       * rather than something the operator has to infer. The roundtable review
+       * path has its own larger cap and is checked against that one. */
+      size_t body_len = body ? strlen(body) : 0;
+      size_t body_cap = rest_path && strcmp(rest_path, "/v1/roundtable/review") == 0
+                            ? (size_t)CLI_V1_MAX_ROUNDTABLE_BODY
+                            : (size_t)CLI_V1_MAX_BODY;
+      if (body_len > body_cap)
+      {
+         fprintf(stderr,
+                 "aimee: '%s' request body is %zu bytes, over the %zu-byte limit the server "
+                 "accepts, so it would be dropped before it was read. Reduce what the request "
+                 "carries (for a workspace sync, untracked files dominate it) and retry.\n",
+                 route->method, body_len, body_cap);
+         free(http_body);
+         free(bearer);
+         free(remote);
+         return -1;
+      }
       static const int retry_delays_ms[] = {200, 500, 1000};
       const int max_retries = (int)(sizeof(retry_delays_ms) / sizeof(retry_delays_ms[0]));
       for (int attempt = 0; attempt <= max_retries; attempt++)

--- a/src/headers/cli_v1_routes_internal.h
+++ b/src/headers/cli_v1_routes_internal.h
@@ -244,4 +244,17 @@ const char *rpc_get(const rpc_opts_t *opts, const char *name);
 int rpc_get_int(const rpc_opts_t *opts, const char *name, int def);
 int rpc_has_flag(const rpc_opts_t *opts, const char *name);
 void rpc_parse(int argc, char **argv, const char **bool_flags, rpc_opts_t *out);
+
+/* The largest /v1 request body the server will accept, mirrored client-side so
+ * the CLI can refuse an oversized request itself. A body over this is dropped by
+ * the listener before it is parsed, which the client can otherwise only report as
+ * "could not reach the endpoint" — blaming a server that is up and answering.
+ *
+ * Mirrored rather than included because headers/server.h pulls in the server's
+ * own dependency chain, which the CLI does not build against.
+ * test_cli_v1_body_cap_matches_server pins these equal to SHTTP_MAX_BODY /
+ * SHTTP_MAX_ROUNDTABLE_BODY. */
+#define CLI_V1_MAX_BODY            (4 * 1024 * 1024)
+#define CLI_V1_MAX_ROUNDTABLE_BODY (128 * 1024 * 1024)
+
 #endif

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -49,6 +49,16 @@ typedef struct cJSON cJSON;
 #define SERVER_LISTEN_BACKLOG  128
 #define CONN_WRITE_DEADLINE_MS 10000 /* 10 seconds */
 
+/* The largest /v1 request body the HTTP listener will accept (the roundtable
+ * review path has its own, larger cap). Lives here rather than inside
+ * server_http.c so a CLIENT can refuse an oversized request itself and say why:
+ * a body over this is dropped by the listener, which the client could otherwise
+ * only report as "could not reach the endpoint" — blaming a server that is up
+ * and answering. The sibling LIMIT_* values below are already documented against
+ * it. */
+#define SHTTP_MAX_BODY            (4 * 1024 * 1024)
+#define SHTTP_MAX_ROUNDTABLE_BODY (128 * 1024 * 1024)
+
 /* Per-method payload size limits */
 #define LIMIT_MEMORY     (256 * 1024)        /* 256KB for memory operations */
 #define LIMIT_TOOL       (4 * 1024 * 1024)   /* 4MB for tool I/O */

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -60,9 +60,9 @@
 #include <unistd.h>
 #include <stdatomic.h>
 
-#define SHTTP_MAX_BODY            (4 * 1024 * 1024)
-#define SHTTP_MAX_ROUNDTABLE_BODY (128 * 1024 * 1024)
-#define SHTTP_BACKLOG             16
+/* SHTTP_MAX_BODY / SHTTP_MAX_ROUNDTABLE_BODY now live in headers/server.h so
+ * clients can honour the same cap. */
+#define SHTTP_BACKLOG 16
 /* ── per-session persona store ──────────────────────────────────────────── */
 
 #define SHTTP_MAX_SESSIONS 256

--- a/src/tests/test_cli_v1_delegate.c
+++ b/src/tests/test_cli_v1_delegate.c
@@ -11,6 +11,7 @@
 #include "cli_client.h"
 #include "platform_path.h"
 #include "cJSON.h"
+#include "server.h" /* SHTTP_MAX_BODY: the cap the CLI mirrors */
 
 #define V1_PROTOCOL_VERSION 1
 
@@ -2074,8 +2075,21 @@ static void test_grant_show_shares_the_list_renderer(void)
    assert(strstr(out, "full") != NULL);
 }
 
+/* The CLI refuses an oversized /v1 body itself, because the listener drops one
+ * before parsing and the client could otherwise only report it as "could not
+ * reach the endpoint" -- blaming a server that is up and answering. That refusal
+ * is only correct while the mirrored cap equals the server's real one. */
+static void test_cli_v1_body_cap_matches_server(void)
+{
+   assert(CLI_V1_MAX_BODY == SHTTP_MAX_BODY);
+   assert(CLI_V1_MAX_ROUNDTABLE_BODY == SHTTP_MAX_ROUNDTABLE_BODY);
+   printf("  cli_v1_body_cap_matches_server: ok (%d / %d)\n", (int)CLI_V1_MAX_BODY,
+          (int)CLI_V1_MAX_ROUNDTABLE_BODY);
+}
+
 int main(void)
 {
+   test_cli_v1_body_cap_matches_server();
    printf("test_cli_v1_delegate\n");
    test_remote_workspace_hidden_roots_are_rejected();
    test_json_error_envelopes_remain_structured();

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -359,7 +359,7 @@
         },
         {
           "path": "src/headers/cli_v1_routes_internal.h",
-          "sha256": "bbefaae8a455f6a1f5193ca516635d9753fb96cefbc7062b30b80f4687209d59"
+          "sha256": "3653d371e3c640b3e1cc4692c380d7cb8e53fec2223b24f747b966cbab3773ae"
         },
         {
           "path": "src/headers/client_constants.h",
@@ -1083,7 +1083,7 @@
         },
         {
           "path": "src/headers/server.h",
-          "sha256": "eaa64f4727529c6c9ac5989bb6c4bcae02994f9265ef5e4fea4bfe0eecf4325a"
+          "sha256": "6e49753551ec43602d09e0d6fcb298682c43af3392bcd3377fd792b765f743b0"
         },
         {
           "path": "src/headers/server_cli_oauth.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "4c9a5fd3fd10d38ef2ea13bdfb69cca1f2aed9701992e3238cee6def39ca5309",
+      "sha256": "b166c3dab001ba2f8b9aee9200e9b5a106e9e721f97bcb7054eb8ba28b749b3f",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
`aimee workspace mirror-sync` blamed the server for a client-side size problem.

## The symptom

```
aimee: 'workspace.mirror-sync' could not reach the aimee-server /v1 endpoint
  (is the server running? check aimee.api.client_endpoint / AIMEE_API_ENDPOINT)
```

The server was running and answering. The same CLI, same endpoint, same moment, gave a clean server-side answer for a different workspace:

```
aimee: workspace: mirror-sync requires a registered `mirror` workspace
  (via https://192.168.1.210:8743)
```

## The cause

Size. That workspace has **247 untracked files**, so the body was **14,229,921 bytes** against the listener's **4 MiB** `SHTTP_MAX_BODY`. An over-cap body is dropped before it is parsed, so the send returns nothing — and the only thing the client had left to say was "could not reach the endpoint", pointing the operator at the one component that was demonstrably fine.

## The fix

The CLI refuses an oversized body itself and names both numbers plus the usual culprit:

```
aimee: 'workspace.mirror-sync' request body is 14229921 bytes, over the 4194304-byte
  limit the server accepts, so it would be dropped before it was read. Reduce what the
  request carries (for a workspace sync, untracked files dominate it) and retry.
```

`SHTTP_MAX_BODY` / `SHTTP_MAX_ROUNDTABLE_BODY` move from `server_http.c` into `headers/server.h`, where the sibling `LIMIT_*` values already document themselves against them. The CLI **mirrors** the values rather than including that header — its dependency chain doesn't build against the CLI — and `test_cli_v1_body_cap_matches_server` pins the two, so the refusal can't outlive the limit it enforces. The roundtable path keeps its own larger cap.

## Verification

Run against the live appliance: the command that produced the misleading message now produces the accurate one, quoted above verbatim.

`make lint` (48/48), `check_c_repository_lock`, and `unit-test-cli-v1-delegate` pass — the pin reports `ok (4194304 / 134217728)`.

## Context

Found while chasing why delegates on that appliance can't obtain a sandbox: the delegate's workspace is a client path the server can't mount, and `mirror-sync` is the supported way to give the server something to reconstruct. This misdiagnosis was blocking that route.
