### PR TITLE
docs: archive delivered content-scope reader identity

### DIFF
--- a/docs/proposals/done/per-user-content-scope-identity-map.md
+++ b/docs/proposals/done/per-user-content-scope-identity-map.md
@@ -7,7 +7,7 @@
 > maintenance authority, readiness gate, and live reader-isolation proof are present on `testing`.
 > Content RLS remains operator-enabled after attribution, exactly as this record requires.
 
-Amends [`per-user-content-scope-reader-identity.md`](../pending/per-user-content-scope-reader-identity.md).
+Amends [`per-user-content-scope-reader-identity.md`](per-user-content-scope-reader-identity.md).
 The earlier framing treated every ingress surface
 as if it connected to aimee-kb and therefore needed to carry independently verifiable proof to it.
 That is the wrong boundary: CLI, web and MCP terminate at aimee-server. Only aimee-server connects to

--- a/docs/proposals/done/per-user-content-scope-reader-identity.md
+++ b/docs/proposals/done/per-user-content-scope-reader-identity.md
@@ -1,6 +1,14 @@
 # Getting caller context to the KB, so content scope can be switched on
 
-Companion to `per-user-content-scope-visibility.md`. That proposal built the database half; this one
+- **State:** DONE — all six bounded reader-context slices delivered and archived 2026-08-15.
+- **Owner:** KB request identity and content scope.
+
+> **Archived after delivery.** This record covers the authenticated request-context half only. The
+> broader table, filesystem, and memory work remains tracked by the
+> [visibility proposal](../pending/per-user-content-scope-visibility.md).
+
+Companion to [`per-user-content-scope-visibility.md`](../pending/per-user-content-scope-visibility.md).
+That proposal tracks the broader database half; this one
 is about the request-context half that has to exist before any of it can be enabled.
 
 ## Problem
@@ -126,12 +134,23 @@ operator enables it.
 - **Negative.** Caller context cannot widen the service principal's KB-resolved membership, and a
   request with no context cannot inherit the previous pooled request's principal.
 
-## Status
+## Delivery evidence
 
-Implemented cumulatively through slice 6. #2656 supplied pair-specific mTLS enforcement, UDS/web/
-thinclient/MCP identity convergence, and caller-scoped reads; #2658 and #2661 supplied exact-project
-background maintenance; the final slice adds live two-user/two-team ordinary-search RLS coverage.
+Implemented cumulatively through slice 6. [#2656](https://github.com/RakuenSoftware/aimee/pull/2656)
+supplied pair-specific mTLS enforcement, UDS/web/thinclient/MCP identity convergence, and
+caller-scoped reads; [#2658](https://github.com/RakuenSoftware/aimee/pull/2658) and
+[#2661](https://github.com/RakuenSoftware/aimee/pull/2661) supplied exact-project background
+maintenance; [#2670](https://github.com/RakuenSoftware/aimee/pull/2670) declared reader readiness
+with live two-user/two-team ordinary-search RLS coverage.
 Schema application records `content_scope_reader_ready = '1'` but does not enable content RLS. The
 operator must finish attribution and call `kb_content_scope_enable()`; incomplete attribution still
-fails closed. The [archived companion identity map](../done/per-user-content-scope-identity-map.md)
+fails closed. The [archived companion identity map](per-user-content-scope-identity-map.md)
 records why no additional proof mechanism is required.
+
+- [`kb_content_scope_enable`](../../../src/db2/schema.sql) refuses activation until the reader
+  readiness marker is present and all content-bearing projects are attributed.
+- [`db2_maintenance_scope_begin`](../../../src/db2/db2_tenant.c) opens the closed-name,
+  exact-project maintenance context on a transaction-local lease.
+- [`test_content_scope_pg.c`](../../../src/tests/test_content_scope_pg.c) verifies readiness, the
+  unattributed-row refusal, ordinary two-user search isolation, and that a caller-less pooled search
+  inherits no prior identity.


### PR DESCRIPTION
## Summary

- move the delivered content-scope reader-identity proposal from pending to done
- record stable merged-PR and source-file evidence for all six reader-context slices
- preserve the broader visibility proposal as pending and repair its companion links

## Why

The authenticated caller-context path, exact-project maintenance authority, readiness gate, and live two-user ordinary-search isolation are already delivered through #2656, #2658, #2661, and #2670. The remaining operator attribution step is the proposal's intentional fail-closed deployment gate, not unfinished reader-context implementation.

## Impact

Documentation and proposal state only; no runtime behavior changes.

## Validation

- `python3 scripts/check-proposal-links.py`
- `python3 scripts/check-proposal-reconcile.py` (report-only pre-existing warnings/findings)
- `make -s -C src lint` (all 55 checks passed)
- Aimee frozen-diff roundtable approved
- `git diff --cached --check`
