### PR TITLE
economizer: the gateway safety net actually runs

### DIFF
--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -513,7 +513,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "cc0914a4db8fcef1f481339ef6fc7207e036a06d24750db780f3a91f83e9504c",
+      "source_sha256": "e85bce52aeb948626286a5082f064277cf7c5e8653a9c42d838583aebb0515e3",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 27,

--- a/dependencies/aimee-repositories.lock.json
+++ b/dependencies/aimee-repositories.lock.json
@@ -513,7 +513,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "e85bce52aeb948626286a5082f064277cf7c5e8653a9c42d838583aebb0515e3",
+      "source_sha256": "1c531bcc3779f19d28c42e62903e37a35f4c2a60e354bb725561141ffaf71a75",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 27,

--- a/src/modules/economizer/economizer_module_client.c
+++ b/src/modules/economizer/economizer_module_client.c
@@ -203,6 +203,8 @@ int econ_module_reduce(const cJSON *messages, const char *system_prompt, econ_mo
       cJSON_AddStringToObject(payload, "closet_denylist", req->closet_denylist);
 
    add_int(payload, "turn", req->turn);
+   if (req->session_key && req->session_key[0])
+      cJSON_AddStringToObject(payload, "session_key", req->session_key);
    if (req->state && req->state[0])
       cJSON_AddStringToObject(payload, "state", req->state);
 
@@ -458,4 +460,49 @@ cJSON *econ_module_record_build(const cJSON *messages, int start_idx, int end_id
    record = cJSON_DetachItemFromObjectCaseSensitive(reply, "record");
    cJSON_Delete(reply);
    return record;
+}
+
+int econ_module_post_status(const char *session_key, int http_status, int mutated, int have_key,
+                            int ttl_ms, const char *stream_reason,
+                            econ_module_post_status_t *out)
+{
+   if (!out)
+      return 1;
+   memset(out, 0, sizeof(*out));
+
+   cJSON *payload = cJSON_CreateObject();
+   if (!payload)
+      return 1;
+   cJSON_AddStringToObject(payload, "session_key", session_key ? session_key : "");
+   cJSON_AddNumberToObject(payload, "http_status", http_status);
+   cJSON_AddBoolToObject(payload, "mutated", mutated ? 1 : 0);
+   cJSON_AddBoolToObject(payload, "have_key", have_key ? 1 : 0);
+   cJSON_AddNumberToObject(payload, "ttl_ms", ttl_ms);
+   if (stream_reason && stream_reason[0])
+      cJSON_AddStringToObject(payload, "stream_reason", stream_reason);
+
+   cJSON *reply = aimee_module_json_call(AIMEE_ECONOMIZER_EVENT_POST_STATUS,
+                                         AIMEE_ECONOMIZER_STAGE_POST_STATUS, payload,
+                                         ECON_MODULE_CALL_MAX_BODY, ECON_MODULE_CALL_TIMEOUT_MS,
+                                         NULL);
+   /* The JSON-call helper has deleted payload. */
+   if (!reply)
+      return 1; /* out stays zeroed: nothing owed, nothing claimed */
+
+   const cJSON *v = cJSON_GetObjectItemCaseSensitive(reply, "action");
+   /* Only the module's explicit "resend" earns a resend. An absent or unexpected
+    * action is not consent to send the request a second time. */
+   if (cJSON_IsString(v) && v->valuestring && strcmp(v->valuestring, "resend") == 0)
+      out->resend = 1;
+   if ((v = cJSON_GetObjectItemCaseSensitive(reply, "restore")) && cJSON_IsBool(v))
+      out->restore = cJSON_IsTrue(v) ? 1 : 0;
+   if ((v = cJSON_GetObjectItemCaseSensitive(reply, "disabled")) && cJSON_IsBool(v))
+      out->disabled = cJSON_IsTrue(v) ? 1 : 0;
+   if ((v = cJSON_GetObjectItemCaseSensitive(reply, "reason")) && cJSON_IsString(v))
+      snprintf(out->reason, sizeof(out->reason), "%s", v->valuestring);
+   if ((v = cJSON_GetObjectItemCaseSensitive(reply, "counter")) && cJSON_IsString(v))
+      snprintf(out->counter, sizeof(out->counter), "%s", v->valuestring);
+
+   cJSON_Delete(reply);
+   return 0;
 }

--- a/src/modules/economizer/economizer_module_client.c
+++ b/src/modules/economizer/economizer_module_client.c
@@ -463,8 +463,7 @@ cJSON *econ_module_record_build(const cJSON *messages, int start_idx, int end_id
 }
 
 int econ_module_post_status(const char *session_key, int http_status, int mutated, int have_key,
-                            int ttl_ms, const char *stream_reason,
-                            econ_module_post_status_t *out)
+                            int ttl_ms, const char *stream_reason, econ_module_post_status_t *out)
 {
    if (!out)
       return 1;
@@ -481,10 +480,9 @@ int econ_module_post_status(const char *session_key, int http_status, int mutate
    if (stream_reason && stream_reason[0])
       cJSON_AddStringToObject(payload, "stream_reason", stream_reason);
 
-   cJSON *reply = aimee_module_json_call(AIMEE_ECONOMIZER_EVENT_POST_STATUS,
-                                         AIMEE_ECONOMIZER_STAGE_POST_STATUS, payload,
-                                         ECON_MODULE_CALL_MAX_BODY, ECON_MODULE_CALL_TIMEOUT_MS,
-                                         NULL);
+   cJSON *reply = aimee_module_json_call(
+       AIMEE_ECONOMIZER_EVENT_POST_STATUS, AIMEE_ECONOMIZER_STAGE_POST_STATUS, payload,
+       ECON_MODULE_CALL_MAX_BODY, ECON_MODULE_CALL_TIMEOUT_MS, NULL);
    /* The JSON-call helper has deleted payload. */
    if (!reply)
       return 1; /* out stays zeroed: nothing owed, nothing claimed */

--- a/src/modules/economizer/economizer_module_client.h
+++ b/src/modules/economizer/economizer_module_client.h
@@ -22,8 +22,8 @@ extern "C"
 
 /* Fixed by the process contract at 4096 + ordinal*256 + stage; economizer is
  * inventory ordinal 27, so these are not a free choice. */
-#define AIMEE_ECONOMIZER_EVENT_REDUCE 11009u
-#define AIMEE_ECONOMIZER_STAGE_REDUCE 1u
+#define AIMEE_ECONOMIZER_EVENT_REDUCE       11009u
+#define AIMEE_ECONOMIZER_STAGE_REDUCE       1u
 #define AIMEE_ECONOMIZER_EVENT_JSON_COMPACT 11010u
 #define AIMEE_ECONOMIZER_STAGE_JSON_COMPACT 2u
 #define AIMEE_ECONOMIZER_EVENT_TOOL_RECALL  11011u

--- a/src/modules/economizer/economizer_module_client.h
+++ b/src/modules/economizer/economizer_module_client.h
@@ -32,6 +32,8 @@ extern "C"
 #define AIMEE_ECONOMIZER_STAGE_TOOL_STATS   4u
 #define AIMEE_ECONOMIZER_EVENT_RECORD_BUILD 11013u
 #define AIMEE_ECONOMIZER_STAGE_RECORD_BUILD 5u
+#define AIMEE_ECONOMIZER_EVENT_POST_STATUS  11014u
+#define AIMEE_ECONOMIZER_STAGE_POST_STATUS  6u
 
 #define ECON_MODULE_JSON_MAX_INPUT  (16u * 1024u * 1024u)
 #define ECON_MODULE_TOOL_OUTPUT_MAX (2u * 1024u * 1024u)
@@ -55,7 +57,11 @@ extern "C"
    } econ_module_seam_t;
 
    /* Everything the module needs, resolved by the caller. The module reads no
-    * ambient config and holds no state, so a request is self-contained. */
+    * ambient config, so a request is self-contained.
+    *
+    * It does hold ONE piece of state -- the gateway seam's circuit breaker, keyed
+    * by session_key below -- because a breaker written on one side of the bus and
+    * read on the other could never fire. Nothing else survives a call. */
    typedef struct
    {
       int history_fold;
@@ -89,6 +95,12 @@ extern "C"
       const char *closet_denylist; /* borrowed; may be NULL */
 
       int turn;
+      /* Whose lever this is, for the gateway seam's circuit breaker. NULL or
+       * empty means the request carried no resolvable identity: it reduces
+       * normally but can never read or trip a breaker, so one anonymous request
+       * cannot switch off another identity's session. Ignored on the delegate
+       * seam, which has no breaker. */
+      const char *session_key;
       /* Serialized reducer state from the previous turn, or NULL on the first.
        * Borrowed. */
       const char *state;
@@ -154,6 +166,31 @@ extern "C"
                           econ_module_result_t *out);
 
    void econ_module_result_free(econ_module_result_t *out);
+
+   /* What a dispatched gateway turn owes now its upstream status is known.
+    *
+    * The module decides AND owns the breaker the decision writes to; this only
+    * carries the answer back. The request body is deliberately not sent: restoring
+    * the pristine array and resending are the caller's, over a body it owns.
+    *
+    * `stream_reason` non-NULL selects the streaming path, where bytes have already
+    * reached the client so nothing can be restored or resent.
+    *
+    * Returns 0 when the module answered. On ANY failure returns non-zero and
+    * zeroes `out`, which reads as "nothing owed": an unreachable module must not
+    * invent a resend, and cannot have tripped a breaker it never saw. */
+   typedef struct
+   {
+      int resend;  /* 1 => restore the pristine array and send exactly once more */
+      int restore; /* 1 => put the pristine array back before anything else */
+      int disabled;
+      char reason[32];
+      char counter[40]; /* telemetry counter to increment; empty when none */
+   } econ_module_post_status_t;
+
+   int econ_module_post_status(const char *session_key, int http_status, int mutated, int have_key,
+                               int ttl_ms, const char *stream_reason,
+                               econ_module_post_status_t *out);
 
    /* Compact one strict JSON value in Go without changing any non-whitespace
     * source byte. Returns 0 with a newly allocated NUL-terminated buffer when

--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -190,12 +190,11 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
       return;
    ctx->have_key = 1;
 
-   /* Honor the circuit breaker: a disabled session is a pristine passthrough. */
-   if (msg_session_is_disabled(ctx->skey))
-   {
-      gw_stat_inc(GW_STAT_SESSION_DISABLED_BLOCKS);
-      return;
-   }
+   /* The circuit breaker is the module's, and it is consulted as part of the
+    * reduce call rather than read here: a breaker written on one side of the bus
+    * and read on the other would never fire, which is exactly how this seam's
+    * safety net came to be inert. A disabled session comes back as the
+    * session_disabled bypass below and is forwarded pristine. */
 
    cJSON *msgs = cJSON_GetObjectItemCaseSensitive(container, key);
    if (!cJSON_IsArray(msgs))
@@ -245,6 +244,7 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    mreq.recall_inject = config_fold_recall_inject();
    mreq.state = state_blob[0] ? state_blob : NULL;
    mreq.turn = gw_state_next_turn(state_blob);
+   mreq.session_key = ctx->skey; /* the module reads its breaker off this */
 
    char closet_denylist[CONFIG_COPY_MAX];
    config_coord_closet_denylist_copy(closet_denylist, sizeof(closet_denylist));
@@ -314,7 +314,13 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    const char *bypass = gw_module_bypass(rrc, mres.bypass);
    if (strcmp(bypass, gw_bypass_reason_str(GW_BYPASS_NONE)) != 0)
    {
-      gw_stat_inc_reason("hard_bypass", bypass);
+      /* A breaker block is its own counter, not a hard bypass: it is the lever
+       * working as designed, and folding it into hard_bypass would make a healthy
+       * tripped session look like a reduction fault. */
+      if (strcmp(bypass, "session_disabled") == 0)
+         gw_stat_inc(GW_STAT_SESSION_DISABLED_BLOCKS);
+      else
+         gw_stat_inc_reason("hard_bypass", bypass);
       gw_provenance_clear(&ctx->st);
       cJSON_Delete(reduced);
       econ_module_result_free(&mres);
@@ -340,52 +346,88 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    gw_stat_record_token_delta(baseline_tok, reduced_tok); /* sampled §4 */
 }
 
+/* Map the module's counter label onto the local enum.
+ *
+ * The module names the counter rather than the caller inferring it, so the
+ * decision and the thing it is recorded as cannot drift apart. An unrecognised
+ * label is DROPPED rather than guessed: a miscounted lever is worse than an
+ * uncounted one, and the label set is pinned on both sides by tests. */
+static int gw_stat_by_name(const char *name, gw_stat_t *out)
+{
+   static const struct
+   {
+      const char *name;
+      gw_stat_t stat;
+   } table[] = {
+       {"4xx_restore_resend", GW_STAT_4XX_RESTORE_RESEND},
+       {"5xx_disable", GW_STAT_5XX_DISABLE},
+       {"stream_error_disable", GW_STAT_STREAM_ERROR_DISABLE},
+       {"session_disabled_blocks", GW_STAT_SESSION_DISABLED_BLOCKS},
+   };
+   if (!name || !name[0] || !out)
+      return 1;
+   for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++)
+      if (strcmp(name, table[i].name) == 0)
+      {
+         *out = table[i].stat;
+         return 0;
+      }
+   return 1;
+}
+
+static void gw_stat_inc_name(const char *name)
+{
+   gw_stat_t which;
+   if (gw_stat_by_name(name, &which) == 0)
+      gw_stat_inc(which);
+}
+
 gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int http_status,
                                           gw_mutate_ctx_t *ctx)
 {
    if (!ctx || !ctx->mutated || !container || !key)
       return GW_POST_NONE;
 
-   int cls = http_status / 100;
-   if (cls == 4)
-   {
-      /* Restore the pristine original, repair defensively, disable the session for
-       * subsequent turns, clear provenance, and signal a single resend. */
-      if (ctx->pristine)
-      {
-         if (gw_replace_messages(container, key, ctx->pristine) == 0)
-         {
-            ctx->pristine = NULL; /* ownership moved back into container */
-            cJSON *restored = cJSON_GetObjectItemCaseSensitive(container, key);
-            if (restored)
-               message_history_repair(restored);
-         }
-      }
-      msg_session_disable(ctx->skey, ctx->ttl_ms, "4xx");
-      gw_provenance_clear(&ctx->st);
-      gw_stat_inc(GW_STAT_4XX_RESTORE_RESEND);
-      ctx->mutated = 0; /* the request is now pristine; no double handling */
-      return GW_POST_RESEND;
-   }
-   if (cls == 5)
-   {
-      /* Provider state is uncertain after a 5xx: disable, do NOT resend. */
-      msg_session_disable(ctx->skey, ctx->ttl_ms, "5xx");
-      gw_provenance_clear(&ctx->st);
-      gw_stat_inc(GW_STAT_5XX_DISABLE);
-      ctx->mutated = 0;
+   /* The decision and the breaker are the module's; what is left here is the
+    * request body and the socket. An unreachable module owes nothing, so the
+    * turn is left exactly as dispatched rather than half-handled. */
+   econ_module_post_status_t d;
+   if (econ_module_post_status(ctx->skey, http_status, ctx->mutated, ctx->have_key, ctx->ttl_ms,
+                               NULL, &d) != 0)
       return GW_POST_NONE;
+   if (!d.resend && !d.restore && !d.disabled && !d.counter[0])
+      return GW_POST_NONE; /* nothing owed: a 2xx, or a turn we never mutated */
+
+   if (d.restore && ctx->pristine)
+   {
+      if (gw_replace_messages(container, key, ctx->pristine) == 0)
+      {
+         ctx->pristine = NULL; /* ownership moved back into container */
+         cJSON *restored = cJSON_GetObjectItemCaseSensitive(container, key);
+         if (restored)
+            message_history_repair(restored);
+      }
    }
-   return GW_POST_NONE;
+   gw_provenance_clear(&ctx->st);
+   if (d.counter[0])
+      gw_stat_inc_name(d.counter);
+   ctx->mutated = 0; /* handled; never twice */
+   return d.resend ? GW_POST_RESEND : GW_POST_NONE;
 }
 
 void gw_stream_disable(gw_mutate_ctx_t *ctx, const char *reason)
 {
-   if (!ctx || !ctx->mutated || !ctx->have_key)
+   if (!ctx)
       return;
-   msg_session_disable(ctx->skey, ctx->ttl_ms, reason ? reason : "stream");
+   econ_module_post_status_t d;
+   if (econ_module_post_status(ctx->skey, 0, ctx->mutated, ctx->have_key, ctx->ttl_ms,
+                               reason ? reason : "stream", &d) != 0)
+      return;
+   if (!d.disabled && !d.counter[0])
+      return;
    gw_provenance_clear(&ctx->st);
-   gw_stat_inc(GW_STAT_STREAM_ERROR_DISABLE);
+   if (d.counter[0])
+      gw_stat_inc_name(d.counter);
    ctx->mutated = 0; /* one disable per turn; a later frame no-ops */
 }
 

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -569,6 +569,22 @@ static int messages_buffered(const char *body, char *resp, int cap)
    http_status = agent_http_post_bytes(url, auth, wire_body.data, wire_body.len, &response,
                                        ag->timeout_ms, extra[0] ? extra : NULL);
 
+   /* THE GATEWAY SAFETY NET. Until now nothing called this, so a reduced payload
+    * the provider rejected tripped no breaker and repeated on every later turn.
+    * The module decides and disables; the restore happens here because the body
+    * is ours.
+    *
+    * A 4xx also asks for ONE resend of this turn with the restored body, which
+    * this path cannot honour yet: the wire body is built once above and rebuilding
+    * it needs that block made re-runnable. The breaker still trips, so the failure
+    * stops repeating from the next turn -- the recovery of THIS turn is what is
+    * still missing. */
+   if (gw_buffered_after_status(req, "messages", http_status, &gwmc) == GW_POST_RESEND)
+      aimee_log(LOG_INFO, "economizer.gateway",
+                "seam=gateway upstream=%d restored to pristine and breaker tripped; the "
+                "single resend of this turn is not wired yet",
+                http_status);
+
    if (http_status != 200 || !response)
    {
       /* Exact parity: relay the upstream status + Anthropic error body verbatim

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1231,6 +1231,17 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    int http_status = http_retry_post_context_bytes(url, auth_header, wire_body.data, wire_body.len,
                                                    &response_body, agent->timeout_ms, extra_headers,
                                                    ra, rb, rm, agent->provider, agent->model, NULL);
+   /* The gateway safety net, before mbox is released: it holds the array the
+    * restore writes back into. The module decides and trips its breaker, so a
+    * reduction the provider rejects stops repeating on later turns. The single
+    * resend of THIS turn is not wired here either -- same reason as the Anthropic
+    * buffered path: the wire body is built once above. */
+   if (gw_buffered_after_status(mbox, "input", http_status, &gwmc) == GW_POST_RESEND)
+      aimee_log(LOG_INFO, "economizer.gateway",
+                "seam=gateway upstream=%d restored to pristine and breaker tripped; the "
+                "single resend of this turn is not wired yet",
+                http_status);
+
    free(body);
    wire_fence_destroy(wire_snapshot);
 

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -75,72 +75,39 @@ static void make_mutated(cJSON **container, gw_mutate_ctx_t *ctx, const char *sk
    cJSON_Delete(pc);
 }
 
-static void test_4xx_restore_resend(void)
+/* The 4xx/5xx decision and the circuit breaker moved into the Go economizer
+ * module, where they are covered by breaker_test.go (including the round trip
+ * that proves a trip blocks the next reduction). A unit test cannot serve a bus
+ * stage, so what is pinned HERE is the half C kept: the FAIL-SAFE.
+ *
+ * With no module reachable the seam must do nothing at all rather than
+ * half-handle the turn. Inventing a resend would send a customer request twice;
+ * claiming a disable would record a breaker that was never set. Both are worse
+ * than leaving the failed turn exactly as dispatched. */
+static void test_post_status_is_inert_without_a_module(void)
 {
-   msg_session_reset();
    gw_stat_reset();
    cJSON *c;
    gw_mutate_ctx_t ctx;
-   const char *skey = "0011223344556677";
-   make_mutated(&c, &ctx, skey);
+   make_mutated(&c, &ctx, "0011223344556677");
 
-   assert(strcmp(first_content(c), "reduced") == 0);
-   gw_post_action_t act = gw_buffered_after_status(c, "messages", 413, &ctx);
-   assert(act == GW_POST_RESEND);
-   assert(strcmp(first_content(c), "pristine") == 0); /* restored */
-   assert(msg_session_is_disabled(skey) == 1);        /* disabled */
-   assert(ctx.st.reduced == 0);                       /* provenance cleared */
-   assert(ctx.mutated == 0);                          /* no double handling */
-   assert(gw_stat_get(GW_STAT_4XX_RESTORE_RESEND) == 1);
-   assert(gw_stat_get_reason("session_disabled_set", "4xx") == 1);
-
-   gw_mutate_ctx_free(&ctx);
-   cJSON_Delete(c);
-}
-
-static void test_5xx_disable_no_resend(void)
-{
-   msg_session_reset();
-   gw_stat_reset();
-   cJSON *c;
-   gw_mutate_ctx_t ctx;
-   const char *skey = "8899aabbccddeeff";
-   make_mutated(&c, &ctx, skey);
-
-   gw_post_action_t act = gw_buffered_after_status(c, "messages", 503, &ctx);
-   assert(act == GW_POST_NONE);
-   assert(strcmp(first_content(c), "reduced") == 0); /* NOT restored — no resend */
-   assert(msg_session_is_disabled(skey) == 1);       /* disabled */
-   assert(ctx.st.reduced == 0);
-   assert(gw_stat_get(GW_STAT_5XX_DISABLE) == 1);
-   assert(gw_stat_get_reason("session_disabled_set", "5xx") == 1);
-
-   gw_mutate_ctx_free(&ctx);
-   cJSON_Delete(c);
-}
-
-static void test_2xx_and_nonmutated_noop(void)
-{
-   msg_session_reset();
-   gw_stat_reset();
-   cJSON *c;
-   gw_mutate_ctx_t ctx;
-   const char *skey = "1234567890abcdef";
-   make_mutated(&c, &ctx, skey);
-
-   /* 200: no state change, no disable, stays reduced */
-   assert(gw_buffered_after_status(c, "messages", 200, &ctx) == GW_POST_NONE);
-   assert(strcmp(first_content(c), "reduced") == 0);
-   assert(msg_session_is_disabled(skey) == 0);
+   assert(gw_buffered_after_status(c, "messages", 413, &ctx) == GW_POST_NONE);
+   assert(strcmp(first_content(c), "reduced") == 0); /* body left as dispatched */
+   assert(ctx.mutated == 1);                         /* the turn was not consumed */
+   assert(gw_stat_get(GW_STAT_4XX_RESTORE_RESEND) == 0);
+   assert(gw_stat_get(GW_STAT_5XX_DISABLE) == 0);
    gw_mutate_ctx_free(&ctx);
    cJSON_Delete(c);
 
-   /* a non-mutated request is entirely inert */
-   cJSON *c2 = container_with("reduced");
+   /* A 5xx is equally inert, and so is the streaming path. */
+   cJSON *c2;
    gw_mutate_ctx_t ctx2;
-   gw_mutate_ctx_init(&ctx2);
-   assert(gw_buffered_after_status(c2, "messages", 400, &ctx2) == GW_POST_NONE);
-   assert(msg_session_count() == 0);
+   make_mutated(&c2, &ctx2, "8899aabbccddeeff");
+   assert(gw_buffered_after_status(c2, "messages", 503, &ctx2) == GW_POST_NONE);
+   gw_stream_disable(&ctx2, "stream_invalid_request");
+   assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 0);
+   assert(ctx2.mutated == 1);
+   assert(msg_session_count() == 0); /* nothing wrote a breaker anywhere */
    gw_mutate_ctx_free(&ctx2);
    cJSON_Delete(c2);
 }
@@ -161,34 +128,6 @@ static void test_dark_default_and_identityless(void)
    assert(strcmp(first_content(c), "orig") == 0);
    gw_mutate_ctx_free(&ctx);
    cJSON_Delete(c);
-}
-
-static void test_stream_disable(void)
-{
-   msg_session_reset();
-   gw_stat_reset();
-   cJSON *c;
-   gw_mutate_ctx_t ctx;
-   const char *skey = "aabbccddeeff0011";
-   make_mutated(&c, &ctx, skey);
-   cJSON_Delete(c); /* streaming holds no restore need */
-
-   /* an invalid-request frame disables; a second call is idempotent (mutated flips off) */
-   gw_stream_disable(&ctx, "stream_invalid_request");
-   assert(msg_session_is_disabled(skey) == 1);
-   assert(ctx.st.reduced == 0);
-   assert(ctx.mutated == 0);
-   assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 1);
-   gw_stream_disable(&ctx, "stream_invalid_request"); /* no-op now */
-   assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 1);
-   gw_mutate_ctx_free(&ctx);
-
-   /* a non-mutated ctx never disables */
-   gw_mutate_ctx_t idle;
-   gw_mutate_ctx_init(&idle);
-   gw_stream_disable(&idle, "stream_invalid_request");
-   assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 1);
-   gw_mutate_ctx_free(&idle);
 }
 
 static void test_stream_error_classify(void)
