### PR TITLE
fix: a unit test that raced the scheduler, and a runner that hid why

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1091,13 +1091,17 @@ unit-tests: $(UNIT_TEST_P1_PREREQ) $(BINARY) $(OBJDIR)/aimee-module $(OBJDIR)/ai
 	  done; \
 	else \
 	  if ! printf '%s\0' $(UNIT_TEST_TARGETS) | \
-	    xargs -0 -n1 -P "$$jobs" sh -c 't="$$1"; log="$$(mktemp /tmp/aimee-test-run.XXXXXX)"; echo "  $$t"; "./$$t" >"$$log" 2>&1; rc="$$?"; cat "$$log"; rm -f "$$log"; if [ "$$rc" -ne 0 ]; then echo "FAILED: $$t" >&2; printf "FAILED: %s\\n" "$$t" >"$$AIMEE_TEST_FAILURE_DIR/failure.$$$$"; fi; exit "$$rc"' _; then \
+	    xargs -0 -n1 -P "$$jobs" sh -c 't="$$1"; log="$$(mktemp /tmp/aimee-test-run.XXXXXX)"; echo "  $$t"; s0=$$(date +%s); "./$$t" >"$$log" 2>&1; rc="$$?"; s1=$$(date +%s); cat "$$log"; rm -f "$$log"; printf "%s %s\\n" "$$((s1-s0))" "$$t" >>"$$AIMEE_TEST_FAILURE_DIR/timings"; if [ "$$rc" -ne 0 ]; then echo "FAILED: $$t" >&2; printf "FAILED: %s\\n" "$$t" >"$$AIMEE_TEST_FAILURE_DIR/failure.$$$$"; fi; exit "$$rc"' _; then \
 	    echo "Unit test failures:" >&2; \
 	    if ! cat "$$fd"/failure.* >&2 2>/dev/null; then \
 	      echo "  (no marker written: a test was killed by a signal before it could" >&2; \
 	      echo "   record itself, or xargs itself failed - re-run with TEST_RUN_JOBS=1)" >&2; \
 	    fi; \
 	    exit 1; \
+	  fi; \
+	  if [ -s "$$fd/timings" ]; then \
+	    echo "slowest in this shard (seconds):"; \
+	    sort -rn "$$fd/timings" | head -5 | sed 's/^/  /'; \
 	  fi; \
 	fi
 	@for t in $(UNIT_TEST_AUX_TARGETS); do \

--- a/src/tests/test_token_audit_load.c
+++ b/src/tests/test_token_audit_load.c
@@ -111,7 +111,8 @@ static void test_sync_concurrency_no_drops(void)
    assert(tail < 5L * 1000000000L);
 }
 
-#define ASYNC_N 250 /* <= the async ring so the batch is enqueued without inline fallback */
+#define ASYNC_N      250 /* <= the async ring so the batch is enqueued without inline fallback */
+#define ASYNC_ROUNDS 3   /* compared at the minimum; see the note in the test below */
 
 static void test_async_nonblocking_no_drops(void)
 {
@@ -123,36 +124,56 @@ static void test_async_nonblocking_no_drops(void)
                                 .completion_tokens = 5,
                                 .estimated_cost_usd = 0.001};
 
-   /* Baseline: synchronous insert cost for the same batch size. */
-   long s0 = now_ns();
-   for (int i = 0; i < ASYNC_N; i++)
+   /* Both costs are measured ROUNDS times and compared at their minimum.
+    *
+    * A single pair of consecutive windows compares two different moments of the
+    * machine, not two implementations: this suite runs its binaries in parallel,
+    * so whichever window happens to land next to a heavy neighbour looks slower.
+    * That made `enqueue_ns < sync_ns` a race against the scheduler -- it holds by
+    * roughly 10x when the box is quiet and flips outright under a loaded `-j8`
+    * run, which is how it failed in CI while passing every time by hand.
+    *
+    * Contention can only ever make a sample SLOWER, so the minimum over a few
+    * rounds converges on the real cost from above and the comparison stops
+    * depending on what else the machine was doing. */
+   long best_sync = -1, best_enqueue = -1;
+   for (int r = 0; r < ASYNC_ROUNDS; r++)
    {
-      row.source = "sync-baseline";
-      assert(db1_token_audit_insert(&row) == 0);
-   }
-   long sync_ns = now_ns() - s0;
+      long s0 = now_ns();
+      for (int i = 0; i < ASYNC_N; i++)
+      {
+         row.source = "sync-baseline";
+         assert(db1_token_audit_insert(&row) == 0);
+      }
+      long sync_ns = now_ns() - s0;
+      if (best_sync < 0 || sync_ns < best_sync)
+         best_sync = sync_ns;
 
