### PR TITLE
feat(db2): promote UTF-8 repair into module

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -86,9 +86,9 @@ Link-closure audit:
 `link-closure-v1.json` accounts for all 141 C translation units in the private DB2 boundary. The
 probe compiles each unit plus exact descriptor-owned support, combines only those objects with a
 relocatable link, supplies no archive, shared library, helper stub, or weak definition, and records
-the 345 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
+the 344 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
 disposition and rationale. The current ledger contains 144 explicit system-link dependencies, 25
-pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 26 support APIs to
+pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 25 support APIs to
 promote. The standalone-link exit condition requires zero entries in the latter three groups; a
 classified ledger alone is not enough.
 
@@ -111,6 +111,13 @@ controlled allocation-failure, and sanitizer parity tests run against the pre-ac
 The allocation-failure case also fixes both copies to preserve length, capacity, and content when
 growth fails. The legacy fixed-buffer string uses elsewhere are not aliases of this lifecycle and
 remain outside the admission.
+
+The third reduction promotes `text_sanitize_utf8`, the allocation-free in-place repair used by
+three DB2 units at five call sites. The descriptor pins its minimal `size_t (char *)` ABI, source
+and header hashes, sole include, empty import set, exact base references, and single export.
+Parity covers every non-NUL byte, valid boundary sequences, every truncated prefix, overlong
+forms, surrogates, values above U+10FFFF, mixed text, empty input, and NULL under both the normal
+and ASan/UBSan/FORTIFY builds.
 
 The gate rejects legacy source additions or omissions, support path escape, symlinks, content drift,
 new unresolved symbols, non-system reference growth, missing evidence, and any attempt to make the

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -410,6 +410,11 @@ references are confined to `c/collab_rules.c`, and its only possible imports are
 growth, long content, ownership transfer, and controlled allocation failure while the monolith
 remains authoritative. Both copies preserve the prior string when that growth allocation fails.
 
+The third admitted unit owns only `text_sanitize_utf8`. It is a deterministic, allocation-free
+in-place repair with no imports and five legacy calls across three DB2 units. Admission pins the
+minimal header, source envelope, export, and base references; exhaustive byte-class, Unicode
+boundary, truncation, mixed-input, NULL, and sanitizer parity protects the monolith contract.
+
 ### 4.3 Supervision and atomic activation
 
 Development may land the exporter, catalog, module binary, and adapters in reviewable commits, but

--- a/scripts/check_db2_link_closure.py
+++ b/scripts/check_db2_link_closure.py
@@ -107,6 +107,27 @@ SUPPORT_UNITS: list[dict[str, object]] = [{
                   "src/modules/db2/c/sketch.c and src/modules/db2/c/kb_payload.c.",
     "evidence": "Seven deterministic, database-free sketch primitives with one allowed libc "
                 "dependency (memset); no DB2, event-bus, provider, I/O, or heap dependency.",
+}, {
+    "path": "src/modules/db2/support/text_primitives.c",
+    "source_sha256": "2bbdb09370052759967f53557d0904398c55c118c964699a97a74a9abad02e78",
+    "header": "src/modules/db2/support/db2_text.h",
+    "header_sha256": "748a028371661444d450f1d365dca5e6988f0ba02730b38bfeb32078e67311b2",
+    "defines": ["text_sanitize_utf8"],
+    "resolves": ["text_sanitize_utf8"],
+    "allowed_includes": ["db2_text.h"],
+    "allowed_header_includes": ["stddef.h"],
+    "allowed_undefined": [],
+    "base_references": {
+        "text_sanitize_utf8": [
+            "src/modules/db2/c/canonical_index.c",
+            "src/modules/db2/c/code_index.c",
+            "src/modules/db2/c/kb_payload.c",
+        ],
+    },
+    "provenance": "Definition promoted from src/text.c; all DB2 calls audited in "
+                  "canonical_index.c, code_index.c, and kb_payload.c.",
+    "evidence": "Deterministic in-place UTF-8 repair with no imports, allocation, I/O, DB, "
+                "event-bus, provider, or platform dependency; exhaustive parity tested.",
 }]
 SYSTEM_PREFIXES = ("PQ", "EVP_", "OPENSSL_", "RAND_", "SHA", "CRYPTO_")
 INJECTED_PREFIXES = (

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "9886a70761a92f0e6e32f97e4c4dfd904a7256e9",
-  "source_fingerprint": "12cc09b56341f9f0dbfbe05fd01ab8e41400f4c4a660469961530d00887f26a8",
+  "source_revision": "2770a84679f82f10c068b245abdb11ce04639f66",
+  "source_fingerprint": "d80b7ff5d0f81e9896efdbe6184cc1682587a2f734ffd180e640915d14164312",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
@@ -260,6 +260,34 @@
       },
       "provenance": "Definitions promoted from src/sketch.c and calls audited in src/modules/db2/c/sketch.c and src/modules/db2/c/kb_payload.c.",
       "evidence": "Seven deterministic, database-free sketch primitives with one allowed libc dependency (memset); no DB2, event-bus, provider, I/O, or heap dependency."
