### PR TITLE
feat(db2): promote UTC support

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -86,9 +86,9 @@ Link-closure audit:
 `link-closure-v1.json` accounts for all 141 C translation units in the private DB2 boundary. The
 probe compiles each unit plus exact descriptor-owned support, combines only those objects with a
 relocatable link, supplies no archive, shared library, helper stub, or weak definition, and records
-the 343 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
+the 341 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
 disposition and rationale. The current ledger contains 144 explicit system-link dependencies, 25
-pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 24 support APIs to
+pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 22 support APIs to
 promote. The standalone-link exit condition requires zero entries in the latter three groups; a
 classified ledger alone is not enough.
 
@@ -125,6 +125,16 @@ calling convention while the parity test compile-time checks both against the au
 enum. Normal and ASan/UBSan/FORTIFY tests cover the complete signed 16-bit selector domain plus
 full-width integer boundaries. The helper has no imports and no pgvector, DB3, provider, database,
 event-bus, allocation, I/O, or platform edge, so it cannot alter either vector ownership boundary.
+
+The fifth reduction promotes the adjacent UTC formatter and parser shared by 18 and two DB2 units,
+respectively. The private header preserves the `size_t` and `time_t` ABI; admission pins both
+exports, exact base references, the three-header source envelope, and only the observed system time
+and parsing imports. The existing Linux `timegm` and Windows `_mkgmtime` branches remain intact.
+Parity covers both stored timestamp spellings, date-only values, epoch and calendar normalization,
+invalid basic ranges and separators, trailing input, NULL/empty input, three host timezones, exact
+formatter grammar, parser round-trip, and a five-second wall-clock window under normal and hardened
+builds. The two formatter callers that also log do not create a support import: logging remains an
+independent injected process-policy decision.
 
 The gate rejects legacy source additions or omissions, support path escape, symlinks, content drift,
 new unresolved symbols, non-system reference growth, missing evidence, and any attempt to make the

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -423,10 +423,28 @@ exercise every signed 16-bit value and the remaining int boundary classes. Its e
 single base reference prove that this slice neither moves pgvector out of DB2 nor couples DB2 to a
 DB3 provider. The DB3 route and multi-observer event contracts are unchanged.
 
-The next support candidates stay explicitly deferred by ownership shape: UTC formatting/parsing
-combines clock nondeterminism with non-standard `timegm`; relation vocabulary moves the semantic
-seed table and its struct/enum ABI; language extractors bring a broad parser/helper closure. Each
-requires its own coherent admission and parity slice rather than being folded into this helper.
+The fifth admitted unit owns the adjacent `now_utc` and `parse_utc_ts` contract. It covers all 18
+DB2 formatter units and both parser units without importing the rest of `util.c`. Admission pins the
+`size_t`/`time_t` ABI, both exports, every base reference, and only the observed system time/parsing
+imports. The inherited `timegm`/`_mkgmtime` platform split is explicit. Normal and hardened parity
+cover both stored spellings, date-only input, inherited calendar normalization, invalid basic
+ranges and separators, trailing input, NULL/empty input, three host timezones, exact formatter
+grammar, parser round-trip, and a five-second `time(NULL)` wall-clock window. `canonical_index.c`
+and `code_index.c` also use `aimee_log`, but the support unit has no logging edge, leaving process
+logging as an independent injected policy.
+
+The next support candidates stay explicitly deferred by ownership shape: relation vocabulary moves
+the semantic seed table and its struct/enum ABI; language extractors bring a broad parser/helper
+closure; platform random/process functions carry OS, entropy, and daemon policy. Each requires its
+own coherent admission and parity slice rather than being folded into this unit.
+
+These reductions remain phase-one precursors, not substitutes for the program exit criteria below:
+standalone C closure reaches zero non-system packaging/injection/promotion debt; the C process is
+atomically activated and removed from the KB link; the Go DB2 provider passes the same event replay
+and PostgreSQL/pgvector parity gates; then the already-frozen DB3 contract connects its 14 portable
+searches, 32 committed-mutation fanouts, 15 provider-control operations, and 12 retained DB2
+authority operations to the selected provider. `docs/db3.md` defines default pgvector, explicit
+external selection, multi-observer fanout, revalidation, fail-closed behavior, and fallback proof.
 
 ### 4.3 Supervision and atomic activation
 

