### PR TITLE
feat(prompts): ask agents for the turn registers the compactor already reads

### DIFF
--- a/src/headers/prompts.h
+++ b/src/headers/prompts.h
@@ -78,6 +78,17 @@ char *prompt_prepend_principles(aimee_mode_t mode, const char *base_prompt);
  * prompt_principles_text). */
 const char *prompt_code_principles_text(void);
 
+/* Turn-register instructions, or NULL when `enabled` is 0.
+ *
+ * The register GRAMMAR has always been parsed — fold_register_parse classifies a turn and
+ * session_compact's record path reads it to decide what belongs under Key Decisions — but
+ * nothing ever ASKED an agent to emit one, so real transcripts contain none and that
+ * extraction is empty in practice. This is the missing half: the request.
+ *
+ * A pure function of its argument so the gate and the wording are testable; the caller
+ * supplies config_fold_register_enabled(). */
+const char *prompt_turn_registers_text(int enabled);
+
 /* Engineer-mode form of prompt_prepend_principles. Caller must free(). */
 char *prompt_prepend_code_principles(const char *base_prompt);
 

--- a/src/prompts.c
+++ b/src/prompts.c
@@ -715,6 +715,28 @@ const char *prompt_code_principles_text(void)
    return prompt_principles_text(AIMEE_MODE_ENGINEER);
 }
 
