### PR TITLE
feat(db2): add DB3 reference routing

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -93,6 +93,10 @@ jobs:
         run: python3 -I -S scripts/gen_db2_declaration_ledger.py
       - name: Test DB2 declaration-ledger failure modes
         run: python3 -I scripts/tests/test_gen_db2_declaration_ledger.py -v
+      - name: Enforce exhaustive DB3 portability decisions
+        run: python3 -I -S scripts/check_db3_portability.py
+      - name: Test DB3 portability-audit failure modes
+        run: python3 -I scripts/tests/test_check_db3_portability.py -v
       - name: Refuse premature DB2 process activation
         run: python3 -I -S scripts/check_db2_activation.py
       - name: Test DB2 activation-gate failure modes

--- a/docs/db3.md
+++ b/docs/db3.md
@@ -1,0 +1,98 @@
+# db3 module contract
+
+## Purpose and ownership
+
+`db3` is the provider-neutral vector serving contract owned by DB2. Pgvector remains physically
+inside DB2, shares DB2's PostgreSQL transactions and schema, and is the default DB3 behavior. An
+external provider such as Qdrant can replace only portable serving operations after it is admitted,
+ready, and explicitly selected. DB2 and its pgvector copy remain the canonical integrity and
+recovery authority.
+
+The logical contract owner will receive the next canonical principal when its executable router and
+first served stage land. The current process-contract schema deliberately forbids reserving a
+principal without a real process and stage, so this design audit does not create a fake deployment.
+Each deployed provider has a distinct strict principal, executable identity, and runtime grant. No
+provider descriptor or production grant exists until that provider ships.
+
+## Routing contract
+
+Committed vector mutations are idempotent notifications from the DB2 outbox. Every admitted
+write observer receives the same operation and reports its own watermark. A duplicate operation or
+generation must be recognized without duplicating an effect. One failed or lagging observer never
+changes which provider serves reads.
+
+Portable reads are request/reply, never observer fanout. Exactly one admitted and ready external
+principal may hold the selected search route. Installing several providers does not imply score
+comparison, fusion, federation, or multiple reads. With no selected external provider, DB2 uses its
+internal pgvector implementation. If a selected provider is unavailable, DB2 fails closed unless
+the route explicitly enables fallback; fallback records the selected principal, failure, and
+`explicit_fallback` provenance.
+
+DB3 returns bounded opaque point IDs and finite scores. DB2 rehydrates every candidate and repeats
+tenant, project, lifecycle, quarantine, and classification checks. Provider responses never confer
+authority and never contain SQL, table names, connection data, provider query JSON, or source rows.
+
+## Current executable slice
+
+`src/modules/db2/db3_route.c` is the descriptor-owned C reference router for the first portable
+operation, memory candidate search. It accepts explicit workspace, project, record type, generation,
+bounded vector, and top-K fields; TLS scope hints do not cross the boundary. Injected callbacks bind
+the internal pgvector implementation, the authenticated selected provider, and DB2's authoritative
+candidate check without importing a provider or private KB header.
+
+The route has four tested outcomes: default pgvector when no external principal is selected,
+external-only serving when the selected principal is ready, typed failure when it is unavailable or
+malformed and fallback is disabled, and `explicit_fallback` with the original external error retained
+when fallback is enabled. Candidate IDs must be positive and unique, generations and request IDs must
+match, vectors and scores must be finite, and every result passes the injected DB2 authorization check.
+
+The same source owns bounded version-one codecs for `db3.apply` and `db3.search`. A real authenticated
+event-bus test admits DB2 plus two distinct provider observers, delivers one committed operation and
+its duplicate to both, proves each provider records only one effect, routes a search only to the
+selected server, and rejects a second serving principal. These are executable pre-activation
+conformance seams; production outbox and pgvector callbacks connect only after the C DB2 closure is
+standalone, so no second database owner or partial runtime grant is introduced here.
+
+## Exhaustive portability audit
+
+`src/modules/db2/eventcontract/vector-portability.json` classifies all 76 current `pgvec_*`
+declarations from the generated DB2 ledger. The five closed outcomes are:
+
+- `portable-search`: 14 bounded candidate searches that can move behind DB3 once DB2 revalidation is
+  wired; memory candidate search is the first vertical slice.
+- `committed-mutation`: 32 upsert/delete surfaces whose logical effects can fan out only after the
+  canonical DB2 transaction commits.
+- `provider-control`: 15 collection, index, health, tuning, and telemetry operations that each
+  provider implements locally and exposes only as bounded readiness/capability evidence.
+- `db2-authority`: 12 schema, recovery, canonical lookup, verification, or process-local operations
+  that remain inside DB2 even when an external provider is selected.
+- `portable-analytics`: 3 path-returning or pair-analysis APIs deferred until a bounded opaque-ID
+  contract lets DB2 revalidate their candidates.
+
+The audit names the provider-specific C declarations for traceability, but those names never become
+wire operations. CI compares the audit with the generated declaration ledger, rejects missing,
+extra, duplicated, or reordered symbols, and pins the exact source-symbol fingerprint. Any new
+pgvector declaration therefore requires an explicit reviewed disposition.
+
+The update workflow is intentionally reviewed rather than automatic: regenerate
+`declarations-v1.json`, run `python3 -I -S scripts/check_db3_portability.py
+--print-source-fingerprint`, classify every added or renamed symbol in exactly one sorted group,
+replace `source_symbols_sha256` with the printed digest, then run the checker and its mutation suite.
+The checker continues to fail until both the classification and fingerprint agree with the ledger.
+
+## Activation sequence and tests
+
+The DB3 contract does not activate ahead of DB2. The existing C DB2 implementation first moves
+behind its module boundary and passes build/link, caller, replay, tenant, schema, concurrency,
+cancellation, durability, and pgvector parity gates. The tested DB3 C routing seam then connects to
+the committed outbox, the selected search grant, internal pgvector, and authoritative DB2 hydration.
+Only after the C process is the sole DB2 owner does the pure-Go DB2 provider reproduce the same
+wire and database-effect fixtures. The final provider switch changes runtime selection, not callers
+or contracts.
+
+The current C conformance tests use two authenticated provider principals and prove that writes reach
+both observers, duplicate operations are idempotent, one search reaches only the selected server, a
+second server cannot own the route, malformed vectors and scores fail closed, unauthorized candidates
+are removed, and explicit fallback is observable. Activation additionally requires the same fixtures
+against real DB2 rows and the committed outbox. C-versus-Go replay runs the no-provider,
+selected-provider, unavailable, and fallback cases before the C implementation can retire.

--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -69,6 +69,18 @@ explicitly private and retained in DB2, lifecycle health is a reviewed retained-
 and 850 production-consumed declarations remain
 without a reviewed disposition.
 
+The separate `vector-portability.json` audit covers all 76 declared `pgvec_*` symbols, including
+internal and currently unconsumed surfaces. It distinguishes provider-neutral candidate searches,
+post-commit mutation fanout, provider-local control, necessarily retained DB2 authority, and deferred
+analytics. The provider-specific C names remain private DB2 implementation details; the audit records
+which logical effects may later receive DB3 operations without leaking those names onto the wire.
+See `docs/db3.md` for routing, admission, fallback, and revalidation invariants.
+
+The descriptor also owns the database-free C reference route and wire codecs for the first portable
+memory-candidate operation. Its internal pgvector, external provider, and authoritative candidate
+checks are injected, so the route can be exhaustively tested before the private DB2 source closure is
+linked. This is not a production cutover: the module remains disabled and no provider grant ships.
+
 A review transition binds the symbol and normalized-signature hash to one closed disposition,
 family, DB3 placement, and nonempty reason. Signature drift invalidates the review. Unsupported or
 ambiguous C declarations, malformed lexical input, stale review rows, premature completeness, and
@@ -109,6 +121,12 @@ comments/literals/directives, identical and conflicting duplicates, malformed ne
 limits, signature-bound review transitions, pgvector retention, output symlinks, reproducibility,
 and unchanged-output failure. Activation-gate mutation tests prove that an incomplete source list,
 weak backend, or remaining direct production caller prevents enablement.
+DB3-portability tests additionally prove exhaustive 76-symbol coverage, closed classification
+identities, fingerprint drift, duplicate/missing/extra detection, ordering, malformed JSON, resource
+limits, and copied-repository CLI behavior.
+Route and authenticated-bus tests cover default pgvector, selected external serving, unavailable and
+malformed providers, explicit fallback provenance, candidate revalidation, finite/bounded codecs,
+two-observer idempotent apply fanout, and one-server-only search.
 
 ## Operational diagnostics
 

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -216,45 +216,48 @@ the authoritative scope, lifecycle, quarantine, and classification checks before
 
 ### 3.3 DB3 observer contract and routing
 
-DB2 is the sole publisher of DB3 mutation and search events. DB3 implementations are multiple
-authorized observers of the same logical module contract:
+DB2 and admitted providers use a single logical DB3 contract. DB2 publishes committed mutations and
+requests portable reads; providers publish readiness and acknowledgements. DB3 implementations may
+be multiple authorized observers of the write side of that contract:
 
 - `db3.capabilities`: metric, maximum dimension/batch/top-K, supported filter nodes, and provider
   generation;
 - `db3.apply`: idempotent committed upsert/delete/tombstone batches with operation and generation IDs;
 - `db3.applied`: per-observer acknowledgement, durable watermark, lag, and typed failure;
-- `db3.search`: query ID, collection, vector, metric, typed filter, top-K, bounded relative timeout,
-  and required provider generation; and
-- `db3.results`: query ID, generation, status, and bounded point IDs, distances, and ranks, with
-  provider identity bound from bus admission rather than trusted from the body.
+- `db3.search`: request/reply carrying query ID, collection, vector, metric, typed filter, top-K,
+  bounded relative timeout, required provider generation, then bounded point IDs, distances, and
+  ranks; and
+- `db3.route`: observable selected-provider, default-pgvector, or explicit-fallback decisions.
 
-The proposed version 1 assigns notification kinds `11777` through `11781` in that order. Each DB3
-notification uses a 40-byte bounded chunk envelope above the event body because valid vectors and
-result batches can exceed one negotiated inline bus slot, while the core bus fragments only correlated
-request/reply streams. The envelope binds wire kind, stream ID, total length, chunk count/index, and
-offset. Reassembly is keyed by the host-stamped provider principal, kind, and stream ID; it rejects
-out-of-order, duplicate, cross-provider, oversized, and noncanonical chunks. DB3 kinds retain the
-bus's default blocking overflow policy so a fan-out never produces a silently partial message.
+The proposed version 1 assigns kinds `11777` through `11781` in that order. Notifications use a
+bounded chunk envelope when a valid apply batch exceeds one negotiated inline bus slot. Correlated
+search uses the bus request/reply stream directly and therefore inherits its fragmentation,
+cancellation, and deadline semantics. Notification reassembly is keyed by the host-stamped provider
+principal, kind, and stream ID; it rejects out-of-order, duplicate, cross-provider, oversized, and
+noncanonical chunks. DB3 kinds retain the bus's default blocking overflow policy so a fan-out never
+produces a silently partial message.
 
 Mutation events use the bus's observer fan-out directly. Each admitted DB3 instance applies the same
-committed outbox operation and publishes its own acknowledgement. Search is correlated scatter/gather:
-DB2 snapshots the configured ready observers, publishes one query, accepts at most one result per
-admission-bound provider identity until the deadline, and records missing/late observers explicitly.
-The provider identity comes from module admission, not a self-asserted payload string.
-The route snapshot, expected-observer set, and overall deadline remain DB2 correlation state. A
-bounded relative timeout in each search body limits provider work because notification fan-out has
-no request/reply cancellation stream; providers cannot rewrite that budget in a result body.
+committed outbox operation and publishes its own acknowledgement. Search is never notification
+fan-out: DB2 sends one correlated request to the exactly one admitted, ready, explicitly selected
+server for the search kind. A second process cannot serve that kind under the same route. The
+provider identity comes from the authenticated serving grant and DB2 route snapshot, not a
+self-asserted payload string. The selected server inherits the overall bus deadline and cancellation;
+it cannot rewrite either in its reply.
 
