### PR TITLE
security: declare content reader readiness

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -184,8 +184,8 @@ use the same server-to-KB path. Caller-less ingest, re-embed, curator and code-i
 closed-name, project-bound maintenance scope. Durable queues are read only far enough to claim work
 and learn its project; content transactions then admit only that project's attributed rows and end
 before any embedder, model, or sidecar call. The scope does not impersonate a user or add a network
-credential. Content-scope readiness remains disabled until operators can explicitly attribute every
-code project to its tenancy project and the enabled policies pass live two-project coverage.
+credential. This release declares the content readers ready after live two-user/two-team coverage,
+but applying the schema does not enable content RLS.
 
 The attribution is deliberately numeric and explicit because tenancy-project names are unique only
 inside a team. On the KB host, list the tenancy project ids and bind each existing code-index project
@@ -198,6 +198,29 @@ aimee-kb project attribute <code-index-project> <kb-project-id>
 
 Re-running `project attribute` replaces the prior binding atomically. It is an org-admin operation;
 both exact projects must already exist, and no name-based fallback is attempted.
+
+Before enabling, the following query must return no rows for either content table:
+
+```bash
+psql "$AIMEE_DB2_URL" -c "
+  SELECT 'kb_documents' AS source, d.project, count(*)
+    FROM kb_documents d LEFT JOIN projects p ON p.name=d.project
+   WHERE p.kb_project IS NULL GROUP BY d.project
+  UNION ALL
+  SELECT 'kb_file_index', f.project, count(*)
+    FROM kb_file_index f LEFT JOIN projects p ON p.name=f.project
+   WHERE p.kb_project IS NULL GROUP BY f.project;"
+```
+
+Then enable the policies as a deliberate operator act:
+
+```bash
+psql "$AIMEE_DB2_URL" -c "select kb_content_scope_enable();"
+```
+
+The function refuses unless the release readiness marker is present and every content-bearing
+project is attributed. To roll back enforcement without changing attribution, call
+`select kb_content_scope_disable();`.
 
 Grants are keyed by server, team, and exact authenticated subject:
 

--- a/docs/proposals/pending/per-user-content-scope-identity-map.md
+++ b/docs/proposals/pending/per-user-content-scope-identity-map.md
@@ -79,9 +79,10 @@ MCP authentication remain owned by those ingress layers.
   by aimee-server.
 - **Web is not a new KB proof problem.** Standard web/PAM/OIDC authentication terminates before the
   server opens the KB request.
-- **Background work remains separate.** Ingest, re-embed, curator and code-indexer authorization is
-  still the open question from #2646. It must be answered before content scope is enabled, but it is
-  not evidence that CLI, web or MCP needs another authentication layer.
+- **Background work remains separate from caller identity.** #2646 was resolved by #2658, with the
+  post-embed scope correction in #2661: closed-name, exact-project maintenance scopes cover ingest,
+  re-embed, curator and code-indexer work. That in-process scope is not evidence that CLI, web or MCP
+  needs another authentication layer.
 
 ## Bounded slices
 
@@ -125,6 +126,8 @@ observable when an operator subsequently enables content scope.
 
 ## Status
 
-Pending. Supersedes the earlier proposal's proof-per-surface framing. The remaining work is identity
-context propagation and tenant scoping over the existing authenticated service boundary, not a new
-authentication mechanism.
+Implemented cumulatively through slice 6: #2656 supplied pair-specific mTLS enforcement, ingress
+identity convergence, and caller-scoped reads; #2658 and #2661 supplied exact-project maintenance;
+the final slice records reader readiness after live RLS isolation coverage. Schema application still
+leaves content RLS disabled. An operator must explicitly attribute every content-bearing code project
+and call `kb_content_scope_enable()`; the function refuses an incomplete backfill.

