### PR TITLE
feat(delegates): the container's NAME is decided where its shape is

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "d34d921e08a4a46849e6f921b5f3827368880035046f7d9bf865f4547c3acf35",
+      "source_sha256": "a71daf327f0d55000cfc69d721c9fa677ebec4570da1ef92ef5b4d82f01ff741",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/containername.go
+++ b/server-go/modules/delegates/containername.go
@@ -1,0 +1,103 @@
+package delegates
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A delegate container's IDENTITY, decided where its shape is decided.
+//
+// `docker start` resumes by name. So a task id reused against a different
+// workspace would resume a container carrying the OLD mounts, and the delegate
+// would work in the previous tree with nothing to say so. Folding the mounts
+// into the name makes a changed mount a different container by construction.
+//
+// That is precisely why this lives beside the spec rather than with the caller:
+// the name exists to track the mounts, and a name computed from one set of
+// mounts while a different set is rendered into the argv is the exact bug the
+// fingerprint was added to prevent.
+
+// containerNameMax bounds a container name. Matches the buffer the backend
+// reads it into.
+const containerNameMax = 127
+
+const containerNamePrefix = "aimee-delegate-"
+
+// sanitizeContainerName folds a task id into what docker accepts for a name:
+// [a-zA-Z0-9_.-]. Everything else becomes '_'. The leading character must be
+// alphanumeric, which the prefix already satisfies.
+func sanitizeContainerName(taskID string) string {
+	var b strings.Builder
+	b.Grow(len(taskID))
+	for i := 0; i < len(taskID); i++ {
+		c := taskID[i]
+		if isAlnum(c) || c == '_' || c == '.' || c == '-' {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	return b.String()
+}
+
+// mountsFingerprint hashes the rendered workspace binds (FNV-1a, 32-bit).
+//
+// It hashes the SAME strings that reach the argv, via renderBind, so the name
+// cannot describe one set of mounts while another is created.
+//
+// Workspace mounts only, matching what the backend has always fingerprinted.
+// The control socket is deliberately excluded: it is the same channel for every
+// delegate on the host, so including it would churn every container name the
+// moment the socket moved, without ever distinguishing two delegates.
+func mountsFingerprint(spec SandboxSpec, mountTable string) uint32 {
+	var h uint32 = 2166136261
+	for _, m := range spec.Mounts {
+		if m.Kind != SandboxWorkspace {
+			continue
+		}
+		for _, c := range []byte(renderBind(m, mountTable)) {
+			h ^= uint32(c)
+			h *= 16777619
+		}
+	}
+	return h
+}
+
+// ContainerName is the name to create or resume this delegate's container under.
+//
+// The mount fingerprint is appended only when a host tree is actually mounted.
+// A delegate with no workspace runs in the backend's scratch dir, which is
+// derived from the task id already — there resuming by task id is the point,
+// and a fingerprint would defeat it.
+//
+// When the name would overflow, the BODY is truncated and the suffix kept.
+// Dropping the suffix instead would collide two different mount sets onto one
+// name, which is the failure this whole mechanism exists to avoid.
+func ContainerName(taskID string, spec SandboxSpec, mountTable string) (string, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return "", fmt.Errorf("task id is required to name a container")
+	}
+
+	name := containerNamePrefix + sanitizeContainerName(taskID)
+
+	hasWorkspace := false
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxWorkspace {
+			hasWorkspace = true
+			break
+		}
+	}
+	if !hasWorkspace {
+		if len(name) > containerNameMax {
+			name = name[:containerNameMax]
+		}
+		return name, nil
+	}
+
+	suffix := fmt.Sprintf("-%08x", mountsFingerprint(spec, mountTable))
+	if len(name)+len(suffix) > containerNameMax {
+		name = name[:containerNameMax-len(suffix)]
+	}
+	return name + suffix, nil
+}

