### PR TITLE
feat(economizer): the gateway folds, for every provider

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -510,7 +510,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "62697dc883145c3f0fa40a378e846107b0b66f9096d42113220905ec8cb80194"
+      "source_sha256": "ea0457c250c0d6776d5b18b9ef10716f9822a4e8447f222f230b23ac05091532"
     }
   ]
 }

--- a/server-go/modules/economizer/gateway_anthropic_test.go
+++ b/server-go/modules/economizer/gateway_anthropic_test.go
@@ -1,0 +1,191 @@
+package economizer
+
+import (
+	"strings"
+	"testing"
+)
+
+// The gateway seam folds Anthropic-shaped traffic now that it carries a freeze
+// boundary. These tests cover the properties that change made a live dependency,
+// on the shape a Claude client actually sends: content-block arrays carrying
+// tool_use / tool_result rather than plain strings.
+//
+// They exist because the box this was built against has no Claude credentials, so
+// the claude path cannot be exercised end to end there. That is a real gap and
+// these do not close it: they pin the mechanics (structure, conservation, freeze
+// stability) so that what remains unverified is the wire contract with Anthropic,
+// not the reducer.
+
+// anthropicFixture builds a conversation in Anthropic's content-block shape, long
+// enough to fold, with tool_use/tool_result pairs and identifiers worth conserving.
+func anthropicFixture(turns int) *JSONValue {
+	m := NewArray()
+	m.Append(mkUser("open incident INC-91024 on /srv/api/gateway.c"))
+	for i := 0; i < turns; i++ {
+		id := "toolu_gw_" + string(rune('a'+i%26))
+		m.Append(mkToolUse(id, "read_log", "/var/log/api/"+id+".log"))
+		m.Append(mkToolResult(id, "worker pid 77"+string(rune('0'+i%10))+" retry window 4s"))
+		m.Append(mkAsst("checked " + id))
+		m.Append(mkUser("continue " + id))
+	}
+	return m
+}
+
+// A fold that splits between a tool_use and its tool_result orphans the pair, and
+// every provider rejects that. Anthropic is the shape where it is easiest to get
+// wrong, because the pairing lives inside the content array rather than in
+// separate messages.
+func TestGatewayFoldKeepsAnthropicToolPairsIntact(t *testing.T) {
+	cfg := &ReduceConfig{
+		GatewaySeam: true,
+		HistoryFold: true,
+		Fold: FoldConfig{
+			Closet:           ClosetConfig{Enabled: true},
+			CompactHeadBytes: 40,
+		},
+	}
+	m := anthropicFixture(8)
+	out := Reduce(m, "sys", SeamGateway, cfg, &ReduceState{Recall: NewRecallIndex()})
+	if !out.Mutated || out.Messages == nil {
+		t.Fatalf("gateway fold did not engage on anthropic-shaped input: %+v", out)
+	}
+
+	// Every surviving tool_result must still have its tool_use ahead of it.
+	open := map[string]bool{}
+	for i := 0; i < out.Messages.Len(); i++ {
+		content := out.Messages.At(i).Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		for j := 0; j < content.Len(); j++ {
+			b := content.At(j)
+			switch b.GetString("type") {
+			case "tool_use":
+				open[b.GetString("id")] = true
+			case "tool_result":
+				if !open[b.GetString("tool_use_id")] {
+					t.Fatalf("orphaned tool_result %q survived the fold",
+						b.GetString("tool_use_id"))
+				}
+			}
+		}
+	}
+}
+
+// Folding is only allowed to be lossy about PROSE. An identifier the user can ask
+// about later has to come back verbatim, or the reduction traded tokens for the
+// answer being wrong -- which is the one trade this module may never make.
+func TestGatewayFoldConservesAnthropicIdentifiers(t *testing.T) {
+	cfg := &ReduceConfig{
+		GatewaySeam: true,
+		HistoryFold: true,
+		Fold: FoldConfig{
+			Closet:           ClosetConfig{Enabled: true},
+			CompactHeadBytes: 40,
+		},
+	}
+	m := anthropicFixture(8)
+	out := Reduce(m, "sys", SeamGateway, cfg, &ReduceState{Recall: NewRecallIndex()})
+	if !out.Mutated || out.Messages == nil {
+		t.Fatal("gateway fold did not engage")
+	}
+	got := PrintJSONUnformatted(out.Messages)
+	// The opening message names a path and an incident id; both are folded away as
+	// prose and must survive in the closet.
+	for _, want := range []string{"/srv/api/gateway.c", "INC-91024"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("identifier %q was lost in the fold", want)
+		}
+	}
+}
+
+// THE PROPERTY THE CLAUDE CHANGE RESTS ON. Anthropic was excluded from the gateway
+// because mutating its wire "would bust the cached prefix" -- true of a gateway
+// that re-folded from cold every turn. With a persisted freeze the prefix must move
+// at most once and then hold byte-identical, because a prefix that moves every turn
+// costs a cache read every turn and folding would be worse than doing nothing.
+func TestGatewayFreezeHoldsAcrossAnthropicTurns(t *testing.T) {
+	cfg := &ReduceConfig{
+		GatewaySeam: true,
+		HistoryFold: true,
+		Fold: FoldConfig{
+			Closet:           ClosetConfig{Enabled: true},
+			CompactHeadBytes: 40,
+		},
+	}
+	// One state carried across turns, exactly as the seam persists and reloads it.
+	st := &ReduceState{Freeze: FoldFreeze{TailCapMsgs: 16}, Recall: NewRecallIndex()}
+
+	prevPrefix := ""
+	prevEpochs := -1
+	reuses := 0
+
+	for turn := 0; turn < 10; turn++ {
+		m := anthropicFixture(8 + turn) // the conversation grows, as a real one does
+		st.Turn = turn
+		out := Reduce(m, "sys", SeamGateway, cfg, st)
+		st.Reduced = false
+
+		if !out.Mutated || out.Messages == nil {
+			continue
+		}
+		prefix := PrintJSONUnformatted(out.Messages.At(0))
+		if prevPrefix != "" && out.Epochs == prevEpochs {
+			if prefix != prevPrefix {
+				t.Fatalf("turn %d: the frozen prefix changed without an epoch advance; "+
+					"an anthropic upstream would miss its cache on every turn", turn)
+			}
+			reuses++
+		}
+		prevPrefix = prefix
+		prevEpochs = out.Epochs
+	}
+
+	if reuses == 0 {
+		t.Fatal("the freeze never held across turns: folding here would cost a cache " +
+			"read every turn, which is the exact reason anthropic used to be excluded")
+	}
+}
+
+// State has to survive the round trip the seam actually performs: serialize, store,
+// reload. If the freeze boundary does not survive it, every gateway turn starts cold
+// and the freeze is decorative.
+func TestGatewayFreezeSurvivesStateRoundTrip(t *testing.T) {
+	cfg := &ReduceConfig{
+		GatewaySeam: true,
+		HistoryFold: true,
+		Fold: FoldConfig{
+			Closet:           ClosetConfig{Enabled: true},
+			CompactHeadBytes: 40,
+		},
+	}
+	st := &ReduceState{Freeze: FoldFreeze{TailCapMsgs: 16}, Recall: NewRecallIndex()}
+	m := anthropicFixture(8)
+	first := Reduce(m, "sys", SeamGateway, cfg, st)
+	if !first.Mutated || first.Messages == nil {
+		t.Fatal("first gateway fold did not engage")
+	}
+	firstPrefix := PrintJSONUnformatted(first.Messages.At(0))
+
+	// Round-trip through exactly what the seam stores.
+	blob, ok := SerializeState(st)
+	if !ok || blob == "" {
+		t.Fatal("the seam would have nothing to persist")
+	}
+	restored := &ReduceState{Recall: NewRecallIndex()}
+	if err := RestoreState(restored, blob); err != nil {
+		t.Fatalf("state did not survive the round trip: %v", err)
+	}
+	restored.Turn = 1
+
+	second := Reduce(anthropicFixture(9), "sys", SeamGateway, cfg, restored)
+	if !second.Mutated || second.Messages == nil {
+		t.Fatal("second gateway fold did not engage after reload")
+	}
+	if second.Epochs == first.Epochs {
+		if got := PrintJSONUnformatted(second.Messages.At(0)); got != firstPrefix {
+			t.Error("the frozen prefix changed across a state reload without an epoch " +
+				"advance; the persisted boundary is not being honoured")
+		}
+	}
+}

