### PR TITLE
feat(economizer): build the page table so eviction is reversible

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "8d2b566fd09ee8a1ee3fe87b4857bb430b094ae57b35cd8593e1c5024ddae3b7"
+      "source_sha256": "53bbcd54ec6314b729ac1e054a4c6b26ef64cecd9e2949445e48eb32ecb13b71"
     },
     {
       "id": "ir",

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -735,7 +735,11 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_register_enabled = 0; /* fold §6: default-off */
    cfg->fold_freeze_enabled = 0;   /* fold §3: default-off */
    cfg->fold_freeze_tail_cap_msgs = 0;
-   cfg->fold_recall_enabled = 0; /* fold §4: default-off */
+   /* fold §4: default-ON. The page table is what makes eviction REVERSIBLE — without
+    * it a folded coordinate is simply gone, and the agent re-derives it. It only ever
+    * ADDS a bounded hint when the newest turn re-touches something already evicted, so
+    * the downside is a few lines of text and the upside is not losing the thread. */
+   cfg->fold_recall_enabled = 1;
    cfg->fold_recall_ttl_turns = 0;
    /* SAFE is useful without provider-specific pricing guesses: it only compacts
     * strict JSON returned by a local tool before that result's first dispatch. */

--- a/src/modules/economizer/context_reduce.c
+++ b/src/modules/economizer/context_reduce.c
@@ -95,6 +95,61 @@ void context_reduce_result_free(reduce_result_t *out)
       cJSON_Delete(out->messages);
    out->messages = NULL;
    out->mutated = 0;
+   free(out->recall_hint);
+   out->recall_hint = NULL;
+   out->recall_surfaced = 0;
+}
+
+/* §4 page table. Record what LEFT the prompt, then tell the caller when the newest turn
+ * re-touches one of those coordinates.
+ *
+ * `evicted_count` is the number of leading ORIGINAL messages the reduction removed or
+ * skeletonized. Harvesting from the original (not the reduced view) is the point: the
+ * page table must know what is no longer visible, including coordinates the closet could
+ * not fit inside its byte budget — precisely the ones the agent will later reach for and
+ * not find.
+ *
+ * Detection runs against the LAST message only: that is the turn the agent just produced,
+ * and re-scanning retained history would re-fire hints for text that never went away. */
+static void recall_track(const cJSON *original, int evicted_count, const reduce_config_t *cfg,
+                         reduce_state_t *st, reduce_result_t *out)
+{
+   if (!cfg->recall_enabled || !st || !cJSON_IsArray((cJSON *)original))
+      return;
+
+   int n = cJSON_GetArraySize((cJSON *)original);
+   if (evicted_count > n)
+      evicted_count = n;
+   for (int i = 0; i < evicted_count; i++)
+   {
+      cJSON *m = cJSON_GetArrayItem((cJSON *)original, i);
+      char *txt = m ? cJSON_PrintUnformatted(m) : NULL;
+      if (!txt)
+         continue;
+      fold_recall_index_add_from_text(&st->recall, txt, strlen(txt));
+      free(txt);
+   }
+
+   if (st->recall.count == 0 || n == 0)
+      return;
+
+   cJSON *last = cJSON_GetArrayItem((cJSON *)original, n - 1);
+   char *last_txt = last ? cJSON_PrintUnformatted(last) : NULL;
+   if (!last_txt)
+      return;
+
+   dstr_t hints;
+   dstr_init(&hints);
+   size_t surfaced =
+       fold_recall_detect(&st->recall, last_txt, st->turn, cfg->recall_ttl_turns, &hints);
+   free(last_txt);
+
+   if (surfaced > 0 && dstr_cstr(&hints))
+   {
+      out->recall_hint = strdup(dstr_cstr(&hints));
+      out->recall_surfaced = (int)surfaced;
+   }
+   dstr_free(&hints);
 }
 
 /* chars/4 token estimate of the first `count` items of an array — the fold-eligible
@@ -299,6 +354,11 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
                cJSON_Delete(compressed_owned);
                compressed_owned = NULL;
             }
+            /* The fold is the only lever that removes whole messages, so it is the
+             * only one whose eviction the page table must record. Compression shrinks
+             * bodies in place — the carrying message stays visible, so nothing has
+             * left the prompt to page back in. */
+            recall_track(messages, fr.folded_msgs, cfg, st, out);
          }
          fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
       }

