### PR TITLE
feat(delegates): bring a delegate container up, and refuse it when isolation is unproven

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "f2d396b101817e399e612adc234f623d5c5b34f476fd2259ef240a300952bb7f",
+      "source_sha256": "9a51e040d74dd8df5b2808671da38783bfd8e4a036689a296b98baf8bb930a24",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/container.go
+++ b/server-go/modules/delegates/container.go
@@ -1,0 +1,135 @@
+package delegates
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Bringing a delegate's container up, and refusing to hand it over when its
+// isolation cannot be established.
+//
+// The sequence is create, start, probe, judge. The probe is the point: a
+// container is only a sandbox if the runtime actually honoured `--network
+// none`, and that is not known until after it starts. So the container is
+// brought up, checked, and DESTROYED if the check fails or cannot be completed
+// -- a container that failed the check must not be left running, because a
+// leftover sandbox with a network is exactly what the check exists to prevent.
+//
+// Running docker is I/O, so the command runner is injected. The sequencing and
+// the failure handling are the part that must be right, and they are testable
+// without a daemon.
+
+// CommandRunner runs one command and returns its combined output. An error
+// means the command did not complete successfully.
+type CommandRunner func(ctx context.Context, name string, args ...string) (string, error)
+
+// ContainerRunner brings delegate containers up.
+type ContainerRunner struct {
+	// Docker is the runtime binary. Empty means "docker".
+	Docker string
+	// Run executes a command. Required.
+	Run CommandRunner
+	// RequireIsolation refuses any container whose isolation cannot be proven,
+	// not merely one proven broken.
+	RequireIsolation bool
+	// MountTable translates bind sources into the daemon's namespace.
+	MountTable string
+}
+
+// ContainerResult is what happened.
+type ContainerResult struct {
+	// Name is the container, whether or not it survived.
+	Name string
+	// Refused is set when the container was destroyed rather than handed over.
+	Refused bool
+	// Reason explains a refusal or a warning, in operator-facing terms.
+	Reason string
+	// Warned is set when something is worth reporting but the container ran.
+	Warned bool
+}
+
+func (r ContainerRunner) docker() string {
+	if r.Docker == "" {
+		return "docker"
+	}
+	return r.Docker
+}
+
+// networkProbeFormat asks the daemon for this container's attached networks and
+// their addresses, which is what JudgeIsolation reads.
+const networkProbeFormat = `{{range $k,$v := .NetworkSettings.Networks}}{{$k}}={{$v.IPAddress}};{{end}}`
+
+// Start creates and starts a delegate container, then proves it is isolated.
+//
+// On refusal the container is destroyed before returning. The caller gets a
+// result explaining why, not an error to interpret: "we would not run this"
+// is an outcome of the run, not a malfunction.
+func (r ContainerRunner) Start(ctx context.Context, req DockerCreateRequest) (ContainerResult, error) {
+	if r.Run == nil {
+		return ContainerResult{}, fmt.Errorf("no command runner configured")
+	}
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec:          req.Spec,
+		ContainerName: req.ContainerName,
+		Image:         req.Image,
+		WorkDir:       req.WorkDir,
+		MountTable:    r.MountTable,
+		Command:       req.Command,
+	})
+	if err != nil {
+		return ContainerResult{Name: req.ContainerName}, err
+	}
+
+	if _, err := r.Run(ctx, r.docker(), args...); err != nil {
+		return ContainerResult{Name: req.ContainerName}, fmt.Errorf("create container: %w", err)
+	}
+	if _, err := r.Run(ctx, r.docker(), "start", req.ContainerName); err != nil {
+		// Nothing is running, but a created container still exists.
+		r.destroy(ctx, req.ContainerName)
+		return ContainerResult{Name: req.ContainerName}, fmt.Errorf("start container: %w", err)
+	}
+
+	verdict := JudgeIsolation(r.probe(ctx, req.ContainerName), r.RequireIsolation)
+	if verdict.Refuse {
+		// A container that failed the isolation check must not be left running.
+		r.destroy(ctx, req.ContainerName)
+		return ContainerResult{
+			Name: req.ContainerName, Refused: true, Reason: verdict.Reason,
+		}, nil
+	}
+	return ContainerResult{
+		Name: req.ContainerName, Warned: verdict.Warn, Reason: verdict.Reason,
+	}, nil
+}
+
+// probe asks whether the container actually got no network.
+func (r ContainerRunner) probe(ctx context.Context, name string) IsolationProbe {
+	out, err := r.Run(ctx, r.docker(), "inspect", "--format", networkProbeFormat, name)
+	return ParseIsolationProbe(out, err != nil)
+}
+
+// destroy removes a container, ignoring the result. It runs on paths that are
+// already failing, and a removal error must not replace the reason the caller
+// needs to see.
+func (r ContainerRunner) destroy(ctx context.Context, name string) {
+	_, _ = r.Run(ctx, r.docker(), "rm", "-f", name)
+}
+
+// Stop removes the container once the delegate has finished.
+//
+// The delegate's work is already on the host -- the worktree is a bind mount --
+// so there is nothing to collect first. Removing the container discards only
+// the container.
+func (r ContainerRunner) Stop(ctx context.Context, name string) error {
+	if r.Run == nil {
+		return fmt.Errorf("no command runner configured")
+	}
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("container name is required")
+	}
+	if _, err := r.Run(ctx, r.docker(), "rm", "-f", name); err != nil {
+		return fmt.Errorf("remove container: %w", err)
+	}
+	return nil
+}

