### PR TITLE
docs: amend S2–S5 with three things the implementation disproved

### DIFF
--- a/docs/proposals/pending/context-paging-s2-s5.md
+++ b/docs/proposals/pending/context-paging-s2-s5.md
@@ -253,3 +253,82 @@ planned as such.
   baseline.
 - Anything that cannot be exercised in-tree is reported validation-pending, never
   silently marked done.
+
+---
+
+# Amendments (2026-08-11), after implementing S2c–S2d and S5a
+
+Three things this proposal got wrong, each found by checking the tree rather than by
+re-reading the plan. Recorded here rather than silently fixed, because the reasoning
+they replace is the reasoning a reviewer would otherwise inherit.
+
+## 1. S2a / S2b were mis-sequenced: production is the gap, not persistence
+
+Verified: `task_rail_start` and `episode_seal_set_conclusion` / `_add_file` have **zero
+live callers**. Nothing creates a rail. Nothing seals an episode.
+
+"Bind them to storage" would therefore persist data that is never produced — precisely
+the *installed and ready is not the same as used* failure this document warns about
+elsewhere. Both slices need a **producer** first:
+
+- `task_rail` needs the agent to declare a plan, which is a prompt/behaviour change.
+- `episode_seal` has a natural producer already available: at a fold boundary, the
+  evicted region yields a file inventory (closet PATH coordinates) and a conclusion
+  (register-tagged verdict turns). Both ingredients now exist from S1 and S2d.
+
+Sequence for these two is **producer → measure → persist**, not persist-first.
+
+## 2. S3 cannot live at the `context_engine` seam
+
+The proposal says S3 plugs into `context_engine.c` *and* that reusing the fold freeze is
+mandatory, or continuous eviction rewrites the prefix every turn and destroys prompt-cache
+hits. Those two requirements are incompatible at that seam:
+
+```c
+int (*compress)(struct context_engine *self, void *messages, const char *focus_topic);
+```
+
+There is **no per-conversation state parameter**, so an engine implemented there cannot
+carry `fold_freeze_t` and cannot keep a stable boundary. Building S3 as specified would
+produce exactly the cache regression the same document forbids.
+
+S3 belongs in the **reducer path**, which already owns `reduce_state_t` — freeze,
+prefix digest, and (since S2c) a page table that survives the run. Either that, or the
+`context_engine` ABI grows a state parameter first; the reducer path is the smaller
+change and the one with the state already in it.
+
+## 3. Continuous paging mostly EXISTS — it is the fold, and it is switched off
+
+The framing of "build continuous paging" was wrong. The mechanism is already written:
+
+| | trigger | shape | freeze-aware | conserves identifiers |
+|---|---|---|---|---|
+| `session_compact` | 80% pressure | one destructive boundary | no | only via S1's record path |
+| `context_fold_view` | every turn | rolling skeleton | **yes** | **yes** (Coordinate Closet) |
+
+The fold is incremental, freeze-aware, closet-conserving, and now reversible via the S2d
+page table. It is `fold_enabled = 0` — **default-off** (`config.c:731`). Meanwhile the
+cliff compactor is default-on.
+
+So S3 is not new machinery. It is:
+
+1. Enable the fold so eviction is continuous.
+2. Let the 80% compactor become the rare fallback rather than the normal path.
+3. Only then consider water marks, which are a refinement of a mechanism that is already
+   running rather than a thing to build from scratch.
+
+### What gates that flip
+
+Flipping `fold_enabled` is a large behaviour change and must not be done on argument
+alone — the same discipline that reversed the `compact.from_record` verdict twice.
+
+- **Prompt-cache impact is the main risk and is unmeasured.** The freeze exists to keep
+  the folded prefix byte-identical; whether it actually holds across real turns needs
+  measuring against realized `cache_read` / `cache_write` token counts, not reasoning.
+- **Quality** should be compared on the existing harness
+  (`benchmarks/compaction-quality`), which currently scores `session_compact` summaries
+  only. Comparing a fold view against a summary needs a harness extension, because they
+  are different artefacts.
+
+Recommended next slice: **measure the fold against the compactor** on retention,
+precision, and cache behaviour — then flip, rather than flip and hope.


