### PR TITLE
refactor(db2): inject memory embedding contract

### DIFF
--- a/docs/modules/db2.md
+++ b/docs/modules/db2.md
@@ -373,7 +373,14 @@ extraction is an error rather than a false zero-fact answer, while missing or fa
 deletes a fact. This moves total debt from 179 to 177, injected-contract debt from 40 to 38, and
 outbound source-boundary includes from 168 to 167.
 
-The remaining 38 non-system rows are sibling-contract migration debt. Session identity, briefing
+The twenty-seventh reduction moves DB2's single-text embedding dependency behind a startup-installed
+host contract. HTTP embedders now traverse the memory module's served `embedding` stage and use its
+process-owned circuit breaker; program-based embedders retain the explicitly documented C host path
+because the Go module declines them without touching its breaker. DB2 independently rejects an
+absent provider, invalid dimensions, and non-finite components. This moves total debt from 177 to
+176, injected-contract debt from 38 to 37, and outbound source-boundary includes from 167 to 166.
+
+The remaining 37 non-system rows are sibling-contract migration debt. Session identity, briefing
 rendering, executable lifecycle, configuration, memory, and other host calls must close through
 their reviewed process contracts before activation; they are not portable-support candidates. Rows
 may be reclassified only with a reviewed contract and replay evidence, so later slices do not hide

--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -21,8 +21,9 @@ thresholds.
 | `extract_index` | `5889` | pattern-first extraction, and the §4 retraction pre-scan (two request shapes, distinct magics) |
 | `retrieve` | `5892` | the §7 PII recall gate: whether a turn asks for sensitive data, and each relation's sensitivity tier (two request shapes) |
 | `reranking` | `5893` | the fixed-point confidence band |
+| `embedding` | `5891` | HTTP single-text embedding and its process-owned dependency breaker |
 
-Only pure decisions moved. Each has a seam in the C: a registered provider that
+Those four pure decisions each have a seam in the C: a registered provider that
 is authoritative and never falls back to the local implementation, because a
 silent fallback lets a broken module look healthy. What a failure does instead
 is chosen per seam: the write gate defers (nothing written, caller retries),
@@ -31,10 +32,13 @@ gate fail closed, withholding rather than exposing. The retraction scan does not
 retract, because that path deletes and a fact left behind is recoverable where
 one deleted by mistake is not.
 
