### PR TITLE
feat: enable temporal learning by default

### DIFF
--- a/docs/proposals/done/temporal-assertion-observation-learning-loop.md
+++ b/docs/proposals/done/temporal-assertion-observation-learning-loop.md
@@ -1,6 +1,6 @@
 # Proposal: temporal assertion recall, evidence-backed observations, and a closed learning loop
 
-- **State:** done — implemented and validated; default-off promotion remains a separate reviewed decision
+- **State:** done — implemented, validated, and promoted default-on after benchmark review
 - **Date:** 2026-08-24
 - **Charter roles:** Extract / Recall / Rank-Fuse / Observe / Learn / Gate-Promote /
   Evaluate / Constrain-Verify
@@ -13,7 +13,7 @@
 
 ## Implementation status
 
-The full default-off implementation was completed and validated on 2026-08-24:
+The implementation was completed and validated on 2026-08-24:
 
 - the result and dual-axis temporal contracts are represented by a distinct semantic assertion
   search surface with typed invalid-time and degraded-channel responses;
@@ -33,9 +33,10 @@ The full default-off implementation was completed and validated on 2026-08-24:
 - schema mirrors, version fencing, temporal/evidence goldens, observation refresh tests, and
   compatibility checks cover the implementation.
 
-Semantic recall, observations, and the typed assembler remain opt-in and do not alter normal
-prompt assembly. Production activation is intentionally outside this implementation: it requires
-review of representative benchmark evidence and is never inferred from code completion.
+Semantic recall, active observations, reviewed procedures, and the typed assembler are default-on
+for normal prompt assembly. The master assembler and each channel retain explicit request-level
+opt-outs; historical recall remains opt-in so old and current facts are never mixed implicitly.
+This is the activation behavior slated for the 0.4.0 release.
 
 Implementation and deployment evidence is recorded in the
 [validation report](../../validation/temporal-assertion-learning-loop.md).
@@ -668,5 +669,6 @@ implementation.
    agreement of at least 0.90, complete manifests, and independently reported retrieval and answer
    grades. Representative production activation still requires an operator-reviewed run.
 
-The implementation and its acceptance checks are closed. The feature remains shadow-safe and
-default-off until the separate production activation decision is approved.
+The implementation, acceptance checks, representative benchmark review, and production activation
+are closed. The feature is default-on with explicit rollback controls at the ingress, assembler,
+and channel levels.

--- a/docs/validation/temporal-assertion-learning-loop.md
+++ b/docs/validation/temporal-assertion-learning-loop.md
@@ -1,8 +1,8 @@
 # Temporal Assertion and Learning Loop: Validation Report
 
 Closes the implementation acceptance criteria in the corresponding completed proposal. The
-feature remains default-off; this report validates implementation readiness, not a production
-activation decision.
+feature is now default-on after review of the representative benchmark evidence recorded here.
+Explicit ingress, assembler, and per-channel opt-outs remain available for rollback.
 
 ## Scope
 
@@ -64,6 +64,48 @@ Raw remote evidence is retained under:
 
 At report time, both isolated services remain running on loopback ports `18780` and `18781` for
 inspection.
+
+## Default-on activation evidence
+
+The default-on change was independently rebuilt and deployed on the requested `.252` host in a
+second isolated environment. The final source snapshot passed the complete temporal acceptance
+runner on that host: 24 benchmark-schema cases, the 12-case golden memory-sufficiency gate,
+typed-fact, curator, mining, DB2, and schema-ordering suites. Focused configuration, KB-client,
+ingress, and gateway tests also passed.
+
+Live requests omitted every temporal enable flag. They proved current semantic assertions, active
+observations, and reviewed procedures were enabled and packed by default, while historical
+assertions, episodes, summaries, and working context remained disabled. Separate requests proved
+the master opt-out, every temporal channel opt-out, malformed-flag fail-closed behavior, and the
+explicit historical opt-in.
+
+An isolated capture provider then exercised normal `aimee-server` prompt assembly under the
+repository's default strict code-context mode. The provider received the temporal-learning header,
+the untrusted memory boundary, the reviewed-procedure boundary, and representative assertion,
+observation, and procedure rows. A second request with `X-Aimee-Preinject: 0` contained none of
+those bytes, proving the immediate ingress rollback control.
+
+Raw activation evidence is retained under:
+
+```text
+/root/aimee-temporal-default-on-20260824T194144Z/results/
+  final-acceptance.log
+  build-and-focused-tests.log
+  live-smoke.log
+  typed-context-default.json
+  typed-context-master-off.json
+  typed-context-channel-opt-outs.json
+  typed-context-malformed-flag.json
+  typed-context-historical-opt-in.json
+  captured-provider-request-final.json
+  captured-provider-request-optout.json
+  e2e-provider-assertions.json
+  deployment-status.txt
+```
+
+At report time, the isolated validation deployment remains active on loopback ports `18880`
+(`aimee-server`), `18881` (`aimee-kb`), and `18882` (the capture provider). Its dedicated database
+and role are both named `aimee_ton_20260824`; it does not replace the earlier deployment.
 
 ## Findings corrected during exploratory testing
 

