### PR TITLE
fix(cli): an async /v1 call must not outlive its own timeout

### DIFF
--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -1211,7 +1211,19 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
    snprintf(runpath, sizeof(runpath), "/v1/runs/%s", idj->valuestring);
    cJSON_Delete(queued);
 
-   int waited = 0;
+   /* Bound the WALL CLOCK, not the sum of the sleeps.
+    *
+    * `waited += step_ms` counted only the 500ms pause while each poll below can
+    * itself block for its own timeout. A server that accepts the poll and then
+    * goes quiet cost 15.5s of real time per iteration and credited 0.5s of it,
+    * so a declared 300000ms budget could run for 600 iterations x 15.5s -- over
+    * two and a half HOURS. A timeout that overruns by two orders of magnitude
+    * is indistinguishable from a hang, and was read as one.
+    *
+    * Two parts, and both are needed: measure elapsed against a monotonic
+    * deadline, and give each poll only the time that is actually LEFT, so a
+    * single stalled request cannot overshoot the budget on its own. */
+   const long long deadline_ms = timeout_ms > 0 ? util_now_ms() + timeout_ms : 0;
    const int step_ms = 500;
    /* A long remote run (delegate ensembles, kb.build, index.scan, …) polls for many
     * minutes. A single transient poll failure — a TLS/connection blip while the run
@@ -1223,7 +1235,17 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
    const int max_consec_fail = 20;
    for (;;)
    {
-      cJSON *snap = cli_v1_send(remote, bearer, "GET", runpath, NULL, 15000, &status);
+      /* Never hand a single poll more time than the whole call has left. */
+      int poll_ms = 15000;
+      if (deadline_ms)
+      {
+         long long left = deadline_ms - util_now_ms();
+         if (left <= 0)
+            return NULL;
+         if (left < poll_ms)
+            poll_ms = (int)left;
+      }
+      cJSON *snap = cli_v1_send(remote, bearer, "GET", runpath, NULL, poll_ms, &status);
       if (!snap)
       {
          if (++consec_fail > max_consec_fail)
@@ -1258,10 +1280,9 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
          }
          cJSON_Delete(snap);
       }
-      if (timeout_ms > 0 && waited >= timeout_ms)
+      if (deadline_ms && util_now_ms() >= deadline_ms)
          return NULL;
       cli_v1_sleep_ms(step_ms);
-      waited += step_ms;
    }
 }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -350,6 +350,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-coord-jobs \
                $(TESTPREFIX)/unit-test-deploy-apply \
                $(TESTPREFIX)/unit-test-cli-v1-subcommands \
+               $(TESTPREFIX)/unit-test-cli-v1-poll-deadline \
                $(TESTPREFIX)/unit-test-plan-waves \
                $(TESTPREFIX)/unit-test-history \
                $(TESTPREFIX)/unit-test-events \
@@ -1317,6 +1318,14 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-workspace-add-noscan
 $(TESTPREFIX)/unit-test-workspace-add-noscan: $(OBJDIR)/tests/test_workspace_add_noscan.o \
                                   $(OBJDIR)/modules/workspace/workspace_client_diff.o \
                                   $(OBJDIR)/cli_v1_routes.o \
+                                  $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/cli_v1_routes_e.o \
+                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+                                  $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-cli-v1-poll-deadline: $(OBJDIR)/tests/test_cli_v1_poll_deadline.o \
+                                  $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o \
                                   $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/cli_v1_routes_e.o \
                                   $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
                                   $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \

