### PR TITLE
feat(delegates): the proxy allowlist and address guard, in the module

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "ee25828e9765ad8e0aae56f124f5c48e3c114100c035c13c6b8867c8ee530332",
+      "source_sha256": "039d7fb181dbff12793300059bc699d51d3ce20de962b78e9445cb77f5d0e8a4",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/proxyguard.go
+++ b/server-go/modules/delegates/proxyguard.go
@@ -1,0 +1,199 @@
+package delegates
+
+import (
+	"net"
+	"strings"
+)
+
+// What the delegate's one outward channel is allowed to reach.
+//
+// The sandbox has no network. The single exception is a proxy to the parent,
+// and this is the rule that proxy applies: a narrow allowlist for software
+// updates, ports 80 and 443 only, and an address guard that refuses anything
+// that is not publicly routable.
+//
+// This is the only hole in the sandbox, so it is decided here, in one place,
+// with no I/O. Resolving a name and opening a socket belong to the caller; what
+// may be reached does not.
+
+// DefaultPackageAllowlist is the set of registry hosts a delegate may install
+// from. Specific hosts, not broad wildcards -- the one wildcard covers the many
+// geographic mirrors that live under archive.ubuntu.com.
+func DefaultPackageAllowlist() []string {
+	return []string{
+		"deb.debian.org",
+		"security.debian.org",
+		"*.archive.ubuntu.com",
+		"security.ubuntu.com",
+		"registry.npmjs.org",
+		"pypi.org",
+		"files.pythonhosted.org",
+	}
+}
+
+// ProxyPortAllowed permits only the two ports a package fetch uses. Anything
+// else is a different protocol wearing a proxy request.
+func ProxyPortAllowed(port int) bool {
+	return port == 80 || port == 443
+}
+
+// ProxyHostAllowed matches a host against the allowlist.
+//
+// An entry is either an exact host or a "*.suffix" wildcard, and both match
+// case-insensitively because DNS does. A wildcard matches the suffix itself as
+// well as anything beneath it, so "*.archive.ubuntu.com" covers
+// archive.ubuntu.com and gb.archive.ubuntu.com alike -- but never
+// notarchive.ubuntu.com, because the boundary is a label, not a substring.
+func ProxyHostAllowed(host string, allowlist []string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return false
+	}
+	// A trailing dot is the same name in DNS; normalise so it cannot be used to
+	// dodge an exact match.
+	host = strings.TrimSuffix(host, ".")
+
+	for _, entry := range allowlist {
+		entry = strings.TrimSpace(strings.ToLower(entry))
+		if entry == "" {
+			continue
+		}
+		if suffix, ok := strings.CutPrefix(entry, "*."); ok {
+			if host == suffix || strings.HasSuffix(host, "."+suffix) {
+				return true
+			}
+			continue
+		}
+		if host == entry {
+			return true
+		}
+	}
+	return false
+}
+
+// ProxyAddressBlocked reports whether an address must not be connected to.
+//
+// Everything that is not publicly routable is refused: loopback, private
+// ranges, CGNAT, link-local -- which includes the 169.254.169.254 cloud
+// metadata endpoint -- multicast, and the reserved and documentation ranges. A
+// package proxy has no reason to reach any of them, and each is a way to turn
+// the sandbox's one permitted channel into a request against the host's own
+// network.
+//
+// A nil or unparseable address is blocked. Failing closed is the only safe
+// direction here: an address that cannot be understood cannot be shown to be
+// public.
+func ProxyAddressBlocked(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+
+	// Any IPv6 form that embeds an IPv4 address inherits the IPv4 policy.
+	// Without this a hostile resolver could map a private v4 address into v6 --
+	// v4-mapped, v4-compatible, NAT64 or 6to4 -- and slip past the v4 checks
+	// entirely.
+	if v4 := embeddedIPv4(ip); v4 != nil {
+		return ipv4Blocked(v4)
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return ipv4Blocked(v4)
+	}
+
+	v6 := ip.To16()
+	if v6 == nil {
+		return true
+	}
+	if ip.IsUnspecified() || ip.IsLoopback() {
+		return true
+	}
+	if v6[0]&0xFE == 0xFC {
+		return true // fc00::/7 unique-local
+	}
+	if v6[0] == 0xFE && v6[1]&0xC0 == 0x80 {
+		return true // fe80::/10 link-local
+	}
+	if v6[0] == 0xFF {
+		return true // ff00::/8 multicast
+	}
+	return false
+}
+
+// embeddedIPv4 returns the IPv4 address carried inside an IPv6 address, or nil.
+//
+// Covers v4-mapped (::ffff:a.b.c.d), v4-compatible (::a.b.c.d, deprecated),
+// NAT64 (64:ff9b::a.b.c.d) and 6to4 (2002:AABB:CCDD::), each of which is a way
+// to name an IPv4 destination without looking like one.
+func embeddedIPv4(ip net.IP) net.IP {
+	v6 := ip.To16()
+	if v6 == nil || ip.To4() != nil {
+		return nil
+	}
+
+	isPrefix := func(prefix []byte) bool {
+		for i, b := range prefix {
+			if v6[i] != b {
+				return false
+			}
+		}
+		return true
+	}
+
+	// v4-mapped ::ffff:0:0/96
+	if isPrefix([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF}) {
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+	}
+	// NAT64 64:ff9b::/96
+	if isPrefix([]byte{0x00, 0x64, 0xFF, 0x9B, 0, 0, 0, 0, 0, 0, 0, 0}) {
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+	}
+	// v4-compatible ::a.b.c.d, excluding :: and ::1 which are handled as v6.
+	if isPrefix(make([]byte, 12)) && (v6[12]|v6[13]|v6[14]|v6[15]) != 0 {
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+	}
+	// 6to4 2002::/16 carries the v4 address at bytes 2..5.
+	if v6[0] == 0x20 && v6[1] == 0x02 {
+		return net.IPv4(v6[2], v6[3], v6[4], v6[5])
+	}
+	return nil
+}
+
+// blockedIPv4Nets are every range a package proxy has no business reaching.
+var blockedIPv4Nets = []string{
+	"0.0.0.0/8",          // this network / unspecified
+	"10.0.0.0/8",         // private
+	"100.64.0.0/10",      // carrier-grade NAT
+	"127.0.0.0/8",        // loopback
+	"169.254.0.0/16",     // link-local, includes 169.254.169.254 cloud metadata
+	"172.16.0.0/12",      // private
+	"192.0.0.0/24",       // IETF protocol assignments
+	"192.0.2.0/24",       // TEST-NET-1
+	"192.168.0.0/16",     // private
+	"198.18.0.0/15",      // benchmarking
+	"198.51.100.0/24",    // TEST-NET-2
+	"203.0.113.0/24",     // TEST-NET-3
+	"224.0.0.0/4",        // multicast
+	"240.0.0.0/4",        // reserved, includes 255.255.255.255
+}
+
+var blockedIPv4 = func() []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(blockedIPv4Nets))
+	for _, cidr := range blockedIPv4Nets {
+		if _, n, err := net.ParseCIDR(cidr); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+func ipv4Blocked(ip net.IP) bool {
+	v4 := ip.To4()
+	if v4 == nil {
+		return true
+	}
+	for _, n := range blockedIPv4 {
+		if n.Contains(v4) {
+			return true
+		}
+	}
+	return false
+}

--- a/server-go/modules/delegates/proxyguard_test.go
+++ b/server-go/modules/delegates/proxyguard_test.go
@@ -1,0 +1,162 @@
+package delegates
+
+import (
+	"net"
+	"testing"
+)
+
+func TestProxyPortAllowed(t *testing.T) {
+	for _, port := range []int{80, 443} {
+		if !ProxyPortAllowed(port) {
+			t.Errorf("port %d should be allowed", port)
+		}
+	}
+	// Anything else is a different protocol wearing a proxy request.
+	for _, port := range []int{22, 25, 445, 3306, 5432, 6379, 8080, 0, -1, 65535} {
+		if ProxyPortAllowed(port) {
+			t.Errorf("port %d should be refused", port)
+		}
+	}
+}
+
+func TestProxyHostAllowedExactAndWildcard(t *testing.T) {
+	allow := DefaultPackageAllowlist()
+
+	for _, host := range []string{
+		"deb.debian.org", "pypi.org", "files.pythonhosted.org",
+		"DEB.DEBIAN.ORG",     // DNS is case-insensitive
+		"deb.debian.org.",    // a trailing dot is the same name
+		"archive.ubuntu.com", // the wildcard covers the suffix itself
+		"gb.archive.ubuntu.com",
+		"us.archive.ubuntu.com",
+	} {
+		if !ProxyHostAllowed(host, allow) {
+			t.Errorf("%q should be allowed", host)
+		}
+	}
+
+	for _, host := range []string{
+		"", "  ", "evil.com", "pypi.org.evil.com",
+		// The wildcard boundary is a label, not a substring.
+		"notarchive.ubuntu.com",
+		"archive.ubuntu.com.evil.com",
+		"debian.org", // the allowlist names deb.debian.org, not the apex
+	} {
+		if ProxyHostAllowed(host, allow) {
+			t.Errorf("%q should be refused", host)
+		}
+	}
+}
+
+// Every range a package proxy has no business reaching. Each is a way to turn
+// the sandbox's one permitted channel into a request against the host network.
+func TestProxyAddressBlocksNonPublicIPv4(t *testing.T) {
+	blocked := []string{
+		"0.0.0.0", "10.0.0.1", "100.64.0.1", "127.0.0.1",
+		"169.254.169.254", // cloud metadata
+		"172.16.0.1", "172.31.255.255", "192.0.0.1", "192.0.2.1",
+		"192.168.1.1", "198.18.0.1", "198.51.100.1", "203.0.113.1",
+		"224.0.0.1", "240.0.0.1", "255.255.255.255",
+	}
+	for _, s := range blocked {
+		if !ProxyAddressBlocked(net.ParseIP(s)) {
+			t.Errorf("%s should be blocked", s)
+		}
+	}
+
+	for _, s := range []string{"1.1.1.1", "8.8.8.8", "93.184.216.34", "151.101.0.1"} {
+		if ProxyAddressBlocked(net.ParseIP(s)) {
+			t.Errorf("%s should be allowed", s)
+		}
+	}
+}
+
+// Without this a hostile resolver could map a private v4 address into v6 and
+// slip past the v4 checks entirely.
+func TestProxyAddressBlocksIPv4EmbeddedInIPv6(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+	}{
+		{"v4-mapped loopback", "::ffff:127.0.0.1"},
+		{"v4-mapped private", "::ffff:10.0.0.1"},
+		{"v4-mapped metadata", "::ffff:169.254.169.254"},
+		{"v4-compatible private", "::192.168.1.1"},
+		{"NAT64 metadata", "64:ff9b::169.254.169.254"},
+		{"NAT64 private", "64:ff9b::10.0.0.1"},
+	}
+	for _, c := range cases {
+		ip := net.ParseIP(c.addr)
+		if ip == nil {
+			t.Fatalf("%s: could not parse %q", c.name, c.addr)
+		}
+		if !ProxyAddressBlocked(ip) {
+			t.Errorf("%s (%s) was not blocked", c.name, c.addr)
+		}
+	}
+
+	// 6to4 carries the v4 address at bytes 2..5: 2002:c0a8:0101:: is
+	// 192.168.1.1.
+	sixToFour := net.ParseIP("2002:c0a8:101::1")
+	if sixToFour == nil {
+		t.Fatal("could not parse the 6to4 address")
+	}
+	if !ProxyAddressBlocked(sixToFour) {
+		t.Error("a 6to4 address embedding a private v4 was not blocked")
+	}
+
+	// A v4-mapped PUBLIC address must still be reachable.
+	if ProxyAddressBlocked(net.ParseIP("::ffff:1.1.1.1")) {
+		t.Error("a v4-mapped public address was blocked")
+	}
+}
+
+func TestProxyAddressBlocksNonPublicIPv6(t *testing.T) {
+	for _, s := range []string{
+		"::",      // unspecified
+		"::1",     // loopback
+		"fc00::1", // unique-local
+		"fd00::1",
+		"fe80::1", // link-local
+		"ff02::1", // multicast
+	} {
+		if !ProxyAddressBlocked(net.ParseIP(s)) {
+			t.Errorf("%s should be blocked", s)
+		}
+	}
+	for _, s := range []string{"2606:4700:4700::1111", "2001:4860:4860::8888"} {
+		if ProxyAddressBlocked(net.ParseIP(s)) {
+			t.Errorf("%s should be allowed", s)
+		}
+	}
+}
+
+// An address that cannot be understood cannot be shown to be public.
+func TestProxyAddressFailsClosed(t *testing.T) {
+	if !ProxyAddressBlocked(nil) {
+		t.Error("a nil address was allowed")
+	}
+	if !ProxyAddressBlocked(net.IP{1, 2, 3}) {
+		t.Error("a malformed address was allowed")
+	}
+}
+
+// The allowlist is specific hosts, not broad wildcards -- one wildcard, for the
+// geographic mirrors.
+func TestDefaultAllowlistIsNarrow(t *testing.T) {
+	wildcards := 0
+	for _, entry := range DefaultPackageAllowlist() {
+		if len(entry) > 0 && entry[0] == '*' {
+			wildcards++
+		}
+	}
+	if wildcards != 1 {
+		t.Errorf("allowlist has %d wildcards, want exactly 1", wildcards)
+	}
+	// A bare wildcard would allow everything.
+	for _, entry := range DefaultPackageAllowlist() {
+		if entry == "*" || entry == "*." {
+			t.Errorf("allowlist contains a catch-all: %q", entry)
+		}
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -91,7 +91,8 @@
     "server-go/modules/delegates/sandboximage.go",
     "server-go/modules/delegates/dockerargs.go",
     "server-go/modules/delegates/container.go",
-    "server-go/modules/delegates/worktreeplan.go"
+    "server-go/modules/delegates/worktreeplan.go",
+    "server-go/modules/delegates/proxyguard.go"
   ],
   "go_tests": [
     "server-go/modules/delegates/delegates_test.go",
@@ -113,7 +114,8 @@
     "server-go/modules/delegates/sandboximage_test.go",
     "server-go/modules/delegates/dockerargs_test.go",
     "server-go/modules/delegates/container_test.go",
-    "server-go/modules/delegates/worktreeplan_test.go"
+    "server-go/modules/delegates/worktreeplan_test.go",
+    "server-go/modules/delegates/proxyguard_test.go"
   ],
   "tests": [
     "src/tests/test_aimee_ir_rescue.c",


### PR DESCRIPTION
feat(delegates): the proxy allowlist and address guard, in the module

The delegate sandbox has no network. Its single exception is the proxy to the
parent, so this is the ONLY hole in the sandbox and the rule governing it now
lives in one place with no I/O: server-go/modules/delegates/proxyguard.go.
Resolving a name and opening a socket stay with the caller; what may be reached
does not.

Three parts, ported from the pure decision core in sandbox_pkg_proxy_core.c:

PORTS. 80 and 443 only. Anything else is a different protocol wearing a proxy
request.

HOSTS. Specific registry hosts, with exactly one wildcard for the many
geographic mirrors under archive.ubuntu.com. A wildcard matches the suffix
itself and anything beneath it, but the boundary is a LABEL, not a substring --
notarchive.ubuntu.com and archive.ubuntu.com.evil.com are both refused, and both
are pinned by test.

ADDRESSES. Everything not publicly routable is blocked: loopback, the private
ranges, CGNAT, link-local -- which is what keeps 169.254.169.254 cloud metadata
out of reach -- multicast, reserved, and the documentation ranges. Each is a way
to turn the sandbox's one permitted channel into a request against the host's
own network.

The IPv6 handling is the subtle part and is carried over deliberately. Any v6
form that EMBEDS a v4 address inherits the v4 policy: v4-mapped, v4-compatible,
NAT64 and 6to4. Without that, a hostile resolver could answer with a private v4
address wrapped in v6 and slip past the v4 checks entirely. All four forms are
tested, including a 6to4 address that carries 192.168.1.1 at bytes 2..5, and a
v4-mapped PUBLIC address is confirmed still reachable so the guard is not simply
refusing everything.

Unparseable or nil addresses are blocked. An address that cannot be understood
cannot be shown to be public, so failing closed is the only safe direction.

ONE DELIBERATE DIFFERENCE FROM THE C, called out rather than slipped in: a
trailing dot is normalised, so "deb.debian.org." matches the allowlist where the
C's exact comparison would have refused it. That is the same DNS name, so this
is correct rather than a widening -- but it IS a behaviour change to a security
allowlist, and it should be reviewed as one.
