### PR TITLE
refactor(db2): inject MDL score contract

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -351,7 +351,14 @@ fail chain verification explicitly. Existing SQLite parity, lifecycle audit, and
 mixed-chain tests preserve the pinned cross-engine digest. This moves total debt from 182 to 181 and
 injected-contract debt from 43 to 42 without copying audit canonicalization into DB2.
 
-The remaining 42 non-system rows are sibling-contract migration debt. Session identity, briefing
+The twenty-fourth reduction replaces DB2 artifact feature emission's direct KB MDL scorer call with
+a startup-installed host contract that returns only the three scalar score values DB2 consumes. The
+KB host retains canonical zstd scoring and installs a thin adapter; an absent or failed scorer keeps
+the artifact commit successful while omitting the optional `mdl-v1` feature row, matching the prior
+scoring-failure behavior. This moves total debt from 181 to 180 and injected-contract debt from 42
+to 41 without copying the MDL implementation or its zstd dependency into DB2.
+
+The remaining 41 non-system rows are sibling-contract migration debt. Session identity, briefing
 rendering, executable lifecycle, configuration, memory, and other host calls must close through
 their reviewed process contracts before activation; they are not portable-support candidates. Rows
 may be reclassified only with a reviewed contract and replay evidence, so later slices do not hide

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -6,8 +6,8 @@
   closure ledgers, reviewed host-adapter rehomes, immutable runtime-config and relationship-seed
   support, the provider-neutral DB3 protocol, authenticated multi-observer bus path, automatic
   deployed-provider default, and the catalog-driven durable projection/outbox seam. The standalone
-  link remains blocked by 42 sibling contracts. Its closure records 181 external symbols: 139
-  declared system links and those 42 injected contracts; portable API debt is zero. This is
+  link remains blocked by 41 sibling contracts. Its closure records 180 external symbols: 139
+  declared system links and those 41 injected contracts; portable API debt is zero. This is
   explicitly not the S4 ownership cutover or
   the S6 pure-Go DB2 port: production remains on direct calls, pgvector remains in DB2, and no
   external provider grant ships until the complete C backend passes replay and S4 activates it.
@@ -543,6 +543,12 @@ canonical row-hash provider owned by the audit module; missing installation or m
 fails appends before commit and makes verification fail closed. The KB host installs the existing
 byte-identical implementation before DB2 initialization, so the process boundary removes the direct
 audit-module link without duplicating its canonicalization or changing stored chain values.
+
+Artifact MDL feature emission now accepts a startup-installed scorer contract as well. Its boundary
+returns only the candidate, residual, and total scalar values DB2 persists; the KB host adapts the
+existing canonical scorer and retains ownership of zstd and ranking internals. Missing or failed
+scoring omits the optional feature row without failing the artifact commit, preserving the previous
+scorer-failure behavior while removing the direct KB link.
 
 The closure compiler now matches the production standalone mode by disabling DB1 and the DB2
 SQLite test shim. SQLite compatibility remains tested separately, but its weak DB1 cache hook and

--- a/scripts/tests/test_check_db2_link_closure.py
+++ b/scripts/tests/test_check_db2_link_closure.py
@@ -730,7 +730,7 @@ class LinkClosureTest(unittest.TestCase):
 
     def test_real_repository_reduces_owned_input_and_bounded_contract_debt(self) -> None:
         contract = json.loads((REPO / checker.CONTRACT).read_text(encoding="utf-8"))
-        self.assertEqual(contract["summary"]["unresolved_symbols"], 181)
+        self.assertEqual(contract["summary"]["unresolved_symbols"], 180)
         self.assertEqual(
             contract["summary"]["dispositions"]["descriptor-owned-copy/generated-input"], 0
         )
