### PR TITLE
Move the delegation chain-depth rule into the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,13 +165,14 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e43a921f64c0946b4a6ae3fa83e71bf1f6bb5968db12c67c77718b56e34712af",
+      "source_sha256": "44ae8d34889891f3562e9969c6d064d787c4cc0e0c3412bc6d2ab3975f6b582f",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
       "serve": [
         6657,
-        6658
+        6658,
+        6659
       ]
     },
     {

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -104,6 +104,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 		config.Stages = []bus.ModuleStage{
 			{EventKind: delegates.EventKind, StageID: delegates.StageInvoke},
 			{EventKind: delegates.EventCapabilities, StageID: delegates.StageCapabilities},
+			{EventKind: delegates.EventChain, StageID: delegates.StageChain},
 		}
 		config.Handler = delegates.Handle
 	case "tools":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -15,7 +15,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657, 6658}},
+		{"delegates", 10, []uint32{6657, 6658, 6659}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7430}},

--- a/server-go/modules/delegates/chain.go
+++ b/server-go/modules/delegates/chain.go
@@ -1,0 +1,98 @@
+package delegates
+
+import (
+	"encoding/binary"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// How deep a delegation chain may go, and when an inherited depth is stale.
+//
+// Depth is carried between processes in an environment variable, so a child
+// spawned by a delegate inherits it and the limit holds across process
+// boundaries. Reading and writing that variable is the caller's business; which
+// answer it implies is this module's.
+
+const (
+	StageChain uint32 = 3
+	EventChain uint32 = 6659
+
+	chainRequestMagic  uint32 = 0x4e484344 /* "DCHN" */
+	chainResponseMagic uint32 = 0x52484344 /* "DCHR" */
+	chainRequestLen           = 20
+	chainResponseLen          = 12
+
+	ChainOpShouldClear byte = 1
+	ChainOpCheckDepth  byte = 2
+)
+
+// ChainEnvShouldClear reports whether an inherited delegation depth is stale and
+// must be dropped rather than believed.
+//
+// Two ways it goes stale. A depth with no parent marker is a leftover from a
+// process that is gone: nothing vouches for it. A parent marker whose process is
+// known not to be running is worse, because it names a specific ancestor that
+// has since exited. Either way the chain being described no longer exists, and
+// inheriting its depth would either forbid a legitimate delegation or let a real
+// one past the limit.
+//
+// parentActiveKnown separates "the parent is gone" from "we could not tell".
+// Only a definite answer clears; an unknown one leaves the depth alone, because
+// discarding it on a failed check would quietly raise the ceiling.
+func ChainEnvShouldClear(hasDepth, hasParent, parentActiveKnown, parentActive bool) bool {
+	if hasDepth && !hasParent {
+		return true
+	}
+	return hasParent && parentActiveKnown && !parentActive
+}
+
+// ChainDepthAllows reports the depth this delegation would run at and whether
+// that is within the limit. The answer is the child's depth, not the parent's:
+// a delegation at the limit is refused before it starts, not after.
+func ChainDepthAllows(parentDepth, maxDepth int32) (current int32, allowed bool) {
+	current = parentDepth + 1
+	return current, current <= maxDepth
+}
+
+func boolByte(v bool) byte {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func handleChain(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if len(request) != chainRequestLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != chainRequestMagic ||
+		request[4] != wireVersion {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	op := request[5]
+	if op != ChainOpShouldClear && op != ChainOpCheckDepth {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	for _, flag := range request[6:10] {
+		if flag > 1 {
+			return nil, bus.ModuleStatusInvalidRequest
+		}
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	response := make([]byte, chainResponseLen)
+	binary.LittleEndian.PutUint32(response[0:4], chainResponseMagic)
+	switch op {
+	case ChainOpShouldClear:
+		clear := ChainEnvShouldClear(request[6] == 1, request[7] == 1, request[8] == 1,
+			request[9] == 1)
+		response[4] = boolByte(clear)
+	default: // ChainOpCheckDepth
+		parent := int32(binary.LittleEndian.Uint32(request[12:16]))
+		max := int32(binary.LittleEndian.Uint32(request[16:20]))
+		current, allowed := ChainDepthAllows(parent, max)
+		response[4] = boolByte(allowed)
+		binary.LittleEndian.PutUint32(response[8:12], uint32(current))
+	}
+	return response, bus.ModuleStatusOK
+}

--- a/server-go/modules/delegates/chain_test.go
+++ b/server-go/modules/delegates/chain_test.go
@@ -1,0 +1,104 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func chainRequest(op byte, flags [4]bool, parent, max int32) []byte {
+	request := make([]byte, chainRequestLen)
+	binary.LittleEndian.PutUint32(request[0:4], chainRequestMagic)
+	request[4] = wireVersion
+	request[5] = op
+	for i, f := range flags {
+		request[6+i] = boolByte(f)
+	}
+	binary.LittleEndian.PutUint32(request[12:16], uint32(parent))
+	binary.LittleEndian.PutUint32(request[16:20], uint32(max))
+	return request
+}
+
+func chainCall(t *testing.T, request []byte) (bool, int32) {
+	t.Helper()
+	response, status := Handle(bus.ModuleInvocation{StageID: StageChain}, request)
+	if status != bus.ModuleStatusOK || len(response) != chainResponseLen ||
+		binary.LittleEndian.Uint32(response[0:4]) != chainResponseMagic {
+		t.Fatalf("response = %x, status = %d", response, status)
+	}
+	return response[4] == 1, int32(binary.LittleEndian.Uint32(response[8:12]))
+}
+
+// An inherited depth is only trustworthy while the chain it describes still
+// exists. Both ways it goes stale must clear it, or a delegation is judged
+// against a chain that has already gone.
+func TestStaleInheritedDepthIsCleared(t *testing.T) {
+	cases := []struct {
+		name                                          string
+		hasDepth, hasParent, parentKnown, parentAlive bool
+		want                                          bool
+	}{
+		{"depth with no parent marker is a leftover", true, false, false, false, true},
+		{"parent known to have exited", true, true, true, false, true},
+		{"parent still running", true, true, true, true, false},
+		// A failed check must not clear: discarding the depth would quietly
+		// raise the ceiling for every delegation underneath it.
+		{"parent liveness unknown", true, true, false, false, false},
+		{"nothing inherited at all", false, false, false, false, false},
+	}
+	for _, c := range cases {
+		flags := [4]bool{c.hasDepth, c.hasParent, c.parentKnown, c.parentAlive}
+		got, _ := chainCall(t, chainRequest(ChainOpShouldClear, flags, 0, 0))
+		if got != c.want {
+			t.Errorf("%s: clear = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// The depth reported is the child's, so a delegation at the limit is refused
+// before it runs rather than after.
+func TestDepthIsCheckedAgainstTheChildNotTheParent(t *testing.T) {
+	cases := []struct {
+		parent, max, wantDepth int32
+		wantAllowed            bool
+	}{
+		{0, 3, 1, true},  // first delegation
+		{2, 3, 3, true},  // exactly at the limit is still allowed
+		{3, 3, 4, false}, // one past it is not
+		{0, 0, 1, false}, // a zero limit forbids delegating at all
+	}
+	for _, c := range cases {
+		allowed, depth := chainCall(t,
+			chainRequest(ChainOpCheckDepth, [4]bool{}, c.parent, c.max))
+		if allowed != c.wantAllowed || depth != c.wantDepth {
+			t.Errorf("parent=%d max=%d: allowed=%v depth=%d, want %v/%d",
+				c.parent, c.max, allowed, depth, c.wantAllowed, c.wantDepth)
+		}
+	}
+}
+
+func TestChainRejectsInvalidEnvelope(t *testing.T) {
+	short := chainRequest(ChainOpCheckDepth, [4]bool{}, 0, 1)[:chainRequestLen-1]
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageChain}, short); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("truncated status = %d", status)
+	}
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageChain},
+		chainRequest(9, [4]bool{}, 0, 1)); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("unknown-op status = %d", status)
+	}
+
+	// A flag byte that is neither 0 nor 1 is not a boolean; refuse rather than
+	// coerce it, since coercion would silently pick an answer.
+	bad := chainRequest(ChainOpShouldClear, [4]bool{}, 0, 0)
+	bad[7] = 2
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageChain}, bad); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("non-boolean flag status = %d", status)
+	}
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageChain, DeadlineNS: 1},
+		chainRequest(ChainOpCheckDepth, [4]bool{}, 0, 1)); status != bus.ModuleStatusCancelled {
+		t.Fatalf("expired status = %d", status)
+	}
+}

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -32,6 +32,9 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 	if invocation.StageID == StageCapabilities {
 		return handleCapabilities(invocation, request)
 	}
