### PR TITLE
build: refuse a surface-baseline re-freeze on the integration branch

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -100,6 +100,46 @@ jobs:
       - name: Enforce refactor surface baselines
         if: github.base_ref != 'testing' && github.ref != 'refs/heads/testing'
         run: python3 -I -S scripts/refactor_baselines.py
+      # The surface baseline is a RELEASE gate, enforced on `main` by the step
+      # above and deliberately not here. That makes re-freezing it on a `testing`
+      # PR pure cost: it is a whole-tree digest, so any two PRs touching public
+      # headers rewrite the same lines and collide. It cost a rebase on three of
+      # five PRs in one migration, and the collisions were never about the
+      # surface -- the digest was recomputed, the diff was mechanical, nobody
+      # read it.
+      #
+      # So on `testing` the baseline is simply NOT MAINTAINED. It goes stale,
+      # which is intended: the promoting testing -> main PR re-freezes it once,
+      # and THAT diff is the useful artifact -- one review of everything a
+      # release changed on the public surface.
+      #
+      # Adding a public header therefore does not require touching this file.
+      - name: Refuse a baseline re-freeze on the integration branch
+        if: github.base_ref == 'testing'
+        run: |
+          set -eu
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          if git diff --quiet FETCH_HEAD -- tests/baselines/refactor/index.json; then
+            echo "surface baseline untouched: ok"
+            exit 0
+          fi
+          cat >&2 <<'MSG'
+          ::error::This PR changes tests/baselines/refactor/index.json, and it targets `testing`.
+
+          The public-surface baseline is a release question. It gates `main`, not this
+          branch, so re-freezing it here achieves nothing and collides with every other
+          PR that does the same.
+
+          Revert the file and push again:
+
+              git checkout origin/testing -- tests/baselines/refactor/index.json
+
+          You do NOT need to re-freeze after adding or changing a public header. The
+          baseline is expected to be stale on `testing`; the promotion PR into `main`
+          re-freezes it once, and that single diff is the review of what the release
+          changed on the public surface.
+          MSG
+          exit 1
       - name: Enforce refactor cleanup accounting
         run: python3 -I -S scripts/check_cleanup_ledger.py
       - name: Test refactor baseline failure modes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,15 @@ the digest, and any two concurrent PRs then collided on the same regenerated
 lines. It cost nineteen rebases in one migration and surfaced no real change to
 the surface in any of them.
 
-So on `testing`: do not re-freeze it. `make -C src lint` no longer asks you to.
+So on `testing`: do not re-freeze it. `make -C src lint` no longer asks you to,
+and CI now REFUSES a pull request into `testing` that changes the baseline. If
+you have already re-frozen it, revert that one file and push again:
+
+    git checkout origin/testing -- tests/baselines/refactor/index.json
+
+Adding or changing a public header does NOT require a re-freeze. The baseline is
+expected to be stale on `testing`; that is what makes the promotion diff worth
+reading.
 
 When promoting `testing` into `main`:
 


### PR DESCRIPTION
## Why a third attempt at this

#2590 scoped the public-surface baseline to `main`. #2609 stopped a checker
self-test from re-imposing it on `testing`. **Neither stopped the actual cost**,
because both addressed *enforcement*, and the cost is *regeneration*: the file is
a whole-tree digest, so any two PRs touching public headers rewrite the same
lines and collide — whether or not anything checks them.

It kept happening. Three of five PRs in one migration needed a rebase, and every
one of those conflicts was in this single generated file. People re-freeze out of
habit, because the workflow used to demand it, and a sentence in CONTRIBUTING
does not compete with a habit.

So the rule is now enforced where it can be: a PR into `testing` that changes
`tests/baselines/refactor/index.json` fails, with the remedy printed in the
error.

## What this means day to day

On `testing` the baseline is **not maintained**. Adding or changing a public
header does not require a re-freeze, and the file is expected to go stale.

That is the design, not a gap: the promoting `testing` → `main` PR re-freezes it
once, and that single diff is the review of everything the release changed on the
public surface — which is worth reading, where nineteen mechanical re-freezes
were not.

## Both directions tested with the real script

- baseline untouched → check passes
- a public header modified and the baseline re-frozen → check **fails**
- the remedy the error prints
  (`git checkout origin/testing -- tests/baselines/refactor/index.json`) →
  check passes again

## CONTRIBUTING

Now says what the gate says, including the part the old wording missed: what to
do when you have *already* re-frozen, and that a public-header change needs no
re-freeze at all.

## Verification

- `make -C src lint` — 56/56
- workflow YAML parses; 26 steps
