### PR TITLE
fix(memory): compare event-time bounds by value, not by text

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "276ad39d67bf5799346cca3e5ce9eea3a1309618486e34dd236b9615ed7b5c46",
+      "source_sha256": "a6c4b8fc381e18ce5448068336b722bd7689059326ac82cc4a07b2a3762b2fbf",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 7,

--- a/src/db2/memory_lifecycle.c
+++ b/src/db2/memory_lifecycle.c
@@ -104,10 +104,35 @@ int db2_memory_valid_at(int64_t memory_id, const char *as_of)
     * as we know", an empty valid_until means "still true". Rows written before
     * supersession began stamping valid_until therefore read as current -- the
     * truthful answer, since we genuinely do not know when they stopped being
-    * true. Inventing a boundary from updated_at would manufacture history. */
-   static const char *sql = "SELECT 1 FROM memories WHERE id = ?1"
-                            " AND (COALESCE(valid_from,'') = '' OR valid_from <= ?2)"
-                            " AND (COALESCE(valid_until,'') = '' OR valid_until > ?3)";
+    * true. Inventing a boundary from updated_at would manufacture history.
+    *
+    * Normalise the separator before comparing, because these columns genuinely
+    * hold TWO formats. schema.sql declares the canonical text form as
+    * 'YYYY-MM-DD HH24:MI:SS' and pg_now_text() writes that, but the C writers
+    * reach these same columns with now_utc(), which is ISO
+    * ("2026-08-09T19:07:23Z"): db2_memory_set_versioned_key and
+    * db2_memory_set_valid_from are both handed a now_utc() stamp by
+    * memory_supersede, while db2_memory_set_lifecycle_state stamps pg_now_text().
+    *
+    * A plain text compare therefore decided on character 10, where 'T' (0x54)
+    * sorts ABOVE ' ' (0x20). Every ISO bound ranked above every space-separated
+    * value, inverting the verdict: a superseded row read as still in force, and
+    * a row not yet valid read as valid. It failed silently, since a wrong
+    * verdict is indistinguishable from a right one, and it only surfaced when
+    * the DATE matched -- decade-apart dates decide at the year and never reach
+    * the separator.
+    *
+    * replace()/rtrim() rather than a ::timestamptz cast: the DB2 unit tests run
+    * on the SQLite shim, where the cast is a syntax error, and these two are
+    * spelled the same in both engines. Offsets other than 'Z' are still compared
+    * textually -- nothing in this tree writes one, and inventing a parser here
+    * would be guessing at data we do not produce. */
+   static const char *sql =
+       "SELECT 1 FROM memories WHERE id = ?1"
+       " AND (NULLIF(valid_from,'') IS NULL"
+       "      OR rtrim(replace(valid_from,'T',' '),'Z') <= rtrim(replace(?2,'T',' '),'Z'))"
+       " AND (NULLIF(valid_until,'') IS NULL"
+       "      OR rtrim(replace(valid_until,'T',' '),'Z') > rtrim(replace(?3,'T',' '),'Z'))";
    char err[ML_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
@@ -117,7 +142,13 @@ int db2_memory_valid_at(int64_t memory_id, const char *as_of)
    aimee_pg_bind_text(st, "?3", as_of);
    int rc = aimee_pg_step(st, err, sizeof(err));
    aimee_pg_finalize(st);
-   return (rc == AIMEE_PG_ROW) ? 1 : 0;
+   if (rc == AIMEE_PG_ROW)
+      return 1;
+   /* A statement error -- an as_of Postgres cannot parse, or a malformed stored
+    * bound -- is "could not tell", not "was not in force". Folding it into 0
+    * would answer a question we failed to evaluate, which is the same lie the
+    * -1 path upstream exists to avoid. */
+   return (rc == AIMEE_PG_DONE) ? 0 : -1;
 }
 
 int db2_memory_lifecycle_mark_pending(int64_t memory_id, int ttl_days)

--- a/src/tests/test_memory_advanced.c
+++ b/src/tests/test_memory_advanced.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include "aimee.h"
@@ -2066,6 +2067,54 @@ int main(void)
       assert(memory_insert(TIER_L2, KIND_FACT, "bt:open", "never superseded", 0.9, "s-bt",
                            &open_row) == 0);
       assert(db2_memory_valid_at(open_row.id, "2099-01-01 00:00:00") == 1);