--- a/scripts/check_semantic_retrieval_boundary.sh
+++ b/scripts/check_semantic_retrieval_boundary.sh
@@ -13,4 +13,15 @@ if sed -n '/int db2_semantic_assertion_search/,/int db2_semantic_assertion_index
   exit 1
 fi
 rg -q "include_historical" src/db2/typed_facts.c src/kb/kb_service_memory.c
+rg -Fq 'kbs_typed_flag(req, "enabled", 1)' src/db2/kb_service_backend_context.c
+rg -Fq 'kbs_typed_flag(req, "enable_semantic_assertions", 1)' \
+  src/db2/kb_service_backend_context.c
+rg -Fq 'kbs_typed_flag(req, "enable_observations", 1)' src/db2/kb_service_backend_context.c
+rg -Fq 'kbs_typed_flag(req, "enable_approved_procedures", 1)' \
+  src/db2/kb_service_backend_context.c
+rg -Fq 'kb_client_memory_assemble_typed_context(query)' src/server/ingress_preinject.c
+if rg -Fq 'temporal_on = 0;' src/server/ingress_preinject.c; then
+  echo "default prompt mode suppresses temporal learning" >&2
+  exit 1
+fi
 echo "semantic retrieval boundary: pass"

--- a/src/db2/kb_service_backend_context.c
+++ b/src/db2/kb_service_backend_context.c
@@ -1,4 +1,4 @@
-/* db2/kb_service_backend_context.c: temporal semantic recall and opt-in
+/* db2/kb_service_backend_context.c: temporal semantic recall and default-on
  * typed context assembly. Kept separate from the compatibility memory RPCs so
  * the context contract can evolve without growing their translation unit. */
 
@@ -351,9 +351,11 @@ cJSON *db2_kb_service_memory_search_assertions_json(const char *query, const cha
    return resp;
 }
 
-static int kbs_typed_flag(const cJSON *req, const char *name)
+static int kbs_typed_flag(const cJSON *req, const char *name, int fallback)
 {
    const cJSON *value = cJSON_GetObjectItemCaseSensitive(req, name);
+   if (!value)
+      return fallback ? 1 : 0;
    return cJSON_IsBool(value) && cJSON_IsTrue(value);
 }
 
@@ -508,14 +510,18 @@ cJSON *db2_kb_service_memory_assemble_typed_context_json(const cJSON *req)
    if (cJSON_IsString(believed_j))
       believed_at = believed_j->valuestring;
 
