### PR TITLE
feat(delegates): the network isolation verdict, in the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "3370e1b35bf651779c784caad9f0e44bba1430c27cdc0e7eb707cd9430c555e9",
+      "source_sha256": "d52a0b306666690afd4a274c04d4f27aca0f5b4c30901a3625ed3b8f96013cef",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "c3cf692baec00ef59b7b457d03b929199516fbdf53981a6f622abec2e3b128b5",
+      "source_sha256": "00ba96a8ee9f099bf547715a8c6cf5d89869eb0b7d887b414a970b27e16cafb2",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/isolation.go
+++ b/server-go/modules/delegates/isolation.go
@@ -1,0 +1,122 @@
+package delegates
+
+import "strings"
+
+// Whether a container that was asked for no network actually got none, and what
+// to do when that cannot be established.
+//
+// `--network none` is a request to the runtime, not a guarantee from it. If the
+// runtime does not honour it, the delegate reaches the network directly and
+// bypasses the egress proxy and its allowlist entirely -- the isolation the
+// whole design rests on is simply absent, silently. So the container is probed
+// after it starts, and this decides what the probe means.
+//
+// The probe itself is I/O and belongs to the caller. What its result IMPLIES is
+// a decision and lives here, where it can be tested without a container.
+
+// IsolationProbe is what the caller observed about the container's networks.
+type IsolationProbe int
+
+const (
+	// IsolationUnknown means the probe could not answer -- it failed, timed
+	// out, or returned something unparseable. NOT the same as isolated.
+	IsolationUnknown IsolationProbe = iota
+	// IsolationConfirmed means no network is attached and none has an address.
+	IsolationConfirmed
+	// IsolationBreached means the container can reach the network.
+	IsolationBreached
+)
+
+// IsolationVerdict is what to do with the run.
+type IsolationVerdict struct {
+	// Refuse means do not run this delegate, and destroy the container.
+	Refuse bool
+	// Warn means the result is worth reporting but not fatal here.
+	Warn bool
+	// Reason is operator-facing and states what was observed and why it
+	// matters, never just "failed".
+	Reason string
+}
+
+// JudgeIsolation decides whether a delegate may run.
+//
+// A confirmed breach always refuses: the container can reach the network
+// regardless of what was asked for, so the egress allowlist is not in force and
+// the delegate could exfiltrate or move laterally.
+//
+// An UNKNOWN result refuses too, but only when isolation is required. That is
+// the point of the setting: an operator who requires isolation will not run a
+// delegate that cannot be PROVEN isolated, because "the probe failed" and "the
+// sandbox is open" are indistinguishable from here. Without the requirement, an
+// unknown result is a warning -- refusing every unprobeable container would
+// make a flaky runtime look like a broken delegate.
+func JudgeIsolation(probe IsolationProbe, requireIsolation bool) IsolationVerdict {
+	switch probe {
+	case IsolationBreached:
+		reason := "container has network egress despite being created with no network: " +
+			"the runtime did not honour isolation, so the delegate can reach the network " +
+			"directly and bypass the egress proxy and its allowlist"
+		if requireIsolation {
+			return IsolationVerdict{Refuse: true, Reason: reason + " -- refusing to run"}
+		}
+		// Still an error worth surfacing: the sandbox is not a sandbox.
+		return IsolationVerdict{Warn: true,
+			Reason: reason + " -- set delegate_sandbox_require_isolation to refuse"}
+
+	case IsolationUnknown:
+		if requireIsolation {
+			return IsolationVerdict{Refuse: true,
+				Reason: "could not verify network isolation and isolation is required -- " +
+					"refusing to run a delegate that cannot be proven isolated"}
+		}
+		return IsolationVerdict{Warn: true, Reason: "could not verify network isolation"}
+	}
+	return IsolationVerdict{}
+}
+
+// ParseIsolationProbe reads a container runtime's network report.
+//
+// The expected shape is "<network>=<ip>;" repeated, which is what docker's
+// inspect template produces. A container is isolated only when every entry is
+// the "none" network AND carries no address: a named network means attachment,
+// and an address means reachability, so either alone is a breach.
+//
+// Unparseable or empty input is UNKNOWN, never isolated. Reading silence as
+// safety is the mistake this whole check exists to prevent.
+func ParseIsolationProbe(report string, probeFailed bool) IsolationProbe {
+	if probeFailed {
+		return IsolationUnknown
+	}
+	trimmed := strings.TrimSpace(report)
+	if trimmed == "" {
+		// No networks at all is a legitimate isolated result: docker prints
+		// nothing when the map is empty.
+		return IsolationConfirmed
+	}
+
+	sawEntry := false
+	for _, entry := range strings.FieldsFunc(trimmed, func(r rune) bool {
+		return r == ';' || r == '\n'
+	}) {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		name, ip, found := strings.Cut(entry, "=")
+		if !found {
+			// A line that does not match the contract is not evidence of
+			// safety.
+			return IsolationUnknown
+		}
+		sawEntry = true
+		name = strings.TrimSpace(name)
+		ip = strings.TrimSpace(ip)
+		if ip != "" || (name != "" && name != "none") {
+			return IsolationBreached
+		}
+	}
+	if !sawEntry {
+		return IsolationUnknown
+	}
+	return IsolationConfirmed
+}