--- a/docs/proposals/pending/per-user-content-scope-reader-identity.md
+++ b/docs/proposals/pending/per-user-content-scope-reader-identity.md
@@ -5,11 +5,11 @@ is about the request-context half that has to exist before any of it can be enab
 
 ## Problem
 
-`kb_content_scope_enable()` still refuses today, and the refusal is correct until the rollout is
-complete. Authenticated content ingress now opens `db2_tenant_scope_begin`, and background content
-work now has a separate named project scope. What remains is operational attribution of every code
-project to its exact tenancy `kb_project`, followed by live RLS coverage and the readiness marker.
-Enabling before those checks are complete can still make existing content disappear.
+Authenticated content ingress opens `db2_tenant_scope_begin`, background content work has a separate
+named project scope, and live RLS coverage proves ordinary searches for two users on two teams. The
+release therefore records reader readiness. `kb_content_scope_enable()` still refuses until the
+operator attributes every content-bearing code project to its exact tenancy `kb_project`; enabling
+before that backfill is complete would make existing content disappear.
 
 This is an authorization-context gap, not a missing authentication system.
 
@@ -128,8 +128,9 @@ operator enables it.
 
 ## Status
 
-Implementation in progress. The connection/caller-context path, explicit admin-only project
-attribution, and project-bound background worker scope are wired while content RLS remains disabled.
-An operator backfill, live two-project RLS coverage, and the slice-6 readiness marker remain;
-`kb_content_scope_enable()` therefore still refuses by construction. The companion identity map
-records why no additional proof mechanism is required.
+Implemented cumulatively through slice 6. #2656 supplied pair-specific mTLS enforcement, UDS/web/
+thinclient/MCP identity convergence, and caller-scoped reads; #2658 and #2661 supplied exact-project
+background maintenance; the final slice adds live two-user/two-team ordinary-search RLS coverage.
+Schema application records `content_scope_reader_ready = '1'` but does not enable content RLS. The
+operator must finish attribution and call `kb_content_scope_enable()`; incomplete attribution still
+fails closed. The companion identity map records why no additional proof mechanism is required.

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -2229,29 +2229,17 @@ DECLARE
   orphan_files BIGINT;
   reader_ready TEXT;
 BEGIN
-  -- THE READER SIDE MUST EXIST FIRST, and today it does not.
-  --
-  -- aimee.principal is transaction-scoped and reset on pooled connections
-  -- (db2_tenant.c), and it is set only inside db2_tenant_scope_begin. Every one
-  -- of that function's callers is a governance, management or vault path: the
-  -- content readers -- kb_payload.c, memory_query.c, kb_service_backend.c --
-  -- open NO tenant scope at all. The service also connects as a non-owner with
-  -- NOBYPASSRLS, by design, so nothing rescues it.
-  --
-  -- So enabling before the read paths carry a principal does not hide
-  -- unattributed rows. It returns NOTHING to EVERY content read, for everyone,
-  -- which is a total outage wearing the costume of a security control.
-  --
-  -- The marker is written by the change that threads the principal through
-  -- those reads. Until then this refuses, because a comment in a proposal is not
-  -- a safeguard and this is exactly the mistake an operator cannot un-make in a
-  -- hurry.
+  -- THE READER SIDE MUST EXIST FIRST. The marker is a release capability fact,
+  -- written only after the authenticated caller path, transaction-local tenant
+  -- scope, every ingress, and project-bound maintenance work have live coverage.
+  -- It does not enable RLS: attribution and the operator act below remain
+  -- separate so applying a migration cannot turn an incomplete backfill into an
+  -- outage.
   SELECT value INTO reader_ready FROM kb_meta WHERE key = 'content_scope_reader_ready';
   IF reader_ready IS DISTINCT FROM '1' THEN
