### PR TITLE
fix(memory): carry --as-of across the server -> kb hop

### DIFF
--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -780,6 +780,28 @@ int kb_client_memory_explain_match(const char *query, int64_t memory_id, memory_
  * 1 for a valid missing row, or -1 when the service/result is unavailable. */
 int kb_client_memory_get(int64_t id, memory_t *out);
 
+/* The EVENT-time verdict for an `as_of` query, kept as a tri-state because the
+ * three answers are genuinely different. UNKNOWN is the service saying "I could
+ * not tell"; folding it into NO is how a bitemporal query lies. UNASKED is the
+ * ordinary no-as_of fetch, which must emit no verdict at all rather than a
+ * default one. */
+typedef enum
+{
+   KB_VALID_AT_UNASKED = 0,
+   KB_VALID_AT_YES,
+   KB_VALID_AT_NO,
+   KB_VALID_AT_UNKNOWN
+} kb_valid_at_t;
+
+/* As-of variant of kb_client_memory_get: forwards `as_of` to aimee-kb, which
+ * owns the valid_from/valid_until interval, and hands back its verdict. The
+ * plain entry point above cannot express this -- memory_t has no field for it
+ * (the valid_at in memory.h belongs to memory_relation_t, a different struct),
+ * so a caller that wants the time answer has to receive it separately.
+ * `as_of` NULL or empty asks nothing and leaves *verdict at UNASKED. */
+int kb_client_memory_get_as_of(int64_t id, const char *as_of, memory_t *out,
+                               kb_valid_at_t *verdict);
+
 /* Insert a memory row via aimee-kb (the DB2 owner).  The full
  * write-side gate pipeline runs inside aimee-kb.  Returns 0 on
  * success (|out| filled if non-NULL) or -1 if kb is unreachable or

--- a/src/modules/kb_client/kb_client_memory.c
+++ b/src/modules/kb_client/kb_client_memory.c
@@ -1201,11 +1201,24 @@ int kb_client_memory_load_eval_corpus(memory_t *out, int max, char *label_out, s
 
 int kb_client_memory_get(int64_t id, memory_t *out)
 {
+   return kb_client_memory_get_as_of(id, NULL, out, NULL);
+}
+
+int kb_client_memory_get_as_of(int64_t id, const char *as_of, memory_t *out, kb_valid_at_t *verdict)
+{
+   if (verdict)
+      *verdict = KB_VALID_AT_UNASKED;
    if (!out)
       return -1;
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddNumberToObject(req, "id", (double)id);
+   /* Only sent when asked. aimee-kb emits as_of/valid_at exactly when it
+    * receives a non-empty as_of, so an empty one here would be indistinguishable
+    * from not asking -- and this omission is what left `memory get --as-of`
+    * marshalling the flag correctly and then dropping it on this hop. */
+   if (as_of && as_of[0])
+      cJSON_AddStringToObject(req, "as_of", as_of);
    char *json = kb_v1_action_request("memory.get", req);
    if (!json)
       return -1;
@@ -1230,6 +1243,16 @@ int kb_client_memory_get(int64_t id, memory_t *out)
       return -1;
    }
    kbc_memory_row_from_json(mem_j, out);
+   /* aimee-kb answers with a bool, or the string "unknown" when it could not
+    * tell. A missing key means it was not asked. */
+   if (verdict)
+   {
+      cJSON *v = cJSON_GetObjectItemCaseSensitive(resp, "valid_at");
+      if (cJSON_IsString(v))
+         *verdict = KB_VALID_AT_UNKNOWN;
+      else if (cJSON_IsBool(v))
+         *verdict = cJSON_IsTrue(v) ? KB_VALID_AT_YES : KB_VALID_AT_NO;
+   }
    cJSON_Delete(resp);
    return 0;
 }

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -361,13 +361,34 @@ int handle_memory_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (!cJSON_IsNumber(jid))
       return server_send_error(conn, "missing id", NULL);
 
