### PR TITLE
put the four tools back on the MCP floor: the trim was measured and it lost

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -77,7 +77,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "0a9957dc9870dd0adfc182ea1ba9b694c005300f29084c2129d5cab7099b7f1b"
+      "source_sha256": "a94b3000879ecf1a8cb624eb0dfa30e5d988a2a949d134a1b22108ac79ff10fd"
     },
     {
       "id": "gateway",

--- a/src/modules/protocols/mcp/mcp_tool_profile.c
+++ b/src/modules/protocols/mcp/mcp_tool_profile.c
@@ -28,13 +28,16 @@ static const char *const MCP_CORE_TOOLS[] = {
     "describe_tool", /* discovery */
     "call_tool",     /* schema-bound dispatch bridge for discovered tools */
     "search_docs",   /* orient */
+    "search_memory",
     "memory_recall",
     "get_identity", /* grounding */
-    /* ast_grep_search stays: it is the ONE code-intel capability with no command
-     * form, so withholding it would leave the agent nothing but a recursive text
-     * search for "does this pattern repeat". (It is separately withheld at
-     * runtime when no ast-grep binary resolves -- see server_mcp_surface.c.) */
+    /* ast_grep_search is additionally withheld at RUNTIME when no ast-grep
+     * binary resolves (server_mcp_surface.c) -- that part stayed, because a tool
+     * that cannot run is different from a tool with a cheaper alternative. */
+    AIMEE_CODE_TOOL_FIND_SYMBOL,
     AIMEE_CODE_TOOL_AST_GREP_SEARCH,
+    AIMEE_CODE_TOOL_PREVIEW_BLAST_RADIUS,
+    AIMEE_CODE_TOOL_INDEX,
     /* SAME REASONING AS delegate_status BELOW, AND THE SAME MEASUREMENT.
      *
      * `index` multiplexes the retrieval an agent needs when the question is not a
@@ -49,26 +52,24 @@ static const char *const MCP_CORE_TOOLS[] = {
      * 1 MB truncation. index_hybrid answers that class of question with a capped,
      * ranked result set and was reachable the whole time -- just never in one
      * call. A tool the agent cannot afford to reach is a tool it does not have. */
-    /* THAT MEASUREMENT NO LONGER DESCRIBES THE ALTERNATIVE, which is why `index`,
-     * find_symbol, preview_blast_radius and search_memory now leave the floor.
+    /* RE-TESTED 2026-08-12 WITH THE COMMAND FORMS IN PLACE, AND THE OLD
+     * MEASUREMENT HELD. The argument for removing these four was that the
+     * fallback had changed: each is now an `aimee ...` command the standing
+     * guidance names, and a command chains where a tool call cannot. That
+     * argument was wrong about what the agent actually does.
      *
-     * When it was taken, dropping a tool from the floor meant the capability cost
-     * find_tools -> describe_tool -> call_tool, so agents used a recursive text
-     * search instead and emitted 2.4 MB doing it. The fallback today is not a
-     * recursive search: every one of those four is an `aimee ...` command the
-     * standing guidance names by hand, and a command CHAINS -- N of them cost one
-     * round trip inside a shell call the agent is already making, where N tool
-     * calls cost N turns.
+     * Trimmed vs untrimmed, same task, n=3 each, healthy box:
+     *   CLI invocations   2.3 -> 1.3 per cell   (DOWN, not up)
+     *   MCP calls         4.3 -> 6.3
+     *   shell commands    9.3 -> 11
+     *   searches            3 -> 4.3   (4.2 KB -> 6.1 KB of output)
+     *   credits         15.52 -> 19.15 mean     (+23%)
      *
-     * Measured 2026-08-12 after the guidance started naming them: aimee CLI
-     * invocations went from 0 across 13 cells to 7 across 3, in exactly the
-     * chained shape asked for. What did NOT happen is substitution -- the agent
-     * added CLI calls while still calling the tools, because a schema present in
-     * every request outcompetes a sentence. Removing them from the floor is what
-     * makes the cheaper surface the default one rather than an alternative.
-     *
-     * They remain reachable: in the "full" profile, and through
-     * find_tools/describe_tool/call_tool for a client with no shell at all. */
+     * The MCP calls it did make were find_tools x4, describe_tool x2,
+     * call_tool x1 -- the discovery detour the comment above describes, paid in
+     * full. Naming a command in guidance does not make the agent prefer it over
+     * a schema that is present in every request; removing the schema just sends
+     * it to discovery and to grep, exactly as before. */
     "git", /* all git/gh ops via one multiplexed tool (command=...) */
     "delegate",
     /* SAME REASONING AS `index` ABOVE, AND THE SAME MEASUREMENT.

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -688,15 +688,25 @@ static void test_tool_profile_filter(void)
 {
    /* Mirror of MCP_CORE_TOOLS in mcp_tool_profile.c — kept in sync intentionally.
     * Includes the P2 discovery meta-tools and schema-bound dispatch bridge. */
-   static const char *const core[] = {"get_help", "find_tools", "describe_tool", "call_tool",
-                                      "search_docs", "memory_recall", "get_identity",
-                                      /* find_symbol, preview_blast_radius, index and search_memory
-                                       * left the floor: each is an `aimee ...` command the standing
-                                       * guidance names, and a command chains where a tool call
-                                       * cannot. ast_grep_search stays -- it is the one code-intel
-                                       * capability with no command form. */
-                                      "ast_grep_search", "git", "delegate", "delegate_status",
-                                      "roundtable_review", "ask_user", "send_message", "note",
+   static const char *const core[] = {"get_help",
+                                      "find_tools",
+                                      "describe_tool",
+                                      "call_tool",
+                                      "search_docs",
+                                      "search_memory",
+                                      "memory_recall",
+                                      "get_identity",
+                                      "find_symbol",
+                                      "ast_grep_search",
+                                      "preview_blast_radius",
+                                      "index",
+                                      "git",
+                                      "delegate",
+                                      "delegate_status",
+                                      "roundtable_review",
+                                      "ask_user",
+                                      "send_message",
+                                      "note",
                                       NULL};
    int expect = 0;
    for (int i = 0; core[i]; i++)
@@ -743,23 +753,28 @@ static void test_tool_profile_filter(void)
     * blocks, so it needs no poller in the floor at all. */
    assert(profile_core_has("delegate_status", core));
 
-   /* `index` is deliberately NOT in the floor any more, and this assertion is
-    * inverted rather than deleted because the reason it existed still matters.
+   /* The retrieval an agent reaches for when the question is NOT a symbol name.
+    * Withholding `index` did not reduce retrieval; it moved it to a recursive
+    * shell search, because that was one visible call while index_hybrid cost a
+    * find_tools -> describe_tool -> call_tool detour. Measured across the
+    * benchmark's aimee cells: 87 shell searches emitting 2.4 MB, one large
+    * enough to hit the client's 1 MB output truncation.
     *
-    * IT USED TO ASSERT THE OPPOSITE, on this measurement: withholding `index`
-    * did not reduce retrieval, it moved retrieval to a recursive shell search --
-    * 87 shell searches emitting 2.4 MB across the benchmark's aimee cells, one
-    * large enough to hit the client's 1 MB truncation -- because that was one
-    * visible call while index_hybrid cost find_tools -> describe_tool ->
-    * call_tool.
+    * THIS ASSERTION WAS INVERTED ONCE, ON 2026-08-12, and inverted back the same
+    * night. The argument was that the fallback had changed -- `aimee index ...`
+    * now exists as a chainable command named in the standing guidance -- so the
+    * detour was no longer the alternative. Re-tested with the commands live and
+    * the guidance naming them, n=3 each side on a healthy box: CLI invocations
+    * went DOWN 2.3 -> 1.3 per cell, MCP calls 4.3 -> 6.3, searches 3 -> 4.3,
+    * search output 4.2 KB -> 6.1 KB, credits 15.52 -> 19.15 mean (+23%). The
+    * calls it did make were find_tools x4, describe_tool x2, call_tool x1: the
+    * detour, paid in full.
     *
-    * What changed is the ALTERNATIVE, not the argument. `aimee index ...` is now
-    * a command the standing guidance names by hand, so the fallback is no longer
-    * a recursive search: it is the same retrieval, chainable with && into a shell
-    * call the agent is already making. The failure mode that justified the old
-    * assertion is only reachable if the command form disappears -- which is what
-    * this now guards. */
-   assert(!profile_core_has("index", core));
+    * So the original finding survives a change that looked like it should have
+    * retired it. A schema present in every request outcompetes a sentence
+    * recommending a command, and removing the schema sends the agent to
+    * discovery and to grep rather than to the command. */
+   assert(profile_core_has("index", core));
    assert(profile_core_has("delegate_status", core));
    {
       cJSON *listed = mcp_build_tools_list();


### PR DESCRIPTION
put the four tools back on the MCP floor: the trim was measured and it lost

I argued in #2607 that the recorded measurement against removing `index` no
longer applied, because the fallback had changed: each of those four is now an
`aimee ...` command the standing guidance names, and a command chains where a
tool call cannot. I inverted the assertion that guarded it and said I would
measure rather than assume.

Measured. The old finding held, and the trim made every number worse.

Same task, n=3 each side, healthy box (5.1 GB of 14.68 cap), same image family:

                       untrimmed      trimmed
  CLI invocations         2.3           1.3     DOWN, not up
  MCP calls               4.3           6.3
  shell commands          9.3          11
  searches                3.0           4.3
  search output         4.2 KB        6.1 KB
  credits mean          15.52         19.15     +23%

The MCP calls it made when the tools were gone were find_tools x4,
describe_tool x2, call_tool x1 -- the discovery detour, paid in full, which is
exactly what the original comment said would happen. It did not reach for the
commands; CLI use FELL.

The lesson is narrower than "do not trim". A schema present in every request
outcompetes a sentence recommending a command. Naming the command in guidance
adds CLI usage (0 -> 7 across cells, measured 2026-08-12) but does not displace
the tool, and removing the tool does not redirect the agent to the command -- it
redirects it to discovery and to grep.

So: floor restored exactly as it was, assertion restored, and BOTH measurements
now sit next to it -- the 2.4 MB one that motivated it and this one that
re-confirmed it against a change which looked like it should have retired it.
The next person to have my idea gets the result of trying it.

KEPT from #2607: ast-grep ships in the image. That is independent and verified
working -- `ast-grep 0.45.1` resolves in the container, and ast_grep_search now
returns results instead of the "No matches found." it used to answer on every
box where the binary was missing. It also stays on the floor: it is the one
code-intel capability with no command form, and it is separately withheld at
runtime when no binary resolves, which is a different thing from having a
cheaper alternative.
