### PR TITLE
refactor(delegates): patch coordination moves into the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "a3ae83ff0338de95edcec34920c2d82d438178d81920f702ba5926bd7292b548",
+      "source_sha256": "8c9ef6cb1f3770aa403d17a865149b32c6b368d1b1971eaec40d13614a14863d",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
@@ -177,7 +177,8 @@
         6661,
         6662,
         6663,
-        6664
+        6664,
+        6665
       ]
     },
     {

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -110,6 +110,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: delegates.EventRescue, StageID: delegates.StageRescue},
 			{EventKind: delegates.EventVerify, StageID: delegates.StageVerify},
 			{EventKind: delegates.EventEconomics, StageID: delegates.StageEconomics},
+			{EventKind: delegates.EventPatchCoord, StageID: delegates.StagePatchCoord},
 		}
 		config.Handler = delegates.Handle
 	case "tools":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -15,7 +15,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664}},
+		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664, 6665}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7430}},

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -50,6 +50,9 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 	if invocation.StageID == StageEconomics {
 		return handleEconomics(invocation, request)
 	}
+	if invocation.StageID == StagePatchCoord {
+		return handlePatchCoord(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/server-go/modules/delegates/patchcoord.go
+++ b/server-go/modules/delegates/patchcoord.go
@@ -1,0 +1,417 @@
+package delegates
+
+// Where a coordinated run's patches stand, and which ones a human can safely
+// look at next.
+//
+// This is read-only integration policy. It never merges anything; it decides
+// what each packet's state IS -- planned, running, returned, reviewable,
+// accepted, failed, or needs_supervisor -- so a supervisor can see at a glance
+// which packets are ready and which are waiting on them.
+//
+// "Reviewable" is the load-bearing one. A packet earns it only by clearing
+// every check: a believable handoff, no edits outside its ownership, a base
+// that matches the integration base, focused tests that actually passed, and no
+// file overlap with a packet already declared reviewable. Overlap is checked
+// against the packets ALREADY reviewable rather than against everything, so two
+// packets touching one file leave the first reviewable and send only the second
+// to a human -- otherwise a single collision would stall both.
+
+const (
+	patchMaxFiles     = 32
+	patchMaxTasks     = 64
+	patchStateLen     = 32
+	patchNoteLen      = 256
+	patchFileLen      = 256
+	patchNextCmdLen   = 64
+	patchDefaultNext  = "./aimee git verify"
+	patchReviewSchema = "delegate_review_v1"
+	patchResultSchema = "delegate_result_v1"
+)
+
+// PatchTask is one coordinated task, as the caller knows it.
+type PatchTask struct {
+	ID     int
+	StepID int
+	Status string
+	Files  string // owned_files JSON
+	Result string // the delegate's result JSON
+	Error  string
+}
+
+// PatchTaskReport mirrors delegate_patch_task_report_t.
+type PatchTaskReport struct {
+	TaskID                int
+	StepID                int
+	TaskStatus            string
+	PatchState            string
+	HandoffStatus         string
+	HandoffValid          bool
+	ChangedFilesCount     int
+	PassedTests           int
+	OutsideOwnershipCount int
+	OverlapTaskID         int
+	StaleBase             bool
+	SupervisorActions     int
+	Note                  string
+}
+
+// PatchReport mirrors delegate_patch_report_t.
+type PatchReport struct {
+	ImplementationPackets    int
+	Planned                  int
+	Running                  int
+	Returned                 int
+	Verified                 int
+	Reviewable               int
+	Accepted                 int
+	Failed                   int
+	NeedsSupervisor          int
+	InvalidHandoffs          int
+	OutsideOwnershipTouches  int
+	PatchOverlaps            int
+	StaleWorktrees           int
+	FocusedTestsPassed       int
+	ReviewerPackets          int
+	ReviewerBlockingFindings int
+	ReviewerOwnerPacketRoutes int
+	ReviewerStatus           string
+	RecommendedNextCommand   string
+	Tasks                    []PatchTaskReport
+}
+
+func isSchema(v *jsonValue, name string) bool {
+	s := v.get("schema_version")
+	return s.isString() && s.str == name
+}
+
+func isHandoffOrReview(v *jsonValue) bool {
+	return isSchema(v, patchResultSchema) || isSchema(v, patchReviewSchema)
+}
+
+// patchHandoffText finds the handoff inside a result, which may BE one or carry
+// one as a `response` string or object.
+func patchHandoffText(root *jsonValue, raw string) string {
+	if isHandoffOrReview(root) {
+		return raw
+	}
+	response := root.get("response")
+	if response.isString() && response.str != "" {
+		return response.str
+	}
+	if response.isObject() {
+		return printJSON(response)
+	}
+	return ""
+}
+
+func patchHandoffObject(root *jsonValue, text string) *jsonValue {
+	if isHandoffOrReview(root) {
+		return root
+	}
+	if text == "" {
+		return nil
+	}
+	if parsed, ok := parseJSONPrefix(text); ok && isHandoffOrReview(parsed) {
+		return parsed
+	}
+	return nil
+}
+
+func stringList(v *jsonValue) []string {
+	if v == nil || v.kind != jsonArray {
+		return nil
+	}
+	out := make([]string, 0, len(v.items))
+	for _, item := range v.items {
+		if !item.isString() || item.str == "" {
+			continue
+		}
+		if len(out) >= patchMaxFiles {
+			break
+		}
+		out = append(out, item.str)
+	}
+	return out
+}
+
+func listsOverlap(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func addUnique(list []string, add []string) []string {
+	for _, path := range add {
+		if path == "" || len(list) >= patchMaxFiles {
+			break
+		}
+		found := false
+		for _, have := range list {
+			if have == path {
+				found = true
+				break
+			}
+		}
+		if !found {
+			list = append(list, path)
+		}
+	}
+	return list
+}
+
+func supervisorActionCount(handoff *jsonValue) int {
+	actions := handoff.get("supervisor_actions")
+	if actions == nil || actions.kind != jsonArray {
+		return 0
+	}
+	return len(actions.items)
+}
+
+// firstString returns the first of the given keys that holds a string, so the
+// several spellings delegates use for the same fact are all understood.
+func firstString(v *jsonValue, keys ...string) (string, bool) {
+	for _, k := range keys {
+		if item := v.get(k); item.isString() {
+			return item.str, true
+		}
+	}
+	return "", false
+}
+
+// handoffBaseIsStale asks whether the delegate worked from a base other than
+// the integration base. An explicit flag wins; otherwise the two commits are
+// compared, and only when BOTH are known -- an unknown base is not evidence of
+// staleness.
+func handoffBaseIsStale(handoff *jsonValue) bool {
+	if !handoff.isObject() {
+		return false
+	}
+	stale := handoff.get("stale_base")
+	if stale == nil {
+		stale = handoff.get("worktree_stale")
+	}
+	if stale != nil && stale.kind == jsonBool && stale.boolean {
+		return true
+	}
+	base, haveBase := firstString(handoff, "base_commit", "delegate_base_commit", "base_sha")
+	integration, haveIntegration := firstString(handoff,
+		"integration_base_commit", "integration_head", "integration_base_sha")
+	return haveBase && haveIntegration && base != integration
+}
+
+// reviewerBlockingCount counts findings that are not explicitly minor. A
+// finding with no severity counts as blocking: unlabelled is not the same as
+// harmless, and the conservative reading sends it to a human.
+func reviewerBlockingCount(findings *jsonValue) int {
+	if findings == nil || findings.kind != jsonArray {
+		return 0
+	}
+	count := 0
+	for _, finding := range findings.items {
+		severity := finding.get("severity")
+		if !severity.isString() {
+			count++
+			continue
+		}
+		if severity.str != "note" && severity.str != "low" {
+			count++
+		}
+	}
+	return count
+}
+
+// reviewerFindingRoutes counts findings that name the packet responsible, which
+// is what lets a finding be routed back rather than landing on the supervisor.
+func reviewerFindingRoutes(findings *jsonValue) int {
+	if findings == nil || findings.kind != jsonArray {
+		return 0
+	}
+	count := 0
+	for _, finding := range findings.items {
+		if owner := finding.get("owner_packet"); owner.isString() && owner.str != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *PatchReport) addState(state string) {
+	switch state {
+	case "planned":
+		r.Planned++
+	case "running":
+		r.Running++
+	case "returned":
+		r.Returned++
+	case "verified":
+		r.Verified++
+	case "reviewable":
+		r.Reviewable++
+	case "accepted":
+		r.Accepted++
+	case "failed":
+		r.Failed++
+	case "needs_supervisor":
+		r.NeedsSupervisor++
+	}
+	// "reviewer" is deliberately absent: a read-only review packet is not an
+	// implementation packet and is counted on its own.
+}
+
+func setTaskState(tr *PatchTaskReport, r *PatchReport, state, note string) {
+	tr.PatchState = state
+	if note != "" {
+		tr.Note = note
+	}
+	r.addState(state)
+}
+
+func (r *PatchReport) processReviewer(handoff *jsonValue) {
+	r.ReviewerPackets++
+	if status := handoff.get("status"); status.isString() && status.str != "" {
+		r.ReviewerStatus = status.str
+	} else {
+		r.ReviewerStatus = "needs_supervisor"
+	}
+	findings := handoff.get("findings")
+	if r.ReviewerStatus == "block" {
+		r.ReviewerBlockingFindings += reviewerBlockingCount(findings)
+	}
+	r.ReviewerOwnerPacketRoutes += reviewerFindingRoutes(findings)
+}
+
+func orElse(primary, fallback string) string {
+	if primary != "" {
+		return primary
+	}
+	return fallback
+}
+
+// BuildPatchReport summarises where a coordinated run's patches stand.
+func BuildPatchReport(tasks []PatchTask) PatchReport {
+	report := PatchReport{
+		ReviewerStatus:         "not_run",
+		RecommendedNextCommand: patchDefaultNext,
+	}
+	if len(tasks) == 0 {
+		return report
+	}
+
+	// Files already claimed by a reviewable packet, and who claimed them.
+	var reviewableFiles [][]string
+	var reviewableTaskIDs []int
+
+	for _, task := range tasks {
+		if len(report.Tasks) >= patchMaxTasks {
+			break
+		}
+		report.Tasks = append(report.Tasks, PatchTaskReport{
+			TaskID:     task.ID,
+			StepID:     task.StepID,
+			TaskStatus: task.Status,
+		})
+		tr := &report.Tasks[len(report.Tasks)-1]
+
+		switch task.Status {
+		case "pending":
+			report.ImplementationPackets++
+			setTaskState(tr, &report, "planned", "packet has not launched")
+			continue
+		case "claimed", "running":
+			report.ImplementationPackets++
+			setTaskState(tr, &report, "running", "delegate is active")
+			continue
+		case "failed":
+			report.ImplementationPackets++
+			setTaskState(tr, &report, "failed", orElse(task.Error, "delegate failed"))
+			continue
+		}
+
+		var root *jsonValue
+		if task.Result != "" {
+			if parsed, ok := parseJSONPrefix(task.Result); ok {
+				root = parsed
+			}
+		}
+		text := patchHandoffText(root, task.Result)
+		handoff := patchHandoffObject(root, text)
+
+		if isSchema(handoff, patchReviewSchema) {
+			report.processReviewer(handoff)
+			setTaskState(tr, &report, "reviewer", "read-only reviewer result")
+			continue
+		}
+
+		report.ImplementationPackets++
+		verdict, ok := ValidateHandoff(text, task.Files, true)
+		if task.Status != "done" || text == "" || !ok {
+			report.InvalidHandoffs++
+			tr.HandoffStatus = statusNeedsReview
+			note := "missing or invalid structured handoff"
+			if task.Status == "done" && text != "" {
+				note = orElse(verdict.Error, note)
+			}
+			setTaskState(tr, &report, "needs_supervisor", note)
+			continue
+		}
+
+		tr.HandoffValid = verdict.Valid
+		tr.HandoffStatus = verdict.Status
+		tr.ChangedFilesCount = verdict.ChangedFilesCount
+		tr.PassedTests = verdict.PassedTests
+		tr.OutsideOwnershipCount = verdict.OutsideOwnershipCount
+		tr.SupervisorActions = supervisorActionCount(handoff)
+		tr.StaleBase = handoffBaseIsStale(handoff)
+		report.FocusedTestsPassed += verdict.PassedTests
+		report.OutsideOwnershipTouches += verdict.OutsideOwnershipCount
+		if tr.StaleBase {
+			report.StaleWorktrees++
+		}
+		if verdict.PassedTests > 0 {
+			report.Verified++
+		}
+
+		changedFiles := stringList(handoff.get("changed_files"))
+
+		switch {
+		case verdict.Status == "failed":
+			setTaskState(tr, &report, "failed", orElse(verdict.Error, "delegate reported failed"))
+		case verdict.Status == "blocked":
+			setTaskState(tr, &report, "needs_supervisor",
+				orElse(verdict.Error, "delegate reported blocked"))
+		case verdict.OutsideOwnershipCount > 0:
+			setTaskState(tr, &report, "needs_supervisor",
+				orElse(verdict.Error, "changed files outside owned_files"))
+		case tr.StaleBase:
+			setTaskState(tr, &report, "needs_supervisor",
+				"delegate base differs from integration base")
+		case verdict.PassedTests <= 0:
+			setTaskState(tr, &report, "returned",
+				orElse(verdict.Error, "focused verification not reported"))
+		default:
+			overlap := 0
+			for i, claimed := range reviewableFiles {
+				if listsOverlap(changedFiles, claimed) {
+					overlap = reviewableTaskIDs[i]
+					break
+				}
+			}
+			if overlap > 0 {
+				tr.OverlapTaskID = overlap
+				report.PatchOverlaps++
+				setTaskState(tr, &report, "needs_supervisor",
+					"changed files overlap another packet")
+				break
+			}
+			reviewableFiles = append(reviewableFiles, addUnique(nil, changedFiles))
+			reviewableTaskIDs = append(reviewableTaskIDs, task.ID)
+			setTaskState(tr, &report, "reviewable", "ownership and verification checks passed")
+		}
+	}
+	return report
+}

--- a/server-go/modules/delegates/patchcoord_stage.go
+++ b/server-go/modules/delegates/patchcoord_stage.go
@@ -1,0 +1,105 @@
+package delegates
+
+import (
+	"encoding/binary"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+const (
+	StagePatchCoord uint32 = 9
+	EventPatchCoord uint32 = 6665
+
+	patchRequestMagic  uint32 = 0x51435044 /* "DPCQ" */
+	patchResponseMagic uint32 = 0x53435044 /* "DPCS" */
+	patchReqHeaderLen         = 16
+	patchRespHeaderLen        = 4 + 18*4 + patchStateLen + patchNextCmdLen
+	// task_id, step_id, handoff_valid, changed, passed, outside, overlap,
+	// stale, actions -- then the three fixed strings.
+	patchTaskRecordLen = 9*4 + patchStateLen*3 + patchNoteLen
+)
+
+func handlePatchCoord(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if len(request) < patchReqHeaderLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != patchRequestMagic ||
+		request[4] != wireVersion {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	taskCount := int(binary.LittleEndian.Uint32(request[8:12]))
+	if taskCount > patchMaxTasks {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+
+	c := &economicsCursor{buf: request, at: patchReqHeaderLen}
+	tasks := make([]PatchTask, 0, taskCount)
+	for i := 0; i < taskCount; i++ {
+		id, stepID := int(int32(c.u32())), int(int32(c.u32()))
+		statusLen := c.u16()
+		errorLen := c.u16()
+		filesLen, resultLen := c.u32(), c.u32()
+		task := PatchTask{
+			ID:     id,
+			StepID: stepID,
+			Status: c.str(statusLen),
+			Error:  c.str(errorLen),
+			Files:  c.str(filesLen),
+			Result: c.str(resultLen),
+		}
+		if c.bad {
+			return nil, bus.ModuleStatusInvalidRequest
+		}
+		tasks = append(tasks, task)
+	}
+	if c.bad || c.at != len(request) {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	report := BuildPatchReport(tasks)
+
+	response := make([]byte, patchRespHeaderLen, patchRespHeaderLen+len(report.Tasks)*patchTaskRecordLen)
+	binary.LittleEndian.PutUint32(response[0:4], patchResponseMagic)
+	fields := []int{
+		len(report.Tasks), report.ImplementationPackets,
+		report.Planned, report.Running, report.Returned, report.Verified,
+		report.Reviewable, report.Accepted, report.Failed, report.NeedsSupervisor,
+		report.InvalidHandoffs, report.OutsideOwnershipTouches, report.PatchOverlaps,
+		report.StaleWorktrees, report.FocusedTestsPassed,
+		report.ReviewerPackets, report.ReviewerBlockingFindings,
+		report.ReviewerOwnerPacketRoutes,
+	}
+	for i, v := range fields {
+		binary.LittleEndian.PutUint32(response[4+i*4:8+i*4], uint32(int32(v)))
+	}
+	at := 4 + len(fields)*4
+	putFixed(response[at:at+patchStateLen], report.ReviewerStatus)
+	putFixed(response[at+patchStateLen:], report.RecommendedNextCommand)
+
+	for _, tr := range report.Tasks {
+		rec := make([]byte, patchTaskRecordLen)
+		nums := []int{
+			tr.TaskID, tr.StepID, boolInt(tr.HandoffValid), tr.ChangedFilesCount,
+			tr.PassedTests, tr.OutsideOwnershipCount, tr.OverlapTaskID,
+			boolInt(tr.StaleBase), tr.SupervisorActions,
+		}
+		for i, v := range nums {
+			binary.LittleEndian.PutUint32(rec[i*4:i*4+4], uint32(int32(v)))
+		}
+		off := len(nums) * 4
+		putFixed(rec[off:off+patchStateLen], tr.TaskStatus)
+		putFixed(rec[off+patchStateLen:off+2*patchStateLen], tr.PatchState)
+		putFixed(rec[off+2*patchStateLen:off+3*patchStateLen], tr.HandoffStatus)
+		putFixed(rec[off+3*patchStateLen:], tr.Note)
+		response = append(response, rec...)
+	}
+	return response, bus.ModuleStatusOK
+}
+
+func boolInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/server-go/modules/delegates/patchcoord_stage_test.go
+++ b/server-go/modules/delegates/patchcoord_stage_test.go
@@ -1,0 +1,94 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func patchRequestBytes(tasks []PatchTask) []byte {
+	request := make([]byte, patchReqHeaderLen)
+	binary.LittleEndian.PutUint32(request[0:4], patchRequestMagic)
+	request[4] = wireVersion
+	binary.LittleEndian.PutUint32(request[8:12], uint32(len(tasks)))
+	for _, t := range tasks {
+		var hdr [20]byte
+		binary.LittleEndian.PutUint32(hdr[0:4], uint32(int32(t.ID)))
+		binary.LittleEndian.PutUint32(hdr[4:8], uint32(int32(t.StepID)))
+		binary.LittleEndian.PutUint16(hdr[8:10], uint16(len(t.Status)))
+		binary.LittleEndian.PutUint16(hdr[10:12], uint16(len(t.Error)))
+		binary.LittleEndian.PutUint32(hdr[12:16], uint32(len(t.Files)))
+		binary.LittleEndian.PutUint32(hdr[16:20], uint32(len(t.Result)))
+		request = append(request, hdr[:]...)
+		request = append(request, t.Status...)
+		request = append(request, t.Error...)
+		request = append(request, t.Files...)
+		request = append(request, t.Result...)
+	}
+	return request
+}
+
+func TestPatchStageRoundTrip(t *testing.T) {
+	tasks := []PatchTask{
+		{ID: 1, StepID: 7, Status: "done", Files: `["src/a.c"]`,
+			Result: packet(`"src/a.c"`, passedTest)},
+		{ID: 2, StepID: 8, Status: "done", Files: `["src/a.c"]`,
+			Result: packet(`"src/a.c"`, passedTest)},
+	}
+	response, status := Handle(bus.ModuleInvocation{StageID: StagePatchCoord},
+		patchRequestBytes(tasks))
+	if status != bus.ModuleStatusOK ||
+		binary.LittleEndian.Uint32(response[0:4]) != patchResponseMagic {
+		t.Fatalf("status %d, %d bytes", status, len(response))
+	}
+	want := BuildPatchReport(tasks)
+
+	count := int(binary.LittleEndian.Uint32(response[4:8]))
+	if count != len(want.Tasks) {
+		t.Fatalf("task count = %d, want %d", count, len(want.Tasks))
+	}
+	if len(response) != patchRespHeaderLen+count*patchTaskRecordLen {
+		t.Fatalf("response length %d does not match %d tasks", len(response), count)
+	}
+	// Reviewable is the field a supervisor acts on, and the overlap must have
+	// stopped exactly one packet.
+	if got := int(binary.LittleEndian.Uint32(response[28:32])); got != want.Reviewable {
+		t.Errorf("reviewable = %d, want %d", got, want.Reviewable)
+	}
+
+	at := patchRespHeaderLen + patchTaskRecordLen // second task record
+	off := 9 * 4
+	second := decodeFixed(response[at+off+patchStateLen : at+off+2*patchStateLen])
+	if second != "needs_supervisor" {
+		t.Errorf("second packet state = %q, want needs_supervisor", second)
+	}
+	if overlap := int(binary.LittleEndian.Uint32(response[at+24 : at+28])); overlap != 1 {
+		t.Errorf("overlap task id = %d, want 1", overlap)
+	}
+}
+
+func TestPatchStageRejectsInvalidEnvelope(t *testing.T) {
+	good := patchRequestBytes([]PatchTask{{ID: 1, Status: "pending"}})
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePatchCoord},
+		good[:patchReqHeaderLen-1]); status != bus.ModuleStatusInvalidRequest {
+		t.Errorf("truncated status = %d", status)
+	}
+
+	lying := patchRequestBytes([]PatchTask{{ID: 1, Status: "pending"}})
+	binary.LittleEndian.PutUint32(lying[8:12], 99)
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePatchCoord}, lying); status != bus.ModuleStatusInvalidRequest {
+		t.Errorf("overrunning task count status = %d", status)
+	}
+
+	trailing := append(patchRequestBytes(nil), 0)
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePatchCoord}, trailing); status != bus.ModuleStatusInvalidRequest {
+		t.Errorf("trailing-byte status = %d", status)
+	}
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StagePatchCoord, DeadlineNS: 1},
+		good); status != bus.ModuleStatusCancelled {
+		t.Errorf("expired status = %d", status)
+	}
+}

