### PR TITLE
fix: keep retracted facts retracted across re-extraction

### DIFF
--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -85,6 +85,27 @@ stale or contradicted records can decay without deleting their history.
 Working memory is not a lower-quality KB. It is session scratch and should not be promoted by
 accident.
 
+### Archival is a recall filter, not an access control
+
+Archived rows are hidden from the default recall surface only when **both** flags are set:
+
+| Key (`memory.lifecycle.*` in the config file) | Default | Effect |
+| --- | --- | --- |
+| `enabled` | `0` | `0` leaves every row looking `active` and the TTL sweep never runs — byte-identical behaviour for operators who have not opted in. `1` runs the sweep each maintenance cycle and tags commitment-shaped statements `pending`. |
+| `hide_archived` | `0` | `1` filters `archived` rows out of default recall (`memory_list`, scored recall). `0` keeps them in recall. |
+
+Both default to `0`, so **archival hides nothing out of the box**. `hide_archived` is also inert on
+its own: it is read only after `enabled` passes, so setting it alone changes nothing.
+
+Even with both set, this is a **relevance filter, not a confidentiality boundary**. `memory_get()`
+returns archived rows by id regardless, by design — the filter keeps stale records out of ranked
+recall, it does not restrict who may read them. Anything that must actually be unreadable needs a
+deletion or retention contract, not archival.
+
+These two keys are parsed from the config file only (`memory.lifecycle` object). They are not
+registered in the flat config table, so they are not reachable through `aimee config get/set` and do
+not appear in the generated [configuration reference](gen/configuration.md).
+
 ## Commands
 
 ```bash

--- a/docs/proposals/pending/memory-table-row-level-security.md
+++ b/docs/proposals/pending/memory-table-row-level-security.md
@@ -1,0 +1,95 @@
+# Proposal: Row-level security for the memory data plane
+
+- **State:** proposed (pending; Not started)
+- **Author:** JBailes
+- **Charter roles:** Constrain-Verify / Enforce, Gate-Promote
+
+## Thesis
+
+No `CREATE POLICY` covers any memory table. RLS today protects the **tenancy
+control plane** and nothing else: `ENABLE` + `FORCE ROW LEVEL SECURITY` is
+applied to exactly five tables — `kb_team`, `kb_project`, `kb_team_membership`,
+`kb_project_membership`, `kb_admin_grant` (`src/db2/schema.sql`) — and all 60
+policies target those plus the `org_*` billing and vault tables.
+
+`memories`, `docs`, `memory_scopes`, `memory_episodes` and the ~20 other
+`memory_*` tables have **no policy and no RLS enabled**. Every isolation
+guarantee on memory rows is enforced by application SQL alone. A mis-written
+JOIN or an injected predicate on a memory path has no database-layer backstop,
+which is precisely the failure class RLS exists to catch — and the one the
+control-plane tables are already defended against.
+
+## Why this is not a policy-writing exercise
+
+The obvious shape of the fix — write a predicate per table, enable FORCE, done —
+**cannot be implemented as stated**, for two independent reasons.
+
+### 1. There is no tenant key on a memory row
+
+`memories` has no `principal`, `tenant`, `team`, or `owner` column. Scope lives
+in a side table:
+
+```sql
+CREATE TABLE memory_scopes (
+  memory_id BIGINT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  scope_type TEXT NOT NULL,
+  scope_value TEXT NOT NULL,
+  PRIMARY KEY (memory_id, scope_type, scope_value));
+```
+
+`scope_type` is drawn from `MEMORY_SCOPE_NONE | GLOBAL | WORKSPACE | PROJECT`
+(`src/headers/memory.h:570`). That vocabulary describes **content organisation**
+— which workspace or project a memory belongs to — not **tenancy**: who is
+permitted to read it. Nothing in it maps to `aimee.principal` or `aimee.team`.
+
+There is therefore no column for a predicate to reference. Writing one requires
+first deciding what owns a memory (a principal? a team? a workspace?), adding
+that column, and backfilling every existing row with the answer. That is a
+product decision about the data model, not a schema patch.
+
+### 2. No memory code path opens a tenant scope
+
+The GUCs that RLS predicates read are set exclusively by `set_tenant_context()`,
+reached from C through `db2_tenant_scope_begin()`. Every caller of it today is
+control plane — `kb_http_*`, the vault paths, the management journals, and their
+tests. **Zero files under `src/modules/memory/` open a tenant scope.**
+
+Because the existing policies are `FORCE`d and `current_setting(..., true)`
+yields NULL on an unset GUC, the design is deliberately fail-closed: no GUC means
+no rows. Enabling FORCE RLS on `memories` before the memory paths set the context
+would return **zero rows on every memory read** — the entire memory layer goes
+dark, silently and by design.
+
+## Sequenced path
+
+Each step is independently shippable and observable; none of them is "add
+policies".
+
+1. **Decide the ownership model.** Does a memory belong to a principal, a team,
+   or a workspace promoted to a tenancy key? Blocks everything below. Needs an
+   explicit decision recorded here.
+2. **Add the tenant column + backfill.** Additive `ALTER TABLE`, a backfill for
+   existing rows, and a documented answer for rows with no determinable owner.
+   No behaviour change yet.
+3. **Thread `db2_tenant_scope_begin()` through the memory paths.** Convert reads
+   and writes to run inside a tenant scope. Still no RLS — verify by asserting
+   the GUC is set, so a missed path is caught before it can fail closed.
+4. **Add policies in report-only form.** Create the policies and verify their
+   predicates against live traffic *without* `FORCE`, so a wrong predicate is
+   visible as a diff rather than as an outage.
+5. **Enable + FORCE.** Only once step 3 shows no unscoped memory path remains.
+6. **Extend the CI gate.** `scripts/run-p1-rls-gate.sh` is already a hard,
+   non-skipping gate that provisions a real Postgres with the three-role split
+   and runs `scripts/p1_rls_isolation_test.sql`. Memory-table isolation
+   assertions belong there, added in the same change as step 5 so the guarantee
+   cannot regress silently.
+
+## Scope note
+
+Until step 1 is decided, memory-row isolation remains an application-layer
+property. That is worth stating plainly in any security review rather than
+leaving the absence of policies to be read as an oversight: the control-plane
+RLS is real and tested; the memory plane is deliberately not covered by it yet,
+and copying the control-plane pattern does not transfer when what you need is
+scope separation on the memory rows themselves rather than on the documents and
+membership graph beside them.

--- a/src/db2/fact_mutation.c
+++ b/src/db2/fact_mutation.c
@@ -851,17 +851,26 @@ int db2_fact_mutation_invalidate(const fact_actor_t *actor, const char *source,
       fm_state_t after = rows[i];
       fm_copy(after.lifecycle, sizeof(after.lifecycle), FACT_LIFECYCLE_INVALIDATED);
       fm_copy(after.invalidated_at, sizeof(after.invalidated_at), now);
+      /* Carry the retracting authority onto the row.  The reactivate gate in
+       * db2_fact_mutation_assert compares an incoming actor against the row's
+       * authority_rank, so leaving the original asserter's rank here would let
+       * the next extraction of the same text re-establish a retracted triple at
+       * the authority that first asserted it.  The selector loop above already
+       * refused any row outranking this actor, so this only ever raises. */
+      after.authority_rank = (int)actor->rank;
       after.version++;
       aimee_pg_stmt_t *u = aimee_pg_prepare(
           conn,
           "UPDATE entity_edges SET lifecycle_state='invalidated',invalidated_at=?2,"
-          " version=version+1,commit_id=?3 WHERE id=?1",
+          " authority_rank=?4,actor_principal=?5,version=version+1,commit_id=?3 WHERE id=?1",
           err, sizeof(err));
       if (!u)
          return fm_end(conn, 0);
       aimee_pg_bind_int64(u, "?1", rows[i].id);
       aimee_pg_bind_text(u, "?2", now);
       aimee_pg_bind_text(u, "?3", commit_id);
+      aimee_pg_bind_int(u, "?4", after.authority_rank);
+      aimee_pg_bind_text(u, "?5", actor->principal);
       int ok = aimee_pg_step(u, err, sizeof(err)) == AIMEE_PG_DONE;
       aimee_pg_finalize(u);
       if (!ok || fm_change(conn, commit_id, rows[i].id, "invalidate", &rows[i], &after,
@@ -1418,6 +1427,13 @@ int db2_fact_commit_rollback(const fact_actor_t *actor, const char *target_commi
          after = current;
          fm_copy(after.lifecycle, sizeof(after.lifecycle), FACT_LIFECYCLE_INVALIDATED);
          fm_copy(after.invalidated_at, sizeof(after.invalidated_at), now);
+         /* Rolling an insertion back is an operator decision about the triple,
+          * not just about this commit's rows.  Record that authority so a later
+          * drain that re-extracts the same triple from new text is refused by
+          * the reactivate gate; the evidence-replay guard only covers an exact
+          * redelivery of the same mention. */
+         if ((int)actor->rank > after.authority_rank)
+            after.authority_rank = (int)actor->rank;
          after.version++;
       }
       else
@@ -1620,6 +1636,10 @@ int db2_fact_ingest_run_rollback(const fact_actor_t *actor, const char *ingest_r
          after = current;
          fm_copy(after.lifecycle, sizeof(after.lifecycle), FACT_LIFECYCLE_INVALIDATED);
          fm_copy(after.invalidated_at, sizeof(after.invalidated_at), now);
+         /* See db2_fact_commit_rollback: the operator's authority must land on
+          * the row so re-extraction cannot re-establish the rolled-back triple. */
+         if ((int)actor->rank > after.authority_rank)
+            after.authority_rank = (int)actor->rank;
          after.version++;
       }
       after.found = 1;

--- a/src/tests/test_fact_lifecycle.c
+++ b/src/tests/test_fact_lifecycle.c
@@ -197,6 +197,43 @@ int main(void)
    assert(s.superseded[0] == '\0' && s.suppressed == 0 && s.invalidated[0] != '\0');
    assert(strcmp(s.lifecycle, FACT_LIFECYCLE_INVALIDATED) == 0);
 
+   /* A user retraction must outrank later machine re-extraction.  ivan/works_for
+    * is MODEL-asserted (rank 10); the USER retraction must stamp USER authority
+    * (rank 30) onto the row, otherwise the row keeps the asserter's rank and the
+    * next SYSTEM drain (rank 20) that re-derives the same triple from new text
+    * clears invalidated_at and resurrects a fact the user deleted. */
+   assert(db2_fact_commit("ivan", NODE_PERSON, "works_for", "acme", NODE_ORG, FACT_AUTHORITY_MODEL,
+                          1) == FACT_GATE_ACCEPT);
+   assert(scalar_int("SELECT authority_rank FROM entity_edges WHERE source='ivan'"
+                     " AND relation='works_for' AND edge_class='semantic'") == FACT_ACTOR_MODEL);
+   assert(db2_fact_retract("ivan", "works_for", NULL, FACT_AUTHORITY_USER) >= 1);
+   assert(scalar_int("SELECT authority_rank FROM entity_edges WHERE source='ivan'"
+                     " AND relation='works_for' AND edge_class='semantic'") == FACT_ACTOR_USER);
+   {
+      fact_actor_t sys;
+      assert(db2_fact_actor_internal(FACT_ACTOR_SYSTEM, &sys) == 0);
+      fact_evidence_input_t rev = {.source_kind = "message",
+                                   .source_id = "message:ivan-reextract",
+                                   .evidence_hash = "hash-ivan-reextract",
+                                   .observed_at = "2026-01-02 00:00:00"};
+      fact_assertion_input_t rai = {.source = "ivan",
+                                    .relation = "works_for",
+                                    .target = "acme",
+                                    .subject_kind = NODE_PERSON,
+                                    .object_kind = NODE_ORG,
+                                    .confidence_class = "B",
+                                    .confidence = 0.7,
+                                    .assertion_kind = FACT_KIND_WORLD_FACT,
+                                    .evidence = &rev,
+                                    .functional = 1};
+      fact_mutation_result_t rmr;
+      assert(db2_fact_mutation_assert(&sys, &rai, &rmr) == 0);
+      assert(strcmp(rmr.lifecycle, FACT_LIFECYCLE_INVALIDATED) == 0);
+      assert(db2_fact_current_count("ivan") == 0);
+      s = edge_state("ivan", "works_for");
+      assert(strcmp(s.lifecycle, FACT_LIFECYCLE_INVALIDATED) == 0 && s.invalidated[0] != '\0');
+   }
+
    /* §4 retract — immutable (parent_of): model refused, user wins. */
    assert(db2_fact_commit("ann", NODE_PERSON, "parent_of", "ben", NODE_PERSON, FACT_AUTHORITY_USER,
                           1) == FACT_GATE_ACCEPT);
@@ -330,6 +367,19 @@ int main(void)
    assert(strcmp(mr.lifecycle, FACT_LIFECYCLE_INVALIDATED) == 0);
    assert(db2_fact_current_count("rollback-subject") == 0);
    assert(scalar_int("SELECT COUNT(*) FROM fact_graph_commits") == commits_before_replay);
+
+   /* A later drain that re-extracts the same triple from NEW text is not a
+    * replay, so the evidence guard above does not apply.  The rollback recorded
+    * the operator's authority on the row, so the reactivate gate must refuse
+    * this SYSTEM re-assertion and the rolled-back triple stays retracted. */
+   fact_evidence_input_t reextract_ev = ev1;
+   reextract_ev.source_id = "message:rollback-reextract";
+   reextract_ev.evidence_hash = "hash-rollback-reextract";
+   ai.evidence = &reextract_ev;
+   assert(db2_fact_mutation_assert(&system_actor, &ai, &mr) == 0);
+   assert(strcmp(mr.lifecycle, FACT_LIFECYCLE_INVALIDATED) == 0);
+   assert(db2_fact_current_count("rollback-subject") == 0);
+   ai.evidence = &ev1;
 
    /* One ingest-run id groups independently committed assertions into one
     * previewable, all-or-nothing rollback. */


### PR DESCRIPTION
## The defect

`db2_fact_mutation_assert` **already** consults the invalidated twin before re-asserting — the reactivate gate at `fact_mutation.c:557` compares the incoming actor against the row's `authority_rank`. The gate was reading the wrong number.

`db2_fact_mutation_invalidate` never wrote the retracting actor's authority onto the row, so the row kept the *original asserter's* rank:

1. MODEL asserts `ivan works_for acme` → row rank 10
2. USER retracts it (`db2_fact_retract` → `invalidate`, rank 30) → lifecycle `invalidated`, **rank still 10**
3. Next drain re-extracts the triple as SYSTEM (rank 20) → `20 >= 10` → `invalidated_at` cleared, fact live again

A user's deletion was undone by the next ingest.

The operator review-reject path already stamped `FACT_ACTOR_OPERATOR` (`:1043`), which is why this hid — that path looked like proof the mechanism worked.

## The fix

Stamp the deciding authority on every transition to `invalidated`, so the existing gate compares against the retractor rather than the asserter. Three sites, one shape:

| Site | Was | Now |
| --- | --- | --- |
| `db2_fact_mutation_invalidate` | rank untouched | set to retracting actor (loop already refused higher-ranked rows, so this only raises) |
| `db2_fact_commit_rollback` | carried row's own rank | raised to operator rank |
| `db2_fact_ingest_run_rollback` | carried row's own rank | raised to operator rank |

Both rollback paths had the same omission: `:411` states a retried ingest must not resurrect a rolled-back assertion, but the evidence-replay guard it points at only covers an *exact* redelivery of one mention — not fresh text yielding the same triple.

`expire_candidates` is deliberately left alone: a SYSTEM TTL sweep over candidates where recurrence is meant to revive them.

## Verification — red/green, both halves proven

| | with fix | fix reverted |
| --- | --- | --- |
| retraction | pass | `authority_rank == FACT_ACTOR_USER` fails (`:210`) |
| retraction, rank probes stripped | pass | `lifecycle == INVALIDATED` fails (`:227`) — fact resurrected |
| rollback re-extraction | pass | `lifecycle == INVALIDATED` fails (`:370`) |

The red case was run twice on purpose — once probing the field, once with the probes removed — so the failure is the observable resurrection, not an internal value.

All fact-layer suites pass: `fact-lifecycle`, `fact-ingest`, `fact-recall`, `typed-facts`, `entity-registry`, `entity-nodes`, `rel-types-store`, `ontology-evolution`. `clang-format` clean.

## Also included

**Archival flags documented** (`docs/KNOWLEDGE.md`). `memory.lifecycle.enabled` and `hide_archived` both default to `0`, so archival hides nothing out of the box, and `hide_archived` is inert without `enabled`. More importantly it is a **relevance filter, not a confidentiality boundary** — `memory_get()` returns archived rows by id regardless, by design. Recommendation: leave both defaults at `0`. Enabling `enabled` starts a sweep that mutates rows, so defaulting it on would silently rewrite user data on upgrade.

**Memory-table RLS filed as a proposal** (`docs/proposals/pending/memory-table-row-level-security.md`) rather than implemented, because it cannot be done by writing policies:

- `memories` has no `principal`/`tenant`/`team`/`owner` column. Scope is a side table of `(scope_type, scope_value)` drawn from `NONE|GLOBAL|WORKSPACE|PROJECT` — content organisation, not tenancy. **There is no column for a predicate to reference.**
- **Zero** files under `src/modules/memory/` open a tenant scope. Every `db2_tenant_scope_begin` caller is control plane.

Since the existing policies are `FORCE`d and fail closed on an unset GUC, enabling RLS on `memories` today would return zero rows on every memory read. The proposal sequences the real path: decide the ownership model → add and backfill the column → thread tenant scope through memory paths → policies report-only → enable FORCE → extend the `p1-rls-gate` CI gate.

## Note

Only the four files above are in this commit. The working tree carries ~640 unrelated modifications from other in-flight work, none of which are included.

https://claude.ai/code/session_011yMHJDEtkjtunYGTZsHRmy