-    RAISE EXCEPTION 'refusing to enable content scope: the content read paths do not set '
-                    'aimee.principal yet, so every content read would return nothing for '
-                    'everyone. The change that threads the principal through those reads sets '
-                    'kb_meta.content_scope_reader_ready=1; enable after it ships.';
+    RAISE EXCEPTION 'refusing to enable content scope: this schema has not declared the '
+                    'authenticated caller path and transaction-local content reader scope ready. '
+                    'Upgrade before enabling.';
   END IF;
   SELECT count(*) INTO orphan_docs FROM kb_documents d
     WHERE NOT EXISTS (SELECT 1 FROM projects p
@@ -14046,6 +14034,12 @@ REVOKE ALL ON FUNCTION kb_management_token_key_use_worm_guard(),
 -- dim); on a one-shot migrate this is simply the recorded build dim.
 INSERT INTO kb_meta (key, value) VALUES ('schema_embedding_dim', '__EMBED_DIM__')
   ON CONFLICT (key) DO NOTHING;
+-- Reader readiness is a SOFTWARE capability, not the operator's enable switch.
+-- Recording it here makes upgrades declare the completed six-slice reader path
+-- while leaving both content tables' RLS flags unchanged. kb_content_scope_enable()
+-- still refuses until every content row has an exact projects.kb_project.
+INSERT INTO kb_meta (key, value) VALUES ('content_scope_reader_ready', '1')
+  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
 -- schema_version: BUMP in lockstep with AIMEE_DB2_SCHEMA_VERSION in db2/db_schema.h
 -- whenever a change here adds/alters an object a runtime kb depends on, so a runtime
 -- kb started against an older schema fails closed.

--- a/src/tests/test_content_scope_pg.c
+++ b/src/tests/test_content_scope_pg.c
@@ -18,22 +18,23 @@
  *     can read. A policy that switched
  *     itself on would turn an upgrade into an outage for every row not yet
  *     attributed, so the off state is asserted rather than assumed.
- *  4. Enabling REFUSES while content is unattributed, because turning it on
- *     then hides those rows from everyone.
+ *  4. Reader readiness is declared without enabling RLS, and enabling still
+ *     REFUSES while content is unattributed.
  *  5. Tenant and maintenance scopes do not outlive their transactions. Their
- *     GUCs live on a POOLED connection, so a leak there is one tenant reading another's rows
- *     rather than merely a stale value.
+ *     GUCs live on a POOLED connection, so a leak there is one tenant reading
+ *     another's rows rather than merely a stale value.
  *  6. The re-embed worker completes its post-embed payload read and vector write
  *     under a fresh exact-project scope, without crossing into a sibling project.
- *
- * WHAT IS NOT HERE: whether a member sees their own project and a stranger does
- * not. That is an end-to-end reader check rather than this DB boundary check.
+ *  7. Maintenance authority is named, exact-project, and transaction-local.
+ *  8. Two users on two teams search the ordinary KB path with FORCE RLS enabled;
+ *     each sees only their own project, and a caller-less search sees neither.
  */
 #include "db2.h"
 #include "db2/db2_internal.h"
 #include "db2/db_postgres.h"
 #include "db2/db2_tenant.h"
 #include "db2/project.h"
+#include "cJSON.h"
 #include "kb.h"
 #include "kb_identity.h"
 #include "memory.h"
@@ -45,6 +46,30 @@
 
 /* Single-value scalar query. Returns 0 and fills out on success. */
 static int scalar(const char *sql, char *out, size_t cap);
+
+/* Count only result objects whose project field exactly matches |project|.
+ * Metadata is deliberately ignored so future diagnostic fields cannot turn a
+ * harmless project-name echo into an isolation-test failure. */
+static int search_project_count(const char *json, const char *project)
+{
+   cJSON *root = json ? cJSON_Parse(json) : NULL;
+   cJSON *results = root ? cJSON_GetObjectItemCaseSensitive(root, "results") : NULL;
+   if (!cJSON_IsArray(results))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   int count = 0;
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, results)
+   {
+      cJSON *value = cJSON_GetObjectItemCaseSensitive(item, "project");
+      if (cJSON_IsString(value) && strcmp(value->valuestring, project) == 0)
+         count++;
+   }
+   cJSON_Delete(root);
+   return count;
+}
 
 static int exec_sql(const char *sql)
 {
@@ -150,10 +175,31 @@ int main(void)
           "0");
    printf("  PASS: they are inert until an operator enables them\n");
 