@@ -739,7 +739,7 @@ class LinkClosureTest(unittest.TestCase):
             contract["summary"]["dispositions"]["portable-core-promotion"], 0
         )
         self.assertEqual(
-            contract["summary"]["dispositions"]["injected-module-contract"], 42
+            contract["summary"]["dispositions"]["injected-module-contract"], 41
         )
         self.assertFalse(any(
             row["symbol"].startswith("cJSON_") for row in contract["unresolved"]

--- a/scripts/tests/test_gen_db2_declaration_ledger.py
+++ b/scripts/tests/test_gen_db2_declaration_ledger.py
@@ -46,11 +46,11 @@ class DeclarationLedgerTests(unittest.TestCase):
         value = ledger.build(REPO_ROOT)
         self.assertEqual(value["summary"], {
             "headers": 136,
-            "declarations": 1351,
+            "declarations": 1352,
             "reviewed": 62,
             "audit_pending": 895,
             "internal_unconsumed": 141,
-            "private_test_only": 253,
+            "private_test_only": 254,
         })
         self.assertFalse(value["declarations_complete"])
         self.assertEqual(

--- a/src/kb/kb_module_stage_adapters.c
+++ b/src/kb/kb_module_stage_adapters.c
@@ -3,6 +3,7 @@
 #include "kb_module_stage_adapters.h"
 
 #include "kb_curator_grounding.h"
+#include "kb_mdl.h"
 #include "kb_route_acl.h"
 
 #include <aimee/audit/audit_worm_chain.h>
@@ -89,6 +90,20 @@ static int control_web_authorize(const char *method, const char *path, int *allo
    return aimee_control_web_response_decode(response, response_len, allowed);
 }
 
+static int score_mdl(const char *candidate, const char *evidence, double *l_candidate,
+                     double *l_residual, double *total)
+{
+   if (!l_candidate || !l_residual || !total)
+      return -1;
+   kb_mdl_score_t score = {0};
+   if (kb_mdl_score(candidate, evidence, &score) != 0)
+      return -1;
+   *l_candidate = score.l_candidate;
+   *l_residual = score.l_residual;
+   *total = score.total;
+   return 0;
+}
+
 int kb_module_postgres_health_probe(int *schema_ok, int *have_pg_trgm, int *kb_tables_ok)
 {
    uint8_t request[AIMEE_POSTGRES_REQUEST_LEN];
@@ -125,6 +140,7 @@ int kb_module_db2_health_probe(int *schema_ok, int *have_pg_trgm, int *kb_tables
 void kb_module_stage_adapters_configure(void)
 {
    aimee_db2_register_audit_hash_provider(audit_worm_row_hash);
+   aimee_db2_register_mdl_score_provider(score_mdl);
    kb_curator_grounding_register_provider(grounding_decide);
    kb_route_acl_register_authorization_provider(control_web_authorize);
 }

--- a/src/modules/db2/c/artifacts.c
+++ b/src/modules/db2/c/artifacts.c
@@ -6,7 +6,6 @@
 #include "db_postgres.h"
 #include "feature_rows.h"
 #include "kb_audit_worm.h"
-#include "kb_mdl.h"
 #include "platform_random.h"
 #include "aimee.h"
 #include "cJSON.h"
@@ -16,6 +15,13 @@
 #include <string.h>
 
 #define ARTIFACT_MDL_FEATURE_SET_VERSION "mdl-v1"
+
+static db2_mdl_score_fn g_mdl_score_provider;
+
+void aimee_db2_register_mdl_score_provider(db2_mdl_score_fn provider)
+{
+   g_mdl_score_provider = provider;
+}
 
 void db2_artifact_gen_id(char *buf, size_t len)
 {
@@ -131,15 +137,18 @@ static void db2_artifact_emit_mdl_features_if_needed(const char *id, const char 
    if (!evidence || !evidence[0])
       evidence = candidate;
 
-   kb_mdl_score_t score;
-   if (kb_mdl_score(candidate, evidence, &score) == 0)
+   double l_candidate;
+   double l_residual;
+   double total;
+   if (g_mdl_score_provider &&
+       g_mdl_score_provider(candidate, evidence, &l_candidate, &l_residual, &total) == 0)
    {
       int rank = artifact_payload_rank(root);
       char features[256];
       snprintf(features, sizeof(features),
                "{\"mdl.l_candidate\":%.6f,\"mdl.l_residual\":%.6f,"
                "\"mdl.total\":%.6f,\"mdl.rank_in_cluster\":%d}",
-               score.l_candidate, score.l_residual, score.total, rank);
+               l_candidate, l_residual, total, rank);
       (void)db2_feature_row_upsert(id, "artifact", scope_kind_copy, scope_id_copy,
                                    ARTIFACT_MDL_FEATURE_SET_VERSION, features, NULL);
    }

--- a/src/modules/db2/c/artifacts.h
+++ b/src/modules/db2/c/artifacts.h
@@ -14,6 +14,13 @@ extern "C"
 {
 #endif
 
+   typedef int (*db2_mdl_score_fn)(const char *candidate, const char *evidence, double *l_candidate,
+                                   double *l_residual, double *total);
+
+   /* Internal declaration of the host contract exported publicly through
+    * <aimee/db2/host_contracts.h>. NULL removes the provider. */
+   void aimee_db2_register_mdl_score_provider(db2_mdl_score_fn provider);
+
    /* Generate a random UUID string (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
     * into buf.  buf must be at least 37 bytes. */
    void db2_artifact_gen_id(char *buf, size_t len);
@@ -223,8 +230,8 @@ extern "C"
     * projects. Writes up to `max` rows into out; returns the count
     * (>= 0), or -1 on error. */
    int db2_artifact_filter_facets(int64_t release_id, const char *project, const char *kind,
-                                   const char *status, const char *priority, const char *component,
-                                   db2_artifact_row_t *out, int max);
+                                  const char *status, const char *priority, const char *component,
+                                  db2_artifact_row_t *out, int max);
    int db2_artifact_filter_facets_scoped(int64_t release_id, const char *project,
                                          const char *exclude_project, const char *kind,
                                          const char *status, const char *priority,

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "3710f2f2868d4eb23e6b2569fbc6ba330e60ee9b",
-  "source_fingerprint": "3830b8a7a4010366f3c6d7a35b942cde975b1fe7ddaa7c6054474af843a610fd",
+  "source_revision": "1d7c6a2d8d0573e61091dcee5b40bd76e281a8eb",
+  "source_fingerprint": "c619e7fe647e73a9c0c2706affea6733bf565767e6ee3924326c9c62ffeea9cf",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM",
@@ -2357,14 +2357,6 @@
       "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
     },
     {
-      "symbol": "kb_mdl_score",
-      "references": [
-        "src/modules/db2/c/artifacts.c"
-      ],
-      "disposition": "injected-module-contract",
-      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
-    },
-    {
       "symbol": "kb_mgmt_token_authority_record_valid",
       "references": [
         "src/modules/db2/c/management_token_authority.c"
@@ -3526,15 +3518,15 @@
   "summary": {
     "translation_units": 138,
     "descriptor_support_units": 22,
-    "unresolved_symbols": 181,
+    "unresolved_symbols": 180,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 0,
-      "injected-module-contract": 42,
+      "injected-module-contract": 41,
       "portable-core-promotion": 0,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 139
     }
   },
-  "fingerprint": "1b1d2440c91161d43569671da2854299c0cba5b8de5e55268896454dcd8709b7"
+  "fingerprint": "1763e0ffb79877032818c2a9b22e91a5cce2a2f0bbe10851e2d2f3cdca31a967"
 }

--- a/src/modules/db2/include/aimee/db2/host_contracts.h
+++ b/src/modules/db2/include/aimee/db2/host_contracts.h
@@ -20,6 +20,16 @@ extern "C"
     * when the provider returns anything other than 64 lowercase hex bytes. */
    void aimee_db2_register_audit_hash_provider(aimee_db2_audit_hash_fn provider);
 
+   /* Score one synthesis candidate against its evidence bundle. The provider
+    * returns 0 and fills all three outputs on success, or -1 when scoring is
+    * unavailable. */
+   typedef int (*aimee_db2_mdl_score_fn)(const char *candidate, const char *evidence,
+                                         double *l_candidate, double *l_residual, double *total);
+
+   /* Install the KB host's canonical MDL scorer during process startup. NULL
+    * removes it; artifact commits continue without optional MDL features. */
+   void aimee_db2_register_mdl_score_provider(aimee_db2_mdl_score_fn provider);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -8097,6 +8097,8 @@ $(TESTPREFIX)/unit-test-retrieval-outcome-bridge: $(OBJDIR)/tests/test_retrieval
                      $(OBJDIR)/server/retrieval_outcome_bridge.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
+$(OBJDIR)/tests/test_artifacts.o: C_FLAGS += -Imodules/db2/include
+
 # Pure render/extract helpers behind the kb_search tool — cJSON + dstr only.
 $(TESTPREFIX)/unit-test-td-search-render: $(OBJDIR)/tests/test_td_search_render.o \
                      $(OBJDIR)/posix/td_search_render.o \

--- a/src/tests/test_artifacts.c
+++ b/src/tests/test_artifacts.c
@@ -19,7 +19,9 @@
 #include "evidence_vectors.h"
 #include "feature_rows.h"
 #include "modules/db2/c/db2_test_shim.h"
+#include <aimee/db2/host_contracts.h>
 #include "cJSON.h"
+#include "kb_mdl.h"
 #include "modules/learning/learning_evidence.h"
 
 /* Stub the memory-store typed verb so learning_promote's memory dispatch is
@@ -71,6 +73,18 @@ static void open_db(void)
 static void close_db(void)
 {
    db2_test_shim_close();
+}
+
+static int score_mdl(const char *candidate, const char *evidence, double *l_candidate,
+                     double *l_residual, double *total)
+{
+   kb_mdl_score_t score = {0};
+   if (!l_candidate || !l_residual || !total || kb_mdl_score(candidate, evidence, &score) != 0)
+      return -1;
+   *l_candidate = score.l_candidate;
+   *l_residual = score.l_residual;
+   *total = score.total;
+   return 0;
 }
 
 /* ---- 1. artifact_write ---- */
@@ -133,6 +147,9 @@ static void test_synthesis_commit_emits_mdl_features(void)
    assert(db2_artifact_set_state(id, "committed") == 0);
 
    char features[512];
+   assert(db2_feature_row_read(id, "artifact", "mdl-v1", features, sizeof(features)) == -1);
+   aimee_db2_register_mdl_score_provider(score_mdl);
+   assert(db2_artifact_set_state(id, "committed") == 0);
    assert(db2_feature_row_read(id, "artifact", "mdl-v1", features, sizeof(features)) == 0);
    assert(strstr(features, "\"mdl.l_candidate\":") != NULL);
    assert(strstr(features, "\"mdl.l_residual\":") != NULL);

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -1237,6 +1237,21 @@
     },
     {
       "consumers": [
+        "src/tests/test_artifacts.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/artifacts.h",
+          "line": 22
+        }
+      ],
+      "signature": "void aimee_db2_register_mdl_score_provider ( db2_mdl_score_fn provider )",
+      "signature_sha256": "e5f7efdd10154625d6ac214c5b44fc9620a13ede315fb55308a0f399ff03b577",
+      "status": "private-test-only",
+      "symbol": "aimee_db2_register_mdl_score_provider"
+    },
+    {
+      "consumers": [
         "src/tests/aimee_pg_sqlite_shim.c",
         "src/tests/test_kb_vault_rewrap_live.c",
         "src/tests/test_management_status_key_ctx.c",
@@ -2882,7 +2897,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 49
+          "line": 56
         }
       ],
       "signature": "int db2_artifact_citation_count ( const char * artifact_id )",
@@ -2905,7 +2920,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 90
+          "line": 97
         }
       ],
       "signature": "int db2_artifact_cite ( const char * artifact_id , const char * source_kind , const char * source_id )",
@@ -2924,7 +2939,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 129
+          "line": 136
         }
       ],
       "signature": "int db2_artifact_count ( const char * kind , const char * state )",
