### PR TITLE
test: execute the memory near-duplicate SQL against real pgvector

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -143,7 +143,7 @@ TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/modules/memor
 # linking both would produce duplicate-symbol errors.
 TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.o
 
-TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-roundtable-brief $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-pg-prepare-classification $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-code-project-lifecycle $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-curator-queue $(TESTPREFIX)/unit-test-curator-pipeline-sched $(TESTPREFIX)/unit-test-curator-custom-stages $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules $(TESTPREFIX)/unit-test-delegate-sandbox-image $(TESTPREFIX)/unit-test-sandbox-pkg-proxy \
+TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-roundtable-brief $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-pg-prepare-classification $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-code-project-lifecycle $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-curator-queue $(TESTPREFIX)/unit-test-curator-pipeline-sched $(TESTPREFIX)/unit-test-curator-custom-stages $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-pgvec-neardup $(TESTPREFIX)/unit-test-rules $(TESTPREFIX)/unit-test-delegate-sandbox-image $(TESTPREFIX)/unit-test-sandbox-pkg-proxy \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-session-degraded-notice $(TESTPREFIX)/unit-test-kb-http-json $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-toolset-thread-scope $(TESTPREFIX)/unit-test-workspace-provider-container $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-mcp-native-dispatch $(TESTPREFIX)/unit-test-extractors \
@@ -1219,6 +1219,21 @@ $(TESTPREFIX)/unit-test-curator-queue: \
                                        $(OBJDIR)/cJSON.o \
                                        $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
+
+# Real libpq, NOT the sqlite shim. Every other unit test links
+# aimee_pg_sqlite_shim.o, which is why no test has ever executed pgvector SQL:
+# operators like <=> do not exist in sqlite, so a shimmed test cannot tell a
+# working vector query from a broken one. This one target swaps the shim for
+# db_postgres.o so the query runs where halfvec actually lives.
+TEST_CORE_OBJS_PG = $(filter-out $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o,$(TEST_CORE_OBJS)) \
+                    $(OBJDIR)/db2/db_postgres.o $(OBJDIR)/db2/entity_edges.o
+
+$(TESTPREFIX)/unit-test-pgvec-neardup: $(OBJDIR)/tests/test_pgvec_neardup.o \
+                    $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o \
+                    $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o \
+                    $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o \
+                    $(TEST_CORE_OBJS_PG)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) $(PQ_LIB)
 
 $(TESTPREFIX)/unit-test-pgvec: $(OBJDIR)/tests/test_pgvec.o \
                     $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o \

