### PR TITLE
db1: generate the wire header from the catalog

### DIFF
--- a/docs/modules/db1.md
+++ b/docs/modules/db1.md
@@ -61,8 +61,13 @@ that has already shipped cannot be renumbered by one that follows. Each
 reservation names the sources it will cover, which makes the outstanding work
 countable from the catalog instead of rediscovered each time. Regrouping or
 renaming a RESERVED family is free; an active one is a contract callers already
-speak. `scripts/gen_db1_contract.py` enforces all of that, and refuses wire
-constants for a family nothing serves yet.
+speak. `scripts/gen_db1_contract.py` GENERATES `db1_module_api.h` from the catalog and
+fails when the file on disk is not what the catalog produces, so the numbering
+and the wire cannot drift apart. Add a family or an operation to the catalog and
+run it with `--write`; never edit the header by hand. A reserved family emits
+nothing, and the wire bounds -- the widest reply and the widest request arity --
+are derived rather than remembered, which is what stops a new family from
+overrunning the decoder's fixed array.
 
 | Family | Event kind | State |
 | --- | --- | --- |

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -106,8 +106,8 @@ def validate_families(raw: object) -> dict[str, dict[str, object]]:
         fail("families", "families must be a nonempty array")
     families: dict[str, dict[str, object]] = {}
     for index, entry in enumerate(raw, start=1):
-        family = keys(entry, {"id", "name", "event_kind", "active", "covers",
-                              "retired_sources"}, f"families[{index-1}]")
+        family = keys(entry, {"id", "name", "event_kind", "active", "doc",
+                              "covers", "retired_sources"}, f"families[{index-1}]")
         # Dense from one, because a family id is its future stage id and stage
         # IDs must be dense from one in the process contract.
         if integer(family["id"], f"families[{index-1}].id", 1, 255) != index:
@@ -128,6 +128,7 @@ def validate_families(raw: object) -> dict[str, dict[str, object]]:
         # a PLAN, in file names, and it is deliberately not machine-checked: a
         # source can hold more than one domain, so "covers" over-states what a
         # family has actually taken. retired_sources is the checked half.
+        text(family["doc"], f"{name}.doc", 512)
         text(family["covers"], f"{name}.covers", 512)
         retired = family["retired_sources"]
         if not isinstance(retired, list) or retired != sorted(set(retired)):
@@ -306,51 +307,174 @@ def validate_retired_sources(root: Path, catalog: dict[str, object]) -> None:
              f"{source!r} is no longer linked into the daemon but no family retires it")
 
 
