### PR TITLE
docs: archive C-to-Go migration measurement

### DIFF
--- a/docs/proposals/done/c-to-go-module-migration-state.md
+++ b/docs/proposals/done/c-to-go-module-migration-state.md
@@ -1,7 +1,13 @@
 # C to Go module migration: what is left, and why
 
-- **State:** NOTES, 2026-08-06. Not a proposal; a record of measurement so the
-  next pass does not repeat the search.
+- **State:** DONE — completed measurement record archived 2026-08-15; not an implementation
+  proposal.
+- **Recorded:** 2026-08-06.
+- **Scope:** C-to-Go module migration inventory.
+
+> **Archived as completed research.** The measurements are a historical snapshot. Items under
+> “Open” require separately scoped architecture proposals; they are not unfinished acceptance
+> criteria for this record.
 - **Context:** the modularization suite's endpoint is that module logic lives in
   Go, runs as its own process, and is reached over the event bus. The C core
   keeps the bus and what is needed to keep things running.
@@ -109,3 +115,9 @@ them and watching the build, lint and full test suites still pass.
   architectural question about dispatch, not a tooling one.
 - **`memory`** is the largest single body of unmigrated C (22,173 lines) and the
   one whose migration would need the kb-over-bus decision first.
+
+## Disposition
+
+Archived 2026-08-15 as a completed measurement record. This document requests no implementation and
+defines no acceptance checklist; its unresolved architecture choices must be proposed and reviewed
+independently before any migration work begins.


### PR DESCRIPTION
## Summary

- move the completed C-to-Go migration measurement record from `pending` to `done`
- label the inventory as a historical 2026-08-06 snapshot
- clarify that its open architecture choices require separately scoped proposals

## Why

The document explicitly describes itself as measurement notes rather than an implementation proposal and defines no acceptance checklist. Keeping it in the pending proposal queue makes completed research look like unfinished implementation work.

## Impact

Documentation-only. No runtime, delegate, or C behavior changes.

## Validation

- `python3 scripts/check-proposal-links.py`
- `python3 scripts/check-proposal-reconcile.py` (only pre-existing report-only premise drift findings)
- `git diff --check`
- `make -s -C src lint` — all 55 checks passed
