### PR TITLE
fix(webchat): restore identities into the managed group, not beside it

### DIFF
--- a/deploy/container/runtime-web-lib.sh
+++ b/deploy/container/runtime-web-lib.sh
@@ -116,16 +116,24 @@ webchat_migrate_legacy_credentials() {
 #
 # Idempotent: an existing account keeps its password, so a restart never resets a
 # credential the operator has already changed.
+# The managed login group, created on demand. Both the restore path and the
+# provision path need it before their first usermod, and each having its own copy
+# is how one of them ended up without it.
+webchat_ensure_login_group() {
+    getent group "$WEBCHAT_LOGIN_GROUP" >/dev/null 2>&1 && return 0
+    if ! groupadd --system "$WEBCHAT_LOGIN_GROUP"; then
+        webchat_log "ERROR: could not create the managed login group"
+        return 1
+    fi
+    return 0
+}
+
 webchat_provision_login() {
     _bs_user="$1"
     _bs_pass="$2"
     [ -n "$_bs_user" ] && [ -n "$_bs_pass" ] || return 0
 
-    getent group "$WEBCHAT_LOGIN_GROUP" >/dev/null 2>&1 || \
-        groupadd --system "$WEBCHAT_LOGIN_GROUP" || {
-            webchat_log "ERROR: could not create the managed login group"
-            return 1
-        }
+    webchat_ensure_login_group || return 1
     if id "$_bs_user" >/dev/null 2>&1; then
         usermod -aG "$WEBCHAT_LOGIN_GROUP" "$_bs_user" 2>/dev/null || true
         # An account can exist WITHOUT being able to log in: the image ships
@@ -218,6 +226,19 @@ webchat_read_seeded_credentials() {
 # operator made since, and restoring over it would silently roll that back.
 webchat_restore_identities() {
     [ -f "$WEBCHAT_IDENTITIES" ] || return 0
+    # The group must exist BEFORE the first usermod. It ships in no image, and this
+    # function runs first in webchat_provision_bootstrap_account -- ahead of
+    # webchat_provision_login, which was the only thing that created it. So on every
+    # container replacement each restored account failed its `usermod -aG`, silently
+    # (|| true), and came back OUTSIDE the managed group.
+    #
+    # That is not cosmetic. UserManager.List() reads the GROUP, so an unmanaged account
+    # is invisible to it, and snapshotManagedIdentities() rebuilds this record from that
+    # list and writes it WHOLESALE. The next account operation therefore dropped the
+    # restored account from the record, and the container replacement after that lost
+    # the account for good -- observed on the testing appliance, where `admin` existed
+    # only in this record (it is in no image) and was one snapshot away from deletion.
+    webchat_ensure_login_group || return 0
     _wc_restored=0
     while IFS=: read -r _wc_u _wc_h; do
         [ -n "$_wc_u" ] && [ -n "$_wc_h" ] || continue
@@ -239,7 +260,14 @@ webchat_restore_identities() {
             userdel -r "$_wc_u" >/dev/null 2>&1 || true
             continue
         fi
-        usermod -aG "$WEBCHAT_LOGIN_GROUP" "$_wc_u" >/dev/null 2>&1 || true
+        # NOT `|| true`. An account outside the managed group is invisible to
+        # UserManager.List(), so the next snapshot rewrites this record without it and
+        # the following container replacement loses it. Swallowing this is what turned a
+        # recoverable group failure into silent account deletion, so say so loudly.
+        if ! usermod -aG "$WEBCHAT_LOGIN_GROUP" "$_wc_u" >/dev/null 2>&1; then
+            webchat_log "WARNING: restored '$_wc_u' but could not add it to $WEBCHAT_LOGIN_GROUP;" \
+                        "it is NOT managed and the next snapshot will drop it"
+        fi
         _wc_restored=$((_wc_restored + 1))
     done < "$WEBCHAT_IDENTITIES"
     [ "$_wc_restored" -gt 0 ] && webchat_log "restored $_wc_restored dashboard login(s) after a container replacement"

--- a/scripts/check-webchat-bootstrap-login.sh
+++ b/scripts/check-webchat-bootstrap-login.sh
@@ -64,16 +64,21 @@ id() {
 # membership and loses only its shadow verifier, and a container recreate drops
 # the accounts while the group definition ships in the image.
 group_members="$test_dir/group-members"
-# A FRESH appliance: the group ships in the image with no members. The old stub
-# answered only for "aimee", never the login group, so this matches what the
-# generation checks below have always seen.
+# A FRESH appliance. The group does NOT ship in the image -- verified against
+# ghcr.io/rakuensoftware/aimee-server:testing, which has no aimee-webchat group and
+# no admin account. The old fixture asserted the opposite (getent group always
+# succeeded), which is exactly why it could not see a restore path whose usermod
+# failed for want of the group. Absent marker = no group yet; groupadd creates it.
 printf '' > "$group_members"
+group_exists="$test_dir/group-exists"
+rm -f "$group_exists"
 shadow_hashes="$test_dir/shadow-hashes"   # "<user> <hash>"; absent => a usable hash
 : > "$shadow_hashes"
 getent() {
   case ${1:-} in
     group)
       [[ ${2:-} == "${WEBCHAT_LOGIN_GROUP:-aimee}" ]] || return 1
+      [[ -f $group_exists ]] || return 1
       printf '%s:x:999:%s\n' "$2" "$(cat "$group_members")"
       ;;
     passwd)
@@ -95,8 +100,11 @@ usermod() {
     return 0
   fi
   printf '%s\n' "$*" >> "$cleared_users"
-  # -aG <group> <user>: reflect the membership so getent group agrees.
+  # -aG <group> <user>: reflect the membership so getent group agrees. Real usermod
+  # FAILS on an unknown group; modelling that is what exposes a restore that runs
+  # before the group is created.
   if [[ ${1:-} == -aG ]]; then
+    [[ -f $group_exists ]] || return 1
     printf '%s,%s\n' "$(cat "$group_members")" "${3:-}" > "$group_members"
   fi
 }
@@ -108,7 +116,7 @@ useradd() {
   # Provisioning adds the supplementary group separately (usermod -aG); model
   # that here so group membership reflects what actually happened.
 }
-groupadd() { :; }
+groupadd() { printf 'x' > "$group_exists"; }
 chpasswd() {
   # -e means the payload is a hash, not a plaintext password (the restore path).
   if [[ ${1:-} == -e ]]; then
@@ -251,6 +259,7 @@ rm -rf "$AIMEE_HOME/webchat"; mkdir -p "$AIMEE_HOME/webchat"
 : > "$cleared_users"
 printf '%s\n' operator legacy aimee "$fixture_process_user" > "$existing_users"   # the image's own users
 printf '' > "$group_members"                                       # group ships empty
+rm -f "$group_exists"          # ...and does NOT ship at all: a replaced container
 printf 'admin:$6$salt$operatorverifier\n' > "$AIMEE_HOME/webchat/identities"
 printf 'generated:aimee-000000000000\n' > "$WEBCHAT_BOOTSTRAP_USER"
 printf 'admin\n' > "$WEBCHAT_BOOTSTRAP_REPLACED"
@@ -258,6 +267,14 @@ restore_log=$(webchat_provision_bootstrap_account 2>&1)
 # The operator's own account is back, with its own verifier...
 grep -Fq 'useradd' "$cleared_users"
 grep -Fq -- "-aG $WEBCHAT_LOGIN_GROUP admin" "$cleared_users"
+# ...and is actually IN the group. Assert the RESULT, not the invocation: usermod
+# records its arguments before it can fail, so the line above passed even while the
+# restore ran ahead of any groupadd and every membership silently failed. An
+# unmanaged account is invisible to UserManager.List(), so the next
+# snapshotManagedIdentities() rewrites this record without it and the following
+# container replacement deletes the operator's account outright. Observed on the
+# testing appliance: `admin` lived only in this record and was one snapshot from gone.
+getent group "$WEBCHAT_LOGIN_GROUP" | grep -Fq admin
 grep -Fq 'chpasswd -e admin:$6$salt$operatorverifier' "$cleared_users"
 grep -Fxq admin "$existing_users"
 # ...so no replacement credential is minted, and the marker naming them stands.


### PR DESCRIPTION
A restored dashboard login came back **outside** the managed group on every
container replacement, and the next account operation then deleted it from the
record that restores it. Two more replacements and the operator's account is gone.

Found while adding a second login to the testing appliance — creating it would
have destroyed `admin`.

## The ordering bug

`webchat_provision_bootstrap_account` calls `webchat_restore_identities` **first**.
The only `groupadd` lived in `webchat_provision_login`, which runs after. The group
ships in no image — verified against `ghcr.io/rakuensoftware/aimee-server:testing`,
which carries neither the `aimee-webchat` group nor any operator account.

So each restored account ran `usermod -aG` against a group that did not exist yet,
failed, and had the failure swallowed by `|| true`.

## Why that is account loss, not a cosmetic group miss

- `UserManager.List()` reads the **group**, so an unmanaged account is invisible to it.
- `snapshotManagedIdentities()` rebuilds the record from that list and writes it
  **wholesale** — there is no merge with what the record already held.

So the first `Create` / `Delete` / `UpdatePassword` after a replacement rewrites the
record *without* the restored account, and the replacement after that has nothing to
restore it from.

On the testing appliance `admin` existed in no image, lived only in that record, was
not in `aimee-webchat`, and was one account operation from deletion.

## The fix

`webchat_ensure_login_group()` is now shared by both paths — each keeping its own
copy is how one ended up without it — and runs before the first `usermod` in the
restore loop. The `usermod` failure is no longer swallowed: an account that cannot
join the group is reported as unmanaged and doomed, because silence is what turned a
recoverable group failure into deletion.

## The fixture asserted the opposite of reality

Its `getent group` stub always succeeded, modelling an image that *ships* the group,
so a restore whose `usermod` failed for want of one could not be seen. It now models
an absent group that `groupadd` creates, and a `usermod` that fails on an unknown
group.

The existing assertion could not have caught this either — it greps for the `-aG`
**invocation**, and the stub records arguments before it can fail, so it passed
throughout. The new assertion reads `getent group` for actual **membership**: the
result, not the call.

**Red-before-green confirmed** — reverting only `runtime-web-lib.sh` fails the check.
The check runs in `lint` (`src/Makefile`), so it gates in CI.

## Appliance state

The live box was repaired by hand (group membership restored, record regenerated
from the managed group). That repair does not survive a redeploy on its own — this
change plus a new image is what makes it permanent.
