### PR TITLE
db1: a list is a struct repeated

### DIFF
--- a/docs/proposals/pending/db1-structured-payloads.md
+++ b/docs/proposals/pending/db1-structured-payloads.md
@@ -95,7 +95,17 @@ Three things stay outside the wire, and none of them are payload shapes:
    to the frame and the generated code marshals them at the boundary. The
    catalog carries the member list; the domain still sees its struct. No frame
    change, as predicted.
-3. **Rows.** A list is a struct repeated, once one row can cross.
+3. ~~**Rows.**~~ Done, and it was a struct repeated as predicted: the reply's
+   own value count divided by the row width is the row count, so nothing new
+   is sent. The bound travels as a request field because it is an allocation
+   on both sides, and the catalog declares a ceiling for it.
+
+   One thing this design did not anticipate: a list whose row is a *single
+   value* rather than a struct — `int64_t *out, int max`, or
+   `char (*out)[N], int max`. Same shape, width one, but the generator builds a
+   row from a declared member list and a bare scalar has no members to declare.
+   Five operations across four sources; the survey now counts it separately as
+   `column`.
 4. **Migrate**, now by whole source, since that is the unit that can move.
 
 Steps 1 and 2 are each a day's work of the kind already done twice — the integer

--- a/docs/proposals/pending/db1-wire-capability-survey.md
+++ b/docs/proposals/pending/db1-wire-capability-survey.md
@@ -223,6 +223,14 @@ per-operation status contract (6) and json (3).
 to 39 — 146 more operations — where alloc and json add one source each and
 status adds three. That is the whole argument for doing it next.
 
+Rows then shipped, and the measurement above held: **260 of 284 operations fit
+the wire and 35 of 49 sources are ready**, with `agent_work` and `delegation`
+complete. What is left is small and independent — `alloc` (10 operations),
+`status` (6), `column` (5) and `json` (3). None of them unlocks more than four
+sources, and all four together unlock fourteen.
+
+The migration is no longer waiting on the wire. It is waiting on cutovers.
+
 ## How to reproduce
 
 `scripts/survey_db1_wire.py` produces every number above. It is a measurement,

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -35,8 +35,12 @@ MAKEFILE = Path("src/Makefile")
 SOURCE_DIR = Path("src/modules/db1")
 CLIENT_DIR = Path("src/db1_client")
 STAGES_HEADER = Path("src/modules/db1/db1_stages.h")
-# Served by the module process alone; the daemon never links it.
-MODULE_ONLY_SOURCES = frozenset({"module_adapter.c"})
+# Served by the module process alone; the daemon never links these, and their
+# absence from DB1_SRCS is the design rather than evidence of a migration.
+# db1_time.c supplies now_utc, which every process defines for itself -- the
+# daemon from util.c. In DB1_SRCS it would be a duplicate symbol there; out of
+# the module it is an undefined one here.
+MODULE_ONLY_SOURCES = frozenset({"module_adapter.c", "db1_time.c"})
 
 # DB1's principal ref. Event kinds are carved 4096 + ref*256 + stage, and a
 # family's id IS its future stage id, so the arithmetic is fixed here too.
@@ -198,7 +202,9 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
             reply_shape = operation["reply"]
             request_shape = operation["request"]
             inbound = 1 if "struct" in request_shape else len(request_shape["fields"])
-            if "struct" in reply_shape:
+            if "list" in reply_shape:
+                outbound = 1                      # T *out, however wide the rows
+            elif "struct" in reply_shape:
                 outbound = 1                      # T *out
             elif reply_shape["fields"]:
                 outbound = 2                      # char *buf, size_t cap
@@ -306,9 +312,41 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
         reply_keys = {"fields", "max_bytes"}
         if "struct" in operation["reply"]:
             reply_keys = reply_keys | {"struct"}
+        if "list" in operation["reply"]:
+            reply_keys = reply_keys | {"list"}
         reply = keys(operation["reply"], reply_keys, f"{name}.reply")
         if "struct" in reply and not re.fullmatch(r"[a-z][a-z0-9_]*_t", str(reply["struct"])):
             fail("reply-struct", f"{name} reply struct must be a _t type name")
+        if "list" in reply:
+            # A list is a struct repeated, so it says which C parameter receives
+            # the rows, which one bounds them, and how many the stage will build.
+            # The bound is the caller's, and it is also the allocation: a stage
+            # that trusted it would let a caller ask for an arbitrary array.
+            listed = keys(reply["list"], {"out", "bound", "max_rows"}, f"{name}.reply.list")
+            if "struct" not in reply:
+                fail("reply-list", f"{name} declares a list but no row struct")
+            if "c_params" not in operation:
+                fail("reply-list", f"{name} declares a list but names no C parameters")
+            params = list(operation["c_params"])
+            if str(listed["out"]) not in params:
+                fail("reply-list", f"{name} list out {listed['out']!r} is not a C parameter")
+            if str(listed["bound"]) not in params:
+                fail("reply-list", f"{name} list bound {listed['bound']!r} is not a C parameter")
+            if listed["out"] == listed["bound"]:
+                fail("reply-list", f"{name} list out and bound must differ")
+            # The remaining parameters map onto the request fields in order, so
+            # the bound's position tells us which field must be the integer.
+            inputs = [p for p in params if p != listed["out"]]
+            if len(inputs) != len(raw_fields):
+                fail("reply-list",
+                     f"{name} has {len(inputs)} input parameters but {len(raw_fields)} "
+                     f"request fields")
+            at = inputs.index(str(listed["bound"]))
+            if str(raw_fields[at]["type"]) != "int":
+                fail("reply-list",
+                     f"{name} list bound {listed['bound']!r} maps to request field "
+                     f"{raw_fields[at]['name']!r}, which must be an int")
+            integer(listed["max_rows"], f"{name}.reply.list.max_rows", 1, 4096)
         reply_fields = reply["fields"]
         if not isinstance(reply_fields, list):
             fail("reply-fields", f"{name} reply fields must be an array")
@@ -738,10 +776,17 @@ static void encode(uint8_t *out, uint32_t op, const char *const *fields, uint32_
 /* Returns the module's status, or -1 when the call never produced one. */
 /* Fills up to `slots` reply values, each into the buffer and capacity the
    caller supplied. A write passes none; a read passes one; a row passes one per
-   member. */
+   member; a list passes one per member per row it is willing to accept.
+
+   `filled_out` reports how many values the reply actually carried, which is how
+   a list learns its length: the rows are not counted separately on the wire
+   because an operation already knows how wide its rows are. Callers that expect
+   a fixed shape pass NULL. */
 static int call_stage(uint32_t op, const char *const *fields, uint32_t count, char *const *values,
-                      const size_t *caps, uint32_t slots)
+                      const size_t *caps, uint32_t slots, uint32_t *filled_out)
 {{
+   if (filled_out)
+      *filled_out = 0u;
    for (uint32_t i = 0; i < slots; ++i)
       if (values[i] && caps[i])
          values[i][0] = '\\0';
@@ -790,6 +835,13 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
          no values is how a write answers, one value is a read, and a member
          apiece is a row. */
       result = (int)status;
+      /* More values than the caller has room for is a contract mismatch, not
+         something to read the first few of: the caller asked for at most this
+         many rows, and a stage answering with more is not answering this call. */
+      if (fields_in > slots)
+         result = -1;
+      else if (filled_out)
+         *filled_out = fields_in;
       uint32_t at = 8u;
       for (uint32_t i = 0; i < fields_in && result != -1; ++i)
       {{
@@ -896,8 +948,18 @@ static int read_result(int status, const char *value_out)
         names = [str(n) for n in operation["c_params"]]
         in_struct = str(request["struct"]) if "struct" in request else ""
         out_struct = str(reply["struct"]) if "struct" in reply else ""
-        split = 1 if in_struct else len(fields)
-        inputs, outputs = names[:split], names[split:]
+        listed = reply.get("list")
+        if listed:
+            # The rows parameter can sit anywhere in the signature -- some
+            # domains put it first -- so the C order is read from c_params and
+            # only the remaining parameters map onto the fields, in order.
+            row_out = str(listed["out"])
+            bound = str(listed["bound"])
+            inputs = [p for p in names if p != row_out]
+            outputs = [row_out]
+        else:
+            split = 1 if in_struct else len(fields)
+            inputs, outputs = names[:split], names[split:]
 
         if in_struct:
             # The struct is the argument; its members are the frame.
@@ -910,7 +972,14 @@ static int read_result(int status, const char *value_out)
             # guarded -- and only where the operation says it must be there.
             guards = [f"!{p} || !{p}[0]" for p, t, need in zip(inputs, types, required)
                       if t == "text" and need]
-        if out_struct:
+        if listed:
+            # Re-order to the C signature: the declarations above are in field
+            # order, which is the same order minus the rows parameter.
+            declared = dict(zip(inputs, params))
+            declared[row_out] = f"{out_struct} *{row_out}"
+            params = [declared[p] for p in names]
+            guards += [f"!{row_out}", f"{bound} <= 0"]
+        elif out_struct:
             params += [f"{out_struct} *{outputs[0]}"]
             guards += [f"!{outputs[0]}"]
         elif reads:
@@ -920,6 +989,15 @@ static int read_result(int status, const char *value_out)
         body = [signature, "{"]
         if guards:
             body += [f"   if ({' || '.join(guards)})", "      return -1;"]
+        if listed:
+            # Clamped rather than refused, because the domain clamps too: this
+            # ceiling is the one the implementation already enforces, so a
+            # caller asking for more has always been given fewer. Refusing here
+            # would break a caller whose array is simply larger than the query
+            # can fill. The clamp precedes the frame so the stage is told the
+            # bound it will actually honour.
+            body += [f"   if ({bound} > {listed['max_rows']})",
+                     f"      {bound} = {listed['max_rows']};"]
         # Integers travel as decimal text: the frame carries counted bytes, and a
         # separate numeric type on the wire would buy nothing a printf does not.
         carried = []
@@ -942,7 +1020,65 @@ static int read_result(int status, const char *value_out)
         body.append(f"   const char *fields[] = {{{', '.join(carried)}}};")
         op_symbol = f"AIMEE_DB1_OP_{str(operation['name']).upper()}"
         arity = len(fields)
-        if out_struct:
+        if listed:
+            members = [(str(f["name"]), str(f["type"])) for f in reply["fields"]]
+            width = len(members)
+            numeric = [i for i, (_, k) in enumerate(members) if k in ("int", "int64")]
+            body.append(f"   char **values = malloc((size_t){bound} * {width}u * sizeof *values);")
+            body.append(f"   size_t *caps = malloc((size_t){bound} * {width}u * sizeof *caps);")
+            if numeric:
+                body.append(f"   char (*scratch)[24] = malloc((size_t){bound} * {len(numeric)}u * "
+                            "sizeof *scratch);")
+            owned = "values, caps" + (", scratch" if numeric else "")
+            checks = " || ".join(f"!{o}" for o in owned.split(", "))
+            body.append(f"   if ({checks})")
+            body.append("   {")
+            for item in owned.split(", "):
+                body.append(f"      free({item});")
+            body.append("      return -1;")
+            body.append("   }")
+            body.append(f"   memset({row_out}, 0, (size_t){bound} * sizeof *{row_out});")
+            body.append(f"   for (int row = 0; row < {bound}; ++row)")
+            body.append("   {")
+            slot = 0
+            for index, (member, kind) in enumerate(members):
+                at = f"row * {width}u + {index}u"
+                if kind in ("int", "int64"):
+                    cell = f"scratch[row * {len(numeric)}u + {slot}u]"
+                    body.append(f"      values[{at}] = {cell};")
+                    body.append(f"      caps[{at}] = sizeof {cell};")
+                    slot += 1
+                else:
+                    body.append(f"      values[{at}] = {row_out}[row].{member};")
+                    body.append(f"      caps[{at}] = sizeof {row_out}[row].{member};")
+            body.append("   }")
+            body.append("   uint32_t filled = 0;")
+            body.append(f"   int status = call_stage({op_symbol}, fields, {arity}, values, caps,")
+            body.append(f"                           (uint32_t)({bound} * {width}), &filled);")
+            body.append("   free(values);")
+            body.append("   free(caps);")
+            fail_free = "".join(f"\n      free({o});" for o in (["scratch"] if numeric else []))
+            # A reply that is not a whole number of rows is not this operation's
+            # reply, whatever its status says.
+            body.append(f"   if (status != (int)AIMEE_DB1_STATUS_OK || filled % {width}u != 0u)")
+            body.append("   {" + fail_free)
+            body.append("      return -1;")
+            body.append("   }")
+            body.append(f"   int rows = (int)(filled / {width}u);")
+            if numeric:
+                body.append("   for (int row = 0; row < rows; ++row)")
+                body.append("   {")
+                slot = 0
+                for member, kind in members:
+                    if kind in ("int", "int64"):
+                        cell = f"scratch[row * {len(numeric)}u + {slot}u]"
+                        conv = ("(int)strtol" if kind == "int" else "(int64_t)strtoll")
+                        body.append(f"      {row_out}[row].{member} = {conv}({cell}, NULL, 10);")
+                        slot += 1
+                body.append("   }")
+                body.append("   free(scratch);")
+            body.append("   return rows;")
+        elif out_struct:
             members = [(str(f["name"]), str(f["type"])) for f in reply["fields"]]
             target = outputs[0]
             # A numeric member is read as text and converted, the same way it was
@@ -961,7 +1097,7 @@ static int read_result(int status, const char *value_out)
             body.append(f"   const size_t caps[] = {{{caps}}};")
             body.append(f"   memset({target}, 0, sizeof *{target});")
             body.append(f"   int status = call_stage({op_symbol}, fields, {arity}, values, caps, "
-                        f"{len(members)});")
+                        f"{len(members)}, NULL);")
             # The domain answers 0 or -1 here: a miss and a failure are the
             # same answer to its callers, and the wire does not invent a
             # distinction the contract never had.
@@ -976,11 +1112,11 @@ static int read_result(int status, const char *value_out)
         elif reads:
             body.append(f"   char *const values[] = {{{outputs[0]}}};")
             body.append(f"   const size_t caps[] = {{{outputs[1]}}};")
-            body.append(f"   int status = call_stage({op_symbol}, fields, {arity}, values, caps, 1);")
+            body.append(f"   int status = call_stage({op_symbol}, fields, {arity}, values, caps, 1, NULL);")
             body.append(f"   return read_result(status, {outputs[0]});")
         else:
             body.append(f"   return write_result(call_stage({op_symbol}, fields, {arity}, "
-                        f"NULL, NULL, 0));")
+                        f"NULL, NULL, 0, NULL));")
         body.append("}")
         out.append("\n" + "\n".join(body) + "\n")
     out.append("\n/* clang-format on */\n")
@@ -1132,9 +1268,20 @@ aimee_module_status_t aimee_db1_stage_{stem}(const uint8_t *request_body, uint32
    value[0] = '\\0';
    int rc = -1;
    int reads = 0;
-   /* A row answers with a value per member; a plain read answers with one. */
+   /* A row answers with a value per member; a plain read answers with one; a
+      list answers with a value per member per row. */
    const char *const *rows = NULL;
    uint32_t row_count = 0u;
+   /* A list returns its length in rc, where a read returns found/not-found, so
+      the two cannot share a status mapping. The three owned blocks below hold
+      the domain's rows, the cell pointers into them and the text for numeric
+      members: all three must outlive write_reply, because that is what reads
+      them. Declared unconditionally so this stays one readable flow -- unlike
+      the static helpers above, an unused local costs nothing. */
+   int listed = 0;
+   void *domain_rows = NULL;
+   void *cells_owned = NULL;
+   void *numeric_owned = NULL;
 
    switch (op)
    {{
@@ -1149,7 +1296,12 @@ aimee_module_status_t aimee_db1_stage_{stem}(const uint8_t *request_body, uint32
       onto MISSING would report a broken store as "nothing recorded", and the
       caller would act on an absence that was never established. */
    uint32_t status;
-   if (rows)
+   if (listed)
+      /* A list answers with how many rows it found, so any count is success and
+         only a negative return is a failure. Zero rows is an empty list, not a
+         miss: the caller asked what was there and the answer was nothing. */
+      status = (rc >= 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
+   else if (rows)
       /* A row-returning domain answers 0 or -1: there is no found/not-found
          distinction to preserve, so neither is invented. */
       status = (rc == 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
@@ -1174,6 +1326,9 @@ aimee_module_status_t aimee_db1_stage_{stem}(const uint8_t *request_body, uint32
          out_count = 0u; /* nothing to report but the status */
       write_reply(response_body, response_capacity, response_len, status, out_values, out_count);
    }}
+   free(cells_owned);
+   free(numeric_owned);
+   free(domain_rows);
    return AIMEE_MODULE_STATUS_OK;
 }}
 /* clang-format on */
@@ -1265,7 +1420,76 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]],
                 else:
                     args.append(f"field[{position}]")
 
-        if out_struct:
+        listed = reply.get("list")
+        if listed:
+            members = [(str(f["name"]), str(f["type"])) for f in reply["fields"]]
+            width = len(members)
+            numeric = [i for i, (_, k) in enumerate(members) if k in ("int", "int64")]
+            row_out = str(listed["out"])
+            bound = str(listed["bound"])
+            inputs = [p for p in operation["c_params"] if p != row_out]
+            at = inputs.index(bound)
+            held = args[at]
+            # The bound is the allocation, so it is checked against the ceiling
+            # the catalog declares before anything is allocated from it. A stage
+            # that took the caller's word would size an array from the wire.
+            parse.append(f"      if ({held} <= 0 || {held} > {listed['max_rows']})\n"
+                         f"      {{\n         free(scratch);\n"
+                         f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n      }}\n")
+            parse.append(f"      {out_struct} *found = calloc((size_t){held}, sizeof *found);\n"
+                         f"      if (!found)\n"
+                         f"      {{\n         free(scratch);\n"
+                         f"         return AIMEE_MODULE_STATUS_INTERNAL;\n      }}\n"
+                         f"      domain_rows = found;\n")
+            ordered = dict(zip(inputs, args))
+            ordered[row_out] = "found"
+            args = [ordered[p] for p in operation["c_params"]]
+            assigns = "".join(
+                f"            cells[row * {width}u + {i}u] = "
+                + (f"numbers[row * {len(numeric)}u + {numeric.index(i)}u];\n"
+                   if kind in ("int", "int64") else f"found[row].{member};\n")
+                for i, (member, kind) in enumerate(members))
+            converts = "".join(
+                f"            snprintf(numbers[row * {len(numeric)}u + {numeric.index(i)}u], 24,\n"
+                f"                     \"{'%lld' if kind == 'int64' else '%d'}\", "
+                f"{'(long long)' if kind == 'int64' else ''}found[row].{member});\n"
+                for i, (member, kind) in enumerate(members) if kind in ("int", "int64"))
+            numbers = (f"         char (*numbers)[24] = malloc((size_t)produced * "
+                       f"{len(numeric)}u * sizeof *numbers);\n" if numeric else "")
+            guard = "!cells" + (" || !numbers" if numeric else "")
+            release = "            free(cells);\n" + ("            free(numbers);\n" if numeric else "")
+            tail.append(
+                "      if (rc > 0)\n"
+                "      {\n"
+                # A domain that answered with more rows than it was given would
+                # otherwise be read past the end of its own array. No test kills
+                # a mutant here and none can from outside: it guards against the
+                # domain breaking its own contract, which the real domain does
+                # not do. Kept because the failure it prevents is a heap
+                # over-read, and the cost is one comparison.
+                f"         uint32_t produced = ((uint32_t)rc < (uint32_t){held})\n"
+                f"                                 ? (uint32_t)rc : (uint32_t){held};\n"
+                f"         const char **cells = malloc((size_t)produced * {width}u * sizeof *cells);\n"
+                + numbers
+                + f"         if ({guard})\n"
+                "         {\n"
+                + release
+                + "            free(scratch);\n"
+                "            free(domain_rows);\n"
+                "            return AIMEE_MODULE_STATUS_INTERNAL;\n"
+                "         }\n"
+                "         cells_owned = cells;\n"
+                + ("         numeric_owned = numbers;\n" if numeric else "")
+                + "         for (uint32_t row = 0; row < produced; ++row)\n"
+                "         {\n"
+                + converts
+                + assigns
+                + "         }\n"
+                "         rows = cells;\n"
+                f"         row_count = produced * {width}u;\n"
+                "      }\n"
+                "      listed = 1;\n")
+        elif out_struct:
             members = [(str(f["name"]), str(f["type"])) for f in reply["fields"]]
             parse.append(f"      {out_struct} out;\n      memset(&out, 0, sizeof out);\n")
             args.append("&out")
@@ -1293,7 +1517,11 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]],
                 + "".join(parse)
                 + f"      rc = {operation['c_name']}({', '.join(args)});\n"
                 + "".join(tail)
