### PR TITLE
feat(delegates): stage 12 -- the command that creates a delegate's container

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "ac6acfc14aac82ab9fd35d96ca082467e044ad2458c4700ed8ba55dcc3e01427",
+      "source_sha256": "d34d921e08a4a46849e6f921b5f3827368880035046f7d9bf865f4547c3acf35",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,
@@ -180,7 +180,8 @@
         6664,
         6665,
         6666,
-        6667
+        6667,
+        6668
       ]
     },
     {

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -113,6 +113,7 @@ func moduleConfig(executable string) (bus.ModuleProcessConfig, bool) {
 			{EventKind: delegates.EventPatchCoord, StageID: delegates.StagePatchCoord},
 			{EventKind: delegates.EventRolePolicy, StageID: delegates.StageRolePolicy},
 			{EventKind: delegates.EventWorktreePlan, StageID: delegates.StageWorktreePlan},
+			{EventKind: delegates.EventLaunchArgs, StageID: delegates.StageLaunchArgs},
 		}
 		config.Handler = delegates.Handle
 	case "tools":

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -18,7 +18,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"memory", 7, []uint32{5889, 5890, 5891, 5892, 5893}},
 		{"learning", 8, []uint32{6145}},
 		{"routing", 9, []uint32{6401}},
-		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664, 6665, 6666, 6667}},
+		{"delegates", 10, []uint32{6657, 6658, 6659, 6660, 6661, 6662, 6663, 6664, 6665, 6666, 6667, 6668}},
 		{"tools", 11, []uint32{6913}},
 		{"workspace", 12, []uint32{7169, 7170, 7171}},
 		{"git", 13, []uint32{7425, 7426, 7427, 7428, 7429, 7430}},

