### PR TITLE
db1: a column is a list one value wide

### DIFF
--- a/docs/proposals/pending/db1-structured-payloads.md
+++ b/docs/proposals/pending/db1-structured-payloads.md
@@ -104,8 +104,14 @@ Three things stay outside the wire, and none of them are payload shapes:
    value* rather than a struct — `int64_t *out, int max`, or
    `char (*out)[N], int max`. Same shape, width one, but the generator builds a
    row from a declared member list and a bare scalar has no members to declare.
-   Five operations across four sources; the survey now counts it separately as
-   `column`.
+
+   The text form is now done: a column declares its row's C type instead of a
+   member list, and the value lands straight in the caller's fixed-width row.
+   It was a smaller change than the name suggests, because a column is a list
+   of width one and the arithmetic was already right. The NUMERIC form
+   (`int64_t *out`) is generated but not enabled — no family that can be
+   activated yet has one, and shipping a path nothing exercises is how the
+   unreachable stage happened. Lifting one check enables it.
 4. **Migrate**, now by whole source, since that is the unit that can move.
 
 Steps 1 and 2 are each a day's work of the kind already done twice — the integer

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -332,8 +332,48 @@ def validate_operations(raw: object, families: dict[str, dict[str, object]]) -> 
             # the rows, which one bounds them, and how many the stage will build.
             # The bound is the caller's, and it is also the allocation: a stage
             # that trusted it would let a caller ask for an arbitrary array.
-            listed = keys(reply["list"], {"out", "bound", "max_rows"}, f"{name}.reply.list")
-            if "struct" not in reply:
+            allowed_list = {"out", "bound", "max_rows"}
+            if "column" in reply["list"]:
+                allowed_list = allowed_list | {"column"}
+            listed = keys(reply["list"], allowed_list, f"{name}.reply.list")
+            # A column is a list whose row is ONE value rather than a struct:
+            # int64_t *out, or char (*out)[WIDTH]. Same frame, same arithmetic,
+            # width one -- the only difference is that the row has no member to
+            # name, so the catalog says what the row's C type is instead.
+            if "column" in listed:
+                column = keys(listed["column"], {"kind", "width"}
+                              if "width" in listed["column"] else {"kind"},
+                              f"{name}.reply.list.column")
+                if "struct" in reply:
+                    fail("reply-column", f"{name} is a column, so it declares no row struct")
+                # Text only, deliberately. The numeric column -- int64_t *out --
+                # exists in the survey but in no family that can be activated
+                # yet, so generating for it would ship a path nothing exercises.
+                # The generator already handles it; lifting this check and
+                # declaring the operation is the whole change when a family
+                # arrives that has one.
+                if str(column["kind"]) != "text":
+                    fail("reply-column",
+                         f"{name} column kind must be text: a numeric column has no operation "
+                         f"to prove it yet")
+                if (str(column["kind"]) == "text") != ("width" in column):
+                    fail("reply-column",
+                         f"{name} column of text needs a width, and a numeric one has none")
+                if "width" in column and not re.fullmatch(r"[A-Z][A-Z0-9_]*", str(column["width"])):
+                    fail("reply-column",
+                         f"{name} column width must be a C identifier, not a literal: the row is "
+                         f"as wide as the header says it is")
+                # reply["fields"] rather than the reply_fields local, which is
+                # not assigned until below: reading it here would validate the
+                # PREVIOUS operation's reply and pass or fail for its reasons.
+                declared_fields = reply["fields"]
+                if not isinstance(declared_fields, list) or len(declared_fields) != 1:
+                    fail("reply-column", f"{name} column declares exactly one value per row")
+                if str(declared_fields[0]["type"]) != str(column["kind"]):
+                    fail("reply-column",
+                         f"{name} column kind {column['kind']!r} disagrees with its declared "
+                         f"field type {declared_fields[0]['type']!r}")
+            elif "struct" not in reply:
                 fail("reply-list", f"{name} declares a list but no row struct")
             if "c_params" not in operation:
                 fail("reply-list", f"{name} declares a list but names no C parameters")