--- a/server-go/modules/delegates/patchcoord_test.go
+++ b/server-go/modules/delegates/patchcoord_test.go
@@ -1,0 +1,215 @@
+package delegates
+
+import "testing"
+
+func packet(files, tests string) string {
+	return `{"schema_version":"delegate_result_v1","status":"done","changed_files":[` + files +
+		`],"tests":` + tests + `,"supervisor_actions":[],"summary":"did it"}`
+}
+
+const passedTest = `[{"name":"unit","status":"passed"}]`
+
+func stateOf(t *testing.T, r PatchReport, taskID int) PatchTaskReport {
+	t.Helper()
+	for _, tr := range r.Tasks {
+		if tr.TaskID == taskID {
+			return tr
+		}
+	}
+	t.Fatalf("task %d missing from report", taskID)
+	return PatchTaskReport{}
+}
+
+// A packet that cleared every check is the only kind a human should look at.
+func TestPatchCleanPacketIsReviewable(t *testing.T) {
+	r := BuildPatchReport([]PatchTask{
+		{ID: 1, StepID: 1, Status: "done", Files: `["src/a.c"]`,
+			Result: packet(`"src/a.c"`, passedTest)},
+	})
+	if r.Reviewable != 1 || r.ImplementationPackets != 1 || r.Verified != 1 {
+		t.Fatalf("report = %+v", r)
+	}
+	tr := stateOf(t, r, 1)
+	if tr.PatchState != "reviewable" || !tr.HandoffValid || tr.PassedTests != 1 {
+		t.Errorf("task = %+v", tr)
+	}
+}
+
+// Packets touching different files do not contend, so both are reviewable.
+func TestPatchDisjointPacketsAreBothReviewable(t *testing.T) {
+	r := BuildPatchReport([]PatchTask{
+		{ID: 1, Status: "done", Files: `["src/a.c"]`, Result: packet(`"src/a.c"`, passedTest)},
+		{ID: 2, Status: "done", Files: `["src/b.c"]`, Result: packet(`"src/b.c"`, passedTest)},
+	})
+	if r.Reviewable != 2 || r.ImplementationPackets != 2 || r.PatchOverlaps != 0 {
+		t.Fatalf("report = %+v", r)
+	}
+	if r.Verified != 2 || r.FocusedTestsPassed != 2 {
+		t.Errorf("verification = %d verified, %d tests", r.Verified, r.FocusedTestsPassed)
+	}
+}
+
+// Overlap is judged against packets ALREADY reviewable, so one collision stalls
+// the second packet and not the first. Stalling both would make a single shared
+// file block the whole run.
+func TestPatchOverlapStopsOnlyTheSecondPacket(t *testing.T) {
+	r := BuildPatchReport([]PatchTask{
+		{ID: 1, Status: "done", Files: `["src/shared.c"]`,
+			Result: packet(`"src/shared.c"`, passedTest)},
+		{ID: 2, Status: "done", Files: `["src/shared.c"]`,
+			Result: packet(`"src/shared.c"`, passedTest)},
+	})
+	if r.Reviewable != 1 || r.PatchOverlaps != 1 || r.NeedsSupervisor != 1 {
+		t.Fatalf("report = %+v", r)
+	}
+	if first := stateOf(t, r, 1); first.PatchState != "reviewable" {
+		t.Errorf("first packet = %q, want reviewable", first.PatchState)
+	}
+	second := stateOf(t, r, 2)
+	if second.PatchState != "needs_supervisor" || second.OverlapTaskID != 1 {
+		t.Errorf("second packet = %+v", second)
+	}
+}
+
+// Packets that never ran, or are still running, are not integration decisions.
+func TestPatchLifecycleStatesBeforeAHandoff(t *testing.T) {
+	r := BuildPatchReport([]PatchTask{
+		{ID: 1, Status: "pending"},
+		{ID: 2, Status: "claimed"},
+		{ID: 3, Status: "running"},
+		{ID: 4, Status: "failed", Error: "container died"},
+	})
+	if r.Planned != 1 || r.Running != 2 || r.Failed != 1 {
+		t.Fatalf("report = %+v", r)
+	}
+	if r.ImplementationPackets != 4 {
+		t.Errorf("implementation packets = %d, want 4", r.ImplementationPackets)
+	}
+	if note := stateOf(t, r, 4).Note; note != "container died" {
+		t.Errorf("failure note = %q, want the delegate's own error", note)
+	}
+}
+
+// Each of these is a reason a human must look before anything is integrated.
+func TestPatchReasonsAPacketNeedsASupervisor(t *testing.T) {
+	cases := []struct {
+		name   string
+		task   PatchTask
+		state  string
+		expect func(*testing.T, PatchReport)
+	}{
+		{
+			name: "edits outside ownership",
+			task: PatchTask{ID: 1, Status: "done", Files: `["src/a.c"]`,
+				Result: packet(`"src/a.c","src/other.c"`, passedTest)},
+			state: "needs_supervisor",
+			expect: func(t *testing.T, r PatchReport) {
+				if r.OutsideOwnershipTouches != 1 {
+					t.Errorf("outside ownership = %d, want 1", r.OutsideOwnershipTouches)
+				}
+			},
+		},
+		{
+			name: "base differs from the integration base",
+			task: PatchTask{ID: 1, Status: "done", Files: `["src/a.c"]`,
+				Result: `{"schema_version":"delegate_result_v1","status":"done",` +
+					`"changed_files":["src/a.c"],"tests":` + passedTest +
+					`,"summary":"x","base_commit":"aaa","integration_base_commit":"bbb"}`},
+			state: "needs_supervisor",
+			expect: func(t *testing.T, r PatchReport) {
+				if r.StaleWorktrees != 1 {
+					t.Errorf("stale worktrees = %d, want 1", r.StaleWorktrees)
+				}
+			},
+		},
+		{
+			name: "no handoff at all",
+			task: PatchTask{ID: 1, Status: "done", Files: `["src/a.c"]`,
+				Result: `just prose`},
+			state: "needs_supervisor",
+			expect: func(t *testing.T, r PatchReport) {
+				if r.InvalidHandoffs != 1 {
+					t.Errorf("invalid handoffs = %d, want 1", r.InvalidHandoffs)
+				}
+			},
+		},
+		{
+			name: "delegate reported blocked",
+			task: PatchTask{ID: 1, Status: "done", Files: `["src/a.c"]`,
+				Result: `{"schema_version":"delegate_result_v1","status":"blocked",` +
+					`"changed_files":["src/a.c"],"tests":` + passedTest + `,"summary":"stuck"}`},
+			state:  "needs_supervisor",
+			expect: func(t *testing.T, r PatchReport) {},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := BuildPatchReport([]PatchTask{c.task})
+			if got := stateOf(t, r, 1).PatchState; got != c.state {
+				t.Errorf("state = %q, want %q", got, c.state)
+			}
+			c.expect(t, r)
+		})
+	}
+}
+
+// Work that came back unverified is "returned", not reviewable: nothing is
+// wrong with it, but nobody has shown it works.
+func TestPatchUnverifiedWorkIsReturned(t *testing.T) {
+	r := BuildPatchReport([]PatchTask{
+		{ID: 1, Status: "done", Files: `["src/a.c"]`, Result: packet(`"src/a.c"`, `[]`)},
+	})
+	if r.Returned != 1 || r.Reviewable != 0 || r.Verified != 0 {
+		t.Fatalf("report = %+v", r)
+	}
+}
+
+// A reviewer packet is read-only: it is not an implementation packet and does
+// not take an integration state.
+func TestPatchReviewerPacketIsCountedSeparately(t *testing.T) {
+	review := `{"schema_version":"delegate_review_v1","status":"block","findings":[` +
+		`{"severity":"high","owner_packet":"p1"},{"severity":"note"},{"owner_packet":"p2"}]}`
+	r := BuildPatchReport([]PatchTask{{ID: 9, Status: "done", Result: review}})
+
+	if r.ReviewerPackets != 1 || r.ImplementationPackets != 0 {
+		t.Fatalf("report = %+v", r)
+	}
+	if r.ReviewerStatus != "block" {
+		t.Errorf("reviewer status = %q", r.ReviewerStatus)
+	}
+	// "high" blocks, "note" does not, and the unlabelled finding counts as
+	// blocking because unlabelled is not the same as harmless.
+	if r.ReviewerBlockingFindings != 2 {
+		t.Errorf("blocking findings = %d, want 2", r.ReviewerBlockingFindings)
+	}
+	if r.ReviewerOwnerPacketRoutes != 2 {
+		t.Errorf("owner routes = %d, want 2", r.ReviewerOwnerPacketRoutes)
+	}
+	if state := stateOf(t, r, 9).PatchState; state != "reviewer" {
+		t.Errorf("state = %q, want reviewer", state)
+	}
+}
+
+// An unknown base is not evidence of staleness; only two KNOWN, differing
+// commits are.
+func TestPatchStaleBaseNeedsBothCommits(t *testing.T) {
+	onlyBase := `{"schema_version":"delegate_result_v1","status":"done",` +
+		`"changed_files":["src/a.c"],"tests":` + passedTest + `,"summary":"x","base_commit":"aaa"}`
+	r := BuildPatchReport([]PatchTask{
+		{ID: 1, Status: "done", Files: `["src/a.c"]`, Result: onlyBase},
+	})
+	if r.StaleWorktrees != 0 || r.Reviewable != 1 {
+		t.Errorf("an unknown integration base was read as stale: %+v", r)
+	}
+}
+
+// An empty run still answers, and says nothing has been reviewed.
+func TestPatchEmptyRun(t *testing.T) {
+	r := BuildPatchReport(nil)
+	if r.ReviewerStatus != "not_run" || r.RecommendedNextCommand != patchDefaultNext {
+		t.Errorf("report = %+v", r)
+	}
+	if len(r.Tasks) != 0 {
+		t.Errorf("tasks = %+v", r.Tasks)
+	}
+}

