### PR TITLE
feat(economizer): carry reducer state across runs in a conversation

### DIFF
--- a/src/db1/checkpoints.c
+++ b/src/db1/checkpoints.c
@@ -108,3 +108,68 @@ int db1_checkpoint_delete(int64_t id)
       return -1;
    return changes > 0 ? 0 : -1;
 }
+
+/* ------------------------------------------- economizer state (context-paging S2c) */
+
+/* Internal label. Not exposed: callers address this state by session id only, so they
+ * cannot collide with it or read it back as an ordinary checkpoint. */
+#define DB1_ECON_STATE_LABEL "economizer-state"
+
+int db1_economizer_state_save(const char *session_id, const char *json)
+{
+   sqlite3 *db = db1_conn();
+   if (!db || !session_id || !session_id[0] || !json)
+      return -1;
+
+   /* Replace rather than append: only the newest row is ever read, so keeping older
+    * ones would grow the table for the length of a session and leave stale reducer
+    * state behind after a crash. Delete-then-insert keeps exactly one row. */
+   sqlite3_stmt *del = NULL;
+   if (sqlite3_prepare_v2(db, "DELETE FROM checkpoints WHERE session_id = ? AND label = ?", -1,
+                          &del, NULL) == SQLITE_OK)
+   {
+      sqlite3_bind_text(del, 1, session_id, -1, SQLITE_TRANSIENT);
+      sqlite3_bind_text(del, 2, DB1_ECON_STATE_LABEL, -1, SQLITE_TRANSIENT);
+      sqlite3_step(del);
+      sqlite3_finalize(del);
+   }
+
+   return db1_checkpoint_insert(DB1_ECON_STATE_LABEL, session_id, 0, json, NULL);
+}
+
+int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz)
+{
+   sqlite3 *db = db1_conn();
+   if (!db || !session_id || !session_id[0] || !out || out_sz == 0)
+      return -1;
+   out[0] = '\0';
+
+   sqlite3_stmt *stmt = NULL;
+   static const char *sql = "SELECT snapshot FROM checkpoints WHERE session_id = ? AND label = ?"
+                            " ORDER BY id DESC LIMIT 1";
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(stmt, 1, session_id, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(stmt, 2, DB1_ECON_STATE_LABEL, -1, SQLITE_TRANSIENT);
+
+   int rc = -1;
+   if (sqlite3_step(stmt) == SQLITE_ROW)
+   {
+      const unsigned char *txt = sqlite3_column_text(stmt, 0);
+      if (txt)
+      {
+         size_t n = strlen((const char *)txt);
+         /* Refuse a row that does not fit rather than returning a truncated prefix:
+          * truncated JSON does not parse, and a caller treating that as "no state"
+          * would silently lose the conversation's page table instead of learning the
+          * row was too big. */
+         if (n < out_sz)
+         {
+            memcpy(out, txt, n + 1);
+            rc = 0;
+         }
+      }
+   }
+   sqlite3_finalize(stmt);
+   return rc;
+}

--- a/src/db1/checkpoints.h
+++ b/src/db1/checkpoints.h
@@ -6,6 +6,7 @@
 #define DEC_DB1_CHECKPOINTS_H 1
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -27,6 +28,27 @@ extern "C"
    int db1_checkpoint_get(int64_t id, db1_checkpoint_t *out);
    int db1_checkpoint_list(int limit, db1_checkpoint_t *out, int max);
    int db1_checkpoint_delete(int64_t id);
+
+   /* Per-conversation economizer state (context-paging S2c).
+    *
+    * Kept as a named checkpoint rather than a new table: it is exactly session-scoped
+    * rewind state, which is what this table already is. The label is an internal
+    * detail so callers cannot collide with it.
+    *
+    * Scalar-only signatures on purpose — the agent loop forward-declares its db1
+    * entry points instead of including this header, and a db1_checkpoint_t in the
+    * signature would force the struct across that boundary.
+    *
+    * STRICTLY session-keyed. Restoring one conversation's reducer state into another
+    * would leak context between sessions; `session_id` must be non-empty or both
+    * calls no-op. Save replaces: only the newest row per session is ever read, and
+    * older ones are pruned so a long-lived session cannot grow the table without
+    * bound.
+    *
+    * load() returns 0 and fills `out` (NUL-terminated, bounded by out_sz) on a hit;
+    * -1 on miss, bad args, or a row that would not fit. */
+   int db1_economizer_state_save(const char *session_id, const char *json);
+   int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz);
 
 #ifdef __cplusplus
 }

