### PR TITLE
feat(git): model the operations aimee could not do

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -806,6 +806,7 @@ set(AGENT_SRCS
 set(GIT_SRCS
     ${AIMEE_SRC_DIR}/modules/git/mcp_git_query.c
     ${AIMEE_SRC_DIR}/modules/git/mcp_git_write.c
+    ${AIMEE_SRC_DIR}/modules/git/mcp_git_integrate.c
     ${AIMEE_SRC_DIR}/modules/git/mcp_git_branch.c
     ${AIMEE_SRC_DIR}/modules/git/mcp_git_pr.c
     ${AIMEE_SRC_DIR}/modules/git/git_verify.c

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -77,7 +77,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "22d8ceed4e8782226fb353dfd41abc92106b2405b0c1d616080b475a43e2acb0"
+      "source_sha256": "06a4010a877fed82b85a6ba6b4fd5338b377c258c02412e630fd37b18e99e806"
     },
     {
       "id": "gateway",
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "ab47ed08a690c0f79c9832d125a157d0d169a13f04fd2058b10dc84e1c594e9a",
+      "source_sha256": "7547d0d9f9be38c982922197b0c18f6ff399710e0cf288c227f8b2b0ae760254",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "7547d0d9f9be38c982922197b0c18f6ff399710e0cf288c227f8b2b0ae760254",
+      "source_sha256": "695c04003cc7741a9c17466cde96f10a371d3cdddcbef7f9b9a7e8c32e57d816",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -40,6 +40,17 @@ Call these directly without CLI. All available via the MCP server.
 | `git_reset [ref] [mode]` | soft/mixed/hard reset |
 | `git_restore files [staged] [source]` | Restore or unstage files |
 | `git_verify [action] [async] [job_id] [base]` | Project verification, health, conflicts, and PR prep |
+| `git_add files \| all` | Stage, including new files (sensitive paths are dropped) |
+| `git_merge ref [action] [abort_on_conflict]` | Merge a ref in; fetches it first, names conflicts, undoes itself on conflict by default |
+| `git_rebase base [action] [abort_on_conflict]` | Rebase onto a branch, same conflict handling |
+| `git_sync [base] [mode]` | Make this branch current with its base: resolve + fetch + rebase (or merge) + report the gap |
+| `git_cherry_pick ref [action]` | Apply a commit here |
+| `git_revert ref [action]` | Back a commit out |
+| `git_switch ref` / `git_checkout ref \| files` | Move to a branch, or restore paths |
+
+For merge/rebase/sync/cherry_pick/revert: omit `action` to start one; `action=continue\|abort\|skip`
+drives one that stopped on a conflict. `command=pr action=create` writes its own title and body from the
+branch's commits when you omit them. See [modules/git.md](modules/git.md#history-integration-merge-rebase-sync-cherry_pick-revert).
 
 ---
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -31,7 +31,7 @@ Call these directly without CLI. All available via the MCP server.
 | `git_branch action [name] [base]` | create/switch/list/delete/claim/orphan |
 | `git_log [count] [ref] [diff_stat]` | Commit log |
 | `git_diff_summary [ref] [stat_only] [files]` | Diff summary |
-| `git_pr action [title] [body] [number] [base]` | create/view/list/edit/checks/watch/merge_status |
+| `git_pr action [title] [body] [number] [base]` | create/view/list/edit/checks/watch/merge_status/merge/**ready**. `create` derives title+body from your commits when omitted; `ready` = sync + push + open the PR |
 | `git_pull [rebase]` | Pull from remote |
 | `git_clone url [path] [branch] [depth]` | Clone repo |
 | `git_stash action [message] [index]` | push/pop/apply/list/drop |

--- a/docs/gen/cli-commands.md
+++ b/docs/gen/cli-commands.md
@@ -747,11 +747,38 @@ Subcommands:
 
 ### `aimee git`
 
-Git helpers.
+Git and GitHub operations (run on aimee-server).
 
 Subcommands:
 
 ```
+  Every command takes an optional primary word then key=value pairs:
+    aimee git merge origin/testing      aimee git pr create title="..."
+    aimee git sync                      aimee git log count=5
+
+  status           Working tree status
+  add <paths|-A>   Stage changes (-A includes new files)
+  commit <msg>     Stage tracked changes and commit
+  push [-f]        Push the session's branch
+  pull / fetch     Bring refs down from a remote
+  sync [base]      Make this branch current with its base (fetch + rebase)
+  merge <ref>      Merge a ref in; conflicts are named and undone by default
+  rebase <base>    Rebase onto a branch, same conflict handling
+  cherry-pick <r>  Apply a commit here
+  revert <ref>     Back a commit out
+    ... any of the five above also take: continue | abort | skip
+  switch <branch>  Move to a branch
+  checkout <paths> Restore paths from a ref
+  restore <paths>  Restore or unstage paths
+  reset <ref>      soft/mixed/hard reset
+  branch <action>  create/switch/list/delete/claim/orphan
+  stash <action>   push/pop/apply/list/drop
+  tag <action>     create/list/delete
+  log / diff       History and diff summaries
+  pr <action>      create/view/list/edit/checks/merge_status/merge/ready
+                   (create writes its own title and body from your commits)
+  issue list       Open issues
+  clone <url>      Clone a repository
   verify           Verify the current changes before merge
 ```
 

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -27,13 +27,13 @@ projects, forge credentials/API, OAuth device flows, and SSH-agent setup. The ap
 is `memory.repository-record.ingest.v1`: Git is submit-only, while [memory](memory.md) retains schema,
 redaction acceptance, persistence, embedding, reranking, and code intelligence.
 
-The descriptor declares this module's twenty-six sources, eighteen module-root headers, fourteen
+The descriptor declares this module's twenty-seven sources, eighteen module-root headers, fourteen
 direct tests, and this document; it sets `ownership_complete: true`. All eighteen headers are
 declared as `private_headers` because they live at the module root rather than under
 `src/modules/git/include/aimee/git/`, the layout the header-layout checker treats as private; sixteen
 pair with a source, and two have no paired source: `git_verify_internal.h` (the verify-family seam)
-and `mcp_git.h` (the shared MCP-git header). Make compiles all twenty-six sources; CMake compiles the
-twelve the thin `aimee` client reaches (the eight `git_verify_*` sources and the four `mcp_git_*`
+and `mcp_git.h` (the shared MCP-git header). Make compiles all twenty-seven sources; CMake compiles the
+thirteen the thin `aimee` client reaches (the eight `git_verify_*` sources and the five `mcp_git_*`
 tools) and omits the fourteen credential, OAuth, ops, forge-vault, host, org-repos, and PR-API sources
 that are server/kb-side, the same intentional thin-client boundary recorded for gateway, learning,
 workspace, vault, and config. This descriptor's `ownership_complete` latch is independent of the
@@ -82,6 +82,57 @@ Surfaces include native/MCP `git_status`, diff, log, branch, commit, push, pull,
 reset, stash, tag, issue, PR, and `aimee git verify` operations plus project/forge credential flows.
 Protocol and tools modules expose these operations, but Git owns their repository semantics, credential
 containment, verification gates, and mutation results.
+
+### History integration: merge, rebase, sync, cherry_pick, revert
+
+`src/modules/git/mcp_git_integrate.c` owns the operations that bring one line of history into another.
+They are one operation with five names — each can stop mid-flight on a conflict, each leaves a state that
+must be continued or abandoned, each commits and so needs an identity — so they share one driver and
+differ only by a row in `OPS`.
+
+They are modeled, not passed through, because the caller states the intent and aimee does the mechanics:
+
+- a remote-looking ref is **fetched first**, so `merge origin/main` cannot merge a stale copy;
+- the **editor is disabled** (`core.editor`/`sequence.editor`), because a blocked editor is
+  indistinguishable from a hang;
+- a **dirty tree is refused up front**, since a conflict in one cannot be cleanly undone;
+- a conflict is reported as **the list of conflicted files**, and by default the operation is **aborted**,
+  so the caller is never handed a half-applied tree it must know how to clean up. `abort_on_conflict=false`
+  opts into resolving in place, then `action=continue` (which refuses while markers remain) or
+  `action=abort`;
+- a continuation **commits with the vaulted operator identity**, via the same `mcp_git_identity_flags`
+  `git_commit` uses — otherwise a conflict resolution would produce an authorless merge commit;
+- an operation already in progress is named, with the way out, instead of letting a second one start on
+  top of it;
+- the result says **what changed** (`pre..post`, commit count, diffstat) rather than echoing git's prose.
+
+`command=sync` is the whole "make this branch current with the branch it will merge into" errand in one
+call: resolve the base (given, else origin's default branch, qualified to the remote's copy), fetch it,
+rebase (default; `mode=merge`) it in, and report the gap it closed. Rebase is the default so a PR branch
+reviews as the work alone.
+
+Writing to `main`/`master` is refused here as everywhere else, so integrating into the default branch
+remains `command=pr action=merge`.
+
+### Staging and ref movement
+
+`command=add` (`files`, or `all` to include new files) is the staging `git_commit` cannot reach — it
+stages tracked changes or the paths it was handed, so a new file had no route. Sensitive paths are
+dropped, and for `all` the screen runs against the resulting **index** rather than the caller's argument
+list, so a pattern-based add cannot slip a `.env` past `command=commit`.
+
+`command=switch` and `command=checkout` are routing, not second implementations: `switch` is
+`branch action=switch` (keeping the worktree lock and ownership registration in one place), and
+`checkout` is `restore` when `files` is given and `switch` otherwise.
+
+### PR title and body are derived
+
+`command=pr action=create` no longer requires `title`. When it is omitted, `pr_derive_from_commits`
+writes both from the commits the branch has that the base does not: a single commit lends its subject and
+its message body verbatim; several keep the conventional-commit prefix they agree on and get a bulleted
+list plus the diffstat. Deterministic, no model call — the commit subjects already are the summary, so
+asking the caller to write one costs a turn to say the same thing. An explicit `title` always wins, and a
+branch with no commits ahead of base is told exactly that.
 
 ## Data and migrations
 

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -78,10 +78,23 @@ a required Git configuration dependency.
 
 ## Surfaces
 
-Surfaces include native/MCP `git_status`, diff, log, branch, commit, push, pull, fetch, clone, restore,
-reset, stash, tag, issue, PR, and `aimee git verify` operations plus project/forge credential flows.
-Protocol and tools modules expose these operations, but Git owns their repository semantics, credential
-containment, verification gates, and mutation results.
+Surfaces include native/MCP `git_status`, diff, log, branch, add, commit, push, pull, fetch, clone,
+restore, reset, stash, tag, issue, PR, merge, rebase, sync, cherry-pick, revert, switch, checkout and
+verify operations plus project/forge credential flows. Protocol and tools modules expose these operations,
+but Git owns their repository semantics, credential containment, verification gates, and mutation results.
+
+The `aimee` CLI reaches all of them through one wildcard `/v1` route (`{"git", NULL, "git.cli", ...}` in
+`cli_v1_routes.c`, marshalled by `marshal_git_cli`) that dispatches `mcp.call` with `tool=git_<command>` —
+previously only `git verify` was routed and every other `aimee git ...` answered "is not a subcommand of
+'git'". The CLI grammar is uniform rather than per-command: `aimee git <command> [primary] [key=value ...]`,
+where the table in `marshal_git_cli` holds the only per-command knowledge (what a bare first, and
+sometimes second, word means). Values are typed the way verify's already are, `continue`/`abort`/`skip` are
+recognised as actions, and the repository defaults to the caller's directory unless `path=` names one.
+`git verify` keeps its own marshaller — its row precedes the wildcard, and the lookup takes the first
+match.
+
+Note that `cmd_git` in `src/cmd_infra.c` parses the same commands for the in-process (non-thin) path; the
+two agree today but are separate parsers, and folding them together is untaken work.
 
 ### History integration: merge, rebase, sync, cherry_pick, revert
 
@@ -124,6 +137,21 @@ list, so a pattern-based add cannot slip a `.env` past `command=commit`.
 `command=switch` and `command=checkout` are routing, not second implementations: `switch` is
 `branch action=switch` (keeping the worktree lock and ownership registration in one place), and
 `checkout` is `restore` when `files` is given and `switch` otherwise.
+
+### `pr action=ready`: the whole "put this up for review" errand
+
+Sync, push, open the PR. It exists because doing them separately makes the caller hold one piece of
+knowledge it should not need — the sync rebases, which rewrites history, so the push after it must be a
+lease-protected force — and because a failure halfway otherwise leaves the caller working out which step
+broke. `ready` runs them in order, **stops at the first real failure and returns that step's own
+explanation** (sync's conflict report already says how to resolve it), and otherwise reports each step on
+its own line. It is idempotent: run it again after more commits and it re-syncs, re-pushes, and says the
+PR is already open rather than failing.
+
+Composition depends on one convention: a git tool reports failure in the text it returns, leading with
+`error` or `conflict`. `mcp_git_response_failed` is the single definition of that check — a wrapper that
+prefixed its own context to a failure (which `sync` originally did) makes a conflict read as success, so
+`sync` now appends its context on failure and prepends it only on success.
 
 ### PR title and body are derived
 

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -84,13 +84,13 @@ verify operations plus project/forge credential flows. Protocol and tools module
 but Git owns their repository semantics, credential containment, verification gates, and mutation results.
 
 The `aimee` CLI reaches all of them through one wildcard `/v1` route (`{"git", NULL, "git.cli", ...}` in
-`cli_v1_routes.c`, marshalled by `marshal_git_cli`) that dispatches `mcp.call` with `tool=git_<command>` —
-previously only `git verify` was routed and every other `aimee git ...` answered "is not a subcommand of
+`cli_v1_routes.c`, marshalled by `marshal_git_cli`) that dispatches `mcp.call` with `tool=git_<command>`.
+Previously only `git verify` was routed and every other `aimee git ...` answered "is not a subcommand of
 'git'". The CLI grammar is uniform rather than per-command: `aimee git <command> [primary] [key=value ...]`,
 where the table in `marshal_git_cli` holds the only per-command knowledge (what a bare first, and
 sometimes second, word means). Values are typed the way verify's already are, `continue`/`abort`/`skip` are
 recognised as actions, and the repository defaults to the caller's directory unless `path=` names one.
-`git verify` keeps its own marshaller — its row precedes the wildcard, and the lookup takes the first
+`git verify` keeps its own marshaller: its row precedes the wildcard, and the lookup takes the first
 match.
 
 Note that `cmd_git` in `src/cmd_infra.c` parses the same commands for the in-process (non-thin) path; the
@@ -99,8 +99,8 @@ two agree today but are separate parsers, and folding them together is untaken w
 ### History integration: merge, rebase, sync, cherry_pick, revert
 
 `src/modules/git/mcp_git_integrate.c` owns the operations that bring one line of history into another.
-They are one operation with five names — each can stop mid-flight on a conflict, each leaves a state that
-must be continued or abandoned, each commits and so needs an identity — so they share one driver and
+They are one operation with five names. Each can stop mid-flight on a conflict, each leaves a state that
+must be continued or abandoned, and each commits and so needs an identity, so they share one driver and
 differ only by a row in `OPS`.
 
 They are modeled, not passed through, because the caller states the intent and aimee does the mechanics:
@@ -114,7 +114,7 @@ They are modeled, not passed through, because the caller states the intent and a
   opts into resolving in place, then `action=continue` (which refuses while markers remain) or
   `action=abort`;
 - a continuation **commits with the vaulted operator identity**, via the same `mcp_git_identity_flags`
-  `git_commit` uses — otherwise a conflict resolution would produce an authorless merge commit;
+  `git_commit` uses, because otherwise a conflict resolution would produce an authorless merge commit;
 - an operation already in progress is named, with the way out, instead of letting a second one start on
   top of it;
 - the result says **what changed** (`pre..post`, commit count, diffstat) rather than echoing git's prose.
@@ -129,7 +129,7 @@ remains `command=pr action=merge`.
 
 ### Staging and ref movement
 
-`command=add` (`files`, or `all` to include new files) is the staging `git_commit` cannot reach — it
+`command=add` (`files`, or `all` to include new files) is the staging `git_commit` cannot reach: commit
 stages tracked changes or the paths it was handed, so a new file had no route. Sensitive paths are
 dropped, and for `all` the screen runs against the resulting **index** rather than the caller's argument
 list, so a pattern-based add cannot slip a `.env` past `command=commit`.
@@ -141,15 +141,15 @@ list, so a pattern-based add cannot slip a `.env` past `command=commit`.
 ### `pr action=ready`: the whole "put this up for review" errand
 
 Sync, push, open the PR. It exists because doing them separately makes the caller hold one piece of
-knowledge it should not need — the sync rebases, which rewrites history, so the push after it must be a
-lease-protected force — and because a failure halfway otherwise leaves the caller working out which step
+knowledge it should not need (the sync rebases, which rewrites history, so the push after it must be a
+lease-protected force), and because a failure halfway otherwise leaves the caller working out which step
 broke. `ready` runs them in order, **stops at the first real failure and returns that step's own
 explanation** (sync's conflict report already says how to resolve it), and otherwise reports each step on
 its own line. It is idempotent: run it again after more commits and it re-syncs, re-pushes, and says the
 PR is already open rather than failing.
 
 Composition depends on one convention: a git tool reports failure in the text it returns, leading with
-`error` or `conflict`. `mcp_git_response_failed` is the single definition of that check — a wrapper that
+`error` or `conflict`. `mcp_git_response_failed` is the single definition of that check. A wrapper that
 prefixed its own context to a failure (which `sync` originally did) makes a conflict read as success, so
 `sync` now appends its context on failure and prepends it only on success.
 
@@ -158,7 +158,7 @@ prefixed its own context to a failure (which `sync` originally did) makes a conf
 `command=pr action=create` no longer requires `title`. When it is omitted, `pr_derive_from_commits`
 writes both from the commits the branch has that the base does not: a single commit lends its subject and
 its message body verbatim; several keep the conventional-commit prefix they agree on and get a bulleted
-list plus the diffstat. Deterministic, no model call — the commit subjects already are the summary, so
+list plus the diffstat. Deterministic, with no model call: the commit subjects already are the summary, so
 asking the caller to write one costs a turn to say the same thing. An explicit `title` always wins, and a
 branch with no commits ahead of base is told exactly that.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -302,7 +302,7 @@ PLATFORM_CLI_OBJS   = $(filter %/cli_client.o %/cli_main.o %/events.o,$(PLATFORM
 # --- MCP git tools (compiled into both shipped binaries; not in LIB_CORE) ---
 # Keep git MCP handlers out of the shared core library so the thin client and
 # server remain the only shipped binaries while still sharing the same handlers.
-MCP_GIT_SRCS = modules/git/mcp_git_query.c modules/git/mcp_git_write.c modules/git/mcp_git_branch.c modules/git/mcp_git_pr.c modules/git/git_verify.c modules/git/git_verify_state.c modules/git/git_verify_config.c modules/git/git_verify_jobs.c modules/git/git_verify_hook.c modules/git/git_verify_ops.c modules/git/git_verify_select.c modules/git/git_verify_step.c
+MCP_GIT_SRCS = modules/git/mcp_git_query.c modules/git/mcp_git_write.c modules/git/mcp_git_integrate.c modules/git/mcp_git_branch.c modules/git/mcp_git_pr.c modules/git/git_verify.c modules/git/git_verify_state.c modules/git/git_verify_config.c modules/git/git_verify_jobs.c modules/git/git_verify_hook.c modules/git/git_verify_ops.c modules/git/git_verify_select.c modules/git/git_verify_step.c
 MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---

--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -221,7 +221,34 @@
      "  disable <id>     Disable a cron job (--all for rollback)\n"
      "  remove <id>      Remove a cron job\n"},
 
-    {"git", "Git helpers", CLIENT_TIER_ADMIN, 0,
+    {"git", "Git and GitHub operations (run on aimee-server)", CLIENT_TIER_ADMIN, 0,
+     "  Every command takes an optional primary word then key=value pairs:\n"
+     "    aimee git merge origin/testing      aimee git pr create title=\"...\"\n"
+     "    aimee git sync                      aimee git log count=5\n"
+     "\n"
+     "  status           Working tree status\n"
+     "  add <paths|-A>   Stage changes (-A includes new files)\n"
+     "  commit <msg>     Stage tracked changes and commit\n"
+     "  push [-f]        Push the session's branch\n"
+     "  pull / fetch     Bring refs down from a remote\n"
+     "  sync [base]      Make this branch current with its base (fetch + rebase)\n"
+     "  merge <ref>      Merge a ref in; conflicts are named and undone by default\n"
+     "  rebase <base>    Rebase onto a branch, same conflict handling\n"
+     "  cherry-pick <r>  Apply a commit here\n"
+     "  revert <ref>     Back a commit out\n"
+     "    ... any of the five above also take: continue | abort | skip\n"
+     "  switch <branch>  Move to a branch\n"
+     "  checkout <paths> Restore paths from a ref\n"
+     "  restore <paths>  Restore or unstage paths\n"
+     "  reset <ref>      soft/mixed/hard reset\n"
+     "  branch <action>  create/switch/list/delete/claim/orphan\n"
+     "  stash <action>   push/pop/apply/list/drop\n"
+     "  tag <action>     create/list/delete\n"
+     "  log / diff       History and diff summaries\n"
+     "  pr <action>      create/view/list/edit/checks/merge_status/merge/ready\n"
+     "                   (create writes its own title and body from your commits)\n"
+     "  issue list       Open issues\n"
+     "  clone <url>      Clone a repository\n"
      "  verify           Verify the current changes before merge\n"},
     {"clean", "Remove local aimee configuration and integrations", CLIENT_TIER_ADMIN, 0, NULL},
     {"mcp-serve", "MCP stdio bridge to aimee-server", CLIENT_TIER_ADMIN, 1, NULL},

--- a/src/cli_v1_routes.c
+++ b/src/cli_v1_routes.c
@@ -324,6 +324,12 @@ static const struct
     {"get-help", NULL, "get_help", "help.get", NULL, 0},
     {"verify", NULL, "git.verify", "mcp.call", NULL, 900000},
     {"git", "verify", "git.verify", "mcp.call", NULL, 900000},
+    /* Every other git subcommand, wildcard so `aimee git <anything>` reaches the
+     * server's git tool instead of "not a subcommand of 'git'". MUST stay after
+     * the verify row: pass 2 takes the first match, and verify has its own
+     * marshaler (--status, async=). Wildcard also means argv[0] is the
+     * subcommand, which is what marshal_git_cli needs to pick the tool. */
+    {"git", NULL, "git.cli", "mcp.call", NULL, 300000},
     {"provider", "list", "provider.list", NULL, "providers", 300000},
     {"provider", "show", "provider.show", NULL, NULL, 0},
     {"provider", "models", "provider.models", NULL, "models", 300000},

--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -549,6 +549,211 @@ static void add_verify_arg(cJSON *args, const char *name, const char *val)
    }
 }
 