--- a/src/modules/delegates/delegate_patch_coordinator.c
+++ b/src/modules/delegates/delegate_patch_coordinator.c
@@ -1,4 +1,18 @@
-/* delegate_patch_coordinator.c: read-only integration policy summary. */
+/* delegate_patch_coordinator.c: the seam to the delegates module's integration
+ * policy, plus the JSON and text rendering of the report it produces.
+ *
+ * Deciding where each packet stands -- planned, running, returned, reviewable,
+ * failed or needs_supervisor -- weighs a believable handoff, ownership, base
+ * staleness, focused verification and file overlap against packets already
+ * declared reviewable. That is a judgement, so it is now
+ * server-go/modules/delegates/patchcoord.go. Moving it also dropped a bus round
+ * trip per task: the handoff rule lives in that module, so the coordinator
+ * calls it directly.
+ *
+ * Fails closed as an EMPTY report: no packets, reviewer status "not_run".
+ * Nothing is reported reviewable, which is the one answer that must never be
+ * invented -- "safe to integrate" is exactly the claim a supervisor acts on.
+ */
 #include <aimee/delegates/delegate_patch_coordinator.h>
 #include "cmd_agent_delegate_impl.h"
 
@@ -6,219 +20,33 @@
 #include <stdlib.h>
 #include <string.h>
 
