### PR TITLE
feat(db2): promote management selector support

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -86,9 +86,9 @@ Link-closure audit:
 `link-closure-v1.json` accounts for all 141 C translation units in the private DB2 boundary. The
 probe compiles each unit plus exact descriptor-owned support, combines only those objects with a
 relocatable link, supplies no archive, shared library, helper stub, or weak definition, and records
-the 344 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
+the 343 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
 disposition and rationale. The current ledger contains 144 explicit system-link dependencies, 25
-pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 25 support APIs to
+pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 24 support APIs to
 promote. The standalone-link exit condition requires zero entries in the latter three groups; a
 classified ledger alone is not enough.
 
@@ -118,6 +118,13 @@ and header hashes, sole include, empty import set, exact base references, and si
 Parity covers every non-NUL byte, valid boundary sequences, every truncated prefix, overlong
 forms, surrogates, values above U+10FFFF, mixed text, empty input, and NULL under both the normal
 and ASan/UBSan/FORTIFY builds.
+
+The fourth reduction promotes `server_mgmt_read_selector_name`, used by only the DB2 management-read
+journal. Its descriptor-private header pins the existing two numeric selector values and int-sized C
+calling convention while the parity test compile-time checks both against the authoritative legacy
+enum. Normal and ASan/UBSan/FORTIFY tests cover the complete signed 16-bit selector domain plus
+full-width integer boundaries. The helper has no imports and no pgvector, DB3, provider, database,
+event-bus, allocation, I/O, or platform edge, so it cannot alter either vector ownership boundary.
 
 The gate rejects legacy source additions or omissions, support path escape, symlinks, content drift,
 new unresolved symbols, non-system reference growth, missing evidence, and any attempt to make the

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -415,6 +415,19 @@ in-place repair with no imports and five legacy calls across three DB2 units. Ad
 minimal header, source envelope, export, and base references; exhaustive byte-class, Unicode
 boundary, truncation, mixed-input, NULL, and sanitizer parity protects the monolith contract.
 
+The fourth admitted unit owns only `server_mgmt_read_selector_name`, the deterministic two-value
+mapping used by `c/management_read_journal.c`. Its private header records the process-side numeric
+ABI without importing the broad legacy management-read surface. Compile-time checks bind both
+values and the int-sized calling convention to `management_read.h`; normal and hardened parity
+exercise every signed 16-bit value and the remaining int boundary classes. Its empty import set and
+single base reference prove that this slice neither moves pgvector out of DB2 nor couples DB2 to a
+DB3 provider. The DB3 route and multi-observer event contracts are unchanged.
+
+The next support candidates stay explicitly deferred by ownership shape: UTC formatting/parsing
+combines clock nondeterminism with non-standard `timegm`; relation vocabulary moves the semantic
+seed table and its struct/enum ABI; language extractors bring a broad parser/helper closure. Each
+requires its own coherent admission and parity slice rather than being folded into this helper.
+
 ### 4.3 Supervision and atomic activation
 
 Development may land the exporter, catalog, module binary, and adapters in reviewable commits, but