-The logical `db3` module owns the result event kinds even when several admitted implementations
-publish them; instances have distinct provider identities and executable attestations under that
-module contract. A provider cannot observe a tenant or collection unless its grant and DB2 route both
-allow it. All observers of a routed event are therefore authorized to see its vector and bounded
-filter metadata.
+The logical `db3` module owns the protocol. Its canonical contract-owner principal is allocated only
+when the executable router and first served stage land: the current process-contract schema correctly
+forbids principal reservations without a real process. Provider instances have distinct strict
+principals and executable attestations; only the selected instance receives the search-serve grant,
+while every routed instance may receive the apply-subscribe grant. No provider process or production
+grant activates until a concrete provider ships. A provider cannot observe a tenant or collection
+unless its grant and DB2 route both allow it.
 
 Default routing is deterministic:
 
 1. with no selected ready DB3 observer, portable operations use DB2 pgvector;
-2. with exactly one selected observer, portable writes fan out to it and portable searches use it;
+2. with exactly one selected observer, portable searches use it while committed writes still fan out
+   to every admitted write observer;
 3. with several observers, committed writes may fan out to every routed observer, while search uses
    exactly one explicitly selected primary; and
 4. an unavailable selected DB3 uses pgvector only when the declared route permits fallback. Fallback
@@ -284,19 +287,21 @@ The migration lands in independently testable slices, but activation remains ato
    lifecycle-health codec, and return `capability_absent` until the real backend closure is linked.
    Exit: the bundle builds, malformed wire vectors fail closed, and DB2 imports no private KB header.
 2. **S2 — catalog and C closure.** Classify every external C declaration and consumer, generate the
-   eight family dispatch surfaces, and remove or promote every dependency that prevents the complete
-   descriptor-owned C source set from linking standalone. Exit: exhaustive catalog and no monolithic
-   core link.
+   eight family dispatch surfaces, freeze an exhaustive disposition for every vector declaration,
+   add database-free reference routing/codecs for the first portable candidate operation, and remove
+   or promote every dependency that prevents the complete descriptor-owned C source set from linking
+   standalone. Exit: exhaustive catalogs and no monolithic core link.
 3. **S3 — replayable C process.** Package schema, DSN, pool, tenancy, and every catalog handler in the
    disabled C process; add reference-vs-process replay, schema, concurrency, cancellation, and fault
    fixtures. Exit: byte and database-effect parity while the KB still serves local calls.
 4. **S4 — atomic C activation.** Start DB2 before consumers, move the DSN and every caller to generated
    bus clients, remove DB2/libpq from the KB link, and make failed DB2 readiness fail closed. Exit:
    only `aimee-module-db2` owns DB2 in the image.
-5. **S5 — DB3 contract and providers.** Land the provider-neutral observer contract, pgvector default
-   adapter, deterministic selection/fallback, committed outbox fan-out, candidate revalidation, and
-   conformance tests for a fake and optional external providers. Exit: one selected external provider
-   can replace every eligible operation without moving retained PostgreSQL-coupled work.
+5. **S5 — DB3 contract and providers.** Connect the provider-neutral reference contract to the
+   pgvector default adapter, deterministic selection/fallback, committed outbox fan-out, and real DB2
+   candidate revalidation; run conformance tests for fake and optional external providers. Exit: one
+   selected external provider can replace every eligible operation without moving retained
+   PostgreSQL-coupled work.
 6. **S6 — pure-Go parity.** Implement the frozen DB2 catalog in `server-go/modules/db2`, embed the same
    SQL, and pass C-vs-Go replay, schema, tenant, concurrency, vector, DB3, durability, and performance
    gates. Exit: a descriptor/runtime switch selects Go without caller or wire changes.
@@ -458,7 +463,7 @@ against both module implementations:
 - **Vector compatibility:** preserve halfvec dimensions, distance operators, index choices, model
   identity, re-embedding locks, and source/vector version coherence. Run the provider-neutral
   conformance corpus against pgvector, a deterministic fake, and every optional provider; verify
-  external-provider outbox lag, tombstones, backfill, comparison, and cutover behavior.
+  external-provider outbox lag, tombstones, backfill, behavioral parity, and cutover behavior.
 - **Concurrency:** run multi-replica startup, schema locking, pool saturation, retry, shutdown, and
   cancellation tests against the supported PostgreSQL versions.
 - **Durability:** inject failures before statement execution, before commit, after ambiguous commit,