@@ -2940,7 +2955,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 225
+          "line": 232
         }
       ],
       "signature": "int db2_artifact_filter_facets ( int64_t release_id , const char * project , const char * kind , const char * status , const char * priority , const char * component , db2_artifact_row_t * out , int max )",
@@ -2957,7 +2972,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 228
+          "line": 235
         }
       ],
       "signature": "int db2_artifact_filter_facets_scoped ( int64_t release_id , const char * project , const char * exclude_project , const char * kind , const char * status , const char * priority , const char * component , db2_artifact_row_t * out , int max )",
@@ -2972,7 +2987,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 240
+          "line": 247
         }
       ],
       "signature": "int db2_artifact_flag_review ( const char * id , const char * reason )",
@@ -3011,7 +3026,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 19
+          "line": 26
         }
       ],
       "signature": "void db2_artifact_gen_id ( char * buf , size_t len )",
@@ -3026,7 +3041,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 168
+          "line": 175
         }
       ],
       "signature": "int db2_artifact_invalidate_citing ( const char * source_kind , const char * source_id , int edit_span_start , int edit_span_end )",
@@ -3046,7 +3061,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 96
+          "line": 103
         }
       ],
       "signature": "int db2_artifact_link ( const char * from_id , const char * to_id , const char * link_kind )",
