### PR TITLE
feat(delegates): stage 11 -- what a delegate needs from the workspace

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "b1d01de98fb8282275d29a860d67996e989dd0dc7a17da3cf291fc1a798872c0",
+      "source_sha256": "ac6acfc14aac82ab9fd35d96ca082467e044ad2458c4700ed8ba55dcc3e01427",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
@@ -179,7 +179,8 @@
         6663,
         6664,
         6665,
-        6666
+        6666,
+        6667
       ]
     },
     {

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -112,6 +112,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: delegates.EventEconomics, StageID: delegates.StageEconomics},
 			{EventKind: delegates.EventPatchCoord, StageID: delegates.StagePatchCoord},
 			{EventKind: delegates.EventRolePolicy, StageID: delegates.StageRolePolicy},
+			{EventKind: delegates.EventWorktreePlan, StageID: delegates.StageWorktreePlan},
 		}
 		config.Handler = delegates.Handle
 	case "tools":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -18,7 +18,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664, 6665, 6666}},
+		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664, 6665, 6666, 6667}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7428, 7429, 7430}},

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -56,6 +56,9 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 	if invocation.StageID == StageRolePolicy {
 		return handleRolePolicy(invocation, request)
 	}
+	if invocation.StageID == StageWorktreePlan {
+		return handleWorktreePlan(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/server-go/modules/delegates/worktreeplan.go
+++ b/server-go/modules/delegates/worktreeplan.go
@@ -31,6 +31,11 @@ type WorktreePlan struct {
 	ReadOnlyMount bool
 }
 
+// workNameMax bounds a work name. The wire field that carries one is sized from
+// this, so a name this module accepts can never be truncated on the way out
+// into a different branch than the one it decided on.
+const workNameMax = 64
+
 // workNameSafe reports whether a work name can appear in a branch name and a
 // directory name.
 //
@@ -38,7 +43,7 @@ type WorktreePlan struct {
 // the set is narrow on purpose: a slash would nest a branch namespace, a space
 // or a quote would split an argument, and a leading dash would read as a flag.
 func workNameSafe(name string) bool {
-	if name == "" || len(name) > 64 {
+	if name == "" || len(name) > workNameMax {
 		return false
 	}
 	if !isAlnum(name[0]) {

--- a/server-go/modules/delegates/worktreeplan_stage.go
+++ b/server-go/modules/delegates/worktreeplan_stage.go
@@ -1,0 +1,74 @@
+package delegates
+
+import (
+	"encoding/binary"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Asking the module what a delegate needs from the workspace.
+//
+// This is the first of the two calls that run a delegate: the caller asks what
+// to request, puts that to the workspace module, and comes back with the answer
+// to have the container specified. Splitting it here is not ceremony -- the
+// worktree must exist before there is a path to mount, so the decision and the
+// creation cannot be one round trip.
+//
+// A refusal is a refusal. When the delegate id cannot name a branch this
+// returns invalid-request rather than a plan with the name left out, because a
+// write delegate with no worktree of its own would silently edit its parent's.
+
+const (
+	StageWorktreePlan uint32 = 11
+	EventWorktreePlan uint32 = 6667
+
+	worktreePlanRequestMagic  uint32 = 0x51545744 /* "DWTQ" */
+	worktreePlanResponseMagic uint32 = 0x53545744 /* "DWTS" */
+	worktreePlanReqHeaderLen         = 16
+	// isolated, read-only, then the work name. The name is bounded, so a fixed
+	// field is enough and the response has no length arithmetic to get wrong.
+	// The field is workNameMax plus room for the terminator: sized exactly, a
+	// full-length name would be truncated into a DIFFERENT branch name than the
+	// one decided above, and silently.
+	worktreePlanWorkNameLen   = workNameMax + 4
+	worktreePlanResponseLen   = 4 + 4 + 4 + worktreePlanWorkNameLen
+	worktreePlanDelegateIDMax = 128
+)
+
+// handleWorktreePlan answers what to ask the workspace module for.
+//
+// Role and delegate id arrive as content. The module looks neither up: which
+// delegate is running is the caller's fact, and a module that remembered it
+// would be tracking someone else's state.
+func handleWorktreePlan(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	if len(request) < worktreePlanReqHeaderLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != worktreePlanRequestMagic ||
+		request[4] != wireVersion {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	c := &economicsCursor{buf: request, at: 8}
+	roleLen, idLen := c.u32(), c.u32()
+	if roleLen > roleMax || idLen > worktreePlanDelegateIDMax {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	role := c.str(roleLen)
+	delegateID := c.str(idLen)
+	if c.bad || c.at != len(request) {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	plan, err := PlanWorktree(role, delegateID)
+	if err != nil {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+
+	response := make([]byte, worktreePlanResponseLen)
+	binary.LittleEndian.PutUint32(response[0:4], worktreePlanResponseMagic)
+	putBool(response[4:8], plan.Isolated)
+	putBool(response[8:12], plan.ReadOnlyMount)
+	putFixed(response[12:], plan.WorkName)
+	return response, bus.ModuleStatusOK
+}

--- a/server-go/modules/delegates/worktreeplan_stage_test.go
+++ b/server-go/modules/delegates/worktreeplan_stage_test.go
@@ -1,0 +1,171 @@
+package delegates
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func worktreePlanRequest(role, delegateID string) []byte {
+	req := make([]byte, worktreePlanReqHeaderLen)
+	binary.LittleEndian.PutUint32(req[0:4], worktreePlanRequestMagic)
+	req[4] = wireVersion
+	binary.LittleEndian.PutUint32(req[8:12], uint32(len(role)))
+	binary.LittleEndian.PutUint32(req[12:16], uint32(len(delegateID)))
+	req = append(req, role...)
+	return append(req, delegateID...)
+}
+
+func decodeWorktreePlan(t *testing.T, response []byte) (isolated, readOnly bool, workName string) {
+	t.Helper()
+	if len(response) != worktreePlanResponseLen {
+		t.Fatalf("response is %d bytes, want %d", len(response), worktreePlanResponseLen)
+	}
+	if binary.LittleEndian.Uint32(response[0:4]) != worktreePlanResponseMagic {
+		t.Fatal("wrong response magic")
+	}
+	name := response[12:]
+	if i := bytes.IndexByte(name, 0); i >= 0 {
+		name = name[:i]
+	}
+	return binary.LittleEndian.Uint32(response[4:8]) == 1,
+		binary.LittleEndian.Uint32(response[8:12]) == 1,
+		string(name)
+}
+
+func callWorktreePlan(t *testing.T, role, delegateID string) ([]byte, bus.ModuleStatus) {
+	t.Helper()
+	return Handle(bus.ModuleInvocation{StageID: StageWorktreePlan},
+		worktreePlanRequest(role, delegateID))
+}
+
+// A write role needs its own worktree, named after the delegate so two
+// delegates in one session cannot land in the same directory.
+func TestWorktreePlanStageWriteRoleIsIsolated(t *testing.T) {
+	response, status := callWorktreePlan(t, "code", "delegate-7")
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v, want OK", status)
+	}
+	isolated, readOnly, name := decodeWorktreePlan(t, response)
+	if !isolated {
+		t.Error("a write role should get its own worktree")
+	}
+	if readOnly {
+		t.Error("a write role's mount must not be read-only")
+	}
+	if name != "delegate-7" {
+		t.Errorf("work name = %q, want the delegate id", name)
+	}
+}
+
+// A read-only role mounts the parent's worktree, so there is nothing to create
+// and no name to give it.
+func TestWorktreePlanStageReadRoleCreatesNothing(t *testing.T) {
+	response, status := callWorktreePlan(t, "review", "delegate-7")
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v, want OK", status)
+	}
+	isolated, readOnly, name := decodeWorktreePlan(t, response)
+	if isolated {
+		t.Error("a read-only role should not get its own worktree")
+	}
+	if !readOnly {
+		t.Error("a read-only role's mount must be read-only")
+	}
+	if name != "" {
+		t.Errorf("work name = %q, want empty", name)
+	}
+}
+
+// An alias must reach the same answer as the role it names -- otherwise
+// "implement" would be planned as read-only and edit its parent's worktree.
+func TestWorktreePlanStageResolvesAliases(t *testing.T) {
+	response, status := callWorktreePlan(t, "implement", "d1")
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v, want OK", status)
+	}
+	if isolated, _, _ := decodeWorktreePlan(t, response); !isolated {
+		t.Error("the alias for a write role should be planned as one")
+	}
+}
+
+// The field is sized so the longest accepted name survives intact. Sized
+// exactly it would come back one character short -- a different branch, and
+// silently.
+func TestWorktreePlanStageCarriesTheLongestAcceptedName(t *testing.T) {
+	name := strings.Repeat("a", workNameMax)
+	response, status := callWorktreePlan(t, "code", name)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v, want OK", status)
+	}
+	_, _, got := decodeWorktreePlan(t, response)
+	if got != name {
+		t.Errorf("work name came back %d bytes, want %d", len(got), len(name))
+	}
+}
+
+// A name that cannot be a branch is a refusal, not a plan with the name
+// dropped: a write delegate without its own worktree edits its parent's.
+func TestWorktreePlanStageRefusesUnusableNames(t *testing.T) {
+	for _, id := range []string{
+		"", "../escape", "has space", "-leading-dash", "a/b",
+		"quote'd", strings.Repeat("a", workNameMax+1),
+	} {
+		if _, status := callWorktreePlan(t, "code", id); status != bus.ModuleStatusInvalidRequest {
+			t.Errorf("delegate id %q: status = %v, want InvalidRequest", id, status)
+		}
+	}
+}
+
+// A read-only role needs no name, so an unusable one must not refuse the plan.
+func TestWorktreePlanStageIgnoresTheNameWhenNothingIsCreated(t *testing.T) {
+	if _, status := callWorktreePlan(t, "review", "../escape"); status != bus.ModuleStatusOK {
+		t.Errorf("status = %v, want OK", status)
+	}
+}
+
+func TestWorktreePlanStageRejectsMalformedRequests(t *testing.T) {
+	good := worktreePlanRequest("code", "d1")
+
+	cases := map[string][]byte{
+		"empty":         {},
+		"short header":  good[:8],
+		"trailing byte": append(append([]byte{}, good...), 0),
+	}
+	// A truncated body: the header promises more than is there.
+	truncated := append([]byte{}, good...)
+	cases["truncated body"] = truncated[:len(truncated)-1]
+	// A length field that overruns the buffer entirely.
+	overrun := append([]byte{}, good...)
+	binary.LittleEndian.PutUint32(overrun[12:16], 1<<20)
+	cases["overrun length"] = overrun
+	// A role longer than any role can be.
+	longRole := append([]byte{}, good...)
+	binary.LittleEndian.PutUint32(longRole[8:12], uint32(roleMax+1))
+	cases["oversized role"] = longRole
+
+	badMagic := append([]byte{}, good...)
+	binary.LittleEndian.PutUint32(badMagic[0:4], 0xDEADBEEF)
+	cases["wrong magic"] = badMagic
+
+	badVersion := append([]byte{}, good...)
+	badVersion[4] = wireVersion + 1
+	cases["wrong version"] = badVersion
+
+	for name, request := range cases {
+		_, status := Handle(bus.ModuleInvocation{StageID: StageWorktreePlan}, request)
+		if status != bus.ModuleStatusInvalidRequest {
+			t.Errorf("%s: status = %v, want InvalidRequest", name, status)
+		}
+	}
+}
+
+func TestWorktreePlanStageHonoursCancellation(t *testing.T) {
+	invocation := bus.ModuleInvocation{StageID: StageWorktreePlan, DeadlineNS: 1}
+	if _, status := Handle(invocation, worktreePlanRequest("code", "d1")); status != bus.ModuleStatusCancelled {
+		t.Errorf("status = %v, want Cancelled", status)
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -88,6 +88,7 @@
     "server-go/modules/delegates/dockerargs.go",
     "server-go/modules/delegates/container.go",
     "server-go/modules/delegates/worktreeplan.go",
+    "server-go/modules/delegates/worktreeplan_stage.go",
     "server-go/modules/delegates/proxyguard.go"
   ],
   "go_tests": [
@@ -111,6 +112,7 @@
     "server-go/modules/delegates/dockerargs_test.go",
     "server-go/modules/delegates/container_test.go",
     "server-go/modules/delegates/worktreeplan_test.go",
+    "server-go/modules/delegates/worktreeplan_stage_test.go",
     "server-go/modules/delegates/proxyguard_test.go"
   ],
   "tests": [

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -176,6 +176,11 @@
           "id": 10,
           "name": "delegate-role-policy",
           "event_kind": 6666
+        },
+        {
+          "id": 11,
+          "name": "delegate-worktree-plan",
+          "event_kind": 6667
         }
       ]
     },


### PR DESCRIPTION
feat(delegates): stage 11 -- what a delegate needs from the workspace

PlanWorktree has been sitting in the module unreachable since #2528. This makes
it a stage (event 6667), which is the first of the two calls that run a
delegate: ask what to request, put that to the workspace module, come back with
the answer to have the container specified.

The split into two calls is forced, not stylistic. The worktree has to exist
before there is a path to mount, so the decision and the creation cannot be one
round trip.

WHAT THE MODULE IS NOT TOLD. Role and delegate id arrive as content and are
forgotten. There is still no base ref anywhere in this path -- the workspace
resolves that by policy, and guessing one is what previously let a session
inherit another session's branch.

A REFUSAL IS A REFUSAL. When the delegate id cannot name a branch, this returns
invalid-request rather than a plan with the name left out. A write delegate that
gets no worktree of its own does not fail; it edits its parent's. The refusal
only applies where the name is load-bearing: a read-only role creates nothing,
so an unusable id is simply unused, and both halves are pinned by test.

ONE SIZING BUG CAUGHT WHILE WRITING THIS. putFixed truncates to leave a NUL
terminator, so a work-name field sized at exactly the 64-character maximum would
return a 63-character name -- a DIFFERENT branch than the one decided, and
silently, which is the same class of collision the work name exists to prevent.
The field is now the maximum plus room for the terminator, the 64 is a named
constant used by both the validator and the wire so they cannot drift, and a
test sends a full-length name and asserts it comes back whole.

The lock's serve grant regenerated to include 6667, which is the check that the
stage is reachable rather than merely written.
