### PR TITLE
db1: stop capping what a request may carry

### DIFF
--- a/docs/proposals/pending/db1-wire-capability-survey.md
+++ b/docs/proposals/pending/db1-wire-capability-survey.md
@@ -103,7 +103,11 @@ shape of the generated wire rather than to a number in it.**
 
 ## Recommended order
 
-1. **Field sizing first.** It blocks 33 already-reachable operations and is the
+1. ~~**Field sizing first.**~~ Done: requests are no longer capped. The frame is
+   sized from the arguments and the decoder allocates from the frame, so a
+   prompt or a document crosses whole, as it always has in-process.
+   `AIMEE_DB1_VALUE_MAX` now bounds only the reply a stage builds.
+1. **Superseded — kept for the reasoning.** It blocks 33 already-reachable operations and is the
    only gap whose failure mode is invisible until production. It is also the one
    that changes the generated code's shape, so doing it before more families
    migrate means fewer files regenerate later.

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -568,13 +568,15 @@ def header_bytes(catalog: dict[str, object]) -> str:
     if state_max:
         limits.append(("AIMEE_DB1_STATE_MAX", f"{state_max}u"))
     if field_max:
-        limits.append(("AIMEE_DB1_FIELD_MAX", f"{field_max}u"))
+        limits.append(("AIMEE_DB1_VALUE_MAX", f"{field_max}u"))
     if fields_max:
         limits.append(("AIMEE_DB1_FIELDS_MAX", f"{fields_max}u"))
     if limits:
