### PR TITLE
fix(ci): reap the TCP server before removing its scratch home

### DIFF
--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -255,7 +255,10 @@ cleanup() {
         kill "$SERVER_PID" 2>/dev/null
         wait "$SERVER_PID" 2>/dev/null || true
     fi
-    rm -rf "$HOME"
+    # Same reasoning as the TCP scratch home: cleanup must not be what
+    # fails the run. This one already reaps the server above, so the
+    # guard only covers other writers still holding the tree.
+    rm -rf "$HOME" || true
 }
 trap cleanup EXIT
 
@@ -381,8 +384,16 @@ else
     echo "  tcp: $TCP_BODY"
     FAIL=$((FAIL + 1))
 fi
+# kill is asynchronous: it returns before the server has exited, while the
+# process is still writing its WAL, socket and logs. Removing the tree then
+# races it -- the walk empties a directory, the still-live server recreates
+# a file in it, and the final rmdir fails with ENOTEMPTY. Under 'set -e'
+# that aborts the whole harness ~40 checks early with no failing check to
+# point at, which reads as a product bug rather than as cleanup. Reap the
+# process first, and never let removing a scratch dir decide the verdict.
 kill "$TCP_SRV_PID" 2>/dev/null || true
-rm -rf "$TCP_HOME"
+wait "$TCP_SRV_PID" 2>/dev/null || true
+rm -rf "$TCP_HOME" || true
 
 # Rebuild only the thin client with a new build ID. The existing server should
 # remain usable because compatibility is gated by major version, not build ID.


### PR DESCRIPTION
## Symptom

`integration-tests` aborts intermittently in CI with **no failing check to point at**:

```
rm: cannot remove '/tmp/aimee-tcp-0ZtVKV': Directory not empty

integration: ABORTED after 21 checks (exit 1).
  The harness exited before its summary - under 'set -e' an unguarded
  command failed, so the checks below this point never ran.
```

Seen on `testing` itself and on unrelated PRs branched from it.

## Diagnosis

`kill` is asynchronous. It returns before the server has exited, while that process is still writing its WAL, socket and logs. Removing the tree then races it: the walk empties a directory, the still-live server recreates a file inside it, and the final rmdir fails with ENOTEMPTY.

Under `set -e` the harness dies right there - roughly 40 checks early. And because cleanup is not a check, `FAIL` is never incremented, so the run reports no failing assertion at all. It reads as a product bug rather than as cleanup.

The other two shutdown sites in this file already reap before removing:

```sh
kill "$SERVER_PID" 2>/dev/null
wait "$SERVER_PID" 2>/dev/null || true
```

Only the TCP scratch server skipped the `wait`.

## Fix

- Reap the TCP server before removing its home, matching the two sites that already do.
- Let neither removal decide the verdict. A scratch directory that another writer (kb, delegate) still holds must not fail a run whose checks all passed - losing a temp directory is not worth a red build.

## Verification

`integration: 62/62 passed` locally. The race is timing-dependent, so a local pass is not proof on its own - the argument is the asymmetry with the two sites that already reap, plus the ENOTEMPTY signature naming a live writer.

## Related

Second of two independent flakes in this harness. The first was #2804, where a nondeterministic snapshot lookup produced five failures that looked like mirror bugs.
