### PR TITLE
db1: keep the delegate ledger in one family, and check that it stays there

### DIFF
--- a/docs/modules/db1.md
+++ b/docs/modules/db1.md
@@ -46,6 +46,20 @@ family owns one event kind and its operations dispatch on an op id inside the
 payload, so DB1 needs one stage per domain rather than one per call -- roughly
 sixty domains against a ceiling of 255.
 
+The catalog is a complete map, not a wish list: every DB1 source belongs to
+exactly one family or to `infrastructure_sources` -- the connection, schema,
+write path and the module's own handler, which have no callers to migrate. An
+unclaimed domain is one nobody is planning to move, and a twice-claimed one is
+two families expecting to own the same rows; both are refused.
+
+Some sources must migrate together, and `coupled_sources` says which and why. A
+family is the unit that activates, so two halves of one ledger in two families
+is a plan to separate them. The delegate ledger is coupled for a recorded
+reason: `server_compute.c` keeps the reservation beside the launch because a
+ledger across a boundary from the launch left paid-for jobs that nothing could
+replay, and a lookup that fails reads as "no reservation" and launches a second
+one.
+
 Each family also records which DB1 sources the daemon has stopped linking, and
 that half IS machine-checked. The plan and the proof are separate on purpose: a
 DB1 source usually holds more than one domain, so "covers" over-states -- family

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -107,7 +107,8 @@ def validate_families(raw: object) -> dict[str, dict[str, object]]:
     families: dict[str, dict[str, object]] = {}
     for index, entry in enumerate(raw, start=1):
         family = keys(entry, {"id", "name", "event_kind", "active", "doc",
-                              "covers", "retired_sources"}, f"families[{index-1}]")
+                              "covers", "sources", "retired_sources"},
+                      f"families[{index-1}]")
         # Dense from one, because a family id is its future stage id and stage
         # IDs must be dense from one in the process contract.
         if integer(family["id"], f"families[{index-1}].id", 1, 255) != index:
@@ -130,6 +131,12 @@ def validate_families(raw: object) -> dict[str, dict[str, object]]:
         # family has actually taken. retired_sources is the checked half.
         text(family["doc"], f"{name}.doc", 512)
         text(family["covers"], f"{name}.covers", 512)
+        sources = family["sources"]
+        if not isinstance(sources, list) or not sources or sources != sorted(set(sources)):
+            fail("family-sources", f"{name}.sources must be sorted, unique and nonempty")
+        for source in sources:
+            if not isinstance(source, str) or not NAME.fullmatch(source):
+                fail("family-source-name", f"{name} names invalid source {source!r}")
         retired = family["retired_sources"]
         if not isinstance(retired, list) or retired != sorted(set(retired)):
             fail("retired-sources", f"{name}.retired_sources must be sorted and unique")
@@ -236,8 +243,9 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
 
 def validate_catalog(value: object) -> dict[str, object]:
     catalog = keys(value, {
-        "schema_version", "module", "wire_version", "catalog_complete", "families",
-        "result_codes", "operations",
+        "schema_version", "module", "wire_version", "catalog_complete",
+        "infrastructure_sources", "coupled_sources", "families", "result_codes",
+        "operations",
     }, "catalog")
     if catalog["schema_version"] != 1:
         fail("schema-version", "schema_version must equal 1")
@@ -259,6 +267,79 @@ def validate_catalog(value: object) -> dict[str, object]:
     catalog["families"] = families
     catalog["operations"] = operations
     return catalog
