### PR TITLE
fix(index): read the code-index scan timestamp in both spellings

### DIFF
--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -956,17 +956,13 @@ int db2_code_index_file_modified_since(int64_t project_id, const char *rel_path,
       const char *ts = aimee_pg_column_text(st, 0);
       if (ts)
       {
-         struct tm tmv;
-         memset(&tmv, 0, sizeof(tmv));
-         if (sscanf(ts, "%d-%d-%dT%d:%d:%d", &tmv.tm_year, &tmv.tm_mon, &tmv.tm_mday, &tmv.tm_hour,
-                    &tmv.tm_min, &tmv.tm_sec) == 6)
-         {
-            tmv.tm_year -= 1900;
-            tmv.tm_mon -= 1;
-            time_t scanned = timegm(&tmv);
-            if (scanned >= mtime)
-               modified = 0;
-         }
+         /* Shared parser: this matched only the ISO spelling, and the column also
+          * holds the canonical text form that pg_now_text() writes. An unparsed
+          * stamp left `modified` at 1, so the file was re-indexed on every scan
+          * -- wasteful rather than wrong, which is why nothing surfaced it. */
+         time_t scanned = parse_utc_ts(ts);
+         if (scanned > 0 && scanned >= mtime)
+            modified = 0;
       }
    }
    aimee_pg_finalize(st);


### PR DESCRIPTION
The last single-format reader of a DB2 timestamp column, completing the audit started in #2474 and continued in #2478.

`code_index.c` matched only the ISO spelling when deciding whether a file had changed since its last scan, and the column also holds the canonical text form `pg_now_text()` writes. An unparsed stamp left `modified` at `1`, so **the file was re-indexed on every scan**.

Wasteful rather than wrong, which is why it never surfaced — the failure mode here is redundant work, not a bad answer. It is the same defect as the `kb/kb.c` ingest-skip check in #2478, landing on the safe side of the branch.

## What this completes

Every reader of these columns is now either format-agnostic (`parse_utc_ts`, or the `%c`-separator idiom in `canonical_index.c`) or reads a date-only prefix where the separator never matters:

| state | sites |
|---|---|
| shared `parse_utc_ts` | `demotion.c`, `memory_conflict.c`, `cmd_doctor.c` ×2, `kb_mining.c`, `kb/kb.c`, `kb_service_kb.c`, `cmd_infra.c`, `code_index.c` |
| already tolerant | `kb_reflection.c`, `memory_effective.c`, `canonical_index.c` |
| date-only prefix | `memory_context.c`, `memory_core_search.c`, `memory_query.c` |
| external formats, deliberately untouched | `forge_app_token.c` (JWT), `delegate_backend_docker.c`, `delegate_sandbox_image.c` (docker output) |

That is the precondition that made writer canonicalisation unsafe to attempt first: with every reader tolerant, the two writers can now be reconciled without silently misparsing anywhere. I have **not** done that here — it is a separate change, and with readers tolerant it is now defensive rather than a bug fix.

## Verification

- `aimee-server` and `aimee-kb` compile under `-Werror` and link
- `make lint` 48/48; `refactor_baselines`, `module_inventory`, `pins` all ok