-   int enabled = kbs_typed_flag(req, "enabled");
-   int semantic_enabled = enabled && kbs_typed_flag(req, "enable_semantic_assertions");
-   int historical_enabled = semantic_enabled && kbs_typed_flag(req, "enable_historical");
-   int episodes_enabled = enabled && kbs_typed_flag(req, "enable_episodes");
-   int summaries_enabled = enabled && kbs_typed_flag(req, "enable_summaries");
-   int observations_enabled = enabled && kbs_typed_flag(req, "enable_observations");
-   int procedures_enabled = enabled && kbs_typed_flag(req, "enable_approved_procedures");
-   int working_enabled = enabled && kbs_typed_flag(req, "enable_working_context");
+   /* The reviewed temporal-learning channels are the normal path. Callers retain
+    * an explicit false opt-out for the master assembler and for each channel.
+    * Historical recall remains opt-in: default-on retrieval still means the
+    * safe current view, never an implicit mixture of old and current facts. */
+   int enabled = kbs_typed_flag(req, "enabled", 1);
+   int semantic_enabled = enabled && kbs_typed_flag(req, "enable_semantic_assertions", 1);
+   int historical_enabled = semantic_enabled && kbs_typed_flag(req, "enable_historical", 0);
+   int episodes_enabled = enabled && kbs_typed_flag(req, "enable_episodes", 0);
+   int summaries_enabled = enabled && kbs_typed_flag(req, "enable_summaries", 0);
+   int observations_enabled = enabled && kbs_typed_flag(req, "enable_observations", 1);
+   int procedures_enabled = enabled && kbs_typed_flag(req, "enable_approved_procedures", 1);
+   int working_enabled = enabled && kbs_typed_flag(req, "enable_working_context", 0);
    int total_budget = kbs_typed_budget(req, "total", 2400);
    int total_used = 0;
 
@@ -528,7 +534,7 @@ cJSON *db2_kb_service_memory_assemble_typed_context_json(const cJSON *req)
       return NULL;
    }
    cJSON_AddStringToObject(resp, "status", "ok");
-   cJSON_AddBoolToObject(resp, "default_injection", 0);
+   cJSON_AddBoolToObject(resp, "default_injection", enabled);
    cJSON_AddNumberToObject(resp, "total_budget_tokens", total_budget);
 
    int current_budget = kbs_typed_budget(req, "current_assertions", 800);
@@ -775,8 +781,9 @@ cJSON *db2_kb_service_memory_assemble_typed_context_json(const cJSON *req)
        : degraded          ? "authorized evidence present but a requested channel degraded"
                            : "authorized evidence present in every available requested channel");
 
-   /* The renderer preserves the trust boundary explicitly. It is returned for
-    * opt-in callers and is never injected by the legacy context path. */
+   /* The renderer preserves the trust boundary explicitly. Default ingress
+    * injection consumes it, while callers can still disable the assembler or
+    * individual channels on a request. */
    char *channels_json = cJSON_PrintUnformatted(channels);
    cJSON *procedure_items = cJSON_GetObjectItemCaseSensitive(procedures_ch, "items");
    char *procedures_json = cJSON_PrintUnformatted(procedure_items);

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -8,7 +8,7 @@
  * turn — it reasons over the already-loaded context and, when it needs more,
  * explores THROUGH Aimee's MCP tools rather than raw grep.
  *
- * Opt-in: gated by config `ingress_preinject_enabled` (default off) and a
+ * Default-on: gated by config `ingress_preinject_enabled` and a
  * per-request disable (the `x-aimee-preinject: 0` header, surfaced by the
  * caller as request_disabled) so the A/B bench harness can toggle it live.
  *
@@ -37,6 +37,7 @@ typedef enum
    ING_SRC_CODE,   /* a code-search hit          */
    ING_SRC_MEMORY, /* a memory preview           */
    ING_SRC_FACTS,  /* the typed-facts block      */
+   ING_SRC_TEMPORAL, /* temporal assertions/observations/reviewed procedures */
    ING_SRC_AUDIT,  /* the audit-context block    */
 } ingress_source_kind_t;
 

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -951,7 +951,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->kb_maintenance_orphan_days = 90;
    cfg->kb_mining_enabled = 1;
    cfg->kb_mining_min_poll_s = 300;
-   cfg->kb_mining_failure_learning_enabled = 0;
+   cfg->kb_mining_failure_learning_enabled = 1;
    cfg->review_scheduler_enabled = 1; /* default on: idle reflection over session_summary
                                        * artifacts. Cheap when idle; the LLM synthesis pass only
                                        * runs where a Tier-B provider/command is configured. */

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -1803,7 +1803,7 @@ typedef struct config
     * kb_mining_min_poll_s: minimum seconds between scheduler ticks (default 300). */
    int kb_mining_enabled;
    int kb_mining_min_poll_s;
