### PR TITLE
fix(git): refresh remote mirrors before tool calls

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "7f316f6a7c6767160934a3f1ee648c357420b0faf7b129aa915d8c16a11d51d8"
+      "source_sha256": "921ad1d3efaefe480dbb2b35df7086e4acdab40f0b299f6009b61416635e308b"
     },
     {
       "id": "ir",
@@ -203,7 +203,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "00888a2ddbe327326b2ee20803dc01f1fdd238830d8497ebcf5d5f883da22775",
+      "source_sha256": "f95baadc73fbc2e6c8bdaf46fa72ce4443e0b3241bc481d80983b4c9a5a3f55e",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -574,6 +574,27 @@ static void handle_tools_call(cJSON *id, cJSON *req)
     * The helper is idempotent, so subsequent tool calls are cheap. */
    cli_workspace_reverse_channel_start();
 
+   /* A remote Git tool runs in the server's reconstructed mirror. Refresh its
+    * immutable client snapshot on every call: unchanged trees reuse the same
+    * generation (preserving server-side commits/index state), while local
+    * commits or edits select a fresh worktree. Fail closed if the refresh cannot
+    * be acknowledged; forwarding would knowingly act on stale source. */
+   if (strcmp(tool, "git") == 0 && cli_workspace_reverse_channel_sync() != 0)
+   {
+      cJSON *result = cJSON_CreateObject();
+      cJSON *content = cJSON_AddArrayToObject(result, "content");
+      cJSON *block = cJSON_CreateObject();
+      cJSON_AddStringToObject(block, "type", "text");
+      cJSON_AddStringToObject(
+          block, "text",
+          "could not refresh the remote workspace mirror; refusing to run Git against a stale "
+          "checkout. Verify the Aimee server connection and retry.");
+      cJSON_AddItemToArray(content, block);
+      cJSON_AddBoolToObject(result, "isError", 1);
+      mcp_respond(id, result);
+      return;
+   }
+
    int timeout = DEFAULT_TIMEOUT_MS;
    if (strcmp(tool, "delegate") == 0)
       timeout = DELEGATE_TIMEOUT_MS;

--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -526,6 +526,23 @@ static cJSON *marshal_workspace_mirror_sync(int argc, char **argv)
    cJSON_AddItemToObject(req, "args", args);
    cJSON_AddStringToObject(req, "head", base);
    cJSON_AddStringToObject(req, "diff", patch ? patch : "");
+   char *line = NULL;
+   const char *br[] = {"git", "-C", root, "symbolic-ref", "--quiet", "--short", "HEAD", NULL};
+   if (safe_exec_capture(br, &line, 512) == 0 && line)
+   {
+      line[strcspn(line, "\r\n")] = '\0';
+      cJSON_AddStringToObject(req, "branch", line);
+   }
+   free(line);
+   line = NULL;
+   const char *up[] = {
+       "git", "-C", root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}", NULL};
+   if (safe_exec_capture(up, &line, 512) == 0 && line)
+   {
+      line[strcspn(line, "\r\n")] = '\0';
+      cJSON_AddStringToObject(req, "upstream", line);
+   }
+   free(line);
    free(patch);
    return req;
 }

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -5,6 +5,7 @@
 
 #include "cli_v1_routes_internal.h"
 #include "platform_path.h"
+#include "platform_random.h"
 #include "cli_client.h"
 #define V1_PROTOCOL_VERSION 1
 #include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
@@ -1727,6 +1728,31 @@ static int cli_v1_mirror_sync_chunked(cJSON *req, int timeout, int json_output)
    /* Borrowed, not copied: `req` outlives this loop, and copying pulled
     * safe_strdup (util.o) into a TU whose test link line does not carry it. */
    const char *head = cJSON_IsString(jhead) ? jhead->valuestring : "";
+   cJSON *jbranch = cJSON_GetObjectItemCaseSensitive(req, "branch");
+   cJSON *jupstream = cJSON_GetObjectItemCaseSensitive(req, "upstream");
+   const char *branch = cJSON_IsString(jbranch) ? jbranch->valuestring : "";
+   const char *upstream = cJSON_IsString(jupstream) ? jupstream->valuestring : "";
+
+   /* A transfer id keeps the server's cross-request assembly ownership explicit.
+    * The server serializes transfers from their empty begin chunk through final
+    * metadata publication; without an id it could not distinguish a delayed
+    * continuation from a second client using the same workspace. */
+   unsigned char transfer_random[16];
+   char transfer[33];
+   if (platform_random_bytes(transfer_random, sizeof(transfer_random)) != 0)
+   {
+      fprintf(stderr, "aimee: workspace mirror-sync: cannot create transfer id\n");
+      free(remote);
+      free(bearer);
+      return 1;
+   }
+   static const char hex[] = "0123456789abcdef";
+   for (size_t i = 0; i < sizeof(transfer_random); i++)
+   {
+      transfer[i * 2] = hex[transfer_random[i] >> 4];
+      transfer[i * 2 + 1] = hex[transfer_random[i] & 0x0f];
+   }
+   transfer[32] = '\0';
 
    size_t sent = 0;
    int seq = 0, rc = 0;
@@ -1765,8 +1791,13 @@ static int cli_v1_mirror_sync_chunked(cJSON *req, int timeout, int json_output)
       free(slice);
       cJSON_AddNumberToObject(body, "seq", seq);
       cJSON_AddBoolToObject(body, "final", final);
+      cJSON_AddStringToObject(body, "transfer", transfer);
       if (final && head[0])
          cJSON_AddStringToObject(body, "head", head);
+      if (final && branch[0])
+         cJSON_AddStringToObject(body, "branch", branch);
+      if (final && upstream[0])
+         cJSON_AddStringToObject(body, "upstream", upstream);
 
       char *wire = cJSON_PrintUnformatted(body);
       cJSON_Delete(body);

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -169,6 +169,10 @@ int cli_workspace_serve_loop(const char *workspace_id, const char *sock, const c
  * this client. start() returns 1 if a channel was started (remote configured),
  * 0 otherwise (incl. co-located). stop() tears it down. One channel per process. */
 int cli_workspace_reverse_channel_start(void);
+/* Refresh the active mirror snapshot from the client's current Git tree.
+ * Remote Git calls use this immediately before dispatch so a long-lived MCP
+ * bridge cannot keep operating on the checkout it saw at process startup. */
+int cli_workspace_reverse_channel_sync(void);
 void cli_workspace_reverse_channel_stop(void);
 
 /* Return the path to an already-running compatible server, or NULL if none

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -306,7 +306,7 @@ typedef struct config
     * a server-side worktree) automatically. Empty for shared/detached entries.
     * Indexed alongside workspaces[]; persisted in the {path,provider,...} object. */
    char workspace_vcs_remote[64][512];
-   char workspace_vcs_head[64][64];
+   char workspace_vcs_head[64][65]; /* SHA-1/SHA-256 object id + NUL */
    /* Per-workspace delegate-sandbox image override ("" == none; fall through to the
     * global delegate_sandbox_image, then the backend default). Indexed alongside
     * workspaces[]; persisted in the {path,provider,...,sandbox_image} object. The

--- a/src/modules/config/config_accessors_4.c
+++ b/src/modules/config/config_accessors_4.c
@@ -408,7 +408,7 @@ const char *config_workspace_vcs_remote(int index)
 
 const char *config_workspace_vcs_head(int index)
 {
-   static _Thread_local char buf[64];
+   static _Thread_local char buf[65];
    buf[0] = 0;
    if (index < 0 || index >= (64))
       return buf;

--- a/src/modules/workspace/cli_workspace_serve.c
+++ b/src/modules/workspace/cli_workspace_serve.c
@@ -324,10 +324,13 @@ static void rc_chomp(char *s)
       s[--n] = '\0';
 }
 
-static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *head, size_t hcap)
+static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *head, size_t hcap,
+                            char *branch, size_t bcap, char *upstream, size_t ucap)
 {
    remote[0] = '\0';
    head[0] = '\0';
+   branch[0] = '\0';
+   upstream[0] = '\0';
    char *out = NULL;
    const char *ru[] = {"git", "-C", root, "remote", "get-url", "origin", NULL};
    if (safe_exec_capture(ru, &out, 1024) == 0 && out)
@@ -343,16 +346,38 @@ static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *h
     * shipped below, which is computed against this same base. */
    if (workspace_client_mirror_base(root, head, hcap) != 0)
       head[0] = '\0';
+   out = NULL;
+   const char *br[] = {"git", "-C", root, "symbolic-ref", "--quiet", "--short", "HEAD", NULL};
+   if (safe_exec_capture(br, &out, 512) == 0 && out)
+   {
+      snprintf(branch, bcap, "%s", out);
+      rc_chomp(branch);
+   }
+   free(out);
+   out = NULL;
+   const char *up[] = {
+       "git", "-C", root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}", NULL};
+   if (safe_exec_capture(up, &out, 512) == 0 && out)
+   {
+      snprintf(upstream, ucap, "%s", out);
+      rc_chomp(upstream);
+   }
+   free(out);
    return remote[0] && head[0];
 }
 #else
-static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *head, size_t hcap)
+static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *head, size_t hcap,
+                            char *branch, size_t bcap, char *upstream, size_t ucap)
 {
    (void)root;
    (void)rcap;
    (void)hcap;
+   (void)bcap;
+   (void)ucap;
    remote[0] = '\0';
    head[0] = '\0';
+   branch[0] = '\0';
+   upstream[0] = '\0';
    return 0;
 }
 #endif
