### PR TITLE
fix: keep retracted facts retracted across re-extraction

### DIFF
--- a/src/modules/db2/c/fact_mutation.c
+++ b/src/modules/db2/c/fact_mutation.c
@@ -1181,17 +1181,28 @@ int db2_fact_mutation_invalidate(const fact_actor_t *actor, const char *source,
       fm_state_t after = rows[i];
       fm_copy(after.lifecycle, sizeof(after.lifecycle), FACT_LIFECYCLE_INVALIDATED);
       fm_copy(after.invalidated_at, sizeof(after.invalidated_at), now);
+      /* Carry the retracting authority onto the row.  The reactivate gate in
+       * db2_fact_mutation_assert compares an incoming actor against the row's
+       * authority_rank, so leaving the original asserter's rank here would let
+       * the next extraction of the same text re-establish a retracted triple at
+       * the authority that first asserted it.  The two rollback paths already
+       * raise the rank this way; the retract path was the one that did not.
+       * The selector loop above already refused any row outranking this actor,
+       * so this only ever raises. */
+      after.authority_rank = (int)actor->rank;
       after.version++;
       aimee_pg_stmt_t *u = aimee_pg_prepare(
           conn,
           "UPDATE entity_edges SET lifecycle_state='invalidated',invalidated_at=?2,"
-          " version=version+1,commit_id=?3 WHERE id=?1",
+          " authority_rank=?4,actor_principal=?5,version=version+1,commit_id=?3 WHERE id=?1",
           err, sizeof(err));
       if (!u)
          return fm_end(conn, 0);
       aimee_pg_bind_int64(u, "?1", rows[i].id);
       aimee_pg_bind_text(u, "?2", now);
       aimee_pg_bind_text(u, "?3", commit_id);
+      aimee_pg_bind_int(u, "?4", after.authority_rank);
+      aimee_pg_bind_text(u, "?5", actor->principal);
       int ok = aimee_pg_step(u, err, sizeof(err)) == AIMEE_PG_DONE;
       aimee_pg_finalize(u);
       if (!ok || fm_change(conn, commit_id, rows[i].id, "invalidate", &rows[i], &after,

--- a/src/tests/test_fact_lifecycle.c
+++ b/src/tests/test_fact_lifecycle.c
@@ -511,6 +511,31 @@ int main(void)
    assert(db2_fact_current_count("rollback-subject") == 0);
    ai.evidence = &ev1;
 
+   /* The retract path needs the same guarantee the rollback above proves, and
+    * for a sharper reason: a USER retraction of a MODEL-asserted fact (rank 10)
+    * must stamp USER authority (rank 30) on the row.  Left at the asserter's
+    * rank, the next SYSTEM drain (rank 20) that re-derives the triple from new
+    * text satisfies 20 >= 10, clears invalidated_at, and resurrects a fact the
+    * user deleted. */
+   assert(db2_fact_commit("ivan", NODE_PERSON, "works_for", "acme", NODE_ORG, FACT_AUTHORITY_MODEL,
+                          1) == FACT_GATE_ACCEPT);
+   assert(scalar_int("SELECT authority_rank FROM entity_edges WHERE source='ivan'"
+                     " AND relation='works_for' AND edge_class='semantic'") == FACT_ACTOR_MODEL);
+   assert(db2_fact_retract("ivan", "works_for", NULL, FACT_AUTHORITY_USER) >= 1);
+   assert(scalar_int("SELECT authority_rank FROM entity_edges WHERE source='ivan'"
+                     " AND relation='works_for' AND edge_class='semantic'") == FACT_ACTOR_USER);
+   fact_evidence_input_t ivan_reextract_ev = ev1;
+   ivan_reextract_ev.source_id = "message:ivan-reextract";
+   ivan_reextract_ev.evidence_hash = "hash-ivan-reextract";
+   ai.source = "ivan";
+   ai.target = "acme";
+   ai.evidence = &ivan_reextract_ev;
+   assert(db2_fact_mutation_assert(&system_actor, &ai, &mr) == 0);
+   assert(strcmp(mr.lifecycle, FACT_LIFECYCLE_INVALIDATED) == 0);
+   assert(db2_fact_current_count("ivan") == 0);
+   ai.source = "rollback-subject";
+   ai.evidence = &ev1;
+
    /* One ingest-run id groups independently committed assertions into one
     * previewable, all-or-nothing rollback. */
    fact_evidence_input_t batch_ev = ev1;


### PR DESCRIPTION
A user's deletion of a fact was undone by the next ingest.

## The defect

`db2_fact_mutation_assert` already consults the invalidated twin before re-asserting, and its reactivate gate compares the incoming actor against the row's `authority_rank`. On the retract path the gate was reading the wrong number.

`db2_fact_mutation_invalidate` never wrote the *retracting* actor's authority onto the row, so the row kept the original *asserter's* rank:

| step | actor | rank | result |
|---|---|---|---|
| assert `ivan works_for acme` | MODEL | 10 | row rank 10 |
| user retracts it | USER | 30 | invalidated, row **still rank 10** |
| offline drain re-derives the same triple | SYSTEM | 20 | 20 >= 10 passes, `invalidated_at` cleared, **fact resurrected** |

## The fix

Stamp the deciding authority on the transition to invalidated, so the gate compares against the retractor rather than the asserter.

This is deliberately narrow. Both rollback paths already raise the rank this way, and the operator review-reject path stamps `FACT_ACTOR_OPERATOR` — which is why the defect hid. Retract was the one remaining transition that did not record who decided.

`expire_candidates` is left alone: it is a SYSTEM TTL sweep over candidates, where recurrence is meant to revive them.

## Test

The assertion is the observable resurrection, not just the internal field: `ivan works_for acme` is MODEL-asserted, USER-retracted, then re-derived by SYSTEM from new evidence (a distinct `source_id`/`evidence_hash`, so the evidence-replay guard does not apply), and must stay invalidated.

## Provenance

Re-landed from `agent/temporal-assertion-learning-loop` (#2871), which is not merging: its conflicts against `testing` are mostly artifacts of the `src/db2` to `src/modules/db2/c` relocation, and it predates the `memory_authority_t` model `testing` now carries.

Scoped to what `testing` still lacks. The rollback half of the original change and its regression test are **already present** there, so this PR carries only the `invalidate` path and its test.