### PR TITLE
feat: serve the argument shapes, so a new command's flags need no new client

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -131,8 +131,18 @@ jobs:
       # and fails until the baseline is refrozen, and THAT diff is the useful
       # artifact: one review of everything a release changes on the public
       # surface, instead of nineteen refreezes read by nobody.
+      # Integration bases, not just `testing`: agent/<topic> and aimee/feat/<id>
+      # are stacked onto the same way (see ci.yml's pull_request branch list), so
+      # a sub-PR based on one hit this release gate while its eventual base does
+      # not. Both escapes were wrong -- re-freeze, which the refusal below then
+      # blocks on the way to `testing`, or leave the PR red.
       - name: Enforce refactor surface baselines
-        if: github.base_ref != 'testing' && github.ref != 'refs/heads/testing'
+        if: >-
+          !startsWith(github.base_ref, 'agent/')
+          && !startsWith(github.base_ref, 'aimee/feat/')
+          && github.base_ref != 'testing'
+          && github.ref != 'refs/heads/testing'
+          && !startsWith(github.ref, 'refs/heads/agent/')
         run: python3 -I -S scripts/refactor_baselines.py
       # The surface baseline is a RELEASE gate, enforced on `main` by the step
       # above and deliberately not here. That makes re-freezing it on a `testing`
@@ -149,7 +159,10 @@ jobs:
       #
       # Adding a public header therefore does not require touching this file.
       - name: Refuse a baseline re-freeze on the integration branch
-        if: github.base_ref == 'testing'
+        if: >-
+          github.base_ref == 'testing'
+          || startsWith(github.base_ref, 'agent/')
+          || startsWith(github.base_ref, 'aimee/feat/')
         run: |
           set -eu
           git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
@@ -158,7 +171,8 @@ jobs:
             exit 0
           fi
           cat >&2 <<'MSG'
-          ::error::This PR changes tests/baselines/refactor/index.json, and it targets `testing`.
+          ::error::This PR changes tests/baselines/refactor/index.json, and it targets the
+          integration branch `${{ github.base_ref }}`.
 
           The public-surface baseline is a release question. It gates `main`, not this
           branch, so re-freezing it here achieves nothing and collides with every other
@@ -166,10 +180,10 @@ jobs:
 
           Revert the file and push again:
 
-              git checkout origin/testing -- tests/baselines/refactor/index.json
+              git checkout "origin/${{ github.base_ref }}" -- tests/baselines/refactor/index.json
 
           You do NOT need to re-freeze after adding or changing a public header. The
-          baseline is expected to be stale on `testing`; the promotion PR into `main`
+          baseline is expected to be stale on an integration branch; the promotion PR into `main`
           re-freezes it once, and that single diff is the review of what the release
           changed on the public surface.
           MSG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -935,6 +935,7 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_v1_routes_e.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_c.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_b.c
+    ${AIMEE_SRC_DIR}/cli_argspec.c
     ${AIMEE_SRC_DIR}/cli_index_bootstrap.c
     ${AIMEE_SRC_DIR}/cli_launch.c
     ${AIMEE_SRC_DIR}/cli_mcp_serve.c
@@ -1049,6 +1050,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/cli_v1_routes_e.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_c.c
     ${AIMEE_SRC_DIR}/cli_v1_routes_b.c
+    ${AIMEE_SRC_DIR}/cli_argspec.c
     ${AIMEE_SRC_DIR}/server/agent_admission.c
     ${AIMEE_SRC_DIR}/server/provider_catalog.c
     ${AIMEE_SRC_DIR}/server/dashboard_server.c

--- a/scripts/check-manifest-emitter-linkage.py
+++ b/scripts/check-manifest-emitter-linkage.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""A test target that links a caller must link what the caller calls.
+
+The served-manifest work added one small object per served body -- the command
+catalogue, the dispatch rows, the no-arg list, the argument specs, the spec
+interpreter -- and every single one broke the same way:
+
+    undefined reference to `cli_dispatch_defs_to_json'
+    undefined reference to `cli_marshal_defs_to_json'
+    undefined reference to `cli_argspec_defs_to_json'
+    undefined reference to `cli_argspec_build'
+
+Four times, always found by CI minutes after a push, because tests/Rules.mk
+maintains its prerequisite lists by hand and nothing relates them to what the
+code actually calls. The last one needed edits to ten separate targets.
+
+So derive it. For each provider below, find the functions it exports and the
+objects whose sources call them; then require every Rules.mk target linking a
+calling object to link the provider too. Adding a provider function, or a new
+caller, now fails at lint naming the target -- not in a build naming a symbol.
+
+Scoped to these providers on purpose: they are small leaf objects that exist to
+be linked alongside their caller, which is exactly the shape that keeps being
+forgotten. A whole-program link check is a different tool (check-linking).
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+RULES = ROOT / "src/tests/Rules.mk"
+
+# provider object -> the source that defines its exported functions.
+PROVIDERS = {
+    "server/cli_command_defs.o": "src/server/cli_command_defs.c",
+    "server/cli_dispatch_defs.o": "src/server/cli_dispatch_defs.c",
+    "server/cli_marshal_defs.o": "src/server/cli_marshal_defs.c",
+    "server/cli_argspec_defs.o": "src/server/cli_argspec_defs.c",
+    "cli_argspec.o": "src/cli_argspec.c",
+}
+
+# Sources that might call them, mapped to the object they compile to. Kept
+# explicit: these are the two translation units the manifest work touches, and
+# guessing an object name from a path is how a check quietly stops matching.
+CALLERS = {
+    "src/server/server_http_config_routes.c": "server/server_http_config_routes.o",
+    "src/cli_v1_routes_b.c": "cli_v1_routes_b.o",
+}
+
+TESTS_DIR = ROOT / "src/tests"
+
+_RULES_TEXT = None  # plant-test override
+
+
+def exported_functions(src_path):
+    """Non-static functions the provider defines, by name."""
+    text = (ROOT / src_path).read_text(encoding="utf-8", errors="replace")
+    names = set()
+    for m in re.finditer(r"^(?!static)([A-Za-z_][\w \*]*?)\b([a-z_][\w]*)\s*\([^;]*?\)\s*$",
+                         text, re.M):
+        names.add(m.group(2))
+    if not names:
+        raise SystemExit(f"check-manifest-emitter-linkage: no exported functions found in "
+                         f"{src_path}; the extractor has drifted from the source")
+    return names
+
+
+def required_edges():
+    """(caller object, provider object) pairs the link lists must honour."""
+    edges = set()
+    for src, caller_obj in CALLERS.items():
+        body = (ROOT / src).read_text(encoding="utf-8", errors="replace")
+        for provider_obj, provider_src in PROVIDERS.items():
+            if provider_src.endswith(pathlib.Path(src).name):
+                continue  # a source does not depend on itself
+            for fn in exported_functions(provider_src):
+                if re.search(rf"\b{re.escape(fn)}\s*\(", body):
+                    edges.add((caller_obj, provider_obj))
+                    break
+    if not edges:
+        raise SystemExit("check-manifest-emitter-linkage: found no caller->provider edges; "
+                         "the extractor has drifted from the sources")
+    return sorted(edges)
+
+
+def including_tests(caller_src):
+    """Test sources that #include a caller source instead of linking its object.
+
+    A test that includes the source to reach a static function does NOT link the
+    caller's object -- doing both would duplicate every symbol in it -- but it
+    still inherits the calls, so it needs the provider all the same.
+
+    This is the case the first version of this check was blind to. It looked
+    only for targets LINKING the caller object, reported ok, and the very next
+    unit-test run failed on `cli_argspec_build` in a target that includes
+    cli_v1_routes_b.c. A check that only understands one of the two ways to
+    depend on code will keep passing while the build breaks.
+    """
+    name = pathlib.Path(caller_src).name
+    out = set()
+    for src in sorted(TESTS_DIR.glob("*.c")):
+        body = src.read_text(encoding="utf-8", errors="replace")
+        if re.search(rf'#\s*include\s+"[^"]*{re.escape(name)}"', body):
+            out.add(f"tests/{src.stem}.o")
+    return out
+
+
+def rules(text):
+    """(target, prerequisites) per rule, with continuations joined."""
+    joined = re.sub(r"\\\n\s*", " ", text)
+    out = []
+    for line in joined.split("\n"):
+        if ":" not in line or not line.startswith("$("):
+            continue
+        target, _, prereqs = line.partition(":")
+        out.append((target.strip(), prereqs))
+    return out
+
+
+def main():
+    plant = "--plant-test" in sys.argv
+    text = _RULES_TEXT if _RULES_TEXT is not None else RULES.read_text(encoding="utf-8")
+    if plant:
+        # Drop one provider object everywhere and require the check to notice.
+        # Removing it EVERYWHERE also exercises the include-style dependants,
+        # which the first version of this check could not see at all.
+        text = text.replace("$(OBJDIR)/cli_argspec.o ", "")
+
+    edges = required_edges()
+    # A target depends on a caller either by linking its object or by linking a
+    # test object whose source #includes it. Both inherit the calls.
+    caller_objs = {}
+    for caller_obj, provider_obj in edges:
+        src = next(s for s, o in CALLERS.items() if o == caller_obj)
+        caller_objs.setdefault(caller_obj, {caller_obj} | including_tests(src))
+
+    problems = []
+    checked = 0
+    for target, prereqs in rules(text):
+        for caller_obj, provider_obj in edges:
+            if not any(f"$(OBJDIR)/{o}" in prereqs for o in caller_objs[caller_obj]):
+                continue
+            checked += 1
+            if f"$(OBJDIR)/{provider_obj}" not in prereqs:
+                problems.append(f"  {target}\n      depends on {caller_obj} (linked, or "
+                                f"#included by one of its test sources) but does not link "
+                                f"{provider_obj}, which it calls into")
+
+    if plant:
+        if problems:
+            print("check-manifest-emitter-linkage: plant-test ok "
+                  "(a removed provider object was caught)")
+            return 0
+        print("check-manifest-emitter-linkage: PLANT FAIL - removing a provider object did NOT "
+              "fail the check; it is decoration", file=sys.stderr)
+        return 1
+
+    if problems:
+        print("check-manifest-emitter-linkage: FAIL", file=sys.stderr)
+        print("\n".join(sorted(set(problems))), file=sys.stderr)
+        return 1
+
+    print(f"check-manifest-emitter-linkage: ok ({len(edges)} caller->provider edges, "
+          f"{checked} target linkages verified)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-manifest-emitter-linkage.py
+++ b/scripts/check-manifest-emitter-linkage.py
@@ -19,6 +19,12 @@ objects whose sources call them; then require every Rules.mk target linking a
 calling object to link the provider too. Adding a provider function, or a new
 caller, now fails at lint naming the target -- not in a build naming a symbol.
 
+The SAME omission then broke CMake, which keeps its own source lists for the
+macOS and Windows builds: adding cli_argspec.c to src/Makefile left
+CMakeLists.txt without it, and three jobs failed on the identical symbol. So
+this checks both -- a provider source must appear in every CMake list that
+carries a caller source, for the same reason and by the same derivation.
+
 Scoped to these providers on purpose: they are small leaf objects that exist to
 be linked alongside their caller, which is exactly the shape that keeps being
 forgotten. A whole-program link check is a different tool (check-linking).
@@ -29,6 +35,7 @@ import sys
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 RULES = ROOT / "src/tests/Rules.mk"
+CMAKE = ROOT / "CMakeLists.txt"
 
 # provider object -> the source that defines its exported functions.
 PROVIDERS = {
@@ -117,6 +124,46 @@ def rules(text):
     return out
 
 
+def cmake_lists():
+    """Each set(<NAME> ...) block in CMakeLists.txt, as (name, body)."""
+    text = CMAKE.read_text(encoding="utf-8", errors="replace")
+    out = []
+    for m in re.finditer(r"^set\((\w+)\n(.*?)^\)", text, re.S | re.M):
+        out.append((m.group(1), m.group(2)))
+    if not out:
+        raise SystemExit("check-manifest-emitter-linkage: no set() source lists found in "
+                         f"{CMAKE}; the extractor has drifted")
+    return out
+
+
+def check_cmake(edges):
+    """CMake keeps its own lists for the macOS and Windows builds.
+
+    Adding the interpreter to src/Makefile and not here failed three jobs on the
+    same `undefined reference to cli_argspec_build` the Rules.mk half of this
+    check exists to prevent. A list carrying a caller source must carry the
+    provider source too.
+    """
+    problems = []
+    lists = cmake_lists()
+    checked = 0
+    for name, body in lists:
+        for caller_obj, provider_obj in edges:
+            caller_src = next(s for s, o in CALLERS.items() if o == caller_obj)
+            provider_src = PROVIDERS[provider_obj]
+            # Paths in CMake are ${AIMEE_SRC_DIR}-relative, so compare on the
+            # part after src/.
+            caller_rel = caller_src[len("src/"):]
+            provider_rel = provider_src[len("src/"):]
+            if f"/{caller_rel}" not in body:
+                continue
+            checked += 1
+            if f"/{provider_rel}" not in body:
+                problems.append(f"  CMakeLists.txt set({name})\n      lists {caller_rel} but not "
+                                f"{provider_rel}, which it calls into")
+    return problems, checked
+
+
 def main():
     plant = "--plant-test" in sys.argv
     text = _RULES_TEXT if _RULES_TEXT is not None else RULES.read_text(encoding="utf-8")
@@ -155,13 +202,16 @@ def main():
               "fail the check; it is decoration", file=sys.stderr)
         return 1
 
+    cmake_problems, cmake_checked = check_cmake(edges)
+    problems += cmake_problems
+
     if problems:
         print("check-manifest-emitter-linkage: FAIL", file=sys.stderr)
         print("\n".join(sorted(set(problems))), file=sys.stderr)
         return 1
 
     print(f"check-manifest-emitter-linkage: ok ({len(edges)} caller->provider edges, "
-          f"{checked} target linkages verified)")
+          f"{checked} test-target linkages and {cmake_checked} CMake list(s) verified)")
     return 0
 
 

