### PR TITLE
fix: stop the compress lever from silently defeating the fold freeze

### DIFF
--- a/src/modules/economizer/context_fold.c
+++ b/src/modules/economizer/context_fold.c
@@ -394,19 +394,32 @@ int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_
       return 0;
    }
 
-   /* Conserve any amputated identifiers in a Coordinate Closet, prepended as a
-    * synthetic user+assistant note pair (matching context_fold_view): a plain-text
-    * turn is valid input for every provider builder, and the PAIR keeps Anthropic
-    * role-alternation intact ahead of the (unchanged) original first turn. When the
-    * closet is disabled or empty, render returns NULL and we emit no note — the head
-    * excerpts still carry the leading bytes of each body. */
+   /* Conserve any amputated identifiers in a Coordinate Closet, APPENDED as a
+    * synthetic user note at the very end of the transcript. When the closet is
+    * disabled or empty, render returns NULL and we emit no note — the head excerpts
+    * still carry the leading bytes of each body.
+    *
+    * Tail placement is load-bearing, not cosmetic. This note summarizes the WHOLE
+    * compressed region (a body count, plus a closet that accumulates), so its text
+    * necessarily changes every turn as more messages age out of the retained band.
+    * At the head it sat inside the fold's frozen prefix, which made the reduced
+    * prefix differ on every single turn and silently defeated the §3 fold-freeze
+    * whenever compress and history_fold ran together (the shipping `aggressive`
+    * preset enables both) — every turn paying a provider cache WRITE where the
+    * freeze exists to buy a cache READ. The tail already varies each turn, so a
+    * growing note costs nothing there; this is the same placement argument
+    * context_reduce.h makes for the §4 recall hint, and it mirrors that injection's
+    * shape (a lone user-role note, no ack). "above" is now literally true, too.
+    *
+    * Downstream the note lands in the fold's RETAINED region, so conserved
+    * identifiers survive verbatim rather than being skeletonized. It is never
+    * written back to stored history, so successive turns do not accumulate notes. */
    char *closet = coord_closet_render(&set, &cfg->closet, compressed_raw, &out->closet_evict);
    coord_set_free(&set);
    if (closet)
    {
       cJSON *note = cJSON_CreateObject();
-      cJSON *ack = cJSON_CreateObject();
-      if (note && ack)
+      if (note)
       {
          dstr_t body;
          dstr_init(&body);
@@ -417,19 +430,30 @@ int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_
          dstr_append_str(&body, closet);
          cJSON_AddStringToObject(note, "role", "user");
          cJSON_AddStringToObject(note, "content", dstr_cstr(&body));
-         cJSON_AddStringToObject(ack, "role", "assistant");
-         cJSON_AddStringToObject(
-             ack, "content",
-             "Understood — identifiers from the compressed tool results are conserved above.");
          dstr_free(&body);
-         /* insert ack first, then note before it, yielding [note, ack, ...original] */
-         cJSON_InsertItemInArray(arr, 0, ack);
-         cJSON_InsertItemInArray(arr, 0, note);
-      }
-      else
-      {
-         cJSON_Delete(note);
-         cJSON_Delete(ack);
+
+         /* Keep Anthropic role-alternation intact. The head insertion used a
+          * user+assistant PAIR for this reason; at the tail only the ends-with-user
+          * case needs a bridge, and the note must stay LAST so the transcript never
+          * ends on an assistant turn (which would read as a prefill). Deterministic:
+          * the bridge depends only on the input's final role. */
+         int tail_n = cJSON_GetArraySize(arr);
+         cJSON *tail_msg = tail_n > 0 ? cJSON_GetArrayItem(arr, tail_n - 1) : NULL;
+         const char *tail_role =
+             tail_msg ? cJSON_GetStringValue(cJSON_GetObjectItem(tail_msg, "role")) : NULL;
+         if (tail_role && strcmp(tail_role, "user") == 0)
+         {
+            cJSON *ack = cJSON_CreateObject();
+            if (ack)
+            {
+               cJSON_AddStringToObject(ack, "role", "assistant");
+               cJSON_AddStringToObject(ack, "content",
+                                       "Understood — identifiers from the compressed tool "
+                                       "results are conserved below.");
+               cJSON_AddItemToArray(arr, ack);
+            }
+         }
+         cJSON_AddItemToArray(arr, note);
       }
       free(closet);
    }

