### PR TITLE
economizer: own the reducer state instead of having C carry it

### DIFF
--- a/scripts/export_c_repositories.py
+++ b/scripts/export_c_repositories.py
@@ -424,20 +424,30 @@ def go_bus_sources(module_id: str | None = None) -> list[str]:
     )
 
 
-def go_process_shared_sources(module_id: str) -> list[str]:
-    """Return shared caller contracts needed by independently built Go modules.
+# Caller-side contracts that live outside any implementation module, mapped to
+# the modules that import them. Each is deliberately not owned by the module it
+# talks to: every peer that calls delegates may import server-go/delegate, and
+# every peer that keeps state in DB1 may import server-go/db1, without importing
+# the serving module. Add entries here in lockstep with the caller's process
+# contract and runtime-bundle coverage.
+GO_SHARED_CONTRACTS = {
+    "server-go/delegate": {"delegates", "roundtable"},
+    "server-go/db1": {"economizer"},
+}
 
-    ``server-go/delegate`` is intentionally outside any implementation module:
-    every module that calls delegates may import it. Add such module IDs here in
-    lockstep with their process contract and runtime-bundle coverage.
-    """
-    if module_id not in {"delegates", "roundtable"}:
-        return []
-    return sorted(
-        path.relative_to(ROOT).as_posix()
-        for path in (ROOT / "server-go/delegate").glob("*.go")
-        if not path.name.endswith("_test.go")
-    )
+
+def go_process_shared_sources(module_id: str) -> list[str]:
+    """Return shared caller contracts needed by independently built Go modules."""
+    sources: list[str] = []
+    for directory, importers in GO_SHARED_CONTRACTS.items():
+        if module_id not in importers:
+            continue
+        sources.extend(
+            path.relative_to(ROOT).as_posix()
+            for path in (ROOT / directory).glob("*.go")
+            if not path.name.endswith("_test.go")
+        )
+    return sorted(sources)
 
 
 def go_dependency_version(module_path: str) -> str:

--- a/server-go/cmd/aimee-module/main.go
+++ b/server-go/cmd/aimee-module/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/JBailes/aimee/server-go/bus"
+	"github.com/JBailes/aimee/server-go/db1"
 	delegatecontract "github.com/JBailes/aimee/server-go/delegate"
 	"github.com/JBailes/aimee/server-go/modules/benchmarks"
 	controlweb "github.com/JBailes/aimee/server-go/modules/control-web"
@@ -42,6 +43,38 @@ var errUsage = errors.New("usage: aimee-module-NAME DAEMON_MODULE_BUS_SOCKET")
 // seats them over. Both are required -- a review with no configured panel,
 // or with no way to reach an agent, is not a degraded review but no review.
 const roundtableDelegatePrincipalRef uint32 = 65