+    },
+    {
+      "path": "src/modules/db2/support/text_primitives.c",
+      "source_sha256": "2bbdb09370052759967f53557d0904398c55c118c964699a97a74a9abad02e78",
+      "header": "src/modules/db2/support/db2_text.h",
+      "header_sha256": "748a028371661444d450f1d365dca5e6988f0ba02730b38bfeb32078e67311b2",
+      "defines": [
+        "text_sanitize_utf8"
+      ],
+      "resolves": [
+        "text_sanitize_utf8"
+      ],
+      "allowed_includes": [
+        "db2_text.h"
+      ],
+      "allowed_header_includes": [
+        "stddef.h"
+      ],
+      "allowed_undefined": [],
+      "base_references": {
+        "text_sanitize_utf8": [
+          "src/modules/db2/c/canonical_index.c",
+          "src/modules/db2/c/code_index.c",
+          "src/modules/db2/c/kb_payload.c"
+        ]
+      },
+      "provenance": "Definition promoted from src/text.c; all DB2 calls audited in canonical_index.c, code_index.c, and kb_payload.c.",
+      "evidence": "Deterministic in-place UTF-8 repair with no imports, allocation, I/O, DB, event-bus, provider, or platform dependency; exhaustive parity tested."
     }
   ],
   "unresolved": [
@@ -3523,16 +3551,6 @@
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
     },
     {
-      "symbol": "text_sanitize_utf8",
-      "references": [
-        "src/modules/db2/c/canonical_index.c",
-        "src/modules/db2/c/code_index.c",
-        "src/modules/db2/c/kb_payload.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
       "symbol": "time",
       "references": [
         "src/modules/db2/c/bandit.c",
@@ -3813,16 +3831,16 @@
   ],
   "summary": {
     "translation_units": 141,
-    "descriptor_support_units": 2,
-    "unresolved_symbols": 345,
+    "descriptor_support_units": 3,
+    "unresolved_symbols": 344,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 25,
       "injected-module-contract": 150,
-      "portable-core-promotion": 26,
+      "portable-core-promotion": 25,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 144
     }
   },
-  "fingerprint": "b59a0e14c6ce628b97fa9c57873f5f7e2b7209166c099358113638533cd383b4"
+  "fingerprint": "a6b6e2be90604ded69a4febf7c6fbed95eca724fe0667e5dc887523011429d8f"
 }

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -14,7 +14,8 @@
     "src/modules/db2/db3_route.c",
     "src/modules/db2/module_adapter.c",
     "src/modules/db2/support/dstr_primitives.c",