--- a/src/modules/economizer/context_fold.h
+++ b/src/modules/economizer/context_fold.h
@@ -114,10 +114,16 @@ extern "C"
     * (JSON structural summary for JSON bodies, else head+tail truncation — the same
     * algorithm the eager seam uses). The exact identifiers in the full body are first
     * nominated into a
-    * Coordinate Closet, which (when cfg->closet.enabled) is prepended as a synthetic
-    * user+assistant note pair (matching context_fold_view's closet emission) so
-    * conserved identifiers ride along. EVERYTHING else — role/type, ids, message
-    * ordering, all non-tool-result content — is byte-for-byte preserved.
+    * Coordinate Closet, which (when cfg->closet.enabled) is APPENDED as a synthetic
+    * user note at the very END of the transcript so conserved identifiers ride along.
+    * EVERYTHING else — role/type, ids, message ordering, all non-tool-result content
+    * — is byte-for-byte preserved.
+    *
+    * That note summarizes a region that GROWS as messages age out of the retained
+    * band, so its text changes every turn. It is appended at the tail (which varies
+    * each turn anyway) rather than the head, because at the head it fell inside the
+    * fold's frozen prefix and defeated the §3 freeze outright whenever compress and
+    * history_fold were composed. See the block comment at the emission site.
     *
     * The input `messages` array is NEVER mutated: out->messages is a fresh
     * deep-copied array the caller owns (fold_result_free). On success with at least
@@ -126,7 +132,10 @@ extern "C"
     * threshold (or on OOM / disabled / too-short), out->folded = 0 and
     * out->messages = NULL (the caller uses the original). Returns 0 on success
     * (incl. no-op), -1 on bad args. Deterministic: identical (messages, cfg) ->
-    * byte-identical out->messages serialization (for freeze/cache warmth). Output
+    * byte-identical out->messages serialization. Note that determinism alone does
+    * NOT give cache warmth across turns — successive turns feed DIFFERENT (growing)
+    * input, so what the prompt cache actually needs is a stable emitted PREFIX,
+    * which is why the note above is appended rather than prepended. Output
     * is provider-native (only bodies shortened + a plain-text note pair), so it is
     * valid input for ALL provider builders, including chatgpt/Responses. */
    int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out);

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -554,10 +554,24 @@ static void test_compress_openai_tool_loop(void)
    cJSON *last_in = cJSON_GetArrayItem(msgs, orig_count - 1);
    assert(strlen(cJSON_GetStringValue(cJSON_GetObjectItem(last_in, "content"))) > 200);
 
-   /* output: a synthetic closet note pair was prepended, then every original
-    * message survives in order — no message dropped, every tool_call_id kept. */
+   /* output: every original message survives in order — no message dropped, every
+    * tool_call_id kept — followed by ONE synthetic closet note APPENDED at the tail.
+    * Tail, not head: the note summarizes a growing region, so at the head it sat in
+    * the fold's frozen prefix and broke freeze reuse (see context_fold.c). */
    int out_count = cJSON_GetArraySize(r.messages);
-   assert(out_count == orig_count + 2);
+   assert(out_count == orig_count + 1);
+   {
+      cJSON *tail = cJSON_GetArrayItem(r.messages, out_count - 1);
+      const char *trole = cJSON_GetStringValue(cJSON_GetObjectItem(tail, "role"));
+      const char *tbody = cJSON_GetStringValue(cJSON_GetObjectItem(tail, "content"));
+      assert(trole && strcmp(trole, "user") == 0);
+      assert(tbody && contains(tbody, "Coordinate Closet"));
+      /* and the ORIGINAL first message is still first — nothing prepended */
+      cJSON *head = cJSON_GetArrayItem(r.messages, 0);
+      const char *hrole = cJSON_GetStringValue(cJSON_GetObjectItem(head, "role"));
+      assert(hrole && strcmp(hrole, "user") == 0);
+      assert(cJSON_GetObjectItem(head, "content"));
+   }
    int in_tool = 0, out_tool = 0;
    cJSON *it;
    cJSON_ArrayForEach(it, msgs)
