### PR TITLE
db1: count the reply, the way the request already counts

### DIFF
--- a/docs/proposals/pending/db1-structured-payloads.md
+++ b/docs/proposals/pending/db1-structured-payloads.md
@@ -85,7 +85,10 @@ Three things stay outside the wire, and none of them are payload shapes:
 
 ## Sequence
 
-1. **Counted reply.** One frame change, both generated sides, family 1's keyed
+1. ~~**Counted reply.**~~ Done: the reply is `status | count | (len | bytes) *
+   count`, and the format is named `db1-fields-v2` because the frame changed.
+   Family 1's keyed blob is a different format and did not move.
+1. **Superseded — kept for the sequence.** One frame change, both generated sides, family 1's keyed
    blob untouched. Unlocks the seven sources the survey attributed to T2, and is
    prerequisite for everything below.
 2. **Struct flattening.** Member lists in the catalog; marshalling in the

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -49,7 +49,7 @@ RESULT_CODES = ("ok", "missing", "invalid", "too_long", "failed")
 SCOPES = ("none", "conversation", "session", "repository", "global")
 TRANSACTIONS = ("none", "single")
 IDEMPOTENCY = ("safe", "idempotent", "unsafe")
-WIRE_FORMATS = ("db1-keyed-blob-v1", "db1-fields-v1")
+WIRE_FORMATS = ("db1-keyed-blob-v1", "db1-fields-v2")
 PAYLOADS = ("none", "state", "text")
 FIELD_TYPES = ("text", "int")
 
@@ -184,7 +184,7 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
             # by rule -- so the C signature carries its own names rather than
             # exporting "key" into a header that has always said repo_path.
             parameters = operation["c_params"]
-            reads = operation["reply"]["payload"] != "none"
+            reads = bool(operation["reply"]["fields"])
             expected = len(operation["request"]["fields"]) + (2 if reads else 0)
             if not isinstance(parameters, list) or len(parameters) != expected or \
                     len(set(parameters)) != expected:
@@ -275,11 +275,19 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
         if len(set(fields)) != len(fields):
             fail("request-field-duplicate", f"{name} repeats a request field")
 
-        reply = keys(operation["reply"], {"payload", "max_bytes"}, f"{name}.reply")
-        if reply["payload"] not in PAYLOADS:
-            fail("reply-payload", f"{name} reply payload must be one of {list(PAYLOADS)}")
+        reply = keys(operation["reply"], {"fields", "max_bytes"}, f"{name}.reply")
+        reply_fields = reply["fields"]
+        if not isinstance(reply_fields, list):
+            fail("reply-fields", f"{name} reply fields must be an array")
+        for position, declared in enumerate(reply_fields):
+            shape = keys(declared, {"name", "type"}, f"{name}.reply.fields[{position}]")
+            if shape["type"] not in PAYLOADS or shape["type"] == "none":
+                fail("reply-payload",
+                     f"{name} reply field type must be one of {[p for p in PAYLOADS if p != 'none']}")
+            if not NAME.fullmatch(str(shape["name"])):
+                fail("reply-field-name", f"{name} invalid reply field {shape['name']!r}")
         max_bytes = integer(reply["max_bytes"], f"{name}.reply.max_bytes", 0, 1 << 20)
-        if (reply["payload"] == "none") != (max_bytes == 0):
+        if (not reply_fields) != (max_bytes == 0):
             fail("reply-bytes", f"{name} reply max_bytes must be zero exactly when it carries nothing")
         operations.append(operation)
     return operations