--- a/scripts/check_db2_link_closure.py
+++ b/scripts/check_db2_link_closure.py
@@ -147,6 +147,49 @@ SUPPORT_UNITS: list[dict[str, object]] = [{
                   "canonical_index.c, code_index.c, and kb_payload.c.",
     "evidence": "Deterministic in-place UTF-8 repair with no imports, allocation, I/O, DB, "
                 "event-bus, provider, or platform dependency; exhaustive parity tested.",
+}, {
+    "path": "src/modules/db2/support/time_primitives.c",
+    "source_sha256": "3a75fa922a9d7ddfbd51a4297461a266d9e14a2c995422a1ae6165116545f04c",
+    "header": "src/modules/db2/support/db2_time.h",
+    "header_sha256": "f6b01dfcda9c2d6e10d2ffb8fae9376dac4ac2fc0cc84bcc10f16f23235117e8",
+    "defines": ["now_utc", "parse_utc_ts"],
+    "resolves": ["now_utc", "parse_utc_ts"],
+    "allowed_includes": ["db2_time.h", "stdio.h", "string.h"],
+    "allowed_header_includes": ["stddef.h", "time.h"],
+    "allowed_undefined": [
+        "__isoc23_sscanf", "__isoc99_sscanf", "gmtime_r", "strftime", "time", "timegm",
+    ],
+    "base_references": {
+        "now_utc": [
+            "src/modules/db2/c/artifacts.c",
+            "src/modules/db2/c/bandit.c",
+            "src/modules/db2/c/calibration.c",
+            "src/modules/db2/c/canonical_index.c",
+            "src/modules/db2/c/code_index.c",
+            "src/modules/db2/c/code_index_ops.c",
+            "src/modules/db2/c/code_project_lifecycle.c",
+            "src/modules/db2/c/corpus_jobs.c",
+            "src/modules/db2/c/corpus_structural.c",
+            "src/modules/db2/c/demotion.c",
+            "src/modules/db2/c/feature_rows.c",
+            "src/modules/db2/c/feedback.c",
+            "src/modules/db2/c/kb_docs.c",
+            "src/modules/db2/c/kb_releases.c",
+            "src/modules/db2/c/report_enrichments.c",
+            "src/modules/db2/c/rules.c",
+            "src/modules/db2/c/tasks.c",
+            "src/modules/db2/c/vector_index_ops.c",
+        ],
+        "parse_utc_ts": [
+            "src/modules/db2/c/code_index.c",
+            "src/modules/db2/c/demotion.c",
+        ],
+    },
+    "provenance": "Adjacent UTC formatter and parser definitions promoted from src/util.c; all "
+                  "eighteen formatter and two parser DB2 units audited.",
+    "evidence": "Shared UTC timestamp contract with only system time/parsing imports; Linux uses "
+                "timegm and the preserved Windows branch uses _mkgmtime. No DB, event-bus, "
+                "provider, pgvector, DB3, allocation, I/O, or logging dependency.",
 }]
 SYSTEM_PREFIXES = ("PQ", "EVP_", "OPENSSL_", "RAND_", "SHA", "CRYPTO_")
 INJECTED_PREFIXES = (

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "2c24b6b5fc57b4d49fdcfed41b79bf5989ba5fd5",
-  "source_fingerprint": "2ca57bc66939d7021a9b23dba8ead15adf1e9ae0d30f6fbefe546eefb131c1a8",
+  "source_revision": "6925305e7764121dfefa3c4e2ee2c6c1f3ac7365",
+  "source_fingerprint": "5e41b9a48251716f26192e3013d63708d9cabc921ebabca16661f07e2d86da4a",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
@@ -312,6 +312,65 @@
       },
       "provenance": "Definition promoted from src/text.c; all DB2 calls audited in canonical_index.c, code_index.c, and kb_payload.c.",
       "evidence": "Deterministic in-place UTF-8 repair with no imports, allocation, I/O, DB, event-bus, provider, or platform dependency; exhaustive parity tested."
