### PR TITLE
feat(delegates): render the sandbox spec into a create command

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e33efdbdbdee688a7a0c156c25dcf48ada8f4ebdfb17c7dc036e54adbba21754",
+      "source_sha256": "f2d396b101817e399e612adc234f623d5c5b34f476fd2259ef240a300952bb7f",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/dockerargs.go
+++ b/server-go/modules/delegates/dockerargs.go
@@ -1,0 +1,125 @@
+package delegates
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Turning a sandbox specification into the command that creates the container.
+//
+// This is the last step where the design's guarantees are still checkable: past
+// here they are argv, and a missing flag is a delegate with a network. So the
+// argv is built in one place, from the spec, and the tests assert the flags
+// rather than trusting that the spec was honoured.
+
+// TranslateMountPath maps a path in THIS process's filesystem namespace to the
+// one the container runtime's daemon sees.
+//
+// Docker resolves bind SOURCES in the daemon's namespace, not the caller's.
+// When aimee itself runs in a container the two differ, and passing an
+// unstranslated path makes a real directory look absent -- at which point
+// docker silently CREATES an empty directory at that source and the delegate
+// gets an empty mount instead of the workspace. Silent, and it looks like the
+// delegate simply found nothing.
+//
+// mountTable is "<destination>\t<source>" per line, as the runtime reports this
+// container's own mounts. The longest matching destination wins, matched on
+// whole path components so /data does not match /database. With no match the
+// path is returned unchanged, which is correct for a host-native process that
+// has no self container to inspect.
+func TranslateMountPath(containerPath, mountTable string) string {
+	if containerPath == "" || !strings.HasPrefix(containerPath, "/") {
+		return containerPath
+	}
+
+	bestLen := 0
+	bestSource := ""
+	for _, line := range strings.Split(mountTable, "\n") {
+		line = strings.TrimRight(line, "\r")
+		destination, source, found := strings.Cut(line, "\t")
+		if !found || destination == "" || source == "" {
+			continue
+		}
+		if !strings.HasPrefix(destination, "/") || !strings.HasPrefix(source, "/") {
+			continue
+		}
+		if len(destination) <= bestLen || !strings.HasPrefix(containerPath, destination) {
+			continue
+		}
+		// Whole components only: /data must not match /database.
+		rest := containerPath[len(destination):]
+		if destination != "/" && rest != "" && !strings.HasPrefix(rest, "/") {
+			continue
+		}
+		bestLen = len(destination)
+		bestSource = source
+	}
+
+	if bestSource == "" {
+		return containerPath
+	}
+	if bestLen == 1 { // the mount is "/", so the whole path is the suffix
+		return bestSource + containerPath
+	}
+	return bestSource + containerPath[bestLen:]
+}
+
+// DockerCreateRequest is everything needed to phrase the create command.
+type DockerCreateRequest struct {
+	Spec          SandboxSpec
+	ContainerName string
+	Image         string
+	// WorkDir is the container's working directory, normally the worktree.
+	WorkDir string
+	// MountTable, when set, translates bind sources into the daemon's
+	// namespace. Empty means this process and the daemon share a view.
+	MountTable string
+	// Command is what the container runs. Empty leaves the image's own.
+	Command []string
+}
+
+// DockerCreateArgs renders the create command for a sandbox.
+//
+// It re-validates the spec first. By this point the spec may have travelled,
+// and the cost of a spec that lost its guarantees on the way is a delegate with
+// a network or a writable copy of the supervisor's branch.
+func DockerCreateArgs(req DockerCreateRequest) ([]string, error) {
+	if err := ValidateSandboxSpec(req.Spec); err != nil {
+		return nil, err
+	}
+	if req.ContainerName == "" {
+		return nil, fmt.Errorf("container name is required")
+	}
+	if !baseImageValid(req.Image) {
+		return nil, fmt.Errorf("invalid image reference: %q", req.Image)
+	}
+
+	args := []string{"create", "--name", req.ContainerName}
+
+	// The isolation primitive. Never conditional, never configurable.
+	args = append(args, "--network", req.Spec.NetworkMode())
+
+	for _, m := range req.Spec.Mounts {
+		source := m.Source
+		if req.MountTable != "" {
+			source = TranslateMountPath(source, req.MountTable)
+		}
+		bind := source + ":" + m.Target
+		if m.ReadOnly {
+			bind += ":ro"
+		}
+		args = append(args, "-v", bind)
+	}
+
+	for _, e := range req.Spec.Env {
+		args = append(args, "-e", e.Name+"="+e.Value)
+	}
+
+	if req.WorkDir != "" {
+		args = append(args, "-w", req.WorkDir)
+	}
+
+	args = append(args, req.Image)
+	args = append(args, req.Command...)
+	return args, nil
+}

