### PR TITLE
feat(git): give the module's merge the semantics the C caller needs

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -226,7 +226,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "83e81204ae95dd3c8635976dbb20264723a591cbedeb3816586bacc4ef931cbb",
+      "source_sha256": "09b5484fe3340481ee412101b9b62825a5a40da2a53d4f963e4b5efef19e70dc",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/server-go/modules/git/forge_request.go
+++ b/server-go/modules/git/forge_request.go
@@ -57,6 +57,10 @@ type ForgeRequest struct {
 	Body   string `json:"body,omitempty"`
 	Draft  bool   `json:"draft,omitempty"`
 	Limit  int    `json:"limit,omitempty"`
+	// MergeMethod is "merge", "squash" or "rebase"; empty means merge.
+	MergeMethod string `json:"merge_method,omitempty"`
+	// ExpectedHeadSHA refuses the merge if the head has moved since it was read.
+	ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
 }
 
 // PullSummary is the subset of a pull request every caller here needs.
@@ -82,6 +86,28 @@ type ForgeResponse struct {
 	Pull          *PullSummary  `json:"pull,omitempty"`
 	Pulls         []PullSummary `json:"pulls,omitempty"`
 	Merged        bool          `json:"merged,omitempty"`
+	MergeSHA      string        `json:"merge_sha,omitempty"`
+	AlreadyMerged bool          `json:"already_merged,omitempty"`
+	// Conflict is TERMINAL, Retryable is a lost race. Both arrive as 405/409 and
+	// the message is the only discriminator the forge gives, so they are reported
+	// apart here rather than left for a caller to guess: retrying a conflict
+	// reproduces it exactly, and giving up on a lost race abandons a merge that
+	// would have succeeded.
+	Conflict  bool `json:"conflict,omitempty"`
+	Retryable bool `json:"retryable,omitempty"`
+}
+
+// isMergeConflict matches the forge's conflict wording, observed live as "Pull
+// Request has merge conflicts". The distinctive NOUN PHRASE is matched, not the
+// whole sentence, so a rewording ("has merge conflict", "merge conflicts
+// detected") still classifies.
+//
+// Bare "conflict" is deliberately NOT matched: HTTP 409 is literally named
+// Conflict and its lost-race messages carry the bare word — precisely the case
+// that must stay retryable. Requiring the pair keeps this from terminating runs
+// a retry would have won.
+func isMergeConflict(message string) bool {
+	return strings.Contains(strings.ToLower(message), "merge conflict")
 }
 
 func nameOK(s string) bool {
@@ -295,22 +321,49 @@ func PerformForge(request ForgeRequest) ForgeResponse {
 		if request.Number <= 0 {
 			return ForgeResponse{Error: "pr merge: a positive number is required"}
 		}
+		method := request.MergeMethod
+		if method == "" {
+			method = "merge"
+		}
+		body := map[string]any{"merge_method": method}
+		// Only a squash synthesises a body from the child commits, which is where
+		// the attribution trailers protected branches reject come back in. A merge
+		// or rebase has nothing to synthesise.
+		if method == "squash" {
+			body["commit_message"] = ""
+		}
+		if request.ExpectedHeadSHA != "" {
+			body["sha"] = request.ExpectedHeadSHA
+		}
 		status, payload, err := forgeCall(http.MethodPut,
-			fmt.Sprintf("%s/pulls/%d/merge", repo, request.Number), request.Token,
-			map[string]any{"merge_method": "merge"})
+			fmt.Sprintf("%s/pulls/%d/merge", repo, request.Number), request.Token, body)
 		if err != nil {
 			return ForgeResponse{Error: "forge: " + err.Error()}
 		}
-		if status < 200 || status > 299 {
-			// 405 and 409 are the forge refusing the merge (not mergeable /
-			// conflict), which callers surface verbatim rather than retrying.
-			return ForgeResponse{Status: status, Error: forgeError(status, payload, "pr merge")}
+		if status >= 200 && status <= 299 {
+			var decoded struct {
+				Merged bool   `json:"merged"`
+				SHA    string `json:"sha"`
+			}
+			_ = json.Unmarshal(payload, &decoded)
+			// The 2xx body carries the merge commit, so the caller needs no
+			// second lookup.
+			return ForgeResponse{Status: status, Merged: true, MergeSHA: decoded.SHA}
 		}
-		var decoded struct {
-			Merged bool `json:"merged"`
+		message := forgeError(status, payload, "pr merge")
+		if status == 405 && strings.Contains(strings.ToLower(string(payload)), "already merged") {
+			return ForgeResponse{Status: status, AlreadyMerged: true}
 		}
-		_ = json.Unmarshal(payload, &decoded)
-		return ForgeResponse{Status: status, Merged: decoded.Merged}
+		if status == 405 || status == 409 {
+			out := ForgeResponse{Status: status, Error: message}
+			if isMergeConflict(message) {
+				out.Conflict = true
+			} else {
+				out.Retryable = true
+			}
+			return out
+		}
+		return ForgeResponse{Status: status, Error: message}
 	}
 	return ForgeResponse{Error: "forge: unsupported operation " + strings.TrimSpace(request.Op)}
 }

--- a/server-go/modules/git/forge_request_test.go
+++ b/server-go/modules/git/forge_request_test.go
@@ -224,3 +224,77 @@ func TestHandleForgeRequestRoutesThroughStageFour(t *testing.T) {
 		t.Fatalf("malformed JSON must be rejected, got %v", status)
 	}
 }
