### PR TITLE
test(db2): ratchet outbound portability debt

### DIFF
--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -61,6 +61,16 @@ Measured on `origin/testing` at `0916c09472`:
 | — production directives | 532 |
 | Lines across the six SQL files | 16,349 |
 
+The physical move also exposed the other side of the source boundary. At the relocation merge,
+DB2's C and header files contain 187 project or vendored-header include directives that resolve
+outside `src/modules/db2/c`: 119 host APIs, 45 private APIs from other modules, 17 vendored cJSON
+includes, three KB-authority headers, two public module APIs, and the generated schema header. A
+directory boundary therefore exists, but the process build is not yet a standalone dependency
+closure. `tests/baselines/db2/source-boundary-v2.json` accounts for every one of these imports and
+the boundary gate rejects growth. Phase one must remove, invert, relocate, or explicitly replace
+them with portable core/system dependencies before the standalone C process can activate; linking
+the monolithic core into the DB2 executable does not satisfy the boundary.
+
 The inventory is reproducible from the cited revision with these bounded commands (the include
 pattern is intentionally the same for file and directive counts):
 

--- a/scripts/check_db2_source_boundary.py
+++ b/scripts/check_db2_source_boundary.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
-"""Freeze DB2's module-owned C boundary and classify every outside consumer.
+"""Freeze DB2's module-owned C boundary and classify both sides of it.
 
 The phase-one DB2 process migration needs two different kinds of evidence:
 
 * the implementation unit being moved (C, header, and SQL files); and
 * every direct include that must eventually become a generated client or remain
-  a private implementation test.
+  a private implementation test; and
+* every project header imported by the DB2 implementation that must be removed,
+  promoted to a portable core API, or declared as a module dependency.
 
