### PR TITLE
security: scope vector and structured document content

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -199,17 +199,53 @@ aimee-kb project attribute <code-index-project> <kb-project-id>
 Re-running `project attribute` replaces the prior binding atomically. It is an org-admin operation;
 both exact projects must already exist, and no name-based fallback is attempted.
 
-Before enabling, the following query must return no rows for either content table:
+Before enabling, the following query must return no rows. Embeddings must agree with their owning
+chunk, regions and table cells inherit through their foreign-key chain, and assets must still have a
+matching document. If pgvector is intentionally unavailable, omit the two embedding arms because
+those optional relations do not exist.
 
 ```bash
 psql "$AIMEE_DB2_URL" -c "
-  SELECT 'kb_documents' AS source, d.project, count(*)
+  SELECT 'kb_documents' AS source, d.project, count(*) AS rows
     FROM kb_documents d LEFT JOIN projects p ON p.name=d.project
    WHERE p.kb_project IS NULL GROUP BY d.project
   UNION ALL
   SELECT 'kb_file_index', f.project, count(*)
     FROM kb_file_index f LEFT JOIN projects p ON p.name=f.project
-   WHERE p.kb_project IS NULL GROUP BY f.project;"
+   WHERE p.kb_project IS NULL GROUP BY f.project
+  UNION ALL
+  SELECT 'kb_embeddings', e.project, count(*)
+    FROM kb_embeddings e
+    LEFT JOIN kb_documents d ON d.id=e.point_id AND d.project=e.project
+    LEFT JOIN projects p ON p.name=d.project
+   WHERE p.kb_project IS NULL GROUP BY e.project
+  UNION ALL
+  SELECT 'kb_pdf_embeddings', e.project, count(*)
+    FROM kb_pdf_embeddings e
+    LEFT JOIN kb_documents d ON d.id=e.point_id AND d.project=e.project
+    LEFT JOIN projects p ON p.name=d.project
+   WHERE p.kb_project IS NULL GROUP BY e.project
+  UNION ALL
+  SELECT 'kb_doc_regions', coalesce(d.project,'<missing chunk>'), count(*)
+    FROM kb_doc_regions r LEFT JOIN kb_documents d ON d.id=r.chunk_id
+    LEFT JOIN projects p ON p.name=d.project
+   WHERE p.kb_project IS NULL GROUP BY d.project
+  UNION ALL
+  SELECT 'kb_table_cells',
+         coalesce(d.project,CASE WHEN r.id IS NULL THEN '<missing region>' ELSE '<missing chunk>' END),
+         count(*)
+    FROM kb_table_cells c LEFT JOIN kb_doc_regions r ON r.id=c.region_id
+    LEFT JOIN kb_documents d ON d.id=r.chunk_id LEFT JOIN projects p ON p.name=d.project
+   WHERE p.kb_project IS NULL
+   GROUP BY coalesce(d.project,
+                     CASE WHEN r.id IS NULL THEN '<missing region>' ELSE '<missing chunk>' END)
+  UNION ALL
+  SELECT 'kb_doc_assets', a.project, count(*)
+    FROM kb_doc_assets a
+    LEFT JOIN kb_documents d ON d.project=a.project AND d.generation=a.generation
+                            AND d.file_path=a.document_key
+    LEFT JOIN projects p ON p.name=d.project
+   WHERE p.kb_project IS NULL GROUP BY a.project;"
 ```
 
 Then enable the policies as a deliberate operator act:
