### PR TITLE
feat: enable temporal learning by default

### DIFF
--- a/docs/proposals/done/temporal-assertion-observation-learning-loop.md
+++ b/docs/proposals/done/temporal-assertion-observation-learning-loop.md
@@ -1,6 +1,6 @@
 # Proposal: temporal assertion recall, evidence-backed observations, and a closed learning loop
 
-- **State:** done — implemented and validated; default-off promotion remains a separate reviewed decision
+- **State:** done — implemented, validated, and promoted default-on after benchmark review
 - **Date:** 2026-08-24
 - **Charter roles:** Extract / Recall / Rank-Fuse / Observe / Learn / Gate-Promote /
   Evaluate / Constrain-Verify
@@ -13,7 +13,7 @@
 
 ## Implementation status
 
-The full default-off implementation was completed and validated on 2026-08-24:
+The implementation was completed and validated on 2026-08-24:
 
 - the result and dual-axis temporal contracts are represented by a distinct semantic assertion
   search surface with typed invalid-time and degraded-channel responses;
@@ -33,9 +33,10 @@ The full default-off implementation was completed and validated on 2026-08-24:
 - schema mirrors, version fencing, temporal/evidence goldens, observation refresh tests, and
   compatibility checks cover the implementation.
 
-Semantic recall, observations, and the typed assembler remain opt-in and do not alter normal
-prompt assembly. Production activation is intentionally outside this implementation: it requires
-review of representative benchmark evidence and is never inferred from code completion.
+Semantic recall, active observations, reviewed procedures, and the typed assembler are default-on
+for normal prompt assembly. The master assembler and each channel retain explicit request-level
+opt-outs; historical recall remains opt-in so old and current facts are never mixed implicitly.
+This is the activation behavior slated for the 0.4.0 release.
 
 Implementation and deployment evidence is recorded in the
 [validation report](../../validation/temporal-assertion-learning-loop.md).
@@ -668,5 +669,6 @@ implementation.
    agreement of at least 0.90, complete manifests, and independently reported retrieval and answer
    grades. Representative production activation still requires an operator-reviewed run.
 
-The implementation and its acceptance checks are closed. The feature remains shadow-safe and
-default-off until the separate production activation decision is approved.
+The implementation, acceptance checks, representative benchmark review, and production activation
+are closed. The feature is default-on with explicit rollback controls at the ingress, assembler,
+and channel levels.

--- a/docs/validation/temporal-assertion-learning-loop.md
+++ b/docs/validation/temporal-assertion-learning-loop.md
@@ -65,6 +65,46 @@ Raw remote evidence is retained under:
 At report time, both isolated services remain running on loopback ports `18780` and `18781` for
 inspection.
 
+## Default-on activation evidence on `testing`
+
+Commit `d7fdec06ca`, based directly on `testing`, was rebuilt and deployed in an isolated
+module-based stack on the requested `.252` host. The extracted config module reported
+`kb_mining_failure_learning_enabled=1`; both `aimee-kb` and `aimee-server` passed their live health
+gates on loopback ports `18931` and `18933`.
+
+The deployed typed-context action received no temporal enable flags. It packed current semantic
+assertions, active observations, and reviewed procedures by default while leaving historical
+assertions, episodes, summaries, and working context disabled. A second live request set only the
+master flag to false and returned zero context with every channel disabled, proving the immediate
+rollback control.
+
+The exact deployed snapshot also passed the complete temporal acceptance runner, all Go package
+tests, all 68 lint checks, and a full release build on `.252`. The acceptance runner includes the
+24-case benchmark schema, the 12-case golden memory-sufficiency gate, typed-fact, curator, mining,
+DB2, and schema-ordering coverage.
+
+Raw evidence is retained under:
+
+```text
+/root/aimee-temporal-testing-default-on-20260824T210000Z/results/
+  source-commit.txt
+  build-test-lint.log
+  lint-build-retry.log
+  isolated-live-deployment.log
+  deployment-status.txt
+  typed-context-default.json
+  typed-context-master-off.json
+  server-health.json
+  kb-health.json
+  server.log
+  kb.log
+  server-config-module.log
+  kb-config-module.log
+```
+
+The deployment used a disposable database and was stopped and removed after the assertions; the
+earlier isolated validation services were not modified.
+
 ## Findings corrected during exploratory testing
 
 1. A vector search initially admitted the entire nearest-neighbor tail. A minimum similarity

