### PR TITLE
delegates: an alias is confined like the role it resolves to

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -166,7 +166,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "d81473465fbe2351c67a947ec6559513f910b997dffa1dabefbb0636d244bd53",
+      "source_sha256": "824e227d506c9a1c95995a010942c05f79a967b7bdccbc44c5ffa460eb04f57b",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 10,

--- a/server-go/modules/delegates/rolepolicy.go
+++ b/server-go/modules/delegates/rolepolicy.go
@@ -90,16 +90,15 @@ func RoleResultCacheEnabled(role string) bool {
 // since changed -- so a review grounded in them can cite something that is no
 // longer there. Withholding those tools forces the answer to come from the tree.
 //
-// DELIBERATELY NOT CANONICALISED, unlike every other rule in this file. The C
-// this replaces compared the raw role, so "review" is confined and its alias
-// "reviewer" is not. Canonicalising here would silently narrow the tool surface
-// of any delegate invoked by an alias, which is a behaviour change to a security
-// boundary and not this migration's to make. The inconsistency is real and worth
-// fixing; it should be fixed deliberately, with its own test and its own
-// decision. See TestRoleSeesCurrentCodeOnlyMatchesTheRawRole.
+// The role is canonicalised first, so an alias is confined exactly as the name
+// it resolves to. The C this replaced compared the RAW role, which meant
+// `--role reviewer` kept the index and memory tools that `--role review` was
+// denied -- the same delegate, the same job, a different tool surface depending
+// on which spelling the caller typed. Nothing chose that; it was what a raw
+// strcmp does when aliases exist everywhere else.
 func RoleSeesCurrentCodeOnly(role string) bool {
-	switch role {
-	case "review", "diagnose", "inspect":
+	switch canonicalRole(role) {
+	case "review", "diagnose":
 		return true
 	}
 	return false

--- a/server-go/modules/delegates/rolepolicy_test.go
+++ b/server-go/modules/delegates/rolepolicy_test.go
@@ -232,30 +232,37 @@ func TestRoleSeesCurrentCodeOnly(t *testing.T) {
 	}
 }
 
-// This rule compares the RAW role, unlike every other one in this file.
+// An alias is confined exactly as the name it resolves to.
 //
-// The C it replaces did the same, so "review" is confined and its alias
-// "reviewer" is not -- even though "reviewer" canonicalises to "review"
-// everywhere else. Canonicalising would silently narrow the tool surface of any
-// delegate invoked by an alias, which is a change to a security boundary and was
-// not this migration's to make.
+// This replaces a test that pinned the opposite. The C compared the raw role, so
+// `--role reviewer` kept the index, memory, docs, notes and remote MCP tools
+// that `--role review` was denied: the same delegate, doing the same job, with a
+// different tool surface depending on which spelling the caller typed. That was
+// not a decision anyone made -- it is what a raw strcmp does in a system where
+// aliases resolve everywhere else -- and it is now fixed.
 //
-// The asymmetry is pinned here so that fixing it has to be a decision: this test
-// fails the moment someone canonicalises, and its failure says why.
-func TestRoleSeesCurrentCodeOnlyMatchesTheRawRole(t *testing.T) {
-	if !RoleSeesCurrentCodeOnly("review") {
-		t.Fatal("review is confined")
+// "reviewer" is the only alias whose answer changes: it is now confined.
+// "inspect" already resolved to "diagnose", which was listed explicitly before
+// and is covered by canonicalisation now.
+func TestAnAliasIsConfinedLikeTheRoleItResolvesTo(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"reviewer", "review"},
+		{"inspect", "diagnose"},
+		{"verifier", "validate"},
+		{"implement", "code"},
+	} {
+		alias, canonical := pair[0], pair[1]
+		if RoleSeesCurrentCodeOnly(alias) != RoleSeesCurrentCodeOnly(canonical) {
+			t.Errorf("%q and %q must agree: an alias is the same role", alias, canonical)
+		}
 	}
-	if RoleSeesCurrentCodeOnly("reviewer") {
-		t.Error("PORTED BEHAVIOUR: the alias is not confined, because the C compared " +
-			"the raw role. If this is now being fixed deliberately, change the rule AND " +
-			"this test together, and say so.")
+	// The change this test exists for.
+	if !RoleSeesCurrentCodeOnly("reviewer") {
+		t.Error("reviewer resolves to review, and review is confined")
 	}
-	// "inspect" canonicalises to "diagnose" and both are listed, so the raw
-	// comparison happens to agree there. Stated so the next reader does not
-	// conclude aliases work in general.
-	if !RoleSeesCurrentCodeOnly("inspect") || !RoleSeesCurrentCodeOnly("diagnose") {
-		t.Error("inspect and diagnose are both listed explicitly")
+	// And what did NOT change: validate and its aliases keep their tools.
+	if RoleSeesCurrentCodeOnly("verifier") || RoleSeesCurrentCodeOnly("validate") {
+		t.Error("validate is not confined, so neither is its alias")
 	}
 }
 

--- a/src/tests/support/delegate_role_policy_stub.c
+++ b/src/tests/support/delegate_role_policy_stub.c
@@ -28,12 +28,10 @@ int delegate_role_enable_tools_by_default(const char *role)
  * no bus; the list itself is pinned against the module in
  * server-go/modules/delegates/rolepolicy_test.go. A test that cares about the
  * distinction registers its own provider instead. */
-/* Raw, not canonicalised -- see RoleSeesCurrentCodeOnly for why the module does
- * the same. */
 int delegate_role_sees_current_code_only(const char *role)
 {
-   return role && (strcmp(role, "review") == 0 || strcmp(role, "diagnose") == 0 ||
-                   strcmp(role, "inspect") == 0);
+   role = test_delegate_policy_role(role);
+   return role && (strcmp(role, "review") == 0 || strcmp(role, "diagnose") == 0);
 }
 
 int delegate_role_needs_parent_diff(const char *role)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -629,8 +629,10 @@ static int agent_test_role_policy(int op, const char *role, int a, int b, int *o
    (void)b;
    if (op != DELEGATE_ROLE_OP_CURRENT_CODE || !out)
       return -1;
-   *out = role && (strcmp(role, "review") == 0 || strcmp(role, "diagnose") == 0 ||
-                   strcmp(role, "inspect") == 0);
+   /* "inspect" resolves to "diagnose" in the module, so both answer the same;
+    * spelled out here because this harness does not canonicalise. */
+   *out = role && (strcmp(role, "review") == 0 || strcmp(role, "reviewer") == 0 ||
+                   strcmp(role, "diagnose") == 0 || strcmp(role, "inspect") == 0);
    return 0;
 }
 


### PR DESCRIPTION
## What

`RoleSeesCurrentCodeOnly` compared the **raw** role, so `--role reviewer` was
treated differently from `--role review` — the same delegate, doing the same job,
with a different tool surface depending on which spelling the caller typed.

Nothing chose that. It is what a raw `strcmp` does in a system where aliases
resolve everywhere else, and it came across in last night's port from C because
preserving it exactly was the safe way to move a security-adjacent rule.

Now canonicalised, like every other rule in `rolepolicy.go`.

## What actually changes

**`reviewer` is the only role whose answer moves.** `inspect` already resolved to
`diagnose`, so it is now covered by canonicalisation rather than by being listed
— the explicit entry is dropped because it had become dead. Nothing else in the
alias table resolves to `review` or `diagnose`.

## Where it lands

`wfe_blocks.c` dispatches its review delegate with role `"reviewer"` (a read-only
reviewer, by its own comment), so this is a live path. That delegate now behaves
as `--role review` already did:

- its system prompt skips KB context injection, and
- broad or mutating `aimee …` commands through `bash`/`execute_script` are
  refused.

## It does not lose its tools

I described this rule earlier as "withholding indexed search, memory, docs, notes
and remote MCP tools". That is the wording of the refusal **message**, and it
only applies where no toolset resolves for the role.

`reviewer` maps to the `review_indexed` toolset, which resolves and returns
first, so the indexed tools are granted exactly as they are for `review` —
something `test_agent.c` has asserted all along
(`agent_tools_tool_allowed_for_role("review", "find_symbol") == 1`).

## Tests

The test that pinned the old asymmetry is replaced by one that pins the new rule
and records what changed, so the next reader sees a decision rather than a
puzzle.

## Verification

- `make -C src unit-tests TEST_RUN_JOBS=1` — `units rc=0`
- `make -C src lint` — 56/56
- `CGO_ENABLED=0 go test ./bus ./modules/... ./cmd/aimee-module` — ok
- `../aimee-server` links