-`embedding` (`5891`) is still unimplemented and continues to fail closed. It is
-not a pure decision (it needs a model and a DB handle), so there is no
-in-process core to relocate; moving it would relocate I/O, not logic. Storage,
-graph, and lifecycle units likewise remain C.
+`embedding` (`5891`) is served by the Go module for HTTP embedders. Its
+process-local circuit breaker distinguishes suppression, authorization refusal,
+and attempted-call failure, and grants exactly one half-open probe. DB2 reaches
+that stage through a startup-installed host contract and accepts only bounded,
+finite vectors. Program-based embedders remain in the C host path by explicit
+contract: the Go module declines those commands without changing its breaker.
+Storage, graph, and lifecycle units likewise remain C.
 
 Every ported decision is held to the C by differential fixtures generated from
 the C itself (`scripts/gen-memory-pattern-fixtures.c`,

--- a/docs/proposals/pending/db2-as-a-go-module.md
+++ b/docs/proposals/pending/db2-as-a-go-module.md
@@ -6,8 +6,8 @@
   closure ledgers, reviewed host-adapter rehomes, immutable runtime-config and relationship-seed
   support, the provider-neutral DB3 protocol, authenticated multi-observer bus path, automatic
   deployed-provider default, and the catalog-driven durable projection/outbox seam. The standalone
-  link remains blocked by 38 sibling contracts. Its closure records 177 external symbols: 139
-  declared system links and those 38 injected contracts; portable API debt is zero. This is
+  link remains blocked by 37 sibling contracts. Its closure records 176 external symbols: 139
+  declared system links and those 37 injected contracts; portable API debt is zero. This is
   explicitly not the S4 ownership cutover or
   the S6 pure-Go DB2 port: production remains on direct calls, pgvector remains in DB2, and no
   external provider grant ships until the complete C backend passes replay and S4 activates it.
@@ -561,6 +561,12 @@ well. The KB adapters carry both bounded request shapes over the memory module's
 DB2 validates candidate counts, fixed-field termination, node kinds, binary scan flags, and
 attribute consistency before acting. An unavailable extractor returns an error instead of claiming
 the turn held zero facts, and an unavailable scanner cannot trigger deletion.
+
+Single-text embedding in DB2 now uses a startup-installed host contract too. HTTP embedding calls
+cross the memory module's served `embedding` event-bus stage, where the process-owned circuit
+breaker lives; the adapter preserves the module's explicit C-host path for program commands that
+the Go owner intentionally declines. DB2 accepts only a dimension within the caller's bound and
+finite vector components, so an absent or malformed answer cannot become a stored vector.
 
 The closure compiler now matches the production standalone mode by disabling DB1 and the DB2
 SQLite test shim. SQLite compatibility remains tested separately, but its weak DB1 cache hook and

--- a/scripts/tests/test_check_db2_link_closure.py
+++ b/scripts/tests/test_check_db2_link_closure.py
@@ -730,7 +730,7 @@ class LinkClosureTest(unittest.TestCase):
 
     def test_real_repository_reduces_owned_input_and_bounded_contract_debt(self) -> None:
         contract = json.loads((REPO / checker.CONTRACT).read_text(encoding="utf-8"))
-        self.assertEqual(contract["summary"]["unresolved_symbols"], 177)
+        self.assertEqual(contract["summary"]["unresolved_symbols"], 176)
         self.assertEqual(
             contract["summary"]["dispositions"]["descriptor-owned-copy/generated-input"], 0
         )
@@ -739,7 +739,7 @@ class LinkClosureTest(unittest.TestCase):
             contract["summary"]["dispositions"]["portable-core-promotion"], 0
         )
         self.assertEqual(
-            contract["summary"]["dispositions"]["injected-module-contract"], 38
+            contract["summary"]["dispositions"]["injected-module-contract"], 37
         )
         self.assertFalse(any(
             row["symbol"].startswith("cJSON_") for row in contract["unresolved"]

--- a/scripts/tests/test_gen_db2_declaration_ledger.py
+++ b/scripts/tests/test_gen_db2_declaration_ledger.py
@@ -46,11 +46,11 @@ class DeclarationLedgerTests(unittest.TestCase):
         value = ledger.build(REPO_ROOT)
         self.assertEqual(value["summary"], {
             "headers": 136,
-            "declarations": 1355,
+            "declarations": 1357,
             "reviewed": 62,
             "audit_pending": 895,
             "internal_unconsumed": 141,
-            "private_test_only": 257,
+            "private_test_only": 259,
         })
         self.assertFalse(value["declarations_complete"])
         self.assertEqual(

--- a/src/kb/kb_module_stage_adapters.c
+++ b/src/kb/kb_module_stage_adapters.c
@@ -5,6 +5,10 @@
 #include "kb_curator_grounding.h"
 #include "kb_mdl.h"
 #include "kb_route_acl.h"
+#include "aimee.h"
+#include "cJSON.h"
+#include "log.h"
+#include "memory.h"
 
 #include <aimee/audit/audit_worm_chain.h>
 #include <aimee/audit/obs_bus.h>
@@ -16,14 +20,16 @@
 #include <aimee/memory/module_api.h>
 #include <aimee/postgres/module_api.h>
 
-#include <stdatomic.h>
 #include <limits.h>
+#include <math.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
 #define KB_MODULE_STAGE_DEADLINE_NS (500ULL * 1000000ULL)
+#define KB_MODULE_EMBED_DEADLINE_NS (25ULL * 1000000000ULL)
 
 static atomic_uint_fast64_t next_trace = 1;
 
@@ -35,21 +41,29 @@ static uint64_t monotonic_ns(void)
    return (uint64_t)now.tv_sec * 1000000000ULL + (uint64_t)now.tv_nsec;
 }
 
-static int call_module(uint32_t event_kind, uint32_t stage_id, const void *request,
-                       uint32_t request_len, void *response, uint32_t response_capacity,
-                       uint32_t *response_len)
+static int call_module_with_budget(uint32_t event_kind, uint32_t stage_id, const void *request,
+                                   uint32_t request_len, void *response, uint32_t response_capacity,
+                                   uint32_t *response_len, uint64_t budget_ns)
 {
    uint64_t now = monotonic_ns();
-   if (!now)
+   if (!now || budget_ns > UINT64_MAX - now)
       return -1;
    uint64_t trace = atomic_fetch_add_explicit(&next_trace, 1, memory_order_relaxed);
    if (trace == 0)
       trace = atomic_fetch_add_explicit(&next_trace, 1, memory_order_relaxed);
-   return obs_bus_module_call(event_kind, stage_id, trace, now + KB_MODULE_STAGE_DEADLINE_NS,
-                              request, request_len, response, response_capacity, response_len, NULL,
+   return obs_bus_module_call(event_kind, stage_id, trace, now + budget_ns, request, request_len,
+                              response, response_capacity, response_len, NULL,
                               NULL) == AIMEE_MODULE_CALL_OK
               ? 0
               : -1;
+}
+
+static int call_module(uint32_t event_kind, uint32_t stage_id, const void *request,
+                       uint32_t request_len, void *response, uint32_t response_capacity,
+                       uint32_t *response_len)
+{
+   return call_module_with_budget(event_kind, stage_id, request, request_len, response,
+                                  response_capacity, response_len, KB_MODULE_STAGE_DEADLINE_NS);
 }
 
 static aimee_module_call_result_t
@@ -225,6 +239,111 @@ static int scan_fact_turn(const char *text, int *is_retraction, int *has_attr,
    return rc;
 }
 
+static int embed_command_is_http(const char *command)
+{
+   return command && (strncmp(command, "http://", strlen("http://")) == 0 ||
+                      strncmp(command, "https://", strlen("https://")) == 0);
+}
+
+static int json_optional_flag(const cJSON *root, const char *name, int *value)
+{
+   const cJSON *item = cJSON_GetObjectItemCaseSensitive(root, name);
+   if (!item)
+   {
+      *value = 0;
+      return 0;
+   }
+   if (!cJSON_IsBool(item))
+      return -1;
+   *value = cJSON_IsTrue(item) ? 1 : 0;
+   return 0;
+}
+
+static int embed_over_module(const char *text, const char *command, int input_type, float *out,
+                             int max_dim)
+{
+   if ((size_t)max_dim > (AIMEE_MODULE_MESSAGE_MAX_BODY - 512u) / 32u)
+      return 0;
+   cJSON *request_json = cJSON_CreateObject();
+   if (!request_json || !cJSON_AddStringToObject(request_json, "base_url", command) ||
+       !cJSON_AddStringToObject(request_json, "input_type",
+                                input_type == AIMEE_DB2_EMBED_QUERY ? "query" : "document") ||
+       !cJSON_AddStringToObject(request_json, "text", text) ||
+       !cJSON_AddNumberToObject(request_json, "max_dim", max_dim))
+   {
+      cJSON_Delete(request_json);
+      return 0;
+   }
+   char *request = cJSON_PrintUnformatted(request_json);
+   cJSON_Delete(request_json);
+   size_t request_len = request ? strlen(request) : 0;
+   size_t response_cap = 512u + (size_t)max_dim * 32u;
+   uint8_t *response = calloc(response_cap + 1u, 1u);
+   uint32_t response_len = 0;
+   int dim = 0;
+   if (!request || request_len == 0 || request_len > AIMEE_MODULE_MESSAGE_MAX_BODY ||
+       request_len > UINT32_MAX || !response || response_cap > UINT32_MAX ||
+       call_module_with_budget(AIMEE_MEMORY_EVENT_EMBED, AIMEE_MEMORY_STAGE_EMBED, request,
+                               (uint32_t)request_len, response, (uint32_t)response_cap,
+                               &response_len, KB_MODULE_EMBED_DEADLINE_NS) != 0)
+      goto done;
+
+   cJSON *root = cJSON_ParseWithLength((const char *)response, response_len);
+   const cJSON *json_dim = root ? cJSON_GetObjectItemCaseSensitive(root, "dim") : NULL;
+   const cJSON *vector = root ? cJSON_GetObjectItemCaseSensitive(root, "vector") : NULL;
+   const cJSON *error = root ? cJSON_GetObjectItemCaseSensitive(root, "error") : NULL;
+   int unavailable = 0, unauthorized = 0, truncated = 0;
+   if (!cJSON_IsObject(root) || !cJSON_IsNumber(json_dim) ||
+       json_dim->valuedouble != (double)json_dim->valueint || json_dim->valueint <= 0 ||
+       json_dim->valueint > max_dim || !cJSON_IsArray(vector) ||
+       cJSON_GetArraySize(vector) != json_dim->valueint ||
+       (error && (!cJSON_IsString(error) || (error->valuestring && error->valuestring[0]))) ||
+       json_optional_flag(root, "unavailable", &unavailable) != 0 || unavailable ||
+       json_optional_flag(root, "unauthorized", &unauthorized) != 0 || unauthorized ||
+       json_optional_flag(root, "truncated", &truncated) != 0)
+   {
+      cJSON_Delete(root);
+      goto done;
+   }
+   for (int i = 0; i < json_dim->valueint; ++i)
+   {
+      const cJSON *component = cJSON_GetArrayItem(vector, i);
+      if (!cJSON_IsNumber(component) || !isfinite(component->valuedouble))
+      {
+         cJSON_Delete(root);
+         goto done;
+      }
+      out[i] = (float)component->valuedouble;
+      if (!isfinite(out[i]))
+      {
+         cJSON_Delete(root);
+         goto done;
+      }
+   }
+   dim = json_dim->valueint;
+   if (truncated)
+      aimee_log(LOG_WARN, "memory",
+                "embedding truncated: module emitted more than max_dim %d; recall degraded",
+                max_dim);
+   cJSON_Delete(root);
+
+done:
+   free(request);
+   free(response);
+   return dim;
+}
+
+static int embed_text(const char *text, const char *command, int input_type, float *out,
+                      int max_dim)
+{
+   if (!text || !command || !command[0] || !out || max_dim <= 0 ||
+       (input_type != AIMEE_DB2_EMBED_DOCUMENT && input_type != AIMEE_DB2_EMBED_QUERY))
+      return 0;
+   if (!embed_command_is_http(command))
+      return memory_embed_text(text, command, (embed_input_type_t)input_type, out, max_dim);
+   return embed_over_module(text, command, input_type, out, max_dim);
+}
+
 int kb_module_postgres_health_probe(int *schema_ok, int *have_pg_trgm, int *kb_tables_ok)
 {
    uint8_t request[AIMEE_POSTGRES_REQUEST_LEN];
@@ -265,6 +384,7 @@ void kb_module_stage_adapters_configure(void)
    aimee_db2_register_fact_gate_provider(check_fact_gate);
    aimee_db2_register_fact_extract_provider(extract_facts);
    aimee_db2_register_fact_scan_provider(scan_fact_turn);
+   aimee_db2_register_embed_provider(embed_text);
    kb_curator_grounding_register_provider(grounding_decide);
    kb_route_acl_register_authorization_provider(control_web_authorize);
 }

--- a/src/modules/db2/c/kb_payload.c
+++ b/src/modules/db2/c/kb_payload.c
@@ -6,7 +6,6 @@
 #include "aimee.h"
 #include "artifacts.h"
 #include "../support/db2_runtime_config.h"
-#include "memory.h"
 #include "pgvec_transport.h"
 
 #include "db_postgres.h"
@@ -15,12 +14,35 @@
 #include "../support/db2_log.h"
 
 #include <ctype.h>
+#include <math.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define KBP_ERRBUF 256
+
+static db2_embed_fn g_embed_provider;
+
+void aimee_db2_register_embed_provider(db2_embed_fn provider)
+{
+   g_embed_provider = provider;
+}
+
+int db2_kb_embed_text(const char *text, const char *command, int input_type, float *out,
+                      int max_dim)
+{
+   if (!text || !command || !command[0] || !out || max_dim <= 0 ||
+       (input_type != DB2_EMBED_DOCUMENT && input_type != DB2_EMBED_QUERY) || !g_embed_provider)
+      return 0;
+   int dim = g_embed_provider(text, command, input_type, out, max_dim);
+   if (dim <= 0 || dim > max_dim)
+      return 0;
+   for (int i = 0; i < dim; ++i)
+      if (!isfinite(out[i]))
+         return 0;
+   return dim;
+}
 
 char *db2_kb_build_document_payload(int64_t doc_id)
 {
@@ -1090,7 +1112,7 @@ int db2_kb_pdf_search_chunks(const char *project, const char *query, int max,
       if (embed_cmd && embed_cmd[0])
       {
          float qvec[EMBED_MAX_DIM];
-         int dim = memory_embed_text(query, embed_cmd, EMBED_INPUT_QUERY, qvec, EMBED_MAX_DIM);
+         int dim = db2_kb_embed_text(query, embed_cmd, DB2_EMBED_QUERY, qvec, EMBED_MAX_DIM);
          if (dim > 0)
          {
             /* Request enough candidates to fill the remaining result budget even after

--- a/src/modules/db2/c/kb_payload.h
+++ b/src/modules/db2/c/kb_payload.h
@@ -17,6 +17,21 @@ extern "C"
 {
 #endif
 
+   enum
+   {
+      DB2_EMBED_DOCUMENT = 0,
+      DB2_EMBED_QUERY = 1,
+   };
+
+   typedef int (*db2_embed_fn)(const char *text, const char *command, int input_type, float *out,
+                               int max_dim);
+
+   /* Internal declarations of the embedding host contract exported publicly
+    * through <aimee/db2/host_contracts.h>. */
+   void aimee_db2_register_embed_provider(db2_embed_fn provider);
+   int db2_kb_embed_text(const char *text, const char *command, int input_type, float *out,
+                         int max_dim);
+
    /* Heap-allocated payload JSON for the kb_documents row, or NULL on
     * missing / SQL error.  Caller frees. */
    char *db2_kb_build_document_payload(int64_t doc_id);

--- a/src/modules/db2/c/kb_service_backend.c
+++ b/src/modules/db2/c/kb_service_backend.c
@@ -449,7 +449,7 @@ static int db2_kb_service_async_process_embed_raw(int64_t document_id, const cha
       snprintf(embed_text, sizeof(embed_text), "%s", content_buf);
 
    float vec[EMBED_MAX_DIM];
-   int dim = memory_embed_text(embed_text, embedding_cmd, EMBED_INPUT_DOCUMENT, vec, EMBED_MAX_DIM);
+   int dim = db2_kb_embed_text(embed_text, embedding_cmd, DB2_EMBED_DOCUMENT, vec, EMBED_MAX_DIM);
    if (dim <= 0)
    {
       snprintf(errbuf, errbuf_size, "embedding generation failed");
@@ -539,7 +539,7 @@ static int db2_kb_service_async_process_embed_pdf(int64_t document_id, const cha
       snprintf(embed_text, sizeof(embed_text), "%s", content_buf);
 
    float vec[EMBED_MAX_DIM];
-   int dim = memory_embed_text(embed_text, embedding_cmd, EMBED_INPUT_DOCUMENT, vec, EMBED_MAX_DIM);
+   int dim = db2_kb_embed_text(embed_text, embedding_cmd, DB2_EMBED_DOCUMENT, vec, EMBED_MAX_DIM);
    if (dim <= 0)
    {
       snprintf(errbuf, errbuf_size, "embedding generation failed");

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "cdf10a8c1b200387f2b87921972e07c0210df90f",
-  "source_fingerprint": "d20994fd2d15d6e84c8665ff0f9e599268cff94cb8a6e0a8a93245f8cf7ef237",
+  "source_revision": "2b3d4551a12b196e44e47b73c062ac2fc7fb013c",
+  "source_fingerprint": "cfd12ec2ac3b07142772310e6e61ec2630231b98bfb014e703c5a78ab3a89685",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM",
@@ -2430,15 +2430,6 @@
       "evidence": "C/POSIX, libpq, SQLite, libm, pthread, or OpenSSL ABI symbol; retain only as an explicit descriptor system dependency."
     },
     {
-      "symbol": "memory_embed_text",
-      "references": [
-        "src/modules/db2/c/kb_payload.c",
-        "src/modules/db2/c/kb_service_backend.c"
-      ],
-      "disposition": "injected-module-contract",
-      "evidence": "The symbol belongs to a KB or sibling-module surface; replace the direct call with an injected bounded contract before standalone linking."
-    },
-    {
       "symbol": "mktime",
       "references": [
         "src/modules/db2/c/entity_edges.c"
@@ -3494,15 +3485,15 @@
   "summary": {
     "translation_units": 138,
     "descriptor_support_units": 22,
-    "unresolved_symbols": 177,
+    "unresolved_symbols": 176,
     "dispositions": {
       "descriptor-owned-copy/generated-input": 0,
-      "injected-module-contract": 38,
+      "injected-module-contract": 37,
       "portable-core-promotion": 0,
       "private-implementation": 0,
       "remove/dead": 0,
       "system-link": 139
     }
   },
-  "fingerprint": "e7d3d850e9c5b5dce234576c1d2a13838b07a3da1e5250b706b2d01aab9a760a"
+  "fingerprint": "c8d5e83bab9ed9383a3b968a617922500cde044b203e455da5b4525cf0f55644"
 }

--- a/src/modules/db2/include/aimee/db2/host_contracts.h
+++ b/src/modules/db2/include/aimee/db2/host_contracts.h
@@ -78,6 +78,23 @@ extern "C"
    void aimee_db2_register_fact_extract_provider(aimee_db2_fact_extract_fn provider);
    void aimee_db2_register_fact_scan_provider(aimee_db2_fact_scan_fn provider);
 
+   enum
+   {
+      AIMEE_DB2_EMBED_DOCUMENT = 0,
+      AIMEE_DB2_EMBED_QUERY = 1,
+   };
+
+   /* Embed one text through the process-owned memory stage. A successful
+    * provider returns a dimension in [1,max_dim] and fills exactly that many
+    * finite floats. Zero means unavailable or failed; it is never a lexical
+    * substitute. */
+   typedef int (*aimee_db2_embed_fn)(const char *text, const char *command, int input_type,
+                                     float *out, int max_dim);
+
+   /* Install the memory embedding adapter. NULL removes it; DB2 then fails
+    * embedding closed instead of linking or falling back to memory internals. */
+   void aimee_db2_register_embed_provider(aimee_db2_embed_fn provider);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/memory/include/aimee/memory/module_api.h
+++ b/src/modules/memory/include/aimee/memory/module_api.h
@@ -1,5 +1,5 @@
 /* Wire contract for the memory process's reranking confidence, typed-fact
- * write-gate, pattern-extraction and PII recall-gate stages. */
+ * write-gate, pattern-extraction, PII recall-gate and embedding stages. */
 #ifndef AIMEE_MEMORY_MODULE_API_H
 #define AIMEE_MEMORY_MODULE_API_H 1
 
@@ -22,6 +22,12 @@
 #define AIMEE_MEMORY_WIRE_VERSION       1u
 #define AIMEE_MEMORY_REQUEST_LEN        16u
 #define AIMEE_MEMORY_RESPONSE_LEN       8u
+
+/* EMBED uses the module's bounded JSON envelope because its vector is variable
+ * width. Request fields are base_url:string, input_type:"document"|"query",
+ * text:string and max_dim:positive integer. A successful response carries
+ * vector:number[] and dim; optional truncated, unavailable and unauthorized
+ * booleans and error:string keep distinct failure facts distinct. */
 
 /* Typed-fact write gate (stage WRITE). Separate magics from the rerank stage so
  * a request routed to the wrong stage is rejected rather than misparsed. */

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -1,5 +1,6 @@
 /* test_kb.c: unit tests for the project knowledge base (kb.c) */
 #include <assert.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,6 +31,32 @@
 /* ------------------------------------------------------------------ */
 /* Test utilities                                                       */
 /* ------------------------------------------------------------------ */
+
+static int test_db2_embed_provider(const char *text, const char *command, int input_type,
+                                   float *out, int max_dim)
+{
+   if (strcmp(command, "test-invalid-dim") == 0)
+      return max_dim + 1;
+   if (strcmp(command, "test-nonfinite") == 0)
+   {
+      out[0] = NAN;
+      return 1;
+   }
+   return memory_embed_text(text, command, (embed_input_type_t)input_type, out, max_dim);
+}
+
+static void test_db2_embed_contract(void)
+{
+   float vec[8] = {0};
+   aimee_db2_register_embed_provider(NULL);
+   assert(db2_kb_embed_text("hello", MEMORY_EMBED_TEST_FIXTURE, DB2_EMBED_QUERY, vec, 8) == 0);
+   aimee_db2_register_embed_provider(test_db2_embed_provider);
+   assert(db2_kb_embed_text("hello", "test-invalid-dim", DB2_EMBED_QUERY, vec, 8) == 0);
+   assert(db2_kb_embed_text("hello", "test-nonfinite", DB2_EMBED_QUERY, vec, 8) == 0);
+   assert(db2_kb_embed_text("hello", MEMORY_EMBED_TEST_FIXTURE, -1, vec, 8) == 0);
+   assert(db2_kb_embed_text("hello", MEMORY_EMBED_TEST_FIXTURE, DB2_EMBED_QUERY, vec, 8) > 0);
+   printf("  PASS: DB2 embedding contract fails closed on unavailable or malformed answers\n");
+}
 
 static int test_kb_vector_upsert_document(int64_t document_id, const float *vec, int dim,
                                           const char *payload_json, void *ctx)
@@ -1218,6 +1245,8 @@ static void test_excludes_node_modules(void)
 int main(void)
 {
    printf("test_kb:\n");
+
+   test_db2_embed_contract();
 
    /* kb_resolve_project tests */
    test_resolve_project_explicit();

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -1237,6 +1237,21 @@
     },
     {
       "consumers": [
+        "src/tests/test_kb.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/kb_payload.h",
+          "line": 31
+        }
+      ],
+      "signature": "void aimee_db2_register_embed_provider ( db2_embed_fn provider )",
+      "signature_sha256": "e9a01b47b5f663d3142a8d4006da6eaead8fce289f6c768e7f845be525558dc7",
+      "status": "private-test-only",
+      "symbol": "aimee_db2_register_embed_provider"
+    },
+    {
+      "consumers": [
         "src/tests/test_fact_ingest.c"
       ],
       "locations": [
@@ -5777,7 +5792,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 100
+          "line": 115
         }
       ],
       "signature": "int db2_curator_invalidate_doc ( const char * project , const char * file_path )",
@@ -5790,7 +5805,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 112
+          "line": 127
         }
       ],
       "signature": "void db2_curator_invalidation_record ( const char * source_kind , const char * source_id , int artifacts_stale )",
@@ -5807,7 +5822,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 115
+          "line": 130
         }
       ],
       "signature": "int db2_curator_invalidations_since ( int64_t since_id , db2_curator_invalidation_t * out , int max )",
@@ -5837,7 +5852,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 96
+          "line": 111
         }
       ],
       "signature": "int db2_curator_reenqueue_extract_all ( void )",
@@ -8648,7 +8663,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 240
+          "line": 255
         }
       ],
       "signature": "int db2_kb_async_count_kind ( const char * kind )",
@@ -8664,7 +8679,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 246
+          "line": 261
         }
       ],
       "signature": "int db2_kb_async_count_kind_pending ( const char * kind )",
