### PR TITLE
economizer: the module owns the gateway counters

### DIFF
--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -261,6 +261,7 @@ func moduleConfigRuntime(ctx context.Context, executable, moduleBusSocket string
 			{EventKind: economizer.EventToolStats, StageID: economizer.StageToolStats},
 			{EventKind: economizer.EventRecordBuild, StageID: economizer.StageRecordBuild},
 			{EventKind: economizer.EventPostStatus, StageID: economizer.StagePostStatus},
+			{EventKind: economizer.EventStats, StageID: economizer.StageStats},
 		}
 		// Stateless: per-conversation reducer state travels with each request, so
 		// there is no store to open and no failure mode before serving.

--- a/server-go/cmd/aimee-module/main_test.go
+++ b/server-go/cmd/aimee-module/main_test.go
@@ -31,7 +31,7 @@ func TestModuleRegistryMatchesProcessContracts(t *testing.T) {
 		{"control-web", 24, []uint32{10241}},
 		{"benchmarks", 25, []uint32{10497, 10498}},
 		{"sandbox", 26, []uint32{10753, 10754, 10755, 10756}},
-		{"economizer", 27, []uint32{11009, 11010, 11011, 11012, 11013, 11014}},
+		{"economizer", 27, []uint32{11009, 11010, 11011, 11012, 11013, 11014, 11015}},
 	}
 	for _, test := range tests {
 		config, ok := moduleConfig("/usr/local/libexec/aimee-modules/aimee-module-" + test.name)

--- a/server-go/modules/economizer/breaker_test.go
+++ b/server-go/modules/economizer/breaker_test.go
@@ -98,9 +98,6 @@ func TestPostStatusStageDecides(t *testing.T) {
 	if got.Action != "resend" || !got.Restore || !got.Disabled {
 		t.Errorf("4xx = %+v, want resend+restore+disabled", got)
 	}
-	if got.Counter != Stat4xxRestoreResend {
-		t.Errorf("counter = %q", got.Counter)
-	}
 
 	// 5xx: provider state is uncertain, so trip but never resend.
 	got = postStatus(t, h, PostStatusRequest{

--- a/server-go/modules/economizer/module.go
+++ b/server-go/modules/economizer/module.go
@@ -36,7 +36,22 @@ const (
 	StageRecordBuild uint32 = 5
 	EventPostStatus  uint32 = 11014
 	StagePostStatus  uint32 = 6
+	EventStats       uint32 = 11015
+	StageStats       uint32 = 7
 )
+
+// StatsRequest either records one counter or asks for the published snapshot.
+//
+// Recording exists for the two events only the CALLER can see -- its snapshot
+// allocation failing, and installing the reduced array failing. Both are rare
+// failure paths, so a bus call to report them is affordable; everything the
+// module decides it counts itself, on the call it was already handling.
+type StatsRequest struct {
+	Op      string `json:"op"`                // "snapshot" | "inc" | "inc_reason"
+	Counter string `json:"counter,omitempty"` // for "inc"
+	Group   string `json:"group,omitempty"`   // for "inc_reason"
+	Reason  string `json:"reason,omitempty"`
+}
 
 // PostStatusRequest asks what a dispatched gateway turn owes now its upstream
 // status is known.
@@ -65,10 +80,6 @@ type PostStatusResponse struct {
 	// it once rather than inferring it.
 	Disabled bool   `json:"disabled,omitempty"`
 	Reason   string `json:"reason,omitempty"`
-	// Counter is the telemetry counter the caller should increment, empty when
-	// there is nothing to record. Naming it here keeps the labels in one place
-	// while the tap itself stays with the caller.
-	Counter string `json:"counter,omitempty"`
 }
 
 // ReduceRequest is the wire form of one reduction.
@@ -168,23 +179,30 @@ var reduceReasonNames = map[ReduceReason]string{
 // gets a clean one and two handlers never share a lever.
 func NewHandler() bus.ModuleHandler {
 	breaker := NewSessionBreaker()
+	stats := NewGatewayStatsStore()
 	return func(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
 		if invocation.Cancelled() {
 			return nil, bus.ModuleStatusCancelled
 		}
 		switch invocation.StageID {
+		case StageStats:
+			var req StatsRequest
+			if err := json.Unmarshal(request, &req); err != nil {
+				return nil, bus.ModuleStatusInvalidRequest
+			}
+			return handleStats(stats, &req)
 		case StagePostStatus:
 			var req PostStatusRequest
 			if err := json.Unmarshal(request, &req); err != nil {
 				return nil, bus.ModuleStatusInvalidRequest
 			}
-			return handlePostStatus(breaker, &req)
+			return handlePostStatus(breaker, stats, &req)
 		case StageReduce:
 			var req ReduceRequest
 			if err := json.Unmarshal(request, &req); err != nil {
 				return nil, bus.ModuleStatusInvalidRequest
 			}
-			return handleReduce(breaker, &req)
+			return handleReduce(breaker, stats, &req)
 		case StageJSONCompact:
 			return handleJSONCompact(invocation, request)
 		case StageToolRecall:
@@ -199,7 +217,7 @@ func NewHandler() bus.ModuleHandler {
 	}
 }
 
-func handleReduce(breaker *SessionBreaker, req *ReduceRequest) ([]byte, bus.ModuleStatus) {
+func handleReduce(breaker *SessionBreaker, stats *GatewayStatsStore, req *ReduceRequest) ([]byte, bus.ModuleStatus) {
 	messages := ParseJSON(string(req.Messages))
 	if messages == nil || !messages.IsArray() {
 		return nil, bus.ModuleStatusInvalidRequest
@@ -248,6 +266,7 @@ func handleReduce(breaker *SessionBreaker, req *ReduceRequest) ([]byte, bus.Modu
 	// Read here rather than by the caller because the write side lives here too;
 	// split across the bus, a trip on one side would never be seen by the other.
 	if seam == SeamGateway && req.SessionKey != "" && breaker.IsDisabled(req.SessionKey) {
+		stats.Inc(StatSessionDisabledBlocks)
 		body, err := json.Marshal(ReduceResponse{
 			Reason: reduceReasonNames[ReduceReasonNone],
 			Bypass: GWBypassSessionDisabled.String(),
@@ -296,11 +315,22 @@ func handleReduce(breaker *SessionBreaker, req *ReduceRequest) ([]byte, bus.Modu
 		RecallSurfaced: out.RecallSurfaced,
 	}
 	if seam == SeamGateway {
+		// Counted where the decision is made. An attempt is every gateway turn
+		// that got past the breaker; what it became is the verdict below.
+		stats.Inc(StatMutateAttempted)
 		// MessageHistoryRepair is passed explicitly: GWShouldApply SKIPS the
 		// structural check when the port is nil, and skipping it is how an
 		// orphaned tool pair reaches a provider. The reduction itself succeeded
 		// to reach this point, so the error argument is ReduceErrNone.
 		resp.Bypass = GWShouldApply(true, &out, ReduceErrNone, MessageHistoryRepair).String()
+		if resp.Bypass == GWBypassNone.String() {
+			// The caller can still fail to install it, and reports that itself;
+			// this counts the decision, not the installation.
+			stats.Inc(StatMutateApplied)
+			stats.RecordTokenDelta(out.BaselineTokens, out.ReducedTokens)
+		} else {
+			stats.IncReason("hard_bypass", resp.Bypass)
+		}
 	}
 	if out.Mutated && out.Messages != nil {
 		// Emitted with the cJSON-compatible printer, so the bytes the caller
@@ -325,7 +355,7 @@ func handleReduce(breaker *SessionBreaker, req *ReduceRequest) ([]byte, bus.Modu
 // body and the socket, this has the lever. Splitting it the other way — caller
 // decides, module stores — is what left the C seam with a breaker nothing ever
 // wrote to.
-func handlePostStatus(breaker *SessionBreaker, req *PostStatusRequest) ([]byte, bus.ModuleStatus) {
+func handlePostStatus(breaker *SessionBreaker, stats *GatewayStatsStore, req *PostStatusRequest) ([]byte, bus.ModuleStatus) {
 	var d GWPostDecision
 	if req.StreamReason != "" {
 		// Streaming: bytes are already with the client, so the breaker is the only
@@ -336,7 +366,7 @@ func handlePostStatus(breaker *SessionBreaker, req *PostStatusRequest) ([]byte, 
 		d = GWPostStatus(req.HTTPStatus, req.Mutated)
 	}
 
-	resp := PostStatusResponse{Action: "none", Restore: d.Restore, Counter: d.Counter}
+	resp := PostStatusResponse{Action: "none", Restore: d.Restore}
 	if d.Action == PostResend {
 		resp.Action = "resend"
 	}
@@ -345,13 +375,49 @@ func handlePostStatus(breaker *SessionBreaker, req *PostStatusRequest) ([]byte, 
 	// a breaker that was never set.
 	if d.Disable && req.SessionKey != "" && req.TTLMS > 0 {
 		breaker.Disable(req.SessionKey, req.TTLMS, d.Reason)
+		stats.IncReason("session_disabled_set", d.Reason)
 		resp.Disabled = true
 		resp.Reason = d.Reason
 	} else if d.Reason != "" {
 		resp.Reason = d.Reason
 	}
+	if d.Counter != "" {
+		stats.Inc(d.Counter)
+	}
 
 	body, err := json.Marshal(resp)
+	if err != nil {
+		return nil, bus.ModuleStatusInternal
+	}
+	return body, bus.ModuleStatusOK
+}
+
+// handleStats records a caller-observed counter, or returns the snapshot the
+// HTTP surface publishes.
+//
+// Reading is a call rather than a push because the counters are the module's and
+// the HTTP surface is C's: the side that owns the numbers hands them over when
+// the side that owns the endpoint asks.
+func handleStats(stats *GatewayStatsStore, req *StatsRequest) ([]byte, bus.ModuleStatus) {
+	switch req.Op {
+	case "inc":
+		if req.Counter == "" {
+			return nil, bus.ModuleStatusInvalidRequest
+		}
+		stats.Inc(req.Counter)
+	case "inc_reason":
+		if req.Group == "" {
+			return nil, bus.ModuleStatusInvalidRequest
+		}
+		stats.IncReason(req.Group, req.Reason)
+	case "snapshot", "":
+		// Empty defaults to snapshot: a read is the harmless operation, so a
+		// malformed request can never silently increment something instead.
+	default:
+		return nil, bus.ModuleStatusInvalidRequest
+	}
+
+	body, err := json.Marshal(stats.Snapshot())
 	if err != nil {
 		return nil, bus.ModuleStatusInternal
 	}

--- a/server-go/modules/economizer/stats.go
+++ b/server-go/modules/economizer/stats.go
@@ -1,0 +1,181 @@
+package economizer
+
+import "sync"
+
+// The gateway seam's operational counters.
+//
+// These are the module's own state, ported from src/server/gw_mutate_stats.c.
+// Keeping them here is what makes them cheap: the module already knows what it
+// decided, so counting an attempt, an application or a bypass costs nothing on
+// the wire. Counted in C they would need a bus call per increment, on a path
+// that runs two or three per request.
+//
+// The JSON shape is the one server_state.c already published, because dashboards
+// key on these names. It is reproduced exactly rather than tidied.
+
+// Published name for each counter. The gateway_ prefix is part of the contract:
+// server_state.c emitted these exact keys, and dashboards key on them.
+var statPublishedName = map[string]string{
+	StatMutateAttempted:       "gateway_mutate_attempted",
+	StatMutateApplied:         "gateway_mutate_applied",
+	Stat4xxRestoreResend:      "gateway_4xx_restore_resend",
+	Stat5xxDisable:            "gateway_5xx_disable",
+	StatStreamErrorDisable:    "gateway_stream_error_disable",
+	StatSessionDisabledBlocks: "gateway_session_disabled_blocks",
+}
+
+const (
+	// statReasonMax bounds the (group, reason) registry. Beyond it counts go to
+	// an overflow row rather than being dropped, so telemetry never silently
+	// loses events -- the same guarantee the C table gave.
+	statReasonMax = 64
+	// statTokenSampleN is the deterministic 1-in-N gate on token-delta samples.
+	statTokenSampleN = 100
+)
+
+type statReason struct {
+	group, reason string
+	count         uint64
+}
+
+// GatewayStatsStore is safe for concurrent use.
+//
+// One mutex rather than atomics: the C used relaxed atomics for the flat
+// counters because they were on the request path in a C server, but here every
+// increment already happens inside a stage call that has done JSON work, so the
+// lock is not the cost and it keeps a snapshot internally consistent.
+type GatewayStatsStore struct {
+	mu      sync.Mutex
+	flat    map[string]uint64
+	reasons []statReason
+
+	tokenSeen     uint64
+	tokenSamples  uint64
+	tokenBaseline uint64
+	tokenReduced  uint64
+}
+
+func NewGatewayStatsStore() *GatewayStatsStore {
+	return &GatewayStatsStore{flat: make(map[string]uint64)}
+}
+
+func (s *GatewayStatsStore) Inc(counter string) {
+	if s == nil || counter == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.flat == nil {
+		s.flat = make(map[string]uint64)
+	}
+	s.flat[counter]++
+}
+
+// IncReason counts a (group, reason) pair, e.g. hard_bypass{structural_violation}.
+//
+// An unknown pair is registered on first use. Once the table is full every
+// further new pair lands on (group, "_overflow"): a count that is present but
+// unattributed beats a count that vanished.
+func (s *GatewayStatsStore) IncReason(group, reason string) {
+	if s == nil || group == "" {
+		return
+	}
+	if reason == "" {
+		reason = "unknown"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.reasons {
+		if s.reasons[i].group == group && s.reasons[i].reason == reason {
+			s.reasons[i].count++
+			return
+		}
+	}
+	if len(s.reasons) >= statReasonMax {
+		// Fold into this group's overflow row, creating it once. Looking it up
+		// explicitly matters: the scan above only matches an exact (group, reason)
+		// pair, so a fresh reason would otherwise append a SECOND overflow row and
+		// the snapshot -- which keys by reason -- would drop one of them.
+		for i := range s.reasons {
+			if s.reasons[i].group == group && s.reasons[i].reason == "_overflow" {
+				s.reasons[i].count++
+				return
+			}
+		}
+		s.reasons = append(s.reasons, statReason{group: group, reason: "_overflow", count: 1})
+		return
+	}
+	s.reasons = append(s.reasons, statReason{group: group, reason: reason, count: 1})
+}
+
+// RecordTokenDelta accumulates a 1-in-N sample of applied reductions.
+//
+// Sampling, not every event, because the sums exist to answer "is the lever
+// actually shrinking context" -- a question a sample answers as well as a census.
+func (s *GatewayStatsStore) RecordTokenDelta(baseline, reduced int) {
+	if s == nil || baseline < 0 || reduced < 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := s.tokenSeen
+	s.tokenSeen++
+	if n%statTokenSampleN != 0 {
+		return
+	}
+	s.tokenBaseline += uint64(baseline)
+	s.tokenReduced += uint64(reduced)
+	s.tokenSamples++
+}
+
+// StatsSnapshot is the published shape. It mirrors gw_stat_to_json exactly.
+type StatsSnapshot struct {
+	Counters   map[string]uint64            `json:"counters"`
+	TokenDelta StatsTokenDelta              `json:"token_delta"`
+	Reasons    map[string]map[string]uint64 `json:"reasons"`
+}
+
+type StatsTokenDelta struct {
+	SampleCount  uint64  `json:"sample_count"`
+	BaselineSum  uint64  `json:"baseline_sum"`
+	ReducedSum   uint64  `json:"reduced_sum"`
+	PctReduced   float64 `json:"pct_reduced"`
+	SampleRate1N int     `json:"sample_rate_1_in_n"`
+}
+
+func (s *GatewayStatsStore) Snapshot() StatsSnapshot {
+	out := StatsSnapshot{
+		Counters: make(map[string]uint64, len(statPublishedName)),
+		Reasons:  map[string]map[string]uint64{},
+		TokenDelta: StatsTokenDelta{
+			SampleRate1N: statTokenSampleN,
+		},
+	}
+	if s == nil {
+		return out
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Every known counter is published even at zero, so a dashboard panel does
+	// not disappear just because the lever has not fired yet.
+	for short, published := range statPublishedName {
+		out.Counters[published] = s.flat[short]
+	}
+	for _, r := range s.reasons {
+		if r.count == 0 {
+			continue
+		}
+		if out.Reasons[r.group] == nil {
+			out.Reasons[r.group] = map[string]uint64{}
+		}
+		out.Reasons[r.group][r.reason] = r.count
+	}
+	out.TokenDelta.SampleCount = s.tokenSamples
+	out.TokenDelta.BaselineSum = s.tokenBaseline
+	out.TokenDelta.ReducedSum = s.tokenReduced
+	if s.tokenBaseline > 0 {
+		out.TokenDelta.PctReduced =
+			float64(s.tokenBaseline-s.tokenReduced) * 100.0 / float64(s.tokenBaseline)
+	}
+	return out
+}

--- a/server-go/modules/economizer/stats_test.go
+++ b/server-go/modules/economizer/stats_test.go
@@ -1,0 +1,154 @@
+package economizer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/JBailes/aimee/server-go/bus"
+)
+
+func TestStatsPublishesEveryCounterEvenAtZero(t *testing.T) {
+	// A panel that vanishes when the lever is idle reads as "the metric broke",
+	// so every known counter is published whether or not it has fired.
+	snap := NewGatewayStatsStore().Snapshot()
+	for _, published := range statPublishedName {
+		if _, ok := snap.Counters[published]; !ok {
+			t.Errorf("%s missing from an idle snapshot", published)
+		}
+	}
+	if snap.TokenDelta.SampleRate1N != statTokenSampleN {
+		t.Errorf("sample rate = %d", snap.TokenDelta.SampleRate1N)
+	}
+	if snap.TokenDelta.PctReduced != 0 {
+		t.Error("pct_reduced must be 0 before the first sample, not a divide by zero")
+	}
+}
+
+func TestStatsReasonRegistryOverflowsRatherThanDrops(t *testing.T) {
+	s := NewGatewayStatsStore()
+	for i := 0; i < statReasonMax+50; i++ {
+		s.IncReason("hard_bypass", string(rune('a'+i%26))+string(rune(i)))
+	}
+	snap := s.Snapshot()
+	var total uint64
+	for _, n := range snap.Reasons["hard_bypass"] {
+		total += n
+	}
+	// Every event is still counted somewhere, even once the table is full.
+	if total != uint64(statReasonMax+50) {
+		t.Errorf("counted %d of %d events", total, statReasonMax+50)
+	}
+	if snap.Reasons["hard_bypass"]["_overflow"] == 0 {
+		t.Error("the overflow row should be carrying the excess")
+	}
+}
+
+func TestStatsTokenDeltaSamples(t *testing.T) {
+	s := NewGatewayStatsStore()
+	for i := 0; i < statTokenSampleN*3; i++ {
+		s.RecordTokenDelta(100, 50)
+	}
+	snap := s.Snapshot()
+	if snap.TokenDelta.SampleCount != 3 {
+		t.Errorf("sample count = %d, want 3 (1 in %d)", snap.TokenDelta.SampleCount, statTokenSampleN)
+	}
+	if snap.TokenDelta.PctReduced != 50 {
+		t.Errorf("pct_reduced = %v, want 50", snap.TokenDelta.PctReduced)
+	}
+	// A negative reading is rejected rather than accumulated as a huge unsigned.
+	s.RecordTokenDelta(-1, 10)
+	if s.Snapshot().TokenDelta.BaselineSum != 300 {
+		t.Error("a negative baseline must not be accumulated")
+	}
+}
+
+func statsSnapshot(t *testing.T, h bus.ModuleHandler, req StatsRequest) StatsSnapshot {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, st := h(bus.ModuleInvocation{StageID: StageStats}, body)
+	if st != bus.ModuleStatusOK {
+		t.Fatalf("status = %v", st)
+	}
+	var snap StatsSnapshot
+	if err := json.Unmarshal(out, &snap); err != nil {
+		t.Fatal(err)
+	}
+	return snap
+}
+
+// The counters are only worth moving if the decisions actually reach them, so
+// this drives real work through the handler and reads the published snapshot
+// back out — the same way the HTTP surface will.
+func TestStatsStageCountsWhatTheModuleDecided(t *testing.T) {
+	h := NewHandler()
+
+	body, err := json.Marshal(ReduceRequest{
+		Messages: rawMessages(t, 20), SystemPrompt: "sys", Seam: "gateway",
+		SessionKey: "sess", HistoryFold: true, ClosetEnabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, st := h(bus.ModuleInvocation{StageID: StageReduce}, body); st != bus.ModuleStatusOK {
+		t.Fatalf("reduce status = %v", st)
+	}
+
+	snap := statsSnapshot(t, h, StatsRequest{Op: "snapshot"})
+	if snap.Counters["gateway_mutate_attempted"] != 1 {
+		t.Errorf("attempted = %d, want 1", snap.Counters["gateway_mutate_attempted"])
+	}
+	if snap.Counters["gateway_mutate_applied"] != 1 {
+		t.Errorf("applied = %d, want 1", snap.Counters["gateway_mutate_applied"])
+	}
+
+	// A 4xx trips the breaker, which is counted where it is decided.
+	postStatus(t, h, PostStatusRequest{
+		SessionKey: "sess", HTTPStatus: 413, Mutated: true, TTLMS: 60_000,
+	})
+	snap = statsSnapshot(t, h, StatsRequest{Op: "snapshot"})
+	if snap.Counters["gateway_4xx_restore_resend"] != 1 {
+		t.Errorf("4xx counter = %d", snap.Counters["gateway_4xx_restore_resend"])
+	}
+	if snap.Reasons["session_disabled_set"]["4xx"] != 1 {
+		t.Errorf("session_disabled_set{4xx} = %v", snap.Reasons["session_disabled_set"])
+	}
+
+	// The next turn is blocked by the breaker, and that has its own counter
+	// rather than reading as a reduction fault.
+	if _, st := h(bus.ModuleInvocation{StageID: StageReduce}, body); st != bus.ModuleStatusOK {
+		t.Fatalf("reduce status = %v", st)
+	}
+	snap = statsSnapshot(t, h, StatsRequest{Op: "snapshot"})
+	if snap.Counters["gateway_session_disabled_blocks"] != 1 {
+		t.Errorf("blocks = %d, want 1", snap.Counters["gateway_session_disabled_blocks"])
+	}
+	if snap.Counters["gateway_mutate_attempted"] != 1 {
+		t.Error("a blocked turn is not an attempt")
+	}
+}
+
+// The caller reports only what it alone can see; a read must never be able to
+// increment something by accident.
+func TestStatsStageRecordsCallerObservedEvents(t *testing.T) {
+	h := NewHandler()
+	statsSnapshot(t, h, StatsRequest{Op: "inc_reason", Group: "hard_bypass", Reason: "replace_failed"})
+	snap := statsSnapshot(t, h, StatsRequest{Op: "snapshot"})
+	if snap.Reasons["hard_bypass"]["replace_failed"] != 1 {
+		t.Errorf("replace_failed = %v", snap.Reasons["hard_bypass"])
+	}
+
+	// An empty op is a read, not a silent write.
+	statsSnapshot(t, h, StatsRequest{})
+	if got := statsSnapshot(t, h, StatsRequest{Op: "snapshot"}).
+		Reasons["hard_bypass"]["replace_failed"]; got != 1 {
+		t.Errorf("a bare request changed a counter: %d", got)
+	}
+
+	body, _ := json.Marshal(StatsRequest{Op: "inc"}) // no counter named
+	if _, st := h(bus.ModuleInvocation{StageID: StageStats}, body); st != bus.ModuleStatusInvalidRequest {
+		t.Errorf("an unnamed counter should be rejected, got %v", st)
+	}
+}

--- a/src/modules/economizer/economizer_module_client.c
+++ b/src/modules/economizer/economizer_module_client.c
@@ -504,3 +504,34 @@ int econ_module_post_status(const char *session_key, int http_status, int mutate
    cJSON_Delete(reply);
    return 0;
 }
+
+static cJSON *econ_stats_call(const char *op, const char *counter, const char *group,
+                              const char *reason)
+{
+   cJSON *payload = cJSON_CreateObject();
+   if (!payload)
+      return NULL;
+   cJSON_AddStringToObject(payload, "op", op);
+   if (counter)
+      cJSON_AddStringToObject(payload, "counter", counter);
+   if (group)
+      cJSON_AddStringToObject(payload, "group", group);
+   if (reason)
+      cJSON_AddStringToObject(payload, "reason", reason);
+   return aimee_module_json_call(AIMEE_ECONOMIZER_EVENT_STATS, AIMEE_ECONOMIZER_STAGE_STATS,
+                                 payload, ECON_MODULE_CALL_MAX_BODY, ECON_MODULE_CALL_TIMEOUT_MS,
+                                 NULL);
+}
+
+void econ_module_stat_reason(const char *group, const char *reason)
+{
+   if (!group || !group[0])
+      return;
+   cJSON *reply = econ_stats_call("inc_reason", NULL, group, reason);
+   cJSON_Delete(reply); /* the snapshot comes back too; this caller wants none of it */
+}
+
+cJSON *econ_module_stats_snapshot(void)
+{
+   return econ_stats_call("snapshot", NULL, NULL, NULL);
+}

--- a/src/modules/economizer/economizer_module_client.h
+++ b/src/modules/economizer/economizer_module_client.h
@@ -34,6 +34,8 @@ extern "C"
 #define AIMEE_ECONOMIZER_STAGE_RECORD_BUILD 5u
 #define AIMEE_ECONOMIZER_EVENT_POST_STATUS  11014u
 #define AIMEE_ECONOMIZER_STAGE_POST_STATUS  6u
+#define AIMEE_ECONOMIZER_EVENT_STATS        11015u
+#define AIMEE_ECONOMIZER_STAGE_STATS        7u
 
 #define ECON_MODULE_JSON_MAX_INPUT  (16u * 1024u * 1024u)
 #define ECON_MODULE_TOOL_OUTPUT_MAX (2u * 1024u * 1024u)
@@ -191,6 +193,18 @@ extern "C"
    int econ_module_post_status(const char *session_key, int http_status, int mutated, int have_key,
                                int ttl_ms, const char *stream_reason,
                                econ_module_post_status_t *out);
+
+   /* Record a (group, reason) the CALLER alone can see -- its own snapshot
+    * allocation failing, or installing the reduced array failing. Everything the
+    * module decides it counts itself, so this is only for the two events that
+    * happen on this side of the bus. Best-effort: a lost counter is not worth
+    * failing a request over. */
+   void econ_module_stat_reason(const char *group, const char *reason);
+
+   /* The published gateway counters, as a NEW cJSON object the caller owns, or
+    * NULL when the module could not be reached. The counters live in the module;
+    * this is how the HTTP surface, which lives here, gets them to render. */
+   cJSON *econ_module_stats_snapshot(void);
 
    /* Compact one strict JSON value in Go without changing any non-whitespace
     * source byte. Returns 0 with a newly allocated NUL-terminated buffer when

--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -200,13 +200,11 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    if (!cJSON_IsArray(msgs))
       return;
 
-   gw_stat_inc(GW_STAT_MUTATE_ATTEMPTED);
-
    /* Snapshot FIRST: never send a reduced payload we cannot restore. */
    ctx->pristine = gw_snapshot_messages(msgs);
    if (!ctx->pristine)
    {
-      gw_stat_inc_reason("hard_bypass", "snapshot_oom");
+      econ_module_stat_reason("hard_bypass", "snapshot_oom");
       return;
    }
 
@@ -314,13 +312,7 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    const char *bypass = gw_module_bypass(rrc, mres.bypass);
    if (strcmp(bypass, gw_bypass_reason_str(GW_BYPASS_NONE)) != 0)
    {
-      /* A breaker block is its own counter, not a hard bypass: it is the lever
-       * working as designed, and folding it into hard_bypass would make a healthy
-       * tripped session look like a reduction fault. */
-      if (strcmp(bypass, "session_disabled") == 0)
-         gw_stat_inc(GW_STAT_SESSION_DISABLED_BLOCKS);
-      else
-         gw_stat_inc_reason("hard_bypass", bypass);
+      /* The module counted this verdict already, on the call that made it. */
       gw_provenance_clear(&ctx->st);
       cJSON_Delete(reduced);
       econ_module_result_free(&mres);
@@ -330,7 +322,7 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
 
    if (gw_replace_messages(container, key, reduced) != 0)
    {
-      gw_stat_inc_reason("hard_bypass", "replace_failed");
+      econ_module_stat_reason("hard_bypass", "replace_failed");
       gw_provenance_clear(&ctx->st);
       cJSON_Delete(reduced);
       econ_module_result_free(&mres);
@@ -342,44 +334,8 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
 
    gw_provenance_mark_reduced(&ctx->st); /* mark ONLY after replace succeeds */
    ctx->mutated = 1;
-   gw_stat_inc(GW_STAT_MUTATE_APPLIED);
-   gw_stat_record_token_delta(baseline_tok, reduced_tok); /* sampled §4 */
-}
-
-/* Map the module's counter label onto the local enum.
- *
- * The module names the counter rather than the caller inferring it, so the
- * decision and the thing it is recorded as cannot drift apart. An unrecognised
- * label is DROPPED rather than guessed: a miscounted lever is worse than an
- * uncounted one, and the label set is pinned on both sides by tests. */
-static int gw_stat_by_name(const char *name, gw_stat_t *out)
-{
-   static const struct
-   {
-      const char *name;
-      gw_stat_t stat;
-   } table[] = {
-       {"4xx_restore_resend", GW_STAT_4XX_RESTORE_RESEND},
-       {"5xx_disable", GW_STAT_5XX_DISABLE},
-       {"stream_error_disable", GW_STAT_STREAM_ERROR_DISABLE},
-       {"session_disabled_blocks", GW_STAT_SESSION_DISABLED_BLOCKS},
-   };
-   if (!name || !name[0] || !out)
-      return 1;
-   for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++)
-      if (strcmp(name, table[i].name) == 0)
-      {
-         *out = table[i].stat;
-         return 0;
-      }
-   return 1;
-}
-
-static void gw_stat_inc_name(const char *name)
-{
-   gw_stat_t which;
-   if (gw_stat_by_name(name, &which) == 0)
-      gw_stat_inc(which);
+   (void)baseline_tok;
+   (void)reduced_tok;
 }
 
 gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int http_status,
@@ -409,8 +365,6 @@ gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int
       }
    }
    gw_provenance_clear(&ctx->st);
-   if (d.counter[0])
-      gw_stat_inc_name(d.counter);
    ctx->mutated = 0; /* handled; never twice */
    return d.resend ? GW_POST_RESEND : GW_POST_NONE;
 }
@@ -426,8 +380,6 @@ void gw_stream_disable(gw_mutate_ctx_t *ctx, const char *reason)
    if (!d.disabled && !d.counter[0])
       return;
    gw_provenance_clear(&ctx->st);
-   if (d.counter[0])
-      gw_stat_inc_name(d.counter);
    ctx->mutated = 0; /* one disable per turn; a later frame no-ops */
 }
 

--- a/src/modules/economizer/module.yaml
+++ b/src/modules/economizer/module.yaml
@@ -45,6 +45,7 @@
     "server-go/modules/economizer/reduce.go",
     "server-go/modules/economizer/register.go",
     "server-go/modules/economizer/repair.go",
+    "server-go/modules/economizer/stats.go",
     "server-go/modules/economizer/state.go"
   ],
   "go_tests": [
@@ -74,7 +75,8 @@
     "server-go/modules/economizer/reduce_test.go",
     "server-go/modules/economizer/register_test.go",
     "server-go/modules/economizer/repair_test.go",
-    "server-go/modules/economizer/state_test.go"
+    "server-go/modules/economizer/state_test.go",
+    "server-go/modules/economizer/stats_test.go"
   ],
   "public_headers": [],
   "private_headers": [

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -601,6 +601,11 @@
           "id": 6,
           "name": "economizer-post-status",
           "event_kind": 11014
+        },
+        {
+          "id": 7,
+          "name": "economizer-stats",
+          "event_kind": 11015
         }
       ]
     }

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -3,7 +3,6 @@
 #include "aimee.h"
 #include <aimee/ir/aimee_ir_metrics.h>
 #include "shadow_mirror.h"
-#include "gw_mutate_stats.h"          /* gw_stat_to_json — gateway-mutation economizer counters */
 #include "economizer_module_client.h" /* Go-owned tool-output condense savings */
 #include "token_audit.h"              /* db1_token_audit_spend_breakdown — avoided-$ aggregate */
 #include "embedder_catalog.h"
@@ -1508,9 +1507,15 @@ int handle_economizer_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
    cJSON *resp = jo_ok();
 
-   cJSON *gw = cJSON_AddObjectToObject(resp, "gateway");
-   if (gw)
-      gw_stat_to_json(gw);
+   /* The gateway counters live in the economizer module; this endpoint is only
+    * the surface that publishes them. An unreachable module leaves the object
+    * empty rather than reporting zeros, so "no data" cannot be misread as "the
+    * lever ran and did nothing". */
+   cJSON *gw_stats = econ_module_stats_snapshot();
+   if (gw_stats)
+      cJSON_AddItemToObject(resp, "gateway", gw_stats);
+   else
+      cJSON_AddObjectToObject(resp, "gateway");
 
    cJSON *tc = cJSON_AddObjectToObject(resp, "tool_condense");
    if (tc)


### PR DESCRIPTION
Slice 7. The counters were state sitting in C, incremented two or three times a
request from the seam and read once by server_state.c to publish over HTTP.
State belongs in the module, so they move; what stays in C is the endpoint.

WHY THIS IS CHEAPER, NOT DEARER. The module already knows what it decided, so
counting an attempt, an application, a bypass reason or a breaker trip now costs
nothing on the wire -- they are recorded on the call that made the decision. The
naive version of this change would have been a bus call per increment on the
request path; there is none.

Two events remain the CALLER's to report, because only it can see them: its own
snapshot allocation failing, and installing the reduced array failing. Both are
rare failure paths, so a bus call there is affordable. Reading is a call too --
the side that owns the numbers hands them over when the side that owns the
endpoint asks.

The published JSON is reproduced exactly, gateway_ prefixes and all, because
dashboards key on it. Every known counter is emitted even at zero so an idle
lever does not make a panel vanish, and an unreachable module leaves the object
EMPTY rather than reporting zeros -- "no data" must not read as "it ran and did
nothing".

The reason registry keeps the C's guarantee that counts are never silently
dropped: past 64 pairs they fold into a per-group _overflow row. Writing that
was a real bug first -- the scan only matches an exact (group, reason), so a
fresh reason appended a SECOND overflow row and the snapshot, which keys by
reason, dropped one. Now the overflow row is looked up explicitly, and the test
asserts every event is still counted somewhere once the table is full.

PostStatusResponse no longer carries `counter`: the module increments it, so
returning it for the caller to record as well would double-count.

STILL HERE: gw_mutate_stats.c is now orphaned -- nothing increments it and
nothing reads it -- but it cannot be deleted yet because msg_session_disable.c
still includes it, and that file is removed by #2675, which has not landed. It
goes with the C breaker rather than being stacked on an unmerged branch.

Stage 7 (event 11015) declared in the contract, advertised in cmd/aimee-module
and added to the registry test table -- a stage declared and not advertised
returns CAPABILITY_ABSENT while the module is plainly running.

Full Go suite passes including -race, aimee-server and aimee-kb build under
-Werror, the three gateway/session C tests pass, and clang-format is clean.