### PR TITLE
db1: carry integer arguments across the boundary

### DIFF
--- a/docs/modules/db1.md
+++ b/docs/modules/db1.md
@@ -46,6 +46,13 @@ family owns one event kind and its operations dispatch on an op id inside the
 payload, so DB1 needs one stage per domain rather than one per call -- roughly
 sixty domains against a ceiling of 255.
 
+Request fields carry a type. Half of what is left takes an integer argument --
+a job id, a spawn id, a threshold -- and those travel as decimal text: the
+client prints, the stage parses, and a field that is not exactly a number is
+refused rather than truncated, so "12abc" cannot become 12. A separate numeric
+type on the wire would buy nothing a printf does not, and the frame already
+carries counted bytes.
+
 Both halves of the boundary are generated: the client the daemon calls and the
 stage handler the module serves. `module_adapter.c` still dispatches by stage
 by hand, because family 1 speaks a different wire and has no C caller at all;

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -51,6 +51,7 @@ TRANSACTIONS = ("none", "single")
 IDEMPOTENCY = ("safe", "idempotent", "unsafe")
 WIRE_FORMATS = ("db1-keyed-blob-v1", "db1-fields-v1")
 PAYLOADS = ("none", "state", "text")
+FIELD_TYPES = ("text", "int")
 
 
 class ContractError(ValueError):
@@ -167,6 +168,7 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
     for index, entry in enumerate(raw):
         allowed = {"family", "id", "name", "wire_format", "scope", "transaction",
                    "idempotency", "results", "request", "reply"}
+        entry.pop("_field_types", None)
         if not isinstance(entry, dict) or not set(entry) <= allowed | {"c_name", "c_params"} or \
                 not allowed <= set(entry):
             fail("keys", f"operations[{index}] keys differ from version 1")
@@ -233,9 +235,17 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
             fail("results-order", f"{name} results must follow the declared result order")
 
         request = keys(operation["request"], {"fields"}, f"{name}.request")
-        fields = request["fields"]
-        if not isinstance(fields, list) or not fields:
+        raw_fields = request["fields"]
+        if not isinstance(raw_fields, list) or not raw_fields:
             fail("request-fields", f"{name} request must declare at least one field")
+        fields = []
+        for position, entry_field in enumerate(raw_fields):
+            declared = keys(entry_field, {"name", "type"}, f"{name}.request.fields[{position}]")
+            if declared["type"] not in FIELD_TYPES:
+                fail("field-type",
+                     f"{name} field {declared['name']!r} type must be one of {list(FIELD_TYPES)}")
+            fields.append(str(declared["name"]))
+        operation["_field_types"] = [str(f["type"]) for f in raw_fields]
         # A scoped operation must take its scoping key FIRST, because that key is
         # the boundary: DB1 rows belong to a conversation, session or repository,
         # and reading without one crosses it.