-The checked-in manifest is exact for boundary files. Outside includes are
-shrink-only: removing an include is progress, while adding a consumer, header,
-or duplicate directive fails until the reviewed manifest is deliberately
-regenerated. This checker does not claim that an include is already a wire
-operation; the operation catalog and codecs are the next migration slice.
+The checked-in manifest is exact for boundary files. Both inbound and outbound
+project includes are shrink-only: removing one is progress, while adding a
+consumer, dependency, header, or duplicate directive fails until the reviewed
+manifest is deliberately regenerated. This checker does not claim that an
+include is already a wire operation. It makes the portability debt measurable
+before the C tree is packaged as an independent process.
 """
 
 from __future__ import annotations
@@ -28,14 +31,25 @@ from typing import NoReturn
 
 
 ROOT = Path(__file__).resolve().parent.parent
-BASELINE = Path("tests/baselines/db2/source-boundary-v1.json")
+BASELINE = Path("tests/baselines/db2/source-boundary-v2.json")
 BOUNDARY = PurePosixPath("src/modules/db2/c")
 CONTRACTS = Path("src/modules/process-contracts.json")
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 SOURCE_KINDS = {"c": ".c", "headers": ".h", "sql": ".sql"}
 INCLUDE = re.compile(r'^\s*#\s*include\s*[<"]([^">]+)[">]')
+INCLUDE_DETAIL = re.compile(r'^\s*#\s*include\s*([<"])([^">]+)[">]')
 DB2_BASENAME = re.compile(r"db2[^/]*\.h$")
 REVISION = re.compile(r"^[0-9a-f]{40}$")
+DEPENDENCY_CLASSES = {
+    "generated-schema-input",
+    "host-api",
+    "kb-authority-leak",
+    "module-private-api",
+    "module-public-api",
+    "portable-core-api",
+    "unresolved-project-include",
+    "vendored-system-api",
+}
 
 
 class BoundaryError(ValueError):
@@ -171,9 +185,139 @@ def _consumers(root: Path) -> list[dict[str, object]]:
     return rows
 
 
-def _payload_fingerprint(source_files: object, consumers: object) -> str:
+def _header_index(root: Path) -> dict[str, list[str]]:
+    """Index repository headers by the spellings accepted by project builds."""
+    source_root = _repo_path(root, Path("src"))
+    candidates: dict[str, set[str]] = {}
+    for path in sorted(source_root.rglob("*.h")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        relative = PurePosixPath(path.relative_to(root).as_posix())
+        source_relative = PurePosixPath(path.relative_to(source_root).as_posix())
+        spellings = {source_relative.as_posix(), relative.name}
+        if "include" in source_relative.parts:
+            index = source_relative.parts.index("include")
+            suffix = PurePosixPath(*source_relative.parts[index + 1:]).as_posix()
+            if suffix:
+                spellings.add(suffix)
+        for spelling in spellings:
+            candidates.setdefault(spelling, set()).add(relative.as_posix())
+    return {key: sorted(values) for key, values in sorted(candidates.items())}
+
+
+def _resolve_project_header(
+    root: Path,
+    source: Path,
+    target: str,
+    index: dict[str, list[str]],
+) -> str | None:
+    """Resolve an include to a repository header, or return None for system headers."""
+    direct = source.parent.joinpath(*PurePosixPath(target).parts)
+    try:
+        resolved = direct.resolve(strict=True)
+        resolved.relative_to(root.resolve())
+    except (OSError, ValueError):
+        pass
+    else:
+        if resolved.is_file() and resolved.suffix == ".h":
+            return resolved.relative_to(root).as_posix()
+
+    # Historical DB2 sources use ../headers and ../kb spellings. Project
+    # include roots made these resolve before the directory relocation, so
+    # normalize only leading parent components and then consult the exact
+    # repository index. Embedded '..' components remain unresolved/fail-safe.
+    parts = list(PurePosixPath(target).parts)
+    while parts and parts[0] == "..":
+        parts.pop(0)
+    # schema_data.h is a deterministic build output, not a tracked source
+    # header. Account for the dependency even in a clean checkout where the
+    # generator has not run yet.
+    if parts == ["schema_data.h"]:
+        return "src/schema_data.h"
+    spellings = [target]
+    if parts:
+        spellings.append(PurePosixPath(*parts).as_posix())
+    spellings.append(PurePosixPath(target).name)
+    for spelling in dict.fromkeys(spellings):
+        matches = index.get(spelling, [])
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _dependency_classification(resolved: PurePosixPath) -> str:
+    parts = resolved.parts
+    if parts[:2] == ("src", "core"):
+        return "portable-core-api"
+    if parts[:2] == ("src", "vendor"):
+        return "vendored-system-api"
+    if parts[:2] == ("src", "kb"):
+        return "kb-authority-leak"
+    if len(parts) >= 3 and parts[:2] == ("src", "modules"):
+        if "include" in parts[3:]:
+            return "module-public-api"
+        return "module-private-api"
+    if parts[:2] == ("src", "headers"):
+        return "host-api"
+    if resolved.as_posix() == "src/schema_data.h":
+        return "generated-schema-input"
+    return "host-api"
+
+
+def _outbound_dependencies(root: Path) -> list[dict[str, object]]:
+    boundary = _repo_path(root, BOUNDARY)
+    index = _header_index(root)
+    rows: list[dict[str, object]] = []
+    for path in sorted(boundary.iterdir()):
+        if not path.is_file() or path.is_symlink() or path.suffix not in {".c", ".h"}:
+            continue
+        counts: Counter[tuple[str, str, str]] = Counter()
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            fail("source-input", f"cannot read {path.relative_to(root)}: {exc}")
+        for line in lines:
+            match = INCLUDE_DETAIL.match(line)
+            if not match:
+                continue
+            delimiter, target = match.groups()
+            resolved = _resolve_project_header(root, path, target, index)
+            if resolved is None:
+                if delimiter == '"':
+                    counts[(
+                        target,
+                        f"unresolved:{target}",
+                        "unresolved-project-include",
+                    )] += 1
+                continue
+            resolved_path = PurePosixPath(resolved)
+            if resolved_path.is_relative_to(BOUNDARY):
+                continue
+            classification = _dependency_classification(resolved_path)
+            counts[(target, resolved, classification)] += 1
+        relative = path.relative_to(root).as_posix()
+        for (target, resolved, classification), count in sorted(counts.items()):
+            rows.append({
+                "source": relative,
+                "header": target,
+                "resolved": resolved,
+                "classification": classification,
+                "count": count,
+            })
+    return rows
+
+
+def _payload_fingerprint(
+    source_files: object,
+    consumers: object,
+    outbound_dependencies: object,
+) -> str:
     canonical = json.dumps(
-        {"source_files": source_files, "consumers": consumers},
+        {
+            "source_files": source_files,
+            "consumers": consumers,
+            "outbound_dependencies": outbound_dependencies,
+        },
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=True,
@@ -181,7 +325,11 @@ def _payload_fingerprint(source_files: object, consumers: object) -> str:
     return hashlib.sha256(canonical).hexdigest()
 
 
-def _summary(source_files: dict[str, list[str]], consumers: list[dict[str, object]]) -> dict[str, int]:
+def _summary(
+    source_files: dict[str, list[str]],
+    consumers: list[dict[str, object]],
+    outbound_dependencies: list[dict[str, object]],
+) -> dict[str, int]:
     include_count = sum(
         include["count"]
         for row in consumers
@@ -198,6 +346,10 @@ def _summary(source_files: dict[str, list[str]], consumers: list[dict[str, objec
         "production_consumers": len(consumers) - test_count,
         "test_consumers": test_count,
         "include_directives": include_count,
+        "outbound_dependency_rows": len(outbound_dependencies),
+        "outbound_include_directives": sum(
+            row["count"] for row in outbound_dependencies  # type: ignore[misc]
+        ),
     }
 
 
@@ -206,7 +358,8 @@ def build_inventory(root: Path, source_revision: str) -> dict[str, object]:
         fail("source-revision", "source revision must be a full lowercase SHA-1")
     source_files = _source_files(root)
     consumers = _consumers(root)
-    summary = _summary(source_files, consumers)
+    outbound_dependencies = _outbound_dependencies(root)
+    summary = _summary(source_files, consumers, outbound_dependencies)
     return {
         "schema_version": SCHEMA_VERSION,
         "source_revision": source_revision,
@@ -214,7 +367,10 @@ def build_inventory(root: Path, source_revision: str) -> dict[str, object]:
         "summary": summary,
         "source_files": source_files,
         "consumers": consumers,
-        "fingerprint": _payload_fingerprint(source_files, consumers),
+        "outbound_dependencies": outbound_dependencies,
+        "fingerprint": _payload_fingerprint(
+            source_files, consumers, outbound_dependencies
+        ),
     }
 
 
@@ -247,6 +403,58 @@ def _baseline_rows(value: object) -> dict[tuple[str, str], tuple[int, str]]:
     return result
 
 
+def _dependency_rows(value: object) -> dict[tuple[str, str, str], tuple[int, str]]:
+    if not isinstance(value, list):
+        fail("baseline-shape", "outbound_dependencies must be an array")
+    result: dict[tuple[str, str, str], tuple[int, str]] = {}
+    previous: tuple[str, str, str] | None = None
+    for index, row in enumerate(value):
+        if not isinstance(row, dict) or set(row) != {
+            "source", "header", "resolved", "classification", "count"
+        }:
+            fail("baseline-shape", f"outbound dependency {index} has invalid keys")
+        source = row["source"]
+        header = row["header"]
+        resolved = row["resolved"]
+        classification = row["classification"]
+        count = row["count"]
+        if not all(isinstance(item, str) for item in (
+            source, header, resolved, classification
+        )) or type(count) is not int or count < 1:
+            fail("baseline-order", f"outbound dependency {index} is invalid")
+        source_path = PurePosixPath(source)
+        if (source_path.is_absolute() or ".." in source_path.parts or
+                not source_path.is_relative_to(BOUNDARY) or
+                source_path.suffix not in {".c", ".h"}):
+            fail("baseline-path", f"outbound dependency {index} has unsafe source {source!r}")
+        header_path = PurePosixPath(header)
+        if (not header or "\\" in header or "\x00" in header or header_path.is_absolute()):
+            fail("baseline-path", f"outbound dependency {index} has unsafe header {header!r}")
+        if resolved.startswith("unresolved:"):
+            if resolved != f"unresolved:{header}":
+                fail("baseline-path", f"outbound dependency {index} has invalid unresolved path")
+        else:
+            resolved_path = PurePosixPath(resolved)
+            if (resolved_path.is_absolute() or ".." in resolved_path.parts or
+                    not resolved_path.parts or resolved_path.parts[0] != "src" or
+                    resolved_path.suffix != ".h"):
+                fail(
+                    "baseline-path",
+                    f"outbound dependency {index} has unsafe resolved path {resolved!r}",
+                )
+        if classification not in DEPENDENCY_CLASSES:
+            fail(
+                "baseline-classification",
+                f"outbound dependency {index} has unknown class {classification!r}",
+            )
+        key = (source, header, resolved)
+        if previous is not None and key <= previous:
+            fail("baseline-order", "outbound dependencies are not sorted and unique")
+        previous = key
+        result[key] = (count, classification)
+    return result
+
+
 def enforce_shrink_only(previous: object, current: object) -> None:
     """Reject compatibility-include allowlist growth across a reviewed PR."""
     if not isinstance(previous, dict) or not isinstance(current, dict):
@@ -268,6 +476,32 @@ def enforce_shrink_only(previous: object, current: object) -> None:
                 f"allowlist entry {key[1]!r} in {key[0]} changed from "
                 f"{prior[1]} to {classification}",
             )
+    # Schema v2 seeds outbound accounting. During that one upgrade, the v1
+    # base still constrains inbound consumers; only the new outbound half has
+    # no predecessor. Every subsequent comparison has both arrays.
+    if "outbound_dependencies" not in previous:
+        return
+    previous_dependencies = _dependency_rows(previous.get("outbound_dependencies"))
+    current_dependencies = _dependency_rows(current.get("outbound_dependencies"))
+    for key, (count, classification) in current_dependencies.items():
+        prior = previous_dependencies.get(key)
+        if prior is None:
+            fail(
+                "baseline-growth",
+                f"new outbound dependency {key[1]!r} in {key[0]} resolves to {key[2]}",
+            )
+        if count > prior[0]:
+            fail(
+                "baseline-growth",
+                f"outbound dependency {key[1]!r} in {key[0]} grew from "
+                f"{prior[0]} to {count}",
+            )
+        if classification != prior[1]:
+            fail(
+                "baseline-classification",
+                f"outbound dependency {key[1]!r} in {key[0]} changed from "
+                f"{prior[1]} to {classification}",
+            )
 
 
 def check_previous_ref(root: Path, baseline_path: Path, previous_ref: str) -> bool:
@@ -286,10 +520,17 @@ def check_previous_ref(root: Path, baseline_path: Path, previous_ref: str) -> bo
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
     )
     if prior.returncode != 0:
-        # The merge that introduces the v1 manifest has no previous payload.
-        # Every later base contains it, so this exception cannot be reused to
-        # expand an established allowlist.
-        return False
+        legacy = relative.as_posix().replace("source-boundary-v2.json", "source-boundary-v1.json")
+        if legacy != relative.as_posix():
+            prior = subprocess.run(
+                ["git", "show", f"{previous_ref}:{legacy}"], cwd=root,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+            )
+        if prior.returncode != 0:
+            # The merge that introduces the first manifest has no previous
+            # payload. Every later base contains v1 or v2, so this exception
+            # cannot be reused to expand an established allowlist.
+            return False
     previous = _loads(prior.stdout, f"{previous_ref}:{relative.as_posix()}")
     current = _load(_repo_path(root, baseline_path))
     enforce_shrink_only(previous, current)
@@ -300,17 +541,19 @@ def check(root: Path, baseline_path: Path = BASELINE) -> dict[str, int]:
     raw = _load(_repo_path(root, baseline_path))
     if not isinstance(raw, dict) or set(raw) != {
         "schema_version", "source_revision", "source_boundary", "summary",
-        "source_files", "consumers", "fingerprint",
+        "source_files", "consumers", "outbound_dependencies", "fingerprint",
     }:
-        fail("baseline-shape", "top-level keys differ from source-boundary v1")
+        fail("baseline-shape", "top-level keys differ from source-boundary v2")
     if raw["schema_version"] != SCHEMA_VERSION or raw["source_boundary"] != BOUNDARY.as_posix():
-        fail("baseline-version", "schema version or source boundary differs from v1")
+        fail("baseline-version", "schema version or source boundary differs from v2")
     if not isinstance(raw["source_revision"], str) or not REVISION.fullmatch(raw["source_revision"]):
         fail("source-revision", "baseline source revision is not a full lowercase SHA-1")
-    if raw["fingerprint"] != _payload_fingerprint(raw["source_files"], raw["consumers"]):
+    if raw["fingerprint"] != _payload_fingerprint(
+        raw["source_files"], raw["consumers"], raw["outbound_dependencies"]
+    ):
         fail("baseline-fingerprint", "baseline payload fingerprint does not match")
     if not isinstance(raw["source_files"], dict) or set(raw["source_files"]) != set(SOURCE_KINDS):
-        fail("baseline-shape", "source_files keys differ from v1")
+        fail("baseline-shape", "source_files keys differ from v2")
     baseline_source_files: dict[str, list[str]] = {}
     for kind in SOURCE_KINDS:
         values = raw["source_files"].get(kind)
@@ -320,7 +563,11 @@ def check(root: Path, baseline_path: Path = BASELINE) -> dict[str, int]:
         baseline_source_files[kind] = values
     baseline_consumers = raw["consumers"]
     _baseline_rows(baseline_consumers)
-    if raw["summary"] != _summary(baseline_source_files, baseline_consumers):
+    baseline_dependencies = raw["outbound_dependencies"]
+    baseline_dependency_rows = _dependency_rows(baseline_dependencies)
+    if raw["summary"] != _summary(
+        baseline_source_files, baseline_consumers, baseline_dependencies
+    ):
         fail("summary-drift", "baseline summary differs from its payload")
     actual_sources = _source_files(root)
     if raw["source_files"] != actual_sources:
@@ -343,10 +590,36 @@ def check(root: Path, baseline_path: Path = BASELINE) -> dict[str, int]:
                 "consumer-classification",
                 f"{key[0]} changed from {expected_classification} to {classification}",
             )
+    actual_dependencies = _outbound_dependencies(root)
+    actual_dependency_rows = _dependency_rows(actual_dependencies)
+    for key, (count, classification) in actual_dependency_rows.items():
+        expected = baseline_dependency_rows.get(key)
+        if expected is None:
+            fail(
+                "dependency-growth",
+                f"new outbound dependency {key[1]!r} in {key[0]} resolves to {key[2]}",
+            )
+        expected_count, expected_classification = expected
+        if count > expected_count:
+            fail(
+                "dependency-growth",
+                f"{key[0]} includes outbound {key[1]!r} {count} times; "
+                f"baseline permits {expected_count}",
+            )
+        if classification != expected_classification:
+            fail(
+                "dependency-classification",
+                f"{key[0]} dependency {key[1]!r} changed from "
+                f"{expected_classification} to {classification}",
+            )
     return {
         "source_files": sum(len(items) for items in actual_sources.values()),
         "consumer_files": len(actual_consumers),
         "include_directives": sum(count for count, _ in actual_rows.values()),
+        "outbound_dependencies": len(actual_dependencies),
+        "outbound_include_directives": sum(
+            count for count, _ in actual_dependency_rows.values()
+        ),
     }
 
 
@@ -387,7 +660,8 @@ def main() -> int:
                 "check_db2_source_boundary: ok "
                 f"({result['source_files']} boundary files, "
                 f"{result['consumer_files']} consumers, "
-                f"{result['include_directives']} includes remain; {suffix})"
+                f"{result['include_directives']} inbound includes, "
+                f"{result['outbound_include_directives']} outbound includes remain; {suffix})"
             )
     except (OSError, BoundaryError) as exc:
         print(f"check_db2_source_boundary: error: {exc}", file=sys.stderr)

--- a/scripts/tests/test_check_db2_source_boundary.py
+++ b/scripts/tests/test_check_db2_source_boundary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the DB2 source-boundary and shrink-only consumer manifest."""
+"""Tests for DB2's source boundary and shrink-only dependency manifest."""
 
 from __future__ import annotations
 
