### PR TITLE
refactor(delegates): handoff validation moves into the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e76e59705a9c8552919ea6250c18e3423dacdf38472eeccce4385fd03d256206",
+      "source_sha256": "fa6ade2c69ea6875fb5497aecb4ffc29d3a1ee7ae0d8a15dca8dcc3c0e60ac9c",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
@@ -173,7 +173,8 @@
         6657,
         6658,
         6659,
-        6660
+        6660,
+        6661
       ]
     },
     {

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -106,6 +106,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: delegates.EventCapabilities, StageID: delegates.StageCapabilities},
 			{EventKind: delegates.EventChain, StageID: delegates.StageChain},
 			{EventKind: delegates.EventPaths, StageID: delegates.StagePaths},
+			{EventKind: delegates.EventHandoff, StageID: delegates.StageHandoff},
 		}
 		config.Handler = delegates.Handle
 	case "tools":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -15,7 +15,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657, 6658, 6659, 6660}},
+		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7430}},

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -38,6 +38,9 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 	if invocation.StageID == StagePaths {
 		return handlePaths(invocation, request)
 	}
+	if invocation.StageID == StageHandoff {
+		return handleHandoff(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/server-go/modules/delegates/handoff.go
+++ b/server-go/modules/delegates/handoff.go
@@ -1,0 +1,249 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"strings"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Whether a delegate's structured handoff can be believed.
+//
+// A delegate reports what it did as JSON. This decides whether that report is
+// well-formed, and then whether it can be taken at face value: one that edited
+// files it was not given, or claims "done" with nothing verified, is downgraded
+// rather than trusted. Both downgrades exist because the delegate is grading its
+// own work.
+
+const (
+	StageHandoff uint32 = 5
+	EventHandoff uint32 = 6661
+
+	handoffRequestMagic  uint32 = 0x444e4844 /* "DHND" */
+	handoffResponseMagic uint32 = 0x564e4844 /* "DHNV" */
+	handoffHeaderLen            = 16
+	handoffStatusLen            = 32
+	handoffErrorLen             = 256
+	handoffResponseLen          = 36 + handoffStatusLen*2 + handoffErrorLen
+	handoffTextMax              = 1 << 20
+
+	statusNeedsReview = "needs_supervisor_review"
+)
+
+// HandoffVerdict mirrors delegate_handoff_validation_t.
+type HandoffVerdict struct {
+	Valid                   bool
+	RepairAttempted         bool
+	DoneWithoutVerification bool
+	NeedsSupervisorReview   bool
+	ChangedFilesCount       int
+	OutsideOwnershipCount   int
+	PassedTests             int
+	CommandsRun             int
+	Status                  string
+	RawStatus               string
+	Error                   string
+}
+
+func (v *HandoffVerdict) fail(msg string) {
+	v.Error = msg
+	v.Status = statusNeedsReview
+	v.NeedsSupervisorReview = true
+}
+
+func statusAllowed(s string) bool {
+	switch s {
+	case "done", "partial", "blocked", "failed":
+		return true
+	}
+	return false
+}
+
+// countNonEmptyStrings ignores blank entries: a blank names no file and is not
+// evidence of one.
+func countNonEmptyStrings(raw []any) int {
+	n := 0
+	for _, item := range raw {
+		if s, ok := item.(string); ok && s != "" {
+			n++
+		}
+	}
+	return n
+}
+
+func containsString(raw []any, needle string) bool {
+	if needle == "" {
+		return false
+	}
+	for _, item := range raw {
+		if s, ok := item.(string); ok && s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// passedTestCount accepts both "passed" and "pass": delegates write either, and
+// rejecting one spelling would read a verified run as unverified.
+func passedTestCount(raw []any) int {
+	n := 0
+	for _, item := range raw {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if s, ok := obj["status"].(string); ok && (s == "passed" || s == "pass") {
+			n++
+		}
+	}
+	return n
+}
+
+// outsideOwnedCount counts edits the delegate was not entitled to make: what it
+// admitted to, plus anything it changed that its ownership list does not cover
+// and it did not already declare. An absent or empty ownership list means
+// ownership was never scoped, so only admitted touches count -- inferring
+// violations from a missing list would flag every ordinary run.
+func outsideOwnedCount(changed, outside, owned []any, ownedPresent bool) int {
+	count := countNonEmptyStrings(outside)
+	if !ownedPresent || len(owned) == 0 {
+		return count
+	}
+	for _, item := range changed {
+		s, ok := item.(string)
+		if !ok || s == "" {
+			continue
+		}
+		if !containsString(owned, s) && !containsString(outside, s) {
+			count++
+		}
+	}
+	return count
+}
+
+func asArray(v any) ([]any, bool) {
+	arr, ok := v.([]any)
+	return arr, ok
+}
+
+// ValidateHandoff parses a delegate's handoff and judges it. ok=false means the
+// report is malformed, which is a different thing from a well-formed report that
+// must not be trusted; the caller needs those apart.
+func ValidateHandoff(text, ownedFilesJSON string, requireVerification bool) (v HandoffVerdict, ok bool) {
+	v.Status = statusNeedsReview
+
+	if text == "" {
+		v.fail("empty delegate handoff")
+		return v, false
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(text), &root); err != nil || root == nil {
+		v.fail("handoff is not valid JSON object")
+		return v, false
+	}
+	if s, isString := root["schema_version"].(string); !isString || s != "delegate_result_v1" {
+		v.fail("missing schema_version delegate_result_v1")
+		return v, false
+	}
+	status, isString := root["status"].(string)
+	if !isString || !statusAllowed(status) {
+		v.fail("invalid handoff status")
+		return v, false
+	}
+	v.RawStatus = status
+	v.Status = status
+
+	changed, changedOK := asArray(root["changed_files"])
+	tests, testsOK := asArray(root["tests"])
+	summary, summaryOK := root["summary"].(string)
+	supervisor, supervisorPresent := root["supervisor_actions"]
+	_, supervisorIsArray := asArray(supervisor)
+	if !changedOK || !testsOK || (supervisorPresent && supervisor != nil && !supervisorIsArray) ||
+		!summaryOK || strings.TrimSpace(summary) == "" {
+		v.fail("handoff missing required fields")
+		return v, false
+	}
+
+	commands, _ := asArray(root["commands_run"])
+	outside, _ := asArray(root["outside_ownership_touches"])
+	v.ChangedFilesCount = countNonEmptyStrings(changed)
+	v.CommandsRun = len(commands)
+	v.PassedTests = passedTestCount(tests)
+
+	var owned []any
+	ownedPresent := false
+	if ownedFilesJSON != "" {
+		if err := json.Unmarshal([]byte(ownedFilesJSON), &owned); err == nil {
+			ownedPresent = true
+		}
+	}
+	v.OutsideOwnershipCount = outsideOwnedCount(changed, outside, owned, ownedPresent)
+
+	v.Valid = true
+	switch {
+	case v.OutsideOwnershipCount > 0:
+		v.Status = statusNeedsReview
+		v.Error = "handoff touched files outside owned_files"
+		v.NeedsSupervisorReview = true
+	case v.RawStatus == "done" && requireVerification && v.PassedTests == 0:
+		// A delegate grading its own work does not get to call it done with
+		// nothing green. Downgraded, not rejected: the work may be fine, but it
+		// is unverified and must be read that way.
+		v.Status = "partial"
+		v.Error = "status=done without passed focused verification; downgraded to partial"
+		v.DoneWithoutVerification = true
+	}
+	return v, true
+}
+
+func putBool(dst []byte, b bool) {
+	if b {
+		binary.LittleEndian.PutUint32(dst, 1)
+	}
+}
+
+func putFixed(dst []byte, s string) {
+	if len(s) >= len(dst) {
+		s = s[:len(dst)-1]
+	}
+	copy(dst, s)
+}
+
+func handleHandoff(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if len(request) < handoffHeaderLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != handoffRequestMagic ||
+		request[4] != wireVersion || request[5] > 1 {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	textLen := int(binary.LittleEndian.Uint32(request[8:12]))
+	ownedLen := int(binary.LittleEndian.Uint32(request[12:16]))
+	if textLen > handoffTextMax || ownedLen > handoffTextMax ||
+		len(request) != handoffHeaderLen+textLen+ownedLen {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	text := string(request[handoffHeaderLen : handoffHeaderLen+textLen])
+	owned := string(request[handoffHeaderLen+textLen:])
+	verdict, _ := ValidateHandoff(text, owned, request[5] == 1)
+
+	// A malformed handoff is a verdict, not a transport failure: the caller
+	// needs the reason, and the reason travels in the body.
+	response := make([]byte, handoffResponseLen)
+	binary.LittleEndian.PutUint32(response[0:4], handoffResponseMagic)
+	putBool(response[4:8], verdict.Valid)
+	putBool(response[8:12], verdict.RepairAttempted)
+	putBool(response[12:16], verdict.DoneWithoutVerification)
+	putBool(response[16:20], verdict.NeedsSupervisorReview)
+	binary.LittleEndian.PutUint32(response[20:24], uint32(verdict.ChangedFilesCount))
+	binary.LittleEndian.PutUint32(response[24:28], uint32(verdict.OutsideOwnershipCount))
+	binary.LittleEndian.PutUint32(response[28:32], uint32(verdict.PassedTests))
+	binary.LittleEndian.PutUint32(response[32:36], uint32(verdict.CommandsRun))
+	putFixed(response[36:36+handoffStatusLen], verdict.Status)
+	putFixed(response[36+handoffStatusLen:36+2*handoffStatusLen], verdict.RawStatus)
+	putFixed(response[36+2*handoffStatusLen:], verdict.Error)
+	return response, bus.ModuleStatusOK
+}

--- a/server-go/modules/delegates/handoff_test.go
+++ b/server-go/modules/delegates/handoff_test.go
@@ -1,0 +1,216 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+const validHandoff = `{"schema_version":"delegate_result_v1","status":"done",` +
+	`"changed_files":["src/foo.c"],"outside_ownership_touches":[],` +
+	`"tests":[{"name":"unit-test-foo","status":"passed"}],` +
+	`"commands_run":["make unit-tests"],"supervisor_actions":[],` +
+	`"summary":"Did the thing."}`
+
+func handoffRequest(text, owned string, requireVerification bool) []byte {
+	request := make([]byte, handoffHeaderLen+len(text)+len(owned))
+	binary.LittleEndian.PutUint32(request[0:4], handoffRequestMagic)
+	request[4] = wireVersion
+	if requireVerification {
+		request[5] = 1
+	}
+	binary.LittleEndian.PutUint32(request[8:12], uint32(len(text)))
+	binary.LittleEndian.PutUint32(request[12:16], uint32(len(owned)))
+	copy(request[handoffHeaderLen:], text)
+	copy(request[handoffHeaderLen+len(text):], owned)
+	return request
+}
+
+func decodeFixed(b []byte) string {
+	if i := strings.IndexByte(string(b), 0); i >= 0 {
+		return string(b[:i])
+	}
+	return string(b)
+}
+
+func handoffCall(t *testing.T, text, owned string, requireVerification bool) HandoffVerdict {
+	t.Helper()
+	response, status := Handle(bus.ModuleInvocation{StageID: StageHandoff},
+		handoffRequest(text, owned, requireVerification))
+	if status != bus.ModuleStatusOK || len(response) != handoffResponseLen ||
+		binary.LittleEndian.Uint32(response[0:4]) != handoffResponseMagic {
+		t.Fatalf("response len %d status %d", len(response), status)
+	}
+	return HandoffVerdict{
+		Valid:                   binary.LittleEndian.Uint32(response[4:8]) == 1,
+		RepairAttempted:         binary.LittleEndian.Uint32(response[8:12]) == 1,
+		DoneWithoutVerification: binary.LittleEndian.Uint32(response[12:16]) == 1,
+		NeedsSupervisorReview:   binary.LittleEndian.Uint32(response[16:20]) == 1,
+		ChangedFilesCount:       int(binary.LittleEndian.Uint32(response[20:24])),
+		OutsideOwnershipCount:   int(binary.LittleEndian.Uint32(response[24:28])),
+		PassedTests:             int(binary.LittleEndian.Uint32(response[28:32])),
+		CommandsRun:             int(binary.LittleEndian.Uint32(response[32:36])),
+		Status:                  decodeFixed(response[36 : 36+handoffStatusLen]),
+		RawStatus:               decodeFixed(response[36+handoffStatusLen : 36+2*handoffStatusLen]),
+		Error:                   decodeFixed(response[36+2*handoffStatusLen:]),
+	}
+}
+
+// Ported from test_delegate_handoff.c.
+func TestValidHandoffParses(t *testing.T) {
+	v := handoffCall(t, validHandoff, `["src/foo.c"]`, true)
+	if !v.Valid || v.Status != "done" || v.RawStatus != "done" {
+		t.Fatalf("verdict = %+v", v)
+	}
+	if v.ChangedFilesCount != 1 || v.CommandsRun != 1 || v.PassedTests != 1 {
+		t.Errorf("counts = %d/%d/%d, want 1/1/1", v.ChangedFilesCount, v.CommandsRun, v.PassedTests)
+	}
+	if v.OutsideOwnershipCount != 0 || v.NeedsSupervisorReview {
+		t.Errorf("clean handoff flagged: %+v", v)
+	}
+}
+
+func TestMalformedHandoffsAreRejectedWithAReason(t *testing.T) {
+	cases := []struct {
+		name, text, wantErr string
+	}{
+		{"empty", "", "empty delegate handoff"},
+		{"not json", "not json at all", "not valid JSON object"},
+		{"wrong schema", `{"schema_version":"v2","status":"done"}`, "delegate_result_v1"},
+		{"unknown status",
+			`{"schema_version":"delegate_result_v1","status":"finished"}`, "invalid handoff status"},
+		{"missing arrays",
+			`{"schema_version":"delegate_result_v1","status":"done","summary":"x"}`,
+			"missing required fields"},
+		// A summary of only whitespace says nothing; same as absent.
+		{"blank summary",
+			`{"schema_version":"delegate_result_v1","status":"done","changed_files":[],` +
+				`"tests":[],"summary":"   "}`, "missing required fields"},
+	}
+	for _, c := range cases {
+		v := handoffCall(t, c.text, "", true)
+		if v.Valid {
+			t.Errorf("%s: accepted", c.name)
+		}
+		if !strings.Contains(v.Error, c.wantErr) {
+			t.Errorf("%s: error = %q, want it to mention %q", c.name, v.Error, c.wantErr)
+		}
+		// Every rejection routes to a human rather than passing silently.
+		if v.Status != statusNeedsReview || !v.NeedsSupervisorReview {
+			t.Errorf("%s: status = %q, want supervisor review", c.name, v.Status)
+		}
+	}
+}
+
+// supervisor_actions is optional, but a non-array is malformed rather than absent.
+func TestSupervisorActionsOptionalButTyped(t *testing.T) {
+	without := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":["src/foo.c"],"tests":[{"status":"passed"}],"summary":"ok"}`
+	if v := handoffCall(t, without, "", true); !v.Valid {
+		t.Errorf("absent supervisor_actions rejected: %q", v.Error)
+	}
+	wrongType := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":[],"tests":[],"supervisor_actions":"nope","summary":"ok"}`
+	if v := handoffCall(t, wrongType, "", true); v.Valid {
+		t.Error("a non-array supervisor_actions was accepted")
+	}
+}
+
+// A delegate does not get to call its own work done with nothing green.
+func TestDoneWithoutVerificationDowngrades(t *testing.T) {
+	unverified := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":["src/foo.c"],"tests":[],"supervisor_actions":[],"summary":"ok"}`
+
+	v := handoffCall(t, unverified, "", true)
+	if !v.Valid || v.Status != "partial" || !v.DoneWithoutVerification {
+		t.Errorf("verdict = %+v, want a partial downgrade", v)
+	}
+
+	v = handoffCall(t, unverified, "", false)
+	if v.Status != "done" || v.DoneWithoutVerification {
+		t.Errorf("verdict = %+v, want done when verification is not required", v)
+	}
+}
+
+// Both spellings are written by delegates; rejecting one would read a verified
+// run as unverified and downgrade it wrongly.
+func TestBothPassSpellingsCount(t *testing.T) {
+	for _, spelling := range []string{"pass", "passed"} {
+		text := `{"schema_version":"delegate_result_v1","status":"done",` +
+			`"changed_files":[],"tests":[{"status":"` + spelling + `"}],"summary":"ok"}`
+		if v := handoffCall(t, text, "", true); v.PassedTests != 1 || v.DoneWithoutVerification {
+			t.Errorf("%q: passed=%d downgraded=%v", spelling, v.PassedTests,
+				v.DoneWithoutVerification)
+		}
+	}
+}
+
+func TestOutsideOwnershipNeedsReview(t *testing.T) {
+	text := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":["src/foo.c","src/bar.c"],"outside_ownership_touches":[],` +
+		`"tests":[{"name":"unit-test-foo","status":"passed"}],"supervisor_actions":[],` +
+		`"summary":"Touched one extra file."}`
+	v := handoffCall(t, text, `["src/foo.c"]`, true)
+	if !v.Valid || v.Status != statusNeedsReview || !v.NeedsSupervisorReview {
+		t.Fatalf("verdict = %+v", v)
+	}
+	if v.OutsideOwnershipCount != 1 || !strings.Contains(v.Error, "outside owned_files") {
+		t.Errorf("count = %d, error = %q", v.OutsideOwnershipCount, v.Error)
+	}
+}
+
+// A file the delegate ADMITTED touching counts once, not twice for also being
+// in changed_files.
+func TestAdmittedTouchCountsOnce(t *testing.T) {
+	text := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":["src/foo.c","src/bar.c"],"outside_ownership_touches":["src/bar.c"],` +
+		`"tests":[{"status":"passed"}],"summary":"ok"}`
+	if v := handoffCall(t, text, `["src/foo.c"]`, true); v.OutsideOwnershipCount != 1 {
+		t.Errorf("count = %d, want 1", v.OutsideOwnershipCount)
+	}
+}
+
+// With no ownership list, ownership was never scoped: inferring violations from
+// an absent list would flag every ordinary run.
+func TestUnscopedOwnershipCountsOnlyAdmittedTouches(t *testing.T) {
+	text := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":["src/a.c","src/b.c"],"outside_ownership_touches":[],` +
+		`"tests":[{"status":"passed"}],"summary":"ok"}`
+	for _, owned := range []string{"", "[]"} {
+		v := handoffCall(t, text, owned, true)
+		if v.OutsideOwnershipCount != 0 || v.NeedsSupervisorReview {
+			t.Errorf("owned=%q: count = %d, review = %v", owned, v.OutsideOwnershipCount,
+				v.NeedsSupervisorReview)
+		}
+	}
+}
+
+// Ownership outranks the verification downgrade: both apply, and the operator
+// needs the more serious one.
+func TestOwnershipOutranksTheVerificationDowngrade(t *testing.T) {
+	text := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":["src/bar.c"],"outside_ownership_touches":[],"tests":[],` +
+		`"summary":"ok"}`
+	v := handoffCall(t, text, `["src/foo.c"]`, true)
+	if v.Status != statusNeedsReview || v.DoneWithoutVerification {
+		t.Errorf("verdict = %+v, want the ownership verdict to win", v)
+	}
+}
+
+func TestHandoffRejectsInvalidEnvelope(t *testing.T) {
+	short := handoffRequest(validHandoff, "", true)[:handoffHeaderLen-1]
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageHandoff}, short); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("truncated status = %d", status)
+	}
+	lying := handoffRequest(validHandoff, "", true)
+	binary.LittleEndian.PutUint32(lying[8:12], 9999)
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageHandoff}, lying); status != bus.ModuleStatusInvalidRequest {
+		t.Fatalf("length-mismatch status = %d", status)
+	}
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageHandoff, DeadlineNS: 1},
+		handoffRequest(validHandoff, "", true)); status != bus.ModuleStatusCancelled {
+		t.Fatalf("expired status = %d", status)
+	}
+}

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -102,6 +102,13 @@ char *delegate_handoff_repair_prompt(const char *previous_response, const char *
  * JSON array, changed files outside that list are reported as supervisor-review
  * items.  If |require_verification| is true, status=done without a passed test is
  * downgraded to partial in |out->status|. */
+/* Fills *out and returns 0 when the module answered, non-zero when it could
+ * not or the handoff was malformed. */
+typedef int (*delegate_handoff_provider_fn)(const char *text, const char *owned_files_json,
+                                            int require_verification,
+                                            delegate_handoff_validation_t *out);
+void delegate_register_handoff_provider(delegate_handoff_provider_fn provider);
+
 int delegate_handoff_validate_text(const char *text, const char *owned_files_json,
                                    int require_verification, delegate_handoff_validation_t *out);
 

--- a/src/modules/delegates/delegate_prompt.c
+++ b/src/modules/delegates/delegate_prompt.c
@@ -52,100 +52,11 @@ int delegate_resolve_prompt_inputs(const char *cli_prompt, const char *file_prom
    return -1;
 }
 
-static void handoff_set_error(delegate_handoff_validation_t *out, const char *msg)
-{
-   if (!out)
-      return;
-   snprintf(out->error, sizeof(out->error), "%s", msg ? msg : "invalid handoff");
-   snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
-   out->needs_supervisor_review = 1;
-}
+static delegate_handoff_provider_fn g_handoff_provider;
 
-static int handoff_status_allowed(const char *status)
+void delegate_register_handoff_provider(delegate_handoff_provider_fn provider)
 {
-   return status && (strcmp(status, "done") == 0 || strcmp(status, "partial") == 0 ||
-                     strcmp(status, "blocked") == 0 || strcmp(status, "failed") == 0);
-}
-
-static int json_array_string_count(cJSON *arr)
-{
-   if (!cJSON_IsArray(arr))
-      return 0;
-   int count = 0;
-   cJSON *item;
-   cJSON_ArrayForEach(item, arr)
-   {
-      if (cJSON_IsString(item) && item->valuestring[0])
-         count++;
-   }
-   return count;
-}
-
-static int json_array_entry_count(cJSON *arr)
-{
-   return cJSON_IsArray(arr) ? cJSON_GetArraySize(arr) : 0;
-}
-
-static int json_array_contains_string(cJSON *arr, const char *needle)
-{
-   if (!cJSON_IsArray(arr) || !needle || !needle[0])
-      return 0;
-   cJSON *item;
-   cJSON_ArrayForEach(item, arr)
-   {
-      if (cJSON_IsString(item) && strcmp(item->valuestring, needle) == 0)
-         return 1;
-   }
-   return 0;
-}
-
-static int handoff_passed_test_count(cJSON *tests)
-{
-   if (!cJSON_IsArray(tests))
-      return 0;
-   int passed = 0;
-   cJSON *item;
-   cJSON_ArrayForEach(item, tests)
-   {
-      if (!cJSON_IsObject(item))
-         continue;
-      cJSON *status = cJSON_GetObjectItemCaseSensitive(item, "status");
-      if (cJSON_IsString(status) &&
-          (strcmp(status->valuestring, "passed") == 0 || strcmp(status->valuestring, "pass") == 0))
-         passed++;
-   }
-   return passed;
-}
-
-static int handoff_outside_owned_count(cJSON *changed, cJSON *outside, cJSON *owned)
-{
-   int count = json_array_string_count(outside);
-   if (!cJSON_IsArray(changed) || !cJSON_IsArray(owned) || cJSON_GetArraySize(owned) == 0)
-      return count;
-
-   cJSON *item;
-   cJSON_ArrayForEach(item, changed)
-   {
-      if (!cJSON_IsString(item) || !item->valuestring[0])
-         continue;
-      if (!json_array_contains_string(owned, item->valuestring) &&
-          !json_array_contains_string(outside, item->valuestring))
-         count++;
-   }
-   return count;
-}
-
-static int handoff_string_blank(const char *s)
-{
-   if (!s)
-      return 1;
-   while (*s)
-   {
-      if (*s != ' ' && *s != '\t' && *s != '\n' && *s != '\r')
-         return 0;
-      s++;
-   }
-   return 1;
+   g_handoff_provider = provider;
 }
 
 char *delegate_handoff_append_contract(const char *prompt, const char *packet_id)
@@ -195,6 +106,15 @@ char *delegate_handoff_repair_prompt(const char *previous_response, const char *
    return out;
 }
 
+/* Whether a delegate's report can be believed is the delegates module's rule.
+ * It was ~150 lines here -- schema and status admission, required-field shape,
+ * the passed-test count, and the two downgrades -- and it is stated once, in
+ * the module, now.
+ *
+ * Fails closed as NEEDS-REVIEW. With no answer the handoff is neither accepted
+ * nor silently dropped: it goes to a human. Treating an unanswerable check as
+ * "valid" would let an unverified delegate report through, which is the exact
+ * thing the two downgrades exist to prevent. */
 int delegate_handoff_validate_text(const char *text, const char *owned_files_json,
                                    int require_verification, delegate_handoff_validation_t *out)
 {
@@ -203,78 +123,14 @@ int delegate_handoff_validate_text(const char *text, const char *owned_files_jso
    memset(out, 0, sizeof(*out));
    snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
 
-   if (!text || !text[0])
+   if (!g_handoff_provider)
    {
-      handoff_set_error(out, "empty delegate handoff");
-      return -1;
-   }
-
-   cJSON *root = cJSON_Parse(text);
-   if (!cJSON_IsObject(root))
-   {
-      cJSON_Delete(root);
-      handoff_set_error(out, "handoff is not valid JSON object");
-      return -1;
-   }
-
-   cJSON *schema = cJSON_GetObjectItemCaseSensitive(root, "schema_version");
-   if (!cJSON_IsString(schema) || strcmp(schema->valuestring, "delegate_result_v1") != 0)
-   {
-      cJSON_Delete(root);
-      handoff_set_error(out, "missing schema_version delegate_result_v1");
-      return -1;
-   }
-
-   cJSON *status = cJSON_GetObjectItemCaseSensitive(root, "status");
-   if (!cJSON_IsString(status) || !handoff_status_allowed(status->valuestring))
-   {
-      cJSON_Delete(root);
-      handoff_set_error(out, "invalid handoff status");
-      return -1;
-   }
-   snprintf(out->raw_status, sizeof(out->raw_status), "%s", status->valuestring);
-   snprintf(out->status, sizeof(out->status), "%s", status->valuestring);
-
-   cJSON *changed = cJSON_GetObjectItemCaseSensitive(root, "changed_files");
-   cJSON *tests = cJSON_GetObjectItemCaseSensitive(root, "tests");
-   cJSON *supervisor = cJSON_GetObjectItemCaseSensitive(root, "supervisor_actions");
-   cJSON *summary = cJSON_GetObjectItemCaseSensitive(root, "summary");
-   if (!cJSON_IsArray(changed) || !cJSON_IsArray(tests) ||
-       (supervisor && !cJSON_IsArray(supervisor)) || !cJSON_IsString(summary) ||
-       handoff_string_blank(summary->valuestring))
-   {
-      cJSON_Delete(root);
-      handoff_set_error(out, "handoff missing required fields");
-      return -1;
-   }
-
-   cJSON *commands = cJSON_GetObjectItemCaseSensitive(root, "commands_run");
-   cJSON *outside = cJSON_GetObjectItemCaseSensitive(root, "outside_ownership_touches");
-   out->changed_files_count = json_array_string_count(changed);
-   out->commands_run = json_array_entry_count(commands);
-   out->passed_tests = handoff_passed_test_count(tests);
-
-   cJSON *owned = owned_files_json && owned_files_json[0] ? cJSON_Parse(owned_files_json) : NULL;
-   out->outside_ownership_count = handoff_outside_owned_count(changed, outside, owned);
-   cJSON_Delete(owned);
-
-   out->valid = 1;
-   if (out->outside_ownership_count > 0)
-   {
-      snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
-      snprintf(out->error, sizeof(out->error), "%s", "handoff touched files outside owned_files");
-      out->needs_supervisor_review = 1;
-   }
-   else if (strcmp(out->raw_status, "done") == 0 && require_verification && out->passed_tests == 0)
-   {
-      snprintf(out->status, sizeof(out->status), "%s", "partial");
       snprintf(out->error, sizeof(out->error), "%s",
-               "status=done without passed focused verification; downgraded to partial");
-      out->done_without_verification = 1;
+               "handoff cannot be validated (delegates module unavailable)");
+      out->needs_supervisor_review = 1;
+      return -1;
    }
-
-   cJSON_Delete(root);
-   return 0;
+   return g_handoff_provider(text, owned_files_json, require_verification, out);
 }
 
 void delegate_handoff_add_validation_json(cJSON *obj, const delegate_handoff_validation_t *v)

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -209,4 +209,55 @@ static inline int aimee_delegates_paths_response_decode(const uint8_t *in, size_
    return (int)count;
 }
 
+/* Handoff validation: whether a delegate's structured report can be believed.
+ * The rule lives only in the Go module; there is no C mirror. */
+#define AIMEE_DELEGATES_EVENT_HANDOFF          6661u
+#define AIMEE_DELEGATES_STAGE_HANDOFF          5u
+#define AIMEE_DELEGATES_HANDOFF_REQUEST_MAGIC  0x444e4844u /* "DHND" */
+#define AIMEE_DELEGATES_HANDOFF_RESPONSE_MAGIC 0x564e4844u /* "DHNV" */
+#define AIMEE_DELEGATES_HANDOFF_HEADER_LEN     16u
+#define AIMEE_DELEGATES_HANDOFF_STATUS_LEN     32u
+#define AIMEE_DELEGATES_HANDOFF_ERROR_LEN      256u
+#define AIMEE_DELEGATES_HANDOFF_RESPONSE_LEN                                                       \
+   (4u + 8u * 4u + AIMEE_DELEGATES_HANDOFF_STATUS_LEN * 2u + AIMEE_DELEGATES_HANDOFF_ERROR_LEN)
+#define AIMEE_DELEGATES_HANDOFF_TEXT_MAX (1u << 20)
+
+static inline size_t aimee_delegates_handoff_request_encode(const char *text, size_t text_len,
+                                                            const char *owned, size_t owned_len,
+                                                            int require_verification, uint8_t *out,
+                                                            size_t cap)
+{
+   if (!out || text_len > AIMEE_DELEGATES_HANDOFF_TEXT_MAX ||
+       owned_len > AIMEE_DELEGATES_HANDOFF_TEXT_MAX ||
+       cap < AIMEE_DELEGATES_HANDOFF_HEADER_LEN + text_len + owned_len)
+      return 0;
+   memset(out, 0, AIMEE_DELEGATES_HANDOFF_HEADER_LEN);
+   aimee_delegates_put_u32(out, AIMEE_DELEGATES_HANDOFF_REQUEST_MAGIC);
+   out[4] = (uint8_t)AIMEE_DELEGATES_WIRE_VERSION;
+   out[5] = require_verification ? 1u : 0u;
+   aimee_delegates_put_u32(out + 8, (uint32_t)text_len);
+   aimee_delegates_put_u32(out + 12, (uint32_t)owned_len);
+   if (text_len)
+      memcpy(out + AIMEE_DELEGATES_HANDOFF_HEADER_LEN, text, text_len);
+   if (owned_len)
+      memcpy(out + AIMEE_DELEGATES_HANDOFF_HEADER_LEN + text_len, owned, owned_len);
+   return AIMEE_DELEGATES_HANDOFF_HEADER_LEN + text_len + owned_len;
+}
+
+/* Copy one fixed-width, NUL-padded field out of the response. */
+static inline void aimee_delegates_handoff_field(const uint8_t *in, size_t at, size_t width,
+                                                 char *out, size_t cap)
+{
+   size_t n = 0;
+   while (n < width && in[at + n] != 0)
+      ++n;
+   if (n >= cap)
+      n = cap ? cap - 1 : 0;
+   if (cap)
+   {
+      memcpy(out, in + at, n);
+      out[n] = '\0';
+   }
+}
+
 #endif

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -74,14 +74,16 @@
     "server-go/modules/delegates/plane/helpers.go",
     "server-go/modules/delegates/capabilities.go",
     "server-go/modules/delegates/chain.go",
-    "server-go/modules/delegates/paths.go"
+    "server-go/modules/delegates/paths.go",
+    "server-go/modules/delegates/handoff.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
     "server-go/modules/delegates/plane/client_test.go",
     "server-go/modules/delegates/capabilities_test.go",
     "server-go/modules/delegates/chain_test.go",
-    "server-go/modules/delegates/paths_test.go"
+    "server-go/modules/delegates/paths_test.go",
+    "server-go/modules/delegates/handoff_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -146,6 +146,11 @@
           "id": 4,
           "name": "delegate-named-paths",
           "event_kind": 6660
+        },
+        {
+          "id": 5,
+          "name": "delegate-handoff-validation",
+          "event_kind": 6661
         }
       ]
     },

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -350,6 +350,55 @@ static int delegate_paths(const char *prompt, unsigned max_paths, char *paths, s
    return rc;
 }
 