@@ -8683,7 +8698,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 93
+          "line": 108
         }
       ],
       "signature": "int db2_kb_async_enqueue ( const char * kind , int64_t document_id , const char * project )",
@@ -8790,7 +8805,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 332
+          "line": 347
         }
       ],
       "signature": "int db2_kb_blob_ref_referenced ( const char * blob_ref )",
@@ -8805,7 +8820,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 22
+          "line": 37
         }
       ],
       "signature": "char * db2_kb_build_document_payload ( int64_t doc_id )",
@@ -8821,7 +8836,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 307
+          "line": 322
         }
       ],
       "signature": "int db2_kb_doc_asset_insert ( const char * project , const char * document_key , int page_no , double x0 , double y0 , double x1 , double y1 , const char * kind , const char * caption , const char * content_type , const char * blob_ref , const char * sensitivity_class )",
@@ -8837,7 +8852,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 317
+          "line": 332
         }
       ],
       "signature": "int db2_kb_doc_asset_open ( const char * project , int64_t asset_id , char * blob_ref_out , size_t ref_cap , char * content_type_out , size_t ct_cap )",
@@ -8852,7 +8867,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 328
+          "line": 343
         }
       ],
       "signature": "int db2_kb_doc_assets_delete_for_doc ( const char * project , const char * document_key )",
