### PR TITLE
fix: make the sandbox work, and enable it by default

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "3cd0c4e472ccef24785768e9b9815f70c12d91cddcdbc851562bfaead75177c7"
+      "source_sha256": "204982e24430acf71a0d345b5c51ee1abe0dcc216cb384a53b4e889d7932a1fa"
     },
     {
       "id": "ir",

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "624ea69bee01464ccfe2e153173b6735c16e6aea8bb5505dc45d23ca07209cc1"
+      "source_sha256": "3cd0c4e472ccef24785768e9b9815f70c12d91cddcdbc851562bfaead75177c7"
     },
     {
       "id": "ir",
@@ -187,7 +187,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "1e3fba6a7f7ecd4c8824150485f04bc6064f0ab7a9746b6a513268bc3e508723",
+      "source_sha256": "86a6e59858e066a79815dd2aec2dd4fee6c0f17c87def79893041bc0f23cad07",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 11,

--- a/docs/proposals/pending/context-paging-not-compaction.md
+++ b/docs/proposals/pending/context-paging-not-compaction.md
@@ -1,0 +1,163 @@
+# Context paging, not compaction
+
+- **State:** proposed.
+
+## Goal
+
+Three properties, in dependency order:
+
+1. **An agent can recall on demand anything that was evicted.** Eviction is
+   reversible.
+2. **We compact better than the clients do** — from state we recorded as it
+   happened, not from a retrospective reading of the transcript.
+3. **The user never feels a compaction.** No multi-minute stall, no visible
+   boundary event.
+
+These are not three parallel goals. (1) licenses (3): if eviction is reversible,
+we can evict early and continuously instead of waiting for a cliff, so the
+transcript never approaches the wall and there is no compaction *event* to feel.
+(2) is what makes (1) reliable — you can only page something back in if you
+conserved an exact coordinate for it, not a model's paraphrase of it.
+
+The deliverable is therefore not a better compactor. It is turning compaction
+from a **periodic cliff** into a **continuous paging system**.
+
+## Why the current design cannot get there
+
+Compaction today is an event: `maybe_compact_before_request()`
+(`src/posix/agent_runtime.c:240`) samples pressure, and at 80%
+(`SESSION_PRESSURE_COMPACT`) rewrites history in one destructive pass. The
+summarised messages are deleted. Anything the summary failed to capture is gone.
+
+Because it is destructive it must be *late* — you delay an irreversible lossy
+step as long as possible. Because it is late it is *large*. Because it is large
+it is a cliff. Every property we want is blocked by the irreversibility.
+
+The client-side compactors (Codex, Claude Code) have the same shape plus a model
+call, which is why they cost minutes.
+
+### What we re-derive that we already knew
+
+`session_compact.c` builds its summary by scraping prose: `token_looks_like_path()`
+guesses which tokens are paths, `flashback_extract_from_text()` pattern-matches
+for errors and decisions (`:196-305`). It is a heuristic reconstruction of facts
+the system recorded first-hand and then discarded.
+
+Meanwhile the economizer records those facts exactly:
+
+- `coord_closet` — uuids, shas, paths, refs, handles extracted **verbatim before
+  truncation**, stamped `{lane, turn, tool_call, result}`, secrets redacted at
+  render, and — critically — `COORD_EVICT_FAIL` rather than silent loss.
+- `fold_register` — each assistant turn classified settled (verdict/hazard) vs
+  transient (in-progress/executing/blocked), from the agent's own tagging.
+- `task_rail` — the plan as a locked state machine with per-step state and
+  evidence, explicitly designed to live *outside* the prompt.
+- `episode_seal` — file inventory plus conclusion, with a file-touch auto-recall
+  predicate.
+- `fold_recall` — a page table of evicted coordinates with a residency TTL and a
+  refetch path.
+
+`session_compact` consumes **none** of it. Verified: no reference to closet,
+rail, seal, register or recall anywhere in the file. The recorders and the
+compactor shipped as separate slices and were never joined.
+
+## Verified shortfall inventory
+
+| # | Shortfall | Evidence |
+|---|---|---|
+| A | `session_compact` consumes no recorded state; re-derives by scraping prose | `src/server/session_compact.c:196-305` |
+| B1 | `task_rail` has zero live callers; DB1 target exists, unbound | `src/db1/checkpoints.c:30` has `session_id` + `snapshot` |
+| B2 | `episode_seal` has zero live callers; DB2 target exists, unbound | `memory_units`, `unit_type="episode_seal"` |
+| B3 | `fold_recall` has zero live callers, default-off, resolver never wired | `fold_recall.h` "Default-off" |
+| C | `reduce_state_t` is a stack local — no record survives the run | `src/posix/agent_runtime.c:600` |
+| D1 | `gw_mutate_upstream_ok` refuses Anthropic egress unconditionally | `gateway_mutate_wire.c:52` |
+| D2 | Gateway session key is per-identity, not per-conversation | `msg_session_disable.h:33` |
+| D3 | Gateway is compress-only, fold deferred | `gateway_mutate_wire.c:113` |
+| E | Whether clients defer their own compaction on lower relayed usage | **unverified** |
+| F | Baseline never run; rounds-to-resume consumed by nothing | `pending/compaction-quality-baseline.md` |
+
+Live and already recording: `coord_closet` and `fold_register`, config-gated at
+`src/posix/agent_runtime.c:773-780`. That is the foundation slice 1 builds on,
+and it needs no new recording to start.
+
+## Slices
+
+### S0 — Settle the unverified premise (E)
+
+Run a long Codex session through the gateway with mutation enabled and observe
+whether its compaction fires at the usual point. The relay is confirmed
+byte-verbatim (`relay_capture_usage`, "without altering it",
+`anthropic_http.c:774`), so upstream computes usage on the reduced payload and
+the smaller number reaches the client. What is *not* known is whether the client
+trusts that number or maintains its own local estimate.
+
+Decisive and cheap. If clients estimate locally, all of D is dead and slices 1-3
+stand on their own merits. **Nothing in D may be built before this returns.**
+
+### S1 — Compact from the record, not the transcript (A)
+
+Rewrite the summary builder to consume closet coordinates, register
+classifications and rail steps. Delete the prose-scraping heuristics as they are
+superseded, not alongside them.
+
+Highest value, no new recording required, and it is the change that makes the
+summary deterministic-from-record. Behaviour change only — no refactor in the
+same commit.
+
+### S2 — Turn the recorders on (B1, B2, B3, C)
+
+- Bind `task_rail` to DB1 `checkpoints.snapshot` keyed by `session_id`.
+- Bind `episode_seal` to DB2 `memory_units`.
+- Promote `reduce_state_t` from stack local to session-scoped persisted state.
+- Wire `fold_recall`'s resolver to `code_span_get` / `memory_get` and default it on.
+
+C is the one that makes the record survive a session boundary, which is what
+turns a per-run structure into an actual memory hierarchy.
+
+### S3 — Continuous paging (the goal)
+
+With recall reliable, move eviction off the 80% trigger and onto a continuous
+low-water/high-water discipline: evict steadily from the moment the transcript
+starts growing, keeping occupancy well below any threshold. `fold_freeze_t`'s
+prefix digest already keeps an unchanged prefix byte-identical, so continuous
+eviction stays prompt-cache-warm rather than thrashing it.
+
+This is where "the user never feels a compaction" is actually delivered: there
+is no cliff because occupancy never approaches one.
+
+### S4 — Gateway (D1, D2, D3) — **conditional on S0**
+
+Make the Anthropic refusal conditional on pressure rather than absolute: the
+cache argument that justifies it inverts once the client is about to compact,
+because the client's own compaction rewrites the prefix anyway. Key sessions by
+message-prefix digest rather than credential. Enable fold at the wire.
+
+### S5 — Measurement (F)
+
+Run the outstanding baseline from `compaction-quality-baseline.md` and wire
+`rounds-to-resume` (`session_compact_result_t.readonly_sigs`) to consume it as a
+regression gate on S1 and S3.
+
+## Risks
+
+- **S1 quality regression.** The prose heuristics may be catching something the
+  structured record misses. S5's baseline is the guard; if S5 cannot run first,
+  S1 ships behind a config flag with the old path retained until measured.
+- **S3 recall thrash.** Aggressive eviction with an unreliable resolver degrades
+  worse than a late cliff. S3 is gated on S2's resolver being wired and on the
+  residency TTL demonstrably preventing re-surfacing loops.
+- **S0 kills S4.** Accepted and by design — that is why S0 is first and why S4 is
+  last.
+
+## Acceptance
+
+- `session_compact` derives its summary from recorded state; the prose-scraping
+  path is deleted, not merely bypassed.
+- `task_rail` and `episode_seal` persist across session boundaries and are
+  recoverable by `session_id`.
+- An agent can page back a coordinate evicted in an earlier session.
+- Transcript occupancy under continuous paging stays below the compact threshold
+  across a long session, with no single-event boundary.
+- The S5 baseline is committed and gates S1/S3 against regression.
+- Every criterion above is exercised by a test or a reproducible harness run.
+  Anything that cannot be run in-tree is reported validation-pending, not done.

--- a/src/headers/sandbox.h
+++ b/src/headers/sandbox.h
@@ -105,6 +105,24 @@ void sandbox_set_audit_hook(sandbox_audit_hook_fn fn);
 void sandbox_set_available_override_for_test(int (*fn)(const char **reason));
 
 /*
+ * sandbox_effective_mode:
+ *   The sandbox mode callers should GATE on (as distinct from the mode sandbox_exec
+ *   builds with). Returns the test override when one is set, else cfg->mode; returns
+ *   SANDBOX_MODE_OFF for a NULL cfg.
+ *
+ *   This exists because the delegate shell guard's fail-closed branch is only
+ *   reachable when the mode is OFF, and now that the mode defaults to WORKSPACE_ONLY
+ *   a test cannot reach it by configuration: the config path is resolved before a
+ *   test can move HOME, so an in-process opt-out never reaches config_sandbox().
+ *   Without this seam that containment branch would go unexercised.
+ *
+ * sandbox_set_mode_override_for_test:
+ *   Force the value sandbox_effective_mode() reports. Pass -1 to clear. Test-only.
+ */
+int sandbox_effective_mode(const sandbox_config_t *cfg);
+void sandbox_set_mode_override_for_test(int mode);
+
+/*
  * sandbox_exec:
  *   Execute |cmd| via /bin/sh -c inside the sandbox described by |cfg|.
  *   The child's stdout/stderr are written to |out_fd|/|err_fd|.

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -710,6 +710,15 @@ static void config_set_defaults(config_t *cfg)
     * parse below carries an env override), so the default lives here, not in
     * config_flat_defaults[]. */
    cfg->delegate_sandbox = 1;
+   /* Default-ON: co-located shell execution is namespace-isolated to the workspace.
+    * This is the mode the delegate shell guard in tool_bash() reads (it refuses a
+    * delegated shell when the mode is OFF), so leaving it at the SANDBOX_MODE_OFF
+    * zero value made that guard refuse EVERY co-located delegate shell on an
+    * unconfigured install — isolation-by-default and delegate-shells-work-by-default
+    * cannot both hold while `delegate_sandbox` defaults on and this defaults off.
+    * Non-flat (sandbox is a SCHEMA_OBJECT section), so the default lives here.
+    * Opt out with `sandbox: {"mode": "off"}` — config_save persists that opt-out. */
+   cfg->sandbox.mode = SANDBOX_MODE_WORKSPACE_ONLY;
    snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
             "proxy");
    cfg->compact_enabled = 1; /* default on; set before no-config early returns */

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1166,8 +1166,13 @@ int config_save(const config_t *cfg)
          cJSON_AddNumberToObject(sess, "max_worktrees", cfg->max_worktrees);
    }
 
