### PR TITLE
fix(ci): address the mirror workspace's own snapshot, not the first one found

### DIFF
--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -685,7 +685,21 @@ check_output "identical mirror-sync continuation persisted" '"seq":1' echo "$RES
 RESP=$(http_rpc "${MIRROR_REQS[5]}") || true
 check_output "identical mirror-sync reuses generation" '"generation":1' echo "$RESP"
 
-SNAPSHOT=$(find "$AIMEE_HOME/workspaces" -name client.snapshot -type f -print -quit) || true
+# Address the mirror workspace by its own snapshot, not by whichever one find
+# happens to walk into first. Every check below derives from $SNAPSHOT -- its
+# directory, its generation, its work-N-* checkouts -- so picking a different
+# workspace's file does not fail here, it fails five checks later with content
+# that looks like a mirror bug. The server keys the directory on
+# fnv1a_hex8(root) (workspace_mirror.c), so the harness can name it exactly.
+MIRROR_HASH=$(python3 - "$MIRROR_CLIENT" <<'HASH'
+import sys
+h = 2166136261
+for byte in sys.argv[1].encode():
+    h = ((h ^ byte) * 16777619) & 0xFFFFFFFF
+print("%08x" % h)
+HASH
+)
+SNAPSHOT="$AIMEE_HOME/workspaces/$MIRROR_HASH/client.snapshot"
 check "mirror snapshot metadata published" test -s "$SNAPSHOT"
 check_output "mirror snapshot records valid .locked ref" \
     'feature.locked origin/feature.locked 2' cat "$SNAPSHOT"


### PR DESCRIPTION
## Symptom

`integration-tests` fails intermittently in CI on unrelated PRs:

```
FAIL: mirror snapshot records valid .locked ref
      (expected 'feature.locked origin/feature.locked 2',
           got '1 <tree> <head> - - 2')
FAIL: reconstructed worktree keeps branch (expected 'feature.locked', got '')
FAIL: reconstructed worktree keeps dirty patch (expected 'file.txt', got '')
FAIL: identical refresh advances publication order (expected ' 2', got ' 4')
FAIL: clean snapshot worktree materialized on first call
```

## Diagnosis

The harness located the mirror snapshot with

```sh
find "$AIMEE_HOME/workspaces" -name client.snapshot -type f -print -quit
```

`-print -quit` returns whichever workspace the directory walk reaches first. When more than one workspace has published a snapshot, that is not necessarily the mirror workspace -- and the harness has no way to notice. Every later check derives from `$SNAPSHOT`: its directory, its generation, its `work-N-*` checkouts. So picking the wrong file does not fail at the lookup; it fails five checks downstream with content that reads like a mirror bug.

**The `- -` is the tell.** Those are an unset branch and upstream. But the check immediately above, `mirror-sync final published`, passed -- and the request it verifies always carries `branch` and `upstream`. A snapshot missing both therefore cannot be the one this test just published. The harness was reading a different workspace's file.

That also explains `expected ' 2', got ' 4'`: a publication counter belonging to some other workspace.

## Fix

The server keys the snapshot directory on `fnv1a_hex8(root)` (`workspace_mirror.c`), so the harness can name the path exactly instead of searching for it.

This is self-checking: a wrong path now fails on the very next check, `mirror snapshot metadata published`, rather than five checks later disguised as a product defect.

## Verification

`integration: 62/62 passed` locally, both before and after -- the search happened to pick correctly on this machine, which is exactly why this only bites in CI.