@@ -370,27 +395,29 @@ static int rc_mirror_coords(const char *root, char *remote, size_t rcap, char *h
  *
  * Best-effort: a failure is reported, never fatal, because a tree at base is
  * still a usable (if stale) sandbox and the drift report will say so. */
-static void rc_ship_client_diff(const char *endpoint, const char *bearer, const char *root,
-                                const char *base)
+static int rc_ship_client_diff(const char *endpoint, const char *bearer, const char *root,
+                               const char *base, const char *branch, const char *upstream)
 {
    char *patch = workspace_client_diff_compute(root, base);
    cJSON *req = cJSON_CreateObject();
    if (!req)
    {
       free(patch);
-      return;
+      return -1;
    }
    cJSON_AddStringToObject(req, "method", "workspace.mirror-sync");
    cJSON *args = cJSON_CreateArray();
    cJSON_AddItemToArray(args, cJSON_CreateString(root));
    cJSON_AddItemToObject(req, "args", args);
    cJSON_AddStringToObject(req, "head", base ? base : "");
+   cJSON_AddStringToObject(req, "branch", branch ? branch : "");
+   cJSON_AddStringToObject(req, "upstream", upstream ? upstream : "");
    cJSON_AddStringToObject(req, "diff", patch ? patch : "");
    free(patch);
    char *body = cJSON_PrintUnformatted(req);
    cJSON_Delete(req);
    if (!body)
-      return;
+      return -1;
    /* Resolve the route rather than hardcode it: the method->path table is the
     * one place that mapping is maintained, and a stale copy here would fail as a
     * 404 the operator would have to trace back to a literal in this file. */
@@ -401,17 +428,22 @@ static void rc_ship_client_diff(const char *endpoint, const char *bearer, const 
       free(body);
       fprintf(stderr, "aimee: no route for workspace.mirror-sync; the server-side sandbox will "
                       "NOT contain uncommitted work\n");
-      return;
+      return -1;
    }
    int status = 0;
    cJSON *resp = cli_http_request(endpoint, verb, path, body, bearer, 60000, &status);
    free(body);
    if (status < 200 || status >= 300)
+   {
       fprintf(stderr,
               "aimee: could not ship the working-tree diff for %s (HTTP %d); the server-side "
               "sandbox will be a clean checkout at HEAD and will NOT contain uncommitted work\n",
               root, status);
+      cJSON_Delete(resp);
+      return -1;
+   }
    cJSON_Delete(resp);
+   return 0;
 }
 
 int cli_workspace_reverse_channel_start(void)
@@ -449,8 +481,9 @@ int cli_workspace_reverse_channel_start(void)
     *
     * (`aimee workspace serve` still registers `detached` explicitly. That is an
     * operator deliberately serving a tree, not an automatic default.) */
-   char ws_remote[512] = "", ws_head[128] = "";
-   if (!rc_mirror_coords(cwd, ws_remote, sizeof(ws_remote), ws_head, sizeof(ws_head)))
+   char ws_remote[512] = "", ws_head[128] = "", ws_branch[256] = "", ws_upstream[256] = "";
+   if (!rc_mirror_coords(cwd, ws_remote, sizeof(ws_remote), ws_head, sizeof(ws_head), ws_branch,
+                         sizeof(ws_branch), ws_upstream, sizeof(ws_upstream)))
    {
       fprintf(stderr,
               "aimee: %s cannot be mirrored (needs a git repository with an `origin` remote and at "
@@ -507,7 +540,7 @@ int cli_workspace_reverse_channel_start(void)
     * and an absent one is a silent clean checkout at head. Runs on the attach
     * path too ("already registered"), because a re-attaching client's tree has
     * usually moved on since the registration that created it. */
-   rc_ship_client_diff(endpoint, bearer, cwd, ws_head);
+   rc_ship_client_diff(endpoint, bearer, cwd, ws_head, ws_branch, ws_upstream);
 
    struct rc_args *a = calloc(1, sizeof(*a));
    if (!a)
@@ -569,6 +602,21 @@ int cli_workspace_reverse_channel_start(void)
    free(a);
    rc_unregister_workspace();
    return 0;
+}
+
+int cli_workspace_reverse_channel_sync(void)
+{
+   /* Co-located MCP and calls made outside a registered Git workspace need no
+    * mirror refresh.  Once a remote mirror channel is active, however, a failed
+    * refresh must stop the Git call rather than silently use its older snapshot. */
+   if (!g_rc_active)
+      return 0;
+   char head[128] = "", remote[512] = "", branch[256] = "", upstream[256] = "";
+   if (!rc_mirror_coords(g_rc_workspace_id, remote, sizeof(remote), head, sizeof(head), branch,
+                         sizeof(branch), upstream, sizeof(upstream)))
+      return -1;
+   return rc_ship_client_diff(g_rc_endpoint, g_rc_bearer, g_rc_workspace_id, head, branch,
+                              upstream);
 }
 
 void cli_workspace_reverse_channel_stop(void)

--- a/src/modules/workspace/workspace_mirror.c
+++ b/src/modules/workspace/workspace_mirror.c
@@ -5,6 +5,7 @@
 #include "workspace_mirror.h"
 #include "aimee_home.h"
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -185,6 +186,44 @@ int workspace_mirror_reconstruct(ws_git_runner_fn run, void *ctx, const char *mi
    return 0;
 }
 
+int workspace_mirror_reconstruct_branch(ws_git_runner_fn run, void *ctx, const char *remote,
+                                        const char *mirror_dir, const char *work_dir,
+                                        const char *head, const char *branch, const char *upstream,
+                                        const char *diff_path)
+{
+   if (!run || !remote || !remote[0] || !mirror_dir || !mirror_dir[0] || !work_dir ||
+       !work_dir[0] || !head || !head[0] || !branch || !branch[0])
+      return -1;
+
+   /* A normal clone has its own refs/index while sharing immutable objects with
+    * the durable mirror.  Multiple client snapshot generations may therefore
+    * retain the same logical branch name without Git's shared-worktree branch
+    * exclusion or cross-generation ref updates. */
+   const char *clone[] = {"clone", "--no-checkout", "--shared", mirror_dir, work_dir, NULL};
+   if (run(ctx, clone, NULL, 0) != 0)
+      return -1;
+   const char *set_url[] = {"-C", work_dir, "remote", "set-url", "origin", remote, NULL};
+   if (run(ctx, set_url, NULL, 0) != 0)
+      return -1;
+   const char *checkout[] = {"-C", work_dir, "checkout", "-B", branch, head, NULL};
+   if (run(ctx, checkout, NULL, 0) != 0)
+      return -1;
+   if (upstream && upstream[0])
+   {
+      const char *track[] = {"-C", work_dir, "branch", "--set-upstream-to", upstream, branch, NULL};
+      if (run(ctx, track, NULL, 0) != 0)
+         return -1;
+   }
+   if (diff_path && diff_path[0])
+   {
+      const char *apply[] = {"-C",       work_dir,  "apply", "--whitespace=nowarn",
+                             "--binary", diff_path, NULL};
+      if (run(ctx, apply, NULL, 0) != 0)
+         return -1;
+   }
+   return 0;
+}
+
 ws_mirror_drift_t workspace_mirror_drift_report(ws_git_runner_fn run, void *ctx,
                                                 const char *mirror_dir, const char *ref,
                                                 const char *client_head, char *out, size_t out_cap)
@@ -269,6 +308,177 @@ int workspace_mirror_diff_path(const char *base_dir, const char *root, char *out
    return 0;
 }
 
+static int snapshot_path(const char *base_dir, const char *root, const char *kind,
+                         unsigned long long generation, const char *digest, char *out,
+                         size_t out_cap)
+{
+   if (!base_dir || !base_dir[0] || !root || !root[0] || !kind || !kind[0] || !out)
+      return -1;
+   char hash[9];
+   fnv1a_hex8(root, hash);
+   int n = generation ? snprintf(out, out_cap, "%s/%s/%s-%llu-%s", base_dir, hash, kind, generation,
+                                 digest ? digest : "")
+                      : snprintf(out, out_cap, "%s/%s/%s", base_dir, hash, kind);
+   if (n < 0 || (size_t)n >= out_cap)
+      return -1;
+   return 0;
+}
+
+int workspace_mirror_snapshot_meta_path(const char *base_dir, const char *root, char *out,
+                                        size_t out_cap)
+{
+   return snapshot_path(base_dir, root, "client.snapshot", 0, NULL, out, out_cap);
+}
+
+int workspace_mirror_snapshot_diff_path(const char *base_dir, const char *root,
+                                        unsigned long long generation, const char *digest,
+                                        char *out, size_t out_cap)
+{
+   if (!generation || !digest || strlen(digest) != 64)
+      return -1;
+   return snapshot_path(base_dir, root, "client.diff", generation, digest, out, out_cap);
+}
+
+int workspace_mirror_snapshot_work_path(const char *base_dir, const char *root,
+                                        unsigned long long generation, const char *digest,
+                                        char *out, size_t out_cap)
+{
+   if (!generation || !digest || strlen(digest) != 64)
+      return -1;
+   return snapshot_path(base_dir, root, "work", generation, digest, out, out_cap);
+}
+
+int workspace_mirror_oid_valid(const char *oid)
+{
+   if (!oid)
+      return 0;
+   size_t len = strlen(oid);
+   if (len != 40 && len != 64)
+      return 0;
+   for (const unsigned char *p = (const unsigned char *)oid; *p; p++)
+      if (!((*p >= '0' && *p <= '9') || (*p >= 'a' && *p <= 'f')))
+         return 0;
+   return 1;
+}
+
+int workspace_mirror_ref_valid(const char *ref)
+{
+   if (!ref || !ref[0])
+      return 1;
+   size_t len = strlen(ref);
+   if (ref[0] == '-' || ref[0] == '/' || ref[len - 1] == '/' || ref[len - 1] == '.' ||
+       strcmp(ref, "@") == 0 || strstr(ref, "..") || strstr(ref, "@{") || strstr(ref, "//"))
+      return 0;
+
+   const char *component = ref;
+   for (const unsigned char *p = (const unsigned char *)ref; *p; p++)
+   {
+      if (*p <= 0x20 || *p == 0x7f || *p == '\\' || *p == '~' || *p == '^' || *p == ':' ||
+          *p == '?' || *p == '*' || *p == '[')
+         return 0;
+      if ((const char *)p == component && *p == '.')
+         return 0;
+      if (*p == '/')
+      {
+         size_t component_len = (const char *)p - component;
+         if (component_len >= 5 && memcmp(p - 5, ".lock", 5) == 0)
+            return 0;
+         component = (const char *)p + 1;
+      }
+   }
+   size_t component_len = ref + len - component;
+   return !(component_len >= 5 && memcmp(ref + len - 5, ".lock", 5) == 0);
+}
+
+int workspace_mirror_snapshot_parse(const char *text, ws_mirror_snapshot_t *out)
+{
+   if (!text || !out)
+      return -1;
+   memset(out, 0, sizeof(*out));
+   char branch[256] = "-", upstream[256] = "-", extra = '\0';
+   int fields = sscanf(text, "%llu %64[a-f0-9] %64[a-f0-9] %255s %255s %llu %c", &out->generation,
+                       out->digest, out->head, branch, upstream, &out->sync_order, &extra);
+   if ((fields != 3 && fields != 5 && fields != 6) || !out->generation ||
+       strlen(out->digest) != 64 || !workspace_mirror_oid_valid(out->head) ||
+       (fields == 6 && !out->sync_order))
+   {
+      memset(out, 0, sizeof(*out));
+      return -1;
+   }
+   if (fields >= 5)
+   {
+      if (strcmp(branch, "-") != 0)
+         snprintf(out->branch, sizeof(out->branch), "%s", branch);
+      if (strcmp(upstream, "-") != 0)
+         snprintf(out->upstream, sizeof(out->upstream), "%s", upstream);
+   }
+   return 0;
+}
+
+static int transfer_id_valid(const char *transfer)
+{
+   if (!transfer || strlen(transfer) != 32)
+      return 0;
+   for (const unsigned char *p = (const unsigned char *)transfer; *p; p++)
+      if (!((*p >= '0' && *p <= '9') || (*p >= 'a' && *p <= 'f')))
+         return 0;
+   return 1;
+}
+
+int workspace_mirror_transfer_paths(const char *base_dir, const char *root, const char *transfer,
+                                    char *assembly, size_t assembly_cap, char *state,
+                                    size_t state_cap, char *lock, size_t lock_cap, char *counter,
+                                    size_t counter_cap)
+{
+   if (!base_dir || !base_dir[0] || !root || !root[0] || !transfer_id_valid(transfer) ||
+       !assembly || !state || !lock || !counter)
+      return -1;
+   char hash[9];
+   fnv1a_hex8(root, hash);
+   int a = snprintf(assembly, assembly_cap, "%s/%s/client.diff.%s", base_dir, hash, transfer);
+   int s = snprintf(state, state_cap, "%s/%s/client.sync.%s", base_dir, hash, transfer);
+   int l = snprintf(lock, lock_cap, "%s/%s/client.sync.lock", base_dir, hash);
+   int c = snprintf(counter, counter_cap, "%s/%s/client.sync.counter", base_dir, hash);
+   return a < 0 || (size_t)a >= assembly_cap || s < 0 || (size_t)s >= state_cap || l < 0 ||
+                  (size_t)l >= lock_cap || c < 0 || (size_t)c >= counter_cap
+              ? -1
+              : 0;
+}
+
+int workspace_mirror_transfer_state_parse(const char *text, ws_mirror_transfer_state_t *out)
+{
+   if (!text || !out)
+      return -1;
+   memset(out, 0, sizeof(*out));
+   char extra = '\0';
+   int fields = sscanf(text, "%llu %u %c", &out->order, &out->next_seq, &extra);
+   if (fields != 2 || !out->order || !out->next_seq)
+   {
+      memset(out, 0, sizeof(*out));
+      return -1;
+   }
+   return 0;
+}
+
+int workspace_mirror_snapshot_next_generation(const ws_mirror_snapshot_t *current, int have_current,
+                                              unsigned long long order, const char *digest,
+                                              unsigned long long *generation_out)
+{
+   if (!order || !digest || strlen(digest) != 64 || !generation_out || (have_current && !current))
+      return -1;
+   if (have_current && current->sync_order > order)
+      return -1; /* a later-started transfer has already published */
+   if (have_current && strcmp(current->digest, digest) == 0)
+      *generation_out = current->generation;
+   else
+   {
+      if (have_current && current->generation == ULLONG_MAX)
+         return -1;
+      *generation_out = have_current ? current->generation + 1 : 1;
+   }
+   return 0;
+}
+
 int workspace_mirror_session_setup(ws_git_runner_fn run, void *ctx, const char *remote,
                                    const char *head, const char *mirror_dir, const char *work_dir,
                                    const char *diff_path, int already_materialized, char *drift_out,
@@ -302,5 +512,37 @@ int workspace_mirror_session_setup(ws_git_runner_fn run, void *ctx, const char *
        workspace_mirror_reconstruct(run, ctx, mirror_dir, work_dir, head, diff_path) != 0)
       return -1;
 
+   return 0;
+}
+
+int workspace_mirror_session_setup_branch(ws_git_runner_fn run, void *ctx, const char *remote,
+                                          const char *head, const char *branch,
+                                          const char *upstream, const char *mirror_dir,
+                                          const char *work_dir, const char *diff_path,
+                                          int already_materialized, char *drift_out,
+                                          size_t drift_cap, ws_mirror_drift_t *verdict_out)
+{
+   if (!branch || !branch[0])
+      return workspace_mirror_session_setup(run, ctx, remote, head, mirror_dir, work_dir, diff_path,
+                                            already_materialized, drift_out, drift_cap,
+                                            verdict_out);
+   if (drift_out && drift_cap)
+      drift_out[0] = '\0';
+   if (verdict_out)
+      *verdict_out = WS_MIRROR_DRIFT_UNKNOWN;
+   if (!run || !mirror_dir || !mirror_dir[0] || !work_dir || !work_dir[0] || !head || !head[0])
+      return -1;
+   if (!already_materialized && (!remote || !remote[0]))
+      return -1;
+   if (!already_materialized && workspace_mirror_ensure(run, ctx, remote, mirror_dir) != 0)
+      return -1;
+   ws_mirror_drift_t d =
+       workspace_mirror_drift_report(run, ctx, mirror_dir, "HEAD", head, drift_out, drift_cap);
+   if (verdict_out)
+      *verdict_out = d;
+   if (!already_materialized &&
+       workspace_mirror_reconstruct_branch(run, ctx, remote, mirror_dir, work_dir, head, branch,
+                                           upstream, diff_path) != 0)
+      return -1;
    return 0;
 }

--- a/src/modules/workspace/workspace_mirror.h
+++ b/src/modules/workspace/workspace_mirror.h
@@ -112,6 +112,64 @@ int workspace_mirror_paths(const char *base_dir, const char *root, char *mirror_
  * returns 0 on success, -1 on bad args / truncation. */
 int workspace_mirror_diff_path(const char *base_dir, const char *root, char *out, size_t out_cap);
 
+/* A mirror-sync snapshot is immutable once published.  The tiny metadata file
+ * names its generation, content digest, and fetchable base head; the matching
+ * diff and reconstructed worktree are generation-qualified.  A new client tree
+ * therefore materializes beside an older server-side Git session instead of
+ * destructively reusing its worktree. */
+typedef struct
+{
+   unsigned long long generation;
+   unsigned long long sync_order;
+   char digest[65];
+   char head[65];
+   char branch[256];
+   char upstream[256];
+} ws_mirror_snapshot_t;
+
+typedef struct
+{
+   unsigned long long order;
+   unsigned next_seq;
+} ws_mirror_transfer_state_t;
+
+int workspace_mirror_snapshot_meta_path(const char *base_dir, const char *root, char *out,
+                                        size_t out_cap);
+int workspace_mirror_snapshot_diff_path(const char *base_dir, const char *root,
+                                        unsigned long long generation, const char *digest,
+                                        char *out, size_t out_cap);
+int workspace_mirror_snapshot_work_path(const char *base_dir, const char *root,
+                                        unsigned long long generation, const char *digest,
+                                        char *out, size_t out_cap);
+/* Git object IDs are lowercase hex and currently use SHA-1 (40 chars) or the
+ * repository-format SHA-256 form (64 chars). */
+int workspace_mirror_oid_valid(const char *oid);
+/* Conservative git-check-ref-format equivalent for branch/upstream names used
+ * as argv by reconstruction. Empty is allowed for detached snapshots. */
+int workspace_mirror_ref_valid(const char *ref);
+int workspace_mirror_snapshot_parse(const char *text, ws_mirror_snapshot_t *out);
+
+/* Durable chunk-transfer coordinates. Each transfer owns a separate assembly
+ * and state file, while lock/counter are shared by the workspace. This lets a
+ * continuation land on another server process without losing ownership. */
+int workspace_mirror_transfer_paths(const char *base_dir, const char *root, const char *transfer,
+                                    char *assembly, size_t assembly_cap, char *state,
+                                    size_t state_cap, char *lock, size_t lock_cap, char *counter,
+                                    size_t counter_cap);
+int workspace_mirror_transfer_state_parse(const char *text, ws_mirror_transfer_state_t *out);
+int workspace_mirror_snapshot_next_generation(const ws_mirror_snapshot_t *current, int have_current,
+                                              unsigned long long order, const char *digest,
+                                              unsigned long long *generation_out);
+
+/* Materialize a Git-capable client snapshot as an independent local clone of
+ * the durable bare mirror.  Unlike `git worktree add --detach`, this preserves
+ * the client's branch name and upstream, and independent clones allow older
+ * snapshot generations to retain their own branch/index state. */
+int workspace_mirror_reconstruct_branch(ws_git_runner_fn run, void *ctx, const char *remote,
+                                        const char *mirror_dir, const char *work_dir,
+                                        const char *head, const char *branch, const char *upstream,
+                                        const char *diff_path);
+
 /* Drive the mirror lifecycle for a detached session, from the registry's VCS
  * coordinates (workspace-resource-plane §3 — the wiring AC #5 turns on):
  *
@@ -137,5 +195,12 @@ int workspace_mirror_session_setup(ws_git_runner_fn run, void *ctx, const char *
                                    const char *head, const char *mirror_dir, const char *work_dir,
                                    const char *diff_path, int already_materialized, char *drift_out,
                                    size_t drift_cap, ws_mirror_drift_t *verdict_out);
+
+int workspace_mirror_session_setup_branch(ws_git_runner_fn run, void *ctx, const char *remote,
+                                          const char *head, const char *branch,
+                                          const char *upstream, const char *mirror_dir,
+                                          const char *work_dir, const char *diff_path,
+                                          int already_materialized, char *drift_out,
+                                          size_t drift_cap, ws_mirror_drift_t *verdict_out);
 
 #endif /* WORKSPACE_MIRROR_H */

--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -147,6 +147,56 @@ static int mirror_reconstruct_cwd(const char *cwd, const char *root, const char 
                               sizeof(work_dir)) != 0)
       return 0;
 
+   /* mirror-sync publishes immutable, generation-qualified snapshots.  Prefer
+    * that atomically-published metadata over the legacy mutable client.diff so
+    * a changed client checkout gets a fresh worktree while repeated Git calls
+    * keep using (and preserving) the same server-side session. */
+   char effective_head[65];
+   snprintf(effective_head, sizeof(effective_head), "%s", head);
+   char effective_branch[256] = "", effective_upstream[256] = "";
+   char snapshot_meta[MAX_PATH_LEN], snapshot_diff[MAX_PATH_LEN];
+   snapshot_diff[0] = '\0';
+   if (workspace_mirror_snapshot_meta_path(base, root, snapshot_meta, sizeof(snapshot_meta)) != 0)
+      return 0;
+
+   /* Absence means this workspace predates snapshot publication and may use the
+    * legacy head/diff pair. Once metadata exists it is authoritative: unreadable
+    * or malformed metadata must fail closed, not silently revive stale state. */
+   {
+      const workspace_provider_t *shared = workspace_provider_shared();
+      ws_stat_t meta_stat;
+      if (shared->stat(shared, snapshot_meta, &meta_stat) != 0)
+         return 0;
+      if (meta_stat.exists)
+      {
+         if (meta_stat.is_dir)
+            return 0;
+         char *metadata = NULL;
+         size_t metadata_len = 0;
+         ws_mirror_snapshot_t snapshot;
+         int valid =
+             shared->read_all(shared, snapshot_meta, &metadata, &metadata_len) == 0 &&
+             workspace_mirror_snapshot_parse(metadata, &snapshot) == 0 &&
+             workspace_mirror_snapshot_work_path(base, root, snapshot.generation, snapshot.digest,
+                                                 work_dir, sizeof(work_dir)) == 0 &&
+             workspace_mirror_snapshot_diff_path(base, root, snapshot.generation, snapshot.digest,
+                                                 snapshot_diff, sizeof(snapshot_diff)) == 0;
+         if (valid)
+         {
+            snprintf(effective_head, sizeof(effective_head), "%s", snapshot.head);
+            snprintf(effective_branch, sizeof(effective_branch), "%s", snapshot.branch);
+            snprintf(effective_upstream, sizeof(effective_upstream), "%s", snapshot.upstream);
+         }
+         free(metadata);
+         if (!valid)
+         {
+            LOG_WARN("workspace",
+                     "client snapshot metadata is invalid for %s; refusing legacy fallback", root);
+            return 0;
+         }
+      }
+   }
+
    /* Ensure the per-workspace parent dir (`<base>/<hash>`) exists before the
     * lifecycle: `git clone --mirror` won't create missing leading dirs, and on a
     * fresh durable volume nothing has created it yet (a prior mirror-sync would
@@ -171,7 +221,11 @@ static int mirror_reconstruct_cwd(const char *cwd, const char *root, const char 
     * the client's working tree. Absent → a clean checkout at head. */
    char diff_path[MAX_PATH_LEN];
    const char *diff_arg = NULL;
-   if (workspace_mirror_diff_path(base, root, diff_path, sizeof(diff_path)) == 0)
+   if (snapshot_diff[0])
+      snprintf(diff_path, sizeof(diff_path), "%s", snapshot_diff);
+   else if (workspace_mirror_diff_path(base, root, diff_path, sizeof(diff_path)) != 0)
+      diff_path[0] = '\0';
+   if (diff_path[0])
    {
       struct stat dst;
       if (stat(diff_path, &dst) == 0 && S_ISREG(dst.st_mode))
@@ -182,9 +236,10 @@ static int mirror_reconstruct_cwd(const char *cwd, const char *root, const char 
     * authenticate under the brokered token, else the per-host vault token for the
     * remote's host, else the server forge identity (§4/§6). */
    ws_mirror_runner_ctx_t rctx = {.wsid = root, .remote = remote};
-   if (workspace_mirror_session_setup(ws_mirror_git_runner, &rctx, remote, head, mirror_dir,
-                                      work_dir, diff_arg, already, drift, drift_cap,
-                                      verdict_out) != 0)
+   if (workspace_mirror_session_setup_branch(ws_mirror_git_runner, &rctx, remote, effective_head,
+                                             effective_branch, effective_upstream, mirror_dir,
+                                             work_dir, diff_arg, already, drift, drift_cap,
+                                             verdict_out) != 0)
    {
       LOG_WARN("workspace", "mirror lifecycle failed for %s (remote=%s head=%.10s)", root,
                remote ? remote : "", head);
@@ -245,7 +300,7 @@ int workspace_turn_resolve_mirror_cwd(const char *cwd, char *out, size_t out_cap
          /* Copied out of the accessor buffers: mirror_reconstruct_cwd stores root
           * and remote in a ws_mirror_runner_ctx_t and drives a git-runner callback
           * chain with it, so a config read anywhere under there would move them. */
-         char root[MAX_PATH_LEN], remote[512], head[64];
+         char root[MAX_PATH_LEN], remote[512], head[65];
          snprintf(root, sizeof(root), "%s", config_workspaces(i));
          snprintf(remote, sizeof(remote), "%s", config_workspace_vcs_remote(i));
          snprintf(head, sizeof(head), "%s", config_workspace_vcs_head(i));
@@ -273,7 +328,7 @@ int workspace_turn_resolve_detached_mirror_cwd(const char *cwd, char *out, size_
          return 0; /* mirror workspaces use the resolver above; shared needs nothing */
       /* Copied out of the accessor buffers for the same reason as the mirror
        * resolver: the runner ctx outlives a config read underneath it. */
-      char root[MAX_PATH_LEN], remote[512], head[64];
+      char root[MAX_PATH_LEN], remote[512], head[65];
       snprintf(root, sizeof(root), "%s", config_workspaces(i));
       snprintf(remote, sizeof(remote), "%s", config_workspace_vcs_remote(i));
       snprintf(head, sizeof(head), "%s", config_workspace_vcs_head(i));
@@ -324,7 +379,7 @@ int workspace_turn_bind_active(const char *cwd)
          /* Drive the server-side mirror lifecycle from the registry's vcs
           * coordinates, then act on the reconstructed local tree (shared fs). */
          /* Same copy-out as the resolver above: these reach the git runner. */
-         char root[MAX_PATH_LEN], remote[512], head[64];
+         char root[MAX_PATH_LEN], remote[512], head[65];
          snprintf(root, sizeof(root), "%s", config_workspaces(i));
          snprintf(remote, sizeof(remote), "%s", config_workspace_vcs_remote(i));
          snprintf(head, sizeof(head), "%s", config_workspace_vcs_head(i));

--- a/src/server/server_runner_endpoints.c
+++ b/src/server/server_runner_endpoints.c
@@ -24,9 +24,13 @@
 #include "platform_path.h"
 #include "server_http.h"  /* session_primary_set/get/clear */
 #include "agent_config.h" /* agent_load_config / agent_find */
+#include "aimee_sha256.h"
 #include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
 #include <pthread.h>
 #include <stdatomic.h>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
@@ -295,6 +299,35 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return send_and_free(conn, resp);
 }
 
+static int mirror_sync_write_atomic(const char *path, const char *data, size_t len)
+{
+   char temp[MAX_PATH_LEN];
+   int n = snprintf(temp, sizeof(temp), "%s.tmp.XXXXXX", path);
+   if (n < 0 || (size_t)n >= sizeof(temp))
+      return -1;
+   int fd = mkstemp(temp);
+   if (fd < 0)
+      return -1;
+   size_t off = 0;
+   while (off < len)
+   {
+      ssize_t wrote = write(fd, data + off, len - off);
+      if (wrote <= 0)
+      {
+         close(fd);
+         unlink(temp);
+         return -1;
+      }
+      off += (size_t)wrote;
+   }
+   int sync_ok = fsync(fd) == 0;
+   int close_ok = close(fd) == 0; /* always close, including after fsync failure */
+   int ok = sync_ok && close_ok && rename(temp, path) == 0;
+   if (!ok)
+      unlink(temp);
+   return ok ? 0 : -1;
+}
+
 /* workspace.mirror-sync: the client serving a `mirror` workspace ships its full
  * working-tree patch vs HEAD (tracked mods + deletions + untracked-file adds, as
  * one `git diff --cached --binary` blob) so the server's reconstructed worktree
@@ -357,33 +390,37 @@ int handle_workspace_mirror_sync(server_ctx_t *ctx, server_conn_t *conn, cJSON *
     * before: seq 0, final true. */
    cJSON *jseq = cJSON_GetObjectItemCaseSensitive(req, "seq");
    cJSON *jfinal = cJSON_GetObjectItemCaseSensitive(req, "final");
-   int seq = cJSON_IsNumber(jseq) ? (int)jseq->valuedouble : 0;
+   if ((jseq && (!cJSON_IsNumber(jseq) || jseq->valuedouble < 0 || jseq->valuedouble > INT_MAX ||
+                 jseq->valuedouble != (int)jseq->valuedouble)) ||
+       (jfinal && !cJSON_IsBool(jfinal)))
+      return server_send_error(conn, "workspace: invalid mirror-sync sequence envelope", NULL);
+   int seq = jseq ? (int)jseq->valuedouble : 0;
    int final = jfinal ? cJSON_IsTrue(jfinal) : 1;
-   if (seq < 0)
-      return server_send_error(conn, "workspace: mirror-sync seq must not be negative", NULL);
 
    const char *client_head = jo_str(req, "head", "");
-   if (final && client_head && client_head[0])
-   {
-      /* Keep the registered provider. Hardcoding "mirror" here would silently
-       * convert a detached workspace on its first sync, and a detached workspace
-       * is detached on purpose: its client serves the live tree, which is better
-       * than any reconstruction while that client is connected. The head is
-       * recorded for the case where no client is. */
-      (void)config_workspace_add(root, ws_provider_kind_to_string(kind), NULL, client_head);
-      /* Republish the live snapshot, for the same reason workspace.add does:
-       * config_load() serves the snapshot rather than disk in the server, so
-       * without this the head sits correct on disk while every reader — the
-       * reconstruct included — keeps using the previous one until the server
-       * loop's next tick. Measured: the patch shipped against the right base and
-       * the checkout still used the stale head, so nothing reconstructed. */
-      (void)config_reload_if_changed();
-   }
+   const char *client_branch = jo_str(req, "branch", "");
+   const char *client_upstream = jo_str(req, "upstream", "");
+   const char *wire_transfer = jo_str(req, "transfer", "");
+   int chunked_request = jseq != NULL || jfinal != NULL;
+   const char *transfer = wire_transfer[0] ? wire_transfer : "00000000000000000000000000000000";
+   if (strlen(client_branch) >= sizeof(((ws_mirror_snapshot_t *)0)->branch) ||
+       strlen(client_upstream) >= sizeof(((ws_mirror_snapshot_t *)0)->upstream) ||
+       !workspace_mirror_ref_valid(client_branch) || !workspace_mirror_ref_valid(client_upstream))
+      return server_send_error(conn, "workspace: invalid branch or upstream in mirror-sync", NULL);
+   if (chunked_request && !wire_transfer[0])
+      return server_send_error(
+          conn,
+          "workspace: chunked mirror-sync requires a transfer id; upgrade the client before "
+          "using Git",
+          NULL);
 
-   char base[MAX_PATH_LEN], diff_path[MAX_PATH_LEN];
+   char base[MAX_PATH_LEN], diff_path[MAX_PATH_LEN], state_path[MAX_PATH_LEN];
+   char lock_path[MAX_PATH_LEN], counter_path[MAX_PATH_LEN];
    if (workspace_mirror_base(base, sizeof(base)) != 0)
       return server_send_error(conn, "workspace: cannot resolve workspaces dir", NULL);
-   if (workspace_mirror_diff_path(base, root, diff_path, sizeof(diff_path)) != 0)
+   if (workspace_mirror_transfer_paths(base, root, transfer, diff_path, sizeof(diff_path),
+                                       state_path, sizeof(state_path), lock_path, sizeof(lock_path),
+                                       counter_path, sizeof(counter_path)) != 0)
       return server_send_error(conn, "workspace: path too long", NULL);
 
    /* Ensure the hashed parent dir exists (the worktree may not be materialized
@@ -393,17 +430,212 @@ int handle_workspace_mirror_sync(server_ctx_t *ctx, server_conn_t *conn, cJSON *
    char *slash = strrchr(parent, '/');
    if (slash)
       *slash = '\0';
-   platform_mkdir_p(parent, 0700);
+   if (platform_mkdir_p(parent, 0700) != 0)
+      return server_send_error(conn, "workspace: cannot create mirror-sync directory", NULL);
+
+   int lock_fd = open(lock_path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
+   if (lock_fd < 0 || flock(lock_fd, LOCK_EX) != 0)
+   {
+      if (lock_fd >= 0)
+         close(lock_fd);
+      return server_send_error(conn, "workspace: cannot lock mirror-sync transfer", NULL);
+   }
+
+#define MIRROR_SYNC_FAIL(message)                                                                  \
+   do                                                                                              \
+   {                                                                                               \
+      (void)flock(lock_fd, LOCK_UN);                                                               \
+      close(lock_fd);                                                                              \
+      return server_send_error(conn, (message), NULL);                                             \
+   } while (0)
 
    const workspace_provider_t *ws = workspace_provider_shared();
-   if (seq > 0 && !ws->append)
-      return server_send_error(
-          conn, "workspace: this provider cannot append, so a chunked sync cannot be reassembled",
-          NULL);
-   int stored = seq == 0 ? ws->write_all(ws, diff_path, diff, strlen(diff))
-                         : ws->append(ws, diff_path, diff, strlen(diff));
-   if (stored != 0)
-      return server_send_error(conn, "workspace: failed to store client diff", NULL);
+   ws_mirror_transfer_state_t transfer_state = {0};
+   if (seq == 0)
+   {
+      unsigned long long prior_order = 0;
+      ws_stat_t counter_stat;
+      if (ws->stat(ws, counter_path, &counter_stat) != 0)
+         MIRROR_SYNC_FAIL("workspace: cannot inspect mirror-sync counter");
+      if (counter_stat.exists)
+      {
+         char *counter_text = NULL;
+         size_t counter_len = 0;
+         char extra = '\0';
+         int parsed = ws->read_all(ws, counter_path, &counter_text, &counter_len) == 0 &&
+                      sscanf(counter_text, "%llu %c", &prior_order, &extra) == 1;
+         free(counter_text);
+         if (!parsed)
+            MIRROR_SYNC_FAIL("workspace: mirror-sync counter is corrupt");
+      }
+      if (prior_order == ULLONG_MAX)
+         MIRROR_SYNC_FAIL("workspace: mirror-sync counter exhausted");
+      transfer_state.order = prior_order + 1;
+      transfer_state.next_seq = 1;
+      char counter_text[64];
+      int counter_len =
+          snprintf(counter_text, sizeof(counter_text), "%llu\n", transfer_state.order);
+      if (counter_len < 0 || (size_t)counter_len >= sizeof(counter_text) ||
+          mirror_sync_write_atomic(counter_path, counter_text, (size_t)counter_len) != 0 ||
+          ws->write_all(ws, diff_path, diff, strlen(diff)) != 0)
+         MIRROR_SYNC_FAIL("workspace: failed to begin mirror-sync transfer");
+   }
+   else
+   {
+      if (!ws->append)
+         MIRROR_SYNC_FAIL(
+             "workspace: this provider cannot append, so chunked sync cannot be reassembled");
+      char *state_text = NULL;
+      size_t state_len = 0;
+      int state_ok = ws->read_all(ws, state_path, &state_text, &state_len) == 0 &&
+                     workspace_mirror_transfer_state_parse(state_text, &transfer_state) == 0;
+      free(state_text);
+      if (!state_ok || transfer_state.next_seq != (unsigned)seq)
+         MIRROR_SYNC_FAIL(
+             "workspace: mirror-sync transfer lost ownership or arrived out of sequence; restart "
+             "the refresh before using Git");
+      if (ws->append(ws, diff_path, diff, strlen(diff)) != 0)
+         MIRROR_SYNC_FAIL("workspace: failed to append client diff");
+      transfer_state.next_seq++;
+   }
+
+   if (!final)
+   {
+      char state_text[96];
+      int state_len = snprintf(state_text, sizeof(state_text), "%llu %u\n", transfer_state.order,
+                               transfer_state.next_seq);
+      if (state_len < 0 || (size_t)state_len >= sizeof(state_text) ||
+          mirror_sync_write_atomic(state_path, state_text, (size_t)state_len) != 0)
+         MIRROR_SYNC_FAIL("workspace: failed to persist mirror-sync transfer state");
+   }
+
+   unsigned long long generation = 0;
+   if (final)
+   {
+      if (!workspace_mirror_oid_valid(client_head))
+         MIRROR_SYNC_FAIL("workspace: final mirror-sync chunk requires a full commit id");
+      /* Publish a complete client snapshot, never a mutable worktree in place.
+       * The transfer-qualified diff above is only the chunk assembly file. Once final arrives,
+       * hash the complete (head, patch) pair, copy it to a generation-qualified
+       * immutable diff, then atomically replace the tiny metadata pointer.  A
+       * resolver racing this request therefore sees either the whole old pair
+       * or the whole new pair. */
+      char *full_diff = NULL;
+      size_t full_len = 0;
+      if (ws->read_all(ws, diff_path, &full_diff, &full_len) != 0)
+         MIRROR_SYNC_FAIL("workspace: failed to read assembled client diff");
+      size_t head_len = strlen(client_head);
+      size_t branch_len = strlen(client_branch), upstream_len = strlen(client_upstream);
+      if (head_len > SIZE_MAX - full_len - branch_len - upstream_len - 3)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: client snapshot is too large");
+      }
+      size_t digest_len = head_len + 1 + branch_len + 1 + upstream_len + 1 + full_len;
+      char *digest_input = malloc(digest_len);
+      char digest[65] = "";
+      if (!digest_input)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: out of memory publishing client snapshot");
+      }
+      memcpy(digest_input, client_head, head_len);
+      digest_input[head_len] = '\n';
+      memcpy(digest_input + head_len + 1, client_branch, branch_len);
+      digest_input[head_len + 1 + branch_len] = '\n';
+      memcpy(digest_input + head_len + 2 + branch_len, client_upstream, upstream_len);
+      digest_input[head_len + 2 + branch_len + upstream_len] = '\n';
+      memcpy(digest_input + head_len + 3 + branch_len + upstream_len, full_diff, full_len);
+      int digest_ok = aimee_sha256_hex(digest_input, digest_len, digest) == 0;
+      free(digest_input);
+      if (!digest_ok)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: failed to digest client snapshot");
+      }
+
+      char meta_path[MAX_PATH_LEN], version_diff[MAX_PATH_LEN];
+      if (workspace_mirror_snapshot_meta_path(base, root, meta_path, sizeof(meta_path)) != 0)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: snapshot path too long");
+      }
+      char *old_text = NULL;
+      size_t old_len = 0;
+      ws_mirror_snapshot_t old_snapshot;
+      ws_stat_t meta_stat;
+      if (ws->stat(ws, meta_path, &meta_stat) != 0)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: cannot inspect client snapshot metadata");
+      }
+      int have_old = meta_stat.exists;
+      int old_valid = !have_old || (ws->read_all(ws, meta_path, &old_text, &old_len) == 0 &&
+                                    workspace_mirror_snapshot_parse(old_text, &old_snapshot) == 0);
+      free(old_text);
+      if (!old_valid)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: existing client snapshot metadata is corrupt");
+      }
+      if (workspace_mirror_snapshot_next_generation(&old_snapshot, have_old, transfer_state.order,
+                                                    digest, &generation) != 0)
+      {
+         free(full_diff);
+         unlink(state_path);
+         unlink(diff_path);
+         MIRROR_SYNC_FAIL(
+             "workspace: a newer mirror-sync already published; restart the refresh before using "
+             "Git");
+      }
+
+      if (workspace_mirror_snapshot_diff_path(base, root, generation, digest, version_diff,
+                                              sizeof(version_diff)) != 0)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: snapshot diff path is too long");
+      }
+
+      /* A digest-qualified diff is immutable. Repeated identical snapshots keep
+       * their generation and must not truncate/rewrite a file a concurrent Git
+       * reconstruction may be reading. Repair only a missing or size-mismatched
+       * payload, using the same atomic writer as metadata publication. */
+      ws_stat_t diff_stat;
+      if (ws->stat(ws, version_diff, &diff_stat) != 0)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: cannot inspect client snapshot diff");
+      }
+      int diff_complete = diff_stat.exists && !diff_stat.is_dir && full_len <= LONG_MAX &&
+                          diff_stat.size == (long)full_len;
+      if (!diff_complete && mirror_sync_write_atomic(version_diff, full_diff, full_len) != 0)
+      {
+         free(full_diff);
+         MIRROR_SYNC_FAIL("workspace: failed to publish client snapshot diff");
+      }
+      free(full_diff);
+
+      char metadata[1024];
+      int metadata_len = snprintf(metadata, sizeof(metadata), "%llu %s %s %s %s %llu\n", generation,
+                                  digest, client_head, client_branch[0] ? client_branch : "-",
+                                  client_upstream[0] ? client_upstream : "-", transfer_state.order);
+      if (metadata_len < 0 || (size_t)metadata_len >= sizeof(metadata))
+         MIRROR_SYNC_FAIL("workspace: snapshot metadata is too long");
+      if (mirror_sync_write_atomic(meta_path, metadata, (size_t)metadata_len) != 0)
+         MIRROR_SYNC_FAIL("workspace: failed to publish snapshot metadata");
+
+      /* Keep the registered provider. Hardcoding mirror would silently convert
+       * a deliberately detached workspace. The snapshot metadata is already
+       * authoritative for reconstruction; this registry update keeps status and
+       * subsequent registrations consistent with it. */
+      (void)config_workspace_add(root, ws_provider_kind_to_string(kind), NULL, client_head);
+      (void)config_reload_if_changed();
+      unlink(state_path);
+      unlink(diff_path);
+   }
+
+   (void)flock(lock_fd, LOCK_UN);
+   close(lock_fd);
 
    cJSON *resp = jo_ok();
    cJSON_AddNumberToObject(resp, "bytes", (double)strlen(diff));
