### PR TITLE
db1: survey what the rest of the migration needs from the wire

### DIFF
--- a/docs/proposals/pending/db1-wire-capability-survey.md
+++ b/docs/proposals/pending/db1-wire-capability-survey.md
@@ -1,0 +1,136 @@
+# Proposal: what the rest of DB1 needs from the wire
+
+Two DB1 families now cross the event bus, and both halves of that boundary are
+generated from `src/modules/db1/eventcontract/operations.json`. Adding a family
+is a catalog edit rather than hand-written wire.
+
+Every family since the second has still cost a surprise, and each surprise was
+the same kind: a capability the wire lacked, found only by reading the callers
+of the family being migrated. Integers were found that way. Optional fields were
+found the same way, one family later. Rather than keep discovering them one at a
+time, this surveys all 281 remaining operations at once and says what is
+actually left.
+
+## Thesis
+
+The remaining work is not one problem. It is 54% already reachable, 6% behind a
+small addition, and 39% behind a real design question — and the largest practical
+risk is not in that 39% at all, but in a field-size cap that lets 33 already
+reachable operations pass their tests and fail on production data.
+
+## What was counted, and what was wrong before
+
+The survey set is every function declared in a reserved family's header that has
+at least one caller **linked into a binary**: 281 operations across 98 caller
+files.
+
+Two earlier counts were wrong, both by trusting an extractor that looked right:
+
+- Reading definitions line by line missed every wrapped signature. Declarations
+  are now read from the headers with the line joins collapsed.
+- `CMD_SRCS` was counted as production. It is not linked into anything — it
+  feeds `cmd-srcs-compile-check`, which compiles those files so they cannot rot
+  silently. **57 of its 109 files are named nowhere else in the Makefile.** That
+  moved the surface from 326 operations to 281, and left 45 operations whose
+  only callers are compile-only.
+
+Those 45 are not necessarily dead: the question of whether those commands should
+be linked is separate, and is not answered here. But they should not be migrated
+on the strength of a caller that never runs, which is how `project_clones` came
+to sit inside an active family without being served.
+
+## What the 281 need
+
+| tier | needs | ops | cumulative |
+| --- | --- | --- | --- |
+| T0 | nothing — fits the wire today | 76 | 76 (27%) |
+| T1 | integer arguments | 78 | 154 (54%) |
+| T2 | a counted reply (integer or multi out-parameter) | 18 | 172 (61%) |
+| T3 | structured payloads (struct in/out, arrays, malloc'd returns) | 109 | 281 (100%) |
+
+T1 shipped, which is what took reachability from 27% to 54%. T2 buys 18
+operations, which is a poor return for a frame change. T3 is the real remainder
+and the only part that needs a design rather than an addition.
+
+Per family, ready means T0 + T1:
+
+| family | ready | total | behind T2 | behind T3 |
+| --- | --- | --- | --- | --- |
+| workflow | 60 | 91 | 6 | 25 |
+| delegation | 27 | 37 | 3 | 7 |
+| runtime | 22 | 35 | 2 | 11 |
+| agent_work | 16 | 38 | 3 | 19 |
+| sessions | 8 | 22 | 0 | 14 |
+| conversation | 8 | 20 | 1 | 11 |
+| telemetry | 8 | 33 | 3 | 22 |
+| identity | 5 | 5 | 0 | 0 |
+
+Only `identity` is fully reachable, and it is the one family that should go last
+rather than first: what is reachable in it is `db1_secret_*` and
+`db1_remote_client_*`, whose caller is `server_bearer_auth.c`.
+
+## The two gaps that are not about tiers
+
+### Optional fields — smaller than it looked
+
+The wire refuses an empty field, and the generated client refuses a NULL one. A
+call-site scan of all 154 reachable operations finds **16** that pass `NULL` or
+`""` as a literal. The remaining 138 need nothing.
+
+This is a lower bound: it sees literals, not a variable that happens to hold
+NULL. It is also cheap to close — the domains already collapse the two
+themselves, so a per-field `required` flag in the catalog is enough, with the
+client mapping NULL to empty and the stage enforcing which fields may be blank.
+
+### Field size — the one that will ship green and fail in production
+
+`AIMEE_DB1_FIELD_MAX` is 512 bytes. **33 of the 154 reachable operations carry a
+prompt, a result, an output, or a JSON blob**, and DB1's own columns run to 16
+KB. A 512-byte cap truncates none of them: the client refuses the call and
+returns the same -1 it returns for a broken store.
+
+That failure is data-dependent, which is what makes it worse than the other
+gaps. Short strings pass every test; the first long prompt fails, and fails
+looking like something else.
+
+The cap is self-imposed. `AIMEE_MODULE_MESSAGE_MAX_BODY` is 16 MB, so the bus
+has room. The obstacle is that the generated wire uses stack arrays on both
+sides — `char field[AIMEE_DB1_FIELDS_MAX][AIMEE_DB1_FIELD_MAX]` in the stage,
+and a request buffer of the same shape in the client. Raising the constant to
+anything useful puts hundreds of kilobytes on the stack. **Large payloads
+therefore require the generated code to allocate, which is a change to the
+shape of the generated wire rather than to a number in it.**
+
+## Recommended order
+
+1. **Field sizing first.** It blocks 33 already-reachable operations and is the
+   only gap whose failure mode is invisible until production. It is also the one
+   that changes the generated code's shape, so doing it before more families
+   migrate means fewer files regenerate later.
+2. **Optional fields.** 16 operations, a per-field flag, no frame change.
+3. **Migrate T0/T1 families**, largest ready-count first: `workflow` (60),
+   `delegation` (27, but see the ledger coupling below), `runtime` (22).
+4. **T2 only when a family actually needs it** — 18 operations do not justify a
+   frame change on their own.
+5. **T3 last**, designed against the real shapes: 109 operations spread across
+   struct arguments, struct and array out-parameters, and malloc'd returns.
+
+Two constraints sit outside the wire and are unchanged by any of this:
+
+- `delegation` is coupled to `agent_jobs` by `coupled_sources`, because
+  `server_compute.c` keeps the reservation beside the launch. A reservation
+  lookup that fails reads as "no reservation" and launches a second paid
+  delegate. That family needs an idempotency story before it crosses, not a
+  wire format.
+- `identity` puts DB1 on the auth path.
+
+## How to reproduce
+
+`scripts/survey_db1_wire.py` produces every number above. It is a measurement,
+not a gate: it reads the headers, the Makefile and the call sites, so its
+answers move when any of those move. Re-run it before trusting these figures
+again, rather than citing this document.
+
+The two counting mistakes described earlier are designed out of it — signatures
+are read from headers with line joins collapsed, and `CMD_SRCS` is excluded —
+because both were made while arriving at these numbers.

--- a/scripts/survey_db1_wire.py
+++ b/scripts/survey_db1_wire.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Measure what the remaining DB1 operations need from the module wire.
+
+Reports, for every DB1 function that a linked binary still calls: the capability
+tier its signature needs, whether its callers pass NULL or an empty string, and
+whether it carries a field the current size cap would refuse.
+
+This is a measurement, not a gate. It reads the headers, the Makefile and the
+call sites, so its numbers move when any of those move -- which is the point.
+docs/proposals/pending/db1-wire-capability-survey.md records what it said on the
+day it was written; re-run this before trusting those numbers again.
+
+Two counting mistakes are deliberately designed out, because both were made:
+
+  * Signatures are read from the HEADERS with line joins collapsed. Reading
+    definitions line by line silently drops every wrapped signature.
+  * CMD_SRCS is excluded. Those files are compiled by cmd-srcs-compile-check so
+    they cannot rot, but they are linked into nothing, and counting them as
+    production inflates the surface by about a fifth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = Path("src/modules/db1/eventcontract/operations.json")
+SOURCE_DIR = Path("src/modules/db1")
+MAKEFILE = Path("src/Makefile")
+
+DECL = re.compile(
+    r"\b(int|void|int64_t|double|size_t|char\s*\*|const\s+char\s*\*)\s+"
+    r"([a-z][a-z0-9_]{3,})\s*\(([^;{]*)\)\s*;", re.S)
+CALL = re.compile(r"\b([a-z][a-z0-9_]{2,})\s*\(")
+
+TEXT = re.compile(r"const char \s*\*\s*\w+$")
+SCALAR = re.compile(r"(int|int64_t|long|unsigned int|unsigned|time_t|double) \w+$")
+OUT_TEXT = re.compile(r"char \s*\*\s*\w+$")
+CAP = re.compile(r"size_t \w+$")
+OUT_NUM = re.compile(r"(int|int64_t|double|size_t) \s*\*\s*\w+$")
+STRUCT_IN = re.compile(r"const [a-z_0-9]+_t \s*\*\s*\w+$")
+STRUCT_OUT = re.compile(r"[a-z_0-9]+_t \s*\*\s*\w+$")
+ARRAY_LEN = re.compile(r"(int|size_t) (max|n|count|cap|limit)\w*$")
+# Names that carry a prompt, a result or a document rather than an identifier.
+LARGE = re.compile(r"(json|metadata|content|prompt|body|payload|text|summary|blob"
+                   r"|result|output|detail|notes?|message|reason|sql|patch|diff)", re.I)
+
+TIER_OF = {"text": 0, "out_text": 0, "int": 1, "out_num": 2}
+TIER_NAME = {
+    0: "T0  fits the wire today",
+    1: "T1  + integer arguments",
+    2: "T2  + counted reply (integer / multi out-parameter)",
+    3: "T3  + structured payloads (struct, array, malloc'd out)",
+}
+
+
+def compile_only_sources(root: Path) -> set[str]:
+    """CMD_SRCS entries that are named nowhere else, so nothing links them."""
+    makefile = (root / MAKEFILE).read_text(encoding="utf-8")
+    block = re.search(r"^CMD_SRCS\s*[:+]?=(.*?)(?=^\w)", makefile, re.M | re.S)
+    if not block:
+        return set()
+    declared = set(re.findall(r"([A-Za-z0-9_/.\-]+)\.c", block.group(1)))
+    rest = re.sub(r"^CMD_SRCS\s*[:+]?=.*?(?=^\w)", "", makefile, flags=re.M | re.S)
+    # A stem counts as linked if it appears anywhere else as a .c OR a .o: some
+    # command objects are linked only through an explicit object list.
+    elsewhere = {Path(x).name for x in re.findall(r"([A-Za-z0-9_/.\-]+)\.[co]\b", rest)}
+    return {s for s in declared if Path(s).name not in elsewhere}
+
+
+def reserved_sources(root: Path) -> dict[str, str]:
+    catalog = json.loads((root / CATALOG).read_text(encoding="utf-8"))
+    return {source: family["name"]
+            for family in catalog["families"] if not family["active"]
+            for source in family["sources"]}
+
+
+def declarations(root: Path, families: dict[str, str]) -> dict[str, dict]:
+    found: dict[str, dict] = {}
+    for header in sorted((root / SOURCE_DIR).glob("*.h")):
+        if header.stem not in families:
+            continue
+        text = re.sub(r"/\*.*?\*/", "", header.read_text(errors="ignore"), flags=re.S)
+        for match in DECL.finditer(text):
+            found[match.group(2)] = {
+                "family": families[header.stem],
+                "source": header.stem,
+                "returns": " ".join(match.group(1).split()),
+                "params": " ".join(match.group(3).split()),
+            }
+    return found
+
+
+def classify(params: str) -> list[str]:
+    raw = params.strip()
+    parts = [p.strip() for p in raw.split(",")] if raw not in ("void", "") else []
+    tags, index = [], 0
+    while index < len(parts):
+        current = parts[index]
+        following = parts[index + 1] if index + 1 < len(parts) else ""
+        if following and OUT_TEXT.search(current) and CAP.search(following):
+            tags.append("out_text")
+            index += 2
+            continue
+        if following and STRUCT_OUT.search(current) and ARRAY_LEN.search(following):
+            tags.append("out_array")
+            index += 2
+            continue
+        if TEXT.search(current):
+            tags.append("text")
+        elif SCALAR.search(current):
+            tags.append("int")
+        elif STRUCT_IN.search(current):
+            tags.append("struct_in")
+        elif OUT_NUM.search(current):
+            tags.append("out_num")
+        elif STRUCT_OUT.search(current) or OUT_TEXT.search(current):
+            tags.append("struct_out")
+        else:
+            tags.append("other")
+        index += 1
+    return tags
+
+
+def split_call(text: str, start: int) -> list[str] | None:
+    """Split one call's arguments, respecting nesting, strings and escapes."""
+    index = text.index("(", start)
+    depth, current, found, in_string, escaped = 0, "", [], False, False
+    while index < len(text):
+        char = text[index]
+        if in_string:
+            current += char
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+            current += char
+        elif char == "(":
+            depth += 1
+            if depth > 1:
+                current += char
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                found.append(current.strip())
+                return found
+            current += char
+        elif char == "," and depth == 1:
+            found.append(current.strip())
+            current = ""
+        else:
+            current += char
+        index += 1
+    return None
+
+
+def survey(root: Path) -> dict:
+    families = reserved_sources(root)
+    declared = declarations(root, families)
+    skip = compile_only_sources(root)
+
+    callers: dict[str, set[str]] = collections.defaultdict(set)
+    for path in sorted((root / "src").rglob("*.c")):
+        relative = path.relative_to(root / "src").as_posix()
+        if relative.startswith("modules/db1/") or "/tests/" in f"/{relative}":
+            continue
+        if relative[:-2] in skip:
+            continue
+        text = path.read_text(errors="ignore")
+        for name in set(CALL.findall(text)):
+            if name in declared:
+                callers[name].add(relative)
+
+    operations = {}
+    for name, sites in callers.items():
+        entry = dict(declared[name], callers=sorted(sites))
+        entry["tags"] = classify(entry["params"])
+        tier = 0
+        for tag in entry["tags"]:
+            tier = max(tier, TIER_OF.get(tag, 3))
+        if entry["returns"] in ("char *", "const char *"):
+            tier = 3
+        entry["tier"] = tier
+        names = [p.split()[-1].lstrip("*") for p in entry["params"].split(",")]
+        entry["large_fields"] = sorted({
+            field for tag, field in zip(entry["tags"], names)
+            if tag == "text" and LARGE.search(field)})
+        operations[name] = entry
+
+    # Nullability, for the operations that could migrate today.
+    for name, entry in operations.items():
+        if entry["tier"] > 1:
+            entry["nullable"] = []
+            continue
+        positions = [i for i, tag in enumerate(entry["tags"]) if tag == "text"]
+        seen = set()
+        for relative in entry["callers"]:
+            text = (root / "src" / relative).read_text(errors="ignore")
+            for match in re.finditer(r"\b" + re.escape(name) + r"\s*\(", text):
+                arguments = split_call(text, match.start())
+                if not arguments or len(arguments) != len(entry["tags"]):
+                    continue
+                for position in positions:
+                    value = arguments[position].strip()
+                    if value in ("NULL", '""'):
+                        seen.add((relative, position, value))
+        entry["nullable"] = sorted(seen)
+    return operations
+
+
+def report(operations: dict) -> None:
+    total = len(operations)
+    tiers = collections.Counter(o["tier"] for o in operations.values())
+    print(f"DB1 operations with a linked caller: {total}")
+    print(f"caller files involved              : "
+          f"{len({c for o in operations.values() for c in o['callers']})}\n")
+    running = 0
+    for tier in sorted(tiers):
+        running += tiers[tier]
+        print(f"  {TIER_NAME[tier]:52} {tiers[tier]:>4}   cumulative "
+              f"{running:>3} ({100 * running // total}%)")
+
+    ready = {n: o for n, o in operations.items() if o["tier"] <= 1}
+    nullable = {n: o for n, o in ready.items() if o["nullable"]}
+    large = {n: o for n, o in ready.items() if o["large_fields"]}
+    print(f"\n  reachable now (T0+T1)                : {len(ready)}")
+    print(f"    of those passing NULL or \"\"        : {len(nullable)}"
+          f"   (literals only -- a lower bound)")
+    print(f"    of those carrying a large field    : {len(large)}"
+          f"   (against AIMEE_DB1_FIELD_MAX)")
+
+    print("\n  by family (ready / total):")
+    families = collections.defaultdict(collections.Counter)
+    for entry in operations.values():
+        families[entry["family"]][entry["tier"]] += 1
+    for family in sorted(families, key=lambda f: -sum(families[f].values())):
+        counts = families[family]
+        print(f"    {family:14} {counts[0] + counts[1]:>3} / {sum(counts.values()):<3}"
+              f"   behind T2 {counts[2]:>2}   behind T3 {counts[3]:>2}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--json", action="store_true", help="emit the raw survey")
+    args = parser.parse_args(argv)
+    operations = survey(args.root.resolve())
+    if args.json:
+        json.dump(operations, sys.stdout, indent=1, sort_keys=True)
+        return 0
+    report(operations)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Every family migrated since the second has cost a surprise, and each was the same kind: a capability the wire lacked, found only by reading the callers of the family being migrated. Integers were found that way. Optional fields were found the same way, one family later.

This measures **all 281 remaining operations at once** instead of discovering them one family at a time.

## The remaining work is three different problems

| tier | needs | ops | cumulative |
| --- | --- | --- | --- |
| T0 | nothing — fits the wire today | 76 | 27% |
| T1 | integer arguments (#2741) | 78 | **54%** |
| T2 | a counted reply | 18 | 61% |
| T3 | structured payloads | 109 | 100% |

T2 buys 18 operations — a poor return for a frame change. T3 is the only part needing a design rather than an addition.

## The largest practical risk is in none of those

`AIMEE_DB1_FIELD_MAX` is **512 bytes**, and **33 of the 154 already-reachable operations** carry a prompt, a result or a JSON blob — against DB1 columns that run to 16 KB.

That failure is data-dependent: short strings pass every test, and the first long prompt fails returning the same `-1` as a broken store. The cap is self-imposed (the bus allows 16 MB), but the generated wire holds fields in **stack arrays**, so raising it changes the shape of the generated code rather than a number in it.

Optional fields turned out smaller than the family that surfaced them suggested: **16 of 154**, and the domains already collapse NULL to empty themselves.

## Two earlier counts were wrong

Both are designed out of the script rather than merely corrected:

- Reading definitions line by line missed every **wrapped signature**.
- `CMD_SRCS` was counted as production when it is linked into nothing — **57 of its 109 files are named nowhere else**. That moved the surface from 326 to 281 and left 45 operations whose only callers never run.

## Reproducible

`scripts/survey_db1_wire.py` is committed with the write-up, because a survey that cannot be re-run is a fixture. **Every number in the document reproduces from it.**

Checked: `check-proposal-links` and `check_pending_audit_manifest` pass. `check-proposal-reconcile` could not run locally (missing PyYAML), so CI is its first real run.