+/* Every git subcommand except verify, from the CLI.
+ *
+ * The shape is uniform on purpose — `aimee git <command> [primary] [key=value]`,
+ * the same form `aimee git verify action=... key=value` already taught — so there
+ * is ONE parser here rather than a hand-written flag grammar per subcommand. The
+ * only per-command knowledge is what a bare first (and sometimes second) word
+ * means, which is the table below; everything else is key=value and is typed the
+ * same way verify's arguments are.
+ *
+ * `aimee git merge origin/testing`, `aimee git sync`, `aimee git rebase continue`,
+ * `aimee git add -A`, `aimee git pr create title="..."`. */
+static const struct
+{
+   const char *sub;    /* CLI subcommand (dashes allowed) */
+   const char *tool;   /* MCP tool it dispatches to */
+   const char *first;  /* what a bare first word means, NULL if none */
+   const char *second; /* what a bare second word means, NULL if none */
+   int rest_files;     /* remaining bare words accumulate into `files` */
+} GIT_CLI[] = {
+    {"status", "git_status", NULL, NULL, 0},
+    {"commit", "git_commit", "message", NULL, 1},
+    {"push", "git_push", NULL, NULL, 0},
+    {"pull", "git_pull", NULL, NULL, 0},
+    {"fetch", "git_fetch", "remote", NULL, 0},
+    {"branch", "git_branch", "action", "name", 0},
+    {"log", "git_log", NULL, NULL, 0},
+    {"diff", "git_diff_summary", "ref", NULL, 1},
+    {"diff_summary", "git_diff_summary", "ref", NULL, 1},
+    {"pr", "git_pr", "action", NULL, 0},
+    {"issue", "git_issue", "action", NULL, 0},
+    {"clone", "git_clone", "url", "path", 0},
+    {"stash", "git_stash", "action", NULL, 0},
+    {"tag", "git_tag", "action", "name", 0},
+    {"reset", "git_reset", "ref", "mode", 0},
+    {"restore", "git_restore", NULL, NULL, 1},
+    {"add", "git_add", NULL, NULL, 1},
+    {"merge", "git_merge", "ref", NULL, 0},
+    {"rebase", "git_rebase", "base", NULL, 0},
+    {"sync", "git_sync", "base", NULL, 0},
+    {"cherry-pick", "git_cherry_pick", "ref", NULL, 0},
+    {"cherry_pick", "git_cherry_pick", "ref", NULL, 0},
+    {"revert", "git_revert", "ref", NULL, 0},
+    {"switch", "git_switch", "ref", NULL, 0},
+    {"checkout", "git_checkout", NULL, NULL, 1},
+    {NULL, NULL, NULL, NULL, 0},
+};
+
+/* Bare words that mean an action rather than a ref, for the operations that can
+ * stop mid-flight. Spelled with or without dashes. */
+static int git_cli_is_resume_word(const char *w)
+{
+   while (*w == '-')
+      w++;
+   return strcmp(w, "continue") == 0 || strcmp(w, "abort") == 0 || strcmp(w, "skip") == 0;
+}
+
+/* Short flags worth keeping, because typing them is reflex. Everything else is
+ * key=value, which needs no aliasing. */
+static int git_cli_flag_alias(const char *arg, cJSON *args)
+{
+   static const struct
+   {
+      const char *flag;
+      const char *key;
+      int value;
+   } aliases[] = {
+       {"-A", "all", 1},
+       {"--all", "all", 1},
+       {"-f", "force", 1},
+       {"--force", "force", 1},
+       {"--rebase", "rebase", 1},
+       {"--prune", "prune", 1},
+       {"--auto", "auto", 1},
+       {"--staged", "staged", 1},
+       {"--keep-conflicts", "abort_on_conflict", 0},
+       {NULL, NULL, 0},
+   };
+   for (int i = 0; aliases[i].flag; i++)
+      if (strcmp(arg, aliases[i].flag) == 0)
+      {
+         cJSON_AddBoolToObject(args, aliases[i].key, aliases[i].value);
+         return 1;
+      }
+   if (strcmp(arg, "--merge") == 0)
+   {
+      cJSON_AddStringToObject(args, "mode", "merge");
+      return 1;
+   }
+   return 0;
+}
+
+static cJSON *marshal_git_cli(int argc, char **argv)
+{
+   if (argc < 1 || !argv[0] || !argv[0][0])
+   {
+      fprintf(stderr, "usage: aimee git <command> [primary] [key=value ...]\n"
+                      "  status commit push pull fetch branch log diff pr issue clone stash\n"
+                      "  tag reset restore verify add merge rebase sync cherry-pick revert\n"
+                      "  switch checkout\n");
+      return NULL;
+   }
+
+   const char *sub = argv[0];
+   int row = -1;
+   for (int i = 0; GIT_CLI[i].sub; i++)
+      if (strcmp(sub, GIT_CLI[i].sub) == 0)
+      {
+         row = i;
+         break;
+      }
+   if (row < 0)
+   {
+      fprintf(stderr,
+              "aimee: '%s' is not a git command. Try: status commit push pull fetch "
+              "branch log diff pr issue clone stash tag reset restore verify add merge "
+              "rebase sync cherry-pick revert switch checkout\n",
+              sub);
+      return NULL;
+   }
+
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "method", "mcp.call");
+   cJSON_AddStringToObject(req, "tool", GIT_CLI[row].tool);
+   const char *sid = getenv("AIMEE_SESSION_ID");
+   if (!sid || !sid[0])
+      sid = getenv("CLAUDE_SESSION_ID");
+   if (sid && sid[0])
+      cJSON_AddStringToObject(req, "session_id", sid);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *files = NULL;
+   int bare = 0;
+
+   for (int i = 1; i < argc; i++)
+   {
+      char *arg = argv[i];
+
+      if (git_cli_flag_alias(arg, args))
+         continue;
+
+      /* key=value / --key=value, typed exactly as verify types its arguments. */
+      const char *raw = arg;
+      if (strncmp(raw, "--", 2) == 0)
+         raw += 2;
+      char *eq = strchr(raw, '=');
+      if (eq)
+      {
+         *eq = '\0';
+         add_verify_arg(args, raw, eq + 1);
+         *eq = '=';
+         continue;
+      }
+
+      if (arg[0] == '-')
+      {
+         /* A bare --flag is a boolean, which is how every boolean in the git
+          * schema reads anyway. */
+         cJSON_AddBoolToObject(args, raw, 1);
+         continue;
+      }
+
+      /* continue/abort/skip is an action wherever an operation can stop. */
+      if (git_cli_is_resume_word(arg) && !cJSON_GetObjectItemCaseSensitive(args, "action"))
+      {
+         cJSON_AddStringToObject(args, "action", arg);
+         continue;
+      }
+
+      bare++;
+      const char *key = (bare == 1) ? GIT_CLI[row].first : (bare == 2 ? GIT_CLI[row].second : NULL);
+      if (key && !cJSON_GetObjectItemCaseSensitive(args, key))
+      {
+         cJSON_AddStringToObject(args, key, arg);
+         continue;
+      }
+      if (GIT_CLI[row].rest_files)
+      {
+         if (!files)
+            files = cJSON_AddArrayToObject(args, "files");
+         cJSON_AddItemToArray(files, cJSON_CreateString(arg));
+         continue;
+      }
+      fprintf(stderr,
+              "aimee: `aimee git %s` does not take '%s' as a bare word; pass it as "
+              "key=value (see `aimee git %s` with no arguments, or the git tool schema)\n",
+              sub, arg, sub);
+      cJSON_Delete(args);
+      cJSON_Delete(req);
+      return NULL;
+   }
+
+   /* Which checkout this is, as everywhere else: the caller's directory unless
+    * they named one. Added last — cJSON keeps duplicates and readers take the
+    * first, so an explicit path= must not be shadowed. */
+   if (!cJSON_GetObjectItemCaseSensitive(args, "path"))
+   {
+      char cwd[4096];
+      if (getcwd(cwd, sizeof(cwd)))
+         cJSON_AddStringToObject(args, "path", cwd);
+   }
+
+   cJSON_AddItemToObject(req, "arguments", args);
+   return req;
+}
+
 static cJSON *marshal_git_verify(int argc, char **argv)
 {
    cJSON *req = cJSON_CreateObject();
@@ -1255,6 +1460,7 @@ static const struct
     {"evidence.provenance_retrieval_event", marshal_audit_provenance},
     {"evidence.trace_retrieval_event", marshal_audit_trace},
     {"get_help", marshal_get_help},
+    {"git.cli", marshal_git_cli},
     {"git.verify", marshal_git_verify},
     {"graph.explain", marshal_graph_explain},
     {"graph.sync_code", marshal_graph_sync_code},

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -55,6 +55,8 @@ static const struct
     {"skill.list", pt_print_skill_list},
     {"skill.show", pt_print_skill_show},
     {"git.verify", pt_print_git_verify},
+    /* Every git command returns MCP content blocks, the same shape verify does. */
+    {"git.cli", pt_print_git_verify},
     {"get_help", pt_print_get_help},
     {"server.health", pt_print_server_health},
     {"session.list", pt_print_session_list},

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -203,8 +203,9 @@ static void s2_native_gate_pretool(const char *sid, const char *tool_name, const
       emit_pretool_deny_json(
           "aimee: delegates do not run git or gh directly — use aimee's git tools, which "
           "execute on aimee-server: git_status, git_log, git_diff_summary, git_branch, "
-          "git_commit, git_push, git_pr, git_verify. (Operator: require_aimee_git: false "
-          "in aimee.yaml opts out.)");
+          "git_add, git_commit, git_push, git_pr, git_verify, git_merge, git_rebase, "
+          "git_sync, git_cherry_pick, git_revert, git_switch. (Operator: "
+          "require_aimee_git: false in aimee.yaml opts out.)");
       exit(0);
    }
 

--- a/src/cmd_infra.c
+++ b/src/cmd_infra.c
@@ -620,6 +620,104 @@ static cJSON *git_sub_clone(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
    return handle_git_clone(args);
 }
 
