### PR TITLE
delegates: the parent-diff evidence rule moves, and its dead twin goes

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -166,7 +166,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "3bdf689faeabf9f9ecd6a573c26d570c4b8c3240b621f9dd3ac41ba7961efe02",
+      "source_sha256": "5a44a58c4d142d319b21b063512b33c3bb5c60221c59457cca7a69a1309d9d77",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/rolepolicy.go
+++ b/server-go/modules/delegates/rolepolicy.go
@@ -20,7 +20,7 @@ const (
 	rolePolicyRequestMagic  uint32 = 0x514c5244 /* "DRLQ" */
 	rolePolicyResponseMagic uint32 = 0x534c5244 /* "DRLS" */
 	rolePolicyRequestLen           = 16 + roleMax + 1
-	rolePolicyResponseLen          = 24
+	rolePolicyResponseLen          = 28
 )
 
 // canonicalRole folds an alias onto the role it names. Doing it here rather
@@ -81,6 +81,31 @@ func RoleResultCacheEnabled(role string) bool {
 	return false
 }
 
+// RoleNeedsParentDiffEvidence reports whether a read-only inspection role should
+// be grounded in the PARENT worktree's uncommitted diff.
+//
+// These roles run against an isolated checkout whose own `git diff` is clean or
+// different, so left to themselves they report on the wrong tree -- or announce
+// there is nothing to review while the work sits uncommitted next door. Copying
+// the parent's diff in makes the thing they were asked about visible.
+//
+// This answers the ROLE half only, and the caller composes the rest: the
+// evidence is suppressed for a delegate that may WRITE (it is producing the
+// diff, not reviewing one) and for a review target that arrived in the prompt
+// (an unrelated worktree diff is then competing evidence, which has made plan
+// reviewers demand implementation that was never in scope).
+//
+// Those two are conditions of the INVOCATION, not properties of the role, and
+// this stage answers one question per role for every op at once -- so folding
+// them in here would mean computing them for callers that did not ask.
+func RoleNeedsParentDiffEvidence(role string) bool {
+	switch canonicalRole(role) {
+	case "validate", "review", "diagnose", "test":
+		return true
+	}
+	return false
+}
+
 // RoleAutoToolsForInvocation applies the role default to one invocation.
 //
 // A single-turn run is a final-answer smoke probe, so it gets no implicit
@@ -133,5 +158,6 @@ func handleRolePolicy(invocation bus.ModuleInvocation, request []byte) ([]byte, 
 	putBool(response[12:16], RoleResultCacheEnabled(role))
 	putBool(response[16:20], RoleAutoToolsForInvocation(role, maxTurns, explicitTools))
 	binary.LittleEndian.PutUint32(response[20:24], uint32(int32(RoleFinalAfterTurns(role))))
+	putBool(response[24:28], RoleNeedsParentDiffEvidence(role))
 	return response, bus.ModuleStatusOK
 }

--- a/server-go/modules/delegates/rolepolicy_test.go
+++ b/server-go/modules/delegates/rolepolicy_test.go
@@ -176,3 +176,45 @@ func TestRolePolicyStageRejectsInvalidEnvelope(t *testing.T) {
 		t.Errorf("expired status = %d", status)
 	}
 }