-   /* Async: hand the rows to the background writer. The enqueue is what the
-    * request thread pays; it must be cheaper than the synchronous insert. */
-   long a0 = now_ns();
-   for (int i = 0; i < ASYNC_N; i++)
-   {
-      row.source = "async-load";
-      if (agent_audit_async_enqueue_row(&row) != 0)
-         (void)db1_token_audit_insert(&row); /* ring full -> inline, never dropped */
-   }
-   long enqueue_ns = now_ns() - a0;
+      /* Async: hand the rows to the background writer. The enqueue is what the
+       * request thread pays; it must be cheaper than the synchronous insert. */
+      long a0 = now_ns();
+      for (int i = 0; i < ASYNC_N; i++)
+      {
+         row.source = "async-load";
+         if (agent_audit_async_enqueue_row(&row) != 0)
+            (void)db1_token_audit_insert(&row); /* ring full -> inline, never dropped */
+      }
+      long enqueue_ns = now_ns() - a0;
+      if (best_enqueue < 0 || enqueue_ns < best_enqueue)
+         best_enqueue = enqueue_ns;
 
-   agent_audit_async_flush(); /* wait for the writer to drain */
+      agent_audit_async_flush(); /* wait for the writer to drain */
+   }
 
    int landed = count_source("async-load");
-   printf("  async: enqueue %d rows in %ld us vs sync insert %ld us; drops=%d\n", ASYNC_N,
-          enqueue_ns / 1000, sync_ns / 1000, ASYNC_N - landed);
+   printf("  async: enqueue %d rows in %ld us vs sync insert %ld us (best of %d); drops=%d\n",
+          ASYNC_N, best_enqueue / 1000, best_sync / 1000, ASYNC_ROUNDS,
+          ASYNC_N * ASYNC_ROUNDS - landed);
    /* Acceptance: every enqueued row lands (drop rate 0)... */
-   assert(landed == ASYNC_N);
+   assert(landed == ASYNC_N * ASYNC_ROUNDS);
    /* ...and the request thread is not blocked on the DB — enqueuing is cheaper
     * than synchronously inserting the same batch. */
