### PR TITLE
Move delegate capability inference into the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,12 +165,13 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "1e598ba1e0522d144cb98869995b96cebbd48d059467fad8d77e5a53dde7d243",
+      "source_sha256": "25567f8f34e9a8d0d13868f355ad4e86294f24b810a94503bee9d077c4a10ce9",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
       "serve": [
-        6657
+        6657,
+        6658
       ]
     },
     {

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "25567f8f34e9a8d0d13868f355ad4e86294f24b810a94503bee9d077c4a10ce9",
+      "source_sha256": "e43a921f64c0946b4a6ae3fa83e71bf1f6bb5968db12c67c77718b56e34712af",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/docs/proposals/pending/delegate-execution-into-the-module.md
+++ b/docs/proposals/pending/delegate-execution-into-the-module.md
@@ -1,0 +1,102 @@
+# Proposal: Move delegate execution into the delegates module
+
+- **State:** PENDING — decided architecture, port not started.
+- **Date:** 2026-08-10.
+- **Charter roles:** Enforce / Constrain-Verify.
+- **Thesis:** delegate execution is logic, so it belongs in the delegates module and is
+  reached over the event bus. The C daemon must not serve it, and the agent-service HTTP
+  socket it is served on today is neither bus traffic nor part of aimee-server's external
+  `/v1` surface, so it goes away.
+
+## 1. What is actually wrong
+
+`server-go/modules/roundtable/reviewer.go` imports `server-go/modules/delegates/plane` and
+calls it over HTTP. `plane/client.go` holds an `http.Client` and a `net.Dialer` doing
+`DialContext(ctx, "unix", socket)`. It is wired live at `server-go/cmd/aimee-module/main.go:60`.
+
+The socket is `AIMEE_AGENT_SERVICE_SOCKET` (see `src/server/roundtable_review_bus.c:109`),
+which is the **C daemon's** agent service. So this is not one Go module calling another: it
+is a Go module reaching back into the C daemon over HTTP.
+
+That is precisely the anti-pattern `bus.ModuleCaller`'s own documentation names
+(`server-go/bus/module_caller.go:18-21`):
+
+> the sole module caller was the C daemon that hosts the bus, so any other Go process had
+> to reach a stage through that daemon's HTTP API rather than over the bus it was already
+> running on.
+
+It breaks three rules at once: modules get no HTTP, modules never talk to each other
+directly, and every inter-module exchange goes over the bus so governance can see it.
+
+## 2. Why roundtable cannot simply be rewired
+
+There is no bus stage to point it at. `server-go/modules/delegates/delegates.go` is 49
+lines and canonicalizes role names — its own comment says it "canonicalizes a delegate role
+**without invoking a delegate**". Execution is ~12,811 lines of C under
+`src/modules/delegates/`.
+
+So roundtable's HTTP client is a *symptom*. It can only be deleted once execution is
+reachable as a stage, which means the port below is the prerequisite, not a follow-up.
+
+Serving execution from the C daemon as a bus stage was considered and **rejected**: the
+daemon owns the bus, mTLS/MCP, the external HTTP surface and the audit tap, and nothing
+else. Delegate execution is none of those.
+
+## 3. The contract
+
+A delegate call is: **persona / model / prompt in, response out**, plus the delegate's own
+`working / failed / done` status.
+
+Nothing about the caller crosses. `ReplayOnly`, `ExecutionVersion`, `WorkItemID`, `Stage`,
+`DurableSlot`, `RetryTag` and `Participant` — every one of which `plane.DelegateRequest`
+carries today — belong to whoever owns work items. A retry is not a field a delegate
+interprets; it is the caller choosing to call again. Fifty resumptions are fifty
+independent calls that know nothing of each other.
+
+`plane.DelegateRequest` is therefore the wrong starting point for the wire contract. It is
+an HTTP API shaped around a workflow client, not a module contract.
+
+A caller may still put state-derived *content* in the request — "we have X, Y and Z, we now
+need A, B and C" is input the delegate consumes and forgets. What it must never do is make
+the delegate a custodian of the caller's state.
+
+## 4. Ordering
+
+The port is large, so it needs slices that each land green. Two properties decide the
+order: a slice must be cuttable over in one commit (never leave a rule in two languages),
+and it must not require the execution entry point to move before its dependencies.
+
+Measured sizes, smallest first, as a starting decomposition:
+
+| Candidate | Lines | Shape |
+| --- | --- | --- |
+| `delegate_role.c` | 237 | already half-ported; the alias table is duplicated in `module_adapter.c` |
+| `delegate_backend.c` | 250 | backend registry |
+| `delegate_economics.c` | 343 | cost/tier report over job+task rows |
+| `delegate_routing.c` | 483 | which delegate for a role |
+| `delegate_launch.c` | 488 | `delegate_launch_coord_job` — the entry point |
+| `delegate_prompt.c` | 1,982 | prompt construction |
+| `delegate_backend_docker.c` | 1,635 | sandbox backend |
+
+The pure decisions (`routing`, `economics`) port first and prove the stage shape. The
+backends move last: they are where the real I/O lives, and they are what makes the entry
+point meaningful.
+
+`delegate_role.c` is a special case worth resolving early. Its alias table is byte-for-byte
+duplicated in the module adapter — the existing comment in `test_process_module_handlers.c`
+records that nothing in the build keeps them in step, and that the duplicate exists because
+the thin client hosts no bus. Deduplicating it needs a decision about whether the thin
+client should canonicalize roles at all.
+
+## 5. Acceptance
+
+- `server-go/modules/roundtable` contains no HTTP client and no import of another module.
+- Delegate execution is reachable only as a bus stage; `AIMEE_AGENT_SERVICE_SOCKET` and
+  `AIMEE_AGENT_SERVICE_URL` are gone.
+- A delegate holds no caller state — only its own `working / failed / done`.
+- `check_go_module_boundary.py` lands with an **empty** allowlist, forbidding
+  `server-go/modules/<a>` from importing `server-go/modules/<b>`.
+
+That last one is the point of the whole exercise: today the rule is a sentence, and the one
+violation of it was live in the shipping module process. When the check exists with nothing
+in it, the rule stops depending on anyone remembering.

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -101,7 +101,10 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 	case "delegates":
 		config.ModuleName = name
 		config.PrincipalRef = 10
-		config.Stages = []bus.ModuleStage{{EventKind: delegates.EventKind, StageID: delegates.StageInvoke}}
+		config.Stages = []bus.ModuleStage{
+			{EventKind: delegates.EventKind, StageID: delegates.StageInvoke},
+			{EventKind: delegates.EventCapabilities, StageID: delegates.StageCapabilities},
+		}
 		config.Handler = delegates.Handle
 	case "tools":
 		config.ModuleName = name

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -15,7 +15,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657}},
+		{"delegates", 10, []uint32{6657, 6658}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7430}},