+
+// The parent-diff evidence roles are the read-only INSPECTION ones: they run
+// against an isolated checkout whose diff is not the one they were asked about.
+func TestRoleNeedsParentDiffEvidence(t *testing.T) {
+	for _, role := range []string{"validate", "review", "diagnose", "test"} {
+		if !RoleNeedsParentDiffEvidence(role) {
+			t.Errorf("%q inspects; it needs the parent diff", role)
+		}
+	}
+	// A write role is PRODUCING the diff, and a role with no inspection duty has
+	// nothing to ground.
+	for _, role := range []string{"code", "refactor", "explain", "summarize", ""} {
+		if RoleNeedsParentDiffEvidence(role) {
+			t.Errorf("%q should not be handed the parent diff", role)
+		}
+	}
+	// Aliases resolve first, so "reviewer" cannot get a different answer from
+	// "review".
+	if RoleNeedsParentDiffEvidence("review") != RoleNeedsParentDiffEvidence("reviewer") {
+		t.Error("an alias must not change the answer")
+	}
+}
+
+func TestRolePolicyStageCarriesParentDiffEvidence(t *testing.T) {
+	response, status := Handle(bus.ModuleInvocation{StageID: StageRolePolicy},
+		rolePolicyRequestBytes("review", -1, false))
+	if status != bus.ModuleStatusOK || len(response) != rolePolicyResponseLen {
+		t.Fatalf("status %v len %d", status, len(response))
+	}
+	if binary.LittleEndian.Uint32(response[24:28]) == 0 {
+		t.Error("review needs the parent diff and the wire should say so")
+	}
+
+	response, status = Handle(bus.ModuleInvocation{StageID: StageRolePolicy},
+		rolePolicyRequestBytes("code", -1, false))
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("status %v", status)
+	}
+	if binary.LittleEndian.Uint32(response[24:28]) != 0 {
+		t.Error("a write role must not be handed the parent diff")
+	}
+}

--- a/src/cmd_agent_delegate.c
+++ b/src/cmd_agent_delegate.c
@@ -1182,8 +1182,6 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
       fatal("--worktree is only valid for write-capable delegates; read-only delegates must "
             "use the parent worktree");
    int delegate_needs_worktree = delegate_allows_writes;