--- a/server-go/modules/delegates/delegates.go
+++ b/server-go/modules/delegates/delegates.go
@@ -59,6 +59,9 @@ func Handle(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.Module
 	if invocation.StageID == StageWorktreePlan {
 		return handleWorktreePlan(invocation, request)
 	}
+	if invocation.StageID == StageLaunchArgs {
+		return handleLaunchArgs(invocation, request)
+	}
 	if invocation.StageID != StageInvoke || len(request) != messageLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != requestMagic || request[4] != wireVersion ||
 		request[5] != 0 || request[7] != 0 || request[6] == 0 || request[6] > roleMax {

--- a/server-go/modules/delegates/launchargs_stage.go
+++ b/server-go/modules/delegates/launchargs_stage.go
@@ -1,0 +1,160 @@
+package delegates
+
+import (
+	"encoding/binary"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+// Asking the module for the command that creates a delegate's container.
+//
+// This is the second of the two calls that run a delegate. The caller has the
+// plan from stage 11 and the worktree the workspace cut for it; here it gets the
+// argv. Everything the sandbox guarantees -- no network, no runtime socket, a
+// read-only role that cannot receive a writable workspace mount, no credential
+// in the environment -- is decided on this side of the wire and validated again
+// before the argv is rendered.
+//
+// The caller executes the argv. It does not assemble one, which is the point:
+// past the argv the guarantees are just flags, and a missing flag is a delegate
+// with a network.
+
+const (
+	StageLaunchArgs uint32 = 12
+	EventLaunchArgs uint32 = 6668
+
+	launchArgsRequestMagic  uint32 = 0x514c4144 /* "DALQ" */
+	launchArgsResponseMagic uint32 = 0x534c4144 /* "DALS" */
+	launchArgsReqHeaderLen         = 16
+
+	// A mount table is the runtime's report of this container's own mounts, so
+	// it is the only field that can be large.
+	launchArgsMountTableMax = 1 << 20
+	launchArgsStringMax     = 4096
+	launchArgsMaxCommand    = 256
+)
+
+// launchArgsRequest is the wire form, kept as one struct so the decode below
+// reads in the same order the encoder writes.
+type launchArgsRequest struct {
+	Role          string
+	RepoRoot      string
+	Worktree      string
+	GitDir        string
+	IsGitCheckout bool
+
+	ParentSocketHost   string
+	ParentSocketTarget string
+	EgressProxy        string
+
+	ContainerName string
+	Image         string
+	WorkDir       string
+	MountTable    string
+	Command       []string
+}
+
+// decodeLaunchArgsRequest reads the request, or reports that it is malformed.
+//
+// Every string is length-prefixed and bounded. The bound matters: these become
+// argv, and an unbounded field is a way to make the caller allocate for a
+// command it was never going to run.
+func decodeLaunchArgsRequest(request []byte) (launchArgsRequest, bool) {
+	var req launchArgsRequest
+	if len(request) < launchArgsReqHeaderLen ||
+		binary.LittleEndian.Uint32(request[0:4]) != launchArgsRequestMagic ||
+		request[4] != wireVersion || request[5] > 1 {
+		return req, false
+	}
+	req.IsGitCheckout = request[5] == 1
+	commandCount := int(binary.LittleEndian.Uint32(request[8:12]))
+	if commandCount > launchArgsMaxCommand {
+		return req, false
+	}
+
+	c := &economicsCursor{buf: request, at: launchArgsReqHeaderLen}
+	readString := func(max int) string {
+		n := c.u32()
+		if n > max {
+			c.bad = true
+			return ""
+		}
+		return c.str(n)
+	}
+
+	req.Role = readString(roleMax)
+	req.RepoRoot = readString(launchArgsStringMax)
+	req.Worktree = readString(launchArgsStringMax)
+	req.GitDir = readString(launchArgsStringMax)
+	req.ParentSocketHost = readString(launchArgsStringMax)
+	req.ParentSocketTarget = readString(launchArgsStringMax)
+	req.EgressProxy = readString(launchArgsStringMax)
+	req.ContainerName = readString(launchArgsStringMax)
+	req.Image = readString(launchArgsStringMax)
+	req.WorkDir = readString(launchArgsStringMax)
+	req.MountTable = readString(launchArgsMountTableMax)
+
+	req.Command = make([]string, 0, commandCount)
+	for i := 0; i < commandCount; i++ {
+		req.Command = append(req.Command, readString(launchArgsStringMax))
+	}
+
+	if c.bad || c.at != len(request) {
+		return launchArgsRequest{}, false
+	}
+	return req, true
+}
+
+// handleLaunchArgs renders the create command for one delegate.
+//
+// The isolation of the plan is derived from the ROLE rather than carried in the
+// request. It is the same decision stage 11 made, and re-deriving it means the
+// two cannot disagree -- a caller that sent a stale "isolated" flag would
+// otherwise get a git directory mounted into a read-only delegate.
+func handleLaunchArgs(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
+	req, ok := decodeLaunchArgsRequest(request)
+	if !ok {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	if invocation.Cancelled() {
+		return nil, bus.ModuleStatusCancelled
+	}
+
+	plan := WorktreePlan{Isolated: RoleIsWrite(req.Role), ReadOnlyMount: !RoleIsWrite(req.Role)}
+	sandboxReq := SandboxRequestFor(plan, req.Role, req.RepoRoot, req.Worktree, req.GitDir,
+		req.IsGitCheckout, req.ParentSocketHost, req.ParentSocketTarget, req.EgressProxy)
+
+	spec, err := BuildSandboxSpec(sandboxReq)
+	if err != nil {
+		// A spec this module refuses to build is not a request to answer
+		// partially. The caller gets nothing to run.
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec:          spec,
+		ContainerName: req.ContainerName,
+		Image:         req.Image,
+		WorkDir:       req.WorkDir,
+		MountTable:    req.MountTable,
+		Command:       req.Command,
+	})
+	if err != nil {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+
+	total := 8
+	for _, a := range args {
+		total += 4 + len(a)
+	}
+	response := make([]byte, 8, total)
+	binary.LittleEndian.PutUint32(response[0:4], launchArgsResponseMagic)
+	binary.LittleEndian.PutUint32(response[4:8], uint32(len(args)))
+	for _, a := range args {
+		var n [4]byte
+		binary.LittleEndian.PutUint32(n[:], uint32(len(a)))
+		response = append(response, n[:]...)
+		response = append(response, a...)
+	}
+	return response, bus.ModuleStatusOK
+}

--- a/server-go/modules/delegates/launchargs_stage_test.go
+++ b/server-go/modules/delegates/launchargs_stage_test.go
@@ -1,0 +1,294 @@
+package delegates
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func encodeLaunchArgs(req launchArgsRequest) []byte {
+	out := make([]byte, launchArgsReqHeaderLen)
+	binary.LittleEndian.PutUint32(out[0:4], launchArgsRequestMagic)
+	out[4] = wireVersion
+	if req.IsGitCheckout {
+		out[5] = 1
+	}
+	binary.LittleEndian.PutUint32(out[8:12], uint32(len(req.Command)))
+
+	put := func(s string) {
+		var n [4]byte
+		binary.LittleEndian.PutUint32(n[:], uint32(len(s)))
+		out = append(out, n[:]...)
+		out = append(out, s...)
+	}
+	put(req.Role)
+	put(req.RepoRoot)
+	put(req.Worktree)
+	put(req.GitDir)
+	put(req.ParentSocketHost)
+	put(req.ParentSocketTarget)
+	put(req.EgressProxy)
+	put(req.ContainerName)
+	put(req.Image)
+	put(req.WorkDir)
+	put(req.MountTable)
+	for _, a := range req.Command {
+		put(a)
+	}
+	return out
+}
+
+func decodeLaunchArgs(t *testing.T, response []byte) []string {
+	t.Helper()
+	if len(response) < 8 {
+		t.Fatalf("response is %d bytes", len(response))
+	}
+	if binary.LittleEndian.Uint32(response[0:4]) != launchArgsResponseMagic {
+		t.Fatal("wrong response magic")
+	}
+	count := int(binary.LittleEndian.Uint32(response[4:8]))
+	args := make([]string, 0, count)
+	at := 8
+	for i := 0; i < count; i++ {
+		n := int(binary.LittleEndian.Uint32(response[at : at+4]))
+		at += 4
+		args = append(args, string(response[at:at+n]))
+		at += n
+	}
+	if at != len(response) {
+		t.Fatalf("decoded %d of %d bytes", at, len(response))
+	}
+	return args
+}
+
+func callLaunchArgs(t *testing.T, req launchArgsRequest) ([]string, bus.ModuleStatus) {
+	t.Helper()
+	response, status := Handle(bus.ModuleInvocation{StageID: StageLaunchArgs}, encodeLaunchArgs(req))
+	if status != bus.ModuleStatusOK {
+		return nil, status
+	}
+	return decodeLaunchArgs(t, response), status
+}
+
+func writeRequest() launchArgsRequest {
+	return launchArgsRequest{
+		Role:               "code",
+		RepoRoot:           "/repo",
+		Worktree:           "/repo/.aimee/worktrees/d1",
+		GitDir:             "/repo/.git/worktrees/d1",
+		IsGitCheckout:      true,
+		ParentSocketHost:   "/run/aimee/aimee.sock",
+		ParentSocketTarget: "/run/aimee.sock",
+		ContainerName:      "aimee-d1",
+		Image:              "ubuntu:22.04",
+		WorkDir:            "/repo/.aimee/worktrees/d1",
+	}
+}
+
+func argIndex(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// The isolation primitive. If this is ever absent the delegate has a network,
+// so it is asserted on the rendered argv rather than on the spec.
+func TestLaunchArgsAlwaysHasNoNetwork(t *testing.T) {
+	for _, role := range []string{"code", "refactor", "review", "search", "validate"} {
+		req := writeRequest()
+		req.Role = role
+		if !RoleIsWrite(role) {
+			req.GitDir = ""
+			req.RepoRoot = ""
+		}
+		args, status := callLaunchArgs(t, req)
+		if status != bus.ModuleStatusOK {
+			t.Fatalf("role %q: status = %v", role, status)
+		}
+		i := argIndex(args, "--network")
+		if i < 0 || i+1 >= len(args) || args[i+1] != "none" {
+			t.Errorf("role %q: argv does not carry --network none: %v", role, args)
+		}
+	}
+}
+
+// A write role gets the repo read-only with its own worktree and git dir
+// writable nested inside; `git status` refreshes its index in that git dir.
+func TestLaunchArgsWriteRoleMountLayering(t *testing.T) {
+	args, status := callLaunchArgs(t, writeRequest())
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", status)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"/repo:/repo:ro",
+		"/repo/.aimee/worktrees/d1:/repo/.aimee/worktrees/d1",
+		"/repo/.git/worktrees/d1:/repo/.git/worktrees/d1",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("argv missing mount %q: %v", want, args)
+		}
+	}
+	// The worktree and git dir must NOT be read-only.
+	if strings.Contains(joined, "/repo/.aimee/worktrees/d1:ro") {
+		t.Error("a write delegate's worktree was mounted read-only")
+	}
+}
+
+// A read-only role mounts the parent's worktree, and the mode is the
+// enforcement -- not a request the delegate is asked to honour.
+func TestLaunchArgsReadOnlyRoleGetsReadOnlyMount(t *testing.T) {
+	req := writeRequest()
+	req.Role = "review"
+	req.RepoRoot = ""
+	req.GitDir = "/repo/.git/worktrees/d1" // supplied, and must be ignored
+	req.Worktree = "/repo"
+
+	args, status := callLaunchArgs(t, req)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", status)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "/repo:/repo:ro") {
+		t.Errorf("the parent worktree was not mounted read-only: %v", args)
+	}
+	// A git dir belongs to an isolated delegate only. Carrying one here would
+	// hand a read-only delegate a writable mount.
+	if strings.Contains(joined, ".git/worktrees") {
+		t.Errorf("a read-only delegate was given a git dir mount: %v", args)
+	}
+}
+
+// The module refuses rather than answering partially: a caller that gets no
+// argv cannot accidentally run a half-specified container.
+func TestLaunchArgsRefusesUnsafeRequests(t *testing.T) {
+	cases := map[string]func(*launchArgsRequest){
+		"not a git checkout":   func(r *launchArgsRequest) { r.IsGitCheckout = false },
+		"relative worktree":    func(r *launchArgsRequest) { r.Worktree = "relative/path" },
+		"empty worktree":       func(r *launchArgsRequest) { r.Worktree = "" },
+		"no container name":    func(r *launchArgsRequest) { r.ContainerName = "" },
+		"bad image reference":  func(r *launchArgsRequest) { r.Image = "ubuntu:22.04; rm -rf /" },
+		"relative socket host": func(r *launchArgsRequest) { r.ParentSocketHost = "sock" },
+	}
+	for name, mutate := range cases {
+		req := writeRequest()
+		mutate(&req)
+		if _, status := callLaunchArgs(t, req); status != bus.ModuleStatusInvalidRequest {
+			t.Errorf("%s: status = %v, want InvalidRequest", name, status)
+		}
+	}
+}
+
+// Binding the runtime's own socket hands the delegate root-equivalent control
+// of the host daemon, so it is refused at any path.
+func TestLaunchArgsRefusesTheRuntimeSocket(t *testing.T) {
+	for _, sock := range []string{
+		"/var/run/docker.sock", "/somewhere/else/docker.sock", "/run/podman.sock",
+	} {
+		req := writeRequest()
+		req.ParentSocketHost = sock
+		if _, status := callLaunchArgs(t, req); status != bus.ModuleStatusInvalidRequest {
+			t.Errorf("%s: status = %v, want InvalidRequest", sock, status)
+		}
+	}
+}
+
+// Docker resolves bind SOURCES in the daemon's namespace. An untranslated path
+// makes docker silently create an EMPTY directory there, and the delegate gets
+// an empty mount instead of the workspace.
+func TestLaunchArgsTranslatesMountSources(t *testing.T) {
+	req := writeRequest()
+	req.MountTable = "/repo\t/host/checkout"
+
+	args, status := callLaunchArgs(t, req)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", status)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "/host/checkout:/repo:ro") {
+		t.Errorf("the repo source was not translated: %v", args)
+	}
+	if !strings.Contains(joined, "/host/checkout/.aimee/worktrees/d1:/repo/.aimee/worktrees/d1") {
+		t.Errorf("the worktree source was not translated: %v", args)
+	}
+}
+
+// The egress proxy is how a no-network delegate still installs software through
+// the narrow update whitelist.
+func TestLaunchArgsCarriesTheEgressProxy(t *testing.T) {
+	req := writeRequest()
+	req.EgressProxy = "http://127.0.0.1:3129"
+
+	args, status := callLaunchArgs(t, req)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", status)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"http_proxy=http://127.0.0.1:3129", "https_proxy=http://127.0.0.1:3129"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("argv missing %q: %v", want, args)
+		}
+	}
+}
+
+func TestLaunchArgsCarriesTheCommand(t *testing.T) {
+	req := writeRequest()
+	req.Command = []string{"sleep", "infinity"}
+
+	args, status := callLaunchArgs(t, req)
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", status)
+	}
+	if len(args) < 2 || args[len(args)-2] != "sleep" || args[len(args)-1] != "infinity" {
+		t.Errorf("the command is not last in argv: %v", args)
+	}
+	// The image must come immediately before it.
+	if args[len(args)-3] != "ubuntu:22.04" {
+		t.Errorf("the image does not precede the command: %v", args)
+	}
+}
+
+func TestLaunchArgsRejectsMalformedRequests(t *testing.T) {
+	good := encodeLaunchArgs(writeRequest())
+
+	cases := map[string][]byte{
+		"empty":         {},
+		"short header":  good[:8],
+		"trailing byte": append(append([]byte{}, good...), 0),
+		"truncated":     good[:len(good)-1],
+	}
+	badMagic := append([]byte{}, good...)
+	binary.LittleEndian.PutUint32(badMagic[0:4], 0xDEADBEEF)
+	cases["wrong magic"] = badMagic
+
+	badVersion := append([]byte{}, good...)
+	badVersion[4] = wireVersion + 1
+	cases["wrong version"] = badVersion
+
+	tooManyCommands := append([]byte{}, good...)
+	binary.LittleEndian.PutUint32(tooManyCommands[8:12], launchArgsMaxCommand+1)
+	cases["command count over the bound"] = tooManyCommands
+
+	overrun := append([]byte{}, good...)
+	binary.LittleEndian.PutUint32(overrun[launchArgsReqHeaderLen:launchArgsReqHeaderLen+4], 1<<20)
+	cases["role length overruns"] = overrun
+
+	for name, request := range cases {
+		_, status := Handle(bus.ModuleInvocation{StageID: StageLaunchArgs}, request)
+		if status != bus.ModuleStatusInvalidRequest {
+			t.Errorf("%s: status = %v, want InvalidRequest", name, status)
+		}
+	}
+}
+
+func TestLaunchArgsHonoursCancellation(t *testing.T) {
+	invocation := bus.ModuleInvocation{StageID: StageLaunchArgs, DeadlineNS: 1}
+	if _, status := Handle(invocation, encodeLaunchArgs(writeRequest())); status != bus.ModuleStatusCancelled {
+		t.Errorf("status = %v, want Cancelled", status)
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -89,6 +89,7 @@
     "server-go/modules/delegates/container.go",
     "server-go/modules/delegates/worktreeplan.go",
     "server-go/modules/delegates/worktreeplan_stage.go",
+    "server-go/modules/delegates/launchargs_stage.go",
     "server-go/modules/delegates/proxyguard.go"
   ],
   "go_tests": [
@@ -113,6 +114,7 @@
     "server-go/modules/delegates/container_test.go",
     "server-go/modules/delegates/worktreeplan_test.go",
     "server-go/modules/delegates/worktreeplan_stage_test.go",
+    "server-go/modules/delegates/launchargs_stage_test.go",
     "server-go/modules/delegates/proxyguard_test.go"
   ],
   "tests": [

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -181,6 +181,11 @@
           "id": 11,
           "name": "delegate-worktree-plan",
           "event_kind": 6667
+        },
+        {
+          "id": 12,
+          "name": "delegate-launch-args",
+          "event_kind": 6668
         }
       ]
     },


