### PR TITLE
fix(git): say when git runs with no forge credential

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -232,7 +232,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e0c58f7d1094b5cd80ad0ebace685721a27a0ab80b9a69ff21e0617475a924a6",
+      "source_sha256": "5970faf8a9069a7956fd3b66939f2ccd37344cf33dbdc11e38e14e2a9c41d136",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -5,6 +5,7 @@
 #include "config.h"
 #include "guardrails.h"
 #include "git_verify.h"
+#include "log.h"
 #include "mcp_git.h"
 #include "platform_process.h"
 #include "util.h"
@@ -155,9 +156,11 @@ char *mcp_git_run(const char *cmd, int *exit_code)
    /* Credential injection: for a server-run command whose cwd is inside a registered
     * workspace, run under an execve environment that authenticates git — never on the
     * command line or disk. The token is resolved through the one shared vault-first
-    * policy: a client-handed per-workspace broker token (§4) wins, else the per-host
-    * vault token for the checkout's `origin`, else the server's own forge identity
-    * (§6); no token → fall through to ambient creds (co-located dev's own gh/SSH).
+    * policy: the per-host vault token for the workspace's remote (or the checkout's
+    * `origin`), else the principal's vaulted forge token, else the server's own forge
+    * identity (§6); no token → fall through to ambient creds (co-located dev's own
+    * gh/SSH). No workspace broker token: aimee git proxies through aimee's own
+    * vaulted credential, and a brokered one would outrank it.
     *
     * This carries AIMEE_GIT_TOKEN_FD and the GIT_ASKPASS shim, NOT GH_TOKEN. The
     * builder is called in FD mode (out_token_fd non-NULL), which puts the secret on a
@@ -173,6 +176,17 @@ char *mcp_git_run(const char *cmd, int *exit_code)
     * sent at least one reader hunting for a broken OAuth that was never broken. */
    if (run_on_server)
    {
+      /* The other half of the same silence: with no workspace owning the cwd the
+       * block below never runs, so git execs bare and no credential is even
+       * attempted. That is the condition this file's header describes as having
+       * caused exactly this bug once, and it is indistinguishable from a bad
+       * token unless it says so. It is also what a broken credential-resolve
+       * stage looks like from here — that stage going unadvertised silently
+       * disabled injection for every git child. */
+      if (have_ws != 0)
+         LOG_WARN("git",
+                  "no registered workspace owns cwd \"%s\": git will run with no forge credential",
+                  cwd ? cwd : "");
       if (have_ws == 0)
       {
          /* Resolve the git credential through the ONE policy
@@ -206,6 +220,18 @@ char *mcp_git_run(const char *cmd, int *exit_code)
          const char *ws_remote = workspace_remote_for_root(wsid);
          char **envp =
              git_cred_inject_build_env_for_repo(NULL, ws_remote, cwd, NULL, environ, &token_fd);
+         /* SAY SO WHEN NOTHING WAS STAGED. Falling through to ambient credentials
+          * is deliberate for a co-located dev with their own gh/SSH, but a server
+          * has none, so the only symptom is git prompting: "could not read
+          * Username", which reads as a dead token and sends the reader to the
+          * vault. Naming the workspace and the remote resolution keyed on
+          * separates "no remote recorded for this workspace" from "the remote is
+          * right and the vault has no entry for its host". */
+         if (token_fd < 0)
+            LOG_WARN("git",
+                     "no forge credential staged for workspace \"%s\" (remote=%s): git will run "
+                     "unauthenticated and a push will fail asking for a username",
+                     wsid, (ws_remote && ws_remote[0]) ? ws_remote : "<none recorded>");
          if (envp)
          {
             /* FD mode: the token rides an inherited memfd, never the environ. */


### PR DESCRIPTION
Complements #2514. That PR reports which source a credential **came from**; this one reports when there is **none** — the case that has been silently misdiagnosed repeatedly.

## Why it matters

Falling through to ambient credentials is deliberate for a co-located dev with their own `gh`/SSH. **A server has none**, so the only symptom is git prompting:

```
fatal: could not read Username for 'https://github.com'
```

That reads as an expired or missing token and sends the reader to the vault. It is not a token problem at all — nothing was ever staged.

## Two warnings, at the two silent branches

- **No registered workspace owns the cwd** → the injection block never runs and git execs bare. This is also what a broken credential-resolve stage looks like from here: when that stage went unadvertised (#2510), *every* git child lost its credential and the only visible symptom was the username prompt.
- **A workspace owns it, but no token was staged** → names the workspace *and* the remote the per-host lookup keyed on, separating "no remote recorded for this workspace" from "the remote is right and the vault has no entry for its host".

The token is never logged. The remote URL is not a secret — `aimee workspace list` already prints it.

Also corrects a stale comment left by #2514: the credential-injection preamble still claimed a client-handed broker token wins, which is precisely what that PR removed.

## Why I am landing this now

`aimee git push` from a mirror still fails on the deployed build with `Permission to RakuenSoftware/aimee.git denied to JBailes`, and I cannot explain it from outside. What I established on the appliance:

- **no** `resolved from:` line is emitted for the push, so `git_cred_inject_build_env_for_repo` staged **no** token
- **no** credential helper is configured anywhere, and **no** mirror remote embeds a credential (checked every checkout under the workspaces tree; all plain URLs)
- yet GitHub answers with an authenticated 403 naming the account

"Nothing was staged" and "GitHub authenticated someone" do not reconcile, and there is currently no log line that would say which branch was taken. These two warnings are exactly that missing line.

## Verification

- All three real links rc=0: `rm -f aimee-server && make -C src -j8 ../aimee-server`, `../aimee-kb`, `cmd-srcs-compile-check`
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src format` then `make -C src lint` — 48/48
- `refactor_baselines` clean; lock repinned, `git` only