--- a/src/modules/economizer/context_reduce.c
+++ b/src/modules/economizer/context_reduce.c
@@ -100,6 +100,162 @@ void context_reduce_result_free(reduce_result_t *out)
    out->recall_surfaced = 0;
 }
 
+/* ------------------------------------------------------- state persistence (S2c) */
+
+/* Order recall keys most-recently-surfaced first, so a size cap drops the coldest.
+ * last_turn -1 means "never surfaced" — those sort last, since a key the agent has
+ * never reached for is the weakest candidate to carry into the next run. */
+static int recall_rank_cmp(const void *a, const void *b)
+{
+   int la = ((const int *)a)[1], lb = ((const int *)b)[1];
+   if (la != lb)
+      return lb - la;                                /* higher last_turn first; -1 sinks */
+   return ((const int *)a)[0] - ((const int *)b)[0]; /* stable by original index */
+}
+
+char *reduce_state_serialize(const reduce_state_t *st)
+{
+   if (!st)
+      return NULL;
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return NULL;
+
+   cJSON_AddNumberToObject(root, "turn", st->turn);
+   cJSON *fz = cJSON_AddObjectToObject(root, "freeze");
+   if (!fz)
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   cJSON_AddNumberToObject(fz, "active", st->freeze.active);
+   cJSON_AddNumberToObject(fz, "frozen_split", st->freeze.frozen_split);
+   cJSON_AddNumberToObject(fz, "tail_cap_msgs", st->freeze.tail_cap_msgs);
+   cJSON_AddNumberToObject(fz, "epochs", st->freeze.epochs);
+   /* The digest is 64-bit; a JSON number is a double and would lose the low bits, so
+    * it travels as a hex string. Losing digest fidelity would silently defeat the
+    * fold's staleness check — the one guard that stops a restored boundary serving an
+    * obsolete prefix. */
+   char dig[32];
+   snprintf(dig, sizeof(dig), "%llx", (unsigned long long)st->freeze.prefix_digest);
+   cJSON_AddStringToObject(fz, "prefix_digest", dig);
+
+   /* Rank keys by recency so the cap below drops the coldest first. */
+   size_t n = st->recall.count;
+   int *rank = n ? malloc(n * 2 * sizeof(int)) : NULL;
+   if (n && !rank)
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   for (size_t i = 0; i < n; i++)
+   {
+      rank[i * 2] = (int)i;
+      rank[i * 2 + 1] = st->recall.last_turn[i];
+   }
+   if (n)
+      qsort(rank, n, 2 * sizeof(int), recall_rank_cmp);
+
+   cJSON *keys = cJSON_AddArrayToObject(root, "recall");
+   size_t kept = 0, dropped = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      size_t idx = (size_t)rank[i * 2];
+      const char *k = st->recall.keys[idx];
+      if (!k || !k[0])
+         continue;
+      /* Budget check against the serialized size so far, not a guessed row width. */
+      char *probe = cJSON_PrintUnformatted(root);
+      size_t used = probe ? strlen(probe) : REDUCE_STATE_SERIAL_MAX;
+      free(probe);
+      if (used + strlen(k) + 48 > REDUCE_STATE_SERIAL_MAX)
+      {
+         dropped = n - i;
+         break;
+      }
+      cJSON *e = cJSON_CreateObject();
+      if (!e)
+         break;
+      cJSON_AddStringToObject(e, "k", k);
+      cJSON_AddNumberToObject(e, "t", st->recall.last_turn[idx]);
+      cJSON_AddItemToArray(keys, e);
+      kept++;
+   }
+   free(rank);
+   cJSON_AddNumberToObject(root, "recall_kept", (double)kept);
+   cJSON_AddNumberToObject(root, "recall_dropped", (double)dropped);
+
+   char *out = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (out && strlen(out) > REDUCE_STATE_SERIAL_MAX)
+   {
+      /* Belt and braces: never hand back something the store would truncate. */
+      free(out);
+      return NULL;
+   }
+   return out;
+}
+
+int reduce_state_restore(reduce_state_t *st, const char *json)
+{
+   if (!st || !json || !json[0])
+      return -1;
+   cJSON *root = cJSON_Parse(json);
+   if (!root)
+      return -1;
+
+   /* Build into a local, then commit in one go: a half-applied freeze (a split without
+    * its digest) is worse than no state at all. */
+   reduce_state_t tmp;
+   memset(&tmp, 0, sizeof(tmp));
+   fold_recall_index_init(&tmp.recall);
+
+   cJSON *t = cJSON_GetObjectItemCaseSensitive(root, "turn");
+   if (cJSON_IsNumber(t))
+      tmp.turn = t->valueint;
+
+   cJSON *fz = cJSON_GetObjectItemCaseSensitive(root, "freeze");
+   if (cJSON_IsObject(fz))
+   {
+      cJSON *v;
+      if ((v = cJSON_GetObjectItemCaseSensitive(fz, "active")) && cJSON_IsNumber(v))
+         tmp.freeze.active = v->valueint;
+      if ((v = cJSON_GetObjectItemCaseSensitive(fz, "frozen_split")) && cJSON_IsNumber(v))
+         tmp.freeze.frozen_split = v->valueint;
+      if ((v = cJSON_GetObjectItemCaseSensitive(fz, "tail_cap_msgs")) && cJSON_IsNumber(v))
+         tmp.freeze.tail_cap_msgs = v->valueint;
+      if ((v = cJSON_GetObjectItemCaseSensitive(fz, "epochs")) && cJSON_IsNumber(v))
+         tmp.freeze.epochs = v->valueint;
+      v = cJSON_GetObjectItemCaseSensitive(fz, "prefix_digest");
+      if (cJSON_IsString(v) && v->valuestring)
+         tmp.freeze.prefix_digest = strtoull(v->valuestring, NULL, 16);
+   }
+
+   cJSON *keys = cJSON_GetObjectItemCaseSensitive(root, "recall");
+   if (cJSON_IsArray(keys))
+   {
+      cJSON *e = NULL;
+      cJSON_ArrayForEach(e, keys)
+      {
+         cJSON *k = cJSON_GetObjectItemCaseSensitive(e, "k");
+         if (!cJSON_IsString(k) || !k->valuestring)
+            continue;
+         fold_recall_index_add(&tmp.recall, k->valuestring);
+         cJSON *lt = cJSON_GetObjectItemCaseSensitive(e, "t");
+         if (cJSON_IsNumber(lt) && tmp.recall.count > 0)
+            tmp.recall.last_turn[tmp.recall.count - 1] = lt->valueint;
+      }
+   }
+   cJSON_Delete(root);
+
+   /* Commit. `reduced` stays 0: it is per-request provenance, and restoring it would
+    * make the next request believe it had already been reduced. */
+   fold_recall_index_free(&st->recall);
+   *st = tmp;
+   st->reduced = 0;
+   return 0;
+}
+
 /* §4 page table. Record what LEFT the prompt, then tell the caller when the newest turn
  * re-touches one of those coordinates.
  *

--- a/src/modules/economizer/context_reduce.h
+++ b/src/modules/economizer/context_reduce.h
@@ -242,6 +242,37 @@ extern "C"
     * may hand out non-owning references into the original array). */
    void context_reduce_result_free(reduce_result_t *out);
 
