### PR TITLE
report cached input tokens to OpenAI-shaped clients

### DIFF
--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -110,18 +110,27 @@ extern "C"
     * {"id":…,"object":"response","created_at":…,"model":…,"status":"completed",
     *  "output":[{"id":…,"type":"message","status":"completed","role":"assistant",
     *  "content":[{"type":"output_text","text":…,"annotations":[]}]}],
-    *  "usage":{"input_tokens":…,"output_tokens":…,"total_tokens":…}}
+    *  "usage":{"input_tokens":…,"output_tokens":…,"total_tokens":…,
+    *           "input_tokens_details":{"cached_tokens":…}}}
+    *
+    * cached_tokens is the part of prompt_tokens the provider served from its
+    * prompt cache. Pass it through from the upstream reply -- do NOT pass 0 as a
+    * placeholder on a path that has the real value. A client bills what this
+    * block says, so a dropped cached count silently prices cache reads at the
+    * full uncached rate (roughly 10x), and looks exactly like caching being
+    * broken rather than unreported. Emitted even when zero.
+    *
     * Returns bytes written (excluding NUL), or -1 if it does not fit. */
    int openai_format_response(const char *id, const char *model, const char *output_text,
-                              long created, int prompt_tokens, int completion_tokens, char *resp,
-                              int cap);
+                              long created, int prompt_tokens, int completion_tokens,
+                              int cached_tokens, char *resp, int cap);
 
    /* Build a `run` object (same message/usage shape as a response, with
     * "object":"run" and the given status, e.g. "completed"). Returns bytes
     * written (excluding NUL), or -1 if it does not fit. */
    int openai_format_run(const char *id, const char *model, const char *output_text, long created,
-                         int prompt_tokens, int completion_tokens, const char *status, char *resp,
-                         int cap);
+                         int prompt_tokens, int completion_tokens, int cached_tokens,
+                         const char *status, char *resp, int cap);
 
    /* Responses API streaming events (data payloads; the caller writes the SSE
     * `event:` line and frames them). Each returns bytes written or -1.
@@ -134,7 +143,7 @@ extern "C"
    int openai_format_responses_delta(const char *item_id, const char *delta, char *resp, int cap);
    int openai_format_responses_completed(const char *id, const char *model, const char *output_text,
                                          long created, int prompt_tokens, int completion_tokens,
-                                         char *resp, int cap);
+                                         int cached_tokens, char *resp, int cap);
 
    /* Responses-API terminal error events (Codex parity). Codex treats both as
     * fatal stream errors:
@@ -182,7 +191,8 @@ extern "C"
                                             const char *arguments, char *resp, int cap);
    int openai_format_responses_completed_items(const char *id, const char *model, long created,
                                                struct cJSON *output_arr, int prompt_tokens,
-                                               int completion_tokens, char *resp, int cap);
+                                               int completion_tokens, int cached_tokens, char *resp,
+                                               int cap);
 
    /* Read an optional numeric sampling field from an OpenAI request body.
     * Returns the value when it is a finite number within [0, hi]; otherwise

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -899,6 +899,39 @@ static void parse_response_openai(cJSON *root, agent_result_t *out)
    agent_free_parsed_response(&parsed);
 }
 
+/* Read a Responses-API `usage` object: the two flat counters AND the cached-input
+ * detail.
+ *
+ * The chat-completions wire reaches `agent_result_t` through the canonical IR
+ * parser, which already carries cached tokens across. The Responses wire does
+ * not -- it is hand-parsed here, in three places that each read exactly
+ * input_tokens and output_tokens. `cached_tokens` lives one level down, in the
+ * `input_tokens_details` sibling, so reading only the flat pair loses it with no
+ * error: cache_read_tokens simply stays 0, which is indistinguishable from a
+ * real cache miss.
+ *
+ * Factored out rather than patched in triplicate because three copies is how the
+ * field came to be missing from all three in the first place. */
+static void read_responses_usage(cJSON *usage, agent_result_t *out)
+{
+   if (!usage)
+      return;
+   cJSON *it = cJSON_GetObjectItem(usage, "input_tokens");
+   cJSON *ot = cJSON_GetObjectItem(usage, "output_tokens");
+   if (it && cJSON_IsNumber(it))
+      out->prompt_tokens = it->valueint;
+   if (ot && cJSON_IsNumber(ot))
+      out->completion_tokens = ot->valueint;
+
+   cJSON *details = cJSON_GetObjectItem(usage, "input_tokens_details");
+   if (details && cJSON_IsObject(details))
+   {
+      cJSON *cached = cJSON_GetObjectItem(details, "cached_tokens");
+      if (cached && cJSON_IsNumber(cached))
+         out->cache_read_tokens = cached->valueint;
+   }
+}
+
 static void parse_response_object(cJSON *root, agent_result_t *out)
 {
    /* Responses API: output[].content[].text where type == "output_text" */
@@ -938,17 +971,7 @@ static void parse_response_object(cJSON *root, agent_result_t *out)
       }
    }
 
