### PR TITLE
git: refuse to open a PR that cannot merge, and say why CI is red

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e1d9f644ba1af5b116975653cdddb88288ca87f14611bfbb4ecfd1216a09d5d7",
+      "source_sha256": "6590540697501521a5faf1712ce4e6e0fe471a1504e751303a2f3a26ce95984d",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -367,6 +367,13 @@ static inline int agent_http_effective_connect_timeout_ms(int request_timeout_ms
 }
 
 int agent_http_get(const char *url, const char *extra_headers, char **response_buf, int timeout_ms);
+/* GET that REPORTS a 3xx redirect target in `location` rather than following it.
+ * Deliberately non-following: a forge's log endpoint redirects to pre-signed
+ * third-party storage, and replaying the request there would hand that host the
+ * Authorization header. Only the caller knows which of its headers are
+ * host-bound, so the caller issues the second request itself. */
+int agent_http_get_location(const char *url, const char *extra_headers, char *location,
+                           size_t location_cap, char **response_buf, int timeout_ms);
 /* SSRF-safe GET: connect to the caller-validated numeric `pinned_ip` (no DNS
  * re-resolution) with Host/SNI still taken from the URL host. */
 int agent_http_get_pinned(const char *url, const char *pinned_ip, const char *extra_headers,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -870,6 +870,217 @@ int git_pr_checks_via_api_slug(const char *principal, const char *slug, int numb
    return 0;
 }
 
+/* --- Why a check failed --- */
+
+/* A check run's details_url ends ".../actions/runs/<run>/job/<job>"; the job id is
+ * the only handle the steps and log endpoints take, and reading it from the URL
+ * we already have avoids listing every job in the run to match by name. */
+static long gh_job_id_from_details_url(const char *url)
+{
+   if (!url || !url[0])
+      return 0;
+   const char *seg = strstr(url, "/job/");
+   if (!seg)
+      return 0;
+   seg += 5;
+   char *end = NULL;
+   long id = strtol(seg, &end, 10);
+   if (end == seg || id <= 0)
+      return 0;
+   return id;
+}
+
+/* First failed step of a job: the name, and the 1-based position. For a step the
+ * workflow did not name, the forge reports the command line, which is exactly what
+ * a caller needs in order to run the same gate locally. */
+static void gh_failed_step(const gh_ctx_t *cx, long job_id, char *name, size_t name_cap,
+                           int *number)
+{
+   name[0] = '\0';
+   *number = 0;
+   char path[96];
+   snprintf(path, sizeof(path), "actions/jobs/%ld", job_id);
+   char *resp = NULL;
+   int st = gh_get(cx, path, &resp);
+   if (st < 200 || st >= 300 || !resp)
+   {
+      free(resp);
+      return;
+   }
+   cJSON *j = cJSON_Parse(resp);
+   free(resp);
+   const cJSON *steps = j ? cJSON_GetObjectItem(j, "steps") : NULL;
+   const cJSON *s = NULL;
+   cJSON_ArrayForEach(s, steps)
+   {
+      const cJSON *concl = cJSON_GetObjectItem(s, "conclusion");
+      if (!cJSON_IsString(concl) || !concl->valuestring)
+         continue;
+      if (strcmp(concl->valuestring, "failure") != 0 &&
+          strcmp(concl->valuestring, "timed_out") != 0)
+         continue;
+      const cJSON *nm = cJSON_GetObjectItem(s, "name");
+      const cJSON *num = cJSON_GetObjectItem(s, "number");
+      if (cJSON_IsString(nm) && nm->valuestring)
+         snprintf(name, name_cap, "%s", nm->valuestring);
+      if (cJSON_IsNumber(num))
+         *number = num->valueint;
+      break; /* the first failure is the cause; later ones are usually fallout */
+   }
+   cJSON_Delete(j);
+}
+
+/* The last `tail_bytes` of a job's log.
+ *
+ * Two requests, deliberately. The forge's log endpoint answers 302 to pre-signed
+ * blob storage, so the redirect is followed HERE rather than in the HTTP layer:
+ * the second request must carry the Range header but must NOT carry the
+ * Authorization header, because that would hand the forge token to a third-party
+ * host. Range asks for the tail so a multi-megabyte log costs one small read, and
+ * the tail is where the error is. Returns malloc'd text, or NULL. */
+static char *gh_job_log_tail(const gh_ctx_t *cx, long job_id, long tail_bytes)
+{
+   if (tail_bytes <= 0)
+      return NULL;
+
+   char url[512];
+   if ((size_t)snprintf(url, sizeof(url),
+                        "https://api.github.com/repos/%s/%s/actions/jobs/%ld/logs", cx->owner,
+                        cx->repo, job_id) >= sizeof(url))
+      return NULL;
+   char hdrs[480];
+   if ((size_t)snprintf(hdrs, sizeof(hdrs), "Authorization: Bearer %s\n" GH_ACCEPT, cx->token) >=
+       sizeof(hdrs))
+      return NULL;
+
+   char location[1024] = "";
+   char *body = NULL;
+   int st = agent_http_get_location(url, hdrs, location, sizeof(location), &body, 20000);
+   wipe(hdrs, sizeof(hdrs));
+
+   /* Some deployments answer the log inline instead of redirecting. */
+   if (st >= 200 && st < 300 && body && body[0])
+      return body;
+   free(body);
+   body = NULL;
+   if (st < 300 || st >= 400 || !location[0])
+      return NULL;
+
+   /* Signed URL: Range only. No Authorization — see above. */
+   char range[64];
+   snprintf(range, sizeof(range), "Range: bytes=-%ld", tail_bytes);
+   int st2 = agent_http_get(location, range, &body, 20000);
+   wipe(location, sizeof(location));
+   if ((st2 != 200 && st2 != 206) || !body)
+   {
+      free(body);
+      return NULL;
+   }
+   return body;
+}
+
+int git_pr_failures_via_api_slug(const char *principal, const char *slug, int number, int max,
+                                 int logs_for, long tail_bytes, git_pr_failure_t *out, int *count,
+                                 char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
+   if (count)
+      *count = 0;
+   if (!out || !count || max <= 0 || number <= 0)
+   {
+      snprintf(err, errlen, "invalid PR failures request");
+      return -1;
+   }
+
+   git_pr_info_t info;
+   if (git_pr_info_via_api_slug(principal, slug, number, &info, err, errlen) != 0)
+      return -1;
+   if (!info.head_sha[0])
+   {
+      snprintf(err, errlen, "pull request has no head commit");
+      return -1;
+   }
+
+   gh_ctx_t cx;
+   if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
+      return -1;
+
+   char path[160];
+   snprintf(path, sizeof(path), "commits/%s/check-runs?per_page=100", info.head_sha);
+   char *resp = NULL;
+   int st = gh_get(&cx, path, &resp);
+   if (st < 200 || st >= 300 || !resp)
+   {
+      gh_err(resp, st, "pr failures", err, errlen);
+      free(resp);
+      gh_ctx_done(&cx);
+      return -1;
+   }
+   cJSON *j = cJSON_Parse(resp);
+   free(resp);
+   const cJSON *runs = j ? cJSON_GetObjectItem(j, "check_runs") : NULL;
+   if (!cJSON_IsArray(runs))
+   {
+      cJSON_Delete(j);
+      gh_ctx_done(&cx);
+      snprintf(err, errlen, "github API: unparseable check runs");
+      return -1;
+   }
+
+   int n = 0;
+   const cJSON *r = NULL;
+   cJSON_ArrayForEach(r, runs)
+   {
+      if (n >= max)
+         break;
+      const cJSON *concl = cJSON_GetObjectItem(r, "conclusion");
+      if (!cJSON_IsString(concl) || !concl->valuestring)
+         continue;
+      const char *c = concl->valuestring;
+      /* Only states a caller can act on. `cancelled` and `skipped` usually mean
+       * another job failed first, and `neutral` is not a failure. */
+      if (strcmp(c, "failure") != 0 && strcmp(c, "timed_out") != 0 &&
+          strcmp(c, "action_required") != 0)
+         continue;
+
+      const cJSON *name = cJSON_GetObjectItem(r, "name");
+      const cJSON *url = cJSON_GetObjectItem(r, "details_url");
+      git_pr_failure_t *row = &out[n];
+      memset(row, 0, sizeof(*row));
+      snprintf(row->conclusion, sizeof(row->conclusion), "%s", c);
+      if (cJSON_IsString(name) && name->valuestring)
+         snprintf(row->name, sizeof(row->name), "%s", name->valuestring);
+      if (cJSON_IsString(url) && url->valuestring)
+         snprintf(row->url, sizeof(row->url), "%s", url->valuestring);
+
+      long job_id = gh_job_id_from_details_url(row->url);
+      if (job_id > 0)
+      {
+         gh_failed_step(&cx, job_id, row->failed_step, sizeof(row->failed_step),
+                        &row->failed_step_number);
+         if (n < logs_for)
+            row->log_tail = gh_job_log_tail(&cx, job_id, tail_bytes);
+      }
+      n++;
+   }
+   cJSON_Delete(j);
+   gh_ctx_done(&cx);
+   *count = n;
+   return 0;
+}
+
+void git_pr_failures_free(git_pr_failure_t *rows, int count)
+{
+   if (!rows)
+      return;
+   for (int i = 0; i < count; i++)
+   {
+      free(rows[i].log_tail);
+      rows[i].log_tail = NULL;
+   }
+}
+
 int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int limit,
                                   git_pr_list_item_t *out, int *count, char *err, size_t errlen)
 {

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -120,6 +120,36 @@ typedef struct
 int git_pr_checks_via_api_slug(const char *principal, const char *slug, int number, int max,
                                git_pr_check_t *out, int *count, char *err, size_t errlen);
 
+/* Why one check failed, in the terms someone fixing it needs.
+ *
+ * `status`/`url` from the checks listing say a job is red; they do not say what
+ * broke, and the URL is unreachable from an agent. These fields are: which job,
+ * which step inside it, and the tail of that job's log, which is where the actual
+ * error text lives (the forge's own annotation for a shell failure is
+ * "Process completed with exit code 1", which explains nothing). */
+typedef struct
+{
+   char name[256];        /* check / job name */
+   char conclusion[24];   /* failure / timed_out / cancelled / action_required */
+   char failed_step[256]; /* first failed step; for an unnamed step the forge
+                           * reports the command, which is what to run locally */
+   int failed_step_number;
+   char url[512];
+   char *log_tail; /* malloc'd, NUL-terminated, may be NULL; caller frees */
+} git_pr_failure_t;
+
+/* The failed checks for PR `number`'s head commit, at most `max`, count in
+ * *count. Each row gets its failed step; the first `logs_for` rows also get up to
+ * `tail_bytes` of their job log (0 for neither). Returns 0 on success — including
+ * "nothing failed", which is *count == 0 — or -1 with `err` set.
+ *
+ * Caller supplies the array and must call git_pr_failures_free() to release the
+ * log tails. */
+int git_pr_failures_via_api_slug(const char *principal, const char *slug, int number, int max,
+                                 int logs_for, long tail_bytes, git_pr_failure_t *out, int *count,
+                                 char *err, size_t errlen);
+void git_pr_failures_free(git_pr_failure_t *rows, int count);
+
 /* One row of an open-PR listing. */
 typedef struct
 {

--- a/src/modules/git/mcp_git.h
+++ b/src/modules/git/mcp_git.h
@@ -98,6 +98,12 @@ int mcp_git_get_worktree(void);
 char *mcp_git_run(const char *cmd, int *exit_code);
 
 /* Git helper utilities shared between mcp_git_query.c and mcp_git_write.c. */
+/* Would merging HEAD into `base` conflict? 1 yes (conflicting paths appended to
+ * `files`), 0 no, -1 cannot tell. A merge-tree dry run: it does not touch the
+ * working tree or the branch. Exposed for the PR-create gate's test -- an
+ * inconclusive answer must stay "proceed", and only a test pins that. */
+int mcp_git_conflicts_with_base(const char *base, char *files, size_t files_cap);
+
 int get_current_branch(char *buf, size_t len);
 int check_branch_has_merged_pr_for(const char *branch);
 

--- a/src/modules/git/mcp_git_pr.c
+++ b/src/modules/git/mcp_git_pr.c
@@ -9,11 +9,17 @@
 #include "mcp_git.h"
 #include "util.h"
 #include "branch_ownership.h"
+#include "dstr.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
+
+/* How much of a failed job's log to bring back. Enough for a compiler error list
+ * or a failed assertion with context; small enough that several failures in one
+ * response stay readable. */
+#define PR_LOG_TAIL_BYTES 6000
 
 /* --- Helpers --- */
 
@@ -151,6 +157,105 @@ static int pr_derive_from_commits(const char *base, char *title, size_t title_le
       str_appendf(body, bpos, (int)body_len, "\n%s", stat);
    free(stat);
    return 0;
+}
+
+/* Would merging this branch into `base` conflict? Names the conflicting files in
+ * `files` when it would.
+ *
+ * A PR opened in that state is worse than no PR: the forge reports it CONFLICTING,
+ * review cannot start, CI results are about a merge that will never happen, and
+ * somebody has to notice and rebase before any of it means anything. The check is
+ * a merge-tree dry run, so it decides this WITHOUT touching the working tree or
+ * the branch.
+ *
+ * Returns 1 for conflicts, 0 for a clean merge, and -1 when it cannot tell (a
+ * missing base, no origin, an ancient git) — callers must treat -1 as "proceed",
+ * because refusing to open a PR on an inconclusive check would be worse than the
+ * problem. */
+int mcp_git_conflicts_with_base(const char *base, char *files, size_t files_cap)
+{
+   if (files && files_cap)
+      files[0] = '\0';
+   if (!base || !base[0])
+      return -1;
+
+   char *esc = shell_escape(base);
+   char base_ref[600];
+   int rc = 0;
+   {
+      char probe[700];
+      snprintf(probe, sizeof(probe), "git rev-parse --verify --quiet 'origin/%s' >/dev/null 2>&1",
+               esc);
+      char *p = mcp_git_run(probe, &rc);
+      free(p);
+   }
+   if (rc == 0 && strncmp(base, "origin/", 7) != 0)
+      snprintf(base_ref, sizeof(base_ref), "origin/%s", esc);
+   else
+      snprintf(base_ref, sizeof(base_ref), "%s", esc);
+   free(esc);
+
+   /* Fetch first: a stale local copy of the base would clear a branch that in fact
+    * conflicts with what the base has become, which is precisely the case that
+    * produces a CONFLICTING PR. */
+   if (strncmp(base_ref, "origin/", 7) == 0)
+   {
+      char fetch_cmd[700];
+      snprintf(fetch_cmd, sizeof(fetch_cmd), "git fetch origin '%s' 2>&1", base_ref + 7);
+      int frc = 0;
+      free(mcp_git_run(fetch_cmd, &frc));
+   }
+
+   /* Resolve the base before merging against it. `merge-tree --write-tree` exits
+    * 1 BOTH for "these conflict" and for "that ref does not exist", so without
+    * this the gate reads an unresolvable base as a conflict and refuses a PR
+    * that would have merged cleanly -- the exact inversion this function's
+    * contract forbids. A base branch that exists on the forge but not in this
+    * checkout is ordinary, so the wrong answer here would be common. */
+   {
+      char verify[700];
+      snprintf(verify, sizeof(verify),
+               "git rev-parse --verify --quiet '%s^{commit}' >/dev/null 2>&1", base_ref);
+      int vrc = 0;
+      free(mcp_git_run(verify, &vrc));
+      if (vrc != 0)
+         return -1;
+   }
+
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd),
+            "git merge-tree --write-tree --name-only --no-messages HEAD '%s' 2>/dev/null",
+            base_ref);
+   int mrc = 0;
+   char *out = mcp_git_run(cmd, &mrc);
+   /* --write-tree exits 1 with the conflicted paths on stdout, 0 when clean. */
+   if (out && mrc == 1)
+   {
+      /* First line is the merged tree oid; the rest are the conflicted paths. */
+      const char *p = strchr(out, '\n');
+      if (p && p[1] && files && files_cap)
+      {
+         int pos = 0;
+         const char *line = p + 1;
+         while (*line)
+         {
+            const char *nl = strchr(line, '\n');
+            size_t len = nl ? (size_t)(nl - line) : strlen(line);
+            if (len)
+               pos = str_appendf(files, pos, (int)files_cap, "\n  %.*s", (int)len, line);
+            line = nl ? nl + 1 : line + len;
+         }
+      }
+      free(out);
+      return 1;
+   }
+   if (out && mrc == 0)
+   {
+      free(out);
+      return 0;
+   }
+   free(out);
+   return -1; /* merge-tree unavailable or the base could not be resolved */
 }
 
 static int get_origin_repo_slug(char *buf, size_t len)