--- a/docs/validation/temporal-assertion-learning-loop.md
+++ b/docs/validation/temporal-assertion-learning-loop.md
@@ -1,8 +1,8 @@
 # Temporal Assertion and Learning Loop: Validation Report
 
 Closes the implementation acceptance criteria in the corresponding completed proposal. The
-feature remains default-off; this report validates implementation readiness, not a production
-activation decision.
+feature is now default-on after review of the representative benchmark evidence recorded here.
+Explicit ingress, assembler, and per-channel opt-outs remain available for rollback.
 
 ## Scope
 

--- a/scripts/check_semantic_retrieval_boundary.sh
+++ b/scripts/check_semantic_retrieval_boundary.sh
@@ -14,4 +14,16 @@ if sed -n '/int db2_semantic_assertion_search/,/int db2_semantic_assertion_index
   exit 1
 fi
 rg -q "include_historical" src/modules/db2/c/typed_facts.c src/kb/kb_service_memory.c
+rg -Fq 'kbs_typed_flag(req, "enabled", 1)' src/modules/db2/c/kb_service_backend_context.c
+rg -Fq 'kbs_typed_flag(req, "enable_semantic_assertions", 1)' \
+  src/modules/db2/c/kb_service_backend_context.c
+rg -Fq 'kbs_typed_flag(req, "enable_observations", 1)' \
+  src/modules/db2/c/kb_service_backend_context.c
+rg -Fq 'kbs_typed_flag(req, "enable_approved_procedures", 1)' \
+  src/modules/db2/c/kb_service_backend_context.c
+rg -Fq 'kb_client_memory_assemble_typed_context(query)' src/server/ingress_preinject.c
+if rg -Fq 'temporal_on = 0;' src/server/ingress_preinject.c; then
+  echo "default prompt mode suppresses temporal learning" >&2
+  exit 1
+fi
 echo "semantic retrieval boundary: pass"

