### PR TITLE
fix(memory): one timestamp parser that reads both stored spellings

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "a6c4b8fc381e18ce5448068336b722bd7689059326ac82cc4a07b2a3762b2fbf",
+      "source_sha256": "e62a9a9eb605c8c3a5ebe14b0e27bbf492a21138b6727ec12e8938773784c104",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 7,

--- a/src/db2/demotion.c
+++ b/src/db2/demotion.c
@@ -651,27 +651,12 @@ int db2_demotion_retrieval_attribution_write(const char *retrieval_event_id,
    return 0;
 }
 
-/* Parse a "YYYY-MM-DD HH:MM:SS" UTC timestamp string and return seconds since
- * epoch.  Returns 0 on parse failure (treated as ancient; no decay impact). */
-static time_t parse_utc_ts(const char *ts)
-{
-   if (!ts || !*ts)
-      return 0;
-   struct tm t;
-   memset(&t, 0, sizeof(t));
-   int n = sscanf(ts, "%d-%d-%d %d:%d:%d", &t.tm_year, &t.tm_mon, &t.tm_mday, &t.tm_hour, &t.tm_min,
-                  &t.tm_sec);
-   if (n < 3)
-      return 0;
-   t.tm_year -= 1900;
-   t.tm_mon -= 1;
-   t.tm_isdst = 0;
-#ifdef _WIN32
-   return _mkgmtime(&t);
-#else
-   return timegm(&t);
-#endif
-}
+/* Timestamp parsing is shared (parse_utc_ts in util.c). This file used to keep
+ * its own copy that matched only "YYYY-MM-DD HH:MM:SS", and these columns also
+ * hold the ISO spelling that now_utc() writes. The mismatch was silent and it
+ * mattered here more than anywhere: an unparsed stamp returns 0, the epoch,
+ * which this decay treats as ancient -- so a memory used minutes ago decayed as
+ * though it had never been used. */
 
 /* Verdict contribution: accepted → +w, negative verdicts → -w, irrelevant → 0. */
 static double verdict_sign(const char *verdict)

--- a/src/headers/aimee.h
+++ b/src/headers/aimee.h
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h> /* time_t: parse_utc_ts */
 
 /* Limits */
 #define MAX_PATH_LEN        4096
@@ -187,6 +188,19 @@ __attribute__((noreturn, format(printf, 1, 2))) void fatal(const char *fmt, ...)
 
 /* Utility: timestamp */
 void now_utc(char *buf, size_t len);
+
+/* Parse a stored UTC timestamp to epoch seconds, accepting BOTH spellings the
+ * tree writes: ISO "2026-08-09T19:07:23Z" (now_utc, from C) and the canonical
+ * text form "2026-08-09 19:07:23" (pg_now_text, from SQL). A trailing 'Z' and a
+ * missing time are both tolerated; a date alone reads as midnight.
+ *
+ * One reader must accept both because one column can hold both: the same DB2
+ * timestamp column is written by C via now_utc() and by SQL via pg_now_text(),
+ * depending on the code path that touched the row. Parsers that admitted only
+ * one spelling did not fail loudly on the other -- they returned 0, "the epoch",
+ * which reads as a real and very old time. Returns 0 when nothing parses, which
+ * keeps that existing contract for callers that treat 0 as "unknown/ancient". */
+time_t parse_utc_ts(const char *s);
 
 #include "config.h"
 #include "util.h"

--- a/src/modules/memory/memory_conflict.c
+++ b/src/modules/memory/memory_conflict.c
@@ -20,28 +20,11 @@
 #include <time.h>
 #include <unistd.h>
 
-#if !defined(AIMEE_DB2_DISABLED)
-static time_t memory_conflict_parse_utc_timestamp(const char *s)
-{
-   if (!s || !s[0])
-      return (time_t)0;
-
-   int year = 0, month = 0, day = 0, hour = 0, min = 0, sec = 0;
-   if (sscanf(s, "%d-%d-%dT%d:%d:%dZ", &year, &month, &day, &hour, &min, &sec) != 6)
-      return (time_t)0;
-
-   struct tm tm_buf;
-   memset(&tm_buf, 0, sizeof(tm_buf));
-   tm_buf.tm_year = year - 1900;
-   tm_buf.tm_mon = month - 1;
-   tm_buf.tm_mday = day;
-   tm_buf.tm_hour = hour;
-   tm_buf.tm_min = min;
-   tm_buf.tm_sec = sec;
-   tm_buf.tm_isdst = 0;
-   return timegm(&tm_buf);
-}
-#endif
+/* Timestamp parsing is shared (parse_utc_ts in util.c). The copy that lived here
+ * matched only the ISO spelling, and these columns also hold the canonical text
+ * form that pg_now_text() writes -- the exact mirror of the space-only copy that
+ * used to live in db2/demotion.c. Both returned 0 for the spelling they did not
+ * know, and 0 is a real timestamp, so neither failed loudly. */
 
 /* --- Session Folding --- */
 