+/* The history-integration commands. Each takes its target ref positionally and
+ * continue/abort/skip as a bare word, because that is how they are spoken:
+ * `aimee git merge origin/testing`, `aimee git rebase --continue`. */
+static cJSON *git_sub_integrate(cJSON *args, int argc, char **argv, cJSON *(*handler)(cJSON *),
+                                const char *what)
+{
+   for (int i = 0; i < argc; i++)
+   {
+      const char *a = argv[i];
+      while (*a == '-')
+         a++;
+      if (strcmp(a, "continue") == 0 || strcmp(a, "abort") == 0 || strcmp(a, "skip") == 0)
+         cJSON_AddStringToObject(args, "action", a);
+      else if (strcmp(argv[i], "--keep-conflicts") == 0)
+         cJSON_AddBoolToObject(args, "abort_on_conflict", 0);
+      else if (argv[i][0] != '-')
+         cJSON_AddStringToObject(args, "ref", argv[i]);
+   }
+   if (!cJSON_GetObjectItemCaseSensitive(args, "ref") &&
+       !cJSON_GetObjectItemCaseSensitive(args, "action"))
+   {
+      fprintf(stderr,
+              "Usage: aimee git %s <ref>            (start one)\n"
+              "       aimee git %s continue|abort   (drive one that hit a conflict)\n"
+              "Add --keep-conflicts to stop in the conflicted state instead of undoing.\n",
+              what, what);
+      return NULL;
+   }
+   return handler(args);
+}
+
+static cJSON *git_sub_merge(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
+{
+   return git_sub_integrate(args, argc, argv, handle_git_merge, "merge");
+}
+
+static cJSON *git_sub_rebase(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
+{
+   /* rebase's target is `base`; the handler accepts either name. */
+   return git_sub_integrate(args, argc, argv, handle_git_rebase, "rebase");
+}
+
+static cJSON *git_sub_cherry_pick(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
+{
+   return git_sub_integrate(args, argc, argv, handle_git_cherry_pick, "cherry-pick");
+}
+
+static cJSON *git_sub_revert(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
+{
+   return git_sub_integrate(args, argc, argv, handle_git_revert, "revert");
+}
+
+static cJSON *git_sub_sync(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
+{
+   for (int i = 0; i < argc; i++)
+   {
+      if (strcmp(argv[i], "--merge") == 0)
+         cJSON_AddStringToObject(args, "mode", "merge");
+      else if (argv[i][0] != '-')
+         cJSON_AddStringToObject(args, "base", argv[i]);
+   }
+   return handle_git_sync(args);
+}
+
+static cJSON *git_sub_add(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
+{
+   cJSON *files = NULL;
+   for (int i = 0; i < argc; i++)
+   {
+      if (strcmp(argv[i], "-A") == 0 || strcmp(argv[i], "--all") == 0)
+         cJSON_AddBoolToObject(args, "all", 1);
+      else if (argv[i][0] != '-')
+      {
+         if (!files)
+            files = cJSON_AddArrayToObject(args, "files");
+         cJSON_AddItemToArray(files, cJSON_CreateString(argv[i]));
+      }
+   }
+   if (!files && !cJSON_GetObjectItemCaseSensitive(args, "all"))
+   {
+      fprintf(stderr, "Usage: aimee git add <paths...>\n"
+                      "       aimee git add -A\n");
+      return NULL;
+   }
+   return handle_git_add(args);
+}
+
+static cJSON *git_sub_switch(app_ctx_t *ctx, cJSON *args, int argc, char **argv)
+{
+   if (argc < 1)
+   {
+      fprintf(stderr, "Usage: aimee git switch <branch>\n");
+      return NULL;
+   }
+   cJSON_AddStringToObject(args, "ref", argv[0]);
+   return handle_git_switch(args);
+}
+
 typedef cJSON *(*git_sub_fn)(app_ctx_t *ctx, cJSON *args, int argc, char **argv);
 
 static const struct
@@ -643,6 +741,14 @@ static const struct
     {"reset", git_sub_reset},
     {"restore", git_sub_restore},
     {"clone", git_sub_clone},
+    {"merge", git_sub_merge},
+    {"rebase", git_sub_rebase},
+    {"cherry-pick", git_sub_cherry_pick},
+    {"cherry_pick", git_sub_cherry_pick},
+    {"revert", git_sub_revert},
+    {"sync", git_sub_sync},
+    {"add", git_sub_add},
+    {"switch", git_sub_switch},
     {NULL, NULL},
 };
 
@@ -651,7 +757,8 @@ void cmd_git(app_ctx_t *ctx, int argc, char **argv)
    if (argc < 1)
    {
       fprintf(stderr, "Usage: aimee git <status|commit|push|pull|fetch|branch|log|diff|"
-                      "pr|issue|stash|tag|reset|restore|clone|verify>\n");
+                      "pr|issue|stash|tag|reset|restore|clone|verify|\n"
+                      "                 merge|rebase|sync|cherry-pick|revert|add|switch>\n");
       return;
    }
 

--- a/src/modules/git/mcp_git.h
+++ b/src/modules/git/mcp_git.h
@@ -49,6 +49,12 @@ cJSON *handle_git_add(cJSON *args);
 cJSON *handle_git_switch(cJSON *args);
 cJSON *handle_git_checkout(cJSON *args);
 
+/* 1 when a git tool's response reports failure. The tools say so in the text they
+ * return (it leads with "error" or "conflict"), and composed operations — sync,
+ * pr action=ready — have to branch on that. Defined once so a wrapper cannot
+ * accidentally bury the marker and make a failure read as success. */
+int mcp_git_response_failed(cJSON *resp);
+
 /* Unstage anything in the index that is_sensitive_file() matches, naming them in
  * report (may be NULL). Returns how many. Screens the INDEX rather than a caller's
  * path list, which is what `add all=true` needs. */

--- a/src/modules/git/mcp_git.h
+++ b/src/modules/git/mcp_git.h
@@ -24,6 +24,45 @@ cJSON *handle_git_reset(cJSON *args);
 cJSON *handle_git_restore(cJSON *args);
 cJSON *handle_git_issue(cJSON *args);
 
+/* Bring one line of history into another. Each takes the target ref (`ref`, or
+ * `base` for rebase) to start, or action=continue/abort/skip to drive one that
+ * stopped on a conflict. aimee fetches a remote-looking ref first, never opens an
+ * editor, reports conflicts as the list of conflicted files, and by default
+ * ABORTS on conflict so the caller is never handed a half-applied tree. */
+cJSON *handle_git_merge(cJSON *args);
+cJSON *handle_git_rebase(cJSON *args);
+cJSON *handle_git_cherry_pick(cJSON *args);
+cJSON *handle_git_revert(cJSON *args);
+
+/* "Make this branch current with the branch it will merge into": resolve the base
+ * (given, else origin's default branch), fetch it, rebase (default) or merge it
+ * in, and report the gap it closed. The whole errand in one call. */
+cJSON *handle_git_sync(cJSON *args);
+
+/* Stage without committing — including new files, which git_commit cannot reach
+ * (it stages tracked changes or the paths it was handed). `files` or `all`. */
+cJSON *handle_git_add(cJSON *args);
+
+/* Routing to the handler that already owns the behaviour, so the caller does not
+ * have to know where it lives: switch -> git_branch action=switch; checkout ->
+ * git_restore when `files` is given, otherwise switch. */
+cJSON *handle_git_switch(cJSON *args);
+cJSON *handle_git_checkout(cJSON *args);
+
+/* Unstage anything in the index that is_sensitive_file() matches, naming them in
+ * report (may be NULL). Returns how many. Screens the INDEX rather than a caller's
+ * path list, which is what `add all=true` needs. */
+int mcp_git_unstage_sensitive(char *report, size_t report_len);
+
+/* The `-c user.name=... -c user.email=...` prefix aimee commits with, resolved
+ * from the vault/checkout config. Returns 1 with the flags in out, 0 when no
+ * identity is configured, -1 when the vault could not be read; pass the
+ * non-positive result to mcp_git_identity_error for the message to return.
+ * Shared by every path that creates a commit, so a conflict continuation is
+ * authored exactly like a git_commit. */
+int mcp_git_identity_flags(char *out, size_t out_len);
+const char *mcp_git_identity_error(int rc);
+
 /* Run a git tool by NAME through the full git dispatch path: mirror-cwd remap,
  * detached-workspace binding, mcp_chdir_git_root (which REFUSES rather than let a
  * mutating op run against the main repo), the mutating-op context-mismatch guard,

--- a/src/modules/git/mcp_git_integrate.c
+++ b/src/modules/git/mcp_git_integrate.c
@@ -1,0 +1,537 @@
+/* mcp_git_integrate.c: the operations that bring one line of history into
+ * another — merge, rebase, cherry-pick, revert — and `sync`, which is the whole
+ * "get my branch current with its base" errand in one call.
+ *
+ * These four are one operation with four names. Each can stop mid-flight on a
+ * conflict, each leaves the repository in a state that needs continuing or
+ * abandoning, and each needs an author identity when it finally commits. So they
+ * share one driver (integrate_run) and differ only by the row in OPS.
+ *
+ * The point of modeling them rather than passing argv through is that AIMEE does
+ * the work the caller would otherwise have to reason about:
+ *   - a remote-looking ref is fetched first, so `merge origin/main` cannot
+ *     silently merge a stale copy;
+ *   - the editor is disabled, so nothing ever blocks waiting on one;
+ *   - a conflict is REPORTED as the list of conflicted files and, by default,
+ *     ABORTED, so the caller is never handed a half-merged tree it has to know
+ *     how to clean up;
+ *   - a continuation commits with the vaulted operator identity, the same as
+ *     git_commit;
+ *   - the result says what changed (commits, files, HEAD) instead of echoing
+ *     git's prose.
+ */
+#include "aimee.h"
+#include "branch_ownership.h"
+#include "cJSON.h"
+#include "mcp_git.h"
+#include "util.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define INTEGRATE_OUT_MAX 8192
+#define CONFLICT_LIST_MAX 4096
+
+static cJSON *mcp_text(const char *text)
+{
+   cJSON *arr = cJSON_CreateArray();
+   cJSON *item = cJSON_CreateObject();
+   cJSON_AddStringToObject(item, "type", "text");
+   cJSON_AddStringToObject(item, "text", text);
+   cJSON_AddItemToArray(arr, item);
+   return arr;
+}
+
+static cJSON *mcp_textf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+static cJSON *mcp_textf(const char *fmt, ...)
+{
+   char buf[INTEGRATE_OUT_MAX];
+   va_list ap;
+   va_start(ap, fmt);
+   vsnprintf(buf, sizeof(buf), fmt, ap);
+   va_end(ap);
+   return mcp_text(buf);
+}
+
+/* One row per operation. `start` and the continuation words are git's own
+ * spelling; everything else about how the operation is driven is shared. */
+typedef struct
+{
+   const char *name;        /* aimee command name, for messages */
+   const char *start;       /* printf with one %s: the escaped target ref */
+   const char *needs_ref;   /* what to call the ref in the "required" error */
+   const char *inprog_ref;  /* ref that exists while the op is stopped mid-flight */
+   const char *cont;        /* git words to continue */
+   const char *abort;       /* git words to abort */
+   const char *skip;        /* git words to skip a commit, NULL if not applicable */
+   int commits_on_continue; /* continuing creates a commit -> needs an identity */
+} integrate_op_t;
+
+static const integrate_op_t OPS[] = {
+    {"merge", "merge --no-edit '%s'", "ref (the branch or commit to merge in)", "MERGE_HEAD",
+     "merge --continue", "merge --abort", NULL, 1},
+    {"rebase", "rebase '%s'", "base (the branch to rebase onto)", "REBASE_HEAD",
+     "rebase --continue", "rebase --abort", "rebase --skip", 1},
+    {"cherry_pick", "cherry-pick '%s'", "ref (the commit to cherry-pick)", "CHERRY_PICK_HEAD",
+     "cherry-pick --continue", "cherry-pick --abort", "cherry-pick --skip", 1},
+    {"revert", "revert --no-edit '%s'", "ref (the commit to revert)", "REVERT_HEAD",
+     "revert --continue", "revert --abort", "revert --skip", 1},
+};
+
+/* Never let git open an editor: these run unattended, and a blocked editor looks
+ * exactly like a hang. core.editor covers merge/revert messages, and
+ * sequence.editor covers the rebase todo list. */
+#define GIT_NO_EDITOR "-c core.editor=true -c sequence.editor=true"
+
+static int run_ok(const char *cmd)
+{
+   int rc = 0;
+   free(mcp_git_run(cmd, &rc));
+   return rc == 0;
+}
+
+static void capture_line(const char *cmd, char *out, size_t out_len)
+{
+   out[0] = '\0';
+   int rc = 0;
+   char *got = mcp_git_run(cmd, &rc);
+   if (got && rc == 0)
+   {
+      snprintf(out, out_len, "%s", got);
+      out[strcspn(out, "\r\n")] = '\0';
+   }
+   free(got);
+}
+
+static void short_head(char *out, size_t out_len)
+{
+   capture_line("git rev-parse --short HEAD 2>/dev/null", out, out_len);
+}
+
+/* Files git has left with conflict markers. This is the one piece of state the
+ * caller genuinely needs from a stopped operation. */
+static int conflicted_files(char *out, size_t out_len)
+{
+   out[0] = '\0';
+   int rc = 0;
+   char *got = mcp_git_run("git diff --name-only --diff-filter=U 2>/dev/null", &rc);
+   if (!got)
+      return 0;
+   int n = 0, pos = 0;
+   char *line = got;
+   while (line && *line)
+   {
+      char *nl = strchr(line, '\n');
+      if (nl)
+         *nl = '\0';
+      if (*line)
+      {
+         n++;
+         pos = str_appendf(out, pos, (int)out_len, "\n  %s", line);
+      }
+      line = nl ? nl + 1 : NULL;
+   }
+   free(got);
+   return n;
+}
+
+/* Is one of these operations already stopped mid-flight? Returns the op, or NULL.
+ * Checked before starting anything: git's own error for this case names a file in
+ * .git, which tells the caller nothing about what to do next. */
+static const integrate_op_t *operation_in_progress(void)
+{
+   for (size_t i = 0; i < sizeof(OPS) / sizeof(OPS[0]); i++)
+   {
+      char cmd[128];
+      snprintf(cmd, sizeof(cmd), "git rev-parse --verify --quiet %s >/dev/null 2>&1",
+               OPS[i].inprog_ref);
+      if (run_ok(cmd))
+         return &OPS[i];
+   }
+   return NULL;
+}
+
+/* A ref naming a remote-tracking branch is only as current as the last fetch, so
+ * fetch it before using it. Silent no-op for a local ref or a raw SHA — that is
+ * what makes `merge origin/main` mean what the caller meant. */
+static void fetch_if_remote(const char *ref, char *note, size_t note_len)
+{
+   note[0] = '\0';
+   const char *slash = strchr(ref, '/');
+   if (!slash || slash == ref)
+      return;
+
+   char remote[128];
+   size_t rlen = (size_t)(slash - ref);
+   if (rlen >= sizeof(remote))
+      return;
+   memcpy(remote, ref, rlen);
+   remote[rlen] = '\0';
+
+   char *esc_remote = shell_escape(remote);
+   char check[256];
+   snprintf(check, sizeof(check), "git remote get-url '%s' >/dev/null 2>&1", esc_remote);
+   if (!run_ok(check))
+   {
+      free(esc_remote);
+      return; /* not a remote name: a branch with a slash, or a path */
+   }
+
+   char *esc_branch = shell_escape(slash + 1);
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "git fetch '%s' '%s' 2>&1", esc_remote, esc_branch);
+   free(esc_remote);
+   free(esc_branch);
+   int rc = 0;
+   char *out = mcp_git_run(cmd, &rc);
+   free(out);
+   if (rc == 0)
+      snprintf(note, note_len, "fetched %s; ", ref);
+   else
+      snprintf(note, note_len, "warning: could not fetch %s (using the local copy); ", ref);
+}
+
+/* What the operation actually did, in the terms the caller cares about. */
+static void describe_change(const char *pre, char *out, size_t out_len)
+{
+   char post[64] = "";
+   short_head(post, sizeof(post));
+   if (strcmp(pre, post) == 0)
+   {
+      snprintf(out, out_len, "already up to date at %s — nothing to do", post);
+      return;
+   }
+
+   char count_cmd[256], stat_cmd[256], count[64] = "", stat[256] = "";
+   snprintf(count_cmd, sizeof(count_cmd), "git rev-list --count '%s'..HEAD 2>/dev/null", pre);
+   snprintf(stat_cmd, sizeof(stat_cmd), "git diff --shortstat '%s' HEAD 2>/dev/null", pre);
+   capture_line(count_cmd, count, sizeof(count));
+   capture_line(stat_cmd, stat, sizeof(stat));
+
+   int pos = snprintf(out, out_len, "%s..%s", pre, post);
+   if (count[0])
+      pos = str_appendf(out, pos, (int)out_len, ", %s commit(s)", count);
+   if (stat[0])
+   {
+      const char *s = stat;
+      while (*s == ' ')
+         s++;
+      pos = str_appendf(out, pos, (int)out_len, ", %s", s);
+   }
+   (void)pos;
+}
+
+/* Continue / abort / skip a stopped operation. Continuing commits, so it needs
+ * the same vaulted identity git_commit uses — without it the merge commit would
+ * have no author. */
+static cJSON *integrate_resume(const integrate_op_t *op, const char *action)
+{
+   const integrate_op_t *live = operation_in_progress();
+   if (!live)
+      return mcp_textf("error: no %s is in progress, so there is nothing to %s", op->name, action);
+   if (live != op)
+      return mcp_textf("error: a %s is in progress, not a %s — use command=%s action=%s",
+                       live->name, op->name, live->name, action);
+
+   const char *words = NULL;
+   if (strcmp(action, "continue") == 0)
+      words = op->cont;
+   else if (strcmp(action, "abort") == 0)
+      words = op->abort;
+   else if (strcmp(action, "skip") == 0)
+      words = op->skip;
+   if (!words)
+      return mcp_textf("error: %s does not support action=%s", op->name, action);
+
+   char pre[64] = "";
+   short_head(pre, sizeof(pre));
+
+   if (strcmp(action, "continue") == 0)
+   {
+      char still[CONFLICT_LIST_MAX];
+      int n = conflicted_files(still, sizeof(still));
+      if (n > 0)
+         return mcp_textf("error: %d file(s) still have conflict markers; resolve and stage them "
+                          "before continuing:%s",
+                          n, still);
+   }
+
+   char ident[768] = "";
+   if (strcmp(action, "continue") == 0 && op->commits_on_continue)
+   {
+      int have = mcp_git_identity_flags(ident, sizeof(ident));
+      if (have <= 0)
+         return mcp_text(mcp_git_identity_error(have));
+   }
+
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd), "git %s %s %s 2>&1", ident, GIT_NO_EDITOR, words);
+   int rc = 0;
+   char *out = mcp_git_run(cmd, &rc);
+
+   if (rc != 0)
+   {
+      char still[CONFLICT_LIST_MAX];
+      int n = conflicted_files(still, sizeof(still));
+      cJSON *r;
+      if (n > 0)
+         r = mcp_textf("error: %s --%s stopped again on %d conflicted file(s):%s\n%s", op->name,
+                       action, n, still, out ? out : "");
+      else
+         r = mcp_textf("error: %s --%s failed: %s", op->name, action, out ? out : "unknown");
+      free(out);
+      return r;
+   }
+   free(out);
+
+   if (strcmp(action, "abort") == 0)
+      return mcp_textf("%s aborted; the tree is back at %s with no changes from it", op->name, pre);
+
+   char change[512];
+   describe_change(pre, change, sizeof(change));
+   return mcp_textf("%s completed (%s): %s", op->name, action, change);
+}
+
+/* Start one of the four. */
+static cJSON *integrate_run(const integrate_op_t *op, cJSON *args)
+{
+   /* Guards first, and the same ones the other writers use: this rewrites the
+    * branch. */
+   char branch[256] = "";
+   get_current_branch(branch, sizeof(branch));
+   if (strcmp(branch, "main") == 0 || strcmp(branch, "master") == 0)
+      return mcp_textf("error: %s blocked — writing to the main branch is not allowed. Work on a "
+                       "feature branch, and merge to main through command=pr action=merge.",
+                       op->name);
+   {
+      cJSON *blocked = branch_own_guard_for(branch, op->name);
+      if (blocked)
+         return blocked;
+   }
+
+   /* rebase takes its target as `base` (that is what it is), the other three take
+    * `ref`. Accept either for both, because the distinction is not worth a failed
+    * call. */
+   cJSON *jref = cJSON_GetObjectItemCaseSensitive(args, "ref");
+   cJSON *jbase = cJSON_GetObjectItemCaseSensitive(args, "base");
+   const char *ref = NULL;
+   if (strcmp(op->name, "rebase") == 0)
+      ref = (cJSON_IsString(jbase) && jbase->valuestring[0])
+                ? jbase->valuestring
+                : ((cJSON_IsString(jref) && jref->valuestring[0]) ? jref->valuestring : NULL);
+   else
+      ref = (cJSON_IsString(jref) && jref->valuestring[0])
+                ? jref->valuestring
+                : ((cJSON_IsString(jbase) && jbase->valuestring[0]) ? jbase->valuestring : NULL);
+   if (!ref)
+      return mcp_textf("error: '%s' is required for %s", op->needs_ref, op->name);
+
+   const integrate_op_t *live = operation_in_progress();
+   if (live)
+      return mcp_textf("error: a %s is already in progress. Finish it with command=%s "
+                       "action=continue, or back out with command=%s action=abort, before "
+                       "starting a %s.",
+                       live->name, live->name, live->name, op->name);
+
+   /* A dirty tree turns a conflict into a mess that cannot be cleanly aborted. */
+   int rc = 0;
+   char *dirty = mcp_git_run("git status --porcelain 2>/dev/null", &rc);
+   int is_dirty = (dirty && dirty[0]);
+   free(dirty);
+   if (is_dirty)
+      return mcp_textf("error: the working tree has uncommitted changes, so a %s could not be "
+                       "cleanly undone if it conflicts. Commit them (command=commit) or set them "
+                       "aside (command=stash action=push) first.",
+                       op->name);
+
+   char fetch_note[256];
+   fetch_if_remote(ref, fetch_note, sizeof(fetch_note));
+
+   char pre[64] = "";
+   short_head(pre, sizeof(pre));
+
+   char *esc_ref = shell_escape(ref);
+   char start[512];
+   snprintf(start, sizeof(start), op->start, esc_ref);
+   free(esc_ref);
+
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd), "git %s %s 2>&1", GIT_NO_EDITOR, start);
+   char *out = mcp_git_run(cmd, &rc);
+
+   if (rc == 0)
+   {
+      char change[512];
+      describe_change(pre, change, sizeof(change));
+      cJSON *r = mcp_textf("%s %s into %s — %s%s", op->name, ref, branch, fetch_note, change);
+      free(out);
+      return r;
+   }
+
+   /* It failed. A conflict is the interesting case and gets the file list; by
+    * default the operation is undone so the caller is never left holding a
+    * half-applied tree it has to know how to clean up. */
+   char conflicts[CONFLICT_LIST_MAX];
+   int n = conflicted_files(conflicts, sizeof(conflicts));
+   if (n == 0)
+   {
+      cJSON *r =
+          mcp_textf("error: %s %s failed: %s%s", op->name, ref, fetch_note, out ? out : "unknown");
+      free(out);
+      return r;
+   }
+   free(out);
+
+   cJSON *jkeep = cJSON_GetObjectItemCaseSensitive(args, "abort_on_conflict");
+   int keep_going = (jkeep && cJSON_IsFalse(jkeep)) ? 1 : 0;
+
+   if (!keep_going)
+   {
+      char abort_cmd[256];
+      snprintf(abort_cmd, sizeof(abort_cmd), "git %s 2>&1", op->abort);
+      int arc = 0;
+      char *aout = mcp_git_run(abort_cmd, &arc);
+      free(aout);
+      if (arc != 0)
+         return mcp_textf("error: %s %s conflicted on %d file(s) and could NOT be aborted — the "
+                          "tree is mid-%s and needs a human:%s",
+                          op->name, ref, n, op->name, conflicts);
+      return mcp_textf("conflict: %s %s touches %d file(s) that changed here too:%s\n\n"
+                       "The %s was aborted, so the tree is unchanged at %s. To resolve them in "
+                       "place instead, re-run with abort_on_conflict=false — then edit the files, "
+                       "command=add, and command=%s action=continue.",
+                       op->name, ref, n, conflicts, op->name, pre, op->name);
+   }
+
+   return mcp_textf("conflict: %s %s stopped on %d file(s), left in progress:%s\n\n"
+                    "Resolve them, stage with command=add, then command=%s action=continue. "
+                    "command=%s action=abort backs the whole %s out.",
+                    op->name, ref, n, conflicts, op->name, op->name, op->name);
+}
+
+static cJSON *integrate_dispatch(const char *name, cJSON *args)
+{
+   const integrate_op_t *op = NULL;
+   for (size_t i = 0; i < sizeof(OPS) / sizeof(OPS[0]); i++)
+      if (strcmp(name, OPS[i].name) == 0)
+         op = &OPS[i];
+   if (!op)
+      return mcp_text("error: unknown integrate operation");
+
+   cJSON *jaction = cJSON_GetObjectItemCaseSensitive(args, "action");
+   const char *action = cJSON_IsString(jaction) ? jaction->valuestring : NULL;
+   if (action && action[0] && strcmp(action, "run") != 0)
+   {
+      if (strcmp(action, "continue") != 0 && strcmp(action, "abort") != 0 &&
+          strcmp(action, "skip") != 0)
+         return mcp_textf("error: unknown action '%s' for %s. Use continue, abort or skip (or "
+                          "omit action to start one).",
+                          action, name);
+      return integrate_resume(op, action);
+   }
+   return integrate_run(op, args);
+}
+
+cJSON *handle_git_merge(cJSON *args)
+{
+   return integrate_dispatch("merge", args);
+}
+cJSON *handle_git_rebase(cJSON *args)
+{
+   return integrate_dispatch("rebase", args);
+}
+cJSON *handle_git_cherry_pick(cJSON *args)
+{
+   return integrate_dispatch("cherry_pick", args);
+}
+cJSON *handle_git_revert(cJSON *args)
+{
+   return integrate_dispatch("revert", args);
+}
+
+/* --- git_sync ---
+ *
+ * The errand, not the mechanics: "make this branch current with the branch it
+ * will merge into". That is a fetch, a choice of rebase or merge, conflict
+ * handling, and a before/after report — which is four calls and a decision the
+ * caller should not have to make, so it is one call here.
+ *
+ * Rebase by default: a PR branch that rebases onto its base reviews as the work
+ * alone, with no merge commits from the base mixed in. */
+cJSON *handle_git_sync(cJSON *args)
+{
+   char branch[256] = "";
+   get_current_branch(branch, sizeof(branch));
+
+   /* Resolve the base the same way a human would guess it: what was asked for,
+    * else what origin says its default branch is, else main. */
+   cJSON *jbase = cJSON_GetObjectItemCaseSensitive(args, "base");
+   char base[256] = "";
+   if (cJSON_IsString(jbase) && jbase->valuestring[0])
+      snprintf(base, sizeof(base), "%s", jbase->valuestring);
+   else
+   {
+      char head_ref[256] = "";
+      capture_line("git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null", head_ref,
+                   sizeof(head_ref));
+      if (head_ref[0])
+         snprintf(base, sizeof(base), "%s", head_ref); /* already origin/<name> */
+      else
+         snprintf(base, sizeof(base), "origin/main");
+   }
+   /* A bare branch name means the remote's copy of it: syncing to a stale local
+    * base is never what was meant. */
+   if (!strchr(base, '/'))
+   {
+      char qualified[256];
+      snprintf(qualified, sizeof(qualified), "origin/%s", base);
+      snprintf(base, sizeof(base), "%s", qualified);
+   }
+
+   if (strcmp(branch, "main") == 0 || strcmp(branch, "master") == 0)
+      return mcp_textf("error: sync blocked — writing to the main branch is not allowed. Switch "
+                       "to a feature branch first (command=switch ref=<branch>).");
+
+   cJSON *jmode = cJSON_GetObjectItemCaseSensitive(args, "mode");
+   const char *mode =
+       (cJSON_IsString(jmode) && jmode->valuestring[0]) ? jmode->valuestring : "rebase";
+   if (strcmp(mode, "rebase") != 0 && strcmp(mode, "merge") != 0)
+      return mcp_text("error: mode must be rebase (default) or merge");
+
+   /* Report the gap before and after, so the answer to "am I current?" is in the
+    * result rather than a follow-up call. */
+   char fetch_note[256];
+   fetch_if_remote(base, fetch_note, sizeof(fetch_note));
+
+   char gap_cmd[512], gap[128] = "";
+   char *esc_base = shell_escape(base);
+   snprintf(gap_cmd, sizeof(gap_cmd), "git rev-list --left-right --count '%s'...HEAD 2>/dev/null",
+            esc_base);
+   free(esc_base);
+   capture_line(gap_cmd, gap, sizeof(gap));
+
+   int behind = 0, ahead = 0;
+   if (gap[0] && sscanf(gap, "%d %d", &behind, &ahead) == 2 && behind == 0)
+      return mcp_textf("%s is already current with %s (%d commit(s) ahead, 0 behind)", branch, base,
+                       ahead);
+
+   cJSON_DeleteItemFromObjectCaseSensitive(args, "base");
+   cJSON_AddStringToObject(args, "base", base);
+   cJSON_DeleteItemFromObjectCaseSensitive(args, "ref");
+   cJSON_AddStringToObject(args, "ref", base);
+
+   cJSON *resp = integrate_dispatch(strcmp(mode, "merge") == 0 ? "merge" : "rebase", args);
+
+   /* Prefix the gap that was closed; the integrate result already says what moved. */
+   cJSON *item = resp ? cJSON_GetArrayItem(resp, 0) : NULL;
+   cJSON *text = item ? cJSON_GetObjectItem(item, "text") : NULL;
+   if (cJSON_IsString(text))
+   {
+      char merged[INTEGRATE_OUT_MAX];
+      snprintf(merged, sizeof(merged), "sync %s <- %s (%d behind, %d ahead) via %s\n%s", branch,
+               base, behind, ahead, mode, text->valuestring);
+      cJSON_ReplaceItemInObject(item, "text", cJSON_CreateString(merged));
+   }
+   return resp;
+}

