### PR TITLE
Build complete C module runtime bundles

### DIFF
--- a/.github/workflows/c-repositories.yml
+++ b/.github/workflows/c-repositories.yml
@@ -14,6 +14,7 @@ on:
       - "src/tests/**"
       - "docs/modules/**"
       - "scripts/export_c_repositories.py"
+      - "scripts/build_c_module_runtime_bundle.py"
       - "scripts/check_c_repository_lock.py"
       - "scripts/validate_module_process_contracts.py"
       - "scripts/check_go_module_runtime_bundle.py"
@@ -33,6 +34,7 @@ on:
       - "src/tests/**"
       - "docs/modules/**"
       - "scripts/export_c_repositories.py"
+      - "scripts/build_c_module_runtime_bundle.py"
       - "scripts/check_c_repository_lock.py"
       - "scripts/validate_module_process_contracts.py"
       - "scripts/check_go_module_runtime_bundle.py"
@@ -53,6 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: python3 -I -S scripts/validate_module_process_contracts.py
       - run: python3 -I scripts/tests/test_export_c_process_build.py -v
+      - run: python3 -I scripts/tests/test_build_c_module_runtime_bundle.py -v
       - run: python3 -I scripts/check_go_module_runtime_bundle.py
       - run: cd server-go && CGO_ENABLED=0 go test ./bus ./modules/... ./cmd/aimee-module
       # The exact commit/digest pins in dependencies/aimee-repositories.lock.json

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -223,6 +223,8 @@ jobs:
         run: python3 -I scripts/tests/test_validate_module_descriptors.py -v
       - name: Test exhaustive standalone C-process export generation
         run: python3 -I scripts/tests/test_export_c_process_build.py -v
+      - name: Test exhaustive C-process runtime-bundle builds
+        run: python3 -I scripts/tests/test_build_c_module_runtime_bundle.py -v
       - name: Enforce canonical module public-header layout
         run: python3 -I -S scripts/check_module_header_layout.py
       - name: Test module public-header layout failure modes

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,23 +48,8 @@ RUN sh scripts/fetch-treesitter.sh \
 
 RUN python3 scripts/export_c_repositories.py --runtime-bundle /module-runtime \
     && mkdir -p /module-runtime/bin \
-    && for source in /module-runtime/src/*.c; do \
-         [ -e "$source" ] || continue; \
-         binary="${source##*/}"; binary="${binary%.c}"; \
-         cc -std=c11 -O2 -Wall -Wextra -Werror -Isrc/core/event_bus/include \
-           -Isrc/modules/memory/include -Isrc/modules/learning/include \
-           -Isrc/modules/routing/include -Isrc/modules/delegates/include \
-           -Isrc/modules/tools/include -Isrc/modules/workspace/include \
-           -Isrc/modules/git/include -Isrc/modules/skills/include \
-           -Isrc/modules/response-composition/include \
-           "$source" \
-           src/core/event_bus/bus_attach.c src/core/event_bus/bus_client.c \
-           src/core/event_bus/bus_endpoint.c src/core/event_bus/bus_region.c \
-           src/core/event_bus/bus_ring.c src/core/event_bus/bus_wire.c \
-           src/core/event_bus/module_protocol.c src/core/event_bus/module_runtime.c \
-           -pthread \
-           -o "/module-runtime/bin/$binary"; \
-       done \
+    && python3 scripts/build_c_module_runtime_bundle.py \
+         --bundle /module-runtime --output /module-runtime/bin \
     && while IFS= read -r module_id; do \
          [ -n "$module_id" ] || continue; \
          install -m 0755 /tmp/aimee-module-go \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -60,23 +60,8 @@ RUN build_version="$AIMEE_VERSION" \
 # Go processes are copies of the static multicall runtime under attested names.
 RUN python3 scripts/export_c_repositories.py --runtime-bundle /module-runtime \
     && mkdir -p /module-runtime/bin \