@@ -413,6 +645,10 @@ int handle_workspace_mirror_sync(server_ctx_t *ctx, server_conn_t *conn, cJSON *
     * one would win and the mirror would reconstruct from a fragment that looks
     * like a complete tree. The client must be able to tell the difference. */
    cJSON_AddBoolToObject(resp, "chunked", 1);
+   cJSON_AddNumberToObject(resp, "order", (double)transfer_state.order);
+   if (generation)
+      cJSON_AddNumberToObject(resp, "generation", (double)generation);
+#undef MIRROR_SYNC_FAIL
    return send_and_free(conn, resp);
 }
 

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -16,6 +16,8 @@ static char g_last_mcp_call_arg_workspace[4096];
 static char g_last_mcp_call_tool[128];
 static int g_last_mcp_call_paths_count;
 static int g_reverse_channel_starts;
+static int g_reverse_channel_syncs;
+static int g_reverse_channel_sync_rc;
 static int g_remote_active;
 static int g_remote_http_failures;
 static int g_remote_http_calls;
@@ -88,6 +90,11 @@ int cli_workspace_reverse_channel_start(void)
 {
    g_reverse_channel_starts++;
    return 0;
+}
+int cli_workspace_reverse_channel_sync(void)
+{
+   g_reverse_channel_syncs++;
+   return g_reverse_channel_sync_rc;
 }
 void cli_workspace_reverse_channel_stop(void)
 {
@@ -937,6 +944,7 @@ static void test_tools_list_preserves_server_error(void)
 static void test_tools_call_success(void)
 {
    g_reverse_channel_starts = 0;
+   g_reverse_channel_syncs = 0;
    g_last_mcp_call_cwd[0] = '\0';
    g_last_mcp_call_arg_cwd[0] = '\0';
 
@@ -969,9 +977,42 @@ static void test_tools_call_success(void)
    assert(strcmp(g_last_mcp_call_cwd, cwd) == 0);
    assert(strcmp(g_last_mcp_call_arg_cwd, cwd) == 0);
    assert(g_reverse_channel_starts == 1);
+   assert(g_reverse_channel_syncs == 0); /* non-Git calls do not pay the sync gate */
 
    cJSON_Delete(resp);
    cJSON_Delete(req);
+}
+
+static void test_git_call_refreshes_mirror_and_fails_closed(void)
+{
+   g_reverse_channel_syncs = 0;
+   g_reverse_channel_sync_rc = 0;
+   g_last_mcp_call_tool[0] = '\0';
+
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "jsonrpc", "2.0");
+   cJSON_AddNumberToObject(req, "id", 12.125);
+   cJSON_AddStringToObject(req, "method", "tools/call");
+   cJSON *params = cJSON_AddObjectToObject(req, "params");
+   cJSON_AddStringToObject(params, "name", "git");
+   cJSON_AddObjectToObject(params, "arguments");
+
+   cJSON *resp = capture_response(req);
+   assert(g_reverse_channel_syncs == 1);
+   assert(strcmp(g_last_mcp_call_tool, "git") == 0);
+   cJSON_Delete(resp);
+
+   g_reverse_channel_sync_rc = -1;
+   g_last_mcp_call_tool[0] = '\0';
+   resp = capture_response(req);
+   cJSON *result = cJSON_GetObjectItemCaseSensitive(resp, "result");
+   assert(cJSON_IsObject(result));
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(result, "isError")));
+   assert(g_reverse_channel_syncs == 2);
+   assert(g_last_mcp_call_tool[0] == '\0');
+   cJSON_Delete(resp);
+   cJSON_Delete(req);
+   g_reverse_channel_sync_rc = 0;
 }
 
 static void test_tools_call_cwd_is_transport_owned(void)
