### PR TITLE
db1: make the survey count return contracts, not just parameters

### DIFF
--- a/docs/proposals/pending/db1-wire-capability-survey.md
+++ b/docs/proposals/pending/db1-wire-capability-survey.md
@@ -43,10 +43,22 @@ to sit inside an active family without being served.
 
 | tier | needs | ops | cumulative |
 | --- | --- | --- | --- |
-| T0 | nothing — fits the wire today | 76 | 76 (27%) |
-| T1 | integer arguments | 78 | 154 (54%) |
-| T2 | a counted reply (integer or multi out-parameter) | 18 | 172 (61%) |
+| T0 | nothing — fits the wire today | 63 | 63 (22%) |
+| T1 | integer arguments | 75 | 138 (49%) |
+| T2 | a richer reply — counted, multi-value, or a status beyond ok/miss/fail | 34 | 172 (61%) |
 | T3 | structured payloads (struct in/out, arrays, malloc'd returns) | 109 | 281 (100%) |
+
+The first version of this table said 76/78/18 and put 154 in reach. It was
+wrong, and the way it was wrong is the more useful fact: it classified
+**parameters** and never the **return contract**. The wire answers a write with
+0 or -1 and a read with found, not-found or error, so an operation that returns
+a count, or a distinguished refusal like `db1_wfe_bind`'s -2 for a single-writer
+conflict, has nowhere to put the distinction it exists to make. Migrating one of
+those would have quietly reported a conflict as an error.
+
+Two mechanical cases were mis-tiered the same way: an operation taking no
+arguments cannot be framed at all, and one with two out buffers has one reply
+value to put them in. Sixteen operations were affected across the three.
 
 T1 shipped, which is what took reachability from 27% to 54%. T2 buys 18
 operations, which is a poor return for a frame change. T3 is the real remainder
@@ -56,16 +68,17 @@ Per family, ready means T0 + T1:
 
 | family | ready | total | behind T2 | behind T3 |
 | --- | --- | --- | --- | --- |
-| workflow | 60 | 91 | 6 | 25 |
-| delegation | 27 | 37 | 3 | 7 |
-| runtime | 22 | 35 | 2 | 11 |
-| agent_work | 16 | 38 | 3 | 19 |
+| workflow | 51 | 91 | 15 | 25 |
+| delegation | 26 | 37 | 4 | 7 |
+| runtime | 20 | 35 | 4 | 11 |
+| agent_work | 15 | 38 | 4 | 19 |
 | sessions | 8 | 22 | 0 | 14 |
-| conversation | 8 | 20 | 1 | 11 |
-| telemetry | 8 | 33 | 3 | 22 |
-| identity | 5 | 5 | 0 | 0 |
+| conversation | 7 | 20 | 2 | 11 |
+| telemetry | 7 | 33 | 4 | 22 |
+| identity | 4 | 5 | 1 | 0 |
 
-Only `identity` is fully reachable, and it is the one family that should go last
+No family is fully reachable now that return contracts count -- `identity` came
+closest at 4 of 5, and it is the one family that should go last
 rather than first: what is reachable in it is `db1_secret_*` and
 `db1_remote_client_*`, whose caller is `server_bearer_auth.c`.
 

--- a/docs/proposals/pending/db1-wire-capability-survey.md
+++ b/docs/proposals/pending/db1-wire-capability-survey.md
@@ -71,9 +71,9 @@ rather than first: what is reachable in it is `db1_secret_*` and
 
 ## The two gaps that are not about tiers
 
-### Optional fields — smaller than it looked
+### Optional fields — smaller than it looked (CLOSED)
 
-The wire refuses an empty field, and the generated client refuses a NULL one. A
+The wire refused an empty field, and the generated client refused a NULL one. A
 call-site scan of all 154 reachable operations finds **16** that pass `NULL` or
 `""` as a literal. The remaining 138 need nothing.
 
@@ -82,9 +82,9 @@ NULL. It is also cheap to close — the domains already collapse the two
 themselves, so a per-field `required` flag in the catalog is enough, with the
 client mapping NULL to empty and the stage enforcing which fields may be blank.
 
-### Field size — the one that will ship green and fail in production
+### Field size — the one that will ship green and fail in production (CLOSED)
 
-`AIMEE_DB1_FIELD_MAX` is 512 bytes. **33 of the 154 reachable operations carry a
+`AIMEE_DB1_FIELD_MAX` was 512 bytes. **33 of the 154 reachable operations carry a
 prompt, a result, an output, or a JSON blob**, and DB1's own columns run to 16
 KB. A 512-byte cap truncates none of them: the client refuses the call and
 returns the same -1 it returns for a broken store.
@@ -100,6 +100,10 @@ and a request buffer of the same shape in the client. Raising the constant to
 anything useful puts hundreds of kilobytes on the stack. **Large payloads
 therefore require the generated code to allocate, which is a change to the
 shape of the generated wire rather than to a number in it.**
+
+Both are closed as of the pull requests that follow this document. The counts
+above are kept as they were measured, because they are what justified the order
+below — not because either still blocks a call.
 
 ## Recommended order
 

--- a/scripts/survey_db1_wire.py
+++ b/scripts/survey_db1_wire.py
@@ -233,10 +233,14 @@ def report(operations: dict) -> None:
     nullable = {n: o for n, o in ready.items() if o["nullable"]}
     large = {n: o for n, o in ready.items() if o["large_fields"]}
     print(f"\n  reachable now (T0+T1)                : {len(ready)}")
-    print(f"    of those passing NULL or \"\"        : {len(nullable)}"
-          f"   (literals only -- a lower bound)")
-    print(f"    of those carrying a large field    : {len(large)}"
-          f"   (against AIMEE_DB1_FIELD_MAX)")
+    # Both of these were blockers once and are not now. They stay in the report
+    # because they say what the reachable set is carrying -- a family full of
+    # documents is a different migration from a family full of identifiers --
+    # but neither refuses a call any more.
+    print(f"    passing NULL or \"\" somewhere      : {len(nullable)}"
+          f"   (carried: fields declare required)")
+    print(f"    carrying a prompt/result/document  : {len(large)}"
+          f"   (carried: requests are not capped)")
 
     print("\n  by family (ready / total):")
     families = collections.defaultdict(collections.Counter)

--- a/scripts/survey_db1_wire.py
+++ b/scripts/survey_db1_wire.py
@@ -54,9 +54,16 @@ TIER_OF = {"text": 0, "out_text": 0, "int": 1, "out_num": 2}
 TIER_NAME = {
     0: "T0  fits the wire today",
     1: "T1  + integer arguments",
-    2: "T2  + counted reply (integer / multi out-parameter)",
+    2: "T2  + a richer reply (counted, multi-value, or a status beyond ok/miss/fail)",
     3: "T3  + structured payloads (struct, array, malloc'd out)",
 }
+
+# A contract that answers with more than success/failure or found/not-found.
+# The wire maps a write to 0/-1 and a read to 1/0/-1, so an operation that
+# returns a count, or a distinguished refusal like the single-writer -2, loses
+# the distinction it exists to make.
+RICH_RETURN = re.compile(r"(\B-2\b|\B-3\b|number of|count of|returns the number|how many)",
+                         re.I)
 
 
 def compile_only_sources(root: Path) -> set[str]:
@@ -85,13 +92,22 @@ def declarations(root: Path, families: dict[str, str]) -> dict[str, dict]:
     for header in sorted((root / SOURCE_DIR).glob("*.h")):
         if header.stem not in families:
             continue
-        text = re.sub(r"/\*.*?\*/", "", header.read_text(errors="ignore"), flags=re.S)
+        raw = header.read_text(errors="ignore")
+        # The comment immediately before a declaration is its contract, and the
+        # contract is where a count or a distinguished refusal is stated.
+        documented: dict[str, str] = {}
+        for pair in re.finditer(r"/\*(.*?)\*/\s*((?:[^;/]|/(?!\*))*?;)", raw, re.S):
+            named = re.search(r"\b([a-z][a-z0-9_]{3,})\s*\(", pair.group(2))
+            if named:
+                documented[named.group(1)] = pair.group(1)
+        text = re.sub(r"/\*.*?\*/", "", raw, flags=re.S)
         for match in DECL.finditer(text):
             found[match.group(2)] = {
                 "family": families[header.stem],
                 "source": header.stem,
                 "returns": " ".join(match.group(1).split()),
                 "params": " ".join(match.group(3).split()),
+                "contract": " ".join(documented.get(match.group(2), "").split()),
             }
     return found
 
@@ -189,6 +205,16 @@ def survey(root: Path) -> dict:
             tier = max(tier, TIER_OF.get(tag, 3))
         if entry["returns"] in ("char *", "const char *"):
             tier = 3
+        # An operation taking nothing cannot be framed: the request carries at
+        # least one counted field.
+        if not entry["tags"]:
+            tier = max(tier, 2)
+        # One reply value, so a second out buffer has nowhere to go.
+        if entry["tags"].count("out_text") > 1:
+            tier = max(tier, 2)
+        if RICH_RETURN.search(entry.get("contract", "")):
+            tier = max(tier, 2)
+            entry["rich_return"] = True
         entry["tier"] = tier
         names = [p.split()[-1].lstrip("*") for p in entry["params"].split(",")]
         entry["large_fields"] = sorted({


### PR DESCRIPTION
Two corrections to the survey, the second found while picking the next cutover.

## The survey was reporting solved problems as blockers

It still said 33 operations were blocked "against `AIMEE_DB1_FIELD_MAX`" **after that constant stopped existing** (#2745), and still counted 16 NULL-passing operations as a gap **after fields learned to declare themselves optional** (#2746). Both counts stay, reworded to say what they are — the reachable set carries 33 documents and 16 absent values, which matters when choosing a family — but neither refuses a call now.

## The survey never counted return contracts

Reading `wfe_binding` to pick a target found three operations the survey called ready that the wire cannot express:

- **`db1_wfe_bind` returns `-2` for a single-writer conflict.** The wire answers a write with 0 or -1, so migrating it would have reported a refusal as an error — losing exactly the distinction the -2 exists to make.
- **`db1_wfe_lease_reclaim_stale` returns the number reclaimed and takes no arguments**; the request frame carries at least one field.
- **`db1_wfe_binding_get` fills two out buffers** against one reply value.

**16 operations affected. Ready drops 154 → 138, T2 grows 18 → 34, and no family is fully reachable any more** (`identity` came closest at 4 of 5).

The count moving matters less than what moved it: a tier table built from signatures alone says an operation fits when its *arguments* fit — and every one of these has arguments that fit perfectly.

Detection now reads the doc comment immediately above each declaration, which is where a count or a distinguished refusal is stated. An earlier attempt matched nothing and reported zero such operations; I took that at face value for exactly as long as it took to re-read `db1_wfe_bind`.