--- a/src/modules/git/mcp_git_integrate.c
+++ b/src/modules/git/mcp_git_integrate.c
@@ -54,6 +54,20 @@ static cJSON *mcp_textf(const char *fmt, ...)
    return mcp_text(buf);
 }
 
+/* See mcp_git.h. The git tools report failure in the text they return — the
+ * leading word is "error" or "conflict" — and composed operations (sync, pr
+ * action=ready) have to branch on it. One definition of the convention, here,
+ * rather than a substring check per caller. */
+int mcp_git_response_failed(cJSON *resp)
+{
+   cJSON *item = resp ? cJSON_GetArrayItem(resp, 0) : NULL;
+   cJSON *text = item ? cJSON_GetObjectItem(item, "text") : NULL;
+   if (!cJSON_IsString(text))
+      return 1;
+   return strncmp(text->valuestring, "error", 5) == 0 ||
+          strncmp(text->valuestring, "conflict", 8) == 0;
+}
+
 /* One row per operation. `start` and the continuation words are git's own
  * spelling; everything else about how the operation is driven is shared. */
 typedef struct
@@ -480,13 +494,23 @@ cJSON *handle_git_sync(cJSON *args)
       else
          snprintf(base, sizeof(base), "origin/main");
    }
-   /* A bare branch name means the remote's copy of it: syncing to a stale local
-    * base is never what was meant. */
+   /* A bare branch name means the remote's copy of it — syncing to a stale local
+    * base is never what was meant — but only if the remote actually has it. A repo
+    * with no origin, or a base that lives only locally, syncs to the local branch
+    * rather than failing on a ref that was never going to resolve. */
    if (!strchr(base, '/'))
    {
-      char qualified[256];
-      snprintf(qualified, sizeof(qualified), "origin/%s", base);
-      snprintf(base, sizeof(base), "%s", qualified);
+      char *esc = shell_escape(base);
+      char probe[512];
+      snprintf(probe, sizeof(probe), "git rev-parse --verify --quiet 'origin/%s' >/dev/null 2>&1",
+               esc);
+      free(esc);
+      if (run_ok(probe))
+      {
+         char qualified[256];
+         snprintf(qualified, sizeof(qualified), "origin/%s", base);
+         snprintf(base, sizeof(base), "%s", qualified);
+      }
    }
 
    if (strcmp(branch, "main") == 0 || strcmp(branch, "master") == 0)
