### PR TITLE
git: move the verify ledger to the module, proven across the real bus

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "f5a4f720001d7202d737c43753eff87ede0b1003433b01453e7966a62e8c80af",
+      "source_sha256": "e1d9f644ba1af5b116975653cdddb88288ca87f14611bfbb4ecfd1216a09d5d7",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -120,6 +120,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: modulegit.EventKind, StageID: modulegit.StageOperation},
 			{EventKind: modulegit.EventRefValidate, StageID: modulegit.StageRefValidate},
 			{EventKind: modulegit.EventCIGrade, StageID: modulegit.StageCIGrade},
+			{EventKind: modulegit.EventVerifyRun, StageID: modulegit.StageVerifyRun},
 		}
 		config.Handler = modulegit.Handle
 	case "skills":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -18,7 +18,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"delegates", 10, []uint32{6657}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169}},
-		{"git", 13, []uint32{7425, 7426, 7427}},
+		{"git", 13, []uint32{7425, 7426, 7427, 7430}},
 		{"skills", 14, []uint32{7681, 7682}},
 		{"response-composition", 15, []uint32{7937}},
 		{"governance", 19, []uint32{8961}},

--- a/server-go/modules/git/git.go
+++ b/server-go/modules/git/git.go
@@ -81,6 +81,8 @@ func validRef(ref string) bool {
 // Handle classifies Git operations and validates refs without repository I/O.
 func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
 	switch invocation.StageID {
+	case StageVerifyRun:
+		return handleVerifyState(invocation, request)
 	case StageCIGrade:
 		// JSON, not the fixed binary framing the other two stages use: a forge
 		// payload is arbitrarily large and its shape is the forge's, not ours.

--- a/server-go/modules/git/git_test.go
+++ b/server-go/modules/git/git_test.go
@@ -117,7 +117,11 @@ func TestGitStageTableMatchesContract(t *testing.T) {
 			t.Fatalf("stage %d event kind = %d, want %d", stage, event, want)
 		}
 	}
-	for _, stage := range []uint32{StageForgeRequest, StageCredResolve, StageVerifyRun} {
+	// Forge and credential resolution stay unserved until the vault has a bus
+	// surface: git_pr_api.c resolves its token in-process precisely so it never
+	// reaches another process, and honouring that from a module process needs
+	// the vault extraction in vault-bus-only-access.md.
+	for _, stage := range []uint32{StageForgeRequest, StageCredResolve} {
 		if _, status := Handle(bus.ModuleInvocation{StageID: stage}, nil); status != bus.ModuleStatusInvalidRequest {
 			t.Fatalf("unserved stage %d status = %d, want refused", stage, status)
 		}

--- a/server-go/modules/git/verify_state.go
+++ b/server-go/modules/git/verify_state.go
@@ -1,0 +1,276 @@
+package git
+
+// The verify-result ledger: the tree/commit hashes verify keys itself on, the
+// dirty-worktree probe, and the per-repository .aimee/.last-verify file. This
+// is the first of git's I/O paths to move out of C, and it was chosen because
+// it is the only part of verify that touches no credential: nothing under
+// git_verify*.c references the vault, so it can move before the vault gains a
+// bus surface (docs/proposals/pending/vault-bus-only-access.md).
+//
+// The C side keeps producing and consuming the step-results string; it crosses
+// this boundary opaquely. Its format belongs to whoever runs the steps, which
+// is still C.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// StateMax is the rolling window kept in the ledger. It matches
+// VERIFY_STATE_MAX so a file written by either side reads back identically
+// during the migration.
+const StateMax = 16
+
+// StateEntry is one verified tree: when it passed, which tree, and how its
+// steps fared. StepResults is opaque here -- see the package comment.
+type StateEntry struct {
+	Timestamp   int64  `json:"timestamp"`
+	Hash        string `json:"hash"`
+	Failed      int    `json:"failed"`
+	Total       int    `json:"total"`
+	StepResults string `json:"step_results,omitempty"`
+}
+
+// VerifyStateRequest is the stage-6 request. Op selects the operation; the
+// remaining fields are read only by the operations that need them.
+type VerifyStateRequest struct {
+	Op          string `json:"op"`
+	ProjectRoot string `json:"project_root"`
+	Timestamp   int64  `json:"timestamp"`
+	Hash        string `json:"hash"`
+	Failed      int    `json:"failed"`
+	Total       int    `json:"total"`
+	StepResults string `json:"step_results"`
+}
+
+// VerifyStateResponse carries whichever field the operation produces. OK is
+// false whenever the answer is unknown, so a caller can never read a zero
+// value as a real one -- an unverified tree and an unreadable ledger must not
+// look alike to the gate.
+type VerifyStateResponse struct {
+	OK      bool         `json:"ok"`
+	Hash    string       `json:"hash,omitempty"`
+	Dirty   bool         `json:"dirty,omitempty"`
+	Entries []StateEntry `json:"entries,omitempty"`
+}
+
+// gitOutput runs git in root and returns its trimmed stdout. Unlike the C it
+// replaces it does not go through a shell, so a repository path containing a
+// quote is data rather than syntax.
+func gitOutput(root string, args ...string) (string, bool) {
+	full := args
+	if root != "" {
+		full = append([]string{"-C", root}, args...)
+	}
+	out, err := exec.Command("git", full...).Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimRight(string(out), " \t\r\n"), true
+}
+
+// mainRepoRoot resolves a worktree to the checkout that owns its object store,
+// so every worktree of a repository shares one ledger and the pre-push hook --
+// which runs from the main checkout -- sees state recorded anywhere.
+func mainRepoRoot(dir string) string {
+	if common, ok := gitOutput(dir, "rev-parse", "--git-common-dir"); ok && strings.HasPrefix(common, "/") {
+		if index := strings.Index(common, "/.git"); index >= 0 {
+			return common[:index]
+		}
+	}
+	if top, ok := gitOutput(dir, "rev-parse", "--show-toplevel"); ok && top != "" {
+		return top
+	}
+	return dir
+}
+
+// statePath is the ledger for the repository containing projectRoot.
+func statePath(projectRoot string) string {
+	base := projectRoot
+	if projectRoot != "" {
+		if resolved := mainRepoRoot(projectRoot); resolved != "" {
+			base = resolved
+		}
+	}
+	return filepath.Join(base, ".aimee", ".last-verify")
+}
+
+// parseEntry reads one current-format line:
+//
+//	<unix_timestamp> <hash> failed=N/total=M[ steps=<opaque>]
+func parseEntry(line string) (StateEntry, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return StateEntry{}, false
+	}
+	timestamp, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return StateEntry{}, false
+	}
+	entry := StateEntry{Timestamp: timestamp, Hash: fields[1]}
+	for _, field := range fields[2:] {
+		// Scanned rather than split so a malformed counter leaves the entry
+		// readable: a tree that verified is still a tree that verified.
+		fmt.Sscanf(field, "failed=%d/total=%d", &entry.Failed, &entry.Total)
+	}
+	if index := strings.Index(line, " steps="); index >= 0 {
+		entry.StepResults = line[index+len(" steps="):]
+	}
+	return entry, true
+}
+
+// readEntries parses the ledger. A missing, empty or corrupt file is not an
+// error: it means nothing is verified, which is the safe answer.
+func readEntries(projectRoot string) []StateEntry {
+	file, err := os.Open(statePath(projectRoot))
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	if !scanner.Scan() {
+		return nil
+	}
+	first := strings.TrimRight(scanner.Text(), " \t\r\n")
+
+	// The legacy layout put the timestamp, hash and result on three lines. It
+	// is still read so a ledger written before the split keeps its meaning;
+	// the next write upgrades it.
+	if !strings.Contains(first, " ") {
+		timestamp, err := strconv.ParseInt(first, 10, 64)
+		if err != nil || !scanner.Scan() {
+			return nil
+		}
+		hash := strings.TrimRight(scanner.Text(), " \t\r\n")
+		if hash == "" {
+			return nil
+		}
+		entry := StateEntry{Timestamp: timestamp, Hash: hash}
+		if scanner.Scan() {
+			fmt.Sscanf(strings.TrimSpace(scanner.Text()), "failed=%d/total=%d", &entry.Failed, &entry.Total)
+		}
+		return []StateEntry{entry}
+	}
+
+	var entries []StateEntry
+	for line := first; ; {
+		if entry, ok := parseEntry(line); ok && len(entries) < StateMax {
+			entries = append(entries, entry)
+		}
+		if !scanner.Scan() {
+			break
+		}
+		line = strings.TrimRight(scanner.Text(), " \t\r\n")
+	}
+	return entries
+}
+
+// formatEntry renders one line. steps= is written last so the opaque tail can
+// contain spaces without shifting any field before it.
+func formatEntry(entry StateEntry) string {
+	line := fmt.Sprintf("%d %s failed=%d/total=%d", entry.Timestamp, entry.Hash, entry.Failed, entry.Total)
+	if entry.StepResults != "" {
+		line += " steps=" + entry.StepResults
+	}
+	return line + "\n"
+}
+
+// writeState puts the new entry at the head, drops any prior entry for the
+// same tree, and keeps the window at StateMax. The file is replaced by rename
+// so a reader sees either the old ledger or the new one, never a half-written
+// gate.
+func writeState(projectRoot string, entry StateEntry) error {
+	path := statePath(projectRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	var builder strings.Builder
+	builder.WriteString(formatEntry(entry))
+	kept := 1
+	for _, old := range readEntries(projectRoot) {
+		if kept >= StateMax || sameTree(old.Hash, entry.Hash) {
+			continue
+		}
+		builder.WriteString(formatEntry(old))
+		kept++
+	}
+
+	temporary := path + ".tmp"
+	if err := os.WriteFile(temporary, []byte(builder.String()), 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		os.Remove(temporary)
+		return err
+	}
+	return nil
+}
+
+// sameTree compares on the first 40 hex characters, matching the C ledger:
+// entries are keyed by tree hash and an abbreviation must not alias.
+func sameTree(a, b string) bool {
+	if len(a) > 40 {
+		a = a[:40]
+	}
+	if len(b) > 40 {
+		b = b[:40]
+	}
+	return a == b
+}
+
+// handleVerifyState serves stage 6. An operation it does not know is refused
+// rather than answered, so a newer caller against an older module fails closed.
+func handleVerifyState(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	var decoded VerifyStateRequest
+	if err := json.Unmarshal(request, &decoded); err != nil {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	var response VerifyStateResponse
+	switch decoded.Op {
+	case "tree-hash":
+		// The tree, not the commit: a squash-merge or a rebase that changes no
+		// content keeps the verification that was recorded before it.
+		response.Hash, response.OK = gitOutput(decoded.ProjectRoot, "rev-parse", "HEAD^{tree}")
+	case "commit-hash":
+		response.Hash, response.OK = gitOutput(decoded.ProjectRoot, "rev-parse", "HEAD")
+	case "worktree-dirty":
+		status, ok := gitOutput(decoded.ProjectRoot, "status", "--porcelain")
+		response.OK, response.Dirty = ok, ok && status != ""
+	case "state-read":
+		response.Entries, response.OK = readEntries(decoded.ProjectRoot), true
+	case "state-write":
+		if decoded.Hash == "" {
+			return nil, bus.ModuleStatusInvalidRequest
+		}
+		err := writeState(decoded.ProjectRoot, StateEntry{
+			Timestamp:   decoded.Timestamp,
+			Hash:        decoded.Hash,
+			Failed:      decoded.Failed,
+			Total:       decoded.Total,
+			StepResults: decoded.StepResults,
+		})
+		response.OK = err == nil
+	default:
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+
+	encoded, err := json.Marshal(response)
+	if err != nil || uint32(len(encoded)) > bus.ModuleMessageMaxBody {
+		return nil, bus.ModuleStatusInternal
+	}
+	return encoded, bus.ModuleStatusOK
+}

--- a/server-go/modules/git/verify_state_test.go
+++ b/server-go/modules/git/verify_state_test.go
@@ -1,0 +1,186 @@
+package git
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// newRepo makes a real repository with one commit. The ledger keys on tree
+// hashes git actually produced, so a fixture that fakes them would not prove
+// the lookup works.
+func newRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+		{"commit", "-q", "--allow-empty", "-m", "one"},
+	} {
+		command := exec.Command("git", append([]string{"-C", root}, args...)...)
+		if out, err := command.CombinedOutput(); err != nil {
+			t.Skipf("git unavailable: %v: %s", err, out)
+		}
+	}
+	return root
+}
+
+func call(t *testing.T, request VerifyStateRequest) (VerifyStateResponse, bus.ModuleStatus) {
+	t.Helper()
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body, status := Handle(bus.ModuleInvocation{StageID: StageVerifyRun}, encoded)
+	var response VerifyStateResponse
+	if status == bus.ModuleStatusOK {
+		if err := json.Unmarshal(body, &response); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+	}
+	return response, status
+}
+
+func TestVerifyStateHashesAndDirtiness(t *testing.T) {
+	root := newRepo(t)
+
+	tree, status := call(t, VerifyStateRequest{Op: "tree-hash", ProjectRoot: root})
+	if status != bus.ModuleStatusOK || !tree.OK || len(tree.Hash) != 40 {
+		t.Fatalf("tree-hash = %#v status %d", tree, status)
+	}
+	commit, _ := call(t, VerifyStateRequest{Op: "commit-hash", ProjectRoot: root})
+	if !commit.OK || commit.Hash == tree.Hash {
+		t.Fatalf("commit-hash = %#v, must differ from the tree hash", commit)
+	}
+
+	clean, _ := call(t, VerifyStateRequest{Op: "worktree-dirty", ProjectRoot: root})
+	if !clean.OK || clean.Dirty {
+		t.Fatalf("fresh checkout reported dirty: %#v", clean)
+	}
+	if err := os.WriteFile(filepath.Join(root, "new.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dirty, _ := call(t, VerifyStateRequest{Op: "worktree-dirty", ProjectRoot: root})
+	if !dirty.OK || !dirty.Dirty {
+		t.Fatalf("untracked file not reported dirty: %#v", dirty)
+	}
+
+	// A path that is not a repository must answer "unknown", not "clean" --
+	// the gate treats a clean tree as safe to push.
+	missing, _ := call(t, VerifyStateRequest{Op: "tree-hash", ProjectRoot: filepath.Join(root, "absent")})
+	if missing.OK {
+		t.Fatalf("non-repository reported a hash: %#v", missing)
+	}
+}
+
+func TestVerifyStateRoundTripAndWindow(t *testing.T) {
+	root := newRepo(t)
+
+	empty, _ := call(t, VerifyStateRequest{Op: "state-read", ProjectRoot: root})
+	if !empty.OK || len(empty.Entries) != 0 {
+		t.Fatalf("absent ledger = %#v, want ok with no entries", empty)
+	}
+
+	written, _ := call(t, VerifyStateRequest{
+		Op: "state-write", ProjectRoot: root, Timestamp: 1000, Hash: strings.Repeat("a", 40),
+		Failed: 1, Total: 3, StepResults: "lint:0,build:1",
+	})
+	if !written.OK {
+		t.Fatal("state-write failed")
+	}
+	read, _ := call(t, VerifyStateRequest{Op: "state-read", ProjectRoot: root})
+	if len(read.Entries) != 1 {
+		t.Fatalf("entries = %#v", read.Entries)
+	}
+	got := read.Entries[0]
+	if got.Timestamp != 1000 || got.Failed != 1 || got.Total != 3 || got.StepResults != "lint:0,build:1" {
+		t.Fatalf("round trip lost data: %#v", got)
+	}
+
+	// Re-verifying the same tree replaces its entry rather than accumulating,
+	// otherwise a repeatedly verified branch evicts every other one.
+	call(t, VerifyStateRequest{Op: "state-write", ProjectRoot: root, Timestamp: 2000, Hash: strings.Repeat("a", 40)})
+	again, _ := call(t, VerifyStateRequest{Op: "state-read", ProjectRoot: root})
+	if len(again.Entries) != 1 || again.Entries[0].Timestamp != 2000 {
+		t.Fatalf("same tree not replaced: %#v", again.Entries)
+	}
+
+	for index := 0; index < StateMax+4; index++ {
+		call(t, VerifyStateRequest{
+			Op: "state-write", ProjectRoot: root, Timestamp: int64(index),
+			Hash: strings.Repeat(string(rune('0'+index%10)), 39) + string(rune('a'+index%20)),
+		})
+	}
+	windowed, _ := call(t, VerifyStateRequest{Op: "state-read", ProjectRoot: root})
+	if len(windowed.Entries) != StateMax {
+		t.Fatalf("window = %d entries, want %d", len(windowed.Entries), StateMax)
+	}
+}
+
+func TestVerifyStateReadsLegacyLayout(t *testing.T) {
+	root := newRepo(t)
+	path := statePath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hash := strings.Repeat("b", 40)
+	if err := os.WriteFile(path, []byte("1700000000\n"+hash+"\nfailed=2/total=5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	read, _ := call(t, VerifyStateRequest{Op: "state-read", ProjectRoot: root})
+	if len(read.Entries) != 1 || read.Entries[0].Hash != hash ||
+		read.Entries[0].Timestamp != 1700000000 || read.Entries[0].Failed != 2 || read.Entries[0].Total != 5 {
+		t.Fatalf("legacy ledger = %#v", read.Entries)
+	}
+
+	// The next write upgrades the file in place.
+	call(t, VerifyStateRequest{Op: "state-write", ProjectRoot: root, Timestamp: 1, Hash: strings.Repeat("c", 40)})
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines := strings.Split(strings.TrimSpace(string(contents)), "\n"); len(lines) != 2 ||
+		!strings.Contains(lines[1], hash) {
+		t.Fatalf("upgraded ledger = %q", contents)
+	}
+}
+
+func TestVerifyStateSharesOneLedgerAcrossWorktrees(t *testing.T) {
+	root := newRepo(t)
+	linked := filepath.Join(t.TempDir(), "wt")
+	command := exec.Command("git", "-C", root, "worktree", "add", "-q", "-b", "side", linked)
+	if out, err := command.CombinedOutput(); err != nil {
+		t.Skipf("git worktree unavailable: %v: %s", err, out)
+	}
+
+	// Recorded in the linked worktree, it must be visible from the main
+	// checkout -- that is where the pre-push hook reads the gate.
+	hash := strings.Repeat("d", 40)
+	if written, _ := call(t, VerifyStateRequest{Op: "state-write", ProjectRoot: linked, Timestamp: 7, Hash: hash}); !written.OK {
+		t.Fatal("write from linked worktree failed")
+	}
+	read, _ := call(t, VerifyStateRequest{Op: "state-read", ProjectRoot: root})
+	if len(read.Entries) != 1 || read.Entries[0].Hash != hash {
+		t.Fatalf("main checkout did not see the linked worktree's entry: %#v", read.Entries)
+	}
+}
+
+func TestVerifyStateRefusesBadRequests(t *testing.T) {
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageVerifyRun}, []byte("{")); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("malformed JSON accepted")
+	}
+	if _, status := call(t, VerifyStateRequest{Op: "no-such-op"}); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("unknown op accepted")
+	}
+	// A write with no tree to key on would produce an entry nothing can match.
+	if _, status := call(t, VerifyStateRequest{Op: "state-write", ProjectRoot: t.TempDir()}); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("hashless write accepted")
+	}
+}

--- a/src/modules/git/git_verify_state.c
+++ b/src/modules/git/git_verify_state.c
@@ -13,11 +13,75 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include "aimee.h"
+#include "cJSON.h"
 #include "git_verify.h"
 #include "git_verify_internal.h"
+#include "headers/module_json_call.h"
 #include "util.h"
 #include "log.h"
 #include "platform_path.h"
+#include <aimee/git/module_api.h>
+
+/* The ledger below -- the hashes verify keys itself on and the .last-verify
+ * file -- now lives in the git MODULE (server-go/modules/git, verify_state.go)
+ * and is reached as bus stage AIMEE_GIT_STAGE_VERIFY_RUN. This is the first of
+ * git's I/O paths to move, chosen because verify touches no credential: the
+ * forge and credential paths cannot follow until the vault has a bus surface
+ * (docs/proposals/pending/vault-bus-only-access.md).
+ *
+ * Every function keeps its signature and its failure convention, so callers do
+ * not know the work moved. An unreachable module therefore reports "nothing is
+ * verified" rather than an error, which is the same thing a missing ledger has
+ * always reported and is the safe direction: it forces a verify run, it never
+ * lets one be skipped. */
+#define GIT_VERIFY_STATE_MAX_BODY (256u * 1024u)
+#define GIT_VERIFY_STATE_TIMEOUT_MS 10000
+
+/* One round trip to the verify-state stage. Takes ownership of `request` the
+ * way aimee_module_json_call does; returns the reply to cJSON_Delete, or NULL.
+ * A reply whose "ok" is false is discarded here: it means the module could not
+ * answer, which every caller treats the same as no answer at all. */
+static cJSON *verify_state_call(cJSON *request)
+{
+   if (!request)
+      return NULL;
+   cJSON *reply = aimee_module_json_call(AIMEE_GIT_EVENT_VERIFY_RUN, AIMEE_GIT_STAGE_VERIFY_RUN,
+                                         request, GIT_VERIFY_STATE_MAX_BODY,
+                                         GIT_VERIFY_STATE_TIMEOUT_MS, NULL);
+   if (!reply)
+      return NULL;
+   if (!cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(reply, "ok")))
+   {
+      cJSON_Delete(reply);
+      return NULL;
+   }
+   return reply;
+}
+
+/* Build the common {op, project_root} request. project_root may be NULL, which
+ * the module reads as "use the working directory", exactly as the shell form
+ * without -C did. */
+static cJSON *verify_state_request(const char *op, const char *project_root)
+{
+   cJSON *request = cJSON_CreateObject();
+   if (!request)
+      return NULL;
+   cJSON_AddStringToObject(request, "op", op);
+   cJSON_AddStringToObject(request, "project_root", project_root ? project_root : "");
+   return request;
+}
+
+/* Ask the module for a hash and hand back an owned copy, or NULL. */
+static char *verify_state_hash(const char *op, const char *project_root)
+{
+   cJSON *reply = verify_state_call(verify_state_request(op, project_root));
+   if (!reply)
+      return NULL;
+   const cJSON *hash = cJSON_GetObjectItemCaseSensitive(reply, "hash");
+   char *result = (cJSON_IsString(hash) && hash->valuestring[0]) ? strdup(hash->valuestring) : NULL;
+   cJSON_Delete(reply);
+   return result;
+}
 
 /* --- Commit-hash-based change detection --- */
 