@@ -3063,7 +3078,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 235
+          "line": 242
         }
       ],
       "signature": "int db2_artifact_links_read ( const char * id , db2_artifact_link_row_t * out , int max )",
@@ -3083,7 +3098,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 147
+          "line": 154
         }
       ],
       "signature": "int db2_artifact_list_proposed ( const char * target_surface , int limit , db2_artifact_proposed_t * out , int max_out )",
@@ -3110,7 +3125,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 208
+          "line": 215
         }
       ],
       "signature": "int db2_artifact_read ( const char * id , db2_artifact_row_t * out , db2_artifact_citation_t * citations , int max_citations , int * citation_count )",
@@ -3125,7 +3140,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 82
+          "line": 89
         }
       ],
       "signature": "int db2_artifact_register_exemplar ( const char * artifact_id , const char * collection )",
@@ -3143,7 +3158,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 154
+          "line": 161
         }
       ],
       "signature": "int db2_artifact_reject ( const char * id , const char * verdict_tag , const char * verdict_scope , const char * counter_example , const char * before_json )",
@@ -3158,7 +3173,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 65
+          "line": 72
         }
       ],
       "signature": "int db2_artifact_review_rollback ( const char * artifact_id , const char * restore_state , const char * verdict_tag , const char * verdict_scope , const char * counter_example )",
