### PR TITLE
fix(delegates): a plain checkout gets ONE mount, not two on the same target

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "a71daf327f0d55000cfc69d721c9fa677ebec4570da1ef92ef5b4d82f01ff741",
+      "source_sha256": "4017a1a55f9d0893bd5720c1dddd7677cc64fc8e8911b7bf1d12049cb5f544ee",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/sandbox.go
+++ b/server-go/modules/delegates/sandbox.go
@@ -170,8 +170,17 @@ func BuildSandboxSpec(req SandboxRequest) (SandboxSpec, error) {
 		if !ok {
 			return spec, fmt.Errorf("repo root must be an absolute path, got %q", req.RepoRoot)
 		}
-		// The tree is readable; only the worktree below is writable.
-		spec.Mounts = append(spec.Mounts, SandboxMount{Source: repo, Target: repo, ReadOnly: true})
+		// A PLAIN checkout carries its own .git, so the repo root IS the
+		// worktree. It needs one writable mount, not a read-only mount of the
+		// same path with a writable one layered over it: two binds on one target
+		// is not a layering, and the delegate would get whichever docker
+		// resolved last -- a coin flip between a writable tree and a read-only
+		// one, discovered only when a write failed.
+		if repo != worktree {
+			// The tree is readable; only the worktree below is writable.
+			spec.Mounts = append(spec.Mounts,
+				SandboxMount{Source: repo, Target: repo, ReadOnly: true})
+		}
 		spec.Mounts = append(spec.Mounts,
 			SandboxMount{Source: worktree, Target: worktree, ReadOnly: false})
 		if gitDir, ok := cleanAbs(req.GitDir); ok {

--- a/server-go/modules/delegates/sandbox_test.go
+++ b/server-go/modules/delegates/sandbox_test.go
@@ -223,3 +223,61 @@ func TestValidateRejectsHandBuiltViolations(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// A PLAIN checkout carries its own .git, so the repo root IS the worktree. It
+// gets ONE writable mount.
+//
+// Two binds on one target is not a layering: the delegate would get whichever
+// docker resolved last, so a write role could silently land on the read-only
+// copy and only find out when a write failed. The backend has always mounted a
+// plain checkout exactly once.
+func TestPlainCheckoutGetsOneWritableMount(t *testing.T) {
+	spec, err := BuildSandboxSpec(SandboxRequest{
+		Role: "code", RepoRoot: "/repo", Worktree: "/repo", IsGitCheckout: true,
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	byTarget := map[string]int{}
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxWorkspace {
+			byTarget[m.Target]++
+		}
+	}
+	if byTarget["/repo"] != 1 {
+		t.Fatalf("/repo mounted %d times, want exactly 1", byTarget["/repo"])
+	}
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxWorkspace && m.Target == "/repo" && m.ReadOnly {
+			t.Error("a write delegate's plain checkout was mounted read-only")
+		}
+	}
+}
+
+// A LINKED worktree still gets the layering: the repo read-only underneath, the
+// worktree writable over it, so a write outside the worktree fails.
+func TestLinkedWorktreeKeepsTheReadOnlyRepoBeneath(t *testing.T) {
+	spec, err := BuildSandboxSpec(SandboxRequest{
+		Role: "code", RepoRoot: "/repo", Worktree: "/repo/.aimee/worktrees/d1",
+		GitDir: "/repo/.git/worktrees/d1", IsGitCheckout: true,
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	var repoRO, worktreeRW bool
+	for _, m := range spec.Mounts {
+		if m.Target == "/repo" && m.ReadOnly {
+			repoRO = true
+		}
+		if m.Target == "/repo/.aimee/worktrees/d1" && !m.ReadOnly {
+			worktreeRW = true
+		}
+	}
+	if !repoRO {
+		t.Error("the repo is not mounted read-only beneath the worktree")
+	}
+	if !worktreeRW {
+		t.Error("the worktree is not writable")
+	}
+}


### PR DESCRIPTION
fix(delegates): a plain checkout gets ONE mount, not two on the same target

Found while wiring the C backend to stage 12, by reading what the backend
actually discovers before it mounts anything.

A PLAIN checkout carries its own .git, so the repo root IS the worktree.
BuildSandboxSpec added the repo read-only and then the worktree writable
unconditionally, which for that case produced two binds on the SAME target:

    -v /repo:/repo:ro  -v /repo:/repo

That is not a layering. A nested mount overlays a parent path; two binds on one
target is just two binds, and the delegate gets whichever docker resolved last.
A write role would land on a coin flip between a writable tree and a read-only
one, and would find out only when a write failed partway through its work --
which reads as a broken repository, not as a bad mount.

The backend has always mounted a plain checkout exactly once, at its own
absolute path; only the linked-worktree case gets three mounts. This restores
that distinction on the Go side, where the decision now lives.

Reachable, not theoretical: it is on the path the moment C calls stage 12, and a
plain checkout is the ordinary case for a delegate that was handed a repository
rather than a sibling worktree.

Both shapes are now pinned by test -- the plain checkout mounted once and
writable, and the linked worktree keeping the read-only repo beneath its
writable worktree so a write outside the worktree still fails.
