### PR TITLE
test: let the MCP git_status check survive a slow runner

### DIFF
--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -512,7 +512,33 @@ RESP=$(mcp_initialized_req '{"jsonrpc":"2.0","id":4,"method":"resources/read","p
 check_output "mcp resources/read config" '"mimeType":"application/json"' echo "$RESP"
 check_output "mcp resources/read config text" '\"protocolVersion\":\"2024-11-05\"' echo "$RESP"
 
-RESP=$(mcp_initialized_req '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"git_status","arguments":{}}}') || true
+# Retry ONCE when the bridge reports the server unreachable.
+#
+# A tools/call is a POST, and cli_mcp_serve.c deliberately never retries those:
+# "a lost response must not duplicate a mutation whose first attempt may have
+# completed." That is right, and it makes this check single-shot -- one slow
+# response on a loaded runner fails it. It has failed twice now for two
+# different reasons, which makes it the flakiest check here.
+#
+# So retry the CHECK, not the request. Safe precisely because git_status is a
+# read: a second attempt cannot duplicate anything, which is the whole reason
+# the product refuses to retry the general case. Anything other than "server
+# unavailable" is a real answer and is asserted on as-is, so a genuine
+# regression still fails on the first attempt.
+mcp_git_status() {
+    local out
+    out=$(mcp_initialized_req '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"git_status","arguments":{}}}' 2>/dev/null) || true
+    case "$out" in
+        *"unavailable after retries"*)
+            echo "  (mcp git_status: bridge reported the server unreachable; retrying once)" >&2
+            sleep 2
+            out=$(mcp_initialized_req '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"git_status","arguments":{}}}' 2>/dev/null) || true
+            ;;
+    esac
+    printf '%s' "$out"
+}
+
+RESP=$(mcp_git_status) || true
 check_output "mcp git_status tool call" '"content"' echo "$RESP"
 check_output "mcp git_status result text" 'branch:' echo "$RESP"
 


### PR DESCRIPTION
`mcp git_status` is the flakiest check in this harness and has now failed twice for two unrelated reasons. The second, on a PR that changes **only a Python report script**:

| PR | integration-tests | duration |
|---|---|---|
| #2811 | **FAIL** | 3m27s |
| #2809 | pass | 2m18s |
| #2812 | pass | 2m09s |

Same harness, same base, a minute slower, and only the slow one failed.

## The mechanism isn't a bug

A `tools/call` is a POST, and `cli_mcp_serve.c` refuses to retry those on purpose:

> Never retry POST tool calls here: a lost response must not duplicate a mutation whose first attempt may have completed.

That's correct. It also makes this check single-shot: one dropped response on a loaded runner is a failed build.

So retry the **check**, not the request. Safe precisely because `git_status` is a *read* — a second attempt cannot duplicate anything, which is the whole reason the product declines to retry the general case. Only an `"unavailable after retries"` answer is retried; anything else is a real answer and is asserted on as-is.

## Plant-tested in both directions

A retry that hides real breakage is worse than the flake it was added for, so both:

**Retry path runs** — endpoint dead for every attempt:
```
  (mcp git_status: bridge reported the server unreachable; retrying once)
FAIL: mcp git_status tool call (expected '"content"', got '...unavailable after retries...')
```

**Real regression not masked** — assertion changed to something the tool never returns: fails on the first attempt, no retry.

Worth noting: my first attempt at the retry plant **didn't fire at all** — it depended on a sentinel file nothing created, so it would have "passed" while proving nothing. Replaced with one whose effect is visible in the output.

integration-tests 62/62 · lint 61/61 · both plants above.