-                + ("      reads = 1;\n" if reads else "")
+                # Not for a list: it declares member fields like a row does, but
+                # an empty list must answer with no values, where a read answers
+                # with one. Setting this would turn "nothing found" into a
+                # single empty string.
+                + ("      reads = 1;\n" if reads and not listed else "")
                 + "      break;\n")
         head = f"   case AIMEE_DB1_OP_{str(operation['name']).upper()}:\n"
         needs = "".join(
@@ -1417,6 +1645,31 @@ def validate_process_contract(root: Path, catalog: dict[str, object]) -> None:
                  f"stage {name!r} must carry id {family['id']} and kind {family['event_kind']}")
 
 
+def validate_dispatch(root: Path, catalog: dict[str, object]) -> None:
+    """Every active family's stage must be reachable from the adapter.
+
+    The generator writes the stage; the adapter's switch is hand-written,
+    because the first family answers a different wire format and is served by a
+    hand-written handler. Nothing connected the two, so activating a family
+    produced a stage that compiled, linked, passed its own tests and could not
+    be called: the runtime invoked the stage id and the switch fell through to
+    its default. That is what happened to conversation, and it went unnoticed
+    because a family with no dispatched stage looks exactly like a family whose
+    callers have not cut over yet.
+    """
+    adapter = (root / "src/modules/db1/module_adapter.c").read_text(encoding="utf-8")
+    families = catalog["families"]
+    assert isinstance(families, dict)
+    for family in families.values():
+        if not family["active"]:
+            continue
+        label = f"case AIMEE_DB1_STAGE_{str(family['name']).upper()}:"
+        if label not in adapter:
+            fail("stage-undispatched",
+                 f"module_adapter.c has no {label} -- an active family whose stage "
+                 f"nothing routes to is a stage no caller can reach")
+
+
 def run(root: Path, write: bool = False) -> None:
     catalog = validate_catalog(load_json(root / CATALOG))
     if write:
@@ -1424,6 +1677,7 @@ def run(root: Path, write: bool = False) -> None:
     validate_header(root, catalog)
     validate_clients(root, catalog, write)
     validate_stages(root, catalog, write)
+    validate_dispatch(root, catalog)
     validate_process_contract(root, catalog)
     validate_source_map(root, catalog)
     validate_coupled_sources(catalog)

--- a/scripts/survey_db1_wire.py
+++ b/scripts/survey_db1_wire.py
@@ -8,8 +8,8 @@ The T0..T3 ladder this script used to print has been retired, because three of
 its four rungs shipped: integer arguments, the counted reply (which carried
 multi-value replies and zero-argument requests with it), and struct flattening.
 A ladder also modelled the remainder as if each rung sat on the one below, and
-it does not -- rows and callee-allocated out-parameters are independent, and
-neither waits on the other.
+it does not -- a callee-allocated out-parameter and a richer return contract
+are independent, and neither waits on the other.
 
 What replaced it is a SET of missing capabilities per operation, unioned per
 source. That matches how migration actually works: the unit that moves is a
@@ -71,7 +71,9 @@ CAP = re.compile(r"size_t \w+$")
 OUT_NUM = re.compile(r"(int|int64_t|double|size_t|long|long long"
                      r"|unsigned long long) \s*\*\s*\w+$")
 STRUCT_IN = re.compile(r"const [a-z_0-9]+_t \s*\*\s*\w+$")
-STRUCT_OUT = re.compile(r"[a-z_0-9]+_t \s*\*\s*\w+$")
+STRUCT_OUT = re.compile(r"([a-z_0-9]+_t) \s*\*\s*\w+$")
+# Types whose "_t" is a scalar rather than a row.
+SCALAR_TYPES = frozenset({"int64_t", "uint64_t", "int32_t", "size_t", "time_t"})
 ARRAY_LEN = re.compile(r"(int|size_t) (max|n|count|cap|limit)\w*$")
 # A callee-allocated out-parameter: the double star is the whole tell, and it is
 # why these fall through STRUCT_OUT/OUT_TEXT, whose \w+$ cannot match a second *.
