### PR TITLE
build: the baseline self-test checks cwd-independence, not surface drift

### DIFF
--- a/scripts/tests/test_refactor_baselines.py
+++ b/scripts/tests/test_refactor_baselines.py
@@ -54,7 +54,24 @@ class RefactorBaselineTests(unittest.TestCase):
         )
 
     def test_repository_baseline_is_cwd_independent(self) -> None:
-        with tempfile.TemporaryDirectory() as cwd:
+        """The checker resolves the repository from its own location, not $PWD.
+
+        This asserts the two runs AGREE, not that they succeed. Asserting success
+        made this test double as a surface-drift gate on every branch: any change
+        to a public header failed it until the baseline was re-frozen, which is
+        the release question the CI workflow deliberately scopes to `main`
+        (see the "Enforce refactor surface baselines" step in
+        .github/workflows/module-inventory.yml). The gate belonged in one place;
+        this test kept enforcing it from another, and did so later and less
+        legibly, because `make lint` no longer runs the check at all.
+
+        Agreement is the property the name promises and the one worth holding:
+        a checker that reads a different tree depending on where it was invoked
+        would pass in CI and fail on a developer's machine, or worse, the
+        reverse.
+        """
+
+        def run(cwd: str) -> tuple[int, str]:
             result = subprocess.run(
                 [sys.executable, "-I", "-S", str(SCRIPT)],
                 cwd=cwd,
@@ -62,7 +79,17 @@ class RefactorBaselineTests(unittest.TestCase):
                 capture_output=True,
                 check=False,
             )
-        self.assertEqual(result.returncode, 0, result.stderr)
+            return result.returncode, result.stdout + result.stderr
+
+        from_root = run(str(ROOT))
+        with tempfile.TemporaryDirectory() as elsewhere:
+            from_elsewhere = run(elsewhere)
+
+        self.assertEqual(
+            from_root,
+            from_elsewhere,
+            "the checker gave different answers from different working directories",
+        )
 
     def test_output_is_deterministic_and_sorted(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## The problem

#2590 scoped the public-surface baseline to `main` — it is a release question,
and asking it on every integration PR cost nineteen rebases in one migration
without surfacing a single real change to the surface.

**That scoping did not hold, and I said at the time it would.** The CI step is
correctly conditional and `refactor-baseline-check` is out of `make lint` — but
`test_refactor_baselines.py` ran the *real* checker against the *real* repository
and asserted it exited 0. So every PR touching a public header still failed CI
until the baseline was re-frozen.

I claimed in #2590 that those tests "test the tool, not this repo's surface".
Seven of them do. This one did not.

It was also the worst possible place for the gate to live. `make lint` no longer
runs the check, so the failure arrived only from CI, from a job named for module
inventory, in a step named for testing the tool — nothing in that chain says
*your header changed and the digest needs re-freezing*. It cost a rebase on three
of the last five PRs.

## What the test now asserts

What its name always promised: run the checker from the repository root and from
an unrelated directory, and the two runs must **agree** — same exit code, same
output.

That is the real property. A checker that read a different tree depending on
where it was invoked would pass in CI and fail on a developer's machine, or the
reverse, and neither would be obvious.

Agreement holds whether or not the baseline is currently frozen, so the release
gate stays in the one place that decides it.

## Both directions proven, not assumed

- With a public header deliberately modified, the checker still reports drift
  (`rc=1`) while this test passes — the gate still works, it just is not this
  test's job.
- With `ROOT` swapped to `Path.cwd()` — a genuine cwd-dependence regression —
  this test fails, and it is the only one that does.

## Verification

- `python3 -I scripts/tests/test_refactor_baselines.py` — 8/8
- `make -C src lint` — 56/56