-   assert(enqueue_ns < sync_ns);
+   assert(best_enqueue < best_sync);
 }
 
 /* ── Real ingress-writer concurrency ─────────────────────────────────────────

--- a/src/tests/test_token_audit_load.c
+++ b/src/tests/test_token_audit_load.c
@@ -35,6 +35,17 @@ static long now_ns(void)
    return (long)ts.tv_sec * 1000000000L + ts.tv_nsec;
 }
 
+/* THIS THREAD's own CPU time. Wall clock measures the machine; this measures
+ * what the calling thread was actually charged for, which is the claim under
+ * test -- "the request thread does not pay for the write". Another process
+ * stealing the CPU inflates wall time and leaves this untouched. */
+static long thread_cpu_ns(void)
+{
+   struct timespec ts;
+   clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+   return (long)ts.tv_sec * 1000000000L + ts.tv_nsec;
+}
+
 static int count_source(const char *src)
 {
    sqlite3_stmt *st = NULL;
@@ -137,21 +148,25 @@ static void test_async_nonblocking_no_drops(void)
     * rounds converges on the real cost from above and the comparison stops
     * depending on what else the machine was doing. */
    long best_sync = -1, best_enqueue = -1;
+   long best_sync_cpu = -1, best_enqueue_cpu = -1;
    for (int r = 0; r < ASYNC_ROUNDS; r++)
    {
-      long s0 = now_ns();
+      long s0 = now_ns(), sc0 = thread_cpu_ns();
       for (int i = 0; i < ASYNC_N; i++)
       {
          row.source = "sync-baseline";
          assert(db1_token_audit_insert(&row) == 0);
       }
       long sync_ns = now_ns() - s0;
+      long sync_cpu = thread_cpu_ns() - sc0;
       if (best_sync < 0 || sync_ns < best_sync)
          best_sync = sync_ns;
+      if (best_sync_cpu < 0 || sync_cpu < best_sync_cpu)
+         best_sync_cpu = sync_cpu;
 
       /* Async: hand the rows to the background writer. The enqueue is what the
        * request thread pays; it must be cheaper than the synchronous insert. */
-      long a0 = now_ns();
+      long a0 = now_ns(), ac0 = thread_cpu_ns();
       for (int i = 0; i < ASYNC_N; i++)
       {
          row.source = "async-load";
@@ -159,21 +174,35 @@ static void test_async_nonblocking_no_drops(void)
             (void)db1_token_audit_insert(&row); /* ring full -> inline, never dropped */
       }
       long enqueue_ns = now_ns() - a0;
+      long enqueue_cpu = thread_cpu_ns() - ac0;
       if (best_enqueue < 0 || enqueue_ns < best_enqueue)
          best_enqueue = enqueue_ns;
+      if (best_enqueue_cpu < 0 || enqueue_cpu < best_enqueue_cpu)
+         best_enqueue_cpu = enqueue_cpu;
 
       agent_audit_async_flush(); /* wait for the writer to drain */
    }
 
    int landed = count_source("async-load");
-   printf("  async: enqueue %d rows in %ld us vs sync insert %ld us (best of %d); drops=%d\n",
-          ASYNC_N, best_enqueue / 1000, best_sync / 1000, ASYNC_ROUNDS,
-          ASYNC_N * ASYNC_ROUNDS - landed);
+   printf("  async: enqueue %d rows in %ld us cpu %ld us vs sync insert %ld us cpu %ld us"
+          " (best of %d); drops=%d\n",
+          ASYNC_N, best_enqueue / 1000, best_enqueue_cpu / 1000, best_sync / 1000,
+          best_sync_cpu / 1000, ASYNC_ROUNDS, ASYNC_N * ASYNC_ROUNDS - landed);
+   fflush(stdout); /* abort() below would otherwise discard the numbers that explain it */
    /* Acceptance: every enqueued row lands (drop rate 0)... */
    assert(landed == ASYNC_N * ASYNC_ROUNDS);
-   /* ...and the request thread is not blocked on the DB — enqueuing is cheaper
-    * than synchronously inserting the same batch. */
-   assert(best_enqueue < best_sync);
+   /* ...and the request thread is not charged for the write: enqueuing costs it
+    * far less CPU than synchronously inserting the same batch.
+    *
+    * The comparison is on THREAD CPU, not wall clock. Wall clock measures the
+    * machine, and this suite runs its binaries in parallel: a 100us enqueue
+    * window preempted by a busy neighbour reads as 866us of wall time while
+    * costing the thread 117us, which is a fact about the scheduler and not
+    * about the writer. Measured under deliberate 3x CPU oversubscription, the
+    * wall-clock form flipped outright; thread CPU held a 12x margin in every
+    * sample (enqueue 77-127us against sync 1497-3236us). Both numbers are
+    * printed above so a future failure can be read rather than guessed at. */
+   assert(best_enqueue_cpu < best_sync_cpu);
 }
 
 /* ── Real ingress-writer concurrency ─────────────────────────────────────────


### PR DESCRIPTION
`test_token_audit_load`'s `test_async_nonblocking_no_drops` fails intermittently
in CI and passes every time when run by hand. It asserted `enqueue_ns < sync_ns`
from two consecutive wall-clock windows, which is a scheduler race by
construction rather than a measurement.

## Why it flips

The suite runs its binaries in parallel, so the two windows see two different
moments of the machine. A ~100µs enqueue window preempted by a busy neighbour
reads as **866µs of wall time while costing the thread 117µs** — a fact about
the scheduler, not about the writer.

The claim under test is that *the request thread does not pay for the write*.
Wall clock cannot express that. `CLOCK_THREAD_CPUTIME_ID` measures what the
calling thread was actually charged, which **is** the claim, and another process
stealing the CPU leaves it untouched.

## The change

- Assert on thread CPU time rather than wall clock.
- Measure three rounds and compare the minimum — contention can only ever make a
  sample slower, so the minimum converges on the real cost from above. Cheap
  insurance on top of the clock change.
- `fflush(stdout)` before the assert. `abort()` discards buffered stdout, which
  is why the first failure I hit reported the assertion and none of the numbers
  that explain it.
- Both wall and CPU figures are printed, so a future failure can be read rather
  than guessed at.

## Measured

25 runs under 32 competing busy-loops on 8 cores:

| | wall | thread CPU |
| --- | --- | --- |
| enqueue 250 rows | 76–866µs | **77–127µs** |
| sync insert 250 rows | 1531–25162µs | **1497–3236µs** |
| worst margin | 6.9× | **13.3×** |

The wall-clock form has been driven to outright failure twice — once with a
single round, once with three (1 failure in 12 runs). The CPU form did not drop
below 13× in any sample.

## Also here: the runner reported no per-test timing

The unit-test runner buffers each test's output to a temp file and `cat`s it at
the end, with no duration, so a slow or marginal test is invisible. It now
records each test's time and prints the five slowest in the shard.

That matters beyond this fix. **pg unit-test shard 3 runs ~15m against ~3m for
shards 1 and 2** — reproducibly, including in green runs — and the aggregate
`unit-tests` gate cannot start until the slowest shard finishes. Shards are
split round-robin by *count*, so a cost imbalance is not something the split can
see. With timing on, a local run names its top five immediately:

```
slowest in this shard (seconds):
  84 build/obj/tests/unit-test-wfe-safety
  76 build/obj/tests/unit-test-wfe-delegate-seam
  40 build/obj/tests/unit-test-git-verify-state-bus
  28 build/obj/tests/unit-test-server-compute
  27 build/obj/tests/unit-test-wfe-foreach
```

## Not changed, deliberately

Shard 3's cost is dominated by `unit-test-curiosity`, which inserts 300 memories
whose `memory_unit_edges` inserts grow with the square of units-per-scope
(observed live in `pg_stat_activity`). Lowering its N would weaken a scoring
assertion whose N was presumably chosen to clear a threshold — trading a slow
test for a flaky one is the opposite of this PR's point. Flagged with the
measurement instead; the promising direction is spreading those memories across
several scopes, which keeps N and the scoring surface while cutting the edge
count.

Verified: `make -j8 all`, `make unit-tests` (all pass), `make lint` (65/65).
