### PR TITLE
feat(db2): freeze boundary and generalize C module export

### DIFF
--- a/.github/workflows/c-repositories.yml
+++ b/.github/workflows/c-repositories.yml
@@ -52,6 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: python3 -I -S scripts/validate_module_process_contracts.py
+      - run: python3 -I scripts/tests/test_export_c_process_build.py -v
       - run: python3 -I scripts/check_go_module_runtime_bundle.py
       - run: cd server-go && CGO_ENABLED=0 go test ./bus ./modules/... ./cmd/aimee-module
       # The exact commit/digest pins in dependencies/aimee-repositories.lock.json

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -76,6 +76,15 @@ jobs:
         run: python3 -I -S scripts/check_module_source_ownership.py
       - name: Test module source ownership failure modes
         run: python3 -I scripts/tests/test_check_module_source_ownership.py -v
+      - name: Freeze the DB2 source boundary and consumer inventory
+        run: python3 -I -S scripts/check_db2_source_boundary.py
+      - name: Refuse DB2 compatibility-include allowlist growth
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          python3 -I -S scripts/check_db2_source_boundary.py --previous-ref FETCH_HEAD
+      - name: Test DB2 source-boundary failure modes
+        run: python3 -I scripts/tests/test_check_db2_source_boundary.py -v
       - name: Enforce module bus boundary
         run: python3 -I -S scripts/check_module_bus_boundary.py
       - name: Test module bus-boundary failure modes
@@ -212,6 +221,8 @@ jobs:
         run: python3 -I -S scripts/validate_module_process_contracts.py
       - name: Test descriptor failure modes and taxonomy convergence
         run: python3 -I scripts/tests/test_validate_module_descriptors.py -v
+      - name: Test exhaustive standalone C-process export generation
+        run: python3 -I scripts/tests/test_export_c_process_build.py -v
       - name: Enforce canonical module public-header layout
         run: python3 -I -S scripts/check_module_header_layout.py
       - name: Test module public-header layout failure modes

