### PR TITLE
fix(git): advertise the forge-request and credential-resolve stages

### DIFF
--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -133,6 +133,8 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: modulegit.EventKind, StageID: modulegit.StageOperation},
 			{EventKind: modulegit.EventRefValidate, StageID: modulegit.StageRefValidate},
 			{EventKind: modulegit.EventCIGrade, StageID: modulegit.StageCIGrade},
+			{EventKind: modulegit.EventForgeRequest, StageID: modulegit.StageForgeRequest},
+			{EventKind: modulegit.EventCredResolve, StageID: modulegit.StageCredResolve},
 			{EventKind: modulegit.EventVerifyRun, StageID: modulegit.StageVerifyRun},
 		}
 		config.Handler = modulegit.Handle

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -18,7 +21,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
-		{"git", 13, []uint32{7425, 7426, 7427, 7430}},
+		{"git", 13, []uint32{7425, 7426, 7427, 7428, 7429, 7430}},
 		{"skills", 14, []uint32{7681, 7682}},
 		{"response-composition", 15, []uint32{7937}},
 		{"governance", 19, []uint32{8961}},
@@ -47,6 +50,79 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 					config.Stages[index], event, wantStage)
 			}
 		}
+	}
+}
+
+// THE TABLE ABOVE IS HAND-WRITTEN, so on its own it proves only that the code
+// matches a second copy of itself. It did exactly that: git shipped for weeks
+// advertising 7425,7426,7427,7430 while process-contracts.json declared
+// git-forge-request (7428) and git-credential-resolve (7429) as well, and this
+// test — despite its name — agreed with the code because someone updated the
+// list to match rather than the contract.
+//
+// Nothing noticed until callers moved onto those stages: the module HANDLES
+// both (Handle routes them) and the grant PERMITS both (serve=7425..7430), but a
+// stage that is never advertised is never available, so every call returned
+// CAPABILITY_ABSENT in ~40ms. That reads as "the module is down" while the
+// module is plainly running, and it silently disabled git credential injection
+// (pushes asked for a username) and every forge operation.
+//
+// So compare against the CONTRACT FILE itself. A stage added to the contract and
+// not advertised — or advertised and not declared — now fails here.
+func TestAdvertisedStagesMatchTheContractFile(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "src", "modules", "process-contracts.json"))
+	if err != nil {
+		t.Fatalf("read process-contracts.json: %v", err)
+	}
+	var contracts struct {
+		Components []struct {
+			ID        string `json:"id"`
+			Execution string `json:"execution"`
+			Stages    []struct {
+				EventKind uint32 `json:"event_kind"`
+				Name      string `json:"name"`
+			} `json:"stages"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(raw, &contracts); err != nil {
+		t.Fatalf("parse process-contracts.json: %v", err)
+	}
+	if len(contracts.Components) == 0 {
+		t.Fatal("no components parsed — the schema moved and this test would pass vacuously")
+	}
+
+	checked := 0
+	for _, declared := range contracts.Components {
+		if declared.Execution != "process" || len(declared.Stages) == 0 {
+			continue // not a module process; nothing to advertise
+		}
+		config, ok := moduleConfig("/usr/local/libexec/aimee-modules/aimee-module-" + declared.ID)
+		if !ok {
+			continue // not built into this binary (e.g. a C-hosted component)
+		}
+		checked++
+		advertised := map[uint32]bool{}
+		for _, s := range config.Stages {
+			advertised[s.EventKind] = true
+		}
+		for _, s := range declared.Stages {
+			// roundtable-review is registered ONLY when this process can convene a
+			// panel (roundtableReviewer() succeeds), which it cannot under test.
+			// That conditionality is deliberate and documented above; every other
+			// declared stage is unconditional and must be advertised.
+			if s.EventKind == 9474 {
+				continue
+			}
+			if !advertised[s.EventKind] {
+				t.Errorf("%s declares %s (event %d) in process-contracts.json but never "+
+					"advertises it: calls fail CAPABILITY_ABSENT though the module is running",
+					declared.ID, s.Name, s.EventKind)
+			}
+		}
+	}
+	// Guard the guard: if nothing was compared, this test proves nothing.
+	if checked == 0 {
+		t.Fatal("no module was actually compared against the contract")
 	}
 }
 


### PR DESCRIPTION
The git module never told the bus it serves 7428 (git-forge-request) or 7429 (git-credential-resolve). Everything else lined up and hid it:

  - Handle() routes both stages
  - process-contracts.json declares both
  - the shipped grant permits both (serve=7425,7426,7427,7428,7429,7430)

but a stage that is not ADVERTISED is not available, so obs_bus_module_available returns false and aimee_module_json_call answers CAPABILITY_ABSENT immediately. Measured: 41ms. Instant failure reads like a dead module, not a missing registration, which is why this was chased as saturation, credentials, and a bad deploy before anyone looked at the advertised list.

WHAT IT BROKE, once callers moved onto those stages:

  - every forge operation -- pr create / view / merge -- failed with "the git module could not be reached" while the module was plainly running.
  - git credential injection silently stopped. mcp_git_run asks stage 5 which workspace owns the cwd; that call fails, so have_ws != 0 and the whole injection block is skipped. git then execs with no credential and a push fails asking for a username. `git status` still worked because it needs no credential -- which is exactly why this looked like a credential bug.

THE TEST THAT SHOULD HAVE CAUGHT IT ASSERTED THE BUG. Despite being called TestModuleRegistryMatchesProcessContracts, it hardcodes the expected event list and someone had updated that list to match the code (7425,7426,7427,7430) rather than the contract. It compared the code against a second copy of itself.

So the new test reads process-contracts.json and compares against it. Two guards on the guard, because my first attempt at it was VACUOUS -- I assumed the wrong schema, every component failed to parse, the loop body never ran and it passed against the unfixed code:

  - fail if no components parse at all
  - fail if no module was actually compared

roundtable-review (9474) is skipped explicitly: it is registered only when the process can convene a panel, which it cannot under test. That conditionality is real and documented; everything else must be advertised unconditionally.

Verified red-before-green: with main.go reverted the test names 7428 and 7429 exactly, and passes with the fix.

This also means #2496 was never disproven. Its credential fix calls stage 5, so on this build it could not run at all -- the fix was unreachable, not wrong.