### PR DESCRIPTION
## Summary

Docs-only. Three corrections to the S2–S5 proposal, each found by checking the tree rather than re-reading the plan. Recorded as an amendment rather than silently edited, because the reasoning they replace is what a reviewer would otherwise inherit.

## 1. S2a / S2b were mis-sequenced

`task_rail_start` and `episode_seal_set_conclusion` / `_add_file` have **zero live callers**. Nothing creates a rail. Nothing seals an episode.

"Bind them to storage" would persist data that is never produced — the *installed and ready is not the same as used* failure this same document warns about. **Production is the gap, not persistence.**

`episode_seal` now has a natural producer available: at a fold boundary, the evicted region yields a file inventory (closet PATH coordinates) and a conclusion (register-tagged verdict turns). Both ingredients exist since S1 and S2d.

## 2. S3 cannot live at the `context_engine` seam

The proposal requires freeze reuse — without it, continuous eviction rewrites the prefix every turn and destroys prompt-cache hits — but:

```c
int (*compress)(struct context_engine *self, void *messages, const char *focus_topic);
```

There is **no per-conversation state parameter**, so an engine there cannot carry `fold_freeze_t`. Building S3 as specified would produce exactly the cache regression the same document forbids.

It belongs in the **reducer path**, which already owns `reduce_state_t` — freeze, prefix digest, and since #2523 a page table that survives the run.

## 3. Continuous paging mostly exists — it is the fold, and it is switched off

| | trigger | shape | freeze-aware | conserves identifiers |
|---|---|---|---|---|
| `session_compact` | 80% pressure | one destructive boundary | no | only via S1's record path |
| `context_fold_view` | every turn | rolling skeleton | **yes** | **yes** |

The fold is incremental, freeze-aware, closet-conserving, and reversible since #2520/#2529. It is `fold_enabled = 0` — **default-off** (`config.c:731`) — while the cliff compactor is default-on.

So S3 is not new machinery. It is: enable the continuous mechanism, let the 80% cliff become the rare fallback, and only then consider water marks as a refinement of something already running.

## What this deliberately does not do

**It does not flip `fold_enabled`.** Prompt-cache impact is the main risk and is unmeasured — whether the freeze actually holds across real turns has to be read off realized `cache_read` / `cache_write` counts, not argued. Quality comparison also needs a harness extension, since a fold view and a summary are different artefacts.

Recommended next slice: **measure the fold against the compactor** on retention, precision and cache behaviour, then flip. That is the same measure-first discipline that has now reversed the `from_record` verdict twice — first when `match_path` turned a loss into a win (#2507), then when precision inverted the "dead even" reading (#2527).

## Verification

- `check_proposal_ordering` — ok
- `check-proposal-links` — ok (32 links across 75 files)
- `make -C src lint` — passed

## Also verified this session (not in this PR)

Delegation is still blocked, and **it is not the sandbox**. With #2513 deployed (`server f261123`), a delegate still cannot run `echo`. Its own report shows why: the **shell root and file-tool root are different directories** — the shell gets an empty `/var/lib/aimee/delegate-ws/deleg-<id>` with no repo, while file tools correctly point at the real mirror worktree. No `.git` means the docker backend refuses to bind-mount it, so **no delegate container is ever created** (`docker ps -a | grep deleg` is empty on .210), so it falls to co-located execution and the guarded-parent path refuses it.

Supporting evidence that the sandbox is not at fault: inside the server container `max_user_namespaces=2147483647`, `unprivileged_userns_clone=1`, and there are no `sandbox: unavailable` lines in its log. #2499 and #2513 are real fixes — verified end-to-end in a container on the test host — but neither unblocks delegates. Captured as memory 157.