@@ -523,14 +547,21 @@ cJSON *handle_git_sync(cJSON *args)
 
    cJSON *resp = integrate_dispatch(strcmp(mode, "merge") == 0 ? "merge" : "rebase", args);
 
-   /* Prefix the gap that was closed; the integrate result already says what moved. */
+   /* Add the gap that was closed — but NEVER in front of a failure. Every caller
+    * reads failure off the leading "error"/"conflict" word (mcp_git_response_failed),
+    * so prefixing context to a conflicted sync would make it look like it worked.
+    * On success the context leads; on failure it trails. */
    cJSON *item = resp ? cJSON_GetArrayItem(resp, 0) : NULL;
    cJSON *text = item ? cJSON_GetObjectItem(item, "text") : NULL;
    if (cJSON_IsString(text))
    {
       char merged[INTEGRATE_OUT_MAX];
-      snprintf(merged, sizeof(merged), "sync %s <- %s (%d behind, %d ahead) via %s\n%s", branch,
-               base, behind, ahead, mode, text->valuestring);
+      if (mcp_git_response_failed(resp))
+         snprintf(merged, sizeof(merged), "%s\n\n(sync %s <- %s: %d behind, %d ahead, via %s)",
+                  text->valuestring, branch, base, behind, ahead, mode);
+      else
+         snprintf(merged, sizeof(merged), "sync %s <- %s (%d behind, %d ahead) via %s\n%s", branch,
+                  base, behind, ahead, mode, text->valuestring);
       cJSON_ReplaceItemInObject(item, "text", cJSON_CreateString(merged));
    }
    return resp;

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -34,6 +34,125 @@ static cJSON *mcp_error(const char *fmt, const char *detail)
    return mcp_text(buf);
 }
 
+/* Write a PR title and body from the commits this branch has that `base` does
+ * not. Returns 0, or -1 when the branch has no such commits (nothing to open).
+ *
+ * Deterministic on purpose — no model call. The commit subjects ARE the summary,
+ * so a title the caller would have written costs a turn to produce and says the
+ * same thing. One commit lends its subject verbatim (and its body, which is
+ * usually the rationale worth reading); several get the shared conventional-commit
+ * prefix where they agree, and the body lists them with the diffstat. */
+static int pr_derive_from_commits(const char *base, char *title, size_t title_len, char *body,
+                                  size_t body_len)
+{
+   title[0] = '\0';
+   body[0] = '\0';
+
+   /* Prefer the remote's copy of the base: a stale local base would attribute
+    * commits to this branch that are already merged. */
+   char *esc_base = shell_escape(base);
+   char range[512];
+   int rc = 0;
+   snprintf(range, sizeof(range), "git rev-parse --verify --quiet 'origin/%s' >/dev/null 2>&1",
+            esc_base);
+   int have_remote_base = 0;
+   {
+      char *probe = mcp_git_run(range, &rc);
+      free(probe);
+      have_remote_base = (rc == 0);
+   }
+   char base_ref[600];
+   if (have_remote_base && strncmp(base, "origin/", 7) != 0)
+      snprintf(base_ref, sizeof(base_ref), "origin/%s", esc_base);
+   else
+      snprintf(base_ref, sizeof(base_ref), "%s", esc_base);
+   free(esc_base);
+
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd), "git log --reverse --format='%%s' '%s'..HEAD 2>/dev/null", base_ref);
+   char *subjects = mcp_git_run(cmd, &rc);
+   if (rc != 0 || !subjects || !subjects[0])
+   {
+      free(subjects);
+      return -1;
+   }
+
+   /* Count and collect. */
+   int n = 0;
+   char first[512] = "";
+   int bpos = 0;
+   char *line = subjects;
+   while (line && *line)
+   {
+      char *nl = strchr(line, '\n');
+      if (nl)
+         *nl = '\0';
+      if (*line)
+      {
+         n++;
+         if (n == 1)
+            snprintf(first, sizeof(first), "%s", line);
+         bpos = str_appendf(body, bpos, (int)body_len, "- %s\n", line);
+      }
+      line = nl ? nl + 1 : NULL;
+   }
+   free(subjects);
+   if (n == 0)
+      return -1;
+
+   if (n == 1)
+   {
+      /* One commit: its subject is the title, and its own body is the rationale. */
+      snprintf(title, title_len, "%s", first);
+      snprintf(cmd, sizeof(cmd), "git log -1 --format='%%b' HEAD 2>/dev/null");
+      char *msg_body = mcp_git_run(cmd, &rc);
+      body[0] = '\0';
+      if (rc == 0 && msg_body && msg_body[0])
+         snprintf(body, body_len, "%s", msg_body);
+      free(msg_body);
+      bpos = (int)strlen(body);
+   }
+   else
+   {
+      /* Several: keep the conventional-commit type when every subject agrees on
+       * one, so the PR title reads like the commits it contains. */
+      char prefix[64] = "";
+      const char *colon = strchr(first, ':');
+      if (colon && colon - first < (long)sizeof(prefix) - 1)
+      {
+         size_t plen = (size_t)(colon - first);
+         memcpy(prefix, first, plen);
+         prefix[plen] = '\0';
+         /* Only a type/scope prefix, not any sentence with a colon in it. */
+         for (char *p = prefix; *p; p++)
+            if (!islower((unsigned char)*p) && *p != '(' && *p != ')' && *p != '-' && *p != '/' &&
+                *p != '_')
+            {
+               prefix[0] = '\0';
+               break;
+            }
+      }
+      char branch[256] = "";
+      get_current_branch(branch, sizeof(branch));
+      const char *topic = branch;
+      const char *slash = strrchr(branch, '/');
+      if (slash && slash[1])
+         topic = slash + 1;
+      if (prefix[0])
+         snprintf(title, title_len, "%s: %s (%d commits)", prefix, topic, n);
+      else
+         snprintf(title, title_len, "%s (%d commits)", topic, n);
+   }
+
+   /* The diffstat is the one thing the subjects do not say: how big this is. */
+   snprintf(cmd, sizeof(cmd), "git diff --stat '%s'...HEAD 2>/dev/null", base_ref);
+   char *stat = mcp_git_run(cmd, &rc);
+   if (rc == 0 && stat && stat[0])
+      str_appendf(body, bpos, (int)body_len, "\n%s", stat);
+   free(stat);
+   return 0;
+}
+
 static int get_origin_repo_slug(char *buf, size_t len)
 {
    if (!buf || len == 0)
@@ -554,15 +673,40 @@ cJSON *handle_git_pr(cJSON *args)
       cJSON *jbody = cJSON_GetObjectItemCaseSensitive(args, "body");
       cJSON *jbase = cJSON_GetObjectItemCaseSensitive(args, "base");
 
+      const char *base = cJSON_IsString(jbase) ? jbase->valuestring : "main";
+
+      /* Title and body are OPTIONAL: the branch's own commits already say what the
+       * change is, so aimee derives them rather than making the caller spend a
+       * model turn writing prose it can read off the history. An explicit title
+       * always wins. */
+      char derived_title[512] = "", derived_body[8192] = "";
       if (!cJSON_IsString(jtitle) || !jtitle->valuestring[0])
-         return mcp_text("error: 'title' parameter is required for create");
+      {
+         if (pr_derive_from_commits(base, derived_title, sizeof(derived_title), derived_body,
+                                    sizeof(derived_body)) != 0)
+            return mcp_text("error: this branch has no commits that are not already on the base, "
+                            "so there is nothing to open a PR for (and no title to derive). Commit "
+                            "your work first, or pass 'title' explicitly.");
+         if (jtitle)
+            cJSON_ReplaceItemInObject(args, "title", cJSON_CreateString(derived_title));
+         else
+            cJSON_AddStringToObject(args, "title", derived_title);
+         jtitle = cJSON_GetObjectItemCaseSensitive(args, "title");
+
+         if (!cJSON_IsString(jbody) || !jbody->valuestring[0])
+         {
+            if (jbody)
+               cJSON_ReplaceItemInObject(args, "body", cJSON_CreateString(derived_body));
+            else
+               cJSON_AddStringToObject(args, "body", derived_body);
+            jbody = cJSON_GetObjectItemCaseSensitive(args, "body");
+         }
+      }
 
       /* Standing directive: no AI attribution in PR bodies (in-place strip is
        * shrink-only, so the cJSON-owned buffer is safe). */
       if (cJSON_IsString(jbody))
          strip_ai_attribution(jbody->valuestring);
-
-      const char *base = cJSON_IsString(jbase) ? jbase->valuestring : "main";
 
       /* Resolve the repository through mcp_git_run, the SAME runner every other git
        * command here goes through, and hand the slug to the API. The API's

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -197,6 +197,127 @@ static int get_origin_repo_slug(char *buf, size_t len)
    return 0;
 }
 
+/* --- action=ready: sync, push, open the PR ---
+ *
+ * "This work is done, put it up for review" is three calls and one piece of
+ * knowledge the caller should not need: that rebasing during the sync rewrites
+ * history, so the push after it has to be a lease-protected force. Doing them
+ * separately also means a failure halfway leaves the caller to work out which
+ * step it was. This runs them in order, stops at the first real failure with that
+ * step's own explanation (sync already says how to resolve a conflict), and
+ * reports each step's outcome on its own line.
+ *
+ * Idempotent: run it again after more commits and it re-syncs, re-pushes, and
+ * says the PR is already open rather than failing. */
+static void first_line_of(cJSON *resp, char *out, size_t out_len)
+{
+   out[0] = '\0';
+   cJSON *item = resp ? cJSON_GetArrayItem(resp, 0) : NULL;
+   cJSON *text = item ? cJSON_GetObjectItem(item, "text") : NULL;
+   if (!cJSON_IsString(text))
+      return;
+   snprintf(out, out_len, "%s", text->valuestring);
+   char *nl = strchr(out, '\n');
+   if (nl)
+      *nl = '\0';
+}
+
+static cJSON *pr_ready(cJSON *args)
+{
+   cJSON *jbase = cJSON_GetObjectItemCaseSensitive(args, "base");
+   const char *base = (cJSON_IsString(jbase) && jbase->valuestring[0]) ? jbase->valuestring : NULL;
+
+   char report[4096];
+   int pos = 0;
+
+   /* 1. Sync. A conflict here is the caller's to resolve, and sync's own message
+    * is the one that explains how — so return it unchanged rather than wrapping. */
+   cJSON *sync_args = cJSON_CreateObject();
+   if (base)
+      cJSON_AddStringToObject(sync_args, "base", base);
+   cJSON *sync_resp = handle_git_sync(sync_args);
+   int synced_moved = 0;
+   {
+      char line[1024];
+      first_line_of(sync_resp, line, sizeof(line));
+      if (mcp_git_response_failed(sync_resp))
+      {
+         cJSON_Delete(sync_args);
+         return sync_resp; /* carries the conflicted files and the way forward */
+      }
+      synced_moved = (strstr(line, "already current") == NULL);
+      pos = str_appendf(report, pos, (int)sizeof(report), "sync: %s\n", line);
+   }
+   cJSON_Delete(sync_resp);
+   cJSON_Delete(sync_args);
+
+   /* 2. Push. A sync that rebased rewrote history, so the push must be
+    * lease-protected — which is also safe when nothing moved, so it is
+    * unconditional rather than a guess about what sync did. */
+   cJSON *push_args = cJSON_CreateObject();
+   cJSON_AddBoolToObject(push_args, "force", 1);
+   cJSON *push_resp = handle_git_push(push_args);
+   {
+      char line[1024];
+      first_line_of(push_resp, line, sizeof(line));
+      if (mcp_git_response_failed(push_resp))
+      {
+         cJSON_Delete(push_args);
+         return push_resp; /* the ownership / merged-PR / verify gates speak for themselves */
+      }
+      pos = str_appendf(report, pos, (int)sizeof(report), "push: %s\n", line);
+   }
+   cJSON_Delete(push_resp);
+   cJSON_Delete(push_args);
+
+   /* 3. Open the PR. Title and body are derived from the commits unless the
+    * caller passed them, so `action=ready` alone is a complete request. */
+   cJSON *create_args = cJSON_CreateObject();
+   cJSON_AddStringToObject(create_args, "action", "create");
+   if (base)
+      cJSON_AddStringToObject(create_args, "base", base);
+   cJSON *jtitle = cJSON_GetObjectItemCaseSensitive(args, "title");
+   cJSON *jbody = cJSON_GetObjectItemCaseSensitive(args, "body");
+   if (cJSON_IsString(jtitle) && jtitle->valuestring[0])
+      cJSON_AddStringToObject(create_args, "title", jtitle->valuestring);
+   if (cJSON_IsString(jbody) && jbody->valuestring[0])
+      cJSON_AddStringToObject(create_args, "body", jbody->valuestring);
+
+   cJSON *create_resp = handle_git_pr(create_args);
+   {
+      char line[1024];
+      first_line_of(create_resp, line, sizeof(line));
+      cJSON *item = cJSON_GetArrayItem(create_resp, 0);
+      cJSON *text = item ? cJSON_GetObjectItem(item, "text") : NULL;
+      const char *full = cJSON_IsString(text) ? text->valuestring : "";
+      if (mcp_git_response_failed(create_resp) && strstr(full, "already exist"))
+         pos = str_appendf(report, pos, (int)sizeof(report),
+                           "pr:   already open for this branch — the new commits are on it now "
+                           "(command=pr action=list to see it)\n");
+      else if (mcp_git_response_failed(create_resp))
+      {
+         /* Synced and pushed, but the PR did not open: say what DID happen, so the
+          * caller does not redo the first two steps. */
+         cJSON *r = mcp_error("%s", full[0] ? full : "error: pr create failed");
+         cJSON *ritem = cJSON_GetArrayItem(r, 0);
+         char merged[4096];
+         snprintf(merged, sizeof(merged), "%s%s", report, full);
+         cJSON_ReplaceItemInObject(ritem, "text", cJSON_CreateString(merged));
+         cJSON_Delete(create_resp);
+         cJSON_Delete(create_args);
+         return r;
+      }
+      else
+         pos = str_appendf(report, pos, (int)sizeof(report), "pr:   %s\n%s\n", line,
+                           full + strlen(line));
+   }
+   cJSON_Delete(create_resp);
+   cJSON_Delete(create_args);
+   (void)synced_moved;
+
+   return mcp_text(report);
+}
+
 /* --- git_pr --- */
 
 cJSON *handle_git_pr(cJSON *args)
@@ -304,9 +425,12 @@ cJSON *handle_git_pr(cJSON *args)
        *
        * Needed because a base protected with "require branches to be up to date"
        * reports its required checks as merely "expected" while the head is BEHIND:
-       * the PR will not merge however green those checks already are, and nothing
-       * else in this tool can clear it (`pull` is a bare `git pull` on the head's
-       * OWN upstream, and there is no merge subcommand).
+       * the PR will not merge however green those checks already are.
+       *
+       * Distinct from command=sync, which is the LOCAL equivalent: sync rebases the
+       * checked-out branch onto its base and needs the checkout; this asks GitHub to
+       * merge the base into a PR head by number, so it works on a PR that is not
+       * checked out here (and on someone else's branch).
        *
        * Deliberately NOT folded into `merge`: this rewrites the contributor's
        * branch and restarts their CI, which is a separate decision from merging.
@@ -765,6 +889,9 @@ cJSON *handle_git_pr(cJSON *args)
       return mcp_text(result);
    }
 
-   return mcp_text(
-       "error: unknown action. Use create/view/list/edit/checks/watch/merge_status/merge/wait");
+   if (strcmp(action, "ready") == 0)
+      return pr_ready(args);
+
+   return mcp_text("error: unknown action. Use "
+                   "create/view/list/edit/checks/watch/merge_status/merge/wait/ready");
 }

--- a/src/modules/git/mcp_git_write.c
+++ b/src/modules/git/mcp_git_write.c
@@ -67,6 +67,45 @@ static int mcp_git_config_reader(const char *key, char *out, size_t out_len, voi
    return out[0] ? 1 : 0;
 }
 
