### PR TITLE
refactor(git): run the PR create in the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -227,7 +227,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "86016ebb8287ca49a606ec0011366f5648849c2a73e3563757c57633eb2f7549",
+      "source_sha256": "db080fd16502a1c7c1f46735e6bb8204dc2496ce48c70ae080111e069cc3c39d",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -3,7 +3,7 @@
 #include "git_pr_api.h"
 
 #include "aimee.h"           /* MAX_PATH_LEN (needed by agent_types.h) */
-#include "agent_exec.h"      /* agent_http_post_content_type */
+#include "agent_exec.h"      /* agent_http_get/put/patch — the ops still on HTTP */
 #include "cJSON.h"           /* request/response JSON */
 #include "git_cred_inject.h" /* git_cred_inject_resolve_token — the ONE cred policy */
 #include "util.h"            /* run_cmd */
@@ -545,56 +545,53 @@ int git_pr_create_via_api_slug(const char *principal, const char *slug, const ch
    if (bclean)
       strip_ai_attribution(bclean);
 
-   cJSON *j = cJSON_CreateObject();
-   cJSON_AddStringToObject(j, "title", title);
-   cJSON_AddStringToObject(j, "head", head);
-   cJSON_AddStringToObject(j, "base", base);
-   cJSON_AddStringToObject(j, "body", bclean ? bclean : "");
-   cJSON_AddBoolToObject(j, "draft", draft ? 1 : 0);
-   free(bclean);
-   char *jbody = cJSON_PrintUnformatted(j);
-   cJSON_Delete(j);
-   if (!jbody)
+   cJSON *extra = cJSON_CreateObject();
+   if (!extra)
    {
+      free(bclean);
       gh_ctx_done(&cx);
       snprintf(err, errlen, "internal error");
       return -1;
    }
+   cJSON_AddStringToObject(extra, "title", title);
+   cJSON_AddStringToObject(extra, "head", head);
+   cJSON_AddStringToObject(extra, "base", base);
+   cJSON_AddStringToObject(extra, "body", bclean ? bclean : "");
+   if (draft)
+      cJSON_AddBoolToObject(extra, "draft", 1);
+   free(bclean);
 
-   char url[512];
-   snprintf(url, sizeof(url), "https://api.github.com/repos/%s/%s/pulls", cx.owner, cx.repo);
-   char auth[PR_TOKEN_MAX + 32];
-   snprintf(auth, sizeof(auth), "Authorization: Bearer %s", cx.token);
-
-   char *resp = NULL;
-   int status =
-       agent_http_post_content_type(url, auth, "application/json", jbody, &resp, 20000, GH_ACCEPT);
-   /* The token only ever lived in aimee-server's memory; wipe both copies now. */
-   wipe(auth, sizeof(auth));
+   cJSON *reply = forge_stage(&cx, "pr_create", extra);
    gh_ctx_done(&cx);
-   free(jbody);
-
-   if (status < 200 || status >= 300 || !resp)
+   if (!reply)
    {
-      gh_err(resp, status, "pr create", err, errlen);
-      free(resp);
+      /* Not a refusal: say the module was unreachable, so a caller does not
+       * record "the forge rejected this PR" for a request never sent. */
+      snprintf(err, errlen, "pr create: the git module could not be reached");
       return -1;
    }
 
-   cJSON *jr = cJSON_Parse(resp);
+   const cJSON *pull = cJSON_GetObjectItemCaseSensitive(reply, "pull");
+   const cJSON *url = pull ? cJSON_GetObjectItemCaseSensitive(pull, "url") : NULL;
+   const cJSON *message = cJSON_GetObjectItemCaseSensitive(reply, "error");
+
    int ok = -1;
-   cJSON *hu = jr ? cJSON_GetObjectItem(jr, "html_url") : NULL;
-   if (cJSON_IsString(hu) && hu->valuestring)
+   if (cJSON_IsString(url) && url->valuestring && url->valuestring[0])
    {
-      snprintf(out, out_cap, "%s", hu->valuestring);
+      snprintf(out, out_cap, "%s", url->valuestring);
       ok = 0;
+   }
+   else if (cJSON_IsString(message) && message->valuestring)
+   {
+      /* The forge's own words -- "A pull request already exists" sends an
+       * operator somewhere useful; "HTTP 422" does not. */
+      snprintf(err, errlen, "%s", message->valuestring);
    }
    else
    {
       snprintf(err, errlen, "github API: unexpected response");
    }
-   cJSON_Delete(jr);
-   free(resp);
+   cJSON_Delete(reply);
    return ok;
 }
 