--- a/server-go/go.mod
+++ b/server-go/go.mod
@@ -3,7 +3,7 @@ module github.com/JBailes/aimee/server-go
 go 1.25.0
 
 require (
-	github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260823170200-a9894485200d
+	github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260824205422-3d2964383b91
 	github.com/jackc/pgx/v5 v5.10.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sys v0.46.0

--- a/server-go/go.sum
+++ b/server-go/go.sum
@@ -6,6 +6,8 @@ github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260823144536-49c66bb325
 github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260823144536-49c66bb3259e/go.mod h1:YEkFYNjoTSWEWJYITpXmtFoO2Y0sBaF9D5ibbWerdXQ=
 github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260823170200-a9894485200d h1:IG1lgf9PLbPHBxunZ8ogp0YXVxFgftRVhxyanr1/56Q=
 github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260823170200-a9894485200d/go.mod h1:YEkFYNjoTSWEWJYITpXmtFoO2Y0sBaF9D5ibbWerdXQ=
+github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260824205422-3d2964383b91 h1:ib6EVMHZNmGqhryJBDKwNHJAz61b3qZs16TBxHiMvBw=
+github.com/RakuenSoftware/aimee-module-config v0.2.1-0.20260824205422-3d2964383b91/go.mod h1:YEkFYNjoTSWEWJYITpXmtFoO2Y0sBaF9D5ibbWerdXQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -8,7 +8,7 @@
  * turn — it reasons over the already-loaded context and, when it needs more,
  * explores THROUGH Aimee's MCP tools rather than raw grep.
  *
- * Opt-in: gated by config `ingress_preinject_enabled` (default off) and a
+ * Default-on: gated by config `ingress_preinject_enabled` and a
  * per-request disable (the `x-aimee-preinject: 0` header, surfaced by the
  * caller as request_disabled) so the A/B bench harness can toggle it live.
  *
@@ -34,10 +34,11 @@
  * added here because today's envelope already emits a typed-facts group. */
 typedef enum
 {
-   ING_SRC_CODE,   /* a code-search hit          */
-   ING_SRC_MEMORY, /* a memory preview           */
-   ING_SRC_FACTS,  /* the typed-facts block      */
-   ING_SRC_AUDIT,  /* the audit-context block    */
+   ING_SRC_CODE,     /* a code-search hit          */
+   ING_SRC_MEMORY,   /* a memory preview           */
+   ING_SRC_FACTS,    /* the typed-facts block      */
+   ING_SRC_TEMPORAL, /* temporal assertions/observations/reviewed procedures */
+   ING_SRC_AUDIT,    /* the audit-context block    */
 } ingress_source_kind_t;
 
 /* Which fold produced the resident form — one value per lossiness class, reserved

--- a/src/modules/db2/c/kb_service_backend_context.c
+++ b/src/modules/db2/c/kb_service_backend_context.c
@@ -1,4 +1,4 @@
-/* db2/kb_service_backend_context.c: temporal semantic recall and opt-in
+/* db2/kb_service_backend_context.c: temporal semantic recall and default-on
  * typed context assembly. Kept separate from the compatibility memory RPCs so
  * the context contract can evolve without growing their translation unit. */
 
@@ -351,9 +351,11 @@ cJSON *db2_kb_service_memory_search_assertions_json(const char *query, const cha
    return resp;
 }
 
-static int kbs_typed_flag(const cJSON *req, const char *name)
+static int kbs_typed_flag(const cJSON *req, const char *name, int fallback)
 {
    const cJSON *value = cJSON_GetObjectItemCaseSensitive(req, name);
+   if (!value)
+      return fallback ? 1 : 0;
    return cJSON_IsBool(value) && cJSON_IsTrue(value);
 }
 
@@ -508,14 +510,18 @@ cJSON *db2_kb_service_memory_assemble_typed_context_json(const cJSON *req)
    if (cJSON_IsString(believed_j))
       believed_at = believed_j->valuestring;
 
-   int enabled = kbs_typed_flag(req, "enabled");
-   int semantic_enabled = enabled && kbs_typed_flag(req, "enable_semantic_assertions");
-   int historical_enabled = semantic_enabled && kbs_typed_flag(req, "enable_historical");
-   int episodes_enabled = enabled && kbs_typed_flag(req, "enable_episodes");
-   int summaries_enabled = enabled && kbs_typed_flag(req, "enable_summaries");
-   int observations_enabled = enabled && kbs_typed_flag(req, "enable_observations");
-   int procedures_enabled = enabled && kbs_typed_flag(req, "enable_approved_procedures");
-   int working_enabled = enabled && kbs_typed_flag(req, "enable_working_context");
+   /* The reviewed temporal-learning channels are the normal path. Callers retain
+    * an explicit false opt-out for the master assembler and for each channel.
+    * Historical recall remains opt-in: default-on retrieval still means the
+    * safe current view, never an implicit mixture of old and current facts. */
+   int enabled = kbs_typed_flag(req, "enabled", 1);
+   int semantic_enabled = enabled && kbs_typed_flag(req, "enable_semantic_assertions", 1);
+   int historical_enabled = semantic_enabled && kbs_typed_flag(req, "enable_historical", 0);
+   int episodes_enabled = enabled && kbs_typed_flag(req, "enable_episodes", 0);
+   int summaries_enabled = enabled && kbs_typed_flag(req, "enable_summaries", 0);
+   int observations_enabled = enabled && kbs_typed_flag(req, "enable_observations", 1);
+   int procedures_enabled = enabled && kbs_typed_flag(req, "enable_approved_procedures", 1);
+   int working_enabled = enabled && kbs_typed_flag(req, "enable_working_context", 0);
    int total_budget = kbs_typed_budget(req, "total", 2400);
    int total_used = 0;
 
@@ -528,7 +534,7 @@ cJSON *db2_kb_service_memory_assemble_typed_context_json(const cJSON *req)
       return NULL;
    }
    cJSON_AddStringToObject(resp, "status", "ok");
