### PR TITLE
refactor(db2): inject fact extraction contracts

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -365,7 +365,15 @@ and returns `FACT_GATE_DEFER` without writing when the provider is absent, fails
 invalid verdict. This moves total debt from 180 to 179 and injected-contract debt from 41 to 40
 without giving DB2 ownership of memory policy.
 
-The remaining 40 non-system rows are sibling-contract migration debt. Session identity, briefing
+The twenty-sixth reduction moves typed-fact pattern extraction and retraction scanning behind two
+startup-installed memory-module contracts. The KB host adapters encode both bounded requests over
+the event bus and validate decoded field sizes and flags; DB2 additionally rejects invalid counts,
+unterminated fields, unknown node kinds, and inconsistent scan answers. Missing or failed
+extraction is an error rather than a false zero-fact answer, while missing or failed scanning never
+deletes a fact. This moves total debt from 179 to 177, injected-contract debt from 40 to 38, and
+outbound source-boundary includes from 168 to 167.
+
+The remaining 38 non-system rows are sibling-contract migration debt. Session identity, briefing
 rendering, executable lifecycle, configuration, memory, and other host calls must close through
 their reviewed process contracts before activation; they are not portable-support candidates. Rows
 may be reclassified only with a reviewed contract and replay evidence, so later slices do not hide

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -6,8 +6,8 @@
   closure ledgers, reviewed host-adapter rehomes, immutable runtime-config and relationship-seed
   support, the provider-neutral DB3 protocol, authenticated multi-observer bus path, automatic
   deployed-provider default, and the catalog-driven durable projection/outbox seam. The standalone
-  link remains blocked by 40 sibling contracts. Its closure records 179 external symbols: 139
-  declared system links and those 40 injected contracts; portable API debt is zero. This is
+  link remains blocked by 38 sibling contracts. Its closure records 177 external symbols: 139
+  declared system links and those 38 injected contracts; portable API debt is zero. This is
   explicitly not the S4 ownership cutover or
   the S6 pure-Go DB2 port: production remains on direct calls, pgvector remains in DB2, and no
   external provider grant ships until the complete C backend passes replay and S4 activates it.
@@ -555,6 +555,12 @@ KB adapter encodes the bounded memory-module request and obtains the authoritati
 event bus, while DB2 validates only the bounded pure-verdict range. A missing, failed, or invalid provider returns
 `FACT_GATE_DEFER` and cannot write a semantic edge, preserving the gate's authoritative fail-closed
 behavior without linking the memory implementation into DB2.
+
+Typed-fact pattern extraction and retraction scanning now use startup-installed host contracts as
+well. The KB adapters carry both bounded request shapes over the memory module's event-bus stage;
+DB2 validates candidate counts, fixed-field termination, node kinds, binary scan flags, and
+attribute consistency before acting. An unavailable extractor returns an error instead of claiming
+the turn held zero facts, and an unavailable scanner cannot trigger deletion.
 
 The closure compiler now matches the production standalone mode by disabling DB1 and the DB2
 SQLite test shim. SQLite compatibility remains tested separately, but its weak DB1 cache hook and

--- a/scripts/tests/test_check_db2_link_closure.py
+++ b/scripts/tests/test_check_db2_link_closure.py
@@ -730,7 +730,7 @@ class LinkClosureTest(unittest.TestCase):
 
     def test_real_repository_reduces_owned_input_and_bounded_contract_debt(self) -> None:
         contract = json.loads((REPO / checker.CONTRACT).read_text(encoding="utf-8"))
-        self.assertEqual(contract["summary"]["unresolved_symbols"], 179)
+        self.assertEqual(contract["summary"]["unresolved_symbols"], 177)
         self.assertEqual(
             contract["summary"]["dispositions"]["descriptor-owned-copy/generated-input"], 0
         )
