### PR TITLE
fix(delegates): the control socket is not translated a second time

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -165,7 +165,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "f6e8093386d9712ca6f4170fea79af54166caa09062be676b10659473a065fff",
+      "source_sha256": "bf7e705540771e8d8e40d66381d35e64180238d1992e5a91857dc30032fdec0f",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/dockerargs.go
+++ b/server-go/modules/delegates/dockerargs.go
@@ -68,9 +68,17 @@ func TranslateMountPath(containerPath, mountTable string) string {
 // into the daemon's namespace. The container name fingerprints these same
 // strings, so both go through here — a name computed from one rendering while
 // another is created is the bug the fingerprint exists to prevent.
+// The CONTROL SOCKET is exempt from translation. Its source arrives already in
+// the daemon's namespace, because the caller resolves it by inspecting its own
+// container -- strictly better information than a mount table, and available
+// for that one path only. Translating an already-host path a second time would
+// re-map it against the table and point the delegate's only outward channel at
+// a directory that does not exist, which docker then silently CREATES. The
+// delegate comes up with an empty directory where its socket should be, and
+// every tool call it makes fails against it.
 func renderBind(m SandboxMount, mountTable string) string {
 	source := m.Source
-	if mountTable != "" {
+	if mountTable != "" && m.Kind != SandboxControlSocket {
 		source = TranslateMountPath(source, mountTable)
 	}
 	bind := source + ":" + m.Target

--- a/server-go/modules/delegates/sandboxenv_test.go
+++ b/server-go/modules/delegates/sandboxenv_test.go
@@ -169,3 +169,51 @@ func TestDockerArgsOmitsUserWhenUnset(t *testing.T) {
 		}
 	}
 }
+
+// The control socket's source is resolved by the caller inspecting its OWN
+// container, which is better information than the mount table and available for
+// that path alone. Translating it again would re-map an already-host path and
+// point the delegate's only outward channel at a directory docker would then
+// silently create -- an empty dir where the socket should be.
+func TestControlSocketIsNotTranslatedTwice(t *testing.T) {
+	spec, err := BuildSandboxSpec(SandboxRequest{
+		WritesAllowed:      true,
+		RepoRoot:           "/repo",
+		Worktree:           "/repo",
+		IsGitCheckout:      true,
+		ParentSocketHost:   "/host/run/aimee-http.sock",
+		ParentSocketTarget: "/run/aimee.sock",
+	})
+	if err != nil {
+		t.Fatalf("BuildSandboxSpec: %v", err)
+	}
+
+	// A table that WOULD rewrite the socket source if it were applied to it.
+	args, err := DockerCreateArgs(DockerCreateRequest{
+		Spec: spec, ContainerName: "c1", Image: "ubuntu:22.04",
+		MountTable: "/host\t/elsewhere\n/repo\t/host/checkout",
+	})
+	if err != nil {
+		t.Fatalf("DockerCreateArgs: %v", err)
+	}
+
+	var sawSocket, sawWorkspace bool
+	for _, a := range args {
+		if a == "/host/run/aimee-http.sock:/run/aimee.sock" {
+			sawSocket = true
+		}
+		if a == "/elsewhere/run/aimee-http.sock:/run/aimee.sock" {
+			t.Error("the control socket source was translated a second time")
+		}
+		if a == "/host/checkout:/repo" {
+			sawWorkspace = true
+		}
+	}
+	if !sawSocket {
+		t.Errorf("the socket bind is missing or altered: %v", args)
+	}
+	// ...and the workspace IS still translated, so the exemption stays narrow.
+	if !sawWorkspace {
+		t.Errorf("the workspace source was not translated: %v", args)
+	}
+}


### PR DESCRIPTION
fix(delegates): the control socket is not translated a second time

Found while wiring the C backend to stage 12, by following where each bind
source actually comes from rather than assuming they come from one place.

There are TWO translation sources in the backend, not one, and they differ in
quality:

  - the WORKSPACE sources are translated from an operator-configured mapping
  - the CONTROL SOCKET is translated by docker_host_path_for_self(), which runs
    a live `docker inspect` against aimee's OWN container

The second is strictly better information, and it is available for that one path
only. So the socket arrives at the module ALREADY in the daemon's namespace,
while the workspace sources still need the table.

renderBind applied the table to every mount, so the socket would have been
translated a second time. Re-mapping an already-host path against the table
points the delegate's only outward channel at a directory that does not exist --
and docker does not fail on a missing bind source, it silently CREATES one. The
delegate would come up with an empty directory where its socket should be, and
every tool call it made would fail against it. Nothing in that sequence reports
a mount problem; it reads as the delegate being broken.

The exemption is narrow and the test keeps it narrow: it uses a table that WOULD
rewrite the socket source, asserts the socket bind is untouched, and asserts in
the same pass that the workspace source IS still translated.

The container-name fingerprint is unaffected -- it already covered workspace
mounts only, so it never hashed the socket either way.

A SECOND MISMATCH FOUND AND NOT FIXED HERE, recorded so it is not tripped over:
the two sides parse mount tables in DIFFERENT FORMATS. Go's TranslateMountPath
reads "<destination>\t<source>" per line, which is what `docker inspect` emits;
C's AIMEE_SANDBOX_HOST_MOUNTS is comma-separated and equals-delimited. Passing
that env var straight through as stage 12's mount_table would match nothing,
translate nothing, and leave every workspace bind pointing at an in-container
path for docker to create empty. That has to be reconciled before the backend
can ask the module for its argv, and it is its own change.