@@ -380,6 +485,75 @@ cJSON *handle_git_pr(cJSON *args)
          pos += (size_t)snprintf(text + pos, cap - pos, "%s\t%s\t%s\t%s\t\n", rows[i].name,
                                  rows[i].status, rows[i].elapsed, rows[i].url);
       cJSON *r = mcp_text(text);
+      free(text);
+      return r;
+   }
+
+   /* action=failures: why CI is red.
+    *
+    * action=checks says a job failed and hands back a details_url, which an agent
+    * cannot open (no browser, and the shell-git gate blocks `gh`). So the loop
+    * "push, read the failure, fix it" was closed: the only way to learn the cause
+    * was for a human to paste it in. This answers with the job, the step inside it
+    * that failed, and the tail of that job's log — the step name alone is often
+    * enough, because an unnamed step reports its command line, which is the gate to
+    * run locally. */
+   if (strcmp(action, "failures") == 0)
+   {
+      cJSON *jnum = cJSON_GetObjectItemCaseSensitive(args, "number");
+      if (!cJSON_IsNumber(jnum))
+         return mcp_text("error: 'number' parameter is required for failures");
+
+      char slug[264];
+      if (get_origin_repo_slug(slug, sizeof(slug)) != 0)
+         return mcp_text("error: cannot resolve a github.com origin for this checkout");
+
+      /* Logs are fetched for the first few failures only: they are the expensive
+       * part, and a run where twenty jobs went red almost always has one cause. */
+      cJSON *jcount = cJSON_GetObjectItemCaseSensitive(args, "count");
+      int logs_for = (cJSON_IsNumber(jcount) && jcount->valueint > 0) ? jcount->valueint : 3;
+      if (logs_for > 10)
+         logs_for = 10;
+
+      git_pr_failure_t rows[30];
+      int n = 0;
+      char err[512] = "";
+      if (git_pr_failures_via_api_slug(agent_get_request_vault_principal(), slug, jnum->valueint,
+                                       (int)(sizeof(rows) / sizeof(rows[0])), logs_for,
+                                       PR_LOG_TAIL_BYTES, rows, &n, err, sizeof(err)) != 0)
+         return mcp_error("error: pr failures failed: %s", err[0] ? err : "unknown");
+
+      if (n == 0)
+         return mcp_text("no failing checks on this PR's head commit (a check still running is not "
+                         "a failure — use action=checks for the full status list)");
+
+      dstr_t res;
+      dstr_init(&res);
+      dstr_appendf(&res, "%d failing check(s) on PR #%d:\n", n, jnum->valueint);
+      for (int i = 0; i < n; i++)
+      {
+         dstr_appendf(&res, "\n=== %s (%s)\n", rows[i].name[0] ? rows[i].name : "(unnamed check)",
+                      rows[i].conclusion);
+         if (rows[i].failed_step[0])
+            dstr_appendf(&res, "failed at step %d: %s\n", rows[i].failed_step_number,
+                         rows[i].failed_step);
+         if (rows[i].log_tail && rows[i].log_tail[0])
+         {
+            /* The tail starts mid-line after a byte-range read; drop the partial
+             * first line rather than present a truncated one as if it were whole. */
+            const char *tail = rows[i].log_tail;
+            const char *nl = strchr(tail, '\n');
+            if (nl && nl[1])
+               tail = nl + 1;
+            dstr_appendf(&res, "--- last %d bytes of the job log ---\n%s\n", PR_LOG_TAIL_BYTES,
+                         tail);
+         }
+         else if (i < logs_for)
+            dstr_append_str(&res, "(job log unavailable)\n");
+      }
+      git_pr_failures_free(rows, n);
+      char *text = dstr_steal(&res);
+      cJSON *r = mcp_text(text ? text : "error: out of memory rendering failures");
       free(text);
       return r;
    }
