### PR TITLE
fix(workspace): stop the mcp bridge serving a tree nobody asks it about

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -212,7 +212,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "627c8c8ee7760d57ab6915681bd4d1e30e608bf4e082709df5a690b9bd1dce1d",
+      "source_sha256": "a24197dc88c3c8a32e2cdb660ca0d906b94db6cdf66812551568c232fc35bf8e",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,

--- a/src/modules/workspace/cli_workspace_serve.c
+++ b/src/modules/workspace/cli_workspace_serve.c
@@ -252,27 +252,24 @@ int cmd_workspace_serve(const char *workspace_id)
  *
  * When mcp-serve / chat target a remote aimee-server, the agent runs on the
  * server but its file/exec tools must act on THIS client's tree. These helpers
- * register the client's cwd as a `detached` workspace and serve it on a
- * background thread, so the server (which binds that workspace per turn by cwd)
- * marshals tool ops back here over runner.poll/respond. No-op for a co-located
- * server. One channel per process. */
-static volatile sig_atomic_t g_rc_stop = 0;
-#ifdef _WIN32
-static HANDLE g_rc_thread = NULL;
-#else
-static pthread_t g_rc_thread;
-#endif
+ * register the client's cwd as a `mirror` workspace and ship its diff, so the
+ * server reconstructs the tree on ITS OWN filesystem and delegates work there.
+ * No-op for a co-located server. One channel per process.
+ *
+ * NO SERVE LOOP. This used to register `detached` and drive one on a background
+ * thread, and the loop outlived that decision: a mirror is reconstructed
+ * server-side and the runner rendezvous a serve loop waits on is created ONLY
+ * for a detached provider (workspace_turn.c), so for a mirror it is never
+ * created at all. The thread polled /v1/runner/poll forever against a tree
+ * nobody serves — every answer "no runner", re-polled at once — which is what
+ * produced ~196k of 200k server log lines and a failed module stage per poll.
+ * `aimee workspace serve` still drives a real loop; that is an operator
+ * deliberately serving a tree, and it registers `detached`. */
 static int g_rc_active = 0;
 static int g_rc_unregister_on_stop = 0;
 static char g_rc_workspace_id[CLI_TUI_PATH_MAX];
 static char g_rc_endpoint[CLI_TUI_PATH_MAX + 32];
 static char *g_rc_bearer = NULL;
-struct rc_args
-{
-   char *id;
-   char *endpoint;
-   char *bearer;
-};
 
 static void rc_unregister_workspace_at(const char *endpoint, const char *bearer,
                                        const char *workspace_id)
@@ -301,29 +298,6 @@ static void rc_unregister_workspace(void)
    free(g_rc_bearer);
    g_rc_bearer = NULL;
 }
-/* Shared body for both thread ABIs: drive the serve loop, then free the args. */
-static void rc_serve_run(struct rc_args *a)
-{
-   cli_workspace_serve_loop(a->id, NULL, a->endpoint, a->bearer, &g_rc_stop);
-   free(a->id);
-   free(a->endpoint);
-   free(a->bearer);
-   free(a);
-}
-#ifdef _WIN32
-static unsigned __stdcall rc_thread_main(void *arg)
-{
-   rc_serve_run((struct rc_args *)arg);
-   return 0;
-}
-#else
-static void *rc_thread_main(void *arg)
-{
-   rc_serve_run((struct rc_args *)arg);
-   return NULL;
-}
-#endif
-
 /* The VCS coordinates the mirror tier seeds from: the fetch URL of `origin` and
  * the current HEAD commit. BOTH are required — the server reconstructs the tree
  * by fetching THIS head from THIS remote — so a directory that is not a repo,
@@ -558,27 +532,9 @@ int cli_workspace_reverse_channel_start(void)
     * usually moved on since the registration that created it. */
    rc_ship_client_diff(endpoint, bearer, cwd, ws_head, ws_branch, ws_upstream);
 
-   struct rc_args *a = calloc(1, sizeof(*a));
-   if (!a)
-   {
-      if (should_unregister)
-         rc_unregister_workspace_at(endpoint, bearer, cwd);
-      free(endpoint);
-      free(bearer);
-      return 0;
-   }
-   a->id = strdup(cwd);
-   if (!a->id)
-   {
-      if (should_unregister)
-         rc_unregister_workspace_at(endpoint, bearer, cwd);
-      free(a);
-      free(endpoint);
-      free(bearer);
-      return 0;
-   }
-   a->endpoint = endpoint; /* ownership passes to the thread */
-   a->bearer = bearer;
+   /* Record what a later stop() needs to tear the registration down. The channel
+    * is "active" from here: the registration and the shipped diff ARE the
+    * channel for a mirror workspace. There is no thread to start. */
    snprintf(g_rc_workspace_id, sizeof(g_rc_workspace_id), "%s", cwd);
    snprintf(g_rc_endpoint, sizeof(g_rc_endpoint), "%s", endpoint);
    g_rc_unregister_on_stop = should_unregister;