+   /* `memory get --as-of <ts>` asks the EVENT-time question, and this handler is
+    * the only thing between the flag and aimee-kb, which owns the interval. It
+    * used to read nothing but the id, so the flag was marshalled, sent, and
+    * silently dropped here: the client printed the row and no verdict, which
+    * reads exactly like "not in force". */
+   cJSON *jas_of = cJSON_GetObjectItemCaseSensitive(req, "as_of");
+   const char *as_of = cJSON_IsString(jas_of) ? jas_of->valuestring : NULL;
+
    memory_t m;
-   int rc = kb_client_memory_get((int64_t)jid->valuedouble, &m);
+   kb_valid_at_t verdict = KB_VALID_AT_UNASKED;
+   int rc = kb_client_memory_get_as_of((int64_t)jid->valuedouble, as_of, &m, &verdict);
 
    cJSON *resp;
    if (rc == 0)
    {
       resp = jo_ok();
+      /* Echo the question with the answer: the client prints "valid at <ts>:
+       * <verdict>", and a verdict with no timestamp beside it is unreadable.
+       * "unknown" stays a string, distinct from false -- "could not tell" and
+       * "was not in force" are different answers. */
+      if (verdict != KB_VALID_AT_UNASKED && as_of)
+      {
+         cJSON_AddStringToObject(resp, "as_of", as_of);
+         if (verdict == KB_VALID_AT_UNKNOWN)
+            cJSON_AddStringToObject(resp, "valid_at", "unknown");
+         else
+            cJSON_AddBoolToObject(resp, "valid_at", verdict == KB_VALID_AT_YES);
+      }
       cJSON *mj = memory_to_json(&m);
       if (mj)
       {

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -495,9 +495,27 @@ if [ "$KB_AVAILABLE" -eq 1 ]; then
 
     RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID}")
     check_output "memory.get by ID" "integration test value" echo "$RESP"
+
+    # `memory get --as-of` crosses client -> aimee-server -> aimee-kb, and it was
+    # once broken in the middle: the server read only the id, so the flag was
+    # marshalled, sent, and dropped, and the client printed the row with no
+    # verdict -- which reads exactly like "not in force". Every unit test around
+    # it passed, because each end was checked against a hand-written payload that
+    # already contained the field. Only the real wire shows the gap, so assert it
+    # here: the verdict must come back, and must NOT appear when nobody asked.
+    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID,\"as_of\":\"2020-01-01 00:00:00\"}")
+    check_output "memory.get --as-of echoes the timestamp" '"as_of"' echo "$RESP"
+    check_output "memory.get --as-of returns an event-time verdict" '"valid_at"' echo "$RESP"
+
+    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID}")
+    if echo "$RESP" | grep -q '"valid_at"'; then
+        check_output "memory.get without --as-of emits no verdict" "no valid_at" echo "found valid_at"
+    else
+        check_output "memory.get without --as-of emits no verdict" "ok" echo "ok"
+    fi
 else
     echo "SKIP: memory write/read round-trip (aimee-kb is not configured)"
-    SKIP=$((SKIP + 3))
+    SKIP=$((SKIP + 6))
 fi
 
 # ============================================================

--- a/src/tests/test_kb_client_memory.c
+++ b/src/tests/test_kb_client_memory.c
@@ -238,6 +238,86 @@ static void test_explicit_scope_overrides_ambient_context(void)
    printf("  PASS: test_explicit_scope_overrides_ambient_context\n");
 }
 