--- a/server-go/modules/delegates/capabilities.go
+++ b/server-go/modules/delegates/capabilities.go
@@ -1,0 +1,109 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"strings"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// What a prompt implies a model must be able to do.
+//
+// This is a routing heuristic, not a fact about the request: it reads a prompt
+// for signs that the work needs a modality the text alone cannot carry, so the
+// router can refuse a model that would silently ignore half the input.
+
+const (
+	StageCapabilities uint32 = 2
+	EventCapabilities uint32 = 6658
+
+	capRequestMagic  uint32 = 0x50414344 /* "DCAP" */
+	capResponseMagic uint32 = 0x53414344 /* "DCAS" */
+	capPromptMax            = 1 << 20
+	capHeaderLen            = 12
+	capResponseLen          = 12
+
+	// Mirrors model_registry.h. A model capability is a property of the model,
+	// so the numbering is the registry's and not this module's to choose.
+	CapTools  uint32 = 1 << 1
+	CapVision uint32 = 1 << 2
+	CapPDF    uint32 = 1 << 3
+	CapAudio  uint32 = 1 << 4
+)
+
+// Markdown image syntax ("![") is deliberately absent: it appears in any doc or
+// diff under review and never means the model must decode an image.
+var visionMarkers = []string{".png", ".jpg", ".jpeg", ".webp", ".gif", "screenshot", "image_url"}
+
+var pdfMarkers = []string{".pdf", " pdf "}
+
+// Audio is required only for actual audio file formats. The bare word "audio"
+// was removed: a prompt implementing speech features in code contains it while
+// needing nothing of the model.
+var audioMarkers = []string{".mp3", ".wav", ".m4a", ".ogg", ".flac", ".aac"}
+
+func containsAny(haystack string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// InferCapabilities reports the capabilities a prompt implies and the smallest
+// context window that can hold it. min is 0 when the prompt is short enough not
+// to constrain the choice.
+func InferCapabilities(prompt string, toolsEnabled bool) (required uint32, minContext int) {
+	if toolsEnabled {
+		required |= CapTools
+	}
+	if prompt == "" {
+		return required, 0
+	}
+
+	lower := strings.ToLower(prompt)
+	if containsAny(lower, visionMarkers) {
+		required |= CapVision
+	}
+	if containsAny(lower, pdfMarkers) {
+		required |= CapPDF
+	}
+	if containsAny(lower, audioMarkers) {
+		required |= CapAudio
+	}
+
+	// Roughly one token per four characters. Only a materially large prompt
+	// constrains the window; enforcing a minimum on short prompts would filter
+	// out models that would have been fine.
+	estimated := len(prompt)/4 + 1
+	if estimated > 4096 {
+		minContext = estimated + 1024
+	}
+	return required, minContext
+}
+
+func handleCapabilities(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if len(request) < capHeaderLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != capRequestMagic || request[4] != wireVersion {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	tools := request[5]
+	if tools > 1 {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	length := int(binary.LittleEndian.Uint32(request[8:12]))
+	if length > capPromptMax || len(request) != capHeaderLen+length {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	required, minContext := InferCapabilities(string(request[capHeaderLen:]), tools == 1)
+	response := make([]byte, capResponseLen)
+	binary.LittleEndian.PutUint32(response[0:4], capResponseMagic)
+	binary.LittleEndian.PutUint32(response[4:8], required)
+	binary.LittleEndian.PutUint32(response[8:12], uint32(minContext))
+	return response, bus.ModuleStatusOK
+}

--- a/server-go/modules/delegates/capabilities_test.go
+++ b/server-go/modules/delegates/capabilities_test.go
@@ -1,0 +1,131 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func capRequest(prompt string, tools bool) []byte {
+	request := make([]byte, capHeaderLen+len(prompt))
+	binary.LittleEndian.PutUint32(request[0:4], capRequestMagic)
+	request[4] = wireVersion
+	if tools {
+		request[5] = 1
+	}
+	binary.LittleEndian.PutUint32(request[8:12], uint32(len(prompt)))
+	copy(request[capHeaderLen:], prompt)
+	return request
+}
+
+func capCall(t *testing.T, prompt string, tools bool) (uint32, int) {
+	t.Helper()
+	response, status := Handle(bus.ModuleInvocation{StageID: StageCapabilities},
+		capRequest(prompt, tools))
+	if status != bus.ModuleStatusOK || len(response) != capResponseLen ||
+		binary.LittleEndian.Uint32(response[0:4]) != capResponseMagic {
+		t.Fatalf("response = %x, status = %d", response, status)
+	}
+	return binary.LittleEndian.Uint32(response[4:8]),
+		int(binary.LittleEndian.Uint32(response[8:12]))
+}
+
+// Ported one-for-one from test_cmd_delegate.c. A prompt that DESCRIBES audio
+// work in code must not force an audio-capable model; only a reference to an
+// actual audio file may. The bare word "audio" appears in any prompt about
+// building speech features and means nothing about what the model must decode.
+func TestAudioComesFromFileExtensionsNotTheWord(t *testing.T) {
+	describes := []string{
+		"Implement an STT (speech-to-text) dispatcher and audio routing module.",
+		"Add audio support to the gateway — implement the audio platform adapter.",
+	}
+	for _, prompt := range describes {
+		if caps, _ := capCall(t, prompt, false); caps&CapAudio != 0 {
+			t.Errorf("%q required audio", prompt)
+		}
+	}
+
+	references := []string{
+		"Transcribe recording.mp3 into text.",
+		"Process speech.wav and output captions.",
+		"Convert podcast.m4a to a transcript.",
+	}
+	for _, prompt := range references {
+		if caps, _ := capCall(t, prompt, false); caps&CapAudio == 0 {
+			t.Errorf("%q did not require audio", prompt)
+		}
+	}
+}
+
+func TestModalitiesAndContextAreInferredTogether(t *testing.T) {
+	long := "Analyze image screenshot.png and report pdf coverage. " + strings.Repeat("a", 20031)
+	caps, minContext := capCall(t, long, true)
+	for _, want := range []struct {
+		bit  uint32
+		name string
+	}{{CapTools, "tools"}, {CapVision, "vision"}, {CapPDF, "pdf"}} {
+		if caps&want.bit == 0 {
+			t.Errorf("missing %s", want.name)
+		}
+	}
+	if minContext <= 0 {
+		t.Errorf("min context = %d, want a bound for a %d-char prompt", minContext, len(long))
+	}
+}
+
+// A short prompt must not constrain the window at all: filtering on it would
+// rule out models that would have been perfectly adequate.
+func TestShortPromptLeavesTheWindowUnconstrained(t *testing.T) {
+	if _, minContext := capCall(t, "fix the typo", false); minContext != 0 {
+		t.Errorf("min context = %d, want 0", minContext)
+	}
+	// Just over the threshold, it does bind.
+	if _, minContext := capCall(t, strings.Repeat("a", 4097*4), false); minContext == 0 {
+		t.Error("a materially large prompt left the window unconstrained")
+	}
+}
+
+// Tools is the one capability that is asserted rather than inferred, so it must
+// not depend on the prompt.
+func TestToolsIsAssertedByTheCallerNotReadFromThePrompt(t *testing.T) {
+	if caps, _ := capCall(t, "", true); caps != CapTools {
+		t.Errorf("empty prompt with tools = %#x, want exactly CapTools", caps)
+	}
+	if caps, _ := capCall(t, "", false); caps != 0 {
+		t.Errorf("empty prompt without tools = %#x, want none", caps)
+	}
+}
+
+// Markdown image syntax appears in any diff or doc under review and never means
+// the model must decode an image.
+func TestMarkdownImageSyntaxIsNotAVisionTrigger(t *testing.T) {
+	if caps, _ := capCall(t, "review this diff: ![alt](docs/diagram)", false); caps&CapVision != 0 {
+		t.Error("markdown image syntax required vision")
+	}
+}
+
+func TestCapabilitiesRejectsInvalidEnvelope(t *testing.T) {
+	short := capRequest("x", false)[:capHeaderLen-1]
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageCapabilities}, short); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("truncated-header status = %d", status)
+	}
+
+	lying := capRequest("x", false)
+	binary.LittleEndian.PutUint32(lying[8:12], 64)
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageCapabilities}, lying); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("length-mismatch status = %d", status)
+	}
+
+	badTools := capRequest("x", false)
+	badTools[5] = 2
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageCapabilities}, badTools); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("out-of-range tools flag status = %d", status)
+	}
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageCapabilities, DeadlineNS: 1},
+		capRequest("x", false)); status != bus.ModuleStatusCancelled {
+		t.Fatalf("expired status = %d", status)
+	}
+}

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -26,8 +26,12 @@ var aliases = map[string]string{
 	"planner": "plan", "planning": "plan",
 }
 