@@ -8868,7 +8883,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 323
+          "line": 338
         }
       ],
       "signature": "int db2_kb_doc_assets_list ( const char * project , const char * document_key , db2_kb_doc_asset_t * out , int max )",
@@ -8944,7 +8959,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 222
+          "line": 237
         }
       ],
       "signature": "int db2_kb_doc_regions_for_chunk ( int64_t chunk_id , db2_kb_pdf_region_t * out , int max )",
@@ -8959,7 +8974,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 159
+          "line": 174
         }
       ],
       "signature": "int64_t db2_kb_doc_regions_insert ( int64_t chunk_id , const char * document_key , int page_no , double x0 , double y0 , double x1 , double y1 , const char * quote , int line_index , const char * content_type , const char * sensitivity_class )",
@@ -9009,7 +9024,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 42
+          "line": 57
         }
       ],
       "signature": "int db2_kb_document_fetch ( int64_t id , const char * project , db2_kb_document_row_t * out )",
@@ -9026,7 +9041,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 129
+          "line": 144
         }
       ],
       "signature": "void db2_kb_documents_delete_for_file ( const char * project , const char * file_path )",
@@ -9039,7 +9054,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 84
+          "line": 99
         }
       ],
       "signature": "int db2_kb_documents_fts_search ( const char * project , const char * query , int64_t * ids , double * scores , int max )",