+/* `memory get --as-of` was marshalled by the client, accepted by aimee-kb, and
+ * lost in between: kb_client_memory_get sent a request carrying nothing but the
+ * id. Every test around it passed anyway, because each end was checked against a
+ * payload written by hand to contain the field -- the CLI marshaller was asserted
+ * to emit as_of, the printer was fed a synthetic reply that already had valid_at,
+ * and the DB2 primitive was called directly. Three green pieces that never
+ * touched each other.
+ *
+ * So this asserts the SERIALIZED REQUEST BODY, which is the thing that was
+ * actually empty. A test that only checked the return value would pass against
+ * the broken version. */
+static char last_request_body[1024];
+static const char *as_of_reply = NULL;
+
+static int as_of_post_handler(const char *url, const char *auth_header, const char *body,
+                              char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   snprintf(last_request_body, sizeof(last_request_body), "%s", body ? body : "");
+   if (response_buf)
+      *response_buf = strdup(as_of_reply);
+   return 200;
+}
+
+static void test_as_of_reaches_the_kb_and_its_verdict_comes_back(void)
+{
+   memory_t m;
+   kb_valid_at_t verdict;
+
+   mock_agent_http_set_post_handler(as_of_post_handler);
+   as_of_reply = "{\"status\":\"ok\",\"as_of\":\"2026-06-12 00:00:00\",\"valid_at\":false,"
+                 "\"memory\":{\"id\":42,\"key\":\"k\",\"content\":\"c\"}}";
+
+   /* The field must be ON THE WIRE. This is the assertion that fails against the
+    * bug: the old request body was {"id":42} and nothing else. */
+   last_request_body[0] = '\0';
+   assert(kb_client_memory_get_as_of(42, "2026-06-12 00:00:00", &m, &verdict) == 0);
+   assert(strstr(last_request_body, "\"as_of\"") != NULL);
+   assert(strstr(last_request_body, "2026-06-12 00:00:00") != NULL);
+   assert(verdict == KB_VALID_AT_NO);
+
+   /* "unknown" must survive as a third answer. Folding it into NO would report
+    * "not in force" for a row the service could not judge. */
+   as_of_reply = "{\"status\":\"ok\",\"as_of\":\"2026-06-12 00:00:00\",\"valid_at\":\"unknown\","
+                 "\"memory\":{\"id\":42,\"key\":\"k\",\"content\":\"c\"}}";
+   assert(kb_client_memory_get_as_of(42, "2026-06-12 00:00:00", &m, &verdict) == 0);
+   assert(verdict == KB_VALID_AT_UNKNOWN);
+
+   as_of_reply = "{\"status\":\"ok\",\"as_of\":\"2026-06-12 00:00:00\",\"valid_at\":true,"
+                 "\"memory\":{\"id\":42,\"key\":\"k\",\"content\":\"c\"}}";
+   assert(kb_client_memory_get_as_of(42, "2026-06-12 00:00:00", &m, &verdict) == 0);
+   assert(verdict == KB_VALID_AT_YES);
+
+   /* Not asking must send no as_of at all: aimee-kb emits the verdict exactly
+    * when it receives a non-empty as_of, so an empty string here would be
+    * indistinguishable from asking. */
+   as_of_reply = "{\"status\":\"ok\",\"memory\":{\"id\":42,\"key\":\"k\",\"content\":\"c\"}}";
+   last_request_body[0] = '\0';
+   assert(kb_client_memory_get_as_of(42, NULL, &m, &verdict) == 0);
+   assert(strstr(last_request_body, "as_of") == NULL);
+   assert(verdict == KB_VALID_AT_UNASKED);
+
+   last_request_body[0] = '\0';
+   assert(kb_client_memory_get_as_of(42, "", &m, &verdict) == 0);
+   assert(strstr(last_request_body, "as_of") == NULL);
+   assert(verdict == KB_VALID_AT_UNASKED);
+
+   /* The plain entry point keeps its six existing callers' behaviour: no as_of
+    * on the wire, and it must still compile against a NULL verdict. */
+   last_request_body[0] = '\0';
+   assert(kb_client_memory_get(42, &m) == 0);
+   assert(strstr(last_request_body, "as_of") == NULL);
+
+   mock_agent_http_reset();
+   printf("  PASS: test_as_of_reaches_the_kb_and_its_verdict_comes_back\n");
+}
+
 int main(void)
 {
    /* A configured kb URL routes kb_client_v1_post_json through agent_http_post
@@ -249,6 +329,7 @@ int main(void)
    test_single_record_miss_is_not_dependency_failure();
    test_ordered_readers_propagate_active_project_context();
    test_explicit_scope_overrides_ambient_context();
+   test_as_of_reaches_the_kb_and_its_verdict_comes_back();
 
    unsetenv("AIMEE_KB_API_URL");
    runtime_secret_remove("AIMEE_KB_API_BEARER_TOKEN");


### PR DESCRIPTION
`aimee memory get <id> --as-of <ts>` printed the memory row and **no verdict**, and its output was byte-identical with the flag, without it, and with a timestamp decades in the past — which reads exactly like "not in force". Found by exercising the deployed appliance after #2458 shipped, not by CI.

## Where it broke

The flag was marshalled correctly by the CLI (#2458) and handled correctly by aimee-kb (#2458). It died on the hop in between, in two places:

| | |
|---|---|
| `handle_memory_get` (`src/server/server_state.c`) | read only `id`, never looked at `as_of` |
| `kb_client_memory_get` (`src/modules/kb_client/kb_client_memory.c`) | built a request containing only `id`, and returned the row via `memory_t` — which has no field for the answer (the `valid_at` in `memory.h` belongs to `memory_relation_t`, a different struct) |

So `as_of` could not reach the KB and `valid_at` could not come back. The KB-side code was correct and complete the whole time; it was simply unreachable.

## The fix

`kb_client_memory_get_as_of()` forwards `as_of` and hands the verdict back as a tri-state. The plain `kb_client_memory_get()` becomes a wrapper, so its **six existing callers are untouched**.

- `UNKNOWN` stays distinct from `NO` — "could not tell" and "was not in force" are different answers, and folding them together is how a bitemporal query lies.
- `UNASKED` emits nothing at all — a verdict on every response would have to mean something for the overwhelmingly common no-`as_of` case.

## Why CI did not catch it — and what is different now

The original tests checked each end against a payload **written by hand to contain the field**: the marshaller was asserted to emit `as_of`, the printer was fed a synthetic reply that already had `valid_at`, and the DB2 primitive was called directly. Three green pieces that never touched each other — a check built on the same assumption as the code it checks.

So the new unit test asserts the **serialized request body**, which is the thing that was actually empty. A test on the return value alone passes against the bug.

**Verified red-before-green.** With the forwarding removed the test fails on the wire assertion itself, not on a downstream symptom:

```
Assertion `strstr(last_request_body, "\"as_of\"") != NULL' failed.
```

It also covers `true` → YES, `false` → NO, `"unknown"` → UNKNOWN, absent → UNASKED, and that not asking puts no `as_of` on the wire at all.

## Known gap — please read

`test_integration.sh` gains real cross-service assertions (verdict present when asked, absent when not), but **those do not run in CI**: `ci.yml` states outright that no workflow invokes the `integration-tests` target. They are a local guard only, which means **the server-handler half of this fix is not CI-enforced**.

Closing that properly means either wiring `integration-tests` into CI, or adding a memory as-of check to the T2 (server+kb split) docker smoke, which is the right conceptual home since it already proves the `AIMEE_KB_API_URL` wiring. I did not add the latter blind — it gates merges and I could not run the docker matrix here to verify the endpoint shapes.

## Verification

- `make lint` — all 48 checks pass
- `refactor_baselines`, `check_module_inventory`, `check_module_source_ownership`, `check_module_bus_boundary`, `check_capability_ownership` — all ok
- `unit-test-kb-client-memory` — green → red → green
- `unit-test-cli-v1-subcommands` — passes
- `aimee-server` compiles under `-Werror` and links
