### PR TITLE
refactor(delegates): role policy moves into the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "8c9ef6cb1f3770aa403d17a865149b32c6b368d1b1971eaec40d13614a14863d",
+      "source_sha256": "3370e1b35bf651779c784caad9f0e44bba1430c27cdc0e7eb707cd9430c555e9",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
@@ -178,7 +178,8 @@
         6662,
         6663,
         6664,
-        6665
+        6665,
+        6666
       ]
     },
     {

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -111,6 +111,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: delegates.EventVerify, StageID: delegates.StageVerify},
 			{EventKind: delegates.EventEconomics, StageID: delegates.StageEconomics},
 			{EventKind: delegates.EventPatchCoord, StageID: delegates.StagePatchCoord},
+			{EventKind: delegates.EventRolePolicy, StageID: delegates.StageRolePolicy},
 		}
 		config.Handler = delegates.Handle
 	case "tools":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -18,7 +18,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664, 6665}},
+		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664, 6665, 6666}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7428, 7429, 7430}},

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -53,6 +53,9 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 	if invocation.StageID == StagePatchCoord {
 		return handlePatchCoord(invocation, request)
 	}
+	if invocation.StageID == StageRolePolicy {
+		return handleRolePolicy(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/server-go/modules/delegates/rolepolicy.go
+++ b/server-go/modules/delegates/rolepolicy.go
@@ -1,0 +1,137 @@
+package delegates
+
+import (
+	"encoding/binary"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// What a delegate ROLE implies about how it should be run.
+//
+// These are fixed policy, not operator configuration: a role's turn cap comes
+// from its template frontmatter and stays with the caller, but whether a role
+// writes, whether it needs tools to do its job at all, and whether its output
+// is safe to cache are properties of the role itself.
+
+const (
+	StageRolePolicy uint32 = 10
+	EventRolePolicy uint32 = 6666
+
+	rolePolicyRequestMagic  uint32 = 0x514c5244 /* "DRLQ" */
+	rolePolicyResponseMagic uint32 = 0x534c5244 /* "DRLS" */
+	rolePolicyRequestLen           = 16 + roleMax + 1
+	rolePolicyResponseLen          = 24
+)
+
+// canonicalRole folds an alias onto the role it names. Doing it here rather
+// than asking back out means the policy answers below are always computed from
+// the same spelling the caller's role resolves to.
+func canonicalRole(role string) string {
+	if canonical, ok := aliases[role]; ok {
+		return canonical
+	}
+	return role
+}
+
+// RoleIsWrite reports whether the role changes the repository.
+func RoleIsWrite(role string) bool {
+	switch canonicalRole(role) {
+	case "code", "refactor":
+		return true
+	}
+	return false
+}
+
+// RoleEnablesToolsByDefault reports whether a role needs tools even without an
+// explicit request.
+//
+// A write role cannot do its job without a filesystem, and left tools-off it
+// cannot fail visibly either: asked to implement, an agent with no file tools
+// returns a per-file diff summary of code it never wrote. Tools-on is the only
+// honest default; an explicit --no-tools still overrides it.
+func RoleEnablesToolsByDefault(role string) bool {
+	if role == "" {
+		return false
+	}
+	canonical := canonicalRole(role)
+	if RoleIsWrite(canonical) {
+		return true
+	}
+	switch canonical {
+	case "review", "search", "execute", "diagnose", "validate",
+		// Novel-mode read-only checks inspect the world bible by default.
+		"continuity", "beat-check":
+		return true
+	}
+	return false
+}
+
+// RoleResultCacheEnabled reports whether a response may be reused keyed only by
+// (role, prompt).
+//
+// Opt-in, and only for pure text transforms. Repository inspection, execution
+// and custom roles must never cache: the same prompt can refer to a changed
+// working tree, so a cached answer would describe a repository that no longer
+// exists.
+func RoleResultCacheEnabled(role string) bool {
+	switch canonicalRole(role) {
+	case "summarize", "format", "draft":
+		return true
+	}
+	return false
+}
+
+// RoleAutoToolsForInvocation applies the role default to one invocation.
+//
+// A single-turn run is a final-answer smoke probe, so it gets no implicit
+// tools; asking for them explicitly still wins.
+func RoleAutoToolsForInvocation(role string, maxTurns int, explicitTools bool) bool {
+	if explicitTools {
+		return true
+	}
+	if maxTurns == 1 {
+		return false
+	}
+	return RoleEnablesToolsByDefault(role)
+}
+
+// RoleFinalAfterTurns is the turn at which an inspection role should stop using
+// tools and answer, or -1 when the role has no early-final policy.
+func RoleFinalAfterTurns(role string) int {
+	switch canonicalRole(role) {
+	case "validate":
+		return 8
+	case "search":
+		return 10
+	case "diagnose":
+		return 12
+	}
+	return -1
+}
+
+func handleRolePolicy(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if len(request) != rolePolicyRequestLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != rolePolicyRequestMagic ||
+		request[4] != wireVersion || request[5] > 1 {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	explicitTools := request[5] == 1
+	maxTurns := int(int32(binary.LittleEndian.Uint32(request[8:12])))
+	roleLen := int(binary.LittleEndian.Uint32(request[12:16]))
+	if roleLen > roleMax {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	role := string(request[16 : 16+roleLen])
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	response := make([]byte, rolePolicyResponseLen)
+	binary.LittleEndian.PutUint32(response[0:4], rolePolicyResponseMagic)
+	putBool(response[4:8], RoleIsWrite(role))
+	putBool(response[8:12], RoleEnablesToolsByDefault(role))
+	putBool(response[12:16], RoleResultCacheEnabled(role))
+	putBool(response[16:20], RoleAutoToolsForInvocation(role, maxTurns, explicitTools))
+	binary.LittleEndian.PutUint32(response[20:24], uint32(int32(RoleFinalAfterTurns(role))))
+	return response, bus.ModuleStatusOK
+}

--- a/server-go/modules/delegates/rolepolicy_test.go
+++ b/server-go/modules/delegates/rolepolicy_test.go
@@ -1,0 +1,178 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Ported from test_delegate_role.c.
+func TestRoleIsWrite(t *testing.T) {
+	for _, role := range []string{"code", "refactor", "implement", "build"} {
+		if !RoleIsWrite(role) {
+			t.Errorf("%q should be a write role", role)
+		}
+	}
+	for _, role := range []string{"review", "validate", "summarize", "", "unknown"} {
+		if RoleIsWrite(role) {
+			t.Errorf("%q should not be a write role", role)
+		}
+	}
+}
+
+// A write role with tools off cannot fail visibly -- it returns a diff summary
+// of code it never wrote -- so tools-on is the only honest default.
+func TestRoleEnablesToolsByDefault(t *testing.T) {
+	on := []string{"code", "refactor", "review", "search", "execute", "diagnose",
+		"validate", "continuity", "beat-check"}
+	for _, role := range on {
+		if !RoleEnablesToolsByDefault(role) {
+			t.Errorf("%q should enable tools by default", role)
+		}
+	}
+	off := []string{"summarize", "format", "draft", "explain", "reason", "plan", ""}
+	for _, role := range off {
+		if RoleEnablesToolsByDefault(role) {
+			t.Errorf("%q should not enable tools by default", role)
+		}
+	}
+	// Aliases resolve before the policy is applied.
+	for _, alias := range []string{"implement", "reviewer", "inspect", "recall",
+		"verifier", "research", "test", "check", "enforce", "build"} {
+		if !RoleEnablesToolsByDefault(alias) {
+			t.Errorf("alias %q did not resolve to a tools-on role", alias)
+		}
+	}
+}
+
+// Caching is opt-in and only for pure text transforms: the same prompt against
+// a changed working tree must never be answered from cache.
+func TestRoleResultCacheEnabled(t *testing.T) {
+	for _, role := range []string{"summarize", "format", "draft", "synthesize"} {
+		if !RoleResultCacheEnabled(role) {
+			t.Errorf("%q should be cacheable", role)
+		}
+	}
+	for _, role := range []string{"code", "review", "search", "diagnose", "execute", "", "custom"} {
+		if RoleResultCacheEnabled(role) {
+			t.Errorf("%q must not be cacheable", role)
+		}
+	}
+}
+
+func TestRoleAutoToolsForInvocation(t *testing.T) {
+	// An explicit request always wins, even for a one-turn probe.
+	if !RoleAutoToolsForInvocation("summarize", 1, true) {
+		t.Error("explicit tools were ignored")
+	}
+	// One turn is a final-answer smoke probe, so no implicit tools.
+	if RoleAutoToolsForInvocation("code", 1, false) {
+		t.Error("a one-turn run got implicit tools")
+	}
+	if !RoleAutoToolsForInvocation("code", 8, false) {
+		t.Error("a multi-turn write role did not get its default tools")
+	}
+	if RoleAutoToolsForInvocation("summarize", 8, false) {
+		t.Error("a text-transform role got implicit tools")
+	}
+}
+
+func TestRoleFinalAfterTurns(t *testing.T) {
+	for role, want := range map[string]int{
+		"validate": 8, "search": 10, "diagnose": 12,
+		"code": -1, "review": -1, "": -1,
+		// Aliases resolve first.
+		"verifier": 8, "recall": 10, "inspect": 12,
+	} {
+		if got := RoleFinalAfterTurns(role); got != want {
+			t.Errorf("%q = %d, want %d", role, got, want)
+		}
+	}
+}
+
+// continuity and beat-check survived the persona-vs-role cull: they are real
+// read-only inspection actions a novel persona genuinely delegates, not
+// restatements of who the delegate is. They inspect the world bible by default,
+// but a one-turn probe still gets no tools.
+func TestRoleNovelInspectionRoles(t *testing.T) {
+	for _, role := range []string{"continuity", "beat-check"} {
+		if RoleIsWrite(role) {
+			t.Errorf("%q must not be a write role", role)
+		}
+	}
+	if !RoleAutoToolsForInvocation("continuity", -1, false) {
+		t.Error("continuity did not get its default tools")
+	}
+	if !RoleAutoToolsForInvocation("beat-check", 2, false) {
+		t.Error("beat-check did not get its default tools")
+	}
+	if RoleAutoToolsForInvocation("continuity", 1, false) {
+		t.Error("a one-turn continuity probe got implicit tools")
+	}
+}
+
+func rolePolicyRequestBytes(role string, maxTurns int, explicitTools bool) []byte {
+	request := make([]byte, rolePolicyRequestLen)
+	binary.LittleEndian.PutUint32(request[0:4], rolePolicyRequestMagic)
+	request[4] = wireVersion
+	if explicitTools {
+		request[5] = 1
+	}
+	binary.LittleEndian.PutUint32(request[8:12], uint32(int32(maxTurns)))
+	binary.LittleEndian.PutUint32(request[12:16], uint32(len(role)))
+	copy(request[16:], role)
+	return request
+}
+
+func TestRolePolicyStageRoundTrip(t *testing.T) {
+	response, status := Handle(bus.ModuleInvocation{StageID: StageRolePolicy},
+		rolePolicyRequestBytes("implement", 8, false))
+	if status != bus.ModuleStatusOK || len(response) != rolePolicyResponseLen ||
+		binary.LittleEndian.Uint32(response[0:4]) != rolePolicyResponseMagic {
+		t.Fatalf("status %d, %d bytes", status, len(response))
+	}
+	// "implement" is an alias for the write role "code".
+	if binary.LittleEndian.Uint32(response[4:8]) != 1 {
+		t.Error("alias did not resolve to a write role")
+	}
+	if binary.LittleEndian.Uint32(response[8:12]) != 1 {
+		t.Error("write role did not enable tools by default")
+	}
+	if binary.LittleEndian.Uint32(response[12:16]) != 0 {
+		t.Error("a write role was reported cacheable")
+	}
+	if int32(binary.LittleEndian.Uint32(response[20:24])) != -1 {
+		t.Error("code should have no early-final turn")
+	}
+
+	// diagnose has one, and a one-turn probe still gets no implicit tools.
+	response, _ = Handle(bus.ModuleInvocation{StageID: StageRolePolicy},
+		rolePolicyRequestBytes("diagnose", 1, false))
+	if int32(binary.LittleEndian.Uint32(response[20:24])) != 12 {
+		t.Error("diagnose lost its early-final turn")
+	}
+	if binary.LittleEndian.Uint32(response[16:20]) != 0 {
+		t.Error("a one-turn probe got implicit tools")
+	}
+}
+
+func TestRolePolicyStageRejectsInvalidEnvelope(t *testing.T) {
+	good := rolePolicyRequestBytes("code", 4, false)
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageRolePolicy},
+		good[:rolePolicyRequestLen-1]); status != bus.ModuleStatusInvalidRequest {
+		t.Errorf("truncated status = %d", status)
+	}
+
+	lying := rolePolicyRequestBytes("code", 4, false)
+	binary.LittleEndian.PutUint32(lying[12:16], uint32(roleMax+1))
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageRolePolicy}, lying); status != bus.ModuleStatusInvalidRequest {
+		t.Errorf("over-long role status = %d", status)
+	}
+
+	if _, status := Handle(bus.ModuleInvocation{StageID: StageRolePolicy, DeadlineNS: 1},
+		good); status != bus.ModuleStatusCancelled {
+		t.Errorf("expired status = %d", status)
+	}
+}

--- a/src/modules/delegates/delegate_role.c
+++ b/src/modules/delegates/delegate_role.c
@@ -79,6 +79,51 @@ static const char *const g_known_roles[] = {"review",    "validate",   "diagnose
                                             "summarize", "format",     "search",     "reason",
                                             "plan",      "continuity", "beat-check", NULL};
 
+static delegate_role_policy_fn g_role_policy;
+
+void delegate_register_role_policy_provider(delegate_role_policy_fn provider)
+{
+   g_role_policy = provider;
+}
+
+/* Fails closed to `fallback`: with no answer, claim nothing about the role. */
+static int role_policy_ask(int op, const char *role, int a, int b, int fallback)
+{
+   int out = fallback;
+   if (!role || !role[0] || !g_role_policy)
+      return fallback;
+   if (g_role_policy(op, role, a, b, &out) != 0)
+      return fallback;
+   return out;
+}
+
+int delegate_role_is_write(const char *role)
+{
+   return role_policy_ask(DELEGATE_ROLE_OP_IS_WRITE, role, 0, 0, 0);
+}
+
+int delegate_role_enable_tools_by_default(const char *role)
+{
+   return role_policy_ask(DELEGATE_ROLE_OP_TOOLS, role, 0, 0, 0);
+}
+
+int delegate_role_result_cache_enabled(const char *role)
+{
+   return role_policy_ask(DELEGATE_ROLE_OP_CACHE, role, 0, 0, 0);
+}
+
+int delegate_role_auto_tools_for_invocation(const char *role, int max_turns, int explicit_tools)
+{
+   if (explicit_tools)
+      return 1;
+   return role_policy_ask(DELEGATE_ROLE_OP_AUTO_TOOLS, role, max_turns, explicit_tools, 0);
+}
+
+int delegate_final_after_turns_for_role(const char *role)
+{
+   return role_policy_ask(DELEGATE_ROLE_OP_FINAL_TURNS, role, 0, 0, -1);
+}
+
 int delegate_role_known(const char *project_root, const char *role)
 {
    if (!role || !role[0])
@@ -113,50 +158,6 @@ const char *delegate_role_canonicalize(const char *role)
    return role;
 }
 
-int delegate_role_is_write(const char *role)
-{
-   if (!role || !role[0])
-      return 0;
-   const char *canonical = delegate_role_canonicalize(role);
-   return strcmp(canonical, "code") == 0 || strcmp(canonical, "refactor") == 0;
-}
-
-int delegate_role_enable_tools_by_default(const char *role)
-{
-   if (!role || !role[0])
-      return 0;
-
-   role = delegate_role_canonicalize(role);
-   /* A write role cannot do its job without a filesystem, and left tools-off it
-    * cannot fail visibly either: asked to implement, an agent with no file tools
-    * returns a per-file diff summary of code it never wrote. Tools-on is the
-    * only honest default here; an explicit --no-tools still overrides it. */
-   return delegate_role_is_write(role) || strcmp(role, "review") == 0 ||
-          strcmp(role, "search") == 0 || strcmp(role, "execute") == 0 ||
-          strcmp(role, "diagnose") == 0 || strcmp(role, "validate") == 0 ||
-          /* Novel-mode read-only checks inspect the world bible by default. */
-          strcmp(role, "continuity") == 0 || strcmp(role, "beat-check") == 0;
-}
-
-int delegate_role_result_cache_enabled(const char *role)
-{
-   if (!role || !role[0])
-      return 0;
-
-   role = delegate_role_canonicalize(role);
-   return strcmp(role, "summarize") == 0 || strcmp(role, "format") == 0 ||
-          strcmp(role, "draft") == 0;
-}
-
-int delegate_role_auto_tools_for_invocation(const char *role, int max_turns, int explicit_tools)
-{
-   if (explicit_tools)
-      return 1;
-   if (max_turns == 1)
-      return 0;
-   return delegate_role_enable_tools_by_default(role);
-}
-
 void delegate_apply_max_turns_override(agent_config_t *cfg, int max_turns)
 {
    if (!cfg || max_turns < 0)
@@ -175,21 +176,6 @@ int delegate_default_max_turns_for_role(const char *role)
    if (!role || !role[0])
       return -1;
    return role_template_max_turns(delegate_role_canonicalize(role));
-}
-
-int delegate_final_after_turns_for_role(const char *role)
-{
-   if (!role || !role[0])
-      return -1;
-
-   role = delegate_role_canonicalize(role);
-   if (strcmp(role, "validate") == 0)
-      return 8;
-   if (strcmp(role, "search") == 0)
-      return 10;
-   if (strcmp(role, "diagnose") == 0)
-      return 12;
-   return -1;
 }
 
 void delegate_apply_max_turns_policy(agent_config_t *cfg, const char *role, int max_turns)

--- a/src/modules/delegates/include/aimee/delegates/delegate_role.h
+++ b/src/modules/delegates/include/aimee/delegates/delegate_role.h
@@ -7,6 +7,25 @@
 typedef int (*delegate_role_canonicalizer_fn)(const char *role, char *out, size_t out_cap);
 void delegate_role_register_canonicalizer(delegate_role_canonicalizer_fn canonicalizer);
 
+/* Role POLICY -- what a role implies about how it is run -- lives in the
+ * delegates module (server-go/modules/delegates/rolepolicy.go). This is the
+ * seam the C side calls through; with no provider registered every answer
+ * below is the conservative one: not a write role, no implicit tools, not
+ * cacheable, no early-final turn. Inventing "cacheable" would serve a stale
+ * answer about a changed working tree, and inventing "tools on" would hand a
+ * filesystem to a role that was never meant to have one.
+ *
+ * op selects the question; `a` carries max_turns and `b` explicit_tools for the
+ * auto-tools op, and both are unused otherwise. */
+#define DELEGATE_ROLE_OP_IS_WRITE     0
+#define DELEGATE_ROLE_OP_TOOLS        1
+#define DELEGATE_ROLE_OP_CACHE        2
+#define DELEGATE_ROLE_OP_AUTO_TOOLS   3
+#define DELEGATE_ROLE_OP_FINAL_TURNS  4
+
+typedef int (*delegate_role_policy_fn)(int op, const char *role, int a, int b, int *out);
+void delegate_register_role_policy_provider(delegate_role_policy_fn provider);
+
 /* Returns 1 when the role should have tool use enabled even without
  * an explicit --tools flag. */
 int delegate_role_enable_tools_by_default(const char *role);

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -489,4 +489,31 @@ static inline size_t aimee_delegates_patch_put_task(int id, int step_id, const c
    return at + result_len;
 }
 
+/* --- Role policy (stage 10) --- */
+
+#define AIMEE_DELEGATES_EVENT_ROLEPOL          6666u
+#define AIMEE_DELEGATES_STAGE_ROLEPOL          10u
+#define AIMEE_DELEGATES_ROLEPOL_REQUEST_MAGIC  0x514c5244u /* "DRLQ" */
+#define AIMEE_DELEGATES_ROLEPOL_RESPONSE_MAGIC 0x534c5244u /* "DRLS" */
+#define AIMEE_DELEGATES_ROLEPOL_REQUEST_LEN    (16u + AIMEE_DELEGATES_ROLE_MAX + 1u)
+#define AIMEE_DELEGATES_ROLEPOL_RESPONSE_LEN   24u
+
+static inline int aimee_delegates_rolepol_request_encode(const char *role, int max_turns,
+                                                         int explicit_tools, uint8_t *out,
+                                                         size_t cap)
+{
+   size_t len = role ? strlen(role) : 0;
+   if (!out || cap < AIMEE_DELEGATES_ROLEPOL_REQUEST_LEN || len > AIMEE_DELEGATES_ROLE_MAX)
+      return -1;
+   memset(out, 0, AIMEE_DELEGATES_ROLEPOL_REQUEST_LEN);
+   aimee_delegates_put_u32(out, AIMEE_DELEGATES_ROLEPOL_REQUEST_MAGIC);
+   out[4] = (uint8_t)AIMEE_DELEGATES_WIRE_VERSION;
+   out[5] = explicit_tools ? 1u : 0u;
+   aimee_delegates_put_u32(out + 8, (uint32_t)max_turns);
+   aimee_delegates_put_u32(out + 12, (uint32_t)len);
+   if (len)
+      memcpy(out + 16, role, len);
+   return 0;
+}
+
 #endif

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -84,7 +84,8 @@
     "server-go/modules/delegates/economics.go",
     "server-go/modules/delegates/economics_stage.go",
     "server-go/modules/delegates/patchcoord.go",
-    "server-go/modules/delegates/patchcoord_stage.go"
+    "server-go/modules/delegates/patchcoord_stage.go",
+    "server-go/modules/delegates/rolepolicy.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -99,7 +100,8 @@
     "server-go/modules/delegates/economics_test.go",
     "server-go/modules/delegates/economics_stage_test.go",
     "server-go/modules/delegates/patchcoord_test.go",
-    "server-go/modules/delegates/patchcoord_stage_test.go"
+    "server-go/modules/delegates/patchcoord_stage_test.go",
+    "server-go/modules/delegates/rolepolicy_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -171,6 +171,11 @@
           "id": 9,
           "name": "delegate-patch-coordination",
           "event_kind": 6665
+        },
+        {
+          "id": 10,
+          "name": "delegate-role-policy",
+          "event_kind": 6666
         }
       ]
     },

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -752,6 +752,44 @@ static void delegate_patch_coord(const db1_coord_task_t *tasks, int task_count,
    free(response);
 }
 
