### PR TITLE
feat(db2): promote sketch support into module

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -84,18 +84,29 @@ linked. This is not a production cutover: the module remains disabled and no pro
 Link-closure audit:
 
 `link-closure-v1.json` accounts for all 141 C translation units in the private DB2 boundary. The
-probe compiles each unit, combines only those objects with a relocatable link, supplies no archive,
-shared library, helper stub, or weak definition, and records the 355 genuinely external symbols plus
-every referencing unit. Each symbol has a reviewed disposition and rationale. The current ledger
-contains 144 explicit system-link dependencies, 25 pinned vendored/generated inputs, 150 sibling or
-KB contracts to inject, and 36 support APIs to promote. The standalone-link exit condition requires
-zero entries in the latter three groups; a classified ledger alone is not enough.
+probe compiles each unit plus exact descriptor-owned support, combines only those objects with a
+relocatable link, supplies no archive, shared library, helper stub, or weak definition, and records
+the 348 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
+disposition and rationale. The current ledger contains 144 explicit system-link dependencies, 25
+pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 29 support APIs to
+promote. The standalone-link exit condition requires zero entries in the latter three groups; a
+classified ledger alone is not enough.
 
-The gate rejects source omissions, symlinks, content drift, new unresolved symbols, changed
-references, missing evidence, and any attempt to make the probe pass through helper objects or
-libraries. Resolved symbols are also surfaced as review-required shrinkage so the ledger and its
-human-readable counts cannot silently become stale. Regeneration never activates the module or
-asserts that the C closure is complete.
+The first closure reduction promotes seven deterministic sketch primitives from `src/sketch.c` into
+the descriptor-owned `support/sketch_primitives.c`. Their DB2 calls are confined to `c/sketch.c` and
+`c/kb_payload.c`. Admission pins the reviewed source and owned-header hashes, exact exports, and base
+references, permits only `sketch.h` and `string.h`, and permits only `memset` as a possible system ABI
+import. An extra export, include, undefined symbol, weak definition, non-system reference edge,
+descriptor omission, or failure to resolve all seven reviewed symbols fails closed. Fixed-vector
+parity and sanitizer tests compare the support implementation with the still-authoritative monolith
+during the pre-activation period. Both are registered in the native suite; the sanitizer target
+compiles independent test, support, and monolith objects with ASan, UBSan, and FORTIFY enabled.
+
+The gate rejects legacy source additions or omissions, support path escape, symlinks, content drift,
+new unresolved symbols, non-system reference growth, missing evidence, and any attempt to make the
+probe pass through helper objects or libraries. Resolved symbols are also surfaced as
+review-required shrinkage so the ledger and its human-readable counts cannot silently become stale.
+Regeneration never activates the module or asserts that the C closure is complete.
 
 A review transition binds the symbol and normalized-signature hash to one closed disposition,
 family, DB3 placement, and nonempty reason. Signature drift invalidates the review. Unsupported or

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -394,6 +394,15 @@ baseline update. This is a migration ledger, not standalone-readiness evidence: 
 the complete source set links through declared system dependencies and bounded injected contracts
 without the monolithic core.
 
+Closure support lands outside the frozen legacy `c/` tree and is admitted by exact executable
+policy, not an author-assigned label. The first unit promotes seven deterministic sketch primitives:
+its global definitions must exactly match the seven reviewed `portable-core-promotion` rows, its
+base call sites are frozen, its only allowed headers are `sketch.h` and `string.h`, and its only
+possible unresolved ABI import is `memset`. It must strictly shrink the aggregate closure without a
+new symbol or non-system reference edge, and fixed-vector plus sanitizer parity runs against the
+pre-activation monolith. This pattern permits bounded process-owned portability code without
+reopening the legacy DB2 feature surface.
+
 ### 4.3 Supervision and atomic activation
 
 Development may land the exporter, catalog, module binary, and adapters in reviewable commits, but

--- a/scripts/check_db2_link_closure.py
+++ b/scripts/check_db2_link_closure.py
@@ -24,8 +24,9 @@ from typing import NoReturn
 ROOT = Path(__file__).resolve().parent.parent
 DESCRIPTOR = Path("src/modules/db2/module.yaml")
 BOUNDARY = Path("src/modules/db2/c")
+SUPPORT_BOUNDARY = Path("src/modules/db2/support")
 CONTRACT = Path("src/modules/db2/eventcontract/link-closure-v1.json")
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DISPOSITIONS = {
     "portable-core-promotion",
     "descriptor-owned-copy/generated-input",
@@ -42,6 +43,52 @@ PROBE_FLAGS = (
     "-fno-lto -fno-common -fno-stack-protector "
     "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
 )
+SUPPORT_COMPILE_FLAGS = (
+    "-std=c11 -Os -Wall -Wextra -Werror " + PROBE_FLAGS
+)
+SUPPORT_INCLUDE_ROOTS = ["src/modules/db2/support"]
+SUPPORT_UNITS: list[dict[str, object]] = [{
+    "path": "src/modules/db2/support/sketch_primitives.c",
+    "source_sha256": "20318d4f9c92894892ef9475f95c1542602f3a7d2b4d9fe6df2b8d63b4986280",
+    "header": "src/modules/db2/support/sketch.h",
+    "header_sha256": "bab2cf2066fc50e583d4490c109a79496ef0f19a430b28cbb850e2b2a74b647d",
+    "defines": [
+        "sketch_bloom_init",
+        "sketch_count_min_init",
+        "sketch_fnv1a",
+        "sketch_hll_add_hash",
+        "sketch_hll_init",
+        "sketch_lsh_band_hash",
+        "sketch_minhash_init",
+    ],
+    "resolves": [
+        "sketch_bloom_init",
+        "sketch_count_min_init",
+        "sketch_fnv1a",
+        "sketch_hll_add_hash",
+        "sketch_hll_init",
+        "sketch_lsh_band_hash",
+        "sketch_minhash_init",
+    ],
+    "allowed_includes": ["sketch.h", "string.h"],
+    "allowed_header_includes": ["stddef.h", "stdint.h"],
+    "allowed_undefined": ["memset"],
+    "base_references": {
+        "sketch_bloom_init": ["src/modules/db2/c/sketch.c"],
+        "sketch_count_min_init": ["src/modules/db2/c/sketch.c"],
+        "sketch_fnv1a": ["src/modules/db2/c/kb_payload.c"],
+        "sketch_hll_add_hash": ["src/modules/db2/c/kb_payload.c"],
+        "sketch_hll_init": [
+            "src/modules/db2/c/kb_payload.c", "src/modules/db2/c/sketch.c",
+        ],
+        "sketch_lsh_band_hash": ["src/modules/db2/c/sketch.c"],
+        "sketch_minhash_init": ["src/modules/db2/c/sketch.c"],
+    },
+    "provenance": "Definitions promoted from src/sketch.c and calls audited in "
+                  "src/modules/db2/c/sketch.c and src/modules/db2/c/kb_payload.c.",
+    "evidence": "Seven deterministic, database-free sketch primitives with one allowed libc "
+                "dependency (memset); no DB2, event-bus, provider, I/O, or heap dependency.",
+}]
 SYSTEM_PREFIXES = ("PQ", "EVP_", "OPENSSL_", "RAND_", "SHA", "CRYPTO_")
 INJECTED_PREFIXES = (
     "anti_pattern_", "api_", "audit_", "code_", "cochange_", "config_", "css_",
@@ -153,7 +200,9 @@ def discover_sources(root: Path) -> list[str]:
 def source_fingerprint(root: Path, sources: list[str]) -> str:
     digest = hashlib.sha256()
     for raw in sources:
-        path = _safe_file(root, raw)
+        boundary = (SUPPORT_BOUNDARY if raw.startswith(SUPPORT_BOUNDARY.as_posix() + "/")
+                    else BOUNDARY)
+        path = _safe_file(root, raw, boundary)
         digest.update(raw.encode("utf-8"))
         digest.update(b"\0")
         digest.update(path.read_bytes())
@@ -188,8 +237,45 @@ def _nm_undefined(output: str) -> set[str]:
     return result
 
 
-def probe(root: Path, sources: list[str]) -> dict[str, list[str]]:
+def _nm_global_definitions(output: str) -> tuple[set[str], set[str]]:
+    definitions: set[str] = set()
+    weak: set[str] = set()
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) < 2 or not SYMBOL.fullmatch(fields[0]) or len(fields[1]) != 1:
+            fail("probe-nm", f"unexpected nm definition row {line!r}")
+        definitions.add(fields[0])
+        if fields[1] in {"W", "w", "V", "v"}:
+            weak.add(fields[0])
+    return definitions, weak
+
+
+def _support_includes(root: Path, raw: str) -> list[str]:
+    path = _safe_file(root, raw, SUPPORT_BOUNDARY)
+    try:
+        text = path.read_text(encoding="utf-8", errors="strict")
+    except (OSError, UnicodeError) as exc:
+        fail("support-source", f"cannot read {raw}: {exc}")
+    result: list[str] = []
+    include = re.compile(r'^\s*#\s*include\s*[<"]([^>"]+)[>"]\s*$')
+    directive = re.compile(r"^\s*#\s*include\b")
+    for number, line in enumerate(text.splitlines(), 1):
+        if not directive.match(line):
+            continue
+        match = include.match(line)
+        if not match:
+            fail("support-include", f"malformed include at {raw}:{number}")
+        result.append(match.group(1))
+    if result != sorted(set(result)):
+        fail("support-include", f"includes must be sorted and unique in {raw}: {result}")
+    return result
+
+
+def probe(
+    root: Path, sources: list[str], support_units: list[dict[str, object]] | None = None
+) -> dict[str, list[str]]:
     """Compile DB2 objects and return truly external symbols with their users."""
+    support_units = support_units or []
     src_root = root / "src"
     with tempfile.TemporaryDirectory(prefix="db2-link-closure-") as raw_tmp:
         tmp = Path(raw_tmp)
@@ -203,14 +289,45 @@ def probe(root: Path, sources: list[str]) -> dict[str, list[str]]:
         if missing:
             fail("probe-object", f"compiler did not create expected objects: {missing[:3]}")
 
+        support_objects: list[Path] = []
+        for unit in support_units:
+            raw = str(unit["path"])
+            source = _safe_file(root, raw, SUPPORT_BOUNDARY)
+            obj = tmp / "support" / f"{PurePosixPath(raw).stem}.o"
+            obj.parent.mkdir(parents=True, exist_ok=True)
+            _run([
+                "cc", *SUPPORT_COMPILE_FLAGS.split(),
+                *(f"-I{root / item}" for item in SUPPORT_INCLUDE_ROOTS),
+                "-c", str(source), "-o", str(obj),
+            ], root)
+            definitions, weak = _nm_global_definitions(_run(
+                ["nm", "-g", "--defined-only", "--format=posix", str(obj)], root
+            ))
+            expected_definitions = set(unit["defines"])
+            if definitions != expected_definitions:
+                fail("support-exports", f"{raw}: expected={sorted(expected_definitions)}, "
+                     f"actual={sorted(definitions)}")
+            if weak:
+                fail("support-weak", f"{raw} defines weak symbols: {sorted(weak)}")
+            undefined = _nm_undefined(
+                _run(["nm", "-u", "--format=posix", str(obj)], root)
+            )
+            allowed_undefined = set(unit["allowed_undefined"])
+            if not undefined <= allowed_undefined:
+                fail("support-undefined", f"{raw}: forbidden undefined symbols "
+                     f"{sorted(undefined - allowed_undefined)}")
+            support_objects.append(obj)
+
         aggregate = tmp / "db2-link-closure.o"
         # A relocatable link resolves DB2-to-DB2 references but accepts external
         # references.  No archive, shared object, helper stub, or weak definition
         # is supplied, so dependencies cannot disappear transitively.
-        _run(["cc", "-r", "-o", str(aggregate), *map(str, objects)], src_root)
+        all_objects = [*objects, *support_objects]
+        _run(["cc", "-r", "-o", str(aggregate), *map(str, all_objects)], src_root)
         external = _nm_undefined(_run(["nm", "-u", "--format=posix", str(aggregate)], src_root))
         references: dict[str, list[str]] = {symbol: [] for symbol in external}
-        for raw, obj in zip(sources, objects, strict=True):
+        all_sources = [*sources, *(str(unit["path"]) for unit in support_units)]
+        for raw, obj in zip(all_sources, all_objects, strict=True):
             for symbol in _nm_undefined(
                     _run(["nm", "-u", "--format=posix", str(obj)], src_root)):
                 if symbol in references:
@@ -248,9 +365,81 @@ def classify(symbol: str) -> tuple[str, str]:
     )
 
 