+    },
+    {
+      "path": "src/modules/db2/support/time_primitives.c",
+      "source_sha256": "3a75fa922a9d7ddfbd51a4297461a266d9e14a2c995422a1ae6165116545f04c",
+      "header": "src/modules/db2/support/db2_time.h",
+      "header_sha256": "f6b01dfcda9c2d6e10d2ffb8fae9376dac4ac2fc0cc84bcc10f16f23235117e8",
+      "defines": [
+        "now_utc",
+        "parse_utc_ts"
+      ],
+      "resolves": [
+        "now_utc",
+        "parse_utc_ts"
+      ],
+      "allowed_includes": [
+        "db2_time.h",
+        "stdio.h",
+        "string.h"
+      ],
+      "allowed_header_includes": [
+        "stddef.h",
+        "time.h"
+      ],
+      "allowed_undefined": [
+        "__isoc23_sscanf",
+        "__isoc99_sscanf",
+        "gmtime_r",
+        "strftime",
+        "time",
+        "timegm"
+      ],
+      "base_references": {
+        "now_utc": [
+          "src/modules/db2/c/artifacts.c",
+          "src/modules/db2/c/bandit.c",
+          "src/modules/db2/c/calibration.c",
+          "src/modules/db2/c/canonical_index.c",
+          "src/modules/db2/c/code_index.c",
+          "src/modules/db2/c/code_index_ops.c",
+          "src/modules/db2/c/code_project_lifecycle.c",
+          "src/modules/db2/c/corpus_jobs.c",
+          "src/modules/db2/c/corpus_structural.c",
+          "src/modules/db2/c/demotion.c",
+          "src/modules/db2/c/feature_rows.c",
+          "src/modules/db2/c/feedback.c",
+          "src/modules/db2/c/kb_docs.c",
+          "src/modules/db2/c/kb_releases.c",
+          "src/modules/db2/c/report_enrichments.c",
+          "src/modules/db2/c/rules.c",
+          "src/modules/db2/c/tasks.c",
+          "src/modules/db2/c/vector_index_ops.c"
+        ],
+        "parse_utc_ts": [
+          "src/modules/db2/c/code_index.c",
+          "src/modules/db2/c/demotion.c"
+        ]
+      },
+      "provenance": "Adjacent UTC formatter and parser definitions promoted from src/util.c; all eighteen formatter and two parser DB2 units audited.",
+      "evidence": "Shared UTC timestamp contract with only system time/parsing imports; Linux uses timegm and the preserved Windows branch uses _mkgmtime. No DB, event-bus, provider, pgvector, DB3, allocation, I/O, or logging dependency."
     }
   ],
   "unresolved": [
@@ -880,7 +939,8 @@
     {
       "symbol": "__isoc23_sscanf",
       "references": [
-        "src/modules/db2/c/memory_query.c"
+        "src/modules/db2/c/memory_query.c",
+        "src/modules/db2/support/time_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -1902,7 +1962,8 @@
         "src/modules/db2/c/memory_conflicts.c",
         "src/modules/db2/c/memory_health.c",
         "src/modules/db2/c/memory_relations.c",
-        "src/modules/db2/c/ontology_evolution.c"
+        "src/modules/db2/c/ontology_evolution.c",
+        "src/modules/db2/support/time_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -2646,40 +2707,6 @@
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
     },
     {
-      "symbol": "now_utc",
-      "references": [
-        "src/modules/db2/c/artifacts.c",
-        "src/modules/db2/c/bandit.c",
-        "src/modules/db2/c/calibration.c",
-        "src/modules/db2/c/canonical_index.c",
-        "src/modules/db2/c/code_index.c",
-        "src/modules/db2/c/code_index_ops.c",
-        "src/modules/db2/c/code_project_lifecycle.c",
-        "src/modules/db2/c/corpus_jobs.c",
-        "src/modules/db2/c/corpus_structural.c",
-        "src/modules/db2/c/demotion.c",
-        "src/modules/db2/c/feature_rows.c",
-        "src/modules/db2/c/feedback.c",
-        "src/modules/db2/c/kb_docs.c",
-        "src/modules/db2/c/kb_releases.c",
-        "src/modules/db2/c/report_enrichments.c",
-        "src/modules/db2/c/rules.c",
-        "src/modules/db2/c/tasks.c",
-        "src/modules/db2/c/vector_index_ops.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "parse_utc_ts",
-      "references": [
-        "src/modules/db2/c/code_index.c",
-        "src/modules/db2/c/demotion.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
       "symbol": "platform_get_exe_path",
       "references": [
         "src/modules/db2/c/kb_service_backend.c"
@@ -3364,7 +3391,8 @@
         "src/modules/db2/c/memory_conflicts.c",
         "src/modules/db2/c/memory_health.c",
         "src/modules/db2/c/memory_relations.c",
-        "src/modules/db2/c/ontology_evolution.c"
+        "src/modules/db2/c/ontology_evolution.c",
+        "src/modules/db2/support/time_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -3585,7 +3613,8 @@
         "src/modules/db2/c/memory_conflicts.c",
         "src/modules/db2/c/memory_health.c",
         "src/modules/db2/c/memory_relations.c",
-        "src/modules/db2/c/ontology_evolution.c"
+        "src/modules/db2/c/ontology_evolution.c",
+        "src/modules/db2/support/time_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -3594,7 +3623,8 @@
       "symbol": "timegm",
       "references": [
         "src/modules/db2/c/canonical_index.c",
-        "src/modules/db2/c/curiosity.c"
+        "src/modules/db2/c/curiosity.c",
+        "src/modules/db2/support/time_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -3847,16 +3877,16 @@
   ],
   "summary": {
     "translation_units": 141,
-    "descriptor_support_units": 4,
-    "unresolved_symbols": 343,
+    "descriptor_support_units": 5,
+    "unresolved_symbols": 341,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 25,
       "injected-module-contract": 150,
-      "portable-core-promotion": 24,
+      "portable-core-promotion": 22,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 144
     }
   },
-  "fingerprint": "e08843d09c6978ccd06174372e57aa9c8499d47548a28a577fc97bff1c17bad7"
+  "fingerprint": "57000eb17b53c2d26ed1c9f70dda79cf3a7c613d914de88ae48961ba377b1c7e"
 }

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -16,7 +16,8 @@
     "src/modules/db2/support/dstr_primitives.c",
     "src/modules/db2/support/management_read_primitives.c",
     "src/modules/db2/support/sketch_primitives.c",
-    "src/modules/db2/support/text_primitives.c"
+    "src/modules/db2/support/text_primitives.c",
+    "src/modules/db2/support/time_primitives.c"
   ],
   "public_headers": [
     "src/modules/db2/include/aimee/db2/client.h",
@@ -34,6 +35,7 @@
     "src/modules/db2/support/db2_dstr.h",
     "src/modules/db2/support/db2_management_read.h",
     "src/modules/db2/support/db2_text.h",
+    "src/modules/db2/support/db2_time.h",
     "src/modules/db2/support/sketch.h"
   ],
   "tests": [
@@ -44,6 +46,7 @@
     "src/tests/test_db2_module_contract.c",
     "src/tests/test_db2_sketch_support.c",
     "src/tests/test_db2_text_support.c",
+    "src/tests/test_db2_time_support.c",
     "src/tests/test_db3_route.c"
   ],
   "docs": [

--- a/src/modules/db2/support/db2_time.h
+++ b/src/modules/db2/support/db2_time.h
@@ -1,0 +1,10 @@
+#ifndef AIMEE_DB2_SUPPORT_TIME_H
+#define AIMEE_DB2_SUPPORT_TIME_H
+
+#include <stddef.h>
+#include <time.h>
+
+void now_utc(char *buf, size_t len);
+time_t parse_utc_ts(const char *s);
+
+#endif

--- a/src/modules/db2/support/time_primitives.c
+++ b/src/modules/db2/support/time_primitives.c
@@ -1,0 +1,47 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "db2_time.h"
+
+#include <stdio.h>
+#include <string.h>
+
+void now_utc(char *buf, size_t len)
+{
+   time_t t = time(NULL);
+   struct tm tm;
+   gmtime_r(&t, &tm);
+   strftime(buf, len, "%Y-%m-%dT%H:%M:%SZ", &tm);
+}
+
+time_t parse_utc_ts(const char *s)
+{
+   if (!s || !s[0])
+      return 0;
+
+   int year = 0, mon = 0, day = 0, hour = 0, min = 0, sec = 0;
+   char sep = 0;
+   int n = sscanf(s, "%d-%d-%d%c%d:%d:%d", &year, &mon, &day, &sep, &hour, &min, &sec);
+   if (n == 3)
+      hour = min = sec = 0;
+   else if (n != 7 || (sep != 'T' && sep != ' '))
+      return 0;
+   if (year < 1970 || mon < 1 || mon > 12 || day < 1 || day > 31)
+      return 0;
+
+   struct tm tmv;
+   memset(&tmv, 0, sizeof(tmv));
+   tmv.tm_year = year - 1900;
+   tmv.tm_mon = mon - 1;
+   tmv.tm_mday = day;
+   tmv.tm_hour = hour;
+   tmv.tm_min = min;
+   tmv.tm_sec = sec;
+   tmv.tm_isdst = 0;
+#if defined(_WIN32) || defined(_WIN64)
+   return _mkgmtime(&tmv);
+#else
+   return timegm(&tmv);
+#endif
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -732,6 +732,7 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-db2-module-contract \
                 $(TESTPREFIX)/unit-test-db2-management-read-support \
                 $(TESTPREFIX)/unit-test-db2-sketch-support \
                 $(TESTPREFIX)/unit-test-db2-text-support \
+                $(TESTPREFIX)/unit-test-db2-time-support \
                 $(TESTPREFIX)/unit-test-db3-route \
                 $(TESTPREFIX)/unit-test-bus-db3
 
@@ -805,7 +806,8 @@ ifeq ($(UNIT_TEST_SHARD_INDEX),0)
 UNIT_TEST_AUX_TARGETS = $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-management-read-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize \
-                        $(TESTPREFIX)/unit-test-db2-text-support-sanitize
+                        $(TESTPREFIX)/unit-test-db2-text-support-sanitize \
+                        $(TESTPREFIX)/unit-test-db2-time-support-sanitize
 else
 UNIT_TEST_AUX_TARGETS =
 endif
@@ -6766,6 +6768,55 @@ unit-test-db2-text-support: $(TESTPREFIX)/unit-test-db2-text-support
 	$<
 
 unit-test-db2-text-support-sanitize: $(TESTPREFIX)/unit-test-db2-text-support-sanitize
+	$<
+
+DB2_TIME_SUPPORT_RENAMES = \
+   -Dnow_utc=db2_support_now_utc \
+   -Dparse_utc_ts=db2_support_parse_utc_ts
+DB2_TIME_SECTION_FLAGS = -ffunction-sections -fdata-sections
+
+$(OBJDIR)/tests/db2_time_support_impl.o: modules/db2/support/time_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TIME_SUPPORT_RENAMES) \
+	      $(DB2_TIME_SECTION_FLAGS) -c -o $@ $<
+
+$(OBJDIR)/tests/db2_time_monolith.o: util.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TIME_SECTION_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-time-support: \
+                     $(OBJDIR)/tests/test_db2_time_support.o \
+                     $(OBJDIR)/tests/db2_time_support_impl.o \
+                     $(OBJDIR)/tests/db2_time_monolith.o
+	$(TESTLINK_MIN) -Wl,--gc-sections -o $@ $^ $(TEST_L_FLAGS)
+
+DB2_TIME_SANITIZE_DIR = $(OBJDIR)/tests/db2-time-support-sanitize
+
+$(DB2_TIME_SANITIZE_DIR)/test.o: tests/test_db2_time_support.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_TIME_SANITIZE_DIR)/support.o: modules/db2/support/time_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TIME_SUPPORT_RENAMES) $(DB2_TIME_SECTION_FLAGS) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_TIME_SANITIZE_DIR)/monolith.o: util.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_TIME_SECTION_FLAGS) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-time-support-sanitize: \
+                     $(DB2_TIME_SANITIZE_DIR)/test.o \
+                     $(DB2_TIME_SANITIZE_DIR)/support.o \
+                     $(DB2_TIME_SANITIZE_DIR)/monolith.o
+	$(CC) $(DB2_SUPPORT_SANITIZE_FLAGS) -Wl,--gc-sections -o $@ $^
+
+.PHONY: unit-test-db2-time-support unit-test-db2-time-support-sanitize
+unit-test-db2-time-support: $(TESTPREFIX)/unit-test-db2-time-support
+	$<
+
+unit-test-db2-time-support-sanitize: $(TESTPREFIX)/unit-test-db2-time-support-sanitize
 	$<
 
 DB2_SKETCH_SUPPORT_RENAMES = \

