### PR TITLE
llm: E2B ships QAT weights, and the docs stop quoting an F1 nobody measured

### DIFF
--- a/bench/tier-a/QUANT_DECISION.md
+++ b/bench/tier-a/QUANT_DECISION.md
@@ -17,6 +17,26 @@ apart.
 > rather than one quietly overwritten. "What would change this" still applies: the
 > E2B half needs a larger gold set, not more runs.
 
+> **THE E2B ARMS BELOW ARE NON-QAT AND NO LONGER DESCRIBE THE SHIPPED IMAGE, 2026-08-08.**
+> `aimee-llm-e2b` now bakes `unsloth/gemma-4-E2B-it-qat-GGUF` at `qat-UD-Q4_K_XL`
+> (2.62 GB), a quantisation-aware-trained checkpoint. This document's E2B rows measured
+> `unsloth/gemma-4-E2B-it-GGUF`, trained at full precision and quantised afterwards, so
+> its 0.7206 is a lower bound on the shipped model rather than a figure for it. The
+> QAT evidence is google's QAT q4_0 arm at **0.6406 strict F1 on `gold_small`
+> (n=1001)**, which is **+0.0389 over the same model's UD-Q4_K_XL** and outside the
+> +/-0.024 interval that n resolves. **That evidence is not on this branch.** It is
+> defect 39 and finding 31 in `MEASUREMENT_LOG.md` as it stands on branch
+> `bench/tier-a-small-models` (629c62eb93, 4ae31f8af8); the copy of that file beside
+> this one stops at defect 30. Two gaps remain open and are stated rather
+> than papered over: the shipped artefact is unsloth's UD *requant* of that QAT
+> checkpoint and was not benchmarked separately, and the QAT arms ran on `gold_small`
+> rather than this document's 69-note set, so no row here is directly comparable to
+> them. **E4B is untouched** — still `UD-Q6_K_XL`, still the measured half, and the
+> Q6-over-Q4 result below is still the only quant comparison in the campaign that
+> cleared significance. The operator-facing half of this note is the F1 caveat under
+> "Pick one of three" in [`docs/SYNTHESIS_MODELS.md`](../../docs/SYNTHESIS_MODELS.md);
+> the two are meant to be read together.
+
 ## The measurement
 
 Six arms, Unsloth Dynamic quants, thinking ON, `--no-mmproj`, `-c 8192`, all on

--- a/bench/tier-a/QUANT_DECISION.md
+++ b/bench/tier-a/QUANT_DECISION.md
@@ -31,7 +31,7 @@ apart.
 > than papered over: the shipped artefact is unsloth's UD *requant* of that QAT
 > checkpoint and was not benchmarked separately, and the QAT arms ran on `gold_small`
 > rather than this document's 69-note set, so no row here is directly comparable to
-> them. **E4B is untouched** — still `UD-Q6_K_XL`, still the measured half, and the
+> them. **E4B is untouched**: still `UD-Q6_K_XL`, still the measured half, and the
 > Q6-over-Q4 result below is still the only quant comparison in the campaign that
 > cleared significance. The operator-facing half of this note is the F1 caveat under
 > "Pick one of three" in [`docs/SYNTHESIS_MODELS.md`](../../docs/SYNTHESIS_MODELS.md);

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -247,7 +247,7 @@ local model. Which model it carries is a property of the tag, because the weight
 
 | image | model | weights |
 | --- | --- | --- |
-| `aimee-llm-e2b` | gemma-4-E2B-it | 2.97 GB (UD-Q4_K_XL) |
+| `aimee-llm-e2b` | gemma-4-E2B-it | 2.62 GB (qat-UD-Q4_K_XL) |
 | `aimee-llm-e4b` | gemma-4-E4B-it | 7.46 GB (UD-Q6_K_XL) |
 
 E4B is the better model; E2B is roughly half the resident memory and about twice the CPU speed. See

