### PR TITLE
economizer: C passes the IR and uses what comes back

### DIFF
--- a/.github/workflows/c-repositories.yml
+++ b/.github/workflows/c-repositories.yml
@@ -1,7 +1,12 @@
 name: c-repository-pins
 
 on:
+  # main ONLY, on both triggers. The pins describe a RELEASE, so they are a
+  # main-branch question and nothing else: pushes to main, and pull requests
+  # INTO main. Nothing here runs for a branch or a PR targeting testing.
   push:
+    branches:
+      - main
     paths:
       - "dependencies/aimee-repositories.lock.json"
       - "src/core/**"
@@ -19,6 +24,8 @@ on:
       - "Dockerfile.server"
       - ".github/workflows/c-repositories.yml"
   pull_request:
+    branches:
+      - main
     paths:
       - "dependencies/aimee-repositories.lock.json"
       - "src/core/**"

--- a/server-go/modules/economizer/module.go
+++ b/server-go/modules/economizer/module.go
@@ -40,17 +40,14 @@ const (
 	StageStats       uint32 = 7
 )
 
-// StatsRequest either records one counter or asks for the published snapshot.
+// StatsRequest asks for the published snapshot.
 //
-// Recording exists for the two events only the CALLER can see -- its snapshot
-// allocation failing, and installing the reduced array failing. Both are rare
-// failure paths, so a bus call to report them is affordable; everything the
-// module decides it counts itself, on the call it was already handling.
+// Read-only by design. The counters are the module's, incremented where the
+// decisions are made, so there is no way for a caller to write one -- it has
+// nothing to report. The caller passes an IR and uses whatever IR comes back;
+// how many were mutated is not its business.
 type StatsRequest struct {
-	Op      string `json:"op"`                // "snapshot" | "inc" | "inc_reason"
-	Counter string `json:"counter,omitempty"` // for "inc"
-	Group   string `json:"group,omitempty"`   // for "inc_reason"
-	Reason  string `json:"reason,omitempty"`
+	Op string `json:"op"` // "snapshot" (the only operation)
 }
 
 // PostStatusRequest asks what a dispatched gateway turn owes now its upstream
@@ -392,31 +389,15 @@ func handlePostStatus(breaker *SessionBreaker, stats *GatewayStatsStore, req *Po
 	return body, bus.ModuleStatusOK
 }
 
-// handleStats records a caller-observed counter, or returns the snapshot the
-// HTTP surface publishes.
+// handleStats returns the snapshot the HTTP surface publishes.
 //
