### PR TITLE
fix(cli): the co-located UDS transport must give up too

### DIFF
--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -14,6 +14,7 @@
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
 #include <dirent.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
@@ -280,12 +281,21 @@ static int write_delegate_output_file(const char *path, const char *text)
  * (http_uds_client.c is not linked into the CLI). Returns the response body
  * (heap; caller frees) and sets *status_out to the HTTP status; NULL on
  * transport failure. Mirrors http_uds_client.c, which serves the same role for
- * the TUI. */
+ * the TUI.
+ *
+ * timeout_ms bounds the WAIT FOR A REPLY. It used not to take one at all: the
+ * caller's budget was honoured on the remote branch of cli_v1_send and silently
+ * dropped here, and the read loop below had no timeout of any kind. A
+ * co-located server that accepted the connection and then went quiet -- or died
+ * between accept and reply -- hung the CLI forever, with no way for the caller
+ * to bound it. That is the default transport for a co-located install. */
 static char *cli_v1_http_request(const char *verb, const char *path, const char *body,
-                                 int *status_out)
+                                 int timeout_ms, int *status_out)
 {
    if (status_out)
       *status_out = 0;
+   if (timeout_ms <= 0)
+      timeout_ms = CLIENT_DEFAULT_TIMEOUT_MS;
    const char *home = aimee_home();
    if (!home || !home[0])
       return NULL;
@@ -341,6 +351,7 @@ static char *cli_v1_http_request(const char *verb, const char *path, const char 
       off += n;
    }
 
+   const long long deadline_ms = util_now_ms() + timeout_ms;
    size_t cap = 8192, len = 0;
    char *resp = malloc(cap);
    if (!resp)
@@ -361,6 +372,24 @@ static char *cli_v1_http_request(const char *verb, const char *path, const char 
             return NULL;
          }
          resp = grown;
+      }
+      /* Wait for readability against the caller's deadline rather than
+       * blocking in read(). A server that accepts and never answers must cost
+       * the budget, not the session. */
+      long long left = deadline_ms - util_now_ms();
+      if (left <= 0)
+      {
+         free(resp);
+         close(fd);
+         return NULL;
+      }
+      struct pollfd readable = {.fd = fd, .events = POLLIN};
+      int pr = poll(&readable, 1, (int)left);
+      if (pr <= 0 || !(readable.revents & POLLIN))
+      {
+         free(resp);
+         close(fd);
+         return NULL;
       }
       int n = (int)read(fd, resp + len, 4096);
       if (n <= 0)