@@ -588,8 +544,6 @@ int cli_workspace_reverse_channel_start(void)
    {
       if (should_unregister)
          rc_unregister_workspace_at(endpoint, bearer, cwd);
-      free(a->id);
-      free(a);
       free(endpoint);
       free(bearer);
       g_rc_workspace_id[0] = '\0';
@@ -597,27 +551,10 @@ int cli_workspace_reverse_channel_start(void)
       g_rc_unregister_on_stop = 0;
       return 0;
    }
-   g_rc_stop = 0;
-#ifdef _WIN32
-   g_rc_thread = (HANDLE)_beginthreadex(NULL, 0, rc_thread_main, a, 0, NULL);
-   if (g_rc_thread)
-   {
-      g_rc_active = 1;
-      return 1;
-   }
-#else
-   if (pthread_create(&g_rc_thread, NULL, rc_thread_main, a) == 0)
-   {
-      g_rc_active = 1;
-      return 1;
-   }
-#endif
-   free(a->id);
-   free(a->endpoint);
-   free(a->bearer);
-   free(a);
-   rc_unregister_workspace();
-   return 0;
+   g_rc_active = 1;
+   free(endpoint);
+   free(bearer);
+   return 1;
 }
 
 int cli_workspace_reverse_channel_sync(void)
@@ -639,18 +576,8 @@ void cli_workspace_reverse_channel_stop(void)
 {
    if (!g_rc_active)
       return;
-   g_rc_stop = 1;
-   /* The poll may be mid-flight (~30s); the process is exiting, so detach
-    * rather than block on join. */
-#ifdef _WIN32
-   if (g_rc_thread)
-   {
-      CloseHandle(g_rc_thread);
-      g_rc_thread = NULL;
-   }
-#else
-   pthread_detach(g_rc_thread);
-#endif
+   /* Nothing to join: the mirror channel is a registration plus a shipped diff,
+    * not a running thread. Tearing down the registration is the whole stop. */
    g_rc_active = 0;
    rc_unregister_workspace();
 }


### PR DESCRIPTION
**This is the caller behind the runner-poll traffic** — the open question from #2511, #2517 and #2522. It turns out to be vestigial.

## What it was doing

`cli_workspace_reverse_channel_start()` registers the client's cwd as a **`mirror`** workspace, then started a background thread driving the runner serve loop.

But the server creates a runner rendezvous **only for a `DETACHED` provider** — `workspace_turn.c` is the single call site of `ws_runner_registry_get_or_create`:

```c
if (kind == WS_PROVIDER_DETACHED) {
    ws_runner_queue_t *q = ws_runner_registry_get_or_create(config_workspaces(i));
```

A mirror is reconstructed on the server's own filesystem and never asks the client to do file or exec work, so **for a mirror workspace that rendezvous is never created at all**.

The loop therefore polled `/v1/runner/poll` forever against a tree nobody serves: every request answered "no runner", the client re-polled immediately (it has no backoff, by design), and the pair produced **196,310 of the last 200,000 `server.log` lines** plus a failed module stage per poll.

## The function's own header gave it away

> *"register the client's cwd as a `detached` workspace and serve it on a background thread"*

The code registers **`mirror`** — deliberately, and the long comment below it explains why: a delegate runs *local to the server*, so the tree must exist there; `detached` would have agents editing the developer's live working copy. **The serve loop simply outlived that change.** It is accretion from a superseded design, not a live path.

## The change

No thread. For a mirror workspace the **registration plus the shipped client diff are the channel** — which is what the mirror tier actually consumes. `stop()` tears the registration down exactly as before; there is nothing to join. The dead thread machinery goes with it (`rc_args`, `rc_serve_run`, `rc_thread_main`, `g_rc_stop`, `g_rc_thread`).

**`aimee workspace serve` is untouched** and still drives a real loop — that is an operator deliberately serving a tree, and it registers `detached`, the tier the reverse channel exists for.

Three earlier changes bounded the **cost** of this traffic — pacing an unserved answer (#2511), reporting `served:false`, and not logging a successful poll (#2522). This removes the **request**.

## Verification

- All three real links rc=0: `../aimee-server`, `../aimee-kb`, `cmd-srcs-compile-check`
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src format` then `make -C src lint` — 48/48
- `refactor_baselines` clean; lock repinned, `workspace` only
- Net −96/+23 lines

## For review

This is a **behavioural change to the client bridge**, not a pure deletion. The evidence that the loop can never receive work is code-local and above, but it deserves a second pair of eyes on whether any deployment registers this bridge as `detached` — I could find none; the provider string is hardcoded to `"mirror"`.

Expected effect once deployed: `/v1/runner/poll` traffic from `mcp-serve` stops entirely, and the residual `CapabilityAbsent` module-stage failures go with it.