@@ -219,8 +255,14 @@ psql "$AIMEE_DB2_URL" -c "select kb_content_scope_enable();"
 ```
 
 The function refuses unless the release readiness marker is present and every content-bearing
-project is attributed. To roll back enforcement without changing attribution, call
+project and child row is attributed consistently. It atomically enables documents, file index,
+general/PDF embeddings, document regions, table cells, and document assets. To roll back enforcement
+without changing attribution, call
 `select kb_content_scope_disable();`.
+
+Re-run `kb_content_scope_enable()` after this upgrade even when document/file-index scope was already
+enabled. The call is idempotent and brings the newly covered vector and structured-document tables
+under the same operator-controlled switch.
 
 Grants are keyed by server, team, and exact authenticated subject:
 

--- a/docs/proposals/pending/per-user-content-scope-visibility.md
+++ b/docs/proposals/pending/per-user-content-scope-visibility.md
@@ -1,5 +1,7 @@
 # Per-user content scope: a project you cannot see returns nothing
 
+- **State:** IN FLIGHT — slices 1–2 are delivered; slice 3 is the current implementation.
+
 ## Problem and boundary
 
 A user who is not a member of a project can still read that project's content.
@@ -111,7 +113,10 @@ Prefer the first. The second is only worth it if a deployment cannot tolerate a 
    before the backfill is proved, because no policy reads them yet.
 2. Policies on `kb_documents` and `kb_file_index` (the search surfaces a user notices first),
    enabled with the backfill in the same change.
-3. `kb_embeddings`, `kb_pdf_embeddings`, `kb_doc_regions` (the last inherits through `chunk_id`).
+3. `kb_embeddings`, `kb_pdf_embeddings`, and the structured-document descendants. Regions inherit
+   through `chunk_id`; table cells inherit through `region_id`; document assets bind their project
+   and document key back to the authoritative chunk. The latter two tables post-date the original
+   proposal and are included so they cannot remain bypasses beside protected regions.
 4. The code index: `files` through `projects`, including what `projects.workspace` means for
    attribution.
 5. `ws_scope_project_path` membership check, so the filesystem and the database agree.
@@ -130,8 +135,12 @@ Prefer the first. The second is only worth it if a deployment cannot tolerate a 
 
 ## Status
 
-Pending. Amended after reading the ingest path: the content-to-tenancy link is one column on
-`projects`, not a change to each content table, and resolving it by project NAME is unsafe because
-`kb_project` names are unique only within a team. Evidence gathered on the merged state of #2632 (all counts and column facts above are read
-from `src/db2/schema.sql` at that commit). Slice 5 blocked on the memory-scope decision; slices 1 to
-4 blocked only on choosing a migration option.
+In flight. Slices 1 and 2 are delivered: `projects.kb_project`, the shared visibility predicate,
+documents/file-index policies, the explicit operator switch, caller propagation, exact-project
+maintenance, and live two-reader isolation are on `testing`. Slice 3 extends that same switch to
+general/PDF embeddings and every structured-document descendant, including the table-cell and asset
+surfaces added after this proposal was written. Applying the schema still enables nothing; the
+operator must complete the documented attribution preflight and call `kb_content_scope_enable()`.
+
+Slices 4 and 5 (code index and filesystem agreement) remain. Slice 6 remains blocked on the explicit
+memory-scope product decision above; this proposal does not silently choose one.

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -2126,8 +2126,8 @@ CREATE POLICY p_project_member ON kb_project
 -- docs/validation/per-user-content-scope-prototype.md; do not "simplify" this
 -- into a name match.
 --
--- NULL means unattributed, and kb_project_visible() denies it. Nothing reads
--- that yet, so an existing deployment is unaffected until the policies land.
+-- NULL means unattributed, and kb_project_visible() denies it. The policies
+-- below remain inert until the operator completes attribution and enables RLS.
 ALTER TABLE projects ADD COLUMN IF NOT EXISTS kb_project BIGINT REFERENCES kb_project(id);
 CREATE INDEX IF NOT EXISTS idx_projects_kb_project ON projects(kb_project);
 
@@ -2176,6 +2176,16 @@ LANGUAGE sql STABLE AS $$
                         current_setting('aimee.maintenance_kb_project', true));
 $$;
 
+-- Resolve a code-index project name through the one authoritative tenancy link.
+-- Child-content policies call this rather than repeating the membership rule or
+-- trying to resolve a non-unique kb_project name.
+CREATE OR REPLACE FUNCTION kb_content_project_visible(p_project TEXT) RETURNS boolean
+LANGUAGE sql STABLE AS $$
+  SELECT p_project IS NOT NULL AND EXISTS (
+    SELECT 1 FROM projects p
+     WHERE p.name = p_project AND kb_project_visible(p.kb_project));
+$$;
+
 -- CONTENT SCOPE, part 2: the policies, DEFINED BUT NOT ENABLED.
 --
 -- A policy is inert until RLS is enabled on its table, so applying this file
@@ -2190,15 +2200,11 @@ $$;
 -- advertised and absent.
 DROP POLICY IF EXISTS p_documents_project ON kb_documents;
 CREATE POLICY p_documents_project ON kb_documents
-  FOR SELECT USING (EXISTS (SELECT 1 FROM projects p
-                            WHERE p.name = kb_documents.project
-                              AND kb_project_visible(p.kb_project)));
+  FOR SELECT USING (kb_content_project_visible(project));
 
 DROP POLICY IF EXISTS p_file_index_project ON kb_file_index;
 CREATE POLICY p_file_index_project ON kb_file_index
-  FOR SELECT USING (EXISTS (SELECT 1 FROM projects p
-                            WHERE p.name = kb_file_index.project
-                              AND kb_project_visible(p.kb_project)));
+  FOR SELECT USING (kb_content_project_visible(project));
 
 DROP POLICY IF EXISTS p_documents_maintenance_write ON kb_documents;
 CREATE POLICY p_documents_maintenance_write ON kb_documents
@@ -2211,6 +2217,109 @@ CREATE POLICY p_file_index_maintenance_write ON kb_file_index
   FOR ALL
   USING (kb_maintenance_content_project(project))
   WITH CHECK (kb_maintenance_content_project(project));
+
+-- Embedding rows carry a cached project, but point_id is the owning
+-- kb_documents row. Require BOTH to agree so a stale or forged cached project
+-- cannot relabel another tenant's payload_json. These relations are optional
+-- when pgvector is unavailable, so their policies are installed conditionally.
+DO $content_scope_vectors$ BEGIN
+  IF to_regclass('kb_embeddings') IS NOT NULL THEN
+    EXECUTE 'DROP POLICY IF EXISTS p_embeddings_project ON kb_embeddings';
+    EXECUTE 'CREATE POLICY p_embeddings_project ON kb_embeddings FOR SELECT USING ('
+            'kb_content_project_visible(project) AND EXISTS ('
+            'SELECT 1 FROM kb_documents d WHERE d.id=kb_embeddings.point_id '
+            'AND d.project=kb_embeddings.project))';
+    EXECUTE 'DROP POLICY IF EXISTS p_embeddings_maintenance_write ON kb_embeddings';
+    EXECUTE 'CREATE POLICY p_embeddings_maintenance_write ON kb_embeddings FOR ALL '
+            'USING (kb_maintenance_content_project(project) AND EXISTS ('
+            'SELECT 1 FROM kb_documents d WHERE d.id=kb_embeddings.point_id '
+            'AND d.project=kb_embeddings.project)) '
+            'WITH CHECK (kb_maintenance_content_project(project) AND EXISTS ('
+            'SELECT 1 FROM kb_documents d WHERE d.id=kb_embeddings.point_id '
+            'AND d.project=kb_embeddings.project))';
+  END IF;
+  IF to_regclass('kb_pdf_embeddings') IS NOT NULL THEN
+    EXECUTE 'DROP POLICY IF EXISTS p_pdf_embeddings_project ON kb_pdf_embeddings';
+    EXECUTE 'CREATE POLICY p_pdf_embeddings_project ON kb_pdf_embeddings FOR SELECT USING ('
+            'kb_content_project_visible(project) AND EXISTS ('
+            'SELECT 1 FROM kb_documents d WHERE d.id=kb_pdf_embeddings.point_id '
+            'AND d.project=kb_pdf_embeddings.project))';
+    EXECUTE 'DROP POLICY IF EXISTS p_pdf_embeddings_maintenance_write ON kb_pdf_embeddings';
+    EXECUTE 'CREATE POLICY p_pdf_embeddings_maintenance_write ON kb_pdf_embeddings FOR ALL '
+            'USING (kb_maintenance_content_project(project) AND EXISTS ('
+            'SELECT 1 FROM kb_documents d WHERE d.id=kb_pdf_embeddings.point_id '
+            'AND d.project=kb_pdf_embeddings.project)) '
+            'WITH CHECK (kb_maintenance_content_project(project) AND EXISTS ('
+            'SELECT 1 FROM kb_documents d WHERE d.id=kb_pdf_embeddings.point_id '
+            'AND d.project=kb_pdf_embeddings.project))';
+  END IF;
+END $content_scope_vectors$;
+
+-- Regions and cells inherit their owner through the mandatory chunk/region
+-- foreign-key chain, never their denormalised document_key. Assets have no
+-- single document row to reference, so they require project + generation +
+-- document_key to match an authoritative chunk. kb_table_cells and kb_doc_assets
+-- were added after the original slice-3 proposal; leaving them out would preserve
+-- direct readable-content bypasses beside protected regions.
+DROP POLICY IF EXISTS p_doc_regions_project ON kb_doc_regions;
+CREATE POLICY p_doc_regions_project ON kb_doc_regions
+  FOR SELECT USING (EXISTS (SELECT 1 FROM kb_documents d
+                             WHERE d.id = kb_doc_regions.chunk_id
+                               AND kb_content_project_visible(d.project)));
+
+DROP POLICY IF EXISTS p_doc_regions_maintenance_write ON kb_doc_regions;
+CREATE POLICY p_doc_regions_maintenance_write ON kb_doc_regions
+  FOR ALL
+  USING (EXISTS (SELECT 1 FROM kb_documents d
+                  WHERE d.id = kb_doc_regions.chunk_id
+                    AND kb_maintenance_content_project(d.project)))
+  WITH CHECK (EXISTS (SELECT 1 FROM kb_documents d
+                       WHERE d.id = kb_doc_regions.chunk_id
+                         AND kb_maintenance_content_project(d.project)));
+
+DROP POLICY IF EXISTS p_table_cells_project ON kb_table_cells;
+CREATE POLICY p_table_cells_project ON kb_table_cells
+  FOR SELECT USING (EXISTS (SELECT 1 FROM kb_doc_regions r
+                              JOIN kb_documents d ON d.id = r.chunk_id
+                             WHERE r.id = kb_table_cells.region_id
+                               AND kb_content_project_visible(d.project)));
+
+DROP POLICY IF EXISTS p_table_cells_maintenance_write ON kb_table_cells;
+CREATE POLICY p_table_cells_maintenance_write ON kb_table_cells
+  FOR ALL
+  USING (EXISTS (SELECT 1 FROM kb_doc_regions r
+                   JOIN kb_documents d ON d.id = r.chunk_id
+                  WHERE r.id = kb_table_cells.region_id
+                    AND kb_maintenance_content_project(d.project)))
+  WITH CHECK (EXISTS (SELECT 1 FROM kb_doc_regions r
+                        JOIN kb_documents d ON d.id = r.chunk_id
+                       WHERE r.id = kb_table_cells.region_id
+                         AND kb_maintenance_content_project(d.project)));
+
+DROP POLICY IF EXISTS p_doc_assets_project ON kb_doc_assets;
+CREATE POLICY p_doc_assets_project ON kb_doc_assets
+  FOR SELECT USING (
+    kb_content_project_visible(project)
+    AND EXISTS (SELECT 1 FROM kb_documents d
+                 WHERE d.project = kb_doc_assets.project
+                   AND d.generation = kb_doc_assets.generation
+                   AND d.file_path = kb_doc_assets.document_key));
+
+DROP POLICY IF EXISTS p_doc_assets_maintenance_write ON kb_doc_assets;
+CREATE POLICY p_doc_assets_maintenance_write ON kb_doc_assets
+  FOR ALL
+  USING (
+    kb_maintenance_content_project(project)
+    AND EXISTS (SELECT 1 FROM kb_documents d
+                 WHERE d.project = kb_doc_assets.project
+                   AND d.generation = kb_doc_assets.generation
+                   AND d.file_path = kb_doc_assets.document_key))
+  WITH CHECK (
+    kb_maintenance_content_project(project)
+    AND EXISTS (SELECT 1 FROM kb_documents d
+                 WHERE d.project = kb_doc_assets.project
+                   AND d.generation = kb_doc_assets.generation
+                   AND d.file_path = kb_doc_assets.document_key));
 
 -- Turn content scoping on, once the rows carry a kb_project.
 --
@@ -2227,6 +2336,11 @@ LANGUAGE plpgsql AS $$
 DECLARE
   orphan_docs BIGINT;
   orphan_files BIGINT;
+  orphan_embeddings BIGINT := 0;
+  orphan_pdf_embeddings BIGINT := 0;
+  orphan_regions BIGINT;
+  orphan_cells BIGINT;
+  orphan_assets BIGINT;
   reader_ready TEXT;
 BEGIN
   -- THE READER SIDE MUST EXIST FIRST. The marker is a release capability fact,
@@ -2241,22 +2355,130 @@ BEGIN
                     'authenticated caller path and transaction-local content reader scope ready. '
                     'Upgrade before enabling.';
   END IF;
+  -- ALTER TABLE below already requires owner authority, but make the full-row
+  -- preflight assumption explicit. A direct owner, a role inheriting the owner,
+  -- or a PostgreSQL BYPASSRLS/superuser role can audit every row once FORCE is
+  -- removed; anyone else is refused rather than allowed to count a tenant slice.
+  IF EXISTS (
+       SELECT 1
+         FROM (VALUES ('kb_documents'), ('kb_file_index'), ('kb_embeddings'),
+                      ('kb_pdf_embeddings'), ('kb_doc_regions'), ('kb_table_cells'),
+                      ('kb_doc_assets')) AS required_relation(name)
+         JOIN pg_class c ON c.oid=to_regclass(required_relation.name)
+        WHERE NOT pg_has_role(current_user, c.relowner, 'USAGE'))
+     AND NOT EXISTS (SELECT 1 FROM pg_roles
+                      WHERE rolname=current_user AND (rolsuper OR rolbypassrls)) THEN
+    RAISE EXCEPTION 'refusing to enable content scope: current role cannot audit every row '
+                    'as the owner or a BYPASSRLS role.';
+  END IF;
+  -- Refuse partial/manual schema states. Optional vector relations are omitted
+  -- only when pgvector made the relation itself unavailable; every relation that
+  -- exists must have both its reader and exact-project maintenance policy.
+  IF EXISTS (
+       SELECT 1
+         FROM (VALUES
+           ('kb_documents','p_documents_project'),
+           ('kb_documents','p_documents_maintenance_write'),
+           ('kb_file_index','p_file_index_project'),
+           ('kb_file_index','p_file_index_maintenance_write'),
+           ('kb_embeddings','p_embeddings_project'),
+           ('kb_embeddings','p_embeddings_maintenance_write'),
+           ('kb_pdf_embeddings','p_pdf_embeddings_project'),
+           ('kb_pdf_embeddings','p_pdf_embeddings_maintenance_write'),
+           ('kb_doc_regions','p_doc_regions_project'),
+           ('kb_doc_regions','p_doc_regions_maintenance_write'),
+           ('kb_table_cells','p_table_cells_project'),
+           ('kb_table_cells','p_table_cells_maintenance_write'),
+           ('kb_doc_assets','p_doc_assets_project'),
+           ('kb_doc_assets','p_doc_assets_maintenance_write'))
+              AS required_policy(relation_name, policy_name)
+        WHERE to_regclass(required_policy.relation_name) IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM pg_policy p
+                           WHERE p.polrelid=to_regclass(required_policy.relation_name)
+                             AND p.polname=required_policy.policy_name)) THEN
+    RAISE EXCEPTION 'refusing to enable content scope: a covered relation exists without '
+                    'its reader or maintenance policy. Reapply the current schema first.';
+  END IF;
+  -- An already-enabled deployment must be able to re-run this switch after an
+  -- upgrade adds another covered table. FORCE would otherwise make the owner's
+  -- preflight queries see only its (normally empty) tenant scope. Removing FORCE
+  -- acquires the table locks inside this transaction; an exception rolls every
+  -- flag back, and success re-enables FORCE below, so there is no unscoped window.
+  ALTER TABLE kb_documents NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_file_index NO FORCE ROW LEVEL SECURITY;
+  IF to_regclass('kb_embeddings') IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE kb_embeddings NO FORCE ROW LEVEL SECURITY';
+  END IF;
+  IF to_regclass('kb_pdf_embeddings') IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE kb_pdf_embeddings NO FORCE ROW LEVEL SECURITY';
+  END IF;
+  ALTER TABLE kb_doc_regions NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_table_cells NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_doc_assets NO FORCE ROW LEVEL SECURITY;
   SELECT count(*) INTO orphan_docs FROM kb_documents d
     WHERE NOT EXISTS (SELECT 1 FROM projects p
                       WHERE p.name = d.project AND p.kb_project IS NOT NULL);
   SELECT count(*) INTO orphan_files FROM kb_file_index f
     WHERE NOT EXISTS (SELECT 1 FROM projects p
                       WHERE p.name = f.project AND p.kb_project IS NOT NULL);
-  IF orphan_docs > 0 OR orphan_files > 0 THEN
-    RAISE EXCEPTION 'refusing to enable content scope: % document rows and % file-index rows '
-                    'have no kb_project, and would become invisible to everyone. Attribute them '
-                    '(projects.kb_project) and call again.', orphan_docs, orphan_files;
+  IF to_regclass('kb_embeddings') IS NOT NULL THEN
+    EXECUTE 'SELECT count(*) FROM kb_embeddings e WHERE NOT EXISTS ('
+            'SELECT 1 FROM kb_documents d JOIN projects p ON p.name=d.project '
+            'WHERE d.id=e.point_id AND d.project=e.project AND p.kb_project IS NOT NULL)'
+      INTO orphan_embeddings;
+  END IF;
+  IF to_regclass('kb_pdf_embeddings') IS NOT NULL THEN
+    EXECUTE 'SELECT count(*) FROM kb_pdf_embeddings e WHERE NOT EXISTS ('
+            'SELECT 1 FROM kb_documents d JOIN projects p ON p.name=d.project '
+            'WHERE d.id=e.point_id AND d.project=e.project AND p.kb_project IS NOT NULL)'
+      INTO orphan_pdf_embeddings;
+  END IF;
+  -- Structured-document relations are mandatory schema tables wherever this
+  -- switch exists; only pgvector-backed relations have an optional arm.
+  SELECT count(*) INTO orphan_regions FROM kb_doc_regions r
+    WHERE NOT EXISTS (SELECT 1 FROM kb_documents d
+                       JOIN projects p ON p.name=d.project
+                      WHERE d.id=r.chunk_id AND p.kb_project IS NOT NULL);
+  SELECT count(*) INTO orphan_cells FROM kb_table_cells c
+    WHERE NOT EXISTS (SELECT 1 FROM kb_doc_regions r
+                       JOIN kb_documents d ON d.id=r.chunk_id
+                       JOIN projects p ON p.name=d.project
+                      WHERE r.id=c.region_id AND p.kb_project IS NOT NULL);
+  SELECT count(*) INTO orphan_assets FROM kb_doc_assets a
+    WHERE NOT EXISTS (SELECT 1 FROM kb_documents d
+                       JOIN projects p ON p.name=d.project
+                      WHERE d.project=a.project AND d.generation=a.generation
+                        AND d.file_path=a.document_key
+                        AND p.kb_project IS NOT NULL);
+  IF orphan_docs > 0 OR orphan_files > 0 OR orphan_embeddings > 0
+     OR orphan_pdf_embeddings > 0 OR orphan_regions > 0 OR orphan_cells > 0
+     OR orphan_assets > 0 THEN
+    RAISE EXCEPTION 'refusing to enable content scope: unattributed/mismatched rows: '
+                    '% documents, % file-index, % embeddings, % PDF embeddings, '
+                    '% regions, % table cells, % assets. They would become invisible to '
+                    'everyone. Attribute projects.kb_project, repair child ownership, and call '
+                    'again.', orphan_docs, orphan_files, orphan_embeddings,
+                    orphan_pdf_embeddings, orphan_regions, orphan_cells, orphan_assets;
   END IF;
   ALTER TABLE kb_documents ENABLE ROW LEVEL SECURITY;
   ALTER TABLE kb_documents FORCE ROW LEVEL SECURITY;
   ALTER TABLE kb_file_index ENABLE ROW LEVEL SECURITY;
   ALTER TABLE kb_file_index FORCE ROW LEVEL SECURITY;
-  RETURN 'content scope enabled on kb_documents, kb_file_index';
+  IF to_regclass('kb_embeddings') IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE kb_embeddings ENABLE ROW LEVEL SECURITY';
+    EXECUTE 'ALTER TABLE kb_embeddings FORCE ROW LEVEL SECURITY';
+  END IF;
+  IF to_regclass('kb_pdf_embeddings') IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE kb_pdf_embeddings ENABLE ROW LEVEL SECURITY';
+    EXECUTE 'ALTER TABLE kb_pdf_embeddings FORCE ROW LEVEL SECURITY';
+  END IF;
+  ALTER TABLE kb_doc_regions ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_doc_regions FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_table_cells ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_table_cells FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_doc_assets ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_doc_assets FORCE ROW LEVEL SECURITY;
+  RETURN 'content scope enabled on project content tables';
 END;
 $$;
 
@@ -2269,6 +2491,20 @@ BEGIN
   ALTER TABLE kb_documents DISABLE ROW LEVEL SECURITY;
   ALTER TABLE kb_file_index NO FORCE ROW LEVEL SECURITY;
   ALTER TABLE kb_file_index DISABLE ROW LEVEL SECURITY;
+  IF to_regclass('kb_embeddings') IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE kb_embeddings NO FORCE ROW LEVEL SECURITY';
+    EXECUTE 'ALTER TABLE kb_embeddings DISABLE ROW LEVEL SECURITY';
+  END IF;
+  IF to_regclass('kb_pdf_embeddings') IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE kb_pdf_embeddings NO FORCE ROW LEVEL SECURITY';
+    EXECUTE 'ALTER TABLE kb_pdf_embeddings DISABLE ROW LEVEL SECURITY';
+  END IF;
+  ALTER TABLE kb_doc_regions NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_doc_regions DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_table_cells NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_table_cells DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE kb_doc_assets NO FORCE ROW LEVEL SECURITY;
+  ALTER TABLE kb_doc_assets DISABLE ROW LEVEL SECURITY;
   RETURN 'content scope disabled';
 END;
 $$;

--- a/src/tests/test_content_scope_pg.c
+++ b/src/tests/test_content_scope_pg.c
@@ -3,7 +3,9 @@
  *
  * Needs a live Postgres: RLS and current_setting have no meaning on the SQLite
  * shim. Reads AIMEE_TEST_PG_URL and SKIPS CLEANLY (exit 0) when it is unset,
- * mirroring test_vault_pg.c, so `make unit-tests` stays green without one.
+ * mirroring test_vault_pg.c, so `make unit-tests` stays green without one. The
+ * vector ownership half also requires pgvector; a database where schema apply
+ * deliberately omitted those optional relations skips this combined proof.
  *
  * WHAT IS PINNED HERE, and why each would otherwise be silent:
  *
@@ -13,9 +15,9 @@
  *     principal set. Deny is the direction the whole design rests on, and a
  *     predicate that answered true here would open every content policy built on
  *     it at once.
- *  3. The user-read and maintenance-write policies exist but are INERT: RLS is
- *     not enabled on either table, so applying this schema changes what nobody
- *     can read. A policy that switched
+ *  3. The user-read and maintenance-write policies exist for documents, file
+ *     index, vector rows, regions, table cells, and document assets, but are
+ *     INERT: applying this schema changes what nobody can read. A policy that switched
  *     itself on would turn an upgrade into an outage for every row not yet
  *     attributed, so the off state is asserted rather than assumed.
  *  4. Reader readiness is declared without enabling RLS, and enabling still
@@ -27,7 +29,8 @@
  *     under a fresh exact-project scope, without crossing into a sibling project.
  *  7. Maintenance authority is named, exact-project, and transaction-local.
  *  8. Two users on two teams search the ordinary KB path with FORCE RLS enabled;
- *     each sees only their own project, and a caller-less search sees neither.
+ *     each sees only their own project in every covered table, and a caller-less
+ *     search sees neither.
  */
 #include "db2.h"
 #include "db2/db2_internal.h"
@@ -96,6 +99,34 @@ static void expect(const char *sql, const char *want)
    }
 }
 
+/* Assert the mechanical per-table half of content scope for one project. The
+ * inherited tables are deliberately joined through their owner ids rather than
+ * their denormalised document_key fields, matching the policies under test. */
+static void expect_project_content_counts(const char *project, const char *want)
+{
+   char sql[1024];
+   snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_documents WHERE project='%s'", project);
+   expect(sql, want);
+   snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_file_index WHERE project='%s'", project);
+   expect(sql, want);
+   snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_embeddings WHERE project='%s'", project);
+   expect(sql, want);
+   snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_pdf_embeddings WHERE project='%s'", project);
+   expect(sql, want);
+   snprintf(sql, sizeof(sql),
+            "SELECT count(*) FROM kb_doc_regions r JOIN kb_documents d ON d.id=r.chunk_id"
+            " WHERE d.project='%s'",
+            project);
+   expect(sql, want);
+   snprintf(sql, sizeof(sql),
+            "SELECT count(*) FROM kb_table_cells c JOIN kb_doc_regions r ON r.id=c.region_id"
+            " JOIN kb_documents d ON d.id=r.chunk_id WHERE d.project='%s'",
+            project);
+   expect(sql, want);
+   snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_doc_assets WHERE project='%s'", project);
+   expect(sql, want);
+}
+
 static int scalar(const char *sql, char *out, size_t cap)
 {
    char err[256] = "";
@@ -131,6 +162,17 @@ int main(void)
    }
    printf("test_content_scope_pg\n");
 
+   char vector_relations[16] = "";
+   if (scalar("SELECT (to_regclass('kb_embeddings') IS NOT NULL)::int"
+              " + (to_regclass('kb_pdf_embeddings') IS NOT NULL)::int",
+              vector_relations, sizeof(vector_relations)) != 0 ||
+       strcmp(vector_relations, "2") != 0)
+   {
+      printf("content_scope_pg: SKIP (pgvector relations unavailable)\n");
+      db2_shutdown();
+      return 0;
+   }
+
    /* 1. The referent exists. */
    expect("SELECT count(*) FROM information_schema.columns"
           " WHERE table_name='projects' AND column_name='kb_project'",
@@ -157,8 +199,9 @@ int main(void)
    /* 3. The policies are DEFINED. They have to be, or enabling would be a
     *     schema change at the worst possible moment. */
    expect("SELECT count(*) FROM pg_policies"
-          " WHERE tablename IN ('kb_documents','kb_file_index')",
-          "4");
+          " WHERE tablename IN ('kb_documents','kb_file_index','kb_embeddings',"
+          " 'kb_pdf_embeddings','kb_doc_regions','kb_table_cells','kb_doc_assets')",
+          "14");
    printf("  PASS: the user-read and maintenance-write policies are defined\n");
 
    /* 4. And INERT. A policy does nothing until RLS is enabled on its table, and
@@ -170,7 +213,8 @@ int main(void)
     *    both must be off, because FORCE without ENABLE is not a state worth
     *    reasoning about later. */
    expect("SELECT count(*) FROM pg_class"
-          " WHERE relname IN ('kb_documents','kb_file_index')"
+          " WHERE relname IN ('kb_documents','kb_file_index','kb_embeddings',"
+          " 'kb_pdf_embeddings','kb_doc_regions','kb_table_cells','kb_doc_assets')"
           "   AND (relrowsecurity OR relforcerowsecurity)",
           "0");
    printf("  PASS: they are inert until an operator enables them\n");
@@ -220,7 +264,8 @@ int main(void)
       printf("  PASS: enabling refuses while content is unattributed\n");
       /* Whatever happened, leave the tables as they were found. */
       expect("SELECT count(*) FROM pg_class"
-             " WHERE relname IN ('kb_documents','kb_file_index')"
+             " WHERE relname IN ('kb_documents','kb_file_index','kb_embeddings',"
+             " 'kb_pdf_embeddings','kb_doc_regions','kb_table_cells','kb_doc_assets')"
              "   AND (relrowsecurity OR relforcerowsecurity)",
              "0");
       assert(exec_sql("DELETE FROM kb_documents"
@@ -413,6 +458,10 @@ int main(void)
                       "SELECT id FROM kb_documents"
                       " WHERE project='scope-maintenance-a'"
                       " AND file_path='scope-maintenance-reembed.md')") == 0);
+      assert(exec_sql("DELETE FROM kb_doc_assets"
+                      " WHERE project='scope-maintenance-a'"
+                      " AND document_key='scope-maintenance-reembed.md'") == 0);
+      /* Regions and cells, if a prior run left any, cascade from kb_documents. */
       assert(exec_sql("DELETE FROM kb_documents"
                       " WHERE project='scope-maintenance-a'"
                       " AND file_path='scope-maintenance-reembed.md'") == 0);
@@ -420,6 +469,9 @@ int main(void)
                       "SELECT id FROM kb_documents"
                       " WHERE project='scope-maintenance-b'"
                       " AND file_path='scope-maintenance-sibling.md')") == 0);
+      assert(exec_sql("DELETE FROM kb_doc_assets"
+                      " WHERE project='scope-maintenance-a'"
+                      " AND document_key='scope-maintenance-sibling.md'") == 0);
       assert(exec_sql("DELETE FROM kb_documents"
                       " WHERE project='scope-maintenance-b'"
                       " AND file_path='scope-maintenance-sibling.md'") == 0);
@@ -446,6 +498,12 @@ int main(void)
       assert(exec_sql("ALTER TABLE kb_documents FORCE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_file_index ENABLE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_file_index FORCE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_embeddings ENABLE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_embeddings FORCE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_pdf_embeddings ENABLE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_pdf_embeddings FORCE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_doc_assets ENABLE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_doc_assets FORCE ROW LEVEL SECURITY") == 0);
       assert(db2_maintenance_job_enter(DB2_MAINTENANCE_CURATOR, "scope-maintenance-a") == 0);
       assert(db2_maintenance_scope_begin_current() == 1);
       expect("SELECT current_setting('aimee.maintenance_project',true)", "scope-maintenance-a");
@@ -466,14 +524,81 @@ int main(void)
       snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_embeddings WHERE point_id=%s",
                sibling_doc);
       expect(sql, "0");
+
+      /* Both vector tables use point_id's document as the owner. A matching
+       * maintenance write succeeds; relabelling the sibling's point_id with the
+       * selected project is rejected even though the cached project alone would
+       * satisfy the maintenance scope. Each expected policy error aborts its
+       * transaction, so start a fresh short scope for the next proof. */
+      assert(db2_maintenance_scope_begin_current() == 1);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_pdf_embeddings(point_id,project,payload_json)"
+               " VALUES (%s,'scope-maintenance-a','{}')",
+               reembed_doc);
+      assert(exec_sql(sql) == 0);
+      assert(db2_maintenance_scope_commit() == 0);
+
+      assert(db2_maintenance_scope_begin_current() == 1);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_embeddings(point_id,project,payload_json)"
+               " VALUES (%s,'scope-maintenance-a','{}')",
+               sibling_doc);
+      assert(exec_sql(sql) != 0);
+      db2_maintenance_scope_rollback();
+
+      assert(db2_maintenance_scope_begin_current() == 1);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_pdf_embeddings(point_id,project,payload_json)"
+               " VALUES (%s,'scope-maintenance-a','{}')",
+               sibling_doc);
+      assert(exec_sql(sql) != 0);
+      db2_maintenance_scope_rollback();
+
+      assert(db2_maintenance_scope_begin_current() == 1);
+      assert(exec_sql("INSERT INTO kb_doc_assets"
+                      " (project,generation,document_key,page_no,kind,caption,content_type,"
+                      "  blob_ref,sensitivity_class)"
+                      " SELECT name,current_generation,'scope-maintenance-reembed.md',1,'page',"
+                      " 'maintenance asset','image/png','maintenance-asset-blob','internal'"
+                      " FROM projects WHERE name='scope-maintenance-a'") == 0);
+      assert(db2_maintenance_scope_commit() == 0);
+
+      assert(db2_maintenance_scope_begin_current() == 1);
+      assert(exec_sql("INSERT INTO kb_doc_assets"
+                      " (project,generation,document_key,page_no,kind,caption,content_type,"
+                      "  blob_ref,sensitivity_class)"
+                      " SELECT 'scope-maintenance-a',current_generation,"
+                      " 'scope-maintenance-sibling.md',1,'page','relabelled asset','image/png',"
+                      " 'relabelled-asset-blob','internal'"
+                      " FROM projects WHERE name='scope-maintenance-a'") != 0);
+      db2_maintenance_scope_rollback();
       db2_maintenance_job_leave();
       printf("  PASS: re-embed reapplies exact-project scope after the embedder round-trip\n");
       printf("  PASS: re-embed cannot cross into an unselected sibling chunk\n");
+      printf("  PASS: both vector writers reject cached-project relabelling\n");
+      printf("  PASS: asset writes require an exact project, generation, and document key\n");
 
       assert(exec_sql("ALTER TABLE kb_documents NO FORCE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_documents DISABLE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_file_index NO FORCE ROW LEVEL SECURITY") == 0);
       assert(exec_sql("ALTER TABLE kb_file_index DISABLE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_embeddings NO FORCE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_embeddings DISABLE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_pdf_embeddings NO FORCE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_pdf_embeddings DISABLE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_doc_assets NO FORCE ROW LEVEL SECURITY") == 0);
+      assert(exec_sql("ALTER TABLE kb_doc_assets DISABLE ROW LEVEL SECURITY") == 0);
+      snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_embeddings WHERE point_id=%s",
+               sibling_doc);
+      expect(sql, "0");
+      snprintf(sql, sizeof(sql), "SELECT count(*) FROM kb_pdf_embeddings WHERE point_id=%s",
+               sibling_doc);
+      expect(sql, "0");
+      snprintf(sql, sizeof(sql), "DELETE FROM kb_pdf_embeddings WHERE point_id=%s", reembed_doc);
+      assert(exec_sql(sql) == 0);
+      assert(exec_sql("DELETE FROM kb_doc_assets"
+                      " WHERE project='scope-maintenance-a'"
+                      " AND document_key='scope-maintenance-reembed.md'") == 0);
       printf("  PASS: maintenance authority is named, project-bound, and transaction-local\n");
    }
 
@@ -542,23 +667,106 @@ int main(void)
                key_b, team_b);
       assert(scalar(sql, ignored, sizeof(ignored)) == 0);
 
+      assert(exec_sql("DELETE FROM kb_embeddings"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
+      assert(exec_sql("DELETE FROM kb_pdf_embeddings"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
+      assert(exec_sql("DELETE FROM kb_doc_assets"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
+      assert(exec_sql("DELETE FROM kb_file_index"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
       assert(exec_sql("DELETE FROM kb_documents"
                       " WHERE project IN ('scope-reader-a','scope-reader-b')"
                       " AND file_path IN ('reader-a.md','reader-b.md')") == 0);
+      char reader_doc_a[64] = "", reader_doc_b[64] = "";
       assert(scalar("INSERT INTO kb_documents"
                     " (project,generation,file_path,file_hash,chunk_index,heading_path,"
                     "  line_start,line_end,content,token_count)"
                     " SELECT name,current_generation,'reader-a.md','reader-a-hash',0,"
                     "  'Reader A',1,1,'readinessisolationtoken belongs to reader alpha',5"
                     " FROM projects WHERE name='scope-reader-a' RETURNING id",
-                    ignored, sizeof(ignored)) == 0);
+                    reader_doc_a, sizeof(reader_doc_a)) == 0);
       assert(scalar("INSERT INTO kb_documents"
                     " (project,generation,file_path,file_hash,chunk_index,heading_path,"
                     "  line_start,line_end,content,token_count)"
                     " SELECT name,current_generation,'reader-b.md','reader-b-hash',0,"
                     "  'Reader B',1,1,'readinessisolationtoken belongs to reader beta',5"
                     " FROM projects WHERE name='scope-reader-b' RETURNING id",
-                    ignored, sizeof(ignored)) == 0);
+                    reader_doc_b, sizeof(reader_doc_b)) == 0);
+
+      assert(exec_sql("INSERT INTO kb_file_index(project,generation,file_path,file_hash,content)"
+                      " SELECT name,current_generation,'reader-a.md','reader-a-hash',"
+                      " 'reader alpha file index' FROM projects WHERE name='scope-reader-a'"
+                      " ON CONFLICT (project,generation,file_path) DO UPDATE"
+                      " SET file_hash=EXCLUDED.file_hash,content=EXCLUDED.content") == 0);
+      assert(exec_sql("INSERT INTO kb_file_index(project,generation,file_path,file_hash,content)"
+                      " SELECT name,current_generation,'reader-b.md','reader-b-hash',"
+                      " 'reader beta file index' FROM projects WHERE name='scope-reader-b'"
+                      " ON CONFLICT (project,generation,file_path) DO UPDATE"
+                      " SET file_hash=EXCLUDED.file_hash,content=EXCLUDED.content") == 0);
+
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_embeddings(point_id,project,payload_json)"
+               " VALUES (%s,'scope-reader-a','{\"project\":\"scope-reader-a\"}')"
+               " ON CONFLICT (point_id) DO UPDATE SET project=EXCLUDED.project,"
+               " payload_json=EXCLUDED.payload_json",
+               reader_doc_a);
+      assert(exec_sql(sql) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_embeddings(point_id,project,payload_json)"
+               " VALUES (%s,'scope-reader-b','{\"project\":\"scope-reader-b\"}')"
+               " ON CONFLICT (point_id) DO UPDATE SET project=EXCLUDED.project,"
+               " payload_json=EXCLUDED.payload_json",
+               reader_doc_b);
+      assert(exec_sql(sql) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_pdf_embeddings(point_id,project,payload_json)"
+               " VALUES (%s,'scope-reader-a','{\"project\":\"scope-reader-a\"}')"
+               " ON CONFLICT (point_id) DO UPDATE SET project=EXCLUDED.project,"
+               " payload_json=EXCLUDED.payload_json",
+               reader_doc_a);
+      assert(exec_sql(sql) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_pdf_embeddings(point_id,project,payload_json)"
+               " VALUES (%s,'scope-reader-b','{\"project\":\"scope-reader-b\"}')"
+               " ON CONFLICT (point_id) DO UPDATE SET project=EXCLUDED.project,"
+               " payload_json=EXCLUDED.payload_json",
+               reader_doc_b);
+      assert(exec_sql(sql) == 0);
+
+      char reader_region_a[64] = "", reader_region_b[64] = "";
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_doc_regions(chunk_id,document_key,page_no,quote,line_index)"
+               " VALUES (%s,'reader-a.md',1,'reader alpha region',0) RETURNING id",
+               reader_doc_a);
+      assert(scalar(sql, reader_region_a, sizeof(reader_region_a)) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_doc_regions(chunk_id,document_key,page_no,quote,line_index)"
+               " VALUES (%s,'reader-b.md',1,'reader beta region',0) RETURNING id",
+               reader_doc_b);
+      assert(scalar(sql, reader_region_b, sizeof(reader_region_b)) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_table_cells(region_id,document_key,page_no,cell_text)"
+               " VALUES (%s,'reader-a.md',1,'reader alpha cell')",
+               reader_region_a);
+      assert(exec_sql(sql) == 0);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO kb_table_cells(region_id,document_key,page_no,cell_text)"
+               " VALUES (%s,'reader-b.md',1,'reader beta cell')",
+               reader_region_b);
+      assert(exec_sql(sql) == 0);
+      assert(exec_sql("INSERT INTO kb_doc_assets"
+                      " (project,generation,document_key,page_no,kind,caption,content_type,"
+                      "  blob_ref,sensitivity_class)"
+                      " SELECT name,current_generation,'reader-a.md',1,'page',"
+                      " 'reader alpha asset','image/png','reader-alpha-blob','internal'"
+                      " FROM projects WHERE name='scope-reader-a'") == 0);
+      assert(exec_sql("INSERT INTO kb_doc_assets"
+                      " (project,generation,document_key,page_no,kind,caption,content_type,"
+                      "  blob_ref,sensitivity_class)"
+                      " SELECT name,current_generation,'reader-b.md',1,'page',"
+                      " 'reader beta asset','image/png','reader-beta-blob','internal'"
+                      " FROM projects WHERE name='scope-reader-b'") == 0);
 
       expect("SELECT count(*) FROM kb_documents d"
              " WHERE NOT EXISTS (SELECT 1 FROM projects p"
@@ -568,10 +776,76 @@ int main(void)
              " WHERE NOT EXISTS (SELECT 1 FROM projects p"
              " WHERE p.name=f.project AND p.kb_project IS NOT NULL)",
              "0");
-      expect("SELECT kb_content_scope_enable()",
-             "content scope enabled on kb_documents, kb_file_index");
+
+      /* A cached vector project is not ownership. point_id is authoritative, so
+       * a stale/relabelled cache must stop the operator switch rather than hide
+       * the inconsistent row behind RLS. */
+      snprintf(sql, sizeof(sql),
+               "UPDATE kb_embeddings SET project='scope-reader-a' WHERE point_id=%s", reader_doc_b);
+      assert(exec_sql(sql) == 0);
+      char err[512] = "";
+      aimee_pg_stmt_t *st =
+          aimee_pg_prepare(db2_conn(), "SELECT kb_content_scope_enable()", err, sizeof(err));
+      int refused = 0;
+      if (st)
+      {
+         if (aimee_pg_step(st, err, sizeof(err)) != AIMEE_PG_ROW)
+            refused = 1;
+         aimee_pg_finalize(st);
+      }
+      else
+      {
+         refused = 1;
+      }
+      if (!refused)
+         fprintf(stderr, "kb_content_scope_enable() accepted a relabelled embedding\n");
+      assert(refused);
+      expect("SELECT count(*) FROM pg_class"
+             " WHERE relname IN ('kb_documents','kb_file_index','kb_embeddings',"
+             " 'kb_pdf_embeddings','kb_doc_regions','kb_table_cells','kb_doc_assets')"
+             "   AND (relrowsecurity OR relforcerowsecurity)",
+             "0");
+      snprintf(sql, sizeof(sql),
+               "UPDATE kb_embeddings SET project='scope-reader-b' WHERE point_id=%s", reader_doc_b);
+      assert(exec_sql(sql) == 0);
+      printf("  PASS: enabling refuses a vector whose cached project disagrees with its owner\n");
+
+      assert(exec_sql("UPDATE kb_doc_assets SET document_key='missing-reader-b.md'"
+                      " WHERE project='scope-reader-b'"
+                      " AND blob_ref='reader-beta-blob'") == 0);
+      memset(err, 0, sizeof(err));
+      st = aimee_pg_prepare(db2_conn(), "SELECT kb_content_scope_enable()", err, sizeof(err));
+      refused = 0;
+      if (st)
+      {
+         if (aimee_pg_step(st, err, sizeof(err)) != AIMEE_PG_ROW)
+            refused = 1;
+         aimee_pg_finalize(st);
+      }
+      else
+      {
+         refused = 1;
+      }
+      if (!refused)
+         fprintf(stderr, "kb_content_scope_enable() accepted an orphan document asset\n");
+      assert(refused);
+      expect("SELECT count(*) FROM pg_class"
+             " WHERE relname IN ('kb_documents','kb_file_index','kb_embeddings',"
+             " 'kb_pdf_embeddings','kb_doc_regions','kb_table_cells','kb_doc_assets')"
+             "   AND (relrowsecurity OR relforcerowsecurity)",
+             "0");
+      assert(exec_sql("UPDATE kb_doc_assets SET document_key='reader-b.md'"
+                      " WHERE project='scope-reader-b'"
+                      " AND blob_ref='reader-beta-blob'") == 0);
+      printf("  PASS: enabling refuses a structured child without an exact owner\n");
+
+      expect("SELECT kb_content_scope_enable()", "content scope enabled on project content tables");
+      expect("SELECT kb_content_scope_enable()", "content scope enabled on project content tables");
+      printf("  PASS: an already-enabled deployment can re-run the expanded switch atomically\n");
 
       assert(db2_tenant_scope_begin(&reader_a, (int64_t)atoll(team_a)) == 0);
+      expect_project_content_counts("scope-reader-a", "1");
+      expect_project_content_counts("scope-reader-b", "0");
       char *result_a =
           kb_search_json_ex(NULL, "readinessisolationtoken", MEMORY_EMBED_TEST_FIXTURE, 10, "rrf");
       assert(result_a);
@@ -594,8 +868,12 @@ int main(void)
       assert(anonymous_a == 0);
       assert(anonymous_b == 0);
       free(anonymous);
+      expect_project_content_counts("scope-reader-a", "0");
+      expect_project_content_counts("scope-reader-b", "0");
 
       assert(db2_tenant_scope_begin(&reader_b, (int64_t)atoll(team_b)) == 0);
+      expect_project_content_counts("scope-reader-a", "0");
+      expect_project_content_counts("scope-reader-b", "1");
       char *result_b =
           kb_search_json_ex(NULL, "readinessisolationtoken", MEMORY_EMBED_TEST_FIXTURE, 10, "rrf");
       assert(result_b);
@@ -610,8 +888,17 @@ int main(void)
 
       expect("SELECT kb_content_scope_disable()", "content scope disabled");
       printf("  PASS: two users on two teams search only their own project under FORCE RLS\n");
+      printf("  PASS: every vector and structured-document child inherits exact ownership\n");
       printf("  PASS: caller-less search inherits no pooled content identity\n");
 
+      assert(exec_sql("DELETE FROM kb_embeddings"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
+      assert(exec_sql("DELETE FROM kb_pdf_embeddings"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
+      assert(exec_sql("DELETE FROM kb_doc_assets"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
+      assert(exec_sql("DELETE FROM kb_file_index"
+                      " WHERE project IN ('scope-reader-a','scope-reader-b')") == 0);
       assert(exec_sql("DELETE FROM kb_documents"
                       " WHERE project IN ('scope-reader-a','scope-reader-b')"
                       " AND file_path IN ('reader-a.md','reader-b.md')") == 0);


### PR DESCRIPTION
## What changed

- extend the explicit content-scope switch from documents/file index to general and PDF embeddings, document regions, table cells, and document assets
- bind vector rows to their authoritative `kb_documents.point_id` owner for both reads and maintenance writes
- bind document assets by project, generation, and document key
- preflight every covered ownership chain and refuse inconsistent or orphan rows
- make the operator switch atomic and idempotent for deployments that already enabled the earlier document policies
- require the operator role to have full-row audit authority and require every expected RLS policy before enabling
- document upgrade preflight/rollback and update the implementation proposal

## Why

Content scope previously stopped at `kb_documents` and `kb_file_index`. Vector payloads and structured-document descendants remained directly readable, and cached ownership fields could not safely stand in for authoritative parent ownership.

This keeps membership resolution in the KB and uses the already-delivered authenticated caller/maintenance contexts. It adds no fourth identity proof or network credential layer.

## Behavior and operations

Applying `schema.sql` remains inert: it defines policies but does not enable RLS. An operator must repair every reported attribution/ownership mismatch and call `kb_content_scope_enable()`. The call now covers all project-content tables atomically; failures roll back prior RLS flags. Existing enabled deployments should re-run it after upgrade.

## Validation

- `make -s -C src all`
- `make -s -C src build/obj/tests/unit-test-content-scope-pg`
- `make -s -C src lint`
- `git diff --check origin/testing...HEAD`
- Aimee frozen-diff roundtable: approved
- live PostgreSQL RLS execution is exercised in CI (local host has no `AIMEE_TEST_PG_URL`)
