### PR TITLE
Move named-path extraction into the delegates module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,14 +165,15 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "44ae8d34889891f3562e9969c6d064d787c4cc0e0c3412bc6d2ab3975f6b582f",
+      "source_sha256": "e76e59705a9c8552919ea6250c18e3423dacdf38472eeccce4385fd03d256206",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
       "serve": [
         6657,
         6658,
-        6659
+        6659,
+        6660
       ]
     },
     {

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -105,6 +105,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: delegates.EventKind, StageID: delegates.StageInvoke},
 			{EventKind: delegates.EventCapabilities, StageID: delegates.StageCapabilities},
 			{EventKind: delegates.EventChain, StageID: delegates.StageChain},
+			{EventKind: delegates.EventPaths, StageID: delegates.StagePaths},
 		}
 		config.Handler = delegates.Handle
 	case "tools":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -15,7 +15,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657, 6658, 6659}},
+		{"delegates", 10, []uint32{6657, 6658, 6659, 6660}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7430}},

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -35,6 +35,9 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 	if invocation.StageID == StageChain {
 		return handleChain(invocation, request)
 	}
+	if invocation.StageID == StagePaths {
+		return handlePaths(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/server-go/modules/delegates/paths.go
+++ b/server-go/modules/delegates/paths.go
@@ -1,0 +1,207 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"strings"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Which files a brief actually names as targets.
+//
+// Used to notice drift: a delegate that was told to edit src/foo.c and did not.
+// Every rule below is deliberately conservative, because the two failure modes
+// are not equally costly. Missing a path means one drift warning that was not
+// raised. Inventing one means telling an operator a successful run failed, which
+// trains them to ignore the check.
+
+const (
+	StagePaths uint32 = 4
+	EventPaths uint32 = 6660
+
+	pathsRequestMagic  uint32 = 0x54415044 /* "DPAT" */
+	pathsResponseMagic uint32 = 0x53415044 /* "DPAS" */
+	pathsHeaderLen            = 12
+	pathsRespHeaderLen        = 8
+	pathsPromptMax            = 1 << 20
+	// Mirrors DELEGATE_DRIFT_MAX_PATHS / DELEGATE_DRIFT_PATH_MAX.
+	pathsMax    = 16
+	pathMaxLen  = 256
+	pathsExtMax = 16
+)
+
+var driftSrcExts = map[string]bool{
+	".c": true, ".h": true, ".cpp": true, ".cc": true, ".cxx": true, ".py": true,
+	".js": true, ".ts": true, ".go": true, ".rs": true, ".java": true, ".rb": true,
+	".sh": true, ".yaml": true, ".yml": true, ".json": true, ".toml": true,
+	".md": true, ".sql": true, ".mk": true, ".conf": true, ".cfg": true,
+}
+
+// Everything after one of these markers is appended evidence, not the brief. A
+// path mentioned only in a diff or a prompt file is not something the delegate
+// was asked to produce.
+var surfaceMarkers = []string{
+	"\n\n# Prompt File\n",
+	"\n# Prompt File\n",
+	"\n\n---\n## Parent Worktree Diff Evidence\n",
+	"\n---\n## Parent Worktree Diff Evidence\n",
+	"\n\n---\n## Validation Evidence Bundle\n",
+	"\n---\n## Validation Evidence Bundle\n",
+}
+
+var negations = []string{
+	"do not ", "don't ", "does not ", "doesn't ", "must not ", "mustn't ",
+	"cannot ", "can't ", "should not ", "shouldn't ", "will not ", "won't ",
+	"skip ", "off-limits", "off limits", "no touch", "do not touch", "not touch",
+	"leave alone", "ignore ",
+}
+
+func isPathChar(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' ||
+		c == '.' || c == '/' || c == '_' || c == '-'
+}
+
+// taskSurfaceLen bounds the scan to the brief itself.
+func taskSurfaceLen(prompt string) int {
+	limit := len(prompt)
+	for _, marker := range surfaceMarkers {
+		if at := strings.Index(prompt, marker); at >= 0 && at < limit {
+			limit = at
+		}
+	}
+	return limit
+}
+
+// isNegated reports whether the brief tells the delegate to leave this path
+// alone: "do NOT touch src/x.c", "skip src/y.c". Scans back to the start of the
+// line, because a negation binds to the sentence it appears in.
+func isNegated(prompt string, pathStart int) bool {
+	lineStart := strings.LastIndexByte(prompt[:pathStart], '\n') + 1
+	prefix := strings.ToLower(prompt[lineStart:pathStart])
+	for _, n := range negations {
+		if strings.Contains(prefix, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// isJSONExampleValue reports whether the token is a quoted path sitting in a
+// JSON value position, i.e. an illustrative schema rather than a target. Prose
+// like `create "src/foo.c"` survives, because the character before the opening
+// quote is then a word or space rather than a structural delimiter.
+func isJSONExampleValue(prompt string, start, end int) bool {
+	if start == 0 || prompt[start-1] != '"' {
+		return false
+	}
+	if end >= len(prompt) || prompt[end] != '"' {
+		return false
+	}
+	b := start - 2
+	for b > 0 && (prompt[b] == ' ' || prompt[b] == '\t' || prompt[b] == '\n' || prompt[b] == '\r') {
+		b--
+	}
+	if b < 0 {
+		return false
+	}
+	return prompt[b] == '[' || prompt[b] == ',' || prompt[b] == ':'
+}
+
+// ExtractNamedPaths returns the repo paths a brief names as targets, in order,
+// without duplicates and capped at max.
+func ExtractNamedPaths(prompt string, max int) []string {
+	if prompt == "" || max <= 0 {
+		return nil
+	}
+	end := taskSurfaceLen(prompt)
+	var out []string
+
+	for i := 0; i < end && len(out) < max; {
+		if !isPathChar(prompt[i]) {
+			i++
+			continue
+		}
+		start := i
+		for i < end && isPathChar(prompt[i]) {
+			i++
+		}
+		tokEnd := i
+		token := prompt[start:tokEnd]
+		// A trailing dot is sentence punctuation, not part of the name.
+		token = strings.TrimRight(token, ".")
+		if token == "" {
+			continue
+		}
+		// `#include <sys/stat.h>` names a system header, not a repo file.
+		if start > 0 && prompt[start-1] == '<' {
+			continue
+		}
+		if isNegated(prompt, start) {
+			continue
+		}
+		if isJSONExampleValue(prompt, start, tokEnd) {
+			continue
+		}
+		// Strip a diff's a/ or b/ prefix.
+		if len(token) > 2 && (token[0] == 'a' || token[0] == 'b') && token[1] == '/' {
+			token = token[2:]
+		}
+		// A path has a directory separator; a bare word is prose.
+		if !strings.Contains(token, "/") {
+			continue
+		}
+		dot := strings.LastIndexByte(token, '.')
+		if dot < 0 {
+			continue
+		}
+		ext := token[dot:]
+		if len(ext) >= pathsExtMax || !driftSrcExts[ext] {
+			continue
+		}
+		if len(token) >= pathMaxLen {
+			continue
+		}
+		duplicate := false
+		for _, seen := range out {
+			if seen == token {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			out = append(out, token)
+		}
+	}
+	return out
+}
+
+func handlePaths(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if len(request) < pathsHeaderLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != pathsRequestMagic ||
+		request[4] != wireVersion {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	max := int(request[5])
+	length := int(binary.LittleEndian.Uint32(request[8:12]))
+	if max == 0 || max > pathsMax || length > pathsPromptMax ||
+		len(request) != pathsHeaderLen+length {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	found := ExtractNamedPaths(string(request[pathsHeaderLen:]), max)
+	response := make([]byte, pathsRespHeaderLen, pathsRespHeaderLen+len(found)*32)
+	binary.LittleEndian.PutUint32(response[0:4], pathsResponseMagic)
+	binary.LittleEndian.PutUint32(response[4:8], uint32(len(found)))
+	// Each path is length-prefixed rather than NUL-terminated: the caller reads
+	// a bounded count and never scans for a terminator it has to trust.
+	for _, p := range found {
+		var n [2]byte
+		binary.LittleEndian.PutUint16(n[:], uint16(len(p)))
+		response = append(response, n[0], n[1])
+		response = append(response, p...)
+	}
+	return response, bus.ModuleStatusOK
+}

--- a/server-go/modules/delegates/paths_test.go
+++ b/server-go/modules/delegates/paths_test.go
@@ -1,0 +1,214 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func pathsRequest(prompt string, max int) []byte {
+	request := make([]byte, pathsHeaderLen+len(prompt))
+	binary.LittleEndian.PutUint32(request[0:4], pathsRequestMagic)
+	request[4] = wireVersion
+	request[5] = byte(max)
+	binary.LittleEndian.PutUint32(request[8:12], uint32(len(prompt)))
+	copy(request[pathsHeaderLen:], prompt)
+	return request
+}
+
+func pathsCall(t *testing.T, prompt string) []string {
+	t.Helper()
+	response, status := Handle(bus.ModuleInvocation{StageID: StagePaths},
+		pathsRequest(prompt, pathsMax))
+	if status != bus.ModuleStatusOK ||
+		binary.LittleEndian.Uint32(response[0:4]) != pathsResponseMagic {
+		t.Fatalf("response = %x, status = %d", response, status)
+	}
+	count := int(binary.LittleEndian.Uint32(response[4:8]))
+	out := make([]string, 0, count)
+	at := pathsRespHeaderLen
+	for i := 0; i < count; i++ {
+		n := int(binary.LittleEndian.Uint16(response[at : at+2]))
+		at += 2
+		out = append(out, string(response[at:at+n]))
+		at += n
+	}
+	return out
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Ported one-for-one from test_delegate_context_shed.c.
+func TestExtractNamedPathsPortedCases(t *testing.T) {
+	cases := []struct {
+		name, prompt string
+		want         []string
+	}{
+		{"prose names no file", "Fix the bug in the authentication module.", nil},
+		{"a single named path", "Edit src/config.c to fix the parsing bug.",
+			[]string{"src/config.c"}},
+		{"a terminal period is punctuation, not part of the name",
+			"Edit only /tmp/aimee-fixture/remaining.c. The tests in " +
+				"/tmp/aimee-fixture/test_remaining.c expect a clamped result.",
+			[]string{"/tmp/aimee-fixture/remaining.c", "/tmp/aimee-fixture/test_remaining.c"}},
+		{"two paths", "Update src/foo.c and src/bar.h to add the new interface.",
+			[]string{"src/foo.c", "src/bar.h"}},
+		{"the same path twice is one target",
+			"Edit src/config.c carefully; do not break src/config.c.",
+			[]string{"src/config.c"}},
+		// A bare filename is prose, not a repo-relative path.
+		{"no separator means not a path", "Fix config.c and util.h.", nil},
+	}
+	for _, c := range cases {
+		if got := pathsCall(t, c.prompt); !sameStrings(got, c.want) {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// A brief that names off-limits files must not have them read as targets, or a
+// successful run reports "named file was not created" for work it was told to
+// leave alone.
+func TestNegatedPathsAreNotTargets(t *testing.T) {
+	prompt := "Implement src/db1/agent_jobs.c with the new schema\n" +
+		"Do NOT touch src/cmd_cron.c — follow-up task\n" +
+		"Skip src/scheduler.c — owned by another delegate\n" +
+		"Don't modify src/headers/legacy.h either\n"
+	if got := pathsCall(t, prompt); !sameStrings(got, []string{"src/db1/agent_jobs.c"}) {
+		t.Errorf("got %v, want only the implement target", got)
+	}
+}
+
+// Negation binds to its own line. A path on a later line is a fresh instruction.
+func TestNegationDoesNotLeakAcrossLines(t *testing.T) {
+	prompt := "Do not touch src/a.c\nEdit src/b.c instead\n"
+	if got := pathsCall(t, prompt); !sameStrings(got, []string{"src/b.c"}) {
+		t.Errorf("got %v, want only src/b.c", got)
+	}
+}
+
+// An illustrative schema shows the delegate the SHAPE of its output; the paths
+// inside it are documentation, not targets.
+func TestJSONExampleValuesAreNotTargets(t *testing.T) {
+	prompt := `Return a packet like {"owned_files":["src/example.c"],"status":"ok"}` +
+		"\nThen edit src/real.c.\n"
+	if got := pathsCall(t, prompt); !sameStrings(got, []string{"src/real.c"}) {
+		t.Errorf("got %v, want only src/real.c", got)
+	}
+}
+
+// Prose that happens to quote a path is still an instruction, so the quote
+// alone must not disqualify it -- only a JSON value position does.
+func TestQuotedPathInProseIsStillATarget(t *testing.T) {
+	if got := pathsCall(t, `Create "src/foo.c" with the new helper.`); !sameStrings(got,
+		[]string{"src/foo.c"}) {
+		t.Errorf("got %v, want src/foo.c", got)
+	}
+}
+
+// A system include names a header the delegate does not own.
+func TestSystemIncludesAreNotTargets(t *testing.T) {
+	if got := pathsCall(t, "Add #include <sys/stat.h> to src/real.c"); !sameStrings(got,
+		[]string{"src/real.c"}) {
+		t.Errorf("got %v, want only src/real.c", got)
+	}
+}
+
+// Everything after an evidence marker is appended context, not the brief: a
+// path mentioned only in a diff was never something the delegate was asked for.
+func TestEvidenceSectionsAreNotScanned(t *testing.T) {
+	prompt := "Edit src/brief.c\n\n---\n## Parent Worktree Diff Evidence\n" +
+		"--- a/src/evidence.c\n+++ b/src/evidence.c\n"
+	if got := pathsCall(t, prompt); !sameStrings(got, []string{"src/brief.c"}) {
+		t.Errorf("got %v, want only src/brief.c", got)
+	}
+}
+
+// A diff's a/ and b/ prefixes are transport, not part of the path.
+func TestDiffPrefixesAreStripped(t *testing.T) {
+	if got := pathsCall(t, "apply to a/src/x.c and b/src/y.c"); !sameStrings(got,
+		[]string{"src/x.c", "src/y.c"}) {
+		t.Errorf("got %v, want the stripped paths", got)
+	}
+}
+
+// An unknown extension is not source the delegate would edit.
+func TestOnlyKnownSourceExtensions(t *testing.T) {
+	if got := pathsCall(t, "see docs/img/diagram.png and src/real.go"); !sameStrings(got,
+		[]string{"src/real.go"}) {
+		t.Errorf("got %v, want only src/real.go", got)
+	}
+}
+
+func TestExtractRespectsTheCap(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 20; i++ {
+		b.WriteString("edit src/f")
+		b.WriteByte(byte('a' + i))
+		b.WriteString(".c\n")
+	}
+	response, status := Handle(bus.ModuleInvocation{StageID: StagePaths},
+		pathsRequest(b.String(), 3))
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %d", status)
+	}
+	if count := binary.LittleEndian.Uint32(response[4:8]); count != 3 {
+		t.Errorf("count = %d, want the requested cap of 3", count)
+	}
+}
+
+func TestPathsRejectsInvalidEnvelope(t *testing.T) {
+	short := pathsRequest("x", pathsMax)[:pathsHeaderLen-1]
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePaths}, short); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("truncated status = %d", status)
+	}
+	lying := pathsRequest("x", pathsMax)
+	binary.LittleEndian.PutUint32(lying[8:12], 64)
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePaths}, lying); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("length-mismatch status = %d", status)
+	}
+	// A cap beyond what the caller's buffer can hold must be refused, not clamped.
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePaths},
+		pathsRequest("x", pathsMax+1)); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("oversized-cap status = %d", status)
+	}
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePaths, DeadlineNS: 1},
+		pathsRequest("x", pathsMax)); status != bus.ModuleStatusCancelled {
+		t.Fatalf("expired status = %d", status)
+	}
+}
+
+// A brief that names an scp target yields the bare host path: the user@host:
+// prefix is not path characters, so the token starts after the colon. Pinned
+// here because the C preflight test depends on exactly this result.
+func TestRemoteScpTargetYieldsTheHostPath(t *testing.T) {
+	prompt := "Update aimee-server on the host. The server config lives at " +
+		"admin@192.168.1.254:/mnt/media/.plugins/aimee-server/server/home/aimee.yaml; " +
+		"read it over SSH and confirm the bearer token."
+	want := []string{"/mnt/media/.plugins/aimee-server/server/home/aimee.yaml"}
+	if got := pathsCall(t, prompt); !sameStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// The other two evidence markers bound the scan exactly as the diff one does.
+func TestPromptFileAndValidationBundleAreNotScanned(t *testing.T) {
+	for _, marker := range []string{"\n\n# Prompt File\n", "\n\n---\n## Validation Evidence Bundle\n"} {
+		prompt := "Edit src/brief.c" + marker + "see src/appended.c\n"
+		if got := pathsCall(t, prompt); !sameStrings(got, []string{"src/brief.c"}) {
+			t.Errorf("marker %q: got %v, want only src/brief.c", marker, got)
+		}
+	}
+}

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -139,6 +139,13 @@ int platform_trace_run_task(agent_config_t *cfg, const char *role, const char *s
  * extension) from a delegate prompt string.  Populates paths[0..max_paths-1]
  * and returns the number of distinct paths found.  Each entry in paths must be
  * at least DELEGATE_DRIFT_PATH_MAX bytes. */
+/* Fills a contiguous paths buffer of `max_paths` rows, each `path_stride` bytes
+ * including the terminator. Returns the count written, or negative when the
+ * module could not answer. */
+typedef int (*delegate_paths_provider_fn)(const char *prompt, unsigned max_paths, char *paths,
+                                          size_t path_stride);
+void delegate_register_paths_provider(delegate_paths_provider_fn provider);
+
 int delegate_extract_named_paths(const char *prompt, char paths[][DELEGATE_DRIFT_PATH_MAX],
                                  int max_paths);
 

--- a/src/modules/delegates/delegate_prompt.c
+++ b/src/modules/delegates/delegate_prompt.c
@@ -297,217 +297,29 @@ void delegate_handoff_add_validation_json(cJSON *obj, const delegate_handoff_val
 
 /* ---- Named-file drift detection ---- */
 
-static const char *const drift_src_exts[] = {
-    ".c",  ".h",    ".cpp", ".cc",   ".cxx",  ".py", ".js",  ".ts", ".go",   ".rs",  ".java", ".rb",
-    ".sh", ".yaml", ".yml", ".json", ".toml", ".md", ".sql", ".mk", ".conf", ".cfg", NULL};
+static delegate_paths_provider_fn g_paths_provider;
 
-static int drift_is_src_extension(const char *ext)
+void delegate_register_paths_provider(delegate_paths_provider_fn provider)
 {
-   for (int i = 0; drift_src_exts[i]; i++)
-      if (strcmp(ext, drift_src_exts[i]) == 0)
-         return 1;
-   return 0;
+   g_paths_provider = provider;
 }
 
-static int drift_path_char(char c)
-{
-   return isalnum((unsigned char)c) || c == '.' || c == '/' || c == '_' || c == '-';
-}
-
-static size_t drift_task_surface_len(const char *prompt)
-{
-   if (!prompt)
-      return 0;
-
-   size_t limit = strlen(prompt);
-   static const char *const markers[] = {
-       "\n\n# Prompt File\n",
-       "\n# Prompt File\n",
-       "\n\n---\n## Parent Worktree Diff Evidence\n",
-       "\n---\n## Parent Worktree Diff Evidence\n",
-       "\n\n---\n## Validation Evidence Bundle\n",
-       "\n---\n## Validation Evidence Bundle\n",
-       NULL,
-   };
-
-   for (int i = 0; markers[i]; i++)
-   {
-      const char *marker = strstr(prompt, markers[i]);
-      if (marker)
-      {
-         size_t pos = (size_t)(marker - prompt);
-         if (pos < limit)
-            limit = pos;
-      }
-   }
-
-   return limit;
-}
-
-/* Briefs commonly say things like "Do NOT touch src/agent_jobs.c" or
- * "skip src/foo.c — it is owned by another delegate". Treating those
- * negated mentions as required outputs leads to spurious "named file was
- * not created" warnings even on a successful run. We scan backwards from
- * the path token to the start of the current line looking for negation
- * cues; if any matches, the path is dropped. The heuristic is
- * intentionally conservative — false positives here just mean the
- * drift check skips a path it should have flagged, which is far less
- * noisy than the current false-negative pattern. */
-static int drift_path_is_negated(const char *prompt, const char *path_start)
-{
-   const char *line_start = path_start;
-   while (line_start > prompt && line_start[-1] != '\n')
-      line_start--;
-
-   size_t span = (size_t)(path_start - line_start);
-   if (span == 0)
-      return 0;
-
-   char buf[256];
-   if (span >= sizeof(buf))
-      span = sizeof(buf) - 1;
-   memcpy(buf, path_start - span, span);
-   buf[span] = '\0';
-   for (size_t i = 0; i < span; i++)
-      buf[i] = (char)tolower((unsigned char)buf[i]);
-
-   static const char *negations[] = {
-       "do not ",     "don't ",     "does not ",   "doesn't ",   "must not ",    "mustn't ",
-       "cannot ",     "can't ",     "should not ", "shouldn't ", "will not ",    "won't ",
-       "skip ",       "off-limits", "off limits",  "no touch",   "do not touch", "not touch",
-       "leave alone", "ignore ",    NULL};
-   for (int i = 0; negations[i]; i++)
-      if (strstr(buf, negations[i]))
-         return 1;
-
-   return 0;
-}
-
-/* Briefs frequently embed an illustrative JSON schema or example
- * (e.g. `"owned_files":["src/x.c"]`) to show a delegate the *shape* of its
- * output. Those quoted paths are documentation, not real output targets, and
- * scraping them produced spurious "named file was not created" failures. A path
- * is treated as such an example value when it is a double-quoted token whose
- * enclosing context is a JSON value position — the opening quote follows (past
- * whitespace) a '[', ',', or ':'. Prose instructions like `create "src/foo.c"`
- * are preserved because the char before the opening quote is a word/space, not a
- * JSON structural delimiter. Conservatively dropping here matches the rest of
- * this check: a missed flag is far quieter than a false failure. */
-static int drift_path_is_json_example_value(const char *prompt, const char *tok_start,
-                                            const char *tok_end)
-{
-   if (tok_start <= prompt || tok_start[-1] != '"')
-      return 0;
-   if (*tok_end != '"')
-      return 0;
-   const char *b = tok_start - 2; /* char before the opening quote */
-   while (b > prompt && (*b == ' ' || *b == '\t' || *b == '\n' || *b == '\r'))
-      b--;
-   if (b < prompt)
-      return 0;
-   return (*b == '[' || *b == ',' || *b == ':');
-}
-
+/* Which repo files a brief names as targets is the delegates module's rule, and
+ * it lives only there. The scan it replaced was long -- an extension table, a
+ * negation table, a JSON-example test and an evidence-section bound -- and a
+ * second copy of that would drift silently.
+ *
+ * Fails closed as EMPTY: with no answer, nothing is named, so the drift check
+ * raises no warning. That is the quiet direction. Guessing a path instead would
+ * tell an operator a successful run failed, which teaches them to ignore the
+ * check entirely. */
 int delegate_extract_named_paths(const char *prompt, char paths[][DELEGATE_DRIFT_PATH_MAX],
                                  int max_paths)
 {
-   if (!prompt || !paths || max_paths <= 0)
+   if (!prompt || !paths || max_paths <= 0 || !g_paths_provider)
       return 0;
-
-   int count = 0;
-   const char *p = prompt;
-   const char *end = prompt + drift_task_surface_len(prompt);
-
-   while (p < end && *p && count < max_paths)
-   {
-      if (!drift_path_char(*p))
-      {
-         p++;
-         continue;
-      }
-
-      const char *start = p;
-      while (p < end && drift_path_char(*p))
-         p++;
-      size_t len = (size_t)(p - start);
-      while (len > 0 && start[len - 1] == '.')
-         len--;
-      if (len == 0)
-         continue;
-      /* Skip angle-bracket system includes: `#include <sys/stat.h>` — the '<'
-       * immediately precedes the token, making it a system path, not a repo path. */
-      if (start > prompt && start[-1] == '<')
-         continue;
-
-      /* Skip paths the brief explicitly negates ("Do NOT touch X", "skip Y"). */
-      if (drift_path_is_negated(prompt, start))
-         continue;
-
-      /* Skip paths that are JSON string-values inside an illustrative example
-       * (e.g. a schema shown to the delegate), not real output targets. */
-      if (drift_path_is_json_example_value(prompt, start, p))
-         continue;
-
-      const char *path_start = start;
-      size_t path_len = len;
-      if (path_len > 2 && (path_start[0] == 'a' || path_start[0] == 'b') && path_start[1] == '/')
-      {
-         path_start += 2;
-         path_len -= 2;
-      }
-
-      /* Require at least one '/' to look like a path */
-      int has_slash = 0;
-      for (size_t i = 0; i < path_len; i++)
-      {
-         if (path_start[i] == '/')
-         {
-            has_slash = 1;
-            break;
-         }
-      }
-      if (!has_slash)
-         continue;
-
-      /* Require a known source extension */
-      const char *last_dot = NULL;
-      for (size_t i = 0; i < path_len; i++)
-         if (path_start[i] == '.')
-            last_dot = path_start + i;
-      if (!last_dot)
-         continue;
-
-      size_t ext_len = (size_t)((path_start + path_len) - last_dot);
-      if (ext_len == 0 || ext_len >= 16)
-         continue;
-      char ext[16];
-      memcpy(ext, last_dot, ext_len);
-      ext[ext_len] = '\0';
-      if (!drift_is_src_extension(ext))
-         continue;
-
-      /* Skip duplicates */
-      int dup = 0;
-      for (int i = 0; i < count; i++)
-      {
-         if (strlen(paths[i]) == path_len && memcmp(paths[i], path_start, path_len) == 0)
-         {
-            dup = 1;
-            break;
-         }
-      }
-      if (dup)
-         continue;
-
-      if (path_len < DELEGATE_DRIFT_PATH_MAX)
-      {
-         memcpy(paths[count], path_start, path_len);
-         paths[count][path_len] = '\0';
-         count++;
-      }
-   }
-
-   return count;
+   int n = g_paths_provider(prompt, (unsigned)max_paths, &paths[0][0], DELEGATE_DRIFT_PATH_MAX);
+   return n > 0 ? n : 0;
 }
 
 /* Returns 1 if prompt contains an explicit intent to create a new file. */

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -152,4 +152,61 @@ static inline int aimee_delegates_chain_response_decode(const uint8_t *in, size_
    return 0;
 }
 
+/* Named-path extraction: which repo files a brief names as targets. The rule
+ * lives only in the Go module -- it is a long scan and a second copy would be
+ * drift waiting to happen -- so there is no C mirror and no parity fixture. */
+#define AIMEE_DELEGATES_EVENT_PATHS           6660u
+#define AIMEE_DELEGATES_STAGE_PATHS           4u
+#define AIMEE_DELEGATES_PATHS_REQUEST_MAGIC   0x54415044u /* "DPAT" */
+#define AIMEE_DELEGATES_PATHS_RESPONSE_MAGIC  0x53415044u /* "DPAS" */
+#define AIMEE_DELEGATES_PATHS_HEADER_LEN      12u
+#define AIMEE_DELEGATES_PATHS_RESP_HEADER_LEN 8u
+#define AIMEE_DELEGATES_PATHS_PROMPT_MAX      (1u << 20)
+
+static inline size_t aimee_delegates_paths_request_encode(const char *prompt, size_t prompt_len,
+                                                          unsigned max_paths, uint8_t *out,
+                                                          size_t cap)
+{
+   if (!out || max_paths == 0 || max_paths > 255 || prompt_len > AIMEE_DELEGATES_PATHS_PROMPT_MAX ||
+       cap < AIMEE_DELEGATES_PATHS_HEADER_LEN + prompt_len)
+      return 0;
+   memset(out, 0, AIMEE_DELEGATES_PATHS_HEADER_LEN);
+   aimee_delegates_put_u32(out, AIMEE_DELEGATES_PATHS_REQUEST_MAGIC);
+   out[4] = (uint8_t)AIMEE_DELEGATES_WIRE_VERSION;
+   out[5] = (uint8_t)max_paths;
+   aimee_delegates_put_u32(out + 8, (uint32_t)prompt_len);
+   if (prompt_len)
+      memcpy(out + AIMEE_DELEGATES_PATHS_HEADER_LEN, prompt, prompt_len);
+   return AIMEE_DELEGATES_PATHS_HEADER_LEN + prompt_len;
+}
+
+/* Copy the returned paths into `paths`, each at most path_stride bytes
+ * including the terminator. Returns the count written, or -1 on a malformed
+ * response. Each path is length-prefixed on the wire, so nothing here scans for
+ * a terminator it would have to trust. */
+static inline int aimee_delegates_paths_response_decode(const uint8_t *in, size_t len, char *paths,
+                                                        size_t path_stride, unsigned max_paths)
+{
+   if (!in || len < AIMEE_DELEGATES_PATHS_RESP_HEADER_LEN || !paths || path_stride == 0 ||
+       aimee_delegates_get_u32(in) != AIMEE_DELEGATES_PATHS_RESPONSE_MAGIC)
+      return -1;
+   uint32_t count = aimee_delegates_get_u32(in + 4);
+   if (count > max_paths)
+      return -1;
+   size_t at = AIMEE_DELEGATES_PATHS_RESP_HEADER_LEN;
+   for (uint32_t i = 0; i < count; ++i)
+   {
+      if (at + 2u > len)
+         return -1;
+      size_t n = (size_t)in[at] | ((size_t)in[at + 1] << 8);
+      at += 2u;
+      if (at + n > len || n + 1u > path_stride)
+         return -1;
+      memcpy(paths + (size_t)i * path_stride, in + at, n);
+      paths[(size_t)i * path_stride + n] = '\0';
+      at += n;
+   }
+   return (int)count;
+}
+
 #endif

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -73,13 +73,15 @@
     "server-go/modules/delegates/plane/client.go",
     "server-go/modules/delegates/plane/helpers.go",
     "server-go/modules/delegates/capabilities.go",
-    "server-go/modules/delegates/chain.go"
+    "server-go/modules/delegates/chain.go",
+    "server-go/modules/delegates/paths.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
     "server-go/modules/delegates/plane/client_test.go",
     "server-go/modules/delegates/capabilities_test.go",
-    "server-go/modules/delegates/chain_test.go"
+    "server-go/modules/delegates/chain_test.go",
+    "server-go/modules/delegates/paths_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -141,6 +141,11 @@
           "id": 3,
           "name": "delegate-chain-depth",
           "event_kind": 6659
+        },
+        {
+          "id": 4,
+          "name": "delegate-named-paths",
+          "event_kind": 6660
         }
       ]
     },

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -316,6 +316,40 @@ static int delegate_chain(unsigned op, int has_depth, int has_parent, int parent
               : -1;
 }
 
