### PR TITLE
feat(delegates): the container for a delegate with no repository

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "110acb73dfe0ebf2c459080a178590028e29ba8df7d9019191e23201830a33a8",
+      "source_sha256": "f6e8093386d9712ca6f4170fea79af54166caa09062be676b10659473a065fff",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/launchargs_stage.go
+++ b/server-go/modules/delegates/launchargs_stage.go
@@ -55,7 +55,10 @@ type launchArgsRequest struct {
 	// RunAsUser is "<uid>:<gid>". The caller supplies it because the uid that
 	// owns the tree is a fact about the host, not about the delegate.
 	RunAsUser string
-	Command   []string
+	// ScratchDir/ScratchTarget describe a delegate with no repository at all.
+	ScratchDir    string
+	ScratchTarget string
+	Command       []string
 }
 
 // decodeLaunchArgsRequest reads the request, or reports that it is malformed.
@@ -98,6 +101,8 @@ func decodeLaunchArgsRequest(request []byte) (launchArgsRequest, bool) {
 	req.WorkDir = readString(launchArgsStringMax)
 	req.MountTable = readString(launchArgsMountTableMax)
 	req.RunAsUser = readString(launchArgsStringMax)
+	req.ScratchDir = readString(launchArgsStringMax)
+	req.ScratchTarget = readString(launchArgsStringMax)
 
 	req.Command = make([]string, 0, commandCount)
 	for i := 0; i < commandCount; i++ {
@@ -134,6 +139,8 @@ func handleLaunchArgs(invocation bus.ModuleInvocation, request []byte) ([]byte, 
 	sandboxReq := SandboxRequestFor(plan, req.RepoRoot, req.Worktree, req.GitDir,
 		req.IsGitCheckout, req.ParentSocketHost, req.ParentSocketTarget, req.EgressProxy)
 	sandboxReq.RunAsUser = req.RunAsUser
+	sandboxReq.ScratchDir = req.ScratchDir
+	sandboxReq.ScratchTarget = req.ScratchTarget
 
 	spec, err := BuildSandboxSpec(sandboxReq)
 	if err != nil {

--- a/server-go/modules/delegates/launchargs_stage_test.go
+++ b/server-go/modules/delegates/launchargs_stage_test.go
@@ -37,6 +37,8 @@ func encodeLaunchArgs(req launchArgsRequest) []byte {
 	put(req.WorkDir)
 	put(req.MountTable)
 	put(req.RunAsUser)
+	put(req.ScratchDir)
+	put(req.ScratchTarget)
 	for _, a := range req.Command {
 		put(a)
 	}

--- a/server-go/modules/delegates/sandbox.go
+++ b/server-go/modules/delegates/sandbox.go
@@ -54,6 +54,10 @@ const (
 	SandboxWorkspace SandboxMountKind = iota
 	// SandboxControlSocket is the single outward channel to the parent.
 	SandboxControlSocket
+	// SandboxScratch is a working directory aimee created for a delegate that
+	// has no repository. It is not caller-supplied, which is the whole reason it
+	// is a separate kind -- see ScratchDir.
+	SandboxScratch
 )
 
 // SandboxMount is one bind mount in the container specification.
@@ -105,6 +109,18 @@ type SandboxRequest struct {
 	// EgressProxy, when set, becomes http_proxy so a no-network delegate can
 	// still install software through the narrow update whitelist.
 	EgressProxy string
+
+	// ScratchDir is a directory AIMEE created for a delegate that has no
+	// repository at all, mounted at ScratchTarget.
+	//
+	// It is exempt from the git-checkout rule, and that exemption is safe only
+	// because of what the rule is for: refusing to bind an ARBITRARY HOST
+	// directory into a delegate. A path aimee just made under its own cache is
+	// categorically not that. To keep the exemption from becoming a way to
+	// smuggle one in, a scratch request may not also name a repository -- the
+	// two are mutually exclusive and the builder refuses a request with both.
+	ScratchDir    string
+	ScratchTarget string
 
 	// RunAsUser is "<uid>:<gid>" and must be set whenever a host tree is
 	// mounted. Containers run as root by default, so every file the delegate
@@ -175,6 +191,47 @@ func cleanAbs(p string) (string, bool) {
 	return path.Clean(p), true
 }
 
+// buildScratchSpec is the container for a delegate with no repository.
+//
+// One writable mount and nothing else: there is no repo to layer beneath it and
+// no git metadata to expose. Everything the sandbox guarantees still holds --
+// the network, the runtime socket and the credential rules are applied by the
+// shared tail below, not skipped here.
+func buildScratchSpec(req SandboxRequest) (SandboxSpec, error) {
+	var spec SandboxSpec
+
+	// The exemption is for aimee's OWN directory. A request that also names a
+	// repository is not that, and is refused rather than resolved in favour of
+	// one of them.
+	if req.Worktree != "" || req.RepoRoot != "" || req.GitDir != "" {
+		return spec, fmt.Errorf(
+			"a scratch container cannot also mount a repository (worktree=%q repo=%q gitdir=%q)",
+			req.Worktree, req.RepoRoot, req.GitDir)
+	}
+
+	source, ok := cleanAbs(req.ScratchDir)
+	if !ok {
+		return spec, fmt.Errorf("scratch dir must be an absolute path, got %q", req.ScratchDir)
+	}
+	target, ok := cleanAbs(req.ScratchTarget)
+	if !ok {
+		return spec, fmt.Errorf("scratch target must be an absolute path, got %q", req.ScratchTarget)
+	}
+
+	// Writable regardless of the role: the delegate has nowhere else to work,
+	// and nothing else can see this directory.
+	spec.Mounts = append(spec.Mounts,
+		SandboxMount{Source: source, Target: target, Kind: SandboxScratch})
+
+	if err := attachSandboxChannel(&spec, req); err != nil {
+		return SandboxSpec{}, err
+	}
+	if err := ValidateSandboxSpec(spec); err != nil {
+		return SandboxSpec{}, err
+	}
+	return spec, nil
+}
+
 // BuildSandboxSpec decides the container's shape for one delegate run.
 //
 // A write role gets three mounts: the repo read-only so the whole tree is
@@ -184,6 +241,10 @@ func cleanAbs(p string) (string, bool) {
 // supervisor's live branch and the mode is the enforcement, not the request.
 func BuildSandboxSpec(req SandboxRequest) (SandboxSpec, error) {
 	var spec SandboxSpec
+
+	if req.ScratchDir != "" {
+		return buildScratchSpec(req)
+	}
 
 	worktree, ok := cleanAbs(req.Worktree)
 	if !ok {
@@ -228,15 +289,33 @@ func BuildSandboxSpec(req SandboxRequest) (SandboxSpec, error) {
 			SandboxMount{Source: worktree, Target: worktree, ReadOnly: true})
 	}
 
+	if err := attachSandboxChannel(&spec, req); err != nil {
+		return SandboxSpec{}, err
+	}
+	if err := ValidateSandboxSpec(spec); err != nil {
+		return SandboxSpec{}, err
+	}
+	return spec, nil
+}
+
+// attachSandboxChannel adds everything that is true of EVERY delegate container
+// regardless of what it mounts: the one outward channel, the environment that
+// makes it usable, and the user it runs as.
+//
+// Shared by the repository and scratch shapes on purpose. These are the parts
+// whose absence is silent -- a container with no AIMEE_API_ENDPOINT starts and
+// looks healthy -- so a second copy that fell one variable behind would be
+// found by a delegate failing mysteriously, not by a test.
+func attachSandboxChannel(spec *SandboxSpec, req SandboxRequest) error {
 	if req.ParentSocketHost != "" {
 		host, ok := cleanAbs(req.ParentSocketHost)
 		if !ok {
-			return spec, fmt.Errorf("parent socket must be an absolute path, got %q",
+			return fmt.Errorf("parent socket must be an absolute path, got %q",
 				req.ParentSocketHost)
 		}
 		target, ok := cleanAbs(req.ParentSocketTarget)
 		if !ok {
-			return spec, fmt.Errorf("parent socket target must be an absolute path, got %q",
+			return fmt.Errorf("parent socket target must be an absolute path, got %q",
 				req.ParentSocketTarget)
 		}
 		spec.Mounts = append(spec.Mounts,
@@ -278,11 +357,7 @@ func BuildSandboxSpec(req SandboxRequest) (SandboxSpec, error) {
 		SandboxEnv{Name: "GIT_CONFIG_VALUE_0", Value: "*"})
 
 	spec.User = req.RunAsUser
-
-	if err := ValidateSandboxSpec(spec); err != nil {
-		return SandboxSpec{}, err
-	}
-	return spec, nil
+	return nil
 }
 
 // ValidateSandboxSpec re-checks a specification against every invariant.

--- a/server-go/modules/delegates/sandboxscratch_test.go
+++ b/server-go/modules/delegates/sandboxscratch_test.go
@@ -1,0 +1,146 @@
+package delegates
+
+import (
+	"strings"
+	"testing"
+)
+
+func scratchRequest() SandboxRequest {
+	return SandboxRequest{
+		ScratchDir:         "/var/cache/aimee/delegates/d1",
+		ScratchTarget:      "/workspace",
+		ParentSocketHost:   "/run/aimee/aimee-http.sock",
+		ParentSocketTarget: "/run/aimee.sock",
+	}
+}
+
+// A delegate with no repository still gets a container: one writable directory
+// aimee made for it, and nothing else.
+func TestScratchContainerHasOneWritableMount(t *testing.T) {
+	spec, err := BuildSandboxSpec(scratchRequest())
+	if err != nil {
+		t.Fatalf("BuildSandboxSpec: %v", err)
+	}
+
+	var scratch []SandboxMount
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxScratch {
+			scratch = append(scratch, m)
+		}
+		if m.Kind == SandboxWorkspace {
+			t.Errorf("a scratch container was given a workspace mount: %+v", m)
+		}
+	}
+	if len(scratch) != 1 {
+		t.Fatalf("got %d scratch mounts, want 1", len(scratch))
+	}
+	if scratch[0].ReadOnly {
+		t.Error("the scratch dir is read-only, so the delegate has nowhere to work")
+	}
+	if scratch[0].Target != "/workspace" {
+		t.Errorf("scratch target = %q", scratch[0].Target)
+	}
+}
+
+// The git-checkout rule exists to refuse an ARBITRARY HOST directory. A path
+// aimee made under its own cache is not that, so it is exempt -- but only when
+// it is genuinely the whole request.
+func TestScratchContainerIsExemptFromTheGitCheckoutRule(t *testing.T) {
+	req := scratchRequest()
+	req.IsGitCheckout = false // never set for a scratch dir
+	if _, err := BuildSandboxSpec(req); err != nil {
+		t.Fatalf("a scratch container was refused for not being a git checkout: %v", err)
+	}
+}
+
+// The exemption must not become a way to smuggle a host tree past the rule, so
+// a request that is both is refused rather than resolved in favour of one.
+func TestScratchAndRepositoryTogetherAreRefused(t *testing.T) {
+	cases := map[string]func(*SandboxRequest){
+		"worktree": func(r *SandboxRequest) { r.Worktree = "/repo" },
+		"repo":     func(r *SandboxRequest) { r.RepoRoot = "/repo" },
+		"gitdir":   func(r *SandboxRequest) { r.GitDir = "/repo/.git" },
+	}
+	for name, mutate := range cases {
+		req := scratchRequest()
+		mutate(&req)
+		if _, err := BuildSandboxSpec(req); err == nil {
+			t.Errorf("a scratch request naming a %s was accepted", name)
+		}
+	}
+}
+
+func TestScratchPathsMustBeAbsolute(t *testing.T) {
+	for name, mutate := range map[string]func(*SandboxRequest){
+		"relative source": func(r *SandboxRequest) { r.ScratchDir = "cache/d1" },
+		"relative target": func(r *SandboxRequest) { r.ScratchTarget = "workspace" },
+		"empty target":    func(r *SandboxRequest) { r.ScratchTarget = "" },
+	} {
+		req := scratchRequest()
+		mutate(&req)
+		if _, err := BuildSandboxSpec(req); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+}
+
+// Every guarantee still applies. The scratch shape shares the channel and the
+// environment with the repository shape rather than reimplementing them.
+func TestScratchContainerKeepsEveryGuarantee(t *testing.T) {
+	spec, err := BuildSandboxSpec(scratchRequest())
+	if err != nil {
+		t.Fatalf("BuildSandboxSpec: %v", err)
+	}
+	if spec.NetworkMode() != "none" {
+		t.Errorf("network mode = %q", spec.NetworkMode())
+	}
+	if _, ok := envValue(spec, "AIMEE_API_ENDPOINT"); !ok {
+		t.Error("a scratch delegate cannot reach its parent")
+	}
+	if _, ok := envValue(spec, "GIT_CONFIG_COUNT"); !ok {
+		t.Error("the git trust config is missing")
+	}
+	var socket bool
+	for _, m := range spec.Mounts {
+		if m.Kind == SandboxControlSocket {
+			socket = true
+		}
+	}
+	if !socket {
+		t.Error("the control socket is not mounted")
+	}
+	if err := ValidateSandboxSpec(spec); err != nil {
+		t.Errorf("the scratch spec does not validate: %v", err)
+	}
+}
+
+// The runtime socket is refused here too: the shared validation is not skipped
+// on this path.
+func TestScratchContainerRefusesTheRuntimeSocket(t *testing.T) {
+	req := scratchRequest()
+	req.ScratchDir = "/var/run/docker.sock"
+	if _, err := BuildSandboxSpec(req); err == nil {
+		t.Error("a scratch container was allowed to bind the runtime socket")
+	}
+}
+
+// The scratch dir reaches the argv as a real bind, writable.
+func TestScratchContainerRendersItsMount(t *testing.T) {
+	spec, err := BuildSandboxSpec(scratchRequest())
+	if err != nil {
+		t.Fatalf("BuildSandboxSpec: %v", err)
+	}
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec: spec, ContainerName: "c1", Image: "ubuntu:22.04",
+	})
+	if err != nil {
+		t.Fatalf("DockerCreateArgs: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "/var/cache/aimee/delegates/d1:/workspace") {
+		t.Errorf("the scratch mount is not in the argv: %v", args)
+	}
+	if strings.Contains(joined, "/workspace:ro") {
+		t.Errorf("the scratch mount was rendered read-only: %v", args)
+	}
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -110,6 +110,7 @@
     "server-go/modules/delegates/rolepolicy_test.go",
     "server-go/modules/delegates/sandbox_test.go",
     "server-go/modules/delegates/sandboxenv_test.go",
+    "server-go/modules/delegates/sandboxscratch_test.go",
     "server-go/modules/delegates/isolation_test.go",
     "server-go/modules/delegates/sandboximage_test.go",
     "server-go/modules/delegates/dockerargs_test.go",


### PR DESCRIPTION
feat(delegates): the container for a delegate with no repository

The last shape the module could not express, and the one blocking the C backend
from asking it for an argv at all.

A delegate that is handed no workspace runs in a directory aimee creates for it.
BuildSandboxSpec could not describe that: it requires an absolute worktree that
IS a git checkout, so every scratch delegate was refused. The backend would have
had to keep a second argv builder for that one case -- which is exactly the
drift this whole migration is removing, since the two would then disagree the
first time either changed.

THE EXEMPTION, AND WHY IT IS SAFE. A scratch container skips the git-checkout
rule. That rule exists for one reason: to refuse binding an ARBITRARY HOST
directory into a delegate. A path aimee just made under its own cache is
categorically not that. To stop the exemption becoming a way to smuggle one in,
a scratch request may not ALSO name a repository -- worktree, repo root and
gitdir are each refused alongside it, rather than the builder resolving the
conflict in favour of one. All three are pinned by test.

Everything else still applies, and applies through the SAME code rather than a
copy: the shared tail is now attachSandboxChannel(), used by both shapes, which
adds the control socket, AIMEE_API_ENDPOINT, the proxy variables, the git trust
config and the container user. These are the parts whose absence is SILENT -- a
container missing AIMEE_API_ENDPOINT starts and looks healthy -- so a second
copy that fell one variable behind would be found by a delegate failing
mysteriously rather than by a test. The scratch tests assert the network mode,
the endpoint, the git config, the socket mount, and that binding the runtime
socket is still refused on this path.

The scratch mount is writable regardless of the role: the delegate has nowhere
else to work, and nothing else can see the directory.

Stage 12 carries scratch_dir and scratch_target so the backend can ask for this
shape over the same call it uses for every other one.