--- a/scripts/check_db2_source_boundary.py
+++ b/scripts/check_db2_source_boundary.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Freeze DB2's source boundary and classify every outside include consumer.
+
+The phase-one DB2 process migration needs two different kinds of evidence:
+
+* the implementation unit being moved (C, header, and SQL files); and
+* every direct include that must eventually become a generated client or remain
+  a private implementation test.
+
+The checked-in manifest is exact for boundary files. Outside includes are
+shrink-only: removing an include is progress, while adding a consumer, header,
+or duplicate directive fails until the reviewed manifest is deliberately
+regenerated. This checker does not claim that an include is already a wire
+operation; the operation catalog and codecs are the next migration slice.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+from typing import NoReturn
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BASELINE = Path("tests/baselines/db2/source-boundary-v1.json")
+BOUNDARY = PurePosixPath("src/db2")
+CONTRACTS = Path("src/modules/process-contracts.json")
+SCHEMA_VERSION = 1
+SOURCE_KINDS = {"c": ".c", "headers": ".h", "sql": ".sql"}
+INCLUDE = re.compile(r'^\s*#\s*include\s*[<"]([^">]+)[">]')
+DB2_BASENAME = re.compile(r"db2[^/]*\.h$")
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+
+
+class BoundaryError(ValueError):
+    """A fail-closed inventory error with a stable rule name."""
+
+
+def fail(rule: str, message: str) -> NoReturn:
+    raise BoundaryError(f"rule={rule}: {message}")
+
+
+def _loads(raw: bytes, label: str) -> object:
+    def no_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        value: dict[str, object] = {}
+        for key, item in pairs:
+            if key in value:
+                fail("json-duplicate-key", f"{label}: duplicate key {key!r}")
+            value[key] = item
+        return value
+
+    if raw.startswith(b"\xef\xbb\xbf"):
+        fail("json-bom", f"{label} begins with a UTF-8 BOM")
+    try:
+        return json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=no_duplicates)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail("json-parse", f"cannot parse {label}: {exc}")
+
+
+def _load(path: Path) -> object:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        fail("input", f"cannot read {path}: {exc}")
+    return _loads(raw, str(path))
+
+
+def _repo_path(root: Path, relative: PurePosixPath | Path) -> Path:
+    candidate = root.joinpath(*PurePosixPath(relative).parts)
+    try:
+        candidate.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        fail("path-containment", f"{relative} escapes the repository root")
+    return candidate
+
+
+def _source_files(root: Path) -> dict[str, list[str]]:
+    boundary = _repo_path(root, BOUNDARY)
+    if not boundary.is_dir() or boundary.is_symlink():
+        fail("boundary", f"{BOUNDARY} must be a real directory")
+    result: dict[str, list[str]] = {}
+    for kind, suffix in SOURCE_KINDS.items():
+        result[kind] = sorted(
+            path.relative_to(root).as_posix()
+            for path in boundary.iterdir()
+            if path.is_file() and not path.is_symlink() and path.suffix == suffix
+        )
+    return result
+
+
+def _process_placements(root: Path) -> dict[str, set[str]]:
+    value = _load(_repo_path(root, CONTRACTS))
+    if not isinstance(value, dict) or not isinstance(value.get("components"), list):
+        fail("process-contracts", f"{CONTRACTS} has no components array")
+    result: dict[str, set[str]] = {}
+    for index, component in enumerate(value["components"]):
+        if not isinstance(component, dict):
+            fail("process-contracts", f"component {index} is not an object")
+        identifier, placements = component.get("id"), component.get("placements")
+        if (not isinstance(identifier, str) or not isinstance(placements, list) or
+                not all(item in {"server", "kb"} for item in placements)):
+            fail("process-contracts", f"component {index} has invalid id/placements")
+        result[identifier] = set(placements)
+    return result
+
+
+def _is_db2_include(target: str) -> bool:
+    path = PurePosixPath(target)
+    parts = path.parts
+    return "db2" in parts[:-1] or bool(DB2_BASENAME.search(path.name))
+
+
+def _classification(path: PurePosixPath, placements: dict[str, set[str]]) -> str:
+    parts = path.parts
+    if len(parts) >= 2 and parts[:2] == ("src", "tests"):
+        return "private-implementation-test"
+    if len(parts) >= 2 and parts[:2] == ("src", "server"):
+        return "server-kb-contract"
+    if len(parts) >= 3 and parts[:2] == ("src", "modules"):
+        module_id = parts[2]
+        if module_id not in placements:
+            # Some legacy source directories (currently guardrails and roadmap)
+            # predate descriptor ownership. Keeping them visible as an explicit
+            # audit class is safer than guessing a bus placement from a path.
+            return "module-placement-audit"
+        if "kb" in placements[module_id]:
+            return "kb-generated-client"
+        return "module-kb-contract"
+    if len(parts) >= 2 and parts[:2] == ("src", "kb"):
+        return "kb-generated-client"
+    return "host-generated-client"
+
+
+def _consumers(root: Path) -> list[dict[str, object]]:
+    source_root = _repo_path(root, Path("src"))
+    placements = _process_placements(root)
+    rows: list[dict[str, object]] = []
+    for path in sorted(source_root.rglob("*")):
+        if (not path.is_file() or path.is_symlink() or path.suffix not in {".c", ".h"} or
+                path.is_relative_to(_repo_path(root, BOUNDARY))):
+            continue
+        counts: Counter[str] = Counter()
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            fail("source-input", f"cannot read {path.relative_to(root)}: {exc}")
+        for line in lines:
+            match = INCLUDE.match(line)
+            if match and _is_db2_include(match.group(1)):
+                counts[match.group(1)] += 1
+        if not counts:
+            continue
+        relative = PurePosixPath(path.relative_to(root).as_posix())
+        rows.append({
+            "path": relative.as_posix(),
+            "classification": _classification(relative, placements),
+            "includes": [
+                {"header": header, "count": count}
+                for header, count in sorted(counts.items())
+            ],
+        })
+    return rows
+
+
+def _payload_fingerprint(source_files: object, consumers: object) -> str:
+    canonical = json.dumps(
+        {"source_files": source_files, "consumers": consumers},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _summary(source_files: dict[str, list[str]], consumers: list[dict[str, object]]) -> dict[str, int]:
+    include_count = sum(
+        include["count"]
+        for row in consumers
+        for include in row["includes"]  # type: ignore[index]
+    )
+    test_count = sum(
+        row["classification"] == "private-implementation-test" for row in consumers
+    )
+    return {
+        "c_files": len(source_files["c"]),
+        "headers": len(source_files["headers"]),
+        "sql_files": len(source_files["sql"]),
+        "consumer_files": len(consumers),
+        "production_consumers": len(consumers) - test_count,
+        "test_consumers": test_count,
+        "include_directives": include_count,
+    }
+
+
+def build_inventory(root: Path, source_revision: str) -> dict[str, object]:
+    if not REVISION.fullmatch(source_revision):
+        fail("source-revision", "source revision must be a full lowercase SHA-1")
+    source_files = _source_files(root)
+    consumers = _consumers(root)
+    summary = _summary(source_files, consumers)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_revision": source_revision,
+        "source_boundary": BOUNDARY.as_posix(),
+        "summary": summary,
+        "source_files": source_files,
+        "consumers": consumers,
+        "fingerprint": _payload_fingerprint(source_files, consumers),
+    }
+
+
+def _baseline_rows(value: object) -> dict[tuple[str, str], tuple[int, str]]:
+    if not isinstance(value, list):
+        fail("baseline-shape", "consumers must be an array")
+    result: dict[tuple[str, str], tuple[int, str]] = {}
+    previous_path = ""
+    for index, row in enumerate(value):
+        if not isinstance(row, dict) or set(row) != {"path", "classification", "includes"}:
+            fail("baseline-shape", f"consumer {index} has invalid keys")
+        path, classification, includes = row["path"], row["classification"], row["includes"]
+        if (not isinstance(path, str) or path <= previous_path or
+                not isinstance(classification, str) or not isinstance(includes, list)):
+            fail("baseline-order", f"consumer {index} is invalid or not path-sorted")
+        previous_path = path
+        previous_header = ""
+        for include in includes:
+            if not isinstance(include, dict) or set(include) != {"header", "count"}:
+                fail("baseline-shape", f"{path}: invalid include row")
+            header, count = include["header"], include["count"]
+            if (not isinstance(header, str) or header <= previous_header or
+                    type(count) is not int or count < 1):
+                fail("baseline-order", f"{path}: includes are invalid or not sorted")
+            previous_header = header
+            key = (path, header)
+            if key in result:
+                fail("baseline-duplicate", f"duplicate consumer/include pair {key}")
+            result[key] = (count, classification)
+    return result
+
+
+def enforce_shrink_only(previous: object, current: object) -> None:
+    """Reject compatibility-include allowlist growth across a reviewed PR."""
+    if not isinstance(previous, dict) or not isinstance(current, dict):
+        fail("baseline-shape", "previous/current manifests must be objects")
+    previous_rows = _baseline_rows(previous.get("consumers"))
+    current_rows = _baseline_rows(current.get("consumers"))
+    for key, (count, classification) in current_rows.items():
+        prior = previous_rows.get(key)
+        if prior is None:
+            fail("baseline-growth", f"new allowlist entry {key[1]!r} in {key[0]}")
+        if count > prior[0]:
+            fail(
+                "baseline-growth",
+                f"allowlist entry {key[1]!r} in {key[0]} grew from {prior[0]} to {count}",
+            )
+        if classification != prior[1]:
+            fail(
+                "baseline-classification",
+                f"allowlist entry {key[1]!r} in {key[0]} changed from "
+                f"{prior[1]} to {classification}",
+            )
+
+
+def check_previous_ref(root: Path, baseline_path: Path, previous_ref: str) -> bool:
+    """Compare the checked manifest with a Git base; return false for first seed."""
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{previous_ref}^{{commit}}"], cwd=root,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+    )
+    if verify.returncode != 0:
+        fail("previous-ref", f"cannot resolve {previous_ref!r} as a commit")
+    relative = PurePosixPath(baseline_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        fail("path-containment", f"{baseline_path} is not repository-relative")
+    prior = subprocess.run(
+        ["git", "show", f"{previous_ref}:{relative.as_posix()}"], cwd=root,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+    )
+    if prior.returncode != 0:
+        # The merge that introduces the v1 manifest has no previous payload.
+        # Every later base contains it, so this exception cannot be reused to
+        # expand an established allowlist.
+        return False
+    previous = _loads(prior.stdout, f"{previous_ref}:{relative.as_posix()}")
+    current = _load(_repo_path(root, baseline_path))
+    enforce_shrink_only(previous, current)
+    return True
+
+
+def check(root: Path, baseline_path: Path = BASELINE) -> dict[str, int]:
+    raw = _load(_repo_path(root, baseline_path))
+    if not isinstance(raw, dict) or set(raw) != {
+        "schema_version", "source_revision", "source_boundary", "summary",
+        "source_files", "consumers", "fingerprint",
+    }:
+        fail("baseline-shape", "top-level keys differ from source-boundary v1")
+    if raw["schema_version"] != SCHEMA_VERSION or raw["source_boundary"] != BOUNDARY.as_posix():
+        fail("baseline-version", "schema version or source boundary differs from v1")
+    if not isinstance(raw["source_revision"], str) or not REVISION.fullmatch(raw["source_revision"]):
+        fail("source-revision", "baseline source revision is not a full lowercase SHA-1")
+    if raw["fingerprint"] != _payload_fingerprint(raw["source_files"], raw["consumers"]):
+        fail("baseline-fingerprint", "baseline payload fingerprint does not match")
+    if not isinstance(raw["source_files"], dict) or set(raw["source_files"]) != set(SOURCE_KINDS):
+        fail("baseline-shape", "source_files keys differ from v1")
+    baseline_source_files: dict[str, list[str]] = {}
+    for kind in SOURCE_KINDS:
+        values = raw["source_files"].get(kind)
+        if (not isinstance(values, list) or not all(isinstance(item, str) for item in values) or
+                values != sorted(set(values))):
+            fail("baseline-order", f"source_files.{kind} must be a sorted unique string array")
+        baseline_source_files[kind] = values
+    baseline_consumers = raw["consumers"]
+    _baseline_rows(baseline_consumers)
+    if raw["summary"] != _summary(baseline_source_files, baseline_consumers):
+        fail("summary-drift", "baseline summary differs from its payload")
+    actual_sources = _source_files(root)
+    if raw["source_files"] != actual_sources:
+        fail("source-drift", "DB2 C/header/SQL file inventory differs from the baseline")
+    baseline_rows = _baseline_rows(raw["consumers"])
+    actual_consumers = _consumers(root)
+    actual_rows = _baseline_rows(actual_consumers)
+    for key, (count, classification) in actual_rows.items():
+        expected = baseline_rows.get(key)
+        if expected is None:
+            fail("include-growth", f"new DB2 include {key[1]!r} in {key[0]}")
+        expected_count, expected_classification = expected
+        if count > expected_count:
+            fail(
+                "include-growth",
+                f"{key[0]} includes {key[1]!r} {count} times; baseline permits {expected_count}",
+            )
+        if classification != expected_classification:
+            fail(
+                "consumer-classification",
+                f"{key[0]} changed from {expected_classification} to {classification}",
+            )
+    return {
+        "source_files": sum(len(items) for items in actual_sources.values()),
+        "consumer_files": len(actual_consumers),
+        "include_directives": sum(count for count, _ in actual_rows.values()),
+    }
+
+
+def _head_revision(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+    )
+    revision = result.stdout.strip()
+    if result.returncode != 0 or not REVISION.fullmatch(revision):
+        fail("source-revision", result.stderr.strip() or "cannot resolve HEAD")
+    return revision
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config-root", type=Path, default=ROOT)
+    parser.add_argument("--baseline", type=Path, default=BASELINE)
+    parser.add_argument("--previous-ref")
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+    root = args.config_root.resolve()
+    try:
+        if args.write:
+            inventory = build_inventory(root, _head_revision(root))
+            target = _repo_path(root, args.baseline)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(inventory, indent=2) + "\n", encoding="utf-8")
+            print(f"check_db2_source_boundary: wrote {args.baseline}")
+        else:
+            result = check(root, args.baseline)
+            if args.previous_ref:
+                compared = check_previous_ref(root, args.baseline, args.previous_ref)
+                suffix = "previous allowlist compared" if compared else "initial allowlist seeded"
+            else:
+                suffix = "current manifest checked"
+            print(
+                "check_db2_source_boundary: ok "
+                f"({result['source_files']} boundary files, "
+                f"{result['consumer_files']} consumers, "
+                f"{result['include_directives']} includes remain; {suffix})"
+            )
+    except (OSError, BoundaryError) as exc:
+        print(f"check_db2_source_boundary: error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_c_repositories.py
+++ b/scripts/export_c_repositories.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from pathlib import PurePosixPath
 import re
 import shutil
 import subprocess
@@ -30,6 +31,14 @@ CORE_VERSION_FILE = ROOT / "src/core/VERSION"
 REMOTE_ROOT = "https://github.com/RakuenSoftware"
 HOSTED_BY_EXECUTABLE = {"wfe": "/usr/local/bin/aimee-wfe"}
 PRINCIPAL_CLASS = 1
+C_BUILD_KEYS = {"include_roots", "pkg_config", "system_libraries"}
+BUILD_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:+-]*$")
+CMAKE_TARGET_PACKAGES = {
+    "OpenSSL::Crypto": "OpenSSL",
+    "OpenSSL::SSL": "OpenSSL",
+    "Threads::Threads": "Threads",
+    "ZLIB::ZLIB": "ZLIB",
+}
 
 
 class ExportError(RuntimeError):