+/* Persisted-state cap. db1_checkpoint_t.snapshot is a fixed char[8192] read buffer, so
+ * anything longer comes back TRUNCATED — and truncated JSON does not parse, which would
+ * turn "my page table got big" into "my state silently vanished". Serialization is
+ * therefore bounded well inside that, and reports what it dropped. */
+#define REDUCE_STATE_SERIAL_MAX 6144
+
+   /* Serialize per-conversation reducer state to JSON (caller frees), or NULL on error.
+    *
+    * Persists the freeze boundary (with its prefix digest) and the §4 page table. Does
+    * NOT persist `reduced`: that is per-REQUEST provenance meaning "a seam already
+    * reduced this request", and restoring it would make the next request skip reduction
+    * entirely.
+    *
+    * Bounded by REDUCE_STATE_SERIAL_MAX. When the page table does not fit, the
+    * LEAST-RECENTLY-SURFACED keys are dropped first (they are the least likely to be
+    * re-touched) and the count is recorded in the JSON, so a shrunken table is visible
+    * rather than mysterious. */
+   char *reduce_state_serialize(const reduce_state_t *st);
+
+   /* Restore state produced by reduce_state_serialize. Returns 0 on success, -1 on bad
+    * args or unparseable JSON.
+    *
+    * ALL-OR-NOTHING: on failure `*st` is left zeroed rather than half-populated, because
+    * a partially restored freeze boundary (split without its digest) would be trusted by
+    * the fold and could serve a stale prefix. `reduced` is always 0 after restore.
+    *
+    * The caller is responsible for keying storage by conversation. Restoring one
+    * conversation's state into another would leak context across sessions — see the
+    * reduce_state_t comment. */
+   int reduce_state_restore(reduce_state_t *st, const char *json);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -73,6 +73,16 @@ void db1_agent_job_heartbeat(int job_id);
 void db1_agent_job_heartbeat_ext(int job_id, const char *current_tool, int api_call_count);
 int db1_agent_job_is_cancelled(int job_id);
 int db1_delegation_spawn_stop_reason(const char *delegation_id, char *out, size_t out_sz);