--- a/src/tests/test_pgvec_neardup.c
+++ b/src/tests/test_pgvec_neardup.c
@@ -1,0 +1,166 @@
+/* test_pgvec_neardup.c: LIVE-postgres check of the memory near-duplicate
+ * self-join.
+ *
+ * Why this exists as its own binary: test_pgvec.c deliberately connects to
+ * nothing -- it takes the address of each pgvec entry point to prove the symbols
+ * link, and calls none of them. That is a linkage test, not a behaviour test, so
+ * the near-duplicate SQL in pgvec_memory_vector_near_duplicate_pairs() shipped
+ * compiled but never once executed. Its failure mode is silent: a query that
+ * errors returns 0 pairs, which is indistinguishable from "nothing was similar",
+ * and the read path then suppresses nothing (or, if the cosine sign were
+ * inverted, suppresses the WRONG rows) with no error anywhere.
+ *
+ * So the assertions below go through the real function against a real pgvector
+ * table -- prepare, named-parameter binding, step, column reads -- rather than
+ * re-typing the SQL into psql, because the binding layer is exactly where a
+ * hand-checked query would still have hidden a bug.
+ *
+ * Skips (exit 0) when AIMEE_TEST_DB2_URL is unset, so CI without a database
+ * stays green; the point of the variable is that this can never quietly
+ * "pass" by connecting to a deployment an operator did not name. */
+#include "db2.h"
+#include "lifecycle.h"
+#include "memory_vectors.h"
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DIM 8
+
+/* Point ids are offset well clear of any real memory id so a mistaken run
+ * against a populated database cannot collide with live rows. */
+#define BASE_ID 9000000001LL
+
+static void fill(float *v, float x0, float x1)
+{
+   memset(v, 0, sizeof(float) * DIM);
+   v[0] = x0;
+   v[1] = x1;
+}
+
+static int pair_present(const int64_t *a, const int64_t *b, int n, int64_t want_a, int64_t want_b)
+{
+   for (int i = 0; i < n; i++)
+      if (a[i] == want_a && b[i] == want_b)
+         return i;
+   return -1;
+}
+
+int main(void)
+{
+   /* Line-buffered: an assert() aborts, and block-buffered stdout would discard
+    * the pair dump that says WHY it aborted -- exactly the context needed. */
+   setvbuf(stdout, NULL, _IOLBF, 0);
+
+   const char *url = getenv("AIMEE_TEST_DB2_URL");
+   if (!url || !*url)
+   {
+      printf("pgvec_neardup: SKIP (AIMEE_TEST_DB2_URL unset)\n");
+      return 0;
+   }
+
+   db2_set_embedding_dim(DIM);
+   if (db2_init(url) != 0)
+   {
+      fprintf(stderr, "pgvec_neardup: db2_init failed\n");
+      return 1;
+   }
+
+   if (pgvec_memory_vector_collection_recreate(DIM) != 0)
+   {
+      fprintf(stderr, "pgvec_neardup: collection_recreate failed\n");
+      return 1;
+   }
+
+   /* Four vectors with cosines known by construction, all unit-length in the
+    * first two components so the expected values are exact enough to assert on:
+    *   1 and 2 are the same direction          -> cosine 1.0
+    *   3 is 2 degrees off 1                    -> cosine ~0.9994  (>= 0.94)
+    *   4 is orthogonal to 1                    -> cosine 0.0      (<  0.94)
+    * Row 5 is never inserted: it stands for a memory written but not yet
+    * embedded, and must appear in no pair at all. */
+   float v[DIM];
+   fill(v, 1.0f, 0.0f);
+   assert(pgvec_memory_vector_upsert_memory(BASE_ID + 0, v, DIM, "{}") == 0);
+   fill(v, 1.0f, 0.0f);
+   assert(pgvec_memory_vector_upsert_memory(BASE_ID + 1, v, DIM, "{}") == 0);
+   fill(v, (float)cos(2.0 * M_PI / 180.0), (float)sin(2.0 * M_PI / 180.0));
+   assert(pgvec_memory_vector_upsert_memory(BASE_ID + 2, v, DIM, "{}") == 0);
+   fill(v, 0.0f, 1.0f);
+   assert(pgvec_memory_vector_upsert_memory(BASE_ID + 3, v, DIM, "{}") == 0);
+
+   const int64_t ids[5] = {BASE_ID + 0, BASE_ID + 1, BASE_ID + 2, BASE_ID + 3, BASE_ID + 4};
+
+   int64_t a[16], b[16];
+   double cos_out[16];
+
+   /* The production threshold. */
+   int n = pgvec_memory_vector_near_duplicate_pairs(ids, 5, 0.94, a, b, cos_out, 16);
+   if (n < 0)
+   {
+      fprintf(stderr, "pgvec_neardup: query returned -1 (no connection?)\n");
+      return 1;
+   }
+   printf("  pairs at 0.94: %d\n", n);
+   for (int i = 0; i < n; i++)
+      printf("    %lld,%lld cosine=%.6f\n", (long long)a[i], (long long)b[i], cos_out[i]);
+
+   /* The three similar rows pair with each other: (0,1) (0,2) (1,2). */
+   assert(n == 3);
+   assert(pair_present(a, b, n, BASE_ID + 0, BASE_ID + 1) >= 0);
+   assert(pair_present(a, b, n, BASE_ID + 0, BASE_ID + 2) >= 0);
+   assert(pair_present(a, b, n, BASE_ID + 1, BASE_ID + 2) >= 0);
+
+   /* The orthogonal row and the unembedded row appear in nothing. */
+   for (int i = 0; i < n; i++)
+   {
+      assert(a[i] != BASE_ID + 3 && b[i] != BASE_ID + 3);
+      assert(a[i] != BASE_ID + 4 && b[i] != BASE_ID + 4);
+   }
+
+   /* Canonical ordering: a < b, so each unordered pair is reported once. */
+   for (int i = 0; i < n; i++)
+      assert(a[i] < b[i]);
+
+   /* Cosine is a similarity, not a distance -- identical vectors must score
+    * 1.0, not 0.0. This is the assertion that catches a dropped "1.0 -". */
+   int idx = pair_present(a, b, n, BASE_ID + 0, BASE_ID + 1);
+   assert(idx >= 0);
+   assert(cos_out[idx] > 0.999);
+
+   /* Ordered closest-first. */
+   for (int i = 1; i < n; i++)
+      assert(cos_out[i] <= cos_out[i - 1] + 1e-9);
+
+   /* A threshold above every actual cosine yields nothing -- proves the bound
+    * is really applied and the earlier 3 was not "everything, unfiltered". */
+   n = pgvec_memory_vector_near_duplicate_pairs(ids, 5, 0.99999, a, b, cos_out, 16);
+   printf("  pairs at 0.99999: %d\n", n);
+   assert(n == 1); /* only the exactly-identical pair survives */
+   assert(pair_present(a, b, n, BASE_ID + 0, BASE_ID + 1) >= 0);
+
+   /* A threshold below everything still excludes nothing but the unembedded
+    * row, and picks up the orthogonal one. */
+   n = pgvec_memory_vector_near_duplicate_pairs(ids, 5, -1.0, a, b, cos_out, 16);
+   printf("  pairs at -1.0: %d\n", n);
+   assert(n == 6); /* C(4,2) over the four embedded rows */
+
+   /* max caps the result rather than overflowing the caller's arrays. */
+   n = pgvec_memory_vector_near_duplicate_pairs(ids, 5, -1.0, a, b, cos_out, 2);
+   printf("  pairs at -1.0 capped to 2: %d\n", n);
+   assert(n == 2);
+
+   /* Bad calls are rejected before any SQL runs. */
+   assert(pgvec_memory_vector_near_duplicate_pairs(NULL, 5, 0.94, a, b, cos_out, 16) == -1);
+   assert(pgvec_memory_vector_near_duplicate_pairs(ids, 1, 0.94, a, b, cos_out, 16) == -1);
+   assert(pgvec_memory_vector_near_duplicate_pairs(ids, 5, 0.94, a, b, cos_out, 0) == -1);
+
+   for (int i = 0; i < 4; i++)
+      (void)pgvec_memory_vector_delete_point(BASE_ID + i);
+
+   db2_shutdown();
+   printf("pgvec_neardup: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Why

`pgvec_memory_vector_near_duplicate_pairs()` — the semantic half of memory near-duplicate suppression, merged in #2439 — shipped **compiled but never once executed**.

Two reasons nothing caught it:

- `test_pgvec.c` deliberately connects to nothing. It takes the address of each pgvec entry point to prove the symbols link, and calls none of them.
- Every unit test links `aimee_pg_sqlite_shim.o`, so `aimee_pg_*` calls go to SQLite. Operators like `<=>` don't exist there — a shimmed test **cannot** tell a working vector query from a broken one.

The failure mode is silent. The function returns `0` when `aimee_pg_prepare` fails, which is indistinguishable from "nothing was similar enough": a broken query suppresses nothing and logs nothing. An inverted cosine is worse — it suppresses the *wrong* memories, dropping evidence from the assembled context with no error anywhere.

Only the lexical Jaccard fallback was covered, and that's the fallback, not the primary path.

## What

`unit-test-pgvec-neardup` swaps the SQLite shim for `db_postgres.o` and drives the **real function** — prepare, named-parameter binding, step, column reads — against a real pgvector table. Deliberately not "re-type the SQL into psql": the binding layer is exactly where a hand-checked query would still have hidden a bug.

Four vectors with cosines known by construction (identical, 2° apart, orthogonal) plus a never-inserted row standing for a memory written but not yet embedded. Assertions cover pair membership, canonical `a < b` ordering, descending sort, the threshold actually being applied, the `max` cap, and rejection of bad calls.

**Skips (exit 0) unless `AIMEE_TEST_DB2_URL` names a database** — CI without postgres stays green, and the test can never quietly "pass" by connecting to a deployment nobody named.

## Verification

Postgres 17 + pgvector on a scratch database (since dropped). **Red-before-green on both halves of the query, independently:**

| Mutation | Effect | Caught by |
|---|---|---|
| drop `1.0 -` from `SELECT` | right rows, wrong scores | identical-pair cosine assertion |
| drop `1.0 -` from `WHERE` | only orthogonal-row pairs survive | pair membership |

Green run:

```
  pairs at 0.94: 3
    9000000001,9000000002 cosine=1.000000
    9000000001,9000000003 cosine=0.999391
    9000000002,9000000003 cosine=0.999391
  pairs at 0.99999: 1
  pairs at -1.0: 6
  pairs at -1.0 capped to 2: 2
pgvec_neardup: all tests passed
```

`cos(2°) = 0.999391` — the value is *right*, not merely above the threshold. **The merged production SQL is correct as written; this PR adds no fix, only the proof that was missing.**

## Gates

clang-format, `check_c_repository_lock`, `refactor_baselines`, `check_module_inventory`, full `make all` — all clean. No production code changed.
