### PR TITLE
kb: the content-to-tenancy referent and the visibility predicate (slice 1)

### DIFF
--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -2070,6 +2070,55 @@ CREATE POLICY p_project_member ON kb_project
          OR id IN (SELECT project FROM kb_project_membership
                    WHERE identity_key = current_setting('aimee.principal', true))));
 
+-- ---------------------------------------------------------------------------
+-- CONTENT SCOPE, part 1: the referent and the predicate. Neither enforces
+-- anything on its own; the policies that read them land with the backfill.
+-- See docs/proposals/pending/per-user-content-scope-visibility.md.
+--
+-- WHY A COLUMN ON `projects` AND NOT ON EACH CONTENT TABLE. kb_documents,
+-- kb_file_index, kb_embeddings and kb_pdf_embeddings all carry `project`, which
+-- holds projects.name (bound at ingest in kb_payload.c). projects.name is
+-- globally UNIQUE, so it identifies exactly one row; one link here therefore
+-- gives every content table a route to tenancy.
+--
+-- AND WHY NOT BY NAME. kb_project is UNIQUE(parent, name): two teams may each
+-- own a project called `aimee`, so a name identifies NOTHING on its own.
+-- Resolving content to tenancy by name lets a member of one team read another
+-- team's content, which is a cross-tenant leak introduced by the control meant
+-- to prevent one. Reproduced in
+-- docs/validation/per-user-content-scope-prototype.md; do not "simplify" this
+-- into a name match.
+--
+-- NULL means unattributed, and kb_project_visible() denies it. Nothing reads
+-- that yet, so an existing deployment is unaffected until the policies land.
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS kb_project BIGINT REFERENCES kb_project(id);
+CREATE INDEX IF NOT EXISTS idx_projects_kb_project ON projects(kb_project);
+
+-- May the current principal see this tenancy project? The rule is
+-- p_project_member's, said ONCE so every content policy calls it rather than
+-- carrying its own copy: (a) the parent team is one of the principal's teams;
+-- (b) a selected billing team narrows it further; (c) a `restricted` project
+-- needs an explicit membership where `team-open` does not.
+--
+-- STABLE, not IMMUTABLE: it reads current_setting and the membership tables.
+-- SECURITY INVOKER (the default) on purpose -- it must see exactly what the
+-- caller sees, and a definer function here would hand back rows the caller's
+-- own RLS denies.
+CREATE OR REPLACE FUNCTION kb_project_visible(p BIGINT) RETURNS boolean
+LANGUAGE sql STABLE AS $$
+  SELECT p IS NOT NULL AND EXISTS (
+    SELECT 1 FROM kb_project k
+     WHERE k.id = p
+       AND k.parent IN (SELECT team FROM kb_team_membership
+                        WHERE identity_key = current_setting('aimee.principal', true))
+       AND (current_setting('aimee.team', true) IS NULL
+            OR current_setting('aimee.team', true) = ''
+            OR k.parent = current_setting('aimee.team', true)::bigint)
+       AND (k.access_mode = 'team-open'
+            OR k.id IN (SELECT project FROM kb_project_membership
+                        WHERE identity_key = current_setting('aimee.principal', true))));
+$$;
+
 -- Admin-gated tenant WRITES (slice 4). Writes are permitted only when the current
 -- principal holds an active org-admin grant, OR is the bootstrap owner. The admin
 -- check keys on the principal's OWN grant row (own-rows policy on kb_admin_grant),

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -5274,6 +5274,16 @@ $(TESTPREFIX)/p7-vault-rewrap-live: $(OBJDIR)/tests/test_kb_vault_rewrap_live.o 
 # [C, SQL, C] kb_audit_event chain and asserts the C verifier accepts it + the SQL row
 # hashes byte-identically in C. Same KB object closure as unit-test-vault-pg (real libpq
 # via db_postgres.o + the kb db2 layer that carries kb_audit_worm.o/schema.sql).
