### PR TITLE
fix(kb): route the remaining timestamp readers through the shared parser

### DIFF
--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -110,6 +110,27 @@ check() {
   fi
 }
 
+check_absent() {
+  # check_absent <name> <substring-that-must-NOT-appear> <curl-args...>
+  # A field that must stay OFF the wire needs its own assertion: check() only
+  # proves presence, and "no verdict was emitted" is exactly what distinguishes
+  # "you did not ask" from "the answer is no".
+  local name="$1" forbidden="$2"; shift 2
+  local body
+  if ! body="$(curl -fsS -k --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)"; then
+    red "  FAIL  $name (no response / curl error)"
+    FAIL=$((FAIL + 1))
+  elif [[ "$body" == *"$forbidden"* ]]; then
+    red   "  FAIL  $name"
+    printf '        must NOT contain: %s\n' "$forbidden"
+    printf '        got: %s\n' "$body"
+    FAIL=$((FAIL + 1))
+  else
+    green "  PASS  $name"
+    PASS=$((PASS + 1))
+  fi
+}
+
 check_status() {
   # check_status <name> <expected-http-code> <curl-args...>  (no auth header added)
   local name="$1" want="$2"; shift 2
@@ -172,6 +193,42 @@ check "GET /v1/kb/status -> kb"  '"vector"'  "${SERVER_URL}/v1/kb/status"
 check "POST /v1/kb/search -> kb" '"hits"'   -X POST -H 'content-type: application/json' \
                                             -d '{"query":"docker smoke test","scope":"all","max_results":3}' \
                                             "${SERVER_URL}/v1/kb/search"
+
+# `memory get --as-of` is a FIELD that has to survive this same hop, and it did
+# not: the server read only the id, so the timestamp was marshalled, sent, and
+# dropped here, and the client printed the row with no verdict -- indistinguishable
+# from "not in force". Unit tests at both ends passed throughout, because each was
+# checked against a payload hand-written to contain the field. Only a real
+# cross-container call catches it, so the assertion belongs in this job.
+#
+# The row is seeded through the KB'S OWN API rather than the server's, because
+# data-plane writes are refused on the server's TCP listener at the default
+# aimee.api.remote_writes=off (server_http_authz.c). Seeding direct keeps this
+# stack exactly as shipped -- turning remote writes on would test a topology
+# nobody deploys. The READ still crosses server -> kb, which is the hop at issue.
+#
+# No `-f`: an HTTP error must leave the body readable so a failure here is
+# diagnosable, and the assignment is guarded so a non-zero curl cannot trip
+# `set -e` and kill the run between checks with no message.
+as_of_seed="$(curl -sS -k --max-time 20 "${AUTH[@]}" -X POST -H 'content-type: application/json' \
+  -d '{"key":"e2e-as-of","content":"as-of smoke value","tier":"L0","kind":"fact"}' \
+  "${KB_URL}/v1/actions/memory.store" 2>&1 || true)"
+mem_id="$(printf '%s' "$as_of_seed" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+if [[ -n "$mem_id" ]]; then
+  check "POST /v1/memory/get --as-of -> kb echoes the timestamp" '"as_of"' \
+        -X POST -H 'content-type: application/json' \
+        -d "{\"id\":${mem_id},\"as_of\":\"2020-01-01T00:00:00Z\"}" "${SERVER_URL}/v1/memory/get"
+  check "POST /v1/memory/get --as-of -> kb returns a verdict" '"valid_at"' \
+        -X POST -H 'content-type: application/json' \
+        -d "{\"id\":${mem_id},\"as_of\":\"2020-01-01T00:00:00Z\"}" "${SERVER_URL}/v1/memory/get"
+  check_absent "POST /v1/memory/get without --as-of emits no verdict" '"valid_at"' \
+        -X POST -H 'content-type: application/json' \
+        -d "{\"id\":${mem_id}}" "${SERVER_URL}/v1/memory/get"
+else
+  red "  FAIL  kb memory.store did not return an id (cannot check --as-of)"
+  printf '        got: %s\n' "${as_of_seed:-<no response>}"
+  FAIL=$((FAIL + 1))
+fi
 
 bold "==> Auth is enforced"
 check_status "GET /v1/health (no bearer) rejected" 401 "${SERVER_URL}/v1/health"

--- a/src/cmd_doctor.c
+++ b/src/cmd_doctor.c
@@ -524,15 +524,19 @@ static void check_index(check_result_t *r, int db2_ready)
    char ts_buf[64] = {0};
    db2_code_index_project_last_scan(ts_buf, sizeof(ts_buf));
 
-   /* Parse timestamp and check if older than 24h */
+   /* Parse timestamp and check if older than 24h.
+    *
+    * parse_utc_ts rather than a local strptime: it reads both spellings the tree
+    * stores (this one matched only ISO, so a pg_now_text() row read as no
+    * timestamp at all), and it converts as UTC. mktime() interpreted these UTC
+    * fields as LOCAL time, so the age was wrong by the host's offset -- on a
+    * UTC+13 box a freshly indexed project reported as stale. */
    int stale = 0;
    if (ts_buf[0])
    {
-      struct tm tm_parsed;
-      memset(&tm_parsed, 0, sizeof(tm_parsed));
-      if (strptime(ts_buf, "%Y-%m-%dT%H:%M:%S", &tm_parsed))
+      time_t indexed_time = parse_utc_ts(ts_buf);
+      if (indexed_time > 0)
       {
-         time_t indexed_time = mktime(&tm_parsed);
          time_t now = time(NULL);
          double hours = difftime(now, indexed_time) / 3600.0;
          if (hours > 24.0)
@@ -704,15 +708,11 @@ static void check_kb_maintenance(check_result_t *r, int kb_rc, const kb_health_t
       snprintf(r->message, sizeof(r->message), "maintenance enabled but has never run");
       return;
    }
-   /* Warn if last run was more than 48 hours ago */
-   struct tm t;
-   memset(&t, 0, sizeof(t));
-   if (sscanf(h->last_maintenance_at, "%d-%d-%d %d:%d:%d", &t.tm_year, &t.tm_mon, &t.tm_mday,
-              &t.tm_hour, &t.tm_min, &t.tm_sec) >= 3)
+   /* Warn if last run was more than 48 hours ago. Shared parser: this copy read
+    * only the space form, and mktime() treated a UTC stamp as local time. */
+   time_t then = parse_utc_ts(h->last_maintenance_at);
+   if (then > 0)
    {
-      t.tm_year -= 1900;
-      t.tm_mon -= 1;
-      time_t then = mktime(&t);
       time_t now = time(NULL);
       double hours_since = difftime(now, then) / 3600.0;
       if (hours_since > 48.0)

--- a/src/cmd_infra.c
+++ b/src/cmd_infra.c
@@ -880,14 +880,10 @@ static time_t parse_db_timestamp_utc(const char *s)
 {
    if (!s || !s[0])
       return (time_t)-1;
-   struct tm tmv;
-   memset(&tmv, 0, sizeof(tmv));
-   if (sscanf(s, "%d-%d-%d %d:%d:%d", &tmv.tm_year, &tmv.tm_mon, &tmv.tm_mday, &tmv.tm_hour,
-              &tmv.tm_min, &tmv.tm_sec) != 6)
-      return (time_t)-1;
-   tmv.tm_year -= 1900;
-   tmv.tm_mon -= 1;
-   return timegm(&tmv);
+   /* Shared parser (space form only here before). Keep this function's -1
+    * sentinel: its callers distinguish "no timestamp" from a real value. */
+   time_t parsed = parse_utc_ts(s);
+   return parsed > 0 ? parsed : (time_t)-1;
 }
 
 static void session_subcmd_list(app_ctx_t *ctx, int argc, char **argv)

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -954,11 +954,11 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
                                 findex_ingested, sizeof(findex_ingested)) == 1 &&
           findex_ingested[0])
       {
-         struct tm tm_ingest;
-         memset(&tm_ingest, 0, sizeof(tm_ingest));
-         strptime(findex_ingested, "%Y-%m-%d %H:%M:%S", &tm_ingest);
-         time_t ingested_t = timegm(&tm_ingest);
-         if (fst.st_mtime < ingested_t)
+         /* Shared parser: this read only the space form AND ignored strptime's
+          * return, so an unparsed stamp left a zeroed tm and compared as the
+          * epoch -- every file then looked newer and was re-ingested. */
+         time_t ingested_t = parse_utc_ts(findex_ingested);
+         if (ingested_t > 0 && fst.st_mtime < ingested_t)
          {
             c->stats->files_skipped++;
             return;

--- a/src/kb/kb_mining.c
+++ b/src/kb/kb_mining.c
@@ -52,29 +52,15 @@ static void mining_sleep_one_second(void)
 #endif
 }
 
+/* Shared parser (parse_utc_ts in util.c). This copy matched only the space form,
+ * and these job stamps are also written in ISO by the C paths, so half of them
+ * read as "no timestamp". */
 static int parse_job_timestamp(const char *value, time_t *out)
 {
-   int year = 0, mon = 0, day = 0, hour = 0, min = 0, sec = 0;
-   if (!value || !value[0] || !out)
+   if (!out)
       return 0;
-   if (sscanf(value, "%d-%d-%d %d:%d:%d", &year, &mon, &day, &hour, &min, &sec) != 6)
-      return 0;
-
-   struct tm tmv;
-   memset(&tmv, 0, sizeof(tmv));
-   tmv.tm_year = year - 1900;
-   tmv.tm_mon = mon - 1;
-   tmv.tm_mday = day;
-   tmv.tm_hour = hour;
-   tmv.tm_min = min;
-   tmv.tm_sec = sec;
-   tmv.tm_isdst = 0;
-#ifdef AIMEE_WINDOWS
-   time_t parsed = _mkgmtime(&tmv);
-#else
-   time_t parsed = timegm(&tmv);
-#endif
-   if (parsed == (time_t)-1)
+   time_t parsed = parse_utc_ts(value);
+   if (parsed <= 0)
       return 0;
    *out = parsed;
    return 1;

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -448,20 +448,16 @@ static cJSON *kb_service_health_object(void)
    if (db2_kb_runtime_state_get("last_ingest_at", last_ingest_at, sizeof(last_ingest_at)) == 0 &&
        last_ingest_at[0])
    {
-      /* Parse ISO8601 prefix YYYY-MM-DD HH:MM:SS to compute days elapsed */
-      struct tm t;
-      memset(&t, 0, sizeof(t));
-      if (sscanf(last_ingest_at, "%d-%d-%d %d:%d:%d", &t.tm_year, &t.tm_mon, &t.tm_mday, &t.tm_hour,
-                 &t.tm_min, &t.tm_sec) >= 3)
+      /* Days elapsed. Shared parser: this read only the space form, and mktime()
+       * treated a UTC stamp as local time, skewing freshness by the host offset.
+       * An unparseable stamp must leave freshness_days at its -1 "unknown", not
+       * fall through to 0 -- "we cannot tell how old this is" and "it is current"
+       * are different answers. */
+      time_t then = parse_utc_ts(last_ingest_at);
+      if (then > 0)
       {
-         t.tm_year -= 1900;
-         t.tm_mon -= 1;
-         time_t then = mktime(&t);
          time_t now = time(NULL);
-         if (then > 0 && now > then)
-            freshness_days = (int)((now - then) / 86400);
-         else
-            freshness_days = 0;
+         freshness_days = (now > then) ? (int)((now - then) / 86400) : 0;
       }
    }
    cJSON_AddStringToObject(resp, "last_ingest_at", last_ingest_at);


### PR DESCRIPTION
Completes the readers-first half started in #2474.

Six sites still parsed a stored timestamp with a hand-rolled format, and every one reads columns that hold **both** spellings — ISO from C's `now_utc()`, the canonical text form from SQL's `pg_now_text()` — so each was wrong for half its input:

| site | what it decides | matched |
|---|---|---|
| `cmd_doctor.c` | index staleness | ISO only |
| `cmd_doctor.c` | maintenance age | space only |
| `kb/kb_mining.c` | job timestamps | space only |
| `kb/kb.c` | ingest skip check | space only |
| `kb/kb_service_kb.c` | freshness days | space only |
| `cmd_infra.c` | session listing | space only |

## Two further bugs these were hiding

**`mktime()` on UTC fields.** Three of them converted with `mktime()`, which interprets `struct tm` as **local** time. These stamps are UTC, so the computed age was off by the host's offset — on a UTC+13 box a project indexed minutes ago reports as stale. `parse_utc_ts` uses `timegm`.

**`kb/kb.c` ignored `strptime`'s return.** An unparsed stamp left a zeroed `tm` and compared as the epoch, so every file looked newer than the index and was re-ingested. It now requires a successful parse before comparing.

## Contracts preserved deliberately

- `cmd_infra.c` keeps its `(time_t)-1` sentinel — its callers distinguish "no timestamp" from a real value, and `parse_utc_ts`'s `0` is not that sentinel.
- `kb_service_kb.c` keeps `freshness_days` at its `-1` "unknown" when the stamp does not parse. **The first version of this commit got that wrong**: routing the failure into the existing `else` reported `0`, turning "we cannot tell how old this is" into "it is current". It compiled and linked cleanly — I caught it by re-reading the control flow I had restructured, not from a failure.

## Verification

- `aimee`, `aimee-server`, `aimee-kb` all compile under `-Werror` and link
- `unit-test-util` green (the shared parser's own tests, red-proven in #2474)
- `make lint` 48/48; `refactor_baselines`, `module_inventory`, `cleanup_ledger`, `pins` all ok
