### PR TITLE
fix(ci): give the harness one MCP session instead of one per request

### DIFF
--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -24,6 +24,18 @@ export PATH="$REPO_ROOT:$PATH"
 export HOME=$(mktemp -d /tmp/aimee-integ-XXXXXX)
 export AIMEE_HOME="$HOME/.config/aimee"
 unset AIMEE_PROFILE
+# One session id for the whole run. Every `aimee mcp-serve` this harness spawns
+# derives its session from AIMEE_SESSION_ID, falling back to its PPID -- and the
+# helpers spawn each request from a separate python process, so without this
+# every single MCP request minted a NEW session and materialized its own
+# `git worktree add` of this entire repository. Eight full checkouts per run,
+# where a real host has one session and one worktree.
+#
+# That is not just waste. The git tool call is the first request that has to
+# reach aimee-server, and on a slow CI disk its checkout ran past the 30s
+# mcp-serve request timeout, failing as "aimee-server unavailable after
+# retries" while the checks either side of it reached that same server fine.
+export AIMEE_SESSION_ID="integ$$"
 mkdir -p "$AIMEE_HOME"
 SOCKET="$AIMEE_HOME/aimee.sock"
 export AIMEE_SOCK="$SOCKET"


### PR DESCRIPTION
## Symptom

The git tool check fails in CI, deterministically on some runners, while the MCP checks either side of it reach that same server happily:

```
FAIL: mcp git_status tool call (expected '"content"',
      got 'aimee-server unavailable after retries. Restart aimee-server and retry.')
```

## Diagnosis

With mcp-serve's stderr now kept (#2799's diagnostics), the timing says what happened:

| spawn | request | elapsed |
|---|---|---|
| 1-4 | initialize, prompts/get, resources/templates/list, resources/read | **~1.1s each** |
| 5 | `tools/call git_status` | **32.2s** -> 30s timeout |

Every `aimee mcp-serve` derives its session from `AIMEE_SESSION_ID`, falling back to its PPID. Both MCP helpers in this harness spawn each request from a **separate python process**, so every request minted a new session id and materialized its own `git worktree add` of this entire repository -- eight full checkouts per run, where a real host has one session and one worktree.

That is not only waste. `git_status` is the first request that has to reach aimee-server, and on a slow CI disk its checkout ran past the 30s mcp-serve request timeout. The server was never unavailable: the client gave up while the checkout was still going. That is why the neighbouring checks pass -- they are served without needing the server at all.

## Fix

Export one session id for the whole run. Every spawn then shares a single session worktree.

This is also the more honest fixture: one host session is exactly what an MCP client presents.

## Verification

Locally, counting distinct session worktrees materialized during a run:

- before: **8**
- after: **1**

`integration: 62/62 passed` both ways -- the failure needs a disk slow enough to cross 30s, which is why it shows in CI and not on a dev box.

## Note

Deliberately not a timeout bump. Raising the 30s would have hidden eight redundant checkouts of the repo per test run rather than removing them.