@@ -1360,6 +1401,7 @@ int main(void)
    test_tools_list_preserves_server_error();
    test_remote_discovery_retries_are_safe();
    test_tools_call_success();
+   test_git_call_refreshes_mirror_and_fails_closed();
    test_tools_call_cwd_is_transport_owned();
    test_tools_call_preview_blast_radius();
    test_tools_call_server_error();

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -313,7 +313,8 @@ int main(void)
       snprintf(cfg.workspace_providers[2], sizeof(cfg.workspace_providers[2]), "mirror");
       snprintf(cfg.workspace_vcs_remote[2], sizeof(cfg.workspace_vcs_remote[2]),
                "https://example.com/r.git");
-      snprintf(cfg.workspace_vcs_head[2], sizeof(cfg.workspace_vcs_head[2]), "abc123def456");
+      snprintf(cfg.workspace_vcs_head[2], sizeof(cfg.workspace_vcs_head[2]),
+               "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
       cfg.memory_maintenance_trigger_inserts = 7;
       cfg.memory_maintenance_trigger_secs = 90;
       cfg.memory_cognify_async_enabled = 1;
@@ -578,7 +579,8 @@ int main(void)
       assert(strcmp(cfg2.workspaces[2], "/tmp/ws-mirror-rt") == 0);
       assert(strcmp(cfg2.workspace_providers[2], "mirror") == 0);
       assert(strcmp(cfg2.workspace_vcs_remote[2], "https://example.com/r.git") == 0);
-      assert(strcmp(cfg2.workspace_vcs_head[2], "abc123def456") == 0);
+      assert(strcmp(cfg2.workspace_vcs_head[2],
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef") == 0);
       assert(cfg2.worktree_gc_enabled == 0);
       assert(cfg2.worktree_gc_max_age_days == 21);
       assert(cfg2.memory_maintenance_trigger_inserts == 7);

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -108,6 +108,7 @@ routes = {
   'server.info': ('GET', '/v1/server/info'),
   'server.health': ('GET', '/v1/server/health'),
   'provider.list': ('GET', '/v1/provider/list'),
+  'workspace.add': ('POST', '/v1/workspaces'),
   'rules.list': ('GET', '/v1/rules'),
   'session.list': ('POST', '/v1/sessions/list'),
   'memory.list': ('POST', '/v1/memory/list'),
@@ -553,7 +554,7 @@ fi
 # ============================================================
 
 check_output "local version command" "aimee" $AIMEE version
-check_output "unported command has no typed route" "has no /v1 route" $AIMEE env
+check_output "unknown command fails before generic forwarding" "unknown command 'env'" $AIMEE env
 
 # ============================================================
 # 8. Tool execution via compute pool
@@ -569,7 +570,98 @@ RESP=$(http_rpc '{"method":"tool.execute","tool":"read_file","arguments":"{\"pat
 check_output "tool.execute read_file" '"status":"ok"' echo "$RESP"
 
 # ============================================================
-# 9. Server shutdown
+# 9. Mirror-sync -> reconstructed MCP Git, end to end
+# ============================================================
+
+MIRROR_CASE="$HOME/mirror-sync-e2e"
+MIRROR_REMOTE="$MIRROR_CASE/remote.git"
+MIRROR_CLIENT="$MIRROR_CASE/client"
+mkdir -p "$MIRROR_CASE"
+# Exercise Git's repository-format SHA-256 object IDs through the entire wire,
+# snapshot, reconstruction, and MCP tool path (SHA-1 is covered by unit tests).
+git init --bare --object-format=sha256 "$MIRROR_REMOTE" >/dev/null
+git init --object-format=sha256 -b feature.locked "$MIRROR_CLIENT" >/dev/null
+git -C "$MIRROR_CLIENT" config user.name "Aimee Integration"
+git -C "$MIRROR_CLIENT" config user.email "aimee-integration@example.invalid"
+printf 'base\n' >"$MIRROR_CLIENT/file.txt"
+git -C "$MIRROR_CLIENT" add file.txt
+git -C "$MIRROR_CLIENT" commit -m base >/dev/null
+git -C "$MIRROR_CLIENT" remote add origin "$MIRROR_REMOTE"
+git -C "$MIRROR_CLIENT" push -u origin feature.locked >/dev/null
+MIRROR_HEAD=$(git -C "$MIRROR_CLIENT" rev-parse HEAD)
+printf 'client edit\n' >>"$MIRROR_CLIENT/file.txt"
+git -C "$MIRROR_CLIENT" diff --binary HEAD >"$MIRROR_CASE/client.diff"
+
+ADD_REQ=$(python3 - "$MIRROR_CLIENT" "$MIRROR_REMOTE" "$MIRROR_HEAD" <<'PY'
+import json, sys
+print(json.dumps({"method": "workspace.add", "root": sys.argv[1], "provider": "mirror",
+                  "remote": sys.argv[2], "head": sys.argv[3], "scan": False}))
+PY
+)
+RESP=$(http_rpc "$ADD_REQ")
+check_output "mirror workspace registered" '"status":"ok"' echo "$RESP"
+
+# Deliberately split a small patch into multiple requests. The durable transfer
+# state is re-read on every request, which is the same contract used when a load
+# balancer or rolling deployment routes consecutive chunks to different server
+# processes sharing AIMEE_WORKSPACES_DIR.
+mapfile -t MIRROR_REQS < <(python3 - "$MIRROR_CLIENT" "$MIRROR_HEAD" \
+    "$MIRROR_CASE/client.diff" <<'PY'
+import json, pathlib, sys
+root, head, path = sys.argv[1:]
+patch = pathlib.Path(path).read_text()
+cut = max(1, len(patch) // 2)
+for transfer in ("0123456789abcdef0123456789abcdef",
+                 "1123456789abcdef0123456789abcdef"):
+    base = {"method": "workspace.mirror-sync", "args": [root], "transfer": transfer}
+    print(json.dumps(base | {"seq": 0, "final": False, "diff": ""}))
+    print(json.dumps(base | {"seq": 1, "final": False, "diff": patch[:cut]}))
+    print(json.dumps(base | {"seq": 2, "final": True, "diff": patch[cut:], "head": head,
+                             "branch": "feature.locked", "upstream": "origin/feature.locked"}))
+PY
+)
+RESP=$(http_rpc "${MIRROR_REQS[0]}")
+check_output "mirror-sync begin persisted" '"order":1' echo "$RESP"
+RESP=$(http_rpc "${MIRROR_REQS[1]}")
+check_output "mirror-sync continuation persisted" '"seq":1' echo "$RESP"
+RESP=$(http_rpc "${MIRROR_REQS[2]}")
+check_output "mirror-sync final published" '"generation":1' echo "$RESP"
+RESP=$(http_rpc "${MIRROR_REQS[3]}")
+check_output "identical mirror-sync begin advances order" '"order":2' echo "$RESP"
+RESP=$(http_rpc "${MIRROR_REQS[4]}")
+check_output "identical mirror-sync continuation persisted" '"seq":1' echo "$RESP"
+RESP=$(http_rpc "${MIRROR_REQS[5]}")
+check_output "identical mirror-sync reuses generation" '"generation":1' echo "$RESP"
+
+SNAPSHOT=$(find "$AIMEE_HOME/workspaces" -name client.snapshot -type f -print -quit)
+check "mirror snapshot metadata published" test -s "$SNAPSHOT"
+check_output "mirror snapshot records valid .locked ref" \
+    'feature.locked origin/feature.locked 2' cat "$SNAPSHOT"
+
+GIT_REQ=$(python3 - "$MIRROR_CLIENT" <<'PY'
+import json, sys
+print(json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                  "params": {"name": "git", "arguments": {"command": "status",
+                                                               "path": sys.argv[1]}}}))
+PY
+)
+RESP=$(mcp_initialized_req "$GIT_REQ")
+check_output "MCP Git resolves reconstructed .locked branch" 'feature.locked' echo "$RESP"
+check_output "MCP Git sees synchronized client edit" 'file.txt' echo "$RESP"
+
+MIRROR_WORK=$(find "$(dirname "$SNAPSHOT")" -maxdepth 1 -type d -name 'work-1-*' -print -quit)
+check_output "reconstructed worktree keeps branch" 'feature.locked' \
+    git -C "$MIRROR_WORK" branch --show-current
+check_output "reconstructed worktree keeps dirty patch" 'file.txt' git -C "$MIRROR_WORK" status --short
+
+# The second identical multi-chunk refresh must retain generation 1 (and
+# therefore the same server-side Git checkout) while advancing publication
+# order to prevent an older transfer rolling it back.
+check_output "identical refresh reuses snapshot generation" '1 ' head -c 2 "$SNAPSHOT"
+check_output "identical refresh advances publication order" ' 2' tail -c 3 "$SNAPSHOT"
+
+# ============================================================
+# 10. Server shutdown
 # ============================================================
 
 kill "$SERVER_PID" 2>/dev/null

--- a/src/tests/test_workspace_mirror.c
+++ b/src/tests/test_workspace_mirror.c
@@ -137,6 +137,18 @@ int main(void)
           -1);
    g_apply_rc = 0;
 
+   /* Git-tool snapshots are independent branch checkouts, not detached shared
+    * worktrees, and retain the client's upstream tracking. */
+   g_cmd_log[0] = '\0';
+   g_clone_rc = g_checkout_rc = 0;
+   assert(workspace_mirror_reconstruct_branch(mock_git, NULL, "https://host/r.git", "/m", "/w-2",
+                                              "abc123", "fix/live", "origin/fix/live",
+                                              "/w/client.diff") == 0);
+   assert(strstr(g_cmd_log, "clone --no-checkout --shared /m /w-2") != NULL);
+   assert(strstr(g_cmd_log, "-C /w-2 remote set-url origin https://host/r.git") != NULL);
+   assert(strstr(g_cmd_log, "-C /w-2 checkout -B fix/live abc123") != NULL);
+   assert(strstr(g_cmd_log, "-C /w-2 branch --set-upstream-to origin/fix/live fix/live") != NULL);
+
    /* --- drift_report: surfaced summary lines for each verdict --- */
    char rep[256];
    g_rev_parse_head = "same"; /* in_sync (no ancestry needed) */
@@ -204,6 +216,113 @@ int main(void)
       assert(strncmp(dp, wd_same, strlen(wd_same)) == 0 && dp[strlen(wd_same)] == '/');
    }
    assert(workspace_mirror_diff_path("/b", "/home/u/proj", tiny, sizeof(tiny)) == -1);
+
+   /* A synchronized client snapshot gets immutable generation-qualified paths. */
+   char sm[256], sd[256], sw[256];
+   assert(workspace_mirror_snapshot_meta_path("/b", "/home/u/proj", sm, sizeof(sm)) == 0);
+   const char *digest_a = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+   const char *digest_b = "1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+   assert(workspace_mirror_snapshot_diff_path("/b", "/home/u/proj", 7, digest_a, sd, sizeof(sd)) ==
+          0);
+   assert(workspace_mirror_snapshot_work_path("/b", "/home/u/proj", 7, digest_a, sw, sizeof(sw)) ==
+          0);
+   assert(strcmp(sm + strlen(sm) - 16, "/client.snapshot") == 0);
+   assert(strstr(sd, "/client.diff-7-") != NULL && strstr(sd, digest_a) != NULL);
+   assert(strstr(sw, "/work-7-") != NULL && strstr(sw, digest_a) != NULL);
+   char sd_concurrent[256];
+   assert(workspace_mirror_snapshot_diff_path("/b", "/home/u/proj", 7, digest_b, sd_concurrent,
+                                              sizeof(sd_concurrent)) == 0);
+   assert(strcmp(sd, sd_concurrent) != 0); /* concurrent next-gen payloads cannot collide */
+   assert(workspace_mirror_snapshot_diff_path("/b", "/home/u/proj", 0, digest_a, sd, sizeof(sd)) ==
+          -1);
+   ws_mirror_snapshot_t snapshot;
+   assert(workspace_mirror_snapshot_parse(
+              "7 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef "
+              "0123456789abcdef0123456789abcdef01234567 fix/live origin/fix/live\n",
+              &snapshot) == 0);
+   assert(snapshot.generation == 7);
+   assert(strcmp(snapshot.head, "0123456789abcdef0123456789abcdef01234567") == 0);
+   assert(strcmp(snapshot.branch, "fix/live") == 0);
+   assert(strcmp(snapshot.upstream, "origin/fix/live") == 0);
+   assert(workspace_mirror_snapshot_parse(
+              "8 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef "
+              "0123456789abcdef0123456789abcdef01234567 - -\n",
+              &snapshot) == 0);
+   assert(snapshot.generation == 8 && snapshot.branch[0] == '\0' && snapshot.upstream[0] == '\0');
+   assert(snapshot.sync_order == 0); /* old five-field metadata remains readable */
+   assert(workspace_mirror_snapshot_parse(
+              "9 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef "
+              "0123456789abcdef0123456789abcdef01234567 fix/live origin/fix/live 42\n",
+              &snapshot) == 0);
+   assert(snapshot.generation == 9 && snapshot.sync_order == 42);
+   assert(strcmp(snapshot.branch, "fix/live") == 0);
+   const char *sha256_oid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+   assert(workspace_mirror_oid_valid("0123456789abcdef0123456789abcdef01234567") == 1);
+   assert(workspace_mirror_oid_valid(sha256_oid) == 1);
+   assert(workspace_mirror_oid_valid("ABCDEF0123456789abcdef0123456789abcdef01") == 0);
+   assert(workspace_mirror_oid_valid("short") == 0);
+   assert(workspace_mirror_ref_valid("") == 1);
+   assert(workspace_mirror_ref_valid("feature.locked") == 1);
+   assert(workspace_mirror_ref_valid("origin/feature.locked") == 1);
+   assert(workspace_mirror_ref_valid("feature.lock") == 0);
+   assert(workspace_mirror_ref_valid("team/feature.lock/next") == 0);
+   assert(workspace_mirror_ref_valid("team/.hidden") == 0);
+   assert(workspace_mirror_ref_valid("-option") == 0);
+   assert(workspace_mirror_ref_valid("bad..ref") == 0);
+   assert(workspace_mirror_ref_valid("bad@{ref") == 0);
+   assert(workspace_mirror_ref_valid("bad//ref") == 0);
+   assert(workspace_mirror_ref_valid("bad ref") == 0);
+   char sha256_metadata[512];
+   snprintf(sha256_metadata, sizeof(sha256_metadata), "%d %s %s main origin/main %d\n", 10,
+            digest_a, sha256_oid, 43);
+   assert(workspace_mirror_snapshot_parse(sha256_metadata, &snapshot) == 0);
+   assert(strcmp(snapshot.head, sha256_oid) == 0 && snapshot.sync_order == 43);
+   assert(workspace_mirror_snapshot_parse(
+              "9 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0 "
+              "0123456789abcdef0123456789abcdef01234567 - -\n",
+              &snapshot) == -1); /* 65-char digest is never truncated into validity */
+   assert(workspace_mirror_snapshot_parse("7 bad bad", &snapshot) == -1);
+
+   /* Chunk ownership is durable and process-independent: every request derives
+    * the same transfer-specific assembly/state paths from wire coordinates,
+    * while another transfer cannot collide with them. */
+   char ta[256], ts[256], tl[256], tc[256], ta2[256], ts2[256], tl2[256], tc2[256];
+   const char *transfer_a = "00112233445566778899aabbccddeeff";
+   const char *transfer_b = "10112233445566778899aabbccddeeff";
+   assert(workspace_mirror_transfer_paths("/b", "/home/u/proj", transfer_a, ta, sizeof(ta), ts,
+                                          sizeof(ts), tl, sizeof(tl), tc, sizeof(tc)) == 0);
+   assert(workspace_mirror_transfer_paths("/b", "/home/u/proj", transfer_b, ta2, sizeof(ta2), ts2,
+                                          sizeof(ts2), tl2, sizeof(tl2), tc2, sizeof(tc2)) == 0);
+   assert(strcmp(ta, ta2) != 0 && strcmp(ts, ts2) != 0);
+   assert(strcmp(tl, tl2) == 0 && strcmp(tc, tc2) == 0);
+   assert(strstr(ta, transfer_a) != NULL && strstr(ts, transfer_a) != NULL);
+   assert(workspace_mirror_transfer_paths("/b", "/home/u/proj", "bad", ta, sizeof(ta), ts,
+                                          sizeof(ts), tl, sizeof(tl), tc, sizeof(tc)) == -1);
+
+   ws_mirror_transfer_state_t transfer_state;
+   assert(workspace_mirror_transfer_state_parse("41 3\n", &transfer_state) == 0);
+   assert(transfer_state.order == 41 && transfer_state.next_seq == 3);
+   assert(workspace_mirror_transfer_state_parse("41 0\n", &transfer_state) == -1);
+   assert(workspace_mirror_transfer_state_parse("41 3 extra\n", &transfer_state) == -1);
+
+   /* Publication order is a CAS-style guard: a later-started transfer may
+    * replace an earlier one, never the reverse; identical content reuses its
+    * generation so repeated Git calls preserve their server-side checkout. */
+   ws_mirror_snapshot_t current = {0};
+   current.generation = 7;
+   current.sync_order = 20;
+   snprintf(current.digest, sizeof(current.digest), "%s", digest_a);
+   unsigned long long next_generation = 0;
+   assert(workspace_mirror_snapshot_next_generation(&current, 1, 21, digest_a, &next_generation) ==
+          0);
+   assert(next_generation == 7);
+   assert(workspace_mirror_snapshot_next_generation(&current, 1, 21, digest_b, &next_generation) ==
+          0);
+   assert(next_generation == 8);
+   assert(workspace_mirror_snapshot_next_generation(&current, 1, 19, digest_b, &next_generation) ==
+          -1);
+   assert(workspace_mirror_snapshot_next_generation(NULL, 0, 1, digest_a, &next_generation) == 0);
+   assert(next_generation == 1);
 
    /* --- session_setup (fresh): ensure(clone) + drift + reconstruct --- */
    g_cmd_log[0] = '\0';

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -307,7 +307,7 @@
         },
         {
           "path": "src/headers/cli_client.h",
-          "sha256": "f48c62db7a70ef4d5efd6002205072f4a3249c413891f9dc613a36b5228124e8"
+          "sha256": "3e9f96b2d7909c7a44e2e56e1cbda866587ed21610553efa5f74c56e9f1951a8"
         },
         {
           "path": "src/headers/cli_code_audit.h",
@@ -1604,7 +1604,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "882906d881b5ee24a22dafb15677987815de4a80cc9c37ce8a8df34a48c17553",
+      "sha256": "59412708dffad9abc82290fdbf17e29fbd25bb12310be9f9c2090a3aab783182",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## Summary

- refresh the client worktree mirror before every remote MCP Git call and fail closed when refresh cannot complete
- make chunked mirror publication durable and cross-process safe, with atomic metadata/snapshots and stale-transfer rejection
- reconstruct independent server clones while preserving branch, upstream, dirty state, and existing server-side Git session state
- support SHA-1 and SHA-256 repositories plus valid Git ref edge cases such as `feature.locked`

## Validation

- full C unit suite (700+ tests)
- integration suite: 69/69 passed, including real SHA-256 multi-chunk sync and MCP Git status
- `make -C src all -j2`
- `make -C src aimee-home-check`
- `python3 -I scripts/check_c_repository_lock.py`
- `bash -n src/tests/test_integration.sh`
- `git diff --check`

## Safety review

Frozen-diff Aimee roundtable approved (`roundtable-66775b148e11a72ab748fdc3`, artifact `b13b28520dc310e4e1c4724015c8bfeb896164a82c715248c3cff5a59878dadf`).
