### PR TITLE
port(economizer): cJSON-compatible printer — unblocks the fold port

### DIFF
--- a/server-go/modules/economizer/cjson.go
+++ b/server-go/modules/economizer/cjson.go
@@ -1,0 +1,285 @@
+package economizer
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// cJSON-compatible JSON printing.
+//
+// The fold embeds serialized sub-objects directly into its skeleton text (a
+// tool_use input, an OpenAI tool_calls arguments string, a tool_result body) and
+// hashes serialized messages for the freeze digest. Both of those live inside the
+// folded prefix, which must stay byte-identical turn to turn or the prompt cache
+// goes cold — the exact failure #2552 fixed.
+//
+// Go's encoding/json cannot be used for that text, because it differs from cJSON
+// in two ways that change bytes without changing meaning:
+//
+//	cJSON_PrintUnformatted: {"zeta":1,"alpha":"a<b&c","path":"/x/y"}
+//	Go json.Marshal(map):   {"alpha":"a<b&c","path":"/x/y","zeta":1}
+//
+//  1. Go sorts map keys; cJSON preserves insertion order.
+//  2. Go HTML-escapes <, > and & by default.
+//
+// So this file reproduces cJSON's printer: insertion order preserved, cJSON's
+// escape set, and cJSON's number spelling.
+
+// JSONValue is an order-preserving parsed JSON value.
+type JSONValue struct {
+	Kind  JSONKind
+	Str   string
+	Num   float64
+	Bool  bool
+	Keys  []string     // object key order, as parsed
+	Vals  []*JSONValue // object values, parallel to Keys
+	Items []*JSONValue // array elements
+}
+
+// JSONKind enumerates the value kinds cJSON distinguishes.
+type JSONKind int
+
+const (
+	JSONNull JSONKind = iota
+	JSONFalse
+	JSONTrue
+	JSONNumber
+	JSONString
+	JSONArray
+	JSONObject
+)
+
+// ParseJSON parses raw into an order-preserving tree, or returns nil if raw is
+// not valid JSON (mirroring cJSON_ParseWithLength returning NULL).
+func ParseJSON(raw string) *JSONValue {
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		return nil
+	}
+	v, err := parseJSONValue(dec, tok)
+	if err != nil {
+		return nil
+	}
+	// Trailing bytes after the first complete value are IGNORED, because
+	// cJSON_ParseWithLength ignores them too (it is called without
+	// require_null_terminated). Verified: cJSON parses `{"a":1}trailing` as
+	// `{"a":1}`. Rejecting it here would make the fold take a different path than
+	// C for the same input.
+	return v
+}
+
+// KNOWN DIVERGENCE from cJSON, documented rather than hidden.
+//
+// cJSON accepts a RAW control byte (< 0x20) inside a string and re-emits it
+// escaped: {"c":"x<0x01>y"} parses and prints as {"c":"xy"}. Go's
+// encoding/json rejects that input outright, so ParseJSON returns nil where
+// cJSON would have succeeded.
+//
+// Consequence: for a malformed-but-cJSON-acceptable body, the compress lever
+// falls back to head+tail where C would have produced a JSON structural summary
+// — different output bytes for the same input. Well-formed producers escape
+// control characters, so this only reaches bodies that were already invalid
+// JSON, but it IS a behaviour difference and is pinned by a test.
+//
+// Closing it needs a hand-written lenient parser; that is a deliberate
+// follow-up, not an oversight.
+
+func parseJSONValue(dec *json.Decoder, tok json.Token) (*JSONValue, error) {
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case '{':
+			v := &JSONValue{Kind: JSONObject}
+			for {
+				kt, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				if d, ok := kt.(json.Delim); ok && d == '}' {
+					return v, nil
+				}
+				key, _ := kt.(string)
+				vt, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				child, err := parseJSONValue(dec, vt)
+				if err != nil {
+					return nil, err
+				}
+				v.Keys = append(v.Keys, key)
+				v.Vals = append(v.Vals, child)
+			}
+		case '[':
+			v := &JSONValue{Kind: JSONArray}
+			for {
+				vt, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				if d, ok := vt.(json.Delim); ok && d == ']' {
+					return v, nil
+				}
+				child, err := parseJSONValue(dec, vt)
+				if err != nil {
+					return nil, err
+				}
+				v.Items = append(v.Items, child)
+			}
+		}
+		return nil, fmt.Errorf("unexpected delimiter %v", t)
+	case string:
+		return &JSONValue{Kind: JSONString, Str: t}, nil
+	case json.Number:
+		f, err := t.Float64()
+		if err != nil {
+			return nil, err
+		}
+		return &JSONValue{Kind: JSONNumber, Num: f}, nil
+	case bool:
+		if t {
+			return &JSONValue{Kind: JSONTrue, Bool: true}, nil
+		}
+		return &JSONValue{Kind: JSONFalse}, nil
+	case nil:
+		return &JSONValue{Kind: JSONNull}, nil
+	}
+	return nil, fmt.Errorf("unexpected token %v", tok)
+}
+
+// cjsonInt reproduces cJSON's valueint: the double truncated to int, clamped at
+// the int bounds rather than wrapping.
+func cjsonInt(d float64) int32 {
+	if d >= math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if d <= math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(d)
+}
+
+// compareDouble reproduces cJSON's compare_double: an EPSILON comparison, not
+// exact equality.
+//
+// This is load-bearing and easy to miss. cJSON accepts the 15-digit spelling
+// whenever it round-trips to within one DBL_EPSILON of the original, so
+// 0.30000000000000004 prints as "0.3". An exact `parsed != d` check would fall
+// through to 17 digits and emit "0.30000000000000004" instead — a different
+// prefix byte for the same input, which is a cold cache.
+func compareDouble(a, b float64) bool {
+	maxVal := math.Abs(a)
+	if math.Abs(b) > maxVal {
+		maxVal = math.Abs(b)
+	}
+	// math.Nextafter(1,2)-1 is DBL_EPSILON (2^-52).
+	const dblEpsilon = 2.220446049250313e-16
+	return math.Abs(a-b) <= maxVal*dblEpsilon
+}
+
+// CJSONNumber spells a number the way cJSON's print_number does.
+//
+// Three branches, in cJSON's order: non-finite prints as null; a value equal to
+// its clamped int prints as that int (so 3.0 is "3", not "3.0"); otherwise 15
+// significant digits, falling back to 17 only when 15 does not round-trip to
+// within DBL_EPSILON.
+func CJSONNumber(d float64) string {
+	if math.IsNaN(d) || math.IsInf(d, 0) {
+		return "null"
+	}
+	if vi := cjsonInt(d); d == float64(vi) {
+		return strconv.FormatInt(int64(vi), 10)
+	}
+	s := fmt.Sprintf("%.15g", d)
+	if parsed, err := strconv.ParseFloat(s, 64); err != nil || !compareDouble(parsed, d) {
+		s = fmt.Sprintf("%.17g", d)
+	}
+	return s
+}
+
+// cjsonEscape writes a JSON string literal using cJSON's escape set.
+//
+// cJSON escapes only ", \, and the control characters; it does NOT escape '/',
+// and it does NOT escape '<', '>' or '&'. It also passes multi-byte UTF-8
+// through untouched rather than emitting \uXXXX surrogate pairs.
+func cjsonEscape(b *strings.Builder, s string) {
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '"':
+			b.WriteString("\\\"")
+		case '\\':
+			b.WriteString("\\\\")
+		case '\b':
+			b.WriteString("\\b")
+		case '\f':
+			b.WriteString("\\f")
+		case '\n':
+			b.WriteString("\\n")
+		case '\r':
+			b.WriteString("\\r")
+		case '\t':
+			b.WriteString("\\t")
+		default:
+			if c < 32 {
+				fmt.Fprintf(b, "\\u%04x", c)
+			} else {
+				b.WriteByte(c)
+			}
+		}
+	}
+	b.WriteByte('"')
+}
+
+// PrintJSONUnformatted renders v the way cJSON_PrintUnformatted does: no
+// whitespace, object keys in their original order.
+func PrintJSONUnformatted(v *JSONValue) string {
+	var b strings.Builder
+	printJSON(&b, v)
+	return b.String()
+}
+
+func printJSON(b *strings.Builder, v *JSONValue) {
+	if v == nil {
+		b.WriteString("null")
+		return
+	}
+	switch v.Kind {
+	case JSONNull:
+		b.WriteString("null")
+	case JSONFalse:
+		b.WriteString("false")
+	case JSONTrue:
+		b.WriteString("true")
+	case JSONNumber:
+		b.WriteString(CJSONNumber(v.Num))
+	case JSONString:
+		cjsonEscape(b, v.Str)
+	case JSONArray:
+		b.WriteByte('[')
+		for i, item := range v.Items {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			printJSON(b, item)
+		}
+		b.WriteByte(']')
+	case JSONObject:
+		b.WriteByte('{')
+		for i, key := range v.Keys {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			cjsonEscape(b, key)
+			b.WriteByte(':')
+			printJSON(b, v.Vals[i])
+		}
+		b.WriteByte('}')
+	}
+}