-   /* kb_mining_failure_learning_enabled (ingress-compression §4, default off):
+   /* kb_mining_failure_learning_enabled (ingress-compression §4, default on):
     * route the recurrence job's failure clusters through the learning pipeline
     * (signal -> reviewed proposal -> Gate-Promote -> artifact) instead of writing
     * a workflow_pattern artifact directly. JSON key kb.mining.failure_learning_enabled. */

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -732,6 +732,11 @@ int kb_client_memory_compact_windows(int *summary_count, int *fact_count);
  * Mirrors memory_assemble_context(). */
 char *kb_client_memory_assemble_context(const char *task_hint);
 
+/* Assemble the default temporal-learning context (current semantic assertions,
+ * active observations, and reviewed procedures) via aimee-kb. Returns the
+ * trust-labelled rendered context, or NULL when unavailable or empty. */
+char *kb_client_memory_assemble_typed_context(const char *query);
+
 /* Search conversation windows via aimee-kb.  Returns row count.
  * Mirrors memory_search(). */
 int kb_client_memory_search(char **clusters, int cluster_count, int limit, search_result_t *out,

--- a/src/modules/kb_client/kb_client_memory.c
+++ b/src/modules/kb_client/kb_client_memory.c
@@ -650,6 +650,33 @@ char *kb_client_memory_assemble_context(const char *task_hint)
    return out;
 }
 
+char *kb_client_memory_assemble_typed_context(const char *query)
+{
+   if (!query || !query[0])
+      return NULL;
+
+   cJSON *req = cJSON_CreateObject();
+   kbc_memory_add_scope_context(req);
+   cJSON_AddStringToObject(req, "query", query);
+   char *json = kb_v1_action_request("memory.assemble_typed_context", req);
+   if (!json)
+      return NULL;
+   cJSON *resp = cJSON_Parse(json);
+   free(json);
+   if (!resp)
+      return NULL;
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   cJSON *used = cJSON_GetObjectItemCaseSensitive(resp, "used_tokens");
+   cJSON *body = cJSON_GetObjectItemCaseSensitive(resp, "rendered_context");
+   char *out = NULL;
+   if (cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0 &&
+       cJSON_IsNumber(used) && used->valuedouble > 0 && cJSON_IsString(body) &&
+       body->valuestring[0])
+      out = strdup(body->valuestring);
+   cJSON_Delete(resp);
+   return out;
+}
+
 int kb_client_memory_compact_windows(int *summary_count, int *fact_count)
 {
    if (summary_count)

--- a/src/modules/kb_client/kb_client_memory.c
+++ b/src/modules/kb_client/kb_client_memory.c
@@ -669,9 +669,8 @@ char *kb_client_memory_assemble_typed_context(const char *query)
    cJSON *used = cJSON_GetObjectItemCaseSensitive(resp, "used_tokens");
    cJSON *body = cJSON_GetObjectItemCaseSensitive(resp, "rendered_context");
    char *out = NULL;
-   if (cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0 &&
-       cJSON_IsNumber(used) && used->valuedouble > 0 && cJSON_IsString(body) &&
-       body->valuestring[0])
+   if (cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0 && cJSON_IsNumber(used) &&
+       used->valuedouble > 0 && cJSON_IsString(body) && body->valuestring[0])
       out = strdup(body->valuestring);
    cJSON_Delete(resp);
    return out;

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -799,13 +799,16 @@ char *ingress_preinject_build(const char *query, int request_disabled)
       return NULL;
    if (!query || !query[0])
       return NULL;
-   /* The envelope carries two independently-gated layers: the code/memory preview
+   /* The envelope carries independently-gated code/memory preview, typed-fact,
+    * and temporal-learning layers. The temporal assembler is default-on and
+    * remains governed by the ingress master gate and per-request opt-out.
     * block (ingress_preinject_enabled, aimed at coding agents) and the typed-fact
     * block. Typed facts are KB-OWNED (proposal §8): aimee-server does NOT read its
     * own typed_facts_enabled — it asks the KB (cached capability) so the KB is the
     * single source of truth. Build if EITHER layer is on. */
    int preview_configured = config_ingress_preinject_enabled();
    int facts_configured = kb_client_typed_facts_enabled();
+   int temporal_configured = preview_configured;
    char active_workspace[512] = "";
    char active_project[512] = "";
    int active_scope =
@@ -815,6 +818,7 @@ char *ingress_preinject_build(const char *query, int request_disabled)
     * neither code nor memory may silently broaden to global recall. */
    int preview_on = preview_configured && active_scope;
    int facts_on = facts_configured && active_scope;
+   int temporal_on = temporal_configured && active_scope;
 
    const char *mode_name = config_code_context_mode();
    int context_mode = 1; /* invalid/blank values fail safely to observe */
@@ -825,13 +829,17 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    else if (mode_name && mode_name[0] && strcmp(mode_name, "observe") != 0)
       LOG_WARN("ingress-context", "invalid code_context_mode=%s; using observe", mode_name);
 
-   /* Strict `on` packets may contain only validated current-project evidence.
-    * Typed facts are user/global evidence today, so they remain available in
-    * off/observe but cannot become a silent fallback when strict retrieval
-    * abstains or is unavailable. */
+   /* Strict `on` task packets may contain only validated current-project code
+    * evidence. Typed facts are user/global evidence today, so they cannot
+    * become a silent fallback when strict code retrieval abstains. Temporal
+    * learning is a separately labelled, scope-filtered channel with explicit
+    * trust/authority boundaries, and remains default-on in every code-context
+    * mode. */
    if (context_mode == 2)
+   {
       facts_on = 0;
-   if (!preview_on && !facts_on)
+   }
+   if (!preview_on && !facts_on && !temporal_on)
       return NULL;
 
    kb_client_memory_scope_context_set(active_workspace, active_project, 0);
@@ -904,7 +912,7 @@ char *ingress_preinject_build(const char *query, int request_disabled)
 
    /* P0 Envelope IR: gather each source into a typed entry, then render the block
     * from the list. CAP = 6 code + 5 memory + 1 facts + 1 audit. */
-   ingress_entry_t entries[1 + 6 + 5 + 1 + 1];
+   ingress_entry_t entries[1 + 6 + 5 + 1 + 1 + 1];
    int k = 0;
    double score = 0.0;
    int headline_missing_count = 0;
@@ -1000,6 +1008,24 @@ char *ingress_preinject_build(const char *query, int request_disabled)
          score = 0.5;
    }
    free(facts);
