### PR TITLE
chore(git): retire the C conflict matcher, now that the module owns it

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -228,7 +228,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "92b3b1c3a1e32af553d29d72e7a5d6ff70f5c71c0d27ac07b7fdf97f7a36729a",
+      "source_sha256": "3bdd111bde503e1b4129b8d9ef47cfd949332886c180666313fd0904b66b49cf",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/server-go/modules/git/forge_request_test.go
+++ b/server-go/modules/git/forge_request_test.go
@@ -219,6 +219,46 @@ func TestPRListOpenAsksForMostRecentlyUpdatedFirst(t *testing.T) {
 	}
 }
 
+// TERMINAL CONFLICT vs RETRYABLE LOST RACE. Both arrive as 405/409 and the
+// message is the only discriminator the forge gives.
+//
+// A content conflict is identical on every retry, so it must be terminal; a
+// moved head/base is a lost race a retry wins. Getting it wrong in the
+// RETRYABLE direction wedges a run forever (observed in this repo: 15 attempts
+// over 3 hours); getting it wrong in the TERMINAL direction kills a run that
+// would have merged. So the predicate fails SAFE toward retry.
+//
+// These cases were previously pinned in C against git_pr_merge_err_is_conflict.
+// The classification now lives here, so the cases live here too — deleting the
+// C copy without this would drop the coverage on the floor.
+func TestMergeConflictClassificationFailsSafeTowardRetry(t *testing.T) {
+	for _, message := range []string{
+		"github API (pr merge, HTTP 405): Pull Request has merge conflicts",
+		"merge conflict",           // minimal phrasing
+		"MERGE CONFLICTS DETECTED", // case-insensitive
+	} {
+		if !isMergeConflict(message) {
+			t.Errorf("should be a TERMINAL conflict: %q", message)
+		}
+	}
+
+	for _, message := range []string{
+		// Lost races: a retry wins these.
+		"github API (pr merge, HTTP 409): Head branch was modified. Review and try the merge again.",
+		"github API (pr merge, HTTP 405): Base branch was modified. Review and try the merge again.",
+		// HTTP 409 is *named* "Conflict", so the bare word must not terminate a
+		// lost-race message that has no content conflict in it at all.
+		"github API (pr merge, HTTP 409): Conflict",
+		// Unrecognised and empty degrade to retry, never to a terminal kill.
+		"github API (pr merge, HTTP 405): failed",
+		"",
+	} {
+		if isMergeConflict(message) {
+			t.Errorf("should stay RETRYABLE: %q", message)
+		}
+	}
+}
+
 func TestGuardsRejectBadInputBeforeAnyCall(t *testing.T) {
 	previous := forgeBaseURL
 	forgeBaseURL = "http://127.0.0.1:1" // any call would fail loudly

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -252,13 +252,13 @@ int git_pr_ci_permits_merge(git_pr_ci_t ci);
  * over 3 hours on one run, holding the single active-root slot). Callers must
  * treat 3 as terminal. */
 