@@ -9054,7 +9069,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 86
+          "line": 101
         }
       ],
       "signature": "int db2_kb_documents_fts_search_scoped ( const char * project , const char * exclude_project , const char * query , int64_t * ids , double * scores , int max )",
@@ -9070,7 +9085,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 65
+          "line": 80
         }
       ],
       "signature": "int db2_kb_documents_get_stored_hash ( const char * project , const char * file_path , char * out , size_t out_len )",
@@ -9085,7 +9100,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 71
+          "line": 86
         }
       ],
       "signature": "int db2_kb_documents_hash_exists ( const char * project , const char * file_hash , char * sample_path , size_t sample_path_len )",
@@ -9100,7 +9115,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 77
+          "line": 92
         }
       ],
       "signature": "int db2_kb_documents_hll_sources_for_hash ( const char * project , const char * file_hash , sketch_hll_t * out )",
@@ -9119,7 +9134,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 135
+          "line": 150
         }
       ],
       "signature": "int64_t db2_kb_documents_insert_chunk ( const char * project , const char * file_path , const char * file_hash , int chunk_index , const char * heading_path , int line_start , int line_end , const char * content , int token_count )",
@@ -9134,7 +9149,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 148
+          "line": 163
         }
       ],
       "signature": "int64_t db2_kb_documents_insert_chunk_pdf ( const char * project , const char * file_path , const char * file_hash , int chunk_index , const char * heading_path , int line_start , int line_end , const char * content , int token_count , const char * chunk_strategy , int page_start , int page_end , const char * sensitivity_class , const char * quarantine_state )",
