### PR TITLE
size the roundtable body cap to the artifact, and stop allocating a claim

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -520,7 +520,7 @@ SERVER_SRCS = server/embedder_catalog.c cli_v1_routes.c cli_v1_routes_b.c cli_v1
 SERVER_SRCS += server/server_runtime_identity.c
 SERVER_SRCS += server/ingress_project_scope.c
 SERVER_SRCS += server/server_write_tier.c server/server_write_tier_db1.c server/server_mgmt_token.c server/kb_verifier_server_stub.c kb/auth_oidc.c server/server_mgmt_audit.c server/server_mgmt_endpoint.c shared/management_read.c server/server_mgmt_read_endpoint.c server/server_mgmt_read_source.c server/server_mgmt_status.c server/server_mgmt_checkpoint_client.c kb/kb_mgmt_status.c kb/kb_mgmt_client.c kb/kb_mgmt_endpoint.c
-SERVER_SRCS += http_content_encoding.c server/server_http_keepalive.c
+SERVER_SRCS += http_content_encoding.c server/server_http_keepalive.c server/server_http_body.c
 SERVER_SRCS += modules/economizer/gateway_mutate_wire.c
 # The one object that links vault_service to the (D7-confined) audit bus, keeping
 # vault_service.o itself bus-free; server-only, co-linked with $(CORE_EVENT_BUS_LIB).

--- a/src/cli_v1_routes.c
+++ b/src/cli_v1_routes.c
@@ -1887,9 +1887,9 @@ cJSON *marshal_roundtable_review(int argc, char **argv)
    }
    char *artifact_text = NULL;
    if (artifact_stdin)
-      artifact_text = marshal_read_stdin_limited(16u * 1024u * 1024u);
+      artifact_text = marshal_read_stdin_limited(CLI_V1_MAX_ROUNDTABLE_ARTIFACT);
    else if (artifact_path)
