### PR TITLE
economizer: delete the C circuit breaker the module replaced

### DIFF
--- a/src/headers/msg_session_disable.h
+++ b/src/headers/msg_session_disable.h
@@ -1,11 +1,14 @@
-/* msg_session_disable.h: the per-session circuit breaker for the economizer
- * gateway-mutation path (proposal economizer-gateway-mutation §2.4). A bounded,
- * process-local, TTL'd set of session keys whose gateway reduction has been
- * disabled because a mutated request failed upstream. Mutation is only ever
- * attempted for a session whose key is RESOLVABLE from a per-identity credential —
- * there is no shared "_anonymous" bucket, so one caller's failure can never disable
- * reduction for an unrelated caller (§7 R5). Process-local; no cross-process
- * replication in v1. All entry points are thread-safe (one internal mutex). */
+/* msg_session_disable.h: the per-identity session key the economizer's
+ * gateway-mutation path is keyed by (proposal economizer-gateway-mutation §2.4).
+ *
+ * The circuit breaker itself is gone from C. It is state, so it lives in the Go
+ * economizer module now, which is what makes it work at all: written on one side
+ * of the bus and read on the other, a trip could never fire.
+ *
+ * What remains is the key derivation, and its property still matters. A key is
+ * only ever RESOLVABLE from a per-identity credential — there is no shared
+ * "_anonymous" bucket — so one caller's failure can never disable reduction for an
+ * unrelated caller (§7 R5). Pure and thread-safe: no state, no lock. */
 #ifndef DEC_MSG_SESSION_DISABLE_H
 #define DEC_MSG_SESSION_DISABLE_H 1
 
@@ -49,21 +52,6 @@ extern "C"
    msg_session_key_status_t msg_session_key_resolve(const char *hdr_session_id, const char *bearer,
                                                     const char *auth_identity,
                                                     char key[MSG_SESSION_KEY_LEN]);
-
-   /* Is `key` currently disabled (present and not expired)? Lazily clears an expired
-    * hit. Safe with any NUL-terminated string; a non-resolved key is never disabled. */
-   int msg_session_is_disabled(const char *key);
-
-   /* Disable `key` for ttl_ms with a stable static-literal `reason` (stored by
-    * pointer). ttl_ms must be > 0 (a non-positive ttl is ignored — the caller is
-    * expected to have failed startup validation). Triggers an insert-time sweep when
-    * the table is more than half full, and evicts (expired-first, else
-    * oldest-inserted) when at capacity. */
-   void msg_session_disable(const char *key, int ttl_ms, const char *reason);
-
-   /* Introspection / test support. */
-   size_t msg_session_count(void); /* live (non-expired) entry count */
-   void msg_session_reset(void);   /* clear the whole table + timers (test-only) */
 
 #ifdef __cplusplus
 }

--- a/src/server/msg_session_disable.c
+++ b/src/server/msg_session_disable.c
@@ -1,232 +1,24 @@
-/* msg_session_disable.c: see msg_session_disable.h. Bounded open-addressing hash
- * set of disabled session keys with per-entry TTL. One global mutex guards the
- * table; lookups probe, expiry is lazy on hit, and a full-rebuild sweep (rate-
- * limited to 60s, or forced when the table crosses cap/2 on insert) reclaims
- * expired entries and tombstones. Eviction at capacity is expired-first then
- * oldest-inserted, so a live disable is never silently re-enabled while any expired
- * entry remains to reclaim. */
+/* msg_session_disable.c: see msg_session_disable.h. Derives the per-identity
+ * session key the gateway seam is keyed by.
+ *
+ * The circuit breaker this file is named after has MOVED: it is state, so it now
+ * lives in the Go economizer module (server-go/modules/economizer/breaker.go),
+ * where the side that writes it and the side that reads it are the same side of
+ * the bus. What remains is the key derivation, which is not state -- it is a pure
+ * function of the request's identity material. The file keeps the old name for
+ * now; renaming it is a separate, mechanical change. */
 #include "msg_session_disable.h"
 
 #include <ctype.h>
-#include <pthread.h>
 #include <stdio.h> /* snprintf — do not rely on a transitive include */
 #include <string.h>
 
-#include "gw_mutate_stats.h"
 #include "harness_memory_common.h" /* hmem_sha256_hex — vendored SHA-256, no OpenSSL */
-#include "util.h"                  /* util_now_ms (monotonic) */
 
 /* The session key is the first 16 hex of a SHA-256 digest; bind that assumption to
  * the vendored helper's output width so a silent migration to a different digest
  * can't slip a truncated wrong-hash key through. */
 _Static_assert(HMEM_HASH_HEX_LEN >= 17, "session key needs >= 16 hex chars + NUL");
