### PR TITLE
db1: the module was serving every request without a database

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -117,6 +117,16 @@ case "$AIMEE_WFE_ENGINE" in
 esac
 export AIMEE_WFE_HTTP_SOCKET="${AIMEE_WFE_HTTP_SOCKET:-$AIMEE_HOME/aimee-wfe-http.sock}"
 export AIMEE_MODULE_BUS_SOCKET="${AIMEE_MODULE_BUS_SOCKET:-$AIMEE_HOME/server-module-bus.sock}"
+# The DB1 module is a separate process and cannot read the daemon's config, so
+# it is told which database to open and refuses to start without it. That is
+# deliberate: a module that guessed a default would serve a DIFFERENT, empty
+# store whenever an operator moved the database, and an empty store answers
+# every read with "no such row" rather than an error.
+#
+# This default matches config's own default. An operator who overrides db1_path
+# in the configuration MUST set AIMEE_DB1_PATH to match, or the module will
+# refuse to start -- loudly, which is the point.
+export AIMEE_DB1_PATH="${AIMEE_DB1_PATH:-$AIMEE_HOME/aimee.db}"
 MODULE_MANIFEST="${AIMEE_MODULE_MANIFEST:-/opt/aimee/module-grants/server.modules}"
 # Existing appliances may need to recover SQLite WAL state and refresh seeded
 # workflow definitions before the C resource socket appears.  A real upgraded

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -294,13 +294,14 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 229 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
+The binaries read 230 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
 
 ### Paths & assets
 
 | Variable | Description |
 |----------|-------------|
 | `AIMEE_BUNDLED_SKILLS_DIR` | Override directory for the bundled skills. |
+| `AIMEE_DB1_PATH` | SQLite database the DB1 module process opens. The module is a separate process and cannot read the config store, so it is told the path and refuses to start without it rather than guessing a default and serving a different, empty database. Set it whenever `db1_path` is overridden in the configuration; the container entrypoint otherwise defaults it to `<AIMEE_HOME>/aimee.db`, which is config's own default. |
 | `AIMEE_FORENSICS_DIR` | Directory for shutdown-forensics dumps. |
 | `AIMEE_GUARDRAILS_PATH` | Path to the guardrails policy file. |
 | `AIMEE_HARNESS_MEMORY_SCOPES` | Path to the agent memory-surface registry config (default `<AIMEE_HOME>/harness_memory_scopes.conf`). Each `client:projects_root:memory_seg` line adds a new agent or overrides a built-in's paths for memory-write interception (writes are redirected into aimee's db1). |

