### PR TITLE
delegates: which roles see only current code is the module's to say

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -166,7 +166,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "5a44a58c4d142d319b21b063512b33c3bb5c60221c59457cca7a69a1309d9d77",
+      "source_sha256": "d81473465fbe2351c67a947ec6559513f910b997dffa1dabefbb0636d244bd53",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/rolepolicy.go
+++ b/server-go/modules/delegates/rolepolicy.go
@@ -20,7 +20,7 @@ const (
 	rolePolicyRequestMagic  uint32 = 0x514c5244 /* "DRLQ" */
 	rolePolicyResponseMagic uint32 = 0x534c5244 /* "DRLS" */
 	rolePolicyRequestLen           = 16 + roleMax + 1
-	rolePolicyResponseLen          = 28
+	rolePolicyResponseLen          = 32
 )
 
 // canonicalRole folds an alias onto the role it names. Doing it here rather
@@ -76,6 +76,30 @@ func RoleEnablesToolsByDefault(role string) bool {
 func RoleResultCacheEnabled(role string) bool {
 	switch canonicalRole(role) {
 	case "summarize", "format", "draft":
+		return true
+	}
+	return false
+}
+
+// RoleSeesCurrentCodeOnly reports whether a role is confined to reading the
+// CURRENT checkout: indexed search, memory, docs, notes and remote MCP tools are
+// withheld from it.
+//
+// These roles answer questions about the code as it is now. An index can be
+// stale, and memory or notes can be confidently wrong about a file that has
+// since changed -- so a review grounded in them can cite something that is no
+// longer there. Withholding those tools forces the answer to come from the tree.
+//
+// DELIBERATELY NOT CANONICALISED, unlike every other rule in this file. The C
+// this replaces compared the raw role, so "review" is confined and its alias
+// "reviewer" is not. Canonicalising here would silently narrow the tool surface
+// of any delegate invoked by an alias, which is a behaviour change to a security
+// boundary and not this migration's to make. The inconsistency is real and worth
+// fixing; it should be fixed deliberately, with its own test and its own
+// decision. See TestRoleSeesCurrentCodeOnlyMatchesTheRawRole.
+func RoleSeesCurrentCodeOnly(role string) bool {
+	switch role {
+	case "review", "diagnose", "inspect":
 		return true
 	}
 	return false
@@ -159,5 +183,6 @@ func handleRolePolicy(invocation bus.ModuleInvocation, request []byte) ([]byte, 
 	putBool(response[16:20], RoleAutoToolsForInvocation(role, maxTurns, explicitTools))
 	binary.LittleEndian.PutUint32(response[20:24], uint32(int32(RoleFinalAfterTurns(role))))
 	putBool(response[24:28], RoleNeedsParentDiffEvidence(role))
+	putBool(response[28:32], RoleSeesCurrentCodeOnly(role))
 	return response, bus.ModuleStatusOK
 }

--- a/server-go/modules/delegates/rolepolicy_test.go
+++ b/server-go/modules/delegates/rolepolicy_test.go
@@ -218,3 +218,60 @@ func TestRolePolicyStageCarriesParentDiffEvidence(t *testing.T) {
 		t.Error("a write role must not be handed the parent diff")
 	}
 }
+
+func TestRoleSeesCurrentCodeOnly(t *testing.T) {
+	for _, role := range []string{"review", "diagnose", "inspect"} {
+		if !RoleSeesCurrentCodeOnly(role) {
+			t.Errorf("%q answers about the code as it is now", role)
+		}
+	}
+	for _, role := range []string{"code", "validate", "execute", "search", "plan", ""} {
+		if RoleSeesCurrentCodeOnly(role) {
+			t.Errorf("%q should keep its index and memory tools", role)
+		}
+	}
+}
+
+// This rule compares the RAW role, unlike every other one in this file.
+//
+// The C it replaces did the same, so "review" is confined and its alias
+// "reviewer" is not -- even though "reviewer" canonicalises to "review"
+// everywhere else. Canonicalising would silently narrow the tool surface of any
+// delegate invoked by an alias, which is a change to a security boundary and was
+// not this migration's to make.
+//
+// The asymmetry is pinned here so that fixing it has to be a decision: this test
+// fails the moment someone canonicalises, and its failure says why.
+func TestRoleSeesCurrentCodeOnlyMatchesTheRawRole(t *testing.T) {
+	if !RoleSeesCurrentCodeOnly("review") {
+		t.Fatal("review is confined")
+	}
+	if RoleSeesCurrentCodeOnly("reviewer") {
+		t.Error("PORTED BEHAVIOUR: the alias is not confined, because the C compared " +
+			"the raw role. If this is now being fixed deliberately, change the rule AND " +
+			"this test together, and say so.")
+	}
+	// "inspect" canonicalises to "diagnose" and both are listed, so the raw
+	// comparison happens to agree there. Stated so the next reader does not
+	// conclude aliases work in general.
+	if !RoleSeesCurrentCodeOnly("inspect") || !RoleSeesCurrentCodeOnly("diagnose") {
+		t.Error("inspect and diagnose are both listed explicitly")
+	}
+}
+
+func TestRolePolicyStageCarriesCurrentCodeOnly(t *testing.T) {
+	response, status := Handle(bus.ModuleInvocation{StageID: StageRolePolicy},
+		rolePolicyRequestBytes("review", -1, false))
+	if status != bus.ModuleStatusOK || len(response) != rolePolicyResponseLen {
+		t.Fatalf("status %v len %d", status, len(response))
+	}
+	if binary.LittleEndian.Uint32(response[28:32]) == 0 {
+		t.Error("review is current-code-only and the wire should say so")
+	}
+
+	response, _ = Handle(bus.ModuleInvocation{StageID: StageRolePolicy},
+		rolePolicyRequestBytes("code", -1, false))
+	if binary.LittleEndian.Uint32(response[28:32]) != 0 {
+		t.Error("a write role keeps its tools")
+	}
+}

--- a/src/modules/delegates/delegate_role.c
+++ b/src/modules/delegates/delegate_role.c
@@ -117,6 +117,11 @@ int delegate_role_needs_parent_diff(const char *role)
    return role_policy_ask(DELEGATE_ROLE_OP_PARENT_DIFF, role, 0, 0, 0);
 }
 