-typedef struct
-{
-   char files[DELEGATE_PATCH_MAX_FILES][DELEGATE_PATCH_FILE_LEN];
-   int count;
-} patch_file_list_t;
-
 static void copy_str(char *dst, size_t cap, const char *src)
 {
    if (dst && cap > 0)
       snprintf(dst, cap, "%s", src ? src : "");
 }
 
-static int json_is_schema(cJSON *obj, const char *schema_name)
+static delegate_patch_provider_fn g_patch_provider;
+
+void delegate_register_patch_provider(delegate_patch_provider_fn provider)
 {
-   cJSON *schema =
-       cJSON_IsObject(obj) ? cJSON_GetObjectItemCaseSensitive(obj, "schema_version") : NULL;
-   return cJSON_IsString(schema) && strcmp(schema->valuestring, schema_name) == 0;
+   g_patch_provider = provider;
 }
 
-static int json_array_to_file_list(cJSON *arr, patch_file_list_t *out)
+void delegate_patch_coordinator_build_report(const db1_coord_job_t *job,
+                                             const db1_coord_task_t *tasks, int task_count,
+                                             delegate_patch_report_t *out)
 {
+   (void)job;
    if (!out)
-      return 0;
+      return;
    memset(out, 0, sizeof(*out));
-   if (!cJSON_IsArray(arr))
-      return 0;
-
-   cJSON *item;
-   cJSON_ArrayForEach(item, arr)
-   {
-      if (!cJSON_IsString(item) || !item->valuestring[0])
-         continue;
-      if (out->count >= DELEGATE_PATCH_MAX_FILES)
-         break;
-      copy_str(out->files[out->count++], sizeof(out->files[0]), item->valuestring);
-   }
-   return out->count;
-}
-
-static int file_list_contains(const patch_file_list_t *list, const char *path)
-{
-   if (!list || !path)
-      return 0;
-   for (int i = 0; i < list->count; i++)
-   {
-      if (strcmp(list->files[i], path) == 0)
-         return 1;
-   }
-   return 0;
-}
-
-static void file_list_add_unique(patch_file_list_t *list, const char *path)
-{
-   if (!list || !path || !path[0] || list->count >= DELEGATE_PATCH_MAX_FILES)
+   copy_str(out->reviewer_status, sizeof(out->reviewer_status), "not_run");
+   copy_str(out->recommended_next_command, sizeof(out->recommended_next_command),
+            "./aimee git verify");
+   if (!g_patch_provider)
       return;
-   if (file_list_contains(list, path))
-      return;
-   copy_str(list->files[list->count++], sizeof(list->files[0]), path);
-}
-
-static int file_lists_overlap(const patch_file_list_t *a, const patch_file_list_t *b)
-{
-   if (!a || !b)
-      return 0;
-   for (int i = 0; i < a->count; i++)
-   {
-      if (file_list_contains(b, a->files[i]))
-         return 1;
-   }
-   return 0;
-}
-
-static void find_handoff_text(cJSON *root, const char *raw, const char **handoff_text,
-                              char **owned_handoff_text)
-{
-   *handoff_text = NULL;
-   *owned_handoff_text = NULL;
-   if (json_is_schema(root, "delegate_result_v1") || json_is_schema(root, "delegate_review_v1"))
-   {
-      *handoff_text = raw;
-      return;
-   }
-
-   cJSON *response =
-       cJSON_IsObject(root) ? cJSON_GetObjectItemCaseSensitive(root, "response") : NULL;
-   if (cJSON_IsString(response) && response->valuestring[0])
-   {
-      *handoff_text = response->valuestring;
-      return;
-   }
-   if (cJSON_IsObject(response))
-      *owned_handoff_text = cJSON_PrintUnformatted(response);
-   if (*owned_handoff_text)
-      *handoff_text = *owned_handoff_text;
-}
-
-static cJSON *handoff_object(cJSON *root, const char *handoff_text, cJSON **owned_handoff)
-{
-   *owned_handoff = NULL;
-   if (json_is_schema(root, "delegate_result_v1") || json_is_schema(root, "delegate_review_v1"))
-      return root;
-   if (!handoff_text || !handoff_text[0])
-      return NULL;
-   *owned_handoff = cJSON_Parse(handoff_text);
-   if (json_is_schema(*owned_handoff, "delegate_result_v1") ||
-       json_is_schema(*owned_handoff, "delegate_review_v1"))
-      return *owned_handoff;
-   cJSON_Delete(*owned_handoff);
-   *owned_handoff = NULL;
-   return NULL;
-}
-
-static int supervisor_action_count(cJSON *handoff)
-{
-   cJSON *actions = cJSON_IsObject(handoff)
-                        ? cJSON_GetObjectItemCaseSensitive(handoff, "supervisor_actions")
-                        : NULL;
-   return cJSON_IsArray(actions) ? cJSON_GetArraySize(actions) : 0;
-}
-
-static int handoff_base_is_stale(cJSON *handoff)
-{
-   if (!cJSON_IsObject(handoff))
-      return 0;
-   cJSON *stale = cJSON_GetObjectItemCaseSensitive(handoff, "stale_base");
-   if (!stale)
-      stale = cJSON_GetObjectItemCaseSensitive(handoff, "worktree_stale");
-   if (cJSON_IsTrue(stale))
-      return 1;
-
-   cJSON *base = cJSON_GetObjectItemCaseSensitive(handoff, "base_commit");
-   if (!cJSON_IsString(base))
-      base = cJSON_GetObjectItemCaseSensitive(handoff, "delegate_base_commit");
-   if (!cJSON_IsString(base))
-      base = cJSON_GetObjectItemCaseSensitive(handoff, "base_sha");
-
-   cJSON *integration = cJSON_GetObjectItemCaseSensitive(handoff, "integration_base_commit");
-   if (!cJSON_IsString(integration))
-      integration = cJSON_GetObjectItemCaseSensitive(handoff, "integration_head");
-   if (!cJSON_IsString(integration))
-      integration = cJSON_GetObjectItemCaseSensitive(handoff, "integration_base_sha");
-
-   return cJSON_IsString(base) && cJSON_IsString(integration) &&
-          strcmp(base->valuestring, integration->valuestring) != 0;
-}
-
-static int reviewer_finding_routes(cJSON *findings)
-{
-   if (!cJSON_IsArray(findings))
-      return 0;
-   int count = 0;
-   cJSON *finding;
-   cJSON_ArrayForEach(finding, findings)
-   {
-      cJSON *owner = cJSON_IsObject(finding)
-                         ? cJSON_GetObjectItemCaseSensitive(finding, "owner_packet")
-                         : NULL;
-      if (cJSON_IsString(owner) && owner->valuestring[0])
-         count++;
-   }
-   return count;
-}
-
-static int reviewer_blocking_count(cJSON *findings)
-{
-   if (!cJSON_IsArray(findings))
-      return 0;
-   int count = 0;
-   cJSON *finding;
-   cJSON_ArrayForEach(finding, findings)
-   {
-      cJSON *severity =
-          cJSON_IsObject(finding) ? cJSON_GetObjectItemCaseSensitive(finding, "severity") : NULL;
-      if (!cJSON_IsString(severity))
-      {
-         count++;
-         continue;
-      }
-      if (strcmp(severity->valuestring, "note") != 0 && strcmp(severity->valuestring, "low") != 0)
-         count++;
-   }
-   return count;
-}
-
-static void add_state(delegate_patch_report_t *report, const char *state)
-{
-   if (!report || !state)
-      return;
-   if (strcmp(state, "planned") == 0)
-      report->planned++;
-   else if (strcmp(state, "running") == 0)
-      report->running++;
-   else if (strcmp(state, "returned") == 0)
-      report->returned++;
-   else if (strcmp(state, "verified") == 0)
-      report->verified++;
-   else if (strcmp(state, "reviewable") == 0)
-      report->reviewable++;
-   else if (strcmp(state, "accepted") == 0)
-      report->accepted++;
-   else if (strcmp(state, "failed") == 0)
-      report->failed++;
-   else if (strcmp(state, "needs_supervisor") == 0)
-      report->needs_supervisor++;
-}
-
-static void set_task_state(delegate_patch_task_report_t *tr, delegate_patch_report_t *report,
-                           const char *state, const char *note)
-{
-   copy_str(tr->patch_state, sizeof(tr->patch_state), state);
-   if (note && note[0])
-      copy_str(tr->note, sizeof(tr->note), note);
-   add_state(report, state);
+   g_patch_provider(tasks, task_count, out);
 }
 
 static void add_task_json(cJSON *arr, const delegate_patch_task_report_t *task)
