### PR TITLE
fix: retain project scope across re-embed writes

### DIFF
--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -960,7 +960,11 @@ int kb_doc_embed_backfill(const char *project, const char *embedding_cmd, int ma
       float vec[EMBED_MAX_DIM];
       int dim =
           memory_embed_text(embed_text, effective_cmd, EMBED_INPUT_DOCUMENT, vec, EMBED_MAX_DIM);
-      if (dim > 0 && sync_vector_embedding(rows[i].id, vec, dim) == 0)
+      /* Payload reconstruction reads kb_documents, so it needs a fresh short
+       * project scope after the embedder round-trip. The fenced helper opens
+       * that transaction, reapplies the current maintenance context, and keeps
+       * the purge generation check atomic with the vector write. */
+      if (dim > 0 && kb_sync_vector_embedding_fenced(project, rows[i].id, vec, dim) == 0)
          embedded++;
       free(rows[i].content);
    }

--- a/src/tests/test_content_scope_pg.c
+++ b/src/tests/test_content_scope_pg.c
@@ -23,6 +23,8 @@
  *  5. Tenant and maintenance scopes do not outlive their transactions. Their
  *     GUCs live on a POOLED connection, so a leak there is one tenant reading another's rows
  *     rather than merely a stale value.
+ *  6. The re-embed worker completes its post-embed payload read and vector write
+ *     under a fresh exact-project scope, without crossing into a sibling project.
  *
  * WHAT IS NOT HERE: whether a member sees their own project and a stranger does
  * not. That is an end-to-end reader check rather than this DB boundary check.
@@ -383,7 +385,7 @@ int main(void)
       assert(db2_maintenance_scope_begin_current() == 0);
       db2_maintenance_job_leave();
 
-      /* Seed one unembedded chunk while the policies are still inert. The
+      /* Seed selected and sibling unembedded chunks while the policies are inert. The
        * backfill discovers it under one maintenance transaction, drops the DB
        * lease for the embedder round-trip, then must open a fresh scope to
        * rebuild its payload from kb_documents and write kb_embeddings. */
@@ -394,6 +396,13 @@ int main(void)
       assert(exec_sql("DELETE FROM kb_documents"
                       " WHERE project='scope-maintenance-a'"
                       " AND file_path='scope-maintenance-reembed.md'") == 0);
+      assert(exec_sql("DELETE FROM kb_embeddings WHERE point_id IN ("
+                      "SELECT id FROM kb_documents"
+                      " WHERE project='scope-maintenance-b'"
+                      " AND file_path='scope-maintenance-sibling.md')") == 0);
+      assert(exec_sql("DELETE FROM kb_documents"
+                      " WHERE project='scope-maintenance-b'"
+                      " AND file_path='scope-maintenance-sibling.md'") == 0);
       char reembed_doc[64] = "";
       assert(scalar("INSERT INTO kb_documents"
                     " (project,generation,file_path,file_hash,chunk_index,heading_path,"
@@ -403,6 +412,15 @@ int main(void)
                     "  'project scoped re-embedding proof',5"
                     " FROM projects WHERE name='scope-maintenance-a' RETURNING id",
                     reembed_doc, sizeof(reembed_doc)) == 0);
+      char sibling_doc[64] = "";
+      assert(scalar("INSERT INTO kb_documents"
+                    " (project,generation,file_path,file_hash,chunk_index,heading_path,"
+                    "  line_start,line_end,content,token_count)"
+                    " SELECT name,current_generation,'scope-maintenance-sibling.md',"
+                    "  'sibling-hash',0,'Sibling scope',1,1,"
+                    "  'must remain outside the selected project',6"
+                    " FROM projects WHERE name='scope-maintenance-b' RETURNING id",
+                    sibling_doc, sizeof(sibling_doc)) == 0);
 
       assert(exec_sql("ALTER TABLE kb_documents ENABLE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_documents FORCE ROW LEVEL SECURITY") == 0);
@@ -416,13 +434,21 @@ int main(void)
 
       assert(db2_maintenance_job_enter(DB2_MAINTENANCE_REEMBED, "scope-maintenance-a") == 0);
       assert(kb_doc_embed_backfill("scope-maintenance-a", MEMORY_EMBED_TEST_FIXTURE, 1) == 1);
-      db2_maintenance_job_leave();
+      assert(db2_maintenance_scope_begin_current() == 1);
       snprintf(sql, sizeof(sql),
-               "SELECT count(*) FROM kb_embeddings"
-               " WHERE point_id=%s AND project='scope-maintenance-a'",
-               reembed_doc);
-      expect(sql, "1");
+               "SELECT CASE WHEN e.project='scope-maintenance-a' AND p.kb_project=%s"
+               " THEN 'bound' ELSE 'wrong' END"
+               " FROM kb_embeddings e JOIN kb_documents d ON d.id=e.point_id"
+               " JOIN projects p ON p.name=d.project WHERE e.point_id=%s",
+               project_a, reembed_doc);
+      expect(sql, "bound");
+      assert(db2_maintenance_scope_commit() == 0);
+      snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_embeddings WHERE point_id=%s",
+               sibling_doc);
+      expect(sql, "0");
+      db2_maintenance_job_leave();
       printf("  PASS: re-embed reapplies exact-project scope after the embedder round-trip\n");
