### PR TITLE
refactor(git): run the default-branch lookup in the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -224,7 +224,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "152a072635b6d4dc63b61d38d614faa9369894cb6ba54a96febd1f55f4a9ec36",
+      "source_sha256": "1c9d6829fca4a749bf9e6bc50f4bac039741ccc3746189dc6e85f86fd27b8d1d",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -104,7 +104,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "970b7b42139ce637a143003adf60268a60339ce627bc159b2f435af8ed3314a0",
+      "source_sha256": "30b7faafaa6d74eae30fb2129ac165bf49b8504f02008401f7cbf94590c5fe83",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 7,

--- a/server-go/modules/memory/embed.go
+++ b/server-go/modules/memory/embed.go
@@ -1,0 +1,279 @@
+package memory
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Breaker defaults, matching DEPENDENCY_BREAKER_DEFAULT_* in C.
+const (
+	breakerThreshold = 3
+	breakerBaseMS    = int64(1000)
+	breakerMaxMS     = int64(30000)
+	embedTimeout     = 20 * time.Second
+)
+
+// embedBreaker is a process-local circuit breaker for the embedder.
+//
+// It lives here because it is STATE, and state belongs to the module. It
+// performs no retries: after `threshold` consecutive failures it suppresses
+// calls for a bounded, jittered, exponential delay and then grants exactly ONE
+// half-open probe. One, not "some": if every suppressed caller probed at once,
+// a recovering embedder would be hit by the whole backlog at the moment it came
+// back, which is the outage the breaker exists to prevent.
+type embedBreaker struct {
+	mu            sync.Mutex
+	failureStreak uint32
+	openCount     uint32
+	probeInflight bool
+	openedAtMS    int64
+	retryAtMS     int64
+	lastSuccessMS int64
+	lastFailureMS int64
+	suppressed    uint64
+}
+
+var breaker embedBreaker
+
+// allow reports whether a call may proceed, and how long until the next chance
+// when it may not.
+func (b *embedBreaker) allow(nowMS int64) (bool, int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.retryAtMS <= 0 {
+		return true, 0
+	}
+	// A BACKWARD wall-clock jump must not extend a bounded outage forever: if
+	// now precedes the moment the breaker opened, the clock moved under us and
+	// the delay can never elapse on its own.
+	eligible := nowMS >= b.retryAtMS || nowMS < b.openedAtMS
+	if eligible && !b.probeInflight {
+		b.probeInflight = true
+		return true, 0
+	}
+	b.suppressed++
+	if !eligible {
+		return false, b.retryAtMS - nowMS
+	}
+	return false, 0
+}
+
+func (b *embedBreaker) reportSuccess(nowMS int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.failureStreak, b.openCount, b.probeInflight = 0, 0, false
+	b.openedAtMS, b.retryAtMS = 0, 0
+	b.lastSuccessMS = nowMS
+}
+
+// cancelProbe releases a claimed probe when a LOCAL error stopped the call from
+// happening. Neither success nor failure may be inferred from that — counting it
+// as either would let a local misconfiguration open the breaker against a
+// dependency that was never contacted.
+func (b *embedBreaker) cancelProbe() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.probeInflight = false
+}
+
+func breakerDelayMS(openCount uint32, nowMS, baseMS, maxMS int64) int64 {
+	if baseMS < 1 {
+		baseMS = 1
+	}
+	if maxMS < baseMS {
+		maxMS = baseMS
+	}
+	delay := baseMS
+	for i := uint32(0); i < openCount && delay < maxMS; i++ {
+		if delay > maxMS/2 {
+			delay = maxMS
+		} else {
+			delay *= 2
+		}
+	}
+	jitterCap := delay / 4
+	if jitterCap > maxMS-delay {
+		jitterCap = maxMS - delay
+	}
+	if jitterCap > 0 {
+		// Deterministic in (now, openCount) rather than random: a breaker whose
+		// delay cannot be reproduced cannot be tested.
+		mixed := uint64(nowMS) ^ (uint64(openCount+1) * 0x9e3779b97f4a7c15)
+		delay += int64(mixed % uint64(jitterCap+1))
+	}
+	return delay
+}
+
+func (b *embedBreaker) reportFailure(nowMS int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.failureStreak < ^uint32(0) {
+		b.failureStreak++
+	}
+	b.lastFailureMS = nowMS
+	b.probeInflight = false
+	if b.failureStreak >= breakerThreshold {
+		b.openedAtMS = nowMS
+		b.retryAtMS = nowMS + breakerDelayMS(b.openCount, nowMS, breakerBaseMS, breakerMaxMS)
+		if b.openCount < ^uint32(0) {
+			b.openCount++
+		}
+	}
+}
+
+// EmbedRequest asks the module to embed one text.
+//
+// NowMS lets the caller supply the clock (the C side has an injectable clock for
+// the same reason): a breaker tested against the wall clock can only be tested
+// by sleeping.
+type EmbedRequest struct {
+	BaseURL   string `json:"base_url"`
+	InputType string `json:"input_type"`
+	Text      string `json:"text"`
+	MaxDim    int    `json:"max_dim"`
+	NowMS     int64  `json:"now_ms,omitempty"`
+}
+
+// EmbedResponse separates the ways this can decline, because they are different
+// facts and a caller that conflates them misreports the embedder's health:
+//
+//	Unavailable  the breaker suppressed the call; nothing was sent
+//	Unauthorized the service was REACHED and refused us (401/403)
+//	Error        the call was attempted and failed
+//
+// Unauthorized is the subtle one: it proves reachability, so it must not count
+// as a failure — and it closes an earlier outage, or a half-open breaker would
+// turn the next authorization result back into "unavailable".
+type EmbedResponse struct {
+	Vector       []float32 `json:"vector,omitempty"`
+	Dim          int       `json:"dim"`
+	Truncated    bool      `json:"truncated,omitempty"`
+	Unavailable  bool      `json:"unavailable,omitempty"`
+	RetryAfterMS int64     `json:"retry_after_ms,omitempty"`
+	Unauthorized bool      `json:"unauthorized,omitempty"`
+	Error        string    `json:"error,omitempty"`
+}
+
+var embedHTTPClient = &http.Client{Timeout: embedTimeout}
+
+// EmbedIsHTTP reports whether a configured embedder command names an HTTP
+// endpoint rather than a program to run.
+func EmbedIsHTTP(command string) bool {
+	return strings.HasPrefix(command, "http://") || strings.HasPrefix(command, "https://")
+}
+
+func nowOr(nowMS int64) int64 {
+	if nowMS > 0 {
+		return nowMS
+	}
+	return time.Now().UnixMilli()
+}
+
+// Embed performs one embedding, owning the breaker around it.
+func Embed(request EmbedRequest) EmbedResponse {
+	now := nowOr(request.NowMS)
+
+	if !EmbedIsHTTP(request.BaseURL) {
+		// A program-based embedder is still driven from C; declining here without
+		// touching the breaker keeps that path's health accounting intact.
+		return EmbedResponse{Error: "embed: base_url is not an http endpoint"}
+	}
+	if request.MaxDim <= 0 {
+		return EmbedResponse{Error: "embed: max_dim must be positive"}
+	}
+
+	allowed, retryAfter := breaker.allow(now)
+	if !allowed {
+		return EmbedResponse{Unavailable: true, RetryAfterMS: retryAfter}
+	}
+
+	if request.Text == "" {
+		// A local refusal, not a dependency verdict: release the probe rather
+		// than blaming the embedder for it.
+		breaker.cancelProbe()
+		return EmbedResponse{Error: "embed: empty text"}
+	}
+
+	// The polarity rides in the query string because the body IS the raw text.
+	endpoint := strings.TrimSuffix(request.BaseURL, "/") + "/embed"
+	if request.InputType != "" {
+		endpoint += "?input_type=" + url.QueryEscape(request.InputType)
+	}
+	httpRequest, err := http.NewRequest(http.MethodPost, endpoint,
+		bytes.NewReader([]byte(request.Text)))
+	if err != nil {
+		breaker.cancelProbe()
+		return EmbedResponse{Error: "embed: " + err.Error()}
+	}
+	httpRequest.Header.Set("Content-Type", "text/plain")
+
+	response, err := embedHTTPClient.Do(httpRequest)
+	if err != nil {
+		breaker.reportFailure(now)
+		return EmbedResponse{Error: "embed: " + err.Error()}
+	}
+	defer response.Body.Close()
+	payload, readErr := io.ReadAll(io.LimitReader(response.Body, int64(bus.ModuleMessageMaxBody)))
+
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+		// Reached and refused. Non-retryable, and it CLOSES any earlier outage.
+		breaker.reportSuccess(now)
+		return EmbedResponse{Unauthorized: true,
+			Error: fmt.Sprintf("embed: not authorized (HTTP %d)", response.StatusCode)}
+	}
+	if readErr != nil || response.StatusCode < 200 || response.StatusCode > 299 || len(payload) == 0 {
+		breaker.reportFailure(now)
+		return EmbedResponse{Error: fmt.Sprintf("embed: HTTP %d", response.StatusCode)}
+	}
+
+	var raw []float64
+	if json.Unmarshal(payload, &raw) != nil {
+		breaker.reportFailure(now)
+		return EmbedResponse{Error: "embed: response is not a JSON array of numbers"}
+	}
+
+	out := EmbedResponse{}
+	// Truncation is REPORTED, never silent: keeping the first max_dim leaves the
+	// stored and query vectors inconsistent with the model's real output and
+	// quietly degrades recall, so an operator has to be told to raise the cap.
+	if len(raw) > request.MaxDim {
+		out.Truncated = true
+		raw = raw[:request.MaxDim]
+	}
+	out.Vector = make([]float32, len(raw))
+	for i, v := range raw {
+		out.Vector[i] = float32(v)
+	}
+	out.Dim = len(out.Vector)
+	if out.Dim == 0 {
+		breaker.reportFailure(now)
+		return EmbedResponse{Error: "embed: response carried no dimensions"}
+	}
+	breaker.reportSuccess(now)
+	return out
+}
+
+// handleEmbed serves memory:3 embedding.
+func handleEmbed(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	var decoded EmbedRequest
+	if err := json.Unmarshal(request, &decoded); err != nil {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+	encoded, err := json.Marshal(Embed(decoded))
+	if err != nil || uint32(len(encoded)) > bus.ModuleMessageMaxBody {
+		return nil, bus.ModuleStatusInternal
+	}
+	return encoded, bus.ModuleStatusOK
+}

--- a/server-go/modules/memory/embed_test.go
+++ b/server-go/modules/memory/embed_test.go
@@ -1,0 +1,273 @@
+package memory
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Each test starts from a closed breaker: the state is process-local, so a test
+// that inherits an open breaker from the one before it passes or fails for
+// reasons that have nothing to do with what it asserts.
+func resetBreaker(t *testing.T) {
+	t.Helper()
+	breaker = embedBreaker{}
+	t.Cleanup(func() { breaker = embedBreaker{} })
+}
+
+type embedStub struct {
+	path, body, contentType string
+	status                  int
+	reply                   string
+	calls                   int
+}
+
+func (s *embedStub) start(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.calls++
+		s.path = r.URL.RequestURI()
+		s.contentType = r.Header.Get("Content-Type")
+		buf := make([]byte, r.ContentLength)
+		if r.ContentLength > 0 {
+			_, _ = r.Body.Read(buf)
+		}
+		s.body = string(buf)
+		if s.status == 0 {
+			s.status = 200
+		}
+		w.WriteHeader(s.status)
+		_, _ = w.Write([]byte(s.reply))
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func TestEmbedPostsRawTextWithThePolarityInTheQuery(t *testing.T) {
+	resetBreaker(t)
+	stub := &embedStub{reply: `[0.5,-0.25,1]`}
+	base := stub.start(t)
+
+	out := Embed(EmbedRequest{BaseURL: base, InputType: "query", Text: "hello", MaxDim: 8, NowMS: 1000})
+	if out.Error != "" {
+		t.Fatalf("unexpected error: %s", out.Error)
+	}
+	// The body IS the raw text, which is why the polarity has to ride in the
+	// query string; embedding a query as a document silently degrades recall.
+	if stub.body != "hello" {
+		t.Fatalf("body = %q, want the raw text", stub.body)
+	}
+	if !strings.Contains(stub.path, "/embed") || !strings.Contains(stub.path, "input_type=query") {
+		t.Fatalf("path = %q", stub.path)
+	}
+	if out.Dim != 3 || out.Vector[0] != 0.5 || out.Vector[1] != -0.25 {
+		t.Fatalf("vector = %+v", out)
+	}
+}
+
+// Truncation must be REPORTED. Keeping the first max_dim leaves stored and query
+// vectors inconsistent with the model's real output and quietly degrades recall,
+// so silence here is the failure.
+func TestEmbedReportsTruncationRatherThanHidingIt(t *testing.T) {
+	resetBreaker(t)
+	stub := &embedStub{reply: `[1,2,3,4,5]`}
+	base := stub.start(t)
+
+	out := Embed(EmbedRequest{BaseURL: base, Text: "t", MaxDim: 3, NowMS: 1000})
+	if !out.Truncated {
+		t.Fatal("over-long output must be reported as truncated")
+	}
+	if out.Dim != 3 {
+		t.Fatalf("dim = %d, want the cap", out.Dim)
+	}
+
+	// At or under the cap there is nothing to report.
+	resetBreaker(t)
+	stub2 := &embedStub{reply: `[1,2,3]`}
+	out = Embed(EmbedRequest{BaseURL: stub2.start(t), Text: "t", MaxDim: 3, NowMS: 1000})
+	if out.Truncated || out.Dim != 3 {
+		t.Fatalf("exactly at the cap is not truncation: %+v", out)
+	}
+}
+
+// 401/403 proves the service is REACHABLE. Counting it as a failure would open
+// the breaker against a service that answered, and a half-open breaker would
+// then turn the next authorization result back into "unavailable".
+func TestUnauthorizedIsReachabilityNotFailure(t *testing.T) {
+	resetBreaker(t)
+	// Put the breaker most of the way to open first, so a miscount would show.
+	breaker.reportFailure(1000)
+	breaker.reportFailure(1000)
+
+	stub := &embedStub{status: 401, reply: `nope`}
+	out := Embed(EmbedRequest{BaseURL: stub.start(t), Text: "t", MaxDim: 4, NowMS: 2000})
+
+	if !out.Unauthorized || out.Error == "" {
+		t.Fatalf("out = %+v", out)
+	}
+	if out.Unavailable {
+		t.Fatal("unauthorized is not unavailable: the service answered")
+	}
+	// It CLOSES the earlier outage rather than adding to it.
+	if breaker.failureStreak != 0 || breaker.retryAtMS != 0 {
+		t.Fatalf("breaker must be closed after a reachable refusal: streak=%d retryAt=%d",
+			breaker.failureStreak, breaker.retryAtMS)
+	}
+}
+
+func TestBreakerOpensAfterThreeFailuresAndSuppressesWithoutCalling(t *testing.T) {
+	resetBreaker(t)
+	stub := &embedStub{status: 500, reply: ``}
+	base := stub.start(t)
+
+	for i := 0; i < breakerThreshold; i++ {
+		out := Embed(EmbedRequest{BaseURL: base, Text: "t", MaxDim: 4, NowMS: 1000})
+		if out.Error == "" {
+			t.Fatalf("attempt %d should have failed", i)
+		}
+		if out.Unavailable {
+			t.Fatalf("attempt %d was suppressed too early", i)
+		}
+	}
+	callsBefore := stub.calls
+
+	// Now suppressed: the point of the breaker is that NOTHING is sent.
+	out := Embed(EmbedRequest{BaseURL: base, Text: "t", MaxDim: 4, NowMS: 1001})
+	if !out.Unavailable {
+		t.Fatalf("the breaker should be open: %+v", out)
+	}
+	if out.RetryAfterMS <= 0 {
+		t.Fatalf("a suppressed call must say when to retry, got %d", out.RetryAfterMS)
+	}
+	if stub.calls != callsBefore {
+		t.Fatalf("a suppressed call must not reach the service (%d -> %d)", callsBefore, stub.calls)
+	}
+}
+
+// Exactly ONE half-open probe. If every suppressed caller probed at once, a
+// recovering embedder would take the whole backlog the moment it came back —
+// the outage the breaker exists to prevent.
+func TestOnlyOneProbeIsGrantedWhenTheDelayElapses(t *testing.T) {
+	resetBreaker(t)
+	for i := 0; i < breakerThreshold; i++ {
+		breaker.reportFailure(1000)
+	}
+	after := breaker.retryAtMS + 1
+
+	if allowed, _ := breaker.allow(after); !allowed {
+		t.Fatal("the first caller after the delay must get the probe")
+	}
+	if allowed, _ := breaker.allow(after); allowed {
+		t.Fatal("a second concurrent caller must not also probe")
+	}
+}
+
+// A backward wall-clock jump must not extend a bounded outage forever: if now
+// precedes the moment it opened, the delay can never elapse on its own.
+func TestBackwardClockJumpDoesNotStrandTheBreakerOpen(t *testing.T) {
+	resetBreaker(t)
+	for i := 0; i < breakerThreshold; i++ {
+		breaker.reportFailure(1_000_000)
+	}
+	if allowed, _ := breaker.allow(1); !allowed {
+		t.Fatal("a now earlier than opened_at must be eligible to probe")
+	}
+}
+
+// A LOCAL refusal never blames the dependency: it releases the claimed probe so
+// a misconfiguration cannot open the breaker against a service never contacted.
+func TestLocalRefusalReleasesTheProbeWithoutCountingAFailure(t *testing.T) {
+	resetBreaker(t)
+	stub := &embedStub{reply: `[1]`}
+	base := stub.start(t)
+
+	out := Embed(EmbedRequest{BaseURL: base, Text: "", MaxDim: 4, NowMS: 1000})
+	if out.Error == "" {
+		t.Fatal("empty text must be refused")
+	}
+	if stub.calls != 0 {
+		t.Fatal("nothing should have been sent")
+	}
+	if breaker.failureStreak != 0 {
+		t.Fatalf("a local refusal is not a dependency failure: streak = %d", breaker.failureStreak)
+	}
+	if breaker.probeInflight {
+		t.Fatal("the claimed probe must be released")
+	}
+}
+
+func TestSuccessClosesAnEarlierOutage(t *testing.T) {
+	resetBreaker(t)
+	breaker.reportFailure(1000)
+	breaker.reportFailure(1000)
+	stub := &embedStub{reply: `[1,2]`}
+	if out := Embed(EmbedRequest{BaseURL: stub.start(t), Text: "t", MaxDim: 4, NowMS: 2000}); out.Error != "" {
+		t.Fatalf("unexpected: %+v", out)
+	}
+	if breaker.failureStreak != 0 || breaker.openCount != 0 {
+		t.Fatalf("success must reset the streak: streak=%d openCount=%d",
+			breaker.failureStreak, breaker.openCount)
+	}
+}
+
+func TestDelayGrowsAndIsCapped(t *testing.T) {
+	// Exponential from the base, capped at the max — and deterministic, so it
+	// can be asserted at all.
+	first := breakerDelayMS(0, 1000, breakerBaseMS, breakerMaxMS)
+	second := breakerDelayMS(1, 1000, breakerBaseMS, breakerMaxMS)
+	if first < breakerBaseMS || second <= first {
+		t.Fatalf("delay must grow: %d then %d", first, second)
+	}
+	if capped := breakerDelayMS(99, 1000, breakerBaseMS, breakerMaxMS); capped > breakerMaxMS {
+		t.Fatalf("delay %d exceeded the cap %d", capped, breakerMaxMS)
+	}
+	if again := breakerDelayMS(1, 1000, breakerBaseMS, breakerMaxMS); again != second {
+		t.Fatal("the same inputs must give the same delay")
+	}
+}
+
+func TestNonHTTPEmbedderIsDeclinedWithoutTouchingTheBreaker(t *testing.T) {
+	resetBreaker(t)
+	out := Embed(EmbedRequest{BaseURL: "/usr/local/bin/embed", Text: "t", MaxDim: 4, NowMS: 1000})
+	if out.Error == "" {
+		t.Fatal("a program-based embedder is not served here")
+	}
+	// That path's health is still accounted for in C; touching this breaker
+	// would corrupt an accounting this module does not own.
+	if breaker.failureStreak != 0 || breaker.probeInflight {
+		t.Fatalf("breaker must be untouched: streak=%d probe=%v",
+			breaker.failureStreak, breaker.probeInflight)
+	}
+	if !EmbedIsHTTP("https://host/x") || EmbedIsHTTP("/usr/bin/x") {
+		t.Fatal("EmbedIsHTTP misclassified")
+	}
+}
+
+func TestHandleEmbedRoutesThroughStageThree(t *testing.T) {
+	resetBreaker(t)
+	stub := &embedStub{reply: `[0.25,0.5]`}
+	request, err := json.Marshal(EmbedRequest{
+		BaseURL: stub.start(t), InputType: "document", Text: "t", MaxDim: 4, NowMS: 1000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, status := Handle(bus.ModuleInvocation{StageID: StageEmbed}, request)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", status)
+	}
+	var decoded EmbedResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Dim != 2 || decoded.Vector[1] != 0.5 {
+		t.Fatalf("decoded = %+v", decoded)
+	}
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageEmbed}, []byte("{")); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("malformed JSON must be rejected, got %v", status)
+	}
+}

