### PR TITLE
feat(memory): close the event-time interval when a memory is superseded

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "fa5fe6655d8abd3181a917ea04b14848fc2eaf58858be3336b67c72d963286b6",
+      "source_sha256": "01defe377ebf6e91a5b19ead7e3431a6ea3da9d3dc22830911abc2b6b5b77eb9",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 7,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "b325907e3b20606f5568b19ddda0bf3c5eff7f6aee3cb916d8d3251b9b81af32",
+      "source_sha256": "ebbab11bd28ba34bd532596414c2b082a11124879b223ea34b7e65112206e785",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 7,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "6877b9eb94e6a8bb395b304231caa4c1472208143a0a3f9aa346e9b6a3428e0f",
+      "source_sha256": "4a869b7c4e3caa830cca3918e3d20dd5497aead391fdd80e1a022f392139ef3a",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 7,

--- a/src/db2/memory_lifecycle.c
+++ b/src/db2/memory_lifecycle.c
@@ -52,11 +52,30 @@ int db2_memory_lifecycle_update_state(int64_t memory_id, const char *new_state,
    const char *reason = (archive_reason && archive_reason[0]) ? archive_reason : "";
 
    /* Same UPDATE shape as the legacy memory_transition_lifecycle: leaving
-    * `pending` clears ttl_at; entering `archived` records the reason. */
+    * `pending` clears ttl_at; entering `archived` records the reason.
+    *
+    * Entering `superseded` or `archived` additionally CLOSES the row's event-time
+    * interval by stamping valid_until.
+    *
+    * Why: lifecycle_state answers "is this true NOW", and that is all it can
+    * answer. It cannot answer "what did we believe on 12 June" -- a superseded
+    * row looks identically superseded whether it stopped being true yesterday or
+    * last year. memory_relations already carries valid_at/invalid_at and has a
+    * working --as-of read path; memories carried valid_from/valid_until columns
+    * that supersession never populated, so the same question about a PREFERENCE
+    * or a DECISION -- exactly the facts most likely to change -- had no answer.
+    *
+    * Only set when currently empty, so a valid_until asserted by a caller who
+    * knows the real end date is never overwritten by the transition timestamp.
+    * The stamp is when we LEARNED it stopped being true, which is the honest
+    * value available here; a caller with better information should say so. */
    static const char *sql =
        "UPDATE memories SET lifecycle_state = ?1,"
        " ttl_at = CASE WHEN ?2 = 'pending' THEN ttl_at ELSE '' END,"
        " archive_reason = CASE WHEN ?3 = 'archived' THEN ?4 ELSE archive_reason END,"
+       " valid_until = CASE WHEN ?6 IN ('superseded','archived') AND"
+       "                         COALESCE(valid_until,'') = ''"
+       "                    THEN pg_now_text() ELSE valid_until END,"
        " updated_at = pg_now_text() WHERE id = ?5";
    char err[ML_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
@@ -67,9 +86,38 @@ int db2_memory_lifecycle_update_state(int64_t memory_id, const char *new_state,
    aimee_pg_bind_text(st, "?3", new_state);
    aimee_pg_bind_text(st, "?4", reason);
    aimee_pg_bind_int64(st, "?5", memory_id);
+   aimee_pg_bind_text(st, "?6", new_state);
    int rc = aimee_pg_step(st, err, sizeof(err));
    aimee_pg_finalize(st);
    return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+int db2_memory_valid_at(int64_t memory_id, const char *as_of)
+{
+   if (memory_id <= 0 || !as_of || !*as_of)
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   /* Absent bounds are OPEN, not closed: an empty valid_from means "as far back
+    * as we know", an empty valid_until means "still true". Rows written before
+    * supersession began stamping valid_until therefore read as current -- the
+    * truthful answer, since we genuinely do not know when they stopped being
+    * true. Inventing a boundary from updated_at would manufacture history. */
+   static const char *sql = "SELECT 1 FROM memories WHERE id = ?1"
+                            " AND (COALESCE(valid_from,'') = '' OR valid_from <= ?2)"
+                            " AND (COALESCE(valid_until,'') = '' OR valid_until > ?3)";
+   char err[ML_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", memory_id);
+   aimee_pg_bind_text(st, "?2", as_of);
+   aimee_pg_bind_text(st, "?3", as_of);
+   int rc = aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+   return (rc == AIMEE_PG_ROW) ? 1 : 0;
 }
 
 int db2_memory_lifecycle_mark_pending(int64_t memory_id, int ttl_days)

--- a/src/db2/memory_lifecycle.h
+++ b/src/db2/memory_lifecycle.h
@@ -76,6 +76,25 @@ extern "C"
    /* Per-state counts. Returns 0 on success. */
    int db2_memory_lifecycle_counts(db2_memory_lifecycle_counts_t *out);
 
+   /* Was this memory true at `as_of`, in EVENT time?
+    *
+    * lifecycle_state answers "is this true now" and nothing else -- a superseded
+    * row looks identically superseded whether it stopped being true yesterday or
+    * last year. This reads the valid_from/valid_until interval instead, so
+    * "what did we believe on 12 June" is answerable for rows the way it already
+    * is for relations (memory_relations.valid_at/invalid_at, --as-of).
+    *
+    * `as_of` is an ISO-8601 timestamp. Returns 1 when the row was in force,
+    * 0 when it was not, -1 on a bad call or no connection.
+    *
+    * An empty valid_from means "as far back as we know" and an empty valid_until
+    * means "still true": absent bounds are open, never closed. A row written
+    * before supersession started stamping valid_until therefore still reads as
+    * current, which is the truthful answer for it -- we do not know when it
+    * stopped being true, and inventing a boundary would be worse than admitting
+    * the interval is open. */
+   int db2_memory_valid_at(int64_t memory_id, const char *as_of);
+
    /* Alert rows. Each fills up to `max` entries and returns the count
     * written. */
    int db2_memory_lifecycle_list_stale_pending(db2_memory_lifecycle_stale_t *out, int max);

--- a/src/tests/test_memory_advanced.c
+++ b/src/tests/test_memory_advanced.c
@@ -10,6 +10,7 @@
 #include "db1.h"
 #include "db2.h"
 #include "db2_test_shim.h"
+#include "db2/memory_lifecycle.h" /* db2_memory_valid_at */
 #include "modules/memory/memory_ontology.h"
 #include "../db2/bandit.h"
 #include "../db2/db2_internal.h"
@@ -1997,6 +1998,48 @@ int main(void)
       /* maybe_run is gated on memory_maintenance.enabled; say so in config. */
       write_test_config("memory_maintenance:\n  enabled: false\n");
       assert(memory_maintenance_maybe_run(NULL) == 0);
+   }
+
+   /* --- event-time intervals: "what did we believe on <date>" ---
+    *
+    * lifecycle_state answers "is this true NOW" and nothing more: a superseded
+    * row looks identically superseded whether it stopped being true yesterday or
+    * last year. Closing valid_until at the transition makes the point-in-time
+    * question answerable for ROWS the way it already is for relations. */
+   {
+      memory_t m;
+      assert(memory_insert(TIER_L2, KIND_PREFERENCE, "bt:pref", "deploy on Fridays is fine", 0.9,
+                           "s-bt", &m) == 0);
+
+      /* While active the interval is open at both ends: true then, true now,
+       * true at an absurd future date. An open bound must never read as closed. */
+      assert(db2_memory_valid_at(m.id, "2000-01-01 00:00:00") == 1);
+      assert(db2_memory_valid_at(m.id, "2099-01-01 00:00:00") == 1);
+
+      /* Supersede it. This is the transition that closes the interval. */
+      assert(memory_transition_lifecycle(m.id, MEMORY_LIFECYCLE_STATE_SUPERSEDED, NULL) == 0);
+
+      /* The past is unchanged -- it WAS true then, and rewriting history is
+       * exactly what a state flag does by omission. */
+      assert(db2_memory_valid_at(m.id, "2000-01-01 00:00:00") == 1);
+      /* ...and it is no longer true at a date after the close. */
+      assert(db2_memory_valid_at(m.id, "2099-01-01 00:00:00") == 0);
+
+      /* Bad calls are refused rather than guessed. */
+      assert(db2_memory_valid_at(m.id, NULL) == -1);
+      assert(db2_memory_valid_at(m.id, "") == -1);
+      assert(db2_memory_valid_at(0, "2020-01-01 00:00:00") == -1);
+
+      /* A row that never closed reads as still true at any date. Rows written
+       * before this stamping existed fall here, and "still true" is the honest
+       * answer for them: we do not know when they stopped, and manufacturing a
+       * boundary would be worse than leaving the interval open. */
+      memory_t open_row;
+      assert(memory_insert(TIER_L2, KIND_FACT, "bt:open", "never superseded", 0.9, "s-bt",
+                           &open_row) == 0);
+      assert(db2_memory_valid_at(open_row.id, "2099-01-01 00:00:00") == 1);
+
+      printf("  bitemporal_rows: ok\n");
    }
 
    db2_test_shim_close();


### PR DESCRIPTION
Fourth of the memory gap-analysis findings.

`lifecycle_state` answers *"is this true **now**"* and nothing more. A superseded row looks identically superseded whether it stopped being true yesterday or last year — so *"what did we believe on 12 June"* was unanswerable for memories. That is exactly the question that matters for a **preference** or a **decision**: the facts most likely to have changed.

`memory_relations` already carries `valid_at`/`invalid_at` with a working `--as-of` read path. The `memories` table has carried `valid_from`/`valid_until` columns all along, and supersession never populated them — the row half of the bi-temporal model was declared but never wired.

## Two halves, both small

**Write.** `db2_memory_lifecycle_transition` stamps `valid_until` when a row enters `superseded` or `archived` — and **only when it is currently empty**, so a `valid_until` asserted by a caller who knows the real end date is never overwritten by the transition timestamp. The stamp records when we *learned* it stopped being true, which is the honest value available at that point.

**Read.** `db2_memory_valid_at(id, as_of)`.

## Absent bounds are open, never closed

Empty `valid_from` means "as far back as we know"; empty `valid_until` means "still true".

Rows written before this stamping existed therefore read as **still current**. That is the truthful answer for them — we genuinely do not know when they stopped being true, and deriving a boundary from `updated_at` would manufacture history that was never recorded.

## Blast radius

**Strictly additive.** `lifecycle_state` semantics are untouched, so none of its ~20 readers is affected. This was checked before writing: the identifier spans **two** tables — `projects` (`current`/`detached`) and `memories` — and no reader of either consults `valid_from`/`valid_until`.

## Test

Asserts the property that makes this worth having: after supersession the row is **still true at a past date** and false at a future one. A state flag cannot express that, which is the entire point.

Also pinned: bad calls are refused rather than guessed (`NULL`, empty, invalid id → `-1`), and a never-closed row reads as still true.

## Verification

- `unit-test-memory-advanced` passes — `bitemporal_rows: ok`
- `../aimee`, `../aimee-server`, `../aimee-kb` build clean under `-Werror`
- `refactor_baselines` ok and `check_module_inventory` ok — **no refreeze needed**, since no tracked public header changed
