### PR TITLE
fix(economizer): make the fold reachable without shipping wire mutation

### DIFF
--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -834,7 +834,17 @@ native_provider_http:
             reduce_config_t rcfg;
             memset(&rcfg, 0, sizeof rcfg);
             rcfg.delegate_seam = 1;
-            rcfg.history_fold = preset.history_fold && !chatgpt;
+            /* The fold is reachable on its own, not only as part of the AGGRESSIVE
+             * preset. `fold.enabled` already existed in config — parsed, saved, with an
+             * accessor — and had ZERO live callers, so the only way to turn the fold on
+             * was economizer.mode=aggressive, which ALSO switches on compress,
+             * command_filter and gateway_seam mutation of live client requests.
+             *
+             * That bundling makes the fold untestable in isolation: measuring its
+             * prompt-cache behaviour would have meant simultaneously shipping wire
+             * mutation, which is gated on an experiment (S0) that has never been run.
+             * Additive and default-off, so aggressive still folds exactly as before. */
+            rcfg.history_fold = (preset.history_fold || config_fold_enabled()) && !chatgpt;
             rcfg.compress = preset.compress;
             rcfg.freeze_guard_enabled = 1;
             rcfg.freeze_guard_horizon = preset.freeze_guard_horizon;


### PR DESCRIPTION
## Why this exists

Asked why I couldn't just enable the fold on a real server and measure it, I went looking — and the answer was not "permission" or "access". It was that **the lever the measurement needs is welded to a lever the measurement must not pull**.

`fold.enabled` already existed in config — parsed, saved, with a generated accessor — and had **zero live callers**. `config_fold_enabled()` was a dead knob.

The only way to turn the fold on is `economizer.mode=aggressive`, and that preset switches on **five things at once** (`config_econ.c:113`):

```c
out->history_fold = 1;   out->compress = 1;   out->command_filter = 1;
out->freeze_guard_horizon = 1;   out->gateway_seam = 1;
out->gateway_session_disable_ttl_ms = 3600000;
```

`gateway_seam` is **live mutation of client requests** at the `/v1` proxy. So "turn the fold on and measure it" meant "also start rewriting the user's live traffic" — which is gated on the S0 experiment that has never been run.

That is precisely why the fold's prompt-cache behaviour — the one thing standing between this programme and its goal — could not be measured on a real server.

## The change

Honour `config_fold_enabled()` at the **delegate seam**, additive to the preset:

```c
rcfg.history_fold = (preset.history_fold || config_fold_enabled()) && !chatgpt;
```

- `fold.enabled` defaults **off**, so no existing install changes.
- `aggressive` still folds exactly as before.
- What becomes possible: enabling the fold **alone**, on one server, with the gateway untouched.

## What this unblocks

The measurement in #2537 answered retention and cost offline and left cache behaviour explicitly open, because no offline harness can observe it. That half needs realized `cache_read` / `cache_write` counts — which aimee **already records** (`agent_ingress_record_cost`) and **already reports**:

```
$ aimee insights --days 1
  calls: 28   prompt tokens: 825218   cache write: 0   cache read: 73600
```

So the A/B is now genuinely runnable: set `fold.enabled` on one server, drive comparable multi-turn work, and diff the cache ratios — without touching gateway mutation.

## Deliberately not done here

**Flipping it anywhere.** This makes the experiment possible; it does not run it. Enabling the fold on a live server is a real behaviour change and should be a decision taken with eyes open, not a side effect of a PR that claims to be about wiring.

## Verification

- `rm -f aimee-server && make -C src -j8 ../aimee-server` — exit 0, zero undefined references
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — all checks passed (`format` run first)
- `check_c_repository_lock`, `refactor_baselines` — no drift

One honest caveat: the change is a single expression in the runtime's config assembly, and there is no unit-test surface over `rcfg` construction. It is verified by build, link, suite and lint — not by a test that asserts the wiring. A test would need a seam that does not currently exist.