@@ -465,13 +473,17 @@ WIRE_FORMAT_DOC = {
     "db1-keyed-blob-v1": """   Request:  op(u32) | key_len(u32) | key | json_len(u32) | json
    Response: status(u32) | json_len(u32) | json
    Lengths are little-endian, matching the rest of the bus surface.""",
-    "db1-fields-v1": """   Request:  op(u32) | field_count(u32) | (len(u32) | bytes) * field_count
-   Response: status(u32) | value_len(u32) | value
+    "db1-fields-v2": """   Request:  op(u32) | field_count(u32) | (len(u32) | bytes) * field_count
+   Response: status(u32) | field_count(u32) | (len(u32) | bytes) * field_count
 
-   The counted form is the one every family after the first uses. The first
-   family fixed its request at exactly two fields, which suits a keyed blob and
-   suits nothing with three, so the count is explicit here rather than implied
-   by the op.""",
+   Counted in both directions. The first family fixed its request at exactly two
+   fields, which suits a keyed blob and suits nothing with three, so the count is
+   explicit here rather than implied by the op.
+
+   The reply counts for the same reason the request does: an operation that
+   answers with a row, or with a list of them, has somewhere to put the values.
+   A reply carrying nothing sends a count of zero, and one carrying a single
+   value sends a count of one -- the shape does not change with the arity.""",
 }
 
 HELPERS = """static inline void aimee_db1_put_u32(uint8_t *p, uint32_t value)
@@ -565,11 +577,12 @@ def header_bytes(catalog: dict[str, object]) -> str:
             reply = operation["reply"]
             request = operation["request"]
             assert isinstance(reply, dict) and isinstance(request, dict)
-            if reply["payload"] == "state":
+            kinds = {str(f["type"]) for f in reply["fields"]}
+            if "state" in kinds:
                 state_max = max(state_max, int(reply["max_bytes"]))
-            if reply["payload"] == "text":
+            if "text" in kinds:
                 field_max = max(field_max, int(reply["max_bytes"]))
-            if operation["wire_format"] == "db1-fields-v1":
+            if operation["wire_format"] == "db1-fields-v2":
                 fields_max = max(fields_max, len(request["fields"]))
 
     limits: list[tuple[str, str]] = []
@@ -707,7 +720,7 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
       return -1;
    /* The reply is bounded by the caller's own buffer: it asked for at most
       value_len bytes, so there is no reason to hold more than that. */
-   size_t response_cap = 8u + (value_out ? value_len : 0u);
+   size_t response_cap = 12u + (value_out ? value_len : 0u);
    uint8_t *request = malloc(request_len);
    uint8_t *response = malloc(response_cap);
    if (!request || !response)
@@ -732,20 +745,37 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
    else
    {{
       uint32_t status = aimee_db1_get_u32(response);
-      uint32_t payload_len = aimee_db1_get_u32(response + 4u);
-      /* A reply whose declared length disagrees with what arrived is not a
-         reply to read part of. */
-      if (payload_len == response_len - 8u)
+      uint32_t fields_in = aimee_db1_get_u32(response + 4u);
+      /* Read the reply's own count rather than assuming one value: a status
+         with no values is how a write answers, and a row is how a read will. */
+      result = (int)status;
+      if (fields_in == 0u)
       {{
-         result = (int)status;
          if (value_out && value_len)
+            value_out[0] = '\\0';
+      }}
+      else
+      {{
+         uint32_t at = 8u;
+         if (at + 4u > response_len)
+            result = -1;
+         else
          {{
-            if (payload_len >= value_len)
+            uint32_t n = aimee_db1_get_u32(response + at);
+            at += 4u;
+            /* A reply whose declared length runs past what arrived is not a
+               reply to read part of. */
+            if (at + n > response_len)
                result = -1;
-            else
+            else if (value_out && value_len)
             {{
-               memcpy(value_out, response + 8u, payload_len);
-               value_out[payload_len] = '\\0';
+               if (n >= value_len)
+                  result = -1;
+               else
+               {{
+                  memcpy(value_out, response + at, n);
+                  value_out[n] = '\\0';
+               }}
             }}
          }}
       }}
@@ -797,7 +827,7 @@ def client_bytes(catalog: dict[str, object], family: dict[str, object],
         assert isinstance(request, dict) and isinstance(reply, dict)
         fields = [str(f["name"]) for f in request["fields"]]
         types = [str(f["type"]) for f in request["fields"]]
-        reads = reply["payload"] != "none"
+        reads = bool(reply["fields"])
         required = [bool(f["required"]) for f in request["fields"]]
         names = [str(n) for n in operation["c_params"]]
         inputs, outputs = names[:len(fields)], names[len(fields):]
@@ -925,17 +955,25 @@ static int read_counted(const uint8_t *body, uint32_t len, uint32_t *offset, cha
    return 0;
 }}
 
-{parse_int}static uint32_t write_reply(uint8_t *out, uint32_t cap, uint32_t *out_len, uint32_t status,
+{parse_int}/* status(u32) | field_count(u32) | (len(u32) | bytes) * count. A write answers
+   with no values, a read with one; the shape is the same either way. */
+static uint32_t write_reply(uint8_t *out, uint32_t cap, uint32_t *out_len, uint32_t status,
                             const char *value)
 {{
-   uint32_t value_len = (uint32_t)strlen(value);
-   if (cap < 8u + value_len)
+   uint32_t count = value ? 1u : 0u;
+   uint32_t value_len = value ? (uint32_t)strlen(value) : 0u;
+   if (cap < 8u + (count ? 4u + value_len : 0u))
       return AIMEE_DB1_STATUS_FAILED;
    aimee_db1_put_u32(out, status);
-   aimee_db1_put_u32(out + 4u, value_len);
-   if (value_len)
-      memcpy(out + 8u, value, value_len);
-   *out_len = 8u + value_len;
+   aimee_db1_put_u32(out + 4u, count);
+   *out_len = 8u;
+   if (count)
+   {{
+      aimee_db1_put_u32(out + 8u, value_len);
+      if (value_len)
+         memcpy(out + 12u, value, value_len);
+      *out_len = 12u + value_len;
+   }}
    return status;
 }}
 
@@ -1005,8 +1043,8 @@ aimee_module_status_t aimee_db1_stage_{stem}(const uint8_t *request_body, uint32
    else
       status = (rc == 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
 
-   write_reply(response_body, response_capacity, response_len,
-               status, (status == AIMEE_DB1_STATUS_OK && reads) ? value : "");
+   write_reply(response_body, response_capacity, response_len, status,
+               reads ? ((status == AIMEE_DB1_STATUS_OK) ? value : "") : NULL);
    return AIMEE_MODULE_STATUS_OK;
 }}
 /* clang-format on */
@@ -1044,7 +1082,7 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]]) 
         assert isinstance(request, dict) and isinstance(reply, dict)
         arity = len(request["fields"])
         types = [str(f["type"]) for f in request["fields"]]
-        reads = reply["payload"] != "none"
+        reads = bool(reply["fields"])
         parse, args = [], []
         for position, kind in enumerate(types):
             if kind == "int":

--- a/scripts/tests/test_gen_db1_contract.py
+++ b/scripts/tests/test_gen_db1_contract.py
@@ -283,12 +283,12 @@ class CatalogTests(unittest.TestCase):
             reserved["active"] = True
             catalog["operations"].append({
                 "family": reserved["name"], "id": 1, "name": "probe_touch",
-                "wire_format": "db1-fields-v1", "scope": "session",
+                "wire_format": "db1-fields-v2", "scope": "session",
                 "transaction": "single", "idempotency": "idempotent",
                 "results": ["ok", "invalid", "failed"],
                 "request": {"fields": [{"name": n, "type": "text", "required": True}
                                        for n in ("key", "a", "b", "c")]},
-                "reply": {"payload": "none", "max_bytes": 0},
+                "reply": {"fields": [], "max_bytes": 0},
             })
             self.write(root, catalog)
             # Activating a family without declaring its stage is refused, which
@@ -398,11 +398,11 @@ class CatalogTests(unittest.TestCase):
         catalog["operations"].append({
             "family": reserved["name"], "id": 1, "name": "probe_forget_if_job",
             "c_name": "db1_probe_forget_if_job", "c_params": ["probe_id", "job_id"],
-            "wire_format": "db1-fields-v1", "scope": "session", "transaction": "single",
+            "wire_format": "db1-fields-v2", "scope": "session", "transaction": "single",
             "idempotency": "idempotent", "results": ["ok", "invalid", "failed"],
             "request": {"fields": [{"name": "key", "type": "text", "required": True},
                                    {"name": "job", "type": "int", "required": True}]},
-            "reply": {"payload": "none", "max_bytes": 0},
+            "reply": {"fields": [], "max_bytes": 0},
         })
         self.write(root, catalog)
         path = root / contract.PROCESS_CONTRACTS
@@ -481,14 +481,14 @@ class CatalogTests(unittest.TestCase):
             "family": reserved["name"], "id": 1, "name": "probe_status_set",
             "c_name": "db1_probe_status_set",
             "c_params": ["probe_id", "status", "pipeline_id", "error"],
-            "wire_format": "db1-fields-v1", "scope": "session", "transaction": "single",
+            "wire_format": "db1-fields-v2", "scope": "session", "transaction": "single",
             "idempotency": "idempotent", "results": ["ok", "invalid", "failed"],
             "request": {"fields": [
                 {"name": "key", "type": "text", "required": True},
                 {"name": "status", "type": "text", "required": True},
                 {"name": "pipeline", "type": "text", "required": False},
                 {"name": "error", "type": "text", "required": False}]},
-            "reply": {"payload": "none", "max_bytes": 0},
+            "reply": {"fields": [], "max_bytes": 0},
         })
         self.write(root, catalog)
         path = root / contract.PROCESS_CONTRACTS
@@ -552,6 +552,21 @@ class CatalogTests(unittest.TestCase):
             self.assertRule(root, "field-required")
         finally:
             tmp.cleanup()
+
+    def test_a_reply_declares_its_fields_and_the_frame_counts_them(self) -> None:
+        # The reply counts for the same reason the request does: an operation
+        # answering with a row, or a list of them, has somewhere to put the
+        # values. A write sends count 0; a single value sends count 1.
+        catalog = self.catalog(REPO_ROOT)
+        for operation in catalog["operations"]:
+            reply = operation["reply"]
+            self.assertIn("fields", reply, f"{operation['name']} reply is not counted")
+            self.assertEqual(bool(reply["fields"]), reply["max_bytes"] > 0)
+        stage = (REPO_ROOT / contract.SOURCE_DIR / "git_ownership_stage.c").read_text()
+        client = (REPO_ROOT / contract.CLIENT_DIR / "git_ownership.c").read_text()
+        # Both sides speak count, not a single length.
+        self.assertIn("uint32_t count = value ? 1u : 0u;", stage)
+        self.assertIn("uint32_t fields_in = aimee_db1_get_u32(response + 4u);", client)
 
     def test_every_operation_is_keyed(self) -> None:
         # DB1 rows belong to a conversation or session; an unkeyed read would

--- a/src/db1_client/git_ownership.c
+++ b/src/db1_client/git_ownership.c
@@ -116,7 +116,7 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
       return -1;
    /* The reply is bounded by the caller's own buffer: it asked for at most
       value_len bytes, so there is no reason to hold more than that. */
-   size_t response_cap = 8u + (value_out ? value_len : 0u);
+   size_t response_cap = 12u + (value_out ? value_len : 0u);
    uint8_t *request = malloc(request_len);
    uint8_t *response = malloc(response_cap);
    if (!request || !response)
@@ -141,20 +141,37 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
    else
    {
       uint32_t status = aimee_db1_get_u32(response);
-      uint32_t payload_len = aimee_db1_get_u32(response + 4u);
-      /* A reply whose declared length disagrees with what arrived is not a
-         reply to read part of. */
-      if (payload_len == response_len - 8u)
+      uint32_t fields_in = aimee_db1_get_u32(response + 4u);
+      /* Read the reply's own count rather than assuming one value: a status
+         with no values is how a write answers, and a row is how a read will. */
+      result = (int)status;
+      if (fields_in == 0u)
       {
-         result = (int)status;
          if (value_out && value_len)
+            value_out[0] = '\0';
+      }
+      else
+      {
+         uint32_t at = 8u;
+         if (at + 4u > response_len)
+            result = -1;
+         else
          {
-            if (payload_len >= value_len)
+            uint32_t n = aimee_db1_get_u32(response + at);
+            at += 4u;
+            /* A reply whose declared length runs past what arrived is not a
+               reply to read part of. */
+            if (at + n > response_len)
                result = -1;
-            else
+            else if (value_out && value_len)
             {
-               memcpy(value_out, response + 8u, payload_len);
-               value_out[payload_len] = '\0';
+               if (n >= value_len)
+                  result = -1;
+               else
+               {
+                  memcpy(value_out, response + at, n);
+                  value_out[n] = '\0';
+               }
             }
          }
       }

--- a/src/modules/db1/db1_module_api.h
+++ b/src/modules/db1/db1_module_api.h
@@ -35,12 +35,16 @@
  * owns which branch, so concurrent local sessions do not stomp on each other.
  *
  * Request:  op(u32) | field_count(u32) | (len(u32) | bytes) * field_count
- * Response: status(u32) | value_len(u32) | value
+ * Response: status(u32) | field_count(u32) | (len(u32) | bytes) * field_count
  *
- * The counted form is the one every family after the first uses. The first
- * family fixed its request at exactly two fields, which suits a keyed blob and
- * suits nothing with three, so the count is explicit here rather than implied
- * by the op. */
+ * Counted in both directions. The first family fixed its request at exactly two
+ * fields, which suits a keyed blob and suits nothing with three, so the count is
+ * explicit here rather than implied by the op.
+ *
+ * The reply counts for the same reason the request does: an operation that
+ * answers with a row, or with a list of them, has somewhere to put the values.
+ * A reply carrying nothing sends a count of zero, and one carrying a single
+ * value sends a count of one -- the shape does not change with the arity. */
 
 #define AIMEE_DB1_EVENT_GIT_OWNERSHIP 11778u
 #define AIMEE_DB1_STAGE_GIT_OWNERSHIP 2u

--- a/src/modules/db1/eventcontract/operations.json
+++ b/src/modules/db1/eventcontract/operations.json
@@ -234,7 +234,12 @@
         ]
       },
       "reply": {
-        "payload": "state",
+        "fields": [
+          {
+            "name": "state",
+            "type": "state"
+          }
+        ],
         "max_bytes": 6144
       }
     },
@@ -267,7 +272,7 @@
         ]
       },
       "reply": {
-        "payload": "none",
+        "fields": [],
         "max_bytes": 0
       }
     },
@@ -281,7 +286,7 @@
         "branch_name",
         "session_id"
       ],
-      "wire_format": "db1-fields-v1",
+      "wire_format": "db1-fields-v2",
       "scope": "repository",
       "transaction": "single",
       "idempotency": "idempotent",
@@ -310,7 +315,7 @@
         ]
       },
       "reply": {
-        "payload": "none",
+        "fields": [],
         "max_bytes": 0
       }
     },
@@ -323,7 +328,7 @@
         "repo_path",
         "branch_name"
       ],
-      "wire_format": "db1-fields-v1",
+      "wire_format": "db1-fields-v2",
       "scope": "repository",
       "transaction": "single",
       "idempotency": "idempotent",
@@ -347,7 +352,7 @@
         ]
       },
       "reply": {
-        "payload": "none",
+        "fields": [],
         "max_bytes": 0
       }
     },
@@ -362,7 +367,7 @@
         "owner_out",
         "owner_len"
       ],
-      "wire_format": "db1-fields-v1",
+      "wire_format": "db1-fields-v2",
       "scope": "repository",
       "transaction": "none",
       "idempotency": "safe",
@@ -387,7 +392,12 @@
         ]
       },
       "reply": {
-        "payload": "text",
+        "fields": [
+          {
+            "name": "value",
+            "type": "text"
+          }
+        ],
         "max_bytes": 512
       }
     },
@@ -402,7 +412,7 @@
         "branch_out",
         "branch_len"
       ],
-      "wire_format": "db1-fields-v1",
+      "wire_format": "db1-fields-v2",
       "scope": "repository",
       "transaction": "none",
       "idempotency": "safe",
@@ -427,7 +437,12 @@
         ]
       },
       "reply": {
-        "payload": "text",
+        "fields": [
+          {
+            "name": "value",
+            "type": "text"
+          }
+        ],
         "max_bytes": 512
       }
     },
@@ -441,7 +456,7 @@
         "session_out",
         "session_len"
       ],
-      "wire_format": "db1-fields-v1",
+      "wire_format": "db1-fields-v2",
       "scope": "global",
       "transaction": "none",
       "idempotency": "safe",
@@ -461,7 +476,12 @@
         ]
       },
       "reply": {
-        "payload": "text",
+        "fields": [
+          {
+            "name": "value",
+            "type": "text"
+          }
+        ],
         "max_bytes": 512
       }
     },
@@ -475,7 +495,7 @@
         "session_id",
         "feature_branch"
       ],
-      "wire_format": "db1-fields-v1",
+      "wire_format": "db1-fields-v2",
       "scope": "repository",
       "transaction": "single",
       "idempotency": "idempotent",
@@ -504,7 +524,7 @@
         ]
       },
       "reply": {
-        "payload": "none",
+        "fields": [],
         "max_bytes": 0
       }
     },
@@ -519,7 +539,7 @@
         "branch_out",
         "branch_len"
       ],
-      "wire_format": "db1-fields-v1",
+      "wire_format": "db1-fields-v2",
       "scope": "repository",
       "transaction": "none",
       "idempotency": "safe",
@@ -544,7 +564,12 @@
         ]
       },
       "reply": {
-        "payload": "text",
+        "fields": [
+          {
+            "name": "value",
+            "type": "text"
+          }
+        ],
         "max_bytes": 512
       }
     }

--- a/src/modules/db1/git_ownership_stage.c
+++ b/src/modules/db1/git_ownership_stage.c
@@ -43,17 +43,25 @@ static int read_counted(const uint8_t *body, uint32_t len, uint32_t *offset, cha
    return 0;
 }
 
+/* status(u32) | field_count(u32) | (len(u32) | bytes) * count. A write answers
+   with no values, a read with one; the shape is the same either way. */
 static uint32_t write_reply(uint8_t *out, uint32_t cap, uint32_t *out_len, uint32_t status,
                             const char *value)
 {
-   uint32_t value_len = (uint32_t)strlen(value);
-   if (cap < 8u + value_len)
+   uint32_t count = value ? 1u : 0u;
+   uint32_t value_len = value ? (uint32_t)strlen(value) : 0u;
+   if (cap < 8u + (count ? 4u + value_len : 0u))
       return AIMEE_DB1_STATUS_FAILED;
    aimee_db1_put_u32(out, status);
-   aimee_db1_put_u32(out + 4u, value_len);
-   if (value_len)
-      memcpy(out + 8u, value, value_len);
-   *out_len = 8u + value_len;
+   aimee_db1_put_u32(out + 4u, count);
+   *out_len = 8u;
+   if (count)
+   {
+      aimee_db1_put_u32(out + 8u, value_len);
+      if (value_len)
+         memcpy(out + 12u, value, value_len);
+      *out_len = 12u + value_len;
+   }
    return status;
 }
 
@@ -258,8 +266,8 @@ aimee_module_status_t aimee_db1_stage_git_ownership(const uint8_t *request_body,
    else
       status = (rc == 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
 
-   write_reply(response_body, response_capacity, response_len,
-               status, (status == AIMEE_DB1_STATUS_OK && reads) ? value : "");
+   write_reply(response_body, response_capacity, response_len, status,
+               reads ? ((status == AIMEE_DB1_STATUS_OK) ? value : "") : NULL);
    return AIMEE_MODULE_STATUS_OK;
 }
 /* clang-format on */

--- a/src/tests/test_db1_git_ownership_client.c
+++ b/src/tests/test_db1_git_ownership_client.c
@@ -61,14 +61,16 @@ obs_bus_module_call(uint32_t event_kind, uint32_t stage_id, uint64_t trace_id, u
    if (stub_result != AIMEE_MODULE_CALL_OK)
       return stub_result;
 
+   /* status | field_count | (len | bytes) * count */
    uint32_t value_len = (uint32_t)strlen(stub_value);
-   if (response_capacity < 8u + value_len)
+   if (response_capacity < 12u + value_len)
       return AIMEE_MODULE_CALL_RESPONSE_TOO_LARGE;
    uint8_t *out = (uint8_t *)response_body;
    aimee_db1_put_u32(out, stub_status);
-   aimee_db1_put_u32(out + 4u, stub_lie_about_length ? value_len + 7u : value_len);
-   memcpy(out + 8u, stub_value, value_len);
-   *response_len = 8u + value_len;
+   aimee_db1_put_u32(out + 4u, 1u);
+   aimee_db1_put_u32(out + 8u, stub_lie_about_length ? value_len + 7u : value_len);
+   memcpy(out + 12u, stub_value, value_len);
+   *response_len = 12u + value_len;
    return AIMEE_MODULE_CALL_OK;
 }
 
@@ -238,6 +240,26 @@ static void test_a_large_field_is_carried_not_refused(void)
    printf("  PASS: test_a_large_field_is_carried_not_refused\n");
 }
 
+/* A value that exactly fills the caller's buffer leaves no room for the NUL, so
+   it is refused rather than terminated one byte past the end. Built with
+   -fsanitize=address this is the check that says so. */
+static void test_a_value_that_fills_the_buffer_is_refused(void)
+{
+   char owner[8];
+   reset();
+   stub_status = AIMEE_DB1_STATUS_OK;
+   stub_value = "12345678"; /* exactly sizeof owner, so the NUL would not fit */
+   assert(db1_git_ownership_get_owner("/repo", "feature", owner, sizeof owner) == -1);
+
+   /* One shorter still fits, terminator included. */
+   reset();
+   stub_status = AIMEE_DB1_STATUS_OK;
+   stub_value = "1234567";
+   assert(db1_git_ownership_get_owner("/repo", "feature", owner, sizeof owner) == 1);
+   assert(strcmp(owner, "1234567") == 0);
+   printf("  PASS: test_a_value_that_fills_the_buffer_is_refused\n");
+}
+
 int main(void)
 {
    printf("db1_git_ownership_client:\n");
@@ -245,6 +267,7 @@ int main(void)
    test_reads_report_found_missing_and_error_apart();
    test_an_unreachable_module_is_an_error_not_an_absence();
    test_a_malformed_reply_is_refused();
+   test_a_value_that_fills_the_buffer_is_refused();
    test_bad_arguments_cost_no_round_trip();
    test_a_large_field_is_carried_not_refused();
    test_every_operation_uses_its_own_op_and_arity();

--- a/src/tests/test_db1_module_stage.c
+++ b/src/tests/test_db1_module_stage.c
@@ -213,18 +213,20 @@ static void test_git_ownership_round_trips(void)
    assert(call_stage(AIMEE_DB1_STAGE_GIT_OWNERSHIP, req, len, resp, &resp_len) ==
           AIMEE_MODULE_STATUS_OK);
    assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
-   uint32_t value_len = aimee_db1_get_u32(resp + 4);
+   assert(aimee_db1_get_u32(resp + 4) == 1u); /* one value in the reply */
+   uint32_t value_len = aimee_db1_get_u32(resp + 8);
    assert(value_len == strlen("sess-abc123"));
-   assert(memcmp(resp + 8, "sess-abc123", value_len) == 0);
+   assert(memcmp(resp + 12, "sess-abc123", value_len) == 0);
 
    const char *by_session[] = {"/repo/one", "sess-abc123"};
    len = fields_frame(req, AIMEE_DB1_OP_OWNERSHIP_BRANCH_FOR_SESSION, by_session, 2);
    assert(call_stage(AIMEE_DB1_STAGE_GIT_OWNERSHIP, req, len, resp, &resp_len) ==
           AIMEE_MODULE_STATUS_OK);
    assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
-   value_len = aimee_db1_get_u32(resp + 4);
+   assert(aimee_db1_get_u32(resp + 4) == 1u);
+   value_len = aimee_db1_get_u32(resp + 8);
    assert(value_len == strlen("feature"));
-   assert(memcmp(resp + 8, "feature", value_len) == 0);
+   assert(memcmp(resp + 12, "feature", value_len) == 0);
 
    /* A row nobody wrote is MISSING, not a failure: no owner is a real answer. */
    const char *absent[] = {"/repo/one", "other"};
@@ -232,7 +234,9 @@ static void test_git_ownership_round_trips(void)
    assert(call_stage(AIMEE_DB1_STAGE_GIT_OWNERSHIP, req, len, resp, &resp_len) ==
           AIMEE_MODULE_STATUS_OK);
    assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_MISSING);
-   assert(aimee_db1_get_u32(resp + 4) == 0u);
+   /* A read answers with its value slot present and empty, not absent. */
+   assert(aimee_db1_get_u32(resp + 4) == 1u);
+   assert(aimee_db1_get_u32(resp + 8) == 0u);
 
    const char *del[] = {"/repo/one", "feature"};
    len = fields_frame(req, AIMEE_DB1_OP_OWNERSHIP_DELETE, del, 2);


### PR DESCRIPTION
Step 1 of the structured-payloads design (#2749). The reply becomes:

```
status(u32) | field_count(u32) | (len(u32) | bytes) * count
```

so an operation answering with a row — or a list of them — has somewhere to put the values. A write sends count 0, a read sends count 1; **the shape no longer changes with the arity.**

The format is renamed `db1-fields-v2` because the frame changed, and a version exists precisely to stop a format's meaning drifting under its own name. Family 1's keyed blob is a different format and did not move. The catalog's reply is now a list of fields for every operation — uniform description, even where the frames differ.

## Mutation testing found the check worth having

A reply value that **exactly fills** the caller's buffer leaves no room for the terminator. Without the length check the NUL lands one byte past the end — a **stack-buffer-overflow**, confirmed under `-fsanitize=address`, that no test covered.

It has one now, in both directions: eight bytes into an eight-byte buffer is refused; seven is accepted and readable.

## Verified
Both DB1 suites under `-fsanitize=address,leak`; the catalog and its 33 tests; the descriptor and module-doc gates; the C build; the daemon; the DB1 module through the runtime bundle; lint (59 checks).

Mutation-checked against a reply length overrunning the frame, a wrong reply count from the stage, a dropped value slot, and the removed overflow check — the first three caught, the fourth is what prompted the new test.