### PR TITLE
port(economizer): context_fold — fold view, freeze, and compress view

### DIFF
--- a/server-go/modules/economizer/fold.go
+++ b/server-go/modules/economizer/fold.go
@@ -1,0 +1,525 @@
+package economizer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Rolling history fold (§1) and boundary-free tool-body compression (§4).
+//
+// Ported from src/modules/economizer/context_fold.c, including the tail-note
+// placement fix from #2552 — see CompressView.
+
+const (
+	FoldDefaultRetainedMsgs = 8
+	FoldDefaultMinFoldMsgs  = 4
+	FoldDefaultExcerptBytes = 160
+	FoldDefaultTailCapMsgs  = 24
+)
+
+// FoldConfig mirrors fold_config_t.
+type FoldConfig struct {
+	Enabled               bool
+	RetainedMsgs          int  // trailing messages kept at full fidelity (0 -> default)
+	MinFoldMsgs           int  // fold only if >= this many would fold (0 -> default)
+	ReasoningExcerptBytes int  // per-message excerpt kept in the skeleton (0 -> default)
+	RegisterEnabled       bool // annotate folded assistant lines with their register
+	Closet                ClosetConfig
+	CompactHeadBytes      int
+	CompactTailBytes      int
+}
+
+// FoldFreeze is the §3 freeze boundary plus the digest that guards it.
+//
+// The digest is what makes reuse honest: a mid-run mutation of the folded prefix
+// (compaction rewriting history, say) would otherwise be reported as a warm
+// reuse when the bytes had in fact changed, claiming a cache that is cold.
+type FoldFreeze struct {
+	Active       bool
+	FrozenSplit  int
+	TailCapMsgs  int // re-epoch when (count - frozenSplit) exceeds this (0 -> default)
+	Epochs       int // count of boundary advances (diagnostic)
+	PrefixDigest uint64
+}
+
+// FoldResult is the outcome of a fold or compress pass.
+type FoldResult struct {
+	Messages       *JSONValue // NEW array; nil when nothing changed
+	Folded         bool
+	FoldedMsgs     int
+	RetainedMsgs   int
+	ReusedBoundary bool // this fold reused a frozen boundary (cache-warm)
+	ClosetEvict    EvictResult
+}
+
+// isCleanUserTurn reports whether m is a user turn carrying no tool_result.
+//
+// The fold may only split on one of these: cutting between a tool_use and its
+// tool_result would orphan the pair and every provider rejects that.
+func isCleanUserTurn(m *JSONValue) bool {
+	if m == nil || m.GetString("role") != "user" {
+		return false
+	}
+	content := m.Get("content")
+	if content.IsString() {
+		return true
+	}
+	if content.IsArray() {
+		for _, b := range content.Items {
+			if b.GetString("type") == "tool_result" {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// appendExcerpt appends up to max bytes of s, single-lined, marking truncation
+// with an ellipsis.
+//
+// If the byte cap would land mid-UTF-8-sequence it backs up to a character
+// boundary, so the emitted string never contains a split multibyte character.
+func appendExcerpt(b *strings.Builder, s string, max int) {
+	n := len(s)
+	if n > max {
+		n = max
+		// back off any continuation byte (0x80-0xBF) so [0,n) ends on a
+		// complete character
+		for n > 0 && s[n]&0xC0 == 0x80 {
+			n--
+		}
+	}
+	for i := 0; i < n; i++ {
+		c := s[i]
+		if c == '\n' || c == '\r' || c == '\t' {
+			c = ' '
+		}
+		b.WriteByte(c)
+	}
+	if n < len(s) {
+		b.WriteString("…")
+	}
+}
+
+// skeletonPrefix emits the "role: " (or "role/register: ") prefix.
+func skeletonPrefix(b *strings.Builder, role, txt string, registerOn bool) {
+	if registerOn && role == "assistant" {
+		fmt.Fprintf(b, "%s/%s: ", role, ParseRegister(txt).Label())
+		return
+	}
+	if role == "" {
+		role = "?"
+	}
+	fmt.Fprintf(b, "%s: ", role)
+}
+
+// skeletonMessage emits one folded message's skeleton line(s) and nominates its
+// identifiers into set.
+//
+// Format-aware and ADDITIVE: a single message can carry multiple shapes at once
+// — an OpenAI assistant turn has both a string `content` AND a top-level
+// `tool_calls` — so the extractors never early-return, and the closet captures
+// identifiers from every provider's calls and results, not just Anthropic's.
+func skeletonMessage(b *strings.Builder, m *JSONValue, turn, excerpt int, registerOn bool, set *CoordSet) {
+	role := m.GetString("role")
+	content := m.Get("content")
+	prov := Provenance{Lane: LaneAgent, TurnID: int64(turn), ToolCallID: -1, ResultIndex: -1}
+
+	// (1) String content (OpenAI/Gemini text, or any plain turn).
+	if content.IsString() {
+		txt := content.Str
+		NominateInto(txt, &prov, set)
+		skeletonPrefix(b, role, txt, registerOn)
+		appendExcerpt(b, txt, excerpt)
+		b.WriteByte('\n')
+	} else if content.IsArray() {
+		// (2) Anthropic content-block array (text / tool_use / tool_result).
+		for _, blk := range content.Items {
+			switch blk.GetString("type") {
+			case "":
+				continue
+			case "text":
+				txt := blk.GetString("text")
+				if txt == "" && blk.Get("text") == nil {
+					continue
+				}
+				NominateInto(txt, &prov, set)
+				skeletonPrefix(b, role, txt, registerOn)
+				appendExcerpt(b, txt, excerpt)
+				b.WriteByte('\n')
+			case "tool_use":
+				name := blk.GetString("name")
+				inp := ""
+				if input := blk.Get("input"); input != nil {
+					inp = PrintJSONUnformatted(input)
+					NominateInto(inp, &prov, set)
+				}
+				if name == "" {
+					name = "tool"
+				}
+				fmt.Fprintf(b, "  $ %s ", name)
+				appendExcerpt(b, inp, excerpt)
+				b.WriteByte('\n')
+			case "tool_result":
+				if cv, ok := blk.Get("content").Text(); ok {
+					NominateInto(cv, &prov, set)
+					b.WriteString("    → ")
+					appendExcerpt(b, cv, excerpt)
+					fmt.Fprintf(b, " (%d bytes)\n", len(cv))
+				}
+			}
+		}
+	}
+
+	// (3) OpenAI / Gemini-as-openai assistant tool calls: a top-level `tool_calls`
+	// array whose function.arguments is a JSON STRING.
+	if toolCalls := m.Get("tool_calls"); toolCalls.IsArray() {
+		for _, tc := range toolCalls.Items {
+			fn := tc.Get("function")
+			name := fn.GetString("name")
+			args := fn.GetString("arguments")
+			if args != "" {
+				NominateInto(args, &prov, set)
+			}
+			if name == "" {
+				name = "tool"
+			}
+			fmt.Fprintf(b, "  $ %s ", name)
+			appendExcerpt(b, args, excerpt)
+			b.WriteByte('\n')
+		}
+	}
+
+	// (4) Responses (chatgpt) top-level items, mirroring the tool_use /
+	// tool_result branches above.
+	switch m.GetString("type") {
+	case "function_call":
+		name := m.GetString("name")
+		args := m.GetString("arguments")
+		if args != "" {
+			NominateInto(args, &prov, set)
+		}
+		if name == "" {
+			name = "tool"
+		}
+		fmt.Fprintf(b, "  $ %s ", name)
+		appendExcerpt(b, args, excerpt)
+		b.WriteByte('\n')
+	case "function_call_output":
+		if ov, ok := m.Get("output").Text(); ok {
+			NominateInto(ov, &prov, set)
+			b.WriteString("    → ")
+			appendExcerpt(b, ov, excerpt)
+			fmt.Fprintf(b, " (%d bytes)\n", len(ov))
+		}
+	}
+}
+
+// prefixDigest is FNV-1a over the serialized bytes of messages[0..n), also
+// returning their total serialized size.
+//
+// Detects prefix mutation for freeze reuse and bounds the closet ratio cap in one
+// pass.
+func prefixDigest(messages *JSONValue, n int) (uint64, int) {
+	var h uint64 = 14695981039346656037
+	total := 0
+	for i := 0; i < n; i++ {
+		item := messages.At(i)
+		if item == nil {
+			continue
+		}
+		s := PrintJSONUnformatted(item)
+		for j := 0; j < len(s); j++ {
+			h ^= uint64(s[j])
+			h *= 1099511628211
+		}
+		total += len(s)
+	}
+	return h, total
+}
+
+// compressBodyField shrinks one body in place, returning whether it was replaced
+// and how many raw bytes it had.
+func compressBodyField(parent *JSONValue, key string, cc *CompactConfig, turn int, set *CoordSet) (bool, int) {
+	node := parent.Get(key)
+	body, ok := node.Text()
+	if !ok {
+		return false, 0
+	}
+	// Below threshold -> keep verbatim.
+	if cc.Threshold > 0 && len(body) <= cc.Threshold {
+		return false, 0
+	}
+	out := CompactBody(body, "", cc)
+	// Commit only on a genuine net shrink, so an over-threshold-but-tiny body
+	// never EXPANDS.
+	if len(out) == 0 || len(out) >= len(body) {
+		return false, 0
+	}
+	prov := Provenance{Lane: LaneAgent, TurnID: int64(turn), ToolCallID: -1, ResultIndex: -1}
+	NominateInto(body, &prov, set)
+	parent.Set(key, NewString(out))
+	return true, len(body)
+}
+
+// compressMessageBodies compresses every oversized tool-result body carried by
+// one message, across all three provider shapes.
+//
+// The shapes are mutually exclusive per message (an OpenAI tool result is a
+// string `content`; an Anthropic tool_result is a block inside an ARRAY
+// `content`; a Responses output is a top-level `output`), so no body is
+// double-counted.
+func compressMessageBodies(m *JSONValue, cc *CompactConfig, turn int, set *CoordSet) (int, int) {
+	n, raw := 0, 0
+	role := m.GetString("role")
+	itype := m.GetString("type")
+
+	// (A) OpenAI / Gemini-as-openai tool result: role=="tool" with string content.
+	if role == "tool" {
+		if ok, b := compressBodyField(m, "content", cc, turn, set); ok {
+			n, raw = n+1, raw+b
+		}
+	}
+
+	// (B) Anthropic tool_result content-block(s) inside a content ARRAY. A role
+	// "tool" message has a STRING content, so this never re-touches it.
+	if content := m.Get("content"); content.IsArray() {
+		for _, blk := range content.Items {
+			if blk.GetString("type") == "tool_result" {
+				if ok, b := compressBodyField(blk, "content", cc, turn, set); ok {
+					n, raw = n+1, raw+b
+				}
+			}
+		}
+	}
+
+	// (C) Responses (chatgpt) top-level function_call_output item.
+	if itype == "function_call_output" {
+		if ok, b := compressBodyField(m, "output", cc, turn, set); ok {
+			n, raw = n+1, raw+b
+		}
+	}
+	return n, raw
+}
+
+// CompressView performs boundary-free tool-result BODY compression.
+//
+// Unlike FoldView this needs NO clean-user-turn boundary: it shrinks oversized
+// bodies in place while keeping the carrying message, its role/type and its
+// tool_use_id / tool_call_id, so a tool_use and its result are never split. That
+// is why it engages on autonomous tool-loops, where the fold's boundary never
+// appears.
+//
+// The conserved-identifier note is APPENDED at the tail, not prepended. That
+// placement is load-bearing (#2552): the note summarizes a region that GROWS as
+// messages age out of the retained band, so at the head it sat inside the fold's
+// frozen prefix and changed the prefix bytes every turn, silently defeating the
+// §3 freeze whenever compress and the fold ran together. The tail already varies
+// each turn, so a growing note costs nothing there.
+func CompressView(messages *JSONValue, cfg *FoldConfig) FoldResult {
+	out := FoldResult{ClosetEvict: EvictNone}
+	if messages == nil || !messages.IsArray() || cfg == nil || !cfg.Enabled {
+		return out
+	}
+	count := messages.Len()
+	retained := cfg.RetainedMsgs
+	if retained <= 0 {
+		retained = FoldDefaultRetainedMsgs
+	}
+	keep := cfg.ReasoningExcerptBytes
+	if keep <= 0 {
+		keep = FoldDefaultExcerptBytes
+	}
+	if count <= 0 || retained >= count {
+		return out // nothing ahead of the retained tail
+	}
+	limit := count - retained // messages [0, limit) are compression-eligible
+
+	// Resolve the shared shrink policy ONCE, so this seam and the eager seam
+	// shrink identically. `keep` is the threshold; the tail is capped to keep/2 so
+	// a small excerpt budget keeps the tail proportional.
+	cc := CompactConfig{Enabled: true, Threshold: keep, HeadBytes: cfg.CompactHeadBytes}
+	tailDefault := cfg.CompactTailBytes
+	if tailDefault <= 0 {
+		tailDefault = CompactDefaultTailBytes
+	}
+	if tailCap := keep / 2; tailCap > 0 && tailCap < tailDefault {
+		cc.TailBytes = tailCap
+	} else {
+		cc.TailBytes = tailDefault
+	}
+
+	// Deep-copy the whole transcript, then shrink only oversized bodies in place.
+	// Every message slot, role/type, id and the ordering survive untouched.
+	arr := messages.Clone()
+
+	var set CoordSet
+	compressedRaw := 0
+	compressed := 0
+	for i := 0; i < limit; i++ {
+		if m := arr.At(i); m != nil {
+			n, raw := compressMessageBodies(m, &cc, i, &set)
+			compressed += n
+			compressedRaw += raw
+		}
+	}
+	if compressed == 0 {
+		return out // no body exceeded the threshold -> caller uses the original
+	}
+
+	closet, evict := RenderCloset(&set, cfg.Closet, compressedRaw)
+	out.ClosetEvict = evict
+	if closet != "" {
+		var body strings.Builder
+		fmt.Fprintf(&body,
+			"[compressed %d oversized tool-result body(ies) above; full bodies remain "+
+				"in history — exact identifiers are conserved in the Coordinate Closet]\n\n",
+			compressed)
+		body.WriteString(closet)
+
+		// Keep Anthropic role-alternation intact. Only the ends-with-user case
+		// needs a bridge, and the note must stay LAST so the transcript never ends
+		// on an assistant turn (which would read as a prefill).
+		if tail := arr.At(arr.Len() - 1); tail != nil && tail.GetString("role") == "user" {
+			ack := NewObject()
+			ack.Set("role", NewString("assistant"))
+			ack.Set("content", NewString(
+				"Understood — identifiers from the compressed tool results are conserved below."))
+			arr.Append(ack)
+		}
+		note := NewObject()
+		note.Set("role", NewString("user"))
+		note.Set("content", NewString(body.String()))
+		arr.Append(note)
+	}
+
+	out.Messages = arr
+	out.Folded = true // flag reused to mean "compressed"
+	out.FoldedMsgs = compressed
+	out.RetainedMsgs = retained
+	return out
+}
+
+// FoldView produces a folded view: a synthetic user turn carrying the skeleton
+// plus the Coordinate Closet, a synthetic assistant ack, then the retained tail
+// verbatim.
+//
+// Never mutates its input and never touches the system prompt.
+func FoldView(messages *JSONValue, cfg *FoldConfig, freeze *FoldFreeze) FoldResult {
+	out := FoldResult{ClosetEvict: EvictNone}
+	if messages == nil || !messages.IsArray() || cfg == nil || !cfg.Enabled {
+		return out
+	}
+
+	count := messages.Len()
+	retained := cfg.RetainedMsgs
+	if retained <= 0 {
+		retained = FoldDefaultRetainedMsgs
+	}
+	minFold := cfg.MinFoldMsgs
+	if minFold <= 0 {
+		minFold = FoldDefaultMinFoldMsgs
+	}
+	excerpt := cfg.ReasoningExcerptBytes
+	if excerpt <= 0 {
+		excerpt = FoldDefaultExcerptBytes
+	}
+	if count <= 0 || retained >= count || count-retained < minFold {
+		return out // too short to fold cleanly
+	}
+
+	tailCap := FoldDefaultTailCapMsgs
+	if freeze != nil && freeze.TailCapMsgs > 0 {
+		tailCap = freeze.TailCapMsgs
+	}
+	if tailCap < retained {
+		tailCap = retained // a cap below the retained band would re-epoch every turn
+	}
+
+	split := -1
+	reused := false
+	foldedBytes := 0
+	var dig uint64
+
+	// §3 fold-freeze: reuse the pinned boundary only when it is still a clean
+	// boundary, the tail is within cap, AND the folded prefix is byte-for-byte
+	// unchanged. The digest check turns a mid-run mutation into an epoch rather
+	// than a false "reuse" claiming a warm cache it does not have.
+	if freeze != nil && freeze.Active {
+		fs := freeze.FrozenSplit
+		if fs >= minFold && fs < count && (count-fs) <= tailCap && isCleanUserTurn(messages.At(fs)) {
+			dig, foldedBytes = prefixDigest(messages, fs)
+			if dig == freeze.PrefixDigest {
+				split = fs
+				reused = true
+			}
+		}
+	}
+
+	if !reused {
+		// fresh boundary: first fold, freeze disabled, or an epoch advance
+		desired := count - retained
+		for s := desired; s >= minFold; s-- {
+			if isCleanUserTurn(messages.At(s)) {
+				split = s
+				break
+			}
+		}
+		if split < minFold {
+			return out // no clean boundary leaves enough folded
+		}
+		dig, foldedBytes = prefixDigest(messages, split)
+	}
+
+	var set CoordSet
+	var body strings.Builder
+	fmt.Fprintf(&body,
+		"[folded %d earlier message(s); skeleton below — exact identifiers are conserved in "+
+			"the Coordinate Closet, full bodies remain in history]\n\n", split)
+	for i := 0; i < split; i++ {
+		skeletonMessage(&body, messages.At(i), i, excerpt, cfg.RegisterEnabled, &set)
+	}
+
+	closet, evict := RenderCloset(&set, cfg.Closet, foldedBytes)
+	out.ClosetEvict = evict
+	if closet != "" {
+		body.WriteByte('\n')
+		body.WriteString(closet)
+	}
+
+	arr := NewArray()
+	fm := NewObject()
+	fm.Set("role", NewString("user"))
+	fm.Set("content", NewString(body.String()))
+	arr.Append(fm)
+	ack := NewObject()
+	ack.Set("role", NewString("assistant"))
+	ack.Set("content", NewString("Understood — continuing from the folded summary above."))
+	arr.Append(ack)
+
+	for i := split; i < count; i++ {
+		if item := messages.At(i); item != nil {
+			arr.Append(item.Clone())
+		}
+	}
+
+	// Commit the freeze state only after a successful build. epochs++ counts
+	// genuine boundary advances, not no-op re-commits of the same boundary.
+	if freeze != nil {
+		advanced := !reused && (!freeze.Active || freeze.FrozenSplit != split || freeze.PrefixDigest != dig)
+		freeze.Active = true
+		freeze.FrozenSplit = split
+		freeze.PrefixDigest = dig
+		if advanced {
+			freeze.Epochs++
+		}
+	}
+
+	out.Messages = arr
+	out.Folded = true
+	out.FoldedMsgs = split
+	out.RetainedMsgs = count - split
+	out.ReusedBoundary = reused
+	return out
+}

--- a/server-go/modules/economizer/fold_test.go
+++ b/server-go/modules/economizer/fold_test.go
@@ -1,0 +1,292 @@
+package economizer
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// DIFFERENTIAL test against the real C fold.
+//
+// The golden strings are the VERBATIM cJSON_PrintUnformatted output of
+// context_fold_view / context_compress_view for these fixtures, captured by
+// compiling src/modules/economizer/context_fold.c against a throwaway harness.
+// The C in this tree already carries the #2552 tail-note fix, so the compress
+// golden pins that placement too.
+//
+// This is the test that makes the fold port trustworthy: the folded prefix is
+// the cache key, so equality has to be on BYTES, not on shape.
+
+func mkUser(text string) *JSONValue {
+	m := NewObject()
+	m.Set("role", NewString("user"))
+	m.Set("content", NewString(text))
+	return m
+}
+
+func mkAsst(text string) *JSONValue {
+	m := NewObject()
+	m.Set("role", NewString("assistant"))
+	m.Set("content", NewString(text))
+	return m
+}
+
+// The tool_use input is built zeta-then-alpha ON PURPOSE: it is what proves the
+// skeleton preserves cJSON key order. Go's encoding/json would emit alpha first.
+func mkToolUse(id, name, argval string) *JSONValue {
+	m := NewObject()
+	m.Set("role", NewString("assistant"))
+	c := NewArray()
+	b := NewObject()
+	b.Set("type", NewString("tool_use"))
+	b.Set("id", NewString(id))
+	b.Set("name", NewString(name))
+	in := NewObject()
+	in.Set("zeta", NewString(argval))
+	in.Set("alpha", NewNumber(3))
+	b.Set("input", in)
+	c.Append(b)
+	m.Set("content", c)
+	return m
+}
+
+func mkToolResult(id, body string) *JSONValue {
+	m := NewObject()
+	m.Set("role", NewString("user"))
+	c := NewArray()
+	b := NewObject()
+	b.Set("type", NewString("tool_result"))
+	b.Set("tool_use_id", NewString(id))
+	b.Set("content", NewString(body))
+	c.Append(b)
+	m.Set("content", c)
+	return m
+}
+
+func foldFixture() *JSONValue {
+	m := NewArray()
+	m.Append(mkUser("start job 7fd5835b-1a2b-4c3d-8e9f-0123456789ab"))
+	m.Append(mkToolUse("toolu_1", "read", "/etc/hosts"))
+	m.Append(mkToolResult("toolu_1", "ok; bound on port=3002"))
+	m.Append(mkAsst("read complete"))
+	m.Append(mkUser("next please"))
+	m.Append(mkToolUse("toolu_2", "bash", "ls -la"))
+	m.Append(mkToolResult("toolu_2", "file listing at /var/lib/aimee/x.log"))
+	m.Append(mkAsst("[verdict] listing done"))
+	m.Append(mkUser("keep going"))
+	m.Append(mkAsst("sure"))
+	m.Append(mkUser("almost there"))
+	m.Append(mkAsst("done"))
+	return m
+}
+
+const foldGolden = `[{"role":"user","content":"[folded 8 earlier message(s); skeleton below — exact identifiers are conserved in the Coordinate Closet, full bodies remain in history]\n\nuser: start job 7fd5835b-1a2b-4c3d-8e9f-012345…\n  $ read {\"zeta\":\"/etc/hosts\",\"alpha\":3}\n    → ok; bound on port=3002 (22 bytes)\nassistant/wip: read complete\nuser: next please\n  $ bash {\"zeta\":\"ls -la\",\"alpha\":3}\n    → file listing at /var/lib/aimee/x.log (36 bytes)\nassistant/verdict: [verdict] listing done\n\nCoordinate Closet (conserved from folded turns):\n  /etc/hosts ⟦path⟧\n  /var/lib/aimee/x.log ⟦path⟧\n  3002 ⟦port⟧\n  7fd5835b-1a2b-4c3d-8e9f-0123456789ab ⟦uuid⟧\n"},{"role":"assistant","content":"Understood — continuing from the folded summary above."},{"role":"user","content":"keep going"},{"role":"assistant","content":"sure"},{"role":"user","content":"almost there"},{"role":"assistant","content":"done"}]`
+
+func TestFoldMatchesC(t *testing.T) {
+	cfg := &FoldConfig{
+		Enabled:               true,
+		RetainedMsgs:          4,
+		MinFoldMsgs:           4,
+		ReasoningExcerptBytes: 40,
+		RegisterEnabled:       true,
+		Closet:                ClosetConfig{Enabled: true},
+	}
+	r := FoldView(foldFixture(), cfg, nil)
+	if !r.Folded || r.Messages == nil {
+		t.Fatal("fixture did not fold")
+	}
+	if got := PrintJSONUnformatted(r.Messages); got != foldGolden {
+		t.Errorf("fold output drifted from C:\n got: %s\nwant: %s", got, foldGolden)
+	}
+	if r.FoldedMsgs != 8 || r.RetainedMsgs != 4 || r.ClosetEvict != EvictNone {
+		t.Errorf("meta: folded=%d retained=%d evict=%v, want 8/4/EvictNone",
+			r.FoldedMsgs, r.RetainedMsgs, r.ClosetEvict)
+	}
+}
+
+// The fold must never mutate its input.
+func TestFoldDoesNotMutateInput(t *testing.T) {
+	m := foldFixture()
+	before := PrintJSONUnformatted(m)
+	cfg := &FoldConfig{Enabled: true, RetainedMsgs: 4, MinFoldMsgs: 4,
+		ReasoningExcerptBytes: 40, Closet: ClosetConfig{Enabled: true}}
+	FoldView(m, cfg, nil)
+	if after := PrintJSONUnformatted(m); after != before {
+		t.Error("FoldView mutated its input")
+	}
+}
+
+func compressFixture() *JSONValue {
+	t := NewArray()
+	t.Append(mkUser("do the task"))
+	for k := 0; k < 6; k++ {
+		id := fmt.Sprintf("call_%02d", k)
+		a := NewObject()
+		a.Set("role", NewString("assistant"))
+		tcs := NewArray()
+		tc := NewObject()
+		tc.Set("id", NewString(id))
+		tc.Set("type", NewString("function"))
+		fn := NewObject()
+		fn.Set("name", NewString("read_file"))
+		fn.Set("arguments", NewString("{}"))
+		tc.Set("function", fn)
+		tcs.Append(tc)
+		a.Set("tool_calls", tcs)
+		t.Append(a)
+
+		// Mirrors the C harness byte-for-byte: repeat the filler while
+		// pos+48 < 900-96, then append the tail.
+		var body strings.Builder
+		for body.Len()+48 < 900-96 {
+			body.WriteString("filler output bytes here; ")
+		}
+		fmt.Fprintf(&body, "tail at /work/src/stage_%d.c done", k)
+
+		tr := NewObject()
+		tr.Set("role", NewString("tool"))
+		tr.Set("tool_call_id", NewString(id))
+		tr.Set("content", NewString(body.String()))
+		t.Append(tr)
+	}
+	return t
+}
+
+func TestCompressMatchesC(t *testing.T) {
+	cfg := &FoldConfig{
+		Enabled:               true,
+		RetainedMsgs:          4,
+		ReasoningExcerptBytes: 120,
+		CompactHeadBytes:      40,
+		Closet:                ClosetConfig{Enabled: true},
+	}
+	r := CompressView(compressFixture(), cfg)
+	if !r.Folded || r.Messages == nil {
+		t.Fatal("fixture did not compress")
+	}
+	if r.FoldedMsgs != 4 || r.ClosetEvict != EvictNone {
+		t.Errorf("meta: compressed=%d evict=%v, want 4/EvictNone", r.FoldedMsgs, r.ClosetEvict)
+	}
+
+	n := r.Messages.Len()
+	last := r.Messages.At(n - 1)
+	// #2552: the conserving note is APPENDED, never prepended.
+	if last.GetString("role") != "user" ||
+		!strings.Contains(last.GetString("content"), "Coordinate Closet") {
+		t.Fatalf("closet note is not the final message: %s", PrintJSONUnformatted(last))
+	}
+	if strings.Contains(r.Messages.At(0).GetString("content"), "Coordinate Closet") {
+		t.Error("closet note must not sit at the head — that is what broke the freeze")
+	}
+	// The original first turn is still first.
+	if r.Messages.At(0).GetString("content") != "do the task" {
+		t.Error("compress reordered the transcript head")
+	}
+	// Buried identifiers past the excerpt window survive via the closet.
+	for k := 0; k < 4; k++ {
+		want := fmt.Sprintf("/work/src/stage_%d.c", k)
+		if !strings.Contains(last.GetString("content"), want) {
+			t.Errorf("closet lost %s", want)
+		}
+	}
+	// The retained tail kept its full bodies.
+	if body := r.Messages.At(n - 2).GetString("content"); !strings.Contains(body, "stage_5.c") ||
+		strings.Contains(body, "bytes omitted") {
+		t.Error("retained tail should not have been compressed")
+	}
+}
+
+// The freeze holds a boundary across turns and re-epochs when the tail outgrows
+// its cap — the property the prompt cache depends on.
+func TestFoldFreezeReusesBoundary(t *testing.T) {
+	cfg := &FoldConfig{Enabled: true, RetainedMsgs: 4, MinFoldMsgs: 4,
+		ReasoningExcerptBytes: 40, Closet: ClosetConfig{Enabled: true}}
+	m := foldFixture()
+	fz := &FoldFreeze{TailCapMsgs: 12}
+
+	r1 := FoldView(m, cfg, fz)
+	if !r1.Folded || r1.ReusedBoundary {
+		t.Fatal("first fold should pin, not reuse")
+	}
+	pinned := fz.FrozenSplit
+	prefix1 := PrintJSONUnformatted(r1.Messages.At(0))
+
+	// Append a round: prefix unchanged and tail within cap -> reuse, and the
+	// emitted prefix must be BYTE-identical.
+	m.Append(mkUser("another request"))
+	m.Append(mkAsst("another answer"))
+	r2 := FoldView(m, cfg, fz)
+	if !r2.ReusedBoundary || fz.FrozenSplit != pinned {
+		t.Fatalf("second fold should reuse the pinned boundary (reused=%v split=%d/%d)",
+			r2.ReusedBoundary, fz.FrozenSplit, pinned)
+	}
+	if got := PrintJSONUnformatted(r2.Messages.At(0)); got != prefix1 {
+		t.Error("reused boundary must yield a byte-identical prefix")
+	}
+
+	// Mutating the folded prefix must force an epoch, not a false reuse.
+	epochsBefore := fz.Epochs
+	m.At(0).Set("content", NewString("MUTATED prefix content"))
+	m.Append(mkUser("carry on"))
+	m.Append(mkAsst("sure"))
+	r3 := FoldView(m, cfg, fz)
+	if r3.ReusedBoundary || fz.Epochs != epochsBefore+1 {
+		t.Errorf("prefix mutation must epoch: reused=%v epochs=%d->%d",
+			r3.ReusedBoundary, epochsBefore, fz.Epochs)
+	}
+}
+
+// A transcript with no clean user-turn boundary must not fold at all.
+func TestFoldNoCleanBoundary(t *testing.T) {
+	m := NewArray()
+	m.Append(mkUser("start"))
+	for k := 0; k < 10; k++ {
+		id := fmt.Sprintf("toolu_%02d", k)
+		m.Append(mkToolUse(id, "read", "/x"))
+		m.Append(mkToolResult(id, "result body"))
+	}
+	cfg := &FoldConfig{Enabled: true, RetainedMsgs: 4, MinFoldMsgs: 4,
+		ReasoningExcerptBytes: 40, Closet: ClosetConfig{Enabled: true}}
+	if r := FoldView(m, cfg, nil); r.Folded {
+		t.Error("a tool loop has no clean boundary and must not fold")
+	}
+}
+
+func TestFoldDisabledAndTooShort(t *testing.T) {
+	cfg := &FoldConfig{Enabled: true, RetainedMsgs: 4, MinFoldMsgs: 4}
+	if r := FoldView(foldFixture(), &FoldConfig{Enabled: false}, nil); r.Folded {
+		t.Error("disabled fold must not fold")
+	}
+	short := NewArray()
+	short.Append(mkUser("hi"))
+	short.Append(mkAsst("hello"))
+	if r := FoldView(short, cfg, nil); r.Folded {
+		t.Error("too-short transcript must not fold")
+	}
+}
+
+// Identical input must fold to identical bytes — the determinism the freeze and
+// the cache both rest on.
+func TestFoldDeterministic(t *testing.T) {
+	cfg := &FoldConfig{Enabled: true, RetainedMsgs: 4, MinFoldMsgs: 4,
+		ReasoningExcerptBytes: 40, Closet: ClosetConfig{Enabled: true}}
+	a := FoldView(foldFixture(), cfg, nil)
+	b := FoldView(foldFixture(), cfg, nil)
+	if PrintJSONUnformatted(a.Messages) != PrintJSONUnformatted(b.Messages) {
+		t.Error("identical input must produce identical folded bytes")
+	}
+}
+
+// Multi-byte characters must not be split by the excerpt cap.
+func TestFoldExcerptUTF8Boundary(t *testing.T) {
+	var b strings.Builder
+	appendExcerpt(&b, strings.Repeat("é", 20), 5) // é is 2 bytes; 5 lands mid-char
+	got := b.String()
+	trimmed := strings.TrimSuffix(got, "…")
+	if len(trimmed)%2 != 0 {
+		t.Errorf("excerpt split a multibyte character: %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncation must be marked: %q", got)
+	}
+}

--- a/server-go/modules/economizer/jsonval.go
+++ b/server-go/modules/economizer/jsonval.go
@@ -1,0 +1,131 @@
+package economizer
+
+// Small accessors over JSONValue, so the ported fold reads like the C it came
+// from (cJSON_GetObjectItem / cJSON_GetStringValue / cJSON_Duplicate) instead of
+// open-coding index lookups at every call site.
+
+// NewString builds a JSON string value.
+func NewString(s string) *JSONValue { return &JSONValue{Kind: JSONString, Str: s} }
+
+// NewNumber builds a JSON number value.
+func NewNumber(n float64) *JSONValue { return &JSONValue{Kind: JSONNumber, Num: n} }
+
+// NewObject builds an empty JSON object.
+func NewObject() *JSONValue { return &JSONValue{Kind: JSONObject} }
+
+// NewArray builds an empty JSON array.
+func NewArray() *JSONValue { return &JSONValue{Kind: JSONArray} }
+
+// Get returns the value for key, or nil. Case-sensitive, like the
+// cJSON_GetObjectItemCaseSensitive the module uses throughout.
+func (v *JSONValue) Get(key string) *JSONValue {
+	if v == nil || v.Kind != JSONObject {
+		return nil
+	}
+	for i, k := range v.Keys {
+		if k == key {
+			return v.Vals[i]
+		}
+	}
+	return nil
+}
+
+// GetString returns the string at key, or "" when absent or not a string.
+func (v *JSONValue) GetString(key string) string {
+	child := v.Get(key)
+	if child == nil || child.Kind != JSONString {
+		return ""
+	}
+	return child.Str
+}
+
+// Set assigns key, appending it (preserving insertion order) or replacing in
+// place if it already exists.
+func (v *JSONValue) Set(key string, val *JSONValue) {
+	if v == nil || v.Kind != JSONObject {
+		return
+	}
+	for i, k := range v.Keys {
+		if k == key {
+			v.Vals[i] = val
+			return
+		}
+	}
+	v.Keys = append(v.Keys, key)
+	v.Vals = append(v.Vals, val)
+}
+
+// Append adds an element to an array.
+func (v *JSONValue) Append(item *JSONValue) {
+	if v == nil || v.Kind != JSONArray {
+		return
+	}
+	v.Items = append(v.Items, item)
+}
+
+// Len is the element count for an array, or the key count for an object.
+func (v *JSONValue) Len() int {
+	if v == nil {
+		return 0
+	}
+	switch v.Kind {
+	case JSONArray:
+		return len(v.Items)
+	case JSONObject:
+		return len(v.Keys)
+	}
+	return 0
+}
+
+// At returns array element i, or nil when out of range.
+func (v *JSONValue) At(i int) *JSONValue {
+	if v == nil || v.Kind != JSONArray || i < 0 || i >= len(v.Items) {
+		return nil
+	}
+	return v.Items[i]
+}
+
+// IsString reports whether v is a JSON string.
+func (v *JSONValue) IsString() bool { return v != nil && v.Kind == JSONString }
+
+// IsArray reports whether v is a JSON array.
+func (v *JSONValue) IsArray() bool { return v != nil && v.Kind == JSONArray }
+
+// Clone deep-copies v, mirroring cJSON_Duplicate(item, 1). The fold never
+// mutates its input, so every published message is a copy.
+func (v *JSONValue) Clone() *JSONValue {
+	if v == nil {
+		return nil
+	}
+	out := &JSONValue{Kind: v.Kind, Str: v.Str, Num: v.Num, Bool: v.Bool}
+	if len(v.Keys) > 0 {
+		out.Keys = append([]string(nil), v.Keys...)
+		out.Vals = make([]*JSONValue, len(v.Vals))
+		for i, child := range v.Vals {
+			out.Vals[i] = child.Clone()
+		}
+	}
+	if len(v.Items) > 0 {
+		out.Items = make([]*JSONValue, len(v.Items))
+		for i, child := range v.Items {
+			out.Items[i] = child.Clone()
+		}
+	}
+	return out
+}
+
+// Text renders v as the text a body carries: a string value yields its contents
+// verbatim, anything else its serialized JSON.
+//
+// This mirrors the C pattern of using valuestring when the node is a string and
+// cJSON_PrintUnformatted otherwise, which is why the printer has to be
+// cJSON-compatible — the serialized form ends up inside the folded prefix.
+func (v *JSONValue) Text() (string, bool) {
+	if v == nil {
+		return "", false
+	}
+	if v.Kind == JSONString {
+		return v.Str, true
+	}
+	return PrintJSONUnformatted(v), true
+}


### PR DESCRIPTION
Ports `src/modules/economizer/context_fold.c` (643 lines): the rolling history fold, the §3 fold-freeze with its prefix digest, and the boundary-free tool-body compress view. **63 tests** in the package, `go vet`/`gofmt` clean, tree builds.

**Stacked on #2556** (the cJSON-compatible printer), which is what makes this port possible at all.

## Verified differentially, byte-for-byte

The goldens in `fold_test.go` are the verbatim `cJSON_PrintUnformatted` output of `context_fold_view` and `context_compress_view` for the same fixtures, captured by compiling the real C against a throwaway harness (deleted; not in this commit). Equality is asserted on the **entire emitted array**, not on shape — because the folded prefix is the cache key, and a shape-only assertion cannot see a cold cache.

The C in this tree already carries #2552, so the compress golden pins the tail-note placement too: the note is the **last** message, and a test asserts it is *not* at the head — which is exactly what broke the freeze before.

## What the golden proves about the printer

The skeleton contains:

```
$ read {"zeta":"/etc/hosts","alpha":3}
```

Key order preserved (`zeta` before `alpha`, as constructed) and `3` rather than `3.0`. Go's `encoding/json` would have emitted `{"alpha":3,"zeta":...}` and the entire prefix would differ on every turn. The fixture builds that input zeta-first **deliberately**, so the ordering is load-bearing in the test rather than incidental.

## Covered beyond the goldens

- The fold never mutates its input.
- The freeze holds a boundary across turns and yields a **byte-identical** prefix on reuse.
- Mutating the folded prefix forces an **epoch** rather than a false reuse claiming a warm cache it does not have.
- A tool loop with no clean user-turn boundary does not fold at all — the case the compress lever exists for.
- Identical input folds to identical bytes.
- The excerpt cap backs off multibyte boundaries instead of splitting a character.

## Also

Adds `jsonval.go` — small accessors over `JSONValue` (`Get`/`GetString`/`Set`/`Append`/`Clone`/`Text`) so the ported code reads like the cJSON it came from instead of open-coding index lookups at every call site.

## Status

Port is roughly **45%** by line count. Still not wired: nothing dispatches to this package, so it remains inert code beside the live C rather than a second live implementation.

Next: `context_reduce.c` (607 ln, the orchestrator — including the composed prefix-stability test from #2552), then `tool_condense.c` (1,179), the provider shims, rails/seals, the gateway wire files, the module descriptor and contracts, and the C cut-over.

Carried, both still open: the dead C seam `agent_compress_tool_result` should be **deleted** rather than kept beside its Go port (#2554), and the OpenAI-family cache telemetry gap (`aimee_backend_openai.c:412`, `aimee_backend_responses.c:298`) remains live in production.