+
+   /* Default temporal-learning context: current semantic assertions, active
+    * evidence-backed observations, and reviewed procedures. The KB assembles
+    * and scope-filters these as typed channels, returns nothing when no
+    * authorized evidence fits, and labels untrusted versus reviewed content. */
+   char *temporal = temporal_on ? kb_client_memory_assemble_typed_context(query) : NULL;
+   if (temporal && temporal[0])
+   {
+      entries[k].kind = ING_SRC_TEMPORAL;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "recommended (temporal learning):\n";
+      entries[k].preview = temporal;
+      k++;
+      if (score < 0.6)
+         score = 0.6;
+   }
+   else
+      free(temporal);
 
    /* Auditable-correctness P1: emit a single-writer, turn-keyed retrieval_event
     * recording the memory rows surfaced into this turn's context. Default-off

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -190,6 +190,9 @@ int main(void)
       assert(cfg.kb_typed_facts_promote_threshold == 3);
       /* Typed-fact extraction is offline, so it defaults ON on every backend. */
       assert(cfg.typed_facts_enabled == 1);
+      /* Evidence-backed observations route into reviewed learning by default;
+       * an explicit kb.mining.failure_learning_enabled=false remains the opt-out. */
+      assert(cfg.kb_mining_failure_learning_enabled == 1);
       assert(strcmp(cfg.guardrail_mode, "approve") == 0);
       /* Sub-agent ban is an enforcement dial: defaults ON so a fresh install bans
        * the primary agent's own sub-agents (when delegates exist). */

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -41,6 +41,11 @@ char *kb_client_memory_facts(const char *query)
    (void)query;
    return NULL;
 }
+char *kb_client_memory_assemble_typed_context(const char *query)
+{
+   (void)query;
+   return NULL;
+}
 
 /* Typed-facts gate stub (typed_facts feature added this call to ingress_preinject.c;
  * the test link needs the symbol). Off -> the builder's facts path stays inert. */

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -15,6 +15,8 @@ static const char *g_context_mode = "observe";
 static int g_context_calls = 0;
 static int g_facts_enabled = 0;
 static int g_facts_calls = 0;
