### PR TITLE
fix(sandbox): decide availability by capability, not by container detection

### DIFF
--- a/src/posix/sandbox.c
+++ b/src/posix/sandbox.c
@@ -16,8 +16,10 @@
  *
  * Container detection:
  *   Checks /.dockerenv, /run/.containerenv, and /proc/1/cgroup for container
- *   markers.  When detected, sandbox_available() returns 0 because nested user
- *   namespaces are often blocked by the outer container's seccomp policy.
+ *   markers.  Detection is DIAGNOSTIC, not a verdict: nested user namespaces work
+ *   inside many containers, so availability is decided by actually attempting
+ *   unshare(CLONE_NEWUSER).  Container-ness only shapes the reason string when that
+ *   real probe fails, so the message points at the container rather than the kernel.
  */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -221,12 +223,19 @@ int sandbox_available(const char **reason)
       *reason = "Linux namespaces not available on this platform";
    return 0;
 #else
-   if (sandbox_detect_container())
-   {
-      if (reason)
-         *reason = "running inside a container — nested namespaces may be blocked";
-      return 0;
-   }
+   /* Being in a container is NOT a verdict. Nested user namespaces work inside many
+    * containers, and this function already ends with an authoritative test: fork a
+    * child and actually call unshare(CLONE_NEWUSER). Returning early on detection made
+    * that test dead code in precisely the deployments that need it — aimee-server ships
+    * as a container, so every co-located delegate shell was refused ("sandbox fallback
+    * could not start") on a capability that was never measured, only inferred from
+    * /.dockerenv.
+    *
+    * Container-ness is kept as DIAGNOSIS: when the real probe below fails, saying so in
+    * container terms points at the right fix (grant the container the capability) rather
+    * than at the kernel. Fail-closed is unchanged — an environment that genuinely cannot
+    * create a user namespace still reports unavailable. */
+   const int in_container = sandbox_detect_container();
 
    /* Probe whether unprivileged user namespaces are permitted.
     * The kernel sysctl /proc/sys/kernel/unprivileged_userns_clone (Debian/Ubuntu)
@@ -241,8 +250,10 @@ int sandbox_available(const char **reason)
          if (rc == 1 && val == 0)
          {
             if (reason)
-               *reason = "unprivileged user namespaces disabled "
-                         "(kernel.unprivileged_userns_clone=0)";
+               *reason = in_container ? "unprivileged user namespaces disabled in this container "
+                                        "(kernel.unprivileged_userns_clone=0)"
+                                      : "unprivileged user namespaces disabled "
+                                        "(kernel.unprivileged_userns_clone=0)";
             return 0;
          }
       }
@@ -269,8 +280,11 @@ int sandbox_available(const char **reason)
    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
    {
       if (reason)
-         *reason = "unshare(CLONE_NEWUSER) failed — kernel may not support "
-                   "unprivileged user namespaces";
+         *reason = in_container ? "unshare(CLONE_NEWUSER) failed inside this container — grant it "
+                                  "unprivileged user namespaces (or run delegates in their own "
+                                  "container) to enable isolated execution"
+                                : "unshare(CLONE_NEWUSER) failed — kernel may not support "
+                                  "unprivileged user namespaces";
       return 0;
    }
 


### PR DESCRIPTION
## Summary

A delegate could not run `echo`.

```
parent worktree write guard requires isolated shell execution;
sandbox fallback could not start; command is not eligible for guarded workspace execution
```

Root cause: `sandbox_available()` returned 0 the moment `sandbox_detect_container()` saw `/.dockerenv`, `/run/.containerenv`, or a `docker`/`lxc`/`containerd` cgroup — with the reason *"nested namespaces **may** be blocked"*. An inference, never a measurement.

The function already ends with the authoritative test: fork a child and actually call `unshare(CLONE_NEWUSER)`. **The early return made that test dead code in exactly the deployments that need it**, because aimee-server ships as a container.

## Why it broke delegates specifically

The guarded-parent path asks for isolated execution (`require_isolation = 1`), so `sandbox_exec_internal` **cannot fall back** — it returns -1. `tool_bash` then tries `guarded_workspace_exec()`, which only permits an allowlisted command chain via `bash_workspace_chain_validate`; `echo` is not eligible. Both failures combine into the message above.

So on any containerised server, co-located delegate shells were refused for a capability that was never tested.

## The fix

Container-ness becomes **diagnosis, not verdict**. Availability is decided by the real probe. Detection only shapes the reason string when that probe genuinely fails, so the message points at the container — *grant it unprivileged user namespaces, or run delegates in their own container* — instead of vaguely at the kernel.

Fail-closed is unchanged: an environment that truly cannot create a user namespace still reports unavailable, and the sysctl checks still run.

## Measured, in a real container

Run in an LXC on the test host with `/.dockerenv` present — exactly what the real server looks like — using probes built from each version:

| | `in_container` | `sandbox_available` | reason |
|---|---|---|---|
| **OLD** | 1 | **0** | running inside a container — nested namespaces may be blocked |
| **NEW** | 1 | **1** | (none) |

The capability was present the whole time. The old code just never asked.

The production "red" is the live delegate refusal quoted above, observed on the deployed server running `vtesting-2409ee4` — which already contains #2499, #2506 and #2507. So this is a distinct fault, not a regression from those.

## Risk, stated rather than discovered

**CI runs in containers.** With this change the sandbox will genuinely engage there, where it previously fell back to unsandboxed execution. That is the intended behaviour of the feature — and `sandbox.mode` now defaults to `WORKSPACE_ONLY` (#2499) — but it is the change most likely to surface gaps in the sandbox mount setup under CI's container.

The userns map race that used to break sandboxed exec outright was fixed in #2499, so the mechanism itself works; what is newly exercised is the mount/bind environment. If a CI job fails on a command that produces no output and exits 127, that is the shape to look for.

## Verification

- `rm -f aimee-server && make -C src -j8 ../aimee-server` — exit 0, zero undefined references
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — all checks passed (`make -C src format` run first)
- `check_c_repository_lock` — ok, no drift
- `refactor_baselines` — ok, no drift (`sandbox.c` is not a tracked surface)
- All re-run after rebasing onto current `testing`

## What this does not fix

Delegates reaching co-located execution at all is itself the deeper issue — they are meant to take the **container** provider path (`delegate_sandbox` defaults on, docker exec into their own container) and never get here. That fall-through is unchanged; this makes the path they currently land on actually work.