### PR TITLE
ci: descriptor-envelope outgrew its own five-minute clock

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -238,7 +238,21 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Raised from 5. This job spends almost all of its time in two
+    # subprocess-heavy suites -- test_validate_module_descriptors (46 tests,
+    # each re-running the validator over the tree; 52s locally) and
+    # test_gen_db1_contract (65s locally) -- which together are ~2 minutes on a
+    # developer machine and roughly double that on a runner.
+    #
+    # It last passed at 4m47s against a 5m cap: thirteen seconds of headroom.
+    # The next runs were killed at 5m15s and 5m16s, on `testing` as well as on
+    # PR branches, so the gate was failing repo-wide on nothing but its own
+    # clock. Its siblings here are at 187s, 68s and 25s against the same cap, so
+    # 5 minutes is not wrong in general -- only for this job.
+    #
+    # 12 puts today's 316s at ~44%, which is the ratio proposal-ordering already
+    # runs at (963s of 30m). Still bounded, so a real hang is still caught.
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
`descriptor-envelope` isn't failing a test — it's being **cancelled at its own `timeout-minutes: 5`**, and it takes the whole `Module inventory` run's verdict with it.

It's a coin flip, on `testing` as much as on PR branches:

| time | branch | result | duration |
|---|---|---|---|
| 13:33 | testing | success | 4m47s |
| 14:48 | testing | **cancelled** | 5m15s |
| 15:05 | PR #2798 | **cancelled** | 5m16s |
| 15:11 | testing | success | **4m56s** ← four seconds of headroom |

A gate that passes with four seconds to spare fails about half the time. I confirmed it's a per-job cut-off rather than a superseded run: its four siblings in the same run all succeeded, one of them finishing *six minutes after* the cancellation.

## Measured, not guessed

Timing every step of the job locally:

```
 82s  test_validate_module_descriptors   (46 tests, each re-running the validator over the tree)
 65s  test_gen_db1_contract
  5s  everything else combined
```

Two subprocess-heavy suites are the entire job — ~2.5 min here, roughly double on a runner. Slow, but **legitimately** so: 46 tests at ~1.1s each is a process spawn per test, not a pathology to fix in passing.

And only this job:

| job | duration | cap |
|---|---|---|
| module-inventory | 187s | 300s |
| git-core-contract | 68s | 300s |
| module-doc-contract | 25s | 300s |
| **descriptor-envelope** | **316s (killed)** | **300s** |
| proposal-ordering | 963s | 1800s |

So five minutes isn't wrong in general — only for this job.

## The change

`timeout-minutes: 5 → 12`, which puts today's 316s at ~44% — the ratio `proposal-ordering` already runs at (963s of 30m). Still bounded, so a genuine hang is still caught rather than burning a runner. The measurement is in the comment so nobody has to retake it.

Landed on its own because it isn't about any feature branch: it was written during #2798 and pushed minutes after that PR merged, so it never reached `testing` with it.
