### PR TITLE
docs: Phase B ordering for DB1, measured

### DIFF
--- a/docs/proposals/pending/db1-as-a-go-module.md
+++ b/docs/proposals/pending/db1-as-a-go-module.md
@@ -149,6 +149,44 @@ The economizer reducer state is still the right first domain: two functions, one
 it finishes a seam that is otherwise complete. `gw_state_key` / `gw_fnv1a` /
 `gw_state_next_turn` follow the blob they key.
 
+#### Phase B ordering, measured
+
+Counted on `testing` at 2695, excluding `db_schema.h`, which exists in both `src/db1` and
+`src/db2` so a name match cannot tell the two apart:
+
+| Module | db1 includes |
+| --- | --- |
+| workflows | 14 |
+| delegates | 5 |
+| roundtable | 4 |
+| roadmap | 3 |
+| config, tools | 2 each |
+| audit, benchmarks, execution-policy, git, guardrails, kb_client, learning, memory, protocols | 1 each |
+
+Fifteen modules, 39 include sites. Nine have a single include, so most of Phase B is small
+cutovers and the ordering falls out of the table: the single-include modules establish the
+pattern, then `roadmap`, `roundtable`, `delegates`, and `workflows` last.
+
+**The coupling is direct, not inherited.** 271 files include a db1 header themselves; only 31
+gain the dependency solely through another header, and 16 of those are through
+`src/headers/db1_optional.h`. So there is no tangle to unpick first: Phase B is a large number
+of individually small cutovers, not a small number of load-bearing ones.
+
+#### `db1_optional.h` is the existing optionality seam, and Phase B must replace it
+
+`src/headers/db1_optional.h` already answers "which DB1 calls may be absent". Server builds
+link the real objects; KB builds do not, and under `AIMEE_DB1_DISABLED` the optional calls
+become null pointers that callers must guard. `src/kb/kb_mcp_osv_stub.c` is the same mechanism
+by hand: it stubs three DB1 symbols so a kb-hosted MCP plugin still runs the OSV supply-chain
+scan without linking DB1.
+
+Two consequences. The set of calls that file marks optional is a ready-made first cut at which
+DB1 surface is genuinely server-only, which informs the stage grouping in §3.1. And the
+weak-reference trick does not survive the move: once a caller reaches DB1 over the bus, "absent
+because unlinked" becomes "absent because unreachable", which is the availability answer every
+other module already gives. Phase B has to carry that guard across rather than delete it, or
+`aimee-kb` silently loses a security gate.
+
 ### Phase C — port the implementation to Go, per domain
 
 Only now does the language change, against a stage contract already proven by Phase B. This


### PR DESCRIPTION
Fifteen modules include db1 headers directly, 39 sites: workflows 14, delegates
5, roundtable 4, roadmap 3, config and tools 2 each, and nine modules with
exactly one. So the ordering falls out of the table -- single-include modules
establish the pattern, workflows last -- and most of Phase B is small cutovers
rather than a few load-bearing ones.

I went looking for cross-component violations to fix alongside this and did not
find them. Two candidates both dissolved on inspection, and both are recorded
here because they are easy to re-discover and misread:

src/db2 appeared to include db1's db_schema.h. It does not; db_schema.h exists
in BOTH src/db1 and src/db2 and those four files include their own. Any survey
by header basename has to exclude it.

src/kb appeared to reach into DB1 through kb_mcp_osv_stub.c. That file is the
opposite: it stubs three DB1 symbols so aimee-kb never links DB1 while a
kb-hosted MCP plugin still runs the OSV supply-chain scan. It includes the
headers only to match signatures.

Nor is there a header tangle to unpick first. 271 files include a db1 header
themselves; only 31 inherit the dependency through another header, and 16 of
those come through db1_optional.h.

Which is the finding worth the most here. db1_optional.h is the EXISTING
optionality seam: it already declares which DB1 calls may be absent, and under
AIMEE_DB1_DISABLED they become null pointers callers must guard. That set is a
ready-made first cut at which DB1 surface is genuinely server-only, so it informs
the stage grouping. And the weak-reference trick does not survive the move --
"absent because unlinked" becomes "absent because unreachable" once a caller
crosses the bus. Phase B has to carry that guard across rather than drop it, or
aimee-kb silently loses a security gate.

Measured on testing at 2695. All four proposal validators pass.