### PR TITLE
Fix Aimee Git repository safety

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -77,7 +77,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "06a4010a877fed82b85a6ba6b4fd5338b377c258c02412e630fd37b18e99e806"
+      "source_sha256": "3d7b9a5f041d3b866fa9f1930d1cbbb65aaf2560423219e9dbdc4bc9aa6737fb"
     },
     {
       "id": "gateway",
@@ -203,7 +203,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "cba141c2207f0c74497d4bdd6d007b9784efafe2c820be5578109ab53aa3bd21",
+      "source_sha256": "00888a2ddbe327326b2ee20803dc01f1fdd238830d8497ebcf5d5f883da22775",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "6590540697501521a5faf1712ce4e6e0fe471a1504e751303a2f3a26ce95984d",
+      "source_sha256": "b730d2369c352985509d26a9290c397f99bcdad85694ef2ac7ebd5f1209c42fe",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -222,7 +222,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "b730d2369c352985509d26a9290c397f99bcdad85694ef2ac7ebd5f1209c42fe",
+      "source_sha256": "48c9c2fe6027aa0877f5ff072395b7bdae12ab5013e6bd1933652bde86ba8340",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -138,6 +138,24 @@ list, so a pattern-based add cannot slip a `.env` past `command=commit`.
 `branch action=switch` (keeping the worktree lock and ownership registration in one place), and
 `checkout` is `restore` when `files` is given and `switch` otherwise.
 
+### Repository selection and raw-shell boundary
+
+For MCP Git operations, an explicit `path` is repository identity, not a hint.
+It is never redirected through stale session state or replaced by a fallback
+checkout. A registered detached workspace routes Git to the client that owns
+that path; a server-visible path runs directly; an inaccessible path fails
+closed with a rebind/adopt/mount/serve explanation. This also permits Git
+operations in another registered repository's managed worktree without relying
+on shell working-directory persistence. `git_clone` is the exception because
+its `path` is a destination that may not exist yet.
+
+This repository-selection contract does not broaden raw Bash authority. The
+attention guard's session-scratchpad carve-out and its parsing of compound
+`cd`, redirects, and heredocs remain a separate subsystem; raw-shell behavior
+outside registered/managed worktrees is intentionally deferred here. Git MCP
+callers should pass `path` on each call instead of depending on a preceding
+shell `cd`, since shell working directories are not session-persistent.
+
 ### `pr action=ready`: the whole "put this up for review" errand
 
 Sync, push, open the PR. It exists because doing them separately makes the caller hold one piece of

--- a/src/branch_ownership.c
+++ b/src/branch_ownership.c
@@ -164,8 +164,8 @@ cJSON *branch_own_guard_for(const char *branch, const char *operation)
    {
       char buf[512];
       snprintf(buf, sizeof(buf),
-               "error: %s blocked — branch '%s' is owned by session %.20s. "
-               "Use git_branch action=claim to take ownership.",
+               "error: %s blocked — branch '%s' is owned by session %s. "
+               "Use branch action=claim with force=true to transfer stale ownership.",
                operation, branch, owner);
       return mcp_text(buf);
    }

--- a/src/modules/git/git_forge_vault.c
+++ b/src/modules/git/git_forge_vault.c
@@ -96,7 +96,7 @@ static int read_git_config(const char *repo_dir, const char *key, int scope, cha
    snprintf(cmd, sizeof(cmd), "%sgit -C '%s' config --get %s 2>/dev/null",
             scope == GIT_CFG_SCOPE_REPO
                 ? "GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null "
-                : "",
+                : "unset GIT_CONFIG_NOSYSTEM GIT_CONFIG_SYSTEM GIT_CONFIG_GLOBAL; ",
             dir, key);
    free(dir);
 

--- a/src/modules/git/mcp_git_branch.c
+++ b/src/modules/git/mcp_git_branch.c
@@ -34,7 +34,8 @@ cJSON *handle_git_branch(cJSON *args)
 {
    cJSON *jaction = cJSON_GetObjectItemCaseSensitive(args, "action");
    if (!cJSON_IsString(jaction))
-      return mcp_text("error: 'action' parameter is required (create/switch/list/delete/claim)");
+      return mcp_text(
+          "error: 'action' parameter is required (create/switch/list/delete/claim/release)");
 
    const char *action = jaction->valuestring;
    cJSON *jname = cJSON_GetObjectItemCaseSensitive(args, "name");
@@ -64,7 +65,7 @@ cJSON *handle_git_branch(cJSON *args)
    }
 
    if (!cJSON_IsString(jname) || !jname->valuestring[0])
-      return mcp_text("error: 'name' parameter is required for create/switch/delete");
+      return mcp_text("error: 'name' parameter is required for create/switch/delete/claim/release");
 
    char *esc_name = shell_escape(jname->valuestring);
 
@@ -165,22 +166,70 @@ cJSON *handle_git_branch(cJSON *args)
              "to create a new branch (it will be created without switching to it).");
       }
 
-      char cmd[512];
-      snprintf(cmd, sizeof(cmd), "git checkout '%s' 2>&1", esc_name);
-      int rc;
+      /* Prefer an existing local branch. If it does not exist but origin has a
+       * branch of that name, create the local branch explicitly from the
+       * remote-tracking ref and set its upstream. Do not rely on checkout's
+       * DWIM heuristic: its result changes when another remote is added. */
+      const char *requested = jname->valuestring;
+      const char *local_name = requested;
+      if (strncmp(requested, "refs/remotes/origin/", 20) == 0)
+         local_name = requested + 20;
+      else if (strncmp(requested, "refs/heads/", 11) == 0)
+         local_name = requested + 11;
+      else if (strncmp(requested, "origin/", 7) == 0)
+         local_name = requested + 7;
+      if (!local_name[0])
+      {
+         free(esc_name);
+         return mcp_text("error: branch name is required after origin/");
+      }
+      char *esc_local = shell_escape(local_name);
+      free(esc_name);
+      char probe[768];
+      int rc = 0;
+      snprintf(probe, sizeof(probe),
+               "git show-ref --verify --quiet 'refs/heads/%s' 2>/dev/null", esc_local);
+      char *probe_out = mcp_git_run(probe, &rc);
+      free(probe_out);
+      int local_exists = rc == 0;
+
+      int tracking_origin = 0;
+      if (!local_exists)
+      {
+         snprintf(probe, sizeof(probe),
+                  "git show-ref --verify --quiet 'refs/remotes/origin/%s' 2>/dev/null",
+                  esc_local);
+         probe_out = mcp_git_run(probe, &rc);
+         free(probe_out);
+         tracking_origin = rc == 0;
+      }
+
+      char cmd[1024];
+      if (tracking_origin)
+         snprintf(cmd, sizeof(cmd), "git checkout -b '%s' --track 'origin/%s' 2>&1", esc_local,
+                  esc_local);
+      else
+         snprintf(cmd, sizeof(cmd), "git checkout '%s' 2>&1", esc_local);
       char *out = mcp_git_run(cmd, &rc);
       if (rc != 0)
       {
          cJSON *r = mcp_error("error: git switch failed: %s", out ? out : "unknown");
          free(out);
-         free(esc_name);
+         free(esc_local);
          return r;
       }
       free(out);
 
-      char result[256];
-      snprintf(result, sizeof(result), "switched to %s", jname->valuestring);
-      free(esc_name);
+      int ownership_ok = !tracking_origin || branch_own_register(local_name) == 0;
+
+      char result[512];
+      if (tracking_origin)
+         snprintf(result, sizeof(result),
+                  "switched to %s (tracking origin/%s)%s", local_name, local_name,
+                  ownership_ok ? "" : "\nwarning: branch ownership could not be recorded");
+      else
+         snprintf(result, sizeof(result), "switched to %s", local_name);
+      free(esc_local);
       return mcp_text(result);
    }
 
@@ -264,12 +313,15 @@ cJSON *handle_git_branch(cJSON *args)
          return mcp_text("error: cannot claim main/master branches");
       }
       char owner[64];
-      if (!branch_own_check(jname->valuestring, owner, sizeof(owner)))
+      cJSON *jforce = cJSON_GetObjectItemCaseSensitive(args, "force");
+      int force = cJSON_IsTrue(jforce);
+      if (!branch_own_check(jname->valuestring, owner, sizeof(owner)) && !force)
       {
          char err[512];
          snprintf(err, sizeof(err),
-                  "error: branch '%s' is owned by session %.20s. "
-                  "Cannot claim a branch owned by another session.",
+                  "error: branch '%s' is owned by session %s. "
+                  "Use branch action=claim with force=true to transfer ownership, or action=release "
+                  "from the owning session.",
                   jname->valuestring, owner);
          free(esc_name);
          return mcp_text(err);
@@ -285,8 +337,31 @@ cJSON *handle_git_branch(cJSON *args)
       return mcp_text(result);
    }
 
+   if (strcmp(action, "release") == 0)
+   {
+      char owner[64] = "";
+      cJSON *jforce = cJSON_GetObjectItemCaseSensitive(args, "force");
+      int force = cJSON_IsTrue(jforce);
+      if (!branch_own_check(jname->valuestring, owner, sizeof(owner)) && !force)
+      {
+         char err[512];
+         snprintf(err, sizeof(err),
+                  "error: branch '%s' is owned by session %s. "
+                  "Use force=true to release another session's stale ownership record.",
+                  jname->valuestring, owner);
+         free(esc_name);
+         return mcp_text(err);
+      }
+      branch_own_delete(jname->valuestring);
+      char result[256];
+      snprintf(result, sizeof(result), "released ownership: %s%s", jname->valuestring,
+               force ? " (forced)" : "");
+      free(esc_name);
+      return mcp_text(result);
+   }
+
    free(esc_name);