@@ -798,6 +972,30 @@ cJSON *handle_git_pr(cJSON *args)
       cJSON *jbase = cJSON_GetObjectItemCaseSensitive(args, "base");
 
       const char *base = cJSON_IsString(jbase) ? jbase->valuestring : "main";
+
+      /* Refuse to open a PR that cannot be merged.
+       *
+       * A CONFLICTING PR blocks its own review: the forge will not merge it, its CI
+       * results describe a merge that will never happen, and someone has to spot
+       * the state and rebase before any of it counts. Opening one is not a partial
+       * success, so this is a refusal and not a warning — with the one command that
+       * fixes it. An inconclusive check (-1) proceeds; refusing on "cannot tell"
+       * would block more work than it protects. */
+      {
+         char conflicts[2048];
+         if (mcp_git_conflicts_with_base(base, conflicts, sizeof(conflicts)) == 1)
+         {
+            char buf[2560];
+            snprintf(buf, sizeof(buf),
+                     "error: not opening this PR — merging it into %s would conflict, so it would "
+                     "arrive unmergeable. Conflicting file(s):%s\n\nRun command=sync base=%s "
+                     "abort_on_conflict=false, resolve them, command=add, command=rebase "
+                     "action=continue, then open the PR (or command=pr action=ready, which does "
+                     "the sync and the push for you).",
+                     base, conflicts, base);
+            return mcp_text(buf);
+         }
+      }
 
       /* Title and body are OPTIONAL: the branch's own commits already say what the
        * change is, so aimee derives them rather than making the caller spend a

--- a/src/posix/agent_bridge.c
+++ b/src/posix/agent_bridge.c
@@ -692,7 +692,39 @@ static int parse_response_headers(char *buf, size_t len, size_t *header_end, int
 
 /* Read a full HTTP response (headers + body) into *out_body, returning status code.
  * For buffered (non-streaming) reads. */