--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -11,6 +11,75 @@
 #include "config.h"
 #include "gateway_mutate.h"
 #include "gw_mutate_stats.h"
+#include "log.h"
+#include "token_tracker.h" /* token_estimate_cost_ex, for the freeze guardrail */
+
+/* Declared rather than including db1.h, the same way agent_runtime.c does: this
+ * seam needs exactly two calls, and pulling the whole db1 surface into an
+ * economizer translation unit would widen the module's dependencies for nothing. */
+int db1_economizer_state_save(const char *session_id, const char *json);
+int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz);
+
+/* The gateway's reducer state is keyed by session key AND a conversation
+ * fingerprint, in its own namespace.
+ *
+ * The namespace prefix keeps it clear of the delegate seam, which keys state by
+ * conversation id: without it a gateway key that happened to equal a conversation
+ * id would load and overwrite that conversation's freeze boundary.
+ *
+ * The fingerprint is the part that matters for correctness. msg_session_key_resolve
+ * is deliberately per-IDENTITY -- "to group one identity's sessions under a stable
+ * key" -- so one user with two concurrent conversations resolves to ONE key. Keyed
+ * on that alone, the two would share a freeze boundary and thrash: each turn would
+ * find the other's prefix digest, fail the match, and re-epoch, so the freeze would
+ * never hold and folding would cost cache reads instead of saving them. Hashing the
+ * first message separates conversations, and it is stable across their turns because
+ * a conversation's opening message does not change. If a client rewrites its history
+ * the fingerprint moves, which correctly reads as a different conversation. */
+static uint64_t gw_fnv1a(const char *s)
+{
+   uint64_t h = 1469598103934665603ull;
+   for (; s && *s; s++)
+   {
+      h ^= (unsigned char)*s;
+      h *= 1099511628211ull;
+   }
+   return h;
+}
+
+static void gw_state_key(const char *skey, cJSON *msgs, char *out, size_t out_sz)
+{
+   uint64_t fp = 0;
+   cJSON *first = msgs ? cJSON_GetArrayItem(msgs, 0) : NULL;
+   if (first)
+   {
+      char *txt = cJSON_PrintUnformatted(first);
+      if (txt)
+      {
+         fp = gw_fnv1a(txt);
+         free(txt);
+      }
+   }
+   snprintf(out, out_sz, "gw:%s:%016llx", skey ? skey : "", (unsigned long long)fp);
+}
+
+/* The module overwrites its loaded state's turn with the request's, so the seam
+ * has to supply an increasing one. The gateway has no turn counter of its own,
+ * so read it back out of the state we persisted last time. Turn drives only the
+ * recall page-table TTL, so a restart resetting it to 0 costs recall freshness
+ * for one session, never correctness. */
+static int gw_state_next_turn(const char *state_json)
+{
+   if (!state_json || !state_json[0])
+      return 0;
+   cJSON *root = cJSON_Parse(state_json);
+   if (!root)
+      return 0;
+   cJSON *turn = cJSON_GetObjectItemCaseSensitive(root, "turn");
+   int next = cJSON_IsNumber(turn) ? turn->valueint + 1 : 0;
+   cJSON_Delete(root);
+   return next;
+}
 
 int gw_economizer_measure(cJSON *messages, const char *system_prompt, const char *model,
                           int retained_msgs, gw_reduce_report_t *out)