-
-#define MSG_SESSION_SLOTS             16384 /* power of two > cap, load factor ~0.61 at cap */
-#define MSG_SESSION_CAP               10000
-#define MSG_SESSION_SWEEP_INTERVAL_MS 60000
-
-enum
-{
-   SLOT_EMPTY = 0,
-   SLOT_USED = 1,
-   SLOT_TOMB = 2
-};
-
-typedef struct
-{
-   char key[MSG_SESSION_KEY_LEN];
-   int state;
-   long long expires_ms;
-   const char *reason; /* static literal, stored by pointer */
-   unsigned long long seq;
-} slot_t;
-
-static slot_t g_tbl[MSG_SESSION_SLOTS];
-static int g_used;
-static unsigned long long g_seq;
-static long long g_last_sweep_ms;
-static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
-
-static unsigned long hash_key(const char *key)
-{
-   /* FNV-1a over the (<=16 char) key. */
-   unsigned long h = 2166136261UL;
-   for (const unsigned char *p = (const unsigned char *)key; *p; p++)
-   {
-      h ^= *p;
-      h *= 16777619UL;
-   }
-   return h & (MSG_SESSION_SLOTS - 1);
-}
-
-/* Locate the slot holding `key`, or -1. Caller holds g_lock. */
-static int find_slot_locked(const char *key)
-{
-   unsigned long i = hash_key(key);
-   for (int probe = 0; probe < MSG_SESSION_SLOTS; probe++)
-   {
-      slot_t *s = &g_tbl[i];
-      if (s->state == SLOT_EMPTY)
-         return -1;
-      if (s->state == SLOT_USED && strncmp(s->key, key, MSG_SESSION_KEY_LEN) == 0)
-         return (int)i;
-      i = (i + 1) & (MSG_SESSION_SLOTS - 1);
-   }
-   return -1;
-}
-
-/* Full rebuild: drop expired + tombstones, rehash live entries into a fresh table.
- * Caller holds g_lock. now_ms is the current monotonic clock. */
-static void sweep_now_locked(long long now_ms)
-{
-   static slot_t rebuilt[MSG_SESSION_SLOTS];
-   memset(rebuilt, 0, sizeof(rebuilt));
-   int used = 0;
-   for (int k = 0; k < MSG_SESSION_SLOTS; k++)
-   {
-      slot_t *s = &g_tbl[k];
-      if (s->state != SLOT_USED || s->expires_ms <= now_ms)
-         continue;
-      unsigned long i = hash_key(s->key);
-      while (rebuilt[i].state == SLOT_USED)
-         i = (i + 1) & (MSG_SESSION_SLOTS - 1);
-      rebuilt[i] = *s;
-      used++;
-   }
-   memcpy(g_tbl, rebuilt, sizeof(g_tbl));
-   g_used = used;
-   g_last_sweep_ms = now_ms;
-}
-
-/* Evict the oldest-inserted live entry (all remaining are live post-sweep). Caller
- * holds g_lock. */
-static void evict_oldest_locked(void)
-{
-   int oldest = -1;
-   unsigned long long best = 0;
-   for (int k = 0; k < MSG_SESSION_SLOTS; k++)
-   {
-      if (g_tbl[k].state != SLOT_USED)
-         continue;
-      if (oldest < 0 || g_tbl[k].seq < best)
-      {
-         best = g_tbl[k].seq;
-         oldest = k;
-      }
-   }
-   if (oldest >= 0)
-   {
-      g_tbl[oldest].state = SLOT_TOMB;
-      g_used--;
-   }
-}
-
-int msg_session_is_disabled(const char *key)
-{
-   if (!key || !key[0])
-      return 0;
-   long long now = util_now_ms();
-   int disabled = 0;
-   pthread_mutex_lock(&g_lock);
-   int idx = find_slot_locked(key);
-   if (idx >= 0)
-   {
-      if (g_tbl[idx].expires_ms > now)
-         disabled = 1;
-      else
-      {
-         g_tbl[idx].state = SLOT_TOMB; /* lazy expiry */
-         g_used--;
-      }
-   }
-   pthread_mutex_unlock(&g_lock);
-   return disabled;
-}
-
-void msg_session_disable(const char *key, int ttl_ms, const char *reason)
-{
-   /* Keys are always the 16-hex output of msg_session_key_resolve; reject anything
-    * else at this cold (failure-path) call site so a mis-sized key can't be silently
-    * truncated by the insert snprintf into a form that lookups then never match. */
-   if (!key || strnlen(key, MSG_SESSION_KEY_LEN) != 16 || ttl_ms <= 0)
-      return;
-   long long now = util_now_ms();
-   pthread_mutex_lock(&g_lock);
-
-   int idx = find_slot_locked(key);
-   if (idx >= 0)
-   {
-      /* Re-disable an existing session: refresh window + reason. */
-      g_tbl[idx].expires_ms = now + ttl_ms;
-      g_tbl[idx].reason = reason;
-      pthread_mutex_unlock(&g_lock);
-      gw_stat_inc_reason("session_disabled_set", reason ? reason : "unknown");
-      return;
-   }
-
-   /* Reclaim before inserting when more than half full (proposal §2.4 cadence), and
-    * always sweep immediately before an eviction so expired entries are dropped
-    * first and a LIVE disable is never evicted while an expired one remains. The
-    * >cap/2 rebuild is O(slots) per insert, but that only bites once >5000 sessions
-    * are concurrently disabled — a catastrophic incident the breaker exists for, and
-    * bounded because the table can never exceed cap. */
-   if (g_used > MSG_SESSION_CAP / 2)
-      sweep_now_locked(now);
-   if (g_used >= MSG_SESSION_CAP)
-      evict_oldest_locked();
-
-   /* Insert at the first tombstone or empty slot on the probe chain. */
-   unsigned long i = hash_key(key);
-   int target = -1;
-   for (int probe = 0; probe < MSG_SESSION_SLOTS; probe++)
-   {
-      if (g_tbl[i].state == SLOT_EMPTY)
-      {
-         if (target < 0)
-            target = (int)i;
-         break;
-      }
-      if (g_tbl[i].state == SLOT_TOMB && target < 0)
-         target = (int)i;
-      i = (i + 1) & (MSG_SESSION_SLOTS - 1);
-   }
-   if (target >= 0)
-   {
-      slot_t *s = &g_tbl[target];
-      snprintf(s->key, sizeof(s->key), "%s", key);
-      s->state = SLOT_USED;
-      s->expires_ms = now + ttl_ms;
-      s->reason = reason;
-      s->seq = ++g_seq;
-      g_used++;
-   }
-   pthread_mutex_unlock(&g_lock);
-   gw_stat_inc_reason("session_disabled_set", reason ? reason : "unknown");
-}
-
-size_t msg_session_count(void)
-{
-   long long now = util_now_ms();
-   size_t n = 0;
-   pthread_mutex_lock(&g_lock);
-   for (int k = 0; k < MSG_SESSION_SLOTS; k++)
-      if (g_tbl[k].state == SLOT_USED && g_tbl[k].expires_ms > now)
-         n++;
-   pthread_mutex_unlock(&g_lock);
-   return n;
-}
-
-void msg_session_reset(void)
-{
-   pthread_mutex_lock(&g_lock);
-   memset(g_tbl, 0, sizeof(g_tbl));
-   g_used = 0;
-   g_seq = 0;
-   g_last_sweep_ms = 0;
-   pthread_mutex_unlock(&g_lock);
-}
-
-/* --- session-key resolution ------------------------------------------------ */
 
 static int is_16_lower_hex(const char *s)
 {

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -107,7 +107,6 @@ static void test_post_status_is_inert_without_a_module(void)
    gw_stream_disable(&ctx2, "stream_invalid_request");
    assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 0);
    assert(ctx2.mutated == 1);