### PR DESCRIPTION
feat(delegates): stage 12 -- the command that creates a delegate's container

This is the second of the two calls that run a delegate, and the one that moves
the decision out of C. The caller has the plan from stage 11 (event 6667) and
the worktree the workspace cut for it; here it gets the argv, ready to execute.

The point is that the caller no longer ASSEMBLES one. Past the argv every
guarantee is just a flag, and a missing flag is a delegate with a network. So
the spec is built and then re-validated before rendering, and the tests assert
on the ARGV rather than on the spec -- `--network none` is checked on the
rendered command for every role, because that is the artifact that runs.

WHAT THE MODULE DERIVES RATHER THAN TRUSTS. Isolation comes from the ROLE, not
from an `isolated` flag in the request. It is the same decision stage 11 made,
and re-deriving it means the two cannot disagree. A caller that sent a stale
flag would otherwise hand a git directory -- a WRITABLE mount -- to a read-only
delegate. There is a test that supplies a git dir on a read-only request and
asserts it is ignored.

REFUSAL IS TOTAL. A spec this module will not build produces no argv at all,
rather than a partial answer: not a git checkout, a relative worktree, a missing
container name, an injectable image reference, or a request that would bind the
runtime's own socket at ANY path. A caller that gets nothing cannot accidentally
run a half-specified container.

The mount-source translation is carried through and tested, because its failure
is silent: docker resolves bind sources in the DAEMON's namespace, and an
untranslated path makes docker CREATE an empty directory there. The delegate
then gets an empty mount instead of the workspace, and it reads as the delegate
simply having found nothing.

Every string on the wire is length-prefixed and bounded. Only the mount table is
allowed to be large, since it is the runtime's report of this container's own
mounts; the rest are argv-sized. The lock's serve grant regenerated to include
6668, which is the check that the stage is reachable rather than merely written.
