### PR TITLE
fix(git): resolve the push credential by the workspace's remote, not the cwd

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -226,7 +226,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "09b5484fe3340481ee412101b9b62825a5a40da2a53d4f963e4b5efef19e70dc",
+      "source_sha256": "084d0d00fbcb9b5eece3b06399854ea9b3c00586afe56c0ad55fc53cfd9e5fed",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -66,6 +66,27 @@ int mcp_git_get_worktree(void)
  * the command still runs here with no injected credential — the same ambient
  * fall-through already documented for "no token", rather than a new failure
  * mode. Returns 0 with `out` set when a workspace owns the cwd, -1 otherwise. */
+/* The remote URL the registry records for the workspace rooted at `root`, or
+ * NULL when unknown. Read from the same accessor the mirror lifecycle uses
+ * (workspace_turn.c), so the two cannot disagree about a workspace's remote.
+ * Returns a pointer into config storage: use it before any further config read.
+ */
+static const char *workspace_remote_for_root(const char *root)
+{
+   if (!root || !root[0])
+      return NULL;
+   for (int i = 0; i < config_workspace_count(); i++)
+   {
+      const char *candidate = config_workspaces(i);
+      if (candidate && strcmp(candidate, root) == 0)
+      {
+         const char *remote = config_workspace_vcs_remote(i);
+         return (remote && remote[0]) ? remote : NULL;
+      }
+   }
+   return NULL;
+}
+
 static int forge_workspace_for_cwd(const char *cwd, int provider_kind, int *runs_on_server,
                                    char *out, size_t outsz)
 {
@@ -165,8 +186,21 @@ char *mcp_git_run(const char *cmd, int *exit_code)
          if (forge_cred_get(wsid, (long)time(NULL), tok, sizeof(tok)) == 0 && tok[0])
             pref = tok;
          int token_fd = -1;
+         /* Hand the policy the workspace's RECORDED REMOTE, not just the cwd.
+          * The per-host vault step keys on the remote's host, which it derives
+          * from an explicit remote URL or, failing that, by running
+          * `git -C <repo_dir> config --get remote.origin.url`. For a mirror the
+          * cwd we were handed is the CLIENT's path: it does not exist on this
+          * server, so that lookup finds nothing, resolution falls through to no
+          * token, and git prompts — "could not read Username", the very failure
+          * this file's header describes. workspace_turn.c already passes the
+          * remote for exactly this reason ("remote URL (per-host vault lookup),
+          * so ctx carries both"); this call site is the one that did not.
+          * cwd is still passed as the fallback for a shared workspace, where it
+          * IS the real checkout and no remote may be recorded. */
+         const char *ws_remote = workspace_remote_for_root(wsid);
          char **envp =
-             git_cred_inject_build_env_for_repo(NULL, NULL, cwd, pref, environ, &token_fd);
+             git_cred_inject_build_env_for_repo(NULL, ws_remote, cwd, pref, environ, &token_fd);
          volatile char *p = (volatile char *)tok;
          for (size_t i = 0; i < sizeof(tok); i++)
             p[i] = 0;

--- a/src/tests/test_git_host_resolve.c
+++ b/src/tests/test_git_host_resolve.c
@@ -57,6 +57,25 @@ int main(void)
    assert(system(setup2) == 0);
    assert(git_host_resolve_token(NULL, dir2, tok, sizeof(tok)) == 0);
 
+   /* THE MIRROR CONDITION. A mirror workspace's server-side checkout is
+    * reconstructed under the mirror base, so the cwd the client handed over does
+    * NOT exist on this host. Resolving by that path finds no origin and yields
+    * no token — which upstream is indistinguishable from "no credential", and is
+    * how `aimee git push` came to fail with "could not read Username" while
+    * reads (which never exec git) kept working.
+    *
+    * So the caller must pass the workspace's RECORDED remote. These two
+    * assertions pin both halves: the path alone is not enough, the remote is. */
+   char absent[256];
+   snprintf(absent, sizeof(absent), "/tmp/aimee-ghr-absent-%d", (int)getpid());
+   assert(access(absent, F_OK) != 0); /* genuinely not present */
+
+   assert(git_host_resolve_token(NULL, absent, tok, sizeof(tok)) == 0);
+   assert(tok[0] == '\0');
+
+   assert(git_host_resolve_token("https://vault.example/a/b.git", absent, tok, sizeof(tok)) == 1);
+   assert(strcmp(tok, "TOK-vaulted") == 0);
+
    /* Dormant again after a NULL re-register. */
    git_host_resolve_register(NULL);
    assert(git_host_resolve_token("https://vault.example/x/y", NULL, tok, sizeof(tok)) == 0);


### PR DESCRIPTION
## The failure

`aimee git push` in a **mirror** workspace fails with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

while every read keeps working. That asymmetry is the whole tell: reads never exec git — `git_pr_api.c` puts the token straight into an `Authorization` header — so only the path that spawns a child child is affected. Upstream this is indistinguishable from a dead or expired credential, which is how it was misread as a token problem more than once (including by me, repeatedly, in the session that found it).

## Root cause

The per-host vault step keys on the remote's **host**, which `git_host_resolve_token` derives either from an explicit remote URL or, failing that, by running:

```
git -C <repo_dir> config --get remote.origin.url
```

`mcp_git_run` passed the **cwd** as `repo_dir`. For a mirror workspace that cwd is the *client's* path — the server-side checkout is reconstructed under the mirror base, so the path does not exist on the server. The origin lookup finds nothing, resolution falls through to no token at all, and git prompts for a username.

`workspace_turn.c` already passes the recorded remote for exactly this reason, and says so:

> `remote URL (per-host vault lookup), so ctx carries both`

reading it from `config_workspace_vcs_remote()`. This call site was the one that did not.

## The fix

Use the same accessor, so the mirror lifecycle and the `aimee git` exec path cannot disagree about a workspace's remote. `cwd` is still passed as the fallback for a **shared** workspace, where it *is* the real checkout and no remote may be recorded.

## Tests

`test_git_host_resolve.c` gains the mirror condition, pinning both halves of what made this invisible:

- a `repo_dir` that does not exist on this host resolves **no** token
- the same lookup **succeeds** once the remote is supplied

`make -C src -j8` clean; full `make -C src unit-tests` green (checked deliberately for link ripples, since `mcp_git_query.o` is linked into several test targets and this adds a `config_*` call to it).

## Validation status

The unit-level behaviour is covered. The true end-to-end — an actual `aimee git push` from a mirror workspace against a deployed server — **has not been run** and is validation-pending; it needs this built and deployed. Flagging that explicitly rather than implying the symptom is confirmed fixed.

Note the deployed `:testing` at the time of diagnosis was `167dc65b80`, which *is* the merge of #2488; that PR corrected the workspace **ownership** detection, and this is the remaining gap in the same path.