@@ -324,11 +263,8 @@ int main(void)
       platform_unsetenv("AIMEE_HOME");
       platform_setenv("AIMEE_NO_CACHE", "1");
    }
-   test_4xx_restore_resend();
-   test_5xx_disable_no_resend();
-   test_2xx_and_nonmutated_noop();
+   test_post_status_is_inert_without_a_module();
    test_dark_default_and_identityless();
-   test_stream_disable();
    test_stream_error_classify();
    test_token_delta_sampling();
    test_no_behavior_change_when_off();


### PR DESCRIPTION
Slice 5b. #2664 gave the module the decision and the breaker; nothing called it,
so the net was still inert. This connects it.

WHAT WAS BROKEN. gw_buffered_after_status and gw_stream_disable had no
production caller at all -- only their own tests and a weak stub. A reduced
payload the provider rejected therefore tripped no breaker, and since
msg_session_disable was reachable only from those dead paths, the pre-send
msg_session_is_disabled read was permanently false. The lever could not switch
itself off, so a bad reduction repeated on every turn of that session.

WHAT NOW HAPPENS. The three dispatch sites -- anthropic_http.c buffered and
streaming, openai_chat.c buffered -- call the seam once the upstream status is
known. It asks the module (stage 6), which decides and writes its own breaker,
and C carries out the half it owns: restoring the body, clearing provenance and
recording the counter the module named. The pre-send breaker read moved into the
reduce call for the same reason the write did: read on one side of the bus and
written on the other, it could never fire.

