### PR TITLE
db1: activation is not cutover, and the survey was counting it as such

### DIFF
--- a/docs/proposals/pending/db1-wire-capability-survey.md
+++ b/docs/proposals/pending/db1-wire-capability-survey.md
@@ -206,14 +206,22 @@ passed by value is an integer, `long long *` is an out-integer the pattern
 simply missed, and `cJSON *` is a document. Three of the four were already
 reachable and were being counted as blocked.
 
-As measured on the day this section was written: **203 of 261 operations fit the
-wire, and 18 of 43 sources are ready** — against 7 of 48 when the body of this
-document was written. What remains is rows (40 operations), alloc (10), a
-per-operation status contract (6) and json (2).
+A third mistake surfaced immediately after, and it was the largest: the survey
+decided what remained by asking which families were **not active**. A family
+goes active to reserve its event kind and let its operations be declared. That
+moves no source out of the daemon — cutover does, by dropping the `.c` from
+`DB1_SRCS`. Seven sources and 23 operations across three active families were
+therefore invisible, including `checkpoints`, and including the very source
+whose client had just been generated. Remaining is now read from `DB1_SRCS`.
 
-**Rows is the next step and it is not close.** It alone takes 18 ready sources
-to 34 — 134 more operations — where alloc adds one source and status adds
-three. That is the whole argument for doing it next.
+As measured after all three corrections: **220 of 284 operations fit the wire,
+and 21 of 49 sources are ready** — against 7 of 48 when the body of this
+document was written. What remains is rows (45 operations), alloc (10), a
+per-operation status contract (6) and json (3).
+
+**Rows is the next step and it is not close.** It alone takes 21 ready sources
+to 39 — 146 more operations — where alloc and json add one source each and
+status adds three. That is the whole argument for doing it next.
 
 ## How to reproduce
 

--- a/scripts/survey_db1_wire.py
+++ b/scripts/survey_db1_wire.py
@@ -21,13 +21,18 @@ call sites, so its numbers move when any of those move -- which is the point.
 docs/proposals/pending/db1-wire-capability-survey.md records what it said on the
 day it was written; re-run this before trusting those numbers again.
 
-Two counting mistakes are deliberately designed out, because both were made:
+Three counting mistakes are deliberately designed out, because all three were
+made, and every one of them flattered the migration:
 
   * Signatures are read from the HEADERS with line joins collapsed. Reading
     definitions line by line silently drops every wrapped signature.
   * CMD_SRCS is excluded. Those files are compiled by cmd-srcs-compile-check so
     they cannot rot, but they are linked into nothing, and counting them as
     production inflates the surface by about a fifth.
+  * What remains is read from DB1_SRCS, not from which families are active. A
+    family goes active to reserve its event kind and let its operations be
+    declared; that moves no source out of the daemon. Treating activation as
+    cutover hid seven sources and 23 operations in three active families.
 """
 
 from __future__ import annotations
@@ -114,11 +119,25 @@ def compile_only_sources(root: Path) -> set[str]:
     return {s for s in declared if Path(s).name not in elsewhere}
 
 
-def reserved_sources(root: Path) -> dict[str, str]:
+def remaining_sources(root: Path) -> dict[str, str]:
+    """Sources the daemon still links, whatever their family's state.
+
+    This used to select families that were not yet active, and that was wrong
+    in the direction that flatters the migration. Activating a family reserves
+    an event kind and lets its operations be declared; it does not move a
+    single source out of the daemon. Cutover does, by dropping the .c from
+    DB1_SRCS -- which is exactly what this reads. Seven sources across three
+    ACTIVE families were invisible under the old rule, including the one whose
+    client had been generated but not yet linked.
+    """
     catalog = json.loads((root / CATALOG).read_text(encoding="utf-8"))
+    makefile = (root / MAKEFILE).read_text(encoding="utf-8")
+    block = re.search(r"^DB1_SRCS\s*[:+]?=(.*?)(?=^\w)", makefile, re.M | re.S)
+    linked = {Path(s).name for s in re.findall(r"([A-Za-z0-9_/.\-]+)\.c",
+                                               block.group(1) if block else "")}
     return {source: family["name"]
-            for family in catalog["families"] if not family["active"]
-            for source in family["sources"]}
+            for family in catalog["families"]
+            for source in family["sources"] if source in linked}
 
 
 def declarations(root: Path, families: dict[str, str]) -> dict[str, dict]:
@@ -233,7 +252,7 @@ def split_call(text: str, start: int) -> list[str] | None:
 
 
 def survey(root: Path) -> dict:
-    families = reserved_sources(root)
+    families = remaining_sources(root)
     declared = declarations(root, families)
     skip = compile_only_sources(root)
 


### PR DESCRIPTION
The survey decided what remained by asking which families were not yet active.
A family goes active to reserve its event kind and let its operations be
declared; it moves no source out of the daemon. Cutover does that, by dropping
the .c from DB1_SRCS.

So every source in an active family was counted as done. Seven were not:
checkpoints, and all six of conversation's -- including payload_rewrite_state,
whose client had been generated in the previous change but, correctly, not yet
linked. The survey was reporting the source I had just worked on as migrated.

Remaining is now read from DB1_SRCS, which is the same fact the cutover itself
turns on. 261 operations across 43 sources becomes 284 across 49, and 18 ready
sources becomes 21.

This is the third counting mistake this instrument has made and the third that
flattered the migration. All three are now designed out rather than fixed, and
the docstring says so, because the pattern is the useful part: every one was a
proxy for the thing I wanted to count rather than the thing itself.

Rows is unaffected as the next step and gets larger: alone it takes 21 ready
sources to 39, 146 operations, where alloc and json add one source each.