@@ -71,14 +140,29 @@ int gw_mutate_is_enabled(void)
 
 int gw_mutate_upstream_ok(int upstream_is_anthropic)
 {
-   /* Gateway wire-mutation is OpenAI-only by policy. An Anthropic upstream serves a
-    * byte-verbatim, prompt-cached passthrough (build_anthropic_parity_headers); mutating
-    * the wire there would bust the cached prefix AND force the request off the parity
-    * passthrough. Reducing that upstream cache-coherently is the pre-economize seam's job
-    * (delegate seam / tool_condense), not the gateway's. So the live mutator engages only
-    * when the serving upstream is NOT Anthropic. `upstream_is_anthropic` is the caller's
-    * driver_is_anthropic()/parity signal. */
-   return !upstream_is_anthropic && gw_mutate_is_enabled();
+   /* ANTHROPIC MUTATES TOO, now that the gateway holds a freeze boundary.
+    *
+    * The old policy was OpenAI-only, because mutating an Anthropic wire "would bust
+    * the cached prefix". That was true of a gateway with no state: every turn
+    * re-folded from cold, so every turn moved the prefix and every turn missed the
+    * cache. It is not true of one that persists a freeze per session. The fold moves
+    * the prefix ONCE, when it first engages; from the next turn the frozen prefix is
+    * byte-identical and the cache reads resume. One miss, bounded, in exchange for
+    * every later turn carrying a folded history.
+    *
+    * Deferring to "the pre-economize seam" was not a real alternative either: that
+    * seam is the delegate loop, which a proxied client never enters. An Anthropic
+    * client through the gateway had NO reduction path at all.
+    *
+    * On the provider's cache breakpoints: the economizer still neither adds, removes,
+    * nor moves one, and the live-surface guard greps this file to keep it that way --
+    * strictly enough that naming the field here in prose trips it, which is the right
+    * trade. Folding can retire a message that happened to carry a breakpoint, leaving
+    * FEWER of them, and fewer is legal (Anthropic caps them at four rather than
+    * requiring them). What it must never do is leave one attached to content that
+    * moved, which is exactly what the freeze prevents. */
+   (void)upstream_is_anthropic;
+   return gw_mutate_is_enabled();
 }
 
 void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