--- a/server-go/modules/memory/memory.go
+++ b/server-go/modules/memory/memory.go
@@ -78,6 +78,8 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 		return handleExtract(invocation, request)
 	case StageRetrieve:
 		return handleRetrieve(invocation, request)
+	case StageEmbed:
+		return handleEmbed(invocation, request)
 	}
 	return handleRerank(invocation, request)
 }

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -8,6 +8,9 @@
 #include "git_cred_inject.h" /* git_cred_inject_resolve_token — the ONE cred policy */
 #include "util.h"            /* run_cmd */
 
+#include "headers/module_json_call.h" /* forge operations run in the module */
+#include <aimee/git/module_api.h>
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -288,38 +291,63 @@ static int gh_get(const gh_ctx_t *cx, const char *path, char **resp)
  * was passed and the local origin/HEAD cache is unset/stale. Returns 0 with buf
  * filled, or -1 — callers must NOT fall back to guessing "main": a repo whose
  * default is e.g. "testing" would get its PR opened against the wrong branch. */
+#define FORGE_STAGE_MAX_BODY   (1024u * 1024u)
+#define FORGE_STAGE_TIMEOUT_MS 25000
+
+/* Run one forge operation in the git module (bus stage 4,
+ * server-go/modules/git/forge_request.go). Which endpoint, which method and
+ * what the answer means are decisions and live there; this carries the facts and
+ * applies the ruling.
+ *
+ * `extra` is merged into the request and consumed. Returns the reply (caller
+ * frees) or NULL when the module could not be reached. */
+static cJSON *forge_stage(const gh_ctx_t *cx, const char *op, cJSON *extra)
+{
+   cJSON *request = cJSON_CreateObject();
+   if (!request)
+   {
+      cJSON_Delete(extra);
+      return NULL;
+   }
+   cJSON_AddStringToObject(request, "op", op);
+   cJSON_AddStringToObject(request, "owner", cx->owner);
+   cJSON_AddStringToObject(request, "repo", cx->repo);
+   cJSON_AddStringToObject(request, "token", cx->token);
+   if (extra)
+   {
+      cJSON *field = extra->child;
+      while (field)
+      {
+         cJSON *next = field->next;
+         cJSON_DetachItemViaPointer(extra, field);
+         cJSON_AddItemToObject(request, field->string, field);
+         field = next;
+      }
+      cJSON_Delete(extra);
+   }
+   return aimee_module_json_call(AIMEE_GIT_EVENT_FORGE_REQUEST, AIMEE_GIT_STAGE_FORGE_REQUEST,
+                                 request, FORGE_STAGE_MAX_BODY, FORGE_STAGE_TIMEOUT_MS, NULL);
+}
+
 static int gh_default_branch(const gh_ctx_t *cx, char *buf, size_t n)
 {
    if (!buf || n == 0)
       return -1;
    buf[0] = '\0';
-   /* Build the URL directly: gh_get() appends a trailing "/<path>", and GitHub
-    * 404s GET /repos/<owner>/<repo>/ (trailing slash) — only the bare form works. */
-   char url[512];
-   if ((size_t)snprintf(url, sizeof(url), "https://api.github.com/repos/%s/%s", cx->owner,
-                        cx->repo) >= sizeof(url))
+   cJSON *reply = forge_stage(cx, "default_branch", NULL);
+   if (!reply)
       return -1;
-   char hdrs[480];
-   if ((size_t)snprintf(hdrs, sizeof(hdrs), "Authorization: Bearer %s\n" GH_ACCEPT, cx->token) >=
-       sizeof(hdrs))
-      return -1;
-   char *resp = NULL;
-   int st = agent_http_get(url, hdrs, &resp, 20000);
-   wipe(hdrs, sizeof(hdrs));
+   const cJSON *branch = cJSON_GetObjectItemCaseSensitive(reply, "default_branch");
    int rc = -1;
-   if (st >= 200 && st < 300 && resp)
+   /* The answer is authoritative: a caller must NOT fall back to guessing
+    * "main", because a repo whose default is "testing" would get its PR opened
+    * against the wrong branch. An empty answer stays a failure. */
+   if (cJSON_IsString(branch) && branch->valuestring[0] && strlen(branch->valuestring) < n)
    {
-      cJSON *j = cJSON_Parse(resp);
-      const cJSON *db = j ? cJSON_GetObjectItem(j, "default_branch") : NULL;
-      if (cJSON_IsString(db) && db->valuestring && db->valuestring[0] &&
-          strlen(db->valuestring) < n)
-      {
-         snprintf(buf, n, "%s", db->valuestring);
-         rc = 0;
-      }
-      cJSON_Delete(j);
+      snprintf(buf, n, "%s", branch->valuestring);
+      rc = 0;
    }
-   free(resp);
+   cJSON_Delete(reply);
    if (rc != 0)
       buf[0] = '\0';
    return rc;

--- a/src/modules/memory/module.yaml
+++ b/src/modules/memory/module.yaml
@@ -46,6 +46,7 @@
     "src/modules/memory/module_adapter.c"
   ],
   "go_sources": [
+    "server-go/modules/memory/embed.go",
     "server-go/modules/memory/extract.go",
     "server-go/modules/memory/memory.go",
     "server-go/modules/memory/ontology.go",
@@ -53,6 +54,7 @@
     "server-go/modules/memory/pii.go"
   ],
   "go_tests": [
+    "server-go/modules/memory/embed_test.go",
     "server-go/modules/memory/extract_conformance_test.go",
     "server-go/modules/memory/gate_conformance_test.go",
     "server-go/modules/memory/memory_test.go",


### PR DESCRIPTION
First caller onto stage 4, which #2489 added the handler for.

The endpoint, the method and the reading of the answer now happen in `server-go/modules/git`. C carries the facts — owner, repo, credential — and applies the ruling.

## The seam

`forge_stage()` is what the remaining callers will use: it merges an operation's own fields into the request and returns the module's reply, so each subsequent migration is a body swap rather than another hand-rolled HTTP call.

## What moves, what stays

| leaves C | stays in C |
|---|---|
| the bare `/repos/<owner>/<repo>` URL (GitHub 404s the trailing-slash form) | resolving the slug from the origin remote |
| Authorization header assembly | resolving the credential (the one vault-first policy) |
| parsing the answer | the rule that an **empty answer is a failure** |

That last one is deliberate and load-bearing: a caller must never fall back to guessing `main`, because a repo whose default is `testing` would get its PR opened against the wrong branch.

## Why only one caller

The stage table was declared *"so the port lands one caller at a time against a fixed stage table rather than renumbering as it goes"* — this follows that.

The merge and create callers need the **Go operation extended first**: `pr_merge` there hardcodes `merge_method` and returns no SHA, while the C supports squash, an expected head SHA, and hands the merge SHA back. Migrating them before extending would quietly drop those.

## Verification

Full gate set, not just `make unit-tests`:

- all three binaries build under `-Werror`; `make unit-tests` green; `make lint` 48/48
- `check-docs`, `check-module-boundary`
- module-inventory steps: `check_module_inventory`, `refactor_baselines`, `check_cleanup_ledger`, `check_module_source_ownership`, `check_module_bus_boundary` (167, unchanged), `check_panel_contract_boundary`, `check_module_test_registration`, `check_capability_ownership`
- `check_c_repository_lock` — `git` pin refreshed with the checker's own `digest_files()`

One note: a suite run showed `unit-test-mcp-client-integration` failing once. It builds and passes standalone, and a clean re-run of the whole suite is green — it was a stale object from an interrupted parallel build earlier in the session, not a defect in this change.
