### PR TITLE
refactor(git): run the PR reads in the module — info, find and list

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -227,7 +227,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "db080fd16502a1c7c1f46735e6bb8204dc2496ce48c70ae080111e069cc3c39d",
+      "source_sha256": "b474b061560e6fa48132ae28c6268e852c17adcd476fa849320caa55c6d5a812",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -227,7 +227,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "b474b061560e6fa48132ae28c6268e852c17adcd476fa849320caa55c6d5a812",
+      "source_sha256": "92b3b1c3a1e32af553d29d72e7a5d6ff70f5c71c0d27ac07b7fdf97f7a36729a",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/server-go/modules/git/forge_request.go
+++ b/server-go/modules/git/forge_request.go
@@ -65,14 +65,28 @@ type ForgeRequest struct {
 
 // PullSummary is the subset of a pull request every caller here needs.
 type PullSummary struct {
-	Number int    `json:"number"`
-	State  string `json:"state"`
-	Title  string `json:"title"`
-	Head   string `json:"head,omitempty"`
-	Base   string `json:"base,omitempty"`
-	Draft  bool   `json:"draft,omitempty"`
-	Merged bool   `json:"merged,omitempty"`
-	URL    string `json:"url,omitempty"`
+	Number  int    `json:"number"`
+	State   string `json:"state"`
+	Title   string `json:"title"`
+	Head    string `json:"head,omitempty"`
+	Base    string `json:"base,omitempty"`
+	HeadSHA string `json:"head_sha,omitempty"`
+	Draft   bool   `json:"draft,omitempty"`
+	Merged  bool   `json:"merged,omitempty"`
+	URL     string `json:"url,omitempty"`
+	// MergedAt is absent when the PR was never merged (the forge sends null).
+	MergedAt string `json:"merged_at,omitempty"`
+	// MergeState is the forge's mergeable_state, UPPER-CASED here. REST spells it
+	// lowercase while gh reported the same values upper-cased as mergeStateStatus,
+	// and callers render that spelling; normalising in one place beats every
+	// caller doing it and one of them forgetting.
+	MergeState string `json:"merge_state,omitempty"`
+	// Mergeable is THREE-valued and must stay that way. The forge answers null
+	// while it is still computing the merge, which is NOT the same as "cannot
+	// merge": treating null as false tells a caller a mergeable PR is conflicted,
+	// and it gives up on a merge that would have succeeded a second later. A nil
+	// pointer here (the field omitted on the wire) means "not known yet".
+	Mergeable *bool `json:"mergeable,omitempty"`
 }
 
 // ForgeResponse reports the HTTP status alongside the parsed answer so a caller
@@ -177,8 +191,13 @@ func summarize(raw []byte) *PullSummary {
 		Draft  bool   `json:"draft"`
 		Merged bool   `json:"merged"`
 		URL    string `json:"html_url"`
-		Head   struct {
+		// Pointer, so "still computing" (null) stays distinct from false.
+		Mergeable  *bool  `json:"mergeable"`
+		MergedAt   string `json:"merged_at"`
+		MergeState string `json:"mergeable_state"`
+		Head       struct {
 			Ref string `json:"ref"`
+			SHA string `json:"sha"`
 		} `json:"head"`
 		Base struct {
 			Ref string `json:"ref"`
@@ -189,8 +208,10 @@ func summarize(raw []byte) *PullSummary {
 	}
 	return &PullSummary{
 		Number: decoded.Number, State: decoded.State, Title: decoded.Title,
-		Head: decoded.Head.Ref, Base: decoded.Base.Ref,
+		Head: decoded.Head.Ref, Base: decoded.Base.Ref, HeadSHA: decoded.Head.SHA,
 		Draft: decoded.Draft, Merged: decoded.Merged, URL: decoded.URL,
+		MergedAt: decoded.MergedAt, MergeState: strings.ToUpper(decoded.MergeState),
+		Mergeable: decoded.Mergeable,
 	}
 }
 

--- a/server-go/modules/git/forge_request.go
+++ b/server-go/modules/git/forge_request.go
@@ -266,9 +266,25 @@ func PerformForge(request ForgeRequest) ForgeResponse {
 
 	case OpPRFindOpen, OpPRListOpen:
 		query := url.Values{"state": {"open"}}
-		if request.Op == OpPRFindOpen && request.Head != "" {
-			// GitHub wants owner-qualified head for this filter.
-			query.Set("head", request.Owner+":"+request.Head)
+		if request.Op == OpPRFindOpen {
+			if request.Head != "" {
+				// GitHub wants owner-qualified head for this filter.
+				query.Set("head", request.Owner+":"+request.Head)
+			}
+			// The BASE matters as much as the head. "Is there already an open PR
+			// for this branch?" is only answered correctly per target branch: the
+			// same head can have an open PR into one base and none into another,
+			// and filtering by head alone answers yes for the wrong one.
+			if request.Base != "" {
+				query.Set("base", request.Base)
+			}
+		}
+		if request.Op == OpPRListOpen {
+			// Most recently updated first. Without this the forge returns
+			// creation order, so a "latest open PRs" listing silently shows the
+			// OLDEST ones once there are more than one page's worth.
+			query.Set("sort", "updated")
+			query.Set("direction", "desc")
 		}
 		if request.Limit > 0 {
 			query.Set("per_page", fmt.Sprint(request.Limit))

--- a/server-go/modules/git/forge_request_test.go
+++ b/server-go/modules/git/forge_request_test.go
@@ -174,6 +174,51 @@ func TestPRFindOpenQualifiesTheHeadWithTheOwner(t *testing.T) {
 	}
 }
 
+// THE BASE IS PART OF THE QUESTION. "Is there already an open PR for this
+// branch?" is only answerable per target branch: the same head can have an open
+// PR into one base and none into another. Filtering by head alone answers yes
+// for the wrong one, and the caller then declines to open a PR it needed.
+func TestPRFindOpenFiltersByBaseAsWellAsHead(t *testing.T) {
+	stub := &forgeStub{reply: `[{"number":5,"state":"open","head":{"ref":"feat"},
+		"base":{"ref":"testing"}}]`}
+	stub.start(t)
+	PerformForge(ForgeRequest{
+		Op: OpPRFindOpen, Owner: "acme", Repo: "r", Token: "t", Head: "feat", Base: "testing",
+	})
+	if !strings.Contains(stub.path, "head=acme%3Afeat") {
+		t.Fatalf("path = %q, want an owner-qualified head filter", stub.path)
+	}
+	if !strings.Contains(stub.path, "base=testing") {
+		t.Fatalf("path = %q, want a base filter", stub.path)
+	}
+
+	// Without a base there must be no base filter at all — an empty base=&
+	// would match nothing rather than "any base".
+	stub2 := &forgeStub{reply: `[]`}
+	stub2.start(t)
+	PerformForge(ForgeRequest{Op: OpPRFindOpen, Owner: "acme", Repo: "r", Token: "t", Head: "feat"})
+	if strings.Contains(stub2.path, "base=") {
+		t.Fatalf("path = %q, want no base filter when none was asked for", stub2.path)
+	}
+}
+
+// A "latest open PRs" listing that silently shows the OLDEST ones is worse than
+// no listing: it reads as authoritative.
+func TestPRListOpenAsksForMostRecentlyUpdatedFirst(t *testing.T) {
+	stub := &forgeStub{reply: `[]`}
+	stub.start(t)
+	PerformForge(ForgeRequest{Op: OpPRListOpen, Owner: "o", Repo: "r", Token: "t", Limit: 20})
+	for _, want := range []string{"sort=updated", "direction=desc", "per_page=20", "state=open"} {
+		if !strings.Contains(stub.path, want) {
+			t.Fatalf("path = %q, missing %s", stub.path, want)
+		}
+	}
+	// The head/base filters belong to find, not to a full listing.
+	if strings.Contains(stub.path, "head=") || strings.Contains(stub.path, "base=") {
+		t.Fatalf("path = %q, a listing must not be filtered by head/base", stub.path)
+	}
+}
+
 func TestGuardsRejectBadInputBeforeAnyCall(t *testing.T) {
 	previous := forgeBaseURL
 	forgeBaseURL = "http://127.0.0.1:1" // any call would fail loudly

--- a/server-go/modules/git/forge_request_test.go
+++ b/server-go/modules/git/forge_request_test.go
@@ -199,6 +199,91 @@ func TestGuardsRejectBadInputBeforeAnyCall(t *testing.T) {
 	}
 }
 
+// MERGEABLE IS THREE-VALUED. The forge answers null while it is still computing
+// the merge, which is NOT "cannot merge". Flattening null to false tells a
+// caller a perfectly mergeable PR is conflicted, and it abandons a merge that
+// would have succeeded a moment later — so absent, true and false are asserted
+// as three distinct outcomes.
+func TestPRInfoKeepsMergeableThreeValued(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want *bool
+	}{
+		{"still computing", `{"number":1,"state":"open","mergeable":null,
+			"head":{"ref":"f","sha":"abc"},"base":{"ref":"testing"}}`, nil},
+		{"mergeable", `{"number":1,"state":"open","mergeable":true,
+			"head":{"ref":"f","sha":"abc"},"base":{"ref":"testing"}}`, boolPtr(true)},
+		{"not mergeable", `{"number":1,"state":"open","mergeable":false,
+			"head":{"ref":"f","sha":"abc"},"base":{"ref":"testing"}}`, boolPtr(false)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &forgeStub{reply: tc.body}
+			stub.start(t)
+			out := PerformForge(ForgeRequest{Op: OpPRInfo, Owner: "o", Repo: "r", Token: "t", Number: 1})
+			if out.Error != "" || out.Pull == nil {
+				t.Fatalf("unexpected: %+v", out)
+			}
+			got := out.Pull.Mergeable
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("mergeable = %v, want %v", got, tc.want)
+			}
+			if got != nil && *got != *tc.want {
+				t.Fatalf("mergeable = %v, want %v", *got, *tc.want)
+			}
+			// And it must survive the wire the same way.
+			encoded, _ := json.Marshal(out.Pull)
+			hasKey := strings.Contains(string(encoded), `"mergeable"`)
+			if hasKey != (tc.want != nil) {
+				t.Fatalf("encoded %s: mergeable key present=%v, want %v", encoded, hasKey, tc.want != nil)
+			}
+		})
+	}
+}
+
+func TestPRInfoCarriesTheRefsAndStateACallerNeeds(t *testing.T) {
+	stub := &forgeStub{reply: `{"number":7,"state":"closed","title":"T","merged":true,
+		"merged_at":"2026-08-10T13:17:33Z","mergeable_state":"clean","html_url":"u",
+		"head":{"ref":"feat","sha":"deadbeef"},"base":{"ref":"testing"}}`}
+	stub.start(t)
+	out := PerformForge(ForgeRequest{Op: OpPRInfo, Owner: "o", Repo: "r", Token: "t", Number: 7})
+	if out.Error != "" || out.Pull == nil {
+		t.Fatalf("unexpected: %+v", out)
+	}
+	p := out.Pull
+	// head_sha is what drift-safety on a merge is checked against, so losing it
+	// silently disables that protection.
+	if p.HeadSHA != "deadbeef" || p.Head != "feat" || p.Base != "testing" {
+		t.Fatalf("refs = %+v", p)
+	}
+	if !p.Merged || p.MergedAt != "2026-08-10T13:17:33Z" {
+		t.Fatalf("merge facts = %+v", p)
+	}
+	// REST spells it lowercase; callers render the upper-cased gh spelling, and
+	// normalising here means no caller has to remember to.
+	if p.MergeState != "CLEAN" {
+		t.Fatalf("merge_state = %q, want CLEAN", p.MergeState)
+	}
+}
+
+// A PR that was never merged has merged_at null; it must not become the string
+// "null" or an empty-but-present value a caller might render.
+func TestNeverMergedHasNoMergedAt(t *testing.T) {
+	stub := &forgeStub{reply: `{"number":1,"state":"open","merged":false,"merged_at":null,
+		"head":{"ref":"f","sha":"abc"},"base":{"ref":"testing"}}`}
+	stub.start(t)
+	out := PerformForge(ForgeRequest{Op: OpPRInfo, Owner: "o", Repo: "r", Token: "t", Number: 1})
+	if out.Pull == nil || out.Pull.MergedAt != "" {
+		t.Fatalf("merged_at = %+v, want empty", out.Pull)
+	}
+	encoded, _ := json.Marshal(out.Pull)
+	if strings.Contains(string(encoded), "merged_at") {
+		t.Fatalf("merged_at must be omitted entirely: %s", encoded)
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
+
 func TestHandleForgeRequestRoutesThroughStageFour(t *testing.T) {
 	stub := &forgeStub{reply: `{"default_branch":"testing"}`}
 	stub.start(t)

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -616,6 +616,12 @@ int git_pr_find_open_via_api_slug(const char *principal, const char *slug, const
 {
    if (out && out_cap)
       out[0] = '\0';
+   /* Clear err like every sibling does. This one returns 0 for "no open PR",
+    * which is a SUCCESS, and a caller reusing the buffer would otherwise read a
+    * stale message from an earlier call and report a failure that never
+    * happened. */
+   if (err && errlen)
+      err[0] = '\0';
    if (number_out)
       *number_out = 0;
    if (!head || !head[0] || !base || !base[0] || strlen(head) > 200 || strlen(base) > 200 ||
@@ -627,23 +633,39 @@ int git_pr_find_open_via_api_slug(const char *principal, const char *slug, const
    gh_ctx_t cx;
    if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
-   char path[700];
-   snprintf(path, sizeof(path), "pulls?state=open&head=%s:%s&base=%s&per_page=1", cx.owner, head,
-            base);
-   char *response = NULL;
-   int status = gh_get(&cx, path, &response);
-   gh_ctx_done(&cx);
-   if (status < 200 || status >= 300 || !response)
+   cJSON *extra = cJSON_CreateObject();
+   if (!extra)
    {
-      gh_err(response, status, "find PR", err, errlen);
-      free(response);
+      gh_ctx_done(&cx);
+      snprintf(err, errlen, "internal error");
       return -1;
    }
+   /* Head AND base: the same head can have an open PR into one base and none
+    * into another, so filtering by head alone answers the question for the
+    * wrong target branch. */
+   cJSON_AddStringToObject(extra, "head", head);
+   cJSON_AddStringToObject(extra, "base", base);
+   cJSON_AddNumberToObject(extra, "limit", 1);
+   cJSON *reply = forge_stage(&cx, "pr_find_open", extra);
+   gh_ctx_done(&cx);
+   if (!reply)
+   {
+      snprintf(err, errlen, "find PR: the git module could not be reached");
+      return -1;
+   }
+   const cJSON *message = cJSON_GetObjectItemCaseSensitive(reply, "error");
+   if (cJSON_IsString(message) && message->valuestring)
+   {
+      snprintf(err, errlen, "%s", message->valuestring);
+      cJSON_Delete(reply);
+      return -1;
+   }
+   /* NO MATCH IS NOT AN ERROR: 0 means "no open PR", which is the answer the
+    * caller acts on by opening one. Reporting -1 here would make it give up. */
    int found = 0;
-   cJSON *array = cJSON_Parse(response);
-   const cJSON *first = cJSON_IsArray(array) ? cJSON_GetArrayItem(array, 0) : NULL;
-   const cJSON *url = first ? cJSON_GetObjectItem(first, "html_url") : NULL;
-   const cJSON *number = first ? cJSON_GetObjectItem(first, "number") : NULL;
+   const cJSON *pull = cJSON_GetObjectItemCaseSensitive(reply, "pull");
+   const cJSON *url = pull ? cJSON_GetObjectItemCaseSensitive(pull, "url") : NULL;
+   const cJSON *number = pull ? cJSON_GetObjectItemCaseSensitive(pull, "number") : NULL;
    if (cJSON_IsString(url) && url->valuestring && url->valuestring[0])
    {
       snprintf(out, out_cap, "%s", url->valuestring);
@@ -651,8 +673,7 @@ int git_pr_find_open_via_api_slug(const char *principal, const char *slug, const
          *number_out = number->valueint;
       found = 1;
    }
-   cJSON_Delete(array);
-   free(response);
+   cJSON_Delete(reply);
    return found;
 }
 
@@ -1124,22 +1145,43 @@ int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int l
    gh_ctx_t cx;
    if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
-   char path[96];
-   snprintf(path, sizeof(path), "pulls?state=open&sort=updated&direction=desc&per_page=%d", limit);
-   char *resp = NULL;
-   int st = gh_get(&cx, path, &resp);
-   gh_ctx_done(&cx);
-   if (st < 200 || st >= 300 || !resp)
+   cJSON *extra = cJSON_CreateObject();
+   if (!extra)
    {
-      gh_err(resp, st, "pr list", err, errlen);
-      free(resp);
+      gh_ctx_done(&cx);
+      snprintf(err, errlen, "internal error");
       return -1;
    }
-   cJSON *arr = cJSON_Parse(resp);
-   free(resp);
+   cJSON_AddNumberToObject(extra, "limit", limit);
+   cJSON *reply = forge_stage(&cx, "pr_list_open", extra);
+   gh_ctx_done(&cx);
+   if (!reply)
+   {
+      snprintf(err, errlen, "pr list: the git module could not be reached");
+      return -1;
+   }
+   const cJSON *message = cJSON_GetObjectItemCaseSensitive(reply, "error");
+   if (cJSON_IsString(message) && message->valuestring)
+   {
+      snprintf(err, errlen, "%s", message->valuestring);
+      cJSON_Delete(reply);
+      return -1;
+   }
+   const cJSON *statusj = cJSON_GetObjectItemCaseSensitive(reply, "status");
+   int status = cJSON_IsNumber(statusj) ? statusj->valueint : 0;
+   cJSON *arr = cJSON_DetachItemFromObjectCaseSensitive(reply, "pulls");
+   cJSON_Delete(reply);
    if (!cJSON_IsArray(arr))
    {
+      /* NO OPEN PRs IS A RESULT, NOT A FAILURE. The stage omits an empty list
+       * entirely, so an absent key on a 2xx is zero rows -- reporting an error
+       * here would turn "nothing to list" into "the listing is broken". */
       cJSON_Delete(arr);
+      if (status >= 200 && status < 300)
+      {
+         *count = 0;
+         return 0;
+      }
       snprintf(err, errlen, "github API: unparseable pr list");
       return -1;
    }
@@ -1152,8 +1194,7 @@ int git_pr_list_open_via_api_slug(const char *principal, const char *slug, int l
       const cJSON *num = cJSON_GetObjectItem(item, "number");
       const cJSON *state = cJSON_GetObjectItem(item, "state");
       const cJSON *title = cJSON_GetObjectItem(item, "title");
-      const cJSON *headj = cJSON_GetObjectItem(item, "head");
-      const cJSON *headref = headj ? cJSON_GetObjectItem(headj, "ref") : NULL;
+      const cJSON *headref = cJSON_GetObjectItem(item, "head");
       const cJSON *mat = cJSON_GetObjectItem(item, "merged_at");
       if (!cJSON_IsNumber(num) || num->valueint <= 0)
          continue; /* a row without a number is not addressable; skip it */

--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -1205,33 +1205,44 @@ int git_pr_info_via_api_slug(const char *principal, const char *slug, int number
    gh_ctx_t cx;
    if (gh_ctx_resolve_slug(principal, slug, &cx, err, errlen) != 0)
       return -1;
-   char path[64];
-   snprintf(path, sizeof(path), "pulls/%d", number);
-   char *resp = NULL;
-   int st = gh_get(&cx, path, &resp);
-   gh_ctx_done(&cx);
-   if (st < 200 || st >= 300 || !resp)
+   cJSON *extra = cJSON_CreateObject();
+   if (!extra)
    {
-      gh_err(resp, st, "pr info", err, errlen);
-      free(resp);
+      gh_ctx_done(&cx);
+      snprintf(err, errlen, "internal error");
       return -1;
    }
-   cJSON *j = cJSON_Parse(resp);
-   free(resp);
+   cJSON_AddNumberToObject(extra, "number", number);
+   cJSON *reply = forge_stage(&cx, "pr_info", extra);
+   gh_ctx_done(&cx);
+   if (!reply)
+   {
+      snprintf(err, errlen, "pr info: the git module could not be reached");
+      return -1;
+   }
+   const cJSON *message = cJSON_GetObjectItemCaseSensitive(reply, "error");
+   cJSON *j = cJSON_DetachItemFromObjectCaseSensitive(reply, "pull");
    if (!j)
    {
-      snprintf(err, errlen, "github API: unparseable pr info");
+      if (cJSON_IsString(message) && message->valuestring)
+         snprintf(err, errlen, "%s", message->valuestring);
+      else
+         snprintf(err, errlen, "github API: unparseable pr info");
+      cJSON_Delete(reply);
       return -1;
    }
+   cJSON_Delete(reply);
+
    const cJSON *state = cJSON_GetObjectItem(j, "state");
    const cJSON *merged = cJSON_GetObjectItem(j, "merged");
+   /* ABSENT means the forge is still computing the merge, which is not the same
+    * as "cannot merge": out->mergeable stays -1 in that case, and only an
+    * explicit boolean moves it to 1/0. */
    const cJSON *mergeable = cJSON_GetObjectItem(j, "mergeable");
-   const cJSON *headj = cJSON_GetObjectItem(j, "head");
-   const cJSON *sha = headj ? cJSON_GetObjectItem(headj, "sha") : NULL;
-   const cJSON *headref = headj ? cJSON_GetObjectItem(headj, "ref") : NULL;
-   const cJSON *basej = cJSON_GetObjectItem(j, "base");
-   const cJSON *baseref = basej ? cJSON_GetObjectItem(basej, "ref") : NULL;
-   const char *sha_s = cJSON_IsString(sha) ? sha->valuestring : NULL;
+   const cJSON *shaj = cJSON_GetObjectItem(j, "head_sha");
+   const cJSON *headref = cJSON_GetObjectItem(j, "head");
+   const cJSON *baseref = cJSON_GetObjectItem(j, "base");
+   const char *sha_s = cJSON_IsString(shaj) ? shaj->valuestring : NULL;
    const char *head_s = cJSON_IsString(headref) ? headref->valuestring : NULL;
    const char *base_s = cJSON_IsString(baseref) ? baseref->valuestring : NULL;
    if (!cJSON_IsString(state) || !state->valuestring || !sha_s || !sha_s[0] || !head_s ||
@@ -1249,23 +1260,20 @@ int git_pr_info_via_api_slug(const char *principal, const char *slug, int number
     * missing or over-long value is left empty rather than failing the whole call
     * the way a missing ref does above. */
    const cJSON *title = cJSON_GetObjectItem(j, "title");
-   const cJSON *hurl = cJSON_GetObjectItem(j, "html_url");
+   const cJSON *hurl = cJSON_GetObjectItem(j, "url");
    const cJSON *mat = cJSON_GetObjectItem(j, "merged_at");
    if (cJSON_IsString(title) && title->valuestring)
       snprintf(out->title, sizeof(out->title), "%s", title->valuestring);
    if (cJSON_IsString(hurl) && hurl->valuestring)
       snprintf(out->html_url, sizeof(out->html_url), "%s", hurl->valuestring);
-   if (cJSON_IsString(mat) && mat->valuestring) /* null when never merged */
+   if (cJSON_IsString(mat) && mat->valuestring) /* absent when never merged */
       snprintf(out->merged_at, sizeof(out->merged_at), "%s", mat->valuestring);
-   const cJSON *mstate = cJSON_GetObjectItem(j, "mergeable_state");
+   /* Already upper-cased by the module: REST spells mergeable_state lowercase
+    * while callers render the gh mergeStateStatus spelling, and normalising it
+    * in one place beats every caller remembering to. */
+   const cJSON *mstate = cJSON_GetObjectItem(j, "merge_state");
    if (cJSON_IsString(mstate) && mstate->valuestring)
-   {
-      /* REST spells it lowercase; gh reported the same values upper-cased as
-       * mergeStateStatus, and callers render that spelling. */
       snprintf(out->merge_state, sizeof(out->merge_state), "%s", mstate->valuestring);
-      for (char *p = out->merge_state; *p; p++)
-         *p = (char)toupper((unsigned char)*p);
-   }
 
    if (cJSON_IsBool(mergeable))
       out->mergeable = cJSON_IsTrue(mergeable) ? 1 : 0; /* null stays -1 (computing) */

--- a/src/tests/test_git_pr_stage.c
+++ b/src/tests/test_git_pr_stage.c
@@ -215,6 +215,57 @@ int main(void)
                                      sizeof(urlbuf), err, sizeof(err)) == -1);
    assert(module_bus_stub_calls() == before);
 
+   /* --- pr_info --------------------------------------------------------- */
+
+   git_pr_info_t info;
+
+   module_bus_stub_reply(
+       "{\"status\":200,\"pull\":{\"number\":7,\"state\":\"closed\",\"title\":\"T\","
+       "\"merged\":true,\"merged_at\":\"2026-08-10T13:17:33Z\",\"merge_state\":\"CLEAN\","
+       "\"url\":\"https://github.com/acme/widgets/pull/7\",\"head\":\"feat\","
+       "\"head_sha\":\"deadbeef\",\"base\":\"testing\",\"mergeable\":true}}");
+   assert(git_pr_info_via_api_slug(NULL, SLUG, 7, &info, err, sizeof(err)) == 0);
+   assert(info.open == 0 && info.merged == 1);
+   assert(strcmp(info.head_sha, "deadbeef") == 0);
+   assert(strcmp(info.head, "feat") == 0 && strcmp(info.base, "testing") == 0);
+   assert(strcmp(info.merge_state, "CLEAN") == 0);
+   assert(strcmp(info.merged_at, "2026-08-10T13:17:33Z") == 0);
+   assert(strcmp(info.html_url, "https://github.com/acme/widgets/pull/7") == 0);
+   assert(info.mergeable == 1);
+
+   /* MERGEABLE IS THREE-VALUED. An ABSENT mergeable means the forge is still
+    * computing the merge; it must stay -1 rather than collapse to 0, or a caller
+    * reads "still computing" as "conflicted" and abandons a mergeable PR. */
+   module_bus_stub_reply("{\"status\":200,\"pull\":{\"number\":7,\"state\":\"open\","
+                         "\"head\":\"feat\",\"head_sha\":\"abc\",\"base\":\"testing\"}}");
+   assert(git_pr_info_via_api_slug(NULL, SLUG, 7, &info, err, sizeof(err)) == 0);
+   assert(info.mergeable == -1);
+   assert(info.open == 1 && info.merged == 0);
+   assert(info.merged_at[0] == '\0'); /* never merged -> no timestamp */
+
+   /* An explicit false is a real answer and must NOT read as "unknown". */
+   module_bus_stub_reply("{\"status\":200,\"pull\":{\"number\":7,\"state\":\"open\","
+                         "\"head\":\"feat\",\"head_sha\":\"abc\",\"base\":\"testing\","
+                         "\"mergeable\":false}}");
+   assert(git_pr_info_via_api_slug(NULL, SLUG, 7, &info, err, sizeof(err)) == 0);
+   assert(info.mergeable == 0);
+
+   /* Missing refs fail the whole call: head_sha is what a merge's drift check is
+    * made against, so proceeding without it would silently disable that. */
+   module_bus_stub_reply(
+       "{\"status\":200,\"pull\":{\"number\":7,\"state\":\"open\",\"head\":\"feat\"}}");
+   assert(git_pr_info_via_api_slug(NULL, SLUG, 7, &info, err, sizeof(err)) == -1);
+   assert(strstr(err, "missing required refs") != NULL);
+
+   /* A refusal carries the forge's own message. */
+   module_bus_stub_reply("{\"status\":404,\"error\":\"pr info: Not Found (HTTP 404)\"}");
+   assert(git_pr_info_via_api_slug(NULL, SLUG, 7, &info, err, sizeof(err)) == -1);
+   assert(strstr(err, "Not Found") != NULL);
+
+   module_bus_stub_absent();
+   assert(git_pr_info_via_api_slug(NULL, SLUG, 7, &info, err, sizeof(err)) == -1);
+   assert(strstr(err, "could not be reached") != NULL);
+
    printf("git_pr_stage: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_git_pr_stage.c
+++ b/src/tests/test_git_pr_stage.c
@@ -266,6 +266,80 @@ int main(void)
    assert(git_pr_info_via_api_slug(NULL, SLUG, 7, &info, err, sizeof(err)) == -1);
    assert(strstr(err, "could not be reached") != NULL);
 
+   /* --- pr_find_open ---------------------------------------------------- */
+
+   int number = 0;
+
+   module_bus_stub_reply("{\"status\":200,\"pull\":{\"number\":5,\"url\":"
+                         "\"https://github.com/acme/widgets/pull/5\"},\"pulls\":[{\"number\":5}]}");
+   assert(git_pr_find_open_via_api_slug(NULL, SLUG, "feat", "testing", urlbuf, sizeof(urlbuf),
+                                        &number, err, sizeof(err)) == 1);
+   assert(number == 5);
+   assert(strcmp(urlbuf, "https://github.com/acme/widgets/pull/5") == 0);
+
+   /* NO MATCH IS NOT AN ERROR. 0 is the answer the caller acts on by opening a
+    * PR; returning -1 would make it give up instead. The stage omits `pull`
+    * entirely when nothing matched. */
+   module_bus_stub_reply("{\"status\":200}");
+   number = 7;
+   assert(git_pr_find_open_via_api_slug(NULL, SLUG, "feat", "testing", urlbuf, sizeof(urlbuf),
+                                        &number, err, sizeof(err)) == 0);
+   assert(number == 0 && urlbuf[0] == '\0');
+   assert(err[0] == '\0'); /* "not found" carries no error text */
+
+   /* A real refusal still is one. */
+   module_bus_stub_reply("{\"status\":404,\"error\":\"pr list: Not Found (HTTP 404)\"}");
+   assert(git_pr_find_open_via_api_slug(NULL, SLUG, "feat", "testing", urlbuf, sizeof(urlbuf),
+                                        &number, err, sizeof(err)) == -1);
+   assert(strstr(err, "Not Found") != NULL);
+
+   /* The head/base guards refuse before anything is sent. */
+   module_bus_stub_reply("{\"status\":200}");
+   before = module_bus_stub_calls();
+   assert(git_pr_find_open_via_api_slug(NULL, SLUG, "", "testing", urlbuf, sizeof(urlbuf), &number,
+                                        err, sizeof(err)) == -1);
+   assert(git_pr_find_open_via_api_slug(NULL, SLUG, "feat&x", "testing", urlbuf, sizeof(urlbuf),
+                                        &number, err, sizeof(err)) == -1);
+   assert(module_bus_stub_calls() == before);
+
+   /* --- pr_list_open ---------------------------------------------------- */
+
+   git_pr_list_item_t rows[4];
+   int count = -1;
+
+   module_bus_stub_reply("{\"status\":200,\"pulls\":["
+                         "{\"number\":9,\"state\":\"open\",\"title\":\"A\",\"head\":\"one\"},"
+                         "{\"number\":8,\"state\":\"closed\",\"title\":\"B\",\"head\":\"two\","
+                         "\"merged_at\":\"2026-08-10T00:00:00Z\"}]}");
+   assert(git_pr_list_open_via_api_slug(NULL, SLUG, 4, rows, &count, err, sizeof(err)) == 0);
+   assert(count == 2);
+   assert(rows[0].number == 9 && strcmp(rows[0].state, "OPEN") == 0);
+   assert(strcmp(rows[0].head, "one") == 0 && strcmp(rows[0].title, "A") == 0);
+   /* A merged PR carries the closed state; callers render MERGED. */
+   assert(rows[1].number == 8 && strcmp(rows[1].state, "MERGED") == 0);
+
+   /* AN EMPTY LIST IS A RESULT, NOT A FAILURE. The stage omits an empty `pulls`
+    * entirely, and reporting an error would turn "no open PRs" into "the
+    * listing is broken". */
+   module_bus_stub_reply("{\"status\":200}");
+   count = -1;
+   assert(git_pr_list_open_via_api_slug(NULL, SLUG, 4, rows, &count, err, sizeof(err)) == 0);
+   assert(count == 0);
+
+   /* The limit is honoured even if the stage returns more rows than asked. */
+   module_bus_stub_reply("{\"status\":200,\"pulls\":[{\"number\":1},{\"number\":2},"
+                         "{\"number\":3},{\"number\":4},{\"number\":5}]}");
+   assert(git_pr_list_open_via_api_slug(NULL, SLUG, 3, rows, &count, err, sizeof(err)) == 0);
+   assert(count == 3);
+
+   module_bus_stub_reply("{\"status\":403,\"error\":\"pr list: Forbidden (HTTP 403)\"}");
+   assert(git_pr_list_open_via_api_slug(NULL, SLUG, 4, rows, &count, err, sizeof(err)) == -1);
+   assert(strstr(err, "Forbidden") != NULL);
+
+   module_bus_stub_absent();
+   assert(git_pr_list_open_via_api_slug(NULL, SLUG, 4, rows, &count, err, sizeof(err)) == -1);
+   assert(strstr(err, "could not be reached") != NULL);
+
    printf("git_pr_stage: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
**Finishes the `git-forge-request` seam.** After default-branch (#2492), merge (#2498) and create (#2500), every PR operation now runs in `server-go/modules/git` — no PR op reaches GitHub from C.

## 1. `info`

The stage's `PullSummary` had to carry more: `head_sha`, `merged_at`, `mergeable_state`, `mergeable`. Added to the **summary** rather than a bespoke response, so create/find/list get the same facts for free.

**`mergeable` stays three-valued.** The forge answers `null` while it is still *computing* the merge — not "cannot merge". Flatten it to `false` and a caller is told a mergeable PR is conflicted, so it abandons a merge that would have succeeded moments later. Go models it as `*bool` and **omits** the key when unknown; C leaves `out->mergeable` at `-1` unless an explicit boolean arrives. Absent/true/false are asserted as three distinct outcomes on both sides.

`mergeable_state` is upper-cased in the module (REST spells it lowercase, callers render the gh `mergeStateStatus` spelling), and `merged_at` is omitted entirely when never merged.

## 2. `find_open` — a parity gap that would have changed behaviour silently

`OpPRFindOpen` filtered only by **head**. The same head can have an open PR into one base and none into another, so head-alone answers *"is there already a PR for this branch?"* for the wrong target branch — and the caller then declines to open a PR it needed. The **base filter is now part of the query**.

## 3. `list_open` — a second parity gap

It did not sort. The forge returns creation order, so a "latest open PRs" listing silently shows the **oldest** once there is more than a page of them, while reading as authoritative. `sort=updated&direction=desc` restores what the C query asked for.

## The response-shape trap: empty is a result, not a failure

`pulls` and `pull` are `omitempty`, so **zero rows omits the key entirely**. Keying off the key's presence would report "the listing is broken" for the ordinary case of nothing to list. So:

- absent `pulls` on a 2xx → **zero rows, return 0**
- absent `pull` on a 2xx → **"no match", return 0** — the answer the caller acts on by opening a PR. An error there would make it give up.

## Bug found and fixed while here

`git_pr_find_open_via_api_slug` never cleared `err`, unlike every sibling. It returns `0` for "no open PR", which is a **success** — so a caller reusing the buffer read a stale message from an earlier call and could report a failure that never happened. Found by a test asserting the not-found path carries no error text.

## What deliberately stayed in C

- required-refs and head/base validation — input guards that must refuse **before anything is sent**
- buffer-length checks — the buffer sizes are C's
- the `MERGED`/upper-case row state — this caller's rendering of state the summary already reports

## Verification

- Red-before-green for every op: against the pre-migration code the suite fails with `migrated op reached HTTP directly via agent_http_get`
- `make -C src -j8` clean; `unit-tests` green; `lint` **exit 0, 48/48**
- `go build` / `vet` / `gofmt -l` clean; `go test ./bus ./modules/... ./cmd/aimee-module` green
- Whole `pins` job locally, including the module supervisor
- Re-run in full **after** merging the branch's remote state (which had picked up #2501), and the lock **recomputed** rather than trusting a clean textual merge — it verified as already current