--- a/src/tests/test_git_pr_stage.c
+++ b/src/tests/test_git_pr_stage.c
@@ -37,6 +37,21 @@ int git_cred_inject_resolve_token(const char *principal, const char *remote_url,
    return 1;
 }
 
+/* The real one lives in util.c, which would drag run_cmd/safe_exec into this
+ * binary for a policy that is tested there. Counting the calls instead keeps the
+ * link small AND pins the thing that actually matters here: the standing
+ * no-AI-attribution strip must still run on the migrated path, before the body
+ * is handed to the stage. Moving code is exactly when such a step gets dropped.
+ */
+static int g_strip_calls;
+
+int strip_ai_attribution(char *text)
+{
+   (void)text;
+   g_strip_calls++;
+   return 0;
+}
+
 /* Any direct HTTP from a migrated op is a bug, so make it loud rather than let
  * the suite pass on a silent fallback. */
 static void http_forbidden(const char *which)
@@ -65,6 +80,20 @@ int agent_http_put(const char *url, const char *auth, const char *body, char **r
    (void)timeout_ms;
    (void)accept;
    http_forbidden("agent_http_put");
+   return -1;
+}
+
+int agent_http_post_content_type(const char *url, const char *auth, const char *content_type,
+                                 const char *body, char **resp, int timeout_ms, const char *accept)
+{
+   (void)url;
+   (void)auth;
+   (void)content_type;
+   (void)body;
+   (void)resp;
+   (void)timeout_ms;
+   (void)accept;
+   http_forbidden("agent_http_post_content_type");
    return -1;
 }
 
@@ -136,6 +165,54 @@ int main(void)
    before = module_bus_stub_calls();
    assert(git_pr_merge_via_api_slug_ex(NULL, SLUG, 0, "merge", NULL, sha, sizeof(sha), err,
                                        sizeof(err)) == -1);
