### PR TITLE
test(db2): ratchet C link closure

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -97,6 +97,13 @@ jobs:
         run: python3 -I -S scripts/check_db3_portability.py
       - name: Test DB3 portability-audit failure modes
         run: python3 -I scripts/tests/test_check_db3_portability.py -v
+      - name: Measure DB2 C link closure
+        run: python3 -I -S scripts/check_db2_link_closure.py
+      - name: Refuse DB2 C link-closure debt growth
+        if: github.event_name == 'pull_request'
+        run: python3 -I -S scripts/check_db2_link_closure.py --no-probe --previous-ref FETCH_HEAD
+      - name: Test DB2 C link-closure failure modes
+        run: python3 -I scripts/tests/test_check_db2_link_closure.py -v
       - name: Refuse premature DB2 process activation
         run: python3 -I -S scripts/check_db2_activation.py
       - name: Test DB2 activation-gate failure modes

--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -81,6 +81,22 @@ memory-candidate operation. Its internal pgvector, external provider, and author
 checks are injected, so the route can be exhaustively tested before the private DB2 source closure is
 linked. This is not a production cutover: the module remains disabled and no provider grant ships.
 
+Link-closure audit:
+
+`link-closure-v1.json` accounts for all 141 C translation units in the private DB2 boundary. The
+probe compiles each unit, combines only those objects with a relocatable link, supplies no archive,
+shared library, helper stub, or weak definition, and records the 355 genuinely external symbols plus
+every referencing unit. Each symbol has a reviewed disposition and rationale. The current ledger
+contains 144 explicit system-link dependencies, 25 pinned vendored/generated inputs, 150 sibling or
+KB contracts to inject, and 36 support APIs to promote. The standalone-link exit condition requires
+zero entries in the latter three groups; a classified ledger alone is not enough.
+
+The gate rejects source omissions, symlinks, content drift, new unresolved symbols, changed
+references, missing evidence, and any attempt to make the probe pass through helper objects or
+libraries. Resolved symbols are also surfaced as review-required shrinkage so the ledger and its
+human-readable counts cannot silently become stale. Regeneration never activates the module or
+asserts that the C closure is complete.
+
 A review transition binds the symbol and normalized-signature hash to one closed disposition,
 family, DB3 placement, and nonempty reason. Signature drift invalidates the review. Unsupported or
 ambiguous C declarations, malformed lexical input, stale review rows, premature completeness, and

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -308,6 +308,14 @@ The migration lands in independently testable slices, but activation remains ato
 7. **S7 — C retirement.** Deploy only the Go provider, remove the C tree and C-only shims after the
    compatibility window, and prove no C DB2 object, stale grant, or fallback executable ships.
 
+This implementation is intentionally split across those ordered PRs. The current S2 owner PR adds
+the exact C link-closure audit and does not claim the C cutover, Go port, or complete DB3 runtime.
+Subsequent autonomous S2 PRs own elimination of each audited dependency cluster. S3 and S4 own the
+replayable C process and atomic ownership switch; S5 owns the deployable provider-neutral DB3
+descriptor, grants, pgvector adapter, and external-provider conformance; S6 owns the aimee-kb Go
+implementation and parity switch. Pulling any of those later owners into this audit PR would violate
+the required C-first ordering and activate an unproven partial closure.
+
 Material changes to operation ownership, fallback semantics, observer selection, or the activation
 boundary return to roundtable review. Mechanical catalog additions follow the frozen rules above.
 
@@ -376,6 +384,15 @@ Audit the 297 consumers by runtime placement before conversion:
 The compatibility headers keep existing typed function signatures only while a consumer group is
 being converted. They contain codecs, never SQL or connection access. A generated manifest accounts
 for all 967 old include directives and fails on an unclassified or newly introduced one.
+
+Before changing dependency clusters, a descriptor-owned link-closure contract freezes every DB2 C
+translation unit and the external symbols left after a no-library relocatable link. The probe may
+resolve DB2-to-DB2 references only; helper objects, weak definitions, archives, shared libraries, and
+transitive core links are forbidden. Every remaining symbol records its referencing units, reviewed
+disposition, and rationale. New debt fails immediately, while resolved debt requires an explicit
+baseline update. This is a migration ledger, not standalone-readiness evidence: S2 exits only when
+the complete source set links through declared system dependencies and bounded injected contracts
+without the monolithic core.
 
 ### 4.3 Supervision and atomic activation
 