-   return mcp_text("error: unknown action. Use create/switch/list/delete/claim");
+   return mcp_text("error: unknown action. Use create/switch/list/delete/claim/release");
 }
 
 /* --- git_stash --- */
@@ -492,6 +567,156 @@ cJSON *handle_git_tag(cJSON *args)
 
 /* --- git_fetch --- */
 
+typedef struct
+{
+   char *head_commit;
+   char *head_ref;
+   char *local_refs;
+   char *index_entries;
+   char *tracked_worktree;
+   char *untracked_contents;
+   char *status;
+} fetch_state_t;
+
+enum
+{
+   FETCH_STATE_OK = 0,
+   FETCH_STATE_HEAD_UNRESOLVED = 1,
+   FETCH_STATE_UNAVAILABLE = -1,
+};
+
+static void fetch_state_free(fetch_state_t *state)
+{
+   if (!state)
+      return;
+   free(state->head_commit);
+   free(state->head_ref);
+   free(state->local_refs);
+   free(state->index_entries);
+   free(state->tracked_worktree);
+   free(state->untracked_contents);
+   free(state->status);
+   memset(state, 0, sizeof(*state));
+}
+
+/* A fetch is allowed to move remote-tracking refs and FETCH_HEAD only. Capture
+ * every local checkout surface that must remain byte-for-byte unchanged:
+ * symbolic HEAD + its commit, every local branch ref, index entries, tracked
+ * worktree content, and untracked paths/content. Requiring a resolvable HEAD
+ * also refuses an unborn checkout before a network operation can make its
+ * recovery more confusing. */
+static void fetch_state_trim_eol(char *value)
+{
+   if (!value)
+      return;
+   size_t len = strlen(value);
+   while (len > 0 && (value[len - 1] == '\n' || value[len - 1] == '\r'))
+      value[--len] = '\0';
+}
+
+/* On success, the caller owns the allocations and must call
+ * fetch_state_free. On either failure the state is already empty. */
+static int fetch_state_capture(fetch_state_t *state)
+{
+   if (!state)
+      return -1;
+   memset(state, 0, sizeof(*state));
+
+   int rc = 0;
+   state->head_commit = mcp_git_run("git rev-parse --verify 'HEAD^{commit}' 2>/dev/null", &rc);
+   if (rc != 0 || !state->head_commit || !state->head_commit[0])
+   {
+      fetch_state_free(state);
+      char *git_dir = mcp_git_run("git rev-parse --git-dir 2>/dev/null", &rc);
+      int result = (rc == 0 && git_dir && git_dir[0]) ? FETCH_STATE_HEAD_UNRESOLVED
+                                                     : FETCH_STATE_UNAVAILABLE;
+      free(git_dir);
+      return result;
+   }
+
+   /* symbolic-ref fails for a detached HEAD; in that case the literal marker
+    * plus head_commit still distinguishes detached from attached state. */
+   state->head_ref = mcp_git_run("git symbolic-ref -q HEAD 2>/dev/null || printf DETACHED", &rc);
+   if (rc != 0 || !state->head_ref)
+      goto fail;
+
+   state->local_refs = mcp_git_run(
+       "LC_ALL=C git for-each-ref --sort=refname --format='%(refname) %(objectname)' refs/heads "
+       "2>/dev/null",
+       &rc);
+   if (rc != 0 || !state->local_refs)
+      goto fail;
+
+   state->index_entries = mcp_git_run(
+       "git ls-files --stage -z 2>/dev/null | git hash-object --stdin 2>/dev/null", &rc);
+   if (rc != 0 || !state->index_entries)
+      goto fail;
+
+   state->tracked_worktree = mcp_git_run(
+       "git diff --no-ext-diff --binary 2>/dev/null | git hash-object --stdin 2>/dev/null", &rc);
+   if (rc != 0 || !state->tracked_worktree)
+      goto fail;
+
+   /* status records the untracked path set; this additional digest detects a
+    * content change at an unchanged untracked path. -z/xargs keeps arbitrary
+    * filenames intact. Ignored files are outside Git's checkout state. */
+   state->untracked_contents = mcp_git_run(
+       "git ls-files --others --exclude-standard -z 2>/dev/null | "
+       "xargs -0 -r git hash-object -- 2>/dev/null | git hash-object --stdin 2>/dev/null",
+       &rc);
+   if (rc != 0 || !state->untracked_contents)
+      goto fail;
+
+   state->status = mcp_git_run(
+       "LC_ALL=C git status --porcelain=v1 --untracked-files=all 2>/dev/null", &rc);
+   if (rc != 0 || !state->status)
+      goto fail;
+   fetch_state_trim_eol(state->head_commit);
+   fetch_state_trim_eol(state->head_ref);
+   fetch_state_trim_eol(state->local_refs);
+   fetch_state_trim_eol(state->index_entries);
+   fetch_state_trim_eol(state->tracked_worktree);
+   fetch_state_trim_eol(state->untracked_contents);
+   fetch_state_trim_eol(state->status);
+   return FETCH_STATE_OK;
+
+fail:
+   fetch_state_free(state);
+   return FETCH_STATE_UNAVAILABLE;
+}
+
+static int fetch_state_equal(const fetch_state_t *a, const fetch_state_t *b)
+{
+   return a && b && a->head_commit && b->head_commit && a->head_ref && b->head_ref &&
+          a->local_refs && b->local_refs && a->index_entries && b->index_entries &&
+          a->tracked_worktree && b->tracked_worktree && a->untracked_contents &&
+          b->untracked_contents && a->status && b->status &&
+          strcmp(a->head_commit, b->head_commit) == 0 && strcmp(a->head_ref, b->head_ref) == 0 &&
+          strcmp(a->local_refs, b->local_refs) == 0 &&
+          strcmp(a->index_entries, b->index_entries) == 0 &&
+          strcmp(a->tracked_worktree, b->tracked_worktree) == 0 &&
+          strcmp(a->untracked_contents, b->untracked_contents) == 0 &&
+          strcmp(a->status, b->status) == 0;
+}
+
+/* The remote name is also embedded below refs/remotes/<name>. Keep that ref
+ * namespace unambiguous and reject option-looking repository arguments. */
+static int fetch_remote_name_safe(const char *remote)
+{
+   if (!remote || !remote[0] || strlen(remote) > 200 || remote[0] == '-' || remote[0] == '.' ||
+       strcmp(remote, "HEAD") == 0 || strcmp(remote, "FETCH_HEAD") == 0 ||
+       strcmp(remote, "ORIG_HEAD") == 0 || strstr(remote, "..") || strstr(remote, "@{") ||
+       strstr(remote, "//"))
+      return 0;
+   size_t len = strlen(remote);
+   if (remote[len - 1] == '/' || remote[len - 1] == '.' || strstr(remote, ".lock"))
+      return 0;
+   for (const unsigned char *p = (const unsigned char *)remote; *p; p++)
+      if (!isalnum(*p) && *p != '-' && *p != '_' && *p != '.' && *p != '/' && *p != '+')
+         return 0;
+   return 1;
+}
+
 cJSON *handle_git_fetch(cJSON *args)
 {
    cJSON *jprune = cJSON_GetObjectItemCaseSensitive(args, "prune");
@@ -501,16 +726,54 @@ cJSON *handle_git_fetch(cJSON *args)
    const char *remote =
        (cJSON_IsString(jremote) && jremote->valuestring[0]) ? jremote->valuestring : "origin";
 
+   if (!fetch_remote_name_safe(remote))
+      return mcp_error("error: %s", "fetch remote name is invalid");
+
+   fetch_state_t before;
+   int before_rc = fetch_state_capture(&before);
+   if (before_rc == FETCH_STATE_HEAD_UNRESOLVED)
+      return mcp_error("error: %s", "fetch refused because HEAD does not resolve");
+   if (before_rc != FETCH_STATE_OK)
+      return mcp_error("error: %s", "fetch refused because checkout state cannot be captured");
+
    char *esc_remote = shell_escape(remote);
-   char cmd[512];
+   char refspec[512];
+   snprintf(refspec, sizeof(refspec), "+refs/heads/*:refs/remotes/%s/*", remote);
+   char *esc_refspec = shell_escape(refspec);
+   char cmd[1024];
+   /* A positional refspec is not enough to contain --prune: Git still consults
+    * remote.<name>.fetch for its prune map. An explicitly empty --refmap
+    * suppresses that configured mapping; the one positional refspec below is
+    * then the only fetch and prune destination. */
    if (prune)
-      snprintf(cmd, sizeof(cmd), "git fetch --prune '%s' 2>&1", esc_remote);
+      snprintf(cmd, sizeof(cmd),
+               "git fetch --no-tags --no-prune-tags --prune --refmap= '%s' '%s' 2>&1",
+               esc_remote, esc_refspec);
    else
-      snprintf(cmd, sizeof(cmd), "git fetch '%s' 2>&1", esc_remote);
+      snprintf(cmd, sizeof(cmd),
+               "git fetch --no-tags --no-prune-tags --refmap= '%s' '%s' 2>&1", esc_remote,
+               esc_refspec);
    free(esc_remote);
+   free(esc_refspec);
 
    int rc;
    char *out = mcp_git_run(cmd, &rc);
+
+   fetch_state_t after;
+   int after_ok = fetch_state_capture(&after) == FETCH_STATE_OK;
+   int unchanged = after_ok && fetch_state_equal(&before, &after);
+   fetch_state_free(&after);
+   if (!unchanged)
+   {
+      cJSON *r = mcp_error(
+          "error: unsafe fetch detected: HEAD, a local branch, the index, or the worktree "
+          "changed (pre-fetch HEAD %s). Stop and inspect the checkout before continuing.",
+          before.head_commit ? before.head_commit : "unknown");
+      fetch_state_free(&before);
+      free(out);
+      return r;
+   }
+   fetch_state_free(&before);
    if (rc != 0)
    {
       cJSON *r = mcp_error("error: git fetch failed: %s", out ? out : "unknown");
@@ -519,7 +782,9 @@ cJSON *handle_git_fetch(cJSON *args)
    }
 
    char result[512];
-   snprintf(result, sizeof(result), "fetched from %s%s", remote, prune ? " (pruned)" : "");
+   snprintf(result, sizeof(result),
+            "fetched branches into refs/remotes/%s/*%s; HEAD and local checkout unchanged",
+            remote, prune ? " (pruned remote-tracking refs)" : "");
    free(out);
    return mcp_text(result);
 }

