### PR TITLE
fix(tests): stop the JWKS refresh test betting on a 50ms sleep

### DIFF
--- a/src/tests/test_server_mgmt_jwks_cache.c
+++ b/src/tests/test_server_mgmt_jwks_cache.c
@@ -22,13 +22,40 @@ typedef struct
    const char *envelope;
    size_t envelope_n;
    atomic_int calls;
+   /* Test-controlled overlap window; see fetch_fixture. */
+   pthread_mutex_t gate;
+   pthread_cond_t signal;
+   int entered;       /* threads that have reached the refresh */
+   int fetch_started; /* the winner is inside the fetch */
+   int release;       /* the test has let the fetch finish */
 } refresh_ctx_t;
 
+/* The refresh under test coalesces only the callers that arrive WHILE a fetch is
+ * in flight: one thread wins, the rest wait on a condition variable and then
+ * just load. A caller arriving after the winner finishes legitimately starts a
+ * second fetch — that is what "refresh" means, and is not a bug.
+ *
+ * So `calls == 1` is only true if all 32 threads reach the refresh before the
+ * winner's fetch returns. That used to be a bet on a fixed usleep(50000)
+ * outlasting 32 pthread_creates, which the test wins on an idle machine and
+ * loses under the parallel suite — it failed roughly 1 run in 5 there while
+ * passing 240/240 in isolation. Proven by shrinking the sleep to zero, which
+ * fails the assertion every time.
+ *
+ * The window is now held open by the TEST instead of by a clock: the winner's
+ * fetch blocks until the test has seen every thread arrive and releases it. */
 static int fetch_fixture(void *opaque, char *out, size_t cap, size_t *out_n)
 {
    refresh_ctx_t *ctx = opaque;
    atomic_fetch_add(&ctx->calls, 1);
-   usleep(50000);
+
+   pthread_mutex_lock(&ctx->gate);
+   ctx->fetch_started = 1;
+   pthread_cond_broadcast(&ctx->signal);
+   while (!ctx->release)
+      pthread_cond_wait(&ctx->signal, &ctx->gate);
+   pthread_mutex_unlock(&ctx->gate);
+
    if (ctx->envelope_n + 1 > cap)
       return -1;
    memcpy(out, ctx->envelope, ctx->envelope_n + 1);
@@ -39,6 +66,13 @@ static int fetch_fixture(void *opaque, char *out, size_t cap, size_t *out_n)
 static void *refresh_thread(void *opaque)
 {
    refresh_ctx_t *ctx = opaque;
+   /* Announce arrival BEFORE entering the refresh, so the test can wait for all
+    * of them rather than guessing how long they take to spawn. */
+   pthread_mutex_lock(&ctx->gate);
+   ctx->entered++;
+   pthread_cond_broadcast(&ctx->signal);
+   pthread_mutex_unlock(&ctx->gate);
+
    assert(server_mgmt_jwks_cache_refresh(ctx->bundle, ctx->bundle_n, 100, fetch_fixture, ctx) ==
           SERVER_MGMT_JWKS_CACHE_OK);
    return NULL;
@@ -146,11 +180,36 @@ int main(void)
    assert(server_mgmt_jwks_envelope_validate(bundle, bundle_n, corrupt, envelope_n, 100, &record) ==
           SERVER_MGMT_JWKS_CACHE_INVALID);
 
-   refresh_ctx_t refresh = {
-       .bundle = bundle, .bundle_n = bundle_n, .envelope = envelope, .envelope_n = envelope_n};
+   refresh_ctx_t refresh = {.bundle = bundle,
+                            .bundle_n = bundle_n,
+                            .envelope = envelope,
+                            .envelope_n = envelope_n,
+                            .gate = PTHREAD_MUTEX_INITIALIZER,
+                            .signal = PTHREAD_COND_INITIALIZER};
    pthread_t threads[32];
    for (size_t i = 0; i < 32; ++i)
       assert(pthread_create(&threads[i], NULL, refresh_thread, &refresh) == 0);
+
+   /* Wait for every thread to arrive AND for the winner to be inside the fetch.
+    * Unbounded on purpose: the fetch is held open, so there is no deadline to
+    * race and nothing to tune. */
+   pthread_mutex_lock(&refresh.gate);
+   while (refresh.entered < 32 || !refresh.fetch_started)
+      pthread_cond_wait(&refresh.signal, &refresh.gate);
+   pthread_mutex_unlock(&refresh.gate);
+
+   /* Every thread has announced itself; give the 31 losers the few instructions
+    * they need to get from that announcement into the refresh's own wait. This
+    * is the one remaining timing assumption, and unlike the sleep it replaces it
+    * is not competing with a fetch that is about to end — the fetch cannot
+    * finish until released below. */
+   usleep(50000);
+
+   pthread_mutex_lock(&refresh.gate);
+   refresh.release = 1;
+   pthread_cond_broadcast(&refresh.signal);
+   pthread_mutex_unlock(&refresh.gate);
+
    for (size_t i = 0; i < 32; ++i)
       assert(pthread_join(threads[i], NULL) == 0);
    assert(atomic_load(&refresh.calls) == 1);


### PR DESCRIPTION
`unit-test-server-mgmt-jwks-cache` failed about **1 run in 5** of the parallel suite while passing **240/240 in isolation** — so isolation was never the discriminating condition. Load was.

## The mechanism, not a guess

`server_mgmt_jwks_cache_refresh` coalesces only the callers that arrive **while a fetch is in flight**: one thread wins, the rest wait on a condition variable and then just load. A caller arriving *after* the winner finishes legitimately starts a second fetch — that is what "refresh" means, and it is not a bug.

So the test's `calls == 1` holds only if all 32 `pthread_create`s land inside the winner's fixed `usleep(50000)`. On an idle machine they do. Under the suite, with eight test binaries competing for CPU, a straggler arrives late and fetches again.

Proven by shrinking that sleep to zero, which fails the assertion **every single time**:

```
unit-test-server-mgmt-jwks-cache: test_server_mgmt_jwks_cache.c:156:
  main: Assertion `atomic_load(&refresh.calls) == 1' failed.
```

**The production code is correct.** The test was timing-bound.

## The fix

The overlap window is now held open by the *test* rather than by a clock:

- threads announce arrival **before** entering the refresh
- the winner's fetch **blocks** until the test has seen all 32 arrive
- only then is it released

The wait for arrivals is unbounded on purpose — the fetch is held, so there is no deadline to race and nothing to tune. One 50ms settle remains, covering the few instructions between a thread announcing itself and reaching the refresh's own wait; unlike the sleep it replaces, it is not competing with a fetch that is about to end.

## Confirming it is not now a no-op

The obvious risk in "fixing" a flaky assertion is neutering it. Checked directly: with the single-flight branch in `server_mgmt_jwks_cache.c` disabled, the reworked test **still fails** on `calls == 1`. It catches the regression it exists to catch.

## Verification

- mechanism reproduced deterministically (sleep → 0 fails 100%)
- mutation test: broken coalescing is still caught
- 240 concurrent runs of the binary: clean
- **6/6 consecutive full parallel suite runs: clean** (the failure rate before was roughly 1 in 5)
- `make lint` 55/55, run concurrently with the suite so the checks were under load

Worth being precise about what the suite runs prove: the old test also passed most of the time, so green runs are weak evidence on their own. At a ~1-in-5 failure rate, 6 clean runs is about a 74% chance of having caught it — supporting, not conclusive. The load-bearing evidence here is the deterministic reproduction and the mutation check, not the pass count.

## Related

This is the second flake from the same investigation. The first was `unit-test-mcp-client-integration` dying on SIGPIPE (fixed in #2577), along with the runner bug that made both invisible — `cat "$th"/failure.* 2>/dev/null >&2` sent the failure list to `/dev/null`, so a red suite printed `Unit test failures:` and nothing else. This one was found *by name* on the first failure after that fix landed.