@@ -241,166 +69,6 @@ static void add_task_json(cJSON *arr, const delegate_patch_task_report_t *task)
    if (task->note[0])
       cJSON_AddStringToObject(obj, "note", task->note);
    cJSON_AddItemToArray(arr, obj);
-}
-
-static void process_reviewer(delegate_patch_report_t *report, cJSON *handoff)
-{
-   report->reviewer_packets++;
-   cJSON *status = cJSON_GetObjectItemCaseSensitive(handoff, "status");
-   if (cJSON_IsString(status) && status->valuestring[0])
-      copy_str(report->reviewer_status, sizeof(report->reviewer_status), status->valuestring);
-   else
-      copy_str(report->reviewer_status, sizeof(report->reviewer_status), "needs_supervisor");
-
-   cJSON *findings = cJSON_GetObjectItemCaseSensitive(handoff, "findings");
-   if (strcmp(report->reviewer_status, "block") == 0)
-      report->reviewer_blocking_findings += reviewer_blocking_count(findings);
-   report->reviewer_owner_packet_routes += reviewer_finding_routes(findings);
-}
-
-void delegate_patch_coordinator_build_report(const db1_coord_job_t *job,
-                                             const db1_coord_task_t *tasks, int task_count,
-                                             delegate_patch_report_t *out)
-{
-   (void)job;
-   if (!out)
-      return;
-   memset(out, 0, sizeof(*out));
-   copy_str(out->reviewer_status, sizeof(out->reviewer_status), "not_run");
-   copy_str(out->recommended_next_command, sizeof(out->recommended_next_command),
-            "./aimee git verify");
-   if (!tasks || task_count <= 0)
-      return;
-
-   patch_file_list_t reviewable_files[DB1_COORD_MAX_TASKS];
-   int reviewable_task_ids[DB1_COORD_MAX_TASKS];
-   int reviewable_count = 0;
-   memset(reviewable_files, 0, sizeof(reviewable_files));
-   memset(reviewable_task_ids, 0, sizeof(reviewable_task_ids));
-
-   for (int i = 0; i < task_count && out->task_count < DB1_COORD_MAX_TASKS; i++)
-   {
-      const db1_coord_task_t *task = &tasks[i];
-      delegate_patch_task_report_t *tr = &out->tasks[out->task_count++];
-      tr->task_id = task->id;
-      tr->step_id = task->step_id;
-      copy_str(tr->task_status, sizeof(tr->task_status), task->status);
-
-      if (strcmp(task->status, "pending") == 0)
-      {
-         out->implementation_packets++;
-         set_task_state(tr, out, "planned", "packet has not launched");
-         continue;
-      }
-      if (strcmp(task->status, "claimed") == 0 || strcmp(task->status, "running") == 0)
-      {
-         out->implementation_packets++;
-         set_task_state(tr, out, "running", "delegate is active");
-         continue;
-      }
-      if (strcmp(task->status, "failed") == 0)
-      {
-         out->implementation_packets++;
-         set_task_state(tr, out, "failed", task->error[0] ? task->error : "delegate failed");
-         continue;
-      }
-
-      cJSON *root = task->result[0] ? cJSON_Parse(task->result) : NULL;
-      const char *handoff_text = NULL;
-      char *owned_handoff_text = NULL;
-      find_handoff_text(root, task->result, &handoff_text, &owned_handoff_text);
-
-      cJSON *owned_handoff = NULL;
-      cJSON *handoff = handoff_object(root, handoff_text, &owned_handoff);
-      if (json_is_schema(handoff, "delegate_review_v1"))
-      {
-         process_reviewer(out, handoff);
-         set_task_state(tr, out, "reviewer", "read-only reviewer result");
-         cJSON_Delete(owned_handoff);
-         free(owned_handoff_text);
-         cJSON_Delete(root);
-         continue;
-      }
-
-      out->implementation_packets++;
-      delegate_handoff_validation_t v;
-      memset(&v, 0, sizeof(v));
-      if (strcmp(task->status, "done") != 0 || !handoff_text ||
-          delegate_handoff_validate_text(handoff_text, task->files, 1, &v) != 0)
-      {
-         out->invalid_handoffs++;
-         copy_str(tr->handoff_status, sizeof(tr->handoff_status), "needs_supervisor_review");
-         set_task_state(tr, out, "needs_supervisor",
-                        v.error[0] ? v.error : "missing or invalid structured handoff");
-         cJSON_Delete(owned_handoff);
-         free(owned_handoff_text);
-         cJSON_Delete(root);
-         continue;
-      }
-
-      tr->handoff_valid = v.valid;
-      copy_str(tr->handoff_status, sizeof(tr->handoff_status), v.status);
-      tr->changed_files_count = v.changed_files_count;
-      tr->passed_tests = v.passed_tests;
-      tr->outside_ownership_count = v.outside_ownership_count;
-      tr->supervisor_actions = supervisor_action_count(handoff);
-      tr->stale_base = handoff_base_is_stale(handoff);
-      out->focused_tests_passed += v.passed_tests;
-      out->outside_ownership_touches += v.outside_ownership_count;
-      if (tr->stale_base)
-         out->stale_worktrees++;
-      if (v.passed_tests > 0)
-         out->verified++;
-
-      cJSON *changed = cJSON_IsObject(handoff)
-                           ? cJSON_GetObjectItemCaseSensitive(handoff, "changed_files")
-                           : NULL;
-      patch_file_list_t changed_files;
-      json_array_to_file_list(changed, &changed_files);
-
-      if (strcmp(v.status, "failed") == 0)
-         set_task_state(tr, out, "failed", v.error[0] ? v.error : "delegate reported failed");
-      else if (strcmp(v.status, "blocked") == 0)
-         set_task_state(tr, out, "needs_supervisor",
-                        v.error[0] ? v.error : "delegate reported blocked");
-      else if (v.outside_ownership_count > 0)
-         set_task_state(tr, out, "needs_supervisor",
-                        v.error[0] ? v.error : "changed files outside owned_files");
-      else if (tr->stale_base)
-         set_task_state(tr, out, "needs_supervisor", "delegate base differs from integration base");
-      else if (v.passed_tests <= 0)
-         set_task_state(tr, out, "returned",
-                        v.error[0] ? v.error : "focused verification not reported");
-      else
-      {
-         int overlap_task_id = 0;
-         for (int r = 0; r < reviewable_count; r++)
-         {
-            if (file_lists_overlap(&changed_files, &reviewable_files[r]))
-            {
-               overlap_task_id = reviewable_task_ids[r];
-               break;
-            }
-         }
-         if (overlap_task_id > 0)
-         {
-            tr->overlap_task_id = overlap_task_id;
-            out->patch_overlaps++;
-            set_task_state(tr, out, "needs_supervisor", "changed files overlap another packet");
-         }
-         else
-         {
-            for (int f = 0; f < changed_files.count; f++)
-               file_list_add_unique(&reviewable_files[reviewable_count], changed_files.files[f]);
-            reviewable_task_ids[reviewable_count++] = task->id;
-            set_task_state(tr, out, "reviewable", "ownership and verification checks passed");
-         }
-      }
-
-      cJSON_Delete(owned_handoff);
-      free(owned_handoff_text);
-      cJSON_Delete(root);
-   }
 }
 
 void delegate_patch_coordinator_add_json(cJSON *obj, const delegate_patch_report_t *report)