--- a/src/modules/git/mcp_git_branch.c
+++ b/src/modules/git/mcp_git_branch.c
@@ -187,8 +187,8 @@ cJSON *handle_git_branch(cJSON *args)
       free(esc_name);
       char probe[768];
       int rc = 0;
-      snprintf(probe, sizeof(probe),
-               "git show-ref --verify --quiet 'refs/heads/%s' 2>/dev/null", esc_local);
+      snprintf(probe, sizeof(probe), "git show-ref --verify --quiet 'refs/heads/%s' 2>/dev/null",
+               esc_local);
       char *probe_out = mcp_git_run(probe, &rc);
       free(probe_out);
       int local_exists = rc == 0;
@@ -197,8 +197,7 @@ cJSON *handle_git_branch(cJSON *args)
       if (!local_exists)
       {
          snprintf(probe, sizeof(probe),
-                  "git show-ref --verify --quiet 'refs/remotes/origin/%s' 2>/dev/null",
-                  esc_local);
+                  "git show-ref --verify --quiet 'refs/remotes/origin/%s' 2>/dev/null", esc_local);
          probe_out = mcp_git_run(probe, &rc);
          free(probe_out);
          tracking_origin = rc == 0;
@@ -224,8 +223,8 @@ cJSON *handle_git_branch(cJSON *args)
 
       char result[512];
       if (tracking_origin)
-         snprintf(result, sizeof(result),
-                  "switched to %s (tracking origin/%s)%s", local_name, local_name,
+         snprintf(result, sizeof(result), "switched to %s (tracking origin/%s)%s", local_name,
+                  local_name,
                   ownership_ok ? "" : "\nwarning: branch ownership could not be recorded");
       else
          snprintf(result, sizeof(result), "switched to %s", local_name);
@@ -318,11 +317,12 @@ cJSON *handle_git_branch(cJSON *args)
       if (!branch_own_check(jname->valuestring, owner, sizeof(owner)) && !force)
       {
          char err[512];
-         snprintf(err, sizeof(err),
-                  "error: branch '%s' is owned by session %s. "
-                  "Use branch action=claim with force=true to transfer ownership, or action=release "
-                  "from the owning session.",
-                  jname->valuestring, owner);
+         snprintf(
+             err, sizeof(err),
+             "error: branch '%s' is owned by session %s. "
+             "Use branch action=claim with force=true to transfer ownership, or action=release "
+             "from the owning session.",
+             jname->valuestring, owner);
          free(esc_name);
          return mcp_text(err);
       }
@@ -629,7 +629,7 @@ static int fetch_state_capture(fetch_state_t *state)
       fetch_state_free(state);
       char *git_dir = mcp_git_run("git rev-parse --git-dir 2>/dev/null", &rc);
       int result = (rc == 0 && git_dir && git_dir[0]) ? FETCH_STATE_HEAD_UNRESOLVED
-                                                     : FETCH_STATE_UNAVAILABLE;
+                                                      : FETCH_STATE_UNAVAILABLE;
       free(git_dir);
       return result;
    }
@@ -667,8 +667,8 @@ static int fetch_state_capture(fetch_state_t *state)
    if (rc != 0 || !state->untracked_contents)
       goto fail;
 
-   state->status = mcp_git_run(
-       "LC_ALL=C git status --porcelain=v1 --untracked-files=all 2>/dev/null", &rc);
+   state->status =
+       mcp_git_run("LC_ALL=C git status --porcelain=v1 --untracked-files=all 2>/dev/null", &rc);
    if (rc != 0 || !state->status)
       goto fail;
    fetch_state_trim_eol(state->head_commit);
@@ -747,12 +747,11 @@ cJSON *handle_git_fetch(cJSON *args)
     * then the only fetch and prune destination. */
    if (prune)
       snprintf(cmd, sizeof(cmd),
-               "git fetch --no-tags --no-prune-tags --prune --refmap= '%s' '%s' 2>&1",
-               esc_remote, esc_refspec);
-   else
-      snprintf(cmd, sizeof(cmd),
-               "git fetch --no-tags --no-prune-tags --refmap= '%s' '%s' 2>&1", esc_remote,
+               "git fetch --no-tags --no-prune-tags --prune --refmap= '%s' '%s' 2>&1", esc_remote,
                esc_refspec);
+   else
+      snprintf(cmd, sizeof(cmd), "git fetch --no-tags --no-prune-tags --refmap= '%s' '%s' 2>&1",
+               esc_remote, esc_refspec);
    free(esc_remote);
    free(esc_refspec);
 
@@ -783,8 +782,8 @@ cJSON *handle_git_fetch(cJSON *args)
 
    char result[512];
    snprintf(result, sizeof(result),
-            "fetched branches into refs/remotes/%s/*%s; HEAD and local checkout unchanged",
-            remote, prune ? " (pruned remote-tracking refs)" : "");
+            "fetched branches into refs/remotes/%s/*%s; HEAD and local checkout unchanged", remote,
+            prune ? " (pruned remote-tracking refs)" : "");
    free(out);
    return mcp_text(result);
 }

--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -792,16 +792,19 @@ int mcp_chdir_git_root(char *old_cwd, size_t old_cwd_len, cJSON *args, char **mi
 
    char candidates[8][MAX_PATH_LEN];
    int candidate_count = 0;
+   cJSON *jpath = args ? cJSON_GetObjectItemCaseSensitive(args, "path") : NULL;
+   int explicit_path = cJSON_IsString(jpath) && jpath->valuestring[0];
    int no_session_redirect =
-       args && cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(args, "no_session_redirect"));
+       explicit_path ||
+       (args && cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(args, "no_session_redirect")));
 
-   /* Priority 1: explicit 'path' argument from tool call */
-   if (args)
-   {
-      cJSON *jpath = cJSON_GetObjectItemCaseSensitive(args, "path");
-      if (cJSON_IsString(jpath) && jpath->valuestring[0])
-         mcp_git_add_candidate(candidates, &candidate_count, 8, jpath->valuestring);
-   }
+   /* An explicit path is an authoritative repository identity, not merely the
+    * first guess before stale session state. If it cannot be read through the
+    * active workspace provider, fail closed instead of falling through to a
+    * different checkout. Clone dispatch removes its destination path before
+    * calling this resolver because that path need not exist yet. */
+   if (explicit_path)
+      mcp_git_add_candidate(candidates, &candidate_count, 8, jpath->valuestring);
 
    /* Priority 2: session CWD tracking file (thread-safe: keyed by session_id) */
    if (!no_session_redirect)
