### PR TITLE
tests: identify the orphan by process, not by pid number

### DIFF
--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -31,17 +31,71 @@ SPEC.loader.exec_module(contract)
 FIXTURES = REPO_ROOT / "tests/fixtures/module-doc-contract"
 
 
-def process_is_gone_or_zombie(pid: int) -> bool:
-    """Return whether Linux reports a process as vanished or a zombie."""
+def _proc_stat_fields(pid: int) -> list[str] | None:
+    """Fields of /proc/<pid>/stat after the comm, or None if the pid is gone.
+
+    Splitting on the LAST ")" is deliberate: comm is an arbitrary program name in
+    parentheses and may itself contain them.
+    """
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
     except (FileNotFoundError, ProcessLookupError):
-        return True
+        return None
     _, separator, tail = stat.rpartition(")")
     fields = tail.split()
     if not separator or not fields:
         raise AssertionError(f"Malformed /proc/{pid}/stat")
-    return fields[0] == "Z"
+    return fields
+
+
+def process_starttime(pid: int) -> str | None:
+    """The process's start time in clock ticks, or None if it is already gone.
+
+    A pid is a NUMBER, and Linux hands numbers out again. Start time is what
+    makes it an identity: a recycled pid names a process that began later, so
+    (pid, starttime) is stable where pid alone is not.
+    """
+    fields = _proc_stat_fields(pid)
+    if fields is None:
+        return None
+    # /proc/<pid>/stat field 22 is starttime; `fields` begins at field 3 (state).
+    return fields[19] if len(fields) > 19 else None
+
+
+def process_is_gone_or_zombie(pid: int, starttime: str | None = None) -> bool:
+    """Return whether the process we meant is vanished, a zombie, or replaced.
+
+    Pass the `starttime` captured when the pid was learned. Without it this
+    answers a question about a NUMBER rather than about a process, and on a busy
+    machine the number can belong to something else by the time it is asked --
+    which reads as "still alive" and is how this reported a working kill as a
+    failure.
+    """
+    fields = _proc_stat_fields(pid)
+    if fields is None:
+        return True
+    if fields[0] == "Z":
+        return True
+    if starttime is not None and (len(fields) <= 19 or fields[19] != starttime):
+        # The pid was recycled: ours is gone and this is somebody else's process.
+        return True
+    return False
+
+
+def describe_process(pid: int) -> str:
+    """What /proc says about a pid, for a failure message that can be acted on."""
+    fields = _proc_stat_fields(pid)
+    if fields is None:
+        return f"pid {pid}: gone"
+    try:
+        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().replace(b"\0", b" ").decode(
+            "utf-8", "replace"
+        ).strip()
+    except OSError:
+        cmdline = "<unreadable>"
+    state = fields[0]
+    start = fields[19] if len(fields) > 19 else "?"
+    return f"pid {pid}: state={state} starttime={start} cmdline={cmdline!r}"
 
 
 def locked_toolchain():
@@ -586,12 +640,23 @@ class ModuleDocContractTests(unittest.TestCase):
             # works the child is gone in milliseconds, and if it does not the child
             # is still there when the deadline expires, so waiting longer costs
             # nothing on success and cannot manufacture one.
+            # Capture the identity BEFORE waiting. After this point the pid may
+            # be recycled, and comparing start times is what tells "our child is
+            # gone" apart from "that number now belongs to someone else".
+            child_start = process_starttime(child_pid)
+
+            # ONE evaluation decides the outcome. The previous shape asked twice
+            # -- once to break the loop, once to set the result -- so a pid
+            # recycled between the two answered "gone" and then "alive", failing
+            # a kill that had worked, in well under a second. That is what this
+            # test did in CI on 2026-08-13.
+            reaped = False
             deadline = time.monotonic() + 30.0
             while time.monotonic() < deadline:
-                if process_is_gone_or_zombie(child_pid):
+                if process_is_gone_or_zombie(child_pid, child_start):
+                    reaped = True
                     break
                 time.sleep(0.01)
-            reaped = process_is_gone_or_zombie(child_pid)
             if not reaped:
                 # Never leave a ten-minute sleep behind for the next test or the
                 # runner to inherit -- the failure is the assertion below, not a
@@ -599,7 +664,9 @@ class ModuleDocContractTests(unittest.TestCase):
                 with contextlib.suppress(ProcessLookupError, PermissionError):
                     os.kill(child_pid, signal.SIGKILL)
             self.assertTrue(
-                reaped, "Git descendant survived process-group timeout"
+                reaped,
+                "Git descendant survived process-group timeout: "
+                + describe_process(child_pid),
             )
             reader.budget.git_deadline = time.monotonic() - 1
             with mock.patch.object(contract.subprocess, "Popen") as popen:


### PR DESCRIPTION
## The failure

`test_decision_deadline_kills_git_and_prevents_late_spawn` failed CI again today
with *"Git descendant survived process-group timeout"* — the second time, after
2026-08-11 widened its wait from ~1s to 30s on the theory that a loaded runner
needed longer.

**That theory was wrong, and the evidence was in the failure itself:**

```
Ran 24 tests in 0.757s
```

A 30-second wait that expires cannot fit inside a sub-second run. The wait never
elapsed. The test was not slow — it was asking the wrong question, twice.

```python
while time.monotonic() < deadline:
    if process_is_gone_or_zombie(child_pid):
        break                                   # ← asked once
    time.sleep(0.01)
reaped = process_is_gone_or_zombie(child_pid)    # ← asked AGAIN
```

Two defects meet there:

1. **Two evaluations.** The loop breaks on one answer and the result is taken
   from a second, later one. Nothing guarantees they agree.
2. **A pid is a number, and Linux hands numbers out again.** Between those two
   calls the killed child can be reaped and its pid recycled on a busy runner.
   The first call sees a zombie and says *gone*; the second sees a live stranger
   wearing the same number and says *alive*. The kill worked, the test failed,
   in well under a second — exactly what was observed.

## The fix

Ask about a **process**, not a number. `/proc/<pid>/stat` field 22 is the start
time, so `(pid, starttime)` is a stable identity: a recycled pid names a process
that began later.

- `process_starttime()` captures the identity when the pid is learned.
- `process_is_gone_or_zombie()` treats a start-time mismatch as *ours is gone,
  this is somebody else's*.
- The wait evaluates **once** and keeps that answer.
- The failure message appends state, start time and cmdline — the old one named
  no process, which is why the first fix had to guess at load.

## Verified, not assumed

The predicate's full truth table against real processes:

| case | verdict | expected |
|---|---|---|
| live, identity matches | not gone | not gone |
| live, identity does **not** match (recycled pid) | **gone** | gone |
| killed, unreaped (state `Z`) | gone | gone |
| killed and reaped | gone | gone |
| **survivor, sampled ~100× over 1s** | **not gone, every time** | not gone |

That last row is the one that matters for trust: if a child survives, the
predicate keeps saying so, which is what keeps the assertion able to fail. A
green test that cannot go red would be worse than the flake.

The suite was also run repeatedly (3×, all green), alongside its two siblings
(`test_module_doc_git_snapshot`, `test_sign_module_docs`).

## Verification

- `python3 -I scripts/tests/test_module_doc_contract.py` — 24/24, three times
- `python3 -I scripts/tests/test_module_doc_git_snapshot.py` — 13/13
- `python3 -I scripts/tests/test_sign_module_docs.py` — 9/9
- `make -C src lint` — 56/56