+def descriptor_support_policy(root: Path, descriptor: object) -> list[dict[str, object]]:
+    if not isinstance(descriptor, dict) or not isinstance(descriptor.get("sources"), list):
+        fail("descriptor", "DB2 descriptor has no sources array")
+    descriptor_sources = descriptor["sources"]
+    assert isinstance(descriptor_sources, list)
+    support_paths = [str(unit["path"]) for unit in SUPPORT_UNITS]
+    actual_support = sorted(
+        item for item in descriptor_sources
+        if isinstance(item, str) and item.startswith(SUPPORT_BOUNDARY.as_posix() + "/")
+    )
+    if actual_support != support_paths:
+        fail("support-descriptor", f"expected={support_paths}, actual={actual_support}")
+    if not support_paths:
+        return []
+    boundary = root / SUPPORT_BOUNDARY
+    if boundary.is_symlink() or not boundary.is_dir():
+        fail("support-boundary", f"{SUPPORT_BOUNDARY} must be a real directory")
+    disk_support = sorted(
+        path.relative_to(root).as_posix() for path in boundary.iterdir()
+        if path.suffix == ".c"
+    )
+    if disk_support != support_paths:
+        fail("support-source-closure", f"expected={support_paths}, actual={disk_support}")
+    expected_headers = sorted(str(unit["header"]) for unit in SUPPORT_UNITS)
+    private_headers = descriptor.get("private_headers")
+    if not isinstance(private_headers, list):
+        fail("support-descriptor", "DB2 descriptor has no private_headers array")
+    actual_headers = sorted(
+        item for item in private_headers
+        if isinstance(item, str) and item.startswith(SUPPORT_BOUNDARY.as_posix() + "/")
+    )
+    if actual_headers != expected_headers:
+        fail("support-descriptor", f"expected headers={expected_headers}, actual={actual_headers}")
+    disk_headers = sorted(
+        path.relative_to(root).as_posix() for path in boundary.iterdir()
+        if path.suffix == ".h"
+    )
+    if disk_headers != expected_headers:
+        fail("support-header-closure", f"expected={expected_headers}, actual={disk_headers}")
+    c_build = descriptor.get("c_build")
+    if not isinstance(c_build, dict) or not isinstance(c_build.get("include_roots"), list):
+        fail("support-build", "DB2 descriptor has no C include-root policy")
+    missing_roots = sorted(set(SUPPORT_INCLUDE_ROOTS) - set(c_build["include_roots"]))
+    if missing_roots:
+        fail("support-build", f"descriptor omits support include roots: {missing_roots}")
+    policy = json.loads(json.dumps(SUPPORT_UNITS))
+    assert isinstance(policy, list)
+    for unit in policy:
+        assert isinstance(unit, dict)
+        raw = str(unit["path"])
+        support_source = _safe_file(root, raw, SUPPORT_BOUNDARY)
+        actual_sha256 = hashlib.sha256(support_source.read_bytes()).hexdigest()
+        if actual_sha256 != unit["source_sha256"]:
+            fail("support-source-hash", f"{raw}: reviewed source content changed")
+        header_raw = str(unit["header"])
+        support_header = _safe_file(root, header_raw, SUPPORT_BOUNDARY)
+        actual_header_sha256 = hashlib.sha256(support_header.read_bytes()).hexdigest()
+        if actual_header_sha256 != unit["header_sha256"]:
+            fail("support-header-hash", f"{header_raw}: reviewed header content changed")
+        includes = _support_includes(root, raw)
+        if includes != unit["allowed_includes"]:
+            fail("support-include", f"{raw}: expected={unit['allowed_includes']}, "
+                 f"actual={includes}")
+        header_includes = _support_includes(root, header_raw)
+        if header_includes != unit["allowed_header_includes"]:
+            fail("support-header-include", f"{header_raw}: "
+                 f"expected={unit['allowed_header_includes']}, actual={header_includes}")
+    return policy
+
+
 def build_contract(root: Path) -> dict[str, object]:
     sources = discover_sources(root)
-    unresolved = probe(root, sources)
+    descriptor = _load(root, DESCRIPTOR)
+    support_units = descriptor_support_policy(root, descriptor)
+    unresolved = probe(root, sources, support_units)
     rows: list[dict[str, object]] = []
     counts = {name: 0 for name in sorted(DISPOSITIONS)}
     for symbol, references in unresolved.items():
@@ -269,18 +458,25 @@ def build_contract(root: Path) -> dict[str, object]:
         "schema_version": SCHEMA_VERSION,
         "module": "db2",
         "source_revision": revision,
-        "source_fingerprint": source_fingerprint(root, sources),
+        "source_fingerprint": source_fingerprint(
+            root, [*sources, *(str(unit["path"]) for unit in support_units),
+                   *(str(unit["header"]) for unit in support_units)]
+        ),
         "probe": {
             "compile_driver": "src/Makefile",
             "extra_c_flags": PROBE_FLAGS,
             "link_mode": "relocatable-no-libraries",
             "helper_objects": [],
             "libraries": [],
+            "support_compile_flags": SUPPORT_COMPILE_FLAGS,
+            "support_include_roots": SUPPORT_INCLUDE_ROOTS,
         },
         "translation_units": sources,