--- a/scripts/export_c_repositories.py
+++ b/scripts/export_c_repositories.py
@@ -222,11 +222,32 @@ def module_owned_files(module_id: str, descriptor: dict[str, object]) -> list[st
     return result
 
 
+NAME_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def c_process_init_symbol(module_id: str, descriptor: dict) -> str | None:
+    """The symbol the process must call before it serves, if it declares one.
+
+    A module owning process-wide state -- an open database, a cache -- has to
+    build it before the runtime registers its stages. Declaring the symbol here
+    rather than hard-coding a call keeps the generated main the same shape for
+    every module, and makes "this module needs setting up" a reviewable line in
+    its descriptor instead of something the reader has to infer from absence.
+    """
+    symbol = descriptor.get("c_init")
+    if symbol is None:
+        return None
+    if not isinstance(symbol, str) or not NAME_PATTERN.fullmatch(symbol):
+        raise ExportError(f"{module_id}: c_init must be a C identifier")
+    return symbol
+
+
 def module_main(
     module_id: str,
     principal_ref: int,
     stages: list[dict[str, object]],
     has_handler: bool = False,
+    init_symbol: str | None = None,
 ) -> str:
     entries = "\n".join(
         f"   {{{stage['event_kind']}u, {stage['id']}u}},"
@@ -238,10 +259,24 @@ extern aimee_module_status_t aimee_module_handler(
     uint32_t *, void *);
 """ if has_handler else ""
     handler_value = "aimee_module_handler" if has_handler else "NULL"
+    # A module that owns process-wide state has to open it before it serves.
+    # Without this the process attaches, registers its stages and answers every
+    # one of them against an unopened store -- which reads to a caller as "the
+    # row is not there" rather than "this module cannot serve", so the failure
+    # is invisible exactly where it matters.
+    init_declaration = f"""
+extern int {init_symbol}(void);
+""" if init_symbol else ""
+    init_call = f"""   if ({init_symbol}() != 0)
+   {{
+      fprintf(stderr, "{module_id}: {init_symbol} failed; refusing to serve\\n");
+      return 1;
+   }}
+""" if init_symbol else ""
     return f"""#include <aimee/core/event_bus/module_runtime.h>
 
 #include <stdio.h>
-{handler_declaration}
+{handler_declaration}{init_declaration}
 
 static const aimee_module_stage_t stages[] = {{
 {entries}
@@ -254,7 +289,7 @@ int main(int argc, char **argv)
       fprintf(stderr, "usage: %s DAEMON_MODULE_BUS_SOCKET\\n", argv[0]);
       return 2;
    }}
-   const aimee_module_process_config_t config = {{
+{init_call}   const aimee_module_process_config_t config = {{
        .socket_path = argv[1],
        .module_name = "{module_id}",
        .principal_class = {PRINCIPAL_CLASS}u,
@@ -500,6 +535,7 @@ def export_module(
     declared_sources = descriptor.get("sources", [])
     assert isinstance(declared_sources, list)
     has_handler = c_process_has_handler(declared_sources)
+    init_symbol = c_process_init_symbol(module_id, descriptor)
     repository = output_root / f"aimee-module-{module_id}"
     repository.mkdir()
     for relative in owned:
@@ -529,7 +565,7 @@ serve={serve}
         if runtime == "c":
             write_text(
                 repository / "runtime/main.c",
-                module_main(module_id, principal_ref, stages, has_handler),
+                module_main(module_id, principal_ref, stages, has_handler, init_symbol),
             )
             write_text(
                 repository / "CMakeLists.txt",
@@ -771,10 +807,11 @@ def export_runtime_bundle(output_root: Path) -> int:
                 module_id, descriptor
             )
             has_handler = c_process_has_handler(sources)
+            init_symbol = c_process_init_symbol(module_id, descriptor)
             main_path = f"src/{binary}.c"
             write_text(
                 output_root / main_path,
-                module_main(module_id, principal_ref, stages, has_handler),
+                module_main(module_id, principal_ref, stages, has_handler, init_symbol),
             )
             c_builds.append({
                 "id": module_id,

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -667,6 +667,7 @@ ENV_GROUP_ORDER = [
 ENV_DESC = {
     # Paths & assets
     "AIMEE_HOME": ("Paths & assets", "Root of the per-user state/config store (config, DB1, `workflows/`, keys). Overrides the platform default."),
+    "AIMEE_DB1_PATH": ("Paths & assets", "SQLite database the DB1 module process opens. The module is a separate process and cannot read the config store, so it is told the path and refuses to start without it rather than guessing a default and serving a different, empty database. Set it whenever `db1_path` is overridden in the configuration; the container entrypoint otherwise defaults it to `<AIMEE_HOME>/aimee.db`, which is config's own default."),
     "AIMEE_INSTALL_PREFIX": ("Paths & assets", "Install prefix used to locate bundled assets and plugins."),
     "AIMEE_BUNDLED_SKILLS_DIR": ("Paths & assets", "Override directory for the bundled skills."),
     "AIMEE_TOOLSETS_CONFIG": ("Paths & assets", "Path to a toolsets config file (overrides the default tool allowlists)."),

--- a/scripts/gen_db1_contract.py
+++ b/scripts/gen_db1_contract.py
@@ -39,8 +39,9 @@ STAGES_HEADER = Path("src/modules/db1/db1_stages.h")
 # absence from DB1_SRCS is the design rather than evidence of a migration.
 # db1_time.c supplies now_utc, which every process defines for itself -- the
 # daemon from util.c. In DB1_SRCS it would be a duplicate symbol there; out of
-# the module it is an undefined one here.
-MODULE_ONLY_SOURCES = frozenset({"module_adapter.c", "db1_time.c"})
+# the module it is an undefined one here. db1_module_init.c opens the store the
+# module serves from, which the daemon opens for itself.
+MODULE_ONLY_SOURCES = frozenset({"module_adapter.c", "db1_time.c", "db1_module_init.c"})
 
 # DB1's principal ref. Event kinds are carved 4096 + ref*256 + stage, and a
 # family's id IS its future stage id, so the arithmetic is fixed here too.

--- a/scripts/validate_module_descriptors.py
+++ b/scripts/validate_module_descriptors.py
@@ -227,7 +227,11 @@ def validate_descriptor(value: object, required: set[str], optional: set[str]) -
     if identifier not in required | optional:
         fail("module-unknown", f"unknown module ID {identifier!r}", "/id")
     required_keys = BASE_KEYS | ({"enabled_by_default"} if identifier in optional else set())
-    allowed_keys = required_keys | set(OWNERSHIP_FIELDS) | {"ownership_complete", "c_build"}
+    # c_init names a symbol the module's process must call before it serves.
+    # Optional, because most modules hold no process-wide state; declared here
+    # rather than inferred, so "this module needs opening" is reviewable.
+    allowed_keys = (required_keys | set(OWNERSHIP_FIELDS)
+                    | {"ownership_complete", "c_build", "c_init"})
     if not required_keys <= set(value) or not set(value) <= allowed_keys:
         fail(
             "descriptor-keys",

--- a/src/modules/db1/db1_module_init.c
+++ b/src/modules/db1/db1_module_init.c
@@ -1,0 +1,45 @@
+/* db1_module_init.c: open the store before the process serves a single stage.
+ *
+ * The DB1 domain keeps one process-wide SQLite connection, set by db1_init and
+ * read by every domain function through db1_conn(). The module process is a
+ * separate process from the daemon, so it has its own copy of that global, and
+ * nothing was setting it: the generated main went straight to
+ * aimee_module_process_run.
+ *
+ * The result was worse than a crash. The process attached, registered its
+ * stages and answered every request -- with db1_conn() returning NULL, so each
+ * domain function took its "no database" branch and returned -1. The stage
+ * mapped that to FAILED, or for a read to MISSING, and MISSING is the same
+ * shape as "there is no such row". A caller asking who owns a branch was told
+ * nobody did. The module looked healthy throughout.
+ *
+ * The path comes from the environment and is NOT derived here. The daemon's
+ * path is a configured value an operator may override, and this module cannot
+ * read that configuration: it is deliberately self-contained, linking neither
+ * the config module nor aimee_home(). Guessing "the default location" would
+ * work until someone moved the database, and then this process would serve a
+ * DIFFERENT, empty store -- which is the failure above wearing a disguise.
+ * Being told or refusing to start are the only two safe answers.
+ */
+#include "db1.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int aimee_db1_module_init(void)
+{
+   const char *path = getenv("AIMEE_DB1_PATH");
+   if (!path || !path[0])
+   {
+      fprintf(stderr,
+              "db1: AIMEE_DB1_PATH is unset; refusing to serve. This process cannot read the "
+              "daemon's configuration, so it must be told which database to open.\n");
+      return -1;
+   }
+   if (db1_init(path) != 0)
+   {
+      fprintf(stderr, "db1: cannot open %s; refusing to serve\n", path);
+      return -1;
+   }
+   return 0;
+}

--- a/src/modules/db1/eventcontract/operations.json
+++ b/src/modules/db1/eventcontract/operations.json
@@ -6,6 +6,7 @@
  "infrastructure_sources": [
   "db",
   "db1_init",
+  "db1_module_init",
   "db1_time",
   "db1_write",
   "db_schema",

--- a/src/modules/db1/module.yaml
+++ b/src/modules/db1/module.yaml
@@ -9,6 +9,7 @@
     "supported": false
   },
   "ownership_complete": true,
+  "c_init": "aimee_db1_module_init",
   "sources": [
     "src/modules/db1/agent_jobs.c",
     "src/modules/db1/agent_log.c",
@@ -24,6 +25,7 @@
     "src/modules/db1/db.c",
     "src/modules/db1/db1_cron_jobs.c",
     "src/modules/db1/db1_init.c",
+    "src/modules/db1/db1_module_init.c",
     "src/modules/db1/db1_time.c",
     "src/modules/db1/db1_trigger.c",
     "src/modules/db1/db1_write.c",

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -673,6 +673,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-db1-git-ownership-client \
                $(TESTPREFIX)/unit-test-db1-conversation-client \
                $(TESTPREFIX)/unit-test-db1-agent-work-client \
+               $(TESTPREFIX)/unit-test-db1-module-bus \
                $(TESTPREFIX)/unit-test-db1-roundtable-pipeline \
                $(TESTPREFIX)/unit-test-roundtable-pipeline-eval \
                $(TESTPREFIX)/unit-test-roundtable-pipeline-chunk \
@@ -4998,6 +4999,45 @@ $(TESTPREFIX)/unit-test-db1-git-ownership-client: \
                                        $(OBJDIR)/db1_client/git_ownership.o \
                                        $(OBJDIR)/module_json_call.o $(OBJDIR)/log.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+# The composition, not either half: the real module binary, the real bus, and
+# the ordinary generated clients the daemon links. Deliberately links
+# DB1_CLIENT_OBJS and NOT the DB1 domain -- linking the domain would answer
+# every call in-process and prove nothing about the module.
+$(TESTPREFIX)/unit-test-db1-module-bus: \
+                                       $(OBJDIR)/tests/test_db1_module_bus.o \
+                                       $(DB1_CLIENT_OBJS) \
+                                       $(OBS_BUS_LINK_OBJS) \
+                                       $(OBJDIR)/core/event_bus/bus_client.o \
+                                       $(OBJDIR)/core/event_bus/bus_attach.o \
+                                       $(OBJDIR)/core/event_bus/bus_host.o \
+                                       $(OBJDIR)/core/event_bus/bus_route.o \
+                                       $(OBJDIR)/core/event_bus/bus_region.o \
+                                       $(OBJDIR)/core/event_bus/bus_region_host.o \
+                                       $(OBJDIR)/core/event_bus/bus_ring.o \
+                                       $(OBJDIR)/core/event_bus/bus_arena.o \
+                                       $(OBJDIR)/core/event_bus/bus_wire.o \
+                                       $(OBJDIR)/core/event_bus/bus_capture.o \
+                                       $(OBJDIR)/module_json_call.o $(OBJDIR)/log.o \
+                                       $(OBJDIR)/modules/config/config.o \
+                                       $(OBJDIR)/platform_random.o \
+                                       $(OBJDIR)/posix/platform_random.o \
+                                       $(OBJDIR)/aimee_home.o \
+                                       $(OBJDIR)/posix/platform_path.o \
+                                       | $(OBJDIR)/aimee-module-db1
+	$(TESTLINK_MIN) -o $@ $^ $(EXTRA_L_FLAGS) -lpthread
+
+.PHONY: unit-test-db1-module-bus
+unit-test-db1-module-bus: $(TESTPREFIX)/unit-test-db1-module-bus $(OBJDIR)/aimee-module-db1
+	$< $(OBJDIR)/aimee-module-db1
+
+# The module binary is produced by the bundle exporter, not this Makefile: the
+# process contract owns which sources a module compiles, and duplicating that
+# list here would let the two drift.
+$(OBJDIR)/aimee-module-db1:
+	@rm -rf $(OBJDIR)/module-bundle
+	@python3 ../scripts/export_c_repositories.py --runtime-bundle $(abspath $(OBJDIR))/module-bundle >/dev/null
+	@python3 ../scripts/build_c_module_runtime_bundle.py --bundle $(abspath $(OBJDIR))/module-bundle --output $(abspath $(OBJDIR)) --placement server >/dev/null
 
 $(TESTPREFIX)/unit-test-db1-agent-work-client: \
                                        $(OBJDIR)/tests/test_db1_agent_work_client.o \

--- a/src/tests/test_db1_module_bus.c
+++ b/src/tests/test_db1_module_bus.c
@@ -1,0 +1,221 @@
+/* test_db1_module_bus.c: the DB1 module, proven to actually serve.
+ *
+ * Every other DB1 test proves one half. The client suites stub the bus and
+ * check the bytes; the stage suite calls the handler in-process and checks the
+ * reply. Both passed while the real module process could not answer a single
+ * request -- its generated main went straight to the runtime without ever
+ * calling db1_init, so every domain function ran against a NULL connection and
+ * returned "no database", which a read reports as MISSING and a caller reads as
+ * "there is no such row".
+ *
+ * That is the gap a halves-only proof leaves: the composition was never
+ * exercised. This fixture closes it. It stands up the daemon's module endpoint,
+ * execs the REAL module binary against it, and drives the ordinary generated
+ * clients -- the same functions the daemon links -- then asserts the data came
+ * back rather than an absence.
+ *
+ * A failure to start the module is a failure of this test, never a skip: a skip
+ * would retire the only coverage the composition has.
+ */
+#include <errno.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <aimee/audit/obs_bus.h>
+
+#include "cognify_jobs.h"
+#include "db1_module_api.h"
+#include "git_ownership.h"
+#include "platform_test_util.h"
+#include "wm.h"
+
+static char g_tmp[512];
+static pid_t g_module = -1;
+
+static void must(int condition, const char *what)
+{
+   if (condition)
+      return;
+   fprintf(stderr, "db1-module-bus: FAILED to %s (errno=%d)\n", what, errno);
+   if (g_module > 0)
+      kill(g_module, SIGKILL);
+   exit(1);
+}
+
+static void write_grant(const char *policy_dir, const char *executable)
+{
+   char path[640];
+   snprintf(path, sizeof(path), "%s/db1.grant", policy_dir);
+   FILE *file = fopen(path, "w");
+   must(file != NULL, "open the grant manifest");
+   /* Every declared stage, not a convenient subset: an ungranted stage and an
+    * unserved one are indistinguishable to a caller, so granting only what this
+    * test happens to call would hide a stage that never registered. */
+   fprintf(file,
+           "version=1\nprincipal_class=1\nprincipal_ref=30\nuid=self\n"
+           "executable=%s\nserve=%u,%u,%u,%u\n",
+           executable, AIMEE_DB1_EVENT_ECONOMIZER_STATE, AIMEE_DB1_EVENT_GIT_OWNERSHIP,
+           AIMEE_DB1_EVENT_CONVERSATION, AIMEE_DB1_EVENT_AGENT_WORK);
+   must(fclose(file) == 0, "write the grant manifest");
+}
+
+static void start_module(const char *executable, const char *socket_path, const char *database)
+{
+   pid_t parent = getpid();
+   pid_t child = fork();
+   must(child >= 0, "fork the module");
+   if (child == 0)
+   {
+      prctl(PR_SET_PDEATHSIG, SIGKILL);
+      if (getppid() != parent)
+         _exit(0);
+      /* The module is told which database to open. It cannot read the daemon's
+         configuration, and deriving a default would let it serve a different
+         store than the one the caller means. */
+      setenv("AIMEE_DB1_PATH", database, 1);
+      execl(executable, executable, socket_path, (char *)NULL);
+      _exit(127);
+   }
+   g_module = child;
+
+   for (int tick = 0; tick < 200; tick++)
+   {
+      if (obs_bus_module_available(AIMEE_DB1_EVENT_AGENT_WORK))
+         return;
+      int status = 0;
+      if (waitpid(child, &status, WNOHANG) == child)
+      {
+         g_module = -1;
+         must(0, "module exited before it attached");
+      }
+      struct timespec pause = {0, 50 * 1000 * 1000};
+      nanosleep(&pause, NULL);
+   }
+   must(0, "module never registered its stages");
+}
+
+static void stop_module(void)
+{
+   if (g_module <= 0)
+      return;
+   kill(g_module, SIGTERM);
+   waitpid(g_module, NULL, 0);
+   g_module = -1;
+}
+
+/* A write followed by a read, both across the bus. This is the assertion the
+   halves could not make: that what one call stored, another call finds. With no
+   database open both calls "succeed" in the sense of returning, and the read
+   reports nothing -- which is why the failure was invisible. */
+static void test_a_write_is_visible_to_a_later_read(void)
+{
+   must(db1_wm_set("sess-bus", "alpha", "stored over the bus", "notes", 0) == 0,
+        "store a working-memory entry through the module");
+
+   wm_entry_t entry;
+   memset(&entry, 0, sizeof entry);
+   must(db1_wm_get("sess-bus", "alpha", &entry) == 0, "read the entry back");
+   must(strcmp(entry.value, "stored over the bus") == 0, "read the value that was written");
+   printf("  PASS: a write is visible to a later read\n");
+}
+
+/* Rows cross whole. A list that came back empty would be indistinguishable from
+   a store that was never opened, so the count and the contents are both checked. */
+static void test_rows_cross_the_bus(void)
+{
+   must(db1_wm_set("sess-rows", "one", "first", "notes", 0) == 0, "store the first row");
+   must(db1_wm_set("sess-rows", "two", "second", "notes", 0) == 0, "store the second row");
+
+   wm_entry_t rows[8];
+   int found = db1_wm_list("sess-rows", "", rows, 8);
+   must(found == 2, "list both rows");
+   must(rows[0].key[0] != '\0' && rows[1].key[0] != '\0', "rows carry their members");
+   printf("  PASS: rows cross the bus\n");
+}
+
+/* The queue's status takes no arguments at all, and a claim distinguishes an
+   empty queue from a broken one. Against an unopened store the claim returns
+   -1, so "empty" and "broken" would be the same answer here too. */
+static void test_the_queue_answers_across_the_bus(void)
+{
+   db1_cognify_job_t job;
+   must(db1_cognify_job_claim_next(&job) == 0, "an empty queue is nothing to claim, not an error");
+
+   must(db1_cognify_job_enqueue(4294967297LL) == 0, "enqueue a job");
+
+   db1_cognify_job_stats_t stats;
+   memset(&stats, 0, sizeof stats);
+   must(db1_cognify_job_status(&stats) == 0, "read the queue status with no arguments");
+   must(stats.pending == 1, "the enqueued job is pending");
+
+   must(db1_cognify_job_claim_next(&job) == 1, "claim the job that is there");
+   must(job.memory_id == 4294967297LL, "the 64-bit id survived the crossing");
+   printf("  PASS: the queue answers across the bus\n");
+}
+
+/* Branch ownership was the first domain migrated and has been reached over the
+   bus for the longest. It is checked here because it is the one whose silent
+   failure is a safety property: a caller told "nobody owns this branch" will
+   take a branch somebody else holds. */
+static void test_branch_ownership_round_trips(void)
+{
+   must(db1_git_ownership_upsert("/repo/bus", "feature", "sess-owner") == 0,
+        "record a branch owner");
+   char owner[128] = {0};
+   must(db1_git_ownership_get_owner("/repo/bus", "feature", owner, sizeof owner) == 1,
+        "find the owner that was just recorded");
+   must(strcmp(owner, "sess-owner") == 0, "the owner is the session that took it");
+   printf("  PASS: branch ownership round trips\n");
+}
+
+int main(int argc, char **argv)
+{
+   /* The suite runs its binaries with no arguments, so default to where the
+      Makefile builds the module rather than needing a bespoke invocation --
+      a test only reachable by a hand-written command is a test CI does not
+      run, which is how the composition went unchecked in the first place. */
+   const char *module = (argc >= 2) ? argv[1] : "build/obj/aimee-module-db1";
+   must(access(module, X_OK) == 0, "find the module binary (pass its path, or build it)");
+
+   snprintf(g_tmp, sizeof(g_tmp), "%s/aimee-db1-bus-%d", platform_tmpdir(), (int)getpid());
+   char policy[640], socket_path[600], executable[640], database[640];
+   snprintf(policy, sizeof(policy), "%s/policy", g_tmp);
+   snprintf(socket_path, sizeof(socket_path), "%s/bus.sock", g_tmp);
+   snprintf(executable, sizeof(executable), "%s/aimee-module-db1", g_tmp);
+   snprintf(database, sizeof(database), "%s/aimee.db", g_tmp);
+
+   char command[1400];
+   snprintf(command, sizeof(command), "mkdir -p '%s' '%s'", g_tmp, policy);
+   must(system(command) == 0, "create the fixture directories");
+   snprintf(command, sizeof(command), "cp '%s' '%s' && chmod 0755 '%s'", module, executable,
+            executable);
+   must(system(command) == 0, "install the module binary");
+
+   write_grant(policy, executable);
+   must(obs_bus_configure_module_runtime(socket_path, policy) == 0,
+        "configure the module endpoint");
+   must(obs_bus_start() == 0, "start the bus");
+
+   start_module(executable, socket_path, database);
+
+   test_a_write_is_visible_to_a_later_read();
+   test_rows_cross_the_bus();
+   test_the_queue_answers_across_the_bus();
+   test_branch_ownership_round_trips();
+
+   stop_module();
+   obs_bus_stop();
+   snprintf(command, sizeof(command), "rm -rf '%s'", g_tmp);
+   (void)system(command);
+   printf("db1-module-bus: ok (the module serves what the daemon asks it for)\n");
+   return 0;
+}


### PR DESCRIPTION
The DB1 module process never opened its store. Its generated main went straight
to aimee_module_process_run, and db1_init was called by nobody -- so every
domain function in that process ran with db1_conn() returning NULL and took its
"no database" branch.

That is worse than a crash. The process attached, registered its stages and
answered everything. A write returned -1; a read returned MISSING, which is the
same shape as "there is no such row". A caller asking who owns a branch was
told nobody did. Nothing logged, nothing restarted, and the module reported
healthy the whole time.

It has been true since git_ownership migrated. Three families and four sources
have been cut over on top of it.

Why the existing tests could not see it. Both halves were covered and both
halves were right: the client suites stub the bus and check the bytes, the
stage suite calls the handler in-process and checks the reply. Neither runs the
composition, and the defect lived exactly there -- in a process that assembles
the two. test_db1_module_bus now stands up the daemon's module endpoint, execs
the real module binary, and drives the ordinary generated clients: a write then
a read, rows, the zero-argument queue status, and branch ownership. Reverting
the fix makes it fail on the first write, which is the only reason to trust it.

A module may declare what it must open before it serves. The descriptor field
is c_init and the generated main calls it, refusing to start when it fails. Not
hard-coded for db1: a module that owns process-wide state is a general shape,
and "this module needs setting up" belongs in its descriptor where it is
reviewable rather than inferred from an absence.

The path is given, never guessed. db1's init reads AIMEE_DB1_PATH and refuses
to start without it. It cannot read the daemon's configuration -- the module is
deliberately self-contained, linking neither the config module nor
aimee_home() -- and db1_path is an operator-overridable value. A module that
defaulted to the usual location would serve a different, EMPTY database the
moment someone moved it, which is this same bug wearing a disguise. The
container entrypoint exports config's own default, and an operator who
overrides db1_path must set the variable to match or the module will refuse to
start, loudly.

Verified: the new end-to-end test passes with the fix and fails without it; 40
generator tests; module descriptor, process-contract and export/bundle suites;
the module bundle builds; make -C src, aimee-server; docs regenerated.

Not verified: the entrypoint change itself. It is a shell export I cannot
exercise without building and running the container, so the deployment path is
reasoned about rather than demonstrated. If it is wrong the module refuses to
start rather than serving an empty store, which is the failure mode I want.