### PR TITLE
refactor(git): run the PR merge in the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -226,7 +226,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "084d0d00fbcb9b5eece3b06399854ea9b3c00586afe56c0ad55fc53cfd9e5fed",
+      "source_sha256": "86016ebb8287ca49a606ec0011366f5648849c2a73e3563757c57633eb2f7549",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -1438,62 +1438,67 @@ int git_pr_merge_via_api_slug_ex(const char *principal, const char *slug, int nu
    if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
 
-   cJSON *j = cJSON_CreateObject();
-   cJSON_AddStringToObject(j, "merge_method", method);
-   /* Only a squash synthesizes a body from the child commits, which is where the
-    * attribution trailers protected branches reject come back in -- see
-    * GIT_PR_SQUASH_MERGE_JSON. A merge or rebase has nothing to synthesize. */
-   if (strcmp(method, "squash") == 0)
-      cJSON_AddStringToObject(j, "commit_message", "");
-   /* Drift safety: GitHub refuses the merge if the head has moved. */
-   if (expected_head_sha && expected_head_sha[0])
-      cJSON_AddStringToObject(j, "sha", expected_head_sha);
-   char *payload = cJSON_PrintUnformatted(j);
-   cJSON_Delete(j);
-   if (!payload)
+   /* The merge itself, its payload shaping (a squash's synthesized body, the
+    * drift-safety sha) and the 405/409 classification all live in the module
+    * now. What stays here is the translation into this function's long-standing
+    * return codes, which callers switch on. */
+   cJSON *extra = cJSON_CreateObject();
+   if (!extra)
    {
       gh_ctx_done(&cx);
       snprintf(err, errlen, "internal error");
       return -1;
    }
+   cJSON_AddNumberToObject(extra, "number", number);
+   cJSON_AddStringToObject(extra, "merge_method", method);
+   if (expected_head_sha && expected_head_sha[0])
+      cJSON_AddStringToObject(extra, "expected_head_sha", expected_head_sha);
 
-   char path[64];
-   snprintf(path, sizeof(path), "pulls/%d/merge", number);
-   char *resp = NULL;
-   int st = gh_put(&cx, path, payload, &resp);
-   free(payload);
+   cJSON *reply = forge_stage(&cx, "pr_merge", extra);
    gh_ctx_done(&cx);
-
-   /* The 200 body carries the merge commit, so the caller needs no second lookup. */
-   if (st >= 200 && st < 300 && resp && out_sha && out_sha_cap)
+   if (!reply)
    {
-      cJSON *jr = cJSON_Parse(resp);
-      const cJSON *sha = jr ? cJSON_GetObjectItem(jr, "sha") : NULL;
-      if (cJSON_IsString(sha) && sha->valuestring)
-         snprintf(out_sha, out_sha_cap, "%s", sha->valuestring);
-      cJSON_Delete(jr);
+      /* Unreachable module is NOT a refused merge: say so, rather than letting a
+       * caller read it as "the forge said no" and stop retrying. */
+      snprintf(err, errlen, "pr merge: the git module could not be reached");
+      return -1;
    }
+
+   const cJSON *merged = cJSON_GetObjectItemCaseSensitive(reply, "merged");
+   const cJSON *already = cJSON_GetObjectItemCaseSensitive(reply, "already_merged");
+   const cJSON *conflict = cJSON_GetObjectItemCaseSensitive(reply, "conflict");
+   const cJSON *retryable = cJSON_GetObjectItemCaseSensitive(reply, "retryable");
+   const cJSON *message = cJSON_GetObjectItemCaseSensitive(reply, "error");
+   const cJSON *sha = cJSON_GetObjectItemCaseSensitive(reply, "merge_sha");
+
    int res;
-   if (st >= 200 && st < 300)
-      res = 0; /* merged */
-   else if (st == 405 && resp && strstr(resp, "already merged"))
-      res = 1;
-   else if (st == 405 || st == 409)
+   if (cJSON_IsTrue(merged))
    {
-      gh_err(resp, st, "pr merge", err, errlen);
-      /* Separate the terminal case from the retryable one. A content conflict is
-       * a property of the two trees: retrying reproduces it exactly. A moved
-       * head/base is a lost race that a retry wins. Both arrive as 405/409, so
-       * the body is the only discriminator GitHub gives us. Match on the message
-       * text produced by gh_err rather than the raw body so a conflict reported
-       * with different JSON framing still classifies. */
-      res = git_pr_merge_err_is_conflict(err) ? 3 : 2;
+      /* The 2xx body carried the merge commit, so no second lookup. */
+      if (out_sha && out_sha_cap && cJSON_IsString(sha) && sha->valuestring)
+         snprintf(out_sha, out_sha_cap, "%s", sha->valuestring);
+      res = 0;
+   }
+   else if (cJSON_IsTrue(already))
+   {
+      res = 1;
    }
    else
    {
-      gh_err(resp, st, "pr merge", err, errlen);
-      res = -1;
+      if (cJSON_IsString(message) && message->valuestring)
+         snprintf(err, errlen, "%s", message->valuestring);
+      else
+         snprintf(err, errlen, "pr merge: refused");
+      /* Terminal vs retryable, decided in the module: a content conflict is a
+       * property of the two trees and a retry reproduces it exactly, while a
+       * moved head/base is a lost race a retry wins. */
+      if (cJSON_IsTrue(conflict))
+         res = 3;
+      else if (cJSON_IsTrue(retryable))
+         res = 2;
+      else
+         res = -1;
    }
-   free(resp);
+   cJSON_Delete(reply);
    return res;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -458,6 +458,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-tpm2-stub \
                $(TESTPREFIX)/unit-test-git-forge-vault \
                $(TESTPREFIX)/unit-test-git-host-resolve \
+               $(TESTPREFIX)/unit-test-git-pr-stage \
                $(TESTPREFIX)/unit-test-git-cred-inject \
                $(TESTPREFIX)/unit-test-git-ssh-agent \
                $(TESTPREFIX)/unit-test-webchat-git-leak \
@@ -2117,6 +2118,18 @@ $(TESTPREFIX)/unit-test-wfe-router: $(OBJDIR)/tests/test_wfe_router.o \
 $(OBJDIR)/tests/test_wfe_autonomous_route.o: C_FLAGS += -Icore/event_bus/include
 $(TESTPREFIX)/unit-test-wfe-autonomous-route: $(OBJDIR)/tests/test_wfe_autonomous_route.o \
                                     $(OBJDIR)/modules/workflows/wfe_autonomous_route.o \
+                                    $(OBJDIR)/module_json_call.o \
+                                    $(OBJDIR)/tests/support/module_bus_stub.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# The C side of the git-forge-request seam: the stage reply is canned through
+# module_bus_stub, so this pins the translation into the caller's return codes
+# without a forge, a credential or a repository. The HTTP entry points are
+# stubbed inside the test TU (and abort), which is why no agent_exec object is
+# linked here.
+$(TESTPREFIX)/unit-test-git-pr-stage: $(OBJDIR)/tests/test_git_pr_stage.o \
+                                    $(OBJDIR)/modules/git/git_pr_api.o \
+                                    $(OBJDIR)/modules/git/git_pr_ci_grade.o \
                                     $(OBJDIR)/module_json_call.o \
                                     $(OBJDIR)/tests/support/module_bus_stub.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_git_pr_stage.c
+++ b/src/tests/test_git_pr_stage.c
@@ -1,0 +1,143 @@
+/* test_git_pr_stage.c — the C side of the git-forge-request seam.
+ *
+ * The forge call itself is the module's job and is tested there
+ * (server-go/modules/git/forge_request_test.go). What is NOT covered there, and
+ * is what this file pins, is the TRANSLATION back into the return codes callers
+ * switch on: 0 merged, 1 already merged, 2 retryable, 3 terminal conflict, -1
+ * error. Getting that mapping wrong is invisible to both sides — the module
+ * answers correctly and the caller still does the wrong thing.
+ *
+ * The stage reply is canned through module_bus_stub, so these assertions are
+ * about the mapping and nothing else. The HTTP entry points are stubbed to
+ * ABORT: a migrated op that quietly fell back to talking to GitHub itself would
+ * otherwise pass this suite while defeating the point of the migration.
+ */
+#include "modules/git/git_pr_api.h"
+#include "support/module_bus_stub.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* --- stubs -------------------------------------------------------------- */
+
+/* A credential is always available: this suite is not about resolution. */
+int git_cred_inject_resolve_token(const char *principal, const char *remote_url,
+                                  const char *repo_dir, const char *preferred_token, char *out,
+                                  size_t cap)
+{
+   (void)principal;
+   (void)remote_url;
+   (void)repo_dir;
+   (void)preferred_token;
+   if (!out || cap == 0)
+      return 0;
+   snprintf(out, cap, "test-token");
+   return 1;
+}
+
+/* Any direct HTTP from a migrated op is a bug, so make it loud rather than let
+ * the suite pass on a silent fallback. */
+static void http_forbidden(const char *which)
+{
+   fprintf(stderr, "migrated op reached HTTP directly via %s\n", which);
+   abort();
+}
+
+int agent_http_get(const char *url, const char *headers, char **resp, int timeout_ms)
+{
+   (void)url;
+   (void)headers;
+   (void)resp;
+   (void)timeout_ms;
+   http_forbidden("agent_http_get");
+   return -1;
+}
+
+int agent_http_put(const char *url, const char *auth, const char *body, char **resp,
+                   int timeout_ms, const char *accept)
+{
+   (void)url;
+   (void)auth;
+   (void)body;
+   (void)resp;
+   (void)timeout_ms;
+   (void)accept;
+   http_forbidden("agent_http_put");
+   return -1;
+}
+
+/* --- helpers ------------------------------------------------------------ */
+
+#define SLUG "acme/widgets"
+
+static int merge_with(const char *reply_json, char *sha, size_t sha_cap, char *err, size_t errlen)
+{
+   module_bus_stub_reply(reply_json);
+   return git_pr_merge_via_api_slug_ex(NULL, SLUG, 7, "merge", NULL, sha, sha_cap, err, errlen);
+}
+
+int main(void)
+{
+   char err[512];
+   char sha[128];
+
+   /* A merge reports the commit from the stage reply, so no second lookup. */
+   assert(merge_with("{\"status\":200,\"merged\":true,\"merge_sha\":\"deadbeef\"}", sha, sizeof(sha),
+                     err, sizeof(err)) == 0);
+   assert(strcmp(sha, "deadbeef") == 0);
+
+   /* Already merged is NOT an error: a caller that retried would open a second
+    * merge of work already on the base. */
+   assert(merge_with("{\"status\":405,\"already_merged\":true}", sha, sizeof(sha), err,
+                     sizeof(err)) == 1);
+
+   /* Retryable — a lost race, which a retry wins. */
+   assert(merge_with("{\"status\":405,\"error\":\"pr merge: Base branch was modified (HTTP 405)\","
+                     "\"retryable\":true}",
+                     sha, sizeof(sha), err, sizeof(err)) == 2);
+   assert(strstr(err, "Base branch was modified") != NULL);
+
+   /* Terminal conflict — retrying reproduces it exactly, so it must not be
+    * classified as retryable. This is the pair the whole split exists for. */
+   assert(merge_with("{\"status\":409,\"error\":\"pr merge: Pull Request has merge conflicts "
+                     "(HTTP 409)\",\"conflict\":true}",
+                     sha, sizeof(sha), err, sizeof(err)) == 3);
+   assert(strstr(err, "merge conflicts") != NULL);
+
+   /* An unclassified refusal is an error, and carries the forge's own words. */
+   assert(merge_with("{\"status\":403,\"error\":\"pr merge: Resource not accessible (HTTP 403)\"}",
+                     sha, sizeof(sha), err, sizeof(err)) == -1);
+   assert(strstr(err, "403") != NULL);
+
+   /* A merge reply with no sha still succeeds; sha is simply left empty. */
+   assert(merge_with("{\"status\":200,\"merged\":true}", sha, sizeof(sha), err, sizeof(err)) == 0);
+   assert(sha[0] == '\0');
+
+   /* THE DISTINCTION THAT MATTERS MOST: an unreachable module is not a refused
+    * merge. Reported as "the forge said no", a caller stops retrying a merge
+    * that was never attempted. */
+   module_bus_stub_absent();
+   assert(git_pr_merge_via_api_slug_ex(NULL, SLUG, 7, "merge", NULL, sha, sizeof(sha), err,
+                                       sizeof(err)) == -1);
+   assert(strstr(err, "could not be reached") != NULL);
+
+   /* An unrecognised method is refused HERE, before anything is sent: coercing
+    * it to a squash would rewrite history the caller did not ask to rewrite. */
+   module_bus_stub_reply("{\"status\":200,\"merged\":true}");
+   int before = module_bus_stub_calls();
+   assert(git_pr_merge_via_api_slug_ex(NULL, SLUG, 7, "octopus", NULL, sha, sizeof(sha), err,
+                                       sizeof(err)) == -1);
+   assert(module_bus_stub_calls() == before); /* nothing was sent */
+   assert(strstr(err, "octopus") != NULL);
+
+   /* A non-positive number is likewise refused before any call. */
+   before = module_bus_stub_calls();
+   assert(git_pr_merge_via_api_slug_ex(NULL, SLUG, 0, "merge", NULL, sha, sizeof(sha), err,
+                                       sizeof(err)) == -1);
+   assert(module_bus_stub_calls() == before);
+
+   printf("git_pr_stage: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_git_pr_stage.c
+++ b/src/tests/test_git_pr_stage.c
@@ -55,8 +55,8 @@ int agent_http_get(const char *url, const char *headers, char **resp, int timeou
    return -1;
 }
 
-int agent_http_put(const char *url, const char *auth, const char *body, char **resp,
-                   int timeout_ms, const char *accept)
+int agent_http_put(const char *url, const char *auth, const char *body, char **resp, int timeout_ms,
+                   const char *accept)
 {
    (void)url;
    (void)auth;
@@ -84,8 +84,8 @@ int main(void)
    char sha[128];
 
    /* A merge reports the commit from the stage reply, so no second lookup. */
-   assert(merge_with("{\"status\":200,\"merged\":true,\"merge_sha\":\"deadbeef\"}", sha, sizeof(sha),
-                     err, sizeof(err)) == 0);
+   assert(merge_with("{\"status\":200,\"merged\":true,\"merge_sha\":\"deadbeef\"}", sha,
+                     sizeof(sha), err, sizeof(err)) == 0);
    assert(strcmp(sha, "deadbeef") == 0);
 
    /* Already merged is NOT an error: a caller that retried would open a second


### PR DESCRIPTION
Second caller onto the `git-forge-request` stage, after the default-branch lookup in #2492. #2493 gave the stage the semantics this caller needs, which unblocked it.

## What moved

The merge call, its payload shaping (a squash's synthesised commit body, the drift-safety `sha`) and the **405/409 classification** now happen in `server-go/modules/git`.

## What deliberately stayed

**The return-code translation.** Callers switch on this function's long-standing codes, so they are preserved exactly:

| code | meaning |
|---|---|
| `0` | merged (`out_sha` filled from the 2xx body — no second lookup) |
| `1` | already merged |
| `2` | retryable |
| `3` | terminal conflict |
| `-1` | error |

The conflict/retryable split is unchanged in behaviour — a content conflict is a property of the two trees and a retry reproduces it exactly, while a moved head/base is a lost race a retry wins — but the decision is now the module's (`Conflict` / `Retryable` on the response) rather than a string match in C.

**The `merge_method` guard.** It refuses an unrecognised method rather than coercing it to a squash, which would rewrite history the caller did not ask to rewrite.

## Failure reporting

An unreachable module now reports `pr merge: the git module could not be reached` rather than an empty refusal, so a caller cannot read a transport failure as "the forge said no" and stop retrying. Conflating those is how a network blip gets recorded as a rejected merge.

## Tests

`src/tests/test_git_pr_stage.c` is new, and closes a gap that predates this PR: **no test target linked `git_pr_api.o`**, which is why neither this migration nor #2492's had any C-side coverage. The stage reply is canned through `module_bus_stub`, so the binary needs no forge, no credential and no repository.

It pins the translation — every return code, `out_sha` present and absent, the forge's own message surviving into `err` — plus:

- an unreachable module reports "could not be reached" rather than a refusal
- both guards (unknown `merge_method`, non-positive number) refuse **before anything is sent**, asserted through the stub's call counter so "refused early" is proven rather than assumed

The HTTP entry points are stubbed to **abort**, which makes this a regression test for the migration itself and not merely the mapping. Verified in both directions before committing:

- against the pre-migration implementation: `migrated op reached HTTP directly via agent_http_put`
- after the migration: `git_pr_stage: all tests passed`

## Dead code flagged, not removed

`git_pr_merge_err_is_conflict()` no longer has a production caller — the classification it existed for moved into the module. It stays exported and covered by `test_git_pr_ci_grade.c`. Removing it is a refactor and is left for a follow-up rather than mixed into this behaviour change.

## Verification

- `make -C src -j8` — clean (full build, not just test targets)
- `make -C src unit-tests` — green, re-run after adding the new target to check for link ripples
- The whole `pins` job locally: `validate_module_process_contracts.py`, `check_go_module_runtime_bundle.py`, `check_c_repository_lock.py`, `go test ./bus ./modules/... ./cmd/aimee-module`, `test_module_supervisor.sh` — all ok
- Lock repinned by recomputing with the exporter's own `digest_files()`/`module_owned_files()`; `git` is the only module that moved, which is the expected blast radius

Remaining callers for this seam: create, info, find/list.