@@ -747,21 +757,36 @@ def client_bytes(catalog: dict[str, object], family: dict[str, object],
         request = operation["request"]
         reply = operation["reply"]
         assert isinstance(request, dict) and isinstance(reply, dict)
-        fields = [str(f) for f in request["fields"]]
+        fields = [str(f["name"]) for f in request["fields"]]
+        types = [str(f["type"]) for f in request["fields"]]
         reads = reply["payload"] != "none"
         names = [str(n) for n in operation["c_params"]]
         inputs, outputs = names[:len(fields)], names[len(fields):]
-        params = [f"const char *{parameter}" for parameter in inputs]
+        params = [(f"int {p}" if t == "int" else f"const char *{p}")
+                  for p, t in zip(inputs, types)]
         if reads:
             params += [f"char *{outputs[0]}", f"size_t {outputs[1]}"]
-        guards = [f"!{parameter}" for parameter in inputs]
+        # An int cannot be null and has no empty case, so only text is guarded.
+        guards = [f"!{p}" for p, t in zip(inputs, types) if t == "text"]
         if reads:
             guards += [f"!{outputs[0]}", f"{outputs[1]} == 0"]
 
         signature = f"int {operation['c_name']}({', '.join(params)})"
-        body = [signature, "{",
-                f"   if ({' || '.join(guards)})", "      return -1;",
-                f"   const char *fields[] = {{{', '.join(inputs)}}};"]
+        body = [signature, "{"]
+        if guards:
+            body += [f"   if ({' || '.join(guards)})", "      return -1;"]
+        # Integers travel as decimal text: the frame carries counted bytes, and a
+        # separate numeric type on the wire would buy nothing a printf does not.
+        carried = []
+        for parameter, kind in zip(inputs, types):
+            if kind == "int":
+                body.append(f"   char {parameter}_text[24];")
+                body.append(f'   snprintf({parameter}_text, sizeof {parameter}_text, "%d", '
+                            f"{parameter});")
+                carried.append(f"{parameter}_text")
+            else:
+                carried.append(parameter)
+        body.append(f"   const char *fields[] = {{{', '.join(carried)}}};")
         op_symbol = f"AIMEE_DB1_OP_{str(operation['name']).upper()}"
         if reads:
             body.append(f"   int status = call_stage({op_symbol}, fields, "
@@ -826,7 +851,7 @@ STAGE_SCAFFOLD = """/* modules/db1/{stem}_stage.c: the {family} stage handler.
 #include "db1_module_api.h"
 #include "{stem}.h"
 
-#include <string.h>
+{int_includes}#include <string.h>
 
 /* Read one counted field, refusing anything that would run past the end or
    carry an embedded NUL: every field here is spliced into a query parameter,
@@ -848,7 +873,7 @@ static int read_counted(const uint8_t *body, uint32_t len, uint32_t *offset, cha
    return 0;
 }}
 
-static uint32_t write_reply(uint8_t *out, uint32_t cap, uint32_t *out_len, uint32_t status,
+{parse_int}static uint32_t write_reply(uint8_t *out, uint32_t cap, uint32_t *out_len, uint32_t status,
                             const char *value)
 {{
    uint32_t value_len = (uint32_t)strlen(value);
@@ -921,6 +946,29 @@ aimee_module_status_t aimee_db1_stage_{stem}(const uint8_t *request_body, uint32
 """
 
 
+PARSE_INT = """/* Parse a field the catalog declared as an integer. Refuses anything that is
+   not exactly a number: a partial parse would turn "12abc" into 12 and act on a
+   value the caller never sent. */
+static int parse_int(const char *text, int *out)
+{{
+   if (!text || !text[0])
+      return 1;
+   char *end = NULL;
+   errno = 0;
+   long value = strtol(text, &end, 10);
+   if (errno != 0 || !end || *end != '\\0' || value < INT_MIN || value > INT_MAX)
+      return 1;
+   *out = (int)value;
+   return 0;
+}}
+"""
+
+INT_INCLUDES = """#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+"""
+
+
 def stage_bytes(family: dict[str, object], operations: list[dict[str, object]]) -> str:
     name = str(family["name"])
     cases = []
@@ -929,19 +977,35 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]]) 
         reply = operation["reply"]
         assert isinstance(request, dict) and isinstance(reply, dict)
         arity = len(request["fields"])
+        types = [str(f["type"]) for f in request["fields"]]
         reads = reply["payload"] != "none"
-        args = [f"field[{i}]" for i in range(arity)]
+        parse, args = [], []
+        for position, kind in enumerate(types):
+            if kind == "int":
+                args.append(f"parsed{position}")
+                parse.append(f"      int parsed{position};\n"
+                             f"      if (parse_int(field[{position}], &parsed{position}) != 0)\n"
+                             f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n")
+            else:
+                args.append(f"field[{position}]")
         if reads:
             args += ["value", "sizeof value"]
-        cases.append(
-            f"   case AIMEE_DB1_OP_{str(operation['name']).upper()}:\n"
-            f"      if (count != {arity}u)\n"
-            f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n"
-            f"      rc = {operation['c_name']}({', '.join(args)});\n"
-            + ("      reads = 1;\n" if reads else "")
-            + "      break;\n")
+        # Braced only when a parsed integer needs scoping: an empty block around
+        # every other case would be noise, and would move files that have not
+        # changed.
+        body = (f"      if (count != {arity}u)\n"
+                f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n"
+                + "".join(parse)
+                + f"      rc = {operation['c_name']}({', '.join(args)});\n"
+                + ("      reads = 1;\n" if reads else "")
+                + "      break;\n")
+        head = f"   case AIMEE_DB1_OP_{str(operation['name']).upper()}:\n"
+        cases.append(head + (f"   {{\n{body}   }}\n" if parse else body))
+    typed = any(f["type"] == "int" for o in operations for f in o["request"]["fields"])
     return STAGE_SCAFFOLD.format(stem=name, family=name.replace("_", " "),
-                                 cases="".join(cases))
+                                 cases="".join(cases),
+                                 parse_int=PARSE_INT if typed else "",
+                                 int_includes=INT_INCLUDES if typed else "")
 
 
 def stages_header_bytes(catalog: dict[str, object]) -> str:

