### PR TITLE
feat(economizer): put the recall hint in front of the model

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -35,7 +35,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "53bbcd54ec6314b729ac1e054a4c6b26ef64cecd9e2949445e48eb32ecb13b71"
+      "source_sha256": "15a4a337fe0fc50b7d2cb772b59c662c965076cf2ec14e1e10e4aa85b4950d1c"
     },
     {
       "id": "ir",

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -1188,6 +1188,11 @@ typedef struct config
     * fold_recall_ttl_turns: don't re-surface the same key within this many turns. */
    int fold_recall_enabled;
    int fold_recall_ttl_turns;
+   /* fold_recall_inject: put the hint in front of the model instead of only reporting
+    * it. Separate from _enabled and default-off, because tracking what was evicted is
+    * inert while injecting CHANGES WHAT THE MODEL DOES, and whether that helps or
+    * derails a turn is a behavioural question for live traffic to answer. */
+   int fold_recall_inject;
 
    /* The single economizer mode. OFF is the pristine baseline. PROOF_GATED
     * verifies the signed empty registry and freezes the completed provider body;

--- a/src/modules/config/config_accessors.h
+++ b/src/modules/config/config_accessors.h
@@ -200,6 +200,7 @@ int config_fold_freeze_enabled(void);
 int config_fold_freeze_tail_cap_msgs(void);
 int config_fold_recall_enabled(void);
 int config_fold_recall_ttl_turns(void);
+int config_fold_recall_inject(void);
 int config_economizer_mode(void);
 int config_module_memory(void);
 int config_module_governance(void);

--- a/src/modules/config/config_accessors_1.c
+++ b/src/modules/config/config_accessors_1.c
@@ -284,6 +284,13 @@ int config_fold_recall_enabled(void)
    return v;
 }
 
+int config_fold_recall_inject(void)
+{
+   int v = 0;
+   config_field_read(offsetof(config_t, fold_recall_inject), sizeof(v), &v);
+   return v;
+}
+
 int config_fold_recall_ttl_turns(void)
 {
    int v = 0;

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1110,6 +1110,8 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(recall, "enabled", cfg->fold_recall_enabled);
          if (cfg->fold_recall_ttl_turns)
             cJSON_AddNumberToObject(recall, "ttl_turns", cfg->fold_recall_ttl_turns);
+         if (cfg->fold_recall_inject) /* default-off: persist only the opt-in */
+            cJSON_AddBoolToObject(recall, "inject", cfg->fold_recall_inject);
       }
    }
 

--- a/src/modules/config/config_sections.c
+++ b/src/modules/config/config_sections.c
@@ -717,6 +717,9 @@ void config_parse_fold_section(config_t *cfg, cJSON *root)
       item = cJSON_GetObjectItemCaseSensitive(recall, "ttl_turns");
       if (cJSON_IsNumber(item) && item->valuedouble > 0)
          cfg->fold_recall_ttl_turns = (int)item->valuedouble;
+      item = cJSON_GetObjectItemCaseSensitive(recall, "inject");
+      if (cJSON_IsBool(item))
+         cfg->fold_recall_inject = cJSON_IsTrue(item) ? 1 : 0;
    }
 }
 

--- a/src/modules/economizer/context_reduce.c
+++ b/src/modules/economizer/context_reduce.c
@@ -308,6 +308,38 @@ static void recall_track(const cJSON *original, int evicted_count, const reduce_
    dstr_free(&hints);
 }
 
+/* Put the hint in front of the model, at the END of the transcript.
+ *
+ * Not the folded prefix and not the system prompt: both are deliberately stable so the
+ * provider prompt cache stays warm (§3 freeze), and a per-turn line in either would bust
+ * the very cache the rest of the economizer exists to protect. The tail already changes
+ * every turn, so appending there costs nothing extra.
+ *
+ * Framed explicitly as a system notice. An unlabelled line appended after the user's turn
+ * reads as something the USER said, which is both wrong and a way for evicted text to put
+ * words in their mouth.
+ *
+ * Appends rather than splicing, so it cannot land between an assistant tool_use and its
+ * matching tool_result — the one structural mistake that would make the request invalid. */
+static void recall_inject(cJSON *reduced, const reduce_result_t *out)
+{
+   if (!cJSON_IsArray(reduced) || !out->recall_hint || !out->recall_hint[0])
+      return;
+   cJSON *note = cJSON_CreateObject();
+   if (!note)
+      return;
+   dstr_t body;
+   dstr_init(&body);
+   dstr_append_str(&body, "[context notice — not from the user] Earlier turns were folded "
+                          "out of this transcript. You referenced something that went with "
+                          "them; it is PAGEABLE, not lost:\n");
+   dstr_append_str(&body, out->recall_hint);
+   cJSON_AddStringToObject(note, "role", "user");
+   cJSON_AddStringToObject(note, "content", dstr_cstr(&body));
+   dstr_free(&body);
+   cJSON_AddItemToArray(reduced, note);
+}
+
 /* chars/4 token estimate of the first `count` items of an array — the fold-eligible
  * prefix region. Provider-agnostic (counts serialized bytes), matching
  * session_compact_estimate_tokens' chars_to_tokens convention. */