+	if invocation.StageID == StageChain {
+		return handleChain(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -3,6 +3,7 @@
 #ifndef DEC_CMD_AGENT_DELEGATE_IMPL_H
 #define DEC_CMD_AGENT_DELEGATE_IMPL_H 1
 
+#include <stdint.h>
 #include "aimee.h"
 #include "agent.h"
 #include "agent_config.h"
@@ -42,6 +43,14 @@ void delegate_worktree_restore(const char *orig_cwd, const char *git_root, const
  *   - Returns -1 without modifying the environment.
  *   - If errbuf is non-NULL, writes a human-readable message into it.
  */
+/* Answers the delegates module's chain questions. Returns 0 and fills *flag
+ * (should-clear, or depth-allowed) and, for the depth op, *current_depth.
+ * Non-zero means the module could not answer. */
+typedef int (*delegate_chain_provider_fn)(unsigned op, int has_depth, int has_parent,
+                                          int parent_known, int parent_active, int parent_depth,
+                                          int max_depth, int *flag, int32_t *current_depth);
+void delegate_register_chain_provider(delegate_chain_provider_fn provider);
+
 int delegate_check_chain_depth(int max_depth, char *errbuf, size_t errbuf_sz);
 int delegate_chain_env_should_clear(const char *depth_env, const char *parent_env,
                                     int parent_active_known, int parent_active);

--- a/src/modules/delegates/delegate_depth.c
+++ b/src/modules/delegates/delegate_depth.c
@@ -5,40 +5,70 @@
  * current depth and the limit can be enforced across process boundaries.
  */
 #include "platform_process.h"
+#include "cmd_agent_delegate_impl.h"
+#include <aimee/delegates/module_api.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
+static delegate_chain_provider_fn g_chain_provider;
+
+void delegate_register_chain_provider(delegate_chain_provider_fn provider)
+{
+   g_chain_provider = provider;
+}
+
+/* Both questions below are the delegates module's rule; this asks them.
+ *
+ * They fail closed in OPPOSITE directions, because the safe answer differs. An
+ * unanswerable staleness question must not clear the depth: discarding it would
+ * raise the ceiling for everything underneath. An unanswerable depth question
+ * must refuse the delegation: allowing it would let a chain run past the limit
+ * this guard exists to enforce. */
 int delegate_chain_env_should_clear(const char *depth_env, const char *parent_env,
                                     int parent_active_known, int parent_active)
 {
-   int has_depth = depth_env && depth_env[0];
-   int has_parent = parent_env && parent_env[0];
-   if (has_depth && !has_parent)
-      return 1;
-   if (has_parent && parent_active_known && !parent_active)
-      return 1;
-   return 0;
+   int clear = 0;
+   if (!g_chain_provider)
+      return 0;
+   return g_chain_provider(AIMEE_DELEGATES_CHAIN_OP_SHOULD_CLEAR, depth_env && depth_env[0],
+                           parent_env && parent_env[0], parent_active_known, parent_active, 0, 0,
+                           &clear, NULL) == 0
+              ? clear
+              : 0;
 }
 
 int delegate_check_chain_depth(int max_depth, char *errbuf, size_t errbuf_sz)
 {
    const char *env_val = getenv("AIMEE_DELEGATE_DEPTH");
    int parent_depth = (env_val && env_val[0]) ? atoi(env_val) : 0;
-   int current_depth = parent_depth + 1;
+   int allowed = 0;
+   int32_t current_depth = 0;
 
-   if (current_depth > max_depth)
+   if (!g_chain_provider ||
+       g_chain_provider(AIMEE_DELEGATES_CHAIN_OP_CHECK_DEPTH, 0, 0, 0, 0, parent_depth, max_depth,
+                        &allowed, &current_depth) != 0)
+   {
+      if (errbuf && errbuf_sz > 0)
+         snprintf(errbuf, errbuf_sz,
+                  "delegation depth cannot be checked (delegates module unavailable); "
+                  "refusing to delegate rather than risk exceeding the limit.");
+      return -1;
+   }
+
+   if (!allowed)
    {
       if (errbuf && errbuf_sz > 0)
          snprintf(errbuf, errbuf_sz,
                   "delegation chain depth limit exceeded (%d/%d). "
                   "Reduce nesting or increase max_delegation_depth in config.",
-                  current_depth, max_depth);
+                  (int)current_depth, max_depth);
       return -1;
    }
 
    char depth_str[32];
-   snprintf(depth_str, sizeof(depth_str), "%d", current_depth);
+   snprintf(depth_str, sizeof(depth_str), "%d", (int)current_depth);
    platform_setenv("AIMEE_DELEGATE_DEPTH", depth_str);
    return 0;
 }

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -31,6 +31,18 @@
 #define AIMEE_DELEGATES_CAP_PDF    (1u << 3)
 #define AIMEE_DELEGATES_CAP_AUDIO  (1u << 4)
 
+/* Chain depth: how deep a delegation may nest, and when an inherited depth is
+ * stale. Depth crosses process boundaries in an environment variable; reading
+ * and writing it is the caller's business, what it implies is the module's. */
+#define AIMEE_DELEGATES_EVENT_CHAIN           6659u
+#define AIMEE_DELEGATES_STAGE_CHAIN           3u
+#define AIMEE_DELEGATES_CHAIN_REQUEST_MAGIC   0x4e484344u /* "DCHN" */
+#define AIMEE_DELEGATES_CHAIN_RESPONSE_MAGIC  0x52484344u /* "DCHR" */
+#define AIMEE_DELEGATES_CHAIN_REQUEST_LEN     20u
+#define AIMEE_DELEGATES_CHAIN_RESPONSE_LEN    12u
+#define AIMEE_DELEGATES_CHAIN_OP_SHOULD_CLEAR 1u
+#define AIMEE_DELEGATES_CHAIN_OP_CHECK_DEPTH  2u
+
 static inline void aimee_delegates_put_u32(uint8_t *p, uint32_t v)
 {
    for (unsigned i = 0; i < 4; ++i)
@@ -101,6 +113,42 @@ static inline int aimee_delegates_cap_response_decode(const uint8_t *in, size_t 
       *required_caps = (unsigned)aimee_delegates_get_u32(in + 4);
    if (min_context)
       *min_context = (int)aimee_delegates_get_u32(in + 8);
+   return 0;
+}
+
+/* Frame a chain question. Flags are booleans and must be 0 or 1; parent_depth
+ * and max_depth are only read by the depth op. */
+static inline int aimee_delegates_chain_request_encode(unsigned op, int has_depth, int has_parent,
+                                                       int parent_known, int parent_active,
+                                                       int32_t parent_depth, int32_t max_depth,
+                                                       uint8_t *out, size_t cap)
+{
+   if (!out || cap < AIMEE_DELEGATES_CHAIN_REQUEST_LEN)
+      return -1;
+   memset(out, 0, AIMEE_DELEGATES_CHAIN_REQUEST_LEN);
+   aimee_delegates_put_u32(out, AIMEE_DELEGATES_CHAIN_REQUEST_MAGIC);
+   out[4] = (uint8_t)AIMEE_DELEGATES_WIRE_VERSION;
+   out[5] = (uint8_t)op;
+   out[6] = has_depth ? 1u : 0u;
+   out[7] = has_parent ? 1u : 0u;
+   out[8] = parent_known ? 1u : 0u;
+   out[9] = parent_active ? 1u : 0u;
+   aimee_delegates_put_u32(out + 12, (uint32_t)parent_depth);
+   aimee_delegates_put_u32(out + 16, (uint32_t)max_depth);
+   return 0;
+}
+
+/* `flag` is the op's boolean answer: should-clear, or depth-allowed. */
+static inline int aimee_delegates_chain_response_decode(const uint8_t *in, size_t len, int *flag,
+                                                        int32_t *current_depth)
+{
+   if (!in || len != AIMEE_DELEGATES_CHAIN_RESPONSE_LEN ||
+       aimee_delegates_get_u32(in) != AIMEE_DELEGATES_CHAIN_RESPONSE_MAGIC || in[4] > 1u)
+      return -1;
+   if (flag)
+      *flag = in[4] == 1u;
+   if (current_depth)
+      *current_depth = (int32_t)aimee_delegates_get_u32(in + 8);
    return 0;
 }
 

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -72,12 +72,14 @@
     "server-go/modules/delegates/delegates.go",
     "server-go/modules/delegates/plane/client.go",
     "server-go/modules/delegates/plane/helpers.go",
-    "server-go/modules/delegates/capabilities.go"
+    "server-go/modules/delegates/capabilities.go",
+    "server-go/modules/delegates/chain.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
     "server-go/modules/delegates/plane/client_test.go",
-    "server-go/modules/delegates/capabilities_test.go"
+    "server-go/modules/delegates/capabilities_test.go",
+    "server-go/modules/delegates/chain_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",

--- a/src/modules/delegates/module_adapter.c
+++ b/src/modules/delegates/module_adapter.c
@@ -119,12 +119,64 @@ static aimee_module_status_t handle_capabilities(const aimee_module_invocation_t
    return AIMEE_MODULE_STATUS_OK;
 }
 
+/* Chain depth. Stated in Go as well (server-go/modules/delegates/chain.go) and
+ * pinned by test_process_module_handlers, because nothing in the build keeps
+ * the two in step. */
+static aimee_module_status_t handle_chain(const aimee_module_invocation_t *invocation,
+                                          const uint8_t *request_body, uint32_t request_len,
+                                          uint8_t *response_body, uint32_t response_capacity,
+                                          uint32_t *response_len)
+{
+   if (request_len != AIMEE_DELEGATES_CHAIN_REQUEST_LEN ||
+       response_capacity < AIMEE_DELEGATES_CHAIN_RESPONSE_LEN ||
+       aimee_delegates_get_u32(request_body) != AIMEE_DELEGATES_CHAIN_REQUEST_MAGIC ||
+       request_body[4] != AIMEE_DELEGATES_WIRE_VERSION)
+      return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+   unsigned op = request_body[5];
+   if (op != AIMEE_DELEGATES_CHAIN_OP_SHOULD_CLEAR && op != AIMEE_DELEGATES_CHAIN_OP_CHECK_DEPTH)
+      return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+   /* A flag that is neither 0 nor 1 is not a boolean; refuse rather than coerce
+    * it, since coercing would silently pick an answer. */
+   for (unsigned i = 6; i < 10; ++i)
+      if (request_body[i] > 1u)
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+   if (aimee_module_invocation_cancelled(invocation))
+      return AIMEE_MODULE_STATUS_CANCELLED;
+
+   memset(response_body, 0, AIMEE_DELEGATES_CHAIN_RESPONSE_LEN);
+   aimee_delegates_put_u32(response_body, AIMEE_DELEGATES_CHAIN_RESPONSE_MAGIC);
+   if (op == AIMEE_DELEGATES_CHAIN_OP_SHOULD_CLEAR)
+   {
+      int has_depth = request_body[6] == 1u, has_parent = request_body[7] == 1u;
+      int parent_known = request_body[8] == 1u, parent_active = request_body[9] == 1u;
+      /* A depth with no parent marker is a leftover from a process that is
+       * gone. A parent known to have exited is worse: it names an ancestor that
+       * no longer exists. An UNKNOWN liveness must not clear -- discarding the
+       * depth there would quietly raise the ceiling underneath it. */
+      int clear = (has_depth && !has_parent) || (has_parent && parent_known && !parent_active);
+      response_body[4] = clear ? 1u : 0u;
+   }
+   else
+   {
+      int32_t parent = (int32_t)aimee_delegates_get_u32(request_body + 12);
+      int32_t max = (int32_t)aimee_delegates_get_u32(request_body + 16);
+      int32_t current = parent + 1; /* the child's depth: refuse before running */
+      response_body[4] = current <= max ? 1u : 0u;
+      aimee_delegates_put_u32(response_body + 8, (uint32_t)current);
+   }
+   *response_len = AIMEE_DELEGATES_CHAIN_RESPONSE_LEN;
+   return AIMEE_MODULE_STATUS_OK;
+}
+
 aimee_module_status_t aimee_module_handler(const aimee_module_invocation_t *invocation,
                                            const uint8_t *request_body, uint32_t request_len,
                                            uint8_t *response_body, uint32_t response_capacity,
                                            uint32_t *response_len, void *user_data)
 {
    (void)user_data;
+   if (invocation && response_len && invocation->stage_id == AIMEE_DELEGATES_STAGE_CHAIN)
+      return handle_chain(invocation, request_body, request_len, response_body, response_capacity,
+                          response_len);
    if (invocation && response_len && invocation->stage_id == AIMEE_DELEGATES_STAGE_CAPABILITIES)
       return handle_capabilities(invocation, request_body, request_len, response_body,
                                  response_capacity, response_len);

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -136,6 +136,11 @@
           "id": 2,
           "name": "delegate-capability-inference",
           "event_kind": 6658
+        },
+        {
+          "id": 3,
+          "name": "delegate-chain-depth",
+          "event_kind": 6659
         }
       ]
     },

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -300,6 +300,22 @@ static int delegate_infer_caps(const char *prompt, int tools_enabled, unsigned *
    return rc;
 }
 
+static int delegate_chain(unsigned op, int has_depth, int has_parent, int parent_known,
+                          int parent_active, int parent_depth, int max_depth, int *flag,
+                          int32_t *current_depth)
+{
+   uint8_t request[AIMEE_DELEGATES_CHAIN_REQUEST_LEN];
+   uint8_t response[AIMEE_DELEGATES_CHAIN_RESPONSE_LEN];
+   uint32_t response_len = 0;
+   return aimee_delegates_chain_request_encode(op, has_depth, has_parent, parent_known,
+                                               parent_active, (int32_t)parent_depth,
+                                               (int32_t)max_depth, request, sizeof(request)) == 0 &&
+                  call_module(AIMEE_DELEGATES_EVENT_CHAIN, AIMEE_DELEGATES_STAGE_CHAIN, request,
+                              sizeof(request), response, sizeof(response), &response_len) == 0
+              ? aimee_delegates_chain_response_decode(response, response_len, flag, current_depth)
+              : -1;
+}
+
 static int tool_classify(const char *name, int *classification)
 {
    uint8_t request[AIMEE_TOOLS_REQUEST_LEN], response[AIMEE_TOOLS_RESPONSE_LEN];
@@ -508,6 +524,7 @@ void server_module_stage_adapters_configure(void)
    learning_router_register_signal_classifier(learning_classify);
    delegate_role_register_canonicalizer(delegate_canonicalize);
    delegate_routing_register_capability_provider(delegate_infer_caps);
+   delegate_register_chain_provider(delegate_chain);
    agent_tools_register_classifier(tool_classify);
    ws_scope_register_ref_validator(workspace_validate);
    /* Same decision, same owner: webuser's runtime dir names a single path

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -1280,6 +1280,24 @@ static void test_delegate_filter_route_scope(void)
    printf("  PASS: test_delegate_filter_route_scope\n");
 }
 
+static int chain_via_module(unsigned op, int has_depth, int has_parent, int parent_known,
+                            int parent_active, int parent_depth, int max_depth, int *flag,
+                            int32_t *current_depth)
+{
+   uint8_t request[AIMEE_DELEGATES_CHAIN_REQUEST_LEN];
+   uint8_t response[AIMEE_DELEGATES_CHAIN_RESPONSE_LEN];
+   uint32_t response_len = 0;
+   aimee_module_invocation_t invocation = {.stage_id = AIMEE_DELEGATES_STAGE_CHAIN};
+   return aimee_delegates_chain_request_encode(op, has_depth, has_parent, parent_known,
+                                               parent_active, (int32_t)parent_depth,
+                                               (int32_t)max_depth, request, sizeof(request)) == 0 &&
+                  aimee_delegates_module_handler(&invocation, request, sizeof(request), response,
+                                                 sizeof(response), &response_len,
+                                                 NULL) == AIMEE_MODULE_STATUS_OK
+              ? aimee_delegates_chain_response_decode(response, response_len, flag, current_depth)
+              : -1;
+}
+
 int main(void)
 {
    /* Fails closed until the module is reachable: no capability is asserted from
@@ -1291,6 +1309,7 @@ int main(void)
       assert(caps == 0 && min_ctx == 0);
    }
    delegate_routing_register_capability_provider(capabilities_via_module);
+   delegate_register_chain_provider(chain_via_module);
    printf("test_cmd_delegate\n");
    setup_role_templates();
    test_depth_zero_when_env_unset();

--- a/src/tests/test_process_module_handlers.c
+++ b/src/tests/test_process_module_handlers.c
@@ -337,6 +337,76 @@ static void test_delegates_capability_inference(void)
    assert(aimee_delegates_cap_request_encode(big, strlen(big), 0, request, sizeof(request)) == 0);
 }
 
+/* Chain depth is stated twice, here in the module's C mirror and in
+ * server-go/modules/delegates/chain.go. These pin both answers. */
+static void test_delegates_chain_depth(void)
+{
+   uint8_t request[AIMEE_DELEGATES_CHAIN_REQUEST_LEN];
+   uint8_t response[AIMEE_DELEGATES_CHAIN_RESPONSE_LEN];
+   uint32_t response_len = 0;
+   aimee_module_invocation_t invocation = {.stage_id = AIMEE_DELEGATES_STAGE_CHAIN};
+
+   /* An inherited depth is trustworthy only while its chain still exists. The
+    * UNKNOWN case must NOT clear: discarding the depth on a failed liveness
+    * check would quietly raise the ceiling for everything underneath it. */
+   struct
+   {
+      int has_depth, has_parent, known, active, want;
+   } clears[] = {
+       {1, 0, 0, 0, 1}, /* depth with no parent marker is a leftover */
+       {1, 1, 1, 0, 1}, /* parent known to have exited */
+       {1, 1, 1, 1, 0}, /* parent still running */
+       {1, 1, 0, 0, 0}, /* liveness unknown: leave it alone */
+       {0, 0, 0, 0, 0}, /* nothing inherited */
+   };
+   for (size_t i = 0; i < sizeof(clears) / sizeof(clears[0]); ++i)
+   {
+      int flag = -1;
+      assert(aimee_delegates_chain_request_encode(
+                 AIMEE_DELEGATES_CHAIN_OP_SHOULD_CLEAR, clears[i].has_depth, clears[i].has_parent,
+                 clears[i].known, clears[i].active, 0, 0, request, sizeof(request)) == 0);
+      assert(aimee_delegates_module_handler(&invocation, request, sizeof(request), response,
+                                            sizeof(response), &response_len,
+                                            NULL) == AIMEE_MODULE_STATUS_OK);
+      assert(aimee_delegates_chain_response_decode(response, response_len, &flag, NULL) == 0);
+      assert(flag == clears[i].want);
+   }
+
+   /* The depth reported is the CHILD's, so a delegation at the limit is refused
+    * before it runs rather than after. */
+   struct
+   {
+      int parent, max, want_depth, want_allowed;
+   } depths[] = {
+       {0, 3, 1, 1},
+       {2, 3, 3, 1},
+       {3, 3, 4, 0},
+       {0, 0, 1, 0},
+   };
+   for (size_t i = 0; i < sizeof(depths) / sizeof(depths[0]); ++i)
+   {
+      int flag = -1;
+      int32_t current = -1;
+      assert(aimee_delegates_chain_request_encode(AIMEE_DELEGATES_CHAIN_OP_CHECK_DEPTH, 0, 0, 0, 0,
+                                                  depths[i].parent, depths[i].max, request,
+                                                  sizeof(request)) == 0);
+      assert(aimee_delegates_module_handler(&invocation, request, sizeof(request), response,
+                                            sizeof(response), &response_len,
+                                            NULL) == AIMEE_MODULE_STATUS_OK);
+      assert(aimee_delegates_chain_response_decode(response, response_len, &flag, &current) == 0);
+      assert(flag == depths[i].want_allowed);
+      assert(current == depths[i].want_depth);
+   }
+
+   /* A flag byte that is neither 0 nor 1 is not a boolean: refused, not coerced. */
+   assert(aimee_delegates_chain_request_encode(AIMEE_DELEGATES_CHAIN_OP_SHOULD_CLEAR, 0, 0, 0, 0, 0,
+                                               0, request, sizeof(request)) == 0);
+   request[7] = 2;
+   assert(aimee_delegates_module_handler(&invocation, request, sizeof(request), response,
+                                         sizeof(response), &response_len,
+                                         NULL) == AIMEE_MODULE_STATUS_INVALID_REQUEST);
+}
+
 static void test_git(void)
 {
    uint8_t request[AIMEE_GIT_REQUEST_LEN], response[AIMEE_GIT_RESPONSE_LEN];
@@ -835,6 +905,7 @@ int main(void)
    test_workspace_runner_frames();
    test_workspace_runner_io_frames();
    test_delegates_capability_inference();
+   test_delegates_chain_depth();
    test_git();
    test_skills();
    test_governance();

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -375,7 +375,7 @@
         },
         {
           "path": "src/headers/cmd_agent_delegate_impl.h",
-          "sha256": "d995c3e5e1b075ee9687f077c6c17ec024eb8aba8392fdd15091d7f2584e4f15"
+          "sha256": "9242342233cff05f138192e16b86ea4279ce6dd3e6b5b7657854bc20f988d9da"
         },
         {
           "path": "src/headers/cmd_agent_delegate_internal.h",
@@ -1463,7 +1463,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "762888db4e96c7fdd956340b5c6ac52e74b8538b6626a50c1721dff3f2e59722"
+          "sha256": "e429b13ecfc1f9c96ac753067f93d852791dc13ea4f48924f6380f120a9a1b1a"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "4d4e4e5e9b12b316bdee492969e8f524eaa23007a2ba0c2981888ec03730ccb0",
+      "sha256": "3e46ac085fbe3b2a684cf9a994052ea690f83d775135a363fe6e62138b42c8fa",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
Second slice of the delegate-execution port. The delegation chain-depth guard's two decisions become the module's rule, reached over the bus.

## What moved

`delegate_depth.c` decided two things: whether an inherited delegation depth has gone stale, and whether a delegation fits the configured limit. Both are pure, so both are now `server-go/modules/delegates/chain.go` on a new stage (event 6659, stage 3).

Reading and writing `AIMEE_DELEGATE_DEPTH` stays with the caller — that is process environment, not a decision. What it *implies* is answered by the module. Cut over in this commit; the rule is not live in two languages.

## The two ends fail closed in opposite directions

This is the part worth review time. When the module cannot answer:

- **staleness must NOT clear the depth** — discarding it would raise the ceiling for every delegation underneath;
- **the depth check MUST refuse** — allowing it would let a chain run past the limit the guard exists to enforce.

Same failure, opposite safe answers, because the risk is not symmetric. A single "fail closed" reflex would have got one of them wrong.

## A distinction that is easy to lose

A parent whose liveness is **unknown** is not a parent **known to have exited**. Only a definite answer clears the inherited depth. The obvious simplification — dropping the `parent_known` term — is exactly what a later reader would do, so the parity test fails when the two are collapsed. Verified by making that edit and watching it fail.

## Boundaries pinned

Depth is reported for the **child**, so a delegation at the limit is refused before it runs rather than after. The table covers the boundaries: at the limit allowed, one past it refused, and a zero limit forbidding delegation entirely.

A flag byte that is neither 0 nor 1 is refused rather than coerced, on both sides — coercion would silently pick an answer.

## Parity

The module's C mirror states the rule too, and nothing in the build keeps it in step with the Go, so `test_process_module_handlers` asserts both answers directly.

## Declared, not merely present

Contract (`6659`, stage 3), descriptor `go_sources`/`go_tests`, dispatch table, registry-vs-contracts test. The lock's `serve` grant is regenerated from the contract.

## Verification

Full `make -C src` (rc=0 — the gap that broke #2494 the first time), C `unit-tests`, `make lint` (48 checks), `go vet`, full `go test ./...`, plus module test-registration, module docs, module boundary, module inventory and the repo lock.