@@ -3182,7 +3197,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 71
+          "line": 78
         }
       ],
       "signature": "int db2_artifact_set_state ( const char * id , const char * new_state )",
@@ -3197,7 +3212,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 76
+          "line": 83
         }
       ],
       "signature": "int db2_artifact_set_target_surface ( const char * id , const char * target_surface )",
@@ -3215,7 +3230,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 173
+          "line": 180
         }
       ],
       "signature": "int db2_artifact_stamp_reflected ( const char * id )",
@@ -3230,7 +3245,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 77
+          "line": 84
         }
       ],
       "signature": "int db2_artifact_target_surface ( const char * id , char * out , int out_len )",
@@ -3243,7 +3258,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 86
+          "line": 93
         }
       ],
       "signature": "int db2_artifact_touch ( const char * id )",
@@ -3259,7 +3274,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 54
+          "line": 61
         }
       ],
       "signature": "int db2_artifact_verdict_suppressed ( const char * verdict_tag , const char * verdict_scope )",
@@ -3301,7 +3316,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 26
+          "line": 33
         }
       ],
       "signature": "int db2_artifact_write ( const char * id , const char * kind , const char * state , const char * scope_kind , const char * scope_id , const char * operator_id , double confidence , const char * payload_json )",
@@ -3316,7 +3331,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 43
+          "line": 50
         }
       ],
       "signature": "int db2_artifact_write_evidence ( const char * kind , const char * scope_kind , const char * scope_id , const char * operator_id , const char * content_hash , const char * payload_json , char * id_out , int id_out_len )",