+# Content-scope referent + predicate (slice 1). REAL-PG test: SKIPs cleanly
+# without AIMEE_TEST_PG_URL, because RLS and current_setting mean nothing on the
+# SQLite shim.
+$(TESTPREFIX)/unit-test-content-scope-pg: $(OBJDIR)/tests/test_content_scope_pg.o \
+                              $(filter-out $(OBJDIR)/kb/kb_main.o,$(KB_OBJS)) $(OBJDIR)/dashboard_kb.o \
+                              $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o \
+                              $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) \
+                              $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(TS_VENDOR_OBJS)
+	$(TESTLINK) -o $@ $^ $(L_KB)
+
 $(TESTPREFIX)/unit-test-kb-audit-worm-pg: $(OBJDIR)/tests/test_kb_audit_worm_pg.o \
                               $(filter-out $(OBJDIR)/kb/kb_main.o,$(KB_OBJS)) $(OBJDIR)/dashboard_kb.o \
                               $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o \
@@ -6911,6 +6921,7 @@ $(TESTPREFIX)/unit-test-config-set-section: $(OBJDIR)/tests/test_config_set_sect
 # cache from binaries that do not reference it.
 TEST_KB_RUNTIME_TARGETS = \
   $(TESTPREFIX)/unit-test-kb-audit-worm-pg \
+  $(TESTPREFIX)/unit-test-content-scope-pg \
   $(TESTPREFIX)/unit-test-kb-bedrock-live \
   $(TESTPREFIX)/unit-test-kb-p2b-egress-live \
   $(TESTPREFIX)/unit-test-kb-vault-key-use-live \