-    "src/modules/db2/support/sketch_primitives.c"
+    "src/modules/db2/support/sketch_primitives.c",
+    "src/modules/db2/support/text_primitives.c"
   ],
   "public_headers": [
     "src/modules/db2/include/aimee/db2/client.h",
@@ -30,6 +31,7 @@
   "private_headers": [
     "src/modules/db2/module_adapter.h",
     "src/modules/db2/support/db2_dstr.h",
+    "src/modules/db2/support/db2_text.h",
     "src/modules/db2/support/sketch.h"
   ],
   "tests": [
@@ -38,6 +40,7 @@
     "src/tests/test_db2_module_contract.c",
     "src/tests/test_db2_dstr_support.c",
     "src/tests/test_db2_sketch_support.c",
+    "src/tests/test_db2_text_support.c",
     "src/tests/test_db3_route.c"
   ],
   "docs": [

--- a/src/modules/db2/support/db2_text.h
+++ b/src/modules/db2/support/db2_text.h
@@ -1,0 +1,9 @@
+/* Descriptor-owned ABI for DB2's UTF-8 repair support. */
+#ifndef AIMEE_DB2_SUPPORT_TEXT_H
+#define AIMEE_DB2_SUPPORT_TEXT_H
+
+#include <stddef.h>
+
+size_t text_sanitize_utf8(char *s);
+
+#endif

--- a/src/modules/db2/support/text_primitives.c
+++ b/src/modules/db2/support/text_primitives.c
@@ -1,0 +1,49 @@
+/* Descriptor-owned DB2 support for deterministic in-place UTF-8 repair. */
+#include "db2_text.h"
+
+size_t text_sanitize_utf8(char *s)
+{
+   if (!s)
+      return 0;
+
+   size_t replaced = 0;
+   for (size_t i = 0; s[i];)
+   {
+      unsigned char c = (unsigned char)s[i];
+      size_t need = 0;
+      if (c <= 0x7f)
+         need = 1;
+      else if (c >= 0xc2 && c <= 0xdf)
+         need = 2;
+      else if (c >= 0xe0 && c <= 0xef)
+         need = 3;
+      else if (c >= 0xf0 && c <= 0xf4)
+         need = 4;
+
+      int valid = need != 0;
+      for (size_t j = 1; valid && j < need; j++)
+         valid = s[i + j] && ((unsigned char)s[i + j] & 0xc0) == 0x80;
+
+      if (valid && need == 3)
+      {
+         unsigned char second = (unsigned char)s[i + 1];
+         if ((c == 0xe0 && second < 0xa0) || (c == 0xed && second > 0x9f))
+            valid = 0;
+      }
+      if (valid && need == 4)
+      {
+         unsigned char second = (unsigned char)s[i + 1];
+         if ((c == 0xf0 && second < 0x90) || (c == 0xf4 && second > 0x8f))
+            valid = 0;
+      }
+
+      if (valid)
+      {
+         i += need;
+         continue;
+      }
+      s[i++] = '?';
+      replaced++;
+   }
+   return replaced;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -730,6 +730,7 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-db2-module-contract \
                 $(TESTPREFIX)/unit-test-bus-db2-module \
                 $(TESTPREFIX)/unit-test-db2-dstr-support \
                 $(TESTPREFIX)/unit-test-db2-sketch-support \
+                $(TESTPREFIX)/unit-test-db2-text-support \
                 $(TESTPREFIX)/unit-test-db3-route \
                 $(TESTPREFIX)/unit-test-bus-db3
 
@@ -801,7 +802,8 @@ UNIT_TEST_SHARD_INDEX ?= 0
 UNIT_TEST_SKIP_P1 ?= 0
 ifeq ($(UNIT_TEST_SHARD_INDEX),0)
 UNIT_TEST_AUX_TARGETS = $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize \
-                        $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize
+                        $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize \
+                        $(TESTPREFIX)/unit-test-db2-text-support-sanitize
 else
 UNIT_TEST_AUX_TARGETS =
 endif
@@ -6663,6 +6665,53 @@ unit-test-db2-dstr-support: $(TESTPREFIX)/unit-test-db2-dstr-support
 	$<
 
 unit-test-db2-dstr-support-sanitize: $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize
+	$<
+
+DB2_TEXT_SUPPORT_RENAMES = -Dtext_sanitize_utf8=db2_support_text_sanitize_utf8
+DB2_TEXT_SECTION_FLAGS = -ffunction-sections -fdata-sections
+
+$(OBJDIR)/tests/db2_text_support_impl.o: modules/db2/support/text_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TEXT_SUPPORT_RENAMES) \
+	      $(DB2_TEXT_SECTION_FLAGS) -c -o $@ $<
+
+$(OBJDIR)/tests/db2_text_monolith.o: text.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TEXT_SECTION_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-text-support: \
+                     $(OBJDIR)/tests/test_db2_text_support.o \
+                     $(OBJDIR)/tests/db2_text_support_impl.o \
+                     $(OBJDIR)/tests/db2_text_monolith.o
+	$(TESTLINK_MIN) -Wl,--gc-sections -o $@ $^ $(TEST_L_FLAGS)
+
+DB2_TEXT_SANITIZE_DIR = $(OBJDIR)/tests/db2-text-support-sanitize
+
+$(DB2_TEXT_SANITIZE_DIR)/test.o: tests/test_db2_text_support.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_TEXT_SANITIZE_DIR)/support.o: modules/db2/support/text_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TEXT_SUPPORT_RENAMES) $(DB2_TEXT_SECTION_FLAGS) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_TEXT_SANITIZE_DIR)/monolith.o: text.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TEXT_SECTION_FLAGS) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-text-support-sanitize: \
+                     $(DB2_TEXT_SANITIZE_DIR)/test.o \
+                     $(DB2_TEXT_SANITIZE_DIR)/support.o \
+                     $(DB2_TEXT_SANITIZE_DIR)/monolith.o
+	$(CC) $(DB2_SUPPORT_SANITIZE_FLAGS) -Wl,--gc-sections -o $@ $^
+
+.PHONY: unit-test-db2-text-support unit-test-db2-text-support-sanitize
+unit-test-db2-text-support: $(TESTPREFIX)/unit-test-db2-text-support
+	$<
+
+unit-test-db2-text-support-sanitize: $(TESTPREFIX)/unit-test-db2-text-support-sanitize
 	$<
 
 DB2_SKETCH_SUPPORT_RENAMES = \