+
+
+def validate_source_map(root: Path, catalog: dict[str, object]) -> None:
+    """Every DB1 source belongs to exactly one family, or to infrastructure.
+
+    This is what makes the catalog a map rather than a wish list: a domain
+    nobody claimed is a domain nobody is planning to move, and a domain claimed
+    twice is two families expecting to own the same rows.
+
+    Infrastructure is named separately because it has no callers to migrate --
+    the connection, the schema, the write path and the module's own handler.
+    """
+    try:
+        on_disk = {path.stem for path in (root / SOURCE_DIR).glob("*.c")}
+    except OSError as exc:
+        fail("unreadable", f"cannot list {SOURCE_DIR}: {exc}")
+
+    infrastructure = catalog["infrastructure_sources"]
+    if not isinstance(infrastructure, list) or infrastructure != sorted(set(infrastructure)):
+        fail("infrastructure", "infrastructure_sources must be sorted and unique")
+
+    families = catalog["families"]
+    assert isinstance(families, dict)
+    owner: dict[str, str] = {}
+    for name, family in families.items():
+        for source in family["sources"]:
+            if source in owner:
+                fail("source-duplicate",
+                     f"{source!r} is claimed by both {owner[source]!r} and {name!r}")
+            owner[source] = name
+    for source in infrastructure:
+        if source in owner:
+            fail("source-duplicate",
+                 f"{source!r} is both infrastructure and claimed by {owner[source]!r}")
+        owner[source] = "(infrastructure)"
+
+    for source in sorted(set(owner) - on_disk):
+        fail("source-absent", f"{source!r} is claimed but is not in {SOURCE_DIR}")
+    for source in sorted(on_disk - set(owner)):
+        fail("source-unclaimed",
+             f"{source!r} is in {SOURCE_DIR} but no family or infrastructure claims it")
+
+
+def validate_coupled_sources(catalog: dict[str, object]) -> None:
+    """Sources that must migrate together must sit in one family.
+
+    A family is the unit that activates, so two halves of one ledger in two
+    families is a plan to split them -- and the coupling here exists because
+    splitting this particular ledger already cost paid-for work that could not
+    be replayed.
+    """
+    groups = catalog["coupled_sources"]
+    if not isinstance(groups, list):
+        fail("coupled", "coupled_sources must be an array")
+    families = catalog["families"]
+    assert isinstance(families, dict)
+    owner = {source: name for name, family in families.items() for source in family["sources"]}
+    for index, group in enumerate(groups):
+        entry = keys(group, {"sources", "reason"}, f"coupled_sources[{index}]")
+        sources = entry["sources"]
+        if not isinstance(sources, list) or len(sources) < 2 or sources != sorted(set(sources)):
+            fail("coupled-sources",
+                 f"coupled_sources[{index}].sources must be sorted, unique and hold at least two")
+        text(entry["reason"], f"coupled_sources[{index}].reason", 512)
+        holders = {owner.get(source) for source in sources}
+        if None in holders:
+            missing = sorted(s for s in sources if s not in owner)
+            fail("coupled-unclaimed",
+                 f"coupled_sources[{index}] names unclaimed source(s) {missing}")
+        if len(holders) != 1:
+            fail("coupled-split",
+                 f"coupled_sources[{index}] is split across families {sorted(holders)}: "
+                 f"{entry['reason']}")
 
 
 def validate_retired_sources(root: Path, catalog: dict[str, object]) -> None:
@@ -518,6 +599,8 @@ def run(root: Path, write: bool = False) -> None:
         (root / HEADER).write_text(header_bytes(catalog), encoding="utf-8")
     validate_header(root, catalog)
     validate_process_contract(root, catalog)
+    validate_source_map(root, catalog)
+    validate_coupled_sources(catalog)
     validate_retired_sources(root, catalog)
     families = catalog["families"]
     operations = catalog["operations"]

--- a/scripts/tests/test_gen_db1_contract.py
+++ b/scripts/tests/test_gen_db1_contract.py
@@ -310,6 +310,69 @@ class CatalogTests(unittest.TestCase):
                 self.assertNotIn(name.upper(), header,
                                  f"reserved family {name} leaked into the wire header")
 
+    def test_every_db1_source_is_claimed_exactly_once(self) -> None:
+        # The property that makes the catalog a map: an unclaimed domain is one
+        # nobody is planning to move, and a twice-claimed one is two families
+        # expecting to own the same rows.
+        catalog = self.catalog(REPO_ROOT)
+        owner: dict[str, str] = {}
+        for family in catalog["families"]:
+            for source in family["sources"]:
+                self.assertNotIn(source, owner, f"{source} claimed twice")
+                owner[source] = family["name"]
+        for source in catalog["infrastructure_sources"]:
+            self.assertNotIn(source, owner, f"{source} is infrastructure and claimed")
+            owner[source] = "(infrastructure)"
+        on_disk = {path.stem for path in (REPO_ROOT / contract.SOURCE_DIR).glob("*.c")}
+        self.assertEqual(set(owner), on_disk)
+
+    def test_an_unclaimed_or_duplicated_source_is_refused(self) -> None:
+        for mutate, rule in (
+            (lambda c: c["families"][2]["sources"].pop(), "source-unclaimed"),
+            (lambda c: c["families"][2]["sources"].append(c["families"][3]["sources"][0]),
+             "source-duplicate"),
+            (lambda c: c["infrastructure_sources"].append("ghost_domain"), "source-absent"),
+        ):
+            with self.subTest(rule=rule):
+                tmp = sandbox()
+                try:
+                    root = Path(tmp.name)
+                    catalog = self.catalog(root)
+                    mutate(catalog)
+                    catalog["families"][2]["sources"].sort()
+                    catalog["infrastructure_sources"].sort()
+                    self.write(root, catalog)
+                    self.assertRule(root, rule)
+                finally:
+                    tmp.cleanup()
+
+    def test_a_coupled_ledger_cannot_be_split_across_families(self) -> None:
+        # This one is not hygiene. server_compute.c records that separating the
+        # reservation ledger from the launch left paid-for jobs nothing could
+        # replay, and a family is the unit that activates -- so two halves in
+        # two families is a plan to separate them again.
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.catalog(root)
+            group = catalog["coupled_sources"][0]["sources"]
+            holder = next(f for f in catalog["families"] if group[0] in f["sources"])
+            other = next(f for f in catalog["families"] if f["name"] != holder["name"])
+            holder["sources"] = sorted(s for s in holder["sources"] if s != group[0])
+            other["sources"] = sorted(other["sources"] + [group[0]])
+            self.write(root, catalog)
+            self.assertRule(root, "coupled-split")
+        finally:
+            tmp.cleanup()
+
+    def test_the_shipped_coupling_names_a_reason(self) -> None:
+        catalog = self.catalog(REPO_ROOT)
+        self.assertTrue(catalog["coupled_sources"])
+        for group in catalog["coupled_sources"]:
+            self.assertGreaterEqual(len(group["sources"]), 2)
+            self.assertTrue(group["reason"].strip(),
+                            "a coupling with no reason cannot be reviewed")
+
     def test_every_operation_is_keyed(self) -> None:
         # DB1 rows belong to a conversation or session; an unkeyed read would
         # cross that boundary.