-   /* Responses API usage: input_tokens, output_tokens */
-   cJSON *usage = cJSON_GetObjectItem(root, "usage");
-   if (usage)
-   {
-      cJSON *it = cJSON_GetObjectItem(usage, "input_tokens");
-      cJSON *ot = cJSON_GetObjectItem(usage, "output_tokens");
-      if (it && cJSON_IsNumber(it))
-         out->prompt_tokens = it->valueint;
-      if (ot && cJSON_IsNumber(ot))
-         out->completion_tokens = ot->valueint;
-   }
+   read_responses_usage(cJSON_GetObjectItem(root, "usage"), out);
 }
 
 /* Parse SSE stream body for the Responses API.
@@ -1019,16 +1042,7 @@ static void parse_response_responses(const char *body, agent_result_t *out)
                cJSON *resp = cJSON_GetObjectItem(ev, "response");
                if (resp)
                {
-                  cJSON *usage = cJSON_GetObjectItem(resp, "usage");
-                  if (usage)
-                  {
-                     cJSON *it = cJSON_GetObjectItem(usage, "input_tokens");
-                     cJSON *ot = cJSON_GetObjectItem(usage, "output_tokens");
-                     if (it && cJSON_IsNumber(it))
-                        out->prompt_tokens = it->valueint;
-                     if (ot && cJSON_IsNumber(ot))
-                        out->completion_tokens = ot->valueint;
-                  }
+                  read_responses_usage(cJSON_GetObjectItem(resp, "usage"), out);
                }
                cJSON_Delete(ev);
             }
@@ -1107,6 +1121,14 @@ static void parse_response_anthropic(cJSON *root, agent_result_t *out)
          out->prompt_tokens = it->valueint;
       if (ot && cJSON_IsNumber(ot))
          out->completion_tokens = ot->valueint;
+      /* Anthropic spells cached input as two FLAT siblings, not a details
+       * object, so this cannot share the Responses reader above. */
+      cJSON *cr = cJSON_GetObjectItem(usage, "cache_read_input_tokens");
+      if (cr && cJSON_IsNumber(cr))
+         out->cache_read_tokens = cr->valueint;
+      cJSON *cw = cJSON_GetObjectItem(usage, "cache_creation_input_tokens");
+      if (cw && cJSON_IsNumber(cw))
+         out->cache_write_tokens = cw->valueint;
    }
 
    /* Prefer the provider-reported model over the served alias set at entry. */

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -754,7 +754,7 @@ static int responses_handler(const char *body, char *resp, int cap)
    free(combined);
 
    int len = openai_format_response(id, model, result.response, created, result.prompt_tokens,
-                                    result.completion_tokens, resp, cap);
+                                    result.completion_tokens, result.cache_read_tokens, resp, cap);
    free(result.response);
    if (len < 0)
    {
@@ -1319,7 +1319,7 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
       if (openai_format_responses_created(id, model, created, frame, sizeof(frame)) > 0)
          emit(ctx, "response.created", frame);
       if (openai_format_responses_completed(id, model, "invalid responses request", created, 0, 0,
-                                            frame, sizeof(frame)) > 0)
+                                            0, frame, sizeof(frame)) > 0)
          emit(ctx, "response.completed", frame);
       free(instructions);
       cJSON_Delete(messages);
