### PR TITLE
Connect to a hosted knowledge base with a setup code

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,6 +2,11 @@
 
 Run the services on one machine. Install only the thin client where you write code.
 
+Using a hosted knowledge base such as aimee cloud? The path is the same, with two differences: start
+from `compose.server-standalone.yaml` instead of the managed profile in Section 1, and at
+[Step 3](#step-3-choose-the-knowledge-base) paste your setup code instead of deploying a local
+knowledge base. Sections 2 and 3, installing and enrolling the client, are unchanged.
+
 ## 1. Start the managed server
 
 You need Docker with Compose v2. The managed server mounts the Docker socket so its browser wizard
@@ -101,8 +106,24 @@ You can change the primary later on the Agents tab.
 
 ![Step 3 of the setup wizard, knowledge base](images/wizard-3-knowledge-base.png)
 
-Deploy one locally, or point at an existing `aimee-kb`. A local knowledge base is the default and
-needs nothing else installed.
+Three choices:
+
+- **Deploy a local knowledge base.** The default, and it needs nothing else installed.
+- **Paste a setup code** from a hosted `aimee-kb`, such as aimee cloud. The code is exchanged for
+  that knowledge base's address and key, so this is the third option with the typing removed.
+- **Connect to an existing `aimee-kb` by hand**, with its URL and bearer token.
+
+The last two both save `kb_mode=remote` and deploy nothing here, so the deploy-topology and
+shared-store steps are skipped for either.
+
+A setup code is single-use and short-lived, so the wizard only redeems it when you press the button,
+never as you type. If it is refused the code stays in the box, because the usual cause is a typo
+rather than a dead code, and re-typing should not cost you a fresh one. Nothing is written until an
+exchange succeeds.
+
+If you are attaching to a hosted knowledge base, start from `compose.server-standalone.yaml` rather
+than the managed profile in [Section 1](#1-start-the-managed-server): it runs `aimee-server` with no
+`aimee-kb` and no PostgreSQL, which is what you want when the knowledge base is somewhere else.
 
 For a local KB, the remaining steps place its embedder and optional synthesizer, choose the bundled
 or external shared store, connect an optional Git host, and add workspaces. The embedder runs inside

--- a/frontend/src/setup/KnowledgeBase.tsx
+++ b/frontend/src/setup/KnowledgeBase.tsx
@@ -8,6 +8,10 @@ import { buildDesiredConfig, type KbMode } from './deployTopology';
  *
  *  • Local  — deploy an aimee-kb on this instance. The following Deploy-topology
  *             + Shared-store (DB2) steps configure it.
+ *  • Cloud  — redeem a setup code from a hosted provider. The code is exchanged
+ *             for a URL and a key, which is what Remote asks an operator to
+ *             paste by hand, so this is Remote with the typing removed and it
+ *             saves identical config.
  *  • Remote — connect to an existing aimee-kb (kb_client_url + bearer token).
  *             Nothing is deployed here, so the wizard skips deploy topology + DB2.
  *
@@ -17,22 +21,48 @@ import { buildDesiredConfig, type KbMode } from './deployTopology';
  * can update its visible steps + restart summary. Self-contained like
  * PrimaryChooser / DeployTopology. */
 
+/* Where a setup code is redeemed. A default rather than a constant: a hosted
+ * aimee is not required to be ours, and someone running their own should not
+ * have to patch a binary to point at it. */
+export const DEFAULT_CLOUD_ENDPOINT = 'https://api.aimee.rakuensoftware.com';
+
+/** Which source the operator picked. Cloud and Remote both persist
+ *  kb_mode='remote'; they differ only in how the URL and key are obtained. */
+type KbSource = 'local' | 'cloud' | 'remote';
+
 export interface KnowledgeBaseProps {
   /** Called after the KB choice is persisted, with the restart-class keys changed
    * and the chosen mode (so the wizard can recompute which steps to show). */
   onSaved: (restartKeys: string[], kbMode: KbMode) => void | Promise<void>;
   /** Injected in tests (vitest node env has no real network). */
   fetchImpl?: typeof fetch;
+  /** Where a setup code is redeemed. Defaults to aimee cloud. */
+  cloudEndpoint?: string;
 }
 
-export default function KnowledgeBase({ onSaved, fetchImpl }: KnowledgeBaseProps) {
+export default function KnowledgeBase({
+  onSaved,
+  fetchImpl,
+  cloudEndpoint: cloudEndpointProp,
+}: KnowledgeBaseProps) {
   const toast = useToast();
   const [cfg, setCfg] = useState<ConfigMap>({});
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  const [kbMode, setKbMode] = useState<KbMode>('local');
+  const [source, setSource] = useState<KbSource>('local');
+
+  const [code, setCode] = useState('');
+  const [redeeming, setRedeeming] = useState(false);
+  const [redeemed, setRedeemed] = useState('');
+  /* Not a visible field. The cloud option asks for exactly one thing, a code;
+   * turning the endpoint into an input turns that into a decision. It stays
+   * overridable as a prop so someone hosting their own is not stuck. */
+  const cloudEndpoint = cloudEndpointProp ?? DEFAULT_CLOUD_ENDPOINT;
+
+  /* Cloud and Remote are the same persisted mode; only the UI differs. */
+  const kbMode: KbMode = source === 'local' ? 'local' : 'remote';
   const [kbUrl, setKbUrl] = useState('');
   const [kbBearer, setKbBearer] = useState('');
 
@@ -42,7 +72,7 @@ export default function KnowledgeBase({ onSaved, fetchImpl }: KnowledgeBaseProps
       const c = await loadConfig({ fetchImpl });
       if (!alive) return;
       setCfg(c);
-      setKbMode(String(c.kb_mode ?? 'local') === 'remote' ? 'remote' : 'local');
+      setSource(String(c.kb_mode ?? 'local') === 'remote' ? 'remote' : 'local');
       setKbUrl(String(c.kb_client_url ?? ''));
       setKbBearer(String(c.kb_client_bearer_token ?? ''));
       setLoaded(true);
@@ -51,6 +81,44 @@ export default function KnowledgeBase({ onSaved, fetchImpl }: KnowledgeBaseProps
       alive = false;
     };
   }, [fetchImpl]);
+
+  /* Exchange a setup code for the URL and key it stands for.
+   *
+   * A code is single-use and short-lived, so this must not fire speculatively.
+   * It sits behind an explicit button, and a failure leaves the code in the box
+   * so a typo can be corrected without burning a fresh one. */
+  async function redeem() {
+    setRedeeming(true);
+    setError('');
+    setRedeemed('');
+    try {
+      const doFetch = fetchImpl ?? fetch;
+      const res = await doFetch(`${cloudEndpoint.replace(/\/+$/, '')}/v1/setup/redeem`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: code.trim() }),
+      });
+      const body = (await res.json()) as {
+        kb_url?: string;
+        bearer?: string;
+        tenant?: string;
+        error?: string;
+      };
+      if (!res.ok) throw new Error(body.error ?? 'That code was not accepted.');
+      if (!body.kb_url || !body.bearer) {
+        throw new Error('The provider did not return a usable knowledge base.');
+      }
+      setKbUrl(body.kb_url);
+      setKbBearer(body.bearer);
+      setRedeemed(body.tenant ? `Connected to ${body.tenant}.` : 'Code accepted.');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'That code was not accepted.';
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setRedeeming(false);
+    }
+  }
 
   async function save() {
     setSaving(true);
@@ -101,7 +169,10 @@ export default function KnowledgeBase({ onSaved, fetchImpl }: KnowledgeBaseProps
     return <div style={{ fontSize: 13, color: 'var(--sg-text-secondary)', padding: '8px 0' }}>Loading…</div>;
   }
 
-  const remote = kbMode === 'remote';
+  const remote = source === 'remote';
+  const cloud = source === 'cloud';
+  /* Nothing to save until a code has actually been exchanged. */
+  const cloudIncomplete = cloud && (kbUrl === '' || kbBearer === '');
 
   return (
     <div style={{ display: 'grid', gap: 14, marginBottom: 8 }}>
@@ -111,15 +182,40 @@ export default function KnowledgeBase({ onSaved, fetchImpl }: KnowledgeBaseProps
 
       <section style={{ display: 'grid', gap: 8 }}>
         <label style={radioRow}>
-          <input type="radio" checked={!remote} onChange={() => setKbMode('local')} />
+          <input type="radio" checked={source === 'local'} onChange={() => setSource('local')} />
           <span>Deploy a local knowledge base (recommended)</span>
         </label>
         <label style={radioRow}>
-          <input type="radio" checked={remote} onChange={() => setKbMode('remote')} />
-          <span>Connect to an existing aimee-kb</span>
+          <input type="radio" checked={source === 'cloud'} onChange={() => setSource('cloud')} />
+          <span>aimee cloud, or another hosted aimee-kb (paste a setup code)</span>
+        </label>
+        <label style={radioRow}>
+          <input type="radio" checked={remote} onChange={() => setSource('remote')} />
+          <span>Connect to an existing aimee-kb by hand</span>
         </label>
 
-        {remote ? (
+        {cloud ? (
+          <div style={{ display: 'grid', gap: 8, paddingLeft: 24 }}>
+            <div style={{ fontSize: 11.5, color: 'var(--sg-text-faint)' }}>
+              Paste the code from your welcome email. It is exchanged for the address and key of
+              your knowledge base, so nothing is deployed here and the next two steps are skipped.
+            </div>
+            <Field label="Setup code">
+              <input style={input} value={code} onChange={(e) => setCode(e.target.value)}
+                placeholder="AIMEE-XXXX-XXXX-XXXX-XXXX-XXXX" autoComplete="off" />
+            </Field>
+            <div>
+              <Button variant="default" disabled={redeeming || code.trim() === ''} onClick={redeem}>
+                {redeeming ? 'Redeeming…' : 'Redeem code'}
+              </Button>
+            </div>
+            {redeemed && (
+              <div style={{ fontSize: 12, color: 'var(--sg-success)' }}>
+                {redeemed} Continue below to finish.
+              </div>
+            )}
+          </div>
+        ) : remote ? (
           <div style={{ display: 'grid', gap: 8, paddingLeft: 24 }}>
             <div style={{ fontSize: 11.5, color: 'var(--sg-text-faint)' }}>
               A remote KB deploys nothing here — aimee-server just connects to it. The deploy-topology
@@ -148,7 +244,7 @@ export default function KnowledgeBase({ onSaved, fetchImpl }: KnowledgeBaseProps
       )}
 
       <div>
-        <Button variant="primary" disabled={saving} onClick={save}>
+        <Button variant="primary" disabled={saving || cloudIncomplete} onClick={save}>
           {saving ? 'Saving…' : 'Save & continue'}
         </Button>
       </div>

--- a/frontend/src/setup/KnowledgeBaseCloud.test.tsx
+++ b/frontend/src/setup/KnowledgeBaseCloud.test.tsx
@@ -1,0 +1,166 @@
+/** @vitest-environment jsdom */
+/* The aimee cloud path through the knowledge-base step.
+ *
+ * A setup code is single-use and expires in 24 hours, so the cost of getting
+ * this wrong is not a retry — it is a customer with a dead code who has to ask
+ * for another. These pin the properties that protect them: the code is only
+ * spent when the operator asks, a rejection does not clear the box, and nothing
+ * is written to config until an exchange has actually succeeded.
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import KnowledgeBase, { DEFAULT_CLOUD_ENDPOINT } from './KnowledgeBase';
+
+vi.mock('@rakuensoftware/smoothgui', () => {
+  const toast = Object.assign(() => {}, { error: () => {}, success: () => {}, info: () => {} });
+  return {
+    Button: ({ children, ...rest }: { children?: unknown } & Record<string, unknown>) => {
+      const props = rest as Record<string, unknown>;
+      return <button {...props}>{children as never}</button>;
+    },
+    useToast: () => toast,
+  };
+});
+
+type Call = { url: string; body: unknown };
+
+/** A fetch stub that answers /api/config, /api/config/set and the redeem
+ *  endpoint, and records everything it was asked. */
+function stubFetch(redeem: { status: number; body: unknown }) {
+  const calls: Call[] = [];
+  const impl = (async (url: string, init?: RequestInit) => {
+    const body = init?.body != null ? JSON.parse(String(init.body)) : undefined;
+    calls.push({ url: String(url), body });
+    if (String(url).endsWith('/api/config')) {
+      return { ok: true, json: async () => ({ config: {} }) } as unknown as Response;
+    }
+    if (String(url).endsWith('/api/config/set')) {
+      return { ok: true, status: 200, json: async () => ({ value: body?.value }) } as unknown as Response;
+    }
+    return {
+      ok: redeem.status < 400,
+      status: redeem.status,
+      json: async () => redeem.body,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const OK_REDEEM = {
+  status: 200,
+  body: { kb_url: 'https://api.aimee.rakuensoftware.com', bearer: 'aik_abc_def', tenant: 'acme-co' },
+};
+
+async function openCloud(stub: ReturnType<typeof stubFetch>) {
+  const onSaved = vi.fn();
+  render(<KnowledgeBase onSaved={onSaved} fetchImpl={stub.impl} />);
+  await screen.findByText(/aimee cloud/i);
+  fireEvent.click(screen.getByLabelText(/aimee cloud/i, { selector: 'input' }));
+  return onSaved;
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', undefined);
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('aimee cloud setup code', () => {
+  it('offers aimee cloud without displacing the local default', async () => {
+    const stub = stubFetch(OK_REDEEM);
+    render(<KnowledgeBase onSaved={vi.fn()} fetchImpl={stub.impl} />);
+    expect(await screen.findByText(/aimee cloud/i)).toBeTruthy();
+    // aimee is self-hostable and local stays the recommended default; the
+    // installer of an AGPL project should not steer people at a paid service.
+    expect(screen.getByText(/Deploy a local knowledge base \(recommended\)/i)).toBeTruthy();
+    const local = screen.getByLabelText(/Deploy a local knowledge base/i, { selector: 'input' }) as HTMLInputElement;
+    expect(local.checked).toBe(true);
+  });
+
+  it('asks for a code and nothing else', async () => {
+    const stub = stubFetch(OK_REDEEM);
+    await openCloud(stub);
+    // One input on the cloud path: the code. No URL, no token, no endpoint.
+    expect(screen.getByPlaceholderText(/AIMEE-/)).toBeTruthy();
+    expect(screen.queryByPlaceholderText(/https:\/\/kb\.example/)).toBeNull();
+  });
+
+  it('does not spend the code until the operator asks', async () => {
+    const stub = stubFetch(OK_REDEEM);
+    await openCloud(stub);
+    fireEvent.change(screen.getByPlaceholderText(/AIMEE-/), {
+      target: { value: 'AIMEE-ABCD-ABCD-ABCD-ABCD-ABCD' },
+    });
+    // Typing must not redeem: the code is single-use.
+    expect(stub.calls.some((c) => c.url.includes('/v1/setup/redeem'))).toBe(false);
+  });
+
+  it('exchanges the code and saves the config it returns', async () => {
+    const stub = stubFetch(OK_REDEEM);
+    const onSaved = await openCloud(stub);
+    vi.stubGlobal('fetch', stub.impl);
+
+    fireEvent.change(screen.getByPlaceholderText(/AIMEE-/), {
+      target: { value: ' aimee-abcd-abcd-abcd-abcd-abcd ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Redeem code/i }));
+    await screen.findByText(/Connected to acme-co/i);
+
+    const redeem = stub.calls.find((c) => c.url.includes('/v1/setup/redeem'));
+    expect(redeem?.url).toBe(`${DEFAULT_CLOUD_ENDPOINT}/v1/setup/redeem`);
+    // Trimmed, so a pasted code with stray whitespace still works.
+    expect((redeem?.body as { code: string }).code).toBe('aimee-abcd-abcd-abcd-abcd-abcd');
+
+    fireEvent.click(screen.getByRole('button', { name: /Save & continue/i }));
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+
+    const saved = new Map(
+      stub.calls
+        .filter((c) => c.url.endsWith('/api/config/set'))
+        .map((c) => [(c.body as { key: string }).key, (c.body as { value: string }).value]),
+    );
+    expect(saved.get('kb_mode')).toBe('remote');
+    expect(saved.get('kb_client_url')).toBe('https://api.aimee.rakuensoftware.com');
+    expect(saved.get('kb_client_bearer_token')).toBe('aik_abc_def');
+    // Cloud persists exactly what the manual remote path would.
+    expect(onSaved.mock.calls[0][1]).toBe('remote');
+  });
+
+  it('cannot be saved before a code has been exchanged', async () => {
+    const stub = stubFetch(OK_REDEEM);
+    await openCloud(stub);
+    const save = screen.getByRole('button', { name: /Save & continue/i }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+
+  it('reports the provider\'s refusal and keeps the code for a retry', async () => {
+    const stub = stubFetch({
+      status: 400,
+      body: { error: 'that code is not valid. Setup codes are single-use and expire after 24 hours' },
+    });
+    await openCloud(stub);
+    vi.stubGlobal('fetch', stub.impl);
+
+    const input = screen.getByPlaceholderText(/AIMEE-/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'AIMEE-WRONG-WRONG-WRONG-WRONG-WRONG' } });
+    fireEvent.click(screen.getByRole('button', { name: /Redeem code/i }));
+
+    await screen.findByText(/single-use and expire/i);
+    // The code stays put: a typo should be correctable without asking for a new one.
+    expect(input.value).toBe('AIMEE-WRONG-WRONG-WRONG-WRONG-WRONG');
+    // And nothing was written.
+    expect(stub.calls.some((c) => c.url.endsWith('/api/config/set'))).toBe(false);
+  });
+
+  it('refuses a response missing the fields it needs', async () => {
+    const stub = stubFetch({ status: 200, body: { tenant: 'acme-co' } });
+    await openCloud(stub);
+    vi.stubGlobal('fetch', stub.impl);
+    fireEvent.change(screen.getByPlaceholderText(/AIMEE-/), { target: { value: 'AIMEE-X' } });
+    fireEvent.click(screen.getByRole('button', { name: /Redeem code/i }));
+    await screen.findByText(/did not return a usable knowledge base/i);
+    expect(stub.calls.some((c) => c.url.endsWith('/api/config/set'))).toBe(false);
+  });
+});


### PR DESCRIPTION
The knowledge-base step offered "deploy locally" or "connect to an existing aimee-kb", and the second asked for a URL **and** a bearer token by hand. For someone arriving from a hosted signup that is two secrets to copy correctly out of an email, and getting either wrong fails later and somewhere else.

There is now a third option that asks for one thing: the code. It is exchanged at the provider for the URL and key it stands for, then saves exactly what the manual remote path saves. Cloud and Remote are the same persisted `kb_mode=remote` and differ only in how the operator obtains the values, so both skip deploy topology and shared store.

**Local stays the default and stays labelled recommended.** aimee is self-hostable and the installer of an AGPL project should not steer people at a paid service; the option is offered, not pushed. There is a test pinning that.

## What the code's lifetime implies

A setup code is single-use and expires, which shapes the behaviour and the tests:

- redemption sits behind an explicit button and never fires while typing, because a speculative exchange **spends** the code;
- a refusal leaves the code in the box, so a typo can be corrected without asking for another;
- Save stays disabled until an exchange has succeeded, so the step cannot write half a configuration;
- a response missing `kb_url` or `bearer` is refused rather than saved as empty strings.

The provider endpoint is a prop with a default rather than a visible field: the option asks for exactly one thing, and an endpoint input would turn that into a decision. Someone hosting their own is still not stuck with the default.

## Docs

QUICKSTART documents all three choices, and says plainly that a hosted knowledge base wants `compose.server-standalone.yaml` rather than the managed profile, since there is nothing local to deploy.

## Checks

193/193 frontend tests, `tsc -b --noEmit` clean, `vite build` clean, and `scripts/check-docs.py` ok.