### PR TITLE
git: declare the stages the C-to-Go port lands against

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,14 +222,17 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "695c04003cc7741a9c17466cde96f10a371d3cdddcbef7f9b9a7e8c32e57d816",
+      "source_sha256": "f5a4f720001d7202d737c43753eff87ede0b1003433b01453e7966a62e8c80af",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,
       "serve": [
         7425,
         7426,
-        7427
+        7427,
+        7428,
+        7429,
+        7430
       ]
     },
     {

--- a/server-go/modules/git/git.go
+++ b/server-go/modules/git/git.go
@@ -17,6 +17,19 @@ const (
 	StageOperation   uint32 = 1
 	StageRefValidate uint32 = 2
 	StageCIGrade     uint32 = 3
+
+	// Stages 4-6 are the destination for the I/O that still lives in C: the
+	// forge HTTP client, credential resolution, and the verify pipeline. They
+	// are declared with the rest of the wire contract so the port lands one
+	// caller at a time against a fixed stage table rather than renumbering as
+	// it goes. No handler serves them yet.
+	EventForgeRequest uint32 = 7428
+	EventCredResolve  uint32 = 7429
+	EventVerifyRun    uint32 = 7430
+	StageForgeRequest uint32 = 4
+	StageCredResolve  uint32 = 5
+	StageVerifyRun    uint32 = 6
+
 	requestMagic     uint32 = 0x53504f47
 	responseMagic    uint32 = 0x534c4347
 	refRequestMagic  uint32 = 0x46455247

--- a/server-go/modules/git/git_test.go
+++ b/server-go/modules/git/git_test.go
@@ -93,3 +93,33 @@ func TestGitRejectsInvalidAndExpiredWire(t *testing.T) {
 		t.Fatalf("embedded-NUL wire status = %d", status)
 	}
 }
+
+// The stage table is the contract in src/modules/process-contracts.json, whose
+// event kinds are derived rather than chosen: 4096 + principal_ref*256 + stage.
+// Stages 4-6 are declared ahead of the C-to-Go port so callers land one at a
+// time against fixed numbering; until a handler serves them they must be
+// refused, not silently accepted.
+func TestGitStageTableMatchesContract(t *testing.T) {
+	const principalRef = 13
+	stages := map[uint32]uint32{
+		StageOperation:    EventKind,
+		StageRefValidate:  EventRefValidate,
+		StageCIGrade:      EventCIGrade,
+		StageForgeRequest: EventForgeRequest,
+		StageCredResolve:  EventCredResolve,
+		StageVerifyRun:    EventVerifyRun,
+	}
+	if len(stages) != 6 {
+		t.Fatalf("stage table has %d entries, want 6 dense stages", len(stages))
+	}
+	for stage, event := range stages {
+		if want := 4096 + principalRef*256 + stage; event != want {
+			t.Fatalf("stage %d event kind = %d, want %d", stage, event, want)
+		}
+	}
+	for _, stage := range []uint32{StageForgeRequest, StageCredResolve, StageVerifyRun} {
+		if _, status := Handle(bus.ModuleInvocation{StageID: stage}, nil); status != bus.ModuleStatusInvalidRequest {
+			t.Fatalf("unserved stage %d status = %d, want refused", stage, status)
+		}
+	}
+}

--- a/src/modules/git/include/aimee/git/module_api.h
+++ b/src/modules/git/include/aimee/git/module_api.h
@@ -15,6 +15,17 @@
  * stages use: a forge's check-runs payload is arbitrarily large and its shape is
  * the forge's, not ours. */
 #define AIMEE_GIT_STAGE_CI_GRADE     3u
+/* Stages 4-6 are the destination for the I/O that still lives in C: the forge
+ * HTTP client, credential resolution, and the verify pipeline. They are declared
+ * with the rest of the wire contract so the port lands one caller at a time
+ * against a fixed stage table rather than renumbering as it goes. Each carries
+ * JSON, for the same reason CI grading does: the payload shape is the forge's. */
+#define AIMEE_GIT_EVENT_FORGE_REQUEST 7428u
+#define AIMEE_GIT_EVENT_CRED_RESOLVE  7429u
+#define AIMEE_GIT_EVENT_VERIFY_RUN    7430u
+#define AIMEE_GIT_STAGE_FORGE_REQUEST 4u
+#define AIMEE_GIT_STAGE_CRED_RESOLVE  5u
+#define AIMEE_GIT_STAGE_VERIFY_RUN    6u
 #define AIMEE_GIT_REQUEST_MAGIC      0x53504f47u /* "GOPS" */
 #define AIMEE_GIT_RESPONSE_MAGIC     0x534c4347u /* "GCLS" */
 #define AIMEE_GIT_REF_REQUEST_MAGIC  0x46455247u /* "GREF" */

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -189,6 +189,21 @@
           "id": 3,
           "name": "git-ci-grade",
           "event_kind": 7427
+        },
+        {
+          "id": 4,
+          "name": "git-forge-request",
+          "event_kind": 7428
+        },
+        {
+          "id": 5,
+          "name": "git-credential-resolve",
+          "event_kind": 7429
+        },
+        {
+          "id": 6,
+          "name": "git-verify-run",
+          "event_kind": 7430
         }
       ]
     },

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1479,7 +1479,7 @@
         },
         {
           "path": "src/modules/git/include/aimee/git/module_api.h",
-          "sha256": "e049765d6007235c1b0fedf2e34624af0c143eaa75f500e219039f508b35d36b"
+          "sha256": "4d6a0ae542328f07c15e47e3d17759a04a55066f0fc186014bbf2af82c7cfb78"
         },
         {
           "path": "src/modules/governance/include/aimee/governance/module_api.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "771926eab733db56faff215a30b51ae53f5e0d5a8e8de240032bf9fc1c206146",
+      "sha256": "9f510d3e8395aff8b585894ac853e9ea35f108b8673b74488eb36c90294d637a",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1479,7 +1479,7 @@
         },
         {
           "path": "src/modules/git/include/aimee/git/module_api.h",
-          "sha256": "e049765d6007235c1b0fedf2e34624af0c143eaa75f500e219039f508b35d36b"
+          "sha256": "4d6a0ae542328f07c15e47e3d17759a04a55066f0fc186014bbf2af82c7cfb78"
         },
         {
           "path": "src/modules/governance/include/aimee/governance/module_api.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "949f05bcc8f2aaff5b713adb801111c78936e640ba18d3141b3c3276ddaa9183",
+      "sha256": "d805110ab0cf024ac12d6d5982f8ce6fd7443baaadfee839e47f75a2ba979cb8",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
First PR of the git C→Go migration.

## Why

The git module's descriptor has said `runtime: go` since the core carving, but what is actually in Go is 275 lines that do no I/O — an operation classifier and a CI grader that grades JSON someone else fetched. The forge HTTP client, credential resolution, and the verify pipeline are ~15k lines of C.

Stage numbering is derived, not chosen: `event_kind = 4096 + principal_ref*256 + stage`. A stage table that grows as the port proceeds renumbers every caller written before it. Declaring the destination stages up front fixes the numbering for the whole migration.

## What

Three new stages on the git component (principal_ref 13):

| stage | name | event kind |
|---|---|---|
| 4 | `git-forge-request` | 7428 |
| 5 | `git-credential-resolve` | 7429 |
| 6 | `git-verify-run` | 7430 |

Declared in `process-contracts.json`, mirrored into the wire-contract header and the Go constants, with the derivation asserted by a test.

No handler serves 4–6 yet, and `main.go` still registers only 1–3. That is the shape roundtable already has — review is declared but only registered by a process that can convene one — and `Handle`'s fail-closed default refuses an unserved stage rather than accepting it. The new test pins that refusal.

Also refreshes git's bus grant (`serve`) and owned-source digest in the repository lock, both of which derive from the stage table.

## Verification

- `validate_module_process_contracts` — ok (26 components, 17 processes)
- `check_go_module_runtime_bundle` — ok
- `check_c_repository_lock` — ok (1 core, 26 modules)
- `check_git_core_contract --require-status roundtable-approved` — ok (unaffected; it governs the proposal doc, not the stage table)
- `go test ./bus ./modules/... ./cmd/aimee-module` — pass
- `sh src/tests/test_module_supervisor.sh` — ok
- `make lint` — 48/48
- `make all` — clean

## Not in this PR

The C-side PR-mergeability gate and CI-failure log visibility are shelved on `shelf/c-side-pr-features` (c9aed53643, 519 lines). They ship inside the migrated path rather than being ported twice.