### PR TITLE
fix(ci): keep nightly fuzz targets in sync

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -26,9 +26,7 @@ jobs:
       - name: Build all fuzz targets
         run: |
           cd src
-          make -j$(nproc) tests/fuzz_extractors tests/fuzz_json_parse \
-               tests/fuzz_memory_search \
-               tests/fuzz_message_frame tests/fuzz_acl_parse
+          make -j$(nproc) fuzz-build
 
       - name: Seed corpus smoke test
         run: cd src && make fuzz
@@ -36,7 +34,15 @@ jobs:
       - name: Extended fuzz run (30 minutes)
         run: |
           cd src
-          PER_TARGET=300  # 5 minutes per target, 6 targets = 30 min
+          mapfile -t targets < <(make -s fuzz-list)
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "No fuzz targets registered"
+            exit 1
+          fi
+
+          TOTAL_SECONDS=1800
+          PER_TARGET=$((TOTAL_SECONDS / ${#targets[@]}))
+          echo "Running ${#targets[@]} targets for ${PER_TARGET}s each"
 
           fuzz_extended() {
             local target="$1"
@@ -62,8 +68,6 @@ jobs:
             echo "--- $name: $iterations iterations completed ---"
           }
 
-          for target in tests/fuzz_extractors tests/fuzz_json_parse \
-                        tests/fuzz_memory_search \
-                        tests/fuzz_message_frame tests/fuzz_acl_parse; do
+          for target in "${targets[@]}"; do
             fuzz_extended "$target"
           done

--- a/src/Makefile
+++ b/src/Makefile
@@ -2529,6 +2529,8 @@ format:
 
 # --- Fuzz testing (standalone mode, no libFuzzer required) ---
 
+.PHONY: fuzz-build fuzz-list
+
 FUZZ_EXTRACTOR_OBJS = $(OBJDIR)/tests/fuzz_extractors.o $(TEST_DATA_OBJS_MOCK)
 
 FUZZ_JSON_OBJS = $(OBJDIR)/tests/fuzz_json_parse.o $(OBJDIR)/cJSON.o
@@ -2669,6 +2671,11 @@ tests/fuzz_server_mgmt_action: $(FUZZ_SERVER_MGMT_ACTION_OBJS)
 
 tests/fuzz_server_mgmt_read_config: $(FUZZ_SERVER_MGMT_READ_CONFIG_OBJS)
 	$(CC) -o $@ $^ $(L_AGENT)
+
+fuzz-build: $(FUZZ_TARGETS)
+
+fuzz-list:
+	@printf '%s\n' $(FUZZ_TARGETS)
 
 fuzz: $(FUZZ_TARGETS)
 	./tests/fuzz_extractors tests/fuzz_corpus/seed.*


### PR DESCRIPTION
## Summary
- remove the retired C memory-search harness from the nightly workflow by using the Makefile as the canonical fuzz target list
- build and extended-fuzz all 13 registered harnesses
- distribute the existing 30-minute budget across the current target set

## Validation
- `make -C src -j$(nproc) fuzz-build`
- `make -C src fuzz`
- `make -C src tests-are-run-check`
- `git diff --check`

Fixes the failing Nightly Fuzz run 33076415511.