+/* What a role implies about how it is run. One call answers whichever question
+ * the caller asked; the module resolves the alias itself, so every answer is
+ * computed from the same canonical spelling. */
+static int delegate_role_policy(int op, const char *role, int a, int b, int *out)
+{
+   uint8_t request[AIMEE_DELEGATES_ROLEPOL_REQUEST_LEN];
+   uint8_t response[AIMEE_DELEGATES_ROLEPOL_RESPONSE_LEN];
+   uint32_t response_len = 0;
+
+   if (!out || aimee_delegates_rolepol_request_encode(role, a, b, request, sizeof(request)) != 0 ||
+       call_module(AIMEE_DELEGATES_EVENT_ROLEPOL, AIMEE_DELEGATES_STAGE_ROLEPOL, request,
+                   sizeof(request), response, sizeof(response), &response_len) != 0 ||
+       response_len != AIMEE_DELEGATES_ROLEPOL_RESPONSE_LEN ||
+       aimee_delegates_get_u32(response) != AIMEE_DELEGATES_ROLEPOL_RESPONSE_MAGIC)
+      return -1;
+
+   switch (op)
+   {
+   case DELEGATE_ROLE_OP_IS_WRITE:
+      *out = (int)aimee_delegates_get_u32(response + 4);
+      return 0;
+   case DELEGATE_ROLE_OP_TOOLS:
+      *out = (int)aimee_delegates_get_u32(response + 8);
+      return 0;
+   case DELEGATE_ROLE_OP_CACHE:
+      *out = (int)aimee_delegates_get_u32(response + 12);
+      return 0;
+   case DELEGATE_ROLE_OP_AUTO_TOOLS:
+      *out = (int)aimee_delegates_get_u32(response + 16);
+      return 0;
+   case DELEGATE_ROLE_OP_FINAL_TURNS:
+      *out = (int)aimee_delegates_get_u32(response + 20);
+      return 0;
+   default:
+      return -1;
+   }
+}
+
 static int tool_classify(const char *name, int *classification)
 {
    uint8_t request[AIMEE_TOOLS_REQUEST_LEN], response[AIMEE_TOOLS_RESPONSE_LEN];
@@ -967,6 +1005,7 @@ void server_module_stage_adapters_configure(void)
    delegate_register_verify_provider(delegate_verify);
    delegate_register_economics_provider(delegate_economics);
    delegate_register_patch_provider(delegate_patch_coord);
+   delegate_register_role_policy_provider(delegate_role_policy);
    agent_tools_register_classifier(tool_classify);
    ws_scope_register_ref_validator(workspace_validate);
    /* Same decision, same owner: webuser's runtime dir names a single path

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -384,49 +384,6 @@ static void test_guarded_lxc_readonly_root_matching(void)
    printf("  PASS: test_guarded_lxc_readonly_root_matching\n");
 }
 
-static void test_role_default_tools(void)
-{
-   assert(delegate_role_enable_tools_by_default("search") == 1);
-   assert(delegate_role_enable_tools_by_default("execute") == 1);
-   assert(delegate_role_enable_tools_by_default("diagnose") == 1);
-   assert(delegate_role_enable_tools_by_default("validate") == 1);
-   assert(delegate_role_enable_tools_by_default("inspect") == 1);
-   assert(delegate_role_enable_tools_by_default("test") == 1);
-   assert(delegate_role_enable_tools_by_default("check") == 1);
-   assert(delegate_role_enable_tools_by_default("research") == 1);
-   /* Write roles need a filesystem to do the job at all. This asserted 0 until a
-    * `code` delegate with no file tools answered with a per-file diff summary of
-    * code it never wrote -- see test_delegate_role.c. */
-   assert(delegate_role_enable_tools_by_default("code") == 1);
-   assert(delegate_role_enable_tools_by_default("refactor") == 1);
-   /* Prose generation is not a write role. */
-   assert(delegate_role_enable_tools_by_default("draft") == 0);
-   assert(delegate_role_enable_tools_by_default(NULL) == 0);
-   assert(delegate_role_enable_tools_by_default("") == 0);
-   printf("  PASS: test_role_default_tools\n");
-}
-
-static void test_role_result_cache_policy(void)
-{
-   assert(delegate_role_result_cache_enabled("review") == 0);
-   assert(delegate_role_result_cache_enabled("validate") == 0);
-   assert(delegate_role_result_cache_enabled("diagnose") == 0);
-   assert(delegate_role_result_cache_enabled("search") == 0);
-   assert(delegate_role_result_cache_enabled("execute") == 0);
-   assert(delegate_role_result_cache_enabled("code") == 0);
-   assert(delegate_role_result_cache_enabled("refactor") == 0);
-   assert(delegate_role_result_cache_enabled("inspect") == 0);
-   assert(delegate_role_result_cache_enabled("test") == 0);
-   assert(delegate_role_result_cache_enabled("summarize") == 1);
-   assert(delegate_role_result_cache_enabled("format") == 1);
-   assert(delegate_role_result_cache_enabled("draft") == 1);
-   assert(delegate_role_result_cache_enabled("reason") == 0);
-   assert(delegate_role_result_cache_enabled("custom-review") == 0);
-   assert(delegate_role_result_cache_enabled(NULL) == 0);
-   assert(delegate_role_result_cache_enabled("") == 0);
-   printf("  PASS: test_role_result_cache_policy\n");
-}
-
 static void test_prompt_plan_inline_prompt_only(void)
 {
    delegate_prompt_plan_t plan;
@@ -1321,8 +1278,6 @@ int main(void)
    test_depth_error_message_content();
    test_delegate_chain_env_clear_policy();
    test_guarded_lxc_readonly_root_matching();
-   test_role_default_tools();
-   test_role_result_cache_policy();
    test_prompt_plan_inline_prompt_only();
    test_prompt_plan_file_only();
    test_prompt_plan_prompt_and_file();

--- a/src/tests/test_delegate_role.c
+++ b/src/tests/test_delegate_role.c
@@ -148,55 +148,6 @@ static void test_empty_role(void)
    printf("  PASS: test_empty_role\n");
 }
 
