### PR TITLE
bench: rig for measuring the fold's prompt-cache behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ scratchpad/
 # Transient deploy/sync bundles for the test container.
 .synctmp/
 src/.testlogs/
+benchmarks/compaction-quality/.cache-ab/

--- a/benchmarks/compaction-quality/cache-ab.sh
+++ b/benchmarks/compaction-quality/cache-ab.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# cache-ab.sh: measure what the fold does to PROMPT-CACHE behaviour.
+#
+# This is the half of the fold-vs-compactor question that no offline harness can answer
+# (see benchmarks/compaction-quality/retention_probe.c, which measures retention and cost
+# and stops there). Cache hits are a property of real traffic against a real provider, so
+# the numbers have to come off realized usage - which aimee already records and
+# `aimee insights` already reports.
+#
+# It SNAPSHOTS and DIFFS. It deliberately does NOT flip config and does NOT drive the
+# workload:
+#   - flipping is a live behaviour change and should be a deliberate command someone
+#     types, not a side effect buried in a measurement script;
+#   - the workload is a delegate dispatch, which happens through the MCP tool, not a
+#     shell.
+#
+# USAGE
+#   ./cache-ab.sh snapshot before-off
+#   ...run the workload...
+#   ./cache-ab.sh snapshot after-off
+#   aimee config set fold.enabled true          # the deliberate step, typed by a human
+#   ./cache-ab.sh snapshot before-on
+#   ...run the SAME workload...
+#   ./cache-ab.sh snapshot after-on
+#   ./cache-ab.sh diff before-off after-off
+#   ./cache-ab.sh diff before-on  after-on
+#   aimee config set fold.enabled false         # restore
+#
+# READING IT. The number that matters is cache_read as a share of prompt tokens. The
+# fold's freeze exists to keep the folded prefix byte-identical turn to turn; if it holds,
+# cache_read/prompt should be comparable or better with the fold on, while prompt tokens
+# themselves fall. If cache_read collapses while prompt falls, the fold is buying smaller
+# requests by throwing away cache warmth - the regression the freeze is meant to prevent,
+# and the reason this is measured rather than argued.
+#
+# CONFOUNDS, stated because they can invalidate the result:
+#   - insights is AGGREGATE over aimee's own agent traffic. Any other delegate or
+#     roundtable running in the window lands in the same totals. Run it quiet.
+#   - cache_read only accrues on a warm prefix, so a workload of one short turn measures
+#     nothing. Use several turns over the same context.
+#   - the two arms must be the SAME work. Different tasks produce different cache shapes
+#     and the comparison is then meaningless.
+set -eu
+
+DIR="${CACHE_AB_DIR:-benchmarks/compaction-quality/.cache-ab}"
+DAYS="${CACHE_AB_DAYS:-1}"
+
+usage() { sed -n '2,40p' "$0"; exit 2; }
+
+case "${1:-}" in
+snapshot)
+   [ $# -eq 2 ] || usage
+   mkdir -p "$DIR"
+   aimee --json insights --days "$DAYS" > "$DIR/$2.json"
+   echo "snapshot $2 -> $DIR/$2.json"
+   ;;
+diff)
+   [ $# -eq 3 ] || usage
+   python3 - "$DIR/$2.json" "$DIR/$3.json" <<'PY'
+import json, sys
+a = json.load(open(sys.argv[1]))
+b = json.load(open(sys.argv[2]))
+
+def d(k):
+    return b.get(k, 0) - a.get(k, 0)
+
+calls  = d("total_calls")
+prompt = d("prompt_tokens")
+cread  = d("cache_read_tokens")
+cwrite = d("cache_write_tokens")
+
+print(f"calls           {calls}")
+print(f"prompt tokens   {prompt}")
+print(f"cache read      {cread}")
+print(f"cache write     {cwrite}")
+if prompt > 0:
+    print(f"cache_read/prompt   {100.0*cread/prompt:.1f}%")
+    print(f"cache_write/prompt  {100.0*cwrite/prompt:.1f}%")
+else:
+    # A zero-delta window is not a 0% cache rate; it is no measurement at all, and
+    # printing 0% would read as a catastrophic result rather than an empty one.
+    print("cache_read/prompt   n/a - no prompt tokens in this window, nothing was measured")
+if calls == 0:
+    print("WARNING: zero calls in this window - the workload did not run, or ran outside it")
+PY
+   ;;
+*)
+   usage
+   ;;
+esac


### PR DESCRIPTION
## Summary

The half of the fold-vs-compactor question that #2537 could not answer. Retention and cost are measurable offline; **cache hits are a property of real traffic against a real provider**, so they have to come off realized usage — which aimee already records and `aimee insights --json` already reports as `cache_read_tokens` / `cache_write_tokens`.

## What it does, and what it refuses to do

It **snapshots** and **diffs**. It deliberately does neither of the two things that would be convenient:

- **It does not flip config.** Enabling the fold on a live server is a real behaviour change and should be a command a human types, not a side effect buried in a measurement script.
- **It does not drive the workload.** That is a delegate dispatch over MCP, not a shell command.

A zero-delta window prints *"nothing was measured"* rather than `0%`, because a 0% cache rate and an empty window are opposite findings that look identical in a ratio.

## Validated — and the validation is the useful part

Ran around a real 8-turn delegate. It captured the delta correctly:

```
calls 1   prompt tokens 42346   cache read 0   cache write 0
```

## The experiment still cannot run, for two reasons this exposed

**1. That delegate path reports no cache tokens at all.** The daily aggregate *does* show cache reads (73600), so some traffic caches — but not this path. Comparing fold-on against fold-off here would be comparing 0 with 0.

**2. Delegates cannot do work.** The shell has been refused all session (memory 157: shell root and file-tool root are different directories, so no container is ever created). This run showed the **file tools failing too** — all eight reads blocked. A delegate cannot build the long realistic transcript that folding needs in the first place.

So the workload has to come from traffic that both **runs long enough to fold** and **reports cache tokens**. Today that is the operator's own sessions, which are not a controllable A/B.

I have recorded that requirement here rather than leaving the next attempt to rediscover it — and rather than running a comparison that would have produced a confident-looking `0.0%` on both arms and meant nothing.

## Where this leaves the fold decision

- **Retention and cost: measured** (#2537). The fold keeps everything at 47% of baseline; the compactor cuts to 31% but loses 25–45% of load-bearing facts.
- **Cache: unmeasured, and now blocked on a working agent workload rather than on tooling.**
- `fold.enabled` is independently switchable since #2539, so the flip is available the moment there is traffic worth measuring.

## Verification

- `make -C src lint` — passed
- Rig exercised end to end against live traffic; local snapshots gitignored