### PR TITLE
port(economizer): context_reduce — the orchestrator

### DIFF
--- a/server-go/modules/economizer/reduce.go
+++ b/server-go/modules/economizer/reduce.go
@@ -1,0 +1,411 @@
+package economizer
+
+import "strings"
+
+// The context_reduce orchestrator: composes the levers, applies the freeze cost
+// guardrail, tracks the page table, and reports the ledger.
+//
+// Ported from src/modules/economizer/context_reduce.c.
+
+// charsPerTokenEst is the chars/4 token estimate the module uses throughout.
+// A forecast, not an invoice: token COUNTS are caching-independent, but the
+// number of tokens a provider actually bills is its tokenizer's business.
+const charsPerTokenEst = 4
+
+// FreezeGuardMaxHorizon caps the configured horizon, so a misconfigured long
+// horizon cannot justify an unbounded cache-write bet on a single run.
+const FreezeGuardMaxHorizon = 5
+
+// Seam identifies where the reducer is running.
+type Seam int
+
+const (
+	SeamGateway Seam = iota
+	SeamDelegate
+)
+
+// ReduceReason records why a request did or did not reduce.
+type ReduceReason int
+
+const (
+	ReasonNone       ReduceReason = iota // no lever enabled at this seam
+	ReasonReduced                        // reduction applied
+	ReasonMeasured                       // measure-only: metrics computed, not mutated
+	ReasonSkipNoGain                     // foldable tokens below MinGainTokens
+	ReasonAlready                        // provenance: a prior seam already reduced
+)
+
+// PriceRates are the per-token provider rates the freeze guardrail needs.
+//
+// Passed IN rather than looked up, because the pricing table lives with the
+// caller. That keeps this module a pure transformer with no ambient state, which
+// is what lets it serve a bus stage without owning a config or pricing
+// connection. Priced=false means the model is unknown and the guard fails open.
+type PriceRates struct {
+	Priced    bool
+	InputCost float64
+	WriteCost float64
+	ReadCost  float64
+}
+
+// ReduceConfig mirrors reduce_config_t. All levers default off.
+type ReduceConfig struct {
+	// Per-lever gates.
+	HistoryFold bool // rolling history skeleton + Coordinate Closet
+	Compress    bool // boundary-free tool-result BODY compression
+
+	// Per-seam enable: a lever only runs at a seam that is on.
+	GatewaySeam  bool
+	DelegateSeam bool
+
+	// Shadow mode: compute the ledger but DO NOT mutate the messages.
+	MeasureOnly bool
+
+	// Net-gain pre-check: skip fold when foldable tokens < this (0 -> no check).
+	MinGainTokens int
+
+	// Freeze cost guardrail. The freeze pins the fold boundary so the reduced
+	// prefix stays byte-identical (cache-warm) turn to turn — but a boundary that
+	// keeps advancing forces provider cache WRITES that can flip reduction
+	// net-negative. When enabled, the boundary is pinned only when the estimated
+	// cache-read savings over Horizon reuses cover the one-time write.
+	FreezeGuardEnabled bool
+	FreezeGuardHorizon int
+	Rates              PriceRates
+
+	// §4 page table. Requires state: the index has to outlive a single call.
+	RecallEnabled  bool
+	RecallTTLTurns int
+	// RecallInject appends the hint to the transcript instead of only reporting
+	// it. Separate from RecallEnabled on purpose: tracking what was evicted is
+	// inert, whereas putting a line in front of the model CHANGES WHAT IT DOES.
+	RecallInject bool
+
+	Fold FoldConfig
+}
+
+// ReduceState is per-CONVERSATION reducer state, owned by the caller and
+// persisted across turns within one conversation. NOT shared across
+// agents/sessions — cross-session sharing would leak context.
+type ReduceState struct {
+	Freeze  FoldFreeze
+	Reduced bool // provenance: a second seam re-measures but does NOT re-reduce
+	Turn    int
+	Recall  *RecallIndex
+}
+
+// ReduceResult is the reduced view plus the ledger.
+type ReduceResult struct {
+	Messages *JSONValue // NEW array when mutated; nil means "use your original"
+	Mutated  bool
+
+	Reason ReduceReason
+
+	BaselineTokens int
+	ReducedTokens  int
+	RemovedTokens  int
+	FoldableTokens int
+
+	EstSavedCostFloor   float64
+	EstSavedCostCeiling float64
+
+	FoldedMsgs     int
+	RetainedMsgs   int
+	ReusedBoundary bool
+	Epochs         int
+	FreezeGuarded  bool
+	ClosetEvict    EvictResult
+
+	RecallHint     string
+	RecallSurfaced int
+}
+
+// FreezeFavorableRates decides whether pinning the boundary pays, from rates
+// alone. Scale-invariant, so the prefix size cancels out.
+func FreezeFavorableRates(inputCost, writeCost, readCost float64, horizon int) bool {
+	if horizon <= 0 {
+		horizon = 1 // one future reuse is enough to justify one write
+	}
+	if horizon > FreezeGuardMaxHorizon {
+		horizon = FreezeGuardMaxHorizon
+	}
+
+	// Per-reuse saving = paying the cache-READ rate instead of the FRESH input
+	// rate. Checked FIRST: with no read discount caching can never pay, so skip
+	// the freeze REGARDLESS of write cost — a free write that yields no read
+	// benefit is still not worth pinning a boundary for.
+	perReuseSaving := inputCost - readCost
+	if perReuseSaving <= 0 {
+		return false
+	}
+
+	// The MARGINAL cost of caching is the write PREMIUM over sending the prefix
+	// fresh once (you pay the input rate on the first turn regardless) — NOT the
+	// full write cost. Providers with free cache creation have a premium <= 0, so
+	// freezing is pure upside.
+	writePremium := writeCost - inputCost
+	if writePremium <= 0 {
+		return true
+	}
+	return float64(horizon)*perReuseSaving >= writePremium
+}
+
+// freezeCostFavorable applies the guardrail for a given prefix size, failing
+// open whenever it cannot know better.
+func freezeCostFavorable(rates PriceRates, prefixTokens, horizon int) bool {
+	if prefixTokens <= 0 {
+		return true // nothing to cache -> no churn possible
+	}
+	if !rates.Priced {
+		return true // fail-open: unpriced model -> do not regress onto it
+	}
+	return FreezeFavorableRates(rates.InputCost, rates.WriteCost, rates.ReadCost, horizon)
+}
+
+// nodeTokenEstimate is the chars/4 estimate of a serialized node.
+func nodeTokenEstimate(node *JSONValue) int {
+	if node == nil {
+		return 0
+	}
+	return len(PrintJSONUnformatted(node)) / charsPerTokenEst
+}
+
+// prefixTokenEstimate estimates the first count items of an array.
+func prefixTokenEstimate(messages *JSONValue, count int) int {
+	if messages == nil || count <= 0 {
+		return 0
+	}
+	total := 0
+	for i := 0; i < count && i < messages.Len(); i++ {
+		total += len(PrintJSONUnformatted(messages.At(i)))
+	}
+	return total / charsPerTokenEst
+}
+
+// recallTrack harvests coordinates out of the evicted region and surfaces any
+// the newest turn re-touches.
+func recallTrack(original *JSONValue, evictedCount int, cfg *ReduceConfig, st *ReduceState, out *ReduceResult) {
+	if !cfg.RecallEnabled || st == nil || original == nil || !original.IsArray() {
+		return
+	}
+	if st.Recall == nil {
+		st.Recall = NewRecallIndex()
+	}
+	n := original.Len()
+	if evictedCount > n {
+		evictedCount = n
+	}
+	for i := 0; i < evictedCount; i++ {
+		st.Recall.AddFromText(PrintJSONUnformatted(original.At(i)))
+	}
+	if st.Recall.Len() == 0 || n == 0 {
+		return
+	}
+	// Detect on the NEWEST turn only: that is the one the agent just wrote, so a
+	// coordinate it mentions there is one it is reaching for now.
+	lastTxt := PrintJSONUnformatted(original.At(n - 1))
+	var hints strings.Builder
+	surfaced := st.Recall.Detect(lastTxt, st.Turn, cfg.RecallTTLTurns, &hints)
+	if surfaced > 0 && hints.Len() > 0 {
+		out.RecallHint = hints.String()
+		out.RecallSurfaced = surfaced
+	}
+}
+
+// recallInject puts the hint in front of the model, at the END of the transcript.
+//
+// Not the folded prefix and not the system prompt: both are deliberately stable
+// so the prompt cache stays warm (§3 freeze), and a per-turn line in either would
+// bust the very cache the rest of the economizer exists to protect.
+//
+// Framed explicitly as a system notice. An unlabelled line appended after the
+// user's turn reads as something the USER said, which is both wrong and a way for
+// evicted text to put words in their mouth.
+//
+// Appends rather than splices, so it cannot land between an assistant tool_use
+// and its matching tool_result — the one structural mistake that would make the
+// request invalid.
+func recallInject(reduced *JSONValue, out *ReduceResult) {
+	if reduced == nil || !reduced.IsArray() || out.RecallHint == "" {
+		return
+	}
+	var body strings.Builder
+	body.WriteString("[context notice — not from the user] Earlier turns were folded " +
+		"out of this transcript. You referenced something that went with " +
+		"them; it is PAGEABLE, not lost:\n")
+	body.WriteString(out.RecallHint)
+	note := NewObject()
+	note.Set("role", NewString("user"))
+	note.Set("content", NewString(body.String()))
+	reduced.Append(note)
+}
+
+// Reduce composes the levers over messages and reports the ledger.
+//
+// Never mutates its input. When a lever ran, Messages is a NEW array and Mutated
+// is true; otherwise Messages is nil and the caller forwards its original.
+func Reduce(messages *JSONValue, systemPrompt string, seam Seam, cfg *ReduceConfig, st *ReduceState) ReduceResult {
+	var out ReduceResult
+	if messages == nil || !messages.IsArray() {
+		out.Reason = ReasonNone
+		return out
+	}
+
+	// Per-seam gate: the economizer only engages at a seam the operator enabled.
+	seamOn := cfg != nil && ((seam == SeamGateway && cfg.GatewaySeam) ||
+		(seam == SeamDelegate && cfg.DelegateSeam))
+	if !seamOn {
+		out.Reason = ReasonNone
+		return out
+	}
+
+	// Baseline = assembled-context tokens. The system prompt is the immutable
+	// prefix zone — counted, never reduced. The +1 is a one-token allowance so a
+	// present (even tiny) system prompt is never estimated as zero.
+	baseline := nodeTokenEstimate(messages)
+	if systemPrompt != "" {
+		baseline += len(systemPrompt)/charsPerTokenEst + 1
+	}
+	out.BaselineTokens = baseline
+	out.ReducedTokens = baseline
+	out.RemovedTokens = 0
+
+	// Provenance: a request can cross both seams. If a prior seam already
+	// reduced, re-measure the baseline but do NOT re-account the opportunity —
+	// that saving belongs to the seam that performed it.
+	if st != nil && st.Reduced {
+		out.Reason = ReasonAlready
+		return out
+	}
+
+	retained := cfg.Fold.RetainedMsgs
+	if retained <= 0 {
+		retained = FoldDefaultRetainedMsgs
+	}
+	n := messages.Len()
+	foldableMsgs := 0
+	if n > retained {
+		foldableMsgs = n - retained
+	}
+	out.FoldableTokens = prefixTokenEstimate(messages, foldableMsgs)
+
+	work := messages
+	var compressedOwned *JSONValue
+
+	// Compress runs FIRST so the fold, when also enabled, sees already-shrunk
+	// bodies. Unlike the fold it needs no clean-user-turn boundary, so it engages
+	// on autonomous tool-loops where the fold never can.
+	if cfg.Compress && !cfg.MeasureOnly {
+		cc := FoldConfig{
+			Enabled:               true,
+			RetainedMsgs:          cfg.Fold.RetainedMsgs,
+			ReasoningExcerptBytes: cfg.Fold.ReasoningExcerptBytes,
+			CompactHeadBytes:      cfg.Fold.CompactHeadBytes,
+			CompactTailBytes:      cfg.Fold.CompactTailBytes,
+			Closet:                cfg.Fold.Closet,
+		}
+		if cr := CompressView(work, &cc); cr.Folded && cr.Messages != nil {
+			compressedOwned = cr.Messages
+			work = compressedOwned
+			out.Mutated = true
+			out.Reason = ReasonReduced
+			out.FoldedMsgs = cr.FoldedMsgs // bodies compressed; fold may overwrite
+			out.ClosetEvict = cr.ClosetEvict
+			if st != nil {
+				st.Reduced = true
+			}
+		}
+	}
+
+	if cfg.HistoryFold && !cfg.MeasureOnly {
+		// Net-gain pre-check: skip when the foldable opportunity is below the
+		// operator's round-trip recovery threshold.
+		if cfg.MinGainTokens > 0 && out.FoldableTokens < cfg.MinGainTokens {
+			if compressedOwned == nil {
+				out.Reason = ReasonSkipNoGain
+				out.Mutated = false
+				out.Messages = nil
+				return out
+			}
+			// compress mutated -> publish below; do not run fold
+		} else {
+			fc := cfg.Fold
+			fc.Enabled = true
+
+			// Freeze cost guardrail: pin the boundary only when the cache-read
+			// savings cover the write churn; otherwise this turn re-derives
+			// without pinning.
+			var freezeArg *FoldFreeze
+			if st != nil {
+				freezeArg = &st.Freeze
+			}
+			if freezeArg != nil && cfg.FreezeGuardEnabled &&
+				!freezeCostFavorable(cfg.Rates, out.FoldableTokens, cfg.FreezeGuardHorizon) {
+				freezeArg = nil
+				out.FreezeGuarded = true
+			}
+
+			if fr := FoldView(work, &fc, freezeArg); fr.Folded && fr.Messages != nil {
+				out.Messages = fr.Messages
+				out.Mutated = true
+				out.Reason = ReasonReduced
+				out.FoldedMsgs = fr.FoldedMsgs
+				out.RetainedMsgs = fr.RetainedMsgs
+				out.ReusedBoundary = fr.ReusedBoundary
+				out.ClosetEvict = fr.ClosetEvict
+				if st != nil {
+					out.Epochs = st.Freeze.Epochs
+					st.Reduced = true
+				}
+				compressedOwned = nil
+
+				// The fold is the only lever that removes whole MESSAGES, so it is
+				// the only one whose eviction the page table must record. Compression
+				// shrinks bodies in place — the carrying message stays visible, so
+				// nothing has left the prompt to page back in.
+				recallTrack(messages, fr.FoldedMsgs, cfg, st, &out)
+				if cfg.RecallInject {
+					recallInject(out.Messages, &out)
+				}
+			}
+		}
+	}
+
+	// Publish the compress-only result when the fold was disabled or no-opped.
+	if compressedOwned != nil && out.Messages == nil {
+		out.Messages = compressedOwned
+	}
+
+	// Recompute the reduced/removed forecast once, over whatever view a lever
+	// produced. The system prompt is counted but never reduced.
+	if out.Mutated && out.Messages != nil {
+		reduced := nodeTokenEstimate(out.Messages)
+		if systemPrompt != "" {
+			reduced += len(systemPrompt)/charsPerTokenEst + 1
+		}
+		out.ReducedTokens = reduced
+		if baseline > reduced {
+			out.RemovedTokens = baseline - reduced
+		}
+	}
+
+	// Cost forecast bracket: floor prices the basis at the CACHE-READ rate
+	// (cache-warm), ceiling at the FRESH input rate (cache-cold). A forecast, never
+	// the headline — the invoice-quality number is realized provider spend.
+	basis := out.RemovedTokens
+	if basis == 0 {
+		basis = out.FoldableTokens
+	}
+	if cfg.Rates.Priced && basis > 0 {
+		out.EstSavedCostFloor = cfg.Rates.ReadCost * float64(basis)
+		out.EstSavedCostCeiling = cfg.Rates.InputCost * float64(basis)
+	}
+
+	// Only the measure path falls through with the reason still unset.
+	if out.Reason == ReasonNone {
+		out.Reason = ReasonMeasured
+		out.Mutated = false
+		out.Messages = nil
+	}
+	return out
+}