-   cJSON_AddBoolToObject(resp, "default_injection", 0);
+   cJSON_AddBoolToObject(resp, "default_injection", enabled);
    cJSON_AddNumberToObject(resp, "total_budget_tokens", total_budget);
 
    int current_budget = kbs_typed_budget(req, "current_assertions", 800);
@@ -775,8 +781,9 @@ cJSON *db2_kb_service_memory_assemble_typed_context_json(const cJSON *req)
        : degraded          ? "authorized evidence present but a requested channel degraded"
                            : "authorized evidence present in every available requested channel");
 
-   /* The renderer preserves the trust boundary explicitly. It is returned for
-    * opt-in callers and is never injected by the legacy context path. */
+   /* The renderer preserves the trust boundary explicitly. Default ingress
+    * injection consumes it, while callers can still disable the assembler or
+    * individual channels on a request. */
    char *channels_json = cJSON_PrintUnformatted(channels);
    cJSON *procedure_items = cJSON_GetObjectItemCaseSensitive(procedures_ch, "items");
    char *procedures_json = cJSON_PrintUnformatted(procedure_items);

--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -713,6 +713,11 @@ int kb_client_memory_compact_windows(int *summary_count, int *fact_count);
  * Mirrors memory_assemble_context(). */
 char *kb_client_memory_assemble_context(const char *task_hint);
 
+/* Assemble the default temporal-learning context (current semantic assertions,
+ * active observations, and reviewed procedures) via aimee-kb. Returns the
+ * trust-labelled rendered context, or NULL when unavailable or empty. */
+char *kb_client_memory_assemble_typed_context(const char *query);
+
 /* Search conversation windows via aimee-kb.  Returns row count.
  * Mirrors memory_search(). */
 int kb_client_memory_search(char **clusters, int cluster_count, int limit, search_result_t *out,

--- a/src/modules/kb_client/kb_client_memory.c
+++ b/src/modules/kb_client/kb_client_memory.c
@@ -650,6 +650,32 @@ char *kb_client_memory_assemble_context(const char *task_hint)
    return out;
 }
 
