### PR TITLE
fix(server): stop logging every successful runner long poll

### DIFF
--- a/src/headers/server_http_internal.h
+++ b/src/headers/server_http_internal.h
@@ -145,6 +145,12 @@ uint32_t server_http_enrollment_caps(uint32_t caps, int is_tcp, int mtls_authent
 void server_http_gzip_set(int enabled);
 int server_http_gzip_peek(void);
 
+/* One access-log line per served request (server_http_response.c). Demotes the
+ * shapes that are noise BY DESIGN — see the definition — so the log stays
+ * readable; everything else logs at INFO as before. */
+void server_http_log_access(const char *method, const char *path, int status,
+                            const char *request_id);
+
 /* PC2: CI webhook route handler (defined in server_ci_route.c). */
 int rh_dev_ci_event(const route_req_t *rq, char *resp, int cap);
 

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -2081,7 +2081,7 @@ void handle_conn(int fd, int is_tcp, int is_management)
    g_rpc_conn_caps = CAPS_READ_ONLY;
    server_http_identity_clear();
    send_response(fd, status, resp, request_id);
-   LOG_INFO("server.http", "%s %s -> %d req_id=%s", method, path, status, request_id);
+   server_http_log_access(method, path, status, request_id);
    free(resp);
    free(body);
 }

--- a/src/server/server_http_response.c
+++ b/src/server/server_http_response.c
@@ -210,3 +210,28 @@ int server_http_gzip_peek(void)
 {
    return tl_gzip;
 }
+
+/* One access-log line per served request.
+ *
+ * A LONG POLL THAT SUCCEEDS IS NOT NEWS. /v1/runner/poll is re-issued the
+ * instant it answers — that is the design — so logging every 200 writes one
+ * line per poll per serving client, forever. Measured on the test appliance:
+ * 196,310 of the last 200,000 lines were this one line; 98% of a 612 MiB
+ * unrotated server.log accumulated in under four days. It buries everything
+ * worth reading, and did: a credential warning sat unnoticed in that file for
+ * hours because the signal-to-noise made it unreadable.
+ *
+ * DEMOTED, NOT DELETED, and only for the 2xx shape. A poll that FAILS still
+ * logs at INFO, which is the case anyone debugging actually wants — dropping
+ * those would trade a noise problem for a blindness one. Same treatment, and
+ * the same reasoning, as the unauthenticated health probe in server_http.c. */
+void server_http_log_access(const char *method, const char *path, int status,
+                            const char *request_id)
+{
+   int quiet_poll = status >= 200 && status < 300 && method && path &&
+                    strcmp(method, "POST") == 0 && strcmp(path, "/v1/runner/poll") == 0;
+   if (quiet_poll)
+      LOG_DEBUG("server.http", "%s %s -> %d req_id=%s", method, path, status, request_id);
+   else
+      LOG_INFO("server.http", "%s %s -> %d req_id=%s", method, path, status, request_id);
+}

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1131,7 +1131,7 @@
         },
         {
           "path": "src/headers/server_http_internal.h",
-          "sha256": "631e81081f4dc57d2dead956a78ec78409ac11bb1f169322321e28e08882f43c"
+          "sha256": "d2495674db42784189be8dee3951c079a50b6f501d1285364e78ea1f552324e9"
         },
         {
           "path": "src/headers/server_identity_token.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "146d009debc4aacb903884b3cf382732c2f4294615fe959b82f4e4deb5048414",
+      "sha256": "68748ab07e630453d7236d9a2392bacfebe18419afe48c6967e4ced13c57ea57",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## The measurement

`/v1/runner/poll` is re-issued the instant it answers — that is what a long poll **is** — so an access line per `200` writes one line per poll per serving client, forever.

On the test appliance, the last 200,000 lines of `server.log`:

```
196310  INFO  server.http: POST /v1/runner/poll -> 200
  3237  INFO  server.http: GET /v1/health -> 401 (mtls required)
   103  INFO  git: forge credential ... resolved from: per-host vault entry
```

**98% of the file is this one line.** 612 MiB accumulated in **under four days** — ~162 MiB and ~1.95 M lines per day — on a disk already at 83%, with no rotation.

## The cost is not only disk

It buries everything worth reading, and it did. A credential warning sat unread in that file for hours because the surrounding noise made it unusable, and several wrong conclusions followed from reading a different sink instead.

## Demoted, not deleted

Only the **2xx** shape moves to `DEBUG`. A poll that **fails** still logs at `INFO` — that is the case anyone debugging actually wants, and dropping it would trade a noise problem for a blindness one.

This is the same treatment, and the same reasoning, already applied a few lines above to the unauthenticated health probe (a `401` every 10 s from the container healthcheck).

## Why the logic is not in `server_http.c`

That file sits **exactly on** the 2500-line `line-check` ceiling. My first version put the predicate inline, pushed it to 2515, and failed the gate. The predicate now lives in `server_http_response.c` — which already owns response handling and has room — and the call site is **one line for one line**, so `server_http.c` is back to 2500 exactly.

That mirrors what the repo already did when it split `server_runner_endpoints.c` out of `server_state.c` for the same reason.

## Not addressed here

- **Whatever is polling this endpoint so hard.** The line is noise by design, but the volume suggests a caller that should not be polling this hard — the same open question as #2511.
- **`server.log` has no rotation.** Even at sane volume it grows without bound.

Both are real and both are separate from this change.

## Verification

- All three real links rc=0: `rm -f aimee-server && make -C src -j8 ../aimee-server`, `../aimee-kb`, `cmd-srcs-compile-check`
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src format` then `make -C src lint` — **48/48, including `line-check`**
- `check_c_repository_lock` ok
- A header changed, so `refactor_baselines` was verified additive (no removed lines) and frozen in a **follow-up commit**, since freeze refuses a dirty tree