@@ -128,18 +212,91 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    }
 
    /* The reduction itself lives in the Go economizer module now; this seam
-    * resolves config and owns the pristine/restore contract. Compress-only at the
-    * gateway: there is no per-conversation state here to hold a freeze boundary,
-    * so the fold has nothing to freeze. */
+    * resolves config and owns the pristine/restore contract.
+    *
+    * THE GATEWAY FOLDS. It used to be compress-only, for the stated reason that
+    * "there is no per-conversation state here to hold a freeze boundary" -- true
+    * of the seam, but not of the deployment: the per-identity session key resolved
+    * above is exactly such a handle, and the reducer state keyed by it survives
+    * between requests in the same place the delegate seam keeps its own. Without
+    * this the gateway could never fold for ANY provider, so the biggest context
+    * consumer aimee has was reachable only through its own agent loop. */
+   char state_blob[ECON_MODULE_STATE_MAX];
+   state_blob[0] = '\0';
+   char skey_ns[MSG_SESSION_KEY_LEN + 24];
+   gw_state_key(ctx->skey, msgs, skey_ns, sizeof skey_ns);
+   (void)db1_economizer_state_load(skey_ns, state_blob, sizeof state_blob);
+
    econ_module_request_t mreq;
    memset(&mreq, 0, sizeof mreq);
    mreq.compress = 1;
+   mreq.history_fold = 1;
    mreq.retained_msgs = config_fold_retained_msgs();
