### PR TITLE
economizer: the module owns the gateway breaker

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -513,7 +513,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "d7ded8d9d1adad4fb6675a93a46a16315742135c340f66d1ab58f193d88e0909",
+      "source_sha256": "80f2025935926c57a237d8df2688ee56c8c9e2b6eb1477e79cd0cc7661f7a715",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 27,
@@ -522,7 +522,8 @@
         11010,
         11011,
         11012,
-        11013
+        11013,
+        11014
       ]
     }
   ]

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -513,7 +513,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "PENDING",
+      "source_sha256": "cc0914a4db8fcef1f481339ef6fc7207e036a06d24750db780f3a91f83e9504c",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 27,

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -260,6 +260,7 @@ func moduleConfigRuntime(ctx context.Context, executable, moduleBusSocket string
 			{EventKind: economizer.EventToolRecall, StageID: economizer.StageToolRecall},
 			{EventKind: economizer.EventToolStats, StageID: economizer.StageToolStats},
 			{EventKind: economizer.EventRecordBuild, StageID: economizer.StageRecordBuild},
+			{EventKind: economizer.EventPostStatus, StageID: economizer.StagePostStatus},
 		}
 		// Stateless: per-conversation reducer state travels with each request, so
 		// there is no store to open and no failure mode before serving.

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -31,7 +31,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"control-web", 24, []uint32{10241}},
 		{"benchmarks", 25, []uint32{10497, 10498}},
 		{"sandbox", 26, []uint32{10753, 10754, 10755, 10756}},