-    && for source in /module-runtime/src/*.c; do \
-         [ -e "$source" ] || continue; \
-         binary="${source##*/}"; binary="${binary%.c}"; \
-         cc -std=c11 -O2 -Wall -Wextra -Werror -Isrc/core/event_bus/include \
-           -Isrc/modules/memory/include -Isrc/modules/learning/include \
-           -Isrc/modules/routing/include -Isrc/modules/delegates/include \
-           -Isrc/modules/tools/include -Isrc/modules/workspace/include \
-           -Isrc/modules/git/include -Isrc/modules/skills/include \
-           -Isrc/modules/response-composition/include \
-           "$source" \
-           src/core/event_bus/bus_attach.c src/core/event_bus/bus_client.c \
-           src/core/event_bus/bus_endpoint.c src/core/event_bus/bus_region.c \
-           src/core/event_bus/bus_ring.c src/core/event_bus/bus_wire.c \
-           src/core/event_bus/module_protocol.c src/core/event_bus/module_runtime.c \
-           -pthread \
-           -o "/module-runtime/bin/$binary"; \
-       done \
+    && python3 scripts/build_c_module_runtime_bundle.py \
+         --bundle /module-runtime --output /module-runtime/bin \
     && while IFS= read -r module_id; do \
          [ -n "$module_id" ] || continue; \
          install -m 0755 /tmp/aimee-module-go \

--- a/docs/core/repository-extraction.md
+++ b/docs/core/repository-extraction.md
@@ -20,6 +20,16 @@ target. Its generated grant is executable/UID/principal-bound and starts with no
 event capabilities; capabilities are added only with the corresponding stable
 event schema.
 
+Container builds use the same descriptor contract through a two-step runtime
+bundle. `export_c_repositories.py --runtime-bundle <directory>` writes generated
+process mains, grants, placement lists, and `c-build.json`. Then
+`build_c_module_runtime_bundle.py` compiles each C process from its generated
+main, every descriptor-owned C source, the canonical event-bus client sources,
+and its declared include roots, pkg-config packages, and system libraries. The
+manifest is data rather than a shell fragment: paths and dependency tokens are
+validated before they become compiler arguments, and no module source is
+concatenated into the generated main.
+
 `dependencies/aimee-repositories.lock.json` records repository URLs, semantic
 versions, exact commits, stable principal identities, and source digests.
 `python3 scripts/check_c_repository_lock.py` fails when a vendored core/module