-      artifact_text = marshal_read_file_limited(artifact_path, 16u * 1024u * 1024u);
+      artifact_text = marshal_read_file_limited(artifact_path, CLI_V1_MAX_ROUNDTABLE_ARTIFACT);
    else if (opts.pos_count > 0 && opts.positional[0])
    {
       FILE *probe = fopen(opts.positional[0], "rb");
@@ -1897,7 +1897,8 @@ cJSON *marshal_roundtable_review(int argc, char **argv)
       {
          fclose(probe);
          artifact_positional = 1;
-         artifact_text = marshal_read_file_limited(opts.positional[0], 16u * 1024u * 1024u);
+         artifact_text =
+             marshal_read_file_limited(opts.positional[0], CLI_V1_MAX_ROUNDTABLE_ARTIFACT);
          if (!artifact_text)
          {
             cJSON_Delete(req);

--- a/src/headers/cli_v1_routes_internal.h
+++ b/src/headers/cli_v1_routes_internal.h
@@ -260,7 +260,14 @@ void rpc_parse(int argc, char **argv, const char **bool_flags, rpc_opts_t *out);
  * own dependency chain, which the CLI does not build against.
  * test_cli_v1_body_cap_matches_server pins these equal to SHTTP_MAX_BODY /
  * SHTTP_MAX_ROUNDTABLE_BODY. */
-#define CLI_V1_MAX_BODY            (4 * 1024 * 1024)
-#define CLI_V1_MAX_ROUNDTABLE_BODY (128 * 1024 * 1024)
+#define CLI_V1_MAX_BODY (4 * 1024 * 1024)
+
+/* Keep in step with ROUNDTABLE_MAX_ARTIFACT / SHTTP_MAX_ROUNDTABLE_BODY in
+ * headers/server.h (2x the artifact); test_cli_v1_body_cap_matches_server pins
+ * them equal. CLI_V1_MAX_ROUNDTABLE_ARTIFACT is what the three artifact reads in
+ * marshal_roundtable_review pass to marshal_read_*_limited -- it was written out
+ * as a bare 16MB literal at each of them. */
+#define CLI_V1_MAX_ROUNDTABLE_ARTIFACT (16 * 1024 * 1024)
+#define CLI_V1_MAX_ROUNDTABLE_BODY     (2 * CLI_V1_MAX_ROUNDTABLE_ARTIFACT)
 
 #endif

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -56,14 +56,30 @@ typedef struct cJSON cJSON;
  * only report as "could not reach the endpoint" — blaming a server that is up
  * and answering. The sibling LIMIT_* values below are already documented against
  * it. */
-#define SHTTP_MAX_BODY            (4 * 1024 * 1024)
-#define SHTTP_MAX_ROUNDTABLE_BODY (128 * 1024 * 1024)
+#define SHTTP_MAX_BODY (4 * 1024 * 1024)
+
+/* The roundtable review artifact is hard-limited where the CLI reads it --
+ * marshal_read_stdin_limited / marshal_read_file_limited in cli_v1_routes.c, all
+ * three call sites -- so a review body is that artifact plus a small envelope.
+ * The transport cap is TWICE the artifact: real review text and diffs escape at
+ * about 1.02x, and the doubling covers the envelope plus quote/backslash-dense
+ * content with room to spare.
+ *
+ * It was 128MB. That assumed a 6x blowup -- every byte a control character
+ * escaping to \u00XX -- and rounded up to 2^27, which made this route accept 32x
+ * what the rest of /v1 does. The artifact reaches cJSON as a NUL-terminated
+ * string, so the all-control-bytes case it was sized for cannot arrive intact.
+ * If an escape-dense artifact ever genuinely needs more room, raise
+ * ROUNDTABLE_MAX_ARTIFACT and let the cap follow; do not re-inflate the
+ * transport limit on its own, because the listener allocates against it. */
+#define ROUNDTABLE_MAX_ARTIFACT   (16 * 1024 * 1024)
+#define SHTTP_MAX_ROUNDTABLE_BODY (2 * ROUNDTABLE_MAX_ARTIFACT)
 
 /* Per-method payload size limits */
 #define LIMIT_MEMORY     (256 * 1024)        /* 256KB for memory operations */
 #define LIMIT_TOOL       (4 * 1024 * 1024)   /* 4MB for tool I/O */
 #define LIMIT_DELEGATE   (4 * 1024 * 1024)   /* 4MB: supports 2MB prompt-file + JSON overhead */
-#define LIMIT_ROUNDTABLE (128 * 1024 * 1024) /* 16MB artifact plus worst-case JSON escaping */
+#define LIMIT_ROUNDTABLE SHTTP_MAX_ROUNDTABLE_BODY /* artifact + JSON escaping; see above */
 #define LIMIT_CHAT       (512 * 1024)        /* 512KB for chat messages */
 #define LIMIT_INGEST     (1024 * 1024)       /* 1MB: client-pushed code files (kb req cap) */
 #define LIMIT_TRANSCRIPT                                                                           \

--- a/src/headers/server_http_internal.h
+++ b/src/headers/server_http_internal.h
@@ -132,6 +132,13 @@ typedef struct
 
 typedef int (*route_handler_fn)(const route_req_t *rq, char *resp, int cap);
 
+/* First slab for a request body. Bodies are overwhelmingly small, so this is the
+ * only allocation most requests ever make; http_body_reserve (server_http_body.c)
+ * doubles from here as bytes actually arrive, rather than trusting the declared
+ * Content-Length. */
+#define HTTP_BODY_INITIAL_ALLOC (64u * 1024u)
+char *http_read_body(int fd, const char *prefix, int prefix_len, int declared, int *out_len);
+
 /* Narrow request-scoped keepalive used by the P5 management challenge. */
 void server_http_keepalive_set(int enabled);
 int server_http_keepalive_peek(void);

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1885,31 +1885,25 @@ void handle_conn(int fd, int is_tcp, int is_management)
          return;
       }
       body_len = (int)declared;
-      body = malloc((size_t)body_len + 1);
+      /* Allocate against bytes RECEIVED, not bytes claimed -- http_read_body
+       * grows as data arrives, with `body_len` (already validated against the
+       * route limit above) as the ceiling. */
+      const char *bs = strstr(buf, "\r\n\r\n");
+      int prefix_len = 0;
+      if (bs)
+      {
+         bs += 4;
+         prefix_len = (int)(buf + total - bs);
+         if (prefix_len < 0)
+            prefix_len = 0;
+         if (prefix_len > body_len)
+            prefix_len = body_len;
+      }
+      int already = 0;
+      body = http_read_body(fd, bs, prefix_len, body_len, &already);
       if (body)
       {
          int declared_body_len = body_len;
-         int already = 0;
-         const char *bs = strstr(buf, "\r\n\r\n");
-         if (bs)
-         {
-            bs += 4;
-            already = (int)(buf + total - bs);
-            if (already < 0)
-               already = 0;
-            if (already > body_len)
-               already = body_len;
-            if (already > 0)
-               memcpy(body, bs, (size_t)already);
-         }
-         while (already < body_len)
-         {
-            int n = server_conn_io_read(fd, body + already, (int)(body_len - already));
-            if (n <= 0)
-               break;
-            already += n;
-         }
-         body[already] = '\0';
          if (server_http_keepalive_peek() && already != declared_body_len)
          {
             server_http_keepalive_set(0);

--- a/src/server/server_http_body.c
+++ b/src/server/server_http_body.c
@@ -1,0 +1,98 @@
+/* server_http_body.c: request-body buffer growth for the /v1 listener.
+ *
+ * Its own translation unit because server_http.c sits one line under the
+ * line-check ceiling (2499 of 2500), so anything added there fails the build.
+ * The concern is self-contained anyway, and it keeps company with the other
+ * small HTTP helpers -- http_content_encoding.c, server_http_keepalive.c. */
+#include "server_http_internal.h"
+#include "server_conn_io.h"
+#include "server.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* Grow *body to hold `need` bytes, doubling, never past `hard`. Returns 0 on
+ * failure with *body still valid and owned by the caller.
+ *
+ * This exists because Content-Length is a CLAIM, not data. The body buffer used
+ * to be malloc'd at the declared length before a single body byte was read, so a
+ * request that merely SAID it was large reserved that much memory for free --
+ * and on /v1/roundtable/review the ceiling was 128MB, so a few concurrent
+ * connections could pin gigabytes without ever sending a payload. Growing as
+ * bytes actually arrive ties the allocation to real data; the declared length is
+ * still the hard ceiling (checked against the route limit by the caller, and
+ * passed in here as `hard`).
+ *
+ * The doubling guard is `next < hard - next` rather than `next * 2 < hard`, so
+ * the size never overflows on the way up; when doubling cannot reach `need`, the
+ * ceiling itself is used. */
+static int http_body_reserve(char **body, size_t *cap, size_t need, size_t hard)
+{
+   if (need <= *cap)
+      return 1;
+   if (need > hard)
+      return 0;
+   size_t next = *cap ? *cap : (size_t)HTTP_BODY_INITIAL_ALLOC;
+   while (next < need && next < hard - next)
+      next *= 2;
+   if (next < need)
+      next = hard;
+   if (next > hard)
+      next = hard;
+   char *grown = realloc(*body, next);
+   if (!grown)
+      return 0;
+   *body = grown;
+   *cap = next;
+   return 1;
+}
+
+/* Read a `declared`-byte request body: the `prefix_len` bytes already sitting in
+ * the header buffer, then whatever is still on the wire. Returns a
+ * NUL-terminated buffer with the bytes ACTUALLY read in *out_len (which is short
+ * of `declared` if the peer stopped early -- the caller decides whether that is
+ * fatal), or NULL if the first slab could not be allocated.
+ *
+ * The caller has already rejected a `declared` over the route limit; this
+ * function never allocates that much on the strength of the claim alone. */
+char *http_read_body(int fd, const char *prefix, int prefix_len, int declared, int *out_len)
+{
+   size_t hard = (size_t)declared + 1;
+   size_t cap = hard < HTTP_BODY_INITIAL_ALLOC ? hard : (size_t)HTTP_BODY_INITIAL_ALLOC;
+   char *body = malloc(cap);
+   if (!body)
+      return NULL;
+
+   int already = 0;
+   if (prefix && prefix_len > 0)
+   {
+      if (!http_body_reserve(&body, &cap, (size_t)prefix_len + 1, hard))
+      {
+         free(body);
+         return NULL;
+      }
+      memcpy(body, prefix, (size_t)prefix_len);
+      already = prefix_len;
+   }
+
+   while (already < declared)
+   {
+      if (!http_body_reserve(&body, &cap, (size_t)already + 2, hard))
+      {
+         free(body);
+         return NULL;
+      }
+      int want = (int)(cap - 1 - (size_t)already);
+      if (want > declared - already)
+         want = declared - already;
+      if (want <= 0)
+         break;
+      int n = server_conn_io_read(fd, body + already, want);
+      if (n <= 0)
+         break;
+      already += n;
+   }
+
+   body[already] = '\0';
+   *out_len = already;
+   return body;
+}


### PR DESCRIPTION
size the roundtable body cap to the artifact, and stop allocating a claim

The roundtable review route accepted a 128MB body -- 32x what the rest of /v1
takes. Nothing needs that. The artifact is hard-limited to 16MB at every point
the CLI reads it (marshal_read_stdin_limited / marshal_read_file_limited, all
three call sites in marshal_roundtable_review), so a review body is that
artifact plus a small envelope. 128MB came from assuming a 6x JSON-escape
blowup -- every byte a control character escaping to \u00XX -- rounded up to
2^27. The artifact reaches cJSON as a NUL-terminated string, so the
all-control-bytes case it was sized for cannot arrive intact, and real review
text and diffs escape at about 1.02x. For scale: a 1M-token context is roughly
4MB of text.

The cap is now 2x the artifact (32MB), and it DERIVES from it --
ROUNDTABLE_MAX_ARTIFACT is the one number, SHTTP_MAX_ROUNDTABLE_BODY and
LIMIT_ROUNDTABLE follow, and the client mirror follows the same shape. The 16MB
artifact limit was previously three bare literals at the three read sites; it is
now CLI_V1_MAX_ROUNDTABLE_ARTIFACT, so the cap and the thing it is a cap ON
cannot drift apart. test_cli_v1_body_cap_matches_server still pins client and
server equal and now reports 4194304 / 33554432.

THE SIZE WAS THE SMALLER HALF. The listener allocated the DECLARED length before
reading a single body byte:

    body_len = (int)declared;
    body = malloc((size_t)body_len + 1);

Content-Length is a claim, not data. A request that merely SAID it was large
reserved that much memory and never had to send anything -- at 128MB, a handful
of concurrent connections pinned gigabytes for free. Lowering the cap alone
would have left that intact, just 4x cheaper per connection.

So the body now grows as bytes actually arrive: a 64KB first slab (most bodies
never outgrow it), doubling through http_body_reserve, with the declared length
still the hard ceiling and still validated against the route limit before any
allocation. An allocation failure mid-read answers 500 rather than truncating
silently, which is what the old code did when malloc returned NULL on a
keep-alive connection.

The read moves to server/server_http_body.c because server_http.c sat at 2499 of
line-check's 2500-line ceiling, so ANY addition failed the build. Extracting the
whole body read rather than shaving comments leaves it at 2493 and puts the
concern with the other small HTTP helpers (http_content_encoding.c,
server_http_keepalive.c). Server-only, so it joins SERVER_SRCS in src/Makefile;
CMake builds the client alone -- server_http.c is not listed there either -- so
it needs no entry, which is why this does not trip the "forgot the second build
system" trap that only fails on Windows CI.

Built clean under -Werror, line-check ok at 2493, and unit-tests pass. Found while chasing a multi-GB
aimee-server RSS retention; this is NOT that bug -- the burst does not reproduce
on ordinary traffic and the evidence there points at a loop on the chatgpt
routing path, not at this. This is a separate amplification vector that the
investigation happened to walk past.
