### PR TITLE
fix(git): stop warning about a cwd that was never set

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -234,7 +234,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e2d848dda5ce460b4f367279a3bf163dcf887187804d4f646565c692704de416",
+      "source_sha256": "924f2a3517743544895a74bcbd0f53a0749efc79bba91fa12ec5df6547512f1c",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 13,

--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -183,10 +183,17 @@ char *mcp_git_run(const char *cmd, int *exit_code)
        * token unless it says so. It is also what a broken credential-resolve
        * stage looks like from here — that stage going unadvertised silently
        * disabled injection for every git child. */
-      if (have_ws != 0)
+      /* Only when a cwd IS set. run_cmd_get_cwd() returns NULL outside a bound
+       * turn, and those are aimee's own housekeeping git calls — a branch name,
+       * a rev-parse — which need no credential and have no workspace to own
+       * them. Warning on them fired several times per push with an empty path
+       * and said nothing; that was noise this instrumentation introduced. The
+       * real anomaly, and all this now reports, is a cwd that exists and that
+       * no registered workspace claims. */
+      if (have_ws != 0 && cwd && cwd[0])
          LOG_WARN("git",
                   "no registered workspace owns cwd \"%s\": git will run with no forge credential",
-                  cwd ? cwd : "");
+                  cwd);
       if (have_ws == 0)
       {
          /* Resolve the git credential through the ONE policy


### PR DESCRIPTION
Cleaning up noise **I introduced** in #2517.

That change added a warning when no registered workspace owns the git command's cwd — credential injection is skipped in that case, and the only other symptom is git asking for a username. The condition was too broad.

`run_cmd_get_cwd()` returns **NULL** outside a bound turn, and aimee makes plenty of housekeeping git calls there (a branch name, a `rev-parse`) which need no credential and have no workspace to own them. So a single push logged **three** copies of:

```
WARN git: no registered workspace owns cwd "": git will run with no forge credential
```

…with an empty path, sitting right next to the INFO lines showing the push had resolved the vaulted credential perfectly well:

```
INFO git: forge credential for https://github.com/RakuenSoftware/aimee.git resolved from: per-host vault entry
```

**A warning that fires on the healthy path teaches the reader to skip it** — the opposite of why it was added, and exactly the signal-to-noise problem that made `server.log` unreadable in the first place.

It now fires only when a cwd **is** set and no registered workspace claims it. That is the real anomaly: a live checkout the server does not recognise, whose git children therefore run unauthenticated.

## Verification

- All three real links rc=0: `../aimee-server`, `../aimee-kb`, `cmd-srcs-compile-check`
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src format` then `lint` — 48/48
- `refactor_baselines` clean; lock repinned, `git` only