@@ -832,7 +835,7 @@ int mcp_chdir_git_root(char *old_cwd, size_t old_cwd_len, cJSON *args, char **mi
 
    /* Priority 3: caller cwd. MCP stdio proxies may be long-lived and launched
     * from a stale directory, so this must not outrank the session cwd file. */
-   if (args)
+   if (!explicit_path && args)
    {
       cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(args, "cwd");
       if (cJSON_IsString(jcwd) && jcwd->valuestring[0])
@@ -841,12 +844,14 @@ int mcp_chdir_git_root(char *old_cwd, size_t old_cwd_len, cJSON *args, char **mi
 
    /* Priority 4: environment fallbacks. Some MCP hosts launch the stdio
     * wrapper from / but preserve a meaningful PWD or explicit override. */
+   if (!explicit_path)
    {
       mcp_git_add_candidate(candidates, &candidate_count, 8, getenv("AIMEE_MCP_CWD"));
       mcp_git_add_candidate(candidates, &candidate_count, 8, getenv("PWD"));
    }
 
    /* Priority 5: process CWD (racy in multi-session but useful as a fallback) */
+   if (!explicit_path)
    {
       char cwd_buf[MAX_PATH_LEN];
       if (getcwd(cwd_buf, sizeof(cwd_buf)))
@@ -855,6 +860,7 @@ int mcp_chdir_git_root(char *old_cwd, size_t old_cwd_len, cJSON *args, char **mi
 
    /* Priority 6: executable directory. This catches repo-local plugin/server
     * launches where the process cwd is not the checkout root. */
+   if (!explicit_path)
    {
       char exe[MAX_PATH_LEN];
       if (platform_get_exe_path(exe, sizeof(exe)) == 0)
@@ -880,7 +886,7 @@ int mcp_chdir_git_root(char *old_cwd, size_t old_cwd_len, cJSON *args, char **mi
    }
 
    if (!git_root[0])
-      return 0; /* No git repo found; run_cmd uses process CWD */
+      return explicit_path ? -2 : 0; /* Explicit identity never falls through. */
 
    /* Worktree redirect: if session has a sibling worktree for this git root,
     * point run_cmd there instead. This is the single place where worktree

--- a/src/modules/git/mcp_git_write.c
+++ b/src/modules/git/mcp_git_write.c
@@ -52,15 +52,33 @@ static int mcp_git_config_reader(const char *key, char *out, size_t out_len, voi
       return 0;
    out[0] = '\0';
 
-   char cmd[256];
-   snprintf(cmd, sizeof(cmd), "git config --get %s 2>/dev/null", key);
+   char cmd[384];
+   snprintf(cmd, sizeof(cmd), "git config --local --get %s 2>/dev/null", key);
    int rc = 0;
    char *got = mcp_git_run(cmd, &rc);
-   if (!got)
-      return 0;
    if (rc == 0)
    {
-      snprintf(out, out_len, "%s", got);
+      snprintf(out, out_len, "%s", got ? got : "");
+      out[strcspn(out, "\r\n")] = '\0';
+   }
+   free(got);
+   if (out[0])
+      return 1;
+
+   /* Delegate launchers deliberately mask ambient Git config so untrusted raw
+    * git commands cannot inherit credential helpers, hooks, or transport
+    * settings. Identity is different: read only these caller-selected
+    * user.name/user.email keys from the operator's normal global config on the
+    * same workspace runner, then pass the values back as explicit `git -c`
+    * arguments. Unmasking this read cannot alter commit behaviour. */
+   snprintf(cmd, sizeof(cmd),
+            "unset GIT_CONFIG_NOSYSTEM GIT_CONFIG_SYSTEM GIT_CONFIG_GLOBAL; "
+            "git config --global --get %s 2>/dev/null",
+            key);
+   got = mcp_git_run(cmd, &rc);
+   if (rc == 0)
+   {
+      snprintf(out, out_len, "%s", got ? got : "");
       out[strcspn(out, "\r\n")] = '\0';
    }
    free(got);

--- a/src/modules/guardrails/guardrails.c
+++ b/src/modules/guardrails/guardrails.c
@@ -418,6 +418,17 @@ static int is_sensitive_exact(const char *filename)
    return policy_list_matches_exact(&g_policy.sensitive_exact, filename);
 }
 
+/* These conventional files document configuration without carrying live
+ * credentials.  A substring rule for `.env` must not make tracked templates
+ * impossible to maintain; real environment variants (for example .env.local
+ * and .env.production) remain sensitive. */
+static int is_env_template(const char *filename)
+{
+   return filename &&
+          (strcmp(filename, ".env.example") == 0 || strcmp(filename, ".env.sample") == 0 ||
+           strcmp(filename, ".env.template") == 0);
+}
+
 static int has_db_extension(const char *filename)
 {
    const char *dot = strrchr(filename, '.');
@@ -431,6 +442,8 @@ int is_sensitive_file(const char *path)
 {
    if (!path)
       return 0;
+   if (is_env_template(basename_of(path)))
+      return 0;
    guardrails_policy_ensure_loaded();
    return policy_list_matches_substring(&g_policy.sensitive_patterns, path);
 }
@@ -443,6 +456,9 @@ classification_t classify_path(const char *file_path)
    result.severity = SEV_GREEN;
 
    const char *fname = basename_of(file_path);
+
+   if (is_env_template(fname))
+      return result;
 
    /* Check exact matches first */
    if (is_sensitive_exact(fname))

--- a/src/modules/protocols/mcp/mcp_tools.c
+++ b/src/modules/protocols/mcp/mcp_tools.c
@@ -1124,7 +1124,9 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
          const char *desc;
       } git_params[] = {
           {"action", "string",
-           "Sub-action for: branch (create/switch/list/delete/claim/orphan), pr "
+           "Sub-action for: branch (create/switch/list/delete/claim/release/orphan; claim "
+           "force=true transfers stale ownership, release drops it; switch creates a "
+           "local tracking branch from origin/<name> when needed), pr "
            "(create/view/list/edit/checks/merge_status/update_branch/merge/ready), stash "
            "(push/pop/apply/list/drop), tag (create/list/delete), issue (list), verify "
            "(run/check/conflicts/env/prepare-pr/status), merge / rebase / sync / cherry_pick / "
@@ -1142,10 +1144,14 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
            "log / diff_summary: ref or range; tag: ref to tag; reset: target ref (default "
            "HEAD~1); merge: branch or commit to merge in; cherry_pick / revert: the commit; "
            "switch / checkout: the branch or ref to move to."},
-          {"force", "boolean", "push: --force-with-lease; branch delete: -D."},
+          {"force", "boolean",
+           "push: --force-with-lease; branch delete: -D; branch claim/release: transfer or remove "
+           "another session's stale ownership record."},
           {"mirror", "boolean", "push: --mirror (DESTRUCTIVE — replaces all remote refs)."},
           {"rebase", "boolean", "pull: use --rebase."},
-          {"prune", "boolean", "fetch: prune stale remote-tracking refs."},
+          {"prune", "boolean",
+           "fetch: prune stale refs only under refs/remotes/<remote>/*; local branches are never "
+           "fetch/prune destinations."},
           {"count", "integer", "log: number of commits (default 10, max 50)."},
           {"diff_stat", "boolean", "log: include per-commit diffstat."},
           {"stat_only", "boolean", "diff_summary: file-level stats only (default true)."},
@@ -1200,8 +1206,9 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
        * so leave it untyped to accept either. */
       cJSON *rem = cJSON_AddObjectToObject(p, "remote");
       cJSON_AddStringToObject(rem, "description",
-                              "fetch: remote name (default origin); branch delete: true to also "
-                              "delete the remote branch.");
+                              "fetch: remote name (default origin), mapped explicitly to "
+                              "refs/remotes/<remote>/* regardless of remote.*.fetch config; "
+                              "branch delete: true to also delete the remote branch.");
 
       cJSON *req = cJSON_CreateArray();
       cJSON_AddItemToArray(req, cJSON_CreateString("command"));
@@ -1221,7 +1228,11 @@ static cJSON *mcp_build_tools_list_ex(int collapse)
               "conflict "
               "report the conflicted files and undo the operation, so you are never handed a "
               "half-applied tree (abort_on_conflict=false to resolve in place, then "
-              "action=continue). command=pr action=create writes its own title and body from the "
+              "action=continue). command=fetch ignores unsafe configured fetch destinations, "
+              "writes/prunes only refs/remotes/<remote>/*, and verifies that HEAD, all local "
+              "branches, the index, and worktree are unchanged. command=switch creates a local "
+              "tracking branch from origin/<branch> when it does not already exist. "
+              "command=pr action=create writes its own title and body from the "
               "branch's commits when you omit them. Remaining "
               "params apply per command (see each description); branch/pr/stash/tag/issue/"
               "verify also take an 'action' sub-selector. Use command=pr action=view to "

--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -335,6 +335,13 @@ int workspace_turn_bind_active(const char *cwd)
    return 0; /* cwd not in any registered workspace */
 }
 
+const char *workspace_turn_git_target(const char *tool, const char *path, const char *cwd)
+{
+   if ((!tool || strcmp(tool, "git_clone") != 0) && path && path[0])
+      return path;
+   return (cwd && cwd[0]) ? cwd : NULL;
+}
+
 /* Is `workspace` a tree aimee may hand a delegate? Canonicalizes into `out` and
  * returns 1 if it lives inside one of the operator's REGISTERED workspace roots.
  *

--- a/src/modules/workspace/workspace_turn.h
+++ b/src/modules/workspace/workspace_turn.h
@@ -18,6 +18,12 @@
  * pair it with workspace_turn_unbind_active after the turn), 0 otherwise. */
 int workspace_turn_bind_active(const char *cwd);
 
+/* Select the client-side repository location that a git MCP call names.
+ * `path` is authoritative for every operation except clone, where it is the
+ * destination rather than an existing repository. `cwd` remains the fallback.
+ * Pure policy seam so dispatch and tests cannot drift on path-vs-cwd priority. */
+const char *workspace_turn_git_target(const char *tool, const char *path, const char *cwd);
+
 /* Bind this thread's file/exec tools to a DELEGATE'S OWN CONTAINER for the turn:
  * acquire a container from the `docker` backend keyed by `task_id`, and route
  * td_bash / read / write / list through it. `image` may be NULL for the backend's

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -1624,35 +1624,49 @@ static cJSON *dispatch_git_tool(server_ctx_t *ctx, server_conn_t *conn, const ch
    if (sid && sid[0])
       session_id_set_override(sid);
 
-   /* A `mirror`-workspace cwd points at the CLIENT's path, which does not exist
+   /* A `mirror`-workspace target points at the CLIENT's path, which does not exist
     * server-side; remap it to the reconstructed server-side worktree (driving the
     * mirror lifecycle: ensure + reconstruct) so the git tool — e.g. `/pr` from the
-    * gateway — operates on the real tree. No-op for shared/detached workspaces. */
+    * gateway — operates on the real tree. `path` is authoritative for every git
+    * operation except clone, whose path is a destination. No-op for
+    * shared/detached workspaces. */
+   cJSON *jpath = cJSON_GetObjectItemCaseSensitive(args, "path");
+   cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(args, "cwd");
+   const char *path_arg = cJSON_IsString(jpath) ? jpath->valuestring : NULL;
+   const char *cwd_arg = cJSON_IsString(jcwd) ? jcwd->valuestring : NULL;
+   const char *git_target = workspace_turn_git_target(tool, path_arg, cwd_arg);
+   int target_is_path = git_target && path_arg && git_target == path_arg;
+   int clone_has_destination = strcmp(tool, "git_clone") == 0 && path_arg && path_arg[0];
+   const char *git_target_key = target_is_path ? "path" : "cwd";
+   char mirror_target[MAX_PATH_LEN] = "";
+   if (git_target &&
+       workspace_turn_resolve_mirror_cwd(git_target, mirror_target, sizeof(mirror_target)))
    {
-      cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(args, "cwd");
-      if (cJSON_IsString(jcwd) && jcwd->valuestring[0])
-      {
-         char work_cwd[MAX_PATH_LEN];
-         if (workspace_turn_resolve_mirror_cwd(jcwd->valuestring, work_cwd, sizeof(work_cwd)))
-            cJSON_ReplaceItemInObject(args, "cwd", cJSON_CreateString(work_cwd));
-      }
+      cJSON_ReplaceItemInObject(args, git_target_key, cJSON_CreateString(mirror_target));
+      git_target = mirror_target;
    }
 
-   /* A `detached`-workspace cwd ALSO points at the CLIENT's path (the workspace
+   /* A `detached`-workspace target ALSO points at the CLIENT's path (the workspace
     * lives on the serving client), so there is nothing to chdir into locally.
-    * Bind the detached provider for this cwd's workspace — exactly as the
+    * Bind the detached provider for this target's workspace — exactly as the
     * chat-turn boundary does — so the git tool's rev-parse / exec marshal over
     * the runner channel to the serving client, which holds the real tree (and
-    * its own creds). No-op for shared/mirror/unregistered cwds (returns 0). */
-   int detached_bound = 0;
-   {
-      cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(args, "cwd");
-      if (cJSON_IsString(jcwd) && jcwd->valuestring[0])
-         detached_bound = workspace_turn_bind_active(jcwd->valuestring);
-   }
+    * its own creds). No-op for shared/mirror/unregistered targets (returns 0). */
+   int detached_bound = git_target ? workspace_turn_bind_active(git_target) : 0;
 
    char *mismatch_err = NULL;
-   int resolved = mcp_chdir_git_root(NULL, 0, args, &mismatch_err);
+   cJSON *resolve_args = args;
+   if (clone_has_destination)
+   {
+      resolve_args = cJSON_Duplicate(args, 1);
+      if (resolve_args)
+         cJSON_DeleteItemFromObjectCaseSensitive(resolve_args, "path");
+      else
+         resolve_args = args;
+   }
+   int resolved = mcp_chdir_git_root(NULL, 0, resolve_args, &mismatch_err);
+   if (resolve_args != args)
+      cJSON_Delete(resolve_args);
 
    if (resolved < 0)
    {
@@ -1663,6 +1677,12 @@ static cJSON *dispatch_git_tool(server_ctx_t *ctx, server_conn_t *conn, const ch
          session_id_clear_override();
       if (is_verify)
          conn_active_verify(conn, verify_sid, 0);
+      if (resolved == -2)
+         return text_content(
+             "error: requested git path is outside the session checkout or unavailable through "
+             "the registered workspace runner. The explicit path was not ignored; refusing to "
+             "fall back to another checkout. Rebind/adopt that workspace, mount it into the "
+             "Aimee session, or serve it as a detached workspace.");
       return text_content("error: session worktree is unavailable (chdir failed). Refusing to run "
                           "git operation on the main repository.");
    }

--- a/src/tests/support/git_cred_inject_stub.c
+++ b/src/tests/support/git_cred_inject_stub.c
@@ -10,6 +10,8 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 char **git_cred_inject_build_env_for_repo(const char *principal, const char *remote_url,
                                           const char *repo_dir, const char *preferred_token,
@@ -76,7 +78,20 @@ int git_identity_resolve_with(const char *principal,
                               char *name_out, size_t name_len, char *email_out, size_t email_len)
 {
    (void)principal;
+   if (getenv("AIMEE_TEST_GIT_IDENTITY_FROM_CONFIG"))
+   {
+      if (!read_cfg || !read_cfg("user.name", name_out, name_len, ud) ||
+          !read_cfg("user.email", email_out, email_len, ud))
+      {
+         if (name_out && name_len)
+            name_out[0] = '\0';
+         if (email_out && email_len)
+            email_out[0] = '\0';
+         return 0;
+      }
+      return 1;
+   }
    (void)read_cfg;
-   (void)ud; /* the stub always has a sealed identity, so no fallback runs */
+   (void)ud; /* normally the stub always has a sealed identity */
    return git_identity_get(name_out, name_len, email_out, email_len);
 }

--- a/src/tests/test_git_forge_vault.c
+++ b/src/tests/test_git_forge_vault.c
@@ -153,6 +153,23 @@ int main(void)
       assert(git_identity_resolve(repo, name, sizeof(name), email, sizeof(email)) == 0);
       assert(name[0] == '\0' && email[0] == '\0');
 
+      /* The operator's normal global identity is valid too. This is the common
+       * workstation setup and must not require duplicating identity into every
+       * Aimee-managed checkout. */
+      assert(system("git config --global user.name 'Global Operator' && "
+                    "git config --global user.email 'global@example.test'") == 0);
+      setenv("GIT_CONFIG_NOSYSTEM", "1", 1);
+      setenv("GIT_CONFIG_SYSTEM", "/dev/null", 1);
+      setenv("GIT_CONFIG_GLOBAL", "/dev/null", 1);
+      assert(git_identity_resolve(repo, name, sizeof(name), email, sizeof(email)) == 1);
+      assert(strcmp(name, "Global Operator") == 0);
+      assert(strcmp(email, "global@example.test") == 0);
+      unsetenv("GIT_CONFIG_NOSYSTEM");
+      unsetenv("GIT_CONFIG_SYSTEM");
+      unsetenv("GIT_CONFIG_GLOBAL");
+      assert(system("git config --global --unset-all user.name && "
+                    "git config --global --unset-all user.email") == 0);
+
       /* Half an identity is not an identity — same rule as the vault path. */
       snprintf(cmd, sizeof(cmd), "git -C %s config user.name 'Repo Operator'", repo);
       assert(system(cmd) == 0);

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -122,6 +122,9 @@ static void test_classify_sensitive(void)
 
    c = classify_path("server.key");
    assert(c.severity == SEV_BLOCK);
+
+   c = classify_path(".env.local");
+   assert(c.severity == SEV_BLOCK);
 }
 
 static void test_classify_database(void)
@@ -139,6 +142,15 @@ static void test_classify_safe(void)
    assert(c.severity == SEV_GREEN);
 
    c = classify_path("src/handler.c");
+   assert(c.severity == SEV_GREEN);
+
+   c = classify_path(".env.example");
+   assert(c.severity == SEV_GREEN);
+
+   c = classify_path("config/.env.sample");
+   assert(c.severity == SEV_GREEN);
+
+   c = classify_path("templates/.env.template");
    assert(c.severity == SEV_GREEN);
 }
 

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -300,6 +300,7 @@ static void test_namespaced_tools_and_dispatch(void)
    int saw_skill_manage = 0;
    int saw_skill_manage_cwd = 0;
    int saw_git_path_is_universal = 0;
+   int saw_git_fetch_is_remote_tracking_only = 0;
    cJSON *tool = NULL;
    cJSON_ArrayForEach(tool, public_tools)
    {
@@ -328,6 +329,7 @@ static void test_namespaced_tools_and_dispatch(void)
        * say the param selects the repository for EVERY command. */
       if (cJSON_IsString(tool_name) && strcmp(tool_name->valuestring, "git") == 0)
       {
+         cJSON *tool_desc = cJSON_GetObjectItemCaseSensitive(tool, "description");
          cJSON *schema = cJSON_GetObjectItemCaseSensitive(tool, "inputSchema");
          cJSON *props = cJSON_GetObjectItemCaseSensitive(schema, "properties");
          cJSON *path = cJSON_GetObjectItemCaseSensitive(props, "path");
@@ -335,6 +337,13 @@ static void test_namespaced_tools_and_dispatch(void)
          if (cJSON_IsString(desc) && strstr(desc->valuestring, "every command") &&
              strstr(desc->valuestring, "SHARED checkout"))
             saw_git_path_is_universal = 1;
+         cJSON *prune = cJSON_GetObjectItemCaseSensitive(props, "prune");
+         cJSON *prune_desc = cJSON_GetObjectItemCaseSensitive(prune, "description");
+         if (cJSON_IsString(tool_desc) &&
+             strstr(tool_desc->valuestring, "writes/prunes only refs/remotes/<remote>/*") &&
+             cJSON_IsString(prune_desc) &&
+             strstr(prune_desc->valuestring, "local branches are never"))
+            saw_git_fetch_is_remote_tracking_only = 1;
       }
       if (cJSON_IsString(tool_name) && strcmp(tool_name->valuestring, "skill_manage") == 0)
       {
@@ -370,6 +379,7 @@ static void test_namespaced_tools_and_dispatch(void)
    assert(saw_skill_manage);
    assert(saw_skill_manage_cwd);
    assert(saw_git_path_is_universal);
+   assert(saw_git_fetch_is_remote_tracking_only);
    cJSON_Delete(public_tools);
 
    mcp_client_registry_shutdown();

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -12,6 +12,7 @@
 #include "session_worktree_key.h"
 #include "modules/workspace/workspace_provider.h"
 #include "modules/git/git_verify.h"
+#include "branch_ownership.h"
 #include "tests/support/git_pr_api_stub.h"
 #include "cJSON.h"
 #include "db_schema.h"
@@ -43,6 +44,7 @@ static void verify_test_write_yaml(const char *tmpdir, char *fake_home, size_t f
 static void verify_test_teardown(const char *tmpdir, const char *fake_home);
 static void setup_ownership_db(void);
 static void teardown_ownership_db(void);
+static void init_nested_git_repo(const char *path, const char *label);
 
 static void setup_git_repo(void)
 {
@@ -168,6 +170,92 @@ static void test_mcp_chdir_session_cwd_precedes_proxy_cwd(void)
 
    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tracked_repo);
    system(cmd);
+   teardown_git_repo();
+}
+
+static void test_explicit_path_is_authoritative_and_live(void)
+{
+   setup_git_repo();
+   setup_ownership_db();
+
+   assert(system("printf 'requested\\n' >> file.txt && git commit -q -am requested-head") == 0);
+
+   char stale[MAX_PATH_LEN];
+   snprintf(stale, sizeof(stale), "/tmp/aimee-test-mcp-git-stale-%d", (int)getpid());
+   init_nested_git_repo(stale, "stale-head");
+
+   const char *sid = "explicit-path-session";
+   session_id_set_override(sid);
+   session_state_t state;
+   memset(&state, 0, sizeof(state));
+   snprintf(state.session_mode, sizeof(state.session_mode), "implement");
+   snprintf(state.guardrail_mode, sizeof(state.guardrail_mode), "approve");
+   state.worktree_count = 1;
+   snprintf(state.worktrees[0].git_root, sizeof(state.worktrees[0].git_root), "%s", g_tmpdir);
+   snprintf(state.worktrees[0].worktree_path, sizeof(state.worktrees[0].worktree_path), "%s", stale);
+   session_state_force_save(&state, sid);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "path", g_tmpdir);
+   assert(mcp_chdir_git_root(NULL, 0, args, NULL) == 1);
+   cJSON *resp = handle_git_log(args);
+   char *result = get_mcp_text(resp);
+   assert(result != NULL);
+   assert(strstr(result, "requested-head") != NULL);
+   assert(strstr(result, "stale-head") == NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   /* Mutations must use the same authoritative path.  This is the direct
+    * regression for branch=create claiming success in an invisible scratch
+    * checkout while leaving the named repository untouched. */
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "path", g_tmpdir);
+   cJSON_AddStringToObject(args, "action", "create");
+   cJSON_AddStringToObject(args, "name", "path-created");
+   assert(mcp_chdir_git_root(NULL, 0, args, NULL) == 1);
+   resp = handle_git_branch(args);
+   result = get_mcp_text(resp);
+   assert(result != NULL);
+   assert(strstr(result, "created: path-created") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(system("git show-ref --verify --quiet refs/heads/path-created") == 0);
+
+   char stale_check[MAX_PATH_LEN + 96];
+   snprintf(stale_check, sizeof(stale_check),
+            "git -C '%s' show-ref --verify --quiet refs/heads/path-created", stale);
+   assert(system(stale_check) != 0);
+
+   /* Delete the stale mapped checkout, then change the requested checkout.
+    * The second call must read the new state live rather than replaying a
+    * cached response or holding the stale worktree provider. */
+   char cmd[MAX_PATH_LEN + 32];
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", stale);
+   assert(system(cmd) == 0);
+   FILE *fp = fopen("live-only.txt", "w");
+   assert(fp != NULL);
+   fputs("live\n", fp);
+   fclose(fp);
+
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "path", g_tmpdir);
+   assert(mcp_chdir_git_root(NULL, 0, args, NULL) == 1);
+   resp = handle_git_status(args);
+   result = get_mcp_text(resp);
+   assert(result != NULL);
+   assert(strstr(result, "live-only.txt") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "path", "/tmp/aimee-path-that-does-not-exist");
+   assert(mcp_chdir_git_root(NULL, 0, args, NULL) == -2);
+   cJSON_Delete(args);
+
+   run_cmd_set_cwd(NULL);
+   session_id_clear_override();
+   teardown_ownership_db();
    teardown_git_repo();
 }
 
@@ -420,6 +508,71 @@ static void test_git_commit_success(void)
    teardown_git_repo();
 }
 
+static void test_git_commit_reads_masked_global_identity(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b global-identity-test && "
+                 "git config --unset-all user.name && git config --unset-all user.email") == 0);
+
+   char fake_home[256] = "/tmp/aimee-test-git-identity-XXXXXX";
+   assert(mkdtemp(fake_home) != NULL);
+   const char *env_names[] = {"HOME", "XDG_CONFIG_HOME", "GIT_CONFIG_NOSYSTEM",
+                              "GIT_CONFIG_SYSTEM", "GIT_CONFIG_GLOBAL",
+                              "AIMEE_TEST_GIT_IDENTITY_FROM_CONFIG"};
+   char *saved[sizeof(env_names) / sizeof(env_names[0])] = {0};
+   for (size_t i = 0; i < sizeof(env_names) / sizeof(env_names[0]); i++)
+   {
+      const char *value = getenv(env_names[i]);
+      saved[i] = value ? strdup(value) : NULL;
+   }
+
+   setenv("HOME", fake_home, 1);
+   setenv("XDG_CONFIG_HOME", fake_home, 1);
+   unsetenv("GIT_CONFIG_NOSYSTEM");
+   unsetenv("GIT_CONFIG_SYSTEM");
+   unsetenv("GIT_CONFIG_GLOBAL");
+   assert(system("git config --global user.name 'Global Operator' && "
+                 "git config --global user.email 'global@example.test'") == 0);
+   setenv("GIT_CONFIG_NOSYSTEM", "1", 1);
+   setenv("GIT_CONFIG_SYSTEM", "/dev/null", 1);
+   setenv("GIT_CONFIG_GLOBAL", "/dev/null", 1);
+   setenv("AIMEE_TEST_GIT_IDENTITY_FROM_CONFIG", "1", 1);
+
+   FILE *fp = fopen("global-author.txt", "w");
+   assert(fp != NULL);
+   fputs("identity\n", fp);
+   fclose(fp);
+   assert(system("git add global-author.txt") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "message", "use global identity");
+   cJSON *resp = handle_git_commit(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "committed") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(system("test \"$(git log -1 --format='%an <%ae>')\" = "
+                 "'Global Operator <global@example.test>'") == 0);
+
+   for (size_t i = 0; i < sizeof(env_names) / sizeof(env_names[0]); i++)
+   {
+      if (saved[i])
+      {
+         setenv(env_names[i], saved[i], 1);
+         free(saved[i]);
+      }
+      else
+      {
+         unsetenv(env_names[i]);
+      }
+   }
+   char clean[320];
+   snprintf(clean, sizeof(clean), "rm -rf '%s'", fake_home);
+   assert(system(clean) == 0);
+   teardown_git_repo();
+}
+
 /* --- Test handle_git_commit with sensitive file filtering --- */
 
 static void test_git_commit_skips_sensitive(void)
@@ -583,6 +736,168 @@ static void test_git_branch_create_and_list(void)
    text = get_mcp_text(resp);
    assert(text != NULL);
    assert(strstr(text, "deleted") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+/* A repository can carry a hostile/broken remote.<name>.fetch configuration.
+ * The MCP fetch operation must override it with a remote-tracking refspec rather
+ * than trusting it to choose which local refs -- and which prune namespace --
+ * are writable. This reproduces the incident configuration exactly. */
+static void test_git_fetch_never_writes_or_prunes_local_branches(void)
+{
+   char root[] = "/tmp/aimee-test-safe-fetch-XXXXXX";
+   assert(mkdtemp(root) != NULL);
+   char remote[512], seed[512], local[512], cmd[4096];
+   snprintf(remote, sizeof(remote), "%s/remote.git", root);
+   snprintf(seed, sizeof(seed), "%s/seed", root);
+   snprintf(local, sizeof(local), "%s/local", root);
+
+   snprintf(cmd, sizeof(cmd),
+            "git init -q --bare '%s' && git init -q -b main '%s' && "
+            "git -C '%s' config user.email test@test && git -C '%s' config user.name test && "
+            "printf 'base\\n' > '%s/file.txt' && git -C '%s' add file.txt && "
+            "git -C '%s' commit -q -m base && git -C '%s' remote add origin '%s' && "
+            "git -C '%s' push -q -u origin main && "
+            "git -C '%s' checkout -q -b feature && printf 'feature\\n' > '%s/feature.txt' && "
+            "git -C '%s' add feature.txt && git -C '%s' commit -q -m feature && "
+            "git -C '%s' push -q -u origin feature && "
+            "git --git-dir='%s' symbolic-ref HEAD refs/heads/main && git clone -q '%s' '%s'",
+            remote, seed, seed, seed, seed, seed, seed, seed, remote, seed, seed, seed, seed, seed,
+            seed, remote, remote, local);
+   assert(system(cmd) == 0);
+
+   /* Advance origin/main after the clone. A fetch that falls back to the bad
+    * configured destination would now try to update refs/heads/main and fail
+    * because main is checked out. */
+   snprintf(cmd, sizeof(cmd),
+            "git -C '%s' checkout -q main && printf 'advanced\\n' >> '%s/file.txt' && "
+            "git -C '%s' commit -q -am advanced && git -C '%s' tag fetch-side-effect && "
+            "git -C '%s' push -q origin main refs/tags/fetch-side-effect",
+            seed, seed, seed, seed, seed);
+   assert(system(cmd) == 0);
+
+   char saved[4096];
+   assert(getcwd(saved, sizeof(saved)) != NULL);
+   assert(chdir(local) == 0);
+   assert(system("git config user.email test@test && git config user.name test && "
+                 "git config --replace-all remote.origin.fetch "
+                 "'+refs/heads/*:refs/heads/*' && "
+                 "git config remote.origin.pruneTags true && git tag local-keep-tag") == 0);
+
+   int local_rc = 0;
+   char *local_main_before = mcp_git_run("git rev-parse refs/heads/main", &local_rc);
+   assert(local_rc == 0);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse refs/heads/main", seed);
+   int expected_rc = 0;
+   char *expected_main = run_cmd(cmd, &expected_rc);
+   assert(local_main_before != NULL && expected_main != NULL && expected_rc == 0);
+   assert(strcmp(local_main_before, expected_main) != 0);
+
+   /* The unsafe configured refspec would try to update checked-out main and
+    * fail. The explicit safe refspec must make this fetch succeed. */
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddBoolToObject(args, "prune", 1);
+   cJSON *resp = handle_git_fetch(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL && strncmp(text, "error:", 6) != 0);
+   char *local_main_after = mcp_git_run("git rev-parse refs/heads/main", &local_rc);
+   assert(local_rc == 0);
+   char *remote_main_after = mcp_git_run("git rev-parse refs/remotes/origin/main", &local_rc);
+   assert(local_rc == 0);
+   char *configured_refspec = mcp_git_run("git config --get remote.origin.fetch", &local_rc);
+   assert(local_rc == 0);
+   assert(local_main_after != NULL && remote_main_after != NULL && configured_refspec != NULL);
+   assert(strcmp(local_main_before, local_main_after) == 0);
+   assert(strcmp(expected_main, remote_main_after) == 0);
+   assert(strcmp(configured_refspec, "+refs/heads/*:refs/heads/*\n") == 0);
+   assert(system("! git show-ref --verify --quiet refs/tags/fetch-side-effect") == 0);
+   assert(system("git show-ref --verify --quiet refs/tags/local-keep-tag") == 0);
+   free(local_main_before);
+   free(local_main_after);
+   free(remote_main_after);
+   free(expected_main);
+   free(configured_refspec);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   assert(system(
+                 "git checkout -q -b local-only && git branch keep-local && "
+                 "git update-ref refs/remotes/origin/stale HEAD && "
+                 "printf 'dirty\\n' >> file.txt && printf 'staged\\n' > staged.txt && "
+                 "git add staged.txt && printf 'untracked\\n' > untracked.txt") == 0);
+
+   char *head_before = mcp_git_run("git rev-parse HEAD", &local_rc);
+   char *status_before =
+       mcp_git_run("git status --porcelain=v1 --untracked-files=all", &local_rc);
+   char *refs_before = mcp_git_run(
+       "git for-each-ref --sort=refname --format='%(refname) %(objectname)' refs/heads", &local_rc);
+   assert(head_before != NULL && status_before != NULL && refs_before != NULL);
+
+   args = cJSON_CreateObject();
+   cJSON_AddBoolToObject(args, "prune", 1);
+   resp = handle_git_fetch(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL && strncmp(text, "error:", 6) != 0);
+
+   char *head_after = mcp_git_run("git rev-parse HEAD", &local_rc);
+   char *status_after =
+       mcp_git_run("git status --porcelain=v1 --untracked-files=all", &local_rc);
+   char *refs_after = mcp_git_run(
+       "git for-each-ref --sort=refname --format='%(refname) %(objectname)' refs/heads", &local_rc);
+   assert(head_after != NULL && status_after != NULL && refs_after != NULL);
+   assert(strcmp(head_before, head_after) == 0);
+   assert(strcmp(status_before, status_after) == 0);
+   assert(strcmp(refs_before, refs_after) == 0);
+   free(head_before);
+   free(head_after);
+   free(status_before);
+   free(status_after);
+   free(refs_before);
+   free(refs_after);
+
+   assert(system("test \"$(git symbolic-ref --short HEAD)\" = local-only && "
+                 "git show-ref --verify --quiet refs/heads/local-only && "
+                 "git show-ref --verify --quiet refs/heads/keep-local && "
+                 "git show-ref --verify --quiet refs/remotes/origin/main && "
+                 "git show-ref --verify --quiet refs/remotes/origin/feature && "
+                 "! git show-ref --verify --quiet refs/remotes/origin/stale") == 0);
+
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   assert(chdir(saved) == 0);
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", root);
+   assert(system(cmd) == 0);
+}
+
+static void test_git_fetch_refuses_unborn_head(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q --orphan unborn && git rm -q -rf .") == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *resp = handle_git_fetch(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "HEAD does not resolve") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+}
+
+static void test_git_fetch_rejects_unsafe_remote_name(void)
+{
+   setup_git_repo();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "remote", "-overwrite");
+   cJSON *resp = handle_git_fetch(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "remote name is invalid") != NULL);
    cJSON_Delete(resp);
    cJSON_Delete(args);
 
@@ -2083,6 +2398,96 @@ static void test_branch_claim(void)
    cJSON_Delete(resp);
    cJSON_Delete(args);
 
+   /* Another session gets an actionable refusal, then may explicitly transfer
+    * stale ownership rather than being trapped by the suggested claim. */
+   session_id_set_override("session-B");
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "claim");
+   cJSON_AddStringToObject(args, "name", "some-branch");
+   resp = handle_git_branch(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "session-A") != NULL);
+   assert(strstr(text, "force=true") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "claim");
+   cJSON_AddStringToObject(args, "name", "some-branch");
+   cJSON_AddBoolToObject(args, "force", 1);
+   resp = handle_git_branch(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "claimed: some-branch") != NULL);
+   char owned[256] = "";
+   assert(branch_own_get_session_branch(owned, sizeof(owned)) == 0);
+   assert(strcmp(owned, "some-branch") == 0);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   /* A non-owner cannot release silently, but force provides the documented
+    * stale-record escape hatch. */
+   session_id_set_override("session-A");
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "release");
+   cJSON_AddStringToObject(args, "name", "some-branch");
+   resp = handle_git_branch(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL && strstr(text, "force=true") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "release");
+   cJSON_AddStringToObject(args, "name", "some-branch");
+   cJSON_AddBoolToObject(args, "force", 1);
+   resp = handle_git_branch(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL && strstr(text, "released ownership") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   session_id_set_override("session-C");
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "claim");
+   cJSON_AddStringToObject(args, "name", "some-branch");
+   resp = handle_git_branch(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL && strstr(text, "claimed: some-branch") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   /* Ownership identity is (canonical repository, branch), not branch name
+    * alone. The same name in another repository must remain independently
+    * claimable without force. */
+   char other_repo[MAX_PATH_LEN];
+   snprintf(other_repo, sizeof(other_repo), "/tmp/aimee-test-owner-scope-%d", (int)getpid());
+   init_nested_git_repo(other_repo, "other-repo");
+   run_cmd_set_cwd(other_repo);
+   session_id_set_override("session-D");
+   args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "claim");
+   cJSON_AddStringToObject(args, "name", "some-branch");
+   resp = handle_git_branch(args);
+   text = get_mcp_text(resp);
+   assert(text != NULL && strstr(text, "claimed: some-branch") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   char repo_owner[64] = "";
+   char other_owner[64] = "";
+   assert(db1_git_ownership_get_owner(g_tmpdir, "some-branch", repo_owner,
+                                      sizeof(repo_owner)) == 1);
+   assert(db1_git_ownership_get_owner(other_repo, "some-branch", other_owner,
+                                      sizeof(other_owner)) == 1);
+   assert(strcmp(repo_owner, "session-C") == 0);
+   assert(strcmp(other_owner, "session-D") == 0);
+   run_cmd_set_cwd(NULL);
+   char clean[MAX_PATH_LEN + 32];
+   snprintf(clean, sizeof(clean), "rm -rf '%s'", other_repo);
+   assert(system(clean) == 0);
+
    session_id_clear_override();
    teardown_ownership_db();
    teardown_git_repo();
@@ -2532,6 +2937,31 @@ static void test_add_refuses_only_sensitive_paths(void)
    teardown_git_repo();
 }
 