@@ -186,7 +169,7 @@ static int retro_scan_due(void)
    char last[64];
    if (!db2_memory_last_retro_scan(last, sizeof(last)))
       return 1;
-   time_t last_scan = memory_conflict_parse_utc_timestamp(last);
+   time_t last_scan = parse_utc_ts(last);
    time_t now = time(NULL);
    if (last_scan > (time_t)0 && now > last_scan && (now - last_scan) < RETRO_CONFLICT_INTERVAL)
       return 0;

--- a/src/tests/test_util.c
+++ b/src/tests/test_util.c
@@ -423,8 +423,47 @@ static void test_strip_ai_attribution(void)
    assert(strcmp(buf, "line one\nline two") == 0);
 }
 
+/* parse_utc_ts must read BOTH spellings, because one DB2 column holds both: C
+ * writes ISO via now_utc(), SQL writes the canonical text form via
+ * pg_now_text(), and which one a row carries depends on the code path that last
+ * touched it.
+ *
+ * The failure this guards is silent. Two copies of this parser used to exist
+ * with OPPOSITE assumptions -- db2/demotion.c matched only the space form,
+ * modules/memory/memory_conflict.c only the ISO form -- and each returned 0 for
+ * the spelling it did not know. 0 is not an error here, it is the epoch: a real
+ * and very old time. In demotion that fed a recency decay, so a memory used
+ * minutes ago scored as though it had never been used. Asserting the two
+ * spellings produce the SAME instant is the assertion that catches it; checking
+ * "did it parse" would pass against both broken copies. */
+static void test_parse_utc_ts_accepts_both_spellings(void)
+{
+   /* 2026-08-09T19:07:23Z == 1786302443 */
+   const time_t expect = 1786302443;
+   assert(parse_utc_ts("2026-08-09T19:07:23Z") == expect);
+   assert(parse_utc_ts("2026-08-09T19:07:23") == expect);
+   assert(parse_utc_ts("2026-08-09 19:07:23") == expect);
+   /* The two spellings are the same instant -- the property that was violated. */
+   assert(parse_utc_ts("2026-08-09 19:07:23") == parse_utc_ts("2026-08-09T19:07:23Z"));
+
+   /* A date alone is midnight, not a failure. */
+   assert(parse_utc_ts("2026-08-09") == 1786233600);
+
+   /* Unparseable input stays 0: callers document 0 as "unknown/ancient", so it
+    * must not become a plausible-looking date. */
+   assert(parse_utc_ts(NULL) == 0);
+   assert(parse_utc_ts("") == 0);
+   assert(parse_utc_ts("not a timestamp") == 0);
+   assert(parse_utc_ts("2026-13-40 99:99:99") == 0);
+   /* A separator that is neither 'T' nor ' ' is not one of our formats. */
+   assert(parse_utc_ts("2026-08-09X19:07:23") == 0);
+
+   printf("  parse_utc_ts accepts both stored spellings\n");
+}
+
 int main(void)
 {
+   test_parse_utc_ts_accepts_both_spellings();
    test_normalize_key();
    test_trigram_similarity();
    test_stem_word();

--- a/src/util.c
+++ b/src/util.c
@@ -147,6 +147,41 @@ void now_utc(char *buf, size_t len)
    strftime(buf, len, "%Y-%m-%dT%H:%M:%SZ", &tm);
 }
 