-        out.append("\n/* Wire bounds, carried from the catalog's declared reply sizes and\n"
-                   "   request arities. Stated so the module refuses an over-long value rather\n"
-                   "   than truncating one into something that looks valid. */\n"
+        out.append("\n/* Wire bounds, carried from the catalog. VALUE_MAX is the widest\n"
+                   "   reply a stage may build; FIELDS_MAX is the widest request arity, and\n"
+                   "   sizes the decoder's pointer array. Requests are NOT capped: they carry\n"
+                   "   prompts and documents, an in-process caller passes those whole, and the\n"
+                   "   frame already bounds what arrived. */\n"
                    + "\n".join(define_block(limits)) + "\n")
 
     out.append("\n" + "\n".join(define_block(
@@ -608,10 +610,12 @@ CLIENT_SCAFFOLD = """/* db1_client/{stem}.c: the {stem} family, reached over the
 
 #include <aimee/audit/obs_bus.h>
 #include <aimee/core/event_bus/module_client.h>
+#include <aimee/core/event_bus/module_protocol.h>
 #include "log.h"
 #include "module_json_call.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define DB1_{upper}_CALL_TIMEOUT_MS 2000
@@ -630,9 +634,14 @@ static void warn_unreachable(int reason)
             reason);
 }}
 
-/* op(u32) | field_count(u32) | (len(u32) | bytes) * count, per db1_module_api.h. */
-static int encode(uint8_t *out, size_t out_sz, uint32_t op, const char *const *fields,
-                  uint32_t count, uint32_t *len_out)
+/* Size the frame from the arguments themselves.
+
+   These carry prompts, results and JSON documents, not just identifiers, and
+   in-process callers have always passed them whole. A fixed cap here would
+   refuse exactly those calls and return the same -1 as a broken store -- fine
+   in a test with short strings, wrong the first time a real prompt arrives. The
+   bus bounds the message instead. */
+static int frame_size(const char *const *fields, uint32_t count, size_t *need_out)
 {{
    if (count == 0u || count > AIMEE_DB1_FIELDS_MAX)
       return -1;
@@ -642,15 +651,17 @@ static int encode(uint8_t *out, size_t out_sz, uint32_t op, const char *const *f
       if (!fields[i] || !fields[i][0])
          return -1;
       size_t n = strlen(fields[i]);
-      /* Refuse here rather than let the module refuse: an over-long field is a
-         caller bug, and the round trip would only rename it. */
-      if (n >= AIMEE_DB1_FIELD_MAX)
+      if (n > AIMEE_MODULE_MESSAGE_MAX_BODY - need - 4u)
          return -1;
       need += 4u + n;
    }}
-   if (need > out_sz)
-      return -1;
+   *need_out = need;
+   return 0;
+}}
 
+/* op(u32) | field_count(u32) | (len(u32) | bytes) * count, per db1_module_api.h. */
+static void encode(uint8_t *out, uint32_t op, const char *const *fields, uint32_t count)
+{{
    uint32_t at = 0;
    aimee_db1_put_u32(out + at, op);
    at += 4u;
@@ -664,8 +675,6 @@ static int encode(uint8_t *out, size_t out_sz, uint32_t op, const char *const *f
       memcpy(out + at, fields[i], n);
       at += n;
    }}
-   *len_out = at;
-   return 0;
 }}
 
 /* Returns the module's status, or -1 when the call never produced one. */
@@ -682,38 +691,56 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
       return -1;
    }}
 
-   uint8_t request[8u + AIMEE_DB1_FIELDS_MAX * (4u + AIMEE_DB1_FIELD_MAX)];
-   uint32_t request_len = 0;
-   if (encode(request, sizeof request, op, fields, count, &request_len) != 0)
+   size_t request_len = 0;
+   if (frame_size(fields, count, &request_len) != 0)
       return -1;
+   /* The reply is bounded by the caller's own buffer: it asked for at most
+      value_len bytes, so there is no reason to hold more than that. */
+   size_t response_cap = 8u + (value_out ? value_len : 0u);
+   uint8_t *request = malloc(request_len);
+   uint8_t *response = malloc(response_cap);
+   if (!request || !response)
+   {{
+      free(request);
+      free(response);
+      return -1;
+   }}
+   encode(request, op, fields, count);
 
-   uint8_t response[8u + AIMEE_DB1_FIELD_MAX];
    uint32_t response_len = 0;
    uint64_t deadline = aimee_module_call_deadline_ns(DB1_{upper}_CALL_TIMEOUT_MS);
    aimee_module_call_result_t rc =
        obs_bus_module_call(AIMEE_DB1_EVENT_{upper}, AIMEE_DB1_STAGE_{upper}, 0, deadline,
-                           request, request_len, response, (uint32_t)sizeof response,
+                           request, (uint32_t)request_len, response, (uint32_t)response_cap,
                            &response_len, NULL, NULL);
-   if (rc != AIMEE_MODULE_CALL_OK || response_len < 8u)
-   {{
-      warn_unreachable((int)rc);
-      return -1;
-   }}
+   free(request);
 
-   uint32_t status = aimee_db1_get_u32(response);
-   uint32_t payload_len = aimee_db1_get_u32(response + 4u);
-   /* A reply whose declared length disagrees with what arrived is not a reply
-      to read part of. */
-   if (payload_len != response_len - 8u)
-      return -1;
-   if (value_out && value_len)
+   int result = -1;
+   if (rc != AIMEE_MODULE_CALL_OK || response_len < 8u)
+      warn_unreachable((int)rc);
+   else
    {{
-      if (payload_len >= value_len)
-         return -1;
-      memcpy(value_out, response + 8u, payload_len);
-      value_out[payload_len] = '\\0';
+      uint32_t status = aimee_db1_get_u32(response);
+      uint32_t payload_len = aimee_db1_get_u32(response + 4u);
+      /* A reply whose declared length disagrees with what arrived is not a
+         reply to read part of. */
+      if (payload_len == response_len - 8u)
+      {{
+         result = (int)status;
+         if (value_out && value_len)
+         {{
+            if (payload_len >= value_len)
+               result = -1;
+            else
+            {{
+               memcpy(value_out, response + 8u, payload_len);
+               value_out[payload_len] = '\\0';
+            }}
+         }}
+      }}
    }}
-   return (int)status;
+   free(response);
+   return result;
 }}
 
 /* A write answers 0 or -1; the store either took it or it did not. */
@@ -851,24 +878,30 @@ STAGE_SCAFFOLD = """/* modules/db1/{stem}_stage.c: the {family} stage handler.
 #include "db1_module_api.h"
 #include "{stem}.h"
 
-{int_includes}#include <string.h>
+{int_includes}#include <stdlib.h>
+#include <string.h>
 
-/* Read one counted field, refusing anything that would run past the end or
-   carry an embedded NUL: every field here is spliced into a query parameter,
-   and a NUL would silently shorten it into a different row. */
-static int read_counted(const uint8_t *body, uint32_t len, uint32_t *offset, char *out,
-                        size_t out_sz)
+/* Copy one counted field out of the frame, NUL-terminated.
+
+   The frame bounds the field, not a fixed cap: these carry prompts, results and
+   JSON documents, and an in-process caller has always passed them whole. An
+   embedded NUL is still refused -- every field is spliced into a query
+   parameter, and a NUL would silently shorten it into a different row. */
+static int read_counted(const uint8_t *body, uint32_t len, uint32_t *offset, char **cursor,
+                        const char **out)
 {{
    if (*offset + 4u > len)
       return 1;
    uint32_t n = aimee_db1_get_u32(body + *offset);
    *offset += 4u;
-   if (n > len || *offset + n > len || n == 0u || n >= out_sz)
+   if (n > len || *offset + n > len || n == 0u)
       return 1;
    if (memchr(body + *offset, 0, n) != NULL)
       return 1;
-   memcpy(out, body + *offset, n);
-   out[n] = '\\0';
+   memcpy(*cursor, body + *offset, n);
+   (*cursor)[n] = '\\0';
+   *out = *cursor;
+   *cursor += n + 1u;
    *offset += n;
    return 0;
 }}
@@ -900,17 +933,30 @@ aimee_module_status_t aimee_db1_stage_{stem}(const uint8_t *request_body, uint32
    if (count == 0u || count > AIMEE_DB1_FIELDS_MAX)
       return AIMEE_MODULE_STATUS_INVALID_REQUEST;
 
-   char field[AIMEE_DB1_FIELDS_MAX][AIMEE_DB1_FIELD_MAX];
+   /* One allocation for every field, sized by the frame that carried them: the
+      fields plus a NUL each cannot exceed this. */
+   const char *field[AIMEE_DB1_FIELDS_MAX];
+   char *scratch = malloc((size_t)request_len + AIMEE_DB1_FIELDS_MAX);
+   if (!scratch)
+      return AIMEE_MODULE_STATUS_INTERNAL;
+   char *cursor = scratch;
+   aimee_module_status_t decoded = AIMEE_MODULE_STATUS_OK;
+
    uint32_t offset = 8u;
    for (uint32_t i = 0; i < count; ++i)
-      if (read_counted(request_body, request_len, &offset, field[i], sizeof field[i]) != 0)
-         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      if (read_counted(request_body, request_len, &offset, &cursor, &field[i]) != 0)
+         decoded = AIMEE_MODULE_STATUS_INVALID_REQUEST;
    /* Trailing bytes mean the caller and the module disagree about the op's
       arity, which is a contract mismatch rather than something to tolerate. */
    if (offset != request_len)
-      return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      decoded = AIMEE_MODULE_STATUS_INVALID_REQUEST;
+   if (decoded != AIMEE_MODULE_STATUS_OK)
+   {{
+      free(scratch);
+      return decoded;
+   }}
 
-   char value[AIMEE_DB1_FIELD_MAX];
+   char value[AIMEE_DB1_VALUE_MAX];
    value[0] = '\\0';
    int rc = -1;
    int reads = 0;
@@ -918,8 +964,10 @@ aimee_module_status_t aimee_db1_stage_{stem}(const uint8_t *request_body, uint32
    switch (op)
    {{
 {cases}   default:
+      free(scratch);
       return AIMEE_MODULE_STATUS_INVALID_REQUEST;
    }}
+   free(scratch);
 
    /* The two conventions must not be flattened. A read returns FOUND(1),
       not-found(0) or error(-1); a write returns 0 or -1. Mapping a read's -1
@@ -965,7 +1013,6 @@ static int parse_int(const char *text, int *out)
 
 INT_INCLUDES = """#include <errno.h>
 #include <limits.h>
-#include <stdlib.h>
 """
 
 
@@ -985,7 +1032,10 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]]) 
                 args.append(f"parsed{position}")
                 parse.append(f"      int parsed{position};\n"
                              f"      if (parse_int(field[{position}], &parsed{position}) != 0)\n"
-                             f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n")
+                             f"      {{\n"
+                             f"         free(scratch);\n"
+                             f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n"
+                             f"      }}\n")
             else:
                 args.append(f"field[{position}]")
         if reads:
@@ -994,7 +1044,10 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]]) 
         # every other case would be noise, and would move files that have not
         # changed.
         body = (f"      if (count != {arity}u)\n"
+                f"      {{\n"
+                f"         free(scratch);\n"
                 f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n"
+                f"      }}\n"
                 + "".join(parse)
                 + f"      rc = {operation['c_name']}({', '.join(args)});\n"
                 + ("      reads = 1;\n" if reads else "")

--- a/src/db1_client/git_ownership.c
+++ b/src/db1_client/git_ownership.c
@@ -27,10 +27,12 @@
 
 #include <aimee/audit/obs_bus.h>
 #include <aimee/core/event_bus/module_client.h>
+#include <aimee/core/event_bus/module_protocol.h>
 #include "log.h"
 #include "module_json_call.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define DB1_GIT_OWNERSHIP_CALL_TIMEOUT_MS 2000
@@ -49,9 +51,14 @@ static void warn_unreachable(int reason)
             reason);
 }
 
-/* op(u32) | field_count(u32) | (len(u32) | bytes) * count, per db1_module_api.h. */
-static int encode(uint8_t *out, size_t out_sz, uint32_t op, const char *const *fields,
-                  uint32_t count, uint32_t *len_out)
+/* Size the frame from the arguments themselves.
+
+   These carry prompts, results and JSON documents, not just identifiers, and
+   in-process callers have always passed them whole. A fixed cap here would
+   refuse exactly those calls and return the same -1 as a broken store -- fine
+   in a test with short strings, wrong the first time a real prompt arrives. The
+   bus bounds the message instead. */
+static int frame_size(const char *const *fields, uint32_t count, size_t *need_out)
 {
    if (count == 0u || count > AIMEE_DB1_FIELDS_MAX)
       return -1;
@@ -61,15 +68,17 @@ static int encode(uint8_t *out, size_t out_sz, uint32_t op, const char *const *f
       if (!fields[i] || !fields[i][0])
          return -1;
       size_t n = strlen(fields[i]);
-      /* Refuse here rather than let the module refuse: an over-long field is a
-         caller bug, and the round trip would only rename it. */
-      if (n >= AIMEE_DB1_FIELD_MAX)
+      if (n > AIMEE_MODULE_MESSAGE_MAX_BODY - need - 4u)
          return -1;
       need += 4u + n;
    }
-   if (need > out_sz)
-      return -1;
+   *need_out = need;
+   return 0;
+}
 
+/* op(u32) | field_count(u32) | (len(u32) | bytes) * count, per db1_module_api.h. */
+static void encode(uint8_t *out, uint32_t op, const char *const *fields, uint32_t count)
+{
    uint32_t at = 0;
    aimee_db1_put_u32(out + at, op);
    at += 4u;
@@ -83,8 +92,6 @@ static int encode(uint8_t *out, size_t out_sz, uint32_t op, const char *const *f
       memcpy(out + at, fields[i], n);
       at += n;
    }
-   *len_out = at;
-   return 0;
 }
 
 /* Returns the module's status, or -1 when the call never produced one. */
@@ -101,38 +108,56 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
       return -1;
    }
 
-   uint8_t request[8u + AIMEE_DB1_FIELDS_MAX * (4u + AIMEE_DB1_FIELD_MAX)];
-   uint32_t request_len = 0;
-   if (encode(request, sizeof request, op, fields, count, &request_len) != 0)
+   size_t request_len = 0;
+   if (frame_size(fields, count, &request_len) != 0)
       return -1;
+   /* The reply is bounded by the caller's own buffer: it asked for at most
+      value_len bytes, so there is no reason to hold more than that. */
+   size_t response_cap = 8u + (value_out ? value_len : 0u);
+   uint8_t *request = malloc(request_len);
+   uint8_t *response = malloc(response_cap);
+   if (!request || !response)
+   {
+      free(request);
+      free(response);
+      return -1;
+   }
+   encode(request, op, fields, count);
 
-   uint8_t response[8u + AIMEE_DB1_FIELD_MAX];
    uint32_t response_len = 0;
    uint64_t deadline = aimee_module_call_deadline_ns(DB1_GIT_OWNERSHIP_CALL_TIMEOUT_MS);
    aimee_module_call_result_t rc =
        obs_bus_module_call(AIMEE_DB1_EVENT_GIT_OWNERSHIP, AIMEE_DB1_STAGE_GIT_OWNERSHIP, 0, deadline,
-                           request, request_len, response, (uint32_t)sizeof response,
+                           request, (uint32_t)request_len, response, (uint32_t)response_cap,
                            &response_len, NULL, NULL);
-   if (rc != AIMEE_MODULE_CALL_OK || response_len < 8u)
-   {
-      warn_unreachable((int)rc);
-      return -1;
-   }
+   free(request);
 
-   uint32_t status = aimee_db1_get_u32(response);
-   uint32_t payload_len = aimee_db1_get_u32(response + 4u);
-   /* A reply whose declared length disagrees with what arrived is not a reply
-      to read part of. */
-   if (payload_len != response_len - 8u)
-      return -1;
-   if (value_out && value_len)
+   int result = -1;
+   if (rc != AIMEE_MODULE_CALL_OK || response_len < 8u)
+      warn_unreachable((int)rc);
+   else
    {
-      if (payload_len >= value_len)
-         return -1;
-      memcpy(value_out, response + 8u, payload_len);
-      value_out[payload_len] = '\0';
+      uint32_t status = aimee_db1_get_u32(response);
+      uint32_t payload_len = aimee_db1_get_u32(response + 4u);
+      /* A reply whose declared length disagrees with what arrived is not a
+         reply to read part of. */
+      if (payload_len == response_len - 8u)
+      {
+         result = (int)status;
+         if (value_out && value_len)
+         {
+            if (payload_len >= value_len)
+               result = -1;
+            else
+            {
+               memcpy(value_out, response + 8u, payload_len);
+               value_out[payload_len] = '\0';
+            }
+         }
+      }
    }
-   return (int)status;
+   free(response);
+   return result;
 }
 
 /* A write answers 0 or -1; the store either took it or it did not. */

--- a/src/modules/db1/db1_module_api.h
+++ b/src/modules/db1/db1_module_api.h
@@ -51,11 +51,13 @@
 #define AIMEE_DB1_OP_OWNERSHIP_BRANCH_FOR_SESSION 4u
 #define AIMEE_DB1_OP_OWNERSHIP_SESSION_BY_PREFIX  5u
 
-/* Wire bounds, carried from the catalog's declared reply sizes and
-   request arities. Stated so the module refuses an over-long value rather
-   than truncating one into something that looks valid. */
+/* Wire bounds, carried from the catalog. VALUE_MAX is the widest
+   reply a stage may build; FIELDS_MAX is the widest request arity, and
+   sizes the decoder's pointer array. Requests are NOT capped: they carry
+   prompts and documents, an in-process caller passes those whole, and the
+   frame already bounds what arrived. */
 #define AIMEE_DB1_STATE_MAX  6144u
-#define AIMEE_DB1_FIELD_MAX  512u
+#define AIMEE_DB1_VALUE_MAX  512u
 #define AIMEE_DB1_FIELDS_MAX 3u
 
 #define AIMEE_DB1_STATUS_OK       0u

--- a/src/modules/db1/git_ownership_stage.c
+++ b/src/modules/db1/git_ownership_stage.c
@@ -15,24 +15,30 @@
 #include "db1_module_api.h"
 #include "git_ownership.h"
 
+#include <stdlib.h>
 #include <string.h>
 
-/* Read one counted field, refusing anything that would run past the end or
-   carry an embedded NUL: every field here is spliced into a query parameter,
-   and a NUL would silently shorten it into a different row. */
-static int read_counted(const uint8_t *body, uint32_t len, uint32_t *offset, char *out,
-                        size_t out_sz)
+/* Copy one counted field out of the frame, NUL-terminated.
+
+   The frame bounds the field, not a fixed cap: these carry prompts, results and
+   JSON documents, and an in-process caller has always passed them whole. An
+   embedded NUL is still refused -- every field is spliced into a query
+   parameter, and a NUL would silently shorten it into a different row. */
+static int read_counted(const uint8_t *body, uint32_t len, uint32_t *offset, char **cursor,
+                        const char **out)
 {
    if (*offset + 4u > len)
       return 1;
    uint32_t n = aimee_db1_get_u32(body + *offset);
    *offset += 4u;
-   if (n > len || *offset + n > len || n == 0u || n >= out_sz)
+   if (n > len || *offset + n > len || n == 0u)
       return 1;
    if (memchr(body + *offset, 0, n) != NULL)
       return 1;
-   memcpy(out, body + *offset, n);
-   out[n] = '\0';
+   memcpy(*cursor, body + *offset, n);
+   (*cursor)[n] = '\0';
+   *out = *cursor;
+   *cursor += n + 1u;
    *offset += n;
    return 0;
 }
@@ -64,17 +70,30 @@ aimee_module_status_t aimee_db1_stage_git_ownership(const uint8_t *request_body,
    if (count == 0u || count > AIMEE_DB1_FIELDS_MAX)
       return AIMEE_MODULE_STATUS_INVALID_REQUEST;
 
-   char field[AIMEE_DB1_FIELDS_MAX][AIMEE_DB1_FIELD_MAX];
+   /* One allocation for every field, sized by the frame that carried them: the
+      fields plus a NUL each cannot exceed this. */
+   const char *field[AIMEE_DB1_FIELDS_MAX];
+   char *scratch = malloc((size_t)request_len + AIMEE_DB1_FIELDS_MAX);
+   if (!scratch)
+      return AIMEE_MODULE_STATUS_INTERNAL;
+   char *cursor = scratch;
+   aimee_module_status_t decoded = AIMEE_MODULE_STATUS_OK;
+
    uint32_t offset = 8u;
    for (uint32_t i = 0; i < count; ++i)
-      if (read_counted(request_body, request_len, &offset, field[i], sizeof field[i]) != 0)
-         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      if (read_counted(request_body, request_len, &offset, &cursor, &field[i]) != 0)
+         decoded = AIMEE_MODULE_STATUS_INVALID_REQUEST;
    /* Trailing bytes mean the caller and the module disagree about the op's
       arity, which is a contract mismatch rather than something to tolerate. */
    if (offset != request_len)
-      return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      decoded = AIMEE_MODULE_STATUS_INVALID_REQUEST;
+   if (decoded != AIMEE_MODULE_STATUS_OK)
+   {
+      free(scratch);
+      return decoded;
+   }
 
-   char value[AIMEE_DB1_FIELD_MAX];
+   char value[AIMEE_DB1_VALUE_MAX];
    value[0] = '\0';
    int rc = -1;
    int reads = 0;
@@ -83,35 +102,52 @@ aimee_module_status_t aimee_db1_stage_git_ownership(const uint8_t *request_body,
    {
    case AIMEE_DB1_OP_OWNERSHIP_UPSERT:
       if (count != 3u)
+      {
+         free(scratch);
          return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
       rc = db1_git_ownership_upsert(field[0], field[1], field[2]);
       break;
    case AIMEE_DB1_OP_OWNERSHIP_DELETE:
       if (count != 2u)
+      {
+         free(scratch);
          return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
       rc = db1_git_ownership_delete(field[0], field[1]);
       break;
    case AIMEE_DB1_OP_OWNERSHIP_OWNER_GET:
       if (count != 2u)
+      {
+         free(scratch);
          return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
       rc = db1_git_ownership_get_owner(field[0], field[1], value, sizeof value);
       reads = 1;
       break;
    case AIMEE_DB1_OP_OWNERSHIP_BRANCH_FOR_SESSION:
       if (count != 2u)
+      {
+         free(scratch);
          return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
       rc = db1_git_ownership_get_branch_for_session(field[0], field[1], value, sizeof value);
       reads = 1;
       break;
    case AIMEE_DB1_OP_OWNERSHIP_SESSION_BY_PREFIX:
       if (count != 1u)
+      {
+         free(scratch);
          return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
       rc = db1_git_ownership_find_session_by_prefix(field[0], value, sizeof value);
       reads = 1;
       break;
    default:
+      free(scratch);
       return AIMEE_MODULE_STATUS_INVALID_REQUEST;
    }
+   free(scratch);
 
    /* The two conventions must not be flattened. A read returns FOUND(1),
       not-found(0) or error(-1); a write returns 0 or -1. Mapping a read's -1

--- a/src/tests/test_db1_git_ownership_client.c
+++ b/src/tests/test_db1_git_ownership_client.c
@@ -12,6 +12,7 @@
  * take one somebody else holds. */
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <aimee/core/event_bus/module_client.h>
@@ -27,6 +28,7 @@ static const char *stub_value = "";
 static int stub_calls;
 static uint8_t stub_request[1024];
 static uint32_t stub_request_len;
+static uint32_t stub_frame_len;
 /* When set, the reply declares a length that disagrees with what it carries. */
 static int stub_lie_about_length;
 
@@ -50,6 +52,9 @@ obs_bus_module_call(uint32_t event_kind, uint32_t stage_id, uint64_t trace_id, u
    assert(deadline_ns != 0);
 
    stub_calls++;
+   /* Record the TRUE length even when the frame outgrows the capture buffer:
+      the point of the large-field test is how many bytes were sent. */
+   stub_frame_len = request_len;
    stub_request_len = request_len < sizeof stub_request ? request_len : 0;
    if (stub_request_len)
       memcpy(stub_request, request_body, stub_request_len);
@@ -75,6 +80,7 @@ static void reset(void)
    stub_value = "";
    stub_calls = 0;
    stub_request_len = 0;
+   stub_frame_len = 0;
    stub_lie_about_length = 0;
 }
 
@@ -175,14 +181,9 @@ static void test_a_malformed_reply_is_refused(void)
 static void test_bad_arguments_cost_no_round_trip(void)
 {
    char owner[128];
-   char over_long[AIMEE_DB1_FIELD_MAX + 8];
-   memset(over_long, 'x', sizeof over_long - 1);
-   over_long[sizeof over_long - 1] = '\0';
-
    reset();
    assert(db1_git_ownership_upsert(NULL, "feature", "sess") == -1);
    assert(db1_git_ownership_upsert("/repo", "", "sess") == -1);
-   assert(db1_git_ownership_upsert(over_long, "feature", "sess") == -1);
    assert(db1_git_ownership_get_owner("/repo", "feature", owner, 0) == -1);
    assert(stub_calls == 0);
    printf("  PASS: test_bad_arguments_cost_no_round_trip\n");
@@ -213,6 +214,30 @@ static void test_every_operation_uses_its_own_op_and_arity(void)
    printf("  PASS: test_every_operation_uses_its_own_op_and_arity\n");
 }
 
+/* A field far larger than any fixed cap is CARRIED, not refused. These fields
+   hold prompts, results and documents elsewhere in DB1, and an in-process
+   caller has always passed them whole -- refusing here would return the same -1
+   as a broken store, and would do it only on production-sized data. */
+static void test_a_large_field_is_carried_not_refused(void)
+{
+   enum
+   {
+      BIG = 64u * 1024u
+   };
+   char *big = malloc(BIG + 1u);
+   assert(big != NULL);
+   memset(big, 'x', BIG);
+   big[BIG] = '\0';
+
+   reset();
+   assert(db1_git_ownership_upsert(big, "feature", "sess-1") == 0);
+   assert(stub_calls == 1);
+   /* 8 header bytes, then each field as a 4-byte length plus its bytes. */
+   assert(stub_frame_len == 8u + (4u + BIG) + (4u + 7u) + (4u + 6u));
+   free(big);
+   printf("  PASS: test_a_large_field_is_carried_not_refused\n");
+}
+
 int main(void)
 {
    printf("db1_git_ownership_client:\n");
@@ -221,6 +246,7 @@ int main(void)
    test_an_unreachable_module_is_an_error_not_an_absence();
    test_a_malformed_reply_is_refused();
    test_bad_arguments_cost_no_round_trip();
+   test_a_large_field_is_carried_not_refused();
    test_every_operation_uses_its_own_op_and_arity();
    printf("db1_git_ownership_client: ok\n");
    return 0;

--- a/src/tests/test_db1_module_stage.c
+++ b/src/tests/test_db1_module_stage.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -352,6 +353,50 @@ static void test_git_ownership_store_failure_is_not_a_miss(void)
    printf("  PASS: test_git_ownership_store_failure_is_not_a_miss\n");
 }
 
+/* The serving side carries a large field too, and frees what it allocated to do
+   it. Built with -fsanitize=address this is also the leak check for the scratch
+   buffer the decoder now owns. */
+static void test_stage_carries_a_large_field(void)
+{
+   char path[PATH_MAX];
+   snprintf(path, sizeof(path), "%s/aimee-test-db1-big-%d.db", platform_tmpdir(), (int)getpid());
+   remove(path);
+   db1_shutdown();
+   assert(db1_init(path) == 0);
+
+   enum
+   {
+      BIG = 32u * 1024u
+   };
+   char *big = malloc(BIG + 1u);
+   assert(big != NULL);
+   memset(big, 'r', BIG);
+   big[BIG] = '\0';
+
+   uint8_t *req = malloc(BIG + 4096u);
+   uint8_t resp[4096];
+   uint32_t resp_len = 0;
+   assert(req != NULL);
+   const char *values[] = {big, "feature", "sess-big"};
+   uint32_t len = fields_frame(req, AIMEE_DB1_OP_OWNERSHIP_UPSERT, values, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_GIT_OWNERSHIP, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_OK);
+   assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
+
+   /* And it round-trips: the long key is what the row was written under. */
+   const char *owner_get[] = {big, "feature"};
+   len = fields_frame(req, AIMEE_DB1_OP_OWNERSHIP_OWNER_GET, owner_get, 2);
+   assert(call_stage(AIMEE_DB1_STAGE_GIT_OWNERSHIP, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_OK);
+   assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
+
+   free(req);
+   free(big);
+   db1_shutdown();
+   remove(path);
+   printf("  PASS: test_stage_carries_a_large_field\n");
+}
+
 int main(void)
 {
    printf("db1_module_stage:\n");
@@ -362,6 +407,7 @@ int main(void)
    test_git_ownership_round_trips();
    test_git_ownership_malformed_frames_are_refused();
    test_git_ownership_store_failure_is_not_a_miss();
+   test_stage_carries_a_large_field();
    printf("db1_module_stage: ok\n");
    return 0;
 }


### PR DESCRIPTION
`AIMEE_DB1_FIELD_MAX` was **512 bytes**, and 33 of the operations already reachable over the bus carry a prompt, a result or a JSON document — against DB1 columns that run to 16 KB.

The client refused those calls and returned the same `-1` it returns for a broken store. Short strings passed every test; the first real prompt would have failed, looking like something else entirely.

### The cap was self-imposed
The bus allows a 16 MB body and the module runtime already heap-allocates both sides of it. The only fixed buffers were the ones this generator emitted. **An in-process caller has always passed these values whole, so refusing them at the boundary was the regression, not the fix.**

Both sides now size from the data: the client measures the arguments and allocates the frame; the decoder allocates once from the frame it was given, which cannot be larger than what arrived.

What stays bounded is what should be — `FIELDS_MAX` still sizes the pointer array, and the renamed `VALUE_MAX` bounds the reply a stage builds. A request cap and a reply cap were never the same thing.

### The test that asserted refusal now asserts the opposite
That is the behaviour being changed: **64 KB through the client**, **32 KB through the stage** and back out of the row it was written under.

### Allocation earns a leak check, not an assurance
Both suites are clean under `-fsanitize=address,leak`. Removing a single `free` from one early-return path is caught there — *64 byte(s) leaked in 2 allocation(s)* — so the check is load-bearing rather than decorative.

### Verified
Both DB1 suites normally and under ASAN+LSAN, the catalog and its 29 tests, the descriptor gate, the C build, the daemon, the DB1 module through the runtime bundle, and lint (58 checks).

Closes the first item in `docs/proposals/pending/db1-wire-capability-survey.md`.