@@ -482,8 +487,8 @@ The concrete CI surface is `db2-contract` (catalog/codegen/fingerprint and negat
 `db2-boundary` (include, DSN-reader allowlist, ELF/import, SQL-location, and runtime-bundle scans), `db2-schema`
 (clean apply plus catalog comparison), `db2-replay` (behavior/tenant/durability vectors),
 `db2-concurrency` (multi-replica and pool reuse), `db2-vector` (dimension/operator/plan fixtures),
-`db3-conformance` (provider contract, multiple-observer fan-out, scope recheck, outbox, generation,
-scatter/gather, routing, and fallback fixtures), and
+`db3-conformance` (provider contract, multiple-observer write fan-out, single-primary reads, scope
+recheck, outbox, generation, routing, and fallback fixtures), and
 `db2-performance` (recorded in-process, C-process, and Go-process budgets). These are new deliverables
 of this proposal and become named Make targets before activation; CI invokes the same targets.
 

--- a/scripts/check_db3_portability.py
+++ b/scripts/check_db3_portability.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Fail closed unless every pgvector declaration has a reviewed DB3 disposition.
+
+The audit is metadata, not a numeric data format: JSON integers are allowed but
+floating-point tokens are deliberately rejected along with NaN and Infinity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import NoReturn
+
+
+ROOT = Path(__file__).resolve().parent.parent
+AUDIT = Path("src/modules/db2/eventcontract/vector-portability.json")
+LEDGER = Path("tests/baselines/db2/declarations-v1.json")
+ROUTE_SOURCE = Path("src/modules/db2/db3_route.c")
+MAX_BYTES = 2_097_152
+MAX_DEPTH = 32
+MAX_ARRAY = 4096
+SYMBOL = re.compile(r"^pgvec_[a-z0-9_]+$")
+INCLUDE = re.compile(r'^\s*#\s*include\s*([<"])([^>"]+)[>"]\s*$')
+INCLUDE_PREFIX = re.compile(r"^\s*#\s*include\b")
+STANDARD_HEADERS = {
+    "assert.h", "errno.h", "float.h", "inttypes.h", "limits.h", "math.h", "stdalign.h",
+    "stdbool.h", "stddef.h", "stdint.h", "stdio.h", "stdlib.h", "string.h", "time.h",
+}
+CLASSIFICATIONS = (
+    ("portable-search", "portable-now", "candidate-search"),
+    ("committed-mutation", "portable-after-commit", "apply"),
+    ("provider-control", "provider-local", "provider-control"),
+    ("db2-authority", "retained-db2", "none"),
+    ("portable-analytics", "deferred", "candidate-analytics"),
+)
+
+
+class PortabilityError(ValueError):
+    """A typed portability-audit failure."""
+
+
+def fail(rule: str, message: str) -> NoReturn:
+    raise PortabilityError(f"rule={rule}: {message}")
+
+
+def _duplicates(label: str):
+    def reject(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        value: dict[str, object] = {}
+        for key, item in pairs:
+            if key in value:
+                fail("json-duplicate-key", f"{label}: duplicate key {key!r}")
+            value[key] = item
+        return value
+    return reject
+
+
+def _reject_number(value: str) -> NoReturn:
+    fail("json-number-domain", f"forbidden number {value!r}")
+
+
+def _domain(value: object, label: str, depth: int = 0) -> None:
+    if depth > MAX_DEPTH:
+        fail("json-depth", f"{label}: nesting exceeds {MAX_DEPTH}")
+    if isinstance(value, str):
+        if any(0xD800 <= ord(char) <= 0xDFFF for char in value):
+            fail("json-surrogate", f"{label}: surrogate code point is forbidden")
+    elif isinstance(value, list):
+        if len(value) > MAX_ARRAY:
+            fail("json-array-size", f"{label}: array exceeds {MAX_ARRAY} items")
+        for item in value:
+            _domain(item, label, depth + 1)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            _domain(key, label, depth + 1)
+            _domain(item, label, depth + 1)
+
+
+def load_json(path: Path) -> object:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        fail("input", f"cannot read {path}: {exc}")
+    if len(raw) > MAX_BYTES:
+        fail("input-size", f"{path} exceeds {MAX_BYTES} bytes")
+    if raw.startswith(b"\xef\xbb\xbf"):
+        fail("json-bom", f"{path} begins with a UTF-8 BOM")
+    try:
+        value = json.loads(
+            raw.decode("utf-8", "strict"),
+            object_pairs_hook=_duplicates(str(path)),
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except UnicodeDecodeError as exc:
+        fail("json-encoding", f"{path}: {exc}")
+    except json.JSONDecodeError as exc:
+        fail("json-parse", f"{path}: {exc.msg} at {exc.lineno}:{exc.colno}")
+    _domain(value, str(path))
+    return value
+
+
+def _object(value: object, keys: set[str], label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        fail("shape", f"{label} must be an object")
+    if set(value) != keys:
+        fail("keys", f"{label} keys differ; expected={sorted(keys)}, actual={sorted(value)}")
+    return value
+
+
+def _text(value: object, label: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > maximum:
+        fail("string", f"{label} must be nonempty and at most {maximum} UTF-8 bytes")
+    return value
+
+
+def source_symbols(ledger: object) -> list[str]:
+    if not isinstance(ledger, dict) or not isinstance(ledger.get("declarations"), list):
+        fail("ledger-shape", "declaration ledger must contain a declarations array")
+    symbols: list[str] = []
+    for index, declaration in enumerate(ledger["declarations"]):
+        if not isinstance(declaration, dict) or not isinstance(declaration.get("symbol"), str):
+            fail("ledger-declaration", f"declarations[{index}] has no string symbol")
+        symbol = declaration["symbol"]
+        if symbol.startswith("pgvec_"):
+            if not SYMBOL.fullmatch(symbol):
+                fail("ledger-symbol", f"invalid pgvector symbol {symbol!r}")
+            symbols.append(symbol)
+    if len(symbols) != len(set(symbols)):
+        fail("ledger-duplicate", "pgvector declaration symbols are not unique")
+    return sorted(symbols)
+
+
+def symbols_sha256(symbols: list[str]) -> str:
+    return hashlib.sha256("".join(f"{symbol}\n" for symbol in symbols).encode()).hexdigest()
+
+
+def validate_route_boundary(root: Path) -> None:
+    path = root / ROUTE_SOURCE
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        fail("route-boundary", f"cannot read {path}: {exc}")
+    if len(raw) > MAX_BYTES:
+        fail("route-boundary", f"{path} exceeds {MAX_BYTES} bytes")
+    try:
+        text = raw.decode("utf-8", "strict")
+    except UnicodeDecodeError as exc:
+        fail("route-boundary", f"{path}: {exc}")
+    imports: list[str] = []
+    for line in text.splitlines():
+        normalized = re.sub(r"/\*.*?\*/", " ", line)
+        if not INCLUDE_PREFIX.match(normalized):
+            if line.lstrip().startswith("#") and re.search(r"\binclude\b", line):
+                fail("route-boundary", f"cannot classify include directive {line!r}")
+            continue
+        match = INCLUDE.fullmatch(normalized)
+        if not match:
+            fail("route-boundary", f"cannot classify include directive {line!r}")
+        delimiter, header = match.groups()
+        if header == "aimee/db2/db3_route.h" and delimiter == "<":
+            imports.append(header)
+        elif delimiter == "<" and header in STANDARD_HEADERS:
+            continue
+        else:
+            fail("route-boundary", f"forbidden non-standard or private include {header!r}")
+    if imports != ["aimee/db2/db3_route.h"]:
+        fail("route-boundary", "the public DB3 route header must be included exactly once")
+
+
+def validate(audit_value: object, ledger_value: object) -> dict[str, int]:
+    audit = _object(audit_value, {
+        "schema_version", "module", "source", "source_symbols_sha256", "classifications",
+    }, "audit")
+    if type(audit["schema_version"]) is not int or audit["schema_version"] != 1:
+        fail("schema-version", "schema_version must equal 1")
+    if audit["module"] != "db3":
+        fail("module", "module must equal 'db3'")
+    if audit["source"] != LEDGER.as_posix():
+        fail("source", f"source must equal {LEDGER.as_posix()!r}")
+    source = source_symbols(ledger_value)
+    expected_hash = symbols_sha256(source)
+    if audit["source_symbols_sha256"] != expected_hash:
+        fail("source-fingerprint", "source_symbols_sha256 does not match the pgvector declarations")
+
+    groups = audit["classifications"]
+    if not isinstance(groups, list) or len(groups) != len(CLASSIFICATIONS):
+        fail("classifications", f"classifications must contain {len(CLASSIFICATIONS)} entries")
+    seen: set[str] = set()
+    summary: dict[str, int] = {}
+    for index, (raw, expected) in enumerate(zip(groups, CLASSIFICATIONS, strict=True)):
+        group = _object(raw, {
+            "id", "disposition", "db3_operation_family", "rationale", "symbols",
+        }, f"classifications[{index}]")
+        identifier, disposition, family = expected
+        if (group["id"], group["disposition"], group["db3_operation_family"]) != expected:
+            fail("classification-identity", f"classification {index} must equal {expected!r}")
+        _text(group["rationale"], f"{identifier}.rationale", 512)
+        symbols = group["symbols"]
+        if not isinstance(symbols, list) or not symbols:
+            fail("classification-symbols", f"{identifier}.symbols must be a nonempty array")
+        if symbols != sorted(symbols):
+            fail("symbol-order", f"{identifier}.symbols must be sorted")
+        for symbol in symbols:
+            if not isinstance(symbol, str) or not SYMBOL.fullmatch(symbol):
+                fail("symbol", f"{identifier} contains invalid symbol {symbol!r}")
+            if symbol in seen:
+                fail("symbol-duplicate", f"{symbol} is classified more than once")
+            seen.add(symbol)
+        summary[identifier] = len(symbols)
+
+    missing = sorted(set(source) - seen)
+    extra = sorted(seen - set(source))
+    if missing or extra:
+        fail("coverage", f"missing={missing}, extra={extra}")
+    return summary
+
+
+def run(root: Path) -> dict[str, int]:
+    summary = validate(load_json(root / AUDIT), load_json(root / LEDGER))
+    validate_route_boundary(root)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--print-source-fingerprint", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.print_source_fingerprint:
+            symbols = source_symbols(load_json(args.root.resolve() / LEDGER))
+            print(f"{symbols_sha256(symbols)}  pgvec-symbols={len(symbols)}")
+            return 0
+        summary = run(args.root.resolve())
+    except PortabilityError as exc:
+        print(f"check_db3_portability: error: {exc}", file=sys.stderr)
+        return 1
+    rendered = ", ".join(f"{name}={count}" for name, count in summary.items())
+    print(f"check_db3_portability: ok (total={sum(summary.values())}; {rendered})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_db3_portability.py
+++ b/scripts/tests/test_check_db3_portability.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Failure-mode tests for the DB3 portability audit."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts/check_db3_portability.py"
+SPEC = importlib.util.spec_from_file_location("check_db3_portability", CHECKER)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+class PortabilityTests(unittest.TestCase):
+    def audit(self) -> dict[str, object]:
+        return json.loads((REPO_ROOT / checker.AUDIT).read_text(encoding="utf-8"))
+
+    def ledger(self) -> dict[str, object]:
+        return json.loads((REPO_ROOT / checker.LEDGER).read_text(encoding="utf-8"))
+
+    def assert_rule(self, mutate, rule: str, *, ledger: bool = False) -> None:
+        audit_value = copy.deepcopy(self.audit())
+        ledger_value = copy.deepcopy(self.ledger())
+        mutate(ledger_value if ledger else audit_value)
+        with self.assertRaisesRegex(checker.PortabilityError, rf"rule={rule}"):
+            checker.validate(audit_value, ledger_value)
+
+    def test_production_audit_covers_every_pgvector_declaration(self) -> None:
+        summary = checker.run(REPO_ROOT)
+        self.assertEqual(sum(summary.values()), 76)
+        self.assertEqual(summary, {
+            "portable-search": 14,
+            "committed-mutation": 32,
+            "provider-control": 15,
+            "db2-authority": 12,
+            "portable-analytics": 3,
+        })
+        source = checker.source_symbols(self.ledger())
+        classified = [
+            symbol
+            for group in self.audit()["classifications"]
+            for symbol in group["symbols"]
+        ]
+        self.assertEqual(sorted(classified), source)
+        self.assertIn("pgvec_memory_vector_search_record_type",
+                      self.audit()["classifications"][0]["symbols"])
+        self.assertIn("pgvec_schema_version",
+                      self.audit()["classifications"][3]["symbols"])
+
+    def test_root_identity_and_closed_classifications(self) -> None:
+        cases = (
+            (lambda value: value.__setitem__("extra", 1), "keys"),
+            (lambda value: value.__setitem__("schema_version", True), "schema-version"),
+            (lambda value: value.__setitem__("module", "db2"), "module"),
+            (lambda value: value.__setitem__("source", "other.json"), "source"),
+            (lambda value: value.__setitem__("classifications", []), "classifications"),
+            (lambda value: value["classifications"][0].__setitem__("id", "search"),
+             "classification-identity"),
+            (lambda value: value["classifications"][0].__setitem__("disposition", "maybe"),
+             "classification-identity"),
+            (lambda value: value["classifications"][0].__setitem__("rationale", ""),
+             "string"),
+            (lambda value: value["classifications"][0].__setitem__("extra", 1), "keys"),
+        )
+        for mutate, rule in cases:
+            with self.subTest(rule=rule):
+                self.assert_rule(mutate, rule)
+
+    def test_missing_extra_duplicate_and_unsorted_symbols_fail_closed(self) -> None:
+        self.assert_rule(
+            lambda value: value["classifications"][0]["symbols"].pop(), "coverage")
+        self.assert_rule(
+            lambda value: value["classifications"][0]["symbols"].append("pgvec_not_real"),
+            "coverage")
+        self.assert_rule(
+            lambda value: value["classifications"][1]["symbols"].append(
+                value["classifications"][0]["symbols"][0]),
+            "symbol-order")
+        self.assert_rule(
+            lambda value: value["classifications"][0]["symbols"].reverse(), "symbol-order")
+        self.assert_rule(
+            lambda value: value["classifications"][0]["symbols"].__setitem__(0, "not_pgvec"),
+            "symbol")
+
+    def test_duplicate_classification_is_rejected_after_sorting(self) -> None:
+        def mutate(value: dict[str, object]) -> None:
+            groups = value["classifications"]
+            duplicate = groups[0]["symbols"][0]
+            groups[1]["symbols"].append(duplicate)
+            groups[1]["symbols"].sort()
+        self.assert_rule(mutate, "symbol-duplicate")
+
+    def test_ledger_addition_removal_and_duplicate_are_rejected(self) -> None:
+        def add(value: dict[str, object]) -> None:
+            row = copy.deepcopy(value["declarations"][0])
+            row["symbol"] = "pgvec_new_operation"
+            value["declarations"].append(row)
+        self.assert_rule(add, "source-fingerprint", ledger=True)
+
+        def remove(value: dict[str, object]) -> None:
+            value["declarations"] = [
+                row for row in value["declarations"]
+                if row["symbol"] != "pgvec_code_search"
+            ]
+        self.assert_rule(remove, "source-fingerprint", ledger=True)
+
+        def duplicate(value: dict[str, object]) -> None:
+            row = next(row for row in value["declarations"]
+                       if row["symbol"] == "pgvec_code_search")
+            value["declarations"].append(copy.deepcopy(row))
+        self.assert_rule(duplicate, "ledger-duplicate", ledger=True)
+
+    def test_source_fingerprint_is_an_independent_gate(self) -> None:
+        self.assert_rule(
+            lambda value: value.__setitem__("source_symbols_sha256", "0" * 64),
+            "source-fingerprint")
+
+    def test_reference_route_import_boundary_is_machine_enforced(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for relative in (checker.AUDIT, checker.LEDGER, checker.ROUTE_SOURCE):
+                target = root / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(REPO_ROOT / relative, target)
+            checker.run(root)
+            route = root / checker.ROUTE_SOURCE
+            route.write_text("#include <stdint.h>\n" + route.read_text(encoding="utf-8"),
+                             encoding="utf-8")
+            checker.run(root)
+            route.write_text('#include "c/pgvec_transport.h"\n' +
+                             route.read_text(encoding="utf-8"), encoding="utf-8")
+            with self.assertRaisesRegex(checker.PortabilityError, "rule=route-boundary"):
+                checker.run(root)
+            original = (REPO_ROOT / checker.ROUTE_SOURCE).read_text(encoding="utf-8")
+            for directive in ('# include "c/pgvec_transport.h"\n',
+                              '#/**/include "c/pgvec_transport.h"\n'):
+                route.write_text(directive + original, encoding="utf-8")
+                with self.assertRaisesRegex(checker.PortabilityError, "rule=route-boundary"):
+                    checker.run(root)
+
+    def test_malformed_json_and_resource_limits_are_typed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = root / "input.json"
+            path.write_text('{"a":1,"a":2}', encoding="utf-8")
+            with self.assertRaisesRegex(checker.PortabilityError, "rule=json-duplicate-key"):
+                checker.load_json(path)
+            path.write_text('{"a":NaN}', encoding="utf-8")
+            with self.assertRaisesRegex(checker.PortabilityError, "rule=json-number-domain"):
+                checker.load_json(path)
+            path.write_bytes(b"x" * (checker.MAX_BYTES + 1))
+            with self.assertRaisesRegex(checker.PortabilityError, "rule=input-size"):
+                checker.load_json(path)
+
+    def test_cli_checks_a_copied_repository_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for relative in (checker.AUDIT, checker.LEDGER, checker.ROUTE_SOURCE):
+                target = root / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(REPO_ROOT / relative, target)
+            result = subprocess.run(
+                [sys.executable, "-I", "-S", str(CHECKER), "--root", str(root)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("total=76", result.stdout)
+            fingerprint = subprocess.run(
+                [sys.executable, "-I", "-S", str(CHECKER), "--root", str(root),
+                 "--print-source-fingerprint"],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(fingerprint.returncode, 0, fingerprint.stderr)
+            self.assertEqual(
+                fingerprint.stdout.strip(),
+                f"{self.audit()['source_symbols_sha256']}  pgvec-symbols=76",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/modules/db2/db3_route.c
+++ b/src/modules/db2/db3_route.c
@@ -1,0 +1,488 @@
+#include <aimee/db2/db3_route.h>
+
+#include <math.h>
+#include <string.h>
+
+#define SEARCH_REQUEST_MAGIC  0x53334244u /* DB3S */
+#define SEARCH_REPLY_MAGIC    0x52334244u /* DB3R */
+#define APPLY_MAGIC           0x41334244u /* DB3A */
+#define WIRE_VERSION          1u
+#define SEARCH_REQUEST_HEADER 36u
+#define SEARCH_REPLY_HEADER   28u
+#define APPLY_HEADER          36u
+
+_Static_assert(sizeof(float) == 4, "DB3 wire requires 32-bit float");
+_Static_assert(sizeof(double) == 8, "DB3 wire requires 64-bit double");
+_Static_assert(AIMEE_DB3_MAX_DIM <= UINT16_MAX, "DB3 dimension must fit its wire field");
+_Static_assert(AIMEE_DB3_MAX_TOP_K <= UINT16_MAX, "DB3 top-K must fit its wire field");
+
+static void put_u16(uint8_t *out, uint16_t value)
+{
+   out[0] = (uint8_t)value;
+   out[1] = (uint8_t)(value >> 8);
+}
+
+static void put_u32(uint8_t *out, uint32_t value)
+{
+   for (unsigned i = 0; i < 4; ++i)
+      out[i] = (uint8_t)(value >> (i * 8));
+}
+
+static void put_u64(uint8_t *out, uint64_t value)
+{
+   for (unsigned i = 0; i < 8; ++i)
+      out[i] = (uint8_t)(value >> (i * 8));
+}
+
+static uint16_t get_u16(const uint8_t *in)
+{
+   return (uint16_t)((uint16_t)in[0] | ((uint16_t)in[1] << 8));
+}
+
+static uint32_t get_u32(const uint8_t *in)
+{
+   uint32_t value = 0;
+   for (unsigned i = 0; i < 4; ++i)
+      value |= (uint32_t)in[i] << (i * 8);
+   return value;
+}
+
+static uint64_t get_u64(const uint8_t *in)
+{
+   uint64_t value = 0;
+   for (unsigned i = 0; i < 8; ++i)
+      value |= (uint64_t)in[i] << (i * 8);
+   return value;
+}
+
+static size_t text_length(const char *text, size_t capacity)
+{
+   const char *end = memchr(text, '\0', capacity);
+   return end ? (size_t)(end - text) : SIZE_MAX;
+}
+
+static int text_valid(const char *text, size_t capacity, int allow_empty)
+{
+   size_t length = text_length(text, capacity);
+   if (length == SIZE_MAX || (!allow_empty && length == 0))
+      return 0;
+   for (size_t i = 0; i < length; ++i)
+   {
+      unsigned char byte = (unsigned char)text[i];
+      if (byte < 0x21u || byte > 0x7eu)
+         return 0;
+   }
+   return 1;
+}
+
+static int vectors_valid(const float *vector, uint32_t dimension)
+{
+   for (uint32_t i = 0; i < dimension; ++i)
+      if (!isfinite(vector[i]))
+         return 0;
+   return 1;
+}
+
+int aimee_db3_search_request_validate(const aimee_db3_search_request_t *request)
+{
+   if (!request || request->request_id == 0 || request->required_generation == 0 ||
+       request->dimension == 0 || request->dimension > AIMEE_DB3_MAX_DIM || request->top_k == 0 ||
+       request->top_k > AIMEE_DB3_MAX_TOP_K ||
+       !text_valid(request->workspace, sizeof(request->workspace), 1) ||
+       !text_valid(request->project, sizeof(request->project), 1) ||
+       (!request->workspace[0] && !request->project[0]) ||
+       !text_valid(request->record_type, sizeof(request->record_type), 0) ||
+       !vectors_valid(request->vector, request->dimension))
+      return -1;
+   return 0;
+}
+
+int aimee_db3_search_reply_validate(const aimee_db3_search_request_t *request,
+                                    const aimee_db3_search_reply_t *reply)
+{
+   if (!request || !reply || reply->request_id != request->request_id ||
+       reply->generation != request->required_generation || reply->count > request->top_k ||
+       reply->count > AIMEE_DB3_MAX_TOP_K)
+      return -1;
+   for (uint32_t i = 0; i < reply->count; ++i)
+   {
+      if (reply->candidates[i].point_id <= 0 || !isfinite(reply->candidates[i].score))
+         return -1;
+      for (uint32_t j = 0; j < i; ++j)
+         if (reply->candidates[j].point_id == reply->candidates[i].point_id)
+            return -1;
+   }
+   return 0;
+}
+
+int aimee_db3_apply_validate(const aimee_db3_apply_t *apply)
+{
+   if (!apply || apply->operation_id == 0 || apply->generation == 0 || apply->point_id <= 0 ||
+       !text_valid(apply->collection, sizeof(apply->collection), 0))
+      return -1;
+   if (apply->kind == AIMEE_DB3_APPLY_UPSERT)
+   {
+      if (apply->dimension == 0 || apply->dimension > AIMEE_DB3_MAX_DIM ||
+          !vectors_valid(apply->vector, apply->dimension))
+         return -1;
+   }
+   else if ((apply->kind != AIMEE_DB3_APPLY_DELETE && apply->kind != AIMEE_DB3_APPLY_TOMBSTONE) ||
+            apply->dimension != 0)
+      return -1;
+   return 0;
+}
+
+static int checked_total(size_t header, size_t a, size_t b, size_t c, size_t item_size,
+                         size_t item_count, size_t *total)
+{
+   if (!total || a > SIZE_MAX - header)
+      return -1;
+   size_t fixed = header + a;
+   if (b > SIZE_MAX - fixed)
+      return -1;
+   fixed += b;
+   if (c > SIZE_MAX - fixed)
+      return -1;
+   fixed += c;
+   if (item_size == 0 || item_count > (SIZE_MAX - fixed) / item_size)
+      return -1;
+   *total = fixed + item_size * item_count;
+   return 0;
+}
+
+int aimee_db3_search_request_encode(const aimee_db3_search_request_t *request, uint8_t *output,
+                                    size_t capacity, size_t *length)
+{
+   if (length)
+      *length = 0;
+   if (!output || !length || aimee_db3_search_request_validate(request) != 0)
+      return -1;
+   size_t workspace_len = text_length(request->workspace, sizeof(request->workspace));
+   size_t project_len = text_length(request->project, sizeof(request->project));
+   size_t record_len = text_length(request->record_type, sizeof(request->record_type));
+   size_t total = 0;
+   if (checked_total(SEARCH_REQUEST_HEADER, workspace_len, project_len, record_len, sizeof(float),
+                     request->dimension, &total) != 0 ||
+       total > capacity || workspace_len > UINT16_MAX || project_len > UINT16_MAX ||
+       record_len > UINT16_MAX || request->dimension > UINT16_MAX || request->top_k > UINT16_MAX)
+      return -1;
+   memset(output, 0, SEARCH_REQUEST_HEADER);
+   put_u32(output, SEARCH_REQUEST_MAGIC);
+   put_u16(output + 4, WIRE_VERSION);
+   put_u16(output + 6, SEARCH_REQUEST_HEADER);
+   put_u64(output + 8, request->request_id);
+   put_u64(output + 16, request->required_generation);
+   put_u16(output + 24, (uint16_t)workspace_len);
+   put_u16(output + 26, (uint16_t)project_len);
+   put_u16(output + 28, (uint16_t)record_len);
+   put_u16(output + 30, (uint16_t)request->dimension);
+   put_u16(output + 32, (uint16_t)request->top_k);
+   size_t offset = SEARCH_REQUEST_HEADER;
+   memcpy(output + offset, request->workspace, workspace_len);
+   offset += workspace_len;
+   memcpy(output + offset, request->project, project_len);
+   offset += project_len;
+   memcpy(output + offset, request->record_type, record_len);
+   offset += record_len;
+   for (uint32_t i = 0; i < request->dimension; ++i)
+   {
+      uint32_t bits = 0;
+      memcpy(&bits, &request->vector[i], sizeof(bits));
+      put_u32(output + offset, bits);
+      offset += sizeof(bits);
+   }
+   *length = total;
+   return 0;
+}
+
+int aimee_db3_search_request_decode(const uint8_t *input, size_t length,
+                                    aimee_db3_search_request_t *request)
+{
+   if (!input || !request || length < SEARCH_REQUEST_HEADER ||
+       get_u32(input) != SEARCH_REQUEST_MAGIC || get_u16(input + 4) != WIRE_VERSION ||
+       get_u16(input + 6) != SEARCH_REQUEST_HEADER || get_u16(input + 34) != 0)
+      return -1;
+   uint16_t workspace_len = get_u16(input + 24), project_len = get_u16(input + 26);
+   uint16_t record_len = get_u16(input + 28), dimension = get_u16(input + 30);
+   uint16_t top_k = get_u16(input + 32);
+   if (workspace_len >= AIMEE_DB3_MAX_SCOPE || project_len >= AIMEE_DB3_MAX_SCOPE ||
+       record_len == 0 || record_len >= AIMEE_DB3_MAX_RECORD_TYPE || dimension == 0 ||
+       dimension > AIMEE_DB3_MAX_DIM || top_k == 0 || top_k > AIMEE_DB3_MAX_TOP_K)
+      return -1;
+   size_t total = 0;
+   if (checked_total(SEARCH_REQUEST_HEADER, workspace_len, project_len, record_len, sizeof(float),
+                     dimension, &total) != 0 ||
+       total != length)
+      return -1;
+   memset(request, 0, sizeof(*request));
+   request->request_id = get_u64(input + 8);
+   request->required_generation = get_u64(input + 16);
+   request->dimension = dimension;
+   request->top_k = top_k;
+   size_t offset = SEARCH_REQUEST_HEADER;
+   memcpy(request->workspace, input + offset, workspace_len);
+   offset += workspace_len;
+   memcpy(request->project, input + offset, project_len);
+   offset += project_len;
+   memcpy(request->record_type, input + offset, record_len);
+   offset += record_len;
+   for (uint32_t i = 0; i < dimension; ++i)
+   {
+      uint32_t bits = get_u32(input + offset);
+      memcpy(&request->vector[i], &bits, sizeof(bits));
+      offset += sizeof(bits);
+   }
+   return aimee_db3_search_request_validate(request);
+}
+
+int aimee_db3_search_reply_encode(const aimee_db3_search_reply_t *reply, uint8_t *output,
+                                  size_t capacity, size_t *length)
+{
+   if (length)
+      *length = 0;
+   if (!reply || !output || !length || reply->request_id == 0 || reply->generation == 0 ||
+       reply->count > AIMEE_DB3_MAX_TOP_K)
+      return -1;
+   size_t total = SEARCH_REPLY_HEADER + (size_t)reply->count * 16u;
+   if (total > capacity)
+      return -1;
+   memset(output, 0, SEARCH_REPLY_HEADER);
+   put_u32(output, SEARCH_REPLY_MAGIC);
+   put_u16(output + 4, WIRE_VERSION);
+   put_u16(output + 6, SEARCH_REPLY_HEADER);
+   put_u64(output + 8, reply->request_id);
+   put_u64(output + 16, reply->generation);
+   put_u32(output + 24, reply->count);
+   size_t offset = SEARCH_REPLY_HEADER;
+   for (uint32_t i = 0; i < reply->count; ++i)
+   {
+      uint64_t score_bits = 0;
+      if (reply->candidates[i].point_id <= 0 || !isfinite(reply->candidates[i].score))
+         return -1;
+      for (uint32_t j = 0; j < i; ++j)
+         if (reply->candidates[j].point_id == reply->candidates[i].point_id)
+            return -1;
+      put_u64(output + offset, (uint64_t)reply->candidates[i].point_id);
+      memcpy(&score_bits, &reply->candidates[i].score, sizeof(score_bits));
+      put_u64(output + offset + 8, score_bits);
+      offset += 16;
+   }
+   *length = total;
+   return 0;
+}
+
+int aimee_db3_search_reply_decode(const uint8_t *input, size_t length,
+                                  aimee_db3_search_reply_t *reply)
+{
+   if (!input || !reply || length < SEARCH_REPLY_HEADER || get_u32(input) != SEARCH_REPLY_MAGIC ||
+       get_u16(input + 4) != WIRE_VERSION || get_u16(input + 6) != SEARCH_REPLY_HEADER)
+      return -1;
+   uint32_t count = get_u32(input + 24);
+   if (count > AIMEE_DB3_MAX_TOP_K || length != SEARCH_REPLY_HEADER + (size_t)count * 16u)
+      return -1;
+   memset(reply, 0, sizeof(*reply));
+   reply->request_id = get_u64(input + 8);
+   reply->generation = get_u64(input + 16);
+   reply->count = count;
+   if (reply->request_id == 0 || reply->generation == 0)
+      return -1;
+   size_t offset = SEARCH_REPLY_HEADER;
+   for (uint32_t i = 0; i < count; ++i)
+   {
+      uint64_t point_bits = get_u64(input + offset);
+      uint64_t score_bits = get_u64(input + offset + 8);
+      if (point_bits == 0 || point_bits > INT64_MAX)
+         return -1;
+      reply->candidates[i].point_id = (int64_t)point_bits;
+      memcpy(&reply->candidates[i].score, &score_bits, sizeof(score_bits));
+      if (reply->candidates[i].point_id <= 0 || !isfinite(reply->candidates[i].score))
+         return -1;
+      for (uint32_t j = 0; j < i; ++j)
+         if (reply->candidates[j].point_id == reply->candidates[i].point_id)
+            return -1;
+      offset += 16;
+   }
+   return 0;
+}
+
+int aimee_db3_apply_encode(const aimee_db3_apply_t *apply, uint8_t *output, size_t capacity,
+                           size_t *length)
+{
+   if (length)
+      *length = 0;
+   if (!output || !length || aimee_db3_apply_validate(apply) != 0)
+      return -1;
+   size_t collection_len = text_length(apply->collection, sizeof(apply->collection));
+   size_t total = 0;
+   if (checked_total(APPLY_HEADER, collection_len, 0, 0, sizeof(float), apply->dimension, &total) !=
+           0 ||
+       total > capacity || collection_len > UINT16_MAX || apply->dimension > UINT16_MAX)
+      return -1;
+   memset(output, 0, APPLY_HEADER);
+   put_u32(output, APPLY_MAGIC);
+   put_u16(output + 4, WIRE_VERSION);
+   output[6] = (uint8_t)apply->kind;
+   put_u64(output + 8, apply->operation_id);
+   put_u64(output + 16, apply->generation);
+   put_u64(output + 24, (uint64_t)apply->point_id);
+   put_u16(output + 32, (uint16_t)collection_len);
+   put_u16(output + 34, (uint16_t)apply->dimension);
+   size_t offset = APPLY_HEADER;
+   memcpy(output + offset, apply->collection, collection_len);
+   offset += collection_len;
+   for (uint32_t i = 0; i < apply->dimension; ++i)
+   {
+      uint32_t bits = 0;
+      memcpy(&bits, &apply->vector[i], sizeof(bits));
+      put_u32(output + offset, bits);
+      offset += sizeof(bits);
+   }
+   *length = total;
+   return 0;
+}
+
+int aimee_db3_apply_decode(const uint8_t *input, size_t length, aimee_db3_apply_t *apply)
+{
+   if (!input || !apply || length < APPLY_HEADER || get_u32(input) != APPLY_MAGIC ||
+       get_u16(input + 4) != WIRE_VERSION || input[7] != 0)
+      return -1;
+   uint16_t collection_len = get_u16(input + 32), dimension = get_u16(input + 34);
+   if (collection_len == 0 || collection_len >= AIMEE_DB3_MAX_COLLECTION ||
+       dimension > AIMEE_DB3_MAX_DIM ||
+       length != APPLY_HEADER + (size_t)collection_len + (size_t)dimension * sizeof(float))
+      return -1;
+   memset(apply, 0, sizeof(*apply));
+   apply->kind = (aimee_db3_apply_kind_t)input[6];
+   apply->operation_id = get_u64(input + 8);
+   apply->generation = get_u64(input + 16);
+   uint64_t point_bits = get_u64(input + 24);
+   if (point_bits == 0 || point_bits > INT64_MAX)
+      return -1;
+   apply->point_id = (int64_t)point_bits;
+   apply->dimension = dimension;
+   size_t offset = APPLY_HEADER;
+   memcpy(apply->collection, input + offset, collection_len);
+   offset += collection_len;
+   for (uint32_t i = 0; i < dimension; ++i)
+   {
+      uint32_t bits = get_u32(input + offset);
+      memcpy(&apply->vector[i], &bits, sizeof(bits));
+      offset += sizeof(bits);
+   }
+   return aimee_db3_apply_validate(apply);
+}
+
+int aimee_db3_route_init(aimee_db3_route_t *route, aimee_db3_search_fn internal_pgvector_search,
+                         void *internal_context,
+                         aimee_db3_candidate_authorize_fn authorize_candidate,
+                         void *authorize_context)
+{
+   if (!route || !internal_pgvector_search || !authorize_candidate)
+      return -1;
+   memset(route, 0, sizeof(*route));
+   route->internal_pgvector_search = internal_pgvector_search;
+   route->internal_context = internal_context;
+   route->authorize_candidate = authorize_candidate;
+   route->authorize_context = authorize_context;
+   return 0;
+}
+
+int aimee_db3_route_select(aimee_db3_route_t *route, uint32_t principal, int ready,
+                           int fallback_enabled, aimee_db3_search_fn external_search,
+                           void *external_context)
+{
+   if (!route || principal == 0 || !external_search)
+      return -1;
+   route->selected_principal = principal;
+   route->selected_ready = ready != 0;
+   route->fallback_enabled = fallback_enabled != 0;
+   route->external_search = external_search;
+   route->external_context = external_context;
+   return 0;
+}
+
+void aimee_db3_route_clear(aimee_db3_route_t *route)
+{
+   if (!route)
+      return;
+   route->selected_principal = 0;
+   route->selected_ready = 0;
+   route->fallback_enabled = 0;
+   route->external_search = NULL;
+   route->external_context = NULL;
+}
+
+static aimee_db3_result_t call_and_validate(aimee_db3_search_fn search, void *context,
+                                            const aimee_db3_search_request_t *request,
+                                            aimee_db3_search_reply_t *reply, int external)
+{
+   memset(reply, 0, sizeof(*reply));
+   if (search(context, request, reply) != 0)
+      return external ? AIMEE_DB3_PROVIDER_FAILURE : AIMEE_DB3_INTERNAL;
+   if (aimee_db3_search_reply_validate(request, reply) != 0)
+      return AIMEE_DB3_INVALID_RESPONSE;
+   return AIMEE_DB3_OK;
+}
+
+static aimee_db3_result_t authorize(aimee_db3_route_t *route,
+                                    const aimee_db3_search_request_t *request,
+                                    aimee_db3_search_reply_t *reply)
+{
+   uint32_t kept = 0;
+   for (uint32_t i = 0; i < reply->count; ++i)
+   {
+      int allowed = route->authorize_candidate(route->authorize_context, request->workspace,
+                                               request->project, reply->candidates[i].point_id);
+      if (allowed < 0)
+         return AIMEE_DB3_INTERNAL;
+      if (allowed)
+         reply->candidates[kept++] = reply->candidates[i];
+   }
+   reply->count = kept;
+   return AIMEE_DB3_OK;
+}
+
+aimee_db3_result_t aimee_db3_memory_candidates_search(aimee_db3_route_t *route,
+                                                      const aimee_db3_search_request_t *request,
+                                                      aimee_db3_search_outcome_t *outcome)
+{
+   if (!outcome)
+      return AIMEE_DB3_INVALID_REQUEST;
+   memset(outcome, 0, sizeof(*outcome));
+   outcome->result = AIMEE_DB3_INVALID_REQUEST;
+   if (!route || !route->internal_pgvector_search || !route->authorize_candidate ||
+       aimee_db3_search_request_validate(request) != 0)
+      return outcome->result;
+
+   outcome->selected_principal = route->selected_principal;
+   if (route->selected_principal == 0)
+   {
+      outcome->route = AIMEE_DB3_ROUTE_DEFAULT_PGVECTOR;
+      outcome->result = call_and_validate(route->internal_pgvector_search, route->internal_context,
+                                          request, &outcome->reply, 0);
+   }
+   else if (route->selected_ready)
+   {
+      outcome->route = AIMEE_DB3_ROUTE_EXTERNAL;
+      outcome->result = call_and_validate(route->external_search, route->external_context, request,
+                                          &outcome->reply, 1);
+      if (outcome->result != AIMEE_DB3_OK)
+         outcome->external_error = (int)outcome->result;
+   }
+   else
+   {
+      outcome->route = AIMEE_DB3_ROUTE_EXTERNAL;
+      outcome->result = AIMEE_DB3_UNAVAILABLE;
+      outcome->external_error = AIMEE_DB3_UNAVAILABLE;
+   }
+
+   if (route->selected_principal != 0 && outcome->result != AIMEE_DB3_OK && route->fallback_enabled)
+   {
+      outcome->route = AIMEE_DB3_ROUTE_EXPLICIT_FALLBACK;
+      outcome->result = call_and_validate(route->internal_pgvector_search, route->internal_context,
+                                          request, &outcome->reply, 0);
+   }
+   if (outcome->result == AIMEE_DB3_OK)
+      outcome->result = authorize(route, request, &outcome->reply);
+   return outcome->result;
+}

--- a/src/modules/db2/eventcontract/vector-portability.json
+++ b/src/modules/db2/eventcontract/vector-portability.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": 1,
+  "module": "db3",
+  "source": "tests/baselines/db2/declarations-v1.json",
+  "source_symbols_sha256": "8933df59106a753dd9d1ce4ab8e0ffebf863b32fc792f83e165419699cf5c034",
+  "classifications": [
+    {
+      "id": "portable-search",
+      "disposition": "portable-now",
+      "db3_operation_family": "candidate-search",
+      "rationale": "The logical operation accepts a bounded vector and closed filters and returns only opaque candidate IDs and scores; DB2 must rehydrate and authorize every hit.",
+      "symbols": [
+        "pgvec_code_search",
+        "pgvec_curator_claim_search",
+        "pgvec_curator_code_unit_search",
+        "pgvec_curator_entity_search",
+        "pgvec_curator_narrative_search",
+        "pgvec_kb_search",
+        "pgvec_kb_search_scoped",
+        "pgvec_kb_service_search_memory_points",
+        "pgvec_kb_vector_search_project",
+        "pgvec_kb_vector_search_scoped",
+        "pgvec_kbpdf_search",
+        "pgvec_memory_search",
+        "pgvec_memory_vector_search_record_type",
+        "pgvec_memory_vector_search_with_kinds"
+      ]
+    },
+    {
+      "id": "committed-mutation",
+      "disposition": "portable-after-commit",
+      "db3_operation_family": "apply",
+      "rationale": "The pgvector call remains DB2's canonical transactional write, while a provider-neutral upsert, delete, or tombstone is safe to fan out from the committed DB2 outbox.",
+      "symbols": [
+        "pgvec_code_delete",
+        "pgvec_code_delete_project",
+        "pgvec_code_upsert",
+        "pgvec_curator_claim_delete",
+        "pgvec_curator_claim_upsert",
+        "pgvec_curator_code_unit_delete",
+        "pgvec_curator_code_unit_delete_project",
+        "pgvec_curator_code_unit_upsert",
+        "pgvec_curator_entity_delete",
+        "pgvec_curator_entity_upsert",
+        "pgvec_curator_narrative_delete",
+        "pgvec_curator_narrative_upsert",
+        "pgvec_kb_delete",
+        "pgvec_kb_delete_current_project",
+        "pgvec_kb_delete_project",
+        "pgvec_kb_service_code_upsert",
+        "pgvec_kb_service_upsert_document_point",
+        "pgvec_kb_upsert",
+        "pgvec_kb_upsert_batch",
+        "pgvec_kb_vector_delete_current_project",
+        "pgvec_kb_vector_delete_point",
+        "pgvec_kb_vector_delete_project",
+        "pgvec_kb_vector_upsert_document",
+        "pgvec_kb_vector_upsert_document_batch",
+        "pgvec_kbpdf_delete",
+        "pgvec_kbpdf_delete_project",
+        "pgvec_kbpdf_upsert",
+        "pgvec_memory_delete",
+        "pgvec_memory_upsert",
+        "pgvec_memory_vector_delete_point",
+        "pgvec_memory_vector_upsert_memory",
+        "pgvec_memory_vector_upsert_unit"
+      ]
+    },
+    {
+      "id": "provider-control",
+      "disposition": "provider-local",
+      "db3_operation_family": "provider-control",
+      "rationale": "Index layout, collection naming, implementation health, statistics, and tuning are provider-local concerns exposed only through bounded DB3 capabilities and readiness evidence.",
+      "symbols": [
+        "pgvec_corpus_index_type",
+        "pgvec_ensure_corpus_index",
+        "pgvec_ensure_index",
+        "pgvec_kb_service_ensure_code_collection",
+        "pgvec_kb_service_ensure_kb_collection",
+        "pgvec_kb_service_ensure_memory_collection",
+        "pgvec_kb_vector_collection_name",
+        "pgvec_memory_vector_collection_exists",
+        "pgvec_memory_vector_collection_name",
+        "pgvec_memory_vector_collection_recreate",
+        "pgvec_memory_vector_ensure_payload_indexes",
+        "pgvec_point_count",
+        "pgvec_search_latency_snapshot",
+        "pgvec_table_ready",
+        "pgvec_vectorscale_available"
+      ]
+    },
+    {
+      "id": "db2-authority",
+      "disposition": "retained-db2",
+      "db3_operation_family": "none",
+      "rationale": "The operation depends on canonical PostgreSQL rows, schema or recovery authority, or process-local state and therefore remains inside DB2 even when an external DB3 provider serves portable work.",
+      "symbols": [
+        "pgvec_code_exists_by_hash",
+        "pgvec_code_node_path",
+        "pgvec_curator_entity_lookup",
+        "pgvec_kb_service_code_exists_by_hash",
+        "pgvec_kb_service_reconcile_orphans",
+        "pgvec_memory_vector_scope_hint_clear",
+        "pgvec_memory_vector_scope_hint_set",
+        "pgvec_schema_version",
+        "pgvec_scroll",
+        "pgvec_vector_status_json",
+        "pgvec_verify_snapshot",
+        "pgvec_verify_snapshot_cleanup"
+      ]
+    },
+    {
+      "id": "portable-analytics",
+      "disposition": "deferred",
+      "db3_operation_family": "candidate-analytics",
+      "rationale": "The current API returns authority-bearing paths or performs provider-specific pair analytics; a later bounded contract must return opaque candidates for DB2 revalidation before this work can move.",
+      "symbols": [
+        "pgvec_code_search_paths",
+        "pgvec_code_similar_pairs",
+        "pgvec_memory_vector_near_duplicate_pairs"
+      ]
+    }
+  ]
+}

--- a/src/modules/db2/include/aimee/db2/db3_route.h
+++ b/src/modules/db2/include/aimee/db2/db3_route.h
@@ -1,0 +1,137 @@
+#ifndef AIMEE_DB2_DB3_ROUTE_H
+#define AIMEE_DB2_DB3_ROUTE_H 1
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define AIMEE_DB3_EVENT_CAPABILITIES 11777u
+#define AIMEE_DB3_EVENT_APPLY        11778u
+#define AIMEE_DB3_EVENT_APPLIED      11779u
+#define AIMEE_DB3_EVENT_SEARCH       11780u
+#define AIMEE_DB3_EVENT_ROUTE        11781u
+
+#define AIMEE_DB3_MAX_SCOPE       64u
+#define AIMEE_DB3_MAX_RECORD_TYPE 32u
+#define AIMEE_DB3_MAX_COLLECTION  32u
+#define AIMEE_DB3_MAX_DIM         4096u
+#define AIMEE_DB3_MAX_TOP_K       256u
+
+typedef enum
+{
+   AIMEE_DB3_OK = 0,
+   AIMEE_DB3_INVALID_REQUEST,
+   AIMEE_DB3_UNAVAILABLE,
+   AIMEE_DB3_PROVIDER_FAILURE,
+   AIMEE_DB3_INVALID_RESPONSE,
+   AIMEE_DB3_INTERNAL
+} aimee_db3_result_t;
+
+typedef enum
+{
+   AIMEE_DB3_ROUTE_DEFAULT_PGVECTOR = 0,
+   AIMEE_DB3_ROUTE_EXTERNAL,
+   AIMEE_DB3_ROUTE_EXPLICIT_FALLBACK
+} aimee_db3_route_kind_t;
+
+typedef enum
+{
+   AIMEE_DB3_APPLY_UPSERT = 1,
+   AIMEE_DB3_APPLY_DELETE = 2,
+   AIMEE_DB3_APPLY_TOMBSTONE = 3
+} aimee_db3_apply_kind_t;
+
+typedef struct
+{
+   int64_t point_id;
+   double score;
+} aimee_db3_candidate_t;
+
+typedef struct
+{
+   uint64_t request_id;
+   uint64_t required_generation;
+   char workspace[AIMEE_DB3_MAX_SCOPE];
+   char project[AIMEE_DB3_MAX_SCOPE];
+   char record_type[AIMEE_DB3_MAX_RECORD_TYPE];
+   uint32_t dimension;
+   uint32_t top_k;
+   float vector[AIMEE_DB3_MAX_DIM];
+} aimee_db3_search_request_t;
+
+typedef struct
+{
+   uint64_t request_id;
+   uint64_t generation;
+   uint32_t count;
+   aimee_db3_candidate_t candidates[AIMEE_DB3_MAX_TOP_K];
+} aimee_db3_search_reply_t;
+
+typedef struct
+{
+   uint64_t operation_id;
+   uint64_t generation;
+   int64_t point_id;
+   aimee_db3_apply_kind_t kind;
+   char collection[AIMEE_DB3_MAX_COLLECTION];
+   uint32_t dimension;
+   float vector[AIMEE_DB3_MAX_DIM];
+} aimee_db3_apply_t;
+
+typedef int (*aimee_db3_search_fn)(void *context, const aimee_db3_search_request_t *request,
+                                   aimee_db3_search_reply_t *reply);
+typedef int (*aimee_db3_candidate_authorize_fn)(void *context, const char *workspace,
+                                                const char *project, int64_t point_id);
+
+typedef struct
+{
+   aimee_db3_search_fn internal_pgvector_search;
+   void *internal_context;
+   aimee_db3_search_fn external_search;
+   void *external_context;
+   aimee_db3_candidate_authorize_fn authorize_candidate;
+   void *authorize_context;
+   uint32_t selected_principal;
+   int selected_ready;
+   int fallback_enabled;
+} aimee_db3_route_t;
+
+typedef struct
+{
+   aimee_db3_result_t result;
+   aimee_db3_route_kind_t route;
+   uint32_t selected_principal;
+   int external_error;
+   aimee_db3_search_reply_t reply;
+} aimee_db3_search_outcome_t;
+
+int aimee_db3_search_request_validate(const aimee_db3_search_request_t *request);
+int aimee_db3_search_reply_validate(const aimee_db3_search_request_t *request,
+                                    const aimee_db3_search_reply_t *reply);
+int aimee_db3_apply_validate(const aimee_db3_apply_t *apply);
+
+int aimee_db3_search_request_encode(const aimee_db3_search_request_t *request, uint8_t *output,
+                                    size_t capacity, size_t *length);
+int aimee_db3_search_request_decode(const uint8_t *input, size_t length,
+                                    aimee_db3_search_request_t *request);
+int aimee_db3_search_reply_encode(const aimee_db3_search_reply_t *reply, uint8_t *output,
+                                  size_t capacity, size_t *length);
+int aimee_db3_search_reply_decode(const uint8_t *input, size_t length,
+                                  aimee_db3_search_reply_t *reply);
+int aimee_db3_apply_encode(const aimee_db3_apply_t *apply, uint8_t *output, size_t capacity,
+                           size_t *length);
+int aimee_db3_apply_decode(const uint8_t *input, size_t length, aimee_db3_apply_t *apply);
+
+int aimee_db3_route_init(aimee_db3_route_t *route, aimee_db3_search_fn internal_pgvector_search,
+                         void *internal_context,
+                         aimee_db3_candidate_authorize_fn authorize_candidate,
+                         void *authorize_context);
+/* principal must be nonzero. Use aimee_db3_route_clear() to deselect the external provider. */
+int aimee_db3_route_select(aimee_db3_route_t *route, uint32_t principal, int ready,
+                           int fallback_enabled, aimee_db3_search_fn external_search,
+                           void *external_context);
+void aimee_db3_route_clear(aimee_db3_route_t *route);
+aimee_db3_result_t aimee_db3_memory_candidates_search(aimee_db3_route_t *route,
+                                                      const aimee_db3_search_request_t *request,
+                                                      aimee_db3_search_outcome_t *outcome);
+
+#endif /* AIMEE_DB2_DB3_ROUTE_H */

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -11,22 +11,27 @@
   },
   "sources": [
     "src/modules/db2/client/generated.c",
+    "src/modules/db2/db3_route.c",
     "src/modules/db2/module_adapter.c"
   ],
   "public_headers": [
     "src/modules/db2/include/aimee/db2/client.h",
+    "src/modules/db2/include/aimee/db2/db3_route.h",
     "src/modules/db2/include/aimee/db2/module_api.h"
   ],
   "contracts": [
     "src/modules/db2/eventcontract/declaration-review.json",
-    "src/modules/db2/eventcontract/operations.json"
+    "src/modules/db2/eventcontract/operations.json",
+    "src/modules/db2/eventcontract/vector-portability.json"
   ],
   "private_headers": [
     "src/modules/db2/module_adapter.h"
   ],
   "tests": [
     "src/tests/test_bus_db2_module.c",
-    "src/tests/test_db2_module_contract.c"
+    "src/tests/test_bus_db3.c",
+    "src/tests/test_db2_module_contract.c",
+    "src/tests/test_db3_route.c"
   ],
   "docs": [
     "docs/modules/db2.md"

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -214,6 +214,19 @@ target_include_directories(test_bus_db2_module PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../modules/db2
   ${CMAKE_CURRENT_SOURCE_DIR}/../modules/db2/include)
 target_link_libraries(test_bus_db2_module PRIVATE aimee-core-event-bus Threads::Threads)
+aimee_add_test(test_db3_route
+  test_db3_route.c
+  ../modules/db2/db3_route.c)
+target_include_directories(test_db3_route PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../modules/db2/include)
+target_link_libraries(test_db3_route PRIVATE m)
+aimee_add_test(test_bus_db3
+  test_bus_db3.c
+  ../modules/db2/db3_route.c)
+target_include_directories(test_bus_db3 PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../core/event_bus/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../modules/db2/include)
+target_link_libraries(test_bus_db3 PRIVATE aimee-core-event-bus Threads::Threads m)
 aimee_add_test(test_bus_capture test_bus_capture.c ../core/event_bus/bus_capture.c ../core/event_bus/bus_client.c ../core/event_bus/bus_attach.c ../core/event_bus/bus_host.c ../core/event_bus/bus_route.c ../core/event_bus/bus_region.c ../core/event_bus/bus_region_host.c ../core/event_bus/bus_ring.c ../core/event_bus/bus_arena.c ../core/event_bus/bus_wire.c)
 target_include_directories(test_bus_capture PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../core/event_bus/include)
 target_link_libraries(test_bus_capture PRIVATE Threads::Threads)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -726,7 +726,9 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-kb-mgmt-offline-hardening
 TEST_TARGETS += $(TESTPREFIX)/unit-test-communication
 TEST_TARGETS += $(TESTPREFIX)/unit-test-process-module-handlers
 TEST_TARGETS += $(TESTPREFIX)/unit-test-db2-module-contract \
-                $(TESTPREFIX)/unit-test-bus-db2-module
+                $(TESTPREFIX)/unit-test-bus-db2-module \
+                $(TESTPREFIX)/unit-test-db3-route \
+                $(TESTPREFIX)/unit-test-bus-db3
 
 MODULE_HANDLER_TEST_OBJS = \
    $(OBJDIR)/tests/module_handlers/memory.o \
@@ -3259,6 +3261,36 @@ $(TESTPREFIX)/unit-test-bus-db2-module: \
 
 .PHONY: unit-test-bus-db2-module
 unit-test-bus-db2-module: $(TESTPREFIX)/unit-test-bus-db2-module
+	$<
+
+$(OBJDIR)/tests/test_db3_route.o: C_FLAGS += -Imodules/db2/include
+$(OBJDIR)/modules/db2/db3_route.o: C_FLAGS += -Imodules/db2/include
+$(TESTPREFIX)/unit-test-db3-route: $(OBJDIR)/tests/test_db3_route.o \
+                                      $(OBJDIR)/modules/db2/db3_route.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lm
+
+.PHONY: unit-test-db3-route
+unit-test-db3-route: $(TESTPREFIX)/unit-test-db3-route
+	$<
+
+$(OBJDIR)/tests/test_bus_db3.o: C_FLAGS += -Icore/event_bus/include -Imodules/db2/include
+$(TESTPREFIX)/unit-test-bus-db3: $(OBJDIR)/tests/test_bus_db3.o \
+                                $(OBJDIR)/modules/db2/db3_route.o \
+                                $(OBJDIR)/core/event_bus/bus_runtime.o \
+                                $(OBJDIR)/core/event_bus/bus_endpoint.o \
+                                $(OBJDIR)/core/event_bus/bus_client.o \
+                                $(OBJDIR)/core/event_bus/bus_attach.o \
+                                $(OBJDIR)/core/event_bus/bus_host.o \
+                                $(OBJDIR)/core/event_bus/bus_route.o \
+                                $(OBJDIR)/core/event_bus/bus_region.o \
+                                $(OBJDIR)/core/event_bus/bus_region_host.o \
+                                $(OBJDIR)/core/event_bus/bus_ring.o \
+                                $(OBJDIR)/core/event_bus/bus_arena.o \
+                                $(OBJDIR)/core/event_bus/bus_wire.o
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread -lm
+
+.PHONY: unit-test-bus-db3
+unit-test-bus-db3: $(TESTPREFIX)/unit-test-bus-db3
 	$<
 
 # Event-bus conformance host harness (feature tree slice 10). A test binary that

--- a/src/tests/test_bus_db3.c
+++ b/src/tests/test_bus_db3.c
@@ -1,0 +1,236 @@
+#define _GNU_SOURCE
+
+#include <aimee/core/event_bus/bus_client.h>
+#include <aimee/core/event_bus/bus_endpoint.h>
+#include <aimee/core/event_bus/bus_host.h>
+#include <aimee/core/event_bus/bus_runtime.h>
+#include <aimee/db2/db3_route.h>
+
+#include "platform_test_util.h"
+
+#include <assert.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define DB2_REF        29u
+#define PROVIDER_A_REF 66u
+#define PROVIDER_B_REF 67u
+#define COLLISION_REF  68u
+
+typedef struct
+{
+   uint64_t operation_id;
+   uint64_t generation;
+   int effects;
+   int duplicates;
+} fake_provider_t;
+
+static void pump(bus_host_t *host, pthread_mutex_t *lock)
+{
+   pthread_mutex_lock(lock);
+   assert(bus_host_pump(host) > 0);
+   pthread_mutex_unlock(lock);
+}
+
+static void wait_for_clients(bus_host_t *host, pthread_mutex_t *lock, uint32_t count)
+{
+   const struct timespec pause = {.tv_sec = 0, .tv_nsec = 1000000};
+   for (int attempt = 0; attempt < 2000; ++attempt)
+   {
+      pthread_mutex_lock(lock);
+      uint32_t admitted = host->admitted;
+      pthread_mutex_unlock(lock);
+      if (admitted >= count)
+         return;
+      nanosleep(&pause, NULL);
+   }
+   assert(!"timed out waiting for DB3 clients");
+}
+
+static void attach(const char *socket_path, uint32_t principal_ref, bus_client_t *client)
+{
+   int fd = -1;
+   assert(bus_endpoint_connect(socket_path, &fd) == 0);
+   assert(bus_client_attach_as(fd, client, 1, principal_ref) == BUS_CLIENT_OK);
+   assert(bus_endpoint_close(&fd) == 0);
+}
+
+static uint32_t slot_for(bus_host_t *host, uint32_t principal_ref)
+{
+   for (uint32_t slot = 0; slot < host->cfg.max_slots; ++slot)
+      if (host->slots[slot].in_use && host->slots[slot].principal_ref == principal_ref)
+         return slot;
+   assert(!"principal has no slot");
+   return UINT32_MAX;
+}
+
+static void receive_apply(bus_client_t *client, fake_provider_t *state, uint64_t expected_seq)
+{
+   bus_event_t event;
+   assert(bus_client_poll(client, &event) == BUS_CLIENT_OK);
+   assert(event.frame.event_kind == AIMEE_DB3_EVENT_APPLY && event.frame.seq == expected_seq);
+   aimee_db3_apply_t apply;
+   assert(aimee_db3_apply_decode(event.payload, event.payload_len, &apply) == 0);
+   if (state->operation_id == apply.operation_id && state->generation == apply.generation)
+      state->duplicates++;
+   else
+   {
+      state->operation_id = apply.operation_id;
+      state->generation = apply.generation;
+      state->effects++;
+   }
+}
+
+int main(void)
+{
+   char directory[256];
+   snprintf(directory, sizeof(directory), "%s/aimee-db3-bus-XXXXXX", platform_tmpdir());
+   assert(mkdtemp(directory) != NULL);
+   char socket_path[512], executable[PATH_MAX];
+   assert(snprintf(socket_path, sizeof(socket_path), "%s/module.sock", directory) > 0);
+   assert(realpath("/proc/self/exe", executable) != NULL);
+
+   const uint32_t apply_kind[] = {AIMEE_DB3_EVENT_APPLY};
+   const uint32_t search_kind[] = {AIMEE_DB3_EVENT_SEARCH};
+   bus_runtime_grant_t grants[] = {
+       {.principal_class = 1,
+        .principal_ref = DB2_REF,
+        .uid = BUS_RUNTIME_SELF_UID,
+        .executable = executable,
+        .publish = apply_kind,
+        .publish_count = 1,
+        .request = search_kind,
+        .request_count = 1},
+       {.principal_class = 1,
+        .principal_ref = PROVIDER_A_REF,
+        .uid = BUS_RUNTIME_SELF_UID,
+        .executable = executable,
+        .subscribe = apply_kind,
+        .subscribe_count = 1,
+        .serve = search_kind,
+        .serve_count = 1},
+       {.principal_class = 1,
+        .principal_ref = PROVIDER_B_REF,
+        .uid = BUS_RUNTIME_SELF_UID,
+        .executable = executable,
+        .subscribe = apply_kind,
+        .subscribe_count = 1},
+       {.principal_class = 1,
+        .principal_ref = COLLISION_REF,
+        .uid = BUS_RUNTIME_SELF_UID,
+        .executable = executable,
+        .serve = search_kind,
+        .serve_count = 1},
+   };
+   bus_host_config_t host_config = {.max_slots = 8,
+                                    .slot_size = 512,
+                                    .inline_budget = 256,
+                                    .queue_capacity = 16,
+                                    .arena_size = 8192};
+   bus_host_t host;
+   assert(bus_host_create(&host, &host_config, NULL, NULL) == BUS_HOST_OK);
+   pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+   bus_runtime_config_t runtime_config = {.socket_path = socket_path,
+                                          .socket_mode = 0600,
+                                          .backlog = 8,
+                                          .stale_after_ns = 5000000000ULL,
+                                          .grants = grants,
+                                          .grant_count = 4};
+   bus_runtime_t *runtime = bus_runtime_start(&host, &lock, &runtime_config);
+   assert(runtime != NULL);
+
+   bus_client_t db2, provider_a, provider_b;
+   attach(socket_path, PROVIDER_A_REF, &provider_a);
+   attach(socket_path, PROVIDER_B_REF, &provider_b);
+   attach(socket_path, DB2_REF, &db2);
+   wait_for_clients(&host, &lock, 3);
+
+   int denied_fd = -1;
+   bus_client_t denied;
+   assert(bus_endpoint_connect(socket_path, &denied_fd) == 0);
+   assert(bus_client_attach_as(denied_fd, &denied, 1, COLLISION_REF) == BUS_CLIENT_DENIED);
+   assert(denied.attach_status == BUS_ATTACH_DENIED_POLICY);
+   assert(bus_endpoint_close(&denied_fd) == 0);
+
+   pthread_mutex_lock(&lock);
+   assert(bus_host_serve_kind(&host, slot_for(&host, PROVIDER_B_REF), AIMEE_DB3_EVENT_SEARCH) !=
+          BUS_HOST_OK);
+   pthread_mutex_unlock(&lock);
+
+   aimee_db3_apply_t apply = {.operation_id = 1001,
+                              .generation = 7,
+                              .point_id = 41,
+                              .kind = AIMEE_DB3_APPLY_UPSERT,
+                              .collection = "memory",
+                              .dimension = 3,
+                              .vector = {0.1f, 0.2f, 0.3f}};
+   uint8_t wire[256];
+   size_t length = 0;
+   assert(aimee_db3_apply_encode(&apply, wire, sizeof(wire), &length) == 0);
+   assert(bus_client_publish(&db2, AIMEE_DB3_EVENT_APPLY, wire, (uint32_t)length) == BUS_CLIENT_OK);
+   pump(&host, &lock);
+   fake_provider_t state_a = {0}, state_b = {0};
+   receive_apply(&provider_a, &state_a, 1);
+   receive_apply(&provider_b, &state_b, 1);
+   assert(state_a.effects == 1 && state_b.effects == 1);
+
+   assert(bus_client_publish(&db2, AIMEE_DB3_EVENT_APPLY, wire, (uint32_t)length) == BUS_CLIENT_OK);
+   pump(&host, &lock);
+   receive_apply(&provider_a, &state_a, 2);
+   receive_apply(&provider_b, &state_b, 2);
+   assert(state_a.effects == 1 && state_b.effects == 1);
+   assert(state_a.duplicates == 1 && state_b.duplicates == 1);
+
+   aimee_db3_search_request_t request = {.request_id = 77,
+                                         .required_generation = 7,
+                                         .workspace = "workspace-a",
+                                         .project = "project-a",
+                                         .record_type = "memory",
+                                         .dimension = 3,
+                                         .top_k = 2,
+                                         .vector = {0.3f, 0.2f, 0.1f}};
+   assert(aimee_db3_search_request_encode(&request, wire, sizeof(wire), &length) == 0);
+   assert(bus_client_request(&db2, AIMEE_DB3_EVENT_SEARCH, 9001, wire, (uint32_t)length) ==
+          BUS_CLIENT_OK);
+   pump(&host, &lock);
+
+   bus_event_t event;
+   assert(bus_client_poll(&provider_a, &event) == BUS_CLIENT_OK);
+   assert((event.frame.hdr_flags & BUS_F_REQUEST) != 0 &&
+          event.frame.event_kind == AIMEE_DB3_EVENT_SEARCH);
+   uint64_t server_correlation = event.frame.correlation_id;
+   aimee_db3_search_request_t decoded_request;
+   assert(aimee_db3_search_request_decode(event.payload, event.payload_len, &decoded_request) == 0);
+   assert(decoded_request.request_id == request.request_id);
+   assert(bus_client_poll(&provider_b, &event) == BUS_CLIENT_EMPTY);
+
+   aimee_db3_search_reply_t reply = {.request_id = request.request_id,
+                                     .generation = request.required_generation,
+                                     .count = 2,
+                                     .candidates = {{41, 0.95}, {42, 0.75}}};
+   assert(aimee_db3_search_reply_encode(&reply, wire, sizeof(wire), &length) == 0);
+   assert(bus_client_reply(&provider_a, AIMEE_DB3_EVENT_SEARCH, server_correlation, wire,
+                           (uint32_t)length) == BUS_CLIENT_OK);
+   pump(&host, &lock);
+   assert(bus_client_poll(&db2, &event) == BUS_CLIENT_OK);
+   assert((event.frame.hdr_flags & BUS_F_REPLY) != 0 && event.frame.correlation_id == 9001);
+   aimee_db3_search_reply_t decoded_reply;
+   assert(aimee_db3_search_reply_decode(event.payload, event.payload_len, &decoded_reply) == 0);
+   assert(aimee_db3_search_reply_validate(&request, &decoded_reply) == 0);
+   assert(decoded_reply.count == 2 && decoded_reply.candidates[0].point_id == 41);
+
+   bus_client_detach(&db2);
+   bus_client_detach(&provider_a);
+   bus_client_detach(&provider_b);
+   bus_runtime_stop(&runtime);
+   bus_host_destroy(&host);
+   pthread_mutex_destroy(&lock);
+   assert(rmdir(directory) == 0);
+   puts("test_bus_db3: two write observers and one read server passed");
+   return 0;
+}

--- a/src/tests/test_db3_route.c
+++ b/src/tests/test_db3_route.c
@@ -1,0 +1,234 @@
+#include <aimee/db2/db3_route.h>
+
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef struct
+{
+   int calls;
+   int mode;
+   int64_t first_id;
+} search_state_t;
+
+typedef struct
+{
+   int calls;
+   int reject_id;
+   int fail;
+} auth_state_t;
+
+static int search(void *context, const aimee_db3_search_request_t *request,
+                  aimee_db3_search_reply_t *reply)
+{
+   search_state_t *state = context;
+   state->calls++;
+   if (state->mode == 1)
+      return -1;
+   reply->request_id = request->request_id;
+   reply->generation = request->required_generation;
+   reply->count = 3;
+   for (uint32_t i = 0; i < reply->count; ++i)
+   {
+      reply->candidates[i].point_id = state->first_id + (int64_t)i;
+      reply->candidates[i].score = 0.9 - 0.1 * (double)i;
+   }
+   if (state->mode == 2)
+      reply->candidates[0].point_id = 0;
+   else if (state->mode == 3)
+      reply->candidates[0].score = NAN;
+   else if (state->mode == 4)
+      reply->candidates[1].point_id = reply->candidates[0].point_id;
+   else if (state->mode == 5)
+      reply->generation++;
+   return 0;
+}
+
+static int authorize(void *context, const char *workspace, const char *project, int64_t point_id)
+{
+   auth_state_t *state = context;
+   state->calls++;
+   assert(strcmp(workspace, "workspace-a") == 0);
+   assert(strcmp(project, "project-a") == 0);
+   if (state->fail)
+      return -1;
+   return point_id != state->reject_id;
+}
+
+static aimee_db3_search_request_t request(void)
+{
+   aimee_db3_search_request_t value = {0};
+   value.request_id = 91;
+   value.required_generation = 7;
+   strcpy(value.workspace, "workspace-a");
+   strcpy(value.project, "project-a");
+   strcpy(value.record_type, "memory");
+   value.dimension = 3;
+   value.top_k = 3;
+   value.vector[0] = 0.25f;
+   value.vector[1] = -0.5f;
+   value.vector[2] = 0.75f;
+   return value;
+}
+
+static void test_default_external_and_authorization(void)
+{
+   search_state_t internal = {.first_id = 10}, external = {.first_id = 20};
+   auth_state_t auth = {.reject_id = 11};
+   aimee_db3_route_t route;
+   assert(aimee_db3_route_init(&route, search, &internal, authorize, &auth) == 0);
+   aimee_db3_search_request_t req = request();
+   aimee_db3_search_outcome_t out;
+
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_OK);
+   assert(out.route == AIMEE_DB3_ROUTE_DEFAULT_PGVECTOR && out.selected_principal == 0);
+   assert(internal.calls == 1 && external.calls == 0 && out.reply.count == 2);
+   assert(out.reply.candidates[0].point_id == 10 && out.reply.candidates[1].point_id == 12);
+
+   auth.reject_id = 21;
+   assert(aimee_db3_route_select(&route, 66, 1, 0, search, &external) == 0);
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_OK);
+   assert(out.route == AIMEE_DB3_ROUTE_EXTERNAL && out.selected_principal == 66);
+   assert(internal.calls == 1 && external.calls == 1 && out.reply.count == 2);
+   assert(out.reply.candidates[0].point_id == 20 && out.reply.candidates[1].point_id == 22);
+
+   aimee_db3_route_clear(&route);
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_OK);
+   assert(out.route == AIMEE_DB3_ROUTE_DEFAULT_PGVECTOR && internal.calls == 2);
+}
+
+static void test_fail_closed_and_explicit_fallback(void)
+{
+   search_state_t internal = {.first_id = 10}, external = {.first_id = 20, .mode = 1};
+   auth_state_t auth = {.reject_id = -1};
+   aimee_db3_route_t route;
+   aimee_db3_search_request_t req = request();
+   aimee_db3_search_outcome_t out;
+   assert(aimee_db3_route_init(&route, search, &internal, authorize, &auth) == 0);
+
+   assert(aimee_db3_route_select(&route, 66, 0, 0, search, &external) == 0);
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_UNAVAILABLE);
+   assert(out.route == AIMEE_DB3_ROUTE_EXTERNAL && out.external_error == AIMEE_DB3_UNAVAILABLE);
+   assert(internal.calls == 0 && external.calls == 0);
+
+   assert(aimee_db3_route_select(&route, 66, 1, 0, search, &external) == 0);
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_PROVIDER_FAILURE);
+   assert(internal.calls == 0 && external.calls == 1);
+
+   assert(aimee_db3_route_select(&route, 66, 1, 1, search, &external) == 0);
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_OK);
+   assert(out.route == AIMEE_DB3_ROUTE_EXPLICIT_FALLBACK);
+   assert(out.external_error == AIMEE_DB3_PROVIDER_FAILURE);
+   assert(internal.calls == 1 && external.calls == 2);
+
+   external.mode = 3;
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_OK);
+   assert(out.route == AIMEE_DB3_ROUTE_EXPLICIT_FALLBACK);
+   assert(out.external_error == AIMEE_DB3_INVALID_RESPONSE);
+   assert(internal.calls == 2 && external.calls == 3);
+
+   route.fallback_enabled = 0;
+   for (int mode = 2; mode <= 5; ++mode)
+   {
+      external.mode = mode;
+      assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_INVALID_RESPONSE);
+      assert(out.reply.count == 3 || mode == 2);
+   }
+
+   external.mode = 0;
+   auth.fail = 1;
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_INTERNAL);
+}
+
+static void test_invalid_requests(void)
+{
+   search_state_t internal = {.first_id = 1};
+   auth_state_t auth = {0};
+   aimee_db3_route_t route;
+   aimee_db3_search_outcome_t out;
+   assert(aimee_db3_route_init(&route, search, &internal, authorize, &auth) == 0);
+   aimee_db3_search_request_t req = request();
+
+   req.vector[1] = INFINITY;
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_INVALID_REQUEST);
+   req = request();
+   req.top_k = 0;
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_INVALID_REQUEST);
+   req = request();
+   req.workspace[0] = '\0';
+   req.project[0] = '\0';
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_INVALID_REQUEST);
+   req = request();
+   memset(req.record_type, 'x', sizeof(req.record_type));
+   assert(aimee_db3_memory_candidates_search(&route, &req, &out) == AIMEE_DB3_INVALID_REQUEST);
+   assert(internal.calls == 0);
+}
+
+static void test_wire_codecs(void)
+{
+   uint8_t wire[512], mutated[512];
+   size_t length = 0;
+   aimee_db3_search_request_t req = request(), decoded_req;
+   assert(aimee_db3_search_request_encode(&req, wire, sizeof(wire), &length) == 0);
+   assert(length == 36 + strlen(req.workspace) + strlen(req.project) + strlen(req.record_type) +
+                        req.dimension * sizeof(float));
+   assert(aimee_db3_search_request_decode(wire, length, &decoded_req) == 0);
+   assert(decoded_req.request_id == req.request_id && decoded_req.dimension == req.dimension);
+   assert(memcmp(decoded_req.vector, req.vector, req.dimension * sizeof(float)) == 0);
+   assert(aimee_db3_search_request_decode(wire, length - 1, &decoded_req) != 0);
+   memcpy(mutated, wire, length);
+   mutated[34] = 1;
+   assert(aimee_db3_search_request_decode(mutated, length, &decoded_req) != 0);
+   memcpy(mutated, wire, length);
+   mutated[length - 1] = 0x7f;
+   mutated[length - 2] = 0x80;
+   mutated[length - 3] = 0;
+   mutated[length - 4] = 0;
+   assert(aimee_db3_search_request_decode(mutated, length, &decoded_req) != 0);
+
+   aimee_db3_search_reply_t reply = {.request_id = req.request_id,
+                                     .generation = req.required_generation,
+                                     .count = 2,
+                                     .candidates = {{101, 0.9}, {102, 0.8}}};
+   aimee_db3_search_reply_t decoded_reply;
+   assert(aimee_db3_search_reply_encode(&reply, wire, sizeof(wire), &length) == 0);
+   assert(aimee_db3_search_reply_decode(wire, length, &decoded_reply) == 0);
+   assert(aimee_db3_search_reply_validate(&req, &decoded_reply) == 0);
+   assert(aimee_db3_search_reply_decode(wire, length - 1, &decoded_reply) != 0);
+   assert(aimee_db3_search_reply_decode(wire, length, &decoded_reply) == 0);
+   decoded_reply.candidates[1].point_id = 101;
+   assert(aimee_db3_search_reply_validate(&req, &decoded_reply) != 0);
+   assert(aimee_db3_search_reply_encode(&decoded_reply, wire, sizeof(wire), &length) != 0);
+
+   aimee_db3_apply_t apply = {.operation_id = 1001,
+                              .generation = 7,
+                              .point_id = 101,
+                              .kind = AIMEE_DB3_APPLY_UPSERT,
+                              .collection = "memory",
+                              .dimension = 3,
+                              .vector = {0.1f, 0.2f, 0.3f}};
+   aimee_db3_apply_t decoded_apply;
+   assert(aimee_db3_apply_encode(&apply, wire, sizeof(wire), &length) == 0);
+   assert(aimee_db3_apply_decode(wire, length, &decoded_apply) == 0);
+   assert(decoded_apply.operation_id == apply.operation_id && decoded_apply.dimension == 3);
+   assert(aimee_db3_apply_decode(wire, length - 1, &decoded_apply) != 0);
+   apply.vector[0] = NAN;
+   assert(aimee_db3_apply_encode(&apply, wire, sizeof(wire), &length) != 0);
+   apply.vector[0] = 0.1f;
+   apply.kind = AIMEE_DB3_APPLY_DELETE;
+   assert(aimee_db3_apply_validate(&apply) != 0);
+   apply.dimension = 0;
+   assert(aimee_db3_apply_validate(&apply) == 0);
+}
+
+int main(void)
+{
+   test_default_external_and_authorization();
+   test_fail_closed_and_explicit_fallback();
+   test_invalid_requests();
+   test_wire_codecs();
+   puts("test_db3_route: routing, fallback, revalidation, and codecs passed");
+   return 0;
+}

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -59,7 +59,19 @@
       "ctest": true,
       "make": true,
       "module": "db2",