@@ -605,15 +619,55 @@ static void test_compress_openai_tool_loop(void)
     * Coordinate Closet note (it is NOT in the shrunk body's head excerpt). */
    char *flat = cJSON_PrintUnformatted(r.messages);
    assert(contains(flat, "/work/src/module_2.c"));
-   /* and the conserving note rode along */
-   const char *note0 =
-       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
-   assert(contains(note0, "Coordinate Closet"));
+   /* and the conserving note rode along (asserted at the tail, above) */
    free(flat);
 
    fold_result_free(&r);
    cJSON_Delete(msgs);
    PASS("compress_openai_tool_loop");
+}
+
+/* The closet note is appended at the TAIL, so it must not leave two consecutive
+ * user turns (Anthropic role-alternation) and must never leave the transcript
+ * ending on an assistant turn (which reads as a prefill). Both end-states are
+ * exercised: a transcript ending in a tool result, and one ending in a user turn. */
+static void test_compress_note_preserves_alternation(void)
+{
+   for (int ends_with_user = 0; ends_with_user <= 1; ends_with_user++)
+   {
+      cJSON *msgs = cJSON_CreateArray();
+      add_user_text(msgs, "start");
+      char body[4096], id[32], path[64];
+      for (int k = 0; k < 12; k++)
+      {
+         snprintf(id, sizeof(id), "call_%02d", k);
+         add_openai_assistant_tool_call(msgs, id, "read_file", "{}");
+         snprintf(path, sizeof(path), "/work/src/alt_%d.c", k);
+         make_big_body(body, sizeof(body), path);
+         add_openai_tool_result(msgs, id, body);
+      }
+      if (ends_with_user)
+         add_user_text(msgs, "now summarize what you found");
+
+      fold_config_t cfg = {.enabled = 1, .retained_msgs = 8, .closet = {.enabled = 1}};
+      fold_result_t r;
+      assert(context_compress_view(msgs, &cfg, &r) == 0);
+      assert(r.folded == 1 && r.messages != NULL);
+
+      int n = cJSON_GetArraySize(r.messages);
+      const char *last =
+          cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, n - 1), "role"));
+      const char *prev =
+          cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, n - 2), "role"));
+      assert(last && strcmp(last, "user") == 0); /* note is last: never a prefill */
+      assert(prev && strcmp(prev, "user") != 0); /* and no consecutive user turns */
+      if (ends_with_user)
+         assert(strcmp(prev, "assistant") == 0); /* the bridge ack was inserted */
+
+      fold_result_free(&r);
+      cJSON_Delete(msgs);
+   }
+   PASS("compress_note_preserves_alternation");
 }
 
 /* (b) Anthropic tool_result content-block shape compresses in place. */
@@ -734,6 +788,7 @@ int main(void)
    test_openai_shape_fold();
    test_responses_shape_fold();
    test_compress_openai_tool_loop();
+   test_compress_note_preserves_alternation();
    test_compress_anthropic_shape();
    test_compress_deterministic();
    test_compress_below_threshold_noop();

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -742,6 +742,139 @@ static void test_compress_measure_only_no_mutation(void)
  * even at the conservative default horizon of 1. The disable branch fires only under
  * adverse pricing (write premium > horizon x per-reuse saving) that no model aimee
  * currently prices satisfies. */
