### PR TITLE
ci: give proposal ordering enough time

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -248,17 +248,16 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # scan_history walks every commit since the historical cutoff -- 2397 of them
-    # against this tip -- and spends two git subprocesses on each, so one run is
-    # about two minutes and this job performs three plus the suite. The 5-minute
-    # budget was set when the job only ran on feature/core-modularization; on
-    # testing it cancels the job mid-step. Raised to fit the real cost.
+    # scan_history walks every commit since the historical cutoff, and that
+    # history keeps growing. Three full-history validations plus the failure-mode
+    # suite can now exceed 20 minutes. Keep enough headroom for a green suite to
+    # publish its result instead of being cancelled during teardown.
     #
     # This grows with history. Making scan_history a single git-log pass would
     # remove it, but that means reimplementing rename/copy detection and the
     # blob claim scan in a gate that governs the Git core contract, so it is
     # deliberately left as separate, reviewable work rather than folded in here.
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## What changed

- raise only the `proposal-ordering` job timeout from 20 to 30 minutes
- keep every proposal-ordering enforcement and failure-mode command unchanged
- update the workflow comment with the durable history-growth reason for the budget

## Why

Draft PR #2694 reached 30/31 green. In Actions run `31895951917`, job `95039210132`, every
proposal-ordering step, both teardown steps, and `Complete job` succeeded. GitHub then marked the
job cancelled at 20m1s because the workflow ceiling was 20 minutes. The authenticated token cannot
rerun that job, so the budget must land on `testing` before #2694 can publish a terminal green
result.

This is a separate CI-only prerequisite so #2694 remains an atomic proposal-lifecycle correction.

## Validation

- parsed `.github/workflows/module-inventory.yml` with `yaml.safe_load`
- `git diff --check`
- `make -s -C src lint` — all 55 checks passed
- frozen diff review: `roundtable-80d714a02eb8ba117c72b47b`

After merge, #2694 will be updated onto `testing`, its checks rerun, and the resulting
`proposal-ordering` duration recorded.
