### PR TITLE
fix(economizer): the delegate history fold runs on chatgpt routes

### DIFF
--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -840,8 +840,23 @@ native_provider_http:
             memset(&mreq, 0, sizeof mreq);
             /* The fold is reachable on its own, not only via the AGGRESSIVE
              * preset: fold.enabled had zero live callers before, so the only way
-             * to turn it on was a tier that also enables wire mutation. */
-            mreq.history_fold = (preset.history_fold || config_fold_enabled()) && !chatgpt;
+             * to turn it on was a tier that also enables wire mutation.
+             *
+             * THE CHATGPT ROUTE FOLDS TOO. It was excluded in #913 as "unverified"
+             * rather than as known-broken, and the exclusion then outlived the
+             * doubt that motivated it: chatgpt is what a codex-provider deployment
+             * actually uses, so excluding it meant the fold never ran there at all.
+             * Measured on CT 403 with the module attached and mode=aggressive, the
+             * same request cost an IDENTICAL 38826 prompt tokens with the
+             * economizer attached and detached — the lever was structurally
+             * unreachable on the only route the box uses.
+             *
+             * The original doubt was about SHAPE: folded turns are {role, content}
+             * with a string content, and agent_build_request_responses forwards
+             * `input` without converting to typed items. The Responses API accepts
+             * that string shorthand, which is why this is safe, and it is verified
+             * live against the real backend rather than argued from the spec. */
+            mreq.history_fold = preset.history_fold || config_fold_enabled();
             mreq.compress = preset.compress;
             mreq.freeze_guard_enabled = 1;
             mreq.freeze_guard_horizon = preset.freeze_guard_horizon;

--- a/src/tests/test_economizer_live_surface.sh
+++ b/src/tests/test_economizer_live_surface.sh
@@ -23,6 +23,12 @@ grep -q 'preset.json_compact' posix/agent_runtime.c ||
     fail "safe JSON compaction is not controlled by its preset"
 grep -q '!anthropic && (preset.history_fold || preset.compress)' posix/agent_runtime.c ||
     fail "agent history reduction is not gated to aggressive OpenAI-family routes"
+# The chatgpt route folds. It was excluded for years as "unverified", which made
+# the fold unreachable on exactly the route a codex-provider deployment uses --
+# measured as a 0-token difference on CT 403. Anthropic stays excluded above (its
+# exact prefix controls cache reuse); chatgpt must not be re-added beside it.
+grep -q 'mreq.history_fold = preset.history_fold || config_fold_enabled();' posix/agent_runtime.c ||
+    fail "the delegate history fold is gated again (chatgpt exclusion reintroduced?)"
 grep -q 'gw_mutate_upstream_ok(parity)' server/anthropic_http.c ||
     fail "Anthropic ingress mutation does not preserve native Anthropic prefixes"
 grep -q 'gw_mutate_upstream_ok(upstream_is_anthropic)' server/openai_chat.c ||


### PR DESCRIPTION
`mreq.history_fold` carried `&& !chatgpt`. That exclusion came from #913, where it was written as **unverified rather than known-broken**: folded turns are `{role, content}` with a string content, and `agent_build_request_responses` forwards `input` without converting to typed items, so nobody had confirmed the Responses API accepted the string shorthand. The doubt was never resolved, and the exclusion outlived it.

**What it cost.** chatgpt is exactly what a `provider: codex` deployment uses, so the fold never ran there at all. Measured on CT 403 with the module attached and `mode=aggressive`, a controlled A/B over an identical 98-message payload:

| Arm | Economizer | prompt_tokens |
|---|---|---|
| A | attached, aggressive | 38,826 |
| B | detached | 38,826 |

Not approximately equal — identical. The lever was structurally unreachable on the only route that box uses.

**Anthropic stays excluded** by the outer gate (`!anthropic`): its exact prefix controls cache reuse. That is a different reason and still live.

The live-surface guard now asserts the fold is ungated, so the exclusion cannot return as quietly as it persisted.

**Verification:** `make lint` — all 54 checks pass. Live verification against the real chatgpt backend follows on deploy; I will post the measured before/after here and revert if the Responses API rejects the folded shape.
