### PR TITLE
fix(guard): resolve the lineage probe dir to an existing directory

### DIFF
--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -1448,7 +1448,7 @@ static int attn_git_shares_foreign_session_history(const char *dir, const char *
  * then silently fell back to "main" -- so on a repo whose default is anything else, the
  * refusal named the wrong branch AND compared the base against it. Observed on one repo
  * in one minute: "('testing')" for a Bash op, "('main')" for an Edit. */
-static void attn_git_dir_for(const char *target, char *out, size_t outlen)
+void attn_git_dir_for(const char *target, char *out, size_t outlen)
 {
    if (!out || !outlen)
       return;
@@ -1456,9 +1456,23 @@ static void attn_git_dir_for(const char *target, char *out, size_t outlen)
    struct stat st;
    if (out[0] && stat(out, &st) == 0 && S_ISDIR(st.st_mode))
       return;
-   char *slash = strrchr(out, '/');
-   if (slash && slash != out)
+   /* Walk UP to the nearest EXISTING directory. Stripping a single component is not
+    * enough when the target is a new file in a not-yet-created directory: the result
+    * is another missing path, so `git -C` cannot run there and BOTH lineage probes
+    * (current branch, default ref) fail. The caller reads default_resolved == 0 as an
+    * unverifiable lineage and fails closed — so creating a file in a new subdirectory
+    * was refused with a branch-lineage error that had nothing to do with the branch,
+    * for every session without a registry row (which is every Claude Code session,
+    * since EnterWorktree writes none). Failing closed on a genuinely unresolvable
+    * default branch is deliberate and is preserved; this only stops a MISSING
+    * DIRECTORY from being mistaken for one. */
+   char *slash;
+   while ((slash = strrchr(out, '/')) != NULL && slash != out)
+   {
       *slash = '\0';
+      if (stat(out, &st) == 0 && S_ISDIR(st.st_mode))
+         return;
+   }
 }
 
 /* Pure decision for the session-isolation guard (testable in isolation).

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -90,6 +90,14 @@ int attn_session_branch_blocked(const char *base_branch, const char *default_bra
  * default branch (`default_resolved` 0) blocks, as the registry path does. */
 int attn_unregistered_lineage_blocked(int default_resolved, int shares_foreign_session_history);
 
+/* Resolve the directory the lineage probes should run `git -C` in, given a mutation
+ * target that may be a directory, an existing file, or a file that does not exist yet.
+ * Walks up to the nearest EXISTING directory: a target inside a not-yet-created
+ * directory would otherwise yield a missing path, both probes would fail, and
+ * attn_unregistered_lineage_blocked would fail closed on a lineage that is actually
+ * fine. Exposed for testing alongside the other lineage helpers. */
+void attn_git_dir_for(const char *target, char *out, size_t outlen);
+
 /* 1 = BLOCK: a WRITING Bash command reaches outside every managed worktree -- `cd <abs>`
  * to an unmanaged directory, or a redirect to an absolute path outside one. The
  * isolation check judges the cwd for Bash, so without this a command starting in a good

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -340,6 +340,50 @@ static void test_session_isolation_decision(void)
    assert(attn_unregistered_lineage_blocked(0, 0) == 1);
    assert(attn_unregistered_lineage_blocked(0, 1) == 1);
 
+   /* ---- git probe directory (attn_git_dir_for) ----
+    * THE REGRESSION: the probe directory was derived by stripping ONE component off the
+    * target. For a new file in a not-yet-created directory that yields another missing
+    * path, so `git -C` fails and BOTH lineage probes come back empty. The caller reads
+    * default_resolved == 0 and fails closed (asserted just above) — so creating a file in
+    * a new subdirectory was refused with a branch-lineage error that had nothing to do
+    * with the branch, for every session without a registry row. */
+   {
+      char tmpl[] = "/tmp/aimee_attn_gitdir_XXXXXX";
+      const char *root = mkdtemp(tmpl);
+      assert(root != NULL);
+
+      char got[2048];
+
+      /* An existing directory is returned as-is. */
+      attn_git_dir_for(root, got, sizeof(got));
+      assert(strcmp(got, root) == 0);
+
+      /* An existing FILE resolves to its (existing) parent. */
+      char existing_file[2200];
+      snprintf(existing_file, sizeof(existing_file), "%s/present.txt", root);
+      FILE *f = fopen(existing_file, "w");
+      assert(f != NULL);
+      fclose(f);
+      attn_git_dir_for(existing_file, got, sizeof(got));
+      assert(strcmp(got, root) == 0);
+
+      /* A new file in a MISSING directory must still resolve to a real directory —
+       * one level of absence... */
+      char one_deep[2200];
+      snprintf(one_deep, sizeof(one_deep), "%s/newdir/corpus.json", root);
+      attn_git_dir_for(one_deep, got, sizeof(got));
+      assert(strcmp(got, root) == 0);
+
+      /* ...and several. A single strip returned "<root>/a/b/c", which does not exist. */
+      char deep[2400];
+      snprintf(deep, sizeof(deep), "%s/a/b/c/corpus.json", root);
+      attn_git_dir_for(deep, got, sizeof(got));
+      assert(strcmp(got, root) == 0);
+
+      unlink(existing_file);
+      rmdir(root);
+   }
+
    /* ---- Bash reaching outside the worktree (attn_bash_escapes_worktree) ----
     * The observed bypass: cwd was a valid managed worktree, so the isolation check
     * passed, while the command cd'd to the shared checkout and wrote there. */

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -299,7 +299,7 @@
         },
         {
           "path": "src/headers/cli_attention_guard.h",
-          "sha256": "37c917b5d973930dae150f31e0cc49ed76db94eb38b545a52c3496cdbc9a9e70"
+          "sha256": "139e1f340b1c42bb8edbe864b40f868e979c0e265be7db53d22ec2425a65fc8c"
         },
         {
           "path": "src/headers/cli_chat_stream.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "27c02ca7f28016f978ceb7ad35b0918610f30b192ca998ee0add8c4dcb4e00fb",
+      "sha256": "9281a0fce30fce8254c7e2612f274200ba7762592cae43f8403956711760a960",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## Summary

Creating a file in a **new subdirectory** was refused by the attention guard, with an error blaming the branch:

```
refusing a mutating op — the worktree at '<path>' is on branch '(unknown)',
which has no launcher registry row and could not be checked, because the
default branch does not resolve here
```

Nothing was wrong with the branch, the worktree, or the registry.

## Root cause

`attn_git_dir_for()` derived the directory for the git lineage probes by stripping **one** component off the mutation target, without checking the result exists:

```c
char *slash = strrchr(out, '/');
if (slash && slash != out) *slash = '\0';   /* one strip, no stat */
```

For a new file in a not-yet-created directory that yields *another* missing path. `git -C <missing>` cannot run, so **both** probes fail — `attn_git_current_branch()` returns empty (hence `'(unknown)'`) and `attn_git_default_ref()` does not resolve.

The caller then reaches `attn_unregistered_lineage_blocked(default_resolved = 0, …)`, which **fails closed by design** — `test_attention_guard.c` already asserts that, and it is correct. So a valid worktree was refused because a directory did not exist yet, and the message pointed at everything except the actual cause.

## Why this hits every Claude Code session

Registry rows are written only by `workspace.c`. Claude Code's `EnterWorktree` writes none — the refusal text concedes this, and the comment at `cli_attention_guard.c:1594` spells it out. So every such session takes the `reg_state == 1` path and depends entirely on these two probes.

Net effect: **creating a file in any new subdirectory was blocked for every Claude Code session in this repo.** `mkdir -p` followed by the identical write succeeded, which is how the cause was finally isolated — after chasing a worktree-registration fault that never existed through three worktrees and a cherry-pick.

## The fix

Walk up to the nearest **existing** directory instead of stripping once.

The fail-closed policy is deliberate and is preserved untouched: a genuinely unresolvable default branch still blocks, and `attn_unregistered_lineage_blocked` is not modified. This only stops a **missing directory** from being mistaken for one.

## Tests

`attn_git_dir_for` is exposed in the header alongside the other lineage helpers, covering: an existing directory, an existing file, one missing level, and several missing levels (a single strip returned `<root>/a/b/c`, which does not exist).

**Verified red-before-green** — important here, because the failure mode is a false signal rather than a crash:

- single-strip behaviour restored → `test_attention_guard.c:375` aborts on `Assertion 'strcmp(got, root) == 0' failed`
- fix restored → `all tests passed`

## Verification

All re-run after rebasing onto current `testing`, not only before:

- `make -C src -j8` — exit 0, zero `error:` (full build, not just `unit-tests`, which does not compile server translation units)
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — **all 48 checks passed**
- `check_c_repository_lock` — ok
- `refactor_baselines` — drift verified additive-only against `origin/testing` (8 insertions, 0 removals in `cli_attention_guard.h`), then frozen

## Not included

The refusal message still cannot distinguish "the probe could not run" from "the lineage is genuinely wrong". With this fix the former should no longer happen spuriously, but a clearer message would have saved the entire investigation. Left out to keep the change minimal; happy to follow up.

---

*Opened with `gh` because `aimee git pr` returned "the git module could not be reached". Plain `aimee git` commands work; only the forge-side `pr` actions fail. `testing` has just merged #2500 (run the PR create in the module) and #2502 (forge-caller-reads), so this may be a deployment gap on the running server rather than a code fault.*