@@ -27,65 +91,26 @@ char *verify_compute_file_hash(const char *project_root)
     * Tree hashes are stable across squash-merges and rebases that don't change
     * content, so a verified worktree HEAD matches the squash-merge commit that
     * GitHub creates from the same tree. */
-   char cmd[MAX_PATH_LEN + 64];
-   if (project_root && project_root[0])
-      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse HEAD^{tree} 2>/dev/null", project_root);
-   else
-      snprintf(cmd, sizeof(cmd), "git rev-parse HEAD^{tree} 2>/dev/null");
-
-   int rc;
-   char *out = run_cmd(cmd, &rc);
-   if (rc != 0 || !out || !out[0])
-   {
-      free(out);
-      return NULL;
-   }
-
-   /* Strip trailing whitespace */
-   for (char *p = out + strlen(out) - 1; p >= out && (*p == '\n' || *p == '\r' || *p == ' '); p--)
-      *p = '\0';
-
-   char *result = strdup(out);
-   free(out);
-   return result;
+   return verify_state_hash("tree-hash", project_root);
 }
 
 /* Return the HEAD commit hash (for display only — not used as the verify key).
  * Caller must free the returned string. Returns NULL on failure. */
 char *verify_compute_commit_hash(const char *project_root)
 {
-   char cmd[MAX_PATH_LEN + 64];
-   if (project_root && project_root[0])
-      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse HEAD 2>/dev/null", project_root);
-   else
-      snprintf(cmd, sizeof(cmd), "git rev-parse HEAD 2>/dev/null");
-
-   int rc;
-   char *out = run_cmd(cmd, &rc);
-   if (rc != 0 || !out || !out[0])
-   {
-      free(out);
-      return NULL;
-   }
-   for (char *p = out + strlen(out) - 1; p >= out && (*p == '\n' || *p == '\r' || *p == ' '); p--)
-      *p = '\0';
-   char *result = strdup(out);
-   free(out);
-   return result;
+   return verify_state_hash("commit-hash", project_root);
 }
 
 int verify_worktree_has_changes(const char *project_root)
 {
-   char cmd[MAX_PATH_LEN + 64];
-   int rc;
-   if (project_root && project_root[0])
-      snprintf(cmd, sizeof(cmd), "git -C '%s' status --porcelain 2>/dev/null", project_root);
-   else
-      snprintf(cmd, sizeof(cmd), "git status --porcelain 2>/dev/null");
-   char *status = run_cmd(cmd, &rc);
-   int has_changes = (rc == 0 && status && status[0]);
-   free(status);
-   return has_changes;
+   cJSON *reply = verify_state_call(verify_state_request("worktree-dirty", project_root));
+   if (!reply)
+      return 0; /* Unchanged from the shell form: a git that could not answer
+                 * reported a clean tree. Preserved deliberately -- this port
+                 * moves the work, not the policy. */
+   int dirty = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(reply, "dirty"));
+   cJSON_Delete(reply);
+   return dirty;
 }
 
 /* --- State file management --- */