--- a/server-go/modules/delegates/isolation_test.go
+++ b/server-go/modules/delegates/isolation_test.go
@@ -1,0 +1,103 @@
+package delegates
+
+import (
+	"strings"
+	"testing"
+)
+
+// A runtime that did not honour isolation leaves the delegate able to reach the
+// network directly, so the egress allowlist is not in force at all.
+func TestJudgeIsolationBreachAlwaysReported(t *testing.T) {
+	required := JudgeIsolation(IsolationBreached, true)
+	if !required.Refuse {
+		t.Error("a confirmed breach did not refuse when isolation is required")
+	}
+	if !strings.Contains(required.Reason, "bypass the egress proxy") {
+		t.Errorf("reason does not say what is at stake: %q", required.Reason)
+	}
+
+	// Without the requirement it still must not pass silently.
+	optional := JudgeIsolation(IsolationBreached, false)
+	if optional.Refuse {
+		t.Error("refused despite isolation not being required")
+	}
+	if !optional.Warn {
+		t.Error("a confirmed breach was neither refused nor warned about")
+	}
+}
+
+// The point of the setting: "the probe failed" and "the sandbox is open" are
+// indistinguishable from here, so an operator who requires isolation gets a
+// refusal rather than a guess.
+func TestJudgeIsolationUnknownRefusesOnlyWhenRequired(t *testing.T) {
+	required := JudgeIsolation(IsolationUnknown, true)
+	if !required.Refuse {
+		t.Error("an unverifiable container ran while isolation was required")
+	}
+	if !strings.Contains(required.Reason, "cannot be proven isolated") {
+		t.Errorf("reason does not explain the refusal: %q", required.Reason)
+	}
+
+	optional := JudgeIsolation(IsolationUnknown, false)
+	if optional.Refuse {
+		t.Error("an unverifiable container was refused without the requirement")
+	}
+	if !optional.Warn {
+		t.Error("an unverifiable container passed with no warning at all")
+	}
+}
+
+func TestJudgeIsolationConfirmedRuns(t *testing.T) {
+	for _, required := range []bool{true, false} {
+		v := JudgeIsolation(IsolationConfirmed, required)
+		if v.Refuse || v.Warn {
+			t.Errorf("required=%v: a properly isolated container was not allowed: %+v",
+				required, v)
+		}
+	}
+}
+
+// A named network means attachment and an address means reachability; either
+// alone is a breach.
+func TestParseIsolationProbe(t *testing.T) {
+	cases := []struct {
+		name   string
+		report string
+		want   IsolationProbe
+	}{
+		{"no networks at all", "", IsolationConfirmed},
+		{"only the none network", "none=;", IsolationConfirmed},
+		{"none network with whitespace", "  none=  ;\n", IsolationConfirmed},
+		{"named network attached", "bridge=;", IsolationBreached},
+		{"none network but has an address", "none=172.17.0.2;", IsolationBreached},
+		{"named network with an address", "bridge=172.17.0.2;", IsolationBreached},
+		{"one clean one attached", "none=;bridge=172.17.0.3;", IsolationBreached},
+		// Anything that does not match the contract is not evidence of safety.
+		{"unparseable", "something unexpected", IsolationUnknown},
+		{"partial entry", "bridge", IsolationUnknown},
+	}
+	for _, c := range cases {
+		if got := ParseIsolationProbe(c.report, false); got != c.want {
+			t.Errorf("%s: %q -> %v, want %v", c.name, c.report, got, c.want)
+		}
+	}
+}
+
+// A failed probe is never isolated. Reading silence as safety is the mistake
+// this check exists to prevent.
+func TestParseIsolationProbeFailureIsNeverIsolated(t *testing.T) {
+	for _, report := range []string{"", "none=;", "bridge=172.17.0.2;"} {
+		if got := ParseIsolationProbe(report, true); got != IsolationUnknown {
+			t.Errorf("a failed probe reporting %q returned %v, want unknown", report, got)
+		}
+	}
+}
+
+// End to end: an unreachable runtime must not silently produce a running
+// delegate when the operator required isolation.
+func TestIsolationFailedProbeUnderRequirementRefuses(t *testing.T) {
+	probe := ParseIsolationProbe("", true)
+	if v := JudgeIsolation(probe, true); !v.Refuse {
+		t.Errorf("failed probe + required isolation did not refuse: %+v", v)
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -85,7 +85,8 @@
     "server-go/modules/delegates/economics_stage.go",
     "server-go/modules/delegates/patchcoord.go",
     "server-go/modules/delegates/patchcoord_stage.go",
-    "server-go/modules/delegates/rolepolicy.go"
+    "server-go/modules/delegates/rolepolicy.go",
+    "server-go/modules/delegates/isolation.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -101,7 +102,8 @@
     "server-go/modules/delegates/economics_stage_test.go",
     "server-go/modules/delegates/patchcoord_test.go",
     "server-go/modules/delegates/patchcoord_stage_test.go",
-    "server-go/modules/delegates/rolepolicy_test.go"
+    "server-go/modules/delegates/rolepolicy_test.go",
+    "server-go/modules/delegates/isolation_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",


### PR DESCRIPTION
feat(delegates): the network isolation verdict, in the module

`--network none` is a request to the runtime, not a guarantee from it. If the
runtime does not honour it, the delegate reaches the network directly and
bypasses the egress proxy and its allowlist entirely -- the isolation the whole
design rests on is simply absent, silently. So the container is probed after it
starts, and this decides what the probe means.

The probe is I/O and stays with the caller. What its result IMPLIES is a
decision, and it now lives in server-go/modules/delegates/isolation.go where it
can be tested without a container.

The rule, carried over from delegate_backend_docker.c:

  - a CONFIRMED breach refuses when isolation is required, and warns loudly
    otherwise. It never passes silently: the sandbox is not a sandbox;
  - an UNKNOWN result refuses too, but only when isolation is required. That is
    the entire point of the setting -- from here, "the probe failed" and "the
    sandbox is open" are indistinguishable, so an operator who requires
    isolation gets a refusal rather than a guess. Without the requirement,
    refusing every unprobeable container would make a flaky runtime look like a
    broken delegate;
  - confirmed isolation runs, with nothing to report.

Parsing is deliberately strict about what counts as safe. A container is
isolated only when every entry is the "none" network AND carries no address: a
named network means attachment, an address means reachability, and either alone
is a breach. Unparseable input is UNKNOWN, never isolated -- reading silence as
safety is the mistake the whole check exists to prevent, and a probe that failed
returns UNKNOWN regardless of what text came back with it.

An empty report IS isolated, because that is what the runtime prints for an
empty network map; the tests pin that alongside the failed-probe case so the two
cannot be conflated later.

Reasons are operator-facing and state what was observed and why it matters,
rather than just "failed" -- someone reading a refused run at 3am needs to know
the allowlist was not in force.