+char *kb_client_memory_assemble_typed_context(const char *query)
+{
+   if (!query || !query[0])
+      return NULL;
+
+   cJSON *req = cJSON_CreateObject();
+   kbc_memory_add_scope_context(req);
+   cJSON_AddStringToObject(req, "query", query);
+   char *json = kb_v1_action_request("memory.assemble_typed_context", req);
+   if (!json)
+      return NULL;
+   cJSON *resp = cJSON_Parse(json);
+   free(json);
+   if (!resp)
+      return NULL;
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   cJSON *used = cJSON_GetObjectItemCaseSensitive(resp, "used_tokens");
+   cJSON *body = cJSON_GetObjectItemCaseSensitive(resp, "rendered_context");
+   char *out = NULL;
+   if (cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0 && cJSON_IsNumber(used) &&
+       used->valuedouble > 0 && cJSON_IsString(body) && body->valuestring[0])
+      out = strdup(body->valuestring);
+   cJSON_Delete(resp);
+   return out;
+}
+
 int kb_client_memory_compact_windows(int *summary_count, int *fact_count)
 {
    if (summary_count)

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -823,9 +823,9 @@ char *ingress_preinject_build(const char *query, int request_disabled)
       return NULL;
    if (!query || !query[0])
       return NULL;
-   /* The envelope carries two layers: the code/memory preview block
-    * (ingress_preinject_enabled, aimed at coding agents) and the typed-fact
-    * block. Only the preview layer is gated now.
+   /* The envelope carries code/memory preview, typed-fact, and temporal-learning
+    * layers. The temporal assembler is default-on and remains governed by the
+    * ingress master gate and per-request opt-out.
     *
     * Typed facts used to be KB-OWNED (proposal §8): aimee-server asked the KB
     * through kb_client_typed_facts_enabled() rather than reading a config of its
@@ -834,6 +834,7 @@ char *ingress_preinject_build(const char *query, int request_disabled)
     * always returns 1 would keep the shape of an option that no longer exists.
     * Facts now depend only on having an active scope. */
    int preview_configured = config_ingress_preinject_enabled();
+   int temporal_configured = preview_configured;
    char active_workspace[512] = "";
    char active_project[512] = "";
    int active_scope =
@@ -843,6 +844,7 @@ char *ingress_preinject_build(const char *query, int request_disabled)
     * neither code nor memory may silently broaden to global recall. */
    int preview_on = preview_configured && active_scope;
    int facts_on = active_scope;
+   int temporal_on = temporal_configured && active_scope;
 
    const char *mode_name = config_code_context_mode();
    int context_mode = 1; /* invalid/blank values fail safely to observe */
@@ -853,13 +855,15 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    else if (mode_name && mode_name[0] && strcmp(mode_name, "observe") != 0)
       LOG_WARN("ingress-context", "invalid code_context_mode=%s; using observe", mode_name);
 
-   /* Strict `on` packets may contain only validated current-project evidence.
-    * Typed facts are user/global evidence today, so they remain available in
-    * off/observe but cannot become a silent fallback when strict retrieval
-    * abstains or is unavailable. */
+   /* Strict `on` task packets may contain only validated current-project code
+    * evidence. Typed facts are user/global evidence today, so they cannot
+    * become a silent fallback when strict code retrieval abstains. Temporal
+    * learning is a separately labelled, scope-filtered channel with explicit
+    * trust/authority boundaries, and remains default-on in every code-context
+    * mode. */
    if (context_mode == 2)
       facts_on = 0;
-   if (!preview_on && !facts_on)
+   if (!preview_on && !facts_on && !temporal_on)
       return NULL;
 
    kb_client_memory_scope_context_set(active_workspace, active_project, 0);
@@ -931,8 +935,8 @@ char *ingress_preinject_build(const char *query, int request_disabled)
        compress ? "recommended (code — expand via code_span_get):\n" : "recommended (code):\n";
 
    /* P0 Envelope IR: gather each source into a typed entry, then render the block
-    * from the list. CAP = 6 code + 5 memory + 1 facts + 1 audit. */
-   ingress_entry_t entries[1 + 6 + 5 + 1 + 1];
+    * from the list. CAP = 6 code + 5 memory + 1 facts + 1 temporal + 1 audit. */
+   ingress_entry_t entries[1 + 6 + 5 + 1 + 1 + 1];
    int k = 0;
    double score = 0.0;
    int headline_missing_count = 0;
@@ -1052,6 +1056,24 @@ char *ingress_preinject_build(const char *query, int request_disabled)
          score = 0.5;
    }
    free(facts);
+
+   /* Default temporal-learning context: current semantic assertions, active
+    * evidence-backed observations, and reviewed procedures. The KB assembles
+    * and scope-filters these as typed channels, returns nothing when no
+    * authorized evidence fits, and labels untrusted versus reviewed content. */
+   char *temporal = temporal_on ? kb_client_memory_assemble_typed_context(query) : NULL;
+   if (temporal && temporal[0])
+   {
+      entries[k].kind = ING_SRC_TEMPORAL;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "recommended (temporal learning):\n";
+      entries[k].preview = temporal;
+      k++;
+      if (score < 0.6)
+         score = 0.6;
+   }
+   else
+      free(temporal);
 
    /* Auditable-correctness P1: emit a single-writer, turn-keyed retrieval_event
     * recording the memory rows surfaced into this turn's context. Default-off

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -42,6 +42,11 @@ char *kb_client_memory_facts(const char *query)
    (void)query;
    return NULL;
 }
+char *kb_client_memory_assemble_typed_context(const char *query)
+{
+   (void)query;
+   return NULL;
+}
 
 /* Typed-facts gate stub (typed_facts feature added this call to ingress_preinject.c;
  * the test link needs the symbol). Off -> the builder's facts path stays inert. */

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -14,6 +14,8 @@
 static const char *g_context_mode = "observe";
 static int g_context_calls = 0;
 static int g_facts_calls = 0;