@@ -1334,8 +1334,8 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
    {
       if (openai_format_responses_created(id, model, created, frame, sizeof(frame)) > 0)
          emit(ctx, "response.created", frame);
-      if (openai_format_responses_completed(id, model, "no agent configured", created, 0, 0, frame,
-                                            sizeof(frame)) > 0)
+      if (openai_format_responses_completed(id, model, "no agent configured", created, 0, 0, 0,
+                                            frame, sizeof(frame)) > 0)
          emit(ctx, "response.completed", frame);
       free(instructions);
       cJSON_Delete(messages);
@@ -1509,7 +1509,8 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
                emit(ctx, "response.incomplete", cf);
          }
          else if (openai_format_responses_completed(id, model, txt, created, parsed.prompt_tokens,
-                                                    parsed.completion_tokens, cf, (int)ccap) > 0)
+                                                    parsed.completion_tokens,
+                                                    parsed.cache_read_tokens, cf, (int)ccap) > 0)
             emit(ctx, "response.completed", cf);
          free(cf);
       }
@@ -1552,8 +1553,9 @@ typedef struct
  * the pointer (buf) on success or "{}" if it does not fit. */
 static const char *run_status_json(const run_job_t *j, const char *status, char *buf, int cap)
 {
-   return openai_format_run(j->run_id, j->model, "", j->created, 0, 0, status, buf, cap) > 0 ? buf
-                                                                                             : "{}";
+   return openai_format_run(j->run_id, j->model, "", j->created, 0, 0, 0, status, buf, cap) > 0
+              ? buf
+              : "{}";
 }
 
 /* Tool-event hook for /v1/runs: append a `tool_call.started` /
@@ -1695,7 +1697,8 @@ static void *run_job_worker(void *arg)
       cJSON_Delete(mc);
    }
    if (openai_format_run(j->run_id, j->model, result.response, j->created, result.prompt_tokens,
-                         result.completion_tokens, "completed", buf, RUN_JSON_CAP) > 0)
+                         result.completion_tokens, result.cache_read_tokens, "completed", buf,
+                         RUN_JSON_CAP) > 0)
    {
       openai_runs_store_append_event(j->run_id, "response.completed", buf);
       openai_runs_store_finalize(j->run_id, OPENAI_RUN_COMPLETED, buf);
@@ -1752,7 +1755,7 @@ static int runs_handler(const char *body, char *resp, int cap)
    snprintf(id, sizeof(id), "run_%ld_%lu", created, atomic_fetch_add(&g_run_seq, 1) + 1);
 
    /* Queued snapshot returned to the caller and stored for GET /v1/runs/{id}. */