--- a/server-go/modules/delegates/containername_test.go
+++ b/server-go/modules/delegates/containername_test.go
@@ -1,0 +1,144 @@
+package delegates
+
+import (
+	"strings"
+	"testing"
+)
+
+func specWithWorkspace(source string) SandboxSpec {
+	return SandboxSpec{Mounts: []SandboxMount{
+		{Source: source, Target: "/repo", Kind: SandboxWorkspace},
+	}}
+}
+
+// Docker container names allow [a-zA-Z0-9_.-]. Anything else becomes '_', and
+// the prefix guarantees the leading character is alphanumeric.
+func TestContainerNameSanitizesTheTaskID(t *testing.T) {
+	name, err := ContainerName("foo bar:baz/qux.v1-2", SandboxSpec{}, "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.HasPrefix(name, containerNamePrefix) {
+		t.Errorf("name %q lost its prefix", name)
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if !isAlnum(c) && c != '_' && c != '.' && c != '-' {
+			t.Errorf("name %q contains %q, which docker will not accept", name, c)
+		}
+	}
+	if !strings.Contains(name, "foo_bar_baz_qux.v1-2") {
+		t.Errorf("name %q did not sanitize as expected", name)
+	}
+}
+
+func TestContainerNameRequiresATaskID(t *testing.T) {
+	for _, id := range []string{"", "   "} {
+		if _, err := ContainerName(id, SandboxSpec{}, ""); err == nil {
+			t.Errorf("task id %q should be refused", id)
+		}
+	}
+}
+
+// The reason this rule exists: `docker start` resumes by name, so a task id
+// reused against a DIFFERENT workspace must not resume the old container. It
+// would run in the previous tree with nothing to say so.
+func TestContainerNameChangesWithTheMounts(t *testing.T) {
+	a, err := ContainerName("task-1", specWithWorkspace("/repo-a"), "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	b, err := ContainerName("task-1", specWithWorkspace("/repo-b"), "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if a == b {
+		t.Errorf("the same name %q was produced for two different workspaces", a)
+	}
+}
+
+// Same task, same mounts: the name must be stable, or resume never works at all.
+func TestContainerNameIsStableForTheSameMounts(t *testing.T) {
+	a, _ := ContainerName("task-1", specWithWorkspace("/repo"), "")
+	b, _ := ContainerName("task-1", specWithWorkspace("/repo"), "")
+	if a != b {
+		t.Errorf("name is not stable: %q vs %q", a, b)
+	}
+}
+
+// The mount mode is part of the mount. A tree mounted read-only is not the same
+// container as the same tree mounted writable.
+func TestContainerNameChangesWithTheMountMode(t *testing.T) {
+	rw := SandboxSpec{Mounts: []SandboxMount{
+		{Source: "/repo", Target: "/repo", Kind: SandboxWorkspace},
+	}}
+	ro := SandboxSpec{Mounts: []SandboxMount{
+		{Source: "/repo", Target: "/repo", ReadOnly: true, Kind: SandboxWorkspace},
+	}}
+	a, _ := ContainerName("task-1", rw, "")
+	b, _ := ContainerName("task-1", ro, "")
+	if a == b {
+		t.Error("read-only and writable mounts produced the same container name")
+	}
+}
+
+// The fingerprint follows the TRANSLATED source, because that is what is
+// actually bound. Fingerprinting the untranslated path would let two different
+// host trees share a name.
+func TestContainerNameFollowsTheTranslatedSource(t *testing.T) {
+	spec := specWithWorkspace("/repo")
+	plain, _ := ContainerName("task-1", spec, "")
+	translated, _ := ContainerName("task-1", spec, "/repo\t/host/checkout")
+	if plain == translated {
+		t.Error("translation did not change the name, so the name does not track the real bind")
+	}
+}
+
+// A delegate with no workspace runs in the backend's scratch dir, which is
+// derived from the task id already. Fingerprinting there would defeat the
+// resume-by-task-id that scratch containers exist for.
+func TestContainerNameHasNoFingerprintWithoutAWorkspace(t *testing.T) {
+	name, err := ContainerName("task-1", SandboxSpec{}, "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if name != containerNamePrefix+"task-1" {
+		t.Errorf("name = %q, want the bare prefixed task id", name)
+	}
+}
+
+// The control socket is the same channel for every delegate on the host, so it
+// distinguishes nothing and is excluded. Including it would churn every name
+// the moment the socket moved.
+func TestContainerNameIgnoresTheControlSocket(t *testing.T) {
+	base := specWithWorkspace("/repo")
+	withSocket := SandboxSpec{Mounts: append(append([]SandboxMount{}, base.Mounts...),
+		SandboxMount{Source: "/run/a.sock", Target: "/run/b.sock", Kind: SandboxControlSocket})}
+
+	a, _ := ContainerName("task-1", base, "")
+	b, _ := ContainerName("task-1", withSocket, "")
+	if a != b {
+		t.Errorf("the control socket changed the name: %q vs %q", a, b)
+	}
+}
+
+// Truncating the SUFFIX would collide two different mount sets onto one name,
+// which is the exact failure the fingerprint exists to prevent. The body gives
+// way instead.
+func TestContainerNameKeepsTheFingerprintWhenTruncating(t *testing.T) {
+	long := strings.Repeat("a", 400)
+	a, err := ContainerName(long, specWithWorkspace("/repo-a"), "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	b, err := ContainerName(long, specWithWorkspace("/repo-b"), "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(a) > containerNameMax {
+		t.Errorf("name is %d bytes, over the %d bound", len(a), containerNameMax)
+	}
+	if a == b {
+		t.Error("two mount sets collided on one name after truncation")
+	}
+}

--- a/server-go/modules/delegates/dockerargs.go
+++ b/server-go/modules/delegates/dockerargs.go
@@ -64,6 +64,22 @@ func TranslateMountPath(containerPath, mountTable string) string {
 	return bestSource + containerPath[bestLen:]
 }
 
+// renderBind is one mount in docker's "-v" form, with its source translated
+// into the daemon's namespace. The container name fingerprints these same
+// strings, so both go through here — a name computed from one rendering while
+// another is created is the bug the fingerprint exists to prevent.
+func renderBind(m SandboxMount, mountTable string) string {
+	source := m.Source
+	if mountTable != "" {
+		source = TranslateMountPath(source, mountTable)
+	}
+	bind := source + ":" + m.Target
+	if m.ReadOnly {
+		bind += ":ro"
+	}
+	return bind
+}
+
 // DockerCreateRequest is everything needed to phrase the create command.
 type DockerCreateRequest struct {
 	Spec          SandboxSpec
@@ -100,15 +116,7 @@ func DockerCreateArgs(req DockerCreateRequest) ([]string, error) {
 	args = append(args, "--network", req.Spec.NetworkMode())
 
 	for _, m := range req.Spec.Mounts {
-		source := m.Source
-		if req.MountTable != "" {
-			source = TranslateMountPath(source, req.MountTable)
-		}
-		bind := source + ":" + m.Target
-		if m.ReadOnly {
-			bind += ":ro"
-		}
-		args = append(args, "-v", bind)
+		args = append(args, "-v", renderBind(m, req.MountTable))
 	}
 
 	for _, e := range req.Spec.Env {

--- a/server-go/modules/delegates/launchargs_stage.go
+++ b/server-go/modules/delegates/launchargs_stage.go
@@ -47,11 +47,11 @@ type launchArgsRequest struct {
 	ParentSocketTarget string
 	EgressProxy        string
 
-	ContainerName string
-	Image         string
-	WorkDir       string
-	MountTable    string
-	Command       []string
+	TaskID     string
+	Image      string
+	WorkDir    string
+	MountTable string
+	Command    []string
 }
 
 // decodeLaunchArgsRequest reads the request, or reports that it is malformed.
@@ -89,7 +89,7 @@ func decodeLaunchArgsRequest(request []byte) (launchArgsRequest, bool) {
 	req.ParentSocketHost = readString(launchArgsStringMax)
 	req.ParentSocketTarget = readString(launchArgsStringMax)
 	req.EgressProxy = readString(launchArgsStringMax)
-	req.ContainerName = readString(launchArgsStringMax)
+	req.TaskID = readString(launchArgsStringMax)
 	req.Image = readString(launchArgsStringMax)
 	req.WorkDir = readString(launchArgsStringMax)
 	req.MountTable = readString(launchArgsMountTableMax)
@@ -131,9 +131,16 @@ func handleLaunchArgs(invocation bus.ModuleInvocation, request []byte) ([]byte, 
 		return nil, bus.ModuleStatusInvalidRequest
 	}
 
+	// The name is computed HERE, from the spec that is about to be rendered, so
+	// it cannot describe a different set of mounts than the ones created.
+	name, err := ContainerName(req.TaskID, spec, req.MountTable)
+	if err != nil {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+
 	args, err := DockerCreateArgs(DockerCreateRequest{
 		Spec:          spec,
-		ContainerName: req.ContainerName,
+		ContainerName: name,
 		Image:         req.Image,
 		WorkDir:       req.WorkDir,
 		MountTable:    req.MountTable,
@@ -143,13 +150,20 @@ func handleLaunchArgs(invocation bus.ModuleInvocation, request []byte) ([]byte, 
 		return nil, bus.ModuleStatusInvalidRequest
 	}
 
-	total := 8
+	total := 12 + len(name)
 	for _, a := range args {
 		total += 4 + len(a)
 	}
+	// The container name travels back with the argv. The caller needs it to
+	// start, exec into and remove the container, and re-deriving it there would
+	// be a second copy of a rule whose entire job is not to have one.
 	response := make([]byte, 8, total)
 	binary.LittleEndian.PutUint32(response[0:4], launchArgsResponseMagic)
-	binary.LittleEndian.PutUint32(response[4:8], uint32(len(args)))
+	binary.LittleEndian.PutUint32(response[4:8], uint32(len(name)))
+	response = append(response, name...)
+	var count [4]byte
+	binary.LittleEndian.PutUint32(count[:], uint32(len(args)))
+	response = append(response, count[:]...)
 	for _, a := range args {
 		var n [4]byte
 		binary.LittleEndian.PutUint32(n[:], uint32(len(a)))

--- a/server-go/modules/delegates/launchargs_stage_test.go
+++ b/server-go/modules/delegates/launchargs_stage_test.go
@@ -30,7 +30,7 @@ func encodeLaunchArgs(req launchArgsRequest) []byte {
 	put(req.ParentSocketHost)
 	put(req.ParentSocketTarget)
 	put(req.EgressProxy)
-	put(req.ContainerName)
+	put(req.TaskID)
 	put(req.Image)
 	put(req.WorkDir)
 	put(req.MountTable)
@@ -40,7 +40,7 @@ func encodeLaunchArgs(req launchArgsRequest) []byte {
 	return out
 }
 
-func decodeLaunchArgs(t *testing.T, response []byte) []string {
+func decodeLaunchArgs(t *testing.T, response []byte) (string, []string) {
 	t.Helper()
 	if len(response) < 8 {
 		t.Fatalf("response is %d bytes", len(response))
@@ -48,9 +48,12 @@ func decodeLaunchArgs(t *testing.T, response []byte) []string {
 	if binary.LittleEndian.Uint32(response[0:4]) != launchArgsResponseMagic {
 		t.Fatal("wrong response magic")
 	}
-	count := int(binary.LittleEndian.Uint32(response[4:8]))
+	nameLen := int(binary.LittleEndian.Uint32(response[4:8]))
+	name := string(response[8 : 8+nameLen])
+	at := 8 + nameLen
+	count := int(binary.LittleEndian.Uint32(response[at : at+4]))
+	at += 4
 	args := make([]string, 0, count)
-	at := 8
 	for i := 0; i < count; i++ {
 		n := int(binary.LittleEndian.Uint32(response[at : at+4]))
 		at += 4
@@ -60,16 +63,23 @@ func decodeLaunchArgs(t *testing.T, response []byte) []string {
 	if at != len(response) {
 		t.Fatalf("decoded %d of %d bytes", at, len(response))
 	}
-	return args
+	return name, args
 }
 
 func callLaunchArgs(t *testing.T, req launchArgsRequest) ([]string, bus.ModuleStatus) {
 	t.Helper()
+	_, args, status := callLaunchArgsNamed(t, req)
+	return args, status
+}
+
+func callLaunchArgsNamed(t *testing.T, req launchArgsRequest) (string, []string, bus.ModuleStatus) {
+	t.Helper()
 	response, status := Handle(bus.ModuleInvocation{StageID: StageLaunchArgs}, encodeLaunchArgs(req))
 	if status != bus.ModuleStatusOK {
-		return nil, status
+		return "", nil, status
 	}
-	return decodeLaunchArgs(t, response), status
+	name, args := decodeLaunchArgs(t, response)
+	return name, args, status
 }
 
 func writeRequest() launchArgsRequest {
@@ -81,7 +91,7 @@ func writeRequest() launchArgsRequest {
 		IsGitCheckout:      true,
 		ParentSocketHost:   "/run/aimee/aimee.sock",
 		ParentSocketTarget: "/run/aimee.sock",
-		ContainerName:      "aimee-d1",
+		TaskID:             "d1",
 		Image:              "ubuntu:22.04",
 		WorkDir:            "/repo/.aimee/worktrees/d1",
 	}
@@ -171,7 +181,7 @@ func TestLaunchArgsRefusesUnsafeRequests(t *testing.T) {
 		"not a git checkout":   func(r *launchArgsRequest) { r.IsGitCheckout = false },
 		"relative worktree":    func(r *launchArgsRequest) { r.Worktree = "relative/path" },
 		"empty worktree":       func(r *launchArgsRequest) { r.Worktree = "" },
-		"no container name":    func(r *launchArgsRequest) { r.ContainerName = "" },
+		"no task id":           func(r *launchArgsRequest) { r.TaskID = "" },
 		"bad image reference":  func(r *launchArgsRequest) { r.Image = "ubuntu:22.04; rm -rf /" },
 		"relative socket host": func(r *launchArgsRequest) { r.ParentSocketHost = "sock" },
 	}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -90,6 +90,7 @@
     "server-go/modules/delegates/worktreeplan.go",
     "server-go/modules/delegates/worktreeplan_stage.go",
     "server-go/modules/delegates/launchargs_stage.go",
+    "server-go/modules/delegates/containername.go",
     "server-go/modules/delegates/proxyguard.go"
   ],
   "go_tests": [
@@ -115,6 +116,7 @@
     "server-go/modules/delegates/worktreeplan_test.go",
     "server-go/modules/delegates/worktreeplan_stage_test.go",
     "server-go/modules/delegates/launchargs_stage_test.go",
+    "server-go/modules/delegates/containername_test.go",
     "server-go/modules/delegates/proxyguard_test.go"
   ],
   "tests": [


### PR DESCRIPTION
feat(delegates): the container's NAME is decided where its shape is

Stage 12 renders the create argv but was handed a container name from outside.
That could not stay: the name's entire job is to track the mounts, and the
mounts are decided in the module. A name computed from one set of mounts while
a different set is rendered into the argv is precisely the bug the name exists
to prevent.

WHY THE NAME CARRIES A MOUNT FINGERPRINT AT ALL. `docker start` resumes by name.
Without the fingerprint a task id reused against a different workspace resumes
a container carrying the OLD mounts, and the delegate works in the previous tree
with nothing to say so. Folding the mounts into the name makes a changed mount a
different container by construction.

So ContainerName() now lives beside the spec, and stage 12 takes a TASK ID
rather than a name, computes the name from the spec it is about to render, and
returns both. The caller needs the name to start, exec into and remove the
container; re-deriving it there would be a second copy of a rule whose whole
purpose is not to have one.

The fingerprint and the argv now hash the SAME strings, through a shared
renderBind(). That closes the gap the previous split invited: the fingerprint
follows the TRANSLATED bind source, so two different host trees cannot share a
name because the untranslated paths happened to match. There is a test for it.

FOUR PROPERTIES CARRIED OVER FROM THE C AND PINNED BY TEST, because each was
learned rather than designed:

  - a different workspace gives a different name; the same one gives the same
    name, or resume never works at all
  - the mount MODE is part of the mount: read-only and writable are not the
    same container
  - no workspace means no fingerprint. A delegate with no tree runs in the
    backend's scratch dir, which is derived from the task id already, and
    resume-by-task-id is the point there
  - on overflow the BODY is truncated and the SUFFIX kept. Dropping the suffix
    would collide two different mount sets onto one name

ONE DELIBERATE SCOPE CHOICE, stated rather than slipped in: the fingerprint
covers WORKSPACE mounts only, matching what the backend has always hashed. The
control socket is excluded because it is the same channel for every delegate on
the host -- it distinguishes nothing, and including it would churn every
container name the moment the socket moved. This change is about WHERE the
decision lives, so the decision itself is carried over unchanged.

The wire change is free: stage 12 landed in #2544 and has no consumers yet.