+static void test_add_allows_env_templates(void)
+{
+   setup_git_repo();
+   assert(system("git checkout -q -b env-template-test") == 0);
+
+   FILE *fp = fopen(".env.example", "w");
+   assert(fp != NULL);
+   fputs("APP_PORT=3000\n", fp);
+   fclose(fp);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON *files = cJSON_AddArrayToObject(args, "files");
+   cJSON_AddItemToArray(files, cJSON_CreateString(".env.example"));
+   cJSON *resp = handle_git_add(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "staged") != NULL);
+   assert(strstr(text, "sensitive") == NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   assert(system("git diff --cached --name-only | grep -qx .env.example") == 0);
+   teardown_git_repo();
+}
+
 static void test_add_requires_files_or_all(void)
 {
    setup_git_repo();
@@ -2558,7 +2988,7 @@ static void test_switch_routes_to_branch_switch(void)
    assert(system("git branch -q target") == 0);
 
    cJSON *args = cJSON_CreateObject();
-   cJSON_AddStringToObject(args, "ref", "target");
+   cJSON_AddStringToObject(args, "ref", "refs/heads/target");
    cJSON *resp = handle_git_switch(args);
    char *text = get_mcp_text(resp);
    assert(text != NULL);
@@ -2568,6 +2998,51 @@ static void test_switch_routes_to_branch_switch(void)
 
    teardown_ownership_db();
    teardown_git_repo();
+}
+
+static void test_switch_creates_tracking_branch_from_origin(void)
+{
+   char root[] = "/tmp/aimee-test-tracking-switch-XXXXXX";
+   assert(mkdtemp(root) != NULL);
+   char remote[512], seed[512], local[512], cmd[4096];
+   snprintf(remote, sizeof(remote), "%s/remote.git", root);
+   snprintf(seed, sizeof(seed), "%s/seed", root);
+   snprintf(local, sizeof(local), "%s/local", root);
+   snprintf(cmd, sizeof(cmd),
+            "git init -q --bare '%s' && git init -q -b main '%s' && "
+            "git -C '%s' config user.email test@test && git -C '%s' config user.name test && "
+            "printf 'base\\n' > '%s/file.txt' && git -C '%s' add file.txt && "
+            "git -C '%s' commit -q -m base && git -C '%s' checkout -q -b topic && "
+            "git -C '%s' push -q '%s' main topic && "
+            "git --git-dir='%s' symbolic-ref HEAD refs/heads/main && git clone -q '%s' '%s'",
+            remote, seed, seed, seed, seed, seed, seed, seed, seed, remote, remote, remote, local);
+   assert(system(cmd) == 0);
+
+   char saved[4096];
+   assert(getcwd(saved, sizeof(saved)) != NULL);
+   assert(chdir(local) == 0);
+   setup_ownership_db();
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "ref", "refs/remotes/origin/topic");
+   cJSON *resp = handle_git_switch(args);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "tracking origin/topic") != NULL);
+   assert(system("test \"$(git symbolic-ref --short HEAD)\" = topic && "
+                 "test \"$(git rev-parse --abbrev-ref '@{upstream}')\" = origin/topic && "
+                 "test \"$(git config branch.topic.remote)\" = origin && "
+                 "test \"$(git config branch.topic.merge)\" = refs/heads/topic") == 0);
+   char owned_branch[256] = "";
+   assert(branch_own_get_session_branch(owned_branch, sizeof(owned_branch)) == 0);
+   assert(strcmp(owned_branch, "topic") == 0);
+
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+   teardown_ownership_db();
+   assert(chdir(saved) == 0);
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", root);
+   assert(system(cmd) == 0);
 }
 
 /* A path-scoped checkout is a restore, and routes there rather than moving HEAD. */