--- a/scripts/check_db2_link_closure.py
+++ b/scripts/check_db2_link_closure.py
@@ -67,6 +67,25 @@ SUPPORT_UNITS: list[dict[str, object]] = [{
     "evidence": "Three deterministic dynamic-string lifecycle functions with only realloc and "
                 "vsnprintf imports; no DB2, event-bus, provider, I/O, or platform dependency.",
 }, {
+    "path": "src/modules/db2/support/management_read_primitives.c",
+    "source_sha256": "2b1799442b2d57c6088eaa8fbcff744d6422bd3011b816bf78f3faefde4b8058",
+    "header": "src/modules/db2/support/db2_management_read.h",
+    "header_sha256": "b95b4714b891a71689bc2ad95bae3f693d6694cde83a3fef481d7212c4c2f318",
+    "defines": ["server_mgmt_read_selector_name"],
+    "resolves": ["server_mgmt_read_selector_name"],
+    "allowed_includes": ["db2_management_read.h"],
+    "allowed_header_includes": [],
+    "allowed_undefined": [],
+    "base_references": {
+        "server_mgmt_read_selector_name": [
+            "src/modules/db2/c/management_read_journal.c",
+        ],
+    },
+    "provenance": "Definition promoted from src/shared/management_read.c; the sole DB2 call was "
+                  "audited in management_read_journal.c.",
+    "evidence": "Deterministic two-value selector mapping with no imports, allocation, I/O, DB, "
+                "event-bus, provider, platform, pgvector, or DB3 dependency; ABI parity tested.",
+}, {
     "path": "src/modules/db2/support/sketch_primitives.c",
     "source_sha256": "20318d4f9c92894892ef9475f95c1542602f3a7d2b4d9fe6df2b8d63b4986280",
     "header": "src/modules/db2/support/sketch.h",

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "2770a84679f82f10c068b245abdb11ce04639f66",
-  "source_fingerprint": "d80b7ff5d0f81e9896efdbe6184cc1682587a2f734ffd180e640915d14164312",
+  "source_revision": "2c24b6b5fc57b4d49fdcfed41b79bf5989ba5fd5",
+  "source_fingerprint": "2ca57bc66939d7021a9b23dba8ead15adf1e9ae0d30f6fbefe546eefb131c1a8",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
@@ -199,6 +199,30 @@
       },
       "provenance": "Definitions and required static helpers promoted from src/dstr.c; all DB2 calls audited in src/modules/db2/c/collab_rules.c.",
       "evidence": "Three deterministic dynamic-string lifecycle functions with only realloc and vsnprintf imports; no DB2, event-bus, provider, I/O, or platform dependency."
+    },
+    {
+      "path": "src/modules/db2/support/management_read_primitives.c",
+      "source_sha256": "2b1799442b2d57c6088eaa8fbcff744d6422bd3011b816bf78f3faefde4b8058",
+      "header": "src/modules/db2/support/db2_management_read.h",
+      "header_sha256": "b95b4714b891a71689bc2ad95bae3f693d6694cde83a3fef481d7212c4c2f318",
+      "defines": [
+        "server_mgmt_read_selector_name"
+      ],
+      "resolves": [
+        "server_mgmt_read_selector_name"
+      ],
+      "allowed_includes": [
+        "db2_management_read.h"
+      ],
+      "allowed_header_includes": [],
+      "allowed_undefined": [],
+      "base_references": {
+        "server_mgmt_read_selector_name": [
+          "src/modules/db2/c/management_read_journal.c"
+        ]
+      },
+      "provenance": "Definition promoted from src/shared/management_read.c; the sole DB2 call was audited in management_read_journal.c.",
+      "evidence": "Deterministic two-value selector mapping with no imports, allocation, I/O, DB, event-bus, provider, platform, pgvector, or DB3 dependency; ABI parity tested."
     },
     {
       "path": "src/modules/db2/support/sketch_primitives.c",
@@ -2928,14 +2952,6 @@
       "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
     },
     {
-      "symbol": "server_mgmt_read_selector_name",
-      "references": [
-        "src/modules/db2/c/management_read_journal.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
       "symbol": "session_briefing_render_commitments",
       "references": [
         "src/modules/db2/c/kb_service_backend_memory.c"
@@ -3831,16 +3847,16 @@
   ],
   "summary": {
     "translation_units": 141,
-    "descriptor_support_units": 3,
-    "unresolved_symbols": 344,
+    "descriptor_support_units": 4,
+    "unresolved_symbols": 343,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 25,
       "injected-module-contract": 150,
-      "portable-core-promotion": 25,
+      "portable-core-promotion": 24,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 144
     }
   },
-  "fingerprint": "a6b6e2be90604ded69a4febf7c6fbed95eca724fe0667e5dc887523011429d8f"
+  "fingerprint": "e08843d09c6978ccd06174372e57aa9c8499d47548a28a577fc97bff1c17bad7"
 }

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -14,6 +14,7 @@
     "src/modules/db2/db3_route.c",
     "src/modules/db2/module_adapter.c",
     "src/modules/db2/support/dstr_primitives.c",
+    "src/modules/db2/support/management_read_primitives.c",
     "src/modules/db2/support/sketch_primitives.c",
     "src/modules/db2/support/text_primitives.c"
   ],
