### PR TITLE
build: resolve the generated-baseline conflict in one command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,23 @@ Keep one purpose per PR. Include:
 - security and failure behavior when the change crosses a trust boundary.
 
 Do not include generated artifacts without their source change.
+
+### When `testing` moves under you
+
+`tests/baselines/refactor/index.json` is generated: a digest per file of the
+public surface. Two branches touching the same file rewrite the same digest
+line, so rebasing onto a moved `testing` conflicts there routinely. Neither
+side's bytes are the answer: the answer is whatever the merged tree produces.
+
+    make -C src resolve-generated     # regenerate it, stage it
+    git rebase --continue
+
+This is a script rather than a git merge driver deliberately. A driver runs
+DURING the merge, before git has necessarily written every merged file, so a
+whole-tree digest computed there can be silently wrong: measured, a driver made
+the rebase complete clean with a baseline that did not match the tree. A loud
+conflict is better than a quiet mismatch, so the conflict stays and only its
+resolution is automated.
+
+The check itself is unchanged and still runs in CI. If you regenerate a baseline
+you did not mean to change, that is a real finding. Read the diff.

--- a/scripts/resolve_generated_conflicts.py
+++ b/scripts/resolve_generated_conflicts.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Resolve a conflict in a GENERATED baseline by regenerating it.
+
+tests/baselines/refactor/index.json is a pure function of the tree: a digest per
+file of the public surface. Two branches that touch the same file both rewrite
+the same digest line, so they conflict on every merge -- and the conflict is
+never interesting, because NEITHER side's bytes are the answer. The answer is
+whatever the merged tree produces.
+
+Run this from a conflicted rebase or merge. It regenerates the baseline from the
+tree as it now stands and stages it. Nothing is weakened: CI still recomputes
+the baseline and fails if it is wrong.
+
+WHY THIS IS A SCRIPT AND NOT A GIT MERGE DRIVER. A merge driver runs DURING the
+merge, when git has not necessarily written every merged file to the working
+tree yet -- so a whole-tree digest computed there can be silently wrong. Tried
+and measured: with a driver the rebase completed clean and the baseline did not
+match the tree, which is strictly worse than the conflict it replaced. Running
+AFTER the merge, when the tree is final, is the only sound time to do this.
+
+Usage:
+    python3 scripts/resolve_generated_conflicts.py        # regenerate + stage
+    python3 scripts/resolve_generated_conflicts.py --check # report, change nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Paths this knows how to derive. A path not listed here is left alone: a
+# conflict nobody can regenerate is a conflict a human has to read.
+GENERATED = {
+    "tests/baselines/refactor/index.json": [
+        sys.executable, "-I", "-S", "scripts/refactor_baselines.py", "freeze", "--accept-dirty",
+    ],
+}
+
+
+def conflicted_paths() -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=U"],
+        cwd=ROOT, capture_output=True, text=True, check=False,
+    )
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true",
+                        help="report what would be regenerated, change nothing")
+    args = parser.parse_args(argv)
+
+    conflicts = conflicted_paths()
+    if not conflicts:
+        print("resolve-generated: no conflicts")
+        return 0
+
+    known = [p for p in conflicts if p in GENERATED]
+    unknown = [p for p in conflicts if p not in GENERATED]
+
+    if args.check:
+        for p in known:
+            print(f"resolve-generated: would regenerate {p}")
+        for p in unknown:
+            print(f"resolve-generated: needs a human: {p}")
+        return 0
+
+    for path in known:
+        # Take either side first so the file is not left with conflict markers
+        # in it while the generator reads the tree around it.
+        subprocess.run(["git", "checkout", "--theirs", "--", path], cwd=ROOT, check=False)
+        result = subprocess.run(GENERATED[path], cwd=ROOT, capture_output=True, text=True)
+        if result.returncode != 0:
+            sys.stderr.write(result.stderr or result.stdout)
+            sys.stderr.write(f"resolve-generated: could not regenerate {path}\n")
+            return 1
+        subprocess.run(["git", "add", "--", path], cwd=ROOT, check=True)
+        print(f"resolve-generated: regenerated and staged {path}")
+
+    for path in unknown:
+        print(f"resolve-generated: left for you: {path}")
+
+    if unknown:
+        print("resolve-generated: resolve the above, then `git rebase --continue`")
+    else:
+        print("resolve-generated: run `git rebase --continue`")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/Makefile
+++ b/src/Makefile
@@ -871,7 +871,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(STATUS_AUTHORIT
 # nothing is stale when nothing exists.
 DEPS = $(ALL_OBJS:.o=.d) $(shell find $(OBJDIR) -name '*.d' 2>/dev/null)
 
-.PHONY: optional-tool-ownership-check refactor-baseline-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check repository-lock-check all clean install inc-check forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check guidance-tool-parity-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check deployed-image-check gen-sdks sdk-parity-check v1-ws-test format unit-tests go-unit-tests verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
+.PHONY: resolve-generated optional-tool-ownership-check refactor-baseline-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check repository-lock-check all clean install inc-check forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check guidance-tool-parity-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check deployed-image-check gen-sdks sdk-parity-check v1-ws-test format unit-tests go-unit-tests verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_RUNTIME_WEB) $(SERVER) $(KB) $(KB_RESOLVER) $(GATEWAY) $(FORWARDER)
 