--- a/src/tests/test_content_scope_pg.c
+++ b/src/tests/test_content_scope_pg.c
@@ -1,0 +1,121 @@
+/* test_content_scope_pg.c: the content-scope referent and predicate (slice 1 of
+ * docs/proposals/pending/per-user-content-scope-visibility.md).
+ *
+ * Needs a live Postgres: RLS and current_setting have no meaning on the SQLite
+ * shim. Reads AIMEE_TEST_PG_URL and SKIPS CLEANLY (exit 0) when it is unset,
+ * mirroring test_vault_pg.c, so `make unit-tests` stays green without one.
+ *
+ * WHAT IS PINNED HERE, and why each would otherwise be silent:
+ *
+ *  1. `projects.kb_project` and `kb_project_visible()` exist after the schema is
+ *     applied. They are the referent every content policy will read.
+ *  2. The predicate DENIES an unattributed project (NULL) and denies with no
+ *     principal set. Deny is the direction the whole design rests on, and a
+ *     predicate that answered true here would open every content policy built on
+ *     it at once.
+ *  3. NOTHING is enforced yet: content is still readable. This slice must be
+ *     landable ahead of the backfill, and a policy arriving early would take an
+ *     existing deployment dark rather than merely fail a test.
+ *
+ * WHAT IS NOT HERE: whether a member sees their own project and a stranger does
+ * not. That needs the policies, which land with the backfill in slice 2. The
+ * end-to-end behaviour was prototyped in
+ * docs/validation/per-user-content-scope-prototype.md.
+ */
+#include "db2.h"
+#include "db2/db2_internal.h"
+#include "db2/db_postgres.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Single-value scalar query. Returns 0 and fills out on success. */
+static int scalar(const char *sql, char *out, size_t cap);
+
+/* assert that `sql` returns `want`, and say what came back when it does not. */
+static void expect(const char *sql, const char *want)
+{
+   char got[128] = "";
+   if (scalar(sql, got, sizeof(got)) != 0)
+   {
+      fprintf(stderr, "query failed: %s\n", sql);
+      assert(0);
+   }
+   if (strcmp(got, want) != 0)
+   {
+      fprintf(stderr, "expected \"%s\", got \"%s\"\n  sql: %s\n", want, got, sql);
+      assert(0);
+   }
+}
+
+static int scalar(const char *sql, char *out, size_t cap)
+{
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(db2_conn(), sql, err, sizeof(err));
+   if (!st)
+   {
+      fprintf(stderr, "prepare failed: %s\n  sql: %s\n", err, sql);
+      return -1;
+   }
+   int rc = -1;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *v = aimee_pg_column_text(st, 0);
+      snprintf(out, cap, "%s", v ? v : "");
+      rc = 0;
+   }
+   aimee_pg_finalize(st);
+   return rc;
+}
+
+int main(void)
+{
+   const char *url = getenv("AIMEE_TEST_PG_URL");
+   if (!url || !url[0])
+   {
+      printf("content_scope_pg: SKIP (AIMEE_TEST_PG_URL unset; real Postgres required)\n");
+      return 0;
+   }
+   if (db2_init(url) != 0)
+   {
+      fprintf(stderr, "content_scope_pg: db2_init failed for %s\n", url);
+      return 1;
+   }
+   printf("test_content_scope_pg\n");
+
+   /* 1. The referent exists. */
+   expect("SELECT count(*) FROM information_schema.columns"
+          " WHERE table_name='projects' AND column_name='kb_project'",
+          "1");
+   printf("  PASS: projects.kb_project exists\n");
+
+   expect("SELECT count(*) FROM pg_proc WHERE proname='kb_project_visible'", "1");
+   printf("  PASS: kb_project_visible exists\n");
+
+   /* 2. It denies what cannot be attributed, and denies with no principal.
+    *
+    *    Asked as an explicit CASE rather than a cast: boolean::text is
+    *    'true'/'false' while psql's tuple output shows 't'/'f', and a test that
+    *    depends on which spelling arrives is testing the driver. 'deny' and
+    *    'allow' are this test's own words, and NULL would arrive as "" and match
+    *    neither -- which matters, because NULL is not the same answer as false
+    *    and must never pass for one. */
+   expect("SELECT CASE WHEN kb_project_visible(NULL) THEN 'allow' ELSE 'deny' END", "deny");
+   printf("  PASS: an unattributed project is denied\n");
+
+   expect("SELECT CASE WHEN kb_project_visible(-1) THEN 'allow' ELSE 'deny' END", "deny");
+   printf("  PASS: an unknown project with no principal is denied\n");
+
+   /* 3. Nothing is enforced yet. If a policy lands before its backfill, this
+    *    fails here rather than in a deployment that has gone quiet. */
+   expect("SELECT count(*) FROM pg_policies"
+          " WHERE tablename IN ('kb_documents','kb_file_index')",
+          "0");
+   printf("  PASS: no content policy is enabled ahead of the backfill\n");
+
+   db2_shutdown();
+   printf("All tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
Slice 1 of the proposal in #2636, as amended by #2637 and prototyped in #2638.

**Additive, and enforces nothing.** `projects` gains a nullable `kb_project` reference; `kb_project_visible()` is defined; no policy reads either yet. That is the point — it lands ahead of the backfill without any chance of taking a deployment dark.

## Why one column

`kb_documents`, `kb_file_index`, `kb_embeddings` and `kb_pdf_embeddings` all carry `project`, holding `projects.name` (bound at ingest in `kb_payload.c`), and `projects.name` is globally `UNIQUE`. One link on `projects` therefore gives every content table a route to tenancy.

**And not by name.** `kb_project` is `UNIQUE(parent, name)` — two teams may each own a project called `aimee`, so a name identifies nothing. Resolving by name lets a member of one team read another's, reproduced in #2638. The schema comment says so at the point where someone would otherwise simplify the `EXISTS` into a name match.

The predicate is `p_project_member`'s rule said once, so content policies call it rather than each carrying a copy. `SECURITY INVOKER` on purpose: a definer function here would return rows the caller's own RLS denies.

## Memory is out of scope

Per the operator: global is global, untagged memories are global, and per-user memory is DB1's concern, not DB2 tenancy. The proposal's memory slice is **dropped, not deferred**.

## Verified on a real Postgres

PG 17, not only in CI. The schema applies clean and is **idempotent on re-apply** (the migrate step re-runs the file); column, function and index exist; the predicate denies `NULL` and denies with no principal; and content stays fully readable by a plain role — the property that makes this safe to land early.

`unit-test-content-scope-pg` skips cleanly without `AIMEE_TEST_PG_URL` and passes against a live one. It caught its own bug on the way: it compared `boolean::text` against `'f'`, which is psql's tuple display, where the cast yields `'false'`. It now asks for a `CASE` value of its own choosing and reports what it saw on failure.

Local: `unit-tests` rc=0, `lint` 56/56.

Next: slice 2 is the policies plus the backfill, which still needs the migration choice (backfill-then-enable, or enable with a dated escape).