-   /* Sandbox config (only save if non-default) */
-   if (cfg->sandbox.mode != SANDBOX_MODE_OFF || cfg->sandbox.network_isolated ||
+   /* Sandbox config (only save if non-default). The default is now
+    * SANDBOX_MODE_WORKSPACE_ONLY, so the value that MUST survive a save is the
+    * explicit opt-out (`mode: "off"`) — mirroring delegate_sandbox above, which
+    * persists only its opt-out. Testing against SANDBOX_MODE_OFF here (the old
+    * predicate) would drop an operator's "off" on the next save and silently
+    * re-enable the sandbox from the default. */
+   if (cfg->sandbox.mode != SANDBOX_MODE_WORKSPACE_ONLY || cfg->sandbox.network_isolated ||
        cfg->sandbox.allow_path_count > 0)
    {
       cJSON *sbox = cJSON_AddObjectToObject(root, "sandbox");

--- a/src/modules/config/config_sections.c
+++ b/src/modules/config/config_sections.c
@@ -881,7 +881,25 @@ void config_parse_sandbox_section(config_t *cfg, cJSON *root)
    {
       item = cJSON_GetObjectItemCaseSensitive(sbox, "mode");
       if (cJSON_IsString(item) && item->valuestring[0])
-         cfg->sandbox.mode = sandbox_mode_from_string(item->valuestring);
+      {
+         /* sandbox_mode_from_string() maps ANY unrecognized string to
+          * SANDBOX_MODE_OFF. That was harmless while OFF was also the default, but
+          * the default is now WORKSPACE_ONLY, so a typo ("wokspace_only") would
+          * SILENTLY DISABLE isolation. Recognize exactly what that parser accepts —
+          * leading 'o'+"off", 'w', 'a' — and on anything else warn and keep the
+          * default rather than downgrading. The loose leading-character match is
+          * preserved deliberately: tightening it to exact strings would regress
+          * existing configs that say "workspace" or "allow". */
+         const char *ms = item->valuestring;
+         const int known = (strcmp(ms, "off") == 0) || ms[0] == 'w' || ms[0] == 'a';
+         if (known)
+            cfg->sandbox.mode = sandbox_mode_from_string(ms);
+         else
+            fprintf(stderr,
+                    "aimee: config warning: sandbox.mode: unknown value \"%s\" — keeping "
+                    "default \"%s\" (valid: off, workspace_only, allowlist)\n",
+                    ms, sandbox_mode_to_string(cfg->sandbox.mode));
+      }
 
       item = cJSON_GetObjectItemCaseSensitive(sbox, "network");
       if (cJSON_IsBool(item))

--- a/src/modules/tools/agent_tools.c
+++ b/src/modules/tools/agent_tools.c
@@ -825,7 +825,7 @@ char *tool_bash(const char *command, int timeout_ms)
     * delegate — the trusted primary (operator) session, which has no active
     * delegation, is unaffected and still runs on the host. */
 #ifdef __linux__
-   const int host_unsandboxed = (sbox_cfg.mode == SANDBOX_MODE_OFF);
+   const int host_unsandboxed = (sandbox_effective_mode(&sbox_cfg) == SANDBOX_MODE_OFF);
 #else
    const int host_unsandboxed = !guarded_parent; /* guarded_parent already refused below */
 #endif
@@ -835,10 +835,15 @@ char *tool_bash(const char *command, int timeout_ms)
       close(stdout_pipe[1]);
       close(stderr_pipe[0]);
       close(stderr_pipe[1]);
+      /* Say DISABLED, not "unavailable": on Linux this branch tests the configured
+       * mode only — sandbox_available() is never consulted here (it is probed inside
+       * sandbox_exec_internal, which this refusal precedes). The old "off/unavailable"
+       * wording sent readers hunting for a broken kernel/namespace setup when the
+       * actual state is a config value. Name the setting so the fix is obvious. */
       return safe_strdup(
           "{\"stdout\":\"\",\"stderr\":\"refused: a delegated shell requires sandbox isolation, "
-          "but the sandbox is off/unavailable; running unsandboxed on the aimee-server host is "
-          "not permitted\",\"exit_code\":-1}");
+          "but the sandbox is disabled (sandbox.mode=off); running unsandboxed on the "
+          "aimee-server host is not permitted\",\"exit_code\":-1}");
    }
 #ifndef __linux__
    if (guarded_parent)

--- a/src/posix/sandbox.c
+++ b/src/posix/sandbox.c
@@ -62,6 +62,20 @@ void sandbox_set_available_override_for_test(int (*fn)(const char **reason))
    g_sbx_avail_override = fn;
 }
 
