### PR TITLE
docs(proposals): governed recall decision record and a privacy module

### DIFF
--- a/docs/proposals/pending/governed-recall-decision-record-and-adversarial-memory-measurement.md
+++ b/docs/proposals/pending/governed-recall-decision-record-and-adversarial-memory-measurement.md
@@ -1,0 +1,445 @@
+# Proposal: Governed recall: a decision record for every candidate, and adversarial measurement of the gates that produce it
+
+- **State:** PENDING. Concepts and design only; no code in this PR. Eight
+  transferable concepts, each scoped as **reuse/extend what exists** and each
+  anchored to a verified surface in the current tree.
+- **Author:** JBailes
+- **Date:** 2026-08-27
+- **Charter roles:** Observe-Record (recall decision record), Enforce (release
+  gate, re-authorization, erasure state), Constrain-Verify (invariants, semantic
+  fuzz), Measure (trajectory-level adversarial benchmark, claim register)
+- **Related pending work:**
+  [`proposal-evidence-provenance-tiers.md`](proposal-evidence-provenance-tiers.md)
+  (classifies and gates untrusted memory; §2, §3 and §7 below amend its stated
+  scope), [`local-first-memory-and-trust-patterns.md`](local-first-memory-and-trust-patterns.md)
+  (IPI/drift threat model).
+
+---
+
+## Thesis
+
+Aimee's memory path already **decides** a great deal on the way to a prompt: it
+scores, orders, drops low-confidence candidates, withholds sensitive facts,
+abstains under threshold, and suppresses outcome-demoted rows. What it does not
+do is **record those decisions**, and what the benchmarks do not do is measure
+them **over a trajectory** rather than a single turn.
+
+Two consequences follow, and they compound:
+
+1. **"Why did the agent say that?" has no answer, and neither does "why did it
+   not?"** A candidate that was dropped leaves no trace. Every gate on the recall
+   path is therefore individually untestable in production and only weakly
+   testable in a benchmark, because the only observable is the final answer.
+2. **The gates are measured single-shot, so their real cost is invisible.** The
+   damage a bad memory does is not that it loses one question; it is that it
+   re-fires in every later step of the same task. A per-question accuracy delta
+   cannot see that, and cannot see which gate paid for the recovery.
+
+The proposal is a single foundation plus seven things it unlocks:
+
+> **Every candidate that reaches the recall path leaves a decision record: a
+> verdict, a reason, and its provenance. Serving is recorded, not only writing.**
+
+Everything else here (the release gate, evidence re-authorization, erasure
+tombstones, the channel-sensitivity axis, the trajectory benchmark, the
+invariants file, the claim register) either produces a reason code or consumes
+one. §1 is the prerequisite; §2–§9 are separately acceptable once it exists.
+
+---
+
+## §0 What already exists (DRY map)
+
+Verified against `a397223849`. Nothing below is inferred from a file name.
+
+| Piece | Existing surface | State |
+| --- | --- | --- |
+| Assembly chokepoint | `emit_candidate` (`memory_assemble.c:387`), called once from the section loop (`:1283`) | **exists**: the single point every served candidate passes |
+| Abstention | `answerability_withheld` / `config_memory_abstain_enabled` (`memory_assemble.c:999`, `:1082`, `:1106`, `:1354`), with `memory_directive_record_retrieval_failure` on threshold crossings | **exists**: recall-side abstain is already first-class |
+| Per-attribute sensitivity gate | `memory_pii_should_inject` / `memory_pii_rel_sensitivity` (`src/modules/memory/memory_pii_gate.c`), wired at `src/modules/db2/c/fact_recall.c:102` and `src/kb/db2_adapters/kb_service_backend_memory.c:1430` | **exists**, fails closed on unknown `rel_type` (`rel_types.sensitivity NOT NULL DEFAULT 'pii'`, `schema.sql:2052`) |
+| Typed-triple write gate | `memory_fact_gate_check` + `FACT_GATE_REJECT_SENSITIVE` (`src/modules/memory/memory_fact_gate.h`) | **exists**: single commit point for semantic edges |
+| Supersession + conflict | `memory_supersede` (`memory_advanced.c:55`, `:286`), `memory_conflict.c`, `db2_memory_supersede_lookup` (`memory_assemble.c:433`) | **exists** |
+| **Destructive-edit authority** | `memory_authority_t` (`src/headers/memory_authority.h`); `memory_delete_as` / `memory_update_content_as` (`headers/memory.h:412`, `:425`) route MODEL authority to `memory_retire` / `memory_supersede` and only USER authority destroys, behind `CAP_MEMORY_ADMIN` (`headers/server.h:156`) | **exists**: the tree already refuses to let a model destroy what a user stated |
+| **Persisted write provenance** | `memory_insert_ex` stores the write's authority as `memories.provenance_category` via `MEMORY_PROVENANCE_FOR` (`memory_core_crud.c:493`), fail-closed to `agent_message` (`schema.sql:605`), derived from the calling surface and never from a request field | **exists and is now populated** |
+| Lineage records | `memory_lineage_insert(object_type, object_id, source_kind, source_ref, confidence)` (`headers/memory.h:497`), `memory_provenance` table | **exists**: per-object origin, one row per assertion |
+| Tamper-evident ledger | `audit_worm_append` (`src/modules/audit/audit_worm.c:135`) plus `_verify` / `_checkpoint` / `_seal` / `_read_page` (`docs/modules/audit.md`) | **exists**, and is stronger than what §1 needs |
+| Write-side audit | `mem_audit("memory.insert" \| ".merge" \| ".update" \| ".reject" \| ".delete", …)` (`memory_core_crud.c:409`-`:652`), documented as **non-content fields only** (`headers/memory.h:428`) | **exists**: mutations only |
+| Action authorization boundary | `policy_check_tool` (`src/server/execution_policy_bus.c:26`, declared `headers/agent_exec.h:236`), consumed by `pre_tool_check` | **exists**: authorizes the *action* |
+| Poison benchmark | `benchmarks/memory/poison_gate.py` + `poison_fixtures.json` | **exists**: two scenarios, single-turn |
+| Recall benchmarks | `benchmarks/locomo/`, `benchmarks/longmemeval/` (direct + LLM tracks, external anchors documented) | **exists**, with anchor discipline |
+
+Two of these landed recently and change what this proposal needs to argue. The
+authority split already establishes that **who is asking** governs whether an
+edit destroys, and `provenance_category` already records **what kind of caller
+wrote a row**, fail-closed. Both are write-side. Neither is readable as a reason
+on the recall path, which is the gap below.
+
+### The verified gaps
+
+- **No recall decision record anywhere.** `memory_assemble.c` contains **32
+  `continue;` statements**, none of which records why the candidate went away;
+  `src/modules/db2/c/fact_recall.c:102` drops a PII-gated fact the same way; and
+  `answerability_withheld` zeroes `cand_count` wholesale. Grepping
+  `src/modules/memory/` for `exclusion`, `drop_reason`, `why_not`,
+  `recall_trace`, or `memory_trace` returns nothing but the `answerability_*`
+  locals and gate comments. Every gate is silent by construction.
+- **Audit records writes, not serves.** `mem_audit` fires on insert, merge,
+  update, reject and delete, and its contract is explicitly non-content.
+  Nothing records that a memory was *injected into a prompt*, nor that one was
+  *withheld*. The WORM ledger is ready to carry it.
+- **Erasure is still an event, not a state, on the path that erases.**
+  `memory_delete_as` (`memory_core_crud.c:621`) is correctly split: MODEL
+  authority retires (the row survives under `key#vN` with `valid_until`
+  stamped, readable through `memory_fact_history`), USER authority hard-deletes.
+  Retirement is versioning, and it deliberately **keeps** the content. The
+  destructive path (`memory_delete`, `:632`, reached from `memory op forget` via
+  `mem_delete` and `kb_client_memory_delete`) wipes provenance, drops the
+  record's own and every unit-scoped pgvector point, and deletes the row,
+  leaving **nothing behind**. So a restore resurrects the content and a
+  re-ingest of the same text is stored as a fresh, clean, high-confidence
+  memory. Neither branch gives recall a reason to state.
+- **Corroboration is intra-memory, not cross-source.** The "≥2 corroborating
+  units per memory" filter in `memory_collect_unit_matches_via_vector`
+  (`memory_core_search_b.c:1251`) groups vector hits by *parent memory_id*. It
+  says "this memory matched in two places", never "two independent sources
+  asserted this value". `memory_lineage` holds the data for the second question;
+  nothing asks it.
+- **Poisoning is measured single-shot.** `poison_gate.py` runs a fixed
+  `clean`/`poison` pair, scores independent questions by token overlap, and
+  gates on `clean_accuracy - poison_accuracy <= delta_max`. There is no
+  multi-step trajectory, no per-trajectory pairing, and no attack taxonomy, so
+  the re-firing cost of a surviving poison is not measured at all.
+- **The action boundary re-checks the action, not the evidence.**
+  `policy_check_tool` authorizes a tool call. Nothing asks whether the memory
+  the plan rested on is *still* servable at the moment the side effect fires.
+
+---
+
+## Part II: Implementation plan
+
+### §1 The recall decision record (Observe-Record): the foundation
+
+Every candidate entering the recall path exits with exactly one of:
+
+- `served`: plus its provenance (source_kind/source_ref, tier, confidence)
+- `withheld`: plus a **reason code** from a closed vocabulary
+- `abstained`: the whole-turn case, with the threshold and candidate count
+
+Reason codes are a small fixed enum, not free text, because they are assertion
+targets in tests and grouping keys in the benchmark. The initial vocabulary is
+exactly what the code already implements silently: `sensitivity_withheld`,
+`below_confidence_floor`, `superseded`, `outcome_demoted`, `wrong_scope`,
+`budget_exhausted`, `truncated`, `duplicate`, `retention_expired` (new, §8),
+`erased` (new, §7), `tier_not_main` (from the tier proposal), plus
+`answerability_withheld` for the turn-level case.
+
+Two invariants, and they are the point of the section:
+
+> **Every served candidate carries provenance. Every withheld candidate carries
+> a reason. A drop site with no reason code is a bug, and CI can see it.**
+
+Placement follows the existing chokepoint: `emit_candidate` is already the sole
+serialization point, so the record is emitted alongside it and the bare
+`continue;` sites on the candidate path become reason-carrying rejects. The record has two sinks with
+different lifetimes:
+
+- **Turn-local trace**, cheap and always on, readable by `aimee memory` /
+  trace surfaces. This is what makes "why did it say that?" answerable.
+- **WORM ledger**, gated (`audit_recall_enabled`, default off), for
+  deployments that need serve-side evidence. `audit_worm_append` already
+  exists and the ledger already carries governed-action evidence; this adds
+  producers, not a store.
+
+Cost control matters: the trace is bounded per turn (a fixed-size ring of
+records, oldest evicted with a counter), and the WORM sink records *decisions*,
+not content.
+
+### §2 Trajectory-level adversarial measurement (Measure)
+
+Extend `benchmarks/memory/` from a two-scenario retrieval gate to a
+**trajectory benchmark**, keeping the existing fixture format as one family.
+
+Three changes, in order of value:
+
+1. **A scenario is a sequence, not a question set.** Ingest turns, then *n*
+   query steps against the same subject. This is what exposes the metric the
+   current gate cannot see:
+
+   > **Compounding-error rate**: given one bad memory that survives the gates,
+   > in how many *later* steps of the same trajectory does it re-fire?
+
+   A single-turn benchmark scores that as one loss. It is not one loss; it is
+   the loss multiplied by the remaining step count, which is precisely why a
+   memory-layer defect is worse than a retrieval miss.
+
+2. **Score paired, per trajectory, governed vs ungoverned.** Report the
+   discordant counts: how many trajectories the gates flip from fail to pass,
+   and, critically, **how many they flip from pass to fail**. An aggregate
+   accuracy delta hides the second number, and the second number is the one
+   that tells you a gate is over-firing. A gate that wins 400 and loses 40 is a
+   different object from one that wins 360 and loses 0.
+
+3. **Report counts, not p-values, for author-designed fixtures.** The scenarios
+   are ours and deterministic, so a significance test over them restates the
+   scenario count we chose and dresses it as evidence. Counts, seeds, and the
+   generator are the honest artifact. (Significance stays appropriate where the
+   corpus is external, LoCoMo and LongMemEval, and those harnesses already do it.)
+
+The existing `validate_forbidden_metadata_ignored` check generalizes and should
+be kept: fixtures whose poison rows carry *trusted-looking* metadata (high
+declared confidence, operator-shaped source tag, high retrieval frequency) are
+the only ones that test metadata-spoof resilience, and the harness should keep
+refusing to grade a fixture that forgot to lie convincingly.
+
+With §1 in place, each scenario also asserts **which gate** produced the
+outcome, by reason code, so a benchmark that passes for the wrong reason
+(a poison excluded by a budget truncation rather than by the trust gate) fails.
+
+### §3 An attack-family taxonomy, including the family we cannot defend (Measure, Constrain-Verify)
+
+Generate scenarios per named family rather than as one blended fixture, and
+report families separately so the headline mixture stays stable when a family
+is added:
+
+| Family | Shape | Expectation |
+| --- | --- | --- |
+| `benign` | ordinary facts, no gate should fire | gates must not interfere |
+| `poisoning` | conflicting value on a lower-trust channel | resolve to the trusted value |
+| `injection` | instruction-shaped content stored as memory | quarantine at write, never serve as instruction |
+| `erasure` | forgotten attribute queried later; a sibling attribute queried too | refuse the first, **still serve the second** |
+| `scope` | two subjects sharing a surface form, distinguished only structurally | never cross |
+| `trigger` | conditional backdoor: poison ranks top **only** when a rare token appears in the query, dormant otherwise | defended by provenance, not by spotting the token |
+| `same_channel` | poison arrives on the **same channel at the same trust**, written later | **known boundary, expected to fail** |
+
+Two families deserve argument.
+
+**`trigger`** is the family a label-based defense silently fails. The poison is
+written first and carries a rare token; on ordinary queries recency favors the
+true fact and the memory looks clean, so a benchmark of ordinary queries reports
+a healthy system. It surfaces only on the triggered query. A defense that works
+here must key off *provenance*, not off any property of the text, which is
+exactly the argument for the tier proposal, and this family is the test that
+proves it rather than asserting it.
+
+**`same_channel` is the honest boundary, and it directly amends the tier
+proposal's stated scope.** If the poison arrives through the same fully-trusted
+channel as the legitimate fact, at equal trust, written later, then a
+provenance-tier model has **zero signal**: it is indistinguishable from the user
+correcting themselves, and latest-wins supersession serves it. Tier 1 does not
+mean "true"; it means "a human asserted it", and a human channel can be wrong or
+compromised. This should be written into the tier proposal as a named
+non-goal before it is accepted, and measured here as a family expected to fail,
+rather than discovered later as a hole in a shipped defense.
+
+There is a partial answer worth building because the substrate already holds the
+data: **source-independent corroboration**. A value asserted by two *independent*
+sources outvotes a single fresh assertion at equal trust. Aimee has one-row-per-
+assertion lineage (`memory_lineage_insert`) and a `memory_provenance` table; what
+it lacks is a resolver that counts *distinct* `source_ref`s for a
+(subject, relation, value) rather than counting vector units of one memory
+(§0, fourth gap). Scoped as an **opt-in conflict-resolution mode**, measured on
+a `same_channel_corroborated` family, and honest that the equal-trust 1-vs-1
+case stays unsolved.
+
+### §4 Two-phase recall: candidate metadata, then release (Enforce)
+
+Split recall into a phase that returns **no content**:
+
+- **Phase 1, candidates:** ids, scores, provenance, and per-candidate verdict
+  and reason (§1 is already computing exactly this). The agent can see *that*
+  three sensitive facts exist and were withheld, without a byte of their text
+  entering the context window.
+- **Phase 2, release:** hand out content for named ids, **re-evaluating the
+  gates at that moment**.
+
+The re-evaluation is the substance, not the ceremony. A phase-1 eligibility is a
+statement about the past; if an erasure, a rejection, a sensitivity change, or a
+retention expiry lands between the phases, a stale eligibility is worthless by
+design. Phase 2 is also the natural place to emit the serve-side WORM record
+from §1, because it is where content actually crosses the boundary.
+
+`emit_candidate` and the section/budget loop around it already form the seam:
+today they select and serialize in one pass; the split makes selection
+inspectable and serialization gated. Existing callers keep a one-shot
+convenience wrapper that runs both phases, so this is an added capability, not a
+migration.
+
+### §5 Evidence re-authorization at the action boundary (Enforce)
+
+`policy_check_tool` authorizes the action. Add a companion question at the same
+boundary:
+
+> The plan rested on memory *M*. Is *M* still servable, **now**?
+
+Answering it is nearly free once §1 and §4 exist: it is the same gate evaluation
+against the same reason vocabulary, keyed by memory id, returning
+`still_valid` plus a reason. The failure it prevents is real and current:
+a long-running or resumed task plans against a fact, the user forgets or rejects
+it mid-run, and the side effect fires on retracted evidence. `pre_tool_check`
+already consumes a policy decision; this adds a second, evidence-shaped input to
+the same enforcement point rather than a new one.
+
+Scope it honestly: this gates **acting on** a memory the agent already holds. It
+does not, and cannot, unwind a value the model has already internalized into its
+reasoning earlier in the turn. It is a re-authorization hook, not amnesia.
+
+### §6 Erasure as durable state, not a delete (Enforce)
+
+Keep the destructive branch of `memory_delete_as`: it should still physically
+remove the row, its vector points, and its provenance. Add, in a store
+deliberately **separate from the memory graph**, a durable tombstone recording what was erased (normalized term tokens
+plus the raw surface form), its scope, the requester, and the time.
+
+Retirement is not a substitute. It versions the row and keeps the content
+readable through `memory_fact_history`, which is correct for a model correction
+and is the opposite of what erasure means. Three properties neither branch
+provides today:
+
+1. **Restore safety.** Restoring a snapshot taken before an erasure silently
+   resurrects the content. This got harder, not easier: the `aimee data db`
+   backup/check/recover group was removed when the store became PostgreSQL
+   (`cmd_data.c:534`), so restores now happen entirely outside Aimee, through
+   `pg_restore`, with no hook for the process to notice. Because tombstones live
+   outside the graph, the supported repair is: restore, then re-union the
+   tombstone set. Idempotent, audited, and it reports how many entries it
+   re-applied.
+2. **Write-side erasure.** A re-ingest of an erased value is quarantined, not
+   stored as a fresh clean record. Without this, "forget X" survives exactly
+   until the next time X is mentioned.
+3. **A recall reason.** `erased` becomes a §1 reason code, so an erasure that
+   is enforced is *visible* as enforced, not merely as an absence.
+
+Matching stays token-based by default. Paraphrase-level matching ("wants kids"
+erased; a note says "planning a family") requires an embedding provider, so it
+is **opt-in, thresholded, and fails audibly** when the provider is down: never
+silently fails open, and never silently fails closed either. It catches
+similarity, not inference, and the proposal should say so.
+
+An **erasure receipt** (what was targeted, what was removed, from which stores,
+requested by whom, appended to the WORM ledger) is the artifact that makes
+`aimee memory op forget` auditable. It is evidence of the action taken, not a
+claim that no derived copy exists anywhere.
+
+### §7 Channel sensitivity: sensitive by provenance, not only by content (Classify-Score)
+
+`memory_pii_rel_sensitivity` keys sensitivity off the `rel_type`, a property of
+*what the fact is*. Add an orthogonal axis: a property of *where it arrived*.
+
+The motivating case is a human free-text field: a note, a scratch comment, a
+pasted fragment. Nothing in it need look sensitive token-by-token, and a
+content-keyed classifier passes it, yet free-text is precisely where volunteered
+sensitive material lands. The channel is the signal, and it is available at
+ingest with no classification at all.
+
+Concretely: the write path records a channel sensitivity alongside the existing
+tier and trust, and a high-sensitivity channel holds content for explicit
+release rather than admitting it at the sensitivity its `rel_type` implies. This
+is a small amendment to the tier proposal's classification entrypoint (it is the
+same write-side hook, carrying one more field), and it composes with the PII
+gate rather than replacing it: `max(content_sensitivity, channel_sensitivity)`
+decides.
+
+Held records need a release path (an explicit, authenticated confirmation that
+promotes them), and the release is a §1-recordable event. Without the release
+path this is a data black hole, so the two ship together.
+
+### §8 A memory invariants file, and fuzz over semantic outcomes (Constrain-Verify)
+
+A short, blunt document listing what must be true regardless of what the score
+says, under one governing rule:
+
+> **A change that improves benchmark recall while violating one of these is a
+> regression.**
+
+The initial list, all of which are already true or become true above: erased
+memory is never selected; rejected memory is never selected; injection-shaped
+memory is never treated as an instruction; wrong-scope memory is excluded
+*before* ranking can make it attractive; superseded facts do not resurrect as
+current truth; every selected memory has provenance; every excluded memory has a
+reason; a persistence reload does not change retrieval results; replaying the
+same ingest sequence does not create duplicate active truth; adding irrelevant
+distractors never makes an excluded memory selectable.
+
+Back it with **seeded fuzz over operation sequences** (writes, supersessions,
+rejections, erasures, scope collisions, injection-shaped content, snapshot
+round-trips), comparing *semantic* outcomes across seeds: which claims were
+selected, whether the turn abstained, and **which reason codes fired**. Not row
+ids, which are expected to differ. The reason codes from §1 are what make this
+possible: without them the only observable is the final string, and a fuzz test
+over final strings is a change detector, not an invariant test.
+
+### §9 A claim register for memory and governance claims (Measure)
+
+Two documents, both cheap, both aimed at the same failure: a number that
+outlives the conditions that produced it:
+
+- **A claim register**: every memory/governance claim we make, with its
+  evidence level, the artifact that backs it, and its risk if wrong. It makes
+  the distinction between "measured on an external corpus", "measured on a
+  fixture we wrote", and "asserted from the design" a *field*, not a matter of
+  how carefully someone read the prose.
+- **A measurement changelog**: when a re-measurement changes a published
+  number, record the before, the after, and the cause, **especially when the
+  correction moves against us**. A harness bug that understated a baseline and
+  was quietly fixed is indistinguishable, from the outside, from one that was
+  never found.
+
+`benchmarks/locomo/BENCHMARK_RESULTS.md` already practices the hardest part of
+this: it names an external anchor, tabulates every way our harness deviates
+from it, and requires deviations beyond a threshold to be explained. Generalize
+that discipline; the register is the index that makes it enforceable rather
+than per-benchmark habit.
+
+One rule worth adopting explicitly, because cross-harness comparison is the
+standing temptation: **rank only what was measured in one harness.** Numbers
+from other harnesses (third-party evaluations, vendor self-reports) belong in
+separate tables, quoted with their conditions, never merged into one leaderboard.
+
+---
+
+## Non-goals
+
+- **A separate compliance or data-subject-request subsystem.** §6 and §7 exist
+  because a memory that cannot durably forget is *incorrect*, not to serve a
+  regulatory workflow. No request intake, ticketing, or approval routing is
+  proposed here.
+- **A second audit store.** §1 and §6 add producers to the existing WORM ledger.
+- **A second policy engine.** §5 adds an input to `policy_check_tool`'s
+  enforcement point; it does not create a parallel decision path.
+- **Changing retrieval ranking.** Every gate here filters. None improves recall,
+  and none should be justified by a recall number.
+- **Free-text reason strings.** The vocabulary is closed and versioned, or it is
+  not testable.
+- **Defending `same_channel`.** Named, measured, expected to fail (§3).
+
+## Sequencing
+
+§1 is the prerequisite for §2, §4, §5 and §8 and should land alone, because it
+is also the largest standalone win: it makes the existing gates observable
+without changing a single decision any of them makes. §3 and §7 should be folded
+into the provenance-tier proposal **before** it is accepted, since both change
+its stated scope. §2, §6, §8 and §9 are independent thereafter; §4 and §5 are
+the largest and should follow the benchmark, so their effect is measurable when
+they land rather than argued.
+
+## Open questions
+
+1. **Reason-code granularity.** One code per gate, or a code plus a
+   gate-specific detail field? Coarse codes are stable test targets; detail is
+   what an operator actually wants at 2am. Probably `code` + optional bounded
+   `detail`, with only `code` assertable in tests.
+2. **Turn-local trace budget.** What is the per-turn record cap before eviction,
+   and does an evicted record leave a counter? (It must, or the trace is
+   quietly lying about completeness.)
+3. **Does the serve-side WORM record belong in the same chain as governed
+   actions,** or a separate stream with its own checkpoint cadence? Recall
+   volume is orders of magnitude above action volume.
+4. **Where does the tombstone store live** relative to the DB1/DB2 split, given
+   that erasure must outlive a restore of either?
+5. **Independence, for corroboration (§3).** Two lineage rows with distinct
+   `source_ref`s are not automatically independent: two ingests of the same
+   upstream document are one source wearing two hats. What is the minimum
+   defensible independence test, and is it worth building before the family is
+   measured?
+6. **Does channel sensitivity (§7) need its own vocabulary,** or does it reuse
+   `rel_sensitivity_t`? Reuse is tempting and probably wrong: the two axes
+   answer different questions and will drift.