--- a/server-go/modules/economizer/reduce_test.go
+++ b/server-go/modules/economizer/reduce_test.go
@@ -1,0 +1,329 @@
+package economizer
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Ported from src/tests/test_context_reduce.c.
+
+func makeMessages(rounds int) *JSONValue {
+	arr := NewArray()
+	for i := 0; i < rounds; i++ {
+		arr.Append(mkUser("please read the file and summarize the relevant section in detail"))
+		arr.Append(mkAsst("here is a fairly long assistant turn that adds bytes to the transcript " +
+			"so the fold-eligible prefix carries real token volume across many turns of the session"))
+	}
+	return arr
+}
+
+// Append one realistic turn: a user ask, an assistant tool_call, a bulky tool
+// result, and an assistant reply — so BOTH levers have something to do.
+func appendTurn(m *JSONValue, k int) {
+	id := fmt.Sprintf("call_%03d", k)
+	m.Append(mkUser("keep going on the migration and report what changed"))
+
+	a := NewObject()
+	a.Set("role", NewString("assistant"))
+	tcs := NewArray()
+	tc := NewObject()
+	tc.Set("id", NewString(id))
+	tc.Set("type", NewString("function"))
+	fn := NewObject()
+	fn.Set("name", NewString("read_file"))
+	fn.Set("arguments", NewString("{}"))
+	tc.Set("function", fn)
+	tcs.Append(tc)
+	a.Set("tool_calls", tcs)
+	m.Append(a)
+
+	var body strings.Builder
+	for body.Len()+48 < 900-96 {
+		body.WriteString("filler output bytes here and on; ")
+	}
+	fmt.Fprintf(&body, "tail at /work/src/stage_%d.c done", k)
+	tr := NewObject()
+	tr.Set("role", NewString("tool"))
+	tr.Set("tool_call_id", NewString(id))
+	tr.Set("content", NewString(body.String()))
+	m.Append(tr)
+
+	m.Append(mkAsst("read the stage file and applied the change; moving to the next one " +
+		"now that the previous edit is confirmed good"))
+}
+
+// THE CACHE CLAIM, through the composed reducer. This is the Go form of the test
+// that found the compress-defeats-freeze bug (#2552).
+//
+// The freeze exists so the reduced PREFIX stays byte-identical turn to turn and
+// the provider prompt cache keeps hitting. fold_test.go proves that for the fold
+// lever alone — but production stacks compress AHEAD of fold and the fold digests
+// the COMPRESSED view, so a compressor whose output for the prefix region drifts
+// as the retained band slides would silently epoch the freeze and bust the cache
+// with every lever still reporting success.
+//
+// The invariant, stated honestly: while the epoch counter holds, the emitted
+// prefix must be byte-identical; a changed prefix is legal ONLY on an epoch
+// advance. Bytes are compared, not token counts — a cache hit is a bytewise
+// prefix match, so anything weaker would pass on a prefix that merely looks the
+// same.
+//
+// RecallInject is deliberately ON: tail placement is claimed to be cache-safe. If
+// the hint ever landed in the prefix instead, this fails.
+func TestReducePrefixStableAcrossTurns(t *testing.T) {
+	m := NewArray()
+	for k := 0; k < 8; k++ {
+		appendTurn(m, k)
+	}
+
+	cfg := &ReduceConfig{
+		DelegateSeam:  true,
+		HistoryFold:   true,
+		Compress:      true,
+		RecallEnabled: true,
+		RecallInject:  true,
+		Fold: FoldConfig{
+			Closet:           ClosetConfig{Enabled: true},
+			CompactHeadBytes: 40,
+		},
+	}
+	st := &ReduceState{Freeze: FoldFreeze{TailCapMsgs: 16}, Recall: NewRecallIndex()}
+
+	prevPrefix := ""
+	prevEpochs := -1
+	reuses, epochs := 0, 0
+
+	for turn := 0; turn < 14; turn++ {
+		st.Turn = turn
+		out := Reduce(m, "sys", SeamDelegate, cfg, st)
+		st.Reduced = false // next turn is a fresh request, not a second seam
+
+		if out.Mutated && out.Messages != nil {
+			prefix := PrintJSONUnformatted(out.Messages.At(0))
+			if prevPrefix != "" {
+				if out.Epochs == prevEpochs {
+					// No epoch advance -> the cache MUST still be warm.
+					if prefix != prevPrefix {
+						t.Fatalf("turn %d: prefix changed without an epoch advance", turn)
+					}
+					reuses++
+				} else {
+					if out.Epochs < prevEpochs {
+						t.Fatalf("turn %d: epochs went backwards", turn)
+					}
+					epochs++
+				}
+			}
+			prevPrefix = prefix
+			prevEpochs = out.Epochs
+		}
+		appendTurn(m, 100+turn)
+	}
+
+	// Guard the guard: a run where the fold never engaged, or never held a
+	// boundary across a turn, would satisfy every assertion above vacuously.
+	if reuses == 0 {
+		t.Fatal("no cache-warm reuse happened — the assertions above were vacuous")
+	}
+	t.Logf("%d cache-warm reuses, %d epoch advance(s)", reuses, epochs)
+}
+
+// The freeze cost guardrail, ported from test_freeze_guard's rate arithmetic.
+func TestReduceFreezeFavorableRates(t *testing.T) {
+	cases := []struct {
+		name               string
+		input, write, read float64
+		horizon            int
+		want               bool
+	}{
+		{"anthropic-like at H=1", 3.0, 3.75, 0.30, 1, true},
+		{"free write, no read discount -> skip", 1.0, 0.0, 1.0, 1, false},
+		{"free write with read discount", 1.0, 0.0, 0.10, 1, true},
+		{"premium far exceeds saving", 1.0, 10.0, 0.10, 1, false},
+		{"horizon clamp cannot cover it", 1.0, 10.0, 0.10, 9999, false},
+		{"mild premium missed at H=1", 1.0, 3.0, 0.10, 1, false},
+		{"same premium covered at H=3", 1.0, 3.0, 0.10, 3, true},
+	}
+	for _, c := range cases {
+		if got := FreezeFavorableRates(c.input, c.write, c.read, c.horizon); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// The guard fails OPEN: an unpriced model or a zero-size prefix must not disable
+// a freeze that would otherwise run.
+func TestReduceFreezeGuardFailsOpen(t *testing.T) {
+	if !freezeCostFavorable(PriceRates{Priced: false}, 100000, 1) {
+		t.Error("unpriced model must fail open")
+	}
+	if !freezeCostFavorable(PriceRates{Priced: true, InputCost: 1, WriteCost: 99, ReadCost: 1}, 0, 1) {
+		t.Error("zero prefix must fail open")
+	}
+}
+
+// A seam that is not enabled is a true no-op: no measurement, no mutation.
+func TestReduceSeamGating(t *testing.T) {
+	m := makeMessages(20)
+	cfg := &ReduceConfig{DelegateSeam: true, HistoryFold: true}
+	out := Reduce(m, "sys", SeamGateway, cfg, nil)
+	if out.Reason != ReasonNone || out.Mutated || out.BaselineTokens != 0 {
+		t.Errorf("disabled seam must be a true no-op: %+v", out)
+	}
+	if out2 := Reduce(m, "sys", SeamDelegate, nil, nil); out2.Reason != ReasonNone {
+		t.Error("nil config must be a no-op")
+	}
+}
+
+// measure_only computes the ledger without touching the transcript.
+func TestReduceMeasureOnly(t *testing.T) {
+	m := makeMessages(20)
+	before := PrintJSONUnformatted(m)
+	cfg := &ReduceConfig{DelegateSeam: true, MeasureOnly: true, HistoryFold: true}
+	out := Reduce(m, "system prompt here", SeamDelegate, cfg, nil)
+	if out.Reason != ReasonMeasured || out.Mutated || out.Messages != nil {
+		t.Errorf("measure-only must not mutate: %+v", out)
+	}
+	if out.BaselineTokens <= 0 || out.ReducedTokens != out.BaselineTokens || out.RemovedTokens != 0 {
+		t.Errorf("measure-only ledger wrong: %+v", out)
+	}
+	if out.FoldableTokens <= 0 {
+		t.Error("measure-only should still report the foldable opportunity")
+	}
+	if PrintJSONUnformatted(m) != before {
+		t.Error("measure-only mutated the input")
+	}
+}
+
+// Provenance: a second seam re-measures but does not re-reduce.
+func TestReduceProvenanceAlready(t *testing.T) {
+	m := makeMessages(20)
+	cfg := &ReduceConfig{DelegateSeam: true, HistoryFold: true}
+	st := &ReduceState{Reduced: true}
+	out := Reduce(m, "sys", SeamDelegate, cfg, st)
+	if out.Reason != ReasonAlready || out.Mutated {
+		t.Errorf("second seam must not re-reduce: %+v", out)
+	}
+	if out.BaselineTokens <= 0 {
+		t.Error("second seam should still re-measure the baseline")
+	}
+	if out.FoldableTokens != 0 {
+		t.Error("second seam must not re-account the opportunity")
+	}
+}
+
+// Below the net-gain threshold, the fold skips without mutating.
+func TestReduceSkipNoGain(t *testing.T) {
+	m := makeMessages(20)
+	cfg := &ReduceConfig{DelegateSeam: true, HistoryFold: true, MinGainTokens: 1000000}
+	out := Reduce(m, "sys", SeamDelegate, cfg, nil)
+	if out.Reason != ReasonSkipNoGain || out.Mutated || out.Messages != nil {
+		t.Errorf("below min_gain must skip cleanly: %+v", out)
+	}
+}
+
+// The fold actually reduces, and the ledger reports a real saving.
+func TestReduceHistoryFoldReduces(t *testing.T) {
+	m := makeMessages(20)
+	cfg := &ReduceConfig{DelegateSeam: true, HistoryFold: true,
+		Fold: FoldConfig{Closet: ClosetConfig{Enabled: true}}}
+	out := Reduce(m, "sys", SeamDelegate, cfg, &ReduceState{})
+	if out.Reason != ReasonReduced || !out.Mutated || out.Messages == nil {
+		t.Fatalf("fold should have reduced: %+v", out)
+	}
+	if out.ReducedTokens >= out.BaselineTokens || out.RemovedTokens == 0 {
+		t.Errorf("ledger shows no saving: %+v", out)
+	}
+	if out.FoldedMsgs <= 0 {
+		t.Error("no messages folded")
+	}
+}
+
+// A coordinate evicted by the fold and re-touched by the newest turn surfaces as
+// a pageable hint; with recall disabled the lever is inert.
+func TestReduceRecallHintOnRetouch(t *testing.T) {
+	const coord = "src/modules/git/retry.c"
+	build := func() *JSONValue {
+		m := makeMessages(20)
+		m.At(1).Set("content", NewString(
+			"the retry backoff lives in "+coord+" and needs care"))
+		m.At(m.Len()-1).Set("content", NewString(
+			"remind me what we concluded about "+coord+" before"))
+		return m
+	}
+	cfg := &ReduceConfig{DelegateSeam: true, HistoryFold: true, RecallEnabled: true,
+		Fold: FoldConfig{Closet: ClosetConfig{Enabled: true}}}
+	st := &ReduceState{Turn: 9, Recall: NewRecallIndex()}
+	out := Reduce(build(), "sys", SeamDelegate, cfg, st)
+	if out.RecallSurfaced < 1 || !strings.Contains(out.RecallHint, coord) {
+		t.Fatalf("expected a recall hint for %s, got %q", coord, out.RecallHint)
+	}
+	if !strings.Contains(out.RecallHint, "code_span_get") {
+		t.Error("hint should name how to page the coordinate back in")
+	}
+
+	// Negative half: disabled recall produces no hint at all.
+	cfgOff := *cfg
+	cfgOff.RecallEnabled = false
+	if off := Reduce(build(), "sys", SeamDelegate, &cfgOff, &ReduceState{Turn: 9}); off.RecallHint != "" {
+		t.Errorf("recall disabled but hinted: %q", off.RecallHint)
+	}
+}
+
+// The injected notice goes at the TAIL and is labelled as not coming from the
+// user — an unlabelled line after the user's turn reads as something they said.
+func TestReduceRecallInjectAppendsNotice(t *testing.T) {
+	const coord = "src/modules/git/retry.c"
+	m := makeMessages(20)
+	m.At(1).Set("content", NewString("the retry backoff lives in "+coord+" and needs care"))
+	m.At(m.Len()-1).Set("content", NewString("remind me about "+coord+" before"))
+
+	cfg := &ReduceConfig{DelegateSeam: true, HistoryFold: true, RecallEnabled: true,
+		RecallInject: true, Fold: FoldConfig{Closet: ClosetConfig{Enabled: true}}}
+	st := &ReduceState{Turn: 9, Recall: NewRecallIndex()}
+	out := Reduce(m, "sys", SeamDelegate, cfg, st)
+	if out.Messages == nil || out.RecallSurfaced < 1 {
+		t.Fatal("expected a reduced view carrying a hint")
+	}
+	last := out.Messages.At(out.Messages.Len() - 1)
+	body := last.GetString("content")
+	if !strings.Contains(body, "context notice — not from the user") {
+		t.Errorf("notice is not labelled as a system notice: %q", body)
+	}
+	if !strings.Contains(body, coord) {
+		t.Error("notice does not carry the coordinate")
+	}
+	if strings.Contains(out.Messages.At(0).GetString("content"), "context notice") {
+		t.Error("the notice must not land in the cache-stable prefix")
+	}
+}
+
+// Compress engages where the fold cannot: a tool loop has no clean user-turn
+// boundary, so fold-only must no-op while compress still shrinks the bodies.
+func TestReduceCompressEngagesWhereFoldCannot(t *testing.T) {
+	foldOnly := &ReduceConfig{DelegateSeam: true, HistoryFold: true,
+		Fold: FoldConfig{Closet: ClosetConfig{Enabled: true}}}
+	if out := Reduce(compressFixture(), "sys", SeamDelegate, foldOnly, &ReduceState{}); out.Mutated {
+		t.Error("fold found a boundary in a tool loop where none exists")
+	}
+
+	compressOnly := &ReduceConfig{DelegateSeam: true, Compress: true,
+		Fold: FoldConfig{Closet: ClosetConfig{Enabled: true}, CompactHeadBytes: 40}}
+	m := compressFixture()
+	origCount := m.Len()
+	out := Reduce(m, "sys", SeamDelegate, compressOnly, &ReduceState{})
+	if out.Reason != ReasonReduced || !out.Mutated || out.Messages == nil {
+		t.Fatalf("compress should have engaged: %+v", out)
+	}
+	if out.ReducedTokens >= out.BaselineTokens {
+		t.Error("compress did not shrink the transcript")
+	}
+	if m.Len() != origCount {
+		t.Error("compress mutated the original")
+	}
+	// A buried path is conserved (the Coordinate Closet rode along).
+	if !strings.Contains(PrintJSONUnformatted(out.Messages), "/work/src/stage_2.c") {
+		t.Error("a buried identifier was lost")
+	}
+}


### PR DESCRIPTION
Ports `src/modules/economizer/context_reduce.c` (607 lines): lever composition (compress ahead of fold), the freeze cost guardrail, the §4 page table and hint injection, seam gating, provenance, the net-gain pre-check, and the ledger. **74 tests** in the package, `go vet`/`gofmt` clean, tree builds.

**Stacked on #2557** (`context_fold`), which is stacked on #2556 (the cJSON printer).

## The headline result

The composed prefix-stability test — the Go form of the one that found the compress-defeats-freeze bug — reports:

```
7 cache-warm reuses, 6 epoch advance(s)
```

which is **exactly** what the fixed C reports in #2552. That is independent confirmation the port reproduces the *fixed behaviour*, not merely that it compiles: same transcript, same lever stack, same boundary arithmetic, same answer.

The test carries its own vacuity guard across too. It requires at least one real reuse, because a run where the fold never engaged would satisfy every byte-equality assertion trivially — and that guard is precisely what exposed the original bug.

## One deliberate design change

The C freeze guardrail calls `token_estimate_cost_ex` to price each cache tier, reaching into the pricing table. The Go module takes the three resolved **rates** as input (`PriceRates`) instead, so it stays a pure transformer with no ambient state — which is what lets it serve a bus stage without owning a config or pricing connection.

The arithmetic itself (`reduce_freeze_favorable_rates`) is already pure and ports one-for-one; its C test cases came across unchanged, including the fail-open paths for an unpriced model and a zero-size prefix. Fail-open matters here: a guardrail that silently *disables* the freeze on an unknown model would cost money quietly.

## Also covered

- Seam gating is a **true** no-op — no measurement, no cost — at a seam the operator did not enable.
- `measure_only` computes the ledger and leaves the transcript byte-identical.
- A second seam re-measures but does not re-account the saving (no double-counting).
- Below `min_gain` the fold skips without mutating.
- A recall hint surfaces for a coordinate the newest turn re-touches, and is inert when recall is off.
- The injected notice lands at the **tail**, is labelled as not coming from the user, and never enters the cache-stable prefix.
- Compress engages on a tool loop where the fold correctly finds no clean boundary.

## Status

Port is roughly **60%** by line count. Nothing dispatches to this package yet, so it stays inert beside the live C rather than a second live implementation that could diverge.

Remaining before cut-over: `tool_condense.c` (1,179 ln), the provider shims (~1,000), `task_rail`/`episode_seal` (410), the gateway wire files (~370), the reducer state serialization, and the module descriptor + `process-contracts.json` entry + `docs/modules/economizer.md`.

Carried decisions, both still open: the dead C seam `agent_compress_tool_result` should be **deleted** rather than kept beside its Go port (#2554), and the OpenAI-family cache telemetry gap (`aimee_backend_openai.c:412`, `aimee_backend_responses.c:298`) remains live in production.