+/* Test-only effective-mode override; <0 means "no override" (production). */
+static int g_sbx_mode_override = -1;
+void sandbox_set_mode_override_for_test(int mode)
+{
+   g_sbx_mode_override = mode;
+}
+
+int sandbox_effective_mode(const sandbox_config_t *cfg)
+{
+   if (g_sbx_mode_override >= 0)
+      return g_sbx_mode_override;
+   return cfg ? (int)cfg->mode : SANDBOX_MODE_OFF;
+}
+
 /* Characters allowed in a bare program path we are willing to surface verbatim.
  * A real program token is a plain path; anything else is refused (see below). */
 static int sbx_prog_char(char c)

--- a/src/posix/sandbox.c
+++ b/src/posix/sandbox.c
@@ -787,11 +787,27 @@ static pid_t sandbox_exec_internal(const sandbox_config_t *cfg, const char *cmd,
 
    if (pipe(g_sync_pipe) != 0)
       return -1;
+   /* Child -> parent readiness. setup_userns_maps() writes /proc/<pid>/uid_map, which
+    * is only permitted once the child is actually IN its new user namespace. g_sync_pipe
+    * only signals parent -> child ("maps written"), so without this second pipe the
+    * parent raced the child's unshare() and — winning that race — wrote uid_map while
+    * the child was still in the initial userns. That fails EPERM, so sandbox_exec
+    * returned -1 and every sandboxed command reported a bare "fork failed". The bug was
+    * invisible while sandbox.mode defaulted to OFF, because this path never ran. */
+   int ready_pipe[2] = {-1, -1};
+   if (pipe(ready_pipe) != 0)
+   {
+      close(g_sync_pipe[0]);
+      close(g_sync_pipe[1]);
+      return -1;
+   }
    int setup_pipe[2] = {-1, -1};
    if (require_isolation && pipe(setup_pipe) != 0)
    {
       close(g_sync_pipe[0]);
       close(g_sync_pipe[1]);
+      close(ready_pipe[0]);
+      close(ready_pipe[1]);
       return -1;
    }
 
@@ -811,6 +827,8 @@ static pid_t sandbox_exec_internal(const sandbox_config_t *cfg, const char *cmd,
    {
       close(g_sync_pipe[0]);
       close(g_sync_pipe[1]);
+      close(ready_pipe[0]);
+      close(ready_pipe[1]);
       if (setup_pipe[0] >= 0)
          close(setup_pipe[0]);
       if (setup_pipe[1] >= 0)
@@ -823,12 +841,19 @@ static pid_t sandbox_exec_internal(const sandbox_config_t *cfg, const char *cmd,
       /* Child — wait for uid/gid map to be written before doing anything */
       close(g_sync_pipe[1]);
       g_sync_pipe[1] = -1;
+      close(ready_pipe[0]);
       if (setup_pipe[0] >= 0)
          close(setup_pipe[0]);
 
       /* Enter user namespace */
       if (unshare(clone_flags & ~SIGCHLD) != 0)
       {
+         /* Report the FAILURE to the parent so it skips the map write (there is no
+          * new userns to map) and releases us, instead of blocking on a readiness
+          * byte that never comes. */
+         char unshared = '0';
+         (void)write(ready_pipe[1], &unshared, 1);
+         close(ready_pipe[1]);
          sync_child_wait();
          if (require_isolation)
          {
@@ -843,6 +868,14 @@ static pid_t sandbox_exec_internal(const sandbox_config_t *cfg, const char *cmd,
             chdir(workspace);
          execl("/bin/sh", "sh", "-c", cmd, (char *)NULL);
          _exit(127);
+      }
+
+      /* We are now IN the new user namespace — tell the parent it is safe to write
+       * our uid/gid maps, then wait for it to finish. */
+      {
+         char unshared = '1';
+         (void)write(ready_pipe[1], &unshared, 1);
+         close(ready_pipe[1]);
       }
 
       sync_child_wait();
@@ -879,10 +912,25 @@ static pid_t sandbox_exec_internal(const sandbox_config_t *cfg, const char *cmd,
    /* Parent: write uid/gid maps then signal child */
    close(g_sync_pipe[0]);
    g_sync_pipe[0] = -1;
+   close(ready_pipe[1]);
    if (setup_pipe[1] >= 0)
       close(setup_pipe[1]);
 
-   if (setup_userns_maps(pid) != 0)
+   /* Block until the child reports whether it entered the new user namespace.
+    * Writing uid_map before unshare() has taken effect fails EPERM — that race is
+    * what made every sandboxed command report "fork failed". A short read (child
+    * died) is treated as "did not unshare". */
+   char child_unshared = '0';
+   {
+      ssize_t rn = read(ready_pipe[0], &child_unshared, 1);
+      close(ready_pipe[0]);
+      if (rn != 1)
+         child_unshared = '0';
+   }
+
+   /* No new userns means there are no maps to write; skipping the write lets the
+    * child's own non-namespaced fallback proceed instead of failing the exec. */
+   if (child_unshared == '1' && setup_userns_maps(pid) != 0)
    {
       /* Maps failed — signal child anyway so it doesn't hang, then reap */
       sync_parent_signal();

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1288,20 +1288,50 @@ static void test_tool_bash(void)
 
 /* Containment: a DELEGATE (untrusted model) must never run a shell UNSANDBOXED on
  * the aimee-server host — that host is uid 0 with the docker socket mounted, so an
- * unsandboxed command is a host-root escalation. The test config's sandbox mode is
- * OFF (default), so tool_bash would otherwise fork on the host; with a delegation
- * active it must refuse instead. The primary session (no delegation) still runs. */
+ * unsandboxed command is a host-root escalation. With a delegation active tool_bash
+ * must refuse instead of forking on the host. The primary session (no delegation)
+ * still runs.
+ *
+ * The sandbox is OPTED OUT explicitly here rather than relying on the config default:
+ * the default is now SANDBOX_MODE_WORKSPACE_ONLY, so an inherited default no longer
+ * reaches the unsandboxed branch at all, and a test that depends on it would silently
+ * stop exercising the containment it exists to prove. `sandbox: {mode: off}` is also
+ * the realistic shape of this risk — an operator who turned isolation off. */
 static void test_tool_bash_delegate_unsandboxed_refused(void)
 {
+   /* Which branch is reachable depends on the EFFECTIVE sandbox mode, which this
+    * binary cannot redirect: the config path is resolved before a test can move HOME,
+    * so an in-process opt-out does not reach config_sandbox(). Assert against the
+    * mode actually in force rather than assuming one. */
+   sandbox_config_t effective;
+   config_sandbox(&effective);
+
    g_test_delegation_id = "test-deleg";
    char *result = tool_bash("echo escalated", 5000);
    assert(result != NULL);
-   assert(strstr(result, "refused") != NULL);   /* fail-closed */
-   assert(strstr(result, "escalated") == NULL); /* the command did NOT run */
-   assert(strstr(result, "\"exit_code\":-1") != NULL);
+
+   if (effective.mode == SANDBOX_MODE_OFF)
+   {
+      /* Containment: a DELEGATE (untrusted model) must never run a shell UNSANDBOXED
+       * on the aimee-server host — that host is uid 0 with the docker socket mounted,
+       * so an unsandboxed command is a host-root escalation. */
+      assert(strstr(result, "refused") != NULL);   /* fail-closed */
+      assert(strstr(result, "escalated") == NULL); /* the command did NOT run */
+      assert(strstr(result, "\"exit_code\":-1") != NULL);
+   }
+   else
+   {
+      /* Sandbox on (the default): the delegate is contained by isolation rather than
+       * by refusal, so the command legitimately runs — INSIDE the sandbox. What must
+       * still hold is that the refusal guard has not been bypassed into a host fork;
+       * a sandboxed run is the safe outcome, an unsandboxed one would not be
+       * distinguishable here, which is why the OFF branch above is the real proof and
+       * is exercised wherever the effective mode is OFF. */
+      assert(strstr(result, "\"exit_code\":0") != NULL);
+   }
    free(result);
 
-   /* The trusted primary (operator) session still runs on the host. */
+   /* The trusted primary (operator) session still runs. */
    g_test_delegation_id = NULL;
    result = tool_bash("echo primary-ok", 5000);
    assert(result != NULL);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1297,46 +1297,49 @@ static void test_tool_bash(void)
  * reaches the unsandboxed branch at all, and a test that depends on it would silently
  * stop exercising the containment it exists to prove. `sandbox: {mode: off}` is also
  * the realistic shape of this risk — an operator who turned isolation off. */
+/* Containment: a DELEGATE (untrusted model) must never run a shell UNSANDBOXED on the
+ * aimee-server host — that host is uid 0 with the docker socket mounted, so an
+ * unsandboxed command is a host-root escalation. With a delegation active tool_bash
+ * must refuse rather than fork on the host; the primary session still runs.
+ *
+ * The mode is forced through the test seam rather than through config. The mode now
+ * defaults to WORKSPACE_ONLY, and this binary cannot redirect config in-process (the
+ * config path resolves before a test can move HOME), so without the override this
+ * fail-closed branch would silently stop being exercised. */
 static void test_tool_bash_delegate_unsandboxed_refused(void)
 {
-   /* Which branch is reachable depends on the EFFECTIVE sandbox mode, which this
-    * binary cannot redirect: the config path is resolved before a test can move HOME,
-    * so an in-process opt-out does not reach config_sandbox(). Assert against the
-    * mode actually in force rather than assuming one. */
-   sandbox_config_t effective;
-   config_sandbox(&effective);
+   sandbox_set_mode_override_for_test(SANDBOX_MODE_OFF);
 
    g_test_delegation_id = "test-deleg";
    char *result = tool_bash("echo escalated", 5000);
    assert(result != NULL);
-
-   if (effective.mode == SANDBOX_MODE_OFF)
-   {
-      /* Containment: a DELEGATE (untrusted model) must never run a shell UNSANDBOXED
-       * on the aimee-server host — that host is uid 0 with the docker socket mounted,
-       * so an unsandboxed command is a host-root escalation. */
-      assert(strstr(result, "refused") != NULL);   /* fail-closed */
-      assert(strstr(result, "escalated") == NULL); /* the command did NOT run */
-      assert(strstr(result, "\"exit_code\":-1") != NULL);
-   }
-   else
-   {
-      /* Sandbox on (the default): the delegate is contained by isolation rather than
-       * by refusal, so the command legitimately runs — INSIDE the sandbox. What must
-       * still hold is that the refusal guard has not been bypassed into a host fork;
-       * a sandboxed run is the safe outcome, an unsandboxed one would not be
-       * distinguishable here, which is why the OFF branch above is the real proof and
-       * is exercised wherever the effective mode is OFF. */
-      assert(strstr(result, "\"exit_code\":0") != NULL);
-   }
+   assert(strstr(result, "refused") != NULL);   /* fail-closed */
+   assert(strstr(result, "escalated") == NULL); /* the command did NOT run */
+   assert(strstr(result, "\"exit_code\":-1") != NULL);
+   /* Names the setting rather than blaming an "unavailable" sandbox. */
+   assert(strstr(result, "sandbox.mode=off") != NULL);
    free(result);
 
-   /* The trusted primary (operator) session still runs. */
+   /* The trusted primary (operator) session still runs on the host. */
    g_test_delegation_id = NULL;
    result = tool_bash("echo primary-ok", 5000);
    assert(result != NULL);
    assert(strstr(result, "primary-ok") != NULL);
    free(result);
+
+   /* With the sandbox ON, the same delegated command is contained by ISOLATION
+    * instead of refusal — it runs, rather than being refused. This is the branch the
+    * new default puts real installs on, so it is asserted rather than assumed. */
+   sandbox_set_mode_override_for_test(SANDBOX_MODE_WORKSPACE_ONLY);
+   g_test_delegation_id = "test-deleg";
+   result = tool_bash("echo contained", 5000);
+   assert(result != NULL);
+   assert(strstr(result, "refused") == NULL);
+   assert(strstr(result, "\"exit_code\":0") != NULL);
+   free(result);
+
+   g_test_delegation_id = NULL;
+   sandbox_set_mode_override_for_test(-1); /* restore production behaviour */
 }
 
 /* A write into a source checkout is redirected into an aimee-managed worktree

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1660,85 +1660,83 @@ int main(void)
       assert(strcmp(cfg2.sandbox.allow_paths[1], "/opt/b") == 0);
    }
 
-   /* --- sandbox: DEFAULT-ON with no sandbox section ---
-    * The delegate shell guard in tool_bash() refuses a delegated shell whenever the
-    * mode is SANDBOX_MODE_OFF. While this defaulted to the zero value that guard
-    * refused every co-located delegate shell on an unconfigured install. */
+   /* --- sandbox mode: defaults, opt-out persistence, and bad input ---
+    *
+    * Read through config_sandbox() rather than a config_t. check-config-encapsulation
+    * ratchets config_t exposure in this file DOWNWARD — the baseline is debt, not
+    * headroom — so these cases go through the accessor the checker steers callers to.
+    * That is also the honest surface: the delegate shell guard in tool_bash() reads
+    * config_sandbox(), not a config_t.
+    *
+    * Deliberately NOT via config_reload(): publishing a snapshot makes every later
+    * config_load() in the process return that snapshot instead of the file
+    * (config.c:1128), which silently breaks any test after this one. With no snapshot
+    * live, config_sandbox() heap-loads from disk, which is what these cases want.
+    * AIMEE_NO_CACHE defeats the stat-keyed load cache so successive rewrites of the
+    * same path are always re-read. */
    {
       char cpath[512];
       snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      sandbox_config_t sb;
+      setenv("AIMEE_NO_CACHE", "1", 1);
+
+      /* DEFAULT-ON with no sandbox section. The guard refuses a delegated shell
+       * whenever the mode is OFF, so while this defaulted to the zero value it
+       * refused every co-located delegate shell on an unconfigured install. */
       FILE *f = fopen(cpath, "w");
       assert(f);
       fprintf(f, "provider: claude\n");
       fclose(f);
+      memset(&sb, 0, sizeof(sb));
+      config_sandbox(&sb);
+      assert(sb.mode == SANDBOX_MODE_WORKSPACE_ONLY);
 
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      assert(config_load(&cfg) == 0);
-      assert(cfg.sandbox.mode == SANDBOX_MODE_WORKSPACE_ONLY);
-   }
-
-   /* --- sandbox: the explicit opt-out SURVIVES a save round-trip ---
-    * config_save persists the sandbox block only when it differs from the default.
-    * With the default flipped to WORKSPACE_ONLY, testing that predicate against
-    * SANDBOX_MODE_OFF would drop an operator's "off" on the next save and silently
-    * re-enable the sandbox. */
-   {
-      char cpath[512];
-      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
-      FILE *f = fopen(cpath, "w");
+      /* The explicit opt-out SURVIVES a save. config_save persists the sandbox block
+       * only when it differs from the default; with the default flipped, testing that
+       * predicate against OFF would drop an operator's "off" on the next save and
+       * silently re-enable the sandbox. config_set_* performs a real load/modify/save
+       * cycle, so it exercises the persistence path without naming config_t. */
+      f = fopen(cpath, "w");
       assert(f);
       fprintf(f, "provider: claude\n"
                  "sandbox:\n"
                  "  mode: off\n");
       fclose(f);
+      memset(&sb, 0, sizeof(sb));
+      config_sandbox(&sb);
+      assert(sb.mode == SANDBOX_MODE_OFF); /* opt-out parsed */
 
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      assert(config_load(&cfg) == 0);
-      assert(cfg.sandbox.mode == SANDBOX_MODE_OFF); /* opt-out parsed */
-      config_save(&cfg);
+      assert(config_set_fold_enabled(0) == 0); /* forces a save of the whole config */
+      memset(&sb, 0, sizeof(sb));
+      config_sandbox(&sb);
+      assert(sb.mode == SANDBOX_MODE_OFF); /* opt-out still honoured after the save */
 
-      static config_t cfg2;
-      memset(&cfg2, 0, sizeof(cfg2));
-      assert(config_load(&cfg2) == 0);
-      assert(cfg2.sandbox.mode == SANDBOX_MODE_OFF); /* opt-out still honoured */
-   }
-
-   /* --- sandbox: an unknown mode string keeps the default, never downgrades ---
-    * sandbox_mode_from_string() maps anything unrecognized to SANDBOX_MODE_OFF, which
-    * would silently disable isolation on a typo now that the default is on. */
-   {
-      char cpath[512];
-      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
-      FILE *f = fopen(cpath, "w");
+      /* An unknown mode string keeps the default and never downgrades.
+       * sandbox_mode_from_string() maps anything unrecognized to OFF, which would
+       * silently disable isolation on a typo now that the default is on. */
+      f = fopen(cpath, "w");
       assert(f);
       fprintf(f, "provider: claude\n"
                  "sandbox:\n"
                  "  mode: wokspace_only\n");
       fclose(f);
+      memset(&sb, 0, sizeof(sb));
+      config_sandbox(&sb);
+      assert(sb.mode == SANDBOX_MODE_WORKSPACE_ONLY);
 
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      assert(config_load(&cfg) == 0);
-      assert(cfg.sandbox.mode == SANDBOX_MODE_WORKSPACE_ONLY);
-   }
-
-   /* --- sandbox: the loose leading-character parse is preserved --- */
-   {
-      char cpath[512];
-      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
-      FILE *f = fopen(cpath, "w");
+      /* The loose leading-character parse is preserved, so configs saying "allow"
+       * or "workspace" do not regress into the default. */
+      f = fopen(cpath, "w");
       assert(f);
       fprintf(f, "provider: claude\n"
                  "sandbox:\n"
                  "  mode: allow\n");
       fclose(f);
+      memset(&sb, 0, sizeof(sb));
+      config_sandbox(&sb);
+      assert(sb.mode == SANDBOX_MODE_ALLOWLIST);
 
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      assert(config_load(&cfg) == 0);
-      assert(cfg.sandbox.mode == SANDBOX_MODE_ALLOWLIST);
+      unsetenv("AIMEE_NO_CACHE");
    }
 
    /* --- compact config: defaults --- */

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1660,6 +1660,87 @@ int main(void)
       assert(strcmp(cfg2.sandbox.allow_paths[1], "/opt/b") == 0);
    }
 
+   /* --- sandbox: DEFAULT-ON with no sandbox section ---
+    * The delegate shell guard in tool_bash() refuses a delegated shell whenever the
+    * mode is SANDBOX_MODE_OFF. While this defaulted to the zero value that guard
+    * refused every co-located delegate shell on an unconfigured install. */
+   {
+      char cpath[512];
+      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      FILE *f = fopen(cpath, "w");
+      assert(f);
+      fprintf(f, "provider: claude\n");
+      fclose(f);
+
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      assert(config_load(&cfg) == 0);
+      assert(cfg.sandbox.mode == SANDBOX_MODE_WORKSPACE_ONLY);
+   }
+
+   /* --- sandbox: the explicit opt-out SURVIVES a save round-trip ---
+    * config_save persists the sandbox block only when it differs from the default.
+    * With the default flipped to WORKSPACE_ONLY, testing that predicate against
+    * SANDBOX_MODE_OFF would drop an operator's "off" on the next save and silently
+    * re-enable the sandbox. */
+   {
+      char cpath[512];
+      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      FILE *f = fopen(cpath, "w");
+      assert(f);
+      fprintf(f, "provider: claude\n"
+                 "sandbox:\n"
+                 "  mode: off\n");
+      fclose(f);
+
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      assert(config_load(&cfg) == 0);
+      assert(cfg.sandbox.mode == SANDBOX_MODE_OFF); /* opt-out parsed */
+      config_save(&cfg);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      assert(config_load(&cfg2) == 0);
+      assert(cfg2.sandbox.mode == SANDBOX_MODE_OFF); /* opt-out still honoured */
+   }
+
+   /* --- sandbox: an unknown mode string keeps the default, never downgrades ---
+    * sandbox_mode_from_string() maps anything unrecognized to SANDBOX_MODE_OFF, which
+    * would silently disable isolation on a typo now that the default is on. */
+   {
+      char cpath[512];
+      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      FILE *f = fopen(cpath, "w");
+      assert(f);
+      fprintf(f, "provider: claude\n"
+                 "sandbox:\n"
+                 "  mode: wokspace_only\n");
+      fclose(f);
+
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      assert(config_load(&cfg) == 0);
+      assert(cfg.sandbox.mode == SANDBOX_MODE_WORKSPACE_ONLY);
+   }
+
+   /* --- sandbox: the loose leading-character parse is preserved --- */
+   {
+      char cpath[512];
+      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      FILE *f = fopen(cpath, "w");
+      assert(f);
+      fprintf(f, "provider: claude\n"
+                 "sandbox:\n"
+                 "  mode: allow\n");
+      fclose(f);
+
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      assert(config_load(&cfg) == 0);
+      assert(cfg.sandbox.mode == SANDBOX_MODE_ALLOWLIST);
+   }
+
    /* --- compact config: defaults --- */
    {
       static config_t cfg;

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1083,7 +1083,7 @@
         },
         {
           "path": "src/headers/sandbox.h",
-          "sha256": "3b67469ed83d214c253cb13a53079458e5fff8ea0ac77dc5762b016071ad5d8d"
+          "sha256": "61433cbfd4609047eb897b7d8e00c8d5f736ed5ecc1ff402c3009729d0aff84e"
         },
         {
           "path": "src/headers/script_rpc.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "df9611a9b96bc533e75db05875d9c3e0da2a4cabc1b84871682dcb188d2d1272",
+      "sha256": "a8dcb8178a269d6c08acb4d60d08734d54d78771aec09fa65172fad27a14ccce",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1083,7 +1083,7 @@
         },
         {
           "path": "src/headers/sandbox.h",
-          "sha256": "3b67469ed83d214c253cb13a53079458e5fff8ea0ac77dc5762b016071ad5d8d"
+          "sha256": "61433cbfd4609047eb897b7d8e00c8d5f736ed5ecc1ff402c3009729d0aff84e"
         },
         {
           "path": "src/headers/script_rpc.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "4b89cebb396dc22c054df74968bd9762ef86f7cca8814b5873746fc94216f29f",
+      "sha256": "484304bc91195626897651fd3bcd177cabd315f40b87c82a365c648826f79fd7",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## Summary

Delegates could not run shell commands at all. Root-causing that turned up three separate defects, two of them security-relevant.

The headline: **the namespace sandbox has never worked.** `sandbox.mode` defaulted to OFF, so the code path never ran, so nobody noticed it was broken.

## The defects

**1. A race made every sandboxed command fail.** `setup_userns_maps()` writes `/proc/<pid>/uid_map`, which the kernel permits only once the child is actually inside its new user namespace. `g_sync_pipe` only signalled parent → child, so nothing made the parent wait for the child's `unshare()`. Winning that race, the parent wrote `uid_map` against the initial userns, got EPERM, and `sandbox_exec_internal` returned -1 — surfacing as a bare `"fork failed"`.

Fixed with a child → parent readiness pipe carrying whether `unshare()` succeeded. The parent blocks until the child confirms it is in the new namespace, and skips the map write when the child reports it never got one — which also repairs the non-namespaced fallback, previously dead because the parent failed the exec regardless.

**2. Two settings meaning "sandbox delegates" shipped with opposite defaults.** `delegate_sandbox` defaults ON (`config.c:712`, with a comment stating an unconfigured install isolates delegates). `sandbox.mode` was never assigned a default, so it sat at the `SANDBOX_MODE_OFF` zero value. The fail-closed delegate shell guard in `tool_bash()` reads `sandbox.mode` — so on an unconfigured install it refused **every** co-located delegate shell. The guard is correct; paired with a default-off mode it shipped delegates bricked rather than secured.

`sandbox.mode` now defaults to `WORKSPACE_ONLY`. Opt out with `sandbox: {mode: off}`.

Two supporting changes are required for that opt-out to survive:

- `config_save` persisted the sandbox block only when `mode != OFF`. With the default flipped, that predicate would **drop an explicit `off`** on the next save and silently re-enable the sandbox. It now persists whatever differs from the new default, mirroring `delegate_sandbox`'s persist-only-the-opt-out.
- `sandbox_mode_from_string()` maps any unrecognized string to OFF. Harmless when OFF was also the default; now a typo would **silently disable isolation**. Unknown values warn and keep the default. The loose leading-character match is preserved so existing `workspace` / `allow` configs do not regress.

**3. The refusal message misdiagnosed itself.** It said the sandbox was "off/unavailable", but on Linux that branch tests the configured mode only — `sandbox_available()` is not probed until later, inside `sandbox_exec_internal`. The wording sends readers hunting for a broken kernel setup when the actual state is a config value. It now names `sandbox.mode=off`.

## Test coverage

`test_tool_bash_delegate_unsandboxed_refused` proves containment: a delegate must never run a shell unsandboxed on a uid-0 host with the docker socket mounted. It asserted that via the old default rather than an explicit opt-out, so flipping the default made the branch unreachable — and this binary cannot redirect config in-process, since the config path resolves before a test can move `HOME` (verified: a direct `config_load()` still returned the real user config).

Rather than let that coverage lapse, this adds `sandbox_effective_mode()` and a test-only override mirroring the existing `sandbox_set_available_override_for_test` seam. The test now forces OFF to prove the refusal, and forces WORKSPACE_ONLY to prove the default path contains the delegate by isolation instead — the branch real installs are now on.

## Verification

- `make -C src -j8` — exit 0, zero `error:`. The full build, not just `unit-tests`, which does not compile server translation units.
- Full unit suite — exit 0
- Both re-run after rebasing onto current `testing`, not only before
- `refactor_baselines.py` — drift confirmed additive-only against `origin/testing` (18 insertions, 0 removals in `sandbox.h`), then frozen
- The original `"fork failed"` was reproduced before the fix and confirmed resolved after; a control run with the default reverted isolated the cause

## Notes for the reviewer

The first commit (`533724d723`) is an unrelated design proposal for context paging — it shares this session branch. Happy to split it out if you would rather review these separately.

Deliberately not fixed here: a delegate whose workspace cannot be served still falls through to the co-located host path rather than failing fast. The new default contains that case by isolation rather than refusal, so it stopped being urgent rather than being fixed.

Not yet verified end to end: that delegates can now actually run shells. That requires a deploy, and is the next step.