@@ -9152,7 +9167,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 143
+          "line": 158
         }
       ],
       "signature": "void db2_kb_documents_link_neighbours ( int64_t doc_id , int64_t prev_id )",
@@ -9169,7 +9184,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 122
+          "line": 137
         }
       ],
       "signature": "int db2_kb_documents_list_chunk_ids_for_file ( const char * project , const char * file_path , int64_t * out , int max )",
@@ -9185,7 +9200,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 59
+          "line": 74
         }
       ],
       "signature": "int db2_kb_documents_list_convention_candidates ( db2_kb_convention_row_t * out , int max )",
@@ -9201,13 +9216,28 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 284
+          "line": 299
         }
       ],
       "signature": "void db2_kb_documents_set_tsr_state ( const char * project , const char * file_path , const char * state )",
       "signature_sha256": "2ad93a6533c85679625b1dc98af047b8cb09933f17e7918c15301707f7f53fcb",
       "status": "audit-pending",
       "symbol": "db2_kb_documents_set_tsr_state"
+    },
+    {
+      "consumers": [
+        "src/tests/test_kb.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/kb_payload.h",
+          "line": 32
+        }
+      ],
+      "signature": "int db2_kb_embed_text ( const char * text , const char * command , int input_type , float * out , int max_dim )",
+      "signature_sha256": "40ff154dda4ae0d9fa654eb042d3136a0504796dba4d5087a681fdcf5644648b",
+      "status": "private-test-only",
+      "symbol": "db2_kb_embed_text"
     },
     {
       "consumers": [
@@ -9443,7 +9473,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 356
+          "line": 371
         }
       ],
       "signature": "int db2_kb_pdf_inspect_structure ( const char * project , const char * document_key , db2_kb_pdf_outline_t * out , int max )",