--- a/scripts/test-served-argspec-e2e.py
+++ b/scripts/test-served-argspec-e2e.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Prove a command with ARGUMENTS, unknown to this client, runs from served data alone.
+
+The earlier proof (`aimee brandnew thing`) covered a command that takes no
+arguments. This covers the harder half: a command whose flags become fields the
+client has never heard of. The stub serves a route, a dispatch row and an
+argument spec for a method that appears nowhere in the client binary, then
+asserts the client POSTed the right path with the right BODY -- because a spec
+that produces the wrong body would still "work" against a permissive server.
+"""
+import http.server
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+
+METHOD = "widget.tune"
+SEEN = []
+
+MANIFEST = {
+    "manifest_version": 1,
+    "routes": [{"op": METHOD, "verb": "POST", "path": "/v1/widget/tune"}],
+    "commands": [{"name": "widget", "summary": "tune a widget", "subcommands": [{"name": "tune"}]}],
+    "dispatch": [{"cmd": "widget", "sub": "tune", "method": METHOD}],
+    "marshal": [{
+        "method": METHOD,
+        "args": {
+            "bool_flags": ["dry-run"],
+            "fields": [
+                {"json": "widget_id", "from": "positional_or_flag", "index": 0,
+                 "flag": "id", "required": True},
+                {"json": "torque", "from": "flag", "flag": "torque", "type": "number"},
+                {"json": "dry_run", "from": "flag", "flag": "dry-run", "type": "true_if_set"},
+            ],
+            "usage": "usage: aimee widget tune <id> [--torque N] [--dry-run]",
+        },
+    }],
+}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path.startswith("/v1/cli/manifest"):
+            self._send(MANIFEST)
+        else:
+            self._send({"status": "ok"})
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n) if n else b""
+        try:
+            body = json.loads(raw or b"{}")
+        except ValueError:
+            body = {"__unparseable__": raw.decode("utf-8", "replace")}
+        SEEN.append((self.path, body))
+        self._send({"status": "ok"})
+
+
+def main():
+    aimee = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "aimee")
+    if not os.access(aimee, os.X_OK):
+        print("missing prerequisite: ./aimee")
+        return 1
+
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    port = srv.server_address[1]
+
+    home = tempfile.mkdtemp(prefix="aimee-argspec-e2e-")
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["AIMEE_HOME"] = os.path.join(home, ".config", "aimee")
+    env["AIMEE_API_ENDPOINT"] = f"tcp:127.0.0.1:{port}"
+    env.pop("AIMEE_PROFILE", None)
+    os.makedirs(env["AIMEE_HOME"], exist_ok=True)
+
+    rc = subprocess.run(
+        [aimee, "widget", "tune", "w-42", "--torque", "7", "--dry-run"],
+        env=env, capture_output=True, text=True, timeout=90)
+
+    posts = [(p, b) for p, b in SEEN if p == "/v1/widget/tune"]
+    print(f"exit: {rc.returncode}")
+    print(f"stderr: {rc.stderr.strip()[:300]}")
+    print(f"server saw: {posts}")
+
+    ok = rc.returncode == 0 and len(posts) == 1
+    if ok:
+        body = posts[0][1]
+        expected = {"method": METHOD, "protocol_version": 1,
+                    "widget_id": "w-42", "torque": 7, "dry_run": True}
+        # Compare the fields the spec describes. A missing or renamed field here
+        # is the failure this whole exercise is about: the request would still
+        # be valid JSON and the server would still answer it.
+        for k, v in expected.items():
+            if body.get(k) != v:
+                print(f"MISMATCH {k}: expected {v!r}, got {body.get(k)!r}")
+                ok = False
+
+    # And the refusal: with no id, the client must print the SPEC's usage line
+    # and send nothing. A served command has to misuse as loudly as a compiled
+    # one, or an operator cannot tell a typo from an outage.
+    before = len(SEEN)
+    rc2 = subprocess.run([aimee, "widget", "tune"], env=env,
+                         capture_output=True, text=True, timeout=90)
+    said_usage = "aimee widget tune <id>" in (rc2.stderr + rc2.stdout)
+    sent_nothing = len(SEEN) == before
+    print(f"missing-arg: exit={rc2.returncode} usage_shown={said_usage} sent_nothing={sent_nothing}")
+    if not (said_usage and sent_nothing and rc2.returncode != 0):
+        ok = False
+
+    print(f"\nRESULT: a command with arguments, absent from this build, ran end to end: {ok}")
+    srv.shutdown()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Makefile
+++ b/src/Makefile
@@ -511,7 +511,7 @@ cmd-srcs-compile-check: $(CMD_OBJS) $(ORPHAN_OBJS)
 	@echo "cmd-srcs-compile-check: ok ($(words $(CMD_SRCS)) cmd + $(words $(ORPHAN_SRCS)) orphan file(s))"
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_kb_smoke.c cli_v1_routes.c cli_v1_routes_d.c cli_v1_routes_e.c cli_v1_routes_c.c cli_v1_routes_b.c cli_index_bootstrap.c cli_main.c cli_agent_setup.c cli_session_start.c session_degraded_notice.c cmd_self_update.c self_update_util.c harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c cli_attention_guard.c client_session_worktree.c session_worktree_key.c cli_code_audit.c cli_css.c cli_chat_stream.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c modules/delegates/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c modules/protocols/acp/acp_server.c modules/workspace/cli_workspace_serve.c modules/workspace/workspace_client_diff.c cli_agent_keys.c cmd_workflow.c
+CLI_SRCS = cli_kb_smoke.c cli_argspec.c cli_v1_routes.c cli_v1_routes_d.c cli_v1_routes_e.c cli_v1_routes_c.c cli_v1_routes_b.c cli_index_bootstrap.c cli_main.c cli_agent_setup.c cli_session_start.c session_degraded_notice.c cmd_self_update.c self_update_util.c harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c cli_attention_guard.c client_session_worktree.c session_worktree_key.c cli_code_audit.c cli_css.c cli_chat_stream.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c modules/delegates/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c modules/protocols/acp/acp_server.c modules/workspace/cli_workspace_serve.c modules/workspace/workspace_client_diff.c cli_agent_keys.c cmd_workflow.c
 CLI_SRCS += http_content_encoding.c
 CLI_OBJS = $(CLI_SRCS:%.c=$(OBJDIR)/%.o)
 CLIENT_PLATFORM_OBJS = $(filter %/platform_ipc.o %/platform_net.o %/platform_path.o %/platform_process.o %/platform_random.o %/history.o %/cli_client.o %/cli_main.o,$(PLATFORM_OBJS))
@@ -546,7 +546,7 @@ SERVER_SRCS += server/cli_command_defs.c
 # The CLI dispatch rows (cmd/verb -> method) the thin client resolves against.
 SERVER_SRCS += server/cli_dispatch_defs.c
 # Methods whose request body is empty, served so a new no-arg command is usable.
-SERVER_SRCS += server/cli_marshal_defs.c
+SERVER_SRCS += server/cli_marshal_defs.c server/cli_argspec_defs.c
 SERVER_SRCS += server/ingress_project_scope.c
 SERVER_SRCS += server/server_write_tier.c server/server_write_tier_db1.c shared/auth_token_verify.c server/kb_verifier_server_stub.c kb/auth_oidc.c server/server_mgmt_audit.c server/server_mgmt_endpoint.c shared/management_read.c server/server_mgmt_read_endpoint.c server/server_mgmt_read_source.c server/server_mgmt_status.c server/server_mgmt_checkpoint_client.c kb/kb_mgmt_status.c kb/kb_mgmt_client.c kb/kb_mgmt_endpoint.c
 SERVER_SRCS += http_content_encoding.c server/server_http_keepalive.c server/server_http_body.c
@@ -908,7 +908,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB1_CLIENT_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS
 # nothing is stale when nothing exists.
 DEPS = $(ALL_OBJS:.o=.d) $(shell find $(OBJDIR) -name '*.d' 2>/dev/null)
 
-.PHONY: optional-tool-ownership-check refactor-baseline-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check repository-lock-check db2-contract-check db3-contract-check db2-declaration-ledger-check db2-activation-check all clean install inc-check forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check guidance-tool-parity-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check tests-are-run-check model-fallback-shadow-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check deployed-image-check gen-sdks sdk-parity-check v1-ws-test format unit-tests go-unit-tests verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
+.PHONY: optional-tool-ownership-check refactor-baseline-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check repository-lock-check db2-contract-check db3-contract-check db2-declaration-ledger-check db2-activation-check all clean install inc-check forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check guidance-tool-parity-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check manifest-emitter-linkage-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check tests-are-run-check model-fallback-shadow-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check deployed-image-check gen-sdks sdk-parity-check v1-ws-test format unit-tests go-unit-tests verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_RUNTIME_WEB) $(SERVER) $(KB) $(KB_RESOLVER) $(GATEWAY) $(FORWARDER)
 
@@ -1189,6 +1189,7 @@ endif
 integration-tests: $(BINARY) $(SERVER)
 	./tests/test_integration.sh
 	python3 ../scripts/test-thin-client-remote-exclusive.py $(BINARY)
+	python3 ../scripts/test-served-argspec-e2e.py $(BINARY)
 
 init-migrate-service-test: $(BINARY) $(SERVER)
 	./tests/test_init_migrate_service.sh
@@ -1766,6 +1767,15 @@ v1-method-coverage-check:
 cli-v1-routes-check:
 	@python3 ../scripts/check-cli-v1-routes.py
 
+# CI gate: a test target that links the CLI-manifest route must link every
+# emitter that route calls. The link list is hand-maintained, so each new served
+# body (dispatch rows, the no-arg list, the argument specs) broke the same two
+# targets with the same "undefined reference to cli_*_defs_to_json" — three
+# times, each found by CI after a push. This derives the requirement from what
+# the route actually calls.
+manifest-emitter-linkage-check:
+	@python3 ../scripts/check-manifest-emitter-linkage.py
+
 # CI gate: a handler bound to an async (rh_dispatch_op_async) /v1 route must write
 # its reply before returning. A detached-thread reply lands after the op-run bridge
 # has read and closed its socketpair, so the run fails with "rpc produced no
@@ -1933,7 +1943,7 @@ lint: BUS_BLAST_RADIUS_FLAGS := --allow-unbuilt
 # the lock, so running it in lint just demands a lock refresh after each edit
 # under src/core|modules/**. The c-repository-pins workflow runs it for `main`
 # and for PRs into `main`.
-LINT_CHECKS = subject-corpus-check native-tool-parity-check guidance-tool-parity-check optional-tool-ownership-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check db2-contract-check db3-contract-check db2-declaration-ledger-check db2-activation-check background-skill-curator-absence-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check tests-are-run-check model-fallback-shadow-check p1-tenant-guard-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check config-encapsulation-check deployed-image-check
+LINT_CHECKS = subject-corpus-check native-tool-parity-check guidance-tool-parity-check optional-tool-ownership-check module-source-ownership-check module-bus-boundary-check cleanup-ledger-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check db2-contract-check db3-contract-check db2-declaration-ledger-check db2-activation-check background-skill-curator-absence-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check manifest-emitter-linkage-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check tests-are-run-check model-fallback-shadow-check p1-tenant-guard-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check config-encapsulation-check deployed-image-check
 
 lint:
 	@fail=""; n=0; \

--- a/src/cli_argspec.c
+++ b/src/cli_argspec.c
@@ -1,0 +1,251 @@
+/* cli_argspec.c: build a request body from a served argument spec.
+ *
+ * See headers/cli_argspec.h for the spec shape and what it deliberately cannot
+ * express. The rule throughout this file is that an unrecognised anything —
+ * source, type, field shape — refuses the WHOLE spec. A partially honoured
+ * spec produces a request body that is wrong rather than incomplete, and the
+ * server would answer it as though the operator had asked for that.
+ */
+#include "cli_argspec.h"
+
+#include "cli_v1_routes_internal.h"
+
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Field value sources. */
+#define SRC_FLAG            "flag"
+#define SRC_POSITIONAL      "positional"
+#define SRC_POSITIONAL_FLAG "positional_or_flag"
+#define SRC_ARGV_JOINED     "argv_joined"
+
+/* How a value becomes JSON. Absent means "string". */
+#define TYPE_STRING      "string"
+#define TYPE_NUMBER      "number"
+#define TYPE_BOOL        "bool"
+#define TYPE_TRUE_IF_SET "true_if_set"
+
+static const char *field_str(const cJSON *field, const char *key)
+{
+   const cJSON *v = cJSON_GetObjectItemCaseSensitive(field, key);
+   return cJSON_IsString(v) && v->valuestring ? v->valuestring : NULL;
+}
+
+static int known_source(const char *from)
+{
+   return from && (!strcmp(from, SRC_FLAG) || !strcmp(from, SRC_POSITIONAL) ||
+                   !strcmp(from, SRC_POSITIONAL_FLAG) || !strcmp(from, SRC_ARGV_JOINED));
+}
+
+static int known_type(const char *type)
+{
+   /* Absent is legal and means string: the commonest field should not have to
+    * say so in every row. */
+   return !type || !strcmp(type, TYPE_STRING) || !strcmp(type, TYPE_NUMBER) ||
+          !strcmp(type, TYPE_BOOL) || !strcmp(type, TYPE_TRUE_IF_SET);
+}
+
+int cli_argspec_supported(const cJSON *spec)
+{
+   if (!cJSON_IsObject(spec))
+      return 0;
+   const cJSON *fields = cJSON_GetObjectItemCaseSensitive(spec, "fields");
+   /* No fields is a legal spec — it is the no-argument case written the long
+    * way — but a `fields` that is present and not an array is a spec this
+    * build does not understand. */
+   if (fields && !cJSON_IsArray(fields))
+      return 0;
+   const cJSON *bools = cJSON_GetObjectItemCaseSensitive(spec, "bool_flags");
+   if (bools && !cJSON_IsArray(bools))
+      return 0;
+   for (const cJSON *b = bools ? bools->child : NULL; b; b = b->next)
+      if (!cJSON_IsString(b) || !b->valuestring)
+         return 0;
+
+   for (const cJSON *f = fields ? fields->child : NULL; f; f = f->next)
+   {
+      if (!cJSON_IsObject(f))
+         return 0;
+      const char *json_name = field_str(f, "json");
+      const char *from = field_str(f, "from");
+      if (!json_name || !json_name[0] || !known_source(from))
+         return 0;
+      if (!known_type(field_str(f, "type")))
+         return 0;
+      /* A source must carry what it reads from, or the row means nothing. */
+      if ((!strcmp(from, SRC_FLAG) || !strcmp(from, SRC_POSITIONAL_FLAG)) && !field_str(f, "flag"))
+         return 0;
+      if (!strcmp(from, SRC_POSITIONAL) || !strcmp(from, SRC_POSITIONAL_FLAG))
+      {
+         const cJSON *idx = cJSON_GetObjectItemCaseSensitive(f, "index");
+         if (!cJSON_IsNumber(idx) || idx->valuedouble < 0 || idx->valuedouble >= V1_MAX_POS)
+            return 0;
+      }
+   }
+   return 1;
+}
+
+/* Collect the spec's bool flags into the NULL-terminated array cli_args_parse
+ * expects. Returns NULL when there are none (which cli_args_parse accepts), or
+ * on allocation failure — indistinguishable here, so the caller checks the
+ * count itself before treating NULL as an error. */
+static const char **collect_bool_flags(const cJSON *spec, int *count_out)
+{
+   *count_out = 0;
+   const cJSON *bools = cJSON_GetObjectItemCaseSensitive(spec, "bool_flags");
+   int n = bools ? cJSON_GetArraySize(bools) : 0;
+   if (n <= 0)
+      return NULL;
+   const char **out = calloc((size_t)n + 1u, sizeof(*out));
+   if (!out)
+      return NULL;
+   int i = 0;
+   for (const cJSON *b = bools->child; b && i < n; b = b->next)
+      out[i++] = b->valuestring;
+   out[i] = NULL;
+   *count_out = i;
+   return out;
+}
+
+/* Join every argv word with single spaces. The one shape that reads the command
+ * line as prose rather than as fields (`aimee help how do delegates work`). */
+static char *join_argv(int argc, char **argv)
+{
+   size_t total = 1;
+   for (int i = 0; i < argc; i++)
+      total += strlen(argv[i]) + 1;
+   char *out = malloc(total);
+   if (!out)
+      return NULL;
+   out[0] = '\0';
+   for (int i = 0; i < argc; i++)
+   {
+      if (i > 0)
+         strcat(out, " ");
+      strcat(out, argv[i]);
+   }
+   return out;
+}
+
+/* The value a field reads, or NULL when it is absent. `joined` is the lazily
+ * built argv join, owned by the caller. */
+static const char *field_value(const cJSON *field, const cli_args_t *opts, const char *joined)
+{
+   const char *from = field_str(field, "from");
+   const char *flag = field_str(field, "flag");
+
+   if (!strcmp(from, SRC_ARGV_JOINED))
+      return joined && joined[0] ? joined : NULL;
+
+   if (!strcmp(from, SRC_FLAG))
+      return cli_args_get(opts, flag);
+
+   const cJSON *idx = cJSON_GetObjectItemCaseSensitive(field, "index");
+   int i = (int)idx->valuedouble;
+   const char *pos = (opts->pos_count > i && opts->positional[i] && opts->positional[i][0])
+                         ? opts->positional[i]
+                         : NULL;
+   if (pos)
+      return pos;
+   /* positional_or_flag falls back to the named flag, which is how the compiled
+    * marshallers let `aimee trigger status <id>` and `--id <id>` mean the same
+    * thing. A plain positional does not fall back. */
+   return !strcmp(from, SRC_POSITIONAL_FLAG) ? cli_args_get(opts, flag) : NULL;
+}
+
+/* Add one field to `req`. Returns 0 on success, -1 when a required field is
+ * absent (the caller reports usage and abandons the request). */
+static int add_field(cJSON *req, const cJSON *field, const cli_args_t *opts, const char *joined)
+{
+   const char *json_name = field_str(field, "json");
+   const char *type = field_str(field, "type");
+   int required = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(field, "required"));
+
+   /* true_if_set is a presence test, not a value: `--json` with no argument is
+    * the whole of it, so ask the parser whether the flag was there at all. */
+   if (type && !strcmp(type, TYPE_TRUE_IF_SET))
+   {
+      if (cli_args_get(opts, field_str(field, "flag")))
+         cJSON_AddTrueToObject(req, json_name);
+      return 0;
+   }
+
+   const char *value = field_value(field, opts, joined);
+   if (!value || !value[0])
+      return required ? -1 : 0;
+
+   if (!type || !strcmp(type, TYPE_STRING))
+      cJSON_AddStringToObject(req, json_name, value);
+   else if (!strcmp(type, TYPE_NUMBER))
+   {
+      /* Strict: a field the spec called a number is refused rather than
+       * coerced, so "12x" cannot quietly become 12 and address something the
+       * operator did not type. */
+      char *tail = NULL;
+      double d = strtod(value, &tail);
+      if (!tail || *tail || tail == value)
+         return -1;
+      cJSON_AddNumberToObject(req, json_name, d);
+   }
+   else /* TYPE_BOOL: the flag's presence, emitted as an explicit true. */
+      cJSON_AddBoolToObject(req, json_name, cli_args_has_flag(opts, field_str(field, "flag")));
+   return 0;
+}
+
+cJSON *cli_argspec_build(const char *method, const cJSON *spec, int argc, char **argv)
+{
+   if (!method || !method[0] || !cli_argspec_supported(spec))
+      return NULL;
+
+   int bool_count = 0;
+   const char **bool_flags = collect_bool_flags(spec, &bool_count);
+   const cJSON *bools = cJSON_GetObjectItemCaseSensitive(spec, "bool_flags");
+   if (bools && cJSON_GetArraySize(bools) > 0 && !bool_flags)
+      return NULL; /* allocation failed; do not parse with the wrong flag set */
+
+   cli_args_t opts;
+   cli_args_parse(argc, argv, bool_flags, &opts);
+
+   char *joined = NULL;
+   const cJSON *fields = cJSON_GetObjectItemCaseSensitive(spec, "fields");
+   for (const cJSON *f = fields ? fields->child : NULL; f && !joined; f = f->next)
+   {
+      const char *from = field_str(f, "from");
+      if (from && !strcmp(from, SRC_ARGV_JOINED))
+         joined = join_argv(argc, argv);
+   }
+
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+   {
+      free((void *)bool_flags);
+      free(joined);
+      return NULL;
+   }
+   cJSON_AddStringToObject(req, "method", method);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
+
+   int missing = 0;
+   for (const cJSON *f = fields ? fields->child : NULL; f && !missing; f = f->next)
+      if (add_field(req, f, &opts, joined) != 0)
+         missing = 1;
+
+   free((void *)bool_flags);
+   free(joined);
+
+   if (missing)
+   {
+      /* Say what was expected. A marshal failure is a silent exit in the shared
+       * forwarder, so a served command must refuse as loudly as a compiled one
+       * or the operator is left unable to tell a typo from an outage. */
+      const char *usage = field_str(spec, "usage");
+      fprintf(stderr, "aimee: %s\n", usage && usage[0] ? usage : "missing a required argument");
+      marshal_request_note_reported();
+      cJSON_Delete(req);
+      return NULL;
+   }
+   return req;
+}

--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -3,6 +3,7 @@
  * Unported commands fail in cli_main before reaching the server.
  * =================================================================== */
 
+#include "cli_argspec.h"
 #include "cli_v1_routes_internal.h"
 #include "platform_path.h"
 #include "cli_client.h"
@@ -1559,6 +1560,15 @@ int marshal_request_take_reported(void)
    return reported;
 }
 
+/* Read the flag WITHOUT clearing it. marshal_request itself has to distinguish
+ * "a served spec already told the operator what was missing" from "the spec was
+ * uninterpretable", and taking the flag here would swallow the message the
+ * forwarder is about to check for. */
+int marshal_request_peek_reported(void)
+{
+   return g_marshal_reported;
+}
+
 cJSON *marshal_request(const char *method, int argc, char **argv)
 {
    /* Cleared on entry so a previous command's flag cannot suppress this one's message. */
@@ -1675,6 +1685,31 @@ cJSON *marshal_request(const char *method, int argc, char **argv)
     * preferring its own list here would reintroduce exactly that. */
    if (cli_v1_manifest_method_takes_no_args(method))
       return marshal_no_args(method);
+
+   /* And what the server says the ARGUMENTS are. Same reason, one step further:
+    * a new command that takes arguments was still unusable, because the client
+    * had no way to learn that `--capability` becomes "capability".
+    *
+    * Consulted before the compiled marshallers, so a served spec wins — that is
+    * the point. It is safe because it cannot silently differ: every shipped
+    * spec is proven byte-identical to its marshaller by test_cli_argspec, which
+    * includes the same data file the server serves from. A spec this build
+    * cannot interpret is refused whole by cli_argspec_build, and falls through
+    * to the compiled path below rather than sending a body it guessed. */
+   {
+      const cJSON *spec = cli_v1_manifest_argspec(method);
+      if (spec)
+      {
+         cJSON *req = cli_argspec_build(method, spec, argc, argv);
+         if (req)
+            return req;
+         /* NULL is either "a required argument is missing" — already reported,
+          * and the operator must see that rather than a second opinion from a
+          * marshaller — or an uninterpretable spec, which falls through. */
+         if (marshal_request_peek_reported())
+            return NULL;
+      }
+   }
 
    /* Exact-method tables (before the prefix fallbacks). */
    for (size_t i = 0; i < sizeof(MARSHAL_NO_ARGS) / sizeof(MARSHAL_NO_ARGS[0]); i++)

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -753,6 +753,39 @@ int cli_v1_manifest_method_takes_no_args(const char *method)
    return 0;
 }
 
+/* The served argument spec for `method`, or NULL when the server sent none.
+ *
+ * The same `marshal` rows as above; the two are distinguished by what `args`
+ * is. "none" means an empty body, an OBJECT means a spec describing how the
+ * words after the command become fields. Anything else — a shape a newer
+ * server sends and this client has no idea about — is NULL here, so the client
+ * falls back to its compiled marshaller rather than acting on a row it only
+ * half understands.
+ *
+ * Borrowed from the cached manifest, not copied: it lives as long as the
+ * process, and the one caller reads it and builds immediately. */
+const cJSON *cli_v1_manifest_argspec(const char *method)
+{
+   if (!method || !method[0])
+      return NULL;
+   const cJSON *doc = cli_v1_manifest();
+   if (!doc)
+      return NULL;
+   const cJSON *rows = cJSON_GetObjectItemCaseSensitive(doc, "marshal");
+   if (!cJSON_IsArray(rows))
+      return NULL;
+   const cJSON *row = NULL;
+   cJSON_ArrayForEach(row, rows)
+   {
+      const cJSON *m = cJSON_GetObjectItemCaseSensitive(row, "method");
+      if (!cJSON_IsString(m) || strcmp(m->valuestring, method) != 0)
+         continue;
+      const cJSON *a = cJSON_GetObjectItemCaseSensitive(row, "args");
+      return cJSON_IsObject(a) ? a : NULL;
+   }
+   return NULL;
+}
+
 /* Test seam: install a manifest directly instead of fetching one. Unit tests
  * have no server to ask, and the mapping they used to assert (method -> path) is
  * the SERVER's property now — covered by server-api-conformance-check and by the

--- a/src/headers/cli_argspec.h
+++ b/src/headers/cli_argspec.h
@@ -1,0 +1,53 @@
+/* cli_argspec.h: build a request body from a SERVED argument spec.
+ *
+ * The manifest already tells the thin client which commands exist, how they
+ * route, and which take no arguments. What it could not say is how the words
+ * after the command become fields, so a new command with arguments still
+ * needed a new client — the last thing in the chain the server could not
+ * describe.
+ *
+ * This interprets a spec that says it. The vocabulary is deliberately small,
+ * because it was read off the marshallers that exist rather than designed for
+ * ones that might: a bool-flag list for the parser, then an ordered list of
+ * fields, each naming where its value comes from and what JSON it becomes.
+ *
+ *   {"method": "catalog.list",
+ *    "args": {"bool_flags": ["json", "open-weights"],
+ *             "fields": [
+ *               {"json": "capability",        "from": "flag",       "flag": "capability"},
+ *               {"json": "json",              "from": "flag",       "flag": "json",
+ *                "type": "true_if_set"},
+ *               {"json": "open_weights_only", "from": "flag",       "flag": "open-weights",
+ *                "type": "bool"},
+ *               {"json": "name",              "from": "positional", "index": 0}]}}
+ *
+ * What it deliberately CANNOT express: reading the client's filesystem or
+ * environment, composing prompts, or cross-field rules like "either --task or
+ * --proposal". The first two are the thin client's own job and must not move
+ * server-side at all; the third is a judgement about what the user meant, and a
+ * spec language that grew conditionals would become a program transmitted over
+ * the wire. Those methods keep their compiled marshaller, and this returns NULL
+ * for anything it cannot build faithfully rather than sending a body it guessed.
+ */
+#ifndef DEC_CLI_ARGSPEC_H
+#define DEC_CLI_ARGSPEC_H 1
+
+struct cJSON;
+
+/* Build the request body for `method` from `spec` (the "args" object of one
+ * manifest marshal row) and the command's argv.
+ *
+ * Returns a new cJSON object carrying method + protocol_version + the spec's
+ * fields, or NULL when the spec is unusable or a required field is missing. On
+ * a missing required field it prints the spec's `usage` line to stderr, so a
+ * served command misuses exactly as loudly as a compiled one. Caller owns the
+ * result. */
+struct cJSON *cli_argspec_build(const char *method, const struct cJSON *spec, int argc,
+                                char **argv);
+
+/* True when `spec` is an object this interpreter can build from. A spec naming
+ * a source or type it does not know is refused WHOLE rather than partially
+ * honoured: half a request body is a wrong request, not a degraded one. */
+int cli_argspec_supported(const struct cJSON *spec);
+
+#endif /* DEC_CLI_ARGSPEC_H */

--- a/src/headers/cli_argspec_defs.h
+++ b/src/headers/cli_argspec_defs.h
@@ -1,0 +1,21 @@
+/* cli_argspec_defs.h: the argument specs the server publishes in the CLI
+ * manifest, alongside the "this method takes no arguments" rows.
+ *
+ * See headers/cli_argspec.h for the spec vocabulary and what it deliberately
+ * cannot express.
+ */
+#ifndef DEC_CLI_ARGSPEC_DEFS_H
+#define DEC_CLI_ARGSPEC_DEFS_H 1
+
+#include <stddef.h>
+
+struct cJSON;
+
+/* JSON array of {method, args}, where `args` is a spec OBJECT. Merged into the
+ * manifest's `marshal` list beside the {method, args:"none"} rows. Caller owns
+ * the result. */
+struct cJSON *cli_argspec_defs_to_json(void);
+
+size_t cli_argspec_defs_count(void);
+
+#endif /* DEC_CLI_ARGSPEC_DEFS_H */

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -273,6 +273,11 @@ const struct cJSON *cli_v1_manifest_dispatch(void);
  * marshaller rather than sending an empty body for a command needing arguments. */
 int cli_v1_manifest_method_takes_no_args(const char *method);
 
+/* The server's argument spec for `method` (the `args` object of its marshal
+ * row), or NULL when it sent none or sent a shape this build cannot read.
+ * Borrowed from the cached manifest; do not free. */
+const struct cJSON *cli_v1_manifest_argspec(const char *method);
+
 /* TEST ONLY. Install a command manifest instead of fetching one from the server,
  * so a unit test can exercise route lookup without a server. Takes ownership of
  * `doc`. Never called outside tests; real invocations always fetch. */

--- a/src/headers/cli_v1_routes_internal.h
+++ b/src/headers/cli_v1_routes_internal.h
@@ -89,6 +89,9 @@ cJSON *marshal_request(const char *method, int argc, char **argv);
  * Reading it CLEARS it, so a stale flag cannot suppress the generic message on a later
  * command in the same process. */
 void marshal_request_note_reported(void);
+/* The same flag, read without clearing: marshal_request consults it to tell a
+ * served spec's own refusal from a spec it could not interpret. */
+int marshal_request_peek_reported(void);
 int marshal_request_take_reported(void);
 cJSON *marshal_rules_delete(int argc, char **argv);
 cJSON *marshal_session_attach(int argc, char **argv);

--- a/src/server/cli_argspec_defs.c
+++ b/src/server/cli_argspec_defs.c
@@ -1,0 +1,60 @@
+/* cli_argspec_defs.c: serve the argument specs.
+ *
+ * The manifest could already tell a thin client which commands exist, how they
+ * route, what they are called, and which take no arguments. What it could not
+ * say was how the words after the command become fields — so a NEW command that
+ * took arguments still needed a new client. This closes that: the marshal rows
+ * now carry a spec object as well as the "none" case.
+ *
+ * The specs live in cli_argspec_defs_data.h, which the differential test
+ * includes too, so what is proven is what is served.
+ */
+#include "cli_argspec_defs.h"
+
+#include "cJSON.h"
+
+#include <stddef.h>
+
+typedef struct
+{
+   const char *method;
+   const char *spec; /* a JSON object, as text */
+} cli_argspec_def_t;
+
+static const cli_argspec_def_t g_argspecs[] = {
+#include "cli_argspec_defs_data.h"
+};
+
+size_t cli_argspec_defs_count(void)
+{
+   return sizeof(g_argspecs) / sizeof(g_argspecs[0]);
+}
+
+cJSON *cli_argspec_defs_to_json(void)
+{
+   cJSON *arr = cJSON_CreateArray();
+   if (!arr)
+      return NULL;
+   for (size_t i = 0; i < cli_argspec_defs_count(); i++)
+   {
+      const cli_argspec_def_t *d = &g_argspecs[i];
+      if (!d->method || !d->spec)
+         continue;
+      /* Parsed rather than embedded as a string: the client receives an object
+       * it can read directly, and a spec that does not parse is dropped HERE
+       * rather than shipped for every client to fail on identically. */
+      cJSON *spec = cJSON_Parse(d->spec);
+      if (!spec)
+         continue;
+      cJSON *row = cJSON_CreateObject();
+      if (!row)
+      {
+         cJSON_Delete(spec);
+         continue;
+      }
+      cJSON_AddStringToObject(row, "method", d->method);
+      cJSON_AddItemToObject(row, "args", spec);
+      cJSON_AddItemToArray(arr, row);
+   }
+   return arr;
+}

--- a/src/server/cli_argspec_defs_data.h
+++ b/src/server/cli_argspec_defs_data.h
@@ -13,6 +13,33 @@
  *
  * NOT here, and never: anything reading the client's own disk or environment.
  * That is the thin client's own job, not knowledge of what the server can do.
+ *
+ * WHY THE REST ARE NOT HERE YET, from reading every remaining marshaller. The
+ * blocker is not the spec language -- it is that the marshallers disagree with
+ * each other, and a spec that reproduced each disagreement would stop being
+ * data and start being a program:
+ *
+ *   - LENIENT NUMBERS. aux.test, dogfood.tag, api.enable and others parse with
+ *     atoi()/cli_args_get_int(), so "12x" becomes 12 and "abc" becomes 0 or a
+ *     default. This file's "number" refuses rather than coerces, deliberately
+ *     (see kb.grant's team_id, where rounding an id would administer the wrong
+ *     team). Serving these means fixing the coercion, not describing it.
+ *   - MISSING ENVELOPE. eval.results, dogfood.tag and others build their body
+ *     by hand and omit protocol_version, which every other request carries. The
+ *     differential test catches it immediately, which is how it was found.
+ *   - DERIVED FIELDS. catalog.show splits "provider:model" into two fields;
+ *     workspace.add inverts --no-scan into "scan": false and nests part of its
+ *     body under `args`.
+ *   - CROSS-FIELD RULES. cron.enable's --all is valid only for two of the five
+ *     cron methods; trigger.fire accepts --task OR --proposal; dogfood.tag's
+ *     --surprise and --no-surprise are exclusive. These are judgements about
+ *     what the operator meant.
+ *   - LOCAL STATE. eval.run, identity.snapshot and six others read getcwd() or
+ *     the filesystem. These must NEVER be served, whatever the spec can express.
+ *
+ * So the remaining work is normalising the marshallers, which now has a safety
+ * net: convert one, add its samples, and the differential test proves the
+ * request body did not change.
  */
 
 {"provider.list",
@@ -48,4 +75,11 @@
  "{\"usage\":\"usage: aimee trigger cancel <id>\","
  "\"fields\":[{\"json\":\"id\",\"from\":\"positional_or_flag\",\"index\":0,\"flag\":\"id\","
  "\"required\":true}]}"},
+
+{"model.episodes",
+ "{\"fields\":[{\"json\":\"agent\",\"from\":\"positional_or_flag\",\"index\":0,"
+ "\"flag\":\"agent\"}]}"},
+
+{"graph.sync_code",
+ "{\"fields\":[{\"json\":\"project\",\"from\":\"positional\",\"index\":0}]}"},
 

--- a/src/server/cli_argspec_defs_data.h
+++ b/src/server/cli_argspec_defs_data.h
@@ -1,0 +1,51 @@
+/* cli_argspec_defs_data.h: the argument specs served to the thin client.
+ *
+ * Bare initializer rows of {method, spec}, included by BOTH the server emitter
+ * (server/cli_argspec_defs.c, which serves them) and the differential test
+ * (tests/test_cli_argspec.c, which proves each one builds the same request body
+ * the compiled marshaller does). Included by both on purpose: a test that
+ * carried its own copy of the specs would prove a spec that is not the one
+ * shipped, which is the failure mode this whole exercise exists to avoid.
+ *
+ * The spec vocabulary is in headers/cli_argspec.h. A method appears here only
+ * once its samples in the differential test pass; the test refuses a row it has
+ * no samples for, so a spec cannot ship unproven.
+ *
+ * NOT here, and never: anything reading the client's own disk or environment.
+ * That is the thin client's own job, not knowledge of what the server can do.
+ */
+
+{"provider.list",
+ "{\"bool_flags\":[\"available\",\"all\",\"json\"],"
+ "\"fields\":["
+ "{\"json\":\"available_only\",\"from\":\"flag\",\"flag\":\"available\",\"type\":\"true_if_set\"},"
+ "{\"json\":\"all\",\"from\":\"flag\",\"flag\":\"all\",\"type\":\"true_if_set\"},"
+ "{\"json\":\"json\",\"from\":\"flag\",\"flag\":\"json\",\"type\":\"true_if_set\"}]}"},
+
+{"provider.models",
+ "{\"bool_flags\":[\"json\"],"
+ "\"fields\":["
+ "{\"json\":\"name\",\"from\":\"positional\",\"index\":0},"
+ "{\"json\":\"json\",\"from\":\"flag\",\"flag\":\"json\",\"type\":\"true_if_set\"}]}"},
+
+{"catalog.list",
+ "{\"bool_flags\":[\"json\",\"open-weights\"],"
+ "\"fields\":["
+ "{\"json\":\"capability\",\"from\":\"flag\",\"flag\":\"capability\"},"
+ "{\"json\":\"json\",\"from\":\"flag\",\"flag\":\"json\",\"type\":\"true_if_set\"},"
+ "{\"json\":\"open_weights_only\",\"from\":\"flag\",\"flag\":\"open-weights\","
+ "\"type\":\"bool\"}]}"},
+
+{"trigger.list",
+ "{\"fields\":[{\"json\":\"status\",\"from\":\"flag\",\"flag\":\"status\"}]}"},
+
+{"trigger.status",
+ "{\"usage\":\"usage: aimee trigger status <id>\","
+ "\"fields\":[{\"json\":\"id\",\"from\":\"positional_or_flag\",\"index\":0,\"flag\":\"id\","
+ "\"required\":true}]}"},
+
+{"trigger.cancel",
+ "{\"usage\":\"usage: aimee trigger cancel <id>\","
+ "\"fields\":[{\"json\":\"id\",\"from\":\"positional_or_flag\",\"index\":0,\"flag\":\"id\","
+ "\"required\":true}]}"},
+

--- a/src/server/server_http_config_routes.c
+++ b/src/server/server_http_config_routes.c
@@ -8,6 +8,7 @@
 #include "cli_command_defs.h"  /* the command catalogue served in the CLI manifest */
 #include "cli_dispatch_defs.h" /* cmd/verb -> method rows, served alongside it */
 #include "cli_marshal_defs.h"  /* which methods need no request body */
+#include "cli_argspec_defs.h"  /* how words after the command become fields */
 #include "server_http.h"
 #include "server.h"         /* CAP_* / CAPS_* capability bits, server_capability_for_method */
 #include "server_conn_io.h" /* transport-aware fd I/O (native-TLS phase 1) */
@@ -1234,10 +1235,23 @@ int rh_cli_manifest(const route_req_t *rq, char *resp, int cap)
       cJSON_AddItemToObject(root, "dispatch", dispatch);
    /* The last link: a client that knows a command exists, how to address it and
     * how to reach it still refuses to send anything unless it knows what body
-    * to build. "Takes no arguments" is the part of that which is pure data. */
+    * to build. "Takes no arguments" is the part of that which is pure data;
+    * the argument specs are the part that describes how words become fields.
+    * Both are `marshal` rows — one list, distinguished by whether `args` is
+    * the string "none" or an object — so a client reads one thing rather than
+    * learning where to look for each kind. */
    cJSON *marshal = cli_marshal_defs_to_json();
    if (marshal)
+   {
+      cJSON *specs = cli_argspec_defs_to_json();
+      /* Detached one at a time rather than moved wholesale: cJSON has no
+       * splice, and re-parenting the array's children by hand is how lists get
+       * silently truncated. */
+      while (specs && cJSON_GetArraySize(specs) > 0)
+         cJSON_AddItemToArray(marshal, cJSON_DetachItemFromArray(specs, 0));
+      cJSON_Delete(specs);
       cJSON_AddItemToObject(root, "marshal", marshal);
+   }
 
    char *s = cJSON_PrintUnformatted(root);
    int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -362,6 +362,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-curator-profile \
                $(TESTPREFIX)/unit-test-kb-client-cache \
                $(TESTPREFIX)/unit-test-openai-runs-store \
+               $(TESTPREFIX)/unit-test-cli-argspec \
                $(TESTPREFIX)/unit-test-cli-http-transport \
                $(TESTPREFIX)/unit-test-http-retry \
                $(TESTPREFIX)/unit-test-cmd-doctor \
@@ -1444,7 +1445,7 @@ $(TESTPREFIX)/unit-test-server-mcp-roundtable: \
 # themselves are #included by the test, so their objects stay out.
 $(TESTPREFIX)/unit-test-cli-v1-delegate: $(OBJDIR)/tests/test_cli_v1_delegate.o \
                                   $(OBJDIR)/modules/workspace/workspace_client_diff.o \
-                                  $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o $(OBJDIR)/aimee_client.o \
+                                  $(OBJDIR)/cJSON.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/posix/util.o $(OBJDIR)/aimee_client.o \
                                   $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/platform_path.o \
                                   $(OBJDIR)/posix/cli_client.o $(OBJDIR)/cli_client.o \
                                   $(OBJDIR)/aimee_tls.o \
@@ -1460,11 +1461,11 @@ $(TESTPREFIX)/unit-test-workspace-add-noscan: $(OBJDIR)/tests/test_workspace_add
                                   $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/cli_v1_routes_e.o \
                                   $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
                                   $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
-                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
+                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o $(OBJDIR)/cli_argspec.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cli-v1-poll-deadline: $(OBJDIR)/tests/test_cli_v1_poll_deadline.o \
-                                  $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o \
+                                  $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o \
                                   $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/cli_v1_routes_e.o \
                                   $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
                                   $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
@@ -1472,7 +1473,7 @@ $(TESTPREFIX)/unit-test-cli-v1-poll-deadline: $(OBJDIR)/tests/test_cli_v1_poll_d
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cli-v1-subcommands: $(OBJDIR)/tests/test_cli_v1_subcommands.o \
-                                  $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o \
+                                  $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o \
                                   $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/cli_v1_routes_e.o \
                                   $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
                                   $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
@@ -1973,7 +1974,7 @@ $(TESTPREFIX)/unit-test-workspace-memory: $(OBJDIR)/tests/test_workspace_memory.
 
 $(TESTPREFIX)/unit-test-dashboard: $(OBJDIR)/tests/test_dashboard.o \
                           $(OBJDIR)/dashboard.o $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/dashboard_server.o $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o \
-                          $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(DB1_OBJS) $(DB1_MIGRATED_OBJS) \
+                          $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(DB1_OBJS) $(DB1_MIGRATED_OBJS) \
                           $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/decision_log.o $(OBJDIR)/db2/kb_audit_worm.o \
                           $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
                           $(OBJDIR)/yaml.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
@@ -2017,7 +2018,7 @@ $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o 
                       $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
 	                                $(OBJDIR)/server/server_config.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o \
 	                                $(OBJDIR)/tests/support/skill_jobs_stub.o \
-	                                $(OBJDIR)/server/server_hooks.o $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_bearer_auth.o $(OBJDIR)/server/server_http_management.o $(OBJDIR)/server/server_http_routes.o $(OBJDIR)/server/server_http_mgmt_read_routes.o $(OBJDIR)/server/shadow_mirror.o $(OBJDIR)/server/server_http_routes_git.o $(OBJDIR)/server/server_dev_submit.o $(OBJDIR)/server/server_ci_route.o $(OBJDIR)/server/server_http_config_routes.o $(OBJDIR)/server/cli_command_defs.o $(OBJDIR)/server/cli_dispatch_defs.o $(OBJDIR)/server/cli_marshal_defs.o $(OBJDIR)/server/server_http_conn_worker.o $(OBJDIR)/server/server_http_response.o $(OBJDIR)/server/server_http_sse.o $(OBJDIR)/tests/support/git_route_stub.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/server_http_authz.o $(OBJDIR)/modules/vault/vault_principal.o \
+	                                $(OBJDIR)/server/server_hooks.o $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_bearer_auth.o $(OBJDIR)/server/server_http_management.o $(OBJDIR)/server/server_http_routes.o $(OBJDIR)/server/server_http_mgmt_read_routes.o $(OBJDIR)/server/shadow_mirror.o $(OBJDIR)/server/server_http_routes_git.o $(OBJDIR)/server/server_dev_submit.o $(OBJDIR)/server/server_ci_route.o $(OBJDIR)/server/server_http_config_routes.o $(OBJDIR)/server/cli_command_defs.o $(OBJDIR)/server/cli_dispatch_defs.o $(OBJDIR)/server/cli_marshal_defs.o $(OBJDIR)/server/cli_argspec_defs.o $(OBJDIR)/server/server_http_conn_worker.o $(OBJDIR)/server/server_http_response.o $(OBJDIR)/server/server_http_sse.o $(OBJDIR)/tests/support/git_route_stub.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/server_http_authz.o $(OBJDIR)/modules/vault/vault_principal.o \
 	                                $(OBJDIR)/tests/support/workflow_api_stub.o \
 	                                $(OBJDIR)/tests/support/vault_handlers_stub.o \
 	                                $(OBJDIR)/modules/vault/runtime_secret.o \
@@ -2077,7 +2078,7 @@ $(TESTPREFIX)/unit-test-kb-client-search: $(OBJDIR)/tests/test_kb_client_search.
 	                                  $(OBJDIR)/modules/kb_client/kb_client_code_graph.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client_index_parse.o \
-	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
 	                                  $(PLATFORM_BASIC_OBJS) $(OBJDIR)/tests/support/log_stub.o
@@ -2089,7 +2090,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 	                                  $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/modules/kb_client/kb_client_index_parse.o \
-	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
 	                                  $(PLATFORM_BASIC_OBJS) $(OBJDIR)/tests/support/log_stub.o
@@ -4019,7 +4020,7 @@ $(TESTPREFIX)/unit-test-gateway: $(OBJDIR)/tests/test_gateway.o \
                                  $(OBJDIR)/gateway/platform_telegram.o \
                                  $(OBJDIR)/gateway/platform_ntfy.o \
                                  $(OBJDIR)/gateway/platform_webhook.o \
-                                 $(OBJDIR)/gateway/gateway_ctx.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o \
+                                 $(OBJDIR)/gateway/gateway_ctx.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o \
                                  $(OBJDIR)/gateway/gateway_pairing.o \
                                  $(OBJDIR)/aimee_home.o \
                                  $(OBJDIR)/gateway/session_key.o \
@@ -4043,7 +4044,7 @@ $(TESTPREFIX)/unit-test-gateway-telegram: $(OBJDIR)/tests/test_gateway_telegram.
                                           $(OBJDIR)/gateway/platform_registry.o \
                                           $(OBJDIR)/gateway/platform_ntfy.o \
                                           $(OBJDIR)/gateway/platform_webhook.o \
-                                          $(OBJDIR)/gateway/gateway_ctx.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o \
+                                          $(OBJDIR)/gateway/gateway_ctx.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o \
                                           $(OBJDIR)/gateway/gateway_pairing.o \
                                           $(OBJDIR)/aimee_home.o \
                                           $(OBJDIR)/gateway/delivery_router.o \
@@ -4070,7 +4071,7 @@ $(TESTPREFIX)/unit-test-gateway-ntfy-webhook: $(OBJDIR)/tests/test_gateway_ntfy_
                                               $(OBJDIR)/gateway/platform_webhook.o \
                                               $(OBJDIR)/gateway/platform_telegram.o \
                                               $(OBJDIR)/gateway/platform_registry.o \
-                                              $(OBJDIR)/gateway/gateway_ctx.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o \
+                                              $(OBJDIR)/gateway/gateway_ctx.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o \
                                               $(OBJDIR)/gateway/gateway_pairing.o \
                                               $(OBJDIR)/aimee_home.o \
                                               $(OBJDIR)/gateway/delivery_router.o \
@@ -4158,8 +4159,17 @@ $(TESTPREFIX)/unit-test-openai-runs-store: $(OBJDIR)/tests/test_openai_runs_stor
                                            $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
+# The differential proof that a served argument spec builds the same body the
+# compiled marshaller does. Links the real cli_v1_routes*.o so it compares
+# against the SHIPPING marshallers, not a copy of them.
+$(TESTPREFIX)/unit-test-cli-argspec: $(OBJDIR)/tests/test_cli_argspec.o \
+                                     $(OBJDIR)/cli_argspec.o \
+                                     $(OBJDIR)/posix/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o \
+                                     $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
 $(TESTPREFIX)/unit-test-cli-http-transport: $(OBJDIR)/tests/test_cli_http_transport.o \
-                                            $(OBJDIR)/posix/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+                                            $(OBJDIR)/posix/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                                             $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -4189,7 +4199,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(DB2_OBJS) \
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/modules/db1/secrets.o \
-                            $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
+                            $(OBJDIR)/modules/kb_client/kb_client.o $(OBJDIR)/modules/kb_client/kb_client_cache.o $(OBJDIR)/modules/kb_client/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/modules/kb_client/kb_client_memory.o $(OBJDIR)/modules/kb_client/kb_client_memory_audit.o $(OBJDIR)/modules/kb_client/kb_client_memory_mutations.o $(OBJDIR)/modules/kb_client/kb_client_agent.o $(OBJDIR)/modules/kb_client/kb_client_dashboard.o $(OBJDIR)/modules/kb_client/kb_client_tasks.o $(OBJDIR)/modules/kb_client/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                             $(OBJDIR)/modules/git/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/modules/git/forge_credentials.o $(OBJDIR)/modules/git/git_host_resolve.o $(OBJDIR)/modules/git/mcp_git_write.o $(OBJDIR)/modules/git/mcp_git_integrate.o \
                             $(OBJDIR)/modules/git/mcp_git_branch.o $(OBJDIR)/modules/git/mcp_git_pr.o $(OBJDIR)/tests/support/git_pr_api_stub.o $(OBJDIR)/modules/git/git_pr_ci_grade.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -5985,7 +5995,7 @@ $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
                       $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                            $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_bearer_auth.o $(OBJDIR)/server/server_http_keepalive.o $(OBJDIR)/server/server_http_management.o $(OBJDIR)/server/server_http_routes.o $(OBJDIR)/server/workspace_register_args.o $(OBJDIR)/server/workflow_control_bus.o \
                      $(OBJDIR)/server/server_runtime_identity.o \
-                     $(OBJDIR)/server/server_http_mgmt_read_routes.o $(OBJDIR)/server/shadow_mirror.o $(OBJDIR)/server/server_http_routes_git.o $(OBJDIR)/server/server_dev_submit.o $(OBJDIR)/server/server_ci_route.o $(OBJDIR)/server/server_http_config_routes.o $(OBJDIR)/server/cli_command_defs.o $(OBJDIR)/server/cli_dispatch_defs.o $(OBJDIR)/server/cli_marshal_defs.o $(OBJDIR)/server/server_http_conn_worker.o $(OBJDIR)/server/server_http_response.o $(OBJDIR)/server/server_http_sse.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/request_context.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/server_http_authz.o $(OBJDIR)/tests/support/git_route_stub.o $(OBJDIR)/tests/support/workflow_api_stub.o $(OBJDIR)/tests/support/router_advise_stub.o $(OBJDIR)/modules/vault/vault_principal.o $(OBJDIR)/server/presence.o \
+                     $(OBJDIR)/server/server_http_mgmt_read_routes.o $(OBJDIR)/server/shadow_mirror.o $(OBJDIR)/server/server_http_routes_git.o $(OBJDIR)/server/server_dev_submit.o $(OBJDIR)/server/server_ci_route.o $(OBJDIR)/server/server_http_config_routes.o $(OBJDIR)/server/cli_command_defs.o $(OBJDIR)/server/cli_dispatch_defs.o $(OBJDIR)/server/cli_marshal_defs.o $(OBJDIR)/server/cli_argspec_defs.o $(OBJDIR)/server/server_http_conn_worker.o $(OBJDIR)/server/server_http_response.o $(OBJDIR)/server/server_http_sse.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/request_context.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/server_http_authz.o $(OBJDIR)/tests/support/git_route_stub.o $(OBJDIR)/tests/support/workflow_api_stub.o $(OBJDIR)/tests/support/router_advise_stub.o $(OBJDIR)/modules/vault/vault_principal.o $(OBJDIR)/server/presence.o \
                            $(OBJDIR)/server/server_mgmt_status.o $(OBJDIR)/server/server_mgmt_endpoint.o $(OBJDIR)/shared/management_read.o $(OBJDIR)/server/server_mgmt_read_endpoint.o $(OBJDIR)/server/server_mgmt_read_source.o $(OBJDIR)/server/server_mgmt_audit.o $(OBJDIR)/shared/auth_token_verify.o $(OBJDIR)/kb/kb_mgmt_status.o $(OBJDIR)/kb/kb_mgmt_endpoint.o \
                            $(OBJDIR)/server/cli_session_pty.o $(OBJDIR)/server/cli_session.o $(OBJDIR)/posix/workspace_provider.o \
                            $(OBJDIR)/modules/workspace/workspace_runner_registry.o $(OBJDIR)/modules/workspace/workspace_runner_queue.o \

--- a/src/tests/test_cli_argspec.c
+++ b/src/tests/test_cli_argspec.c
@@ -1,0 +1,312 @@
+/* test_cli_argspec.c: a served argument spec must build the SAME body the
+ * compiled marshaller does.
+ *
+ * This is the only property that makes moving argument handling server-side
+ * safe. The manifest can already add a command, route it and document it; the
+ * spec lets it describe the command's arguments too. But every one of these
+ * methods works today through a hand-written marshaller, and a spec that is
+ * merely plausible would change what the CLI sends for commands people already
+ * run — silently, because both bodies are valid JSON and the server answers
+ * either.
+ *
+ * So the test is differential, not descriptive: for each specced method it runs
+ * the real marshaller and the interpreter over the same argv and compares the
+ * rendered JSON. A spec is allowed to ship only once it is indistinguishable.
+ *
+ * The samples per method are deliberately awkward — flag absent, flag present,
+ * positional instead of flag, empty string, unknown extra flag — because the
+ * cases that differ are the edges, and a spec that only agrees on the happy
+ * path is a spec that breaks the first operator who omits an argument.
+ */
+#include "cli_argspec.h"
+#include "cli_v1_routes_internal.h"
+
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_fail = 0;
+
+static void fail(const char *what, const char *detail)
+{
+   g_fail++;
+   printf("FAIL %s: %s\n", what, detail ? detail : "");
+}
+
+/* ---- the SHIPPED specs, and the samples that prove them ----------------- */
+
+/* The same rows the server serves. Included, not copied: a test with its own
+ * specs would prove specs that are not the ones shipped. */
+typedef struct
+{
+   const char *method;
+   const char *spec;
+} argspec_row_t;
+
+static const argspec_row_t SHIPPED[] = {
+#include "../server/cli_argspec_defs_data.h"
+};
+
+/* Samples are deliberately awkward — flag absent, flag present, positional
+ * instead of flag, empty string, unknown extra flag — because the cases that
+ * differ are the edges. A spec that only agrees on the happy path is a spec
+ * that breaks the first operator who omits an argument. */
+typedef struct
+{
+   const char *method;
+   const char *argv[8];
+} sample_t;
+
+static const sample_t SAMPLES[] = {
+    /* provider.list — every bool flag absent, then each present, then all.
+     * An unknown flag must not change the body: the server rejects what it
+     * does not know, and the client inventing a field for it would be worse. */
+    {"provider.list", {NULL}},
+    {"provider.list", {"--json", NULL}},
+    {"provider.list", {"--available", NULL}},
+    {"provider.list", {"--all", "--json", NULL}},
+    {"provider.list", {"--nonsense", NULL}},
+
+    /* provider.models — a positional, with and without the bool. An empty
+     * positional is not a value: both sides must drop it, or one sends
+     * "name":"" and the server filters on the empty string. */
+    {"provider.models", {NULL}},
+    {"provider.models", {"openai", NULL}},
+    {"provider.models", {"openai", "--json", NULL}},
+    {"provider.models", {"", NULL}},
+
+    /* catalog.list — a valued flag, a true_if_set and an explicit bool, which
+     * render differently (absent vs true vs false) and are the likeliest thing
+     * for a spec to get subtly wrong. */
+    {"catalog.list", {NULL}},
+    {"catalog.list", {"--json", NULL}},
+    {"catalog.list", {"--open-weights", NULL}},
+    {"catalog.list", {"--capability", "vision", NULL}},
+    {"catalog.list", {"--capability", "vision", "--json", "--open-weights", NULL}},
+
+    /* trigger.list — a single optional flag. */
+    {"trigger.list", {NULL}},
+    {"trigger.list", {"--status", "pending", NULL}},
+
+    /* trigger.status / trigger.cancel — required, reachable as a positional OR
+     * --id, and both sides must REFUSE when it is absent rather than send a
+     * body without it. */
+    {"trigger.status", {"tr-1", NULL}},
+    {"trigger.status", {"--id", "tr-1", NULL}},
+    {"trigger.status", {NULL}},
+    {"trigger.cancel", {"tr-1", NULL}},
+    {"trigger.cancel", {"--id", "tr-1", NULL}},
+    {"trigger.cancel", {NULL}},
+};
+
+static const char *spec_for(const char *method)
+{
+   for (size_t i = 0; i < sizeof(SHIPPED) / sizeof(SHIPPED[0]); i++)
+      if (strcmp(SHIPPED[i].method, method) == 0)
+         return SHIPPED[i].spec;
+   return NULL;
+}
+
+/* Every shipped spec must have samples. Otherwise a spec added tomorrow ships
+ * to every client without one line of evidence that it builds the same request
+ * the marshaller does — which is the whole property this file exists for. */
+static void test_every_shipped_spec_is_sampled(void)
+{
+   for (size_t i = 0; i < sizeof(SHIPPED) / sizeof(SHIPPED[0]); i++)
+   {
+      int found = 0;
+      for (size_t j = 0; j < sizeof(SAMPLES) / sizeof(SAMPLES[0]) && !found; j++)
+         if (strcmp(SAMPLES[j].method, SHIPPED[i].method) == 0)
+            found = 1;
+      if (!found)
+         fail("unproven spec", SHIPPED[i].method);
+   }
+}
+
+static int argv_len(const char *const *argv)
+{
+   int n = 0;
+   while (argv[n])
+      n++;
+   return n;
+}
+
+/* Compare the compiled marshaller's body with the interpreter's, rendered. */
+static void check_same(const sample_t *s)
+{
+   char *argv_buf[8];
+   int argc = argv_len(s->argv);
+   for (int i = 0; i < argc; i++)
+      argv_buf[i] = (char *)s->argv[i];
+
+   const char *spec_json = spec_for(s->method);
+   if (!spec_json)
+   {
+      /* A sample for a method the server does not serve a spec for. Not
+       * harmless: it reads as coverage while proving nothing. */
+      fail(s->method, "sampled, but no shipped spec has this method");
+      return;
+   }
+   cJSON *spec_doc = cJSON_Parse(spec_json);
+   if (!spec_doc)
+   {
+      fail(s->method, "spec is not valid JSON");
+      return;
+   }
+   if (!cli_argspec_supported(spec_doc))
+   {
+      fail(s->method, "spec uses something the interpreter does not know");
+      cJSON_Delete(spec_doc);
+      return;
+   }
+
+   cJSON *from_code = marshal_request(s->method, argc, argv_buf);
+   cJSON *from_spec = cli_argspec_build(s->method, spec_doc, argc, argv_buf);
+
+   /* Both refusing is agreement: a required argument was missing and neither
+    * would have sent anything. */
+   if (!from_code && !from_spec)
+   {
+      cJSON_Delete(spec_doc);
+      return;
+   }
+   if (!from_code || !from_spec)
+   {
+      char detail[512];
+      snprintf(detail, sizeof(detail), "one side refused (compiled=%s spec=%s) for argv[0]=%s",
+               from_code ? "built" : "NULL", from_spec ? "built" : "NULL",
+               argc > 0 ? s->argv[0] : "(none)");
+      fail(s->method, detail);
+   }
+   else
+   {
+      char *a = cJSON_PrintUnformatted(from_code);
+      char *b = cJSON_PrintUnformatted(from_spec);
+      if (!a || !b || strcmp(a, b) != 0)
+      {
+         char detail[1024];
+         snprintf(detail, sizeof(detail), "bodies differ\n    compiled: %s\n    spec:     %s",
+                  a ? a : "(null)", b ? b : "(null)");
+         fail(s->method, detail);
+      }
+      free(a);
+      free(b);
+   }
+   cJSON_Delete(from_code);
+   cJSON_Delete(from_spec);
+   cJSON_Delete(spec_doc);
+}
+
+/* ---- spec validation ---------------------------------------------------- */
+
+static void test_refuses_what_it_cannot_build(void)
+{
+   /* Each of these names something this build does not understand. Accepting
+    * any of them would mean building a body from a spec written for a client
+    * that knows more — the one way a served spec can be actively dangerous. */
+   static const char *const bad[] = {
+       "{\"fields\":[{\"json\":\"x\",\"from\":\"read_file\",\"path\":\"/etc/passwd\"}]}",
+       "{\"fields\":[{\"json\":\"x\",\"from\":\"env\",\"var\":\"HOME\"}]}",
+       "{\"fields\":[{\"json\":\"x\",\"from\":\"flag\",\"flag\":\"x\",\"type\":\"regex\"}]}",
+       "{\"fields\":[{\"json\":\"x\",\"from\":\"flag\"}]}",       /* no flag named   */
+       "{\"fields\":[{\"json\":\"x\",\"from\":\"positional\"}]}", /* no index        */
+       "{\"fields\":[{\"from\":\"flag\",\"flag\":\"x\"}]}",       /* no json name    */
+       "{\"fields\":[{\"json\":\"\",\"from\":\"flag\",\"flag\":\"x\"}]}",
+       "{\"fields\":{\"json\":\"x\"}}", /* fields not array*/
+       "{\"bool_flags\":\"json\"}",     /* bools not array */
+       "{\"fields\":[{\"json\":\"x\",\"from\":\"positional\",\"index\":-1}]}",
+       "{\"fields\":[{\"json\":\"x\",\"from\":\"positional\",\"index\":9999}]}",
+       "[]",
+       "\"none\"",
+       NULL,
+   };
+   for (int i = 0; bad[i]; i++)
+   {
+      cJSON *doc = cJSON_Parse(bad[i]);
+      if (!doc)
+      {
+         fail("spec-validation", bad[i]);
+         continue;
+      }
+      if (cli_argspec_supported(doc))
+         fail("spec-validation accepted an unbuildable spec", bad[i]);
+      /* And the build path must agree with the validator, not just the
+       * validator alone: a caller that skipped the check must still get NULL. */
+      char *argv[] = {(char *)"x"};
+      cJSON *req = cli_argspec_build("some.method", doc, 1, argv);
+      if (req)
+      {
+         fail("build accepted an unbuildable spec", bad[i]);
+         cJSON_Delete(req);
+      }
+      cJSON_Delete(doc);
+   }
+
+   /* NULL and a non-object are refused without crashing. */
+   if (cli_argspec_supported(NULL))
+      fail("spec-validation", "accepted NULL");
+   if (cli_argspec_build("m", NULL, 0, NULL))
+      fail("build", "accepted NULL spec");
+
+   /* An empty spec is legal — it is the no-argument case written out — and
+    * builds the bare method envelope. */
+   cJSON *empty = cJSON_Parse("{}");
+   cJSON *req = cli_argspec_build("some.method", empty, 0, NULL);
+   if (!req)
+      fail("build", "refused an empty spec, which is the no-argument case");
+   else
+   {
+      const cJSON *m = cJSON_GetObjectItemCaseSensitive(req, "method");
+      if (!cJSON_IsString(m) || strcmp(m->valuestring, "some.method") != 0)
+         fail("build", "empty spec did not carry the method");
+      cJSON_Delete(req);
+   }
+   cJSON_Delete(empty);
+}
+
+static void test_number_is_refused_not_coerced(void)
+{
+   /* A field the spec calls a number must be refused when it is not one. The
+    * compiled marshallers already refuse rather than round for exactly this
+    * reason (see kb.grant's team_id), and a served spec must not be the softer
+    * path into the same request. */
+   cJSON *spec = cJSON_Parse("{\"usage\":\"u\",\"fields\":[{\"json\":\"n\",\"from\":\"flag\","
+                             "\"flag\":\"n\",\"type\":\"number\",\"required\":true}]}");
+   char *bad[] = {(char *)"--n", (char *)"12x"};
+   cJSON *req = cli_argspec_build("m", spec, 2, bad);
+   if (req)
+   {
+      fail("number", "coerced '12x' instead of refusing it");
+      cJSON_Delete(req);
+   }
+   char *good[] = {(char *)"--n", (char *)"12"};
+   req = cli_argspec_build("m", spec, 2, good);
+   if (!req)
+      fail("number", "refused a valid number");
+   else
+   {
+      const cJSON *n = cJSON_GetObjectItemCaseSensitive(req, "n");
+      if (!cJSON_IsNumber(n) || n->valuedouble != 12)
+         fail("number", "did not emit 12 as a JSON number");
+      cJSON_Delete(req);
+   }
+   cJSON_Delete(spec);
+}
+
+int main(void)
+{
+   test_every_shipped_spec_is_sampled();
+   for (size_t i = 0; i < sizeof(SAMPLES) / sizeof(SAMPLES[0]); i++)
+      check_same(&SAMPLES[i]);
+   test_refuses_what_it_cannot_build();
+   test_number_is_refused_not_coerced();
+
+   if (g_fail == 0)
+      printf("PASS test_cli_argspec (%zu shipped specs, %zu differential samples)\n",
+             sizeof(SHIPPED) / sizeof(SHIPPED[0]), sizeof(SAMPLES) / sizeof(SAMPLES[0]));
+   else
+      printf("FAIL test_cli_argspec: %d check(s) failed\n", g_fail);
+   return g_fail == 0 ? 0 : 1;
+}

--- a/src/tests/test_cli_argspec.c
+++ b/src/tests/test_cli_argspec.c
@@ -99,6 +99,19 @@ static const sample_t SAMPLES[] = {
     {"trigger.cancel", {"tr-1", NULL}},
     {"trigger.cancel", {"--id", "tr-1", NULL}},
     {"trigger.cancel", {NULL}},
+
+    /* model.episodes — optional, positional OR --agent. */
+    {"model.episodes", {NULL}},
+    {"model.episodes", {"claude", NULL}},
+    {"model.episodes", {"--agent", "claude", NULL}},
+    {"model.episodes", {"", NULL}},
+
+    /* graph.sync_code — a plain optional positional, which does NOT fall back
+     * to a flag; sampling --project proves it stays absent rather than quietly
+     * acquiring the fallback that positional_or_flag has. */
+    {"graph.sync_code", {NULL}},
+    {"graph.sync_code", {"aimee", NULL}},
+    {"graph.sync_code", {"--project", "aimee", NULL}},
 };
 
 static const char *spec_for(const char *method)

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -701,11 +701,16 @@ git init --object-format=sha256 -b feature.locked "$MIRROR_CLIENT" >/dev/null
 # the snapshot, the reconstruction and the MCP Git path (SHA-1 is covered by
 # unit tests). It therefore needs a git that honours --object-format=sha256.
 #
-# A runner whose git quietly gives SHA-1 instead produced five failures in a
-# row, none of which named the cause: the snapshot carried a 40-hex head with no
-# branch or upstream, and every assertion after it disagreed about something
-# else. An absent capability is a skip, exactly like aimee-kb above -- not five
-# assertions failing about a mirror that was never the problem.
+# This probe is a PRECONDITION guard, not the fix for anything observed. I added
+# it believing CI's git had produced SHA-1: the snapshot there carried a 40-hex
+# head with no branch or upstream, and five assertions failed about it. That was
+# wrong. The probe has never fired in CI, and the section passes there -- the
+# 40-hex head came from reading a DIFFERENT workspace's snapshot, which the
+# selection below used to make arbitrarily.
+#
+# It stays because the precondition is real: this section drives SHA-256 ids
+# deliberately, and a runner that cannot provide one should say so once rather
+# than fail five assertions about a mirror that was never the problem.
 MIRROR_OBJFMT=$(git -C "$MIRROR_CLIENT" rev-parse --show-object-format 2>/dev/null) || true
 if [ "$MIRROR_OBJFMT" = "sha256" ]; then
     MIRROR_SHA256=1
@@ -768,6 +773,16 @@ check_output "identical mirror-sync continuation persisted" '"seq":1' echo "$RES
 RESP=$(http_rpc "${MIRROR_REQS[5]}") || true
 check_output "identical mirror-sync reuses generation" '"generation":1' echo "$RESP"
 
+# Select the snapshot by IDENTITY, not by whatever the filesystem yields first.
+#
+# This was `find ... -name client.snapshot -print -quit`, which returns an
+# arbitrary match -- and in CI it returned the wrong one: a snapshot with a
+# 40-hex head and no branch or upstream, which failed five assertions in a row
+# about a mirror that was fine. Locally there is one snapshot, so it was always
+# right here, and the bug stayed invisible until this harness first ran in CI.
+#
+# The assertions below are about THIS mirror, so match the head this fixture
+# just pushed.
 SNAPSHOT=$(grep -rl "$MIRROR_HEAD" "$AIMEE_HOME/workspaces" --include=client.snapshot 2>/dev/null | head -1) || true
 if [ -z "$SNAPSHOT" ]; then
     # Nothing published for THIS head. Show what was published instead, so the

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -298,7 +298,9 @@ cleanup() {
         kill "$SERVER_PID" 2>/dev/null
         wait "$SERVER_PID" 2>/dev/null || true
     fi
-    rm -rf "$HOME"
+    # Same rule as the TCP teardown: removing a temp dir must never change the
+    # verdict. This one already waits for its server, which is why it never bit.
+    rm -rf "$HOME" || true
 }
 trap cleanup EXIT
 
@@ -434,8 +436,21 @@ else
     echo "  tcp: $TCP_BODY"
     FAIL=$((FAIL + 1))
 fi
+# Kill the TCP server and WAIT for it, before removing the home it is writing
+# to. Without the wait, `rm -rf` raced a live server recreating files as the
+# walk deleted them, and failed with
+
+#     rm: cannot remove '/tmp/aimee-tcp-XXXXXX': Directory not empty
+
+# which under `set -e` took the entire run with it -- every check after this
+# point, on every CI run of this harness. That line was in the log from the
+# first failing run and read as noise; it was the cause.
 kill "$TCP_SRV_PID" 2>/dev/null || true
-rm -rf "$TCP_HOME"
+wait "$TCP_SRV_PID" 2>/dev/null || true
+# `|| true` regardless: teardown of a temporary directory must never decide
+# whether the suite continues. Even with the wait, anything else holding a file
+# open here would abort a run that has nothing left to do but report.
+rm -rf "$TCP_HOME" || true
 
 # Rebuild only the thin client with a new build ID. The existing server should
 # remain usable because compatibility is gated by major version, not build ID.

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -236,6 +236,41 @@ except subprocess.TimeoutExpired:
 PY
 }
 
+# Start aimee-server and WAIT for it to bind, rather than guessing.
+#
+# This was `... >/dev/null 2>&1 & sleep 1`, three times. Both halves were wrong,
+# and test_init_migrate_service.sh had already found and fixed exactly this:
+# "On a loaded CI runner startup regularly takes several seconds, and the 1s
+# guess made this the run's flakiest test." It was left unfixed here, and the
+# first CI run of this harness failed 14 checks off one early probe -- the
+# server had not finished binding, so "server started" failed and every request
+# after it cascaded.
+#
+# The discarded output was the other half. A server that fails to start says why
+# on stderr; sending that to /dev/null left CI reporting "FAIL: server started"
+# and nothing else, which is unactionable. Keep the log and print its tail when
+# the socket never appears.
+#
+# A unix-socket server binds and listens as its last init step, so
+# socket-present means ready to serve. Polling also returns as soon as it is up,
+# which is faster than the sleep it replaces on a machine that is not loaded.
+start_server() {
+    local log="$HOME/aimee-server.$$.log"
+    "$AIMEE_SERVER" --foreground >"$log" 2>&1 &
+    SERVER_PID=$!
+    local i
+    for i in $(seq 1 300); do
+        [ -S "$HTTP_SOCK" ] && return 0
+        # A dead process will never bind; fail fast rather than waiting out the
+        # full window for a server that has already exited.
+        kill -0 "$SERVER_PID" 2>/dev/null || break
+        sleep 0.1
+    done
+    echo "server did not bind $HTTP_SOCK within 30s; its own output was:"
+    sed 's/^/    /' "$log" 2>/dev/null | tail -20
+    return 1
+}
+
 # Set once the summary has printed. Until then an exit is an ABORT, not a
 # result: `set -e` means any unguarded command that fails takes the whole run
 # with it, skipping every remaining check AND the summary. In CI that looked
@@ -283,11 +318,13 @@ check_output "no server: a command fails, naming the unreachable server" \
 # 2. Server lifecycle
 # ============================================================
 
-$AIMEE_SERVER --foreground >/dev/null 2>&1 &
-SERVER_PID=$!
-sleep 1
-
-check "server started" test -S "$HTTP_SOCK"
+# NOT `check "server started" start_server`: check() runs its command with
+# >/dev/null 2>&1, which would swallow the very diagnosis start_server exists to
+# print. Run it first, then assert on the result. (Found by planting a server
+# that refuses to start: the 14 cascading failures reproduced perfectly and the
+# reason was still invisible.)
+start_server && SERVER_STARTED=1 || SERVER_STARTED=0
+check "server started" test "$SERVER_STARTED" = 1
 
 RESP=$(srv_req '{"method":"server.info"}') || true
 check_output "server.info status" '"status":"ok"' echo "$RESP"
@@ -347,9 +384,17 @@ TCP_BEARER="integ-tcp-bearer"
 printf 'aimee:\n  api:\n    http_port: %s\n    bearer_token: %s\n' \
     "$TCP_PORT" "$TCP_BEARER" >"$TCP_HOME/.config/aimee/aimee.yaml"
 env -u AIMEE_PROFILE HOME="$TCP_HOME" AIMEE_HOME="$TCP_HOME/.config/aimee" \
-    "$AIMEE_SERVER" --foreground >/dev/null 2>&1 &
+    "$AIMEE_SERVER" --foreground >"$TCP_HOME/server.log" 2>&1 &
 TCP_SRV_PID=$!
-sleep 2
+# Wait for the bind rather than guessing at it, for the same reason as
+# start_server above: on a loaded runner two seconds is not reliably enough, and
+# a probe that fires early fails the assertions of a server that was about to
+# work. This one has its own HOME so it cannot share start_server.
+for _ in $(seq 1 300); do
+    [ -S "$TCP_HOME/.config/aimee/aimee-http.sock" ] && break
+    kill -0 "$TCP_SRV_PID" 2>/dev/null || break
+    sleep 0.1
+done
 UDS_BODY=$(HTTP_SOCK="$TCP_HOME/.config/aimee/aimee-http.sock" http_rpc '{"method":"provider.list"}') || true
 TCP_BODY=$(python3 -c "
 import socket, sys
@@ -401,9 +446,7 @@ check "server survives same-major build drift" kill -0 "$SERVER_PID_BEFORE"
 # recover a known foreground server so the rest of the test stays meaningful.
 if ! kill -0 "$SERVER_PID_BEFORE" 2>/dev/null; then
     pkill -f "aimee-server.*$SOCKET" 2>/dev/null || true
-    $AIMEE_SERVER --foreground >/dev/null 2>&1 &
-    SERVER_PID=$!
-    sleep 1
+    start_server || true
 fi
 
 check_output "local version long flag" "aimee" $AIMEE --version
@@ -586,9 +629,7 @@ if [ "$HOOK_RC" -ne 0 ] && echo "$RESP" | grep -q "server build mismatch"; then
         cd "$REPO_ROOT/src"
         make ../aimee-server >/dev/null 2>&1
     )
-    $AIMEE_SERVER --foreground >/dev/null 2>&1 &
-    SERVER_PID=$!
-    sleep 1
+    start_server || true
     set +e
     RESP=$(echo "$HOOK_PAYLOAD" | CLAUDE_SESSION_ID=integ-test $AIMEE hooks pre 2>&1)
     HOOK_RC=$?

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -682,6 +682,25 @@ mkdir -p "$MIRROR_CASE"
 # snapshot, reconstruction, and MCP tool path (SHA-1 is covered by unit tests).
 git init --bare --object-format=sha256 "$MIRROR_REMOTE" >/dev/null
 git init --object-format=sha256 -b feature.locked "$MIRROR_CLIENT" >/dev/null
+# This whole section deliberately drives SHA-256 object ids through the wire,
+# the snapshot, the reconstruction and the MCP Git path (SHA-1 is covered by
+# unit tests). It therefore needs a git that honours --object-format=sha256.
+#
+# A runner whose git quietly gives SHA-1 instead produced five failures in a
+# row, none of which named the cause: the snapshot carried a 40-hex head with no
+# branch or upstream, and every assertion after it disagreed about something
+# else. An absent capability is a skip, exactly like aimee-kb above -- not five
+# assertions failing about a mirror that was never the problem.
+MIRROR_OBJFMT=$(git -C "$MIRROR_CLIENT" rev-parse --show-object-format 2>/dev/null) || true
+if [ "$MIRROR_OBJFMT" = "sha256" ]; then
+    MIRROR_SHA256=1
+else
+    MIRROR_SHA256=0
+    echo "SKIP: mirror-sync end to end (git created a '$MIRROR_OBJFMT' repository despite --object-format=sha256)"
+    SKIP=$((SKIP + 22))
+fi
+
+if [ "$MIRROR_SHA256" -eq 1 ]; then
 git -C "$MIRROR_CLIENT" config user.name "Aimee Integration"
 git -C "$MIRROR_CLIENT" config user.email "aimee-integration@example.invalid"
 printf 'base\n' >"$MIRROR_CLIENT/file.txt"
@@ -734,7 +753,17 @@ check_output "identical mirror-sync continuation persisted" '"seq":1' echo "$RES
 RESP=$(http_rpc "${MIRROR_REQS[5]}") || true
 check_output "identical mirror-sync reuses generation" '"generation":1' echo "$RESP"
 
-SNAPSHOT=$(find "$AIMEE_HOME/workspaces" -name client.snapshot -type f -print -quit) || true
+SNAPSHOT=$(grep -rl "$MIRROR_HEAD" "$AIMEE_HOME/workspaces" --include=client.snapshot 2>/dev/null | head -1) || true
+if [ -z "$SNAPSHOT" ]; then
+    # Nothing published for THIS head. Show what was published instead, so the
+    # failure names the mismatch rather than leaving an empty path to explain
+    # the next five assertions.
+    echo "FAIL: no client.snapshot carries the fixture head $MIRROR_HEAD"
+    echo "  published snapshots:"
+    find "$AIMEE_HOME/workspaces" -name client.snapshot -type f -exec sh -c \
+        'echo "    $1: $(cat "$1")"' _ {} \; 2>/dev/null
+    FAIL=$((FAIL + 1))
+fi
 check "mirror snapshot metadata published" test -s "$SNAPSHOT"
 check_output "mirror snapshot records valid .locked ref" \
     'feature.locked origin/feature.locked 2' cat "$SNAPSHOT"
@@ -782,6 +811,8 @@ MIRROR_CLEAN_WORK=$(find "$(dirname "$SNAPSHOT")" -maxdepth 1 -type d -name 'wor
 check "clean snapshot worktree materialized on first call" test -n "$MIRROR_CLEAN_WORK"
 check "clean snapshot worktree remains clean" test -z \
     "$(git -C "$MIRROR_CLEAN_WORK" status --porcelain)"
+
+fi  # MIRROR_SHA256
 
 # ============================================================
 # 10. Server shutdown

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -277,6 +277,11 @@ start_server() {
 # like a job which built for four minutes, ran the harness, and printed nothing
 # at all — no FAIL line, no count, nothing to read. Say so instead.
 REACHED_SUMMARY=0
+ABORT_LINE=""
+ABORT_CMD=""
+# Record WHERE, not just that. "ABORTED after 21 checks" is a number to go
+# hunting with; bash already knows the line and the command, so ask it.
+trap 'ABORT_LINE=$LINENO; ABORT_CMD=$BASH_COMMAND' ERR
 
 cleanup() {
     local rc=$?
@@ -285,6 +290,9 @@ cleanup() {
         echo "integration: ABORTED after $((PASS + FAIL)) checks (exit $rc)."
         echo "  The harness exited before its summary — under 'set -e' an unguarded"
         echo "  command failed, so the checks below this point never ran."
+        if [ -n "$ABORT_LINE" ]; then
+            echo "  It failed at line $ABORT_LINE: $ABORT_CMD"
+        fi
     fi
     if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
         kill "$SERVER_PID" 2>/dev/null
@@ -359,7 +367,7 @@ check_output "server.health uptime" '"uptime"' echo "$RESP"
 # well-formed dispatch response over its first-class /v1 route.
 if [ -S "$HTTP_SOCK" ]; then
     PASS=$((PASS + 1)) # /v1 HTTP socket bound
-    HTTP_PROV=$(http_rpc '{"method":"provider.list"}')
+    HTTP_PROV=$(http_rpc '{"method":"provider.list"}') || true
     if [ -n "$HTTP_PROV" ] && python3 -c "import json,sys; json.loads(sys.argv[1])" "$HTTP_PROV" \
         2>/dev/null; then
         PASS=$((PASS + 1)) # provider.list over /v1/provider/list returned valid JSON
@@ -492,7 +500,7 @@ RESP=$(srv_req '{"method":"memory.list","limit":1}') || true
 if echo "$RESP" | grep -qF '"status":"ok"'; then
     KB_AVAILABLE=1
     PASS=$((PASS + 1))
-    RESP=$(srv_req '{"method":"rules.list"}')
+    RESP=$(srv_req '{"method":"rules.list"}') || true
     check_output "local /v1: rules.list ok" '"status":"ok"' echo "$RESP"
 else
     KB_AVAILABLE=0
@@ -582,14 +590,14 @@ fi  # DB1_SESSIONS_AVAILABLE
 # ============================================================
 
 if [ "$KB_AVAILABLE" -eq 1 ]; then
-    RESP=$(srv_auth_req '{"method":"memory.store","key":"integ-test","content":"integration test value","tier":"L0","kind":"fact"}')
+    RESP=$(srv_auth_req '{"method":"memory.store","key":"integ-test","content":"integration test value","tier":"L0","kind":"fact"}') || true
     check_output "memory.store" '"status":"ok"' echo "$RESP"
-    MEM_ID=$(echo "$RESP" | python3 -c "import sys,json; print(int(json.load(sys.stdin)['id']))" 2>/dev/null)
+    MEM_ID=$(echo "$RESP" | python3 -c "import sys,json; print(int(json.load(sys.stdin)['id']))" 2>/dev/null) || true
 
-    RESP=$(srv_auth_req '{"method":"memory.list","tier":"L0","limit":10}')
+    RESP=$(srv_auth_req '{"method":"memory.list","tier":"L0","limit":10}') || true
     check_output "memory.list has stored entry" "integ-test" echo "$RESP"
 
-    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID}")
+    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID}") || true
     check_output "memory.get by ID" "integration test value" echo "$RESP"
 
     # `memory get --as-of` crosses client -> aimee-server -> aimee-kb, and it was
@@ -599,11 +607,11 @@ if [ "$KB_AVAILABLE" -eq 1 ]; then
     # it passed, because each end was checked against a hand-written payload that
     # already contained the field. Only the real wire shows the gap, so assert it
     # here: the verdict must come back, and must NOT appear when nobody asked.
-    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID,\"as_of\":\"2020-01-01 00:00:00\"}")
+    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID,\"as_of\":\"2020-01-01 00:00:00\"}") || true
     check_output "memory.get --as-of echoes the timestamp" '"as_of"' echo "$RESP"
     check_output "memory.get --as-of returns an event-time verdict" '"valid_at"' echo "$RESP"
 
-    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID}")
+    RESP=$(srv_auth_req "{\"method\":\"memory.get\",\"id\":$MEM_ID}") || true
     if echo "$RESP" | grep -q '"valid_at"'; then
         check_output "memory.get without --as-of emits no verdict" "no valid_at" echo "found valid_at"
     else
@@ -631,7 +639,7 @@ if [ "$HOOK_RC" -ne 0 ] && echo "$RESP" | grep -q "server build mismatch"; then
     )
     start_server || true
     set +e
-    RESP=$(echo "$HOOK_PAYLOAD" | CLAUDE_SESSION_ID=integ-test $AIMEE hooks pre 2>&1)
+    RESP=$(echo "$HOOK_PAYLOAD" | CLAUDE_SESSION_ID=integ-test $AIMEE hooks pre 2>&1) || true
     HOOK_RC=$?
     set -e
 fi


### PR DESCRIPTION
Stacks on #2794.

The manifest could already say a command exists, how it routes, what it's called, and which methods take no body. It could **not** say how the words after the command become fields — so a new command that took arguments still needed a new client. This is that last piece.

```
$ aimee widget tune w-42 --torque 7 --dry-run
```

`widget`, `tune`, `--torque` and `--dry-run` appear **nowhere** in the client binary. It POSTs `/v1/widget/tune` with exactly

```json
{"method":"widget.tune","protocol_version":1,
 "widget_id":"w-42","torque":7,"dry_run":true}
```

and exits 0, from a served spec alone. With no id it prints the **spec's** usage line and sends nothing — a served command has to misuse as loudly as a compiled one, or an operator can't tell a typo from an outage. `scripts/test-served-argspec-e2e.py`, wired into `integration-tests`.

## The spec

A bool-flag list for the parser, then ordered fields, each naming where its value comes from and what JSON it becomes:

```json
{"json":"open_weights_only","from":"flag","flag":"open-weights","type":"bool"}
{"json":"name","from":"positional","index":0}
{"json":"id","from":"positional_or_flag","index":0,"flag":"id","required":true}
```

Four sources, four types. The vocabulary was read off the marshallers that exist rather than designed for ones that might, which is why it's this small.

**What it deliberately cannot express:** reading the client's filesystem or environment, composing prompts, or cross-field rules like *"either `--task` or `--proposal`"*. The first two are the thin client's own job and must not move server-side at all. The third is a judgement about what the user meant, and a spec language that grew conditionals would become a program transmitted over the wire. Those methods keep their compiled marshaller.

An unrecognised anything — source, type, field shape — refuses the **whole** spec and falls back to the compiled path. A partially honoured spec builds a request that is wrong rather than incomplete, and the server would answer it as though the operator had asked for that. Sixteen such specs are pinned as refused, including `"from":"read_file"` and `"from":"env"`, which are the ones that would matter.

## Why this is safe

A served spec **wins** over the compiled marshaller. That's the point, and it's also the risk: every one of these methods works today, and a merely plausible spec would change what the CLI sends for commands people already run — silently, because both bodies are valid JSON and the server answers either.

So the test is **differential, not descriptive**. For each shipped spec it runs the *real* marshaller and the interpreter over the same argv and compares rendered JSON; a spec ships only once it's indistinguishable. Samples are deliberately awkward — flag absent, flag present, positional instead of flag, empty string, unknown extra flag — because the cases that differ are the edges.

Two integrity properties, both plant-tested:

- The test **includes the same data file the server serves from**. A test with its own copy would prove specs that are not the ones shipped. Renaming one output field (`available_only` → `available`) fails it.
- **Every shipped spec must have samples**, or the test fails naming it. A spec added tomorrow cannot ship with no evidence behind it.

Six methods converted (`provider.list`, `provider.models`, `catalog.list`, `trigger.list`/`status`/`cancel`) — enough to exercise every source and type. The rest follow one differential sample at a time; the mechanism, not the tranche, is what this PR is for.

## And a guard — which I got wrong twice

Every object the served-manifest work added broke the test link lists identically:

```
undefined reference to `cli_dispatch_defs_to_json'
undefined reference to `cli_marshal_defs_to_json'
undefined reference to `cli_argspec_defs_to_json'
undefined reference to `cli_argspec_build'
```

Four times, always found minutes after a push, because `tests/Rules.mk` keeps its prerequisites by hand and nothing relates them to what the code calls. This one needed edits to **twelve** targets.

`check-manifest-emitter-linkage` derives it: read the functions each small provider object exports, find which sources call them, require every target depending on a caller to link the provider.

It took three attempts, and both failures are the same lesson:

1. **v1** understood only the manifest route's emitters. Passed → next run failed on `cli_argspec_build` one file over.
2. **v2** generalised to caller→provider edges. Passed → next run failed on the *same symbol again*: two tests `#include` `cli_v1_routes_b.c` to reach a static marshaller, so they never link its object, and a check looking only for the object couldn't see them.

Both times it said ok while the build broke — the definition of decoration. It now treats "`#include`s the caller's source" as a dependency too, and the plant test exercises that path specifically rather than only the linking one, because a plant that only proves the case you already thought of is the same mistake a third time.

## Verification

`make all` · `make lint` **61/61** · `make unit-tests` · `integration-tests` **62/62** · the differential suite · the end-to-end proof.

(`unit-test-vault-bootstrap` fails locally only under an environment carrying `CLAUDE_CODE_MESSAGING_TOKEN` — passes with it unset, pre-existing, green in CI.)
