### PR TITLE
feat: add the memory workspace ownership binding

### DIFF
--- a/docs/proposals/pending/memory-table-row-level-security.md
+++ b/docs/proposals/pending/memory-table-row-level-security.md
@@ -60,6 +60,47 @@ no rows. Enabling FORCE RLS on `memories` before the memory paths set the contex
 would return **zero rows on every memory read** — the entire memory layer goes
 dark, silently and by design.
 
+## Decisions (settled)
+
+1. **A workspace is a collection of projects, and it may be owned by any entity
+   kind** — a principal, a team, an org, or a kind not yet defined. The owner is
+   therefore **polymorphic** `(owner_kind, owner_id)`, not a foreign key into one
+   table. `owner_kind` is deliberately unconstrained; the resolver fails closed on
+   a kind it cannot resolve, so an unknown kind is unreadable rather than wrongly
+   readable.
+2. **A workspace-less memory resolves to the global scope** — readable by any
+   authenticated principal. This is what makes the migration safe: existing
+   untagged rows stay visible rather than disappearing when policies go live.
+
+Consequences worth stating:
+
+- **`org` cannot be resolved yet.** There is no org membership table in this
+  schema — the `org_*` tables are budget, model, telemetry and vault records,
+  none of which record who belongs to an org. An org-owned workspace resolves to
+  unreadable until such a source exists. Known gap, not an oversight.
+- **An unmapped workspace fails closed.** A memory tagged with a workspace that
+  has no owner row is unreadable. Step 2's migration must therefore populate
+  owners for every workspace in use *before* step 5, and step 4's report-only
+  pass is what surfaces the stragglers.
+
+## Correction: the conversion surface is far smaller than 365 call sites
+
+The earlier count (267 `db2_*` entry points, 365 call sites) measures db2 *usage*,
+not the number of places a tenant scope must be opened. Memory operations already
+funnel their workspace/project context through a thread-local choke point,
+`db2_memory_scope_context_set()` (`src/db2/memory_scope_query.c`), and it has
+**two production callers**: `src/kb/kb_service_memory.c` and
+`src/modules/memory/memory_core_search_c.c`. Everything else is tests.
+
+The tenant GUC should be set per request/transaction, the way
+`db2_tenant_scope_begin()` already does for the control plane, rather than at each
+of 365 call sites. Step 3 is scoped to the request entry points plus that choke
+point.
+
+Also corrected: `memory_workspaces` is **legacy**. `memory_scopes`
+(`scope_type='workspace'`) is the canonical scope tag, so policies must predicate
+on `memory_scopes`, not the legacy table.
+
 ## Sequenced path
 
 Each step is independently shippable and observable; none of them is "add

--- a/scripts/p1_rls_isolation_test.sql
+++ b/scripts/p1_rls_isolation_test.sql
@@ -169,6 +169,81 @@ BEGIN
   END;
 END $$;
 
+-- ---------------------------------------------------------------------------
+-- memory_workspace_readable(): the predicate future memory policies will call.
+-- No memory table has RLS enabled yet, so these assert the RESOLVER's behaviour
+-- directly. Each case is one rule from the ownership model.
+INSERT INTO memory_workspace_owner(workspace, owner_kind, owner_id) VALUES
+  ('ws_alice_owned', 'principal', 'oidc:test:alice'),
+  ('ws_alpha_team',  'team',      '900001'),
+  ('ws_beta_team',   'team',      '900002'),
+  ('ws_org_owned',   'org',       'org-1'),
+  ('ws_typo_kind',   'principle', 'oidc:test:alice');
+
+SELECT set_tenant_context('oidc:test:alice', 900001);
+DO $$
+BEGIN
+  -- Workspace-less is global scope: readable by an authenticated principal.
+  IF NOT memory_workspace_readable('') THEN
+    RAISE EXCEPTION 'FAIL: empty workspace not readable as global scope';
+  END IF;
+  IF NOT memory_workspace_readable(NULL) THEN
+    RAISE EXCEPTION 'FAIL: NULL workspace not readable as global scope';
+  END IF;
+  -- Principal-owned: the owning principal reads it.
+  IF NOT memory_workspace_readable('ws_alice_owned') THEN
+    RAISE EXCEPTION 'FAIL: owner principal cannot read own workspace';
+  END IF;
+  -- Team-owned: alice is a member of alpha (900001), not beta (900002).
+  IF NOT memory_workspace_readable('ws_alpha_team') THEN
+    RAISE EXCEPTION 'FAIL: team member cannot read team workspace';
+  END IF;
+  IF memory_workspace_readable('ws_beta_team') THEN
+    RAISE EXCEPTION 'FAIL: non-member read a foreign team workspace';
+  END IF;
+  -- An unmapped workspace has no owner row: fail closed.
+  IF memory_workspace_readable('ws_never_mapped') THEN
+    RAISE EXCEPTION 'FAIL: unmapped workspace was readable';
+  END IF;
+  -- org has no membership source in this schema yet: must fail closed.
+  IF memory_workspace_readable('ws_org_owned') THEN
+    RAISE EXCEPTION 'FAIL: org-owned workspace readable without a membership source';
+  END IF;
+  -- An owner_kind the resolver does not know must fail closed, not open.
+  IF memory_workspace_readable('ws_typo_kind') THEN
+    RAISE EXCEPTION 'FAIL: unknown owner_kind was readable';
+  END IF;
+END $$;
+
+-- bob is beta-only: the team cases invert for him.
+SELECT set_tenant_context('oidc:test:bob', 900002);
+DO $$
+BEGIN
+  IF memory_workspace_readable('ws_alpha_team') THEN
+    RAISE EXCEPTION 'FAIL: bob read alpha team workspace';
+  END IF;
+  IF NOT memory_workspace_readable('ws_beta_team') THEN
+    RAISE EXCEPTION 'FAIL: bob cannot read his own team workspace';
+  END IF;
+  IF memory_workspace_readable('ws_alice_owned') THEN
+    RAISE EXCEPTION 'FAIL: bob read alice''s principal-owned workspace';
+  END IF;
+END $$;
+
+-- Fail-closed with no tenant context: even global scope is unreadable.
+RESET ROLE;
+SET ROLE aimee_kb_runtime;
+SELECT set_config('aimee.principal', '', true);
+DO $$
+BEGIN
+  IF memory_workspace_readable('') THEN
+    RAISE EXCEPTION 'FAIL: global scope readable with no principal set';
+  END IF;
+  IF memory_workspace_readable('ws_alice_owned') THEN
+    RAISE EXCEPTION 'FAIL: owned workspace readable with no principal set';
+  END IF;
+END $$;
+
 RESET ROLE;
 ROLLBACK;
 

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -14026,6 +14026,70 @@ REVOKE ALL ON FUNCTION kb_management_token_key_use_worm_guard(),
   kb_management_token_authority_finalize(TEXT,TEXT) FROM PUBLIC;
 
 -- ============================================================================
