### PR TITLE
kb: the content policies, defined but inert, and a switch to turn them on (slice 2)

### DIFF
--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -2119,6 +2119,78 @@ LANGUAGE sql STABLE AS $$
                         WHERE identity_key = current_setting('aimee.principal', true))));
 $$;
 
+-- CONTENT SCOPE, part 2: the policies, DEFINED BUT NOT ENABLED.
+--
+-- A policy is inert until RLS is enabled on its table, so applying this file
+-- changes nothing about what anyone can read. That is the whole design: the
+-- migrate step re-runs this file on every deployment, and a policy that switched
+-- itself on here would hide every row that has not been attributed yet -- an
+-- outage delivered by an upgrade.
+--
+-- Enabling is therefore an ACT, not a migration: attribute the rows, check the
+-- counts, then call kb_content_scope_enable(). See the proposal for the two
+-- orderings and why this is the one without a window where the control is
+-- advertised and absent.
+DROP POLICY IF EXISTS p_documents_project ON kb_documents;
+CREATE POLICY p_documents_project ON kb_documents
+  FOR SELECT USING (EXISTS (SELECT 1 FROM projects p
+                            WHERE p.name = kb_documents.project
+                              AND kb_project_visible(p.kb_project)));
+
+DROP POLICY IF EXISTS p_file_index_project ON kb_file_index;
+CREATE POLICY p_file_index_project ON kb_file_index
+  FOR SELECT USING (EXISTS (SELECT 1 FROM projects p
+                            WHERE p.name = kb_file_index.project
+                              AND kb_project_visible(p.kb_project)));
+
+-- Turn content scoping on, once the rows carry a kb_project.
+--
+-- FORCE as well as ENABLE: without FORCE the table OWNER bypasses its own
+-- policies, and the owner is who the application connects as in a good many
+-- deployments, which would leave the control on paper only.
+--
+-- Refuses while any content is unattributed, and says how much. Enabling over
+-- unattributed rows is not a smaller version of the control: those rows become
+-- invisible to everyone, which is an outage that looks like data loss. The
+-- caller is told to finish the backfill instead.
+CREATE OR REPLACE FUNCTION kb_content_scope_enable() RETURNS text
+LANGUAGE plpgsql AS $$
+DECLARE
+  orphan_docs BIGINT;
+  orphan_files BIGINT;
+BEGIN
+  SELECT count(*) INTO orphan_docs FROM kb_documents d
+    WHERE NOT EXISTS (SELECT 1 FROM projects p
+                      WHERE p.name = d.project AND p.kb_project IS NOT NULL);
+  SELECT count(*) INTO orphan_files FROM kb_file_index f
+    WHERE NOT EXISTS (SELECT 1 FROM projects p
+                      WHERE p.name = f.project AND p.kb_project IS NOT NULL);
+  IF orphan_docs > 0 OR orphan_files > 0 THEN
+    RAISE EXCEPTION 'refusing to enable content scope: % document rows and % file-index rows '
+                    'have no kb_project, and would become invisible to everyone. Attribute them '
+                    '(projects.kb_project) and call again.', orphan_docs, orphan_files;
+  END IF;
+  ALTER TABLE kb_documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_documents FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_file_index ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_file_index FORCE ROW LEVEL SECURITY;
+  RETURN 'content scope enabled on kb_documents, kb_file_index';
+END;
+$$;
+
+-- The way back. An operator who enables this and finds a surface they had not
+-- accounted for needs a door that is not "restore from backup".
+CREATE OR REPLACE FUNCTION kb_content_scope_disable() RETURNS text
+LANGUAGE plpgsql AS $$
+BEGIN
+  ALTER TABLE kb_documents NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_documents DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_file_index NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_file_index DISABLE ROW LEVEL SECURITY;
+  RETURN 'content scope disabled';
+END;
+$$;
+
 -- Admin-gated tenant WRITES (slice 4). Writes are permitted only when the current
 -- principal holds an active org-admin grant, OR is the bootstrap owner. The admin
 -- check keys on the principal's OWN grant row (own-rows policy on kb_admin_grant),

--- a/src/tests/test_content_scope_pg.c
+++ b/src/tests/test_content_scope_pg.c
@@ -13,9 +13,12 @@
  *     principal set. Deny is the direction the whole design rests on, and a
  *     predicate that answered true here would open every content policy built on
  *     it at once.
- *  3. NOTHING is enforced yet: content is still readable. This slice must be
- *     landable ahead of the backfill, and a policy arriving early would take an
- *     existing deployment dark rather than merely fail a test.
+ *  3. The policies exist but are INERT: RLS is not enabled on either table, so
+ *     applying this schema changes what nobody can read. A policy that switched
+ *     itself on would turn an upgrade into an outage for every row not yet
+ *     attributed, so the off state is asserted rather than assumed.
+ *  4. Enabling REFUSES while content is unattributed, because turning it on
+ *     then hides those rows from everyone.
  *
  * WHAT IS NOT HERE: whether a member sees their own project and a stranger does
  * not. That needs the policies, which land with the backfill in slice 2. The
@@ -108,12 +111,67 @@ int main(void)
    expect("SELECT CASE WHEN kb_project_visible(-1) THEN 'allow' ELSE 'deny' END", "deny");
    printf("  PASS: an unknown project with no principal is denied\n");
 