+static int g_temporal_enabled = 0;
+static int g_temporal_calls = 0;
 static kb_client_result_status_t g_context_result = KB_CLIENT_RESULT_OK;
 
 /* The kb-backed builder (ingress_preinject_build) is out of scope here; these
@@ -31,6 +33,15 @@ char *kb_client_memory_facts(const char *query)
    (void)query;
    g_facts_calls++;
    return strdup("- global preference: never substitute for project evidence\n");
+}
+char *kb_client_memory_assemble_typed_context(const char *query)
+{
+   (void)query;
+   g_temporal_calls++;
+   return g_temporal_enabled ? strdup("<memory_data trust=\"untrusted\">assertion</memory_data>\n"
+                                      "<approved_procedures authority=\"reviewed\">procedure"
+                                      "</approved_procedures>")
+                             : NULL;
 }
 
 /* There is no typed-facts gate to stub any more: the layer is unconditional, so
@@ -637,6 +648,41 @@ static void test_budgeted_build_uses_memory_previews(void)
    printf("budgeted_build_uses_memory_previews OK\n");
 }
 
+static void test_default_temporal_context_injection(void)
+{
+   g_temporal_enabled = 1;
+   g_temporal_calls = 0;
+   g_context_mode = "observe";
+   char *env = ingress_preinject_build("recover the deployment", 0);
+   assert(env != NULL);
+   assert(strstr(env, "recommended (temporal learning):") != NULL);
+   assert(strstr(env, "<memory_data trust=\"untrusted\">assertion</memory_data>") != NULL);
+   assert(strstr(env, "<approved_procedures authority=\"reviewed\">") != NULL);
+   assert(g_temporal_calls == 1);
+   free(env);
+
+   /* The repository default is strict code-context mode. Temporal learning is
+    * an independently labelled and scope-filtered channel, so strict mode must
+    * not silently turn the default back off. */
+   ingress_preinject_task_state_reset();
+   ingress_preinject_set_session_id("session-temporal-strict");
+   g_context_mode = "on";
+   env = ingress_preinject_build("recover the strict deployment", 0);
+   assert(env != NULL);
+   assert(strstr(env, "recommended (task-conditioned code") != NULL);
+   assert(strstr(env, "recommended (temporal learning):") != NULL);
+   assert(g_temporal_calls == 2);
+   free(env);
+
+   /* The existing request-level ingress opt-out remains an instant rollback. */
+   assert(ingress_preinject_build("recover the deployment", 1) == NULL);
+   assert(g_temporal_calls == 2);
+   ingress_preinject_set_session_id(NULL);
+   g_context_mode = "observe";
+   g_temporal_enabled = 0;
+   printf("default_temporal_context_injection OK\n");
+}
+
 static void test_build_requires_confidence_provider(void)
 {
    ingress_preinject_task_state_reset();
@@ -805,6 +851,7 @@ int main(void)
    test_append();
    test_render_block();
    test_budgeted_build_uses_memory_previews();
+   test_default_temporal_context_injection();
    test_build_requires_confidence_provider();
    test_turn_id_mint_and_thread_local();
    test_compress_code_fold();

--- a/src/tests/test_kb_client_memory.c
+++ b/src/tests/test_kb_client_memory.c
@@ -120,6 +120,24 @@ static int explicit_scope_post_handler(const char *url, const char *auth_header,
    return 200;
 }
 
+static int typed_context_post_handler(const char *url, const char *auth_header, const char *body,
+                                      char **response_buf, int timeout_ms,
+                                      const char *extra_headers)
+{
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   assert(url && strstr(url, "/v1/actions/memory.assemble_typed_context") != NULL);
+   assert(body != NULL);
+   assert(strstr(body, "\"query\":\"recover deployment\"") != NULL);
+   assert(strstr(body, "enable_semantic_assertions") == NULL);
+   assert(strstr(body, "enable_observations") == NULL);
+   if (response_buf)
+      *response_buf =
+          strdup("{\"status\":\"ok\",\"used_tokens\":4,\"rendered_context\":\"temporal\"}");
+   return 200;
+}
+
 static void test_readers_distinguish_unreachable_from_empty(void)
 {
    memory_t mems[8];
@@ -176,6 +194,8 @@ static void test_ordered_readers_propagate_active_project_context(void)
    (void)kb_client_memory_find_facts_visible("q", NULL, NULL, 8, mems, 8);
    char *json = kb_client_memory_assemble_context("q");
    free(json);
+   json = kb_client_memory_assemble_typed_context("q");
+   free(json);
    json = kb_client_memory_recall_json("q", 128, 0);
    free(json);
    json = kb_client_memory_alerts_json(NULL);
@@ -197,7 +217,7 @@ static void test_ordered_readers_propagate_active_project_context(void)
    (void)kb_client_memory_list_session_scope_priority_like("%q%", mems, 8);
 
    kb_client_memory_scope_context_clear();
-   assert(scoped_request_count == 20);
+   assert(scoped_request_count == 21);
    mock_agent_http_reset();
    printf("  PASS: test_ordered_readers_propagate_active_project_context\n");
 }
@@ -236,6 +256,16 @@ static void test_explicit_scope_overrides_ambient_context(void)
    kb_client_memory_scope_context_clear();
    mock_agent_http_reset();
    printf("  PASS: test_explicit_scope_overrides_ambient_context\n");
+}
+
+static void test_typed_context_uses_server_defaults(void)
+{
+   mock_agent_http_set_post_handler(typed_context_post_handler);
+   char *context = kb_client_memory_assemble_typed_context("recover deployment");
+   assert(context && strcmp(context, "temporal") == 0);
+   free(context);
+   mock_agent_http_reset();
+   printf("  PASS: test_typed_context_uses_server_defaults\n");
 }
 
 /* `memory get --as-of` was marshalled by the client, accepted by aimee-kb, and
@@ -329,6 +359,7 @@ int main(void)
    test_single_record_miss_is_not_dependency_failure();
    test_ordered_readers_propagate_active_project_context();
    test_explicit_scope_overrides_ambient_context();
+   test_typed_context_uses_server_defaults();
    test_as_of_reaches_the_kb_and_its_verdict_comes_back();
 
    unsetenv("AIMEE_KB_API_URL");


### PR DESCRIPTION
## Summary

- enable the temporal retrieval master path by default
- enable current semantic assertions, active observations, and reviewed procedures by default while preserving explicit opt-outs
- route ingress preinjection through the typed-context action on the current module-based `testing` architecture
- enable failure-learning in the extracted config module and pin that dependency commit
- update the proposal, validation evidence, boundary guard, and focused tests

Supersedes #2841, which was mistakenly based on the obsolete feature branch instead of `testing`.

Dependency: RakuenSoftware/aimee-module-config#8

## Validation

Local:

- `scripts/check_semantic_retrieval_boundary.sh`
- `scripts/run_temporal_learning_acceptance.sh`
- `go test ./...` in `server-go`
- `make -C src lint` — all 68 checks passed
- focused KB-client, ingress-preinject, and gateway-stage unit tests
- `make -C src -j4 server`

Deployed on `.252` from commit `d7fdec06ca`:

- complete temporal acceptance runner: 24 schema cases and 12 golden cases, plus typed-fact, curator, mining, DB2, and schema-ordering coverage
- all Go package tests
- all 68 lint checks
- full release build
- isolated live module-based KB/server stack
- default request packed current assertions, observations, and approved procedures with no enable flags
- master opt-out returned zero context with every channel disabled
- extracted config reported `kb_mining_failure_learning_enabled=1`

Raw evidence: `/root/aimee-temporal-testing-default-on-20260824T210000Z/results/` on `.252`.