+/* Append one realistic turn: a user ask, an assistant tool_call, a bulky tool result,
+ * and an assistant reply. Gives BOTH levers something to do — compress needs fat tool
+ * bodies, fold needs clean user-turn boundaries. */
+static void append_turn(cJSON *m, int k)
+{
+   char id[32];
+   snprintf(id, sizeof(id), "call_%03d", k);
+
+   cJSON *u = cJSON_CreateObject();
+   cJSON_AddStringToObject(u, "role", "user");
+   cJSON_AddStringToObject(u, "content", "keep going on the migration and report what changed");
+   cJSON_AddItemToArray(m, u);
+
+   cJSON *a = cJSON_CreateObject();
+   cJSON_AddStringToObject(a, "role", "assistant");
+   cJSON *tcs = cJSON_AddArrayToObject(a, "tool_calls");
+   cJSON *tc = cJSON_CreateObject();
+   cJSON_AddStringToObject(tc, "id", id);
+   cJSON_AddStringToObject(tc, "type", "function");
+   cJSON *fn = cJSON_AddObjectToObject(tc, "function");
+   cJSON_AddStringToObject(fn, "name", "read_file");
+   cJSON_AddStringToObject(fn, "arguments", "{}");
+   cJSON_AddItemToArray(tcs, tc);
+   cJSON_AddItemToArray(m, a);
+
+   cJSON *t = cJSON_CreateObject();
+   cJSON_AddStringToObject(t, "role", "tool");
+   cJSON_AddStringToObject(t, "tool_call_id", id);
+   char body[900];
+   size_t pos = 0;
+   while (pos + 48 < sizeof(body) - 96)
+      pos += (size_t)snprintf(body + pos, sizeof(body) - pos, "filler output bytes here and on; ");
+   snprintf(body + pos, sizeof(body) - pos, "tail at /work/src/stage_%d.c done", k);
+   cJSON_AddStringToObject(t, "content", body);
+   cJSON_AddItemToArray(m, t);
+
+   cJSON *a2 = cJSON_CreateObject();
+   cJSON_AddStringToObject(a2, "role", "assistant");
+   cJSON_AddStringToObject(a2, "content",
+                           "read the stage file and applied the change; moving to the next one "
+                           "now that the previous edit is confirmed good");
+   cJSON_AddItemToArray(m, a2);
+}
+
+/* THE CACHE CLAIM, tested end-to-end through the composed reducer.
+ *
+ * The freeze exists so the reduced PREFIX stays byte-identical turn-to-turn and the
+ * provider prompt cache keeps hitting. test_context_fold.c proves that for the fold
+ * lever in isolation — but production stacks compress AHEAD of fold and the fold
+ * digests the COMPRESSED view, so a compressor whose output for the prefix region
+ * drifts as the retained band slides would silently epoch the freeze and bust the
+ * cache with every lever still reporting success. Nothing asserted that.
+ *
+ * The invariant, stated honestly: while the epoch counter holds, the emitted prefix
+ * must be byte-identical; a changed prefix is legal ONLY on an epoch advance. That is
+ * the property the cache actually depends on. Bytes are compared, not token counts —
+ * a cache hit is a bytewise prefix match, so anything weaker would pass on a prefix
+ * that "looks the same" and still misses.
+ *
+ * recall_inject is deliberately ON: the header claims tail placement is cache-safe.
+ * If the hint ever landed in the prefix instead, this test fails. */
+static void test_prefix_stable_across_turns(void)
+{
+   cJSON *m = cJSON_CreateArray();
+   for (int k = 0; k < 8; k++)
+      append_turn(m, k);
+
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1;
+   cfg.compress = 1;
+   cfg.freeze = 1;
+   cfg.fold.closet.enabled = 1;
+   cfg.fold.compact_head_bytes = 40;
+   cfg.recall_enabled = 1;
+   cfg.recall_inject = 1;
+
+   reduce_state_t st = {0};
+   st.freeze.tail_cap_msgs = 16;
+
+   char *prev_prefix = NULL;
+   int prev_epochs = -1;
+   int reuses = 0; /* turns that held the prefix steady */
+   int epochs = 0; /* legitimate boundary advances */
+
+   /* claude-3-5-sonnet: priced with a cache-read discount, so the freeze guardrail
+    * finds the pin cost-favorable and the freeze is actually live for this run. */
+   for (int turn = 0; turn < 14; turn++)
+   {
+      st.turn = turn;
+      reduce_result_t out;
+      assert(context_reduce(m, "sys", "claude-3-5-sonnet", "s-freeze", REDUCE_SEAM_DELEGATE, &cfg,
+                            &st, &out) == 0);
+      st.reduced = 0; /* next turn is a fresh request, not a second seam on this one */
+
+      if (out.mutated && out.messages)
+      {
+         char *prefix = cJSON_PrintUnformatted(cJSON_GetArrayItem(out.messages, 0));
+         assert(prefix != NULL);
+         if (prev_prefix)
+         {
+            if (out.epochs == prev_epochs)
+            {
+               /* No epoch advance -> the cache MUST still be warm. */
+               assert(strcmp(prev_prefix, prefix) == 0);
+               reuses++;
+            }
+            else
+            {
+               assert(out.epochs > prev_epochs); /* epochs only ever advance */
+               epochs++;
+            }
+         }
+         free(prev_prefix);
+         prev_prefix = prefix;
+         prev_epochs = out.epochs;
+      }
+      context_reduce_result_free(&out);
+      append_turn(m, 100 + turn);
+   }
+
+   /* Guard the guard: a run where the fold never engaged, or never held a boundary
+    * across a turn, would satisfy every assertion above vacuously. */
+   assert(reuses > 0);
+
+   free(prev_prefix);
+   fold_recall_index_free(&st.recall);
+   cJSON_Delete(m);
+   printf("  prefix stable across turns: %d cache-warm reuses, %d epoch advance(s)\n", reuses,
+          epochs);
+   PASS("composed reduce keeps the emitted prefix byte-identical while frozen");
+}
+
 static void test_freeze_guard(void)
 {
    /* zero prefix -> no churn possible -> always favorable */
@@ -827,6 +960,7 @@ int main(void)
    test_history_fold_skip_no_gain();
    test_compress_engages_where_fold_cannot();
    test_compress_measure_only_no_mutation();
+   test_prefix_stable_across_turns();
    printf("All context_reduce tests passed.\n");
    return 0;
 }