--- a/server-go/modules/delegates/container_test.go
+++ b/server-go/modules/delegates/container_test.go
@@ -1,0 +1,212 @@
+package delegates
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeDocker records what was run and answers from a script, so the sequencing
+// and the failure handling can be tested without a daemon.
+type fakeDocker struct {
+	calls []string
+	// probeOut is what `inspect` returns.
+	probeOut string
+	// probeErr makes the probe itself fail.
+	probeErr bool
+	// failOn makes the named subcommand fail ("create", "start", ...).
+	failOn string
+}
+
+func (f *fakeDocker) run(ctx context.Context, name string, args ...string) (string, error) {
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	f.calls = append(f.calls, sub)
+	if f.failOn != "" && sub == f.failOn {
+		return "", errors.New("command failed")
+	}
+	if sub == "inspect" {
+		if f.probeErr {
+			return "", errors.New("probe failed")
+		}
+		return f.probeOut, nil
+	}
+	return "", nil
+}
+
+func (f *fakeDocker) ran(sub string) bool {
+	for _, c := range f.calls {
+		if c == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func startReq(t *testing.T) DockerCreateRequest {
+	t.Helper()
+	spec, err := BuildSandboxSpec(writeReq())
+	if err != nil {
+		t.Fatalf("build spec: %v", err)
+	}
+	return DockerCreateRequest{
+		Spec: spec, ContainerName: "aimee-delegate-1", Image: "ubuntu:22.04",
+	}
+}
+
+// The happy path: created, started, proven isolated, handed over.
+func TestContainerStartIsolated(t *testing.T) {
+	fake := &fakeDocker{probeOut: "none=;"}
+	runner := ContainerRunner{Run: fake.run}
+
+	res, err := runner.Start(context.Background(), startReq(t))
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if res.Refused || res.Warned {
+		t.Errorf("an isolated container was not handed over: %+v", res)
+	}
+	if !fake.ran("create") || !fake.ran("start") || !fake.ran("inspect") {
+		t.Errorf("expected create, start and inspect: %v", fake.calls)
+	}
+	if fake.ran("rm") {
+		t.Errorf("an isolated container was destroyed: %v", fake.calls)
+	}
+}
+
+// A container that got a network is not a sandbox, and must not be left
+// running -- a leftover container with network access is exactly what the check
+// exists to prevent.
+func TestContainerStartDestroysOnBreach(t *testing.T) {
+	fake := &fakeDocker{probeOut: "bridge=172.17.0.2;"}
+	runner := ContainerRunner{Run: fake.run, RequireIsolation: true}
+
+	res, err := runner.Start(context.Background(), startReq(t))
+	if err != nil {
+		t.Fatalf("start returned an error rather than a refusal: %v", err)
+	}
+	if !res.Refused {
+		t.Fatalf("a container with network egress was handed over: %+v", res)
+	}
+	if !fake.ran("rm") {
+		t.Errorf("the refused container was left running: %v", fake.calls)
+	}
+	if !strings.Contains(res.Reason, "bypass the egress proxy") {
+		t.Errorf("reason does not say what is at stake: %q", res.Reason)
+	}
+}
+
+// "The probe failed" and "the sandbox is open" are indistinguishable, so under
+// the requirement an unprovable container is destroyed too.
+func TestContainerStartDestroysOnUnprovableIsolation(t *testing.T) {
+	fake := &fakeDocker{probeErr: true}
+	runner := ContainerRunner{Run: fake.run, RequireIsolation: true}
+
+	res, err := runner.Start(context.Background(), startReq(t))
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !res.Refused {
+		t.Fatalf("an unprovable container was handed over: %+v", res)
+	}
+	if !fake.ran("rm") {
+		t.Errorf("the refused container was left running: %v", fake.calls)
+	}
+}
+
+// Without the requirement an unprovable container runs, but not silently.
+func TestContainerStartWarnsWhenIsolationNotRequired(t *testing.T) {
+	fake := &fakeDocker{probeErr: true}
+	runner := ContainerRunner{Run: fake.run}
+
+	res, err := runner.Start(context.Background(), startReq(t))
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if res.Refused {
+		t.Errorf("refused without the requirement: %+v", res)
+	}
+	if !res.Warned || res.Reason == "" {
+		t.Errorf("an unverified container ran with nothing reported: %+v", res)
+	}
+	if fake.ran("rm") {
+		t.Errorf("destroyed a container it decided to run: %v", fake.calls)
+	}
+}
+
+// A container that was created but could not start still exists, so it is
+// cleaned up rather than left behind.
+func TestContainerStartCleansUpWhenStartFails(t *testing.T) {
+	fake := &fakeDocker{failOn: "start"}
+	runner := ContainerRunner{Run: fake.run}
+
+	if _, err := runner.Start(context.Background(), startReq(t)); err == nil {
+		t.Fatal("a failed start was reported as success")
+	}
+	if !fake.ran("rm") {
+		t.Errorf("the created container was left behind: %v", fake.calls)
+	}
+}
+
+// Nothing was created, so there is nothing to clean up and no probe to run.
+func TestContainerStartCreateFailure(t *testing.T) {
+	fake := &fakeDocker{failOn: "create"}
+	runner := ContainerRunner{Run: fake.run}
+
+	if _, err := runner.Start(context.Background(), startReq(t)); err == nil {
+		t.Fatal("a failed create was reported as success")
+	}
+	if fake.ran("inspect") {
+		t.Errorf("probed a container that was never created: %v", fake.calls)
+	}
+}
+
+// A spec that lost its guarantees must never reach the daemon.
+func TestContainerStartRefusesABrokenSpecBeforeRunningAnything(t *testing.T) {
+	fake := &fakeDocker{}
+	runner := ContainerRunner{Run: fake.run}
+
+	broken := DockerCreateRequest{
+		Spec: SandboxSpec{
+			ReadOnly: true,
+			Mounts:   []SandboxMount{{Source: "/srv/repo", Target: "/srv/repo"}},
+		},
+		ContainerName: "c1", Image: "ubuntu:22.04",
+	}
+	if _, err := runner.Start(context.Background(), broken); err == nil {
+		t.Fatal("a broken spec was accepted")
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("ran commands for a spec that should have been refused: %v", fake.calls)
+	}
+}
+
+// The delegate's work is already on the host via the bind mount, so stopping
+// discards only the container.
+func TestContainerStop(t *testing.T) {
+	fake := &fakeDocker{}
+	runner := ContainerRunner{Run: fake.run}
+
+	if err := runner.Stop(context.Background(), "aimee-delegate-1"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !fake.ran("rm") {
+		t.Errorf("stop did not remove the container: %v", fake.calls)
+	}
+	if err := runner.Stop(context.Background(), "  "); err == nil {
+		t.Error("an empty container name was accepted")
+	}
+}
+
+func TestContainerRunnerRequiresACommandRunner(t *testing.T) {
+	var runner ContainerRunner
+	if _, err := runner.Start(context.Background(), startReq(t)); err == nil {
+		t.Error("started with no command runner")
+	}
+	if err := runner.Stop(context.Background(), "c1"); err == nil {
+		t.Error("stopped with no command runner")
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -89,7 +89,8 @@
     "server-go/modules/delegates/sandbox.go",
     "server-go/modules/delegates/isolation.go",
     "server-go/modules/delegates/sandboximage.go",
-    "server-go/modules/delegates/dockerargs.go"
+    "server-go/modules/delegates/dockerargs.go",
+    "server-go/modules/delegates/container.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -109,7 +110,8 @@
     "server-go/modules/delegates/sandbox_test.go",
     "server-go/modules/delegates/isolation_test.go",
     "server-go/modules/delegates/sandboximage_test.go",
-    "server-go/modules/delegates/dockerargs_test.go"
+    "server-go/modules/delegates/dockerargs_test.go",
+    "server-go/modules/delegates/container_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",


### PR DESCRIPTION
feat(delegates): bring a delegate container up, and refuse it when isolation is unproven

The sequence is create, start, probe, judge -- and the probe is the point. A
container is only a sandbox if the runtime actually honoured `--network none`,
and that is not knowable until after it starts. So the container is brought up,
checked, and DESTROYED when the check fails or cannot be completed. A container
that failed the check must not be left running: a leftover sandbox with a
network is precisely what the check exists to prevent.

Running docker is I/O, so the command runner is INJECTED. The sequencing and the
failure handling are the part that has to be right, and injecting the runner
makes them testable without a daemon -- including the paths that are awkward to
reach for real: a runtime that ignored the network flag, a probe that will not
answer, and a create that succeeded followed by a start that did not.

What the tests pin, none of which needs docker:

  - an isolated container is handed over and NOT destroyed;
  - a container with network egress is destroyed and refused, with a reason that
    says the egress allowlist was not in force;
  - an UNPROVABLE container is destroyed too when isolation is required, because
    "the probe failed" and "the sandbox is open" are indistinguishable from
    here;
  - without that requirement it runs, but never silently -- the result carries
    the warning;
  - a created-but-unstartable container is cleaned up rather than left behind;
  - a failed create runs no probe, because nothing exists to probe;
  - a spec that lost its guarantees reaches NO command at all: zero calls are
    made before it is refused.

A refusal is returned as a result, not an error. "We would not run this" is an
outcome of the run, and the caller needs the reason rather than an error to
interpret.

Stop removes the container and nothing else. The delegate's work is already on
the host -- the worktree is a bind mount -- so there is nothing to collect
first, and discarding the container discards only the container.