+   assert(module_bus_stub_calls() == before);
+
+   /* --- pr_create ------------------------------------------------------- */
+
+   char urlbuf[512];
+
+   /* The created PR's URL comes from the stage reply's pull summary. */
+   module_bus_stub_reply("{\"status\":201,\"pull\":{\"number\":42,\"url\":"
+                         "\"https://github.com/acme/widgets/pull/42\"}}");
+   g_strip_calls = 0;
+   assert(git_pr_create_via_api_slug(NULL, SLUG, "feat", "testing", "A title", "body", 0, urlbuf,
+                                     sizeof(urlbuf), err, sizeof(err)) == 0);
+   assert(strcmp(urlbuf, "https://github.com/acme/widgets/pull/42") == 0);
+   /* The body was put through the attribution strip on the way to the stage. */
+   assert(g_strip_calls == 1);
+
+   /* A refusal must arrive as the forge's OWN words: "A pull request already
+    * exists" sends an operator somewhere useful, "HTTP 422" does not. */
+   module_bus_stub_reply(
+       "{\"status\":422,\"error\":\"pr create: A pull request already exists (HTTP 422)\"}");
+   assert(git_pr_create_via_api_slug(NULL, SLUG, "feat", "testing", "A title", "body", 0, urlbuf,
+                                     sizeof(urlbuf), err, sizeof(err)) == -1);
+   assert(strstr(err, "already exists") != NULL);
+   assert(urlbuf[0] == '\0'); /* a refused create reports no URL */
+
+   /* A 2xx carrying no URL is not a success: reporting one would hand the caller
+    * an empty link for a PR it cannot confirm was opened. */
+   module_bus_stub_reply("{\"status\":201,\"pull\":{\"number\":42}}");
+   assert(git_pr_create_via_api_slug(NULL, SLUG, "feat", "testing", "A title", "body", 0, urlbuf,
+                                     sizeof(urlbuf), err, sizeof(err)) == -1);
+   assert(err[0] != '\0');
+
+   /* Unreachable module is not a refused create. */
+   module_bus_stub_absent();
+   assert(git_pr_create_via_api_slug(NULL, SLUG, "feat", "testing", "A title", "body", 0, urlbuf,
+                                     sizeof(urlbuf), err, sizeof(err)) == -1);
+   assert(strstr(err, "could not be reached") != NULL);
+
+   /* Without a checkout there is nothing to infer head/base/title from, and
+    * guessing is how a PR lands on the wrong base. Refuse before sending. */
+   module_bus_stub_reply("{\"status\":201,\"pull\":{\"url\":\"u\"}}");
+   before = module_bus_stub_calls();
+   assert(git_pr_create_via_api_slug(NULL, SLUG, "", "testing", "A title", "body", 0, urlbuf,
+                                     sizeof(urlbuf), err, sizeof(err)) == -1);
+   assert(git_pr_create_via_api_slug(NULL, SLUG, "feat", "", "A title", "body", 0, urlbuf,
+                                     sizeof(urlbuf), err, sizeof(err)) == -1);
+   assert(git_pr_create_via_api_slug(NULL, SLUG, "feat", "testing", "", "body", 0, urlbuf,
+                                     sizeof(urlbuf), err, sizeof(err)) == -1);
    assert(module_bus_stub_calls() == before);
 
    printf("git_pr_stage: all tests passed\n");


### PR DESCRIPTION
Third caller onto the `git-forge-request` stage, after the default-branch lookup (#2492) and the merge (#2498).

## What moved

The POST, its request shaping, and the refusal message now come from `server-go/modules/git`. What stays in C is the contract callers rely on: **`0` with the PR's URL in `out`, or `-1` with `err`**.

## What deliberately stayed

**The no-checkout guard.** Without a checkout there is nothing to infer head/base/title from, and guessing is how a PR lands on the wrong base — so it still refuses before anything is sent.

**The attribution strip.** The standing no-AI-attribution policy still runs on the body before it reaches the stage. Dropping a step like that is exactly the risk when moving code, so the test asserts it was applied rather than trusting the diff.

## Failure modes kept distinct

Collapsing these misleads whoever reads the error:

- **unreachable module** → `pr create: the git module could not be reached`, not a refusal. A caller must not record "the forge rejected this PR" for a request never sent.
- **refusal** → the forge's *own* words. `A pull request already exists` sends an operator somewhere useful; `HTTP 422` does not.
- **2xx with no URL** → treated as a failure, not a success with an empty link for a PR we cannot confirm was opened.

## Tests

`test_git_pr_stage` gains the create cases: success and URL extraction, refusal carrying the forge message (and reporting no URL), the empty-URL 2xx, unreachable module, and all three no-checkout guards refusing **before anything is sent** (asserted via the stub's call counter).

Both new HTTP stubs **abort**, which makes this a regression test for the migration itself rather than just the mapping. Verified in both directions:

- pre-migration: `migrated op reached HTTP directly via agent_http_post_content_type`
- post-migration: `git_pr_stage: all tests passed`

`strip_ai_attribution` is stubbed as a *counter* rather than linked from `util.c` — that would drag `run_cmd`/`safe_exec` into the binary for a policy tested there, and counting pins the thing that matters here (that it still runs).

## Verification

- `make -C src -j8` — clean
- `make -C src unit-tests` — green (re-run after the new link deps)
- `make -C src lint` — all 48 checks passed, run **before** pushing this time
- Whole `pins` job locally: contracts, runtime bundle, lock check, `go test ./bus ./modules/... ./cmd/aimee-module`, module supervisor — all ok
- Lock repinned via the exporter's own digest functions; `git` is the only module that moved

Remaining callers for this seam: info, find/list.