### PR TITLE
Fix managed identity and index scope release blockers

### DIFF
--- a/deploy/container/runtime-web-lib.sh
+++ b/deploy/container/runtime-web-lib.sh
@@ -250,7 +250,14 @@ webchat_restore_identities() {
             '!'* | '*'*) continue ;;
         esac
         getent passwd "$_wc_u" >/dev/null 2>&1 && continue
-        if ! useradd --create-home --shell /usr/sbin/nologin "$_wc_u" >/dev/null 2>&1; then
+        # Name the managed group as both primary and supplementary, matching
+        # runtime-web's live account-creation path. Otherwise useradd tries to
+        # allocate a same-named private group and restoration fails for standard
+        # operator names such as "operator" when that system group already
+        # exists in the image.
+        if ! useradd --create-home --gid "$WEBCHAT_LOGIN_GROUP" \
+                     --groups "$WEBCHAT_LOGIN_GROUP" \
+                     --shell /usr/sbin/nologin "$_wc_u" >/dev/null 2>&1; then
             webchat_log "WARNING: could not restore the login '$_wc_u'"
             continue
         fi

--- a/scripts/check-webchat-bootstrap-login.sh
+++ b/scripts/check-webchat-bootstrap-login.sh
@@ -277,6 +277,7 @@ printf 'admin\n' > "$WEBCHAT_BOOTSTRAP_REPLACED"
 restore_log=$(webchat_provision_bootstrap_account 2>&1)
 # The operator's own account is back, with its own verifier...
 grep -Fq 'useradd' "$cleared_users"
+grep -Fq "useradd --create-home --gid $WEBCHAT_LOGIN_GROUP --groups $WEBCHAT_LOGIN_GROUP --shell /usr/sbin/nologin admin" "$cleared_users"
 grep -Fq -- "-aG $WEBCHAT_LOGIN_GROUP admin" "$cleared_users"
 # ...and is actually IN the group. Assert the RESULT, not the invocation: usermod
 # records its arguments before it can fail, so the line above passed even while the

--- a/src/cli_argspec.c
+++ b/src/cli_argspec.c
@@ -68,9 +68,10 @@
  * They are NAMED, FIXED facts, not a general escape. There is deliberately no
  * `{"from": "env", "name": <anything>}`: that would let a server -- or anyone
  * who could answer as one -- ask the client to read AWS_SECRET_ACCESS_KEY and