+      "test": "src/tests/test_bus_db3.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "db2",
       "test": "src/tests/test_db2_module_contract.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "db2",
+      "test": "src/tests/test_db3_route.c"
     },
     {
       "ctest": false,


### PR DESCRIPTION
## What changed

- adds the descriptor-owned C reference route and bounded v1 codecs for DB3 memory candidate search and committed apply events
- keeps pgvector inside DB2 as the default route, with exactly one selected external read provider and explicit, observable fallback
- requires every returned candidate to pass an injected authoritative DB2 check
- proves authenticated write fanout to two provider observers, idempotent duplicate handling, and single-server read routing
- classifies all 76 current `pgvec_*` declarations into portable search, post-commit mutation, provider-local control, retained DB2 authority, or deferred analytics
- corrects the proposal's former scatter/gather contradiction and documents provider identity and activation sequencing

This is a pre-activation reference slice. The DB2 process remains disabled; it does not add a second database owner or move production callers before the complete C closure is ready.

## Validation

- 482 Python tests
- 695 native unit-test binaries
- all Go packages
- all 58 lint checks
- DB3 route and real authenticated bus tests under normal, AddressSanitizer, UBSan, and `_FORTIFY_SOURCE=3` builds
- standalone C-process export/runtime-bundle, DB2 boundary, activation, descriptor, docs, and proposal-ordering gates
- final Aimee roundtable review; concrete findings were addressed