@@ -739,7 +739,7 @@ class LinkClosureTest(unittest.TestCase):
             contract["summary"]["dispositions"]["portable-core-promotion"], 0
         )
         self.assertEqual(
-            contract["summary"]["dispositions"]["injected-module-contract"], 40
+            contract["summary"]["dispositions"]["injected-module-contract"], 38
         )
         self.assertFalse(any(
             row["symbol"].startswith("cJSON_") for row in contract["unresolved"]

--- a/scripts/tests/test_gen_db2_declaration_ledger.py
+++ b/scripts/tests/test_gen_db2_declaration_ledger.py
@@ -46,11 +46,11 @@ class DeclarationLedgerTests(unittest.TestCase):
         value = ledger.build(REPO_ROOT)
         self.assertEqual(value["summary"], {
             "headers": 136,
-            "declarations": 1353,
+            "declarations": 1355,
             "reviewed": 62,
             "audit_pending": 895,
             "internal_unconsumed": 141,
-            "private_test_only": 255,
+            "private_test_only": 257,
         })
         self.assertFalse(value["declarations_complete"])
         self.assertEqual(

--- a/src/kb/kb_module_stage_adapters.c
+++ b/src/kb/kb_module_stage_adapters.c
@@ -17,7 +17,10 @@
 #include <aimee/postgres/module_api.h>
 
 #include <stdatomic.h>
+#include <limits.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #define KB_MODULE_STAGE_DEADLINE_NS (500ULL * 1000000ULL)
@@ -141,6 +144,87 @@ static int check_fact_gate(int head_kind, const char *rel_type, int tail_kind, i
    }
 }
 
+_Static_assert(sizeof(((aimee_db2_fact_candidate_t *)0)->subject) ==
+                   AIMEE_MEMORY_TRIPLE_SUBJECT_MAX,
+               "memory wire subject capacity must match the DB2 host contract");
+_Static_assert(sizeof(((aimee_db2_fact_candidate_t *)0)->rel_type) ==
+                   AIMEE_MEMORY_TRIPLE_REL_TYPE_MAX,
+               "memory wire relation capacity must match the DB2 host contract");
+_Static_assert(sizeof(((aimee_db2_fact_candidate_t *)0)->object) == AIMEE_MEMORY_TRIPLE_OBJECT_MAX,
+               "memory wire object capacity must match the DB2 host contract");
+
+static int extract_facts(const char *text, aimee_db2_fact_candidate_t *out, int max, int *count)
+{
+   if (!text || !out || max <= 0 || !count)
+      return -1;
+   size_t request_len = aimee_memory_extract_request_size(text);
+   if (!request_len || request_len > AIMEE_MODULE_MESSAGE_MAX_BODY || request_len > UINT32_MAX)
+      return -1;
+
+   size_t response_cap = AIMEE_MEMORY_EXTRACT_RESPONSE_MAX(max);
+   uint8_t *request = malloc(request_len);
+   aimee_memory_triple_t *triples = calloc((size_t)max, sizeof(*triples));
+   uint8_t *response = malloc(response_cap);
+   uint32_t response_len = 0, found = 0;
+   int rc = -1;
+   if (request && triples && response && response_cap <= UINT32_MAX &&
+       aimee_memory_extract_request_encode(text, (uint32_t)max, request, request_len) == 0 &&
+       call_module(AIMEE_MEMORY_EVENT_EXTRACT_INDEX, AIMEE_MEMORY_STAGE_EXTRACT_INDEX, request,
+                   (uint32_t)request_len, response, (uint32_t)response_cap, &response_len) == 0 &&
+       aimee_memory_extract_response_decode(response, response_len, triples, (uint32_t)max,
+                                            &found) == 0)
+   {
+      rc = 0;
+      for (uint32_t i = 0; i < found; ++i)
+      {
+         if (triples[i].subject_kind > INT_MAX || triples[i].object_kind > INT_MAX)
+         {
+            rc = -1;
+            break;
+         }
+         memset(&out[i], 0, sizeof(out[i]));
+         memcpy(out[i].subject, triples[i].subject, sizeof(out[i].subject));
+         memcpy(out[i].rel_type, triples[i].rel_type, sizeof(out[i].rel_type));
+         memcpy(out[i].object, triples[i].object, sizeof(out[i].object));
+         out[i].subject_kind = (int)triples[i].subject_kind;
+         out[i].object_kind = (int)triples[i].object_kind;
+      }
+      if (rc == 0)
+         *count = (int)found;
+   }
+   free(request);
+   free(triples);
+   free(response);
+   return rc;
+}
+
+_Static_assert(AIMEE_DB2_FACT_ATTR_MAX == AIMEE_MEMORY_SCAN_ATTR_MAX,
+               "memory wire attribute capacity must match the DB2 host contract");
+
+static int scan_fact_turn(const char *text, int *is_retraction, int *has_attr,
+                          char attr[AIMEE_DB2_FACT_ATTR_MAX])
+{
+   if (!text || !is_retraction || !has_attr || !attr)
+      return -1;
+   size_t request_len = aimee_memory_scan_request_size(text);
+   if (!request_len || request_len > AIMEE_MODULE_MESSAGE_MAX_BODY || request_len > UINT32_MAX)
+      return -1;
+   uint8_t *request = malloc(request_len);
+   uint8_t response[AIMEE_MEMORY_SCAN_RESPONSE_MAX];
+   uint32_t response_len = 0;
+   if (!request)
+      return -1;
+   int rc = aimee_memory_scan_request_encode(text, request, request_len) == 0 &&
+                    call_module(AIMEE_MEMORY_EVENT_EXTRACT_INDEX, AIMEE_MEMORY_STAGE_EXTRACT_INDEX,
+                                request, (uint32_t)request_len, response, sizeof(response),
+                                &response_len) == 0
+                ? aimee_memory_scan_response_decode(response, response_len, is_retraction, has_attr,
+                                                    attr, AIMEE_DB2_FACT_ATTR_MAX)
+                : -1;
+   free(request);
+   return rc;
+}
+
 int kb_module_postgres_health_probe(int *schema_ok, int *have_pg_trgm, int *kb_tables_ok)
 {
    uint8_t request[AIMEE_POSTGRES_REQUEST_LEN];
@@ -179,6 +263,8 @@ void kb_module_stage_adapters_configure(void)
    aimee_db2_register_audit_hash_provider(audit_worm_row_hash);
    aimee_db2_register_mdl_score_provider(score_mdl);
    aimee_db2_register_fact_gate_provider(check_fact_gate);
+   aimee_db2_register_fact_extract_provider(extract_facts);
+   aimee_db2_register_fact_scan_provider(scan_fact_turn);
    kb_curator_grounding_register_provider(grounding_decide);
    kb_route_acl_register_authorization_provider(control_web_authorize);
 }

--- a/src/modules/db2/c/fact_ingest.c
+++ b/src/modules/db2/c/fact_ingest.c
@@ -6,28 +6,68 @@
 #include "rel_types_store.h"  /* db2_fact_commit */
 #include "../headers/aimee.h" /* config_t */
 #include "../support/db2_runtime_config.h"
-#include "modules/memory/memory_extract_patterns.h" /* memory_extract_patterns, retraction */
-#include "modules/memory/memory_pii_gate.h"         /* memory_pii_turn_requests_sensitive */
-#include "../support/db2_log.h"                     /* LOG_WARN */
+#include "modules/memory/memory_pii_gate.h" /* memory_pii_turn_requests_sensitive */
+#include "../support/db2_log.h"             /* LOG_WARN */
 
 #define FI_MAX_TRIPLES 16
+
+static db2_fact_extract_fn g_fact_extract_provider;
+static db2_fact_scan_fn g_fact_scan_provider;
+
+void aimee_db2_register_fact_extract_provider(db2_fact_extract_fn provider)
+{
+   g_fact_extract_provider = provider;
+}
+
+void aimee_db2_register_fact_scan_provider(db2_fact_scan_fn provider)
+{
+   g_fact_scan_provider = provider;
+}
+
+static int fact_kind_valid(int kind)
+{
+   return (kind >= NODE_FILE && kind <= NODE_SCALAR) || kind == NODE_OTHER;
+}
+
+static int fact_field_terminated(const char *field, size_t capacity)
+{
+   for (size_t i = 0; i < capacity; ++i)
+      if (field[i] == '\0')
+         return 1;
+   return 0;
+}
+
+static int fact_candidate_valid(const db2_fact_candidate_t *candidate)
+{
+   return candidate && candidate->subject[0] && candidate->rel_type[0] && candidate->object[0] &&
+          fact_field_terminated(candidate->subject, sizeof(candidate->subject)) &&
+          fact_field_terminated(candidate->rel_type, sizeof(candidate->rel_type)) &&
+          fact_field_terminated(candidate->object, sizeof(candidate->object)) &&
+          fact_kind_valid(candidate->subject_kind) && fact_kind_valid(candidate->object_kind);
+}
 
 int db2_fact_ingest_text(const char *text, fact_authority_t authority, int enabled)
 {
    if (!text)
       return -1;
 
-   pattern_triple_t triples[FI_MAX_TRIPLES];
-   int nt = memory_extract_patterns(text, triples, FI_MAX_TRIPLES);
-   if (nt <= 0)
-      return nt < 0 ? -1 : 0;
+   db2_fact_candidate_t triples[FI_MAX_TRIPLES] = {0};
+   int nt = 0;
+   if (!g_fact_extract_provider ||
+       g_fact_extract_provider(text, triples, FI_MAX_TRIPLES, &nt) != 0 || nt < 0 ||
+       nt > FI_MAX_TRIPLES)
+      return -1;
+   for (int i = 0; i < nt; ++i)
+      if (!fact_candidate_valid(&triples[i]))
+         return -1;
 
    int written = 0;
    for (int i = 0; i < nt; i++)
    {
-      const pattern_triple_t *t = &triples[i];
-      fact_gate_verdict_t v = db2_fact_commit(t->subject, t->subject_kind, t->rel_type, t->object,
-                                              t->object_kind, authority, enabled);
+      const db2_fact_candidate_t *t = &triples[i];
+      fact_gate_verdict_t v =
+          db2_fact_commit(t->subject, (memory_node_kind_t)t->subject_kind, t->rel_type, t->object,
+                          (memory_node_kind_t)t->object_kind, authority, enabled);
       /* Count the triples the gate let through when enabled: ACCEPT writes/bumps a
        * validated edge, NOVEL stages a provisional rel_type + a Class-C edge. A
        * re-ingest of a known triple still counts (it bumps weight, no new row).
@@ -55,14 +95,18 @@ int db2_typed_fact_ingress(const char *query, char *facts_out, size_t facts_cap)
     * safely no-ops). This stays synchronous: it is a cheap Postgres write, no LLM.
     * Fact EXTRACTION is offline-only (the memory_facts drain runs pattern + LLM),
     * so we do NOT run db2_fact_ingest_text() on the turn hot path. */
-   memory_pattern_turn_t scan;
-   if (memory_pattern_scan_turn(query, &scan) != 0)
+   int is_retraction = 0;
+   int has_attr = 0;
+   char attr[DB2_FACT_ATTR_MAX] = "";
+   if (!g_fact_scan_provider || g_fact_scan_provider(query, &is_retraction, &has_attr, attr) != 0 ||
+       is_retraction < 0 || is_retraction > 1 || has_attr < 0 || has_attr > 1 ||
+       !fact_field_terminated(attr, sizeof(attr)) || ((attr[0] != '\0') != (has_attr == 1)))
       /* No answer from the scanner. Do NOT retract: this path deletes, and
        * leaving a fact the user asked to forget is recoverable (they can ask
        * again) where deleting one they did not name is not. */
       LOG_WARN("memory", "retraction scan gave no answer; not retracting this turn");
-   else if (scan.is_retraction && scan.has_attr)
-      (void)db2_fact_retract("user", scan.attr, NULL, FACT_AUTHORITY_USER);
+   else if (is_retraction && has_attr)
+      (void)db2_fact_retract("user", attr, NULL, FACT_AUTHORITY_USER);
 
    /* §7 read: the user's facts + facts about any entity named in the turn,
     * PII-gated, into the envelope. */

--- a/src/modules/db2/c/fact_ingest.h
+++ b/src/modules/db2/c/fact_ingest.h
@@ -15,6 +15,30 @@ extern "C"
 {
 #endif
 
+#define DB2_FACT_SUBJECT_MAX  128
+#define DB2_FACT_REL_TYPE_MAX 64
+#define DB2_FACT_OBJECT_MAX   128
+#define DB2_FACT_ATTR_MAX     128
+
+   typedef struct
+   {
+      char subject[DB2_FACT_SUBJECT_MAX];
+      char rel_type[DB2_FACT_REL_TYPE_MAX];
+      char object[DB2_FACT_OBJECT_MAX];
+      int subject_kind;
+      int object_kind;
+   } db2_fact_candidate_t;
+
+   typedef int (*db2_fact_extract_fn)(const char *text, db2_fact_candidate_t *out, int max,
+                                      int *count);
+   typedef int (*db2_fact_scan_fn)(const char *text, int *is_retraction, int *has_attr,
+                                   char attr[DB2_FACT_ATTR_MAX]);
+
+   /* Internal declarations of the host contracts exported publicly through
+    * <aimee/db2/host_contracts.h>. NULL removes the corresponding provider. */
+   void aimee_db2_register_fact_extract_provider(db2_fact_extract_fn provider);
+   void aimee_db2_register_fact_scan_provider(db2_fact_scan_fn provider);
+
    /* Run pattern-first ingest on one turn's `text`: extract candidate triples
     * (§6) and route each through the typed gate db2_fact_commit with `authority`
     * (§5 class keying). `enabled` is the master gate (config.typed_facts_enabled):
@@ -25,9 +49,8 @@ extern "C"
     * count, not a "new rows inserted" count. 0 when disabled / nothing matched, -1
     * on bad args.
     *
-    * Retraction is NOT handled here: callers should first check
-    * memory_pattern_is_retraction() and route a correction through
-    * db2_fact_retract() instead of ingesting the turn as new assertions. */
+    * Retraction is NOT handled here; the full ingress path obtains the memory
+    * module's scan verdict before routing a correction through db2_fact_retract. */
    int db2_fact_ingest_text(const char *text, fact_authority_t authority, int enabled);
 
    /* The full per-turn typed-fact ingress orchestration (the KB context_block

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "aa4d5b14011f86db7e34651fab63e01fdebb18ca",
-  "source_fingerprint": "da37bb8b83d0e438c198231c84e535f0c5d44c938d18311a71d3e9fed08e08c9",
+  "source_revision": "cdf10a8c1b200387f2b87921972e07c0210df90f",
+  "source_fingerprint": "d20994fd2d15d6e84c8665ff0f9e599268cff94cb8a6e0a8a93245f8cf7ef237",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM",
@@ -2439,22 +2439,6 @@
       "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
     },
     {
-      "symbol": "memory_extract_patterns",
-      "references": [
-        "src/modules/db2/c/fact_ingest.c"
-      ],
-      "disposition": "injected-module-contract",
-      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
-    },
-    {
-      "symbol": "memory_pattern_scan_turn",
-      "references": [
-        "src/modules/db2/c/fact_ingest.c"
-      ],
-      "disposition": "injected-module-contract",
-      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
-    },
-    {
       "symbol": "mktime",
       "references": [
         "src/modules/db2/c/entity_edges.c"
@@ -3510,15 +3494,15 @@
   "summary": {
     "translation_units": 138,
     "descriptor_support_units": 22,
-    "unresolved_symbols": 179,
+    "unresolved_symbols": 177,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 0,
-      "injected-module-contract": 40,
+      "injected-module-contract": 38,
       "portable-core-promotion": 0,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 139
     }
   },
-  "fingerprint": "3985c4acc8ca0a1306317255bf234360c71dc98097678f130b6e14fbbf58e47c"
+  "fingerprint": "e7d3d850e9c5b5dce234576c1d2a13838b07a3da1e5250b706b2d01aab9a760a"
 }

--- a/src/modules/db2/include/aimee/db2/host_contracts.h
+++ b/src/modules/db2/include/aimee/db2/host_contracts.h
@@ -49,6 +49,35 @@ extern "C"
     * an authoritative verdict. */
    void aimee_db2_register_fact_gate_provider(aimee_db2_fact_gate_fn provider);
 
+#define AIMEE_DB2_FACT_SUBJECT_MAX  128
+#define AIMEE_DB2_FACT_REL_TYPE_MAX 64
+#define AIMEE_DB2_FACT_OBJECT_MAX   128
+#define AIMEE_DB2_FACT_ATTR_MAX     128
+
+   typedef struct
+   {
+      char subject[AIMEE_DB2_FACT_SUBJECT_MAX];
+      char rel_type[AIMEE_DB2_FACT_REL_TYPE_MAX];
+      char object[AIMEE_DB2_FACT_OBJECT_MAX];
+      int subject_kind;
+      int object_kind;
+   } aimee_db2_fact_candidate_t;
+
+   /* Extract bounded typed-fact candidates through the host memory module. The
+    * provider returns 0 and a count in [0,max], or -1 when it cannot answer. */
+   typedef int (*aimee_db2_fact_extract_fn)(const char *text, aimee_db2_fact_candidate_t *out,
+                                            int max, int *count);
+
+   /* Scan one turn for a retraction cue and optional attribute. Both flags must
+    * be 0 or 1, and attr is non-empty exactly when has_attr is 1. */
+   typedef int (*aimee_db2_fact_scan_fn)(const char *text, int *is_retraction, int *has_attr,
+                                         char attr[AIMEE_DB2_FACT_ATTR_MAX]);
+
+   /* Install the memory module's extraction and retraction-scan adapters. NULL
+    * removes a provider; extraction then fails and scanning cannot delete. */
+   void aimee_db2_register_fact_extract_provider(aimee_db2_fact_extract_fn provider);
+   void aimee_db2_register_fact_scan_provider(aimee_db2_fact_scan_fn provider);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/tests/test_fact_ingest.c
+++ b/src/tests/test_fact_ingest.c
@@ -28,11 +28,100 @@ static int check_fact_gate(int head_kind, const char *rel_type, int tail_kind, i
    return 0;
 }
 
+_Static_assert(sizeof(((db2_fact_candidate_t *)0)->subject) ==
+                   sizeof(((pattern_triple_t *)0)->subject),
+               "test extractor subject capacity must match DB2");
+_Static_assert(sizeof(((db2_fact_candidate_t *)0)->rel_type) ==
+                   sizeof(((pattern_triple_t *)0)->rel_type),
+               "test extractor relation capacity must match DB2");
+_Static_assert(sizeof(((db2_fact_candidate_t *)0)->object) ==
+                   sizeof(((pattern_triple_t *)0)->object),
+               "test extractor object capacity must match DB2");
+
+static int extract_facts(const char *text, db2_fact_candidate_t *out, int max, int *count)
+{
+   if (!text || !out || max <= 0 || max > 32 || !count)
+      return -1;
+   pattern_triple_t triples[32] = {0};
+   int found = memory_extract_patterns(text, triples, max);
+   if (found < 0)
+      return -1;
+   for (int i = 0; i < found; ++i)
+   {
+      memcpy(out[i].subject, triples[i].subject, sizeof(out[i].subject));
+      memcpy(out[i].rel_type, triples[i].rel_type, sizeof(out[i].rel_type));
+      memcpy(out[i].object, triples[i].object, sizeof(out[i].object));
+      out[i].subject_kind = (int)triples[i].subject_kind;
+      out[i].object_kind = (int)triples[i].object_kind;
+   }
+   *count = found;
+   return 0;
+}
+
+static int failing_extract(const char *text, db2_fact_candidate_t *out, int max, int *count)
+{
+   (void)text;
+   (void)out;
+   (void)max;
+   (void)count;
+   return -1;
+}
+
+static int invalid_extract_count(const char *text, db2_fact_candidate_t *out, int max, int *count)
+{
+   (void)text;
+   (void)out;
+   *count = max + 1;
+   return 0;
+}
+
+static int scan_fact_turn(const char *text, int *is_retraction, int *has_attr,
+                          char attr[DB2_FACT_ATTR_MAX])
+{
+   memory_pattern_turn_t scan;
+   if (memory_pattern_scan_turn(text, &scan) != 0)
+      return -1;
+   *is_retraction = scan.is_retraction;
+   *has_attr = scan.has_attr;
+   memcpy(attr, scan.attr, DB2_FACT_ATTR_MAX);
+   return 0;
+}
+
+static int failing_scan(const char *text, int *is_retraction, int *has_attr,
+                        char attr[DB2_FACT_ATTR_MAX])
+{
+   (void)text;
+   (void)is_retraction;
+   (void)has_attr;
+   (void)attr;
+   return -1;
+}
+
+static int invalid_scan(const char *text, int *is_retraction, int *has_attr,
+                        char attr[DB2_FACT_ATTR_MAX])
+{
+   (void)text;
+   *is_retraction = 1;
+   *has_attr = 1;
+   attr[0] = '\0';
+   return 0;
+}
+
 int main(void)
 {
    db2_test_shim_open();
    aimee_db2_register_fact_gate_provider(check_fact_gate);
    assert(db2_rel_types_ensure_seed() == 0);
+
+   /* Extraction is authoritative: absence, failure, or an invalid count cannot
+    * be mistaken for a turn with zero facts. */
+   assert(db2_fact_ingest_text("my city is Berlin", FACT_AUTHORITY_USER, 1) == -1);
+   aimee_db2_register_fact_extract_provider(failing_extract);
+   assert(db2_fact_ingest_text("my city is Berlin", FACT_AUTHORITY_USER, 1) == -1);
+   aimee_db2_register_fact_extract_provider(invalid_extract_count);
+   assert(db2_fact_ingest_text("my city is Berlin", FACT_AUTHORITY_USER, 1) == -1);
+   assert(semantic_count("user") == 0);
+   aimee_db2_register_fact_extract_provider(extract_facts);
 
    /* Disabled: the gate is observe-only — nothing is written. */
    assert(db2_fact_ingest_text("my email is theo@example.com", FACT_AUTHORITY_USER, 0) == 0);
@@ -57,14 +146,19 @@ int main(void)
    /* No template in the text -> nothing committed. */
    assert(db2_fact_ingest_text("the server crashed last night", FACT_AUTHORITY_USER, 1) == 0);
 
-   /* §4 retraction flow (the handler's glue): a retraction turn extracts the named
-    * attribute and retracts it. After ingesting email+city, "forget my email"
-    * supersedes only the email fact. */
+   /* §4 retraction flow: no scanner, a failed scanner, or an inconsistent answer
+    * cannot delete. The host-installed scanner then retracts only the named fact. */
    assert(db2_fact_current_count("user") == 2); /* email + city currently believed */
-   char attr[128];
-   assert(memory_pattern_is_retraction("please forget my email"));
-   assert(memory_pattern_possessive_attr("please forget my email", attr, sizeof(attr)) == 1);
-   assert(db2_fact_retract("user", attr, NULL, FACT_AUTHORITY_USER) == 1);
+   assert(db2_typed_fact_ingress("please forget my email", NULL, 0) == 0);
+   assert(db2_fact_current_count("user") == 2);
+   aimee_db2_register_fact_scan_provider(failing_scan);
+   assert(db2_typed_fact_ingress("please forget my email", NULL, 0) == 0);
+   assert(db2_fact_current_count("user") == 2);
+   aimee_db2_register_fact_scan_provider(invalid_scan);
+   assert(db2_typed_fact_ingress("please forget my email", NULL, 0) == 0);
+   assert(db2_fact_current_count("user") == 2);
+   aimee_db2_register_fact_scan_provider(scan_fact_turn);
+   assert(db2_typed_fact_ingress("please forget my email", NULL, 0) == 0);
    assert(db2_fact_current_count("user") == 1); /* only city remains current */
 
    /* Bad args. */

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -1237,6 +1237,21 @@
     },
     {
       "consumers": [
+        "src/tests/test_fact_ingest.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/fact_ingest.h",
+          "line": 39
+        }
+      ],
+      "signature": "void aimee_db2_register_fact_extract_provider ( db2_fact_extract_fn provider )",
+      "signature_sha256": "13d592fd1c7dc0e9416cd39e7911f080042abd2aa9c46537b64280161e84dd91",
+      "status": "private-test-only",
+      "symbol": "aimee_db2_register_fact_extract_provider"
+    },
+    {
+      "consumers": [
         "src/tests/test_fact_ingest.c",
         "src/tests/test_fact_lifecycle.c",
         "src/tests/test_fact_recall.c",
@@ -1253,6 +1268,21 @@
       "signature_sha256": "8f2225aa4902b730d36b0d307d6312d7ad44dc383db012512b86283e2c93ef94",
       "status": "private-test-only",
       "symbol": "aimee_db2_register_fact_gate_provider"
+    },
+    {
+      "consumers": [
+        "src/tests/test_fact_ingest.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/fact_ingest.h",
+          "line": 40
+        }
+      ],
+      "signature": "void aimee_db2_register_fact_scan_provider ( db2_fact_scan_fn provider )",
+      "signature_sha256": "778769db9a9b8ed08848a401aaac428b3a2886f97b72b9d2ab1671285aba7401",
+      "status": "private-test-only",
+      "symbol": "aimee_db2_register_fact_scan_provider"
     },
     {
       "consumers": [
@@ -8066,7 +8096,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/fact_ingest.h",
-          "line": 31
+          "line": 54
         }
       ],
       "signature": "int db2_fact_ingest_text ( const char * text , fact_authority_t authority , int enabled )",
@@ -8123,7 +8153,6 @@
     },
     {
       "consumers": [
-        "src/tests/test_fact_ingest.c",
         "src/tests/test_fact_lifecycle.c",
         "src/tests/test_fact_recall.c"
       ],
@@ -20474,12 +20503,13 @@
     },
     {
       "consumers": [
-        "src/kb/db2_adapters/kb_service_backend_memory.c"
+        "src/kb/db2_adapters/kb_service_backend_memory.c",
+        "src/tests/test_fact_ingest.c"
       ],
       "locations": [
         {
           "header": "src/modules/db2/c/fact_ingest.h",
-          "line": 39
+          "line": 62
         }
       ],
       "signature": "int db2_typed_fact_ingress ( const char * query , char * facts_out , size_t facts_cap )",
@@ -23754,15 +23784,15 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "4355164d3f5671d14a4cfaaf2388965d5979ec9e7039c698c9c657be2bd2d5bc",
+  "fingerprint": "348e667bd71112ab01faee4d53276342d0397593ec4290bc3c07bd3819218fed",
   "module": "db2",
   "schema_version": 1,
   "summary": {
     "audit_pending": 895,
-    "declarations": 1353,
+    "declarations": 1355,
     "headers": 136,
     "internal_unconsumed": 141,
-    "private_test_only": 255,
+    "private_test_only": 257,
     "reviewed": 62
   }
 }


### PR DESCRIPTION
## Summary

- replace DB2 direct links to memory pattern extraction and retraction scanning with startup-injected host contracts
- carry both bounded request shapes through the existing memory module event-bus stage
- validate counts, fixed-field termination, node kinds, flags, and attribute consistency before DB2 acts
- preserve fail-closed behavior: extraction failures return an error; scan failures never delete

## Closure movement

- unresolved external symbols: 179 -> 177
- injected-contract debt: 40 -> 38
- outbound source-boundary includes: 168 -> 167
- no activation or ownership cutover

## Validation

- focused fact-ingest unit test
- full repository lint
- DB2 contract, declaration-ledger, activation, module-inventory, docs, and test-registration gates
- DB2 link-closure and source-boundary checks
- git diff --check

## Review status

The required frozen-diff roundtable was attempted, but aimee-server remained unavailable after its built-in retries. This PR is intentionally draft and roundtable approval is still pending.