### PR TITLE
fix(workspace): accept clean mirror snapshots

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -203,7 +203,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "f95baadc73fbc2e6c8bdaf46fa72ce4443e0b3241bc481d80983b4c9a5a3f55e",
+      "source_sha256": "6a4c71e1fb767878c896974270788db1d82aeb205ef8d5eb5b49e45f20ce3757",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,

--- a/src/modules/workspace/workspace_mirror.c
+++ b/src/modules/workspace/workspace_mirror.c
@@ -173,12 +173,14 @@ int workspace_mirror_reconstruct(ws_git_runner_fn run, void *ctx, const char *mi
       run(ctx, clean, NULL, 0); /* best-effort: drop a prior turn's stray untracked */
    }
 
-   /* Apply the client's working-tree patch on top, if any. `--binary` so the
-    * git-binary hunks the client ships for binary files apply too; the same
-    * patch also carries tracked mods, deletions, and untracked-file additions. */
+   /* Apply the client's working-tree patch on top, if any. A clean client still
+    * publishes a zero-byte snapshot file, so --allow-empty makes that valid on
+    * the first Git call instead of leaving a correctly-created but rejected
+    * worktree behind. `--binary` covers binary hunks; the same patch also carries
+    * tracked mods, deletions, and untracked-file additions. */
    if (diff_path && diff_path[0])
    {
-      const char *apply[] = {"-C",       work_dir,  "apply", "--whitespace=nowarn",
+      const char *apply[] = {"-C",       work_dir,  "apply", "--allow-empty", "--whitespace=nowarn",
                              "--binary", diff_path, NULL};
       if (run(ctx, apply, NULL, 0) != 0)
          return -1;
@@ -216,7 +218,7 @@ int workspace_mirror_reconstruct_branch(ws_git_runner_fn run, void *ctx, const c
    }
    if (diff_path && diff_path[0])
    {
-      const char *apply[] = {"-C",       work_dir,  "apply", "--whitespace=nowarn",
+      const char *apply[] = {"-C",       work_dir,  "apply", "--allow-empty", "--whitespace=nowarn",
                              "--binary", diff_path, NULL};
       if (run(ctx, apply, NULL, 0) != 0)
          return -1;

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -660,6 +660,28 @@ check_output "reconstructed worktree keeps dirty patch" 'file.txt' git -C "$MIRR
 check_output "identical refresh reuses snapshot generation" '1 ' head -c 2 "$SNAPSHOT"
 check_output "identical refresh advances publication order" ' 2' tail -c 3 "$SNAPSHOT"
 
+# A clean checkout publishes an empty diff file. It must work on the FIRST Git
+# call for the new snapshot generation; previously git apply rejected the
+# zero-byte patch after creating the right checkout, making that first call fail.
+EMPTY_REQ=$(python3 - "$MIRROR_CLIENT" "$MIRROR_HEAD" <<'PY'
+import json, sys
+print(json.dumps({"method": "workspace.mirror-sync", "args": [sys.argv[1]],
+                  "transfer": "2123456789abcdef0123456789abcdef", "diff": "",
+                  "head": sys.argv[2], "branch": "feature.locked",
+                  "upstream": "origin/feature.locked"}))
+PY
+)
+RESP=$(http_rpc "$EMPTY_REQ")
+check_output "clean mirror-sync publishes a new generation" '"generation":2' echo "$RESP"
+
+RESP=$(mcp_initialized_req "$GIT_REQ")
+check_output "first MCP Git call accepts clean snapshot" 'feature.locked' echo "$RESP"
+MIRROR_CLEAN_WORK=$(find "$(dirname "$SNAPSHOT")" -maxdepth 1 -type d -name 'work-2-*' \
+    -print -quit)
+check "clean snapshot worktree materialized on first call" test -n "$MIRROR_CLEAN_WORK"
+check "clean snapshot worktree remains clean" test -z \
+    "$(git -C "$MIRROR_CLEAN_WORK" status --porcelain)"
+
 # ============================================================
 # 10. Server shutdown
 # ============================================================

--- a/src/tests/test_workspace_mirror.c
+++ b/src/tests/test_workspace_mirror.c
@@ -109,7 +109,8 @@ int main(void)
    assert(workspace_mirror_reconstruct(mock_git, NULL, "/m", "/w", "abc123", "/w/.client.diff") ==
           0);
    assert(strstr(g_cmd_log, "-C /m worktree add --detach --force /w abc123") != NULL);
-   assert(strstr(g_cmd_log, "-C /w apply --whitespace=nowarn --binary /w/.client.diff") != NULL);
+   assert(strstr(g_cmd_log,
+                 "-C /w apply --allow-empty --whitespace=nowarn --binary /w/.client.diff") != NULL);
    assert(strstr(g_cmd_log, "checkout") == NULL); /* add succeeded → no fallback */
 
    /* --- reconstruct: no diff → clean checkout, NO apply --- */
@@ -148,6 +149,9 @@ int main(void)
    assert(strstr(g_cmd_log, "-C /w-2 remote set-url origin https://host/r.git") != NULL);
    assert(strstr(g_cmd_log, "-C /w-2 checkout -B fix/live abc123") != NULL);
    assert(strstr(g_cmd_log, "-C /w-2 branch --set-upstream-to origin/fix/live fix/live") != NULL);
+   assert(strstr(g_cmd_log,
+                 "-C /w-2 apply --allow-empty --whitespace=nowarn --binary /w/client.diff") !=
+          NULL);
 
    /* --- drift_report: surfaced summary lines for each verdict --- */
    char rep[256];


### PR DESCRIPTION
## Problem

A clean client mirror snapshot publishes a zero-byte diff. The server reconstructed the correct first-call worktree, then `git apply` rejected that empty file, so the first explicit-path Git operation failed.

## Fix

- pass `--allow-empty` in both mirror reconstruction paths
- retain failure behavior for malformed/conflicting non-empty patches
- add unit assertions and an end-to-end first-call clean-snapshot regression
- refresh the workspace repository source lock

## Validation

- focused workspace mirror unit test
- integration suite: 73/73
- full C unit suite
- formatter/lint gate
- repository lock check
- frozen-diff roundtable: approved (`roundtable-0998f3816c88423744dc2097`)
- deployment Git 2.39.5 confirmed to support `git apply --allow-empty`