### PR TITLE
feat(db2): promote dstr support into module

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -86,9 +86,9 @@ Link-closure audit:
 `link-closure-v1.json` accounts for all 141 C translation units in the private DB2 boundary. The
 probe compiles each unit plus exact descriptor-owned support, combines only those objects with a
 relocatable link, supplies no archive, shared library, helper stub, or weak definition, and records
-the 348 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
+the 345 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
 disposition and rationale. The current ledger contains 144 explicit system-link dependencies, 25
-pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 29 support APIs to
+pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 26 support APIs to
 promote. The standalone-link exit condition requires zero entries in the latter three groups; a
 classified ledger alone is not enough.
 
@@ -101,6 +101,16 @@ descriptor omission, or failure to resolve all seven reviewed symbols fails clos
 parity and sanitizer tests compare the support implementation with the still-authoritative monolith
 during the pre-activation period. Both are registered in the native suite; the sanitizer target
 compiles independent test, support, and monolith objects with ASan, UBSan, and FORTIFY enabled.
+
+The second reduction promotes the three-function dynamic-string lifecycle used only by
+`c/collab_rules.c`: `dstr_init`, `dstr_appendf`, and `dstr_steal`. The descriptor owns the exact
+three-word `dstr_t` ABI and support implementation; admission pins both hashes, those three exports,
+the sole base call site, the four-header source envelope, and only `realloc` and `vsnprintf` as
+possible imports. Empty, formatting, repeated-growth, long-content, ownership-transfer, ABI-layout,
+controlled allocation-failure, and sanitizer parity tests run against the pre-activation monolith.
+The allocation-failure case also fixes both copies to preserve length, capacity, and content when
+growth fails. The legacy fixed-buffer string uses elsewhere are not aliases of this lifecycle and
+remain outside the admission.
 
 The gate rejects legacy source additions or omissions, support path escape, symlinks, content drift,
 new unresolved symbols, non-system reference growth, missing evidence, and any attempt to make the

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -403,6 +403,13 @@ new symbol or non-system reference edge, and fixed-vector plus sanitizer parity 
 pre-activation monolith. This pattern permits bounded process-owned portability code without
 reopening the legacy DB2 feature surface.
 
+The next admitted unit applies the same policy to the sole DB2 dynamic-string lifecycle. It owns the
+exact `dstr_t` field layout and only `dstr_init`, `dstr_appendf`, and `dstr_steal`; all three base
+references are confined to `c/collab_rules.c`, and its only possible imports are `realloc` and
+`vsnprintf`. Normal and ASan/UBSan/FORTIFY parity cover empty state, formatting, repeated capacity
+growth, long content, ownership transfer, and controlled allocation failure while the monolith
+remains authoritative. Both copies preserve the prior string when that growth allocation fails.
+
 ### 4.3 Supervision and atomic activation
 
 Development may land the exporter, catalog, module binary, and adapters in reviewable commits, but

