### PR TITLE
fix(git): move the credential-resolve decision into the Go module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -224,7 +224,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "48c9c2fe6027aa0877f5ff072395b7bdae12ab5013e6bd1933652bde86ba8340",
+      "source_sha256": "152a072635b6d4dc63b61d38d614faa9369894cb6ba54a96febd1f55f4a9ec36",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/server-go/modules/git/cred_resolve.go
+++ b/server-go/modules/git/cred_resolve.go
@@ -1,0 +1,144 @@
+package git
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Provider kinds, mirroring ws_provider_kind_t. Only DETACHED is named in the
+// decision below; the rest are here so a caller's value is readable in a trace.
+const (
+	ProviderShared    uint32 = 0
+	ProviderDetached  uint32 = 1
+	ProviderMirror    uint32 = 2
+	ProviderContainer uint32 = 3
+)
+
+// CredResolveRequest carries the facts C holds; the decisions stay here.
+//
+// The caller passes the registered roots rather than this module reading them:
+// where the list is stored is not a decision, and shipping it keeps the module
+// free of config I/O. AimeeHome is passed for the same reason, and deliberately
+// as the HOME rather than a mirror path — where a provider materialises a root
+// is a decision, so it is derived here.
+type CredResolveRequest struct {
+	Cwd          string   `json:"cwd"`
+	ProviderKind uint32   `json:"provider_kind"`
+	AimeeHome    string   `json:"aimee_home"`
+	Workspaces   []string `json:"workspaces"`
+}
+
+// CredResolveResponse answers both questions the git path has to ask before it
+// execs: does this command run on the server, and if so which registered
+// workspace owns the directory it runs in (so a credential can be keyed to it).
+//
+// Workspace is the REGISTERED root, never the materialised path, so credential
+// keys do not change when a provider relocates where work happens.
+type CredResolveResponse struct {
+	RunsOnServer bool   `json:"runs_on_server"`
+	Workspace    string `json:"workspace"`
+}
+
+// runsOnServer states the rule instead of listing the kinds that satisfy it.
+//
+// Only a detached workspace marshals git to its client, which holds both the
+// filesystem authority and its own credentials; everything else runs on the
+// server and therefore needs the server-side credential. Written the other way
+// round — as a list of kinds — this silently excluded `mirror`, whose git runs
+// on the server like any other, so every push from a mirror workspace exec'd
+// with no GIT_ASKPASS and no tty and reported "could not read Username". That
+// reads as a dead token; the token was fine. A list fails the same way for the
+// next provider added, whereas the negative form makes the credentialed path
+// the default and leaves only the deliberate exception to state.
+func runsOnServer(kind uint32) bool { return kind != ProviderDetached }
+
+// mirrorBase resolves where the mirror tier keeps its server-side trees:
+// AIMEE_WORKSPACES_DIR when it names an absolute path (a deployment points this
+// at a persistent volume), else <aimee home>/workspaces. Mirrors
+// workspace_mirror_base(); the two are pinned to the same answer by the tests.
+func mirrorBase(aimeeHome string) string {
+	if env := os.Getenv("AIMEE_WORKSPACES_DIR"); strings.HasPrefix(env, "/") {
+		return env
+	}
+	if aimeeHome == "" {
+		return ""
+	}
+	return aimeeHome + "/workspaces"
+}
+
+// fnv1aHex8 reproduces the 8-hex FNV-1a the mirror tier keys its server-side
+// trees by. It must agree with the C derivation exactly — the two are compared
+// against shared vectors in the tests — because a disagreement here does not
+// fail loudly: it silently reports "no workspace owns this path", and the caller
+// concludes there is no credential to inject.
+func fnv1aHex8(s string) string {
+	var h uint32 = 2166136261
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+	return fmt.Sprintf("%08x", h)
+}
+
+// atOrUnder reports whether path is prefix itself or sits beneath it, comparing
+// whole path components: "/srv/repo" must never claim "/srv/repo-backup".
+func atOrUnder(path, prefix string) bool {
+	if prefix == "" || len(prefix) > len(path) || path[:len(prefix)] != prefix {
+		return false
+	}
+	return len(path) == len(prefix) || path[len(prefix)] == '/' || prefix[len(prefix)-1] == '/'
+}
+
+// workspaceForPath returns the registered root that owns path, or "".
+//
+// A registered root is not always where the work happens. A `mirror` workspace
+// is registered under the CLIENT's path — a directory that does not exist on
+// this server at all — while the server reconstructs a worktree under
+// <mirror base>/<hash(root)>/ and runs there. Matching only the registered root
+// therefore answers "no workspace" about the live checkout.
+//
+// The hashed PARENT is matched rather than the "work" directory: a live worktree
+// is generation-qualified ("work-1-<digest>"), so comparing against
+// "<base>/<hash>/work" misses the very directory git runs in.
+func workspaceForPath(cwd, mirrorBase string, workspaces []string) string {
+	if cwd == "" {
+		return ""
+	}
+	for _, root := range workspaces {
+		if root == "" {
+			continue
+		}
+		if atOrUnder(cwd, root) {
+			return root
+		}
+		if mirrorBase != "" && atOrUnder(cwd, mirrorBase+"/"+fnv1aHex8(root)) {
+			return root
+		}
+	}
+	return ""
+}
+
+// handleCredResolve serves git-credential-resolve (stage 5).
+func handleCredResolve(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	var decoded CredResolveRequest
+	if err := json.Unmarshal(request, &decoded); err != nil {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+	response := CredResolveResponse{RunsOnServer: runsOnServer(decoded.ProviderKind)}
+	if response.RunsOnServer {
+		response.Workspace = workspaceForPath(decoded.Cwd, mirrorBase(decoded.AimeeHome),
+			decoded.Workspaces)
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil || uint32(len(encoded)) > bus.ModuleMessageMaxBody {
+		return nil, bus.ModuleStatusInternal
+	}
+	return encoded, bus.ModuleStatusOK
+}

--- a/server-go/modules/git/cred_resolve_test.go
+++ b/server-go/modules/git/cred_resolve_test.go
@@ -1,0 +1,179 @@
+package git
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// The hash keys the mirror tier's server-side trees, and C derives it too
+// (fnv1a_hex8 in workspace_mirror.c). A disagreement does not fail loudly: it
+// reports "no workspace owns this path", the caller concludes there is no
+// credential to inject, and git runs bare. So pin exact values rather than
+// re-deriving them here — a test that recomputes the hash the same way agrees
+// with itself no matter which side drifted.
+//
+// The expected values were PRINTED BY THE C FUNCTION, not worked out by hand:
+// compile fnv1a_hex8 from src/modules/workspace/workspace_mirror.c and feed it
+// these strings. The first three are also the published FNV-1a 32-bit vectors,
+// so a wrong constant here shows up as disagreeing with the standard rather
+// than only with us. (Hand-deriving the fourth is how the first draft of this
+// test failed against a correct implementation.)
+func TestFNV1aHex8MatchesTheCDerivation(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"", "811c9dc5"},
+		{"a", "e40c292c"},
+		{"foobar", "bf9cf968"},
+		{"/home/someone/proj/.aimee/worktrees/076a64f1-deadbeef/main", "1f663ffc"},
+		{"/home/someone/proj/main", "691bf9f4"},
+		{"/home/someone/other", "f4965e2b"},
+	} {
+		if got := fnv1aHex8(tc.in); got != tc.want {
+			t.Fatalf("fnv1aHex8(%q) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRunsOnServerIsEverythingButDetached(t *testing.T) {
+	for _, kind := range []uint32{ProviderShared, ProviderMirror, ProviderContainer} {
+		if !runsOnServer(kind) {
+			t.Fatalf("provider kind %d must run on the server", kind)
+		}
+	}
+	if runsOnServer(ProviderDetached) {
+		t.Fatal("a detached workspace marshals git to its client and must not run here")
+	}
+	// An unknown kind must default to the credentialed server path, not fall
+	// into the bare one: that default is the whole point of the negative form.
+	if !runsOnServer(99) {
+		t.Fatal("an unrecognised provider kind must default to running on the server")
+	}
+}
+
+// The bug: a mirror workspace is registered under the CLIENT's path, which does
+// not exist on this server, while git runs in the reconstruction under
+// <base>/<hash(root)>/. Matching only the registered root answered "no
+// workspace" about the live checkout, so no credential was injected.
+func TestWorkspaceForPathCoversTheServerSideTree(t *testing.T) {
+	const root = "/home/someone/proj/.aimee/worktrees/076a64f1-deadbeef/main"
+	const base = "/var/lib/aimee-workspaces"
+	roots := []string{"/srv/other", root}
+	hashed := base + "/" + fnv1aHex8(root)
+
+	for _, cwd := range []string{
+		root,               // in place
+		root + "/src/x.c",  // beneath the registered root
+		hashed + "/work",   // the plain reconstruction
+		hashed + "/mirror", // the bare mirror
+		// Generation-qualified: the live worktree carries a generation and a
+		// digest, so an exact "<base>/<hash>/work" comparison misses it.
+		hashed + "/work-1-7df53596872a77b213ab54022a810bc7",
+		hashed + "/work-2-33265f6f97729ac86a284ce69a6c5f45/src/x.c",
+	} {
+		if got := workspaceForPath(cwd, base, roots); got != root {
+			t.Fatalf("workspaceForPath(%q) = %q, want the registered root %q", cwd, got, root)
+		}
+	}
+}
+
+// A containment test that says yes too often hands one workspace's credential to
+// work running outside it, so the misses matter as much as the hits.
+func TestWorkspaceForPathRejectsPathsItDoesNotOwn(t *testing.T) {
+	const root = "/home/someone/proj/main"
+	const base = "/var/lib/aimee-workspaces"
+	roots := []string{root}
+
+	for _, cwd := range []string{
+		"/var/tmp/not-a-workspace",
+		root + "-sibling", // shares a textual prefix only
+		base + "/" + fnv1aHex8("/home/someone/other") + "/work", // another workspace's tree
+		"",
+	} {
+		if got := workspaceForPath(cwd, base, roots); got != "" {
+			t.Fatalf("workspaceForPath(%q) = %q, want no owner", cwd, got)
+		}
+	}
+
+	// With no mirror base resolved, the hashed arm must simply not fire rather
+	// than match everything under "/".
+	if got := workspaceForPath(base+"/"+fnv1aHex8(root)+"/work", "", roots); got != "" {
+		t.Fatalf("with no mirror base the reconstruction must not resolve, got %q", got)
+	}
+}
+
+func TestHandleCredResolveAnswersBothQuestions(t *testing.T) {
+	const root = "/home/someone/proj/main"
+	const base = "/var/lib/aimee-workspaces"
+	t.Setenv("AIMEE_WORKSPACES_DIR", base)
+	live := base + "/" + fnv1aHex8(root) + "/work-1-abc"
+
+	request, err := json.Marshal(CredResolveRequest{
+		Cwd: live, ProviderKind: ProviderMirror, AimeeHome: "/unused", Workspaces: []string{root},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, status := Handle(bus.ModuleInvocation{StageID: StageCredResolve}, request)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v, want OK", status)
+	}
+	var decoded CredResolveResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.RunsOnServer {
+		t.Fatal("a mirror workspace runs git on the server")
+	}
+	if decoded.Workspace != root {
+		t.Fatalf("workspace = %q, want the registered root %q", decoded.Workspace, root)
+	}
+
+	// Detached: no server-side run, and no workspace is reported — the client
+	// holds its own credentials, and naming a workspace here would invite the
+	// caller to inject one anyway.
+	request, err = json.Marshal(CredResolveRequest{
+		Cwd: root, ProviderKind: ProviderDetached, AimeeHome: "/unused", Workspaces: []string{root},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, status = Handle(bus.ModuleInvocation{StageID: StageCredResolve}, request)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v, want OK", status)
+	}
+	decoded = CredResolveResponse{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.RunsOnServer || decoded.Workspace != "" {
+		t.Fatalf("detached must not run here nor name a workspace, got %+v", decoded)
+	}
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageCredResolve}, []byte("{")); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("malformed JSON must be rejected, got %v", status)
+	}
+}
+
+// mirrorBase must agree with workspace_mirror_base(): the env override wins only
+// when it names an absolute path, and otherwise the home decides. Getting this
+// wrong does not fail loudly — it points the hashed lookup at a directory that
+// holds nothing, so every mirror workspace silently reports "no owner" again.
+func TestMirrorBaseMatchesTheCResolution(t *testing.T) {
+	t.Setenv("AIMEE_WORKSPACES_DIR", "/mnt/vol/workspaces")
+	if got := mirrorBase("/home/u/.config/aimee"); got != "/mnt/vol/workspaces" {
+		t.Fatalf("an absolute env override must win, got %q", got)
+	}
+	// A relative value is not a path the C side would accept either.
+	t.Setenv("AIMEE_WORKSPACES_DIR", "relative/dir")
+	if got := mirrorBase("/home/u/.config/aimee"); got != "/home/u/.config/aimee/workspaces" {
+		t.Fatalf("a relative override must be ignored, got %q", got)
+	}
+	t.Setenv("AIMEE_WORKSPACES_DIR", "")
+	if got := mirrorBase("/home/u/.config/aimee"); got != "/home/u/.config/aimee/workspaces" {
+		t.Fatalf("base = %q, want the home-derived path", got)
+	}
+	if got := mirrorBase(""); got != "" {
+		t.Fatalf("with no home there is no base, got %q", got)
+	}
+}

--- a/server-go/modules/git/git.go
+++ b/server-go/modules/git/git.go
@@ -81,6 +81,8 @@ func validRef(ref string) bool {
 // Handle classifies Git operations and validates refs without repository I/O.
 func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
 	switch invocation.StageID {
+	case StageCredResolve:
+		return handleCredResolve(invocation, request)
 	case StageVerifyRun:
 		return handleVerifyState(invocation, request)
 	case StageCIGrade:

--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -9,8 +9,11 @@
 #include "platform_process.h"
 #include "util.h"
 #include "modules/workspace/workspace_provider.h"
+#include "headers/module_json_call.h"
 #include "forge_credentials.h"
 #include "git_cred_inject.h"
+#include "aimee_home.h"
+#include <aimee/git/module_api.h>
 #include <time.h>
 
 extern char **environ;
@@ -39,30 +42,73 @@ int mcp_git_get_worktree(void)
    return s_in_worktree;
 }
 
-/* Route a git/gh shell command-line to where aimee's git rails live. SHARED and
- * CONTAINER both run server-side (run_cmd) — a container-sandboxed delegate has no
- * git and no creds, so its git must run on the server against the path-identity
- * bind-mounted worktree; only a `detached` workspace marshals to its client-held
- * filesystem authority. See mcp_git_run for the rationale. */
-/* The registered workspace root containing `cwd`, copied into out[outsz].
- * Returns 0 on a match, -1 otherwise. */
-static int forge_workspace_for_cwd(const char *cwd, char *out, size_t outsz)
+#define GIT_CRED_RESOLVE_MAX_BODY   (256u * 1024u)
+#define GIT_CRED_RESOLVE_TIMEOUT_MS 5000
+
+/* Ask the git module where this command runs, and which workspace owns its cwd.
+ *
+ * Both are DECISIONS, so neither is taken here. This carries the facts the
+ * module cannot see — the active workspace's provider kind, the registered
+ * roots, and the mirror base, whose resolution reads the environment and the
+ * instance home — and applies the ruling. The module is server-go/modules/git
+ * (cred_resolve.go), reached as bus stage AIMEE_GIT_STAGE_CRED_RESOLVE.
+ *
+ * Deciding it here is what broke. The server-run test was a LIST of provider
+ * kinds that omitted `mirror`, and the cwd was prefix-matched against the
+ * registered root — which for a mirror workspace is the CLIENT's path, a
+ * directory that does not exist on this server, while git runs in a
+ * reconstruction elsewhere. Both said "not ours" about a live checkout, so the
+ * credential below was never injected and git ran bare: "could not read
+ * Username", indistinguishable from a dead token, while reads kept working
+ * because git_pr_api.c never execs git.
+ *
+ * On a module failure `*runs_on_server` stays 1 and no workspace is reported, so
+ * the command still runs here with no injected credential — the same ambient
+ * fall-through already documented for "no token", rather than a new failure
+ * mode. Returns 0 with `out` set when a workspace owns the cwd, -1 otherwise. */
+static int forge_workspace_for_cwd(const char *cwd, int provider_kind, int *runs_on_server,
+                                   char *out, size_t outsz)
 {
-   if (!cwd || !cwd[0])
+   if (out && outsz)
+      out[0] = '\0';
+   if (runs_on_server)
+      *runs_on_server = 1;
+
+   cJSON *request = cJSON_CreateObject();
+   if (!request)
       return -1;
-   for (int i = 0; i < config_workspace_count(); i++)
+   cJSON_AddStringToObject(request, "cwd", cwd ? cwd : "");
+   cJSON_AddNumberToObject(request, "provider_kind", provider_kind);
+   /* The instance home, not a mirror path: resolving where a provider puts its
+    * trees is the module's job, and reaching into the workspace module's headers
+    * to ask would be the cross-module coupling the bus exists to replace. */
+   const char *home = aimee_home();
+   cJSON_AddStringToObject(request, "aimee_home", home ? home : "");
+   cJSON *roots = cJSON_AddArrayToObject(request, "workspaces");
+   for (int i = 0; roots && i < config_workspace_count(); i++)
    {
-      const char *ws = config_workspaces(i);
-      size_t len = ws ? strlen(ws) : 0;
-      if (len == 0)
-         continue;
-      if (strncmp(cwd, ws, len) == 0 && (cwd[len] == '/' || cwd[len] == '\0'))
-      {
-         snprintf(out, outsz, "%s", ws);
-         return 0;
-      }
+      const char *root = config_workspaces(i);
+      if (root && root[0])
+         cJSON_AddItemToArray(roots, cJSON_CreateString(root));
    }
-   return -1;
+
+   cJSON *reply =
+       aimee_module_json_call(AIMEE_GIT_EVENT_CRED_RESOLVE, AIMEE_GIT_STAGE_CRED_RESOLVE, request,
+                              GIT_CRED_RESOLVE_MAX_BODY, GIT_CRED_RESOLVE_TIMEOUT_MS, NULL);
+   if (!reply)
+      return -1;
+   const cJSON *on_server = cJSON_GetObjectItemCaseSensitive(reply, "runs_on_server");
+   if (runs_on_server && cJSON_IsBool(on_server))
+      *runs_on_server = cJSON_IsTrue(on_server) ? 1 : 0;
+   const cJSON *owner = cJSON_GetObjectItemCaseSensitive(reply, "workspace");
+   int found = 0;
+   if (cJSON_IsString(owner) && owner->valuestring[0] && out && outsz)
+   {
+      snprintf(out, outsz, "%s", owner->valuestring);
+      found = 1;
+   }
+   cJSON_Delete(reply);
+   return found ? 0 : -1;
 }
 
 char *mcp_git_run(const char *cmd, int *exit_code)
@@ -77,10 +123,12 @@ char *mcp_git_run(const char *cmd, int *exit_code)
     * need the network the sandbox deliberately removes, and running git there would
     * push the forge credential into the sandbox this design exists to keep it out of.
     * The delegate's worktree is bind-mounted path-identically, so the server sees the
-    * delegate's edits at the same path. Run git on the server for SHARED and
-    * CONTAINER alike; only a DETACHED workspace (the client holds both the filesystem
-    * and its own creds) marshals git to the client and stays on the provider path. */
-   int run_on_server = (ws->kind == WS_PROVIDER_SHARED || ws->kind == WS_PROVIDER_CONTAINER);
+    * delegate's edits at the same path. Which kinds that covers is the module's
+    * ruling, not a list kept here — see forge_workspace_for_cwd. */
+   const char *cwd = run_cmd_get_cwd();
+   char wsid[MAX_PATH_LEN];
+   int run_on_server = 1;
+   int have_ws = forge_workspace_for_cwd(cwd, (int)ws->kind, &run_on_server, wsid, sizeof(wsid));
    const workspace_provider_t *exec_ws = run_on_server ? workspace_provider_shared() : ws;
 
    /* Credential injection: for a server-run command whose cwd is inside a registered
@@ -104,9 +152,7 @@ char *mcp_git_run(const char *cmd, int *exit_code)
     * sent at least one reader hunting for a broken OAuth that was never broken. */
    if (run_on_server)
    {
-      const char *cwd = run_cmd_get_cwd();
-      char wsid[MAX_PATH_LEN];
-      if (cwd && forge_workspace_for_cwd(cwd, wsid, sizeof(wsid)) == 0)
+      if (have_ws == 0)
       {
          /* Resolve the git credential through the ONE policy
           * (git_cred_inject_build_env_for_repo) so the precedence never drifts

--- a/src/modules/git/module.yaml
+++ b/src/modules/git/module.yaml
@@ -46,11 +46,13 @@
   ],
   "go_sources": [
     "server-go/modules/git/ci_grade.go",
+    "server-go/modules/git/cred_resolve.go",
     "server-go/modules/git/git.go",
     "server-go/modules/git/verify_state.go"
   ],
   "go_tests": [
     "server-go/modules/git/ci_grade_test.go",
+    "server-go/modules/git/cred_resolve_test.go",
     "server-go/modules/git/git_test.go",
     "server-go/modules/git/verify_state_test.go"
   ],


### PR DESCRIPTION
Replaces #2486, which had the right diagnosis and put the fix in the wrong language.

`git push` from a `mirror` workspace failed with "could not read Username", which reads as a dead credential. The vault was fine — the audit log shows the host credential resolving `ok` at the second of the push — and reads kept working because `git_pr_api.c` uses the token in-process and never execs git. That asymmetry, `pr list` fine while every push failed, is what made a routing bug look like a token one.

## Two decisions in C were wrong, and both were wrong *because* they were in C

- the server-run test was a **list of provider kinds** that omitted `mirror`, whose git runs on the server like any other
- the cwd was **prefix-matched against the registered root** — which for a mirror is the CLIENT's path, a directory that does not exist on this server, while git runs in a reconstruction elsewhere

Both said "not ours" about a live checkout, so the credential block was skipped and git exec'd with no `GIT_ASKPASS` and no tty.

## The destination already existed

| | |
|---|---|
| `server-go/modules/git/git.go` | declares `StageCredResolve` (5) / `EventCredResolve` (7429) as *"the destination for the I/O that still lives in C: the forge HTTP client, credential resolution, and the verify pipeline… No handler serves them yet."* |
| `src/modules/git/include/aimee/git/module_api.h` | declares the same constants |
| `src/modules/process-contracts.json` | already lists `git-credential-resolve` |

Only the handler was missing. So this **adds the handler** and changes no contract.

## What C keeps

C carries facts and applies a ruling: the active provider kind, the registered roots, and the instance home. Deliberately the **home**, not a mirror path — where a provider materialises a root is itself a decision, so the module derives it.

An earlier draft called `workspace_mirror_base()` from the git module and `module-bus-boundary` **rejected it, correctly**: that is the cross-module coupling the bus exists to replace. The gate still reports **167 declared crossings, unchanged** — nothing was declared to make this pass.

On a module failure the command still runs here with no injected credential — the ambient fall-through already documented for "no token", not a new failure mode.

## Tests

| test | pins |
|---|---|
| `fnv1aHex8` | vectors **printed by the C function**, not hand-derived — a drift between the two hashes does not fail loudly, it reports "no workspace owns this path" and git runs bare. Three are the published FNV-1a vectors, so a wrong constant disagrees with the standard too. |
| `runsOnServer` | everything but detached, **including an unrecognised kind** — that default is the whole point of the negative form |
| `workspaceForPath` | in-place roots, the bare mirror, the plain reconstruction and generation-qualified `work-1`/`work-2` paths resolve; an unrelated path, another workspace's tree, and a sibling sharing a textual prefix all miss |
| `mirrorBase` | the env override wins only when absolute, else the home decides — matching `workspace_mirror_base()` |

Red-proven: with the hashed arm removed, `workspaceForPath` and the handler test both fail on the reconstruction.

Worth recording — **I hand-derived one hash vector and it was wrong against a correct implementation.** The value now comes from compiling `fnv1a_hex8` and printing it. The misses matter as much as the hits here: a containment test that says yes too often hands one workspace's credential to work running outside it.

## Verification

- `go test ./...` across every module, `gofmt`, `go vet` clean
- full `make unit-tests` green; all three binaries build under `-Werror`
- `make lint` 48/48; `module-bus-boundary` ok **and unchanged**; `validate_module_process_contracts` ok; `check_go_module_runtime_bundle` ok (17 Go, 0 C)
- `refactor_baselines`, `module_inventory`, `source_ownership`, `cleanup_ledger` ok; `git` pin refreshed with the checker's own `digest_files()`