-   /* 5. Enabling refuses while any content is unattributed. Turning it on over
-    *    unattributed rows does not give a weaker control, it hides those rows
-    *    from everyone, which reads as data loss. The refusal is the feature. */
+   /* 5. The release declares reader readiness without enabling RLS. Enabling
+    *    still refuses while any content is unattributed: turning it on over an
+    *    orphan does not give a weaker control, it hides that row from everyone. */
    {
+      expect("SELECT value FROM kb_meta WHERE key='content_scope_reader_ready'", "1");
+      printf("  PASS: reader readiness is declared without enabling content scope\n");
+
+      char orphan_id[64] = "";
+      assert(scalar("INSERT INTO projects(name,root,scanned_at,kb_project)"
+                    " VALUES ('scope-unattributed','/scope/unattributed','',NULL)"
+                    " ON CONFLICT (name) DO UPDATE SET kb_project=NULL RETURNING id",
+                    orphan_id, sizeof(orphan_id)) == 0);
+      assert(exec_sql("DELETE FROM kb_documents"
+                      " WHERE project='scope-unattributed'"
+                      " AND file_path='scope-unattributed.md'") == 0);
+      assert(exec_sql("DELETE FROM projects WHERE name='scope-unattributed'") == 0);
+      assert(scalar("INSERT INTO kb_documents"
+                    " (project,generation,file_path,file_hash,chunk_index,heading_path,"
+                    "  line_start,line_end,content,token_count)"
+                    " SELECT name,current_generation,'scope-unattributed.md','orphan-hash',0,"
+                    "  'Unattributed',1,1,'must block content scope enable',5"
+                    " FROM projects WHERE id="
+                    " (SELECT id FROM projects WHERE name='scope-unattributed') RETURNING id",
+                    orphan_id, sizeof(orphan_id)) == 0);
+
       char err[512] = "";
       aimee_pg_stmt_t *st =
           aimee_pg_prepare(db2_conn(), "SELECT kb_content_scope_enable()", err, sizeof(err));
@@ -168,44 +214,18 @@ int main(void)
       {
          refused = 1;
       }
-      /* Two independent reasons to refuse, and the reader one comes first: the
-         content read paths set no aimee.principal today, so enabling would
-         return nothing to everyone rather than hiding unattributed rows. That
-         one holds even on an empty database, which is why it is checked
-         separately from the attribution refusal below. */
-      char marker[64] = "";
-      assert(scalar("SELECT coalesce((SELECT value FROM kb_meta"
-                    "  WHERE key='content_scope_reader_ready'),'0')",
-                    marker, sizeof(marker)) == 0);
-      if (strcmp(marker, "1") != 0)
-      {
-         if (!refused)
-            fprintf(stderr, "kb_content_scope_enable() accepted while readers set no principal\n");
-         assert(refused);
-         printf("  PASS: enabling refuses while the read paths carry no principal\n");
-      }
-
-      /* The fixture database has no attributed content, so this must refuse.
-         A pass here with an empty kb_documents would prove nothing, so the
-         count is checked too. */
-      char docs[64] = "";
-      assert(scalar("SELECT count(*) FROM kb_documents", docs, sizeof(docs)) == 0);
-      if (strcmp(docs, "0") != 0)
-      {
-         if (!refused)
-            fprintf(stderr, "kb_content_scope_enable() accepted %s unattributed rows\n", docs);
-         assert(refused);
-         printf("  PASS: enabling refuses while content is unattributed\n");
-      }
-      else
-      {
-         printf("  SKIP: no content rows in this database to refuse over\n");
-      }
+      if (!refused)
+         fprintf(stderr, "kb_content_scope_enable() accepted an unattributed row\n");
+      assert(refused);
+      printf("  PASS: enabling refuses while content is unattributed\n");
       /* Whatever happened, leave the tables as they were found. */
       expect("SELECT count(*) FROM pg_class"
              " WHERE relname IN ('kb_documents','kb_file_index')"
              "   AND (relrowsecurity OR relforcerowsecurity)",
              "0");
+      assert(exec_sql("DELETE FROM kb_documents"
+                      " WHERE project='scope-unattributed'"
+                      " AND file_path='scope-unattributed.md'") == 0);
    }
 
    /* 6. A tenant scope must not survive its transaction.
@@ -455,6 +475,153 @@ int main(void)
       assert(exec_sql("ALTER TABLE kb_file_index NO FORCE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_file_index DISABLE ROW LEVEL SECURITY") == 0);
       printf("  PASS: maintenance authority is named, project-bound, and transaction-local\n");
+   }
+
+   /* 8. The final reader proof uses the ordinary hybrid-search function, not a
+    *    hand-written policy query. Two authenticated users belong to different
+    *    teams whose projects contain the same unique term. Once the operator
+    *    enables FORCE RLS, each search must materialize only its own row, and a
+    *    caller-less search after pooled-scope cleanup must materialize neither. */
+   {
+      char team_a[64] = "", team_b[64] = "", project_a[64] = "", project_b[64] = "";
+      char ignored[64] = "", sql[2048];
+      assert(scalar("INSERT INTO kb_team(name) VALUES ('scope-reader-team-a')"
+                    " ON CONFLICT (name) DO UPDATE SET name=EXCLUDED.name RETURNING id",
+                    team_a, sizeof(team_a)) == 0);
+      assert(scalar("INSERT INTO kb_team(name) VALUES ('scope-reader-team-b')"
+                    " ON CONFLICT (name) DO UPDATE SET name=EXCLUDED.name RETURNING id",
+                    team_b, sizeof(team_b)) == 0);
+
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_project(parent,name,access_mode)"
+               " VALUES (%s,'scope-reader-a','team-open')"
+               " ON CONFLICT (parent,name) DO UPDATE SET access_mode='team-open' RETURNING id",
+               team_a);
+      assert(scalar(sql, project_a, sizeof(project_a)) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_project(parent,name,access_mode)"
+               " VALUES (%s,'scope-reader-b','team-open')"
+               " ON CONFLICT (parent,name) DO UPDATE SET access_mode='team-open' RETURNING id",
+               team_b);
+      assert(scalar(sql, project_b, sizeof(project_b)) == 0);
+
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO projects(name,root,scanned_at,kb_project)"
+               " VALUES ('scope-reader-a','/scope/reader-a','',%s)"
+               " ON CONFLICT (name) DO UPDATE SET kb_project=EXCLUDED.kb_project,"
+               " lifecycle_state='current' RETURNING id",
+               project_a);
+      assert(scalar(sql, ignored, sizeof(ignored)) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO projects(name,root,scanned_at,kb_project)"
+               " VALUES ('scope-reader-b','/scope/reader-b','',%s)"
+               " ON CONFLICT (name) DO UPDATE SET kb_project=EXCLUDED.kb_project,"
+               " lifecycle_state='current' RETURNING id",
+               project_b);
+      assert(scalar(sql, ignored, sizeof(ignored)) == 0);
+
+      kb_principal_t reader_a = {.kind = KB_PRIN_OIDC, .authenticated = 1};
+      kb_principal_t reader_b = {.kind = KB_PRIN_OIDC, .authenticated = 1};
+      snprintf(reader_a.issuer, sizeof(reader_a.issuer), "%s", "https://reader.invalid");
+      snprintf(reader_a.subject, sizeof(reader_a.subject), "%s", "alice");
+      snprintf(reader_b.issuer, sizeof(reader_b.issuer), "%s", "https://reader.invalid");
+      snprintf(reader_b.subject, sizeof(reader_b.subject), "%s", "bob");
+      char key_a[640] = "", key_b[640] = "";
+      assert(kb_identity_key(&reader_a, key_a, sizeof(key_a)) == 0);
+      assert(kb_identity_key(&reader_b, key_b, sizeof(key_b)) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_team_membership(identity_key,team,is_default)"
+               " VALUES ('%s',%s,1) ON CONFLICT (identity_key,team)"
+               " DO UPDATE SET is_default=1 RETURNING id",
+               key_a, team_a);
+      assert(scalar(sql, ignored, sizeof(ignored)) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_team_membership(identity_key,team,is_default)"
+               " VALUES ('%s',%s,1) ON CONFLICT (identity_key,team)"
+               " DO UPDATE SET is_default=1 RETURNING id",
+               key_b, team_b);
+      assert(scalar(sql, ignored, sizeof(ignored)) == 0);
+
+      assert(exec_sql("DELETE FROM kb_documents"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')"
+                      " AND file_path IN ('reader-a.md','reader-b.md')") == 0);
+      assert(scalar("INSERT INTO kb_documents"
+                    " (project,generation,file_path,file_hash,chunk_index,heading_path,"
+                    "  line_start,line_end,content,token_count)"
+                    " SELECT name,current_generation,'reader-a.md','reader-a-hash',0,"
+                    "  'Reader A',1,1,'readinessisolationtoken belongs to reader alpha',5"
+                    " FROM projects WHERE name='scope-reader-a' RETURNING id",
+                    ignored, sizeof(ignored)) == 0);
+      assert(scalar("INSERT INTO kb_documents"
+                    " (project,generation,file_path,file_hash,chunk_index,heading_path,"
+                    "  line_start,line_end,content,token_count)"
+                    " SELECT name,current_generation,'reader-b.md','reader-b-hash',0,"
+                    "  'Reader B',1,1,'readinessisolationtoken belongs to reader beta',5"
+                    " FROM projects WHERE name='scope-reader-b' RETURNING id",
+                    ignored, sizeof(ignored)) == 0);
+
+      expect("SELECT count(*) FROM kb_documents d"
+             " WHERE NOT EXISTS (SELECT 1 FROM projects p"
+             " WHERE p.name=d.project AND p.kb_project IS NOT NULL)",
+             "0");
+      expect("SELECT count(*) FROM kb_file_index f"
+             " WHERE NOT EXISTS (SELECT 1 FROM projects p"
+             " WHERE p.name=f.project AND p.kb_project IS NOT NULL)",
+             "0");
+      expect("SELECT kb_content_scope_enable()",
+             "content scope enabled on kb_documents, kb_file_index");
+
+      assert(db2_tenant_scope_begin(&reader_a, (int64_t)atoll(team_a)) == 0);
+      char *result_a =
+          kb_search_json_ex(NULL, "readinessisolationtoken", MEMORY_EMBED_TEST_FIXTURE, 10, "rrf");
+      assert(result_a);
+      int result_a_own = search_project_count(result_a, "scope-reader-a");
+      int result_a_other = search_project_count(result_a, "scope-reader-b");
+      if (result_a_own != 1 || result_a_other != 0)
+         fprintf(stderr, "reader A search crossed content scope: %s\n", result_a);
+      assert(result_a_own == 1);
+      assert(result_a_other == 0);
+      free(result_a);
+      assert(db2_tenant_scope_commit() == 0);
+
+      char *anonymous =
+          kb_search_json_ex(NULL, "readinessisolationtoken", MEMORY_EMBED_TEST_FIXTURE, 10, "rrf");
+      assert(anonymous);
+      int anonymous_a = search_project_count(anonymous, "scope-reader-a");
+      int anonymous_b = search_project_count(anonymous, "scope-reader-b");
+      if (anonymous_a != 0 || anonymous_b != 0)
+         fprintf(stderr, "caller-less search inherited content scope: %s\n", anonymous);
+      assert(anonymous_a == 0);
+      assert(anonymous_b == 0);
+      free(anonymous);
+
+      assert(db2_tenant_scope_begin(&reader_b, (int64_t)atoll(team_b)) == 0);
+      char *result_b =
+          kb_search_json_ex(NULL, "readinessisolationtoken", MEMORY_EMBED_TEST_FIXTURE, 10, "rrf");
+      assert(result_b);
+      int result_b_own = search_project_count(result_b, "scope-reader-b");
+      int result_b_other = search_project_count(result_b, "scope-reader-a");
+      if (result_b_own != 1 || result_b_other != 0)
+         fprintf(stderr, "reader B search crossed content scope: %s\n", result_b);
+      assert(result_b_own == 1);
+      assert(result_b_other == 0);
+      free(result_b);
+      assert(db2_tenant_scope_commit() == 0);
+
+      expect("SELECT kb_content_scope_disable()", "content scope disabled");
+      printf("  PASS: two users on two teams search only their own project under FORCE RLS\n");
+      printf("  PASS: caller-less search inherits no pooled content identity\n");
+
+      assert(exec_sql("DELETE FROM kb_documents"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')"
+                      " AND file_path IN ('reader-a.md','reader-b.md')") == 0);
+      assert(exec_sql("DELETE FROM projects WHERE name IN ('scope-reader-a','scope-reader-b')") ==
+             0);
+      snprintf(sql, sizeof(sql), "DELETE FROM kb_team_membership WHERE identity_key IN ('%s','%s')",
+               key_a, key_b);
+      assert(exec_sql(sql) == 0);
+      assert(exec_sql("DELETE FROM kb_team"
+                      " WHERE name IN ('scope-reader-team-a','scope-reader-team-b')") == 0);
    }
 
    db2_shutdown();


