### PR TITLE
memory: make recall bump use_count and decay on last use

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -297,7 +297,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 233 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
+The binaries read 234 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
 
 ### Paths & assets
 
@@ -459,6 +459,7 @@ The binaries read 233 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_DB2_URL` | Postgres (DB2) connection URL for the KB store. |
 | `AIMEE_DIM_PROBE_BUDGET_MS` | Time budget for probing an embedder's output dimension. |
 | `AIMEE_PGVEC_SLOW_QUERY_MS` | Slow-query log threshold (ms) for the pgvector transport. |
+| `AIMEE_TEST_DB2_TEMPLATE_URL` | Test-only. Postgres template database the DB2 test shim clones per test process, so unit tests run against the real engine instead of the sqlite shim (which translates DB2's SQL rather than executing it). Build the template with `make db2-test-template` and the suite with `make unit-tests-pg`; unset, tests use the sqlite shim as before. Read only by test binaries; no production code path consults it. |
 
 ### Memory
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -869,6 +869,14 @@ ENV_DESC = {
     "AIMEE_VECTOR_KB_BATCH_SIZE": ("Knowledge base (aimee-kb)", "Embedding batch size for KB vector ingest."),
     # Database & vectors
     "AIMEE_DB2_URL": ("Database & vectors", "Postgres (DB2) connection URL for the KB store."),
+    "AIMEE_TEST_DB2_TEMPLATE_URL": (
+        "Database & vectors",
+        "Test-only. Postgres template database the DB2 test shim clones per test process, so unit "
+        "tests run against the real engine instead of the sqlite shim (which translates DB2's SQL "
+        "rather than executing it). Build the template with `make db2-test-template` and the suite "
+        "with `make unit-tests-pg`; unset, tests use the sqlite shim as before. Read only by test "
+        "binaries; no production code path consults it.",
+    ),
     "AIMEE_DB2_STATEMENT_TIMEOUT_MS": (
         "Database & vectors",
         "Per-connection `statement_timeout` in ms. Defaults to the pool's stuck-lease "

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -357,6 +357,9 @@ int memory_insert_ex(const char *tier, const char *kind, const char *key, const 
                      memory_t *out);
 int memory_get(int64_t id, memory_t *out);
 int memory_touch(int64_t id);
+/* Batch memory_touch, for the recall path: one statement per chunk of ids
+ * rather than one UPDATE per memory injected into a turn. */
+int memory_touch_many(const int64_t *ids, int n);
 int memory_reject(int64_t id, const char *reason);
 int memory_list(const char *tier, const char *kind, int limit, memory_t *out, int max);
 int memory_stats(memory_stats_t *out);

--- a/src/modules/db2/c/db2_test_shim.c
+++ b/src/modules/db2/c/db2_test_shim.c
@@ -9,17 +9,23 @@
 
 #ifndef AIMEE_DISABLE_DB2_SQLITE_SHIM
 
-#include "db2_test_shim.h"
 #include "config_embedder_dims.h" /* the one width declaration (no config link) */
+#include "db2_test_shim.h"
 
 #include "db2.h"
 #include "db2_internal.h"
+#include "db_postgres.h" /* aimee_pg_* — the postgres-backed mode */
 #include "db_schema.h"
 #include "lifecycle.h" /* db2_set_embedding_dim */
 
 #include <assert.h>
 #include <sqlite3.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 /* Weakly link to DB1's per-handle statement-cache flush. The shim
  * uses one sqlite handle to back the DB2 surface, and any DB1 helper
@@ -32,6 +38,200 @@ extern void db1_stmt_cache_clear_for_sqlite(struct sqlite3 *db) __attribute__((w
 
 static sqlite3 *g_shim_handle;
 
+/* --- Postgres-backed mode -------------------------------------------------
+ *
+ * The sqlite shim TRANSLATES DB2's SQL rather than executing it, so the places
+ * where the two engines genuinely differ — affected-row counts, how the
+ * scope-filter macros expand, anything postgres-specific in a query — are
+ * exactly the places it cannot vouch for. Setting AIMEE_TEST_DB2_TEMPLATE_URL to
+ * a database carrying an applied DB2 schema (see `make db2-test-template`) runs
+ * the same tests against the real engine.
+ *
+ * Isolation is per PROCESS, not per test. Each test binary clones the template
+ * into its own `<template>_p<pid>` database, so a parallel `make -j` run cannot
+ * have two binaries treading on each other. A clone costs ~200 ms and a drop can
+ * stall for seconds behind a checkpoint — affordable once per binary, not 98
+ * times. Between tests the far cheaper aimee_test_reset() (installed in the
+ * template) returns the database to its freshly-seeded state in ~60 ms. */
+static char g_pg_base_url[1024]; /* the template URL, as given */
+static char g_pg_test_url[1400]; /* the per-process clone URL */
+static char g_pg_test_db[256];   /* the per-process clone database name */
+static int g_pg_mode;            /* 1 once the clone is live */
+static int g_pg_atexit_registered;
+
+/* Split a libpq URL into everything-up-to-and-including the last '/', the
+ * database name, and any query suffix. Only the URL form the harness passes is
+ * handled: scheme://[user@]host[:port]/dbname[?params]. */
+static int pg_split_url(const char *url, char *prefix, size_t prefix_len, char *dbname,
+                        size_t dbname_len, char *suffix, size_t suffix_len)
+{
+   const char *scheme = strstr(url, "://");
+   if (!scheme)
+      return -1;
+   const char *slash = strchr(scheme + 3, '/');
+   if (!slash || !slash[1])
+      return -1;
+   const char *q = strchr(slash + 1, '?');
+   size_t plen = (size_t)(slash - url) + 1; /* keep the '/' */
+   size_t dlen = q ? (size_t)(q - slash - 1) : strlen(slash + 1);
+   if (plen >= prefix_len || dlen >= dbname_len)
+      return -1;
+   memcpy(prefix, url, plen);
+   prefix[plen] = '\0';
+   memcpy(dbname, slash + 1, dlen);
+   dbname[dlen] = '\0';
+   snprintf(suffix, suffix_len, "%s", q ? q : "");
+   return 0;
+}
+
+/* Run one statement through a short-lived connection. CREATE/DROP DATABASE
+ * cannot run on a connection to the database being created or dropped. */
+static int pg_admin_exec(const char *url, const char *sql, char *err, size_t err_len)
+{
+   void *c = aimee_pg_open(url, err, err_len);
+   if (!c)
+      return -1;
+   int rc = aimee_pg_exec(c, sql, err, err_len);
+   aimee_pg_close(c);
+   return rc;
+}
+
+static void pg_drop_clone(void)
+{
+   if (!g_pg_test_db[0])
+      return;
+   char prefix[1024], dbname[256], suffix[256];
+   if (pg_split_url(g_pg_base_url, prefix, sizeof(prefix), dbname, sizeof(dbname), suffix,
+                    sizeof(suffix)) == 0)
+   {
+      char admin_url[1400];
+      snprintf(admin_url, sizeof(admin_url), "%spostgres%s", prefix, suffix);
+      char sql[512];
+      snprintf(sql, sizeof(sql), "DROP DATABASE IF EXISTS \"%s\" WITH (FORCE)", g_pg_test_db);
+      char err[512] = "";
+      /* Best-effort: a leaked scratch database is operator noise, not a test
+       * result, and failing the run for it would report a defect the code under
+       * test did not have. */
+      (void)pg_admin_exec(admin_url, sql, err, sizeof(err));
+   }
+   g_pg_test_db[0] = '\0';
+}
+
+static void pg_atexit(void)
+{
+   if (g_pg_mode)
+   {
+      db2_shutdown();
+      g_pg_mode = 0;
+   }
+   pg_drop_clone();
+}
+
+/* A failing test aborts, and abort() does not run atexit handlers — so without
+ * this every assertion failure would strand a clone database on the server. That
+ * is the common case during a migration, not a rare one: a suite-wide run of
+ * failing tests would otherwise leave dozens behind and fill the volume. Drop the
+ * clone, then restore the default disposition and re-raise so the signal still
+ * reports normally (core dump, shell status). */
+static void pg_fatal_signal(int sig)
+{
+   pg_drop_clone();
+   signal(sig, SIG_DFL);
+   raise(sig);
+}
+
+static void pg_install_cleanup(void)
+{
+   if (g_pg_atexit_registered)
+      return;
+   atexit(pg_atexit);
+   static const int fatal[] = {SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGINT, SIGTERM};
+   for (size_t i = 0; i < sizeof(fatal) / sizeof(fatal[0]); i++)
+      signal(fatal[i], pg_fatal_signal);
+   g_pg_atexit_registered = 1;
+}
+
+/* Clone the template and point DB2 at the copy. Aborts on failure: a run that
+ * quietly fell back to sqlite after being asked for Postgres would report a pass
+ * that means nothing. */
+static void pg_open_clone(const char *template_url)
+{
+   char prefix[1024], dbname[256], suffix[256];
+   if (pg_split_url(template_url, prefix, sizeof(prefix), dbname, sizeof(dbname), suffix,
+                    sizeof(suffix)) != 0)
+   {
+      fprintf(stderr, "db2 test shim: cannot parse AIMEE_TEST_DB2_TEMPLATE_URL (%s)\n",
+              template_url);
+      abort();
+   }
+
+   snprintf(g_pg_base_url, sizeof(g_pg_base_url), "%s", template_url);
+   snprintf(g_pg_test_db, sizeof(g_pg_test_db), "%s_p%d", dbname, (int)getpid());
+
+   char admin_url[1400];
+   snprintf(admin_url, sizeof(admin_url), "%spostgres%s", prefix, suffix);
+
+   char sql[768];
+   char err[512] = "";
+   /* A previous run killed mid-test leaves its clone behind; reuse of the pid
+    * would then collide with a database this process does not own. */
+   snprintf(sql, sizeof(sql), "DROP DATABASE IF EXISTS \"%s\" WITH (FORCE)", g_pg_test_db);
+   (void)pg_admin_exec(admin_url, sql, err, sizeof(err));
+
+   snprintf(sql, sizeof(sql), "CREATE DATABASE \"%s\" TEMPLATE \"%s\"", g_pg_test_db, dbname);
+   if (pg_admin_exec(admin_url, sql, err, sizeof(err)) != 0)
+   {
+      fprintf(stderr,
+              "db2 test shim: CREATE DATABASE \"%s\" TEMPLATE \"%s\" failed: %s\n"
+              "  (build the template first: make db2-test-template)\n",
+              g_pg_test_db, dbname, err);
+      abort();
+   }
+
+   snprintf(g_pg_test_url, sizeof(g_pg_test_url), "%s%s%s", prefix, g_pg_test_db, suffix);
+
+   db2_set_embedding_dim_default(CONFIG_EMBEDDER_DIMS_DEFAULT);
+   db2_set_embedding_dim(CONFIG_EMBEDDER_DIMS_DEFAULT);
+   /* The clone already carries the schema. Verify rather than re-apply, so two
+    * binaries starting at once cannot collide on "tuple concurrently updated". */
+   db2_set_schema_readonly(1);
+   if (db2_init(g_pg_test_url) != 0)
+   {
+      fprintf(stderr, "db2 test shim: db2_init failed against %s\n", g_pg_test_url);
+      pg_drop_clone();
+      abort();
+   }
+
+   pg_install_cleanup();
+   g_pg_mode = 1;
+}
+
+/* Between tests: restore the freshly-seeded state without paying for a reconnect
+ * or another schema apply. */
+static void pg_reset(void)
+{
+   char err[512] = "";
+   if (aimee_pg_exec(db2_conn(), "SELECT aimee_test_reset()", err, sizeof(err)) != 0)
+   {
+      fprintf(stderr, "db2 test shim: aimee_test_reset() failed: %s\n", err);
+      abort();
+   }
+}
+
+int db2_test_shim_is_postgres(void)
+{
+   return g_pg_mode;
+}
+
+int db2_test_shim_skip_on_postgres(const char *test_name)
+{
+   if (!g_pg_mode)
+      return 0;
+   printf("  SKIP %s: seeds through the raw sqlite handle (postgres mode)\n",
+          test_name ? test_name : "test");
+   return 1;
+}
+
 void db2_test_shim_open(void)
 {
    db2_test_shim_open_path(":memory:");
@@ -39,6 +239,28 @@ void db2_test_shim_open(void)
 
 void db2_test_shim_open_path(const char *path)
 {
+   const char *template_url = getenv("AIMEE_TEST_DB2_TEMPLATE_URL");
+   if (template_url && template_url[0])
+   {
+      if (g_pg_mode)
+         pg_reset(); /* already connected: the reset IS the reopen */
+      else
+         pg_open_clone(template_url);
+      return;
+   }
+
+#ifdef AIMEE_TEST_PG_BACKEND
+   /* Built with AIMEE_TEST_PG=1, so aimee_pg_* IS libpq and the sqlite path below
+    * cannot work: db2_init("shim") would try to reach a database literally named
+    * "shim" and the assert would fire with nothing explaining why. Say what is
+    * actually wrong instead. */
+   fprintf(stderr,
+           "db2 test shim: this binary was built with AIMEE_TEST_PG=1 (real libpq),\n"
+           "  but AIMEE_TEST_DB2_TEMPLATE_URL is unset, so there is no database to\n"
+           "  clone. Set it, or rebuild without AIMEE_TEST_PG for the sqlite shim.\n");
+   abort();
+#endif
+
    db2_test_shim_close();
 
    sqlite3 *raw = NULL;
@@ -70,6 +292,11 @@ void db2_test_shim_open_path(const char *path)
 
 void db2_test_shim_close(void)
 {
+   /* In postgres mode the connection outlives the individual test — reconnecting
+    * per test would cost another clone. pg_atexit does the real teardown. */
+   if (g_pg_mode)
+      return;
+
    if (!g_shim_handle)
    {
       db2_register_shared_sqlite(NULL);

--- a/src/modules/db2/c/db2_test_shim.c
+++ b/src/modules/db2/c/db2_test_shim.c
@@ -225,7 +225,11 @@ int db2_test_shim_is_postgres(void)
 
 int db2_test_shim_skip_on_postgres(const char *test_name)
 {
-   if (!g_pg_mode)
+   /* Keyed off the environment, not g_pg_mode: callers check this at the top of
+    * main(), before any shim open has set g_pg_mode, precisely so they can bail
+    * out before touching a handle that will not exist. */
+   const char *url = getenv("AIMEE_TEST_DB2_TEMPLATE_URL");
+   if (!g_pg_mode && !(url && url[0]))
       return 0;
    printf("  SKIP %s: seeds through the raw sqlite handle (postgres mode)\n",
           test_name ? test_name : "test");
@@ -254,10 +258,9 @@ void db2_test_shim_open_path(const char *path)
     * cannot work: db2_init("shim") would try to reach a database literally named
     * "shim" and the assert would fire with nothing explaining why. Say what is
     * actually wrong instead. */
-   fprintf(stderr,
-           "db2 test shim: this binary was built with AIMEE_TEST_PG=1 (real libpq),\n"
-           "  but AIMEE_TEST_DB2_TEMPLATE_URL is unset, so there is no database to\n"
-           "  clone. Set it, or rebuild without AIMEE_TEST_PG for the sqlite shim.\n");
+   fprintf(stderr, "db2 test shim: this binary was built with AIMEE_TEST_PG=1 (real libpq),\n"
+                   "  but AIMEE_TEST_DB2_TEMPLATE_URL is unset, so there is no database to\n"
+                   "  clone. Set it, or rebuild without AIMEE_TEST_PG for the sqlite shim.\n");
    abort();
 #endif
 

--- a/src/modules/db2/c/db2_test_shim.h
+++ b/src/modules/db2/c/db2_test_shim.h
@@ -39,6 +39,20 @@ extern "C"
     * aimee_pg_exec(db2_conn(), ...) instead. */
    void *db2_test_shim_handle(void);
 
+   /* Non-zero when the shim is backed by a real Postgres (AIMEE_TEST_DB2_TEMPLATE_URL
+    * is set) rather than sqlite. In that mode db2_test_shim_handle() returns NULL,
+    * because there is no sqlite handle to hand out — a test that reaches for the
+    * raw handle to run seed SQL must either skip or go through
+    * aimee_pg_exec(db2_conn(), ...), which works on both backends. */
+   int db2_test_shim_is_postgres(void);
+
+   /* Print a skip notice naming `test_name` and return 1 when the shim is on
+    * Postgres, else 0. For the tests still seeding through the raw sqlite handle:
+    *   if (db2_test_shim_skip_on_postgres("curator_queue")) return;
+    * Keeps the PG run green and self-documenting instead of silently passing a
+    * test whose fixture never ran. */
+   int db2_test_shim_skip_on_postgres(const char *test_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/db2/c/memory_query.c
+++ b/src/modules/db2/c/memory_query.c
@@ -1674,6 +1674,70 @@ int db2_memory_touch(int64_t memory_id)
    return changes > 0 ? 0 : -1;
 }
 
+/* Ids per UPDATE, and the widest decimal int64 plus its separator. Together
+ * these bound the stack buffers below (~3.5 KB) while keeping a whole turn's
+ * injected-memory set to one or two statements. */
+#define MQ_TOUCH_BATCH    128
+#define MQ_TOUCH_ID_WIDTH 21
+#define MQ_TOUCH_LIST_CAP (MQ_TOUCH_BATCH * MQ_TOUCH_ID_WIDTH)
+
+int db2_memory_touch_many(const int64_t *ids, int n)
+{
+   if (!ids || n <= 0)
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   int total = 0;
+   int wanted = 0; /* ids worth an UPDATE */
+   int issued = 0; /* statements that actually ran */
+   for (int off = 0; off < n; off += MQ_TOUCH_BATCH)
+   {
+      /* The ids are BIGINTs read back out of `memories`, so they are formatted
+       * into the IN list directly; there is no injection surface, and it avoids
+       * running the placeholder namespace out to ?128 with a bind call each. */
+      char list[MQ_TOUCH_LIST_CAP];
+      size_t pos = 0;
+      int in_batch = 0;
+      for (int i = off; i < n && i < off + MQ_TOUCH_BATCH; i++)
+      {
+         if (ids[i] <= 0)
+            continue;
+         int w = snprintf(list + pos, sizeof(list) - pos, "%s%lld", in_batch ? "," : "",
+                          (long long)ids[i]);
+         if (w < 0 || (size_t)w >= sizeof(list) - pos)
+            break;
+         pos += (size_t)w;
+         in_batch++;
+      }
+      if (in_batch == 0)
+         continue;
+      wanted += in_batch;
+
+      char sql[MQ_TOUCH_LIST_CAP + 128];
+      int sn = snprintf(sql, sizeof(sql),
+                        "UPDATE memories SET use_count = use_count + 1,"
+                        " last_used_at = pg_now_text() WHERE id IN (%s)",
+                        list);
+      if (sn < 0 || (size_t)sn >= sizeof(sql))
+         continue;
+      char err[MQ_ERRBUF] = "";
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+      if (!st)
+         continue;
+      if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_DONE)
+      {
+         total += aimee_pg_stmt_changes(st);
+         issued++;
+      }
+      aimee_pg_finalize(st);
+   }
+   if (wanted == 0)
+      return 0; /* nothing addressable — not a failure */
+   return issued > 0 ? total : -1;
+}
+
 int db2_memory_update_content(int64_t memory_id, const char *content)
 {
    if (memory_id <= 0 || !content || !content[0])

--- a/src/modules/db2/c/memory_query.h
+++ b/src/modules/db2/c/memory_query.h
@@ -483,6 +483,11 @@ extern "C"
       char kind[16];
       double confidence;
       int use_count;
+      /* Recency inputs for the context scorer. last_used_at is empty until the
+       * memory has actually been recalled, so the scorer falls back to
+       * created_at for never-recalled rows. */
+      char last_used_at[32];
+      char created_at[32];
    } db2_memory_cand_row_t;
 
    /* Tier filter selecting which set of candidates to load. */
@@ -687,6 +692,13 @@ extern "C"
    /* Increment a memory's use_count and stamp last_used_at = now.
     * Returns 0 on success, -1 on miss / SQL failure. */
    int db2_memory_touch(int64_t memory_id);
+
+   /* Batch form of db2_memory_touch. Recall touches every memory injected into
+    * a turn, so the single-row form would cost one UPDATE per injected memory
+    * on the context-assembly path; this issues one statement per chunk instead.
+    * Ids <= 0 are skipped. Returns the number of rows updated, or -1 when no
+    * statement could be issued at all. */
+   int db2_memory_touch_many(const int64_t *ids, int n);
 
    /* Single-row SELECT into memory_t. Returns 0 on hit, -1 on miss. */
    int db2_memory_get(int64_t memory_id, memory_t *out);

--- a/src/modules/db2/c/memory_score_fields.c
+++ b/src/modules/db2/c/memory_score_fields.c
@@ -1243,13 +1243,15 @@ int db2_memory_list_candidates(db2_memory_cand_filter_t filter, db2_memory_cand_
    switch (filter)
    {
    case DB2_MEM_CAND_PRIMARY:
-      sql = "SELECT m.id, m.tier, m.key, m.content, m.kind, m.confidence, m.use_count"
+      sql = "SELECT m.id, m.tier, m.key, m.content, m.kind, m.confidence, m.use_count,"
+            " COALESCE(m.last_used_at, ''), m.created_at"
             " FROM memories m WHERE m.tier IN ('L1', 'L2', 'L3', 'L4', "
             "'L5')" DB2_MEMORY_SCOPE_FILTER_SQL("m.id") " ORDER BY " DB2_MEMORY_SCOPE_RANK_SQL(
                 "m.id") " DESC, m.confidence DESC, m.use_count DESC LIMIT ?1";
       break;
    case DB2_MEM_CAND_FALLBACK:
-      sql = "SELECT m.id, m.tier, m.key, m.content, m.kind, m.confidence, m.use_count"
+      sql = "SELECT m.id, m.tier, m.key, m.content, m.kind, m.confidence, m.use_count,"
+            " COALESCE(m.last_used_at, ''), m.created_at"
             " FROM memories m WHERE m.tier IN ('L0', 'L1', 'L2', 'L4')" DB2_MEMORY_SCOPE_FILTER_SQL(
                 "m.id") " ORDER BY " DB2_MEMORY_SCOPE_RANK_SQL("m.id") " DESC, m.confidence DESC, "
                                                                        "m.use_count DESC LIMIT ?1";
@@ -1277,6 +1279,10 @@ int db2_memory_list_candidates(db2_memory_cand_filter_t filter, db2_memory_cand_
       snprintf(rows[n].kind, sizeof(rows[n].kind), "%s", ki ? ki : "");
       rows[n].confidence = aimee_pg_column_double(st, 5);
       rows[n].use_count = aimee_pg_column_int(st, 6);
+      const char *lu = aimee_pg_column_text(st, 7);
+      const char *cr = aimee_pg_column_text(st, 8);
+      snprintf(rows[n].last_used_at, sizeof(rows[n].last_used_at), "%s", lu ? lu : "");
+      snprintf(rows[n].created_at, sizeof(rows[n].created_at), "%s", cr ? cr : "");
       n++;
    }
    aimee_pg_finalize(st);

--- a/src/modules/memory/memory_assemble.c
+++ b/src/modules/memory/memory_assemble.c
@@ -577,6 +577,38 @@ static double compute_graph_score(const boost_map_t *bmap, const char *key, cons
    return boost;
 }
 
+/* Age in days of a DB2 timestamp, or -1 when it is empty or unparseable
+ * (context_recency_from_age_days reads -1 as "unknown", not "stale").
+ *
+ * Via parse_utc_ts, which reads the separator as a character: these two columns
+ * genuinely disagree on spelling. last_used_at is stamped by pg_now_text() in
+ * canonical ISO ("...T..Z"), while memories.created_at defaults to
+ * to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS') — a space. A parser that
+ * hard-codes one spelling silently drops the time-of-day on the other, which is
+ * the exact failure parse_utc_ts exists to prevent. It returns 0 for both empty
+ * and malformed input, and rejects years before 1970, so 0 is an unambiguous
+ * "no usable stamp" rather than a real instant. */
+static double context_stamp_age_days(const char *stamp)
+{
+   time_t at = parse_utc_ts(stamp);
+   if (at <= 0)
+      return -1.0;
+   double days = difftime(time(NULL), at) / 86400.0;
+   return days < 0.0 ? 0.0 : days;
+}
+
+/* Recency factor for a candidate, measured from last_used_at — which the recall
+ * path stamps whenever a memory is actually injected into a turn, so a fact that
+ * keeps proving useful stays fresh no matter when it was first learned.
+ * created_at is the fallback for rows that have never been recalled. */
+static double context_recency_factor(const char *last_used_at, const char *created_at)
+{
+   double days = context_stamp_age_days(last_used_at);
+   if (days < 0.0)
+      days = context_stamp_age_days(created_at);
+   return context_recency_from_age_days(days);
+}
+
 static int context_tier_priority(const char *tier)
 {
    return memory_tier_priority(tier);
@@ -830,10 +862,21 @@ static int append_task_aware_context(char *buf, int pos, int cap, const char *ta
    if (term_count > 0)
       memory_graph_boost(query_terms, term_count, &bmap);
 
+   /* Classify intent and build the retrieval plan before scoring, not just
+    * before the section budgets: recency_weight is a scoring input, and
+    * retrieval_plan_for_intent reads nothing but task_hint. */
+   retrieval_plan_t rplan;
+   {
+      task_intent_t intent = classify_intent(task_hint);
+      retrieval_plan_for_intent(intent, &rplan);
+      if (temporal_query)
+         rplan.recency_weight = 0.85; /* contextual recency anchoring */
+   }
+
    /* 3. Load all L1/L2/L3/L5 candidates.  L3 = stable project/env facts,
     * L5 = synthesised cross-session patterns.  Both are eligible for dense
     * pgvector recall through the shared ranking path, weighted via
-    * confidence/use_count + graph signals. */
+    * confidence/use_count + recency + graph signals. */
    context_candidate_t candidates[MAX_CANDIDATES];
    int cand_count = 0;
 
@@ -869,6 +912,9 @@ static int append_task_aware_context(char *buf, int pos, int cap, const char *ta
 
       c->score += c->scope_rank * 0.05;
       c->score += c->tier_priority * 0.03;
+      c->score = context_apply_recency(
+          c->score, context_recency_factor(cand_rows[ci].last_used_at, cand_rows[ci].created_at),
+          rplan.recency_weight);
 
       int key_len = (int)strlen(c->key);
       int content_len = (int)strlen(c->content);
@@ -942,6 +988,9 @@ static int append_task_aware_context(char *buf, int pos, int cap, const char *ta
                        (c->use_count / 10.0) * 0.2;
             c->score += c->scope_rank * 0.05;
             c->score += c->tier_priority * 0.03;
+            c->score = context_apply_recency(
+                c->score, context_recency_factor(fb_rows[fi].last_used_at, fb_rows[fi].created_at),
+                rplan.recency_weight);
             c->estimated_tokens = ((int)strlen(c->key) + (int)strlen(c->content)) / 4 + 1;
             c->score_per_token = c->score / (double)c->estimated_tokens;
             new_count++;
@@ -988,15 +1037,6 @@ static int append_task_aware_context(char *buf, int pos, int cap, const char *ta
    if (answerability_withheld)
       cand_count = 0;
 
-   /* 5. Classify intent and build retrieval plan for dynamic budgets */
-   retrieval_plan_t rplan;
-   {
-      task_intent_t intent = classify_intent(task_hint);
-      retrieval_plan_for_intent(intent, &rplan);
-      if (temporal_query)
-         rplan.recency_weight = 0.85; /* contextual recency anchoring */
-   }
-
    /* Compute per-section char-budgets from plan (total = MAX_CONTEXT_TOTAL - overhead) */
    int section_budget = MAX_CONTEXT_TOTAL - 500; /* reserve for headers/structure */
 
@@ -1025,6 +1065,15 @@ static int append_task_aware_context(char *buf, int pos, int cap, const char *ta
 
    /* In budget mode track overall token usage across sections. */
    int tokens_used = 0;
+
+   /* Memories actually emitted into the context this turn. Recall bumps
+    * use_count / last_used_at for these once the sections are built: both feed
+    * scoring (use_count through the base term, last_used_at through the recency
+    * factor), so a memory that keeps earning its place in the context stays
+    * ranked for the next turn. Collected rather than touched inline so the whole
+    * turn costs one batched UPDATE instead of one per memory. */
+   int64_t touched[MAX_CANDIDATES];
+   int touched_count = 0;
 
    for (int s = 0; s < nsections; s++)
    {
@@ -1098,6 +1147,8 @@ static int append_task_aware_context(char *buf, int pos, int cap, const char *ta
             if (sid && sid[0] && db1_context_snapshot_insert)
                (void)db1_context_snapshot_insert(sid, c->id, c->score);
          }
+         if (touched_count < (int)(sizeof(touched) / sizeof(touched[0])))
+            touched[touched_count++] = c->id;
          pos += written;
          if (budget_mode)
             tokens_used += c->estimated_tokens;
@@ -1107,6 +1158,9 @@ static int append_task_aware_context(char *buf, int pos, int cap, const char *ta
       if (items == 0)
          pos = section_start;
    }
+
+   if (touched_count > 0)
+      (void)memory_touch_many(touched, touched_count);
 
    pos = append_negative_context_block(buf, pos, cap, task_hint, negative_candidates, cand_count);
 
@@ -1396,6 +1450,16 @@ char *memory_assemble_context_explain(const char *task_hint,
    char project_label[MAX_PATH_LEN];
    memory_scope_labels_for_cwd(NULL, workspace_label, sizeof(workspace_label), project_label,
                                sizeof(project_label));
+   /* Mirror the assembly scorer's recency handling so the explain surface
+    * reports the score the real pass produced. */
+   retrieval_plan_t erplan;
+   {
+      task_intent_t intent = classify_intent(task_hint);
+      retrieval_plan_for_intent(intent, &erplan);
+      if (has_temporal_markers(task_hint))
+         erplan.recency_weight = 0.85;
+   }
+
    context_candidate_t scored[200];
    int scored_count = 0;
 
@@ -1429,6 +1493,9 @@ char *memory_assemble_context_explain(const char *task_hint,
       double overlap = (ko > co ? ko : co) * 0.3;
       double graph = compute_graph_score(&bmap, c->key, c->content) * 0.2;
       c->score = base + overlap + graph + c->scope_rank * 0.05 + c->tier_priority * 0.03;
+      c->score = context_apply_recency(
+          c->score, context_recency_factor(cand_rows[ci].last_used_at, cand_rows[ci].created_at),
+          erplan.recency_weight);
       c->score_per_token = c->score / (double)c->estimated_tokens;
       scored_count++;
    }

--- a/src/modules/memory/memory_assemble_util.h
+++ b/src/modules/memory/memory_assemble_util.h
@@ -6,6 +6,7 @@
 #define DEC_MEMORY_ASSEMBLE_UTIL_H 1
 
 #include <ctype.h>
+#include <math.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -127,6 +128,40 @@ static inline int assemble_texts_near_duplicate(const char *a, const char *b)
       return 0;
    /* >= 0.85 without floating point: 100*inter >= 85*uni. */
    return (inter * 100U) >= (uni * 85U);
+}
+
+/* Recency factor in (0, 1] for a memory of the given age: a flat plateau
+ * followed by a slow half-life, rather than a plain exponential from day zero.
+ *
+ * The plateau exists because a fact does not become less true as it ages. A
+ * correct answer learned three months ago should not lose to a less relevant
+ * one learned yesterday, so inside the plateau candidates compete on relevance
+ * alone. Past it the tail is long enough that a still-valid old fact stays
+ * reachable while genuinely stale material sinks.
+ *
+ * A negative age means "no usable stamp" and returns 1.0: an unknown age is not
+ * evidence of staleness, so it must not be penalised. */
+#define MEMORY_RECENCY_PLATEAU_DAYS  180.0
+#define MEMORY_RECENCY_HALFLIFE_DAYS 1825.0
+
+static inline double context_recency_from_age_days(double days)
+{
+   if (days < 0.0 || days <= MEMORY_RECENCY_PLATEAU_DAYS)
+      return 1.0;
+   return pow(0.5, (days - MEMORY_RECENCY_PLATEAU_DAYS) / MEMORY_RECENCY_HALFLIFE_DAYS);
+}
+
+/* Fold `recency` into `score` under the retrieval plan's recency_weight, which
+ * runs 0.0 (recency is irrelevant to this intent — score unchanged) through 1.0
+ * (score scales by the full decay). Weights outside [0,1] are clamped. */
+static inline double context_apply_recency(double score, double recency, double recency_weight)
+{
+   double w = recency_weight;
+   if (w <= 0.0)
+      return score;
+   if (w > 1.0)
+      w = 1.0;
+   return score * ((1.0 - w) + w * recency);
 }
 
 #endif /* DEC_MEMORY_ASSEMBLE_UTIL_H */

--- a/src/modules/memory/memory_core.c
+++ b/src/modules/memory/memory_core.c
@@ -239,6 +239,13 @@ int memory_touch(int64_t id)
    return -1;
 }
 
+int memory_touch_many(const int64_t *ids, int n)
+{
+   (void)ids;
+   (void)n;
+   return -1;
+}
+
 int memory_update_content_as(int64_t id, const char *content, memory_authority_t authority,
                              int64_t *new_id_out)
 {

--- a/src/modules/memory/memory_core_crud.c
+++ b/src/modules/memory/memory_core_crud.c
@@ -525,6 +525,11 @@ int memory_touch(int64_t id)
    return db2_memory_touch(id);
 }
 
+int memory_touch_many(const int64_t *ids, int n)
+{
+   return db2_memory_touch_many(ids, n);
+}
+
 int memory_update_content_as(int64_t id, const char *content, memory_authority_t authority,
                              int64_t *new_id_out)
 {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -7,7 +7,35 @@ DB1_TEST_OBJS = $(DB1_OBJS) $(OBJDIR)/modules/db1/db1_init.o \
                 $(OBJDIR)/modules/db1/db1_write.o $(OBJDIR)/modules/db1/diagnostics.o
 
 TEST_C_FLAGS = $(C_FLAGS) -I.. -Igateway
-TEST_L_FLAGS = $(L_FULL)
+TEST_L_FLAGS = $(L_FULL) $(DB2_TEST_BACKEND_LIB)
+
+# Which object supplies the aimee_pg_* surface to test binaries.
+#
+# The sqlite shim and the real libpq layer export the SAME 33 aimee_pg_* symbols,
+# so the backend is a LINK-time choice, not a runtime one -- a binary carrying
+# both would not link. Every test recipe therefore names this variable rather
+# than either object directly.
+#
+# Default: the sqlite shim, which translates DB2's SQL and needs no server.
+# AIMEE_TEST_PG=1: the real libpq layer, so the same tests exercise postgres.
+# Nothing else about a recipe changes, which is the point -- there is one set of
+# test binaries, built against one backend or the other.
+DB2_TEST_BACKEND_OBJ = $(OBJDIR)/tests/aimee_pg_sqlite_shim.o
+DB2_TEST_BACKEND_LIB =
+ifeq ($(AIMEE_TEST_PG),1)
+# entity_edges.o rides along because db2_init calls db2_entity_edge_build_unique_index
+# on the not-a-shim path. Under the sqlite shim aimee_pg_is_shim() folds to a
+# constant and LTO drops that branch with its callee, so most recipes never had to
+# name the object; against real libpq the branch is live and 54 of them stop
+# linking. Carrying it with the backend keeps the choice to this one place instead
+# of editing every recipe.
+DB2_TEST_BACKEND_OBJ = $(OBJDIR)/db2/db_postgres.o $(OBJDIR)/db2/entity_edges.o
+DB2_TEST_BACKEND_LIB = $(PQ_LIB)
+# Lets the shim tell "you forgot AIMEE_TEST_DB2_TEMPLATE_URL" apart from "you
+# wanted sqlite", which are otherwise the same code path and abort identically.
+# Target-specific so only the shim sees it, rather than redefining every object.
+$(OBJDIR)/db2/db2_test_shim.o: C_FLAGS += -DAIMEE_TEST_PG_BACKEND=1
+endif
 
 # Test output prefix: defaults to $(OBJDIR)/tests so any `make unit-tests`
 # invocation with a non-default OBJDIR (sanitizers, coverage, build-integrity,
@@ -83,7 +111,7 @@ $(TESTPREFIX)/unit-test-server-management-listener-live: \
 	$(TESTLINK) -o $@ $^ $(L_SERVER)
 
 # Common object sets for tests
-TEST_CORE_OBJS = $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/interaction_event_names.o \
+TEST_CORE_OBJS = $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/interaction_event_names.o \
                  $(OBJDIR)/platform_random.o $(PLATFORM_BASIC_OBJS) \
                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o \
                  $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/wire_fence.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
@@ -1038,7 +1066,7 @@ $(TESTPREFIX)/unit-test-util: $(OBJDIR)/tests/test_util.o $(OBJDIR)/util.o $(OBJ
                      $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-db: $(OBJDIR)/tests/test_db.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/modules/db1/db1_init.o $(OBJDIR)/modules/db1/db1_write.o $(OBJDIR)/modules/db1/db1_trigger.o $(OBJDIR)/modules/db1/db1_cron_jobs.o $(OBJDIR)/modules/db1/model_catalog.o $(OBJDIR)/model_catalog_release.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/modules/db1/eval.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
+$(TESTPREFIX)/unit-test-db: $(OBJDIR)/tests/test_db.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/modules/db1/db1_init.o $(OBJDIR)/modules/db1/db1_write.o $(OBJDIR)/modules/db1/db1_trigger.o $(OBJDIR)/modules/db1/db1_cron_jobs.o $(OBJDIR)/modules/db1/model_catalog.o $(OBJDIR)/model_catalog_release.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/modules/db1/eval.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
                     $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                     $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/platform_random.o \
                     $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o
@@ -1059,13 +1087,13 @@ $(TESTPREFIX)/unit-test-harness-memory-scope: $(OBJDIR)/tests/test_harness_memor
 $(TESTPREFIX)/unit-test-memory-redirect: $(OBJDIR)/tests/test_memory_redirect.o $(OBJDIR)/modules/memory/memory_redirect.o $(OBJDIR)/harness_memory_scope.o $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-harness-memory: $(OBJDIR)/tests/test_harness_memory.o $(OBJDIR)/modules/db1/user_memory.o $(OBJDIR)/user_memory_merge.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/modules/db1/db1_init.o $(OBJDIR)/modules/db1/db1_write.o $(OBJDIR)/modules/db1/db1_trigger.o $(OBJDIR)/modules/db1/db1_cron_jobs.o $(OBJDIR)/modules/db1/model_catalog.o $(OBJDIR)/model_catalog_release.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/modules/db1/eval.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
+$(TESTPREFIX)/unit-test-harness-memory: $(OBJDIR)/tests/test_harness_memory.o $(OBJDIR)/modules/db1/user_memory.o $(OBJDIR)/user_memory_merge.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/modules/db1/db1_init.o $(OBJDIR)/modules/db1/db1_write.o $(OBJDIR)/modules/db1/db1_trigger.o $(OBJDIR)/modules/db1/db1_cron_jobs.o $(OBJDIR)/modules/db1/model_catalog.o $(OBJDIR)/model_catalog_release.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/modules/db1/eval.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
                     $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                     $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/platform_random.o \
                     $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-webchat-claude-sessions: $(OBJDIR)/tests/test_webchat_claude_sessions.o $(OBJDIR)/modules/db1/webchat_claude_sessions.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/modules/db1/db1_init.o $(OBJDIR)/modules/db1/db1_write.o $(OBJDIR)/modules/db1/db1_trigger.o $(OBJDIR)/modules/db1/db1_cron_jobs.o $(OBJDIR)/modules/db1/model_catalog.o $(OBJDIR)/model_catalog_release.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/modules/db1/eval.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
+$(TESTPREFIX)/unit-test-webchat-claude-sessions: $(OBJDIR)/tests/test_webchat_claude_sessions.o $(OBJDIR)/modules/db1/webchat_claude_sessions.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/modules/db1/db1_init.o $(OBJDIR)/modules/db1/db1_write.o $(OBJDIR)/modules/db1/db1_trigger.o $(OBJDIR)/modules/db1/db1_cron_jobs.o $(OBJDIR)/modules/db1/model_catalog.o $(OBJDIR)/model_catalog_release.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/modules/db1/eval.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
                     $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                     $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/platform_random.o \
                     $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o
@@ -1077,8 +1105,8 @@ $(TESTPREFIX)/unit-test-db2: $(OBJDIR)/tests/test_db2.o $(OBJDIR)/db2/db2_init.o
 
 $(TESTPREFIX)/unit-test-pg-prepare-classification: \
                                       $(OBJDIR)/tests/test_pg_prepare_classification.o \
-                                      $(OBJDIR)/tests/aimee_pg_sqlite_shim.o
-	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL) -lsqlite3 -lm
+                                      $(DB2_TEST_BACKEND_OBJ)
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL) $(DB2_TEST_BACKEND_LIB) -lsqlite3 -lm
 
 $(TESTPREFIX)/unit-test-schema-subst: $(OBJDIR)/tests/test_schema_subst.o \
                                       $(OBJDIR)/db2/db_schema.o
@@ -1393,7 +1421,7 @@ $(TESTPREFIX)/unit-test-curator-queue: \
 # operators like <=> do not exist in sqlite, so a shimmed test cannot tell a
 # working vector query from a broken one. This one target swaps the shim for
 # db_postgres.o so the query runs where halfvec actually lives.
-TEST_CORE_OBJS_PG = $(filter-out $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o,$(TEST_CORE_OBJS)) \
+TEST_CORE_OBJS_PG = $(filter-out $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o,$(TEST_CORE_OBJS)) \
                     $(OBJDIR)/db2/db_postgres.o $(OBJDIR)/db2/entity_edges.o
 
 $(TESTPREFIX)/unit-test-pgvec-neardup: $(OBJDIR)/tests/test_pgvec_neardup.o \
@@ -1432,13 +1460,13 @@ $(TESTPREFIX)/unit-test-memory-embed-batch: \
                     $(OBJDIR)/cJSON.o $(OBJDIR)/log.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-rules: $(OBJDIR)/tests/test_rules.o $(DB1_TEST_OBJS) $(DB1_MIGRATED_OBJS) $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+$(TESTPREFIX)/unit-test-rules: $(OBJDIR)/tests/test_rules.o $(DB1_TEST_OBJS) $(DB1_MIGRATED_OBJS) $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                        $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                        $(OBJDIR)/platform_random.o $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-context-discover: $(OBJDIR)/tests/test_context_discover.o $(OBJDIR)/context_discover.o \
-                       $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
+                       $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                        $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/platform_random.o $(OBJDIR)/log.o \
                        $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -1528,7 +1556,7 @@ $(TESTPREFIX)/unit-test-memory: $(CONFIG_ACCESSOR_OBJS) $(OBJDIR)/tests/test_mem
                         $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/tests/support/kb_client_test_stub.o \
                         $(OBJDIR)/posix/memory.o \
                         $(OBJDIR)/modules/memory/memory_logic.o $(OBJDIR)/modules/memory/memory_health.o $(OBJDIR)/db2/fact_lifecycle.o $(OBJDIR)/modules/memory/memory_conflict.o $(OBJDIR)/modules/memory/memory_context.o $(OBJDIR)/modules/memory/memory_assemble.o \
-                        $(OBJDIR)/modules/memory/memory_advanced.o $(OBJDIR)/modules/memory/memory_prospective.o $(OBJDIR)/modules/memory/memory_lifecycle.o $(OBJDIR)/modules/memory/memory_directives.o $(OBJDIR)/modules/memory/memory_maintenance.o $(OBJDIR)/modules/memory/memory_graph.o $(OBJDIR)/modules/memory/memory_graph_fusion.o $(OBJDIR)/modules/memory/memory_scan.o $(OBJDIR)/modules/memory/memory_improve.o $(OBJDIR)/modules/memory/memory_episodes.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
+                        $(OBJDIR)/modules/memory/memory_advanced.o $(OBJDIR)/modules/memory/memory_prospective.o $(OBJDIR)/modules/memory/memory_lifecycle.o $(OBJDIR)/modules/memory/memory_directives.o $(OBJDIR)/modules/memory/memory_maintenance.o $(OBJDIR)/modules/memory/memory_graph.o $(OBJDIR)/modules/memory/memory_graph_fusion.o $(OBJDIR)/modules/memory/memory_scan.o $(OBJDIR)/modules/memory/memory_improve.o $(OBJDIR)/modules/memory/memory_episodes.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
                         $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/modules/vault/runtime_secret.o \
                         $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/platform_random.o \
                         $(OBJDIR)/aimee_home.o \
@@ -1542,7 +1570,7 @@ $(TESTPREFIX)/unit-test-memory: $(CONFIG_ACCESSOR_OBJS) $(OBJDIR)/tests/test_mem
                         $(OBJDIR)/render.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(DB1_MIGRATED_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-tasks: $(OBJDIR)/tests/test_tasks.o $(OBJDIR)/tasks.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+$(TESTPREFIX)/unit-test-tasks: $(OBJDIR)/tests/test_tasks.o $(OBJDIR)/tasks.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                        $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/modules/vault/runtime_secret.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                        $(OBJDIR)/aimee_home.o \
                        $(OBJDIR)/platform_random.o $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) \
@@ -1641,7 +1669,7 @@ $(TESTPREFIX)/unit-test-cli-acp: $(OBJDIR)/tests/test_cli_acp.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-extractors: $(OBJDIR)/tests/test_extractors.o $(OBJDIR)/extractors.o \
-                           $(OBJDIR)/extractors_extra.o $(OBJDIR)/extractors_new_langs.o $(OBJDIR)/code_treesitter.o $(OBJDIR)/index.o $(OBJDIR)/cochange.o $(OBJDIR)/modules/css/css_analyze.o $(OBJDIR)/db2/css_graph.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+                           $(OBJDIR)/extractors_extra.o $(OBJDIR)/extractors_new_langs.o $(OBJDIR)/code_treesitter.o $(OBJDIR)/index.o $(OBJDIR)/cochange.o $(OBJDIR)/modules/css/css_analyze.o $(OBJDIR)/db2/css_graph.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                            $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                            $(OBJDIR)/platform_random.o $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) \
                            $(OBJDIR)/modules/memory/memory_core.o $(OBJDIR)/modules/memory/memory_core_crud.o $(OBJDIR)/modules/memory/memory_core_helpers.o $(OBJDIR)/modules/memory/memory_core_helpers_b.o $(OBJDIR)/modules/memory/memory_core_search.o $(OBJDIR)/modules/memory/memory_core_search_b.o $(OBJDIR)/modules/memory/memory_core_search_c.o $(OBJDIR)/modules/memory/memory_core_scope_embed.o $(OBJDIR)/modules/memory/memory_core_tiers.o $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/kb_payload.o $(OBJDIR)/db2/kb_service_backend.o $(OBJDIR)/db2/kb_service_backend_ingest.o $(OBJDIR)/db2/memory_lifecycle.o $(OBJDIR)/db2/memory_payload.o $(OBJDIR)/db2/memory_promotion.o $(OBJDIR)/db2/memory_query.o $(OBJDIR)/db2/memory_query_bookkeeping.o $(OBJDIR)/db2/memory_entity_graph.o $(OBJDIR)/db2/memory_score_fields.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_scenes.o $(OBJDIR)/db2/memory_briefing.o $(OBJDIR)/db2/memory_health.o $(OBJDIR)/db2/memory_row_mapper_pg.o $(OBJDIR)/db2/memory_relations.o $(OBJDIR)/db2/memory_conflicts.o $(OBJDIR)/db2/vector_index_ops.o $(OBJDIR)/db2/code_index_ops.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/db2/feedback.o $(OBJDIR)/db2/notes.o $(OBJDIR)/db2/anti_patterns.o $(OBJDIR)/db2/curiosity.o $(OBJDIR)/db2/entity_edges.o $(OBJDIR)/db2/entity_profiles.o $(OBJDIR)/db2/epistemic_directives.o $(OBJDIR)/db2/failed_queries.o $(OBJDIR)/db2/kind_lifecycle.o $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o $(OBJDIR)/tests/support/mock_agent_http.o $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/tests/support/kb_client_test_stub.o $(OBJDIR)/posix/memory.o \
@@ -2007,7 +2035,7 @@ $(TESTPREFIX)/unit-test-dashboard: $(OBJDIR)/tests/test_dashboard.o \
                           $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_argspec.o $(OBJDIR)/modules/workspace/workspace_client_diff.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/aimee_client.o $(OBJDIR)/http_uds_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/cli_v1_routes_e.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(DB1_TEST_OBJS) $(DB1_MIGRATED_OBJS) \
                           $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_hardening.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/decision_log.o $(OBJDIR)/db2/kb_audit_worm.o \
                           $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
-                          $(OBJDIR)/yaml.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+                          $(OBJDIR)/yaml.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                           $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/dstr.o \
                           $(OBJDIR)/modules/vault/runtime_secret.o \
                           $(OBJDIR)/tests/support/mock_agent_http.o \
@@ -2127,7 +2155,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 	                                  $(PLATFORM_BASIC_OBJS) $(OBJDIR)/tests/support/log_stub.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(OBJDIR)/tests/delegate_permissions_stub.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+$(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(OBJDIR)/tests/delegate_permissions_stub.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                                $(OBJDIR)/tests/support/delegate_role_policy_stub.o \
                                $(OBJDIR)/tests/support/toolset_stub.o \
                                $(OBJDIR)/tests/support/agent_source_authority_stub.o \
@@ -3481,6 +3509,38 @@ db2-replay: $(TESTPREFIX)/unit-test-bus-db2-process $(OBJDIR)/aimee-module-db2-r
 	@test -n "$$AIMEE_DB2_URL" || { echo "db2-replay requires AIMEE_DB2_URL" >&2; exit 1; }
 	$< $(abspath $(OBJDIR)/aimee-module-db2-replay)
 
+# --- Postgres-backed unit tests -------------------------------------------
+#
+# The sqlite shim translates DB2's SQL rather than executing it, so engine-level
+# behaviour (affected-row counts, scope-macro expansion, postgres-only syntax) is
+# unverified by a normal `make unit-tests`. Point AIMEE_TEST_DB2_TEMPLATE_URL at a
+# postgres database and db2_test_shim_open* clones it per test binary instead of
+# opening sqlite -- the same tests, the real engine.
+#
+#   make db2-test-template AIMEE_TEST_DB2_TEMPLATE_URL=postgresql://.../aimee_test_tpl
+#   make unit-tests-pg     AIMEE_TEST_DB2_TEMPLATE_URL=postgresql://.../aimee_test_tpl
+$(TESTPREFIX)/db2-test-template: $(OBJDIR)/tests/db2_test_template.o \
+                            $(DB2_OBJS) $(OBJDIR)/db2/db_postgres.o \
+                            $(OBJDIR)/log.o $(OBJDIR)/util.o
+	$(TESTLINK_MIN) -o $@ $^ $(PQ_LIB) -lpthread -lm $(EXTRA_L_FLAGS)
+
+.PHONY: db2-test-template
+db2-test-template: $(TESTPREFIX)/db2-test-template
+	@test -n "$$AIMEE_TEST_DB2_TEMPLATE_URL" || \
+	  { echo "db2-test-template requires AIMEE_TEST_DB2_TEMPLATE_URL" >&2; exit 1; }
+	$< "$$AIMEE_TEST_DB2_TEMPLATE_URL" tests/db2_test_reset.sql
+
+# Rebuild the template, then run the suite against it. The template is rebuilt
+# every time on purpose: a schema change that never reached the template would
+# otherwise be tested against a stale copy, which is the failure mode this whole
+# mode exists to close.
+.PHONY: unit-tests-pg
+unit-tests-pg:
+	@test -n "$$AIMEE_TEST_DB2_TEMPLATE_URL" || \
+	  { echo "unit-tests-pg requires AIMEE_TEST_DB2_TEMPLATE_URL" >&2; exit 1; }
+	$(MAKE) db2-test-template
+	$(MAKE) unit-tests
+
 $(OBJDIR)/tests/test_db3_route.o: C_FLAGS += -Imodules/db2/include
 $(OBJDIR)/modules/db2/db3_route.o: C_FLAGS += -Imodules/db2/include
 $(TESTPREFIX)/unit-test-db3-route: $(OBJDIR)/tests/test_db3_route.o \
@@ -3588,7 +3648,7 @@ BUS_MEM_OBJS = $(OBJDIR)/modules/db1/user_memory.o $(OBJDIR)/modules/db1/db.o $(
                $(OBJDIR)/modules/db1/db1_trigger.o $(OBJDIR)/modules/db1/db1_cron_jobs.o \
                $(OBJDIR)/modules/db1/guardrail_events.o \
                $(OBJDIR)/modules/db1/model_catalog.o $(OBJDIR)/model_catalog_release.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/modules/db1/eval.o \
-               $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+               $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o \
                $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o \
                $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o \
@@ -4586,7 +4646,7 @@ $(TESTPREFIX)/unit-test-hud: $(OBJDIR)/tests/test_hud.o $(OBJDIR)/hud.o \
 
 $(TESTPREFIX)/unit-test-history: $(OBJDIR)/tests/test_history.o $(OBJDIR)/history.o $(OBJDIR)/cJSON.o \
                          $(OBJDIR)/util.o $(OBJDIR)/text.o \
-                         $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
+                         $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
                          $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/platform_random.o \
                          $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -5528,7 +5588,7 @@ $(TESTPREFIX)/unit-test-workspace-manifest: $(OBJDIR)/tests/test_workspace_manif
 $(TESTPREFIX)/unit-test-lsp: $(OBJDIR)/tests/test_lsp.o \
                               $(OBJDIR)/modules/lsp/lsp_client.o \
                               $(OBJDIR)/modules/lsp/lsp_manager.o \
-                              $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+                              $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                               $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/modules/config/config_mode.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                               $(OBJDIR)/aimee_home.o \
                               $(OBJDIR)/util.o $(OBJDIR)/text.o \
@@ -6445,7 +6505,7 @@ $(TESTPREFIX)/unit-test-collab-rules: $(OBJDIR)/tests/test_collab_rules.o $(TEST
 
 $(TESTPREFIX)/unit-test-json-fluent: $(OBJDIR)/tests/test_json_fluent.o $(OBJDIR)/json_fluent.o \
                                       $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o \
-                                      $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/cJSON.o
+                                      $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-config: $(OBJDIR)/tests/test_cmd_config.o $(OBJDIR)/cmd_data.o \
@@ -8513,7 +8573,7 @@ $(TESTPREFIX)/unit-test-mcp-client-registry: $(OBJDIR)/tests/test_mcp_client_reg
                      $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/config/config_accessors_0.o $(OBJDIR)/modules/config/config_accessors_1.o $(OBJDIR)/modules/config/config_accessors_2.o $(OBJDIR)/modules/config/config_accessors_3.o $(OBJDIR)/modules/config/config_accessors_4.o $(OBJDIR)/modules/config/config_accessors_5.o $(OBJDIR)/modules/config/config_accessors_6.o $(OBJDIR)/modules/config/config_accessors_7.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/platform_random.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o \
                      $(OBJDIR)/yaml.o \
                      $(OBJDIR)/modules/db1/db.o \
-                     $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
+                     $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o \
                      $(OBJDIR)/log.o \
                      $(OBJDIR)/aimee_home.o \
                      $(OBJDIR)/server/osv_check.o \
@@ -8521,7 +8581,7 @@ $(TESTPREFIX)/unit-test-mcp-client-registry: $(OBJDIR)/tests/test_mcp_client_reg
                      $(OBJDIR)/modules/protocols/mcp/mcp_client_registry.o \
                      $(TEST_MCP_CLIENT_OBJS) \
                      $(TESTPREFIX)/mock-mcp-server
-	$(TESTLINK) -o $@ $(OBJDIR)/tests/test_mcp_client_registry.o $(CONFIG_ACCESSOR_OBJS) $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/protocols/mcp/mcp_tools.o $(OBJDIR)/modules/protocols/mcp/mcp_tool_profile.o $(OBJDIR)/modules/protocols/mcp/mcp_tools_extended.o $(OBJDIR)/modules/protocols/mcp/mcp_skill_tools.o $(OBJDIR)/modules/protocols/mcp/mcp_tools_gateway.o $(OBJDIR)/server/session_search_tool.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/platform_random.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/log.o $(OBJDIR)/server/osv_check.o $(OBJDIR)/modules/vault/runtime_secret.o $(OBJDIR)/modules/protocols/mcp/mcp_client_registry.o $(TEST_MCP_CLIENT_OBJS) $(TEST_L_FLAGS)
+	$(TESTLINK) -o $@ $(OBJDIR)/tests/test_mcp_client_registry.o $(CONFIG_ACCESSOR_OBJS) $(OBJDIR)/modules/config/config_fields.o $(OBJDIR)/modules/protocols/mcp/mcp_tools.o $(OBJDIR)/modules/protocols/mcp/mcp_tool_profile.o $(OBJDIR)/modules/protocols/mcp/mcp_tools_extended.o $(OBJDIR)/modules/protocols/mcp/mcp_skill_tools.o $(OBJDIR)/modules/protocols/mcp/mcp_tools_gateway.o $(OBJDIR)/server/session_search_tool.o $(OBJDIR)/modules/config/config.o $(OBJDIR)/modules/config/config_sections.o $(OBJDIR)/modules/config/config_database.o $(OBJDIR)/modules/config/config_learning.o $(OBJDIR)/modules/config/config_memory.o $(OBJDIR)/modules/config/config_charter.o $(OBJDIR)/modules/config/config_trigger.o $(OBJDIR)/modules/config/config_kb_maintenance.o $(OBJDIR)/modules/config/config_kb_curator.o $(OBJDIR)/modules/config/config_server_api.o $(OBJDIR)/modules/config/config_skills.o $(OBJDIR)/platform_random.o $(OBJDIR)/modules/config/config_save.o $(OBJDIR)/modules/config/config_elements.o $(OBJDIR)/modules/config/config_econ.o $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/modules/db1/db.o $(OBJDIR)/modules/db1/db_schema.o $(OBJDIR)/modules/db1/maintenance.o $(DB2_TEST_BACKEND_OBJ) $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/log.o $(OBJDIR)/server/osv_check.o $(OBJDIR)/modules/vault/runtime_secret.o $(OBJDIR)/modules/protocols/mcp/mcp_client_registry.o $(TEST_MCP_CLIENT_OBJS) $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-agent-request-build: $(OBJDIR)/tests/test_agent_request_build.o \
                                        $(OBJDIR)/server/agent_request_build.o \

--- a/src/tests/db2_test_reset.sql
+++ b/src/tests/db2_test_reset.sql
@@ -1,0 +1,60 @@
+CREATE SCHEMA IF NOT EXISTS aimee_test_seed;
+
+-- Snapshot every public table that carries rows right after the schema is
+-- applied. Those rows ARE the baseline a test expects to find (kind_lifecycle,
+-- tool_registry, kb_meta and friends are seeded by schema.sql), so the per-test
+-- reset has to put them back after truncating rather than leave the table bare.
+CREATE OR REPLACE FUNCTION aimee_test_seed_capture() RETURNS int AS $$
+DECLARE
+   r        record;
+   nonempty boolean;
+   n        int := 0;
+BEGIN
+   FOR r IN SELECT tablename AS t FROM pg_tables WHERE schemaname = 'public' LOOP
+      EXECUTE format('SELECT EXISTS (SELECT 1 FROM public.%I)', r.t) INTO nonempty;
+      IF NOT nonempty THEN
+         CONTINUE;
+      END IF;
+      EXECUTE format('DROP TABLE IF EXISTS aimee_test_seed.%I', r.t);
+      EXECUTE format('CREATE TABLE aimee_test_seed.%I AS SELECT * FROM public.%I', r.t, r.t);
+      n := n + 1;
+   END LOOP;
+   RETURN n;
+END $$ LANGUAGE plpgsql;
+
+-- Return the database to the freshly-applied-schema state.
+--
+-- Only non-empty tables are touched: TRUNCATE takes an ACCESS EXCLUSIVE lock and
+-- does file work per relation, so blanket-truncating all 217 costs ~250 ms while
+-- a typical test dirties a handful and resets in single-digit ms.
+--
+-- session_replication_role = replica suppresses user triggers for the duration.
+-- The schema installs db3_reject_vector_truncate on the eight vector tables to
+-- stop a production operator truncating an index out from under its rebuild;
+-- that guard is correct and stays, but a test fixture resetting its own scratch
+-- database is exactly the case it is not aimed at.
+CREATE OR REPLACE FUNCTION aimee_test_reset() RETURNS void AS $$
+DECLARE
+   r        record;
+   nonempty boolean;
+   victims  text[] := '{}';
+BEGIN
+   PERFORM set_config('session_replication_role', 'replica', true);
+
+   FOR r IN SELECT tablename AS t FROM pg_tables WHERE schemaname = 'public' LOOP
+      EXECUTE format('SELECT EXISTS (SELECT 1 FROM public.%I)', r.t) INTO nonempty;
+      IF nonempty THEN
+         victims := victims || format('public.%I', r.t);
+      END IF;
+   END LOOP;
+
+   IF array_length(victims, 1) > 0 THEN
+      EXECUTE format('TRUNCATE %s RESTART IDENTITY CASCADE', array_to_string(victims, ', '));
+   END IF;
+
+   FOR r IN SELECT tablename AS t FROM pg_tables WHERE schemaname = 'aimee_test_seed' LOOP
+      EXECUTE format('INSERT INTO public.%I SELECT * FROM aimee_test_seed.%I', r.t, r.t);
+   END LOOP;
+
+   PERFORM set_config('session_replication_role', 'origin', true);
+END $$ LANGUAGE plpgsql;

--- a/src/tests/db2_test_template.c
+++ b/src/tests/db2_test_template.c
@@ -1,0 +1,166 @@
+/* db2_test_template.c: build the Postgres template database the DB2 test shim
+ * clones from (see db2_test_shim.c's postgres-backed mode).
+ *
+ * Applying the schema costs the better part of a second and only has to happen
+ * once per run, not once per test binary — so it happens here, and every test
+ * process gets a cheap `CREATE DATABASE ... TEMPLATE` copy instead.
+ *
+ *   usage: db2-test-template <template-url> <reset-sql-path>
+ *
+ * Drops and recreates <template-url>'s database, applies the DB2 schema to it,
+ * installs the reset helpers from <reset-sql-path>, then snapshots whatever rows
+ * the schema seeded so aimee_test_reset() can restore them between tests. */
+#include "aimee.h"
+#include "config_embedder_dims.h"
+#include "modules/db2/c/db2.h"
+#include "modules/db2/c/db_postgres.h"
+#include "modules/db2/c/lifecycle.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TPL_ERRBUF 1024
+
+/* Split scheme://[user@]host[:port]/dbname[?params] the same way the shim does. */
+static int split_url(const char *url, char *prefix, size_t prefix_len, char *dbname,
+                     size_t dbname_len, char *suffix, size_t suffix_len)
+{
+   const char *scheme = strstr(url, "://");
+   if (!scheme)
+      return -1;
+   const char *slash = strchr(scheme + 3, '/');
+   if (!slash || !slash[1])
+      return -1;
+   const char *q = strchr(slash + 1, '?');
+   size_t plen = (size_t)(slash - url) + 1;
+   size_t dlen = q ? (size_t)(q - slash - 1) : strlen(slash + 1);
+   if (plen >= prefix_len || dlen >= dbname_len)
+      return -1;
+   memcpy(prefix, url, plen);
+   prefix[plen] = '\0';
+   memcpy(dbname, slash + 1, dlen);
+   dbname[dlen] = '\0';
+   snprintf(suffix, suffix_len, "%s", q ? q : "");
+   return 0;
+}
+
+static int admin_exec(const char *url, const char *sql)
+{
+   char err[TPL_ERRBUF] = "";
+   void *c = aimee_pg_open(url, err, sizeof(err));
+   if (!c)
+   {
+      fprintf(stderr, "db2-test-template: connect failed: %s\n", err);
+      return -1;
+   }
+   int rc = aimee_pg_exec(c, sql, err, sizeof(err));
+   if (rc != 0)
+      fprintf(stderr, "db2-test-template: %s\n  failed: %s\n", sql, err);
+   aimee_pg_close(c);
+   return rc;
+}
+
+static char *slurp(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long n = ftell(f);
+   if (n < 0 || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = (char *)malloc((size_t)n + 1);
+   if (buf && fread(buf, 1, (size_t)n, f) == (size_t)n)
+      buf[n] = '\0';
+   else
+   {
+      free(buf);
+      buf = NULL;
+   }
+   fclose(f);
+   return buf;
+}
+
+int main(int argc, char **argv)
+{
+   if (argc != 3)
+   {
+      fprintf(stderr, "usage: %s <template-url> <reset-sql-path>\n", argv[0]);
+      return 2;
+   }
+   const char *url = argv[1];
+   const char *reset_path = argv[2];
+
+   char prefix[1024], dbname[256], suffix[256];
+   if (split_url(url, prefix, sizeof(prefix), dbname, sizeof(dbname), suffix, sizeof(suffix)) != 0)
+   {
+      fprintf(stderr, "db2-test-template: cannot parse url (%s)\n", url);
+      return 2;
+   }
+
+   char *reset_sql = slurp(reset_path);
+   if (!reset_sql)
+   {
+      fprintf(stderr, "db2-test-template: cannot read %s\n", reset_path);
+      return 2;
+   }
+
+   char admin_url[1400];
+   snprintf(admin_url, sizeof(admin_url), "%spostgres%s", prefix, suffix);
+
+   /* Rebuild from scratch: a template carrying a previous run's leftovers would
+    * hand every test binary a database that is not the freshly-seeded state the
+    * reset restores back to. FORCE evicts clones still connected from a killed run. */
+   char sql[768];
+   snprintf(sql, sizeof(sql), "DROP DATABASE IF EXISTS \"%s\" WITH (FORCE)", dbname);
+   if (admin_exec(admin_url, sql) != 0)
+   {
+      free(reset_sql);
+      return 1;
+   }
+   snprintf(sql, sizeof(sql), "CREATE DATABASE \"%s\"", dbname);
+   if (admin_exec(admin_url, sql) != 0)
+   {
+      free(reset_sql);
+      return 1;
+   }
+
+   /* db2_init applies the schema, including the rows schema.sql seeds. */
+   db2_set_embedding_dim_default(CONFIG_EMBEDDER_DIMS_DEFAULT);
+   db2_set_embedding_dim(CONFIG_EMBEDDER_DIMS_DEFAULT);
+   if (db2_init(url) != 0)
+   {
+      fprintf(stderr, "db2-test-template: db2_init failed against %s\n", url);
+      free(reset_sql);
+      return 1;
+    }
+
+   char err[TPL_ERRBUF] = "";
+   int rc = aimee_pg_exec(db2_conn(), reset_sql, err, sizeof(err));
+   free(reset_sql);
+   if (rc != 0)
+   {
+      fprintf(stderr, "db2-test-template: installing reset helpers failed: %s\n", err);
+      db2_shutdown();
+      return 1;
+   }
+
+   if (aimee_pg_exec(db2_conn(), "SELECT aimee_test_seed_capture()", err, sizeof(err)) != 0)
+   {
+      fprintf(stderr, "db2-test-template: seed capture failed: %s\n", err);
+      db2_shutdown();
+      return 1;
+   }
+
+   db2_shutdown();
+   printf("db2-test-template: %s ready\n", dbname);
+   return 0;
+}

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -905,6 +905,9 @@ static void test_queue_code_units_skipped_without_synthesis_endpoint(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_code_unit"))
+      return 0;
+
    printf("curator_code_unit:\n");
 
    test_force_curator_gate_off();

--- a/src/tests/test_curator_contradictions.c
+++ b/src/tests/test_curator_contradictions.c
@@ -65,6 +65,9 @@ static void test_contradiction(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_contradictions"))
+      return 0;
+
    test_empty();
    test_contradiction();
    printf("curator_contradictions: all tests passed\n");

--- a/src/tests/test_curator_index_claims.c
+++ b/src/tests/test_curator_index_claims.c
@@ -70,6 +70,9 @@ static void test_seeded_commits(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_index_claims"))
+      return 0;
+
    db2_test_shim_open();
    int rc = kb_curator_index_claims_one(NULL);
    assert(rc == 0);

--- a/src/tests/test_curator_index_code_unit.c
+++ b/src/tests/test_curator_index_code_unit.c
@@ -72,6 +72,9 @@ static void test_seeded_commits(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_index_code_unit"))
+      return 0;
+
    db2_test_shim_open();
    int rc = kb_curator_index_code_unit_one(NULL);
    assert(rc == 0);

--- a/src/tests/test_curator_index_narrative.c
+++ b/src/tests/test_curator_index_narrative.c
@@ -67,6 +67,9 @@ static void test_seeded_commits(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_index_narrative"))
+      return 0;
+
    db2_test_shim_open();
    int rc = kb_curator_index_narrative_one(NULL);
    assert(rc == 0);

--- a/src/tests/test_curator_invalidate.c
+++ b/src/tests/test_curator_invalidate.c
@@ -21,6 +21,9 @@ static int scalar(sqlite3 *db, const char *sql)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_invalidate"))
+      return 0;
+
    db2_test_shim_open();
    sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
    assert(db != NULL);

--- a/src/tests/test_curator_link_artifacts.c
+++ b/src/tests/test_curator_link_artifacts.c
@@ -188,6 +188,9 @@ static void test_semantic_below_threshold(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_link_artifacts"))
+      return 0;
+
    test_empty();
    test_seeded_links();
    test_normalized_links();

--- a/src/tests/test_curator_pipeline.c
+++ b/src/tests/test_curator_pipeline.c
@@ -78,6 +78,9 @@ static void seed(sqlite3 *db, const char *sql)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_pipeline"))
+      return 0;
+
    db2_test_shim_open();
    sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
    assert(db != NULL);

--- a/src/tests/test_curator_promote.c
+++ b/src/tests/test_curator_promote.c
@@ -79,6 +79,9 @@ static void test_pick_seeded(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_promote"))
+      return 0;
+
    test_scope_lattice();
    test_drain_graceful();
    test_pick_seeded();

--- a/src/tests/test_curator_queue.c
+++ b/src/tests/test_curator_queue.c
@@ -381,6 +381,9 @@ static void test_only_current_document_generation_queues(sqlite3 *db)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_queue"))
+      return 0;
+
    /* Deterministic config: HOME with no aimee.yaml -> config_load (called inside
     * the queue) returns built-in defaults (extract_docs default-ON). */
    platform_setenv("HOME", "/tmp");

--- a/src/tests/test_curator_resolve_entities.c
+++ b/src/tests/test_curator_resolve_entities.c
@@ -215,6 +215,9 @@ static void test_resolve_cross_scope(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_resolve_entities"))
+      return 0;
+
    db2_test_shim_open();
    test_embed_text();
    test_point_id();

--- a/src/tests/test_curator_serve.c
+++ b/src/tests/test_curator_serve.c
@@ -86,6 +86,9 @@ static void test_contradictions(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_serve"))
+      return 0;
+
    test_implements();
    test_synthesize();
    test_contradictions();

--- a/src/tests/test_curator_synthesize.c
+++ b/src/tests/test_curator_synthesize.c
@@ -105,6 +105,9 @@ static void test_restore_fragment_record(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_synthesize"))
+      return 0;
+
    test_gated_empty();
    test_pick_seeded();
    test_restore_fragment_record();

--- a/src/tests/test_curator_version.c
+++ b/src/tests/test_curator_version.c
@@ -61,6 +61,9 @@ static void clear_extract_jobs(sqlite3 *db)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("curator_version"))
+      return 0;
+
    /* 1. first observation records baselines, no replay. */
    sqlite3 *db = open_db();
    seed_corpus(db);

--- a/src/tests/test_kb_releases_db.c
+++ b/src/tests/test_kb_releases_db.c
@@ -190,6 +190,9 @@ static void test_release_membership(void)
 
 int main(void)
 {
+   if (db2_test_shim_skip_on_postgres("kb_releases_db"))
+      return 0;
+
    printf("kb_releases_db:\n");
    test_create_read();
    test_promote_activates();

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -257,6 +257,41 @@ static void test_touch_memory(void)
    teardown();
 }
 
+static void test_touch_many(void)
+{
+   setup();
+   memory_t a, b, c;
+   memory_insert(TIER_L2, KIND_FACT, "batch-a", "alpha", 0.8, "s1", &a);
+   memory_insert(TIER_L2, KIND_FACT, "batch-b", "beta", 0.8, "s1", &b);
+   memory_insert(TIER_L2, KIND_FACT, "batch-c", "gamma", 0.8, "s1", &c);
+
+   /* The recall path collects every memory it injected and touches them in one
+    * call, so the batch form must bump each id exactly once -- ids it cannot
+    * address (0 / negative) are skipped rather than aborting the batch. */
+   int64_t ids[] = {a.id, 0, b.id, -1};
+   assert(memory_touch_many(ids, 4) == 2);
+
+   memory_t got;
+   memory_get(a.id, &got);
+   assert(got.use_count >= 2);
+   assert(got.last_used_at[0] != '\0');
+   memory_get(b.id, &got);
+   assert(got.use_count >= 2);
+
+   /* An id absent from the batch must be left alone. */
+   memory_get(c.id, &got);
+   assert(got.use_count == 1);
+
+   /* Empty and degenerate batches are a no-op, not an error: a turn that
+    * injected nothing must not look like a failed write. */
+   assert(memory_touch_many(NULL, 0) == 0);
+   assert(memory_touch_many(ids, 0) == 0);
+   int64_t none[] = {0, -5};
+   assert(memory_touch_many(none, 2) == 0);
+
+   teardown();
+}
+
 static void test_promote(void)
 {
    setup();
@@ -2551,6 +2586,7 @@ int main(void)
    test_insert_merge();
    test_near_duplicate_numeric_keys_remain_distinct();
    test_touch_memory();
+   test_touch_many();
    test_promote();
    test_memory_promote_uses_calibration_profile();
    test_memory_promote_calibration_ab_slot();

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include "cJSON.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -873,9 +874,16 @@ static void test_semantic_profile_duplicate_keeps_single_active_entry(void)
    assert(first.id == second.id);
 
    char dup_err[128] = "";
-   aimee_pg_stmt_t *dup_st = aimee_pg_prepare(
-       db2_conn(), "SELECT COUNT(*), use_count, content FROM memories WHERE id = ?1", dup_err,
-       sizeof(dup_err));
+   /* MAX() rather than bare columns beside COUNT(*): sqlite tolerates selecting
+    * ungrouped columns alongside an aggregate, postgres rejects it outright
+    * ("must appear in the GROUP BY clause"). id is the primary key, so the
+    * aggregate is over at most one row and MAX() reads back exactly that row's
+    * value -- same assertion, valid SQL on both engines. */
+   aimee_pg_stmt_t *dup_st =
+       aimee_pg_prepare(db2_conn(),
+                        "SELECT COUNT(*), COALESCE(MAX(use_count), 0),"
+                        " COALESCE(MAX(content), '') FROM memories WHERE id = ?1",
+                        dup_err, sizeof(dup_err));
    assert(dup_st != NULL);
    aimee_pg_bind_int64(dup_st, "?1", first.id);
    assert(aimee_pg_step(dup_st, dup_err, sizeof(dup_err)) == AIMEE_PG_ROW);
@@ -2380,13 +2388,45 @@ static void test_audit_provenance_emit_captures_version(void)
    char read_id[64] = "", payload[8192] = "";
    assert(db2_demotion_retrieval_event_by_turn("p2-emit-turn", read_id, sizeof read_id, payload,
                                                sizeof payload) == 1);
-   assert(strstr(payload, "\"surfaced_items\"") != NULL);
-   char id_needle[48];
-   snprintf(id_needle, sizeof id_needle, "\"id\":%lld", (long long)id);
-   assert(strstr(payload, id_needle) != NULL);
-   assert(strstr(payload, "\"v\":\"") != NULL); /* a point-in-time version was captured */
-   /* back-compat: surfaced_ids is still present. */
-   assert(strstr(payload, "\"surfaced_ids\"") != NULL);
+   /* Parse rather than substring-match. artifacts.payload is jsonb, and postgres
+    * normalises jsonb on the way back out -- it reorders keys and prints a space
+    * after every colon, so a needle like "\"id\":7" never matches what the server
+    * returns. Against the sqlite shim, where the column is plain text holding the
+    * exact bytes cJSON emitted, the same needle matched; the assertion was
+    * testing the serializer's formatting rather than the payload's content. */
+   cJSON *doc = cJSON_Parse(payload);
+   assert(doc != NULL);
+
+   cJSON *items = cJSON_GetObjectItemCaseSensitive(doc, "surfaced_items");
+   assert(cJSON_IsArray(items));
+
+   int seen_id = 0, seen_version = 0;
+   for (int i = 0; i < cJSON_GetArraySize(items); i++)
+   {
+      cJSON *it = cJSON_GetArrayItem(items, i);
+      cJSON *idj = cJSON_GetObjectItemCaseSensitive(it, "id");
+      if (!cJSON_IsNumber(idj) || (int64_t)idj->valuedouble != id)
+         continue;
+      seen_id = 1;
+      cJSON *v = cJSON_GetObjectItemCaseSensitive(it, "v");
+      /* a point-in-time version was captured */
+      seen_version = cJSON_IsString(v) && v->valuestring && v->valuestring[0];
+   }
+   assert(seen_id);
+   assert(seen_version);
+
+   /* back-compat: surfaced_ids is still present, and still carries the id. */
+   cJSON *ids_json = cJSON_GetObjectItemCaseSensitive(doc, "surfaced_ids");
+   assert(cJSON_IsArray(ids_json));
+   int seen_back_compat_id = 0;
+   for (int i = 0; i < cJSON_GetArraySize(ids_json); i++)
+   {
+      cJSON *n = cJSON_GetArrayItem(ids_json, i);
+      if (cJSON_IsNumber(n) && (int64_t)n->valuedouble == id)
+         seen_back_compat_id = 1;
+   }
+   assert(seen_back_compat_id);
+   cJSON_Delete(doc);
 
    teardown();
    printf("  audit provenance emit captures point-in-time version OK\n");

--- a/src/tests/test_memory_assemble_util.c
+++ b/src/tests/test_memory_assemble_util.c
@@ -3,6 +3,7 @@
  * Header is static inline → this test links nothing extra. */
 #include "modules/memory/memory_assemble_util.h"
 #include <assert.h>
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -111,11 +112,77 @@ static void test_near_duplicate(void)
    printf("near_duplicate OK\n");
 }
 
+static void test_recency_curve(void)
+{
+   /* Inside the plateau nothing decays: a fact three months old must not be
+    * outranked on age alone, which is the whole point of the flat zone. */
+   assert(context_recency_from_age_days(0.0) == 1.0);
+   assert(context_recency_from_age_days(1.0) == 1.0);
+   assert(context_recency_from_age_days(MEMORY_RECENCY_PLATEAU_DAYS) == 1.0);
+
+   /* An unknown age is not evidence of staleness. */
+   assert(context_recency_from_age_days(-1.0) == 1.0);
+
+   /* Exactly one half-life past the plateau halves the factor. */
+   double half =
+       context_recency_from_age_days(MEMORY_RECENCY_PLATEAU_DAYS + MEMORY_RECENCY_HALFLIFE_DAYS);
+   assert(fabs(half - 0.5) < 1e-9);
+
+   /* Monotonically decreasing past the plateau, and never zero -- an old fact
+    * sinks but stays reachable. */
+   double prev = 1.0;
+   for (double d = MEMORY_RECENCY_PLATEAU_DAYS + 1.0; d < 8000.0; d += 137.0)
+   {
+      double r = context_recency_from_age_days(d);
+      assert(r < prev);
+      assert(r > 0.0);
+      prev = r;
+   }
+
+   /* The tail is deliberately gentle: a year past the plateau must still be
+    * worth more than half its original score, or correct old facts get buried
+    * under fresher but less relevant ones. */
+   assert(context_recency_from_age_days(MEMORY_RECENCY_PLATEAU_DAYS + 365.0) > 0.8);
+
+   printf("recency_curve OK\n");
+}
+
+static void test_apply_recency(void)
+{
+   /* recency_weight 0 means the intent does not care about age; the score must
+    * come through untouched rather than picking up a near-1.0 multiplier. */
+   assert(context_apply_recency(0.75, 0.25, 0.0) == 0.75);
+   assert(context_apply_recency(0.75, 0.25, -1.0) == 0.75);
+
+   /* Full weight applies the whole decay. */
+   assert(fabs(context_apply_recency(0.8, 0.5, 1.0) - 0.4) < 1e-9);
+
+   /* Out-of-range weights clamp rather than amplifying the decay. */
+   assert(fabs(context_apply_recency(0.8, 0.5, 4.0) - 0.4) < 1e-9);
+
+   /* Partial weight interpolates: half weight on a 0.5 factor gives 0.75x. */
+   assert(fabs(context_apply_recency(1.0, 0.5, 0.5) - 0.75) < 1e-9);
+
+   /* A fresh candidate is never penalised at any weight. */
+   for (double w = 0.0; w <= 1.0; w += 0.1)
+      assert(fabs(context_apply_recency(0.6, 1.0, w) - 0.6) < 1e-9);
+
+   /* Ordering: given equal base scores, the fresher candidate wins whenever
+    * recency actually carries weight. */
+   double fresh = context_apply_recency(0.5, context_recency_from_age_days(10.0), 0.7);
+   double stale = context_apply_recency(0.5, context_recency_from_age_days(4000.0), 0.7);
+   assert(fresh > stale);
+
+   printf("apply_recency OK\n");
+}
+
 int main(void)
 {
    test_xml_escape();
    test_xml_tag_for_header();
    test_near_duplicate();
+   test_recency_curve();
+   test_apply_recency();
    printf("memory_assemble_util: all tests passed\n");
    return 0;
 }

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -15275,7 +15275,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 678
+          "line": 683
         }
       ],
       "signature": "int db2_memory_aggregate ( const char * entity_seed , const char * keyword , memory_t * out , int max , int * truncated_out )",
@@ -15290,7 +15290,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 1026
+          "line": 1038
         }
       ],
       "signature": "void db2_memory_alias_insert ( int64_t memory_id , const char * alias , double weight )",
@@ -15305,7 +15305,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 951
+          "line": 963
         }
       ],
       "signature": "void db2_memory_aliases_delete_for_memory ( int64_t memory_id )",
@@ -15320,7 +15320,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 811
+          "line": 823
         }
       ],
       "signature": "int db2_memory_alloc_all_ids ( int64_t * * out_ids , size_t * out_count )",
@@ -15413,7 +15413,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 1022
+          "line": 1034
         }
       ],
       "signature": "void db2_memory_chunk_upsert ( int64_t memory_id , int chunk_index , const char * chunk_text )",
@@ -15428,7 +15428,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 948
+          "line": 960
         }
       ],
       "signature": "void db2_memory_chunks_delete_for_memory ( int64_t memory_id )",
@@ -15443,7 +15443,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 1018
+          "line": 1030
         }
       ],
       "signature": "int db2_memory_chunks_list ( int64_t memory_id , db2_memory_chunk_row_t * out , int max )",
@@ -15504,7 +15504,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 630
+          "line": 635
         }
       ],
       "signature": "int db2_memory_collect_relation_token_matches ( const char * token , int limit , memory_t * out , int max )",
@@ -15649,7 +15649,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 854
+          "line": 866
         }
       ],
       "signature": "void db2_memory_coref_audit_insert ( int64_t memory_id , const char * session_id , const char * outcome , const char * entity , const char * mode , double confidence )",
@@ -15701,7 +15701,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 800
+          "line": 812
         }
       ],
       "signature": "int db2_memory_count_by_tier_kind ( db2_memory_tier_kind_count_t * out , int max )",
@@ -15717,7 +15717,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 569
+          "line": 574
         }
       ],
       "review": {
@@ -15738,7 +15738,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 555
+          "line": 560
         }
       ],
       "review": {
@@ -15759,7 +15759,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 572
+          "line": 577
         }
       ],
       "review": {
@@ -15781,7 +15781,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 577
+          "line": 582
         }
       ],
       "review": {
@@ -15853,7 +15853,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 685
+          "line": 690
         }
       ],
       "signature": "int db2_memory_dedupe_by_key ( int dry_run )",
@@ -15868,7 +15868,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 706
+          "line": 718
         }
       ],
       "signature": "int db2_memory_delete_row ( int64_t memory_id )",
@@ -15883,7 +15883,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 824
+          "line": 836
         }
       ],
       "signature": "void db2_memory_entities_delete_for_memory ( int64_t memory_id )",
@@ -15900,7 +15900,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 1008
+          "line": 1020
         }
       ],
       "signature": "int db2_memory_entities_list_weighted ( int64_t memory_id , db2_memory_entity_row_t * out , int max )",
@@ -15917,7 +15917,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 815
+          "line": 827
         }
       ],
       "signature": "void db2_memory_entity_insert ( int64_t memory_id , const char * entity , const char * role , double weight )",
@@ -15963,7 +15963,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 885
+          "line": 897
         }
       ],
       "signature": "int64_t db2_memory_episode_insert ( int64_t memory_id , const char * episode_key , const char * episode_text , const char * source_session , const char * reference_time )",
@@ -15978,7 +15978,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 1031
+          "line": 1043
         }
       ],
       "signature": "int db2_memory_episode_unit_ids_for_session ( int64_t memory_id , const char * source_session , int64_t * out , int max )",
@@ -15993,7 +15993,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 1037
+          "line": 1049
         }
       ],
       "signature": "int db2_memory_episode_unit_ids_supersedes ( int64_t source_memory_id , int64_t * out , int max )",
@@ -16008,7 +16008,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 903
+          "line": 915
         }
       ],
       "signature": "void db2_memory_episodes_delete_for_memory ( int64_t memory_id )",
@@ -16039,7 +16039,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 940
+          "line": 952
         }
       ],
       "signature": "void db2_memory_event_frame_insert ( int64_t memory_id , const char * actor , const char * action , const char * object , const char * location , const char * event_time , const char * evidence_kind )",
@@ -16054,7 +16054,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 945
+          "line": 957
         }
       ],
       "signature": "void db2_memory_event_frames_delete_for_memory ( int64_t memory_id )",
@@ -16070,7 +16070,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 936
+          "line": 948
         }
       ],
       "signature": "int db2_memory_event_frames_list ( int64_t memory_id , db2_memory_event_frame_row_t * out , int max )",
@@ -16136,7 +16136,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 644
+          "line": 649
         }
       ],
       "signature": "int db2_memory_filter_archived_ids ( const int64_t * ids , int n , int64_t * out , int max )",
@@ -16151,7 +16151,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 743
+          "line": 755
         }
       ],
       "signature": "int db2_memory_find_conflicting_l2 ( const char * key , const char * content , double * existing_confidence_out )",
@@ -16184,7 +16184,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 750
+          "line": 762
         }
       ],
       "review": {
@@ -16212,7 +16212,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 692
+          "line": 704
         }
       ],
       "signature": "int db2_memory_get ( int64_t memory_id , memory_t * out )",
@@ -16228,7 +16228,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 892
+          "line": 904
         }
       ],
       "signature": "int db2_memory_get_by_unit_id ( int64_t unit_id , memory_t * out )",
@@ -16319,7 +16319,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 983
+          "line": 995
         }
       ],
       "signature": "int db2_memory_get_session_kinds ( int64_t memory_id , char * session_out , int session_len , char * kind_out , int kind_len , char * explicit_kind_out , int explicit_kind_len )",
@@ -16334,7 +16334,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 839
+          "line": 851
         }
       ],
       "signature": "int db2_memory_get_source_session ( int64_t memory_id , char * out , int out_len )",
@@ -16684,7 +16684,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 755
+          "line": 767
         }
       ],
       "review": {
@@ -16705,7 +16705,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 511
+          "line": 516
         }
       ],
       "signature": "int db2_memory_l1_session_clusters ( const char * excluded_source , int min_count , db2_memory_l1_cluster_row_t * rows , int max )",
@@ -16720,7 +16720,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 533
+          "line": 538
         }
       ],
       "signature": "int db2_memory_l1_session_content ( const char * session_id , db2_memory_content_row_t * rows , int max )",
@@ -16735,7 +16735,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 522
+          "line": 527
         }
       ],
       "signature": "int db2_memory_l1_session_created_at ( const char * session_id , db2_memory_created_at_row_t * rows , int max )",
@@ -16750,7 +16750,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 598
+          "line": 603
         }
       ],
       "signature": "int db2_memory_l2_cross_key_pairs ( int max_pairs , db2_memory_pair_row_t * out , int max )",
@@ -16765,7 +16765,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 603
+          "line": 608
         }
       ],
       "signature": "int db2_memory_l2_fact_vs_decision_pairs ( int max_pairs , db2_memory_pair_row_t * out , int max )",
@@ -16780,7 +16780,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 566
+          "line": 571
         }
       ],
       "signature": "int db2_memory_last_retro_scan ( char * out , int out_len )",
@@ -16917,7 +16917,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 718
+          "line": 730
         }
       ],
       "signature": "int db2_memory_lineage_get ( const char * object_type , int64_t object_id , memory_lineage_t * out , int max )",
@@ -16932,7 +16932,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 611
+          "line": 616
         }
       ],
       "signature": "int64_t db2_memory_lineage_insert ( const char * object_type , int64_t object_id , const char * source_kind , const char * source_ref , double confidence )",
@@ -16993,7 +16993,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 964
+          "line": 976
         }
       ],
       "signature": "int db2_memory_links_with_targets ( int64_t memory_id , db2_memory_link_target_row_t * out , int max )",
@@ -17009,7 +17009,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 725
+          "line": 737
         }
       ],
       "signature": "int db2_memory_list ( const char * tier , const char * kind , int hide_archived , int limit , memory_t * out , int max )",
@@ -17055,7 +17055,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 497
+          "line": 502
         }
       ],
       "signature": "int db2_memory_list_candidates ( db2_memory_cand_filter_t filter , db2_memory_cand_row_t * rows , int max )",
@@ -17115,7 +17115,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 1048
+          "line": 1060
         }
       ],
       "signature": "int db2_memory_list_id_key_content ( int limit , db2_memory_id_key_content_row_t * out , int max )",
@@ -17191,7 +17191,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 850
+          "line": 862
         }
       ],
       "signature": "int db2_memory_list_prior_in_session ( const char * session_id , int64_t before_id , int limit , db2_memory_prior_row_t * out , int max )",
@@ -17207,7 +17207,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 549
+          "line": 554
         }
       ],
       "signature": "int db2_memory_list_recall_section ( db2_memory_recall_section_t section , db2_memory_cand_row_t * rows , int max )",
@@ -17238,7 +17238,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 771
+          "line": 783
         }
       ],
       "signature": "int db2_memory_list_session_scope_priority ( memory_t * out , int max )",
@@ -17254,7 +17254,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 779
+          "line": 791
         }
       ],
       "signature": "int db2_memory_list_session_scope_priority_like ( const char * pattern , memory_t * out , int max )",
@@ -17299,7 +17299,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 737
+          "line": 749
         }
       ],
       "signature": "int db2_memory_load_eval_corpus ( memory_t * out , int max , char * label_out , size_t label_len )",
@@ -17344,7 +17344,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 873
+          "line": 885
         }
       ],
       "signature": "void db2_memory_lookup_primary_entity ( int64_t memory_id , char * out , int out_len )",
@@ -17359,7 +17359,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 878
+          "line": 890
         }
       ],
       "signature": "void db2_memory_lookup_time_bounds ( int64_t memory_id , char * valid_at_out , int valid_len , char * invalid_at_out , int invalid_len )",
@@ -17432,7 +17432,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 835
+          "line": 847
         }
       ],
       "signature": "void db2_memory_negation_tokens_update ( int64_t memory_id , const char * new_tokens )",
@@ -17447,7 +17447,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 831
+          "line": 843
         }
       ],
       "signature": "int db2_memory_parse_created_date ( int64_t memory_id , int * year , int * month , int * day )",
@@ -17462,7 +17462,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 670
+          "line": 675
         }
       ],
       "signature": "int db2_memory_pick_first_temporal_ref ( int64_t memory_id , char * out , int out_len )",
@@ -17794,7 +17794,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 699
+          "line": 711
         }
       ],
       "review": {
@@ -17852,7 +17852,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 582
+          "line": 587
         }
       ],
       "signature": "int db2_memory_prune_orphaned_l0 ( void )",
@@ -17867,7 +17867,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 607
+          "line": 612
         }
       ],
       "signature": "void db2_memory_record_retro_scan_marker ( const char * ts )",
@@ -17882,7 +17882,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 713
+          "line": 725
         }
       ],
       "signature": "int db2_memory_reject ( int64_t memory_id , const char * reason )",
@@ -17944,7 +17944,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 900
+          "line": 912
         }
       ],
       "signature": "void db2_memory_relations_delete_for_memory ( int64_t memory_id )",
@@ -18287,7 +18287,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 786
+          "line": 798
         }
       ],
       "signature": "int db2_memory_search_facts_patterns_by_keyword ( const char * keyword , memory_t * out , int max )",
@@ -18338,7 +18338,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 560
+          "line": 565
         }
       ],
       "review": {
@@ -18359,7 +18359,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 662
+          "line": 667
         }
       ],
       "signature": "int db2_memory_session_neighbors_after ( const char * session_id , int64_t after_id , int limit , memory_t * out , int max )",
@@ -18374,7 +18374,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 657
+          "line": 662
         }
       ],
       "signature": "int db2_memory_session_neighbors_before ( const char * session_id , int64_t before_id , int limit , memory_t * out , int max )",
@@ -18497,7 +18497,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 922
+          "line": 934
         }
       ],
       "signature": "void db2_memory_summaries_delete_for_memory ( int64_t memory_id )",
@@ -18514,7 +18514,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 914
+          "line": 926
         }
       ],
       "signature": "int db2_memory_summaries_list ( int64_t memory_id , int limit , db2_memory_summary_row_t * out , int max )",
@@ -18544,7 +18544,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 919
+          "line": 931
         }
       ],
       "signature": "void db2_memory_summary_upsert ( int64_t memory_id , const char * scope , const char * summary )",
@@ -18574,7 +18574,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 820
+          "line": 832
         }
       ],
       "signature": "void db2_memory_temporal_insert ( int64_t memory_id , const char * ref_key , const char * granularity , double weight )",
@@ -18589,7 +18589,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 827
+          "line": 839
         }
       ],
       "signature": "void db2_memory_temporal_refs_delete_for_memory ( int64_t memory_id )",
@@ -18605,7 +18605,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 996
+          "line": 1008
         }
       ],
       "signature": "int db2_memory_temporal_refs_list ( int64_t memory_id , db2_memory_temporal_ref_row_t * out , int max )",
@@ -18621,7 +18621,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 764
+          "line": 776
         }
       ],
       "signature": "int db2_memory_top_l2_facts ( memory_t * out , int max )",
@@ -18636,7 +18636,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 689
+          "line": 694
         }
       ],
       "signature": "int db2_memory_touch ( int64_t memory_id )",
@@ -18646,12 +18646,27 @@
     },
     {
       "consumers": [
+        "src/modules/memory/memory_core_crud.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/memory_query.h",
+          "line": 701
+        }
+      ],
+      "signature": "int db2_memory_touch_many ( const int64_t * ids , int n )",
+      "signature_sha256": "72056e96cf93a3648766c905adc0cbef9bc4284b2669d373ebf118f5d4e9020e",
+      "status": "audit-pending",
+      "symbol": "db2_memory_touch_many"
+    },
+    {
+      "consumers": [
         "src/modules/memory/memory_core_search.c"
       ],
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 651
+          "line": 656
         }
       ],
       "signature": "int db2_memory_unit_active_meta ( int64_t unit_id , double * weight_out , char * unit_type_out , int unit_type_len , char * unit_kind_out , int unit_kind_len )",
@@ -18681,7 +18696,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 896
+          "line": 908
         }
       ],
       "signature": "void db2_memory_unit_edge_insert ( int64_t src_unit_id , int64_t dst_unit_id , const char * edge_type , double weight )",
@@ -18696,7 +18711,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 976
+          "line": 988
         }
       ],
       "signature": "void db2_memory_unit_edges_delete_for_memory ( int64_t memory_id )",
@@ -18741,7 +18756,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 971
+          "line": 983
         }
       ],
       "signature": "int64_t db2_memory_unit_insert ( int64_t memory_id , const char * unit_type , const char * memory_kind , const char * unit_key , const char * unit_text , double weight )",
@@ -18757,7 +18772,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 703
+          "line": 715
         }
       ],
       "signature": "int db2_memory_unit_list_ids ( int64_t memory_id , int64_t * out , int max )",
@@ -18772,7 +18787,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 979
+          "line": 991
         }
       ],
       "signature": "void db2_memory_units_delete_for_memory ( int64_t memory_id )",
@@ -18788,7 +18803,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 869
+          "line": 881
         }
       ],
       "signature": "int db2_memory_units_list ( int64_t memory_id , db2_memory_unit_row_t * out , int max )",
@@ -18803,7 +18818,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 709
+          "line": 721
         }
       ],
       "signature": "int db2_memory_update_content ( int64_t memory_id , const char * content )",
@@ -20301,7 +20316,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 694
+          "line": 706
         }
       ],
       "signature": "int db2_retrieval_shortcut_lookup ( const char * normalized_query , int64_t * ids , int max , int * promoted_out , int64_t * hit_count_out )",
@@ -20316,7 +20331,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_query.h",
-          "line": 696
+          "line": 708
         }
       ],
       "signature": "int db2_retrieval_shortcut_observe ( const char * normalized_query , const int64_t * ids , int count )",
@@ -25845,12 +25860,12 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "fc2f6c048f43629b29e0321bc9baef09762809359fd7c11ede11002df86953bf",
+  "fingerprint": "88f7854ed278a7dcb6a4c8f579dad82be760a8c2b0b09e522a695924619c6407",
   "module": "db2",
   "schema_version": 1,
   "summary": {
-    "audit_pending": 672,
-    "declarations": 1400,
+    "audit_pending": 673,
+    "declarations": 1401,
     "headers": 138,
     "internal_unconsumed": 153,
     "private_test_only": 281,

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -21956,6 +21956,19 @@
       "symbol": "db2_test_shim_handle"
     },
     {
+      "consumers": [],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/db2_test_shim.h",
+          "line": 47
+        }
+      ],
+      "signature": "int db2_test_shim_is_postgres ( void )",
+      "signature_sha256": "e70c03189a52acb47ef9d01810a20a538467879158f59c163a0c1d203cbf80ca",
+      "status": "internal-unconsumed",
+      "symbol": "db2_test_shim_is_postgres"
+    },
+    {
       "consumers": [
         "src/tests/bench_perf.c",
         "src/tests/fuzz_memory_search.c",
@@ -22077,6 +22090,35 @@
       "signature_sha256": "ad7991115c322c152c5128a38199139f3209b512471868876e5f56ee9b342a1a",
       "status": "private-test-only",
       "symbol": "db2_test_shim_open_path"
+    },
+    {
+      "consumers": [
+        "src/tests/test_curator_code_unit.c",
+        "src/tests/test_curator_contradictions.c",
+        "src/tests/test_curator_index_claims.c",
+        "src/tests/test_curator_index_code_unit.c",
+        "src/tests/test_curator_index_narrative.c",
+        "src/tests/test_curator_invalidate.c",
+        "src/tests/test_curator_link_artifacts.c",
+        "src/tests/test_curator_pipeline.c",
+        "src/tests/test_curator_promote.c",
+        "src/tests/test_curator_queue.c",
+        "src/tests/test_curator_resolve_entities.c",
+        "src/tests/test_curator_serve.c",
+        "src/tests/test_curator_synthesize.c",
+        "src/tests/test_curator_version.c",
+        "src/tests/test_kb_releases_db.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/db2_test_shim.h",
+          "line": 54
+        }
+      ],
+      "signature": "int db2_test_shim_skip_on_postgres ( const char * test_name )",
+      "signature_sha256": "99307390ff5ca7a00f8223e625a790b4899c9c2dece2dc6c799d5eea54644daa",
+      "status": "private-test-only",
+      "symbol": "db2_test_shim_skip_on_postgres"
     },
     {
       "consumers": [],
@@ -25860,15 +25902,15 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "88f7854ed278a7dcb6a4c8f579dad82be760a8c2b0b09e522a695924619c6407",
+  "fingerprint": "d49755f68094611b7f31248273eaa52c81ef6e512037ab7f035a21677757ae0f",
   "module": "db2",
   "schema_version": 1,
   "summary": {
     "audit_pending": 673,
-    "declarations": 1401,
+    "declarations": 1403,
     "headers": 138,
-    "internal_unconsumed": 153,
-    "private_test_only": 281,
+    "internal_unconsumed": 154,
+    "private_test_only": 282,
     "reviewed": 294
   }
 }


### PR DESCRIPTION
Two related changes: two memory-ranking signals that were computed but never
reached the score, and the Postgres test mode that verified the fix (and found
two test defects on the way).

## The memory change

**`use_count` was never incremented on recall.** The context scorer weights every
candidate by `confidence * 0.3 + (use_count / 10.0) * 0.2`, but `db2_memory_touch`
had exactly three callers — the `aimee memory op` CLI verb, the KB RPC handler,
and tests. For any memory nobody had touched by hand that term was permanently
zero, so a signal the ranking already paid for carried no information.

It is now bumped where a memory is actually injected into a turn, beside the
existing `db1_context_snapshot_insert` — not when it merely turns up as a
candidate. Ids are collected during emit and flushed once through a new
`db2_memory_touch_many`; the single-row form would have cost one UPDATE per
injected memory on the context-assembly path.

**`recency_weight` was set in six places and read by none.** `retrieval_plan_t`
carried it, `memory_context.c` set it per intent, and `memory_assemble.c`
overrode it to 0.85 for temporal queries with a comment promising that "recent
memories float to the top". No scorer ever looked at it, and there was no recency
term at all. It is now applied at all three scoring sites (primary candidates,
the relaxed-tier fallback, the explain surface), interpolated so weight 0 leaves
a score exactly as it was.

The curve is a flat 180-day plateau then a 1825-day half-life, rather than an
exponential from day zero: a fact does not become less true as it ages, so inside
the plateau candidates compete on relevance alone, and past it the tail is gentle
enough that a still-valid old fact stays reachable. It is measured from
`last_used_at`, which the first half of this change finally keeps current — so a
fact that keeps earning its place stays fresh regardless of when it was learned.

Timestamps go through `parse_utc_ts`. The two columns genuinely disagree on
spelling: `pg_now_text()` writes canonical ISO (`...T...Z`) while
`memories.created_at` defaults to `to_char(..., 'YYYY-MM-DD HH24:MI:SS')` with a
space. A parser hard-coding either one silently floors the other to midnight —
exactly the failure `parse_utc_ts` exists to prevent, and exactly what an earlier
revision of this branch did before the Postgres run surfaced it.

## The Postgres test mode

The sqlite shim *translates* DB2's SQL rather than executing it, so the places the
two engines differ are precisely the places it cannot vouch for. The tree already
knew: `unit-test-pgvec-neardup` swaps the shim for `db_postgres.o` with a comment
noting that "every other unit test links `aimee_pg_sqlite_shim.o`, which is why no
test has ever executed pgvector SQL". This generalises that one-target escape
hatch to the suite.

The backend is a **link-time** choice, not a runtime one — the shim and
`db_postgres.o` export the same 33 `aimee_pg_*` symbols, so a binary carrying both
does not link. Every recipe now names `DB2_TEST_BACKEND_OBJ`, and `AIMEE_TEST_PG=1`
swaps it. `entity_edges.o` rides along in that mode: `db2_init` calls
`db2_entity_edge_build_unique_index` on the not-a-shim path, which LTO drops with
its callee when `aimee_pg_is_shim()` folds to a constant — 54 recipes stopped
linking against real libpq without it, and carrying it with the backend fixes all
54 in one line.

Isolation is per process: each binary clones a prepared template into
`<template>_p<pid>`, so a parallel `make -j` cannot collide. Between tests
`aimee_test_reset()` restores the freshly-seeded state in ~60 ms instead of paying
~700 ms for another schema apply; it truncates only non-empty tables (blanket-
truncating all 217 costs ~250 ms) and restores the rows `schema.sql` seeds, without
which `kind_lifecycle` and friends come back empty. Cleanup runs from a signal
handler as well as `atexit`, because a failing test calls `abort()` and `abort()`
does not run `atexit` handlers — during a migration that is the common path, and
every failure would otherwise strand a database on the server.

```
make db2-test-template AIMEE_TEST_DB2_TEMPLATE_URL=postgresql://.../aimee_test_tpl
make unit-tests-pg     AIMEE_TEST_DB2_TEMPLATE_URL=postgresql://.../aimee_test_tpl
```

## What it found

Two real test defects, both invisible to sqlite:

- `test_audit_provenance_emit_captures_version` matched `"id":N` as a substring of
  `artifacts.payload`. That column is `jsonb`, and Postgres normalises jsonb on the
  way out — reordering keys and printing a space after every colon — so the needle
  never matches what the server returns. It now parses the payload, which is the
  assertion that was meant. Production does no substring matching on jsonb columns,
  so nothing shipped was affected.
- `test_semantic_profile_duplicate_keeps_single_active_entry` selected bare columns
  alongside `COUNT(*)` with no `GROUP BY`. Sqlite tolerates it; Postgres rejects it
  outright. The repository has no other instance of the shape.

## Verification

Against PostgreSQL 17.11:

- A standalone probe exercised the changed SQL directly — `db2_memory_touch_many`
  returns the affected-row count through `PQcmdTuples` (the sqlite shim uses
  `sqlite3_changes`, a different implementation), skips unaddressable ids, sums
  correctly across the 128-id chunk boundary, and `db2_memory_list_candidates`
  places the two new columns correctly alongside the scope-filter macros in both
  the PRIMARY and FALLBACK filters.
- Of the 93 DB2-touching tests: **54 pass, 15 skip, 24 fail**. The skips are the
  raw-sqlite-handle tests, now reporting the reason instead of aborting. The 24
  are pre-existing sqlite-isms this mode exposes — `PRAGMA` statements, more jsonb
  substring matching, and embedder backoff that escalates with wall-clock time and
  so trips on a slower backend. `unit-test-memory` is among them: it reaches line
  1482 and fails on an embedder-dependent counter, well past the new batch-touch
  test, which passes.

Default (sqlite) mode is unchanged and off by default:

- `make lint` — 62/62.
- `make all server` clean.
- `make unit-tests` — only the pre-existing `unit-test-vault-bootstrap` failure,
  which reproduces identically on this branch's parent.
- Memory retrieval eval unchanged at mrr 0.947 / recall@5 0.981. Note it drives
  `find_facts_ex`, not the context-assembly scorer this PR changes, so it is a
  no-regression check rather than a measurement of the improvement — there is no
  eval covering that scorer's ranking today, which is the natural next step.

## Not done here

The 24 remaining Postgres failures are each a small independent fix, and the mode
is opt-in, so they do not block this. Wiring `unit-tests-pg` into CI should wait
until they are green, otherwise the gate lands red.