+-- Memory tenancy binding (step 2 of docs/proposals/pending/
+-- memory-table-row-level-security.md). ADDITIVE ONLY: no RLS is enabled on any
+-- memory table by this block, and nothing reads these objects yet. It exists so
+-- the ownership model has a home before any policy depends on it.
+--
+-- A workspace is a collection of projects and may be owned by ANY entity kind --
+-- a principal, a team, an org, or a kind not yet defined -- so the owner is
+-- polymorphic (owner_kind, owner_id) rather than a foreign key into one table.
+-- owner_kind is deliberately NOT constrained to a fixed list: the resolver below
+-- fails closed on a kind it cannot resolve, so an unknown kind is unreadable
+-- rather than wrongly readable.
+CREATE TABLE IF NOT EXISTS memory_workspace_owner (
+  workspace  TEXT PRIMARY KEY,
+  owner_kind TEXT NOT NULL,
+  owner_id   TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (pg_now_text()));
+
+-- memory_workspace_readable(workspace): the single predicate every future memory
+-- policy calls, so adding an owner kind is one branch here rather than an edit to
+-- ~29 policies.
+--
+-- STABLE and NOT security definer on purpose. It reads kb_team_membership, which
+-- is itself under FORCE RLS with p_member_self (identity_key = the principal GUC),
+-- so the membership probe sees ONLY the calling principal's own rows -- exactly the
+-- question being asked ("is MY principal in that team"), at least privilege. A
+-- SECURITY DEFINER here would widen that to every principal's memberships for no
+-- gain.
+--
+-- Fail-closed by construction: current_setting(..., true) yields NULL when the GUC
+-- is unset, so an unauthenticated session matches nothing.
+--
+-- owner_kind='org' is intentionally absent: there is no org membership table in
+-- this schema (the org_* tables are budget, model, telemetry and vault records,
+-- none of which record who belongs to an org). An org-owned workspace therefore
+-- resolves to unreadable until that membership source exists. This is a known
+-- gap, not an oversight.
+CREATE OR REPLACE FUNCTION memory_workspace_readable(p_workspace TEXT)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT CASE
+    -- A workspace-less memory is global scope: readable by any authenticated
+    -- principal. An unset principal GUC still yields false.
+    WHEN p_workspace IS NULL OR p_workspace = '' THEN
+      current_setting('aimee.principal', true) IS NOT NULL
+        AND current_setting('aimee.principal', true) <> ''
+    ELSE EXISTS (
+      SELECT 1 FROM memory_workspace_owner o
+       WHERE o.workspace = p_workspace
+         AND (
+              (o.owner_kind = 'principal'
+                 AND o.owner_id = current_setting('aimee.principal', true))
+           OR (o.owner_kind = 'team'
+                 AND EXISTS (SELECT 1 FROM kb_team_membership m
+                              WHERE m.team::text = o.owner_id
+                                AND m.identity_key =
+                                    current_setting('aimee.principal', true)))
+             ))
+  END;
+$$;
+
+-- ============================================================================
 -- Schema build metadata (recorded LAST, after every object above, so its presence
 -- at the current values proves a complete, current migration). A HARDENED-tier
 -- runtime kb connects as a non-owner role that CANNOT apply DDL; it reads these to