--- a/server-go/modules/economizer/cjson_test.go
+++ b/server-go/modules/economizer/cjson_test.go
@@ -1,0 +1,126 @@
+package economizer
+
+import "testing"
+
+// DIFFERENTIAL test against real cJSON.
+//
+// Every `want` below is the VERBATIM stdout of cJSON_PrintUnformatted for that
+// input, captured by compiling src/vendor/cJSON.c against a throwaway harness.
+// They are not hand-written expectations.
+//
+// This printer exists because the fold embeds serialized sub-objects into its
+// skeleton text and hashes serialized messages for the freeze digest, both of
+// which sit in the cache-sensitive folded prefix. A byte of drift here is a cold
+// cache on every turn — with every test that checks only CONTENT still green.
+
+func roundTrip(t *testing.T, raw string) string {
+	t.Helper()
+	v := ParseJSON(raw)
+	if v == nil {
+		t.Fatalf("ParseJSON(%q) returned nil", raw)
+	}
+	return PrintJSONUnformatted(v)
+}
+
+// The two ways Go's encoding/json diverges: key reordering and HTML escaping.
+func TestCJSONPreservesOrderAndDoesNotHTMLEscape(t *testing.T) {
+	raw := `{"zeta":1,"alpha":"a<b&c>d","path":"/x/y"}`
+	want := `{"zeta":1,"alpha":"a<b&c>d","path":"/x/y"}`
+	if got := roundTrip(t, raw); got != want {
+		t.Errorf("\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestCJSONNumberSpelling(t *testing.T) {
+	raw := `{"a":3.0,"b":0.1,"c":1e300,"d":-0.0000001,"e":2147483648,` +
+		`"f":1234567890123456789,"g":0.30000000000000004,"h":-2147483649}`
+	want := `{"a":3,"b":0.1,"c":1e+300,"d":-1e-07,"e":2147483648,` +
+		`"f":1.2345678901234568e+18,"g":0.3,"h":-2147483649}`
+	if got := roundTrip(t, raw); got != want {
+		t.Errorf("\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// 0.30000000000000004 -> "0.3" is the case that pins the EPSILON round-trip
+// check. With exact equality this would emit all 17 digits.
+func TestCJSONNumberEpsilonRoundTrip(t *testing.T) {
+	if got := CJSONNumber(0.30000000000000004); got != "0.3" {
+		t.Errorf("CJSONNumber(0.30000000000000004) = %q, want \"0.3\"", got)
+	}
+	// And a value that genuinely needs 17 digits still gets them.
+	if got := CJSONNumber(1234567890123456789); got != "1.2345678901234568e+18" {
+		t.Errorf("CJSONNumber(1234567890123456789) = %q", got)
+	}
+}
+
+// The control character is written as the six-character ESCAPE , not a raw
+// 0x01 byte — a raw byte is invalid JSON that encoding/json rejects (see
+// TestCJSONRawControlByteDivergence).
+func TestCJSONEscapes(t *testing.T) {
+	raw := "{\"q\":\"he said \\\"hi\\\"\",\"bs\":\"a\\\\b\",\"ctl\":\"x\\u0001y\"," +
+		"\"ws\":\"a\\tb\\nc\\r\",\"uni\":\"héllo → 世界\",\"slash\":\"a/b\"}"
+	want := "{\"q\":\"he said \\\"hi\\\"\",\"bs\":\"a\\\\b\",\"ctl\":\"x\\u0001y\"," +
+		"\"ws\":\"a\\tb\\nc\\r\",\"uni\":\"héllo → 世界\",\"slash\":\"a/b\"}"
+	if got := roundTrip(t, raw); got != want {
+		t.Errorf("\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestCJSONNestingAndEmpties(t *testing.T) {
+	raw := `{"o":{},"a":[],"n":null,"t":true,"f":false,"deep":[{"k":[1,2,{"z":"y"}]}]}`
+	want := `{"o":{},"a":[],"n":null,"t":true,"f":false,"deep":[{"k":[1,2,{"z":"y"}]}]}`
+	if got := roundTrip(t, raw); got != want {
+		t.Errorf("\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestCJSONOddKeys(t *testing.T) {
+	raw := `{"":1,"k":2}`
+	want := `{"":1,"k":2}`
+	if got := roundTrip(t, raw); got != want {
+		t.Errorf("\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// Invalid input parses to nil, mirroring cJSON_ParseWithLength returning NULL.
+func TestCJSONParseFailure(t *testing.T) {
+	for _, bad := range []string{"", "{", "not json", `{"a":}`} {
+		if v := ParseJSON(bad); v != nil {
+			t.Errorf("ParseJSON(%q) should be nil, got %+v", bad, v)
+		}
+	}
+}
+
+// Trailing bytes are IGNORED, matching cJSON_ParseWithLength, which is called
+// without require_null_terminated. Verified against C: it parses
+// `{"a":1}trailing` as `{"a":1}`.
+func TestCJSONTrailingBytesIgnored(t *testing.T) {
+	if got := roundTrip(t, `{"a":1}trailing`); got != `{"a":1}` {
+		t.Errorf("got %s, want {\"a\":1}", got)
+	}
+}
+
+// KNOWN DIVERGENCE, pinned so it cannot drift silently.
+//
+// cJSON accepts a RAW control byte inside a string and re-emits it escaped:
+// C turns {"c":"x<0x01>y"} into {"c":"xy"}. Go's encoding/json rejects
+// that input, so ParseJSON returns nil where cJSON would have succeeded, and the
+// compress lever then falls back to head+tail where C produced a JSON summary.
+func TestCJSONRawControlByteDivergence(t *testing.T) {
+	raw := "{\"c\":\"x\x01y\"}"
+	if v := ParseJSON(raw); v != nil {
+		t.Fatal("encoding/json unexpectedly accepted a raw control byte — the " +
+			"documented divergence has closed; update the comment in cjson.go")
+	}
+}
+
+// Non-finite doubles print as null, as cJSON does.
+func TestCJSONNonFinite(t *testing.T) {
+	one := 1.0
+	zero := 0.0
+	for _, d := range []float64{one / zero, -one / zero} {
+		if got := CJSONNumber(d); got != "null" {
+			t.Errorf("CJSONNumber(%v) = %q, want \"null\"", d, got)
+		}
+	}
+}

--- a/server-go/modules/economizer/compact.go
+++ b/server-go/modules/economizer/compact.go
@@ -1,7 +1,6 @@
 package economizer
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -115,101 +114,18 @@ func startsWithJSON(s string) bool {
 	return i < len(s) && (s[i] == '{' || s[i] == '[')
 }
 
-// jsonNode is a decoded JSON value retaining object key order, which cJSON
-// preserves and encoding/json's map does not. Key order changes the summary
-// bytes, so it has to be kept.
-type jsonNode struct {
-	kind    byte // 'o' object, 'a' array, 's' string, 'n' number, 'b' bool, 'z' null
-	keys    []string
-	vals    []*jsonNode
-	str     string
-	num     float64
-	boolean bool
-}
-
-func decodeJSON(raw string) *jsonNode {
-	dec := json.NewDecoder(strings.NewReader(raw))
-	dec.UseNumber()
-	tok, err := dec.Token()
-	if err != nil {
-		return nil
-	}
-	node, err := decodeValue(dec, tok)
-	if err != nil {
-		return nil
-	}
-	return node
-}
-
-func decodeValue(dec *json.Decoder, tok json.Token) (*jsonNode, error) {
-	switch t := tok.(type) {
-	case json.Delim:
-		if t == '{' {
-			n := &jsonNode{kind: 'o'}
-			for {
-				kt, err := dec.Token()
-				if err != nil {
-					return nil, err
-				}
-				if d, ok := kt.(json.Delim); ok && d == '}' {
-					return n, nil
-				}
-				key, _ := kt.(string)
-				vt, err := dec.Token()
-				if err != nil {
-					return nil, err
-				}
-				child, err := decodeValue(dec, vt)
-				if err != nil {
-					return nil, err
-				}
-				n.keys = append(n.keys, key)
-				n.vals = append(n.vals, child)
-			}
-		}
-		if t == '[' {
-			n := &jsonNode{kind: 'a'}
-			for {
-				vt, err := dec.Token()
-				if err != nil {
-					return nil, err
-				}
-				if d, ok := vt.(json.Delim); ok && d == ']' {
-					return n, nil
-				}
-				child, err := decodeValue(dec, vt)
-				if err != nil {
-					return nil, err
-				}
-				n.vals = append(n.vals, child)
-			}
-		}
-		return nil, fmt.Errorf("unexpected delim %v", t)
-	case string:
-		return &jsonNode{kind: 's', str: t}, nil
-	case json.Number:
-		f, _ := t.Float64()
-		return &jsonNode{kind: 'n', num: f}, nil
-	case bool:
-		return &jsonNode{kind: 'b', boolean: t}, nil
-	case nil:
-		return &jsonNode{kind: 'z'}, nil
-	}
-	return nil, fmt.Errorf("unexpected token")
-}
-
 // describeJSON renders the structural summary, depth-limited so a deeply nested
 // document cannot produce an enormous summary.
-func describeJSON(node *jsonNode, b *boundBuf, depth int) {
+func describeJSON(node *JSONValue, b *boundBuf, depth int) {
 	if node == nil || b.pos >= b.cap {
 		return
 	}
-	switch node.kind {
-	case 'o':
-		count := len(node.keys)
+	switch node.Kind {
+	case JSONObject:
+		count := len(node.Keys)
 		b.appendf("{")
 		first := true
-		for i, key := range node.keys {
+		for i, key := range node.Keys {
 			if b.pos >= b.cap {
 				break
 			}
@@ -219,17 +135,17 @@ func describeJSON(node *jsonNode, b *boundBuf, depth int) {
 			first = false
 			b.appendf("\"%s\": ", key)
 			if depth < 2 {
-				describeJSON(node.vals[i], b, depth+1)
+				describeJSON(node.Vals[i], b, depth+1)
 			} else {
-				b.appendf("%s", typeGlyph(node.vals[i]))
+				b.appendf("%s", typeGlyph(node.Vals[i]))
 			}
 		}
 		b.appendf("}")
 		if count > 5 {
 			b.appendf(" /* %d keys */", count)
 		}
-	case 'a':
-		count := len(node.vals)
+	case JSONArray:
+		count := len(node.Items)
 		if count == 0 {
 			b.appendf("[]")
 			return
@@ -237,45 +153,43 @@ func describeJSON(node *jsonNode, b *boundBuf, depth int) {
 		b.appendf("[/* %d items */", count)
 		if depth < 2 {
 			b.appendf(" ")
-			describeJSON(node.vals[0], b, depth+1)
+			describeJSON(node.Items[0], b, depth+1)
 			if count > 1 {
 				b.appendf(", ...")
 			}
 		}
 		b.appendf("]")
-	case 's':
-		if len(node.str) <= 64 {
-			b.appendf("\"%s\"", node.str)
+	case JSONString:
+		if len(node.Str) <= 64 {
+			b.appendf("\"%s\"", node.Str)
 		} else {
-			b.appendf("\"%s...\"", node.str[:60]) // C's %.60s is a BYTE precision
+			b.appendf("\"%s...\"", node.Str[:60]) // C's %.60s is a BYTE precision
 		}
-	case 'n':
-		b.appendf("%s", cFormatG(node.num))
-	case 'b':
-		if node.boolean {
-			b.appendf("true")
-		} else {
-			b.appendf("false")
-		}
+	case JSONNumber:
+		b.appendf("%s", cFormatG(node.Num))
+	case JSONTrue:
+		b.appendf("true")
+	case JSONFalse:
+		b.appendf("false")
 	default:
 		b.appendf("null")
 	}
 }
 
-func typeGlyph(n *jsonNode) string {
+func typeGlyph(n *JSONValue) string {
 	if n == nil {
 		return "null"
 	}
-	switch n.kind {
-	case 's':
+	switch n.Kind {
+	case JSONString:
 		return "<string>"
-	case 'n':
+	case JSONNumber:
 		return "<number>"
-	case 'o':
+	case JSONObject:
 		return "{...}"
-	case 'a':
+	case JSONArray:
 		return "[...]"
-	case 'b':
+	case JSONTrue, JSONFalse:
 		return "<bool>"
 	}
 	return "null"
@@ -284,7 +198,7 @@ func typeGlyph(n *jsonNode) string {
 // compactJSONSummary returns the structural summary, or ok=false when the body
 // is not valid JSON (the caller then falls back to head+tail).
 func compactJSONSummary(raw string) (string, bool) {
-	node := decodeJSON(raw)
+	node := ParseJSON(raw)
 	if node == nil {
 		return "", false
 	}

--- a/server-go/modules/economizer/compact.go
+++ b/server-go/modules/economizer/compact.go
@@ -9,12 +9,14 @@ import (
 
 // Tool-result body shrink — the single algorithm both reduction seams use.
 //
-// Ported from src/compact.c. NOTE FOR THE CUT-OVER: compact_body has TWO
-// production callers in C — the economizer's lazy lever (context_fold.c) and the
-// EAGER per-result seam (src/server/agent_policy.c:923), which is outside this
-// module. This Go copy must not go live until the eager seam also routes here,
-// or the algorithm exists in two languages — precisely the failure the migration
-// notes record as having already cost a review cycle on roundtable.
+// Ported from src/compact.c.
+//
+// CORRECTION to an earlier note in this file: compact_body does NOT have two
+// live callers. The eager per-result seam (agent_compress_tool_result in
+// src/server/agent_policy.c) is uncalled dead code — see eager.go — so the only
+// live caller is the economizer's lazy lever in context_fold.c. Moving this to
+// Go therefore creates no two-languages problem, provided the dead C seam is
+// deleted rather than left in place.
 //
 // Output byte-identity is load-bearing, not cosmetic: these bodies sit inside the
 // folded prefix, and a prefix that differs by one byte is a cold prompt cache. So

--- a/server-go/modules/economizer/eager.go
+++ b/server-go/modules/economizer/eager.go
@@ -1,0 +1,125 @@
+package economizer
+
+const (
+	// AgentToolOutputMax is the built-in per-result model-visible cap.
+	AgentToolOutputMax = 32 * 1024
+	// AgentToolOutputRawMax is the ceiling an operator setting is clamped to.
+	AgentToolOutputRawMax = 32 * 1024
+)
+
+// ToolOutputCapClamp resolves the per-result cap: 0/unset gives the built-in
+// default, and an operator value is clamped to the raw ceiling.
+func ToolOutputCapClamp(configured int) int {
+	if configured <= 0 {
+		return AgentToolOutputMax
+	}
+	if configured > AgentToolOutputRawMax {
+		return AgentToolOutputRawMax
+	}
+	return configured
+}
+
+// EagerConfig is the resolved application config the eager seam needs.
+//
+// Passed in rather than read from a config store, so this module stays a pure
+// transformer with no ambient state — which is what lets it serve a bus stage
+// without owning a config connection.
+type EagerConfig struct {
+	Compact       CompactConfig
+	ToolOutputCap int // 0 -> built-in default, via ToolOutputCapClamp
+	Closet        ClosetConfig
+}
+
+// EagerResult reports what the seam did, so the caller can log it. The C version
+// logs from inside; keeping the logging in the caller leaves this function pure
+// and testable.
+type EagerResult struct {
+	Body      string
+	Compacted bool
+	Evict     EvictResult
+}
+
+// CompressToolResult is the EAGER tool-result seam: shrink via the shared
+// CompactBody core, conserve identifiers in the Coordinate Closet, and bound the
+// result to the per-result cap.
+//
+// Ported from agent_compress_tool_result in src/server/agent_policy.c.
+//
+// STATUS — READ BEFORE WIRING. The C original has NO callers and NO tests. A
+// repo-wide search finds only its definition, its declaration in agent_exec.h,
+// and prose in compact.h. A CI gate used to assert exactly that, listing it under
+// "legacy_calls" beside context_reduce and build_fold_view and failing if any
+// production source reached it; that gate was removed in 9d478dcaa6 (economizer
+// off/safe/aggressive tiers).
+//
+// So its header comment — "the ONLY writer of compacted bodies into history" — no
+// longer describes anything that runs, and the Coordinate Closet's P1 "wired
+// return-only into agent_compress_tool_result" wiring is inert with it.
+//
+// Consequences worth being explicit about:
+//   - compact_body has ONE live caller, the lazy lever in context_fold.c. Moving
+//     it to Go therefore does NOT put the shrink algorithm in two languages.
+//   - This port exists so the seam has a single home if it is ever revived. The
+//     C original should be DELETED rather than kept in parallel; keeping both is
+//     the two-languages problem for real, and for a path nothing calls.
+//
+// The hard cap is applied by THIS seam, not the core — it is per-seam policy.
+// The cap is resolved once so the closet budget and the final bound agree.
+//
+// toolName may be empty to skip per-tool overrides.
+func CompressToolResult(raw, toolName string, cfg EagerConfig) EagerResult {
+	if raw == "" {
+		return EagerResult{}
+	}
+
+	cap := ToolOutputCapClamp(cfg.ToolOutputCap)
+
+	out := CompactBody(raw, toolName, &cfg.Compact)
+	compacted := len(out) < len(raw)
+
+	// Fold §2 — when the result was compacted, conserve the verbatim identifiers
+	// from the PRE-truncation raw so they survive the shrink. That ordering is the
+	// whole point: nominating from the compacted body would only find what the
+	// shrink already kept.
+	closet := ""
+	evict := EvictNone
+	if cfg.Closet.Enabled && compacted {
+		// The conserved values originate from the same tool result as the body —
+		// same trust level — so stamping them AGENT elevates no trust.
+		prov := Provenance{Lane: LaneAgent, TurnID: -1, ToolCallID: -1, ResultIndex: -1}
+		var set CoordSet
+		NominateInto(raw, &prov, &set)
+
+		// Bound the closet budget so body + closet can never exceed the hard cap.
+		hardRoom := cap - 256
+		if hardRoom < 0 {
+			hardRoom = 0 // tiny operator cap: no room for a closet
+		}
+		cb := cfg.Closet.BudgetBytes
+		if cb > hardRoom {
+			cb = hardRoom
+		}
+		ccfg := ClosetConfig{
+			Enabled:     true,
+			BudgetBytes: cb,
+			MaxRatioPct: cfg.Closet.MaxRatioPct,
+			Denylist:    cfg.Closet.Denylist,
+		}
+		closet, evict = RenderCloset(&set, ccfg, len(raw))
+	}
+
+	// Hard cap: the result never exceeds the resolved per-result cap regardless of
+	// what the summary produced, with closet bytes reserved inside it.
+	bodyCap := cap
+	if len(closet) > 0 && len(closet)+1 < cap {
+		bodyCap = cap - len(closet) - 1
+	}
+	if len(out) > bodyCap {
+		out = out[:bodyCap] // byte truncation, as in C
+	}
+
+	if len(closet) > 0 {
+		out = out + "\n" + closet
+	}
+	return EagerResult{Body: out, Compacted: compacted, Evict: evict}
+}

--- a/server-go/modules/economizer/eager_test.go
+++ b/server-go/modules/economizer/eager_test.go
@@ -1,0 +1,129 @@
+package economizer
+
+import (
+	"strings"
+	"testing"
+)
+
+// The C original (agent_compress_tool_result) has NO tests and, as of this
+// commit, NO callers — see the note on CompressToolResult. These are therefore
+// written against its documented contract rather than ported from a C suite,
+// and they are what make the ported behaviour checkable at all.
+
+func eagerCfg() EagerConfig {
+	return EagerConfig{
+		Compact: CompactConfig{Enabled: true, Threshold: 64, HeadBytes: 20, TailBytes: 20},
+		Closet:  ClosetConfig{Enabled: true, BudgetBytes: 2048, MaxRatioPct: 100},
+	}
+}
+
+func TestEagerEmptyRaw(t *testing.T) {
+	if got := CompressToolResult("", "", eagerCfg()); got.Body != "" || got.Compacted {
+		t.Errorf("empty raw must produce an empty, uncompacted result: %+v", got)
+	}
+}
+
+func TestEagerPassThroughWhenSmall(t *testing.T) {
+	raw := "small result"
+	got := CompressToolResult(raw, "", eagerCfg())
+	if got.Body != raw || got.Compacted {
+		t.Errorf("below threshold must pass through unchanged: %+v", got)
+	}
+}
+
+// The closet nominates from the PRE-truncation raw, so an identifier that the
+// shrink discards still survives. This is the whole reason the seam exists.
+func TestEagerConservesIdentifiersDroppedByTheShrink(t *testing.T) {
+	// Put the identifier in the middle, where head+tail truncation will drop it.
+	raw := strings.Repeat("a", 200) +
+		" /home/u/src/buried.c handle:deadbeef " +
+		strings.Repeat("b", 200)
+	got := CompressToolResult(raw, "", eagerCfg())
+	if !got.Compacted {
+		t.Fatalf("fixture should have compacted: %q", got.Body)
+	}
+	if strings.Contains(got.Body[:strings.Index(got.Body, "\n")+1], "buried.c") {
+		t.Skip("fixture no longer buries the identifier; adjust the padding")
+	}
+	for _, want := range []string{"/home/u/src/buried.c", "handle:deadbeef", "Coordinate Closet"} {
+		if !strings.Contains(got.Body, want) {
+			t.Errorf("identifier %q was lost by the shrink and not conserved", want)
+		}
+	}
+}
+
+// No closet is rendered when nothing shrank: there is nothing to conserve
+// against, and appending one would only add bytes.
+func TestEagerNoClosetWhenNotCompacted(t *testing.T) {
+	raw := "short /home/u/src/x.c body"
+	got := CompressToolResult(raw, "", eagerCfg())
+	if got.Compacted {
+		t.Fatal("fixture should not compact")
+	}
+	if strings.Contains(got.Body, "Coordinate Closet") {
+		t.Error("closet must not be appended when nothing was compacted")
+	}
+}
+
+func TestEagerClosetDisabled(t *testing.T) {
+	cfg := eagerCfg()
+	cfg.Closet.Enabled = false
+	raw := strings.Repeat("a", 200) + " /home/u/src/buried.c " + strings.Repeat("b", 200)
+	got := CompressToolResult(raw, "", cfg)
+	if strings.Contains(got.Body, "Coordinate Closet") {
+		t.Error("closet disabled but still rendered")
+	}
+}
+
+// The hard cap is per-seam policy and must hold regardless of what the shrink
+// produced, with the closet counted inside it.
+func TestEagerHardCapIncludesCloset(t *testing.T) {
+	cfg := eagerCfg()
+	cfg.ToolOutputCap = 300
+	raw := strings.Repeat("a", 200) +
+		" /home/u/src/one.c /home/u/src/two.c handle:abc123 " +
+		strings.Repeat("b", 2000)
+	got := CompressToolResult(raw, "", cfg)
+	if len(got.Body) > 300 {
+		t.Errorf("result %d bytes exceeds the resolved cap of 300", len(got.Body))
+	}
+}
+
+// A cap so small there is no room for a closet must still produce a bounded
+// body rather than failing.
+func TestEagerTinyCapStillBounded(t *testing.T) {
+	cfg := eagerCfg()
+	cfg.ToolOutputCap = 100
+	raw := strings.Repeat("a", 100) + " /home/u/src/x.c " + strings.Repeat("b", 2000)
+	got := CompressToolResult(raw, "", cfg)
+	if len(got.Body) > 100 {
+		t.Errorf("result %d bytes exceeds the tiny cap of 100", len(got.Body))
+	}
+}
+
+func TestToolOutputCapClamp(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{0, AgentToolOutputMax},
+		{-1, AgentToolOutputMax},
+		{1024, 1024},
+		{AgentToolOutputRawMax + 1, AgentToolOutputRawMax},
+	}
+	for _, c := range cases {
+		if got := ToolOutputCapClamp(c.in); got != c.want {
+			t.Errorf("ToolOutputCapClamp(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// Per-tool overrides reach the shared core through this seam.
+func TestEagerPerToolDisable(t *testing.T) {
+	cfg := eagerCfg()
+	cfg.Compact.PerTool = []PerToolCompact{{Tool: "read_file", Threshold: -1}}
+	raw := strings.Repeat("a", 500)
+	if got := CompressToolResult(raw, "read_file", cfg); got.Body != raw || got.Compacted {
+		t.Error("per-tool -1 must disable compaction for that tool")
+	}
+	if got := CompressToolResult(raw, "other", cfg); !got.Compacted {
+		t.Error("per-tool override must not leak to other tools")
+	}
+}


### PR DESCRIPTION
Next installment of the economizer Go port (follows #2554). Adds an order-preserving JSON parser and a printer that reproduces `cJSON_PrintUnformatted` byte-for-byte, and consolidates `compact.go` onto it. **55 tests** in the package, `go vet`/`gofmt` clean, tree builds.

## Why this exists

`context_fold` embeds serialized sub-objects **directly into its skeleton text** (a `tool_use` input, an OpenAI `tool_calls` arguments string, a `tool_result` body) and hashes serialized messages for the freeze digest. Both land inside the folded prefix, which must stay byte-identical turn to turn or the prompt cache goes cold — the exact failure #2552 fixed.

Go's `encoding/json` cannot produce that text:

```
cJSON: {"zeta":1,"alpha":"a<b&c>d","path":"/x/y"}
Go:    {"alpha":"a<b&c>d","path":"/x/y","zeta":1}
```

Go sorts map keys; cJSON preserves insertion order. Go HTML-escapes `<`, `>` and `&`; cJSON does not.

So this was the blocker in front of the fold port, and it is now cleared.

## Verified differentially

Every expectation is the **verbatim stdout of `cJSON_PrintUnformatted`** for that input, captured by compiling `src/vendor/cJSON.c` against a throwaway harness (deleted; not in this commit). Three C behaviours the harness caught that I would otherwise have got wrong:

1. **`print_number`'s round-trip check uses `compare_double` — an EPSILON comparison, not exact equality.** cJSON prints `0.30000000000000004` as `"0.3"`, because the 15-digit spelling round-trips to within one `DBL_EPSILON`. An exact `!=` check falls through to 17 digits and emits `"0.30000000000000004"` — a different prefix byte for the same input.
2. **`cJSON_ParseWithLength` ignores trailing bytes** (called without `require_null_terminated`): it parses `{"a":1}trailing` as `{"a":1}`. My first version rejected that, which would have taken a different path than C.
3. **Numbers equal to their int-clamped value print via `%d`**, so `3.0` is `"3"`; everything else is `%1.15g` with a `%1.17g` fallback.

## Known divergence, pinned by a test

cJSON accepts a **raw control byte** inside a string and re-emits it escaped; Go's `encoding/json` rejects that input, so `ParseJSON` returns nil where cJSON succeeds — and the compress lever then falls back to head+tail where C produced a JSON summary.

Only reachable for bodies that were already invalid JSON (well-formed producers escape control characters), but it is a real behaviour difference, so it is documented in `cjson.go` and pinned by `TestCJSONRawControlByteDivergence` rather than left to be discovered. Closing it needs a hand-written lenient parser — a deliberate follow-up, not an oversight.

## Consolidation

Removes `compact.go`'s private `jsonNode` tree in favour of the shared `JSONValue`, so the package has one JSON representation instead of two. The compact differential tests pass unchanged, which is what shows the refactor moved no bytes.

## Status

Port is roughly **30%** by line count. `context_fold` (643 ln) is now unblocked and is the next unit, followed by `context_reduce` (607), `tool_condense` (1,179), the provider shims, rails/seals, the gateway wire files, the module wiring, and the C cut-over.

Still open from #2554, both flagged there: the dead C seam `agent_compress_tool_result` should be **deleted** rather than kept beside its Go port, and the OpenAI-family cache telemetry gap (`aimee_backend_openai.c:412`, `aimee_backend_responses.c:298`) remains live in production.