+
+      /* SAME-DAY comparison, in both spellings of a timestamp.
+       *
+       * Every assertion above passes even when the bounds are compared as plain
+       * TEXT, because 2000 and 2099 differ from the stored year in the YEAR: the
+       * comparison decides at character 2 and never reaches the separator. The
+       * bug lived at character 10. Bounds are stored ISO by now_utc()
+       * ("2026-08-09T19:07:23Z") and a caller writes "2026-08-09 23:59:59";
+       * 'T' (0x54) sorts above ' ' (0x20), so a text compare ranked the stored
+       * bound above the query and inverted the verdict. It only shows when the
+       * DATE matches and the compare gets that far -- which is why coarse
+       * decade-apart dates missed it for the whole life of the feature. */
+      char today[16];
+      {
+         time_t nowt = time(NULL);
+         struct tm tmv;
+         gmtime_r(&nowt, &tmv);
+         strftime(today, sizeof(today), "%Y-%m-%d", &tmv);
+      }
+      char iso_after[40], spaced_after[40], iso_before[40], spaced_before[40];
+      snprintf(iso_after, sizeof(iso_after), "%sT23:59:59Z", today);
+      snprintf(spaced_after, sizeof(spaced_after), "%s 23:59:59", today);
+      snprintf(iso_before, sizeof(iso_before), "%sT00:00:00Z", today);
+      snprintf(spaced_before, sizeof(spaced_before), "%s 00:00:00", today);
+
+      /* valid_until side: m closed earlier today, so a later time today is out.
+       * The spaced form is the one that read "still in force" against the bug. */
+      assert(db2_memory_valid_at(m.id, iso_after) == 0);
+      assert(db2_memory_valid_at(m.id, spaced_after) == 0);
+      assert(db2_memory_valid_at(m.id, iso_before) == 1);
+      assert(db2_memory_valid_at(m.id, spaced_before) == 1);
+
+      /* valid_from side: memory_supersede stamps the replacement's valid_from at
+       * the same instant it closes the old row's valid_until, so the intervals
+       * meet exactly -- at that instant the old row is out and the new one in,
+       * with neither a gap nor an overlap. Later today the replacement is in
+       * force; against the bug the spaced form read "not yet valid". */
+      memory_t sup_src, replacement;
+      assert(memory_insert(TIER_L2, KIND_PREFERENCE, "bt:from", "original value", 0.9, "s-bt",
+                           &sup_src) == 0);
+      assert(memory_supersede(sup_src.id, "replacement value", 0.9, "s-bt", &replacement) == 0);
+      assert(db2_memory_valid_at(replacement.id, spaced_after) == 1);
+      assert(db2_memory_valid_at(replacement.id, iso_after) == 1);
+      assert(db2_memory_valid_at(replacement.id, spaced_before) == 0);
+      assert(db2_memory_valid_at(replacement.id, iso_before) == 0);
+
+      /* The superseded original closed at that same instant. */
+      assert(db2_memory_valid_at(sup_src.id, spaced_after) == 0);
 
       printf("  bitemporal_rows: ok\n");
    }


### PR DESCRIPTION
`memory get --as-of` returned confidently wrong verdicts whenever the query landed on the **same date** as the stored bound: a superseded row read as still in force, and a row not yet valid read as valid. Found by exercising the deployed appliance after #2471.

## Root cause: the columns hold two timestamp formats

`schema.sql` declares the canonical text form as `'YYYY-MM-DD HH24:MI:SS'` and `pg_now_text()` writes that — but the C writers reach the same columns with `now_utc()`, which is ISO (`2026-08-09T19:07:23Z`):

| writer | stamp | column |
|---|---|---|
| `db2_memory_set_versioned_key` | `now_utc()` — ISO | `valid_until` |
| `db2_memory_set_valid_from` | `now_utc()` — ISO | `valid_from` |
| `db2_memory_lifecycle_update_state` | `pg_now_text()` — space | `valid_until` |

`db2_memory_valid_at` compared them as **text**, so the decision fell on character 10, where `'T'` (0x54) sorts above `' '` (0x20). Every ISO bound ranked above every space-separated value — inverting the answer in **both** directions depending on which writer had stamped the row. It failed silently: a wrong verdict is indistinguishable from a right one.

## The fix

Normalise the separator on both sides before comparing.

`replace()`/`rtrim()` rather than a `::timestamptz` cast — the DB2 unit tests run on the **SQLite shim**, where the cast is a syntax error, and both functions are spelled identically in SQLite and Postgres. Offsets other than `Z` remain textual; nothing in this tree writes one, and inventing a parser here would be guessing at data we do not produce.

A statement error now returns `-1` (unknown) instead of `0`. "Could not evaluate" is not "was not in force" — the same distinction the `-1` path already exists to preserve.

## Why the existing test missed it

It asserted across **decade-apart** dates — `2000` and `2099` against a 2026 stamp — so every comparison decided at the **year** and never reached the separator. The bug was simply unreachable from those inputs.

The new assertions use **same-day** timestamps either side of the close, in both spellings, which is the only shape that gets that far. Verified **red-before-green**: against the old SQL they fail, while the pre-existing decade-apart assertions still pass *in that same run* — which is exactly the blind spot, demonstrated rather than asserted.

## A correction to my earlier report

While diagnosing #2471 I reported a second defect: that `memory_supersede` never closes the old row's interval. **That was wrong.** `db2_memory_set_versioned_key` does stamp `valid_until`, at the same instant the replacement's `valid_from` is stamped, so the two intervals meet exactly — at that instant the old row is out and the new one in, with neither a gap nor an overlap. The apparent failure to close was this comparison bug wearing another mask. The new test asserts that closure directly, so the claim is now pinned by a test rather than by inference.

## Known latent issue (not addressed here)

The write-side format inconsistency remains: three writers, two formats. Today there is exactly **one** comparison site (this one), so behaviour is correct — but a future comparison written without normalising would be bitten. That is now documented prominently at the comparison site. Canonicalising the writers is a broader change with no behavioural gain today, so I left it out deliberately.

## Verification

- `unit-test-memory-advanced` — green → red → green (`bitemporal_rows: ok`)
- `unit-test-kb-client-memory` — still green
- `make lint` — all 48 checks pass
- `refactor_baselines`, module inventory / source-ownership / bus-boundary — all ok
