### PR TITLE
feat(delegates): sandbox image selection and build spec, in the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "00ba96a8ee9f099bf547715a8c6cf5d89869eb0b7d887b414a970b27e16cafb2",
+      "source_sha256": "e33efdbdbdee688a7a0c156c25dcf48ada8f4ebdfb17c7dc036e54adbba21754",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/sandboximage.go
+++ b/server-go/modules/delegates/sandboximage.go
@@ -1,0 +1,155 @@
+package delegates
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// Which image a delegate's sandbox runs, and how one is built from a spec.
+//
+// The sandbox has no network, so its toolchain has to be baked into the image
+// at build time -- a Rust repo needs cargo, a C repo gcc and make, a docs repo
+// nothing. A project can therefore declare a base image plus packages, and a
+// derived image is built once and reused by content.
+//
+// The build itself is I/O and belongs to the caller. Deciding WHAT to build --
+// and refusing a specification that would smuggle shell into the build -- is a
+// decision and lives here.
+
+const sandboxTagPrefix = "aimee-sbx:"
+
+// sandboxTagHexLen is how much of the content hash names the image. Twelve hex
+// characters matches the existing tags, so images built before this code are
+// still found and reused rather than silently rebuilt.
+const sandboxTagHexLen = 12
+
+// packageNameValid reports whether a package name is safe to place in a build
+// RUN line.
+//
+// This is the injection boundary. The name goes into a shell command inside
+// `docker build`, so anything outside this set -- a space, a semicolon, a
+// backtick, $( -- would let a project's config file run arbitrary commands
+// during the build, which happens WITH network access. Must start
+// alphanumeric, then alphanumerics and . _ + : - only.
+func packageNameValid(pkg string) bool {
+	if pkg == "" {
+		return false
+	}
+	if !isAlnum(pkg[0]) {
+		return false
+	}
+	for i := 0; i < len(pkg); i++ {
+		c := pkg[i]
+		if isAlnum(c) || c == '.' || c == '_' || c == '+' || c == ':' || c == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// baseImageValid allows what an image reference legitimately contains. Same
+// injection boundary as a package name, plus '/' for registry and repository
+// segments.
+func baseImageValid(base string) bool {
+	if base == "" {
+		return false
+	}
+	for i := 0; i < len(base); i++ {
+		c := base[i]
+		if isAlnum(c) || c == '.' || c == '_' || c == '+' || c == ':' || c == '-' || c == '/' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// SandboxDockerfile renders the build for a base image plus packages.
+//
+// With no packages the result is just the FROM line: a project that names a
+// base and installs nothing should not get an apt invocation it never asked
+// for. The apt list is removed in the same layer so the image does not carry
+// the package index around.
+func SandboxDockerfile(base string, packages []string) (string, error) {
+	if !baseImageValid(base) {
+		return "", fmt.Errorf("invalid base image reference: %q", base)
+	}
+	for _, pkg := range packages {
+		if !packageNameValid(pkg) {
+			return "", fmt.Errorf("invalid package name: %q", pkg)
+		}
+	}
+	if len(packages) == 0 {
+		return fmt.Sprintf("FROM %s\n", base), nil
+	}
+	return fmt.Sprintf(
+		"FROM %s\n"+
+			"RUN apt-get update && apt-get install -y --no-install-recommends %s && "+
+			"rm -rf /var/lib/apt/lists/*\n",
+		base, strings.Join(packages, " ")), nil
+}
+
+// SandboxContentTag names an image by what it contains, so identical content
+// resolves to the same tag and an already-built image is reused instead of
+// rebuilt.
+func SandboxContentTag(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return sandboxTagPrefix + hex.EncodeToString(sum[:])[:sandboxTagHexLen]
+}
+
+// SandboxImageSource is where a resolved image came from. The order is the
+// precedence order, most specific first.
+type SandboxImageSource int
+
+const (
+	// SandboxImageNone means nothing was configured and the caller should use
+	// its default image.
+	SandboxImageNone SandboxImageSource = iota
+	// SandboxImageProject is the repo's own declaration -- it travels with the
+	// code, because the code knows what toolchain it needs.
+	SandboxImageProject
+	// SandboxImageWorkspace is a per-workspace override.
+	SandboxImageWorkspace
+	// SandboxImageGlobal is the installation-wide default.
+	SandboxImageGlobal
+)
+
+// SandboxImageCandidates is what the caller found configured. Each is the image
+// reference or empty. Reading the files is the caller's job; choosing between
+// them is the rule.
+type SandboxImageCandidates struct {
+	Project   string
+	Workspace string
+	Global    string
+}
+
+// ResolveSandboxImage picks the image, most specific first.
+//
+// The project's own declaration wins because it travels with the code: a repo
+// that says it needs a Rust toolchain is right about that regardless of what
+// the workspace or the installation prefers. An invalid reference is refused
+// rather than silently skipped -- falling through to a less specific image
+// would run the delegate with a toolchain nobody chose.
+func ResolveSandboxImage(c SandboxImageCandidates) (string, SandboxImageSource, error) {
+	for _, candidate := range []struct {
+		ref    string
+		source SandboxImageSource
+	}{
+		{c.Project, SandboxImageProject},
+		{c.Workspace, SandboxImageWorkspace},
+		{c.Global, SandboxImageGlobal},
+	} {
+		if candidate.ref == "" {
+			continue
+		}
+		if !baseImageValid(candidate.ref) {
+			return "", SandboxImageNone,
+				fmt.Errorf("invalid sandbox image reference: %q", candidate.ref)
+		}
+		return candidate.ref, candidate.source, nil
+	}
+	return "", SandboxImageNone, nil
+}

--- a/server-go/modules/delegates/sandboximage_test.go
+++ b/server-go/modules/delegates/sandboximage_test.go
@@ -1,0 +1,149 @@
+package delegates
+
+import (
+	"strings"
+	"testing"
+)
+
+// The injection boundary. A package name goes into a shell command inside
+// `docker build`, and that build runs WITH network access -- so anything that
+// escapes the name is arbitrary code execution during image construction.
+func TestSandboxDockerfileRefusesShellInPackageNames(t *testing.T) {
+	hostile := []string{
+		"curl; rm -rf /",
+		"curl && wget evil",
+		"$(id)",
+		"`id`",
+		"pkg|tee",
+		"pkg>out",
+		"pkg out",          // a space is two arguments
+		"pkg\nRUN evil",    // a newline is a new Dockerfile instruction
+		"-flag",            // must start alphanumeric
+		"",                 // empty
+		"pkg'quote",
+		"pkg\"quote",
+		"pkg\\escape",
+	}
+	for _, pkg := range hostile {
+		if _, err := SandboxDockerfile("ubuntu:22.04", []string{pkg}); err == nil {
+			t.Errorf("accepted hostile package name %q", pkg)
+		}
+	}
+}
+
+// Real package names must still work, including the punctuation Debian uses.
+func TestSandboxDockerfileAcceptsRealPackageNames(t *testing.T) {
+	packages := []string{"gcc", "make", "g++", "libssl-dev", "python3.11", "gcc:amd64", "ca_certs"}
+	df, err := SandboxDockerfile("ubuntu:22.04", packages)
+	if err != nil {
+		t.Fatalf("rejected real package names: %v", err)
+	}
+	for _, pkg := range packages {
+		if !strings.Contains(df, pkg) {
+			t.Errorf("%q missing from the dockerfile", pkg)
+		}
+	}
+	if !strings.HasPrefix(df, "FROM ubuntu:22.04\n") {
+		t.Errorf("dockerfile does not start with the base: %q", df)
+	}
+	// The package index must not be left in the image.
+	if !strings.Contains(df, "rm -rf /var/lib/apt/lists/*") {
+		t.Error("apt lists are not cleaned up in the same layer")
+	}
+}
+
+// A base reference is the same injection boundary, and legitimately contains
+// registry and repository separators.
+func TestSandboxDockerfileBaseValidation(t *testing.T) {
+	for _, base := range []string{
+		"ubuntu:22.04",
+		"ghcr.io/org/image:tag",
+		"registry.example.com:5000/team/img:1.2.3",
+	} {
+		if _, err := SandboxDockerfile(base, nil); err != nil {
+			t.Errorf("rejected valid base %q: %v", base, err)
+		}
+	}
+	for _, base := range []string{
+		"", "ubuntu:22.04 && evil", "$(id)", "ubuntu\nRUN evil", "ubuntu;rm",
+	} {
+		if _, err := SandboxDockerfile(base, nil); err == nil {
+			t.Errorf("accepted hostile base %q", base)
+		}
+	}
+}
+
+// A project that names a base and installs nothing should not get an apt
+// invocation it never asked for.
+func TestSandboxDockerfileWithNoPackagesIsJustTheBase(t *testing.T) {
+	df, err := SandboxDockerfile("ubuntu:22.04", nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if df != "FROM ubuntu:22.04\n" {
+		t.Errorf("dockerfile = %q, want only the FROM line", df)
+	}
+}
+
+// Identical content must resolve to the same tag, or every turn rebuilds an
+// image that already exists.
+func TestSandboxContentTagIsStableAndContentAddressed(t *testing.T) {
+	a, _ := SandboxDockerfile("ubuntu:22.04", []string{"gcc", "make"})
+	again, _ := SandboxDockerfile("ubuntu:22.04", []string{"gcc", "make"})
+	different, _ := SandboxDockerfile("ubuntu:22.04", []string{"gcc"})
+
+	if SandboxContentTag(a) != SandboxContentTag(again) {
+		t.Error("the same content produced two different tags")
+	}
+	if SandboxContentTag(a) == SandboxContentTag(different) {
+		t.Error("different content produced the same tag")
+	}
+	tag := SandboxContentTag(a)
+	if !strings.HasPrefix(tag, "aimee-sbx:") {
+		t.Errorf("tag = %q, want the aimee-sbx prefix", tag)
+	}
+	// The existing tag shape must be preserved or previously built images stop
+	// being found and every sandbox rebuilds.
+	if got := len(strings.TrimPrefix(tag, "aimee-sbx:")); got != 12 {
+		t.Errorf("tag hash length = %d, want 12", got)
+	}
+}
+
+// The repo's own declaration wins: a project that says it needs a Rust
+// toolchain is right about that, whatever the workspace or installation prefers.
+func TestResolveSandboxImagePrecedence(t *testing.T) {
+	all := SandboxImageCandidates{
+		Project: "proj:1", Workspace: "ws:1", Global: "glob:1",
+	}
+	ref, source, err := ResolveSandboxImage(all)
+	if err != nil || ref != "proj:1" || source != SandboxImageProject {
+		t.Errorf("ref=%q source=%v err=%v, want the project image", ref, source, err)
+	}
+
+	ref, source, _ = ResolveSandboxImage(SandboxImageCandidates{Workspace: "ws:1", Global: "glob:1"})
+	if ref != "ws:1" || source != SandboxImageWorkspace {
+		t.Errorf("ref=%q source=%v, want the workspace image", ref, source)
+	}
+
+	ref, source, _ = ResolveSandboxImage(SandboxImageCandidates{Global: "glob:1"})
+	if ref != "glob:1" || source != SandboxImageGlobal {
+		t.Errorf("ref=%q source=%v, want the global image", ref, source)
+	}
+
+	// Nothing configured is not an error: the caller runs its default image.
+	ref, source, err = ResolveSandboxImage(SandboxImageCandidates{})
+	if ref != "" || source != SandboxImageNone || err != nil {
+		t.Errorf("ref=%q source=%v err=%v, want no image and no error", ref, source, err)
+	}
+}
+
+// Falling through to a less specific image would run the delegate with a
+// toolchain nobody chose, so an invalid reference is refused instead.
+func TestResolveSandboxImageRefusesRatherThanFallingThrough(t *testing.T) {
+	_, _, err := ResolveSandboxImage(SandboxImageCandidates{
+		Project: "evil;rm -rf /", Global: "ubuntu:22.04",
+	})
+	if err == nil {
+		t.Error("an invalid project image silently fell through to the global default")
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -87,7 +87,8 @@
     "server-go/modules/delegates/patchcoord_stage.go",
     "server-go/modules/delegates/rolepolicy.go",
     "server-go/modules/delegates/sandbox.go",
-    "server-go/modules/delegates/isolation.go"
+    "server-go/modules/delegates/isolation.go",
+    "server-go/modules/delegates/sandboximage.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -105,7 +106,8 @@
     "server-go/modules/delegates/patchcoord_stage_test.go",
     "server-go/modules/delegates/rolepolicy_test.go",
     "server-go/modules/delegates/sandbox_test.go",
-    "server-go/modules/delegates/isolation_test.go"
+    "server-go/modules/delegates/isolation_test.go",
+    "server-go/modules/delegates/sandboximage_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",


### PR DESCRIPTION
feat(delegates): sandbox image selection and build spec, in the module

The sandbox has no network, so its toolchain must be baked into the image at
build time -- a Rust repo needs cargo, a C repo gcc and make, a docs repo
nothing. A project therefore declares a base image plus packages and a derived
image is built once and reused by content. Deciding WHAT to build is a decision
and now lives in server-go/modules/delegates/sandboximage.go; running `docker
build` stays with the caller.

PACKAGE AND BASE NAMES ARE AN INJECTION BOUNDARY, and that is the point of this
slice. A name goes into a shell command inside `docker build`, and unlike the
delegate sandbox itself that build runs WITH network access. A project's config
file is therefore an execution vector: `packages: ["curl; rm -rf /"]` or a name
containing $(...), a backtick, a pipe, or a newline that opens a second
Dockerfile instruction. Names must start alphanumeric and contain only
alphanumerics and . _ + : - ; a base reference may additionally contain / for
registry and repository segments. Thirteen hostile package names and five
hostile bases are pinned by test.

An invalid reference is REFUSED rather than skipped. Falling through to the next
candidate would run the delegate on a toolchain nobody chose -- a project
declaring a broken image would silently get the installation default and its
build would fail in a way that points at the wrong thing.

Precedence is most specific first: the repo's own declaration, then a
per-workspace override, then the global default. The project wins because it
travels with the code -- a repo that says it needs a Rust toolchain is right
about that whatever the workspace or the installation prefers. Nothing
configured is not an error; the caller runs its default image.

The content tag keeps its existing shape, aimee-sbx: plus twelve hex characters
of the content hash. That is pinned by test on purpose: shortening or
lengthening it would stop previously built images from being found, and every
sandbox would rebuild while appearing to work.

With no packages the result is only the FROM line. A project that names a base
and installs nothing should not get an apt invocation it never asked for, and
the apt lists are removed in the same layer so the image does not carry the
package index.

isAlnum is reused from rescue.go rather than redeclared -- the build caught the
duplicate.
