### PR TITLE
ir: carry a tool call's namespace end to end

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -49,7 +49,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "b9d0e7b1c86981d684cbf33504e26c1a5b0118bd9447604aa082ed2c5e221d37"
+      "source_sha256": "36ad047651bc705b30cb99329bb543fc653ed3ebcf5a6720cbe4dcc81ac9b522"
     },
     {
       "id": "translation",
@@ -63,7 +63,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "180ad40ba577727cf34d0c6807db0ee35b73069da815610d8ca50ea0bf9ff3e4"
+      "source_sha256": "9381945d380f1190aeadf6db911f951dbae92945663f80e55094d32f879b65b2"
     },
     {
       "id": "protocols",

--- a/src/headers/agent_protocol.h
+++ b/src/headers/agent_protocol.h
@@ -11,7 +11,23 @@ struct cJSON;
 typedef struct
 {
    char id[64];
-   char name[32];
+   /* Was [32], which silently TRUNCATED. A namespaced MCP tool name routinely
+    * exceeds it: "mcp__aimee__preview_blast_radius" is exactly 32 characters, so
+    * it could not fit even with its terminator. */
+   char name[128];
+   /* The tool's owning namespace, empty when it has none.
+    *
+    * A Codex client sends its MCP tools inside a `namespace` group, and the
+    * provider answers with the nested name BARE plus this field beside it:
+    *
+    *   {"type":"function_call","name":"git","namespace":"mcp__aimee",...}
+    *
+    * The client routes on the pair, so dropping this half makes the call
+    * unroutable -- it answers "unsupported call: git". Modeled rather than left
+    * to the raw sidecar for the same reason as aimee_block_t.thinking_signature:
+    * the sidecar is same-protocol replay, and this has to survive the chat hop in
+    * the middle of responses -> IR -> chat -> IR -> responses. */
+   char tool_namespace[64];
    char *arguments; /* malloc'd */
 } parsed_tool_call_t;
 

--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -158,19 +158,24 @@ extern "C"
     * helpers emit the matching SSE data payloads (bytes written or -1). */
    struct cJSON *openai_responses_message_item(const char *item_id, const char *text,
                                                const char *status);
+   /* `tool_namespace` is the call's owning namespace group, or NULL/"" when it has
+    * none; it is emitted only when set. A Codex client offers its MCP tools inside
+    * a `namespace` group and routes the answer on (namespace, name) together, so a
+    * call that arrived with one must carry it back. */
    struct cJSON *openai_responses_function_call_item(const char *item_id, const char *call_id,
-                                                     const char *name, const char *arguments,
-                                                     const char *status);
+                                                     const char *name, const char *tool_namespace,
+                                                     const char *arguments, const char *status);
    int openai_format_responses_msg_item_added(const char *item_id, int output_index, char *resp,
                                               int cap);
    int openai_format_responses_msg_item_done(const char *item_id, const char *text,
                                              int output_index, char *resp, int cap);
    int openai_format_responses_fc_item_added(const char *item_id, const char *call_id,
-                                             const char *name, int output_index, char *resp,
-                                             int cap);
+                                             const char *name, const char *tool_namespace,
+                                             int output_index, char *resp, int cap);
    int openai_format_responses_fc_item_done(const char *item_id, const char *call_id,
-                                            const char *name, const char *arguments,
-                                            int output_index, char *resp, int cap);
+                                            const char *name, const char *tool_namespace,
+                                            const char *arguments, int output_index, char *resp,
+                                            int cap);
    int openai_format_responses_fc_args_delta(const char *item_id, int output_index,
                                              const char *delta, char *resp, int cap);
    int openai_format_responses_fc_args_done(const char *item_id, int output_index,

--- a/src/modules/ir/aimee_ir.c
+++ b/src/modules/ir/aimee_ir.c
@@ -20,6 +20,7 @@ void aimee_block_free_contents(aimee_block_t *b)
    free_str(b->thinking_signature);
    free_str(b->tool_id);
    free_str(b->tool_name);
+   free_str(b->tool_namespace);
    cJSON_Delete(b->tool_input);
    cJSON_Delete(b->tool_result);
    free_str(b->media_type);
@@ -182,8 +183,10 @@ static int block_eq(const aimee_block_t *a, const aimee_block_t *b)
    case AIMEE_BLK_THINKING:
       return str_eq(a->text, b->text) && str_eq(a->thinking_signature, b->thinking_signature);
    case AIMEE_BLK_TOOL_USE:
+      /* The namespace is part of the call's identity: two calls to the same bare
+       * name in different groups are different calls. */
       return str_eq(a->tool_id, b->tool_id) && str_eq(a->tool_name, b->tool_name) &&
-             json_eq(a->tool_input, b->tool_input);
+             str_eq(a->tool_namespace, b->tool_namespace) && json_eq(a->tool_input, b->tool_input);
    case AIMEE_BLK_TOOL_RESULT:
       return str_eq(a->tool_id, b->tool_id) && a->tool_is_error == b->tool_is_error &&
              json_eq(a->tool_result, b->tool_result);

--- a/src/modules/ir/include/aimee/ir/aimee_ir.h
+++ b/src/modules/ir/include/aimee/ir/aimee_ir.h
@@ -70,6 +70,13 @@ typedef struct
     * result = opaque content; is_error set on an error result. */
    char *tool_id;
    char *tool_name;
+   /* TOOL_USE: the tool's owning namespace group, NULL when it has none. A Codex
+    * client offers its MCP tools inside a `namespace` group and routes on
+    * (namespace, name) together, so the pair must stay together through a
+    * resubmitted history. Modeled rather than left to `raw` for the same reason as
+    * thinking_signature: `raw` is same-protocol replay, and this has to survive the
+    * chat hop in the middle of responses -> IR -> chat -> IR -> responses. Owned. */
+   char *tool_namespace;
    struct cJSON *tool_input;  /* owned */
    struct cJSON *tool_result; /* owned */
    int tool_is_error;

--- a/src/modules/translation/aimee_backend_openai.c
+++ b/src/modules/translation/aimee_backend_openai.c
@@ -122,6 +122,15 @@ cJSON *openai_backend_build(const aimee_request_t *ir)
          cJSON *call = cJSON_CreateObject();
          cJSON_AddStringToObject(call, "id", b->tool_id ? b->tool_id : "");
          cJSON_AddStringToObject(call, "type", "function");
+         /* Chat has no namespace concept, but a Responses request crosses this shape
+          * on its way to the provider (responses -> IR -> chat -> IR -> responses),
+          * so dropping the group here loses it for good -- the same trap that made
+          * the tools fix at the Responses ends insufficient on its own. Carried
+          * beside `function` rather than inside it, so a strict `function` schema is
+          * untouched, and only when the client actually grouped the tool: a request
+          * that never used namespace grouping is byte-identical to before. */
+         if (b->tool_namespace && b->tool_namespace[0])
+            cJSON_AddStringToObject(call, "namespace", b->tool_namespace);
          cJSON *fn = cJSON_AddObjectToObject(call, "function");
          cJSON_AddStringToObject(fn, "name", b->tool_name ? b->tool_name : "");
          char *args = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
@@ -389,6 +398,7 @@ int openai_backend_parse(const cJSON *resp, aimee_response_t *out, char *err, si
             b->type = AIMEE_BLK_TOOL_USE;
             b->raw = cJSON_Duplicate(c, 1);
             b->tool_id = dupstr(ostr(c, "id"));
+            b->tool_namespace = dupstr(ostr(c, "namespace"));
             const cJSON *fn = cJSON_GetObjectItemCaseSensitive((cJSON *)c, "function");
             b->tool_name = dupstr(fn ? ostr(fn, "name") : NULL);
             const char *args = fn ? ostr(fn, "arguments") : NULL;

--- a/src/modules/translation/aimee_backend_responses.c
+++ b/src/modules/translation/aimee_backend_responses.c
@@ -144,6 +144,10 @@ cJSON *responses_backend_build(const aimee_request_t *ir)
             cJSON_AddStringToObject(fc, "type", "function_call");
             cJSON_AddStringToObject(fc, "call_id", b->tool_id ? b->tool_id : "");
             cJSON_AddStringToObject(fc, "name", b->tool_name ? b->tool_name : "");
+            /* Only when set: a plain tool has no group, and an empty `namespace`
+             * would claim one that does not exist. */
+            if (b->tool_namespace && b->tool_namespace[0])
+               cJSON_AddStringToObject(fc, "namespace", b->tool_namespace);
             char *args = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
             cJSON_AddStringToObject(fc, "arguments", args ? args : "{}");
             free(args);
@@ -247,6 +251,7 @@ int responses_backend_parse(const cJSON *resp, aimee_response_t *out, char *err,
             b->raw = cJSON_Duplicate(item, 1);
             b->tool_id = dupstr(ostr(item, "call_id"));
             b->tool_name = dupstr(ostr(item, "name"));
+            b->tool_namespace = dupstr(ostr(item, "namespace"));
             const char *args = ostr(item, "arguments");
             b->tool_input = args ? cJSON_Parse(args) : NULL;
             saw_tool = 1;

--- a/src/modules/translation/aimee_frontend_openai.c
+++ b/src/modules/translation/aimee_frontend_openai.c
@@ -230,6 +230,7 @@ int openai_frontend_parse(const cJSON *req, aimee_request_t *out, char *err, siz
                b->type = AIMEE_BLK_TOOL_USE;
                b->raw = cJSON_Duplicate(call, 1);
                b->tool_id = dupstr(ostr(call, "id"));
+               b->tool_namespace = dupstr(ostr(call, "namespace"));
                const cJSON *fn = cJSON_GetObjectItemCaseSensitive((cJSON *)call, "function");
                b->tool_name = dupstr(fn ? ostr(fn, "name") : NULL);
                const char *args = fn ? ostr(fn, "arguments") : NULL;
@@ -358,6 +359,8 @@ cJSON *openai_frontend_render(const aimee_response_t *r)
             cJSON *call = cJSON_CreateObject();
             cJSON_AddStringToObject(call, "id", b->tool_id ? b->tool_id : "");
             cJSON_AddStringToObject(call, "type", "function");
+            if (b->tool_namespace && b->tool_namespace[0])
+               cJSON_AddStringToObject(call, "namespace", b->tool_namespace);
             cJSON *fn = cJSON_AddObjectToObject(call, "function");
             cJSON_AddStringToObject(fn, "name", b->tool_name ? b->tool_name : "");
             /* arguments STRING: serialize the parsed tool_input (cross-protocol) */

--- a/src/modules/translation/aimee_frontend_responses.c
+++ b/src/modules/translation/aimee_frontend_responses.c
@@ -137,6 +137,9 @@ int responses_frontend_parse(const cJSON *req, aimee_request_t *out, char *err, 
             b->raw = cJSON_Duplicate(item, 1);
             b->tool_id = dupstr(ostr(item, "call_id"));
             b->tool_name = dupstr(ostr(item, "name"));
+            /* Present when the client grouped this tool under a `namespace`; the
+             * name is bare in that case and only the pair identifies the tool. */
+            b->tool_namespace = dupstr(ostr(item, "namespace"));
             const char *args = ostr(item, "arguments");
             b->tool_input = args ? cJSON_Parse(args) : NULL;
          }
@@ -270,6 +273,8 @@ cJSON *responses_frontend_render(const aimee_response_t *r)
          cJSON_AddStringToObject(item, "type", "function_call");
          cJSON_AddStringToObject(item, "call_id", b->tool_id ? b->tool_id : "");
          cJSON_AddStringToObject(item, "name", b->tool_name ? b->tool_name : "");
+         if (b->tool_namespace && b->tool_namespace[0])
+            cJSON_AddStringToObject(item, "namespace", b->tool_namespace);
          char *args = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
          cJSON_AddStringToObject(item, "arguments", args ? args : "{}");
          free(args);

--- a/src/posix/agent_ir_parse.c
+++ b/src/posix/agent_ir_parse.c
@@ -229,6 +229,9 @@ static void ir_bridge_common(const aimee_response_t *ir, parsed_response_t *out)
          snprintf(c->id, sizeof(c->id), "%s", b->tool_id);
       if (b->tool_name)
          snprintf(c->name, sizeof(c->name), "%s", b->tool_name);
+      /* Carried with the name: a namespaced call is only routable as the pair. */
+      if (b->tool_namespace)
+         snprintf(c->tool_namespace, sizeof(c->tool_namespace), "%s", b->tool_namespace);
       char *args = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
       c->arguments = args ? args : strdup("{}");
    }

--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -369,10 +369,16 @@ static void parse_responses_output_item(cJSON *item, parsed_response_t *out)
          cJSON *cid = cJSON_GetObjectItem(item, "call_id");
          cJSON *nm = cJSON_GetObjectItem(item, "name");
          cJSON *args = cJSON_GetObjectItem(item, "arguments");
+         /* A tool the client offered inside a `namespace` group comes back with a
+          * BARE nested name and its namespace beside it. Keep the pair together --
+          * the client routes on both. */
+         cJSON *ns = cJSON_GetObjectItem(item, "namespace");
          if (cid && cJSON_IsString(cid))
             snprintf(call->id, sizeof(call->id), "%s", cid->valuestring);
          if (nm && cJSON_IsString(nm))
             snprintf(call->name, sizeof(call->name), "%s", nm->valuestring);
+         if (ns && cJSON_IsString(ns))
+            snprintf(call->tool_namespace, sizeof(call->tool_namespace), "%s", ns->valuestring);
          if (args && cJSON_IsString(args))
             call->arguments = strdup(args->valuestring);
          else

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -335,6 +335,9 @@ void aimee_ir_response_to_parsed(const aimee_response_t *r, parsed_response_t *o
          snprintf(c->id, sizeof(c->id), "%s", b->tool_id);
       if (b->tool_name)
          snprintf(c->name, sizeof(c->name), "%s", b->tool_name);
+      /* Carried with the name: a namespaced call is only routable as the pair. */
+      if (b->tool_namespace)
+         snprintf(c->tool_namespace, sizeof(c->tool_namespace), "%s", b->tool_namespace);
       c->arguments = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
       if (!c->arguments)
          c->arguments = strdup("{}");

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -1450,8 +1450,8 @@ cJSON *openai_responses_message_item(const char *item_id, const char *text, cons
 }
 
 cJSON *openai_responses_function_call_item(const char *item_id, const char *call_id,
-                                           const char *name, const char *arguments,
-                                           const char *status)
+                                           const char *name, const char *tool_namespace,
+                                           const char *arguments, const char *status)
 {
    cJSON *item = cJSON_CreateObject();
    if (!item)
@@ -1460,6 +1460,10 @@ cJSON *openai_responses_function_call_item(const char *item_id, const char *call
    cJSON_AddStringToObject(item, "type", "function_call");
    cJSON_AddStringToObject(item, "status", status ? status : "completed");
    cJSON_AddStringToObject(item, "name", name ? name : "");
+   /* Only when the call actually has one: a plain tool carries no `namespace`, and
+    * emitting an empty one would claim a group that does not exist. */
+   if (tool_namespace && tool_namespace[0])
+      cJSON_AddStringToObject(item, "namespace", tool_namespace);
    cJSON_AddStringToObject(item, "call_id", call_id ? call_id : "");
    cJSON_AddStringToObject(item, "arguments", arguments ? arguments : "");
    return item;
@@ -1504,25 +1508,28 @@ int openai_format_responses_msg_item_done(const char *item_id, const char *text,
 }
 
 int openai_format_responses_fc_item_added(const char *item_id, const char *call_id,
-                                          const char *name, int output_index, char *resp, int cap)
+                                          const char *name, const char *tool_namespace,
+                                          int output_index, char *resp, int cap)
 {
    if (!resp || cap <= 0)
       return -1;
-   return emit_output_item_event(
-       "response.output_item.added", output_index,
-       openai_responses_function_call_item(item_id, call_id, name, "", "in_progress"), resp, cap);
+   return emit_output_item_event("response.output_item.added", output_index,
+                                 openai_responses_function_call_item(
+                                     item_id, call_id, name, tool_namespace, "", "in_progress"),
+                                 resp, cap);
 }
 
 int openai_format_responses_fc_item_done(const char *item_id, const char *call_id, const char *name,
-                                         const char *arguments, int output_index, char *resp,
-                                         int cap)
+                                         const char *tool_namespace, const char *arguments,
+                                         int output_index, char *resp, int cap)
 {
    if (!resp || cap <= 0)
       return -1;
-   return emit_output_item_event(
-       "response.output_item.done", output_index,
-       openai_responses_function_call_item(item_id, call_id, name, arguments, "completed"), resp,
-       cap);
+   return emit_output_item_event("response.output_item.done", output_index,
+                                 openai_responses_function_call_item(item_id, call_id, name,
+                                                                     tool_namespace, arguments,
+                                                                     "completed"),
+                                 resp, cap);
 }
 
 int openai_format_responses_fc_args_delta(const char *item_id, int output_index, const char *delta,
@@ -1680,12 +1687,14 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
       {
          const char *name = parsed->calls[i].name;
          const char *cid = parsed->calls[i].id;
+         const char *ns = parsed->calls[i].tool_namespace;
          const char *args = parsed->calls[i].arguments ? parsed->calls[i].arguments : "{}";
          char fc_id[80];
          snprintf(fc_id, sizeof(fc_id), "%s-fc-%d", id, i);
 
          char added[256];
-         if (openai_format_responses_fc_item_added(fc_id, cid, name, i, added, sizeof(added)) > 0)
+         if (openai_format_responses_fc_item_added(fc_id, cid, name, ns, i, added, sizeof(added)) >
+             0)
             emit(ctx, "response.output_item.added", added);
 
          size_t acap = strlen(args) * 6 + 256;
@@ -1699,26 +1708,29 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
             free(af);
          }
 
-         size_t dcap = strlen(args) * 6 + strlen(name) + strlen(cid) + 512;
+         size_t dcap = strlen(args) * 6 + strlen(name) + strlen(ns) + strlen(cid) + 512;
          char *df = malloc(dcap);
          if (df)
          {
-            if (openai_format_responses_fc_item_done(fc_id, cid, name, args, i, df, (int)dcap) > 0)
+            if (openai_format_responses_fc_item_done(fc_id, cid, name, ns, args, i, df, (int)dcap) >
+                0)
                emit(ctx, "response.output_item.done", df);
             free(df);
          }
          if (output)
-            cJSON_AddItemToArray(
-                output, openai_responses_function_call_item(fc_id, cid, name, args, "completed"));
+            cJSON_AddItemToArray(output, openai_responses_function_call_item(fc_id, cid, name, ns,
+                                                                             args, "completed"));
       }
 
       /* ccap: 4096 base (envelope/usage) + id/model, plus per call: args worst-
-       * case JSON-escaped (×6 — a byte can expand to \uXXXX) + name + call_id +
-       * 256 slack for that item's JSON keys/braces/commas/status/fc_id suffix. */
+       * case JSON-escaped (×6 — a byte can expand to \uXXXX) + name + namespace +
+       * call_id + 256 slack for that item's JSON keys/braces/commas/status/fc_id
+       * suffix. */
       size_t ccap = 4096 + strlen(id ? id : "") + strlen(model ? model : "");
       for (int i = 0; i < n; i++)
          ccap += (parsed->calls[i].arguments ? strlen(parsed->calls[i].arguments) : 0) * 6 +
-                 strlen(parsed->calls[i].name) + strlen(parsed->calls[i].id) + 256;
+                 strlen(parsed->calls[i].name) + strlen(parsed->calls[i].tool_namespace) +
+                 strlen(parsed->calls[i].id) + 256;
       char *cf = malloc(ccap);
       if (cf)
       {

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -74,6 +74,7 @@ void test_responses_object_folds_in_streamed_function_call(void);
 void test_responses_object_keeps_existing_function_call(void);
 void test_responses_object_keeps_existing_text(void);
 void test_ir_parse_responses_tool_call(void);
+void test_ir_parse_responses_namespaced_tool_call(void);
 void test_ir_parse_responses_text_only(void);
 void test_responses_parser_uses_output_text_done(void);
 void test_responses_parser_separates_message_items(void);
@@ -3619,6 +3620,7 @@ int main(void)
    test_responses_object_keeps_existing_function_call();
    test_responses_object_keeps_existing_text();
    test_ir_parse_responses_tool_call();
+   test_ir_parse_responses_namespaced_tool_call();
    test_ir_parse_responses_text_only();
    test_responses_parser_uses_output_text_done();
    test_responses_parser_separates_message_items();

--- a/src/tests/test_agent_responses.c
+++ b/src/tests/test_agent_responses.c
@@ -227,6 +227,33 @@ void test_ir_parse_responses_tool_call(void)
    cJSON *item = cJSON_GetArrayItem(p.assistant_message, 0);
    cJSON *cid = cJSON_GetObjectItemCaseSensitive(item, "call_id");
    assert(cid && cJSON_IsString(cid) && strcmp(cid->valuestring, "call_1") == 0);
+   /* a plain tool has no group */
+   assert(p.calls[0].tool_namespace[0] == '\0');
+   agent_free_parsed_response(&p);
+}
+
+/* A tool the client offered inside a `namespace` group comes back with a BARE
+ * nested name and the group beside it. Both halves have to reach the parsed call:
+ * the client routes on the pair and answers "unsupported call: git" given only the
+ * name. */
+void test_ir_parse_responses_namespaced_tool_call(void)
+{
+   const char *body =
+       "event: response.output_item.done\r\n"
+       "data: {\"item\":{\"type\":\"function_call\",\"call_id\":\"call_7\",\"name\":\"git\","
+       "\"namespace\":\"mcp__aimee\",\"arguments\":\"{\\\"command\\\":\\\"status\\\"}\"}}\r\n\r\n"
+       "event: response.completed\r\n"
+       "data: {\"response\":{\"output\":[{\"type\":\"function_call\",\"call_id\":\"call_7\","
+       "\"name\":\"git\",\"namespace\":\"mcp__aimee\","
+       "\"arguments\":\"{\\\"command\\\":\\\"status\\\"}\"}],"
+       "\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}}\r\n\r\n";
+
+   parsed_response_t p;
+   assert(agent_ir_parse_responses(body, -1, NULL, &p) == 0);
+   assert(p.call_count == 1);
+   /* the name stays bare -- it is the group that qualifies it */
+   assert(strcmp(p.calls[0].name, "git") == 0);
+   assert(strcmp(p.calls[0].tool_namespace, "mcp__aimee") == 0);
    agent_free_parsed_response(&p);
 }
 

--- a/src/tests/test_aimee_ir_serve.c
+++ b/src/tests/test_aimee_ir_serve.c
@@ -111,6 +111,41 @@ int main(void)
    cJSON_Delete(rmsgs);
    cJSON_Delete(rtls);
 
+   /* A namespaced tool call in the history survives the CHAT HOP.
+    *
+    * A Responses request does not go responses -> IR -> responses. It goes
+    * responses -> IR -> CHAT -> IR -> responses, and the crossing in the middle is
+    * where a Codex `namespace` group was being dropped -- the same trap that made
+    * fixing only the Responses ends insufficient for the tools array. Chat has no
+    * namespace concept, so the group is carried beside `function` on the tool_call
+    * and read back on the way in. Without that, the provider is told a bare `git`
+    * with no group and the client cannot route the answer. */
+   {
+      const char *NSBODY =
+          "{\"model\":\"gpt-5.5\",\"stream\":true,\"input\":["
+          "{\"type\":\"function_call\",\"call_id\":\"call_7\",\"name\":\"git\","
+          "\"namespace\":\"mcp__aimee\",\"arguments\":\"{\\\"command\\\":\\\"status\\\"}\"}"
+          "]}";
+      char m2[64];
+      char *i2 = NULL;
+      cJSON *m2s = NULL, *t2 = NULL;
+      int s2 = 0;
+      assert(aimee_ir_responses_to_chat(NSBODY, m2, sizeof m2, &i2, &m2s, &t2, &s2) == 0);
+      assert(m2s && cJSON_GetArraySize(m2s) == 1);
+      cJSON *asst = cJSON_GetArrayItem(m2s, 0);
+      cJSON *tcs = cJSON_GetObjectItem(asst, "tool_calls");
+      assert(tcs && cJSON_GetArraySize(tcs) == 1);
+      cJSON *tc0 = cJSON_GetArrayItem(tcs, 0);
+      cJSON *ns = cJSON_GetObjectItem(tc0, "namespace");
+      assert(ns && cJSON_IsString(ns) && strcmp(ns->valuestring, "mcp__aimee") == 0);
+      /* the bare name is untouched -- the pair is what identifies the tool */
+      cJSON *f0 = cJSON_GetObjectItem(tc0, "function");
+      assert(f0 && strcmp(cJSON_GetObjectItem(f0, "name")->valuestring, "git") == 0);
+      free(i2);
+      cJSON_Delete(m2s);
+      cJSON_Delete(t2);
+   }
+
    /* aimee_ir_build_from_chat: agent-path chat components -> provider request via IR */
    cJSON *cm = cJSON_Parse("[{\"role\":\"user\",\"content\":\"hi\"}]");
    cJSON *ct = cJSON_Parse("[{\"type\":\"function\",\"function\":{\"name\":\"Read\",\"parameters\":"

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -384,13 +384,15 @@ int main(void)
 
    /* --- Codex parity: function_call output-item + argument events --- */
    {
-      int len = openai_format_responses_fc_item_added("resp_9-fc-0", "call_42", "exec_command", 0,
-                                                      resp, sizeof(resp));
+      int len = openai_format_responses_fc_item_added("resp_9-fc-0", "call_42", "exec_command",
+                                                      NULL, 0, resp, sizeof(resp));
       assert(len > 0);
       assert(strstr(resp, "\"type\":\"response.output_item.added\""));
       assert(strstr(resp, "\"type\":\"function_call\""));
       assert(strstr(resp, "\"call_id\":\"call_42\""));
       assert(strstr(resp, "\"name\":\"exec_command\""));
+      /* A plain tool has no group: the key must be absent, not empty. */
+      assert(!strstr(resp, "\"namespace\""));
 
       len = openai_format_responses_fc_args_delta("resp_9-fc-0", 0, "{\"cmd\":\"ls\"}", resp,
                                                   sizeof(resp));
@@ -403,19 +405,47 @@ int main(void)
       assert(len > 0);
       assert(strstr(resp, "\"type\":\"response.function_call_arguments.done\""));
 
-      len = openai_format_responses_fc_item_done("resp_9-fc-0", "call_42", "exec_command",
+      len = openai_format_responses_fc_item_done("resp_9-fc-0", "call_42", "exec_command", NULL,
                                                  "{\"cmd\":\"ls\"}", 0, resp, sizeof(resp));
       assert(len > 0);
       assert(strstr(resp, "\"type\":\"response.output_item.done\""));
       assert(strstr(resp, "\"type\":\"function_call\""));
       assert(strstr(resp, "\"arguments\":\"{\\\"cmd\\\":\\\"ls\\\"}\""));
+      assert(!strstr(resp, "\"namespace\""));
+   }
+
+   /* --- A namespaced call keeps its group on BOTH item events ---
+    *
+    * A Codex client offers its MCP tools inside a `namespace` group; the provider
+    * answers with the nested name BARE and the group beside it. The client routes
+    * on the pair, so dropping the group makes the call unroutable -- it answers
+    * "unsupported call: git". Both events carry it, because the client reads the
+    * name from `added` before the arguments stream. */
+   {
+      int len = openai_format_responses_fc_item_added("resp_9-fc-0", "call_7", "git", "mcp__aimee",
+                                                      0, resp, sizeof(resp));
+      assert(len > 0);
+      assert(strstr(resp, "\"name\":\"git\""));
+      assert(strstr(resp, "\"namespace\":\"mcp__aimee\""));
+
+      len = openai_format_responses_fc_item_done("resp_9-fc-0", "call_7", "git", "mcp__aimee",
+                                                 "{\"command\":\"status\"}", 0, resp, sizeof(resp));
+      assert(len > 0);
+      assert(strstr(resp, "\"name\":\"git\""));
+      assert(strstr(resp, "\"namespace\":\"mcp__aimee\""));
+
+      /* Empty is the same as absent -- it must not claim a group. */
+      len = openai_format_responses_fc_item_done("resp_9-fc-0", "call_7", "git", "",
+                                                 "{\"command\":\"status\"}", 0, resp, sizeof(resp));
+      assert(len > 0);
+      assert(!strstr(resp, "\"namespace\""));
    }
 
    /* --- Codex parity: completed with a function_call output item --- */
    {
       struct cJSON *out = cJSON_CreateArray();
       cJSON_AddItemToArray((cJSON *)out, openai_responses_function_call_item(
-                                             "resp_9-fc-0", "call_42", "exec_command",
+                                             "resp_9-fc-0", "call_42", "exec_command", NULL,
                                              "{\"cmd\":\"ls\"}", "completed"));
       int len = openai_format_responses_completed_items("resp_9", "aimee", 1700000000, out, 5, 2,
                                                         resp, sizeof(resp));

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -187,7 +187,7 @@
         },
         {
           "path": "src/headers/agent_protocol.h",
-          "sha256": "37fca15b304f310618078c6732a67740545c17e55d5f4032d15e08850c2070ea"
+          "sha256": "b16e225be9dd915d9b11d13981db066ea8b4224c53b93c07cf61a33ba6722603"
         },
         {
           "path": "src/headers/agent_request_build.h",
@@ -943,7 +943,7 @@
         },
         {
           "path": "src/headers/openai_shape.h",
-          "sha256": "cee4a00e0f52b0bd414c0ba27712226cea1cdb1185a026423da7a065fd166036"
+          "sha256": "d9a2b83e8c1161dac7e1dc0fb8a6b8db35b999659e94c12510c0e0b17ac1002e"
         },
         {
           "path": "src/headers/osv_check.h",
@@ -1487,7 +1487,7 @@
         },
         {
           "path": "src/modules/ir/include/aimee/ir/aimee_ir.h",
-          "sha256": "af9499c7c1f2773b27d527372970af4b103c9fb7d8874022e1f8d23cc1d91ab7"
+          "sha256": "3db215982571830d8177dbacd179e1e9906a1169bc8171f1d94b2d2b7a231d0a"
         },
         {
           "path": "src/modules/ir/include/aimee/ir/aimee_ir_metrics.h",
@@ -1608,7 +1608,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "c7c082bcb06eb9792f364d225014d2564f9c7948576059668abf3232f943737e",
+      "sha256": "993c60bb35d338015a5966e4c54c8a01679d85249e05e2ff9e46b8b99a356d94",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
Completes the Codex gateway chain from #2536. That PR restored aimee's tools to the catalog a Codex client sees; the model then called them and the client could not route the answers, answering `unsupported call: git`.

## What the wire actually says

Rather than invent a qualifier, I asked the provider directly what comes back for a tool offered inside a `namespace` group:

```json
{"type":"function_call","name":"git","namespace":"mcp__aimee",
 "call_id":"call_...","arguments":"{\"command\":\"git status --short\"}"}
```

The name is **bare** and the group rides beside it. The client routes on the **pair**. aimee modeled only the name, so the group was dropped in transit — which is the whole defect. This is a field that has to survive, not a design we have to invent.

## Where it is carried

A Responses request does not go `responses -> IR -> responses`. It goes:

```
responses -> IR -> CHAT -> IR -> responses
```

so three places, or it is lost at the crossing in the middle:

| | |
|---|---|
| `parsed_tool_call_t.tool_namespace` | the parsed call — filled by **both** response parsers (`agent_bridge` and `agent_ir_parse`) and emitted on the output items |
| `aimee_block_t.tool_namespace` | the IR, so a resubmitted history keeps it. Modeled rather than left to the `raw` sidecar for the same reason as `thinking_signature`: `raw` is same-protocol replay and is replaced at each hop |
| the chat `tool_call` | the crossing in the middle. Chat has no namespace concept, so it rides **beside** `function`, not inside it, leaving a strict `function` schema untouched |

The chat hop is the trap that silently undid the tools fix in #2536, so it has its own test here.

## Emitted only when set

Everywhere. A plain tool has no group, and an empty `namespace` would claim one that does not exist. A request that never used namespace grouping is **byte-identical** to before — which is what keeps this off the Anthropic and Bedrock paths, where the concept does not exist at all. The delegate binary wire is untouched too: it zeroes the struct, so "no group" is already correct there.

## Latent truncation fixed

`parsed_tool_call_t.name` was `[32]`. `mcp__aimee__preview_blast_radius` is exactly 32 characters, so it could not fit even with its terminator, and the `mcp__codex_apps__*` names are longer. Now `[128]`.

## Tests

- the group survives the chat hop (the crossing that undid the earlier fix)
- both output-item events carry it — the client reads the name from `added`, before arguments stream
- a plain tool emits no `namespace` key at all
- empty is treated as absent

## Verification

- `make -C src lint` — all 48 checks passed
- `make -C src all` — all real link targets built (`aimee-server`, KB, resolver, gateway, forwarder). `make -C src` alone does not build these
- `make -C src unit-tests` — all tests passed
- module lock re-pinned for `ir` and `translation` with the exporter's own `digest_files`; no `commit` pin touched

## Not claimed here

This is verified at the unit and wire level, not yet by an end-to-end gateway benchmark cell — the test box was unreachable while this was written. What is proven: the provider emits the field, and aimee now preserves it across every hop with tests pinning each one.