+        "descriptor_support_units": support_units,
         "unresolved": rows,
         "summary": {
             "translation_units": len(sources),
+            "descriptor_support_units": len(support_units),
             "unresolved_symbols": len(rows),
             "dispositions": counts,
         },
@@ -303,19 +499,86 @@ def _string_list(value: object, label: str, *, symbols: bool = False) -> list[st
     return result
 
 
+def _validate_support_units(
+    root: Path, value: object, legacy_units: list[str], *, check_files: bool
+) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        fail("support-shape", "descriptor_support_units must be an array")
+    result: list[dict[str, object]] = []
+    previous = ""
+    required = {
+        "path", "header", "defines", "resolves", "allowed_includes",
+        "allowed_header_includes", "allowed_undefined", "base_references",
+        "provenance", "evidence", "source_sha256", "header_sha256",
+    }
+    for index, unit in enumerate(value):
+        if not isinstance(unit, dict) or set(unit) != required:
+            fail("support-shape", f"descriptor_support_units[{index}] has invalid keys")
+        path = unit["path"]
+        if not isinstance(path, str) or path <= previous:
+            fail("support-order", "support paths must be sorted and unique")
+        previous = path
+        if check_files:
+            _safe_file(root, path, SUPPORT_BOUNDARY)
+        header = unit["header"]
+        if not isinstance(header, str):
+            fail("support-header", f"{path}: header must be a path")
+        if check_files:
+            _safe_file(root, header, SUPPORT_BOUNDARY)
+        source_sha256 = unit["source_sha256"]
+        if not isinstance(source_sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", source_sha256):
+            fail("support-source-hash", f"{path}: source_sha256 must be lowercase SHA-256")
+        header_sha256 = unit["header_sha256"]
+        if not isinstance(header_sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", header_sha256):
+            fail("support-header-hash", f"{header}: header_sha256 must be lowercase SHA-256")
+        defines = _string_list(unit["defines"], f"support[{index}].defines", symbols=True)
+        resolves = _string_list(unit["resolves"], f"support[{index}].resolves", symbols=True)
+        includes = _string_list(unit["allowed_includes"],
+                                f"support[{index}].allowed_includes")
+        header_includes = _string_list(
+            unit["allowed_header_includes"],
+            f"support[{index}].allowed_header_includes",
+        )
+        allowed_undefined = _string_list(
+            unit["allowed_undefined"], f"support[{index}].allowed_undefined", symbols=True
+        )
+        if defines != resolves:
+            fail("support-resolves", f"{path}: global definitions must exactly equal resolves")
+        if any("/" in item or "\\" in item for item in [*includes, *header_includes]):
+            fail("support-include", f"{path}: include names must not contain paths")
+        base_references = unit["base_references"]
+        if not isinstance(base_references, dict) or sorted(base_references) != resolves:
+            fail("support-provenance", f"{path}: base_references must cover every resolve")
+        for symbol, references in base_references.items():
+            checked = _string_list(references, f"support[{index}].base_references.{symbol}")
+            if any(item not in legacy_units for item in checked):
+                fail("support-provenance", f"{path}: {symbol} names a non-legacy reference")
+        for field in ("provenance", "evidence"):
+            text = unit[field]
+            if not isinstance(text, str) or len(text.strip()) < 24:
+                fail("support-evidence", f"{path}: {field} requires reviewable evidence")
+        result.append(unit)
+    return result
+
+
 def validate_contract(
     root: Path, value: object, *, check_files: bool = True
-) -> tuple[list[str], dict[str, dict[str, object]]]:
+) -> tuple[list[str], list[dict[str, object]], dict[str, dict[str, object]]]:
     if not isinstance(value, dict):
         fail("contract-shape", "closure contract must be an object")
+    version = value.get("schema_version")
+    if version not in {1, SCHEMA_VERSION}:
+        fail("contract-version", "closure contract must be schema v1 or v2 for db2")
     required = {
         "schema_version", "module", "source_revision", "source_fingerprint",
         "probe", "translation_units", "unresolved", "summary", "fingerprint",
     }
+    if version == SCHEMA_VERSION:
+        required.add("descriptor_support_units")
     if set(value) != required:
         fail("contract-keys", f"keys mismatch: expected={sorted(required)}, actual={sorted(value)}")
-    if value["schema_version"] != SCHEMA_VERSION or value["module"] != "db2":
-        fail("contract-version", "closure contract must be schema v1 for db2")
+    if value["module"] != "db2":
+        fail("contract-version", "closure contract must belong to db2")
     if (not isinstance(value["source_revision"], str) or
             not REVISION.fullmatch(value["source_revision"])):
         fail("contract-revision", "source_revision must be a lowercase 40-hex commit")
@@ -330,12 +593,21 @@ def validate_contract(
         "helper_objects": [],
         "libraries": [],
     }
+    if version == SCHEMA_VERSION:
+        expected_probe.update({
+            "support_compile_flags": SUPPORT_COMPILE_FLAGS,
+            "support_include_roots": SUPPORT_INCLUDE_ROOTS,
+        })
     if probe_value != expected_probe:
         fail("probe-policy", "probe must use the frozen no-library/no-helper policy")
     units = _string_list(value["translation_units"], "translation_units")
     if check_files:
         for item in units:
             _safe_file(root, item)
+    support_units = _validate_support_units(
+        root, value.get("descriptor_support_units", []), units, check_files=check_files
+    )
+    all_units = [*units, *(str(unit["path"]) for unit in support_units)]
 
     unresolved_value = value["unresolved"]
     if not isinstance(unresolved_value, list) or not unresolved_value:
@@ -353,7 +625,7 @@ def validate_contract(
             fail("unresolved-order", "unresolved rows must be sorted and unique")
         previous = symbol
         references = _string_list(row["references"], f"unresolved[{index}].references")
-        if any(item not in units for item in references):
+        if any(item not in all_units for item in references):
             fail("unresolved-reference", f"{symbol} references an undeclared translation unit")
         if row["disposition"] not in DISPOSITIONS:
             fail("unresolved-disposition", f"{symbol} has invalid disposition")
@@ -363,8 +635,10 @@ def validate_contract(
         rows[symbol] = row
 
     summary = value["summary"]
-    if not isinstance(summary, dict) or set(summary) != {
-            "translation_units", "unresolved_symbols", "dispositions"}:
+    summary_keys = {"translation_units", "unresolved_symbols", "dispositions"}
+    if version == SCHEMA_VERSION:
+        summary_keys.add("descriptor_support_units")
+    if not isinstance(summary, dict) or set(summary) != summary_keys:
         fail("summary-shape", "summary has invalid keys")
     counts = {name: 0 for name in sorted(DISPOSITIONS)}
     for row in rows.values():
@@ -374,6 +648,8 @@ def validate_contract(
         "unresolved_symbols": len(rows),
         "dispositions": counts,
     }
+    if version == SCHEMA_VERSION:
+        expected_summary["descriptor_support_units"] = len(support_units)
     if summary != expected_summary:
         fail("summary-drift", f"summary mismatch: expected={expected_summary}")
 
@@ -387,7 +663,7 @@ def validate_contract(
     expected_fingerprint = hashlib.sha256(encoded).hexdigest()
     if fingerprint != expected_fingerprint:
         fail("contract-fingerprint", "contract content fingerprint does not match")
-    return units, rows
+    return units, support_units, rows
 
 
 def check(root: Path, *, run_probe: bool = True) -> None:
@@ -397,21 +673,31 @@ def check(root: Path, *, run_probe: bool = True) -> None:
     if CONTRACT.as_posix() not in descriptor["contracts"]:
         fail("descriptor-contract", f"DB2 descriptor does not own {CONTRACT}")
     contract = _load(root, CONTRACT)
-    units, rows = validate_contract(root, contract)
+    units, support_units, rows = validate_contract(root, contract)
+    assert isinstance(contract, dict)
+    if contract["schema_version"] != SCHEMA_VERSION:
+        fail("contract-version", f"current closure contract must be schema v{SCHEMA_VERSION}")
+    expected_support = descriptor_support_policy(root, descriptor)
+    if support_units != expected_support:
+        fail("support-policy", "contract support units differ from reviewed checker policy")
     discovered = discover_sources(root)
     if units != discovered:
         missing = sorted(set(discovered) - set(units))
         extra = sorted(set(units) - set(discovered))
         fail("source-closure", f"translation-unit mismatch; missing={missing}, extra={extra}")
-    assert isinstance(contract, dict)
-    actual_source_fingerprint = source_fingerprint(root, units)
+    all_sources = [
+        *units,
+        *(str(unit["path"]) for unit in support_units),
+        *(str(unit["header"]) for unit in support_units),
+    ]
+    actual_source_fingerprint = source_fingerprint(root, all_sources)
     if contract["source_fingerprint"] != actual_source_fingerprint:
         fail(
             "source-fingerprint",
             "DB2 translation-unit content changed; regenerate and review closure",
         )
     if run_probe:
-        actual = probe(root, units)
+        actual = probe(root, units, support_units)
         expected = {symbol: list(row["references"]) for symbol, row in rows.items()}
         if actual != expected:
             added = sorted(set(actual) - set(expected))
@@ -423,11 +709,43 @@ def check(root: Path, *, run_probe: bool = True) -> None:
 
 
 def compare_contracts(root: Path, previous: object, current: object) -> None:
-    previous_units, previous_rows = validate_contract(root, previous, check_files=False)
-    current_units, current_rows = validate_contract(root, current)
+    previous_units, previous_support, previous_rows = validate_contract(
+        root, previous, check_files=False
+    )
+    current_units, current_support, current_rows = validate_contract(root, current)
     added_units = sorted(set(current_units) - set(previous_units))
     if added_units:
         fail("previous-source-growth", f"new DB2 translation units are forbidden: {added_units}")
+    removed_units = sorted(set(previous_units) - set(current_units))
+    if removed_units:
+        fail("previous-source-removal", f"legacy DB2 translation units disappeared: {removed_units}")
+    previous_support_by_path = {str(unit["path"]): unit for unit in previous_support}
+    current_support_by_path = {str(unit["path"]): unit for unit in current_support}
+    removed_support = sorted(set(previous_support_by_path) - set(current_support_by_path))
+    if removed_support:
+        fail("previous-support-removal", f"descriptor support units disappeared: {removed_support}")
+    changed_support = sorted(
+        path for path in set(previous_support_by_path) & set(current_support_by_path)
+        if previous_support_by_path[path] != current_support_by_path[path]
+    )
+    if changed_support:
+        fail("previous-support-change", f"reviewed support policy changed: {changed_support}")
+    added_support = [
+        current_support_by_path[path]
+        for path in sorted(set(current_support_by_path) - set(previous_support_by_path))
+    ]
+    for unit in added_support:
+        base_references = unit["base_references"]
+        assert isinstance(base_references, dict)
+        for symbol in unit["resolves"]:
+            before = previous_rows.get(str(symbol))
+            if (before is None or before["disposition"] != "portable-core-promotion" or
+                    before["references"] != base_references[symbol]):
+                fail("previous-support-admission",
+                     f"{unit['path']}: {symbol} lacks exact portable-core base evidence")
+            if symbol in current_rows:
+                fail("previous-support-resolution",
+                     f"{unit['path']}: declared resolution {symbol} remains unresolved")
     added_symbols = sorted(set(current_rows) - set(previous_rows))
     if added_symbols:
         fail("previous-symbol-growth", f"new unresolved symbols are forbidden: {added_symbols}")
@@ -435,10 +753,19 @@ def compare_contracts(root: Path, previous: object, current: object) -> None:
     for symbol in sorted(set(current_rows) & set(previous_rows)):
         before = set(previous_rows[symbol]["references"])
         after = set(current_rows[symbol]["references"])
-        if not after <= before:
+        growth = after - before
+        permitted_paths = {
+            str(unit["path"]) for unit in added_support
+            if symbol in unit["allowed_undefined"]
+        }
+        if growth and not (
+                previous_rows[symbol]["disposition"] == "system-link" and
+                growth <= permitted_paths):
             expanded.append(symbol)
     if expanded:
         fail("previous-reference-growth", f"unresolved reference sets grew: {expanded}")
+    if added_support and len(current_rows) >= len(previous_rows):
+        fail("previous-support-shrink", "support admission must strictly shrink unresolved debt")
 
 
 def check_previous(root: Path, ref: str, current: object) -> None:

--- a/scripts/tests/test_check_db2_link_closure.py
+++ b/scripts/tests/test_check_db2_link_closure.py
@@ -24,6 +24,8 @@ SPEC.loader.exec_module(checker)
 
 class LinkClosureTest(unittest.TestCase):
     def setUp(self) -> None:
+        self.production_support = checker.SUPPORT_UNITS
+        checker.SUPPORT_UNITS = []
         self.temp = tempfile.TemporaryDirectory()
         self.root = Path(self.temp.name)
         (self.root / "src/modules/db2/c").mkdir(parents=True)
@@ -35,12 +37,13 @@ class LinkClosureTest(unittest.TestCase):
         self._write_all()
 
     def tearDown(self) -> None:
+        checker.SUPPORT_UNITS = self.production_support
         self.temp.cleanup()
 
     def _contract(self) -> dict[str, object]:
         sources = ["src/modules/db2/c/a.c"]
         result: dict[str, object] = {
-            "schema_version": 1,
+            "schema_version": checker.SCHEMA_VERSION,
             "module": "db2",
             "source_revision": "a" * 40,
             "source_fingerprint": checker.source_fingerprint(self.root, sources),
@@ -50,8 +53,11 @@ class LinkClosureTest(unittest.TestCase):
                 "link_mode": "relocatable-no-libraries",
                 "helper_objects": [],
                 "libraries": [],
+                "support_compile_flags": checker.SUPPORT_COMPILE_FLAGS,
+                "support_include_roots": checker.SUPPORT_INCLUDE_ROOTS,
             },
             "translation_units": sources,
+            "descriptor_support_units": [],
             "unresolved": [{
                 "symbol": "outside",
                 "references": sources,
@@ -60,6 +66,7 @@ class LinkClosureTest(unittest.TestCase):
             }],
             "summary": {
                 "translation_units": 1,
+                "descriptor_support_units": 0,
                 "unresolved_symbols": 1,
                 "dispositions": {
                     name: int(name == "portable-core-promotion")
@@ -77,7 +84,7 @@ class LinkClosureTest(unittest.TestCase):
         value["fingerprint"] = hashlib.sha256(encoded).hexdigest()
 
     def _write_all(self) -> None:
-        descriptor = {"contracts": [checker.CONTRACT.as_posix()]}
+        descriptor = {"contracts": [checker.CONTRACT.as_posix()], "sources": []}
         (self.root / checker.DESCRIPTOR).write_text(json.dumps(descriptor), encoding="utf-8")
         (self.root / checker.CONTRACT).write_text(json.dumps(self.contract), encoding="utf-8")
 
@@ -92,10 +99,54 @@ class LinkClosureTest(unittest.TestCase):
             counts[row["disposition"]] += 1
         value["summary"] = {
             "translation_units": len(value["translation_units"]),  # type: ignore[arg-type]
+            "descriptor_support_units": len(value["descriptor_support_units"]),  # type: ignore[arg-type]
             "unresolved_symbols": len(rows),  # type: ignore[arg-type]
             "dispositions": counts,
         }
         self._fingerprint(value)
+
+    def _support_row(self) -> dict[str, object]:
+        support = self.root / "src/modules/db2/support"
+        support.mkdir(parents=True, exist_ok=True)
+        (support / "fixture.c").write_text(
+            '#include "sketch.h"\nint outside(void) { return 7; }\n', encoding="utf-8"
+        )
+        (support / "sketch.h").write_text(
+            "#include <stddef.h>\n#include <stdint.h>\n", encoding="utf-8"
+        )
+        return {
+            "path": "src/modules/db2/support/fixture.c",
+            "header": "src/modules/db2/support/sketch.h",
+            "source_sha256": hashlib.sha256(
+                (support / "fixture.c").read_bytes()
+            ).hexdigest(),
+            "header_sha256": hashlib.sha256(
+                (support / "sketch.h").read_bytes()
+            ).hexdigest(),
+            "defines": ["outside"],
+            "resolves": ["outside"],
+            "allowed_includes": ["sketch.h"],
+            "allowed_header_includes": ["stddef.h", "stdint.h"],
+            "allowed_undefined": ["memset"],
+            "base_references": {"outside": ["src/modules/db2/c/a.c"]},
+            "provenance": "Fixture definition and DB2 call site are pinned exactly.",
+            "evidence": "Deterministic fixture support with no private dependency.",
+        }
+
+    def _support_comparison(self) -> tuple[dict[str, object], dict[str, object]]:
+        previous = copy.deepcopy(self.contract)
+        previous["unresolved"].append({  # type: ignore[union-attr]
+            "symbol": "z_remaining",
+            "references": ["src/modules/db2/c/a.c"],
+            "disposition": "system-link",
+            "evidence": "A fixture system dependency that remains unresolved.",
+        })
+        self._refresh_summary(previous)
+        current = copy.deepcopy(previous)
+        current["descriptor_support_units"] = [self._support_row()]
+        current["unresolved"] = [current["unresolved"][1]]  # type: ignore[index]
+        self._refresh_summary(current)
+        return previous, current
 
     def test_valid_metadata(self) -> None:
         checker.check(self.root, run_probe=False)
@@ -212,6 +263,15 @@ class LinkClosureTest(unittest.TestCase):
         with self.assertRaisesRegex(checker.ClosureError, "previous-source-growth"):
             checker.compare_contracts(self.root, previous, current)
 
+    def test_previous_contract_rejects_removed_translation_unit(self) -> None:
+        previous = copy.deepcopy(self.contract)
+        previous["translation_units"] = [
+            "src/modules/db2/c/a.c", "src/modules/db2/c/b.c",
+        ]
+        self._refresh_summary(previous)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-source-removal"):
+            checker.compare_contracts(self.root, previous, self.contract)
+
     def test_previous_contract_allows_reviewed_symbol_removal(self) -> None:
         previous = copy.deepcopy(self.contract)
         previous["unresolved"].append({  # type: ignore[union-attr]
@@ -238,6 +298,204 @@ class LinkClosureTest(unittest.TestCase):
         self._refresh_summary(current)
         with self.assertRaisesRegex(checker.ClosureError, "previous-reference-growth"):
             checker.compare_contracts(self.root, previous, current)
+
+    def test_previous_contract_allows_exact_support_shrink(self) -> None:
+        previous, current = self._support_comparison()
+        checker.compare_contracts(self.root, previous, current)
+
+    def test_support_admission_requires_portable_base_disposition(self) -> None:
+        previous, current = self._support_comparison()
+        previous["unresolved"][0]["disposition"] = "injected-module-contract"  # type: ignore[index]
+        self._refresh_summary(previous)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-support-admission"):
+            checker.compare_contracts(self.root, previous, current)
+
+    def test_support_admission_requires_declared_resolution(self) -> None:
+        previous, current = self._support_comparison()
+        current["unresolved"].insert(0, previous["unresolved"][0])  # type: ignore[union-attr,index]
+        self._refresh_summary(current)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-support-resolution"):
+            checker.compare_contracts(self.root, previous, current)
+
+    def test_support_admission_rejects_non_system_reference_growth(self) -> None:
+        previous, current = self._support_comparison()
+        current["unresolved"][0]["references"].append(  # type: ignore[index,union-attr]
+            "src/modules/db2/support/fixture.c"
+        )
+        self._refresh_summary(current)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-reference-growth"):
+            checker.compare_contracts(self.root, previous, current)
+
+    def test_reviewed_support_policy_cannot_be_relabelled(self) -> None:
+        _, previous = self._support_comparison()
+        current = copy.deepcopy(previous)
+        current["descriptor_support_units"][0]["evidence"] += " Changed."  # type: ignore[index]
+        self._refresh_summary(current)
+        with self.assertRaisesRegex(checker.ClosureError, "previous-support-change"):
+            checker.compare_contracts(self.root, previous, current)
+
+    def test_support_path_escape_fails(self) -> None:
+        unit = self._support_row()
+        unit["path"] = "../fixture.c"
+        with self.assertRaisesRegex(checker.ClosureError, "source-path"):
+            checker._validate_support_units(
+                self.root, [unit], ["src/modules/db2/c/a.c"], check_files=True
+            )
+
+    def test_support_descriptor_omission_fails(self) -> None:
+        descriptor = json.loads((REPO / checker.DESCRIPTOR).read_text(encoding="utf-8"))
+        descriptor["sources"].remove("src/modules/db2/support/sketch_primitives.c")
+        with mock.patch.object(checker, "SUPPORT_UNITS", self.production_support):
+            with self.assertRaisesRegex(checker.ClosureError, "support-descriptor"):
+                checker.descriptor_support_policy(REPO, descriptor)
+
+    def test_support_header_descriptor_omission_fails(self) -> None:
+        descriptor = json.loads((REPO / checker.DESCRIPTOR).read_text(encoding="utf-8"))
+        descriptor["private_headers"].remove("src/modules/db2/support/sketch.h")
+        with mock.patch.object(checker, "SUPPORT_UNITS", self.production_support):
+            with self.assertRaisesRegex(checker.ClosureError, "support-descriptor"):
+                checker.descriptor_support_policy(REPO, descriptor)
+
+    def test_support_forbidden_include_fails(self) -> None:
+        unit = self._support_row()
+        path = self.root / str(unit["path"])
+        path.write_text('#include <stdio.h>\n#include "sketch.h"\n', encoding="utf-8")
+        unit["source_sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+        descriptor = {
+            "sources": [unit["path"]],
+            "private_headers": [unit["header"]],
+            "c_build": {"include_roots": checker.SUPPORT_INCLUDE_ROOTS},
+        }
+        with mock.patch.object(checker, "SUPPORT_UNITS", [unit]):
+            with self.assertRaisesRegex(checker.ClosureError, "support-include"):
+                checker.descriptor_support_policy(self.root, descriptor)
+
+    def test_support_include_policy_must_be_canonical(self) -> None:
+        unit = self._support_row()
+        unit["allowed_includes"] = ["sketch.h", "sketch.h"]
+        with self.assertRaisesRegex(checker.ClosureError, "contract-order"):
+            checker._validate_support_units(
+                self.root, [unit], ["src/modules/db2/c/a.c"], check_files=True
+            )
+
+    def test_reviewed_support_source_hash_is_required(self) -> None:
+        unit = self._support_row()
+        path = self.root / str(unit["path"])
+        path.write_text("int outside(void) { return 8; }\n", encoding="utf-8")
+        descriptor = {
+            "sources": [unit["path"]],
+            "private_headers": [unit["header"]],
+            "c_build": {"include_roots": checker.SUPPORT_INCLUDE_ROOTS},
+        }
+        with mock.patch.object(checker, "SUPPORT_UNITS", [unit]):
+            with self.assertRaisesRegex(checker.ClosureError, "support-source-hash"):
+                checker.descriptor_support_policy(self.root, descriptor)
+
+    def test_reviewed_support_header_hash_is_required(self) -> None:
+        unit = self._support_row()
+        path = self.root / str(unit["header"])
+        path.write_text("#include <stdint.h>\n", encoding="utf-8")
+        descriptor = {
+            "sources": [unit["path"]],
+            "private_headers": [unit["header"]],
+            "c_build": {"include_roots": checker.SUPPORT_INCLUDE_ROOTS},
+        }
+        with mock.patch.object(checker, "SUPPORT_UNITS", [unit]):
+            with self.assertRaisesRegex(checker.ClosureError, "support-header-hash"):
+                checker.descriptor_support_policy(self.root, descriptor)
+
+    def test_support_forbidden_header_include_fails(self) -> None:
+        unit = self._support_row()
+        path = self.root / str(unit["header"])
+        path.write_text(
+            "#include <stddef.h>\n#include <stdint.h>\n#include <stdio.h>\n",
+            encoding="utf-8",
+        )
+        unit["header_sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+        descriptor = {
+            "sources": [unit["path"]],
+            "private_headers": [unit["header"]],
+            "c_build": {"include_roots": checker.SUPPORT_INCLUDE_ROOTS},
+        }
+        with mock.patch.object(checker, "SUPPORT_UNITS", [unit]):
+            with self.assertRaisesRegex(checker.ClosureError, "support-header-include"):
+                checker.descriptor_support_policy(self.root, descriptor)
+
+    def test_undeclared_support_source_fails(self) -> None:
+        unit = self._support_row()
+        (self.root / "src/modules/db2/support/other.c").write_text(
+            "int other(void) { return 1; }\n", encoding="utf-8"
+        )
+        descriptor = {
+            "sources": [unit["path"]],
+            "private_headers": [unit["header"]],
+            "c_build": {"include_roots": checker.SUPPORT_INCLUDE_ROOTS},
+        }
+        with mock.patch.object(checker, "SUPPORT_UNITS", [unit]):
+            with self.assertRaisesRegex(checker.ClosureError, "support-source-closure"):
+                checker.descriptor_support_policy(self.root, descriptor)
+
+    def test_undeclared_support_header_fails(self) -> None:
+        unit = self._support_row()
+        (self.root / "src/modules/db2/support/other.h").write_text(
+            "#pragma once\n", encoding="utf-8"
+        )
+        descriptor = {
+            "sources": [unit["path"]],
+            "private_headers": [unit["header"]],
+            "c_build": {"include_roots": checker.SUPPORT_INCLUDE_ROOTS},
+        }
+        with mock.patch.object(checker, "SUPPORT_UNITS", [unit]):
+            with self.assertRaisesRegex(checker.ClosureError, "support-header-closure"):
+                checker.descriptor_support_policy(self.root, descriptor)
+
+    def test_support_build_include_root_is_required(self) -> None:
+        unit = self._support_row()
+        descriptor = {
+            "sources": [unit["path"]],
+            "private_headers": [unit["header"]],
+            "c_build": {"include_roots": []},
+        }
+        with mock.patch.object(checker, "SUPPORT_UNITS", [unit]):
+            with self.assertRaisesRegex(checker.ClosureError, "support-build"):
+                checker.descriptor_support_policy(self.root, descriptor)
+
+    def _probe_support(self, source_text: str, defines: list[str]) -> None:
+        support = self.root / "src/modules/db2/support"
+        support.mkdir(parents=True, exist_ok=True)
+        (support / "fixture.c").write_text(source_text, encoding="utf-8")
+        (self.root / "src/Makefile").write_text(
+            "$(OBJDIR)/db2/%.o: modules/db2/c/%.c\n"
+            "\t@mkdir -p $(dir $@)\n"
+            "\t$(CC) -c $(EXTRA_C_FLAGS) -o $@ $<\n",
+            encoding="utf-8",
+        )
+        unit = {
+            "path": "src/modules/db2/support/fixture.c",
+            "defines": defines,
+            "allowed_undefined": ["memset"],
+        }
+        checker.probe(self.root, checker.discover_sources(self.root), [unit])
+
+    def test_support_extra_export_fails(self) -> None:
+        with self.assertRaisesRegex(checker.ClosureError, "support-exports"):
+            self._probe_support(
+                "int wanted(void) { return 1; } int extra(void) { return 2; }\n",
+                ["wanted"],
+            )
+
+    def test_support_new_undefined_symbol_fails(self) -> None:
+        with self.assertRaisesRegex(checker.ClosureError, "support-undefined"):
+            self._probe_support(
+                "extern int forbidden(void); int wanted(void) { return forbidden(); }\n",
+                ["wanted"],
+            )
+
+    def test_support_weak_export_fails(self) -> None:
+        with self.assertRaisesRegex(checker.ClosureError, "support-weak"):
+            self._probe_support(
+                "__attribute__((weak)) int wanted(void) { return 1; }\n", ["wanted"]
+            )
 
     def test_previous_ref_rejects_option_injection(self) -> None:
         with self.assertRaisesRegex(checker.ClosureError, "previous-ref"):
@@ -299,8 +557,9 @@ class LinkClosureTest(unittest.TestCase):
         ], check=True)
         subprocess.run([str(output)], check=True)
 
-    def test_real_repository_contract_metadata(self) -> None:
-        checker.check(REPO, run_probe=False)
+    def test_real_repository_contract_and_probe(self) -> None:
+        with mock.patch.object(checker, "SUPPORT_UNITS", self.production_support):
+            checker.check(REPO, run_probe=True)
 
 
 if __name__ == "__main__":

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,14 +1,18 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "db2",
-  "source_revision": "bb3de1cdb04fbfdcdb2a146f0dcd802ee41af3f5",
-  "source_fingerprint": "c6486704635e400898dc14c7cdc41060e81e88beb0392f777e3d10bb98a3fb55",
+  "source_revision": "45b864b8a8d5b1b3ef2d752e5c2f44bd02bc7540",
+  "source_fingerprint": "fb050d2d8987e57dec8df4a9dfb0422d3a64b09f6f3737abcb824fe59903bfe7",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
     "link_mode": "relocatable-no-libraries",
     "helper_objects": [],
-    "libraries": []
+    "libraries": [],
+    "support_compile_flags": "-std=c11 -Os -Wall -Wextra -Werror -fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
+    "support_include_roots": [
+      "src/modules/db2/support"
+    ]
   },
   "translation_units": [
     "src/modules/db2/c/admin_grant.c",
@@ -152,6 +156,69 @@
     "src/modules/db2/c/vector_status.c",
     "src/modules/db2/c/workflow_patterns.c",
     "src/modules/db2/c/write_tier_grant.c"
+  ],
+  "descriptor_support_units": [
+    {
+      "path": "src/modules/db2/support/sketch_primitives.c",
+      "source_sha256": "20318d4f9c92894892ef9475f95c1542602f3a7d2b4d9fe6df2b8d63b4986280",
+      "header": "src/modules/db2/support/sketch.h",
+      "header_sha256": "bab2cf2066fc50e583d4490c109a79496ef0f19a430b28cbb850e2b2a74b647d",
+      "defines": [
+        "sketch_bloom_init",
+        "sketch_count_min_init",
+        "sketch_fnv1a",
+        "sketch_hll_add_hash",
+        "sketch_hll_init",
+        "sketch_lsh_band_hash",
+        "sketch_minhash_init"
+      ],
+      "resolves": [
+        "sketch_bloom_init",
+        "sketch_count_min_init",
+        "sketch_fnv1a",
+        "sketch_hll_add_hash",
+        "sketch_hll_init",
+        "sketch_lsh_band_hash",
+        "sketch_minhash_init"
+      ],
+      "allowed_includes": [
+        "sketch.h",
+        "string.h"
+      ],
+      "allowed_header_includes": [
+        "stddef.h",
+        "stdint.h"
+      ],
+      "allowed_undefined": [
+        "memset"
+      ],
+      "base_references": {
+        "sketch_bloom_init": [
+          "src/modules/db2/c/sketch.c"
+        ],
+        "sketch_count_min_init": [
+          "src/modules/db2/c/sketch.c"
+        ],
+        "sketch_fnv1a": [
+          "src/modules/db2/c/kb_payload.c"
+        ],
+        "sketch_hll_add_hash": [
+          "src/modules/db2/c/kb_payload.c"
+        ],
+        "sketch_hll_init": [
+          "src/modules/db2/c/kb_payload.c",
+          "src/modules/db2/c/sketch.c"
+        ],
+        "sketch_lsh_band_hash": [
+          "src/modules/db2/c/sketch.c"
+        ],
+        "sketch_minhash_init": [
+          "src/modules/db2/c/sketch.c"
+        ]
+      },
+      "provenance": "Definitions promoted from src/sketch.c and calls audited in src/modules/db2/c/sketch.c and src/modules/db2/c/kb_payload.c.",
+      "evidence": "Seven deterministic, database-free sketch primitives with one allowed libc dependency (memset); no DB2, event-bus, provider, I/O, or heap dependency."
+    }
   ],
   "unresolved": [
     {
@@ -2854,63 +2921,6 @@
       "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
     },
     {
-      "symbol": "sketch_bloom_init",
-      "references": [
-        "src/modules/db2/c/sketch.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "sketch_count_min_init",
-      "references": [
-        "src/modules/db2/c/sketch.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "sketch_fnv1a",
-      "references": [
-        "src/modules/db2/c/kb_payload.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "sketch_hll_add_hash",
-      "references": [
-        "src/modules/db2/c/kb_payload.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "sketch_hll_init",
-      "references": [
-        "src/modules/db2/c/kb_payload.c",
-        "src/modules/db2/c/sketch.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "sketch_lsh_band_hash",
-      "references": [
-        "src/modules/db2/c/sketch.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "sketch_minhash_init",
-      "references": [
-        "src/modules/db2/c/sketch.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
       "symbol": "sleep",
       "references": [
         "src/modules/db2/c/db2_pool.c"
@@ -3783,15 +3793,16 @@
   ],
   "summary": {
     "translation_units": 141,
-    "unresolved_symbols": 355,
+    "descriptor_support_units": 1,
+    "unresolved_symbols": 348,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 25,
       "injected-module-contract": 150,
-      "portable-core-promotion": 36,
+      "portable-core-promotion": 29,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 144
     }
   },
-  "fingerprint": "c7a14b0dbfbf6daadce77a14cea0df0052716f66239e6161fb0de8112671ac77"
+  "fingerprint": "d92a1385034247a19ff75052595ce82a8b42baf44f02016839a9ce85b5849563"
 }

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -12,7 +12,8 @@
   "sources": [
     "src/modules/db2/client/generated.c",
     "src/modules/db2/db3_route.c",
-    "src/modules/db2/module_adapter.c"
+    "src/modules/db2/module_adapter.c",
+    "src/modules/db2/support/sketch_primitives.c"
   ],
   "public_headers": [
     "src/modules/db2/include/aimee/db2/client.h",
@@ -26,12 +27,14 @@
     "src/modules/db2/eventcontract/vector-portability.json"
   ],
   "private_headers": [
-    "src/modules/db2/module_adapter.h"
+    "src/modules/db2/module_adapter.h",
+    "src/modules/db2/support/sketch.h"
   ],
   "tests": [
     "src/tests/test_bus_db2_module.c",
     "src/tests/test_bus_db3.c",
     "src/tests/test_db2_module_contract.c",
+    "src/tests/test_db2_sketch_support.c",
     "src/tests/test_db3_route.c"
   ],
   "docs": [
@@ -39,7 +42,8 @@
   ],
   "c_build": {
     "include_roots": [
-      "src/modules/db2/include"
+      "src/modules/db2/include",
+      "src/modules/db2/support"
     ],
     "pkg_config": [],
     "system_libraries": []

--- a/src/modules/db2/support/sketch.h
+++ b/src/modules/db2/support/sketch.h
@@ -1,0 +1,48 @@
+/* Descriptor-owned ABI for DB2's deterministic sketch support subset. */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SKETCH_BLOOM_M_BITS (1u << 20)
+#define SKETCH_BLOOM_K      7
+#define SKETCH_BLOOM_BYTES  (SKETCH_BLOOM_M_BITS / 8)
+
+#define SKETCH_MINHASH_PERMUTATIONS 128
+#define SKETCH_LSH_BANDS            32
+#define SKETCH_LSH_ROWS_PER_BAND    4
+#define SKETCH_COUNT_MIN_WIDTH      65536
+#define SKETCH_COUNT_MIN_DEPTH      4
+#define SKETCH_HLL_PRECISION        12
+#define SKETCH_HLL_REGISTERS        (1u << SKETCH_HLL_PRECISION)
+
+typedef struct
+{
+   uint8_t bits[SKETCH_BLOOM_BYTES];
+   uint64_t item_count;
+} sketch_bloom_t;
+
+typedef struct
+{
+   uint64_t values[SKETCH_MINHASH_PERMUTATIONS];
+} sketch_minhash_t;
+
+typedef struct
+{
+   uint32_t counters[SKETCH_COUNT_MIN_DEPTH][SKETCH_COUNT_MIN_WIDTH];
+   uint64_t item_count;
+} sketch_count_min_t;
+
+typedef struct
+{
+   uint8_t registers[SKETCH_HLL_REGISTERS];
+   uint64_t item_count;
+} sketch_hll_t;
+
+void sketch_bloom_init(sketch_bloom_t *b);
+void sketch_minhash_init(sketch_minhash_t *sig);
+uint64_t sketch_lsh_band_hash(const sketch_minhash_t *sig, int band);
+void sketch_count_min_init(sketch_count_min_t *cm);
+void sketch_hll_init(sketch_hll_t *hll);
+void sketch_hll_add_hash(sketch_hll_t *hll, uint64_t h);
+uint64_t sketch_fnv1a(const void *data, size_t len);

--- a/src/modules/db2/support/sketch_primitives.c
+++ b/src/modules/db2/support/sketch_primitives.c
@@ -1,0 +1,87 @@
+/* Descriptor-owned DB2 process support for deterministic sketch primitives. */
+#include "sketch.h"
+
+#include <string.h>
+
+#define FNV_OFFSET 14695981039346656037ULL
+#define FNV_PRIME  1099511628211ULL
+
+uint64_t sketch_fnv1a(const void *data, size_t len)
+{
+   const uint8_t *p = (const uint8_t *)data;
+   uint64_t h = FNV_OFFSET;
+   for (size_t i = 0; i < len; i++)
+   {
+      h ^= (uint64_t)p[i];
+      h *= FNV_PRIME;
+   }
+   return h;
+}
+
+static uint64_t fnv1a_seeded(const void *data, size_t len, uint64_t seed)
+{
+   uint64_t h = sketch_fnv1a(&seed, sizeof(seed));
+   const uint8_t *p = (const uint8_t *)data;
+   for (size_t i = 0; i < len; i++)
+   {
+      h ^= (uint64_t)p[i];
+      h *= FNV_PRIME;
+   }
+   return h;
+}
+
+void sketch_bloom_init(sketch_bloom_t *b)
+{
+   memset(b->bits, 0, sizeof(b->bits));
+   b->item_count = 0;
+}
+
+void sketch_minhash_init(sketch_minhash_t *sig)
+{
+   for (int i = 0; i < SKETCH_MINHASH_PERMUTATIONS; i++)
+      sig->values[i] = UINT64_MAX;
+}
+
+uint64_t sketch_lsh_band_hash(const sketch_minhash_t *sig, int band)
+{
+   if (!sig || band < 0 || band >= SKETCH_LSH_BANDS)
+      return 0;
+   return fnv1a_seeded(&sig->values[band * SKETCH_LSH_ROWS_PER_BAND],
+                       sizeof(uint64_t) * SKETCH_LSH_ROWS_PER_BAND,
+                       0x6a09e667f3bcc909ULL ^ (uint64_t)band);
+}
+
+void sketch_count_min_init(sketch_count_min_t *cm)
+{
+   memset(cm, 0, sizeof(*cm));
+}
+
+void sketch_hll_init(sketch_hll_t *hll)
+{
+   memset(hll, 0, sizeof(*hll));
+}
+
+static uint8_t hll_rank(uint64_t x)
+{
+   uint8_t rank = 1;
+   int max_rank = 64 - SKETCH_HLL_PRECISION + 1;
+   while (rank < max_rank && (x & (1ULL << 63)) == 0)
+   {
+      rank++;
+      x <<= 1;
+   }
+   return rank;
+}
+
+void sketch_hll_add_hash(sketch_hll_t *hll, uint64_t h)
+{
+   uint32_t idx;
+   uint8_t rank;
+   if (!hll)
+      return;
+   idx = (uint32_t)(h & (SKETCH_HLL_REGISTERS - 1));
+   rank = hll_rank(h << SKETCH_HLL_PRECISION);
+   if (rank > hll->registers[idx])
+      hll->registers[idx] = rank;
+   hll->item_count++;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -727,6 +727,7 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-communication
 TEST_TARGETS += $(TESTPREFIX)/unit-test-process-module-handlers
 TEST_TARGETS += $(TESTPREFIX)/unit-test-db2-module-contract \
                 $(TESTPREFIX)/unit-test-bus-db2-module \
+                $(TESTPREFIX)/unit-test-db2-sketch-support \
                 $(TESTPREFIX)/unit-test-db3-route \
                 $(TESTPREFIX)/unit-test-bus-db3
 
@@ -796,6 +797,11 @@ $(TESTPREFIX)/unit-test-communication: $(OBJDIR)/tests/test_communication.o \
 UNIT_TEST_SHARD_COUNT ?= 1
 UNIT_TEST_SHARD_INDEX ?= 0
 UNIT_TEST_SKIP_P1 ?= 0
+ifeq ($(UNIT_TEST_SHARD_INDEX),0)
+UNIT_TEST_AUX_TARGETS = $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize
+else
+UNIT_TEST_AUX_TARGETS =
+endif
 ifeq ($(UNIT_TEST_SHARD_COUNT),1)
 UNIT_TEST_TARGETS := $(TEST_TARGETS)
 else
@@ -815,7 +821,8 @@ endif
 # verify gate brings the real module up on a real bus
 # (tests/support/git_module_fixture.c). Build it here and name it in the
 # environment, so no suite has to grow an argv contract to find it.
-unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(OBJDIR)/aimee-module $(UNIT_TEST_TARGETS)
+unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(OBJDIR)/aimee-module \
+            $(UNIT_TEST_TARGETS) $(UNIT_TEST_AUX_TARGETS)
 	@if ! printf '%s:%s\n' "$(UNIT_TEST_SHARD_COUNT)" "$(UNIT_TEST_SHARD_INDEX)" | \
 	     awk -F: '$$1 ~ /^[0-9]+$$/ && $$2 ~ /^[0-9]+$$/ && $$1 > 0 && $$2 < $$1 { ok=1 } END { exit !ok }'; then \
 	  echo "invalid unit-test shard $(UNIT_TEST_SHARD_INDEX)/$(UNIT_TEST_SHARD_COUNT)" >&2; \
@@ -890,6 +897,10 @@ unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(OBJDIR)/aimee-module $(UNIT_TEST_
 	    exit 1; \
 	  fi; \
 	fi
+	@for t in $(UNIT_TEST_AUX_TARGETS); do \
+	  echo "  $$t"; \
+	  "./$$t"; \
+	done
 	@echo "All tests passed."
 
 $(TESTPREFIX)/unit-test-util: $(OBJDIR)/tests/test_util.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
@@ -6581,6 +6592,57 @@ $(TESTPREFIX)/unit-test-sketch: $(OBJDIR)/tests/test_sketch.o \
                      $(OBJDIR)/sketch.o \
                      $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
+
+DB2_SKETCH_SUPPORT_RENAMES = \
+   -Dsketch_bloom_init=db2_support_sketch_bloom_init \
+   -Dsketch_count_min_init=db2_support_sketch_count_min_init \
+   -Dsketch_fnv1a=db2_support_sketch_fnv1a \
+   -Dsketch_hll_add_hash=db2_support_sketch_hll_add_hash \
+   -Dsketch_hll_init=db2_support_sketch_hll_init \
+   -Dsketch_lsh_band_hash=db2_support_sketch_lsh_band_hash \
+   -Dsketch_minhash_init=db2_support_sketch_minhash_init
+
+$(OBJDIR)/tests/db2_sketch_support_impl.o: modules/db2/support/sketch_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SKETCH_SUPPORT_RENAMES) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-sketch-support: \
+                     $(OBJDIR)/tests/test_db2_sketch_support.o \
+                     $(OBJDIR)/tests/db2_sketch_support_impl.o \
+                     $(OBJDIR)/sketch.o
+	$(TESTLINK_MIN) -o $@ $^ $(TEST_L_FLAGS) -lm
+
+DB2_SKETCH_SANITIZE_DIR = $(OBJDIR)/tests/db2-sketch-support-sanitize
+DB2_SKETCH_SANITIZE_FLAGS = -O1 -g -fno-lto -fsanitize=address,undefined \
+                            -fno-omit-frame-pointer -U_FORTIFY_SOURCE \
+                            -D_FORTIFY_SOURCE=3
+
+$(DB2_SKETCH_SANITIZE_DIR)/test.o: tests/test_db2_sketch_support.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SKETCH_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_SKETCH_SANITIZE_DIR)/support.o: modules/db2/support/sketch_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SKETCH_SUPPORT_RENAMES) \
+	      $(DB2_SKETCH_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_SKETCH_SANITIZE_DIR)/monolith.o: sketch.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SKETCH_SANITIZE_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-sketch-support-sanitize: \
+                     $(DB2_SKETCH_SANITIZE_DIR)/test.o \
+                     $(DB2_SKETCH_SANITIZE_DIR)/support.o \
+                     $(DB2_SKETCH_SANITIZE_DIR)/monolith.o
+	$(CC) $(DB2_SKETCH_SANITIZE_FLAGS) -o $@ $^ -lm
+
+.PHONY: unit-test-db2-sketch-support
+unit-test-db2-sketch-support: $(TESTPREFIX)/unit-test-db2-sketch-support
+	$<
+
+.PHONY: unit-test-db2-sketch-support-sanitize
+unit-test-db2-sketch-support-sanitize: $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize
+	$<
 
 $(TESTPREFIX)/unit-test-kb-lab: $(OBJDIR)/tests/test_kb_lab.o \
                      $(OBJDIR)/kb/kb_lab.o \

--- a/src/tests/test_db2_sketch_support.c
+++ b/src/tests/test_db2_sketch_support.c
@@ -1,0 +1,103 @@
+/* Parity tests for descriptor-owned DB2 sketch support. */
+#include "sketch.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+uint64_t db2_support_sketch_fnv1a(const void *data, size_t len);
+void db2_support_sketch_bloom_init(sketch_bloom_t *b);
+void db2_support_sketch_minhash_init(sketch_minhash_t *sig);
+uint64_t db2_support_sketch_lsh_band_hash(const sketch_minhash_t *sig, int band);
+void db2_support_sketch_count_min_init(sketch_count_min_t *cm);
+void db2_support_sketch_hll_init(sketch_hll_t *hll);
+void db2_support_sketch_hll_add_hash(sketch_hll_t *hll, uint64_t h);
+
+static void test_fnv_parity(void)
+{
+   static const unsigned char binary[] = {0x00, 0x01, 0x7f, 0x80, 0xff};
+   assert(db2_support_sketch_fnv1a("", 0) == UINT64_C(0xcbf29ce484222325));
+   assert(db2_support_sketch_fnv1a("hello", 5) == UINT64_C(0xa430d84680aabd0b));
+   assert(db2_support_sketch_fnv1a(binary, sizeof(binary)) == UINT64_C(0xa5bcd1d1065f84b6));
+   assert(db2_support_sketch_fnv1a("", 0) == sketch_fnv1a("", 0));
+   assert(db2_support_sketch_fnv1a("hello", 5) == sketch_fnv1a("hello", 5));
+   assert(db2_support_sketch_fnv1a(binary, sizeof(binary)) == sketch_fnv1a(binary, sizeof(binary)));
+   assert(db2_support_sketch_fnv1a(NULL, 0) == sketch_fnv1a(NULL, 0));
+}
+
+static void test_init_parity(void)
+{
+   sketch_bloom_t bloom_a, bloom_b;
+   static sketch_count_min_t count_a, count_b;
+   sketch_minhash_t minhash_a, minhash_b;
+   sketch_hll_t hll_a, hll_b;
+
+   memset(&bloom_a, 0xa5, sizeof(bloom_a));
+   bloom_b = bloom_a;
+   sketch_bloom_init(&bloom_a);
+   db2_support_sketch_bloom_init(&bloom_b);
+   assert(memcmp(&bloom_a, &bloom_b, sizeof(bloom_a)) == 0);
+   assert(bloom_b.item_count == 0);
+
+   memset(&count_a, 0xa5, sizeof(count_a));
+   memcpy(&count_b, &count_a, sizeof(count_a));
+   sketch_count_min_init(&count_a);
+   db2_support_sketch_count_min_init(&count_b);
+   assert(memcmp(&count_a, &count_b, sizeof(count_a)) == 0);
+   assert(count_b.item_count == 0);
+
+   memset(&minhash_a, 0xa5, sizeof(minhash_a));
+   minhash_b = minhash_a;
+   sketch_minhash_init(&minhash_a);
+   db2_support_sketch_minhash_init(&minhash_b);
+   assert(memcmp(&minhash_a, &minhash_b, sizeof(minhash_a)) == 0);
+   for (size_t i = 0; i < SKETCH_MINHASH_PERMUTATIONS; i++)
+      assert(minhash_b.values[i] == UINT64_MAX);
+
+   memset(&hll_a, 0xa5, sizeof(hll_a));
+   hll_b = hll_a;
+   sketch_hll_init(&hll_a);
+   db2_support_sketch_hll_init(&hll_b);
+   assert(memcmp(&hll_a, &hll_b, sizeof(hll_a)) == 0);
+   assert(hll_b.item_count == 0);
+}
+
+static void test_lsh_parity(void)
+{
+   sketch_minhash_t signature;
+   for (size_t i = 0; i < SKETCH_MINHASH_PERMUTATIONS; i++)
+      signature.values[i] = UINT64_C(0x9e3779b97f4a7c15) ^ (uint64_t)i;
+   for (int band = 0; band < SKETCH_LSH_BANDS; band++)
+      assert(db2_support_sketch_lsh_band_hash(&signature, band) ==
+             sketch_lsh_band_hash(&signature, band));
+   assert(db2_support_sketch_lsh_band_hash(NULL, 0) == 0);
+   assert(db2_support_sketch_lsh_band_hash(&signature, -1) == 0);
+   assert(db2_support_sketch_lsh_band_hash(&signature, SKETCH_LSH_BANDS) == 0);
+}
+
+static void test_hll_add_parity(void)
+{
+   static const uint64_t hashes[] = {
+       0, 1, UINT64_C(0x1000), UINT64_C(0x8000000000000000), UINT64_MAX,
+   };
+   sketch_hll_t a, b;
+   sketch_hll_init(&a);
+   db2_support_sketch_hll_init(&b);
+   for (size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++)
+   {
+      sketch_hll_add_hash(&a, hashes[i]);
+      db2_support_sketch_hll_add_hash(&b, hashes[i]);
+   }
+   assert(memcmp(&a, &b, sizeof(a)) == 0);
+   assert(b.item_count == sizeof(hashes) / sizeof(hashes[0]));
+   db2_support_sketch_hll_add_hash(NULL, 7);
+}
+
+int main(void)
+{
+   test_fnv_parity();
+   test_init_parity();
+   test_lsh_parity();
+   test_hll_add_parity();
+   return 0;
+}

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -68,6 +68,12 @@
       "test": "src/tests/test_db2_module_contract.c"
     },
     {
+      "ctest": false,
+      "make": true,
+      "module": "db2",
+      "test": "src/tests/test_db2_sketch_support.c"
+    },
+    {
       "ctest": true,
       "make": true,
       "module": "db2",


### PR DESCRIPTION
Promotes the first seven deterministic sketch primitives from the monolith into descriptor-owned DB2 support without changing the frozen legacy C boundary or activating the module.

The link-closure contract now admits support only through pinned source/header hashes, exact exports, base references, include roots, and a single allowed libc import. It strictly ratchets unresolved debt from 355 to 348 and rejects legacy source additions or removals, new symbols, reference growth, weak exports, or packaging drift.

Validation:
- roundtable approved with no findings after requested fixes
- 697 native test targets represented, with normal parity plus registered ASan/UBSan/FORTIFY parity
- 526 Python tests
- Go test suite
- all 58 lint checks and docs/proposal gates
- live production closure probe and origin/testing debt comparison
- production C runtime export and standalone bundle build