### PR TITLE
feat(delegates): the delegate sandbox specification, in the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "3370e1b35bf651779c784caad9f0e44bba1430c27cdc0e7eb707cd9430c555e9",
+      "source_sha256": "c3cf692baec00ef59b7b457d03b929199516fbdf53981a6f622abec2e3b128b5",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/docs/proposals/pending/delegate-execution-in-the-module.md
+++ b/docs/proposals/pending/delegate-execution-in-the-module.md
@@ -1,0 +1,97 @@
+# Delegate execution moves into the module
+
+Status: pending
+Owner: delegates
+
+## The design
+
+A delegate is a completely sandboxed container. That is the whole of it:
+
+```
+  container: agent loop + tools + file edits
+     │  (only outward path)
+     ▼
+  parent module proxy ──► LLM traffic
+                     └──► very limited whitelist: software updates
+     │
+     ▼
+  event bus / egress proxy module
+```
+
+- Files arrive by **bind mount**. A role that writes gets its own branch and
+  worktree, mounted read-write. A role that does not write mounts the
+  **parent's** worktree, permission-enforced read-only.
+- Which mount a delegate gets is already decided in Go: `RoleIsWrite` at stage
+  10 / event 6666. There is no separate isolation question to invent.
+- The delegate has **no network** except the one proxy to its parent module.
+- The agent loop runs **inside** the container. Its LLM calls leave through the
+  parent proxy, then the module, then egress.
+- The container holds **no credentials of any kind**. Work that needs them is
+  done by a module on the delegate's behalf — git through the git module,
+  secrets through the vault module — each reached over the bus.
+- When the delegate finishes the container exits, and the parent already has the
+  edited files, because the worktree is a bind mount.
+
+## What this design does NOT need
+
+The current C carries machinery for problems this design does not have. Naming
+them is the point of this document, because each is a deletion rather than a
+port:
+
+| Machinery | Why it goes |
+|---|---|
+| result shipping / diff transport | the bind mount IS the transport |
+| in-container credentials | the container never authenticates |
+| ssh backend | a delegate is a container |
+| local backend | a delegate is a container |
+
+## What must be preserved
+
+The C is accretion in structure, but it encodes constraints that were measured,
+not assumed. These are not optional and must survive the move:
+
+1. `--network none`. The container's only reachable peer is the parent, over a
+   bound unix socket.
+2. **Never** bind `/var/run/docker.sock`. That hands a delegate root-equivalent
+   control of the host daemon.
+3. Refuse to bind-mount a directory that is not a git checkout. Otherwise any
+   host directory can be mounted into a delegate.
+4. Mount layering for a write delegate, validated on docker 26.1.5:
+   - `<repo>:ro` — the tree is readable, and a write outside the worktree fails
+     with "Read-only file system"
+   - `<worktree>` read-write — nested mount correctly overlays the read-only repo
+   - `<gitdir>` read-write — `git status` refreshes its index there, so a
+     read-only `.git` breaks it
+5. A consequence of (4) is that `git commit` inside the container fails: blobs
+   cannot be written to a read-only object store. This is intended. Commits run
+   module-side, which is the same rule as "credentialed work is done by
+   modules".
+6. Docker resolves bind **sources** in the daemon's namespace, not the calling
+   process's. When aimee itself runs in a container the two differ, and an
+   untranslated source silently mounts the wrong directory.
+7. Isolation is **verified at runtime**, not assumed: ask the host daemon for
+   the container's attached networks and confirm none is attached and none has
+   an IP.
+8. `http_proxy` points at the egress so a `--network none` delegate can still
+   install software — the narrow update whitelist, and nothing broader.
+
+## Why read-only must be enforced rather than trusted
+
+A read-only delegate mounts the **parent's** worktree — the branch a supervisor
+is actively working in. If the mount is writable and the delegate is merely
+asked not to write, a review or diagnose delegate can corrupt the supervisor's
+branch. The mode is the enforcement; the role is only what selects it.
+
+## Order of work
+
+1. **Sandbox specification** (this slice). A pure function: given a role and the
+   workspace, produce the container specification — mounts and their modes,
+   network posture, environment. No I/O, fully testable, and the place where
+   every invariant above is stated once.
+2. Container lifecycle in Go, driven by that specification.
+3. The parent proxy: the single outward channel.
+4. Retire the C driver and backends, deleting rather than translating the
+   machinery listed above.
+
+Sequencing matters: the specification is where the safety properties live, so it
+is written and tested before anything creates a container.