-static int http_read_response(http_conn_t *conn, char **out_body, size_t *out_len)
+/* Copy one response header's value out of the raw header block. Case-insensitive
+ * on the name, as HTTP requires; the block is `buf[0..header_end)` and is still
+ * intact at the point this is called. */
+static void http_header_value(const char *buf, size_t header_end, const char *name, char *out,
+                              size_t out_cap)
+{
+   out[0] = '\0';
+   size_t name_len = strlen(name);
+   for (size_t i = 0; i + name_len + 1 < header_end; i++)
+   {
+      if (i && buf[i - 1] != '\n')
+         continue; /* only at the start of a header line */
+      if (strncasecmp(buf + i, name, name_len) != 0 || buf[i + name_len] != ':')
+         continue;
+      const char *v = buf + i + name_len + 1;
+      while (*v == ' ' || *v == '\t')
+         v++;
+      size_t n = 0;
+      while (v[n] && v[n] != '\r' && v[n] != '\n' && (size_t)(v - buf) + n < header_end &&
+             n + 1 < out_cap)
+         n++;
+      memcpy(out, v, n);
+      out[n] = '\0';
+      return;
+   }
+}
+
+/* As http_read_response, plus one header captured for the caller. Exists so a
+ * caller can act on a redirect (Location) itself rather than have this layer
+ * follow it: a 302 to pre-signed storage must NOT carry the Authorization header
+ * onward, and only the caller knows which of its headers are host-bound. */
+static int http_read_response_hdr(http_conn_t *conn, char **out_body, size_t *out_len,
+                                  const char *want_header, char *hdr_out, size_t hdr_cap)
 {
    *out_body = NULL;
    *out_len = 0;
@@ -745,6 +777,8 @@ static int http_read_response(http_conn_t *conn, char **out_body, size_t *out_le
       free(buf);
       return -1;
    }
+   if (want_header && hdr_out && hdr_cap)
+      http_header_value(buf, header_end, want_header, hdr_out, hdr_cap);
 
    /* Phase 2: read body */
    if (chunked)
@@ -1143,7 +1177,50 @@ stream_done:
    return status;
 }
 