-def header_constants(root: Path) -> dict[str, int]:
-    try:
-        text_value = (root / HEADER).read_text(encoding="utf-8")
-    except OSError as exc:
-        fail("unreadable", f"cannot read {HEADER}: {exc}")
-    found: dict[str, int] = {}
-    for match in re.finditer(r"^#define\s+(AIMEE_DB1_[A-Z0-9_]+)\s+(\d+)u?\s*$",
-                             text_value, re.M):
-        found[match.group(1)] = int(match.group(2))
-    return found
+PREAMBLE = """/* Wire contract for the DB1 process's bounded stages.
+ *
+ * GENERATED from src/modules/db1/eventcontract/operations.json by
+ * scripts/gen_db1_contract.py. Do not edit: add a family or an operation to the
+ * catalog and regenerate, so the numbering and the wire cannot drift apart.
+ *
+ * DB1 is the server's SQLite store. It is becoming a module so that callers
+ * reach it over the event bus instead of linking it, which is what the module
+ * doctrine requires of state. The C implementation stays for now; only the
+ * boundary is new. See docs/proposals/pending/db1-as-a-go-module.md.
+ *
+ * Event kinds are fixed by the process contract at 4096 + ref*256 + stage. DB1
+ * declares principal ref {ref}, so these are not a free choice. */
+#ifndef AIMEE_DB1_MODULE_API_H
+#define AIMEE_DB1_MODULE_API_H 1
+
+#include <stddef.h>
+#include <stdint.h>
+"""
+
+# One paragraph per wire format, emitted the first time a family uses it.
+WIRE_FORMAT_DOC = {
+    "db1-keyed-blob-v1": """   Request:  op(u32) | key_len(u32) | key | json_len(u32) | json
+   Response: status(u32) | json_len(u32) | json
+   Lengths are little-endian, matching the rest of the bus surface.""",
+    "db1-fields-v1": """   Request:  op(u32) | field_count(u32) | (len(u32) | bytes) * field_count
+   Response: status(u32) | value_len(u32) | value
+
+   The counted form is the one every family after the first uses. The first
+   family fixed its request at exactly two fields, which suits a keyed blob and
+   suits nothing with three, so the count is explicit here rather than implied
+   by the op.""",
+}
+
+HELPERS = """static inline void aimee_db1_put_u32(uint8_t *p, uint32_t value)
+{
+   for (unsigned i = 0; i < 4; ++i)
+      p[i] = (uint8_t)(value >> (i * 8u));
+}
+
+static inline uint32_t aimee_db1_get_u32(const uint8_t *p)
+{
+   uint32_t value = 0;
+   for (unsigned i = 0; i < 4; ++i)
+      value |= (uint32_t)p[i] << (i * 8u);
+   return value;
+}
+
+#endif /* AIMEE_DB1_MODULE_API_H */
+"""
+
+
+def wrap(prose: str, first: str, rest: str, width: int = 79) -> list[str]:
+    """Reflow a catalog sentence into a C comment, deterministically."""
+    words, lines, current = prose.split(), [], first
+    for word in words:
+        # The prefix already carries its own trailing space, so the first word on
+        # a line is appended bare -- otherwise every comment opens "/*  Family".
+        candidate = f"{current}{word}" if current in (first, rest) else f"{current} {word}"
+        if len(candidate) > width and current not in (first, rest):
+            lines.append(current.rstrip())
+            current = f"{rest}{word}"
+        else:
+            current = candidate
+    if current.strip():
+        lines.append(current.rstrip())
+    return lines
+
+
+def define_block(pairs: list[tuple[str, str]]) -> list[str]:
+    """#defines with their values aligned, the way the tree writes them."""
+    if not pairs:
+        return []
+    width = max(len(name) for name, _ in pairs)
+    return [f"#define {name.ljust(width)} {value}" for name, value in pairs]
+
+
+def header_bytes(catalog: dict[str, object]) -> str:
+    families = catalog["families"]
+    operations = catalog["operations"]
+    assert isinstance(families, dict) and isinstance(operations, list)
+    by_family: dict[str, list[dict[str, object]]] = {}
+    for operation in operations:
+        by_family.setdefault(str(operation["family"]), []).append(operation)
+
+    out = [PREAMBLE.replace("{ref}", str(PRINCIPAL_REF))]
+    seen_formats: set[str] = set()
+    field_max = 0
+    fields_max = 0
+    state_max = 0
+
+    for family in sorted(families.values(), key=lambda f: int(f["id"])):
+        if not family["active"]:
+            # A constant for a family nothing serves would invite a caller to
+            # speak an event with no listener.
+            continue
+        name = str(family["name"])
+        upper = name.upper()
+        own = by_family.get(name, [])
+        block = [""]
+        block.extend(wrap(f"Family {family['id']}: {family['doc']}", "/* ", " * "))
+        wire = str(own[0]["wire_format"]) if own else ""
+        if wire and wire not in seen_formats:
+            # Described once, beside the first family that speaks it.
+            seen_formats.add(wire)
+            block.append(" *")
+            for line in WIRE_FORMAT_DOC[wire].rstrip().split("\n"):
+                block.append((" * " + line.strip()).rstrip() if line.strip() else " *")
+        block[-1] += " */"
+        block.append("")
+        block.extend(define_block([
+            (f"AIMEE_DB1_EVENT_{upper}", f"{family['event_kind']}u"),
+            (f"AIMEE_DB1_STAGE_{upper}", f"{family['id']}u"),
+        ]))
+        if own:
+            block.append("")
+            block.extend(define_block([
+                (f"AIMEE_DB1_OP_{str(o['name']).upper()}", f"{o['id']}u") for o in own
+            ]))
+        out.append("\n".join(block) + "\n")
+
+        for operation in own:
+            reply = operation["reply"]
+            request = operation["request"]
+            assert isinstance(reply, dict) and isinstance(request, dict)
+            if reply["payload"] == "state":
+                state_max = max(state_max, int(reply["max_bytes"]))
+            if reply["payload"] == "text":
+                field_max = max(field_max, int(reply["max_bytes"]))
+            if operation["wire_format"] == "db1-fields-v1":
+                fields_max = max(fields_max, len(request["fields"]))
+
+    limits: list[tuple[str, str]] = []
+    if state_max:
+        limits.append(("AIMEE_DB1_STATE_MAX", f"{state_max}u"))
+    if field_max:
+        limits.append(("AIMEE_DB1_FIELD_MAX", f"{field_max}u"))
+    if fields_max:
+        limits.append(("AIMEE_DB1_FIELDS_MAX", f"{fields_max}u"))
+    if limits:
+        out.append("\n/* Wire bounds, carried from the catalog's declared reply sizes and\n"
+                   "   request arities. Stated so the module refuses an over-long value rather\n"
+                   "   than truncating one into something that looks valid. */\n"
+                   + "\n".join(define_block(limits)) + "\n")
+
+    out.append("\n" + "\n".join(define_block(
+        [(f"AIMEE_DB1_STATUS_{code.upper()}", f"{index}u")
+         for index, code in enumerate(RESULT_CODES)])) + "\n")
+    out.append("\n" + HELPERS)
+    return "".join(out)
 
 
 def validate_header(root: Path, catalog: dict[str, object]) -> None:
-    """The hand-written wire header must agree with the catalog, in both directions."""
-    constants = header_constants(root)
-    families = catalog["families"]
-    assert isinstance(families, dict)
-    for name, family in families.items():
-        if not family["active"]:
-            # A reserved family must NOT have wire constants yet: a constant is
-            # a promise to callers, and nothing serves this one.
-            leaked = [key for key in constants if name.upper() in key]
-            if leaked:
-                fail("header-reserved",
-                     f"reserved family {name!r} already has wire constants {leaked}")
-            continue
-        event = f"AIMEE_DB1_EVENT_{name.upper()}"
-        stage = f"AIMEE_DB1_STAGE_{name.upper()}"
-        if constants.get(event) != family["event_kind"]:
-            fail("header-event",
-                 f"{HEADER} must define {event} as {family['event_kind']}")
-        if constants.get(stage) != family["id"]:
-            fail("header-stage", f"{HEADER} must define {stage} as {family['id']}")
+    """The header must be exactly what the catalog generates.
 
-    operations = catalog["operations"]
-    assert isinstance(operations, list)
-    for operation in operations:
-        symbol = f"AIMEE_DB1_OP_{str(operation['name']).upper()}"
-        if constants.get(symbol) != operation["id"]:
-            fail("header-op", f"{HEADER} must define {symbol} as {operation['id']}")
-
-    for index, code in enumerate(RESULT_CODES):
-        symbol = f"AIMEE_DB1_STATUS_{code.upper()}"
-        if constants.get(symbol) != index:
-            fail("header-status", f"{HEADER} must define {symbol} as {index}")
+    A whole-file comparison rather than a constant-by-constant one: it also
+    catches a constant for a family nothing serves, a stale limit, and hand
+    edits that the per-symbol checks would have walked straight past.
+    """
+    expected = header_bytes(catalog)
+    try:
+        actual = (root / HEADER).read_text(encoding="utf-8")
+    except OSError as exc:
+        fail("unreadable", f"cannot read {HEADER}: {exc}")
+    if actual != expected:
+        fail("header-stale",
+             f"{HEADER} is not what the catalog generates; run "
+             f"scripts/gen_db1_contract.py --write")
 
 
 def validate_process_contract(root: Path, catalog: dict[str, object]) -> None:
@@ -388,8 +512,10 @@ def validate_process_contract(root: Path, catalog: dict[str, object]) -> None:
                  f"stage {name!r} must carry id {family['id']} and kind {family['event_kind']}")
 
 
-def run(root: Path) -> None:
+def run(root: Path, write: bool = False) -> None:
     catalog = validate_catalog(load_json(root / CATALOG))
+    if write:
+        (root / HEADER).write_text(header_bytes(catalog), encoding="utf-8")
     validate_header(root, catalog)
     validate_process_contract(root, catalog)
     validate_retired_sources(root, catalog)
@@ -405,9 +531,11 @@ def run(root: Path) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--write", action="store_true",
+                        help="regenerate the wire header from the catalog")
     args = parser.parse_args(argv)
     try:
-        run(args.root.resolve())
+        run(args.root.resolve(), args.write)
     except ContractError as exc:
         print(f"gen_db1_contract: error: {exc}", file=sys.stderr)
         return 1

--- a/scripts/tests/test_gen_db1_contract.py
+++ b/scripts/tests/test_gen_db1_contract.py
@@ -128,18 +128,20 @@ class CatalogTests(unittest.TestCase):
                     f"#define {symbol} {reserved['event_kind']}u\n"
                     "#endif /* AIMEE_DB1_MODULE_API_H */"),
                 encoding="utf-8")
-            self.assertRule(root, "header-reserved")
+            # Subsumed by the whole-file check: a constant for a family nothing
+            # serves is simply not what the catalog generates.
+            self.assertRule(root, "header-stale")
         finally:
             tmp.cleanup()
 
     def test_header_drift_is_caught_in_every_direction(self) -> None:
         for original, replacement, rule in (
             ("AIMEE_DB1_EVENT_ECONOMIZER_STATE 11777u",
-             "AIMEE_DB1_EVENT_ECONOMIZER_STATE 11778u", "header-event"),
+             "AIMEE_DB1_EVENT_ECONOMIZER_STATE 11778u", "header-stale"),
             ("AIMEE_DB1_STAGE_ECONOMIZER_STATE 1u",
-             "AIMEE_DB1_STAGE_ECONOMIZER_STATE 2u", "header-stage"),
-            ("AIMEE_DB1_OP_STATE_SAVE 2u", "AIMEE_DB1_OP_STATE_SAVE 3u", "header-op"),
-            ("AIMEE_DB1_STATUS_TOO_LONG 3u", "AIMEE_DB1_STATUS_TOO_LONG 9u", "header-status"),
+             "AIMEE_DB1_STAGE_ECONOMIZER_STATE 2u", "header-stale"),
+            ("AIMEE_DB1_OP_STATE_SAVE 2u", "AIMEE_DB1_OP_STATE_SAVE 3u", "header-stale"),
+            ("AIMEE_DB1_STATUS_TOO_LONG 3u", "AIMEE_DB1_STATUS_TOO_LONG 9u", "header-stale"),
         ):
             with self.subTest(rule=rule):
                 tmp = sandbox()
@@ -242,6 +244,71 @@ class CatalogTests(unittest.TestCase):
         for family in catalog["families"]:
             self.assertNotIn("module_adapter.c", family["retired_sources"])
         contract.run(REPO_ROOT)