@@ -3305,6 +3780,7 @@ int main(void)
    test_git_status_modified();
    test_mcp_chdir_uses_cwd_argument();
    test_mcp_chdir_session_cwd_precedes_proxy_cwd();
+   test_explicit_path_is_authoritative_and_live();
    test_mcp_chdir_repairs_stale_delegate_tracked_cwd();
    test_mcp_chdir_keeps_stale_delegate_cwd_when_repair_missing();
    test_mcp_chdir_does_not_repair_delegate_session_cwd();
@@ -3312,11 +3788,15 @@ int main(void)
    test_mcp_chdir_uses_pwd_fallback();
    test_git_commit_missing_message();
    test_git_commit_success();
+   test_git_commit_reads_masked_global_identity();
    test_git_commit_skips_sensitive();
    test_git_container_provider_runs_on_server();
    test_git_push_requires_branch();
    test_git_branch_missing_action();
    test_git_branch_create_and_list();
+   test_git_fetch_never_writes_or_prunes_local_branches();
+   test_git_fetch_refuses_unborn_head();
+   test_git_fetch_rejects_unsafe_remote_name();
    /* test_git_log skipped: format string issue in handle_git_log */
    test_git_clone_missing_url();
    test_git_stash_unknown_action();
@@ -3404,8 +3884,10 @@ int main(void)
    /* Staging and ref movement */
    test_add_all_stages_new_files_but_not_secrets();
    test_add_refuses_only_sensitive_paths();