-static void test_is_write_code_role(void)
-{
-   assert(delegate_role_is_write("code") == 1);
-   printf("  PASS: test_is_write_code_role\n");
-}
-
-static void test_is_write_refactor_role(void)
-{
-   assert(delegate_role_is_write("refactor") == 1);
-   printf("  PASS: test_is_write_refactor_role\n");
-}
-
-static void test_is_write_implement_alias(void)
-{
-   assert(delegate_role_is_write("implement") == 1);
-   printf("  PASS: test_is_write_implement_alias\n");
-}
-
-static void test_is_write_read_only_roles(void)
-{
-   assert(delegate_role_is_write("review") == 0);
-   assert(delegate_role_is_write("validate") == 0);
-   assert(delegate_role_is_write("diagnose") == 0);
-   assert(delegate_role_is_write("execute") == 0);
-   assert(delegate_role_is_write("draft") == 0);
-   assert(delegate_role_is_write("planner") == 0);
-   printf("  PASS: test_is_write_read_only_roles\n");
-}
-
-static void test_is_write_null_empty(void)
-{
-   assert(delegate_role_is_write(NULL) == 0);
-   assert(delegate_role_is_write("") == 0);
-   printf("  PASS: test_is_write_null_empty\n");
-}
-
-static void test_novel_roles(void)
-{
-   /* continuity and beat-check survive the persona-vs-role cull: they are real
-    * read-only inspection actions a novel persona genuinely delegates, not
-    * restatements of who the delegate is. */
-   assert(delegate_role_is_write("continuity") == 0);
-   assert(delegate_role_is_write("beat-check") == 0);
-   assert(delegate_role_auto_tools_for_invocation("continuity", -1, 0) == 1);
-   assert(delegate_role_auto_tools_for_invocation("beat-check", 2, 0) == 1);
-   assert(delegate_role_auto_tools_for_invocation("continuity", 1, 0) == 0);
-   printf("  PASS: test_novel_roles\n");
-}
-
 /* The cull deleted the roles that only restated a persona. Writing prose or a
  * lyric is the `draft` action performed BY a novel/songwriter persona, so these
  * names must now be rejected outright rather than silently degrading to a
@@ -278,23 +229,6 @@ static void test_known_roles_cover_documented_and_aliased(void)
    printf("  PASS: test_known_roles_cover_documented_and_aliased\n");
 }
 
-static void test_inspection_turn_policies(void)
-{
-   assert(delegate_default_max_turns_for_role("review") == 20);
-   assert(delegate_default_max_turns_for_role("test") == 12);
-   assert(delegate_default_max_turns_for_role("diagnose") == 16);
-   assert(delegate_default_max_turns_for_role("code") == -1);
-   assert(delegate_final_after_turns_for_role("review") == -1);
-   assert(delegate_final_after_turns_for_role("validate") == 8);
-   assert(delegate_final_after_turns_for_role("test") == 8);
-   assert(delegate_final_after_turns_for_role("search") == 10);
-   assert(delegate_final_after_turns_for_role("diagnose") == 12);
-   assert(delegate_final_after_turns_for_role("inspect") == 12);
-   assert(delegate_final_after_turns_for_role("plan") == -1);
-   assert(delegate_final_after_turns_for_role("code") == -1);
-   printf("  PASS: test_inspection_turn_policies\n");
-}
-
 static void test_apply_max_turns_policy(void)
 {
    agent_config_t cfg;
@@ -359,49 +293,6 @@ static void test_apply_max_turns_cap(void)
    printf("  PASS: test_apply_max_turns_cap\n");
 }
 
-static void test_auto_tools_policy(void)
-{
-   assert(delegate_role_auto_tools_for_invocation("diagnose", -1, 0) == 1);
-   assert(delegate_role_auto_tools_for_invocation("validate", 2, 0) == 1);
-   assert(delegate_role_auto_tools_for_invocation("diagnose", 1, 0) == 0);
-   assert(delegate_role_auto_tools_for_invocation("inspect", 1, 0) == 0);
-   assert(delegate_role_auto_tools_for_invocation("diagnose", 1, 1) == 1);
-   assert(delegate_role_auto_tools_for_invocation("review", -1, 0) == 1);
-   assert(delegate_role_auto_tools_for_invocation("review", 1, 0) == 0);
-   printf("  PASS: test_auto_tools_policy\n");
-}
-
-/* A write role left tools-off cannot fail visibly. Measured: a `code` packet
- * delegated over MCP -- which had no way to ask for tools -- came back with a
- * per-file diff summary naming files that were never created, and the caller
- * had to disprove it by searching the disk. `review` enabled tools by default
- * and `code` did not, so delegation worked for inspection and fabricated for
- * implementation: the failure distribution that builds trust before it lies. */
-static void test_write_roles_get_tools_by_default(void)
-{
-   assert(delegate_role_enable_tools_by_default("code") == 1);
-   assert(delegate_role_enable_tools_by_default("refactor") == 1);
-   /* Through the aliases a caller actually types. */
-   assert(delegate_role_auto_tools_for_invocation("implement", -1, 0) == 1);
-   assert(delegate_role_auto_tools_for_invocation("build", -1, 0) == 1);
-
-   /* Every write role, whatever the alias table holds, by the same rule. */
-   static const char *const write_roles[] = {"code", "refactor", "implement", "build"};
-   for (size_t i = 0; i < sizeof(write_roles) / sizeof(write_roles[0]); i++)
-   {
-      assert(delegate_role_is_write(write_roles[i]) == 1);
-      assert(delegate_role_auto_tools_for_invocation(write_roles[i], -1, 0) == 1);
-   }
-
-   /* The two overrides still win: a single turn cannot use tools, and an
-    * explicit --no-tools is honored (server side) as a deliberate choice. */
-   assert(delegate_role_auto_tools_for_invocation("code", 1, 0) == 0);
-
-   /* Prose generation is not a write role and stays text-only. */
-   assert(delegate_role_enable_tools_by_default("draft") == 0);
-   printf("  PASS: test_write_roles_get_tools_by_default\n");
-}
-
 int main(void)
 {
    printf("test_delegate_role\n");
@@ -417,20 +308,11 @@ int main(void)
    test_unknown_role_unchanged();
    test_null_role();
    test_empty_role();
-   test_is_write_code_role();
-   test_is_write_refactor_role();
-   test_is_write_implement_alias();
-   test_is_write_read_only_roles();
-   test_is_write_null_empty();
-   test_novel_roles();
    test_culled_persona_roles_are_rejected();
    test_unknown_roles_are_not_known();
    test_known_roles_cover_documented_and_aliased();
-   test_inspection_turn_policies();
    test_apply_max_turns_policy();
    test_apply_max_turns_cap();
-   test_auto_tools_policy();
-   test_write_roles_get_tools_by_default();
    printf("All tests passed.\n");
    return 0;
 }

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1439,7 +1439,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_role.h",
-          "sha256": "e249d64bcb1536060b7661e9b4b9db596c5b455f6ead7520da30effc1fd5e62e"
+          "sha256": "757f10c476a51fdd48f02260b6fd165533849f56791c11c23838de45d5cbb9ad"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_run_phases.h",
@@ -1463,7 +1463,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "ba6a868446393417605d595debf6a7d9b8d0e4183c6690f4b10f4f3f6d9b2450"
+          "sha256": "23463ffa296da122fee11a3a8014f2cde2462babcf76564d114a34aad0777c63"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "e798a88313064caf1a32d678e0abcab3f6dffd4f97850cc0f03f6619fdf1cc57",
+      "sha256": "146d009debc4aacb903884b3cf382732c2f4294615fe959b82f4e4deb5048414",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
refactor(delegates): role policy moves into the module

