### PR TITLE
Reject the C-only direct dataset benchmark track

### DIFF
--- a/docs/proposals/rejected/dataset-benchmark-direct-track.md
+++ b/docs/proposals/rejected/dataset-benchmark-direct-track.md
@@ -1,9 +1,25 @@
 # Proposal: restore a dataset benchmark track (LoCoMo / LongMemEval)
 
-- **State:** PENDING — tech debt. The direct track was deleted rather than
-  repaired; this records what it did, why it went, and what restoring it costs.
-  Not urgent: the per-PR regression gate that exercises these datasets is
-  unaffected and still runs.
+- **State:** REJECTED — archived 2026-08-14 under the Go-or-rejected policy.
+
+## Decision
+
+This proposal is rejected under the current implementation policy: pending proposal work must be
+implemented in Go or moved to `rejected/`. The recorded restoration path is a C benchmark-module
+entry point in `aimee-kb`, backed by C DB2/pgvector code and the rejected C/SQL scratch-store
+design. The synchronous `memory.benchmark` service explicitly returns an async-only envelope for
+LoCoMo and LongMemEval rather than hosting those suites.
+
+Porting the benchmark engine and its scratch-store ownership to Go would be a new architecture, not
+completion of this direct-track proposal. It would also duplicate the existing benchmark and DB2
+owners. This rejection does not remove working coverage: the per-PR LLM regression track, live
+retrieval suites, and poison gate remain unaffected as recorded below.
+
+## Archived technical record
+
+The direct track was deleted rather than repaired; this records what it did, why it went, and what
+restoring it costs. It was not urgent because the per-PR regression gate that exercises these
+datasets remained unaffected.
 
 ## Why this exists
 

--- a/docs/proposals/rejected/eval-temp-store-schema-relocation.md
+++ b/docs/proposals/rejected/eval-temp-store-schema-relocation.md
@@ -11,8 +11,8 @@ scratch-store APIs and callers. Reimplementing that internal DB2/benchmark bound
 create a second storage owner rather than complete this proposal.
 
 This is a scope and ownership rejection, not a claim that the shadow-schema conflict is fixed. The
-[dataset-driven direct benchmark](../pending/dataset-benchmark-direct-track.md) remains blocked
-unless it adopts a new Go-owned design that avoids the C scratch store. The live
+related [dataset-driven direct benchmark](dataset-benchmark-direct-track.md) was also rejected;
+reviving it would require a new Go-owned design that avoids the C scratch store. The live
 `memory.benchmark` path and shipping benchmark gates remain unaffected, as recorded below.
 
 ## Archived technical record


### PR DESCRIPTION
## Summary

- move the deleted direct LoCoMo/LongMemEval benchmark-track proposal from pending to rejected
- record why its C benchmark/DB2 restoration path cannot be completed as a Go implementation
- update the rejected scratch-store record with the reciprocal lifecycle link

## Why

The proposal's recorded restoration path is a C benchmark-module entry point in `aimee-kb`, backed by C DB2/pgvector code and the already rejected C/SQL scratch-store design. The synchronous `memory.benchmark` service explicitly returns an async-only envelope for these suites. Porting those owners to Go would be a new architecture and duplicate ownership, not completion of the proposal, so the Go-or-rejected policy requires rejection.

Existing per-PR LLM regression coverage, live retrieval suites, and the poison gate remain unchanged.

## Validation

- `make -s -C src lint` — all 56 checks passed
- `python3 scripts/check-proposal-links.py`
- `python3 scripts/check-proposal-reconcile.py`
- `git diff --cached --check`
- Aimee roundtable review — approved, 3/3 participants, not degraded