--- a/src/modules/delegates/include/aimee/delegates/delegate_patch_coordinator.h
+++ b/src/modules/delegates/include/aimee/delegates/delegate_patch_coordinator.h
@@ -52,6 +52,15 @@ typedef struct
    delegate_patch_task_report_t tasks[DB1_COORD_MAX_TASKS];
 } delegate_patch_report_t;
 
+/* Where a run's patches stand is the delegates module's rule
+ * (server-go/modules/delegates/patchcoord.go). This is the seam the C side
+ * calls through; with no provider registered the report stays empty with a
+ * "not_run" reviewer status, so nothing is reported as reviewable. Declaring a
+ * packet ready to integrate is the one answer that must never be invented. */
+typedef void (*delegate_patch_provider_fn)(const db1_coord_task_t *tasks, int task_count,
+                                           delegate_patch_report_t *out);
+void delegate_register_patch_provider(delegate_patch_provider_fn provider);
+
 void delegate_patch_coordinator_build_report(const db1_coord_job_t *job,
                                              const db1_coord_task_t *tasks, int task_count,
                                              delegate_patch_report_t *out);

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -420,4 +420,73 @@ static inline size_t aimee_delegates_econ_put_agent(const char *name, int tier, 
    return at + 4;
 }
 
+/* --- Patch coordination (stage 9) --- */
+
+#define AIMEE_DELEGATES_EVENT_PATCH          6665u
+#define AIMEE_DELEGATES_STAGE_PATCH          9u
+#define AIMEE_DELEGATES_PATCH_REQUEST_MAGIC  0x51435044u /* "DPCQ" */
+#define AIMEE_DELEGATES_PATCH_RESPONSE_MAGIC 0x53435044u /* "DPCS" */
+#define AIMEE_DELEGATES_PATCH_REQ_HEADER_LEN 16u
+#define AIMEE_DELEGATES_PATCH_STATE_LEN      32u
+#define AIMEE_DELEGATES_PATCH_NOTE_LEN       256u
+#define AIMEE_DELEGATES_PATCH_NEXTCMD_LEN    64u
+#define AIMEE_DELEGATES_PATCH_RUN_FIELDS     18u
+#define AIMEE_DELEGATES_PATCH_RESP_HEADER_LEN                                                      \
+   (4u + AIMEE_DELEGATES_PATCH_RUN_FIELDS * 4u + AIMEE_DELEGATES_PATCH_STATE_LEN +                 \
+    AIMEE_DELEGATES_PATCH_NEXTCMD_LEN)
+#define AIMEE_DELEGATES_PATCH_TASK_FIELDS 9u
+#define AIMEE_DELEGATES_PATCH_TASK_REC_LEN                                                         \
+   (AIMEE_DELEGATES_PATCH_TASK_FIELDS * 4u + AIMEE_DELEGATES_PATCH_STATE_LEN * 3u +                \
+    AIMEE_DELEGATES_PATCH_NOTE_LEN)
+#define AIMEE_DELEGATES_PATCH_MAX_TASKS 64u
+
+static inline size_t aimee_delegates_patch_request_begin(uint32_t task_count, uint8_t *out,
+                                                         size_t cap)
+{
+   if (!out || cap < AIMEE_DELEGATES_PATCH_REQ_HEADER_LEN ||
+       task_count > AIMEE_DELEGATES_PATCH_MAX_TASKS)
+      return 0;
+   memset(out, 0, AIMEE_DELEGATES_PATCH_REQ_HEADER_LEN);
+   aimee_delegates_put_u32(out, AIMEE_DELEGATES_PATCH_REQUEST_MAGIC);
+   out[4] = 1; /* wire version */
+   aimee_delegates_put_u32(out + 8, task_count);
+   return AIMEE_DELEGATES_PATCH_REQ_HEADER_LEN;
+}
+
+static inline size_t aimee_delegates_patch_put_task(int id, int step_id, const char *status,
+                                                    const char *error, const char *files,
+                                                    const char *result, uint8_t *out, size_t at,
+                                                    size_t cap)
+{
+   size_t status_len = status ? strlen(status) : 0;
+   size_t error_len = error ? strlen(error) : 0;
+   size_t files_len = files ? strlen(files) : 0;
+   size_t result_len = result ? strlen(result) : 0;
+   if (!out || at == 0 || status_len > 0xffffu || error_len > 0xffffu ||
+       at + 20 + status_len + error_len + files_len + result_len > cap)
+      return 0;
+
+   aimee_delegates_put_u32(out + at, (uint32_t)id);
+   aimee_delegates_put_u32(out + at + 4, (uint32_t)step_id);
+   out[at + 8] = (uint8_t)(status_len & 0xffu);
+   out[at + 9] = (uint8_t)((status_len >> 8) & 0xffu);
+   out[at + 10] = (uint8_t)(error_len & 0xffu);
+   out[at + 11] = (uint8_t)((error_len >> 8) & 0xffu);
+   aimee_delegates_put_u32(out + at + 12, (uint32_t)files_len);
+   aimee_delegates_put_u32(out + at + 16, (uint32_t)result_len);
+   at += 20;
+   if (status_len)
+      memcpy(out + at, status, status_len);
+   at += status_len;
+   if (error_len)
+      memcpy(out + at, error, error_len);
+   at += error_len;
+   if (files_len)
+      memcpy(out + at, files, files_len);
+   at += files_len;
+   if (result_len)
+      memcpy(out + at, result, result_len);
+   return at + result_len;
+}
+
 #endif

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -82,7 +82,9 @@
     "server-go/modules/delegates/rescue_stage.go",
     "server-go/modules/delegates/verify.go",
     "server-go/modules/delegates/economics.go",
-    "server-go/modules/delegates/economics_stage.go"
+    "server-go/modules/delegates/economics_stage.go",
+    "server-go/modules/delegates/patchcoord.go",
+    "server-go/modules/delegates/patchcoord_stage.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -95,7 +97,9 @@
     "server-go/modules/delegates/rescue_stage_test.go",
     "server-go/modules/delegates/verify_test.go",
     "server-go/modules/delegates/economics_test.go",
-    "server-go/modules/delegates/economics_stage_test.go"
+    "server-go/modules/delegates/economics_stage_test.go",
+    "server-go/modules/delegates/patchcoord_test.go",
+    "server-go/modules/delegates/patchcoord_stage_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -166,6 +166,11 @@
           "id": 8,
           "name": "delegate-economics-report",
           "event_kind": 6664
+        },
+        {
+          "id": 9,
+          "name": "delegate-patch-coordination",
+          "event_kind": 6665
         }
       ]
     },

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -6,6 +6,7 @@
 #include <aimee/delegates/delegate_xml_fallback.h>
 #include "delegate_verify.h"
 #include <aimee/delegates/delegate_economics.h>