@@ -515,6 +547,8 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
              * bodies in place — the carrying message stays visible, so nothing has
              * left the prompt to page back in. */
             recall_track(messages, fr.folded_msgs, cfg, st, out);
+            if (cfg->recall_inject)
+               recall_inject(out->messages, out);
          }
          fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
       }

--- a/src/modules/economizer/context_reduce.h
+++ b/src/modules/economizer/context_reduce.h
@@ -97,6 +97,19 @@ extern "C"
       int recall_enabled;
       int recall_ttl_turns; /* anti-thrash residency; 0 -> FOLD_RECALL_DEFAULT_TTL_TURNS */
 
+      /* Append the recall hint to the reduced transcript instead of only reporting it.
+       * Default-off, and separate from recall_enabled on purpose: tracking what was
+       * evicted is inert, whereas putting a line in front of the model CHANGES WHAT IT
+       * DOES, and whether that helps or derails a turn is a behavioural question that
+       * needs evaluating on live traffic, not asserting here.
+       *
+       * Placement is the END of the transcript, which is the cache-cheapest option: the
+       * tail already varies every turn, whereas the folded prefix is deliberately
+       * byte-identical for prompt-cache warmth (§3 freeze) and the system prompt sits
+       * at the front of everything cached. A per-turn hint in either of those would bust
+       * a cache the rest of the economizer exists to keep warm. */
+      int recall_inject;
+
       fold_config_t fold; /* history-fold sub-config (reused verbatim) */
    } reduce_config_t;
 

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -850,6 +850,7 @@ native_provider_http:
             rcfg.fold.closet.denylist = closet_denylist[0] ? closet_denylist : NULL;
             rcfg.recall_enabled = config_fold_recall_enabled();
             rcfg.recall_ttl_turns = config_fold_recall_ttl_turns();