-   int len = openai_format_run(id, model, "", created, 0, 0, "queued", resp, cap);
+   int len = openai_format_run(id, model, "", created, 0, 0, 0, "queued", resp, cap);
    if (len < 0)
    {
       free(prompt);

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -945,6 +945,13 @@ int openai_format_chat_completion_tool_calls(const char *id, const char *model,
    cJSON_AddNumberToObject(usage, "completion_tokens", (double)parsed->completion_tokens);
    cJSON_AddNumberToObject(usage, "total_tokens",
                            (double)(parsed->prompt_tokens + parsed->completion_tokens));
+   /* Chat-completions spells the cached-input detail `prompt_tokens_details`,
+    * where the Responses API spells it `input_tokens_details`. Same quantity,
+    * different sibling name -- so it needs its own line here rather than the
+    * shared Responses helper. */
+   cJSON *ptd = cJSON_AddObjectToObject(usage, "prompt_tokens_details");
+   if (ptd)
+      cJSON_AddNumberToObject(ptd, "cached_tokens", (double)parsed->cache_read_tokens);
 
    char *s = cJSON_PrintUnformatted(root);
    cJSON_Delete(root);
@@ -1212,6 +1219,35 @@ int openai_format_text_completion(const char *id, const char *model, const char 
 
 /* ── openai_format_response (Responses API) ──────────────────────────────── */
 
+/* Attach a Responses-shaped `usage` block, INCLUDING the cached-input detail.
+ *
+ * cached_tokens is the portion of prompt_tokens the provider served from its
+ * prompt cache. It is NOT a flat counter: OpenAI reports it in a sibling object
+ * (`input_tokens_details.cached_tokens`), and a usage block that enumerates only
+ * the flat fields drops it silently -- the field is not missing from the input,
+ * it is missing from the enumeration, so nothing errors and no test that asserts
+ * the flat counters notices.
+ *
+ * That is not hypothetical: it is why every benchmark cell run through this
+ * gateway reported cache_read=0 while every other arm reported 89-95%. The
+ * client (Codex) can only bill what we hand it, so an omitted field reads as
+ * "prompt caching never worked" and prices the whole conversation at the
+ * uncached rate. Emitted unconditionally, even at zero, so a client can tell a
+ * genuine cache miss from a build that does not report caching at all. */
+static void add_responses_usage(cJSON *parent, int prompt_tokens, int completion_tokens,
+                                int cached_tokens)
+{
+   cJSON *usage = cJSON_AddObjectToObject(parent, "usage");
+   if (!usage)
+      return;
+   cJSON_AddNumberToObject(usage, "input_tokens", (double)prompt_tokens);
+   cJSON_AddNumberToObject(usage, "output_tokens", (double)completion_tokens);
+   cJSON_AddNumberToObject(usage, "total_tokens", (double)(prompt_tokens + completion_tokens));
+   cJSON *details = cJSON_AddObjectToObject(usage, "input_tokens_details");
+   if (details)
+      cJSON_AddNumberToObject(details, "cached_tokens", (double)cached_tokens);
+}
+
 /* Build a `response` object (caller owns the returned cJSON, or NULL on OOM).
  * status is e.g. "completed" or "in_progress". When with_output != 0 the
  * assistant output message + content part + usage are included; otherwise the
@@ -1219,7 +1255,8 @@ int openai_format_text_completion(const char *id, const char *model, const char 
  * response just after creation). */
 static cJSON *build_response_object(const char *id, const char *model, const char *output_text,
                                     long created, int prompt_tokens, int completion_tokens,
-                                    const char *status, int with_output, const char *object_type)
+                                    int cached_tokens, const char *status, int with_output,
+                                    const char *object_type)
 {
    cJSON *root = cJSON_CreateObject();
    if (!root)
@@ -1267,13 +1304,7 @@ static cJSON *build_response_object(const char *id, const char *model, const cha
    cJSON_AddStringToObject(part, "text", output_text ? output_text : "");
    cJSON_AddItemToObject(part, "annotations", cJSON_CreateArray());
 
-   cJSON *usage = cJSON_AddObjectToObject(root, "usage");
-   if (usage)
-   {
-      cJSON_AddNumberToObject(usage, "input_tokens", (double)prompt_tokens);
-      cJSON_AddNumberToObject(usage, "output_tokens", (double)completion_tokens);
-      cJSON_AddNumberToObject(usage, "total_tokens", (double)(prompt_tokens + completion_tokens));
-   }
+   add_responses_usage(root, prompt_tokens, completion_tokens, cached_tokens);
    return root;
 }
 
@@ -1292,23 +1323,26 @@ static int emit_json(cJSON *root, char *resp, int cap)
 }
 
 int openai_format_response(const char *id, const char *model, const char *output_text, long created,
-                           int prompt_tokens, int completion_tokens, char *resp, int cap)
+                           int prompt_tokens, int completion_tokens, int cached_tokens, char *resp,
+                           int cap)
 {
    if (!resp || cap <= 0)
       return -1;
-   cJSON *root = build_response_object(id, model, output_text, created, prompt_tokens,
-                                       completion_tokens, "completed", 1, "response");
+   cJSON *root =
+       build_response_object(id, model, output_text, created, prompt_tokens, completion_tokens,
+                             cached_tokens, "completed", 1, "response");
    return emit_json(root, resp, cap);
 }
 
 int openai_format_run(const char *id, const char *model, const char *output_text, long created,
-                      int prompt_tokens, int completion_tokens, const char *status, char *resp,
-                      int cap)
+                      int prompt_tokens, int completion_tokens, int cached_tokens,
+                      const char *status, char *resp, int cap)
 {
    if (!resp || cap <= 0)
       return -1;
-   cJSON *root = build_response_object(id, model, output_text, created, prompt_tokens,
-                                       completion_tokens, status ? status : "completed", 1, "run");
+   cJSON *root =
+       build_response_object(id, model, output_text, created, prompt_tokens, completion_tokens,
+                             cached_tokens, status ? status : "completed", 1, "run");
    return emit_json(root, resp, cap);
 }
 