--- a/scripts/check_db2_link_closure.py
+++ b/scripts/check_db2_link_closure.py
@@ -48,6 +48,25 @@ SUPPORT_COMPILE_FLAGS = (
 )
 SUPPORT_INCLUDE_ROOTS = ["src/modules/db2/support"]
 SUPPORT_UNITS: list[dict[str, object]] = [{
+    "path": "src/modules/db2/support/dstr_primitives.c",
+    "source_sha256": "ae448e0ae6e0464922042536b77ab396ea230d5ba16ec977e003ecd614cf22ab",
+    "header": "src/modules/db2/support/db2_dstr.h",
+    "header_sha256": "47d3f825ea79b187a1f500e7bf58beda95dc472a4573ebff7128212019185b7c",
+    "defines": ["dstr_appendf", "dstr_init", "dstr_steal"],
+    "resolves": ["dstr_appendf", "dstr_init", "dstr_steal"],
+    "allowed_includes": ["db2_dstr.h", "stdarg.h", "stdio.h", "stdlib.h"],
+    "allowed_header_includes": ["stddef.h"],
+    "allowed_undefined": ["realloc", "vsnprintf"],
+    "base_references": {
+        "dstr_appendf": ["src/modules/db2/c/collab_rules.c"],
+        "dstr_init": ["src/modules/db2/c/collab_rules.c"],
+        "dstr_steal": ["src/modules/db2/c/collab_rules.c"],
+    },
+    "provenance": "Definitions and required static helpers promoted from src/dstr.c; all DB2 "
+                  "calls audited in src/modules/db2/c/collab_rules.c.",
+    "evidence": "Three deterministic dynamic-string lifecycle functions with only realloc and "
+                "vsnprintf imports; no DB2, event-bus, provider, I/O, or platform dependency.",
+}, {
     "path": "src/modules/db2/support/sketch_primitives.c",
     "source_sha256": "20318d4f9c92894892ef9475f95c1542602f3a7d2b4d9fe6df2b8d63b4986280",
     "header": "src/modules/db2/support/sketch.h",

--- a/src/dstr.c
+++ b/src/dstr.c
@@ -86,6 +86,13 @@ void dstr_vappendf(dstr_t *s, const char *fmt, va_list ap)
    /* Need more space */
    dstr_reserve(s, (size_t)n);
    avail = s->cap > s->len ? s->cap - s->len : 0;
+   if ((size_t)n >= avail)
+   {
+      if (s->data)
+         s->data[s->len] = '\0';
+      va_end(ap2);
+      return; /* reserve failed; preserve the existing string */
+   }
    vsnprintf(s->data + s->len, avail, fmt, ap2);
    s->len += (size_t)n;
    va_end(ap2);

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "45b864b8a8d5b1b3ef2d752e5c2f44bd02bc7540",
-  "source_fingerprint": "fb050d2d8987e57dec8df4a9dfb0422d3a64b09f6f3737abcb824fe59903bfe7",
+  "source_revision": "9886a70761a92f0e6e32f97e4c4dfd904a7256e9",
+  "source_fingerprint": "12cc09b56341f9f0dbfbe05fd01ab8e41400f4c4a660469961530d00887f26a8",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
@@ -158,6 +158,48 @@
     "src/modules/db2/c/write_tier_grant.c"
   ],
   "descriptor_support_units": [
+    {
+      "path": "src/modules/db2/support/dstr_primitives.c",
+      "source_sha256": "ae448e0ae6e0464922042536b77ab396ea230d5ba16ec977e003ecd614cf22ab",
+      "header": "src/modules/db2/support/db2_dstr.h",
+      "header_sha256": "47d3f825ea79b187a1f500e7bf58beda95dc472a4573ebff7128212019185b7c",
+      "defines": [
+        "dstr_appendf",
+        "dstr_init",
+        "dstr_steal"
+      ],
+      "resolves": [
+        "dstr_appendf",
+        "dstr_init",
+        "dstr_steal"
+      ],
+      "allowed_includes": [
+        "db2_dstr.h",
+        "stdarg.h",
+        "stdio.h",
+        "stdlib.h"
+      ],
+      "allowed_header_includes": [
+        "stddef.h"
+      ],
+      "allowed_undefined": [
+        "realloc",
+        "vsnprintf"
+      ],
+      "base_references": {
+        "dstr_appendf": [
+          "src/modules/db2/c/collab_rules.c"
+        ],
+        "dstr_init": [
+          "src/modules/db2/c/collab_rules.c"
+        ],
+        "dstr_steal": [
+          "src/modules/db2/c/collab_rules.c"
+        ]
+      },
+      "provenance": "Definitions and required static helpers promoted from src/dstr.c; all DB2 calls audited in src/modules/db2/c/collab_rules.c.",
+      "evidence": "Three deterministic dynamic-string lifecycle functions with only realloc and vsnprintf imports; no DB2, event-bus, provider, I/O, or platform dependency."
+    },
     {
       "path": "src/modules/db2/support/sketch_primitives.c",
       "source_sha256": "20318d4f9c92894892ef9475f95c1542602f3a7d2b4d9fe6df2b8d63b4986280",
@@ -1601,30 +1643,6 @@
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
     },
     {
-      "symbol": "dstr_appendf",
-      "references": [
-        "src/modules/db2/c/collab_rules.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "dstr_init",
-      "references": [
-        "src/modules/db2/c/collab_rules.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "dstr_steal",
-      "references": [
-        "src/modules/db2/c/collab_rules.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
       "symbol": "exp",
       "references": [
         "src/modules/db2/c/curiosity.c",
@@ -2808,7 +2826,8 @@
         "src/modules/db2/c/db2_witness_emit.c",
         "src/modules/db2/c/db_postgres.c",
         "src/modules/db2/c/memory_export.c",
-        "src/modules/db2/c/memory_query.c"
+        "src/modules/db2/c/memory_query.c",
+        "src/modules/db2/support/dstr_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -3785,7 +3804,8 @@
     {
       "symbol": "vsnprintf",
       "references": [
-        "src/modules/db2/c/db2_reembed.c"
+        "src/modules/db2/c/db2_reembed.c",
+        "src/modules/db2/support/dstr_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -3793,16 +3813,16 @@
   ],
   "summary": {
     "translation_units": 141,
-    "descriptor_support_units": 1,
-    "unresolved_symbols": 348,
+    "descriptor_support_units": 2,
+    "unresolved_symbols": 345,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 25,
       "injected-module-contract": 150,
-      "portable-core-promotion": 29,
+      "portable-core-promotion": 26,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 144
     }
   },
-  "fingerprint": "d92a1385034247a19ff75052595ce82a8b42baf44f02016839a9ce85b5849563"
+  "fingerprint": "b59a0e14c6ce628b97fa9c57873f5f7e2b7209166c099358113638533cd383b4"
 }

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -13,6 +13,7 @@
     "src/modules/db2/client/generated.c",
     "src/modules/db2/db3_route.c",
     "src/modules/db2/module_adapter.c",
+    "src/modules/db2/support/dstr_primitives.c",
     "src/modules/db2/support/sketch_primitives.c"
   ],
   "public_headers": [
@@ -28,12 +29,14 @@
   ],
   "private_headers": [
     "src/modules/db2/module_adapter.h",
+    "src/modules/db2/support/db2_dstr.h",
     "src/modules/db2/support/sketch.h"
   ],
   "tests": [
     "src/tests/test_bus_db2_module.c",
     "src/tests/test_bus_db3.c",
     "src/tests/test_db2_module_contract.c",
+    "src/tests/test_db2_dstr_support.c",
     "src/tests/test_db2_sketch_support.c",
     "src/tests/test_db3_route.c"
   ],

--- a/src/modules/db2/support/db2_dstr.h
+++ b/src/modules/db2/support/db2_dstr.h
@@ -1,0 +1,18 @@
+/* Descriptor-owned ABI for DB2's dynamic-string support subset. */
+#ifndef AIMEE_DB2_SUPPORT_DSTR_H
+#define AIMEE_DB2_SUPPORT_DSTR_H
+
+#include <stddef.h>
+
+typedef struct
+{
+   char *data;
+   size_t len;
+   size_t cap;
+} dstr_t;
+
+void dstr_init(dstr_t *s);
+__attribute__((format(printf, 2, 3))) void dstr_appendf(dstr_t *s, const char *fmt, ...);
+char *dstr_steal(dstr_t *s);
+
+#endif

--- a/src/modules/db2/support/dstr_primitives.c
+++ b/src/modules/db2/support/dstr_primitives.c
@@ -1,0 +1,83 @@
+/* Descriptor-owned DB2 process support for the required dstr_t lifecycle. */
+#include "db2_dstr.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DSTR_INIT_CAP 64
+
+void dstr_init(dstr_t *s)
+{
+   s->data = NULL;
+   s->len = 0;
+   s->cap = 0;
+}
+
+static void dstr_reserve(dstr_t *s, size_t additional)
+{
+   size_t needed = s->len + additional + 1;
+   if (needed <= s->cap)
+      return;
+
+   size_t newcap = s->cap ? s->cap : DSTR_INIT_CAP;
+   while (newcap < needed)
+      newcap *= 2;
+
+   char *p = realloc(s->data, newcap);
+   if (!p)
+      return;
+   s->data = p;
+   s->cap = newcap;
+}
+
+static void dstr_vappendf(dstr_t *s, const char *fmt, va_list ap)
+{
+   va_list ap2;
+   va_copy(ap2, ap);
+
+   size_t avail = s->cap > s->len ? s->cap - s->len : 0;
+   int n = vsnprintf(s->data ? s->data + s->len : NULL, avail, fmt, ap);
+   if (n < 0)
+   {
+      va_end(ap2);
+      return;
+   }
+
+   if ((size_t)n < avail)
+   {
+      s->len += (size_t)n;
+      va_end(ap2);
+      return;
+   }
+
+   dstr_reserve(s, (size_t)n);
+   avail = s->cap > s->len ? s->cap - s->len : 0;
+   if ((size_t)n >= avail)
+   {
+      if (s->data)
+         s->data[s->len] = '\0';
+      va_end(ap2);
+      return;
+   }
+   vsnprintf(s->data + s->len, avail, fmt, ap2);
+   s->len += (size_t)n;
+   va_end(ap2);
+}
+
+void dstr_appendf(dstr_t *s, const char *fmt, ...)
+{
+   va_list ap;
+   va_start(ap, fmt);
+   dstr_vappendf(s, fmt, ap);
+   va_end(ap);
+}
+
+char *dstr_steal(dstr_t *s)
+{
+   char *p = s->data;
+   s->data = NULL;
+   s->len = 0;
+   s->cap = 0;
+   return p;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -728,6 +728,7 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-communication
 TEST_TARGETS += $(TESTPREFIX)/unit-test-process-module-handlers
 TEST_TARGETS += $(TESTPREFIX)/unit-test-db2-module-contract \
                 $(TESTPREFIX)/unit-test-bus-db2-module \
+                $(TESTPREFIX)/unit-test-db2-dstr-support \
                 $(TESTPREFIX)/unit-test-db2-sketch-support \
                 $(TESTPREFIX)/unit-test-db3-route \
                 $(TESTPREFIX)/unit-test-bus-db3
@@ -799,7 +800,8 @@ UNIT_TEST_SHARD_COUNT ?= 1
 UNIT_TEST_SHARD_INDEX ?= 0
 UNIT_TEST_SKIP_P1 ?= 0
 ifeq ($(UNIT_TEST_SHARD_INDEX),0)
-UNIT_TEST_AUX_TARGETS = $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize
+UNIT_TEST_AUX_TARGETS = $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize \
+                        $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize
 else
 UNIT_TEST_AUX_TARGETS =
 endif
@@ -6613,6 +6615,56 @@ $(TESTPREFIX)/unit-test-sketch: $(OBJDIR)/tests/test_sketch.o \
                      $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
 
+DB2_DSTR_SUPPORT_RENAMES = \
+   -Ddstr_appendf=db2_support_dstr_appendf \
+   -Ddstr_init=db2_support_dstr_init \
+   -Ddstr_steal=db2_support_dstr_steal
+DB2_DSTR_TEST_ALLOCATOR = -Drealloc=db2_test_realloc
+
+$(OBJDIR)/tests/db2_dstr_support_impl.o: modules/db2/support/dstr_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_DSTR_SUPPORT_RENAMES) \
+	      $(DB2_DSTR_TEST_ALLOCATOR) -c -o $@ $<
+
+$(OBJDIR)/tests/db2_dstr_monolith.o: dstr.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_DSTR_TEST_ALLOCATOR) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-dstr-support: \
+                     $(OBJDIR)/tests/test_db2_dstr_support.o \
+                     $(OBJDIR)/tests/db2_dstr_support_impl.o \
+                     $(OBJDIR)/tests/db2_dstr_monolith.o
+	$(TESTLINK_MIN) -o $@ $^ $(TEST_L_FLAGS)
+
+DB2_DSTR_SANITIZE_DIR = $(OBJDIR)/tests/db2-dstr-support-sanitize
+
+$(DB2_DSTR_SANITIZE_DIR)/test.o: tests/test_db2_dstr_support.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_DSTR_SANITIZE_DIR)/support.o: modules/db2/support/dstr_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_DSTR_SUPPORT_RENAMES) \
+	      $(DB2_DSTR_TEST_ALLOCATOR) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_DSTR_SANITIZE_DIR)/monolith.o: dstr.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_DSTR_TEST_ALLOCATOR) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-dstr-support-sanitize: \
+                     $(DB2_DSTR_SANITIZE_DIR)/test.o \
+                     $(DB2_DSTR_SANITIZE_DIR)/support.o \
+                     $(DB2_DSTR_SANITIZE_DIR)/monolith.o
+	$(CC) $(DB2_SUPPORT_SANITIZE_FLAGS) -o $@ $^
+
+.PHONY: unit-test-db2-dstr-support unit-test-db2-dstr-support-sanitize
+unit-test-db2-dstr-support: $(TESTPREFIX)/unit-test-db2-dstr-support
+	$<
+
+unit-test-db2-dstr-support-sanitize: $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize
+	$<
+
 DB2_SKETCH_SUPPORT_RENAMES = \
    -Dsketch_bloom_init=db2_support_sketch_bloom_init \
    -Dsketch_count_min_init=db2_support_sketch_count_min_init \
