### PR TITLE
ci(e2e): assert --as-of survives the server -> kb hop, seeding via the kb

### DIFF
--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -110,6 +110,27 @@ check() {
   fi
 }
 
+check_absent() {
+  # check_absent <name> <substring-that-must-NOT-appear> <curl-args...>
+  # A field that must stay OFF the wire needs its own assertion: check() only
+  # proves presence, and "no verdict was emitted" is exactly what distinguishes
+  # "you did not ask" from "the answer is no".
+  local name="$1" forbidden="$2"; shift 2
+  local body
+  if ! body="$(curl -fsS -k --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)"; then
+    red "  FAIL  $name (no response / curl error)"
+    FAIL=$((FAIL + 1))
+  elif [[ "$body" == *"$forbidden"* ]]; then
+    red   "  FAIL  $name"
+    printf '        must NOT contain: %s\n' "$forbidden"
+    printf '        got: %s\n' "$body"
+    FAIL=$((FAIL + 1))
+  else
+    green "  PASS  $name"
+    PASS=$((PASS + 1))
+  fi
+}
+
 check_status() {
   # check_status <name> <expected-http-code> <curl-args...>  (no auth header added)
   local name="$1" want="$2"; shift 2
@@ -172,6 +193,42 @@ check "GET /v1/kb/status -> kb"  '"vector"'  "${SERVER_URL}/v1/kb/status"
 check "POST /v1/kb/search -> kb" '"hits"'   -X POST -H 'content-type: application/json' \
                                             -d '{"query":"docker smoke test","scope":"all","max_results":3}' \
                                             "${SERVER_URL}/v1/kb/search"
+
+# `memory get --as-of` is a FIELD that has to survive this same hop, and it did
+# not: the server read only the id, so the timestamp was marshalled, sent, and
+# dropped here, and the client printed the row with no verdict -- indistinguishable
+# from "not in force". Unit tests at both ends passed throughout, because each was
+# checked against a payload hand-written to contain the field. Only a real
+# cross-container call catches it, so the assertion belongs in this job.
+#
+# The row is seeded through the KB'S OWN API rather than the server's, because
+# data-plane writes are refused on the server's TCP listener at the default
+# aimee.api.remote_writes=off (server_http_authz.c). Seeding direct keeps this
+# stack exactly as shipped -- turning remote writes on would test a topology
+# nobody deploys. The READ still crosses server -> kb, which is the hop at issue.
+#
+# No `-f`: an HTTP error must leave the body readable so a failure here is
+# diagnosable, and the assignment is guarded so a non-zero curl cannot trip
+# `set -e` and kill the run between checks with no message.
+as_of_seed="$(curl -sS -k --max-time 20 "${AUTH[@]}" -X POST -H 'content-type: application/json' \
+  -d '{"key":"e2e-as-of","content":"as-of smoke value","tier":"L0","kind":"fact"}' \
+  "${KB_URL}/v1/actions/memory.store" 2>&1 || true)"
+mem_id="$(printf '%s' "$as_of_seed" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+if [[ -n "$mem_id" ]]; then
+  check "POST /v1/memory/get --as-of -> kb echoes the timestamp" '"as_of"' \
+        -X POST -H 'content-type: application/json' \
+        -d "{\"id\":${mem_id},\"as_of\":\"2020-01-01T00:00:00Z\"}" "${SERVER_URL}/v1/memory/get"
+  check "POST /v1/memory/get --as-of -> kb returns a verdict" '"valid_at"' \
+        -X POST -H 'content-type: application/json' \
+        -d "{\"id\":${mem_id},\"as_of\":\"2020-01-01T00:00:00Z\"}" "${SERVER_URL}/v1/memory/get"
+  check_absent "POST /v1/memory/get without --as-of emits no verdict" '"valid_at"' \
+        -X POST -H 'content-type: application/json' \
+        -d "{\"id\":${mem_id}}" "${SERVER_URL}/v1/memory/get"
+else
+  red "  FAIL  kb memory.store did not return an id (cannot check --as-of)"
+  printf '        got: %s\n' "${as_of_seed:-<no response>}"
+  FAIL=$((FAIL + 1))
+fi
 
 bold "==> Auth is enforced"
 check_status "GET /v1/health (no bearer) rejected" 401 "${SERVER_URL}/v1/health"


### PR DESCRIPTION
Second attempt at closing the CI gap left by #2471, avoiding the wall the first one hit (#2473).

## What sank the first attempt

Data-plane writes are refused on the server's TCP listener at the default `aimee.api.remote_writes=off` (`server_http_authz.c`), so `POST /v1/memory/store` could never seed a row there. I had checked the route table's `cap 0` and concluded writes were fine — that is the *per-route* capability, while a separate global gate governs writes on the remote listener.

## What this does instead

Seed the row through the **KB's own API** (`POST /v1/actions/memory.store`) and read it back **through the server**. The write never touches the gated listener, so the stack stays exactly as shipped — turning remote writes on would have tested a topology nobody deploys — and the read still crosses `server -> kb`, which is the hop that dropped the field.

| | |
|---|---|
| `as_of` sent | response **must** carry `"as_of"` and `"valid_at"` |
| `as_of` absent | response **must not** carry `"valid_at"` |

Only the pair separates "you did not ask" from "the answer is no", and the bug looked exactly like the latter. `check_absent()` is new because `check()` can only prove presence.

## The shell defect that hid the first diagnosis

Under `set -euo pipefail`, `var="$(curl -fsS ...)"` **exits the script** when curl returns non-zero. The FAIL branch was unreachable, and the previous run died between checks with no message — the log showed four passes then teardown, which told me nothing about why.

This version drops `-f` so the body survives for the error report, and guards the assignment. Verified by driving the fragment with a curl stub returning 22:

```
RED   FAIL  kb memory.store did not return an id (cannot check --as-of)
        got: {"error":"unauthorized"}
REACHED THE END: FAIL=1   (the previous version exited silently here)
```

So even if the seed is refused for some reason I have not anticipated, this reports the body and the run continues, instead of vanishing.

## Verification

- `bash -n` clean, `make lint` 48/48, `check_c_repository_lock` ok
- `check_absent`'s three branches driven through a stubbed curl: absent passes, present fails, transport error fails rather than reading as absence
- `KB_URL` is already proven correct in this environment by the existing kb-direct health check
- the KB gates `/v1/actions` only when a bearer is configured, and the same `AUTH` header the existing checks use is presented

Still not run end to end locally — no Docker on the dev box. `e2e-docker (T2)` on this PR is the verification.
