### PR TITLE
fix: publish the host session id so one session is one worktree

### DIFF
--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -8,7 +8,8 @@
 #include "session_degraded_notice.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h"     /* attn_require_session_worktree */
-#include "client_session_worktree.h" /* client_session_worktree_ensure */
+#include "client_session_worktree.h" /* client_session_worktree_ensure, _id_publish */
+#include "aimee_home.h"              /* aimee_home */
 #include "cmd_self_update.h"         /* aimee_self_update_notice */
 #include "agent_code_capabilities.h"
 #include "aimee_session_guidance.h"
@@ -583,6 +584,20 @@ int handle_session_start(int json_output)
    cJSON *hook_json = stdin_data ? cJSON_Parse(stdin_data) : NULL;
    if (client_hook_payload_session_id(hook_json, hook_sid, sizeof(hook_sid)))
       sid = hook_sid;
+
+   /* Share it with the rest of the session BEFORE any transport choice, because
+    * both branches below return.
+    *
+    * This hook holds the only authoritative copy of the host's session id, and
+    * used to keep it: it built its worktree from the id and then exited. `aimee
+    * mcp serve`, which has no way to learn it, fell through to minting a random
+    * one -- so the same Claude Code session ran on TWO session ids and therefore
+    * two worktrees, with the proxy (and every delegate and `aimee git` call
+    * behind it) bound to the empty one and refusing the worktree that actually
+    * held the work. Publishing here is the half of that rendezvous that was
+    * never written; the reader has always been there. */
+   if (sid && sid[0])
+      (void)client_session_id_publish(sid, aimee_home());
 
    /* Detect server-invoked context: AIMEE_SESSION_ID is set by chat_stream_worker
     * in the environment of the claude subprocess it forks. */

--- a/src/client_session_worktree.c
+++ b/src/client_session_worktree.c
@@ -28,6 +28,126 @@ void client_session_worktree_key(const char *sid, char *out, size_t cap)
 }
 
 #ifndef _WIN32
