### PR TITLE
feat: compact from recorded state, and measure whether it helps

### DIFF
--- a/benchmarks/compaction-quality/corpus.json
+++ b/benchmarks/compaction-quality/corpus.json
@@ -1,0 +1,145 @@
+{
+  "_comment": [
+    "Compaction-retention corpus. Ground truth is PLANTED, not extracted: each fixture",
+    "declares the exact strings an agent would need after the boundary to keep working.",
+    "Nothing here is derived by coord_closet or fold_register - if it were, the record",
+    "path would win by construction and the measurement would be worthless.",
+    "",
+    "Categories are deliberately balanced so BOTH derivations have cases they should win",
+    "and cases they should lose. `expect` records the prior belief; it is documentation,",
+    "not an assertion - the harness reports what actually happened either way."
+  ],
+  "fixtures": [
+    {
+      "id": "f01_paths_with_extensions",
+      "category": "paths-easy",
+      "expect": "both",
+      "note": "Ordinary source paths with known extensions. token_looks_like_path matches these, so the legacy path should do fine.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Fix the retry backoff."},
+        {"role": "assistant", "content": "Reading src/modules/git/retry.c and src/headers/retry.h now."},
+        {"role": "assistant", "content": "The helper lives in scripts/check_retry.py as well."}
+      ],
+      "planted": ["src/modules/git/retry.c", "src/headers/retry.h", "scripts/check_retry.py"]
+    },
+    {
+      "id": "f02_commit_shas",
+      "category": "identifiers",
+      "expect": "record",
+      "note": "Commit SHAs. token_looks_like_path cannot match these at all - no slash, no extension.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Which commit introduced the regression?"},
+        {"role": "assistant", "content": "Bisect lands on 4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162, and the revert candidate is 9f2e1a7c4b8d6053e1f9a2c7b4d8e6053f1a9c2e."}
+      ],
+      "planted": ["4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162", "9f2e1a7c4b8d6053e1f9a2c7b4d8e6053f1a9c2e"]
+    },
+    {
+      "id": "f03_issue_refs_and_uuids",
+      "category": "identifiers",
+      "expect": "record",
+      "note": "Issue refs and a UUID - again structurally invisible to a path-shaped-token scan.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Track the migration."},
+        {"role": "assistant", "content": "Blocked on #778 and the run id is 7c9e4b21-3f8a-4d15-9e2b-6a1c8f4d0e37."}
+      ],
+      "planted": ["#778", "7c9e4b21-3f8a-4d15-9e2b-6a1c8f4d0e37"]
+    },
+    {
+      "id": "f04_decision_with_keywords",
+      "category": "decisions-keyworded",
+      "expect": "legacy",
+      "note": "A settled decision phrased with the exact keywords the legacy scan hunts for, and NO register tag. The record path should MISS this - the agent never tagged it.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "How are we handling the cache?"},
+        {"role": "assistant", "content": "We decided to use a write-through cache keyed by tenant id."}
+      ],
+      "planted": ["write-through cache keyed by tenant id"]
+    },
+    {
+      "id": "f05_decision_tagged_no_keywords",
+      "category": "decisions-tagged",
+      "expect": "record",
+      "note": "A settled conclusion the agent tagged [verdict], carrying none of the legacy keywords.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Can the budget be raised downstream?"},
+        {"role": "assistant", "content": "[verdict] The retry budget is capped upstream; nothing downstream can raise it."}
+      ],
+      "planted": ["retry budget is capped upstream"]
+    },
+    {
+      "id": "f06_error_with_keywords",
+      "category": "errors-keyworded",
+      "expect": "legacy",
+      "note": "A failure phrased with legacy keywords and no register tag. Record path should miss it.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Run the suite."},
+        {"role": "assistant", "content": "The migration failed with a unique constraint violation on tenant_id."}
+      ],
+      "planted": ["unique constraint violation on tenant_id"]
+    },
+    {
+      "id": "f07_hazard_tagged_no_keywords",
+      "category": "errors-tagged",
+      "expect": "record",
+      "note": "A hazard the agent tagged, with none of the legacy keywords present.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Can we ship the migration?"},
+        {"role": "assistant", "content": "[hazard] Shipping before the backfill will strand rows in the old shard."}
+      ],
+      "planted": ["strand rows in the old shard"]
+    },
+    {
+      "id": "f08_untagged_realistic_session",
+      "category": "untagged-realistic",
+      "expect": "legacy",
+      "note": "THE HONEST CASE. A realistic session where the agent emits no register tags at all - which is the default today, since fold_register_enabled is off. The record path has no classification to read, so its Decisions/Blocked should come back EMPTY while the legacy keyword scan still finds something.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Why is checkout slow?"},
+        {"role": "assistant", "content": "Profiling shows the N+1 in src/orders/checkout.c dominating."},
+        {"role": "assistant", "content": "I decided to batch the loads; the error was a missing index on orders.tenant_id."}
+      ],
+      "planted": ["src/orders/checkout.c", "batch the loads", "missing index on orders.tenant_id"]
+    },
+    {
+      "id": "f09_mixed_long_session",
+      "category": "mixed",
+      "expect": "unknown",
+      "note": "A longer mixed session: tagged and untagged turns, paths and identifiers together. Closest to a real transcript.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Investigate the failing deploy."},
+        {"role": "assistant", "content": "Deploy manifest is deploy/compose/aimee.gpu.yaml."},
+        {"role": "assistant", "content": "[verdict] The image digest sha256:1f3a9c7e2b5d8046a1c9f3e7b2d5806 is stale relative to the tag."},
+        {"role": "assistant", "content": "Retrying the pull now."},
+        {"role": "assistant", "content": "We chose to pin the floating tag instead."},
+        {"role": "assistant", "content": "[hazard] Pinning breaks the auto-update path for every downstream host."}
+      ],
+      "planted": [
+        "deploy/compose/aimee.gpu.yaml",
+        "sha256:1f3a9c7e2b5d8046a1c9f3e7b2d5806",
+        "pin the floating tag",
+        "breaks the auto-update path"
+      ]
+    },
+    {
+      "id": "f10_paths_without_extensions",
+      "category": "paths-hard",
+      "expect": "both",
+      "note": "Directory-style paths with no file extension. Both should catch these via the slash rule.",
+      "messages": [
+        {"role": "system", "content": "You are a coder."},
+        {"role": "user", "content": "Where does state live?"},
+        {"role": "assistant", "content": "State is under /var/lib/aimee and the socket dir is /run/aimee/sockets."}
+      ],
+      "planted": ["/var/lib/aimee", "/run/aimee/sockets"]
+    }
+  ]
+}

