### PR TITLE
fix: let a detached workspace record what a client-less turn needs

### DIFF
--- a/src/server/server_runner_endpoints.c
+++ b/src/server/server_runner_endpoints.c
@@ -156,9 +156,20 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          return server_send_error(conn, "workspace: not a directory", NULL);
    }
 
-   /* Mirror workspaces carry the client VCS coordinates the lifecycle seeds from. */
-   int add_rc = config_workspace_add(abs, provider, is_mirror ? remote : NULL,
-                                     (is_mirror && head) ? head : NULL);
+   /* Mirror workspaces carry the client VCS coordinates the lifecycle seeds from.
+    *
+    * A DETACHED workspace may carry them too. It is served by its client, so
+    * while that client is connected nothing here is used — the live tree is
+    * better than any reconstruction of it. But a background delegate runs after
+    * the dispatching client has gone, and then the alternative is not a stale
+    * tree, it is no tree at all: the turn lands in a scratch directory holding no
+    * repository. Recording the coordinates lets that case fall back to the
+    * server-side reconstruction instead, which is what
+    * workspace_turn_resolve_detached_mirror_cwd exists to do. Nothing could set
+    * them before, so that fallback was unreachable. */
+   int wants_vcs = is_mirror || is_detached;
+   int add_rc = config_workspace_add(abs, provider, wants_vcs ? remote : NULL,
+                                     (wants_vcs && head) ? head : NULL);
    /* Already registered is the state the caller asked for, so it is not an
     * error: workspace.add is idempotent. Rejecting the second call made every
     * re-run of any automation that registers its workspace fail at setup,
@@ -302,19 +313,33 @@ int handle_workspace_mirror_sync(server_ctx_t *ctx, server_conn_t *conn, cJSON *
    const char *root = argv[0];
    const char *diff = jo_str(req, "diff", "");
 
-   /* Only a registered `mirror` workspace has a server-side tree to mirror. */
-   int is_mirror = 0;
+   /* A `mirror` workspace always has a server-side tree to mirror. A `detached`
+    * one does too once it has recorded a remote — its client serves the live tree
+    * while connected, but a background delegate arrives after that client is gone
+    * and would otherwise get a scratch directory with no repository in it. Both
+    * reconstruct through the same path, so both may sync into it; a workspace
+    * with no remote recorded has nothing to reconstruct from and is refused. */
+   int syncable = 0, has_remote = 0;
+   ws_provider_kind_t kind = WS_PROVIDER_SHARED;
    int ws_n = config_workspace_count();
    for (int i = 0; i < ws_n; i++)
       if (strcmp(config_workspaces(i), root) == 0)
       {
-         is_mirror =
-             ws_provider_kind_from_string(config_workspace_providers(i)) == WS_PROVIDER_MIRROR;
+         kind = ws_provider_kind_from_string(config_workspace_providers(i));
+         has_remote = config_workspace_vcs_remote(i)[0] != '\0';
+         syncable = (kind == WS_PROVIDER_MIRROR) || (kind == WS_PROVIDER_DETACHED && has_remote);
          break;
       }
-   if (!is_mirror)
+   if (!syncable)
       return server_send_error(
-          conn, "workspace: mirror-sync requires a registered `mirror` workspace", NULL);
+          conn,
+          kind == WS_PROVIDER_DETACHED
+              ? "workspace: this detached workspace has no remote recorded, so there is nothing to "
+                "reconstruct from. Re-register it with `--remote <url>` (and `--head <sha>`), or "
+                "use `--provider mirror`."
+              : "workspace: mirror-sync requires a `mirror` workspace, or a `detached` one with a "
+                "remote recorded",
+          NULL);
 
    /* The patch and the commit it applies to arrive together, and the registry is
     * updated from the same request. A client's base moves whenever the developer
@@ -340,7 +365,12 @@ int handle_workspace_mirror_sync(server_ctx_t *ctx, server_conn_t *conn, cJSON *
    const char *client_head = jo_str(req, "head", "");
    if (final && client_head && client_head[0])
    {
-      (void)config_workspace_add(root, "mirror", NULL, client_head);
+      /* Keep the registered provider. Hardcoding "mirror" here would silently
+       * convert a detached workspace on its first sync, and a detached workspace
+       * is detached on purpose: its client serves the live tree, which is better
+       * than any reconstruction while that client is connected. The head is
+       * recorded for the case where no client is. */
+      (void)config_workspace_add(root, ws_provider_kind_to_string(kind), NULL, client_head);
       /* Republish the live snapshot, for the same reason workspace.add does:
        * config_load() serves the snapshot rather than disk in the server, so
        * without this the head sits correct on disk while every reader — the


### PR DESCRIPTION
Closes the gap that made a background delegate land in a directory with no repository in it — without forcing a choice between live file serving and working delegates.

## Correct code, unreachable condition

`workspace_turn_resolve_detached_mirror_cwd` (added earlier in this series) reconstructs a server-side tree for a **detached** workspace from its recorded `remote` and `head`, so a background delegate — which runs *after* the dispatching client has disconnected — gets a real checkout instead of a scratch directory.

Nothing could ever record those coordinates:

- `workspace.add` stored `remote`/`head` **only** for a `mirror` workspace
- `mirror-sync` **refused** anything that wasn't one

So the fallback was guarded by a condition that could not occur. My own change, dead on arrival.

## Three changes

| | |
|---|---|
| **add** | stores `remote`/`head` for a detached workspace too. They're the client's own VCS coordinates either way, and while its client is connected nothing reads them — the live tree beats any reconstruction. They matter only when no client is there. |
| **mirror-sync** | accepts a detached workspace that has a remote recorded (both providers reconstruct through the same path), and refuses one without a remote by naming exactly what to re-register. |
| **head update** | keeps the registered provider instead of hardcoding `"mirror"`, which silently converted a detached workspace on its first sync. |

That last one matters on its own: a first sync used to change what a workspace *is*.

## No forced tradeoff

The alternative was telling you to re-register as `--provider mirror`, which downgrades interactive work — a mirror shows the last synced state, detached serves live files.

**A detached workspace stays detached.** Its client keeps serving the live tree interactively; the recorded coordinates come into play only for a turn that has no client at all, where the alternative isn't a stale tree, it's no tree.

## Verified end to end

Against a real `aimee-server` built from this branch:

```
provider after add:
  /tmp/…/repo  [detached remote=/tmp/…/origin.git head=2f9a4606d8]

workspace mirror-sync: shipped 4516176 byte(s) in 36 chunk(s)
stored bytes: 4516176 (chunk size 131072)
RESULT: reassembled patch applies cleanly to a checkout at base

provider after sync:
  /tmp/…/repo  [detached remote=/tmp/…/origin.git head=2f9a4606d8]
```

Coordinates recorded, a detached workspace synced, patch valid, and the provider unchanged afterwards.

## Gates

`make unit-tests` (full suite, all binaries linked), `make lint` (48/48), `check_c_repository_lock`, `refactor_baselines`, and `module-inventory` — all pass locally. That's every CI job that has caught something in this series.
