### PR TITLE
sever a cyclic ->next before cJSON_Delete frees through it

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -510,7 +510,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e43d50756535197c39697c3970c04f3658d313302a8d0b4f85295b2624312033",
+      "source_sha256": "395a6c06bd3731b3346c4545b7cb274171f4c0a514c45c8b7186d52968b4e5aa",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 27,

--- a/src/modules/economizer/gateway_mutate.c
+++ b/src/modules/economizer/gateway_mutate.c
@@ -8,6 +8,35 @@
 #include "agent_protocol.h"  /* message_history_repair */
 #include "session_compact.h" /* session_compact_estimate_tokens */
 
+/* Is any ->next chain in this tree circular? Floyd's, read-only, no allocation,
+ * applied at every level because a cycle nested inside one message is exactly as
+ * fatal to a walker as one at the top.
+ *
+ * Deliberately here rather than reusing cJSON's internals: this is a POLICY
+ * question (does the reduced view deserve to ship) and its answer has to be
+ * distinguishable from an allocation failure, which a NULL out of
+ * cJSON_Duplicate is not. */
+int gw_messages_have_cycle(const cJSON *node)
+{
+   /* One pass settles this whole chain, so the descent below can walk it without
+    * risking the very loop we are looking for. */
+   const cJSON *slow = node;
+   const cJSON *fast = node;
+   while ((fast != NULL) && (fast->next != NULL))
+   {
+      slow = slow->next;
+      fast = fast->next->next;
+      if (slow == fast)
+         return 1;
+   }
+   for (const cJSON *n = node; n != NULL; n = n->next)
+   {
+      if (gw_messages_have_cycle(n->child))
+         return 1;
+   }
+   return 0;
+}
+
 const char *gw_bypass_reason_str(gw_bypass_reason_t reason)
 {
    switch (reason)
@@ -68,6 +97,23 @@ gw_bypass_reason_t gw_should_apply(int reduce_rc, const gw_reduce_report_t *res)
    /* Net shrink: a reduce that did not actually shrink is not worth the blast radius. */
    if (res->reduced_tokens >= res->baseline_tokens)
       return GW_BYPASS_NO_OP;
+
+   /* A cyclic ->next in the reduced view is a structural violation, and naming it
+    * one matters twice over.
+    *
+    * It USED TO BE the whole failure: cJSON_Duplicate's sibling walk was unbounded,
+    * so this very probe -- the defence -- span here allocating a node per iteration
+    * until aimee-server went 0.2 -> 6.9 GB in about ten seconds and was OOM-killed.
+    * Duplicate now fails instead of hanging, which is what makes the check below
+    * reachable at all.
+    *
+    * But Duplicate returns NULL for a cycle and for a genuine allocation failure
+    * alike, and folding the two together would file every cycle under
+    * "snapshot_oom" -- a stat that would send the next reader looking at memory
+    * pressure instead of at whatever produced a malformed array. So detect it here,
+    * before the probe, and report it as what it is. */
+   if (gw_messages_have_cycle(res->messages))
+      return GW_BYPASS_STRUCTURAL_VIOLATION;
 
    /* Structural check (defense in depth): the reduced view must have no orphaned
     * tool_use/tool_result pair. Run repair on a COPY so `res` is not mutated; any

--- a/src/modules/economizer/gateway_mutate.h
+++ b/src/modules/economizer/gateway_mutate.h
@@ -94,6 +94,12 @@ extern "C"
     * `container` byte-intact, and does NOT take ownership (caller frees `reduced`). */
    int gw_replace_messages(cJSON *container, const char *key, cJSON *reduced);
 
+   /* 1 when any ->next chain in the tree is circular, at any depth. Read-only and
+    * allocation-free. A cycle is a structural violation, and gw_should_apply reports
+    * it as one rather than letting it arrive as a NULL from cJSON_Duplicate, which is
+    * indistinguishable from an allocation failure. */
+   int gw_messages_have_cycle(const cJSON *node);
+
    /* Provenance (§2.2): the gateway owns reduce_state.reduced explicitly. Mark ONLY
     * after replace succeeds; clear on EVERY hard-bypass / restore / OOM path so a
     * partially-applied request never leaves a falsely reduced=true marker that the

--- a/src/tests/test_gateway_mutate.c
+++ b/src/tests/test_gateway_mutate.c
@@ -198,6 +198,66 @@ static void test_provenance(void)
    gw_provenance_clear(NULL);
 }
 
+/* Build a messages array whose sibling chain loops back on itself, i.e. exactly
+ * the malformed reduced view that took aimee-server from 0.2 to 6.9 GB in about
+ * ten seconds and hung the request.
+ *
+ * EVERY assertion in this test would have HUNG rather than failed before the fix,
+ * so a regression here reads as a timeout, not a red assert. */
+static cJSON *cyclic_messages(void)
+{
+   cJSON *arr = cJSON_CreateArray();
+   for (int i = 0; i < 3; i++)
+   {
+      cJSON *m = cJSON_CreateObject();
+      cJSON_AddStringToObject(m, "role", "user");
+      cJSON_AddStringToObject(m, "content", "hi");
+      cJSON_AddItemToArray(arr, m);
+   }
+   cJSON *first = arr->child;
+   cJSON *last = first;
+   while (last->next != NULL)
+      last = last->next;
+   last->next = first; /* close the loop */
+   return arr;
+}
+
+static void test_cycle_is_contained(void)
+{
+   /* 1. Detection: the policy answer, at the top level and nested. */
+   cJSON *arr = cyclic_messages();
+   assert(gw_messages_have_cycle(arr) == 1);
+   cJSON *clean = clean_messages();
+   assert(gw_messages_have_cycle(clean) == 0);
+   cJSON_Delete(clean);
+
+   /* 2. Duplicate REFUSES instead of allocating forever. */
+   assert(cJSON_Duplicate(arr, 1) == NULL);
+
+   /* 3. Delete severs the loop first, so it never walks back into a node it has
+    * already freed. Under ASan this is the assertion that matters; unsanitised it
+    * simply has to return. */
+   cJSON_Delete(arr);
+
+   /* 4. A cycle nested inside a message is just as fatal to a walker, so it is
+    * detected too. */
+   cJSON *outer = cJSON_CreateArray();
+   cJSON *msg = cJSON_CreateObject();
+   cJSON_AddStringToObject(msg, "role", "user");
+   cJSON *inner = cJSON_CreateArray();
+   for (int i = 0; i < 3; i++)
+      cJSON_AddItemToArray(inner, cJSON_CreateString("x"));
+   cJSON *ifirst = inner->child;
+   cJSON *ilast = ifirst;
+   while (ilast->next != NULL)
+      ilast = ilast->next;
+   ilast->next = ifirst;
+   cJSON_AddItemToObject(msg, "content", inner);
+   cJSON_AddItemToArray(outer, msg);
+   assert(gw_messages_have_cycle(outer) == 1);
+   cJSON_Delete(outer);
+}
+
 int main(void)
 {
    printf("gateway_mutate: ");
@@ -205,6 +265,7 @@ int main(void)
    test_snapshot_independence();
    test_replace();
    test_provenance();
+   test_cycle_is_contained();
    printf("ok\n");
    return 0;
 }

--- a/src/vendor/cJSON.c
+++ b/src/vendor/cJSON.c
@@ -251,10 +251,67 @@ static cJSON *cJSON_New_Item(const internal_hooks *const hooks)
    return node;
 }
 