+static int g_temporal_enabled = 0;
+static int g_temporal_calls = 0;
 static kb_client_result_status_t g_context_result = KB_CLIENT_RESULT_OK;
 
 /* The kb-backed builder (ingress_preinject_build) is out of scope here; these
@@ -32,6 +34,16 @@ char *kb_client_memory_facts(const char *query)
    (void)query;
    g_facts_calls++;
    return strdup("- global preference: never substitute for project evidence\n");
+}
+char *kb_client_memory_assemble_typed_context(const char *query)
+{
+   (void)query;
+   g_temporal_calls++;
+   return g_temporal_enabled
+              ? strdup("<memory_data trust=\"untrusted\">assertion</memory_data>\n"
+                       "<approved_procedures authority=\"reviewed\">procedure"
+                       "</approved_procedures>")
+              : NULL;
 }
 
 /* Typed-facts gate stub: off, so the builder's facts path stays inert here
@@ -555,6 +567,41 @@ static void test_budgeted_build_uses_memory_previews(void)
    printf("budgeted_build_uses_memory_previews OK\n");
 }
 
+static void test_default_temporal_context_injection(void)
+{
+   g_temporal_enabled = 1;
+   g_temporal_calls = 0;
+   g_context_mode = "observe";
+   char *env = ingress_preinject_build("recover the deployment", 0);
+   assert(env != NULL);
+   assert(strstr(env, "recommended (temporal learning):") != NULL);
+   assert(strstr(env, "<memory_data trust=\"untrusted\">assertion</memory_data>") != NULL);
+   assert(strstr(env, "<approved_procedures authority=\"reviewed\">") != NULL);
+   assert(g_temporal_calls == 1);
+   free(env);
+
+   /* The repository default is strict code-context mode. Temporal learning is
+    * an independently labelled and scope-filtered channel, so strict mode must
+    * not silently turn the default back off. */
+   ingress_preinject_task_state_reset();
+   ingress_preinject_set_session_id("session-temporal-strict");
+   g_context_mode = "on";
+   env = ingress_preinject_build("recover the strict deployment", 0);
+   assert(env != NULL);
+   assert(strstr(env, "recommended (task-conditioned code") != NULL);
+   assert(strstr(env, "recommended (temporal learning):") != NULL);
+   assert(g_temporal_calls == 2);
+   free(env);
+
+   /* The existing request-level ingress opt-out remains an instant rollback. */
+   assert(ingress_preinject_build("recover the deployment", 1) == NULL);
+   assert(g_temporal_calls == 2);
+   ingress_preinject_set_session_id(NULL);
+   g_context_mode = "observe";
+   g_temporal_enabled = 0;
+   printf("default_temporal_context_injection OK\n");
+}
+
 /* P0 Envelope IR: the renderer reproduces the old inline rendering — group
  * headers, single blank-line separators between non-empty groups, the
  * header-rides-the-first-fitting-candidate rule, the budget/omitted gate, the
@@ -711,6 +758,7 @@ int main(void)
    test_append();
    test_render_block();
    test_budgeted_build_uses_memory_previews();
+   test_default_temporal_context_injection();
    test_turn_id_mint_and_thread_local();
    test_compress_code_fold();
    printf("all tests passed\n");

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -39,11 +39,10 @@ char *kb_client_memory_assemble_typed_context(const char *query)
 {
    (void)query;
    g_temporal_calls++;
-   return g_temporal_enabled
-              ? strdup("<memory_data trust=\"untrusted\">assertion</memory_data>\n"
-                       "<approved_procedures authority=\"reviewed\">procedure"
-                       "</approved_procedures>")
-              : NULL;
+   return g_temporal_enabled ? strdup("<memory_data trust=\"untrusted\">assertion</memory_data>\n"
+                                      "<approved_procedures authority=\"reviewed\">procedure"
+                                      "</approved_procedures>")
+                             : NULL;
 }
 
 /* Typed-facts gate stub: off, so the builder's facts path stays inert here

--- a/src/tests/test_kb_client_memory.c
+++ b/src/tests/test_kb_client_memory.c
@@ -120,6 +120,24 @@ static int explicit_scope_post_handler(const char *url, const char *auth_header,
    return 200;
 }
 
+static int typed_context_post_handler(const char *url, const char *auth_header, const char *body,
+                                      char **response_buf, int timeout_ms,
+                                      const char *extra_headers)
+{
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   assert(url && strstr(url, "/v1/actions/memory.assemble_typed_context") != NULL);
+   assert(body != NULL);
+   assert(strstr(body, "\"query\":\"recover deployment\"") != NULL);
+   assert(strstr(body, "enable_semantic_assertions") == NULL);
+   assert(strstr(body, "enable_observations") == NULL);
+   if (response_buf)
+      *response_buf =
+          strdup("{\"status\":\"ok\",\"used_tokens\":4,\"rendered_context\":\"temporal\"}");
+   return 200;
+}
+
 static void test_readers_distinguish_unreachable_from_empty(void)
 {
    memory_t mems[8];
@@ -176,6 +194,8 @@ static void test_ordered_readers_propagate_active_project_context(void)
    (void)kb_client_memory_find_facts_visible("q", NULL, NULL, 8, mems, 8);
    char *json = kb_client_memory_assemble_context("q");
    free(json);
+   json = kb_client_memory_assemble_typed_context("q");
+   free(json);
    json = kb_client_memory_recall_json("q", 128, 0);
    free(json);
    json = kb_client_memory_alerts_json(NULL);
@@ -197,7 +217,7 @@ static void test_ordered_readers_propagate_active_project_context(void)
    (void)kb_client_memory_list_session_scope_priority_like("%q%", mems, 8);
 
    kb_client_memory_scope_context_clear();
-   assert(scoped_request_count == 20);
+   assert(scoped_request_count == 21);
    mock_agent_http_reset();
    printf("  PASS: test_ordered_readers_propagate_active_project_context\n");
 }
@@ -238,6 +258,16 @@ static void test_explicit_scope_overrides_ambient_context(void)
    printf("  PASS: test_explicit_scope_overrides_ambient_context\n");
 }
 
+static void test_typed_context_uses_server_defaults(void)
+{
+   mock_agent_http_set_post_handler(typed_context_post_handler);
+   char *context = kb_client_memory_assemble_typed_context("recover deployment");
+   assert(context && strcmp(context, "temporal") == 0);
+   free(context);
+   mock_agent_http_reset();
+   printf("  PASS: test_typed_context_uses_server_defaults\n");
+}
+
 int main(void)
 {
    /* A configured kb URL routes kb_client_v1_post_json through agent_http_post
@@ -249,6 +279,7 @@ int main(void)
    test_single_record_miss_is_not_dependency_failure();
    test_ordered_readers_propagate_active_project_context();
    test_explicit_scope_overrides_ambient_context();
+   test_typed_context_uses_server_defaults();
 
    unsetenv("AIMEE_KB_API_URL");
    runtime_secret_remove("AIMEE_KB_API_BEARER_TOKEN");


### PR DESCRIPTION
## Summary

- enable current semantic assertions, active observations, reviewed procedures, and typed-context assembly by default
- inject the trust-labelled temporal context through normal prompt ingress, including strict code-context mode
- keep master, ingress, and per-channel opt-outs; historical recall and the remaining typed channels stay opt-in
- enable failure-learning routing by default and document the reviewed 0.4.0 activation decision
- add boundary guards and focused regression coverage for defaults, scope propagation, strict mode, and rollback

## Validation

- `scripts/run_temporal_learning_acceptance.sh`
- `make -C src -j4 build/obj/tests/unit-test-config build/obj/tests/unit-test-kb-client-memory build/obj/tests/unit-test-ingress-preinject build/obj/tests/unit-test-gw-stage-memory`, followed by all four binaries
- `make -C src -j4 server`
- `git diff --check`

## .252 deployment evidence

The exact source snapshot was rebuilt and deployed in an isolated validation environment on `192.168.1.252`. The full acceptance runner, focused suites, and server build passed. Live API requests verified default-on assembly, the master and channel opt-outs, malformed-flag fail-closed behavior, historical opt-in, normal strict-mode ingress injection, and `X-Aimee-Preinject: 0` rollback.

Evidence: `/root/aimee-temporal-default-on-20260824T194144Z/results/` on `.252`. Validation services use loopback ports 18880-18882 and do not replace the earlier deployment.

## Stack

This PR is intentionally based on the validated temporal feature branch from #2833. The current `testing` branch has since extracted configuration into an external module; integrating this stack there should port the default in that module as a separate, reviewable migration.