+
+    def test_generation_is_deterministic(self) -> None:
+        catalog = contract.validate_catalog(contract.load_json(REPO_ROOT / contract.CATALOG))
+        self.assertEqual(contract.header_bytes(catalog), contract.header_bytes(catalog))
+
+    def test_writing_the_header_is_idempotent(self) -> None:
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            contract.run(root, write=True)
+            once = (root / contract.HEADER).read_text(encoding="utf-8")
+            contract.run(root, write=True)
+            self.assertEqual(once, (root / contract.HEADER).read_text(encoding="utf-8"))
+        finally:
+            tmp.cleanup()
+
+    def test_a_new_family_brings_its_constants_and_widens_the_bounds(self) -> None:
+        # The reason to generate at all: adding a family should not require
+        # remembering that the decoder's fixed array is sized by the widest
+        # request in the catalog. Getting that wrong was a stack overflow once.
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.catalog(root)
+            reserved = self.reserved(catalog)
+            reserved["active"] = True
+            catalog["operations"].append({
+                "family": reserved["name"], "id": 1, "name": "probe_touch",
+                "wire_format": "db1-fields-v1", "scope": "session",
+                "transaction": "single", "idempotency": "idempotent",
+                "results": ["ok", "invalid", "failed"],
+                "request": {"fields": ["key", "a", "b", "c"]},
+                "reply": {"payload": "none", "max_bytes": 0},
+            })
+            self.write(root, catalog)
+            # Activating a family without declaring its stage is refused, which
+            # is the cross-check doing its job -- so declare it.
+            path = root / contract.PROCESS_CONTRACTS
+            document = json.loads(path.read_text(encoding="utf-8"))
+            for component in document["components"]:
+                if component["id"] == "db1":
+                    component["stages"].append({
+                        "id": reserved["id"],
+                        "name": "db1-" + reserved["name"].replace("_", "-"),
+                        "event_kind": reserved["event_kind"],
+                    })
+            path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+
+            contract.run(root, write=True)
+            header = (root / contract.HEADER).read_text(encoding="utf-8")
+            upper = reserved["name"].upper()
+            self.assertIn(f"#define AIMEE_DB1_EVENT_{upper} {reserved['event_kind']}u", header)
+            self.assertIn("AIMEE_DB1_OP_PROBE_TOUCH", header)
+            self.assertRegex(header, r"AIMEE_DB1_FIELDS_MAX\s+4u")
+        finally:
+            tmp.cleanup()
+
+    def test_a_reserved_family_emits_nothing(self) -> None:
+        catalog = contract.validate_catalog(contract.load_json(REPO_ROOT / contract.CATALOG))
+        header = contract.header_bytes(catalog)
+        families = catalog["families"]
+        for name, family in families.items():
+            if not family["active"]:
+                self.assertNotIn(name.upper(), header,
+                                 f"reserved family {name} leaked into the wire header")
 
     def test_every_operation_is_keyed(self) -> None:
         # DB1 rows belong to a conversation or session; an unkeyed read would

--- a/src/modules/db1/db1_module_api.h
+++ b/src/modules/db1/db1_module_api.h
@@ -1,5 +1,9 @@
 /* Wire contract for the DB1 process's bounded stages.
  *
+ * GENERATED from src/modules/db1/eventcontract/operations.json by
+ * scripts/gen_db1_contract.py. Do not edit: add a family or an operation to the
+ * catalog and regenerate, so the numbering and the wire cannot drift apart.
+ *
  * DB1 is the server's SQLite store. It is becoming a module so that callers
  * reach it over the event bus instead of linking it, which is what the module
  * doctrine requires of state. The C implementation stays for now; only the
@@ -13,32 +17,31 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* Stage 1: the economizer's per-conversation reducer state. Chosen as the first
- * stage because it has exactly one production caller, so it proves the boundary
- * without a wide cutover. */
+/* Family 1: the economizer's per-conversation reducer state. Chosen as the
+ * first family because it has exactly one production caller, so it proved the
+ * boundary without a wide cutover.
+ *
+ * Request:  op(u32) | key_len(u32) | key | json_len(u32) | json
+ * Response: status(u32) | json_len(u32) | json
+ * Lengths are little-endian, matching the rest of the bus surface. */
+
 #define AIMEE_DB1_EVENT_ECONOMIZER_STATE 11777u
 #define AIMEE_DB1_STAGE_ECONOMIZER_STATE 1u
 