+      printf("  PASS: re-embed cannot cross into an unselected sibling chunk\n");
 
       assert(exec_sql("ALTER TABLE kb_documents NO FORCE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_documents DISABLE ROW LEVEL SECURITY") == 0);

--- a/src/tests/test_content_scope_pg.c
+++ b/src/tests/test_content_scope_pg.c
@@ -24,16 +24,17 @@
  *     GUCs live on a POOLED connection, so a leak there is one tenant reading another's rows
  *     rather than merely a stale value.
  *
- * WHAT IS NOT HERE: the full worker wiring or whether a member sees their own
- * project and a stranger does not. Those are end-to-end checks rather than this
- * DB boundary check.
+ * WHAT IS NOT HERE: whether a member sees their own project and a stranger does
+ * not. That is an end-to-end reader check rather than this DB boundary check.
  */
 #include "db2.h"
 #include "db2/db2_internal.h"
 #include "db2/db_postgres.h"
 #include "db2/db2_tenant.h"
 #include "db2/project.h"
+#include "kb.h"
 #include "kb_identity.h"
+#include "memory.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -381,6 +382,28 @@ int main(void)
       assert(db2_maintenance_job_enter(DB2_MAINTENANCE_CURATOR, "scope-maintenance-a") == 0);
       assert(db2_maintenance_scope_begin_current() == 0);
       db2_maintenance_job_leave();
+
+      /* Seed one unembedded chunk while the policies are still inert. The
+       * backfill discovers it under one maintenance transaction, drops the DB
+       * lease for the embedder round-trip, then must open a fresh scope to
+       * rebuild its payload from kb_documents and write kb_embeddings. */
+      assert(exec_sql("DELETE FROM kb_embeddings WHERE point_id IN ("
+                      "SELECT id FROM kb_documents"
+                      " WHERE project='scope-maintenance-a'"
+                      " AND file_path='scope-maintenance-reembed.md')") == 0);
+      assert(exec_sql("DELETE FROM kb_documents"
+                      " WHERE project='scope-maintenance-a'"
+                      " AND file_path='scope-maintenance-reembed.md'") == 0);
+      char reembed_doc[64] = "";
+      assert(scalar("INSERT INTO kb_documents"
+                    " (project,generation,file_path,file_hash,chunk_index,heading_path,"
+                    "  line_start,line_end,content,token_count)"
+                    " SELECT name,current_generation,'scope-maintenance-reembed.md',"
+                    "  'scope-hash',0,'Background scope',1,1,"
+                    "  'project scoped re-embedding proof',5"
+                    " FROM projects WHERE name='scope-maintenance-a' RETURNING id",
+                    reembed_doc, sizeof(reembed_doc)) == 0);
+
       assert(exec_sql("ALTER TABLE kb_documents ENABLE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_documents FORCE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_file_index ENABLE ROW LEVEL SECURITY") == 0);
@@ -390,6 +413,17 @@ int main(void)
       expect("SELECT current_setting('aimee.maintenance_project',true)", "scope-maintenance-a");
       assert(db2_maintenance_scope_commit() == 0);
       db2_maintenance_job_leave();
+
+      assert(db2_maintenance_job_enter(DB2_MAINTENANCE_REEMBED, "scope-maintenance-a") == 0);
+      assert(kb_doc_embed_backfill("scope-maintenance-a", MEMORY_EMBED_TEST_FIXTURE, 1) == 1);
+      db2_maintenance_job_leave();
+      snprintf(sql, sizeof(sql),
+               "SELECT count(*) FROM kb_embeddings"
+               " WHERE point_id=%s AND project='scope-maintenance-a'",
+               reembed_doc);
+      expect(sql, "1");
+      printf("  PASS: re-embed reapplies exact-project scope after the embedder round-trip\n");
+
       assert(exec_sql("ALTER TABLE kb_documents NO FORCE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_documents DISABLE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_file_index NO FORCE ROW LEVEL SECURITY") == 0);


### PR DESCRIPTION
## What changed

- routes background re-embed vector writes through the existing project-fenced transaction helper
- reapplies the current named maintenance context after the embedder round-trip
- keeps payload reconstruction and vector upsert under the exact attributed KB project and purge-generation guard
- adds a live-PostgreSQL regression that enables forced content RLS and exercises the complete backfill path

## Why

PR #2658 collected re-embed candidates under maintenance scope, released that scope for the external embedder call, then rebuilt the vector payload from `kb_documents` without opening a new scope. Once content RLS is enabled, that payload read is invisible and backfill cannot complete.

Found by the required post-implementation roundtable immediately after #2658 merged.

## Validation

- `make -s -C src lint` (all 56 checks)
- `make -s -C src build/obj/tests/unit-test-content-scope-pg build/obj/tests/unit-test-kb build/obj/tests/unit-test-curator-queue`
- `unit-test-kb` and `unit-test-curator-queue` pass
- `unit-test-content-scope-pg` compiles and skips locally without `AIMEE_TEST_PG_URL`; CI runs it against pgvector/PostgreSQL