--- a/scripts/build_c_module_runtime_bundle.py
+++ b/scripts/build_c_module_runtime_bundle.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Compile descriptor-owned C module processes from a runtime-bundle manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import re
+import shlex
+import subprocess
+import sys
+from typing import NoReturn
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BUILD_MANIFEST = "c-build.json"
+MODULE_ID = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+BUILD_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:+-]*$")
+MODULE_KEYS = {
+    "id", "binary", "main", "sources", "include_roots", "pkg_config",
+    "system_libraries",
+}
+CORE_EVENT_BUS_SOURCES = [
+    "src/core/event_bus/bus_attach.c",
+    "src/core/event_bus/bus_client.c",
+    "src/core/event_bus/bus_endpoint.c",
+    "src/core/event_bus/bus_region.c",
+    "src/core/event_bus/bus_ring.c",
+    "src/core/event_bus/bus_wire.c",
+    "src/core/event_bus/module_protocol.c",
+    "src/core/event_bus/module_runtime.c",
+]
+IMPORTED_TARGET_FLAGS = {
+    "OpenSSL::Crypto": "-lcrypto",
+    "OpenSSL::SSL": "-lssl",
+    "Threads::Threads": "-pthread",
+    "ZLIB::ZLIB": "-lz",
+}
+
+
+class BuildError(RuntimeError):
+    """A fail-closed runtime-bundle build error."""
+
+
+def fail(message: str) -> NoReturn:
+    raise BuildError(message)
+
+
+def strict_json(raw: bytes) -> object:
+    def no_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        value: dict[str, object] = {}
+        for key, item in pairs:
+            if key in value:
+                fail(f"C build manifest contains duplicate key {key!r}")
+            value[key] = item
+        return value
+
+    if raw.startswith(b"\xef\xbb\xbf"):
+        fail("C build manifest begins with a UTF-8 BOM")
+    try:
+        return json.loads(raw.decode("utf-8", "strict"), object_pairs_hook=no_duplicates)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"cannot parse {BUILD_MANIFEST}: {exc}")
+
+
+def safe_relative(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        fail(f"{label} must be a string")
+    pure = PurePosixPath(value)
+    if (not value or "\\" in value or pure.is_absolute() or "." in pure.parts or
+            ".." in pure.parts or pure.as_posix() != value):
+        fail(f"{label} is not a safe relative path: {value!r}")
+    return value
+
+
+def string_array(value: object, label: str, *, paths: bool = False,
+                 nonempty: bool = False) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        fail(f"{label} must be a string array")
+    if nonempty and not value:
+        fail(f"{label} must not be empty")
+    if value != sorted(set(value)):
+        fail(f"{label} must be sorted and unique")
+    for item in value:
+        if paths:
+            safe_relative(item, label)
+        elif not BUILD_TOKEN.fullmatch(item):
+            fail(f"{label} contains unsafe token {item!r}")
+    return value
+
+
+def load_builds(bundle: Path) -> list[dict[str, object]]:
+    try:
+        value = strict_json((bundle / BUILD_MANIFEST).read_bytes())
+    except OSError as exc:
+        fail(f"cannot load {BUILD_MANIFEST}: {exc}")
+    if not isinstance(value, dict) or set(value) != {"schema_version", "modules"}:
+        fail("C build manifest top-level keys differ from v1")
+    modules = value["modules"]
+    if value["schema_version"] != 1 or not isinstance(modules, list):
+        fail("C build manifest schema_version/modules are invalid")
+    previous = ""
+    result: list[dict[str, object]] = []
+    for index, module in enumerate(modules):
+        if not isinstance(module, dict) or set(module) != MODULE_KEYS:
+            fail(f"module {index}: keys differ from C build v1")
+        identifier = module["id"]
+        if (not isinstance(identifier, str) or not MODULE_ID.fullmatch(identifier) or
+                identifier <= previous):
+            fail(f"module {index}: IDs must be valid, sorted, and unique")
+        previous = identifier
+        if module["binary"] != f"aimee-module-{identifier}":
+            fail(f"{identifier}: binary does not match module identity")
+        main = safe_relative(module["main"], f"{identifier}.main")
+        if main != f"src/aimee-module-{identifier}.c":
+            fail(f"{identifier}: generated main path is not canonical")
+        sources = string_array(module["sources"], f"{identifier}.sources", paths=True,
+                               nonempty=True)
+        if any(PurePosixPath(source).suffix != ".c" for source in sources):
+            fail(f"{identifier}: sources must all be C translation units")
+        string_array(module["include_roots"], f"{identifier}.include_roots", paths=True,
+                     nonempty=True)
+        string_array(module["pkg_config"], f"{identifier}.pkg_config")
+        libraries = string_array(module["system_libraries"],
+                                 f"{identifier}.system_libraries")
+        for library in libraries:
+            if "::" in library and library not in IMPORTED_TARGET_FLAGS:
+                fail(f"{identifier}: unsupported imported target {library!r}")
+        result.append(module)
+    return result
+
+
+def real_file(root: Path, relative: str, label: str) -> Path:
+    lexical = root.joinpath(*PurePosixPath(relative).parts)
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = lexical.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, ValueError) as exc:
+        fail(f"{label} is missing or escapes its root: {relative}: {exc}")
+    if resolved != lexical or not resolved.is_file():
+        fail(f"{label} is not a real regular file: {relative}")
+    return resolved
+
+
+def real_directory(root: Path, relative: str, label: str) -> Path:
+    lexical = root.joinpath(*PurePosixPath(relative).parts)
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = lexical.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, ValueError) as exc:
+        fail(f"{label} is missing or escapes its root: {relative}: {exc}")
+    if resolved != lexical or not resolved.is_dir():
+        fail(f"{label} is not a real directory: {relative}")
+    return resolved
+
+
+def pkg_config_flags(executable: str, packages: list[str]) -> tuple[list[str], list[str]]:
+    if not packages:
+        return [], []
+    results: list[list[str]] = []
+    for mode in ("--cflags", "--libs"):
+        try:
+            completed = subprocess.run(
+                [executable, mode, *packages], check=True, text=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            detail = getattr(exc, "stderr", "") or str(exc)
+            fail(f"pkg-config {mode} failed: {detail.strip()}")
+        try:
+            results.append(shlex.split(completed.stdout, posix=True))
+        except ValueError as exc:
+            fail(f"pkg-config {mode} returned malformed flags: {exc}")
+    return results[0], results[1]
+
+
+def compiler_command(module: dict[str, object], root: Path, bundle: Path, output: Path,
+                     cc: str, pkg_config: str) -> list[str]:
+    identifier = module["id"]
+    assert isinstance(identifier, str)
+    sources = module["sources"]
+    include_roots = module["include_roots"]
+    packages = module["pkg_config"]
+    libraries = module["system_libraries"]
+    assert all(isinstance(value, list) for value in (
+        sources, include_roots, packages, libraries
+    ))
+    main = real_file(bundle, module["main"], f"{identifier}.main")
+    owned_sources = [real_file(root, item, f"{identifier}.sources") for item in sources]
+    core_sources = [real_file(root, item, "event-bus source")
+                    for item in CORE_EVENT_BUS_SOURCES]
+    include_paths = [real_directory(root, "src/core/event_bus/include", "event-bus include")]
+    include_paths.extend(
+        real_directory(root, item, f"{identifier}.include_roots")
+        for item in include_roots
+    )
+    cflags, pkg_libraries = pkg_config_flags(pkg_config, packages)
+    system_flags = [
+        IMPORTED_TARGET_FLAGS.get(library, f"-l{library}") for library in libraries
+    ]
+    binary = output / module["binary"]
+    return [
+        cc, "-std=c11", "-O2", "-Wall", "-Wextra", "-Werror",
+        *(f"-I{path}" for path in include_paths), *cflags, str(main),
+        *(str(path) for path in owned_sources), *(str(path) for path in core_sources),
+        *pkg_libraries, *system_flags, "-o", str(binary),
+    ]
+
+
+def build(bundle: Path, output: Path, root: Path, cc: str, pkg_config: str) -> int:
+    modules = load_builds(bundle)
+    output.mkdir(parents=True, exist_ok=True)
+    for module in modules:
+        command = compiler_command(module, root, bundle, output, cc, pkg_config)
+        try:
+            subprocess.run(command, check=True)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            fail(f"{module['id']}: compiler failed: {exc}")
+        binary = output / str(module["binary"])
+        if not binary.is_file() or binary.is_symlink():
+            fail(f"{module['id']}: compiler did not create {binary}")
+    return len(modules)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--cc", default="cc")
+    parser.add_argument("--pkg-config", default="pkg-config")
+    args = parser.parse_args(argv)
+    try:
+        count = build(args.bundle.resolve(), args.output.resolve(), args.root.resolve(),
+                      args.cc, args.pkg_config)
+    except BuildError as exc:
+        print(f"build_c_module_runtime_bundle: error: {exc}", file=sys.stderr)
+        return 1
+    print(f"build_c_module_runtime_bundle: ok ({count} C module(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_go_module_runtime_bundle.py
+++ b/scripts/check_go_module_runtime_bundle.py
@@ -46,6 +46,12 @@ def main() -> int:
             if set(actual_go) & set(actual_c):
                 return fail("a migrated module also has a generated C runtime")
             manifest = json.loads((bundle / "MANIFEST.json").read_text(encoding="utf-8"))
+            c_build = json.loads((bundle / "c-build.json").read_text(encoding="utf-8"))
+            if c_build.get("schema_version") != 1 or \
+                    [row.get("id") for row in c_build.get("modules", [])] != sorted(expected_c):
+                return fail("C build manifest differs from the canonical contracts")
+            if manifest.get("c_build") != "c-build.json":
+                return fail("runtime manifest does not bind the C build manifest")
             if manifest.get("runtimes") != {name: row["runtime"] for name, row in contracts.items()
                                              if row["execution"] == "process"}:
                 return fail("runtime manifest differs from the canonical contracts")
@@ -77,9 +83,14 @@ def main() -> int:
         for dockerfile in (ROOT / "Dockerfile", ROOT / "Dockerfile.server"):
             text = dockerfile.read_text(encoding="utf-8")
             for required in ("AS module-go-build", "./cmd/aimee-module",
-                             "/module-runtime/go.modules", "/tmp/aimee-module-go"):
+                             "/module-runtime/go.modules", "/tmp/aimee-module-go",
+                             "build_c_module_runtime_bundle.py"):
                 if required not in text:
                     return fail(f"{dockerfile.name}: missing {required!r}")
+            for forbidden in ("for source in /module-runtime/src/*.c",
+                              "src/core/event_bus/bus_attach.c src/core/event_bus/bus_client.c"):
+                if forbidden in text:
+                    return fail(f"{dockerfile.name}: retains legacy C build fragment {forbidden!r}")
     except (OSError, UnicodeError, json.JSONDecodeError, exporter.ExportError) as exc:
         return fail(str(exc))
     print(f"check_go_module_runtime_bundle: ok ({len(expected_go)} Go, {len(expected_c)} C)")

--- a/scripts/export_c_repositories.py
+++ b/scripts/export_c_repositories.py
@@ -358,6 +358,11 @@ install(FILES ${{CMAKE_CURRENT_BINARY_DIR}}/{module_id}.grant
 """
 
 
+def c_process_has_handler(sources: list[str]) -> bool:
+    """A C process owns a handler when any declared source is its module adapter."""
+    return any(PurePosixPath(source).name == "module_adapter.c" for source in sources)
+
+
 def go_module_main(module_id: str, principal_ref: int,
                    stages: list[dict[str, object]]) -> str:
     """Generate one independently buildable Go process entry point."""
@@ -482,8 +487,9 @@ def export_module(
     if descriptor.get("id") != module_id:
         raise ExportError(f"{descriptor_path}: descriptor id mismatch")
     owned = module_owned_files(module_id, descriptor)
-    adapter_source = f"src/modules/{module_id}/module_adapter.c"
-    has_handler = adapter_source in owned
+    declared_sources = descriptor.get("sources", [])
+    assert isinstance(declared_sources, list)
+    has_handler = c_process_has_handler(declared_sources)
     repository = output_root / f"aimee-module-{module_id}"
     repository.mkdir()
     for relative in owned:
@@ -730,14 +736,13 @@ def export_runtime_bundle(output_root: Path) -> int:
     placement_rows: dict[str, list[str]] = {"server": [], "kb": []}
     runtimes: dict[str, str] = {}
     go_modules: list[str] = []
+    c_builds: list[dict[str, object]] = []
     count = 0
     for module_id, contract in contracts.items():
         if contract["execution"] != "process":
             continue
         descriptor = load_json(ROOT / f"src/modules/{module_id}/module.yaml")
-        adapter_source = f"src/modules/{module_id}/module_adapter.c"
-        owned = module_owned_files(module_id, descriptor)
-        has_handler = adapter_source in owned
+        module_owned_files(module_id, descriptor)
         enabled = module_id in required or descriptor.get("enabled_by_default") is True
         principal_ref = contract["principal_ref"]
         stages = contract["stages"]
@@ -752,10 +757,24 @@ def export_runtime_bundle(output_root: Path) -> int:
         assert isinstance(runtime, str)
         runtimes[module_id] = runtime
         if runtime == "c":
-            generated = module_main(module_id, principal_ref, stages, has_handler)
-            if has_handler:
-                generated += "\n" + (ROOT / adapter_source).read_text(encoding="utf-8")
-            write_text(output_root / "src" / f"{binary}.c", generated)
+            sources, include_roots, pkg_config, libraries = c_process_build(
+                module_id, descriptor
+            )
+            has_handler = c_process_has_handler(sources)
+            main_path = f"src/{binary}.c"
+            write_text(
+                output_root / main_path,
+                module_main(module_id, principal_ref, stages, has_handler),
+            )
+            c_builds.append({
+                "id": module_id,
+                "binary": binary,
+                "main": main_path,
+                "sources": sources,
+                "include_roots": include_roots,
+                "pkg_config": pkg_config,
+                "system_libraries": libraries,
+            })
         else:
             go_sources = descriptor.get("go_sources", [])
             if not isinstance(go_sources, list) or not go_sources:
@@ -801,11 +820,17 @@ serve=
     for placement, rows in placement_rows.items():
         write_text(output_root / f"{placement}.modules", "\n".join(rows) + "\n")
     write_text(output_root / "go.modules", "\n".join(go_modules) + "\n")
+    c_builds.sort(key=lambda row: str(row["id"]))
+    write_text(
+        output_root / "c-build.json",
+        json.dumps({"schema_version": 1, "modules": c_builds}, indent=2) + "\n",
+    )
     write_text(
         output_root / "MANIFEST.json",
         json.dumps(
             {"schema_version": 1, "contracts": str(process_contracts.CONTRACTS.relative_to(ROOT)),
-             "process_count": count, "runtimes": runtimes, "placements": placement_rows},
+             "c_build": "c-build.json", "process_count": count,
+             "runtimes": runtimes, "placements": placement_rows},
             indent=2,
         ) + "\n",
     )

--- a/scripts/tests/test_build_c_module_runtime_bundle.py
+++ b/scripts/tests/test_build_c_module_runtime_bundle.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Tests for descriptor-owned C process builds in runtime bundles."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILDER = REPO_ROOT / "scripts/build_c_module_runtime_bundle.py"
+SPEC = importlib.util.spec_from_file_location("build_c_module_runtime_bundle", BUILDER)
+assert SPEC and SPEC.loader
+builder = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(builder)
+
+
+class RuntimeBundleBuildTests(unittest.TestCase):
+    def fixture(self) -> tuple[tempfile.TemporaryDirectory[str], Path, Path, Path]:
+        temporary = tempfile.TemporaryDirectory()
+        base = Path(temporary.name)
+        root = base / "repo"
+        bundle = base / "bundle"
+        output = base / "bin"
+        files = [
+            *builder.CORE_EVENT_BUS_SOURCES,
+            "src/modules/db2/c/store.c",
+            "src/modules/db2/module_adapter.c",
+        ]
+        for relative in files:
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("int aimee_fixture;\n", encoding="utf-8")
+        (root / "src/core/event_bus/include").mkdir(parents=True)
+        (root / "src/modules/db2/include").mkdir(parents=True)
+        main = bundle / "src/aimee-module-db2.c"
+        main.parent.mkdir(parents=True)
+        main.write_text("int main(void) { return 0; }\n", encoding="utf-8")
+        self.write_manifest(bundle)
+        return temporary, root, bundle, output
+
+    def write_manifest(self, bundle: Path) -> None:
+        value = {
+            "schema_version": 1,
+            "modules": [{
+                "id": "db2",
+                "binary": "aimee-module-db2",
+                "main": "src/aimee-module-db2.c",
+                "sources": [
+                    "src/modules/db2/c/store.c",
+                    "src/modules/db2/module_adapter.c",
+                ],
+                "include_roots": ["src/modules/db2/include"],
+                "pkg_config": ["libpq"],
+                "system_libraries": [
+                    "OpenSSL::Crypto",
+                    "Threads::Threads",
+                    "ZLIB::ZLIB",
+                    "m",
+                    "zstd",
+                ],
+            }],
+        }
+        bundle.mkdir(parents=True, exist_ok=True)
+        (bundle / builder.BUILD_MANIFEST).write_text(
+            json.dumps(value, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def executable(self, path: Path, content: str) -> None:
+        path.write_text(content, encoding="utf-8")
+        path.chmod(path.stat().st_mode | 0o111)
+
+    def test_build_compiles_generated_main_all_sources_and_dependencies(self) -> None:
+        temporary, root, bundle, output = self.fixture()
+        try:
+            log = Path(temporary.name) / "compiler-args.json"
+            compiler = Path(temporary.name) / "fake-cc"
+            pkg_config = Path(temporary.name) / "fake-pkg-config"
+            self.executable(
+                compiler,
+                "#!/usr/bin/env python3\n"
+                "import json, os, pathlib, sys\n"
+                "pathlib.Path(os.environ['FAKE_CC_LOG']).write_text(json.dumps(sys.argv[1:]))\n"
+                "pathlib.Path(sys.argv[sys.argv.index('-o') + 1]).write_text('binary')\n",
+            )
+            self.executable(
+                pkg_config,
+                "#!/usr/bin/env python3\n"
+                "import sys\n"
+                "print('-I/pkg/include' if sys.argv[1] == '--cflags' else '-L/pkg/lib -lpq')\n",
+            )
+            environment = os.environ.copy()
+            environment["FAKE_CC_LOG"] = str(log)
+            result = subprocess.run(
+                [sys.executable, "-I", "-S", str(BUILDER),
+                 "--bundle", str(bundle), "--output", str(output),
+                 "--root", str(root), "--cc", str(compiler),
+                 "--pkg-config", str(pkg_config)],
+                text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                env=environment, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((output / "aimee-module-db2").read_text(), "binary")
+            arguments = json.loads(log.read_text(encoding="utf-8"))
+            expected_sources = [
+                bundle / "src/aimee-module-db2.c",
+                root / "src/modules/db2/c/store.c",
+                root / "src/modules/db2/module_adapter.c",
+                *(root / relative for relative in builder.CORE_EVENT_BUS_SOURCES),
+            ]
+            for source in expected_sources:
+                self.assertEqual(arguments.count(str(source)), 1)
+            for flag in ("-I/pkg/include", "-L/pkg/lib", "-lpq", "-lcrypto",
+                         "-pthread", "-lz", "-lm", "-lzstd"):
+                self.assertIn(flag, arguments)
+        finally:
+            temporary.cleanup()
+
+    def test_manifest_rejects_path_escape_unknown_target_and_unsorted_modules(self) -> None:
+        mutations = (
+            (lambda value: value["modules"][0].__setitem__("main", "../main.c"),
+             "safe relative path"),
+            (lambda value: (
+                value["modules"][0]["system_libraries"].append("Unknown::Target"),
+                value["modules"][0]["system_libraries"].sort(),
+            ), "unsupported imported target"),
+            (lambda value: value["modules"].append(dict(value["modules"][0])),
+             "sorted, and unique"),
+        )
+        for mutate, message in mutations:
+            temporary, _root, bundle, _output = self.fixture()
+            try:
+                path = bundle / builder.BUILD_MANIFEST
+                value = json.loads(path.read_text(encoding="utf-8"))
+                mutate(value)
+                path.write_text(json.dumps(value), encoding="utf-8")
+                with self.subTest(message=message), self.assertRaisesRegex(
+                    builder.BuildError, message
+                ):
+                    builder.load_builds(bundle)
+            finally:
+                temporary.cleanup()
+
+    def test_missing_owned_source_and_symlink_include_fail_closed(self) -> None:
+        temporary, root, bundle, output = self.fixture()
+        try:
+            (root / "src/modules/db2/c/store.c").unlink()
+            module = builder.load_builds(bundle)[0]
+            with self.assertRaisesRegex(builder.BuildError, "missing or escapes"):
+                builder.compiler_command(module, root, bundle, output, "cc", "pkg-config")
+        finally:
+            temporary.cleanup()
+
+        temporary, root, bundle, output = self.fixture()
+        try:
+            include = root / "src/modules/db2/include"
+            include.rmdir()
+            include.symlink_to(root / "src/modules/db2/c", target_is_directory=True)
+            module = builder.load_builds(bundle)[0]
+            with self.assertRaisesRegex(builder.BuildError, "not a real directory"):
+                builder.compiler_command(module, root, bundle, output, "cc", "pkg-config")
+        finally:
+            temporary.cleanup()
+
+    def test_empty_manifest_is_a_successful_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            bundle = base / "bundle"
+            bundle.mkdir()
+            (bundle / builder.BUILD_MANIFEST).write_text(
+                '{"schema_version": 1, "modules": []}\n', encoding="utf-8"
+            )
+            output = base / "bin"
+            self.assertEqual(builder.build(bundle, output, base, "cc", "pkg-config"), 0)
+            self.assertEqual(list(output.iterdir()), [])
+
+    def test_duplicate_json_key_and_bom_fail_closed(self) -> None:
+        for raw, message in (
+            (b'{"schema_version":1,"schema_version":1,"modules":[]}',
+             "duplicate key"),
+            (b'\xef\xbb\xbf{"schema_version":1,"modules":[]}', "UTF-8 BOM"),
+        ):
+            with tempfile.TemporaryDirectory() as temporary:
+                bundle = Path(temporary)
+                (bundle / builder.BUILD_MANIFEST).write_bytes(raw)
+                with self.subTest(message=message), self.assertRaisesRegex(
+                    builder.BuildError, message
+                ):
+                    builder.load_builds(bundle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_export_c_process_build.py
+++ b/scripts/tests/test_export_c_process_build.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -109,6 +112,51 @@ class CProcessBuildTests(unittest.TestCase):
         self.assertEqual(cmake.count("find_package(OpenSSL REQUIRED)"), 1)
         self.assertIn("OpenSSL::Crypto", cmake)
         self.assertIn("OpenSSL::SSL", cmake)
+
+    def test_runtime_bundle_emits_an_exhaustive_non_amalgamated_c_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "repo"
+            bundle = Path(temporary) / "bundle"
+            descriptor_path = root / "src/modules/db2/module.yaml"
+            descriptor_path.parent.mkdir(parents=True)
+            descriptor = {
+                "id": "db2",
+                **self.descriptor(),
+            }
+            descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+            inventory = root / "inventory.json"
+            inventory.write_text(
+                json.dumps({"required": ["db2"], "optional": []}), encoding="utf-8"
+            )
+            contracts_path = root / "process-contracts.json"
+            contracts_path.write_text('{"clients": []}\n', encoding="utf-8")
+            contract = {
+                "execution": "process",
+                "runtime": "c",
+                "principal_ref": 29,
+                "placements": ["kb"],
+                "stages": [{"id": 1, "name": "lifecycle", "event_kind": 11521}],
+            }
+            with mock.patch.object(exporter, "ROOT", root), \
+                    mock.patch.object(exporter, "INVENTORY", inventory), \
+                    mock.patch.object(exporter.process_contracts, "CONTRACTS", contracts_path), \
+                    mock.patch.object(exporter.process_contracts, "validate",
+                                      return_value={"db2": contract}):
+                self.assertEqual(exporter.export_runtime_bundle(bundle), 1)
+
+            build = json.loads((bundle / "c-build.json").read_text(encoding="utf-8"))
+            self.assertEqual(build["modules"], [{
+                "id": "db2",
+                "binary": "aimee-module-db2",
+                "main": "src/aimee-module-db2.c",
+                **self.descriptor()["c_build"],
+                "sources": self.descriptor()["sources"],
+            }])
+            main = (bundle / "src/aimee-module-db2.c").read_text(encoding="utf-8")
+            self.assertIn("extern aimee_module_status_t aimee_module_handler", main)
+            self.assertNotIn("db2_init", main)
+            self.assertIn("db2\t/usr/local/libexec/aimee-modules/aimee-module-db2",
+                          (bundle / "kb.modules").read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Emits a strict c-build.json manifest for C process entries in exported runtime bundles.
- Adds a portable builder that compiles each module-owned source and canonical event-bus source exactly once.
- Carries pkg-config and system-library dependencies through the descriptor boundary.
- Switches both runtime Dockerfiles from hardcoded source lists to the manifest-driven builder.
- Validates the new binding in CI and documents the two-step export/build flow.

## Why

This is the approved C-packaging prerequisite for moving DB2 behind the module boundary before the Go and DB3 work. It keeps runtime activation unchanged while making future C-backed modules portable and independently buildable.

The architecture roundtable was consulted. Its only blocking feedback asked for the entire later Go/DB3 migration in this same diff; the project owner explicitly selected the separate prerequisite slice instead.

## Validation

- 57 Python descriptor, identity, DB2-boundary, exporter, and builder tests.
- CGO_ENABLED=0 go test ./... in server-go.
- Module inventory, source ownership, event-bus boundary, runtime-bundle, and supervisor checks.
- Python syntax and diff validation.