@@ -27,9 +27,10 @@ class BoundaryTests(unittest.TestCase):
         tmp = tempfile.TemporaryDirectory()
         root = Path(tmp.name)
         files = {
-            "src/modules/db2/c/store.c": '#include "store.h"\n',
+            "src/modules/db2/c/store.c": '#include "store.h"\n#include "aimee.h"\n',
             "src/modules/db2/c/store.h": "int db2_store(void);\n",
             "src/modules/db2/c/schema.sql": "CREATE TABLE sample(id integer);\n",
+            "src/headers/aimee.h": "int aimee_runtime(void);\n",
             "src/kb/consumer.c": '#include "modules/db2/c/store.h"\n',
             "src/server/consumer.c": '#include "../modules/db2/c/store.h"\n',
             "src/tests/test_store.c": '#include "modules/db2/c/store.h"\n',
@@ -78,6 +79,13 @@ class BoundaryTests(unittest.TestCase):
             self.assertEqual(classes["src/server/consumer.c"], "server-kb-contract")
             self.assertEqual(classes["src/tests/test_store.c"], "private-implementation-test")
             self.assertEqual(classes["src/modules/memory/consumer.c"], "module-kb-contract")
+            self.assertEqual(first["outbound_dependencies"], [{
+                "source": "src/modules/db2/c/store.c",
+                "header": "aimee.h",
+                "resolved": "src/headers/aimee.h",
+                "classification": "host-api",
+                "count": 1,
+            }])
         finally:
             tmp.cleanup()
 
@@ -114,6 +122,108 @@ class BoundaryTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(checker.BoundaryError, "baseline permits 1"):
                 checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_new_outbound_dependency_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / "src/headers/config.h").write_text(
+                "int config_value(void);\n", encoding="utf-8"
+            )
+            (root / "src/modules/db2/c/store.c").write_text(
+                '#include "store.h"\n#include "aimee.h"\n#include "config.h"\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=dependency-growth"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_duplicate_outbound_dependency_growth_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / "src/modules/db2/c/store.c").write_text(
+                '#include "store.h"\n#include "aimee.h"\n#include "aimee.h"\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.BoundaryError, "baseline permits 1"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_unresolved_quoted_include_is_rejected(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / "src/modules/db2/c/store.c").write_text(
+                '#include "store.h"\n#include "aimee.h"\n#include "missing_authority.h"\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                checker.BoundaryError, "unresolved:missing_authority.h"
+            ):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_outbound_dependency_classes_are_explicit(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            headers = {
+                "src/core/include/aimee/core/portable.h": "int core_api(void);\n",
+                "src/modules/audit/include/aimee/audit/public.h": "int audit_api(void);\n",
+                "src/modules/memory/private.h": "int memory_private(void);\n",
+                "src/vendor/headers/vendor_api.h": "int vendor_api(void);\n",
+                "src/kb/private.h": "int kb_private(void);\n",
+            }
+            for relative, content in headers.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            (root / "src/modules/db2/c/store.c").write_text(
+                '#include "store.h"\n'
+                '#include "aimee.h"\n'
+                '#include "aimee/core/portable.h"\n'
+                '#include "aimee/audit/public.h"\n'
+                '#include "modules/memory/private.h"\n'
+                '#include "vendor_api.h"\n'
+                '#include "kb/private.h"\n'
+                '#include "schema_data.h"\n',
+                encoding="utf-8",
+            )
+            rows = checker.build_inventory(root, self.revision)["outbound_dependencies"]
+            classes = {row["resolved"]: row["classification"] for row in rows}
+            self.assertEqual(classes["src/core/include/aimee/core/portable.h"],
+                             "portable-core-api")
+            self.assertEqual(classes["src/modules/audit/include/aimee/audit/public.h"],
+                             "module-public-api")
+            self.assertEqual(classes["src/modules/memory/private.h"], "module-private-api")
+            self.assertEqual(classes["src/vendor/headers/vendor_api.h"], "vendored-system-api")
+            self.assertEqual(classes["src/kb/private.h"], "kb-authority-leak")
+            self.assertEqual(classes["src/schema_data.h"], "generated-schema-input")
+        finally:
+            tmp.cleanup()
+
+    def test_outbound_baseline_paths_and_classes_fail_closed(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            value = json.loads((root / checker.BASELINE).read_text(encoding="utf-8"))
+            for field, replacement, rule in (
+                ("source", "../escape.c", "baseline-path"),
+                ("resolved", "../../escape.h", "baseline-path"),
+                ("classification", "trusted-by-assertion", "baseline-classification"),
+            ):
+                tampered = json.loads(json.dumps(value))
+                tampered["outbound_dependencies"][0][field] = replacement
+                with self.subTest(field=field), self.assertRaisesRegex(
+                    checker.BoundaryError, f"rule={rule}"
+                ):
+                    checker._dependency_rows(tampered["outbound_dependencies"])
         finally:
             tmp.cleanup()
 
@@ -203,6 +313,34 @@ class BoundaryTests(unittest.TestCase):
                 checker.BoundaryError, "rule=baseline-classification"
             ):
                 checker.enforce_shrink_only(previous, reclassified)
+
+            dependency_removed = json.loads(json.dumps(previous))
+            dependency_removed["outbound_dependencies"] = []
+            checker.enforce_shrink_only(previous, dependency_removed)
+
+            dependency_grown = json.loads(json.dumps(previous))
+            dependency_grown["outbound_dependencies"][0]["count"] += 1
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=baseline-growth"):
+                checker.enforce_shrink_only(previous, dependency_grown)
+
+            dependency_added = json.loads(json.dumps(previous))
+            dependency_added["outbound_dependencies"].append({
+                "source": "src/modules/db2/c/store.c",
+                "header": "config.h",
+                "resolved": "src/headers/config.h",
+                "classification": "host-api",
+                "count": 1,
+            })
+            with self.assertRaisesRegex(checker.BoundaryError, "new outbound dependency"):
+                checker.enforce_shrink_only(previous, dependency_added)
+
+            legacy_v1 = json.loads(json.dumps(previous))
+            legacy_v1.pop("outbound_dependencies")
+            checker.enforce_shrink_only(legacy_v1, previous)
+            legacy_growth = json.loads(json.dumps(previous))
+            legacy_growth["consumers"][0]["includes"][0]["count"] += 1
+            with self.assertRaisesRegex(checker.BoundaryError, "rule=baseline-growth"):
+                checker.enforce_shrink_only(legacy_v1, legacy_growth)
         finally:
             tmp.cleanup()
 

--- a/tests/baselines/db2/source-boundary-v2.json
+++ b/tests/baselines/db2/source-boundary-v2.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 1,
-  "source_revision": "9ba836017ed4299600d1cc3f76b2e252b20d7920",
+  "schema_version": 2,
+  "source_revision": "92d5e436a12079dfff94dba0febfce882d108f57",
   "source_boundary": "src/modules/db2/c",
   "summary": {
     "c_files": 141,
@@ -9,7 +9,9 @@
     "consumer_files": 297,
     "production_consumers": 147,
     "test_consumers": 150,
-    "include_directives": 967
+    "include_directives": 967,
+    "outbound_dependency_rows": 187,
+    "outbound_include_directives": 187
   },
   "source_files": {
     "c": [
@@ -5955,5 +5957,1316 @@
       ]
     }
   ],
