### PR TITLE
fix(git): never let a broker token outrank the vaulted credential

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -211,7 +211,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "1873e45d05e17768ab090042179d2737659bb4b011bad6e4de445065d60f702c",
+      "source_sha256": "627c8c8ee7760d57ab6915681bd4d1e30e608bf4e082709df5a690b9bd1dce1d",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,
@@ -232,7 +232,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "3bdd111bde503e1b4129b8d9ef47cfd949332886c180666313fd0904b66b49cf",
+      "source_sha256": "e0c58f7d1094b5cd80ad0ebace685721a27a0ab80b9a69ff21e0617475a924a6",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/git_cred_inject.c
+++ b/src/modules/git/git_cred_inject.c
@@ -6,6 +6,7 @@
 #include "git_host_cred.h"     /* git_host_cred_list — "is git configured at all?" */
 #include "git_host_resolve.h"  /* git_host_resolve_token (per-host vault seam) */
 #include "git_ssh_agent.h"     /* git_ssh_agent_ensure */
+#include "log.h"               /* LOG_INFO — report which credential source won */
 #include "util.h"              /* GIT_AGENT_SSH_COMMAND */
 
 #include <stdio.h>
@@ -140,18 +141,32 @@ static void wipe(void *p, size_t n)
  * Returns 1 (token written) or 0 (none — caller may still have ssh/ambient).
  * `out` is always either a full token or empty; never a partial value. */
 static int resolve_token(const char *principal, const char *remote_url, const char *repo_dir,
-                         const char *preferred_token, char *out, size_t cap)
+                         const char *preferred_token, char *out, size_t cap, const char **source)
 {
+   if (source)
+      *source = "none";
    if (out && cap)
       out[0] = '\0';
    if (!out || cap == 0)
       return 0;
 
-   /* 1. A live caller-supplied token (inline clone token / workspace broker). */
+   /* 1. A live caller-supplied token (inline clone token / workspace broker).
+    *
+    * THIS WINS OVER THE VAULT, which is the point — a caller holding a live
+    * brokered credential means it. It also means two call sites asking about
+    * the SAME repo can authenticate as DIFFERENT tokens: an exec path that
+    * passes a broker token uses that, while an in-process forge call that
+    * passes none uses the vault. When one succeeds and the other is refused,
+    * that difference is the first thing to check, and until this reported its
+    * source there was no way to see it from outside. */
    if (preferred_token && preferred_token[0])
    {
       if ((size_t)snprintf(out, cap, "%s", preferred_token) < cap)
+      {
+         if (source)
+            *source = "caller-supplied (workspace broker / inline clone token)";
          return 1;
+      }
       wipe(out, cap); /* would truncate a secret → wipe the partial, fail closed */
       return 0;
    }
@@ -159,17 +174,29 @@ static int resolve_token(const char *principal, const char *remote_url, const ch
    /* 2. Per-host vault token, keyed by the repo's remote host (resolved from the
     * explicit remote URL, else the checkout's `origin`), via the shared seam. */
    if (git_host_resolve_token(remote_url, repo_dir, out, cap) == 1 && out[0])
+   {
+      if (source)
+         *source = "per-host vault entry";
       return 1;
+   }
    out[0] = '\0';
 
    /* 3. The environment's vaulted forge token. */
    if (git_forge_vault_token(principal, out, cap) == 1 && out[0])
+   {
+      if (source)
+         *source = "principal's vaulted forge token";
       return 1;
+   }
    out[0] = '\0';
 
    /* 4. The server's forge-App identity (AIMEE_FORGE_TOKEN). */
    if (forge_cred_server_identity(out, cap, NULL, 0) == 1 && out[0])
+   {
+      if (source)
+         *source = "server forge identity";
       return 1;
+   }
    out[0] = '\0';
    return 0;
 }
@@ -183,8 +210,21 @@ char **git_cred_inject_build_env_for_repo(const char *principal, const char *rem
    const int fd_mode = (out_token_fd != NULL);
 
    char token[GIT_CRED_TOKEN_MAX] = {0};
-   int have_token =
-       resolve_token(principal, remote_url, repo_dir, preferred_token, token, sizeof(token));
+   const char *source = "none";
+   int have_token = resolve_token(principal, remote_url, repo_dir, preferred_token, token,
+                                  sizeof(token), &source);
+
+   /* SAY WHICH CREDENTIAL THIS EXEC WILL AUTHENTICATE AS. The token is never
+    * logged; its SOURCE is, because that is the fact nobody could see. A forge
+    * call and a git exec against the same repo can resolve different tokens —
+    * the exec path supplies a workspace broker token, which outranks the vault —
+    * so "pr create works but push is denied" is a credential question that
+    * looks like a permissions question. One line here answers it. */
+   if (have_token)
+      LOG_INFO("git", "forge credential for %s resolved from: %s",
+               (remote_url && remote_url[0]) ? remote_url
+                                             : ((repo_dir && repo_dir[0]) ? repo_dir : "<unknown>"),
+               source);
 
    /* FD MODE: stage the token in an anonymous CLOEXEC memfd (never a named path,
     * never in the env). The askpass reads it via /proc/self/fd/<target>; the
@@ -236,7 +276,7 @@ int git_cred_inject_resolve_token(const char *principal, const char *remote_url,
                                   const char *repo_dir, const char *preferred_token, char *out,
                                   size_t cap)
 {
-   return resolve_token(principal, remote_url, repo_dir, preferred_token, out, cap);
+   return resolve_token(principal, remote_url, repo_dir, preferred_token, out, cap, NULL);
 }
 
 int git_cred_forge_configured(void)

--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -177,14 +177,19 @@ char *mcp_git_run(const char *cmd, int *exit_code)
       {
          /* Resolve the git credential through the ONE policy
           * (git_cred_inject_build_env_for_repo) so the precedence never drifts
-          * from the other call sites: a client-handed per-workspace broker token
-          * (§4) is passed as preferred_token and wins, else per-host server vault
-          * → server identity → ambient. The policy injects GH_TOKEN + the
-          * GIT_ASKPASS shim and wipes its own token copy. */
-         char tok[4096] = {0};
-         const char *pref = NULL;
-         if (forge_cred_get(wsid, (long)time(NULL), tok, sizeof(tok)) == 0 && tok[0])
-            pref = tok;
+          * from the other call sites: per-host server vault → the principal's
+          * vaulted forge token → server identity → ambient.
+          *
+          * NO WORKSPACE BROKER TOKEN HERE, deliberately. It used to be fetched
+          * and passed as preferred_token, which outranks the vault — so this
+          * exec path authenticated as a different, weaker credential than the
+          * in-process forge calls next door, which pass none and get the vault.
+          * The result was a split personality against the same repository:
+          * `pr create` succeeded on the vaulted credential while `push` was
+          * refused with "Permission to <repo> denied to <user>", which reads as
+          * a permissions problem on an account that in fact has admin. Operator
+          * ruling: aimee git proxies through aimee's OWN vaulted credential, so
+          * that is the only thing this path may use. */
          int token_fd = -1;
          /* Hand the policy the workspace's RECORDED REMOTE, not just the cwd.
           * The per-host vault step keys on the remote's host, which it derives
@@ -200,10 +205,7 @@ char *mcp_git_run(const char *cmd, int *exit_code)
           * IS the real checkout and no remote may be recorded. */
          const char *ws_remote = workspace_remote_for_root(wsid);
          char **envp =
-             git_cred_inject_build_env_for_repo(NULL, ws_remote, cwd, pref, environ, &token_fd);
-         volatile char *p = (volatile char *)tok;
-         for (size_t i = 0; i < sizeof(tok); i++)
-            p[i] = 0;
+             git_cred_inject_build_env_for_repo(NULL, ws_remote, cwd, NULL, environ, &token_fd);
          if (envp)
          {
             /* FD mode: the token rides an inherited memfd, never the environ. */

--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -53,26 +53,25 @@ static int cwd_in_workspace(const char *cwd, const char *ws)
    return strncmp(cwd, ws, len) == 0 && (cwd[len] == '/' || cwd[len] == '\\' || cwd[len] == '\0');
 }
 
-/* The mirror runner needs both the workspace_id (broker key) and the workspace's
- * remote URL (per-host vault lookup), so ctx carries both. */
+/* The mirror runner needs the workspace's remote URL for the per-host vault
+ * lookup. It used to carry a workspace_id as well, purely as the broker key;
+ * that went with the broker token itself. */
 typedef struct
 {
-   const char *wsid;   /* workspace root / broker key, or NULL */
    const char *remote; /* the workspace's vcs remote URL, or NULL */
 } ws_mirror_runner_ctx_t;
 
 /* Production git runner for the mirror lifecycle: prepend "git" and fork/exec
  * (combined stdout+stderr). Credentials are resolved through the one shared
- * vault-first policy: the workspace's brokered forge token (§4) wins, else the
- * per-host vault token for the remote's host, else the server identity (§6),
- * injected ONLY into the child (never the command line or disk), exactly as
- * mcp_git_run does. No credential → the local ops + ambient-cred clone run
- * unchanged via the shared provider's exec seam. The same env is harmlessly
- * present for the local git ops (rev-parse / worktree / apply) too. */
+ * vault-first policy: the per-host vault token for the remote's host, else the
+ * principal's vaulted forge token, else the server identity (§6), injected ONLY
+ * into the child (never the command line or disk), exactly as mcp_git_run does.
+ * No credential → the local ops + ambient-cred clone run unchanged via the
+ * shared provider's exec seam. The same env is harmlessly present for the local
+ * git ops (rev-parse / worktree / apply) too. */
 static int ws_mirror_git_runner(void *ctx, const char *const args[], char *out, size_t out_cap)
 {
    const ws_mirror_runner_ctx_t *rctx = (const ws_mirror_runner_ctx_t *)ctx;
-   const char *wsid = rctx ? rctx->wsid : NULL;
    const char *remote = rctx ? rctx->remote : NULL;
    const char *argv[64];
    int n = 0;
@@ -83,21 +82,17 @@ static int ws_mirror_git_runner(void *ctx, const char *const args[], char *out, 
 
    /* Resolve the git credential through the ONE policy
     * (git_cred_inject_build_env_for_repo) so the precedence never drifts from the
-    * other call sites: the workspace's brokered forge token (§4) is passed as
-    * preferred_token and wins, else per-host server vault → server identity →
-    * ambient. The policy injects GH_TOKEN + the GIT_ASKPASS shim and wipes its
-    * own token copy. */
-   char tok[4096] = {0};
-   const char *pref = NULL;
-   if (wsid && wsid[0] && forge_cred_get(wsid, (long)time(NULL), tok, sizeof(tok)) == 0 && tok[0])
-      pref = tok;
+    * other call sites: per-host server vault → the principal's vaulted forge
+    * token → server identity → ambient. The policy injects GH_TOKEN + the
+    * GIT_ASKPASS shim and wipes its own token copy.
+    *
+    * NO WORKSPACE BROKER TOKEN, by operator ruling: aimee git proxies through
+    * aimee's OWN vaulted credential. A brokered token passed as preferred_token
+    * outranks the vault, so this path would authenticate as something weaker
+    * than the in-process forge calls that pass none — the same repository, two
+    * identities, and a push refused for an account that has admin. */
    int token_fd = -1;
-   char **envp = git_cred_inject_build_env_for_repo(NULL, remote, NULL, pref, environ, &token_fd);
-   {
-      volatile char *p = (volatile char *)tok;
-      for (size_t i = 0; i < sizeof(tok); i++)
-         p[i] = 0;
-   }
+   char **envp = git_cred_inject_build_env_for_repo(NULL, remote, NULL, NULL, environ, &token_fd);
 
    char *cap = NULL;
    int rc;
@@ -235,7 +230,7 @@ static int mirror_reconstruct_cwd(const char *cwd, const char *root, const char 
    /* Pass the workspace root + remote as the runner ctx so its git calls
     * authenticate under the brokered token, else the per-host vault token for the
     * remote's host, else the server forge identity (§4/§6). */
-   ws_mirror_runner_ctx_t rctx = {.wsid = root, .remote = remote};
+   ws_mirror_runner_ctx_t rctx = {.remote = remote};
    if (workspace_mirror_session_setup_branch(ws_mirror_git_runner, &rctx, remote, effective_head,
                                              effective_branch, effective_upstream, mirror_dir,
                                              work_dir, diff_arg, already, drift, drift_cap,


### PR DESCRIPTION
## The ruling the code did not honour

**aimee git proxies through aimee's OWN vaulted credential.** There is no broker credential for a caller to hand in. That has been stated more than once; `resolve_token` did the opposite.

## What it actually did

`resolve_token` takes `preferred_token` **first**, ahead of the vault, and two call sites filled it from `forge_cred_get(wsid)` — the per-workspace broker. So the exec path and the in-process forge path authenticated as **different tokens against the same repository**:

| call | `preferred_token` | credential used | result |
|---|---|---|---|
| `aimee git pr create` | none | **vaulted credential** | ✅ works |
| `aimee git push` | broker token | weaker credential | ❌ 403 |

The push surfaced as:

```
remote: Permission to RakuenSoftware/aimee.git denied to JBailes.
```

…on an account holding **full admin**. That reads as a permissions problem and sends you to GitHub's settings. The account was never the problem. I chased the token's scopes twice on that evidence and was wrong both times — the two operations were simply not using the same token.

## The fix

Removed at both sites — `mcp_git_run` and `ws_mirror_git_runner`. Both now pass `NULL` and take the per-host vault entry, exactly as the forge path does. The mirror runner's ctx loses its `wsid`, which existed *only* as the broker key.

`preferred_token` itself stays: an inline clone token is a genuine caller-supplied credential for a repo the vault has no entry for. What is gone is the **workspace broker** feeding it.

## Why this was invisible

Nothing said which of four credentials a given git child would authenticate as. So a split like the above looks like a permissions fault rather than a resolution one — and there was no way to tell from outside.

`resolve_token` now **reports which source won**, and the exec path logs it:

```
forge credential for https://github.com/RakuenSoftware/aimee.git resolved from: per-host vault entry
```

The **source only, never the token**. The remote URL is not a secret — `aimee workspace list` already prints it.

## Verification

- `make -C src` returned **0 with `LOG_INFO` undeclared**. The test configuration caught it as an implicit-declaration error under `-Werror`, and only via `TEST_RUN_JOBS=1` — the parallel run prints an empty failure list. `log.h` is now included explicitly.
- Removing the broker lookup stranded `wsid`; caught by the same serial run as `-Werror=unused-variable`, and the dead struct field went with it.
- **All three real links**: `rm -f aimee-server && make -C src -j8 ../aimee-server` rc=0, `../aimee-kb` rc=0, `cmd-srcs-compile-check` rc=0
- `make -C src format` then `make -C src lint` — **48/48**
- `TEST_RUN_JOBS=1 unit-tests` — exit 0
- `refactor_baselines` ok; contracts / runtime-bundle / lock checks ok
- Lock repinned — **git and workspace** both moved, which is the expected blast radius

## Expected effect

`aimee git push` from a mirror workspace should now authenticate with the vaulted admin credential and succeed. I will deploy this to the appliance and confirm, and the new log line will state the source rather than leaving it to inference.