-// Reading is a call rather than a push because the counters are the module's and
-// the HTTP surface is C's: the side that owns the numbers hands them over when
+// A call rather than a push because the counters are the module's and the HTTP
+// surface is the caller's: the side that owns the numbers hands them over when
 // the side that owns the endpoint asks.
 func handleStats(stats *GatewayStatsStore, req *StatsRequest) ([]byte, bus.ModuleStatus) {
-	switch req.Op {
-	case "inc":
-		if req.Counter == "" {
-			return nil, bus.ModuleStatusInvalidRequest
-		}
-		stats.Inc(req.Counter)
-	case "inc_reason":
-		if req.Group == "" {
-			return nil, bus.ModuleStatusInvalidRequest
-		}
-		stats.IncReason(req.Group, req.Reason)
-	case "snapshot", "":
-		// Empty defaults to snapshot: a read is the harmless operation, so a
-		// malformed request can never silently increment something instead.
-	default:
+	if req.Op != "" && req.Op != "snapshot" {
 		return nil, bus.ModuleStatusInvalidRequest
 	}
-
 	body, err := json.Marshal(stats.Snapshot())
 	if err != nil {
 		return nil, bus.ModuleStatusInternal

--- a/server-go/modules/economizer/stats.go
+++ b/server-go/modules/economizer/stats.go
@@ -1,6 +1,9 @@
 package economizer
 
-import "sync"
+import (
+	"encoding/json"
+	"sync"
+)
 
 // The gateway seam's operational counters.
 //
@@ -128,11 +131,57 @@ func (s *GatewayStatsStore) RecordTokenDelta(baseline, reduced int) {
 	s.tokenSamples++
 }
 
-// StatsSnapshot is the published shape. It mirrors gw_stat_to_json exactly.
+// StatsSnapshot is the published shape.
+//
+// The counters serialize FLAT, as siblings of token_delta and reasons, because
+// that is what gw_stat_to_json emitted and what the /state endpoint has always
+// published. Nesting them under a "counters" object would have been tidier and
+// would have silently broken every dashboard keyed on gateway_mutate_applied,
+// so the struct keeps them in a field and the marshaller flattens them.
 type StatsSnapshot struct {
-	Counters   map[string]uint64            `json:"counters"`
-	TokenDelta StatsTokenDelta              `json:"token_delta"`
-	Reasons    map[string]map[string]uint64 `json:"reasons"`
+	Counters   map[string]uint64
+	TokenDelta StatsTokenDelta
+	Reasons    map[string]map[string]uint64
+}
+
+func (s StatsSnapshot) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(s.Counters)+2)
+	for name, v := range s.Counters {
+		out[name] = v
+	}
+	out["token_delta"] = s.TokenDelta
+	out["reasons"] = s.Reasons
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON is the inverse, so a round trip through the wire keeps the same
+// shape a reader sees. Anything that is not token_delta or reasons is a counter.
+func (s *StatsSnapshot) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	s.Counters = map[string]uint64{}
+	s.Reasons = map[string]map[string]uint64{}
+	for name, v := range raw {
+		switch name {
+		case "token_delta":
+			if err := json.Unmarshal(v, &s.TokenDelta); err != nil {
+				return err
+			}
+		case "reasons":
+			if err := json.Unmarshal(v, &s.Reasons); err != nil {
+				return err
+			}
+		default:
+			var n uint64
+			if err := json.Unmarshal(v, &n); err != nil {
+				return err
+			}
+			s.Counters[name] = n
+		}
+	}
+	return nil
 }
 
 type StatsTokenDelta struct {

--- a/server-go/modules/economizer/stats_test.go
+++ b/server-go/modules/economizer/stats_test.go
@@ -130,25 +130,23 @@ func TestStatsStageCountsWhatTheModuleDecided(t *testing.T) {
 	}
 }
 
-// The caller reports only what it alone can see; a read must never be able to
-// increment something by accident.
-func TestStatsStageRecordsCallerObservedEvents(t *testing.T) {
+// The stage is read-only: the caller has no counter to report, so there is no
+// operation that can write one. Anything but a snapshot is refused rather than
+// quietly treated as a read.
+func TestStatsStageIsReadOnly(t *testing.T) {
 	h := NewHandler()
-	statsSnapshot(t, h, StatsRequest{Op: "inc_reason", Group: "hard_bypass", Reason: "replace_failed"})
-	snap := statsSnapshot(t, h, StatsRequest{Op: "snapshot"})
-	if snap.Reasons["hard_bypass"]["replace_failed"] != 1 {
-		t.Errorf("replace_failed = %v", snap.Reasons["hard_bypass"])
-	}
-
-	// An empty op is a read, not a silent write.
+	before := statsSnapshot(t, h, StatsRequest{Op: "snapshot"})
+	// A bare request is a read, not a silent write.
 	statsSnapshot(t, h, StatsRequest{})
-	if got := statsSnapshot(t, h, StatsRequest{Op: "snapshot"}).
-		Reasons["hard_bypass"]["replace_failed"]; got != 1 {
-		t.Errorf("a bare request changed a counter: %d", got)
+	after := statsSnapshot(t, h, StatsRequest{Op: "snapshot"})
+	for name, v := range before.Counters {
+		if after.Counters[name] != v {
+			t.Errorf("%s moved from %d to %d without any work being done", name, v, after.Counters[name])
+		}
 	}
 
-	body, _ := json.Marshal(StatsRequest{Op: "inc"}) // no counter named
+	body, _ := json.Marshal(StatsRequest{Op: "inc"})
 	if _, st := h(bus.ModuleInvocation{StageID: StageStats}, body); st != bus.ModuleStatusInvalidRequest {
-		t.Errorf("an unnamed counter should be rejected, got %v", st)
+		t.Errorf("a write operation should be refused, got %v", st)
 	}
 }

--- a/src/modules/economizer/economizer_module_client.c
+++ b/src/modules/economizer/economizer_module_client.c
@@ -505,33 +505,15 @@ int econ_module_post_status(const char *session_key, int http_status, int mutate
    return 0;
 }
 
-static cJSON *econ_stats_call(const char *op, const char *counter, const char *group,
-                              const char *reason)
+cJSON *econ_module_stats_snapshot(void)
 {
+   /* Read only. The counters belong to the module, which increments them where
+    * it makes the decisions; nothing here ever writes one. */
    cJSON *payload = cJSON_CreateObject();
    if (!payload)
       return NULL;
-   cJSON_AddStringToObject(payload, "op", op);
-   if (counter)
-      cJSON_AddStringToObject(payload, "counter", counter);
-   if (group)
-      cJSON_AddStringToObject(payload, "group", group);
-   if (reason)
-      cJSON_AddStringToObject(payload, "reason", reason);
+   cJSON_AddStringToObject(payload, "op", "snapshot");
    return aimee_module_json_call(AIMEE_ECONOMIZER_EVENT_STATS, AIMEE_ECONOMIZER_STAGE_STATS,
                                  payload, ECON_MODULE_CALL_MAX_BODY, ECON_MODULE_CALL_TIMEOUT_MS,
                                  NULL);
-}
-
-void econ_module_stat_reason(const char *group, const char *reason)
-{
-   if (!group || !group[0])
-      return;
-   cJSON *reply = econ_stats_call("inc_reason", NULL, group, reason);
-   cJSON_Delete(reply); /* the snapshot comes back too; this caller wants none of it */
-}
-
-cJSON *econ_module_stats_snapshot(void)
-{
-   return econ_stats_call("snapshot", NULL, NULL, NULL);
 }

--- a/src/modules/economizer/economizer_module_client.h
+++ b/src/modules/economizer/economizer_module_client.h
@@ -194,13 +194,6 @@ extern "C"
                                int ttl_ms, const char *stream_reason,
                                econ_module_post_status_t *out);
 
-   /* Record a (group, reason) the CALLER alone can see -- its own snapshot
-    * allocation failing, or installing the reduced array failing. Everything the
-    * module decides it counts itself, so this is only for the two events that
-    * happen on this side of the bus. Best-effort: a lost counter is not worth
-    * failing a request over. */
-   void econ_module_stat_reason(const char *group, const char *reason);
-
    /* The published gateway counters, as a NEW cJSON object the caller owns, or
     * NULL when the module could not be reached. The counters live in the module;
     * this is how the HTTP surface, which lives here, gets them to render. */

--- a/src/modules/economizer/gateway_mutate.c
+++ b/src/modules/economizer/gateway_mutate.c
@@ -44,22 +44,6 @@ const char *gw_module_bypass(int reduce_rc, const char *bypass)
    return bypass;
 }
 
-cJSON *gw_snapshot_messages(const cJSON *messages)
-{
-   if (!messages)
-      return NULL;
-   /* cJSON_Duplicate(recurse=1) deep-copies every child + string, and frees all
-    * partially-built sub-objects itself on any allocation failure, returning NULL. */
-   return cJSON_Duplicate((cJSON *)messages, 1);
-}
-
-int gw_snapshot_token_count(cJSON *messages)
-{
-   if (!messages)
-      return 0;
-   return session_compact_estimate_tokens(messages);
-}
-
 int gw_replace_messages(cJSON *container, const char *key, cJSON *reduced)
 {
    if (!container || !key || !reduced)

--- a/src/modules/economizer/gateway_mutate.h
+++ b/src/modules/economizer/gateway_mutate.h
@@ -82,16 +82,6 @@ extern "C"
     * string owned by gw_bypass_reason_str, never NULL. */
    const char *gw_module_bypass(int reduce_rc, const char *bypass);
 
-   /* Deep copy of a messages array (every message + string independently allocated),
-    * so restoring the pristine original is independent of any retained references.
-    * Returns NULL on allocation failure (cJSON_Duplicate frees its own partial work);
-    * the caller MUST then hard-bypass (never send an un-restorable reduced payload).
-    * `messages` is not modified. */
-   cJSON *gw_snapshot_messages(const cJSON *messages);
-
-   /* Estimated token count of a messages array (for the token-delta telemetry). */
-   int gw_snapshot_token_count(cJSON *messages);
-
    /* Install `reduced` as container[key], replacing the existing array. Takes
     * ownership of `reduced` on success (it is added to `container`). Returns 0 on
     * success; on failure returns non-zero (map to GW_BYPASS_REPLACE_FAILED), leaves

--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -10,7 +10,7 @@
 #include "agent_protocol.h" /* message_history_repair */
 #include "config.h"
 #include "gateway_mutate.h"
-#include "gw_mutate_stats.h"
+#include <aimee/audit/obs_bus.h> /* obs_bus_module_available */
 #include "log.h"
 #include "token_tracker.h" /* token_estimate_cost_ex, for the freeze guardrail */
 
@@ -181,6 +181,20 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
       return; /* dark unless the economizer tier is aggressive (OpenAI-family egress only) */
    econ_preset_t ep;
    econ_preset_current(&ep);
+   /* NOBODY HOME, NOTHING TO DO. If no process is serving the reduce stage the
+    * answer is already known -- the IR goes as it is -- so ask before paying for
+    * a question that cannot be answered. Everything between here and the call is
+    * work spent on that request: a SHA-256 key derivation, a print of the first
+    * message to fingerprint the conversation, a DB1 read for the reducer state,
+    * and a dozen config lookups. Cheap once; per request, on a deployment with
+    * the economizer detached, it is all waste.
+    *
+    * Availability is a local registration check with no I/O of its own, and it
+    * is only an optimisation: the call underneath still refuses when the module
+    * disappears between this check and it. */
+   if (!obs_bus_module_available(AIMEE_ECONOMIZER_EVENT_REDUCE))
+      return;
+
    ctx->mutate_on = 1;
    ctx->ttl_ms = ep.gateway_session_disable_ttl_ms;
 

--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -125,10 +125,12 @@ void gw_mutate_ctx_free(gw_mutate_ctx_t *ctx)
 {
    if (!ctx)
       return;
-   if (ctx->pristine)
+   if (ctx->original)
    {
-      cJSON_Delete(ctx->pristine);
-      ctx->pristine = NULL;
+      /* The swap stood: the container owns the reduced array and this is the
+       * original we set aside. Nothing put it back, so free it here. */
+      cJSON_Delete(ctx->original);
+      ctx->original = NULL;
    }
 }
 
@@ -199,14 +201,6 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    cJSON *msgs = cJSON_GetObjectItemCaseSensitive(container, key);
    if (!cJSON_IsArray(msgs))
       return;
-
-   /* Snapshot FIRST: never send a reduced payload we cannot restore. */
-   ctx->pristine = gw_snapshot_messages(msgs);
-   if (!ctx->pristine)
-   {
-      econ_module_stat_reason("hard_bypass", "snapshot_oom");
-      return;
-   }
 
    /* The reduction itself lives in the Go economizer module now; this seam
     * resolves config and owns the pristine/restore contract.
@@ -312,30 +306,35 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    const char *bypass = gw_module_bypass(rrc, mres.bypass);
    if (strcmp(bypass, gw_bypass_reason_str(GW_BYPASS_NONE)) != 0)
    {
-      /* The module counted this verdict already, on the call that made it. */
-      gw_provenance_clear(&ctx->st);
-      cJSON_Delete(reduced);
-      econ_module_result_free(&mres);
-      /* keep pristine: not mutated, but harmless; freed in ctx_free */
-      return;
-   }
-
-   if (gw_replace_messages(container, key, reduced) != 0)
-   {
-      econ_module_stat_reason("hard_bypass", "replace_failed");
+      /* Unusable answer: the request goes as it already is. Nothing was taken
+       * apart, so there is nothing to put back. */
       gw_provenance_clear(&ctx->st);
       cJSON_Delete(reduced);
       econ_module_result_free(&mres);
       return;
    }
-   int baseline_tok = mres.baseline_tokens;
-   int reduced_tok = mres.reduced_tokens;
    econ_module_result_free(&mres);
 
-   gw_provenance_mark_reduced(&ctx->st); /* mark ONLY after replace succeeds */
+   /* DETACH, don't copy. The original array leaves the container intact and
+    * stays owned here, so swapping it back is a pointer move rather than a
+    * restore -- and the deep copy this seam used to take on EVERY request,
+    * only to free it unused, is gone. Detaching cannot fail, so neither can
+    * this. */
+   cJSON *original = cJSON_DetachItemFromObjectCaseSensitive(container, key);
+   if (!cJSON_AddItemToObject(container, key, reduced))
+   {
+      /* Install failed: put the original straight back. The request is exactly
+       * what it was before this function ran. */
+      cJSON_Delete(reduced);
+      if (original)
+         cJSON_AddItemToObject(container, key, original);
+      gw_provenance_clear(&ctx->st);
+      return;
+   }
+   ctx->original = original;
+
+   gw_provenance_mark_reduced(&ctx->st); /* mark ONLY after the swap succeeds */
    ctx->mutated = 1;
-   (void)baseline_tok;
-   (void)reduced_tok;
 }
 
 gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int http_status,