+static int delegate_handoff(const char *text, const char *owned_files_json,
+                            int require_verification, delegate_handoff_validation_t *out)
+{
+   size_t text_len = text ? strlen(text) : 0;
+   size_t owned_len = owned_files_json ? strlen(owned_files_json) : 0;
+   if (text_len > AIMEE_DELEGATES_HANDOFF_TEXT_MAX || owned_len > AIMEE_DELEGATES_HANDOFF_TEXT_MAX)
+      return -1;
+   size_t request_cap = AIMEE_DELEGATES_HANDOFF_HEADER_LEN + text_len + owned_len;
+   uint8_t *request = malloc(request_cap);
+   if (!request)
+      return -1;
+   size_t request_len = aimee_delegates_handoff_request_encode(
+       text, text_len, owned_files_json, owned_len, require_verification, request, request_cap);
+
+   uint8_t response[AIMEE_DELEGATES_HANDOFF_RESPONSE_LEN];
+   uint32_t response_len = 0;
+   int rc =
+       request_len > 0 &&
+               call_module(AIMEE_DELEGATES_EVENT_HANDOFF, AIMEE_DELEGATES_STAGE_HANDOFF, request,
+                           (uint32_t)request_len, response, sizeof(response), &response_len) == 0
+           ? 0
+           : -1;
+   free(request);
+   if (rc != 0 || response_len != AIMEE_DELEGATES_HANDOFF_RESPONSE_LEN ||
+       aimee_delegates_get_u32(response) != AIMEE_DELEGATES_HANDOFF_RESPONSE_MAGIC)
+      return -1;
+
+   out->valid = (int)aimee_delegates_get_u32(response + 4);
+   out->repair_attempted = (int)aimee_delegates_get_u32(response + 8);
+   out->done_without_verification = (int)aimee_delegates_get_u32(response + 12);
+   out->needs_supervisor_review = (int)aimee_delegates_get_u32(response + 16);
+   out->changed_files_count = (int)aimee_delegates_get_u32(response + 20);
+   out->outside_ownership_count = (int)aimee_delegates_get_u32(response + 24);
+   out->passed_tests = (int)aimee_delegates_get_u32(response + 28);
+   out->commands_run = (int)aimee_delegates_get_u32(response + 32);
+   aimee_delegates_handoff_field(response, 36, AIMEE_DELEGATES_HANDOFF_STATUS_LEN, out->status,
+                                 sizeof(out->status));
+   aimee_delegates_handoff_field(response, 36 + AIMEE_DELEGATES_HANDOFF_STATUS_LEN,
+                                 AIMEE_DELEGATES_HANDOFF_STATUS_LEN, out->raw_status,
+                                 sizeof(out->raw_status));
+   aimee_delegates_handoff_field(response, 36 + 2 * AIMEE_DELEGATES_HANDOFF_STATUS_LEN,
+                                 AIMEE_DELEGATES_HANDOFF_ERROR_LEN, out->error, sizeof(out->error));
+   /* A malformed handoff is a verdict, not a transport failure: the module
+    * answered, and the answer is "not valid". The caller distinguishes the two
+    * by the return code, so an invalid handoff must report non-zero here while
+    * still carrying its reason in *out. */
+   return out->valid ? 0 : -1;
+}
+
 static int tool_classify(const char *name, int *classification)
 {
    uint8_t request[AIMEE_TOOLS_REQUEST_LEN], response[AIMEE_TOOLS_RESPONSE_LEN];
@@ -560,6 +609,7 @@ void server_module_stage_adapters_configure(void)
    delegate_routing_register_capability_provider(delegate_infer_caps);
    delegate_register_chain_provider(delegate_chain);
    delegate_register_paths_provider(delegate_paths);
+   delegate_register_handoff_provider(delegate_handoff);
    agent_tools_register_classifier(tool_classify);
    ws_scope_register_ref_validator(workspace_validate);
    /* Same decision, same owner: webuser's runtime dir names a single path

--- a/src/tests/test_coord_jobs.c
+++ b/src/tests/test_coord_jobs.c
@@ -1,3 +1,4 @@
+#include "cmd_agent_delegate_impl.h"
 #include <assert.h>
 #include "platform_test_util.h"
 #include <stdio.h>
@@ -627,8 +628,87 @@ static void test_delegate_economics_report_from_coord_job(void)
    printf("  PASS: test_delegate_economics_report_from_coord_job\n");
 }
 
+/* Judging a handoff is the delegates module's rule now
+ * (server-go/modules/delegates/handoff.go) and this binary hosts no bus. The
+ * subject of these tests is COORDINATION -- which packets are reviewable, which
+ * conflict, which need a supervisor -- so the test supplies the verdicts it
+ * wants to coordinate over.
+ *
+ * This is deliberately NOT the rule. It does not check schema_version, status
+ * admission, summary presence or the done-without-verification downgrade; it
+ * reads only the two numbers these fixtures vary, so it cannot drift into a
+ * second copy of a rule that lives in exactly one place. */
+static int coordjobs_test_handoff_provider(const char *text, const char *owned_files_json,
+                                           int require_verification,
+                                           delegate_handoff_validation_t *out)
+{
+   (void)require_verification;
+   memset(out, 0, sizeof(*out));
+   snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
+   if (!text || !text[0])
+      return -1;
+
+   cJSON *root = cJSON_Parse(text);
+   if (!cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      snprintf(out->error, sizeof(out->error), "%s", "handoff is not valid JSON object");
+      out->needs_supervisor_review = 1;
+      return -1;
+   }
+
+   cJSON *changed = cJSON_GetObjectItemCaseSensitive(root, "changed_files");
+   cJSON *tests = cJSON_GetObjectItemCaseSensitive(root, "tests");
+   cJSON *owned = owned_files_json ? cJSON_Parse(owned_files_json) : NULL;
+
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, tests)
+   {
+      cJSON *st = cJSON_GetObjectItemCaseSensitive(item, "status");
+      if (cJSON_IsString(st) && strcmp(st->valuestring, "passed") == 0)
+         out->passed_tests++;
+   }
+   cJSON_ArrayForEach(item, changed)
+   {
+      if (!cJSON_IsString(item))
+         continue;
+      out->changed_files_count++;
+      int owned_here = 0;
+      cJSON *o = NULL;
+      cJSON_ArrayForEach(o, owned)
+      {
+         if (cJSON_IsString(o) && strcmp(o->valuestring, item->valuestring) == 0)
+         {
+            owned_here = 1;
+            break;
+         }
+      }
+      if (cJSON_IsArray(owned) && cJSON_GetArraySize(owned) > 0 && !owned_here)
+         out->outside_ownership_count++;
+   }
+   cJSON_Delete(owned);
+
+   cJSON *raw = cJSON_GetObjectItemCaseSensitive(root, "status");
+   if (cJSON_IsString(raw))
+   {
+      snprintf(out->raw_status, sizeof(out->raw_status), "%s", raw->valuestring);
+      snprintf(out->status, sizeof(out->status), "%s", raw->valuestring);
+   }
+   cJSON_Delete(root);
+
+   out->valid = 1;
+   if (out->outside_ownership_count > 0)
+   {
+      snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
+      snprintf(out->error, sizeof(out->error), "%s", "handoff touched files outside owned_files");
+      out->needs_supervisor_review = 1;
+   }
+   return 0;
+}
+
 int main(void)
 {
+   delegate_register_handoff_provider(coordjobs_test_handoff_provider);
    printf("test_coord_jobs:\n");
    test_job_create();
    test_adhoc_job_create();

--- a/src/tests/test_delegate_economics.c
+++ b/src/tests/test_delegate_economics.c
@@ -4,6 +4,8 @@
 #include <string.h>
 
 #include <aimee/delegates/delegate_economics.h>
+#include "cmd_agent_delegate_impl.h"
+#include "cJSON.h"
 
 static void add_agent(agent_config_t *cfg, int idx, const char *name, int tier)
 {
@@ -204,8 +206,86 @@ static void test_agent_result_json_metadata(void)
    printf("  PASS: test_agent_result_json_metadata\n");
 }
 
+/* Judging a handoff is the delegates module's rule now
+ * (server-go/modules/delegates/handoff.go) and this binary hosts no bus. The
+ * subject of these tests is COORDINATION -- which packets are reviewable, which
+ * conflict, which need a supervisor -- so the test supplies the verdicts it
+ * wants to coordinate over.
+ *
+ * This is deliberately NOT the rule. It does not check schema_version, status
+ * admission, summary presence or the done-without-verification downgrade; it
+ * reads only the two numbers these fixtures vary, so it cannot drift into a
+ * second copy of a rule that lives in exactly one place. */
+static int econ_test_handoff_provider(const char *text, const char *owned_files_json,
+                                      int require_verification, delegate_handoff_validation_t *out)
+{
+   (void)require_verification;
+   memset(out, 0, sizeof(*out));
+   snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
+   if (!text || !text[0])
+      return -1;
+
+   cJSON *root = cJSON_Parse(text);
+   if (!cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      snprintf(out->error, sizeof(out->error), "%s", "handoff is not valid JSON object");
+      out->needs_supervisor_review = 1;
+      return -1;
+   }
+
+   cJSON *changed = cJSON_GetObjectItemCaseSensitive(root, "changed_files");
+   cJSON *tests = cJSON_GetObjectItemCaseSensitive(root, "tests");
+   cJSON *owned = owned_files_json ? cJSON_Parse(owned_files_json) : NULL;
+
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, tests)
+   {
+      cJSON *st = cJSON_GetObjectItemCaseSensitive(item, "status");
+      if (cJSON_IsString(st) && strcmp(st->valuestring, "passed") == 0)
+         out->passed_tests++;
+   }
+   cJSON_ArrayForEach(item, changed)
+   {
+      if (!cJSON_IsString(item))
+         continue;
+      out->changed_files_count++;
+      int owned_here = 0;
+      cJSON *o = NULL;
+      cJSON_ArrayForEach(o, owned)
+      {
+         if (cJSON_IsString(o) && strcmp(o->valuestring, item->valuestring) == 0)
+         {
+            owned_here = 1;
+            break;
+         }
+      }
+      if (cJSON_IsArray(owned) && cJSON_GetArraySize(owned) > 0 && !owned_here)
+         out->outside_ownership_count++;
+   }
+   cJSON_Delete(owned);
+
+   cJSON *raw = cJSON_GetObjectItemCaseSensitive(root, "status");
+   if (cJSON_IsString(raw))
+   {
+      snprintf(out->raw_status, sizeof(out->raw_status), "%s", raw->valuestring);
+      snprintf(out->status, sizeof(out->status), "%s", raw->valuestring);
+   }
+   cJSON_Delete(root);
+
+   out->valid = 1;
+   if (out->outside_ownership_count > 0)
+   {
+      snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
+      snprintf(out->error, sizeof(out->error), "%s", "handoff touched files outside owned_files");
+      out->needs_supervisor_review = 1;
+   }
+   return 0;
+}
+
 int main(void)
 {
+   delegate_register_handoff_provider(econ_test_handoff_provider);
    test_tier_distribution_and_handoff_counts();
    test_tier0_heavy_verdict_recommends_broader_delegation();
    test_mixed_and_expensive_only_verdicts();

--- a/src/tests/test_delegate_handoff.c
+++ b/src/tests/test_delegate_handoff.c
@@ -5,138 +5,6 @@
 #include <string.h>
 #include "cmd_agent_delegate_impl.h"
 
-static const char *valid_handoff =
-    "{"
-    "\"schema_version\":\"delegate_result_v1\","
-    "\"status\":\"done\","
-    "\"packet_id\":\"packet-one\","
-    "\"changed_files\":[\"src/foo.c\"],"
-    "\"owned_files_touched\":true,"
-    "\"outside_ownership_touches\":[],"
-    "\"commands_run\":[{\"command\":\"make -C src test\",\"exit_code\":0,"
-    "\"summary\":\"built focused test\"}],"
-    "\"tests\":[{\"name\":\"unit-test-foo\",\"status\":\"passed\","
-    "\"command\":\"./src/build/obj/tests/unit-test-foo\"}],"
-    "\"risks\":[],"
-    "\"supervisor_actions\":[],"
-    "\"summary\":\"Implemented focused change.\""
-    "}";
-
-static void test_valid_handoff_parses(void)
-{
-   delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text(valid_handoff, "[\"src/foo.c\"]", 1, &v) == 0);
-   assert(v.valid == 1);
-   assert(strcmp(v.status, "done") == 0);
-   assert(strcmp(v.raw_status, "done") == 0);
-   assert(v.changed_files_count == 1);
-   assert(v.commands_run == 1);
-   assert(v.passed_tests == 1);
-   assert(v.outside_ownership_count == 0);
-   assert(v.needs_supervisor_review == 0);
-   printf("  PASS: test_valid_handoff_parses\n");
-}
-
-static void test_invalid_json_rejected(void)
-{
-   delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text("not json", NULL, 1, &v) != 0);
-   assert(v.valid == 0);
-   assert(strcmp(v.status, "needs_supervisor_review") == 0);
-   assert(strstr(v.error, "valid JSON object") != NULL);
-   printf("  PASS: test_invalid_json_rejected\n");
-}
-
-static void test_missing_required_fields_rejected(void)
-{
-   const char *json = "{\"schema_version\":\"delegate_result_v1\",\"status\":\"done\"}";
-   delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text(json, NULL, 1, &v) != 0);
-   assert(v.valid == 0);
-   assert(strcmp(v.status, "needs_supervisor_review") == 0);
-   assert(strstr(v.error, "required fields") != NULL);
-   printf("  PASS: test_missing_required_fields_rejected\n");
-}
-
-static void test_supervisor_actions_optional(void)
-{
-   const char *json = "{"
-                      "\"schema_version\":\"delegate_result_v1\","
-                      "\"status\":\"done\","
-                      "\"changed_files\":[\"src/foo.c\"],"
-                      "\"tests\":[{\"name\":\"unit-test-foo\",\"status\":\"passed\"}],"
-                      "\"summary\":\"Implemented focused change.\""
-                      "}";
-   delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text(json, "[\"src/foo.c\"]", 1, &v) == 0);
-   assert(v.valid == 1);
-   assert(strcmp(v.status, "done") == 0);
-   assert(v.passed_tests == 1);
-   printf("  PASS: test_supervisor_actions_optional\n");
-}
-
-static void test_empty_summary_rejected(void)
-{
-   const char *json = "{"
-                      "\"schema_version\":\"delegate_result_v1\","
-                      "\"status\":\"done\","
-                      "\"changed_files\":[],"
-                      "\"tests\":[],"
-                      "\"supervisor_actions\":[],"
-                      "\"summary\":\"   \""
-                      "}";
-   delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text(json, NULL, 1, &v) != 0);
-   assert(v.valid == 0);
-   assert(strstr(v.error, "required fields") != NULL);
-   printf("  PASS: test_empty_summary_rejected\n");
-}
-
-static void test_done_without_verification_downgrades(void)
-{
-   const char *json = "{"
-                      "\"schema_version\":\"delegate_result_v1\","
-                      "\"status\":\"done\","
-                      "\"changed_files\":[\"src/foo.c\"],"
-                      "\"tests\":[],"
-                      "\"supervisor_actions\":[],"
-                      "\"summary\":\"No verification was run.\""
-                      "}";
-   delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text(json, "[\"src/foo.c\"]", 1, &v) == 0);
-   assert(v.valid == 1);
-   assert(strcmp(v.raw_status, "done") == 0);
-   assert(strcmp(v.status, "partial") == 0);
-   assert(v.done_without_verification == 1);
-   assert(strstr(v.error, "downgraded") != NULL);
-
-   assert(delegate_handoff_validate_text(json, "[\"src/foo.c\"]", 0, &v) == 0);
-   assert(strcmp(v.status, "done") == 0);
-   assert(v.done_without_verification == 0);
-   printf("  PASS: test_done_without_verification_downgrades\n");
-}
-
-static void test_outside_owned_files_need_review(void)
-{
-   const char *json = "{"
-                      "\"schema_version\":\"delegate_result_v1\","
-                      "\"status\":\"done\","
-                      "\"changed_files\":[\"src/foo.c\",\"src/bar.c\"],"
-                      "\"outside_ownership_touches\":[],"
-                      "\"tests\":[{\"name\":\"unit-test-foo\",\"status\":\"passed\"}],"
-                      "\"supervisor_actions\":[],"
-                      "\"summary\":\"Touched one extra file.\""
-                      "}";
-   delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text(json, "[\"src/foo.c\"]", 1, &v) == 0);
-   assert(v.valid == 1);
-   assert(strcmp(v.status, "needs_supervisor_review") == 0);
-   assert(v.needs_supervisor_review == 1);
-   assert(v.outside_ownership_count == 1);
-   assert(strstr(v.error, "outside owned_files") != NULL);
-   printf("  PASS: test_outside_owned_files_need_review\n");
-}
-
 static void test_prompt_contract_helpers(void)
 {
    char *prompt = delegate_handoff_append_contract("Implement packet.", "packet-alpha");
@@ -156,8 +24,18 @@ static void test_prompt_contract_helpers(void)
 
 static void test_validation_json_fields(void)
 {
+   /* The subject is what add_validation_json EMITS, so the verdict is stated
+    * rather than computed: judging a handoff is the delegates module rule now
+    * and this binary hosts no bus. The rule is covered in
+    * server-go/modules/delegates/handoff_test.go. */
    delegate_handoff_validation_t v;
-   assert(delegate_handoff_validate_text(valid_handoff, "[\"src/foo.c\"]", 1, &v) == 0);
+   memset(&v, 0, sizeof(v));
+   v.valid = 1;
+   v.passed_tests = 1;
+   v.changed_files_count = 1;
+   snprintf(v.status, sizeof(v.status), "%s", "done");
+   snprintf(v.raw_status, sizeof(v.raw_status), "%s", "done");
+
    cJSON *obj = cJSON_CreateObject();
    delegate_handoff_add_validation_json(obj, &v);
    assert(cJSON_IsTrue(cJSON_GetObjectItem(obj, "handoff_valid")));
@@ -170,13 +48,6 @@ static void test_validation_json_fields(void)
 
 int main(void)
 {
-   test_valid_handoff_parses();
-   test_invalid_json_rejected();
-   test_missing_required_fields_rejected();
-   test_supervisor_actions_optional();
-   test_empty_summary_rejected();
-   test_done_without_verification_downgrades();
-   test_outside_owned_files_need_review();
    test_prompt_contract_helpers();
    test_validation_json_fields();
    printf("delegate_handoff: all tests passed\n");

--- a/src/tests/test_delegate_patch_coordinator.c
+++ b/src/tests/test_delegate_patch_coordinator.c
@@ -1,5 +1,6 @@
 /* test_delegate_patch_coordinator.c: read-only delegate patch-state report tests. */
 #include <aimee/delegates/delegate_patch_coordinator.h>
+#include "cmd_agent_delegate_impl.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -15,6 +16,83 @@ static void init_task(db1_coord_task_t *task, int id, const char *status, const 
    snprintf(task->files, sizeof(task->files), "%s", files ? files : "[]");
    if (result)
       snprintf(task->result, sizeof(task->result), "%s", result);
+}
+
+/* Judging a handoff is the delegates module's rule now
+ * (server-go/modules/delegates/handoff.go) and this binary hosts no bus. The
+ * subject of these tests is COORDINATION -- which packets are reviewable, which
+ * conflict, which need a supervisor -- so the test supplies the verdicts it
+ * wants to coordinate over.
+ *
+ * This is deliberately NOT the rule. It does not check schema_version, status
+ * admission, summary presence or the done-without-verification downgrade; it
+ * reads only the two numbers these fixtures vary, so it cannot drift into a
+ * second copy of a rule that lives in exactly one place. */
+static int coord_test_handoff_provider(const char *text, const char *owned_files_json,
+                                       int require_verification, delegate_handoff_validation_t *out)
+{
+   (void)require_verification;
+   memset(out, 0, sizeof(*out));
+   snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
+   if (!text || !text[0])
+      return -1;
+
+   cJSON *root = cJSON_Parse(text);
+   if (!cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      snprintf(out->error, sizeof(out->error), "%s", "handoff is not valid JSON object");
+      out->needs_supervisor_review = 1;
+      return -1;
+   }
+
+   cJSON *changed = cJSON_GetObjectItemCaseSensitive(root, "changed_files");
+   cJSON *tests = cJSON_GetObjectItemCaseSensitive(root, "tests");
+   cJSON *owned = owned_files_json ? cJSON_Parse(owned_files_json) : NULL;
+
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, tests)
+   {
+      cJSON *st = cJSON_GetObjectItemCaseSensitive(item, "status");
+      if (cJSON_IsString(st) && strcmp(st->valuestring, "passed") == 0)
+         out->passed_tests++;
+   }
+   cJSON_ArrayForEach(item, changed)
+   {
+      if (!cJSON_IsString(item))
+         continue;
+      out->changed_files_count++;
+      int owned_here = 0;
+      cJSON *o = NULL;
+      cJSON_ArrayForEach(o, owned)
+      {
+         if (cJSON_IsString(o) && strcmp(o->valuestring, item->valuestring) == 0)
+         {
+            owned_here = 1;
+            break;
+         }
+      }
+      if (cJSON_IsArray(owned) && cJSON_GetArraySize(owned) > 0 && !owned_here)
+         out->outside_ownership_count++;
+   }
+   cJSON_Delete(owned);
+
+   cJSON *raw = cJSON_GetObjectItemCaseSensitive(root, "status");
+   if (cJSON_IsString(raw))
+   {
+      snprintf(out->raw_status, sizeof(out->raw_status), "%s", raw->valuestring);
+      snprintf(out->status, sizeof(out->status), "%s", raw->valuestring);
+   }
+   cJSON_Delete(root);
+
+   out->valid = 1;
+   if (out->outside_ownership_count > 0)
+   {
+      snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
+      snprintf(out->error, sizeof(out->error), "%s", "handoff touched files outside owned_files");
+      out->needs_supervisor_review = 1;
+   }
+   return 0;
 }
 
 static void make_handoff(char *buf, size_t len, const char *status, const char *changed,
@@ -154,6 +232,7 @@ static void test_brief_mentions_next_command(void)
 
 int main(void)
 {
+   delegate_register_handoff_provider(coord_test_handoff_provider);
    printf("delegate_patch_coordinator:\n");
    test_disjoint_verified_packets_are_reviewable();
    test_outside_owned_files_need_supervisor();

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -3511,8 +3511,52 @@ static void test_codex_oauth_vault_server_principal_fallback(void)
    printf("PASS: codex oauth vault server-principal fallback + D15 locked hard-miss\n");
 }
 
+/* Judging a handoff is the delegates module's rule now
+ * (server-go/modules/delegates/handoff.go) and this binary hosts no bus. The
+ * subject of the three handoff tests here is COMPUTE'S REPAIR LOOP -- a valid
+ * handoff costs one agent call, a malformed one is repaired and retried, and a
+ * second malformed one is an error -- so the test states the one thing its
+ * fixtures vary: whether the agent's text is a well-formed handoff at all.
+ *
+ * This is deliberately NOT the rule. It does not check status admission, the
+ * required arrays, summary presence, ownership or the done-without-verification
+ * downgrade, so it cannot drift into a second copy of a rule that lives in
+ * exactly one place. */
+static int compute_test_handoff_provider(const char *text, const char *owned_files_json,
+                                         int require_verification,
+                                         delegate_handoff_validation_t *out)
+{
+   (void)owned_files_json;
+   (void)require_verification;
+   memset(out, 0, sizeof(*out));
+   snprintf(out->status, sizeof(out->status), "%s", "needs_supervisor_review");
+
+   cJSON *root = text ? cJSON_Parse(text) : NULL;
+   cJSON *schema = cJSON_GetObjectItemCaseSensitive(root, "schema_version");
+   if (!cJSON_IsObject(root) || !cJSON_IsString(schema) ||
+       strcmp(schema->valuestring, "delegate_result_v1") != 0)
+   {
+      cJSON_Delete(root);
+      snprintf(out->error, sizeof(out->error), "%s", "handoff is not valid JSON object");
+      out->needs_supervisor_review = 1;
+      return -1;
+   }
+
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(root, "status");
+   if (cJSON_IsString(status))
+   {
+      snprintf(out->raw_status, sizeof(out->raw_status), "%s", status->valuestring);
+      snprintf(out->status, sizeof(out->status), "%s", status->valuestring);
+   }
+   cJSON_Delete(root);
+   out->valid = 1;
+   out->passed_tests = 1;
+   return 0;
+}
+
 int main(void)
 {
+   delegate_register_handoff_provider(compute_test_handoff_provider);
    test_codex_oauth_vault_server_principal_fallback();
    /* DB1 owns delegation_spawns + delegation_messages. */
    assert(db1_init(":memory:") == 0);

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -375,7 +375,7 @@
         },
         {
           "path": "src/headers/cmd_agent_delegate_impl.h",
-          "sha256": "092401b1242c4ef798632f98c5d53c94fee04214f3e7a4cb8a32e0856cd3a939"
+          "sha256": "b1e19a5e79e3350e0e2391ebec1e5e1d53aae796bfa0173039ba80eefff4f8da"
         },
         {
           "path": "src/headers/cmd_agent_delegate_internal.h",
@@ -1463,7 +1463,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "05142c381f0a7881c3f5e072b7c4a850e3bc1b9cdc4bc48ab5001d263ce1dd6f"
+          "sha256": "7bb7b304134232ff16c2438e7e02726c3b4e6d822c49e8d82534a50105eb292e"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "4b89cebb396dc22c054df74968bd9762ef86f7cca8814b5873746fc94216f29f",
+      "sha256": "df9611a9b96bc533e75db05875d9c3e0da2a4cabc1b84871682dcb188d2d1272",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
refactor(delegates): handoff validation moves into the module

Whether a delegate's report can be believed was ~150 lines of C: schema and
status admission, the required-field shape, the passed-test count, and the two
downgrades. It is a decision about trust, so it is now
server-go/modules/delegates/handoff.go on a new stage.

No C mirror. Two slices ago a mirror was defensible because the rule was small
enough to state twice and pin with a parity test; this one is a schema check, an
admission list, an ownership reconciliation and two interacting downgrades whose
ORDER is load-bearing. A second copy would drift and the pin would only say so
afterwards. The rule exists once and its tests moved with it.

Fails closed as NEEDS-REVIEW, not as valid. With no answer the handoff is
neither accepted nor dropped -- it goes to a human. Calling an unanswerable
check "valid" would pass through exactly the unverified report the downgrades
exist to catch.

Ownership outranks the verification downgrade. Both can fire on one handoff, and
an operator needs the more serious of the two; the ported tests pin that
ordering rather than leaving it to whichever branch happens to run last.

Five C test binaries link the validation object and reach it. Each keeps its own
subject and now states the verdicts it wants to reason about:

  - patch-coordinator, economics and coord-jobs are about COORDINATION -- which
    packets are reviewable, which conflict, which need a supervisor -- so they
    supply passed-test and outside-ownership counts directly;
  - server-compute is about the REPAIR LOOP -- a valid handoff costs one agent
    call, a malformed one is repaired and retried, a twice-malformed one is an
    error -- so it states only whether the text is a well-formed handoff.

Those providers are deliberately not the rule. None checks schema_version,
status admission, summary presence or the downgrades; each reads only the axis
its own fixtures vary, so none can drift into a second copy.

server-compute was found by listing the test targets that LINK
delegate_prompt.o, not by grepping for callers -- it never names the function,
reaching validation through handle_delegate and the worker. Eight binaries link
it, five reach it.

The ported Go tests add what the old C comments described but never asserted:
both "pass" and "passed" spellings counting as verification, an admitted
outside-ownership touch counting once rather than twice, and an absent ownership
list meaning unscoped rather than universally violated.

Declared in the contract (6661, stage 5), the descriptor, the dispatch table and
the registry-vs-contracts test, with the serve grant regenerated.