--- a/src/tests/test_cli_v1_poll_deadline.c
+++ b/src/tests/test_cli_v1_poll_deadline.c
@@ -1,0 +1,168 @@
+/* test_cli_v1_poll_deadline.c: an async /v1 call must honour its own timeout.
+ *
+ * cli_v1_run_and_poll POSTs an async route, gets a run handle, then polls
+ * GET /v1/runs/{id} until the run is terminal. It used to credit only its 500ms
+ * sleep against the caller's budget:
+ *
+ *     if (timeout_ms > 0 && waited >= timeout_ms) return NULL;
+ *     cli_v1_sleep_ms(step_ms);
+ *     waited += step_ms;
+ *
+ * while each poll could block for its own 15s. A server that accepts the poll
+ * and then goes quiet therefore burned 15.5s of wall clock per iteration and
+ * counted 0.5s of it, so a declared 300000ms budget could run for HOURS.
+ *
+ * That is not a hypothetical: `aimee git` against a workspace the server could
+ * not resolve sat far past the 300s printed in its own route table, which read
+ * as a hang and was diagnosed as one.
+ *
+ * The stub below reproduces exactly that server: it answers the POST with a run
+ * handle, then accepts every poll and never replies. The assertion is on ELAPSED
+ * WALL CLOCK, because that is the property that was broken -- with the old
+ * accounting this test runs for over a minute; with the deadline it returns
+ * inside its budget.
+ */
+#include <arpa/inet.h>
+#include <assert.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "cJSON.h"
+#include "cli_client.h"
+#include "util.h" /* util_now_ms */
+
+#define BUDGET_MS 2000
+/* Generous: the point is to separate "inside the budget" from the old
+ * behaviour, which needed a poll's full 15s before it even looked at the
+ * clock. Anything under the first poll timeout proves the deadline is real. */
+#define CEILING_MS 9000
+
+static atomic_int g_stop;
+static atomic_int g_polls;
+
+typedef struct
+{
+   int listen_fd;
+} stub_t;
+
+/* Answers the first request (the POST) with a run handle, then accepts every
+ * poll and holds it open without replying. Connections are kept open until the
+ * test says stop, so the client sees a stalled server rather than a refusal. */
+static void *stub_server(void *arg)
+{
+   stub_t *s = (stub_t *)arg;
+   int held[64];
+   int held_n = 0;
+   int first = 1;
+
+   while (!atomic_load(&g_stop))
+   {
+      struct timeval tv = {.tv_sec = 0, .tv_usec = 200000};
+      fd_set rd;
+      FD_ZERO(&rd);
+      FD_SET(s->listen_fd, &rd);
+      if (select(s->listen_fd + 1, &rd, NULL, NULL, &tv) <= 0)
+         continue;
+
+      int c = accept(s->listen_fd, NULL, NULL);
+      if (c < 0)
+         continue;
+
+      char req[4096];
+      ssize_t r = recv(c, req, sizeof(req) - 1, 0);
+      if (r <= 0)
+      {
+         close(c);
+         continue;
+      }
+      req[r] = '\0';
+
+      if (first)
+      {
+         first = 0;
+         const char *body = "{\"id\":\"oprun_1_1\"}";
+         char resp[256];
+         int n = snprintf(resp, sizeof(resp),
+                          "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                          "Content-Length: %zu\r\nConnection: close\r\n\r\n%s",
+                          strlen(body), body);
+         ssize_t w = send(c, resp, (size_t)n, 0);
+         (void)w;
+         close(c);
+         continue;
+      }
+
+      /* A poll. Say nothing at all and keep the socket open. */
+      atomic_fetch_add(&g_polls, 1);
+      if (held_n < (int)(sizeof(held) / sizeof(held[0])))
+         held[held_n++] = c;
+      else
+         close(c);
+   }
+
+   for (int i = 0; i < held_n; i++)
+      close(held[i]);
+   return NULL;
+}
+
+int main(void)
+{
+   printf("cli_v1_poll_deadline:\n");
+
+   stub_t stub;
+   stub.listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+   assert(stub.listen_fd >= 0);
+   int one = 1;
+   setsockopt(stub.listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+   struct sockaddr_in addr;
+   memset(&addr, 0, sizeof(addr));
+   addr.sin_family = AF_INET;
+   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   addr.sin_port = 0; /* ephemeral: no fixed port to collide with a parallel test */
+   assert(bind(stub.listen_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+   assert(listen(stub.listen_fd, 16) == 0);
+
+   socklen_t alen = sizeof(addr);
+   assert(getsockname(stub.listen_fd, (struct sockaddr *)&addr, &alen) == 0);
+   int port = ntohs(addr.sin_port);
+
+   pthread_t th;
+   assert(pthread_create(&th, NULL, stub_server, &stub) == 0);
+
+   char endpoint[64];
+   snprintf(endpoint, sizeof(endpoint), "http://127.0.0.1:%d", port);
+   setenv("AIMEE_API_ENDPOINT", endpoint, 1);
+
+   /* dev.sweep is an async route, so this goes through cli_v1_run_and_poll. */
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "method", "dev.sweep");
+
+   long long start = util_now_ms();
+   cJSON *resp = cli_v1_dispatch(req, BUDGET_MS);
+   long long elapsed = util_now_ms() - start;
+
+   cJSON_Delete(req);
+   if (resp)
+      cJSON_Delete(resp);
+
+   atomic_store(&g_stop, 1);
+   pthread_join(th, NULL);
+   close(stub.listen_fd);
+   unsetenv("AIMEE_API_ENDPOINT");
+
+   printf("  budget=%dms elapsed=%lldms polls=%d\n", BUDGET_MS, elapsed, atomic_load(&g_polls));
+   assert(atomic_load(&g_polls) >= 1); /* the run handle was accepted and polled */
+   assert(elapsed < CEILING_MS);       /* the budget bounds the wall clock */
+
+   printf("  a stalled server does not outlive the caller's timeout: ok\n");
+   printf("All cli_v1_poll_deadline tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
`cli_v1_run_and_poll` POSTs an async route, takes the run handle, then polls `GET /v1/runs/{id}`. It credited only its 500 ms sleep against the caller's budget:

```c
if (timeout_ms > 0 && waited >= timeout_ms) return NULL;
cli_v1_sleep_ms(step_ms);
waited += step_ms;
```

while each poll could block for its own 15 s. A server that **accepts** the poll and then goes quiet cost 15.5 s of wall clock per iteration and counted 0.5 s of it. `aimee git`'s declared 300000 ms budget would have needed ~600 iterations × 15.5 s to expire — **over two and a half hours**.

### How it was found
`aimee git` against a workspace the server could not resolve sat far past the 300 s printed in its own route table, with no output. That reads as a hang, and I diagnosed it as one for a long time. The timeout was there; it simply could not arrive.

### The fix — two parts, both needed
1. Measure the budget against a **monotonic deadline** instead of a sum of sleeps.
2. Give each poll only the time that is actually **left**, so a single stalled request cannot overshoot the budget on its own.

Without (2) a 2 s budget still waits out a full 15 s poll before it looks at the clock.

### Red before green
The test stands up a loopback stub that answers the POST with a run handle, then accepts every poll and never replies — the exact server shape above — and asserts on **elapsed wall clock**, because that is the property that was broken. Same test either side of the fix:

```
unfixed: 77s   for a declared 2000ms budget   → assertion fails
fixed:   2003ms for a declared 2000ms budget  → passes
```

The stub binds an **ephemeral** port rather than a fixed one, so it cannot collide with another test running in parallel.

### What does not change
With no timeout (`timeout_ms <= 0`) there is no deadline and each poll keeps its 15 s, so delegate ensembles, `kb.build` and `index.scan` still poll for as long as they need. The bounded run of consecutive poll failures — which exists so a transient TLS blip does not abandon a live run — is untouched.

### Verification
`make lint` 56/56, full C unit suite passes.