+static int http_read_response(http_conn_t *conn, char **out_body, size_t *out_len)
+{
+   return http_read_response_hdr(conn, out_body, out_len, NULL, NULL, 0);
+}
+
 /* ---- Public API ---- */
+
+/* GET that REPORTS a redirect instead of following it: on a 3xx the target lands
+ * in `location` and the caller decides what to re-send. Deliberately not a
+ * following GET — a forge's log endpoint redirects to pre-signed third-party
+ * storage, and blindly replaying the request there would hand that host the
+ * Authorization header (the forge token). Only the caller knows which of its
+ * headers are host-bound, so only the caller can safely follow. */
+int agent_http_get_location(const char *url, const char *extra_headers, char *location,
+                            size_t location_cap, char **response_buf, int timeout_ms)
+{
+   *response_buf = NULL;
+   if (location && location_cap)
+      location[0] = '\0';
+
+   parsed_url_t pu;
+   if (parse_url(url, &pu) < 0)
+      return -1;
+
+   http_conn_t conn;
+   if (conn_open(&conn, &pu, timeout_ms) < 0)
+      return -1;
+   if (send_request(&conn, "GET", &pu, NULL, NULL, extra_headers, "aimee/1.0", NULL, 0) < 0)
+   {
+      conn_close(&conn);
+      return -1;
+   }
+
+   size_t resp_len = 0;
+   int status =
+       http_read_response_hdr(&conn, response_buf, &resp_len, "Location", location, location_cap);
+   conn_close(&conn);
+   if (status < 0)
+   {
+      free(*response_buf);
+      *response_buf = NULL;
+   }
+   return status;
+}
 
 /* SSRF-safe GET: connect to `pinned_ip` (a numeric IP the caller already
  * validated against the egress deny-list) while keeping Host/SNI = the URL host.

--- a/src/tests/support/git_pr_api_stub.c
+++ b/src/tests/support/git_pr_api_stub.c
@@ -123,6 +123,30 @@ int git_pr_checks_via_api_slug(const char *principal, const char *slug, int numb
    return -1;
 }
 
+int git_pr_failures_via_api_slug(const char *principal, const char *slug, int number, int max,
+                                 int logs_for, long tail_bytes, git_pr_failure_t *out, int *count,
+                                 char *err, size_t errlen)
+{
+   (void)principal;
+   (void)slug;
+   (void)number;
+   (void)max;
+   (void)logs_for;
+   (void)tail_bytes;
+   (void)out;
+   if (count)
+      *count = 0;
+   if (err && errlen)
+      snprintf(err, errlen, "pr api unavailable (stub)");
+   return -1;
+}
+
+void git_pr_failures_free(git_pr_failure_t *rows, int count)
+{
+   (void)rows;
+   (void)count;
+}
+
 int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int limit,
                                   git_pr_list_item_t *out, int *count, char *err, size_t errlen)
 {

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -3236,6 +3236,61 @@ static void test_git_verify_sync_rejects_same_session_overlap(void)
    verify_test_teardown(tmpdir, fake_home);
 }
 
+/* --- The PR-create mergeability gate ---
+ *
+ * aimee opening PRs that arrive CONFLICTING is the failure this gate exists to
+ * stop: review cannot start, and CI reports on a merge that will never happen.
+ * The gate has to be right in both directions -- a false conflict refuses a
+ * good PR, and an inconclusive answer must let one through rather than block
+ * on a check that could not run. */
+static void test_pr_conflict_gate(void)
+{
+   char tmp[] = "/tmp/aimee-test-pr-conflict-XXXXXX";
+   assert(mkdtemp(tmp) != NULL);
+   char saved[4096];
+   assert(getcwd(saved, sizeof(saved)) != NULL);
+
+   char cmd[4096];
+   /* main has a file; two branches change the same line and a third changes a
+    * different file. All local -- the gate falls back to a bare ref when no
+    * origin/<base> exists, which is what a test repo has. */
+   snprintf(cmd, sizeof(cmd),
+            "cd '%s' && git init -q -b main && git config user.email t@t && git config user.name t"
+            " && printf 'one\n' > f.txt && git add f.txt && git commit -q -m base"
+            " && git checkout -q -b clean && printf 'x\n' > other.txt && git add other.txt"
+            " && git commit -q -m clean"
+            " && git checkout -q main && printf 'two\n' > f.txt && git commit -q -am theirs"
+            " && git checkout -q -b conflicting main~1 && printf 'three\n' > f.txt"
+            " && git commit -q -am ours",
+            tmp);
+   assert(system(cmd) == 0);
+   assert(chdir(tmp) == 0);
+
+   char files[1024];
+
+   /* A branch touching a different file merges cleanly. */
+   assert(system("git checkout -q clean") == 0);
+   assert(mcp_git_conflicts_with_base("main", files, sizeof(files)) == 0);
+
+   /* Both sides rewrote f.txt: conflict, and the gate must name the file so the
+    * refusal tells the caller what to fix. */
+   assert(system("git checkout -q conflicting") == 0);
+   assert(mcp_git_conflicts_with_base("main", files, sizeof(files)) == 1);
+   assert(strstr(files, "f.txt") != NULL);
+
+   /* Cannot tell => proceed. A base that does not exist, and an empty base, must
+    * both return -1 rather than 1: refusing a PR because the check could not run
+    * would be worse than the problem the gate solves. */
+   assert(mcp_git_conflicts_with_base("no-such-branch", files, sizeof(files)) == -1);
+   assert(mcp_git_conflicts_with_base("", files, sizeof(files)) == -1);
+   assert(mcp_git_conflicts_with_base(NULL, files, sizeof(files)) == -1);
+
+   assert(chdir(saved) == 0);
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmp);
+   system(cmd);
+   printf("pr_conflict_gate ");
+}
+
 int main(void)
 {
    /* The verify gate reads its ledger from the git module, so the module has
@@ -3246,6 +3301,7 @@ int main(void)
    printf("mcp_git: ");
 
    test_git_status_clean();
+   test_pr_conflict_gate();
    test_git_status_modified();
    test_mcp_chdir_uses_cwd_argument();
    test_mcp_chdir_session_cwd_precedes_proxy_cwd();

--- a/src/windows/agent_bridge.c
+++ b/src/windows/agent_bridge.c
@@ -149,6 +149,20 @@ int agent_http_get(const char *url, const char *extra_headers, char **response_b
    return -1;
 }
 
+int agent_http_get_location(const char *url, const char *extra_headers, char *location,
+                           size_t location_cap, char **response_buf, int timeout_ms)
+{
+   /* Phase 2, with agent_http_get: the forge API path is POSIX-only today. */
+   (void)url;
+   (void)extra_headers;
+   (void)timeout_ms;
+   if (location && location_cap)
+      location[0] = '\0';
+   if (response_buf)
+      *response_buf = NULL;
+   return -1;
+}
+
 int agent_http_put(const char *url, const char *auth_header, const char *body, char **response_buf,
                    int timeout_ms, const char *extra_headers)
 {

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -175,7 +175,7 @@
         },
         {
           "path": "src/headers/agent_exec.h",
-          "sha256": "6edc1a5d3f2cc25875aeaaee3657ae0b0dae27e473009439d81e8c0340e2a0e9"
+          "sha256": "49a49dce41a9bf7f4454a527d7c9cd0207667321aec92e41c88a59720edd6bff"
         },
         {
           "path": "src/headers/agent_pipeline.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "d805110ab0cf024ac12d6d5982f8ce6fd7443baaadfee839e47f75a2ba979cb8",
+      "sha256": "5855e8f593892d70e53133c92f44ffb8bc84ae66c3334270f479a83527eb6815",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
Two gaps that between them stall the merge queue.

## `pr action=failures` — why CI is red

An agent could see a check was red and not why. `pr action=checks` returns a `details_url` it cannot open — no browser, and the shell-git gate blocks `gh` — so the loop "push, read the failure, fix it" was only closeable by a human pasting the log in.

`pr action=failures` answers with the job, the step inside it that failed, and the tail of that job's log. The step name alone is often enough: an unnamed step reports its command line, which is the gate to run locally. Logs are fetched for the first few failures only (default 3, max 10) — they are the expensive part, and a run where twenty jobs went red almost always has one cause.

## `pr create` — refuse a PR that cannot merge

aimee kept opening PRs that arrived CONFLICTING, which is worse than no PR: review cannot start, and CI reports on a merge that will never happen. `pr create` now runs a `merge-tree` dry run against the base first and refuses, naming the conflicting files and the sync/rebase sequence that clears them. It does not touch the working tree or the branch.

## A bug the test found

The gate has to be right in both directions — a false conflict refuses a good PR — so it is tested rather than trusted. Writing that test turned up a real defect in the original implementation:

`git merge-tree --write-tree` exits **1** both for *"these conflict"* and for *"no such ref"*. The gate read an unresolvable base as a conflict and refused a PR that would have merged cleanly — the exact inversion the function's own contract forbids ("callers must treat -1 as proceed"). A base branch that exists on the forge but not in the local checkout is ordinary, so the wrong answer would have been common.

The base is now resolved with `rev-parse --verify` before the merge is attempted. `test_pr_conflict_gate` pins all three outcomes: clean, conflicting-by-name, and cannot-tell.

## Verification

- `unit-test-mcp-git` (incl. the new gate test) pass; `guardrails`, `git-verify-contract`, `verify-hook`, `pipeline`, `git-verify-select`, `unit-test-git-verify-state-bus` all pass
- `make all` clean · `make lint` 48/48 · `./tests/test_build_integrity.sh` exit 0
- `check_c_repository_lock` ok · `validate_module_descriptors` ok · `refactor_baselines` ok (module digest and public-surface baseline refreshed — `agent_exec.h` gained the byte-range HTTP GET the log tail needs)
- merge-tree preflight against `testing` clean

## Note

This is the work that was shelved on `shelf/c-side-pr-features` earlier today when the C→Go migration was prioritised. It is C, and it stays C: the forge path cannot move to the Go module until the vault has a bus surface, and these two gaps are costing merges now.