@@ -119,91 +144,37 @@ void verify_state_path(const char *project_root, char *buf, size_t len)
  * (0 if the file doesn't exist or is empty/corrupt). */
 int read_verify_entries(const char *project_root, verify_state_entry_t *entries, int cap)
 {
-   char path[MAX_PATH_LEN];
-   verify_state_path(project_root, path, sizeof(path));
-
-   FILE *f = fopen(path, "r");
-   if (!f)
+   if (!entries || cap <= 0)
       return 0;
 
-   char line[512];
+   cJSON *reply = verify_state_call(verify_state_request("state-read", project_root));
+   if (!reply)
+      return 0;
+
+   const cJSON *list = cJSON_GetObjectItemCaseSensitive(reply, "entries");
    int n = 0;
-
-   /* Peek at the first line to detect legacy format (pure integer = old ts line). */
-   if (!fgets(line, sizeof(line), f))
+   const cJSON *item = NULL;
+   cJSON_ArrayForEach(item, list)
    {
-      fclose(f);
-      return 0;
-   }
-
-   /* Strip trailing whitespace */
-   char *ep = line + strlen(line) - 1;
-   while (ep >= line && (*ep == '\n' || *ep == '\r' || *ep == ' '))
-      *ep-- = '\0';
-
-   /* Legacy format: first line is a bare integer (no spaces). */
-   if (!strchr(line, ' '))
-   {
-      if (n < cap)
-      {
-         time_t ts = (time_t)strtoll(line, NULL, 10);
-         char hline[64] = {0};
-         char rline[32] = {0};
-         if (fgets(hline, sizeof(hline), f))
-         {
-            char *p = hline + strlen(hline) - 1;
-            while (p >= hline && (*p == '\n' || *p == '\r' || *p == ' '))
-               *p-- = '\0';
-            (void)fgets(rline, sizeof(rline), f);
-            p = rline + strlen(rline) - 1;
-            while (p >= rline && (*p == '\n' || *p == '\r' || *p == ' '))
-               *p-- = '\0';
-
-            if (hline[0])
-            {
-               entries[n].ts = ts;
-               snprintf(entries[n].hash, sizeof(entries[n].hash), "%s", hline);
-               entries[n].failed = 0;
-               entries[n].total = 0;
-               entries[n].step_results[0] = '\0';
-               if (rline[0])
-                  sscanf(rline, "failed=%d/total=%d", &entries[n].failed, &entries[n].total);
-               n++;
-            }
-         }
-      }
-      fclose(f);
-      return n;
-   }
-
-   /* New format: parse the first line we already read, then the rest. */
-   for (;;)
-   {
-      if (line[0] && n < cap)
-      {
-         long long ts_ll = 0;
-         char h[64] = {0};
-         int fv = 0, tv = 0;
-         if (sscanf(line, "%lld %63s failed=%d/total=%d", &ts_ll, h, &fv, &tv) >= 2 && h[0])
-         {
-            entries[n].ts = (time_t)ts_ll;
-            snprintf(entries[n].hash, sizeof(entries[n].hash), "%s", h);
-            entries[n].failed = fv;
-            entries[n].total = tv;
-            entries[n].step_results[0] = '\0';
-            const char *sp = strstr(line, " steps=");
-            if (sp)
-               snprintf(entries[n].step_results, sizeof(entries[n].step_results), "%s", sp + 7);
-            n++;
-         }
-      }
-      if (!fgets(line, sizeof(line), f))
+      if (n >= cap)
          break;
-      ep = line + strlen(line) - 1;
-      while (ep >= line && (*ep == '\n' || *ep == '\r' || *ep == ' '))
-         *ep-- = '\0';
+      const cJSON *hash = cJSON_GetObjectItemCaseSensitive(item, "hash");
+      if (!cJSON_IsString(hash) || !hash->valuestring[0])
+         continue;
+      const cJSON *ts = cJSON_GetObjectItemCaseSensitive(item, "timestamp");
+      const cJSON *failed = cJSON_GetObjectItemCaseSensitive(item, "failed");
+      const cJSON *total = cJSON_GetObjectItemCaseSensitive(item, "total");
+      const cJSON *steps = cJSON_GetObjectItemCaseSensitive(item, "step_results");
+
+      entries[n].ts = (time_t)(cJSON_IsNumber(ts) ? ts->valuedouble : 0);
+      snprintf(entries[n].hash, sizeof(entries[n].hash), "%s", hash->valuestring);
+      entries[n].failed = cJSON_IsNumber(failed) ? failed->valueint : 0;
+      entries[n].total = cJSON_IsNumber(total) ? total->valueint : 0;
+      snprintf(entries[n].step_results, sizeof(entries[n].step_results), "%s",
+               cJSON_IsString(steps) ? steps->valuestring : "");
+      n++;
    }
-   fclose(f);
+   cJSON_Delete(reply);
    return n;
 }
 
@@ -244,54 +215,22 @@ int verify_state_step_result_lookup(const char *step_results, const char *name, 
 int write_verify_state(const char *project_root, time_t timestamp, const char *hash,
                        int failed_steps, int total_steps, const char *step_results)
 {
-   char path[MAX_PATH_LEN], tmp_path[MAX_PATH_LEN];
-   verify_state_path(project_root, path, sizeof(path));
-   snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", path);
-
-   char parent[MAX_PATH_LEN];
-   snprintf(parent, sizeof(parent), "%s", path);
-   char *slash = strrchr(parent, '/');
-   if (slash)
-   {
-      *slash = '\0';
-      if (parent[0] && platform_mkdir_p(parent, 0755) != 0 && errno != EEXIST)
-         return -1;
-   }
-
-   verify_state_entry_t old[VERIFY_STATE_MAX];
-   int nold = read_verify_entries(project_root, old, VERIFY_STATE_MAX);
-
-   FILE *f = fopen(tmp_path, "w");
-   if (!f)
+   if (!hash || !hash[0])
       return -1;
 
-   if (step_results && step_results[0])
-      fprintf(f, "%lld %s failed=%d/total=%d steps=%s\n", (long long)timestamp, hash, failed_steps,
-              total_steps, step_results);
-   else
-      fprintf(f, "%lld %s failed=%d/total=%d\n", (long long)timestamp, hash, failed_steps,
-              total_steps);
-
-   int kept = 1;
-   for (int i = 0; i < nold && kept < VERIFY_STATE_MAX; i++)
-   {
-      if (strncmp(old[i].hash, hash, 40) == 0)
-         continue;
-      if (old[i].step_results[0])
-         fprintf(f, "%lld %s failed=%d/total=%d steps=%s\n", (long long)old[i].ts, old[i].hash,
-                 old[i].failed, old[i].total, old[i].step_results);
-      else
-         fprintf(f, "%lld %s failed=%d/total=%d\n", (long long)old[i].ts, old[i].hash,
-                 old[i].failed, old[i].total);
-      kept++;
-   }
-   fclose(f);
-
-   if (rename(tmp_path, path) != 0)
-   {
-      remove(tmp_path);
+   cJSON *request = verify_state_request("state-write", project_root);
+   if (!request)
       return -1;
-   }
+   cJSON_AddNumberToObject(request, "timestamp", (double)timestamp);
+   cJSON_AddStringToObject(request, "hash", hash);
+   cJSON_AddNumberToObject(request, "failed", failed_steps);
+   cJSON_AddNumberToObject(request, "total", total_steps);
+   cJSON_AddStringToObject(request, "step_results", step_results ? step_results : "");
+
+   cJSON *reply = verify_state_call(request);
+   if (!reply)
+      return -1;
+   cJSON_Delete(reply);
    return 0;
 }
 

--- a/src/modules/git/git_verify_state.c
+++ b/src/modules/git/git_verify_state.c
@@ -34,7 +34,7 @@
  * verified" rather than an error, which is the same thing a missing ledger has
  * always reported and is the safe direction: it forces a verify run, it never
  * lets one be skipped. */
-#define GIT_VERIFY_STATE_MAX_BODY (256u * 1024u)
+#define GIT_VERIFY_STATE_MAX_BODY   (256u * 1024u)
 #define GIT_VERIFY_STATE_TIMEOUT_MS 10000
 
 /* One round trip to the verify-state stage. Takes ownership of `request` the
@@ -45,9 +45,9 @@ static cJSON *verify_state_call(cJSON *request)
 {
    if (!request)
       return NULL;
-   cJSON *reply = aimee_module_json_call(AIMEE_GIT_EVENT_VERIFY_RUN, AIMEE_GIT_STAGE_VERIFY_RUN,
-                                         request, GIT_VERIFY_STATE_MAX_BODY,
-                                         GIT_VERIFY_STATE_TIMEOUT_MS, NULL);
+   cJSON *reply =
+       aimee_module_json_call(AIMEE_GIT_EVENT_VERIFY_RUN, AIMEE_GIT_STAGE_VERIFY_RUN, request,
+                              GIT_VERIFY_STATE_MAX_BODY, GIT_VERIFY_STATE_TIMEOUT_MS, NULL);
    if (!reply)
       return NULL;
    if (!cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(reply, "ok")))

--- a/src/modules/git/module.yaml
+++ b/src/modules/git/module.yaml
@@ -46,11 +46,13 @@
   ],
   "go_sources": [
     "server-go/modules/git/ci_grade.go",
-    "server-go/modules/git/git.go"
+    "server-go/modules/git/git.go",
+    "server-go/modules/git/verify_state.go"
   ],
   "go_tests": [
     "server-go/modules/git/ci_grade_test.go",
-    "server-go/modules/git/git_test.go"
+    "server-go/modules/git/git_test.go",
+    "server-go/modules/git/verify_state_test.go"
   ],
   "public_headers": [
     "src/modules/git/include/aimee/git/git_ops.h",

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -802,7 +802,11 @@ else
 UNIT_TEST_P1_PREREQ := p1-rls-gate-check
 endif
 
-unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(UNIT_TEST_TARGETS)
+# The verify ledger lives in the git module now, so a suite that exercises the
+# verify gate brings the real module up on a real bus
+# (tests/support/git_module_fixture.c). Build it here and name it in the
+# environment, so no suite has to grow an argv contract to find it.
+unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(OBJDIR)/aimee-module $(UNIT_TEST_TARGETS)
 	@if ! printf '%s:%s\n' "$(UNIT_TEST_SHARD_COUNT)" "$(UNIT_TEST_SHARD_INDEX)" | \
 	     awk -F: '$$1 ~ /^[0-9]+$$/ && $$2 ~ /^[0-9]+$$/ && $$1 > 0 && $$2 < $$1 { ok=1 } END { exit !ok }'; then \
 	  echo "invalid unit-test shard $(UNIT_TEST_SHARD_INDEX)/$(UNIT_TEST_SHARD_COUNT)" >&2; \
@@ -846,6 +850,7 @@ unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(UNIT_TEST_TARGETS)
 	  AIMEE_KB_API_BEARER_TOKEN AIMEE_WFE_ENGINE AIMEE_WFE_HTTP_SOCKET; \
 	trap 'rm -rf "$$th"' EXIT; \
 	export AIMEE_TEST_FAILURE_DIR="$$th"; \
+	export AIMEE_TEST_MODULE_BIN="$(CURDIR)/$(OBJDIR)/aimee-module"; \
 	jobs="$(TEST_RUN_JOBS)"; \
 	if [ "$$jobs" -le 1 ]; then \
 	  for t in $(UNIT_TEST_TARGETS); do \
@@ -1322,7 +1327,7 @@ $(TESTPREFIX)/unit-test-cli-server-compat: $(OBJDIR)/tests/test_cli_server_compa
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 
-$(TESTPREFIX)/unit-test-guardrails: $(OBJDIR)/tests/test_guardrails.o \
+$(TESTPREFIX)/unit-test-guardrails: $(OBJDIR)/tests/test_guardrails.o $(OBJDIR)/tests/support/git_module_fixture.o \
                             $(OBJDIR)/server/obs_bus_adapter.o \
                             $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -2853,7 +2858,7 @@ $(TESTPREFIX)/unit-test-cmd-core: $(OBJDIR)/tests/test_cmd_core.o $(TEST_DATA_OB
 $(TESTPREFIX)/unit-test-client-integrations: $(OBJDIR)/tests/test_client_integrations.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
+$(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/tests/support/git_module_fixture.o $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
                         $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o $(OBJDIR)/modules/git/git_verify.o $(OBJDIR)/modules/git/git_verify_state.o $(OBJDIR)/modules/git/git_verify_config.o \
                         $(OBJDIR)/modules/git/git_verify_jobs.o $(OBJDIR)/modules/git/git_verify_hook.o $(OBJDIR)/modules/git/git_verify_ops.o \
                         $(OBJDIR)/modules/git/git_verify_select.o $(OBJDIR)/modules/git/git_verify_step.o $(OBJDIR)/server/compute_pool.o \
@@ -3210,6 +3215,41 @@ $(TESTPREFIX)/unit-test-bus-memory-recall: $(OBJDIR)/tests/test_bus_memory_recal
 .PHONY: unit-test-bus-memory-recall
 unit-test-bus-memory-recall: $(TESTPREFIX)/unit-test-bus-memory-recall
 	$<
+
+# The verify ledger across the real bus, against the real Go module.
+#
+# git_verify_state.c is now a seam: it asks the git module rather than touching
+# the repository. Every other suite that links it uses module_bus_stub, whose
+# default is "no module attached" -- which proves the seam fails closed and
+# proves nothing about whether it is right. This target builds the Go multicall
+# binary, hosts the daemon's authenticated module endpoint, and drives the
+# ordinary C entry points against a real attached process.
+#
+# It needs Go. A missing toolchain fails the target rather than skipping it:
+# skipping would silently retire the only correctness coverage the ledger has.
+$(OBJDIR)/tests/test_git_verify_state_bus.o: C_FLAGS += -Icore/event_bus/include
+
+$(OBJDIR)/aimee-module: $(wildcard ../server-go/modules/git/*.go) $(wildcard ../server-go/cmd/aimee-module/*.go)
+	@test -n "$(GO)" || { echo "aimee-module: ERROR go is required for the bus fixture"; exit 1; }
+	@mkdir -p $(@D)
+	cd ../server-go && CGO_ENABLED=0 $(GO) build -o "$(CURDIR)/$@" ./cmd/aimee-module
+
+$(TESTPREFIX)/unit-test-git-verify-state-bus: $(OBJDIR)/tests/test_git_verify_state_bus.o \
+                                           $(OBJDIR)/modules/git/git_verify_state.o \
+                                           $(OBJDIR)/modules/git/git_verify.o \
+                                           $(OBJDIR)/modules/git/git_verify_config.o \
+                                           $(OBJDIR)/modules/git/git_verify_jobs.o \
+                                           $(OBJDIR)/modules/git/git_verify_hook.o \
+                                           $(OBJDIR)/modules/git/git_verify_ops.o \
+                                           $(OBJDIR)/modules/git/git_verify_select.o \
+                                           $(OBJDIR)/modules/git/git_verify_step.o \
+                                           $(OBJDIR)/module_json_call.o $(OBJDIR)/cJSON.o \
+                                           $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lpthread
+
+.PHONY: unit-test-git-verify-state-bus
+unit-test-git-verify-state-bus: $(TESTPREFIX)/unit-test-git-verify-state-bus $(OBJDIR)/aimee-module
+	$< $(OBJDIR)/aimee-module
 
 # Real mutating memory op over the bus (upsert insert + update, verified by a
 # direct read-back of the store). Same DB1 path + bus objects as the recall test.
@@ -3585,6 +3625,7 @@ unit-test-module-protocol: $(TESTPREFIX)/unit-test-module-protocol
 # force every bus test to relink.
 BUS_TEST_TARGETS := $(addprefix $(TESTPREFIX)/, \
    unit-test-bus-endpoint unit-test-bus-runtime unit-test-bus-memory-recall \
+   unit-test-git-verify-state-bus \
    unit-test-bus-memory-upsert unit-test-bus-config-autonomy \
    unit-test-bus-audit-durability unit-test-bus-audit-replay \
    unit-test-bus-audit-retention unit-test-bus-audit-replay-tool \

--- a/src/tests/support/git_module_fixture.c
+++ b/src/tests/support/git_module_fixture.c
@@ -1,0 +1,123 @@
+/* git_module_fixture.c -- see git_module_fixture.h. */
+#include "git_module_fixture.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <aimee/audit/obs_bus.h>
+#include <aimee/git/module_api.h>
+
+static pid_t g_module = -1;
+static char g_root[256];
+
+static void die(const char *what)
+{
+   fprintf(stderr, "git_module_fixture: %s (errno=%s)\n", what, strerror(errno));
+   if (g_module > 0)
+      kill(g_module, SIGKILL);
+   abort();
+}
+
+static void run(const char *format, ...)
+{
+   char command[1024];
+   va_list args;
+   va_start(args, format);
+   vsnprintf(command, sizeof(command), format, args);
+   va_end(args);
+   if (system(command) != 0)
+      die(command);
+}
+
+void git_module_fixture_stop(void)
+{
+   if (g_module > 0)
+   {
+      kill(g_module, SIGTERM);
+      waitpid(g_module, NULL, 0);
+      g_module = -1;
+   }
+   if (g_root[0])
+   {
+      char command[512];
+      snprintf(command, sizeof(command), "rm -rf '%s'", g_root);
+      (void)system(command);
+      g_root[0] = '\0';
+   }
+}
+
+void git_module_fixture_start(void)
+{
+   if (g_module > 0)
+      return;
+
+   const char *source = getenv("AIMEE_TEST_MODULE_BIN");
+   if (!source || !source[0])
+      die("AIMEE_TEST_MODULE_BIN is unset; the make rule must build and name the module binary");
+
+   snprintf(g_root, sizeof(g_root), "/tmp/aimee-git-module-fixture-%d", (int)getpid());
+   char policy[320], socket_path[256], executable[320];
+   snprintf(policy, sizeof(policy), "%s/policy", g_root);
+   snprintf(socket_path, sizeof(socket_path), "%s/bus.sock", g_root);
+   snprintf(executable, sizeof(executable), "%s/aimee-module-git", g_root);
+   run("mkdir -p '%s'", policy);
+
+   /* A real file at this exact name, not a symlink: the module derives its
+    * identity from argv[0]'s basename, and the runtime pins the peer's
+    * resolved executable path against the grant. */
+   run("cp '%s' '%s' && chmod 0755 '%s'", source, executable, executable);
+
+   char grant_path[384];
+   snprintf(grant_path, sizeof(grant_path), "%s/git.grant", policy);
+   FILE *grant = fopen(grant_path, "w");
+   if (!grant)
+      die("open the grant manifest");
+   fprintf(grant,
+           "version=1\nprincipal_class=1\nprincipal_ref=13\nuid=self\n"
+           "executable=%s\nserve=%u,%u,%u,%u\n",
+           executable, AIMEE_GIT_EVENT_OPERATION, AIMEE_GIT_EVENT_REF_VALIDATE,
+           AIMEE_GIT_EVENT_CI_GRADE, AIMEE_GIT_EVENT_VERIFY_RUN);
+   if (fclose(grant) != 0)
+      die("write the grant manifest");
+
+   if (obs_bus_configure_module_runtime(socket_path, policy) != 0)
+      die("configure the module endpoint");
+   if (obs_bus_start() != 0)
+      die("start the bus");
+
+   pid_t child = fork();
+   if (child < 0)
+      die("fork the module");
+   if (child == 0)
+   {
+      execl(executable, executable, socket_path, (char *)NULL);
+      _exit(127);
+   }
+   g_module = child;
+   atexit(git_module_fixture_stop);
+
+   /* Attachment is asynchronous; poll for the registration rather than
+    * sleeping, so a module that died is noticed rather than waited out. */
+   for (int tick = 0; tick < 200; tick++)
+   {
+      if (obs_bus_module_available(AIMEE_GIT_EVENT_VERIFY_RUN))
+         return;
+      int status = 0;
+      if (waitpid(child, &status, WNOHANG) == child)
+      {
+         g_module = -1;
+         die("module exited before it attached");
+      }
+      struct timespec pause = {0, 50 * 1000 * 1000};
+      nanosleep(&pause, NULL);
+   }
+   die("module never registered the verify stage");
+}

--- a/src/tests/support/git_module_fixture.h
+++ b/src/tests/support/git_module_fixture.h
@@ -1,0 +1,28 @@
+/* git_module_fixture: bring the real git module up on a real bus, for tests.
+ *
+ * git_verify_state.c is a seam now -- it asks the git module instead of
+ * touching the repository. A suite that exercises the verify gate therefore
+ * needs the module attached, or the gate correctly reports "nothing verified"
+ * and the suite's assertions fail for a reason that has nothing to do with
+ * what it is testing.
+ *
+ * The module binary's path comes from AIMEE_TEST_MODULE_BIN, set by the make
+ * rule that builds it, so a suite does not have to grow an argv contract.
+ */
+#ifndef AIMEE_TESTS_GIT_MODULE_FIXTURE_H
+#define AIMEE_TESTS_GIT_MODULE_FIXTURE_H 1
+
+/* Configure and start the bus, exec the module, and wait until it serves the
+ * verify stage. Aborts on failure: a suite that silently continued without the
+ * module would report green while testing a fail-closed stub.
+ *
+ * Idempotent -- a second call while the module is running is a no-op, so a
+ * suite may call it from more than one entry point. */
+void git_module_fixture_start(void);
+
+/* Stop the module. Registered with atexit() by start(), so a suite normally
+ * does not call it; exposed for a test that wants to prove absent-module
+ * behaviour. */
+void git_module_fixture_stop(void);
+
+#endif

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -442,14 +442,16 @@ fi
 # Verification runs inside the server image, whose deployment posture is
 # expressed through AIMEE_* environment overrides. Those values are correct for
 # the live daemon but must not override config fixtures in repository unit tests.
-if sed -n '/^unit-tests:/,/^$(TESTPREFIX)\/unit-test-util:/p' tests/Rules.mk |
-   grep -qF 'unset AIMEE_HOME AIMEE_API_REMOTE_WRITES AIMEE_API_MTLS AIMEE_API_BEARER_TOKEN' &&
-   sed -n '/^unit-tests:/,/^$(TESTPREFIX)\/unit-test-util:/p' tests/Rules.mk |
-       grep -qF 'AIMEE_SERVER_HTTP_BIND AIMEE_WORKSPACES_DIR AIMEE_KB_API_URL' &&
-   sed -n '/^unit-tests:/,/^$(TESTPREFIX)\/unit-test-util:/p' tests/Rules.mk |
-       grep -qF 'AIMEE_KB_API_BEARER_TOKEN AIMEE_WFE_ENGINE AIMEE_WFE_HTTP_SOCKET' &&
-   sed -n '/^go-unit-tests:/,/^verify-local:/p' Makefile |
-       grep -qF 'unset AIMEE_WFE_ENGINE AIMEE_WFE_HTTP_SOCKET'; then
+# Match in-shell rather than piping into grep -q. Under `set -o pipefail` such
+# a pipeline reports the SIGPIPE that grep's early exit sends back to its
+# writer, so the check starts failing purely because the recipe grew past a
+# 4KiB pipe block -- a false red that says nothing about the overrides.
+unit_tests_recipe=$(sed -n '/^unit-tests:/,/^$(TESTPREFIX)\/unit-test-util:/p' tests/Rules.mk)
+go_unit_tests_recipe=$(sed -n '/^go-unit-tests:/,/^verify-local:/p' Makefile)
+if [[ "$unit_tests_recipe" == *'unset AIMEE_HOME AIMEE_API_REMOTE_WRITES AIMEE_API_MTLS AIMEE_API_BEARER_TOKEN'* &&
+      "$unit_tests_recipe" == *'AIMEE_SERVER_HTTP_BIND AIMEE_WORKSPACES_DIR AIMEE_KB_API_URL'* &&
+      "$unit_tests_recipe" == *'AIMEE_KB_API_BEARER_TOKEN AIMEE_WFE_ENGINE AIMEE_WFE_HTTP_SOCKET'* &&
+      "$go_unit_tests_recipe" == *'unset AIMEE_WFE_ENGINE AIMEE_WFE_HTTP_SOCKET'* ]]; then
     pass "unit verification removes server deployment overrides"
 else
     fail "unit verification inherits server deployment overrides"

--- a/src/tests/test_git_verify_state_bus.c
+++ b/src/tests/test_git_verify_state_bus.c
@@ -1,0 +1,274 @@
+/* test_git_verify_state_bus.c: the verify ledger, proven across the real bus.
+ *
+ * The C seam in git_verify_state.c no longer does the work; it asks the git
+ * module. Every other test of that seam links module_bus_stub, whose honest
+ * default is "no module attached" -- useful for proving the seam fails closed,
+ * useless for proving it is correct. Correctness needs the actual module, and
+ * the rollout proposal asks for exactly that: behaviour shown to be equivalent
+ * THROUGH the bus, not beside it.
+ *
+ * So this fixture stands up the daemon's authenticated module endpoint, execs
+ * the real Go binary against it, and drives the ordinary C entry points. What
+ * it proves is agreement with git itself and round-trip fidelity of the
+ * ledger -- the same claims the in-process implementation used to carry.
+ *
+ * The module is a separate program, so a failure to start is a failure of the
+ * test, never a skip: a skip here would silently retire the only coverage the
+ * ledger has.
+ */
+#include <errno.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <aimee/audit/obs_bus.h>
+#include <aimee/git/module_api.h>
+#include "modules/git/git_verify.h"
+#include "modules/git/git_verify_internal.h"
+
+static char g_tmp[512];
+static pid_t g_module = -1;
+
+static void must(int condition, const char *what)
+{
+   if (condition)
+      return;
+   fprintf(stderr, "FAIL: %s (errno=%s)\n", what, strerror(errno));
+   if (g_module > 0)
+      kill(g_module, SIGKILL);
+   abort();
+}
+
+/* Run a command and return its trimmed first line, or NULL. Used only to ask
+ * git for the truth the module's answer is compared against. */
+static char *shell(const char *format, ...)
+{
+   char command[2048];
+   va_list args;
+   va_start(args, format);
+   vsnprintf(command, sizeof(command), format, args);
+   va_end(args);
+
+   FILE *pipe = popen(command, "r");
+   if (!pipe)
+      return NULL;
+   static char buffer[512];
+   char *line = fgets(buffer, sizeof(buffer), pipe);
+   int status = pclose(pipe);
+   if (!line || status != 0)
+      return NULL;
+   buffer[strcspn(buffer, "\r\n")] = '\0';
+   return buffer[0] ? buffer : NULL;
+}
+
+/* Copy the multicall binary to the name the module runtime will pin. main.go
+ * derives the module from argv[0]'s basename, and the grant is checked against
+ * the peer's resolved executable path -- so this must be a real file at that
+ * name, not a symlink back to the shared binary. */
+static void install_module_binary(const char *source, const char *destination)
+{
+   must(shell("cp '%s' '%s' && chmod 0755 '%s'", source, destination, destination) != NULL ||
+            access(destination, X_OK) == 0,
+        "copy the module binary");
+   must(access(destination, X_OK) == 0, "module binary is executable");
+}
+
+static void write_grant(const char *policy_dir, const char *executable)
+{
+   char path[640];
+   snprintf(path, sizeof(path), "%s/git.grant", policy_dir);
+   FILE *file = fopen(path, "w");
+   must(file != NULL, "open the grant manifest");
+   /* The serve set is the contract's, not a convenient subset: a grant that
+    * omitted a declared stage would make an unserved stage indistinguishable
+    * from an ungranted one. */
+   fprintf(file,
+           "version=1\nprincipal_class=1\nprincipal_ref=13\nuid=self\n"
+           "executable=%s\nserve=%u,%u,%u,%u\n",
+           executable, AIMEE_GIT_EVENT_OPERATION, AIMEE_GIT_EVENT_REF_VALIDATE,
+           AIMEE_GIT_EVENT_CI_GRADE, AIMEE_GIT_EVENT_VERIFY_RUN);
+   must(fclose(file) == 0, "write the grant manifest");
+}
+
+static void start_module(const char *executable, const char *socket_path)
+{
+   pid_t child = fork();
+   must(child >= 0, "fork the module");
+   if (child == 0)
+   {
+      execl(executable, executable, socket_path, (char *)NULL);
+      _exit(127);
+   }
+   g_module = child;
+
+   /* Attachment is asynchronous. Poll availability rather than sleeping: the
+    * point of the fixture is that a real process really registered. */
+   for (int tick = 0; tick < 200; tick++)
+   {
+      if (obs_bus_module_available(AIMEE_GIT_EVENT_VERIFY_RUN))
+         return;
+      int status = 0;
+      if (waitpid(child, &status, WNOHANG) == child)
+      {
+         g_module = -1;
+         must(0, "module exited before it attached");
+      }
+      struct timespec pause = {0, 50 * 1000 * 1000};
+      nanosleep(&pause, NULL);
+   }
+   must(0, "module never registered the verify stage");
+}
+
+static void stop_module(void)
+{
+   if (g_module <= 0)
+      return;
+   kill(g_module, SIGTERM);
+   waitpid(g_module, NULL, 0);
+   g_module = -1;
+}
+
+/* The hashes must be git's, not merely self-consistent: a module that returned
+ * a stable wrong value would pass a round-trip test and fail every real gate. */
+static void test_hashes_match_git(const char *repo)
+{
+   char *expected_tree = shell("git -C '%s' rev-parse HEAD^{tree}", repo);
+   must(expected_tree != NULL, "git produced a tree hash");
+   char tree_copy[128];
+   snprintf(tree_copy, sizeof(tree_copy), "%s", expected_tree);
+
+   char *expected_commit = shell("git -C '%s' rev-parse HEAD", repo);
+   must(expected_commit != NULL, "git produced a commit hash");
+
+   char *tree = verify_compute_file_hash(repo);
+   must(tree != NULL && strcmp(tree, tree_copy) == 0, "tree hash matches git");
+   char *commit = verify_compute_commit_hash(repo);
+   must(commit != NULL && strcmp(commit, expected_commit) == 0, "commit hash matches git");
+   free(tree);
+   free(commit);
+
+   must(verify_worktree_has_changes(repo) == 0, "a fresh checkout is clean");
+   must(shell("touch '%s/dirty.txt'", repo) != NULL || access(repo, F_OK) == 0, "dirty the tree");
+   must(verify_worktree_has_changes(repo) == 1, "an untracked file makes the tree dirty");
+   must(shell("rm -f '%s/dirty.txt'", repo) != NULL || 1, "undirty the tree");
+}
+
+static void test_ledger_round_trip(const char *repo)
+{
+   verify_state_entry_t entries[VERIFY_STATE_MAX];
+   must(read_verify_entries(repo, entries, VERIFY_STATE_MAX) == 0, "a fresh repo has no ledger");
+
+   const char *hash = "1111111111111111111111111111111111111111";
+   must(write_verify_state(repo, 1700000000, hash, 1, 4, "lint:0,build:1") == 0,
+        "write the ledger");
+
+   int count = read_verify_entries(repo, entries, VERIFY_STATE_MAX);
+   must(count == 1, "the written entry reads back");
+   must(entries[0].ts == 1700000000, "timestamp survives the round trip");
+   must(strcmp(entries[0].hash, hash) == 0, "hash survives the round trip");
+   must(entries[0].failed == 1 && entries[0].total == 4, "counters survive the round trip");
+   must(strcmp(entries[0].step_results, "lint:0,build:1") == 0, "step results survive");
+
+   must(find_verify_entry(entries, count, hash) == 0, "the entry is findable by hash");
+
+   /* The step-results string is still produced and read by C; the module
+    * carries it opaquely. Proving the lookup works on a string that made the
+    * round trip is what shows the two sides agree on it. */
+   int rc = -1;
+   must(verify_state_step_result_lookup(entries[0].step_results, "build", &rc) == 1 && rc == 1,
+        "a step's recorded exit code survives");
+
+   /* Re-verifying the same tree replaces rather than appends. */
+   must(write_verify_state(repo, 1700000100, hash, 0, 4, "") == 0, "rewrite the same tree");
+   count = read_verify_entries(repo, entries, VERIFY_STATE_MAX);
+   must(count == 1 && entries[0].ts == 1700000100, "the same tree is replaced, not duplicated");
+}
+
+/* The pre-push hook runs from the main checkout, so state recorded in a linked
+ * worktree has to be visible there. This is the one behaviour that depends on
+ * the module resolving the repository the same way C used to. */
+static void test_worktree_sharing(const char *repo)
+{
+   /* Inside the fixture directory, so it goes away with everything else. A
+    * path outside it survives the run and the next one silently adopts a
+    * worktree whose repository no longer exists. */
+   char linked[640];
+   snprintf(linked, sizeof(linked), "%s/linked", g_tmp);
+   must(access(linked, F_OK) != 0, "the linked worktree path is unused");
+   (void)shell("git -C '%s' worktree add -q -b side '%s' 2>&1", repo, linked);
+   must(access(linked, F_OK) == 0, "add a linked worktree");
+
+   const char *hash = "2222222222222222222222222222222222222222";
+   must(write_verify_state(linked, 1700000200, hash, 0, 2, "") == 0, "write from the worktree");
+
+   verify_state_entry_t entries[VERIFY_STATE_MAX];
+   int count = read_verify_entries(repo, entries, VERIFY_STATE_MAX);
+   must(find_verify_entry(entries, count, hash) >= 0,
+        "the main checkout sees the linked worktree's entry");
+}
+
+/* With the module gone the seam must report "nothing verified" -- the state
+ * that forces a verify run. Reporting a verified tree here would let an
+ * unverified push through on a broken deployment. */
+static void test_absent_module_fails_closed(const char *repo)
+{
+   stop_module();
+   for (int tick = 0; tick < 200 && obs_bus_module_available(AIMEE_GIT_EVENT_VERIFY_RUN); tick++)
+   {
+      struct timespec pause = {0, 50 * 1000 * 1000};
+      nanosleep(&pause, NULL);
+   }
+
+   verify_state_entry_t entries[VERIFY_STATE_MAX];
+   must(read_verify_entries(repo, entries, VERIFY_STATE_MAX) == 0,
+        "an absent module reports no verified trees");
+   must(verify_compute_file_hash(repo) == NULL, "an absent module yields no tree hash");
+   must(write_verify_state(repo, 1, "3333333333333333333333333333333333333333", 0, 1, "") == -1,
+        "an absent module fails the write rather than losing it silently");
+}
+
+int main(int argc, char **argv)
+{
+   must(argc >= 2, "usage: test_git_verify_state_bus <path to aimee-module binary>");
+
+   snprintf(g_tmp, sizeof(g_tmp), "/tmp/aimee-verify-bus-%d", (int)getpid());
+   char policy[640], socket_path[512], executable[640], repo[640];
+   snprintf(policy, sizeof(policy), "%s/policy", g_tmp);
+   snprintf(socket_path, sizeof(socket_path), "%s/bus.sock", g_tmp);
+   snprintf(executable, sizeof(executable), "%s/aimee-module-git", g_tmp);
+   snprintf(repo, sizeof(repo), "%s/repo", g_tmp);
+   must(shell("mkdir -p '%s' '%s' '%s'", g_tmp, policy, repo) != NULL || access(g_tmp, F_OK) == 0,
+        "create the fixture directories");
+
+   install_module_binary(argv[1], executable);
+   write_grant(policy, executable);
+
+   must(obs_bus_configure_module_runtime(socket_path, policy) == 0,
+        "configure the module endpoint");
+   must(obs_bus_start() == 0, "start the bus");
+
+   must(shell("git -C '%s' init -q -b main && git -C '%s' config user.email t@example.com && "
+              "git -C '%s' config user.name t && git -C '%s' commit -q --allow-empty -m one",
+              repo, repo, repo, repo) != NULL ||
+            access(repo, F_OK) == 0,
+        "create the fixture repository");
+
+   start_module(executable, socket_path);
+
+   test_hashes_match_git(repo);
+   test_ledger_round_trip(repo);
+   test_worktree_sharing(repo);
+   test_absent_module_fails_closed(repo);
+
+   stop_module();
+   (void)shell("rm -rf '%s'", g_tmp);
+   printf("git-verify-state-bus: ok (ledger agrees with git across the real module)\n");
+   return 0;
+}

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -18,6 +18,7 @@
 #include "modules/workspace/workspace_turn.h" /* workspace_turn_set_container_bound_for_test */
 #include "platform_test_util.h"
 #include "modules/git/git_verify.h"
+#include "support/git_module_fixture.h"
 
 /* Per-case in-memory DB2 backing for test bodies that round-trip
  * memory-subsystem state. The shim helper owns the sqlite handle and
@@ -3749,6 +3750,11 @@ int main(void)
    unlink(db_path);
    assert(db1_init(db_path) == 0);
    assert(server_obs_bus_configure() == 0);
+   /* The verify gate reads its ledger from the git module, so the module has
+    * to be up or every verify assertion below fails on a correctly closed
+    * gate rather than on what it means to test. After the suite's own bus
+    * configuration, not before: reconfiguring a running bus is refused. */
+   git_module_fixture_start();
    /* anti_patterns is DB2 (Postgres). */
 
    test_classify_sensitive();

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -18,6 +18,7 @@
 #include "../db1/db1.h"
 #include "../db2/db2.h"
 #include "../db2/db2_internal.h"
+#include "support/git_module_fixture.h"
 
 /* --- Helpers --- */
 
@@ -3237,6 +3238,11 @@ static void test_git_verify_sync_rejects_same_session_overlap(void)
 
 int main(void)
 {
+   /* The verify gate reads its ledger from the git module, so the module has
+    * to be up or every verify assertion below fails on a correctly closed
+    * gate rather than on what it means to test. */
+   git_module_fixture_start();
+
    printf("mcp_git: ");
 
    test_git_status_clean();


### PR DESCRIPTION
Second PR of the git C→Go migration. Follows #2463, which declared the stage table.

## What moved

`git_verify_state.c` was ~283 lines of subprocess and file I/O: the tree/commit hashes verify keys itself on, the dirty-worktree probe, and the `.aimee/.last-verify` ledger. That work is now `server-go/modules/git/verify_state.go`, served as stage 6 (`git-verify-run`, 7430). The C functions keep their signatures and their failure conventions — callers do not know the work moved.

**Why verify and not forge.** `git_pr_api.c` resolves its token in-process precisely so it never reaches another process — it exists to close the last place a webchat git action put a token in a child's `/proc/<pid>/environ`. Honouring that from a module process needs the vault, and no Go module can reach it: vault is `execution: core`, and `docs/proposals/pending/vault-bus-only-access.md` (operator ruling, 2026-08-07) governs the extraction. Verify was the one path touching no credential — nothing under `git_verify*.c` references the vault.

## The fixture is most of this PR

Porting the seam made it untestable. Seven suites link `git_verify_state.o`; the two that exercise the verify gate — `guardrails` and `mcp-git` — drove it in-process. With the work behind a bus call they saw a correctly closed gate and failed on it. Nothing proved the module answered *correctly*, only that its absence was handled.

`tests/support/git_module_fixture.c` does what the rollout proposal asks — equivalence shown **through** the bus:

- hosts the daemon's authenticated module endpoint (`obs_bus_configure_module_runtime` + `obs_bus_start`)
- writes a grant pinning the module executable, at the name the runtime resolves
- execs the real Go binary and waits for the stage to register
- binary path via `AIMEE_TEST_MODULE_BIN`, set by the `unit-tests` rule, so no suite grows an argv contract

`test_git_verify_state_bus.c` is the correctness proof: hashes compared against **git itself** rather than merely round-tripped, ledger fidelity including the opaque step-results string, one ledger shared across linked worktrees, and — after killing the module — the fail-closed behaviour the stub-based suites were the only witness to.

A missing Go toolchain **fails** the target rather than skipping it. A skip would silently retire the only correctness coverage the ledger has.

## Verification

- `unit-test-git-verify-state-bus` — ok, and repeatable across five consecutive runs
- `guardrails`, `mcp-git`, `git-verify-select`, `git-verify-contract`, `verify-hook`, `pipeline` — all pass
- `go test ./bus ./modules/... ./cmd/aimee-module` — pass
- `make all` — clean; `make lint` — 48/48
- merge-tree preflight against `testing` — clean

## Notes

- `guardrails` starts the fixture *after* its own `server_obs_bus_configure()`; reconfiguring a running bus is refused.
- Stages 4 and 5 stay unserved and are asserted to be refused. They unblock only after the vault extraction.