@@ -943,8 +983,12 @@ def client_bytes(catalog: dict[str, object], family: dict[str, object],
     # A returned string maps its own miss (NULL) and never goes through this,
     # so a family of writes, rows and returned strings has no use for it -- and
     # an unused static is a -Werror failure.
-    plain_read = any("struct" not in o["reply"] and o["reply"]["fields"]
-                     and o.get("c_returns") != "text" for o in operations)
+    # A plain read is the only shape that goes through read_result: not a row,
+    # not a list (a COLUMN has fields and no struct, so it looks like a read
+    # until you ask), and not a returned string, which maps its own miss.
+    plain_read = any("struct" not in o["reply"] and "list" not in o["reply"]
+                     and o["reply"]["fields"] and o.get("c_returns") != "text"
+                     for o in operations)
     reader = ("""/* A read answers found(1) / not-found(0) / error(-1), which is what the direct
    implementation returns and what its callers already branch on. */
 static int read_result(int status, const char *value_out)
@@ -981,6 +1025,7 @@ static int read_result(int status, const char *value_out)
             # only the remaining parameters map onto the fields, in order.
             row_out = str(listed["out"])
             bound = str(listed["bound"])
+            column = listed.get("column")
             inputs = [p for p in names if p != row_out]
             outputs = [row_out]
         else:
@@ -1004,7 +1049,14 @@ static int read_result(int status, const char *value_out)
             # Re-order to the C signature: the declarations above are in field
             # order, which is the same order minus the rows parameter.
             declared = dict(zip(inputs, params))
-            declared[row_out] = f"{out_struct} *{row_out}"
+            if column:
+                # char (*out)[WIDTH] for a text column, int64_t *out for a
+                # numeric one: the row's own C type, spelled as the header does.
+                declared[row_out] = (
+                    f"char (*{row_out})[{column['width']}]" if str(column["kind"]) == "text"
+                    else f"{'int64_t' if column['kind'] == 'int64' else 'int'} *{row_out}")
+            else:
+                declared[row_out] = f"{out_struct} *{row_out}"
             params = [declared[p] for p in names]
             guards += [f"!{row_out}", f"{bound} <= 0"]
         elif out_struct:
@@ -1102,8 +1154,10 @@ static int read_result(int status, const char *value_out)
                     body.append(f"      caps[{at}] = sizeof {cell};")
                     slot += 1
                 else:
-                    body.append(f"      values[{at}] = {row_out}[row].{member};")
-                    body.append(f"      caps[{at}] = sizeof {row_out}[row].{member};")
+                    cell = (f"{row_out}[row]" if column
+                            else f"{row_out}[row].{member}")
+                    body.append(f"      values[{at}] = {cell};")
+                    body.append(f"      caps[{at}] = sizeof {cell};")
             body.append("   }")
             body.append("   uint32_t filled = 0;")
             body.append(f"   int status = call_stage({op_symbol}, fields, {arity}, values, caps,")
@@ -1126,7 +1180,9 @@ static int read_result(int status, const char *value_out)
                     if kind in ("int", "int64"):
                         cell = f"scratch[row * {len(numeric)}u + {slot}u]"
                         conv = ("(int)strtol" if kind == "int" else "(int64_t)strtoll")
-                        body.append(f"      {row_out}[row].{member} = {conv}({cell}, NULL, 10);")
+                        target = (f"{row_out}[row]" if column
+                                  else f"{row_out}[row].{member}")
+                        body.append(f"      {target} = {conv}({cell}, NULL, 10);")
                         slot += 1
                 body.append("   }")
                 body.append("   free(scratch);")
@@ -1493,6 +1549,7 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]],
             numeric = [i for i, (_, k) in enumerate(members) if k in ("int", "int64")]
             row_out = str(listed["out"])
             bound = str(listed["bound"])
+            column = listed.get("column")
             inputs = [p for p in operation["c_params"] if p != row_out]
             at = inputs.index(bound)
             held = args[at]
@@ -1502,7 +1559,11 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]],
             parse.append(f"      if ({held} <= 0 || {held} > {listed['max_rows']})\n"
                          f"      {{\n         free(scratch);\n"
                          f"         return AIMEE_MODULE_STATUS_INVALID_REQUEST;\n      }}\n")
-            parse.append(f"      {out_struct} *found = calloc((size_t){held}, sizeof *found);\n"
+            row_decl = (
+                (f"char (*found)[{column['width']}]" if str(column["kind"]) == "text"
+                 else f"{'int64_t' if column['kind'] == 'int64' else 'int'} *found")
+                if column else f"{out_struct} *found")
+            parse.append(f"      {row_decl} = calloc((size_t){held}, sizeof *found);\n"
                          f"      if (!found)\n"
                          f"      {{\n         free(scratch);\n"
                          f"         return AIMEE_MODULE_STATUS_INTERNAL;\n      }}\n"
@@ -1513,12 +1574,14 @@ def stage_bytes(family: dict[str, object], operations: list[dict[str, object]],
             assigns = "".join(
                 f"            cells[row * {width}u + {i}u] = "
                 + (f"numbers[row * {len(numeric)}u + {numeric.index(i)}u];\n"
-                   if kind in ("int", "int64") else f"found[row].{member};\n")
+                   if kind in ("int", "int64")
+                   else (f"found[row];\n" if column else f"found[row].{member};\n"))
                 for i, (member, kind) in enumerate(members))
             converts = "".join(
                 f"            snprintf(numbers[row * {len(numeric)}u + {numeric.index(i)}u], 24,\n"
                 f"                     \"{'%lld' if kind == 'int64' else '%d'}\", "
-                f"{'(long long)' if kind == 'int64' else ''}found[row].{member});\n"
+                f"{'(long long)' if kind == 'int64' else ''}"
+                f"{'found[row]' if column else f'found[row].{member}'});\n"
                 for i, (member, kind) in enumerate(members) if kind in ("int", "int64"))
             numbers = (f"         char (*numbers)[24] = malloc((size_t)produced * "
                        f"{len(numeric)}u * sizeof *numbers);\n" if numeric else "")

--- a/scripts/survey_db1_wire.py
+++ b/scripts/survey_db1_wire.py
@@ -103,18 +103,18 @@ LARGE = re.compile(r"(json|metadata|content|prompt|body|payload|text|summary|blo
 # What a tag still needs from the wire. A tag absent from this map needs
 # nothing: text, int, out_text, out_num, struct_in and struct_out all cross
 # today, the last two since struct flattening.
-# Rows of a struct cross today. Rows of a single value do not: the generator
-# builds a row out of a declared member list, and a bare int64_t or a
-# char (*)[N] has no members to declare. Same shape, width one -- but it is
-# generator work that has not been done, so it is counted as missing.
+# Rows cross today, struct or column: a column is a list one value wide, and
+# char (*out)[N] lands straight in the caller's fixed-width row. The NUMERIC
+# column -- int64_t *out -- is the one that does not, only because no family
+# that can be activated yet has one to prove it against.
 NEEDS = {
-    "out_column": "column",
+    "out_column_numeric": "column",
     "alloc_out": "alloc",
     "json_in": "json",
     "other": "unknown",
 }
 CAPABILITY = {
-    "column": "column -- a list whose row is one value rather than a struct",
+    "column": "column -- a list of one NUMERIC value per row (text columns cross)",
     "alloc": "alloc -- a callee-allocated out-parameter, T ** or char **",
     "json": "json -- a cJSON tree, which the wire carries but the client must build",
     "status": "status -- a return contract beyond ok/miss/fail, per operation",
@@ -212,15 +212,15 @@ def classify(params: str, enums: frozenset[str] = frozenset()) -> list[str]:
             # int64_t matches the _t pattern too, so a column of integers would
             # otherwise be counted as a struct it has no members for.
             row = STRUCT_OUT.search(current).group(1)
-            tags.append("out_column" if row in SCALAR_TYPES else "out_rows")
+            tags.append("out_column_numeric" if row in SCALAR_TYPES else "out_rows")
             index += 2
             continue
         if following and OUT_TEXT_ROWS.search(current) and ARRAY_LEN.search(following):
-            tags.append("out_column")
+            tags.append("out_rows")
             index += 2
             continue
         if OUT_TEXT_ROWS.search(current):
-            tags.append("out_column")
+            tags.append("out_rows")
         elif JSON_IN.search(current):
             tags.append("json_in")
         elif ALLOC_OUT.search(current):

--- a/src/db1_client/conversation.c
+++ b/src/db1_client/conversation.c
@@ -370,4 +370,40 @@ int db1_payload_rewrite_record(const char *session_id, int deferred, int bytes_s
    return write_result(call_stage(AIMEE_DB1_OP_REWRITE_RECORD, fields, 6, NULL, NULL, 0, NULL));
 }
 
+int db1_wm_search_session_ids(const char *query, char (*out)[WM_SESSION_ID_LEN], int max)
+{
+   if (!query || !query[0] || !out || max <= 0)
+      return -1;
+   if (max > 64)
+      max = 64;
+   char arg1[24];
+   snprintf(arg1, sizeof arg1, "%d", max);
+   const char *fields[] = {query, arg1};
+   char **values = malloc((size_t)max * 1u * sizeof *values);
+   size_t *caps = malloc((size_t)max * 1u * sizeof *caps);
+   if (!values || !caps)
+   {
+      free(values);
+      free(caps);
+      return -1;
+   }
+   memset(out, 0, (size_t)max * sizeof *out);
+   for (int row = 0; row < max; ++row)
+   {
+      values[row * 1u + 0u] = out[row];
+      caps[row * 1u + 0u] = sizeof out[row];
+   }
+   uint32_t filled = 0;
+   int status = call_stage(AIMEE_DB1_OP_WM_SEARCH_SESSION_IDS, fields, 2, values, caps,
+                           (uint32_t)(max * 1), &filled);
+   free(values);
+   free(caps);
+   if (status != (int)AIMEE_DB1_STATUS_OK || filled % 1u != 0u)
+   {
+      return -1;
+   }
+   int rows = (int)(filled / 1u);
+   return rows;
+}
+
 /* clang-format on */

--- a/src/modules/db1/conversation_stage.c
+++ b/src/modules/db1/conversation_stage.c
@@ -449,6 +449,65 @@ aimee_module_status_t aimee_db1_stage_conversation(const uint8_t *request_body, 
       rc = db1_payload_rewrite_record(field[0], parsed1, parsed2, parsed3, field[4], field[5]);
       break;
    }
+   case AIMEE_DB1_OP_WM_SEARCH_SESSION_IDS:
+   {
+      if (count != 2u)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[0][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (!field[1][0])
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      int parsed1;
+      if (parse_int(field[1], &parsed1) != 0)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      if (parsed1 <= 0 || parsed1 > 64)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INVALID_REQUEST;
+      }
+      char (*found)[WM_SESSION_ID_LEN] = calloc((size_t)parsed1, sizeof *found);
+      if (!found)
+      {
+         free(scratch);
+         return AIMEE_MODULE_STATUS_INTERNAL;
+      }
+      domain_rows = found;
+      rc = db1_wm_search_session_ids(field[0], found, parsed1);
+      if (rc > 0)
+      {
+         uint32_t produced = ((uint32_t)rc < (uint32_t)parsed1)
+                                 ? (uint32_t)rc : (uint32_t)parsed1;
+         const char **cells = malloc((size_t)produced * 1u * sizeof *cells);
+         if (!cells)
+         {
+            free(cells);
+            free(scratch);
+            free(domain_rows);
+            return AIMEE_MODULE_STATUS_INTERNAL;
+         }
+         cells_owned = cells;
+         for (uint32_t row = 0; row < produced; ++row)
+         {
+            cells[row * 1u + 0u] = found[row];
+         }
+         rows = cells;
+         row_count = produced * 1u;
+      }
+      listed = 1;
+      break;
+   }
    default:
       free(scratch);
       return AIMEE_MODULE_STATUS_INVALID_REQUEST;

--- a/src/modules/db1/db1_module_api.h
+++ b/src/modules/db1/db1_module_api.h
@@ -62,13 +62,14 @@
 #define AIMEE_DB1_EVENT_CONVERSATION 11779u
 #define AIMEE_DB1_STAGE_CONVERSATION 3u
 
-#define AIMEE_DB1_OP_REWRITE_STATE_GET   1u
-#define AIMEE_DB1_OP_REWRITE_STATE_SET   2u
-#define AIMEE_DB1_OP_WM_SET              3u
-#define AIMEE_DB1_OP_WM_GET              4u
-#define AIMEE_DB1_OP_WM_LIST             5u
-#define AIMEE_DB1_OP_WM_ASSEMBLE_CONTEXT 6u
-#define AIMEE_DB1_OP_REWRITE_RECORD      7u
+#define AIMEE_DB1_OP_REWRITE_STATE_GET     1u
+#define AIMEE_DB1_OP_REWRITE_STATE_SET     2u
+#define AIMEE_DB1_OP_WM_SET                3u
+#define AIMEE_DB1_OP_WM_GET                4u
+#define AIMEE_DB1_OP_WM_LIST               5u
+#define AIMEE_DB1_OP_WM_ASSEMBLE_CONTEXT   6u
+#define AIMEE_DB1_OP_REWRITE_RECORD        7u
+#define AIMEE_DB1_OP_WM_SEARCH_SESSION_IDS 8u
 
 /* Wire bounds, carried from the catalog. VALUE_MAX is the widest
    reply a stage may build; FIELDS_MAX is the widest request arity, and

--- a/src/modules/db1/eventcontract/operations.json
+++ b/src/modules/db1/eventcontract/operations.json
@@ -1047,6 +1047,58 @@
     "fields": [],
     "max_bytes": 0
    }
+  },
+  {
+   "family": "conversation",
+   "id": 8,
+   "name": "wm_search_session_ids",
+   "c_name": "db1_wm_search_session_ids",
+   "c_params": [
+    "query",
+    "out",
+    "max"
+   ],
+   "wire_format": "db1-fields-v2",
+   "scope": "global",
+   "transaction": "none",
+   "idempotency": "safe",
+   "results": [
+    "ok",
+    "invalid",
+    "failed"
+   ],
+   "request": {
+    "fields": [
+     {
+      "name": "query",
+      "type": "text",
+      "required": true
+     },
+     {
+      "name": "max",
+      "type": "int",
+      "required": true
+     }
+    ]
+   },
+   "reply": {
+    "list": {
+     "out": "out",
+     "bound": "max",
+     "max_rows": 64,
+     "column": {
+      "kind": "text",
+      "width": "WM_SESSION_ID_LEN"
+     }
+    },
+    "fields": [
+     {
+      "name": "session_id",
+      "type": "text"
+     }
+    ],
+    "max_bytes": 8192
+   }
   }
  ]
 }

--- a/src/tests/test_db1_conversation_client.c
+++ b/src/tests/test_db1_conversation_client.c
@@ -21,6 +21,8 @@
 /* --- the stubbed bus ------------------------------------------------------ */
 
 #define WM_LIST_WIDTH 8u
+/* A column is a list one value wide. */
+#define WM_COLUMN_WIDTH 1u
 
 static int stub_available = 1;
 static aimee_module_call_result_t stub_result = AIMEE_MODULE_CALL_OK;
@@ -35,6 +37,8 @@ static int stub_extra_values;
 /* When set, the reply is this single value rather than rows: the returned
    string path answers with one. */
 static const char *stub_text;
+/* Rows are this many values wide; a column reply is one. */
+static uint32_t stub_width = WM_LIST_WIDTH;
 
 int obs_bus_module_available(uint32_t event_kind)
 {
@@ -86,14 +90,14 @@ obs_bus_module_call(uint32_t event_kind, uint32_t stage_id, uint64_t trace_id, u
       *response_len = 12u + n;
       return AIMEE_MODULE_CALL_OK;
    }
-   uint32_t values = stub_rows * WM_LIST_WIDTH + (uint32_t)stub_extra_values;
+   uint32_t values = stub_rows * stub_width + (uint32_t)stub_extra_values;
    aimee_db1_put_u32(out, stub_status);
    aimee_db1_put_u32(out + 4u, values);
    uint32_t at = 8u;
    for (uint32_t i = 0; i < values; ++i)
    {
       char text[64];
-      cell_text(text, sizeof text, i / WM_LIST_WIDTH, i % WM_LIST_WIDTH);
+      cell_text(text, sizeof text, i / stub_width, i % stub_width);
       uint32_t n = (uint32_t)strlen(text);
       if (response_capacity < at + 4u + n)
          return AIMEE_MODULE_CALL_RESPONSE_TOO_LARGE;
@@ -116,6 +120,7 @@ static void reset(void)
    stub_rows = 0;
    stub_extra_values = 0;
    stub_text = NULL;
+   stub_width = WM_LIST_WIDTH;
 }
 
 /* --- reading back the frame the client emitted ---------------------------- */
@@ -319,9 +324,59 @@ static void test_an_unreachable_store_returns_no_string(void)
    printf("  PASS: test_an_unreachable_store_returns_no_string\n");
 }
 
+/* A column is a list whose row is one value rather than a struct: the same
+   frame and the same arithmetic, width one. The value lands in the caller's
+   fixed-width row directly, with no member to name. */
+static void test_a_column_fills_the_callers_rows(void)
+{
+   reset();
+   stub_width = WM_COLUMN_WIDTH;
+   stub_rows = 3u;
+   char ids[8][WM_SESSION_ID_LEN];
+   int found = db1_wm_search_session_ids("needle", ids, 8);
+   assert(found == 3);
+   /* member 0 of each row, because a column has only member 0. */
+   assert(strcmp(ids[0], "1000") == 0);
+   assert(strcmp(ids[1], "1001") == 0);
+   assert(strcmp(ids[2], "1002") == 0);
+   assert(ids[3][0] == '\0');
+   printf("  PASS: test_a_column_fills_the_callers_rows\n");
+}
+
+/* The same refusals a struct list makes, because it is the same code path:
+   an empty column is zero rows, and a reply longer than the caller's array is
+   refused rather than truncated. */
+static void test_a_column_refuses_what_a_row_list_refuses(void)
+{
+   reset();
+   stub_width = WM_COLUMN_WIDTH;
+   char ids[4][WM_SESSION_ID_LEN];
+   assert(db1_wm_search_session_ids("needle", ids, 4) == 0);
+
+   reset();
+   stub_width = WM_COLUMN_WIDTH;
+   stub_rows = 9u;
+   assert(db1_wm_search_session_ids("needle", ids, 4) == -1);
+
+   reset();
+   stub_width = WM_COLUMN_WIDTH;
+   stub_status = AIMEE_DB1_STATUS_FAILED;
+   stub_rows = 1u;
+   assert(db1_wm_search_session_ids("needle", ids, 4) == -1);
+
+   reset();
+   assert(db1_wm_search_session_ids(NULL, ids, 4) == -1);
+   assert(db1_wm_search_session_ids("needle", NULL, 4) == -1);
+   assert(db1_wm_search_session_ids("needle", ids, 0) == -1);
+   assert(stub_calls == 0);
+   printf("  PASS: test_a_column_refuses_what_a_row_list_refuses\n");
+}
+
 int main(void)
 {
    printf("db1_conversation_client:\n");
+   test_a_column_fills_the_callers_rows();
+   test_a_column_refuses_what_a_row_list_refuses();
    test_a_returned_string_is_the_callers_to_free();
    test_an_empty_returned_string_is_a_miss();
    test_an_unreachable_store_returns_no_string();

--- a/src/tests/test_db1_module_stage.c
+++ b/src/tests/test_db1_module_stage.c
@@ -628,9 +628,72 @@ static void test_an_unassembled_context_is_a_miss(void)
    printf("  PASS: test_an_unassembled_context_is_a_miss\n");
 }
 
+/* A column crosses as one value per row. The reply's count is the row count
+   because the width is one, and the stage allocates the caller's fixed-width
+   rows rather than a struct array. */
+static void test_a_column_of_session_ids_crosses(void)
+{
+   char path[PATH_MAX];
+   snprintf(path, sizeof(path), "%s/aimee-test-db1-wmcol-%d.db", platform_tmpdir(), (int)getpid());
+   remove(path);
+   db1_shutdown();
+   assert(db1_init(path) == 0);
+
+   assert(db1_wm_set("sess-col-a", "k", "findable marker", "notes", 0) == 0);
+   assert(db1_wm_set("sess-col-b", "k", "findable marker", "notes", 0) == 0);
+   assert(db1_wm_set("sess-col-c", "k", "unrelated", "notes", 0) == 0);
+
+   uint8_t req[1024], resp[4096];
+   uint32_t resp_len = 0;
+   const char *args[] = {"findable", "16"};
+   uint32_t len = fields_frame(req, AIMEE_DB1_OP_WM_SEARCH_SESSION_IDS, args, 2);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_OK);
+   assert(aimee_db1_get_u32(resp) == AIMEE_DB1_STATUS_OK);
+   /* Two sessions matched, one value each: width one means count is rows. */
+   assert(aimee_db1_get_u32(resp + 4u) == 2u);
+   uint32_t n = 0;
+   const char *first = reply_value(resp, resp_len, 0u, &n);
+   assert(n == strlen("sess-col-a") &&
+          (memcmp(first, "sess-col-a", n) == 0 || memcmp(first, "sess-col-b", n) == 0));
+
+   db1_shutdown();
+   remove(path);
+   printf("  PASS: test_a_column_of_session_ids_crosses\n");
+}
+
+/* The bound is still an allocation, and still checked before anything is
+   allocated from it -- a column sizes an array of fixed-width rows. */
+static void test_a_column_bound_is_still_checked(void)
+{
+   char path[PATH_MAX];
+   snprintf(path, sizeof(path), "%s/aimee-test-db1-wmcolb-%d.db", platform_tmpdir(), (int)getpid());
+   remove(path);
+   db1_shutdown();
+   assert(db1_init(path) == 0);
+
+   uint8_t req[1024], resp[4096];
+   uint32_t resp_len = 0;
+   const char *too_many[] = {"needle", "65"};
+   uint32_t len = fields_frame(req, AIMEE_DB1_OP_WM_SEARCH_SESSION_IDS, too_many, 2);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_INVALID_REQUEST);
+
+   const char *none[] = {"needle", "0"};
+   len = fields_frame(req, AIMEE_DB1_OP_WM_SEARCH_SESSION_IDS, none, 2);
+   assert(call_stage(AIMEE_DB1_STAGE_CONVERSATION, req, len, resp, &resp_len) ==
+          AIMEE_MODULE_STATUS_INVALID_REQUEST);
+
+   db1_shutdown();
+   remove(path);
+   printf("  PASS: test_a_column_bound_is_still_checked\n");
+}
+
 int main(void)
 {
    printf("db1_module_stage:\n");
+   test_a_column_of_session_ids_crosses();
+   test_a_column_bound_is_still_checked();
    test_assembled_context_crosses_and_is_released();
    test_an_unassembled_context_is_a_miss();
    test_malformed_frames_are_refused();


### PR DESCRIPTION
Four of the five remaining "column" operations take char (*out)[N] rather than
a struct array -- a list of one text value per row. The generator built rows
from a declared member list, and a bare row has no member to name, so a column
declares its row's C type instead:

  "column": {"kind": "text", "width": "WM_SESSION_ID_LEN"}

and the value lands straight in out[row]. Nothing else moved: same frame, same
bound, same reply arithmetic, width one. The width is required to be a C
identifier rather than a literal, because the row is exactly as wide as the
header says it is and a number here would drift from it silently.

Proved with db1_wm_search_session_ids, which also completes wm: seven of its
eight symbols are now declared, and the eighth is db1_wm_gc, which takes no
arguments and has no linked caller.

The numeric column, int64_t *out, is generated but refused by the validator.
No family that can be activated yet has one to prove it against, and shipping a
generated path that nothing exercises is exactly how the conversation stage came
to be unreachable. Lifting one check and declaring an operation is the change
when a family arrives that needs it.

read_result was being emitted for a column. It has reply fields and no struct,
so the "is this a plain read" test said yes -- it looks like a read until you
ask whether it is a list. That is a -Werror unused-function on any family whose
reads are all rows, columns or returned strings, which is what caught it.

Verified: the FULL unit-tests target (only unit-test-vault-bootstrap fails, and
it fails on a clean checkout too -- it asserts on credential environment
variables and passes under env -i); 40 generator tests; three db1 suites clean
under ASAN/LSAN; all 59 lint checks; make -C src, aimee-server,
cmd-srcs-compile-check; the module bundle; both module validators;
module-inventory and db2 link closure against origin/testing.

Mutation-tested, three mutants, three killed -- all by the C type system, which
is a real kill: a column accessor that keeps the struct member, a stage that
indexes a member of a row that has none, and a column declared as a flat char *
each fail to compile. The types make the wrong version unbuildable rather than
merely wrong.

Measured after: 271 of 291 operations fit the wire, 37 of 48 sources ready,
from 34. What is left is alloc as an out-parameter (10), status (6), json (3)
and the numeric column (1).