+            rcfg.recall_inject = config_fold_recall_inject();
             agent_reduce_state.reduced = 0;
             agent_reduce_state.turn = turn;
             if (context_reduce(messages, sys, fb_agent.model, NULL, REDUCE_SEAM_DELEGATE, &rcfg,

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -297,6 +297,87 @@ static void test_recall_disabled_is_inert(void)
    PASS("recall disabled: nothing tracked, no hint");
 }
 
+/* Injection puts the hint in front of the model. Default-off and separate from tracking,
+ * because reporting is inert while injecting changes what the model does. */
+static void test_recall_inject_appends_notice(void)
+{
+   cJSON *m = make_messages(20);
+   cJSON *early = cJSON_GetArrayItem(m, 1);
+   cJSON_ReplaceItemInObject(early, "content",
+                             cJSON_CreateString("inspect src/modules/git/retry.c closely here"));
+   cJSON *last = cJSON_GetArrayItem(m, cJSON_GetArraySize(m) - 1);
+   cJSON_ReplaceItemInObject(last, "content",
+                             cJSON_CreateString("what about src/modules/git/retry.c ?"));
+
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1;
+   cfg.fold.closet.enabled = 1;
+   cfg.recall_enabled = 1;
+   cfg.recall_inject = 1;
+
+   reduce_state_t st = {0};
+   reduce_result_t out;
+   assert(context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out) == 0);
+   assert(out.mutated == 1 && out.recall_surfaced >= 1);
+
+   int n = cJSON_GetArraySize(out.messages);
+   cJSON *tail = cJSON_GetArrayItem(out.messages, n - 1);
+   const char *txt = cJSON_GetStringValue(cJSON_GetObjectItem(tail, "content"));
+   assert(txt != NULL);
+   assert(strstr(txt, "src/modules/git/retry.c") != NULL);
+   /* Labelled as a notice: an unlabelled line appended after the user's turn reads as
+    * something the USER said, which is a way for evicted text to put words in their
+    * mouth. */
+   assert(strstr(txt, "not from the user") != NULL);
+
+   /* Appended at the very END — never spliced between an assistant tool_use and its
+    * matching tool_result, which would make the request structurally invalid. */
+   assert(tail != cJSON_GetArrayItem(out.messages, 0));
+
+   context_reduce_result_free(&out);
+   fold_recall_index_free(&st.recall);
+   cJSON_Delete(m);
+   PASS("recall injection appends a labelled notice at the tail");
+}
+
+/* Tracking without injection must leave the transcript exactly as the fold produced it:
+ * the reporting contract is what callers with their own placement rely on. */
+static void test_recall_inject_off_leaves_transcript(void)
+{
+   cJSON *m = make_messages(20);
+   cJSON *early = cJSON_GetArrayItem(m, 1);
+   cJSON_ReplaceItemInObject(early, "content",
+                             cJSON_CreateString("inspect src/modules/git/retry.c closely here"));
+   cJSON *last = cJSON_GetArrayItem(m, cJSON_GetArraySize(m) - 1);
+   cJSON_ReplaceItemInObject(last, "content",
+                             cJSON_CreateString("what about src/modules/git/retry.c ?"));
+
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1;
+   cfg.fold.closet.enabled = 1;
+   cfg.recall_enabled = 1;
+   cfg.recall_inject = 0; /* the lever under test */
+
+   reduce_state_t st = {0};
+   reduce_result_t out;
+   assert(context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out) == 0);
+   assert(out.recall_surfaced >= 1); /* still tracked and reported */
+   assert(out.recall_hint != NULL);
+
+   int n = cJSON_GetArraySize(out.messages);
+   cJSON *tail = cJSON_GetArrayItem(out.messages, n - 1);
+   const char *txt = cJSON_GetStringValue(cJSON_GetObjectItem(tail, "content"));
+   assert(txt != NULL);
+   assert(strstr(txt, "not from the user") == NULL); /* nothing appended */
+
+   context_reduce_result_free(&out);
+   fold_recall_index_free(&st.recall);
+   cJSON_Delete(m);
+   PASS("injection off: hint reported, transcript untouched");
+}
+
 /* ------------------------------------------------ state persistence (S2c) */
 
 /* Round-trip: the freeze boundary and the page table survive, so a later run continues
@@ -630,6 +711,8 @@ int main(void)
    test_history_fold_reduces();
    test_recall_hint_on_retouch();
    test_recall_disabled_is_inert();
+   test_recall_inject_appends_notice();
+   test_recall_inject_off_leaves_transcript();
    test_state_serialize_round_trip();
    test_state_never_restores_reduced();
    test_state_restore_all_or_nothing();


### PR DESCRIPTION
## Summary

Completes S2d. #2520 built the page table and **reported** hints on `reduce_result_t` without placing them, because where a hint belongs in a transcript is a provider-shaped decision. This makes that placement, behind its own lever.

## Placement is the design question, not an implementation detail

The hint goes at the **end of the transcript** — deliberately *not* the folded prefix and *not* the system prompt.

Both of those are kept **stable on purpose** so the provider prompt cache stays warm: the §3 freeze exists specifically to keep the folded prefix byte-identical turn to turn, and the system prompt sits at the front of everything cached. A per-turn hint in either would bust the very cache the rest of the economizer exists to protect — and would do so *precisely on the turns where a hint fires*. The tail already changes every turn, so appending there costs nothing extra.

It **appends** rather than splices, so it can never land between an assistant `tool_use` and its matching `tool_result` — the one structural mistake that would make the request invalid.

## The note is labelled

`[context notice — not from the user]`.

An unlabelled line appended after the user's turn reads as something the **user** said. That is both wrong and a route for evicted text to put words in their mouth — the same class of concern as the register-grammar guard measured in #2527.

## Default-off, and separate from tracking

`fold_recall.inject` is its own flag, off by default.

Tracking what was evicted is **inert**. Putting a line in front of the model **changes what it does**, and whether that helps or derails a turn is a behavioural question that live traffic has to answer. I cannot evaluate that headless, so the lever ships off and the reporting contract stays for callers that want their own placement.

Flipping it on is a small, reversible experiment once someone can watch real turns.

## Tests

- injection on: a labelled notice naming the re-touched coordinate is appended at the tail
- injection off: the hint is still reported, and the transcript is left exactly as the fold produced it

## Verification

- `rm -f aimee-server && make -C src -j8 ../aimee-server` — exit 0, zero undefined references
- `make -C src -j8 ../aimee-kb`, `cmd-srcs-compile-check` — exit 0
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — all checks passed (`format` run first)
- `docs-gen-check` — ok
- `check_c_repository_lock` — config digest repinned
- `refactor_baselines` — no drift

## S2 status

| slice | state |
|---|---|
| S2c persist reducer state | merged (#2523) |
| S2d page table | merged (#2520) |
| S2d hint injection | this PR |
| S2a `task_rail`, S2b `episode_seal` | **re-scoped** — see below |

S2a/S2b were specified as "bind to storage", but both have **zero live callers**: nothing creates a rail or seals an episode. Persisting data that is never produced would be the "installed and ready is not the same as used" failure the proposal itself warns about. For those two, **production is the gap, not persistence** — flagged in #2527 and needing a proposal amendment before either is worth doing.

Next is S3 (continuous paging), which this unblocks: evicting aggressively is only safe once eviction is reversible *and* the agent can be told what became pageable.