### PR TITLE
delegates: delete delegate_build_tier_context, which never did anything

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -166,7 +166,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "9a549d0fcb5717a859a7579faa7aa8e821510533ee18453c6edb9a39684b42cd",
+      "source_sha256": "8617975d1c47ac4bab50dc55129cf8c035c4554663b065a66f2c8a4727816ba6",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/src/cmd_agent_delegate.c
+++ b/src/cmd_agent_delegate.c
@@ -456,16 +456,6 @@ static void cmd_delegate_plan(int argc, char **argv)
    cJSON_Delete(plan);
 }
 
-/* Nested delegate creation is denied at runtime; do not add a prompt block that
- * tells delegates to fan out work they cannot actually create. */
-char *delegate_build_tier_context(const char *via_name, int tier_override, const char *role)
-{
-   (void)via_name;
-   (void)tier_override;
-   (void)role;
-   return NULL;
-}
-
 void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
 {
    (void)ctx;
@@ -836,28 +826,6 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
             sys_prompt = skill_sys_prompt;
             skill_sys_prompt = NULL; /* ownership transferred to template_sys_prompt */
          }
-      }
-   }
-
-   /* Inject tier orchestration context for tools-enabled mid-tier delegates */
-   {
-      char *tier_ctx = delegate_build_tier_context(via_agent_name, tier_override, role);
-      if (tier_ctx)
-      {
-         size_t base_len = sys_prompt ? strlen(sys_prompt) : 0;
-         size_t ctx_len = strlen(tier_ctx);
-         char *combined = malloc(base_len + ctx_len + 1);
-         if (combined)
-         {
-            if (sys_prompt)
-               memcpy(combined, sys_prompt, base_len);
-            memcpy(combined + base_len, tier_ctx, ctx_len + 1);
-            if (template_sys_prompt)
-               free(template_sys_prompt);
-            template_sys_prompt = combined;
-            sys_prompt = combined;
-         }
-         free(tier_ctx);
       }
    }
 

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -216,7 +216,6 @@ int delegate_worktree_has_changes(const char *wt_path);
  *   via_name      — pin by agent name (mutually exclusive with tier_override)
  *   tier_override — pin by tier number (-1 = use default routing)
  *   role          — the delegation role (used to resolve the agent) */
-char *delegate_build_tier_context(const char *via_name, int tier_override, const char *role);
 
 /* Route override helpers shared by the direct CLI and server-routed delegate
  * paths. Provider routing picks the cheapest enabled agent for the requested

--- a/src/modules/delegates/delegate_prompt.c
+++ b/src/modules/delegates/delegate_prompt.c
@@ -1408,16 +1408,6 @@ char *delegate_bound_root_notice(const char *shell_root, const char *file_root,
    return out;
 }
 
-/* Nested delegate creation is denied at runtime; do not add a prompt block that
- * tells delegates to fan out work they cannot actually create. */
-char *delegate_build_tier_context(const char *via_name, int tier_override, const char *role)
-{
-   (void)via_name;
-   (void)tier_override;
-   (void)role;
-   return NULL;
-}
-
 char *delegate_rewrite_prompt_cwd(const char *prompt, const char *cwd, const char *worktree_path,
                                   int *occurrences_out)
 {

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1347,11 +1347,6 @@ void delegate_worker(void *arg)
    delegate_append_owned_block(&system_prompt, &template_sys_prompt,
                                delegate_inject_graph_context(prompt, cwd));
 
-   /* Tier orchestration context: for tools-enabled mid-tier delegates, append
-    * instructions describing how to fan out sub-tasks to lower-tier agents. */
-   delegate_append_owned_block(&system_prompt, &template_sys_prompt,
-                               delegate_build_tier_context(via_name, tier_override, role));
-
    /* Named-file drift guard: extract any repo-relative paths named in the prompt
     * and check pre-flight conditions before running the agent. */
    char named_paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -379,7 +379,7 @@
         },
         {
           "path": "src/headers/cmd_agent_delegate_impl.h",
-          "sha256": "6e68f7769c0119c4346136f52e0eb735c8b7bd3d49855779f0188de2a61efb80"
+          "sha256": "d13e3ed8de607d577111232ac89f4f332dc27c7f63f22f08022054fccf8ce3ba"
         },
         {
           "path": "src/headers/cmd_agent_delegate_internal.h",
@@ -1628,7 +1628,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "9939a03ac45661ae28ee422e34793a49b7209aa90259427fdaa9cac7a0766ecb",
+      "sha256": "f0c2eecb4cb873d97fe97a7ef6974e427c2fa613d64d482ca31517d6a77a0df7",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## What

Deletes `delegate_build_tier_context`, which returns `NULL` unconditionally — in
both of its two byte-identical copies.

Nested delegate creation is denied at runtime, so the prompt block this once
built was removed and the body reduced to `return NULL`. The function, its
declaration, and its two call sites stayed behind.

## Why delete it rather than leave it

The stub itself was harmless. Its live call site was not:

```c
/* Tier orchestration context: for tools-enabled mid-tier delegates, append
 * instructions describing how to fan out sub-tasks to lower-tier agents. */
delegate_append_owned_block(&system_prompt, &template_sys_prompt,
                            delegate_build_tier_context(via_name, tier_override, role));
```

Every word of that comment describes behaviour that does not happen. Anyone
reading `server_compute.c` to find out what a mid-tier delegate is told would
believe delegates are instructed to fan out work, and would have to follow two
hops to discover they are not. A stub returning NULL is dead weight; a stub with
a comment claiming otherwise is a false statement about the system.

Removing the call is provably a no-op rather than a judgement call:
`delegate_append_owned_block` opens with `if (!block) return;`.

## Removed

- the definition in `delegate_prompt.c`
- the identical copy and its 21-line caller in `cmd_agent_delegate.c` — which
  links into no binary, but is still compiled by `cmd-srcs-compile-check`
- the declaration in `cmd_agent_delegate_impl.h`
- the live call in `server_compute.c`, with its comment

48 lines, no behaviour change.

Two things worth noting: the stub existed twice with no duplicate-symbol error,
because the second copy ships nowhere; and removing the caller left a formatting
artifact that `aimee-home-check` caught via clang-format rather than the
compiler.

## Verification

- `make -C src unit-tests TEST_RUN_JOBS=1` — `units rc=0`
- `make -C src lint` — 56/56
- `make -C src cmd-srcs-compile-check` — ok
- `../aimee-server` and `../aimee` both link