--- a/scripts/tests/test_gen_db1_contract.py
+++ b/scripts/tests/test_gen_db1_contract.py
@@ -286,7 +286,8 @@ class CatalogTests(unittest.TestCase):
                 "wire_format": "db1-fields-v1", "scope": "session",
                 "transaction": "single", "idempotency": "idempotent",
                 "results": ["ok", "invalid", "failed"],
-                "request": {"fields": ["key", "a", "b", "c"]},
+                "request": {"fields": [{"name": n, "type": "text"}
+                                       for n in ("key", "a", "b", "c")]},
                 "reply": {"payload": "none", "max_bytes": 0},
             })
             self.write(root, catalog)
@@ -389,6 +390,87 @@ class CatalogTests(unittest.TestCase):
             self.assertTrue(group["reason"].strip(),
                             "a coupling with no reason cannot be reviewed")
 
+    def integer_catalog(self, root: Path) -> dict:
+        """Activate a reserved family with one text-and-integer operation."""
+        catalog = self.catalog(root)
+        reserved = self.reserved(catalog)
+        reserved["active"] = True
+        catalog["operations"].append({
+            "family": reserved["name"], "id": 1, "name": "probe_forget_if_job",
+            "c_name": "db1_probe_forget_if_job", "c_params": ["probe_id", "job_id"],
+            "wire_format": "db1-fields-v1", "scope": "session", "transaction": "single",
+            "idempotency": "idempotent", "results": ["ok", "invalid", "failed"],
+            "request": {"fields": [{"name": "key", "type": "text"},
+                                   {"name": "job", "type": "int"}]},
+            "reply": {"payload": "none", "max_bytes": 0},
+        })
+        self.write(root, catalog)
+        path = root / contract.PROCESS_CONTRACTS
+        document = json.loads(path.read_text(encoding="utf-8"))
+        for component in document["components"]:
+            if component["id"] == "db1":
+                component["stages"].append({
+                    "id": reserved["id"],
+                    "name": "db1-" + reserved["name"].replace("_", "-"),
+                    "event_kind": reserved["event_kind"]})
+        path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+        return catalog
+
+    def test_an_integer_argument_is_converted_on_both_sides(self) -> None:
+        # Integers travel as decimal text, so the client prints and the stage
+        # parses. Half of that is a silent corruption: a client that sent an int
+        # raw would be read as whatever those bytes spell.
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.integer_catalog(root)
+            contract.run(root, write=True)
+            reserved = next(f for f in catalog["families"]
+                            if any(o["family"] == f["name"] and o.get("c_name")
+                                   for o in catalog["operations"])
+                            and f["name"] != "git_ownership")
+            client = (root / contract.CLIENT_DIR / f"{reserved['name']}.c").read_text()
+            stage = (root / contract.SOURCE_DIR / f"{reserved['name']}_stage.c").read_text()
+
+            self.assertIn("int db1_probe_forget_if_job(const char *probe_id, int job_id)", client)
+            self.assertIn('snprintf(job_id_text, sizeof job_id_text, "%d", job_id);', client)
+            self.assertIn("{probe_id, job_id_text}", client)
+            # An int has no null to guard, so only the text argument is checked.
+            self.assertIn("if (!probe_id)", client)
+            self.assertNotIn("!job_id", client)
+
+            self.assertIn("parse_int(field[1], &parsed1)", stage)
+            self.assertIn("rc = db1_probe_forget_if_job(field[0], parsed1);", stage)
+        finally:
+            tmp.cleanup()
+
+    def test_a_partial_integer_is_refused_rather_than_truncated(self) -> None:
+        # "12abc" must not become 12: the module would act on a value the caller
+        # never sent. The generated parser checks the whole field.
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            self.integer_catalog(root)
+            contract.run(root, write=True)
+            stage = next((root / contract.SOURCE_DIR).glob("*_stage.c"))
+            text = stage.read_text(encoding="utf-8")
+            self.assertIn("*end != '\\0'", text)
+            self.assertIn("errno != 0", text)
+            self.assertIn("value < INT_MIN || value > INT_MAX", text)
+        finally:
+            tmp.cleanup()
+
+    def test_field_types_are_closed(self) -> None:
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.catalog(root)
+            catalog["operations"][0]["request"]["fields"][0]["type"] = "float"
+            self.write(root, catalog)
+            self.assertRule(root, "field-type")
+        finally:
+            tmp.cleanup()
+
     def test_every_operation_is_keyed(self) -> None:
         # DB1 rows belong to a conversation or session; an unkeyed read would
         # cross that boundary.