@@ -31,14 +32,16 @@
   "private_headers": [
     "src/modules/db2/module_adapter.h",
     "src/modules/db2/support/db2_dstr.h",
+    "src/modules/db2/support/db2_management_read.h",
     "src/modules/db2/support/db2_text.h",
     "src/modules/db2/support/sketch.h"
   ],
   "tests": [
     "src/tests/test_bus_db2_module.c",
     "src/tests/test_bus_db3.c",
-    "src/tests/test_db2_module_contract.c",
     "src/tests/test_db2_dstr_support.c",
+    "src/tests/test_db2_management_read_support.c",
+    "src/tests/test_db2_module_contract.c",
     "src/tests/test_db2_sketch_support.c",
     "src/tests/test_db2_text_support.c",
     "src/tests/test_db3_route.c"

--- a/src/modules/db2/support/db2_management_read.h
+++ b/src/modules/db2/support/db2_management_read.h
@@ -1,0 +1,17 @@
+#ifndef AIMEE_DB2_SUPPORT_MANAGEMENT_READ_H
+#define AIMEE_DB2_SUPPORT_MANAGEMENT_READ_H
+
+/*
+ * Descriptor-owned numeric ABI for the one management-read selector helper
+ * currently required by DB2.  The authoritative legacy enum is compile-time
+ * checked by the parity test while the monolith remains active.
+ */
+enum
+{
+   DB2_SERVER_MGMT_READ_SELECTOR_AGENTS = 1,
+   DB2_SERVER_MGMT_READ_SELECTOR_CONFIG = 2
+};
+
+const char *server_mgmt_read_selector_name(int selector);
+
+#endif

--- a/src/modules/db2/support/management_read_primitives.c
+++ b/src/modules/db2/support/management_read_primitives.c
@@ -1,0 +1,8 @@
+#include "db2_management_read.h"
+
+const char *server_mgmt_read_selector_name(int selector)
+{
+   return selector == DB2_SERVER_MGMT_READ_SELECTOR_AGENTS   ? "agents"
+          : selector == DB2_SERVER_MGMT_READ_SELECTOR_CONFIG ? "config"
+                                                             : 0;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -729,6 +729,7 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-process-module-handlers
 TEST_TARGETS += $(TESTPREFIX)/unit-test-db2-module-contract \
                 $(TESTPREFIX)/unit-test-bus-db2-module \
                 $(TESTPREFIX)/unit-test-db2-dstr-support \
+                $(TESTPREFIX)/unit-test-db2-management-read-support \
                 $(TESTPREFIX)/unit-test-db2-sketch-support \
                 $(TESTPREFIX)/unit-test-db2-text-support \
                 $(TESTPREFIX)/unit-test-db3-route \
@@ -802,6 +803,7 @@ UNIT_TEST_SHARD_INDEX ?= 0
 UNIT_TEST_SKIP_P1 ?= 0
 ifeq ($(UNIT_TEST_SHARD_INDEX),0)
 UNIT_TEST_AUX_TARGETS = $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize \
+                        $(TESTPREFIX)/unit-test-db2-management-read-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-text-support-sanitize
 else
@@ -6665,6 +6667,58 @@ unit-test-db2-dstr-support: $(TESTPREFIX)/unit-test-db2-dstr-support
 	$<
 
 unit-test-db2-dstr-support-sanitize: $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize
+	$<
+
+DB2_MGMT_READ_SUPPORT_RENAMES = \
+   -Dserver_mgmt_read_selector_name=db2_support_server_mgmt_read_selector_name
+DB2_MGMT_READ_SECTION_FLAGS = -ffunction-sections -fdata-sections
+
+$(OBJDIR)/tests/db2_management_read_support_impl.o: \
+                     modules/db2/support/management_read_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_MGMT_READ_SUPPORT_RENAMES) \
+	      $(DB2_MGMT_READ_SECTION_FLAGS) -c -o $@ $<
+
+$(OBJDIR)/tests/db2_management_read_monolith.o: shared/management_read.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_MGMT_READ_SECTION_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-management-read-support: \
+                     $(OBJDIR)/tests/test_db2_management_read_support.o \
+                     $(OBJDIR)/tests/db2_management_read_support_impl.o \
+                     $(OBJDIR)/tests/db2_management_read_monolith.o
+	$(TESTLINK_MIN) -Wl,--gc-sections -o $@ $^ $(TEST_L_FLAGS)
+
+DB2_MGMT_READ_SANITIZE_DIR = $(OBJDIR)/tests/db2-management-read-support-sanitize
+
+$(DB2_MGMT_READ_SANITIZE_DIR)/test.o: tests/test_db2_management_read_support.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_MGMT_READ_SANITIZE_DIR)/support.o: \
+                     modules/db2/support/management_read_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_MGMT_READ_SUPPORT_RENAMES) \
+	      $(DB2_MGMT_READ_SECTION_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_MGMT_READ_SANITIZE_DIR)/monolith.o: shared/management_read.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_MGMT_READ_SECTION_FLAGS) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-management-read-support-sanitize: \
+                     $(DB2_MGMT_READ_SANITIZE_DIR)/test.o \
+                     $(DB2_MGMT_READ_SANITIZE_DIR)/support.o \
+                     $(DB2_MGMT_READ_SANITIZE_DIR)/monolith.o
+	$(CC) $(DB2_SUPPORT_SANITIZE_FLAGS) -Wl,--gc-sections -o $@ $^
+
+.PHONY: unit-test-db2-management-read-support \
+        unit-test-db2-management-read-support-sanitize
+unit-test-db2-management-read-support: $(TESTPREFIX)/unit-test-db2-management-read-support
+	$<
+
+unit-test-db2-management-read-support-sanitize: \
+                     $(TESTPREFIX)/unit-test-db2-management-read-support-sanitize
 	$<
 
 DB2_TEXT_SUPPORT_RENAMES = -Dtext_sanitize_utf8=db2_support_text_sanitize_utf8