+time_t parse_utc_ts(const char *s)
+{
+   if (!s || !s[0])
+      return 0;
+
+   /* Read the separator as a character rather than matching a literal, so the
+    * ISO 'T' and the canonical form's space are the same parse. This is the
+    * shape canonical_index.c already uses; the parsers that hard-coded one
+    * spelling were the ones that silently returned the epoch for the other. */
+   int year = 0, mon = 0, day = 0, hour = 0, min = 0, sec = 0;
+   char sep = 0;
+   int n = sscanf(s, "%d-%d-%d%c%d:%d:%d", &year, &mon, &day, &sep, &hour, &min, &sec);
+   if (n == 3)
+      hour = min = sec = 0; /* a date alone is midnight */
+   else if (n != 7 || (sep != 'T' && sep != ' '))
+      return 0;
+   if (year < 1970 || mon < 1 || mon > 12 || day < 1 || day > 31)
+      return 0;
+
+   struct tm tmv;
+   memset(&tmv, 0, sizeof(tmv));
+   tmv.tm_year = year - 1900;
+   tmv.tm_mon = mon - 1;
+   tmv.tm_mday = day;
+   tmv.tm_hour = hour;
+   tmv.tm_min = min;
+   tmv.tm_sec = sec;
+   tmv.tm_isdst = 0;
+#if defined(_WIN32) || defined(_WIN64)
+   return _mkgmtime(&tmv);
+#else
+   return timegm(&tmv);
+#endif
+}
+
 /* --- Filler words for normalization --- */
 
 static const char *filler_words[] = {"the",   "a",     "an",    "is",    "are",      "was",

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -227,7 +227,7 @@
         },
         {
           "path": "src/headers/aimee.h",
-          "sha256": "0e456d360e19f3ef621101d26d615fc8f86a03e3172494fe1952743bd233378c"
+          "sha256": "cb42d7fcd99d54ff226eab0b3de62045e336f5ed752c108a75235abc678660d3"
         },
         {
           "path": "src/headers/aimee_client.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "eb3c21fdcf26988c29fdace28fa6689de8c6d5caedf4b1232b3791fab66c8929",
+      "sha256": "882906d881b5ee24a22dafb15677987815de4a80cc9c37ce8a8df34a48c17553",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
DB2 timestamp columns hold **two spellings of the same instant**, because two writers reach them: C writes ISO via `now_utc()` (`2026-08-09T19:07:23Z`) and SQL writes the canonical text form via `pg_now_text()` (`2026-08-09 19:07:23`). Which one a row carries depends on the code path that last touched it — I confirmed this on the live appliance, where `created_at`/`updated_at` come back ISO despite `schema.sql` declaring the space form canonical.

## Two parsers, opposite assumptions, both silent

| copy | matched | consequence on the other spelling |
|---|---|---|
| `db2/demotion.c` | space only | returns `0` |
| `modules/memory/memory_conflict.c` | ISO only | returns `0` |

`0` is not an error here — it is **the epoch**, a real and very old time. In `demotion.c` that value feeds a recency decay, so **a memory used minutes ago scored as though it had never been used**. Neither failed loudly; both produced a confident wrong answer. Same family as #2472.

Both are replaced by `parse_utc_ts()` in `util.c`, which reads the separator as a character rather than matching a literal — the shape `canonical_index.c` already uses. A trailing `Z` is optional, a bare date reads as midnight, and anything else still returns `0`, preserving the contract callers rely on.

## Scope: readers first, writers after

This is the **enabling half** of canonicalising these timestamps, not the whole job. Making the writers agree cannot come first: the tree still has six readers that accept only the space form and three that accept only ISO, so changing either writer today would silently misparse in the others.

I measured this before choosing a direction, and it is why I did not simply "canonicalise the writers" as first framed — that ordering breaks live parsers, in a way that yields wrong dates rather than errors. With readers tolerant, a writer change becomes safe and mechanical.

## The test

It asserts the two spellings resolve to the **same instant**, which is the property that was violated. Asserting merely "it parsed" would pass against both broken copies.

**Verified red against each original parser in turn** — the space-only version fails on the ISO input, the ISO-only version fails on the space input:

```
A) space-only: Assertion `parse_utc_ts("2026-08-09T19:07:23Z") == expect' failed.
B) ISO-only:   Assertion `parse_utc_ts("2026-08-09 19:07:23")  == expect' failed.
```

Epoch constants were computed rather than hand-derived (my first attempt had an arithmetic slip that the test caught).

## Verification

- `unit-test-util` — green → red (both variants) → green
- `make lint` 48/48; `check_c_repository_lock` ok (memory-module pin refreshed with the checker's own `digest_files()`, since `memory_conflict.c` is module-owned)
- `aimee` and `aimee-server` both compile under `-Werror` and link