-  "fingerprint": "7f81672282ee6929abb2dbe4a71f94ddded25d3b40f8e492d61faf94e9409677"
+  "outbound_dependencies": [
+    {
+      "source": "src/modules/db2/c/admin_grant.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/artifacts.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/artifacts.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/artifacts.c",
+      "header": "kb_mdl.h",
+      "resolved": "src/kb_mdl.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/artifacts.c",
+      "header": "platform_random.h",
+      "resolved": "src/headers/platform_random.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/bandit.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/calibration.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/calibration.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/canonical_index.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/canonical_index.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/canonical_index.c",
+      "header": "index.h",
+      "resolved": "src/headers/index.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/canonical_index.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/canonical_index.c",
+      "header": "modules/memory/memory_ontology.h",
+      "resolved": "src/modules/memory/memory_ontology.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/canonical_index.c",
+      "header": "util.h",
+      "resolved": "src/headers/util.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/canonical_index.h",
+      "header": "index.h",
+      "resolved": "src/headers/index.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_audit.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_audit.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_audit.c",
+      "header": "code_audit_graph.h",
+      "resolved": "src/headers/code_audit_graph.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_index.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_index.c",
+      "header": "../headers/code_match.h",
+      "resolved": "src/headers/code_match.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_index.c",
+      "header": "../headers/log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_index.c",
+      "header": "util.h",
+      "resolved": "src/headers/util.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_index.h",
+      "header": "../headers/index.h",
+      "resolved": "src/headers/index.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_index_ops.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_project_lifecycle.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/code_projection.c",
+      "header": "modules/memory/memory_ontology.h",
+      "resolved": "src/modules/memory/memory_ontology.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/collab_rules.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/collab_rules.c",
+      "header": "dstr.h",
+      "resolved": "src/headers/dstr.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/collab_rules.h",
+      "header": "../headers/collab_rules.h",
+      "resolved": "src/headers/collab_rules.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/corpus_structural.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/corpus_structural.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/corpus_structural.c",
+      "header": "util.h",
+      "resolved": "src/headers/util.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_build.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_build.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_deps.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_deps.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_deps.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_deps.h",
+      "header": "index.h",
+      "resolved": "src/headers/index.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_identity.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_identity.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_resolver.c",
+      "header": "c_system_headers.h",
+      "resolved": "src/headers/c_system_headers.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_review.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_review.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_route.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_route.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_stats.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/cross_repo_stats.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/css_graph.h",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/css_graph.h",
+      "header": "css_analyze.h",
+      "resolved": "src/modules/css/css_analyze.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/css_migration.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/css_migration.h",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/css_render.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/css_render.c",
+      "header": "css_render_oracle.h",
+      "resolved": "src/modules/css/css_render_oracle.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/curiosity.c",
+      "header": "util.h",
+      "resolved": "src/headers/util.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_hardening.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_init.c",
+      "header": "../headers/log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_internal.h",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_learning.h",
+      "header": "aimee/learning/learning.h",
+      "resolved": "src/modules/learning/include/aimee/learning/learning.h",
+      "classification": "module-public-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_reembed.c",
+      "header": "../headers/log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_tenant.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_tenant.h",
+      "header": "kb_identity.h",
+      "resolved": "src/headers/kb_identity.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_test_shim.c",
+      "header": "modules/config/config_embedder_dims.h",
+      "resolved": "src/modules/config/config_embedder_dims.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_checkpoint.c",
+      "header": "modules/vault/vault_witness_checkpoint.h",
+      "resolved": "src/modules/vault/vault_witness_checkpoint.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_checkpoint.c",
+      "header": "modules/vault/vault_witness_merkle.h",
+      "resolved": "src/modules/vault/vault_witness_merkle.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_checkpoint.c",
+      "header": "modules/vault/vault_witness_record.h",
+      "resolved": "src/modules/vault/vault_witness_record.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_checkpoint.c",
+      "header": "modules/vault/vault_witness_signer.h",
+      "resolved": "src/modules/vault/vault_witness_signer.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_checkpoint.c",
+      "header": "modules/vault/vault_witness_verify.h",
+      "resolved": "src/modules/vault/vault_witness_verify.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_emit.c",
+      "header": "modules/vault/vault_witness_checkpoint.h",
+      "resolved": "src/modules/vault/vault_witness_checkpoint.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_emit.c",
+      "header": "modules/vault/vault_witness_record.h",
+      "resolved": "src/modules/vault/vault_witness_record.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_emit.c",
+      "header": "modules/vault/vault_witness_signer.h",
+      "resolved": "src/modules/vault/vault_witness_signer.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db2_witness_emit.h",
+      "header": "modules/vault/vault_witness_export.h",
+      "resolved": "src/modules/vault/vault_witness_export.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db_schema.c",
+      "header": "../schema_data.h",
+      "resolved": "src/schema_data.h",
+      "classification": "generated-schema-input",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/db_schema.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/demotion.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/demotion.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/enrollments.c",
+      "header": "kb_identity.h",
+      "resolved": "src/headers/kb_identity.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/enrollments.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/entity_edges.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/entity_edges.c",
+      "header": "../headers/rel_types.h",
+      "resolved": "src/headers/rel_types.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/entity_registry.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/epistemic_directives.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_ingest.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_ingest.c",
+      "header": "../headers/log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_ingest.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_ingest.c",
+      "header": "modules/memory/memory_extract_patterns.h",
+      "resolved": "src/modules/memory/memory_extract_patterns.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_ingest.c",
+      "header": "modules/memory/memory_pii_gate.h",
+      "resolved": "src/modules/memory/memory_pii_gate.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_lifecycle.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_lifecycle.c",
+      "header": "../headers/rel_types.h",
+      "resolved": "src/headers/rel_types.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_lifecycle.h",
+      "header": "modules/memory/memory_fact_gate.h",
+      "resolved": "src/modules/memory/memory_fact_gate.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fact_recall.c",
+      "header": "modules/memory/memory_pii_gate.h",
+      "resolved": "src/modules/memory/memory_pii_gate.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/feature_rows.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/feedback.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fidelity.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/fidelity.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_audit_worm.c",
+      "header": "aimee/audit/audit_worm_chain.h",
+      "resolved": "src/modules/audit/include/aimee/audit/audit_worm_chain.h",
+      "classification": "module-public-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_audit_worm.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_maintenance.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_payload.c",
+      "header": "../headers/log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_payload.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_payload.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_payload.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_payload.c",
+      "header": "memory.h",
+      "resolved": "src/headers/memory.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_payload.h",
+      "header": "../headers/sketch.h",
+      "resolved": "src/headers/sketch.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_runtime_state.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend.c",
+      "header": "platform_process.h",
+      "resolved": "src/headers/platform_process.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend.h",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "agent_coord.h",
+      "resolved": "src/headers/agent_coord.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "agent_eval.h",
+      "resolved": "src/modules/benchmarks/agent_eval.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "dashboard.h",
+      "resolved": "src/headers/dashboard.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "memory.h",
+      "resolved": "src/headers/memory.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "modules/learning/learning_evidence.h",
+      "resolved": "src/modules/learning/learning_evidence.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "modules/learning/learning_implicit.h",
+      "resolved": "src/modules/learning/learning_implicit.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_agent.c",
+      "header": "trace_analysis.h",
+      "resolved": "src/headers/trace_analysis.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_export.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_export.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_export.h",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_ingest.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_memory.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_memory.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_memory.c",
+      "header": "memory.h",
+      "resolved": "src/headers/memory.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_memory.c",
+      "header": "modules/memory/memory_pii_gate.h",
+      "resolved": "src/modules/memory/memory_pii_gate.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kb_service_backend_memory.c",
+      "header": "session_briefing.h",
+      "resolved": "src/headers/session_briefing.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/kind_lifecycle.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/learning.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_action_journal.c",
+      "header": "platform_random.h",
+      "resolved": "src/headers/platform_random.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_action_journal.h",
+      "header": "kb_identity.h",
+      "resolved": "src/headers/kb_identity.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_identity_journal.h",
+      "header": "kb_identity.h",
+      "resolved": "src/headers/kb_identity.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_intent_fields.h",
+      "header": "platform_random.h",
+      "resolved": "src/headers/platform_random.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_jwks_publication.h",
+      "header": "../kb/kb_mgmt_jwks_publication.h",
+      "resolved": "src/kb/kb_mgmt_jwks_publication.h",
+      "classification": "kb-authority-leak",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_read_journal.c",
+      "header": "platform_random.h",
+      "resolved": "src/headers/platform_random.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_read_journal.h",
+      "header": "kb_identity.h",
+      "resolved": "src/headers/kb_identity.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_read_journal.h",
+      "header": "management_read.h",
+      "resolved": "src/headers/management_read.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_token_authority.h",
+      "header": "../kb/kb_mgmt_token_authority.h",
+      "resolved": "src/kb/kb_mgmt_token_authority.h",
+      "classification": "kb-authority-leak",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_token_authority.h",
+      "header": "kb_mgmt_token_authority_ipc.h",
+      "resolved": "src/headers/kb_mgmt_token_authority_ipc.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/management_token_roots.h",
+      "header": "../kb/kb_mgmt_token_roots_provision.h",
+      "resolved": "src/kb/kb_mgmt_token_roots_provision.h",
+      "classification": "kb-authority-leak",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/membership.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_conflicts.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_entity_graph.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_export.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_health.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_lint.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_payload.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_query.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_query_bookkeeping.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_relations.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_row_mapper_pg.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_scope_query.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/memory_score_fields.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/oidc_jwks.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/ontology_evolution.c",
+      "header": "../headers/rel_types.h",
+      "resolved": "src/headers/rel_types.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/ontology_evolution.h",
+      "header": "../headers/rel_types.h",
+      "resolved": "src/headers/rel_types.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/org_model_catalog.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/org_model_catalog.c",
+      "header": "kb_models_validate.h",
+      "resolved": "src/headers/kb_models_validate.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/org_vault_rewrap.h",
+      "header": "vault_crypto.h",
+      "resolved": "src/modules/vault/vault_crypto.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/org_vault_rewrap.h",
+      "header": "vault_reseal_receipt.h",
+      "resolved": "src/modules/vault/vault_reseal_receipt.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/pgvec_transport.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/pgvec_transport.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/project.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/prospective_memories.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rel_types_store.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rel_types_store.c",
+      "header": "../headers/rel_types.h",
+      "resolved": "src/headers/rel_types.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rel_types_store.c",
+      "header": "modules/memory/memory_pii_gate.h",
+      "resolved": "src/modules/memory/memory_pii_gate.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rel_types_store.h",
+      "header": "modules/memory/memory_fact_gate.h",
+      "resolved": "src/modules/memory/memory_fact_gate.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rel_types_store.h",
+      "header": "modules/memory/memory_ontology.h",
+      "resolved": "src/modules/memory/memory_ontology.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/report_enrichments.c",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/report_enrichments.h",
+      "header": "../headers/report_enrichment.h",
+      "resolved": "src/headers/report_enrichment.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rules.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rules.c",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/rules.c",
+      "header": "config.h",
+      "resolved": "src/modules/config/config.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/sketch.h",
+      "header": "../headers/sketch.h",
+      "resolved": "src/headers/sketch.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/tasks.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/team.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/typed_facts.h",
+      "header": "../headers/aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+      "header": "vault_mutation_budget.h",
+      "resolved": "src/modules/vault/vault_mutation_budget.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+      "header": "vault_reseal_receipt.h",
+      "resolved": "src/modules/vault/vault_reseal_receipt.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_pg.c",
+      "header": "log.h",
+      "resolved": "src/headers/log.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_pg.c",
+      "header": "vault_crypto.h",
+      "resolved": "src/modules/vault/vault_crypto.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_pg.c",
+      "header": "vault_kek_check.h",
+      "resolved": "src/modules/vault/vault_kek_check.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_pg.c",
+      "header": "vault_principal.h",
+      "resolved": "src/modules/vault/vault_principal.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_pg.c",
+      "header": "vault_store.h",
+      "resolved": "src/modules/vault/vault_store.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vault_pg.h",
+      "header": "vault_internal.h",
+      "resolved": "src/modules/vault/vault_internal.h",
+      "classification": "module-private-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vector_index_ops.c",
+      "header": "aimee.h",
+      "resolved": "src/headers/aimee.h",
+      "classification": "host-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/vector_status.h",
+      "header": "cJSON.h",
+      "resolved": "src/vendor/headers/cJSON.h",
+      "classification": "vendored-system-api",
+      "count": 1
+    },
+    {
+      "source": "src/modules/db2/c/write_tier_grant.h",
+      "header": "kb_identity_token.h",
+      "resolved": "src/headers/kb_identity_token.h",
+      "classification": "host-api",
+      "count": 1
+    }
+  ],
+  "fingerprint": "35b4469ef5de6da05f6c6cbc1a9c46a2d28aeb74a5a2aed1adbad0c97ff17317"
 }


### PR DESCRIPTION
## Summary

- extend the DB2 source-boundary inventory to account for project headers imported by the module-owned C tree
- classify and freeze 187 outbound dependencies with a shrink-only v2 baseline
- reject new, growing, unresolved, path-escaping, or unclassified outbound dependencies
- preserve the v1 inbound-consumer ratchet during the v2 baseline transition
- document the measured standalone-build closure that must be burned down before the C process activates

This is an incremental C-boundary prerequisite. It does not change production DB2, pgvector, DSN ownership, process registration, or runtime behavior.

## Measured closure

- 119 host API imports
- 45 private cross-module imports
- 17 vendored cJSON imports
- 3 KB-authority leaks
- 2 public module API imports
- 1 generated schema input

## Validation

- `python3 -m unittest scripts.tests.test_check_db2_source_boundary` (17 tests)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (433 tests)
- `make -s -j2 all server`
- `make -s -j2 unit-tests` (691 native binaries)
- `CGO_ENABLED=0 go test ./...`
- `make -s lint` (55 checks)
- `python3 -I -S scripts/check_db2_source_boundary.py --previous-ref origin/testing`