--- a/server-go/modules/delegates/dockerargs_test.go
+++ b/server-go/modules/delegates/dockerargs_test.go
@@ -1,0 +1,198 @@
+package delegates
+
+import (
+	"strings"
+	"testing"
+)
+
+func argsFor(t *testing.T, req SandboxRequest) []string {
+	t.Helper()
+	spec, err := BuildSandboxSpec(req)
+	if err != nil {
+		t.Fatalf("build spec: %v", err)
+	}
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec:          spec,
+		ContainerName: "aimee-delegate-1",
+		Image:         "ubuntu:22.04",
+		WorkDir:       req.Worktree,
+	})
+	if err != nil {
+		t.Fatalf("build args: %v", err)
+	}
+	return args
+}
+
+func hasFlagValue(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// The one flag the whole design rests on. Never conditional, never
+// configurable.
+func TestDockerArgsAlwaysDisablesNetwork(t *testing.T) {
+	for _, req := range []SandboxRequest{writeReq(), readReq()} {
+		args := argsFor(t, req)
+		if !hasFlagValue(args, "--network", "none") {
+			t.Errorf("--network none missing from %v", args)
+		}
+	}
+}
+
+// A read-only role's workspace must carry :ro all the way to the command, or
+// the enforcement was only ever a comment.
+func TestDockerArgsReadOnlyRoleGetsReadOnlyBind(t *testing.T) {
+	args := argsFor(t, readReq())
+	if !hasFlagValue(args, "-v", "/srv/repo:/srv/repo:ro") {
+		t.Errorf("the parent worktree was not bound read-only: %v", args)
+	}
+	// Only the control socket may be writable.
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] != "-v" {
+			continue
+		}
+		bind := args[i+1]
+		if strings.HasSuffix(bind, ":ro") {
+			continue
+		}
+		if !strings.Contains(bind, "aimee.sock") {
+			t.Errorf("writable bind for a read-only role: %q", bind)
+		}
+	}
+}
+
+// A write role gets the tree readable and only its worktree writable.
+func TestDockerArgsWriteRoleMountModes(t *testing.T) {
+	args := argsFor(t, writeReq())
+	if !hasFlagValue(args, "-v", "/srv/repo:/srv/repo:ro") {
+		t.Errorf("repo not bound read-only: %v", args)
+	}
+	wt := "/srv/repo/.aimee/worktrees/w1/main"
+	if !hasFlagValue(args, "-v", wt+":"+wt) {
+		t.Errorf("worktree not bound writable: %v", args)
+	}
+	gd := "/srv/repo/.git/worktrees/w1"
+	if !hasFlagValue(args, "-v", gd+":"+gd) {
+		t.Errorf("git dir not bound writable: %v", args)
+	}
+}
+
+// The image is the last thing before the command, or docker parses a flag as
+// the image.
+func TestDockerArgsImageAndCommandOrdering(t *testing.T) {
+	spec, err := BuildSandboxSpec(writeReq())
+	if err != nil {
+		t.Fatalf("build spec: %v", err)
+	}
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec: spec, ContainerName: "c1", Image: "ubuntu:22.04",
+		Command: []string{"sleep", "infinity"},
+	})
+	if err != nil {
+		t.Fatalf("build args: %v", err)
+	}
+	for i, a := range args {
+		if a == "ubuntu:22.04" {
+			if i+2 >= len(args) || args[i+1] != "sleep" || args[i+2] != "infinity" {
+				t.Errorf("command does not follow the image: %v", args)
+			}
+			return
+		}
+	}
+	t.Errorf("image missing from %v", args)
+}
+
+// The spec may have travelled by the time it gets here, and a spec that lost
+// its guarantees produces a delegate with a network.
+func TestDockerArgsRevalidatesTheSpec(t *testing.T) {
+	broken := SandboxSpec{
+		ReadOnly: true,
+		Mounts:   []SandboxMount{{Source: "/srv/repo", Target: "/srv/repo"}},
+	}
+	if _, err := DockerCreateArgs(DockerCreateRequest{
+		Spec: broken, ContainerName: "c1", Image: "ubuntu:22.04",
+	}); err == nil {
+		t.Error("a spec with a writable workspace mount for a read-only role was rendered")
+	}
+
+	sock := SandboxSpec{Mounts: []SandboxMount{{
+		Source: "/var/run/docker.sock", Target: "/var/run/docker.sock",
+		Kind: SandboxControlSocket,
+	}}}
+	if _, err := DockerCreateArgs(DockerCreateRequest{
+		Spec: sock, ContainerName: "c1", Image: "ubuntu:22.04",
+	}); err == nil {
+		t.Error("the docker socket was rendered into a create command")
+	}
+}
+
+func TestDockerArgsRejectsHostileImageReference(t *testing.T) {
+	spec, _ := BuildSandboxSpec(writeReq())
+	for _, image := range []string{"", "ubuntu; rm -rf /", "$(id)", "ubuntu\nRUN evil"} {
+		if _, err := DockerCreateArgs(DockerCreateRequest{
+			Spec: spec, ContainerName: "c1", Image: image,
+		}); err == nil {
+			t.Errorf("accepted hostile image %q", image)
+		}
+	}
+}
+
+// Docker resolves bind sources in the DAEMON's namespace. An untranslated path
+// makes a real directory look absent, and docker then creates an empty one --
+// the delegate gets an empty mount and simply appears to find nothing.
+func TestTranslateMountPath(t *testing.T) {
+	table := "/srv/repo\t/host/data/repo\n/run/aimee\t/host/run/aimee\n"
+	cases := []struct{ in, want string }{
+		{"/srv/repo", "/host/data/repo"},
+		{"/srv/repo/sub/file.c", "/host/data/repo/sub/file.c"},
+		{"/run/aimee/server.sock", "/host/run/aimee/server.sock"},
+		// No mapping: unchanged, which is right for a host-native process.
+		{"/elsewhere/path", "/elsewhere/path"},
+	}
+	for _, c := range cases {
+		if got := TranslateMountPath(c.in, table); got != c.want {
+			t.Errorf("%q -> %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// Whole components only: /data must not match /database.
+func TestTranslateMountPathMatchesWholeComponents(t *testing.T) {
+	table := "/data\t/host/data\n"
+	if got := TranslateMountPath("/database/file", table); got != "/database/file" {
+		t.Errorf("/database/file was rewritten by a /data mount: %q", got)
+	}
+	if got := TranslateMountPath("/data/file", table); got != "/host/data/file" {
+		t.Errorf("/data/file -> %q, want /host/data/file", got)
+	}
+}
+
+// The longest destination wins, so a nested mount beats its parent.
+func TestTranslateMountPathLongestMatchWins(t *testing.T) {
+	table := "/srv\t/host/srv\n/srv/repo\t/host/elsewhere/repo\n"
+	if got := TranslateMountPath("/srv/repo/x", table); got != "/host/elsewhere/repo/x" {
+		t.Errorf("nested mount lost to its parent: %q", got)
+	}
+}
+
+// A root mount is the degenerate case and must not double the separator.
+func TestTranslateMountPathRootMount(t *testing.T) {
+	if got := TranslateMountPath("/srv/repo", "/\t/host\n"); got != "/host/srv/repo" {
+		t.Errorf("root mount -> %q, want /host/srv/repo", got)
+	}
+}
+
+// Garbage in the table must not corrupt a path.
+func TestTranslateMountPathIgnoresMalformedRows(t *testing.T) {
+	table := "no-tab-here\n\trelative\tsource\n/srv/repo\t/host/repo\n"
+	if got := TranslateMountPath("/srv/repo/x", table); got != "/host/repo/x" {
+		t.Errorf("malformed rows disturbed the match: %q", got)
+	}
+	if got := TranslateMountPath("relative/path", table); got != "relative/path" {
+		t.Errorf("a relative path was rewritten: %q", got)
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -88,7 +88,8 @@
     "server-go/modules/delegates/rolepolicy.go",
     "server-go/modules/delegates/sandbox.go",
     "server-go/modules/delegates/isolation.go",
-    "server-go/modules/delegates/sandboximage.go"
+    "server-go/modules/delegates/sandboximage.go",
+    "server-go/modules/delegates/dockerargs.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -107,7 +108,8 @@
     "server-go/modules/delegates/rolepolicy_test.go",
     "server-go/modules/delegates/sandbox_test.go",
     "server-go/modules/delegates/isolation_test.go",
-    "server-go/modules/delegates/sandboximage_test.go"
+    "server-go/modules/delegates/sandboximage_test.go",
+    "server-go/modules/delegates/dockerargs_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",


### PR DESCRIPTION
feat(delegates): render the sandbox spec into a create command

The last step where the design's guarantees are still checkable. Past here they
are argv, and a missing flag is a delegate with a network -- so the command is
built in one place, from the spec, and the tests assert the flags rather than
trusting the spec was honoured on the way.

DockerCreateArgs RE-VALIDATES the spec before rendering. The spec may have
travelled by the time it arrives, and the cost of one that lost its guarantees
in transit is a delegate with a network, or a writable copy of the supervisor's
branch. Validating again is cheap; discovering it afterwards is not.

--network none is emitted unconditionally. It is not a field the caller can set
and not a branch that can be taken the other way.

Bind sources are translated into the DAEMON's namespace, and this is a silent
failure worth stating plainly. Docker resolves sources in the daemon's view, not
the caller's. When aimee itself runs in a container the two differ, and an
untranslated path makes a real directory look absent -- at which point docker
CREATES an empty directory at that source. The delegate then gets an empty mount
and simply appears to have found nothing in the workspace. Nothing errors.

The translation matches the longest destination on WHOLE path components, so
/data does not rewrite /database, and a nested mount beats its parent. A path
with no mapping is returned unchanged, which is correct for a host-native
process with no self container to inspect; malformed rows in the table are
skipped rather than allowed to corrupt a path. The root-mount case is handled
separately so the separator is not doubled.

Tests pin the properties, not the implementation: no network for either role,
:ro reaching the command for a read-only role with the control socket as the
only writable bind, the three-mount layering for a write role, the image
appearing last so docker cannot parse a flag as the image, and a hostile image
reference being refused the same way package names are.