@@ -3331,7 +3346,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 32
+          "line": 39
         }
       ],
       "signature": "int db2_artifact_write_ex ( const char * id , const char * kind , const char * state , const char * scope_kind , const char * scope_id , const char * operator_id , double confidence , int attempt_count , const char * payload_json )",
@@ -3347,7 +3362,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 124
+          "line": 131
         }
       ],
       "signature": "int db2_audit_event_list ( const char * since , const char * until , const char * scope_kind , int limit , db2_audit_event_row_t * out , int max )",
@@ -3369,7 +3384,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 100
+          "line": 107
         }
       ],
       "signature": "int db2_audit_event_write ( const char * id , const char * source_artifact_id , const char * target_surface , const char * target_id , const char * operator_id , const char * scope_kind , const char * scope_id , double applied_confidence , int flagged_for_review , const char * before_json , const char * after_json )",
@@ -3384,7 +3399,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 58
+          "line": 65
         }
       ],
       "signature": "int db2_audit_read_latest_before ( const char * artifact_id , char * out , int out_len )",
@@ -5758,7 +5773,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/artifacts.h",
-          "line": 166
+          "line": 173
         }
       ],
       "signature": "int db2_curator_reembed_all ( void )",
@@ -23720,15 +23735,15 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "6192b7f027a51bfba99f957475efe268bbbd335786c7079736d91c58f91848a7",
+  "fingerprint": "953e4e1bfebd4f7b2a276d968dab7509ade957a801ed71c9334f32e56b5cba89",
   "module": "db2",
   "schema_version": 1,
   "summary": {
     "audit_pending": 895,
-    "declarations": 1351,
+    "declarations": 1352,
     "headers": 136,
     "internal_unconsumed": 141,
-    "private_test_only": 253,
+    "private_test_only": 254,
     "reviewed": 62
   }
 }


### PR DESCRIPTION
## Summary

- replace DB2 artifact emission's direct `kb_mdl_score` call with a startup-installed host contract
- keep the canonical MDL/zstd implementation in the KB host through a thin scalar adapter
- preserve commit behavior when scoring is absent or fails by omitting only the optional `mdl-v1` row
- reduce standalone link closure from 181 to 180 unresolved symbols and injected-contract debt from 42 to 41
- reduce DB2 source-boundary outbound includes from 169 to 168

This is a supervised C-backend boundary reduction only. It does not activate DB2/DB3, change provider selection, or perform the ownership cutover.

## Validation

- `make -s -C src lint`
- `make -s -C src kb db2-contract-check db2-declaration-ledger-check db2-activation-check module-inventory-check docs-check tests-are-run-check`
- `python3 -I -S scripts/check_db2_link_closure.py --previous-ref origin/testing`
- `python3 -I -S scripts/check_db2_source_boundary.py`
- `python3 -I -S scripts/gen_db2_declaration_ledger.py`
- `python3 -I -S scripts/check_module_test_registration.py`
- `src/build/obj/tests/unit-test-artifacts`

## Review state

Draft: Aimee's required frozen-diff roundtable could not run because `aimee-server` is unavailable after retries. This is explicitly pending roundtable approval and must not be merged on the basis of local validation alone.