--- a/src/tests/test_db2_management_read_support.c
+++ b/src/tests/test_db2_management_read_support.c
@@ -1,0 +1,54 @@
+/* ABI and behavior parity for descriptor-owned DB2 management-read support. */
+#include "management_read.h"
+
+#include <assert.h>
+#include <limits.h>
+#include <string.h>
+
+const char *db2_support_server_mgmt_read_selector_name(int selector);
+
+_Static_assert((int)SERVER_MGMT_READ_SELECTOR_AGENTS == 1, "agents selector ABI drifted");
+_Static_assert((int)SERVER_MGMT_READ_SELECTOR_CONFIG == 2, "config selector ABI drifted");
+_Static_assert(sizeof(server_mgmt_read_selector_t) == sizeof(int),
+               "legacy selector calling convention is no longer int-sized");
+
+static void assert_result(int selector, const char *expected)
+{
+   const char *legacy = server_mgmt_read_selector_name((server_mgmt_read_selector_t)selector);
+   const char *support = db2_support_server_mgmt_read_selector_name(selector);
+
+   if (!expected)
+   {
+      assert(legacy == NULL);
+      assert(support == NULL);
+      return;
+   }
+   assert(legacy != NULL);
+   assert(support != NULL);
+   assert(strcmp(legacy, expected) == 0);
+   assert(strcmp(support, expected) == 0);
+}
+
+static void test_complete_selector_partition(void)
+{
+   /* A dense signed 16-bit subdomain exercises every selector equivalence class. */
+   for (int selector = INT16_MIN; selector <= INT16_MAX; selector++)
+   {
+      const char *expected = selector == SERVER_MGMT_READ_SELECTOR_AGENTS   ? "agents"
+                             : selector == SERVER_MGMT_READ_SELECTOR_CONFIG ? "config"
+                                                                            : NULL;
+      assert_result(selector, expected);
+   }
+
+   /* Exercise the remaining int-width boundary classes. */
+   assert_result(INT_MIN, NULL);
+   assert_result(INT16_MIN - 1, NULL);
+   assert_result(INT16_MAX + 1, NULL);
+   assert_result(INT_MAX, NULL);
+}
+
+int main(void)
+{
+   test_complete_selector_partition();
+   return 0;
+}

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -68,6 +68,12 @@
       "test": "src/tests/test_db2_dstr_support.c"
     },
     {
+      "ctest": false,
+      "make": true,
+      "module": "db2",
+      "test": "src/tests/test_db2_management_read_support.c"
+    },
+    {
       "ctest": true,
       "make": true,
       "module": "db2",


### PR DESCRIPTION
## What changed

- promote `server_mgmt_read_selector_name` into descriptor-owned DB2 support
- pin the private numeric ABI, exact source/header hashes, sole export, zero imports, and sole DB2 base reference
- add normal and ASan/UBSan/FORTIFY parity coverage across all signed 16-bit values plus full-width integer boundaries
- ratchet standalone-link closure from 344 to 343 unresolved symbols and portable promotion debt from 25 to 24

## Boundary impact

This is the next pre-activation C-encapsulation slice. It does not change runtime ownership:
pgvector remains in DB2, and the existing DB3 provider route and multi-observer event-bus contracts
are unchanged. The module remains disabled until complete closure and atomic activation.

## Validation

- focused normal and ASan/UBSan/FORTIFY selector parity
- DB2 link-closure probe, previous-ref ratchet, and 45 failure-mode tests
- DB2 source boundary, DB3 portability, activation, inventory, and registration gates
- full native suite: 700 binaries
- full Python meta-suite: 530 tests
- all 58 lint checks
- build-integrity
- focused roundtable review of the exact staged artifact: approved with no findings