--- a/src/modules/economizer/context_reduce.h
+++ b/src/modules/economizer/context_reduce.h
@@ -44,6 +44,7 @@
 #define DEC_CONTEXT_REDUCE_H 1
 
 #include "context_fold.h" /* fold_config_t, fold_freeze_t (reused, not duplicated) */
+#include "fold_recall.h"  /* §4 page table carried in reduce_state_t */
 #include <cJSON.h>
 
 #ifdef __cplusplus
@@ -90,6 +91,12 @@ extern "C"
       int freeze_guard_enabled;
       int freeze_guard_horizon; /* expected reuse turns for break-even (0 -> 1) */
 
+      /* §4 page table. Requires `st`: the index has to outlive a single call, so with
+       * no per-conversation state there is nowhere to record what was evicted and the
+       * lever stays inert. */
+      int recall_enabled;
+      int recall_ttl_turns; /* anti-thrash residency; 0 -> FOLD_RECALL_DEFAULT_TTL_TURNS */
+
       fold_config_t fold; /* history-fold sub-config (reused verbatim) */
    } reduce_config_t;
 
@@ -107,6 +114,13 @@ extern "C"
       int reduced;          /* provenance: set once a seam has reduced this request
                              * set -> a second seam re-measures but does NOT re-reduce */
       int turn;             /* current turn index (freeze residency + ledger) */
+
+      /* §4 page table: coordinates that have LEFT the prompt in this conversation, so
+       * a later turn re-touching one can be told it is pageable rather than gone. This
+       * is what makes eviction reversible; it must persist across turns, which is why
+       * it lives here and not inside a single fold call. Owned by the caller: release
+       * with fold_recall_index_free() when the conversation ends. */
+      fold_recall_index_t recall;
    } reduce_state_t;
 
    /* Why a request did/didn't reduce — recorded in the ledger for auditability. */
@@ -167,6 +181,15 @@ extern "C"
       int reused_boundary; /* 1 = freeze reused (cache-warm) */
       int epochs;
       int freeze_guarded; /* 1 = the cost guardrail disabled freeze this turn */
+
+      /* §4: bounded recall hints for folded coordinates the NEWEST turn re-touched,
+       * or NULL when none fired. Freed by context_reduce_result_free.
+       *
+       * Reported rather than injected: where a hint belongs in the transcript is a
+       * provider-shaped decision (role alternation, content-block vs string), and the
+       * reducer does not own that. The caller surfaces it. */
+      char *recall_hint;
+      int recall_surfaced; /* number of coordinates surfaced this turn */
    } reduce_result_t;
 
    /* Run the economizer for one request at one seam.

--- a/src/modules/economizer/fold_recall.c
+++ b/src/modules/economizer/fold_recall.c
@@ -1,6 +1,7 @@
 /* fold_recall.c: page folded content back in on re-touch (fold §4, P4).
  * See fold_recall.h. Pure: dstr + libc only. */
 #include "fold_recall.h"
+#include "coord_closet.h" /* nomination: the page table reuses the closet's matchers */
 
 #include <stdlib.h>
 #include <string.h>
@@ -92,6 +93,31 @@ void fold_recall_index_add(fold_recall_index_t *ix, const char *key)
    ix->keys[ix->count] = copy;
    ix->last_turn[ix->count] = -1;
    ix->count++;