+int delegate_role_sees_current_code_only(const char *role)
+{
+   return role_policy_ask(DELEGATE_ROLE_OP_CURRENT_CODE, role, 0, 0, 0);
+}
+
 int delegate_role_auto_tools_for_invocation(const char *role, int max_turns, int explicit_tools)
 {
    if (explicit_tools)

--- a/src/modules/delegates/include/aimee/delegates/delegate_role.h
+++ b/src/modules/delegates/include/aimee/delegates/delegate_role.h
@@ -23,6 +23,7 @@ void delegate_role_register_canonicalizer(delegate_role_canonicalizer_fn canonic
 #define DELEGATE_ROLE_OP_AUTO_TOOLS   3
 #define DELEGATE_ROLE_OP_FINAL_TURNS  4
 #define DELEGATE_ROLE_OP_PARENT_DIFF  5
+#define DELEGATE_ROLE_OP_CURRENT_CODE 6
 
 typedef int (*delegate_role_policy_fn)(int op, const char *role, int a, int b, int *out);
 void delegate_register_role_policy_provider(delegate_role_policy_fn provider);
@@ -52,6 +53,17 @@ int delegate_role_auto_tools_for_invocation(const char *role, int max_turns, int
  * Fails to 0: with no provider the delegate simply runs without the extra
  * context, which is what it did before this evidence existed. */
 int delegate_role_needs_parent_diff(const char *role);
+
+/* Returns 1 when a role is confined to reading the CURRENT checkout: indexed
+ * search, memory, docs, notes and remote MCP tools are withheld from it.
+ *
+ * Fails to 0, which WIDENS the tool surface rather than narrowing it. That is
+ * the uncomfortable direction, and it is chosen because the alternative is
+ * worse: with no provider every role would lose its index and memory tools, and
+ * a delegate silently stripped of the tools it was configured with fails in a
+ * way nobody can diagnose from the outside. A missing module must not
+ * reconfigure the fleet. */
+int delegate_role_sees_current_code_only(const char *role);
 
 /* Apply a one-shot CLI max-turn override to every configured delegate route.
  * max_turns < 0 means "no override"; 0 preserves the runtime's unlimited

--- a/src/modules/delegates/include/aimee/delegates/module_api.h
+++ b/src/modules/delegates/include/aimee/delegates/module_api.h
@@ -496,7 +496,7 @@ static inline size_t aimee_delegates_patch_put_task(int id, int step_id, const c
 #define AIMEE_DELEGATES_ROLEPOL_REQUEST_MAGIC  0x514c5244u /* "DRLQ" */
 #define AIMEE_DELEGATES_ROLEPOL_RESPONSE_MAGIC 0x534c5244u /* "DRLS" */
 #define AIMEE_DELEGATES_ROLEPOL_REQUEST_LEN    (16u + AIMEE_DELEGATES_ROLE_MAX + 1u)
-#define AIMEE_DELEGATES_ROLEPOL_RESPONSE_LEN   28u
+#define AIMEE_DELEGATES_ROLEPOL_RESPONSE_LEN   32u
 
 static inline int aimee_delegates_rolepol_request_encode(const char *role, int max_turns,
                                                          int explicit_tools, uint8_t *out,

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -27,6 +27,7 @@
 #include "cJSON.h"
 #include <ctype.h>
 #include <pthread.h>
+#include <aimee/delegates/delegate_role.h>
 
 /* --- Auto-snapshot turn context (thread-local, set by the agent runtime) ---
  *
@@ -473,12 +474,12 @@ int agent_tools_strip_delegate_respond(parsed_response_t *parsed)
 
 /* Tool definition builders are in agent_tools_defs.c */
 
+/* WHICH roles are confined to the current checkout is the delegates module's
+ * (role policy). This stays as a named function because five call sites read
+ * better asking a question than repeating a seam call. */
 int agent_tools_role_current_code_only(const char *role)
 {
-   if (!role || !role[0])
-      return 0;
-   return strcmp(role, "review") == 0 || strcmp(role, "diagnose") == 0 ||
-          strcmp(role, "inspect") == 0;
+   return delegate_role_sees_current_code_only(role);
 }
 
 /* The three read-only worktree tools review_indexed carries under slice 7. Kept as

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -790,6 +790,9 @@ static int delegate_role_policy(int op, const char *role, int a, int b, int *out
    case DELEGATE_ROLE_OP_PARENT_DIFF:
       *out = (int)aimee_delegates_get_u32(response + 24);
       return 0;
+   case DELEGATE_ROLE_OP_CURRENT_CODE:
+      *out = (int)aimee_delegates_get_u32(response + 28);
+      return 0;
    default:
       return -1;
    }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -4292,6 +4292,7 @@ $(TESTPREFIX)/unit-test-compact-prune: $(OBJDIR)/tests/test_compact_prune.o \
                                           $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                           $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                           $(OBJDIR)/server/agent_tools.o \
+                                          $(OBJDIR)/modules/delegates/delegate_role.o \
                                           $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -4304,6 +4305,7 @@ $(TESTPREFIX)/unit-test-session-compact-focused: $(OBJDIR)/tests/test_session_co
                                           $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                           $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                           $(OBJDIR)/server/agent_tools.o \
+                                          $(OBJDIR)/modules/delegates/delegate_role.o \
                                           $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -4316,6 +4318,7 @@ $(TESTPREFIX)/unit-test-session-compact: $(OBJDIR)/tests/test_session_compact.o 
                                           $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                           $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                           $(OBJDIR)/server/agent_tools.o \
+                                          $(OBJDIR)/modules/delegates/delegate_role.o \
                                           $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -4329,6 +4332,7 @@ $(TESTPREFIX)/unit-test-rounds-to-resume: $(OBJDIR)/tests/test_rounds_to_resume.
                                           $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                           $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                           $(OBJDIR)/server/agent_tools.o \
+                                          $(OBJDIR)/modules/delegates/delegate_role.o \
                                           $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -4778,6 +4782,7 @@ $(TESTPREFIX)/unit-test-workspace-provider-container: \
 $(TESTPREFIX)/unit-test-toolset-thread-scope: \
                                        $(OBJDIR)/tests/test_toolset_thread_scope.o \
                                        $(OBJDIR)/server/agent_tools.o \
+                                       $(OBJDIR)/modules/delegates/delegate_role.o \
                                        $(OBJDIR)/toolset.o \
                                        $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -5643,6 +5648,7 @@ $(TESTPREFIX)/unit-test-delegate-driver: $(OBJDIR)/tests/test_delegate_driver.o 
                                  $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                  $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                  $(OBJDIR)/server/agent_tools.o \
+                                 $(OBJDIR)/modules/delegates/delegate_role.o \
                                  $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -5658,6 +5664,7 @@ $(TESTPREFIX)/unit-test-agent-http: $(OBJDIR)/tests/test_agent_http.o \
                                 $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                 $(OBJDIR)/model_registry.o \
                                 $(OBJDIR)/server/agent_tools.o \
+                                $(OBJDIR)/modules/delegates/delegate_role.o \
                                 $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -5670,6 +5677,7 @@ $(TESTPREFIX)/unit-test-mcp-native-dispatch: \
                                        $(OBJDIR)/modules/tools/agent_tools_dispatch.o \
                                        $(OBJDIR)/modules/tools/agent_tools_completion.o \
                                        $(OBJDIR)/server/agent_tools.o \
+                                       $(OBJDIR)/modules/delegates/delegate_role.o \
                                        $(OBJDIR)/toolset.o \
                                        $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -5683,6 +5691,7 @@ $(TESTPREFIX)/unit-test-mcp-native-surface: $(OBJDIR)/tests/test_mcp_native_surf
                                 $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                 $(OBJDIR)/model_registry.o \
                                 $(OBJDIR)/server/agent_tools.o \
+                                $(OBJDIR)/modules/delegates/delegate_role.o \
                                 $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -6096,6 +6105,7 @@ $(TESTPREFIX)/unit-test-context-engine: $(OBJDIR)/tests/test_context_engine.o \
                      $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                      $(OBJDIR)/server/agent_tools.o \
+                     $(OBJDIR)/modules/delegates/delegate_role.o \
                      $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -6882,6 +6892,7 @@ $(TESTPREFIX)/compaction-retention-probe: $(OBJDIR)/tests/retention_probe.o \
                                           $(OBJDIR)/modules/delegates/delegate_xml_fallback.o \
                                           $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                           $(OBJDIR)/server/agent_tools.o \
+                                          $(OBJDIR)/modules/delegates/delegate_role.o \
                                           $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/support/delegate_role_policy_stub.c
+++ b/src/tests/support/delegate_role_policy_stub.c
@@ -28,6 +28,14 @@ int delegate_role_enable_tools_by_default(const char *role)
  * no bus; the list itself is pinned against the module in
  * server-go/modules/delegates/rolepolicy_test.go. A test that cares about the
  * distinction registers its own provider instead. */
+/* Raw, not canonicalised -- see RoleSeesCurrentCodeOnly for why the module does
+ * the same. */
+int delegate_role_sees_current_code_only(const char *role)
+{
+   return role && (strcmp(role, "review") == 0 || strcmp(role, "diagnose") == 0 ||
+                   strcmp(role, "inspect") == 0);
+}
+
 int delegate_role_needs_parent_diff(const char *role)
 {
    role = test_delegate_policy_role(role);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -617,8 +617,28 @@ static void test_tool_surface_single_source(void)
    cJSON_Delete(resp);
 }
 
+/* A role-policy provider so the current-code question has an answer here.
+ *
+ * WHICH roles are confined is the module's list, pinned against the module
+ * (server-go/modules/delegates/rolepolicy_test.go). This harness mirrors it only
+ * so the tool-filtering assertions below have the same ground truth they always
+ * had; what is asserted HERE is that the answer reaches the tool policy. */
+static int agent_test_role_policy(int op, const char *role, int a, int b, int *out)
+{
+   (void)a;
+   (void)b;
+   if (op != DELEGATE_ROLE_OP_CURRENT_CODE || !out)
+      return -1;
+   *out = role && (strcmp(role, "review") == 0 || strcmp(role, "diagnose") == 0 ||
+                   strcmp(role, "inspect") == 0);
+   return 0;
+}
+
 static void test_current_code_only_role_tool_policy(void)
 {
+   delegate_register_role_policy_provider(agent_test_role_policy);
+
+   /* The seam carries the module's answer through to the tool policy. */
    assert(agent_tools_role_current_code_only("review") == 1 &&
           agent_tools_role_current_code_only("diagnose") == 1);
    assert(agent_tools_role_current_code_only("inspect") == 1 &&

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -1447,7 +1447,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_role.h",
-          "sha256": "dc5e7811699218e26e202de1957fca31cbe669d41c513274077c45dcd6c3c60f"
+          "sha256": "cda8dcea776a609a713a8e68a5b00247450b543dc6ce57c954d6743750ea4ef5"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/delegate_run_phases.h",
@@ -1471,7 +1471,7 @@
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/module_api.h",
-          "sha256": "ca961601963165a6a78d5d3c5c4fa0933670216bf0339a349d9aca5c103238c8"
+          "sha256": "9ad846d77b1654acebadfbd62c8065eaf2cfd3e972f05d5c4ec3410ca632da5d"
         },
         {
           "path": "src/modules/delegates/include/aimee/delegates/panel_provider.h",
@@ -1628,7 +1628,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "609cb02399d378480c0f002cbe79c78efcb03d5600383ea481ac23e854952b8c",
+      "sha256": "7ee07955265906804d3f984d4ae6a3048fcc4845ee649d3dfa15021ddcc7511c",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
## What

`agent_tools_role_current_code_only()` decided, in `src/server/agent_tools.c`,
that `review`/`diagnose`/`inspect` are confined to reading the **current
checkout**: indexed search, memory, docs, notes and remote MCP tools are withheld
from them. That list now lives in `server-go/modules/delegates/rolepolicy.go`,
reached through a new op on the role-policy seam.

## It was in the wrong place twice over

Server C is meant to own the bus, mTLS/MCP, the HTTP APIs and the audit tap. A
role list is none of those.

And I had earlier argued this rule "belongs to the tools module, so moving it
would make tools depend on delegates" — **wrong on the facts.** All five callers
(`server/agent_tools.c`, `server/agent_runtime.c`, `posix/agent_runtime.c`,
`modules/tools/agent_tools_dispatch.c`) compile into the *same server binary*,
which already registers the delegates role-policy provider. No new dependency;
one more op on a seam that was already there.

## The rule is ported exactly, including an inconsistency

The C compared the **raw** role, so `review` is confined and its alias `reviewer`
is not — even though `reviewer` canonicalises to `review` everywhere else in that
same file.

Canonicalising would silently narrow the tool surface of any delegate invoked by
an alias. That is a change to a security boundary and not this migration's to
make, so the raw comparison is preserved and the asymmetry is pinned by
`TestRoleSeesCurrentCodeOnlyMatchesTheRawRole`, which fails the moment someone
canonicalises and explains why in its failure message.

**It looks like a real bug. It deserves its own decision.**

## The seam fails to 0, which widens the tool surface

The uncomfortable direction, chosen deliberately: with no provider, failing to 1
would strip every role of its index and memory tools, and a delegate silently
reconfigured by a missing module fails in a way nobody can diagnose from outside.
A missing module must not reconfigure the fleet.

## Eleven test link sets

Turning a widely-linked function into a seam call means every test linking
`server/agent_tools.o` also needs the seam's object — and the suite surfaces them
one at a time. They were enumerated from `tests/Rules.mk` in one pass instead
(rules mentioning `agent_tools.o`, minus those already linking `delegate_role.o`
or the shared stub), and all eleven built before re-running.

Safe to do mechanically because it is a **link** error: a test missing the object
cannot build, so the fix cannot hide a behaviour change.

`test_agent.c` now registers a provider and asserts the answer **reaches** the
tool policy; the list itself is pinned against the module.

## Unrelated pre-existing breakage, untouched

`benchmarks/compaction-quality/retention_probe.c` includes `context_reduce.h`,
which exists nowhere in the repo. It is a hand-run probe, not in `TEST_TARGETS`,
so `make unit-tests` is unaffected. Flagged, not "fixed".

## Verification

- `make -C src unit-tests TEST_RUN_JOBS=1` — `units rc=0`
- `make -C src lint` — 56/56
- `CGO_ENABLED=0 go test ./bus ./modules/... ./cmd/aimee-module` — ok
- `../aimee-server` links