--- a/scripts/check_db2_link_closure.py
+++ b/scripts/check_db2_link_closure.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Measure and ratchet the legacy DB2 C link-closure gap.
+
+The probe compiles every C translation unit in the module-owned DB2 boundary,
+combines only those objects with a relocatable link, and records the remaining
+undefined symbols.  It deliberately supplies no helper objects or libraries:
+the result is evidence of work still required, not a claim that DB2 links as a
+standalone process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+import tempfile
+from typing import NoReturn
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DESCRIPTOR = Path("src/modules/db2/module.yaml")
+BOUNDARY = Path("src/modules/db2/c")
+CONTRACT = Path("src/modules/db2/eventcontract/link-closure-v1.json")
+SCHEMA_VERSION = 1
+DISPOSITIONS = {
+    "portable-core-promotion",
+    "descriptor-owned-copy/generated-input",
+    "injected-module-contract",
+    "system-link",
+    "private-implementation",
+    "remove/dead",
+}
+SYMBOL = re.compile(r"^[A-Za-z_][A-Za-z0-9_.$@]*$")
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+# Measure source-level ABI dependencies, not distro-specific compiler hardening
+# thunks. Production builds retain their normal fortify and stack-protector policy.
+PROBE_FLAGS = (
+    "-fno-lto -fno-common -fno-stack-protector "
+    "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
+)
+SYSTEM_PREFIXES = ("PQ", "EVP_", "OPENSSL_", "RAND_", "SHA", "CRYPTO_")
+INJECTED_PREFIXES = (
+    "anti_pattern_", "api_", "audit_", "code_", "cochange_", "config_", "css_",
+    "db1_", "kb_", "learning_", "memory_", "module_", "vault_", "wfe_",
+)
+SYSTEM_SYMBOLS = {
+    "_GLOBAL_OFFSET_TABLE_", "_exit", "abort", "accept", "atoi", "atoll", "bind",
+    "calloc", "clock_gettime", "close", "connect", "dlclose", "dlopen", "dlsym",
+    "difftime", "exp", "fclose", "fcntl", "fflush", "fgets", "fopen", "fprintf", "fputc",
+    "fputs", "fread",
+    "free", "fseek", "ftell", "fwrite", "getenv", "getpid", "gmtime", "gmtime_r",
+    "htonl", "htons", "inet_ntop", "inet_pton", "listen", "log10", "malloc", "memchr", "memcmp",
+    "memcpy", "memmove", "memset", "mktime", "nanosleep", "ntohl", "ntohs", "open",
+    "poll", "pthread_cond_broadcast", "pthread_cond_destroy", "pthread_cond_init",
+    "pthread_cond_signal", "pthread_cond_timedwait", "pthread_cond_wait", "pthread_create",
+    "pthread_equal", "pthread_getspecific", "pthread_join", "pthread_key_create",
+    "pthread_mutex_destroy", "pthread_mutex_init", "pthread_mutex_lock",
+    "pthread_mutex_trylock", "pthread_mutex_unlock", "pthread_once", "pthread_self",
+    "pthread_setspecific", "qsort",
+    "read", "realloc", "realpath", "recv", "select", "send", "setsockopt", "shutdown", "sleep",
+    "snprintf", "socket", "sqlite3_close", "sqlite3_errmsg", "sqlite3_exec", "sqlite3_free",
+    "sqlite3_open", "stat", "stderr", "strcasecmp", "strcasestr", "strchr", "strcmp", "strcpy",
+    "strcspn", "strdup", "strerror",
+    "strftime", "strlen", "strncasecmp", "strncat", "strncmp", "strncpy", "strnlen",
+    "strrchr", "strstr", "strtod", "strtok_r", "strtol", "strtoll", "time", "timegm",
+    "tolower", "toupper", "unlink", "usleep", "vsnprintf", "write",
+}
+
+
+class ClosureError(ValueError):
+    """A fail-closed link-closure invariant."""
+
+
+def fail(rule: str, message: str) -> NoReturn:
+    raise ClosureError(f"rule={rule}: {message}")
+
+
+def _loads(raw: bytes, label: str) -> object:
+    def unique(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                fail("json-duplicate-key", f"{label}: duplicate key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_constant(token: str) -> NoReturn:
+        fail("json-number-domain", f"{label}: forbidden number {token!r}")
+
+    if raw.startswith(b"\xef\xbb\xbf"):
+        fail("json-bom", f"{label} begins with a UTF-8 BOM")
+    try:
+        return json.loads(
+            raw.decode("utf-8", "strict"),
+            object_pairs_hook=unique,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        fail("json-parse", f"cannot parse {label}: {exc}")
+
+
+def _load(root: Path, relative: Path) -> object:
+    path = root / relative
+    try:
+        if path.is_symlink() or not path.is_file():
+            fail("input", f"{relative} must be a regular non-symlink file")
+        return _loads(path.read_bytes(), str(relative))
+    except OSError as exc:
+        fail("input", f"cannot read {relative}: {exc}")
+
+
+def _safe_file(root: Path, raw: str, boundary: Path = BOUNDARY) -> Path:
+    pure = PurePosixPath(raw)
+    if (not raw or "\\" in raw or pure.is_absolute() or "." in pure.parts or
+            ".." in pure.parts or pure.as_posix() != raw):
+        fail("source-path", f"invalid repository-relative source path {raw!r}")
+    expected = PurePosixPath(boundary.as_posix())
+    try:
+        pure.relative_to(expected)
+    except ValueError:
+        fail("source-boundary", f"source is outside {boundary}: {raw}")
+    path = root.joinpath(*pure.parts)
+    try:
+        resolved = path.resolve()
+        resolved.relative_to(root.resolve())
+    except (OSError, ValueError):
+        fail("source-path", f"source escapes repository: {raw}")
+    if path.is_symlink() or not path.is_file() or resolved != path.absolute():
+        fail("source-file", f"source must be a regular non-symlink file: {raw}")
+    return path
+
+
+def discover_sources(root: Path) -> list[str]:
+    boundary = root / BOUNDARY
+    if boundary.is_symlink() or not boundary.is_dir():
+        fail("source-boundary", f"{BOUNDARY} must be a real directory")
+    result: list[str] = []
+    for path in sorted(boundary.iterdir()):
+        if path.suffix != ".c":
+            continue
+        relative = path.relative_to(root).as_posix()
+        _safe_file(root, relative)
+        result.append(relative)
+    if not result:
+        fail("source-empty", "DB2 C boundary contains no translation units")
+    return result
+
+
+def source_fingerprint(root: Path, sources: list[str]) -> str:
+    digest = hashlib.sha256()
+    for raw in sources:
+        path = _safe_file(root, raw)
+        digest.update(raw.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _run(command: list[str], cwd: Path) -> str:
+    try:
+        completed = subprocess.run(
+            command, cwd=cwd, check=False, text=True, encoding="utf-8",
+            errors="strict", stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    except (OSError, UnicodeError) as exc:
+        fail("probe-exec", f"cannot execute {command[0]}: {exc}")
+    if completed.returncode:
+        detail = (completed.stderr or completed.stdout).strip()
+        fail("probe-command", f"{command[0]} exited {completed.returncode}: {detail}")
+    return completed.stdout
+
+
+def _nm_undefined(output: str) -> set[str]:
+    result: set[str] = set()
+    for line in output.splitlines():
+        fields = line.split()
+        if not fields:
+            continue
+        candidate = fields[0]
+        if candidate.endswith(":") or not SYMBOL.fullmatch(candidate):
+            fail("probe-nm", f"unexpected nm undefined-symbol row {line!r}")
+        result.add(candidate)
+    return result
+
+
+def probe(root: Path, sources: list[str]) -> dict[str, list[str]]:
+    """Compile DB2 objects and return truly external symbols with their users."""
+    src_root = root / "src"
+    with tempfile.TemporaryDirectory(prefix="db2-link-closure-") as raw_tmp:
+        tmp = Path(raw_tmp)
+        targets = [str(tmp / "db2" / (PurePosixPath(item).stem + ".o")) for item in sources]
+        command = [
+            "make", "-s", f"OBJDIR={tmp}", f"EXTRA_C_FLAGS={PROBE_FLAGS}", *targets,
+        ]
+        _run(command, src_root)
+        objects = [tmp / "db2" / (PurePosixPath(item).stem + ".o") for item in sources]
+        missing = [str(path) for path in objects if not path.is_file() or path.is_symlink()]
+        if missing:
+            fail("probe-object", f"compiler did not create expected objects: {missing[:3]}")
+
+        aggregate = tmp / "db2-link-closure.o"
+        # A relocatable link resolves DB2-to-DB2 references but accepts external
+        # references.  No archive, shared object, helper stub, or weak definition
+        # is supplied, so dependencies cannot disappear transitively.
+        _run(["cc", "-r", "-o", str(aggregate), *map(str, objects)], src_root)
+        external = _nm_undefined(_run(["nm", "-u", "--format=posix", str(aggregate)], src_root))
+        references: dict[str, list[str]] = {symbol: [] for symbol in external}
+        for raw, obj in zip(sources, objects, strict=True):
+            for symbol in _nm_undefined(
+                    _run(["nm", "-u", "--format=posix", str(obj)], src_root)):
+                if symbol in references:
+                    references[symbol].append(raw)
+        missing_references = sorted(symbol for symbol, rows in references.items() if not rows)
+        if missing_references:
+            fail("probe-reference", f"symbols have no referencing unit: {missing_references}")
+        return {symbol: sorted(rows) for symbol, rows in sorted(references.items())}
+
+
+def classify(symbol: str) -> tuple[str, str]:
+    """Return a conservative reviewed starting disposition and its rationale."""
+    if symbol.startswith("__") or symbol in SYSTEM_SYMBOLS or symbol.startswith(SYSTEM_PREFIXES):
+        return (
+            "system-link",
+            "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an "
+            "explicit descriptor system dependency.",
+        )
+    if symbol.startswith("cJSON_"):
+        return (
+            "descriptor-owned-copy/generated-input",
+            "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned "
+            "vendored source rather than inherit a monolithic-core object.",
+        )
+    if symbol.startswith(INJECTED_PREFIXES):
+        return (
+            "injected-module-contract",
+            "The symbol belongs to a KB or sibling-module surface; replace the direct call with an "
+            "injected bounded contract before standalone linking.",
+        )
+    return (
+        "portable-core-promotion",
+        "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable "
+        "API or reclassify with stronger owner evidence before closure.",
+    )
+
+
+def build_contract(root: Path) -> dict[str, object]:
+    sources = discover_sources(root)
+    unresolved = probe(root, sources)
+    rows: list[dict[str, object]] = []
+    counts = {name: 0 for name in sorted(DISPOSITIONS)}
+    for symbol, references in unresolved.items():
+        disposition, evidence = classify(symbol)
+        counts[disposition] += 1
+        rows.append({
+            "symbol": symbol,
+            "references": references,
+            "disposition": disposition,
+            "evidence": evidence,
+        })
+    revision = _run(["git", "rev-parse", "HEAD"], root).strip()
+    if not REVISION.fullmatch(revision):
+        fail("contract-revision", "git did not return a lowercase 40-hex revision")
+    result: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "module": "db2",
+        "source_revision": revision,
+        "source_fingerprint": source_fingerprint(root, sources),
+        "probe": {
+            "compile_driver": "src/Makefile",
+            "extra_c_flags": PROBE_FLAGS,
+            "link_mode": "relocatable-no-libraries",
+            "helper_objects": [],
+            "libraries": [],
+        },
+        "translation_units": sources,
+        "unresolved": rows,
+        "summary": {
+            "translation_units": len(sources),
+            "unresolved_symbols": len(rows),
+            "dispositions": counts,
+        },
+    }
+    encoded = json.dumps(
+        result, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+    ).encode("utf-8")
+    result["fingerprint"] = hashlib.sha256(encoded).hexdigest()
+    return result
+
+
+def _string_list(value: object, label: str, *, symbols: bool = False) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        fail("contract-shape", f"{label} must be a non-empty string array")
+    result = list(value)
+    if result != sorted(set(result)):
+        fail("contract-order", f"{label} must be sorted and unique")
+    if symbols and any(not SYMBOL.fullmatch(item) for item in result):
+        fail("contract-symbol", f"{label} contains an invalid symbol")
+    return result
+
+
+def validate_contract(
+    root: Path, value: object, *, check_files: bool = True
+) -> tuple[list[str], dict[str, dict[str, object]]]:
+    if not isinstance(value, dict):
+        fail("contract-shape", "closure contract must be an object")
+    required = {
+        "schema_version", "module", "source_revision", "source_fingerprint",
+        "probe", "translation_units", "unresolved", "summary", "fingerprint",
+    }
+    if set(value) != required:
+        fail("contract-keys", f"keys mismatch: expected={sorted(required)}, actual={sorted(value)}")
+    if value["schema_version"] != SCHEMA_VERSION or value["module"] != "db2":
+        fail("contract-version", "closure contract must be schema v1 for db2")
+    if (not isinstance(value["source_revision"], str) or
+            not REVISION.fullmatch(value["source_revision"])):
+        fail("contract-revision", "source_revision must be a lowercase 40-hex commit")
+    if not isinstance(value["source_fingerprint"], str) or not re.fullmatch(
+            r"[0-9a-f]{64}", value["source_fingerprint"]):
+        fail("contract-fingerprint", "source_fingerprint must be lowercase SHA-256")
+    probe_value = value["probe"]
+    expected_probe = {
+        "compile_driver": "src/Makefile",
+        "extra_c_flags": PROBE_FLAGS,
+        "link_mode": "relocatable-no-libraries",
+        "helper_objects": [],
+        "libraries": [],
+    }
+    if probe_value != expected_probe:
+        fail("probe-policy", "probe must use the frozen no-library/no-helper policy")
+    units = _string_list(value["translation_units"], "translation_units")
+    if check_files:
+        for item in units:
+            _safe_file(root, item)
+
+    unresolved_value = value["unresolved"]
+    if not isinstance(unresolved_value, list) or not unresolved_value:
+        fail("contract-shape", "unresolved must be a non-empty array until closure is complete")
+    rows: dict[str, dict[str, object]] = {}
+    previous = ""
+    for index, row in enumerate(unresolved_value):
+        if not isinstance(row, dict) or set(row) != {
+                "symbol", "references", "disposition", "evidence"}:
+            fail("unresolved-shape", f"unresolved[{index}] has invalid keys")
+        symbol = row["symbol"]
+        if not isinstance(symbol, str) or not SYMBOL.fullmatch(symbol):
+            fail("contract-symbol", f"unresolved[{index}] has invalid symbol")
+        if symbol <= previous:
+            fail("unresolved-order", "unresolved rows must be sorted and unique")
+        previous = symbol
+        references = _string_list(row["references"], f"unresolved[{index}].references")
+        if any(item not in units for item in references):
+            fail("unresolved-reference", f"{symbol} references an undeclared translation unit")
+        if row["disposition"] not in DISPOSITIONS:
+            fail("unresolved-disposition", f"{symbol} has invalid disposition")
+        evidence = row["evidence"]
+        if not isinstance(evidence, str) or len(evidence.strip()) < 12:
+            fail("unresolved-evidence", f"{symbol} requires concise reviewable evidence")
+        rows[symbol] = row
+
+    summary = value["summary"]
+    if not isinstance(summary, dict) or set(summary) != {
+            "translation_units", "unresolved_symbols", "dispositions"}:
+        fail("summary-shape", "summary has invalid keys")
+    counts = {name: 0 for name in sorted(DISPOSITIONS)}
+    for row in rows.values():
+        counts[str(row["disposition"])] += 1
+    expected_summary = {
+        "translation_units": len(units),
+        "unresolved_symbols": len(rows),
+        "dispositions": counts,
+    }
+    if summary != expected_summary:
+        fail("summary-drift", f"summary mismatch: expected={expected_summary}")
+
+    fingerprint_payload = dict(value)
+    fingerprint = fingerprint_payload.pop("fingerprint")
+    if not isinstance(fingerprint, str) or not re.fullmatch(r"[0-9a-f]{64}", fingerprint):
+        fail("contract-fingerprint", "fingerprint must be lowercase SHA-256")
+    encoded = json.dumps(
+        fingerprint_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+    ).encode("utf-8")
+    expected_fingerprint = hashlib.sha256(encoded).hexdigest()
+    if fingerprint != expected_fingerprint:
+        fail("contract-fingerprint", "contract content fingerprint does not match")
+    return units, rows
+
+
+def check(root: Path, *, run_probe: bool = True) -> None:
+    descriptor = _load(root, DESCRIPTOR)
+    if not isinstance(descriptor, dict) or not isinstance(descriptor.get("contracts"), list):
+        fail("descriptor", "DB2 descriptor has no contracts array")
+    if CONTRACT.as_posix() not in descriptor["contracts"]:
+        fail("descriptor-contract", f"DB2 descriptor does not own {CONTRACT}")
+    contract = _load(root, CONTRACT)
+    units, rows = validate_contract(root, contract)
+    discovered = discover_sources(root)
+    if units != discovered:
+        missing = sorted(set(discovered) - set(units))
+        extra = sorted(set(units) - set(discovered))
+        fail("source-closure", f"translation-unit mismatch; missing={missing}, extra={extra}")
+    assert isinstance(contract, dict)
+    actual_source_fingerprint = source_fingerprint(root, units)
+    if contract["source_fingerprint"] != actual_source_fingerprint:
+        fail(
+            "source-fingerprint",
+            "DB2 translation-unit content changed; regenerate and review closure",
+        )
+    if run_probe:
+        actual = probe(root, units)
+        expected = {symbol: list(row["references"]) for symbol, row in rows.items()}
+        if actual != expected:
+            added = sorted(set(actual) - set(expected))
+            removed = sorted(set(expected) - set(actual))
+            changed = sorted(symbol for symbol in set(actual) & set(expected)
+                             if actual[symbol] != expected[symbol])
+            fail("unresolved-drift",
+                 f"closure changed; added={added}, removed={removed}, references_changed={changed}")
+
+
+def compare_contracts(root: Path, previous: object, current: object) -> None:
+    previous_units, previous_rows = validate_contract(root, previous, check_files=False)
+    current_units, current_rows = validate_contract(root, current)
+    added_units = sorted(set(current_units) - set(previous_units))
+    if added_units:
+        fail("previous-source-growth", f"new DB2 translation units are forbidden: {added_units}")
+    added_symbols = sorted(set(current_rows) - set(previous_rows))
+    if added_symbols:
+        fail("previous-symbol-growth", f"new unresolved symbols are forbidden: {added_symbols}")
+    expanded: list[str] = []
+    for symbol in sorted(set(current_rows) & set(previous_rows)):
+        before = set(previous_rows[symbol]["references"])
+        after = set(current_rows[symbol]["references"])
+        if not after <= before:
+            expanded.append(symbol)
+    if expanded:
+        fail("previous-reference-growth", f"unresolved reference sets grew: {expanded}")
+
+
+def check_previous(root: Path, ref: str, current: object) -> None:
+    """Reject closure-debt growth even when the checked contract was regenerated."""
+    if not ref or ref.startswith("-") or any(char.isspace() for char in ref):
+        fail("previous-ref", f"invalid previous ref {ref!r}")
+    _run(["git", "rev-parse", "--verify", f"{ref}^{{commit}}"], root)
+    previous_paths = _run(
+        ["git", "ls-tree", "--name-only", ref, "--", CONTRACT.as_posix()], root
+    ).splitlines()
+    if not previous_paths:
+        # The first contract-introduction PR has no predecessor to compare.
+        return
+    if previous_paths != [CONTRACT.as_posix()]:
+        fail("previous-contract", f"unexpected contract paths at {ref}: {previous_paths}")
+    raw = _run(["git", "show", f"{ref}:{CONTRACT.as_posix()}"], root).encode("utf-8")
+    compare_contracts(root, _loads(raw, f"{ref}:{CONTRACT}"), current)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-probe", action="store_true", help="validate metadata only")
+    parser.add_argument("--write-contract", action="store_true",
+                        help="regenerate the reviewed closure contract")
+    parser.add_argument("--previous-ref", help="reject debt growth relative to a git ref")
+    args = parser.parse_args()
+    try:
+        if args.write_contract:
+            value = build_contract(ROOT)
+            path = ROOT / CONTRACT
+            path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n",
+                            encoding="utf-8")
+            print(f"check_db2_link_closure: wrote {CONTRACT}")
+            return 0
+        check(ROOT, run_probe=not args.no_probe)
+        if args.previous_ref:
+            check_previous(ROOT, args.previous_ref, _load(ROOT, CONTRACT))
+    except ClosureError as exc:
+        print(f"check_db2_link_closure: error: {exc}", file=sys.stderr)
+        return 1
+    print("check_db2_link_closure: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_db2_link_closure.py
+++ b/scripts/tests/test_check_db2_link_closure.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "check_db2_link_closure", REPO / "scripts/check_db2_link_closure.py"
+)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+class LinkClosureTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "src/modules/db2/c").mkdir(parents=True)
+        (self.root / "src/modules/db2/eventcontract").mkdir(parents=True)
+        (self.root / "src/modules/db2/c/a.c").write_text(
+            "extern int outside(void);\nint a(void) { return outside(); }\n", encoding="utf-8"
+        )
+        self.contract = self._contract()
+        self._write_all()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _contract(self) -> dict[str, object]:
+        sources = ["src/modules/db2/c/a.c"]
+        result: dict[str, object] = {
+            "schema_version": 1,
+            "module": "db2",
+            "source_revision": "a" * 40,
+            "source_fingerprint": checker.source_fingerprint(self.root, sources),
+            "probe": {
+                "compile_driver": "src/Makefile",
+                "extra_c_flags": checker.PROBE_FLAGS,
+                "link_mode": "relocatable-no-libraries",
+                "helper_objects": [],
+                "libraries": [],
+            },
+            "translation_units": sources,
+            "unresolved": [{
+                "symbol": "outside",
+                "references": sources,
+                "disposition": "portable-core-promotion",
+                "evidence": "Fixture-owned unresolved support dependency.",
+            }],
+            "summary": {
+                "translation_units": 1,
+                "unresolved_symbols": 1,
+                "dispositions": {
+                    name: int(name == "portable-core-promotion")
+                    for name in sorted(checker.DISPOSITIONS)
+                },
+            },
+        }
+        self._fingerprint(result)
+        return result
+
+    @staticmethod
+    def _fingerprint(value: dict[str, object]) -> None:
+        value.pop("fingerprint", None)
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+        value["fingerprint"] = hashlib.sha256(encoded).hexdigest()
+
+    def _write_all(self) -> None:
+        descriptor = {"contracts": [checker.CONTRACT.as_posix()]}
+        (self.root / checker.DESCRIPTOR).write_text(json.dumps(descriptor), encoding="utf-8")
+        (self.root / checker.CONTRACT).write_text(json.dumps(self.contract), encoding="utf-8")
+
+    def _rewrite(self) -> None:
+        self._fingerprint(self.contract)
+        (self.root / checker.CONTRACT).write_text(json.dumps(self.contract), encoding="utf-8")
+
+    def _refresh_summary(self, value: dict[str, object]) -> None:
+        rows = value["unresolved"]
+        counts = {name: 0 for name in sorted(checker.DISPOSITIONS)}
+        for row in rows:  # type: ignore[union-attr]
+            counts[row["disposition"]] += 1
+        value["summary"] = {
+            "translation_units": len(value["translation_units"]),  # type: ignore[arg-type]
+            "unresolved_symbols": len(rows),  # type: ignore[arg-type]
+            "dispositions": counts,
+        }
+        self._fingerprint(value)
+
+    def test_valid_metadata(self) -> None:
+        checker.check(self.root, run_probe=False)
+
+    def test_duplicate_json_key_fails(self) -> None:
+        (self.root / checker.DESCRIPTOR).write_text(
+            '{"contracts":[],"contracts":[]}', encoding="utf-8"
+        )
+        with self.assertRaisesRegex(checker.ClosureError, "json-duplicate-key"):
+            checker.check(self.root, run_probe=False)
+
+    def test_symlink_source_fails(self) -> None:
+        source = self.root / "src/modules/db2/c/a.c"
+        target = self.root / "target.c"
+        source.rename(target)
+        source.symlink_to(target)
+        with self.assertRaisesRegex(checker.ClosureError, "source-file"):
+            checker.check(self.root, run_probe=False)
+
+    def test_path_escape_fails(self) -> None:
+        self.contract["translation_units"] = ["../outside.c"]
+        self._rewrite()
+        with self.assertRaisesRegex(checker.ClosureError, "source-path"):
+            checker.check(self.root, run_probe=False)
+
+    def test_omitted_source_fails(self) -> None:
+        (self.root / "src/modules/db2/c/b.c").write_text("int b;\n", encoding="utf-8")
+        with self.assertRaisesRegex(checker.ClosureError, "source-closure"):
+            checker.check(self.root, run_probe=False)
+
+    def test_undeclared_missing_source_fails(self) -> None:
+        self.contract["translation_units"] = [
+            "src/modules/db2/c/a.c", "src/modules/db2/c/missing.c"
+        ]
+        self._rewrite()
+        with self.assertRaisesRegex(checker.ClosureError, "source-file"):
+            checker.check(self.root, run_probe=False)
+
+    def test_duplicate_source_fails(self) -> None:
+        self.contract["translation_units"] = [
+            "src/modules/db2/c/a.c", "src/modules/db2/c/a.c"
+        ]
+        self._rewrite()
+        with self.assertRaisesRegex(checker.ClosureError, "contract-order"):
+            checker.check(self.root, run_probe=False)
+
+    def test_source_fingerprint_drift_fails(self) -> None:
+        (self.root / "src/modules/db2/c/a.c").write_text("int changed;\n", encoding="utf-8")
+        with self.assertRaisesRegex(checker.ClosureError, "source-fingerprint"):
+            checker.check(self.root, run_probe=False)
+
+    def test_invalid_disposition_fails(self) -> None:
+        self.contract["unresolved"][0]["disposition"] = "guess"  # type: ignore[index]
+        self._rewrite()
+        with self.assertRaisesRegex(checker.ClosureError, "unresolved-disposition"):
+            checker.check(self.root, run_probe=False)
+
+    def test_missing_evidence_fails(self) -> None:
+        self.contract["unresolved"][0]["evidence"] = "short"  # type: ignore[index]
+        self._rewrite()
+        with self.assertRaisesRegex(checker.ClosureError, "unresolved-evidence"):
+            checker.check(self.root, run_probe=False)
+
+    def test_helper_object_policy_fails(self) -> None:
+        self.contract["probe"]["helper_objects"] = ["core.a"]  # type: ignore[index]
+        self._rewrite()
+        with self.assertRaisesRegex(checker.ClosureError, "probe-policy"):
+            checker.check(self.root, run_probe=False)
+
+    def test_library_policy_fails(self) -> None:
+        self.contract["probe"]["libraries"] = ["aimee-core"]  # type: ignore[index]
+        self._rewrite()
+        with self.assertRaisesRegex(checker.ClosureError, "probe-policy"):
+            checker.check(self.root, run_probe=False)
+
+    def test_new_unresolved_symbol_fails(self) -> None:
+        actual = {"outside": ["src/modules/db2/c/a.c"], "new_symbol": ["src/modules/db2/c/a.c"]}
+        with mock.patch.object(checker, "probe", return_value=actual):
+            with self.assertRaisesRegex(checker.ClosureError, "new_symbol"):
+                checker.check(self.root)
+
+    def test_resolved_symbol_shrinkage_is_reported_for_review(self) -> None:
+        with mock.patch.object(checker, "probe", return_value={}):
+            with self.assertRaisesRegex(checker.ClosureError, r"removed=\['outside'\]"):
+                checker.check(self.root)
+
+    def test_reference_change_fails(self) -> None:
+        actual = {"outside": ["src/modules/db2/c/b.c"]}
+        with mock.patch.object(checker, "probe", return_value=actual):
+            with self.assertRaisesRegex(checker.ClosureError, "references_changed"):
+                checker.check(self.root)
+
+    def test_previous_contract_rejects_new_symbol(self) -> None:
+        previous = copy.deepcopy(self.contract)
+        current = copy.deepcopy(self.contract)
+        current["unresolved"].append({  # type: ignore[union-attr]
+            "symbol": "z_new",
+            "references": ["src/modules/db2/c/a.c"],
+            "disposition": "portable-core-promotion",
+            "evidence": "A new unresolved fixture dependency.",
+        })
+        self._refresh_summary(current)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-symbol-growth"):
+            checker.compare_contracts(self.root, previous, current)
+
+    def test_previous_contract_rejects_new_translation_unit(self) -> None:
+        (self.root / "src/modules/db2/c/b.c").write_text("int b;\n", encoding="utf-8")
+        previous = copy.deepcopy(self.contract)
+        current = copy.deepcopy(self.contract)
+        current["translation_units"] = [
+            "src/modules/db2/c/a.c", "src/modules/db2/c/b.c"
+        ]
+        self._refresh_summary(current)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-source-growth"):
+            checker.compare_contracts(self.root, previous, current)
+
+    def test_previous_contract_allows_reviewed_symbol_removal(self) -> None:
+        previous = copy.deepcopy(self.contract)
+        previous["unresolved"].append({  # type: ignore[union-attr]
+            "symbol": "z_old",
+            "references": ["src/modules/db2/c/a.c"],
+            "disposition": "portable-core-promotion",
+            "evidence": "An old fixture dependency that was resolved.",
+        })
+        self._refresh_summary(previous)
+        checker.compare_contracts(self.root, previous, self.contract)
+
+    def test_previous_contract_rejects_reference_growth(self) -> None:
+        (self.root / "src/modules/db2/c/b.c").write_text("int b;\n", encoding="utf-8")
+        previous = copy.deepcopy(self.contract)
+        current = copy.deepcopy(self.contract)
+        for value in (previous, current):
+            value["translation_units"] = [
+                "src/modules/db2/c/a.c", "src/modules/db2/c/b.c"
+            ]
+            self._refresh_summary(value)
+        current["unresolved"][0]["references"].append(  # type: ignore[index,union-attr]
+            "src/modules/db2/c/b.c"
+        )
+        self._refresh_summary(current)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-reference-growth"):
+            checker.compare_contracts(self.root, previous, current)
+
+    def test_previous_ref_rejects_option_injection(self) -> None:
+        with self.assertRaisesRegex(checker.ClosureError, "previous-ref"):
+            checker.check_previous(self.root, "--bad", self.contract)
+
+    def test_previous_ref_allows_absent_initial_contract(self) -> None:
+        with mock.patch.object(checker, "_run", side_effect=["commit\n", ""]):
+            checker.check_previous(self.root, "base", self.contract)
+
+    def test_previous_ref_does_not_hide_contract_read_failure(self) -> None:
+        failure = checker.ClosureError("rule=probe-command: git show failed")
+        with mock.patch.object(
+            checker,
+            "_run",
+            side_effect=["commit\n", f"{checker.CONTRACT.as_posix()}\n", failure],
+        ):
+            with self.assertRaisesRegex(checker.ClosureError, "git show failed"):
+                checker.check_previous(self.root, "base", self.contract)
+
+    def test_real_no_library_probe_resolves_only_sibling_units(self) -> None:
+        (self.root / "src/modules/db2/c/b.c").write_text(
+            "int inside(void) { return 7; }\n", encoding="utf-8"
+        )
+        (self.root / "src/modules/db2/c/a.c").write_text(
+            "extern int inside(void); extern int outside(void);\n"
+            "int a(void) { return inside() + outside(); }\n", encoding="utf-8"
+        )
+        (self.root / "src/Makefile").write_text(
+            "$(OBJDIR)/db2/%.o: modules/db2/c/%.c\n"
+            "\t@mkdir -p $(dir $@)\n"
+            "\t$(CC) -c $(EXTRA_C_FLAGS) -o $@ $<\n",
+            encoding="utf-8",
+        )
+        sources = checker.discover_sources(self.root)
+        self.assertEqual(
+            checker.probe(self.root, sources),
+            {"outside": ["src/modules/db2/c/a.c"]},
+        )
+
+    def test_probe_fixture_executes_with_sanitizers_and_fortify(self) -> None:
+        source = self.root / "src/modules/db2/c/a.c"
+        source.write_text(
+            "#include <string.h>\n"
+            "extern int outside(void);\n"
+            "int a(void) { char x[8] = {0}; return outside() + (int)strlen(x); }\n",
+            encoding="utf-8",
+        )
+        harness = self.root / "harness.c"
+        harness.write_text(
+            "int a(void); int outside(void) { return 7; }\n"
+            "int main(void) { return a() == 7 ? 0 : 1; }\n",
+            encoding="utf-8",
+        )
+        output = self.root / "sanitized-fixture"
+        subprocess.run([
+            "cc", "-O1", "-g", "-fsanitize=address,undefined",
+            "-fno-omit-frame-pointer", "-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=3",
+            str(source), str(harness), "-o", str(output),
+        ], check=True)
+        subprocess.run([str(output)], check=True)
+
+    def test_real_repository_contract_metadata(self) -> None:
+        checker.check(REPO, run_probe=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,0 +1,3797 @@
+{
+  "schema_version": 1,
+  "module": "db2",
+  "source_revision": "bb3de1cdb04fbfdcdb2a146f0dcd802ee41af3f5",
+  "source_fingerprint": "c6486704635e400898dc14c7cdc41060e81e88beb0392f777e3d10bb98a3fb55",
+  "probe": {
+    "compile_driver": "src/Makefile",
+    "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
+    "link_mode": "relocatable-no-libraries",
+    "helper_objects": [],
+    "libraries": []
+  },
+  "translation_units": [
+    "src/modules/db2/c/admin_grant.c",
+    "src/modules/db2/c/agent_hints.c",
+    "src/modules/db2/c/agent_outcomes.c",
+    "src/modules/db2/c/anti_patterns.c",
+    "src/modules/db2/c/artifacts.c",
+    "src/modules/db2/c/bandit.c",
+    "src/modules/db2/c/calibration.c",
+    "src/modules/db2/c/canonical_index.c",
+    "src/modules/db2/c/code_audit.c",
+    "src/modules/db2/c/code_index.c",
+    "src/modules/db2/c/code_index_ops.c",
+    "src/modules/db2/c/code_project_lifecycle.c",
+    "src/modules/db2/c/code_projection.c",
+    "src/modules/db2/c/collab_rules.c",
+    "src/modules/db2/c/corpus_jobs.c",
+    "src/modules/db2/c/corpus_structural.c",
+    "src/modules/db2/c/cross_repo_build.c",
+    "src/modules/db2/c/cross_repo_classify.c",
+    "src/modules/db2/c/cross_repo_deps.c",
+    "src/modules/db2/c/cross_repo_identity.c",
+    "src/modules/db2/c/cross_repo_resolver.c",
+    "src/modules/db2/c/cross_repo_review.c",
+    "src/modules/db2/c/cross_repo_route.c",
+    "src/modules/db2/c/cross_repo_stats.c",
+    "src/modules/db2/c/css_graph.c",
+    "src/modules/db2/c/css_insights.c",
+    "src/modules/db2/c/css_migration.c",
+    "src/modules/db2/c/css_render.c",
+    "src/modules/db2/c/curator_gaps.c",
+    "src/modules/db2/c/curator_terms.c",
+    "src/modules/db2/c/curiosity.c",
+    "src/modules/db2/c/db2_hardening.c",
+    "src/modules/db2/c/db2_init.c",
+    "src/modules/db2/c/db2_pool.c",
+    "src/modules/db2/c/db2_reembed.c",
+    "src/modules/db2/c/db2_tenant.c",
+    "src/modules/db2/c/db2_test_shim.c",
+    "src/modules/db2/c/db2_witness_checkpoint.c",
+    "src/modules/db2/c/db2_witness_emit.c",
+    "src/modules/db2/c/db_postgres.c",
+    "src/modules/db2/c/db_schema.c",
+    "src/modules/db2/c/decision_log.c",
+    "src/modules/db2/c/demotion.c",
+    "src/modules/db2/c/enrollments.c",
+    "src/modules/db2/c/entity_edges.c",
+    "src/modules/db2/c/entity_nodes.c",
+    "src/modules/db2/c/entity_profiles.c",
+    "src/modules/db2/c/entity_registry.c",
+    "src/modules/db2/c/epistemic_directives.c",
+    "src/modules/db2/c/evidence_vectors.c",
+    "src/modules/db2/c/fact_ingest.c",
+    "src/modules/db2/c/fact_lifecycle.c",
+    "src/modules/db2/c/fact_recall.c",
+    "src/modules/db2/c/failed_queries.c",
+    "src/modules/db2/c/feature_rows.c",
+    "src/modules/db2/c/feedback.c",
+    "src/modules/db2/c/fidelity.c",
+    "src/modules/db2/c/kb_audit_worm.c",
+    "src/modules/db2/c/kb_docs.c",
+    "src/modules/db2/c/kb_maintenance.c",
+    "src/modules/db2/c/kb_payload.c",
+    "src/modules/db2/c/kb_releases.c",
+    "src/modules/db2/c/kb_runtime_state.c",
+    "src/modules/db2/c/kb_service_backend.c",
+    "src/modules/db2/c/kb_service_backend_agent.c",
+    "src/modules/db2/c/kb_service_backend_export.c",
+    "src/modules/db2/c/kb_service_backend_ingest.c",
+    "src/modules/db2/c/kb_service_backend_memory.c",
+    "src/modules/db2/c/kb_vectors.c",
+    "src/modules/db2/c/kind_lifecycle.c",
+    "src/modules/db2/c/learning.c",
+    "src/modules/db2/c/learning_synth_ops.c",
+    "src/modules/db2/c/lessons.c",
+    "src/modules/db2/c/management_action_journal.c",
+    "src/modules/db2/c/management_client_instance.c",
+    "src/modules/db2/c/management_identity_journal.c",
+    "src/modules/db2/c/management_jwks_publication.c",
+    "src/modules/db2/c/management_jwks_runtime.c",
+    "src/modules/db2/c/management_read_journal.c",
+    "src/modules/db2/c/management_status_key.c",
+    "src/modules/db2/c/management_status_provision.c",
+    "src/modules/db2/c/management_status_runtime.c",
+    "src/modules/db2/c/management_token_authority.c",
+    "src/modules/db2/c/management_token_roots.c",
+    "src/modules/db2/c/membership.c",
+    "src/modules/db2/c/memory_briefing.c",
+    "src/modules/db2/c/memory_conflicts.c",
+    "src/modules/db2/c/memory_entity_graph.c",
+    "src/modules/db2/c/memory_export.c",
+    "src/modules/db2/c/memory_health.c",
+    "src/modules/db2/c/memory_lifecycle.c",
+    "src/modules/db2/c/memory_lint.c",
+    "src/modules/db2/c/memory_payload.c",
+    "src/modules/db2/c/memory_promotion.c",
+    "src/modules/db2/c/memory_query.c",
+    "src/modules/db2/c/memory_query_bookkeeping.c",
+    "src/modules/db2/c/memory_relations.c",
+    "src/modules/db2/c/memory_row_mapper_pg.c",
+    "src/modules/db2/c/memory_scenes.c",
+    "src/modules/db2/c/memory_scope_query.c",
+    "src/modules/db2/c/memory_score_fields.c",
+    "src/modules/db2/c/memory_vectors.c",
+    "src/modules/db2/c/mining.c",
+    "src/modules/db2/c/notes.c",
+    "src/modules/db2/c/oidc_jwks.c",
+    "src/modules/db2/c/ontology_evolution.c",
+    "src/modules/db2/c/org_budget.c",
+    "src/modules/db2/c/org_egress.c",
+    "src/modules/db2/c/org_model_catalog.c",
+    "src/modules/db2/c/org_rate.c",
+    "src/modules/db2/c/org_spend.c",
+    "src/modules/db2/c/org_telemetry.c",
+    "src/modules/db2/c/org_telemetry_fmt.c",
+    "src/modules/db2/c/org_token_audit.c",
+    "src/modules/db2/c/org_vault_key_use.c",
+    "src/modules/db2/c/org_vault_rewrap.c",
+    "src/modules/db2/c/org_vault_rotation.c",
+    "src/modules/db2/c/pgvec_kb_service.c",
+    "src/modules/db2/c/pgvec_transport.c",
+    "src/modules/db2/c/pgvec_verify.c",
+    "src/modules/db2/c/project.c",
+    "src/modules/db2/c/prospective_memories.c",
+    "src/modules/db2/c/rel_types_store.c",
+    "src/modules/db2/c/report_enrichments.c",
+    "src/modules/db2/c/rules.c",
+    "src/modules/db2/c/server_registry.c",
+    "src/modules/db2/c/shadow_delta.c",
+    "src/modules/db2/c/sketch.c",
+    "src/modules/db2/c/stopwords.c",
+    "src/modules/db2/c/tasks.c",
+    "src/modules/db2/c/team.c",
+    "src/modules/db2/c/tool_registry.c",
+    "src/modules/db2/c/trace_mining.c",
+    "src/modules/db2/c/typed_facts.c",
+    "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+    "src/modules/db2/c/vault_operator_status_runtime.c",
+    "src/modules/db2/c/vault_pg.c",
+    "src/modules/db2/c/vector_index_ops.c",
+    "src/modules/db2/c/vector_status.c",
+    "src/modules/db2/c/workflow_patterns.c",
+    "src/modules/db2/c/write_tier_grant.c"
+  ],
+  "unresolved": [
+    {
+      "symbol": "CRYPTO_memcmp",
+      "references": [
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "EVP_Digest",
+      "references": [
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_jwks_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "EVP_DigestFinal_ex",
+      "references": [
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_status_provision.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "EVP_DigestInit_ex",
+      "references": [
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_status_provision.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "EVP_DigestUpdate",
+      "references": [
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_status_provision.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "EVP_MD_CTX_free",
+      "references": [
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_status_provision.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "EVP_MD_CTX_new",
+      "references": [
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_status_provision.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "EVP_sha256",
+      "references": [
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_jwks_runtime.c",
+        "src/modules/db2/c/management_status_provision.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "OPENSSL_cleanse",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQcancelCreate",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQcancelFinish",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQcancelPoll",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQcancelSocket",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQcancelStart",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQclear",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQcmdTuples",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQconnectPoll",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQconnectStartParams",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQconnectdb",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQconninfoFree",
+      "references": [
+        "src/modules/db2/c/db2_hardening.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQconninfoParse",
+      "references": [
+        "src/modules/db2/c/db2_hardening.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQconsumeInput",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQerrorMessage",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQescapeByteaConn",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQexec",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQexecParams",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQfinish",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQflush",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQfname",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQfreemem",
+      "references": [
+        "src/modules/db2/c/db2_hardening.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQftype",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQgetResult",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQgetisnull",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQgetlength",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQgetvalue",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQisBusy",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQnfields",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQntuples",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQresetPoll",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQresetStart",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQresultErrorField",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQresultErrorMessage",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQresultStatus",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQsendQuery",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQsendQueryParams",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQsetnonblocking",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQsocket",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQsslInUse",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQstatus",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQtransactionStatus",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "PQunescapeBytea",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "RAND_bytes",
+      "references": [
+        "src/modules/db2/c/enrollments.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "SHA256",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/entity_nodes.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/org_telemetry_fmt.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "_GLOBAL_OFFSET_TABLE_",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db2_tenant.c",
+        "src/modules/db2/c/db2_test_shim.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/memory_scope_query.c",
+        "src/modules/db2/c/memory_vectors.c",
+        "src/modules/db2/c/tool_registry.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__assert_fail",
+      "references": [
+        "src/modules/db2/c/db2_test_shim.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__ctype_b_loc",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/curator_terms.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/entity_registry.c",
+        "src/modules/db2/c/epistemic_directives.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/notes.c",
+        "src/modules/db2/c/prospective_memories.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__ctype_tolower_loc",
+      "references": [
+        "src/modules/db2/c/anti_patterns.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/entity_registry.c",
+        "src/modules/db2/c/epistemic_directives.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/notes.c",
+        "src/modules/db2/c/prospective_memories.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__ctype_toupper_loc",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__errno_location",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/management_read_journal.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__isoc23_sscanf",
+      "references": [
+        "src/modules/db2/c/memory_query.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__isoc23_strtoll",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__isoc99_sscanf",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/entity_edges.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "__tls_get_addr",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_tenant.c",
+        "src/modules/db2/c/memory_scope_query.c",
+        "src/modules/db2/c/memory_vectors.c",
+        "src/modules/db2/c/tool_registry.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "_exit",
+      "references": [
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "aimee_log",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_identity.c",
+        "src/modules/db2/c/cross_repo_review.c",
+        "src/modules/db2/c/cross_repo_route.c",
+        "src/modules/db2/c/cross_repo_stats.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db2_tenant.c",
+        "src/modules/db2/c/enrollments.c",
+        "src/modules/db2/c/fact_ingest.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/learning.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "anti_pattern_escalate",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "anti_pattern_extract_from_failures",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "anti_pattern_extract_from_feedback",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "api_dashboard_directives",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "api_dashboard_recall",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "api_dashboard_reminders",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "api_logs",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "api_memory_stats",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "atoi",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/pgvec_transport.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "atoll",
+      "references": [
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_releases.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "audit_worm_row_hash",
+      "references": [
+        "src/modules/db2/c/kb_audit_worm.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "cJSON_AddArrayToObject",
+      "references": [
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_AddBoolToObject",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/vector_status.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_AddItemToArray",
+      "references": [
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_ingest.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_payload.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_AddItemToObject",
+      "references": [
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_payload.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_AddNumberToObject",
+      "references": [
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_payload.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/vector_status.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_AddObjectToObject",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_AddStringToObject",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_ingest.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_payload.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/vector_status.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_CreateArray",
+      "references": [
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_ingest.c",
+        "src/modules/db2/c/memory_payload.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_CreateNumber",
+      "references": [
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_CreateObject",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_ingest.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_payload.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/vector_status.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_CreateString",
+      "references": [
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_payload.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_Delete",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_payload.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/rules.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_DeleteItemFromObjectCaseSensitive",
+      "references": [
+        "src/modules/db2/c/demotion.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_GetArrayItem",
+      "references": [
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/org_model_catalog.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_GetArraySize",
+      "references": [
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/memory_payload.c",
+        "src/modules/db2/c/org_model_catalog.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_GetObjectItemCaseSensitive",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/pgvec_transport.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_IsArray",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/org_model_catalog.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_IsBool",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_IsNumber",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_IsObject",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_IsString",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/pgvec_transport.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_IsTrue",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_Parse",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/pgvec_transport.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_ParseWithOpts",
+      "references": [
+        "src/modules/db2/c/org_model_catalog.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "cJSON_PrintUnformatted",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_payload.c",
+        "src/modules/db2/c/rules.c"
+      ],
+      "disposition": "descriptor-owned-copy/generated-input",
+      "evidence": "Implemented by src/vendor/cJSON.c; the standalone DB2 bundle must package the pinned vendored source rather than inherit a monolithic-core object."
+    },
+    {
+      "symbol": "calloc",
+      "references": [
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "clock_gettime",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/kb_maintenance.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "cochange_is_hex_sha",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "cochange_pairs_for_commit",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "code_audit_dead_exports",
+      "references": [
+        "src/modules/db2/c/code_audit.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "code_audit_find_cycles",
+      "references": [
+        "src/modules/db2/c/code_audit.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "code_import_identity",
+      "references": [
+        "src/modules/db2/c/code_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "code_import_resolves_path",
+      "references": [
+        "src/modules/db2/c/code_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "code_match_line",
+      "references": [
+        "src/modules/db2/c/code_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_audit_worm_enabled",
+      "references": [
+        "src/modules/db2/c/kb_audit_worm.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_cache_disabled",
+      "references": [
+        "src/modules/db2/c/rules.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_code_cochange_git_enabled",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_css_style_graph_enabled",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/css_migration.c",
+        "src/modules/db2/c/css_render.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_embedder_command_current",
+      "references": [
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_caller_collision_c",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_distinctiveness_v",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_graph_enabled",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_k",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_len_min",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_m",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_max_candidates",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_p_pct",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_curator_cross_repo_review_queue_max",
+      "references": [
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_pdf_vector_enabled",
+      "references": [
+        "src/modules/db2/c/kb_payload.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_kb_purge_fence_ttl_s",
+      "references": [
+        "src/modules/db2/c/kb_runtime_state.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_present",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "config_typed_facts_enabled",
+      "references": [
+        "src/modules/db2/c/css_migration.c",
+        "src/modules/db2/c/fact_ingest.c",
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "correction_behavior_to_text",
+      "references": [
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "css_analyze",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "css_extract_class_tokens",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "css_render_oracle_compare",
+      "references": [
+        "src/modules/db2/c/css_render.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "css_render_result_free",
+      "references": [
+        "src/modules/db2/c/css_render.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "css_render_snapshot_free",
+      "references": [
+        "src/modules/db2/c/css_render.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "css_render_snapshot_parse",
+      "references": [
+        "src/modules/db2/c/css_render.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "css_stylesheet_free",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "db1_stmt_cache_clear_for_sqlite",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_test_shim.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "difftime",
+      "references": [
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/entity_edges.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "dstr_appendf",
+      "references": [
+        "src/modules/db2/c/collab_rules.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "dstr_init",
+      "references": [
+        "src/modules/db2/c/collab_rules.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "dstr_steal",
+      "references": [
+        "src/modules/db2/c/collab_rules.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "exp",
+      "references": [
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/entity_edges.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "extract_calls",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "extract_definitions",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "extract_exports",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "extract_imports_sys",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "extract_routes",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "fclose",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/rules.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "fflush",
+      "references": [
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "fgets",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "fopen",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/rules.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "fprintf",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/rules.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "fputs",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "fread",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "free",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/code_projection.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/css_migration.c",
+        "src/modules/db2/c/css_render.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/db2_witness_emit.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_query.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/pgvec_verify.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "fseek",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "ftell",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "getenv",
+      "references": [
+        "src/modules/db2/c/db2_hardening.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/pgvec_transport.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "gmtime",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_export.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "gmtime_r",
+      "references": [
+        "src/modules/db2/c/bandit.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/cross_repo_review.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/entity_profiles.c",
+        "src/modules/db2/c/fact_lifecycle.c",
+        "src/modules/db2/c/kb_audit_worm.c",
+        "src/modules/db2/c/memory_conflicts.c",
+        "src/modules/db2/c/memory_health.c",
+        "src/modules/db2/c/memory_relations.c",
+        "src/modules/db2/c/ontology_evolution.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "inet_pton",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "kb_cert_serial_normalize",
+      "references": [
+        "src/modules/db2/c/enrollments.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "kb_identity_key",
+      "references": [
+        "src/modules/db2/c/db2_tenant.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "kb_identity_token_authority_record_valid",
+      "references": [
+        "src/modules/db2/c/management_token_authority.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "kb_mdl_score",
+      "references": [
+        "src/modules/db2/c/artifacts.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "kb_mgmt_token_authority_record_valid",
+      "references": [
+        "src/modules/db2/c/management_token_authority.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "kb_models_endpoint_valid",
+      "references": [
+        "src/modules/db2/c/org_model_catalog.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "kb_models_name_clean",
+      "references": [
+        "src/modules/db2/c/org_model_catalog.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "kb_models_wire_valid",
+      "references": [
+        "src/modules/db2/c/org_model_catalog.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "learning_dispatch_result_to_json",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "learning_evidence_write_event",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "learning_implicit_record_correction",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "learning_router_record_signal",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "log10",
+      "references": [
+        "src/modules/db2/c/curiosity.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "malloc",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_projection.c",
+        "src/modules/db2/c/css_migration.c",
+        "src/modules/db2/c/db2_witness_emit.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "memchr",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/management_jwks_runtime.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "memcmp",
+      "references": [
+        "src/modules/db2/c/anti_patterns.c",
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/db2_witness_emit.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_jwks_runtime.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "memmove",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/cross_repo_deps.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "memory_alerts",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_answer_evidence_decision_str",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_answer_evidence_reason_str",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_ask_query",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_ask_query_scoped",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_assemble_context",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_briefing",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_check_drift",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_collect_scopes",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_compact_windows",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_delete",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_diagnose_scoped",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_effectiveness_stats",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_embed_text",
+      "references": [
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_episode_card_generate",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_explain_match",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_extract_patterns",
+      "references": [
+        "src/modules/db2/c/fact_ingest.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_fact_gate_check",
+      "references": [
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_fact_history",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_find_facts",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_find_facts_scoped",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_find_facts_visible",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_find_facts_visible_ex",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_fold_session",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_get",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_get_context_block",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_get_entity_edges",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_get_entity_profile",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_get_episode",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_get_provenance",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_insert_ex",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_learn_style",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_link_create",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_link_delete",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_link_query",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_list",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_list_conflicts",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_maintenance_run",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_maintenance_summary_to_json",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_ontology_node_kind_to_text",
+      "references": [
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_pattern_scan_turn",
+      "references": [
+        "src/modules/db2/c/fact_ingest.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_pii_rel_sensitivity",
+      "references": [
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_pii_rel_sensitivity_batch",
+      "references": [
+        "src/modules/db2/c/fact_recall.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_pii_should_inject",
+      "references": [
+        "src/modules/db2/c/fact_recall.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_pii_turn_requests_sensitive",
+      "references": [
+        "src/modules/db2/c/fact_ingest.c",
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_primary_scope",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_prospective_complete",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_prospective_create",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_prospective_list",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_prospective_mark_triggered",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_prospective_match",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_prospective_sweep_expired",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_query_edges",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_query_health",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_recall",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_reject",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_scan_conversations",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_agent.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_scope_level_name",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_scope_visibility_rank",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_search",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_search_graph",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_search_graph_as_of",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_stats",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_supersede",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_tag_scope",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_tag_workspace",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_touch",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_update_content",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "memory_upsert_workflow",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "mktime",
+      "references": [
+        "src/modules/db2/c/entity_edges.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "nanosleep",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "now_utc",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/bandit.c",
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/code_index_ops.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/corpus_jobs.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/feature_rows.c",
+        "src/modules/db2/c/feedback.c",
+        "src/modules/db2/c/kb_docs.c",
+        "src/modules/db2/c/kb_releases.c",
+        "src/modules/db2/c/report_enrichments.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/tasks.c",
+        "src/modules/db2/c/vector_index_ops.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "parse_utc_ts",
+      "references": [
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/demotion.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "platform_get_exe_path",
+      "references": [
+        "src/modules/db2/c/kb_service_backend.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "platform_random_bytes",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_identity_journal.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "platform_random_hex",
+      "references": [
+        "src/modules/db2/c/management_read_journal.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "platform_spawn_daemon",
+      "references": [
+        "src/modules/db2/c/kb_service_backend.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "poll",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_cond_signal",
+      "references": [
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_cond_timedwait",
+      "references": [
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_create",
+      "references": [
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_equal",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_getspecific",
+      "references": [
+        "src/modules/db2/c/db2_init.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_join",
+      "references": [
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_key_create",
+      "references": [
+        "src/modules/db2/c/db2_init.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_mutex_destroy",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_mutex_init",
+      "references": [
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_mutex_lock",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/enrollments.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_mutex_trylock",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_mutex_unlock",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/enrollments.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_once",
+      "references": [
+        "src/modules/db2/c/db2_init.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_self",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "pthread_setspecific",
+      "references": [
+        "src/modules/db2/c/db2_init.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "qsort",
+      "references": [
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "realloc",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/db2_witness_emit.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_query.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "realpath",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "rel_sensitivity_to_text",
+      "references": [
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "rel_type_is_functional",
+      "references": [
+        "src/modules/db2/c/entity_edges.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "rel_type_normalize",
+      "references": [
+        "src/modules/db2/c/fact_lifecycle.c",
+        "src/modules/db2/c/ontology_evolution.c",
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "rel_types_seed_at",
+      "references": [
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "rel_types_seed_count",
+      "references": [
+        "src/modules/db2/c/rel_types_store.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "rel_types_seed_lookup",
+      "references": [
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/fact_lifecycle.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "run_cmd",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "server_mgmt_read_selector_name",
+      "references": [
+        "src/modules/db2/c/management_read_journal.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "session_briefing_render_commitments",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "session_briefing_render_directives",
+      "references": [
+        "src/modules/db2/c/kb_service_backend_memory.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "session_id",
+      "references": [
+        "src/modules/db2/c/kb_service_backend.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "shell_escape",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sketch_bloom_init",
+      "references": [
+        "src/modules/db2/c/sketch.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sketch_count_min_init",
+      "references": [
+        "src/modules/db2/c/sketch.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sketch_fnv1a",
+      "references": [
+        "src/modules/db2/c/kb_payload.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sketch_hll_add_hash",
+      "references": [
+        "src/modules/db2/c/kb_payload.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sketch_hll_init",
+      "references": [
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/sketch.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sketch_lsh_band_hash",
+      "references": [
+        "src/modules/db2/c/sketch.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sketch_minhash_init",
+      "references": [
+        "src/modules/db2/c/sketch.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "sleep",
+      "references": [
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "snprintf",
+      "references": [
+        "src/modules/db2/c/admin_grant.c",
+        "src/modules/db2/c/agent_outcomes.c",
+        "src/modules/db2/c/anti_patterns.c",
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/bandit.c",
+        "src/modules/db2/c/calibration.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/code_index_ops.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/code_projection.c",
+        "src/modules/db2/c/corpus_jobs.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_identity.c",
+        "src/modules/db2/c/cross_repo_review.c",
+        "src/modules/db2/c/cross_repo_stats.c",
+        "src/modules/db2/c/css_graph.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/css_migration.c",
+        "src/modules/db2/c/css_render.c",
+        "src/modules/db2/c/curator_gaps.c",
+        "src/modules/db2/c/curator_terms.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db2_hardening.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/db2_witness_emit.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/decision_log.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/enrollments.c",
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/entity_nodes.c",
+        "src/modules/db2/c/entity_profiles.c",
+        "src/modules/db2/c/entity_registry.c",
+        "src/modules/db2/c/epistemic_directives.c",
+        "src/modules/db2/c/evidence_vectors.c",
+        "src/modules/db2/c/fact_lifecycle.c",
+        "src/modules/db2/c/fact_recall.c",
+        "src/modules/db2/c/feature_rows.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_audit_worm.c",
+        "src/modules/db2/c/kb_docs.c",
+        "src/modules/db2/c/kb_maintenance.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_releases.c",
+        "src/modules/db2/c/kb_runtime_state.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_ingest.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/learning.c",
+        "src/modules/db2/c/learning_synth_ops.c",
+        "src/modules/db2/c/lessons.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_status_provision.c",
+        "src/modules/db2/c/management_status_runtime.c",
+        "src/modules/db2/c/management_token_roots.c",
+        "src/modules/db2/c/membership.c",
+        "src/modules/db2/c/memory_briefing.c",
+        "src/modules/db2/c/memory_conflicts.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/memory_health.c",
+        "src/modules/db2/c/memory_lifecycle.c",
+        "src/modules/db2/c/memory_lint.c",
+        "src/modules/db2/c/memory_payload.c",
+        "src/modules/db2/c/memory_promotion.c",
+        "src/modules/db2/c/memory_query.c",
+        "src/modules/db2/c/memory_query_bookkeeping.c",
+        "src/modules/db2/c/memory_relations.c",
+        "src/modules/db2/c/memory_row_mapper_pg.c",
+        "src/modules/db2/c/memory_scenes.c",
+        "src/modules/db2/c/memory_scope_query.c",
+        "src/modules/db2/c/memory_score_fields.c",
+        "src/modules/db2/c/memory_vectors.c",
+        "src/modules/db2/c/mining.c",
+        "src/modules/db2/c/notes.c",
+        "src/modules/db2/c/oidc_jwks.c",
+        "src/modules/db2/c/ontology_evolution.c",
+        "src/modules/db2/c/org_budget.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/org_rate.c",
+        "src/modules/db2/c/org_spend.c",
+        "src/modules/db2/c/org_telemetry.c",
+        "src/modules/db2/c/org_telemetry_fmt.c",
+        "src/modules/db2/c/org_vault_rotation.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/project.c",
+        "src/modules/db2/c/prospective_memories.c",
+        "src/modules/db2/c/rel_types_store.c",
+        "src/modules/db2/c/report_enrichments.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/server_registry.c",
+        "src/modules/db2/c/shadow_delta.c",
+        "src/modules/db2/c/sketch.c",
+        "src/modules/db2/c/stopwords.c",
+        "src/modules/db2/c/tasks.c",
+        "src/modules/db2/c/team.c",
+        "src/modules/db2/c/tool_registry.c",
+        "src/modules/db2/c/typed_facts.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c",
+        "src/modules/db2/c/vault_pg.c",
+        "src/modules/db2/c/vector_index_ops.c",
+        "src/modules/db2/c/workflow_patterns.c",
+        "src/modules/db2/c/write_tier_grant.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "sqlite3_close",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_test_shim.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "sqlite3_errmsg",
+      "references": [
+        "src/modules/db2/c/db_schema.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "sqlite3_exec",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_test_shim.c",
+        "src/modules/db2/c/db_schema.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "sqlite3_free",
+      "references": [
+        "src/modules/db2/c/db_schema.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "sqlite3_open",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_test_shim.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "stat",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "stderr",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strcasecmp",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/corpus_structural.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strcasestr",
+      "references": [
+        "src/modules/db2/c/corpus_structural.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strchr",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_resolver.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/kb_runtime_state.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strcmp",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/code_projection.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/corpus_jobs.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_classify.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_identity.c",
+        "src/modules/db2/c/cross_repo_resolver.c",
+        "src/modules/db2/c/cross_repo_review.c",
+        "src/modules/db2/c/cross_repo_stats.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/css_render.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db2_hardening.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db2_pool.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/enrollments.c",
+        "src/modules/db2/c/entity_registry.c",
+        "src/modules/db2/c/epistemic_directives.c",
+        "src/modules/db2/c/fact_recall.c",
+        "src/modules/db2/c/feedback.c",
+        "src/modules/db2/c/fidelity.c",
+        "src/modules/db2/c/kb_audit_worm.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_releases.c",
+        "src/modules/db2/c/kb_runtime_state.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_agent.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/kb_service_backend_ingest.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/lessons.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_jwks_runtime.c",
+        "src/modules/db2/c/management_read_journal.c",
+        "src/modules/db2/c/management_status_provision.c",
+        "src/modules/db2/c/management_status_runtime.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/management_token_roots.c",
+        "src/modules/db2/c/memory_health.c",
+        "src/modules/db2/c/memory_lifecycle.c",
+        "src/modules/db2/c/memory_query.c",
+        "src/modules/db2/c/memory_query_bookkeeping.c",
+        "src/modules/db2/c/ontology_evolution.c",
+        "src/modules/db2/c/org_budget.c",
+        "src/modules/db2/c/org_egress.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/org_telemetry_fmt.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/prospective_memories.c",
+        "src/modules/db2/c/report_enrichments.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/sketch.c",
+        "src/modules/db2/c/typed_facts.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c",
+        "src/modules/db2/c/vault_pg.c",
+        "src/modules/db2/c/write_tier_grant.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strcpy",
+      "references": [
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/corpus_jobs.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_identity.c",
+        "src/modules/db2/c/css_render.c",
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/decision_log.c",
+        "src/modules/db2/c/entity_nodes.c",
+        "src/modules/db2/c/kb_audit_worm.c",
+        "src/modules/db2/c/kb_maintenance.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/memory_lint.c",
+        "src/modules/db2/c/memory_query.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/pgvec_verify.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/shadow_delta.c",
+        "src/modules/db2/c/tasks.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strcspn",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strdup",
+      "references": [
+        "src/modules/db2/c/agent_hints.c",
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/css_render.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend_ingest.c",
+        "src/modules/db2/c/memory_query.c",
+        "src/modules/db2/c/pgvec_verify.c",
+        "src/modules/db2/c/rules.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strftime",
+      "references": [
+        "src/modules/db2/c/bandit.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/cross_repo_review.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/entity_profiles.c",
+        "src/modules/db2/c/fact_lifecycle.c",
+        "src/modules/db2/c/kb_audit_worm.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/memory_conflicts.c",
+        "src/modules/db2/c/memory_health.c",
+        "src/modules/db2/c/memory_relations.c",
+        "src/modules/db2/c/ontology_evolution.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strlen",
+      "references": [
+        "src/modules/db2/c/anti_patterns.c",
+        "src/modules/db2/c/artifacts.c",
+        "src/modules/db2/c/bandit.c",
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/collab_rules.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_identity.c",
+        "src/modules/db2/c/cross_repo_resolver.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/db2_tenant.c",
+        "src/modules/db2/c/db2_witness_checkpoint.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/enrollments.c",
+        "src/modules/db2/c/entity_nodes.c",
+        "src/modules/db2/c/epistemic_directives.c",
+        "src/modules/db2/c/fact_recall.c",
+        "src/modules/db2/c/kb_audit_worm.c",
+        "src/modules/db2/c/kb_payload.c",
+        "src/modules/db2/c/kb_service_backend_memory.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_status_key.c",
+        "src/modules/db2/c/management_status_provision.c",
+        "src/modules/db2/c/management_token_roots.c",
+        "src/modules/db2/c/memory_export.c",
+        "src/modules/db2/c/org_egress.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/org_telemetry_fmt.c",
+        "src/modules/db2/c/org_vault_key_use.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/org_vault_rotation.c",
+        "src/modules/db2/c/pgvec_transport.c",
+        "src/modules/db2/c/project.c",
+        "src/modules/db2/c/prospective_memories.c",
+        "src/modules/db2/c/rules.c",
+        "src/modules/db2/c/server_registry.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strncasecmp",
+      "references": [
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_identity.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strncat",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/corpus_structural.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strncmp",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_audit.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_resolver.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strncpy",
+      "references": [
+        "src/modules/db2/c/curator_terms.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strnlen",
+      "references": [
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/management_jwks_runtime.c",
+        "src/modules/db2/c/management_read_journal.c",
+        "src/modules/db2/c/management_status_runtime.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/org_telemetry_fmt.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strrchr",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/cross_repo_identity.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strstr",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/corpus_structural.c",
+        "src/modules/db2/c/cross_repo_build.c",
+        "src/modules/db2/c/cross_repo_deps.c",
+        "src/modules/db2/c/css_insights.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c",
+        "src/modules/db2/c/management_jwks_publication.c",
+        "src/modules/db2/c/management_status_key.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/management_token_roots.c",
+        "src/modules/db2/c/org_budget.c",
+        "src/modules/db2/c/org_model_catalog.c",
+        "src/modules/db2/c/org_rate.c",
+        "src/modules/db2/c/org_spend.c",
+        "src/modules/db2/c/org_telemetry.c",
+        "src/modules/db2/c/org_vault_key_use.c",
+        "src/modules/db2/c/vault_operator_status_runtime.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strtod",
+      "references": [
+        "src/modules/db2/c/db_postgres.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strtok_r",
+      "references": [
+        "src/modules/db2/c/canonical_index.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strtol",
+      "references": [
+        "src/modules/db2/c/db2_init.c",
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/db_schema.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "strtoll",
+      "references": [
+        "src/modules/db2/c/db_postgres.c",
+        "src/modules/db2/c/management_action_journal.c",
+        "src/modules/db2/c/management_client_instance.c",
+        "src/modules/db2/c/management_identity_journal.c",
+        "src/modules/db2/c/management_read_journal.c",
+        "src/modules/db2/c/management_token_authority.c",
+        "src/modules/db2/c/memory_query_bookkeeping.c",
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "text_sanitize_utf8",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/code_index.c",
+        "src/modules/db2/c/kb_payload.c"
+      ],
+      "disposition": "portable-core-promotion",
+      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
+    },
+    {
+      "symbol": "time",
+      "references": [
+        "src/modules/db2/c/bandit.c",
+        "src/modules/db2/c/code_project_lifecycle.c",
+        "src/modules/db2/c/cross_repo_review.c",
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/c/demotion.c",
+        "src/modules/db2/c/enrollments.c",
+        "src/modules/db2/c/entity_edges.c",
+        "src/modules/db2/c/entity_profiles.c",
+        "src/modules/db2/c/fact_lifecycle.c",
+        "src/modules/db2/c/kb_audit_worm.c",
+        "src/modules/db2/c/kb_service_backend.c",
+        "src/modules/db2/c/kb_service_backend_export.c",
+        "src/modules/db2/c/memory_conflicts.c",
+        "src/modules/db2/c/memory_health.c",
+        "src/modules/db2/c/memory_relations.c",
+        "src/modules/db2/c/ontology_evolution.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "timegm",
+      "references": [
+        "src/modules/db2/c/canonical_index.c",
+        "src/modules/db2/c/curiosity.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "tolower",
+      "references": [
+        "src/modules/db2/c/curator_terms.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "usleep",
+      "references": [
+        "src/modules/db2/c/kb_service_backend.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    },
+    {
+      "symbol": "vault_aad_build_v1_safe",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_aad_build_v2",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_crypto_random",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_dek_unwrap",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_dek_wrap",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_kek_check_verify",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_kek_check_wrap",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_mutation_budget_current",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_mutation_budget_deadline_ms",
+      "references": [
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_reseal_operation_id_from_hex",
+      "references": [
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_reseal_operation_id_to_hex",
+      "references": [
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_reseal_receipt_decode",
+      "references": [
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_reseal_receipt_digest",
+      "references": [
+        "src/modules/db2/c/org_vault_rewrap.c",
+        "src/modules/db2/c/vault_operator_rewrap_runtime.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_secret_decrypt",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_secret_encrypt",
+      "references": [
+        "src/modules/db2/c/vault_pg.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_checkpoint_digest",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_checkpoint_encode",
+      "references": [
+        "src/modules/db2/c/db2_witness_emit.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_checkpoint_sign",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_checkpoint_verify",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_export_frame",
+      "references": [
+        "src/modules/db2/c/db2_witness_emit.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_leaf_hash",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_merkle_root",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_record_digest",
+      "references": [
+        "src/modules/db2/c/db2_witness_emit.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_record_encode",
+      "references": [
+        "src/modules/db2/c/db2_witness_emit.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_shard_key_hash",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_signer_identity",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vault_witness_verify_checkpoint_run",
+      "references": [
+        "src/modules/db2/c/db2_witness_checkpoint.c"
+      ],
+      "disposition": "injected-module-contract",
+      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
+    },
+    {
+      "symbol": "vsnprintf",
+      "references": [
+        "src/modules/db2/c/db2_reembed.c"
+      ],
+      "disposition": "system-link",
+      "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
+    }
+  ],
+  "summary": {
+    "translation_units": 141,
+    "unresolved_symbols": 355,
+    "dispositions": {
+      "descriptor-owned-copy/generated-input": 25,
+      "injected-module-contract": 150,
+      "portable-core-promotion": 36,
+      "private-implementation": 0,
+      "remove/dead": 0,
+      "system-link": 144
+    }
+  },
+  "fingerprint": "c7a14b0dbfbf6daadce77a14cea0df0052716f66239e6161fb0de8112671ac77"
+}

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -21,6 +21,7 @@
   ],
   "contracts": [
     "src/modules/db2/eventcontract/declaration-review.json",
+    "src/modules/db2/eventcontract/link-closure-v1.json",
     "src/modules/db2/eventcontract/operations.json",
     "src/modules/db2/eventcontract/vector-portability.json"
   ],


### PR DESCRIPTION
## Summary

- add an exact, reviewed DB2 C link-closure contract covering all 141 module-owned translation units and 355 remaining external symbols
- classify every symbol with its referencing translation units, disposition, and evidence
- compile and relocatably link only DB2-owned objects, with no helper objects or libraries, so transitive dependencies cannot hide closure debt
- add a shrink-only comparison against the target branch: no new translation units, unresolved symbols, or referencing translation units
- wire the contract, checker, focused tests, and target-branch ratchet into module inventory CI

This is the pre-cutover closure ratchet in the approved C-first sequence. It does not activate DB2 as a standalone module, port DB2 to Go, or activate DB3 runtime routing. Those remain ordered follow-up slices after the C boundary is closed.

## Validation

- 25 focused link-closure tests
- 508 repository Python tests
- live 141-translation-unit no-library probe
- shrink-only comparison against `origin/testing`
- 695 native C unit-test binaries
- `go test ./...` for `server-go`
- all 58 repository lint checks
- proposal ordering, module descriptors/docs, DB2 boundary/activation, and DB3 portability checks