+   test_add_allows_env_templates();
    test_add_requires_files_or_all();
    test_switch_routes_to_branch_switch();
+   test_switch_creates_tracking_branch_from_origin();
    test_checkout_with_files_restores();
    test_switch_requires_a_ref();
 

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -192,7 +192,8 @@ static void test_explicit_path_is_authoritative_and_live(void)
    snprintf(state.guardrail_mode, sizeof(state.guardrail_mode), "approve");
    state.worktree_count = 1;
    snprintf(state.worktrees[0].git_root, sizeof(state.worktrees[0].git_root), "%s", g_tmpdir);
-   snprintf(state.worktrees[0].worktree_path, sizeof(state.worktrees[0].worktree_path), "%s", stale);
+   snprintf(state.worktrees[0].worktree_path, sizeof(state.worktrees[0].worktree_path), "%s",
+            stale);
    session_state_force_save(&state, sid);
 
    cJSON *args = cJSON_CreateObject();
@@ -516,8 +517,11 @@ static void test_git_commit_reads_masked_global_identity(void)
 
    char fake_home[256] = "/tmp/aimee-test-git-identity-XXXXXX";
    assert(mkdtemp(fake_home) != NULL);
-   const char *env_names[] = {"HOME", "XDG_CONFIG_HOME", "GIT_CONFIG_NOSYSTEM",
-                              "GIT_CONFIG_SYSTEM", "GIT_CONFIG_GLOBAL",
+   const char *env_names[] = {"HOME",
+                              "XDG_CONFIG_HOME",
+                              "GIT_CONFIG_NOSYSTEM",
+                              "GIT_CONFIG_SYSTEM",
+                              "GIT_CONFIG_GLOBAL",
                               "AIMEE_TEST_GIT_IDENTITY_FROM_CONFIG"};
    char *saved[sizeof(env_names) / sizeof(env_names[0])] = {0};
    for (size_t i = 0; i < sizeof(env_names) / sizeof(env_names[0]); i++)
@@ -823,15 +827,13 @@ static void test_git_fetch_never_writes_or_prunes_local_branches(void)
    cJSON_Delete(resp);
    cJSON_Delete(args);
 
-   assert(system(
-                 "git checkout -q -b local-only && git branch keep-local && "
+   assert(system("git checkout -q -b local-only && git branch keep-local && "
                  "git update-ref refs/remotes/origin/stale HEAD && "
                  "printf 'dirty\\n' >> file.txt && printf 'staged\\n' > staged.txt && "
                  "git add staged.txt && printf 'untracked\\n' > untracked.txt") == 0);
 
    char *head_before = mcp_git_run("git rev-parse HEAD", &local_rc);
-   char *status_before =
-       mcp_git_run("git status --porcelain=v1 --untracked-files=all", &local_rc);
+   char *status_before = mcp_git_run("git status --porcelain=v1 --untracked-files=all", &local_rc);
    char *refs_before = mcp_git_run(
        "git for-each-ref --sort=refname --format='%(refname) %(objectname)' refs/heads", &local_rc);
    assert(head_before != NULL && status_before != NULL && refs_before != NULL);
@@ -843,8 +845,7 @@ static void test_git_fetch_never_writes_or_prunes_local_branches(void)
    assert(text != NULL && strncmp(text, "error:", 6) != 0);
 
    char *head_after = mcp_git_run("git rev-parse HEAD", &local_rc);
-   char *status_after =
-       mcp_git_run("git status --porcelain=v1 --untracked-files=all", &local_rc);
+   char *status_after = mcp_git_run("git status --porcelain=v1 --untracked-files=all", &local_rc);
    char *refs_after = mcp_git_run(
        "git for-each-ref --sort=refname --format='%(refname) %(objectname)' refs/heads", &local_rc);
    assert(head_after != NULL && status_after != NULL && refs_after != NULL);
@@ -2477,8 +2478,8 @@ static void test_branch_claim(void)
 
    char repo_owner[64] = "";
    char other_owner[64] = "";
-   assert(db1_git_ownership_get_owner(g_tmpdir, "some-branch", repo_owner,
-                                      sizeof(repo_owner)) == 1);
+   assert(db1_git_ownership_get_owner(g_tmpdir, "some-branch", repo_owner, sizeof(repo_owner)) ==
+          1);
    assert(db1_git_ownership_get_owner(other_repo, "some-branch", other_owner,
                                       sizeof(other_owner)) == 1);
    assert(strcmp(repo_owner, "session-C") == 0);

--- a/src/tests/test_workspace_turn.c
+++ b/src/tests/test_workspace_turn.c
@@ -134,6 +134,14 @@ int main(void)
    assert(workspace_turn_bind_active("") == 0);
    assert(workspace_provider_active() == shared);
 
+   /* Git repository identity: explicit path beats cwd, except clone path is a
+    * not-yet-existing destination and therefore cannot select a repository. */
+   assert(strcmp(workspace_turn_git_target("git_status", "/explicit/repo", "/caller/repo"),
+                 "/explicit/repo") == 0);
+   assert(strcmp(workspace_turn_git_target("git_clone", "/new/destination", "/caller/repo"),
+                 "/caller/repo") == 0);
+   assert(workspace_turn_git_target("git_status", NULL, NULL) == NULL);
+
    /* AC #6 — foreign-cwd trust gate (pure decision). A remote peer (not
     * trusted-local) supplying a raw absolute path that did NOT bind a detached
     * provider is rejected; every other combination is allowed. */


### PR DESCRIPTION
## Summary

- make explicit `path` authoritative for every Git operation except clone, route it through detached/mirror workspace providers, and fail closed instead of falling back to stale session state
- constrain fetch/prune to `refs/remotes/<remote>/*`, disable tag pruning, snapshot local checkout state before and after fetch, and create tracking branches from `origin/<branch>`
- add force claim/release recovery for stale branch ownership while preserving repository-scoped ownership
- recover the operator's global Git author identity through the active workspace runner even when delegate safety masks ambient Git config
- allow conventional `.env.example`, `.env.sample`, and `.env.template` files while retaining protection for real environment files

## Root cause

Git dispatch selected and bound workspaces from `cwd` while the resolver treated `path` as only the first fallback candidate. Stale session mappings could therefore replace an explicitly named checkout. Fetch also trusted configured remote refmaps, allowing remote branches and pruning to target local branch refs.

The identity lookup inherited the delegate's deliberately masked global Git configuration, ownership recovery exposed no usable transfer operation, and the sensitive-file matcher treated every `.env*` filename as secret material.

## Impact

Aimee Git now either operates on the exact requested repository or returns a clear adoption/mount/runner error. Fetch cannot update or prune local branches or tags, commits can use a correctly configured operator identity, stale ownership can be recovered explicitly, and checked-in environment templates remain maintainable.

## Validation

- `unit-test-mcp-git`
- `unit-test-guardrails`
- `unit-test-workspace-turn`
- `unit-test-mcp-client-registry`
- `unit-test-git-forge-vault`
- `unit-test-attention-guard`
- compiled `server_mcp.o`
- `git diff --check`
- frozen-diff Aimee roundtable approved with no blocking findings