- * post it back. A spec can ask for the working directory and the session id
- * because those are the two the CLI already puts on the wire, and for nothing
- * else. Adding a third is a deliberate act, not a configuration. */
+ * post it back. A spec can ask for the working directory, session id, and
+ * active project because those are fixed values the CLI already puts on the
+ * wire, and for nothing else. Adding another is a deliberate act, not a
+ * configuration. */
 /* An ordered cascade for ONE field: the first source that yields a value wins,
  * and `default` supplies a literal when none does. memory.recall's task_hint is
  * --task, then positional[0], then --query, then the literal "session start".
@@ -96,6 +97,7 @@
 #define SRC_FIRST_OF         "first_of"
 #define SRC_CWD              "cwd"
 #define SRC_SESSION          "session"
+#define SRC_PROJECT          "project"
 
 /* Whether a field present-but-empty is sent or dropped. Absent means "drop".
  *
@@ -201,13 +203,14 @@ static const char *field_str(const cJSON *field, const char *key)
 
 static int known_source(const char *from)
 {
-   return from && (!strcmp(from, SRC_FLAG) || !strcmp(from, SRC_POSITIONAL) ||
-                   !strcmp(from, SRC_POSITIONAL_FLAG) || !strcmp(from, SRC_FLAG_POSITIONAL) ||
-                   !strcmp(from, SRC_ARGV_JOINED) || !strcmp(from, SRC_ARGV_ARRAY) ||
-                   !strcmp(from, SRC_ARGV_INDEX) || !strcmp(from, SRC_REPEATED_FLAG) ||
-                   !strcmp(from, SRC_CWD) || !strcmp(from, SRC_SESSION) ||
-                   !strcmp(from, SRC_FIRST_OF) || !strcmp(from, SRC_POSITIONAL_ARRAY) ||
-                   !strcmp(from, SRC_CONST) || !strcmp(from, SRC_POSITIONAL_JOIN));
+   return from &&
+          (!strcmp(from, SRC_FLAG) || !strcmp(from, SRC_POSITIONAL) ||
+           !strcmp(from, SRC_POSITIONAL_FLAG) || !strcmp(from, SRC_FLAG_POSITIONAL) ||
+           !strcmp(from, SRC_ARGV_JOINED) || !strcmp(from, SRC_ARGV_ARRAY) ||
+           !strcmp(from, SRC_ARGV_INDEX) || !strcmp(from, SRC_REPEATED_FLAG) ||
+           !strcmp(from, SRC_CWD) || !strcmp(from, SRC_SESSION) || !strcmp(from, SRC_PROJECT) ||
+           !strcmp(from, SRC_FIRST_OF) || !strcmp(from, SRC_POSITIONAL_ARRAY) ||
+           !strcmp(from, SRC_CONST) || !strcmp(from, SRC_POSITIONAL_JOIN));
 }
 
 static int known_empty(const char *e)
@@ -388,6 +391,18 @@ static const char *field_value(const cJSON *field, const cli_args_t *opts, const
       if (s && s[0])
          return s;
       return "default";
+   }
+
+   if (!strcmp(from, SRC_PROJECT))
+   {
+      /* marshal_add_index_context(): an explicit flag wins, then the launcher
+       * supplied stable project id. This remains a fixed, non-secret fact; a
+       * served spec still cannot name an arbitrary environment variable. */
+      const char *project = cli_args_get(opts, flag && flag[0] ? flag : "project");
+      if (project && project[0])
+         return project;
+      project = getenv("AIMEE_PROJECT_ID");
+      return project && project[0] ? project : NULL;
    }
 
    if (!strcmp(from, SRC_POSITIONAL_JOIN))

--- a/src/headers/cli_argspec.h
+++ b/src/headers/cli_argspec.h
@@ -85,6 +85,10 @@
  * A constant concatenation and a length limit are less computation than the
  * clamp above, and neither consults another field.
  *