@@ -1900,6 +1900,18 @@ background-skill-curator-absence-check:
 # The refactor surface baseline. Not in lint until now, which is why a header
 # change passed local lint and failed CI on "surface drift" -- the same shape as
 # the four gates wired in beside it: a guard nothing runs is not a guard.
+# Resolve a conflicted GENERATED baseline by regenerating it from the merged
+# tree, then staging it. Run from a conflicted rebase or merge.
+#
+# NOT a git merge driver, on purpose. A driver runs DURING the merge, before git
+# has necessarily written every merged file to the tree, so a whole-tree digest
+# computed there can be silently wrong. Measured: with a driver the rebase
+# completed clean and the baseline did NOT match the tree -- strictly worse than
+# the conflict it replaced, because a conflict is loud. After the merge the tree
+# is final, which is the only sound time to regenerate.
+resolve-generated:
+	@cd .. && python3 -I -S scripts/resolve_generated_conflicts.py
+
 refactor-baseline-check:
 	@cd .. && python3 -I -S scripts/refactor_baselines.py
 


### PR DESCRIPTION
build: resolve the generated-baseline conflict in one command

Rebasing onto a moving `testing` has been costing five or six round trips per
PR. This makes it one command, and it does so without touching a single check.

THE PAIN IS NOT TEST STRICTNESS. Across nineteen rebases in this migration,
every conflict was in ONE file: tests/baselines/refactor/index.json, which is
GENERATED. Two branches touching the same source file rewrite the same digest
line, so they collide every time, and neither side's bytes are ever the answer.
Relaxing what the tests assert would not have prevented any of them, because
nothing was asserting anything: git was merging two hashes.

So:

    make -C src resolve-generated     # regenerate from the merged tree, stage it
    git rebase --continue

NOT A GIT MERGE DRIVER, AND THIS IS THE PART WORTH READING. A merge driver is
the obvious fix and I built it first. It is unsound here, and I measured that
rather than reasoning about it:

  - with the driver configured, the rebase completed CLEAN;
  - the baseline it produced did not match the tree;
  - with the driver removed, the same rebase conflicted loudly, as it should.

A driver runs DURING the merge, when git has not necessarily written every
merged file to the working tree, so a whole-tree digest computed there is
computed against a half-written tree. That converts a loud conflict into a quiet
mismatch, which is strictly worse. The only sound time to regenerate is after
the merge, when the tree is final, so the conflict stays and only its resolution
is automated. Both the script and the Makefile target say so where someone
reaching for a driver would read it.

VERIFIED ON A REAL CONFLICT, not on the happy path: two branches editing the top
and bottom of the same tracked file, so the source auto-merges and only the
baseline collides, which is exactly the case that kept biting. The resolver
cleared it, the rebase continued, `refactor_baselines.py` then reported ok
against the merged tree, and both edits survived.

WHAT IS DELIBERATELY NOT AUTOMATED: any path the script does not know how to
derive is listed and left alone. A conflict nobody can regenerate is a conflict
a human has to read. The lock file is one of these: there is no supported
in-tree command to re-pin it, so it is not claimed here.

THE OTHER HALF OF THE COST is mine, not the tooling's: I was re-running the full
suite and the whole gate sweep after a rebase whose only delta was a regenerated
digest, which took long enough that `testing` moved again before I could push.
That is a habit to fix, not a check to weaken.