-// Handle canonicalizes a delegate role without invoking a delegate.
+// Handle canonicalizes a delegate role, or infers what a prompt needs of a
+// model, without invoking a delegate.
 func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if invocation.StageID == StageCapabilities {
+		return handleCapabilities(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -215,6 +215,12 @@ int delegate_apply_route_overrides(agent_config_t *cfg, const char *role, const 
                                    int tier_override, const char *provider_override,
                                    const char *model_override, char *errbuf, size_t errbuf_sz);
 int delegate_route_preflight(agent_config_t *cfg, const char *role, char *errbuf, size_t errbuf_sz);
+/* Answers the delegates module's capability question. Returns 0 and fills both
+ * outputs, or non-zero when the module cannot be reached. */
+typedef int (*delegate_capability_provider_fn)(const char *prompt, int tools_enabled,
+                                               unsigned *required_caps, int *min_context);
+void delegate_routing_register_capability_provider(delegate_capability_provider_fn provider);
+
 void delegate_infer_capability_requirements(const char *prompt, int tools_enabled,
                                             unsigned *required_caps_out, int *min_context_out);
 /* Disable every agent whose declared max_scope ceiling cannot serve a packet of

--- a/src/modules/delegates/delegate_routing.c
+++ b/src/modules/delegates/delegate_routing.c
@@ -8,46 +8,28 @@
 #include <ctype.h>
 #include <string.h>
 
+static delegate_capability_provider_fn g_capability_provider;
+
+void delegate_routing_register_capability_provider(delegate_capability_provider_fn provider)
+{
+   g_capability_provider = provider;
+}
+
+/* What a prompt implies a model must be able to do is the delegates module's
+ * rule; this asks it. It used to be restated here -- the marker lists, the
+ * four-chars-per-token estimate, the 4096 threshold -- with nothing keeping the
+ * two copies in step.
+ *
+ * Fails closed: no capabilities and no context floor when the module cannot be
+ * reached. Guessing would route work to a model that cannot see half its input,
+ * which is worse than routing nothing. */
 void delegate_infer_capability_requirements(const char *prompt, int tools_enabled,
                                             unsigned *required_caps_out, int *min_context_out)
 {
    unsigned required = 0;
    int min_context = 0;
-
-   if (tools_enabled)
-      required |= MODEL_CAP_TOOLS;
-
-   if (prompt && prompt[0])
-   {
-      /* Vision is INFERRED from text and is a SOFT routing preference (see
-       * MODEL_CAP_MODALITY_SOFT): the router relaxes it when no model qualifies.
-       * Markdown image syntax ("![") is deliberately NOT a trigger — it appears in
-       * any doc/diff under review and never means the model must decode an image. */
-      if (str_contains_ci(prompt, ".png") || str_contains_ci(prompt, ".jpg") ||
-          str_contains_ci(prompt, ".jpeg") || str_contains_ci(prompt, ".webp") ||
-          str_contains_ci(prompt, ".gif") || str_contains_ci(prompt, "screenshot") ||
-          str_contains_ci(prompt, "image_url"))
-         required |= MODEL_CAP_VISION;
-      if (str_contains_ci(prompt, ".pdf") || str_contains_ci(prompt, " pdf "))
-         required |= MODEL_CAP_PDF;
-      /* Require audio capability only when the prompt references actual audio
-       * file formats — not when it merely describes audio features in code.
-       * The bare word "audio" was removed because prompts implementing
-       * speech/audio features in code (e.g. gateway STT adapter) contain the
-       * word "audio" but do not need the model to process audio files. */
-      if (str_contains_ci(prompt, ".mp3") || str_contains_ci(prompt, ".wav") ||
-          str_contains_ci(prompt, ".m4a") || str_contains_ci(prompt, ".ogg") ||
-          str_contains_ci(prompt, ".flac") || str_contains_ci(prompt, ".aac"))
-         required |= MODEL_CAP_AUDIO;
-
-      /* Approximate 1 token ~= 4 chars. Only enforce minimum context on
-       * materially large prompts so short prompts do not over-filter. */
-      size_t chars = strlen(prompt);
-      int estimated_tokens = (int)(chars / 4) + 1;
-      if (estimated_tokens > 4096)
-         min_context = estimated_tokens + 1024;
-   }
-
+   if (g_capability_provider)
+      (void)g_capability_provider(prompt, tools_enabled, &required, &min_context);
    if (required_caps_out)
       *required_caps_out = required;
    if (min_context_out)

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -6,13 +6,30 @@
 #include <stdint.h>
 #include <string.h>
 
-#define AIMEE_DELEGATES_EVENT_INVOKE    6657u
-#define AIMEE_DELEGATES_STAGE_INVOKE    1u
-#define AIMEE_DELEGATES_REQUEST_MAGIC   0x4c4f5244u /* "DROL" */
-#define AIMEE_DELEGATES_RESPONSE_MAGIC  0x4e414344u /* "DCAN" */
-#define AIMEE_DELEGATES_WIRE_VERSION    1u
-#define AIMEE_DELEGATES_ROLE_MAX        63u
-#define AIMEE_DELEGATES_MESSAGE_LEN     72u
+#define AIMEE_DELEGATES_EVENT_INVOKE   6657u
+#define AIMEE_DELEGATES_STAGE_INVOKE   1u
+#define AIMEE_DELEGATES_REQUEST_MAGIC  0x4c4f5244u /* "DROL" */
+#define AIMEE_DELEGATES_RESPONSE_MAGIC 0x4e414344u /* "DCAN" */
+#define AIMEE_DELEGATES_WIRE_VERSION   1u
+#define AIMEE_DELEGATES_ROLE_MAX       63u
+#define AIMEE_DELEGATES_MESSAGE_LEN    72u
+
+/* Capability inference: what a prompt implies a model must be able to do. */
+#define AIMEE_DELEGATES_EVENT_CAPABILITIES 6658u
+#define AIMEE_DELEGATES_STAGE_CAPABILITIES 2u
+#define AIMEE_DELEGATES_CAP_REQUEST_MAGIC  0x50414344u /* "DCAP" */
+#define AIMEE_DELEGATES_CAP_RESPONSE_MAGIC 0x53414344u /* "DCAS" */
+#define AIMEE_DELEGATES_CAP_HEADER_LEN     12u
+#define AIMEE_DELEGATES_CAP_RESPONSE_LEN   12u
+#define AIMEE_DELEGATES_CAP_PROMPT_MAX     (1u << 20)
+
+/* Mirrors model_registry.h. A model capability is a property of the model, so
+ * the numbering belongs to the registry and is restated here only so the wire
+ * has a definition that does not depend on server headers. */
+#define AIMEE_DELEGATES_CAP_TOOLS  (1u << 1)
+#define AIMEE_DELEGATES_CAP_VISION (1u << 2)
+#define AIMEE_DELEGATES_CAP_PDF    (1u << 3)
+#define AIMEE_DELEGATES_CAP_AUDIO  (1u << 4)
 
 static inline void aimee_delegates_put_u32(uint8_t *p, uint32_t v)
 {
@@ -29,7 +46,7 @@ static inline uint32_t aimee_delegates_get_u32(const uint8_t *p)
 }
 
 static inline int aimee_delegates_message_encode(uint32_t magic, const char *role, uint8_t *out,
-                                                  size_t cap)
+                                                 size_t cap)
 {
    size_t len = role ? strlen(role) : 0;
    if (!out || cap < AIMEE_DELEGATES_MESSAGE_LEN || len == 0 || len > AIMEE_DELEGATES_ROLE_MAX)
@@ -43,7 +60,7 @@ static inline int aimee_delegates_message_encode(uint32_t magic, const char *rol
 }
 
 static inline int aimee_delegates_message_decode(const uint8_t *in, size_t len, uint32_t magic,
-                                                  char *role, size_t role_cap)
+                                                 char *role, size_t role_cap)
 {
    if (!in || len != AIMEE_DELEGATES_MESSAGE_LEN || !role || role_cap == 0 ||
        aimee_delegates_get_u32(in) != magic || in[4] != AIMEE_DELEGATES_WIRE_VERSION ||
@@ -52,6 +69,38 @@ static inline int aimee_delegates_message_decode(const uint8_t *in, size_t len, 
       return -1;
    memcpy(role, in + 8, in[6]);
    role[in[6]] = '\0';
+   return 0;
+}
+
+/* Frame a prompt for capability inference. Returns the encoded length, or 0
+ * when it does not fit. A prompt is carried whole because the rule reads its
+ * text; there is nothing smaller to send that preserves the answer. */
+static inline size_t aimee_delegates_cap_request_encode(const char *prompt, size_t prompt_len,
+                                                        int tools_enabled, uint8_t *out, size_t cap)
+{
+   if (!out || prompt_len > AIMEE_DELEGATES_CAP_PROMPT_MAX ||
+       cap < AIMEE_DELEGATES_CAP_HEADER_LEN + prompt_len)
+      return 0;
+   memset(out, 0, AIMEE_DELEGATES_CAP_HEADER_LEN);
+   aimee_delegates_put_u32(out, AIMEE_DELEGATES_CAP_REQUEST_MAGIC);
+   out[4] = (uint8_t)AIMEE_DELEGATES_WIRE_VERSION;
+   out[5] = tools_enabled ? 1u : 0u;
+   aimee_delegates_put_u32(out + 8, (uint32_t)prompt_len);
+   if (prompt_len)
+      memcpy(out + AIMEE_DELEGATES_CAP_HEADER_LEN, prompt, prompt_len);
+   return AIMEE_DELEGATES_CAP_HEADER_LEN + prompt_len;
+}
+
+static inline int aimee_delegates_cap_response_decode(const uint8_t *in, size_t len,
+                                                      unsigned *required_caps, int *min_context)
+{
+   if (!in || len != AIMEE_DELEGATES_CAP_RESPONSE_LEN ||
+       aimee_delegates_get_u32(in) != AIMEE_DELEGATES_CAP_RESPONSE_MAGIC)
+      return -1;
+   if (required_caps)
+      *required_caps = (unsigned)aimee_delegates_get_u32(in + 4);
+   if (min_context)
+      *min_context = (int)aimee_delegates_get_u32(in + 8);
    return 0;
 }
 

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -71,11 +71,13 @@
   "go_sources": [
     "server-go/modules/delegates/delegates.go",
     "server-go/modules/delegates/plane/client.go",
-    "server-go/modules/delegates/plane/helpers.go"
+    "server-go/modules/delegates/plane/helpers.go",
+    "server-go/modules/delegates/capabilities.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
-    "server-go/modules/delegates/plane/client_test.go"
+    "server-go/modules/delegates/plane/client_test.go",
+    "server-go/modules/delegates/capabilities_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",

--- a/src/modules/delegates/module_adapter.c
+++ b/src/modules/delegates/module_adapter.c
@@ -1,6 +1,8 @@
 #include <aimee/core/event_bus/module_runtime.h>
 #include <aimee/delegates/module_api.h>
 
+#include <ctype.h>
+#include <stdlib.h>
 #include <string.h>
 
 static const char *canonical(const char *role)
@@ -9,27 +11,123 @@ static const char *canonical(const char *role)
    {
       const char *alias;
       const char *role;
-   } aliases[] = {{"implement", "code"},       {"build", "code"},
-                  {"reviewer", "review"},      {"verifier", "validate"},
-                  {"test", "validate"},        {"check", "validate"},
-                  {"evaluate", "validate"},    {"evaluate-optimize", "validate"},
-                  {"inspect", "diagnose"},     {"research", "execute"},
-                  {"enforce", "execute"},      {"recall", "search"},
-                  {"synthesize", "summarize"}, {"rank-fuse", "reason"},
-                  {"classify-score", "reason"},{"planner", "plan"},
-                  {"planning", "plan"},        {NULL, NULL}};
+   } aliases[] = {{"implement", "code"},        {"build", "code"},
+                  {"reviewer", "review"},       {"verifier", "validate"},
+                  {"test", "validate"},         {"check", "validate"},
+                  {"evaluate", "validate"},     {"evaluate-optimize", "validate"},
+                  {"inspect", "diagnose"},      {"research", "execute"},
+                  {"enforce", "execute"},       {"recall", "search"},
+                  {"synthesize", "summarize"},  {"rank-fuse", "reason"},
+                  {"classify-score", "reason"}, {"planner", "plan"},
+                  {"planning", "plan"},         {NULL, NULL}};
    for (size_t i = 0; aliases[i].alias; ++i)
       if (strcmp(role, aliases[i].alias) == 0)
          return aliases[i].role;
    return role;
 }
 
-aimee_module_status_t aimee_module_handler(
-    const aimee_module_invocation_t *invocation, const uint8_t *request_body,
-    uint32_t request_len, uint8_t *response_body, uint32_t response_capacity,
-    uint32_t *response_len, void *user_data)
+/* Capability inference: what a prompt implies a model must be able to do. The
+ * Go module states the same rule; test_process_module_handlers pins the two
+ * together, because nothing in the build otherwise would. */
+static int cap_contains_ci(const char *haystack, const char *needle)
+{
+   size_t nlen = strlen(needle);
+   if (nlen == 0)
+      return 1;
+   for (const char *p = haystack; *p; ++p)
+   {
+      size_t i = 0;
+      while (i < nlen && p[i] && tolower((unsigned char)p[i]) == tolower((unsigned char)needle[i]))
+         ++i;
+      if (i == nlen)
+         return 1;
+   }
+   return 0;
+}
+
+static int cap_contains_any(const char *prompt, const char *const *markers, size_t count)
+{
+   for (size_t i = 0; i < count; ++i)
+      if (cap_contains_ci(prompt, markers[i]))
+         return 1;
+   return 0;
+}
+
+static void infer_capabilities(const char *prompt, int tools_enabled, uint32_t *required_out,
+                               uint32_t *min_context_out)
+{
+   /* Markdown image syntax ("![") is deliberately not a trigger: it appears in
+    * any doc or diff under review and never means an image must be decoded. */
+   static const char *const vision[] = {".png", ".jpg",       ".jpeg",    ".webp",
+                                        ".gif", "screenshot", "image_url"};
+   static const char *const pdf[] = {".pdf", " pdf "};
+   /* Only actual audio file formats. The bare word "audio" appears in prompts
+    * that implement speech features in code and asks nothing of the model. */
+   static const char *const audio[] = {".mp3", ".wav", ".m4a", ".ogg", ".flac", ".aac"};
+
+   uint32_t required = tools_enabled ? AIMEE_DELEGATES_CAP_TOOLS : 0u;
+   uint32_t min_context = 0;
+   if (prompt && prompt[0])
+   {
+      if (cap_contains_any(prompt, vision, sizeof(vision) / sizeof(vision[0])))
+         required |= AIMEE_DELEGATES_CAP_VISION;
+      if (cap_contains_any(prompt, pdf, sizeof(pdf) / sizeof(pdf[0])))
+         required |= AIMEE_DELEGATES_CAP_PDF;
+      if (cap_contains_any(prompt, audio, sizeof(audio) / sizeof(audio[0])))
+         required |= AIMEE_DELEGATES_CAP_AUDIO;
+      /* Roughly one token per four characters; only a materially large prompt
+       * constrains the window. */
+      size_t estimated = strlen(prompt) / 4 + 1;
+      if (estimated > 4096)
+         min_context = (uint32_t)(estimated + 1024);
+   }
+   *required_out = required;
+   *min_context_out = min_context;
+}
+
+static aimee_module_status_t handle_capabilities(const aimee_module_invocation_t *invocation,
+                                                 const uint8_t *request_body, uint32_t request_len,
+                                                 uint8_t *response_body, uint32_t response_capacity,
+                                                 uint32_t *response_len)
+{
+   if (request_len < AIMEE_DELEGATES_CAP_HEADER_LEN ||
+       response_capacity < AIMEE_DELEGATES_CAP_RESPONSE_LEN ||
+       aimee_delegates_get_u32(request_body) != AIMEE_DELEGATES_CAP_REQUEST_MAGIC ||
+       request_body[4] != AIMEE_DELEGATES_WIRE_VERSION || request_body[5] > 1u)
+      return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+   uint32_t length = aimee_delegates_get_u32(request_body + 8);
+   if (length > AIMEE_DELEGATES_CAP_PROMPT_MAX ||
+       request_len != AIMEE_DELEGATES_CAP_HEADER_LEN + length)
+      return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+   if (aimee_module_invocation_cancelled(invocation))
+      return AIMEE_MODULE_STATUS_CANCELLED;
+
+   char *prompt = malloc((size_t)length + 1);
+   if (!prompt)
+      return AIMEE_MODULE_STATUS_INTERNAL;
+   memcpy(prompt, request_body + AIMEE_DELEGATES_CAP_HEADER_LEN, length);
+   prompt[length] = '\0';
+   uint32_t required = 0, min_context = 0;
+   infer_capabilities(prompt, request_body[5] == 1u, &required, &min_context);
+   free(prompt);
+
+   memset(response_body, 0, AIMEE_DELEGATES_CAP_RESPONSE_LEN);
+   aimee_delegates_put_u32(response_body, AIMEE_DELEGATES_CAP_RESPONSE_MAGIC);
+   aimee_delegates_put_u32(response_body + 4, required);
+   aimee_delegates_put_u32(response_body + 8, min_context);
+   *response_len = AIMEE_DELEGATES_CAP_RESPONSE_LEN;
+   return AIMEE_MODULE_STATUS_OK;
+}
+
+aimee_module_status_t aimee_module_handler(const aimee_module_invocation_t *invocation,
+                                           const uint8_t *request_body, uint32_t request_len,
+                                           uint8_t *response_body, uint32_t response_capacity,
+                                           uint32_t *response_len, void *user_data)
 {
    (void)user_data;
+   if (invocation && response_len && invocation->stage_id == AIMEE_DELEGATES_STAGE_CAPABILITIES)
+      return handle_capabilities(invocation, request_body, request_len, response_body,
+                                 response_capacity, response_len);
    char role[AIMEE_DELEGATES_ROLE_MAX + 1];
    if (!invocation || !response_len || invocation->stage_id != AIMEE_DELEGATES_STAGE_INVOKE ||
        response_capacity < AIMEE_DELEGATES_MESSAGE_LEN ||

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -131,6 +131,11 @@
           "id": 1,
           "name": "delegate-invocation",
           "event_kind": 6657
+        },
+        {
+          "id": 2,
+          "name": "delegate-capability-inference",
+          "event_kind": 6658
         }
       ]
     },

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -14,6 +14,7 @@
 #include "modules/memory/memory_fact_gate.h"
 #include "modules/memory/memory_pii_gate.h"
 #include "modules/skills/skill_trigger_policy.h"
+#include "cmd_agent_delegate_impl.h" /* delegate_routing_register_capability_provider */
 #include "modules/webuser/webuser_runtime.h"
 #include "modules/workspace/workspace_scope.h"
 #include <aimee/audit/obs_bus.h>

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -270,6 +270,35 @@ static int delegate_canonicalize(const char *role, char *out, size_t out_cap)
               : -1;
 }
 
+/* A prompt is carried whole, so the request is sized to it rather than to a
+ * fixed frame. Failure leaves the caller's outputs untouched and reports -1:
+ * guessing a capability set here would route work to a model that cannot see
+ * half its input, which is worse than refusing to route it. */
+static int delegate_infer_caps(const char *prompt, int tools_enabled, unsigned *required_caps,
+                               int *min_context)
+{
+   size_t prompt_len = prompt ? strlen(prompt) : 0;
+   if (prompt_len > AIMEE_DELEGATES_CAP_PROMPT_MAX)
+      return -1;
+   size_t request_cap = AIMEE_DELEGATES_CAP_HEADER_LEN + prompt_len;
+   uint8_t *request = malloc(request_cap);
+   if (!request)
+      return -1;
+   size_t request_len =
+       aimee_delegates_cap_request_encode(prompt, prompt_len, tools_enabled, request, request_cap);
+   uint8_t response[AIMEE_DELEGATES_CAP_RESPONSE_LEN];
+   uint32_t response_len = 0;
+   int rc =
+       request_len > 0 &&
+               call_module(AIMEE_DELEGATES_EVENT_CAPABILITIES, AIMEE_DELEGATES_STAGE_CAPABILITIES,
+                           request, (uint32_t)request_len, response, sizeof(response),
+                           &response_len) == 0
+           ? aimee_delegates_cap_response_decode(response, response_len, required_caps, min_context)
+           : -1;
+   free(request);
+   return rc;
+}
+
 static int tool_classify(const char *name, int *classification)
 {
    uint8_t request[AIMEE_TOOLS_REQUEST_LEN], response[AIMEE_TOOLS_RESPONSE_LEN];
@@ -477,6 +506,7 @@ void server_module_stage_adapters_configure(void)
    memory_pii_register_sensitivity_batch(memory_pii_sensitivity);
    learning_router_register_signal_classifier(learning_classify);
    delegate_role_register_canonicalizer(delegate_canonicalize);
+   delegate_routing_register_capability_provider(delegate_infer_caps);
    agent_tools_register_classifier(tool_classify);
    ws_scope_register_ref_validator(workspace_validate);
    /* Same decision, same owner: webuser's runtime dir names a single path

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -4048,6 +4048,7 @@ $(TESTPREFIX)/unit-test-cmd-delegate: $(OBJDIR)/tests/test_cmd_delegate.o \
                              $(OBJDIR)/role_templates.o \
                              $(OBJDIR)/modules/delegates/delegate_prompt.o $(OBJDIR)/modules/delegates/delegate_routing.o \
                              $(OBJDIR)/modules/delegates/delegate_checkout.o $(OBJDIR)/cJSON.o \
+                             $(OBJDIR)/tests/module_handlers/delegates.o \
                              $(OBJDIR)/util.o $(OBJDIR)/posix/platform_process.o $(OBJDIR)/posix/util.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -10,6 +10,44 @@
 #include <aimee/delegates/delegate_role.h>
 #include "model_registry.h"
 #include "log.h"
+#include <aimee/core/event_bus/module_runtime.h>
+#include <aimee/delegates/module_api.h>
+
+extern aimee_module_status_t aimee_delegates_module_handler(const aimee_module_invocation_t *,
+                                                            const uint8_t *, uint32_t, uint8_t *,
+                                                            uint32_t, uint32_t *, void *);
+
+int aimee_module_invocation_cancelled(const aimee_module_invocation_t *invocation)
+{
+   (void)invocation;
+   return 0;
+}
+
+/* Capability inference is the delegates module's rule now, so the unit test
+ * asks the module the same way production does, through the C wire-parity
+ * fixture, rather than reimplementing the answer locally. */
+static int capabilities_via_module(const char *prompt, int tools_enabled, unsigned *required_caps,
+                                   int *min_context)
+{
+   size_t prompt_len = prompt ? strlen(prompt) : 0;
+   size_t request_cap = AIMEE_DELEGATES_CAP_HEADER_LEN + prompt_len;
+   uint8_t *request = malloc(request_cap);
+   if (!request)
+      return -1;
+   size_t request_len =
+       aimee_delegates_cap_request_encode(prompt, prompt_len, tools_enabled, request, request_cap);
+   uint8_t response[AIMEE_DELEGATES_CAP_RESPONSE_LEN];
+   uint32_t response_len = 0;
+   aimee_module_invocation_t invocation = {.stage_id = AIMEE_DELEGATES_STAGE_CAPABILITIES};
+   int rc =
+       request_len > 0 && aimee_delegates_module_handler(
+                              &invocation, request, (uint32_t)request_len, response,
+                              sizeof(response), &response_len, NULL) == AIMEE_MODULE_STATUS_OK
+           ? aimee_delegates_cap_response_decode(response, response_len, required_caps, min_context)
+           : -1;
+   free(request);
+   return rc;
+}
 #include "modules/tools/agent_tools_internal.h"
 #include "provider_cli_adapter.h"
 #include "cJSON.h"
@@ -1244,6 +1282,15 @@ static void test_delegate_filter_route_scope(void)
 
 int main(void)
 {
+   /* Fails closed until the module is reachable: no capability is asserted from
+    * a local guess. */
+   {
+      unsigned caps = 0xffffffffu;
+      int min_ctx = -1;
+      delegate_infer_capability_requirements("screenshot.png", 1, &caps, &min_ctx);
+      assert(caps == 0 && min_ctx == 0);
+   }
+   delegate_routing_register_capability_provider(capabilities_via_module);
    printf("test_cmd_delegate\n");
    setup_role_templates();
    test_depth_zero_when_env_unset();

--- a/src/tests/test_process_module_handlers.c
+++ b/src/tests/test_process_module_handlers.c
@@ -289,6 +289,54 @@ static void test_workspace_runner_io_frames(void)
    assert(aimee_ws_io_response_decode(reply, sizeof(reply), &chunk, &chunk_len, &more) < 0);
 }
 
+/* Capability inference is stated twice, here in the module's C mirror and in
+ * server-go/modules/delegates/capabilities.go, and nothing in the build keeps
+ * them in step. These pin the answers a drifting edit would change. */
+static void test_delegates_capability_inference(void)
+{
+   uint8_t response[AIMEE_DELEGATES_CAP_RESPONSE_LEN];
+   uint8_t request[AIMEE_DELEGATES_CAP_HEADER_LEN + 256];
+   uint32_t response_len = 0;
+   aimee_module_invocation_t invocation = {.stage_id = AIMEE_DELEGATES_STAGE_CAPABILITIES};
+
+   struct
+   {
+      const char *prompt;
+      int tools;
+      unsigned expect;
+   } cases[] = {
+       /* A file reference needs the modality; describing the work in code does not. */
+       {"Transcribe recording.mp3 into text.", 0, AIMEE_DELEGATES_CAP_AUDIO},
+       {"Implement an STT dispatcher and audio routing module.", 0, 0},
+       {"Analyze screenshot.png", 0, AIMEE_DELEGATES_CAP_VISION},
+       {"review this diff: ![alt](docs/diagram)", 0, 0},
+       {"read the spec.pdf", 0, AIMEE_DELEGATES_CAP_PDF},
+       /* Tools is asserted by the caller, never read out of the prompt. */
+       {"", 1, AIMEE_DELEGATES_CAP_TOOLS},
+       {"", 0, 0},
+   };
+   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i)
+   {
+      size_t n = aimee_delegates_cap_request_encode(cases[i].prompt, strlen(cases[i].prompt),
+                                                    cases[i].tools, request, sizeof(request));
+      assert(n > 0);
+      assert(aimee_delegates_module_handler(&invocation, request, (uint32_t)n, response,
+                                            sizeof(response), &response_len,
+                                            NULL) == AIMEE_MODULE_STATUS_OK);
+      unsigned caps = 0;
+      int min_ctx = 0;
+      assert(aimee_delegates_cap_response_decode(response, response_len, &caps, &min_ctx) == 0);
+      assert(caps == cases[i].expect);
+      assert(min_ctx == 0); /* every prompt here is short */
+   }
+
+   /* Encode refuses a prompt the buffer cannot hold rather than overrunning it. */
+   char big[600];
+   memset(big, 'a', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+   assert(aimee_delegates_cap_request_encode(big, strlen(big), 0, request, sizeof(request)) == 0);
+}
+
 static void test_git(void)
 {
    uint8_t request[AIMEE_GIT_REQUEST_LEN], response[AIMEE_GIT_RESPONSE_LEN];
@@ -786,6 +834,7 @@ int main(void)
    test_workspace();
    test_workspace_runner_frames();
    test_workspace_runner_io_frames();
+   test_delegates_capability_inference();
    test_git();
    test_skills();
    test_governance();

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -375,7 +375,7 @@
         },
         {
           "path": "src/headers/cmd_agent_delegate_impl.h",
-          "sha256": "034ab8863662bc892f297a745d4867fba17787ad78264f76fdbf9176b42960aa"
+          "sha256": "d995c3e5e1b075ee9687f077c6c17ec024eb8aba8392fdd15091d7f2584e4f15"
         },
         {
           "path": "src/headers/cmd_agent_delegate_internal.h",
@@ -1463,7 +1463,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "9342493c58b64c15962561d67119aab495ab5cd3391e3d37137eca4916af3b92"
+          "sha256": "762888db4e96c7fdd956340b5c6ac52e74b8538b6626a50c1721dff3f2e59722"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "f2ef82de521bf3bc254983cf0ebfd302238bbf2bdf03611bb6743e1977dfd972",
+      "sha256": "4d4e4e5e9b12b316bdee492969e8f524eaa23007a2ba0c2981888ec03730ccb0",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
First slice of moving delegate execution out of the C mono-application: capability inference becomes the delegates module's rule, reached over the bus.

## What moved

`delegate_infer_capability_requirements` decided what a prompt implies a model must be able to do — the vision/pdf/audio marker lists, the four-chars-per-token estimate, the 4096-token threshold. That is a decision, so it is now `server-go/modules/delegates/capabilities.go` on a new stage (event 6658, stage 2). The C function asks for the answer instead of computing it.

Cut over in the same commit. The rule does not exist as a live path in two languages.

## Fails closed

C returns no capabilities and no context floor when the module cannot be reached, and the test asserts that state before the provider is registered. Guessing here would route work to a model that cannot see half its input — a prompt referencing `recording.mp3` handed to a model with no audio capability — which is worse than routing none of it.

## The two mirrors are pinned, and the pin bites

The module's C fixture states the rule as well, and nothing in the build keeps it in step with the Go. So `test_process_module_handlers` asserts the answers themselves rather than trusting that both were written correctly.

Verified by breaking it: putting the bare word `"audio"` back into the C mirror's marker list fails the parity test immediately. That is precisely the regression the original C comment warned about — prompts implementing speech features in code contain "audio" and need nothing of the model.

## Tests

Ported one-for-one from `test_cmd_delegate.c`, plus three cases the C suite did not cover:

- a short prompt must leave the context window unconstrained, since filtering on it would rule out models that were perfectly adequate;
- `tools` is asserted by the caller and never read out of the prompt;
- markdown image syntax is not a vision trigger, because it appears in any diff under review.

## Declared, not merely present

The contract (`6658`, stage 2), the descriptor's `go_sources`/`go_tests`, the dispatch table, and the registry-vs-contracts test — the four places that make a stage reachable. The lock's `serve` grant is regenerated from the contract rather than hand-edited.

## Also included

`docs/proposals/pending/delegate-execution-into-the-module.md` records the rest of this port. Two findings worth a reviewer's attention:

- `server-go/modules/roundtable` calls **the C daemon's** agent service over HTTP (`plane/client.go` holds an `http.Client` and a `net.Dialer`), wired live at `cmd/aimee-module/main.go:60`. It is not calling another Go module. It cannot be rewired until delegate execution is reachable as a stage, so the port is the prerequisite and not a follow-up.
- Delegate execution is ~12,811 lines of C; the Go module was 49 lines of role canonicalisation. The proposal decomposes what remains and states the contract shape: persona/model/prompt in, response out, plus the delegate's own working/failed/done — no caller state.

## Verification

C `unit-tests`, `make lint` (48 checks), `go vet ./...`, full `go test ./...`, and every step of the module-inventory job: inventory, refactor baselines, cleanup ledger, source ownership, bus boundary, panel contract boundary, module docs, test registration, skill-curator absence — plus `check-docs`, `check-module-boundary` and the repo lock.
