### PR TITLE
fix(workspace): say why a mirror could not be resolved

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -224,7 +224,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "a736ad8ba9e59a15bceaac8f7d46e67d459d5c2cb7b9de1c8d4b830bc09f39b1",
+      "source_sha256": "fed65372d21a7dace06e0df4b79b917a194c0f45e6a73a793339b7eeba710a23",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,

--- a/scripts/test-tmpdir-baseline.json
+++ b/scripts/test-tmpdir-baseline.json
@@ -141,6 +141,6 @@
     "src/tests/test_workspace_provider.c": 1,
     "src/tests/test_workspace_provider_detached.c": 2,
     "src/tests/test_workspace_scope.c": 1,
-    "src/tests/test_workspace_turn.c": 28
+    "src/tests/test_workspace_turn.c": 31
   }
 }

--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -133,14 +133,42 @@ static int mirror_reconstruct_cwd(const char *cwd, const char *root, const char 
    if (out && out_cap)
       out[0] = '\0';
    if (!head || !head[0] || !out || !out_cap)
-      return 0; /* without a client head there is nothing to reconstruct */
+   {
+      /* Every `return 0` below means "this mirror could not be resolved", and
+       * each one used to be silent. The caller then left the client-side path
+       * in place, which does not exist server-side, and the request fell
+       * through to the workspace RUNNER — where it waited out WS_RUNNER_OP_MS
+       * (600s) and failed with "unavailable through the registered workspace
+       * runner".
+       *
+       * So the operator saw a ten-minute stall and an error naming a subsystem
+       * that was never the problem, with NOTHING in the log: no clone, no
+       * fetch, no warning, no trace of the decision that actually caused it.
+       * Diagnosing it took hours of black-box probing and produced three wrong
+       * theories (a server deadlock, a stale session, missing credentials)
+       * before the real shape appeared. A resolver that fails invisibly and
+       * blames its fallback is the defect; the log line is the fix. */
+      LOG_WARN("workspace", "mirror resolve: no client head for %s — nothing to reconstruct",
+               root ? root : "(null)");
+      return 0;
+   }
 
    char base[MAX_PATH_LEN], mirror_dir[MAX_PATH_LEN], work_dir[MAX_PATH_LEN];
    if (workspace_mirror_base(base, sizeof(base)) != 0)
-      return 0; /* durable workspaces dir (AIMEE_WORKSPACES_DIR / aimee_home) unresolvable */
+   {
+      LOG_WARN("workspace",
+               "mirror resolve: workspaces dir unresolvable (AIMEE_WORKSPACES_DIR / aimee_home) "
+               "for %s",
+               root);
+      return 0;
+   }
    if (workspace_mirror_paths(base, root, mirror_dir, sizeof(mirror_dir), work_dir,
                               sizeof(work_dir)) != 0)
+   {
+      LOG_WARN("workspace", "mirror resolve: cannot derive mirror/work paths under %s for %s", base,
+               root);
       return 0;
+   }
 
    /* mirror-sync publishes immutable, generation-qualified snapshots.  Prefer
     * that atomically-published metadata over the legacy mutable client.diff so
@@ -152,7 +180,11 @@ static int mirror_reconstruct_cwd(const char *cwd, const char *root, const char 
    char snapshot_meta[MAX_PATH_LEN], snapshot_diff[MAX_PATH_LEN];
    snapshot_diff[0] = '\0';
    if (workspace_mirror_snapshot_meta_path(base, root, snapshot_meta, sizeof(snapshot_meta)) != 0)
+   {
+      LOG_WARN("workspace", "mirror resolve: cannot derive the snapshot metadata path for %s",
+               root);
       return 0;
+   }
 
    /* Absence means this workspace predates snapshot publication and may use the
     * legacy head/diff pair. Once metadata exists it is authoritative: unreadable
@@ -161,11 +193,19 @@ static int mirror_reconstruct_cwd(const char *cwd, const char *root, const char 
       const workspace_provider_t *shared = workspace_provider_shared();
       ws_stat_t meta_stat;
       if (shared->stat(shared, snapshot_meta, &meta_stat) != 0)
+      {
+         LOG_WARN("workspace", "mirror resolve: cannot stat snapshot metadata %s for %s",
+                  snapshot_meta, root);
          return 0;
+      }
       if (meta_stat.exists)
       {
          if (meta_stat.is_dir)
+         {
+            LOG_WARN("workspace", "mirror resolve: snapshot metadata path %s is a directory",
+                     snapshot_meta);
             return 0;
+         }
          char *metadata = NULL;
          size_t metadata_len = 0;
          ws_mirror_snapshot_t snapshot;
@@ -299,10 +339,21 @@ int workspace_turn_resolve_mirror_cwd(const char *cwd, char *out, size_t out_cap
          snprintf(root, sizeof(root), "%s", config_workspaces(i));
          snprintf(remote, sizeof(remote), "%s", config_workspace_vcs_remote(i));
          snprintf(head, sizeof(head), "%s", config_workspace_vcs_head(i));
-         return mirror_reconstruct_cwd(cwd, root, remote, head, out, out_cap, NULL, 0, &v);
+         int resolved = mirror_reconstruct_cwd(cwd, root, remote, head, out, out_cap, NULL, 0, &v);
+         if (!resolved)
+            LOG_WARN("workspace",
+                     "mirror resolve FAILED for registered workspace %s (cwd=%s); the caller will "
+                     "fall back to the runner path and report a runner error after its timeout",
+                     root, cwd);
+         return resolved;
       }
       return 0; /* matched, but not a mirror workspace */
    }