FAIL-SAFE. An unreachable module owes nothing. econ_module_post_status zeroes
its result and returns non-zero, and the seam then leaves the turn exactly as
dispatched: no invented resend, which would send a customer request twice, and
no claimed disable, which would record a breaker that was never set. That is
what the rewritten wire test pins, because a unit test cannot serve a bus stage
-- the decision itself is covered in Go by breaker_test.go, including the round
trip proving a trip blocks the next reduction.

A breaker block is now its own counter rather than a hard_bypass, so a healthy
tripped session stops reading as a reduction fault.

STILL MISSING, deliberately: the single RESEND of the CURRENT turn. The module
asks for it on a 4xx and C logs that it cannot honour it, because the wire body
is built once and rebuilding it means making that block re-runnable -- a
refactor that should not ride along with a behaviour change. The breaker still
trips, so the failure stops repeating from the next turn; what is not recovered
is the turn that failed.

Also still standing: msg_session_disable/is_disabled now have no production
caller (key_resolve still does), so the C breaker table is dead weight. Pure
removal, kept out of this commit the same way #2663 was kept out of the cutover
that preceded it.

aimee-server and aimee-kb build under -Werror; gateway_mutate, gateway_mutate_wire
and msg_session_disable pass; full Go suite passes; descriptors and lock current.