@@ -259,6 +268,96 @@ int main(int argc, char **argv)
 """
 
 
+def c_process_build(module_id: str, descriptor: dict[str, object]) -> tuple[
+        list[str], list[str], list[str], list[str]]:
+    """Return validated C sources, include roots, pkg-config deps, and link items."""
+    sources = descriptor.get("sources")
+    if not isinstance(sources, list) or not sources or not all(isinstance(item, str) for item in sources):
+        raise ExportError(f"{module_id}: C process must declare descriptor-owned sources")
+    c_sources = [item for item in sources if PurePosixPath(item).suffix == ".c"]
+    if len(c_sources) != len(sources):
+        raise ExportError(f"{module_id}: C process sources must all be .c files")
+    if c_sources != sorted(set(c_sources)):
+        raise ExportError(f"{module_id}: C process sources must be sorted and unique")
+    build = descriptor.get("c_build")
+    if not isinstance(build, dict) or set(build) != C_BUILD_KEYS:
+        raise ExportError(f"{module_id}: C process must declare exact c_build fields")
+
+    parsed: dict[str, list[str]] = {}
+    for field in sorted(C_BUILD_KEYS):
+        entries = build[field]
+        if not isinstance(entries, list) or not all(isinstance(item, str) for item in entries):
+            raise ExportError(f"{module_id}: c_build.{field} must be a string array")
+        if entries != sorted(set(entries)):
+            raise ExportError(f"{module_id}: c_build.{field} must be sorted and unique")
+        if field == "include_roots" and not entries:
+            raise ExportError(f"{module_id}: c_build.include_roots must not be empty")
+        for entry in entries:
+            if field == "include_roots":
+                pure = PurePosixPath(entry)
+                if (not entry or "\\" in entry or pure.is_absolute() or "." in pure.parts or
+                        ".." in pure.parts or pure.as_posix() != entry):
+                    raise ExportError(f"{module_id}: unsafe include root {entry!r}")
+            elif not BUILD_TOKEN.fullmatch(entry):
+                raise ExportError(f"{module_id}: unsafe c_build.{field} token {entry!r}")
+            elif field == "system_libraries" and "::" in entry and entry not in CMAKE_TARGET_PACKAGES:
+                raise ExportError(f"{module_id}: unsupported imported CMake target {entry!r}")
+        parsed[field] = entries
+    return c_sources, parsed["include_roots"], parsed["pkg_config"], parsed["system_libraries"]
+
+
+def c_process_cmake(module_id: str, binary: str, version: str,
+                    descriptor: dict[str, object]) -> str:
+    """Generate the standalone build for a descriptor-owned C process."""
+    sources, include_roots, pkg_config, libraries = c_process_build(module_id, descriptor)
+    source_lines = "\n".join(f"    {source}" for source in sources)
+    include_lines = "\n".join(
+        f"    ${{CMAKE_CURRENT_SOURCE_DIR}}/{root}" for root in include_roots
+    )
+    package_names = sorted({
+        CMAKE_TARGET_PACKAGES[library]
+        for library in libraries
+        if library in CMAKE_TARGET_PACKAGES
+    })
+    discovery: list[str] = [f"find_package({package} REQUIRED)" for package in package_names]
+    link_items = ["aimee::aimee-core-event-bus-client"]
+    if pkg_config:
+        discovery.extend([
+            "find_package(PkgConfig REQUIRED)",
+            f"pkg_check_modules(MODULE_PKG REQUIRED IMPORTED_TARGET {' '.join(pkg_config)})",
+        ])
+        link_items.append("PkgConfig::MODULE_PKG")
+    link_items.extend(libraries)
+    discovery_text = "\n".join(discovery)
+    if discovery_text:
+        discovery_text += "\n"
+    link_lines = "\n".join(f"    {item}" for item in link_items)
+    return f"""cmake_minimum_required(VERSION 3.16)
+project(aimee_module_{module_id.replace('-', '_')} VERSION {version} LANGUAGES C)
+
+include(GNUInstallDirs)
+find_package(aimee-core {version} EXACT CONFIG REQUIRED)
+{discovery_text}if(NOT TARGET aimee::aimee-core-event-bus-client)
+    message(FATAL_ERROR "{binary} requires the Linux event-bus client")
+endif()
+add_executable({binary}
+    runtime/main.c
+{source_lines}
+)
+target_compile_features({binary} PRIVATE c_std_11)
+target_include_directories({binary} PRIVATE
+{include_lines}
+)
+target_link_libraries({binary} PRIVATE
+{link_lines}
+)
+configure_file(grants/module.grant.in ${{CMAKE_CURRENT_BINARY_DIR}}/{module_id}.grant @ONLY)
+install(TARGETS {binary} RUNTIME DESTINATION ${{CMAKE_INSTALL_BINDIR}})
+install(FILES ${{CMAKE_CURRENT_BINARY_DIR}}/{module_id}.grant
+        DESTINATION ${{CMAKE_INSTALL_DATADIR}}/aimee/module-grants)
+"""
+
+
 def go_module_main(module_id: str, principal_ref: int,
                    stages: list[dict[str, object]]) -> str:
     """Generate one independently buildable Go process entry point."""
@@ -418,23 +517,7 @@ serve={serve}
             )
             write_text(
                 repository / "CMakeLists.txt",
-                f"""cmake_minimum_required(VERSION 3.16)
-project(aimee_module_{module_id.replace('-', '_')} VERSION {version} LANGUAGES C)
-
-include(GNUInstallDirs)
-find_package(aimee-core {version} EXACT CONFIG REQUIRED)
-if(NOT TARGET aimee::aimee-core-event-bus-client)
-    message(FATAL_ERROR "{binary} requires the Linux event-bus client")
-endif()
-add_executable({binary} runtime/main.c{f' {adapter_source}' if has_handler else ''})
-target_compile_features({binary} PRIVATE c_std_11)
-target_include_directories({binary} PRIVATE src/modules/{module_id}/include)
-target_link_libraries({binary} PRIVATE aimee::aimee-core-event-bus-client)
-configure_file(grants/module.grant.in ${{CMAKE_CURRENT_BINARY_DIR}}/{module_id}.grant @ONLY)
-install(TARGETS {binary} RUNTIME DESTINATION ${{CMAKE_INSTALL_BINDIR}})
-install(FILES ${{CMAKE_CURRENT_BINARY_DIR}}/{module_id}.grant
-        DESTINATION ${{CMAKE_INSTALL_DATADIR}}/aimee/module-grants)
-""",
+                c_process_cmake(module_id, binary, version, descriptor),
             )
             handler_text = (
                 "Its repository-owned handler implements the declared stage contract."

--- a/scripts/tests/test_check_db2_source_boundary.py
+++ b/scripts/tests/test_check_db2_source_boundary.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Tests for the DB2 source-boundary and shrink-only consumer manifest."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts/check_db2_source_boundary.py"
+SPEC = importlib.util.spec_from_file_location("check_db2_source_boundary", CHECKER)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+class BoundaryTests(unittest.TestCase):
+    revision = "a" * 40
+
+    def repo(self) -> tempfile.TemporaryDirectory[str]:
+        tmp = tempfile.TemporaryDirectory()
+        root = Path(tmp.name)
+        files = {
+            "src/db2/store.c": '#include "store.h"\n',
+            "src/db2/store.h": "int db2_store(void);\n",
+            "src/db2/schema.sql": "CREATE TABLE sample(id integer);\n",
+            "src/kb/consumer.c": '#include "db2/store.h"\n',
+            "src/server/consumer.c": '#include "../db2/store.h"\n',
+            "src/tests/test_store.c": '#include "db2/store.h"\n',
+            "src/modules/memory/consumer.c": '#include "db2/store.h"\n',
+        }
+        for relative, content in files.items():
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        contracts = {
+            "components": [
+                {"id": "memory", "placements": ["server"]},
+            ],
+        }
+        path = root / checker.CONTRACTS
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(contracts), encoding="utf-8")
+        self.write_baseline(root)
+        return tmp
+
+    def write_baseline(self, root: Path) -> None:
+        path = root / checker.BASELINE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(checker.build_inventory(root, self.revision), indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_production_tree_matches_baseline(self) -> None:
+        result = checker.check(REPO_ROOT)
+        self.assertEqual(result["source_files"], 284)
+        self.assertEqual(result["consumer_files"], 297)
+        self.assertEqual(result["include_directives"], 967)
+
+    def test_inventory_is_deterministic_sorted_and_classified(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            first = checker.build_inventory(root, self.revision)
+            second = checker.build_inventory(root, self.revision)
+            self.assertEqual(first, second)
+            rows = first["consumers"]
+            self.assertEqual([row["path"] for row in rows], sorted(row["path"] for row in rows))
+            classes = {row["path"]: row["classification"] for row in rows}
+            self.assertEqual(classes["src/kb/consumer.c"], "kb-generated-client")
+            self.assertEqual(classes["src/server/consumer.c"], "server-kb-contract")
+            self.assertEqual(classes["src/tests/test_store.c"], "private-implementation-test")
+            self.assertEqual(classes["src/modules/memory/consumer.c"], "module-kb-contract")
+        finally:
+            tmp.cleanup()
+
+    def test_include_removal_is_allowed(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / "src/kb/consumer.c").write_text("/* migrated */\n", encoding="utf-8")
+            result = checker.check(root)
+            self.assertEqual(result["consumer_files"], 3)
+            self.assertEqual(result["include_directives"], 3)
+        finally:
+            tmp.cleanup()
+
+    def test_new_consumer_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / "src/kb/new.c").write_text('#include "db2/store.h"\n', encoding="utf-8")
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=include-growth"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_duplicate_include_growth_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / "src/kb/consumer.c").write_text(
+                '#include "db2/store.h"\n#include "db2/store.h"\n', encoding="utf-8"
+            )
+            with self.assertRaisesRegex(checker.BoundaryError, "baseline permits 1"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_boundary_file_drift_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / "src/db2/new.c").write_text("int new_db2_file;\n", encoding="utf-8")
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=source-drift"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_consumer_placement_change_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CONTRACTS
+            value = json.loads(path.read_text(encoding="utf-8"))
+            value["components"][0]["placements"] = ["server", "kb"]
+            path.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=consumer-classification"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_tampered_payload_or_summary_is_rejected(self) -> None:
+        for field, rule in (("fingerprint", "baseline-fingerprint"), ("summary", "summary-drift")):
+            tmp = self.repo()
+            try:
+                root = Path(tmp.name)
+                path = root / checker.BASELINE
+                value = json.loads(path.read_text(encoding="utf-8"))
+                if field == "fingerprint":
+                    value[field] = "0" * 64
+                else:
+                    value[field]["consumer_files"] += 1
+                path.write_text(json.dumps(value), encoding="utf-8")
+                with self.subTest(field=field), self.assertRaisesRegex(
+                    checker.BoundaryError, f"rule={rule}"
+                ):
+                    checker.check(root)
+            finally:
+                tmp.cleanup()
+
+    def test_reviewed_allowlist_may_only_shrink(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            previous = checker.build_inventory(root, self.revision)
+            current = json.loads(json.dumps(previous))
+            current["consumers"][0]["includes"][0]["count"] = 0
+            # A real shrink removes the zero-count row from the manifest.
+            current["consumers"][0]["includes"].pop(0)
+            current["consumers"].pop(0)
+            checker.enforce_shrink_only(previous, current)
+
+            grown = json.loads(json.dumps(previous))
+            grown["consumers"][0]["includes"][0]["count"] += 1
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=baseline-growth"):
+                checker.enforce_shrink_only(previous, grown)
+
+            added = json.loads(json.dumps(previous))
+            added["consumers"].append({
+                "path": "src/zz_new.c",
+                "classification": "host-generated-client",
+                "includes": [{"header": "db2/store.h", "count": 1}],
+            })
+            with self.assertRaisesRegex(checker.BoundaryError, "new allowlist entry"):
+                checker.enforce_shrink_only(previous, added)
+
+            reclassified = json.loads(json.dumps(previous))
+            reclassified["consumers"][0]["classification"] = "host-generated-client"
+            with self.assertRaisesRegex(
+                checker.BoundaryError, "rule=baseline-classification"
+            ):
+                checker.enforce_shrink_only(previous, reclassified)
+        finally:
+            tmp.cleanup()
+
+    def test_duplicate_json_key_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.BASELINE
+            path.write_text('{"schema_version":1,"schema_version":1}\n', encoding="utf-8")
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=json-duplicate-key"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_cli_is_cwd_independent(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-I", "-S", str(CHECKER)],
+            cwd="/tmp",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("297 consumers", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_export_c_process_build.py
+++ b/scripts/tests/test_export_c_process_build.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Tests for exhaustive standalone C-process export generation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPORTER = REPO_ROOT / "scripts/export_c_repositories.py"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+SPEC = importlib.util.spec_from_file_location("export_c_repositories", EXPORTER)
+assert SPEC and SPEC.loader
+exporter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(exporter)
+
+
+class CProcessBuildTests(unittest.TestCase):
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "sources": [
+                "src/modules/db2/c/db2_init.c",
+                "src/modules/db2/c/db_postgres.c",
+                "src/modules/db2/module_adapter.c",
+            ],
+            "c_build": {
+                "include_roots": [
+                    "src",
+                    "src/modules/db2/c",
+                    "src/modules/db2/include",
+                ],
+                "pkg_config": ["libpq"],
+                "system_libraries": [
+                    "OpenSSL::Crypto",
+                    "Threads::Threads",
+                    "ZLIB::ZLIB",
+                    "m",
+                    "zstd",
+                ],
+            },
+        }
+
+    def test_cmake_compiles_every_owned_source_once(self) -> None:
+        cmake = exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", self.descriptor())
+        for source in self.descriptor()["sources"]:
+            self.assertEqual(cmake.count(source), 1)
+        self.assertIn("find_package(aimee-core 1.2.3 EXACT CONFIG REQUIRED)", cmake)
+        self.assertIn("find_package(OpenSSL REQUIRED)", cmake)
+        self.assertIn("find_package(Threads REQUIRED)", cmake)
+        self.assertIn("find_package(ZLIB REQUIRED)", cmake)
+        self.assertIn("pkg_check_modules(MODULE_PKG REQUIRED IMPORTED_TARGET libpq)", cmake)
+        self.assertIn("PkgConfig::MODULE_PKG", cmake)
+        self.assertIn("${CMAKE_CURRENT_SOURCE_DIR}/src/modules/db2/c", cmake)
+        self.assertNotIn("runtime/main.c src/modules/db2/module_adapter.c", cmake)
+
+    def test_descriptor_order_is_required_for_reproducible_cmake(self) -> None:
+        for field in ("sources", "include_roots", "pkg_config", "system_libraries"):
+            descriptor = self.descriptor()
+            target = descriptor["sources"] if field == "sources" else descriptor["c_build"][field]
+            if len(target) == 1:
+                target.append("libssl")
+            target.reverse()
+            with self.subTest(field=field), self.assertRaisesRegex(
+                exporter.ExportError, "sorted and unique"
+            ):
+                exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", descriptor)
+
+    def test_missing_build_contract_or_sources_fails_closed(self) -> None:
+        descriptor = self.descriptor()
+        descriptor.pop("c_build")
+        with self.assertRaisesRegex(exporter.ExportError, "exact c_build fields"):
+            exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", descriptor)
+        descriptor = self.descriptor()
+        descriptor["sources"] = []
+        with self.assertRaisesRegex(exporter.ExportError, "descriptor-owned sources"):
+            exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", descriptor)
+
+    def test_non_c_source_and_cmake_injection_are_rejected(self) -> None:
+        descriptor = self.descriptor()
+        descriptor["sources"][0] = "src/modules/db2/c/provider.cpp"
+        with self.assertRaisesRegex(exporter.ExportError, "must all be .c"):
+            exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", descriptor)
+
+        for field, value in (
+            ("include_roots", "../outside"),
+            ("pkg_config", "libpq)\nmessage(FATAL_ERROR injected)"),
+            ("system_libraries", "m;injected"),
+        ):
+            descriptor = self.descriptor()
+            descriptor["c_build"][field].append(value)
+            descriptor["c_build"][field].sort()
+            with self.subTest(field=field), self.assertRaisesRegex(exporter.ExportError, "unsafe"):
+                exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", descriptor)
+
+        descriptor = self.descriptor()
+        descriptor["c_build"]["system_libraries"].append("Unknown::Target")
+        descriptor["c_build"]["system_libraries"].sort()
+        with self.assertRaisesRegex(exporter.ExportError, "unsupported imported CMake target"):
+            exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", descriptor)
+
+    def test_repeated_imported_targets_discover_each_package_once(self) -> None:
+        descriptor = self.descriptor()
+        descriptor["c_build"]["system_libraries"].append("OpenSSL::SSL")
+        descriptor["c_build"]["system_libraries"].sort()
+        cmake = exporter.c_process_cmake("db2", "aimee-module-db2", "1.2.3", descriptor)
+        self.assertEqual(cmake.count("find_package(OpenSSL REQUIRED)"), 1)
+        self.assertIn("OpenSSL::Crypto", cmake)
+        self.assertIn("OpenSSL::SSL", cmake)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_principal_ref_identity.py
+++ b/scripts/tests/test_principal_ref_identity.py
@@ -100,6 +100,27 @@ class PrincipalRefIsAnIdentity(unittest.TestCase):
     def test_the_shipped_inventory_validates(self) -> None:
         self.assertEqual(run_validator().returncode, 0)
 
+    def test_c_build_is_reserved_for_c_processes(self) -> None:
+        for identifier in ("memory", "config"):
+            descriptor_path = ROOT / f"src/modules/{identifier}/module.yaml"
+            original = descriptor_path.read_text(encoding="utf-8")
+            try:
+                descriptor = json.loads(original)
+                descriptor["c_build"] = {
+                    "include_roots": ["src"],
+                    "pkg_config": [],
+                    "system_libraries": [],
+                }
+                descriptor_path.write_text(
+                    json.dumps(descriptor, indent=2) + "\n", encoding="utf-8"
+                )
+                result = run_validator()
+                with self.subTest(identifier=identifier):
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("c_build", result.stderr)
+            finally:
+                descriptor_path.write_text(original, encoding="utf-8")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -213,6 +213,55 @@ class DescriptorTests(unittest.TestCase):
         complete_type["ownership_complete"] = 1
         self.assert_rule(complete_type, "ownership-complete-type")
 
+    def test_c_build_contract_is_closed_sorted_and_safe(self) -> None:
+        descriptor = self.required()
+        descriptor["c_build"] = {
+            "include_roots": ["src", "src/modules/memory"],
+            "pkg_config": ["libpq"],
+            "system_libraries": ["OpenSSL::Crypto", "m"],
+        }
+        required, optional = self.taxonomy()
+        self.assertEqual(
+            validator.validate_descriptor(descriptor, required, optional), "memory"
+        )
+
+        cases = (
+            ({"include_roots": ["src"], "pkg_config": []}, "c-build-shape"),
+            ({"include_roots": [], "pkg_config": [], "system_libraries": []},
+             "c-build-empty"),
+            ({"include_roots": ["src", "src"], "pkg_config": [],
+              "system_libraries": []}, "c-build-order"),
+            ({"include_roots": ["../outside"], "pkg_config": [],
+              "system_libraries": []}, "c-build-path"),
+            ({"include_roots": ["src"], "pkg_config": ["libpq;injected"],
+              "system_libraries": []}, "c-build-token"),
+            ({"include_roots": ["src"], "pkg_config": [],
+              "system_libraries": [7]}, "c-build-type"),
+        )
+        for build, rule in cases:
+            mutated = self.required()
+            mutated["c_build"] = build
+            with self.subTest(rule=rule):
+                self.assert_rule(mutated, rule)
+
+    def test_c_build_include_roots_must_be_real_directories(self) -> None:
+        descriptor = json.loads(
+            (REPO_ROOT / "src/modules/module-runtime/module.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        descriptor["c_build"] = {
+            "include_roots": ["src/modules/module-runtime/missing"],
+            "pkg_config": [],
+            "system_libraries": [],
+        }
+        required, optional = self.taxonomy()
+        validator.validate_descriptor(descriptor, required, optional)
+        with self.assertRaisesRegex(
+            validator.DescriptorError, r"rule=c-build-directory"
+        ):
+            validator.validate_ownership(REPO_ROOT, "module-runtime", descriptor)
+
     def test_ownership_is_optional_and_report_preserves_declared_order(self) -> None:
         report = validator.ownership_report(REPO_ROOT, [Path("src/modules")])
         self.assertEqual(report["schema_version"], 1)

--- a/scripts/validate_module_descriptors.py
+++ b/scripts/validate_module_descriptors.py
@@ -24,6 +24,8 @@ MAX_DEPTH = 32
 MAX_ARRAY = 256
 ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 BASE_KEYS = {"descriptor_version", "id", "dependencies", "runtime_toggle"}
+C_BUILD_KEYS = {"include_roots", "pkg_config", "system_libraries"}
+BUILD_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:+-]*$")
 OWNERSHIP_FIELDS = (
     "sources", "private_headers", "public_headers", "tests", "docs", "go_sources", "go_tests",
 )
@@ -162,6 +164,28 @@ def schema() -> dict[str, object]:
             },
             "enabled_by_default": {"type": "boolean"},
             "ownership_complete": {"type": "boolean"},
+            "c_build": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": sorted(C_BUILD_KEYS),
+                "properties": {
+                    "include_roots": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "uniqueItems": True,
+                    },
+                    "pkg_config": {
+                        "type": "array",
+                        "items": {"type": "string", "pattern": BUILD_TOKEN_RE.pattern},
+                        "uniqueItems": True,
+                    },
+                    "system_libraries": {
+                        "type": "array",
+                        "items": {"type": "string", "pattern": BUILD_TOKEN_RE.pattern},
+                        "uniqueItems": True,
+                    },
+                },
+            },
             "runtime_toggle": {
                 "type": "object",
                 "additionalProperties": False,
@@ -201,7 +225,7 @@ def validate_descriptor(value: object, required: set[str], optional: set[str]) -
     if identifier not in required | optional:
         fail("module-unknown", f"unknown module ID {identifier!r}", "/id")
     required_keys = BASE_KEYS | ({"enabled_by_default"} if identifier in optional else set())
-    allowed_keys = required_keys | set(OWNERSHIP_FIELDS) | {"ownership_complete"}
+    allowed_keys = required_keys | set(OWNERSHIP_FIELDS) | {"ownership_complete", "c_build"}
     if not required_keys <= set(value) or not set(value) <= allowed_keys:
         fail(
             "descriptor-keys",
@@ -261,6 +285,33 @@ def validate_descriptor(value: object, required: set[str], optional: set[str]) -
     if "ownership_complete" in value and type(value["ownership_complete"]) is not bool:
         fail("ownership-complete-type", "ownership_complete must be boolean",
              "/ownership_complete")
+    if "c_build" in value:
+        build = value["c_build"]
+        if not isinstance(build, dict) or set(build) != C_BUILD_KEYS:
+            fail("c-build-shape", f"c_build keys must equal {sorted(C_BUILD_KEYS)}", "/c_build")
+        for field in sorted(C_BUILD_KEYS):
+            entries = build[field]
+            if not isinstance(entries, list):
+                fail("c-build-type", f"c_build.{field} must be an array", f"/c_build/{field}")
+            if field == "include_roots" and not entries:
+                fail("c-build-empty", "c_build.include_roots must not be empty",
+                     "/c_build/include_roots")
+            previous = ""
+            for index, entry in enumerate(entries):
+                pointer = f"/c_build/{field}/{index}"
+                if not isinstance(entry, str):
+                    fail("c-build-type", f"c_build.{field} entries must be strings", pointer)
+                if entry <= previous:
+                    fail("c-build-order", f"c_build.{field} must be sorted and unique", pointer)
+                previous = entry
+                if field == "include_roots":
+                    pure = PurePosixPath(entry)
+                    if (not entry or "\\" in entry or pure.is_absolute() or "." in pure.parts or
+                            ".." in pure.parts or pure.as_posix() != entry):
+                        fail("c-build-path", f"invalid repository-relative include root {entry!r}",
+                             pointer)
+                elif not BUILD_TOKEN_RE.fullmatch(entry):
+                    fail("c-build-token", f"invalid build token {entry!r}", pointer)
     return identifier
 
 
@@ -453,6 +504,17 @@ def validate_ownership(
     ownership = report["ownership"]
     assert isinstance(ownership, dict)
     claimed: dict[str, str] = {}
+    build = value.get("c_build")
+    if isinstance(build, dict):
+        for index, raw in enumerate(build["include_roots"]):
+            pointer = f"/c_build/include_roots/{index}"
+            pure = PurePosixPath(raw)
+            lexical = repo.resolve().joinpath(*pure.parts)
+            resolved = _resolve_owned(lexical, pointer)
+            if not _contained(resolved, repo.resolve()):
+                fail("c-build-path-escape", f"include root escapes repository: {raw}", pointer)
+            if resolved != lexical or not resolved.is_dir():
+                fail("c-build-directory", f"include root is not a real directory: {raw}", pointer)
     for field in OWNERSHIP_FIELDS:
         raw_entries = value.get(field, [])
         if not isinstance(raw_entries, list):

--- a/scripts/validate_module_process_contracts.py
+++ b/scripts/validate_module_process_contracts.py
@@ -111,9 +111,13 @@ def validate() -> dict[str, dict[str, object]]:
         if component_id in PROCESS_REQUIRED and execution != "process":
             raise ContractError(f"{component_id}: required feature must be a process")
 
+        descriptor = load(ROOT / f"src/modules/{component_id}/module.yaml")
+
         if execution == "core":
             if set(raw) != {"id", "execution", "placements"}:
                 raise ContractError(f"{component_id}: core component has process fields")
+            if "c_build" in descriptor:
+                raise ContractError(f"{component_id}: core component must not declare c_build")
         else:
             keys = set(raw) - {"hosted_by"}
             if keys != {"id", "execution", "runtime", "principal_ref", "placements", "stages"}:
@@ -132,6 +136,9 @@ def validate() -> dict[str, dict[str, object]]:
                 raise ContractError(f"{component_id}: process runtime must be c or go")
             if (component_id in GO_PROCESSES) != (runtime == "go"):
                 raise ContractError(f"{component_id}: runtime differs from the migration set")
+            if ("c_build" in descriptor) != (runtime == "c"):
+                raise ContractError(
+                    f"{component_id}: c_build must exist exactly for a C process runtime")
             principal_ref = raw["principal_ref"]
             expected_ref = declared_refs[component_id]
             if type(principal_ref) is not int or principal_ref != expected_ref or principal_ref in refs:

--- a/src/modules/module.schema.json
+++ b/src/modules/module.schema.json
@@ -4,6 +4,40 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "c_build": {
+      "additionalProperties": false,
+      "properties": {
+        "include_roots": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "pkg_config": {
+          "items": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:+-]*$",
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "system_libraries": {
+          "items": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:+-]*$",
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "include_roots",
+        "pkg_config",
+        "system_libraries"
+      ],
+      "type": "object"
+    },
     "dependencies": {
       "items": {
         "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",

--- a/tests/baselines/db2/source-boundary-v1.json
+++ b/tests/baselines/db2/source-boundary-v1.json
@@ -1,0 +1,5959 @@
+{
+  "schema_version": 1,
+  "source_revision": "12d7d6b037f4846b30ad4ae5ef002e965145951a",
+  "source_boundary": "src/db2",
+  "summary": {
+    "c_files": 141,
+    "headers": 137,
+    "sql_files": 6,
+    "consumer_files": 297,
+    "production_consumers": 147,
+    "test_consumers": 150,
+    "include_directives": 967
+  },
+  "source_files": {
+    "c": [
+      "src/db2/admin_grant.c",
+      "src/db2/agent_hints.c",
+      "src/db2/agent_outcomes.c",
+      "src/db2/anti_patterns.c",
+      "src/db2/artifacts.c",
+      "src/db2/bandit.c",
+      "src/db2/calibration.c",
+      "src/db2/canonical_index.c",
+      "src/db2/code_audit.c",
+      "src/db2/code_index.c",
+      "src/db2/code_index_ops.c",
+      "src/db2/code_project_lifecycle.c",
+      "src/db2/code_projection.c",
+      "src/db2/collab_rules.c",
+      "src/db2/corpus_jobs.c",
+      "src/db2/corpus_structural.c",
+      "src/db2/cross_repo_build.c",
+      "src/db2/cross_repo_classify.c",
+      "src/db2/cross_repo_deps.c",
+      "src/db2/cross_repo_identity.c",
+      "src/db2/cross_repo_resolver.c",
+      "src/db2/cross_repo_review.c",
+      "src/db2/cross_repo_route.c",
+      "src/db2/cross_repo_stats.c",
+      "src/db2/css_graph.c",
+      "src/db2/css_insights.c",
+      "src/db2/css_migration.c",
+      "src/db2/css_render.c",
+      "src/db2/curator_gaps.c",
+      "src/db2/curator_terms.c",
+      "src/db2/curiosity.c",
+      "src/db2/db2_hardening.c",
+      "src/db2/db2_init.c",
+      "src/db2/db2_pool.c",
+      "src/db2/db2_reembed.c",
+      "src/db2/db2_tenant.c",
+      "src/db2/db2_test_shim.c",
+      "src/db2/db2_witness_checkpoint.c",
+      "src/db2/db2_witness_emit.c",
+      "src/db2/db_postgres.c",
+      "src/db2/db_schema.c",
+      "src/db2/decision_log.c",
+      "src/db2/demotion.c",
+      "src/db2/enrollments.c",
+      "src/db2/entity_edges.c",
+      "src/db2/entity_nodes.c",
+      "src/db2/entity_profiles.c",
+      "src/db2/entity_registry.c",
+      "src/db2/epistemic_directives.c",
+      "src/db2/evidence_vectors.c",
+      "src/db2/fact_ingest.c",
+      "src/db2/fact_lifecycle.c",
+      "src/db2/fact_recall.c",
+      "src/db2/failed_queries.c",
+      "src/db2/feature_rows.c",
+      "src/db2/feedback.c",
+      "src/db2/fidelity.c",
+      "src/db2/kb_audit_worm.c",
+      "src/db2/kb_docs.c",
+      "src/db2/kb_maintenance.c",
+      "src/db2/kb_payload.c",
+      "src/db2/kb_releases.c",
+      "src/db2/kb_runtime_state.c",
+      "src/db2/kb_service_backend.c",
+      "src/db2/kb_service_backend_agent.c",
+      "src/db2/kb_service_backend_export.c",
+      "src/db2/kb_service_backend_ingest.c",
+      "src/db2/kb_service_backend_memory.c",
+      "src/db2/kb_vectors.c",
+      "src/db2/kind_lifecycle.c",
+      "src/db2/learning.c",
+      "src/db2/learning_synth_ops.c",
+      "src/db2/lessons.c",
+      "src/db2/management_action_journal.c",
+      "src/db2/management_client_instance.c",
+      "src/db2/management_identity_journal.c",
+      "src/db2/management_jwks_publication.c",
+      "src/db2/management_jwks_runtime.c",
+      "src/db2/management_read_journal.c",
+      "src/db2/management_status_key.c",
+      "src/db2/management_status_provision.c",
+      "src/db2/management_status_runtime.c",
+      "src/db2/management_token_authority.c",
+      "src/db2/management_token_roots.c",
+      "src/db2/membership.c",
+      "src/db2/memory_briefing.c",
+      "src/db2/memory_conflicts.c",
+      "src/db2/memory_entity_graph.c",
+      "src/db2/memory_export.c",
+      "src/db2/memory_health.c",
+      "src/db2/memory_lifecycle.c",
+      "src/db2/memory_lint.c",
+      "src/db2/memory_payload.c",
+      "src/db2/memory_promotion.c",
+      "src/db2/memory_query.c",
+      "src/db2/memory_query_bookkeeping.c",
+      "src/db2/memory_relations.c",
+      "src/db2/memory_row_mapper_pg.c",
+      "src/db2/memory_scenes.c",
+      "src/db2/memory_scope_query.c",
+      "src/db2/memory_score_fields.c",
+      "src/db2/memory_vectors.c",
+      "src/db2/mining.c",
+      "src/db2/notes.c",
+      "src/db2/oidc_jwks.c",
+      "src/db2/ontology_evolution.c",
+      "src/db2/org_budget.c",
+      "src/db2/org_egress.c",
+      "src/db2/org_model_catalog.c",
+      "src/db2/org_rate.c",
+      "src/db2/org_spend.c",
+      "src/db2/org_telemetry.c",
+      "src/db2/org_telemetry_fmt.c",
+      "src/db2/org_token_audit.c",
+      "src/db2/org_vault_key_use.c",
+      "src/db2/org_vault_rewrap.c",
+      "src/db2/org_vault_rotation.c",
+      "src/db2/pgvec_kb_service.c",
+      "src/db2/pgvec_transport.c",
+      "src/db2/pgvec_verify.c",
+      "src/db2/project.c",
+      "src/db2/prospective_memories.c",
+      "src/db2/rel_types_store.c",
+      "src/db2/report_enrichments.c",
+      "src/db2/rules.c",
+      "src/db2/server_registry.c",
+      "src/db2/shadow_delta.c",
+      "src/db2/sketch.c",
+      "src/db2/stopwords.c",
+      "src/db2/tasks.c",
+      "src/db2/team.c",
+      "src/db2/tool_registry.c",
+      "src/db2/trace_mining.c",
+      "src/db2/typed_facts.c",
+      "src/db2/vault_operator_rewrap_runtime.c",
+      "src/db2/vault_operator_status_runtime.c",
+      "src/db2/vault_pg.c",
+      "src/db2/vector_index_ops.c",
+      "src/db2/vector_status.c",
+      "src/db2/workflow_patterns.c",
+      "src/db2/write_tier_grant.c"
+    ],
+    "headers": [
+      "src/db2/admin_grant.h",
+      "src/db2/agent_hints.h",
+      "src/db2/agent_outcomes.h",
+      "src/db2/anti_patterns.h",
+      "src/db2/artifacts.h",
+      "src/db2/bandit.h",
+      "src/db2/calibration.h",
+      "src/db2/canonical_index.h",
+      "src/db2/code_index.h",
+      "src/db2/code_index_ops.h",
+      "src/db2/code_project_lifecycle.h",
+      "src/db2/code_projection.h",
+      "src/db2/collab_rules.h",
+      "src/db2/corpus_jobs.h",
+      "src/db2/corpus_structural.h",
+      "src/db2/cross_repo_build.h",
+      "src/db2/cross_repo_classify.h",
+      "src/db2/cross_repo_deps.h",
+      "src/db2/cross_repo_identity.h",
+      "src/db2/cross_repo_resolver.h",
+      "src/db2/cross_repo_review.h",
+      "src/db2/cross_repo_route.h",
+      "src/db2/cross_repo_stats.h",
+      "src/db2/css_graph.h",
+      "src/db2/css_insights.h",
+      "src/db2/css_migration.h",
+      "src/db2/css_render.h",
+      "src/db2/curator_gaps.h",
+      "src/db2/curator_terms.h",
+      "src/db2/curiosity.h",
+      "src/db2/db2.h",
+      "src/db2/db2_hardening.h",
+      "src/db2/db2_internal.h",
+      "src/db2/db2_learning.h",
+      "src/db2/db2_pool.h",
+      "src/db2/db2_tenant.h",
+      "src/db2/db2_test_shim.h",
+      "src/db2/db2_witness_checkpoint.h",
+      "src/db2/db2_witness_emit.h",
+      "src/db2/db_postgres.h",
+      "src/db2/db_schema.h",
+      "src/db2/decision_log.h",
+      "src/db2/demotion.h",
+      "src/db2/enrollments.h",
+      "src/db2/entity_edges.h",
+      "src/db2/entity_nodes.h",
+      "src/db2/entity_profiles.h",
+      "src/db2/entity_registry.h",
+      "src/db2/epistemic_directives.h",
+      "src/db2/eval_support.h",
+      "src/db2/evidence_vectors.h",
+      "src/db2/fact_ingest.h",
+      "src/db2/fact_lifecycle.h",
+      "src/db2/fact_recall.h",
+      "src/db2/failed_queries.h",
+      "src/db2/feature_rows.h",
+      "src/db2/feedback.h",
+      "src/db2/fidelity.h",
+      "src/db2/kb_audit_worm.h",
+      "src/db2/kb_docs.h",
+      "src/db2/kb_maintenance.h",
+      "src/db2/kb_payload.h",
+      "src/db2/kb_releases.h",
+      "src/db2/kb_runtime_state.h",
+      "src/db2/kb_service_backend.h",
+      "src/db2/kb_service_backend_export.h",
+      "src/db2/kb_vectors.h",
+      "src/db2/kind_lifecycle.h",
+      "src/db2/learning_synth_ops.h",
+      "src/db2/lessons.h",
+      "src/db2/lifecycle.h",
+      "src/db2/management_action_journal.h",
+      "src/db2/management_client_instance.h",
+      "src/db2/management_identity_journal.h",
+      "src/db2/management_intent_fields.h",
+      "src/db2/management_jwks_publication.h",
+      "src/db2/management_jwks_runtime.h",
+      "src/db2/management_read_journal.h",
+      "src/db2/management_status_key.h",
+      "src/db2/management_status_provision.h",
+      "src/db2/management_status_runtime.h",
+      "src/db2/management_token_authority.h",
+      "src/db2/management_token_roots.h",
+      "src/db2/membership.h",
+      "src/db2/memory_briefing.h",
+      "src/db2/memory_conflicts.h",
+      "src/db2/memory_export.h",
+      "src/db2/memory_health.h",
+      "src/db2/memory_lifecycle.h",
+      "src/db2/memory_lint.h",
+      "src/db2/memory_payload.h",
+      "src/db2/memory_promotion.h",
+      "src/db2/memory_query.h",
+      "src/db2/memory_relations.h",
+      "src/db2/memory_scenes.h",
+      "src/db2/memory_scope_query.h",
+      "src/db2/memory_vectors.h",
+      "src/db2/mining.h",
+      "src/db2/notes.h",
+      "src/db2/oidc_jwks.h",
+      "src/db2/ontology_evolution.h",
+      "src/db2/org_budget.h",
+      "src/db2/org_egress.h",
+      "src/db2/org_model_catalog.h",
+      "src/db2/org_rate.h",
+      "src/db2/org_spend.h",
+      "src/db2/org_telemetry.h",
+      "src/db2/org_telemetry_fmt.h",
+      "src/db2/org_token_audit.h",
+      "src/db2/org_vault_key_use.h",
+      "src/db2/org_vault_rewrap.h",
+      "src/db2/org_vault_rotation.h",
+      "src/db2/pgvec_kb_service.h",
+      "src/db2/pgvec_scope_query.h",
+      "src/db2/pgvec_transport.h",
+      "src/db2/project.h",
+      "src/db2/prospective_memories.h",
+      "src/db2/rel_types_store.h",
+      "src/db2/report_enrichments.h",
+      "src/db2/rules.h",
+      "src/db2/server_registry.h",
+      "src/db2/shadow_delta.h",
+      "src/db2/sketch.h",
+      "src/db2/stopwords.h",
+      "src/db2/tasks.h",
+      "src/db2/team.h",
+      "src/db2/tool_registry.h",
+      "src/db2/trace_mining.h",
+      "src/db2/typed_facts.h",
+      "src/db2/vault_operator_rewrap_runtime.h",
+      "src/db2/vault_operator_status_runtime.h",
+      "src/db2/vault_pg.h",
+      "src/db2/vector_index_ops.h",
+      "src/db2/vector_status.h",
+      "src/db2/vector_verify.h",
+      "src/db2/workflow_patterns.h",
+      "src/db2/write_tier_grant.h"
+    ],
+    "sql": [
+      "src/db2/cases.sql",
+      "src/db2/roadmap.sql",
+      "src/db2/schema.sql",
+      "src/db2/schema_grants.sql",
+      "src/db2/schema_roles.sql",
+      "src/db2/schema_sqlite.sql"
+    ]
+  },
+  "consumers": [
+    {
+      "path": "src/cmd_core.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/cmd_data.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/cmd_doctor.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/cmd_memory_core.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/cmd_memory_curiosity.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/curiosity.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/cmd_memory_embed.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/collab_rules.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/cmd_memory_vector.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/cmd_session_lifecycle.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rules.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/dashboard_kb.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/decision_log.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_conflicts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/prospective_memories.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/index.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/css_graph.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/canonical_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/corpus_jobs.h",
+          "count": 1
+        },
+        {
+          "header": "db2/enrollments.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_kb_service.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        },
+        {
+          "header": "db2/sketch.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2_pool.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_accounts.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/enrollments.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_bootstrap.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/enrollments.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_budget.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_code.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/canonical_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_project_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_projection.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_classify.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_deps.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_review.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_stats.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_nodes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lessons.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_code_graphfb.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/code_projection.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lessons.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_code_lifecycle.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/code_project_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_classify.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_stats.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_console.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/ontology_evolution.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_egress.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/enrollments.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_egress.h",
+          "count": 1
+        },
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_governance.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/decision_log.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_grants.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_intent_fields.h",
+          "count": 1
+        },
+        {
+          "header": "db2/write_tier_grant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_identity_login.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/management_identity_journal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_intent_fields.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_ingest.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_docs.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_insights.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_jobs.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_listener.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_models.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_pdf.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_rate.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_reflections.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_releases.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_docs.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_releases.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_search.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_releases.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_servers.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "../../db2/server_registry.h",
+          "count": 1
+        },
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_team.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_http_telemetry.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/http/kb_tls_serve.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "../../db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "../../db2/management_jwks_runtime.h",
+          "count": 1
+        },
+        {
+          "header": "../../db2/server_registry.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/enrollments.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/bandit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/sketch.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_bandit.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/bandit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_bedrock_egress.h",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/org_model_catalog.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_blob_reconcile.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_calibrate.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/calibration.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_conventions.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_demote.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/demotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_detect.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_doc_pdf.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_egress_admission.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "../db2/org_budget.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/org_rate.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/org_token_audit.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_evidence_embed.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/evidence_vectors.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_features.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_identity.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/management_intent_fields.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_identity_resolve.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_ingest_workers.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/canonical_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_kb_service.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_intel_payload.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/bandit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/calibration.h",
+          "count": 1
+        },
+        {
+          "header": "db2/demotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_learning_synth.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/learning_synth_ops.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_learning_version.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/evidence_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/learning_synth_ops.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_main.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_audit_worm.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rel_types_store.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vault_operator_status_runtime.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vault_pg.h",
+          "count": 1
+        },
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_management_action.h",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/management_action_journal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_management_cert_lifecycle.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_management_cert_lifecycle.h",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/management_client_instance.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_management_health_exchange.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_management_health_exchange.h",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/server_registry.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_management_runtime.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/management_action_journal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_read_journal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_memory_facts.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/fact_ingest.h",
+          "count": 1
+        },
+        {
+          "header": "db2/fact_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rel_types_store.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_mining.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_learning.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/mining.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_neardup.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_planner.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_ranker.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_ranker_fit.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/demotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_reasoning.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_reflection.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_kb_service.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_agent.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/demotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feedback.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_artifacts.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_code_embed.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_nodes.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/pgvec_kb_service.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_css.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/css_graph.h",
+          "count": 1
+        },
+        {
+          "header": "db2/css_insights.h",
+          "count": 1
+        },
+        {
+          "header": "db2/css_migration.h",
+          "count": 1
+        },
+        {
+          "header": "db2/css_render.h",
+          "count": 1
+        },
+        {
+          "header": "db2/typed_facts.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_graph.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_projection.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_nodes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_kb.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/canonical_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_maintenance.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend_export.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_kb_service.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_status.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_memory.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/bandit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/code_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/demotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/fidelity.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scope_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_service_workers.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_maintenance.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_surprising_judge.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/canonical_index.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_vault_key_use.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_vault_operator_runtime.h",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/vault_operator_rewrap_runtime.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_vault_policy.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_vault_rotation.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_vault_rotation_ops.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/kb_witness_cadence.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_emit.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/lessons_capture.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/lessons.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/lessons_session_capture.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/lessons.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/managed_server_identity_install.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/membership.h",
+          "count": 1
+        },
+        {
+          "header": "db2/server_registry.h",
+          "count": 1
+        },
+        {
+          "header": "db2/team.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/kb/roadmap.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/benchmarks/agent_eval_benchmarks.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_kb_service.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/execution-policy/execution_policy.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/tool_registry.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/guardrails/guardrails_semantic.c",
+      "classification": "module-placement-audit",
+      "includes": [
+        {
+          "header": "db2/bandit.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_contradictions.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_drain.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/cross_repo_build.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_identity.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_route.h",
+          "count": 1
+        },
+        {
+          "header": "db2/cross_repo_stats.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/decision_log.h",
+          "count": 1
+        },
+        {
+          "header": "db2/ontology_evolution.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_extract.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_extract_code.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_index_claims.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_index_code_unit.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_index_narrative.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_link_artifacts.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_promote.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_queue.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_resolve_entities.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/pgvec_transport.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_serve.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_synthesize.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/kb-synthesis/kb_curator_version.c",
+      "classification": "kb-generated-client",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/learning/learning_bundle.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/evidence_vectors.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/learning/learning_evidence.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/anti_patterns.h",
+          "count": 1
+        },
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/demotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_nodes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/epistemic_directives.h",
+          "count": 1
+        },
+        {
+          "header": "db2/evidence_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        },
+        {
+          "header": "db2/learning_synth_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rules.h",
+          "count": 1
+        },
+        {
+          "header": "db2/workflow_patterns.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/learning/learning_router.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/collab_rules.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_learning.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_advanced.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/anti_patterns.h",
+          "count": 1
+        },
+        {
+          "header": "db2/bandit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/decision_log.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feedback.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_briefing.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rules.h",
+          "count": 1
+        },
+        {
+          "header": "db2/tasks.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_assemble.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/anti_patterns.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scope_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rules.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_conflict.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/memory_conflicts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_context.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rules.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_crud.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_helpers.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_helpers_b.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_scope_embed.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_search.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scope_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_search_b.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scope_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_search_c.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scope_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_core_tiers.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feature_rows.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/stopwords.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vector_verify.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_directives.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/epistemic_directives.h",
+          "count": 1
+        },
+        {
+          "header": "db2/failed_queries.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_episodes.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_scenes.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_graph.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_graph_fusion.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_nodes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_graph_fusion.h",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_health.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/memory_health.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_improve.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/feedback.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_relations.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_lifecycle.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/memory_lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_logic.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/calibration.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kind_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_promotion.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_maintenance.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/code_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "db2/curiosity.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_prospective.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/prospective_memories.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/memory/memory_scan.c",
+      "classification": "module-kb-contract",
+      "includes": [
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_profiles.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/roadmap/roadmap_auto.c",
+      "classification": "module-placement-audit",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/roadmap/roadmap_milestone.c",
+      "classification": "module-placement-audit",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/roadmap/roadmap_reassess.c",
+      "classification": "module-placement-audit",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/modules/roadmap/roadmap_report.c",
+      "classification": "module-placement-audit",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/server/agent_policy.c",
+      "classification": "server-kb-contract",
+      "includes": [
+        {
+          "header": "db2/tool_registry.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/server/agent_runtime.c",
+      "classification": "server-kb-contract",
+      "includes": [
+        {
+          "header": "db2/agent_hints.h",
+          "count": 1
+        },
+        {
+          "header": "db2/agent_outcomes.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2/rules.h",
+          "count": 1
+        },
+        {
+          "header": "db2/tasks.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/server/retrieval_outcome_bridge.c",
+      "classification": "server-kb-contract",
+      "includes": [
+        {
+          "header": "db2/demotion.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/server/server_mcp.c",
+      "classification": "server-kb-contract",
+      "includes": [
+        {
+          "header": "db2/curiosity.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/server/server_mcp_ast_grep.c",
+      "classification": "server-kb-contract",
+      "includes": [
+        {
+          "header": "db2/curiosity.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/server/server_mcp_call_table.c",
+      "classification": "server-kb-contract",
+      "includes": [
+        {
+          "header": "db2/curiosity.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/aimee_pg_sqlite_shim.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/bench_perf.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/fuzz_memory_search.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/identity_mint_live_main.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/management_token_authority.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/support/corpus_jobs_http_stub.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/support/kb_http_route_stubs.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/management_identity_journal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/server_registry.h",
+          "count": 1
+        },
+        {
+          "header": "db2/write_tier_grant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/support/kb_txn_stub.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_artifacts.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_bandit.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/bandit.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_calibration.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cmd_doctor.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_code_index_ops.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/code_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_code_project_lifecycle.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/code_project_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/kb_audit_worm.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_code_projection.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_projection.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_nodes.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_code_vectors.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/entity_nodes.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/pgvec_kb_service.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_collab_rules.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_content_scope_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/project.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_context_assembly.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_corpus_jobs.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_corpus_structural.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_corpus_terms_gaps.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cross_repo_acceptance.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/cross_repo_deps.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/cross_repo_review.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cross_repo_build.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/cross_repo_build.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cross_repo_deps_orch.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/cross_repo_deps.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/cross_repo_identity.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/cross_repo_review.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/cross_repo_route.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cross_repo_identity.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/cross_repo_identity.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cross_repo_review.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/cross_repo_review.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cross_repo_route.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/cross_repo_route.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_cross_repo_stats.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/cross_repo_stats.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_css_graph.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_graph.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_css_insights.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_graph.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_insights.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_css_migration.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_graph.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_migration.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/typed_facts.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_css_render.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_graph.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_migration.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/css_render.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_code_unit.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_contradictions.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_index_claims.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_index_code_unit.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_index_narrative.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_invalidate.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_link_artifacts.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_pipeline.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_promote.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_queue.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_resolve_entities.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_serve.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_synthesize.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curator_version.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_curiosity.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/curiosity.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_db.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db_schema.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_db2.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_schema.h",
+          "count": 1
+        },
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_pool.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_db2_code_audit.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_service_backend.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_db2_conn_bounds.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_pool.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_db2_conn_open.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_pool.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_db2_hardening.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_hardening.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_db2_pool.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_pool.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_decision_log.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_demotion.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_embedder_probe_register.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_embedding_dim.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_schema.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_entity_nodes.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/entity_nodes.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_entity_registry.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_registry.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_evidence_embed.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_fact_ingest.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/fact_ingest.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/fact_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/ontology_evolution.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/rel_types_store.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_fact_lifecycle.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/fact_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/rel_types_store.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_fact_recall.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_registry.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/fact_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/fact_recall.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/rel_types_store.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_features.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/sketch.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_feedback.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_feedback_shadow.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/shadow_delta.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_fidelity.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/fidelity.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_graph_fusion.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_graph_scoring.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_guardrails.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_index.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/kb_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/pgvec_kb_service.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/sketch.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_audit_worm.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_audit_worm_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_bedrock_live.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_model_catalog.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_doc_pdf.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/kb_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_export.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/kb_service_backend_export.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_graph.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/code_projection.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_http_grants.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/write_tier_grant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_http_identity_login.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/management_identity_journal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_http_routes.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/code_project_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/decision_log.h",
+          "count": 1
+        },
+        {
+          "header": "db2/enrollments.h",
+          "count": 1
+        },
+        {
+          "header": "db2/lifecycle.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_http_servers_health.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_maintenance.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_management_runtime.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/management_read_journal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_mgmt_status_custody.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/management_status_key.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_mining.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_learning.h",
+          "count": 1
+        },
+        {
+          "header": "db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_p2b_egress_live.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/enrollments.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_vault_key_use.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vault_pg.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_reflection.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_releases_db.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/kb_releases.h",
+          "count": 1
+        },
+        {
+          "header": "db2/kb_runtime_state.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_tenancy_shim_guard.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_tenant.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_vault_key_use.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/org_vault_key_use.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_vault_key_use_live.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_vault_key_use.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_vault_rewrap_live.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_vault_rewrap.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_vault_rotation.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/org_vault_rotation.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_vault_rotation_live.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_kb_vault_rotation_ops_live.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_learning_bundle.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_learning_metrics.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_learning_synth.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_learning_version.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_management_action_journal.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_action_journal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_management_client_instance.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_client_instance.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_management_identity_journal.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_tenant.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_identity_journal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_management_status_key_ctx.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_status_key.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_management_status_runtime.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/management_status_runtime.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_mcp_git.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/code_index_ops.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/demotion.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory_advanced.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/bandit.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory_audit_hook.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory_embed_dim_guard.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_vectors.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory_filter.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory_health.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory_ranker_boundary.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_memory_retrieval_eval.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_query.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_notes.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_ontology_evolution.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/ontology_evolution.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/rel_types_store.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_org_model_catalog_target.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_model_catalog.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_org_telemetry.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/org_telemetry_fmt.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_org_vault_rewrap.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_pool.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_vault_rewrap.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_pg_prepare_classification.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_pgvec.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/kb_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_vectors.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/pgvec_scope_query.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/pgvec_transport.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/vector_verify.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_pgvec_neardup.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_planner.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_ranker_fit.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_reasoning.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_rel_types_store.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_edges.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/entity_registry.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/rel_types_store.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_report_enrichments.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_roadmap.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/artifacts.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_roadmap_decompose.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_rules.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_schema_subst.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_schema.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_session_briefing.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_subject_grammar.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/management_intent_fields.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_tasks.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_tool_prompts.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_tool_validation.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db2_test_shim.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_trace_analysis.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_typed_facts.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/fact_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/fact_recall.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/rel_types_store.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/typed_facts.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_vault_operator_status_runtime.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2/vault_operator_status_runtime.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_vault_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/vault_pg.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_vault_reseal_orchestrator_live.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "db2/org_vault_rewrap.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_wiki_render.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_witness_canary_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_emit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_witness_checkpoint_produce_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_witness_emit_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_emit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_witness_recovery_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_emit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_witness_tamper_pg.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_emit.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_working_profile.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tests/test_workspace_memory.c",
+      "classification": "private-implementation-test",
+      "includes": [
+        {
+          "header": "../db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/db_postgres.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_briefing.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_lifecycle.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_query.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_relations.h",
+          "count": 1
+        },
+        {
+          "header": "../db2/memory_scope_query.h",
+          "count": 1
+        },
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2_test_shim.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tools/witness_boot_tpm_harness.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_internal.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db2_witness_checkpoint.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/tools/witness_cadence_harness.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2.h",
+          "count": 1
+        },
+        {
+          "header": "db2/db_postgres.h",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "path": "src/trace_analysis.c",
+      "classification": "host-generated-client",
+      "includes": [
+        {
+          "header": "db2/anti_patterns.h",
+          "count": 1
+        },
+        {
+          "header": "db2/memory_payload.h",
+          "count": 1
+        },
+        {
+          "header": "db2/trace_mining.h",
+          "count": 1
+        }
+      ]
+    }
+  ],
+  "fingerprint": "b15c7761ecec50bfa60f22479f7e60f3855a771e0af52f0a8c25d25570f26fac"
+}


### PR DESCRIPTION
## Summary

- freeze the existing `src/db2` C/header/SQL boundary and classify all 297 outside consumers
- make the compatibility-include inventory shrink-only across pull requests
- add a strict `c_build` descriptor contract for standalone C module sources, include roots, pkg-config dependencies, and system libraries
- make C repository export compile every descriptor-owned C source and wire the negative suites into CI

This is the first mechanical prerequisite from the merged DB2/DB3 proposal. It does **not** switch DB2 ownership or production traffic yet.

## Baseline

- 141 C files
- 137 headers
- 6 SQL files
- 297 consumer files (147 production, 150 tests)
- 967 direct includes

## Validation

- 44 descriptor/schema/ownership tests
- 11 DB2 boundary and shrink-only negative tests
- 5 C exporter generation tests
- 7 principal/process identity tests
- full `CGO_ENABLED=0 go test ./...` under `server-go`
- runtime-bundle and 29-repository export validation
- module inventory/source ownership/bus boundary checks
- docs, JSON, YAML, Python compile, and diff checks