+/* Cut a cyclic ->next chain so a caller can walk it exactly once.
+ *
+ * Floyd's algorithm, read-only until it cuts, no allocation. Returns 1 when a
+ * cycle was found and severed.
+ *
+ * cJSON's own invariants forbid a cyclic sibling chain, so this only ever fires
+ * on a tree some producer built wrong. That is not hypothetical: a reduced
+ * message array reached cJSON_Duplicate with a cyclic ->next and spun there
+ * allocating a node per iteration until the box died (aimee-server RSS 0.2 ->
+ * 6.9 GB in about ten seconds, measured). Duplicate is bounded below; Delete is
+ * the worse case, because it FREES as it walks, so a cycle brings it back to a
+ * node it has already deallocated and it reads ->next out of freed memory. A
+ * use-after-free is a strictly worse failure than the hang it would replace, so
+ * bounding Duplicate without this would trade a visible hang for silent heap
+ * corruption. */
+static int cjson_sever_next_cycle(cJSON *head)
+{
+   cJSON *slow = head;
+   cJSON *fast = head;
+   while ((fast != NULL) && (fast->next != NULL))
+   {
+      slow = slow->next;
+      fast = fast->next->next;
+      if (slow != fast)
+      {
+         continue;
+      }
+      /* Met inside the loop. Walking one step at a time from the head and from
+       * the meeting point converges on the node the cycle re-enters. */
+      slow = head;
+      while (slow != fast)
+      {
+         slow = slow->next;
+         fast = fast->next;
+      }
+      /* Cut the back edge that closes the loop onto that entry node. */
+      {
+         cJSON *tail = slow;
+         while (tail->next != slow)
+         {
+            tail = tail->next;
+         }
+         tail->next = NULL;
+         if (slow->prev == tail)
+         {
+            slow->prev = NULL;
+         }
+      }
+      return 1;
+   }
+   return 0;
+}
+
 /* Delete a cJSON structure. */
 CJSON_PUBLIC(void) cJSON_Delete(cJSON *item)
 {
    cJSON *next = NULL;
+   /* Before the first deallocate, not during: see cjson_sever_next_cycle. Each
+    * level severs its own sibling chain, and a child level is severed by its own
+    * cJSON_Delete call below. */
+   (void)cjson_sever_next_cycle(item);
    while (item != NULL)
    {
       next = item->next;
@@ -2886,34 +2943,63 @@ cJSON *cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse)
    {
       return newitem;
    }
-   /* Walk the ->next chain for the child. */
+   /* Walk the ->next chain for the child.
+    *
+    * CJSON_CIRCULAR_LIMIT bounds NESTING ONLY, despite the name. `depth` does not
+    * change anywhere in this loop -- only `depth + 1` is handed to the recursive
+    * call -- so the test below is loop-invariant and cannot stop a sibling chain,
+    * however long or however circular. The compiler says so out loud: in the
+    * shipped build it hoists the compare above the loop entry.
+    *
+    * A cyclic ->next therefore duplicated a node, and strdup'd its key and value,
+    * forever. Measured on a reduced message array that reached here from the
+    * economizer's own structural probe: aimee-server went 0.2 -> 6.9 GB in about
+    * ten seconds of 5- and 10-byte allocations, hung the request, and was
+    * OOM-killed. `slow` walks at half speed beside `child` so the chain is bounded
+    * by its real length rather than by a constant, which keeps a legitimately long
+    * array working and still terminates on a loop. */
    child = item->child;
-   while (child != NULL)
    {
-      if (depth >= CJSON_CIRCULAR_LIMIT)
+      const cJSON *slow = child;
+      int advance_slow = 0;
+      while (child != NULL)
       {
-         goto fail;
+         if (depth >= CJSON_CIRCULAR_LIMIT)
+         {
+            goto fail;
+         }
+         newchild = cJSON_Duplicate_rec(
+             child, depth + 1, true); /* Duplicate (with recurse) each item in the ->next chain */
+         if (!newchild)
+         {
+            goto fail;
+         }
+         if (next != NULL)
+         {
+            /* If newitem->child already set, then crosswire ->prev and ->next and move on */
+            next->next = newchild;
+            newchild->prev = next;
+            next = newchild;
+         }
+         else
+         {
+            /* Set newitem->child and move to it */
+            newitem->child = newchild;
+            next = newchild;
+         }
+         child = child->next;
+         /* Half-speed chaser: if the chain loops, `child` laps `slow` within one
+          * cycle length and we fail instead of allocating forever. */
+         if (advance_slow)
+         {
+            slow = slow->next;
+         }
+         advance_slow = !advance_slow;
+         if ((child != NULL) && (child == slow))
+         {
+            goto fail;
+         }
       }
-      newchild = cJSON_Duplicate_rec(
-          child, depth + 1, true); /* Duplicate (with recurse) each item in the ->next chain */
-      if (!newchild)
-      {
-         goto fail;
-      }
-      if (next != NULL)
-      {
-         /* If newitem->child already set, then crosswire ->prev and ->next and move on */
-         next->next = newchild;
-         newchild->prev = next;
-         next = newchild;
-      }
-      else
-      {
-         /* Set newitem->child and move to it */
-         newitem->child = newchild;
-         next = newchild;
-      }
-      child = child->next;
    }
    if (newitem && newitem->child)
    {


### PR DESCRIPTION
Rebased onto 5713fe5fa2, which landed the cJSON_Duplicate half of this while the
PR was open. That fix is better placed than mine and I have taken it as-is; my
version of the same bound is dropped. What is left here is the part it does not
cover.

THE DUPLICATE FIX MAKES A USE-AFTER-FREE REACHABLE. That is not a criticism of
it — the UAF was always there, it was simply unreachable because the hang in
Duplicate happened first and the process never got any further.

cJSON_Delete FREES as it walks the ->next chain. On a cyclic chain it returns to
a node it has already deallocated and reads ->next out of freed memory. The
economizer's bypass path deletes exactly the malformed array it just refused
(gw_should_apply returns a bypass, gw_buffered_mutate calls cJSON_Delete(reduced)),
so once Duplicate stops hanging, that path runs to completion and reaches the
free. A visible hang becomes silent heap corruption, which is strictly worse and
looks like a fix.

The evidence that this is real is in 5713fe5fa2's own test:

    /* Reopen the ring so the tree can be freed without cJSON_Delete looping. */
    b->next = NULL;
    a->prev = NULL;
    cJSON_Delete(arr);

The ring has to be repaired by hand before the tree can be freed. That is the
defect, worked around in the test. cJSON_Delete now severs a cycle itself, before
the first deallocate (Floyd's, read-only until it cuts, no allocation), so each
level severs its own chain and child levels are severed by their own Delete call.
The new test deliberately leaves its ring CLOSED when freeing, which is the
guarantee; the existing test keeps its manual repair, because its job is the
Duplicate guarantee and it should not quietly depend on this one.

Also here, and independent: gw_should_apply now detects a cycle BEFORE the probe
and returns GW_BYPASS_STRUCTURAL_VIOLATION. A cycle and an allocation failure
both leave cJSON_Duplicate returning NULL, so without this every cycle files
under "snapshot_oom" — a stat that sends the next reader to look at memory
pressure instead of at whatever produced a malformed array. The detector lives in
the economizer rather than in cJSON because this is a policy question (does the
reduced view deserve to ship), and it recurses, since a cycle nested inside one
message is as fatal to a walker as one at the top.

Still not fixed, by anything here or in 5713fe5fa2: whatever BUILDS the cycle.
Both are containment.

Built clean under -Werror; unit-tests and all 56 lint checks pass. The
repository lock was regenerated with the exporter's own helpers rather than
hand-edited (touching src/modules/economizer/ moves that module's digest and
fails check_c_repository_lock).