### PR DESCRIPTION
## The bug

The §3 fold-freeze exists to keep the reduced **prefix** byte-identical turn to turn so the provider prompt cache keeps hitting. `test_context_fold.c` proved that for the fold lever *alone*. Nothing tested the **composed** path — which is what actually ships: the `aggressive` economizer preset enables `history_fold` **and** `compress` together, compress runs first, and the fold digests the *compressed* view.

`context_compress_view` prepended a synthetic note at **index 0** whose text embeds a count of compressed bodies plus a Coordinate Closet that accumulates. Both grow as messages age out of the retained band, so the first message of the prefix was *by construction* a summary of a growing region. The prefix digest therefore changed on **every turn**, the freeze re-epoched every turn, and the boundary was never once reused — every turn paying a provider cache **write** exactly where the freeze exists to buy a cache **read**.

Every lever still reported success, so nothing surfaced it.

## Measurement

14-turn composed run (fold + compress + freeze + recall_inject):

| | cache-warm reuses | epoch advances |
|---|---|---|
| before | **0** | 14 (one per turn) |
| after | **7** | 6 |

Isolation runs pinned the cause exactly:

- compress **off** → 9 reuses / 4 epochs
- compress **on**, closet disabled (which suppresses the note) → 9 reuses / 4 epochs — identical

The note was the whole of it.

## The fix

Append the note at the **tail** instead of the head. The tail already varies every turn, so a growing note costs nothing there — the same placement argument `context_reduce.h` already makes for the §4 recall hint, whose injection shape this now mirrors. Downstream the note lands in the fold's **retained** region, so conserved identifiers survive verbatim rather than being skeletonized, and `"body(ies) above"` becomes literally true (at the head it claimed "above" with nothing above it).

The head insertion used a user+assistant **pair** to keep Anthropic role alternation intact. At the tail only the ends-with-user case needs a bridge ack, and the note stays last so the transcript never ends on an assistant turn (which would read as a prefill). Both end-states are pinned by a test.

### Tradeoff, measured

Because the note is now retained verbatim rather than folded into the skeleton, it costs tokens every turn. Measured over the same 14-turn run: the note grows ~35 B/turn and reaches 845 B, about **7.5%** of the reduced transcript by turn 13, and it is always the last message. That is the price of the warm prefix, and it buys cache reads on the entire folded prefix instead of a full write every turn. Conservation also gets strictly stronger — identifiers survive verbatim instead of being excerpt-truncated by the skeleton.

## Tests

- **`test_prefix_stable_across_turns`** — drives 14 turns through `context_reduce` with the full lever stack and asserts the emitted prefix is **byte-identical** whenever the epoch counter holds, allowing change only on a genuine epoch advance. Compares *bytes*, not token counts: a cache hit is a bytewise prefix match, so anything weaker would pass on a prefix that merely looks the same. It guards against vacuity by requiring at least one real reuse — **that guard is what caught this bug.**
- **`test_compress_note_preserves_alternation`** — no consecutive user turns, and never an assistant-final transcript, for both end-states.

## Verification

- Retention quality unchanged: fold **20/20** recall at 47% cost; legacy 11/20, record 15/20.
- Economizer suite green (`context_fold`, `context_reduce`, `coord_closet`, `fold_recall`, `fold_register`, `fold_budget`, `economizer_{proof,anthropic,openai,activation,wire_snapshot}`, `config_economizer`).
- All **48** lint checks pass; `aimee-server` and `aimee-kb` both link; `cmd-srcs-compile-check` ok.

## Note on the cache A/B

This supersedes the live cache A/B I had been attempting. That measurement is not obtainable from delegate traffic: the delegate provider reports `cache_read: 0` / `cache_write: 0` across 158 calls and 3.1M prompt tokens on CT 403 (and the same on .210), so the telemetry needed simply is not emitted. Prefix byte-stability is the property the cache actually keys on, it is decidable deterministically, and — unlike the A/B — it found a real bug.
