### PR TITLE
fix(tests): make unit-test-server-management-listener-live link again

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -58,8 +58,19 @@ P5B3C_LIVE_SERVER_OBJS = $(filter-out $(OBJDIR)/server/server_main.o,$(SERVER_OB
                            $(SERVER_CMD_OBJS) $(CORE_OBJS) $(DB1_OBJS) $(PLATFORM_OBJS) \
                            $(MCP_GIT_OBJS) $(OBJDIR)/aimee_client.o
 
+# No log_stub.o here: this target links the real server objects, and those
+# already carry log.o. Having both put two definitions of aimee_log in one link
+# and the target had not built AT ALL -- it is absent from UNIT_TEST_TARGETS, so
+# nothing ran it and nothing reported it. The stub cannot replace log.o either;
+# it defines aimee_log and nothing else, while the server needs log_init,
+# log_set_level, audit_last_event and friends from the same object.
+# The two core libraries are prerequisites for the same reason they are on the
+# $(SERVER) rule: nothing else here builds them, so on a clean tree the link
+# failed with "cannot find build/obj/libaimee-core-connection.a". It only ever
+# appeared to work when a previous server build happened to leave them behind.
 $(TESTPREFIX)/unit-test-server-management-listener-live: \
-    $(OBJDIR)/tests/test_server_management_listener_live.o $(P5B3C_LIVE_SERVER_OBJS) $(OBJDIR)/tests/support/log_stub.o
+    $(OBJDIR)/tests/test_server_management_listener_live.o $(P5B3C_LIVE_SERVER_OBJS) \
+    $(CORE_EVENT_BUS_LIB) $(CORE_CONNECTION_LIB)
 	$(TESTLINK) -o $@ $^ $(L_SERVER)
 
 # Common object sets for tests


### PR DESCRIPTION
`unit-test-server-management-listener-live` **could not build at all**, and nothing said so, because nothing builds it: the target is absent from `UNIT_TEST_TARGETS` and no CI job names it. It has a rule and a `.PHONY` alias and has simply been dead.

Two independent faults, each fatal on its own.

### 1. `multiple definition of 'aimee_log'`
The rule linked `tests/support/log_stub.o` **on top of** the real server objects, which already carry `log.o`.

Filtering `log.o` out instead would only trade this error for a list of undefined references: the stub defines `aimee_log` and nothing else, while the server needs `log_init`, `log_set_level`, `audit_last_event` and the rest from that same object. So the stub is the redundant half and it goes. It remains in use by eight other targets and stays in the tree.

### 2. `cannot find build/obj/libaimee-core-connection.a`
The two core libraries were never prerequisites, so make did not build them first. This would only ever have appeared to work when an earlier server build happened to leave them in `build/obj`. They are prerequisites of the `$(SERVER)` rule for exactly this reason; now they are prerequisites here too.

### Verified by running it, not just building it
```
test_server_management_listener_live: SKIP (requires root-owned TLS fixtures)
```
That is its designed behaviour off root (`geteuid() != 0`).

### Why this does *not* join `UNIT_TEST_TARGETS`
As root the test generates real TLS material and stands up a live listener. Adding it to the ordinary suite would make an unprivileged run a silent no-op and a privileged run newly able to fail. Wiring it into a job that actually has those fixtures is a decision for whoever owns that surface — so this PR restores the link and says plainly that **the target's link is still unexercised by CI and can rot the same way again**.

### Verification
`make lint` 56/56, full C unit suite passes.