delegate_role.c mixed two different things. Role POLICY -- does this role write,
does it need tools to do its job at all, is its output safe to reuse, when
should an inspection role stop and answer -- is fixed and is now
server-go/modules/delegates/rolepolicy.go on a new stage.

Role IDENTITY and operator configuration stayed: canonicalization, which roles
are known, the culled-persona rejections, and the max-turns policy that reads a
role template's frontmatter. Those are things an operator edits under the
Personas tab, not rules, and moving them would have turned configuration into
code.

Canonicalization happens INSIDE the module now, so every answer is computed
from the same spelling the caller's alias resolves to. That is why research,
verifier, inspect, test and check all reach the right policy without a second
round trip back through C to canonicalize first.

Fails closed conservatively on every question: not a write role, no implicit
tools, not cacheable, no early-final turn. The two that matter are the last two.
Inventing "cacheable" would answer a prompt about a working tree that has since
changed; inventing "tools on" would hand a filesystem to a role that was never
meant to have one.

Eleven rule tests moved to Go with their cases, across two files -- the policy
was asserted in test_delegate_role.c and again in test_cmd_delegate.c.
test_novel_roles was missed on the first pass and the build caught it; its exact
cases are pinned now: continuity and beat-check inspect the world bible by
default, but a one-turn run is a final-answer smoke probe and still gets no
tools. What remains in test_delegate_role.c is identity and configuration --
canonicalization, known roles, culled personas, and the max-turns policy.

Declared in the contract (6666, stage 10), the descriptor, the dispatch table
and the registry-vs-contracts test, with the serve grant regenerated.

Verified against the real link and the real lint before committing:
../aimee-server deleted and relinked from scratch, ../aimee-kb,
cmd-srcs-compile-check, `make -C src format` then `make -C src lint` (48
checks), the full sequential C suite, and go vet plus the full Go suite.
