### PR TITLE
ci: bind the C repository pins to main only

### DIFF
--- a/.github/workflows/c-repositories.yml
+++ b/.github/workflows/c-repositories.yml
@@ -47,5 +47,17 @@ jobs:
       - run: python3 -I -S scripts/validate_module_process_contracts.py
       - run: python3 -I scripts/check_go_module_runtime_bundle.py
       - run: cd server-go && CGO_ENABLED=0 go test ./bus ./modules/... ./cmd/aimee-module
-      - run: python3 -I scripts/check_c_repository_lock.py
+      # The exact commit/digest pins in dependencies/aimee-repositories.lock.json
+      # describe a RELEASE: which external core/module repository commit each
+      # vendored mirror was cut from. `testing` is the integration tip, where the
+      # vendored source is meant to run ahead of any published repository commit,
+      # so enforcing the lock there only demands a lock refresh after every edit
+      # under src/core|modules/** — noise that says nothing about the change.
+      # `main` (and every PR into it) is where the pins must hold, because that is
+      # what ships and what the main deployments run. Refresh with
+      # `export_c_repositories.py --refresh-lock-root` when a release is cut; see
+      # docs/core/repository-extraction.md.
+      - name: Repository pins (main only)
+        if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+        run: python3 -I scripts/check_c_repository_lock.py
       - run: sh src/tests/test_module_supervisor.sh

--- a/docs/core/repository-extraction.md
+++ b/docs/core/repository-extraction.md
@@ -26,3 +26,16 @@ versions, exact commits, stable principal identities, and source digests.
 mirror drifts from its external repository pin. The vendored mirrors remain in
 the main repository during behavioral migration so existing builds do not
 silently switch implementations.
+
+The pins bind on `main` only. They describe a release: which published
+repository commit each vendored mirror was cut from. So the check runs in the
+`c-repository-pins` workflow for pushes to `main` and for pull requests into
+`main`, and nowhere else. `testing` and the branches feeding it are the
+integration tip: their vendored source is expected to run ahead of any published
+repository commit, and enforcing the lock there would only demand a refresh
+after every edit under `src/core/**` or `src/modules/**`. For that reason
+`repository-lock-check` is not part of `make lint` or `make verify-local`; run
+`make repository-lock-check` when you want it. Refresh the pins with
+`python3 scripts/export_c_repositories.py --refresh-lock-root <repository-set>`
+as part of cutting a release, before opening the `testing` → `main` pull
+request.

--- a/src/Makefile
+++ b/src/Makefile
@@ -931,10 +931,14 @@ go-unit-tests:
 # forwarder and resolver because they have no dynamic-link policy to inspect.
 # Keep the phases explicit and ordered: build the authoritative `all` set, check
 # dynamic-link boundaries, inspect every shipping artifact, then run the suite.
+#
+# The repository lock is not verified here: it pins a release, binds only on
+# `main`, and verify-local runs on branches whose whole job is to move the
+# vendored source ahead of it. `make repository-lock-check` still runs it on
+# demand, and the c-repository-pins workflow runs it for `main`.
 verify-local: all
 	@$(MAKE) check-linking
 	@$(MAKE) lint
-	@cd .. && python3 -I scripts/check_c_repository_lock.py
 	@$(MAKE) TEST_RUN_JOBS=$(AIMEE_VERIFY_TEST_JOBS) unit-tests
 	@$(MAKE) go-unit-tests
 	@echo "verify-local: ok"
@@ -1869,7 +1873,14 @@ lint: BUS_BLAST_RADIUS_FLAGS := --allow-unbuilt
 # target-specific variable on `lint`, and target-specific variables do NOT cross
 # a recursive make, so bus-blast-radius-check would otherwise lose
 # --allow-unbuilt and start demanding the whole shipping set.
