### PR TITLE
docs: archive delivered content-scope identity map

### DIFF
--- a/docs/proposals/done/per-user-content-scope-identity-map.md
+++ b/docs/proposals/done/per-user-content-scope-identity-map.md
@@ -1,6 +1,14 @@
 # The KB boundary already has an identity; preserve it for content scope
 
-Amends `per-user-content-scope-reader-identity.md`. The earlier framing treated every ingress surface
+- **State:** DONE — all six bounded slices delivered and archived 2026-08-15.
+- **Owner:** KB content scope.
+
+> **Archived after delivery.** The identity map, caller-context propagation, project-bound
+> maintenance authority, readiness gate, and live reader-isolation proof are present on `testing`.
+> Content RLS remains operator-enabled after attribution, exactly as this record requires.
+
+Amends [`per-user-content-scope-reader-identity.md`](../pending/per-user-content-scope-reader-identity.md).
+The earlier framing treated every ingress surface
 as if it connected to aimee-kb and therefore needed to carry independently verifiable proof to it.
 That is the wrong boundary: CLI, web and MCP terminate at aimee-server. Only aimee-server connects to
 aimee-kb.
@@ -124,10 +132,20 @@ observable when an operator subsequently enables content scope.
 - **Background decision remains explicit.** The separately selected #2646 policy is implemented and
   tested before the readiness marker is set; this proposal does not preselect it.
 
-## Status
+## Delivery evidence
 
 Implemented cumulatively through slice 6: #2656 supplied pair-specific mTLS enforcement, ingress
 identity convergence, and caller-scoped reads; #2658 and #2661 supplied exact-project maintenance;
 the final slice records reader readiness after live RLS isolation coverage. Schema application still
 leaves content RLS disabled. An operator must explicitly attribute every content-bearing code project
 and call `kb_content_scope_enable()`; the function refuses an incomplete backfill.
+
+- [`kb_project_visible`](../../../src/db2/schema.sql#L2144) centralizes project visibility, while
+  [`kb_content_scope_enable`](../../../src/db2/schema.sql#L2225) fails closed until readers and
+  attribution are ready.
+- [`db2_maintenance_scope_begin`](../../../src/db2/db2_tenant.c#L197) owns the closed-name,
+  exact-project maintenance context and transaction-local cleanup.
+- [`test_content_scope_pg.c`](../../../src/tests/test_content_scope_pg.c#L140) proves the predicate,
+  readiness marker, maintenance isolation, re-embed boundary, pooled-context cleanup, and ordinary
+  two-reader search isolation; the end-to-end reader proof begins at
+  [`test_content_scope_pg.c:480`](../../../src/tests/test_content_scope_pg.c#L480).

--- a/docs/proposals/pending/per-user-content-scope-reader-identity.md
+++ b/docs/proposals/pending/per-user-content-scope-reader-identity.md
@@ -133,4 +133,5 @@ thinclient/MCP identity convergence, and caller-scoped reads; #2658 and #2661 su
 background maintenance; the final slice adds live two-user/two-team ordinary-search RLS coverage.
 Schema application records `content_scope_reader_ready = '1'` but does not enable content RLS. The
 operator must finish attribution and call `kb_content_scope_enable()`; incomplete attribution still
-fails closed. The companion identity map records why no additional proof mechanism is required.
+fails closed. The [archived companion identity map](../done/per-user-content-scope-identity-map.md)
+records why no additional proof mechanism is required.


### PR DESCRIPTION
## Summary

- move the delivered per-user content-scope identity map from pending to done
- record the schema, maintenance, readiness, and live reader-isolation evidence
- repair the pending companion proposal's link to the archived identity map

## Why

The proposal's six bounded delivery slices are already present on `testing` through the merged implementation work and live PostgreSQL isolation coverage. The archive record preserves the deliberate operator gate: content RLS remains disabled until attribution is complete and `kb_content_scope_enable()` succeeds.

## Impact

Documentation and proposal state only; no runtime behavior changes.

## Validation

- `python3 scripts/check-proposal-links.py`
- `python3 scripts/check-proposal-reconcile.py` (report-only pre-existing warnings/findings)
- `make -s -C src lint` (all 55 checks passed)
- `git diff --cached --check`