--- a/src/modules/db1/eventcontract/operations.json
+++ b/src/modules/db1/eventcontract/operations.json
@@ -3,6 +3,24 @@
   "module": "db1",
   "wire_version": 1,
   "catalog_complete": false,
+  "infrastructure_sources": [
+    "db",
+    "db1_init",
+    "db1_write",
+    "db_schema",
+    "module_adapter"
+  ],
+  "coupled_sources": [
+    {
+      "sources": [
+        "agent_jobs",
+        "delegate_reservation",
+        "delegation_checkpoint",
+        "delegations"
+      ],
+      "reason": "a reservation resolves to a job id, and server_compute.c records that the ledger and the launch were co-located after a ledger across a boundary from the launch left paid-for jobs that nothing could replay"
+    }
+  ],
   "families": [
     {
       "id": 1,
@@ -11,6 +29,9 @@
       "active": true,
       "doc": "the economizer's per-conversation reducer state. Chosen as the first family because it has exactly one production caller, so it proved the boundary without a wide cutover.",
       "covers": "checkpoints (the economizer's reducer state only)",
+      "sources": [
+        "checkpoints"
+      ],
       "retired_sources": []
     },
     {
@@ -20,6 +41,9 @@
       "active": true,
       "doc": "branch ownership for the MCP git flows. Rows say which session owns which branch, so concurrent local sessions do not stomp on each other.",
       "covers": "git_ownership",
+      "sources": [
+        "git_ownership"
+      ],
       "retired_sources": [
         "git_ownership.c"
       ]
@@ -31,6 +55,14 @@
       "active": false,
       "doc": "server and webchat session rows.",
       "covers": "server_sessions, primary_sessions, session_state, session_paths, webchat_claude_sessions, webchat_live",
+      "sources": [
+        "primary_sessions",
+        "server_sessions",
+        "session_paths",
+        "session_state",
+        "webchat_claude_sessions",
+        "webchat_live"
+      ],
       "retired_sources": []
     },
     {
@@ -38,8 +70,15 @@
       "name": "agent_work",
       "event_kind": 11780,
       "active": false,
-      "doc": "queued agent work: jobs, logs and the cron that drives them.",
-      "covers": "agent_jobs, agent_log, coord_jobs, cognify_jobs, db1_cron_jobs, db1_trigger",
+      "doc": "queued agent work: logs, coordination jobs and the cron that drives them.",
+      "covers": "agent_log, coord_jobs, cognify_jobs, db1_cron_jobs, db1_trigger",
+      "sources": [
+        "agent_log",
+        "cognify_jobs",
+        "coord_jobs",
+        "db1_cron_jobs",
+        "db1_trigger"
+      ],
       "retired_sources": []
     },
     {
@@ -47,8 +86,15 @@
       "name": "delegation",
       "event_kind": 11781,
       "active": false,
-      "doc": "delegation spawns, reservations and their checkpoints.",
-      "covers": "delegations, delegate_reservation, delegate_learning, delegation_checkpoint",
+      "doc": "delegation spawns, reservations, checkpoints and the agent_jobs ledger they reserve against. These move as ONE unit: a reservation resolves to a job id, and server_compute.c records that the ledger and the launch were deliberately co-located because a ledger across a boundary from the launch left paid-for jobs that nothing could replay. Splitting them across families would restore exactly that topology one migration at a time.",
+      "covers": "delegations, delegate_reservation, delegate_learning, delegation_checkpoint, agent_jobs",
+      "sources": [
+        "agent_jobs",
+        "delegate_learning",
+        "delegate_reservation",
+        "delegation_checkpoint",
+        "delegations"
+      ],
       "retired_sources": []
     },
     {
@@ -58,6 +104,15 @@
       "active": false,
       "doc": "the workflow engine's stores, plans and traces.",
       "covers": "wfe_store, wfe_binding, execution_plans, execution_trace, pipelines, roadmap_runtime, roundtable_pipeline",
+      "sources": [
+        "execution_plans",
+        "execution_trace",
+        "pipelines",
+        "roadmap_runtime",
+        "roundtable_pipeline",
+        "wfe_binding",
+        "wfe_store"
+      ],
       "retired_sources": []
     },
     {
@@ -67,6 +122,14 @@
       "active": false,
       "doc": "per-conversation context, clarifications and working memory.",
       "covers": "conv_context, clarify, payload_rewrite_state, user_memory, wm, windows",
+      "sources": [
+        "clarify",
+        "conv_context",
+        "payload_rewrite_state",
+        "user_memory",
+        "windows",
+        "wm"
+      ],
       "retired_sources": []
     },
     {
@@ -76,6 +139,12 @@
       "active": false,
       "doc": "secrets and the replay stores behind token consumption.",
       "covers": "secrets, server_identity_jti, server_management_jti, remote_client_grant",
+      "sources": [
+        "remote_client_grant",
+        "secrets",
+        "server_identity_jti",
+        "server_management_jti"
+      ],
       "retired_sources": []
     },
     {
@@ -85,6 +154,16 @@
       "active": false,
       "doc": "token accounting, evaluations and recorded events.",
       "covers": "token_audit, cost_fold, interaction_events, guardrail_events, eval, ensemble, diagnose, diagnostics",
+      "sources": [
+        "cost_fold",
+        "diagnose",
+        "diagnostics",
+        "ensemble",
+        "eval",
+        "guardrail_events",
+        "interaction_events",
+        "token_audit"
+      ],
       "retired_sources": []
     },
     {
@@ -94,6 +173,22 @@
       "active": false,
       "doc": "local runtime resolution, caches and model metadata.",
       "covers": "runtime_state, project_clones, local_operator, env, model_catalog, model_pricing, working_profile_local, tool_local_availability, caches, web_page_cache, fsnap, decisions, maintenance, mcp_osv_cache",
+      "sources": [
+        "caches",
+        "decisions",
+        "env",
+        "fsnap",
+        "local_operator",
+        "maintenance",
+        "mcp_osv_cache",
+        "model_catalog",
+        "model_pricing",
+        "project_clones",
+        "runtime_state",
+        "tool_local_availability",
+        "web_page_cache",
+        "working_profile_local"
+      ],
       "retired_sources": []
     }
   ],