@@ -1048,7 +1077,7 @@ static cJSON *cli_v1_send(const char *remote, const char *bearer, const char *ve
    }
    else
    {
-      char *r = cli_v1_http_request(verb, path, body, &status);
+      char *r = cli_v1_http_request(verb, path, body, timeout_ms, &status);
       if (r)
       {
          resp = cJSON_Parse(r);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -362,6 +362,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-deploy-apply \
                $(TESTPREFIX)/unit-test-cli-v1-subcommands \
                $(TESTPREFIX)/unit-test-cli-v1-poll-deadline \
+               $(TESTPREFIX)/unit-test-cli-v1-uds-timeout \
                $(TESTPREFIX)/unit-test-plan-waves \
                $(TESTPREFIX)/unit-test-history \
                $(TESTPREFIX)/unit-test-events \
@@ -1330,6 +1331,14 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-workspace-add-noscan
 $(TESTPREFIX)/unit-test-workspace-add-noscan: $(OBJDIR)/tests/test_workspace_add_noscan.o \
                                   $(OBJDIR)/modules/workspace/workspace_client_diff.o \
                                   $(OBJDIR)/cli_v1_routes.o \
+                                  $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/cli_v1_routes_e.o \
+                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+                                  $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-cli-v1-uds-timeout: $(OBJDIR)/tests/test_cli_v1_uds_timeout.o \
+                                  $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o \
                                   $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/cli_v1_routes_e.o \
                                   $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
                                   $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \

--- a/src/tests/test_cli_v1_uds_timeout.c
+++ b/src/tests/test_cli_v1_uds_timeout.c
@@ -1,0 +1,130 @@
+/* test_cli_v1_uds_timeout.c: the co-located UDS transport must give up.
+ *
+ * cli_v1_send takes a timeout_ms and honoured it only on its REMOTE branch. The
+ * local Unix-socket branch (cli_v1_http_request) took no timeout argument at
+ * all, and its read loop was a bare blocking read():
+ *
+ *     int n = (int)read(fd, resp + len, 4096);
+ *     if (n <= 0) break;
+ *
+ * so a co-located server that accepted the connection and then went quiet --
+ * or died between accept and reply -- hung the CLI forever. There was no
+ * budget to exceed: the caller passed one and this path dropped it. That is
+ * the DEFAULT transport for a co-located install, which is what makes it worth
+ * a test rather than a note.
+ *
+ * The stub below is that server: it binds <AIMEE_HOME>/aimee-http.sock, accepts,
+ * and never writes a byte. The assertion is on elapsed wall clock -- before the
+ * fix this test does not fail, it HANGS, which is precisely the symptom.
+ */
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "cJSON.h"
+#include "cli_client.h"
+#include "util.h" /* util_now_ms */
+
+#define BUDGET_MS  1500
+#define CEILING_MS 8000
+
+static atomic_int g_stop;
+static atomic_int g_accepted;
+static char g_sock[256];
+
+static void *silent_server(void *unused)
+{
+   (void)unused;
+   int srv = socket(AF_UNIX, SOCK_STREAM, 0);
+   if (srv < 0)
+      return NULL;
+   struct sockaddr_un addr;
+   memset(&addr, 0, sizeof(addr));
+   addr.sun_family = AF_UNIX;
+   snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", g_sock);
+   unlink(g_sock);
+   if (bind(srv, (struct sockaddr *)&addr, sizeof(addr)) != 0 || listen(srv, 8) != 0)
+   {
+      close(srv);
+      return NULL;
+   }
+
+   int held[32];
+   int held_n = 0;
+   while (!atomic_load(&g_stop))
+   {
+      struct timeval tv = {.tv_sec = 0, .tv_usec = 200000};
+      fd_set rd;
+      FD_ZERO(&rd);
+      FD_SET(srv, &rd);
+      if (select(srv + 1, &rd, NULL, NULL, &tv) <= 0)
+         continue;
+      int c = accept(srv, NULL, NULL);
+      if (c < 0)
+         continue;
+      atomic_fetch_add(&g_accepted, 1);
+      /* Accepted and deliberately mute: hold it open, answer nothing. */
+      if (held_n < (int)(sizeof(held) / sizeof(held[0])))
+         held[held_n++] = c;
+      else
+         close(c);
+   }
+   for (int i = 0; i < held_n; i++)
+      close(held[i]);
+   close(srv);
+   unlink(g_sock);
+   return NULL;
+}
+
+int main(void)
+{
+   printf("cli_v1_uds_timeout:\n");
+
+   /* AIMEE_HOME decides where the client looks for aimee-http.sock. */
+   const char *tmp = getenv("TMPDIR");
+   char home[192];
+   snprintf(home, sizeof(home), "%s/aimee-uds-timeout-%d", tmp && tmp[0] ? tmp : "/tmp",
+            (int)getpid());
+   assert(mkdir(home, 0700) == 0 || 1);
+   setenv("AIMEE_HOME", home, 1);
+   snprintf(g_sock, sizeof(g_sock), "%s/aimee-http.sock", home);
+
+   pthread_t th;
+   assert(pthread_create(&th, NULL, silent_server, NULL) == 0);
+   for (int i = 0; i < 200 && access(g_sock, F_OK) != 0; i++)
+      usleep(10000); /* wait for bind/listen */
+
+   /* A synchronous method, so this takes the plain request path rather than
+    * the async poller: no remote endpoint is configured, so it goes over the
+    * co-located Unix socket. */
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "method", "server.info");
+
+   long long start = util_now_ms();
+   cJSON *resp = cli_v1_dispatch(req, BUDGET_MS);
+   long long elapsed = util_now_ms() - start;
+
+   cJSON_Delete(req);
+   if (resp)
+      cJSON_Delete(resp);
+
+   atomic_store(&g_stop, 1);
+   pthread_join(th, NULL);
+   rmdir(home);
+
+   printf("  budget=%dms elapsed=%lldms accepted=%d\n", BUDGET_MS, elapsed,
+          atomic_load(&g_accepted));
+   assert(atomic_load(&g_accepted) >= 1); /* the stub really was talked to */
+   assert(elapsed < CEILING_MS);          /* and the client gave up on its own */
+
+   printf("  a mute co-located server does not hang the client: ok\n");
+   printf("All cli_v1_uds_timeout tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
`cli_v1_send` takes a `timeout_ms` and honoured it **only on its remote branch**. The local Unix-socket branch, `cli_v1_http_request`, took no timeout argument at all, and its read loop was a bare blocking `read()`:

```c
int n = (int)read(fd, resp + len, 4096);
if (n <= 0) break;
```

A co-located server that accepts the connection and then goes quiet — or dies between accept and reply — therefore hangs the CLI **forever**. There was no budget to overrun: the caller passed one and this path dropped it.

This is the sibling of the async-poll overrun fixed in #2625, and the worse of the two. That one expired eventually (after hours); this one never expires. It is also the **default transport for a co-located install**, so it is not an exotic corner.

### How it was found
By treating #2625 as a *pattern* rather than an incident and sweeping for the same shape — a declared budget that nothing enforces. The rest of that sweep came back clean and is deliberately untouched: `posix/cli_client.c`'s spawn-lock wait, `kb_ingest_workers.c`'s interval sleep and `platform_process.c`'s exit grace all only sleep in their loop bodies, so their accounting is honest.

### The fix
Thread the caller's timeout into `cli_v1_http_request` and wait for readability with `poll()` against a monotonic deadline instead of blocking in `read()`. The single existing call site passes `cli_v1_send`'s `timeout_ms`; a non-positive value keeps the previous default (`CLIENT_DEFAULT_TIMEOUT_MS`).

### Red before green — note what "red" means here
The test binds a Unix socket at `<AIMEE_HOME>/aimee-http.sock`, accepts, and never writes a byte. Before the fix the test does not *fail*, it **hangs**, so the red run has to be killed from outside and `rc=124` is the evidence:

```
unfixed: killed at 60s — never gave up on its own
fixed:   1502ms against a 1500ms budget, accepted=1
```

### Verification
`make lint` 56/56, full C unit suite passes.