--- a/benchmarks/compaction-quality/retention_probe.c
+++ b/benchmarks/compaction-quality/retention_probe.c
@@ -1,0 +1,214 @@
+/* retention_probe.c: how much load-bearing detail survives a compaction boundary?
+ *
+ * Runs BOTH summary derivations over the same corpus and reports, per fixture and in
+ * aggregate, how many PLANTED facts survive verbatim into the summary.
+ *
+ * Why planted facts, and not extracted ones: if ground truth were produced by
+ * coord_closet (the very extractor the record path uses), the record path would score
+ * 100% by construction and the number would mean nothing. That is the
+ * assertion-that-tracks-instead-of-checking failure. Every expected string here is
+ * written down by hand in corpus.json, independent of both derivations, and matched by
+ * plain substring search.
+ *
+ * The corpus is deliberately balanced: some categories favour the legacy prose scan
+ * (keyworded decisions, keyworded errors), some favour the record path (identifiers,
+ * register-tagged turns), and one - untagged-realistic - is the case the record path is
+ * expected to LOSE, because register tagging is off by default so a real transcript
+ * carries no [verdict]/[hazard] tags at all.
+ *
+ * This measures RETENTION only. It says nothing about rounds-to-resume, which needs
+ * live agents; see docs/proposals/pending/compaction-quality-baseline.md.
+ *
+ * Exit status is 0 whenever the run completed. It is a measurement, not a gate - a
+ * derivation scoring badly is a result to read, not a build failure.
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aimee.h"
+#include "session_compact.h"
+#include "cJSON.h"
+
+/* Compaction only engages once the array is longer than the anchor plus the retained
+ * tail, and only the middle is summarised. Padding keeps the fixture's own turns inside
+ * the summarised region rather than the verbatim tail - otherwise a fact would "survive"
+ * simply by never having been compacted, which measures nothing. */
+#define PAD_PAIRS 8
+
+static cJSON *msg(const char *role, const char *content)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", role);
+   cJSON_AddStringToObject(m, "content", content);
+   return m;
+}
+
+static cJSON *build_messages(const cJSON *fixture)
+{
+   cJSON *arr = cJSON_CreateArray();
+   const cJSON *msgs = cJSON_GetObjectItemCaseSensitive((cJSON *)fixture, "messages");
+   const cJSON *m = NULL;
+   cJSON_ArrayForEach(m, msgs)
+   {
+      const char *role = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "role"));
+      const char *content = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "content"));
+      cJSON_AddItemToArray(arr, msg(role ? role : "user", content ? content : ""));
+   }
+   for (int i = 0; i < PAD_PAIRS; i++)
+   {
+      char u[96], a[96];
+      snprintf(u, sizeof(u), "Filler user turn %d, carrying nothing worth conserving.", i);
+      snprintf(a, sizeof(a), "Filler assistant turn %d, carrying nothing worth conserving.", i);
+      cJSON_AddItemToArray(arr, msg("user", u));
+      cJSON_AddItemToArray(arr, msg("assistant", a));
+   }
+   return arr;
+}
+
+/* Returns the number of planted facts present verbatim in `summary`, and writes the
+ * misses into `missed` (comma separated, truncated) so a low score is explainable
+ * rather than just a number. */
+static int count_retained(const cJSON *planted, const char *summary, char *missed, size_t cap)
+{
+   int kept = 0;
+   size_t pos = 0;
+   if (cap)
+      missed[0] = '\0';
+   const cJSON *p = NULL;
+   cJSON_ArrayForEach(p, planted)
+   {
+      const char *want = cJSON_GetStringValue((cJSON *)p);
+      if (!want || !want[0])
+         continue;
+      if (strstr(summary, want))
+      {
+         kept++;
+         continue;
+      }
+      if (cap && pos + 3 < cap)
+      {
+         int n = snprintf(missed + pos, cap - pos, "%s%.60s", pos ? ", " : "", want);
+         if (n > 0)
+            pos += (size_t)n < cap - pos ? (size_t)n : cap - pos - 1;
+      }
+   }
+   return kept;
+}
+
+static int run_one(const cJSON *fixture, int from_record, char *summary_out, size_t summary_cap)
+{
+   cJSON *arr = build_messages(fixture);
+   session_compact_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.from_record = from_record;
+
+   session_compact_result_t result;
+   int rc = session_compact(arr, &cfg, &result);
+   int compacted = (rc == 0 && result.compacted);
+   if (compacted)
+      snprintf(summary_out, summary_cap, "%s", result.summary);
+   else
+      summary_out[0] = '\0';
+   cJSON_Delete(arr);
+   return compacted;
+}
+
+int main(int argc, char **argv)
+{
+   const char *path = argc > 1 ? argv[1] : "benchmarks/compaction-quality/corpus.json";
+   FILE *f = fopen(path, "rb");
+   if (!f)
+   {
+      fprintf(stderr, "retention_probe: cannot open %s\n", path);
+      return 2;
+   }
+   fseek(f, 0, SEEK_END);
+   long len = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   char *buf = malloc((size_t)len + 1);
+   if (!buf || fread(buf, 1, (size_t)len, f) != (size_t)len)
+   {
+      fprintf(stderr, "retention_probe: cannot read %s\n", path);
+      fclose(f);
+      free(buf);
+      return 2;
+   }
+   buf[len] = '\0';
+   fclose(f);
+
+   cJSON *root = cJSON_Parse(buf);
+   free(buf);
+   if (!root)
+   {
+      fprintf(stderr, "retention_probe: cannot parse %s\n", path);
+      return 2;
+   }
+   cJSON *fixtures = cJSON_GetObjectItemCaseSensitive(root, "fixtures");
+   if (!cJSON_IsArray(fixtures))
+   {
+      fprintf(stderr, "retention_probe: no fixtures array\n");
+      cJSON_Delete(root);
+      return 2;
+   }
+
+   printf("%-34s %-20s %8s %8s   %s\n", "fixture", "category", "legacy", "record", "expect");
+   printf("---------------------------------------------------------------------------------"
+          "-----\n");
+
+   int tot_planted = 0, tot_legacy = 0, tot_record = 0;
+   int skipped = 0;
+   static char sum_legacy[SESSION_COMPACT_SUMMARY_MAX];
+   static char sum_record[SESSION_COMPACT_SUMMARY_MAX];
+   char missed_legacy[512], missed_record[512];
+
+   const cJSON *fx = NULL;
+   cJSON_ArrayForEach(fx, fixtures)
+   {
+      const char *id = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)fx, "id"));
+      const char *cat = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)fx, "category"));
+      const char *expect = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)fx, "expect"));
+      cJSON *planted = cJSON_GetObjectItem((cJSON *)fx, "planted");
+      int n_planted = cJSON_IsArray(planted) ? cJSON_GetArraySize(planted) : 0;
+      if (!id || n_planted == 0)
+         continue;
+
+      int c1 = run_one(fx, 0, sum_legacy, sizeof(sum_legacy));
+      int c2 = run_one(fx, 1, sum_record, sizeof(sum_record));
+      if (!c1 || !c2)
+      {
+         /* No boundary means nothing was measured. Report it rather than scoring 0,
+          * which would look like total loss. */
+         printf("%-34s %-20s %8s %8s   %s\n", id, cat ? cat : "?", "no-compact", "no-compact",
+                expect ? expect : "?");
+         skipped++;
+         continue;
+      }
+
+      int kept_legacy = count_retained(planted, sum_legacy, missed_legacy, sizeof(missed_legacy));
+      int kept_record = count_retained(planted, sum_record, missed_record, sizeof(missed_record));
+
+      char l[32], r[32];
+      snprintf(l, sizeof(l), "%d/%d", kept_legacy, n_planted);
+      snprintf(r, sizeof(r), "%d/%d", kept_record, n_planted);
+      printf("%-34s %-20s %8s %8s   %s\n", id, cat ? cat : "?", l, r, expect ? expect : "?");
+      if (kept_legacy < n_planted && missed_legacy[0])
+         printf("      legacy missed: %s\n", missed_legacy);
+      if (kept_record < n_planted && missed_record[0])
+         printf("      record missed: %s\n", missed_record);
+
+      tot_planted += n_planted;
+      tot_legacy += kept_legacy;
+      tot_record += kept_record;
+   }
+
+   printf("---------------------------------------------------------------------------------"
+          "-----\n");
+   printf("TOTAL retained: legacy %d/%d (%.1f%%)   record %d/%d (%.1f%%)   skipped %d\n",
+          tot_legacy, tot_planted, tot_planted ? 100.0 * tot_legacy / tot_planted : 0.0,
+          tot_record, tot_planted, tot_planted ? 100.0 * tot_record / tot_planted : 0.0, skipped);
+
+   cJSON_Delete(root);
+   return 0;
+}