--- a/src/tests/test_db2_time_support.c
+++ b/src/tests/test_db2_time_support.c
@@ -1,0 +1,114 @@
+/* Parity tests for descriptor-owned DB2 UTC timestamp support. */
+#include "aimee.h"
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+void db2_support_now_utc(char *buf, size_t len);
+time_t db2_support_parse_utc_ts(const char *s);
+
+_Static_assert(sizeof(time_t) == sizeof(db2_support_parse_utc_ts("1970-01-01")),
+               "support parser must preserve the time_t ABI");
+
+static void assert_parse_parity(const char *input)
+{
+   assert(parse_utc_ts(input) == db2_support_parse_utc_ts(input));
+}
+
+static void test_parse_corpus(void)
+{
+   static const char *const corpus[] = {
+       "1970-01-01T00:00:00Z",
+       "1970-01-02T00:00:00Z",
+       "2000-02-29T12:34:56Z",
+       "2038-01-19T03:14:07Z",
+       "2026-08-16 09:30:00",
+       "2026-08-16",
+       "2024-02-31T00:00:00Z",
+       "2024-01-01T24:00:00Z",
+       "2024-01-01T00:60:00Z",
+       "2024-01-01T00:00:60Z",
+       "2024-01-01T00:00:00Ztrailing",
+       "1969-12-31T23:59:59Z",
+       "2024-00-01T00:00:00Z",
+       "2024-13-01T00:00:00Z",
+       "2024-01-00T00:00:00Z",
+       "2024-01-32T00:00:00Z",
+       "2024/01/01T00:00:00Z",
+       "2024-01-01X00:00:00Z",
+       "2024-01-01T00:00",
+       "2024-01-01Z",
+       "not-a-time",
+       "",
+       NULL,
+   };
+   for (size_t i = 0; i < sizeof(corpus) / sizeof(corpus[0]); i++)
+      assert_parse_parity(corpus[i]);
+
+   assert(parse_utc_ts("1970-01-02T00:00:00Z") == 86400);
+   assert(db2_support_parse_utc_ts("1970-01-02T00:00:00Z") == 86400);
+}
+
+static void test_timezone_independence(void)
+{
+   static const char *const zones[] = {"UTC0", "PST8PDT", "JST-9"};
+   const char *saved = getenv("TZ");
+   char *saved_copy = saved ? strdup(saved) : NULL;
+
+   for (size_t i = 0; i < sizeof(zones) / sizeof(zones[0]); i++)
+   {
+      assert(setenv("TZ", zones[i], 1) == 0);
+      tzset();
+      assert(parse_utc_ts("1970-01-02 00:00:00") == 86400);
+      assert(db2_support_parse_utc_ts("1970-01-02 00:00:00") == 86400);
+      assert_parse_parity("2024-02-31T12:34:56Z");
+   }
+
+   if (saved_copy)
+   {
+      assert(setenv("TZ", saved_copy, 1) == 0);
+      free(saved_copy);
+   }
+   else
+      assert(unsetenv("TZ") == 0);
+   tzset();
+}
+
+static void assert_utc_shape(const char text[21])
+{
+   assert(strlen(text) == 20);
+   assert(text[4] == '-' && text[7] == '-' && text[10] == 'T');
+   assert(text[13] == ':' && text[16] == ':' && text[19] == 'Z');
+   for (size_t i = 0; i < 20; i++)
+      if (i != 4 && i != 7 && i != 10 && i != 13 && i != 16 && i != 19)
+         assert(isdigit((unsigned char)text[i]));
+}
+
+static void test_now_utc(void)
+{
+   char legacy[21] = "";
+   char support[21] = "";
+   time_t before = time(NULL);
+   now_utc(legacy, sizeof(legacy));
+   db2_support_now_utc(support, sizeof(support));
+   time_t after = time(NULL);
+
+   assert_utc_shape(legacy);
+   assert_utc_shape(support);
+   time_t legacy_epoch = parse_utc_ts(legacy);
+   time_t support_epoch = db2_support_parse_utc_ts(support);
+   assert(legacy_epoch >= before - 5 && legacy_epoch <= after + 5);
+   assert(support_epoch >= before - 5 && support_epoch <= after + 5);
+   assert(labs((long)(legacy_epoch - support_epoch)) <= 5);
+}
+
+int main(void)
+{
+   test_parse_corpus();
+   test_timezone_independence();
+   test_now_utc();
+   return 0;
+}

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -92,6 +92,12 @@
       "test": "src/tests/test_db2_text_support.c"
     },
     {
+      "ctest": false,
+      "make": true,
+      "module": "db2",
+      "test": "src/tests/test_db2_time_support.c"
+    },
+    {
       "ctest": true,
       "make": true,
       "module": "db2",


### PR DESCRIPTION
## Summary

- promote DB2's adjacent `now_utc` and `parse_utc_ts` implementations from the monolith into descriptor-owned support
- pin the support header/source hashes, exports, includes, system imports, and all 20 DB2 callsite edges
- reduce unresolved C link-closure debt from 343 to 341 and portable-core promotion debt from 24 to 22
- preserve the existing `timegm`/`_mkgmtime` platform split without changing pgvector or DB3 behavior

## Tests

- focused normal and ASan/UBSan/FORTIFY UTC parity tests
- 45 link-closure checker tests
- DB2 source-boundary, DB3 portability, activation, and module registration gates
- all 58 lint checks
- build-integrity
- 701 native unit-test binaries plus sanitizer auxiliaries
- 530 Python meta-tests
- frozen-diff roundtable review: approved (`roundtable-dce60e033a09d7752af6481e`)
