### PR TITLE
build: retire the binary a rename left behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /aimee-server
 aimee-forwarder
 /aimee-mcp
+/aimee-webchat
 /aimee-kb
 /aimee-witness-verify
 /aimee-kb-resolver

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,12 @@ KB_STATUS_AUTHORITY = ../aimee-kb-status-authority$(EXEEXT)
 KB_TOKEN_AUTHORITY = ../aimee-kb-token-authority$(EXEEXT)
 RUNTIME_WEB = ../aimee-runtime-web$(EXEEXT)
 GATEWAY = ../aimee-gateway$(EXEEXT)
-RETIRED_ROOT_BINARIES = ../aimee-client$(EXEEXT) ../aimee-worker$(EXEEXT)
+# Binaries a rename left behind. `all` removes these first so a renamed artifact
+# does not sit in the repo root forever: aimee-webchat became aimee-runtime-web
+# and its 14MB predecessor was never retired, so it stayed untracked, unignored,
+# and large enough to push a workspace sync past the server's 4MB body cap.
+RETIRED_ROOT_BINARIES = ../aimee-client$(EXEEXT) ../aimee-worker$(EXEEXT) \
+                        ../aimee-webchat$(EXEEXT)
 
 # aimee-runtime-web is the only Go artifact and needs the Go toolchain (go.mod pins a
 # newer Go than some distros package, e.g. Debian 13 ships 1.24). The C services


### PR DESCRIPTION
A 14,675,256-byte unstripped ELF binary, `aimee-webchat`, sits in the repo root. **No rule builds it** — the Go browser UI became `aimee-runtime-web` (`RUNTIME_WEB`), and the predecessor was never added to `RETIRED_ROOT_BINARIES`. Every `make all` since the rename has walked straight past it.

It was also missing from `.gitignore`, which already covers its siblings:

```
/aimee-client   /aimee-worker   /aimee-runtime-web
```

So it was **untracked and unignored** — one `git add -A` from being committed. `.gitignore` even carries a comment about that exact accident happening once before:

> *Provisioning and authority binaries. These were absent, so a `git add -A` after building them committed the artifacts — which is exactly what happened once.*

## It broke something real

`aimee workspace mirror-sync` ships the untracked set. This one file is **88% of a 16.7MB payload** against the listener's 4MB cap, so the workspace could not be synced to the server at all while it sat there — which in turn is what blocks a server-side delegate from getting a workspace it can mount.

## Retired, not just ignored

Ignoring alone would hide a dead file forever, and being unnoticed is precisely how it reached 14MB and broke sync. `make` now deletes it, the same way `aimee-client` and `aimee-worker` are handled, and `.gitignore` covers it so a stale copy can't be committed before the next build clears it.

```
$ make -n retire-obsolete-binaries
rm -rf ../aimee-client ../aimee-worker ../aimee-webchat
```

## Audit performed alongside

- **Tracked files that are compiled artifacts: none.** Checked by content (`file --mime-type` over every path in `git ls-files`), not by extension — so a binary with an innocuous name would still have been caught.
- **Untracked, unignored compiled artifacts: exactly this one.**

So the repo carries no committed binaries, and after this the working tree carries no unignored ones either.

## Verification

`make lint` — all 48 checks pass.