+int db1_economizer_state_save(const char *session_id, const char *json);
+int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz);
+
+/* The agent loop declares a local `char session_id[128]` for the ephemeral-SSH id,
+ * which shadows the global session_id() accessor inside that function. Reach the
+ * conversation id through this alias rather than renaming a buffer the SSH paths use. */
+static const char *econ_conversation_id(void)
+{
+   return session_id();
+}
 const char *delegation_active_id(void);
 
 static int agent_delegation_stopped(char *buf, size_t bufsz)
@@ -628,6 +638,24 @@ native_provider_http:
     * prefix across turns. SAFE never enters context_reduce. */
    reduce_state_t agent_reduce_state;
    memset(&agent_reduce_state, 0, sizeof(agent_reduce_state));
+   /* S2c: continue this conversation's reducer state instead of restarting it. A run
+    * is one agent invocation, but a conversation spans several, so without this every
+    * user turn re-derives the fold boundary and starts with an EMPTY page table — a
+    * coordinate evicted in the previous run would be unrecoverable.
+    *
+    * Strictly keyed by session id, and skipped entirely when there is no session:
+    * restoring another conversation's state here would leak its context. A restored
+    * freeze boundary is safe because it carries its prefix digest, which the fold
+    * re-checks and re-epochs on mismatch. */
+   {
+      const char *econ_sid = econ_conversation_id();
+      if (econ_sid && econ_sid[0])
+      {
+         char saved[REDUCE_STATE_SERIAL_MAX + 1];
+         if (db1_economizer_state_load(econ_sid, saved, sizeof(saved)) == 0)
+            (void)reduce_state_restore(&agent_reduce_state, saved);
+      }
+   }
 
    while (turn < max_t)
    {
@@ -1929,6 +1957,20 @@ native_provider_http:
    cJSON_Delete(tools);
    cJSON_Delete(messages);
    free(assembled_sys);
+   /* Hand this conversation's reducer state to the next run before releasing it. Best
+    * effort: a failed save costs a cold start next turn, never correctness. */
+   {
+      const char *econ_sid = econ_conversation_id();
+      if (econ_sid && econ_sid[0])
+      {
+         char *econ_json = reduce_state_serialize(&agent_reduce_state);
+         if (econ_json)
+         {
+            (void)db1_economizer_state_save(econ_sid, econ_json);
+            free(econ_json);
+         }
+      }
+   }
    /* The §4 page table grows across the whole run and owns its keys. */
    fold_recall_index_free(&agent_reduce_state.recall);
 

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -297,6 +297,130 @@ static void test_recall_disabled_is_inert(void)
    PASS("recall disabled: nothing tracked, no hint");
 }
 