+/* See mcp_git.h. Commit AS THE CONFIGURED OPERATOR, or not at all.
+ *
+ * git_ops points GIT_CONFIG_GLOBAL/SYSTEM at /dev/null, so git has no ambient
+ * identity to fall back on: aimee supplies one or the commit has no author.
+ * Refuse rather than invent a persona. A bot author is not free either, since
+ * GitHub adds a Co-authored-by trailer to the squash of any PR whose commits
+ * carry two distinct authors, and the standing directive forbids those.
+ *
+ * Shared because every path that CREATES a commit needs the same identity:
+ * git_commit, and the merge/rebase/cherry-pick/revert continuations. */
+int mcp_git_identity_flags(char *out, size_t out_len)
+{
+   if (!out || !out_len)
+      return -1;
+   out[0] = '\0';
+   char name[256] = "", email[256] = "";
+   int have = git_identity_resolve_with(agent_get_request_vault_principal(), mcp_git_config_reader,
+                                        NULL, name, sizeof(name), email, sizeof(email));
+   if (have <= 0)
+      return have;
+   char *esc_name = shell_escape(name);
+   char *esc_email = shell_escape(email);
+   snprintf(out, out_len, "-c user.name='%s' -c user.email='%s'", esc_name, esc_email);
+   free(esc_name);
+   free(esc_email);
+   return 1;
+}
+
+/* See mcp_git.h. */
+const char *mcp_git_identity_error(int rc)
+{
+   if (rc < 0)
+      return "error: could not read the git identity from the vault";
+   return "error: no git identity is configured, so this commit would have no author. "
+          "Set one on this checkout with `git config user.name` and `git config user.email` "
+          "(both, or neither takes effect), or seal AIMEE_GIT_AUTHOR_NAME and "
+          "AIMEE_GIT_AUTHOR_EMAIL into the vault to apply one everywhere.";
+}
+
 /* Return a standard error response for main branch protection.
  * Caller should return the result directly from the handler. */
 static cJSON *main_branch_blocked(const char *operation)
@@ -175,37 +214,15 @@ cJSON *handle_git_commit(cJSON *args)
       free(out);
    }
 
-   /* Commit AS THE CONFIGURED OPERATOR, or not at all.
-    *
-    * git_ops points GIT_CONFIG_GLOBAL/SYSTEM at /dev/null, so git has no ambient
-    * identity to fall back on here: aimee supplies one or the commit has no
-    * author. Refuse rather than invent a persona. A bot author is not free
-    * either, since GitHub adds a Co-authored-by trailer to the squash of any PR
-    * whose commits carry two distinct authors, and the standing directive
-    * forbids those. */
-   char author_name[256] = "", author_email[256] = "";
-   int have_identity = git_identity_resolve_with(
-       agent_get_request_vault_principal(), mcp_git_config_reader, NULL, author_name,
-       sizeof(author_name), author_email, sizeof(author_email));
-   if (have_identity < 0)
-      return mcp_text("error: could not read the git identity from the vault");
-   if (have_identity == 0)
-      return mcp_text("error: no git identity is configured, so this commit would have no author. "
-                      "Set one on this checkout with `git config user.name` and "
-                      "`git config user.email` (both, or neither takes effect), or seal "
-                      "AIMEE_GIT_AUTHOR_NAME and AIMEE_GIT_AUTHOR_EMAIL into the vault to apply "
-                      "one everywhere.");
+   char ident[768];
+   int have_identity = mcp_git_identity_flags(ident, sizeof(ident));
+   if (have_identity <= 0)
+      return mcp_text(mcp_git_identity_error(have_identity));
 
    char *esc_msg = shell_escape(jmsg->valuestring);
-   char *esc_name = shell_escape(author_name);
-   char *esc_email = shell_escape(author_email);
    char commit_cmd[8192];
-   snprintf(commit_cmd, sizeof(commit_cmd),
-            "git -c user.name='%s' -c user.email='%s' commit -m '%s' 2>&1", esc_name, esc_email,
-            esc_msg);
+   snprintf(commit_cmd, sizeof(commit_cmd), "git %s commit -m '%s' 2>&1", ident, esc_msg);
    free(esc_msg);
-   free(esc_name);
-   free(esc_email);
 
    int rc;
    char *out = mcp_git_run(commit_cmd, &rc);
@@ -618,6 +635,187 @@ cJSON *handle_git_reset(cJSON *args)
    snprintf(result, sizeof(result), "reset (--%s) to %s, HEAD now at %s", mode, ref, hash);
    free(out);
    return mcp_text(result);
+}
+
+/* --- git_add ---
+ *
+ * Staging as its own operation. git_commit stages what it is about to commit and
+ * nothing else (tracked files with -u, or the paths it was handed), so there was
+ * no way to stage a NEW file, or to stage now and commit later. Sensitive paths
+ * are dropped here exactly as git_commit drops them, and `all` is screened the
+ * same way — the screen runs against the resulting index, not against the
+ * caller's argument list, so `all` cannot sweep in a .env that a path list
+ * would have been refused. */
+cJSON *handle_git_add(cJSON *args)
+{
+   char branch[256] = "";
+   get_current_branch(branch, sizeof(branch));
+   if (strcmp(branch, "main") == 0 || strcmp(branch, "master") == 0)
+      return main_branch_blocked("add");
+   {
+      cJSON *blocked = branch_own_guard_for(branch, "add");
+      if (blocked)
+         return blocked;
+   }
+
+   cJSON *jfiles = cJSON_GetObjectItemCaseSensitive(args, "files");
+   cJSON *jall = cJSON_GetObjectItemCaseSensitive(args, "all");
+   int all = (jall && cJSON_IsTrue(jall)) ? 1 : 0;
+   int have_files = cJSON_IsArray(jfiles) && cJSON_GetArraySize(jfiles) > 0;
+
+   if (!all && !have_files)
+      return mcp_text("error: 'files' (array of paths) or 'all' (true, stages every change "
+                      "including new files) is required");
+
+   int skipped = 0;
+   char cmd[8192];
+   int pos;
+   if (all)
+   {
+      pos = snprintf(cmd, sizeof(cmd), "git add -A");
+   }
+   else
+   {
+      pos = snprintf(cmd, sizeof(cmd), "git add --");
+      int count = cJSON_GetArraySize(jfiles);
+      for (int i = 0; i < count; i++)
+      {
+         cJSON *f = cJSON_GetArrayItem(jfiles, i);
+         if (!cJSON_IsString(f))
+            continue;
+         if (is_sensitive_file(f->valuestring))
+         {
+            skipped++;
+            continue;
+         }
+         char *esc = shell_escape(f->valuestring);
+         pos = str_appendf(cmd, pos, (int)sizeof(cmd), " '%s'", esc);
+         free(esc);
+      }
+      if (pos <= (int)strlen("git add --"))
+         return mcp_text("error: every path given is a sensitive file (.env, credentials, keys); "
+                         "nothing was staged");
+   }
+   str_appendf(cmd, pos, (int)sizeof(cmd), " 2>&1");
+
+   int rc;
+   char *out = mcp_git_run(cmd, &rc);
+   if (rc != 0)
+   {
+      cJSON *r = mcp_error("error: git add failed: %s", out ? out : "unknown");
+      free(out);
+      return r;
+   }
+   free(out);
+
+   /* Screen the INDEX, not the argument list: `all` stages by pattern, so this is
+    * the only place that can see what it actually picked up. */
+   char unstaged[2048] = "";
+   int unstaged_n = mcp_git_unstage_sensitive(unstaged, sizeof(unstaged));
+
+   char *staged = mcp_git_run("git diff --cached --name-only 2>/dev/null", &rc);
+   int staged_n = 0;
+   if (staged)
+      for (const char *p = staged; *p; p++)
+         if (*p == '\n')
+            staged_n++;
+
+   char result[SUMMARY_MAX];
+   int rpos = snprintf(result, sizeof(result), "staged %d file(s)", staged_n);
+   if (skipped)
+      rpos =
+          str_appendf(result, rpos, (int)sizeof(result),
+                      "\nwarning: skipped %d sensitive path(s) (.env, credentials, keys)", skipped);
+   if (unstaged_n)
+      rpos = str_appendf(result, rpos, (int)sizeof(result),
+                         "\nwarning: unstaged %d sensitive "
+                         "file(s) that `all` had picked up: %s",
+                         unstaged_n, unstaged);
+   if (staged && staged[0])
+      rpos = str_appendf(result, rpos, (int)sizeof(result), "\n%s", staged);
+   (void)rpos;
+   free(staged);
+   return mcp_text(result);
+}
+
+/* See mcp_git.h. Kept next to git_add because that is what needs it: `add -A`
+ * stages by pattern, and git_commit only screens paths it was handed. */
+int mcp_git_unstage_sensitive(char *report, size_t report_len)
+{
+   if (report && report_len)
+      report[0] = '\0';
+   int rc = 0;
+   char *staged = mcp_git_run("git diff --cached --name-only 2>/dev/null", &rc);
+   if (!staged)
+      return 0;
+
+   int n = 0, rpos = 0;
+   char *line = staged;
+   while (line && *line)
+   {
+      char *nl = strchr(line, '\n');
+      if (nl)
+         *nl = '\0';
+      if (*line && is_sensitive_file(line))
+      {
+         char *esc = shell_escape(line);
+         char cmd[MAX_PATH_LEN + 64];
+         snprintf(cmd, sizeof(cmd), "git restore --staged -- '%s' 2>&1", esc);
+         free(esc);
+         int unstage_rc = 0;
+         free(mcp_git_run(cmd, &unstage_rc));
+         if (unstage_rc == 0)
+         {
+            n++;
+            if (report && report_len)
+               rpos = str_appendf(report, rpos, (int)report_len, "%s%s", n > 1 ? ", " : "", line);
+         }
+      }
+      line = nl ? nl + 1 : NULL;
+   }
+   free(staged);
+   return n;
+}
+
+/* --- git_switch / git_checkout ---
+ *
+ * Pure routing to the handler that already owns each behaviour, so the model does
+ * not have to know that "switch branches" lives under git_branch and "throw away
+ * my edits to this file" lives under git_restore. No second implementation: the
+ * worktree lock, the ownership registration and the restore semantics stay in
+ * one place each. */
+cJSON *handle_git_switch(cJSON *args)
+{
+   cJSON *jname = cJSON_GetObjectItemCaseSensitive(args, "name");
+   cJSON *jref = cJSON_GetObjectItemCaseSensitive(args, "ref");
+   if ((!cJSON_IsString(jname) || !jname->valuestring[0]) && cJSON_IsString(jref) &&
+       jref->valuestring[0])
+      cJSON_AddStringToObject(args, "name", jref->valuestring);
+   if (!cJSON_IsString(cJSON_GetObjectItemCaseSensitive(args, "name")))
+      return mcp_text("error: 'ref' (the branch to switch to) is required");
+
+   cJSON *jaction = cJSON_GetObjectItemCaseSensitive(args, "action");
+   if (jaction)
+      cJSON_ReplaceItemInObject(args, "action", cJSON_CreateString("switch"));
+   else
+      cJSON_AddStringToObject(args, "action", "switch");
+   return handle_git_branch(args);
+}
+
+cJSON *handle_git_checkout(cJSON *args)
+{
+   cJSON *jfiles = cJSON_GetObjectItemCaseSensitive(args, "files");
+   if (cJSON_IsArray(jfiles) && cJSON_GetArraySize(jfiles) > 0)
+   {
+      /* Path-scoped checkout is a restore: `source` is what git spells as the ref
+       * to take the content from. */
+      cJSON *jref = cJSON_GetObjectItemCaseSensitive(args, "ref");
+      if (cJSON_IsString(jref) && jref->valuestring[0] &&
+          !cJSON_GetObjectItemCaseSensitive(args, "source"))
+         cJSON_AddStringToObject(args, "source", jref->valuestring);
+      return handle_git_restore(args);
+   }
+   return handle_git_switch(args);
 }
 
 /* --- git_restore --- */

--- a/src/modules/git/module.yaml
+++ b/src/modules/git/module.yaml
@@ -38,6 +38,7 @@
     "src/modules/git/git_verify_state.c",
     "src/modules/git/git_verify_step.c",
     "src/modules/git/mcp_git_branch.c",
+    "src/modules/git/mcp_git_integrate.c",
     "src/modules/git/mcp_git_pr.c",
     "src/modules/git/mcp_git_query.c",
     "src/modules/git/mcp_git_write.c",

--- a/src/modules/protocols/mcp/mcp_tools.c
+++ b/src/modules/protocols/mcp/mcp_tools.c
@@ -1125,7 +1125,7 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
       } git_params[] = {
           {"action", "string",
            "Sub-action for: branch (create/switch/list/delete/claim/orphan), pr "
-           "(create/view/list/edit/checks/merge_status/update_branch/merge), stash "
+           "(create/view/list/edit/checks/merge_status/update_branch/merge/ready), stash "
            "(push/pop/apply/list/drop), tag (create/list/delete), issue (list), verify "
            "(run/check/conflicts/env/prepare-pr/status), merge / rebase / sync / cherry_pick / "
            "revert (omit to start one; continue/abort/skip to drive one that stopped on a "
@@ -1225,7 +1225,10 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
               "branch's commits when you omit them. Remaining "
               "params apply per command (see each description); branch/pr/stash/tag/issue/"
               "verify also take an 'action' sub-selector. Use command=pr action=view to "
-              "check a PR's merge state before pushing. PASS 'path' WHENEVER YOU MEAN A "
+              "check a PR's merge state before pushing. command=pr action=ready is the whole \"put "
+              "this up for review\" errand: sync, lease-protected push, and open the PR (deriving "
+              "title and body), stopping at the first real failure with that step's own "
+              "explanation. PASS 'path' WHENEVER YOU MEAN A "
               "SPECIFIC CHECKOUT: without it the repository is inferred from session state, "
               "and a worktree-isolated session can silently act on the shared checkout — "
               "committing or pushing another branch's work.",

--- a/src/modules/protocols/mcp/mcp_tools.c
+++ b/src/modules/protocols/mcp/mcp_tools.c
@@ -1107,10 +1107,11 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
       cJSON_AddStringToObject(cmd, "type", "string");
       cJSON_AddStringToObject(cmd, "description", "Git subcommand to run (required).");
       cJSON *en = cJSON_AddArrayToObject(cmd, "enum");
-      static const char *const git_cmds[] = {"status", "commit", "push",         "pull",  "fetch",
-                                             "branch", "log",    "diff_summary", "pr",    "issue",
-                                             "clone",  "stash",  "tag",          "reset", "restore",
-                                             "verify", NULL};
+      static const char *const git_cmds[] = {
+          "status",       "commit", "push",     "pull",   "fetch", "branch",      "log",
+          "diff_summary", "pr",     "issue",    "clone",  "stash", "tag",         "reset",
+          "restore",      "verify", "merge",    "rebase", "sync",  "cherry_pick", "revert",
+          "add",          "switch", "checkout", NULL};
       for (int i = 0; git_cmds[i]; i++)
          cJSON_AddItemToArray(en, cJSON_CreateString(git_cmds[i]));
 
@@ -1126,15 +1127,21 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
            "Sub-action for: branch (create/switch/list/delete/claim/orphan), pr "
            "(create/view/list/edit/checks/merge_status/update_branch/merge), stash "
            "(push/pop/apply/list/drop), tag (create/list/delete), issue (list), verify "
-           "(run/check/conflicts/env/prepare-pr/status)."},
+           "(run/check/conflicts/env/prepare-pr/status), merge / rebase / sync / cherry_pick / "
+           "revert (omit to start one; continue/abort/skip to drive one that stopped on a "
+           "conflict)."},
           {"message", "string",
            "commit: commit message; stash: message; tag: annotated-tag message."},
-          {"files", "array", "commit / diff_summary / restore: file paths."},
+          {"files", "array", "commit / diff_summary / restore / add / checkout: file paths."},
           {"name", "string", "branch / tag: name."},
-          {"base", "string", "branch: base ref; pr / verify: base branch (default main)."},
+          {"base", "string",
+           "branch: base ref; pr / verify: base branch (default main); rebase: the branch to "
+           "rebase onto; sync: the branch to become current with (default: origin's default "
+           "branch)."},
           {"ref", "string",
            "log / diff_summary: ref or range; tag: ref to tag; reset: target ref (default "
-           "HEAD~1)."},
+           "HEAD~1); merge: branch or commit to merge in; cherry_pick / revert: the commit; "
+           "switch / checkout: the branch or ref to move to."},
           {"force", "boolean", "push: --force-with-lease; branch delete: -D."},
           {"mirror", "boolean", "push: --mirror (DESTRUCTIVE — replaces all remote refs)."},
           {"rebase", "boolean", "pull: use --rebase."},