-/* Does this 405/409 merge error describe a content CONFLICT (terminal) rather
- * than a lost race (retryable)? Text-matching a forge message is unlovely, but
- * GitHub returns the same status for both and the message is the only signal it
- * gives. Fails SAFE: an unrecognised message is reported as NOT a conflict, so
- * an unfamiliar phrasing degrades to today's retry behaviour rather than
- * terminating a run that could have succeeded. Pure; unit-tested. */
-int git_pr_merge_err_is_conflict(const char *err);
+/* The conflict-vs-lost-race classification itself now happens in the git module
+ * (server-go/modules/git, isMergeConflict): the merge runs there, so the message
+ * is read where it arrives rather than re-derived from a rendered error string
+ * here. The stage reports the two apart as `conflict` and `retryable`, and the
+ * 2-vs-3 mapping above is a straight translation of those. The phrasings that
+ * must and must not terminate are pinned by
+ * TestMergeConflictClassificationFailsSafeTowardRetry. */
 int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number, char *err,
                          size_t errlen);
 int git_pr_merge_via_api_slug(const char *principal, const char *slug, int number, char *err,

--- a/src/modules/git/git_pr_ci_grade.c
+++ b/src/modules/git/git_pr_ci_grade.c
@@ -3,15 +3,18 @@
  * Split from git_pr_api.c so it links — and unit-tests — without the
  * HTTP/credential stack. The aggregation itself has since moved to the git
  * module (server-go/modules/git/ci_grade.go); what stays here is the request,
- * the ruling, and the two pure predicates below, which are a handful of
- * comparisons on the merge path and would gain nothing from a round trip. */
+ * the ruling, and the pure predicate below, which is a handful of comparisons
+ * on the merge path and would gain nothing from a round trip.
+ *
+ * The conflict-vs-lost-race predicate that used to sit here went with the merge
+ * into the module: the message is now read where it arrives instead of being
+ * re-derived from a rendered error string. */
 #include "git_pr_api.h"
 
 #include "cJSON.h"
 #include "headers/module_json_call.h"
 
 #include <aimee/git/module_api.h>
-#include <ctype.h>
 #include <string.h>
 
 /* A forge's check-runs payload for a busy repository is the largest thing this
@@ -20,43 +23,6 @@
 /* The caller already spent two HTTP round trips reaching the forge, so a short
  * bus deadline here only converts a slow module into a refused merge. */
 #define GIT_PR_CI_GRADE_TIMEOUT_MS 10000
-
-/* Case-insensitive substring search. Not strcasestr(): that is a GNU extension,
- * and this file is deliberately built into minimal test binaries that do not
- * define _GNU_SOURCE. */
-static const char *ci_grade_casestr(const char *hay, const char *needle)
-{
-   if (!hay || !needle || !needle[0])
-      return NULL;
-   for (const char *h = hay; *h; h++)
-   {
-      const char *a = h, *b = needle;
-      while (*a && *b && tolower((unsigned char)*a) == tolower((unsigned char)*b))
-      {
-         a++;
-         b++;
-      }
-      if (!*b)
-         return h;
-   }
-   return NULL;
-}
-
-int git_pr_merge_err_is_conflict(const char *err)
-{
-   if (!err || !err[0])
-      return 0;
-   /* GitHub's conflict wording, observed live: "Pull Request has merge
-    * conflicts". Match the distinctive noun phrase rather than the whole
-    * sentence, so a reworded message ("has merge conflict", "merge conflicts
-    * detected") still classifies.
-    *
-    * "conflict" alone is deliberately NOT matched: HTTP 409 is literally named
-    * "Conflict" and its lost-race messages can carry the bare word, and that is
-    * exactly the case that must stay retryable. Requiring the pair keeps the
-    * predicate from terminating runs that a retry would have won. */
-   return ci_grade_casestr(err, "merge conflict") != NULL;
-}
 
 int git_pr_ci_permits_merge(git_pr_ci_t ci)
 {

--- a/src/tests/test_git_pr_ci_grade.c
+++ b/src/tests/test_git_pr_ci_grade.c
@@ -99,30 +99,11 @@ int main(void)
    /* end to end: an unreadable answer must not reach a merge */
    assert(!git_pr_ci_permits_merge(grade_with("not json")));
 
-   /* --- terminal conflict vs retryable lost race (both arrive as 405/409) ---
-    * A content conflict is identical on every retry, so it must be terminal; a
-    * moved head/base is a lost race a retry wins. Getting this wrong in the
-    * retryable direction wedges a run forever (observed: 15 attempts over 3
-    * hours); getting it wrong in the terminal direction kills a run that would
-    * have merged. Hence the predicate fails SAFE toward retry. */
-   assert(git_pr_merge_err_is_conflict("github API (pr merge, HTTP 405): Pull Request has merge "
-                                       "conflicts"));
-   assert(git_pr_merge_err_is_conflict("merge conflict"));           /* minimal phrasing */
-   assert(git_pr_merge_err_is_conflict("MERGE CONFLICTS DETECTED")); /* case-insensitive */
-
-   /* Lost races must stay retryable — these are the messages a retry wins. */
-   assert(!git_pr_merge_err_is_conflict(
-       "github API (pr merge, HTTP 409): Head branch was modified. Review and try the merge "
-       "again."));
-   assert(!git_pr_merge_err_is_conflict("github API (pr merge, HTTP 405): Base branch was "
-                                        "modified. Review and try the merge again."));
-   /* The bare word must NOT terminate: HTTP 409 is named "Conflict", so a
-    * lost-race message can carry it with no content conflict involved. */
-   assert(!git_pr_merge_err_is_conflict("github API (pr merge, HTTP 409): Conflict"));
-   /* Unrecognised / empty degrade to retry, never to a terminal kill. */
-   assert(!git_pr_merge_err_is_conflict("github API (pr merge, HTTP 405): failed"));
-   assert(!git_pr_merge_err_is_conflict(""));
-   assert(!git_pr_merge_err_is_conflict(NULL));
+   /* The terminal-conflict vs retryable-lost-race classification moved into the
+    * git module with the merge itself. Its cases — including the ones that must
+    * NOT terminate, which is the direction that wedged a run for 15 attempts
+    * over 3 hours — are pinned in
+    * server-go/modules/git: TestMergeConflictClassificationFailsSafeTowardRetry. */
 
    printf("ok\n");
    return 0;


### PR DESCRIPTION
`git_pr_merge_err_is_conflict` lost its last production caller when the merge moved into the module (#2498) — the stage reports `conflict` and `retryable` apart, and C just translates them. I flagged it there and left it for a follow-up rather than mixing a deletion into a behaviour change. This is that follow-up.

## Coverage moved first, then the code

This is the part worth reviewing. The C test carried cases the Go side **did not have**: `isMergeConflict` had no direct test at all, only incidental exercise through a single 409 case.

Deleting the C copy on its own would have quietly dropped the lost-race cases:

- `Head branch was modified`
- `Base branch was modified`
- the bare word `Conflict` — which HTTP 409 is *literally named after*

Those are the ones that must **not** terminate. Getting that direction wrong wedged a run for **15 attempts over 3 hours**, holding the single active-root slot. They are now pinned directly against `isMergeConflict`, and every case passes unchanged against the Go implementation — so this is a relocation of coverage, not a loss of it.

## Also removed

`ci_grade_casestr` (the deleted function was its only caller) and the `<ctype.h>` include it needed. The file header no longer claims "two pure predicates" when one remains.

## How the dead helper was found — the first build lied

Worth calling out, because it nearly shipped: after removing the function, `make -C src -j8` reported **exit 0** with `ci_grade_casestr` already unreferenced. A stale object had satisfied the build. Touching the TU and rebuilding gave the real answer:

```
modules/git/git_pr_ci_grade.c:27:20: error: 'ci_grade_casestr' defined but not used [-Werror=unused-function]
```

All verification below was re-run after forcing recompilation of both touched TUs, rather than trusting the first green.

## Verification

- Forced rebuild of the touched TUs, then `make -C src -j8` — **exit 0, zero `error:`/`warning:`**
- `make -C src unit-tests` — green
- `make -C src lint` — exit 0, 48/48
- `refactor_baselines.py` — **ok, no drift** (checked explicitly because this edits a header; that check passes independently of the other inventory checks)
- `go test ./bus ./modules/... ./cmd/aimee-module` — green; `gofmt -l` clean
- Whole `pins` job locally, including the module supervisor
- Lock repinned via the exporter's own digest functions; `git` the only module moved