-   assert(msg_session_count() == 0); /* nothing wrote a breaker anywhere */
    gw_mutate_ctx_free(&ctx2);
    cJSON_Delete(c2);
 }

--- a/src/tests/test_msg_session_disable.c
+++ b/src/tests/test_msg_session_disable.c
@@ -11,13 +11,6 @@
 #include "harness_memory_common.h"
 #include "msg_session_disable.h"
 
-static void sleep_ms(int ms)
-{
-   struct timespec ts = {ms / 1000, (long)(ms % 1000) * 1000000L};
-   nanosleep(&ts, NULL);
-}
-
-/* First 16 hex of SHA-256(s), into out[17]. */
 static void sha16(const char *s, char out[MSG_SESSION_KEY_LEN])
 {
    char full[HMEM_HASH_HEX_LEN];
@@ -96,92 +89,10 @@ static void test_resolve(void)
    assert(strcmp(key, expect) == 0);
 }
 
-static void test_disable_ttl(void)
-{
-   msg_session_reset();
-   gw_stat_reset();
-
-   char a[MSG_SESSION_KEY_LEN], b[MSG_SESSION_KEY_LEN];
-   sha16("sessA", a);
-   sha16("sessB", b);
-
-   assert(msg_session_is_disabled(a) == 0);
-   msg_session_disable(a, 3600000, "4xx");
-   assert(msg_session_is_disabled(a) == 1);
-   assert(msg_session_is_disabled(b) == 0); /* distinct sessions independent */
-   assert(msg_session_count() == 1);
-   assert(gw_stat_get_reason("session_disabled_set", "4xx") == 1);
-
-   /* identity-less / empty key never disables */
-   msg_session_disable("", 3600000, "x");
-   assert(msg_session_is_disabled("") == 0);
-
-   /* TTL expiry: tiny ttl -> expired after a short sleep, lazily cleared on read */
-   msg_session_disable(b, 1, "5xx");
-   sleep_ms(15);
-   assert(msg_session_is_disabled(b) == 0);
-   assert(msg_session_count() == 1); /* only a remains */
-
-   /* ttl<=0 is ignored */
-   char c[MSG_SESSION_KEY_LEN];
-   sha16("sessC", c);
-   msg_session_disable(c, 0, "x");
-   msg_session_disable(c, -5, "x");
-   assert(msg_session_is_disabled(c) == 0);
-}
-
-static void test_eviction(void)
-{
-   msg_session_reset();
-   char key[MSG_SESSION_KEY_LEN];
-
-   /* Fill to capacity with live entries; one more must not exceed the cap, and the
-    * OLDEST-inserted live entry is the one evicted. */
-   snprintf(key, sizeof(key), "%016x", 0);
-   char first[MSG_SESSION_KEY_LEN];
-   memcpy(first, key, sizeof(key));
-   for (int i = 0; i < 10000; i++)
-   {
-      snprintf(key, sizeof(key), "%016x", i);
-      msg_session_disable(key, 3600000, "4xx");
-   }
-   assert(msg_session_count() == 10000);
-   assert(msg_session_is_disabled(first) == 1);
-
-   snprintf(key, sizeof(key), "%016x", 10000); /* the 10001st */
-   msg_session_disable(key, 3600000, "4xx");
-   assert(msg_session_count() == 10000);        /* bounded */
-   assert(msg_session_is_disabled(first) == 0); /* oldest evicted */
-   assert(msg_session_is_disabled(key) == 1);   /* newest present */
-}
-
-static void test_sweep_reclaims_expired(void)
-{
-   msg_session_reset();
-   char key[MSG_SESSION_KEY_LEN];
-
-   /* Insert > cap/2 short-lived entries, let them expire, then one more insert must
-    * trigger the insert-time sweep (size > cap/2) and reclaim them. */
-   for (int i = 0; i < 5001; i++)
-   {
-      snprintf(key, sizeof(key), "%016x", i);
-      msg_session_disable(key, 1, "5xx");
-   }
-   sleep_ms(20);
-   snprintf(key, sizeof(key), "%016x", 900000);
-   msg_session_disable(key, 3600000, "4xx");
-   /* the sweep dropped the 5001 expired; only the fresh one survives */
-   assert(msg_session_count() == 1);
-   assert(msg_session_is_disabled(key) == 1);
-}
-
 int main(void)
 {
    printf("msg_session_disable: ");
    test_resolve();
-   test_disable_ttl();
-   test_eviction();
-   test_sweep_reclaims_expired();
    printf("ok\n");
    return 0;
 }