@@ -9458,7 +9488,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 344
+          "line": 359
         }
       ],
       "signature": "int db2_kb_pdf_open_neighbors ( const char * project , int64_t chunk_id , db2_kb_pdf_chunk_t * out , int max )",
@@ -9473,7 +9503,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 339
+          "line": 354
         }
       ],
       "signature": "int db2_kb_pdf_open_page ( const char * project , const char * document_key , int page_no , db2_kb_pdf_region_t * out , int max )",
@@ -9489,7 +9519,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 229
+          "line": 244
         }
       ],
       "signature": "int db2_kb_pdf_quarantine_confirm ( const char * project , const char * document_key )",
@@ -9504,7 +9534,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 230
+          "line": 245
         }
       ],
       "signature": "int db2_kb_pdf_quarantine_reject ( const char * project , const char * document_key )",
@@ -9519,7 +9549,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 236
+          "line": 251
         }
       ],
       "signature": "int db2_kb_pdf_reembed_project ( const char * project )",
@@ -9535,7 +9565,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 207
+          "line": 222
         }
       ],
       "signature": "int db2_kb_pdf_search_chunks ( const char * project , const char * query , int max , db2_kb_pdf_chunk_t * out , db2_kb_answerability_t * ans_out )",
@@ -9551,7 +9581,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 286
+          "line": 301
         }
       ],
       "signature": "int db2_kb_pdf_tsr_state ( const char * project , const char * document_key , char * out , size_t out_len )",