--- a/docs/SYNTHESIS_MODELS.md
+++ b/docs/SYNTHESIS_MODELS.md
@@ -16,7 +16,7 @@ distinction this page replaces.
 | --- | --- | --- |
 | **Simplest thing that works** | Point `SYNTHESIS_ENDPOINT` at an external OpenAI-compatible endpoint | Best quality, no local GPU or RAM cost, your notes leave the machine |
 | **Local, and quality matters most** | deploy the `aimee-llm-e4b` sidecar | 0.81 F1 extraction, 7.46 GB of weights (UD-Q6_K_XL), 3.3 tok/s on 8 CPU threads |
-| **Local, and the box is small** | deploy the `aimee-llm-e2b` sidecar | QAT weights, 2.62 GB (`qat-UD-Q4_K_XL`), ~6.3 tok/s on 8 CPU threads — both the F1 and the throughput caveats below apply |
+| **Local, and the box is small** | deploy the `aimee-llm-e2b` sidecar | QAT weights, 2.62 GB (`qat-UD-Q4_K_XL`), ~6.3 tok/s on 8 CPU threads, and both the F1 and the throughput caveats below apply |
 
 **The two images do not carry the same quant, and the asymmetry is the point.** On
 the 69-note gold set, dropping Q6 to Q4 costs E4B 0.0862 F1 (95% CI
@@ -31,20 +31,20 @@ Q6, and the F1 difference is smaller than one gold triple.
 choice from the quant.** QAT trains the model with the Q4 rounding in the loop, so
 it recovers most of what Q4 costs a model this small. Measured at n=1001 on
 `gold_small`, google's QAT q4_0 arm scores **0.6406 strict F1**, which is **+0.0389
-over the same model's UD-Q4_K_XL** — outside the +/-0.024 interval that n resolves,
+over the same model's UD-Q4_K_XL**, outside the +/-0.024 interval that n resolves,
 so it is one of the few deltas in that campaign that clears its own noise floor.
 That evidence lives on the unmerged `bench/tier-a-small-models` branch (defect 39 and
 finding 31 in its `MEASUREMENT_LOG.md`, 629c62eb93 and 4ae31f8af8), not in the copy
 of that file on this branch.
 
-**Do not read 0.6406 against the 0.81 in the table.** They are different gold sets —
-`gold_small` at n=1001 versus the 69-note set — and the campaign found that even the
+**Do not read 0.6406 against the 0.81 in the table.** They are different gold sets,
+`gold_small` at n=1001 versus the 69-note set, and the campaign found that even the
 same model on overlapping corpora moves by more than the gap between them. The
 +0.0389 is a paired within-corpus delta and is the part that transfers; the absolute
 is quoted so the delta has something to sit on, not as a rank against E4B.
 
 **The F1 number for E2B is deliberately absent from the table above.** What ships is
-unsloth's UD requant *of* google's QAT checkpoint — chosen over google's own GGUF
+unsloth's UD requant *of* google's QAT checkpoint, chosen over google's own GGUF
 because google publishes no MTP draft and no resolvable `repo:tag`, both of which
 this image's addressing depends on, and because it is 2.62 GB against google's 3.35
 GB. That requant has not been benchmarked on its own. The +0.0389 is evidence for
@@ -63,8 +63,8 @@ E4B's F1 above is its shipped quant at strict F1 on that set, measured on
 GPU so throughput is not a confound. The throughput figures are `llama-bench` at
 Q8_0 on 8 CPU threads and have NOT been re-measured at the shipped quants, so treat
 them as the shape of the gap rather than a prediction; E2B at Q4 will be somewhat
-faster than the 6.3 shown. E2B's 6.3 is doubly carried over — Q8_0 rather than the
-shipped Q4, and the non-QAT weights rather than the QAT ones — which is the same
+faster than the 6.3 shown. E2B's 6.3 is doubly carried over, Q8_0 rather than the
+shipped Q4 and the non-QAT weights rather than the QAT ones, which is the same
 reason its F1 was dropped; it is kept only because a throughput ordering survives a
 weight swap in a way an F1 figure does not. See
 [the caveats](#caveats-you-should-read-before-leaning-on-any-of-this). Resident
@@ -172,7 +172,7 @@ Q8_0; the images ship `qat-UD-Q4_K_XL` for E2B and `UD-Q6_K_XL` for E4B.
 non-QAT pair it covers scores 0.7206 (E2B Q4) and 0.8062 (E4B Q6), so the Q8_0 table
 overstates E4B slightly and understates the non-QAT E2B by more than a little. Of
 those two, only 0.8062 still describes a shipped image: E2B has since moved to QAT
-weights, so its row there is a lower bound rather than the shipped figure — see the
+weights, so its row there is a lower bound rather than the shipped figure. See the
 F1 caveat under "Pick one of three". Prefer the
 QUANT_DECISION numbers when the question is "what will I get", and this section
 when the question is "how do the two models compare on one lane".

--- a/docs/SYNTHESIS_MODELS.md
+++ b/docs/SYNTHESIS_MODELS.md
@@ -16,7 +16,7 @@ distinction this page replaces.
 | --- | --- | --- |
 | **Simplest thing that works** | Point `SYNTHESIS_ENDPOINT` at an external OpenAI-compatible endpoint | Best quality, no local GPU or RAM cost, your notes leave the machine |
 | **Local, and quality matters most** | deploy the `aimee-llm-e4b` sidecar | 0.81 F1 extraction, 7.46 GB of weights (UD-Q6_K_XL), 3.3 tok/s on 8 CPU threads |
-| **Local, and the box is small** | deploy the `aimee-llm-e2b` sidecar | 0.72 F1 extraction, 2.97 GB of weights (UD-Q4_K_XL), 6.3 tok/s on 8 CPU threads |
+| **Local, and the box is small** | deploy the `aimee-llm-e2b` sidecar | QAT weights, 2.62 GB (`qat-UD-Q4_K_XL`), ~6.3 tok/s on 8 CPU threads — both the F1 and the throughput caveats below apply |
 
 **The two images do not carry the same quant, and the asymmetry is the point.** On
 the 69-note gold set, dropping Q6 to Q4 costs E4B 0.0862 F1 (95% CI
@@ -27,18 +27,46 @@ its tie is broken by the role E2B exists for. On the small box where you would p
 E2B at all, Q4 is 1.70 GB of VRAM and 2.68 GB of host RSS against 2.30 and 3.86 at
 Q6, and the F1 difference is smaller than one gold triple.
 
-Be careful reading that as "Q4 is free for E2B". It is not measured to be equal. It
-is measured to be *indistinguishable*, which is a statement about the set as much as
-the model, and `QUANT_DECISION.md` argues the opposite call on a directional prior
-(pooled P(Q6 > Q4) = 0.946). The full six-arm table, the memory figures, and what
+**E2B additionally ships quantisation-aware-trained weights, and that is a separate
+choice from the quant.** QAT trains the model with the Q4 rounding in the loop, so
+it recovers most of what Q4 costs a model this small. Measured at n=1001 on
+`gold_small`, google's QAT q4_0 arm scores **0.6406 strict F1**, which is **+0.0389
+over the same model's UD-Q4_K_XL** — outside the +/-0.024 interval that n resolves,
+so it is one of the few deltas in that campaign that clears its own noise floor.
+That evidence lives on the unmerged `bench/tier-a-small-models` branch (defect 39 and
+finding 31 in its `MEASUREMENT_LOG.md`, 629c62eb93 and 4ae31f8af8), not in the copy
+of that file on this branch.
+
+**Do not read 0.6406 against the 0.81 in the table.** They are different gold sets —
+`gold_small` at n=1001 versus the 69-note set — and the campaign found that even the
+same model on overlapping corpora moves by more than the gap between them. The
++0.0389 is a paired within-corpus delta and is the part that transfers; the absolute
+is quoted so the delta has something to sit on, not as a rank against E4B.
+
+**The F1 number for E2B is deliberately absent from the table above.** What ships is
+unsloth's UD requant *of* google's QAT checkpoint — chosen over google's own GGUF
+because google publishes no MTP draft and no resolvable `repo:tag`, both of which
+this image's addressing depends on, and because it is 2.62 GB against google's 3.35
+GB. That requant has not been benchmarked on its own. The +0.0389 is evidence for
+QAT weights, not for this particular requant of them, and the old 0.72 belongs to the
+non-QAT build that no longer ships. Quoting either as the shipped figure would be
+inventing a measurement. E4B's 0.81 is unaffected: that image is unchanged.
+
+Be careful reading the Q6/Q4 result as "Q4 is free for E2B". It is not measured to be
+equal. It is measured to be *indistinguishable*, which is a statement about the set as
+much as the model, and `QUANT_DECISION.md` argues the opposite call on a directional
+prior (pooled P(Q6 > Q4) = 0.946). The full six-arm table, the memory figures, and what
 would resolve the E2B half are in
 [`bench/tier-a/QUANT_DECISION.md`](../bench/tier-a/QUANT_DECISION.md).
 
-The F1 figures above are the shipped quants at strict F1 on that set, measured on
+E4B's F1 above is its shipped quant at strict F1 on that set, measured on
 GPU so throughput is not a confound. The throughput figures are `llama-bench` at
 Q8_0 on 8 CPU threads and have NOT been re-measured at the shipped quants, so treat
 them as the shape of the gap rather than a prediction; E2B at Q4 will be somewhat
-faster than the 6.3 shown. See
+faster than the 6.3 shown. E2B's 6.3 is doubly carried over — Q8_0 rather than the
+shipped Q4, and the non-QAT weights rather than the QAT ones — which is the same
+reason its F1 was dropped; it is kept only because a throughput ordering survives a
+weight swap in a way an F1 figure does not. See
 [the caveats](#caveats-you-should-read-before-leaning-on-any-of-this). Resident
 memory is larger than the weights by the KV cache for your configured context, which
 is a deployment setting rather than a property of the model.
@@ -139,10 +167,13 @@ difference is insignificant. The paired test is the one to read.
 
 **The quantisation in the tables above does not match what ships, and the gap is
 now measured rather than assumed.** Every number in this section was taken at
-Q8_0; the images ship UD-Q4_K_XL for E2B and UD-Q6_K_XL for E4B.
-`bench/tier-a/QUANT_DECISION.md` measures all six arms on the same gold set, and
-the shipped pair scores 0.7206 (E2B Q4) and 0.8062 (E4B Q6), so the Q8_0 table
-overstates E4B slightly and understates E2B by more than a little. Prefer the
+Q8_0; the images ship `qat-UD-Q4_K_XL` for E2B and `UD-Q6_K_XL` for E4B.
+`bench/tier-a/QUANT_DECISION.md` measures all six arms on the same gold set, and the
+non-QAT pair it covers scores 0.7206 (E2B Q4) and 0.8062 (E4B Q6), so the Q8_0 table
+overstates E4B slightly and understates the non-QAT E2B by more than a little. Of
+those two, only 0.8062 still describes a shipped image: E2B has since moved to QAT
+weights, so its row there is a lower bound rather than the shipped figure — see the
+F1 caveat under "Pick one of three". Prefer the
 QUANT_DECISION numbers when the question is "what will I get", and this section
 when the question is "how do the two models compare on one lane".
 
@@ -215,7 +246,7 @@ target lives (it moved from `examples/` to `tools/`, which changes the cmake
 flags).
 
 **The model-to-repo mapping is fixed at build time, not resolved at run time.**
-`gemma-4-E2B-it` maps to `unsloth/gemma-4-E2B-it-GGUF` at `UD-Q4_K_XL` and
+`gemma-4-E2B-it` maps to `unsloth/gemma-4-E2B-it-qat-GGUF` at `qat-UD-Q4_K_XL` and
 `gemma-4-E4B-it` to `unsloth/gemma-4-E4B-it-GGUF` at `UD-Q6_K_XL`: per-model
 quants, decided by measurement (see QUANT_DECISION.md), with
 `scripts/synthesis-model-table.sh` as the single source of truth for the pairing
@@ -302,8 +333,8 @@ It buys an operational property too. The sidecar holds no data, so moving betwee
 synthesis to a running deployment, or removing it, is a container swap with the kb left running. The
 embedder is still a one-way door; synthesis is not.
 
-Weights are baked per-model, 7.46 GB for E4B at UD-Q6_K_XL and 2.97 GB for E2B at
-UD-Q4_K_XL, from unsloth's GGUF repos, which is where the UD quants are published.
+Weights are baked per-model, 7.46 GB for E4B at UD-Q6_K_XL and 2.62 GB for E2B at
+qat-UD-Q4_K_XL, from unsloth's GGUF repos, which is where the UD quants are published.
 The quant is a property of the model, not of the channel; see
 `scripts/synthesis-model-table.sh`.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -286,7 +286,7 @@ deliberate bumping.
 ## Bundled synthesis weights are baked into the image
 
 The weights ship inside the `aimee-llm-*` images, at a quant chosen per model:
-7.46 GB for E4B at UD-Q6_K_XL, 2.97 GB for E2B at UD-Q4_K_XL. The container downloads nothing at any point: an image either has its model
+7.46 GB for E4B at UD-Q6_K_XL, 2.62 GB for E2B at qat-UD-Q4_K_XL. The container downloads nothing at any point: an image either has its model
 or it does not, and `docker pull` is the one download, with the registry's retry and
 resume behind it.
 

--- a/frontend/src/setup/deployTopology.ts
+++ b/frontend/src/setup/deployTopology.ts
@@ -101,12 +101,12 @@ export const SYNTHESIS_MODELS: SynthesisModelChoice[] = [
   {
     id: 'gemma-4-E4B-it',
     label: 'gemma-4-E4B-it',
-    blurb: 'The better model. 7.46 GB at UD-Q6_K_XL, deployed as the aimee-llm-e4b sidecar.',
+    blurb: 'The better model. 7.46 GB at UD-Q6_K_XL, deployed as the aimee-llm-e4b sidecar. Measured at 0.81 F1 extraction.',
   },
   {
     id: 'gemma-4-E2B-it',
     label: 'gemma-4-E2B-it',
-    blurb: '2.97 GB at UD-Q4_K_XL, deployed as aimee-llm-e2b. Faster, and weaker at extraction (0.72 F1 against 0.81).',
+    blurb: '2.62 GB at qat-UD-Q4_K_XL, deployed as aimee-llm-e2b. Faster, and weaker at extraction. Its quantisation-aware-trained weights measured +0.039 F1 over the plain Q4 build on a different gold set, but this exact requant has not been benchmarked, so no F1 is quoted for it.',
   },
 ];
 

--- a/scripts/fetch-synthesis-model.sh
+++ b/scripts/fetch-synthesis-model.sh
@@ -20,7 +20,15 @@
 #
 # An explicit repo+filename per model id: no quant-tag resolution at runtime,
 # which is what silently served the wrong file when a tag stopped matching.
-# UD-Q6_K_XL (Unsloth Dynamic Q6) is published only in unsloth's repos.
+# The UD (Unsloth Dynamic) quants are published only in unsloth's repos.
+#
+# THE TWO ENTRIES ARE DELIBERATELY NOT THE SAME QUANT, and E2B is deliberately the
+# QAT checkpoint: see the header of scripts/synthesis-model-table.sh, which carries
+# the reasoning and the measurement. KEEP THE TWO TABLES IN STEP. They serve
+# different builds -- that one Dockerfile.llm, this one Dockerfile.model -- and they
+# have drifted before: this entry sat on a non-QAT UD-Q6_K_XL E2B while the other
+# had moved to UD-Q4_K_XL, so the model image and the sidecar image disagreed about
+# which weights "gemma-4-E2B-it" names.
 set -eu
 
 model=${1:?usage: fetch-synthesis-model.sh <model-id> <outdir>}
@@ -29,8 +37,8 @@ mirror=${AIMEE_MODEL_MIRROR:-}
 
 case "$model" in
   gemma-4-E2B-it)
-    repo=unsloth/gemma-4-E2B-it-GGUF; file=gemma-4-E2B-it-UD-Q6_K_XL.gguf
-    sha=ae15474bc78f68c6a44bd17cad32f672b9501d90c4a0eed2fceeb6878ed530c5 ;;
+    repo=unsloth/gemma-4-E2B-it-qat-GGUF; file=gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf
+    sha=e531007218dfab990486a5de7676a6932d6ea8dea233d1f698d7c21cf8a16889 ;;
   gemma-4-E4B-it)
     repo=unsloth/gemma-4-E4B-it-GGUF; file=gemma-4-E4B-it-UD-Q6_K_XL.gguf
     sha=17b9c459b28b420ce20d75bcfc329db4fac1343792a964c3ae2e2680ce768932 ;;

--- a/scripts/synthesis-model-table.sh
+++ b/scripts/synthesis-model-table.sh
@@ -12,7 +12,25 @@
 # is 1.6-1.8x slower with nothing to indicate why.
 #
 # THE QUANT IS PER MODEL, not one global. E2B ships Q4 because it is the small-box
-# option and 1.4 GB matters there; E4B ships Q6 because it is the quality option.
+# option and every GB matters there; E4B ships Q6 because it is the quality option.
+#
+# E2B ALSO SHIPS QAT WEIGHTS, and that is why its quant tag carries a `qat-` prefix
+# while E4B's does not. Quantisation-aware training recovers most of what Q4 costs a
+# model this small: the campaign measured google's QAT q4_0 arm at +0.0389 strict F1
+# over the same model's UD-Q4_K_XL, a delta outside the +/-0.024 interval that n=1001
+# resolves. That evidence is NOT on this branch -- it is defect 39 in
+# bench/tier-a/MEASUREMENT_LOG.md on branch bench/tier-a-small-models (629c62eb93),
+# whose copy of that file runs past the defect 30 this branch stops at. What ships here is unsloth's
+# UD requant OF THAT QAT CHECKPOINT -- it keeps the repo-shaped addressing and the
+# in-repo MTP draft that google's GGUF repo does not publish, and it is 2.62 GB
+# against google's 3.35 GB. It has NOT been benchmarked separately; the +0.0389 is
+# evidence for QAT weights, not for this exact requant of them.
+#
+# The `qat-` prefix lives in the QUANT rather than the model id on purpose: the model
+# id is the image axis (aimee-llm-e2b) and is referenced from config, the wizard and
+# the deploy layer, while `files` builds ${model}-${quant}.gguf -- which is exactly
+# the published gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf. The MTP draft is NOT qat-tagged
+# in that repo; it is mtp-${model}.gguf, so that half of `files` is unchanged.
 #
 # THE SHA256 IS THE POINT. It is Hugging Face's own LFS oid, which is also the name
 # HF gives the blob in its cache -- so a baked cache is self-verifying: the filename
@@ -35,10 +53,10 @@ model=${2:?usage: synthesis-model-table.sh <repo|quant|sha|mtpsha|files> <model-
 
 case "$model" in
   gemma-4-E2B-it)
-    repo=unsloth/gemma-4-E2B-it-GGUF
-    quant=UD-Q4_K_XL
-    sha=b52f438017efaec5debf1c0d8be690571e212a07c312f1102bbce927258cfc32
-    mtpsha=9eba819938efccfd6044f8af84e3bbfddc639a2bcf32ebc36420e6a649191919 ;;
+    repo=unsloth/gemma-4-E2B-it-qat-GGUF
+    quant=qat-UD-Q4_K_XL
+    sha=e531007218dfab990486a5de7676a6932d6ea8dea233d1f698d7c21cf8a16889
+    mtpsha=586f2460b909008640981ec34060aa864e03c144fbabfb3173c4335087e4aae0 ;;
   gemma-4-E4B-it)
     repo=unsloth/gemma-4-E4B-it-GGUF
     quant=UD-Q6_K_XL


### PR DESCRIPTION
`aimee-llm-e2b` now bakes **`unsloth/gemma-4-E2B-it-qat-GGUF` at `qat-UD-Q4_K_XL`** (2.62 GB) in place of `unsloth/gemma-4-E2B-it-GGUF` at `UD-Q4_K_XL` (2.97 GB).

**E4B is untouched** — same repo, same `UD-Q6_K_XL`, same two digests. The only E4B lines in the diff are comments. Its Q6 is the one quant comparison in the campaign that cleared significance, and nothing here disturbs it.

| | before | after |
|---|---|---|
| repo | `unsloth/gemma-4-E2B-it-GGUF` | `unsloth/gemma-4-E2B-it-qat-GGUF` |
| quant | `UD-Q4_K_XL` | `qat-UD-Q4_K_XL` |
| size | 2.97 GB | 2.62 GB |

## Why QAT

Quantisation-aware training recovers most of what Q4 costs a model this small. Google's QAT q4_0 arm measured **0.6406 strict F1 on `gold_small` (n=1001), +0.0389 over the same model's UD-Q4_K_XL** — outside the ±0.024 interval n=1001 resolves, so one of the few deltas in that campaign that clears its own noise floor.

## Why unsloth's requant and not google's GGUF, given google's is the arm that was measured

`google/gemma-4-E2B-it-qat-q4_0-gguf` publishes no `mtp-*.gguf` and its `repo:tag` manifests return 400. This image depends on both: the MTP draft is a separate artefact resolved from the same repo by `-hfd`, and the entrypoint addresses the model repo-shaped precisely because the file-path form does not engage MTP. Taking google's would have meant a second repo for the draft plus a new addressing path, to ship 3.35 GB where unsloth ships 2.62.

**What that costs, stated rather than glossed:** the shipped artefact is unsloth's UD requant *of* google's QAT checkpoint and has not been benchmarked on its own. The +0.0389 is evidence for QAT weights, not for this requant of them.

## Why no F1 is quoted for E2B anywhere user-facing

Neither available number is honest as "what you get":

- the old **0.72** belongs to weights that no longer ship;
- **0.6406** is a different build on a different gold set, and printed beside E4B's 0.81 it reads as a rank when the two sets are not comparable.

So the caveat carries the delta, the absolute, and the corpus mismatch, and the table carries no E2B F1. The throughput figure is kept and annotated — a throughput ordering survives a weight swap in a way an F1 figure does not.

## Also fixed: a drift between the two model tables

`fetch-synthesis-model.sh`'s E2B entry sat on a non-QAT `UD-Q6_K_XL` while `synthesis-model-table.sh` had moved to `UD-Q4_K_XL`, so `Dockerfile.model` and `Dockerfile.llm` disagreed about which weights `gemma-4-E2B-it` names. Both files now carry the same coordinates and a header saying to keep them in step.

## The bench evidence is not on this branch

`bench/tier-a/MEASUREMENT_LOG.md` here stops at defect 30. Defect 39 and finding 31 live on `bench/tier-a-small-models` (`629c62eb93`, `4ae31f8af8`). Every citation names the branch and commit rather than pointing at a local file that does not contain them. Merging that evidence forward is worth doing separately.

## Verified

- Both digests against HF `paths-info`: `e5310072…` main (2,620,370,976 bytes), `586f2460…` MTP.
- `-hf repo:qat-UD-Q4_K_XL` resolves to the same model blob the Dockerfile waits on.
- `files` output for both models; `sh -n` on both scripts; unknown model still exits 1.
- No stale `2.97 GB` / `0.72 F1` / old-repo references outside the historical `bench/` records, which are left alone.
- Roundtable review: approved, six suggestions, all applied except the digest re-check already done.

## Not verified — needs the CI image build

That `-hfd "$repo"` picks the root `mtp-gemma-4-E2B-it.gguf`. Inferred from the two working builds on the same repo layout, not observed. A wrong pick fails the blob wait loudly rather than shipping a draft-less image.

The shipped requant's own F1 is also unmeasured. Benching it is the follow-up, and it is what would let a number go back into the table.

## Rebuild note

`rev` hashes `synthesis-model-table.sh`, so **both** `aimee-llm-e2b` and `aimee-llm-e4b` rebuild and get new tags. E4B's weights are byte-identical; only its tag moves.
