### PR TITLE
fix: stop PII memory from crossing to aimee-kb

### DIFF
--- a/src/modules/kb_client/kb_client.h
+++ b/src/modules/kb_client/kb_client.h
@@ -824,6 +824,13 @@ int kb_client_memory_get(int64_t id, memory_t *out);
  * write-side gate pipeline runs inside aimee-kb.  Returns 0 on
  * success (|out| filled if non-NULL) or -1 if kb is unreachable or
  * the gate rejected the write.  Mirrors memory_insert(). */
+/* Returned when memory content carries a secret/PII span that cannot be cleanly
+ * redacted. The write is REFUSED CLIENT-SIDE: no request is issued, so the text
+ * never reaches aimee-kb. Distinct from -1 (kb unreachable or kb-side rejection)
+ * so a caller can tell "we would not send this" from "we could not send this".
+ * Every content-carrying memory.* wrapper below returns it. */
+#define KB_CLIENT_MEMORY_WITHHELD_PII (-2)
+
 int kb_client_memory_insert(const char *tier, const char *kind, const char *key,
                             const char *content, double confidence, const char *session_id,
                             memory_t *out);

--- a/src/modules/kb_client/kb_client_memory_mutations.c
+++ b/src/modules/kb_client/kb_client_memory_mutations.c
@@ -3,11 +3,66 @@
 #include "memory_query.h"
 #include "tasks.h"
 
-#include "kb_client.h" /* kb_client_memory_audit_note (defined in kb_client_memory_audit.c) */
+#include "kb_client.h"       /* kb_client_memory_audit_note (defined in kb_client_memory_audit.c) */
+#include "memory_platform.h" /* gate_check_sensitive */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* PII must never cross the aimee-server -> aimee-kb boundary.
+ *
+ * The screen runs HERE, client-side, before any request is issued -- not on the
+ * kb side. A gate that runs after the POST has already moved the data it exists
+ * to contain: "aimee-kb rejected it" still means aimee-kb received it. Placing it
+ * in these wrappers rather than at their call sites means the seven callers
+ * cannot forget it, the same reason the evidence ledger lives in a trigger.
+ *
+ * gate_check_sensitive is the platform classifier: 2 = a secret/PII span it
+ * cannot cleanly redact, 1 = redacted into the caller's buffer, 0 = clean.
+ *
+ * Returns 0 with *out NULL when `text` may be sent as-is; 0 with *out set to a
+ * heap copy the caller must free when a redacted form must be sent instead; and
+ * -1 when the text must not leave this process at all. An allocation failure
+ * returns -1: unable to classify means unable to send.
+ */
+/* The key is the record's lookup handle, so redacting it in place would silently
+ * change which record the caller is addressing -- worse than refusing. ANY
+ * sensitivity in a key therefore withholds the whole write, redactable or not.
+ * An allocation failure withholds too: unable to classify means unable to send. */
+static int kbc_pii_key_sensitive(const char *key)
+{
+   if (!key || !key[0])
+      return 0;
+   size_t cap = strlen(key) + 32;
+   char *buf = malloc(cap);
+   if (!buf)
+      return 1;
+   int verdict = gate_check_sensitive(key, buf, cap);
+   free(buf);
+   return verdict != 0;
+}
+
+static int kbc_pii_screen(const char *text, char **out)
+{
+   *out = NULL;
+   if (!text || !text[0])
+      return 0;
+   /* Sized so the prefix plus the [REDACTED] marker always fits; the classifier
+    * only reports 2 for a span it could not locate, never for a small buffer. */
+   size_t cap = strlen(text) + 32;
+   char *buf = malloc(cap);
+   if (!buf)
+      return -1;
+   int verdict = gate_check_sensitive(text, buf, cap);
+   if (verdict == 1)
+   {
+      *out = buf;
+      return 0;
+   }
+   free(buf);
+   return verdict == 0 ? 0 : -1;
+}
 
 int kb_client_memory_supersede(int64_t old_id, const char *new_content, double confidence,
                                const char *session_id, memory_t *out)