+   mreq.min_fold_msgs = config_fold_min_fold_msgs();
+   mreq.excerpt_bytes = config_fold_excerpt_bytes();
+   mreq.compact_head_bytes = config_compact_head_bytes();
+   mreq.compact_tail_bytes = config_compact_tail_bytes();
+   mreq.register_enabled = config_fold_register_enabled();
+   mreq.closet_enabled = config_coord_closet_enabled();
+   mreq.closet_budget_bytes = config_coord_closet_budget_bytes();
+   mreq.closet_max_ratio_pct = config_coord_closet_max_ratio_pct();
+   mreq.recall_enabled = config_fold_recall_enabled();
+   mreq.recall_ttl_turns = config_fold_recall_ttl_turns();
+   mreq.recall_inject = config_fold_recall_inject();
+   mreq.state = state_blob[0] ? state_blob : NULL;
+   mreq.turn = gw_state_next_turn(state_blob);
+
+   char closet_denylist[CONFIG_COPY_MAX];
+   config_coord_closet_denylist_copy(closet_denylist, sizeof(closet_denylist));
+   mreq.closet_denylist = closet_denylist[0] ? closet_denylist : NULL;
+
+   /* The freeze is what makes folding safe for a prefix-cached upstream, so it is
+    * not optional here the way it is a tunable on the delegate seam. The module
+    * does the arithmetic; this side supplies the per-tier rates. */
+   mreq.freeze_guard_enabled = 1;
+   mreq.freeze_guard_horizon = ep.freeze_guard_horizon;
+   {
+      token_usage_t w = {0}, in = {0}, rd = {0};
+      w.cache_write_tokens = 1000;
+      in.input_tokens = 1000;
+      rd.cache_read_tokens = 1000;
+      int priced = 0;
+      double wc = token_estimate_cost_ex(model, &w, &priced);
+      if (priced)
+      {
+         mreq.priced = 1;
+         mreq.write_cost = wc;
+         mreq.input_cost = token_estimate_cost_ex(model, &in, NULL);
+         mreq.read_cost = token_estimate_cost_ex(model, &rd, NULL);
+      }
+   }
 
    cJSON *reduced = NULL;
    econ_module_result_t mres;
    int rrc =
        econ_module_reduce(msgs, system_prompt, ECON_MODULE_SEAM_GATEWAY, &mreq, &reduced, &mres);
+
+   /* Persist BEFORE the apply decision, and regardless of it. The freeze boundary
+    * has to advance on every turn the module saw, not only the ones that shipped a
+    * reduced payload: drop it on a bypass and the next turn re-folds from cold,
+    * which moves the prefix and costs the cache read the freeze exists to keep.
+    * Mirrors the delegate seam, which persists on the same unconditional terms. */
+   if (mres.state && mres.state[0])
+      (void)db1_economizer_state_save(skey_ns, mres.state);
+
+   /* One line per gateway reduction, because until now this seam was invisible:
+    * its telemetry goes to the obs bus, nothing reached server.log, and proving
+    * whether it had run at all meant inferring from token deltas. reused=1 is the
+    * signal that actually matters -- it means the freeze held and the folded prefix
+    * was byte-identical to last turn, which is the difference between folding that
+    * pays for itself and folding that burns a cache read every turn. */
+   if (rrc == 0)
+      aimee_log(LOG_INFO, "economizer.gateway",
+                "seam=gateway mutated=%d reason=%s baseline=%d reduced=%d removed=%d "
+                "folded=%d retained=%d reused=%d",
+                mres.mutated, mres.reason[0] ? mres.reason : "none", mres.baseline_tokens,
+                mres.reduced_tokens, mres.removed_tokens, mres.folded_msgs, mres.retained_msgs,
+                mres.reused_boundary);
 
    /* Reuse the pure decision helper by handing it the module's ledger. An
     * unreachable module is a no-op, not an internal error: the request is

--- a/src/modules/economizer/gateway_mutate_wire.h
+++ b/src/modules/economizer/gateway_mutate_wire.h
@@ -40,11 +40,12 @@ extern "C"
     * OFF hot path. gw_buffered_mutate re-checks internally (defense in depth). */
    int gw_mutate_is_enabled(void);
 