@@ -354,11 +353,13 @@ gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int
    if (!d.resend && !d.restore && !d.disabled && !d.counter[0])
       return GW_POST_NONE; /* nothing owed: a 2xx, or a turn we never mutated */
 
-   if (d.restore && ctx->pristine)
+   if (d.restore && ctx->original)
    {
-      if (gw_replace_messages(container, key, ctx->pristine) == 0)
+      /* Swap the original back in. gw_replace_messages frees the reduced array
+       * the container currently holds and installs this one. */
+      if (gw_replace_messages(container, key, ctx->original) == 0)
       {
-         ctx->pristine = NULL; /* ownership moved back into container */
+         ctx->original = NULL; /* ownership moved back into the container */
          cJSON *restored = cJSON_GetObjectItemCaseSensitive(container, key);
          if (restored)
             message_history_repair(restored);

--- a/src/modules/economizer/gateway_mutate_wire.h
+++ b/src/modules/economizer/gateway_mutate_wire.h
@@ -27,7 +27,12 @@ extern "C"
       int have_key;  /* a per-identity session key was resolvable */
       int mutated;   /* the reduced payload was actually installed + dispatched */
       char skey[MSG_SESSION_KEY_LEN];
-      cJSON *pristine;    /* owned deep copy of the original array (NULL once restored/freed) */
+      /* The request's ORIGINAL array, detached from the container when the
+       * reduced one was swapped in, and owned here until it is either swapped
+       * back or freed. NULL whenever no swap happened -- which is every path
+       * where the module did not answer or answered unusably, because those
+       * leave the container untouched. Detached, never copied. */
+      cJSON *original;
       gw_provenance_t st; /* provenance marker owner */
       int ttl_ms;         /* disable-window TTL resolved from config */
    } gw_mutate_ctx_t;

--- a/src/tests/test_gateway_mutate.c
+++ b/src/tests/test_gateway_mutate.c
@@ -1,9 +1,12 @@
 /* test_gateway_mutate.c: what C still owns on the gateway-mutation path
- * (proposal §2.2/§2.3). The apply/bypass decision itself now lives in the Go
- * economizer module, so what is covered here is reading its verdict without
- * ever treating silence as consent; snapshot is an independent deep copy;
- * replace installs cleanly; provenance is mark-only-after-replace /
- * clear-on-bypass. */
+ * (proposal §2.2/§2.3). The apply/bypass decision lives in the Go economizer
+ * module, so what is covered here is reading its verdict without ever treating
+ * silence as consent; replace installs cleanly; provenance is
+ * mark-only-after-replace / clear-on-bypass.
+ *
+ * The snapshot helpers are gone with the deep copy they served: the seam now
+ * DETACHES the original array instead of duplicating it, so there is no copy to
+ * prove independent of its source. */
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -50,34 +53,6 @@ static void test_module_bypass(void)
    assert(strcmp(gw_bypass_reason_str(GW_BYPASS_REPLACE_FAILED), "replace_failed") == 0);
    assert(strcmp(gw_bypass_reason_str(GW_BYPASS_STRUCTURAL_VIOLATION), "structural_violation") ==
           0);
-}
-
-static void test_snapshot_independence(void)
-{
-   cJSON *orig = clean_messages();
-   assert(gw_snapshot_messages(NULL) == NULL);
-   cJSON *snap = gw_snapshot_messages(orig);
-   assert(snap != NULL);
-   assert(cJSON_GetArraySize(snap) == 1);
-   assert(gw_snapshot_token_count(snap) > 0);
-
-   /* mutate the original: the snapshot is a fully independent deep copy */
-   cJSON *extra = cJSON_CreateObject();
-   cJSON_AddStringToObject(extra, "role", "user");
-   cJSON_AddStringToObject(extra, "content", "second");
-   cJSON_AddItemToArray(orig, extra);
-   assert(cJSON_GetArraySize(orig) == 2);
-   assert(cJSON_GetArraySize(snap) == 1); /* unchanged */
-
-   /* editing a string in the original does not touch the snapshot */
-   cJSON *first = cJSON_GetArrayItem(orig, 0);
-   cJSON_ReplaceItemInObjectCaseSensitive(first, "content", cJSON_CreateString("mutated"));
-   cJSON *snap_first = cJSON_GetArrayItem(snap, 0);
-   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(snap_first, "content")),
-                 "hello world this is a longer message") == 0);
-
-   cJSON_Delete(orig);
-   cJSON_Delete(snap);
 }
 
 static void test_replace(void)