-LINT_CHECKS = subject-corpus-check native-tool-parity-check guidance-tool-parity-check optional-tool-ownership-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check repository-lock-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check model-fallback-shadow-check p1-tenant-guard-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check config-encapsulation-check deployed-image-check
+#
+# repository-lock-check is deliberately NOT here. It verifies release pins (which
+# external repository commit each vendored mirror was cut from), which only bind
+# on `main`; on every other branch the vendored source is meant to run ahead of
+# the lock, so running it in lint just demands a lock refresh after each edit
+# under src/core|modules/**. The c-repository-pins workflow runs it for `main`
+# and for PRs into `main`.
+LINT_CHECKS = subject-corpus-check native-tool-parity-check guidance-tool-parity-check optional-tool-ownership-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check model-fallback-shadow-check p1-tenant-guard-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check config-encapsulation-check deployed-image-check
 
 lint:
 	@fail=""; n=0; \

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -432,11 +432,22 @@ else
     fail "verify-local can race lint against a partial shipping build"
 fi
 
-if sed -n '/^verify-local:/,/^[^[:space:]#].*:/p' Makefile |
-   grep -qF 'python3 -I scripts/check_c_repository_lock.py'; then
-    pass "verify-local rejects stale extracted-repository source pins"
+# The extracted-repository pins record which published core/module repository
+# commit each vendored mirror was cut from, which is a fact about a RELEASE. They
+# bind on `main` alone: every other branch is meant to carry vendored source
+# ahead of the lock, so running the check there only demands a lock refresh after
+# each edit under src/core|modules/**. Guard the placement in both directions --
+# absent from the every-branch gates, present in the workflow under a main-only
+# condition -- so neither half can drift back on its own.
+if ! sed -n '/^verify-local:/,/^[^[:space:]#].*:/p' Makefile |
+     grep -qF 'python3 -I scripts/check_c_repository_lock.py' &&
+   ! grep '^LINT_CHECKS = ' Makefile | grep -qF 'repository-lock-check' &&
+   grep -B2 -F 'run: python3 -I scripts/check_c_repository_lock.py' \
+        ../.github/workflows/c-repositories.yml |
+     grep -qF "if: github.ref == 'refs/heads/main' || github.base_ref == 'main'"; then
+    pass "extracted-repository source pins are enforced for main alone"
 else
-    fail "verify-local can pass with stale extracted-repository source pins"
+    fail "extracted-repository source pins are enforced off main, or not on it"
 fi
 
 # Verification runs inside the server image, whose deployment posture is


### PR DESCRIPTION
The pins in `dependencies/aimee-repositories.lock.json` record which published
core/module repository commit each vendored mirror was cut from. That is a
release fact, but it was enforced on every branch.

`testing` carries vendored source ahead of any published commit by design, so
the check fired after any edit under `src/core/**` or `src/modules/**` and asked
for a lock refresh that said nothing about the change.

## What was enforcing it

Three places, not one. Gating only the workflow would not have helped, because
CI's `lint` job runs `cd src && make lint`, which ran the same check anyway.

| Where | Ran on | Now |
| --- | --- | --- |
| `c-repository-pins` workflow, `check_c_repository_lock.py` step | every push + PR | `main` pushes and PRs into `main` |
| `make lint` (`LINT_CHECKS`), which CI's lint job runs | every branch | removed |
| `make verify-local` | every local/agent verify | removed |

The gate is `if: github.ref == 'refs/heads/main' || github.base_ref == 'main'`.
Since `branch-policy.yml` allows PRs into `main` only from `testing`, the pins
are verified exactly once per release, on the `testing` -> `main` PR.

## Notes

- The `pins` **job** still runs everywhere; only the lock step is conditional, so
  any required-status-check context on `main` is unchanged.
- `scripts/check_c_repository_lock.py` is untouched, and
  `make repository-lock-check` still runs it on demand.
- By design, the lock now drifts on `testing` and the release PR fails until
  someone runs `export_c_repositories.py --refresh-lock-root <repository-set>`.
  That is documented in `docs/core/repository-extraction.md` as a release step.
  Automating it at release-cut time in `auto-release.yml` is a possible
  follow-up.

## Verification

- `make lint` gives all 55 checks passing (was 56 with the lock check).
- `python3 -I scripts/check_c_repository_lock.py` gives ok (1 core, 27 modules),
  so the target still works on demand.
- Workflow YAML parses with the `if` on the intended step.
- Unrelated and pre-existing: `scripts/refactor_baselines.py` reports surface
  drift at canonical line 18 on the clean `testing` tip, before these changes.
  Left alone.
