### PR TITLE
docs: correct the register-tagging unlock — it was the wrong lever

### DIFF
--- a/docs/proposals/pending/context-paging-s2-s5.md
+++ b/docs/proposals/pending/context-paging-s2-s5.md
@@ -194,14 +194,34 @@ us whether any of this actually helps an agent get its work done.
 
 ## Cross-cutting: register tagging is the real unlock
 
-`fold_register_enabled` defaults off. That single flag is why the record derivation is a
-lateral move rather than a win, and why S1 ships dark. Turning it on requires agents to
-actually emit `[verdict]` / `[hazard]` / `[wip]` registers, which is a **prompt/behaviour
-change, not a code change** — and therefore needs its own measurement, because an agent
-that tags unreliably is worse than one that never tags (a mis-tagged `[verdict]` promotes
-a guess into the summary as a settled fact).
+> **Corrected 2026-08-11 — the paragraph this replaces named the wrong lever.** It said
+> `fold_register_enabled` defaults off and that this is why the record derivation is a
+> lateral move. Both halves were wrong, and the wrong version shipped in #2532 and was
+> repeated in #2537 and #2541, so it is corrected here rather than quietly edited.
 
-Sequence: enable tagging → measure tagging *accuracy* → re-run the retention probe →
+Two facts from the tree:
+
+1. **The record path does not read that flag.** `session_compact`'s record derivation
+   calls `fold_register_parse` unconditionally — `fold_register_enabled` appears **zero**
+   times in `src/server/session_compact.c`. The flag gates the *fold's* skeleton
+   annotation (`context_fold.c:79`), which is a different consumer.
+2. **Nothing asks agents to emit registers.** There is no `prompts/` directory; the system
+   prompt is `PROMPT_STANDARD_TEXT` in `src/prompts.c`, and it never mentions
+   `[verdict]` / `[hazard]` / `[wip]`. The only occurrences of those tags in the whole
+   repository are unit tests and this document.
+
+So flipping `fold_register_enabled` would change nothing for the compactor. Real
+transcripts carry no registers because **agents are never asked for them**, which on its
+own explains the measured result: record 15/20 vs legacy 11/20 overall, and dead even at
+10/14 on fixtures matching real transcripts.
+
+The actual unlock is a **prompt change** in `src/prompts.c`. That is a behaviour change
+for every agent, and an agent that tags *unreliably* is worse than one that never tags —
+a mis-tagged `[verdict]` promotes a guess into the summary as a settled fact, which is the
+failure mode the precision axis was built to catch.
+
+Sequence: add the instruction (gated, so it can be enabled for one server rather than
+everywhere) → measure tagging **accuracy** → re-run `benchmarks/compaction-quality` →
 only then revisit the `compact.from_record` default.
 
 ## Risks


### PR DESCRIPTION
## Summary

Docs-only. I have been saying — in #2532, then repeated in #2537 and #2541, and in memory — that `compact.from_record` is a lateral move **because `fold_register_enabled` defaults off**.

**Both halves of that are wrong.** Corrected in place, with the correction visible rather than quietly edited, because the wrong version is what a reader would otherwise inherit.

## What the tree actually says

**1. The record path does not read that flag.**

`session_compact`'s record derivation calls `fold_register_parse` **unconditionally** — `fold_register_enabled` appears **zero** times in `src/server/session_compact.c`. The flag gates the *fold's* skeleton annotation (`context_fold.c:79`), which is a different consumer entirely.

**2. Nothing asks agents to emit registers.**

There is no `prompts/` directory. The system prompt is `PROMPT_STANDARD_TEXT` in `src/prompts.c`, and it never mentions `[verdict]` / `[hazard]` / `[wip]`. The only occurrences of those tags anywhere in the repository are unit tests and this proposal.

## Why it matters

Flipping `fold_register_enabled` would have changed **nothing** for the compactor. Anyone acting on the old text would have flipped a flag, seen no difference, and been left without an explanation.

The real reason is simpler and cheaper to fix: real transcripts carry no registers because **agents are never asked for them**. That alone explains the measured result — record 15/20 vs legacy 11/20 overall, and dead even at 10/14 on the fixtures that match real transcripts.

## The actual unlock

A **prompt change** in `src/prompts.c`.

That is a behaviour change for every agent, and an agent that tags *unreliably* is worse than one that never tags — a mis-tagged `[verdict]` promotes a guess into the summary as a settled fact, which is exactly the failure the precision axis in #2527 exists to catch.

The sequence stands, with the first step corrected:

1. add the instruction — **gated**, so it can be enabled on one server rather than everywhere
2. measure tagging **accuracy**
3. re-run `benchmarks/compaction-quality`
4. only then revisit the `compact.from_record` default

## Not bundled here

**The prompt edit itself.** It changes how every agent writes, its benefit is unproven, and its failure mode is worse than the status quo. That deserves its own decision rather than riding along in a docs correction.

## Verification

- `check_proposal_ordering` — ok
- `check-proposal-links` — ok
- `make -C src lint` — passed