-   /* Provider-gated enable: gateway wire-mutation is OpenAI-only. Returns true only when
-    * the serving upstream is NOT Anthropic AND gw_mutate_is_enabled(). An Anthropic upstream
-    * is a byte-verbatim prompt-cached passthrough, so it is reduced (if at all) at the
-    * pre-economize seam, never by mutating the live wire. `upstream_is_anthropic` is the
-    * caller's driver_is_anthropic()/parity signal. */
+   /* Enable gate, now provider-agnostic: returns gw_mutate_is_enabled() for every
+    * upstream. Anthropic was excluded while the gateway kept no state and therefore
+    * re-folded from cold every turn, moving the prefix each time; with a per-session
+    * freeze the prefix moves once and then holds, so the vendor is no longer the
+    * deciding factor. `upstream_is_anthropic` is retained for the callers' existing
+    * driver_is_anthropic()/parity signal and for a future provider-specific rule.  */
    int gw_mutate_upstream_ok(int upstream_is_anthropic);
 
    /* Pre-send: under the aggressive-tier live mutation, resolve the session key from the thread-

--- a/src/modules/economizer/module.yaml
+++ b/src/modules/economizer/module.yaml
@@ -58,6 +58,7 @@
     "server-go/modules/economizer/eager_test.go",
     "server-go/modules/economizer/episode_test.go",
     "server-go/modules/economizer/fold_test.go",
+    "server-go/modules/economizer/gateway_anthropic_test.go",
     "server-go/modules/economizer/gateway_test.go",
     "server-go/modules/economizer/gateway_wire_test.go",
     "server-go/modules/economizer/json_compact_test.go",

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -898,6 +898,18 @@ native_provider_http:
                                    &reduced_messages, &econ_res) == 0 &&
                 econ_res.mutated && reduced_messages)
                reduce_active = 1;
+            /* Same line the gateway seam emits, for the same reason: the delegate
+             * seam recorded NOTHING about what a reduction saved.
+             * agent_record_reduce_ledger was deleted as having no callers and
+             * nothing replaced it, so the only way to tell whether the fold had run
+             * was to diff token counts between two deploys. reused=1 means the
+             * freeze held and the prefix was byte-identical to last turn. */
+            aimee_log(LOG_INFO, "economizer.delegate",
+                      "seam=delegate mutated=%d reason=%s baseline=%d reduced=%d removed=%d "
+                      "folded=%d retained=%d reused=%d",
+                      econ_res.mutated, econ_res.reason[0] ? econ_res.reason : "none",
+                      econ_res.baseline_tokens, econ_res.reduced_tokens, econ_res.removed_tokens,
+                      econ_res.folded_msgs, econ_res.retained_msgs, econ_res.reused_boundary);
             /* Persist the state the module handed back, so the freeze boundary
              * and page table survive into the next turn. */
             if (econ_res.state && econ_res.state[0])

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -511,8 +511,9 @@ static int messages_buffered(const char *body, char *resp, int cap)
     * the pointer cached above (line ~397) could now dangle. */
    model = jo_cstr(req, "model");
 