@@ -6633,28 +6685,28 @@ $(TESTPREFIX)/unit-test-db2-sketch-support: \
 	$(TESTLINK_MIN) -o $@ $^ $(TEST_L_FLAGS) -lm
 
 DB2_SKETCH_SANITIZE_DIR = $(OBJDIR)/tests/db2-sketch-support-sanitize
-DB2_SKETCH_SANITIZE_FLAGS = -O1 -g -fno-lto -fsanitize=address,undefined \
-                            -fno-omit-frame-pointer -U_FORTIFY_SOURCE \
-                            -D_FORTIFY_SOURCE=3
+DB2_SUPPORT_SANITIZE_FLAGS = -O1 -g -fno-lto -fsanitize=address,undefined \
+                             -fno-omit-frame-pointer -U_FORTIFY_SOURCE \
+                             -D_FORTIFY_SOURCE=3
 
 $(DB2_SKETCH_SANITIZE_DIR)/test.o: tests/test_db2_sketch_support.c
 	@mkdir -p $(dir $@)
-	$(CC) $(TEST_C_FLAGS) $(DB2_SKETCH_SANITIZE_FLAGS) -c -o $@ $<
+	$(CC) $(TEST_C_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
 
 $(DB2_SKETCH_SANITIZE_DIR)/support.o: modules/db2/support/sketch_primitives.c
 	@mkdir -p $(dir $@)
 	$(CC) $(TEST_C_FLAGS) $(DB2_SKETCH_SUPPORT_RENAMES) \
-	      $(DB2_SKETCH_SANITIZE_FLAGS) -c -o $@ $<
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
 
 $(DB2_SKETCH_SANITIZE_DIR)/monolith.o: sketch.c
 	@mkdir -p $(dir $@)
-	$(CC) $(TEST_C_FLAGS) $(DB2_SKETCH_SANITIZE_FLAGS) -c -o $@ $<
+	$(CC) $(TEST_C_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
 
 $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize: \
                      $(DB2_SKETCH_SANITIZE_DIR)/test.o \
                      $(DB2_SKETCH_SANITIZE_DIR)/support.o \
                      $(DB2_SKETCH_SANITIZE_DIR)/monolith.o
-	$(CC) $(DB2_SKETCH_SANITIZE_FLAGS) -o $@ $^ -lm
+	$(CC) $(DB2_SUPPORT_SANITIZE_FLAGS) -o $@ $^ -lm
 
 .PHONY: unit-test-db2-sketch-support
 unit-test-db2-sketch-support: $(TESTPREFIX)/unit-test-db2-sketch-support

--- a/src/tests/test_db2_dstr_support.c
+++ b/src/tests/test_db2_dstr_support.c
@@ -1,0 +1,115 @@
+/* Parity tests for descriptor-owned DB2 dynamic-string support. */
+#include "dstr.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+void db2_support_dstr_init(dstr_t *s);
+void db2_support_dstr_appendf(dstr_t *s, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+char *db2_support_dstr_steal(dstr_t *s);
+
+static unsigned fail_realloc_count;
+
+void *db2_test_realloc(void *ptr, size_t size)
+{
+   if (fail_realloc_count)
+   {
+      fail_realloc_count--;
+      return NULL;
+   }
+   return realloc(ptr, size);
+}
+
+_Static_assert(offsetof(dstr_t, data) == 0, "dstr_t.data must remain first");
+_Static_assert(offsetof(dstr_t, len) == sizeof(char *), "dstr_t.len ABI drift");
+_Static_assert(offsetof(dstr_t, cap) == sizeof(char *) + sizeof(size_t), "dstr_t.cap ABI drift");
+_Static_assert(sizeof(dstr_t) == sizeof(char *) + 2 * sizeof(size_t), "dstr_t size drift");
+
+static void assert_same(const dstr_t *monolith, const dstr_t *support)
+{
+   assert(monolith->len == support->len);
+   assert(monolith->cap == support->cap);
+   assert((monolith->data == NULL) == (support->data == NULL));
+   if (monolith->data)
+      assert(memcmp(monolith->data, support->data, monolith->len + 1) == 0);
+}
+
+static void test_empty_lifecycle(void)
+{
+   dstr_t monolith, support;
+   dstr_init(&monolith);
+   db2_support_dstr_init(&support);
+   assert_same(&monolith, &support);
+   assert(dstr_steal(&monolith) == NULL);
+   assert(db2_support_dstr_steal(&support) == NULL);
+   assert_same(&monolith, &support);
+}
+
+static void test_format_and_growth_parity(void)
+{
+   dstr_t monolith, support;
+   dstr_init(&monolith);
+   db2_support_dstr_init(&support);
+
+   dstr_appendf(&monolith, "# Rules (epoch %d)\n", 17);
+   db2_support_dstr_appendf(&support, "# Rules (epoch %d)\n", 17);
+   assert_same(&monolith, &support);
+
+   for (int i = 0; i < 128; i++)
+   {
+      dstr_appendf(&monolith, "%d. %s-%08x\n", i + 1, "policy", (unsigned)i);
+      db2_support_dstr_appendf(&support, "%d. %s-%08x\n", i + 1, "policy", (unsigned)i);
+      assert_same(&monolith, &support);
+   }
+
+   char long_text[4097];
+   memset(long_text, 'x', sizeof(long_text) - 1);
+   long_text[sizeof(long_text) - 1] = '\0';
+   dstr_appendf(&monolith, "%s", long_text);
+   db2_support_dstr_appendf(&support, "%s", long_text);
+   assert_same(&monolith, &support);
+
+   char *monolith_data = dstr_steal(&monolith);
+   char *support_data = db2_support_dstr_steal(&support);
+   assert(monolith_data != NULL);
+   assert(support_data != NULL);
+   assert(strcmp(monolith_data, support_data) == 0);
+   assert_same(&monolith, &support);
+   free(monolith_data);
+   free(support_data);
+}
+
+static void test_allocation_failure_preserves_state(void)
+{
+   dstr_t monolith, support;
+   dstr_init(&monolith);
+   db2_support_dstr_init(&support);
+   dstr_appendf(&monolith, "%s", "seed");
+   db2_support_dstr_appendf(&support, "%s", "seed");
+   assert_same(&monolith, &support);
+
+   size_t original_len = monolith.len;
+   size_t original_cap = monolith.cap;
+   fail_realloc_count = 2;
+   dstr_appendf(&monolith, "%01024d", 7);
+   db2_support_dstr_appendf(&support, "%01024d", 7);
+   assert(fail_realloc_count == 0);
+   assert_same(&monolith, &support);
+   assert(monolith.len == original_len);
+   assert(monolith.cap == original_cap);
+   assert(strcmp(monolith.data, "seed") == 0);
+
+   free(dstr_steal(&monolith));
+   free(db2_support_dstr_steal(&support));
+}
+
+int main(void)
+{
+   test_empty_lifecycle();
+   test_format_and_growth_parity();
+   test_allocation_failure_preserves_state();
+   return 0;
+}

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -62,6 +62,12 @@
       "test": "src/tests/test_bus_db3.c"
     },
     {
+      "ctest": false,
+      "make": true,
+      "module": "db2",
+      "test": "src/tests/test_db2_dstr_support.c"
+    },
+    {
       "ctest": true,
       "make": true,
       "module": "db2",


### PR DESCRIPTION
Promotes the three-function dynamic-string lifecycle used by DB2 collaborative rules into descriptor-owned support while leaving the frozen legacy DB2 source boundary unchanged.

Key changes:
- add an exact descriptor-owned dstr ABI and implementation
- reduce live unresolved closure from 348 to 345 and portable promotion debt from 29 to 26
- pin support source/header hashes, exports, imports, includes, and sole legacy call site
- add monolith parity, ABI, growth, ownership, controlled allocation-failure, ASan/UBSan/FORTIFY, descriptor, and closure coverage
- fix the authoritative and promoted dstr append path so allocation failure preserves content, length, and capacity

Validation:
- 530 Python tests
- complete native unit suite
- all 58 lint checks
- build-integrity and 46 descriptor tests
- DB2 source-boundary and link-closure ratchets against testing
- all Go modules
- proposal ordering
- roundtable approved the immutable commit artifact with no findings