+/* --- Session-id rendezvous -------------------------------------------------
+ *
+ * Every process of one agent session must agree on the session id, because the
+ * worktree is keyed on it: disagree and the session gets TWO worktrees, and
+ * whichever process holds the wrong one operates on an empty checkout. That is
+ * not hypothetical -- a Claude Code session was landing its edits in the
+ * hook's worktree while `aimee git` and every delegate were bound to the
+ * proxy's, which refused the real one as "outside the session checkout".
+ *
+ * The rendezvous is a file named for a process both sides can name. `aimee mcp
+ * serve` reads session-ppid-<its own ppid>, and its parent IS the host process
+ * (verified: the proxy is a direct child of `claude`). The hook cannot use its
+ * own getppid() for this: its command carries an environment assignment, so the
+ * host must run it through a shell, and the hook is therefore a GRANDchild --
+ * publishing under its immediate parent would name a shell that exits
+ * immediately and that the proxy never asks about.
+ *
+ * So the hook walks up to the host and publishes there as well. Only as far as
+ * the host: publishing under every ancestor would eventually name something
+ * shared (a terminal, a service manager) and hand one session's id to an
+ * unrelated one -- the precise collision the ppid key exists to avoid. */
+#if defined(__linux__)
+/* The parent of `pid`, or 0 when it cannot be read. Parsed from the END of
+ * /proc/<pid>/stat: comm sits in field 2 wrapped in parentheses and may itself
+ * contain spaces or ')', so everything before the LAST ") " is skipped rather
+ * than tokenising from the front. */
+static pid_t csw_parent_of(pid_t pid)
+{
+   char path[64];
+   snprintf(path, sizeof(path), "/proc/%d/stat", (int)pid);
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return 0;
+   char buf[512];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   fclose(f);
+   buf[n] = '\0';
+   char *tail = strrchr(buf, ')');
+   if (!tail || !tail[1])
+      return 0;
+   int ppid = 0;
+   char state = 0;
+   if (sscanf(tail + 1, " %c %d", &state, &ppid) != 2 || ppid <= 0)
+      return 0;
+   return (pid_t)ppid;
+}
+
+static int csw_comm_is(pid_t pid, const char *name)
+{
+   char path[64];
+   snprintf(path, sizeof(path), "/proc/%d/comm", (int)pid);
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return 0;
+   char buf[64] = "";
+   if (!fgets(buf, sizeof(buf), f))
+   {
+      fclose(f);
+      return 0;
+   }
+   fclose(f);
+   buf[strcspn(buf, "\r\n")] = '\0';
+   return strcmp(buf, name) == 0;
+}
+#endif /* __linux__ */
+
+/* Write `sid` to <aimee_home>/session-ppid-<pid>. Authoritative: the caller
+ * holds the id the HOST assigned, which outranks anything a peer minted for
+ * itself, so this truncates rather than failing on an existing file. */
+static void csw_publish_at(const char *home, pid_t pid, const char *sid)
+{
+   char path[4200];
+   if (snprintf(path, sizeof(path), "%s/session-ppid-%d", home, (int)pid) >= (int)sizeof(path))
+      return;
+   int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+   if (fd < 0)
+      return;
+   size_t len = strlen(sid);
+   ssize_t wrote = write(fd, sid, len);
+   (void)wrote;
+   close(fd);
+}
+
+int client_session_id_publish(const char *sid, const char *home)
+{
+   if (!sid || !sid[0] || !home || !home[0])
+      return -1;
+   /* Reject anything that could escape the filename or the file's one-line
+    * contract; a session id is an opaque token from the host, not a path. */
+   for (const char *p = sid; *p; p++)
+      if (*p == '/' || *p == '\n' || *p == '\r' || (unsigned char)*p < 0x20)
+         return -1;
+
+   int published = 0;
+   pid_t parent = getppid();
+   if (parent > 1)
+   {
+      csw_publish_at(home, parent, sid);
+      published++;
+   }
+#if defined(__linux__)
+   /* Up to the host process, and no further. */
+   pid_t pid = parent;
+   for (int depth = 0; depth < 8 && pid > 1; depth++)
+   {
+      if (csw_comm_is(pid, "claude"))
+      {
+         if (pid != parent)
+         {
+            csw_publish_at(home, pid, sid);
+            published++;
+         }
+         break;
+      }
+      pid = csw_parent_of(pid);
+   }
+#endif
+   return published > 0 ? 0 : -1;
+}
+
 /* Run `git <argv...>` with NO shell (fork/execvp), discarding stderr. Captures
  * the first trimmed stdout line into out[cap] (out may be NULL — status only).
  * Returns the child's exit code (0 = success), or -1 if it could not be spawned
@@ -361,6 +481,13 @@ int client_session_worktree_base(const char *git_root, char *buf, size_t cap)
    (void)git_root;
    if (buf && cap)
       buf[0] = '\0';
+   return -1;
+}
+
+int client_session_id_publish(const char *sid, const char *home)
+{
+   (void)sid;
+   (void)home;
    return -1;
 }
 

--- a/src/headers/client_session_worktree.h
+++ b/src/headers/client_session_worktree.h
@@ -61,4 +61,20 @@ int client_session_worktree_base(const char *git_root, char *buf, size_t cap);
  * tests and so both call sites derive the same key. */
 void client_session_worktree_key(const char *sid, char *out, size_t cap);
 
+/* Publish the HOST-assigned session id under <home>/session-ppid-<pid> so the
+ * session's other processes resolve the same one, and therefore the same
+ * worktree. Written for the caller's parent AND, on Linux, for the host process
+ * found by walking up to it -- a hook whose command carries an env assignment
+ * runs under a shell and so is a grandchild, while `aimee mcp serve` is a direct
+ * child and reads the key named for the host. The walk stops at the host so no
+ * shared ancestor (terminal, service manager) is ever named.
+ *
+ * Authoritative: truncates an existing file, because the host's id outranks one
+ * a peer minted for itself when it could not find this. Rejects a sid
+ * containing '/', a newline, or a control character.
+ *
+ * Returns 0 when at least one location was published, -1 otherwise (including
+ * on Windows, where session-worktree isolation is not a feature). */
+int client_session_id_publish(const char *sid, const char *home);
+
 #endif /* DEC_CLIENT_SESSION_WORKTREE_H */

--- a/src/tests/test_client_session_worktree.c
+++ b/src/tests/test_client_session_worktree.c
@@ -15,6 +15,10 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <sys/wait.h>
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
 
 static char g_tmp_root[512];
 
@@ -355,6 +359,148 @@ static void test_reclaim_keeps_a_dirty_pre_rekey_worktree(void)
    printf("  reclaim: dirty pre-rekey worktree kept, not destroyed: ok\n");
 }
 