@@ -1323,7 +1357,8 @@ int openai_format_responses_created(const char *id, const char *model, long crea
    if (!root)
       return -1;
    cJSON_AddStringToObject(root, "type", "response.created");
-   cJSON *obj = build_response_object(id, model, "", created, 0, 0, "in_progress", 0, "response");
+   cJSON *obj =
+       build_response_object(id, model, "", created, 0, 0, 0, "in_progress", 0, "response");
    if (!obj)
    {
       cJSON_Delete(root);
@@ -1350,7 +1385,7 @@ int openai_format_responses_delta(const char *item_id, const char *delta, char *
 
 int openai_format_responses_completed(const char *id, const char *model, const char *output_text,
                                       long created, int prompt_tokens, int completion_tokens,
-                                      char *resp, int cap)
+                                      int cached_tokens, char *resp, int cap)
 {
    if (!resp || cap <= 0)
       return -1;
@@ -1359,7 +1394,7 @@ int openai_format_responses_completed(const char *id, const char *model, const c
       return -1;
    cJSON_AddStringToObject(root, "type", "response.completed");
    cJSON *obj = build_response_object(id, model, output_text, created, prompt_tokens,
-                                      completion_tokens, "completed", 1, "response");
+                                      completion_tokens, cached_tokens, "completed", 1, "response");
    if (!obj)
    {
       cJSON_Delete(root);
@@ -1379,7 +1414,7 @@ int openai_format_responses_failed(const char *id, const char *model, long creat
       return -1;
    cJSON_AddStringToObject(root, "type", "response.failed");
    /* Base response object (output:[] is fine; Codex reads only response.error). */
-   cJSON *obj = build_response_object(id, model, "", created, 0, 0, "failed", 0, "response");
+   cJSON *obj = build_response_object(id, model, "", created, 0, 0, 0, "failed", 0, "response");
    if (!obj)
    {
       cJSON_Delete(root);
@@ -1404,7 +1439,7 @@ int openai_format_responses_incomplete(const char *id, const char *model, long c
    if (!root)
       return -1;
    cJSON_AddStringToObject(root, "type", "response.incomplete");
-   cJSON *obj = build_response_object(id, model, "", created, 0, 0, "incomplete", 0, "response");
+   cJSON *obj = build_response_object(id, model, "", created, 0, 0, 0, "incomplete", 0, "response");
    if (!obj)
    {
       cJSON_Delete(root);
@@ -1567,7 +1602,8 @@ int openai_format_responses_fc_args_done(const char *item_id, int output_index,
  * message. */
 int openai_format_responses_completed_items(const char *id, const char *model, long created,
                                             cJSON *output_arr, int prompt_tokens,
-                                            int completion_tokens, char *resp, int cap)
+                                            int completion_tokens, int cached_tokens, char *resp,
+                                            int cap)
 {
    if (!resp || cap <= 0)
    {
@@ -1595,13 +1631,7 @@ int openai_format_responses_completed_items(const char *id, const char *model, l
    cJSON_AddStringToObject(r, "model", model ? model : "");
    cJSON_AddStringToObject(r, "status", "completed");
    cJSON_AddItemToObject(r, "output", output_arr ? output_arr : cJSON_CreateArray());
-   cJSON *usage = cJSON_AddObjectToObject(r, "usage");
-   if (usage)
-   {
-      cJSON_AddNumberToObject(usage, "input_tokens", (double)prompt_tokens);
-      cJSON_AddNumberToObject(usage, "output_tokens", (double)completion_tokens);
-      cJSON_AddNumberToObject(usage, "total_tokens", (double)(prompt_tokens + completion_tokens));
-   }
+   add_responses_usage(r, prompt_tokens, completion_tokens, cached_tokens);
    return emit_json(root, resp, cap);
 }
 
@@ -1734,9 +1764,9 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
       char *cf = malloc(ccap);
       if (cf)
       {
-         if (openai_format_responses_completed_items(id, model, created, output,
-                                                     parsed->prompt_tokens,
-                                                     parsed->completion_tokens, cf, (int)ccap) > 0)
+         if (openai_format_responses_completed_items(
+                 id, model, created, output, parsed->prompt_tokens, parsed->completion_tokens,
+                 parsed->cache_read_tokens, cf, (int)ccap) > 0)
             emit(ctx, "response.completed", cf);
          free(cf);
       }
@@ -1751,6 +1781,7 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
       cJSON *empty_output = cJSON_CreateArray();
       int pt = parsed ? parsed->prompt_tokens : 0;
       int ct = parsed ? parsed->completion_tokens : 0;
+      int cr = parsed ? parsed->cache_read_tokens : 0;
       size_t ccap = 4096 + strlen(id ? id : "") + strlen(model ? model : "");
       char *cf = malloc(ccap);
       if (cf)
@@ -1758,8 +1789,8 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
          /* completed_items takes ownership of empty_output (attaches it to
           * the response object it serializes, and frees it on every error
           * path), so we must NOT delete it here — that was a double free. */
-         if (openai_format_responses_completed_items(id, model, created, empty_output, pt, ct, cf,
-                                                     (int)ccap) > 0)
+         if (openai_format_responses_completed_items(id, model, created, empty_output, pt, ct, cr,
+                                                     cf, (int)ccap) > 0)
             emit(ctx, "response.completed", cf);
          free(cf);
       }

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -274,7 +274,7 @@ int main(void)
 
    /* --- responses: format response object --- */
    {
-      int len = openai_format_response("resp_42", "aimee", "the answer", 1700000000, 7, 3, resp,
+      int len = openai_format_response("resp_42", "aimee", "the answer", 1700000000, 7, 3, 0, resp,
                                        sizeof(resp));
       assert(len > 0);
       assert(strstr(resp, "\"object\":\"response\""));
@@ -354,7 +354,7 @@ int main(void)
       assert(strstr(resp, "\"item_id\":\"resp_9-msg\""));
       assert(strstr(resp, "\"delta\":\"lorem\""));
 
-      len = openai_format_responses_completed("resp_9", "aimee", "the answer", 1700000000, 7, 3,
+      len = openai_format_responses_completed("resp_9", "aimee", "the answer", 1700000000, 7, 3, 0,
                                               resp, sizeof(resp));
       assert(len > 0);
       assert(strstr(resp, "\"type\":\"response.completed\""));
@@ -447,13 +447,43 @@ int main(void)
       cJSON_AddItemToArray((cJSON *)out, openai_responses_function_call_item(
                                              "resp_9-fc-0", "call_42", "exec_command", NULL,
                                              "{\"cmd\":\"ls\"}", "completed"));
-      int len = openai_format_responses_completed_items("resp_9", "aimee", 1700000000, out, 5, 2,
+      int len = openai_format_responses_completed_items("resp_9", "aimee", 1700000000, out, 5, 2, 4,
                                                         resp, sizeof(resp));
       assert(len > 0);
       assert(strstr(resp, "\"type\":\"response.completed\""));
       assert(strstr(resp, "\"type\":\"function_call\""));
       assert(strstr(resp, "\"call_id\":\"call_42\""));
       assert(strstr(resp, "\"total_tokens\":7"));
+      /* The tool-call turn is the one the Codex gateway emits most, and it is
+       * where the cached count went missing on the wire. */
+      assert(strstr(resp, "\"input_tokens_details\":{\"cached_tokens\":4}"));
+   }
+
+   /* --- Cached input tokens survive to the client on every usage-bearing shape.
+    *
+    * A client bills what these blocks say. When the cached count is dropped, the
+    * conversation is priced at the full uncached rate -- about 10x on the cached
+    * portion -- and the symptom is indistinguishable from prompt caching being
+    * broken. Asserted on each emitter separately because each builds its own
+    * usage object, which is exactly how one path kept the field and the others
+    * never had it. Zero is asserted as PRESENT, not absent: a client must be able
+    * to tell a real cache miss from a gateway that does not report caching. --- */
+   {
+      int len = openai_format_responses_completed("resp_c", "aimee", "hi", 1700000000, 100, 5, 80,
+                                                  resp, sizeof(resp));
+      assert(len > 0);
+      assert(strstr(resp, "\"input_tokens\":100"));
+      assert(strstr(resp, "\"input_tokens_details\":{\"cached_tokens\":80}"));
+
+      len = openai_format_response("resp_d", "aimee", "hi", 1700000000, 100, 5, 0, resp,
+                                   sizeof(resp));
+      assert(len > 0);
+      assert(strstr(resp, "\"input_tokens_details\":{\"cached_tokens\":0}"));
+
+      len = openai_format_run("run_e", "aimee", "hi", 1700000000, 100, 5, 64, "completed", resp,
+                              sizeof(resp));
+      assert(len > 0);
+      assert(strstr(resp, "\"input_tokens_details\":{\"cached_tokens\":64}"));
    }
 
    /* --- Codex parity: terminal error events --- */

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -951,7 +951,7 @@
         },
         {
           "path": "src/headers/openai_shape.h",
-          "sha256": "d9a2b83e8c1161dac7e1dc0fb8a6b8db35b999659e94c12510c0e0b17ac1002e"
+          "sha256": "57f06881cc7d56e9eca995931a36d6f92e456e9b4724dd20599186be3fdf1ef8"
         },
         {
           "path": "src/headers/osv_check.h",
@@ -1624,7 +1624,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "e82da193c32395767fdf74139d34e456471806d46050dd862a81498f850b1705",
+      "sha256": "4e3dae815268a84217abc7f96b0784440a758fe669beaba4c945b21b1df6a2db",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
report cached input tokens to OpenAI-shaped clients

A client bills what our usage block says. The OpenAI-shaped egress rebuilt that
block from five scalars and never emitted the cached-input detail, so every
client driven through this gateway was told cached_tokens=0 no matter what the
provider actually served from cache -- pricing the cached portion at the full
uncached rate, roughly 10x.

Measured, not theorised: across three benchmark result sets the gateway arm
reported a 0.0% cache hit rate in 8 of 8 cells, while every other arm in the
same corpus -- including aimee's own direct-MCP arm -- reported 89-95%. Exactly
zero, with no variance, is the signature of a field that is never serialised
rather than a cache that never hits. Credits then scaled with tool-call count
(0 calls 18.99, 2 calls 22.48, 6 calls 26.69 on the same task), because each
extra call is another full-context resend billed as if none of it were cached.

Two independent gaps, both on the OpenAI-shaped path:

  egress - openai_shape.c enumerated input_tokens/output_tokens/total_tokens and
    stopped. cached_tokens is not a flat counter; it lives in the
    input_tokens_details sibling (prompt_tokens_details on chat-completions), so
    a hand-built usage object drops it with no error and no failing test.

  ingest - the Responses wire is hand-parsed in agent_runtime.c, in three places
    that each read exactly the two flat counters. The chat-completions wire goes
    through the canonical IR parser, which already carried cached tokens across,
    which is why only one of the two wires was ever right.

Why the Anthropic path was correct and this one was not: anthropic_ingress.c has
to translate between genuinely different shapes, so someone mapped the fields by
hand and saw the cached count. OpenAI shape in, OpenAI shape out does not feel
like translation at all -- but it is a rebuild, and a rebuild silently loses
whatever the author did not enumerate.

The three duplicated Responses parses are folded into one read_responses_usage,
because three copies is how the field came to be missing from all three.

Emitted unconditionally, including at zero, so a client can distinguish a real
cache miss from a build that does not report caching.

Tests assert the detail on each usage-bearing emitter separately, since each
builds its own usage object. Verified red first: with the emission disabled the
new assertion fails at test_openai_shape.c:459.

Not yet established: whether the upstream provider was in fact caching this
traffic. If it was, the gateway arm's measured cost is substantially an
instrument error; if it was not, there is a real caching problem this omission
was hiding. This change is what makes that question answerable.
