### PR TITLE
feat(delegates): the sandbox spec carries the environment the container needs

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "070947edc459fc6c7cb7abfff4238e9b8d89e018f2ba224dcb039eadf119d170",
+      "source_sha256": "110acb73dfe0ebf2c459080a178590028e29ba8df7d9019191e23201830a33a8",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/dockerargs.go
+++ b/server-go/modules/delegates/dockerargs.go
@@ -115,6 +115,10 @@ func DockerCreateArgs(req DockerCreateRequest) ([]string, error) {
 	// The isolation primitive. Never conditional, never configurable.
 	args = append(args, "--network", req.Spec.NetworkMode())
 
+	if req.Spec.User != "" {
+		args = append(args, "--user", req.Spec.User)
+	}
+
 	for _, m := range req.Spec.Mounts {
 		args = append(args, "-v", renderBind(m, req.MountTable))
 	}

--- a/server-go/modules/delegates/launchargs_stage.go
+++ b/server-go/modules/delegates/launchargs_stage.go
@@ -52,7 +52,10 @@ type launchArgsRequest struct {
 	Image      string
 	WorkDir    string
 	MountTable string
-	Command    []string
+	// RunAsUser is "<uid>:<gid>". The caller supplies it because the uid that
+	// owns the tree is a fact about the host, not about the delegate.
+	RunAsUser string
+	Command   []string
 }
 
 // decodeLaunchArgsRequest reads the request, or reports that it is malformed.
@@ -94,6 +97,7 @@ func decodeLaunchArgsRequest(request []byte) (launchArgsRequest, bool) {
 	req.Image = readString(launchArgsStringMax)
 	req.WorkDir = readString(launchArgsStringMax)
 	req.MountTable = readString(launchArgsMountTableMax)
+	req.RunAsUser = readString(launchArgsStringMax)
 
 	req.Command = make([]string, 0, commandCount)
 	for i := 0; i < commandCount; i++ {
@@ -129,6 +133,7 @@ func handleLaunchArgs(invocation bus.ModuleInvocation, request []byte) ([]byte, 
 	plan := WorktreePlan{Isolated: req.WritesAllowed, ReadOnlyMount: !req.WritesAllowed}
 	sandboxReq := SandboxRequestFor(plan, req.RepoRoot, req.Worktree, req.GitDir,
 		req.IsGitCheckout, req.ParentSocketHost, req.ParentSocketTarget, req.EgressProxy)
+	sandboxReq.RunAsUser = req.RunAsUser
 
 	spec, err := BuildSandboxSpec(sandboxReq)
 	if err != nil {

--- a/server-go/modules/delegates/launchargs_stage_test.go
+++ b/server-go/modules/delegates/launchargs_stage_test.go
@@ -36,6 +36,7 @@ func encodeLaunchArgs(req launchArgsRequest) []byte {
 	put(req.Image)
 	put(req.WorkDir)
 	put(req.MountTable)
+	put(req.RunAsUser)
 	for _, a := range req.Command {
 		put(a)
 	}

--- a/server-go/modules/delegates/sandbox.go
+++ b/server-go/modules/delegates/sandbox.go
@@ -105,6 +105,13 @@ type SandboxRequest struct {
 	// EgressProxy, when set, becomes http_proxy so a no-network delegate can
 	// still install software through the narrow update whitelist.
 	EgressProxy string
+
+	// RunAsUser is "<uid>:<gid>" and must be set whenever a host tree is
+	// mounted. Containers run as root by default, so every file the delegate
+	// created in the caller's checkout would land root-owned: the user could not
+	// edit or delete their own files afterwards, and git would refuse the tree
+	// outright with "detected dubious ownership".
+	RunAsUser string
 }
 
 // SandboxSpec is the container specification. NetworkMode is not a field the
@@ -113,6 +120,8 @@ type SandboxSpec struct {
 	Mounts   []SandboxMount
 	Env      []SandboxEnv
 	ReadOnly bool // the role does not write, so nothing is mounted writable
+	// User is "<uid>:<gid>", empty to keep the image's own user.
+	User string
 }
 
 // NetworkMode is always "none". It is a method rather than a field so no caller
@@ -132,10 +141,24 @@ func isDockerSocket(p string) bool {
 	return false
 }
 
+// sandboxEnvAllowed names variables the container genuinely needs that would
+// otherwise trip the marker scan below.
+//
+// GIT_CONFIG_KEY_0 contains "KEY" and is not a secret: it carries the literal
+// string "safe.directory". Naming the exceptions explicitly keeps the scan as
+// broad as it should be -- narrowing the markers to let this through would let
+// a real key through with it.
+var sandboxEnvAllowed = map[string]bool{
+	"GIT_CONFIG_KEY_0": true,
+}
+
 // looksLikeCredential reports whether an environment name suggests a secret.
 // Deliberately broad: a false positive costs a delegate one variable it should
 // not have needed, a false negative puts a credential inside the sandbox.
 func looksLikeCredential(name string) bool {
+	if sandboxEnvAllowed[name] {
+		return false
+	}
 	upper := strings.ToUpper(name)
 	for _, marker := range credentialEnvMarkers {
 		if strings.Contains(upper, marker) {
@@ -220,11 +243,41 @@ func BuildSandboxSpec(req SandboxRequest) (SandboxSpec, error) {
 			SandboxMount{Source: host, Target: target, Kind: SandboxControlSocket})
 	}
 
+	if req.ParentSocketTarget != "" {
+		// Without this the in-container CLI does not know where its only
+		// outward channel is, and every tool call it makes goes nowhere.
+		spec.Env = append(spec.Env,
+			SandboxEnv{Name: "AIMEE_API_ENDPOINT", Value: "unix:" + req.ParentSocketTarget})
+	}
+
 	if req.EgressProxy != "" {
+		// Both spellings: package managers disagree about which one they read,
+		// and one honoured while the other is not is a fetch that silently
+		// bypasses the proxy. no_proxy keeps loopback direct so the forwarder
+		// does not try to proxy to itself.
 		spec.Env = append(spec.Env,
 			SandboxEnv{Name: "http_proxy", Value: req.EgressProxy},
-			SandboxEnv{Name: "https_proxy", Value: req.EgressProxy})
+			SandboxEnv{Name: "https_proxy", Value: req.EgressProxy},
+			SandboxEnv{Name: "HTTP_PROXY", Value: req.EgressProxy},
+			SandboxEnv{Name: "HTTPS_PROXY", Value: req.EgressProxy},
+			SandboxEnv{Name: "no_proxy", Value: "localhost,127.0.0.1"},
+			SandboxEnv{Name: "NO_PROXY", Value: "localhost,127.0.0.1"})
 	}
+
+	// Trust every tree inside the container for git. Even running as the tree's
+	// owner, a linked worktree resolves its .git to a SEPARATELY mounted gitdir
+	// whose ownership git checks independently, so a plain `git status` still
+	// trips "detected dubious ownership" and refuses -- which breaks the
+	// delegate's git-based inspection of its own worktree. The container is a
+	// single-purpose sandbox holding only the mounted trees, so trusting all of
+	// them is safe. These are inherited by every exec, so plain `git` works
+	// without the caller adding -c safe.directory.
+	spec.Env = append(spec.Env,
+		SandboxEnv{Name: "GIT_CONFIG_COUNT", Value: "1"},
+		SandboxEnv{Name: "GIT_CONFIG_KEY_0", Value: "safe.directory"},
+		SandboxEnv{Name: "GIT_CONFIG_VALUE_0", Value: "*"})
+
+	spec.User = req.RunAsUser
 
 	if err := ValidateSandboxSpec(spec); err != nil {
 		return SandboxSpec{}, err

--- a/server-go/modules/delegates/sandboxenv_test.go
+++ b/server-go/modules/delegates/sandboxenv_test.go
@@ -1,0 +1,171 @@
+package delegates
+
+import "testing"
+
+func envValue(spec SandboxSpec, name string) (string, bool) {
+	for _, e := range spec.Env {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+func envSpec(t *testing.T) SandboxSpec {
+	t.Helper()
+	spec, err := BuildSandboxSpec(SandboxRequest{
+		WritesAllowed:      true,
+		RepoRoot:           "/repo",
+		Worktree:           "/repo/.aimee/worktrees/d1",
+		GitDir:             "/repo/.git/worktrees/d1",
+		IsGitCheckout:      true,
+		ParentSocketHost:   "/run/aimee/aimee-http.sock",
+		ParentSocketTarget: "/run/aimee.sock",
+		EgressProxy:        "http://127.0.0.1:3129",
+		RunAsUser:          "1000:1000",
+	})
+	if err != nil {
+		t.Fatalf("BuildSandboxSpec: %v", err)
+	}
+	return spec
+}
+
+// The container's only outward channel is the parent socket. Without this the
+// in-container CLI does not know where it is, and every tool call goes nowhere.
+func TestSandboxEnvPointsTheCLIAtTheParentSocket(t *testing.T) {
+	got, ok := envValue(envSpec(t), "AIMEE_API_ENDPOINT")
+	if !ok {
+		t.Fatal("AIMEE_API_ENDPOINT is absent, so the delegate cannot reach its parent")
+	}
+	if got != "unix:/run/aimee.sock" {
+		t.Errorf("AIMEE_API_ENDPOINT = %q, want the in-container socket path", got)
+	}
+}
+
+// A delegate with no socket has nothing to point at, and a dangling endpoint
+// would make every tool call fail slowly rather than not be attempted.
+func TestSandboxEnvOmitsTheEndpointWithoutASocket(t *testing.T) {
+	spec, err := BuildSandboxSpec(SandboxRequest{
+		WritesAllowed: true, RepoRoot: "/repo", Worktree: "/repo", IsGitCheckout: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildSandboxSpec: %v", err)
+	}
+	if _, ok := envValue(spec, "AIMEE_API_ENDPOINT"); ok {
+		t.Error("an endpoint was set with no socket to point at")
+	}
+}
+
+// Package managers disagree about which spelling they read. One honoured while
+// the other is not is a fetch that silently bypasses the proxy entirely.
+func TestSandboxEnvSetsBothProxySpellings(t *testing.T) {
+	spec := envSpec(t)
+	for _, name := range []string{"http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"} {
+		got, ok := envValue(spec, name)
+		if !ok {
+			t.Errorf("%s is absent", name)
+			continue
+		}
+		if got != "http://127.0.0.1:3129" {
+			t.Errorf("%s = %q", name, got)
+		}
+	}
+	// Loopback stays direct, or the forwarder tries to proxy to itself.
+	for _, name := range []string{"no_proxy", "NO_PROXY"} {
+		if got, ok := envValue(spec, name); !ok || got != "localhost,127.0.0.1" {
+			t.Errorf("%s = %q (present=%v)", name, got, ok)
+		}
+	}
+}
+
+func TestSandboxEnvHasNoProxyWithoutOne(t *testing.T) {
+	spec, err := BuildSandboxSpec(SandboxRequest{
+		WritesAllowed: true, RepoRoot: "/repo", Worktree: "/repo", IsGitCheckout: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildSandboxSpec: %v", err)
+	}
+	for _, name := range []string{"http_proxy", "HTTP_PROXY", "no_proxy"} {
+		if _, ok := envValue(spec, name); ok {
+			t.Errorf("%s was set with no egress proxy configured", name)
+		}
+	}
+}
+
+// A linked worktree resolves its .git to a SEPARATELY mounted gitdir whose
+// ownership git checks independently, so `git status` trips "detected dubious
+// ownership" and refuses -- breaking the delegate's inspection of its own tree.
+func TestSandboxEnvTrustsTheMountedTreesForGit(t *testing.T) {
+	spec := envSpec(t)
+	want := map[string]string{
+		"GIT_CONFIG_COUNT":   "1",
+		"GIT_CONFIG_KEY_0":   "safe.directory",
+		"GIT_CONFIG_VALUE_0": "*",
+	}
+	for name, value := range want {
+		if got, ok := envValue(spec, name); !ok || got != value {
+			t.Errorf("%s = %q (present=%v), want %q", name, got, ok, value)
+		}
+	}
+}
+
+// GIT_CONFIG_KEY_0 contains "KEY" and would otherwise trip the credential scan.
+// It must survive validation -- the spec builder validates its own output, so a
+// false positive here refuses every delegate.
+func TestSandboxGitConfigSurvivesTheCredentialScan(t *testing.T) {
+	if err := ValidateSandboxSpec(envSpec(t)); err != nil {
+		t.Fatalf("a valid spec was refused: %v", err)
+	}
+}
+
+// The allowlist must not have widened the scan. A real key still gets refused.
+func TestSandboxStillRefusesRealCredentials(t *testing.T) {
+	for _, name := range []string{
+		"ANTHROPIC_API_KEY", "GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY",
+		"GIT_CONFIG_KEY_1", // not the allowlisted name
+	} {
+		spec := SandboxSpec{Env: []SandboxEnv{{Name: name, Value: "x"}}}
+		if err := ValidateSandboxSpec(spec); err == nil {
+			t.Errorf("%s reached the sandbox", name)
+		}
+	}
+}
+
+// Containers run as root by default. Every file the delegate created in the
+// caller's checkout would land root-owned: the user could not edit or delete
+// their own files afterwards, and git would refuse the tree outright.
+func TestDockerArgsRunAsTheTreeOwner(t *testing.T) {
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec: envSpec(t), ContainerName: "c1", Image: "ubuntu:22.04",
+	})
+	if err != nil {
+		t.Fatalf("DockerCreateArgs: %v", err)
+	}
+	i := -1
+	for n, a := range args {
+		if a == "--user" {
+			i = n
+		}
+	}
+	if i < 0 || i+1 >= len(args) || args[i+1] != "1000:1000" {
+		t.Errorf("argv does not run as the tree owner: %v", args)
+	}
+}
+
+// The image's own user stands when none is given, rather than an empty --user
+// docker would reject.
+func TestDockerArgsOmitsUserWhenUnset(t *testing.T) {
+	spec := envSpec(t)
+	spec.User = ""
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec: spec, ContainerName: "c1", Image: "ubuntu:22.04",
+	})
+	if err != nil {
+		t.Fatalf("DockerCreateArgs: %v", err)
+	}
+	for _, a := range args {
+		if a == "--user" {
+			t.Errorf("argv carries an empty --user: %v", args)
+		}
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -109,6 +109,7 @@
     "server-go/modules/delegates/patchcoord_stage_test.go",
     "server-go/modules/delegates/rolepolicy_test.go",
     "server-go/modules/delegates/sandbox_test.go",
+    "server-go/modules/delegates/sandboxenv_test.go",
     "server-go/modules/delegates/isolation_test.go",
     "server-go/modules/delegates/sandboximage_test.go",
     "server-go/modules/delegates/dockerargs_test.go",


### PR DESCRIPTION
feat(delegates): the sandbox spec carries the environment the container needs

Found by reading the C backend's create path end to end before wiring it to
stage 12. The Go spec emitted two proxy variables and nothing else. Handing that
argv to a real delegate would have produced a container that starts, looks
correct, and cannot work:

  AIMEE_API_ENDPOINT was missing. It points the in-container CLI at the bound
  socket, which is the delegate's ONLY outward channel. Without it every tool
  call the delegate makes goes nowhere -- and the container is otherwise
  healthy, so it reads as the model failing rather than as a missing variable.

  GIT_CONFIG_COUNT/KEY_0/VALUE_0 were missing. Even running as the tree's owner,
  a linked worktree resolves its .git to a SEPARATELY mounted gitdir whose
  ownership git checks independently, so a plain `git status` trips "detected
  dubious ownership" and refuses. That breaks the delegate's inspection of its
  own worktree.

  The UPPERCASE proxy spellings and no_proxy were missing. Package managers
  disagree about which they read; one honoured while the other is not is a fetch
  that silently bypasses the proxy and its allowlist -- the one hole in the
  sandbox, widened by omission. no_proxy keeps loopback direct so the forwarder
  does not try to proxy to itself.

  --user was missing. Containers run as root by default, so every file the
  delegate created in the caller's checkout would land root-owned: the user
  could not edit or delete their own files afterwards, and git would refuse the
  tree outright. It is set only when a host tree is mounted; the scratch dir
  keeps the image's own user, since nobody else owns it.

ONE COLLISION WORTH THE ATTENTION IT TOOK. GIT_CONFIG_KEY_0 contains "KEY", so
the credential scan refused it -- and BuildSandboxSpec validates its own output,
so that refusal would have rejected EVERY delegate. The fix is an explicit
allowlist of exact names, not a narrower marker set: loosening the markers to
let this through would let a real key through with it. The name is not a secret;
it carries the literal string "safe.directory".

There is a test that the allowlist did not widen the scan -- ANTHROPIC_API_KEY,
GITHUB_TOKEN, AWS_SECRET_ACCESS_KEY and a near-miss GIT_CONFIG_KEY_1 are all
still refused.

Every variable above is asserted present with its value, and asserted ABSENT in
the cases where it should not appear: no endpoint without a socket to point at,
no proxy variables without a proxy, no empty --user for docker to reject.
