### PR TITLE
fix(ci): show what the server was doing when a check fails

### DIFF
--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -54,8 +54,40 @@ check() {
         PASS=$((PASS + 1))
     else
         echo "FAIL: $desc"
+        dump_server_log
         FAIL=$((FAIL + 1))
     fi
+}
+
+# What the server was doing when a check failed. Bounded, and only for the
+# first few failures: enough to diagnose, not enough to bury the summary.
+# Without this a server-side stall is invisible -- the client reports only that
+# it gave up, which reads as "the server is down" even while the checks either
+# side of it are served fine.
+SERVER_LOG=""
+SERVER_LOG_DUMPS=0
+dump_server_log() {
+    [ "$SERVER_LOG_DUMPS" -lt 3 ] || return 0
+    SERVER_LOG_DUMPS=$((SERVER_LOG_DUMPS + 1))
+    # Say which case this is rather than going quiet. A silent helper here would
+    # repeat, in miniature, the bug it exists to fix: the reader cannot tell
+    # "the server said nothing" from "nobody looked".
+    # Two different files, and the useful one is not the obvious one. The
+    # redirect on start_server captures only what the server writes to
+    # stdout/stderr, which for a healthy boot is nothing; the request log --
+    # every route, its status and its timing -- goes to AIMEE_HOME/server.log.
+    # Prefer that, and fall back to the capture so a server that dies before it
+    # can open its log still gets to say why.
+    local shown=0
+    local f
+    for f in "$AIMEE_HOME/server.log" "$SERVER_LOG"; do
+        [ -n "$f" ] && [ -s "$f" ] || continue
+        echo "  aimee-server log (last 20 lines of $f):"
+        tail -20 "$f" 2>/dev/null | sed 's/^/    /'
+        shown=1
+        break
+    done
+    [ "$shown" -eq 1 ] || echo "  aimee-server log: nothing recorded in $AIMEE_HOME/server.log or ${SERVER_LOG:-(no capture path)}"
 }
 
 check_output() {
@@ -68,6 +100,7 @@ check_output() {
         PASS=$((PASS + 1))
     else
         echo "FAIL: $desc (expected '$expected', got '$(echo "$output" | head -1)')"
+        dump_server_log
         FAIL=$((FAIL + 1))
     fi
 }
@@ -261,7 +294,11 @@ PY
 # socket-present means ready to serve. Polling also returns as soon as it is up,
 # which is faster than the sleep it replaces on a machine that is not loaded.
 start_server() {
-    local log="$HOME/aimee-server.$$.log"
+    # Global, not local: a failing CHECK needs this as much as a failing bind.
+    # A server that answers slowly, or not at all, says why here and nowhere
+    # else, and every check that reads only the client's side has to guess.
+    SERVER_LOG="$HOME/aimee-server.$$.log"
+    local log="$SERVER_LOG"
     "$AIMEE_SERVER" --foreground >"$log" 2>&1 &
     SERVER_PID=$!
     local i


### PR DESCRIPTION
## Why

When a check fails, this harness prints only the client's side. A server that answers slowly, or not at all, says why in its own log and nowhere else -- so every such failure gets diagnosed by inference.

The live example:

```
FAIL: mcp git_status tool call (expected '"content"',
      got 'aimee-server unavailable after retries. Restart aimee-server and retry.')
```

That reads as "the server is down", while the MCP checks either side of it are served by that same server fine. What it actually means is that one request did not come back inside the client's 30s timeout -- and the reason is in the request log nobody printed.

## What

Print the last 20 lines of the server's log on a failed check, for the first three failures only: enough to diagnose, not enough to bury the summary.

## Two details that each cost a round trip to find

**The useful file is not the obvious one.** `start_server`'s redirect captures stdout/stderr, which for a healthy boot is **empty** -- I wired the dump to it first and got nothing. The request log (every route, status and `req_id`) is `AIMEE_HOME/server.log`. This prefers that, and falls back to the capture so a server that dies before opening its log still gets to say why.

**The helper never goes quiet.** If neither file has anything it says so and names both paths. A silent helper here would repeat, in miniature, the bug it exists to fix: the reader cannot tell *"the server said nothing"* from *"nobody looked"*.

## Plant test

Breaking one expectation now prints:

```
FAIL: mcp git_status tool call (expected 'ZZPLANTZZ', got '...')
  aimee-server log (last 20 lines of /tmp/aimee-integ-9FeprP/.config/aimee/server.log):
    2026-08-18T16:51:29Z INFO  server.http: GET /v1/cli/manifest -> 200 req_id=1745998-8
    2026-08-18T16:51:29Z INFO  server.http: POST /v1/api/enable -> 200 req_id=1745998-9
    ...
```

`integration: 62/62` with the plant reverted.

## Related

Fourth instance of the same shape in this harness: the server's startup log, the abort's line number, mcp-serve's stderr (#2799), and now the request log. Each was evidence that existed and was discarded.