@@ -132,7 +107,6 @@ int main(void)
 {
    printf("gateway_mutate: ");
    test_module_bypass();
-   test_snapshot_independence();
    test_replace();
    test_provenance();
    printf("ok\n");

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -69,9 +69,12 @@ static void make_mutated(cJSON **container, gw_mutate_ctx_t *ctx, const char *sk
    ctx->mutated = 1;
    ctx->ttl_ms = 3600000;
    snprintf(ctx->skey, sizeof(ctx->skey), "%s", skey);
-   ctx->st.reduced = 1; /* provenance marked (post-replace) */
-   cJSON *pc = container_with("pristine");
-   ctx->pristine = cJSON_Duplicate(cJSON_GetObjectItemCaseSensitive(pc, "messages"), 1);
+   ctx->st.reduced = 1; /* provenance marked (post-swap) */
+   /* Stand in for the detached original the seam sets aside when it swaps the
+      reduced array in. Detached, not copied -- so this is simply an array the
+      ctx owns. */
+   cJSON *pc = container_with("original");
+   ctx->original = cJSON_DetachItemFromObjectCaseSensitive(pc, "messages");
    cJSON_Delete(pc);
 }
 


### PR DESCRIPTION
The seam kept two counters -- snapshot_oom and replace_failed -- which I had
justified as "only the caller can see them". That was the wrong question. C has
no business knowing a counter exists; it passes an IR and uses whatever IR
comes back. Those two only existed because of HOW C applied the reduction, not
because of anything about the gateway.

THE RULE, made literal: if the module does not answer, or answers unusably, the
IR is used AS IS. Not restored, not repaired -- untouched, because nothing was
taken apart in the first place.

That deletes the machinery those counters served. The seam used to deep-copy the
whole messages array on EVERY request so it could put the original back, then
free that copy unused on almost every path. It now DETACHES the original when it
swaps the reduced array in: a pointer move, not a copy. Detaching cannot fail,
so the snapshot_oom path is not merely uncounted but impossible, and a failed
install re-attaches the original and leaves the request exactly as it arrived,
so replace_failed is not an outcome worth a counter either.

Gone with them: gw_snapshot_messages, gw_snapshot_token_count, and
econ_module_stat_reason. The stats stage is now READ-ONLY -- there is no
operation a caller can use to write a counter, because it has nothing to report.
The only thing C still asks the module about counters is to hand them over so
the /state endpoint can publish them.

ALSO FIXES A REGRESSION I INTRODUCED IN #2679: StatsSnapshot nested the counters
under a "counters" object, where gw_stat_to_json emitted them FLAT as siblings of
token_delta and reasons. I claimed the shape was reproduced exactly; it was not,
and every dashboard keyed on gateway_mutate_applied would have gone blank.
MarshalJSON now flattens them and UnmarshalJSON is its inverse, so a wire round
trip preserves the published shape.

The snapshot-independence test goes with the copy it proved independent, and the
wire fixture now sets aside a detached array rather than a duplicate.

aimee-server and aimee-kb build under -Werror, the three C tests pass, the full
Go suite passes including -race, clang-format and descriptors clean.