--- a/server-go/modules/delegates/sandbox.go
+++ b/server-go/modules/delegates/sandbox.go
@@ -1,0 +1,247 @@
+package delegates
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// What a delegate's container is allowed to be.
+//
+// A delegate is a completely sandboxed container: files arrive by bind mount,
+// it has no network except one socket to its parent, and it holds no
+// credentials. This file decides the container's shape and nothing else -- it
+// creates nothing, so every safety property below is checkable by a test rather
+// than by watching a container run.
+//
+// The properties that must hold, and which the tests pin:
+//
+//   - no network, ever
+//   - the docker socket is never mounted, at any path
+//   - a read-only role can only ever receive read-only mounts
+//   - the workspace must be a git checkout
+//   - no credential ever appears in the environment
+
+// ErrNotGitCheckout is returned when the workspace is not a git checkout.
+// Without this, any host directory could be mounted into a delegate.
+var ErrNotGitCheckout = errors.New("workspace is not a git checkout")
+
+// dockerSocketNames are refused as a mount source at ANY path. Binding the
+// docker socket hands a delegate root-equivalent control of the host daemon.
+var dockerSocketNames = []string{"docker.sock", "containerd.sock", "podman.sock"}
+
+// credentialEnvMarkers name environment variables that must never reach the
+// container. The container performs no authenticated work: LLM traffic is
+// proxied through the parent, and anything else needing credentials is done by
+// a module over the bus.
+var credentialEnvMarkers = []string{
+	"KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "AUTH",
+	"SESSION", "COOKIE", "PRIVATE",
+}
+
+// SandboxMountKind separates the workspace from the control channel.
+//
+// The distinction is load-bearing: a read-only delegate must not receive a
+// writable WORKSPACE mount, but its parent socket has to stay writable, because
+// connecting to a unix socket requires write permission on it. Without the
+// distinction the rule is either too weak (allow any writable mount) or too
+// strong (a read-only delegate cannot talk to its parent at all).
+type SandboxMountKind int
+
+const (
+	// SandboxWorkspace is repository content.
+	SandboxWorkspace SandboxMountKind = iota
+	// SandboxControlSocket is the single outward channel to the parent.
+	SandboxControlSocket
+)
+
+// SandboxMount is one bind mount in the container specification.
+type SandboxMount struct {
+	Source   string
+	Target   string
+	ReadOnly bool
+	Kind     SandboxMountKind
+}
+
+// SandboxEnv is one environment entry.
+type SandboxEnv struct {
+	Name  string
+	Value string
+}
+
+// SandboxRequest is what the caller knows about the run. Every filesystem fact
+// is supplied rather than discovered: this module does not stat the workspace,
+// because the workspace owns its files.
+type SandboxRequest struct {
+	Role string
+
+	// RepoRoot is the parent checkout. Mounted read-only for a write delegate
+	// so the tree is readable but only the worktree is writable.
+	RepoRoot string
+	// Worktree is this delegate's own worktree when the role writes, or the
+	// PARENT's worktree when it does not.
+	Worktree string
+	// GitDir is this delegate's git metadata directory. Only meaningful for a
+	// write delegate; `git status` refreshes its index there.
+	GitDir string
+	// IsGitCheckout is the caller's answer to "is Worktree a git checkout".
+	IsGitCheckout bool
+
+	// ParentSocketHost is the host path of the parent module's unix socket --
+	// the single outward channel. ParentSocketTarget is where it appears
+	// inside the container.
+	ParentSocketHost   string
+	ParentSocketTarget string
+
+	// EgressProxy, when set, becomes http_proxy so a no-network delegate can
+	// still install software through the narrow update whitelist.
+	EgressProxy string
+}
+
+// SandboxSpec is the container specification. NetworkMode is not a field the
+// caller can set: it is always none.
+type SandboxSpec struct {
+	Mounts   []SandboxMount
+	Env      []SandboxEnv
+	ReadOnly bool // the role does not write, so nothing is mounted writable
+}
+
+// NetworkMode is always "none". It is a method rather than a field so no caller
+// can construct a spec with a network, and no future edit can widen it by
+// assignment.
+func (SandboxSpec) NetworkMode() string { return "none" }
+
+// isDockerSocket reports whether a path names a container runtime socket,
+// judged by base name so it is caught at any location.
+func isDockerSocket(p string) bool {
+	base := path.Base(strings.TrimRight(p, "/"))
+	for _, name := range dockerSocketNames {
+		if base == name {
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeCredential reports whether an environment name suggests a secret.
+// Deliberately broad: a false positive costs a delegate one variable it should
+// not have needed, a false negative puts a credential inside the sandbox.
+func looksLikeCredential(name string) bool {
+	upper := strings.ToUpper(name)
+	for _, marker := range credentialEnvMarkers {
+		if strings.Contains(upper, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanAbs(p string) (string, bool) {
+	if p == "" || !strings.HasPrefix(p, "/") {
+		return "", false
+	}
+	return path.Clean(p), true
+}
+
+// BuildSandboxSpec decides the container's shape for one delegate run.
+//
+// A write role gets three mounts: the repo read-only so the whole tree is
+// readable and a write outside its worktree fails, then its own worktree and
+// git directory read-write nested inside. A read-only role gets exactly one
+// mount -- the parent's worktree -- and it is read-only because that is the
+// supervisor's live branch and the mode is the enforcement, not the request.
+func BuildSandboxSpec(req SandboxRequest) (SandboxSpec, error) {
+	var spec SandboxSpec
+
+	worktree, ok := cleanAbs(req.Worktree)
+	if !ok {
+		return spec, fmt.Errorf("worktree must be an absolute path, got %q", req.Worktree)
+	}
+	if !req.IsGitCheckout {
+		return spec, fmt.Errorf("%w: %s", ErrNotGitCheckout, worktree)
+	}
+
+	write := RoleIsWrite(req.Role)
+	spec.ReadOnly = !write
+
+	if write {
+		repo, ok := cleanAbs(req.RepoRoot)
+		if !ok {
+			return spec, fmt.Errorf("repo root must be an absolute path, got %q", req.RepoRoot)
+		}
+		// The tree is readable; only the worktree below is writable.
+		spec.Mounts = append(spec.Mounts, SandboxMount{Source: repo, Target: repo, ReadOnly: true})
+		spec.Mounts = append(spec.Mounts,
+			SandboxMount{Source: worktree, Target: worktree, ReadOnly: false})
+		if gitDir, ok := cleanAbs(req.GitDir); ok {
+			// `git status` refreshes its index here, so a read-only .git breaks
+			// it. `git commit` still fails, because objects live in the
+			// read-only repo -- intended, commits run module-side.
+			spec.Mounts = append(spec.Mounts,
+				SandboxMount{Source: gitDir, Target: gitDir, ReadOnly: false})
+		}
+	} else {
+		// The parent's worktree. Read-only is enforced by the mount, not by
+		// asking the delegate not to write.
+		spec.Mounts = append(spec.Mounts,
+			SandboxMount{Source: worktree, Target: worktree, ReadOnly: true})
+	}
+
+	if req.ParentSocketHost != "" {
+		host, ok := cleanAbs(req.ParentSocketHost)
+		if !ok {
+			return spec, fmt.Errorf("parent socket must be an absolute path, got %q",
+				req.ParentSocketHost)
+		}
+		target, ok := cleanAbs(req.ParentSocketTarget)
+		if !ok {
+			return spec, fmt.Errorf("parent socket target must be an absolute path, got %q",
+				req.ParentSocketTarget)
+		}
+		spec.Mounts = append(spec.Mounts,
+			SandboxMount{Source: host, Target: target, Kind: SandboxControlSocket})
+	}
+
+	if req.EgressProxy != "" {
+		spec.Env = append(spec.Env,
+			SandboxEnv{Name: "http_proxy", Value: req.EgressProxy},
+			SandboxEnv{Name: "https_proxy", Value: req.EgressProxy})
+	}
+
+	if err := ValidateSandboxSpec(spec); err != nil {
+		return SandboxSpec{}, err
+	}
+	return spec, nil
+}
+
+// ValidateSandboxSpec re-checks a specification against every invariant.
+//
+// BuildSandboxSpec calls this on its own output, so the guarantees hold even if
+// the construction above is later changed carelessly. It is exported so a
+// caller can check a spec it did not build.
+func ValidateSandboxSpec(spec SandboxSpec) error {
+	for _, m := range spec.Mounts {
+		if isDockerSocket(m.Source) {
+			return fmt.Errorf("refusing to mount a container runtime socket: %s", m.Source)
+		}
+		if _, ok := cleanAbs(m.Source); !ok {
+			return fmt.Errorf("mount source must be an absolute path, got %q", m.Source)
+		}
+		if _, ok := cleanAbs(m.Target); !ok {
+			return fmt.Errorf("mount target must be an absolute path, got %q", m.Target)
+		}
+		// A read-only role must not receive a writable WORKSPACE mount by any
+		// route. The control socket is the sole exemption and must stay
+		// writable to be connectable.
+		if spec.ReadOnly && m.Kind == SandboxWorkspace && !m.ReadOnly {
+			return fmt.Errorf("read-only delegate given a writable workspace mount: %s", m.Target)
+		}
+	}
+	for _, e := range spec.Env {
+		if looksLikeCredential(e.Name) {
+			return fmt.Errorf("refusing to pass a credential into the sandbox: %s", e.Name)
+		}
+	}
+	return nil
+}

--- a/server-go/modules/delegates/sandbox_test.go
+++ b/server-go/modules/delegates/sandbox_test.go
@@ -1,0 +1,225 @@
+package delegates
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func writeReq() SandboxRequest {
+	return SandboxRequest{
+		Role:               "code",
+		RepoRoot:           "/srv/repo",
+		Worktree:           "/srv/repo/.aimee/worktrees/w1/main",
+		GitDir:             "/srv/repo/.git/worktrees/w1",
+		IsGitCheckout:      true,
+		ParentSocketHost:   "/run/aimee/server.sock",
+		ParentSocketTarget: "/run/aimee.sock",
+		EgressProxy:        "http://egress:3128",
+	}
+}
+
+func readReq() SandboxRequest {
+	return SandboxRequest{
+		Role:               "review",
+		RepoRoot:           "/srv/repo",
+		Worktree:           "/srv/repo",
+		IsGitCheckout:      true,
+		ParentSocketHost:   "/run/aimee/server.sock",
+		ParentSocketTarget: "/run/aimee.sock",
+	}
+}
+
+func findMount(spec SandboxSpec, target string) (SandboxMount, bool) {
+	for _, m := range spec.Mounts {
+		if m.Target == target {
+			return m, true
+		}
+	}
+	return SandboxMount{}, false
+}
+
+// A write delegate gets the tree readable and only its own worktree writable,
+// so an edit outside its ownership fails at the filesystem rather than being
+// caught later by review.
+func TestSandboxWriteDelegateMountLayering(t *testing.T) {
+	spec, err := BuildSandboxSpec(writeReq())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if spec.ReadOnly {
+		t.Error("a write role produced a read-only sandbox")
+	}
+
+	repo, ok := findMount(spec, "/srv/repo")
+	if !ok || !repo.ReadOnly {
+		t.Errorf("repo mount = %+v, want present and read-only", repo)
+	}
+	worktree, ok := findMount(spec, "/srv/repo/.aimee/worktrees/w1/main")
+	if !ok || worktree.ReadOnly {
+		t.Errorf("worktree mount = %+v, want present and writable", worktree)
+	}
+	// git status refreshes its index here, so a read-only .git breaks it.
+	gitDir, ok := findMount(spec, "/srv/repo/.git/worktrees/w1")
+	if !ok || gitDir.ReadOnly {
+		t.Errorf("git dir mount = %+v, want present and writable", gitDir)
+	}
+}
+
+// The supervisor's live branch. The mount mode is the enforcement -- a delegate
+// that is merely asked not to write can still write.
+func TestSandboxReadOnlyDelegateCannotGetAWritableWorkspace(t *testing.T) {
+	spec, err := BuildSandboxSpec(readReq())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !spec.ReadOnly {
+		t.Fatal("a read role produced a writable sandbox")
+	}
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxWorkspace && !m.ReadOnly {
+			t.Errorf("writable workspace mount for a read-only role: %+v", m)
+		}
+	}
+	// Exactly one workspace mount: the parent's worktree, not a fresh one.
+	workspaceMounts := 0
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxWorkspace {
+			workspaceMounts++
+		}
+	}
+	if workspaceMounts != 1 {
+		t.Errorf("read-only delegate got %d workspace mounts, want 1", workspaceMounts)
+	}
+}
+
+// The socket must stay writable or the delegate cannot connect to its parent at
+// all -- and it is the ONLY thing exempt from the read-only rule.
+func TestSandboxControlSocketStaysWritableForAReadOnlyRole(t *testing.T) {
+	spec, err := BuildSandboxSpec(readReq())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	sock, ok := findMount(spec, "/run/aimee.sock")
+	if !ok {
+		t.Fatal("no control socket mount")
+	}
+	if sock.Kind != SandboxControlSocket {
+		t.Errorf("socket mount kind = %v, want control socket", sock.Kind)
+	}
+	if sock.ReadOnly {
+		t.Error("control socket mounted read-only; the delegate could not connect")
+	}
+}
+
+// One flag removes lateral movement and data exfiltration. It is a method, not
+// a field, so no caller can set it to anything else.
+func TestSandboxHasNoNetwork(t *testing.T) {
+	for _, req := range []SandboxRequest{writeReq(), readReq()} {
+		spec, err := BuildSandboxSpec(req)
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		if spec.NetworkMode() != "none" {
+			t.Errorf("network mode = %q, want none", spec.NetworkMode())
+		}
+	}
+}
+
+// Binding a container runtime socket hands the delegate root-equivalent control
+// of the host daemon. Refused by base name, so it is caught at any path.
+func TestSandboxRefusesContainerRuntimeSockets(t *testing.T) {
+	for _, p := range []string{
+		"/var/run/docker.sock",
+		"/some/other/place/docker.sock",
+		"/run/containerd/containerd.sock",
+		"/run/podman/podman.sock",
+	} {
+		req := writeReq()
+		req.ParentSocketHost = p
+		if _, err := BuildSandboxSpec(req); err == nil {
+			t.Errorf("%s was accepted as a mount source", p)
+		}
+	}
+}
+
+// Without this, any host directory could be mounted into a delegate.
+func TestSandboxRequiresAGitCheckout(t *testing.T) {
+	req := writeReq()
+	req.IsGitCheckout = false
+	_, err := BuildSandboxSpec(req)
+	if !errors.Is(err, ErrNotGitCheckout) {
+		t.Errorf("err = %v, want ErrNotGitCheckout", err)
+	}
+}
+
+// The container performs no authenticated work, so a credential in its
+// environment is a leak with no upside.
+func TestSandboxRefusesCredentialsInTheEnvironment(t *testing.T) {
+	for _, name := range []string{
+		"ANTHROPIC_API_KEY", "GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY",
+		"DB_PASSWORD", "VAULT_CREDENTIAL", "SESSION_ID", "AUTH_HEADER",
+	} {
+		spec := SandboxSpec{Env: []SandboxEnv{{Name: name, Value: "x"}}}
+		if err := ValidateSandboxSpec(spec); err == nil {
+			t.Errorf("%s was allowed into the sandbox", name)
+		}
+	}
+	// The proxy variables are not credentials and must survive.
+	spec, err := BuildSandboxSpec(writeReq())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	var sawProxy bool
+	for _, e := range spec.Env {
+		if e.Name == "http_proxy" && e.Value == "http://egress:3128" {
+			sawProxy = true
+		}
+		if looksLikeCredential(e.Name) {
+			t.Errorf("credential-looking env survived: %s", e.Name)
+		}
+	}
+	if !sawProxy {
+		t.Error("http_proxy missing; a no-network delegate could not install software")
+	}
+}
+
+// Relative paths would resolve against whatever the daemon's cwd happens to be.
+func TestSandboxRequiresAbsolutePaths(t *testing.T) {
+	req := writeReq()
+	req.Worktree = "relative/worktree"
+	if _, err := BuildSandboxSpec(req); err == nil {
+		t.Error("a relative worktree was accepted")
+	}
+
+	req = writeReq()
+	req.RepoRoot = "repo"
+	if _, err := BuildSandboxSpec(req); err == nil {
+		t.Error("a relative repo root was accepted")
+	}
+}
+
+// ValidateSandboxSpec is the backstop: it must reject a hand-built spec that
+// violates an invariant, so the guarantees do not depend on BuildSandboxSpec
+// staying correct.
+func TestValidateRejectsHandBuiltViolations(t *testing.T) {
+	writableWorkspaceForReadRole := SandboxSpec{
+		ReadOnly: true,
+		Mounts:   []SandboxMount{{Source: "/srv/repo", Target: "/srv/repo"}},
+	}
+	if err := ValidateSandboxSpec(writableWorkspaceForReadRole); err == nil {
+		t.Error("a writable workspace mount for a read-only role was accepted")
+	}
+
+	dockerSock := SandboxSpec{
+		Mounts: []SandboxMount{{
+			Source: "/var/run/docker.sock", Target: "/var/run/docker.sock",
+			Kind: SandboxControlSocket,
+		}},
+	}
+	if err := ValidateSandboxSpec(dockerSock); err == nil {
+		t.Error("the docker socket was accepted")
+	} else if !strings.Contains(err.Error(), "runtime socket") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -85,7 +85,8 @@
     "server-go/modules/delegates/economics_stage.go",
     "server-go/modules/delegates/patchcoord.go",
     "server-go/modules/delegates/patchcoord_stage.go",
-    "server-go/modules/delegates/rolepolicy.go"
+    "server-go/modules/delegates/rolepolicy.go",
+    "server-go/modules/delegates/sandbox.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -101,7 +102,8 @@
     "server-go/modules/delegates/economics_stage_test.go",
     "server-go/modules/delegates/patchcoord_test.go",
     "server-go/modules/delegates/patchcoord_stage_test.go",
-    "server-go/modules/delegates/rolepolicy_test.go"
+    "server-go/modules/delegates/rolepolicy_test.go",
+    "server-go/modules/delegates/sandbox_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",


### PR DESCRIPTION
**Stacked on #2512** — `BuildSandboxSpec` calls `RoleIsWrite`, which that PR
introduces. Merge #2512 first; this PR's diff against `testing` will then be
just the three files it adds.

---

feat(delegates): the delegate sandbox specification, in the module

First slice of delegate execution. It decides what a delegate's container is
allowed to BE, and creates nothing -- so every safety property is checkable by a
test instead of by watching a container run.

The design it implements (docs/proposals/pending/delegate-execution-in-the-module.md):
a delegate is a completely sandboxed container, files arrive by bind mount, it
has no network except one socket to its parent, and it holds no credentials.

Which mount a delegate gets follows from the role policy already migrated at
stage 10: a write role gets the repo read-only with its own worktree and git dir
writable nested inside, so an edit outside its ownership fails at the filesystem
rather than being caught later by review. A read-only role mounts the PARENT's
worktree, and the mount mode is the enforcement -- that is the supervisor's live
branch, and a delegate merely asked not to write can still write.

The mount KIND distinction is load-bearing and was not obvious. A read-only
delegate must not receive a writable workspace mount, but its parent socket has
to stay writable, because connecting to a unix socket requires write permission
on it. Without separating the two, the rule is either too weak (any writable
mount passes) or too strong (a read-only delegate cannot reach its parent at
all). That bug was live in the first draft here and the distinction is what
fixes it.

NetworkMode is a method, not a field, so no caller can construct a sandbox with
a network and no later edit can widen it by assignment.

ValidateSandboxSpec re-checks the invariants on the builder's own output and is
exported, so the guarantees hold for a hand-built spec too and do not depend on
BuildSandboxSpec staying correct.

Invariants carried over from delegate_backend_docker.c rather than rediscovered
by incident -- several were measured against docker 26.1.5:

  - never mount a container runtime socket, refused by base name so it is caught
    at any path, because it hands the delegate root-equivalent control of the
    host daemon;
  - refuse a workspace that is not a git checkout, or any host directory can be
    mounted into a delegate;
  - the git dir must be writable because `git status` refreshes its index there,
    while `git commit` still fails against the read-only object store -- which is
    intended, since commits run module-side;
  - http_proxy survives so a no-network delegate can still install software
    through the narrow update whitelist.

No credential of any kind may enter the environment; the check is deliberately
broad, because a false positive costs a variable the delegate should not have
needed and a false negative puts a secret inside the sandbox.

Whether the workspace is a git checkout is an INPUT, not something this module
stats. The workspace owns its files; delegates asks for facts in the request,
the same way the known-tool set and agent tiers already arrive.

Nothing calls this yet -- the container lifecycle is the next slice. The
specification is written and tested first deliberately: it is where the safety
properties live, so it lands before anything can create a container.