--- a/src/db2/schema_grants.sql
+++ b/src/db2/schema_grants.sql
@@ -102,6 +102,13 @@ BEGIN
   REVOKE ALL ON FUNCTION set_tenant_context(TEXT, BIGINT) FROM PUBLIC;
   GRANT EXECUTE ON FUNCTION set_tenant_context(TEXT, BIGINT) TO aimee_kb_runtime;
 
+  -- memory_workspace_readable is the predicate future memory policies call. It
+  -- reads only the calling principal's own membership rows (it is STABLE, not
+  -- SECURITY DEFINER), but EXECUTE is still narrowed off PUBLIC to match every
+  -- other tenancy function here.
+  REVOKE ALL ON FUNCTION memory_workspace_readable(TEXT) FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION memory_workspace_readable(TEXT) TO aimee_kb_runtime;
+
   -- P5-A authoritative registry: runtime reaches state only through audited,
   -- bounded definer APIs; direct reads and writes are unavailable.
   REVOKE ALL ON kb_server_registry, kb_cert_revocation_generation FROM aimee_kb_runtime;

--- a/src/db2/schema_sqlite.sql
+++ b/src/db2/schema_sqlite.sql
@@ -649,3 +649,13 @@ CREATE TABLE IF NOT EXISTS org_egress_dispatch (
 );
 CREATE INDEX IF NOT EXISTS idx_org_egress_recover
   ON org_egress_dispatch(state,lease_expires_at,id);
+
+-- Mirrors memory_workspace_owner in schema.sql so check-schema-sync sees the same
+-- table set. The Postgres side additionally defines memory_workspace_readable();
+-- the shim cannot enforce RLS, so no resolver is defined here.
+CREATE TABLE IF NOT EXISTS memory_workspace_owner (
+  workspace  TEXT PRIMARY KEY,
+  owner_kind TEXT NOT NULL,
+  owner_id   TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT ''
+);


### PR DESCRIPTION
Step 2 of the [memory RLS proposal](docs/proposals/pending/memory-table-row-level-security.md), following #2865.

**Additive only — no RLS is enabled on any memory table, and nothing reads these objects yet.** It gives the ownership model a home before any policy depends on it.

## The model, as decided

A workspace is a collection of projects and may be owned by **any entity kind**, so `memory_workspace_owner` carries a polymorphic `(owner_kind, owner_id)` rather than a FK into one table. `owner_kind` is intentionally **unconstrained**: the resolver fails closed on a kind it cannot resolve, so an unknown kind is unreadable rather than wrongly readable.

`memory_workspace_readable(workspace)` is the single predicate every future memory policy calls, so adding an owner kind is one branch here instead of an edit to ~29 policies.

It is `STABLE` and deliberately **not** `SECURITY DEFINER`. It reads `kb_team_membership`, which is itself under FORCE RLS with `p_member_self`, so the membership probe sees only the calling principal's own rows — exactly the question being asked ("is *my* principal in that team"), at least privilege. A definer would widen that to every principal's memberships for no gain.

## Resolution rules

| Case | Result |
| --- | --- |
| Workspace-less (`NULL` or `''`) | Global scope — readable by any authenticated principal |
| Principal-owned | That principal only |
| Team-owned | Members, via `kb_team_membership` |
| Unmapped workspace | **Fail closed** |
| `owner_kind='org'` | **Fail closed** — see below |
| Unknown `owner_kind` | **Fail closed** |
| Principal GUC unset | **Fail closed**, including global scope |

Each is asserted in `scripts/p1_rls_isolation_test.sql`, both directions (alice reads her team's workspace and not bob's; bob the inverse).

## Two things worth flagging

**`org` cannot be resolved.** There is no org membership table in this schema — the `org_*` tables are budget, model, telemetry and vault records, none recording who belongs to an org. An org-owned workspace is unreadable until such a source exists. Known gap, encoded as fail-closed rather than left implicit.

**An unmapped workspace fails closed**, so the migration must populate owners for every workspace in use *before* FORCE is enabled. Step 4's report-only pass is what surfaces the stragglers. Workspace-less rows resolving to global scope is what keeps existing untagged data visible.

## Also in this PR

Two corrections to #2865, now in the proposal:

- **The conversion surface is far smaller than 365 call sites.** That number measured db2 *usage*. Memory operations already funnel workspace/project context through a thread-local choke point, `db2_memory_scope_context_set()`, which has **two production callers**. The tenant GUC should be set per request/transaction the way `db2_tenant_scope_begin()` already does, not per call site.
- **`memory_workspaces` is legacy.** `memory_scopes` (`scope_type='workspace'`) is canonical, so policies must predicate on it.

`schema_version` is **not** bumped: nothing in the runtime depends on these objects yet. That bump belongs with the step that enables FORCE.

## Verification

Locally: `schema-sync-check` (215 shared tables), `charter-tables-check`, `proposal-links-check` all pass.

The resolver is Postgres-only and there is **no Postgres in this environment**, so its assertions are verified by the `p1-rls-gate` CI job against a real server — not locally. Worth a look at that job before merge.

https://claude.ai/code/session_011yMHJDEtkjtunYGTZsHRmy