### PR TITLE
fix(delegates): the CALLER says whether a delegate writes; the module says what that shape is

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "4017a1a55f9d0893bd5720c1dddd7677cc64fc8e8911b7bf1d12049cb5f544ee",
+      "source_sha256": "070947edc459fc6c7cb7abfff4238e9b8d89e018f2ba224dcb039eadf119d170",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/launchargs_stage.go
+++ b/server-go/modules/delegates/launchargs_stage.go
@@ -37,7 +37,8 @@ const (
 // launchArgsRequest is the wire form, kept as one struct so the decode below
 // reads in the same order the encoder writes.
 type launchArgsRequest struct {
-	Role          string
+	// WritesAllowed is the caller's composed answer, not the role's default.
+	WritesAllowed bool
 	RepoRoot      string
 	Worktree      string
 	GitDir        string
@@ -63,10 +64,11 @@ func decodeLaunchArgsRequest(request []byte) (launchArgsRequest, bool) {
 	var req launchArgsRequest
 	if len(request) < launchArgsReqHeaderLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != launchArgsRequestMagic ||
-		request[4] != wireVersion || request[5] > 1 {
+		request[4] != wireVersion || request[5] > 3 {
 		return req, false
 	}
-	req.IsGitCheckout = request[5] == 1
+	req.IsGitCheckout = request[5]&1 != 0
+	req.WritesAllowed = request[5]&2 != 0
 	commandCount := int(binary.LittleEndian.Uint32(request[8:12]))
 	if commandCount > launchArgsMaxCommand {
 		return req, false
@@ -82,7 +84,6 @@ func decodeLaunchArgsRequest(request []byte) (launchArgsRequest, bool) {
 		return c.str(n)
 	}
 
-	req.Role = readString(roleMax)
 	req.RepoRoot = readString(launchArgsStringMax)
 	req.Worktree = readString(launchArgsStringMax)
 	req.GitDir = readString(launchArgsStringMax)
@@ -107,10 +108,15 @@ func decodeLaunchArgsRequest(request []byte) (launchArgsRequest, bool) {
 
 // handleLaunchArgs renders the create command for one delegate.
 //
-// The isolation of the plan is derived from the ROLE rather than carried in the
-// request. It is the same decision stage 11 made, and re-deriving it means the
-// two cannot disagree -- a caller that sent a stale "isolated" flag would
-// otherwise get a git directory mounted into a read-only delegate.
+// Whether the delegate writes is CARRIED, not re-derived from the role. The
+// role's default is only one input: the caller narrows it with a prompt rule
+// this module cannot see, so a module that re-derived from the role would
+// disagree with the decision the caller actually made -- and would hand a
+// writable tree, and a git directory, to a delegate already ruled read-only.
+//
+// The caller must therefore send the SAME flag it sent to stage 11. It is the
+// one fact that has to agree across the two calls, which is why it is a single
+// composed boolean rather than a set of inputs each side re-combines.
 func handleLaunchArgs(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
 	req, ok := decodeLaunchArgsRequest(request)
 	if !ok {
@@ -120,8 +126,8 @@ func handleLaunchArgs(invocation bus.ModuleInvocation, request []byte) ([]byte, 
 		return nil, bus.ModuleStatusCancelled
 	}
 
-	plan := WorktreePlan{Isolated: RoleIsWrite(req.Role), ReadOnlyMount: !RoleIsWrite(req.Role)}
-	sandboxReq := SandboxRequestFor(plan, req.Role, req.RepoRoot, req.Worktree, req.GitDir,
+	plan := WorktreePlan{Isolated: req.WritesAllowed, ReadOnlyMount: !req.WritesAllowed}
+	sandboxReq := SandboxRequestFor(plan, req.RepoRoot, req.Worktree, req.GitDir,
 		req.IsGitCheckout, req.ParentSocketHost, req.ParentSocketTarget, req.EgressProxy)
 
 	spec, err := BuildSandboxSpec(sandboxReq)

--- a/server-go/modules/delegates/launchargs_stage_test.go
+++ b/server-go/modules/delegates/launchargs_stage_test.go
@@ -13,7 +13,10 @@ func encodeLaunchArgs(req launchArgsRequest) []byte {
 	binary.LittleEndian.PutUint32(out[0:4], launchArgsRequestMagic)
 	out[4] = wireVersion
 	if req.IsGitCheckout {
-		out[5] = 1
+		out[5] |= 1
+	}
+	if req.WritesAllowed {
+		out[5] |= 2
 	}
 	binary.LittleEndian.PutUint32(out[8:12], uint32(len(req.Command)))
 
@@ -23,7 +26,6 @@ func encodeLaunchArgs(req launchArgsRequest) []byte {
 		out = append(out, n[:]...)
 		out = append(out, s...)
 	}
-	put(req.Role)
 	put(req.RepoRoot)
 	put(req.Worktree)
 	put(req.GitDir)
@@ -84,7 +86,7 @@ func callLaunchArgsNamed(t *testing.T, req launchArgsRequest) (string, []string,
 
 func writeRequest() launchArgsRequest {
 	return launchArgsRequest{
-		Role:               "code",
+		WritesAllowed:      true,
 		RepoRoot:           "/repo",
 		Worktree:           "/repo/.aimee/worktrees/d1",
 		GitDir:             "/repo/.git/worktrees/d1",
@@ -109,10 +111,12 @@ func argIndex(args []string, want string) int {
 // The isolation primitive. If this is ever absent the delegate has a network,
 // so it is asserted on the rendered argv rather than on the spec.
 func TestLaunchArgsAlwaysHasNoNetwork(t *testing.T) {
-	for _, role := range []string{"code", "refactor", "review", "search", "validate"} {
+	for _, writes := range []bool{true, false} {
 		req := writeRequest()
-		req.Role = role
-		if !RoleIsWrite(role) {
+		req.WritesAllowed = writes
+		role := "a writing delegate"
+		if !writes {
+			role = "a read-only delegate"
 			req.GitDir = ""
 			req.RepoRoot = ""
 		}
@@ -154,7 +158,7 @@ func TestLaunchArgsWriteRoleMountLayering(t *testing.T) {
 // enforcement -- not a request the delegate is asked to honour.
 func TestLaunchArgsReadOnlyRoleGetsReadOnlyMount(t *testing.T) {
 	req := writeRequest()
-	req.Role = "review"
+	req.WritesAllowed = false
 	req.RepoRoot = ""
 	req.GitDir = "/repo/.git/worktrees/d1" // supplied, and must be ignored
 	req.Worktree = "/repo"

--- a/server-go/modules/delegates/sandbox.go
+++ b/server-go/modules/delegates/sandbox.go
@@ -74,7 +74,15 @@ type SandboxEnv struct {
 // is supplied rather than discovered: this module does not stat the workspace,
 // because the workspace owns its files.
 type SandboxRequest struct {
-	Role string
+	// WritesAllowed is whether THIS delegate may write its worktree.
+	//
+	// Not derived from the role here, deliberately. The role's default is one
+	// input (stage 10), but the caller narrows it further -- a write role whose
+	// prompt does not ask for writes does not get a writable tree. Re-deriving
+	// from the role would make this module disagree with the decision the caller
+	// actually made, and the disagreement would show up as a delegate writing
+	// into a tree the caller had already ruled read-only.
+	WritesAllowed bool
 
 	// RepoRoot is the parent checkout. Mounted read-only for a write delegate
 	// so the tree is readable but only the worktree is writable.
@@ -162,7 +170,7 @@ func BuildSandboxSpec(req SandboxRequest) (SandboxSpec, error) {
 		return spec, fmt.Errorf("%w: %s", ErrNotGitCheckout, worktree)
 	}
 
-	write := RoleIsWrite(req.Role)
+	write := req.WritesAllowed
 	spec.ReadOnly = !write
 
 	if write {

--- a/server-go/modules/delegates/sandbox_test.go
+++ b/server-go/modules/delegates/sandbox_test.go
@@ -8,7 +8,7 @@ import (
 
 func writeReq() SandboxRequest {
 	return SandboxRequest{
-		Role:               "code",
+		WritesAllowed:      true,
 		RepoRoot:           "/srv/repo",
 		Worktree:           "/srv/repo/.aimee/worktrees/w1/main",
 		GitDir:             "/srv/repo/.git/worktrees/w1",
@@ -21,7 +21,7 @@ func writeReq() SandboxRequest {
 
 func readReq() SandboxRequest {
 	return SandboxRequest{
-		Role:               "review",
+		WritesAllowed:      false,
 		RepoRoot:           "/srv/repo",
 		Worktree:           "/srv/repo",
 		IsGitCheckout:      true,
@@ -233,7 +233,7 @@ func TestValidateRejectsHandBuiltViolations(t *testing.T) {
 // plain checkout exactly once.
 func TestPlainCheckoutGetsOneWritableMount(t *testing.T) {
 	spec, err := BuildSandboxSpec(SandboxRequest{
-		Role: "code", RepoRoot: "/repo", Worktree: "/repo", IsGitCheckout: true,
+		WritesAllowed: true, RepoRoot: "/repo", Worktree: "/repo", IsGitCheckout: true,
 	})
 	if err != nil {
 		t.Fatalf("err = %v", err)
@@ -259,7 +259,7 @@ func TestPlainCheckoutGetsOneWritableMount(t *testing.T) {
 // worktree writable over it, so a write outside the worktree fails.
 func TestLinkedWorktreeKeepsTheReadOnlyRepoBeneath(t *testing.T) {
 	spec, err := BuildSandboxSpec(SandboxRequest{
-		Role: "code", RepoRoot: "/repo", Worktree: "/repo/.aimee/worktrees/d1",
+		WritesAllowed: true, RepoRoot: "/repo", Worktree: "/repo/.aimee/worktrees/d1",
 		GitDir: "/repo/.git/worktrees/d1", IsGitCheckout: true,
 	})
 	if err != nil {

--- a/server-go/modules/delegates/worktreeplan.go
+++ b/server-go/modules/delegates/worktreeplan.go
@@ -69,8 +69,12 @@ func workNameSafe(name string) bool {
 // policy and fails hard when it cannot: guessing one is what let a session
 // inherit another session's branch, and a delegate is in no better position to
 // guess than a session was.
-func PlanWorktree(role, delegateID string) (WorktreePlan, error) {
-	if !RoleIsWrite(role) {
+//
+// writesAllowed is the caller's composed answer, not the role's default. A
+// write role whose prompt does not ask for writes needs no worktree of its own,
+// and cutting one for it would leave a branch nobody ever commits to.
+func PlanWorktree(writesAllowed bool, delegateID string) (WorktreePlan, error) {
+	if !writesAllowed {
 		// Nothing to create: the parent's worktree, mounted read-only.
 		return WorktreePlan{ReadOnlyMount: true}, nil
 	}
@@ -92,10 +96,10 @@ func PlanWorktree(role, delegateID string) (WorktreePlan, error) {
 // Keeping this next to PlanWorktree is deliberate: the plan's ReadOnlyMount and
 // the spec's mount modes are the same decision, and computing them in one place
 // stops a future edit from making a read-only delegate a writable mount.
-func SandboxRequestFor(plan WorktreePlan, role, repoRoot, worktree, gitDir string,
+func SandboxRequestFor(plan WorktreePlan, repoRoot, worktree, gitDir string,
 	isGitCheckout bool, socketHost, socketTarget, egressProxy string) SandboxRequest {
 	req := SandboxRequest{
-		Role:               role,
+		WritesAllowed:      plan.Isolated,
 		RepoRoot:           repoRoot,
 		Worktree:           worktree,
 		IsGitCheckout:      isGitCheckout,

--- a/server-go/modules/delegates/worktreeplan_stage.go
+++ b/server-go/modules/delegates/worktreeplan_stage.go
@@ -37,21 +37,28 @@ const (
 
 // handleWorktreePlan answers what to ask the workspace module for.
 //
-// Role and delegate id arrive as content. The module looks neither up: which
-// delegate is running is the caller's fact, and a module that remembered it
-// would be tracking someone else's state.
+// Whether this delegate writes, and which delegate it is, arrive as content.
+// The module looks neither up: both are the caller's facts, and a module that
+// remembered them would be tracking someone else's state.
 func handleWorktreePlan(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
 	if len(request) < worktreePlanReqHeaderLen ||
 		binary.LittleEndian.Uint32(request[0:4]) != worktreePlanRequestMagic ||
 		request[4] != wireVersion {
 		return nil, bus.ModuleStatusInvalidRequest
 	}
-	c := &economicsCursor{buf: request, at: 8}
-	roleLen, idLen := c.u32(), c.u32()
-	if roleLen > roleMax || idLen > worktreePlanDelegateIDMax {
+	// The caller's COMPOSED answer, not the role. A write role whose prompt does
+	// not ask for writes needs no worktree of its own.
+	if request[5] > 1 {
 		return nil, bus.ModuleStatusInvalidRequest
 	}
-	role := c.str(roleLen)
+	writesAllowed := request[5] == 1
+
+	// The length lives in the fixed header; the body starts after it.
+	idLen := int(binary.LittleEndian.Uint32(request[8:12]))
+	if idLen > worktreePlanDelegateIDMax {
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+	c := &economicsCursor{buf: request, at: worktreePlanReqHeaderLen}
 	delegateID := c.str(idLen)
 	if c.bad || c.at != len(request) {
 		return nil, bus.ModuleStatusInvalidRequest
@@ -60,7 +67,7 @@ func handleWorktreePlan(invocation bus.ModuleInvocation, request []byte) ([]byte
 		return nil, bus.ModuleStatusCancelled
 	}
 
-	plan, err := PlanWorktree(role, delegateID)
+	plan, err := PlanWorktree(writesAllowed, delegateID)
 	if err != nil {
 		return nil, bus.ModuleStatusInvalidRequest
 	}

--- a/server-go/modules/delegates/worktreeplan_stage_test.go
+++ b/server-go/modules/delegates/worktreeplan_stage_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/JBailes/aimee/server-go/bus"
 )
 
-func worktreePlanRequest(role, delegateID string) []byte {
+func worktreePlanRequest(writesAllowed bool, delegateID string) []byte {
 	req := make([]byte, worktreePlanReqHeaderLen)
 	binary.LittleEndian.PutUint32(req[0:4], worktreePlanRequestMagic)
 	req[4] = wireVersion
-	binary.LittleEndian.PutUint32(req[8:12], uint32(len(role)))
-	binary.LittleEndian.PutUint32(req[12:16], uint32(len(delegateID)))
-	req = append(req, role...)
+	if writesAllowed {
+		req[5] = 1
+	}
+	binary.LittleEndian.PutUint32(req[8:12], uint32(len(delegateID)))
 	return append(req, delegateID...)
 }
 
@@ -36,16 +37,16 @@ func decodeWorktreePlan(t *testing.T, response []byte) (isolated, readOnly bool,
 		string(name)
 }
 
-func callWorktreePlan(t *testing.T, role, delegateID string) ([]byte, bus.ModuleStatus) {
+func callWorktreePlan(t *testing.T, writesAllowed bool, delegateID string) ([]byte, bus.ModuleStatus) {
 	t.Helper()
 	return Handle(bus.ModuleInvocation{StageID: StageWorktreePlan},
-		worktreePlanRequest(role, delegateID))
+		worktreePlanRequest(writesAllowed, delegateID))
 }
 
 // A write role needs its own worktree, named after the delegate so two
 // delegates in one session cannot land in the same directory.
 func TestWorktreePlanStageWriteRoleIsIsolated(t *testing.T) {
-	response, status := callWorktreePlan(t, "code", "delegate-7")
+	response, status := callWorktreePlan(t, true, "delegate-7")
 	if status != bus.ModuleStatusOK {
 		t.Fatalf("status = %v, want OK", status)
 	}
@@ -64,7 +65,7 @@ func TestWorktreePlanStageWriteRoleIsIsolated(t *testing.T) {
 // A read-only role mounts the parent's worktree, so there is nothing to create
 // and no name to give it.
 func TestWorktreePlanStageReadRoleCreatesNothing(t *testing.T) {
-	response, status := callWorktreePlan(t, "review", "delegate-7")
+	response, status := callWorktreePlan(t, false, "delegate-7")
 	if status != bus.ModuleStatusOK {
 		t.Fatalf("status = %v, want OK", status)
 	}
@@ -80,24 +81,12 @@ func TestWorktreePlanStageReadRoleCreatesNothing(t *testing.T) {
 	}
 }
 
-// An alias must reach the same answer as the role it names -- otherwise
-// "implement" would be planned as read-only and edit its parent's worktree.
-func TestWorktreePlanStageResolvesAliases(t *testing.T) {
-	response, status := callWorktreePlan(t, "implement", "d1")
-	if status != bus.ModuleStatusOK {
-		t.Fatalf("status = %v, want OK", status)
-	}
-	if isolated, _, _ := decodeWorktreePlan(t, response); !isolated {
-		t.Error("the alias for a write role should be planned as one")
-	}
-}
-
 // The field is sized so the longest accepted name survives intact. Sized
 // exactly it would come back one character short -- a different branch, and
 // silently.
 func TestWorktreePlanStageCarriesTheLongestAcceptedName(t *testing.T) {
 	name := strings.Repeat("a", workNameMax)
-	response, status := callWorktreePlan(t, "code", name)
+	response, status := callWorktreePlan(t, true, name)
 	if status != bus.ModuleStatusOK {
 		t.Fatalf("status = %v, want OK", status)
 	}
@@ -114,7 +103,7 @@ func TestWorktreePlanStageRefusesUnusableNames(t *testing.T) {
 		"", "../escape", "has space", "-leading-dash", "a/b",
 		"quote'd", strings.Repeat("a", workNameMax+1),
 	} {
-		if _, status := callWorktreePlan(t, "code", id); status != bus.ModuleStatusInvalidRequest {
+		if _, status := callWorktreePlan(t, true, id); status != bus.ModuleStatusInvalidRequest {
 			t.Errorf("delegate id %q: status = %v, want InvalidRequest", id, status)
 		}
 	}
@@ -122,13 +111,13 @@ func TestWorktreePlanStageRefusesUnusableNames(t *testing.T) {
 
 // A read-only role needs no name, so an unusable one must not refuse the plan.
 func TestWorktreePlanStageIgnoresTheNameWhenNothingIsCreated(t *testing.T) {
-	if _, status := callWorktreePlan(t, "review", "../escape"); status != bus.ModuleStatusOK {
+	if _, status := callWorktreePlan(t, false, "../escape"); status != bus.ModuleStatusOK {
 		t.Errorf("status = %v, want OK", status)
 	}
 }
 
 func TestWorktreePlanStageRejectsMalformedRequests(t *testing.T) {
-	good := worktreePlanRequest("code", "d1")
+	good := worktreePlanRequest(true, "d1")
 
 	cases := map[string][]byte{
 		"empty":         {},
@@ -140,12 +129,12 @@ func TestWorktreePlanStageRejectsMalformedRequests(t *testing.T) {
 	cases["truncated body"] = truncated[:len(truncated)-1]
 	// A length field that overruns the buffer entirely.
 	overrun := append([]byte{}, good...)
-	binary.LittleEndian.PutUint32(overrun[12:16], 1<<20)
+	binary.LittleEndian.PutUint32(overrun[8:12], 1<<20)
 	cases["overrun length"] = overrun
-	// A role longer than any role can be.
-	longRole := append([]byte{}, good...)
-	binary.LittleEndian.PutUint32(longRole[8:12], uint32(roleMax+1))
-	cases["oversized role"] = longRole
+	// A length inside the bound that still runs past the end of the buffer.
+	short := append([]byte{}, good...)
+	binary.LittleEndian.PutUint32(short[8:12], uint32(worktreePlanDelegateIDMax))
+	cases["length past the end"] = short
 
 	badMagic := append([]byte{}, good...)
 	binary.LittleEndian.PutUint32(badMagic[0:4], 0xDEADBEEF)
@@ -165,7 +154,7 @@ func TestWorktreePlanStageRejectsMalformedRequests(t *testing.T) {
 
 func TestWorktreePlanStageHonoursCancellation(t *testing.T) {
 	invocation := bus.ModuleInvocation{StageID: StageWorktreePlan, DeadlineNS: 1}
-	if _, status := Handle(invocation, worktreePlanRequest("code", "d1")); status != bus.ModuleStatusCancelled {
+	if _, status := Handle(invocation, worktreePlanRequest(true, "d1")); status != bus.ModuleStatusCancelled {
 		t.Errorf("status = %v, want Cancelled", status)
 	}
 }

--- a/server-go/modules/delegates/worktreeplan_test.go
+++ b/server-go/modules/delegates/worktreeplan_test.go
@@ -5,8 +5,10 @@ import "testing"
 // A write delegate needs somewhere of its own so the supervisor can inspect and
 // merge its edits deliberately.
 func TestPlanWorktreeWriteRoleIsIsolated(t *testing.T) {
+	// The caller composes this from the role AND its prompt rule; the module is
+	// told the answer. Roles named for readability.
 	for _, role := range []string{"code", "refactor", "implement"} {
-		plan, err := PlanWorktree(role, "deleg-7")
+		plan, err := PlanWorktree(true, "deleg-7")
 		if err != nil {
 			t.Fatalf("%s: %v", role, err)
 		}
@@ -26,7 +28,7 @@ func TestPlanWorktreeWriteRoleIsIsolated(t *testing.T) {
 // is a directory to clean up.
 func TestPlanWorktreeReadOnlyRoleCreatesNothing(t *testing.T) {
 	for _, role := range []string{"review", "validate", "diagnose", "summarize"} {
-		plan, err := PlanWorktree(role, "deleg-7")
+		plan, err := PlanWorktree(false, "deleg-7")
 		if err != nil {
 			t.Fatalf("%s: %v", role, err)
 		}
@@ -51,12 +53,12 @@ func TestPlanWorktreeRejectsUnsafeDelegateIDs(t *testing.T) {
 		"has;semi", "$(id)", "has..dots", "has\nnewline",
 	}
 	for _, id := range hostile {
-		if _, err := PlanWorktree("code", id); err == nil {
+		if _, err := PlanWorktree(true, id); err == nil {
 			t.Errorf("accepted unsafe delegate id %q", id)
 		}
 	}
 	for _, id := range []string{"deleg7", "deleg-7", "deleg_7", "a", "D7"} {
-		if _, err := PlanWorktree("code", id); err != nil {
+		if _, err := PlanWorktree(true, id); err != nil {
 			t.Errorf("rejected safe delegate id %q: %v", id, err)
 		}
 	}
@@ -65,7 +67,7 @@ func TestPlanWorktreeRejectsUnsafeDelegateIDs(t *testing.T) {
 // A read-only delegate's id is never used, so a hostile one cannot reach a
 // branch name through this path either.
 func TestPlanWorktreeReadOnlyIgnoresTheDelegateID(t *testing.T) {
-	plan, err := PlanWorktree("review", "$(id); rm -rf /")
+	plan, err := PlanWorktree(false, "$(id); rm -rf /")
 	if err != nil {
 		t.Fatalf("a read-only plan failed on an id it does not use: %v", err)
 	}
@@ -77,8 +79,8 @@ func TestPlanWorktreeReadOnlyIgnoresTheDelegateID(t *testing.T) {
 // The plan's read-only decision and the sandbox's mount modes are the same
 // decision, and must not drift apart.
 func TestSandboxRequestForMatchesThePlan(t *testing.T) {
-	writePlan, _ := PlanWorktree("code", "deleg-7")
-	req := SandboxRequestFor(writePlan, "code", "/srv/repo",
+	writePlan, _ := PlanWorktree(true, "deleg-7")
+	req := SandboxRequestFor(writePlan, "/srv/repo",
 		"/srv/repo/.aimee/worktrees/w1/main", "/srv/repo/.git/worktrees/w1", true,
 		"/run/aimee/server.sock", "/run/aimee.sock", "")
 	spec, err := BuildSandboxSpec(req)
@@ -92,8 +94,8 @@ func TestSandboxRequestForMatchesThePlan(t *testing.T) {
 		t.Error("an isolated delegate did not get its git dir")
 	}
 
-	readPlan, _ := PlanWorktree("review", "deleg-8")
-	req = SandboxRequestFor(readPlan, "review", "/srv/repo", "/srv/repo", "", true,
+	readPlan, _ := PlanWorktree(false, "deleg-8")
+	req = SandboxRequestFor(readPlan, "/srv/repo", "/srv/repo", "", true,
 		"/run/aimee/server.sock", "/run/aimee.sock", "")
 	spec, err = BuildSandboxSpec(req)
 	if err != nil {
@@ -112,8 +114,8 @@ func TestSandboxRequestForMatchesThePlan(t *testing.T) {
 // A read-only delegate writes nothing, so it needs no writable git dir -- and
 // must not be handed one even if the caller passes a path.
 func TestSandboxRequestForReadOnlyDropsTheGitDir(t *testing.T) {
-	readPlan, _ := PlanWorktree("review", "deleg-8")
-	req := SandboxRequestFor(readPlan, "review", "/srv/repo", "/srv/repo",
+	readPlan, _ := PlanWorktree(false, "deleg-8")
+	req := SandboxRequestFor(readPlan, "/srv/repo", "/srv/repo",
 		"/srv/repo/.git", true, "", "", "")
 	if req.GitDir != "" {
 		t.Errorf("git dir = %q, want empty for a read-only delegate", req.GitDir)


### PR DESCRIPTION
fix(delegates): the CALLER says whether a delegate writes; the module says what that shape is

Correcting my own reasoning in #2544. I justified deriving isolation from the
ROLE inside stages 11 and 12 on the grounds that re-deriving means the two
stages cannot disagree. That was right about the two stages and wrong about the
system: it makes both stages disagree with the CALLER.

server_compute.c does not use the role alone:

    delegate_allows_writes = delegate_role_is_write(role)
                             && delegate_prompt_allows_writes(prompt)

The role's default is only one input. A write role whose PROMPT does not ask for
writes is treated as read-only, and that narrowing lives in delegate_prompt.c,
which the module cannot see. A module that re-derived from the role would hand a
writable worktree -- and a writable git directory -- to a delegate the caller
had already ruled read-only. The mount is the enforcement, so that is not a
cosmetic disagreement; it is the boundary failing open.

So both stages now take the caller's COMPOSED answer:

  - stage 11 (6667) carries writes_allowed instead of a role
  - stage 12 (6668) carries writes_allowed instead of a role
  - SandboxRequest.Role becomes SandboxRequest.WritesAllowed

This is the caller-passes-inventory pattern every other fact in these stages
already uses: whether THIS delegate writes is not something the module can look
up. RoleIsWrite stays exactly where it belongs, in stage 10, as one input the
caller composes -- it is simply no longer re-derived silently downstream.

It is also the one fact that must agree across the two calls, which is why it is
a single composed boolean rather than a set of inputs each side re-combines.

TWO THINGS FOUND WHILE MAKING THE CHANGE:

The stage 11 request read its delegate id from offset 12 while the fixed header
is 16 bytes, so the id was read out of the header's own padding. It was latent
only because the encoder and decoder agreed on the wrong thing; the first real C
encoder would have hit it. The length now reads from the header and the body
starts after it.

The "overrun length" malformed-request case was pointed at the old field
position, so it had stopped testing anything. It now overruns the real field,
and a second case covers a length that is inside the bound but still runs past
the end of the buffer.

Dropping the role also drops the alias test from stage 11 -- resolving an alias
is stage 10's job, and this stage no longer sees a role to resolve. Both stages
landed unconsumed (#2535, #2544), so the wire change costs nothing.