@@ -1163,12 +1170,19 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
            "(clone: destination path; verify: repo path.)"},
           {"branch", "string", "clone: branch to checkout."},
           {"depth", "integer", "clone: shallow depth."},
-          {"mode", "string", "reset: soft / mixed (default) / hard."},
+          {"mode", "string",
+           "reset: soft / mixed (default) / hard; sync: rebase (default) / merge."},
           {"staged", "boolean", "restore: unstage (restore --staged)."},
           {"source", "string", "restore: restore from this ref."},
           {"async", "boolean", "verify run: run in background (default true)."},
           {"job_id", "integer", "verify: job id for action=status."},
           {"index", "integer", "stash: stash index for apply/drop."},
+          {"abort_on_conflict", "boolean",
+           "merge / rebase / sync / cherry_pick / revert: on a conflict, undo the operation and "
+           "report the conflicted files (default true — the tree is left untouched). Set false to "
+           "stop in the conflicted state and resolve in place, then action=continue."},
+          {"all", "boolean",
+           "add: stage every change including new files (sensitive files are unstaged again)."},
           {NULL, NULL, NULL},
       };
       for (int i = 0; git_params[i].key; i++)
@@ -1199,7 +1213,16 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
               "git",
               "Git + GitHub operations (use instead of the 'git'/'gh' CLIs via Bash). Set "
               "'command' to one of: status, commit, push, pull, fetch, branch, log, "
-              "diff_summary, pr, issue, clone, stash, tag, reset, restore, verify. Remaining "
+              "diff_summary, pr, issue, clone, stash, tag, reset, restore, verify, merge, rebase, "
+              "sync, cherry_pick, revert, add, switch, checkout. State the INTENT and aimee does "
+              "the mechanics: command=sync brings this branch current with its base (resolves the "
+              "base, fetches, rebases, reports the gap it closed) in one call; merge/rebase/"
+              "cherry_pick/revert fetch a remote ref first, never open an editor, and on a "
+              "conflict "
+              "report the conflicted files and undo the operation, so you are never handed a "
+              "half-applied tree (abort_on_conflict=false to resolve in place, then "
+              "action=continue). command=pr action=create writes its own title and body from the "
+              "branch's commits when you omit them. Remaining "
               "params apply per command (see each description); branch/pr/stash/tag/issue/"
               "verify also take an 'action' sub-selector. Use command=pr action=view to "
               "check a PR's merge state before pushing. PASS 'path' WHENEVER YOU MEAN A "