+ * The fixed `cwd`, `session`, and `project` sources are named client facts. The
+ * project source reproduces the CLI's `--project` then `AIMEE_PROJECT_ID`
+ * precedence without exposing a general environment-variable reader.
+ *
  * So: a field's rule may depend on its own value, its own flags, named client
  * facts the SERVER asked for, and the invocation's ARITY. It may not depend on
  * another field's value, and it may not compute one. That still forbids things:

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -393,7 +393,10 @@ static int kb_search_project_scope(const char *body, char *project, size_t proje
    if (strcmp(scope, "all") == 0)
    {
       cJSON_Delete(root);
-      if (verified)
+      /* A service credential is the managed deployment's data-plane identity:
+       * it spans projects but remains tenant-bounded by the resolved caller
+       * context and is still excluded from administrative routes. */
+      if (verified && strcmp(verified_kind, KB_SCOPE_KIND_SERVICE) != 0)
       {
          snprintf(out_buf, (size_t)out_cap,
                   "{\"error\":{\"type\":\"forbidden\",\"message\":\"a scoped credential "

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -25,6 +25,7 @@
 #include "modules/db2/c/lessons.h" /* §3 actuation: earned-trust tie-break */
 #include "kb/lessons_reflect.h"    /* reflect the ledger into per-node trust */
 #include "kb_reqctx.h"
+#include "kb_scope.h"
 #include <time.h>
 #include "kb/kb_graph_analytics.h"
 #include "kb/kb_service_graph.h"
@@ -126,7 +127,12 @@ int code_request_project(const char *query_string, char *project, size_t project
                   "one current project\"}}");
          return 400;
       }
-      if (has_verified_scope)
+      /* The managed server's service credential is the deployment data-plane
+       * identity. It spans projects (kb_scope_authorized makes the same
+       * distinction for named targets), so it may perform an explicitly-wide
+       * read inside the tenant selected by the authenticated service/caller
+       * intersection. Project and other limited credentials remain fenced. */
+      if (has_verified_scope && strcmp(verified_kind, KB_SCOPE_KIND_SERVICE) != 0)
       {
          snprintf(out_buf, (size_t)out_cap,
                   "{\"error\":{\"type\":\"forbidden\",\"message\":\"a scoped credential cannot "

--- a/src/server/cli_argspec_defs_data.h
+++ b/src/server/cli_argspec_defs_data.h
@@ -169,7 +169,8 @@
 {"index.find",
  "{\"bool_flags\":[\"json\"],\"fields\":[{\"json\":\"identifier\","
  "\"count_min\":1,\"from\":\"positional\",\"index\":0,\"empty\":\"emit\""
- "},{\"json\":\"scope\",\"from\":\"flag\",\"flag\":\"scope\",\"empty\":"
+ "},{\"json\":\"project\",\"from\":\"project\"},{\"json\":\"scope\","
+ "\"from\":\"flag\",\"flag\":\"scope\",\"empty\":"
  "\"drop\"},{\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
 
 {"memory.list",
@@ -193,9 +194,9 @@
  "{\"bool_flags\":[\"json\"],\"fields\":[{\"json\":\"symbol\","
  "\"count_min\":1,\"from\":\"positional\",\"index\":0,\"empty\":\"emit\""
  "},{\"json\":\"project\",\"count_min\":2,\"from\":\"positional\","
- "\"index\":1,\"empty\":\"emit\"},{\"json\":\"scope\",\"from\":\"flag\","
- "\"flag\":\"scope\",\"empty\":\"drop\"},{\"json\":\"cwd\",\"from\":"
- "\"cwd\"}]}"},
+ "\"index\":1,\"empty\":\"emit\"},{\"json\":\"project\",\"count_max\":1,"
+ "\"from\":\"project\"},{\"json\":\"scope\",\"from\":\"flag\",\"flag\":"
+ "\"scope\",\"empty\":\"drop\"},{\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
 
 {"kb.search",
  "{\"fields\":[{\"json\":\"query\",\"count_min\":1,\"from\":"
@@ -363,20 +364,17 @@
  "},{\"json\":\"file_path\",\"count_min\":2,\"from\":\"positional\","
  "\"index\":1,\"empty\":\"emit\"},{\"json\":\"file_path\",\"count_min\":"
  "1,\"count_max\":1,\"from\":\"positional\",\"index\":0,\"empty\":"
- "\"emit\"},{\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
+ "\"emit\"},{\"json\":\"project\",\"count_max\":1,\"from\":\"project\"},{"
+ "\"json\":\"scope\",\"from\":\"flag\",\"flag\":\"scope\"},{\"json\":"
+ "\"cwd\",\"from\":\"cwd\"}]}"},
 
 {"index.hybrid",
  "{\"bool_flags\":[\"json\"],\"fields\":[{\"json\":\"queries\",\"from\":"
  "\"positional_array\",\"count_min\":2},{\"json\":\"query\","
  "\"count_min\":1,\"count_max\":1,\"from\":\"positional\",\"index\":0,"
- "\"empty\":\"emit\"},{\"json\":\"scope\",\"from\":\"flag\",\"flag\":"
+ "\"empty\":\"emit\"},{\"json\":\"project\",\"from\":\"project\"},{\"json\":"
+ "\"scope\",\"from\":\"flag\",\"flag\":"
  "\"scope\"},{\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
-
-{"index.investigate",
- "{\"bool_flags\":[\"json\"],\"fields\":[{\"json\":\"queries\",\"from\":"
- "\"positional_array\",\"count_min\":2},{\"json\":\"query\","
- "\"count_min\":1,\"count_max\":1,\"from\":\"positional\",\"index\":0,"
- "\"empty\":\"emit\"},{\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
 
 {"index.structure",
  "{\"bool_flags\":[\"json\"],\"fields\":[{\"json\":\"project\","
@@ -384,7 +382,9 @@
  "},{\"json\":\"file_path\",\"count_min\":2,\"from\":\"positional\","
  "\"index\":1,\"empty\":\"emit\"},{\"json\":\"file_path\",\"count_min\":"
  "1,\"count_max\":1,\"from\":\"positional\",\"index\":0,\"empty\":"
- "\"emit\"},{\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
+ "\"emit\"},{\"json\":\"project\",\"count_max\":1,\"from\":\"project\"},{"
+ "\"json\":\"scope\",\"from\":\"flag\",\"flag\":\"scope\"},{\"json\":"
+ "\"cwd\",\"from\":\"cwd\"}]}"},
 
 {"skill.pin",
  "{\"fields\":[{\"json\":\"cwd\",\"from\":\"cwd\"},{\"json\":\"name\","
@@ -919,7 +919,9 @@
  "\"ambiguous\"},{\"json\":\"direction\",\"from\":\"flag\",\"flag\":"
  "\"reverse\",\"type\":\"const_if_set\",\"value\":\"in\"},{\"json\":"
  "\"dry_run\",\"from\":\"flag\",\"flag\":\"dry-run\",\"type\":"
- "\"true_if_set\"},{\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
+ "\"true_if_set\"},{\"json\":\"project\",\"count_max\":0,\"from\":\"project\"},{"
+ "\"json\":\"scope\",\"from\":\"flag\",\"flag\":\"scope\"},{"
+ "\"json\":\"cwd\",\"from\":\"cwd\"}]}"},
 
 /* The inverted-flag pair: `compress` is true unless --no-compress was given. */
 

--- a/src/tests/test_cli_argspec.c
+++ b/src/tests/test_cli_argspec.c
@@ -121,6 +121,7 @@ static const sample_t SAMPLES[] = {
     {"index.find", {"", NULL}},
     {"index.find", {"foo", "--scope", "", NULL}},
     {"index.find", {"--json", "foo", NULL}},
+    {"index.find", {"foo", "--project", "explicit-project", NULL}},
 
     {"memory.list", {NULL}},
     {"memory.list", {"--tier", "L2", NULL}},
@@ -149,6 +150,7 @@ static const sample_t SAMPLES[] = {
     {"index.find_callers", {"", "", NULL}},
     {"index.find_callers", {"p0", "p1", "p2", NULL}},
     {"index.find_callers", {"--unknown-flag", "x", NULL}},
+    {"index.find_callers", {"p0", "--project", "explicit-project", NULL}},
     {"kb.search", {NULL}},
     {"kb.search", {"--project", "v", NULL}},
     {"kb.search", {"--scope", "v", NULL}},
@@ -424,6 +426,7 @@ static const sample_t SAMPLES[] = {
     {"session.brief", {"p0", "p1", NULL}},
     {"index.deps", {"p0", NULL}},
     {"index.deps", {"p0", "p1", NULL}},
+    {"index.deps", {"--project", "explicit-project", "--scope", "all", NULL}},
     {"session.close", {"p0", NULL}},
     {"session.close", {"p0", "p1", NULL}},
     {"session.get", {"p0", NULL}},
@@ -438,6 +441,7 @@ static const sample_t SAMPLES[] = {
     {"index.blast_radius", {"", NULL}},
     {"index.blast_radius", {"", "", NULL}},
     {"index.blast_radius", {"--unknown-flag", "x", NULL}},
+    {"index.blast_radius", {"p0", "--project", "explicit-project", "--scope", "all", NULL}},
     {"index.hybrid", {NULL}},
     {"index.hybrid", {"--scope", "v", NULL}},
     {"index.hybrid", {"--scope", "v", NULL}},
@@ -447,11 +451,7 @@ static const sample_t SAMPLES[] = {
     {"index.hybrid", {"p0", "p1", NULL}},
     {"index.hybrid", {"", NULL}},
     {"index.hybrid", {"--unknown-flag", "x", NULL}},
-    {"index.investigate", {NULL}},
-    {"index.investigate", {"p0", NULL}},
-    {"index.investigate", {"p0", "p1", NULL}},
-    {"index.investigate", {"", NULL}},
-    {"index.investigate", {"--unknown-flag", "x", NULL}},
+    {"index.hybrid", {"p0", "--project", "explicit-project", NULL}},
     {"index.structure", {NULL}},
     {"index.structure", {"p0", NULL}},
     {"index.structure", {"p0", "p1", NULL}},
@@ -459,6 +459,7 @@ static const sample_t SAMPLES[] = {
     {"index.structure", {"", NULL}},
     {"index.structure", {"", "", NULL}},
     {"index.structure", {"--unknown-flag", "x", NULL}},
+    {"index.structure", {"p0", "--project", "explicit-project", "--scope", "all", NULL}},
     {"skill.pin", {NULL}},
     {"skill.pin", {"--unknown-flag", "x", NULL}},
     {"skill.unpin", {NULL}},
@@ -2288,6 +2289,11 @@ int main(void)
     * unnoticed when it was planted. Set it to something no sample passes as a
     * flag, and the samples below separate the three steps. */
    setenv("AIMEE_SESSION_ID", "env-session-id", 1);
+   /* The project source has the same fixed-context property: an explicit flag
+    * wins, otherwise the launcher-provided project id is sent. A nonempty env
+    * value makes every shared index-context sample prove the fallback rather
+    * than accidentally agreeing when both sides omit it. */
+   setenv("AIMEE_PROJECT_ID", "env-project-id", 1);
 
    test_every_shipped_spec_is_sampled();
    for (size_t i = 0; i < sizeof(SAMPLES) / sizeof(SAMPLES[0]); i++)

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -5995,6 +5995,17 @@ static void test_service_scope_is_data_plane_not_admin(void)
                         sizeof(buf));
    assert(s != 403);
 
+   /* MAY: explicitly search across the tenant's projects. Managed server
+    * callers have no project-scoped credential to supply, so rejecting
+    * scope=all here makes the CLI's prescribed fallback unusable. */
+   s = kb_http_route_ex("GET", "/v1/code/find", "identifier=foo&scope=all", svc_auth, svc_tok, NULL,
+                        0, buf, sizeof(buf));
+   assert(s != 403);
+   const char *search_all = "{\"query\":\"needle\",\"scope\":\"all\"}";
+   s = kb_http_route_ex("POST", "/v1/search", NULL, svc_auth, svc_tok, search_all,
+                        (int)strlen(search_all), buf, sizeof(buf));
+   assert(s != 403);
+
    /* MUST NOT: any maintenance route. This is the boundary that makes a service
     * credential worth issuing instead of the owner token. */
    static const char *const admin_routes[] = {


### PR DESCRIPTION
## Summary

- allow the managed KB service identity to perform explicit tenant-wide `scope=all` data-plane reads while preserving project-scoped and administrative fences
- preserve `--project` / `AIMEE_PROJECT_ID` in server-served CLI argspecs for index find, callers, blast-radius, hybrid, structure, and deps
- restore PAM-backed web operators with the managed login group so force-recreate does not lose usernames that collide with image system groups
- add differential argspec, KB route, and bootstrap restoration regressions

## Release validation

Validated on the isolated Proxmox CT on `192.168.1.252` using the published `:testing` release plus these patched binaries:

- fresh onboarding, bootstrap retirement, PAM login, first-owner claim, mTLS enrollment, Vault-backed git identity, TLS/CSRF/invalid-credential checks
- public thin-client project and `scope=all` find/hybrid against an indexed release fixture
- worktree ingest, duplicate re-scan idempotency, browser clone/list/delete lifecycle, and shared-index retention
- dependency stop/recovery (`ready` 200 -> 503 -> 200), container restart/recreate persistence, managed deploy apply, and exact KB `:testing` repin
- post-recreate operator restoration: account restored, login 200, no new bootstrap authority
- final health: server, KB, and PostgreSQL healthy; readiness 200/true; no authority container

Local gate: `env -u AIMEE_SESSION_ID -u CLAUDE_SESSION_ID -u CODEX_THREAD_ID make -C src verify-ci`

Result: `verify-ci: ok` (657 C tests, Go and cross-language suites, build integrity, 70/70 configured integrations, thin-client transport, served-argspec E2E, docs generation check).