### PR DESCRIPTION
Slice 6, the removal #2672 earned. The breaker now lives in the Go economizer
module (breaker.go), and with the seam wired to stage 6 nothing in C writes or
reads the old table any more: msg_session_disable and msg_session_is_disabled
had no production caller left, only their own tests.

Gone: the bounded open-addressing table and everything that served it -- the
slot array, the mutex, hash_key, find_slot_locked, sweep_now_locked,
evict_oldest_locked, the disable/is_disabled entry points and the count/reset
test hooks. With them go the pthread, gw_mutate_stats and util includes, which
existed only for the table.

KEPT, because it is still called from gw_buffered_mutate and is not state:
msg_session_key_resolve and its is_16_lower_hex guard. The property that
mattered survives with it -- a key is only ever resolvable from a per-identity
credential, with no shared anonymous bucket, so one caller can never disable
reduction for an unrelated caller (§7 R5).

The file and header keep the msg_session_disable name while holding no disable.
That is misleading and worth fixing, but a rename touches every include of it
and is mechanical, so it is left as its own change rather than buried here.

Net -309 lines. The tests for the deleted table go with it; test_resolve stays
and still passes.

aimee-server and aimee-kb build under -Werror, gateway_mutate,
gateway_mutate_wire and msg_session_disable all pass, and lint (clang-format)
is clean. No module-owned file changed, so the lock is untouched.

---
Re-lands #2673, which never reached `testing`: it was stacked on `agent/econ-gateway-safety-net` (#2672) and merged into that branch *after* #2672 had already merged, so its content stopped there. Same single commit, cherry-picked onto current `testing` and re-verified.