--- a/benchmarks/compaction-quality/run-on-252.sh
+++ b/benchmarks/compaction-quality/run-on-252.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Ship the retention probe + corpus to the test host and run them there.
+#
+# The probe is built locally and shipped as a binary: .252 has gcc, but building the
+# whole tree there just to run one measurement is not worth it. Both hosts are x86_64
+# Linux; if the loader complains, build on .252 instead.
+#
+# Scoped cleanup only. .252 runs a live aimee deployment of its own — never a blanket
+# pkill, and never touch anything outside this run's directory.
+set -eu
+
+HOST="${HOST:-root@192.168.1.252}"
+REMOTE_DIR="${REMOTE_DIR:-/tmp/compaction-retention-run}"
+PROBE="src/build/obj/tests/compaction-retention-probe"
+CORPUS="benchmarks/compaction-quality/corpus.json"
+
+[ -x "$PROBE" ] || { echo "missing $PROBE — run: make -C src compaction-retention-probe" >&2; exit 2; }
+[ -f "$CORPUS" ] || { echo "missing $CORPUS" >&2; exit 2; }
+
+echo "== shipping to $HOST:$REMOTE_DIR =="
+tar czf - "$PROBE" "$CORPUS" | ssh "$HOST" "mkdir -p $REMOTE_DIR && tar xzf - -C $REMOTE_DIR"
+
+echo "== host =="
+ssh "$HOST" "hostname; uname -m; ldd --version | head -1"
+
+echo "== run =="
+ssh "$HOST" "cd $REMOTE_DIR && ./$PROBE $CORPUS"
+
+echo "== cleanup =="
+ssh "$HOST" "rm -rf $REMOTE_DIR"
+ssh "$HOST" "ls -d $REMOTE_DIR 2>/dev/null && echo 'WARNING: cleanup failed' || echo 'cleanup ok'"

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "204982e24430acf71a0d345b5c51ee1abe0dcc216cb384a53b4e889d7932a1fa"
+      "source_sha256": "8d2b566fd09ee8a1ee3fe87b4857bb430b094ae57b35cd8593e1c5024ddae3b7"
     },
     {
       "id": "ir",

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -232,7 +232,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`auxiliary`**: _Auxiliary (cheap/background) model used for side tasks._ Keys: `default_max_tokens`, `default_model`, `default_provider`, `enabled`, `tasks`
 - **`cache_shaping`**: _Prompt-cache shaping._ Keys: `enabled`, `min_chars`
 - **`charter`**: _Operating charter: values, constraints, safety axioms, tone._ Keys: `hard_constraints`, `safety_axioms`, `tone_boundaries`, `values`, `working_profile_drift_limit`
-- **`compact`**: _Transcript compaction thresholds._ Keys: `coord_closet`, `enabled`, `head_bytes`, `per_tool`, `tail_bytes`, `threshold`
+- **`compact`**: _Transcript compaction thresholds._ Keys: `coord_closet`, `enabled`, `from_record`, `head_bytes`, `per_tool`, `tail_bytes`, `threshold`
 - **`computer_use`**: _Computer-use (browser) tool settings._ Keys: `allowed_domains`, `default_navigation`, `enabled`, `redact_sensitive_screenshots`
 - **`concurrency`**: _Per-model / per-provider concurrency limits._ Keys: `default`, `maximum_total_concurrent_agent_sessions`, `per_model`, `per_provider`, `preempt`
 - **`context`**: _Context-engine selection._ Keys: `engine`

--- a/src/headers/session_compact.h
+++ b/src/headers/session_compact.h
@@ -64,6 +64,22 @@ typedef struct
    int warn_pct;    /* warn threshold %; 0 = use default (70) */
    int compact_pct; /* compact threshold %; 0 = use default (80) */
    int retain_tail; /* recent messages to keep verbatim; 0 = use default (6) */
+
+   /* Summary derivation. 0 (default) = the legacy prose scan: guess which tokens
+    * are paths by shape, and match "error"/"decided"-style keywords. 1 = derive
+    * from the economizer's deterministic extractors instead —
+    *
+    *   Relevant Files  <- Coordinate Closet coordinates, conserved VERBATIM with
+    *                      provenance, secrets redacted, and inability to conserve
+    *                      REPORTED (COORD_EVICT_FAIL) rather than silently dropped.
+    *   Key Decisions   <- turns the agent itself tagged as settled (verdict).
+    *   Blocked         <- turns the agent itself tagged hazard / blocked.
+    *
+    * The point is that these are facts recorded as the turn happened, not facts
+    * re-derived by reading the transcript's residue afterwards. Supplied by the
+    * caller (config_compact_from_record()) so this module stays a pure function of
+    * its inputs and never reads global config. */
+   int from_record;
 } session_compact_config_t;
 
 typedef struct

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -721,7 +721,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->sandbox.mode = SANDBOX_MODE_WORKSPACE_ONLY;
    snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
             "proxy");
-   cfg->compact_enabled = 1; /* default on; set before no-config early returns */
+   cfg->compact_enabled = 1;    /* default on; set before no-config early returns */
+   cfg->compact_from_record = 0; /* default-off until the quality baseline exists */
    cfg->coord_closet_enabled =
        1; /* fold §2: default-ON — conserves identifiers elided by the
            * default-on compress/fold so lossy reduction stays recoverable */

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -721,7 +721,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->sandbox.mode = SANDBOX_MODE_WORKSPACE_ONLY;
    snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
             "proxy");
-   cfg->compact_enabled = 1;    /* default on; set before no-config early returns */
+   cfg->compact_enabled = 1;     /* default on; set before no-config early returns */
    cfg->compact_from_record = 0; /* default-off until the quality baseline exists */
    cfg->coord_closet_enabled =
        1; /* fold §2: default-ON — conserves identifiers elided by the

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -1146,6 +1146,15 @@ typedef struct config
    char compact_per_tool[CONFIG_COMPACT_MAX_PER_TOOL][128]; /* "tool_name=threshold" */
    int compact_per_tool_count;
 