--- a/src/tests/test_db2_text_support.c
+++ b/src/tests/test_db2_text_support.c
@@ -1,0 +1,152 @@
+/* Exhaustive parity tests for descriptor-owned DB2 UTF-8 repair. */
+#include "util.h"
+
+#include <assert.h>
+#include <string.h>
+
+size_t db2_support_text_sanitize_utf8(char *s);
+
+static void assert_parity(const unsigned char *input, size_t len, size_t expected)
+{
+   char monolith[16];
+   char support[16];
+   assert(len < sizeof(monolith));
+   memcpy(monolith, input, len);
+   memcpy(support, input, len);
+   monolith[len] = support[len] = '\0';
+
+   size_t monolith_count = text_sanitize_utf8(monolith);
+   size_t support_count = db2_support_text_sanitize_utf8(support);
+   if (expected != (size_t)-1)
+   {
+      assert(monolith_count == expected);
+      assert(support_count == expected);
+   }
+   assert(monolith_count == support_count);
+   assert(memcmp(monolith, support, len + 1) == 0);
+}
+
+static void test_single_bytes(void)
+{
+   for (unsigned value = 1; value <= 255; value++)
+   {
+      unsigned char input[] = {(unsigned char)value};
+      assert_parity(input, sizeof(input), value <= 0x7f ? 0 : 1);
+   }
+   assert_parity((const unsigned char *)"", 0, 0);
+   assert(text_sanitize_utf8(NULL) == 0);
+   assert(db2_support_text_sanitize_utf8(NULL) == 0);
+}
+
+static void test_valid_and_truncated_sequences(void)
+{
+   static const unsigned char valid[][4] = {
+       {0xc2, 0x80, 0, 0},       {0xdf, 0xbf, 0, 0},    {0xe0, 0xa0, 0x80, 0},
+       {0xed, 0x9f, 0xbf, 0},    {0xef, 0xbf, 0xbf, 0}, {0xf0, 0x90, 0x80, 0x80},
+       {0xf4, 0x8f, 0xbf, 0xbf},
+   };
+   static const size_t lengths[] = {2, 2, 3, 3, 3, 4, 4};
+   for (size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++)
+   {
+      assert_parity(valid[i], lengths[i], 0);
+      for (size_t truncated = 1; truncated < lengths[i]; truncated++)
+         assert_parity(valid[i], truncated, truncated);
+   }
+}
+
+static void test_invalid_ranges_and_mixed_text(void)
+{
+   static const unsigned char invalid[][4] = {
+       {0xc0, 0x80, 0, 0},       {0xc1, 0xbf, 0, 0},       {0xe0, 0x9f, 0x80, 0},
+       {0xed, 0xa0, 0x80, 0},    {0xf0, 0x8f, 0x80, 0x80}, {0xf4, 0x90, 0x80, 0x80},
+       {0xf5, 0x80, 0x80, 0x80}, {0xff, 0x80, 0x80, 0x80},
+   };
+   static const size_t lengths[] = {2, 2, 3, 3, 4, 4, 4, 4};
+   for (size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++)
+      assert_parity(invalid[i], lengths[i], lengths[i]);
+
+   static const unsigned char mixed[] = {
+       'a', 0xc2, 0xa2, '-', 0xe0, 0x80, 0x80, '-', 0xf0, 0x9f, 0x98, 0x80, 0x80, 'z',
+   };
+   assert_parity(mixed, sizeof(mixed), 4);
+}
+
+static void test_exhaustive_multibyte_space(void)
+{
+   unsigned char input[4];
+
+   for (unsigned lead = 0xc2; lead <= 0xdf; lead++)
+      for (unsigned second = 0x80; second <= 0xbf; second++)
+      {
+         input[0] = (unsigned char)lead;
+         input[1] = (unsigned char)second;
+         assert_parity(input, 2, 0);
+      }
+
+   for (unsigned lead = 0xe0; lead <= 0xef; lead++)
+      for (unsigned second = 0x80; second <= 0xbf; second++)
+         for (unsigned third = 0x80; third <= 0xbf; third++)
+         {
+            input[0] = (unsigned char)lead;
+            input[1] = (unsigned char)second;
+            input[2] = (unsigned char)third;
+            int valid = !((lead == 0xe0 && second < 0xa0) || (lead == 0xed && second > 0x9f));
+            assert_parity(input, 3, valid ? 0 : 3);
+         }
+
+   for (unsigned lead = 0xf0; lead <= 0xf4; lead++)
+      for (unsigned second = 0x80; second <= 0xbf; second++)
+         for (unsigned third = 0x80; third <= 0xbf; third++)
+            for (unsigned fourth = 0x80; fourth <= 0xbf; fourth++)
+            {
+               input[0] = (unsigned char)lead;
+               input[1] = (unsigned char)second;
+               input[2] = (unsigned char)third;
+               input[3] = (unsigned char)fourth;
+               int valid = !((lead == 0xf0 && second < 0x90) || (lead == 0xf4 && second > 0x8f));
+               assert_parity(input, 4, valid ? 0 : 4);
+            }
+}
+
+static void test_every_truncation_and_malformed_position(void)
+{
+   for (unsigned lead = 0xc2; lead <= 0xf4; lead++)
+   {
+      size_t need = lead <= 0xdf ? 2 : lead <= 0xef ? 3 : 4;
+      unsigned char input[4] = {(unsigned char)lead, 0x80, 0x80, 0x80};
+      if (lead == 0xe0)
+         input[1] = 0xa0;
+      else if (lead == 0xed)
+         input[1] = 0x9f;
+      else if (lead == 0xf0)
+         input[1] = 0x90;
+      else if (lead == 0xf4)
+         input[1] = 0x8f;
+
+      for (size_t truncated = 1; truncated < need; truncated++)
+         assert_parity(input, truncated, truncated);
+
+      for (size_t position = 1; position < need; position++)
+      {
+         unsigned char original = input[position];
+         for (unsigned value = 1; value <= 255; value++)
+         {
+            if ((value & 0xc0) == 0x80)
+               continue;
+            input[position] = (unsigned char)value;
+            assert_parity(input, need, (size_t)-1);
+         }
+         input[position] = original;
+      }
+   }
+}
+
+int main(void)
+{
+   test_single_bytes();
+   test_valid_and_truncated_sequences();
+   test_invalid_ranges_and_mixed_text();
+   test_exhaustive_multibyte_space();
+   test_every_truncation_and_malformed_position();
+   return 0;
+}

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -80,6 +80,12 @@
       "test": "src/tests/test_db2_sketch_support.c"
     },
     {
+      "ctest": false,
+      "make": true,
+      "module": "db2",
+      "test": "src/tests/test_db2_text_support.c"
+    },
+    {
       "ctest": true,
       "make": true,
       "module": "db2",


### PR DESCRIPTION
Promotes the allocation-free UTF-8 repair used by DB2 into descriptor-owned module support while leaving the frozen legacy boundary unchanged.

- reduce live closure from 345 to 344 and portable promotion debt from 26 to 25
- pin the minimal ABI, source/header hashes, empty import set, exact export, include, and three referencing DB2 units
- exhaustively compare all two-, three-, and four-byte lead/continuation combinations, every truncated prefix, every malformed continuation position, single bytes, mixed input, empty input, and NULL
- run the identical corpus under normal and ASan/UBSan/FORTIFY builds
- register descriptor ownership and ratchet baselines

Focused closure, source-boundary, descriptor, registration, sanitizer, and build-integrity gates pass. Roundtable approved the exact artifact with no findings.