-/* Request:  op(u32) | key_len(u32) | key | json_len(u32) | json
-   Response: status(u32) | json_len(u32) | json
-   Lengths are little-endian, matching the rest of the bus surface. */
 #define AIMEE_DB1_OP_STATE_LOAD 1u
 #define AIMEE_DB1_OP_STATE_SAVE 2u
 
-/* A reducer state blob is bounded by the caller's buffer today
-   (ECON_MODULE_STATE_MAX). The wire cap is stated here so the module can refuse
-   an over-long value rather than truncate one. */
-#define AIMEE_DB1_STATE_MAX 6144u
+/* Family 2: branch ownership for the MCP git flows. Rows say which session
+ * owns which branch, so concurrent local sessions do not stomp on each other.
+ *
+ * Request:  op(u32) | field_count(u32) | (len(u32) | bytes) * field_count
+ * Response: status(u32) | value_len(u32) | value
+ *
+ * The counted form is the one every family after the first uses. The first
+ * family fixed its request at exactly two fields, which suits a keyed blob and
+ * suits nothing with three, so the count is explicit here rather than implied
+ * by the op. */
 
-/* Family 2: branch ownership for the MCP git flows. Rows say which session owns
-   which branch, so concurrent local sessions do not stomp on each other.
-
-   Request:  op(u32) | field_count(u32) | (len(u32) | bytes) * field_count
-   Response: status(u32) | value_len(u32) | value
-
-   The counted form is the one every family after the first uses. Stage 1 fixed
-   its request at exactly two fields, which suited a keyed blob and suits nothing
-   with three, so the count is explicit here rather than implied by the op. */
 #define AIMEE_DB1_EVENT_GIT_OWNERSHIP 11778u
 #define AIMEE_DB1_STAGE_GIT_OWNERSHIP 2u
 
@@ -48,9 +51,10 @@
 #define AIMEE_DB1_OP_OWNERSHIP_BRANCH_FOR_SESSION 4u
 #define AIMEE_DB1_OP_OWNERSHIP_SESSION_BY_PREFIX  5u
 
-/* Bounds the repo path, branch, session id and prefix a request may carry, and
-   the value a reply returns. Stated so the module refuses an over-long field
-   rather than truncating one into a different row. */
+/* Wire bounds, carried from the catalog's declared reply sizes and
+   request arities. Stated so the module refuses an over-long value rather
+   than truncating one into something that looks valid. */
+#define AIMEE_DB1_STATE_MAX  6144u
 #define AIMEE_DB1_FIELD_MAX  512u
 #define AIMEE_DB1_FIELDS_MAX 3u
 

--- a/src/modules/db1/eventcontract/operations.json
+++ b/src/modules/db1/eventcontract/operations.json
@@ -9,6 +9,7 @@
       "name": "economizer_state",
       "event_kind": 11777,
       "active": true,
+      "doc": "the economizer's per-conversation reducer state. Chosen as the first family because it has exactly one production caller, so it proved the boundary without a wide cutover.",
       "covers": "checkpoints (the economizer's reducer state only)",
       "retired_sources": []
     },
@@ -17,6 +18,7 @@
       "name": "git_ownership",
       "event_kind": 11778,
       "active": true,
+      "doc": "branch ownership for the MCP git flows. Rows say which session owns which branch, so concurrent local sessions do not stomp on each other.",
       "covers": "git_ownership",
       "retired_sources": [
         "git_ownership.c"
@@ -27,6 +29,7 @@
       "name": "sessions",
       "event_kind": 11779,
       "active": false,
+      "doc": "server and webchat session rows.",
       "covers": "server_sessions, primary_sessions, session_state, session_paths, webchat_claude_sessions, webchat_live",
       "retired_sources": []
     },