-		{"economizer", 27, []uint32{11009, 11010, 11011, 11012, 11013}},
+		{"economizer", 27, []uint32{11009, 11010, 11011, 11012, 11013, 11014}},
 	}
 	for _, test := range tests {
 		config, ok := moduleConfig("/usr/local/libexec/aimee-modules/aimee-module-" + test.name)

--- a/server-go/modules/economizer/breaker.go
+++ b/server-go/modules/economizer/breaker.go
@@ -1,0 +1,148 @@
+package economizer
+
+import (
+	"sync"
+	"time"
+)
+
+// The gateway's per-session circuit breaker.
+//
+// This is the economizer's OWN state: "I have switched my reduction lever off
+// for this session, until this moment." It is not the caller's session state and
+// carries nothing about the caller beyond the opaque key it was handed — no
+// history, no correlation between turns, no idempotency on anyone's behalf. The
+// module may hold it precisely because it is the module's own business.
+//
+// Volatile by design, exactly as the C table it replaces was. A breaker that
+// forgets on restart fails OPEN: reduction resumes and, if the payload is still
+// bad, the next rejection trips it again within one turn. Persisting it would
+// mean a restart could not clear a stuck breaker, which is the worse failure.
+
+const (
+	// breakerCap bounds the table. The C used 10000 with a 16384-slot open
+	// addressing table; a Go map needs no load factor, so only the cap carries
+	// over. Reaching it means thousands of sessions are concurrently disabled —
+	// the catastrophic incident the breaker exists for — and the bound is what
+	// keeps that from also becoming a memory problem.
+	breakerCap = 10000
+	// breakerSweepAbove is the fill level past which an insert sweeps expired
+	// entries first, so a LIVE disable is never evicted while a dead one remains.
+	breakerSweepAbove = breakerCap / 2
+)
+
+type breakerEntry struct {
+	expires time.Time
+	seq     uint64
+	reason  string
+}
+
+// SessionBreaker is safe for concurrent use.
+type SessionBreaker struct {
+	mu      sync.Mutex
+	entries map[string]breakerEntry
+	seq     uint64
+}
+
+func NewSessionBreaker() *SessionBreaker {
+	return &SessionBreaker{entries: make(map[string]breakerEntry)}
+}
+
+// IsDisabled reports whether the lever is currently off for key.
+//
+// Expiry is lazy: an entry found past its deadline is dropped here rather than
+// waiting for a sweep, so the common lookup path also does the cleanup.
+func (b *SessionBreaker) IsDisabled(key string) bool {
+	if b == nil || key == "" {
+		return false
+	}
+	now := time.Now()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	e, ok := b.entries[key]
+	if !ok {
+		return false
+	}
+	if e.expires.After(now) {
+		return true
+	}
+	delete(b.entries, key)
+	return false
+}
+
+// Disable trips the breaker for ttlMS milliseconds.
+//
+// A non-positive TTL is rejected rather than treated as "forever": it would
+// otherwise mean a misconfigured zero silently disables the lever permanently.
+// Re-disabling a live session refreshes both the window and the reason, so the
+// breaker reports why it is CURRENTLY off, not why it first tripped.
+func (b *SessionBreaker) Disable(key string, ttlMS int, reason string) {
+	if b == nil || key == "" || ttlMS <= 0 {
+		return
+	}
+	if reason == "" {
+		reason = "unknown"
+	}
+	now := time.Now()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.entries == nil {
+		b.entries = make(map[string]breakerEntry)
+	}
+	if e, ok := b.entries[key]; ok {
+		e.expires = now.Add(time.Duration(ttlMS) * time.Millisecond)
+		e.reason = reason
+		b.entries[key] = e
+		return
+	}
+	if len(b.entries) > breakerSweepAbove {
+		b.sweepLocked(now)
+	}
+	if len(b.entries) >= breakerCap {
+		b.evictOldestLocked()
+	}
+	b.seq++
+	b.entries[key] = breakerEntry{
+		expires: now.Add(time.Duration(ttlMS) * time.Millisecond),
+		seq:     b.seq,
+		reason:  reason,
+	}
+}
+
+// Reason returns why the lever is off for key, empty when it is not.
+func (b *SessionBreaker) Reason(key string) string {
+	if b == nil || key == "" {
+		return ""
+	}
+	now := time.Now()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if e, ok := b.entries[key]; ok && e.expires.After(now) {
+		return e.reason
+	}
+	return ""
+}
+
+func (b *SessionBreaker) sweepLocked(now time.Time) {
+	for k, e := range b.entries {
+		if !e.expires.After(now) {
+			delete(b.entries, k)
+		}
+	}
+}
+
+// evictOldestLocked drops the entry disabled longest ago. Callers sweep first,
+// so this only ever runs when the table is full of LIVE disables and something
+// has to go; oldest-first means the survivor set is the most recent trouble.
+func (b *SessionBreaker) evictOldestLocked() {
+	var oldestKey string
+	var oldestSeq uint64
+	first := true
+	for k, e := range b.entries {
+		if first || e.seq < oldestSeq {
+			oldestKey, oldestSeq, first = k, e.seq, false
+		}
+	}
+	if !first {
+		delete(b.entries, oldestKey)
+	}
+}

--- a/server-go/modules/economizer/breaker_test.go
+++ b/server-go/modules/economizer/breaker_test.go
@@ -1,0 +1,200 @@
+package economizer
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func TestBreakerTripsAndExpires(t *testing.T) {
+	b := NewSessionBreaker()
+	if b.IsDisabled("k") {
+		t.Fatal("a fresh breaker disables nothing")
+	}
+	b.Disable("k", 60_000, "4xx")
+	if !b.IsDisabled("k") {
+		t.Error("a tripped session should read as disabled")
+	}
+	if b.Reason("k") != "4xx" {
+		t.Errorf("reason = %q, want 4xx", b.Reason("k"))
+	}
+	if b.IsDisabled("other") {
+		t.Error("tripping one session must not disable another")
+	}
+
+	// An elapsed window reads as enabled again, and the entry is dropped.
+	b.Disable("short", 1, "5xx")
+	time.Sleep(5 * time.Millisecond)
+	if b.IsDisabled("short") {
+		t.Error("an expired disable should have lapsed")
+	}
+}
+
+func TestBreakerRejectsWhatCannotBeATrip(t *testing.T) {
+	b := NewSessionBreaker()
+	// A non-positive TTL would otherwise mean "disabled forever" — a
+	// misconfigured zero must not silently switch the lever off permanently.
+	b.Disable("k", 0, "4xx")
+	b.Disable("k", -1, "4xx")
+	if b.IsDisabled("k") {
+		t.Error("a non-positive TTL must not disable")
+	}
+	// No key means no lever; disabling must not become a global switch.
+	b.Disable("", 60_000, "4xx")
+	if b.IsDisabled("") {
+		t.Error("the empty key must never read as disabled")
+	}
+}
+
+func TestBreakerRedisableRefreshesTheReason(t *testing.T) {
+	b := NewSessionBreaker()
+	b.Disable("k", 60_000, "4xx")
+	b.Disable("k", 60_000, "5xx")
+	// The breaker reports why it is CURRENTLY off, not why it first tripped.
+	if got := b.Reason("k"); got != "5xx" {
+		t.Errorf("reason = %q, want 5xx", got)
+	}
+}
+
+func TestBreakerStaysBounded(t *testing.T) {
+	b := NewSessionBreaker()
+	for i := 0; i < breakerCap+500; i++ {
+		b.Disable(string(rune('a'+i%26))+string(rune(i)), 60_000, "4xx")
+	}
+	b.mu.Lock()
+	n := len(b.entries)
+	b.mu.Unlock()
+	if n > breakerCap {
+		t.Errorf("breaker holds %d entries, cap is %d", n, breakerCap)
+	}
+}
+
+func postStatus(t *testing.T, h bus.ModuleHandler, req PostStatusRequest) PostStatusResponse {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, st := h(bus.ModuleInvocation{StageID: StagePostStatus}, body)
+	if st != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", st)
+	}
+	var resp PostStatusResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestPostStatusStageDecides(t *testing.T) {
+	h := NewHandler()
+
+	// 4xx: our payload was rejected, so restore, trip and resend once.
+	got := postStatus(t, h, PostStatusRequest{
+		SessionKey: "s1", HTTPStatus: 413, Mutated: true, TTLMS: 60_000,
+	})
+	if got.Action != "resend" || !got.Restore || !got.Disabled {
+		t.Errorf("4xx = %+v, want resend+restore+disabled", got)
+	}
+	if got.Counter != Stat4xxRestoreResend {
+		t.Errorf("counter = %q", got.Counter)
+	}
+
+	// 5xx: provider state is uncertain, so trip but never resend.
+	got = postStatus(t, h, PostStatusRequest{
+		SessionKey: "s2", HTTPStatus: 503, Mutated: true, TTLMS: 60_000,
+	})
+	if got.Action != "none" || got.Restore || !got.Disabled {
+		t.Errorf("5xx = %+v, want none+no-restore+disabled", got)
+	}
+
+	// 2xx owes nothing, and neither does a turn that was never mutated: an
+	// unrelated provider error must not switch the lever off.
+	for _, tc := range []PostStatusRequest{
+		{SessionKey: "s3", HTTPStatus: 200, Mutated: true, TTLMS: 60_000},
+		{SessionKey: "s4", HTTPStatus: 400, Mutated: false, TTLMS: 60_000},
+	} {
+		got = postStatus(t, h, tc)
+		if got.Action != "none" || got.Disabled {
+			t.Errorf("%+v -> %+v, want inert", tc, got)
+		}
+	}
+}
+
+func TestPostStatusStageStreamPath(t *testing.T) {
+	h := NewHandler()
+	// Streaming: bytes are with the client, so trip but never resend.
+	got := postStatus(t, h, PostStatusRequest{
+		SessionKey: "s1", Mutated: true, HaveKey: true,
+		TTLMS: 60_000, StreamReason: "stream_invalid_request",
+	})
+	if got.Action != "none" || got.Restore {
+		t.Errorf("stream must not resend or restore: %+v", got)
+	}
+	if !got.Disabled || got.Reason != "stream_invalid_request" {
+		t.Errorf("stream = %+v, want disabled with its reason", got)
+	}
+
+	// Without a key there is nothing to disable, so nothing is claimed.
+	got = postStatus(t, h, PostStatusRequest{
+		Mutated: true, HaveKey: false, TTLMS: 60_000, StreamReason: "stream",
+	})
+	if got.Disabled {
+		t.Error("no session key must not report a trip")
+	}
+}
+
+// A trip is only worth anything if the NEXT turn sees it. This is the round trip
+// the C seam never had: its breaker was written on a path nothing called, so the
+// pre-send read was permanently false. Both halves live here now, so one handler
+// can prove the loop closes.
+func TestTrippedBreakerBlocksTheNextReduction(t *testing.T) {
+	h := NewHandler()
+
+	reduce := func(key string) ReduceResponse {
+		t.Helper()
+		body, err := json.Marshal(ReduceRequest{
+			Messages:      rawMessages(t, 20),
+			SystemPrompt:  "sys",
+			Seam:          "gateway",
+			SessionKey:    key,
+			HistoryFold:   true,
+			ClosetEnabled: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, st := h(bus.ModuleInvocation{StageID: StageReduce}, body)
+		if st != bus.ModuleStatusOK {
+			t.Fatalf("status = %v", st)
+		}
+		var resp ReduceResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	if before := reduce("sess"); !before.Mutated {
+		t.Fatalf("expected a reduction before the breaker trips: %+v", before)
+	}
+
+	postStatus(t, h, PostStatusRequest{
+		SessionKey: "sess", HTTPStatus: 413, Mutated: true, TTLMS: 60_000,
+	})
+
+	after := reduce("sess")
+	if after.Mutated {
+		t.Error("a disabled session must pass through pristine")
+	}
+	if after.Bypass != "session_disabled" {
+		t.Errorf("bypass = %q, want session_disabled", after.Bypass)
+	}
+
+	// The breaker is per session, so an untouched identity still reduces.
+	if other := reduce("elsewhere"); !other.Mutated {
+		t.Error("one session's breaker must not disable another's")
+	}
+}

--- a/server-go/modules/economizer/gateway.go
+++ b/server-go/modules/economizer/gateway.go
@@ -23,6 +23,7 @@ const (
 	GWBypassReduceFormatUnsupported
 	// Gateway-side outcomes.
 	GWBypassNoOp                // nothing changed / not a net shrink / not REDUCED
+	GWBypassSessionDisabled     // the breaker is open for this session
 	GWBypassStructuralViolation // an orphaned tool pair was found
 	GWBypassSnapshotOOM         // a required deep copy failed
 	GWBypassReplaceFailed       // installing the reduced array failed
@@ -36,6 +37,7 @@ var gwBypassNames = map[GWBypassReason]string{
 	GWBypassReduceInternalAssertion: "reduce_internal_assertion",
 	GWBypassReduceFormatUnsupported: "reduce_format_unsupported",
 	GWBypassNoOp:                    "no_op",
+	GWBypassSessionDisabled:         "session_disabled",
 	GWBypassStructuralViolation:     "structural_violation",
 	GWBypassSnapshotOOM:             "snapshot_oom",
 	GWBypassReplaceFailed:           "replace_failed",
@@ -144,6 +146,67 @@ func GWShouldApply(reduceOK bool, res *ReduceResult, err ReduceError, repair Str
 		}
 	}
 	return GWBypassNone
+}
+
+// GWPostDecision is what a caller must do once the upstream status is known.
+//
+// It carries no payload and touches no store, so the same decision serves an
+// in-process caller that owns the request body and a bus caller that only has
+// the status. Restoring the pristine array, tripping the breaker and resending
+// are the CALLER's to perform — this only says which of them are owed.
+type GWPostDecision struct {
+	Action  PostAction
+	Restore bool   // put the pristine array back before doing anything else
+	Disable bool   // trip the session breaker
+	Reason  string // breaker reason, and the label telemetry records
+	Counter string // the counter to increment, "" when there is nothing to record
+}
+
+// GWPostStatus decides what a buffered turn owes after its upstream status.
+//
+// 4xx: the provider rejected the payload we built, so the reduction is the prime
+// suspect — restore the pristine original, trip the breaker and resend ONCE.
+//
+// 5xx: provider state is uncertain, since the request may have been partially
+// processed, so trip the breaker but do NOT resend. Resending after an ambiguous
+// server error risks duplicating work the provider already did.
+//
+// A turn that was never mutated owes nothing: there is no reduction to blame and
+// nothing to restore, so an unrelated provider error must not disable the lever.
+func GWPostStatus(httpStatus int, mutated bool) GWPostDecision {
+	if !mutated {
+		return GWPostDecision{}
+	}
+	switch httpStatus / 100 {
+	case 4:
+		return GWPostDecision{
+			Action: PostResend, Restore: true, Disable: true,
+			Reason: "4xx", Counter: Stat4xxRestoreResend,
+		}
+	case 5:
+		return GWPostDecision{
+			Disable: true, Reason: "5xx", Counter: Stat5xxDisable,
+		}
+	}
+	return GWPostDecision{}
+}
+
+// GWStreamDisable decides what a STREAMING turn owes when it fails after
+// dispatch. Nothing can be restored or resent once bytes have gone to the
+// client, so the breaker is all that is left.
+//
+// Without a session key there is no breaker to trip, and disabling is skipped
+// rather than applied to some other identity's session.
+func GWStreamDisable(mutated, haveKey bool, reason string) GWPostDecision {
+	if !mutated || !haveKey {
+		return GWPostDecision{}
+	}
+	if reason == "" {
+		reason = "stream"
+	}
+	return GWPostDecision{
+		Disable: true, Reason: reason, Counter: StatStreamErrorDisable,
+	}
 }
 
 // GWReplaceMessages installs the reduced array under key.

--- a/server-go/modules/economizer/gateway_wire.go
+++ b/server-go/modules/economizer/gateway_wire.go
@@ -204,49 +204,47 @@ func BufferedAfterStatus(container *JSONValue, key string, httpStatus int,
 	if ctx == nil || !ctx.Mutated || container == nil || key == "" {
 		return PostNone
 	}
-	switch httpStatus / 100 {
-	case 4:
-		if ctx.Pristine != nil {
-			if GWReplaceMessages(container, key, ctx.Pristine) {
-				ctx.Pristine = nil // ownership moved back into the container
-				if restored := container.Get(key); restored != nil && deps.Repair != nil {
-					deps.Repair(restored)
-				}
-			}
-		}
-		if deps.Sessions != nil {
-			deps.Sessions.Disable(ctx.Key, ctx.TTLMS, "4xx")
-		}
-		GWProvenanceClear(&ctx.State)
-		statsInc(deps, Stat4xxRestoreResend)
-		ctx.Mutated = false // the request is pristine now; no double handling
-		return PostResend
-	case 5:
-		if deps.Sessions != nil {
-			deps.Sessions.Disable(ctx.Key, ctx.TTLMS, "5xx")
-		}
-		GWProvenanceClear(&ctx.State)
-		statsInc(deps, Stat5xxDisable)
-		ctx.Mutated = false
+	// The decision is GWPostStatus's; this only carries it out over the request
+	// body it owns. Keeping the two apart is what lets the bus caller, which has
+	// the status but not the body, reach the same verdict.
+	d := GWPostStatus(httpStatus, ctx.Mutated)
+	if !d.Disable && d.Action == PostNone {
 		return PostNone
 	}
-	return PostNone
+	if d.Restore && ctx.Pristine != nil {
+		if GWReplaceMessages(container, key, ctx.Pristine) {
+			ctx.Pristine = nil // ownership moved back into the container
+			if restored := container.Get(key); restored != nil && deps.Repair != nil {
+				deps.Repair(restored)
+			}
+		}
+	}
+	if d.Disable && deps.Sessions != nil {
+		deps.Sessions.Disable(ctx.Key, ctx.TTLMS, d.Reason)
+	}
+	GWProvenanceClear(&ctx.State)
+	if d.Counter != "" {
+		statsInc(deps, d.Counter)
+	}
+	ctx.Mutated = false // handled; never twice
+	return d.Action
 }
 
 // StreamDisable trips the breaker for a streaming turn that failed after
 // dispatch. One disable per turn: a later frame no-ops.
 func StreamDisable(deps GatewayDeps, ctx *MutateCtx, reason string) {
-	if ctx == nil || !ctx.Mutated || !ctx.HaveKey {
+	if ctx == nil {
 		return
 	}
-	if reason == "" {
-		reason = "stream"
+	d := GWStreamDisable(ctx.Mutated, ctx.HaveKey, reason)
+	if !d.Disable {
+		return
 	}
 	if deps.Sessions != nil {
-		deps.Sessions.Disable(ctx.Key, ctx.TTLMS, reason)
+		deps.Sessions.Disable(ctx.Key, ctx.TTLMS, d.Reason)
 	}
 	GWProvenanceClear(&ctx.State)
-	statsInc(deps, StatStreamErrorDisable)
+	statsInc(deps, d.Counter)
 	ctx.Mutated = false
 }
 

--- a/server-go/modules/economizer/module.go
+++ b/server-go/modules/economizer/module.go
@@ -11,10 +11,14 @@ import (
 // algorithms that already live here: fresh-result JSON compaction, spill recall,
 // and the process-local condensation counters.
 //
-// The module is STATELESS: per-conversation reducer state travels in and out
-// with the request, because the caller already persists it (db1_economizer_state
-// save/load). That keeps the module free of a store and lets any process serve
-// the stage.
+// Per-conversation reducer state travels in and out with the request, because
+// the caller already persists it (db1_economizer_state save/load).
+//
+// The gateway's circuit breaker is the one thing the module DOES hold, in
+// breaker.go. It is the module's own lever -- "my reduction is switched off for
+// this session" -- not the caller's session state, and it is deliberately
+// volatile. Holding it here is what makes tripping it mean anything: a breaker
+// written on one side of the bus and read on the other would never fire.
 
 // Event kind and stage id, fixed by the process contract at
 // 4096 + ordinal*256 + stage. The economizer is inventory ordinal 27, so these
@@ -30,7 +34,42 @@ const (
 	StageToolStats   uint32 = 4
 	EventRecordBuild uint32 = 11013
 	StageRecordBuild uint32 = 5
+	EventPostStatus  uint32 = 11014
+	StagePostStatus  uint32 = 6
 )
+
+// PostStatusRequest asks what a dispatched gateway turn owes now its upstream
+// status is known.
+//
+// The request body is NOT here and never will be: restoring the pristine array
+// and resending are the HTTP caller's, over a body it owns. This decides, and
+// owns the breaker the decision writes to.
+type PostStatusRequest struct {
+	SessionKey string `json:"session_key"`
+	HTTPStatus int    `json:"http_status,omitempty"`
+	Mutated    bool   `json:"mutated"`
+	TTLMS      int    `json:"ttl_ms,omitempty"`
+	// HaveKey and StreamReason select the streaming path, where bytes have
+	// already reached the client so nothing can be restored or resent.
+	HaveKey      bool   `json:"have_key,omitempty"`
+	StreamReason string `json:"stream_reason,omitempty"`
+}
+
+// PostStatusResponse is the decision plus what was done to the breaker.
+type PostStatusResponse struct {
+	// Action is "none" or "resend". "resend" means the caller must put its
+	// pristine array back and send exactly once more.
+	Action  string `json:"action"`
+	Restore bool   `json:"restore,omitempty"`
+	// Disabled reports that the breaker was tripped HERE, so the caller records
+	// it once rather than inferring it.
+	Disabled bool   `json:"disabled,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+	// Counter is the telemetry counter the caller should increment, empty when
+	// there is nothing to record. Naming it here keeps the labels in one place
+	// while the tap itself stays with the caller.
+	Counter string `json:"counter,omitempty"`
+}
 
 // ReduceRequest is the wire form of one reduction.
 //
@@ -41,6 +80,11 @@ type ReduceRequest struct {
 	Messages     json.RawMessage `json:"messages"`
 	SystemPrompt string          `json:"system_prompt,omitempty"`
 	Seam         string          `json:"seam"` // "gateway" | "delegate"
+	// SessionKey identifies whose lever this is, for the gateway seam's breaker.
+	// Empty means the request carried no resolvable identity, which reduces
+	// normally but can never trip or read a breaker — otherwise one anonymous
+	// request could switch off another identity's session.
+	SessionKey string `json:"session_key,omitempty"`
 
 	// Config, resolved by the caller.
 	HistoryFold        bool       `json:"history_fold,omitempty"`
@@ -119,18 +163,28 @@ var reduceReasonNames = map[ReduceReason]string{
 }
 
 // NewHandler serves the economizer's reduce stage.
+//
+// The breaker is created per handler rather than as a package global so a test
+// gets a clean one and two handlers never share a lever.
 func NewHandler() bus.ModuleHandler {
+	breaker := NewSessionBreaker()
 	return func(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
 		if invocation.Cancelled() {
 			return nil, bus.ModuleStatusCancelled
 		}
 		switch invocation.StageID {
+		case StagePostStatus:
+			var req PostStatusRequest
+			if err := json.Unmarshal(request, &req); err != nil {
+				return nil, bus.ModuleStatusInvalidRequest
+			}
+			return handlePostStatus(breaker, &req)
 		case StageReduce:
 			var req ReduceRequest
 			if err := json.Unmarshal(request, &req); err != nil {
 				return nil, bus.ModuleStatusInvalidRequest
 			}
-			return handleReduce(&req)
+			return handleReduce(breaker, &req)
 		case StageJSONCompact:
 			return handleJSONCompact(invocation, request)
 		case StageToolRecall:
@@ -145,7 +199,7 @@ func NewHandler() bus.ModuleHandler {
 	}
 }
 
-func handleReduce(req *ReduceRequest) ([]byte, bus.ModuleStatus) {
+func handleReduce(breaker *SessionBreaker, req *ReduceRequest) ([]byte, bus.ModuleStatus) {
 	messages := ParseJSON(string(req.Messages))
 	if messages == nil || !messages.IsArray() {
 		return nil, bus.ModuleStatusInvalidRequest
@@ -187,6 +241,23 @@ func handleReduce(req *ReduceRequest) ([]byte, bus.ModuleStatus) {
 			},
 		},
 	}
+	// Honour the breaker BEFORE reducing. A disabled session is a pristine
+	// passthrough: the whole point of tripping it was to stop spending effort on
+	// a payload shape this session has already shown the provider rejects.
+	//
+	// Read here rather than by the caller because the write side lives here too;
+	// split across the bus, a trip on one side would never be seen by the other.
+	if seam == SeamGateway && req.SessionKey != "" && breaker.IsDisabled(req.SessionKey) {
+		body, err := json.Marshal(ReduceResponse{
+			Reason: reduceReasonNames[ReduceReasonNone],
+			Bypass: GWBypassSessionDisabled.String(),
+		})
+		if err != nil {
+			return nil, bus.ModuleStatusInternal
+		}
+		return body, bus.ModuleStatusOK
+	}
+
 	// The seam gate lives in the config, so set the one this request arrived on.
 	if seam == SeamGateway {
 		cfg.GatewaySeam = true
@@ -239,6 +310,45 @@ func handleReduce(req *ReduceRequest) ([]byte, bus.ModuleStatus) {
 	}
 	if blob, ok := SerializeState(st); ok {
 		resp.State = blob
+	}
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return nil, bus.ModuleStatusInternal
+	}
+	return body, bus.ModuleStatusOK
+}
+
+// handlePostStatus applies the post-dispatch decision and owns the breaker write.
+//
+// The caller is told what to DO rather than asked what to do: it has the request
+// body and the socket, this has the lever. Splitting it the other way — caller
+// decides, module stores — is what left the C seam with a breaker nothing ever
+// wrote to.
+func handlePostStatus(breaker *SessionBreaker, req *PostStatusRequest) ([]byte, bus.ModuleStatus) {
+	var d GWPostDecision
+	if req.StreamReason != "" {
+		// Streaming: bytes are already with the client, so the breaker is the only
+		// lever left. HaveKey gates it because without a key there is nothing to
+		// disable.
+		d = GWStreamDisable(req.Mutated, req.HaveKey, req.StreamReason)
+	} else {
+		d = GWPostStatus(req.HTTPStatus, req.Mutated)
+	}
+
+	resp := PostStatusResponse{Action: "none", Restore: d.Restore, Counter: d.Counter}
+	if d.Action == PostResend {
+		resp.Action = "resend"
+	}
+	// A trip needs somewhere to record it and a window to last for. Report
+	// Disabled only when the write actually happened, so the caller never records
+	// a breaker that was never set.
+	if d.Disable && req.SessionKey != "" && req.TTLMS > 0 {
+		breaker.Disable(req.SessionKey, req.TTLMS, d.Reason)
+		resp.Disabled = true
+		resp.Reason = d.Reason
+	} else if d.Reason != "" {
+		resp.Reason = d.Reason
 	}
 
 	body, err := json.Marshal(resp)

--- a/src/modules/economizer/module.yaml
+++ b/src/modules/economizer/module.yaml
@@ -17,6 +17,7 @@
     "src/modules/economizer/gateway_mutate_wire.c"
   ],
   "go_sources": [
+    "server-go/modules/economizer/breaker.go",
     "server-go/modules/economizer/budget.go",
     "server-go/modules/economizer/cjson.go",
     "server-go/modules/economizer/closet.go",
@@ -47,6 +48,7 @@
     "server-go/modules/economizer/state.go"
   ],
   "go_tests": [
+    "server-go/modules/economizer/breaker_test.go",
     "server-go/modules/economizer/budget_test.go",
     "server-go/modules/economizer/cjson_test.go",
     "server-go/modules/economizer/closet_test.go",

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -596,6 +596,11 @@
           "id": 5,
           "name": "economizer-record-build",
           "event_kind": 11013
+        },
+        {
+          "id": 6,
+          "name": "economizer-post-status",
+          "event_kind": 11014
         }
       ]
     }


### PR DESCRIPTION
The gateway's post-dispatch safety net has never run. gw_buffered_after_status,
gw_stream_disable and both classifiers have no production caller -- only tests
and a weak stub -- so on a 4xx nothing restores the pristine payload, on a 5xx
nothing trips the breaker, and the deep copy gw_buffered_mutate takes on every
request is freed unused. msg_session_disable is called only from those dead
paths, so the breaker's write side is unreachable and msg_session_is_disabled
is permanently false. Bounded by the lever being dark unless the aggressive
tier is on, but it means the design has never actually protected anything.

This wires it in Go rather than resurrecting it in C, because a circuit breaker
is STATE and state belongs in the module. The C table it replaces is not a
pattern to copy; it is C to be deleted.

WHAT MOVED. GWPostStatus and GWStreamDisable are the decision, extracted pure
out of BufferedAfterStatus and StreamDisable, which now call them -- one
implementation, two callers, so the in-process path and the bus path cannot
drift. breaker.go is the lever itself: a bounded, TTL'd, mutex-guarded table
matching the C's semantics (cap 10000, lazy expiry, sweep before evict, oldest
evicted first, re-disable refreshes window and reason). Stage 6 applies a
decision and owns the write.

WHY THE MODULE HOLDS IT. This is the economizer's own lever -- 'my reduction is
off for this session' -- not the caller's session state; it carries nothing
about the caller but an opaque key, no history and no correlation. Splitting it
the other way, caller decides and module stores, is precisely what left the C
seam with a breaker nothing ever wrote to. The pre-send read moved with it, for
the same reason: written on one side of the bus and read on the other, a trip
would never fire. That round trip is now a test, and it fails if either half is
unwired.

Volatile on purpose. A breaker that forgets on restart fails OPEN: reduction
resumes and a still-bad payload trips it again within one turn, where
persisting it would mean a restart could not clear a stuck lever.

NOT YET CLOSED: no C calls stage 6, so the gap stands until the seam does. This
adds the owner and the contract; the caller is the next slice.

go test -race clean, full Go suite passes, aimee-server and aimee-kb build under
-Werror, descriptors validate, lock and process contract carry the new stage.