@@ -12391,7 +12421,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 268
+          "line": 283
         }
       ],
       "signature": "int db2_kb_table_cell_insert ( int64_t region_id , const char * document_key , int page_no , int cell_row , int cell_col , const char * cell_text , const char * subject , const char * relation , const char * object , int tsr_confidence , const char * sensitivity_class )",
@@ -12407,7 +12437,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 277
+          "line": 292
         }
       ],
       "signature": "int db2_kb_table_cells_lookup ( const char * project , const char * document_key , int page_no , db2_kb_table_cell_t * out , int max )",
@@ -12425,7 +12455,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 166
+          "line": 181
         }
       ],
       "signature": "int db2_kb_txn_begin ( void )",
@@ -12443,7 +12473,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 167
+          "line": 182
         }
       ],
       "signature": "int db2_kb_txn_commit ( void )",
@@ -12462,7 +12492,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/kb_payload.h",
-          "line": 168
+          "line": 183
         }
       ],
       "signature": "void db2_kb_txn_rollback ( void )",
@@ -23784,15 +23814,15 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "348e667bd71112ab01faee4d53276342d0397593ec4290bc3c07bd3819218fed",
+  "fingerprint": "6f7af39565097397a554afd4793960204fb554564972c8fd089826bc42683834",
   "module": "db2",
   "schema_version": 1,
   "summary": {
     "audit_pending": 895,
-    "declarations": 1355,
+    "declarations": 1357,
     "headers": 136,
     "internal_unconsumed": 141,
-    "private_test_only": 257,
+    "private_test_only": 259,
     "reviewed": 62
   }
 }


### PR DESCRIPTION
## Summary

- replace DB2 direct calls to memory_embed_text with a bounded startup-injected embedding contract
- route HTTP embedders over memory event 5891 so the Go module owns the dependency breaker
- retain the documented C host path for program-based embedders that the Go module intentionally declines
- preserve query/document polarity and reject missing providers, invalid dimensions, malformed JSON, and non-finite vectors

## Closure movement

- unresolved external symbols: 177 -> 176
- injected-contract debt: 38 -> 37
- outbound source-boundary includes: 167 -> 166
- no DB3 provider activation or DB2 ownership cutover

## Validation

- focused unit-test-kb suite, including missing/malformed provider answers and existing async embedding behavior
- production aimee-kb build
- full repository lint
- DB2 contract, declaration-ledger, activation, module-inventory, docs, and test-registration gates
- DB2 link-closure and source-boundary checks
- 59 link-closure tests and 14 declaration-ledger tests
- git diff --check

## Review status

The required frozen-diff roundtable was attempted, but aimee-server remained unavailable after its built-in retries. This PR is intentionally draft and roundtable approval is still pending.