--- a/src/server/s2_native_gate_hook.c
+++ b/src/server/s2_native_gate_hook.c
@@ -87,8 +87,9 @@ static int s2_decide(const char *sid, const char *tool_name, const char *tool_in
       snprintf(msg, msg_n,
                "aimee: delegates do not run git or gh directly — use aimee's git tools, which "
                "execute on aimee-server: git_status, git_log, git_diff_summary, git_branch, "
-               "git_commit, git_push, git_pr, git_verify. (Operator: require_aimee_git: false "
-               "in aimee.yaml opts out.)");
+               "git_add, git_commit, git_push, git_pr, git_verify, git_merge, git_rebase, "
+               "git_sync, git_cherry_pick, git_revert, git_switch. (Operator: "
+               "require_aimee_git: false in aimee.yaml opts out.)");
       return 2;
    }
 

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -1583,14 +1583,29 @@ static const struct
    git_tool_fn fn;
    int mutating;
 } git_tool_table[] = {
-    {"git_status", handle_git_status, 0}, {"git_commit", handle_git_commit, 1},
-    {"git_push", handle_git_push, 1},     {"git_branch", handle_git_branch, 0},
-    {"git_log", handle_git_log, 0},       {"git_diff_summary", handle_git_diff_summary, 0},
-    {"git_pr", handle_git_pr, 1},         {"git_pull", handle_git_pull, 1},
-    {"git_clone", handle_git_clone, 0},   {"git_stash", handle_git_stash, 0},
-    {"git_tag", handle_git_tag, 0},       {"git_fetch", handle_git_fetch, 0},
-    {"git_reset", handle_git_reset, 1},   {"git_restore", handle_git_restore, 1},
+    {"git_status", handle_git_status, 0},
+    {"git_commit", handle_git_commit, 1},
+    {"git_push", handle_git_push, 1},
+    {"git_branch", handle_git_branch, 0},
+    {"git_log", handle_git_log, 0},
+    {"git_diff_summary", handle_git_diff_summary, 0},
+    {"git_pr", handle_git_pr, 1},
+    {"git_pull", handle_git_pull, 1},
+    {"git_clone", handle_git_clone, 0},
+    {"git_stash", handle_git_stash, 0},
+    {"git_tag", handle_git_tag, 0},
+    {"git_fetch", handle_git_fetch, 0},
+    {"git_reset", handle_git_reset, 1},
+    {"git_restore", handle_git_restore, 1},
     {"git_issue", handle_git_issue, 0},
+    {"git_merge", handle_git_merge, 1},
+    {"git_rebase", handle_git_rebase, 1},
+    {"git_cherry_pick", handle_git_cherry_pick, 1},
+    {"git_revert", handle_git_revert, 1},
+    {"git_sync", handle_git_sync, 1},
+    {"git_add", handle_git_add, 1},
+    {"git_switch", handle_git_switch, 0},
+    {"git_checkout", handle_git_checkout, 1},
 };
 
 static cJSON *dispatch_git_tool(server_ctx_t *ctx, server_conn_t *conn, const char *tool,
@@ -1662,7 +1677,6 @@ static cJSON *dispatch_git_tool(server_ctx_t *ctx, server_conn_t *conn, const ch
          is_mutating = git_tool_table[i].mutating;
          break;
       }
-
    if (mismatch_err && is_mutating)
    {
       run_cmd_set_cwd(NULL);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2836,7 +2836,7 @@ $(TESTPREFIX)/unit-test-trace-analysis: $(OBJDIR)/tests/test_trace_analysis.o $(
 
 $(TESTPREFIX)/unit-test-cmd-branch: $(OBJDIR)/tests/test_cmd_branch.o $(OBJDIR)/cmd_branch.o \
                            $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
-                           $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
+                           $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
                            $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -2845,14 +2845,14 @@ $(TESTPREFIX)/unit-test-cmd-core: $(OBJDIR)/tests/test_cmd_core.o $(TEST_DATA_OB
                          $(OBJDIR)/cmd_util.o \
                          $(OBJDIR)/cmd_infra.o \
                          $(OBJDIR)/cmd_init.o \
-                         $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
+                         $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
                          $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-client-integrations: $(OBJDIR)/tests/test_client_integrations.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
+$(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
                         $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o $(OBJDIR)/modules/git/git_verify.o $(OBJDIR)/modules/git/git_verify_state.o $(OBJDIR)/modules/git/git_verify_config.o \
                         $(OBJDIR)/modules/git/git_verify_jobs.o $(OBJDIR)/modules/git/git_verify_hook.o $(OBJDIR)/modules/git/git_verify_ops.o \
                         $(OBJDIR)/modules/git/git_verify_select.o $(OBJDIR)/modules/git/git_verify_step.o $(OBJDIR)/server/compute_pool.o \
@@ -3867,7 +3867,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
                             $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
-                            $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
+                            $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
                             $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -3878,7 +3878,7 @@ $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
                             $(DB2_OBJS) \
                             $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
-                            $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o \
+                            $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
                             $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -256,6 +256,46 @@ cJSON *handle_git_issue(cJSON *args)
    (void)args;
    return stub_git_content("git_issue");
 }
+cJSON *handle_git_merge(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_merge");
+}
+cJSON *handle_git_rebase(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_rebase");
+}
+cJSON *handle_git_cherry_pick(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_cherry_pick");
+}
+cJSON *handle_git_revert(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_revert");
+}
+cJSON *handle_git_sync(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_sync");
+}
+cJSON *handle_git_add(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_add");
+}
+cJSON *handle_git_switch(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_switch");
+}
+cJSON *handle_git_checkout(cJSON *args)
+{
+   (void)args;
+   return stub_git_content("git_checkout");
+}
 
 static int g_tools_list_forbidden;
 

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -525,9 +525,9 @@ static void test_osv_offline_cache_miss_allows(void)
    "get_help {topic} req:\n"                                                                       \
    "get_identity {} req:\n"                                                                        \
    "git "                                                                                          \
-   "{action,async,auto,base,body,branch,command,count,depth,diff_stat,expected_head_sha,files,"    \
-   "force,index,job_id,merge_method,message,mirror,mode,name,number,path,prune,rebase,ref,remote," \
-   "source,staged,stat_only,state,title,url,wait} req:command\n"                                   \
+   "{abort_on_conflict,action,all,async,auto,base,body,branch,command,count,depth,diff_stat,"      \
+   "expected_head_sha,files,force,index,job_id,merge_method,message,mirror,mode,name,number,path," \
+   "prune,rebase,ref,remote,source,staged,stat_only,state,title,url,wait} req:command\n"           \
    "graph {command,cwd,entity,episode_key,limit,project,query,scope,workspace} req:command\n"      \
    "host {command,name} req:command\n"                                                             \
    "index "                                                                                        \
@@ -609,18 +609,32 @@ static void tool_signature(cJSON *tool, char *out, size_t outsz)
    if (cJSON_IsArray(req))
       cJSON_ArrayForEach(c, req) if (cJSON_IsString(c) && nr < 48) rq[nr++] = c->valuestring;
    qsort(rq, (size_t)nr, sizeof(rq[0]), tools_cmp_ptr);
+   /* Clamped appends: snprintf returns what it WOULD have written, so a signature
+    * wider than the buffer would otherwise walk past it (and, before the clamp,
+    * silently truncate away the `req:` half — a tool could lose a required
+    * parameter and this golden would not notice). */
    int o = snprintf(out, outsz, "%s {", cJSON_IsString(name) ? name->valuestring : "?");
+   if (o > (int)outsz - 1)
+      o = (int)outsz - 1;
+#define SIG_APPEND(...)                                                                            \
+   do                                                                                              \
+   {                                                                                               \
+      int n_ = snprintf(out + o, outsz - (size_t)o, __VA_ARGS__);                                  \
+      o = (n_ < 0 || o + n_ > (int)outsz - 1) ? (int)outsz - 1 : o + n_;                           \
+   } while (0)
    for (int i = 0; i < nk; i++)
-      o += snprintf(out + o, outsz - (size_t)o, "%s%s", i ? "," : "", keys[i]);
-   o += snprintf(out + o, outsz - (size_t)o, "} req:");
+      SIG_APPEND("%s%s", i ? "," : "", keys[i]);
+   SIG_APPEND("} req:");
    for (int i = 0; i < nr; i++)
-      o += snprintf(out + o, outsz - (size_t)o, "%s%s", i ? "," : "", rq[i]);
+      SIG_APPEND("%s%s", i ? "," : "", rq[i]);
+#undef SIG_APPEND
+   assert(o < (int)outsz - 1); /* a truncated signature is not a check */
 }
 static void test_tools_list_surface(void)
 {
    cJSON *tools = mcp_build_tools_list();
    assert(cJSON_IsArray(tools));
-   static char sigs[256][256];
+   static char sigs[256][512];
    int ns = 0;
    cJSON *tool = NULL;
    cJSON_ArrayForEach(tool, tools)
@@ -636,7 +650,7 @@ static void test_tools_list_surface(void)
       ns++;
    }
    qsort(sigs, (size_t)ns, sizeof(sigs[0]), tools_cmp_row);
-   static char joined[256 * 256];
+   static char joined[256 * 512];
    int o = 0;
    for (int i = 0; i < ns; i++)
       o += snprintf(joined + o, sizeof(joined) - (size_t)o, "%s\n", sigs[i]);

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -2694,6 +2694,78 @@ static void test_pr_create_with_no_commits_says_so(void)
    teardown_git_repo();
 }
 
+/* --- pr action=ready --- */
+
+/* ready stops at the FIRST real failure and returns that step's own explanation,
+ * so the caller is never told "ready failed" with no idea which part. Here the
+ * sync conflicts, so the conflicted file must come back — and nothing must have
+ * been pushed. */
+static void test_pr_ready_stops_at_the_failing_step(void)
+{
+   setup_conflicting_branches();
+   setup_ownership_db();
+   session_id_set_override("session-A");
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "ready");
+   cJSON_AddStringToObject(args, "base", "side");
+   cJSON *resp = handle_git_pr(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   /* sync's own conflict report, verbatim — not a generic ready failure. */
+   assert(strstr(text, "file.txt") != NULL);
+   assert(strstr(text, "push:") == NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   session_id_clear_override();
+   teardown_ownership_db();
+   teardown_git_repo();
+}
+
+/* When the sync succeeds, the push is attempted next and its failure is what
+ * comes back (no origin in the fixture) — proving the steps run in order and the
+ * report is not fabricated. */
+static void test_pr_ready_runs_sync_then_push(void)
+{
+   setup_git_repo();
+   setup_ownership_db();
+   session_id_set_override("session-A");
+   assert(system("git checkout -q -b feat/ready && echo x > x.txt && git add x.txt && "
+                 "git commit -q -m 'feat: work'") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "ready");
+   cJSON_AddStringToObject(args, "base", "master");
+   cJSON *resp = handle_git_pr(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   /* The push is the step that fails here, and its own message says so. */
+   assert(strstr(text, "push") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   session_id_clear_override();
+   teardown_ownership_db();
+   teardown_git_repo();
+}
+
+static void test_pr_unknown_action_lists_ready(void)
+{
+   setup_git_repo();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "nonsense");
+   cJSON *resp = handle_git_pr(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "ready") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
 static void test_feature_branch_commit_allowed(void)
 {
    setup_git_repo();
@@ -3279,6 +3351,9 @@ int main(void)
    test_pr_create_derives_title_from_single_commit();
    test_pr_create_derives_title_from_many_commits();
    test_pr_create_with_no_commits_says_so();
+   test_pr_ready_stops_at_the_failing_step();
+   test_pr_ready_runs_sync_then_push();
+   test_pr_unknown_action_lists_ready();
 
    printf("all tests passed\n");
    return 0;

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -2188,6 +2188,512 @@ static void test_main_branch_delete_blocked(void)
    teardown_git_repo();
 }
 
+/* --- The integration operations: merge / rebase / cherry-pick / revert / sync --- */
+
+/* Two branches with a commit each, both touching file.txt, so a merge of one into
+ * the other conflicts. Leaves HEAD on `integration`. */
+static void setup_conflicting_branches(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b side && echo side > file.txt && "
+                 "git commit -q -am 'side change'") == 0);
+   assert(system("git checkout -q -b integration HEAD~1 && echo mine > file.txt && "
+                 "git commit -q -am 'my change'") == 0);
+}
+
+/* A clean merge reports what moved, not git's prose. */
+static void test_merge_clean_reports_the_change(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b side && echo side > side.txt && "
+                 "git add side.txt && git commit -q -m 'side commit'") == 0);
+   assert(system("git checkout -q -b integration HEAD~1") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "side");
+   cJSON *resp = handle_git_merge(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") == NULL);
+   assert(strstr(text, "merge side into integration") != NULL);
+   assert(strstr(text, "commit(s)") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(system("test -f side.txt") == 0);
+
+   teardown_git_repo();
+}
+
+/* The default on conflict: name the conflicted files AND undo the merge, so the
+ * caller is never left holding a tree it has to know how to clean up. */
+static void test_merge_conflict_aborts_and_names_files(void)
+{
+   setup_conflicting_branches();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "side");
+   cJSON *resp = handle_git_merge(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "conflict") != NULL);
+   assert(strstr(text, "file.txt") != NULL);
+   assert(strstr(text, "aborted") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   /* The tree really is clean: no MERGE_HEAD, no conflict markers. */
+   assert(system("git rev-parse --verify --quiet MERGE_HEAD >/dev/null 2>&1") != 0);
+   assert(system("git diff --name-only --diff-filter=U | grep -q .") != 0);
+   assert(system("grep -q '<<<<<<<' file.txt") != 0);
+
+   teardown_git_repo();
+}
+
+/* abort_on_conflict=false is the opt-in to resolving in place — and then
+ * action=continue finishes it. */
+static void test_merge_keep_conflicts_then_continue(void)
+{
+   setup_conflicting_branches();
+   setup_ownership_db();
+   session_id_set_override("session-A");
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "side");
+   cJSON_AddBoolToObject(args, "abort_on_conflict", 0);
+   cJSON *resp = handle_git_merge(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "conflict") != NULL);
+   assert(strstr(text, "left in progress") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(system("git rev-parse --verify --quiet MERGE_HEAD >/dev/null 2>&1") == 0);
+
+   /* Continuing before resolving must refuse rather than commit the markers. */
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "continue");
+   resp = handle_git_merge(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "still have conflict markers") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   assert(system("echo resolved > file.txt && git add file.txt") == 0);
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "continue");
+   resp = handle_git_merge(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "merge completed") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(system("git rev-parse --verify --quiet MERGE_HEAD >/dev/null 2>&1") != 0);
+
+   session_id_clear_override();
+   teardown_ownership_db();
+   teardown_git_repo();
+}
+
+/* action=abort backs the whole thing out. */
+static void test_merge_action_abort(void)
+{
+   setup_conflicting_branches();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "side");
+   cJSON_AddBoolToObject(args, "abort_on_conflict", 0);
+   cJSON *resp = handle_git_merge(args);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "abort");
+   resp = handle_git_merge(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "merge aborted") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(system("git rev-parse --verify --quiet MERGE_HEAD >/dev/null 2>&1") != 0);
+
+   teardown_git_repo();
+}
+
+/* A half-finished operation is reported as such, with the way out, instead of
+ * letting a second one start on top of it. */
+static void test_second_operation_refused_while_one_is_in_progress(void)
+{
+   setup_conflicting_branches();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "side");
+   cJSON_AddBoolToObject(args, "abort_on_conflict", 0);
+   cJSON *resp = handle_git_merge(args);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "base", "side");
+   resp = handle_git_rebase(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "merge is already in progress") != NULL);
+   assert(strstr(text, "action=continue") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+/* An uncommitted tree cannot be cleanly restored after a conflict, so the
+ * operation is refused before it starts rather than half-done. */
+static void test_integrate_refuses_dirty_tree(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b work && echo dirty >> file.txt") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "master");
+   cJSON *resp = handle_git_merge(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "uncommitted changes") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+static void test_integrate_blocked_on_main(void)
+{
+   setup_git_repo();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "HEAD");
+   cJSON *resp = handle_git_merge(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") != NULL);
+   assert(strstr(text, "main branch") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+static void test_integrate_requires_a_ref(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b work") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *resp = handle_git_cherry_pick(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") != NULL);
+   assert(strstr(text, "cherry-pick") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+/* cherry-pick and revert run through the same driver, so one round-trip each is
+ * enough to show the wiring is right. */
+static void test_cherry_pick_and_revert(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b side && echo side > side.txt && "
+                 "git add side.txt && git commit -q -m 'side commit'") == 0);
+   char sha[64] = "";
+   FILE *fp = popen("git rev-parse --short HEAD", "r");
+   assert(fp != NULL);
+   assert(fgets(sha, sizeof(sha), fp) != NULL);
+   pclose(fp);
+   sha[strcspn(sha, "\r\n")] = '\0';
+   assert(system("git checkout -q -b picker HEAD~1") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", sha);
+   cJSON *resp = handle_git_cherry_pick(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") == NULL);
+   assert(system("test -f side.txt") == 0);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "HEAD");
+   resp = handle_git_revert(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") == NULL);
+   assert(system("test -f side.txt") != 0); /* the revert took it back out */
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+/* sync answers "am I current?" without a follow-up call. */
+static void test_sync_reports_already_current(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b work") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "base", "master");
+   cJSON *resp = handle_git_sync(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   /* No origin in this fixture, so the base resolves to the local ref and the
+    * answer is the gap: zero behind. */
+   assert(strstr(text, "already current") != NULL || strstr(text, "sync work") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+static void test_sync_rejects_unknown_mode(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b work") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "mode", "squash");
+   cJSON *resp = handle_git_sync(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "mode must be rebase") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+/* --- git_add --- */
+
+/* `all` stages new files (which git_commit cannot reach) but not secrets, and the
+ * screen runs against the index so a pattern-based add cannot slip one past. */
+static void test_add_all_stages_new_files_but_not_secrets(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b staging-test") == 0);
+
+   FILE *fp = fopen(".env", "w");
+   assert(fp != NULL);
+   fputs("SECRET=xyz\n", fp);
+   fclose(fp);
+   fp = fopen("normal.txt", "w");
+   assert(fp != NULL);
+   fputs("normal\n", fp);
+   fclose(fp);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddBoolToObject(args, "all", 1);
+   cJSON *resp = handle_git_add(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "staged") != NULL);
+   assert(strstr(text, ".env") != NULL); /* named in the unstaged warning */
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   assert(system("git diff --cached --name-only | grep -qx normal.txt") == 0);
+   assert(system("git diff --cached --name-only | grep -qx .env") != 0);
+
+   teardown_git_repo();
+}
+
+static void test_add_refuses_only_sensitive_paths(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b staging-test") == 0);
+   FILE *fp = fopen(".env", "w");
+   assert(fp != NULL);
+   fputs("SECRET=xyz\n", fp);
+   fclose(fp);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *files = cJSON_AddArrayToObject(args, "files");
+   cJSON_AddItemToArray(files, cJSON_CreateString(".env"));
+   cJSON *resp = handle_git_add(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "sensitive") != NULL);
+   assert(strstr(text, "nothing was staged") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+static void test_add_requires_files_or_all(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b staging-test") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *resp = handle_git_add(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") != NULL);
+   assert(strstr(text, "'all'") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+/* --- switch / checkout routing --- */
+
+static void test_switch_routes_to_branch_switch(void)
+{
+   setup_git_repo();
+   setup_ownership_db();
+   assert(system("git branch -q target") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "target");
+   cJSON *resp = handle_git_switch(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "switched to target") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_ownership_db();
+   teardown_git_repo();
+}
+
+/* A path-scoped checkout is a restore, and routes there rather than moving HEAD. */
+static void test_checkout_with_files_restores(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b work && echo changed > file.txt") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *files = cJSON_AddArrayToObject(args, "files");
+   cJSON_AddItemToArray(files, cJSON_CreateString("file.txt"));
+   cJSON *resp = handle_git_checkout(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "restored") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(system("grep -q 'hello world' file.txt") == 0);
+
+   teardown_git_repo();
+}
+
+static void test_switch_requires_a_ref(void)
+{
+   setup_git_repo();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *resp = handle_git_switch(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "error") != NULL);
+   assert(strstr(text, "'ref'") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+/* --- PR title/body derivation --- */
+
+/* One commit: the PR is that commit. No model call, no invented prose. */
+static void test_pr_create_derives_title_from_single_commit(void)
+{
+   setup_git_repo();
+   setup_ownership_db();
+   session_id_set_override("session-A");
+   assert(system("git checkout -q -b feat/derive && echo x > x.txt && git add x.txt && "
+                 "git commit -q -m 'feat(thing): make it work' -m 'Because it did not.'") == 0);
+
+   /* No origin remote in the fixture, so create cannot reach the forge — but it
+    * must get PAST the title requirement, which is what this covers. The old
+    * behaviour was a hard 'title is required'. */
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "create");
+   cJSON_AddStringToObject(args, "base", "master");
+   cJSON *resp = handle_git_pr(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "'title' parameter is required") == NULL);
+   cJSON *jtitle = cJSON_GetObjectItemCaseSensitive(args, "title");
+   assert(cJSON_IsString(jtitle));
+   assert(strcmp(jtitle->valuestring, "feat(thing): make it work") == 0);
+   cJSON *jbody = cJSON_GetObjectItemCaseSensitive(args, "body");
+   assert(cJSON_IsString(jbody));
+   assert(strstr(jbody->valuestring, "Because it did not.") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   session_id_clear_override();
+   teardown_ownership_db();
+   teardown_git_repo();
+}
+
+/* Several commits: the shared conventional-commit prefix is kept and the body
+ * lists them, so the PR reads like the commits it contains. */
+static void test_pr_create_derives_title_from_many_commits(void)
+{
+   setup_git_repo();
+   setup_ownership_db();
+   session_id_set_override("session-A");
+   assert(system("git checkout -q -b feat/many && echo a > a.txt && git add a.txt && "
+                 "git commit -q -m 'feat: first bit' && echo b > b.txt && git add b.txt && "
+                 "git commit -q -m 'feat: second bit'") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "create");
+   cJSON_AddStringToObject(args, "base", "master");
+   cJSON *resp = handle_git_pr(args);
+   cJSON *jtitle = cJSON_GetObjectItemCaseSensitive(args, "title");
+   assert(cJSON_IsString(jtitle));
+   assert(strstr(jtitle->valuestring, "feat: many") != NULL);
+   assert(strstr(jtitle->valuestring, "2 commits") != NULL);
+   cJSON *jbody = cJSON_GetObjectItemCaseSensitive(args, "body");
+   assert(cJSON_IsString(jbody));
+   assert(strstr(jbody->valuestring, "- feat: first bit") != NULL);
+   assert(strstr(jbody->valuestring, "- feat: second bit") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   session_id_clear_override();
+   teardown_ownership_db();
+   teardown_git_repo();
+}
+
+/* Nothing to open a PR for is its own answer, not a derived-title crash. */
+static void test_pr_create_with_no_commits_says_so(void)
+{
+   setup_git_repo();
+   setup_ownership_db();
+   session_id_set_override("session-A");
+   assert(system("git checkout -q -b feat/empty") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "create");
+   cJSON_AddStringToObject(args, "base", "master");
+   cJSON *resp = handle_git_pr(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "no commits") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   session_id_clear_override();
+   teardown_ownership_db();
+   teardown_git_repo();
+}
+
 static void test_feature_branch_commit_allowed(void)
 {
    setup_git_repo();
@@ -2747,6 +3253,32 @@ int main(void)
    test_main_branch_reset_blocked();
    test_main_branch_delete_blocked();
    test_feature_branch_commit_allowed();
+
+   /* Integration operations */
+   test_merge_clean_reports_the_change();
+   test_merge_conflict_aborts_and_names_files();
+   test_merge_keep_conflicts_then_continue();
+   test_merge_action_abort();
+   test_second_operation_refused_while_one_is_in_progress();
+   test_integrate_refuses_dirty_tree();
+   test_integrate_blocked_on_main();
+   test_integrate_requires_a_ref();
+   test_cherry_pick_and_revert();
+   test_sync_reports_already_current();
+   test_sync_rejects_unknown_mode();
+
+   /* Staging and ref movement */
+   test_add_all_stages_new_files_but_not_secrets();
+   test_add_refuses_only_sensitive_paths();
+   test_add_requires_files_or_all();
+   test_switch_routes_to_branch_switch();
+   test_checkout_with_files_restores();
+   test_switch_requires_a_ref();
+
+   /* PR title/body derivation */
+   test_pr_create_derives_title_from_single_commit();
+   test_pr_create_derives_title_from_many_commits();
+   test_pr_create_with_no_commits_says_so();
 
    printf("all tests passed\n");
    return 0;

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -7,7 +7,7 @@
       "files": [
         {
           "path": "docs/gen/cli-commands.md",
-          "sha256": "07047b4d488662f336fa762250b93d45a47427ce832d483c9f3cf4ae166b8968"
+          "sha256": "dc50b347d6d4da379036a7541a81075371c61cadfb1fe0a809f74f9a1130ca75"
         },
         {
           "path": "src/gateway/gateway_main.c",


### PR DESCRIPTION
## The problem

The git tool modeled 16 subcommands. Delegates cannot shell out to git at all (`require_aimee_git` in `s2_native_gate_hook.c`), so merge, rebase, cherry-pick, revert, staging a new file, and moving between refs had **no route from any agent surface** — PRs waiting on an integration were stuck. On top of that the thin `aimee` CLI routed only `git verify` over `/v1`, so every other `aimee git ...` answered *"is not a subcommand of 'git'"*.

## The approach

These are **modeled operations, not a passthrough**. An `argv` passthrough would hand the work back to the model: it composes the flags, then reasons about whatever half-merged tree comes out. Here the caller states intent and aimee does the mechanics, so the effort and the tokens stay on this side.

### `mcp_git_integrate.c` — merge, rebase, sync, cherry_pick, revert

One driver; they differ only by a row in `OPS`, because they are one operation with five names (each can stop on a conflict, each needs continuing or abandoning, each commits). What it absorbs:

- **fetches a remote-looking ref first**, so `merge origin/main` cannot merge a stale copy;
- **disables the editor** (`core.editor`/`sequence.editor`) — a blocked editor is indistinguishable from a hang;
- **refuses a dirty tree up front**, because a conflict in one cannot be cleanly undone;
- on conflict, reports **the conflicted files** and by default **aborts**, so the caller is never handed a half-applied tree. `abort_on_conflict=false` opts into resolving in place, then `action=continue` (which refuses while markers remain) / `abort` / `skip`;
- a continuation **commits with the vaulted operator identity**, via `mcp_git_identity_flags` extracted from `git_commit` — otherwise a resolved merge would have no author;
- an operation already in progress is **named, with the way out**, instead of letting a second start on top;
- the result says **what changed** (`pre..post`, commit count, diffstat), not git's prose.

`command=sync` is the whole "get current with my base" errand in one call: resolve the base (given, else origin's default branch), fetch, rebase (default; `mode=merge`), report the gap closed.

### Staging and ref movement

`command=add` (`files`, or `all`) stages what `git_commit` cannot reach — it stages tracked changes or the paths it was handed, so a new file had no route. For `all` the sensitive-file screen runs against the resulting **index** rather than the caller's argument list, so a pattern-based add cannot slip a `.env` past commit's own screen. `switch`/`checkout` are routing to `branch action=switch` and `restore` — no second implementation.

### PRs write themselves

`pr action=create` no longer requires `title`: it derives title and body from the commits the branch has that base does not. One commit lends its subject and message body verbatim; several keep the conventional-commit prefix they agree on and get a bulleted list plus the diffstat. Deterministic, no model call.

`pr action=ready` is sync + lease-protected push + open the PR, stopping at the first real failure with that step's own explanation, and idempotent on re-run.

### CLI

One wildcard `/v1` route plus one uniform marshaller: `aimee git <command> [primary] [key=value ...]`, the form `aimee git verify action=...` already taught. The only per-command knowledge is what a bare first (and sometimes second) word means. `continue`/`abort`/`skip` read as actions; `-A`/`-f`/`--merge`/`--keep-conflicts` alias to their parameters.

## Defects found along the way

- **`sync` qualified a bare base to `origin/<base>` unconditionally**, failing on a ref that was never going to resolve (no origin, or a local-only base). Now qualifies only when origin has it.
- **`sync` prefixed its own context to the integrate result**, burying the leading `error`/`conflict` word that callers read failure from — a conflicted sync looked like success to `pr_ready`. The convention now has one definition (`mcp_git_response_failed`), and `sync` appends on failure rather than prepending.
- **The tools-list golden harness truncated signatures at 256 chars**, so the widened git schema silently lost its `req:` half — a tool could have dropped a required parameter without the golden noticing. Clamped and widened.

## Verification

`make all` clean, `make aimee-home-check` (clang-format) ok, module ownership/inventory/docs/header checks pass.

23 new tests in `unit-test-mcp-git`, driving real repositories: clean merge; conflict-aborts-and-names-files (asserting the tree really is clean afterwards — no `MERGE_HEAD`, no markers); keep-conflicts → refuse-then-continue; `action=abort`; second-operation-refused; dirty-tree refusal; main-branch block; missing-ref; cherry-pick+revert round trip; sync current / bad mode; `add` all-vs-secrets, only-sensitive, missing-args; switch/checkout routing; the three PR-derivation cases; and three for `ready`. Plus `unit-test-mcp-client-registry`, `unit-test-cli-mcp-serve`, `unit-test-cli-v1-subcommands`, `unit-test-cmd-core`, `unit-test-cmd-branch`.

CLI routing verified live against a server-visible checkout: `aimee git log count=2 path=...` reaches the server, dispatches `git_log` with the typed integer, and prints real commits.

## Note for review

`cmd_git` in `src/cmd_infra.c` parses the same commands for the in-process (non-thin) path. The two agree today but are separate parsers; folding them together is untaken work, called out in `docs/modules/git.md`.

## Deploy

This is C in `aimee-server` — the running server needs a rebuild/restart before delegates see any of it.