+#include <aimee/delegates/delegate_patch_coordinator.h>
 #include <aimee/git/git_ops.h>
 #include "gw_stage_governance.h"
 #include "ingress_preinject.h"
@@ -622,6 +623,135 @@ static void delegate_economics(const db1_coord_task_t *tasks, int task_count,
                                  out->cost_model_label, sizeof(out->cost_model_label));
 }
 
+/* Where a run's patches stand. The task rows are gathered here; the module
+ * reads the six fields the rule needs and forgets them. */
+static void delegate_patch_coord(const db1_coord_task_t *tasks, int task_count,
+                                 delegate_patch_report_t *out)
+{
+   if (!out || task_count < 0 || (uint32_t)task_count > AIMEE_DELEGATES_PATCH_MAX_TASKS)
+      return;
+
+   size_t cap = AIMEE_DELEGATES_PATCH_REQ_HEADER_LEN;
+   for (int i = 0; i < task_count; i++)
+   {
+      cap += 20 + strlen(tasks[i].status) + strlen(tasks[i].error) + strlen(tasks[i].files) +
+             strlen(tasks[i].result);
+   }
+
+   uint8_t *request = malloc(cap);
+   if (!request)
+      return;
+   size_t at = aimee_delegates_patch_request_begin((uint32_t)task_count, request, cap);
+   for (int i = 0; i < task_count && at; i++)
+   {
+      at = aimee_delegates_patch_put_task(tasks[i].id, tasks[i].step_id, tasks[i].status,
+                                          tasks[i].error, tasks[i].files, tasks[i].result, request,
+                                          at, cap);
+   }
+   if (at == 0 || at > UINT32_MAX)
+   {
+      free(request);
+      return;
+   }
+
+   size_t response_cap = AIMEE_DELEGATES_PATCH_RESP_HEADER_LEN +
+                         AIMEE_DELEGATES_PATCH_MAX_TASKS * AIMEE_DELEGATES_PATCH_TASK_REC_LEN;
+   uint8_t *response = malloc(response_cap);
+   if (!response)
+   {
+      free(request);
+      return;
+   }
+
+   uint32_t response_len = 0;
+   int rc = call_module(AIMEE_DELEGATES_EVENT_PATCH, AIMEE_DELEGATES_STAGE_PATCH, request,
+                        (uint32_t)at, response, (uint32_t)response_cap, &response_len);
+   free(request);
+   if (rc != 0 || response_len < AIMEE_DELEGATES_PATCH_RESP_HEADER_LEN ||
+       aimee_delegates_get_u32(response) != AIMEE_DELEGATES_PATCH_RESPONSE_MAGIC)
+   {
+      free(response);
+      return;
+   }
+
+   int *run_fields[] = {
+       &out->task_count,
+       &out->implementation_packets,
+       &out->planned,
+       &out->running,
+       &out->returned,
+       &out->verified,
+       &out->reviewable,
+       &out->accepted,
+       &out->failed,
+       &out->needs_supervisor,
+       &out->invalid_handoffs,
+       &out->outside_ownership_touches,
+       &out->patch_overlaps,
+       &out->stale_worktrees,
+       &out->focused_tests_passed,
+       &out->reviewer_packets,
+       &out->reviewer_blocking_findings,
+       &out->reviewer_owner_packet_routes,
+   };
+   for (unsigned i = 0; i < AIMEE_DELEGATES_PATCH_RUN_FIELDS; i++)
+      *run_fields[i] = (int)aimee_delegates_get_u32(response + 4 + i * 4);
+
+   size_t off = 4 + AIMEE_DELEGATES_PATCH_RUN_FIELDS * 4;
+   aimee_delegates_handoff_field(response, off, AIMEE_DELEGATES_PATCH_STATE_LEN,
+                                 out->reviewer_status, sizeof(out->reviewer_status));
+   off += AIMEE_DELEGATES_PATCH_STATE_LEN;
+   aimee_delegates_handoff_field(response, off, AIMEE_DELEGATES_PATCH_NEXTCMD_LEN,
+                                 out->recommended_next_command,
+                                 sizeof(out->recommended_next_command));
+
+   int count = out->task_count;
+   if (count < 0 || (uint32_t)count > AIMEE_DELEGATES_PATCH_MAX_TASKS ||
+       response_len != AIMEE_DELEGATES_PATCH_RESP_HEADER_LEN +
+                           (uint32_t)count * AIMEE_DELEGATES_PATCH_TASK_REC_LEN)
+   {
+      /* The header and the body disagree: report nothing rather than a
+       * partially decoded run. */
+      memset(out, 0, sizeof(*out));
+      free(response);
+      return;
+   }
+
+   for (int i = 0; i < count; i++)
+   {
+      const uint8_t *rec = response + AIMEE_DELEGATES_PATCH_RESP_HEADER_LEN +
+                           (size_t)i * AIMEE_DELEGATES_PATCH_TASK_REC_LEN;
+      delegate_patch_task_report_t *tr = &out->tasks[i];
+      int *task_fields[] = {
+          &tr->task_id,
+          &tr->step_id,
+          &tr->handoff_valid,
+          &tr->changed_files_count,
+          &tr->passed_tests,
+          &tr->outside_ownership_count,
+          &tr->overlap_task_id,
+          &tr->stale_base,
+          &tr->supervisor_actions,
+      };
+      for (unsigned f = 0; f < AIMEE_DELEGATES_PATCH_TASK_FIELDS; f++)
+         *task_fields[f] = (int)aimee_delegates_get_u32(rec + f * 4);
+
+      size_t s_off = AIMEE_DELEGATES_PATCH_TASK_FIELDS * 4;
+      aimee_delegates_handoff_field(rec, s_off, AIMEE_DELEGATES_PATCH_STATE_LEN, tr->task_status,
+                                    sizeof(tr->task_status));
+      s_off += AIMEE_DELEGATES_PATCH_STATE_LEN;
+      aimee_delegates_handoff_field(rec, s_off, AIMEE_DELEGATES_PATCH_STATE_LEN, tr->patch_state,
+                                    sizeof(tr->patch_state));
+      s_off += AIMEE_DELEGATES_PATCH_STATE_LEN;
+      aimee_delegates_handoff_field(rec, s_off, AIMEE_DELEGATES_PATCH_STATE_LEN, tr->handoff_status,
+                                    sizeof(tr->handoff_status));
+      s_off += AIMEE_DELEGATES_PATCH_STATE_LEN;
+      aimee_delegates_handoff_field(rec, s_off, AIMEE_DELEGATES_PATCH_NOTE_LEN, tr->note,
+                                    sizeof(tr->note));
+   }
+   free(response);
+}
+
 static int tool_classify(const char *name, int *classification)
 {
    uint8_t request[AIMEE_TOOLS_REQUEST_LEN], response[AIMEE_TOOLS_RESPONSE_LEN];
@@ -836,6 +966,7 @@ void server_module_stage_adapters_configure(void)
    delegate_register_rescue_provider(delegate_rescue);
    delegate_register_verify_provider(delegate_verify);
    delegate_register_economics_provider(delegate_economics);
+   delegate_register_patch_provider(delegate_patch_coord);
    agent_tools_register_classifier(tool_classify);
    ws_scope_register_ref_validator(workspace_validate);
    /* Same decision, same owner: webuser's runtime dir names a single path

--- a/src/tests/test_delegate_patch_coordinator.c
+++ b/src/tests/test_delegate_patch_coordinator.c
@@ -5,19 +5,6 @@
 #include <stdio.h>
 #include <string.h>
 
-static void init_task(db1_coord_task_t *task, int id, const char *status, const char *files,
-                      const char *result)
-{
-   memset(task, 0, sizeof(*task));
-   task->id = id;
-   task->job_id = 1;
-   task->step_id = id + 100;
-   snprintf(task->status, sizeof(task->status), "%s", status);
-   snprintf(task->files, sizeof(task->files), "%s", files ? files : "[]");
-   if (result)
-      snprintf(task->result, sizeof(task->result), "%s", result);
-}
-
 /* Judging a handoff is the delegates module's rule now
  * (server-go/modules/delegates/handoff.go) and this binary hosts no bus. The
  * subject of these tests is COORDINATION -- which packets are reviewable, which
@@ -95,128 +82,6 @@ static int coord_test_handoff_provider(const char *text, const char *owned_files
    return 0;
 }
 
-static void make_handoff(char *buf, size_t len, const char *status, const char *changed,
-                         const char *tests, const char *extra)
-{
-   snprintf(buf, len,
-            "{"
-            "\"schema_version\":\"delegate_result_v1\","
-            "\"status\":\"%s\","
-            "\"packet_id\":\"packet-one\","
-            "\"changed_files\":[%s],"
-            "\"outside_ownership_touches\":[],"
-            "\"tests\":[%s],"
-            "\"supervisor_actions\":[],"
-            "\"summary\":\"result\"%s"
-            "}",
-            status, changed, tests, extra ? extra : "");
-}
-
-static void test_disjoint_verified_packets_are_reviewable(void)
-{
-   char h1[1024], h2[1024];
-   make_handoff(h1, sizeof(h1), "done", "\"src/a.c\"",
-                "{\"name\":\"unit-a\",\"status\":\"passed\"}", "");
-   make_handoff(h2, sizeof(h2), "done", "\"src/b.c\"",
-                "{\"name\":\"unit-b\",\"status\":\"passed\"}", "");
-
-   db1_coord_task_t tasks[2];
-   init_task(&tasks[0], 1, "done", "[\"src/a.c\"]", h1);
-   init_task(&tasks[1], 2, "done", "[\"src/b.c\"]", h2);
-
-   delegate_patch_report_t report;
-   delegate_patch_coordinator_build_report(NULL, tasks, 2, &report);
-   assert(report.implementation_packets == 2);
-   assert(report.reviewable == 2);
-   assert(report.needs_supervisor == 0);
-   assert(report.verified == 2);
-   assert(report.focused_tests_passed == 2);
-   assert(strcmp(report.tasks[0].patch_state, "reviewable") == 0);
-   assert(strcmp(report.tasks[1].patch_state, "reviewable") == 0);
-   printf("  PASS: test_disjoint_verified_packets_are_reviewable\n");
-}
-
-static void test_outside_owned_files_need_supervisor(void)
-{
-   char h[1024];
-   make_handoff(h, sizeof(h), "done", "\"src/a.c\",\"src/outside.c\"",
-                "{\"name\":\"unit-a\",\"status\":\"passed\"}", "");
-
-   db1_coord_task_t task;
-   init_task(&task, 3, "done", "[\"src/a.c\"]", h);
-
-   delegate_patch_report_t report;
-   delegate_patch_coordinator_build_report(NULL, &task, 1, &report);
-   assert(report.needs_supervisor == 1);
-   assert(report.outside_ownership_touches == 1);
-   assert(strcmp(report.tasks[0].patch_state, "needs_supervisor") == 0);
-   assert(strstr(report.tasks[0].note, "outside") != NULL);
-   printf("  PASS: test_outside_owned_files_need_supervisor\n");
-}
-
-static void test_overlapping_patches_need_supervisor(void)
-{
-   char h1[1024], h2[1024];
-   make_handoff(h1, sizeof(h1), "done", "\"src/shared.c\"",
-                "{\"name\":\"unit-a\",\"status\":\"passed\"}", "");
-   make_handoff(h2, sizeof(h2), "done", "\"src/shared.c\"",
-                "{\"name\":\"unit-b\",\"status\":\"passed\"}", "");
-
-   db1_coord_task_t tasks[2];
-   init_task(&tasks[0], 4, "done", "[\"src/shared.c\"]", h1);
-   init_task(&tasks[1], 5, "done", "[\"src/shared.c\"]", h2);
-
-   delegate_patch_report_t report;
-   delegate_patch_coordinator_build_report(NULL, tasks, 2, &report);
-   assert(report.reviewable == 1);
-   assert(report.needs_supervisor == 1);
-   assert(report.patch_overlaps == 1);
-   assert(report.tasks[1].overlap_task_id == 4);
-   assert(strcmp(report.tasks[1].patch_state, "needs_supervisor") == 0);
-   printf("  PASS: test_overlapping_patches_need_supervisor\n");
-}
-
-static void test_stale_base_metadata_needs_supervisor(void)
-{
-   char h[1024];
-   make_handoff(h, sizeof(h), "done", "\"src/a.c\"", "{\"name\":\"unit-a\",\"status\":\"passed\"}",
-                ",\"base_commit\":\"aaa\",\"integration_base_commit\":\"bbb\"");
-
-   db1_coord_task_t task;
-   init_task(&task, 6, "done", "[\"src/a.c\"]", h);
-
-   delegate_patch_report_t report;
-   delegate_patch_coordinator_build_report(NULL, &task, 1, &report);
-   assert(report.stale_worktrees == 1);
-   assert(report.needs_supervisor == 1);
-   assert(report.tasks[0].stale_base == 1);
-   assert(strcmp(report.tasks[0].patch_state, "needs_supervisor") == 0);
-   printf("  PASS: test_stale_base_metadata_needs_supervisor\n");
-}
-
-static void test_reviewer_routes_owner_packet_findings(void)
-{
-   const char *review = "{"
-                        "\"schema_version\":\"delegate_review_v1\","
-                        "\"status\":\"block\","
-                        "\"findings\":[{\"severity\":\"high\","
-                        "\"owner_packet\":\"packet-a\","
-                        "\"description\":\"missing check\"}],"
-                        "\"missing_requirements\":[]"
-                        "}";
-   db1_coord_task_t task;
-   init_task(&task, 7, "done", "[]", review);
-
-   delegate_patch_report_t report;
-   delegate_patch_coordinator_build_report(NULL, &task, 1, &report);
-   assert(report.reviewer_packets == 1);
-   assert(strcmp(report.reviewer_status, "block") == 0);
-   assert(report.reviewer_blocking_findings == 1);
-   assert(report.reviewer_owner_packet_routes == 1);
-   assert(strcmp(report.tasks[0].patch_state, "reviewer") == 0);
-   printf("  PASS: test_reviewer_routes_owner_packet_findings\n");
-}
-
 static void test_brief_mentions_next_command(void)
 {
    delegate_patch_report_t report;
@@ -234,11 +99,6 @@ int main(void)
 {
    delegate_register_handoff_provider(coord_test_handoff_provider);
    printf("delegate_patch_coordinator:\n");
-   test_disjoint_verified_packets_are_reviewable();
-   test_outside_owned_files_need_supervisor();
-   test_overlapping_patches_need_supervisor();
-   test_stale_base_metadata_needs_supervisor();
-   test_reviewer_routes_owner_packet_findings();
    test_brief_mentions_next_command();
    printf("delegate_patch_coordinator: all tests passed\n");
    return 0;

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1431,7 +1431,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_patch_coordinator.h",
-          "sha256": "fe0f5b87611fff9020ae141b2ba2cde3814bb9ca4addc27c9dfe0389b5f6b46a"
+          "sha256": "2874f272ffb76d1a32ca765f2b3a719bf5f8ecb7d88d7552912776cf6bd464e9"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_plan.h",
@@ -1463,7 +1463,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "4eff975db056d964031bb8fffe618cd57216fbdbcf97a8d3d37b0ef45cdc4b5d"
+          "sha256": "ba6a868446393417605d595debf6a7d9b8d0e4183c6690f4b10f4f3f6d9b2450"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "d6019d00e59662475f8e3325d0728ecd9405a6867e72b49fe206aed7b6c92e7f",
+      "sha256": "eb1ed439d7ba172114394907f5bb48560a4eba2774d1de94753af2d1cd7e5140",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1431,7 +1431,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_patch_coordinator.h",
-          "sha256": "fe0f5b87611fff9020ae141b2ba2cde3814bb9ca4addc27c9dfe0389b5f6b46a"
+          "sha256": "2874f272ffb76d1a32ca765f2b3a719bf5f8ecb7d88d7552912776cf6bd464e9"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_plan.h",
@@ -1463,7 +1463,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "4eff975db056d964031bb8fffe618cd57216fbdbcf97a8d3d37b0ef45cdc4b5d"
+          "sha256": "ba6a868446393417605d595debf6a7d9b8d0e4183c6690f4b10f4f3f6d9b2450"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "dde99e615465d5a705b536a8f0c464a8933fce1da9e1bb56fd29fce6519a0359",
+      "sha256": "e798a88313064caf1a32d678e0abcab3f6dffd4f97850cc0f03f6619fdf1cc57",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
refactor(delegates): patch coordination moves into the module

Where a coordinated run's patches stand was ~355 lines of C: whether a packet is
planned, running, returned, reviewable, failed or needs a supervisor, weighed
from a believable handoff, ownership, base staleness, focused verification and
file overlap. That is a judgement, so it is now
server-go/modules/delegates/patchcoord.go on a new stage.

REVIEWABLE is the load-bearing answer, and its overlap check is deliberately
asymmetric. A packet contends only against packets ALREADY declared reviewable,
so when two touch the same file the first stays reviewable and only the second
goes to a human. Comparing against every packet would stall both and turn one
shared file into a stalled run. The ported tests pin that ordering rather than
leaving it to iteration order.

Moving it dropped a bus round trip per task, as the economics slice did: the
handoff rule lives in this module, so the coordinator calls ValidateHandoff
in-process instead of asking back out through C for every row.

Fails closed as an EMPTY report with reviewer status "not_run" -- nothing
reviewable. That is the one answer that must never be invented: "safe to
integrate" is precisely what a supervisor acts on, and a fabricated one would be
acted on before anybody noticed the module was unreachable.

Two smaller judgements travelled with it, both stated in the module:

  - a reviewer finding with NO severity counts as blocking. Unlabelled is not
    the same as harmless, and the conservative reading sends it to a human;
  - an unknown base is not evidence of staleness. Only two KNOWN, differing
    commits mean the delegate worked from the wrong base.

The C test keeps test_brief_mentions_next_command, which builds a report
directly and exercises delegate_patch_coordinator_brief -- still C rendering.
The five rule tests moved to Go with their cases, plus the disjoint-packets
shape that had no Go equivalent. Only one test binary links the object, from the
link graph rather than a caller grep.

Declared in the contract (6665, stage 9), the descriptor, the dispatch table and
the registry-vs-contracts test, with the serve grant regenerated.

Verified against the real link and the real lint: ../aimee-server deleted and
relinked from scratch, plus ../aimee-kb and cmd-srcs-compile-check, and
`make -C src format` then `make -C src lint` (48 checks) BEFORE committing --
the gate that failed on #2508 after hand-edited C went in unformatted.
