### PR TITLE
feat(delegates): decide what a delegate needs from the workspace

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "9a51e040d74dd8df5b2808671da38783bfd8e4a036689a296b98baf8bb930a24",
+      "source_sha256": "ee25828e9765ad8e0aae56f124f5c48e3c114100c035c13c6b8867c8ee530332",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/worktreeplan.go
+++ b/server-go/modules/delegates/worktreeplan.go
@@ -1,0 +1,105 @@
+package delegates
+
+import (
+	"fmt"
+	"strings"
+)
+
+// What a delegate needs from the workspace before it can run.
+//
+// A write delegate needs its own branch and worktree, so its edits land
+// somewhere the supervisor can inspect and merge deliberately. A read-only
+// delegate needs nothing created at all -- it mounts the parent's worktree, and
+// cutting a worktree for it would be work whose only product is a directory to
+// clean up.
+//
+// This decides WHAT TO ASK FOR. The workspace module owns worktrees and does
+// the cutting; delegates does not create one, name the branch, or -- and this
+// is the part that matters -- choose the base ref.
+
+// WorktreePlan is the request to put to the workspace module.
+type WorktreePlan struct {
+	// Isolated means the delegate needs its own branch and worktree. False
+	// means it uses the parent's, and nothing is created.
+	Isolated bool
+	// WorkName distinguishes this delegate's worktree from its siblings under
+	// the same session. Empty when not isolated.
+	WorkName string
+	// ReadOnlyMount is true when the resulting mount must be read-only. It
+	// tracks Isolated inversely and is stated separately because it is what the
+	// sandbox spec consumes, and the two must not drift apart.
+	ReadOnlyMount bool
+}
+
+// workNameSafe reports whether a work name can appear in a branch name and a
+// directory name.
+//
+// Branch names go into git commands and directory names into mount paths, so
+// the set is narrow on purpose: a slash would nest a branch namespace, a space
+// or a quote would split an argument, and a leading dash would read as a flag.
+func workNameSafe(name string) bool {
+	if name == "" || len(name) > 64 {
+		return false
+	}
+	if !isAlnum(name[0]) {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if isAlnum(c) || c == '-' || c == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// PlanWorktree decides what a delegate needs from the workspace.
+//
+// The work name is derived from the delegate's own identity so two delegates in
+// one session do not collide on a worktree -- that collision previously put two
+// delegates in the same directory, each overwriting the other's edits.
+//
+// There is deliberately NO base ref here. The workspace resolves the base by
+// policy and fails hard when it cannot: guessing one is what let a session
+// inherit another session's branch, and a delegate is in no better position to
+// guess than a session was.
+func PlanWorktree(role, delegateID string) (WorktreePlan, error) {
+	if !RoleIsWrite(role) {
+		// Nothing to create: the parent's worktree, mounted read-only.
+		return WorktreePlan{ReadOnlyMount: true}, nil
+	}
+	name := strings.TrimSpace(delegateID)
+	if !workNameSafe(name) {
+		return WorktreePlan{}, fmt.Errorf(
+			"delegate id %q cannot name a branch or directory", delegateID)
+	}
+	return WorktreePlan{Isolated: true, WorkName: name}, nil
+}
+
+// SandboxRequestFor assembles the sandbox request once the workspace has
+// answered.
+//
+// worktree and gitDir are what the workspace returned: for an isolated delegate
+// its own, for a read-only one the parent's worktree and an empty git dir --
+// nothing writable is needed because nothing is written.
+//
+// Keeping this next to PlanWorktree is deliberate: the plan's ReadOnlyMount and
+// the spec's mount modes are the same decision, and computing them in one place
+// stops a future edit from making a read-only delegate a writable mount.
+func SandboxRequestFor(plan WorktreePlan, role, repoRoot, worktree, gitDir string,
+	isGitCheckout bool, socketHost, socketTarget, egressProxy string) SandboxRequest {
+	req := SandboxRequest{
+		Role:               role,
+		RepoRoot:           repoRoot,
+		Worktree:           worktree,
+		IsGitCheckout:      isGitCheckout,
+		ParentSocketHost:   socketHost,
+		ParentSocketTarget: socketTarget,
+		EgressProxy:        egressProxy,
+	}
+	if plan.Isolated {
+		req.GitDir = gitDir
+	}
+	return req
+}

--- a/server-go/modules/delegates/worktreeplan_test.go
+++ b/server-go/modules/delegates/worktreeplan_test.go
@@ -1,0 +1,121 @@
+package delegates
+
+import "testing"
+
+// A write delegate needs somewhere of its own so the supervisor can inspect and
+// merge its edits deliberately.
+func TestPlanWorktreeWriteRoleIsIsolated(t *testing.T) {
+	for _, role := range []string{"code", "refactor", "implement"} {
+		plan, err := PlanWorktree(role, "deleg-7")
+		if err != nil {
+			t.Fatalf("%s: %v", role, err)
+		}
+		if !plan.Isolated {
+			t.Errorf("%s: a write role did not get its own worktree", role)
+		}
+		if plan.ReadOnlyMount {
+			t.Errorf("%s: a write role got a read-only mount", role)
+		}
+		if plan.WorkName != "deleg-7" {
+			t.Errorf("%s: work name = %q", role, plan.WorkName)
+		}
+	}
+}
+
+// Cutting a worktree for a read-only delegate would be work whose only product
+// is a directory to clean up.
+func TestPlanWorktreeReadOnlyRoleCreatesNothing(t *testing.T) {
+	for _, role := range []string{"review", "validate", "diagnose", "summarize"} {
+		plan, err := PlanWorktree(role, "deleg-7")
+		if err != nil {
+			t.Fatalf("%s: %v", role, err)
+		}
+		if plan.Isolated {
+			t.Errorf("%s: a read-only role asked for its own worktree", role)
+		}
+		if !plan.ReadOnlyMount {
+			t.Errorf("%s: a read-only role did not require a read-only mount", role)
+		}
+		if plan.WorkName != "" {
+			t.Errorf("%s: a read-only role named a branch: %q", role, plan.WorkName)
+		}
+	}
+}
+
+// The name reaches a branch name and a mount path, so a slash would nest a
+// namespace, a space or a quote would split an argument, and a leading dash
+// would read as a flag.
+func TestPlanWorktreeRejectsUnsafeDelegateIDs(t *testing.T) {
+	hostile := []string{
+		"", "  ", "-flag", "has space", "has/slash", "has'quote", `has"quote`,
+		"has;semi", "$(id)", "has..dots", "has\nnewline",
+	}
+	for _, id := range hostile {
+		if _, err := PlanWorktree("code", id); err == nil {
+			t.Errorf("accepted unsafe delegate id %q", id)
+		}
+	}
+	for _, id := range []string{"deleg7", "deleg-7", "deleg_7", "a", "D7"} {
+		if _, err := PlanWorktree("code", id); err != nil {
+			t.Errorf("rejected safe delegate id %q: %v", id, err)
+		}
+	}
+}
+
+// A read-only delegate's id is never used, so a hostile one cannot reach a
+// branch name through this path either.
+func TestPlanWorktreeReadOnlyIgnoresTheDelegateID(t *testing.T) {
+	plan, err := PlanWorktree("review", "$(id); rm -rf /")
+	if err != nil {
+		t.Fatalf("a read-only plan failed on an id it does not use: %v", err)
+	}
+	if plan.WorkName != "" {
+		t.Errorf("work name = %q, want empty", plan.WorkName)
+	}
+}
+
+// The plan's read-only decision and the sandbox's mount modes are the same
+// decision, and must not drift apart.
+func TestSandboxRequestForMatchesThePlan(t *testing.T) {
+	writePlan, _ := PlanWorktree("code", "deleg-7")
+	req := SandboxRequestFor(writePlan, "code", "/srv/repo",
+		"/srv/repo/.aimee/worktrees/w1/main", "/srv/repo/.git/worktrees/w1", true,
+		"/run/aimee/server.sock", "/run/aimee.sock", "")
+	spec, err := BuildSandboxSpec(req)
+	if err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	if spec.ReadOnly {
+		t.Error("a write plan produced a read-only sandbox")
+	}
+	if _, ok := findMount(spec, "/srv/repo/.git/worktrees/w1"); !ok {
+		t.Error("an isolated delegate did not get its git dir")
+	}
+
+	readPlan, _ := PlanWorktree("review", "deleg-8")
+	req = SandboxRequestFor(readPlan, "review", "/srv/repo", "/srv/repo", "", true,
+		"/run/aimee/server.sock", "/run/aimee.sock", "")
+	spec, err = BuildSandboxSpec(req)
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	if !spec.ReadOnly {
+		t.Error("a read-only plan produced a writable sandbox")
+	}
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxWorkspace && !m.ReadOnly {
+			t.Errorf("read-only plan produced a writable workspace mount: %+v", m)
+		}
+	}
+}
+
+// A read-only delegate writes nothing, so it needs no writable git dir -- and
+// must not be handed one even if the caller passes a path.
+func TestSandboxRequestForReadOnlyDropsTheGitDir(t *testing.T) {
+	readPlan, _ := PlanWorktree("review", "deleg-8")
+	req := SandboxRequestFor(readPlan, "review", "/srv/repo", "/srv/repo",
+		"/srv/repo/.git", true, "", "", "")
+	if req.GitDir != "" {
+		t.Errorf("git dir = %q, want empty for a read-only delegate", req.GitDir)
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -90,7 +90,8 @@
     "server-go/modules/delegates/isolation.go",
     "server-go/modules/delegates/sandboximage.go",
     "server-go/modules/delegates/dockerargs.go",
-    "server-go/modules/delegates/container.go"
+    "server-go/modules/delegates/container.go",
+    "server-go/modules/delegates/worktreeplan.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -111,7 +112,8 @@
     "server-go/modules/delegates/isolation_test.go",
     "server-go/modules/delegates/sandboximage_test.go",
     "server-go/modules/delegates/dockerargs_test.go",
-    "server-go/modules/delegates/container_test.go"
+    "server-go/modules/delegates/container_test.go",
+    "server-go/modules/delegates/worktreeplan_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",


### PR DESCRIPTION
feat(delegates): decide what a delegate needs from the workspace

A write delegate needs its own branch and worktree, so its edits land somewhere
the supervisor can inspect and merge deliberately. A read-only delegate needs
NOTHING created: it mounts the parent's worktree, and cutting one for it would
be work whose only product is a directory to clean up.

This decides what to ASK FOR. The workspace module owns worktrees and does the
cutting; delegates does not create one, name the branch, or choose the base ref.

THE ABSENT BASE REF IS THE POINT. There is deliberately no base here. The
workspace resolves it by policy and fails hard when it cannot -- its own comment
records why: guessing a base is what let a session inherit another session's
branch. A delegate is in no better position to guess than a session was, so it
does not offer one, and the failure stays where the knowledge is.

The work name comes from the delegate's own identity, so two delegates in one
session cannot collide on a worktree. That collision previously put two
delegates in the same directory, each overwriting the other's edits.

The name is validated because it reaches a git branch name and a mount path: a
slash would nest a branch namespace, a space or a quote would split an argument,
and a leading dash would read as a flag. A read-only delegate's id is never
used, so a hostile one cannot reach a branch name through this path at all --
pinned by test so a later edit cannot start using it.

SandboxRequestFor sits next to the plan on purpose. The plan's read-only
decision and the sandbox's mount modes are the SAME decision, and computing them
apart is how a read-only delegate ends up with a writable mount. A read-only
delegate also gets no git dir even when the caller passes one: it writes
nothing, so it needs nothing writable.