-   /* Only AGGRESSIVE and only an OpenAI-family upstream. Native Anthropic
-    * requests keep the client's exact cache prefix and cache_control layout. */
+   /* Only AGGRESSIVE. Native Anthropic requests are mutated too now: the gateway
+    * holds a per-session freeze, so a folded prefix stays byte-identical after the
+    * turn it first engages, which is what the client's cache prefix needs. */
    if (gw_mutate_upstream_ok(parity))
    {
       char *mut_sys = anthropic_system_to_text(req);

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1183,9 +1183,10 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
 
    int tok = agent_request_max_tokens(agent, max_tokens);
 
-   /* AGGRESSIVE may apply the existing lossy reducer to OpenAI-family request
-    * history. SAFE never enters this path. Anthropic-backed routes remain
-    * untouched to preserve their cache prefix. */
+   /* AGGRESSIVE may apply the existing lossy reducer to request history. SAFE
+    * never enters this path. Anthropic-backed routes are no longer excluded: the
+    * gateway's per-session freeze keeps a folded prefix byte-identical, which is
+    * what their cache prefix actually requires. */
    gw_mutate_ctx_t gwmc;
    gw_mutate_ctx_init(&gwmc);
    cJSON *mbox = NULL;

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -15,6 +15,29 @@
 #include "platform_path.h"
 #include "platform_test_util.h"
 
+/* The seam now carries reducer state per session so it can hold a freeze boundary.
+ * These fixtures stand in for db1 rather than linking sqlite into what is a pure
+ * decision fixture: every test below runs with the module unreachable, so the seam
+ * bypasses before it would ever read a state blob. Persistence itself is covered by
+ * the Go module's state tests and verified live on the deploy. */
+int db1_economizer_state_save(const char *session_id, const char *json);
+int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz);
+
+int db1_economizer_state_save(const char *session_id, const char *json)
+{
+   (void)session_id;
+   (void)json;
+   return 0;
+}
+
+int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz)
+{
+   (void)session_id;
+   if (out && out_sz)
+      out[0] = '\0';
+   return -1; /* "no state": the first turn of a session takes this path */
+}
+
 /* A container {"messages":[<msg>]} whose single message tags which array it is. */
 static cJSON *container_with(const char *tag)
 {
@@ -252,14 +275,15 @@ static void test_no_behavior_change_when_off(void)
 
 static void test_upstream_provider_gate(void)
 {
-   /* Policy: gateway wire-mutation is OpenAI-only. An Anthropic upstream is ALWAYS excluded,
-    * regardless of the enable state, so its prompt-cached verbatim passthrough is never
-    * mutated. For a non-Anthropic upstream the helper simply mirrors the base enable gate
-    * (off under this test's default config HOME). */
-   assert(gw_mutate_upstream_ok(1) == 0);                      /* Anthropic: never mutate */
-   assert(gw_mutate_upstream_ok(0) == gw_mutate_is_enabled()); /* non-Anthropic: base gate */
+   /* Policy: the upstream's provider no longer decides. Anthropic was excluded while
+    * the gateway had no freeze boundary to keep a folded prefix byte-stable; now that
+    * it persists one per session, BOTH providers follow the same base enable gate.
+    * The gate that matters is the tier, not the vendor. */
+   assert(gw_mutate_upstream_ok(1) == gw_mutate_is_enabled()); /* Anthropic: base gate */
+   assert(gw_mutate_upstream_ok(0) == gw_mutate_is_enabled()); /* non-Anthropic: same */
    assert(gw_mutate_is_enabled() == 0);                        /* default config -> dark */
    assert(gw_mutate_upstream_ok(0) == 0);                      /* so both are off here */
+   assert(gw_mutate_upstream_ok(1) == 0);                      /* including Anthropic */
 }
 
 /* gw_stat_to_json: the JSON the /v1/economizer/stats endpoint serves reflects the


### PR DESCRIPTION
Two changes that only make sense together, both aimed at one goal: the economizer working over the gateway for chatgpt **and** claude.

## The gateway now holds a freeze boundary

It was compress-only, for the stated reason that *"there is no per-conversation state here to hold a freeze boundary, so the fold has nothing to freeze."* That was true of the seam and false of the deployment: the per-identity session key it already resolves is exactly such a handle, and reducer state keyed by it persists in the same place the delegate seam keeps its own.

Without this the gateway could never fold for **any** provider — so a proxied client, which never enters the delegate loop, had no history reduction at all.

**State is keyed by session key AND a hash of the first message.** `msg_session_key_resolve` is per-IDENTITY by design ("to group one identity's sessions under a stable key"), so one user with two live conversations resolves to ONE key. Sharing a freeze between them would make each turn find the other's prefix digest, fail the match and re-epoch — the freeze would never hold, and folding would *cost* cache reads rather than save them. The first message is stable across a conversation's turns and differs between conversations, which is the discriminator needed.

## Anthropic is no longer excluded

The old rule was OpenAI-only because mutating an Anthropic wire "would bust the cached prefix". True of a stateless gateway that re-folded from cold every turn; not true of one that persists a freeze. The prefix moves **once** and then holds byte-identical — one miss, not one per turn.

The suggested alternative — reduce at "the pre-economize seam" — was never available to these requests, because that seam is the delegate loop.

On the provider's cache breakpoints: the economizer still neither adds, removes, nor moves one. Folding can retire a message that carried one, leaving *fewer*, which is legal (Anthropic caps them at four rather than requiring them).

## Observability

Adds the one log line this seam never had. Its telemetry goes to the obs bus and nothing reached `server.log`, so answering "did the gateway reduce anything?" meant inferring from token deltas. `reused=1` is the field that matters — it means the freeze held.

## Verification

`make lint` all 54 checks pass; full unit suite passes; `unit-test-gateway-mutate-wire` and `unit-test-gateway-mutate` pass.

Four new Go tests on Anthropic's content-block shape:
- `tool_use`/`tool_result` pairs survive unorphaned
- identifiers are conserved verbatim through the fold
- the freeze holds byte-identical across ten growing turns
- it survives the serialize/store/reload round trip the seam actually performs

**Limit, stated plainly:** CT 403 has no Claude credentials — no models, no traffic, not one mention in its log — so the claude path could not be exercised end to end. These tests pin the reducer mechanics; what remains unverified is the wire contract with Anthropic itself. That needs a box with Claude credentials.