+
+// economizerStorePrincipalRef is the economizer's OUTBOUND identity. A module's
+// serving grant requests nothing, so reaching another module's stage needs a
+// second principal that is granted exactly that request and nothing else.
+const economizerStorePrincipalRef uint32 = 66
+
+// economizerStore seats the economizer's reducer state on DB1.
+//
+// A failure here is not fatal to the module. Reducer state makes the NEXT turn
+// cheaper, so a module that cannot reach the store still reduces -- it just
+// never warms up. Refusing to serve would turn a lost optimization into a lost
+// feature, so this returns a nil store and lets the caller carry on.
+func economizerStore(ctx context.Context, moduleBusSocket string) economizer.StateStore {
+	if ctx == nil || moduleBusSocket == "" {
+		return nil
+	}
+	busClient, err := bus.ConnectClient(ctx, moduleBusSocket, 1, economizerStorePrincipalRef)
+	if err != nil {
+		return nil
+	}
+	caller, err := bus.NewConcurrentModuleCaller(ctx, busClient)
+	if err != nil {
+		busClient.Detach()
+		return nil
+	}
+	store, err := db1.NewClient(caller, 0)
+	if err != nil {
+		busClient.Detach()
+		return nil
+	}
+	return store
+}
 
 func roundtableReviewer(ctx context.Context, moduleBusSocket string) (*roundtable.PanelReviewer, error) {
 	home := os.Getenv("AIMEE_HOME")
@@ -264,9 +297,11 @@ func moduleConfigRuntime(ctx context.Context, executable, moduleBusSocket string
 			{EventKind: economizer.EventPostStatus, StageID: economizer.StagePostStatus},
 			{EventKind: economizer.EventStats, StageID: economizer.StageStats},
 		}
-		// Stateless: per-conversation reducer state travels with each request, so
-		// there is no store to open and no failure mode before serving.
-		config.Handler = economizer.NewHandler()
+		// Per-conversation reducer state is the module's own, kept in DB1 over
+		// the bus. An unreachable store is not a failure mode before serving:
+		// the module reduces without warming up.
+		config.Handler = economizer.NewHandlerWithStore(
+			economizerStore(ctx, moduleBusSocket))
 	case "postgres":
 		config.ModuleName = name
 		config.PrincipalRef = 28

--- a/server-go/modules/economizer/episode_test.go
+++ b/server-go/modules/economizer/episode_test.go
@@ -10,7 +10,7 @@ func TestEpisodeInventoryAndTouch(t *testing.T) {
 	s.AddFile("src/modules/db2/c/code_index.c")
 	s.AddFile("src/headers/code_span.h")
 	s.AddFile("src/modules/db2/c/code_index.c") // duplicate
-	s.AddFile("")                     // ignored
+	s.AddFile("")                               // ignored
 
 	if len(s.Files) != 2 {
 		t.Fatalf("file count = %d, want 2", len(s.Files))

--- a/server-go/modules/economizer/gateway_wire.go
+++ b/server-go/modules/economizer/gateway_wire.go
@@ -44,6 +44,14 @@ const (
 	Stat5xxDisable            = "5xx_disable"
 	StatStreamErrorDisable    = "stream_error_disable"
 	StatHardBypass            = "hard_bypass"
+
+	// Reducer state is an optimization, so a store failure degrades silently by
+	// design -- the reduction still runs, it just never warms up. That is
+	// exactly why it has to be COUNTED: a fold that has quietly stopped reusing
+	// its freeze boundary looks like a fold that is working, and the only other
+	// evidence is a token bill that does not fall.
+	StatStateUnavailable = "state_unavailable"
+	StatStateSaveFailed  = "state_save_failed"
 )
 
 // GatewayConfig is the resolved configuration for one request.

--- a/server-go/modules/economizer/module.go
+++ b/server-go/modules/economizer/module.go
@@ -117,10 +117,12 @@ type ReduceRequest struct {
 	ClosetMaxRatioPct     int    `json:"closet_max_ratio_pct,omitempty"`
 	ClosetDenylist        string `json:"closet_denylist,omitempty"`
 
-	// State is the serialized per-conversation reducer state, empty on the first
-	// turn of a conversation.
-	State string `json:"state,omitempty"`
-	Turn  int    `json:"turn,omitempty"`
+	// StateKey identifies the conversation whose reducer state this reduction
+	// continues. The caller owns conversation identity, so it names the
+	// conversation; the module owns the state kept under that name, so the blob
+	// and the turn counter never cross this boundary. Empty means "do not
+	// persist", which reduces normally but always from cold.
+	StateKey string `json:"state_key,omitempty"`
 }
 
 // ReduceResponse carries the reduced view and the ledger.
@@ -155,11 +157,6 @@ type ReduceResponse struct {
 
 	RecallHint     string `json:"recall_hint,omitempty"`
 	RecallSurfaced int    `json:"recall_surfaced,omitempty"`
-
-	// State is the serialized reducer state to persist for the next turn. Empty
-	// when it could not be serialized, which the caller treats as "keep what you
-	// have" rather than "clear it".
-	State string `json:"state,omitempty"`
 }
 
 var reduceReasonNames = map[ReduceReason]string{
@@ -174,7 +171,15 @@ var reduceReasonNames = map[ReduceReason]string{
 //
 // The breaker is created per handler rather than as a package global so a test
 // gets a clean one and two handlers never share a lever.
+// NewHandler serves without a state store: reductions still run, they just
+// never warm up between turns. Used where no store is reachable, and by tests.
 func NewHandler() bus.ModuleHandler {
+	return NewHandlerWithStore(nil)
+}
+
+// NewHandlerWithStore serves with somewhere to keep per-conversation reducer
+// state. A nil store is legal and means the same as NewHandler.
+func NewHandlerWithStore(store StateStore) bus.ModuleHandler {
 	breaker := NewSessionBreaker()
 	stats := NewGatewayStatsStore()
 	return func(invocation bus.ModuleInvocation, request []byte) ([]byte, bus.ModuleStatus) {
@@ -199,7 +204,7 @@ func NewHandler() bus.ModuleHandler {
 			if err := json.Unmarshal(request, &req); err != nil {
 				return nil, bus.ModuleStatusInvalidRequest
 			}
-			return handleReduce(breaker, stats, &req)
+			return handleReduce(breaker, stats, store, &req)
 		case StageJSONCompact:
 			return handleJSONCompact(invocation, request)
 		case StageToolRecall:
@@ -214,7 +219,8 @@ func NewHandler() bus.ModuleHandler {
 	}
 }
 
-func handleReduce(breaker *SessionBreaker, stats *GatewayStatsStore, req *ReduceRequest) ([]byte, bus.ModuleStatus) {
+func handleReduce(breaker *SessionBreaker, stats *GatewayStatsStore, store StateStore,
+	req *ReduceRequest) ([]byte, bus.ModuleStatus) {
 	messages := ParseJSON(string(req.Messages))
 	if messages == nil || !messages.IsArray() {
 		return nil, bus.ModuleStatusInvalidRequest
@@ -281,17 +287,7 @@ func handleReduce(breaker *SessionBreaker, stats *GatewayStatsStore, req *Reduce
 		cfg.DelegateSeam = true
 	}
 
-	st := &ReduceState{Turn: req.Turn, Recall: NewRecallIndex()}
-	if req.State != "" {
-		// A state we cannot read is DISCARDED rather than fatal: the reduction
-		// still runs, it just starts from a cold freeze and an empty page table.
-		// Failing the whole request would be worse than losing one turn of warmth.
-		_ = RestoreState(st, req.State)
-		st.Turn = req.Turn
-		if st.Recall == nil {
-			st.Recall = NewRecallIndex()
-		}
-	}
+	st := restoreState(store, stats, req.StateKey)
 
 	out := Reduce(messages, req.SystemPrompt, seam, cfg, st)
 
@@ -335,9 +331,12 @@ func handleReduce(breaker *SessionBreaker, stats *GatewayStatsStore, req *Reduce
 		// prefix and cost the cache.
 		resp.Messages = json.RawMessage(PrintJSONUnformatted(out.Messages))
 	}
-	if blob, ok := SerializeState(st); ok {
-		resp.State = blob
-	}
+	// Persist BEFORE any bypass decision and regardless of it. The freeze
+	// boundary has to advance on every turn the reducer saw, not only the ones
+	// that shipped a reduced payload: drop it on a bypass and the next turn
+	// re-folds from cold, moving the prefix and costing the cache read the
+	// freeze exists to keep.
+	persistState(store, stats, req.StateKey, st)
 
 	body, err := json.Marshal(resp)
 	if err != nil {

--- a/server-go/modules/economizer/module_test.go
+++ b/server-go/modules/economizer/module_test.go
@@ -211,6 +211,37 @@ func TestModuleStoreFailuresAreNotFatal(t *testing.T) {
 	}
 }
 
+// A module wired without a store is the degradation that never heals: it is
+// decided once at startup and lasts the life of the process. It is therefore
+// the one that most needs counting.
+func TestAMissingStoreIsCountedWhenAConversationWasNamed(t *testing.T) {
+	handler := NewHandlerWithStore(nil)
+	body, err := json.Marshal(ReduceRequest{
+		Messages:      rawMessages(t, 20),
+		Seam:          "gateway",
+		HistoryFold:   true,
+		ClosetEnabled: true,
+		StateKey:      "conv-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, status := handler(bus.ModuleInvocation{StageID: StageReduce}, body); status != bus.ModuleStatusOK {
+		t.Fatalf("a storeless module must still reduce: %v", status)
+	}
+	out, status := handler(bus.ModuleInvocation{StageID: StageStats}, []byte(`{}`))
+	if status != bus.ModuleStatusOK {
+		t.Fatalf("stats stage status = %v", status)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out, &raw); err != nil {
+		t.Fatalf("stats are not JSON: %v", err)
+	}
+	if n, _ := raw["economizer_state_unavailable"].(float64); n < 1 {
+		t.Errorf("a named conversation with no store went uncounted: %v", raw)
+	}
+}
+
 // A store that degrades must be COUNTED, because degrading is silent by design:
 // the fold keeps running and simply stops warming up, which looks exactly like a
 // fold that is working.

--- a/server-go/modules/economizer/module_test.go
+++ b/server-go/modules/economizer/module_test.go
@@ -1,8 +1,10 @@
 package economizer
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +20,53 @@ func invoke(t *testing.T, req ReduceRequest) (ReduceResponse, bus.ModuleStatus) 
 		t.Fatal(err)
 	}
 	out, status := NewHandler()(bus.ModuleInvocation{StageID: StageReduce}, body)
+	var resp ReduceResponse
+	if status == bus.ModuleStatusOK {
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("response is not JSON: %v", err)
+		}
+	}
+	return resp, status
+}
+
+// memStore is a StateStore that keeps blobs in memory, so the state tests
+// exercise the module's own load/save path without needing a bus.
+type memStore struct {
+	blobs   map[string]string
+	loadErr error
+	saveErr error
+	loads   int
+	saves   int
+}
+
+func (m *memStore) LoadState(_ context.Context, key string) (string, bool, error) {
+	m.loads++
+	if m.loadErr != nil {
+		return "", false, m.loadErr
+	}
+	blob, ok := m.blobs[key]
+	return blob, ok && blob != "", nil
+}
+
+func (m *memStore) SaveState(_ context.Context, key, blob string) error {
+	m.saves++
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	if m.blobs == nil {
+		m.blobs = map[string]string{}
+	}
+	m.blobs[key] = blob
+	return nil
+}
+
+func invokeWithStore(t *testing.T, store StateStore, req ReduceRequest) (ReduceResponse, bus.ModuleStatus) {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, status := NewHandlerWithStore(store)(bus.ModuleInvocation{StageID: StageReduce}, body)
 	var resp ReduceResponse
 	if status == bus.ModuleStatusOK {
 		if err := json.Unmarshal(out, &resp); err != nil {
@@ -80,47 +129,144 @@ func TestModuleNoMutationOmitsMessages(t *testing.T) {
 	}
 }
 
-// State round-trips through the stage, so a conversation keeps its freeze
-// boundary and page table across turns.
+// State round-trips through the STORE, so a conversation keeps its freeze
+// boundary and page table across turns without the caller ever handling it.
 func TestModuleStateRoundTrip(t *testing.T) {
-	first, status := invoke(t, ReduceRequest{
-		Messages:      rawMessages(t, 20),
-		Seam:          "delegate",
-		HistoryFold:   true,
-		ClosetEnabled: true,
-		RecallEnabled: true,
-		Turn:          1,
-	})
-	if status != bus.ModuleStatusOK || first.State == "" {
-		t.Fatalf("expected serialized state back: %+v", first)
+	store := &memStore{}
+	turn := func() ReduceRequest {
+		return ReduceRequest{
+			Messages:      rawMessages(t, 20),
+			Seam:          "delegate",
+			HistoryFold:   true,
+			ClosetEnabled: true,
+			RecallEnabled: true,
+			StateKey:      "conv-1",
+		}
+	}
+	if _, status := invokeWithStore(t, store, turn()); status != bus.ModuleStatusOK {
+		t.Fatalf("first turn status = %v", status)
+	}
+	first, ok := store.blobs["conv-1"]
+	if !ok || first == "" {
+		t.Fatalf("the module must persist its own state, store = %+v", store.blobs)
 	}
 
-	second, status := invoke(t, ReduceRequest{
+	if _, status := invokeWithStore(t, store, turn()); status != bus.ModuleStatusOK {
+		t.Fatalf("second turn status = %v", status)
+	}
+	if store.blobs["conv-1"] == "" {
+		t.Error("state should survive a second turn")
+	}
+	// The turn counter is the module's to advance now that it owns the blob.
+	var restored ReduceState
+	if err := RestoreState(&restored, store.blobs["conv-1"]); err != nil {
+		t.Fatalf("stored state is unreadable: %v", err)
+	}
+	if restored.Turn < 1 {
+		t.Errorf("turn should advance across turns, got %d", restored.Turn)
+	}
+}
+
+// A conversation with no key still reduces; it just never warms up. This is the
+// path a caller takes when it has no conversation identity to name.
+func TestModuleWithoutAStateKeyNeverPersists(t *testing.T) {
+	store := &memStore{}
+	resp, status := invokeWithStore(t, store, ReduceRequest{
 		Messages:      rawMessages(t, 20),
 		Seam:          "delegate",
 		HistoryFold:   true,
 		ClosetEnabled: true,
-		RecallEnabled: true,
-		State:         first.State,
-		Turn:          2,
 	})
-	if status != bus.ModuleStatusOK {
-		t.Fatalf("status = %v", status)
+	if status != bus.ModuleStatusOK || !resp.Mutated {
+		t.Fatalf("the reduction should still run: status=%v resp=%+v", status, resp)
 	}
-	if second.State == "" {
-		t.Error("state should survive a second turn")
+	if store.loads != 0 || store.saves != 0 {
+		t.Errorf("an unkeyed request touched the store: %d loads, %d saves",
+			store.loads, store.saves)
+	}
+}
+
+// An unreachable store costs one cold turn, not the reduction. Reducer state is
+// an optimization, so every storage failure lands in the same safe place.
+func TestModuleStoreFailuresAreNotFatal(t *testing.T) {
+	for name, store := range map[string]*memStore{
+		"load fails": {loadErr: errStoreDown},
+		"save fails": {saveErr: errStoreDown},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, status := invokeWithStore(t, store, ReduceRequest{
+				Messages:      rawMessages(t, 20),
+				Seam:          "delegate",
+				HistoryFold:   true,
+				ClosetEnabled: true,
+				StateKey:      "conv-1",
+			})
+			if status != bus.ModuleStatusOK {
+				t.Fatalf("a store failure must not fail the reduction: %v", status)
+			}
+			if !resp.Mutated {
+				t.Error("the reduction should still have run")
+			}
+		})
+	}
+}
+
+// A store that degrades must be COUNTED, because degrading is silent by design:
+// the fold keeps running and simply stops warming up, which looks exactly like a
+// fold that is working.
+func TestStoreDegradationIsCounted(t *testing.T) {
+	for name, tc := range map[string]struct {
+		store   *memStore
+		counter string
+	}{
+		"unreachable on load": {&memStore{loadErr: errStoreDown}, "economizer_state_unavailable"},
+		"unreadable blob":     {&memStore{blobs: map[string]string{"conv-1": "{not valid"}}, "economizer_state_unavailable"},
+		"write fails":         {&memStore{saveErr: errStoreDown}, "economizer_state_save_failed"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			handler := NewHandlerWithStore(tc.store)
+			body, err := json.Marshal(ReduceRequest{
+				Messages:      rawMessages(t, 20),
+				Seam:          "gateway",
+				HistoryFold:   true,
+				ClosetEnabled: true,
+				StateKey:      "conv-1",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, status := handler(bus.ModuleInvocation{StageID: StageReduce}, body); status != bus.ModuleStatusOK {
+				t.Fatalf("degradation must not fail the reduction: %v", status)
+			}
+			out, status := handler(bus.ModuleInvocation{StageID: StageStats}, []byte(`{}`))
+			if status != bus.ModuleStatusOK {
+				t.Fatalf("stats stage status = %v", status)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(out, &raw); err != nil {
+				t.Fatalf("stats are not JSON: %v", err)
+			}
+			got, ok := raw[tc.counter]
+			if !ok {
+				t.Fatalf("counter %q absent from stats: %v", tc.counter, raw)
+			}
+			if n, _ := got.(float64); n < 1 {
+				t.Errorf("counter %q = %v, want at least 1", tc.counter, got)
+			}
+		})
 	}
 }
 
 // An unreadable state is DISCARDED, not fatal: the reduction still runs, it just
 // starts cold. Failing the request would cost more than one turn of warmth.
 func TestModuleBadStateIsNotFatal(t *testing.T) {
-	resp, status := invoke(t, ReduceRequest{
+	store := &memStore{blobs: map[string]string{"conv-1": "{not valid"}}
+	resp, status := invokeWithStore(t, store, ReduceRequest{
 		Messages:      rawMessages(t, 20),
 		Seam:          "delegate",
 		HistoryFold:   true,
 		ClosetEnabled: true,
-		State:         "{not valid",
+		StateKey:      "conv-1",
 	})
 	if status != bus.ModuleStatusOK {
 		t.Fatalf("a bad state blob must not fail the request: %v", status)
@@ -311,3 +457,5 @@ func TestModuleEventKindMatchesContract(t *testing.T) {
 		}
 	}
 }
+
+var errStoreDown = errors.New("store is unreachable")

--- a/server-go/modules/economizer/state_store.go
+++ b/server-go/modules/economizer/state_store.go
@@ -1,0 +1,81 @@
+package economizer
+
+import "context"
+
+// StateStore is where a seam's per-conversation reducer state lives between
+// turns. The economizer owns this state, so it loads and saves it itself rather
+// than having a caller carry the blob in and back out: a caller that ferries
+// state has to know the module has state at all, which is the coupling the
+// module boundary exists to remove.
+//
+// server-go/db1.Client satisfies this over the bus. It is an interface here so
+// the module depends on the capability rather than on DB1.
+type StateStore interface {
+	// LoadState returns the stored blob and whether one was found. A miss is
+	// not an error: the first turn of a conversation has no state.
+	LoadState(ctx context.Context, key string) (string, bool, error)
+	SaveState(ctx context.Context, key, blob string) error
+}
+
+// restoreState seats the reducer state for this turn.
+//
+// Every failure here is deliberately soft, and they all land in the same place:
+// a cold start. Reducer state is an optimization -- it carries a freeze
+// boundary and a page table that make the NEXT turn cheaper -- so losing it
+// costs one cold turn, while failing the request costs the caller its whole
+// reduction. No store configured, no key, an unreachable store, and an
+// unreadable blob are therefore all the same outcome by design.
+func restoreState(store StateStore, stats *GatewayStatsStore, key string) *ReduceState {
+	st := &ReduceState{Recall: NewRecallIndex()}
+	if store == nil || key == "" {
+		return st
+	}
+	blob, found, err := store.LoadState(context.Background(), key)
+	if err != nil {
+		statsIncStore(stats, StatStateUnavailable)
+		return st
+	}
+	if !found || blob == "" {
+		return st
+	}
+	if err := RestoreState(st, blob); err != nil {
+		// Discard rather than fail: see above. Counted as unavailable because
+		// the effect is identical -- this turn runs cold.
+		statsIncStore(stats, StatStateUnavailable)
+		return &ReduceState{Recall: NewRecallIndex()}
+	}
+	// The stored turn is the one that WROTE this state, so this turn is the
+	// next one. The caller used to compute this; it is the module's to know.
+	st.Turn++
+	if st.Recall == nil {
+		st.Recall = NewRecallIndex()
+	}
+	return st
+}
+
+// persistState writes the state this turn produced. A blob that will not
+// serialize is left unwritten, which the next turn reads as "keep what you
+// have" rather than as a cleared boundary.
+func persistState(store StateStore, stats *GatewayStatsStore, key string, st *ReduceState) {
+	if store == nil || key == "" {
+		return
+	}
+	blob, ok := SerializeState(st)
+	if !ok || blob == "" {
+		return
+	}
+	// A failed write costs the next turn its warmth and nothing else, so it is
+	// not worth failing a reduction that already succeeded -- but it is worth
+	// counting, because nothing else would show it.
+	if err := store.SaveState(context.Background(), key, blob); err != nil {
+		statsIncStore(stats, StatStateSaveFailed)
+	}
+}
+
+// statsIncStore counts a store outcome when there is somewhere to count it.
+func statsIncStore(stats *GatewayStatsStore, counter string) {
+	if stats == nil {
+		return
+	}
+	stats.Inc(counter)
+}

--- a/server-go/modules/economizer/state_store.go
+++ b/server-go/modules/economizer/state_store.go
@@ -27,7 +27,17 @@ type StateStore interface {
 // unreadable blob are therefore all the same outcome by design.
 func restoreState(store StateStore, stats *GatewayStatsStore, key string) *ReduceState {
 	st := &ReduceState{Recall: NewRecallIndex()}
-	if store == nil || key == "" {
+	if key == "" {
+		// The caller named no conversation, so there is nothing to continue.
+		// Not counted: running cold is the correct and intended outcome.
+		return st
+	}
+	if store == nil {
+		// A caller that named a conversation expects continuity, and there is
+		// nowhere to get it. This is the one degradation that never heals --
+		// the store is wired once at startup -- so it must not be the one that
+		// goes uncounted.
+		statsIncStore(stats, StatStateUnavailable)
 		return st
 	}
 	blob, found, err := store.LoadState(context.Background(), key)

--- a/server-go/modules/economizer/stats.go
+++ b/server-go/modules/economizer/stats.go
@@ -25,6 +25,10 @@ var statPublishedName = map[string]string{
 	Stat5xxDisable:            "gateway_5xx_disable",
 	StatStreamErrorDisable:    "gateway_stream_error_disable",
 	StatSessionDisabledBlocks: "gateway_session_disabled_blocks",
+	// Not gateway_-prefixed: reducer state backs both seams, so a failure to
+	// reach it is not a gateway fact.
+	StatStateUnavailable: "economizer_state_unavailable",
+	StatStateSaveFailed:  "economizer_state_save_failed",
 }
 
 const (

--- a/src/modules/economizer/economizer_module_client.c
+++ b/src/modules/economizer/economizer_module_client.c
@@ -139,9 +139,7 @@ void econ_module_result_free(econ_module_result_t *out)
    if (!out)
       return;
    free(out->recall_hint);
-   free(out->state);
    out->recall_hint = NULL;
-   out->state = NULL;
 }
 
 int econ_module_reduce(const cJSON *messages, const char *system_prompt, econ_module_seam_t seam,
@@ -202,11 +200,10 @@ int econ_module_reduce(const cJSON *messages, const char *system_prompt, econ_mo
    if (req->closet_denylist && req->closet_denylist[0])
       cJSON_AddStringToObject(payload, "closet_denylist", req->closet_denylist);
 
-   add_int(payload, "turn", req->turn);
    if (req->session_key && req->session_key[0])
       cJSON_AddStringToObject(payload, "session_key", req->session_key);
-   if (req->state && req->state[0])
-      cJSON_AddStringToObject(payload, "state", req->state);
+   if (req->state_key && req->state_key[0])
+      cJSON_AddStringToObject(payload, "state_key", req->state_key);
 
    /* Ask for the result code instead of discarding it. Passing NULL here made an
     * economizer that was never reached indistinguishable from one that ran and
@@ -251,8 +248,6 @@ int econ_module_reduce(const cJSON *messages, const char *system_prompt, econ_mo
       out->closet_evicted = cJSON_IsTrue(cJSON_GetObjectItem((cJSON *)reply, "closet_evicted"));
       if ((v = cJSON_GetObjectItemCaseSensitive(reply, "recall_hint")) && cJSON_IsString(v))
          out->recall_hint = dup_or_null(v->valuestring);
-      if ((v = cJSON_GetObjectItemCaseSensitive(reply, "state")) && cJSON_IsString(v))
-         out->state = dup_or_null(v->valuestring);
    }
 
    /* An ABSENT messages field means "forward your original untouched" — the

--- a/src/modules/economizer/economizer_module_client.h
+++ b/src/modules/economizer/economizer_module_client.h
@@ -96,19 +96,21 @@ extern "C"
       int closet_max_ratio_pct;
       const char *closet_denylist; /* borrowed; may be NULL */
 
-      int turn;
       /* Whose lever this is, for the gateway seam's circuit breaker. NULL or
        * empty means the request carried no resolvable identity: it reduces
        * normally but can never read or trip a breaker, so one anonymous request
        * cannot switch off another identity's session. Ignored on the delegate
        * seam, which has no breaker. */
       const char *session_key;
-      /* Serialized reducer state from the previous turn, or NULL on the first.
+      /* Names the conversation whose reducer state this turn continues. The
+       * caller owns conversation identity, so it supplies the name; the module
+       * owns the state kept under it, and loads and saves it itself. NULL or
+       * empty reduces normally but always from cold, and persists nothing.
        * Borrowed. */
-      const char *state;
+      const char *state_key;
    } econ_module_request_t;
 
-   /* The ledger, plus the state to persist for the next turn. */
+   /* The ledger. Reducer state is the module's own and never travels here. */
    typedef struct
    {
       int mutated; /* 1 when `messages` was replaced */
@@ -144,7 +146,6 @@ extern "C"
 
       int recall_surfaced;
       char *recall_hint; /* owned; free with econ_module_result_free */
-      char *state;       /* owned; persist verbatim, free with econ_module_result_free */
    } econ_module_result_t;
 
    /* Reduce `messages`, returning a NEW array in `*reduced` or NULL.

--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -14,12 +14,6 @@
 #include "log.h"
 #include "token_tracker.h" /* token_estimate_cost_ex, for the freeze guardrail */
 
-/* Declared rather than including db1.h, the same way agent_runtime.c does: this
- * seam needs exactly two calls, and pulling the whole db1 surface into an
- * economizer translation unit would widen the module's dependencies for nothing. */
-int db1_economizer_state_save(const char *session_id, const char *json);
-int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz);
-
 /* The gateway's reducer state is keyed by session key AND a conversation
  * fingerprint, in its own namespace.
  *
@@ -61,24 +55,6 @@ static void gw_state_key(const char *skey, cJSON *msgs, char *out, size_t out_sz
       }
    }
    snprintf(out, out_sz, "gw:%s:%016llx", skey ? skey : "", (unsigned long long)fp);
-}
-
-/* The module overwrites its loaded state's turn with the request's, so the seam
- * has to supply an increasing one. The gateway has no turn counter of its own,
- * so read it back out of the state we persisted last time. Turn drives only the
- * recall page-table TTL, so a restart resetting it to 0 costs recall freshness
- * for one session, never correctness. */
-static int gw_state_next_turn(const char *state_json)
-{
-   if (!state_json || !state_json[0])
-      return 0;
-   cJSON *root = cJSON_Parse(state_json);
-   if (!root)
-      return 0;
-   cJSON *turn = cJSON_GetObjectItemCaseSensitive(root, "turn");
-   int next = cJSON_IsNumber(turn) ? turn->valueint + 1 : 0;
-   cJSON_Delete(root);
-   return next;
 }
 
 int gw_economizer_measure(cJSON *messages, const char *system_prompt, const char *model,
@@ -226,11 +202,8 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
     * between requests in the same place the delegate seam keeps its own. Without
     * this the gateway could never fold for ANY provider, so the biggest context
     * consumer aimee has was reachable only through its own agent loop. */
-   char state_blob[ECON_MODULE_STATE_MAX];
-   state_blob[0] = '\0';
    char skey_ns[MSG_SESSION_KEY_LEN + 24];
    gw_state_key(ctx->skey, msgs, skey_ns, sizeof skey_ns);
-   (void)db1_economizer_state_load(skey_ns, state_blob, sizeof state_blob);
 
    econ_module_request_t mreq;
    memset(&mreq, 0, sizeof mreq);
@@ -248,8 +221,7 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    mreq.recall_enabled = config_fold_recall_enabled();
    mreq.recall_ttl_turns = config_fold_recall_ttl_turns();
    mreq.recall_inject = config_fold_recall_inject();
-   mreq.state = state_blob[0] ? state_blob : NULL;
-   mreq.turn = gw_state_next_turn(state_blob);
+   mreq.state_key = skey_ns;     /* the module keeps its reducer state under this */
    mreq.session_key = ctx->skey; /* the module reads its breaker off this */
 
    char closet_denylist[CONFIG_COPY_MAX];
@@ -281,14 +253,6 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    econ_module_result_t mres;
    int rrc =
        econ_module_reduce(msgs, system_prompt, ECON_MODULE_SEAM_GATEWAY, &mreq, &reduced, &mres);
-
-   /* Persist BEFORE the apply decision, and regardless of it. The freeze boundary
-    * has to advance on every turn the module saw, not only the ones that shipped a
-    * reduced payload: drop it on a bypass and the next turn re-folds from cold,
-    * which moves the prefix and costs the cache read the freeze exists to keep.
-    * Mirrors the delegate seam, which persists on the same unconditional terms. */
-   if (mres.state && mres.state[0])
-      (void)db1_economizer_state_save(skey_ns, mres.state);
 
    /* One line per gateway reduction, because until now this seam was invisible:
     * its telemetry goes to the obs bus, nothing reached server.log, and proving

--- a/src/modules/economizer/module.yaml
+++ b/src/modules/economizer/module.yaml
@@ -45,8 +45,9 @@
     "server-go/modules/economizer/reduce.go",
     "server-go/modules/economizer/register.go",
     "server-go/modules/economizer/repair.go",
-    "server-go/modules/economizer/stats.go",
-    "server-go/modules/economizer/state.go"
+    "server-go/modules/economizer/state.go",
+    "server-go/modules/economizer/state_store.go",
+    "server-go/modules/economizer/stats.go"
   ],
   "go_tests": [
     "server-go/modules/economizer/breaker_test.go",

--- a/src/modules/process-contracts.json
+++ b/src/modules/process-contracts.json
@@ -683,6 +683,17 @@
         6657,
         6678
       ]
+    },
+    {
+      "id": "economizer-db1",
+      "principal_ref": 66,
+      "executable": "/usr/local/libexec/aimee-modules/aimee-module-economizer",
+      "placements": [
+        "server"
+      ],
+      "request": [
+        11777
+      ]
     }
   ]
 }

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -75,8 +75,6 @@ void db1_agent_job_heartbeat(int job_id);
 void db1_agent_job_heartbeat_ext(int job_id, const char *current_tool, int api_call_count);
 int db1_agent_job_is_cancelled(int job_id);
 int db1_delegation_spawn_stop_reason(const char *delegation_id, char *out, size_t out_sz);
-int db1_economizer_state_save(const char *session_id, const char *json);
-int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz);
 
 /* The agent loop declares a local `char session_id[128]` for the ephemeral-SSH id,
  * which shadows the global session_id() accessor inside that function. Reach the
@@ -637,26 +635,6 @@ native_provider_http:
    mw_pipeline_cfgs_t mw_cfgs;
    mw_pipeline_build(&mw_pipeline, &mw_cfgs, &agent->middleware, mw_max_turns, agent->model);
 
-   /* The reducer's state is now the MODULE's shape, so this side carries it as an
-    * opaque blob: loaded once, handed to each reduce, and saved back whenever the
-    * module returns a new one.
-    *
-    * A run is one agent invocation, but a conversation spans several, so without
-    * this every user turn would re-derive the fold boundary and start with an
-    * EMPTY page table — a coordinate evicted in the previous run would be
-    * unrecoverable.
-    *
-    * Strictly keyed by session id and skipped entirely when there is none:
-    * restoring another conversation's state here would leak its context. */
-   char agent_reduce_state_blob[ECON_MODULE_STATE_MAX + 1];
-   agent_reduce_state_blob[0] = '\0';
-   {
-      const char *econ_sid = econ_conversation_id();
-      if (econ_sid && econ_sid[0])
-         (void)db1_economizer_state_load(econ_sid, agent_reduce_state_blob,
-                                         sizeof(agent_reduce_state_blob));
-   }
-
    while (turn < max_t)
    {
       /* Stop before issuing a fourth provider request without evidence. The
@@ -874,8 +852,15 @@ native_provider_http:
             mreq.recall_enabled = config_fold_recall_enabled();
             mreq.recall_ttl_turns = config_fold_recall_ttl_turns();
             mreq.recall_inject = config_fold_recall_inject();
-            mreq.turn = turn;
-            mreq.state = agent_reduce_state_blob;
+            /* Name the conversation and let the module keep its own reducer
+             * state under it. A run is one agent invocation but a conversation
+             * spans several, so without a stable name every user turn would
+             * re-derive the fold boundary and start with an EMPTY page table --
+             * a coordinate evicted in the previous run would be unrecoverable.
+             *
+             * Strictly the session id, and NULL when there is none: a shared or
+             * guessed name here would serve one conversation another's context. */
+            mreq.state_key = econ_conversation_id();
 
             /* The freeze guardrail prices each cache tier; the module does the
              * arithmetic, this side supplies the rates. */
@@ -917,14 +902,6 @@ native_provider_http:
                          econ_res.mutated, econ_res.reason[0] ? econ_res.reason : "none",
                          econ_res.baseline_tokens, econ_res.reduced_tokens, econ_res.removed_tokens,
                          econ_res.folded_msgs, econ_res.retained_msgs, econ_res.reused_boundary);
-            /* Persist the state the module handed back, so the freeze boundary
-             * and page table survive into the next turn. */
-            if (econ_res.state && econ_res.state[0])
-            {
-               snprintf(agent_reduce_state_blob, sizeof agent_reduce_state_blob, "%s",
-                        econ_res.state);
-               db1_economizer_state_save(econ_conversation_id(), agent_reduce_state_blob);
-            }
          }
       }
       cJSON *eff_messages = reduce_active ? reduced_messages : messages;

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -14,29 +14,6 @@
 #include "platform_path.h"
 #include "platform_test_util.h"
 
-/* The seam now carries reducer state per session so it can hold a freeze boundary.
- * These fixtures stand in for db1 rather than linking sqlite into what is a pure
- * decision fixture: every test below runs with the module unreachable, so the seam
- * bypasses before it would ever read a state blob. Persistence itself is covered by
- * the Go module's state tests and verified live on the deploy. */
-int db1_economizer_state_save(const char *session_id, const char *json);
-int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz);
-
-int db1_economizer_state_save(const char *session_id, const char *json)
-{
-   (void)session_id;
-   (void)json;
-   return 0;
-}
-
-int db1_economizer_state_load(const char *session_id, char *out, size_t out_sz)
-{
-   (void)session_id;
-   if (out && out_sz)
-      out[0] = '\0';
-   return -1; /* "no state": the first turn of a session takes this path */
-}
-
 /* A container {"messages":[<msg>]} whose single message tags which array it is. */
 static cJSON *container_with(const char *tag)
 {


### PR DESCRIPTION
Phase B: DB1's first caller crosses the bus.

The economizer keeps per-conversation reducer state, so it now loads and saves that state itself over DB1's stage rather than having the seam ferry a blob in and back out. **Both seams stop touching DB1.**

The caller still *names* the conversation — it owns session and conversation identity — but the blob, the turn counter, and where any of it is stored are the module's own. The names are unchanged (the gateway's namespaced session key, the delegate seam's conversation id), so existing state is **not orphaned** and there is no cold start on deploy.

### The outbound principal
A module's serving grant requests nothing, so the economizer could not call DB1 at all. The call needs a second principal: client `66`, granted exactly event `11777` and nothing else, mirroring `roundtable-delegates`.

### Degradation is counted, not silent
Every storage failure degrades to a cold start rather than failing the reduction — reducer state makes the *next* turn cheaper, so losing it costs one cold turn while failing the request costs the caller its reduction. An unreachable store at startup is the same case, so the module serves without one.

That degradation is silent by design, which is why it is now counted (`economizer_state_unavailable`, `economizer_state_save_failed` — deliberately not `gateway_`-prefixed, since both seams use the store). A fold that has quietly stopped reusing its freeze boundary looks like a fold that is working, and the only other evidence is a token bill that does not fall; this seam has lost a night to that ambiguity once already.

### Verified
go build/vet/test across server-go, C build, lint (58 checks), descriptor and process-contract validators, the C-process export and runtime-bundle suites, and `unit-test-gateway-mutate-wire`. Mutation-checked against an uncounted load failure, an uncounted save failure, a turn that never advances, and persistence without a key — all four caught.

The real economizer→bus→DB1 path is exercised end-to-end only by e2e-docker; that is the check I could not run locally and the one most likely to surface a grant or wiring mistake.