+
+// The 405/409 pair is the subtle one. A CONTENT conflict is a property of the
+// two trees: retrying reproduces it exactly, so it is terminal. A moved
+// head/base is a lost race a retry wins. Both arrive with the same statuses and
+// the message is the only discriminator the forge gives, so misreading it either
+// terminates a run that would have succeeded or spins on one that never will.
+func TestMergeSeparatesTerminalConflictFromLostRace(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		status          int
+		reply           string
+		conflict, retry bool
+		alreadyMerged   bool
+	}{
+		{"content conflict is terminal", 409,
+			`{"message":"Pull Request has merge conflicts"}`, true, false, false},
+		// HTTP 409 is literally named "Conflict"; the bare word must NOT
+		// terminate, or every lost race is misread as unmergeable.
+		{"bare conflict wording is a lost race", 409,
+			`{"message":"Conflict: head branch was modified"}`, false, true, false},
+		{"405 lost race", 405, `{"message":"Base branch was modified"}`, false, true, false},
+		{"already merged", 405, `{"message":"Pull Request is already merged"}`, false, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &forgeStub{status: tc.status, reply: tc.reply}
+			stub.start(t)
+			out := PerformForge(ForgeRequest{
+				Op: OpPRMerge, Owner: "o", Repo: "r", Token: "t", Number: 3,
+			})
+			if out.Merged {
+				t.Fatal("a refused merge must never report merged")
+			}
+			if out.Conflict != tc.conflict || out.Retryable != tc.retry ||
+				out.AlreadyMerged != tc.alreadyMerged {
+				t.Fatalf("conflict=%v retryable=%v already=%v, want %v/%v/%v",
+					out.Conflict, out.Retryable, out.AlreadyMerged,
+					tc.conflict, tc.retry, tc.alreadyMerged)
+			}
+		})
+	}
+}
+
+func TestMergeCarriesMethodDriftGuardAndReturnsTheSHA(t *testing.T) {
+	stub := &forgeStub{reply: `{"merged":true,"sha":"abc123"}`}
+	stub.start(t)
+	out := PerformForge(ForgeRequest{
+		Op: OpPRMerge, Owner: "o", Repo: "r", Token: "t", Number: 3,
+		MergeMethod: "squash", ExpectedHeadSHA: "deadbeef",
+	})
+	if !out.Merged || out.MergeSHA != "abc123" {
+		t.Fatalf("out = %+v", out)
+	}
+	// Only a squash synthesises a body from the child commits, which is where the
+	// attribution trailers protected branches reject come back in.
+	if !strings.Contains(stub.body, `"merge_method":"squash"`) ||
+		!strings.Contains(stub.body, `"commit_message":""`) {
+		t.Fatalf("squash body = %s", stub.body)
+	}
+	// Drift safety: the forge refuses if the head moved since it was read.
+	if !strings.Contains(stub.body, `"sha":"deadbeef"`) {
+		t.Fatalf("body missing the expected head sha: %s", stub.body)
+	}
+
+	// A plain merge has nothing to synthesise, so no commit_message is sent.
+	stub2 := &forgeStub{reply: `{"merged":true,"sha":"x"}`}
+	stub2.start(t)
+	PerformForge(ForgeRequest{Op: OpPRMerge, Owner: "o", Repo: "r", Token: "t", Number: 3})
+	if strings.Contains(stub2.body, "commit_message") {
+		t.Fatalf("a plain merge must not synthesise a message: %s", stub2.body)
+	}
+	if !strings.Contains(stub2.body, `"merge_method":"merge"`) {
+		t.Fatalf("default method = %s", stub2.body)
+	}
+}


### PR DESCRIPTION
Prerequisite for migrating the merge caller onto stage 4 (#2489, #2492).

The first cut of `pr_merge` hardcoded `merge_method`, ignored the drift guard and returned no SHA — so moving the caller onto it would have **silently dropped all three**. This closes that gap first, deliberately, before any caller moves.

## What it gains

- **`merge_method`** — squash synthesises an empty `commit_message`, because that is where the attribution trailers protected branches reject come back in. A merge or rebase has nothing to synthesise, and a test asserts it sends none.
- **`expected_head_sha`** — the drift guard; the forge refuses if the head moved since it was read.
- **the merge SHA** from the 2xx body, so the caller needs no second lookup.

## The distinction that matters

A terminal conflict and a lost race **both arrive as 405/409**, and the message is the only discriminator the forge gives:

| | |
|---|---|
| a **content conflict** | a property of the two trees — retrying reproduces it exactly, so the run must stop |
| a **moved head/base** | a race a retry wins — stopping abandons a merge that would have succeeded |

The predicate matches the noun phrase **`merge conflict`**, case-insensitively, so a rewording (`has merge conflict`, `merge conflicts detected`) still classifies — and deliberately **not** the bare word `conflict`, because HTTP 409 is literally named *Conflict* and its lost-race messages carry that word.

**Verified red**: loosened to bare `conflict`, the lost-race case fails.

```
--- FAIL: TestMergeSeparatesTerminalConflictFromLostRace/bare_conflict_wording_is_a_lost_race
```

`already merged` (405 with that wording) stays its own answer rather than an error — it means the work is done, not that anything went wrong.

## Verification

- `go test` green, `gofmt`, `go vet` clean
- all three binaries build under `-Werror`; `make lint` 48/48
- `check-docs`, `check-module-boundary`, `check_module_inventory`, `refactor_baselines`, `check_cleanup_ledger`, `check_module_source_ownership`, `check_module_bus_boundary` (167, unchanged), `check_module_test_registration`
- `validate_module_process_contracts` ok; `git` pin refreshed with the checker's own `digest_files()`