### PR DESCRIPTION
## What changed

- record kb_meta.content_scope_reader_ready = 1 as the final software-capability marker without enabling content RLS during migration
- keep kb_content_scope_enable() as the explicit operator act, with fail-closed refusal for any content-bearing project that lacks exact projects.kb_project attribution
- extend the live PostgreSQL content-scope test to exercise the ordinary hybrid search path under ENABLE + FORCE ROW LEVEL SECURITY
- prove two OIDC users on two distinct teams each materialize exactly one result from their own project, never the sibling project, while a caller-less search sees neither
- parse actual result objects rather than matching arbitrary JSON metadata, and clean up all final-slice fixtures
- document attribution preflight, enable, and rollback commands
- update the proposal status to account for the cumulative implementation in #2656, #2658, and #2661

## Why

Slices 1-5 are merged: the existing triple-authenticated service boundary carries caller context, the KB resolves membership, content reads open transaction-local tenant scope, every ingress converges on that path, and background work uses named exact-project maintenance scope. The remaining bounded slice is to prove ordinary reads under live RLS and declare reader readiness. Enabling remains deliberately separate so schema application cannot turn an incomplete operator backfill into hidden content.

## Validation

- make -s -C src all
- make -s -C src lint — all 56 checks passed
- the focused unit-test-content-scope-pg target compiled and linked
- unit-test-content-scope-pg skips locally because AIMEE_TEST_PG_URL is unavailable; required CI supplies a pgvector PostgreSQL sidecar and executes the live path
- focused KB, KB HTTP-route, and KB identity suites passed before the final hardening commit
- git diff --check

## Security boundary

This adds no credential or fourth proof layer. Pair-specific mTLS, rotating bearer, and PAM/OIDC service identity remain the network invariant from #2656; KB-owned membership and exact-project maintenance authority are unchanged.