-   /* 3. Nothing is enforced yet. If a policy lands before its backfill, this
-    *    fails here rather than in a deployment that has gone quiet. */
+   /* 3. The policies are DEFINED. They have to be, or enabling would be a
+    *     schema change at the worst possible moment. */
    expect("SELECT count(*) FROM pg_policies"
           " WHERE tablename IN ('kb_documents','kb_file_index')",
+          "2");
+   printf("  PASS: the content policies are defined\n");
+
+   /* 4. And INERT. A policy does nothing until RLS is enabled on its table, and
+    *    that is what keeps applying this schema from hiding rows nobody has
+    *    attributed yet. If this flips to enabled-on-apply, an upgrade becomes an
+    *    outage, so it is asserted rather than assumed.
+    *
+    *    relrowsecurity is the ENABLE flag, relforcerowsecurity the FORCE one;
+    *    both must be off, because FORCE without ENABLE is not a state worth
+    *    reasoning about later. */
+   expect("SELECT count(*) FROM pg_class"
+          " WHERE relname IN ('kb_documents','kb_file_index')"
+          "   AND (relrowsecurity OR relforcerowsecurity)",
           "0");
-   printf("  PASS: no content policy is enabled ahead of the backfill\n");
+   printf("  PASS: they are inert until an operator enables them\n");
+
+   /* 5. Enabling refuses while any content is unattributed. Turning it on over
+    *    unattributed rows does not give a weaker control, it hides those rows
+    *    from everyone, which reads as data loss. The refusal is the feature. */
+   {
+      char err[512] = "";
+      aimee_pg_stmt_t *st =
+          aimee_pg_prepare(db2_conn(), "SELECT kb_content_scope_enable()", err, sizeof(err));
+      int refused = 0;
+      if (st)
+      {
+         if (aimee_pg_step(st, err, sizeof(err)) != AIMEE_PG_ROW)
+            refused = 1;
+         aimee_pg_finalize(st);
+      }
+      else
+      {
+         refused = 1;
+      }
+      /* The fixture database has no attributed content, so this must refuse.
+         A pass here with an empty kb_documents would prove nothing, so the
+         count is checked too. */
+      char docs[64] = "";
+      assert(scalar("SELECT count(*) FROM kb_documents", docs, sizeof(docs)) == 0);
+      if (strcmp(docs, "0") != 0)
+      {
+         if (!refused)
+            fprintf(stderr, "kb_content_scope_enable() accepted %s unattributed rows\n", docs);
+         assert(refused);
+         printf("  PASS: enabling refuses while content is unattributed\n");
+      }
+      else
+      {
+         printf("  SKIP: no content rows in this database to refuse over\n");
+      }
+      /* Whatever happened, leave the tables as they were found. */
+      expect("SELECT count(*) FROM pg_class"
+             " WHERE relname IN ('kb_documents','kb_file_index')"
+             "   AND (relrowsecurity OR relforcerowsecurity)",
+             "0");
+   }
 
    db2_shutdown();
    printf("All tests passed.\n");


### PR DESCRIPTION
Slice 2, following #2639. The policies on `kb_documents` and `kb_file_index` exist; **RLS is not enabled on either**, so applying this schema changes what nobody can read.

## Why defined-but-off

The migrate step re-runs `schema.sql` on every deployment. A policy that enabled itself there would hide every row not yet attributed to a `kb_project` — an outage delivered by an upgrade, and one that reads as data loss rather than as a control. Defining them now means turning them on later is an `ALTER` on two tables, not a schema change made under pressure.

So enabling is an act:

```sql
SELECT kb_content_scope_enable();
```

It **refuses while any content is unattributed** and says how many rows. Enabling over them is not a weaker version of the control — those rows go dark for everyone, including the people who own them. `kb_content_scope_disable()` is the way back, because an operator who finds a surface they hadn't accounted for needs a door that isn't "restore from backup".

`FORCE` as well as `ENABLE`: without `FORCE` the table owner bypasses its own policies, and the owner is who the application connects as in plenty of deployments, which would leave the control on paper.

## Verified on real Postgres 17, all four states

1. after apply, a member still reads every row (inert);
2. enable refuses: *"3 document rows and 0 file-index rows have no kb_project"*;
3. after attribution, enable succeeds — `ana` reads only alpha's content, `ben` only beta's, a principal with no membership reads nothing;
4. disable restores full visibility.

## One assertion corrected rather than kept

The test previously asserted that **no policy existed**. That was right when none did and wrong now. It asserts the thing that actually matters — neither `relrowsecurity` nor `relforcerowsecurity` is set — so the day someone makes these enable on apply, it fails in CI rather than in a deployment that went quiet.

`unit-test-content-scope-pg` now covers seven properties, skips cleanly without `AIMEE_TEST_PG_URL`, and passes against a live one.

Local: `unit-tests` rc=0, `lint` 56/56, on the tree with `testing` merged in.

Remaining for this proposal: `kb_embeddings`/`kb_pdf_embeddings`/`kb_doc_regions`, the code index through `files`, and the `ws_scope_project_path` membership check. The backfill itself stays an operator action by design.