+static int delegate_paths(const char *prompt, unsigned max_paths, char *paths, size_t path_stride)
+{
+   size_t prompt_len = prompt ? strlen(prompt) : 0;
+   if (prompt_len > AIMEE_DELEGATES_PATHS_PROMPT_MAX)
+      return -1;
+   size_t request_cap = AIMEE_DELEGATES_PATHS_HEADER_LEN + prompt_len;
+   uint8_t *request = malloc(request_cap);
+   if (!request)
+      return -1;
+   size_t request_len =
+       aimee_delegates_paths_request_encode(prompt, prompt_len, max_paths, request, request_cap);
+
+   /* Bounded by what the module can return: a count it caps, each path bounded
+    * by the caller's stride, plus a two-byte length prefix each. */
+   uint32_t response_cap =
+       (uint32_t)(AIMEE_DELEGATES_PATHS_RESP_HEADER_LEN + max_paths * (path_stride + 2));
+   uint8_t *response = malloc(response_cap);
+   if (!response)
+   {
+      free(request);
+      return -1;
+   }
+   uint32_t response_len = 0;
+   int rc = request_len > 0 &&
+                    call_module(AIMEE_DELEGATES_EVENT_PATHS, AIMEE_DELEGATES_STAGE_PATHS, request,
+                                (uint32_t)request_len, response, response_cap, &response_len) == 0
+                ? aimee_delegates_paths_response_decode(response, response_len, paths, path_stride,
+                                                        max_paths)
+                : -1;
+   free(request);
+   free(response);
+   return rc;
+}
+
 static int tool_classify(const char *name, int *classification)
 {
    uint8_t request[AIMEE_TOOLS_REQUEST_LEN], response[AIMEE_TOOLS_RESPONSE_LEN];
@@ -525,6 +559,7 @@ void server_module_stage_adapters_configure(void)
    delegate_role_register_canonicalizer(delegate_canonicalize);
    delegate_routing_register_capability_provider(delegate_infer_caps);
    delegate_register_chain_provider(delegate_chain);
+   delegate_register_paths_provider(delegate_paths);
    agent_tools_register_classifier(tool_classify);
    ws_scope_register_ref_validator(workspace_validate);
    /* Same decision, same owner: webuser's runtime dir names a single path

--- a/src/tests/test_delegate_context_shed.c
+++ b/src/tests/test_delegate_context_shed.c
@@ -36,168 +36,6 @@ static void make_file(const char *relpath)
    fclose(f);
 }
 
-/* ---- delegate_extract_named_paths ---- */
-
-static void test_extract_no_paths(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n = delegate_extract_named_paths("Fix the bug in the authentication module.", paths,
-                                        DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 0);
-   printf("  extract_no_paths: ok\n");
-}
-
-static void test_extract_single_path(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n = delegate_extract_named_paths("Edit src/config.c to fix the parsing bug.", paths,
-                                        DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 1);
-   assert(strcmp(paths[0], "src/config.c") == 0);
-   printf("  extract_single_path: ok\n");
-}
-
-static void test_extract_trims_terminal_period(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n =
-       delegate_extract_named_paths("Edit only /tmp/aimee-fixture/remaining.c. The tests in "
-                                    "/tmp/aimee-fixture/test_remaining.c expect a clamped result.",
-                                    paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 2);
-   assert(strcmp(paths[0], "/tmp/aimee-fixture/remaining.c") == 0);
-   assert(strcmp(paths[1], "/tmp/aimee-fixture/test_remaining.c") == 0);
-   printf("  extract_trims_terminal_period: ok\n");
-}
-
-static void test_extract_multiple_paths(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n = delegate_extract_named_paths("Update src/foo.c and src/bar.h to add the new interface.",
-                                        paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 2);
-   printf("  extract_multiple_paths: ok\n");
-}
-
-static void test_extract_deduplication(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n = delegate_extract_named_paths("Edit src/config.c carefully; do not break src/config.c.",
-                                        paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 1);
-   assert(strcmp(paths[0], "src/config.c") == 0);
-   printf("  extract_deduplication: ok\n");
-}
-
-static void test_extract_no_slash_skipped(void)
-{
-   /* bare filenames without '/' are not repo-relative paths */
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n =
-       delegate_extract_named_paths("Fix config.c and util.h.", paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 0);
-   printf("  extract_no_slash_skipped: ok\n");
-}
-
-static void test_extract_skips_negated_references(void)
-{
-   /* "Do NOT touch / Don't / skip" are common in briefs that name
-    * off-limits files. Treating those as required outputs leads to
-    * spurious "named file was not created" warnings. */
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   const char *prompt = "Implement src/db1/agent_jobs.c with the new schema\n"
-                        "Do NOT touch src/cmd_cron.c — follow-up task\n"
-                        "Skip src/scheduler.c — owned by another delegate\n"
-                        "Don't modify src/headers/legacy.h either\n";
-   int n = delegate_extract_named_paths(prompt, paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 1);
-   assert(strcmp(paths[0], "src/db1/agent_jobs.c") == 0);
-   printf("  extract_skips_negated_references: ok\n");
-}
-
-static void test_extract_skips_json_example_values(void)
-{
-   /* Briefs often embed an illustrative JSON schema to show the delegate the
-    * shape of its output. Quoted paths in JSON value position (after [ , :) are
-    * documentation, not output targets — scraping them caused spurious
-    * "named file 'src/x.c' was not created" failures. Prose instructions that
-    * happen to quote a real path ("create \"src/real.c\"") must still count. */
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   const char *prompt = "Implement the decomposer. The schema is:\n"
-                        "{\"units\":[{\"local_id\":\"t1\",\"owned_files\":[\"src/x.c\"],"
-                        "\"read_context\":[\"src/y.h\"]}]}\n"
-                        "Now create \"src/roadmap_decompose.c\" with that logic.\n";
-   int n = delegate_extract_named_paths(prompt, paths, DELEGATE_DRIFT_MAX_PATHS);
-   /* src/x.c and src/y.h are JSON example values → dropped; the prose-quoted
-    * src/roadmap_decompose.c (quote preceded by the word "create ") survives. */
-   assert(n == 1);
-   assert(strcmp(paths[0], "src/roadmap_decompose.c") == 0);
-   printf("  extract_skips_json_example_values: ok\n");
-}
-
-static void test_extract_unknown_extension_skipped(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n = delegate_extract_named_paths("Edit src/binary.exe to fix it.", paths,
-                                        DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 0);
-   printf("  extract_unknown_extension_skipped: ok\n");
-}
-
-static void test_extract_various_extensions(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n = delegate_extract_named_paths("Update src/module.py and config/settings.yaml", paths,
-                                        DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 2);
-   printf("  extract_various_extensions: ok\n");
-}
-
-static void test_extract_ignores_prompt_file_attachment(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   const char *prompt = "Review this patch for regressions.\n\n"
-                        "# Prompt File\n"
-                        "diff --git a/src/foo.c b/src/foo.c\n"
-                        "--- a/src/foo.c\n"
-                        "+++ b/src/foo.c\n"
-                        "+   const char *paths[] = {\"isolated/context.c\"};\n";
-   int n = delegate_extract_named_paths(prompt, paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 0);
-   printf("  extract_ignores_prompt_file_attachment: ok\n");
-}
-
-static void test_extract_ignores_validation_evidence_bundle(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   const char *prompt =
-       "Slot probe A. Reply exactly: minimax-slot-A-ok\n\n"
-       "---\n"
-       "## Parent Worktree Diff Evidence\n"
-       "Use this bundle as the source of truth.\n\n"
-       "---\n"
-       "## Validation Evidence Bundle\n"
-       "repo_evidence:\n"
-       "- build_files_absent: ./tests/test_install_noninteractive.sh, CMakeLists.txt\n"
-       "branch_changed_files:\n"
-       "src/delegate_prompt.c\n";
-   int n = delegate_extract_named_paths(prompt, paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 0);
-   printf("  extract_ignores_validation_evidence_bundle: ok\n");
-}
-
-static void test_extract_normalizes_git_diff_prefixes(void)
-{
-   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   const char *prompt = "Review findings for diff --git a/src/foo.c b/src/foo.c and "
-                        "the hunk header +++ b/src/bar.h.";
-   int n = delegate_extract_named_paths(prompt, paths, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 2);
-   assert(strcmp(paths[0], "src/foo.c") == 0);
-   assert(strcmp(paths[1], "src/bar.h") == 0);
-   printf("  extract_normalizes_git_diff_prefixes: ok\n");
-}
-
 /* ---- delegate_check_named_file_drift (pre-flight) ---- */
 
 static void test_preflight_nonexistent_no_create_intent(void)
@@ -284,10 +122,14 @@ static void test_preflight_remote_scp_path_skipped(void)
        "admin@192.168.1.254:/mnt/media/.plugins/aimee-server/server/home/aimee.yaml; "
        "read it over SSH and confirm the bearer token.";
 
+   /* The subject here is the PREFLIGHT, not the extraction: a named path that
+    * does not resolve under the worktree must not hard-fail the delegate. What
+    * the tokenizer yields for this brief is pinned in the delegates module's own
+    * tests (server-go/modules/delegates/paths_test.go), so it is stated as a
+    * literal rather than recomputed through a stage this binary cannot reach. */
    char extracted[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
-   int n = delegate_extract_named_paths(prompt, extracted, DELEGATE_DRIFT_MAX_PATHS);
-   assert(n == 1);
-   assert(strcmp(extracted[0], "/mnt/media/.plugins/aimee-server/server/home/aimee.yaml") == 0);
+   snprintf(extracted[0], DELEGATE_DRIFT_PATH_MAX, "%s",
+            "/mnt/media/.plugins/aimee-server/server/home/aimee.yaml");
 
    char errbuf[512] = {0};
    const char *paths[] = {extracted[0]};
@@ -668,20 +510,6 @@ int kb_client_index_find(const char *identifier, term_hit_t *out, int max)
 int main(void)
 {
    printf("test_delegate_context_shed:\n");
-
-   test_extract_no_paths();
-   test_extract_single_path();
-   test_extract_trims_terminal_period();
-   test_extract_multiple_paths();
-   test_extract_deduplication();
-   test_extract_no_slash_skipped();
-   test_extract_skips_negated_references();
-   test_extract_skips_json_example_values();
-   test_extract_unknown_extension_skipped();
-   test_extract_various_extensions();
-   test_extract_ignores_prompt_file_attachment();
-   test_extract_ignores_validation_evidence_bundle();
-   test_extract_normalizes_git_diff_prefixes();
 
    test_preflight_nonexistent_no_create_intent();
    test_preflight_nonexistent_with_create_intent();

--- a/src/tests/test_delegate_dispatch_reliability.c
+++ b/src/tests/test_delegate_dispatch_reliability.c
@@ -1,6 +1,5 @@
 /* test_delegate_dispatch_reliability.c: unit tests for delegate dispatch
  * reliability improvements (Phase 2):
- *   1. delegate_extract_named_paths — multi-file scope detection
  *   2. delegate_inject_code_context — context injection via code index */
 #include <assert.h>
 #include <stdio.h>
@@ -82,6 +81,22 @@ static void set_blast_radius(const char *const *deps, int ndeps, const char *con
 /* Drive the real config_load via a temp AIMEE_HOME/aimee.yaml (config.o is linked,
  * so config_load can't be stubbed). AIMEE_NO_CACHE defeats the config cache. */
 static char g_graph_home[256];
+/* The graph-context tests below feed a prompt that names a file and assert on
+ * the block built AROUND it. Finding that file is the delegates module's rule
+ * now (server-go/modules/delegates/paths.go) and this binary hosts no bus, so
+ * the referenced path is stated here. What the tokenizer yields for prompts like
+ * these is pinned in that module's own tests; the subject here is the block. */
+static int test_paths_provider(const char *prompt, unsigned max_paths, char *paths,
+                               size_t path_stride)
+{
+   if (!prompt || !paths || max_paths == 0)
+      return -1;
+   if (!strstr(prompt, "src/foo.c"))
+      return 0;
+   snprintf(paths, path_stride, "%s", "src/foo.c");
+   return 1;
+}
+
 static void graph_flag_setup(void)
 {
    snprintf(g_graph_home, sizeof(g_graph_home), "/tmp/aimee-gctx-%d", (int)getpid());
@@ -99,54 +114,6 @@ static void graph_flag_write(int on)
       fprintf(f, "delegate_graph_context_enabled: %s\n", on ? "true" : "false");
       fclose(f);
    }
-}
-
-/* ── 1. delegate_extract_named_paths tests ──────────────────────────────── */
-
-static void test_extract_no_paths(void)
-{
-   char paths[16][256];
-   int n = delegate_extract_named_paths("just some text with no file references", paths, 16);
-   assert(n == 0);
-   printf("  PASS: test_extract_no_paths\n");
-}
-
-static void test_extract_single_path(void)
-{
-   char paths[16][256];
-   int n = delegate_extract_named_paths("Edit src/foo.c to add error handling.", paths, 16);
-   assert(n == 1);
-   assert(strstr(paths[0], "src/foo.c") != NULL);
-   printf("  PASS: test_extract_single_path\n");
-}
-
-static void test_extract_multi_path(void)
-{
-   char paths[16][256];
-   int n = delegate_extract_named_paths(
-       "Update src/server/server.c and src/headers/server.h with the new field.", paths, 16);
-   assert(n == 2);
-   printf("  PASS: test_extract_multi_path (count=%d)\n", n);
-}
-
-static void test_extract_deduplicates(void)
-{
-   char paths[16][256];
-   int n = delegate_extract_named_paths("Edit src/foo.c — src/foo.c has the function you need.",
-                                        paths, 16);
-   assert(n == 1);
-   printf("  PASS: test_extract_deduplicates\n");
-}
-
-static void test_extract_skips_system_includes(void)
-{
-   char paths[16][256];
-   /* <sys/stat.h> should be skipped (angle-bracket system include) */
-   int n =
-       delegate_extract_named_paths("#include <sys/stat.h> — edit src/real.c instead.", paths, 16);
-   assert(n == 1);
-   assert(strstr(paths[0], "src/real.c") != NULL);
-   printf("  PASS: test_extract_skips_system_includes\n");
 }
 
 /* ── 2. delegate_inject_code_context tests ──────────────────────────────── */
@@ -277,13 +244,8 @@ static void test_worktree_has_changes_nonexistent_path(void)
 
 int main(void)
 {
+   delegate_register_paths_provider(test_paths_provider);
    printf("delegate_dispatch_reliability:\n");
-
-   test_extract_no_paths();
-   test_extract_single_path();
-   test_extract_multi_path();
-   test_extract_deduplicates();
-   test_extract_skips_system_includes();
 
    test_inject_returns_null_when_no_hits();
    test_inject_returns_context_block_with_hits();

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -375,7 +375,7 @@
         },
         {
           "path": "src/headers/cmd_agent_delegate_impl.h",
-          "sha256": "9242342233cff05f138192e16b86ea4279ce6dd3e6b5b7657854bc20f988d9da"
+          "sha256": "092401b1242c4ef798632f98c5d53c94fee04214f3e7a4cb8a32e0856cd3a939"
         },
         {
           "path": "src/headers/cmd_agent_delegate_internal.h",
@@ -1463,7 +1463,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "e429b13ecfc1f9c96ac753067f93d852791dc13ea4f48924f6380f120a9a1b1a"
+          "sha256": "05142c381f0a7881c3f5e072b7c4a850e3bc1b9cdc4bc48ab5001d263ce1dd6f"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "3e46ac085fbe3b2a684cf9a994052ea690f83d775135a363fe6e62138b42c8fa",
+      "sha256": "4b89cebb396dc22c054df74968bd9762ef86f7cca8814b5873746fc94216f29f",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
Third slice of the delegate-execution port. Named-path extraction becomes the module's rule.

## What moved

`delegate_extract_named_paths` decided which repo files a brief names as targets — ~180 lines of scanning in C: an extension table, a negation table, a JSON-example test, an evidence-section bound and a diff-prefix strip. That is a decision, so it is now `server-go/modules/delegates/paths.go` on a new stage (event 6660, stage 4).

## No C mirror this time

The previous two delegate slices kept one, because their rules were small enough to state twice and pin with a parity test. This one is five interacting heuristics. A second copy would drift, and a parity test would only tell us afterwards. So the rule exists once, its tests move with it, and the C side is the provider call.

## Fails closed as empty

With no answer nothing is named, so the drift check stays quiet. That is the right direction here: inventing a path would tell an operator a successful run failed, which is how a check earns being ignored.

## Two C tests now state their input

In both, extraction was setup rather than subject:

- the **preflight** case asserts that a named path which does not resolve must not hard-fail the delegate;
- the **graph-context** cases assert the block built *around* a referenced file.

The second is worth a reviewer's attention because it is what the suite caught: `delegate_inject_graph_context` extracts internally, so with no provider registered it found nothing, built no block, and returned NULL. Four tests failed on `ctx != NULL`. They now use a test-local provider that names the file the prompt references.

What the tokenizer actually yields for those prompts is pinned in the module's own tests — including the scp brief whose `user@host:` prefix leaves the bare host path, the exact string the preflight case depends on.

## Tests

Ported one-for-one from `test_delegate_context_shed.c` and `test_delegate_dispatch_reliability.c`, plus the cases the old comments described but nothing asserted:

- negation binds to its own line rather than leaking to the next;
- a quoted path in prose is still a target, while the same token in a JSON value position is not;
- all three evidence markers bound the scan, not just the diff one.

## Declared, not merely present

Contract (`6660`, stage 4), descriptor `go_sources`/`go_tests`, dispatch table, registry-vs-contracts test, with the `serve` grant regenerated from the contract.

## Verification

Full `make -C src` rc=0, C `unit-tests` rc=0 (run with `TEST_RUN_JOBS=1`, see below), `make lint` (48 checks), `go vet`, full `go test ./...`, and every step of the module-inventory job plus `check-docs`, `check-module-boundary` and the repo lock.

Worth recording for whoever hits it next: under the default parallel runner this failure printed `Unit test failures:` followed by an empty list — the per-test marker file is not written when `xargs -P` shuts down, and interleaved output buried the assertion in a 6.6 MB log. `TEST_RUN_JOBS=1` named the failing target in one run.