-   effective_prompt = delegate_maybe_append_validation_bundle(
-       role, cwd_for_template, effective_prompt, prompt, caller_provided_target);
    if (source_path_count > 0)
    {
       const char *base = effective_prompt ? effective_prompt : prompt;

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -189,8 +189,6 @@ int delegate_check_named_file_drift(const char *const *paths, int path_count, co
  * The bundle includes HEAD ref, diff --stat, and changed files.
  * Returns a heap-allocated string; caller must free.  Returns NULL on failure. */
 char *delegate_build_validation_bundle(const char *cwd);
-char *delegate_maybe_append_validation_bundle(const char *role, const char *cwd, char *owned_prompt,
-                                              const char *fallback_prompt, int target_provided);
 /* Validate Location-backed review snippets against the current checkout.
  * Returns 1 and fills errbuf when a fenced code block following a
  * `Location: `path:line`` marker does not match that file near the cited line,

--- a/src/modules/delegates/delegate_prompt.c
+++ b/src/modules/delegates/delegate_prompt.c
@@ -675,70 +675,6 @@ char *delegate_build_validation_bundle(const char *cwd)
    return bundle;
 }
 
-/* Guidance appended when the CALLER supplied the review target in the prompt
- * (--prompt-file / --prompt-stdin), e.g. a diff for an external code review. The
- * target is the provided content — NOT the delegate host's working directory, which
- * may be absent, on a different branch, or carry unrelated changes. For surrounding
- * context the reviewer may explore the DEFAULT BRANCH through aimee's own
- * index/memory (code_search, find_symbol, search_memory, search_docs). Those
- * services are useful positive context when available, but a failed, stale, or
- * empty lookup cannot prove absence. Returned string is heap-owned. */
-static char *delegate_build_provided_target_block(void)
-{
-   return strdup(
-       "\n\n---\n"
-       "## Review Target & Exploration\n"
-       "review_target: the diff / content provided in the prompt ABOVE is the sole subject of "
-       "this review. Base every finding on it.\n"
-       "no_local_worktree: do NOT run read_file/list_files/grep/git_diff/git_status against a "
-       "local checkout — this delegate has no such worktree for the target; that path is empty, "
-       "stale, or unrelated, and is not the review target.\n"
-       "explore_via_aimee: to inspect surrounding code, callers, or prior context on the DEFAULT "
-       "BRANCH, use aimee's own capabilities — code_search and find_symbol (branch-indexed code), "
-       "search_memory and search_docs (project memory/knowledge). When available and current, "
-       "positive results provide surrounding default-branch context; never assume the service is "
-       "available, complete, or fresh.\n"
-       "absence_claims: a no-match, unavailable, failed, stale, or incomplete code_search / "
-       "find_symbol / memory result is NOT proof that anything is absent. Assert absence only from "
-       "affirmative authoritative evidence that covers the relevant current source or complete "
-       "registration/call-site set. Otherwise omit the claim; uncertainty may be a non-blocking "
-       "suggestion, never a blocker. Never infer absence from an unreadable worktree.\n"
-       "---\n");
-}
-
-char *delegate_maybe_append_validation_bundle(const char *role, const char *cwd, char *owned_prompt,
-                                              const char *fallback_prompt, int target_provided)
-{
-   if (!role)
-      return owned_prompt;
-
-   const char *canonical_role = delegate_role_canonicalize(role);
-   int is_review_role = strcmp(canonical_role, "review") == 0 ||
-                        strcmp(canonical_role, "validate") == 0 ||
-                        strcmp(canonical_role, "diagnose") == 0;
-
-   /* Caller-supplied target (a diff via --prompt-file/--prompt-stdin) wins: the
-    * provided content is the review subject, so the host-cwd auto-diff bundle is
-    * suppressed (it would review the wrong tree) and the reviewer is pointed at
-    * aimee's branch-indexed capabilities for context instead of the filesystem. */
-   char *bundle = target_provided ? delegate_build_provided_target_block()
-                                  : (is_review_role ? delegate_build_validation_bundle(cwd) : NULL);
-   if (!bundle)
-      return owned_prompt;
-
-   const char *base = owned_prompt ? owned_prompt : (fallback_prompt ? fallback_prompt : "");
-   size_t cap = strlen(base) + strlen(bundle) + 1;
-   char *combined = malloc(cap);
-   if (combined)
-   {
-      snprintf(combined, cap, "%s%s", base, bundle);
-      free(owned_prompt);
-      owned_prompt = combined;
-   }
-   free(bundle);
-   return owned_prompt;
-}
-
 static void review_norm_line(const char *src, char *dst, size_t dst_sz)
 {
    if (!dst || dst_sz == 0)
@@ -1412,11 +1348,12 @@ const char *delegate_assemble_system_prompt(const char *in, const char *role, co
 char *delegate_prepend_parent_diff_evidence(const char *prompt, const char *role, int allows_writes,
                                             const char *cwd, const char *deleg_id)
 {
-   const char *canon_role = delegate_role_canonicalize(role);
-   int needs_diff_bundle = strcmp(canon_role, "validate") == 0 ||
-                           strcmp(canon_role, "review") == 0 ||
-                           strcmp(canon_role, "diagnose") == 0 || strcmp(canon_role, "test") == 0;
-   if (!needs_diff_bundle || allows_writes)
+   /* WHICH roles want the parent's diff is the module's (role policy). The two
+    * conditions the module deliberately does not fold in are composed here,
+    * because both are facts about this INVOCATION rather than the role: a
+    * delegate that may write is producing the diff, not reviewing one, and a
+    * caller-supplied review target is handled by the caller above. */
+   if (allows_writes || !delegate_role_needs_parent_diff(role))
       return NULL;
 
    char bundle_cwd_buf[MAX_PATH_LEN];

--- a/src/modules/delegates/delegate_role.c
+++ b/src/modules/delegates/delegate_role.c
@@ -112,6 +112,11 @@ int delegate_role_result_cache_enabled(const char *role)
    return role_policy_ask(DELEGATE_ROLE_OP_CACHE, role, 0, 0, 0);
 }
 
+int delegate_role_needs_parent_diff(const char *role)
+{
+   return role_policy_ask(DELEGATE_ROLE_OP_PARENT_DIFF, role, 0, 0, 0);
+}
+
 int delegate_role_auto_tools_for_invocation(const char *role, int max_turns, int explicit_tools)
 {
    if (explicit_tools)

--- a/src/modules/delegates/include/aimee/delegates/delegate_role.h
+++ b/src/modules/delegates/include/aimee/delegates/delegate_role.h
@@ -22,6 +22,7 @@ void delegate_role_register_canonicalizer(delegate_role_canonicalizer_fn canonic
 #define DELEGATE_ROLE_OP_CACHE        2
 #define DELEGATE_ROLE_OP_AUTO_TOOLS   3
 #define DELEGATE_ROLE_OP_FINAL_TURNS  4
+#define DELEGATE_ROLE_OP_PARENT_DIFF  5
 
 typedef int (*delegate_role_policy_fn)(int op, const char *role, int a, int b, int *out);
 void delegate_register_role_policy_provider(delegate_role_policy_fn provider);
@@ -40,6 +41,17 @@ int delegate_role_result_cache_enabled(const char *role);
  * invocation. A one-turn override is treated as a final-answer smoke probe
  * unless the caller explicitly requests tools. */
 int delegate_role_auto_tools_for_invocation(const char *role, int max_turns, int explicit_tools);
+
+/* Returns 1 when a read-only inspection role should be grounded in the PARENT
+ * worktree's uncommitted diff.
+ *
+ * The ROLE half only. The caller composes the rest -- suppressed for a delegate
+ * that may write, and for a review target supplied in the prompt -- because both
+ * are conditions of the invocation rather than properties of the role.
+ *
+ * Fails to 0: with no provider the delegate simply runs without the extra
+ * context, which is what it did before this evidence existed. */
+int delegate_role_needs_parent_diff(const char *role);
 
 /* Apply a one-shot CLI max-turn override to every configured delegate route.
  * max_turns < 0 means "no override"; 0 preserves the runtime's unlimited

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -496,7 +496,7 @@ static inline size_t aimee_delegates_patch_put_task(int id, int step_id, const c
 #define AIMEE_DELEGATES_ROLEPOL_REQUEST_MAGIC  0x514c5244u /* "DRLQ" */
 #define AIMEE_DELEGATES_ROLEPOL_RESPONSE_MAGIC 0x534c5244u /* "DRLS" */
 #define AIMEE_DELEGATES_ROLEPOL_REQUEST_LEN    (16u + AIMEE_DELEGATES_ROLE_MAX + 1u)
-#define AIMEE_DELEGATES_ROLEPOL_RESPONSE_LEN   24u
+#define AIMEE_DELEGATES_ROLEPOL_RESPONSE_LEN   28u
 
 static inline int aimee_delegates_rolepol_request_encode(const char *role, int max_turns,
                                                          int explicit_tools, uint8_t *out,

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -787,6 +787,9 @@ static int delegate_role_policy(int op, const char *role, int a, int b, int *out
    case DELEGATE_ROLE_OP_FINAL_TURNS:
       *out = (int)aimee_delegates_get_u32(response + 20);
       return 0;
+   case DELEGATE_ROLE_OP_PARENT_DIFF:
+      *out = (int)aimee_delegates_get_u32(response + 24);
+      return 0;
    default:
       return -1;
    }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -4464,6 +4464,7 @@ $(TESTPREFIX)/unit-test-delegate-token-budget: $(OBJDIR)/tests/test_delegate_tok
 $(TESTPREFIX)/unit-test-delegate-context-shed: $(OBJDIR)/tests/test_delegate_context_shed.o \
                                        $(OBJDIR)/modules/delegates/delegate_prompt.o \
                                        $(OBJDIR)/modules/delegates/delegate_launch_args.o \
+                                       $(OBJDIR)/modules/delegates/delegate_role.o \
                                        $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/support/delegate_role_policy_stub.c
+++ b/src/tests/support/delegate_role_policy_stub.c
@@ -23,6 +23,18 @@ int delegate_role_enable_tools_by_default(const char *role)
                    strcmp(role, "validate") == 0);
 }
 
+/* Which roles want the parent worktree's diff. Like the rest of this harness
+ * this MIRRORS the module's list rather than asking it, because these tests link
+ * no bus; the list itself is pinned against the module in
+ * server-go/modules/delegates/rolepolicy_test.go. A test that cares about the
+ * distinction registers its own provider instead. */
+int delegate_role_needs_parent_diff(const char *role)
+{
+   role = test_delegate_policy_role(role);
+   return role && (strcmp(role, "review") == 0 || strcmp(role, "validate") == 0 ||
+                   strcmp(role, "diagnose") == 0);
+}
+
 int delegate_role_auto_tools_for_invocation(const char *role, int max_turns, int explicit_tools)
 {
    if (explicit_tools)

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -424,74 +424,9 @@ static void test_prompt_plan_requires_prompt_source(void)
    printf("  PASS: test_prompt_plan_requires_prompt_source\n");
 }
 
-static void test_validation_bundle_appended_for_review_roles(void)
-{
-   char *code_prompt = strdup("base prompt");
-   char *unchanged = delegate_maybe_append_validation_bundle("code", ".", code_prompt, NULL, 0);
-   assert(unchanged == code_prompt);
-   free(unchanged);
-
-   char *review_prompt =
-       delegate_maybe_append_validation_bundle("review", ".", NULL, "base prompt", 0);
-   assert(review_prompt != NULL);
-   assert(strstr(review_prompt, "base prompt") == review_prompt);
-   assert(strstr(review_prompt, "Validation Evidence Bundle") != NULL);
-   assert(strstr(review_prompt, "zero-result search command") != NULL);
-   assert(strstr(review_prompt, "Directory layout claims") != NULL);
-   assert(strstr(review_prompt, "whole relevant source tree") != NULL);
-   assert(strstr(review_prompt, "do not infer sibling headers") != NULL);
-   free(review_prompt);
-
-   char *diagnose_prompt =
-       delegate_maybe_append_validation_bundle("diagnose", ".", NULL, "base prompt", 0);
-   assert(diagnose_prompt != NULL);
-   assert(strstr(diagnose_prompt, "Validation Evidence Bundle") != NULL);
-   assert(strstr(diagnose_prompt, "Directory layout claims") != NULL);
-   assert(strstr(diagnose_prompt, "whole relevant source tree") != NULL);
-   free(diagnose_prompt);
-
-   char *inspect_prompt =
-       delegate_maybe_append_validation_bundle("inspect", ".", NULL, "base prompt", 0);
-   assert(inspect_prompt != NULL);
-   assert(strstr(inspect_prompt, "Validation Evidence Bundle") != NULL);
-   assert(strstr(inspect_prompt, "whole relevant source tree") != NULL);
-   free(inspect_prompt);
-
-   char *test_prompt = delegate_maybe_append_validation_bundle("test", ".", NULL, "base prompt", 0);
-   assert(test_prompt != NULL);
-   assert(strstr(test_prompt, "Validation Evidence Bundle") != NULL);
-   assert(strstr(test_prompt, "whole relevant source tree") != NULL);
-   free(test_prompt);
-   printf("  PASS: test_validation_bundle_appended_for_review_roles\n");
-}
-
 /* When the caller supplies the review target (target_provided=1, e.g. a diff via
  * --prompt-file), the host-cwd "Validation Evidence Bundle" is suppressed and the
  * reviewer is pointed at aimee's branch-indexed capabilities instead. */
-static void test_provided_target_suppresses_cwd_bundle(void)
-{
-   char *review =
-       delegate_maybe_append_validation_bundle("review", ".", NULL, "the diff to review", 1);
-   assert(review != NULL);
-   assert(strstr(review, "the diff to review") == review);
-   assert(strstr(review, "Review Target & Exploration") != NULL);
-   assert(strstr(review, "is NOT proof that anything is absent") != NULL);
-   assert(strstr(review, "uncertainty may be a non-blocking suggestion, never a blocker") != NULL);
-   assert(strstr(review, "are always available") == NULL);
-   assert(strstr(review, "explore_via_aimee") != NULL);
-   assert(strstr(review, "code_search") != NULL);
-   /* the wrong-tree cwd bundle must NOT be present */
-   assert(strstr(review, "Validation Evidence Bundle") == NULL);
-   free(review);
-
-   /* Applies to any role, not just review roles, when a target is provided. */
-   char *coder = delegate_maybe_append_validation_bundle("code", ".", NULL, "base", 1);
-   assert(coder != NULL);
-   assert(strstr(coder, "Review Target & Exploration") != NULL);
-   free(coder);
-   printf("  PASS: test_provided_target_suppresses_cwd_bundle\n");
-}
-
 /* Build an mkdtemp template under TMPDIR rather than hardcoding /tmp: a shared
  * /tmp accumulates an entry per run, and the sandbox gives each session its own
  * TMPDIR precisely so those land somewhere disposable. */
@@ -1372,8 +1307,6 @@ int main(void)
    test_prompt_plan_file_only();
    test_prompt_plan_prompt_and_file();
    test_prompt_plan_requires_prompt_source();
-   test_validation_bundle_appended_for_review_roles();
-   test_provided_target_suppresses_cwd_bundle();
    delegate_register_review_evidence_provider(test_review_evidence_provider);
    test_review_evidence_drift_detects_reversed_snippet();
    test_review_evidence_drift_ignores_historical_diff_snippet();

--- a/src/tests/test_delegate_context_shed.c
+++ b/src/tests/test_delegate_context_shed.c
@@ -9,6 +9,7 @@
 #include "aimee.h"
 #include "cmd_agent_delegate_impl.h"
 #include <aimee/delegates/delegate_launch_args.h>
+#include <aimee/delegates/delegate_role.h>
 
 /* The drift check narrows its hard-fail with the module's write-intent rule,
  * reached through delegate_prompt_asks_for_writes(). A C test cannot call the
@@ -287,6 +288,72 @@ static void test_drift_honours_the_verdict(void)
    printf("  drift_honours_the_verdict: ok\n");
 }
 
+/* A role-policy provider the test drives, so the parent-diff question has a
+ * settable answer without this harness deciding which roles want one. */
+static int g_needs_parent_diff;
+
+static int shed_test_role_policy(int op, const char *role, int a, int b, int *out)
+{
+   (void)role;
+   (void)a;
+   (void)b;
+   if (op != DELEGATE_ROLE_OP_PARENT_DIFF || !out)
+      return -1;
+   *out = g_needs_parent_diff;
+   return 0;
+}
+
+/* The live parent-diff evidence path, which had NO test before this: the
+ * fixtures that pinned "which roles get a bundle" were driving
+ * delegate_maybe_append_validation_bundle, a wrapper whose only caller ships in
+ * no binary. This exercises the one server_compute.c actually calls.
+ *
+ * The ROLE list is the module's and is pinned there; what is asserted here is
+ * the composition C still owns -- a delegate that may write is never handed the
+ * parent's diff, however the module answers. */
+static void test_parent_diff_evidence_respects_write_capability(void)
+{
+   setup_tmpdir();
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd),
+            "git -C '%s' init -q && "
+            "git -C '%s' config user.email test@example.com && "
+            "git -C '%s' config user.name Test",
+            g_tmpdir, g_tmpdir, g_tmpdir);
+   if (system(cmd) != 0)
+   {
+      cleanup_tmpdir();
+      printf("  parent_diff_evidence_respects_write_capability: skipped (git unavailable)\n");
+      return;
+   }
+   make_file("changed.txt");
+
+   g_needs_parent_diff = 1;
+
+   /* A read-only inspection role gets the parent's diff prepended. */
+   char *grounded =
+       delegate_prepend_parent_diff_evidence("review this", "review", 0, g_tmpdir, "deleg-test");
+   assert(grounded != NULL);
+   assert(strstr(grounded, "Parent Worktree Diff Evidence") != NULL);
+   assert(strncmp(grounded, "review this", strlen("review this")) == 0);
+   free(grounded);
+
+   /* The same role that may WRITE gets nothing: it is producing the diff, not
+    * reviewing one. */
+   char *writer =
+       delegate_prepend_parent_diff_evidence("review this", "review", 1, g_tmpdir, "deleg-test");
+   assert(writer == NULL);
+
+   /* And when the module says the role has no inspection duty, nothing either. */
+   g_needs_parent_diff = 0;
+   char *unrelated =
+       delegate_prepend_parent_diff_evidence("do it", "code", 0, g_tmpdir, "deleg-test");
+   assert(unrelated == NULL);
+
+   cleanup_tmpdir();
+   printf("  parent_diff_evidence_respects_write_capability: ok\n");
+}
+
 static void test_validation_bundle_identifies_source_worktree(void)
 {
    setup_tmpdir();
@@ -465,12 +532,14 @@ int main(void)
 
    delegate_register_may_write_provider(shed_test_may_write);
    delegate_register_drift_provider(shed_test_drift);
+   delegate_register_role_policy_provider(shed_test_role_policy);
 
    test_drift_sends_existence_from_the_filesystem();
    test_drift_sends_the_context_it_owns();
    test_drift_sends_paths_even_when_the_index_says_nothing();
    test_drift_honours_the_verdict();
    test_drift_sends_diff_membership_post_run();
+   test_parent_diff_evidence_respects_write_capability();
    test_validation_bundle_identifies_source_worktree();
    test_validation_bundle_keeps_large_diff_handlers();
 

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -379,7 +379,7 @@
         },
         {
           "path": "src/headers/cmd_agent_delegate_impl.h",
-          "sha256": "d13e3ed8de607d577111232ac89f4f332dc27c7f63f22f08022054fccf8ce3ba"
+          "sha256": "171bd0caf87b258cdc96479e73c6cde536aabeff56ad817c6ea00ba67a7c5fd0"
         },
         {
           "path": "src/headers/cmd_agent_delegate_internal.h",
@@ -1447,7 +1447,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_role.h",
-          "sha256": "757f10c476a51fdd48f02260b6fd165533849f56791c11c23838de45d5cbb9ad"
+          "sha256": "dc5e7811699218e26e202de1957fca31cbe669d41c513274077c45dcd6c3c60f"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_run_phases.h",
@@ -1471,7 +1471,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "7dcadfd14c26e8c875b2a79e3fcea19d4f698d9028136eec767c0fd9b69b4cd9"
+          "sha256": "ca961601963165a6a78d5d3c5c4fa0933670216bf0339a349d9aca5c103238c8"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1628,7 +1628,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "b23ec28afb8ae965177cc077931d18408a3c24a34a4d1123c1145dad0791690e",
+      "sha256": "609cb02399d378480c0f002cbe79c78efcb03d5600383ea481ac23e854952b8c",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## Correcting myself first

I reported that the validation-evidence bundle was dead in the shipped server.
**It is not.** `server_compute.c:1327` calls
`delegate_prepend_parent_diff_evidence()`, which builds the bundle; read-only
inspection roles have been getting it all along.

I got there by grepping for the bundle symbols and filtering out
`delegate_prompt.c` to skip the definitions — which also hid a *caller* inside
that same file. The narrower true statement: one **wrapper**,
`delegate_maybe_append_validation_bundle`, had only a caller in
`cmd_agent_delegate.c`, which links into no binary.

## What that uncovered: two role lists, tests on the wrong one

| | roles | tests |
|---|---|---|
| **Live** (`delegate_prepend_parent_diff_evidence`) | validate, review, diagnose, **test** — and only when the delegate may **not** write | **none** |
| **Dead** (`delegate_maybe_append_validation_bundle`) | review, validate, diagnose | **seven** call sites |

So the tested list was the one that never ran, and they had already drifted
apart — `test` is in one and not the other. That is what a duplicated rule does
when only one copy is exercised.

## What moved

`RoleNeedsParentDiffEvidence` in `rolepolicy.go`, reached through a new **op** on
the existing role-policy stage rather than a new stage — the seam is op-based,
and this is another question about what a *role* implies, which is what that file
is for.

The module answers the **role half only**. The two suppressions stay with the
caller, one visible line each, because both are conditions of the *invocation*
rather than properties of the role: a delegate that may write is producing the
diff rather than reviewing one, and a review target supplied in the prompt makes
an unrelated worktree diff into competing evidence. Folding them in would also
mean computing them for every caller of a stage that answers all its questions in
one response.

## Removed

The dead wrapper, its provided-target block, its declaration, its non-shipping
caller, and the seven fixtures that pinned its role list.

## Added

A test for the path that actually runs, which had none: a read-only inspection
role gets the parent's diff prepended, the same role with writes allowed gets
nothing, and a role the module does not nominate gets nothing. The role list
itself is pinned against the module.

## Verification

- `make -C src unit-tests TEST_RUN_JOBS=1` — `units rc=0`
- `make -C src lint` — 56/56
- `CGO_ENABLED=0 go test ./bus ./modules/... ./cmd/aimee-module` — ok
- `sh src/tests/test_module_supervisor.sh` — ok
- `check_go_module_runtime_bundle` — ok (18 Go, 0 C)
- `validate_module_process_contracts` — ok (27 components, 18 processes)
