### PR TITLE
fix(log): rotate server.log instead of growing it forever

### DIFF
--- a/src/headers/log.h
+++ b/src/headers/log.h
@@ -14,6 +14,12 @@ typedef enum
 /* Initialize logging. Call once at startup. */
 void log_init(log_level_t level);
 
+/* Tell the logger that stderr is a FILE at `path`, so it can roll that file down
+ * its generations once it grows past the size cap. Call it only where stderr has
+ * actually been redirected to a file — passing a path while stderr is a terminal
+ * would rotate nothing and reopen the terminal onto a file. NULL/"" disables. */
+void log_set_rotating_sink(const char *path);
+
 /* Set the global log level at runtime. */
 void log_set_level(log_level_t level);
 

--- a/src/log.c
+++ b/src/log.c
@@ -19,6 +19,18 @@ static pthread_mutex_t log_mutex = PTHREAD_MUTEX_INITIALIZER;
 #define AUDIT_MAX_SIZE  (10 * 1024 * 1024) /* 10MB */
 #define AUDIT_MAX_FILES 5
 
+/* The server redirects stderr into <config dir>/server.log and never rotated
+ * it. Observed on the test appliance: 612 MiB and 7.4 million lines in under
+ * four days, on a disk at 83%, with no bound of any kind — a busy period simply
+ * grows the file until something else breaks. Same generations policy as the
+ * audit log next door, larger because this is chattier by nature. */
+#define SERVER_LOG_MAX_SIZE  (64 * 1024 * 1024) /* 64MB */
+#define SERVER_LOG_MAX_FILES 5
+/* Checking st_size on every line would stat() per log call. Sampling bounds the
+ * overshoot to (interval x line length) — a few hundred KB past the threshold,
+ * which does not matter — for one stat per interval. */
+#define SERVER_LOG_CHECK_EVERY 512
+
 static const char *level_names[] = {"ERROR", "WARN", "INFO", "DEBUG"};
 
 void log_init(log_level_t level)
@@ -70,6 +82,57 @@ static void format_timestamp(char *buf, size_t len)
    strftime(buf, len, "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
 }
 
+/* Roll <path> down its generations and reopen stderr onto a fresh file.
+ * Caller MUST hold log_mutex.
+ *
+ * ORDER MATTERS: rename first, then freopen. Renaming a file that is still open
+ * leaves the descriptor pointing at the SAME inode, so without the reopen the
+ * server would keep writing into server.log.1 and the "current" file would stay
+ * empty forever — rotation that silently loses the live log. */
+static void server_log_rotate_locked(const char *path)
+{
+   struct stat st;
+   if (stat(path, &st) != 0 || st.st_size < SERVER_LOG_MAX_SIZE)
+      return;
+
+   char old_path[4096], new_path[4096];
+   for (int i = SERVER_LOG_MAX_FILES - 1; i >= 0; i--)
+   {
+      if (i == 0)
+         snprintf(old_path, sizeof(old_path), "%s", path);
+      else
+         snprintf(old_path, sizeof(old_path), "%s.%d", path, i - 1);
+      snprintf(new_path, sizeof(new_path), "%s.%d", path, i);
+      /* remove(), not platform_unlink(): this runs from every aimee_log call, so
+       * the dependency would reach every binary that links log.o — several test
+       * targets link it without the platform layer and failed to link. remove()
+       * is ISO C and behaves on both platforms. */
+      if (i == SERVER_LOG_MAX_FILES - 1)
+         remove(new_path);
+      rename(old_path, new_path);
+   }
+
+   /* If this fails stderr keeps pointing at the rotated inode: messages still
+    * land in server.log.0 rather than vanishing, which is the safer failure. */
+   FILE *reopened = freopen(path, "a", stderr);
+   if (reopened)
+      setvbuf(stderr, NULL, _IOLBF, 0);
+}
+
+/* Set by the server once it has redirected stderr into server.log. Empty for
+ * the CLI, whose stderr is the user's terminal and must never be rotated. */
+static char g_server_log_path[4096];
+
+void log_set_rotating_sink(const char *path)
+{
+   pthread_mutex_lock(&log_mutex);
+   if (path && path[0])
+      snprintf(g_server_log_path, sizeof(g_server_log_path), "%s", path);
+   else
+      g_server_log_path[0] = '\0';
+   pthread_mutex_unlock(&log_mutex);
+}
+
 void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
 {
    if (level > global_level)
@@ -79,6 +142,16 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
    format_timestamp(ts, sizeof(ts));
 
    pthread_mutex_lock(&log_mutex);
+
+   if (g_server_log_path[0])
+   {
+      static unsigned since_check;
+      if (++since_check >= SERVER_LOG_CHECK_EVERY)
+      {
+         since_check = 0;
+         server_log_rotate_locked(g_server_log_path);
+      }
+   }
 
    fprintf(stderr, "%s %-5s %s: ", ts, level_names[level], module ? module : "aimee");
 

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -169,6 +169,9 @@ static int run_server(const char *socket_path, log_level_t log_level)
          setvbuf(log_fp, NULL, _IOLBF, 0);
          platform_server_redirect_stderr(log_fp);
          fclose(log_fp);
+         /* stderr is now this file, so it is ours to bound. Only registered
+          * here: the CLI's stderr is the user's terminal. */
+         log_set_rotating_sink(log_path);
       }
    }
 