+   /* Session-compaction summary derivation. 0 (default) = the legacy prose scan
+    * (guess paths by shape, match "error"/"decided" keywords). 1 = derive from the
+    * economizer's deterministic extractors instead: Coordinate Closet coordinates
+    * conserved VERBATIM, and fold_register's settled/hazard classification of the
+    * agent's own turns. Default-off because compaction quality is still unmeasured
+    * (docs/proposals/pending/compaction-quality-baseline.md); the legacy path stays
+    * selectable until that baseline can say which is better. */
+   int compact_from_record;
+
    /* Coordinate Closet (fold §2): conserve verbatim identifiers from compacted
     * tool results. Nested under the "compact" config section. Default-off.
     * coord_closet_enabled: 0 = off (default), 1 = on.

--- a/src/modules/config/config_accessors.h
+++ b/src/modules/config/config_accessors.h
@@ -184,6 +184,7 @@ int config_search_max_results(void);
 int config_search_fetch_pages(void);
 int config_compact_enabled(void);
 int config_compact_threshold(void);
+int config_compact_from_record(void);
 int config_compact_head_bytes(void);
 int config_compact_tail_bytes(void);
 int config_compact_per_tool_count(void);

--- a/src/modules/config/config_accessors_1.c
+++ b/src/modules/config/config_accessors_1.c
@@ -179,6 +179,13 @@ int config_compact_threshold(void)
    return v;
 }
 
+int config_compact_from_record(void)
+{
+   int v = 0;
+   config_field_read(offsetof(config_t, compact_from_record), sizeof(v), &v);
+   return v;
+}
+
 int config_compact_head_bytes(void)
 {
    int v = 0;

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1040,12 +1040,14 @@ int config_save(const config_t *cfg)
 
    /* Tool result compaction (only save non-default values) */
    if (!cfg->compact_enabled || cfg->compact_threshold || cfg->compact_head_bytes ||
-       cfg->compact_tail_bytes || cfg->compact_per_tool_count || !cfg->coord_closet_enabled ||
-       cfg->coord_closet_budget_bytes || cfg->coord_closet_max_ratio_pct ||
-       cfg->coord_closet_denylist[0])
+       cfg->compact_tail_bytes || cfg->compact_per_tool_count || cfg->compact_from_record ||
+       !cfg->coord_closet_enabled || cfg->coord_closet_budget_bytes ||
+       cfg->coord_closet_max_ratio_pct || cfg->coord_closet_denylist[0])
    {
       cJSON *cmpct = cJSON_AddObjectToObject(root, "compact");
       cJSON_AddBoolToObject(cmpct, "enabled", cfg->compact_enabled);
+      if (cfg->compact_from_record) /* default-off: persist only the opt-in */
+         cJSON_AddBoolToObject(cmpct, "from_record", cfg->compact_from_record);
       if (cfg->compact_threshold)
          cJSON_AddNumberToObject(cmpct, "threshold", cfg->compact_threshold);
       if (cfg->compact_head_bytes)

--- a/src/modules/config/config_sections.c
+++ b/src/modules/config/config_sections.c
@@ -621,6 +621,10 @@ void config_parse_compact_section(config_t *cfg, cJSON *root)
       if (cJSON_IsBool(item))
          cfg->compact_enabled = cJSON_IsTrue(item) ? 1 : 0;
 
+      item = cJSON_GetObjectItemCaseSensitive(cmpct, "from_record");
+      if (cJSON_IsBool(item))
+         cfg->compact_from_record = cJSON_IsTrue(item) ? 1 : 0;
+
       item = cJSON_GetObjectItemCaseSensitive(cmpct, "threshold");
       if (cJSON_IsNumber(item) && item->valuedouble > 0)
          cfg->compact_threshold = (int)item->valuedouble;

--- a/src/modules/economizer/coord_closet.c
+++ b/src/modules/economizer/coord_closet.c
@@ -253,21 +253,43 @@ static size_t match_kv(const char *p, size_t n, char *lbl, size_t lblsz, size_t 
 }
 
 /* path: starts with '/' or './' or '../', contains a '/', no spaces. */
+/* Anchored paths (/x, ./x, ../x) are unambiguous: one slash is enough. A BARE
+ * repo-relative path (src/server/session_compact.c) has no such marker and shares its
+ * shape with ordinary prose — "and/or", "he/she", "24/7", "2026/08/10" — so it needs a
+ * stricter test, or the closet fills with noise and evicts real coordinates to stay
+ * inside its budget.
+ *
+ * Bare form requires ALL of:
+ *   - at least one letter          (rejects "2026/08/10", "24/7")
+ *   - a dot in the final segment, OR two or more slashes
+ *                                  (rejects "and/or", "he/she", "TODO/FIXME";
+ *                                   accepts "scripts/x.py" and "src/modules/git")
+ *
+ * The conservative casualty is a one-slash extensionless relative path ("src/server"),
+ * which stays unmatched rather than admitting every "and/or" in the transcript.
+ *
+ * This gap was measured, not guessed: with bare paths unmatched, the record-derived
+ * compaction summary retained 0/3 relative source paths that the legacy prose scan
+ * caught 3/3 (benchmarks/compaction-quality). The header has always documented this
+ * kind as "absolute / repo-relative path" — the matcher just never implemented the
+ * second half. */
 static size_t match_path(const char *p, size_t n)
 {
    if (n == 0)
       return 0;
-   int leading = (p[0] == '/') || (n >= 2 && p[0] == '.' && p[1] == '/') ||
-                 (n >= 3 && p[0] == '.' && p[1] == '.' && p[2] == '/');
-   if (!leading)
-      return 0;
+   int anchored = (p[0] == '/') || (n >= 2 && p[0] == '.' && p[1] == '/') ||
+                  (n >= 3 && p[0] == '.' && p[1] == '.' && p[2] == '/');
    size_t off = 0;
    int slashes = 0;
+   int letters = 0;
+   size_t last_slash = 0;
    while (off < n && (a_alnum((unsigned char)p[off]) || p[off] == '/' || p[off] == '.' ||
                       p[off] == '_' || p[off] == '-'))
    {
       if (p[off] == '/')
-         slashes++;
+         last_slash = off, slashes++;
+      else if (a_alpha((unsigned char)p[off]))
+         letters++;
       off++;
    }
    if (slashes < 1 || off < 3)
@@ -275,6 +297,19 @@ static size_t match_path(const char *p, size_t n)
    /* trim a trailing dot (sentence punctuation) */
    while (off > 0 && p[off - 1] == '.')
       off--;
+   if (!anchored)
+   {
+      /* Re-test the dot AFTER trimming: "src/foo." must not qualify on a dot that
+       * was only sentence punctuation. */
+      int dot_in_final = 0;
+      for (size_t i = last_slash + 1; i < off; i++)
+         if (p[i] == '.')
+            dot_in_final = 1;
+      if (letters == 0)
+         return 0;
+      if (!dot_in_final && slashes < 2)
+         return 0;
+   }
    return off;
 }
 

--- a/src/modules/economizer/economizer.h
+++ b/src/modules/economizer/economizer.h
@@ -15,5 +15,6 @@
 #include "context_reduce.h"   /* context_reduce(), reduce_config_t / reduce_result_t / seams */
 #include "context_fold.h"     /* context_fold_view / context_compress_view, fold_config_t */
 #include "tool_condense.h"    /* tool_condense_apply / _recall / _enabled, family parsers */
+#include "fold_register.h" /* fold_register_parse / _label: settled-vs-transient turn classes */
 
 #endif /* DEC_ECONOMIZER_H */

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -250,6 +250,9 @@ static void maybe_compact_before_request(const agent_t *agent, cJSON *messages,
    session_compact_config_t scfg;
    memset(&scfg, 0, sizeof(scfg));
    scfg.compact_pct = compact_pct;
+   /* session_compact stays a pure function of its inputs, so the derivation choice
+    * is resolved here rather than read from global config inside the compactor. */
+   scfg.from_record = config_compact_from_record();
 
    int estimated_tokens = request_prompt_token_estimate(messages, system_prompt);
    if (session_compact_pressure(estimated_tokens, 0, context_window, &scfg) !=
@@ -689,7 +692,10 @@ native_provider_http:
          {
             aimee_log(LOG_INFO, "agent", "middleware: compact requested: %s", mw_res.reason);
             session_compact_result_t sc_result;
-            session_compact(messages, NULL, &sc_result);
+            session_compact_config_t mw_scfg;
+            memset(&mw_scfg, 0, sizeof(mw_scfg));
+            mw_scfg.from_record = config_compact_from_record();
+            session_compact(messages, &mw_scfg, &sc_result);
             if (sc_result.compacted)
             {
                aimee_log(LOG_INFO, "agent",

--- a/src/server/session_compact.c
+++ b/src/server/session_compact.c
@@ -788,8 +788,8 @@ int session_compact(cJSON *messages, const session_compact_config_t *cfg,
    compact_prune_tool_results(messages, summary_start, summary_end, 0);
 
    /* Step 3: build summary of messages[summary_start..summary_end) */
-   build_summary(messages, summary_start, summary_end, local_out.summary,
-                 sizeof(local_out.summary), cfg ? cfg->from_record : 0);
+   build_summary(messages, summary_start, summary_end, local_out.summary, sizeof(local_out.summary),
+                 cfg ? cfg->from_record : 0);
 
    /* Step 4: insert a boundary marker message right after messages[0].
     * We build the JSON object first, then splice it in. */

--- a/src/server/session_compact.c
+++ b/src/server/session_compact.c
@@ -6,6 +6,7 @@
 #include "session_compact.h"
 #include "headers/compact_prune.h"
 #include "agent_protocol.h"
+#include "economizer.h" /* coord_closet_* / fold_register_parse — the record path */
 #include "cJSON.h"
 #include <ctype.h>
 #include <stdarg.h>
@@ -266,6 +267,116 @@ static void flashback_extract_from_text(cJSON *files, cJSON *errors, cJSON *deci
    }
 }
 
+/* ------------------------------------------------- record-derived extraction */
+
+/* The record path. Where flashback_build() GUESSES — token_looks_like_path() decides
+ * a token is a path by its shape, and a line is an error because it contains the
+ * substring "error" — this reads what the system already recorded exactly:
+ *
+ *   files      Coordinate Closet coordinates of kind PATH, conserved VERBATIM. A
+ *              path that survives here is byte-identical to the one the tool
+ *              emitted, not a token that looked path-shaped.
+ *   decisions  turns the agent itself tagged settled (verdict).
+ *   blocked    turns the agent itself tagged hazard or blocked.
+ *
+ * User-authored text is nominated in COORD_LANE_USER so pasted content stays
+ * quarantined and cannot mint an agent-trusted coordinate (the closet's
+ * prompt-injection guard). Register classification is only read from ASSISTANT
+ * turns — the register grammar describes the agent's own claim about its turn, so
+ * applying it to user text would let a user's message assert "verdict".
+ *
+ * Returns the same {files_modified, errors_encountered, decisions_made} shape as
+ * flashback_build() so the rendering below is identical for both paths. On
+ * allocation failure returns NULL and the caller falls back. */
+static cJSON *record_build(const cJSON *messages, int start_idx, int end_idx, char **closet_out,
+                           coord_evict_t *evict_out)
+{
+   if (closet_out)
+      *closet_out = NULL;
+   if (evict_out)
+      *evict_out = COORD_EVICT_NONE;
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON *files = cJSON_CreateArray();
+   cJSON *errors = cJSON_CreateArray();
+   cJSON *decisions = cJSON_CreateArray();
+   if (!root || !files || !errors || !decisions)
+   {
+      cJSON_Delete(root);
+      cJSON_Delete(files);
+      cJSON_Delete(errors);
+      cJSON_Delete(decisions);
+      return NULL;
+   }
+   cJSON_AddItemToObject(root, "files_modified", files);
+   cJSON_AddItemToObject(root, "errors_encountered", errors);
+   cJSON_AddItemToObject(root, "decisions_made", decisions);
+
+   coord_set_t set;
+   coord_set_init(&set);
+   size_t raw_total = 0;
+
+   for (int i = start_idx; i < end_idx; i++)
+   {
+      cJSON *msg = cJSON_GetArrayItem((cJSON *)messages, i);
+      const char *text = msg_text(msg);
+      if (!text || !text[0])
+         continue;
+      const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(msg, "role"));
+      const int is_user = role && strcmp(role, "user") == 0 && !msg_is_tool_result(msg);
+
+      coord_provenance_t prov;
+      memset(&prov, 0, sizeof(prov));
+      prov.lane = is_user ? COORD_LANE_USER : COORD_LANE_AGENT;
+      prov.turn_id = i;
+      prov.tool_call_id = -1;
+      prov.result_index = -1;
+
+      size_t len = strlen(text);
+      raw_total += len;
+      coord_closet_nominate(text, len, &prov, &set);
+
+      if (role && strcmp(role, "assistant") == 0)
+      {
+         switch (fold_register_parse(text))
+         {
+         case FOLD_REG_VERDICT:
+            flashback_add_unique(decisions, text, 180);
+            break;
+         case FOLD_REG_HAZARD:
+         case FOLD_REG_BLOCKED:
+            flashback_add_unique(errors, text, 180);
+            break;
+         default:
+            break; /* in-progress / executing: transient work, not a settled fact */
+         }
+      }
+   }
+
+   /* Paths are what the legacy path tried to guess, so they populate Relevant Files
+    * directly. Every other kind (sha, uuid, ref, handle, key=value) is conserved in
+    * the rendered closet block below rather than being flattened into a file list. */
+   for (size_t i = 0; i < set.count; i++)
+   {
+      if (set.items[i].kind == COORD_KIND_PATH && set.items[i].value)
+         flashback_add_unique(files, set.items[i].value, 160);
+   }
+
+   if (closet_out)
+   {
+      coord_closet_config_t ccfg;
+      memset(&ccfg, 0, sizeof(ccfg));
+      ccfg.enabled = 1; /* built-in budget/ratio defaults */
+      coord_evict_t why = COORD_EVICT_NONE;
+      *closet_out = coord_closet_render(&set, &ccfg, raw_total, &why);
+      if (evict_out)
+         *evict_out = why;
+   }
+
+   coord_set_free(&set);
+   return root;
+}
+
 static cJSON *flashback_build(const cJSON *messages, int start_idx, int end_idx)
 {
    cJSON *root = NULL;
@@ -336,7 +447,7 @@ static void append_flashback_json(char *buf, size_t *pos, size_t cap, cJSON *roo
 /* Build a structured text summary of messages[start_idx .. end_idx-1].
  * Writes the result into buf (length SESSION_COMPACT_SUMMARY_MAX). */
 static void build_summary(const cJSON *messages, int start_idx, int end_idx, char *buf,
-                          size_t buf_len)
+                          size_t buf_len, int from_record)
 {
    if (!buf || buf_len == 0)
       return;
@@ -389,7 +500,15 @@ static void build_summary(const cJSON *messages, int start_idx, int end_idx, cha
       }
    }
 
-   cJSON *flashback = flashback_build(messages, start_idx, end_idx);
+   /* The record path falls back to the prose scan if it cannot allocate, so a
+    * summary is never emptied by an allocation failure. */
+   char *closet_block = NULL;
+   coord_evict_t closet_evict = COORD_EVICT_NONE;
+   cJSON *flashback = NULL;
+   if (from_record)
+      flashback = record_build(messages, start_idx, end_idx, &closet_block, &closet_evict);
+   if (!flashback)
+      flashback = flashback_build(messages, start_idx, end_idx);
    cJSON *files = flashback ? cJSON_GetObjectItem(flashback, "files_modified") : NULL;
    cJSON *errors = flashback ? cJSON_GetObjectItem(flashback, "errors_encountered") : NULL;
    cJSON *decisions = flashback ? cJSON_GetObjectItem(flashback, "decisions_made") : NULL;
@@ -460,6 +579,23 @@ static void build_summary(const cJSON *messages, int start_idx, int end_idx, cha
 
    append_format(tmp, &pos, sizeof(tmp), "## Relevant Files\n");
    append_array_items(tmp, &pos, sizeof(tmp), files, "None recorded.");
+
+   /* Conserved coordinates: shas, uuids, refs, handles and key=value pairs kept
+    * BYTE-EXACT from the discarded turns, so the agent can still address what it
+    * can no longer see. A coordinate that did not fit is announced rather than
+    * silently dropped — that announcement is the whole point of COORD_EVICT_FAIL. */
+   if (closet_block && closet_block[0])
+   {
+      append_format(tmp, &pos, sizeof(tmp), "## Conserved Coordinates\n");
+      append_truncated(tmp, &pos, sizeof(tmp), closet_block, 1600);
+      append_format(tmp, &pos, sizeof(tmp), "\n\n");
+   }
+   if (closet_evict == COORD_EVICT_FAIL)
+      append_format(tmp, &pos, sizeof(tmp),
+                    "- NOTE: some identifiers could not be conserved within the budget; "
+                    "re-read the source before relying on any identifier not listed above.\n\n");
+   free(closet_block);
+
    append_flashback_json(tmp, &pos, sizeof(tmp), flashback);
    cJSON_Delete(flashback);
 
@@ -653,7 +789,7 @@ int session_compact(cJSON *messages, const session_compact_config_t *cfg,
 
    /* Step 3: build summary of messages[summary_start..summary_end) */
    build_summary(messages, summary_start, summary_end, local_out.summary,
-                 sizeof(local_out.summary));
+                 sizeof(local_out.summary), cfg ? cfg->from_record : 0);
 
    /* Step 4: insert a boundary marker message right after messages[0].
     * We build the JSON object first, then splice it in. */
@@ -740,7 +876,10 @@ int session_compact_focused(const char *topic, char *out, size_t out_len)
    cJSON_AddStringToObject(asst_msg, "content", "Acknowledged.");
    cJSON_AddItemToArray(messages, asst_msg);
 
-   build_summary(messages, 0, 1, out, out_len);
+   /* Legacy derivation: this builds a synthetic 2-message conversation purely to
+    * render an "Active Task" heading from a topic string. There is no recorded
+    * history behind it, so there is nothing for the record path to read. */
+   build_summary(messages, 0, 1, out, out_len, 0);
    cJSON_Delete(messages);
    return 0;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -6910,3 +6910,29 @@ TEST_KB_RUNTIME_TARGETS = \
   $(TESTPREFIX)/unit-test-witness-tamper-pg
 $(filter-out $(TEST_KB_RUNTIME_TARGETS),$(TEST_TARGETS)): \
   $(OBJDIR)/modules/vault/runtime_secret.o
+
+# ---------------------------------------------------------------- benchmark probes
+# Compaction retention probe: measures how much load-bearing detail survives a
+# compaction boundary under each summary derivation. Deliberately NOT in
+# TEST_TARGETS -- it is a measurement, not a gate, and a derivation scoring badly
+# is a result to read rather than a build failure. Run it explicitly:
+#   make -C src compaction-retention-probe
+#   src/build/obj/tests/compaction-retention-probe benchmarks/compaction-quality/corpus.json
+$(OBJDIR)/tests/retention_probe.o: ../benchmarks/compaction-quality/retention_probe.c
+	@mkdir -p $(dir $@)
+	$(CC) -c $(TEST_C_FLAGS) -o $@ $<
+
+$(TESTPREFIX)/compaction-retention-probe: $(OBJDIR)/tests/retention_probe.o \
+                                          $(OBJDIR)/server/session_compact.o $(OBJDIR)/server/rounds_to_resume.o $(OBJDIR)/server/compact_prune.o \
+                                          $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o \
+                                          $(OBJDIR)/server/agent_request_shaping.o \
+                                          $(OBJDIR)/modules/delegates/delegate_driver.o \
+                                          $(OBJDIR)/modules/delegates/delegate_openai.o \
+                                          $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
+                                          $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
+                                          $(OBJDIR)/server/agent_tools.o \
+                                          $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+.PHONY: compaction-retention-probe
+compaction-retention-probe: $(TESTPREFIX)/compaction-retention-probe

--- a/src/tests/test_coord_closet.c
+++ b/src/tests/test_coord_closet.c
@@ -346,6 +346,81 @@ static void test_disabled_returns_null(void)
    PASS("disabled_returns_null");
 }
 
+/* Bare repo-relative paths are conserved, and prose that merely contains a slash is
+ * not. Measured motivation: with bare paths unmatched, a record-derived compaction
+ * summary retained 0/3 relative source paths the legacy prose scan caught 3/3
+ * (benchmarks/compaction-quality). The header has always called this kind
+ * "absolute / repo-relative path"; only the anchored half was implemented. */
+static void test_bare_relative_paths(void)
+{
+   /* The closet is capped at raw_len by design (it may never exceed the bytes it came
+    * from), so an identifier-dense fixture must be padded or the cap evicts most of
+    * what is under test and the assertions measure the budget, not the matcher. */
+   char raw[4096];
+   int used = snprintf(raw, sizeof(raw),
+                       "Reading src/modules/git/retry.c and src/headers/retry.h plus "
+                       "scripts/check_retry.py, deploy/compose/aimee.gpu.yaml and src/modules/git "
+                       "-- and/or he/she 24/7 2026/08/10 TODO/FIXME notwithstanding. ");
+   memset(raw + used, ' ', sizeof(raw) - (size_t)used - 1);
+   raw[sizeof(raw) - 1] = '\0';
+
+   coord_set_t set;
+   coord_set_init(&set);
+   coord_provenance_t prov = {COORD_LANE_AGENT, 1, 1, 0};
+   coord_closet_nominate(raw, strlen(raw), &prov, &set);
+   coord_closet_config_t cfg = {.enabled = 1, .budget_bytes = 100000};
+   coord_evict_t why = COORD_EVICT_NONE;
+   char *out = coord_closet_render(&set, &cfg, strlen(raw), &why);
+   assert(out);
+   assert(why == COORD_EVICT_NONE); /* nothing evicted, so a miss is a real miss */
+
+   /* Conserved: dotted final segment, or two-plus segments. */
+   assert(contains(out, "src/modules/git/retry.c"));
+   assert(contains(out, "src/headers/retry.h"));
+   assert(contains(out, "scripts/check_retry.py"));
+   assert(contains(out, "deploy/compose/aimee.gpu.yaml"));
+   assert(contains(out, "src/modules/git")); /* two slashes, no extension */
+
+   /* Rejected: prose. A closet full of "and/or" evicts real coordinates to stay
+    * inside its byte budget, so these matter as much as the matches. */
+   assert(!contains(out, "and/or"));
+   assert(!contains(out, "he/she"));
+   assert(!contains(out, "24/7"));       /* no letters */
+   assert(!contains(out, "2026/08/10")); /* no letters, despite two slashes */
+   assert(!contains(out, "TODO/FIXME")); /* letters, but one slash and no extension */
+
+   free(out);
+   coord_set_free(&set);
+   printf("  PASS: bare_relative_paths\n");
+}
+
+/* Anchored paths keep their old, looser rule: one slash is enough and no letter or
+ * extension is required, because the leading /, ./ or ../ already disambiguates. */
+static void test_anchored_paths_unchanged(void)
+{
+   char raw[4096];
+   int used = snprintf(raw, sizeof(raw), "state /var/lib/aimee here ./x/y there ../z/w and /1/2 ");
+   memset(raw + used, ' ', sizeof(raw) - (size_t)used - 1);
+   raw[sizeof(raw) - 1] = '\0';
+
+   coord_set_t set;
+   coord_set_init(&set);
+   coord_provenance_t prov = {COORD_LANE_AGENT, 1, 1, 0};
+   coord_closet_nominate(raw, strlen(raw), &prov, &set);
+   coord_closet_config_t cfg = {.enabled = 1, .budget_bytes = 100000};
+   coord_evict_t why = COORD_EVICT_NONE;
+   char *out = coord_closet_render(&set, &cfg, strlen(raw), &why);
+   assert(out);
+   assert(why == COORD_EVICT_NONE);
+   assert(contains(out, "/var/lib/aimee"));
+   assert(contains(out, "./x/y"));
+   assert(contains(out, "../z/w"));
+   assert(contains(out, "/1/2")); /* digits only, still anchored -> still conserved */
+   free(out);
+   coord_set_free(&set);
+   printf("  PASS: anchored_paths_unchanged\n");
+}
+
 int main(void)
 {
    printf("coord_closet tests:\n");
@@ -361,6 +436,8 @@ int main(void)
    test_user_lane_divider();
    test_long_value_within_budget();
    test_boundary_and_punctuation_nits();
+   test_bare_relative_paths();
+   test_anchored_paths_unchanged();
    test_disabled_returns_null();
    printf("ALL PASS\n");
    return 0;

--- a/src/tests/test_session_compact.c
+++ b/src/tests/test_session_compact.c
@@ -408,7 +408,8 @@ static cJSON *make_record_conversation(void)
        arr, make_msg("assistant", "[verdict] The retry budget is capped upstream at 4a7f19c2b8e30d1"
                                   "5f6a2c9b40e7d3814aa9c5162; nothing downstream can raise it."));
    cJSON_AddItemToArray(
-       arr, make_msg("assistant", "[hazard] Touching #778 without the migration will strand rows."));
+       arr,
+       make_msg("assistant", "[hazard] Touching #778 without the migration will strand rows."));
    for (int i = 0; i < 8; i++)
    {
       cJSON_AddItemToArray(arr, make_msg("user", "continue"));

--- a/src/tests/test_session_compact.c
+++ b/src/tests/test_session_compact.c
@@ -391,6 +391,159 @@ static void test_compact_summary_has_structured_sections(void)
    PASS("compact_summary_has_structured_sections");
 }
 
+/* ------------------------------------------------- record-derived derivation */
+
+/* Build a conversation whose salient facts are INVISIBLE to the legacy prose scan:
+ *   - the settled conclusion contains no "decided"/"chosen"/"will use" keyword
+ *   - the hazard contains no "error"/"failed"/"denied" keyword
+ *   - the identifiers are a commit sha and an issue ref, which token_looks_like_path()
+ *     does not recognise at all (it only matches slashes and known extensions)
+ * Both are tagged with the register grammar the agent itself emits. */
+static cJSON *make_record_conversation(void)
+{
+   cJSON *arr = cJSON_CreateArray();
+   cJSON_AddItemToArray(arr, make_msg("system", "You are a coder."));
+   cJSON_AddItemToArray(arr, make_msg("user", "Investigate the retry path."));
+   cJSON_AddItemToArray(
+       arr, make_msg("assistant", "[verdict] The retry budget is capped upstream at 4a7f19c2b8e30d1"
+                                  "5f6a2c9b40e7d3814aa9c5162; nothing downstream can raise it."));
+   cJSON_AddItemToArray(
+       arr, make_msg("assistant", "[hazard] Touching #778 without the migration will strand rows."));
+   for (int i = 0; i < 8; i++)
+   {
+      cJSON_AddItemToArray(arr, make_msg("user", "continue"));
+      cJSON_AddItemToArray(arr, make_msg("assistant", "[wip] Reading src/modules/git/retry.c."));
+   }
+   return arr;
+}
+
+/* The register-tagged conclusion reaches Key Decisions, and the hazard reaches
+ * Blocked — neither carries a keyword the legacy scan looks for, so this fails
+ * unless the classification is genuinely being read. */
+static void test_record_uses_register_classification(void)
+{
+   cJSON *arr = make_record_conversation();
+   session_compact_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.from_record = 1;
+
+   session_compact_result_t result;
+   assert(session_compact(arr, &cfg, &result) == 0);
+   assert(result.compacted == 1);
+
+   const char *decisions = strstr(result.summary, "## Key Decisions");
+   const char *blocked = strstr(result.summary, "## Blocked");
+   assert(decisions && blocked);
+   assert(strstr(decisions, "retry budget is capped upstream") != NULL);
+   assert(strstr(blocked, "without the migration will strand rows") != NULL);
+
+   /* A transient [wip] turn is work-in-progress, not a settled fact. */
+   assert(strstr(decisions, "Reading src/modules/git/retry.c") == NULL);
+
+   cJSON_Delete(arr);
+   PASS("record_uses_register_classification");
+}
+
+/* Identifiers are conserved BYTE-EXACT, not paraphrased or reshaped. */
+static void test_record_conserves_coordinates_verbatim(void)
+{
+   cJSON *arr = make_record_conversation();
+   session_compact_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.from_record = 1;
+
+   session_compact_result_t result;
+   assert(session_compact(arr, &cfg, &result) == 0);
+   assert(result.compacted == 1);
+
+   /* The full sha, character for character — a summariser that re-typed it from
+    * memory, or truncated it, fails here. */
+   assert(strstr(result.summary, "4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162") != NULL);
+
+   cJSON_Delete(arr);
+   PASS("record_conserves_coordinates_verbatim");
+}
+
+/* The flag genuinely selects a derivation: the same input yields a summary the
+ * legacy path cannot produce. This is the guard against the record path silently
+ * degrading back to prose scraping. */
+static void test_record_flag_selects_derivation(void)
+{
+   cJSON *legacy_arr = make_record_conversation();
+   session_compact_result_t legacy;
+   session_compact_config_t legacy_cfg;
+   memset(&legacy_cfg, 0, sizeof(legacy_cfg));
+   legacy_cfg.from_record = 0;
+   assert(session_compact(legacy_arr, &legacy_cfg, &legacy) == 0);
+
+   cJSON *record_arr = make_record_conversation();
+   session_compact_result_t record;
+   session_compact_config_t record_cfg;
+   memset(&record_cfg, 0, sizeof(record_cfg));
+   record_cfg.from_record = 1;
+   assert(session_compact(record_arr, &record_cfg, &record) == 0);
+
+   assert(legacy.compacted == 1 && record.compacted == 1);
+   assert(strcmp(legacy.summary, record.summary) != 0);
+
+   /* The sha is a coordinate, not a path-shaped token: only the record path keeps it. */
+   assert(strstr(record.summary, "4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162") != NULL);
+   assert(strstr(legacy.summary, "4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162") == NULL);
+
+   cJSON_Delete(legacy_arr);
+   cJSON_Delete(record_arr);
+   PASS("record_flag_selects_derivation");
+}
+
+/* The legacy path stays intact and selectable — it is the fallback until the
+ * quality baseline can say which derivation is better. */
+static void test_record_off_keeps_legacy_sections(void)
+{
+   cJSON *arr = make_record_conversation();
+   session_compact_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.from_record = 0;
+
+   session_compact_result_t result;
+   assert(session_compact(arr, &cfg, &result) == 0);
+   assert(result.compacted == 1);
+
+   const char *sections[] = {"## Active Task",       "## Goal",           "## Constraints",
+                             "## Completed Actions", "## Active State",   "## In Progress",
+                             "## Blocked",           "## Key Decisions",  "## Resolved Questions",
+                             "## Pending User Asks", "## Relevant Files", NULL};
+   for (int i = 0; sections[i]; i++)
+      assert(strstr(result.summary, sections[i]) != NULL);
+   assert(strstr(result.summary, "Flashback JSON:") != NULL);
+
+   cJSON_Delete(arr);
+   PASS("record_off_keeps_legacy_sections");
+}
+
+/* Every section the boundary contract promises is still present on the record
+ * path — a different derivation must not change the summary's shape. */
+static void test_record_keeps_section_contract(void)
+{
+   cJSON *arr = make_record_conversation();
+   session_compact_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.from_record = 1;
+
+   session_compact_result_t result;
+   assert(session_compact(arr, &cfg, &result) == 0);
+   assert(result.compacted == 1);
+
+   const char *sections[] = {"## Active Task",       "## Goal",           "## Constraints",
+                             "## Completed Actions", "## Active State",   "## In Progress",
+                             "## Blocked",           "## Key Decisions",  "## Resolved Questions",
+                             "## Pending User Asks", "## Relevant Files", NULL};
+   for (int i = 0; sections[i]; i++)
+      assert(strstr(result.summary, sections[i]) != NULL);
+
+   cJSON_Delete(arr);
+   PASS("record_keeps_section_contract");
+}
+
 static void test_compact_idempotent_on_small(void)
 {
    /* Compacting an already-small array should be a no-op */
@@ -595,6 +748,11 @@ int main(void)
    test_compact_summary_has_original_task();
    test_compact_summary_has_flashback_json();
    test_compact_summary_has_structured_sections();
+   test_record_uses_register_classification();
+   test_record_conserves_coordinates_verbatim();
+   test_record_flag_selects_derivation();
+   test_record_off_keeps_legacy_sections();
+   test_record_keeps_section_contract();
    test_compact_idempotent_on_small();
    test_compact_result_counts();
 

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -27,7 +27,7 @@
       "files": [
         {
           "path": "docs/gen/configuration.md",
-          "sha256": "e59be7eaf39122b6e06821a81c86ec4d56f73cba454676c4b5ad6e1ad369ca86"
+          "sha256": "3e54073262534d31b04a2cb0951c04f28aaae1949e9df1afe7a769f511fa8155"
         }
       ]
     },
@@ -1215,7 +1215,7 @@
         },
         {
           "path": "src/headers/session_compact.h",
-          "sha256": "627ac2af680a83d76243b23110d17f8b1f7058addd5068340fa8375d8e9cb54b"
+          "sha256": "68fbbe8ccba619bda6c7c5c86cd5655babe3ffb771c4e784d5835397af7d52cd"
         },
         {
           "path": "src/headers/session_search_tool.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "d6019d00e59662475f8e3325d0728ecd9405a6867e72b49fe206aed7b6c92e7f",
+      "sha256": "dde99e615465d5a705b536a8f0c464a8933fce1da9e1bb56fd29fce6519a0359",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## Summary

Compaction summaries are built by **scraping prose**: `token_looks_like_path()` decides a token is a path by its shape, and a line is an error because it contains the substring "error". Meanwhile the economizer already records those facts exactly — and `session_compact.c` referenced none of it. The recorders and the compactor shipped as separate slices and were never joined.

This joins them, adds a harness that measures whether it actually helps, and fixes the bug that measurement found.

## What changes

**1. A record-derived summary derivation** (`compact.from_record`, default-off)

| Section | Legacy | Record |
|---|---|---|
| Relevant Files | path-shaped-token guess | Coordinate Closet paths, **verbatim** |
| Key Decisions | keyword match on "decided/chosen" | turns the agent tagged `[verdict]` |
| Blocked | keyword match on "error/failed" | turns the agent tagged `[hazard]`/`[blocked]` |
| *Conserved Coordinates* | *(shas, refs, handles simply lost)* | byte-exact, `COORD_EVICT_FAIL` announced |

`session_compact()` stays a **pure function of its inputs** — the flag lives in `session_compact_config_t` and `agent_runtime` resolves it from config. That constraint is why the scope is closet + register only: `task_rail` and `episode_seal` need external session state and would break the contract.

User text is nominated in `COORD_LANE_USER`, and register classification is read only from assistant turns — otherwise a pasted user message could assert `[verdict]` and inject a "settled decision" into the summary.

**2. A retention harness** (`benchmarks/compaction-quality`)

Ground truth is **planted by hand** in `corpus.json`, never extracted. Deriving it with `coord_closet` — the extractor the record path uses — would score that path 100% by construction and measure nothing. Ten fixtures balanced so each derivation has cases it should win and cases it should lose, including one the record path was *expected* to lose.

Deliberately outside `TEST_TARGETS`: a measurement, not a gate.

**3. `match_path()` conserves bare repo-relative paths**

The measurement immediately found a real bug. `match_path()` required a leading `/`, `./` or `../`, so `src/modules/git/retry.c` was never nominated — while `coord_closet.h` has always documented `COORD_KIND_PATH` as *"absolute / repo-relative path"*. Only the anchored half was implemented, and relative paths are the most common identifier in a coding transcript.

Bare paths need a stricter test than anchored ones, since they share a shape with prose. Bare form now requires at least one letter, plus either a dot in the final segment or two-or-more slashes — so `and/or`, `he/she`, `24/7`, `2026/08/10` and `TODO/FIXME` stay out. A closet full of those evicts real coordinates to stay inside its byte budget, so the rejections are tested as carefully as the matches. Anchored paths keep their looser rule unchanged.

## Measured result

Run on the test host (`pvetest`, Debian glibc 2.41) and locally, identical numbers:

```
TOTAL retained: legacy 11/20 (55.0%)   record 15/20 (75.0%)
```

Before the `match_path` fix the record path scored **10/20** — it was *losing*. That fix took `f01` from 0/3 to 3/3 and `f09` from 2/4 to 3/4.

**The headline flatters it, and the honest subset matters more.** Every remaining record loss has one cause: no register tags means empty Decisions/Blocked. On the fixtures representing *today's* defaults — `fold_register_enabled` is off, so real transcripts carry no tags — legacy and record are **dead even at 10/14**. The record path trades decision/error recall for identifier recall.

That is why **`compact.from_record` stays default-off** in this PR. It is not yet a strict improvement under current defaults, and the legacy path remains selectable until it is. The unlock is register tagging; the harness makes re-measuring one command.

Note the probe measures **recall only** — whether a planted fact survived. It says nothing about precision (whether the summary also accumulated junk), so "75%" should not be read as "better summary" without that second axis.

## Verification

- `rm -f aimee-server && make -C src -j8 ../aimee-server` — exit 0, zero undefined references. `make -C src` alone does **not** relink the server, and this change makes a `SERVER_SRCS` file call into the economizer, which is exactly the layering trap that broke #2505.
- `make -C src -j8 ../aimee-kb` — exit 0
- `make -C src -j8 cmd-srcs-compile-check` — exit 0
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — **all 48 checks passed**
- `check_c_repository_lock` — ok (config digest repinned)
- `refactor_baselines` — additive drift verified, then frozen
- New tests: 5 for the derivation (one asserts the SHA is present in the record summary and **absent** from the legacy one), 2 for the path matcher covering both matches and prose rejections

## Follow-ups, not included

- Register tagging is off by default, which is what caps the record path today.
- A precision axis for the harness — the corpus measures recall only.
- `rounds-to-resume` still needs live agents; this is the retention half of `docs/proposals/pending/compaction-quality-baseline.md`.