@@ -35,6 +38,7 @@
       "name": "agent_work",
       "event_kind": 11780,
       "active": false,
+      "doc": "queued agent work: jobs, logs and the cron that drives them.",
       "covers": "agent_jobs, agent_log, coord_jobs, cognify_jobs, db1_cron_jobs, db1_trigger",
       "retired_sources": []
     },
@@ -43,6 +47,7 @@
       "name": "delegation",
       "event_kind": 11781,
       "active": false,
+      "doc": "delegation spawns, reservations and their checkpoints.",
       "covers": "delegations, delegate_reservation, delegate_learning, delegation_checkpoint",
       "retired_sources": []
     },
@@ -51,6 +56,7 @@
       "name": "workflow",
       "event_kind": 11782,
       "active": false,
+      "doc": "the workflow engine's stores, plans and traces.",
       "covers": "wfe_store, wfe_binding, execution_plans, execution_trace, pipelines, roadmap_runtime, roundtable_pipeline",
       "retired_sources": []
     },
@@ -59,6 +65,7 @@
       "name": "conversation",
       "event_kind": 11783,
       "active": false,
+      "doc": "per-conversation context, clarifications and working memory.",
       "covers": "conv_context, clarify, payload_rewrite_state, user_memory, wm, windows",
       "retired_sources": []
     },
@@ -67,6 +74,7 @@
       "name": "identity",
       "event_kind": 11784,
       "active": false,
+      "doc": "secrets and the replay stores behind token consumption.",
       "covers": "secrets, server_identity_jti, server_management_jti, remote_client_grant",
       "retired_sources": []
     },
@@ -75,6 +83,7 @@
       "name": "telemetry",
       "event_kind": 11785,
       "active": false,
+      "doc": "token accounting, evaluations and recorded events.",
       "covers": "token_audit, cost_fold, interaction_events, guardrail_events, eval, ensemble, diagnose, diagnostics",
       "retired_sources": []
     },
@@ -83,6 +92,7 @@
       "name": "runtime",
       "event_kind": 11786,
       "active": false,
+      "doc": "local runtime resolution, caches and model metadata.",
       "covers": "runtime_state, project_clones, local_operator, env, model_catalog, model_pricing, working_profile_local, tool_local_availability, caches, web_page_cache, fsnap, decisions, maintenance, mcp_osv_cache",
       "retired_sources": []
     }


### PR DESCRIPTION
Two families and seven operations were enough hand-written wire; the next family has roughly **twenty-five**. So `db1_module_api.h` is generated now, and the catalog is the only place a number is written down.

### The bounds are why this matters more than tidiness
`AIMEE_DB1_FIELDS_MAX` sizes the adapter's fixed field array. Getting it wrong is not a validation slip — it was a **stack-buffer-overflow** when the check that enforces it was removed (proved under ASAN in #2730). It is now derived from the widest request the catalog declares, so adding a family with four fields widens it automatically instead of depending on someone remembering the connection.

Demonstrated by dry-run: activating a reserved family with a 4-field operation emitted its constants and moved `FIELDS_MAX` from `3u` to `4u` with no code change.

### Checking is now whole-file
A constant for a family nothing serves, a stale bound, and any hand edit all fail the same way — `header-stale` — and the fix is to regenerate rather than to guess which symbol drifted. The per-symbol rules it replaces are gone, so the tests that named them now name `header-stale`; the drift they describe is still caught.

The prose moved into the catalog rather than being lost: each family carries a `doc` line, and each wire format is described once beside the first family that speaks it.

### Safety property
**Every constant is byte-identical** to the header this replaces — diffed against `origin/testing` — which is what made this safe to do at all.

### Verified
Generation deterministic and idempotent; a hand edit refused; a reserved family emits nothing; the catalog's 22 tests; the descriptor, process-contract and module-doc gates; the C build; lint (58 checks); and both DB1 unit tests.