--- a/src/tests/test_log.c
+++ b/src/tests/test_log.c
@@ -1,7 +1,10 @@
 /* test_log.c: tests for logging infrastructure */
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include "log.h"
 
 static void test_log_parse_level(void)
@@ -54,6 +57,60 @@ static void test_log_level_filtering(void)
    aimee_log(LOG_DEBUG, "test", "this should be suppressed");
 }
 
+/* Rotation, end to end: redirect stderr to a real file, push it past the cap,
+ * and check both halves of the contract.
+ *
+ * The second half is the one worth having. Renaming a file that is still open
+ * leaves the descriptor on the SAME inode, so a rotation that forgets to reopen
+ * keeps writing into the ROTATED file while the current one stays empty — the
+ * log looks rotated and is silently being lost. The size assertions below would
+ * pass without the reopen; the "still writes to the current file" assertion is
+ * what fails. */
+static void test_server_log_rotates_and_keeps_writing(void)
+{
+   char dir[256], path[300], rotated[320];
+   snprintf(dir, sizeof(dir), "/tmp/aimee-logrot-%d", (int)getpid());
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", dir, dir);
+   assert(system(cmd) == 0);
+   snprintf(path, sizeof(path), "%s/server.log", dir);
+   snprintf(rotated, sizeof(rotated), "%s.0", path);
+
+   FILE *fp = freopen(path, "a", stderr);
+   assert(fp != NULL);
+   setvbuf(stderr, NULL, _IOLBF, 0);
+
+   log_init(LOG_INFO);
+   log_set_rotating_sink(path);
+
+   /* A 64MB cap with ~1KB lines needs a lot of lines; the sampling interval
+    * means the check runs every 512 messages either way. */
+   char big[1024];
+   memset(big, 'x', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+   for (int i = 0; i < 80000; i++)
+      aimee_log(LOG_INFO, "rot", "%s", big);
+
+   fflush(stderr);
+   struct stat st_cur, st_rot;
+   int have_rotated = (stat(rotated, &st_rot) == 0);
+
+   /* Put stderr back before asserting, so a failure is still reportable. */
+   log_set_rotating_sink(NULL);
+   (void)freopen("/dev/null", "a", stderr);
+
+   assert(have_rotated); /* the cap was crossed and a generation was made */
+   assert(st_rot.st_size >= (64 * 1024 * 1024));
+
+   /* THE REOPEN: the current file exists and is receiving the newest lines. */
+   assert(stat(path, &st_cur) == 0);
+   assert(st_cur.st_size > 0);
+   assert(st_cur.st_size < st_rot.st_size); /* fresh file, not the old inode */
+
+   snprintf(cmd, sizeof(cmd), "rm -rf %s", dir);
+   assert(system(cmd) == 0);
+}
+
 int main(void)
 {
    printf("test_log:\n");
@@ -65,6 +122,8 @@ int main(void)
    printf("  log_calls_no_crash: OK\n");
    test_log_level_filtering();
    printf("  log_level_filtering: OK\n");
+   test_server_log_rotates_and_keeps_writing();
+   printf("  server_log_rotation: OK\n");
    printf("All log tests passed.\n");
    return 0;
 }

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -19,7 +19,7 @@
         },
         {
           "path": "src/server/server_main.c",
-          "sha256": "4afacbd65680ebcae084ebf86773f6b1af9a753cb1ec5eb5a1e7e226490475dd"
+          "sha256": "8e5dea99b361a5540dd0ab4ce55fddedda27763ba627894e73745a18ca505a5a"
         }
       ]
     },