@@ -396,7 +478,8 @@ class CatalogTests(unittest.TestCase):
         try:
             root = Path(tmp.name)
             catalog = self.catalog(root)
-            catalog["operations"][0]["request"]["fields"] = ["state"]
+            catalog["operations"][0]["request"]["fields"] = [
+                {"name": "state", "type": "text"}]
             self.write(root, catalog)
             self.assertRule(root, "request-key")
         finally:

--- a/src/modules/db1/eventcontract/operations.json
+++ b/src/modules/db1/eventcontract/operations.json
@@ -226,7 +226,10 @@
       ],
       "request": {
         "fields": [
-          "key"
+          {
+            "name": "key",
+            "type": "text"
+          }
         ]
       },
       "reply": {
@@ -250,8 +253,14 @@
       ],
       "request": {
         "fields": [
-          "key",
-          "state"
+          {
+            "name": "key",
+            "type": "text"
+          },
+          {
+            "name": "state",
+            "type": "text"
+          }
         ]
       },
       "reply": {
@@ -280,9 +289,18 @@
       ],
       "request": {
         "fields": [
-          "key",
-          "branch",
-          "session"
+          {
+            "name": "key",
+            "type": "text"
+          },
+          {
+            "name": "branch",
+            "type": "text"
+          },
+          {
+            "name": "session",
+            "type": "text"
+          }
         ]
       },
       "reply": {
@@ -310,8 +328,14 @@
       ],
       "request": {
         "fields": [
-          "key",
-          "branch"
+          {
+            "name": "key",
+            "type": "text"
+          },
+          {
+            "name": "branch",
+            "type": "text"
+          }
         ]
       },
       "reply": {
@@ -342,8 +366,14 @@
       ],
       "request": {
         "fields": [
-          "key",
-          "branch"
+          {
+            "name": "key",
+            "type": "text"
+          },
+          {
+            "name": "branch",
+            "type": "text"
+          }
         ]
       },
       "reply": {
@@ -374,8 +404,14 @@
       ],
       "request": {
         "fields": [
-          "key",
-          "session"
+          {
+            "name": "key",
+            "type": "text"
+          },
+          {
+            "name": "session",
+            "type": "text"
+          }
         ]
       },
       "reply": {
@@ -405,7 +441,10 @@
       ],
       "request": {
         "fields": [
-          "prefix"
+          {
+            "name": "prefix",
+            "type": "text"
+          }
         ]
       },
       "reply": {


### PR DESCRIPTION
I measured what actually blocks the remaining **326 operations** rather than guessing:

| | ops | |
|---|---|---|
| fit the wire as it stands | 72 | 22% |
| **need only an integer argument** | **80** | **24%** |
| take no arguments at all | 11 | 3% |
| need out-parameter or struct work | 163 | 50% |

So the single biggest blocker is an int — and an int needs **no new frame**. It travels as decimal text, which is what the counted-bytes frame already carries.

Request fields now declare a type. The client prints an integer into a local buffer and sends it as a field; the stage parses it back and refuses anything that is not exactly a number, so `"12abc"` cannot arrive as `12` and have the module act on a value nobody sent. An int has no null and no empty case, so only text arguments keep their guard.

### Every shipped file is byte-identical afterwards
That took two corrections to achieve: the integer parser was emitted unconditionally and tripped `-Werror=unused-function` on a family with no integers, and the braces that scope a parsed value were wrapped around every case rather than only the ones needing them. Both would have moved files that had not changed.

### Proved by generation, not assertion
A dry-run family with a text-and-integer operation emits the conversion on both sides and **compiles clean under `-Werror`** with the same flags the tree uses.

### One thing worth naming
This ships capability ahead of its first consumer. It is not speculative — 80 operations are measurably blocked on it today — but no family activates here, so the path is exercised by the generator's tests and a compile check rather than in production.

### Verified
The catalog and its 29 tests, the descriptor and module-doc gates, the C build, the daemon, lint (58 checks), and both DB1 unit suites.