+/* Read back what client_session_id_publish wrote for `pid`, or "" if absent. */
+static void read_published(const char *home, pid_t pid, char *out, size_t cap)
+{
+   out[0] = '\0';
+   char path[4200];
+   snprintf(path, sizeof path, "%s/session-ppid-%d", home, (int)pid);
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return;
+   if (fgets(out, (int)cap, f))
+      out[strcspn(out, "\r\n")] = '\0';
+   fclose(f);
+}
+
+/* The publish half of the session-id rendezvous. Without it `aimee mcp serve`
+ * finds nothing, mints its own id, and the session ends up on two worktrees. */
+static void test_publish_reaches_the_parent(void)
+{
+   char home[4200];
+   snprintf(home, sizeof home, "%s/publish-home", g_tmp_root);
+   shell("mkdir -p '%s'", home);
+
+   assert(client_session_id_publish("sess-abc-123", home) == 0);
+
+   char got[128];
+   read_published(home, getppid(), got, sizeof got);
+   assert(strcmp(got, "sess-abc-123") == 0);
+
+   /* Authoritative: the host's id replaces one a peer minted for itself, so a
+    * second publish must overwrite rather than leave the stale value. */
+   assert(client_session_id_publish("sess-xyz-999", home) == 0);
+   read_published(home, getppid(), got, sizeof got);
+   assert(strcmp(got, "sess-xyz-999") == 0);
+
+   printf("  PASS: publish reaches the parent and overwrites\n");
+}
+
+/* A session id is an opaque host token, not a path fragment: anything that
+ * could escape the filename or the file's one-line contract is refused rather
+ * than written somewhere unintended. */
+static void test_publish_rejects_unusable_ids(void)
+{
+   char home[4200];
+   snprintf(home, sizeof home, "%s/publish-home-reject", g_tmp_root);
+   shell("mkdir -p '%s'", home);
+
+   assert(client_session_id_publish("../escape", home) == -1);
+   assert(client_session_id_publish("has\nnewline", home) == -1);
+   assert(client_session_id_publish("", home) == -1);
+   assert(client_session_id_publish(NULL, home) == -1);
+   assert(client_session_id_publish("fine", NULL) == -1);
+
+   printf("  PASS: publish refuses ids it cannot name a file for\n");
+}
+
+#if defined(__linux__)
+/* The walk is the whole point, and it is the part that is easy to get wrong.
+ *
+ * The hook is NOT a direct child of the host: its command carries an env
+ * assignment, so the host runs it through a shell. Publishing only under
+ * getppid() therefore names a shell that exits immediately, and `aimee mcp
+ * serve` -- which reads the key named for its OWN parent, the host -- never
+ * finds it. Rebuild that exact chain here: a process renamed "claude", a
+ * stand-in shell beneath it, and the publisher beneath that. */
+static void test_publish_walks_past_the_shell_to_the_host(void)
+{
+   char home[4200];
+   snprintf(home, sizeof home, "%s/publish-home-walk", g_tmp_root);
+   shell("mkdir -p '%s'", home);
+
+   pid_t host = fork();
+   assert(host >= 0);
+   if (host == 0)
+   {
+      prctl(PR_SET_NAME, "claude", 0, 0, 0);
+      pid_t sh = fork(); /* stands in for the shell the host spawns */
+      if (sh == 0)
+      {
+         /* fork() INHERITS comm, so this must be renamed or it would still read
+          * "claude" and the walk would stop here. The real shell is execve'd,
+          * which resets it — rename to match rather than let the test pass for
+          * a reason production does not have. */
+         prctl(PR_SET_NAME, "sh", 0, 0, 0);
+         pid_t hook = fork();
+         if (hook == 0)
+         {
+            _exit(client_session_id_publish("host-assigned-sid", home) == 0 ? 0 : 1);
+         }
+         int st = 1;
+         waitpid(hook, &st, 0);
+         _exit(WIFEXITED(st) ? WEXITSTATUS(st) : 1);
+      }
+      int st = 1;
+      waitpid(sh, &st, 0);
+      _exit(WIFEXITED(st) ? WEXITSTATUS(st) : 1);
+   }
+   int status = 1;
+   waitpid(host, &status, 0);
+   assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+   /* The host's key is what the proxy will ask for. */
+   char got[128];
+   read_published(home, host, got, sizeof got);
+   assert(strcmp(got, "host-assigned-sid") == 0);
+
+   printf("  PASS: publish walks past the shell and names the host\n");
+}
+
+/* And it must stop there. Publishing under every ancestor would eventually name
+ * a terminal or a service manager and hand one session's id to an unrelated
+ * one -- the collision the per-process key exists to prevent. */
+static void test_publish_stops_at_the_host(void)
+{
+   char home[4200];
+   snprintf(home, sizeof home, "%s/publish-home-stop", g_tmp_root);
+   shell("mkdir -p '%s'", home);
+
+   pid_t host = fork();
+   assert(host >= 0);
+   if (host == 0)
+   {
+      prctl(PR_SET_NAME, "claude", 0, 0, 0);
+      pid_t hook = fork();
+      if (hook == 0)
+         _exit(client_session_id_publish("host-assigned-sid", home) == 0 ? 0 : 1);
+      int st = 1;
+      waitpid(hook, &st, 0);
+      _exit(WIFEXITED(st) ? WEXITSTATUS(st) : 1);
+   }
+   int status = 1;
+   waitpid(host, &status, 0);
+   assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+   /* This test process is the host's parent — it must NOT have been named. */
+   char got[128];
+   read_published(home, getpid(), got, sizeof got);
+   assert(got[0] == '\0');
+
+   printf("  PASS: publish stops at the host, not above it\n");
+}
+#endif /* __linux__ */
+
 int main(void)
 {
    printf("client session worktree bootstrap\n");
@@ -375,6 +521,12 @@ int main(void)
    test_ensure_requires_a_session_id_and_a_repo();
    test_ensure_reclaims_pre_rekey_worktree();
    test_reclaim_keeps_a_dirty_pre_rekey_worktree();
+   test_publish_reaches_the_parent();
+   test_publish_rejects_unusable_ids();
+#if defined(__linux__)
+   test_publish_walks_past_the_shell_to_the_host();
+   test_publish_stops_at_the_host();
+#endif
 
    shell("rm -rf '%s'", g_tmp_root);
    printf("all client session worktree tests passed\n");

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -375,7 +375,7 @@
         },
         {
           "path": "src/headers/client_session_worktree.h",
-          "sha256": "762ba612370db270a14cc4ac10f88f709ffbf43bc6b8d9754730cbe51b0dc4e0"
+          "sha256": "78e22b1a9a6ffc2ce266738e554a91032f6ffe7d104cf066b446b55890c555db"
         },
         {
           "path": "src/headers/cmd_agent_delegate_impl.h",
@@ -1628,7 +1628,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "48dd546a79fe56458eb9175e38a6eed1fabce8b06c130db0adba046ad2ac42c2",
+      "sha256": "47b461467f57f15215477ad9b31d0e8c721ff600adafa6fedb0a913eeacc86cc",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
A Claude Code session was running on **two session ids**, and therefore two worktrees.

The SessionStart hook resolved the host-assigned id, built `.aimee/worktrees/<key>/main` from it, and exited without telling anyone. `aimee mcp serve` has no way to learn that id: it checks `AIMEE_SESSION_ID` (the host does not set it for MCP servers), then `session-ppid-<its ppid>` (nobody had ever written one), then mints a random UUID — keying a second, empty worktree.

Everything behind the proxy went to the empty one: delegates launched against a checkout with no files, and `aimee git` refused the worktree that actually held the work as *"outside the session checkout"*. `~/.aimee` held **zero** `session-ppid-*` files to show for it.

The reader half of this rendezvous has been there all along. The writer was never implemented.

## What changed

The hook now publishes the id it already holds — but not under its own `getppid()`. Its hook command carries an `AIMEE_HOOK_CLIENT=` assignment, which cannot be `execve`'d, so the host runs it through a shell and the hook is a **grandchild**. Publishing there names a shell that exits immediately and that nothing ever asks about.

It walks up to the host instead, which is exactly the pid the proxy asks for — the proxy is a direct child of it.

The walk **stops at the host**. Publishing under every ancestor would eventually name a terminal or a service manager and hand one session's id to an unrelated session — the collision the per-process key exists to prevent. Writes are authoritative (truncating): the host's id outranks one a peer minted for itself because it could not find this.

## Verification

Verified in the real process tree, not just in theory. A probe run the way the host runs the hook (shell, env prefix) published under:

```
session-ppid-2057627 -> pid 2057627 comm=claude   <- this session's host
session-ppid-4053563 -> pid 4053563 comm=<gone>   <- the ephemeral shell
```

and `2057627` is the parent of this session's `aimee mcp-serve` (`2057675`). Nothing above the host was named.

Four unit tests rebuild that chain with `prctl`: host renamed `claude`, a shell beneath it, the publisher beneath that — covering the walk, the stop condition, overwrite semantics, and rejection of ids that cannot name a file.

The first version of the walk test passed *for the wrong reason*: `fork()` inherits `comm`, so the stand-in shell was also called `claude` and the walk stopped one level early. The real shell is `execve`'d, which resets it, so the stand-in is renamed to match.

Full `make lint` (55 checks) and the C unit suite pass.

## Not verified

- **End to end.** Confirming the hook and the proxy actually converge needs a *fresh* Claude Code session, which cannot be done from inside the session being fixed.
- **A residual ordering question.** If the proxy resolves its id before the hook publishes, it will have cached a minted one for that session. The hook fires at session start, before any tool call can reach the proxy, so the common ordering is covered — but that is reasoning, not a measurement.