@@ -875,7 +875,7 @@
         },
         {
           "path": "src/headers/log.h",
-          "sha256": "bfa3a228bccbe18c3411b85edb0f18483fea4fe05d170e5104a6ba5c5efd4cf8"
+          "sha256": "d95c790b2eb557ad85d7d792b1b000717a95c2ca420a0b7d538af40a9b0ddfb7"
         },
         {
           "path": "src/headers/management_read.h",
@@ -1616,7 +1616,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "68748ab07e630453d7236d9a2392bacfebe18419afe48c6967e4ced13c57ea57",
+      "sha256": "05ab7aef92d01b31270f91ce5c71a6742080b146091d25544d46996bcff80d42",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## The problem

The server redirects stderr into the config dir's `server.log` and **nothing ever bounded it**. On the test appliance:

| | |
|---|---|
| Size | 612 MiB |
| Lines | 7,412,825 |
| Span | **under four days** |
| Disk | already at 83% |
| Cap / generations | **none** |

A busy period simply grows the file until something else on the box breaks.

Size is not the only cost. **An unreadable log is an unused one** — a credential warning sat in that file for hours while the failure it explained was chased through four wrong theories, because nothing could be found in it.

## The fix

Same policy as the audit log a few lines below — roll down N generations at a size cap — with a larger cap (64 MiB × 5) because this file is chattier by nature.

Checked every `SERVER_LOG_CHECK_EVERY` (512) messages rather than every line: one `stat()` per 512 logs, with overshoot bounded by (interval × line length), a few hundred KB past the threshold.

**Only the server registers the sink.** The CLI's stderr is the user's terminal and must never be rotated onto a file, so `log_set_rotating_sink()` is called exactly where the redirect happens.

## Order matters, and the test is built around it

**rename first, THEN freopen.** Renaming a file that is still open leaves the descriptor on the **same inode**, so a rotation that forgets the reopen keeps writing into `server.log.0` while the current file stays empty — rotation that silently loses the live log.

Verified red-before-green: with the `freopen` removed the new test **aborts (exit 134)**. Worth stressing — the size assertions alone would **not** have caught it; both files exist and both look right. It is the *"the current file is still receiving lines"* assertion that fails.

## `remove()` rather than `platform_unlink()`

This path is reachable from **every** `aimee_log` call, so that dependency propagated to every binary linking `log.o` and broke the link of test targets that do not take the platform layer — `unit-test-script-runner`, then `unit-test-ingress-preinject`, with more behind them. `remove()` is ISO C and behaves on both platforms, so no Makefile churn.

`audit_rotate` keeps `platform_unlink` — it is only reachable via `audit_log_open` and is dead-stripped in those binaries, which is why the existing code never hit this.

## Verification

- Red-before-green on the reopen, as above
- All three real links rc=0: `../aimee-server`, `../aimee-kb`, `cmd-srcs-compile-check`
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0 (the link ripple above was caught here, not by the default build)
- `make -C src format` then `make -C src lint` — 48/48
- `check_c_repository_lock` ok
- A header changed, so `refactor_baselines` was verified additive (no removed lines) and frozen in a **follow-up commit**

## Note on the existing 612 MiB file

This bounds future growth; it does not shrink the file already on the appliance. That one is now mostly the pre-#2511 poll storm and can be truncated or left to age out through the new generations.