+/* ------------------------------------------------ state persistence (S2c) */
+
+/* Round-trip: the freeze boundary and the page table survive, so a later run continues
+ * the conversation instead of restarting the economizer from scratch. */
+static void test_state_serialize_round_trip(void)
+{
+   reduce_state_t st = {0};
+   st.turn = 12;
+   st.freeze.active = 1;
+   st.freeze.frozen_split = 9;
+   st.freeze.tail_cap_msgs = 24;
+   st.freeze.epochs = 3;
+   st.freeze.prefix_digest = 0xfeedfacecafeb00dULL;
+   fold_recall_index_add(&st.recall, "src/modules/git/retry.c");
+   fold_recall_index_add(&st.recall, "memory:8817");
+   st.recall.last_turn[0] = 5;
+   st.recall.last_turn[1] = -1;
+
+   char *json = reduce_state_serialize(&st);
+   assert(json != NULL);
+   assert(strlen(json) <= REDUCE_STATE_SERIAL_MAX);
+
+   reduce_state_t back = {0};
+   assert(reduce_state_restore(&back, json) == 0);
+   assert(back.turn == 12);
+   assert(back.freeze.active == 1);
+   assert(back.freeze.frozen_split == 9);
+   assert(back.freeze.tail_cap_msgs == 24);
+   assert(back.freeze.epochs == 3);
+   /* The digest must survive EXACTLY: it is the guard that stops a restored boundary
+    * being reused over a prefix that has since changed. A JSON number would have lost
+    * the low bits here. */
+   assert(back.freeze.prefix_digest == 0xfeedfacecafeb00dULL);
+   assert(back.recall.count == 2);
+
+   free(json);
+   fold_recall_index_free(&st.recall);
+   fold_recall_index_free(&back.recall);
+   PASS("state round-trips, including the full 64-bit prefix digest");
+}
+
+/* `reduced` is per-REQUEST provenance. Restoring it would make the next request think a
+ * seam had already reduced it, and skip reduction for the rest of the conversation. */
+static void test_state_never_restores_reduced(void)
+{
+   reduce_state_t st = {0};
+   st.reduced = 1;
+   st.turn = 4;
+   char *json = reduce_state_serialize(&st);
+   assert(json != NULL);
+   assert(strstr(json, "reduced") == NULL); /* not even written */
+
+   reduce_state_t back = {0};
+   back.reduced = 1; /* pre-dirtied: restore must clear it */
+   assert(reduce_state_restore(&back, json) == 0);
+   assert(back.reduced == 0);
+
+   free(json);
+   fold_recall_index_free(&back.recall);
+   PASS("reduced is never persisted or restored");
+}
+
+/* Unparseable input must leave NO state, not half of one: a split without its digest
+ * would be trusted by the fold and could serve a stale prefix. */
+static void test_state_restore_all_or_nothing(void)
+{
+   reduce_state_t st = {0};
+   st.freeze.active = 1;
+   st.freeze.frozen_split = 7;
+   fold_recall_index_add(&st.recall, "src/a.c");
+
+   assert(reduce_state_restore(&st, "{\"freeze\":{\"frozen_spl") == -1); /* truncated */
+   assert(reduce_state_restore(&st, "") == -1);
+   assert(reduce_state_restore(&st, NULL) == -1);
+   /* Prior state is untouched by a failed restore. */
+   assert(st.freeze.frozen_split == 7);
+   assert(st.recall.count == 1);
+
+   fold_recall_index_free(&st.recall);
+   PASS("failed restore leaves prior state intact");
+}
+
+/* The store reads into a fixed char[8192], so oversize must be bounded HERE and the loss
+ * reported — truncated JSON would not parse, turning a large page table into no state. */
+static void test_state_serialize_bounded_and_reports_drops(void)
+{
+   reduce_state_t st = {0};
+   for (int i = 0; i < 400; i++)
+   {
+      char key[64];
+      snprintf(key, sizeof(key), "src/generated/module_%03d/file_%03d.c", i, i);
+      fold_recall_index_add(&st.recall, key);
+      st.recall.last_turn[i] = i; /* newer keys have higher last_turn */
+   }
+
+   char *json = reduce_state_serialize(&st);
+   assert(json != NULL);
+   assert(strlen(json) <= REDUCE_STATE_SERIAL_MAX);
+   assert(strstr(json, "recall_dropped") != NULL);
+
+   reduce_state_t back = {0};
+   assert(reduce_state_restore(&back, json) == 0);
+   assert(back.recall.count > 0);
+   assert(back.recall.count < 400); /* genuinely capped */
+
+   /* The COLDEST keys are the ones dropped: key 399 was surfaced most recently and
+    * must survive, key 000 must not. */
+   int has_newest = 0, has_oldest = 0;
+   for (size_t i = 0; i < back.recall.count; i++)
+   {
+      if (strstr(back.recall.keys[i], "file_399"))
+         has_newest = 1;
+      if (strstr(back.recall.keys[i], "file_000"))
+         has_oldest = 1;
+   }
+   assert(has_newest);
+   assert(!has_oldest);
+
+   free(json);
+   fold_recall_index_free(&st.recall);
+   fold_recall_index_free(&back.recall);
+   PASS("serialization is bounded, drops the coldest keys, and says so");
+}
+
 /* Net-gain pre-check: foldable below min_gain_tokens -> skip, no mutation. */
 static void test_history_fold_skip_no_gain(void)
 {
@@ -506,6 +630,10 @@ int main(void)
    test_history_fold_reduces();
    test_recall_hint_on_retouch();
    test_recall_disabled_is_inert();
+   test_state_serialize_round_trip();
+   test_state_never_restores_reduced();
+   test_state_restore_all_or_nothing();
+   test_state_serialize_bounded_and_reports_drops();
    test_history_fold_skip_no_gain();
    test_compress_engages_where_fold_cannot();
    test_compress_measure_only_no_mutation();


### PR DESCRIPTION
## Summary

S2c of the context-paging programme. `reduce_state_t` was a **stack local**, so the fold boundary and the §4 page table died with each agent invocation.

A run is one invocation, but a conversation spans several. So every user turn re-derived the fold boundary from scratch and started with an **empty page table** — a coordinate evicted in the previous run was simply unrecoverable. That defeats the point of building the table in #2520 at all.

## What changes

- `reduce_state_serialize` / `reduce_state_restore`, keyed by conversation.
- `db1_economizer_state_save` / `_load` persist it as a named checkpoint. That table is already session-scoped rewind state, so this needs **no new table and no migration**.
- Save **replaces** rather than appends: only the newest row is ever read, so appending would grow the table for the length of a session and strand stale reducer state after a crash.

## Three things done deliberately

**Session keying is strict.** Restoring one conversation's reducer state into another would leak context between sessions — the `reduce_state_t` comment says as much. Both calls no-op without a session id.

**The 64-bit prefix digest travels as hex, not as a JSON number.** A JSON number is a double and would lose the low bits. That digest is the one guard that stops a restored boundary being reused over a prefix that has since changed, so losing fidelity would silently defeat the fold's staleness check — a quiet correctness bug rather than a loud one. There is a test asserting the exact value survives.

**Serialization is bounded and reports what it dropped.** `db1_checkpoint_t.snapshot` is a fixed `char[8192]` read buffer, so an unbounded page table would come back truncated — and truncated JSON does not parse, turning "my state got big" into "my state silently vanished". Serialization caps at 6144 bytes, drops the **coldest** keys first (ranked by last-surfaced turn), and records the dropped count. `load()` refuses an oversize row rather than returning an unparseable prefix.

`restore()` is **all-or-nothing** — a half-applied freeze (a split without its digest) would be trusted by the fold — and never restores `reduced`, which is per-request provenance whose restoration would make the next request skip reduction entirely.

## Tests

- round-trip including the **exact** 64-bit digest
- `reduced` is neither written nor restored, even from a pre-dirtied state
- failed restore (truncated / empty / NULL) leaves prior state **intact**
- oversize serialization stays under the cap, reports drops, and keeps the newest key while dropping the oldest

## Verification

- `rm -f aimee-server && make -C src -j8 ../aimee-server` — exit 0, zero undefined references, **re-run after `make format`** since formatting rewrites tracked files
- `make -C src -j8 ../aimee-kb` — exit 0
- `make -C src -j8 cmd-srcs-compile-check` — exit 0
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — all checks passed
- `check_c_repository_lock`, `refactor_baselines` — no drift

The real link mattered here: this makes an `AGENT_SRCS` file call into db1, and the first attempt failed to compile because the agent loop declares a local `session_id[128]` buffer that shadows the global `session_id()` accessor. Hence `econ_conversation_id()`.

## Status of S2

- **S2c** — this PR
- **S2d** — landed (#2520)
- **S2a / S2b** (`task_rail` → DB1, `episode_seal` → DB2) — remaining, and now have a persistence pattern to follow

S3 (continuous paging) is unblocked once S2 completes, since aggressive eviction is only safe when eviction is reversible *and* the page table outlives the run.