### PR TITLE
One owner for what a workspace name may be

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -203,7 +203,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e02bc3213730126e6a849e19442e19a6fd5867a338be2a8529eef2fcbea5d0e4",
+      "source_sha256": "cb1f3e6a1f908a5881f368643b30051374e2adf1e19bf3c61d03cd86a670f7f2",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,

--- a/src/modules/workspace/workspace_scope.c
+++ b/src/modules/workspace/workspace_scope.c
@@ -33,28 +33,19 @@ void ws_scope_register_ref_validator(ws_scope_ref_validator_fn validator)
 
 int ws_scope_name_valid(const char *name)
 {
-   if (!name || !name[0])
+   /* One owner for what a name may be. This used to restate the module's rule
+    * in C -- the same alphabet, the same 64-byte cap, the same refusal of "."
+    * and ".." -- with nothing in the build keeping the two copies in step, so
+    * either could be tightened alone and the seams would disagree about the
+    * same string.
+    *
+    * A name is simply a ref with no separator in it: the module answers a
+    * slash-free ref by asking exactly the name question. So reject the
+    * separator here, which is the only part that is about being a single
+    * component, and let the module decide the rest. */
+   if (!name || !name[0] || strchr(name, '/'))
       return 0;
-   size_t n = strlen(name);
-   if (n > WS_NAME_MAX)
-      return 0;
-   if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
-      return 0;
-   /* First char alnum (no leading '.', '-' — keeps names off hidden files and
-    * away from looking like CLI flags downstream). */
-   unsigned char c0 = (unsigned char)name[0];
-   int alnum0 = (c0 >= 'A' && c0 <= 'Z') || (c0 >= 'a' && c0 <= 'z') || (c0 >= '0' && c0 <= '9');
-   if (!alnum0)
-      return 0;
-   for (size_t i = 0; i < n; i++)
-   {
-      unsigned char c = (unsigned char)name[i];
-      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-               c == '.' || c == '_' || c == '-';
-      if (!ok)
-         return 0;
-   }
-   return 1;
+   return ws_scope_project_ref_valid(name, strlen(name));
 }
 
 int ws_scope_project_ref_valid(const char *buf, size_t len)

--- a/src/tests/test_workspace_scope.c
+++ b/src/tests/test_workspace_scope.c
@@ -45,6 +45,14 @@ int main(void)
    assert(mkdtemp(dir) != NULL);
    setenv("AIMEE_WORKSPACES_DIR", dir, 1);
 
+   /* Both admission questions fail closed until the module that owns them is
+    * reachable. A name is a ref with no separator, so it is the same rule and
+    * the same owner: neither may answer "allowed" from a local guess just
+    * because the module cannot be asked. */
+   assert(!ws_scope_project_ref_valid("foo", 3));
+   assert(!ws_scope_name_valid("alice"));
+   ws_scope_register_ref_validator(validate_ref_via_module);
+
    /* --- name validation --- */
    assert(ws_scope_name_valid("alice"));
    assert(ws_scope_name_valid("a.b_c-1"));
@@ -64,12 +72,6 @@ int main(void)
    n65[65] = '\0';
    assert(ws_scope_name_valid(n64));
    assert(!ws_scope_name_valid(n65));
-
-   /* Project references fail closed until the event-bus provider is installed.
-    * The unit test then uses the C wire-parity fixture for the supervised Go
-    * workspace stage. */
-   assert(!ws_scope_project_ref_valid("foo", 3));
-   ws_scope_register_ref_validator(validate_ref_via_module);
 
    /* cap==0 / NULL out are rejected, not written */
    char tiny[1];


### PR DESCRIPTION
Removes a duplicated rule: `ws_scope_name_valid` restated in C what the workspace module already decides.

## The duplication

`src/modules/workspace/workspace_scope.c` carried its own copy of "what may a name be" — the same alphabet, the same 64-byte cap, the same refusal of `.` and `..` — while its sibling `ws_scope_project_ref_valid` already asked the module. Nothing in the build kept the two in step, so either could be tightened alone and the seams would then disagree about the same string. That is exactly the state `docs/proposals/pending/c-to-go-module-migration-state.md` warns about: *"Never leave the rule in two languages."*

## Why delegation is exact, not approximate

A name is a ref with no separator. The module's `ref_valid` returns `name_valid(ref)` when the ref contains no `/`, so for a slash-free string the two questions are the same question. C therefore keeps only the part that is genuinely about being a single component — rejecting the separator — and the module decides the rest.

## Fails closed

`ws_scope_name_valid` now returns 0 before the module is reachable, matching the ref path. That is deliberate: neither admission question may answer "allowed" from a local guess just because the module cannot be asked. The test asserts that state explicitly instead of registering the provider first and never covering it.

## The parity is demonstrated, not assumed

Both implementations agreed today, so a test that merely passes proves nothing. Loosening the **module's** leading-character rule makes `ws_scope_name_valid(".hidden")` start returning true and the test fail — so C is verifiably reading the module's answer rather than coincidentally agreeing with it.

## Blast radius

Callers are `ws_registry.c`, `git_project.c`, `webuser_editor.c` — all server-side. KB links `workspace_scope.c` but registers no validator (it has its own `kb_module_stage_adapters_configure`) and links none of those callers, so no KB path reaches this.

## Verification

C `unit-tests`, `make lint` (48 checks), and every step of the module-inventory job: `check_module_inventory.sh`, `refactor_baselines.py`, `check_cleanup_ledger.py`, `check_module_source_ownership.py`, `check_module_bus_boundary.py`, `check_module_docs.py`, `check_module_test_registration.py`, plus `check-docs.py`, `check-module-boundary.py` and the repo lock.