+   /* Not in any registered workspace. Worth saying: a session worktree is
+    * expected to be registered, and "not registered" and "registered but
+    * unresolvable" produce the SAME downstream error, which is what made this
+    * hard to tell apart from the outside. */
+   LOG_INFO("workspace", "mirror resolve: %s is not inside any registered workspace", cwd);
    return 0;
 }
 

--- a/src/tests/test_workspace_turn.c
+++ b/src/tests/test_workspace_turn.c
@@ -349,6 +349,60 @@ int main(void)
          assert(g_acquires == 0);
          rmdir("/tmp/aimee-root-authorized");
 
+         /* A mirror workspace that cannot be resolved must SAY SO.
+          *
+          * Every failure path in mirror_reconstruct_cwd used to return 0 in silence.
+          * The caller then left the client-side path in place, the request fell
+          * through to the workspace runner, waited out WS_RUNNER_OP_MS (600s) and
+          * failed with "unavailable through the registered workspace runner" -- an
+          * error naming a subsystem that was never the problem, with nothing in the
+          * log to contradict it. Diagnosing that took hours and produced three wrong
+          * theories. A diagnostic nobody can see is the defect, so assert the line is
+          * actually emitted rather than trusting that it was added. */
+         {
+            c.workspace_count = 1;
+            snprintf(c.workspaces[0], MAX_PATH_LEN, "/tmp/ws-mirror-unresolvable");
+            snprintf(c.workspace_providers[0], sizeof(c.workspace_providers[0]), "mirror");
+            snprintf(c.workspace_vcs_remote[0], sizeof(c.workspace_vcs_remote[0]),
+                     "https://example.invalid/r.git");
+            c.workspace_vcs_head[0][0] = '\0'; /* no client head -> cannot reconstruct */
+            assert(config_save(&c) == 0);
+
+            char capture[512];
+            snprintf(capture, sizeof(capture), "%s/wsturn-log-XXXXXX", platform_tmpdir());
+            int cap_fd = mkstemp(capture);
+            assert(cap_fd >= 0);
+            fflush(stderr);
+            int saved = dup(STDERR_FILENO);
+            assert(saved >= 0);
+            assert(dup2(cap_fd, STDERR_FILENO) >= 0);
+
+            char out[MAX_PATH_LEN] = "sentinel";
+            int rc = workspace_turn_resolve_mirror_cwd("/tmp/ws-mirror-unresolvable/src", out,
+                                                       sizeof(out));
+
+            fflush(stderr);
+            assert(dup2(saved, STDERR_FILENO) >= 0);
+            close(saved);
+
+            assert(rc == 0); /* behaviour unchanged: still refuses to resolve */
+            assert(!out[0]); /* and still clears the output */
+
+            FILE *f = fopen(capture, "r");
+            assert(f);
+            char logged[4096] = "";
+            size_t n = fread(logged, 1, sizeof(logged) - 1, f);
+            logged[n] = '\0';
+            fclose(f);
+            unlink(capture);
+            close(cap_fd);
+
+            /* The point of the change: it is no longer silent. */
+            assert(strstr(logged, "mirror resolve") != NULL);
+            assert(strstr(logged, "/tmp/ws-mirror-unresolvable") != NULL);
+            printf("  unresolvable mirror is reported, not silent: ok\n");
+         }
+
          /* restore the real roots for the cases below */
          memset(&c, 0, sizeof(c));
          config_load(&c);


### PR DESCRIPTION
`mirror_reconstruct_cwd` had six ways to give up and **all of them were silent**. The caller then left the client-side path in place — which does not exist server-side — the request fell through to the workspace runner, waited out `WS_RUNNER_OP_MS` (600 s), and failed with:

```
requested git path is outside the session checkout or unavailable through
the registered workspace runner
```

naming a subsystem that was never the problem, with nothing in the log to contradict it. Over a full 600 s window the server-side workspace directory count never moved and no git process ran.

That silence cost hours and produced three wrong theories in a row, each disproved by measurement: a server-side deadlock (restarting the container changed nothing), a stale pre-fix session (a live post-fix session failed identically), and a missing GitHub credential (the server clones the repo anonymously in 12 s). The resolver knew the answer the whole time and had no way to say it.

### What changes
Every bail now names itself and the workspace: no client head, unresolvable workspaces dir, underivable mirror/work paths, underivable snapshot metadata path, unstatable metadata, and the "matched a registered mirror but could not resolve it" case that immediately precedes the misleading runner error.

**Behaviour is unchanged** — each path still returns 0 and still clears the output.

### The test asserts the line is emitted
A diagnostic nobody can see is the defect being fixed, so the test does not merely check that logging was added: it registers a mirror workspace with no head, captures stderr across the call, and requires **both** the message and the workspace root to appear. Verified red first — against the unpatched resolver it aborts on that assertion.

### On the lock file
`workspace` is a vendored module, so `dependencies/aimee-repositories.lock.json` carries a digest of its owned files. It is **regenerated** here with the exporter's own helpers (never hand edited), and only `workspace`'s `source_sha256` moves.

Worth stating plainly, because I had it wrong for most of this work: this **does not re-pin anything upstream**. `check_c_repository_lock` validates that `commit` is SHA-1-*shaped* and that `source_sha256` matches the **local** files — it never resolves the commit remotely.

### Other guards
The three new `/tmp/ws-mirror-unresolvable` literals are **recorded** in the tmpdir baseline rather than converted, per that guard's own rule: nothing creates that path, it is a workspace root the test registers and reasons about.

### Verification
`make lint` 56/56, full C unit suite passes, rebased onto current `testing` with both digests re-verified after the rebase.