+/* The wording deliberately biases AGAINST tagging. A compaction boundary carries a
+ * tagged turn forward as a settled fact while discarding the reasoning that produced it,
+ * so a mis-tagged [verdict] is worse than no tag at all: it asserts a guess and outlives
+ * its evidence. Untagged means work-in-progress, which is both the safe default and the
+ * common case, and the text says so rather than leaving the model to infer it. */
+const char *prompt_turn_registers_text(int enabled)
+{
+   if (!enabled)
+      return NULL;
+   return "## Turn registers\n"
+          "Prefix a turn with ONE of these tags only when it genuinely applies; otherwise "
+          "write no tag:\n"
+          "  [verdict]  a settled conclusion you believe is final\n"
+          "  [hazard]   a risk or blocker the next reader must not miss\n"
+          "  [blocked]  you cannot proceed without an answer\n"
+          "An untagged turn is treated as work in progress, which is the safe default and "
+          "usually correct. Do NOT tag speculation, a partial finding, or a plan as "
+          "[verdict]: when this conversation is later compacted, tagged turns are carried "
+          "forward as settled facts while the reasoning behind them is discarded, so a "
+          "wrong tag outlives its evidence.\n";
+}
+
 char *prompt_prepend_code_principles(const char *base_prompt)
 {
    return prompt_prepend_principles(AIMEE_MODE_ENGINEER, base_prompt);

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -1582,6 +1582,16 @@ char *agent_build_exec_context_for_role(const agent_t *agent, const agent_networ
    ctx_appendf(buf, cap, &pos, "%s", agent_exec_instructions(task_type));
    ctx_appendf(buf, cap, &pos, "%s", prompt_principles_text(config_current_mode()));
 
+   /* Turn registers (fold §6): ask for the tags the record path already knows how to
+    * read. Gated on the same flag that turns on the fold's skeleton annotation, because
+    * both are the same feature — the grammar is either in use end to end or it is not.
+    * Default-off, so no agent's behaviour changes until someone enables it to measure. */
+   {
+      const char *registers = prompt_turn_registers_text(config_fold_register_enabled());
+      if (registers)
+         ctx_appendf(buf, cap, &pos, "%s", registers);
+   }
+
    char cwd_buf[MAX_PATH_LEN];
    const char *cwd = agent_context_cwd(cwd_buf, sizeof(cwd_buf));
    char memory_project[MAX_PATH_LEN] = "";

--- a/src/tests/test_prompts.c
+++ b/src/tests/test_prompts.c
@@ -89,6 +89,28 @@ int main(void)
       assert(prompt_tier_from_string(NULL) == PROMPT_STANDARD);
    }
 
+   /* --- prompt_turn_registers_text: gate and wording ---
+    * The register grammar has always been PARSED (fold_register_parse, and
+    * session_compact's record path reads it for Key Decisions) while nothing ever ASKED
+    * an agent to emit one — so real transcripts carry no tags and that extraction is
+    * empty in practice. This is the request half, and it must stay off by default. */
+   {
+      assert(prompt_turn_registers_text(0) == NULL); /* default-off changes nobody */
+
+      const char *t = prompt_turn_registers_text(1);
+      assert(t != NULL);
+      /* Names every tag the parser recognises as load-bearing; asking for a tag the
+       * record path ignores would train agents to emit noise. */
+      assert(strstr(t, "[verdict]") != NULL);
+      assert(strstr(t, "[hazard]") != NULL);
+      assert(strstr(t, "[blocked]") != NULL);
+      /* Biases AGAINST tagging. A mis-tagged [verdict] survives compaction as a settled
+       * fact while its reasoning is discarded, so it is worse than no tag at all — the
+       * text has to say that, not merely list the tags. */
+      assert(strstr(t, "Do NOT tag speculation") != NULL);
+      assert(strstr(t, "safe default") != NULL);
+   }
+
    /* --- prompt_tier_to_string --- */
    {
       assert(strcmp(prompt_tier_to_string(PROMPT_MINIMAL), "MINIMAL") == 0);

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1015,7 +1015,7 @@
         },
         {
           "path": "src/headers/prompts.h",
-          "sha256": "5deda4033a60bd48d0cde5380a0f057c302e66baf49920ee108f66d99d354960"
+          "sha256": "02be31c44afc5aef3a81c37a708dd4fe913f72225f29851aec526b25d6117048"
         },
         {
           "path": "src/headers/provider_catalog.h",
@@ -1608,7 +1608,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "993c60bb35d338015a5966e4c54c8a01679d85249e05e2ff9e46b8b99a356d94",
+      "sha256": "e5af0ebf37128d0b67df0854643424ae10d950f9036b096a73c3304ee2543579",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## Summary

The register **grammar** has always been parsed. `fold_register_parse` classifies a turn, and `session_compact`'s record path reads it to decide what belongs under Key Decisions and Blocked.

**Nothing ever asked an agent to emit one.**

There is no `prompts/` directory; the system prompt is `PROMPT_STANDARD_TEXT` in `src/prompts.c` and it never mentions `[verdict]` / `[hazard]` / `[wip]`. Before this commit the only occurrences of those tags anywhere in the repository were unit tests and a proposal.

So real transcripts contain no registers, that extraction is empty in practice, and the measured result follows directly from it: **record 15/20 vs legacy 11/20 overall, dead even at 10/14** on the fixtures that match real transcripts (#2537).

This adds the missing half — the request.

## Gating

`config_fold_register_enabled()`, which already existed and until now only turned on the fold's skeleton annotation. Same flag because it is the same feature: the grammar is either in use end to end or it is not.

**Default-off.** No agent's behaviour changes until someone enables it in order to measure. (See #2545 for the correction to the earlier, wrong claim that this flag gated the *compactor* — it never did.)

## The wording biases against tagging, deliberately

A compaction boundary carries a tagged turn forward as a settled fact **while discarding the reasoning that produced it**. So a mis-tagged `[verdict]` is worse than no tag at all: it asserts a guess, and it outlives its evidence.

The text therefore says untagged means work-in-progress, that this is the safe default and usually correct, and not to tag speculation, a partial finding, or a plan. That is the failure mode the precision axis in #2527 exists to catch, so the instruction is written to avoid manufacturing it.

## Testability

Extracted as `prompt_turn_registers_text(enabled)` rather than inlined at the call site.

The inline version had **no test surface at all** — nothing in the suite calls `agent_build_exec_context_for_role`, which needs an agent, a network and KB context. I shipped one untestable wiring change already (#2539) and did not want to make a habit of it.

As a pure function both the gate and the wording are testable. The test asserts:
- default-off returns `NULL`
- every tag the parser treats as load-bearing is named — asking for a tag the record path ignores would train agents to emit noise
- the anti-tagging warning is present, not merely a list of tags

## Where this sits

Step 1 of the sequence in the S2–S5 proposal: **add the instruction → measure tagging accuracy → re-run the retention probe → only then revisit the `compact.from_record` default.**

This is step 1 only. Enabling it anywhere, and the accuracy measurement, are separate deliberate acts.

## Verification

- `rm -f aimee-server && make -C src -j8 ../aimee-server` — exit 0, zero undefined references
- `make -C src -j8 ../aimee-kb`, `cmd-srcs-compile-check` — exit 0
- `make -C src TEST_RUN_JOBS=1 unit-tests` — exit 0
- `make -C src lint` — all checks passed (`format` run first)
- `check_c_repository_lock` — ok; `refactor_baselines` — additive drift verified, frozen