--- a/docs/proposals/pending/privacy-data-subject-rights-module.md
+++ b/docs/proposals/pending/privacy-data-subject-rights-module.md
@@ -1,0 +1,430 @@
+# Proposal: a `privacy` module: data-subject rights over everything Aimee persists
+
+- **State:** PENDING. Module specification and phasing; no code in this PR. The
+  descriptor and canonical-doc outline in §10 are the contract an implementation
+  must hit.
+- **Author:** JBailes
+- **Date:** 2026-08-27
+- **Charter roles:** Classify-Score (subject-data registry), Plan (dry-run
+  report), Enforce (erasure, restriction, requester authority), Attest (signed
+  receipts), Constrain-Verify (coverage latch, residual verification)
+- **Proposed module id:** `privacy` (optional, `enabled_by_default: false`)
+- **Depends on:**
+  [`governed-recall-decision-record-and-adversarial-memory-measurement.md`](governed-recall-decision-record-and-adversarial-memory-measurement.md)
+  §6 (erasure as durable state). Erasure without tombstones is undone by the
+  next backup restore, so P3 below cannot ship before it.
+- **Related:** [`proposal-evidence-provenance-tiers.md`](proposal-evidence-provenance-tiers.md)
+  (provenance classification at write time).
+
+---
+
+## Thesis
+
+The request workflow is the easy part. Intake, plan, approve, execute, verify is
+five endpoints and a state machine, and any competent implementation gets it
+right in a week.
+
+The hard part, and the only part worth designing carefully, is this:
+
+> **Which of the things Aimee persists contain data about a person, and where
+> does the derived copy live?**
+
+Aimee persists a lot. `src/modules/db2/c/schema.sql` declares **241 tables**
+(the SQLite mirror declares 237). DB1 is a separate store behind its own module
+boundary, and its table count **could not be established by inspection at all**:
+there is no single schema file to count, which is itself an instance of the
+problem rather than an aside. On top of both sit pgvector points, on-disk
+session and trajectory artifacts, the audit log, KB documents, and a long tail
+of *derived* objects: `memory_chunks`,
+`memory_units`, `memory_summaries`, `memory_episodes`, `memory_aliases`,
+`memory_entities`, `memory_event_frames`, `entity_profiles`, `entity_edges`,
+`memory_lineage`, and the embeddings computed from all of them. A subject's
+sentence enters once and lands in a dozen places under a dozen ids.
+
+That produces the failure mode this module exists to prevent:
+
+**A hand-written list of tables is wrong the day someone adds the next one.**
+This is not hypothetical: DB2 grew by twenty-one tables between the branch this
+work started on and the branch it merges into. An
+erasure implemented as "delete from these seventeen tables" degrades silently:
+it keeps returning success while a new derived store quietly accumulates copies
+nobody enumerated. The absence of an error is not evidence of erasure.
+
+So the load-bearing idea is not the workflow. It is a **declared, CI-enforced
+disposition for every persisted store, defaulting fail-closed**, on exactly the
+pattern the tree already uses twice: `rel_types.sensitivity` is `NOT NULL
+DEFAULT 'pii'` so an unclassified relation is withheld rather than leaked, and
+`ownership_complete: true` makes an undeclared module-local source a CI failure
+rather than a silent gap. This proposal applies the same latch to persistence.
+
+Everything else here is downstream of that registry.
+
+---
+
+## §0 What already exists (DRY map)
+
+Verified against `a397223849`.
+
+| Piece | Existing surface | State |
+| --- | --- | --- |
+| Per-memory removal, split by authority | `memory_delete_as` (`memory_core_crud.c:621`): MODEL authority retires (row survives as `key#vN`, `valid_until` stamped, readable via `memory_fact_history`); USER authority hard-deletes through `memory_delete` (`:632`), which wipes `memory_provenance`, drops the record's own and every unit-scoped pgvector point, and deletes the row | **exists**: the right primitive, at the wrong granularity for a subject |
+| Destructive-edit gate | `memory_authority_t` (`src/headers/memory_authority.h`) plus `CAP_MEMORY_ADMIN` (`headers/server.h:156`) | **exists**: a model cannot destroy what a user stated |
+| Cascade fan-out | **23** `REFERENCES memories(id) ON DELETE CASCADE` children in `src/modules/db2/c/schema.sql`: chunks, units, aliases, entities, episodes, relations, summaries, temporal refs, event frames, scopes, workspaces, links, conflicts and more | **exists**: derived rows follow the parent, **if** the parent is found |
+| Scope columns | `memories.scope_type` / `memories.scope_value` (default `global` / `_global`), plus `memory_workspaces`, `memory_scopes`, `memory_entities`, `entity_profiles.entity_id` | **exists**: candidate subject-key paths |
+| Persisted write provenance | `memories.provenance_category`, fail-closed to `agent_message` (`schema.sql:605`), written from the calling surface's authority via `MEMORY_PROVENANCE_FOR` (`memory_core_crud.c:493`) | **exists and is populated** |
+| Lineage | `memory_lineage(object_type, object_id, source_kind, source_ref, …)` | **exists**: how a record entered, per assertion |
+| Fail-closed sensitivity default | `rel_types.sensitivity TEXT NOT NULL DEFAULT 'pii'` (`schema.sql:2052`); `memory_pii_rel_sensitivity` withholds unknown types | **exists**: the exact pattern §2 copies |
+| Withholding at the shared boundary | `FACT_GATE_REJECT_SENSITIVE` (`src/modules/memory/memory_fact_gate.h`): credential/regulated-PII relations stay local and never reach the shared KB | **exists**: an existing personal-data boundary |
+| Tamper-evident evidence | `audit_worm_append` (`src/modules/audit/audit_worm.c:135`), `_verify` / `_checkpoint` / `_seal` / `_read_page`; keys under vault custody (`docs/modules/audit.md`) | **exists**: the receipt store, already built |
+| Non-content audit contract | The memory audit hook is documented as taking **non-content fields only** (`headers/memory.h:428`) | **exists**: the property §5 depends on |
+| Hash-chained KB events | `kb_audit_event(actor_role, actor_principal, action, subject, verdict, prev_hash, row_hash)` (`schema.sql:183`) | **exists**: already carries an `actor_principal` |
+| Action authorization | `policy_check_tool` (`src/server/execution_policy_bus.c:26`, declared `headers/agent_exec.h:236`) | **exists**: where an execute must be gated |
+| Organizational identity | `governance` module: OIDC issuer profiles, org accounts/roles, tenant binding (`docs/modules/governance.md`) | **exists**, optional; supplies a verified requester when present |
+| Signing custody | `vault`: signing material and protected references (`docs/modules/vault.md`) | **exists**: receipt keys have a home |
+| Scoped identity | `workspace`: scoped resource identity, containment, `ws_scope_*` (`docs/modules/workspace.md`) | **exists**: the containment boundary a subject scope rides on |
+
+### The verified gaps
+
+- **No subject concept anywhere.** There is no data-subject identifier, no
+  registry of which stores hold subject data, and no query that answers "what do
+  we hold about this person". `memories.scope_value`, `memory_entities.entity`
+  and `entity_profiles.entity_id` are the nearest things and none is a declared
+  subject key.
+- **No store-level classification.** Nothing marks a table as containing,
+  deriving, or excluding subject data, so nothing can fail CI when the next
+  store arrives unclassified. Note the contrast: the *row-level* fail-closed
+  default already exists (`rel_types.sensitivity`), and the *store-level* one
+  does not.
+- **Erasure is per-id, and leaves no state.** `memory_delete_as` takes an
+  `int64_t id`. There is no subject-scoped erasure, and the destructive branch
+  leaves nothing behind, so a restore resurrects erased content and a re-ingest
+  stores it fresh. The retire branch is not erasure: it deliberately keeps the
+  content readable.
+- **Restore is now entirely outside Aimee.** The `aimee data db`
+  backup/check/recover group was removed when the store became PostgreSQL
+  (`cmd_data.c:534`): backups are `pg_dump`'s job. The process has no hook at
+  which to notice that a restore just undid an erasure.
+- **Derived stores are only reachable through their parent.** The 23 cascades
+  are correct and are not enough: subject data that entered through a path with
+  no `memories` parent row (KB documents, interaction-event embeddings, entity
+  profiles, trajectory artifacts on disk) is not reached by deleting memories.
+- **No export.** Nothing produces a machine-readable bundle of what is held
+  about one subject.
+- **No receipt.** `mem_audit("memory.delete", …)` records that a row was
+  deleted, by id and without content. Nothing records what a *request* targeted,
+  what each store confirmed, and what could not be confirmed.
+
+---
+
+## Part II: The module
+
+### §1 Naming and boundary
+
+The module is `privacy`, not `dsar`. DSAR is the *request surface*; the module
+owns more than the request: the subject-data registry, subject resolution,
+export, erasure, restriction, retention dispositions, and receipts. A request
+workflow is one consumer of those. Naming it `dsar` would make the registry look
+like an implementation detail of a workflow, when the dependency runs the other
+way and the registry is the part that must outlive any particular intake
+channel.
+
+`privacy` **owns**: the subject-data registry and its latch, subject resolution,
+the rights operations (access, portability, erasure, restriction,
+rectification), the request lifecycle, and signed receipts.
+
+`privacy` **does not own**: the audit ledger (it appends to `audit`), the
+decision to authorize an action (it asks `execution-policy`), signing material
+(`vault`), organizational identity (`governance`), memory semantics (`memory`),
+or any intake connector (out of core, see §9).
+
+### §2 The subject-data registry, and the latch that keeps it honest
+
+A declared disposition for every persisted store: each DB2 and DB1 table, each
+pgvector namespace, each on-disk artifact class.
+
+| Disposition | Meaning | Required fields |
+| --- | --- | --- |
+| `subject_data` | Holds data about a person directly | the subject-key path: how to go from a subject id to the rows |
+| `derived` | Holds material computed from another store | the parent store, and whether the parent's cascade actually reaches it |
+| `no_subject_data` | Structural, operational, or code-derived only | a one-line justification |
+| `evidence_retained` | Deliberately not erased (see §5) | the retention rationale |
+
+Three properties make this a control rather than a document:
+
+1. **Fail closed.** An unclassified store is treated as `subject_data` with an
+   unknown key path, which makes every request involving it *incomplete*. Not
+   "assume clean and proceed": a request that cannot enumerate a store reports
+   that it could not, and the reported outcome is partial.
+2. **CI-enforced coverage.** A `check-subject-data-coverage` latch parses
+   `src/db2/schema.sql` and `src/db1/schema.sql`, and fails when a `CREATE TABLE`
+   has no registry entry. This is the same shape as the existing
+   `ownership_complete` rule, and it is the one mechanism that keeps the module
+   correct as the schema grows.
+3. **`derived` entries assert their reachability.** A `derived` entry that
+   claims the parent cascade reaches it is a testable claim, and §8 tests it by
+   erasing a parent and asserting the child is gone. The cascades in
+   `db2/schema.sql` are real, and the registry should prove it rather than trust it.
+
+The registry is also the honest answer to "can you delete my data?" before any
+request arrives: it is a map of exposure, readable on its own.
+
+### §3 Subject resolution
+
+A subject is a declared identity with a scope, resolved to a candidate row set
+across the registry. Two things matter more than the mechanism:
+
+**Resolution is a first-class, reviewable step, not a join.** Aimee holds
+free-text memories about people who are not users. A subject scope built from an
+exact key (`memory_scopes`, `memory_entities`, an account id) is precise and
+incomplete; one built from name matching is broader and wrong in both
+directions. The plan report (§4) shows *how* each candidate was matched and at
+what confidence, so an approver can see the difference between "this row is
+keyed to the subject" and "this row mentions a common first name".
+
+**A joint record belongs to more than one subject.** "The user said their
+colleague is on leave until March" is data about two people. Erasure and export
+must treat those differently: erasing on behalf of the colleague should not
+silently destroy the user's record of their own statement, and exporting to the
+user should not disclose the colleague. The registry marks stores that can hold
+joint records; the plan flags them individually; and the default for a joint
+record under erasure is **redact the subject's portion, retain the rest**, with
+the decision visible in the plan rather than buried in a policy default.
+
+### §4 The request lifecycle
+
+Four operations, each separately auditable, each with a contract that is more
+than a name.
+
+**`plan`** is a **dry run that touches nothing**, and this is a hard contract,
+not a convention: it opens no write transaction. It produces the report an
+approver reads, listing per store the matched rows, the match basis and
+confidence, joint records, derived material that will follow, and anything the
+registry could not enumerate. A plan that reports "0 stores unenumerable" is the
+only kind that should be approved without discussion.
+
+**`approve` / `reject`** record a human decision against the plan, with the
+approver's identity and the plan's hash. Approving a *stale* plan is refused:
+if the data changed since the plan was produced, the approval is for a report
+that no longer describes reality.
+
+**`execute`** is **idempotent per request id**. A retried, duplicated, or
+replayed execute performs the work exactly once and returns the original
+outcome. This is the property that makes the operation safe to expose to any
+retrying caller, and it is cheap to get right at the start and expensive to
+retrofit.
+
+**`verify`** returns **evidence, not an acknowledgement**. It re-runs the
+enumeration after the fact and reports what it now finds: zero residuals, or a
+count and a location. A verify that always returns "ok" is worse than no verify,
+because it converts an unknown into a false assurance. Residuals are a normal
+outcome (a replica lagging, an unenumerable store, a joint record retained by
+design) and must be reportable as such.
+
+### §5 Erasure, and the audit trail that must survive it
+
+Erasure composes three things that already exist or are already proposed:
+
+1. **Physical removal** via the existing primitives: the row, its 23 cascades,
+   its pgvector points. The destructive branch of `memory_delete_as`
+   (`memory_core_crud.c:632`) already does exactly this per memory and is the
+   right building block. Subject-scoped erasure is USER authority by
+   construction, so it takes that branch and must clear `CAP_MEMORY_ADMIN`.
+2. **A durable tombstone** outside the memory graph, from the recall proposal's
+   §6, so a backup restore cannot resurrect the content and a re-ingest is
+   quarantined rather than stored fresh. **This module cannot honestly claim
+   erasure without it**, which is why P3 is sequenced behind it.
+3. **A receipt** (§6).
+
+**The audit ledger is deliberately not erased, and this needs stating plainly
+rather than resolving quietly.** The WORM ledger is the proof that the erasure
+happened; erasing it destroys the evidence the subject's own request generated.
+The resolution is structural, not an exemption: the ledger records *decisions,
+identifiers and hashes, never subject content*, so there is nothing in it to
+erase. That is a claim the registry must back, with `audit`-owned stores
+classified `evidence_retained` and a test asserting that no subject content
+reaches an appended record. The memory audit hook already documents itself as
+non-content (`headers/memory.h:428`), so the claim starts from a stated contract
+rather than from hope, and the test pins it. If that test cannot be made to pass, the ledger
+schema is wrong and should change, rather than the claim being softened.
+
+**Restriction (Art. 18) is not erasure and should not be implemented as one.**
+Restriction means retained but not used, which is exactly a recall-time
+exclusion reason. It composes with the recall decision record rather than
+touching storage at all, and it is the cheaper, safer, and more common
+operation. Where a request is ambiguous or the subject's identity is unverified,
+restriction is the correct provisional action while the request is reviewed.
+
+### §6 Receipts
+
+A receipt records what a request targeted, what each store confirmed removed,
+what could not be confirmed and why, the requester and approver identities, the
+timestamps, and the ledger head hash at completion. Signed with a vault-held key
+and appended to the WORM ledger.
+
+Its honesty properties are the point. A receipt that reports a residual is doing
+its job; one that reports clean success for a store the registry could not
+enumerate is manufacturing false evidence. **The receipt is evidence of the
+action the module took. It is not an attestation that no copy of the data exists
+anywhere**, and its own wording should say so, so that the artifact cannot be
+quoted as more than it is once it is detached from this document.
+
+### §7 Requester authority: the request is untrusted input
+
+An erasure request is a destructive, hard-to-reverse action arriving over a
+channel. It is exactly the shape of input this codebase already treats as
+untrusted everywhere else, and it deserves the same treatment.
+
+- **Strict mode holds rather than executes.** An unverified, unauthenticated, or
+  anomalous request (a bulk erasure, a subject scope resolving to an implausible
+  fraction of the store) is queued for human approval, not run.
+- **`execute` is not an agent-callable tool by default.** An agent may `plan`,
+  which is read-only and useful. Exposing `execute` to a model that reads
+  untrusted content puts subject-data destruction one indirect prompt injection
+  away. If it is ever exposed, it is behind the same approval gate a human
+  request goes through, and `policy_check_tool` is the enforcement point.
+- **Identity comes from the transport, not the payload.** A request that names
+  its own requester is asserting, not proving. Where `governance` is enabled, the
+  verified principal is available; where it is not, the module runs in an
+  operator-local mode and says so in the receipt rather than implying an
+  authentication it did not perform.
+
+### §8 Tests and failure behavior
+
+The module's failure mode must be **incomplete, loudly**, never **complete,
+quietly**. Concretely:
+
+- An unclassified store makes every overlapping request partial, and the
+  partiality appears in the plan, the receipt and the verify.
+- A `derived` registry entry claiming parent-cascade reachability is tested by
+  erasing a parent and asserting the child rows and vector points are gone. This
+  is the test that catches a new derived table added without a cascade.
+- A restore-then-verify test: erase, back up, restore an *older* snapshot,
+  re-verify. The erased content must not be servable. Without the tombstone this
+  test fails, which is the intended signal, not a flaky test.
+- A re-ingest test: erase a value, ingest the same text again, assert it is
+  quarantined rather than stored clean.
+- An idempotency test: execute the same request id concurrently and after a
+  crash; assert exactly-once.
+- A joint-record test: erasure for subject A leaves B's record intact; export for
+  A does not disclose B.
+- A ledger-content test: no appended audit record contains subject content.
+
+### §9 What this module is not
+
+- **Not an ITSM or ticketing integration.** Intake connectors (email, queue,
+  webhook, drop folder) are adapters over the four operations and belong outside
+  core. The module must be complete and testable with no connector at all.
+- **Not consent management.** Consent capture is an upstream concern; this
+  module enforces the consequences.
+- **Not a compliance certification, and not legal advice.** It helps an operator
+  meet obligations. Compliance is a property of the operator's whole process.
+- **Not a promise of physical deletion everywhere.** Backups, replicas, and
+  systems Aimee does not control are reported, not claimed.
+- **Not able to recall what was already sent upstream.** This limit is specific
+  to Aimee and belongs in the module's own documentation: memory content that was
+  injected into a prompt and sent to a model provider has left the boundary. The
+  module can stop it being sent again; it cannot unsend it. Any deployment claim
+  that ignores this is false, and the receipt should not be phrased in a way that
+  invites the reading.
+- **Not a second audit store, not a second policy engine.** It appends to
+  `audit` and asks `execution-policy`.
+
+### §10 Descriptor and canonical documentation
+
+Proposed `src/modules/privacy/module.yaml`:
+
+```json
+{
+  "descriptor_version": 1,
+  "id": "privacy",
+  "dependencies": [
+    "audit",
+    "config",
+    "execution-policy",
+    "ir",
+    "memory",
+    "module-runtime",
+    "protocols",
+    "vault",
+    "workspace"
+  ],
+  "enabled_by_default": false,
+  "runtime_toggle": { "supported": false },
+  "ownership_complete": true
+}
+```
+
+Two descriptor choices worth defending:
+
+**`runtime_toggle.supported: false`, and `enabled_by_default: false`.** Selected
+before startup, and once selected it cannot be dropped at runtime. Toggling it
+off while restrictions and tombstones exist would silently stop honouring them,
+which is the one failure this module cannot be allowed to have. Decommissioning
+is an audited operation, not a config flip.
+
+**`governance` is not a dependency.** The module consumes a verified principal
+when governance is present and runs operator-local when it is not, exactly as
+`execution-policy` remains the local enforcement boundary when governance is
+absent. Depending on it would make data-subject rights unavailable to
+single-operator deployments, which inverts the intent.
+
+`docs/modules/privacy.md` follows the enforced thirteen-section contract:
+Purpose and non-goals / Public contracts / Dependencies and consumers /
+Providers and readiness / Configuration and activation / Surfaces / Data and
+migrations / Security and privacy / Supported journeys / Tests and failure
+behavior / Operational diagnostics / Compatibility / Extension and removal.
+`Providers and readiness` carries the load: readiness must separate registry
+coverage, subject-resolution availability, tombstone-store availability, ledger
+appendability, and signing-key custody. A module that can plan but cannot
+tombstone is **not** ready for erasure, and must report that rather than a
+single green light.
+
+Proposed surfaces: an `aimee privacy` command family (`map`, `subject`, `plan`,
+`approve`, `execute`, `verify`, `receipt`), matching `/v1/privacy/*` routes, and
+a **plan-only** tool exposure per §7. No name collides with an existing command.
+
+---
+
+## Phasing
+
+Each phase is independently useful and independently shippable, and the ordering
+is a dependency chain, not a preference.
+
+| Phase | Content | Gate |
+| --- | --- | --- |
+| **P1** | Subject-data registry + `check-subject-data-coverage` latch | Ships alone. Delivers the exposure map with no behavior change, and is the prerequisite for every later phase. |
+| **P2** | Subject resolution + `plan` (read-only) | Ships alone. Non-destructive by contract, so it is safe well before erasure exists. |
+| **P3** | `execute` erasure + receipts + `verify` | **Blocked on** the recall proposal's §6 tombstones. |
+| **P4** | Export / portability bundle | Blocked on the joint-record decision (open question 2). |
+| **P5** | Restriction and rectification | Blocked on the recall decision record (that proposal's §1), since restriction *is* an exclusion reason. |
+| **P6** | Intake connectors | Out of core. |
+
+P1 and P2 together answer "what do you hold about me, and what would deleting it
+touch?" with no destructive capability in the tree at all. That is most of the
+value and none of the risk, and it should not wait for P3.
+
+## Open questions
+
+1. **What is a subject identifier here?** An account, an OIDC subject claim, an
+   `entity_profiles.entity_id`, or a request-scoped declared identity resolved
+   at plan time? The last is the most honest and the least convenient, and it
+   makes every plan a review step rather than a lookup.
+2. **Joint records under export.** Redaction of the other subject's portion is
+   the obvious answer and is hard to do well on free text. Is a conservative
+   "exclude the whole record and list it as excluded" better than a redaction
+   that might leak? It is worse for the subject and safer for the third party.
+3. **Does the registry live in the schema or beside it?** A comment convention
+   parsed out of `schema.sql` keeps the classification adjacent to the
+   definition, which is where it will actually be maintained; a separate file is
+   easier to validate and easier to let drift.
+4. **Scope of the on-disk artifact classes.** Session transcripts, trajectory
+   exports and workspace working trees hold subject content and have no schema
+   to latch against. What is the enumeration mechanism, and is it in P1 or a
+   phase of its own?
+5. **Retention dispositions.** Does this module own default retention windows
+   per store, or only report what other modules declare? Owning them centralizes
+   a policy that several modules currently imply and none states.
+6. **Verify cost.** A full re-enumeration across every registered store may be
+   expensive on a large deployment. Is verify sampled with a stated confidence,
+   or exhaustive and slow? A sampled verify must never report as an exhaustive
+   one.


### PR DESCRIPTION
Two PENDING proposals. Concepts and design only, no code. Both `§0` DRY maps are verified against `a397223849`, the current `testing` tip.

## `governed-recall-decision-record-and-adversarial-memory-measurement.md`

The recall path already decides a great deal on the way to a prompt: it scores, orders, drops low-confidence candidates, withholds sensitive facts, abstains under threshold. It records none of it. `memory_assemble.c` holds 32 `continue;` statements and not one states a reason, so "why did the agent say that?" and "why did it not?" are both unanswerable, and every gate is individually untestable.

One foundation:

> Every candidate that reaches the recall path leaves a decision record: a verdict, a reason, and its provenance. Serving is recorded, not only writing.

Then seven things it unlocks: trajectory-level adversarial measurement (compounding-error rate, paired discordant counts), an attack-family taxonomy, two-phase recall, evidence re-authorization at the action boundary, erasure tombstones, a channel-sensitivity axis, a memory invariants file, and a claim register.

Two sections change another proposal's scope and should be folded into it before it is accepted: `§3` names the same-channel family that a provenance-tier model structurally cannot defend (equal trust, same channel, written later, so provenance has no signal), and `§7` adds a provenance axis to a sensitivity gate that is currently keyed only on `rel_type`.

`§1` should land alone. It is the largest standalone win and changes no decision any gate currently makes.

## `privacy-data-subject-rights-module.md`

Specifies an optional `privacy` module (`enabled_by_default: false`) owning data-subject rights: the subject-data registry, subject resolution, access, portability, erasure, restriction, rectification, the request lifecycle, and signed receipts.

The argument is that the workflow is the easy part. `schema.sql` declares 241 tables, DB1's count could not be established by inspection at all, and one sentence lands across 23 cascade children plus vectors, KB documents, entity profiles and on-disk artifacts. A hand-written table list degrades silently: it keeps returning success while a new derived store accumulates copies nobody enumerated. DB2 grew by twenty-one tables between the branch this work started on and this one.

So the load-bearing proposal is a **declared, CI-enforced disposition for every persisted store, failing closed**, on the pattern the tree already uses twice (`rel_types.sensitivity NOT NULL DEFAULT 'pii'`, `ownership_complete`). The row-level fail-closed default exists; the store-level one does not.

Points worth reviewer attention:

- The audit ledger is deliberately not erased, resolved structurally rather than by exemption: it records decisions and hashes, never subject content. The memory audit hook already documents itself as non-content, and `§8` requires a test that pins it. If the test cannot pass, the ledger schema changes, not the claim.
- `execute` is not an agent-callable tool. `plan` is read-only and safe to expose; subject-data destruction reachable from a model that reads untrusted content is one indirect injection away.
- Restriction (Art. 18) is a recall exclusion reason, not a delete, so it composes with the other proposal's `§1`.
- P3 is explicitly blocked on that proposal's `§6` tombstones. The `aimee data db` group was removed when the store became PostgreSQL, so restores now happen entirely outside Aimee via `pg_restore` with no hook to notice an erasure being undone.
- One Aimee-specific limit is written into the module's non-goals: content already injected into a prompt and sent to a model provider has left the boundary. The module can stop it being sent again; it cannot unsend it.

P1 and P2 answer "what do you hold about me, and what would deleting it touch?" with no destructive capability in the tree.

## Checks

`scripts/check-docs.py` and `scripts/check-proposal-links.py` both pass on this branch.
