### PR TITLE
fix(snapshot): stop a 0.1s clock failing the tree scan as a contract violation

### DIFF
--- a/scripts/module_doc_git_snapshot.py
+++ b/scripts/module_doc_git_snapshot.py
@@ -35,7 +35,13 @@ MAX_ORIGIN_BYTES = 512
 MAX_ORIGINS_BYTES = 8_192
 MAX_OUTPUT_BYTES = 65_536
 MAX_TREE_ENTRIES = 100_000
-MAX_TREE_SCAN_SECONDS = 0.1
+# A stuck-filesystem backstop, NOT a performance budget -- see _tree_bytes. Sized so
+# only a filesystem that has stopped answering can reach it; MAX_TREE_ENTRIES is what
+# actually bounds a large tree, and it does so deterministically.
+MAX_TREE_SCAN_SECONDS = 30.0
+# Read the clock once per this many entries. Per-file, the syscall was a measurable
+# share of the scan it was supposed to be policing.
+TREE_SCAN_CLOCK_INTERVAL = 1024
 MIN_DISK_BYTES = 1_048_576
 MAX_DISK_BYTES = 8_589_934_592
 DEFAULT_DISK_BYTES = 536_870_912
@@ -96,13 +102,33 @@ def _sanitize(raw: bytes) -> str:
 
 
 def _tree_bytes(root: Path) -> int:
+    """Total size of every regular file under `root`, with the scan itself bounded.
+
+    MAX_TREE_ENTRIES is the real bound and it is DETERMINISTIC: the same tree gives
+    the same verdict on every machine. The clock is only a backstop for a filesystem
+    that has stopped answering, where the entry count would never advance.
+
+    Which is why the clock must not be tight. At 0.1s, checked once per file, a
+    contended CI runner failed this on a fixture tree of a few dozen files -- and it
+    surfaces as `rule=snapshot-disk`, a CONTRACT violation, so a scheduling hiccup on
+    a shared runner reads as "this snapshot broke the rules". Observed twice on
+    2026-08-09, on two unrelated branches, while the same tree passed locally and on
+    the integration tip. A budget that a healthy tree can miss is not measuring the
+    tree.
+
+    So the clock is now generous enough that only a genuinely stuck filesystem trips
+    it, and it is read once per block of entries rather than once per file: at 0.1s
+    the per-file time.monotonic() was itself part of what made the scan slow.
+    """
     total = 0
     entries = 0
     deadline = time.monotonic() + MAX_TREE_SCAN_SECONDS
     for directory, _, files in os.walk(root):
         for name in files:
             entries += 1
-            if entries > MAX_TREE_ENTRIES or time.monotonic() >= deadline:
+            if entries > MAX_TREE_ENTRIES:
+                contract.fail("snapshot-disk", "snapshot tree scan exceeds its budget")
+            if entries % TREE_SCAN_CLOCK_INTERVAL == 0 and time.monotonic() >= deadline:
                 contract.fail("snapshot-disk", "snapshot tree scan exceeds its budget")
             with suppress(OSError):
                 total += (Path(directory) / name).stat().st_size

--- a/scripts/tests/test_module_doc_git_snapshot.py
+++ b/scripts/tests/test_module_doc_git_snapshot.py
@@ -393,6 +393,33 @@ class GitSnapshotTests(unittest.TestCase):
             ),
         )
 
+    def test_tree_scan_is_bounded_by_entries_not_by_the_clock(self) -> None:
+        """The scan budget must be deterministic.
+
+        The entry cap is the bound that decides a verdict, and the same tree must get
+        the same answer everywhere. The clock is only a stuck-filesystem backstop: at
+        0.1s it failed a few-dozen-file fixture on a contended CI runner and reported
+        it as rule=snapshot-disk, i.e. a contract violation, on two unrelated branches
+        while the identical tree passed locally.
+        """
+        tree = self.root / "scan"
+        tree.mkdir()
+        for index in range(8):
+            (tree / f"f{index}").write_bytes(b"x" * 16)
+
+        # A healthy tree is measured, not rejected -- and the clock does not decide it.
+        self.assertEqual(snapshot._tree_bytes(tree), 8 * 16)
+        with mock.patch.object(snapshot, "MAX_TREE_SCAN_SECONDS", 0.0):
+            self.assertEqual(
+                snapshot._tree_bytes(tree),
+                8 * 16,
+                "an already-expired clock must not fail a tree well under the entry cap",
+            )
+
+        # The deterministic cap still fires, and still as snapshot-disk.
+        with mock.patch.object(snapshot, "MAX_TREE_ENTRIES", 4):
+            self.assert_rule("snapshot-disk", lambda: snapshot._tree_bytes(tree))
+
     def test_sensitive_output_is_discarded_and_failure_is_fixed(self) -> None:
         secret = "Authorization: Bearer REFLECTED-SECRET"
         env = snapshot._base_env(self.root)


### PR DESCRIPTION
`_tree_bytes` bounded its scan two ways: `MAX_TREE_ENTRIES`, and a **wall-clock
deadline of 0.1 seconds** read once per file. The clock was the one that fired.

On 2026-08-09 it failed `module-doc-contract` on two unrelated branches —
`feat/request-extended-thinking` (#2464) and `fix/cli-remote-local-socket-cmds` —
while the identical tree passed locally and on `testing`. The fixture it choked on
is a few dozen files. **100ms is not a property of that tree; it is a property of
how busy the runner was.**

## Why this is worse than a slow test

`contract.fail()` reports `rule=snapshot-disk`, so a scheduling hiccup on a shared
runner reads as *"this snapshot broke the rules"*. In
`test_platform_output_timeout_and_disk_bounds` it preempted the assertion under
test, and the failure printed as:

```
AssertionError: "rule=snapshot-platform" does not match
                "rule=snapshot-disk: snapshot tree scan exceeds its budget"
```

which points at the memfd platform guard — nowhere near the actual cause. Anyone
debugging that starts in the wrong file.

## The fix

`MAX_TREE_ENTRIES` was always the real bound, and it is **deterministic**: the same
tree earns the same verdict on every machine. The clock only ever needed to cover a
filesystem that has stopped answering, where the entry count never advances.

- `MAX_TREE_SCAN_SECONDS` 0.1 → **30.0** — reachable only by a genuinely stuck mount
- Clock read once per **1024 entries** instead of once per file: at 0.1s the
  per-file `time.monotonic()` was itself part of what made the scan slow enough to trip

**No budget is loosened for a tree that is actually too large.** The entry cap and
the byte ceiling are untouched.

## Test

Pins the intent rather than the timing: a healthy tree is **measured, not rejected**,
even with the clock already expired (`MAX_TREE_SCAN_SECONDS` patched to `0.0`), while
the entry cap still fails as `snapshot-disk`.

**Red-before-green confirmed** — reverting only `module_doc_git_snapshot.py` fails it.
`test_module_doc_git_snapshot.py` 13/13 and `test_module_doc_contract.py` 24/24 pass.

Unblocks #2464, whose only failing check is this.