@@ -15,9 +70,18 @@ int kb_client_memory_supersede(int64_t old_id, const char *new_content, double c
    if (old_id <= 0 || !new_content)
       return -1;
 
+   char *sup_red = NULL;
+   if (kbc_pii_screen(new_content, &sup_red) != 0)
+   {
+      kb_client_memory_audit_note("memory.supersede.withheld_pii", old_id, "", "", "", confidence,
+                                  session_id, 0);
+      return KB_CLIENT_MEMORY_WITHHELD_PII;
+   }
+
    cJSON *req = cJSON_CreateObject();
    cJSON_AddNumberToObject(req, "old_id", (double)old_id);
-   cJSON_AddStringToObject(req, "new_content", new_content);
+   cJSON_AddStringToObject(req, "new_content", sup_red ? sup_red : new_content);
+   free(sup_red);
    cJSON_AddNumberToObject(req, "confidence", confidence);
    if (session_id && session_id[0])
       cJSON_AddStringToObject(req, "session_id", session_id);
@@ -299,13 +363,24 @@ int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *k
    if (!key || !content)
       return -1;
 
+   char *content_red = NULL;
+   if (kbc_pii_key_sensitive(key) || kbc_pii_screen(content, &content_red) != 0)
+   {
+      free(content_red);
+      /* Deliberately no key in this note: the key may be what was sensitive. */
+      kb_client_memory_audit_note("memory.insert.withheld_pii", 0, tier, kind, "", confidence,
+                                  session_id, 0);
+      return KB_CLIENT_MEMORY_WITHHELD_PII;
+   }
+
    cJSON *req = cJSON_CreateObject();
    if (tier && tier[0])
       cJSON_AddStringToObject(req, "tier", tier);
    if (kind && kind[0])
       cJSON_AddStringToObject(req, "kind", kind);
    cJSON_AddStringToObject(req, "key", key);
-   cJSON_AddStringToObject(req, "content", content);
+   cJSON_AddStringToObject(req, "content", content_red ? content_red : content);
+   free(content_red);
    if (use_cases && use_cases[0])
       cJSON_AddStringToObject(req, "use_cases", use_cases);
    cJSON_AddNumberToObject(req, "confidence", confidence);
@@ -557,9 +632,16 @@ int kb_client_memory_update(int64_t id, const char *content)
 {
    if (id <= 0 || !content || !content[0])
       return -1;
+   char *upd_red = NULL;
+   if (kbc_pii_screen(content, &upd_red) != 0)
+   {
+      kb_client_memory_audit_note("memory.update.withheld_pii", id, "", "", "", 0.0, "", 0);
+      return KB_CLIENT_MEMORY_WITHHELD_PII;
+   }
    cJSON *req = cJSON_CreateObject();
    cJSON_AddNumberToObject(req, "id", (double)id);
-   cJSON_AddStringToObject(req, "content", content);
+   cJSON_AddStringToObject(req, "content", upd_red ? upd_red : content);
+   free(upd_red);
    char *json = kb_v1_action_request("memory.update", req);
    if (!json)
       return -1;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1759,6 +1759,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 	                                  $(OBJDIR)/modules/kb_client/kb_client_index_parse.o \
 	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
+	                                  $(OBJDIR)/posix/memory.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
 	                                  $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_kb_client_memory.c
+++ b/src/tests/test_kb_client_memory.c
@@ -268,6 +268,98 @@ static void test_typed_context_uses_server_defaults(void)
    printf("  PASS: test_typed_context_uses_server_defaults\n");
 }
 
+/* ---------------------------------------------------------------------------
+ * PII must never cross to aimee-kb.
+ *
+ * The assertion that matters is NOT "the call returned an error" -- it is that
+ * NO REQUEST WAS ISSUED. A gate that lets the POST happen and then reports a
+ * rejection has already moved the data it exists to contain. g_pii_posts counts
+ * transmissions; for withheld content it must stay at zero.
+ */
+static int g_pii_posts;
+static char g_pii_last_body[4096];
+
+static int recording_post_handler(const char *url, const char *auth_header, const char *body,
+                                  char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   g_pii_posts++;
+   snprintf(g_pii_last_body, sizeof(g_pii_last_body), "%s", body ? body : "");
+   if (response_buf)
+      *response_buf = strdup("{\"status\":\"ok\",\"memory\":{\"id\":7}}");
+   return 200;
+}
+
+static void test_pii_never_reaches_kb(void)
+{
+   const char *secret = "my password: hunter2trustno1";
+
+   /* 1. Clean content is transmitted unchanged. */
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(recording_post_handler);
+   g_pii_posts = 0;
+   g_pii_last_body[0] = '\0';
+   assert(kb_client_memory_insert(TIER_L1, KIND_FACT, "k-clean", "the sky is blue", 1.0, "s",
+                                  NULL) == 0);
+   assert(g_pii_posts == 1);
+   assert(strstr(g_pii_last_body, "the sky is blue") != NULL);
+
+   /* 2. Redactable content crosses only in redacted form: the secret itself is
+    *    absent from the wire, and the marker is present. */
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(recording_post_handler);
+   g_pii_posts = 0;
+   g_pii_last_body[0] = '\0';
+   int rc = kb_client_memory_insert(TIER_L1, KIND_FACT, "k-secret", secret, 1.0, "s", NULL);
+   if (rc == 0)
+   {
+      assert(g_pii_posts == 1);
+      assert(strstr(g_pii_last_body, "hunter2trustno1") == NULL);
+      assert(strstr(g_pii_last_body, "REDACTED") != NULL);
+   }
+   else
+   {
+      /* Unredactable -> withheld outright, and nothing was sent. */
+      assert(rc == KB_CLIENT_MEMORY_WITHHELD_PII);
+      assert(g_pii_posts == 0);
+   }
+
+   /* 3. A sensitive KEY withholds the whole write: the key is the lookup handle
+    *    and cannot be redacted in place. Nothing is transmitted. */
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(recording_post_handler);
+   g_pii_posts = 0;
+   rc = kb_client_memory_insert(TIER_L1, KIND_FACT, secret, "benign body", 1.0, "s", NULL);
+   assert(rc == KB_CLIENT_MEMORY_WITHHELD_PII);
+   assert(g_pii_posts == 0);
+
+   /* 4. The same screen guards update and supersede, not just insert. */
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(recording_post_handler);
+   g_pii_posts = 0;
+   g_pii_last_body[0] = '\0';
+   rc = kb_client_memory_update(42, secret);
+   if (rc == KB_CLIENT_MEMORY_WITHHELD_PII)
+      assert(g_pii_posts == 0);
+   else
+      assert(strstr(g_pii_last_body, "hunter2trustno1") == NULL);
+
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(recording_post_handler);
+   g_pii_posts = 0;
+   g_pii_last_body[0] = '\0';
+   rc = kb_client_memory_supersede(42, secret, 1.0, "s", NULL);
+   if (rc == KB_CLIENT_MEMORY_WITHHELD_PII)
+      assert(g_pii_posts == 0);
+   else
+      assert(strstr(g_pii_last_body, "hunter2trustno1") == NULL);
+
+   mock_agent_http_reset();
+}
+
 int main(void)
 {
    /* A configured kb URL routes kb_client_v1_post_json through agent_http_post
@@ -280,6 +372,7 @@ int main(void)
    test_ordered_readers_propagate_active_project_context();
    test_explicit_scope_overrides_ambient_context();
    test_typed_context_uses_server_defaults();
+   test_pii_never_reaches_kb();
 
    unsetenv("AIMEE_KB_API_URL");
    runtime_secret_remove("AIMEE_KB_API_BEARER_TOKEN");


### PR DESCRIPTION
Memory content moved from aimee-server to aimee-kb **completely ungated**. Neither side screened it: `kb_client_memory_insert_ex` posted `key` and `content` verbatim, and `kb_handle_memory_store` inserted whatever arrived.

## The gate already existed and was never wired in

`gate_check_sensitive` (`posix/memory.c`, `windows/memory.c`) is the platform classifier — `2` = a secret/PII span it cannot cleanly redact, `1` = redacted into the caller's buffer, `0` = clean. `memory_gate_check` wraps it with REJECT/REDACT semantics and is exported from `headers/memory.h`.

**`memory_gate_check` has zero callers.** The only live use of the classifier anywhere is `trajectory_export.c`. A fully implemented PII gate has been sitting unreferenced while memory content shipped to kb untouched.

## The fix

Screen client-side, in the three wrappers that carry content: `kb_client_memory_insert_ex`, `kb_client_memory_update`, `kb_client_memory_supersede`.

**Client-side is the point.** A gate on the kb side has already accepted the data it exists to keep out — "aimee-kb rejected it" still means aimee-kb received it. Putting it in the wrappers rather than at their seven call sites means a caller cannot forget it, the same reasoning that puts the evidence ledger in a trigger rather than in application code.

| Input | Result |
| --- | --- |
| Clean content | Sent unchanged |
| Redactable content | Sent as `[REDACTED]`; the secret never reaches the wire |
| Unredactable content | **Withheld** — no request issued |
| Sensitive **key** | **Withheld entirely**, redactable or not |
| Allocation failure | **Withheld** — unable to classify means unable to send |

A sensitive key withholds rather than redacts because the key is the record's lookup handle: a redacted key silently changes *which record* is being addressed. The withheld audit note deliberately omits the key, since the key may be what was sensitive.

Callers get `KB_CLIENT_MEMORY_WITHHELD_PII` (-2), distinct from -1 so "we would not send this" is distinguishable from "we could not send this". Existing callers treat any non-zero as failure, so they fail closed unchanged.

## Verification — red/green

The assertion that matters is **not** that the call returned an error, but that **no request was issued**. The test counts transmissions through the mocked transport and requires zero for withheld content.

- **Green:** clean content passes through; redactable content crosses only as `[REDACTED]` with the secret absent; a sensitive key sends nothing.
- **Red** (screen disabled): `hunter2trustno1` appears on the wire and the test fails.

Two things the test caught that I had wrong: my first version *redacted* a sensitive key instead of withholding it, and my first red run silently no-opped — the edit hadn't applied, so "red passed" was a false alarm. Both are why the red half is worth actually running.

The test target had to link `posix/memory.o`, which it did not before.

## Scope note — the other half of your requirement

You said PII should **stay on aimee-server**. This PR delivers "never reaches aimee-kb", which is the enforceable and security-critical half. The other half needs a decision:

**`handle_memory_store` has no local store.** It persists *only* by calling `kb_client_memory_insert` — on that path aimee-server has no memory of its own, so withheld PII is currently not stored anywhere rather than kept locally. Making it "stay" requires a local memory store on the server path that does not exist today. I did not invent one. Worth deciding whether withheld memories should go to a local DB1 store, or whether refusing them outright is the intended behaviour.

https://claude.ai/code/session_011yMHJDEtkjtunYGTZsHRmy