### PR DESCRIPTION
I went to migrate family 5 and found a reason not to, written in the code it would have moved.

`server_compute.c` keeps the delegate reservation beside the launch because **"when the ledger lived across the network from the launch, a crash between the two left a paid-for job that nothing could replay"**. A reservation lookup that fails returns the same `-1` as a miss, and the caller reads that as "no reservation" and launches a second delegate. That is duplicate paid spend, not a degraded cache.

### The catalog made it worse than the code did
`delegate_reservation` sat in family 5 while `agent_jobs` — the ledger it reserves against — sat in family 4. **A family is the unit that activates**, so that grouping was a plan to separate the two, one migration at a time. Both were reserved, so correcting it costs nothing now and would have cost money later.

Rather than leave that as a comment somebody has to find, the constraint is data: `coupled_sources` names the group and the reason, and splitting it across families is refused.

### The catalog is now a complete map
Every DB1 source belongs to exactly one family or to `infrastructure_sources` (connection, schema, write path, the module's own handler — no callers to migrate). All 62 reconcile: **57 domains across ten families, 5 infrastructure, none claimed twice, none invented.**

An unclaimed domain is one nobody is planning to move — which is how `project_clones` went unnoticed until its family claimed it without serving it.

### Verified
The catalog and its 26 tests, the descriptor, process-contract and module-doc gates, the C build, lint (58 checks).

Mutation-checked against the ledger split back apart, a domain left unclaimed, a domain claimed twice, infrastructure overlapping a family, and a claim on a source that does not exist — all five caught, the first by the coupling rule this adds.