@@ -83,14 +85,18 @@ LARGE = re.compile(r"(json|metadata|content|prompt|body|payload|text|summary|blo
 # What a tag still needs from the wire. A tag absent from this map needs
 # nothing: text, int, out_text, out_num, struct_in and struct_out all cross
 # today, the last two since struct flattening.
+# Rows of a struct cross today. Rows of a single value do not: the generator
+# builds a row out of a declared member list, and a bare int64_t or a
+# char (*)[N] has no members to declare. Same shape, width one -- but it is
+# generator work that has not been done, so it is counted as missing.
 NEEDS = {
-    "out_array": "rows",
+    "out_column": "column",
     "alloc_out": "alloc",
     "json_in": "json",
     "other": "unknown",
 }
 CAPABILITY = {
-    "rows": "rows -- a list of rows, which is a struct repeated",
+    "column": "column -- a list whose row is one value rather than a struct",
     "alloc": "alloc -- a callee-allocated out-parameter (generator, not frame)",
     "json": "json -- a cJSON tree, which the wire carries but the client must build",
     "status": "status -- a return contract beyond ok/miss/fail, per operation",
@@ -184,15 +190,18 @@ def classify(params: str, enums: frozenset[str] = frozenset()) -> list[str]:
             index += 2
             continue
         if following and STRUCT_OUT.search(current) and ARRAY_LEN.search(following):
-            tags.append("out_array")
+            # int64_t matches the _t pattern too, so a column of integers would
+            # otherwise be counted as a struct it has no members for.
+            row = STRUCT_OUT.search(current).group(1)
+            tags.append("out_column" if row in SCALAR_TYPES else "out_rows")
             index += 2
             continue
         if following and OUT_TEXT_ROWS.search(current) and ARRAY_LEN.search(following):
-            tags.append("out_array")
+            tags.append("out_column")
             index += 2
             continue
         if OUT_TEXT_ROWS.search(current):
-            tags.append("out_array")
+            tags.append("out_column")
         elif JSON_IN.search(current):
             tags.append("json_in")
         elif ALLOC_OUT.search(current):
@@ -366,7 +375,7 @@ def report(operations: dict) -> None:
             continue
         print(f"    + {need:9} {len(gained):>2} more sources"
               f"   {sum(source_ops[s] for s in gained):>3} operations")
-    for combo in ("rows alloc", "rows alloc json status"):
+    for combo in ("column alloc", "column alloc json status"):
         allowed = set(combo.split())
         gained = [s for s, n in per_source.items() if n and n <= allowed]
         print(f"    + {combo:17} {len(gained):>2} more sources"

--- a/scripts/tests/test_gen_db1_contract.py
+++ b/scripts/tests/test_gen_db1_contract.py
@@ -53,6 +53,10 @@ def sandbox() -> tempfile.TemporaryDirectory[str]:
     for generated in list((REPO_ROOT / contract.SOURCE_DIR).glob("*_stage.c")) + \
             [REPO_ROOT / contract.STAGES_HEADER]:
         shutil.copy2(generated, root / contract.SOURCE_DIR / generated.name)
+    # The adapter is real content too: it is where the dispatch rule reads which
+    # stages are actually routed, and an empty file reads as none of them.
+    shutil.copy2(REPO_ROOT / contract.SOURCE_DIR / "module_adapter.c",
+                 root / contract.SOURCE_DIR / "module_adapter.c")
     return tmp
 
 
@@ -75,6 +79,21 @@ class CatalogTests(unittest.TestCase):
             if not family["active"]:
                 return family
         self.skipTest("no reserved family remains to exercise")
+
+    def route(self, root: Path, family: dict) -> None:
+        """Route a newly activated family's stage in the sandbox adapter.
+
+        Activating a family in the catalog is only half of it: the adapter's
+        switch is what makes the stage reachable, and the dispatch rule holds
+        the two together. These tests activate a family to exercise something
+        else, so they have to do the other half too.
+        """
+        adapter = root / contract.SOURCE_DIR / "module_adapter.c"
+        label = f"case AIMEE_DB1_STAGE_{family['name'].upper()}:"
+        adapter.write_text(
+            adapter.read_text(encoding="utf-8").replace(
+                "   default:", f"   {label}\n      break;\n   default:", 1),
+            encoding="utf-8")
 
     def assertRule(self, root: Path, rule: str) -> None:
         with self.assertRaises(contract.ContractError) as caught:
@@ -287,6 +306,7 @@ class CatalogTests(unittest.TestCase):
             catalog = self.catalog(root)
             reserved = self.reserved(catalog)
             reserved["active"] = True
+            self.route(root, reserved)
             catalog["operations"].append({
                 "family": reserved["name"], "id": 1, "name": "probe_touch",
                 "wire_format": "db1-fields-v2", "scope": "session",
@@ -402,6 +422,7 @@ class CatalogTests(unittest.TestCase):
         catalog = self.catalog(root)
         reserved = self.reserved(catalog)
         reserved["active"] = True
+        self.route(root, reserved)
         catalog["operations"].append({
             "family": reserved["name"], "id": 1, "name": "probe_forget_if_job",
             "c_name": "db1_probe_forget_if_job", "c_params": ["probe_id", "job_id"],
@@ -483,6 +504,7 @@ class CatalogTests(unittest.TestCase):
         catalog = self.catalog(root)
         reserved = self.reserved(catalog)
         reserved["active"] = True
+        self.route(root, reserved)
         catalog["operations"].append({
             "family": reserved["name"], "id": 1, "name": "probe_status_set",
             "c_name": "db1_probe_status_set",
@@ -622,6 +644,93 @@ class CatalogTests(unittest.TestCase):
         for family in catalog["families"]:
             self.assertTrue(family["covers"].strip(),
                             f"{family['name']} reserves a kind but names no sources")
+
+
+    def test_an_active_family_must_have_its_stage_dispatched(self) -> None:
+        # A generated stage that nothing routes to compiles, links and passes
+        # its own tests while being unreachable. That is what happened to the
+        # conversation family: the adapter's switch is hand-written, because the
+        # first family answers a different wire format, and nothing tied the two
+        # together until this rule.
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            adapter = root / contract.SOURCE_DIR / "module_adapter.c"
+            adapter.write_text(
+                adapter.read_text(encoding="utf-8").replace(
+                    "case AIMEE_DB1_STAGE_CONVERSATION:", "case 999999:"),
+                encoding="utf-8")
+            self.assertRule(root, "stage-undispatched")
+        finally:
+            tmp.cleanup()
+
+    def listing(self, catalog: dict) -> dict:
+        for operation in catalog["operations"]:
+            if "list" in operation["reply"]:
+                return operation
+        self.skipTest("no list operation to exercise")
+
+    def test_a_list_names_the_parameter_that_receives_the_rows(self) -> None:
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.catalog(root)
+            self.listing(catalog)["reply"]["list"]["out"] = "not_a_parameter"
+            self.write(root, catalog)
+            self.assertRule(root, "reply-list")
+        finally:
+            tmp.cleanup()
+
+    def test_a_list_bound_must_be_an_integer_field(self) -> None:
+        # The bound is the allocation on both sides. Pointing it at a text field
+        # would make the stage size an array from a string.
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.catalog(root)
+            operation = self.listing(catalog)
+            operation["reply"]["list"]["bound"] = operation["c_params"][0]
+            self.write(root, catalog)
+            self.assertRule(root, "reply-list")
+        finally:
+            tmp.cleanup()
+
+    def test_a_list_ceiling_is_bounded(self) -> None:
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.catalog(root)
+            self.listing(catalog)["reply"]["list"]["max_rows"] = 1 << 20
+            self.write(root, catalog)
+            self.assertRule(root, "integer")
+        finally:
+            tmp.cleanup()
+
+    def test_a_list_must_declare_the_row_it_repeats(self) -> None:
+        # A list is a struct repeated. Without the struct there is no row type
+        # to write the members back into.
+        tmp = sandbox()
+        try:
+            root = Path(tmp.name)
+            catalog = self.catalog(root)
+            del self.listing(catalog)["reply"]["struct"]
+            self.write(root, catalog)
+            self.assertRule(root, "reply-list")
+        finally:
+            tmp.cleanup()
+
+    def test_the_generated_list_client_divides_the_reply_by_the_row_width(self) -> None:
+        # The width is never sent: an operation knows how wide its rows are, so
+        # the reply's own value count is what carries the length.
+        client = (REPO_ROOT / contract.CLIENT_DIR / "conversation.c").read_text(encoding="utf-8")
+        self.assertIn("int rows = (int)(filled / 8u);", client)
+        self.assertIn("filled % 8u != 0u", client)
+
+    def test_the_generated_list_stage_bounds_what_it_allocates(self) -> None:
+        stage = (REPO_ROOT / contract.SOURCE_DIR / "conversation_stage.c").read_text(
+            encoding="utf-8")
+        self.assertIn("if (parsed2 <= 0 || parsed2 > 64)", stage)
+        self.assertIn("calloc((size_t)parsed2, sizeof *found)", stage)
 
 
 if __name__ == "__main__":

--- a/src/db1_client/conversation.c
+++ b/src/db1_client/conversation.c
@@ -17,6 +17,7 @@
  * catalog permanently one reformat apart. */
 /* clang-format off */
 #include "payload_rewrite_state.h"
+#include "wm.h"
 
 #include "db1_module_api.h"
 
@@ -96,10 +97,17 @@ static void encode(uint8_t *out, uint32_t op, const char *const *fields, uint32_
 /* Returns the module's status, or -1 when the call never produced one. */
 /* Fills up to `slots` reply values, each into the buffer and capacity the
    caller supplied. A write passes none; a read passes one; a row passes one per
-   member. */
+   member; a list passes one per member per row it is willing to accept.
+
+   `filled_out` reports how many values the reply actually carried, which is how
+   a list learns its length: the rows are not counted separately on the wire
+   because an operation already knows how wide its rows are. Callers that expect
+   a fixed shape pass NULL. */
 static int call_stage(uint32_t op, const char *const *fields, uint32_t count, char *const *values,
-                      const size_t *caps, uint32_t slots)
+                      const size_t *caps, uint32_t slots, uint32_t *filled_out)
 {
+   if (filled_out)
+      *filled_out = 0u;
    for (uint32_t i = 0; i < slots; ++i)
       if (values[i] && caps[i])
          values[i][0] = '\0';
@@ -148,6 +156,13 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
          no values is how a write answers, one value is a read, and a member
          apiece is a row. */
       result = (int)status;
+      /* More values than the caller has room for is a contract mismatch, not
+         something to read the first few of: the caller asked for at most this
+         many rows, and a stage answering with more is not answering this call. */
+      if (fields_in > slots)
+         result = -1;
+      else if (filled_out)
+         *filled_out = fields_in;
       uint32_t at = 8u;
       for (uint32_t i = 0; i < fields_in && result != -1; ++i)
       {
@@ -205,7 +220,7 @@ int db1_payload_rewrite_state_get(const char *session_id, payload_rewrite_state_
    char *const values[] = {out->session_id, slot1, slot2, out->last_prefix_hash, slot4, out->last_rewrite_at, slot6, slot7, slot8, out->rewrite_reason, out->updated_at};
    const size_t caps[] = {sizeof out->session_id, sizeof slot1, sizeof slot2, sizeof out->last_prefix_hash, sizeof slot4, sizeof out->last_rewrite_at, sizeof slot6, sizeof slot7, sizeof slot8, sizeof out->rewrite_reason, sizeof out->updated_at};
    memset(out, 0, sizeof *out);
-   int status = call_stage(AIMEE_DB1_OP_REWRITE_STATE_GET, fields, 1, values, caps, 11);
+   int status = call_stage(AIMEE_DB1_OP_REWRITE_STATE_GET, fields, 1, values, caps, 11, NULL);
    if (status != (int)AIMEE_DB1_STATUS_OK)
       return -1;
    out->payload_epoch = (int64_t)strtoll(slot1, NULL, 10);
@@ -234,7 +249,91 @@ int db1_payload_rewrite_state_set(const payload_rewrite_state_t *state)
    char arg8[24];
    snprintf(arg8, sizeof arg8, "%d", state->bytes_saved_pending);
    const char *fields[] = {state->session_id, arg1, arg2, state->last_prefix_hash, arg4, state->last_rewrite_at, arg6, arg7, arg8, state->rewrite_reason, state->updated_at};
-   return write_result(call_stage(AIMEE_DB1_OP_REWRITE_STATE_SET, fields, 11, NULL, NULL, 0));
+   return write_result(call_stage(AIMEE_DB1_OP_REWRITE_STATE_SET, fields, 11, NULL, NULL, 0, NULL));
+}
+
+int db1_wm_set(const char *session_id, const char *key, const char *value, const char *category, int ttl_seconds)
+{
+   if (!session_id || !session_id[0] || !key || !key[0] || !value || !value[0])
+      return -1;
+   char arg4[24];
+   snprintf(arg4, sizeof arg4, "%d", ttl_seconds);
+   const char *fields[] = {session_id, key, value, category ? category : "", arg4};
+   return write_result(call_stage(AIMEE_DB1_OP_WM_SET, fields, 5, NULL, NULL, 0, NULL));
+}
+
+int db1_wm_get(const char *session_id, const char *key, wm_entry_t *out)
+{
+   if (!session_id || !session_id[0] || !key || !key[0] || !out)
+      return -1;
+   const char *fields[] = {session_id, key};
+   char slot0[24];
+   char *const values[] = {slot0, out->session_id, out->key, out->value, out->category, out->created_at, out->updated_at, out->expires_at};
+   const size_t caps[] = {sizeof slot0, sizeof out->session_id, sizeof out->key, sizeof out->value, sizeof out->category, sizeof out->created_at, sizeof out->updated_at, sizeof out->expires_at};
+   memset(out, 0, sizeof *out);
+   int status = call_stage(AIMEE_DB1_OP_WM_GET, fields, 2, values, caps, 8, NULL);
+   if (status != (int)AIMEE_DB1_STATUS_OK)
+      return -1;
+   out->id = (int64_t)strtoll(slot0, NULL, 10);
+   return 0;
+}
+
+int db1_wm_list(const char *session_id, const char *category, wm_entry_t *out, int max)
+{
+   if (!session_id || !session_id[0] || !out || max <= 0)
+      return -1;
+   if (max > 64)
+      max = 64;
+   char arg2[24];
+   snprintf(arg2, sizeof arg2, "%d", max);
+   const char *fields[] = {session_id, category ? category : "", arg2};
+   char **values = malloc((size_t)max * 8u * sizeof *values);
+   size_t *caps = malloc((size_t)max * 8u * sizeof *caps);
+   char (*scratch)[24] = malloc((size_t)max * 1u * sizeof *scratch);
+   if (!values || !caps || !scratch)
+   {
+      free(values);
+      free(caps);
+      free(scratch);
+      return -1;
+   }
+   memset(out, 0, (size_t)max * sizeof *out);
+   for (int row = 0; row < max; ++row)
+   {
+      values[row * 8u + 0u] = scratch[row * 1u + 0u];
+      caps[row * 8u + 0u] = sizeof scratch[row * 1u + 0u];
+      values[row * 8u + 1u] = out[row].session_id;
+      caps[row * 8u + 1u] = sizeof out[row].session_id;
+      values[row * 8u + 2u] = out[row].key;
+      caps[row * 8u + 2u] = sizeof out[row].key;
+      values[row * 8u + 3u] = out[row].value;
+      caps[row * 8u + 3u] = sizeof out[row].value;
+      values[row * 8u + 4u] = out[row].category;
+      caps[row * 8u + 4u] = sizeof out[row].category;
+      values[row * 8u + 5u] = out[row].created_at;
+      caps[row * 8u + 5u] = sizeof out[row].created_at;
+      values[row * 8u + 6u] = out[row].updated_at;
+      caps[row * 8u + 6u] = sizeof out[row].updated_at;
+      values[row * 8u + 7u] = out[row].expires_at;
+      caps[row * 8u + 7u] = sizeof out[row].expires_at;
+   }
+   uint32_t filled = 0;
+   int status = call_stage(AIMEE_DB1_OP_WM_LIST, fields, 3, values, caps,
+                           (uint32_t)(max * 8), &filled);
+   free(values);
+   free(caps);
+   if (status != (int)AIMEE_DB1_STATUS_OK || filled % 8u != 0u)
+   {
+      free(scratch);
+      return -1;
+   }
+   int rows = (int)(filled / 8u);
+   for (int row = 0; row < rows; ++row)
+   {
+      out[row].id = (int64_t)strtoll(scratch[row * 1u + 0u], NULL, 10);
+   }
+   free(scratch);
+   return rows;
 }
 
 /* clang-format on */

--- a/src/db1_client/git_ownership.c
+++ b/src/db1_client/git_ownership.c
@@ -101,10 +101,17 @@ static void encode(uint8_t *out, uint32_t op, const char *const *fields, uint32_
 /* Returns the module's status, or -1 when the call never produced one. */
 /* Fills up to `slots` reply values, each into the buffer and capacity the
    caller supplied. A write passes none; a read passes one; a row passes one per
-   member. */
+   member; a list passes one per member per row it is willing to accept.
+
+   `filled_out` reports how many values the reply actually carried, which is how
+   a list learns its length: the rows are not counted separately on the wire
+   because an operation already knows how wide its rows are. Callers that expect
+   a fixed shape pass NULL. */
 static int call_stage(uint32_t op, const char *const *fields, uint32_t count, char *const *values,
-                      const size_t *caps, uint32_t slots)
+                      const size_t *caps, uint32_t slots, uint32_t *filled_out)
 {
+   if (filled_out)
+      *filled_out = 0u;
    for (uint32_t i = 0; i < slots; ++i)
       if (values[i] && caps[i])
          values[i][0] = '\0';
@@ -153,6 +160,13 @@ static int call_stage(uint32_t op, const char *const *fields, uint32_t count, ch
          no values is how a write answers, one value is a read, and a member
          apiece is a row. */
       result = (int)status;
+      /* More values than the caller has room for is a contract mismatch, not
+         something to read the first few of: the caller asked for at most this
+         many rows, and a stage answering with more is not answering this call. */
+      if (fields_in > slots)
+         result = -1;
+      else if (filled_out)
+         *filled_out = fields_in;
       uint32_t at = 8u;
       for (uint32_t i = 0; i < fields_in && result != -1; ++i)
       {
@@ -211,7 +225,7 @@ int db1_git_ownership_upsert(const char *repo_path, const char *branch_name, con
    if (!repo_path || !repo_path[0] || !branch_name || !branch_name[0] || !session_id || !session_id[0])
       return -1;
    const char *fields[] = {repo_path, branch_name, session_id};
-   return write_result(call_stage(AIMEE_DB1_OP_OWNERSHIP_UPSERT, fields, 3, NULL, NULL, 0));
+   return write_result(call_stage(AIMEE_DB1_OP_OWNERSHIP_UPSERT, fields, 3, NULL, NULL, 0, NULL));
 }
 
 int db1_git_ownership_delete(const char *repo_path, const char *branch_name)
@@ -219,7 +233,7 @@ int db1_git_ownership_delete(const char *repo_path, const char *branch_name)
    if (!repo_path || !repo_path[0] || !branch_name || !branch_name[0])
       return -1;
    const char *fields[] = {repo_path, branch_name};
-   return write_result(call_stage(AIMEE_DB1_OP_OWNERSHIP_DELETE, fields, 2, NULL, NULL, 0));
+   return write_result(call_stage(AIMEE_DB1_OP_OWNERSHIP_DELETE, fields, 2, NULL, NULL, 0, NULL));
 }
 
 int db1_git_ownership_get_owner(const char *repo_path, const char *branch_name, char *owner_out, size_t owner_len)
@@ -229,7 +243,7 @@ int db1_git_ownership_get_owner(const char *repo_path, const char *branch_name, 
    const char *fields[] = {repo_path, branch_name};
    char *const values[] = {owner_out};
    const size_t caps[] = {owner_len};
-   int status = call_stage(AIMEE_DB1_OP_OWNERSHIP_OWNER_GET, fields, 2, values, caps, 1);
+   int status = call_stage(AIMEE_DB1_OP_OWNERSHIP_OWNER_GET, fields, 2, values, caps, 1, NULL);
    return read_result(status, owner_out);
 }
 
@@ -240,7 +254,7 @@ int db1_git_ownership_get_branch_for_session(const char *repo_path, const char *
    const char *fields[] = {repo_path, session_id};
    char *const values[] = {branch_out};
    const size_t caps[] = {branch_len};
-   int status = call_stage(AIMEE_DB1_OP_OWNERSHIP_BRANCH_FOR_SESSION, fields, 2, values, caps, 1);
+   int status = call_stage(AIMEE_DB1_OP_OWNERSHIP_BRANCH_FOR_SESSION, fields, 2, values, caps, 1, NULL);
    return read_result(status, branch_out);
 }
 
@@ -251,7 +265,7 @@ int db1_git_ownership_find_session_by_prefix(const char *session_prefix, char *s
    const char *fields[] = {session_prefix};
    char *const values[] = {session_out};
    const size_t caps[] = {session_len};
-   int status = call_stage(AIMEE_DB1_OP_OWNERSHIP_SESSION_BY_PREFIX, fields, 1, values, caps, 1);
+   int status = call_stage(AIMEE_DB1_OP_OWNERSHIP_SESSION_BY_PREFIX, fields, 1, values, caps, 1, NULL);
    return read_result(status, session_out);
 }
 
@@ -260,7 +274,7 @@ int db1_session_feature_branch_upsert(const char *repo_path, const char *session
    if (!repo_path || !repo_path[0] || !session_id || !session_id[0] || !feature_branch || !feature_branch[0])
       return -1;
    const char *fields[] = {repo_path, session_id, feature_branch};
-   return write_result(call_stage(AIMEE_DB1_OP_FEATURE_BRANCH_UPSERT, fields, 3, NULL, NULL, 0));
+   return write_result(call_stage(AIMEE_DB1_OP_FEATURE_BRANCH_UPSERT, fields, 3, NULL, NULL, 0, NULL));
 }
 
 int db1_session_feature_branch_get(const char *repo_path, const char *session_id, char *branch_out, size_t branch_len)
@@ -270,7 +284,7 @@ int db1_session_feature_branch_get(const char *repo_path, const char *session_id
    const char *fields[] = {repo_path, session_id};
    char *const values[] = {branch_out};
    const size_t caps[] = {branch_len};
-   int status = call_stage(AIMEE_DB1_OP_FEATURE_BRANCH_GET, fields, 2, values, caps, 1);
+   int status = call_stage(AIMEE_DB1_OP_FEATURE_BRANCH_GET, fields, 2, values, caps, 1, NULL);
    return read_result(status, branch_out);
 }
 

--- a/src/modules/db1/conversation_stage.c
+++ b/src/modules/db1/conversation_stage.c
@@ -14,6 +14,7 @@
 
 #include "db1_module_api.h"
 #include "payload_rewrite_state.h"
+#include "wm.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -141,9 +142,20 @@ aimee_module_status_t aimee_db1_stage_conversation(const uint8_t *request_body, 
    value[0] = '\0';
    int rc = -1;
    int reads = 0;
-   /* A row answers with a value per member; a plain read answers with one. */
+   /* A row answers with a value per member; a plain read answers with one; a
+      list answers with a value per member per row. */
    const char *const *rows = NULL;
    uint32_t row_count = 0u;
+   /* A list returns its length in rc, where a read returns found/not-found, so
+      the two cannot share a status mapping. The three owned blocks below hold
+      the domain's rows, the cell pointers into them and the text for numeric
+      members: all three must outlive write_reply, because that is what reads
+      them. Declared unconditionally so this stays one readable flow -- unlike
+      the static helpers above, an unused local costs nothing. */
+   int listed = 0;
+   void *domain_rows = NULL;
+   void *cells_owned = NULL;
+   void *numeric_owned = NULL;
 
    switch (op)
    {
@@ -232,6 +244,141 @@ aimee_module_status_t aimee_db1_stage_conversation(const uint8_t *request_body, 
       rc = db1_payload_rewrite_state_set(&row);
       break;
    }
+   case AIMEE_DB1_OP_WM_SET:
+   {
+      if (count != 5u)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[0][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[1][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[2][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[4][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      int parsed4;
+      if (parse_int(field[4], &parsed4) != 0)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      rc = db1_wm_set(field[0], field[1], field[2], field[3], parsed4);
+      break;
+   }
+   case AIMEE_DB1_OP_WM_GET:
+   {
+      if (count != 2u)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[0][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[1][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      wm_entry_t out;
+      memset(&out, 0, sizeof out);
+      rc = db1_wm_get(field[0], field[1], &out);
+      char text0[24];
+      snprintf(text0, sizeof text0, "%lld", (long long)out.id);
+      const char *const row_values[] = {text0, out.session_id, out.key, out.value, out.category, out.created_at, out.updated_at, out.expires_at};
+      rows = row_values;
+      row_count = 8u;
+      reads = 1;
+      break;
+   }
+   case AIMEE_DB1_OP_WM_LIST:
+   {
+      if (count != 3u)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[0][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[2][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      int parsed2;
+      if (parse_int(field[2], &parsed2) != 0)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (parsed2 <= 0 || parsed2 > 64)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      wm_entry_t *found = calloc((size_t)parsed2, sizeof *found);
+      if (!found)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INTERNAL;
+      }
+      domain_rows = found;
+      rc = db1_wm_list(field[0], field[1], found, parsed2);
+      if (rc > 0)
+      {
+         uint32_t produced = ((uint32_t)rc < (uint32_t)parsed2)
+                                 ? (uint32_t)rc : (uint32_t)parsed2;
+         const char **cells = malloc((size_t)produced * 8u * sizeof *cells);
+         char (*numbers)[24] = malloc((size_t)produced * 1u * sizeof *numbers);
+         if (!cells || !numbers)
+         {
+            free(cells);
+            free(numbers);
+            free(scratch);
+            free(domain_rows);
+            return AIMEE_MODULE_STATUS_INTERNAL;
+         }
+         cells_owned = cells;
+         numeric_owned = numbers;
+         for (uint32_t row = 0; row < produced; ++row)
+         {
+            snprintf(numbers[row * 1u + 0u], 24,
+                     "%lld", (long long)found[row].id);
+            cells[row * 8u + 0u] = numbers[row * 1u + 0u];
+            cells[row * 8u + 1u] = found[row].session_id;
+            cells[row * 8u + 2u] = found[row].key;
+            cells[row * 8u + 3u] = found[row].value;
+            cells[row * 8u + 4u] = found[row].category;
+            cells[row * 8u + 5u] = found[row].created_at;
+            cells[row * 8u + 6u] = found[row].updated_at;
+            cells[row * 8u + 7u] = found[row].expires_at;
+         }
+         rows = cells;
+         row_count = produced * 8u;
+      }
+      listed = 1;
+      break;
+   }
    default:
       free(scratch);
       return AIMEE_MODULE_STATUS_INVALID_REQUEST;
@@ -243,7 +390,12 @@ aimee_module_status_t aimee_db1_stage_conversation(const uint8_t *request_body, 
       onto MISSING would report a broken store as "nothing recorded", and the
       caller would act on an absence that was never established. */
    uint32_t status;
-   if (rows)
+   if (listed)
+      /* A list answers with how many rows it found, so any count is success and
+         only a negative return is a failure. Zero rows is an empty list, not a
+         miss: the caller asked what was there and the answer was nothing. */
+      status = (rc >= 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
+   else if (rows)
       /* A row-returning domain answers 0 or -1: there is no found/not-found
          distinction to preserve, so neither is invented. */
       status = (rc == 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
@@ -268,6 +420,9 @@ aimee_module_status_t aimee_db1_stage_conversation(const uint8_t *request_body, 
          out_count = 0u; /* nothing to report but the status */
       write_reply(response_body, response_capacity, response_len, status, out_values, out_count);
    }
+   free(cells_owned);
+   free(numeric_owned);
+   free(domain_rows);
    return AIMEE_MODULE_STATUS_OK;
 }
 /* clang-format on */

--- a/src/modules/db1/db1_module_api.h
+++ b/src/modules/db1/db1_module_api.h
@@ -64,6 +64,9 @@
 
 #define AIMEE_DB1_OP_REWRITE_STATE_GET 1u
 #define AIMEE_DB1_OP_REWRITE_STATE_SET 2u
+#define AIMEE_DB1_OP_WM_SET            3u
+#define AIMEE_DB1_OP_WM_GET            4u
+#define AIMEE_DB1_OP_WM_LIST           5u
 
 /* Wire bounds, carried from the catalog. VALUE_MAX is the widest
    reply a stage may build; FIELDS_MAX is the widest request arity, and
@@ -71,7 +74,7 @@
    prompts and documents, an in-process caller passes those whole, and the
    frame already bounds what arrived. */
 #define AIMEE_DB1_STATE_MAX  6144u
-#define AIMEE_DB1_VALUE_MAX  512u
+#define AIMEE_DB1_VALUE_MAX  8192u
 #define AIMEE_DB1_FIELDS_MAX 11u
 
 #define AIMEE_DB1_STATUS_OK       0u

--- a/src/modules/db1/db1_time.c
+++ b/src/modules/db1/db1_time.c
@@ -1,0 +1,31 @@
+/* db1_time.c: the timestamp primitive the DB1 module process needs.
+ *
+ * now_utc is declared in the shared header and defined once per process rather
+ * than in a library: the daemon gets it from src/util.c and the DB2 module from
+ * its own support file. DB1 is a process now too, so it supplies its own.
+ *
+ * This file is in the module descriptor and deliberately NOT in DB1_SRCS. The
+ * daemon still links the DB1 domain alongside util.c, so a second definition
+ * there would be a duplicate symbol; the module links the domain without
+ * util.c, so without this one it is an undefined symbol. Each binary gets
+ * exactly one, which is why the file exists rather than the call being routed
+ * through something shared.
+ *
+ * It is bit-for-bit the same format the other two produce, because these
+ * timestamps are compared as text and written into the same columns. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "aimee.h"
+
+#include <stddef.h>
+#include <time.h>
+
+void now_utc(char *buf, size_t len)
+{
+   time_t t = time(NULL);
+   struct tm tm;
+   gmtime_r(&t, &tm);
+   strftime(buf, len, "%Y-%m-%dT%H:%M:%SZ", &tm);
+}

--- a/src/modules/db1/eventcontract/operations.json
+++ b/src/modules/db1/eventcontract/operations.json
@@ -1,738 +1,950 @@
 {
-  "schema_version": 1,
-  "module": "db1",
-  "wire_version": 1,
-  "catalog_complete": false,
-  "infrastructure_sources": [
-    "db",
-    "db1_init",
-    "db1_write",
-    "db_schema",
-    "module_adapter"
-  ],
-  "coupled_sources": [
-    {
-      "sources": [
-        "agent_jobs",
-        "delegate_reservation",
-        "delegation_checkpoint",
-        "delegations"
-      ],
-      "reason": "a reservation resolves to a job id, and server_compute.c records that the ledger and the launch were co-located after a ledger across a boundary from the launch left paid-for jobs that nothing could replay"
-    }
-  ],
-  "families": [
-    {
-      "id": 1,
-      "name": "economizer_state",
-      "event_kind": 11777,
-      "active": true,
-      "doc": "the economizer's per-conversation reducer state. Chosen as the first family because it has exactly one production caller, so it proved the boundary without a wide cutover.",
-      "client_doc": "",
-      "covers": "checkpoints (the economizer's reducer state only)",
-      "sources": [
-        "checkpoints"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 2,
-      "name": "git_ownership",
-      "event_kind": 11778,
-      "active": true,
-      "doc": "branch ownership for the MCP git flows. Rows say which session owns which branch, so concurrent local sessions do not stomp on each other.",
-      "client_doc": "A failure returns -1, never \"no owner\". branch_own_check() reads a negative as \"no enforcement\" and allows the operation, which is what it has always done without a database, whereas a fabricated 0 would assert the branch is unowned and let a caller take one somebody else holds.",
-      "covers": "git_ownership",
-      "sources": [
-        "git_ownership"
-      ],
-      "retired_sources": [
-        "git_ownership.c"
-      ]
-    },
-    {
-      "id": 3,
-      "name": "conversation",
-      "event_kind": 11779,
-      "active": true,
-      "doc": "per-conversation context, clarifications and working memory.",
-      "client_doc": "",
-      "covers": "conv_context, clarify, payload_rewrite_state, user_memory, wm, windows",
-      "sources": [
-        "clarify",
-        "conv_context",
-        "payload_rewrite_state",
-        "user_memory",
-        "windows",
-        "wm"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 4,
-      "name": "agent_work",
-      "event_kind": 11780,
-      "active": false,
-      "doc": "queued agent work: logs, coordination jobs and the cron that drives them.",
-      "client_doc": "",
-      "covers": "agent_log, coord_jobs, cognify_jobs, db1_cron_jobs, db1_trigger",
-      "sources": [
-        "agent_log",
-        "cognify_jobs",
-        "coord_jobs",
-        "db1_cron_jobs",
-        "db1_trigger"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 5,
-      "name": "delegation",
-      "event_kind": 11781,
-      "active": false,
-      "doc": "delegation spawns, reservations, checkpoints and the agent_jobs ledger they reserve against. These move as ONE unit: a reservation resolves to a job id, and server_compute.c records that the ledger and the launch were deliberately co-located because a ledger across a boundary from the launch left paid-for jobs that nothing could replay. Splitting them across families would restore exactly that topology one migration at a time.",
-      "client_doc": "",
-      "covers": "delegations, delegate_reservation, delegate_learning, delegation_checkpoint, agent_jobs",
-      "sources": [
-        "agent_jobs",
-        "delegate_learning",
-        "delegate_reservation",
-        "delegation_checkpoint",
-        "delegations"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 6,
-      "name": "workflow",
-      "event_kind": 11782,
-      "active": false,
-      "doc": "the workflow engine's stores, plans and traces.",
-      "client_doc": "",
-      "covers": "wfe_store, wfe_binding, execution_plans, execution_trace, pipelines, roadmap_runtime, roundtable_pipeline",
-      "sources": [
-        "execution_plans",
-        "execution_trace",
-        "pipelines",
-        "roadmap_runtime",
-        "roundtable_pipeline",
-        "wfe_binding",
-        "wfe_store"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 7,
-      "name": "sessions",
-      "event_kind": 11783,
-      "active": false,
-      "doc": "server and webchat session rows.",
-      "client_doc": "",
-      "covers": "server_sessions, primary_sessions, session_state, session_paths, webchat_claude_sessions, webchat_live",
-      "sources": [
-        "primary_sessions",
-        "server_sessions",
-        "session_paths",
-        "session_state",
-        "webchat_claude_sessions",
-        "webchat_live"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 8,
-      "name": "identity",
-      "event_kind": 11784,
-      "active": false,
-      "doc": "secrets and the replay stores behind token consumption.",
-      "client_doc": "",
-      "covers": "secrets, server_identity_jti, server_management_jti, remote_client_grant",
-      "sources": [
-        "remote_client_grant",
-        "secrets",
-        "server_identity_jti",
-        "server_management_jti"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 9,
-      "name": "telemetry",
-      "event_kind": 11785,
-      "active": false,
-      "doc": "token accounting, evaluations and recorded events.",
-      "client_doc": "",
-      "covers": "token_audit, cost_fold, interaction_events, guardrail_events, eval, ensemble, diagnose, diagnostics",
-      "sources": [
-        "cost_fold",
-        "diagnose",
-        "diagnostics",
-        "ensemble",
-        "eval",
-        "guardrail_events",
-        "interaction_events",
-        "token_audit"
-      ],
-      "retired_sources": []
-    },
-    {
-      "id": 10,
-      "name": "runtime",
-      "event_kind": 11786,
-      "active": false,
-      "doc": "local runtime resolution, caches and model metadata.",
-      "client_doc": "",
-      "covers": "runtime_state, project_clones, local_operator, env, model_catalog, model_pricing, working_profile_local, tool_local_availability, caches, web_page_cache, fsnap, decisions, maintenance, mcp_osv_cache",
-      "sources": [
-        "caches",
-        "decisions",
-        "env",
-        "fsnap",
-        "local_operator",
-        "maintenance",
-        "mcp_osv_cache",
-        "model_catalog",
-        "model_pricing",
-        "project_clones",
-        "runtime_state",
-        "tool_local_availability",
-        "web_page_cache",
-        "working_profile_local"
-      ],
-      "retired_sources": []
-    }
-  ],
-  "result_codes": [
+ "schema_version": 1,
+ "module": "db1",
+ "wire_version": 1,
+ "catalog_complete": false,
+ "infrastructure_sources": [
+  "db",
+  "db1_init",
+  "db1_time",
+  "db1_write",
+  "db_schema",
+  "module_adapter"
+ ],
+ "coupled_sources": [
+  {
+   "sources": [
+    "agent_jobs",
+    "delegate_reservation",
+    "delegation_checkpoint",
+    "delegations"
+   ],
+   "reason": "a reservation resolves to a job id, and server_compute.c records that the ledger and the launch were co-located after a ledger across a boundary from the launch left paid-for jobs that nothing could replay"
+  }
+ ],
+ "families": [
+  {
+   "id": 1,
+   "name": "economizer_state",
+   "event_kind": 11777,
+   "active": true,
+   "doc": "the economizer's per-conversation reducer state. Chosen as the first family because it has exactly one production caller, so it proved the boundary without a wide cutover.",
+   "client_doc": "",
+   "covers": "checkpoints (the economizer's reducer state only)",
+   "sources": [
+    "checkpoints"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 2,
+   "name": "git_ownership",
+   "event_kind": 11778,
+   "active": true,
+   "doc": "branch ownership for the MCP git flows. Rows say which session owns which branch, so concurrent local sessions do not stomp on each other.",
+   "client_doc": "A failure returns -1, never \"no owner\". branch_own_check() reads a negative as \"no enforcement\" and allows the operation, which is what it has always done without a database, whereas a fabricated 0 would assert the branch is unowned and let a caller take one somebody else holds.",
+   "covers": "git_ownership",
+   "sources": [
+    "git_ownership"
+   ],
+   "retired_sources": [
+    "git_ownership.c"
+   ]
+  },
+  {
+   "id": 3,
+   "name": "conversation",
+   "event_kind": 11779,
+   "active": true,
+   "doc": "per-conversation context, clarifications and working memory.",
+   "client_doc": "",
+   "covers": "conv_context, clarify, payload_rewrite_state, user_memory, wm, windows",
+   "sources": [
+    "clarify",
+    "conv_context",
+    "payload_rewrite_state",
+    "user_memory",
+    "windows",
+    "wm"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 4,
+   "name": "agent_work",
+   "event_kind": 11780,
+   "active": false,
+   "doc": "queued agent work: logs, coordination jobs and the cron that drives them.",
+   "client_doc": "",
+   "covers": "agent_log, coord_jobs, cognify_jobs, db1_cron_jobs, db1_trigger",
+   "sources": [
+    "agent_log",
+    "cognify_jobs",
+    "coord_jobs",
+    "db1_cron_jobs",
+    "db1_trigger"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 5,
+   "name": "delegation",
+   "event_kind": 11781,
+   "active": false,
+   "doc": "delegation spawns, reservations, checkpoints and the agent_jobs ledger they reserve against. These move as ONE unit: a reservation resolves to a job id, and server_compute.c records that the ledger and the launch were deliberately co-located because a ledger across a boundary from the launch left paid-for jobs that nothing could replay. Splitting them across families would restore exactly that topology one migration at a time.",
+   "client_doc": "",
+   "covers": "delegations, delegate_reservation, delegate_learning, delegation_checkpoint, agent_jobs",
+   "sources": [
+    "agent_jobs",
+    "delegate_learning",
+    "delegate_reservation",
+    "delegation_checkpoint",
+    "delegations"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 6,
+   "name": "workflow",
+   "event_kind": 11782,
+   "active": false,
+   "doc": "the workflow engine's stores, plans and traces.",
+   "client_doc": "",
+   "covers": "wfe_store, wfe_binding, execution_plans, execution_trace, pipelines, roadmap_runtime, roundtable_pipeline",
+   "sources": [
+    "execution_plans",
+    "execution_trace",
+    "pipelines",
+    "roadmap_runtime",
+    "roundtable_pipeline",
+    "wfe_binding",
+    "wfe_store"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 7,
+   "name": "sessions",
+   "event_kind": 11783,
+   "active": false,
+   "doc": "server and webchat session rows.",
+   "client_doc": "",
+   "covers": "server_sessions, primary_sessions, session_state, session_paths, webchat_claude_sessions, webchat_live",
+   "sources": [
+    "primary_sessions",
+    "server_sessions",
+    "session_paths",
+    "session_state",
+    "webchat_claude_sessions",
+    "webchat_live"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 8,
+   "name": "identity",
+   "event_kind": 11784,
+   "active": false,
+   "doc": "secrets and the replay stores behind token consumption.",
+   "client_doc": "",
+   "covers": "secrets, server_identity_jti, server_management_jti, remote_client_grant",
+   "sources": [
+    "remote_client_grant",
+    "secrets",
+    "server_identity_jti",
+    "server_management_jti"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 9,
+   "name": "telemetry",
+   "event_kind": 11785,
+   "active": false,
+   "doc": "token accounting, evaluations and recorded events.",
+   "client_doc": "",
+   "covers": "token_audit, cost_fold, interaction_events, guardrail_events, eval, ensemble, diagnose, diagnostics",
+   "sources": [
+    "cost_fold",
+    "diagnose",
+    "diagnostics",
+    "ensemble",
+    "eval",
+    "guardrail_events",
+    "interaction_events",
+    "token_audit"
+   ],
+   "retired_sources": []
+  },
+  {
+   "id": 10,
+   "name": "runtime",
+   "event_kind": 11786,
+   "active": false,
+   "doc": "local runtime resolution, caches and model metadata.",
+   "client_doc": "",
+   "covers": "runtime_state, project_clones, local_operator, env, model_catalog, model_pricing, working_profile_local, tool_local_availability, caches, web_page_cache, fsnap, decisions, maintenance, mcp_osv_cache",
+   "sources": [
+    "caches",
+    "decisions",
+    "env",
+    "fsnap",
+    "local_operator",
+    "maintenance",
+    "mcp_osv_cache",
+    "model_catalog",
+    "model_pricing",
+    "project_clones",
+    "runtime_state",
+    "tool_local_availability",
+    "web_page_cache",
+    "working_profile_local"
+   ],
+   "retired_sources": []
+  }
+ ],
+ "result_codes": [
+  "ok",
+  "missing",
+  "invalid",
+  "too_long",
+  "failed"
+ ],
+ "operations": [
+  {
+   "family": "economizer_state",
+   "id": 1,
+   "name": "state_load",
+   "wire_format": "db1-keyed-blob-v1",
+   "scope": "conversation",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
     "ok",
     "missing",
     "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [
+     {
+      "name": "state",
+      "type": "state"
+     }
+    ],
+    "max_bytes": 6144
+   }
+  },
+  {
+   "family": "economizer_state",
+   "id": 2,
+   "name": "state_save",
+   "wire_format": "db1-keyed-blob-v1",
+   "scope": "conversation",
+   "transaction": "single",
+   "idempotency": "idempotent",
+   "results": [
+    "ok",
+    "invalid",
     "too_long",
     "failed"
-  ],
-  "operations": [
-    {
-      "family": "economizer_state",
-      "id": 1,
-      "name": "state_load",
-      "wire_format": "db1-keyed-blob-v1",
-      "scope": "conversation",
-      "transaction": "none",
-      "idempotency": "safe",
-      "results": [
-        "ok",
-        "missing",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [
-          {
-            "name": "state",
-            "type": "state"
-          }
-        ],
-        "max_bytes": 6144
-      }
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "state",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [],
+    "max_bytes": 0
+   }
+  },
+  {
+   "family": "git_ownership",
+   "id": 1,
+   "name": "ownership_upsert",
+   "c_name": "db1_git_ownership_upsert",
+   "c_params": [
+    "repo_path",
+    "branch_name",
+    "session_id"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "repository",
+   "transaction": "single",
+   "idempotency": "idempotent",
+   "results": [
+    "ok",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "branch",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "session",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [],
+    "max_bytes": 0
+   }
+  },
+  {
+   "family": "git_ownership",
+   "id": 2,
+   "name": "ownership_delete",
+   "c_name": "db1_git_ownership_delete",
+   "c_params": [
+    "repo_path",
+    "branch_name"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "repository",
+   "transaction": "single",
+   "idempotency": "idempotent",
+   "results": [
+    "ok",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "branch",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [],
+    "max_bytes": 0
+   }
+  },
+  {
+   "family": "git_ownership",
+   "id": 3,
+   "name": "ownership_owner_get",
+   "c_name": "db1_git_ownership_get_owner",
+   "c_params": [
+    "repo_path",
+    "branch_name",
+    "owner_out",
+    "owner_len"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "repository",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "missing",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "branch",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [
+     {
+      "name": "value",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 512
+   }
+  },
+  {
+   "family": "git_ownership",
+   "id": 4,
+   "name": "ownership_branch_for_session",
+   "c_name": "db1_git_ownership_get_branch_for_session",
+   "c_params": [
+    "repo_path",
+    "session_id",
+    "branch_out",
+    "branch_len"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "repository",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "missing",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "session",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [
+     {
+      "name": "value",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 512
+   }
+  },
+  {
+   "family": "git_ownership",
+   "id": 5,
+   "name": "ownership_session_by_prefix",
+   "c_name": "db1_git_ownership_find_session_by_prefix",
+   "c_params": [
+    "session_prefix",
+    "session_out",
+    "session_len"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "global",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "missing",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "prefix",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [
+     {
+      "name": "value",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 512
+   }
+  },
+  {
+   "family": "git_ownership",
+   "id": 6,
+   "name": "feature_branch_upsert",
+   "c_name": "db1_session_feature_branch_upsert",
+   "c_params": [
+    "repo_path",
+    "session_id",
+    "feature_branch"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "repository",
+   "transaction": "single",
+   "idempotency": "idempotent",
+   "results": [
+    "ok",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "session",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "branch",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [],
+    "max_bytes": 0
+   }
+  },
+  {
+   "family": "git_ownership",
+   "id": 7,
+   "name": "feature_branch_get",
+   "c_name": "db1_session_feature_branch_get",
+   "c_params": [
+    "repo_path",
+    "session_id",
+    "branch_out",
+    "branch_len"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "repository",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "missing",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "session",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [
+     {
+      "name": "value",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 512
+   }
+  },
+  {
+   "family": "conversation",
+   "id": 1,
+   "name": "rewrite_state_get",
+   "c_name": "db1_payload_rewrite_state_get",
+   "c_params": [
+    "session_id",
+    "out"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "session",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "missing",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "struct": "payload_rewrite_state_t",
+    "fields": [
+     {
+      "name": "session_id",
+      "type": "text"
+     },
+     {
+      "name": "payload_epoch",
+      "type": "int64"
+     },
+     {
+      "name": "compaction_epoch",
+      "type": "int64"
+     },
+     {
+      "name": "last_prefix_hash",
+      "type": "text"
+     },
+     {
+      "name": "last_payload_tokens",
+      "type": "int"
+     },
+     {
+      "name": "last_rewrite_at",
+      "type": "text"
+     },
+     {
+      "name": "deferred_rewrite_count",
+      "type": "int"
+     },
+     {
+      "name": "consecutive_deferred_count",
+      "type": "int"
+     },
+     {
+      "name": "bytes_saved_pending",
+      "type": "int"
+     },
+     {
+      "name": "rewrite_reason",
+      "type": "text"
+     },
+     {
+      "name": "updated_at",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 512
+   }
+  },
+  {
+   "family": "conversation",
+   "id": 2,
+   "name": "rewrite_state_set",
+   "c_name": "db1_payload_rewrite_state_set",
+   "c_params": [
+    "state"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "session",
+   "transaction": "single",
+   "idempotency": "idempotent",
+   "results": [
+    "ok",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "struct": "payload_rewrite_state_t",
+    "fields": [
+     {
+      "name": "session_id",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "payload_epoch",
+      "type": "int64",
+      "required": false
+     },
+     {
+      "name": "compaction_epoch",
+      "type": "int64",
+      "required": false
+     },
+     {
+      "name": "last_prefix_hash",
+      "type": "text",
+      "required": false
+     },
+     {
+      "name": "last_payload_tokens",
+      "type": "int",
+      "required": false
+     },
+     {
+      "name": "last_rewrite_at",
+      "type": "text",
+      "required": false
+     },
+     {
+      "name": "deferred_rewrite_count",
+      "type": "int",
+      "required": false
+     },
+     {
+      "name": "consecutive_deferred_count",
+      "type": "int",
+      "required": false
+     },
+     {
+      "name": "bytes_saved_pending",
+      "type": "int",
+      "required": false
+     },
+     {
+      "name": "rewrite_reason",
+      "type": "text",
+      "required": false
+     },
+     {
+      "name": "updated_at",
+      "type": "text",
+      "required": false
+     }
+    ]
+   },
+   "reply": {
+    "fields": [],
+    "max_bytes": 0
+   }
+  },
+  {
+   "family": "conversation",
+   "id": 3,
+   "name": "wm_set",
+   "c_name": "db1_wm_set",
+   "c_params": [
+    "session_id",
+    "key",
+    "value",
+    "category",
+    "ttl_seconds"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "session",
+   "transaction": "single",
+   "idempotency": "idempotent",
+   "results": [
+    "ok",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "entry_key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "value",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "category",
+      "type": "text",
+      "required": false
+     },
+     {
+      "name": "ttl_seconds",
+      "type": "int",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "fields": [],
+    "max_bytes": 0
+   }
+  },
+  {
+   "family": "conversation",
+   "id": 4,
+   "name": "wm_get",
+   "c_name": "db1_wm_get",
+   "c_params": [
+    "session_id",
+    "key",
+    "out"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "session",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "missing",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "entry_key",
+      "type": "text",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "struct": "wm_entry_t",
+    "fields": [
+     {
+      "name": "id",
+      "type": "int64"
+     },
+     {
+      "name": "session_id",
+      "type": "text"
+     },
+     {
+      "name": "key",
+      "type": "text"
+     },
+     {
+      "name": "value",
+      "type": "text"
+     },
+     {
+      "name": "category",
+      "type": "text"
+     },
+     {
+      "name": "created_at",
+      "type": "text"
+     },
+     {
+      "name": "updated_at",
+      "type": "text"
+     },
+     {
+      "name": "expires_at",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 8192
+   }
+  },
+  {
+   "family": "conversation",
+   "id": 5,
+   "name": "wm_list",
+   "c_name": "db1_wm_list",
+   "c_params": [
+    "session_id",
+    "category",
+    "out",
+    "max"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "session",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "key",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "category",
+      "type": "text",
+      "required": false
+     },
+     {
+      "name": "max",
+      "type": "int",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "struct": "wm_entry_t",
+    "list": {
+     "out": "out",
+     "bound": "max",
+     "max_rows": 64
     },
-    {
-      "family": "economizer_state",
-      "id": 2,
-      "name": "state_save",
-      "wire_format": "db1-keyed-blob-v1",
-      "scope": "conversation",
-      "transaction": "single",
-      "idempotency": "idempotent",
-      "results": [
-        "ok",
-        "invalid",
-        "too_long",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "state",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [],
-        "max_bytes": 0
-      }
-    },
-    {
-      "family": "git_ownership",
-      "id": 1,
-      "name": "ownership_upsert",
-      "c_name": "db1_git_ownership_upsert",
-      "c_params": [
-        "repo_path",
-        "branch_name",
-        "session_id"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "repository",
-      "transaction": "single",
-      "idempotency": "idempotent",
-      "results": [
-        "ok",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "branch",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "session",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [],
-        "max_bytes": 0
-      }
-    },
-    {
-      "family": "git_ownership",
-      "id": 2,
-      "name": "ownership_delete",
-      "c_name": "db1_git_ownership_delete",
-      "c_params": [
-        "repo_path",
-        "branch_name"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "repository",
-      "transaction": "single",
-      "idempotency": "idempotent",
-      "results": [
-        "ok",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "branch",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [],
-        "max_bytes": 0
-      }
-    },
-    {
-      "family": "git_ownership",
-      "id": 3,
-      "name": "ownership_owner_get",
-      "c_name": "db1_git_ownership_get_owner",
-      "c_params": [
-        "repo_path",
-        "branch_name",
-        "owner_out",
-        "owner_len"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "repository",
-      "transaction": "none",
-      "idempotency": "safe",
-      "results": [
-        "ok",
-        "missing",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "branch",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [
-          {
-            "name": "value",
-            "type": "text"
-          }
-        ],
-        "max_bytes": 512
-      }
-    },
-    {
-      "family": "git_ownership",
-      "id": 4,
-      "name": "ownership_branch_for_session",
-      "c_name": "db1_git_ownership_get_branch_for_session",
-      "c_params": [
-        "repo_path",
-        "session_id",
-        "branch_out",
-        "branch_len"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "repository",
-      "transaction": "none",
-      "idempotency": "safe",
-      "results": [
-        "ok",
-        "missing",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "session",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [
-          {
-            "name": "value",
-            "type": "text"
-          }
-        ],
-        "max_bytes": 512
-      }
-    },
-    {
-      "family": "git_ownership",
-      "id": 5,
-      "name": "ownership_session_by_prefix",
-      "c_name": "db1_git_ownership_find_session_by_prefix",
-      "c_params": [
-        "session_prefix",
-        "session_out",
-        "session_len"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "global",
-      "transaction": "none",
-      "idempotency": "safe",
-      "results": [
-        "ok",
-        "missing",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "prefix",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [
-          {
-            "name": "value",
-            "type": "text"
-          }
-        ],
-        "max_bytes": 512
-      }
-    },
-    {
-      "family": "git_ownership",
-      "id": 6,
-      "name": "feature_branch_upsert",
-      "c_name": "db1_session_feature_branch_upsert",
-      "c_params": [
-        "repo_path",
-        "session_id",
-        "feature_branch"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "repository",
-      "transaction": "single",
-      "idempotency": "idempotent",
-      "results": [
-        "ok",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "session",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "branch",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [],
-        "max_bytes": 0
-      }
-    },
-    {
-      "family": "git_ownership",
-      "id": 7,
-      "name": "feature_branch_get",
-      "c_name": "db1_session_feature_branch_get",
-      "c_params": [
-        "repo_path",
-        "session_id",
-        "branch_out",
-        "branch_len"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "repository",
-      "transaction": "none",
-      "idempotency": "safe",
-      "results": [
-        "ok",
-        "missing",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "session",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "fields": [
-          {
-            "name": "value",
-            "type": "text"
-          }
-        ],
-        "max_bytes": 512
-      }
-    },
-    {
-      "family": "conversation",
-      "id": 1,
-      "name": "rewrite_state_get",
-      "c_name": "db1_payload_rewrite_state_get",
-      "c_params": [
-        "session_id",
-        "out"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "session",
-      "transaction": "none",
-      "idempotency": "safe",
-      "results": [
-        "ok",
-        "missing",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "fields": [
-          {
-            "name": "key",
-            "type": "text",
-            "required": true
-          }
-        ]
-      },
-      "reply": {
-        "struct": "payload_rewrite_state_t",
-        "fields": [
-          {
-            "name": "session_id",
-            "type": "text"
-          },
-          {
-            "name": "payload_epoch",
-            "type": "int64"
-          },
-          {
-            "name": "compaction_epoch",
-            "type": "int64"
-          },
-          {
-            "name": "last_prefix_hash",
-            "type": "text"
-          },
-          {
-            "name": "last_payload_tokens",
-            "type": "int"
-          },
-          {
-            "name": "last_rewrite_at",
-            "type": "text"
-          },
-          {
-            "name": "deferred_rewrite_count",
-            "type": "int"
-          },
-          {
-            "name": "consecutive_deferred_count",
-            "type": "int"
-          },
-          {
-            "name": "bytes_saved_pending",
-            "type": "int"
-          },
-          {
-            "name": "rewrite_reason",
-            "type": "text"
-          },
-          {
-            "name": "updated_at",
-            "type": "text"
-          }
-        ],
-        "max_bytes": 512
-      }
-    },
-    {
-      "family": "conversation",
-      "id": 2,
-      "name": "rewrite_state_set",
-      "c_name": "db1_payload_rewrite_state_set",
-      "c_params": [
-        "state"
-      ],
-      "wire_format": "db1-fields-v2",
-      "scope": "session",
-      "transaction": "single",
-      "idempotency": "idempotent",
-      "results": [
-        "ok",
-        "invalid",
-        "failed"
-      ],
-      "request": {
-        "struct": "payload_rewrite_state_t",
-        "fields": [
-          {
-            "name": "session_id",
-            "type": "text",
-            "required": true
-          },
-          {
-            "name": "payload_epoch",
-            "type": "int64",
-            "required": false
-          },
-          {
-            "name": "compaction_epoch",
-            "type": "int64",
-            "required": false
-          },
-          {
-            "name": "last_prefix_hash",
-            "type": "text",
-            "required": false
-          },
-          {
-            "name": "last_payload_tokens",
-            "type": "int",
-            "required": false
-          },
-          {
-            "name": "last_rewrite_at",
-            "type": "text",
-            "required": false
-          },
-          {
-            "name": "deferred_rewrite_count",
-            "type": "int",
-            "required": false
-          },
-          {
-            "name": "consecutive_deferred_count",
-            "type": "int",
-            "required": false
-          },
-          {
-            "name": "bytes_saved_pending",
-            "type": "int",
-            "required": false
-          },
-          {
-            "name": "rewrite_reason",
-            "type": "text",
-            "required": false
-          },
-          {
-            "name": "updated_at",
-            "type": "text",
-            "required": false
-          }
-        ]
-      },
-      "reply": {
-        "fields": [],
-        "max_bytes": 0
-      }
-    }
-  ]
+    "fields": [
+     {
+      "name": "id",
+      "type": "int64"
+     },
+     {
+      "name": "session_id",
+      "type": "text"
+     },
+     {
+      "name": "key",
+      "type": "text"
+     },
+     {
+      "name": "value",
+      "type": "text"
+     },
+     {
+      "name": "category",
+      "type": "text"
+     },
+     {
+      "name": "created_at",
+      "type": "text"
+     },
+     {
+      "name": "updated_at",
+      "type": "text"
+     },
+     {
+      "name": "expires_at",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 8192
+   }
+  }
+ ]
 }

--- a/src/modules/db1/git_ownership_stage.c
+++ b/src/modules/db1/git_ownership_stage.c
@@ -109,9 +109,20 @@ aimee_module_status_t aimee_db1_stage_git_ownership(const uint8_t *request_body,
    value[0] = '\0';
    int rc = -1;
    int reads = 0;
-   /* A row answers with a value per member; a plain read answers with one. */
+   /* A row answers with a value per member; a plain read answers with one; a
+      list answers with a value per member per row. */
    const char *const *rows = NULL;
    uint32_t row_count = 0u;
+   /* A list returns its length in rc, where a read returns found/not-found, so
+      the two cannot share a status mapping. The three owned blocks below hold
+      the domain's rows, the cell pointers into them and the text for numeric
+      members: all three must outlive write_reply, because that is what reads
+      them. Declared unconditionally so this stays one readable flow -- unlike
+      the static helpers above, an unused local costs nothing. */
+   int listed = 0;
+   void *domain_rows = NULL;
+   void *cells_owned = NULL;
+   void *numeric_owned = NULL;
 
    switch (op)
    {
@@ -261,7 +272,12 @@ aimee_module_status_t aimee_db1_stage_git_ownership(const uint8_t *request_body,
       onto MISSING would report a broken store as "nothing recorded", and the
       caller would act on an absence that was never established. */
    uint32_t status;
-   if (rows)
+   if (listed)
+      /* A list answers with how many rows it found, so any count is success and
+         only a negative return is a failure. Zero rows is an empty list, not a
+         miss: the caller asked what was there and the answer was nothing. */
+      status = (rc >= 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
+   else if (rows)
       /* A row-returning domain answers 0 or -1: there is no found/not-found
          distinction to preserve, so neither is invented. */
       status = (rc == 0) ? AIMEE_DB1_STATUS_OK : AIMEE_DB1_STATUS_FAILED;
@@ -286,6 +302,9 @@ aimee_module_status_t aimee_db1_stage_git_ownership(const uint8_t *request_body,
          out_count = 0u; /* nothing to report but the status */
       write_reply(response_body, response_capacity, response_len, status, out_values, out_count);
    }
+   free(cells_owned);
+   free(numeric_owned);
+   free(domain_rows);
    return AIMEE_MODULE_STATUS_OK;
 }
 /* clang-format on */

--- a/src/modules/db1/module.yaml
+++ b/src/modules/db1/module.yaml
@@ -23,6 +23,7 @@
     "src/modules/db1/db.c",
     "src/modules/db1/db1_cron_jobs.c",
     "src/modules/db1/db1_init.c",
+    "src/modules/db1/db1_time.c",
     "src/modules/db1/db1_trigger.c",
     "src/modules/db1/db1_write.c",
     "src/modules/db1/db_schema.c",

--- a/src/modules/db1/module_adapter.c
+++ b/src/modules/db1/module_adapter.c
@@ -134,6 +134,9 @@ aimee_module_status_t aimee_module_handler(const aimee_module_invocation_t *invo
    case AIMEE_DB1_STAGE_GIT_OWNERSHIP:
       return aimee_db1_stage_git_ownership(request_body, request_len, response_body,
                                            response_capacity, response_len);
+   case AIMEE_DB1_STAGE_CONVERSATION:
+      return aimee_db1_stage_conversation(request_body, request_len, response_body,
+                                          response_capacity, response_len);
    default:
       return AIMEE_MODULE_STATUS_INVALID_REQUEST;
    }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -660,6 +660,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-db1-cost-fold \
                $(TESTPREFIX)/unit-test-db1-module-stage \
                $(TESTPREFIX)/unit-test-db1-git-ownership-client \
+               $(TESTPREFIX)/unit-test-db1-conversation-client \
                $(TESTPREFIX)/unit-test-db1-roundtable-pipeline \
                $(TESTPREFIX)/unit-test-roundtable-pipeline-eval \
                $(TESTPREFIX)/unit-test-roundtable-pipeline-chunk \
@@ -4984,6 +4985,12 @@ $(TESTPREFIX)/unit-test-db1-git-ownership-client: \
                                        $(OBJDIR)/module_json_call.o $(OBJDIR)/log.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
+$(TESTPREFIX)/unit-test-db1-conversation-client: \
+                                       $(OBJDIR)/tests/test_db1_conversation_client.o \
+                                       $(OBJDIR)/db1_client/conversation.o \
+                                       $(OBJDIR)/module_json_call.o $(OBJDIR)/log.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
 $(TESTPREFIX)/unit-test-db1-module-stage: \
                                        $(OBJDIR)/tests/test_db1_module_stage.o \
                                        $(OBJDIR)/modules/db1/module_adapter.o \
@@ -4993,6 +5000,7 @@ $(TESTPREFIX)/unit-test-db1-module-stage: \
                                        $(OBJDIR)/modules/db1/git_ownership_stage.o \
                                        $(OBJDIR)/modules/db1/conversation_stage.o \
                                        $(OBJDIR)/modules/db1/payload_rewrite_state.o \
+                                       $(OBJDIR)/modules/db1/wm.o $(OBJDIR)/util.o \
                                        $(OBJDIR)/core/event_bus/module_runtime.o \
                                        $(OBJDIR)/core/event_bus/module_protocol.o \
                                        $(OBJDIR)/core/event_bus/bus_attach.o \

--- a/src/tests/test_db1_conversation_client.c
+++ b/src/tests/test_db1_conversation_client.c
@@ -1,0 +1,262 @@
+/* test_db1_conversation_client.c: the list half of the generated bus client.
+ *
+ * A list is the one shape whose reply length is not fixed by the operation, so
+ * the client works out how many rows arrived by dividing the reply's own value
+ * count by the width it knows. Everything that can go wrong goes wrong there:
+ * a reply that is not a whole number of rows, a reply longer than the caller's
+ * array, and a bound the caller chose rather than the domain.
+ *
+ * The bus is stubbed. What the real module answers is covered by
+ * unit-test-db1-module-stage; what matters here is the framing, the row
+ * arithmetic and the fact that a broken reply is refused rather than read. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <aimee/core/event_bus/module_client.h>
+#include "db1_module_api.h"
+#include "wm.h"
+
+/* --- the stubbed bus ------------------------------------------------------ */
+
+#define WM_LIST_WIDTH 8u
+
+static int stub_available = 1;
+static aimee_module_call_result_t stub_result = AIMEE_MODULE_CALL_OK;
+static uint32_t stub_status = AIMEE_DB1_STATUS_OK;
+static int stub_calls;
+static uint8_t stub_request[4096];
+static uint32_t stub_request_len;
+/* How many rows to answer with, and how many values to actually claim: the two
+   are separate so a reply can be made to lie about its own shape. */
+static uint32_t stub_rows;
+static int stub_extra_values;
+
+int obs_bus_module_available(uint32_t event_kind)
+{
+   assert(event_kind == AIMEE_DB1_EVENT_CONVERSATION);
+   return stub_available;
+}
+
+/* Row r, member m: a value distinct enough that a transposed index shows up. */
+static void cell_text(char *out, size_t cap, uint32_t row, uint32_t member)
+{
+   if (member == 0u)
+      snprintf(out, cap, "%u", 1000u + row); /* the int64 id */
+   else
+      snprintf(out, cap, "r%um%u", row, member);
+}
+
+aimee_module_call_result_t
+obs_bus_module_call(uint32_t event_kind, uint32_t stage_id, uint64_t trace_id, uint64_t deadline_ns,
+                    const void *request_body, uint32_t request_len, void *response_body,
+                    uint32_t response_capacity, uint32_t *response_len,
+                    aimee_module_cancelled_fn cancelled, void *cancel_context)
+{
+   (void)trace_id;
+   (void)cancelled;
+   (void)cancel_context;
+   assert(event_kind == AIMEE_DB1_EVENT_CONVERSATION);
+   assert(stage_id == AIMEE_DB1_STAGE_CONVERSATION);
+   assert(deadline_ns != 0);
+
+   stub_calls++;
+   stub_request_len = request_len < sizeof stub_request ? request_len : 0;
+   if (stub_request_len)
+      memcpy(stub_request, request_body, stub_request_len);
+   if (stub_result != AIMEE_MODULE_CALL_OK)
+      return stub_result;
+
+   uint32_t values = stub_rows * WM_LIST_WIDTH + (uint32_t)stub_extra_values;
+   uint8_t *out = (uint8_t *)response_body;
+   if (response_capacity < 8u)
+      return AIMEE_MODULE_CALL_RESPONSE_TOO_LARGE;
+   aimee_db1_put_u32(out, stub_status);
+   aimee_db1_put_u32(out + 4u, values);
+   uint32_t at = 8u;
+   for (uint32_t i = 0; i < values; ++i)
+   {
+      char text[64];
+      cell_text(text, sizeof text, i / WM_LIST_WIDTH, i % WM_LIST_WIDTH);
+      uint32_t n = (uint32_t)strlen(text);
+      if (response_capacity < at + 4u + n)
+         return AIMEE_MODULE_CALL_RESPONSE_TOO_LARGE;
+      aimee_db1_put_u32(out + at, n);
+      at += 4u;
+      memcpy(out + at, text, n);
+      at += n;
+   }
+   *response_len = at;
+   return AIMEE_MODULE_CALL_OK;
+}
+
+static void reset(void)
+{
+   stub_available = 1;
+   stub_result = AIMEE_MODULE_CALL_OK;
+   stub_status = AIMEE_DB1_STATUS_OK;
+   stub_calls = 0;
+   stub_request_len = 0;
+   stub_rows = 0;
+   stub_extra_values = 0;
+}
+
+/* --- reading back the frame the client emitted ---------------------------- */
+
+static const char *frame_field(uint32_t index, uint32_t *len_out)
+{
+   uint32_t count = aimee_db1_get_u32(stub_request + 4u);
+   assert(index < count);
+   uint32_t at = 8u;
+   for (uint32_t i = 0;; ++i)
+   {
+      uint32_t n = aimee_db1_get_u32(stub_request + at);
+      at += 4u;
+      if (i == index)
+      {
+         *len_out = n;
+         return (const char *)stub_request + at;
+      }
+      at += n;
+   }
+}
+
+/* --- the tests ------------------------------------------------------------ */
+
+/* The reply carries every member of every row and nothing that says how many
+   rows there are: the width is the operation's own contract, so the count
+   divides out. */
+static void test_a_list_reply_becomes_rows(void)
+{
+   reset();
+   stub_rows = 3u;
+   wm_entry_t rows[8];
+   int found = db1_wm_list("sess-1", "notes", rows, 8);
+   assert(found == 3);
+   assert(stub_calls == 1);
+
+   /* Members land in their own columns, not shifted by one. */
+   assert(strcmp(rows[0].key, "r0m2") == 0);
+   assert(strcmp(rows[0].value, "r0m3") == 0);
+   assert(strcmp(rows[2].key, "r2m2") == 0);
+   assert(strcmp(rows[2].expires_at, "r2m7") == 0);
+   /* The int64 member is converted, not left as the text it travelled as. */
+   assert(rows[0].id == 1000);
+   assert(rows[2].id == 1002);
+   /* Rows beyond what arrived are left cleared rather than stale. */
+   assert(rows[3].key[0] == '\0' && rows[3].id == 0);
+   printf("  PASS: test_a_list_reply_becomes_rows\n");
+}
+
+/* Nothing found is an empty list and a success, not a failure and not a row of
+   empty strings. A caller iterating the result must see zero iterations. */
+static void test_an_empty_list_is_zero_rows_not_an_error(void)
+{
+   reset();
+   stub_rows = 0u;
+   wm_entry_t rows[4];
+   assert(db1_wm_list("sess-1", "", rows, 4) == 0);
+   assert(rows[0].key[0] == '\0');
+   printf("  PASS: test_an_empty_list_is_zero_rows_not_an_error\n");
+}
+
+/* A reply that is not a whole number of rows is not this operation's reply.
+   Reading the rows that did fit would hand the caller a truncated final row
+   built from whatever the next row's members would have been. */
+static void test_a_partial_row_is_refused(void)
+{
+   reset();
+   stub_rows = 2u;
+   stub_extra_values = 3; /* two rows and a fragment */
+   wm_entry_t rows[8];
+   assert(db1_wm_list("sess-1", "", rows, 8) == -1);
+   printf("  PASS: test_a_partial_row_is_refused\n");
+}
+
+/* More values than the caller has room for is a contract mismatch. Reading the
+   first few would silently drop rows the caller asked for and was told it got. */
+static void test_more_rows_than_asked_for_is_refused(void)
+{
+   reset();
+   stub_rows = 5u;
+   wm_entry_t rows[2];
+   assert(db1_wm_list("sess-1", "", rows, 2) == -1);
+   printf("  PASS: test_more_rows_than_asked_for_is_refused\n");
+}
+
+/* A failed status is -1 even though the reply is well formed: the caller must
+   not read "no working memory" out of a store that could not be reached. */
+static void test_a_failed_status_is_not_an_empty_list(void)
+{
+   reset();
+   stub_status = AIMEE_DB1_STATUS_FAILED;
+   wm_entry_t rows[4];
+   assert(db1_wm_list("sess-1", "", rows, 4) == -1);
+
+   reset();
+   stub_available = 0;
+   assert(db1_wm_list("sess-1", "", rows, 4) == -1);
+   assert(stub_calls == 0);
+   printf("  PASS: test_a_failed_status_is_not_an_empty_list\n");
+}
+
+/* The bound the stage is told is the bound the client will honour. Sending the
+   caller's larger number would invite a reply the client then refuses as too
+   long -- a call that fails on well-formed data. */
+static void test_the_bound_sent_is_the_bound_clamped(void)
+{
+   reset();
+   stub_rows = 1u;
+   wm_entry_t rows[100];
+   assert(db1_wm_list("sess-1", "", rows, 100) == 1);
+   uint32_t len = 0;
+   const char *sent = frame_field(2u, &len);
+   assert(len == 2 && memcmp(sent, "64", 2) == 0);
+
+   /* A bound under the ceiling travels unchanged. */
+   reset();
+   stub_rows = 1u;
+   assert(db1_wm_list("sess-1", "", rows, 7) == 1);
+   sent = frame_field(2u, &len);
+   assert(len == 1 && memcmp(sent, "7", 1) == 0);
+   printf("  PASS: test_the_bound_sent_is_the_bound_clamped\n");
+}
+
+/* Arguments the operation cannot use cost no round trip: the optional category
+   travels as empty, but a missing session key or an unusable bound is refused
+   before a frame is built. */
+static void test_unusable_arguments_cost_no_round_trip(void)
+{
+   reset();
+   wm_entry_t rows[4];
+   assert(db1_wm_list(NULL, "", rows, 4) == -1);
+   assert(db1_wm_list("", "", rows, 4) == -1);
+   assert(db1_wm_list("sess-1", "", NULL, 4) == -1);
+   assert(db1_wm_list("sess-1", "", rows, 0) == -1);
+   assert(db1_wm_list("sess-1", "", rows, -1) == -1);
+   assert(stub_calls == 0);
+
+   /* The optional category is allowed to be absent, and travels as empty. */
+   reset();
+   stub_rows = 1u;
+   assert(db1_wm_list("sess-1", NULL, rows, 4) == 1);
+   uint32_t len = 1;
+   frame_field(1u, &len);
+   assert(len == 0);
+   printf("  PASS: test_unusable_arguments_cost_no_round_trip\n");
+}
+
+int main(void)
+{
+   printf("db1_conversation_client:\n");
+   test_a_list_reply_becomes_rows();
+   test_an_empty_list_is_zero_rows_not_an_error();
+   test_a_partial_row_is_refused();
+   test_more_rows_than_asked_for_is_refused();
+   test_a_failed_status_is_not_an_empty_list();
+   test_the_bound_sent_is_the_bound_clamped();
+   test_unusable_arguments_cost_no_round_trip();
+   printf("db1_conversation_client: ok\n");
+   return 0;
+}

--- a/src/tests/test_db1_module_stage.c
+++ b/src/tests/test_db1_module_stage.c
@@ -18,6 +18,7 @@
 #include "db1.h"
 #include "git_ownership.h"
 #include "platform_test_util.h"
+#include "wm.h"
 
 aimee_module_status_t aimee_module_handler(const aimee_module_invocation_t *invocation,
                                            const uint8_t *request_body, uint32_t request_len,
@@ -406,6 +407,167 @@ static void test_stage_carries_a_large_field(void)
    printf("  PASS: test_stage_carries_a_large_field\n");
 }
 
+/* Read one counted value out of a reply, by index. */
+static const char *reply_value(const uint8_t *resp, uint32_t resp_len, uint32_t index,
+                               uint32_t *len_out)
+{
+   uint32_t at = 8u;
+   for (uint32_t i = 0; i < aimee_db1_get_u32(resp + 4u); ++i)
+   {
+      assert(at + 4u <= resp_len);
+      uint32_t n = aimee_db1_get_u32(resp + at);
+      at += 4u;
+      assert(at + n <= resp_len);
+      if (i == index)
+      {
+         *len_out = n;
+         return (const char *)resp + at;
+      }
+      at += n;
+   }
+   assert(0 && "reply has no such value");
+   return NULL;
+}
+
+/* A list crosses as its rows flattened member by member, and the reply's own
+   value count is what tells the caller how many rows arrived -- an operation
+   knows how wide its rows are, so the width is never sent. */
+static void test_wm_list_returns_every_member_of_every_row(void)
+{
+   char path[PATH_MAX];
+   snprintf(path, sizeof(path), "%s/aimee-test-db1-wmlist-%d.db", platform_tmpdir(), (int)getpid());
+   remove(path);
+   db1_shutdown();
+   assert(db1_init(path) == 0);
+
+   assert(db1_wm_set("sess-1", "alpha", "first", "notes", 0) == 0);
+   assert(db1_wm_set("sess-1", "beta", "second", "notes", 0) == 0);
+   /* Another session's entry must not appear in this session's list. */
+   assert(db1_wm_set("sess-2", "gamma", "third", "notes", 0) == 0);
+
+   uint8_t req[1024], resp[8192];
+   uint32_t resp_len = 0;
+   const char *list[] = {"sess-1", "", "16"};
+   uint32_t len = fields_frame(req, AIMEE_DB1_OP_WM_LIST, list, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_OK);
+   assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
+   /* Two rows of eight members: the count is rows times width, not a row
+      count, because the width is the operation's own contract. */
+   assert(aimee_db1_get_u32(resp + 4u) == 16u);
+
+   /* The key member of each row, at member offset 2 of 8. */
+   uint32_t n = 0;
+   const char *first = reply_value(resp, resp_len, 2u, &n);
+   assert(n == strlen("alpha") && memcmp(first, "alpha", n) == 0);
+   const char *second = reply_value(resp, resp_len, 8u + 2u, &n);
+   assert(n == strlen("beta") && memcmp(second, "beta", n) == 0);
+   /* The int64 id member travels as decimal text like every other integer. */
+   const char *id = reply_value(resp, resp_len, 0u, &n);
+   assert(n > 0 && id[0] >= '0' && id[0] <= '9');
+
+   db1_shutdown();
+   remove(path);
+   printf("  PASS: test_wm_list_returns_every_member_of_every_row\n");
+}
+
+/* An empty list is an answer, not an absence. The stage must not borrow the
+   read convention here: a read with nothing to say returns one empty value and
+   MISSING, and a list saying "there are none" would then be indistinguishable
+   from a row whose every member is blank. */
+static void test_wm_list_finds_nothing_and_says_so(void)
+{
+   char path[PATH_MAX];
+   snprintf(path, sizeof(path), "%s/aimee-test-db1-wmnone-%d.db", platform_tmpdir(), (int)getpid());
+   remove(path);
+   db1_shutdown();
+   assert(db1_init(path) == 0);
+
+   uint8_t req[1024], resp[8192];
+   uint32_t resp_len = 0;
+   const char *list[] = {"sess-empty", "", "16"};
+   uint32_t len = fields_frame(req, AIMEE_DB1_OP_WM_LIST, list, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_OK);
+   assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
+   assert(aimee_db1_get_u32(resp + 4u) == 0u);
+
+   db1_shutdown();
+   remove(path);
+   printf("  PASS: test_wm_list_finds_nothing_and_says_so\n");
+}
+
+/* The bound is an allocation. A stage that took the caller's word for it would
+   size an array from the wire, so it is checked against the ceiling the catalog
+   declares before anything is allocated from it. */
+static void test_wm_list_refuses_a_bound_it_will_not_allocate(void)
+{
+   char path[PATH_MAX];
+   snprintf(path, sizeof(path), "%s/aimee-test-db1-wmcap-%d.db", platform_tmpdir(), (int)getpid());
+   remove(path);
+   db1_shutdown();
+   assert(db1_init(path) == 0);
+
+   uint8_t req[1024], resp[8192];
+   uint32_t resp_len = 0;
+   const char *too_many[] = {"sess-1", "", "65"};
+   uint32_t len = fields_frame(req, AIMEE_DB1_OP_WM_LIST, too_many, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_INVALID_REQUEST);
+
+   const char *none[] = {"sess-1", "", "0"};
+   len = fields_frame(req, AIMEE_DB1_OP_WM_LIST, none, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_INVALID_REQUEST);
+
+   const char *negative[] = {"sess-1", "", "-4"};
+   len = fields_frame(req, AIMEE_DB1_OP_WM_LIST, negative, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_INVALID_REQUEST);
+
+   /* Not a number at all is refused by the same parse every integer uses. */
+   const char *nonsense[] = {"sess-1", "", "sixteen"};
+   len = fields_frame(req, AIMEE_DB1_OP_WM_LIST, nonsense, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_INVALID_REQUEST);
+
+   db1_shutdown();
+   remove(path);
+   printf("  PASS: test_wm_list_refuses_a_bound_it_will_not_allocate\n");
+}
+
+/* A bound smaller than what is stored is honoured: the caller's array is the
+   limit, and returning more rows than it asked for would write past its end. */
+static void test_wm_list_stops_at_the_bound_it_was_given(void)
+{
+   char path[PATH_MAX];
+   snprintf(path, sizeof(path), "%s/aimee-test-db1-wmbound-%d.db", platform_tmpdir(),
+            (int)getpid());
+   remove(path);
+   db1_shutdown();
+   assert(db1_init(path) == 0);
+
+   for (int i = 0; i < 5; ++i)
+   {
+      char key[32];
+      snprintf(key, sizeof key, "key-%d", i);
+      assert(db1_wm_set("sess-1", key, "value", "notes", 0) == 0);
+   }
+
+   uint8_t req[1024], resp[8192];
+   uint32_t resp_len = 0;
+   const char *list[] = {"sess-1", "", "2"};
+   uint32_t len = fields_frame(req, AIMEE_DB1_OP_WM_LIST, list, 3);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_OK);
+   assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
+   assert(aimee_db1_get_u32(resp + 4u) == 16u); /* two rows, not five */
+
+   db1_shutdown();
+   remove(path);
+   printf("  PASS: test_wm_list_stops_at_the_bound_it_was_given\n");
+}
+
 int main(void)
 {
    printf("db1_module_stage:\n");
@@ -417,6 +579,10 @@ int main(void)
    test_git_ownership_malformed_frames_are_refused();
    test_git_ownership_store_failure_is_not_a_miss();
    test_stage_carries_a_large_field();
+   test_wm_list_returns_every_member_of_every_row();
+   test_wm_list_finds_nothing_and_says_so();
+   test_wm_list_refuses_a_bound_it_will_not_allocate();
+   test_wm_list_stops_at_the_bound_it_was_given();
    printf("db1_module_stage: ok\n");
    return 0;
 }


### PR DESCRIPTION
Step 3 of docs/proposals/pending/db1-structured-payloads.md, and the design
held: nothing new goes on the wire. A list reply is its rows flattened member
by member, and the reply's own value count divided by the row width is the row
count -- an operation already knows how wide its rows are, so the width is
never sent.

The bound is the one genuinely new idea. It travels as a request field because
it is an allocation on BOTH sides: the client sizes a slot array from it and
the stage callocs the domain's row array from it. So the catalog declares a
per-operation ceiling, the stage refuses a bound above it before allocating,
and the client clamps rather than refuses -- the ceiling is the one the domain
already enforces, so a caller with a larger array has always been given fewer
rows, and refusing would break it for no gain.

Activates wm's three operations in the conversation family, which makes wm a
whole ready source. Rows of a struct now cross; rows of a single value do not,
and the survey counts that separately as "column" -- five operations whose row
is a bare int64_t or a char (*)[N], with no members to declare.

The generated stage was unreachable, and nothing said so.

The adapter's switch is hand-written, because the first family answers a
different wire format through a hand-written handler. Nothing tied it to the
catalog, so activating conversation in the previous change produced a stage
that compiled, linked, passed its own tests and could not be called: the
runtime invoked the stage id and the switch fell through to its default. It
went unnoticed because a family with no dispatched stage is indistinguishable
from one whose callers have not cut over. A new rule, stage-undispatched, now
fails the build when an active family's stage is not routed.

db1_time.c supplies now_utc to the module process. wm.c is the first migrated
source to call it, and each process defines it for itself -- the daemon from
util.c, DB2 from its own support file. It is module-only by construction: in
DB1_SRCS it would be a duplicate symbol in the daemon, out of the module it is
an undefined one there.

Verified: 40 generator tests; three C suites clean under ASAN/LSAN; all 59 lint
checks; make -C src, aimee-server, cmd-srcs-compile-check; the db1 module
bundle; both module validators.

Mutation-tested, six mutants, five killed:
  client drops the whole-row check          killed
  client accepts more values than slots     killed
  client stops clamping the bound           killed
  stage drops the ceiling on the bound      killed
  stage treats an empty list as a read      killed
  stage trusts the domain's row count       SURVIVED
The survivor guards against the domain returning more rows than it was given.
No test can kill it from outside, because the real domain does not do that. It
is kept and marked as such in the generator: the failure it prevents is a heap
over-read and the cost is one comparison.

Measured after: 260 of 284 operations fit the wire and 35 of 49 sources are
ready, from 21 sources and 69 operations. agent_work and delegation are
complete. The migration is no longer waiting on the wire.