### PR TITLE
feat(db2): promote relation helpers

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -86,9 +86,9 @@ Link-closure audit:
 `link-closure-v1.json` accounts for all 141 C translation units in the private DB2 boundary. The
 probe compiles each unit plus exact descriptor-owned support, combines only those objects with a
 relocatable link, supplies no archive, shared library, helper stub, or weak definition, and records
-the 341 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
+the 339 genuinely external symbols plus every referencing unit. Each symbol has a reviewed
 disposition and rationale. The current ledger contains 144 explicit system-link dependencies, 25
-pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 22 support APIs to
+pinned vendored/generated inputs, 150 sibling or KB contracts to inject, and 20 support APIs to
 promote. The standalone-link exit condition requires zero entries in the latter three groups; a
 classified ledger alone is not enough.
 
@@ -135,6 +135,18 @@ invalid basic ranges and separators, trailing input, NULL/empty input, three hos
 formatter grammar, parser round-trip, and a five-second wall-clock window under normal and hardened
 builds. The two formatter callers that also log do not create a support import: logging remains an
 independent injected process-policy decision.
+
+The sixth reduction promotes `rel_type_normalize` and `rel_type_is_functional` without importing the
+relationship enum, seed-table, or memory-ontology surface. The private header exposes only string,
+integer, and `size_t` ABI. Admission pins both exports, four DB2 referencing units, the three-header
+source envelope, and only the observed ctype and `strcmp` imports. Parity covers the legacy corpus,
+every non-NUL one- and two-byte input, every output length through the full test buffer, canary
+preservation, NULL input/output, zero-length output, all nine functional relations, and representative
+multi-valued and non-canonical labels under normal and hardened builds. Seed iteration, lookup, and
+enum text conversion remain deferred to a deliberate shared-type boundary. The byte parity preserves
+the legacy process-locale ctype behavior, and the legacy/support comparison fails if the duplicated
+functional set drifts. This slice moves total debt from 341 to 339 and portable promotion debt from
+22 to 20.
 
 The gate rejects legacy source additions or omissions, support path escape, symlinks, content drift,
 new unresolved symbols, non-system reference growth, missing evidence, and any attempt to make the

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -433,10 +433,20 @@ grammar, parser round-trip, and a five-second `time(NULL)` wall-clock window. `c
 and `code_index.c` also use `aimee_log`, but the support unit has no logging edge, leaving process
 logging as an independent injected policy.
 
-The next support candidates stay explicitly deferred by ownership shape: relation vocabulary moves
-the semantic seed table and its struct/enum ABI; language extractors bring a broad parser/helper
-closure; platform random/process functions carry OS, entropy, and daemon policy. Each requires its
-own coherent admission and parity slice rather than being folded into this unit.
+The sixth admitted unit owns `rel_type_normalize` and `rel_type_is_functional`, the relation helpers
+whose ABI needs only strings, integers, and `size_t`. It deliberately does not import `rel_types.h`
+or its transitive memory-ontology types. Admission pins both exports, their four DB2 referencing
+units, and only the observed ctype and `strcmp` imports. Normal and hardened parity cover the legacy
+corpus, every non-NUL one- and two-byte input, all output lengths through the full test buffer,
+canaries, NULL and zero-length handling, every functional relation, and representative negative
+labels. The byte parity intentionally preserves the process-locale ctype behavior of the authoritative
+copy, and the legacy/support comparison makes drift in the duplicated functional set a test failure.
+
+The next support candidates stay explicitly deferred by ownership shape: relation seed iteration,
+lookup, and enum text conversion move the semantic seed table or its struct/enum ABI; language
+extractors bring a broad parser/helper closure; platform random/process functions carry OS, entropy,
+and daemon policy. Each requires its own coherent admission and parity slice rather than being folded
+into this unit.
 
 These reductions remain phase-one precursors, not substitutes for the program exit criteria below:
 standalone C closure reaches zero non-system packaging/injection/promotion debt; the C process is

--- a/scripts/check_db2_link_closure.py
+++ b/scripts/check_db2_link_closure.py
@@ -86,6 +86,31 @@ SUPPORT_UNITS: list[dict[str, object]] = [{
     "evidence": "Deterministic two-value selector mapping with no imports, allocation, I/O, DB, "
                 "event-bus, provider, platform, pgvector, or DB3 dependency; ABI parity tested.",
 }, {
+    "path": "src/modules/db2/support/rel_type_primitives.c",
+    "source_sha256": "a3a9e88f2a90c0de5d09f952c60ff90843f4f332a9c2a411e2dc1e081f31cce1",
+    "header": "src/modules/db2/support/db2_rel_type_helpers.h",
+    "header_sha256": "cd1b904cb2fe0ff443ab94d1044ce6eefd71aa4e004ddca4641de27be9a391a2",
+    "defines": ["rel_type_is_functional", "rel_type_normalize"],
+    "resolves": ["rel_type_is_functional", "rel_type_normalize"],
+    "allowed_includes": ["ctype.h", "db2_rel_type_helpers.h", "string.h"],
+    "allowed_header_includes": ["stddef.h"],
+    "allowed_undefined": ["__ctype_b_loc", "__ctype_tolower_loc", "strcmp"],
+    "base_references": {
+        "rel_type_is_functional": ["src/modules/db2/c/entity_edges.c"],
+        "rel_type_normalize": [
+            "src/modules/db2/c/fact_lifecycle.c",
+            "src/modules/db2/c/ontology_evolution.c",
+            "src/modules/db2/c/rel_types_store.c",
+        ],
+    },
+    "provenance": "Definitions promoted from the DB-free core in src/rel_types.c; all DB2 calls "
+                  "audited in entity_edges.c, fact_lifecycle.c, ontology_evolution.c, and "
+                  "rel_types_store.c.",
+    "evidence": "Relation normalization preserves the legacy process-locale ctype behavior and "
+                "functional classification; only ctype and strcmp are imported. No ontology "
+                "enum/header, DB, event-bus, provider, platform, pgvector, DB3, allocation, I/O, "
+                "or logging dependency.",
+}, {
     "path": "src/modules/db2/support/sketch_primitives.c",
     "source_sha256": "20318d4f9c92894892ef9475f95c1542602f3a7d2b4d9fe6df2b8d63b4986280",
     "header": "src/modules/db2/support/sketch.h",

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "6925305e7764121dfefa3c4e2ee2c6c1f3ac7365",
-  "source_fingerprint": "5e41b9a48251716f26192e3013d63708d9cabc921ebabca16661f07e2d86da4a",
+  "source_revision": "eb42135a5cb800e0a00b813f8e377c2f8e2c06a0",
+  "source_fingerprint": "e64190da1dced2a596143d14f4111308db2a3fd7544e8e7bae3c23d289ae5688",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0",
@@ -223,6 +223,45 @@
       },
       "provenance": "Definition promoted from src/shared/management_read.c; the sole DB2 call was audited in management_read_journal.c.",
       "evidence": "Deterministic two-value selector mapping with no imports, allocation, I/O, DB, event-bus, provider, platform, pgvector, or DB3 dependency; ABI parity tested."
+    },
+    {
+      "path": "src/modules/db2/support/rel_type_primitives.c",
+      "source_sha256": "a3a9e88f2a90c0de5d09f952c60ff90843f4f332a9c2a411e2dc1e081f31cce1",
+      "header": "src/modules/db2/support/db2_rel_type_helpers.h",
+      "header_sha256": "cd1b904cb2fe0ff443ab94d1044ce6eefd71aa4e004ddca4641de27be9a391a2",
+      "defines": [
+        "rel_type_is_functional",
+        "rel_type_normalize"
+      ],
+      "resolves": [
+        "rel_type_is_functional",
+        "rel_type_normalize"
+      ],
+      "allowed_includes": [
+        "ctype.h",
+        "db2_rel_type_helpers.h",
+        "string.h"
+      ],
+      "allowed_header_includes": [
+        "stddef.h"
+      ],
+      "allowed_undefined": [
+        "__ctype_b_loc",
+        "__ctype_tolower_loc",
+        "strcmp"
+      ],
+      "base_references": {
+        "rel_type_is_functional": [
+          "src/modules/db2/c/entity_edges.c"
+        ],
+        "rel_type_normalize": [
+          "src/modules/db2/c/fact_lifecycle.c",
+          "src/modules/db2/c/ontology_evolution.c",
+          "src/modules/db2/c/rel_types_store.c"
+        ]
+      },
+      "provenance": "Definitions promoted from the DB-free core in src/rel_types.c; all DB2 calls audited in entity_edges.c, fact_lifecycle.c, ontology_evolution.c, and rel_types_store.c.",
+      "evidence": "Relation normalization preserves the legacy process-locale ctype behavior and functional classification; only ctype and strcmp are imported. No ontology enum/header, DB, event-bus, provider, platform, pgvector, DB3, allocation, I/O, or logging dependency."
     },
     {
       "path": "src/modules/db2/support/sketch_primitives.c",
@@ -892,7 +931,8 @@
         "src/modules/db2/c/epistemic_directives.c",
         "src/modules/db2/c/kb_payload.c",
         "src/modules/db2/c/notes.c",
-        "src/modules/db2/c/prospective_memories.c"
+        "src/modules/db2/c/prospective_memories.c",
+        "src/modules/db2/support/rel_type_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -907,7 +947,8 @@
         "src/modules/db2/c/epistemic_directives.c",
         "src/modules/db2/c/kb_payload.c",
         "src/modules/db2/c/notes.c",
-        "src/modules/db2/c/prospective_memories.c"
+        "src/modules/db2/c/prospective_memories.c",
+        "src/modules/db2/support/rel_type_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -2928,24 +2969,6 @@
       "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
     },
     {
-      "symbol": "rel_type_is_functional",
-      "references": [
-        "src/modules/db2/c/entity_edges.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
-      "symbol": "rel_type_normalize",
-      "references": [
-        "src/modules/db2/c/fact_lifecycle.c",
-        "src/modules/db2/c/ontology_evolution.c",
-        "src/modules/db2/c/rel_types_store.c"
-      ],
-      "disposition": "portable-core-promotion",
-      "evidence": "Legacy project-owned support symbol outside the DB2 boundary; promote a minimal portable API or reclassify with stronger owner evidence before closure."
-    },
-    {
       "symbol": "rel_types_seed_at",
       "references": [
         "src/modules/db2/c/rel_types_store.c"
@@ -3313,7 +3336,8 @@
         "src/modules/db2/c/vault_operator_rewrap_runtime.c",
         "src/modules/db2/c/vault_operator_status_runtime.c",
         "src/modules/db2/c/vault_pg.c",
-        "src/modules/db2/c/write_tier_grant.c"
+        "src/modules/db2/c/write_tier_grant.c",
+        "src/modules/db2/support/rel_type_primitives.c"
       ],
       "disposition": "system-link",
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
@@ -3877,16 +3901,16 @@
   ],
   "summary": {
     "translation_units": 141,
-    "descriptor_support_units": 5,
-    "unresolved_symbols": 341,
+    "descriptor_support_units": 6,
+    "unresolved_symbols": 339,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 25,
       "injected-module-contract": 150,
-      "portable-core-promotion": 22,
+      "portable-core-promotion": 20,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 144
     }
   },
-  "fingerprint": "57000eb17b53c2d26ed1c9f70dda79cf3a7c613d914de88ae48961ba377b1c7e"
+  "fingerprint": "ec443b173961450cb982112d85f6de82248c366ba9d3e2a94fa94cf53504476d"
 }

--- a/src/modules/db2/module.yaml
+++ b/src/modules/db2/module.yaml
@@ -15,6 +15,7 @@
     "src/modules/db2/module_adapter.c",
     "src/modules/db2/support/dstr_primitives.c",
     "src/modules/db2/support/management_read_primitives.c",
+    "src/modules/db2/support/rel_type_primitives.c",
     "src/modules/db2/support/sketch_primitives.c",
     "src/modules/db2/support/text_primitives.c",
     "src/modules/db2/support/time_primitives.c"
@@ -34,6 +35,7 @@
     "src/modules/db2/module_adapter.h",
     "src/modules/db2/support/db2_dstr.h",
     "src/modules/db2/support/db2_management_read.h",
+    "src/modules/db2/support/db2_rel_type_helpers.h",
     "src/modules/db2/support/db2_text.h",
     "src/modules/db2/support/db2_time.h",
     "src/modules/db2/support/sketch.h"
@@ -44,6 +46,7 @@
     "src/tests/test_db2_dstr_support.c",
     "src/tests/test_db2_management_read_support.c",
     "src/tests/test_db2_module_contract.c",
+    "src/tests/test_db2_rel_type_support.c",
     "src/tests/test_db2_sketch_support.c",
     "src/tests/test_db2_text_support.c",
     "src/tests/test_db2_time_support.c",

--- a/src/modules/db2/support/db2_rel_type_helpers.h
+++ b/src/modules/db2/support/db2_rel_type_helpers.h
@@ -1,0 +1,9 @@
+#ifndef AIMEE_DB2_REL_TYPE_HELPERS_H
+#define AIMEE_DB2_REL_TYPE_HELPERS_H
+
+#include <stddef.h>
+
+void rel_type_normalize(const char *in, char *out, size_t out_len);
+int rel_type_is_functional(const char *rel_type);
+
+#endif

--- a/src/modules/db2/support/rel_type_primitives.c
+++ b/src/modules/db2/support/rel_type_primitives.c
@@ -1,0 +1,48 @@
+#include <ctype.h>
+#include "db2_rel_type_helpers.h"
+#include <string.h>
+
+void rel_type_normalize(const char *in, char *out, size_t out_len)
+{
+   if (!out || out_len == 0)
+      return;
+   size_t o = 0;
+   int prev_us = 1;
+   int prev_lower_or_digit = 0;
+   for (const char *p = in ? in : ""; *p && o + 1 < out_len; p++)
+   {
+      unsigned char c = (unsigned char)*p;
+      if (isalnum(c))
+      {
+         if (isupper(c) && prev_lower_or_digit && !prev_us && o + 1 < out_len)
+            out[o++] = '_';
+         if (o + 1 < out_len)
+            out[o++] = (char)tolower(c);
+         prev_us = 0;
+         prev_lower_or_digit = (islower(c) || isdigit(c));
+      }
+      else if (!prev_us)
+      {
+         out[o++] = '_';
+         prev_us = 1;
+         prev_lower_or_digit = 0;
+      }
+   }
+   while (o > 0 && out[o - 1] == '_')
+      o--;
+   out[o] = '\0';
+}
+
+int rel_type_is_functional(const char *rel_type)
+{
+   if (!rel_type)
+      return 0;
+   static const char *const functional[] = {
+       "lives_in", "born_in",   "age",      "located_in",    "has_hostname",
+       "spouse",   "works_for", "has_role", "device_has_ip",
+   };
+   for (size_t i = 0; i < sizeof(functional) / sizeof(functional[0]); i++)
+      if (strcmp(rel_type, functional[i]) == 0)
+         return 1;
+   return 0;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -730,6 +730,7 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-db2-module-contract \
                 $(TESTPREFIX)/unit-test-bus-db2-module \
                 $(TESTPREFIX)/unit-test-db2-dstr-support \
                 $(TESTPREFIX)/unit-test-db2-management-read-support \
+                $(TESTPREFIX)/unit-test-db2-rel-type-support \
                 $(TESTPREFIX)/unit-test-db2-sketch-support \
                 $(TESTPREFIX)/unit-test-db2-text-support \
                 $(TESTPREFIX)/unit-test-db2-time-support \
@@ -805,6 +806,7 @@ UNIT_TEST_SKIP_P1 ?= 0
 ifeq ($(UNIT_TEST_SHARD_INDEX),0)
 UNIT_TEST_AUX_TARGETS = $(TESTPREFIX)/unit-test-db2-dstr-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-management-read-support-sanitize \
+                        $(TESTPREFIX)/unit-test-db2-rel-type-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-sketch-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-text-support-sanitize \
                         $(TESTPREFIX)/unit-test-db2-time-support-sanitize
@@ -6817,6 +6819,55 @@ unit-test-db2-time-support: $(TESTPREFIX)/unit-test-db2-time-support
 	$<
 
 unit-test-db2-time-support-sanitize: $(TESTPREFIX)/unit-test-db2-time-support-sanitize
+	$<
+
+DB2_REL_TYPE_SUPPORT_RENAMES = \
+   -Drel_type_is_functional=db2_support_rel_type_is_functional \
+   -Drel_type_normalize=db2_support_rel_type_normalize
+DB2_REL_TYPE_SECTION_FLAGS = -ffunction-sections -fdata-sections
+
+$(OBJDIR)/tests/db2_rel_type_support_impl.o: modules/db2/support/rel_type_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_REL_TYPE_SUPPORT_RENAMES) \
+	      $(DB2_REL_TYPE_SECTION_FLAGS) -c -o $@ $<
+
+$(OBJDIR)/tests/db2_rel_type_monolith.o: rel_types.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_REL_TYPE_SECTION_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-rel-type-support: \
+                     $(OBJDIR)/tests/test_db2_rel_type_support.o \
+                     $(OBJDIR)/tests/db2_rel_type_support_impl.o \
+                     $(OBJDIR)/tests/db2_rel_type_monolith.o
+	$(TESTLINK_MIN) -Wl,--gc-sections -o $@ $^ $(TEST_L_FLAGS)
+
+DB2_REL_TYPE_SANITIZE_DIR = $(OBJDIR)/tests/db2-rel-type-support-sanitize
+
+$(DB2_REL_TYPE_SANITIZE_DIR)/test.o: tests/test_db2_rel_type_support.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_REL_TYPE_SANITIZE_DIR)/support.o: modules/db2/support/rel_type_primitives.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_REL_TYPE_SUPPORT_RENAMES) $(DB2_REL_TYPE_SECTION_FLAGS) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(DB2_REL_TYPE_SANITIZE_DIR)/monolith.o: rel_types.c
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_C_FLAGS) $(DB2_REL_TYPE_SECTION_FLAGS) \
+	      $(DB2_SUPPORT_SANITIZE_FLAGS) -c -o $@ $<
+
+$(TESTPREFIX)/unit-test-db2-rel-type-support-sanitize: \
+                     $(DB2_REL_TYPE_SANITIZE_DIR)/test.o \
+                     $(DB2_REL_TYPE_SANITIZE_DIR)/support.o \
+                     $(DB2_REL_TYPE_SANITIZE_DIR)/monolith.o
+	$(CC) $(DB2_SUPPORT_SANITIZE_FLAGS) -Wl,--gc-sections -o $@ $^
+
+.PHONY: unit-test-db2-rel-type-support unit-test-db2-rel-type-support-sanitize
+unit-test-db2-rel-type-support: $(TESTPREFIX)/unit-test-db2-rel-type-support
+	$<
+
+unit-test-db2-rel-type-support-sanitize: $(TESTPREFIX)/unit-test-db2-rel-type-support-sanitize
 	$<
 
 DB2_SKETCH_SUPPORT_RENAMES = \

--- a/src/tests/test_db2_rel_type_support.c
+++ b/src/tests/test_db2_rel_type_support.c
@@ -1,0 +1,93 @@
+/* Parity tests for descriptor-owned DB2 relationship helpers. */
+#include "aimee.h"
+#include "rel_types.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+void db2_support_rel_type_normalize(const char *in, char *out, size_t out_len);
+int db2_support_rel_type_is_functional(const char *rel_type);
+/* The Make rules rename only the support TU; legacy names below resolve through rel_types.c. */
+
+static void assert_normalize_parity(const char *input, size_t out_len)
+{
+   unsigned char legacy[80];
+   unsigned char support[80];
+   memset(legacy, 0xa5, sizeof(legacy));
+   memset(support, 0xa5, sizeof(support));
+
+   rel_type_normalize(input, (char *)legacy, out_len);
+   db2_support_rel_type_normalize(input, (char *)support, out_len);
+   assert(memcmp(legacy, support, sizeof(legacy)) == 0);
+   for (size_t i = out_len; i < sizeof(legacy); i++)
+      assert(legacy[i] == 0xa5);
+}
+
+static void test_normalize_corpus(void)
+{
+   static const char *const corpus[] = {
+       NULL,
+       "",
+       "worksFor",
+       "Works For",
+       "works-for",
+       "__already__snake__",
+       "deviceHasIP",
+       "123ABC",
+       " punctuation! everywhere? ",
+       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-extra",
+   };
+   for (size_t i = 0; i < sizeof(corpus) / sizeof(corpus[0]); i++)
+      for (size_t out_len = 0; out_len <= 79; out_len++)
+         assert_normalize_parity(corpus[i], out_len);
+
+   char untouched = 'x';
+   rel_type_normalize("worksFor", NULL, 8);
+   db2_support_rel_type_normalize("worksFor", NULL, 8);
+   rel_type_normalize("worksFor", &untouched, 0);
+   assert(untouched == 'x');
+   db2_support_rel_type_normalize("worksFor", &untouched, 0);
+   assert(untouched == 'x');
+}
+
+static void test_normalize_all_bytes(void)
+{
+   char input[3] = "";
+   for (unsigned int first = 1; first <= UINT8_MAX; first++)
+   {
+      input[0] = (char)first;
+      input[1] = '\0';
+      assert_normalize_parity(input, 80);
+      for (unsigned int second = 1; second <= UINT8_MAX; second++)
+      {
+         input[1] = (char)second;
+         input[2] = '\0';
+         assert_normalize_parity(input, 80);
+      }
+   }
+}
+
+static void test_functional_parity(void)
+{
+   static const char *const corpus[] = {
+       "lives_in", "born_in",       "age",   "located_in", "has_hostname", "spouse",   "works_for",
+       "has_role", "device_has_ip", "knows", "member_of",  "parent_of",    "worksFor", "",
+       NULL,
+   };
+   for (size_t i = 0; i < sizeof(corpus) / sizeof(corpus[0]); i++)
+      assert(rel_type_is_functional(corpus[i]) == db2_support_rel_type_is_functional(corpus[i]));
+
+   for (size_t i = 0; i < 9; i++)
+      assert(db2_support_rel_type_is_functional(corpus[i]) == 1);
+   for (size_t i = 9; i < sizeof(corpus) / sizeof(corpus[0]); i++)
+      assert(db2_support_rel_type_is_functional(corpus[i]) == 0);
+}
+
+int main(void)
+{
+   test_normalize_corpus();
+   test_normalize_all_bytes();
+   test_functional_parity();
+   return 0;
+}

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -83,6 +83,12 @@
       "ctest": false,
       "make": true,
       "module": "db2",
+      "test": "src/tests/test_db2_rel_type_support.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "db2",
       "test": "src/tests/test_db2_sketch_support.c"
     },
     {


### PR DESCRIPTION
## Summary

- promote `rel_type_normalize` and `rel_type_is_functional` into descriptor-owned DB2 support
- keep the support ABI independent of relationship enums, seed tables, and memory-ontology headers
- pin source/header hashes, exact exports, ctype/strcmp imports, and all four DB2 referencing units
- reduce unresolved C link-closure debt from 341 to 339 and portable-core promotion debt from 22 to 20
- leave pgvector in DB2 and DB3 routing/multi-observer behavior unchanged

## Tests

- normal and ASan/UBSan/FORTIFY parity targets
- legacy corpus, every non-NUL one- and two-byte input, every output length through the test buffer, canaries, NULL/zero-length handling, and functional relation coverage
- 45 link-closure checker tests
- DB2 source-boundary, DB3 portability, activation, and module registration gates
- all 58 lint checks
- build-integrity
- 702 native unit-test binaries plus sanitizer auxiliaries
- 530 Python meta-tests
- intent and frozen-diff roundtable reviews approved (`roundtable-4e92c1d744faf3ae7eba1344`, `roundtable-1678f84aee39f9b6c93b4134`)