+}
+
+size_t fold_recall_index_add_from_text(fold_recall_index_t *ix, const char *text, size_t len)
+{
+   if (!ix || !text || len == 0)
+      return 0;
+
+   coord_set_t set;
+   coord_set_init(&set);
+   /* Provenance is irrelevant here: the page table stores addresses, not conserved
+    * values, and never renders them into the prompt as trusted content. */
+   coord_closet_nominate(text, len, NULL, &set);
+
+   size_t before = ix->count;
+   for (size_t i = 0; i < set.count; i++)
+   {
+      if (!set.items[i].value)
+         continue;
+      /* Addresses only — see the header. */
+      if (set.items[i].kind != COORD_KIND_PATH && set.items[i].kind != COORD_KIND_HANDLE)
+         continue;
+      fold_recall_index_add(ix, set.items[i].value);
+   }
+   coord_set_free(&set);
+   return ix->count - before;
 }
 
 size_t fold_recall_detect(fold_recall_index_t *ix, const char *turn_text, int turn, int ttl_turns,

--- a/src/modules/economizer/fold_recall.h
+++ b/src/modules/economizer/fold_recall.h
@@ -36,6 +36,21 @@ extern "C"
    void fold_recall_index_init(fold_recall_index_t *ix);
    void fold_recall_index_free(fold_recall_index_t *ix);
 
+   /* Harvest recall keys out of `text` and add them (deduplicated) to the index.
+    *
+    * Only coordinates that NAME SOMETHING A RESOLVER CAN FETCH become recall keys:
+    * paths (code_span_get) and handle:/memory: ids (memory_get). A sha, a uuid, a
+    * digit-bearing key=value or an issue ref is a fact worth conserving verbatim in
+    * the closet, but it is not an ADDRESS — there is nothing to page back in, so a
+    * recall hint for one would be noise the agent cannot act on.
+    *
+    * Called on the region being evicted, so the page table records what LEFT the
+    * prompt — deliberately including coordinates the closet could not fit inside its
+    * byte budget, which are exactly the ones most in need of a later hint.
+    *
+    * Returns the number of NEW keys added. */
+   size_t fold_recall_index_add_from_text(fold_recall_index_t *ix, const char *text, size_t len);
+
    /* Add a recall key (path / handle:id / memory:id) if not already present.
     * Copies the string. Empty/NULL keys are ignored. */
    void fold_recall_index_add(fold_recall_index_t *ix, const char *key);

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -820,6 +820,8 @@ native_provider_http:
             rcfg.fold.closet.budget_bytes = config_coord_closet_budget_bytes();
             rcfg.fold.closet.max_ratio_pct = config_coord_closet_max_ratio_pct();
             rcfg.fold.closet.denylist = closet_denylist[0] ? closet_denylist : NULL;
+            rcfg.recall_enabled = config_fold_recall_enabled();
+            rcfg.recall_ttl_turns = config_fold_recall_ttl_turns();
             agent_reduce_state.reduced = 0;
             agent_reduce_state.turn = turn;
             if (context_reduce(messages, sys, fb_agent.model, NULL, REDUCE_SEAM_DELEGATE, &rcfg,
@@ -1927,6 +1929,8 @@ native_provider_http:
    cJSON_Delete(tools);
    cJSON_Delete(messages);
    free(assembled_sys);
+   /* The §4 page table grows across the whole run and owns its keys. */
+   fold_recall_index_free(&agent_reduce_state.recall);
 
    /* Cleanup ephemeral SSH */
    if (has_ephemeral_ssh)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -4318,6 +4318,7 @@ $(TESTPREFIX)/unit-test-fold-register: $(OBJDIR)/tests/test_fold_register.o $(OB
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-fold-recall: $(OBJDIR)/tests/test_fold_recall.o $(OBJDIR)/modules/economizer/fold_recall.o \
+                                  $(OBJDIR)/modules/economizer/coord_closet.o \
                                   $(OBJDIR)/dstr.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -214,6 +214,89 @@ static void test_history_fold_reduces(void)
    PASS("history_fold reduces: new folded array, original untouched");
 }
 
+/* §4 page table, end to end through the orchestrator: a coordinate that is FOLDED AWAY
+ * and then referenced again by the newest turn produces a recall hint, so the agent
+ * learns the content is pageable rather than gone. This is the property that makes
+ * eviction reversible; without it the fold is destructive. */
+static void test_recall_hint_on_retouch(void)
+{
+   cJSON *m = make_messages(20); /* 40 messages; the prefix folds away */
+
+   /* Put an address deep in the prefix (evicted), then re-touch it in the newest turn
+    * (retained). Anything in the retained tail was never evicted, so a hint proves the
+    * key came from the folded region rather than from text still in view. */
+   cJSON *early = cJSON_GetArrayItem(m, 1);
+   cJSON_ReplaceItemInObject(early, "content",
+                             cJSON_CreateString("inspect src/modules/git/retry.c closely, it is "
+                                                "the file that matters for this task"));
+   cJSON *last = cJSON_GetArrayItem(m, cJSON_GetArraySize(m) - 1);
+   cJSON_ReplaceItemInObject(last, "content",
+                             cJSON_CreateString("what did we conclude about "
+                                                "src/modules/git/retry.c ?"));
+
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1;
+   cfg.fold.closet.enabled = 1;
+   cfg.recall_enabled = 1;
+
+   reduce_state_t st = {0};
+   st.turn = 7;
+   reduce_result_t out;
+   assert(context_reduce(m, "system prompt here", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st,
+                         &out) == 0);
+   assert(out.mutated == 1);
+   assert(out.folded_msgs > 0);
+
+   assert(out.recall_surfaced >= 1);
+   assert(out.recall_hint != NULL);
+   assert(strstr(out.recall_hint, "src/modules/git/retry.c") != NULL);
+   /* The hint names the resolvers, so the agent knows how to act on it. */
+   assert(strstr(out.recall_hint, "code_span_get") != NULL);
+
+   /* The page table persists in the caller-owned state, not in the result. */
+   assert(st.recall.count > 0);
+
+   context_reduce_result_free(&out);
+   assert(out.recall_hint == NULL); /* freed with the result */
+   fold_recall_index_free(&st.recall);
+   cJSON_Delete(m);
+   PASS("recall hint fires when the newest turn re-touches a folded coordinate");
+}
+
+/* Default-off stays off: with the lever disabled nothing is tracked and no hint is
+ * produced, so enabling it is an explicit choice and the reducer is unchanged without. */
+static void test_recall_disabled_is_inert(void)
+{
+   cJSON *m = make_messages(20);
+   cJSON *early = cJSON_GetArrayItem(m, 1);
+   cJSON_ReplaceItemInObject(early, "content",
+                             cJSON_CreateString("inspect src/modules/git/retry.c closely here"));
+   cJSON *last = cJSON_GetArrayItem(m, cJSON_GetArraySize(m) - 1);
+   cJSON_ReplaceItemInObject(last, "content",
+                             cJSON_CreateString("what about src/modules/git/retry.c ?"));
+
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1;
+   cfg.fold.closet.enabled = 1;
+   cfg.recall_enabled = 0; /* the lever under test */
+
+   reduce_state_t st = {0};
+   reduce_result_t out;
+   assert(context_reduce(m, "system prompt here", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st,
+                         &out) == 0);
+   assert(out.mutated == 1);
+   assert(out.recall_hint == NULL);
+   assert(out.recall_surfaced == 0);
+   assert(st.recall.count == 0);
+
+   context_reduce_result_free(&out);
+   fold_recall_index_free(&st.recall);
+   cJSON_Delete(m);
+   PASS("recall disabled: nothing tracked, no hint");
+}
+
 /* Net-gain pre-check: foldable below min_gain_tokens -> skip, no mutation. */
 static void test_history_fold_skip_no_gain(void)
 {
@@ -421,6 +504,8 @@ int main(void)
    test_provenance_already_reduced();
    test_unpriced_model_no_cost();
    test_history_fold_reduces();
+   test_recall_hint_on_retouch();
+   test_recall_disabled_is_inert();
    test_history_fold_skip_no_gain();
    test_compress_engages_where_fold_cannot();
    test_compress_measure_only_no_mutation();

--- a/src/tests/test_fold_recall.c
+++ b/src/tests/test_fold_recall.c
@@ -104,9 +104,69 @@ static void test_whole_token_match(void)
    PASS("whole_token_match");
 }
 
+/* Harvesting turns evicted text into a page table. Only ADDRESSES become keys: a sha or
+ * an issue ref is a fact the closet conserves verbatim, but there is nothing to page back
+ * in, so a recall hint for one would be noise the agent cannot act on. */
+static void test_harvest_addresses_only(void)
+{
+   fold_recall_index_t ix;
+   fold_recall_index_init(&ix);
+
+   const char *evicted = "Edited src/modules/git/retry.c and /var/lib/aimee/state, see "
+                         "memory:8817 and handle:abc12. Commit "
+                         "4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162 closes #778, "
+                         "retries=5.";
+   size_t added = fold_recall_index_add_from_text(&ix, evicted, strlen(evicted));
+   assert(added == ix.count);
+   assert(ix.count > 0);
+
+   dstr_t hints;
+   dstr_init(&hints);
+   /* Re-touch every candidate at once; whatever is in the table surfaces. */
+   const char *turn = "look again at src/modules/git/retry.c /var/lib/aimee/state memory:8817 "
+                      "handle:abc12 4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162 #778 retries=5";
+   fold_recall_detect(&ix, turn, 1, 4, &hints);
+   const char *h = dstr_cstr(&hints);
+   assert(h);
+
+   /* Addresses: pageable via code_span_get / memory_get. */
+   assert(has(h, "src/modules/git/retry.c"));
+   assert(has(h, "/var/lib/aimee/state"));
+   assert(has(h, "memory:8817"));
+   assert(has(h, "handle:abc12"));
+
+   /* Not addresses: conserved elsewhere, never a recall hint. */
+   assert(!has(h, "4a7f19c2b8e30d15f6a2c9b40e7d3814aa9c5162"));
+   assert(!has(h, "#778"));
+   assert(!has(h, "retries=5"));
+
+   dstr_free(&hints);
+   fold_recall_index_free(&ix);
+   PASS("harvest_addresses_only");
+}
+
+/* Harvesting is idempotent: folding turn after turn must not grow the table with
+ * duplicates of coordinates already evicted. */
+static void test_harvest_dedups_across_calls(void)
+{
+   fold_recall_index_t ix;
+   fold_recall_index_init(&ix);
+   const char *t = "src/a/b.c and memory:7";
+   size_t first = fold_recall_index_add_from_text(&ix, t, strlen(t));
+   size_t before = ix.count;
+   size_t second = fold_recall_index_add_from_text(&ix, t, strlen(t));
+   assert(first > 0);
+   assert(second == 0);
+   assert(ix.count == before);
+   fold_recall_index_free(&ix);
+   PASS("harvest_dedups_across_calls");
+}
+
 int main(void)
 {
    printf("fold_recall tests:\n");
+   test_harvest_addresses_only();
+   test_harvest_dedups_across_calls();
    test_add_dedup();
    test_detect_and_ttl();
    test_empty_and_null();


### PR DESCRIPTION
## Summary

S2d of the context-paging programme ([proposal](../blob/testing/docs/proposals/pending/context-paging-s2-s5.md)), and its keystone.

Until an evicted coordinate can be **paged back in**, folding is destructive — which is why compaction has to be late, which is why it lands as a cliff the user waits on. Everything else in the programme depends on this one property.

`fold_recall` already had every piece except the wiring: the index, whole-token detection, a residency TTL, and hint text that already names `code_span_get` / `memory_get`. It had **zero live callers**. This connects it.

## What changes

- **`fold_recall_index_add_from_text()`** harvests a page table out of evicted text, reusing the closet's matchers rather than growing a second set.
- **Addresses only.** Paths and `handle:` / `memory:` ids name something a resolver can fetch. A sha, uuid, issue ref or `key=value` is a fact the closet conserves verbatim, but there is nothing to page back in — a hint for one is noise the agent cannot act on.
- **The index lives in `reduce_state_t`**, which is per-conversation and outlives a single call. A page table that died with one fold would be pointless.
- **Harvest from the ORIGINAL evicted region**, deliberately including coordinates the closet could not fit inside its byte budget. Those are precisely the ones the agent will later reach for and not find.
- **Only the fold is tracked.** Compression shrinks bodies in place and the carrying message stays visible, so nothing has left the prompt.
- **Detection runs against the newest turn only.** Scanning retained history would re-fire hints for text that never went away.

## Reported, not injected

Hints land on `reduce_result_t.recall_hint`, not in the transcript.

Where a hint belongs is a provider-shaped decision — role alternation, content-block vs string — and the reducer does not own that. The caller surfaces it. Injection is the follow-up slice, deliberately separated because it is the risky half and this is the substantive half.

## Default flip

`fold_recall_enabled` goes **0 → 1**. It only ever adds a bounded hint when the newest turn re-touches something already evicted, so the cost is a few lines of text and the benefit is not losing the thread.

Wired at the **delegate seam** (`agent_runtime`). The gateway seam does not set `recall_enabled`, so it stays inert there until that seam has per-conversation state to hold the table — noted rather than half-wired.

## Tests

Unit, on the harvester:
- addresses become keys; sha / `#778` / `retries=5` explicitly do **not**
- harvesting is idempotent across turns (no duplicate growth)

End to end through `context_reduce`, which is what actually proves the wiring:
- a coordinate folded away and then referenced by the newest turn produces a hint naming `code_span_get`
- the page table persists in caller-owned state, and the hint is freed with the result
- with the lever off: nothing tracked, no hint, `st.recall.count == 0`

The end-to-end test is honest by construction: harvesting only runs over the evicted region, so a hint cannot come from text still in view.

## Verification

- `rm -f aimee-server && make -C src -j8 ../aimee-server` — exit 0, zero undefined references
- `make -C src -j8 ../aimee-kb` — exit 0
- `make -C src -j8 cmd-srcs-compile-check` — exit 0
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — all checks passed (`make -C src format` run first)
- `check_c_repository_lock` — config digest repinned
- `refactor_baselines` — no drift

## Next

S2a/S2b/S2c (bind `task_rail` and `episode_seal`, promote `reduce_state_t` off the stack) are independent of each other and now unblocked. S3's continuous paging is gated on this slice, since evicting aggressively is only safe once eviction is reversible.